### PR TITLE
Adding size to Storage's NSDictionary representation

### DIFF
--- a/Example/Storage/Tests/Unit/FIRStorageMetadataTests.m
+++ b/Example/Storage/Tests/Unit/FIRStorageMetadataTests.m
@@ -43,8 +43,10 @@
     kFIRStorageMetadataMetageneration : @"67890",
     kFIRStorageMetadataName : @"path/to/object",
     kFIRStorageMetadataTimeCreated : @"1992-08-07T17:22:53.108Z",
-    kFIRStorageMetadataUpdated : @"2016-03-01T20:16:01.673Z"
+    kFIRStorageMetadataUpdated : @"2016-03-01T20:16:01.673Z",
+    kFIRStorageMetadataSize : @1337
   };
+  
   FIRStorageMetadata *metadata = [[FIRStorageMetadata alloc] initWithDictionary:metaDict];
   XCTAssertNotNil(metadata);
   XCTAssertEqualObjects(metadata.bucket, metaDict[kFIRStorageMetadataBucket]);
@@ -69,6 +71,8 @@
                         metaDict[kFIRStorageMetadataTimeCreated]);
   XCTAssertEqualObjects([metadata RFC3339StringFromDate:metadata.updated],
                         metaDict[kFIRStorageMetadataUpdated]);
+  NSNumber *size = [NSNumber numberWithLong:metadata.size];
+  XCTAssertEqualObjects(size, metaDict[kFIRStorageMetadataSize]);
 }
 
 - (void)testDictionaryRepresentation {
@@ -85,8 +89,10 @@
     kFIRStorageMetadataMetageneration : @"67890",
     kFIRStorageMetadataName : @"path/to/object",
     kFIRStorageMetadataTimeCreated : @"1992-08-07T17:22:53.108Z",
-    kFIRStorageMetadataUpdated : @"2016-03-01T20:16:01.673Z"
+    kFIRStorageMetadataUpdated : @"2016-03-01T20:16:01.673Z",
+    kFIRStorageMetadataSize : @1337
   };
+  
   FIRStorageMetadata *metadata = [[FIRStorageMetadata alloc] initWithDictionary:metaDict];
   NSDictionary *dictRepresentation = [metadata dictionaryRepresentation];
   XCTAssertNotEqual(dictRepresentation, nil);
@@ -116,6 +122,8 @@
                         metaDict[kFIRStorageMetadataTimeCreated]);
   XCTAssertEqualObjects(dictRepresentation[kFIRStorageMetadataUpdated],
                         metaDict[kFIRStorageMetadataUpdated]);
+  XCTAssertEqualObjects(dictRepresentation[kFIRStorageMetadataSize],
+                        metaDict[kFIRStorageMetadataSize]);
 }
 
 - (void)testInitialzeNoDownloadTokensGetToken {

--- a/Example/Storage/Tests/Unit/FIRStorageMetadataTests.m
+++ b/Example/Storage/Tests/Unit/FIRStorageMetadataTests.m
@@ -46,7 +46,6 @@
     kFIRStorageMetadataUpdated : @"2016-03-01T20:16:01.673Z",
     kFIRStorageMetadataSize : @1337
   };
-  
   FIRStorageMetadata *metadata = [[FIRStorageMetadata alloc] initWithDictionary:metaDict];
   XCTAssertNotNil(metadata);
   XCTAssertEqualObjects(metadata.bucket, metaDict[kFIRStorageMetadataBucket]);
@@ -71,7 +70,7 @@
                         metaDict[kFIRStorageMetadataTimeCreated]);
   XCTAssertEqualObjects([metadata RFC3339StringFromDate:metadata.updated],
                         metaDict[kFIRStorageMetadataUpdated]);
-  NSNumber *size = [NSNumber numberWithLong:metadata.size];
+  NSNumber *size = [NSNumber numberWithLongLong:metadata.size];
   XCTAssertEqualObjects(size, metaDict[kFIRStorageMetadataSize]);
 }
 
@@ -92,7 +91,6 @@
     kFIRStorageMetadataUpdated : @"2016-03-01T20:16:01.673Z",
     kFIRStorageMetadataSize : @1337
   };
-  
   FIRStorageMetadata *metadata = [[FIRStorageMetadata alloc] initWithDictionary:metaDict];
   NSDictionary *dictRepresentation = [metadata dictionaryRepresentation];
   XCTAssertNotEqual(dictRepresentation, nil);

--- a/Firebase/Storage/FIRStorageMetadata.m
+++ b/Firebase/Storage/FIRStorageMetadata.m
@@ -180,7 +180,7 @@
   if (_path) {
     metadataDictionary[kFIRStorageMetadataName] = _path;
   }
-  
+
   if (_size) {
     metadataDictionary[kFIRStorageMetadataSize] = [NSNumber numberWithLongLong:_size];
   }

--- a/Firebase/Storage/FIRStorageMetadata.m
+++ b/Firebase/Storage/FIRStorageMetadata.m
@@ -182,7 +182,7 @@
   }
   
   if (_size) {
-    metadataDictionary[kFIRStorageMetadataSize] = [NSNumber numberWithLong:_size];
+    metadataDictionary[kFIRStorageMetadataSize] = [NSNumber numberWithLongLong:_size];
   }
 
   return [metadataDictionary copy];

--- a/Firebase/Storage/FIRStorageMetadata.m
+++ b/Firebase/Storage/FIRStorageMetadata.m
@@ -180,6 +180,10 @@
   if (_path) {
     metadataDictionary[kFIRStorageMetadataName] = _path;
   }
+  
+  if (_size) {
+    metadataDictionary[kFIRStorageMetadataSize] = [NSNumber numberWithLong:_size];
+  }
 
   return [metadataDictionary copy];
 }


### PR DESCRIPTION
Adding the missing size parameter to StorageMetadata.

As per Google internal issue: https://b.corp.google.com/issues/38041797