### PR TITLE
Enable direct channel in the sample app

### DIFF
--- a/Example/Messaging/App/AppDelegate.swift
+++ b/Example/Messaging/App/AppDelegate.swift
@@ -50,6 +50,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     FirebaseApp.configure()
     Messaging.messaging().delegate = self
+    Messaging.messaging().shouldEstablishDirectChannel = true
 
     NotificationsController.configure()
 
@@ -109,6 +110,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 extension AppDelegate: MessagingDelegate {
   func messaging(_ messaging: Messaging, didRefreshRegistrationToken fcmToken: String) {
     printFCMToken()
+  }
+
+  // Direct channel data messages are delivered here, on iOS 10.0+.
+  // The `shouldEstablishDirectChannel` property should be be set to |true| before data messages can
+  // arrive.
+  func messaging(_ messaging: Messaging, didReceive remoteMessage: MessagingRemoteMessage) {
+    // Convert to pretty-print JSON
+    guard let data =
+        try? JSONSerialization.data(withJSONObject: remoteMessage.appData, options: .prettyPrinted),
+        let prettyPrinted = String(data: data, encoding: .utf8) else {
+      return
+    }
+    print("Received direct channel message:\n\(prettyPrinted)")
   }
 }
 


### PR DESCRIPTION
This demonstrates the simple property, `shouldEstablishDirectChannel`, that can be set to `true` to have Firebase Messaging manage a direct, socket-based channel to the FCM server. This allows for direct "data" messages to be sent from the server to the SDK.