### PR TITLE
Disabling NSJSON edge case test on iOS 11

### DIFF
--- a/Example/Database/Tests/Unit/FLevelDBStorageEngineTests.m
+++ b/Example/Database/Tests/Unit/FLevelDBStorageEngineTests.m
@@ -46,29 +46,29 @@
 #define TEN_MEG_MINUS_ONE_NODE ([FTestHelpers leafNodeOfSize:10*1024*1024 - 1])
 
 #define SAMPLE_PARAMS \
-([[[[[FQueryParams defaultInstance] orderBy:[[FPathIndex alloc] initWithPath:PATH(@"child")]] \
-startAt:[FSnapshotUtilities nodeFrom:@"startVal"] childKey:@"startKey"] \
-endAt:[FSnapshotUtilities nodeFrom:@"endVal"] childKey:@"endKey"] \
-limitToLast:5])
+    ([[[[[FQueryParams defaultInstance] orderBy:[[FPathIndex alloc] initWithPath:PATH(@"child")]] \
+      startAt:[FSnapshotUtilities nodeFrom:@"startVal"] childKey:@"startKey"] \
+      endAt:[FSnapshotUtilities nodeFrom:@"endVal"] childKey:@"endKey"] \
+      limitToLast:5])
 
 #define SAMPLE_QUERY \
-([[FQuerySpec alloc] initWithPath:[FPath pathWithString:@"foo"] params:SAMPLE_PARAMS])
+    ([[FQuerySpec alloc] initWithPath:[FPath pathWithString:@"foo"] params:SAMPLE_PARAMS])
 
 #define DEFAULT_FOO_QUERY \
-([[FQuerySpec alloc] initWithPath:[FPath pathWithString:@"foo"] params:[FQueryParams defaultInstance]])
+    ([[FQuerySpec alloc] initWithPath:[FPath pathWithString:@"foo"] params:[FQueryParams defaultInstance]])
 
 #define SAMPLE_TRACKED_QUERY \
-([[FTrackedQuery alloc] initWithId:1 \
-query:SAMPLE_QUERY \
-isPinned:NO \
-lastUse:100 \
-Active:NO \
-isComplete:NO])
+    ([[FTrackedQuery alloc] initWithId:1 \
+                                 query:SAMPLE_QUERY \
+                              isPinned:NO \
+                               lastUse:100 \
+                                Active:NO \
+                            isComplete:NO])
 #define OVERWRITE_RECORD(__path, __node, __writeId) \
-([[FWriteRecord alloc] initWithPath:[FPath pathWithString:__path] overwrite:__node writeId:__writeId visible:YES])
+    ([[FWriteRecord alloc] initWithPath:[FPath pathWithString:__path] overwrite:__node writeId:__writeId visible:YES])
 
 #define MERGE_RECORD(__path, __merge, __writeId) \
-([[FWriteRecord alloc] initWithPath:[FPath pathWithString:__path] merge:__merge writeId:__writeId])
+    ([[FWriteRecord alloc] initWithPath:[FPath pathWithString:__path] merge:__merge writeId:__writeId])
 
 - (void)testUserWriteIsPersisted {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
@@ -115,12 +115,12 @@ isComplete:NO])
 
 - (void)testHugeWritesCanBeInterleavedWithSmallWrites {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-    
+
     [engine saveUserOverwrite:NODE(@"node-1") atPath:PATH(@"foo/1") writeId:1];
     [engine saveUserOverwrite:TEN_MEG_NODE atPath:PATH(@"foo/2") writeId:2];
     [engine saveUserOverwrite:NODE(@"node-3") atPath:PATH(@"foo/3") writeId:3];
     [engine saveUserOverwrite:FIVE_MEG_NODE atPath:PATH(@"foo/4") writeId:4];
-    
+
     NSArray *expected = @[OVERWRITE_RECORD(@"foo/1", NODE(@"node-1"), 1),
                           OVERWRITE_RECORD(@"foo/2", TEN_MEG_NODE, 2),
                           OVERWRITE_RECORD(@"foo/3", NODE(@"node-3"), 3),
@@ -132,10 +132,10 @@ isComplete:NO])
 // It's always good to have tests, so what the heck...
 - (void)testSameWriteIdOverwritesOldMultiPartWrite {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-    
+
     [engine saveUserOverwrite:TEN_MEG_NODE atPath:PATH(@"foo/bar") writeId:1];
     [engine saveUserOverwrite:NODE(@"second") atPath:PATH(@"other/path") writeId:1];
-    
+
     XCTAssertEqualObjects(engine.userWrites, @[OVERWRITE_RECORD(@"other/path", NODE(@"second"), 1)]);
 }
 
@@ -158,7 +158,7 @@ isComplete:NO])
 
 - (void)testRemoveAllUserWrites {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-    
+
     [engine saveUserOverwrite:NODE(@"node-1") atPath:PATH(@"foo/1") writeId:1];
     [engine saveUserOverwrite:TEN_MEG_NODE atPath:PATH(@"foo/2") writeId:2];
     FCompoundWrite *merge = [[FCompoundWrite emptyWrite] addWrite:TEN_MEG_NODE atKey:@"update"];
@@ -188,7 +188,7 @@ isComplete:NO])
     [engine updateServerCache:NODE(@"unaffected") atPath:PATH(@"unaffected") merge:NO];
     [engine updateServerCache:NODE(@"later-qux") atPath:PATH(@"foo/later-qux") merge:NO];
     [engine updateServerCache:NODE(@"latest-bar") atPath:PATH(@"foo/bar") merge:NO];
-    
+
     id<FNode> expected = [[SAMPLE_NODE updateImmediateChild:@"bar" withNewChild:NODE(@"latest-bar")]
                           updateImmediateChild:@"later-qux" withNewChild:NODE(@"later-qux")];
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], expected);
@@ -203,7 +203,7 @@ isComplete:NO])
     [engine updateServerCache:NODE(@"later-qux") atPath:PATH(@"foo/later-qux") merge:NO];
     [engine updateServerCache:NODE(@"latest-bar") atPath:PATH(@"foo/bar") merge:NO];
     [engine updateServerCache:NODE(@"latest-foo") atPath:PATH(@"foo") merge:NO];
-    
+
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], NODE(@"latest-foo"));
 }
 
