### PR TITLE
Fixing parsing for double numbers

### DIFF
--- a/Example/Database/Tests/Integration/FEventTests.m
+++ b/Example/Database/Tests/Integration/FEventTests.m
@@ -74,10 +74,6 @@
         
 }
 
-- (void) testWriteTwoNestedLeafNodesChange {
-    
-}
-
 - (void) testSetMultipleEventListenersOnSameNode {
     
     FTupleFirebase* tuple = [FTestHelpers getRandomNodePair];

--- a/Example/Database/Tests/Unit/FLevelDBStorageEngineTests.m
+++ b/Example/Database/Tests/Unit/FLevelDBStorageEngineTests.m
@@ -491,6 +491,26 @@
     XCTAssertEqualObjects([[engine serverCacheAtPath:PATH(@"foo")] dataHash], hashFor247);
 }
 
+- (void)testIntegersAreReturnedsAsIntegers {
+    id intValue = @247;
+    id longValue = @1542405709418655810;
+    id doubleValue = @0xFFFFFFFFFFFFFFFFUL;  // This number can't be represented as a signed long.
+  
+    id<FNode> expectedData = NODE((@{@"int": @247, @"long": longValue, @"double": doubleValue}));
+    FLevelDBStorageEngine *engine = [self cleanStorageEngine];
+    [engine updateServerCache:expectedData atPath:PATH(@"foo") merge:NO];
+    id<FNode> actualData = [engine serverCacheAtPath:PATH(@"foo")];
+    NSNumber* actualInt = [actualData val][@"int"];
+    NSNumber* actualLong = [actualData val][@"long"];
+    NSNumber* actualDouble = [actualData val][@"double"];
+  
+    XCTAssertEqualObjects([actualInt stringValue], [intValue stringValue]);
+    XCTAssertEqual(CFNumberGetType((CFNumberRef)actualInt), kCFNumberSInt64Type);
+    XCTAssertEqualObjects([actualLong stringValue ], [longValue stringValue]);
+    XCTAssertEqual(CFNumberGetType((CFNumberRef)actualLong), kCFNumberSInt64Type);
+    XCTAssertEqual(CFNumberGetType((CFNumberRef)actualDouble), kCFNumberFloat64Type);
+}
+
 // TODO[offline]: Somehow test estimated server size?
 // TODO[offline]: Test pruning!
 

--- a/Firebase/Database/Persistence/FLevelDBStorageEngine.m
+++ b/Firebase/Database/Persistence/FLevelDBStorageEngine.m
@@ -669,6 +669,8 @@ static NSString* trackedQueryKeysKey(NSUInteger trackedQueryId, NSString *key) {
             if ((double)(long long)[value doubleValue] != [value doubleValue]) {
                 NSString *doubleString = [value stringValue];
                 return [NSNumber numberWithDouble:[doubleString doubleValue]];
+            } else {
+                return [NSNumber numberWithLong:[value longValue]];
             }
         }
     }


### PR DESCRIPTION
NSJSONSerialization parses long values as doubles and returns NSNumber that are backed by doubles to the users. For NSNumbers that can be stored as longs, we can overwrite this behavior by re-running the initialization step.

This addresses https://github.com/firebase/firebase-ios-sdk/issues/91.