### PR TITLE
Schedules automatic auth token refresh as soon as the triggering...

### DIFF
--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -308,6 +308,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
         if (strongSelf && !strongSelf->_autoRefreshTokens) {
           FIRLogInfo(kFIRLoggerAuth, @"I-AUT000002", @"Token auto-refresh enabled.");
           strongSelf->_autoRefreshTokens = YES;
+          [strongSelf scheduleAutoTokenRefresh];
           strongSelf->_applicationDidBecomeActiveObserver = [[NSNotificationCenter defaultCenter]
               addObserverForName:UIApplicationDidBecomeActiveNotification
                           object:nil


### PR DESCRIPTION
Schedules automatic auth token refresh as soon as the triggering method is called.

The issue is revealed by https://github.com/firebase/firebase-ios-sdk/pull/42 that we no longer automatically triggering token refresh at sample app start.
