### PR TITLE
Documents phone auth with reference docs

### DIFF
--- a/Firebase/Auth/Source/FIRAuth.h
+++ b/Firebase/Auth/Source/FIRAuth.h
@@ -355,6 +355,20 @@ FIR_SWIFT_NAME(Auth)
         </li>
         <li>@c FIRAuthErrorCodeInvalidEmail - Indicates the email address is malformed.
         </li>
+        <li>@c FIRAuthErrorCodeMissingVerificationID - Indicates that the phone auth credential was
+            created with an empty verification ID.
+        </li>
+        <li>@c FIRAuthErrorCodeMissingVerificationCode - Indicates that the phone auth credential
+            was created with an empty verification code.
+        </li>
+        <li>@c FIRAuthErrorCodeInvalidVerificationCode - Indicates that the phone auth credential
+            was created with an invalid verification Code.
+        </li>
+        <li>@c FIRAuthErrorCodeInvalidVerificationID - Indicates that the phone auth credential was
+            created with an invalid verification ID.
+        </li>
+        <li>@c FIRAuthErrorCodeSessionExpired - Indicates that the SMS code has expired.
+        </li>
     </ul>
 
     @remarks See @c FIRAuthErrors for a list of error codes that are common to all API methods.

--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -524,7 +524,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                  isReauthentication:(BOOL)isReauthentication
                                            callback:(nullable FIRAuthDataResultCallback)callback {
   if ([credential isKindOfClass:[FIREmailPasswordAuthCredential class]]) {
-    // Special case for email/password credentials:
+    // Special case for email/password credentials
     FIREmailPasswordAuthCredential *emailPasswordCredential =
         (FIREmailPasswordAuthCredential *)credential;
     [self signInWithEmail:emailPasswordCredential.email
@@ -541,7 +541,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
 
   #if TARGET_OS_IOS
   if ([credential isKindOfClass:[FIRPhoneAuthCredential class]]) {
-    // Special case for phone auth credential
+    // Special case for phone auth credentials
     FIRPhoneAuthCredential *phoneCredential = (FIRPhoneAuthCredential *)credential;
     [self signInWithPhoneCredential:phoneCredential callback:^(FIRUser *_Nullable user,
                                                                NSError *_Nullable error) {


### PR DESCRIPTION
Adds error documentation pertaining to phone authentication to the signInAndRetrieveDataWithCredential:completion: method