### PR TITLE
mark FIRDatabase init unavailable

### DIFF
--- a/Firebase/Database/Api/FIRDatabase.h
+++ b/Firebase/Database/Api/FIRDatabase.h
@@ -29,6 +29,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 FIR_SWIFT_NAME(Database)
 @interface FIRDatabase : NSObject
+  
+/**
+ * The NSObject initializer that has been marked as unavailable. Use the `database` 
+ * method instead
+ *
+ * @return An instancetype instance
+*/
++ (instancetype) init __attribute__((unavailable("use the database method instead")));
 
 /**
  * Gets the instance of FIRDatabase for the default FIRApp.


### PR DESCRIPTION
FIRDatabase's initializer is inherited from NSObject and causes subtle bugs if called. See #31 for more information about this change