@@ -213,7 +213,7 @@ isComplete:NO])
     // this does not affect the node
     [engine updateServerCache:NODE(@"unaffected") atPath:PATH(@"unaffected") merge:NO];
     [engine updateServerCache:NODE(@"latest-foo") atPath:PATH(@"foo") merge:NO];
-    
+
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"unaffected")], NODE(@"unaffected"));
 }
 
@@ -229,10 +229,10 @@ isComplete:NO])
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     id<FNode> existingNode = NODE((@{@"foo": @"foo-value", @"bar": @"bar-value"}));
     [engine updateServerCache:existingNode atPath:PATH(@"foo") merge:NO];
-    
+
     FCompoundWrite *merge = [FCompoundWrite compoundWriteWithValueDictionary:@{@"foo": @"new-foo-value", @"baz": @"baz-value"}];
     [engine updateServerCacheWithMerge:merge atPath:PATH(@"foo")];
-    
+
     id<FNode> expected = NODE((@{@"foo": @"new-foo-value", @"bar": @"bar-value", @"baz": @"baz-value"}));
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], expected);
 }
@@ -241,10 +241,10 @@ isComplete:NO])
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     id<FNode> existingNode = NODE((@{@"foo": @{ @"bar": @"bar-value", @"baz": @"baz-value"}, @"qux": @"qux-value"}));
     [engine updateServerCache:existingNode atPath:PATH(@"foo") merge:NO];
-    
+
     FCompoundWrite *merge = [FCompoundWrite compoundWriteWithValueDictionary:@{@"foo/bar": @"new-bar-value", @"quu": @"quu-value"}];
     [engine updateServerCacheWithMerge:merge atPath:PATH(@"foo")];
-    
+
     id<FNode> expected = NODE((@{@"foo": @{ @"bar": @"new-bar-value", @"baz": @"baz-value"}, @"qux": @"qux-value", @"quu": @"quu-value"}));
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], expected);
 }
@@ -253,10 +253,10 @@ isComplete:NO])
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     FCompoundWrite *merge1 = [FCompoundWrite compoundWriteWithValueDictionary:@{@"foo": @"foo-value", @"bar": @"bar-value"}];
     [engine updateServerCacheWithMerge:merge1 atPath:PATH(@"foo")];
-    
+
     FCompoundWrite *merge2 = [FCompoundWrite compoundWriteWithValueDictionary:@{@"foo": @"new-foo-value", @"baz": @"baz-value"}];
     [engine updateServerCacheWithMerge:merge2 atPath:PATH(@"foo")];
-    
+
     id<FNode> expected = NODE((@{@"foo": @"new-foo-value", @"bar": @"bar-value", @"baz": @"baz-value"}));
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], expected);
 }
@@ -265,35 +265,35 @@ isComplete:NO])
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     id<FNode> initial = NODE((@{@"foo": @"foo-value", @"bar": @"bar-value"}));
     [engine updateServerCache:initial atPath:PATH(@"foo") merge:NO];
-    
+
     FCompoundWrite *merge2 = [FCompoundWrite compoundWriteWithValueDictionary:@{@"foo": @"new-foo-value", @"baz": @"baz-value"}];
     [engine updateServerCacheWithMerge:merge2 atPath:PATH(@"foo")];
-    
+
     id<FNode> replacingNode = NODE((@{@"qux": @"qux-value", @"quu": @"quu-value"}));
     [engine updateServerCache:replacingNode atPath:PATH(@"foo") merge:NO];
-    
+
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], replacingNode);
 }
 
 - (void)testEmptyOverwriteDeletesNodeFromHigherWrite {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-    
+
     id<FNode> initial = NODE((@{@"foo": @"foo-value", @"bar": @"bar-value"}));
     [engine updateServerCache:initial atPath:PATH(@"foo") merge:NO];
-    
+
     // delete bar
     [engine updateServerCache:NODE(nil) atPath:PATH(@"foo/bar") merge:NO];
-    
+
     id<FNode> expected = NODE((@{@"foo": @"foo-value"}));
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], expected);
 }
 
 - (void)testDeeperReadFromHigherSet {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-    
+
     id<FNode> initial = NODE((@{@"foo": @"foo-value", @"bar": @"bar-value"}));
     [engine updateServerCache:initial atPath:PATH(@"foo") merge:NO];
-    
+
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo/bar")], NODE(@"bar-value"));
 }
 
@@ -302,13 +302,13 @@ isComplete:NO])
     [engine updateServerCache:NODE(@"level-0") atPath:PATH(@"") merge:NO];
     [engine updateServerCache:NODE(@"level-1") atPath:PATH(@"lvl1") merge:NO];
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"")], NODE((@{@"lvl1": @"level-1"})));
-    
+
     [engine updateServerCache:NODE(@"level-2") atPath:PATH(@"lvl1/lvl2") merge:NO];
-    
+
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"lvl1")], NODE((@{@"lvl2": @"level-2"})));
-    
+
     [engine updateServerCache:NODE(@"level-4") atPath:PATH(@"lvl1/lvl2/lvl3/lvl4") merge:NO];
-    
+
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"lvl1")], NODE((@{@"lvl2": @{@"lvl3": @{@"lvl4": @"level-4"}}})));
 }
 
@@ -316,7 +316,7 @@ isComplete:NO])
 // This test causes a split on Android so it doesn't really make sense here, but why not test anyways...
 - (void)testHugeNodeWithSplit {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-    
+
     id<FNode> outer = [FEmptyNode emptyNode];
     // This structure ensures splits at various depths
     for (NSUInteger i = 0; i < 100; i++) { // Outer
@@ -335,7 +335,7 @@ isComplete:NO])
         outer = [outer updateImmediateChild:outerKey withNewChild:inner];
     }
     [engine updateServerCache:outer atPath:PATH(@"foo") merge:NO];
-    
+
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], outer);
 }
 
@@ -346,26 +346,26 @@ isComplete:NO])
         NSString *outerKey = [NSString stringWithFormat:@"key-%lu", (unsigned long)i];
         outer = [outer updateImmediateChild:outerKey withNewChild:ONE_MEG_NODE];
     }
