### PR TITLE
Handle missing email error

### DIFF
--- a/Example/Auth/Tests/FIRAuthTests.m
+++ b/Example/Auth/Tests/FIRAuthTests.m
@@ -1200,6 +1200,25 @@ static const NSTimeInterval kWaitInterval = .5;
   [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
 }
 
+/** @fn testCreateUserEmptyEmailFailure
+    @brief Tests the flow of a failed @c createUserWithEmail:password:completion: call due to an
+        empty email adress. This error occurs on the client side, so there is no need to fake an RPC
+        response.
+ */
+- (void)testCreateUserEmptyEmailFailure {
+  [self expectGetAccountInfo];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+  [[FIRAuth auth] signOut:NULL];
+  [[FIRAuth auth] createUserWithEmail:@""
+                             password:kPassword
+                           completion:^(FIRUser *_Nullable user, NSError *_Nullable error) {
+    XCTAssertTrue([NSThread isMainThread]);
+    XCTAssertEqual(error.code, FIRAuthErrorCodeMissingEmail);
+    [expectation fulfill];
+  }];
+  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+}
+
 /** @fn testSendPasswordResetEmailSuccess
     @brief Tests the flow of a successful @c sendPasswordResetWithEmail:completion: call.
  */

--- a/Example/Auth/Tests/FIRSignUpNewUserResponseTests.m
+++ b/Example/Auth/Tests/FIRSignUpNewUserResponseTests.m
@@ -94,6 +94,12 @@ static NSString *const kPasswordLoginDisabledErrorMessage = @"PASSWORD_LOGIN_DIS
  */
 static NSString *const kInvalidEmailErrorMessage = @"INVALID_EMAIL";
 
+/** @var kMissingEmailErrorMessage
+    @brief The error returned by the server if an email address was expected and one was not
+        provided.
+ */
+static NSString *const kMissingEmailErrorMessage = @"MISSING_EMAIL";
+
 /** @var kWeakPasswordErrorMessage
     @brief This is the error message the server will respond with if the new user's password
         is too weak that it is too short.
@@ -242,11 +248,11 @@ static const double kAllowedTimeDifference = 0.1;
   XCTAssertEqual(RPCError.code, FIRAuthErrorCodeOperationNotAllowed);
 }
 
-/** @fn testinvalidEmailError
+/** @fn testInvalidEmailError
     @brief This test simulates making a request containing an invalid email address and receiving @c
         FIRAuthErrorInvalidEmail error as a result.
  */
