### PR TITLE
Fixes Auth Sample app import paths.

### DIFF
--- a/AuthSamples/Podfile
+++ b/AuthSamples/Podfile
@@ -8,6 +8,7 @@ target 'Sample' do
   # Lock to the 1.0.9 version of InstanceID since 1.0.10 added a dependency
   # to FirebaseCore
   pod 'FirebaseInstanceID', '1.0.9'
+  pod 'GTMSessionFetcher/Core'
 end
 
 target 'SwiftBear' do
@@ -20,7 +21,7 @@ target 'ApiTests' do
   pod 'FirebaseDev/Auth', :path => '../'
   pod 'GoogleSignIn'
   pod 'FirebaseInstanceID', '1.0.9'
-  pod 'GTMSessionFetcher'
+  pod 'GTMSessionFetcher/Core'
 end
 
 target 'EarlGreyTests' do

--- a/AuthSamples/Sample/ApplicationDelegate.m
+++ b/AuthSamples/Sample/ApplicationDelegate.m
@@ -16,15 +16,12 @@
 
 #import "ApplicationDelegate.h"
 
+#import "AuthProviders.h"
 #import "FIRApp.h"
 #import "FirebaseAuth.h"
-#import "AuthProviders.h"
+#import "FIRLogger.h"
+#import "GTMSessionFetcherLogging.h"
 #import "MainViewController.h"
-
-#if INTERNAL_GOOGLE3_BUILD
-#import "googlemac/iPhone/Identity/Firebear/InternalUtils/FIRSessionFetcherLogging.h"
-#import "third_party/firebase/ios/Source/FirebaseCore/Library/Private/FIRLogger.h"
-#endif
 
 /** @var gOpenURLDelegate
     @brief The delegate to for application:openURL:... method.
@@ -39,10 +36,8 @@ static __weak id<OpenURLDelegate> gOpenURLDelegate;
 
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-#if INTERNAL_GOOGLE3_BUILD
-  [FIRSessionFetcherLogging setEnabled:YES];
+  [GTMSessionFetcher  setLoggingEnabled:YES];
   FIRSetLoggerLevel(FIRLoggerLevelInfo);
-#endif
 
   // Configure the default Firebase application:
   [FIRApp configure];

--- a/AuthSamples/Sample/MainViewController.m
+++ b/AuthSamples/Sample/MainViewController.m
@@ -33,10 +33,6 @@
 #import "UserInfoViewController.h"
 #import "UserTableViewCell.h"
 
-#if INTERNAL_GOOGLE3_BUILD
-#import "third_party/objective_c/FirebaseDatabase/FirebaseDatabase.framework/Headers/FirebaseDatabase.h"
-#endif
-
 /** @var kTokenGetButtonText
     @brief The text of the "Get Token" button.
  */
@@ -539,10 +535,6 @@ typedef void (^FIRTokenCallback)(NSString *_Nullable token, NSError *_Nullable e
                                                  name:FIRAuthStateDidChangeNotification
                                                object:nil];
     self.useStatusBarSpinner = YES;
-#if INTERNAL_GOOGLE3_BUILD
-    // Trigger automatic token refresh.
-    [[FIRDatabase database] reference];
-#endif
   }
   return self;
 }

--- a/AuthSamples/Sample/SettingsViewController.m
+++ b/AuthSamples/Sample/SettingsViewController.m
@@ -19,23 +19,20 @@
 #import <objc/runtime.h>
 
 #import "FIRApp.h"
+#import "FIRAuth_Internal.h"
+#import "FIRAuthAPNSToken.h"
+#import "FIRAuthAPNSTokenManager.h"
+#import "FIRAuthAppCredential.h"
+#import "FIRAuthAppCredentialManager.h"
 #import "FIROptions.h"
 #import "FirebaseAuth.h"
 #import "StaticContentTableViewManager.h"
 #import "UIViewController+Alerts.h"
 
-#if INTERNAL_GOOGLE3_BUILD
-#import "googlemac/iPhone/Identity/Firebear/Auth/Source/FIRAuth_Internal.h"
-#import "googlemac/iPhone/Identity/Firebear/Auth/Source/FIRAuthAPNSToken.h"
-#import "googlemac/iPhone/Identity/Firebear/Auth/Source/FIRAuthAPNSTokenManager.h"
-#import "googlemac/iPhone/Identity/Firebear/Auth/Source/FIRAuthAppCredential.h"
-#import "googlemac/iPhone/Identity/Firebear/Auth/Source/FIRAuthAppCredentialManager.h"
-#import "googlemac/iPhone/InstanceID/Firebase/Lib/Source/FIRInstanceID+Internal.h"
-#else
+// Declares a private method of FIRInstanceID to work around a bug.
 @interface FIRInstanceID : NSObject
 + (void)notifyTokenRefresh;
 @end