-    
+
     [engine updateServerCache:outer atPath:PATH(@"foo") merge:NO];
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], outer);
 }
 
 - (void)testPriorityWorks {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-    
+
     [engine updateServerCache:NODE(@"bar-value") atPath:PATH(@"foo/bar") merge:NO];
     [engine updateServerCache:NODE(@"prio-value") atPath:PATH(@"foo/.priority") merge:NO];
-    
+
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], NODE((@{ @".priority": @"prio-value", @"bar": @"bar-value"})));
 }
 
 - (void)testSimilarSiblingsAreNotLoaded {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-    
+
     [engine updateServerCache:NODE(@"value") atPath:PATH(@"foo/123") merge:NO];
     [engine updateServerCache:NODE(@"sibling-value") atPath:PATH(@"foo/1230") merge:NO];
-    
+
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo/123")], NODE(@"value"));
 }
 
@@ -373,12 +373,12 @@ isComplete:NO])
 // Fix whenever we have too much time on our hands
 - (void)priorityIsCleared {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-    
+
     [engine updateServerCache:NODE((@{@"bar": @"bar-value"})) atPath:PATH(@"foo") merge:NO];
     [engine updateServerCache:NODE(@"prio-value") atPath:PATH(@"foo/.priority") merge:NO];
     [engine updateServerCache:NODE(nil) atPath:PATH(@"foo/bar") merge:NO];
     [engine updateServerCache:NODE(@"baz-value") atPath:PATH(@"foo/baz") merge:NO];
-    
+
     // Priority should have been cleaned out
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], NODE(@{@"baz": @"baz-value"}));
 }
@@ -386,7 +386,7 @@ isComplete:NO])
 - (void)testHugeLeafNode {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine updateServerCache:TEN_MEG_NODE atPath:PATH(@"foo") merge:NO];
-    
+
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], TEN_MEG_NODE);
 }
 
@@ -394,7 +394,7 @@ isComplete:NO])
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine updateServerCache:TEN_MEG_NODE atPath:PATH(@"foo/one") merge:NO];
     [engine updateServerCache:TEN_MEG_MINUS_ONE_NODE atPath:PATH(@"foo/two") merge:NO];
-    
+
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo/one")], TEN_MEG_NODE);
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo/two")], TEN_MEG_MINUS_ONE_NODE);
 }
@@ -403,7 +403,7 @@ isComplete:NO])
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine updateServerCache:TEN_MEG_NODE atPath:PATH(@"foo") merge:NO];
     [engine updateServerCache:NODE(@"tiny") atPath:PATH(@"foo") merge:NO];
-    
+
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], NODE(@"tiny"));
 }
 
@@ -411,7 +411,7 @@ isComplete:NO])
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine updateServerCache:TEN_MEG_NODE atPath:PATH(@"foo") merge:NO];
     [engine updateServerCache:FIVE_MEG_NODE atPath:PATH(@"foo") merge:NO];
-    
+
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], FIVE_MEG_NODE);
 }
 
@@ -419,16 +419,23 @@ isComplete:NO])
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine updateServerCache:TEN_MEG_NODE atPath:PATH(@"foo") merge:NO];
     [engine updateServerCache:NODE(@"deep-value") atPath:PATH(@"foo/deep") merge:NO];
-    
+
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], NODE((@{@"deep": @"deep-value"})));
 }
 
 // Well this is awkward, but NSJSONSerialization fails to deserialize JSON with tiny/huge doubles
 // It is kind of bad we raise "invalid" data, but at least we don't crash *trollface*
 - (void)testExtremeDoublesAsServerCache {
+#ifdef TARGET_OS_IPHONE
+    if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion == 11) {
+        // NSJSONSerialization on iOS 11 correctly serializes small and large doubles.
+        return;
+    }
+#endif
+
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine updateServerCache:NODE((@{@"works": @"value", @"fails": @(2.225073858507201e-308)})) atPath:PATH(@"foo") merge:NO];
-    
+
     // Will drop the tiny double
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], NODE(@{@"works": @"value"}));
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo/fails")], [FEmptyNode emptyNode]);
@@ -441,10 +448,10 @@ isComplete:NO])
         return;
     }
 #endif
-    
+
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     id<FNode> tinyDouble = NODE(@(2.225073858507201e-308));
-    
+
     FQueryParams *params = [[[FQueryParams defaultInstance] startAt:tinyDouble] endAt:tinyDouble];
     FTrackedQuery *doesNotWork = [[FTrackedQuery alloc] initWithId:0
                                                              query:[[FQuerySpec alloc] initWithPath:PATH(@"foo") params:params]
@@ -461,25 +468,18 @@ isComplete:NO])
 }
 
 - (void)testExtremeDoublesAsUserWrites {
-#ifdef TARGET_OS_IPHONE
-    if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion == 11) {
-        // NSJSONSerialization on iOS 11 correctly serializes small and large doubles.
-        return;
-    }
-#endif
-    
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     id<FNode> tinyDouble = NODE(@(2.225073858507201e-308));
-    
+
     [engine saveUserOverwrite:tinyDouble atPath:PATH(@"foo") writeId:1];
     [engine saveUserMerge:[[FCompoundWrite emptyWrite] addWrite:tinyDouble atPath:PATH(@"bar")] atPath:PATH(@"foo") writeId:2];
     [engine saveUserOverwrite:NODE(@"should-work") atPath:PATH(@"other") writeId:3];
-    
+
     // The other two should be dropped and only the valid should remain
     XCTAssertEqualObjects([engine userWrites], @[[[FWriteRecord alloc] initWithPath:PATH(@"other")
-                                                                          overwrite:NODE(@"should-work")
-                                                                            writeId:3
-                                                                            visible:YES]]);
+                                                                   overwrite:NODE(@"should-work")
+                                                                     writeId:3
+                                                                     visible:YES]]);
 }
 
 - (void)testLongValuesDontLosePrecision {
@@ -499,7 +499,7 @@ isComplete:NO])
 - (void)testDoublesAreRoundedProperly {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine updateServerCache:NODE(@(2.47)) atPath:PATH(@"foo") merge:NO];
-    
+
     // Expected hash for 2.47 parsed correctly
     NSString *hashFor247 = @"EsibHXKcBp2/b/bn/a0C5WffcUU=";
     XCTAssertEqualObjects([[engine serverCacheAtPath:PATH(@"foo")] dataHash], hashFor247);
