### PR TITLE
Change pod spec lint verbose tail to 40

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_install:
 
 script:
   - ./test.sh
-  - pod lib lint FirebaseCommunity.podspec --verbose | tail -200
+  - pod lib lint FirebaseCommunity.podspec --verbose | tail -40


### PR DESCRIPTION
200 is too much easily scroll up to check otherwise successful test runs for 65 error codes