-- (void)testinvalidEmailError {
+- (void)testInvalidEmailError {
   FIRSignUpNewUserRequest *request = [[FIRSignUpNewUserRequest alloc] initWithAPIKey:kTestAPIKey];
 
   __block BOOL callbackInvoked;

--- a/Example/Auth/Tests/FIRSignUpNewUserResponseTests.m
+++ b/Example/Auth/Tests/FIRSignUpNewUserResponseTests.m
@@ -94,12 +94,6 @@ static NSString *const kPasswordLoginDisabledErrorMessage = @"PASSWORD_LOGIN_DIS
  */
 static NSString *const kInvalidEmailErrorMessage = @"INVALID_EMAIL";
 
-/** @var kMissingEmailErrorMessage
-    @brief The error returned by the server if an email address was expected and one was not
-        provided.
- */
-static NSString *const kMissingEmailErrorMessage = @"MISSING_EMAIL";
-
 /** @var kWeakPasswordErrorMessage
     @brief This is the error message the server will respond with if the new user's password
         is too weak that it is too short.

--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -93,7 +93,7 @@ static NSString *const kUserKey = @"%@_firebase_user";
 /** @var kMissingEmailInvalidParameterExceptionReason
     @brief The key of missing email key @c invalidParameterException.
  */
-static NSString *const kEmailInvalidParameterReason = @"The email used to initiate user password "
+static NSString *const kEmailInvalidParameterReason = @"The email used to initiate password reset "
     "cannot be nil";
 
 static NSString *const kPasswordResetRequestType = @"PASSWORD_RESET";
@@ -648,6 +648,10 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
     if (![request.password length]) {
       decoratedCallback(nil, [FIRAuthErrorUtils
           weakPasswordErrorWithServerResponseReason:kMissingPasswordReason]);
+      return;
+    }
+    if (![request.email length]) {
+      decoratedCallback(nil, [FIRAuthErrorUtils missingEmail]);
       return;
     }
     [FIRAuthBackend signUpNewUser:request

--- a/Firebase/Auth/Source/FIRAuthErrorUtils.m
+++ b/Firebase/Auth/Source/FIRAuthErrorUtils.m
@@ -217,6 +217,11 @@ static NSString *const kFIRAuthErrorMessageInvalidSender = @"The email template 
 static NSString *const kFIRAuthErrorMessageInvalidRecipientEmail = @"The action code is invalid. "
    "This can happen if the code is malformed, expired, or has already been used.";
 
+/** @var kFIRAuthErrorMessageMissingEmail
+    @brief Message for @c FIRAuthErrorCodeMissingEmail error code.
+ */
+static NSString *const kFIRAuthErrorMessageMissingEmail = @"An email address must be provided.";
+
 /** @var kFIRAuthErrorMessageMissingContinueURI
     @brief Message for @c FIRAuthErrorCodeMissingContinueURI error code.
  */
@@ -381,6 +386,8 @@ static NSString *FIRAuthErrorDescription(FIRAuthErrorCode code) {
       return kFIRAuthErrorMessageInvalidMessagePayload;
     case FIRAuthErrorCodeInvalidRecipientEmail:
       return kFIRAuthErrorMessageInvalidRecipientEmail;
+    case FIRAuthErrorCodeMissingEmail:
+      return kFIRAuthErrorMessageMissingEmail;
     case FIRAuthErrorCodeMissingPhoneNumber:
       return kFIRAuthErrorMessageMissingPhoneNumber;
     case FIRAuthErrorCodeInvalidPhoneNumber:
@@ -474,6 +481,8 @@ static NSString *const FIRAuthErrorCodeString(FIRAuthErrorCode code) {
       return @"ERROR_INVALID_SENDER";
     case FIRAuthErrorCodeInvalidRecipientEmail:
       return @"ERROR_INVALID_RECIPIENT_EMAIL";
+    case FIRAuthErrorCodeMissingEmail:
+      return @"MISSING_EMAIL";
     case FIRAuthErrorCodeMissingPhoneNumber:
       return @"ERROR_MISSING_PHONE_NUMBER";
     case FIRAuthErrorCodeInvalidPhoneNumber:
@@ -729,6 +738,10 @@ static NSString *const FIRAuthErrorCodeString(FIRAuthErrorCode code) {
 
 + (NSError *)invalidRecipientEmailErrorWithMessage:(nullable NSString *)message {
   return [self errorWithCode:FIRAuthInternalErrorCodeInvalidRecipientEmail message:message];
+}
+
++ (NSError *)missingEmail {
+  return [self errorWithCode:FIRAuthInternalErrorCodeMissingEmail];
 }
 
 + (NSError *)missingPhoneNumberErrorWithMessage:(nullable NSString *)message {

--- a/Firebase/Auth/Source/FIRAuthErrors.h
+++ b/Firebase/Auth/Source/FIRAuthErrors.h
@@ -184,7 +184,11 @@ typedef NS_ENUM(NSInteger, FIRAuthErrorCode) {
      */
     FIRAuthErrorCodeInvalidRecipientEmail = 17033,
 
-    // The enum values between 17033 and 17041 are reserved and should NOT be used for new error
+    /** Indicates that an email address was expected but one was not provided.
+     */
+    FIRAuthErrorCodeMissingEmail = 17034,
+
+    // The enum values between 17034 and 17041 are reserved and should NOT be used for new error
     // codes.
 
     /** Indicates that a phone number was not provided in a call to

--- a/Firebase/Auth/Source/Private/FIRAuthErrorUtils.h
+++ b/Firebase/Auth/Source/Private/FIRAuthErrorUtils.h
@@ -313,6 +313,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSError *)invalidRecipientEmailErrorWithMessage:(nullable NSString *)message;
 
+/** @fn missingEmail
+    @brief Constructs an @c NSError with the @c FIRAuthErrorCodeMissingEmail code.
+    @return The NSError instance associated with the given FIRAuthError.
+ */
++ (NSError *)missingEmail;
+
 /** @fn missingPhoneNumberErrorWithMessage:
     @brief Constructs an @c NSError with the @c FIRAuthErrorCodeMissingPhoneNumber code.
     @param message Error message from the backend, if any.

--- a/Firebase/Auth/Source/Private/FIRAuthInternalErrors.h
+++ b/Firebase/Auth/Source/Private/FIRAuthInternalErrors.h
@@ -238,6 +238,11 @@ typedef NS_ENUM(NSInteger, FIRAuthInternalErrorCode) {
   FIRAuthInternalErrorCodeInvalidRecipientEmail =
       FIRAuthPublicErrorCodeFlag | FIRAuthErrorCodeInvalidRecipientEmail,
 
+  /** Indicates that an email address was expected but one was not provided.
+   */
+  FIRAuthInternalErrorCodeMissingEmail =
+      FIRAuthPublicErrorCodeFlag | FIRAuthErrorCodeMissingEmail,
+
   /** Indicates that a phone number was not provided in a call to @c verifyPhoneNumber:completion:.
    */
   FIRAuthInternalErrorCodeMissingPhoneNumber =


### PR DESCRIPTION
Adds appropriate error handling for missing email in the createUserWithEmail:password:completion: flow.

 Also fixes a few typos.