@@ -509,7 +509,7 @@ isComplete:NO])
     id intValue = @247;
     id longValue = @1542405709418655810;
     id doubleValue = @0xFFFFFFFFFFFFFFFFUL;  // This number can't be represented as a signed long.
-    
+
     id<FNode> expectedData = NODE((@{@"int": @247, @"long": longValue, @"double": doubleValue}));
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine updateServerCache:expectedData atPath:PATH(@"foo") merge:NO];
@@ -517,7 +517,7 @@ isComplete:NO])
     NSNumber* actualInt = [actualData val][@"int"];
     NSNumber* actualLong = [actualData val][@"long"];
     NSNumber* actualDouble = [actualData val][@"double"];
-    
+
     XCTAssertEqualObjects([actualInt stringValue], [intValue stringValue]);
     XCTAssertEqual(CFNumberGetType((CFNumberRef)actualInt), kCFNumberSInt64Type);
     XCTAssertEqualObjects([actualLong stringValue ], [longValue stringValue]);
@@ -530,28 +530,28 @@ isComplete:NO])
 
 - (void)testSaveAndLoadTrackedQueries {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-    
+
     NSArray *queries = @[[[FTrackedQuery alloc] initWithId:1 query:SAMPLE_QUERY lastUse:100 isActive:NO isComplete:NO],
                          [[FTrackedQuery alloc] initWithId:2 query:[FQuerySpec defaultQueryAtPath:PATH(@"a")] lastUse:200 isActive:NO isComplete:NO],
                          [[FTrackedQuery alloc] initWithId:3 query:[FQuerySpec defaultQueryAtPath:PATH(@"b")] lastUse:300 isActive:YES isComplete:NO],
                          [[FTrackedQuery alloc] initWithId:4 query:[FQuerySpec defaultQueryAtPath:PATH(@"c")] lastUse:400 isActive:NO isComplete:YES],
                          [[FTrackedQuery alloc] initWithId:5 query:[FQuerySpec defaultQueryAtPath:PATH(@"foo")] lastUse:500 isActive:NO isComplete:NO]];
-    
+
     [queries enumerateObjectsUsingBlock:^(FTrackedQuery *query, NSUInteger idx, BOOL *stop) {
         [engine saveTrackedQuery:query];
     }];
-    
+
     XCTAssertEqualObjects([engine loadTrackedQueries], queries);
 }
 
 - (void)testOverwriteTrackedQueryById {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-    
+
     FTrackedQuery *first = [[FTrackedQuery alloc] initWithId:1 query:SAMPLE_QUERY lastUse:100 isActive:NO isComplete:NO];
     FTrackedQuery *second = [[FTrackedQuery alloc] initWithId:1 query:DEFAULT_FOO_QUERY lastUse:200 isActive:YES isComplete:YES];
     [engine saveTrackedQuery:first];
     [engine saveTrackedQuery:second];
-    
+
     XCTAssertEqualObjects([engine loadTrackedQueries], @[second]);
 }
 
@@ -563,7 +563,7 @@ isComplete:NO])
     [engine saveTrackedQuery:query1];
     [engine saveTrackedQuery:query2];
     [engine saveTrackedQuery:query3];
-    
+
     [engine removeTrackedQuery:2];
     XCTAssertEqualObjects([engine loadTrackedQueries], (@[query1, query3]));
 }
@@ -573,7 +573,7 @@ isComplete:NO])
     NSSet *keys = [NSSet setWithArray:@[@"foo", @"☁", @"10", @"٩(͡๏̯͡๏)۶"]];
     [engine setTrackedQueryKeys:keys forQueryId:1];
     [engine setTrackedQueryKeys:[NSSet setWithArray:@[@"not", @"included"]] forQueryId:2];
-    
+
     XCTAssertEqualObjects([engine trackedQueryKeysForQuery:1], keys);
 }
 
@@ -581,7 +581,7 @@ isComplete:NO])
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine setTrackedQueryKeys:[NSSet setWithArray:@[@"a", @"b", @"c"]] forQueryId:1];
     [engine setTrackedQueryKeys:[NSSet setWithArray:@[@"c", @"d", @"e"]] forQueryId:1];
-    
+
     XCTAssertEqualObjects([engine trackedQueryKeysForQuery:1], ([NSSet setWithArray:@[@"c", @"d", @"e"]]));
 }
 
@@ -602,17 +602,16 @@ isComplete:NO])
     [engine saveTrackedQuery:query2];
     [engine setTrackedQueryKeys:[NSSet setWithArray:@[@"a", @"b"]] forQueryId:1];
     [engine setTrackedQueryKeys:[NSSet setWithArray:@[@"b", @"c"]] forQueryId:2];
-    
+
     XCTAssertEqualObjects([engine loadTrackedQueries], (@[query1, query2]));
     XCTAssertEqualObjects([engine trackedQueryKeysForQuery:1], ([NSSet setWithArray:@[@"a", @"b"]]));
     XCTAssertEqualObjects([engine trackedQueryKeysForQuery:2], ([NSSet setWithArray:@[@"b", @"c"]]));
-    
+
     [engine removeTrackedQuery:1];
-    
+
     XCTAssertEqualObjects([engine loadTrackedQueries], (@[query2]));
     XCTAssertEqualObjects([engine trackedQueryKeysForQuery:1], [NSSet set]);
     XCTAssertEqualObjects([engine trackedQueryKeysForQuery:2], ([NSSet setWithArray:@[@"b", @"c"]]));
 }
 
 @end
-

--- a/Example/Database/Tests/Unit/FLevelDBStorageEngineTests.m
+++ b/Example/Database/Tests/Unit/FLevelDBStorageEngineTests.m
@@ -46,29 +46,29 @@
 #define TEN_MEG_MINUS_ONE_NODE ([FTestHelpers leafNodeOfSize:10*1024*1024 - 1])
 
 #define SAMPLE_PARAMS \