-#endif
 
 /** @var kIdentityToolkitRequestClassName
     @brief The class name of Identity Toolkit requests.
@@ -238,7 +235,6 @@ static NSString *hexString(NSData *data) {
         [weakSelf toggleAPIHostWithRequestClassName:kSecureTokenRequestClassName];
       }],
     ]],
-#if INTERNAL_GOOGLE3_BUILD
     [StaticContentTableViewSection sectionWithTitle:@"Phone Auth" cells:@[
       [StaticContentTableViewCell cellWithTitle:@"APNs Token"
                                           value:[self APNSTokenString]
@@ -251,7 +247,6 @@ static NSString *hexString(NSData *data) {
         [weakSelf clearAppCredential];
       }],
     ]],
-#endif  // INTERNAL_GOOGLE3_BUILD
   ]];
 }
 
@@ -304,8 +299,6 @@ static NSString *hexString(NSData *data) {
     }
   }
 }
-
-#if INTERNAL_GOOGLE3_BUILD
 
 /** @fn APNSTokenString
     @brief Returns a string representing APNS token.
@@ -375,7 +368,5 @@ static NSString *hexString(NSData *data) {
     }
   }];
 }
-
-#endif  // INTERNAL_GOOGLE3_BUILD
 
 @end

--- a/AuthSamples/Samples.xcodeproj/project.pbxproj
+++ b/AuthSamples/Samples.xcodeproj/project.pbxproj
@@ -29,9 +29,9 @@
 		AB62D09AF8C1196E07F37D3B /* Pods_SwiftBear.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1F689EE8E0E6F83D82429F0 /* Pods_SwiftBear.framework */; };
 		BD555A1DCF4E889DC3338248 /* Pods_FirebaseAuthUnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FFAD3F37BC4D7CEF0CAD579 /* Pods_FirebaseAuthUnitTests.framework */; };
 		BE7B447C1EC2508300FA4C1B /* AuthCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE7B447A1EC2507800FA4C1B /* AuthCredentials.swift */; };
+		D99C31A11ED7A0ED00607534 /* GoogleService-Info_multi.plist in Resources */ = {isa = PBXBuildFile; fileRef = D99C31A01ED7A0ED00607534 /* GoogleService-Info_multi.plist */; };
 		D9AE2A641ED751C900DDAD18 /* FirebaseAuthApiTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D9AE2A631ED751C900DDAD18 /* FirebaseAuthApiTests.m */; };
 		D9AE2A661ED757C400DDAD18 /* FirebaseAuthEarlGreyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D9AE2A651ED757C400DDAD18 /* FirebaseAuthEarlGreyTests.m */; };
-		D99C31A11ED7A0ED00607534 /* GoogleService-Info_multi.plist in Resources */ = {isa = PBXBuildFile; fileRef = D99C31A01ED7A0ED00607534 /* GoogleService-Info_multi.plist */; };
 		DE5371B31EA7E89D000DA57F /* FIRAdditionalUserInfoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DE5371831EA7E89D000DA57F /* FIRAdditionalUserInfoTests.m */; };
 		DE5371B41EA7E89D000DA57F /* FIRApp+FIRAuthUnitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DE5371851EA7E89D000DA57F /* FIRApp+FIRAuthUnitTests.m */; };
 		DE5371B51EA7E89D000DA57F /* FIRAuthAppCredentialTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DE5371861EA7E89D000DA57F /* FIRAuthAppCredentialTests.m */; };
@@ -192,9 +192,9 @@
 		D1EE09E5B9A6C092236222A9 /* Pods-Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Sample/Pods-Sample.debug.xcconfig"; sourceTree = "<group>"; };
 		D5FE06BD9AA795DFBA9EFAAD /* Pods_Sample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Sample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D90D8C411ED3B72B00C6BE87 /* AuthCredentials.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AuthCredentials.h; sourceTree = "<group>"; };
+		D99C31A01ED7A0ED00607534 /* GoogleService-Info_multi.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info_multi.plist"; sourceTree = "<group>"; };
 		D9AE2A631ED751C900DDAD18 /* FirebaseAuthApiTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FirebaseAuthApiTests.m; sourceTree = "<group>"; };
 		D9AE2A651ED757C400DDAD18 /* FirebaseAuthEarlGreyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FirebaseAuthEarlGreyTests.m; sourceTree = "<group>"; };
-		D99C31A01ED7A0ED00607534 /* GoogleService-Info_multi.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info_multi.plist"; sourceTree = "<group>"; };
 		D9D6F0DE0BB3F49EF1B7CBB3 /* Pods-SwiftSample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftSample.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftSample/Pods-SwiftSample.release.xcconfig"; sourceTree = "<group>"; };
 		DE5371831EA7E89D000DA57F /* FIRAdditionalUserInfoTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FIRAdditionalUserInfoTests.m; path = ../../Example/Auth/Tests/FIRAdditionalUserInfoTests.m; sourceTree = "<group>"; };
 		DE5371841EA7E89D000DA57F /* FIRApp+FIRAuthUnitTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "FIRApp+FIRAuthUnitTests.h"; path = "../../Example/Auth/Tests/FIRApp+FIRAuthUnitTests.h"; sourceTree = "<group>"; };
@@ -1458,6 +1458,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
+				USER_HEADER_SEARCH_PATHS = "$(inherited) ../Firebase/Core/Private ../Firebase/Auth/Source/Private";
 			};
 			name = Debug;
 		};
@@ -1473,6 +1474,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.FirebaseExperimental1.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
+				USER_HEADER_SEARCH_PATHS = "$(inherited) ../Firebase/Core/Private ../Firebase/Auth/Source/Private";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This fixes Auth Sample app import paths for external dependencies and private headers. There should no longer be two builds, one for GOOGLE3 and one for the rest of the world.
