### PR TITLE
Rename FirebaseDev to FirebaseCommunity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_install:
 
 script:
   - ./test.sh
-  - pod lib lint FirebaseDev.podspec
+  - pod lib lint FirebaseCommunity.podspec

--- a/AuthSamples/Podfile
+++ b/AuthSamples/Podfile
@@ -2,7 +2,7 @@ use_frameworks!
 platform :ios, '8.0'
 
 target 'Sample' do
-  pod 'FirebaseDev/Auth', :path => '../'
+  pod 'FirebaseCommunity/Auth', :path => '../'
   pod 'FBSDKLoginKit'
   pod 'GoogleSignIn'
   # Lock to the 1.0.9 version of InstanceID since 1.0.10 added a dependency
@@ -12,30 +12,30 @@ target 'Sample' do
 end
 
 target 'SwiftSample' do
-  pod 'FirebaseDev/Auth', :path => '../'
+  pod 'FirebaseCommunity/Auth', :path => '../'
   pod 'GoogleSignIn'
   pod 'FirebaseInstanceID', '1.0.9'
 end
 
 target 'ApiTests' do
-  pod 'FirebaseDev/Auth', :path => '../'
+  pod 'FirebaseCommunity/Auth', :path => '../'
   pod 'GoogleSignIn'
   pod 'FirebaseInstanceID', '1.0.9'
   pod 'GTMSessionFetcher/Core'
 end
 
 target 'EarlGreyTests' do
-  pod 'FirebaseDev/Auth', :path => '../'
+  pod 'FirebaseCommunity/Auth', :path => '../'
   pod 'GoogleSignIn'
   pod 'FirebaseInstanceID', '1.0.9'
   pod 'EarlGrey'
 end
 
 target 'TestApp' do
-  pod 'FirebaseDev/Auth', :path => '../'
+  pod 'FirebaseCommunity/Auth', :path => '../'
 end
 
 target 'FirebaseAuthUnitTests' do
-  pod 'FirebaseDev/Auth', :path => '../'
+  pod 'FirebaseCommunity/Auth', :path => '../'
   pod 'OCMock'
 end

--- a/AuthSamples/Samples.xcodeproj/project.pbxproj
+++ b/AuthSamples/Samples.xcodeproj/project.pbxproj
@@ -105,7 +105,7 @@
 		DEE13A161E9FFD1F00D1BABA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DEE13A141E9FFD1F00D1BABA /* LaunchScreen.storyboard */; };
 		DEE13A171E9FFD1F00D1BABA /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DEE13A151E9FFD1F00D1BABA /* Main.storyboard */; };
 		DEE13A1A1E9FFD2E00D1BABA /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DEE13A191E9FFD2E00D1BABA /* GoogleService-Info.plist */; };
-		DEE13AA21EA1724300D1BABA /* FirebaseDev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEE13A2C1EA12B8D00D1BABA /* FirebaseDev.framework */; };
+		DEE13AA21EA1724300D1BABA /* FirebaseCommunity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DEE13A2C1EA12B8D00D1BABA /* FirebaseCommunity.framework */; };
 		DEE13ACB1EA1764B00D1BABA /* Auth-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DEE13ABE1EA1764B00D1BABA /* Auth-Info.plist */; };
 		DEE13ACC1EA1764B00D1BABA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DEE13AC01EA1764B00D1BABA /* LaunchScreen.storyboard */; };
 		DEE13ACD1EA1764B00D1BABA /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DEE13AC21EA1764B00D1BABA /* Main.storyboard */; };
@@ -289,7 +289,7 @@
 		DEE13A191E9FFD2E00D1BABA /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		DEE13A201EA1252D00D1BABA /* ApiTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ApiTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DEE13A241EA1252D00D1BABA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		DEE13A2C1EA12B8D00D1BABA /* FirebaseDev.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseDev.framework; path = "../../../Library/Developer/Xcode/DerivedData/Samples-dzyyktlzbrpvmobgpcqwaobjmibu/Build/Products/Debug-iphonesimulator/FirebaseDev/FirebaseDev.framework"; sourceTree = "<group>"; };
+		DEE13A2C1EA12B8D00D1BABA /* FirebaseCommunity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseCommunity.framework; path = "../../../Library/Developer/Xcode/DerivedData/Samples-dzyyktlzbrpvmobgpcqwaobjmibu/Build/Products/Debug-iphonesimulator/FirebaseCommunity/FirebaseCommunity.framework"; sourceTree = "<group>"; };
 		DEE13A321EA1642A00D1BABA /* EarlGreyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EarlGreyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DEE13A361EA1642A00D1BABA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DEE13A421EA16EE400D1BABA /* FirebaseAuthUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FirebaseAuthUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -343,7 +343,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DEE13AA21EA1724300D1BABA /* FirebaseDev.framework in Frameworks */,
