### PR TITLE
Fixing FIRLogger init cost

### DIFF
--- a/Example/Core/App/iOS/FIRAppDelegate.m
+++ b/Example/Core/App/iOS/FIRAppDelegate.m
@@ -14,11 +14,13 @@
 
 #import "FIRAppDelegate.h"
 
+@import FirebaseCommunity;
+
 @implementation FIRAppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-    // Override point for customization after application launch.
+  [FIRApp configure];
     return YES;
 }
 

--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -69,9 +69,11 @@ static BOOL sFIRAnalyticsDebugMode;
 
 static FIRLoggerLevel sFIRLoggerMaximumLevel;
 
+#ifdef DEBUG
 /// The regex pattern for the message code.
 static NSString *const kMessageCodePattern = @"^I-[A-Z]{3}[0-9]{6}$";
 static NSRegularExpression *sMessageCodeRegex;
+#endif
 
 void FIRLoggerInitializeASL() {
   dispatch_once(&sFIRLoggerOnceToken, ^{
@@ -112,8 +114,10 @@ void FIRLoggerInitializeASL() {
     dispatch_set_target_queue(sFIRClientQueue,
                               dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0));
 
+#ifdef DEBUG
     sMessageCodeRegex =
         [NSRegularExpression regularExpressionWithPattern:kMessageCodePattern options:0 error:NULL];
+#endif
   });
 }
 


### PR DESCRIPTION
- Fixing the FIRLogger init cost by moving the  initialization of sMessageCodeRegex under #ifdef DEBUG

- Adding [FIRApp configure] to the Core example app to make Core changes testing easier