-    ([[[[[FQueryParams defaultInstance] orderBy:[[FPathIndex alloc] initWithPath:PATH(@"child")]] \
-      startAt:[FSnapshotUtilities nodeFrom:@"startVal"] childKey:@"startKey"] \
-      endAt:[FSnapshotUtilities nodeFrom:@"endVal"] childKey:@"endKey"] \
-      limitToLast:5])
+([[[[[FQueryParams defaultInstance] orderBy:[[FPathIndex alloc] initWithPath:PATH(@"child")]] \
+startAt:[FSnapshotUtilities nodeFrom:@"startVal"] childKey:@"startKey"] \
+endAt:[FSnapshotUtilities nodeFrom:@"endVal"] childKey:@"endKey"] \
+limitToLast:5])
 
 #define SAMPLE_QUERY \
-    ([[FQuerySpec alloc] initWithPath:[FPath pathWithString:@"foo"] params:SAMPLE_PARAMS])
+([[FQuerySpec alloc] initWithPath:[FPath pathWithString:@"foo"] params:SAMPLE_PARAMS])
 
 #define DEFAULT_FOO_QUERY \
-    ([[FQuerySpec alloc] initWithPath:[FPath pathWithString:@"foo"] params:[FQueryParams defaultInstance]])
+([[FQuerySpec alloc] initWithPath:[FPath pathWithString:@"foo"] params:[FQueryParams defaultInstance]])
 
 #define SAMPLE_TRACKED_QUERY \
-    ([[FTrackedQuery alloc] initWithId:1 \
-                                 query:SAMPLE_QUERY \
-                              isPinned:NO \
-                               lastUse:100 \
-                                Active:NO \
-                            isComplete:NO])
+([[FTrackedQuery alloc] initWithId:1 \
+query:SAMPLE_QUERY \
+isPinned:NO \
+lastUse:100 \
+Active:NO \
+isComplete:NO])
 #define OVERWRITE_RECORD(__path, __node, __writeId) \
-    ([[FWriteRecord alloc] initWithPath:[FPath pathWithString:__path] overwrite:__node writeId:__writeId visible:YES])
+([[FWriteRecord alloc] initWithPath:[FPath pathWithString:__path] overwrite:__node writeId:__writeId visible:YES])
 
 #define MERGE_RECORD(__path, __merge, __writeId) \
-    ([[FWriteRecord alloc] initWithPath:[FPath pathWithString:__path] merge:__merge writeId:__writeId])
+([[FWriteRecord alloc] initWithPath:[FPath pathWithString:__path] merge:__merge writeId:__writeId])
 
 - (void)testUserWriteIsPersisted {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
@@ -115,12 +115,12 @@
 
 - (void)testHugeWritesCanBeInterleavedWithSmallWrites {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-
+    
     [engine saveUserOverwrite:NODE(@"node-1") atPath:PATH(@"foo/1") writeId:1];
     [engine saveUserOverwrite:TEN_MEG_NODE atPath:PATH(@"foo/2") writeId:2];
     [engine saveUserOverwrite:NODE(@"node-3") atPath:PATH(@"foo/3") writeId:3];
     [engine saveUserOverwrite:FIVE_MEG_NODE atPath:PATH(@"foo/4") writeId:4];
-
+    
     NSArray *expected = @[OVERWRITE_RECORD(@"foo/1", NODE(@"node-1"), 1),
                           OVERWRITE_RECORD(@"foo/2", TEN_MEG_NODE, 2),
                           OVERWRITE_RECORD(@"foo/3", NODE(@"node-3"), 3),
@@ -132,10 +132,10 @@
 // It's always good to have tests, so what the heck...
 - (void)testSameWriteIdOverwritesOldMultiPartWrite {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-
+    
     [engine saveUserOverwrite:TEN_MEG_NODE atPath:PATH(@"foo/bar") writeId:1];
     [engine saveUserOverwrite:NODE(@"second") atPath:PATH(@"other/path") writeId:1];
-
+    
     XCTAssertEqualObjects(engine.userWrites, @[OVERWRITE_RECORD(@"other/path", NODE(@"second"), 1)]);
 }
 
@@ -158,7 +158,7 @@
 
 - (void)testRemoveAllUserWrites {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-
+    
     [engine saveUserOverwrite:NODE(@"node-1") atPath:PATH(@"foo/1") writeId:1];
     [engine saveUserOverwrite:TEN_MEG_NODE atPath:PATH(@"foo/2") writeId:2];
     FCompoundWrite *merge = [[FCompoundWrite emptyWrite] addWrite:TEN_MEG_NODE atKey:@"update"];
@@ -188,7 +188,7 @@
     [engine updateServerCache:NODE(@"unaffected") atPath:PATH(@"unaffected") merge:NO];
     [engine updateServerCache:NODE(@"later-qux") atPath:PATH(@"foo/later-qux") merge:NO];
     [engine updateServerCache:NODE(@"latest-bar") atPath:PATH(@"foo/bar") merge:NO];
-
+    
     id<FNode> expected = [[SAMPLE_NODE updateImmediateChild:@"bar" withNewChild:NODE(@"latest-bar")]
                           updateImmediateChild:@"later-qux" withNewChild:NODE(@"later-qux")];
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], expected);
@@ -203,7 +203,7 @@
     [engine updateServerCache:NODE(@"later-qux") atPath:PATH(@"foo/later-qux") merge:NO];
     [engine updateServerCache:NODE(@"latest-bar") atPath:PATH(@"foo/bar") merge:NO];
     [engine updateServerCache:NODE(@"latest-foo") atPath:PATH(@"foo") merge:NO];
-
+    
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], NODE(@"latest-foo"));
 }
 
@@ -213,7 +213,7 @@
     // this does not affect the node
     [engine updateServerCache:NODE(@"unaffected") atPath:PATH(@"unaffected") merge:NO];
     [engine updateServerCache:NODE(@"latest-foo") atPath:PATH(@"foo") merge:NO];
-
+    
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"unaffected")], NODE(@"unaffected"));
 }
 
@@ -229,10 +229,10 @@
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     id<FNode> existingNode = NODE((@{@"foo": @"foo-value", @"bar": @"bar-value"}));
     [engine updateServerCache:existingNode atPath:PATH(@"foo") merge:NO];
-
+    
     FCompoundWrite *merge = [FCompoundWrite compoundWriteWithValueDictionary:@{@"foo": @"new-foo-value", @"baz": @"baz-value"}];
     [engine updateServerCacheWithMerge:merge atPath:PATH(@"foo")];
