### PR TITLE
Add UIKit import to FIRAuth implementation

### DIFF
--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -15,6 +15,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 #import "Private/FIRAuth_Internal.h"
 

--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -15,7 +15,6 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 
 #import "Private/FIRAuth_Internal.h"
 
@@ -58,6 +57,7 @@
 #import "FIRVerifyPhoneNumberResponse.h"
 
 #if TARGET_OS_IOS
+#import <UIKit/UIKit.h>
 #import "Private/FIRAuthAPNSToken.h"
 #import "Private/FIRAuthAPNSTokenManager.h"
 #import "Private/FIRAuthAppCredentialManager.h"


### PR DESCRIPTION
Adds UIKit import to FIRAuth implementation. UIApplicationDidBecomeActiveNotification is used by this class so UIKit should be explicitly imported.