+				DEE13AA21EA1724300D1BABA /* FirebaseCommunity.framework in Frameworks */,
 				BD555A1DCF4E889DC3338248 /* Pods_FirebaseAuthUnitTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -585,7 +585,7 @@
 		FC34A5565C2ACFA8C5AA3B1E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				DEE13A2C1EA12B8D00D1BABA /* FirebaseDev.framework */,
+				DEE13A2C1EA12B8D00D1BABA /* FirebaseCommunity.framework */,
 				D5FE06BD9AA795DFBA9EFAAD /* Pods_Sample.framework */,
 				BC8C39EF1F42A0C750FF5186 /* Pods_SwiftSample.framework */,
 				6EC09307D636721EAAB89BB2 /* Pods_ApiTests.framework */,

--- a/AuthSamples/SwiftSample/AppDelegate.swift
+++ b/AuthSamples/SwiftSample/AppDelegate.swift
@@ -16,7 +16,7 @@
 
 import UIKit
 
-import FirebaseDev.FirebaseCore
+import FirebaseCommunity.FirebaseCore
 import GoogleSignIn
 
 @UIApplicationMain

--- a/AuthSamples/SwiftSample/ViewController.swift
+++ b/AuthSamples/SwiftSample/ViewController.swift
@@ -16,7 +16,7 @@
 
 import UIKit
 
-import FirebaseDev.FirebaseAuth
+import FirebaseCommunity.FirebaseAuth
 import GoogleSignIn
 
 final class ViewController: UIViewController, UITextFieldDelegate {

--- a/Example/Firebase.xcodeproj/project.pbxproj
+++ b/Example/Firebase.xcodeproj/project.pbxproj
@@ -179,7 +179,7 @@
 		D064E6B51ED9B31C001956DF /* FIRTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = DEE14D7C1E844677006FA992 /* FIRTestCase.m */; };
 		D067EF831ED9BDE00095C27F /* Shared.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AFAF36F41EC28C25004BDEE5 /* Shared.xcassets */; };
 		D067EF841ED9BDFF0095C27F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = DEE14D711E844677006FA992 /* GoogleService-Info.plist */; };
-		D090052E1EDB2FA300154410 /* FirebaseDev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D090052D1EDB2FA300154410 /* FirebaseDev.framework */; };
+		D090052E1EDB2FA300154410 /* FirebaseCommunity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D090052D1EDB2FA300154410 /* FirebaseCommunity.framework */; };
 		D09005311EDB32D600154410 /* OCMock-iOS/OCMock.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D09005301EDB32D600154410 /* OCMock-iOS/OCMock.framework */; settings = {ATTRIBUTES = (); }; };
 		D09005331EDB32F100154410 /* OCMock-iOS/OCMock.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D09005301EDB32D600154410 /* OCMock-iOS/OCMock.framework */; settings = {ATTRIBUTES = (); }; };
 		D09005351EDB330E00154410 /* OCMock-iOS/OCMock.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D09005301EDB32D600154410 /* OCMock-iOS/OCMock.framework */; settings = {ATTRIBUTES = (); }; };
@@ -193,18 +193,18 @@
 		D09005471EDB359F00154410 /* OCMock-OSX/OCMock.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D090053F1EDB34F900154410 /* OCMock-OSX/OCMock.framework */; settings = {ATTRIBUTES = (); }; };
 		D09005491EDB35B700154410 /* OCMock-OSX/OCMock.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D090053F1EDB34F900154410 /* OCMock-OSX/OCMock.framework */; settings = {ATTRIBUTES = (); }; };
 		D090054B1EDB35C100154410 /* OCMock-OSX/OCMock.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D090053F1EDB34F900154410 /* OCMock-OSX/OCMock.framework */; settings = {ATTRIBUTES = (); }; };
