### PR TITLE
Not sending messages to closed websocket connections

### DIFF
--- a/Firebase/Database/Realtime/FWebSocketConnection.m
+++ b/Firebase/Database/Realtime/FWebSocketConnection.m
@@ -163,7 +163,7 @@
 }
 
 - (void) nop:(NSTimer *)timer {
-    if(self.webSocket) {
+    if (!isClosed) {
         FFLog(@"I-RDB083004", @"(wsc:%@) nop", self.connectionId);
         [self.webSocket send:@"0"];        
     }


### PR DESCRIPTION
This should be a safe change since the timer function 'nop' is only ever run after the WebSocket is initialized.

This works around potential issues in the WebSocket layer after we close the connection and should address Google-internal issue: https://b.corp.google.com/issues/62363018