### PR TITLE
Use verbose pod lib lint in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_install:
 
 script:
   - ./test.sh
-  - pod lib lint FirebaseCommunity.podspec --verbose
+  - pod lib lint FirebaseCommunity.podspec --verbose | tail -200

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_install:
 
 script:
   - ./test.sh
-  - pod lib lint FirebaseCommunity.podspec
+  - pod lib lint FirebaseCommunity.podspec --verbose


### PR DESCRIPTION
Hopefully helps avoid the `no output received in the last 10m` error that occasionally happens on travis.