-		D090054F1EDB366100154410 /* FirebaseDev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D090054E1EDB366100154410 /* FirebaseDev.framework */; };
-		D09005531EDB36BD00154410 /* FirebaseDev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09005521EDB36BD00154410 /* FirebaseDev.framework */; };
-		D09005571EDB36ED00154410 /* FirebaseDev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09005561EDB36ED00154410 /* FirebaseDev.framework */; };
-		D09005581EDB370500154410 /* FirebaseDev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09005561EDB36ED00154410 /* FirebaseDev.framework */; };
-		D090055C1EDB372000154410 /* FirebaseDev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D090055B1EDB372000154410 /* FirebaseDev.framework */; };
-		D090055D1EDB372800154410 /* FirebaseDev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D090055B1EDB372000154410 /* FirebaseDev.framework */; };
-		D090055F1EDB372E00154410 /* FirebaseDev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D090055E1EDB372E00154410 /* FirebaseDev.framework */; };
-		D09005671EDB37A600154410 /* FirebaseDev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09005661EDB37A600154410 /* FirebaseDev.framework */; };
-		D09005681EDB37AE00154410 /* FirebaseDev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09005661EDB37A600154410 /* FirebaseDev.framework */; };
-		D090056B1EDB37DD00154410 /* FirebaseDev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09005691EDB37B600154410 /* FirebaseDev.framework */; };
-		D090056C1EDB37E500154410 /* FirebaseDev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09005541EDB36DB00154410 /* FirebaseDev.framework */; };
-		D090056D1EDB37E800154410 /* FirebaseDev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09005541EDB36DB00154410 /* FirebaseDev.framework */; };
+		D090054F1EDB366100154410 /* FirebaseCommunity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D090054E1EDB366100154410 /* FirebaseCommunity.framework */; };
+		D09005531EDB36BD00154410 /* FirebaseCommunity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09005521EDB36BD00154410 /* FirebaseCommunity.framework */; };
+		D09005571EDB36ED00154410 /* FirebaseCommunity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09005561EDB36ED00154410 /* FirebaseCommunity.framework */; };
+		D09005581EDB370500154410 /* FirebaseCommunity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09005561EDB36ED00154410 /* FirebaseCommunity.framework */; };
+		D090055C1EDB372000154410 /* FirebaseCommunity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D090055B1EDB372000154410 /* FirebaseCommunity.framework */; };
+		D090055D1EDB372800154410 /* FirebaseCommunity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D090055B1EDB372000154410 /* FirebaseCommunity.framework */; };
+		D090055F1EDB372E00154410 /* FirebaseCommunity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D090055E1EDB372E00154410 /* FirebaseCommunity.framework */; };
+		D09005671EDB37A600154410 /* FirebaseCommunity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09005661EDB37A600154410 /* FirebaseCommunity.framework */; };
+		D09005681EDB37AE00154410 /* FirebaseCommunity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09005661EDB37A600154410 /* FirebaseCommunity.framework */; };
+		D090056B1EDB37DD00154410 /* FirebaseCommunity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09005691EDB37B600154410 /* FirebaseCommunity.framework */; };
+		D090056C1EDB37E500154410 /* FirebaseCommunity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09005541EDB36DB00154410 /* FirebaseCommunity.framework */; };
+		D090056D1EDB37E800154410 /* FirebaseCommunity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D09005541EDB36DB00154410 /* FirebaseCommunity.framework */; };
 		D0EDB2C51EDA04F800B6C31B /* Shared.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AFAF36F41EC28C25004BDEE5 /* Shared.xcassets */; };
 		D0EDB2D71EDA057800B6C31B /* FIRAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = D0EDB2D21EDA056A00B6C31B /* FIRAppDelegate.m */; };
 		D0EDB2D81EDA057800B6C31B /* FIRViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D0EDB2D41EDA056A00B6C31B /* FIRViewController.m */; };
