### PR TITLE
Fix build break from macOS - Auth merge

### DIFF
--- a/Example/Auth/Tests/FIRAuthTests.m
+++ b/Example/Auth/Tests/FIRAuthTests.m
@@ -1215,7 +1215,7 @@ static const NSTimeInterval kWaitInterval = .5;
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [[FIRAuth auth] signOut:NULL];
   [[FIRAuth auth] createUserWithEmail:@""
-                             password:kPassword
+                             password:kFakePassword
                            completion:^(FIRUser *_Nullable user, NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
     XCTAssertEqual(error.code, FIRAuthErrorCodeMissingEmail);


### PR DESCRIPTION
master and the macOS branch were inconsistent about naming of kPassword and kFakePassword. I fixed the compile failure by making it kFakePassword. Auth team may want to revisit.

With this change All iOS and MacOS unit tests succeed.