-
+    
     id<FNode> expected = NODE((@{@"foo": @"new-foo-value", @"bar": @"bar-value", @"baz": @"baz-value"}));
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], expected);
 }
@@ -241,10 +241,10 @@
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     id<FNode> existingNode = NODE((@{@"foo": @{ @"bar": @"bar-value", @"baz": @"baz-value"}, @"qux": @"qux-value"}));
     [engine updateServerCache:existingNode atPath:PATH(@"foo") merge:NO];
-
+    
     FCompoundWrite *merge = [FCompoundWrite compoundWriteWithValueDictionary:@{@"foo/bar": @"new-bar-value", @"quu": @"quu-value"}];
     [engine updateServerCacheWithMerge:merge atPath:PATH(@"foo")];
-
+    
     id<FNode> expected = NODE((@{@"foo": @{ @"bar": @"new-bar-value", @"baz": @"baz-value"}, @"qux": @"qux-value", @"quu": @"quu-value"}));
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], expected);
 }
@@ -253,10 +253,10 @@
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     FCompoundWrite *merge1 = [FCompoundWrite compoundWriteWithValueDictionary:@{@"foo": @"foo-value", @"bar": @"bar-value"}];
     [engine updateServerCacheWithMerge:merge1 atPath:PATH(@"foo")];
-
+    
     FCompoundWrite *merge2 = [FCompoundWrite compoundWriteWithValueDictionary:@{@"foo": @"new-foo-value", @"baz": @"baz-value"}];
     [engine updateServerCacheWithMerge:merge2 atPath:PATH(@"foo")];
-
+    
     id<FNode> expected = NODE((@{@"foo": @"new-foo-value", @"bar": @"bar-value", @"baz": @"baz-value"}));
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], expected);
 }
@@ -265,35 +265,35 @@
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     id<FNode> initial = NODE((@{@"foo": @"foo-value", @"bar": @"bar-value"}));
     [engine updateServerCache:initial atPath:PATH(@"foo") merge:NO];
-
+    
     FCompoundWrite *merge2 = [FCompoundWrite compoundWriteWithValueDictionary:@{@"foo": @"new-foo-value", @"baz": @"baz-value"}];
     [engine updateServerCacheWithMerge:merge2 atPath:PATH(@"foo")];
-
+    
     id<FNode> replacingNode = NODE((@{@"qux": @"qux-value", @"quu": @"quu-value"}));
     [engine updateServerCache:replacingNode atPath:PATH(@"foo") merge:NO];
-
+    
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], replacingNode);
 }
 
 - (void)testEmptyOverwriteDeletesNodeFromHigherWrite {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-
+    
     id<FNode> initial = NODE((@{@"foo": @"foo-value", @"bar": @"bar-value"}));
     [engine updateServerCache:initial atPath:PATH(@"foo") merge:NO];
-
+    
     // delete bar
     [engine updateServerCache:NODE(nil) atPath:PATH(@"foo/bar") merge:NO];
-
+    
     id<FNode> expected = NODE((@{@"foo": @"foo-value"}));
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], expected);
 }
 
 - (void)testDeeperReadFromHigherSet {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-
+    
     id<FNode> initial = NODE((@{@"foo": @"foo-value", @"bar": @"bar-value"}));
     [engine updateServerCache:initial atPath:PATH(@"foo") merge:NO];
-
+    
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo/bar")], NODE(@"bar-value"));
 }
 
@@ -302,13 +302,13 @@
     [engine updateServerCache:NODE(@"level-0") atPath:PATH(@"") merge:NO];
     [engine updateServerCache:NODE(@"level-1") atPath:PATH(@"lvl1") merge:NO];
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"")], NODE((@{@"lvl1": @"level-1"})));
-
+    
     [engine updateServerCache:NODE(@"level-2") atPath:PATH(@"lvl1/lvl2") merge:NO];
-
+    
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"lvl1")], NODE((@{@"lvl2": @"level-2"})));
-
+    
     [engine updateServerCache:NODE(@"level-4") atPath:PATH(@"lvl1/lvl2/lvl3/lvl4") merge:NO];
-
+    
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"lvl1")], NODE((@{@"lvl2": @{@"lvl3": @{@"lvl4": @"level-4"}}})));
 }
 
@@ -316,7 +316,7 @@
 // This test causes a split on Android so it doesn't really make sense here, but why not test anyways...
 - (void)testHugeNodeWithSplit {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-
+    
     id<FNode> outer = [FEmptyNode emptyNode];
     // This structure ensures splits at various depths
     for (NSUInteger i = 0; i < 100; i++) { // Outer
@@ -335,7 +335,7 @@
         outer = [outer updateImmediateChild:outerKey withNewChild:inner];
     }
     [engine updateServerCache:outer atPath:PATH(@"foo") merge:NO];
-
+    
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], outer);
 }
 
@@ -346,26 +346,26 @@
         NSString *outerKey = [NSString stringWithFormat:@"key-%lu", (unsigned long)i];
         outer = [outer updateImmediateChild:outerKey withNewChild:ONE_MEG_NODE];
     }
-
+    
     [engine updateServerCache:outer atPath:PATH(@"foo") merge:NO];
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], outer);
 }
 
 - (void)testPriorityWorks {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-
+    
     [engine updateServerCache:NODE(@"bar-value") atPath:PATH(@"foo/bar") merge:NO];
     [engine updateServerCache:NODE(@"prio-value") atPath:PATH(@"foo/.priority") merge:NO];
-
+    
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], NODE((@{ @".priority": @"prio-value", @"bar": @"bar-value"})));
 }
 
 - (void)testSimilarSiblingsAreNotLoaded {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-
+    
     [engine updateServerCache:NODE(@"value") atPath:PATH(@"foo/123") merge:NO];
     [engine updateServerCache:NODE(@"sibling-value") atPath:PATH(@"foo/1230") merge:NO];
-
+    
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo/123")], NODE(@"value"));
 }
 