@@ -859,17 +859,17 @@
 		D064E6A41ED9B1BF001956DF /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		D064E6A61ED9B1BF001956DF /* Core-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Core-Info.plist"; sourceTree = "<group>"; };
 		D064E6BF1ED9B31C001956DF /* Core_Tests_macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Core_Tests_macOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D090052D1EDB2FA300154410 /* FirebaseDev.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseDev.framework; path = "FirebaseDev-Auth-Core-Root-iOS/FirebaseDev.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D090052D1EDB2FA300154410 /* FirebaseCommunity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseCommunity.framework; path = "FirebaseCommunity-Auth-Core-Root-iOS/FirebaseCommunity.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D09005301EDB32D600154410 /* OCMock-iOS/OCMock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = "OCMock-iOS/OCMock.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D090053F1EDB34F900154410 /* OCMock-OSX/OCMock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = "OCMock-OSX/OCMock.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D090054E1EDB366100154410 /* FirebaseDev.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseDev.framework; path = "FirebaseDev-Auth-Core-Root-OSX/FirebaseDev.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D09005521EDB36BD00154410 /* FirebaseDev.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseDev.framework; path = "FirebaseDev-Core-Root-iOS/FirebaseDev.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D09005541EDB36DB00154410 /* FirebaseDev.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseDev.framework; path = "FirebaseDev-Core-Root-Storage-OSX/FirebaseDev.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D09005561EDB36ED00154410 /* FirebaseDev.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseDev.framework; path = "FirebaseDev-Core-Database-Root-iOS/FirebaseDev.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D090055B1EDB372000154410 /* FirebaseDev.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseDev.framework; path = "FirebaseDev-Core-Database-Root-OSX/FirebaseDev.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D090055E1EDB372E00154410 /* FirebaseDev.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseDev.framework; path = "FirebaseDev-Core-Messaging-Root/FirebaseDev.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D09005661EDB37A600154410 /* FirebaseDev.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseDev.framework; path = "FirebaseDev-Core-Root-Storage-iOS/FirebaseDev.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D09005691EDB37B600154410 /* FirebaseDev.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseDev.framework; path = "FirebaseDev-Core-Root-OSX/FirebaseDev.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D090054E1EDB366100154410 /* FirebaseCommunity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseCommunity.framework; path = "FirebaseCommunity-Auth-Core-Root-OSX/FirebaseCommunity.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D09005521EDB36BD00154410 /* FirebaseCommunity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseCommunity.framework; path = "FirebaseCommunity-Core-Root-iOS/FirebaseCommunity.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D09005541EDB36DB00154410 /* FirebaseCommunity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseCommunity.framework; path = "FirebaseCommunity-Core-Root-Storage-OSX/FirebaseCommunity.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D09005561EDB36ED00154410 /* FirebaseCommunity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseCommunity.framework; path = "FirebaseCommunity-Core-Database-Root-iOS/FirebaseCommunity.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D090055B1EDB372000154410 /* FirebaseCommunity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseCommunity.framework; path = "FirebaseCommunity-Core-Database-Root-OSX/FirebaseCommunity.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D090055E1EDB372E00154410 /* FirebaseCommunity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseCommunity.framework; path = "FirebaseCommunity-Core-Messaging-Root/FirebaseCommunity.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D09005661EDB37A600154410 /* FirebaseCommunity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseCommunity.framework; path = "FirebaseCommunity-Core-Root-Storage-iOS/FirebaseCommunity.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D09005691EDB37B600154410 /* FirebaseCommunity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FirebaseCommunity.framework; path = "FirebaseCommunity-Core-Root-OSX/FirebaseCommunity.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0EDB2CD1EDA04F800B6C31B /* Storage_Example_macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Storage_Example_macOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0EDB2D01EDA056A00B6C31B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		D0EDB2D11EDA056A00B6C31B /* FIRAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FIRAppDelegate.h; sourceTree = "<group>"; };
@@ -898,7 +898,7 @@
 		DE0E5BB91EA7D92E00FAA825 /* FIRVerifyClientRequestTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FIRVerifyClientRequestTest.m; sourceTree = "<group>"; };
 		DE0E5BBA1EA7D92E00FAA825 /* FIRVerifyClientResponseTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FIRVerifyClientResponseTests.m; sourceTree = "<group>"; };
 		DE45C6641E7DA8CB009E6ACD /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		DE4E711A1E953ABC00070092 /* FirebaseDev.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = FirebaseDev.podspec; path = ../FirebaseDev.podspec; sourceTree = "<group>"; };
+		DE4E711A1E953ABC00070092 /* FirebaseCommunity.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = FirebaseCommunity.podspec; path = ../FirebaseCommunity.podspec; sourceTree = "<group>"; };
 		DE750DB51EB3DD4000A75E47 /* FIRAuthAPNSTokenManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FIRAuthAPNSTokenManagerTests.m; sourceTree = "<group>"; };
 		DE750DB61EB3DD4000A75E47 /* FIRAuthAPNSTokenTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FIRAuthAPNSTokenTests.m; sourceTree = "<group>"; };
 		DE750DB71EB3DD4000A75E47 /* FIRAuthAppCredentialManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FIRAuthAppCredentialManagerTests.m; sourceTree = "<group>"; };
@@ -1075,7 +1075,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				296461E35E6F9E49566104CC /* Pods_Storage_IntegrationTests_iOS.framework in Frameworks */,
-				D09005681EDB37AE00154410 /* FirebaseDev.framework in Frameworks */,
+				D09005681EDB37AE00154410 /* FirebaseCommunity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1084,7 +1084,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BB8642A73C1F482CBEEEA18B /* Pods_Database_IntegrationTests_iOS.framework in Frameworks */,
-				D09005581EDB370500154410 /* FirebaseDev.framework in Frameworks */,
+				D09005581EDB370500154410 /* FirebaseCommunity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1109,7 +1109,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				72A4F3F8704E8148ADF12B0D /* Pods_Auth_Tests_macOS.framework in Frameworks */,
-				D090054F1EDB366100154410 /* FirebaseDev.framework in Frameworks */,
+				D090054F1EDB366100154410 /* FirebaseCommunity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1126,7 +1126,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				45A77EEB247ECF2500F13784 /* Pods_Core_Tests_macOS.framework in Frameworks */,
-				D090056B1EDB37DD00154410 /* FirebaseDev.framework in Frameworks */,
+				D090056B1EDB37DD00154410 /* FirebaseCommunity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1143,7 +1143,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C01629804D17B03619DABA5D /* Pods_Storage_Tests_macOS.framework in Frameworks */,
-				D090056D1EDB37E800154410 /* FirebaseDev.framework in Frameworks */,
+				D090056D1EDB37E800154410 /* FirebaseCommunity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1152,7 +1152,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5BA5BCACADA152589E33D130 /* Pods_Storage_IntegrationTests_macOS.framework in Frameworks */,
-				D090056C1EDB37E500154410 /* FirebaseDev.framework in Frameworks */,
+				D090056C1EDB37E500154410 /* FirebaseCommunity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1169,7 +1169,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				960665EC1C5F7A0E843A354F /* Pods_Database_Tests_macOS.framework in Frameworks */,
-				D090055C1EDB372000154410 /* FirebaseDev.framework in Frameworks */,
+				D090055C1EDB372000154410 /* FirebaseCommunity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1178,7 +1178,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1D6A9D4E7CD72397532C488F /* Pods_Database_IntegrationTests_macOS.framework in Frameworks */,
-				D090055D1EDB372800154410 /* FirebaseDev.framework in Frameworks */,
+				D090055D1EDB372800154410 /* FirebaseCommunity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1195,7 +1195,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B4C784B02835699995BDB245 /* Pods_Database_Tests_iOS.framework in Frameworks */,
-				D09005571EDB36ED00154410 /* FirebaseDev.framework in Frameworks */,
+				D09005571EDB36ED00154410 /* FirebaseCommunity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1212,7 +1212,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D22080FB4B7F4238FAC548D6 /* Pods_Auth_Tests_iOS.framework in Frameworks */,
-				D090052E1EDB2FA300154410 /* FirebaseDev.framework in Frameworks */,
+				D090052E1EDB2FA300154410 /* FirebaseCommunity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1221,7 +1221,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7AE9A7433F2BD9A52022AC71 /* Pods_Messaging_Tests_iOS.framework in Frameworks */,
-				D090055F1EDB372E00154410 /* FirebaseDev.framework in Frameworks */,
+				D090055F1EDB372E00154410 /* FirebaseCommunity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1241,7 +1241,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				53F96D962AC7E1FB44B321D7 /* Pods_Storage_Tests_iOS.framework in Frameworks */,
-				D09005671EDB37A600154410 /* FirebaseDev.framework in Frameworks */,
+				D09005671EDB37A600154410 /* FirebaseCommunity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1258,7 +1258,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7A02646DEF386689CCFB9011 /* Pods_Core_Tests_iOS.framework in Frameworks */,
-				D09005531EDB36BD00154410 /* FirebaseDev.framework in Frameworks */,
+				D09005531EDB36BD00154410 /* FirebaseCommunity.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1377,15 +1377,15 @@
 		6003F58C195388D20070C39A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				D09005691EDB37B600154410 /* FirebaseDev.framework */,
