### PR TITLE
Add comments to each FIRLoggerLevel value.

### DIFF
--- a/Firebase/Core/FIRLoggerLevel.h
+++ b/Firebase/Core/FIRLoggerLevel.h
@@ -20,11 +20,18 @@
  * The log levels used by internal logging.
  */
 typedef NS_ENUM(NSInteger, FIRLoggerLevel) {
-  FIRLoggerLevelError = 3 /*ASL_LEVEL_ERR*/,
-  FIRLoggerLevelWarning = 4 /*ASL_LEVEL_WARNING*/,
-  FIRLoggerLevelNotice = 5 /*ASL_LEVEL_NOTICE*/,
-  FIRLoggerLevelInfo = 6 /*ASL_LEVEL_INFO*/,
-  FIRLoggerLevelDebug = 7 /*ASL_LEVEL_DEBUG*/,
+  /** Error level, matches ASL_LEVEL_ERR. */
+  FIRLoggerLevelError = 3,
+  /** Warning level, matches ASL_LEVEL_WARNING. */
+  FIRLoggerLevelWarning = 4,
+  /** Notice level, matches ASL_LEVEL_NOTICE. */
+  FIRLoggerLevelNotice = 5,
+  /** Info level, matches ASL_LEVEL_NOTICE. */
+  FIRLoggerLevelInfo = 6,
+  /** Debug level, matches ASL_LEVEL_DEBUG. */
+  FIRLoggerLevelDebug = 7,
+  /** Minimum log level. */
   FIRLoggerLevelMin = FIRLoggerLevelError,
+  /** Maximum log level. */
   FIRLoggerLevelMax = FIRLoggerLevelDebug
 } FIR_SWIFT_NAME(FirebaseLoggerLevel);


### PR DESCRIPTION
Docs aren't being generated properly for FIRLoggerLevel because
it's missing the proper documentation.