### PR TITLE
Fixes ApiTests and separates its credentials from Sample

### DIFF
--- a/AuthSamples/ApiTests/AuthCredentialsTemplate.h
+++ b/AuthSamples/ApiTests/AuthCredentialsTemplate.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+Some of the Auth Credentials needs to be populated for the ApiTests to work.
+
+Please follow the following steps to populate the valid AuthCredentials
+and copy it to AuthCredentials.h file
+
+You will need to replace the following values:
+
+$KGOOGLE_CLIENT_ID
+Get the value of the CLIENT_ID key in the GoogleService-Info.plist file..
+
+$KGOOGLE_TEST_ACCOUNT_REFRESH_TOKEN
+GOOGLE_TEST_ACCOUNT_REFRESH_TOKEN is the Google SignIn refresh token obtained for the Google client
+ID, saved for continuous tests.
+
+$KGOOGLE_USER_NAME
+The name of the test user for Google SignIn.
+Make sure the name of the test user to be "John Test" as defined by kGoogleTestAccountName
+in ApiTests/FirebearApiTests.m
+
+$KFACEBOOK_APP_ID
+FACEBOOK_APP_ID is the developer's Facebook app's ID, to be used to test the 
+'Signing in with Facebook' feature of Firebase Auth. Follow the instructions 
+on the Facebook developer site: https://developers.facebook.com/docs/apps/register 
+to obtain such an id.
+
+$KFACEBOOK_APP_ACCESS_TOKEN
+Once you have an Facebook App Id, click on dashboard from your app you can see
+both your App ID and the App Secret. Once you have both of these generate the 
+access token using the step 13 of https://smashballoon.com/custom-facebook-feed/access-token/
+Follow the same link for comprehensive information on how to get the access token.
+
+$KFACEBOOK_USER_NAME
+The name of the test user for Facebook Login.
+
+$KCUSTOM_AUTH_TOKEN_URL
+A URL to return a Custom Auth token.
+
+$KCUSTOM_AUTH_USER_ID
+The ID of the test user in the Custom Auth token.
+*/
+
+#define KGOOGLE_CLIENT_ID $KGOOGLE_CLIENT_ID
+#define KGOOGLE_TEST_ACCOUNT_REFRESH_TOKEN $KGOOGLE_TEST_ACCOUNT_REFRESH_TOKEN
+#define KGOOGLE_USER_NAME $KGOOGLE_USER_NAME
+#define KFACEBOOK_APP_ID $KFACEBOOK_APP_ID
+#define KFACEBOOK_APP_ACCESS_TOKEN $KFACEBOOK_APP_ACCESS_TOKEN
+#define KFACEBOOK_USER_NAME $KFACEBOOK_USER_NAME
+#define KCUSTOM_AUTH_TOKEN_URL $KCUSTOM_AUTH_TOKEN_URL
+#define KCUSTOM_AUTH_USER_ID $KCUSTOM_AUTH_USER_ID

--- a/AuthSamples/ApiTests/FirebearApiTests.m
+++ b/AuthSamples/ApiTests/FirebearApiTests.m
@@ -19,7 +19,7 @@
 
 #import "FIRApp.h"
 #import "FirebaseAuth.h"
-#import "../Sample/AuthCredentials.h"
+#import "AuthCredentials.h"
 
 #ifdef NO_NETWORK
 #import "ioReplayer/IORManager.h"
@@ -29,27 +29,27 @@
 #import <GTMSessionFetcher/GTMSessionFetcher.h>
 #import <GTMSessionFetcher/GTMSessionFetcherService.h>
 
+/** The user name string for Custom Auth testing account. */
+static NSString *const kCustomAuthTestingAccountUserID = KCUSTOM_AUTH_USER_ID;
+
+/** The url for obtaining a valid custom token string used to test Custom Auth. */
+static NSString *const kCustomTokenUrl = KCUSTOM_AUTH_TOKEN_URL;
+
 /** Facebook app access token that will be used for Facebook Graph API, which is different from
  * account access token.
  */
-static NSString *const kAppAccessToken = KAPP_ACCESS_TOKEN;
-
-/** The user name string for BYOAuth testing account. */
-static NSString *const kBYOAuthTestingAccountUserName = @"John GoogleSpeed";
-
-/** The url for obtaining a valid custom token string used to test BYOAuth. */
-static NSString *const kCustomTokenUrl = @"https://fb-sa-1211.appspot.com/token";
+static NSString *const kFacebookAppAccessToken = KFACEBOOK_APP_ACCESS_TOKEN;
 
 /** Facebook app ID that will be used for Facebook Graph API. */
 static NSString *const kFacebookAppID = KFACEBOOK_APP_ID;
 
 static NSString *const kFacebookGraphApiAuthority = @"graph.facebook.com";
 