-				D09005661EDB37A600154410 /* FirebaseDev.framework */,
-				D090055E1EDB372E00154410 /* FirebaseDev.framework */,
-				D090055B1EDB372000154410 /* FirebaseDev.framework */,
-				D09005561EDB36ED00154410 /* FirebaseDev.framework */,
-				D09005541EDB36DB00154410 /* FirebaseDev.framework */,
-				D09005521EDB36BD00154410 /* FirebaseDev.framework */,
-				D090054E1EDB366100154410 /* FirebaseDev.framework */,
-				D090052D1EDB2FA300154410 /* FirebaseDev.framework */,
+				D09005691EDB37B600154410 /* FirebaseCommunity.framework */,
+				D09005661EDB37A600154410 /* FirebaseCommunity.framework */,
+				D090055E1EDB372E00154410 /* FirebaseCommunity.framework */,
+				D090055B1EDB372000154410 /* FirebaseCommunity.framework */,
+				D09005561EDB36ED00154410 /* FirebaseCommunity.framework */,
+				D09005541EDB36DB00154410 /* FirebaseCommunity.framework */,
+				D09005521EDB36BD00154410 /* FirebaseCommunity.framework */,
+				D090054E1EDB366100154410 /* FirebaseCommunity.framework */,
+				D090052D1EDB2FA300154410 /* FirebaseCommunity.framework */,
 				D09005301EDB32D600154410 /* OCMock-iOS/OCMock.framework */,
 				D090053F1EDB34F900154410 /* OCMock-OSX/OCMock.framework */,
 				DE45C6641E7DA8CB009E6ACD /* XCTest.framework */,