@@ -373,12 +373,12 @@
 // Fix whenever we have too much time on our hands
 - (void)priorityIsCleared {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-
+    
     [engine updateServerCache:NODE((@{@"bar": @"bar-value"})) atPath:PATH(@"foo") merge:NO];
     [engine updateServerCache:NODE(@"prio-value") atPath:PATH(@"foo/.priority") merge:NO];
     [engine updateServerCache:NODE(nil) atPath:PATH(@"foo/bar") merge:NO];
     [engine updateServerCache:NODE(@"baz-value") atPath:PATH(@"foo/baz") merge:NO];
-
+    
     // Priority should have been cleaned out
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], NODE(@{@"baz": @"baz-value"}));
 }
@@ -386,7 +386,7 @@
 - (void)testHugeLeafNode {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine updateServerCache:TEN_MEG_NODE atPath:PATH(@"foo") merge:NO];
-
+    
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], TEN_MEG_NODE);
 }
 
@@ -394,7 +394,7 @@
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine updateServerCache:TEN_MEG_NODE atPath:PATH(@"foo/one") merge:NO];
     [engine updateServerCache:TEN_MEG_MINUS_ONE_NODE atPath:PATH(@"foo/two") merge:NO];
-
+    
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo/one")], TEN_MEG_NODE);
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo/two")], TEN_MEG_MINUS_ONE_NODE);
 }
@@ -403,7 +403,7 @@
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine updateServerCache:TEN_MEG_NODE atPath:PATH(@"foo") merge:NO];
     [engine updateServerCache:NODE(@"tiny") atPath:PATH(@"foo") merge:NO];
-
+    
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], NODE(@"tiny"));
 }
 
@@ -411,7 +411,7 @@
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine updateServerCache:TEN_MEG_NODE atPath:PATH(@"foo") merge:NO];
     [engine updateServerCache:FIVE_MEG_NODE atPath:PATH(@"foo") merge:NO];
-
+    
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], FIVE_MEG_NODE);
 }
 
@@ -419,7 +419,7 @@
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine updateServerCache:TEN_MEG_NODE atPath:PATH(@"foo") merge:NO];
     [engine updateServerCache:NODE(@"deep-value") atPath:PATH(@"foo/deep") merge:NO];
-
+    
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], NODE((@{@"deep": @"deep-value"})));
 }
 
@@ -428,16 +428,21 @@
 - (void)testExtremeDoublesAsServerCache {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine updateServerCache:NODE((@{@"works": @"value", @"fails": @(2.225073858507201e-308)})) atPath:PATH(@"foo") merge:NO];
-
+    
     // Will drop the tiny double
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo")], NODE(@{@"works": @"value"}));
     XCTAssertEqualObjects([engine serverCacheAtPath:PATH(@"foo/fails")], [FEmptyNode emptyNode]);
 }
 
 - (void)testExtremeDoublesAsTrackedQuery {
+    if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion == 11) {
+        // NSJSONSerialization on iOS 11 correctly serializes small and large doubles.
+        return;
+    }
+    
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     id<FNode> tinyDouble = NODE(@(2.225073858507201e-308));
-
+    
     FQueryParams *params = [[[FQueryParams defaultInstance] startAt:tinyDouble] endAt:tinyDouble];
     FTrackedQuery *doesNotWork = [[FTrackedQuery alloc] initWithId:0
                                                              query:[[FQuerySpec alloc] initWithPath:PATH(@"foo") params:params]
@@ -454,18 +459,23 @@
 }
 
 - (void)testExtremeDoublesAsUserWrites {
+    if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion == 11) {
+        // NSJSONSerialization on iOS 11 correctly serializes small and large doubles.
+        return;
+    }
+    
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     id<FNode> tinyDouble = NODE(@(2.225073858507201e-308));
-
+    
     [engine saveUserOverwrite:tinyDouble atPath:PATH(@"foo") writeId:1];
     [engine saveUserMerge:[[FCompoundWrite emptyWrite] addWrite:tinyDouble atPath:PATH(@"bar")] atPath:PATH(@"foo") writeId:2];
     [engine saveUserOverwrite:NODE(@"should-work") atPath:PATH(@"other") writeId:3];
-
+    
     // The other two should be dropped and only the valid should remain
     XCTAssertEqualObjects([engine userWrites], @[[[FWriteRecord alloc] initWithPath:PATH(@"other")
-                                                                   overwrite:NODE(@"should-work")
-                                                                     writeId:3
-                                                                     visible:YES]]);
+                                                                          overwrite:NODE(@"should-work")
+                                                                            writeId:3
+                                                                            visible:YES]]);
 }
 
 - (void)testLongValuesDontLosePrecision {
@@ -485,7 +495,7 @@
 - (void)testDoublesAreRoundedProperly {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine updateServerCache:NODE(@(2.47)) atPath:PATH(@"foo") merge:NO];
-
+    
     // Expected hash for 2.47 parsed correctly
     NSString *hashFor247 = @"EsibHXKcBp2/b/bn/a0C5WffcUU=";
     XCTAssertEqualObjects([[engine serverCacheAtPath:PATH(@"foo")] dataHash], hashFor247);
@@ -495,7 +505,7 @@
     id intValue = @247;
     id longValue = @1542405709418655810;
     id doubleValue = @0xFFFFFFFFFFFFFFFFUL;  // This number can't be represented as a signed long.
-
+    
     id<FNode> expectedData = NODE((@{@"int": @247, @"long": longValue, @"double": doubleValue}));
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine updateServerCache:expectedData atPath:PATH(@"foo") merge:NO];
@@ -503,7 +513,7 @@
     NSNumber* actualInt = [actualData val][@"int"];
     NSNumber* actualLong = [actualData val][@"long"];
     NSNumber* actualDouble = [actualData val][@"double"];
-
+    
     XCTAssertEqualObjects([actualInt stringValue], [intValue stringValue]);
     XCTAssertEqual(CFNumberGetType((CFNumberRef)actualInt), kCFNumberSInt64Type);
     XCTAssertEqualObjects([actualLong stringValue ], [longValue stringValue]);
