### PR TITLE
Uses framework imports for GoogleSignIn, FBSDKCoreKit, and FBSDKLoginKit

### DIFF
--- a/AuthSamples/Sample/FacebookAuthProvider.m
+++ b/AuthSamples/Sample/FacebookAuthProvider.m
@@ -16,11 +16,12 @@
 
 #import "FacebookAuthProvider.h"
 
+#import <FBSDKCoreKit/FBSDKCoreKit.h>
+#import <FBSDKLoginKit/FBSDKLoginKit.h>
+
 #import "FIRFacebookAuthProvider.h"
 #import "ApplicationDelegate.h"
 #import "AuthCredentials.h"
-#import "FBSDKCoreKit.h"
-#import "FBSDKLoginKit.h"
 
 /** @var kFacebookAppId
     @brief The App ID for the Facebook SDK.

--- a/AuthSamples/Sample/GoogleAuthProvider.m
+++ b/AuthSamples/Sample/GoogleAuthProvider.m
@@ -16,13 +16,12 @@
 
 #import "GoogleAuthProvider.h"
 
+#import <GoogleSignIn/GoogleSignIn.h>
+
 #import "FIRApp.h"
 #import "FIROptions.h"
 #import "FIRGoogleAuthProvider.h"
 #import "ApplicationDelegate.h"
-
-@import GoogleSignIn;
-
 
 /** @typedef GoogleSignInCallback
     @brief The type of block invoked when a @c GIDGoogleUser object is ready or an error has
@@ -34,8 +33,6 @@ typedef void (^GoogleSignInCallback)(GIDGoogleUser *user, NSError *error);
 
 /** @class GoogleAuthDelegate
     @brief The designated delegate class for Google Sign-In.
-    @param callback A block which is invoked when the sign-in flow finishes. Invoked asynchronously
-        on an unspecified thread in the future.
  */
 @interface GoogleAuthDelegate : NSObject <GIDSignInDelegate, GIDSignInUIDelegate, OpenURLDelegate>
 


### PR DESCRIPTION
This is to make the code more flexible in other build environments.
