### PR TITLE
Update error messages to be Swift friendly.

### DIFF
--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -282,7 +282,8 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                 format:@"The default FIRApp instance must be configured before the default FIRAuth"
                        @"instance can be initialized. One way to ensure that is to call "
                        @"`[FIRApp configure];` (`FirebaseApp.configure()` in Swift) in the App "
-                       @"Delegate's `application:didFinishLaunchingWithOptions:`."];
+                       @"Delegate's `application:didFinishLaunchingWithOptions:` "
+                       @"(`application(_:didFinishLaunchingWithOptions:)` in Swift)."];
   }
   return [self authWithApp:defaultApp];
 }

--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -281,8 +281,8 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
     [NSException raise:NSInternalInconsistencyException
                 format:@"The default FIRApp instance must be configured before the default FIRAuth"
                        @"instance can be initialized. One way to ensure that is to call "
-                       @"`[FIRApp configure];` is called in "
-                       @"`application:didFinishLaunchingWithOptions:`."];
+                       @"`[FIRApp configure];` (`FirebaseApp.configure()` in Swift) in the App "
+                       @"Delegate's `application:didFinishLaunchingWithOptions:`."];
   }
   return [self authWithApp:defaultApp];
 }

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -82,8 +82,9 @@ static FIRApp *sDefaultApp;
                       kFIRAppDiagnosticsErrorKey : [FIRApp errorForMissingOptions]
                     }];
     [NSException raise:kFirebaseCoreErrorDomain
-                format:@"[FIRApp configure] could not find a valid GoogleService-Info.plist in "
-                       @"your project. Please download one from %@.",
+                format:@"`[FIRApp configure]` (`FirebaseApp.configure()` in Swift) could not find "
+                       @"a valid GoogleService-Info.plist in your project. Please download one "
+                       @"from %@.",
                        kPlistURL];
   }
   [FIRApp configureDefaultAppWithOptions:options sendingNotifications:YES];
@@ -178,8 +179,8 @@ static FIRApp *sDefaultApp;
     return sDefaultApp;
   }
   FIRLogError(kFIRLoggerCore, @"I-COR000003", @"The default Firebase app has not yet been "
-              @"configured. Add [FIRApp configure] to your application initialization. Read more: "
-              @"https://goo.gl/ctyzm8.");
+              @"configured. Add `[FIRApp configure];` (`FirebaseApp.configure()` in Swift) to your "
+              @"application initialization. Read more: https://goo.gl/ctyzm8.");
   return nil;
 }
 

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -82,7 +82,7 @@ static FIRApp *sDefaultApp;
                       kFIRAppDiagnosticsErrorKey : [FIRApp errorForMissingOptions]
                     }];
     [NSException raise:kFirebaseCoreErrorDomain
-                format:@"`[FIRApp configure]` (`FirebaseApp.configure()` in Swift) could not find "
+                format:@"`[FIRApp configure];` (`FirebaseApp.configure()` in Swift) could not find "
                        @"a valid GoogleService-Info.plist in your project. Please download one "
                        @"from %@.",
                        kPlistURL];

--- a/Firebase/Core/FIROptions.h
+++ b/Firebase/Core/FIROptions.h
@@ -105,8 +105,9 @@ FIR_SWIFT_NAME(FirebaseOptions)
                         databaseURL:(NSString *)databaseURL
                       storageBucket:(NSString *)storageBucket
                   deepLinkURLScheme:(NSString *)deepLinkURLScheme
-    DEPRECATED_MSG_ATTRIBUTE("Use `-[[FIROptions alloc] initWithGoogleAppID:gcmSenderID:]` and "
-                             "properties instead.");
+    DEPRECATED_MSG_ATTRIBUTE("Use `-[[FIROptions alloc] initWithGoogleAppID:GCMSenderID:]` "
+                             "(`FirebaseOptions(googleAppID:gcmSenderID:)` in Swift)` and property "
+                             "setters instead.");
 
 /**
  * Initializes a customized instance of FIROptions from the file at the given plist file path.


### PR DESCRIPTION
Error messages should include Swift references on top of the
Objective-C references.

Fixes issue #39 