@@ -516,28 +526,28 @@
 
 - (void)testSaveAndLoadTrackedQueries {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-
+    
     NSArray *queries = @[[[FTrackedQuery alloc] initWithId:1 query:SAMPLE_QUERY lastUse:100 isActive:NO isComplete:NO],
                          [[FTrackedQuery alloc] initWithId:2 query:[FQuerySpec defaultQueryAtPath:PATH(@"a")] lastUse:200 isActive:NO isComplete:NO],
                          [[FTrackedQuery alloc] initWithId:3 query:[FQuerySpec defaultQueryAtPath:PATH(@"b")] lastUse:300 isActive:YES isComplete:NO],
                          [[FTrackedQuery alloc] initWithId:4 query:[FQuerySpec defaultQueryAtPath:PATH(@"c")] lastUse:400 isActive:NO isComplete:YES],
                          [[FTrackedQuery alloc] initWithId:5 query:[FQuerySpec defaultQueryAtPath:PATH(@"foo")] lastUse:500 isActive:NO isComplete:NO]];
-
+    
     [queries enumerateObjectsUsingBlock:^(FTrackedQuery *query, NSUInteger idx, BOOL *stop) {
         [engine saveTrackedQuery:query];
     }];
-
+    
     XCTAssertEqualObjects([engine loadTrackedQueries], queries);
 }
 
 - (void)testOverwriteTrackedQueryById {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
-
+    
     FTrackedQuery *first = [[FTrackedQuery alloc] initWithId:1 query:SAMPLE_QUERY lastUse:100 isActive:NO isComplete:NO];
     FTrackedQuery *second = [[FTrackedQuery alloc] initWithId:1 query:DEFAULT_FOO_QUERY lastUse:200 isActive:YES isComplete:YES];
     [engine saveTrackedQuery:first];
     [engine saveTrackedQuery:second];
-
+    
     XCTAssertEqualObjects([engine loadTrackedQueries], @[second]);
 }
 
@@ -549,7 +559,7 @@
     [engine saveTrackedQuery:query1];
     [engine saveTrackedQuery:query2];
     [engine saveTrackedQuery:query3];
-
+    
     [engine removeTrackedQuery:2];
     XCTAssertEqualObjects([engine loadTrackedQueries], (@[query1, query3]));
 }
@@ -559,7 +569,7 @@
     NSSet *keys = [NSSet setWithArray:@[@"foo", @"☁", @"10", @"٩(͡๏̯͡๏)۶"]];
     [engine setTrackedQueryKeys:keys forQueryId:1];
     [engine setTrackedQueryKeys:[NSSet setWithArray:@[@"not", @"included"]] forQueryId:2];
-
+    
     XCTAssertEqualObjects([engine trackedQueryKeysForQuery:1], keys);
 }
 
@@ -567,7 +577,7 @@
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine setTrackedQueryKeys:[NSSet setWithArray:@[@"a", @"b", @"c"]] forQueryId:1];
     [engine setTrackedQueryKeys:[NSSet setWithArray:@[@"c", @"d", @"e"]] forQueryId:1];
-
+    
     XCTAssertEqualObjects([engine trackedQueryKeysForQuery:1], ([NSSet setWithArray:@[@"c", @"d", @"e"]]));
 }
 
@@ -588,16 +598,17 @@
     [engine saveTrackedQuery:query2];
     [engine setTrackedQueryKeys:[NSSet setWithArray:@[@"a", @"b"]] forQueryId:1];
     [engine setTrackedQueryKeys:[NSSet setWithArray:@[@"b", @"c"]] forQueryId:2];
-
+    
     XCTAssertEqualObjects([engine loadTrackedQueries], (@[query1, query2]));
     XCTAssertEqualObjects([engine trackedQueryKeysForQuery:1], ([NSSet setWithArray:@[@"a", @"b"]]));
     XCTAssertEqualObjects([engine trackedQueryKeysForQuery:2], ([NSSet setWithArray:@[@"b", @"c"]]));
-
+    
     [engine removeTrackedQuery:1];
-
+    
     XCTAssertEqualObjects([engine loadTrackedQueries], (@[query2]));
     XCTAssertEqualObjects([engine trackedQueryKeysForQuery:1], [NSSet set]);
     XCTAssertEqualObjects([engine trackedQueryKeysForQuery:2], ([NSSet setWithArray:@[@"b", @"c"]]));
 }
 
 @end
+

--- a/Example/Database/Tests/Unit/FLevelDBStorageEngineTests.m
+++ b/Example/Database/Tests/Unit/FLevelDBStorageEngineTests.m
@@ -435,10 +435,12 @@ isComplete:NO])
 }
 
 - (void)testExtremeDoublesAsTrackedQuery {
+#ifdef TARGET_OS_IPHONE
     if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion == 11) {
         // NSJSONSerialization on iOS 11 correctly serializes small and large doubles.
         return;
     }
+#endif
     
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     id<FNode> tinyDouble = NODE(@(2.225073858507201e-308));
@@ -459,10 +461,12 @@ isComplete:NO])
 }
 
 - (void)testExtremeDoublesAsUserWrites {
+#ifdef TARGET_OS_IPHONE
     if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion == 11) {
         // NSJSONSerialization on iOS 11 correctly serializes small and large doubles.
         return;
     }
+#endif
     
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     id<FNode> tinyDouble = NODE(@(2.225073858507201e-308));

--- a/Example/Database/Tests/Unit/FLevelDBStorageEngineTests.m
+++ b/Example/Database/Tests/Unit/FLevelDBStorageEngineTests.m
@@ -426,7 +426,7 @@
 // Well this is awkward, but NSJSONSerialization fails to deserialize JSON with tiny/huge doubles
 // It is kind of bad we raise "invalid" data, but at least we don't crash *trollface*
 - (void)testExtremeDoublesAsServerCache {
-#ifdef TARGET_OS_IPHONE
+#ifdef TARGET_OS_IOS
     if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion == 11) {
         // NSJSONSerialization on iOS 11 correctly serializes small and large doubles.
         return;
@@ -442,7 +442,7 @@
 }
 
 - (void)testExtremeDoublesAsTrackedQuery {
-#ifdef TARGET_OS_IPHONE
+#ifdef TARGET_OS_IOS
     if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion == 11) {
         // NSJSONSerialization on iOS 11 correctly serializes small and large doubles.
         return;


### PR DESCRIPTION
The "extremeDouble" tests for the iOS RTDB SDK rely on the fact that NSJSONSerialization can't correctly handle tiny double values. This has been fixed in iOS 11 and the tests fail.

I don't believe the tests add value in iOS 11 and hence I disabled them. 