### PR TITLE
Add Foundation import so TARGET_OS_IOS (or other TARGET_OS_*) gets defined

### DIFF
--- a/Example/Auth/Tests/FIRAuthTests.m
+++ b/Example/Auth/Tests/FIRAuthTests.m
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 #import <XCTest/XCTest.h>
 
 #import "FIRAppInternal.h"

--- a/Example/Auth/Tests/FIRUserTests.m
+++ b/Example/Auth/Tests/FIRUserTests.m
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 #import <XCTest/XCTest.h>
 
 #import "EmailPassword/FIREmailAuthProvider.h"

--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 #import "Private/FIRAuth_Internal.h"
 
 #import "FIRAppAssociationRegistration.h"

--- a/Firebase/Auth/Source/FIRUser.m
+++ b/Firebase/Auth/Source/FIRUser.m
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 #import "Private/FIRUser_Internal.h"
 
 #import "AuthProviders/EmailPassword/FIREmailPasswordAuthCredential.h"

--- a/Firebase/Auth/Source/FirebaseAuth.h
+++ b/Firebase/Auth/Source/FirebaseAuth.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 #import "FIREmailAuthProvider.h"
 #import "FIRFacebookAuthProvider.h"
 #import "FIRGitHubAuthProvider.h"

--- a/Firebase/Auth/Source/Private/FIRAuth_Internal.h
+++ b/Firebase/Auth/Source/Private/FIRAuth_Internal.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 #import "FIRAuth.h"
 
 #if TARGET_OS_IOS

--- a/Firebase/Auth/Source/RPCs/FIRAuthBackend.m
+++ b/Firebase/Auth/Source/RPCs/FIRAuthBackend.m
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 #import "FIRAuthBackend.h"
 
 #import "../AuthProviders/Phone/FIRPhoneAuthCredential_Internal.h"

--- a/Firebase/Core/FIRAppEnvironmentUtil.m
+++ b/Firebase/Core/FIRAppEnvironmentUtil.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
+#import <Foundation/Foundation.h>
 
 #import "Private/FIRAppEnvironmentUtil.h"
 

--- a/Firebase/Core/FIRNetworkURLSession.m
+++ b/Firebase/Core/FIRNetworkURLSession.m
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <Foundation/Foundation.h>
+
 #import "Private/FIRNetworkURLSession.h"
 
 #import "Private/FIRMutableDictionary.h"

--- a/Firebase/Core/FIRReachabilityChecker.m
+++ b/Firebase/Core/FIRReachabilityChecker.m
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <Foundation/Foundation.h>
+
 #import "Private/FIRReachabilityChecker.h"
 #import "Private/FIRReachabilityChecker+Internal.h"
 

--- a/Firebase/Database/Core/FPersistentConnection.m
+++ b/Firebase/Database/Core/FPersistentConnection.m
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#import <Foundation/Foundation.h>
 
 #import <SystemConfiguration/SystemConfiguration.h>
 #import <netinet/in.h>

--- a/Firebase/Database/Core/FRepo.m
+++ b/Firebase/Database/Core/FRepo.m
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 #import <dlfcn.h>
 #import "FRepo.h"
 #import "FSnapshotUtilities.h"

--- a/Firebase/Database/Persistence/FLevelDBStorageEngine.m
+++ b/Firebase/Database/Persistence/FLevelDBStorageEngine.m
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 #import "FLevelDBStorageEngine.h"
 
 #import "APLevelDB.h"

--- a/Firebase/Database/Realtime/FWebSocketConnection.m
+++ b/Firebase/Database/Realtime/FWebSocketConnection.m
@@ -16,6 +16,8 @@
 
 // Targetted compilation is ONLY for testing. UIKit is weak-linked in actual release build.
 
+#import <Foundation/Foundation.h>
+
 #import "FWebSocketConnection.h"
 #import "FConstants.h"
 #import "FIRDatabaseReference.h"

--- a/Firebase/Database/third_party/SocketRocket/FSRWebSocket.m
+++ b/Firebase/Database/third_party/SocketRocket/FSRWebSocket.m
@@ -14,6 +14,8 @@
 //   limitations under the License.
 //
 
+#import <Foundation/Foundation.h>
+
 #import "FSRWebSocket.h"
 
 #if TARGET_OS_IOS

--- a/Firebase/Storage/FIRStorageUtils.m
+++ b/Firebase/Storage/FIRStorageUtils.m
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <Foundation/Foundation.h>
+
 #if TARGET_OS_IOS
 #import <MobileCoreServices/MobileCoreServices.h>
 #elif TARGET_OS_OSX


### PR DESCRIPTION
The #if check added in the macOS PR was depending on the pch inserted into the CocoaPods build to import TargetConditionals.h and define the TARGET_OS's. 

This PR makes the build succeed outside of CocoaPods by importing Foundation wherever the TARGET_OS is checked. 