### PR TITLE
Remove modulemap for usage as a Pod dependency

### DIFF
--- a/Firebase/Firebase/module.modulemap
+++ b/Firebase/Firebase/module.modulemap
@@ -1,4 +1,0 @@
-module Firebase {
-  export *
-  header "Firebase.h"
-}

--- a/FirebaseDev.podspec
+++ b/FirebaseDev.podspec
@@ -21,7 +21,6 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.subspec 'Root' do |sp|
     sp.source_files = 'Firebase/Firebase/Firebase.h'
     sp.public_header_files = 'Firebase/Firebase/Firebase.h'
-    sp.preserve_paths = 'Firebase/Firebase/module.modulemap'
     sp.user_target_xcconfig = { 'HEADER_SEARCH_PATHS' => '$(inherited) "${PODS_ROOT}/Firebase/Firebase/Firebase"' }
   end
 


### PR DESCRIPTION
As I couldn't use Firebase as a dependency app, I followed [a CocoaPods developer advice suggesting to remove the modulemap file](https://github.com/CocoaPods/CocoaPods/issues/6138#issuecomment-258960994) to see if it worked. It did and I was able to build a Pod using Firebase as a dependency. 

It creates this diff in the module map of the pod. Not 100% sure it's correct (especially as FirebaseDev might not be a good module name), but probaly worth a discussion.

```diff
1c1,3
< module Firebase {
---
> framework module FirebaseDev {
>   umbrella header "FirebaseDev-umbrella.h"
> 
3,4c5,6
<   header "Firebase.h"
< }
\ No newline at end of file
---
>   module * { export * }
> }
```