-static NSString *const kFacebookTestAccountName = @"MichaelTest";
+static NSString *const kFacebookTestAccountName = KFACEBOOK_USER_NAME;
 
-static NSString *const kGoogleTestAccountName = @"John Test";
+static NSString *const kGoogleTestAccountName = KGOOGLE_USER_NAME;
 
-/** The invalid custom token string for testing BYOAuth. */
+/** The invalid custom token string for testing Custom Auth. */
 static NSString *const kInvalidCustomToken = @"invalid token.";
 
 /** The testing email address for testCreateAccountWithEmailAndPassword. */
@@ -217,7 +217,7 @@ static NSTimeInterval const kExpectationsTimeout = 30;
   XCTAssertEqualObjects(auth.currentUser.email, kExistingTestingEmailToSignIn);
 }
 
-- (void)testSignInWithValidBYOAuthToken {
+- (void)testSignInWithValidCustomAuthToken {
   FIRAuth *auth = [FIRAuth auth];
   if (!auth) {
     XCTFail(@"Could not obtain auth object.");
@@ -233,7 +233,7 @@ static NSTimeInterval const kExpectationsTimeout = 30;
   NSLog(@"The valid token is: %@", customToken);
 
   XCTestExpectation *expectation =
-      [self expectationWithDescription:@"BYOAuthToken sign-in finished."];
+      [self expectationWithDescription:@"CustomAuthToken sign-in finished."];
 
   [auth signInWithCustomToken:customToken
                    completion:^(FIRUser *_Nullable user, NSError *_Nullable error) {
@@ -246,21 +246,21 @@ static NSTimeInterval const kExpectationsTimeout = 30;
                                handler:^(NSError *error) {
                                  if (error != nil) {
                                    XCTFail(@"Failed to wait for expectations "
-                                           @"in BYOAuthToken sign in. Error: %@",
+                                           @"in CustomAuthToken sign in. Error: %@",
                                            error.localizedDescription);
                                  }
                                }];
 
-  XCTAssertEqualObjects(auth.currentUser.displayName, kBYOAuthTestingAccountUserName);
+  XCTAssertEqualObjects(auth.currentUser.uid, kCustomAuthTestingAccountUserID);
 }
 
-- (void)testSignInWithInvalidBYOAuthToken {
+- (void)testSignInWithInvalidCustomAuthToken {
   FIRAuth *auth = [FIRAuth auth];
   if (!auth) {
     XCTFail(@"Could not obtain auth object.");
   }
   XCTestExpectation *expectation =
-      [self expectationWithDescription:@"Invalid BYOAuthToken sign-in finished."];
+      [self expectationWithDescription:@"Invalid CustomAuthToken sign-in finished."];
 
   [auth signInWithCustomToken:kInvalidCustomToken
                    completion:^(FIRUser *_Nullable user, NSError *_Nullable error) {
@@ -272,7 +272,7 @@ static NSTimeInterval const kExpectationsTimeout = 30;
                                handler:^(NSError *error) {
                                  if (error != nil) {
                                    XCTFail(@"Failed to wait for expectations "
-                                           @"in BYOAuthToken sign in. Error: %@",
+                                           @"in CustomAuthToken sign in. Error: %@",
                                            error.localizedDescription);
                                  }
                                }];
@@ -379,7 +379,7 @@ static NSTimeInterval const kExpectationsTimeout = 30;
   // Build the POST request.
   NSString *bodyString =
       [NSString stringWithFormat:@"installed=true&name=%@&permissions=read_stream&access_token=%@",
-                                 kFacebookTestAccountName, kAppAccessToken];
+                                 kFacebookTestAccountName, kFacebookAppAccessToken];
   NSData *postData = [bodyString dataUsingEncoding:NSUTF8StringEncoding];
   GTMSessionFetcherService *service = [[GTMSessionFetcherService alloc] init];
   GTMSessionFetcher *fetcher = [service fetcherWithURLString:urltoCreateTestUser];
@@ -470,7 +470,7 @@ static NSTimeInterval const kExpectationsTimeout = 30;
 
   // Build the POST request.
   NSString *bodyString =
-      [NSString stringWithFormat:@"method=delete&access_token=%@", kAppAccessToken];
+      [NSString stringWithFormat:@"method=delete&access_token=%@", kFacebookAppAccessToken];
   NSData *postData = [bodyString dataUsingEncoding:NSUTF8StringEncoding];
   GTMSessionFetcherService *service = [[GTMSessionFetcherService alloc] init];
   GTMSessionFetcher *fetcher = [service fetcherWithURLString:urltoDeleteTestUser];

--- a/AuthSamples/Sample/AuthCredentialsTemplate.h
+++ b/AuthSamples/Sample/AuthCredentialsTemplate.h
@@ -21,33 +21,12 @@ Please follow the following steps to populate the valid AuthCredentials
 and copy it to AuthCredentials.h file
 
 You will need to replace the following values:
-$KGOOGLE_CLIENT_ID
-Get the value of the CLIENT_ID key in the GoogleService-Info.plist file..
 
 $KFACEBOOK_APP_ID
 FACEBOOK_APP_ID is the developer's Facebook app's ID, to be used to test the 
 'Signing in with Facebook' feature of Firebase Auth. Follow the instructions 
 on the Facebook developer site: https://developers.facebook.com/docs/apps/register 
-to obtain such an id
-
-$KAPP_ACCESS_TOKEN
-Once you have an Facebook App Id, click on dashboard from your app you can see
-both your App ID and the App Secret. Once you have both of these generate the 
-access token using the step 13 of https://smashballoon.com/custom-facebook-feed/access-token/
-Follow the same link for comprehensive information on how to get the access token.
-
-$KGOOGLE_TEST_ACCOUNT_REFRESH_TOKEN
-GOOGLE_TEST_ACCOUNT_REFRESH_TOKEN is the Google SignIn refresh token obtained for the Google client ID, 
-saved for continuous tests.
-
-The users that are behind these tokens must have user names as declared in the code, i.e., 
-"John Test" for Google and "MichaelTest" for Facebook, or the FirebearApiTests will fail.
-This can be found in ApiTests/FirebearApiTests.m with variable names kFacebookTestAccountName and
-kGoogleTestAccountName
-
+to obtain such an id.
 */
 
-#define KAPP_ACCESS_TOKEN $KAPP_ACCESS_TOKEN
 #define KFACEBOOK_APP_ID $KFACEBOOK_APP_ID
-#define KGOOGLE_CLIENT_ID $KGOOGLE_CLIENT_ID
-#define KGOOGLE_TEST_ACCOUNT_REFRESH_TOKEN $KGOOGLE_TEST_ACCOUNT_REFRESH_TOKEN

--- a/AuthSamples/Samples.xcodeproj/project.pbxproj
+++ b/AuthSamples/Samples.xcodeproj/project.pbxproj
@@ -192,6 +192,7 @@
 		CDD2401395E91D0923BC5CD8 /* Pods_TestApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D1EE09E5B9A6C092236222A9 /* Pods-Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Sample/Pods-Sample.debug.xcconfig"; sourceTree = "<group>"; };
 		D5FE06BD9AA795DFBA9EFAAD /* Pods_Sample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Sample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D90D8C411ED3B72B00C6BE87 /* AuthCredentials.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AuthCredentials.h; sourceTree = "<group>"; };
 		D9D6F0DE0BB3F49EF1B7CBB3 /* Pods-SwiftSample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftSample.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftSample/Pods-SwiftSample.release.xcconfig"; sourceTree = "<group>"; };
 		DE5371831EA7E89D000DA57F /* FIRAdditionalUserInfoTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FIRAdditionalUserInfoTests.m; path = ../../Example/Auth/Tests/FIRAdditionalUserInfoTests.m; sourceTree = "<group>"; };
 		DE5371841EA7E89D000DA57F /* FIRApp+FIRAuthUnitTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "FIRApp+FIRAuthUnitTests.h"; path = "../../Example/Auth/Tests/FIRApp+FIRAuthUnitTests.h"; sourceTree = "<group>"; };
@@ -523,6 +524,7 @@
 		DEE13A211EA1252D00D1BABA /* ApiTests */ = {
 			isa = PBXGroup;
 			children = (
+				D90D8C411ED3B72B00C6BE87 /* AuthCredentials.h */,
 				DEE13A2A1EA125CD00D1BABA /* FirebearApiTests.m */,
 				DEE13A241EA1252D00D1BABA /* Info.plist */,
 			);


### PR DESCRIPTION
In addition to fixing ApiTests and using the official term "Custom Auth", this PR also puts all of ApiTests' credentials including test user names into its own template, so developers won't need to bother with them if them don't expect ApiTests would be affected.