@@ -1422,7 +1422,7 @@
 		60FF7A9C1954A5C5007DD14C /* Podspec Metadata */ = {
 			isa = PBXGroup;
 			children = (
-				DE4E711A1E953ABC00070092 /* FirebaseDev.podspec */,
+				DE4E711A1E953ABC00070092 /* FirebaseCommunity.podspec */,
 				8496034D8156555C5FCF8F14 /* README.md */,
 				E2C2834C90DBAB56D568189F /* LICENSE */,
 			);

--- a/Example/Messaging/App/iOS/AppDelegate.swift
+++ b/Example/Messaging/App/iOS/AppDelegate.swift
@@ -15,7 +15,7 @@
  */
 
 import UIKit
-import FirebaseDev
+import FirebaseCommunity
 import UserNotifications
 
 @UIApplicationMain

--- a/Example/Messaging/App/iOS/MessagingViewController.swift
+++ b/Example/Messaging/App/iOS/MessagingViewController.swift
@@ -16,7 +16,7 @@
 
 import UIKit
 
-import FirebaseDev
+import FirebaseCommunity
 
 enum Row: String {
   case apnsToken = "apnsToken"

--- a/Example/Messaging/App/iOS/NotificationsController.swift
+++ b/Example/Messaging/App/iOS/NotificationsController.swift
@@ -17,7 +17,7 @@
 import UIKit
 import UserNotifications
 
-import FirebaseDev
+import FirebaseCommunity
 
 enum NotificationsControllerAllowedNotificationType: String {
   case none = "None"

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -4,7 +4,7 @@ use_frameworks!
 target 'Core_Example_iOS' do
   platform :ios, '8.0'
 
-  pod 'FirebaseDev/Core', :path => '../'
+  pod 'FirebaseCommunity/Core', :path => '../'
 
   target 'Core_Tests_iOS' do
     inherit! :search_paths
@@ -15,7 +15,7 @@ end
 target 'Core_Example_macOS' do
   platform :osx, '10.10'
 
-  pod 'FirebaseDev/Core', :path => '../'
+  pod 'FirebaseCommunity/Core', :path => '../'
 
   target 'Core_Tests_macOS' do
     inherit! :search_paths
@@ -26,7 +26,7 @@ end
 target 'Auth_Example_iOS' do
   platform :ios, '8.0'
 
-  pod 'FirebaseDev/Auth', :path => '../'
+  pod 'FirebaseCommunity/Auth', :path => '../'
 
   target 'Auth_Tests_iOS' do
     inherit! :search_paths
@@ -37,7 +37,7 @@ end
 target 'Auth_Example_macOS' do
   platform :osx, '10.10'
 
-  pod 'FirebaseDev/Auth', :path => '../'
+  pod 'FirebaseCommunity/Auth', :path => '../'
 
   target 'Auth_Tests_macOS' do
     inherit! :search_paths
@@ -48,7 +48,7 @@ end
 target 'Database_Example_iOS' do
   platform :ios, '8.0'
 
-  pod 'FirebaseDev/Database', :path => '../'
+  pod 'FirebaseCommunity/Database', :path => '../'
 
   target 'Database_Tests_iOS' do
     inherit! :search_paths
@@ -64,7 +64,7 @@ end
 target 'Database_Example_macOS' do
   platform :osx, '10.10'
 
-  pod 'FirebaseDev/Database', :path => '../'
+  pod 'FirebaseCommunity/Database', :path => '../'
 
   target 'Database_Tests_macOS' do
     inherit! :search_paths
@@ -80,7 +80,7 @@ end
 target 'Messaging_Example_iOS' do
   platform :ios, '8.0'
 
-  pod 'FirebaseDev/Messaging', :path => '../'
+  pod 'FirebaseCommunity/Messaging', :path => '../'
   # Lock to the 1.0.9 version of InstanceID since 1.0.10 added a dependency
   # to FirebaseCore
   pod 'FirebaseInstanceID', '1.0.9'
@@ -94,7 +94,7 @@ end
 target 'Storage_Example_iOS' do
   platform :ios, '8.0'
 
-  pod 'FirebaseDev/Storage', :path => '../'
+  pod 'FirebaseCommunity/Storage', :path => '../'
 
   target 'Storage_Tests_iOS' do
     inherit! :search_paths
@@ -110,7 +110,7 @@ end
 target 'Storage_Example_macOS' do
   platform :osx, '10.10'
 
-  pod 'FirebaseDev/Storage', :path => '../'
+  pod 'FirebaseCommunity/Storage', :path => '../'
 
   target 'Storage_Tests_macOS' do
     inherit! :search_paths

--- a/Firebase/Auth/FirebaseAuth.podspec
+++ b/Firebase/Auth/FirebaseAuth.podspec
@@ -15,7 +15,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.license          = { :type => 'Apache', :file => '../../LICENSE' }
   s.authors          = 'Google, Inc.'
 
-  # NOTE that the FirebaseDev pod is neither publicly deployed nor yet interchangeable with the
+  # NOTE that the FirebaseCommunity pod is neither publicly deployed nor yet interchangeable with the
   # Firebase pod
   s.source           = { :git => 'https://github.com/firebase/firebase-ios-sdk.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/Firebase'
@@ -59,7 +59,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
     ' FIRAuth_MINOR_VERSION=' + s.version.to_s.split(".")[0] + "." + s.version.to_s.split(".")[1]
   }
   s.framework = 'Security'
-#  s.dependency 'FirebaseDev/Core'
+#  s.dependency 'FirebaseCommunity/Core'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
   s.dependency 'GoogleToolboxForMac/NSDictionary+URLArguments', '~> 2.1'
 end

--- a/Firebase/Core/FirebaseCore.podspec
+++ b/Firebase/Core/FirebaseCore.podspec
@@ -15,7 +15,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.license          = { :type => 'Apache', :file => '../../LICENSE' }
   s.authors          = 'Google, Inc.'
 
-  # NOTE that the FirebaseDev pod is neither publicly deployed nor yet interchangeable with the
+  # NOTE that the FirebaseCommunity pod is neither publicly deployed nor yet interchangeable with the
   # Firebase pod
   s.source           = { :git => 'https://github.com/firebase/firebase-ios-sdk.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/Firebase'

--- a/Firebase/Database/FirebaseDatabase.podspec
+++ b/Firebase/Database/FirebaseDatabase.podspec
@@ -15,7 +15,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.license          = { :type => 'Apache', :file => '../../LICENSE' }
   s.authors          = 'Google, Inc.'
 
-  # NOTE that the FirebaseDev pod is neither publicly deployed nor yet interchangeable with the
+  # NOTE that the FirebaseCommunity pod is neither publicly deployed nor yet interchangeable with the
   # Firebase pod
   s.source           = { :git => 'https://github.com/firebase/firebase-ios-sdk.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/Firebase'
@@ -42,7 +42,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.framework = 'Security'
   s.framework = 'SystemConfiguration'
   s.dependency 'leveldb-library'
-#  s.dependency 'FirebaseDev/Core'
+#  s.dependency 'FirebaseCommunity/Core'
   s.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' =>
     '$(inherited) ' +
     'FIRDatabase_VERSION=' + s.version.to_s }

--- a/Firebase/Messaging/FirebaseMessaging.podspec
+++ b/Firebase/Messaging/FirebaseMessaging.podspec
@@ -15,7 +15,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.license          = { :type => 'Apache', :file => '../../LICENSE' }
   s.authors          = 'Google, Inc.'
 
-  # NOTE that the FirebaseDev pod is neither publicly deployed nor yet interchangeable with the
+  # NOTE that the FirebaseCommunity pod is neither publicly deployed nor yet interchangeable with the
   # Firebase pod
   s.source           = { :git => 'https://github.com/firebase/firebase-ios-sdk.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/Firebase'
@@ -35,7 +35,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   }
   s.framework = 'AddressBook'
   s.framework = 'SystemConfiguration'
-#  s.dependency 'FirebaseDev/Core'
+#  s.dependency 'FirebaseCommunity/Core'
   s.dependency 'GoogleToolboxForMac/Logger', '~> 2.1'
   s.dependency 'Protobuf', '~> 3.1'
 end

--- a/Firebase/Storage/FirebaseStorage.podspec
+++ b/Firebase/Storage/FirebaseStorage.podspec
@@ -15,7 +15,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.license          = { :type => 'Apache', :file => '../../LICENSE' }
   s.authors          = 'Google, Inc.'
 
-  # NOTE that the FirebaseDev pod is neither publicly deployed nor yet interchangeable with the
+  # NOTE that the FirebaseCommunity pod is neither publicly deployed nor yet interchangeable with the
   # Firebase pod
   s.source           = { :git => 'https://github.com/firebase/firebase-ios-sdk.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/Firebase'
@@ -38,7 +38,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
 
   s.ios.framework = 'MobileCoreServices'
   s.osx.framework = 'CoreServices'
-#    s.dependency 'FirebaseDev/Core'
+#    s.dependency 'FirebaseCommunity/Core'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
   s.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' =>
     '$(inherited) ' +

--- a/FirebaseCommunity.podspec
+++ b/FirebaseCommunity.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name             = 'FirebaseDev'
+  s.name             = 'FirebaseCommunity'
   s.version          = '0.0.1'
   s.summary          = 'Firebase Open Source Libraries for iOS.'
 
@@ -11,7 +11,7 @@ Firebase Development CocoaPod including experimental and community supported fea
   s.license          = { :type => 'Apache', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
-  # NOTE that the FirebaseDev pod is neither publicly deployed nor yet interchangeable with the
+  # NOTE that the FirebaseCommunity pod is neither publicly deployed nor yet interchangeable with the
   # Firebase pod
   s.source           = { :git => 'https://github.com/firebase/firebase-ios-sdk.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/Firebase'
@@ -37,7 +37,7 @@ Firebase Development CocoaPod including experimental and community supported fea
       'Firebase/Core/FIROptions.h',
       'Firebase/Core/FIRCoreSwiftNameSupport.h'
     sp.dependency 'GoogleToolboxForMac/NSData+zlib', '~> 2.1'
-    sp.dependency 'FirebaseDev/Root'
+    sp.dependency 'FirebaseCommunity/Root'
   end
 
   s.subspec 'Auth' do |sp|
@@ -77,7 +77,7 @@ Firebase Development CocoaPod including experimental and community supported fea
       ' -DFIRAuth_MINOR_VERSION=' + s.version.to_s.split(".")[0] + "." + s.version.to_s.split(".")[1]
     }
     sp.framework = 'Security'
-    sp.dependency 'FirebaseDev/Core'
+    sp.dependency 'FirebaseCommunity/Core'
     sp.dependency 'GTMSessionFetcher/Core', '~> 1.1'
     sp.dependency 'GoogleToolboxForMac/NSDictionary+URLArguments', '~> 2.1'
   end
@@ -103,7 +103,7 @@ Firebase Development CocoaPod including experimental and community supported fea
     sp.framework = 'Security'
     sp.framework = 'SystemConfiguration'
     sp.dependency 'leveldb-library'
-    sp.dependency 'FirebaseDev/Core'
+    sp.dependency 'FirebaseCommunity/Core'
     sp.xcconfig = { 'OTHER_CFLAGS' => '-DFIRDatabase_VERSION=' + s.version.to_s }
   end
 
@@ -123,7 +123,7 @@ Firebase Development CocoaPod including experimental and community supported fea
     }
     sp.framework = 'AddressBook'
     sp.framework = 'SystemConfiguration'
-    sp.dependency 'FirebaseDev/Core'
+    sp.dependency 'FirebaseCommunity/Core'
     sp.dependency 'GoogleToolboxForMac/Logger', '~> 2.1'
     sp.dependency 'Protobuf', '~> 3.1'
   end
@@ -144,7 +144,7 @@ Firebase Development CocoaPod including experimental and community supported fea
       'Firebase/Storage/FIRStorageUploadTask.h'
     sp.ios.framework = 'MobileCoreServices'
     sp.osx.framework = 'CoreServices'
-    sp.dependency 'FirebaseDev/Core'
+    sp.dependency 'FirebaseCommunity/Core'
     sp.dependency 'GTMSessionFetcher/Core', '~> 1.1'
     sp.xcconfig = { 'OTHER_CFLAGS' => '-DFIRStorage_VERSION=' + s.version.to_s }
   end

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ FirebaseAuth, FirebaseDatabase, FirebaseMessaging, and FirebaseStorage. By
 following the usage instructions below, they can be developed and debugged with
 unit tests, integration tests, and reference samples.
 
-Note, however, that the resulting FirebaseDev pod is NOT interoperable with the
+Note, however, that the resulting FirebaseCommunity pod is NOT interoperable with the
 official Firebase release pods because of different pod dependency definitions.
 
 Instructions and a script to build replaceable static library
@@ -83,16 +83,16 @@ The iOS Simulator cannot register for remote notifications, and will not receive
  
 We've seen an amazing amount of interest and contributions to improve the Firebase SDKs, and we are very grateful!  We'd like to empower as many developers as we can to be able to use Firebase and participate in the Firebase community. 
  
-Note that if you are using CocoaPods and using the FirebaseDev podspec (the one in this repo), you cannot bring in Pods from the official Firebase podspec, because of duplicated symbol conflicts. If you're not using one of the open-source SDKs in this repo for development purposes, we recommend using the regular Firebase pods for the best experience.
+Note that if you are using CocoaPods and using the FirebaseCommunity podspec (the one in this repo), you cannot bring in Pods from the official Firebase podspec, because of duplicated symbol conflicts. If you're not using one of the open-source SDKs in this repo for development purposes, we recommend using the regular Firebase pods for the best experience.
  
-To get started using the FirebaseDev SDKs, here is a typical Podfile:
+To get started using the FirebaseCommunity SDKs, here is a typical Podfile:
  
 ```
 use_frameworks!
  
 target 'MyAppTarget' do
   platform :ios, '8.0'
-  pod 'FirebaseDev', :git => 'https://github.com/firebase/firebase-ios-sdk.git'
+  pod 'FirebaseCommunity', :git => 'https://github.com/firebase/firebase-ios-sdk.git'
 end
 ``` 
 Replace `MyAppTarget` with the name of the target in your Xcode project.


### PR DESCRIPTION
Renamed to better delineate the purpose of the FirebaseCommunity pod as opposed to the Firebase pod.  See the [README](https://github.com/firebase/firebase-ios-sdk/blob/master/README.md) for more details.