### PR TITLE
Add method to check if `defaultApp` is configured.

### DIFF
--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -568,6 +568,19 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   XCTAssertEqual([[FIRApp defaultApp] getUID], @"highlander");
 }
 
+- (void)testIsAppConfigured {
+  // Ensure it's false before anything is configured.
+  XCTAssertFalse([FIRApp isDefaultAppConfigured]);
+
+  // Configure it and ensure it's configured.
+  [FIRApp configure];
+  XCTAssertTrue([FIRApp isDefaultAppConfigured]);
+
+  // Reset the apps and ensure it's not configured anymore.
+  [FIRApp resetApps];
+  XCTAssertFalse([FIRApp isDefaultAppConfigured]);
+}
+
 #pragma mark - private
 
 - (NSDictionary <NSString *, NSObject *> *)expectedUserInfoWithAppName:(NSString *)name

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -379,6 +379,10 @@ static FIRApp *sDefaultApp;
   return FIRCreateError(kFirebaseCoreErrorDomain, FIRErrorCodeInvalidAppID, errorDict);
 }
 
++ (BOOL)isDefaultAppConfigured {
+  return (sDefaultApp != nil);
+}
+
 - (void)checkExpectedBundleID {
   NSArray *bundles = [FIRBundleUtil relevantBundles];
   NSString *expectedBundleID = [self expectedBundleID];

--- a/Firebase/Core/Private/FIRAppInternal.h
+++ b/Firebase/Core/Private/FIRAppInternal.h
@@ -98,6 +98,10 @@ typedef NSString *_Nullable (^FIRAppGetUIDImplementation)();
                                                  errorCode:(FIRErrorCode)code
                                                    service:(NSString *)service
                                                     reason:(NSString *)reason;
+/**
+ * Checks if the default app is configured without trying to configure it.
+ */
++ (BOOL)isDefaultAppConfigured;
 
 /**
  * Used by each SDK to send logs about SDK configuration status to Clearcut.


### PR DESCRIPTION
This lets other SDKs check if the default `FIRApp` is set up without
accessing it, which causes unnecessary log messages to appear.
