### PR TITLE
Add clang-format options and script; apply to FirebaseCore

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+BasedOnStyle: Google
+ColumnLimit: 100
+BinPackParameters: false
+AllowAllParametersOfDeclarationOnNextLine: true
+ObjCSpaceBeforeProtocolList: true
+SpacesInContainerLiterals: true
+PointerAlignment: Right

--- a/.clang-format
+++ b/.clang-format
@@ -5,4 +5,3 @@ AllowAllParametersOfDeclarationOnNextLine: true
 ObjCSpaceBeforeProtocolList: true
 SpacesInContainerLiterals: true
 PointerAlignment: Right
-AllowShortBlocksOnASingleLine: true

--- a/.clang-format
+++ b/.clang-format
@@ -5,3 +5,4 @@ AllowAllParametersOfDeclarationOnNextLine: true
 ObjCSpaceBeforeProtocolList: true
 SpacesInContainerLiterals: true
 PointerAlignment: Right
+AllowShortBlocksOnASingleLine: true

--- a/Example/Core/App/iOS/FIRAppDelegate.h
+++ b/Example/Core/App/iOS/FIRAppDelegate.h
@@ -18,6 +18,6 @@
 
 @interface FIRAppDelegate : UIResponder <UIApplicationDelegate>
 
-@property (strong, nonatomic) UIWindow *window;
+@property(strong, nonatomic) UIWindow *window;
 
 @end

--- a/Example/Core/App/iOS/FIRAppDelegate.m
+++ b/Example/Core/App/iOS/FIRAppDelegate.m
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@import FirebaseCommunity;
 #import "FIRAppDelegate.h"
 
 @import FirebaseCommunity;

--- a/Example/Core/App/iOS/FIRAppDelegate.m
+++ b/Example/Core/App/iOS/FIRAppDelegate.m
@@ -15,8 +15,6 @@
 @import FirebaseCommunity;
 #import "FIRAppDelegate.h"
 
-@import FirebaseCommunity;
-
 @implementation FIRAppDelegate
 
 - (BOOL)application:(UIApplication *)application

--- a/Example/Core/App/iOS/FIRAppDelegate.m
+++ b/Example/Core/App/iOS/FIRAppDelegate.m
@@ -18,37 +18,41 @@
 
 @implementation FIRAppDelegate
 
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
-{
+- (BOOL)application:(UIApplication *)application
+    didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   [FIRApp configure];
-    return YES;
+  return YES;
 }
 
-- (void)applicationWillResignActive:(UIApplication *)application
-{
-    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+- (void)applicationWillResignActive:(UIApplication *)application {
+  // Sent when the application is about to move from active to inactive state. This can occur for
+  // certain types of temporary interruptions (such as an incoming phone call or SMS message) or
+  // when the user quits the application and it begins the transition to the background state.
+  // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame
+  // rates. Games should use this method to pause the game.
 }
 
-- (void)applicationDidEnterBackground:(UIApplication *)application
-{
-    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+  // Use this method to release shared resources, save user data, invalidate timers, and store
+  // enough application state information to restore your application to its current state in case
+  // it is terminated later.
+  // If your application supports background execution, this method is called instead of
+  // applicationWillTerminate: when the user quits.
 }
 
-- (void)applicationWillEnterForeground:(UIApplication *)application
-{
-    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+  // Called as part of the transition from the background to the inactive state; here you can undo
+  // many of the changes made on entering the background.
 }
 
-- (void)applicationDidBecomeActive:(UIApplication *)application
-{
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+  // Restart any tasks that were paused (or not yet started) while the application was inactive. If
+  // the application was previously in the background, optionally refresh the user interface.
 }
 
-- (void)applicationWillTerminate:(UIApplication *)application
-{
-    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+- (void)applicationWillTerminate:(UIApplication *)application {
+  // Called when the application is about to terminate. Save data if appropriate. See also
+  // applicationDidEnterBackground:.
 }
 
 @end

--- a/Example/Core/App/iOS/FIRViewController.m
+++ b/Example/Core/App/iOS/FIRViewController.m
@@ -20,16 +20,14 @@
 
 @implementation FIRViewController
 
-- (void)viewDidLoad
-{
-    [super viewDidLoad];
-	// Do any additional setup after loading the view, typically from a nib.
+- (void)viewDidLoad {
+  [super viewDidLoad];
+  // Do any additional setup after loading the view, typically from a nib.
 }
 
-- (void)didReceiveMemoryWarning
-{
-    [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
+- (void)didReceiveMemoryWarning {
+  [super didReceiveMemoryWarning];
+  // Dispose of any resources that can be recreated.
 }
 
 @end

--- a/Example/Core/App/iOS/main.m
+++ b/Example/Core/App/iOS/main.m
@@ -15,9 +15,8 @@
 @import UIKit;
 #import "FIRAppDelegate.h"
 
-int main(int argc, char * argv[])
-{
-    @autoreleasepool {
-        return UIApplicationMain(argc, argv, nil, NSStringFromClass([FIRAppDelegate class]));
-    }
+int main(int argc, char* argv[]) {
+  @autoreleasepool {
+    return UIApplicationMain(argc, argv, nil, NSStringFromClass([FIRAppDelegate class]));
+  }
 }

--- a/Example/Core/App/macOS/FIRAppDelegate.h
+++ b/Example/Core/App/macOS/FIRAppDelegate.h
@@ -18,6 +18,4 @@
 
 @interface FIRAppDelegate : NSObject <NSApplicationDelegate>
 
-
 @end
-

--- a/Example/Core/App/macOS/FIRAppDelegate.m
+++ b/Example/Core/App/macOS/FIRAppDelegate.m
@@ -23,13 +23,11 @@
 @implementation FIRAppDelegate
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
-    // Insert code here to initialize your application
+  // Insert code here to initialize your application
 }
-
 
 - (void)applicationWillTerminate:(NSNotification *)aNotification {
-    // Insert code here to tear down your application
+  // Insert code here to tear down your application
 }
-
 
 @end

--- a/Example/Core/App/macOS/FIRViewController.h
+++ b/Example/Core/App/macOS/FIRViewController.h
@@ -18,6 +18,4 @@
 
 @interface FIRViewController : NSViewController
 
-
 @end
-

--- a/Example/Core/App/macOS/FIRViewController.m
+++ b/Example/Core/App/macOS/FIRViewController.m
@@ -19,17 +19,15 @@
 @implementation FIRViewController
 
 - (void)viewDidLoad {
-    [super viewDidLoad];
+  [super viewDidLoad];
 
-    // Do any additional setup after loading the view.
+  // Do any additional setup after loading the view.
 }
-
 
 - (void)setRepresentedObject:(id)representedObject {
-    [super setRepresentedObject:representedObject];
+  [super setRepresentedObject:representedObject];
 
-    // Update the view, if already loaded.
+  // Update the view, if already loaded.
 }
-
 
 @end

--- a/Example/Core/App/macOS/main.m
+++ b/Example/Core/App/macOS/main.m
@@ -16,6 +16,4 @@
 
 #import <Cocoa/Cocoa.h>
 
-int main(int argc, const char * argv[]) {
-    return NSApplicationMain(argc, argv);
-}
+int main(int argc, const char* argv[]) { return NSApplicationMain(argc, argv); }

--- a/Example/Core/Tests/FIRAppAssociationRegistrationUnitTests.m
+++ b/Example/Core/Tests/FIRAppAssociationRegistrationUnitTests.m
@@ -34,9 +34,7 @@ static NSString *kKey2 = @"key2";
 /** @var gCreateNewObject
     @brief A block that returns a new object everytime it is called.
  */
-static id _Nullable (^gCreateNewObject)() = ^id _Nullable() {
-  return [[NSObject alloc] init];
-};
+static id _Nullable (^gCreateNewObject)() = ^id _Nullable() { return [[NSObject alloc] init]; };
 
 /** @class FIRAppAssociationRegistrationTests
     @brief Tests for @c FIRAppAssociationRegistration
@@ -52,8 +50,8 @@ static id _Nullable (^gCreateNewObject)() = ^id _Nullable() {
   id result = [FIRAppAssociationRegistration registeredObjectWithHost:host
                                                                   key:kKey
                                                         creationBlock:^id _Nullable() {
-    return obj;
-  }];
+                                                          return obj;
+                                                        }];
   XCTAssertEqual(obj, result);
 }
 
@@ -62,8 +60,8 @@ static id _Nullable (^gCreateNewObject)() = ^id _Nullable() {
   id obj = [FIRAppAssociationRegistration registeredObjectWithHost:host
                                                                key:kKey
                                                      creationBlock:^id _Nullable() {
-    return nil;
-  }];
+                                                       return nil;
+                                                     }];
   XCTAssertNil(obj);
 }
 
@@ -76,10 +74,10 @@ static id _Nullable (^gCreateNewObject)() = ^id _Nullable() {
     [FIRAppAssociationRegistration registeredObjectWithHost:host
                                                         key:kKey
                                               creationBlock:^id _Nullable() {
-      id obj = gCreateNewObject();
-      weakObj = obj;
-      return obj;
-    }];
+                                                id obj = gCreateNewObject();
+                                                weakObj = obj;
+                                                return obj;
+                                              }];
     // Verify that neither the host nor the object is released yet, i.e., the host owns the object
     // because nothing else retains the object.
     XCTAssertNotNil(weakHost);
@@ -139,14 +137,15 @@ static id _Nullable (^gCreateNewObject)() = ^id _Nullable() {
 
 - (void)testReentrySameHostSameKey {
   id host = gCreateNewObject();
-  XCTAssertThrows([FIRAppAssociationRegistration registeredObjectWithHost:host
-                                                                key:kKey
-                                                      creationBlock:^id _Nullable() {
-    [FIRAppAssociationRegistration registeredObjectWithHost:host
-                                                        key:kKey
-                                              creationBlock:gCreateNewObject];
-    return gCreateNewObject();
-  }]);
+  XCTAssertThrows([FIRAppAssociationRegistration
+      registeredObjectWithHost:host
+                           key:kKey
+                 creationBlock:^id _Nullable() {
+                   [FIRAppAssociationRegistration registeredObjectWithHost:host
+                                                                       key:kKey
+                                                             creationBlock:gCreateNewObject];
+                   return gCreateNewObject();
+                 }]);
 }
 
 - (void)testReentrySameHostDifferentKey {
@@ -154,11 +153,12 @@ static id _Nullable (^gCreateNewObject)() = ^id _Nullable() {
   [FIRAppAssociationRegistration registeredObjectWithHost:host
                                                       key:kKey1
                                             creationBlock:^id _Nullable() {
-    [FIRAppAssociationRegistration registeredObjectWithHost:host
-                                                        key:kKey2
-                                              creationBlock:gCreateNewObject];
-    return gCreateNewObject();
-  }];
+                                              [FIRAppAssociationRegistration
+                                                  registeredObjectWithHost:host
+                                                                       key:kKey2
+                                                             creationBlock:gCreateNewObject];
+                                              return gCreateNewObject();
+                                            }];
   // Expect no exception raised.
 }
 
@@ -168,11 +168,12 @@ static id _Nullable (^gCreateNewObject)() = ^id _Nullable() {
   [FIRAppAssociationRegistration registeredObjectWithHost:host1
                                                       key:kKey
                                             creationBlock:^id _Nullable() {
-    [FIRAppAssociationRegistration registeredObjectWithHost:host2
-                                                        key:kKey
-                                              creationBlock:gCreateNewObject];
-    return gCreateNewObject();
-  }];
+                                              [FIRAppAssociationRegistration
+                                                  registeredObjectWithHost:host2
+                                                                       key:kKey
+                                                             creationBlock:gCreateNewObject];
+                                              return gCreateNewObject();
+                                            }];
   // Expect no exception raised.
 }
 
@@ -182,11 +183,12 @@ static id _Nullable (^gCreateNewObject)() = ^id _Nullable() {
   [FIRAppAssociationRegistration registeredObjectWithHost:host1
                                                       key:kKey1
                                             creationBlock:^id _Nullable() {
-    [FIRAppAssociationRegistration registeredObjectWithHost:host2
-                                                        key:kKey2
-                                              creationBlock:gCreateNewObject];
-    return gCreateNewObject();
-  }];
+                                              [FIRAppAssociationRegistration
+                                                  registeredObjectWithHost:host2
+                                                                       key:kKey2
+                                                             creationBlock:gCreateNewObject];
+                                              return gCreateNewObject();
+                                            }];
   // Expect no exception raised.
 }
 

--- a/Example/Core/Tests/FIRAppAssociationRegistrationUnitTests.m
+++ b/Example/Core/Tests/FIRAppAssociationRegistrationUnitTests.m
@@ -47,10 +47,11 @@ static id _Nullable (^gCreateNewObject)() = ^id _Nullable() { return [[NSObject 
 - (void)testPassObject {
   id host = gCreateNewObject();
   id obj = gCreateNewObject();
-  id result =
-      [FIRAppAssociationRegistration registeredObjectWithHost:host
-                                                          key:kKey
-                                                creationBlock:^id _Nullable() { return obj; }];
+  id result = [FIRAppAssociationRegistration registeredObjectWithHost:host
+                                                                  key:kKey
+                                                        creationBlock:^id _Nullable() {
+                                                          return obj;
+                                                        }];
   XCTAssertEqual(obj, result);
 }
 
@@ -58,7 +59,9 @@ static id _Nullable (^gCreateNewObject)() = ^id _Nullable() { return [[NSObject 
   id host = gCreateNewObject();
   id obj = [FIRAppAssociationRegistration registeredObjectWithHost:host
                                                                key:kKey
-                                                     creationBlock:^id _Nullable() { return nil; }];
+                                                     creationBlock:^id _Nullable() {
+                                                       return nil;
+                                                     }];
   XCTAssertNil(obj);
 }
 

--- a/Example/Core/Tests/FIRAppAssociationRegistrationUnitTests.m
+++ b/Example/Core/Tests/FIRAppAssociationRegistrationUnitTests.m
@@ -47,11 +47,10 @@ static id _Nullable (^gCreateNewObject)() = ^id _Nullable() { return [[NSObject 
 - (void)testPassObject {
   id host = gCreateNewObject();
   id obj = gCreateNewObject();
-  id result = [FIRAppAssociationRegistration registeredObjectWithHost:host
-                                                                  key:kKey
-                                                        creationBlock:^id _Nullable() {
-                                                          return obj;
-                                                        }];
+  id result =
+      [FIRAppAssociationRegistration registeredObjectWithHost:host
+                                                          key:kKey
+                                                creationBlock:^id _Nullable() { return obj; }];
   XCTAssertEqual(obj, result);
 }
 
@@ -59,9 +58,7 @@ static id _Nullable (^gCreateNewObject)() = ^id _Nullable() { return [[NSObject 
   id host = gCreateNewObject();
   id obj = [FIRAppAssociationRegistration registeredObjectWithHost:host
                                                                key:kKey
-                                                     creationBlock:^id _Nullable() {
-                                                       return nil;
-                                                     }];
+                                                     creationBlock:^id _Nullable() { return nil; }];
   XCTAssertNil(obj);
 }
 

--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "FIRTestCase.h"
 #import "FirebaseCommunity/FIRAppInternal.h"
 #import "FirebaseCommunity/FIROptionsInternal.h"
-#import "FIRTestCase.h"
 
 NSString *const kFIRTestAppName1 = @"test_app_name_1";
 NSString *const kFIRTestAppName2 = @"test-app-name-2";
@@ -42,7 +42,6 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 + (BOOL)validateAppIDFingerprint:(NSString *)appID withVersion:(NSString *)version;
 
 @end
-
 
 @interface FIRAppTest : FIRTestCase
 
@@ -73,8 +72,8 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 }
 
 - (void)testConfigure {
-  NSDictionary *expectedUserInfo = [self expectedUserInfoWithAppName:kFIRDefaultAppName
-                                                        isDefaultApp:YES];
+  NSDictionary *expectedUserInfo =
+      [self expectedUserInfoWithAppName:kFIRDefaultAppName isDefaultApp:YES];
   OCMExpect([self.notificationCenterMock postNotificationName:kFIRAppReadyToConfigureSDKNotification
                                                        object:[FIRApp class]
                                                      userInfo:expectedUserInfo]);
@@ -99,8 +98,8 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   XCTAssertThrows([FIRApp configureWithOptions:nil]);
   XCTAssertTrue([FIRApp allApps].count == 0);
 
-  NSDictionary *expectedUserInfo = [self expectedUserInfoWithAppName:kFIRDefaultAppName
-                                                        isDefaultApp:YES];
+  NSDictionary *expectedUserInfo =
+      [self expectedUserInfoWithAppName:kFIRDefaultAppName isDefaultApp:YES];
   OCMExpect([self.notificationCenterMock postNotificationName:kFIRAppReadyToConfigureSDKNotification
                                                        object:[FIRApp class]
                                                      userInfo:expectedUserInfo]);
@@ -128,8 +127,8 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
                                                   storageBucket:nil
                                               deepLinkURLScheme:nil];
 
-  NSDictionary *expectedUserInfo = [self expectedUserInfoWithAppName:kFIRDefaultAppName
-                                                        isDefaultApp:YES];
+  NSDictionary *expectedUserInfo =
+      [self expectedUserInfoWithAppName:kFIRDefaultAppName isDefaultApp:YES];
   OCMExpect([self.notificationCenterMock postNotificationName:kFIRAppReadyToConfigureSDKNotification
                                                        object:[FIRApp class]
                                                      userInfo:expectedUserInfo]);
@@ -149,12 +148,12 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   XCTAssertThrows([FIRApp configureWithName:nil options:[FIROptions defaultOptions]]);
   XCTAssertThrows([FIRApp configureWithName:kFIRTestAppName1 options:nil]);
   XCTAssertThrows([FIRApp configureWithName:@"" options:[FIROptions defaultOptions]]);
-  XCTAssertThrows([FIRApp configureWithName:kFIRDefaultAppName
-                                    options:[FIROptions defaultOptions]]);
+  XCTAssertThrows(
+      [FIRApp configureWithName:kFIRDefaultAppName options:[FIROptions defaultOptions]]);
   XCTAssertTrue([FIRApp allApps].count == 0);
 
-  NSDictionary *expectedUserInfo = [self expectedUserInfoWithAppName:kFIRTestAppName1
-                                                        isDefaultApp:NO];
+  NSDictionary *expectedUserInfo =
+      [self expectedUserInfoWithAppName:kFIRTestAppName1 isDefaultApp:NO];
   OCMExpect([self.notificationCenterMock postNotificationName:kFIRAppReadyToConfigureSDKNotification
                                                        object:[FIRApp class]
                                                      userInfo:expectedUserInfo]);
@@ -176,8 +175,8 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   FIROptions *newOptions = [options copy];
   newOptions.deepLinkURLScheme = kDeepLinkURLScheme;
 
-  NSDictionary *expectedUserInfo1 = [self expectedUserInfoWithAppName:kFIRTestAppName1
-                                                        isDefaultApp:NO];
+  NSDictionary *expectedUserInfo1 =
+      [self expectedUserInfoWithAppName:kFIRTestAppName1 isDefaultApp:NO];
   OCMExpect([self.notificationCenterMock postNotificationName:kFIRAppReadyToConfigureSDKNotification
                                                        object:[FIRApp class]
                                                      userInfo:expectedUserInfo1]);
@@ -197,8 +196,8 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
                                                             storageBucket:nil
                                                         deepLinkURLScheme:nil];
 
-  NSDictionary *expectedUserInfo2 = [self expectedUserInfoWithAppName:kFIRTestAppName2
-                                                         isDefaultApp:NO];
+  NSDictionary *expectedUserInfo2 =
+      [self expectedUserInfoWithAppName:kFIRTestAppName2 isDefaultApp:NO];
   OCMExpect([self.notificationCenterMock postNotificationName:kFIRAppReadyToConfigureSDKNotification
                                                        object:[FIRApp class]
                                                      userInfo:expectedUserInfo2]);
@@ -275,12 +274,12 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 
   [app getTokenForcingRefresh:YES
                  withCallback:^(NSString *_Nullable token, NSError *_Nullable error) {
-    getTokenCallbackWasCalled = YES;
-  }];
+                   getTokenCallbackWasCalled = YES;
+                 }];
 
   XCTAssert(getTokenCallbackWasCalled,
             @"The callback should be invoked by the base implementation when no block for "
-            "'getTokenImplementation' has been specified.");
+             "'getTokenImplementation' has been specified.");
 
   getTokenCallbackWasCalled = NO;
 
@@ -291,18 +290,18 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   };
   [app getTokenForcingRefresh:YES
                  withCallback:^(NSString *_Nullable token, NSError *_Nullable error) {
-    getTokenCallbackWasCalled = YES;
-  }];
+                   getTokenCallbackWasCalled = YES;
+                 }];
 
   XCTAssert(getTokenImplementationWasCalled,
             @"The 'getTokenImplementation' block was never called.");
   XCTAssert(passedRefreshValue,
             @"The value for the 'refresh' parameter wasn't passed to the 'getTokenImplementation' "
-            "block correctly.");
+             "block correctly.");
   XCTAssert(getTokenCallbackWasCalled,
             @"The 'getTokenImplementation' should have invoked the callback. This could be an "
-            "error in this test, or the callback parameter may not have been passed to the "
-            "implementation correctly.");
+             "error in this test, or the callback parameter may not have been passed to the "
+             "implementation correctly.");
 
   getTokenImplementationWasCalled = NO;
   getTokenCallbackWasCalled = NO;
@@ -310,12 +309,11 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 
   [app getTokenForcingRefresh:NO
                  withCallback:^(NSString *_Nullable token, NSError *_Nullable error) {
-    getTokenCallbackWasCalled = YES;
-  }];
+                   getTokenCallbackWasCalled = YES;
+                 }];
 
-  XCTAssertFalse(passedRefreshValue,
-                 @"The value for the 'refresh' parameter wasn't passed to the "
-                 "'getTokenImplementation' block correctly.");
+  XCTAssertFalse(passedRefreshValue, @"The value for the 'refresh' parameter wasn't passed to the "
+                                      "'getTokenImplementation' block correctly.");
 }
 
 - (void)testModifyingOptionsThrows {
@@ -338,8 +336,8 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 }
 
 - (void)testOptionsLocking {
-  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
-                                                    GCMSenderID:kGCMSenderID];
+  FIROptions *options =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
   options.projectID = kProjectID;
   options.databaseURL = kDatabaseURL;
 
@@ -484,14 +482,14 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   XCTAssertFalse([FIRApp validateAppIDFormat:@"01:1337:ios:deadbeef" withVersion:kGoodVersionV1]);
   XCTAssertFalse([FIRApp validateAppIDFormat:@"10:1337:ios:deadbeef" withVersion:kGoodVersionV1]);
   XCTAssertFalse([FIRApp validateAppIDFormat:@"11:1337:ios:deadbeef" withVersion:kGoodVersionV1]);
-  XCTAssertFalse([FIRApp validateAppIDFormat:@"21:1337:ios:5e18052ab54fbfec"
-                                 withVersion:kGoodVersionV2]);
-  XCTAssertFalse([FIRApp validateAppIDFormat:@"22:1337:ios:5e18052ab54fbfec"
-                                 withVersion:kGoodVersionV2]);
-  XCTAssertFalse([FIRApp validateAppIDFormat:@"02:1337:ios:5e18052ab54fbfec"
-                                 withVersion:kGoodVersionV2]);
-  XCTAssertFalse([FIRApp validateAppIDFormat:@"20:1337:ios:5e18052ab54fbfec"
-                                 withVersion:kGoodVersionV2]);
+  XCTAssertFalse(
+      [FIRApp validateAppIDFormat:@"21:1337:ios:5e18052ab54fbfec" withVersion:kGoodVersionV2]);
+  XCTAssertFalse(
+      [FIRApp validateAppIDFormat:@"22:1337:ios:5e18052ab54fbfec" withVersion:kGoodVersionV2]);
+  XCTAssertFalse(
+      [FIRApp validateAppIDFormat:@"02:1337:ios:5e18052ab54fbfec" withVersion:kGoodVersionV2]);
+  XCTAssertFalse(
+      [FIRApp validateAppIDFormat:@"20:1337:ios:5e18052ab54fbfec" withVersion:kGoodVersionV2]);
 
   // Extra fields.
   XCTAssertFalse([FIRApp validateAppIDFormat:@"ab:1:1337:ios:deadbeef" withVersion:kGoodVersionV1]);
@@ -532,31 +530,31 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   XCTAssertFalse([FIRApp validateAppIDFingerprint:kGoodAppIDV1 withVersion:kGoodAppIDV1]);
 
   // Versions digits that may make a partial match.
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"01:1337:ios:deadbeef"
-                                      withVersion:kGoodVersionV1]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"10:1337:ios:deadbeef"
-                                      withVersion:kGoodVersionV1]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"11:1337:ios:deadbeef"
-                                      withVersion:kGoodVersionV1]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"21:1337:ios:5e18052ab54fbfec"
-                                      withVersion:kGoodVersionV2]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"22:1337:ios:5e18052ab54fbfec"
-                                      withVersion:kGoodVersionV2]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"02:1337:ios:5e18052ab54fbfec"
-                                      withVersion:kGoodVersionV2]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"20:1337:ios:5e18052ab54fbfec"
-                                      withVersion:kGoodVersionV2]);
+  XCTAssertFalse(
+      [FIRApp validateAppIDFingerprint:@"01:1337:ios:deadbeef" withVersion:kGoodVersionV1]);
+  XCTAssertFalse(
+      [FIRApp validateAppIDFingerprint:@"10:1337:ios:deadbeef" withVersion:kGoodVersionV1]);
+  XCTAssertFalse(
+      [FIRApp validateAppIDFingerprint:@"11:1337:ios:deadbeef" withVersion:kGoodVersionV1]);
+  XCTAssertFalse(
+      [FIRApp validateAppIDFingerprint:@"21:1337:ios:5e18052ab54fbfec" withVersion:kGoodVersionV2]);
+  XCTAssertFalse(
+      [FIRApp validateAppIDFingerprint:@"22:1337:ios:5e18052ab54fbfec" withVersion:kGoodVersionV2]);
+  XCTAssertFalse(
+      [FIRApp validateAppIDFingerprint:@"02:1337:ios:5e18052ab54fbfec" withVersion:kGoodVersionV2]);
+  XCTAssertFalse(
+      [FIRApp validateAppIDFingerprint:@"20:1337:ios:5e18052ab54fbfec" withVersion:kGoodVersionV2]);
   // Extra fields.
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"ab:1:1337:ios:deadbeef"
-                                      withVersion:kGoodVersionV1]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"1:ab:1337:ios:deadbeef"
-                                      withVersion:kGoodVersionV1]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"1:1337:ab:ios:deadbeef"
-                                      withVersion:kGoodVersionV1]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"1:1337:ios:ab:deadbeef"
-                                      withVersion:kGoodVersionV1]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"1:1337:ios:deadbeef:ab"
-                                      withVersion:kGoodVersionV1]);
+  XCTAssertFalse(
+      [FIRApp validateAppIDFingerprint:@"ab:1:1337:ios:deadbeef" withVersion:kGoodVersionV1]);
+  XCTAssertFalse(
+      [FIRApp validateAppIDFingerprint:@"1:ab:1337:ios:deadbeef" withVersion:kGoodVersionV1]);
+  XCTAssertFalse(
+      [FIRApp validateAppIDFingerprint:@"1:1337:ab:ios:deadbeef" withVersion:kGoodVersionV1]);
+  XCTAssertFalse(
+      [FIRApp validateAppIDFingerprint:@"1:1337:ios:ab:deadbeef" withVersion:kGoodVersionV1]);
+  XCTAssertFalse(
+      [FIRApp validateAppIDFingerprint:@"1:1337:ios:deadbeef:ab" withVersion:kGoodVersionV1]);
 }
 
 #pragma mark - Internal Methods
@@ -564,7 +562,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 - (void)testAuthGetUID {
   [FIRApp configure];
 
-  [FIRApp defaultApp].getUIDImplementation = ^NSString *{ return @"highlander"; };
+  [FIRApp defaultApp].getUIDImplementation = ^NSString * { return @"highlander"; };
   XCTAssertEqual([[FIRApp defaultApp] getUID], @"highlander");
 }
 
@@ -583,8 +581,8 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 
 #pragma mark - private
 
-- (NSDictionary <NSString *, NSObject *> *)expectedUserInfoWithAppName:(NSString *)name
-                                                          isDefaultApp:(BOOL)isDefaultApp {
+- (NSDictionary<NSString *, NSObject *> *)expectedUserInfoWithAppName:(NSString *)name
+                                                         isDefaultApp:(BOOL)isDefaultApp {
   return @{
     kFIRAppNameKey : name,
     kFIRAppIsDefaultAppKey : [NSNumber numberWithBool:isDefaultApp],

--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -244,9 +244,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   [FIRApp configure];
   self.app = [FIRApp defaultApp];
   XCTAssertTrue([FIRApp allApps].count == 1);
-  [self.app deleteApp:^(BOOL success) {
-    XCTAssertTrue(success);
-  }];
+  [self.app deleteApp:^(BOOL success) { XCTAssertTrue(success); }];
   OCMVerify([self.notificationCenterMock postNotificationName:kFIRAppDeleteNotification
                                                        object:[FIRApp class]
                                                      userInfo:[OCMArg any]]);

--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -244,7 +244,9 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   [FIRApp configure];
   self.app = [FIRApp defaultApp];
   XCTAssertTrue([FIRApp allApps].count == 1);
-  [self.app deleteApp:^(BOOL success) { XCTAssertTrue(success); }];
+  [self.app deleteApp:^(BOOL success) {
+    XCTAssertTrue(success);
+  }];
   OCMVerify([self.notificationCenterMock postNotificationName:kFIRAppDeleteNotification
                                                        object:[FIRApp class]
                                                      userInfo:[OCMArg any]]);

--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import "FIRTestCase.h"
+
 #import "FirebaseCommunity/FIRAppInternal.h"
 #import "FirebaseCommunity/FIROptionsInternal.h"
 

--- a/Example/Core/Tests/FIRBundleUtilTest.m
+++ b/Example/Core/Tests/FIRBundleUtilTest.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "FirebaseCommunity/FIRBundleUtil.h"
-
 #import "FIRTestCase.h"
+
+#import "FirebaseCommunity/FIRBundleUtil.h"
 
 static NSString *const kResultPath = @"resultPath";
 static NSString *const kResourceName = @"resourceName";

--- a/Example/Core/Tests/FIRBundleUtilTest.m
+++ b/Example/Core/Tests/FIRBundleUtilTest.m
@@ -43,11 +43,10 @@ static NSString *const kFileType = @"fileType";
 
 - (void)testFindOptionsDictionaryPath {
   [OCMStub([self.mockBundle pathForResource:kResourceName ofType:kFileType]) andReturn:kResultPath];
-  XCTAssertEqualObjects(
-      [FIRBundleUtil optionsDictionaryPathWithResourceName:kResourceName
-                                               andFileType:kFileType
-                                                 inBundles:@[ self.mockBundle ]],
-      kResultPath);
+  XCTAssertEqualObjects([FIRBundleUtil optionsDictionaryPathWithResourceName:kResourceName
+                                                                 andFileType:kFileType
+                                                                   inBundles:@[ self.mockBundle ]],
+                        kResultPath);
 }
 
 - (void)testFindOptionsDictionaryPath_notFound {
@@ -61,11 +60,10 @@ static NSString *const kFileType = @"fileType";
   [OCMStub([self.mockBundle pathForResource:kResourceName ofType:kFileType]) andReturn:kResultPath];
 
   NSArray *bundles = @[ mockBundleEmpty, self.mockBundle ];
-  XCTAssertEqualObjects(
-      [FIRBundleUtil optionsDictionaryPathWithResourceName:kResourceName
-                                               andFileType:kFileType
-                                                 inBundles:bundles],
-      kResultPath);
+  XCTAssertEqualObjects([FIRBundleUtil optionsDictionaryPathWithResourceName:kResourceName
+                                                                 andFileType:kFileType
+                                                                   inBundles:bundles],
+                        kResultPath);
 }
 
 - (void)testBundleIdentifierExistsInBundles {
@@ -80,7 +78,7 @@ static NSString *const kFileType = @"fileType";
 }
 
 - (void)testBundleIdentifierExistsInBundles_emptyBundlesArray {
-  XCTAssertFalse([FIRBundleUtil hasBundleIdentifier:@"com.google.test" inBundles:@[ ]]);
+  XCTAssertFalse([FIRBundleUtil hasBundleIdentifier:@"com.google.test" inBundles:@[]]);
 }
 
 @end

--- a/Example/Core/Tests/FIRLoggerTest.m
+++ b/Example/Core/Tests/FIRLoggerTest.m
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import "FIRTestCase.h"
+
 #import "FirebaseCommunity/FIRLogger.h"
 
 #import <asl.h>

--- a/Example/Core/Tests/FIRLoggerTest.m
+++ b/Example/Core/Tests/FIRLoggerTest.m
@@ -234,9 +234,7 @@ static NSString *const kMessageCode = @"I-COR000001";
 
 - (void)drainFIRClientQueue {
   dispatch_semaphore_t workerSemaphore = dispatch_semaphore_create(0);
-  dispatch_async(getFIRClientQueue(), ^{
-    dispatch_semaphore_signal(workerSemaphore);
-  });
+  dispatch_async(getFIRClientQueue(), ^{ dispatch_semaphore_signal(workerSemaphore); });
   dispatch_semaphore_wait(workerSemaphore, DISPATCH_TIME_FOREVER);
 }
 
@@ -250,9 +248,7 @@ static NSString *const kMessageCode = @"I-COR000001";
   NSMutableArray *allMsg = [[NSMutableArray alloc] init];
   while ((m = asl_next(r)) != NULL) {
     val = asl_get(m, ASL_KEY_MSG);
-    if (val) {
-      [allMsg addObject:[NSString stringWithUTF8String:val]];
-    }
+    if (val) { [allMsg addObject:[NSString stringWithUTF8String:val]]; }
   }
   asl_free(m);
   asl_release(r);

--- a/Example/Core/Tests/FIRLoggerTest.m
+++ b/Example/Core/Tests/FIRLoggerTest.m
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "FirebaseCommunity/FIRLogger.h"
 #import "FIRTestCase.h"
+#import "FirebaseCommunity/FIRLogger.h"
 
 #import <asl.h>
 
@@ -155,7 +155,6 @@ static NSString *const kMessageCode = @"I-COR000001";
   XCTAssertThrows(FIRLogError(kFIRLoggerCore, @"A-APP000001", @"Message."));
 }
 
-
 - (void)testLoggerInterface {
   XCTAssertNoThrow(FIRLogError(kFIRLoggerCore, kMessageCode, @"Message."));
   XCTAssertNoThrow(FIRLogError(kFIRLoggerCore, kMessageCode, @"Configure %@.", @"blah"));
@@ -173,12 +172,11 @@ static NSString *const kMessageCode = @"I-COR000001";
   XCTAssertNoThrow(FIRLogDebug(kFIRLoggerCore, kMessageCode, @"Configure %@.", @"blah"));
 }
 
-
 // asl_set_filter does not perform as expected in unit test environment with simulator. The
 // following test only checks whether the logs have been sent to system with the default settings in
 // the unit test environment.
 - (void)testSystemLogWithDefaultStatus {
-#if !(BUG128) // Disable until https://github.com/firebase/firebase-ios-sdk/issues/128 is fixed
+#if !(BUG128)  // Disable until https://github.com/firebase/firebase-ios-sdk/issues/128 is fixed
   // Test fails on device and iOS 9 simulators - b/38130372
   return;
 #else
@@ -225,15 +223,13 @@ static NSString *const kMessageCode = @"I-COR000001";
   XCTAssertEqual(FIRLoggerLevelDebug, ASL_LEVEL_DEBUG);
 }
 
-
 // Helper functions.
 - (BOOL)logExists {
   [self drainFIRClientQueue];
-  NSString *correctMsg = [NSString stringWithFormat:@"%@[%@] %@", kFIRLoggerCore, kMessageCode,
-      self.randomLogString];
+  NSString *correctMsg =
+      [NSString stringWithFormat:@"%@[%@] %@", kFIRLoggerCore, kMessageCode, self.randomLogString];
   return [self messageWasLogged:correctMsg];
 }
-
 
 - (void)drainFIRClientQueue {
   dispatch_semaphore_t workerSemaphore = dispatch_semaphore_create(0);

--- a/Example/Core/Tests/FIRLoggerTest.m
+++ b/Example/Core/Tests/FIRLoggerTest.m
@@ -234,7 +234,9 @@ static NSString *const kMessageCode = @"I-COR000001";
 
 - (void)drainFIRClientQueue {
   dispatch_semaphore_t workerSemaphore = dispatch_semaphore_create(0);
-  dispatch_async(getFIRClientQueue(), ^{ dispatch_semaphore_signal(workerSemaphore); });
+  dispatch_async(getFIRClientQueue(), ^{
+    dispatch_semaphore_signal(workerSemaphore);
+  });
   dispatch_semaphore_wait(workerSemaphore, DISPATCH_TIME_FOREVER);
 }
 
@@ -248,7 +250,9 @@ static NSString *const kMessageCode = @"I-COR000001";
   NSMutableArray *allMsg = [[NSMutableArray alloc] init];
   while ((m = asl_next(r)) != NULL) {
     val = asl_get(m, ASL_KEY_MSG);
-    if (val) { [allMsg addObject:[NSString stringWithUTF8String:val]]; }
+    if (val) {
+      [allMsg addObject:[NSString stringWithUTF8String:val]];
+    }
   }
   asl_free(m);
   asl_release(r);

--- a/Example/Core/Tests/FIROptionsTest.m
+++ b/Example/Core/Tests/FIROptionsTest.m
@@ -42,8 +42,7 @@ extern NSString *const kFIRLibraryVersionID;
 
 - (void)testInit {
   NSDictionary *optionsDictionary = [FIROptions defaultOptionsDictionary];
-  FIROptions *options =
-      [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
+  FIROptions *options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   [self assertOptionsMatchDefaults:options andProjectID:YES];
   XCTAssertNil(options.deepLinkURLScheme);
   XCTAssertTrue(options.usingOptionsFromDefaultPlist);
@@ -95,8 +94,8 @@ extern NSString *const kFIRLibraryVersionID;
   XCTAssertEqualObjects(options.deepLinkURLScheme, kDeepLinkURLScheme);
   XCTAssertFalse(options.usingOptionsFromDefaultPlist);
 
-  FIROptions *options2 = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
-                                                     GCMSenderID:kGCMSenderID];
+  FIROptions *options2 =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
   options2.androidClientID = kAndroidClientID;
   options2.APIKey = kAPIKey;
   options2.bundleID = kBundleID;
@@ -112,15 +111,15 @@ extern NSString *const kFIRLibraryVersionID;
 
   // nil GoogleAppID should throw an exception
   XCTAssertThrows([[FIROptions alloc] initWithGoogleAppID:nil
-                                           bundleID:kBundleID
-                                        GCMSenderID:kGCMSenderID
-                                             APIKey:kCustomizedAPIKey
-                                           clientID:nil
-                                         trackingID:nil
-                                    androidClientID:nil
-                                        databaseURL:nil
-                                      storageBucket:nil
-                                  deepLinkURLScheme:nil]);
+                                                 bundleID:kBundleID
+                                              GCMSenderID:kGCMSenderID
+                                                   APIKey:kCustomizedAPIKey
+                                                 clientID:nil
+                                               trackingID:nil
+                                          androidClientID:nil
+                                              databaseURL:nil
+                                            storageBucket:nil
+                                        deepLinkURLScheme:nil]);
 }
 
 - (void)testinitWithContentsOfFile {
@@ -159,8 +158,8 @@ extern NSString *const kFIRLibraryVersionID;
 
 - (void)testCopyingProperties {
   NSMutableString *mutableString;
-  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
-                                                    GCMSenderID:kGCMSenderID];
+  FIROptions *options =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
   mutableString = [[NSMutableString alloc] initWithString:@"1"];
   options.APIKey = mutableString;
   [mutableString appendString:@"2"];
@@ -322,7 +321,7 @@ extern NSString *const kFIRLibraryVersionID;
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   mainDictionary = @{ kFIRIsAnalyticsCollectionDeactivated : @NO };
   OCMExpect([mainBundleMock infoDictionary]).andReturn(mainDictionary);
-  expectedAnalyticsOptions =  @{
+  expectedAnalyticsOptions = @{
     kFIRIsAnalyticsCollectionDeactivated : @NO,  // override
     kFIRIsAnalyticsCollectionEnabled : @YES,
     kFIRIsMeasurementEnabled : @YES

--- a/Example/Core/Tests/FIROptionsTest.m
+++ b/Example/Core/Tests/FIROptionsTest.m
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "FIRTestCase.h"
+
 #import "FirebaseCommunity/FIRAppInternal.h"
 #import "FirebaseCommunity/FIRBundleUtil.h"
 #import "FirebaseCommunity/FIROptionsInternal.h"
-
-#import "FIRTestCase.h"
 
 extern NSString *const kFIRIsMeasurementEnabled;
 extern NSString *const kFIRIsAnalyticsCollectionEnabled;

--- a/Example/Core/Tests/FIROptionsTest.m
+++ b/Example/Core/Tests/FIROptionsTest.m
@@ -151,7 +151,9 @@ extern NSString *const kFIRLibraryVersionID;
 
   // Custom `matchProjectID` parameter to be removed once the deprecated `FIROptions` constructor is
   // removed.
-  if (matchProjectID) { XCTAssertEqualObjects(options.projectID, kProjectID); }
+  if (matchProjectID) {
+    XCTAssertEqualObjects(options.projectID, kProjectID);
+  }
 }
 
 - (void)testCopyingProperties {
@@ -443,7 +445,9 @@ extern NSString *const kFIRLibraryVersionID;
 
   XCTAssertEqual(uniqueMainCombinations.count, 27);
   int mainSizeCount[4] = {0};
-  for (NSDictionary *dictionary in uniqueMainCombinations) { mainSizeCount[dictionary.count]++; }
+  for (NSDictionary *dictionary in uniqueMainCombinations) {
+    mainSizeCount[dictionary.count]++;
+  }
   XCTAssertEqual(mainSizeCount[0], 1);
   XCTAssertEqual(mainSizeCount[1], 6);
   XCTAssertEqual(mainSizeCount[2], 12);

--- a/Example/Core/Tests/FIROptionsTest.m
+++ b/Example/Core/Tests/FIROptionsTest.m
@@ -151,9 +151,7 @@ extern NSString *const kFIRLibraryVersionID;
 
   // Custom `matchProjectID` parameter to be removed once the deprecated `FIROptions` constructor is
   // removed.
-  if (matchProjectID) {
-    XCTAssertEqualObjects(options.projectID, kProjectID);
-  }
+  if (matchProjectID) { XCTAssertEqualObjects(options.projectID, kProjectID); }
 }
 
 - (void)testCopyingProperties {
@@ -445,9 +443,7 @@ extern NSString *const kFIRLibraryVersionID;
 
   XCTAssertEqual(uniqueMainCombinations.count, 27);
   int mainSizeCount[4] = {0};
-  for (NSDictionary *dictionary in uniqueMainCombinations) {
-    mainSizeCount[dictionary.count]++;
-  }
+  for (NSDictionary *dictionary in uniqueMainCombinations) { mainSizeCount[dictionary.count]++; }
   XCTAssertEqual(mainSizeCount[0], 1);
   XCTAssertEqual(mainSizeCount[1], 6);
   XCTAssertEqual(mainSizeCount[2], 12);

--- a/Example/Shared/FIRSampleAppUtilities.h
+++ b/Example/Shared/FIRSampleAppUtilities.h
@@ -20,7 +20,7 @@ NS_SWIFT_NAME(SampleAppUtilities)
 @interface FIRSampleAppUtilities : NSObject
 
 + (BOOL)appContainsRealServiceInfoPlist;
-+ (void)presentAlertForInvalidServiceInfoPlistFromViewController:(UIViewController *)
-      viewController NS_SWIFT_NAME(presentAlertForInvalidServiceInfoPlistFrom(_:));
++ (void)presentAlertForInvalidServiceInfoPlistFromViewController:(UIViewController *)viewController
+    NS_SWIFT_NAME(presentAlertForInvalidServiceInfoPlistFrom(_:));
 
 @end

--- a/Example/Shared/FIRSampleAppUtilities.m
+++ b/Example/Shared/FIRSampleAppUtilities.m
@@ -55,8 +55,8 @@ NSString *const kInvalidPlistAlertMessage = @"This sample app needs to be update
     return NO;
   }
 
-  NSString *plistFilePath = [bundle pathForResource:kServiceInfoFileName
-                                             ofType:kServiceInfoFileType];
+  NSString *plistFilePath =
+      [bundle pathForResource:kServiceInfoFileName ofType:kServiceInfoFileType];
   if (!plistFilePath.length) {
     return NO;
   }
@@ -78,24 +78,25 @@ NSString *const kInvalidPlistAlertMessage = @"This sample app needs to be update
   return YES;
 }
 
-+ (void)presentAlertForInvalidServiceInfoPlistFromViewController:(UIViewController *)
-      viewController {
++ (void)presentAlertForInvalidServiceInfoPlistFromViewController:
+    (UIViewController *)viewController {
   NSString *message = [NSString stringWithFormat:kInvalidPlistAlertMessage, kGithubRepoURLString];
   UIAlertController *alertController =
       [UIAlertController alertControllerWithTitle:kInvalidPlistAlertTitle
                                           message:message
                                    preferredStyle:UIAlertControllerStyleAlert];
-  UIAlertAction *viewReadmeAction =
-      [UIAlertAction actionWithTitle:@"View Github"
-                               style:UIAlertActionStyleDefault
-                             handler:^(UIAlertAction * _Nonnull action) {
-        NSURL *githubURL = [NSURL URLWithString:kGithubRepoURLString];
-        [FIRSampleAppUtilities navigateToURL:githubURL fromViewController:viewController];
+  UIAlertAction *viewReadmeAction = [UIAlertAction
+      actionWithTitle:@"View Github"
+                style:UIAlertActionStyleDefault
+              handler:^(UIAlertAction *_Nonnull action) {
+                NSURL *githubURL = [NSURL URLWithString:kGithubRepoURLString];
+                [FIRSampleAppUtilities navigateToURL:githubURL fromViewController:viewController];
 
-      }];
+              }];
   [alertController addAction:viewReadmeAction];
 
-  UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Close" style:UIAlertActionStyleCancel handler:nil];
+  UIAlertAction *cancelAction =
+      [UIAlertAction actionWithTitle:@"Close" style:UIAlertActionStyleCancel handler:nil];
   [alertController addAction:cancelAction];
 
   [viewController presentViewController:alertController animated:YES completion:nil];

--- a/Example/Shared/FIRSampleAppUtilities.m
+++ b/Example/Shared/FIRSampleAppUtilities.m
@@ -51,29 +51,19 @@ NSString *const kInvalidPlistAlertMessage = @"This sample app needs to be update
 
 + (BOOL)containsRealServiceInfoPlistInBundle:(NSBundle *)bundle {
   NSString *bundlePath = bundle.bundlePath;
-  if (!bundlePath.length) {
-    return NO;
-  }
+  if (!bundlePath.length) { return NO; }
 
   NSString *plistFilePath =
       [bundle pathForResource:kServiceInfoFileName ofType:kServiceInfoFileType];
-  if (!plistFilePath.length) {
-    return NO;
-  }
+  if (!plistFilePath.length) { return NO; }
 
   NSDictionary *plist = [NSDictionary dictionaryWithContentsOfFile:plistFilePath];
-  if (!plist) {
-    return NO;
-  }
+  if (!plist) { return NO; }
 
   // Perform a very naive validation by checking to see if the plist has the dummy google app id
   NSString *googleAppID = plist[kGoogleAppIDPlistKey];
-  if (!googleAppID.length) {
-    return NO;
-  }
-  if ([googleAppID isEqualToString:kDummyGoogleAppID]) {
-    return NO;
-  }
+  if (!googleAppID.length) { return NO; }
+  if ([googleAppID isEqualToString:kDummyGoogleAppID]) { return NO; }
 
   return YES;
 }

--- a/Example/Shared/FIRSampleAppUtilities.m
+++ b/Example/Shared/FIRSampleAppUtilities.m
@@ -51,19 +51,29 @@ NSString *const kInvalidPlistAlertMessage = @"This sample app needs to be update
 
 + (BOOL)containsRealServiceInfoPlistInBundle:(NSBundle *)bundle {
   NSString *bundlePath = bundle.bundlePath;
-  if (!bundlePath.length) { return NO; }
+  if (!bundlePath.length) {
+    return NO;
+  }
 
   NSString *plistFilePath =
       [bundle pathForResource:kServiceInfoFileName ofType:kServiceInfoFileType];
-  if (!plistFilePath.length) { return NO; }
+  if (!plistFilePath.length) {
+    return NO;
+  }
 
   NSDictionary *plist = [NSDictionary dictionaryWithContentsOfFile:plistFilePath];
-  if (!plist) { return NO; }
+  if (!plist) {
+    return NO;
+  }
 
   // Perform a very naive validation by checking to see if the plist has the dummy google app id
   NSString *googleAppID = plist[kGoogleAppIDPlistKey];
-  if (!googleAppID.length) { return NO; }
-  if ([googleAppID isEqualToString:kDummyGoogleAppID]) { return NO; }
+  if (!googleAppID.length) {
+    return NO;
+  }
+  if ([googleAppID isEqualToString:kDummyGoogleAppID]) {
+    return NO;
+  }
 
   return YES;
 }

--- a/Firebase/Core/FIRAnalyticsConfiguration.m
+++ b/Firebase/Core/FIRAnalyticsConfiguration.m
@@ -33,7 +33,7 @@
   }
   [[NSNotificationCenter defaultCenter] postNotificationName:name
                                                       object:self
-                                                    userInfo:@{ name : value }];
+                                                    userInfo:@{name : value}];
 }
 
 - (void)setMinimumSessionInterval:(NSTimeInterval)minimumSessionInterval {

--- a/Firebase/Core/FIRAnalyticsConfiguration.m
+++ b/Firebase/Core/FIRAnalyticsConfiguration.m
@@ -21,12 +21,16 @@
 + (FIRAnalyticsConfiguration *)sharedInstance {
   static FIRAnalyticsConfiguration *sharedInstance = nil;
   static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{ sharedInstance = [[FIRAnalyticsConfiguration alloc] init]; });
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [[FIRAnalyticsConfiguration alloc] init];
+  });
   return sharedInstance;
 }
 
 - (void)postNotificationName:(NSString *)name value:(id)value {
-  if (!name.length || !value) { return; }
+  if (!name.length || !value) {
+    return;
+  }
   [[NSNotificationCenter defaultCenter] postNotificationName:name
                                                       object:self
                                                     userInfo:@{name : value}];

--- a/Firebase/Core/FIRAnalyticsConfiguration.m
+++ b/Firebase/Core/FIRAnalyticsConfiguration.m
@@ -21,16 +21,12 @@
 + (FIRAnalyticsConfiguration *)sharedInstance {
   static FIRAnalyticsConfiguration *sharedInstance = nil;
   static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    sharedInstance = [[FIRAnalyticsConfiguration alloc] init];
-  });
+  dispatch_once(&onceToken, ^{ sharedInstance = [[FIRAnalyticsConfiguration alloc] init]; });
   return sharedInstance;
 }
 
 - (void)postNotificationName:(NSString *)name value:(id)value {
-  if (!name.length || !value) {
-    return;
-  }
+  if (!name.length || !value) { return; }
   [[NSNotificationCenter defaultCenter] postNotificationName:name
                                                       object:self
                                                     userInfo:@{name : value}];

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -15,9 +15,9 @@
 #include <sys/utsname.h>
 
 #import "FIRApp.h"
+#import "FIRConfiguration.h"
 #import "Private/FIRAppInternal.h"
 #import "Private/FIRBundleUtil.h"
-#import "FIRConfiguration.h"
 #import "Private/FIRLogger.h"
 #import "Private/FIROptionsInternal.h"
 
@@ -109,8 +109,9 @@ static FIRApp *sDefaultApp;
                       kFIRAppDiagnosticsConfigurationTypeKey : @(FIRConfigTypeCore),
                       kFIRAppDiagnosticsErrorKey : [FIRApp errorForMissingOptions]
                     }];
-    [NSException raise:kFirebaseCoreErrorDomain format:@"Please check there is a valid "
-                                                       @"GoogleService-Info.plist in the project."];
+    [NSException raise:kFirebaseCoreErrorDomain
+                format:@"Please check there is a valid "
+                       @"GoogleService-Info.plist in the project."];
   }
   [FIRApp configureDefaultAppWithOptions:options sendingNotifications:NO];
 }
@@ -150,13 +151,12 @@ static FIRApp *sDefaultApp;
   NSString *lowerCaseName = [name lowercaseString];
   for (NSInteger charIndex = 0; charIndex < lowerCaseName.length; charIndex++) {
     char character = [lowerCaseName characterAtIndex:charIndex];
-     if (!((character >= 'a' && character <= 'z')
-           || (character >= '0' && character <= '9')
-           || character == '_'
-           || character == '-'))  {
-       [NSException raise:kFirebaseCoreErrorDomain format:@"App name should only contain Letters, "
-                                                      @"Numbers, Underscores, and Dashes."];
-     }
+    if (!((character >= 'a' && character <= 'z') || (character >= '0' && character <= '9') ||
+          character == '_' || character == '-')) {
+      [NSException raise:kFirebaseCoreErrorDomain
+                  format:@"App name should only contain Letters, "
+                         @"Numbers, Underscores, and Dashes."];
+    }
   }
 
   if (sAllApps && sAllApps[name]) {
@@ -179,7 +179,8 @@ static FIRApp *sDefaultApp;
   if (sDefaultApp) {
     return sDefaultApp;
   }
-  FIRLogError(kFIRLoggerCore, @"I-COR000003", @"The default Firebase app has not yet been "
+  FIRLogError(kFIRLoggerCore, @"I-COR000003",
+              @"The default Firebase app has not yet been "
               @"configured. Add `[FIRApp configure];` (`FirebaseApp.configure()` in Swift) to your "
               @"application initialization. Read more: https://goo.gl/ctyzm8.");
   return nil;
@@ -224,9 +225,7 @@ static FIRApp *sDefaultApp;
         sDefaultApp = nil;
       }
       if (!self.alreadySentDeleteNotification) {
-        NSDictionary *appInfoDict = @ {
-          kFIRAppNameKey : self.name
-        };
+        NSDictionary *appInfoDict = @{kFIRAppNameKey : self.name};
         [[NSNotificationCenter defaultCenter] postNotificationName:kFIRAppDeleteNotification
                                                             object:[self class]
                                                           userInfo:appInfoDict];
@@ -299,7 +298,8 @@ static FIRApp *sDefaultApp;
   }
 
   if (NSClassFromString(@"FIRAppIndexing") != nil) {
-    FIRLogDebug(kFIRLoggerCore, @"I-COR000024", @"Firebase App Indexing on iOS is deprecated. "
+    FIRLogDebug(kFIRLoggerCore, @"I-COR000024",
+                @"Firebase App Indexing on iOS is deprecated. "
                 @"You don't need to take any action at this time. Learn more about Firebase App "
                 @"Indexing at https://firebase.google.com/docs/app-indexing/.");
   }
@@ -336,7 +336,7 @@ static FIRApp *sDefaultApp;
 
 + (void)sendNotificationsToSDKs:(FIRApp *)app {
   NSNumber *isDefaultApp = [NSNumber numberWithBool:(app == sDefaultApp)];
-  NSDictionary *appInfoDict = @ {
+  NSDictionary *appInfoDict = @{
     kFIRAppNameKey : app.name,
     kFIRAppIsDefaultAppKey : isDefaultApp,
     kFIRGoogleAppIDKey : app.options.googleAppID
@@ -362,20 +362,17 @@ static FIRApp *sDefaultApp;
                                                     reason:(NSString *)reason {
   NSString *description =
       [NSString stringWithFormat:@"Configuration failed for service %@.", service];
-  NSDictionary *errorDict = @{
-    NSLocalizedDescriptionKey : description,
-    NSLocalizedFailureReasonErrorKey : reason
-  };
+  NSDictionary *errorDict =
+      @{NSLocalizedDescriptionKey : description, NSLocalizedFailureReasonErrorKey : reason};
   return FIRCreateError(domain, code, errorDict);
 }
 
 + (NSError *)errorForInvalidAppID {
   NSDictionary *errorDict = @{
-      NSLocalizedDescriptionKey :
-      @"Unable to validate Google App ID",
-      NSLocalizedRecoverySuggestionErrorKey :
-      @"Check formatting and location of GoogleService-Info.plist or GoogleAppID set in the "
-      @"customized options."
+    NSLocalizedDescriptionKey : @"Unable to validate Google App ID",
+    NSLocalizedRecoverySuggestionErrorKey :
+        @"Check formatting and location of GoogleService-Info.plist or GoogleAppID set in the "
+        @"customized options."
   };
   return FIRCreateError(kFirebaseCoreErrorDomain, FIRErrorCodeInvalidAppID, errorDict);
 }
@@ -391,14 +388,15 @@ static FIRApp *sDefaultApp;
   // backward compatibility.
   if (expectedBundleID != nil &&
       ![FIRBundleUtil hasBundleIdentifier:expectedBundleID inBundles:bundles]) {
-    FIRLogInfo(kFIRLoggerCore, @"I-COR000008", @"The project's Bundle ID is inconsistent with "
-                @"either the Bundle ID in '%@.%@', or the Bundle ID in the options if you are "
-                @"using a customized options. To ensure that everything can be configured "
-                @"correctly, you may need to make the Bundle IDs consistent. To continue with this "
-                @"plist file, you may change your app's bundle identifier to '%@'. Or you can "
-                @"download a new configuration file that matches your bundle identifier from %@ "
-                @"and replace the current one.", kServiceInfoFileName, kServiceInfoFileType,
-                expectedBundleID, kPlistURL);
+    FIRLogInfo(kFIRLoggerCore, @"I-COR000008",
+               @"The project's Bundle ID is inconsistent with "
+               @"either the Bundle ID in '%@.%@', or the Bundle ID in the options if you are "
+               @"using a customized options. To ensure that everything can be configured "
+               @"correctly, you may need to make the Bundle IDs consistent. To continue with this "
+               @"plist file, you may change your app's bundle identifier to '%@'. Or you can "
+               @"download a new configuration file that matches your bundle identifier from %@ "
+               @"and replace the current one.",
+               kServiceInfoFileName, kServiceInfoFileType, expectedBundleID, kPlistURL);
   }
 }
 
@@ -421,16 +419,16 @@ static FIRApp *sDefaultApp;
 - (BOOL)isAppIDValid {
   NSString *appID = _options.googleAppID;
   BOOL isValid = [FIRApp validateAppID:appID];
-  if (!isValid){
+  if (!isValid) {
     NSString *expectedBundleID = [self expectedBundleID];
-    FIRLogError(kFIRLoggerCore, @"I-COR000009", @"The GOOGLE_APP_ID either in the plist file "
+    FIRLogError(kFIRLoggerCore, @"I-COR000009",
+                @"The GOOGLE_APP_ID either in the plist file "
                 @"'%@.%@' or the one set in the customized options is invalid. If you are using "
                 @"the plist file, use the iOS version of bundle identifier to download the file, "
                 @"and do not manually edit the GOOGLE_APP_ID. You may change your app's bundle "
                 @"identifier to '%@'. Or you can download a new configuration file that matches "
                 @"your bundle identifier from %@ and replace the current one.",
                 kServiceInfoFileName, kServiceInfoFileType, expectedBundleID, kPlistURL);
-
   };
   return isValid;
 }
@@ -583,7 +581,7 @@ static FIRApp *sDefaultApp;
 
 - (void)sendLogsWithServiceName:(NSString *)serviceName
                         version:(NSString *)version
-                          error:(NSError *)error{
+                          error:(NSError *)error {
   NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] initWithDictionary:@{
     kFIRAppDiagnosticsConfigurationTypeKey : @(FIRConfigTypeSDK),
     kFIRAppDiagnosticsSDKNameKey : serviceName,
@@ -593,10 +591,9 @@ static FIRApp *sDefaultApp;
   if (error) {
     userInfo[kFIRAppDiagnosticsErrorKey] = error;
   }
-  [[NSNotificationCenter defaultCenter]
-      postNotificationName:kFIRAppDiagnosticsNotification
-                    object:nil
-                  userInfo:userInfo];
+  [[NSNotificationCenter defaultCenter] postNotificationName:kFIRAppDiagnosticsNotification
+                                                      object:nil
+                                                    userInfo:userInfo];
 }
 
 @end

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -176,9 +176,7 @@ static FIRApp *sDefaultApp;
 }
 
 + (FIRApp *)defaultApp {
-  if (sDefaultApp) {
-    return sDefaultApp;
-  }
+  if (sDefaultApp) { return sDefaultApp; }
   FIRLogError(kFIRLoggerCore, @"I-COR000003",
               @"The default Firebase app has not yet been "
               @"configured. Add `[FIRApp configure];` (`FirebaseApp.configure()` in Swift) to your "
@@ -190,9 +188,7 @@ static FIRApp *sDefaultApp;
   @synchronized(self) {
     if (sAllApps) {
       FIRApp *app = sAllApps[name];
-      if (app) {
-        return app;
-      }
+      if (app) { return app; }
     }
     FIRLogError(kFIRLoggerCore, @"I-COR000004", @"App with name %@ does not exist.", name);
     return nil;
@@ -221,9 +217,7 @@ static FIRApp *sDefaultApp;
     if (sAllApps && sAllApps[self.name]) {
       FIRLogDebug(kFIRLoggerCore, @"I-COR000006", @"Deleting app named %@", self.name);
       [sAllApps removeObjectForKey:self.name];
-      if ([self.name isEqualToString:kFIRDefaultAppName]) {
-        sDefaultApp = nil;
-      }
+      if ([self.name isEqualToString:kFIRDefaultAppName]) { sDefaultApp = nil; }
       if (!self.alreadySentDeleteNotification) {
         NSDictionary *appInfoDict = @{kFIRAppNameKey : self.name};
         [[NSNotificationCenter defaultCenter] postNotificationName:kFIRAppDeleteNotification
@@ -240,9 +234,7 @@ static FIRApp *sDefaultApp;
 }
 
 + (void)addAppToAppDictionary:(FIRApp *)app {
-  if (!sAllApps) {
-    sAllApps = [NSMutableDictionary dictionary];
-  }
+  if (!sAllApps) { sAllApps = [NSMutableDictionary dictionary]; }
   if ([app configureCore]) {
     sAllApps[app.name] = app;
     [[NSNotificationCenter defaultCenter]
@@ -436,23 +428,17 @@ static FIRApp *sDefaultApp;
 + (BOOL)validateAppID:(NSString *)appID {
   // Failing validation only occurs when we are sure we are looking at a V2 app ID and it does not
   // have a valid fingerprint, otherwise we just warn about the potential issue.
-  if (!appID.length) {
-    return NO;
-  }
+  if (!appID.length) { return NO; }
 
   // All app IDs must start with at least "<version number>:".
   NSString *const versionPattern = @"^\\d+:";
   NSRegularExpression *versionRegex =
       [NSRegularExpression regularExpressionWithPattern:versionPattern options:0 error:NULL];
-  if (!versionRegex) {
-    return NO;
-  }
+  if (!versionRegex) { return NO; }
 
   NSRange appIDRange = NSMakeRange(0, appID.length);
   NSArray *versionMatches = [versionRegex matchesInString:appID options:0 range:appIDRange];
-  if (versionMatches.count != 1) {
-    return NO;
-  }
+  if (versionMatches.count != 1) { return NO; }
 
   NSRange versionRange = [(NSTextCheckingResult *)versionMatches.firstObject range];
   NSString *appIDVersion = [appID substringWithRange:versionRange];
@@ -462,13 +448,9 @@ static FIRApp *sDefaultApp;
     return YES;
   }
 
-  if (![FIRApp validateAppIDFormat:appID withVersion:appIDVersion]) {
-    return NO;
-  }
+  if (![FIRApp validateAppIDFormat:appID withVersion:appIDVersion]) { return NO; }
 
-  if (![FIRApp validateAppIDFingerprint:appID withVersion:appIDVersion]) {
-    return NO;
-  }
+  if (![FIRApp validateAppIDFingerprint:appID withVersion:appIDVersion]) { return NO; }
 
   return YES;
 }
@@ -492,30 +474,20 @@ static FIRApp *sDefaultApp;
  * @return YES if provided string fufills the expected format, NO otherwise.
  */
 + (BOOL)validateAppIDFormat:(NSString *)appID withVersion:(NSString *)version {
-  if (!appID.length || !version.length) {
-    return NO;
-  }
+  if (!appID.length || !version.length) { return NO; }
 
-  if (![version hasSuffix:@":"]) {
-    return NO;
-  }
+  if (![version hasSuffix:@":"]) { return NO; }
 
-  if (![appID hasPrefix:version]) {
-    return NO;
-  }
+  if (![appID hasPrefix:version]) { return NO; }
 
   NSString *const pattern = @"^\\d+:ios:[a-f0-9]+$";
   NSRegularExpression *regex =
       [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:NULL];
-  if (!regex) {
-    return NO;
-  }
+  if (!regex) { return NO; }
 
   NSRange localRange = NSMakeRange(version.length, appID.length - version.length);
   NSUInteger numberOfMatches = [regex numberOfMatchesInString:appID options:0 range:localRange];
-  if (numberOfMatches != 1) {
-    return NO;
-  }
+  if (numberOfMatches != 1) { return NO; }
   return YES;
 }
 
@@ -531,37 +503,25 @@ static FIRApp *sDefaultApp;
  *         otherwise.
  */
 + (BOOL)validateAppIDFingerprint:(NSString *)appID withVersion:(NSString *)version {
-  if (!appID.length || !version.length) {
-    return NO;
-  }
+  if (!appID.length || !version.length) { return NO; }
 
-  if (![version hasSuffix:@":"]) {
-    return NO;
-  }
+  if (![version hasSuffix:@":"]) { return NO; }
 
-  if (![appID hasPrefix:version]) {
-    return NO;
-  }
+  if (![appID hasPrefix:version]) { return NO; }
 
   // Extract the supplied fingerprint from the supplied app ID.
   // This assumes the app ID format is the same for all known versions below. If the app ID format
   // changes in future versions, the tokenizing of the app ID format will need to take into account
   // the version of the app ID.
   NSArray *components = [appID componentsSeparatedByString:@":"];
-  if (components.count != 4) {
-    return NO;
-  }
+  if (components.count != 4) { return NO; }
 
   NSString *suppliedFingerprintString = components[3];
-  if (!suppliedFingerprintString.length) {
-    return NO;
-  }
+  if (!suppliedFingerprintString.length) { return NO; }
 
   uint64_t suppliedFingerprint;
   NSScanner *scanner = [NSScanner scannerWithString:suppliedFingerprintString];
-  if (![scanner scanHexLongLong:&suppliedFingerprint]) {
-    return NO;
-  }
+  if (![scanner scanHexLongLong:&suppliedFingerprint]) { return NO; }
 
   if ([version isEqual:@"1:"]) {
     // The v1 hash algorithm is not permitted on the client so the actual hash cannot be validated.
@@ -588,9 +548,7 @@ static FIRApp *sDefaultApp;
     kFIRAppDiagnosticsSDKVersionKey : version,
     kFIRAppDiagnosticsFIRAppKey : self
   }];
-  if (error) {
-    userInfo[kFIRAppDiagnosticsErrorKey] = error;
-  }
+  if (error) { userInfo[kFIRAppDiagnosticsErrorKey] = error; }
   [[NSNotificationCenter defaultCenter] postNotificationName:kFIRAppDiagnosticsNotification
                                                       object:nil
                                                     userInfo:userInfo];

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -176,7 +176,9 @@ static FIRApp *sDefaultApp;
 }
 
 + (FIRApp *)defaultApp {
-  if (sDefaultApp) { return sDefaultApp; }
+  if (sDefaultApp) {
+    return sDefaultApp;
+  }
   FIRLogError(kFIRLoggerCore, @"I-COR000003",
               @"The default Firebase app has not yet been "
               @"configured. Add `[FIRApp configure];` (`FirebaseApp.configure()` in Swift) to your "
@@ -188,7 +190,9 @@ static FIRApp *sDefaultApp;
   @synchronized(self) {
     if (sAllApps) {
       FIRApp *app = sAllApps[name];
-      if (app) { return app; }
+      if (app) {
+        return app;
+      }
     }
     FIRLogError(kFIRLoggerCore, @"I-COR000004", @"App with name %@ does not exist.", name);
     return nil;
@@ -217,7 +221,9 @@ static FIRApp *sDefaultApp;
     if (sAllApps && sAllApps[self.name]) {
       FIRLogDebug(kFIRLoggerCore, @"I-COR000006", @"Deleting app named %@", self.name);
       [sAllApps removeObjectForKey:self.name];
-      if ([self.name isEqualToString:kFIRDefaultAppName]) { sDefaultApp = nil; }
+      if ([self.name isEqualToString:kFIRDefaultAppName]) {
+        sDefaultApp = nil;
+      }
       if (!self.alreadySentDeleteNotification) {
         NSDictionary *appInfoDict = @{kFIRAppNameKey : self.name};
         [[NSNotificationCenter defaultCenter] postNotificationName:kFIRAppDeleteNotification
@@ -234,7 +240,9 @@ static FIRApp *sDefaultApp;
 }
 
 + (void)addAppToAppDictionary:(FIRApp *)app {
-  if (!sAllApps) { sAllApps = [NSMutableDictionary dictionary]; }
+  if (!sAllApps) {
+    sAllApps = [NSMutableDictionary dictionary];
+  }
   if ([app configureCore]) {
     sAllApps[app.name] = app;
     [[NSNotificationCenter defaultCenter]
@@ -428,17 +436,23 @@ static FIRApp *sDefaultApp;
 + (BOOL)validateAppID:(NSString *)appID {
   // Failing validation only occurs when we are sure we are looking at a V2 app ID and it does not
   // have a valid fingerprint, otherwise we just warn about the potential issue.
-  if (!appID.length) { return NO; }
+  if (!appID.length) {
+    return NO;
+  }
 
   // All app IDs must start with at least "<version number>:".
   NSString *const versionPattern = @"^\\d+:";
   NSRegularExpression *versionRegex =
       [NSRegularExpression regularExpressionWithPattern:versionPattern options:0 error:NULL];
-  if (!versionRegex) { return NO; }
+  if (!versionRegex) {
+    return NO;
+  }
 
   NSRange appIDRange = NSMakeRange(0, appID.length);
   NSArray *versionMatches = [versionRegex matchesInString:appID options:0 range:appIDRange];
-  if (versionMatches.count != 1) { return NO; }
+  if (versionMatches.count != 1) {
+    return NO;
+  }
 
   NSRange versionRange = [(NSTextCheckingResult *)versionMatches.firstObject range];
   NSString *appIDVersion = [appID substringWithRange:versionRange];
@@ -448,9 +462,13 @@ static FIRApp *sDefaultApp;
     return YES;
   }
 
-  if (![FIRApp validateAppIDFormat:appID withVersion:appIDVersion]) { return NO; }
+  if (![FIRApp validateAppIDFormat:appID withVersion:appIDVersion]) {
+    return NO;
+  }
 
-  if (![FIRApp validateAppIDFingerprint:appID withVersion:appIDVersion]) { return NO; }
+  if (![FIRApp validateAppIDFingerprint:appID withVersion:appIDVersion]) {
+    return NO;
+  }
 
   return YES;
 }
@@ -474,20 +492,30 @@ static FIRApp *sDefaultApp;
  * @return YES if provided string fufills the expected format, NO otherwise.
  */
 + (BOOL)validateAppIDFormat:(NSString *)appID withVersion:(NSString *)version {
-  if (!appID.length || !version.length) { return NO; }
+  if (!appID.length || !version.length) {
+    return NO;
+  }
 
-  if (![version hasSuffix:@":"]) { return NO; }
+  if (![version hasSuffix:@":"]) {
+    return NO;
+  }
 
-  if (![appID hasPrefix:version]) { return NO; }
+  if (![appID hasPrefix:version]) {
+    return NO;
+  }
 
   NSString *const pattern = @"^\\d+:ios:[a-f0-9]+$";
   NSRegularExpression *regex =
       [NSRegularExpression regularExpressionWithPattern:pattern options:0 error:NULL];
-  if (!regex) { return NO; }
+  if (!regex) {
+    return NO;
+  }
 
   NSRange localRange = NSMakeRange(version.length, appID.length - version.length);
   NSUInteger numberOfMatches = [regex numberOfMatchesInString:appID options:0 range:localRange];
-  if (numberOfMatches != 1) { return NO; }
+  if (numberOfMatches != 1) {
+    return NO;
+  }
   return YES;
 }
 
@@ -503,25 +531,37 @@ static FIRApp *sDefaultApp;
  *         otherwise.
  */
 + (BOOL)validateAppIDFingerprint:(NSString *)appID withVersion:(NSString *)version {
-  if (!appID.length || !version.length) { return NO; }
+  if (!appID.length || !version.length) {
+    return NO;
+  }
 
-  if (![version hasSuffix:@":"]) { return NO; }
+  if (![version hasSuffix:@":"]) {
+    return NO;
+  }
 
-  if (![appID hasPrefix:version]) { return NO; }
+  if (![appID hasPrefix:version]) {
+    return NO;
+  }
 
   // Extract the supplied fingerprint from the supplied app ID.
   // This assumes the app ID format is the same for all known versions below. If the app ID format
   // changes in future versions, the tokenizing of the app ID format will need to take into account
   // the version of the app ID.
   NSArray *components = [appID componentsSeparatedByString:@":"];
-  if (components.count != 4) { return NO; }
+  if (components.count != 4) {
+    return NO;
+  }
 
   NSString *suppliedFingerprintString = components[3];
-  if (!suppliedFingerprintString.length) { return NO; }
+  if (!suppliedFingerprintString.length) {
+    return NO;
+  }
 
   uint64_t suppliedFingerprint;
   NSScanner *scanner = [NSScanner scannerWithString:suppliedFingerprintString];
-  if (![scanner scanHexLongLong:&suppliedFingerprint]) { return NO; }
+  if (![scanner scanHexLongLong:&suppliedFingerprint]) {
+    return NO;
+  }
 
   if ([version isEqual:@"1:"]) {
     // The v1 hash algorithm is not permitted on the client so the actual hash cannot be validated.
@@ -548,7 +588,9 @@ static FIRApp *sDefaultApp;
     kFIRAppDiagnosticsSDKVersionKey : version,
     kFIRAppDiagnosticsFIRAppKey : self
   }];
-  if (error) { userInfo[kFIRAppDiagnosticsErrorKey] = error; }
+  if (error) {
+    userInfo[kFIRAppDiagnosticsErrorKey] = error;
+  }
   [[NSNotificationCenter defaultCenter] postNotificationName:kFIRAppDiagnosticsNotification
                                                       object:nil
                                                     userInfo:userInfo];

--- a/Firebase/Core/FIRBundleUtil.m
+++ b/Firebase/Core/FIRBundleUtil.m
@@ -27,9 +27,7 @@
   for (NSBundle *bundle in bundles) {
     NSString *path = [bundle pathForResource:resourceName ofType:fileType];
     // Use the first one we find.
-    if (path) {
-      return path;
-    }
+    if (path) { return path; }
   }
   return nil;
 }
@@ -55,9 +53,7 @@
 
 + (BOOL)hasBundleIdentifier:(NSString *)bundleIdentifier inBundles:(NSArray *)bundles {
   for (NSBundle *bundle in bundles) {
-    if ([bundle.bundleIdentifier isEqualToString:bundleIdentifier]) {
-      return YES;
-    }
+    if ([bundle.bundleIdentifier isEqualToString:bundleIdentifier]) { return YES; }
   }
   return NO;
 }

--- a/Firebase/Core/FIRBundleUtil.m
+++ b/Firebase/Core/FIRBundleUtil.m
@@ -27,7 +27,9 @@
   for (NSBundle *bundle in bundles) {
     NSString *path = [bundle pathForResource:resourceName ofType:fileType];
     // Use the first one we find.
-    if (path) { return path; }
+    if (path) {
+      return path;
+    }
   }
   return nil;
 }
@@ -53,7 +55,9 @@
 
 + (BOOL)hasBundleIdentifier:(NSString *)bundleIdentifier inBundles:(NSArray *)bundles {
   for (NSBundle *bundle in bundles) {
-    if ([bundle.bundleIdentifier isEqualToString:bundleIdentifier]) { return YES; }
+    if ([bundle.bundleIdentifier isEqualToString:bundleIdentifier]) {
+      return YES;
+    }
   }
   return NO;
 }

--- a/Firebase/Core/FIRConfiguration.m
+++ b/Firebase/Core/FIRConfiguration.m
@@ -47,5 +47,4 @@ extern void FIRSetLoggerLevel(FIRLoggerLevel loggerLevel);
   FIRSetLoggerLevel(loggerLevel);
 }
 
-
 @end

--- a/Firebase/Core/FIRConfiguration.m
+++ b/Firebase/Core/FIRConfiguration.m
@@ -21,17 +21,13 @@ extern void FIRSetLoggerLevel(FIRLoggerLevel loggerLevel);
 + (instancetype)sharedInstance {
   static FIRConfiguration *sharedInstance = nil;
   static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    sharedInstance = [[FIRConfiguration alloc] init];
-  });
+  dispatch_once(&onceToken, ^{ sharedInstance = [[FIRConfiguration alloc] init]; });
   return sharedInstance;
 }
 
 - (instancetype)init {
   self = [super init];
-  if (self) {
-    _analyticsConfiguration = [FIRAnalyticsConfiguration sharedInstance];
-  }
+  if (self) { _analyticsConfiguration = [FIRAnalyticsConfiguration sharedInstance]; }
   return self;
 }
 

--- a/Firebase/Core/FIRConfiguration.m
+++ b/Firebase/Core/FIRConfiguration.m
@@ -21,13 +21,17 @@ extern void FIRSetLoggerLevel(FIRLoggerLevel loggerLevel);
 + (instancetype)sharedInstance {
   static FIRConfiguration *sharedInstance = nil;
   static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{ sharedInstance = [[FIRConfiguration alloc] init]; });
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [[FIRConfiguration alloc] init];
+  });
   return sharedInstance;
 }
 
 - (instancetype)init {
   self = [super init];
-  if (self) { _analyticsConfiguration = [FIRAnalyticsConfiguration sharedInstance]; }
+  if (self) {
+    _analyticsConfiguration = [FIRAnalyticsConfiguration sharedInstance];
+  }
   return self;
 }
 

--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -100,9 +100,7 @@ void FIRLoggerInitializeASL() {
     }
 
     // We should disable debug mode if we are running from App Store.
-    if (sFIRLoggerDebugMode && [FIRAppEnvironmentUtil isFromAppStore]) {
-      sFIRLoggerDebugMode = NO;
-    }
+    if (sFIRLoggerDebugMode && [FIRAppEnvironmentUtil isFromAppStore]) { sFIRLoggerDebugMode = NO; }
 
     // Need to call asl_add_output_file so that the logs can appear in Xcode's console view. Set
     // the ASL filter mask for this output file up to debug level so that all messages are
@@ -125,9 +123,7 @@ void FIRSetAnalyticsDebugMode(BOOL analyticsDebugMode) {
   FIRLoggerInitializeASL();
   dispatch_async(sFIRClientQueue, ^{
     // We should not enable debug mode if we are running from App Store.
-    if (analyticsDebugMode && [FIRAppEnvironmentUtil isFromAppStore]) {
-      return;
-    }
+    if (analyticsDebugMode && [FIRAppEnvironmentUtil isFromAppStore]) { return; }
     sFIRAnalyticsDebugMode = analyticsDebugMode;
     asl_set_filter(sFIRLoggerClient, ASL_FILTER_MASK_UPTO(ASL_LEVEL_DEBUG));
   });
@@ -141,9 +137,7 @@ void FIRSetLoggerLevel(FIRLoggerLevel loggerLevel) {
   FIRLoggerInitializeASL();
   dispatch_async(sFIRClientQueue, ^{
     // We should not raise the logger level if we are running from App Store.
-    if (loggerLevel >= FIRLoggerLevelNotice && [FIRAppEnvironmentUtil isFromAppStore]) {
-      return;
-    }
+    if (loggerLevel >= FIRLoggerLevelNotice && [FIRAppEnvironmentUtil isFromAppStore]) { return; }
 
     sFIRLoggerMaximumLevel = loggerLevel;
     asl_set_filter(sFIRLoggerClient, ASL_FILTER_MASK_UPTO(loggerLevel));
@@ -187,9 +181,7 @@ void FIRLogBasic(FIRLoggerLevel level,
     canLog = YES;
   }
 
-  if (!canLog) {
-    return;
-  }
+  if (!canLog) { return; }
 #ifdef DEBUG
   NSCAssert(messageCode.length == 11, @"Incorrect message code length.");
   NSRange messageCodeRange = NSMakeRange(0, messageCode.length);
@@ -199,9 +191,8 @@ void FIRLogBasic(FIRLoggerLevel level,
 #endif
   NSString *logMsg = [[NSString alloc] initWithFormat:message arguments:args_ptr];
   logMsg = [NSString stringWithFormat:@"%@[%@] %@", service, messageCode, logMsg];
-  dispatch_async(sFIRClientQueue, ^{
-    asl_log(sFIRLoggerClient, NULL, level, "%s", logMsg.UTF8String);
-  });
+  dispatch_async(sFIRClientQueue,
+                 ^{ asl_log(sFIRLoggerClient, NULL, level, "%s", logMsg.UTF8String); });
 }
 
 /**

--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -105,8 +105,8 @@ void FIRLoggerInitializeASL() {
     }
 
     // Need to call asl_add_output_file so that the logs can appear in Xcode's console view. Set
-    // the ASL filter mask for this output file up to debug level so that all messages are viewable
-    // in the console.
+    // the ASL filter mask for this output file up to debug level so that all messages are
+    // viewable in the console.
     asl_add_output_file(sFIRLoggerClient, STDERR_FILENO, kFIRLoggerCustomASLMessageFormat,
                         ASL_TIME_FMT_LCL, ASL_FILTER_MASK_UPTO(ASL_LEVEL_DEBUG), ASL_ENCODE_SAFE);
 

--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -20,9 +20,9 @@
 #include <asl.h>
 #include <assert.h>
 #include <stdbool.h>
+#include <sys/sysctl.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <sys/sysctl.h>
 
 FIRLoggerService kFIRLoggerABTesting = @"[Firebase/ABTesting]";
 FIRLoggerService kFIRLoggerAdMob = @"[Firebase/AdMob]";
@@ -90,10 +90,10 @@ void FIRLoggerInitializeASL() {
     NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
     BOOL debugMode = [userDefaults boolForKey:kFIRPersistedDebugModeKey];
 
-    if ([arguments containsObject:kFIRDisableDebugModeApplicationArgument]) { // Default mode
+    if ([arguments containsObject:kFIRDisableDebugModeApplicationArgument]) {  // Default mode
       [userDefaults removeObjectForKey:kFIRPersistedDebugModeKey];
-    } else if ([arguments containsObject:kFIREnableDebugModeApplicationArgument]
-               || debugMode) { // Debug mode
+    } else if ([arguments containsObject:kFIREnableDebugModeApplicationArgument] ||
+               debugMode) {  // Debug mode
       [userDefaults setBool:YES forKey:kFIRPersistedDebugModeKey];
       asl_set_filter(sFIRLoggerClient, ASL_FILTER_MASK_UPTO(ASL_LEVEL_DEBUG));
       sFIRLoggerDebugMode = YES;
@@ -166,21 +166,18 @@ void FIRResetLogger() {
   [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFIRPersistedDebugModeKey];
 }
 
-aslclient getFIRLoggerClient() {
-  return sFIRLoggerClient;
-}
+aslclient getFIRLoggerClient() { return sFIRLoggerClient; }
 
-dispatch_queue_t getFIRClientQueue() {
-  return sFIRClientQueue;
-}
+dispatch_queue_t getFIRClientQueue() { return sFIRClientQueue; }
 
-BOOL getFIRLoggerDebugMode() {
-  return sFIRLoggerDebugMode;
-}
+BOOL getFIRLoggerDebugMode() { return sFIRLoggerDebugMode; }
 #endif
 
-void FIRLogBasic(FIRLoggerLevel level, FIRLoggerService service, NSString *messageCode,
-                 NSString *message, va_list args_ptr) {
+void FIRLogBasic(FIRLoggerLevel level,
+                 FIRLoggerService service,
+                 NSString *messageCode,
+                 NSString *message,
+                 va_list args_ptr) {
   FIRLoggerInitializeASL();
   BOOL canLog = level <= sFIRLoggerMaximumLevel;
 
@@ -215,13 +212,13 @@ void FIRLogBasic(FIRLoggerLevel level, FIRLoggerService service, NSString *messa
  * Calling FIRLogDebug(kFIRLoggerCore, @"I-COR000001", @"Configure succeed.") shows:
  * yyyy-mm-dd hh:mm:ss.SSS sender[PID] <Debug> [Firebase/Core][I-COR000001] Configure succeed.
  */
-#define FIR_LOGGING_FUNCTION(level) \
-void FIRLog##level(FIRLoggerService service, NSString *messageCode, NSString *message, ...) { \
-  va_list args_ptr; \
-  va_start(args_ptr, message); \
-  FIRLogBasic(FIRLoggerLevel##level, service, messageCode, message, args_ptr); \
-  va_end(args_ptr); \
-}
+#define FIR_LOGGING_FUNCTION(level)                                                             \
+  void FIRLog##level(FIRLoggerService service, NSString *messageCode, NSString *message, ...) { \
+    va_list args_ptr;                                                                           \
+    va_start(args_ptr, message);                                                                \
+    FIRLogBasic(FIRLoggerLevel##level, service, messageCode, message, args_ptr);                \
+    va_end(args_ptr);                                                                           \
+  }
 
 FIR_LOGGING_FUNCTION(Error)
 FIR_LOGGING_FUNCTION(Warning)

--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -100,7 +100,9 @@ void FIRLoggerInitializeASL() {
     }
 
     // We should disable debug mode if we are running from App Store.
-    if (sFIRLoggerDebugMode && [FIRAppEnvironmentUtil isFromAppStore]) { sFIRLoggerDebugMode = NO; }
+    if (sFIRLoggerDebugMode && [FIRAppEnvironmentUtil isFromAppStore]) {
+      sFIRLoggerDebugMode = NO;
+    }
 
     // Need to call asl_add_output_file so that the logs can appear in Xcode's console view. Set
     // the ASL filter mask for this output file up to debug level so that all messages are
@@ -123,7 +125,9 @@ void FIRSetAnalyticsDebugMode(BOOL analyticsDebugMode) {
   FIRLoggerInitializeASL();
   dispatch_async(sFIRClientQueue, ^{
     // We should not enable debug mode if we are running from App Store.
-    if (analyticsDebugMode && [FIRAppEnvironmentUtil isFromAppStore]) { return; }
+    if (analyticsDebugMode && [FIRAppEnvironmentUtil isFromAppStore]) {
+      return;
+    }
     sFIRAnalyticsDebugMode = analyticsDebugMode;
     asl_set_filter(sFIRLoggerClient, ASL_FILTER_MASK_UPTO(ASL_LEVEL_DEBUG));
   });
@@ -137,7 +141,9 @@ void FIRSetLoggerLevel(FIRLoggerLevel loggerLevel) {
   FIRLoggerInitializeASL();
   dispatch_async(sFIRClientQueue, ^{
     // We should not raise the logger level if we are running from App Store.
-    if (loggerLevel >= FIRLoggerLevelNotice && [FIRAppEnvironmentUtil isFromAppStore]) { return; }
+    if (loggerLevel >= FIRLoggerLevelNotice && [FIRAppEnvironmentUtil isFromAppStore]) {
+      return;
+    }
 
     sFIRLoggerMaximumLevel = loggerLevel;
     asl_set_filter(sFIRLoggerClient, ASL_FILTER_MASK_UPTO(loggerLevel));
@@ -181,7 +187,9 @@ void FIRLogBasic(FIRLoggerLevel level,
     canLog = YES;
   }
 
-  if (!canLog) { return; }
+  if (!canLog) {
+    return;
+  }
 #ifdef DEBUG
   NSCAssert(messageCode.length == 11, @"Incorrect message code length.");
   NSRange messageCodeRange = NSMakeRange(0, messageCode.length);
@@ -191,8 +199,9 @@ void FIRLogBasic(FIRLoggerLevel level,
 #endif
   NSString *logMsg = [[NSString alloc] initWithFormat:message arguments:args_ptr];
   logMsg = [NSString stringWithFormat:@"%@[%@] %@", service, messageCode, logMsg];
-  dispatch_async(sFIRClientQueue,
-                 ^{ asl_log(sFIRLoggerClient, NULL, level, "%s", logMsg.UTF8String); });
+  dispatch_async(sFIRClientQueue, ^{
+    asl_log(sFIRLoggerClient, NULL, level, "%s", logMsg.UTF8String);
+  });
 }
 
 /**

--- a/Firebase/Core/FIRMutableDictionary.m
+++ b/Firebase/Core/FIRMutableDictionary.m
@@ -36,43 +36,31 @@
 
 - (NSString *)description {
   __block NSString *description;
-  dispatch_sync(_queue, ^{
-    description = _objects.description;
-  });
+  dispatch_sync(_queue, ^{ description = _objects.description; });
   return description;
 }
 
 - (id)objectForKey:(id)key {
   __block id object;
-  dispatch_sync(_queue, ^{
-    object = _objects[key];
-  });
+  dispatch_sync(_queue, ^{ object = _objects[key]; });
   return object;
 }
 
 - (void)setObject:(id)object forKey:(id<NSCopying>)key {
-  dispatch_async(_queue, ^{
-    _objects[key] = object;
-  });
+  dispatch_async(_queue, ^{ _objects[key] = object; });
 }
 
 - (void)removeObjectForKey:(id)key {
-  dispatch_async(_queue, ^{
-    [_objects removeObjectForKey:key];
-  });
+  dispatch_async(_queue, ^{ [_objects removeObjectForKey:key]; });
 }
 
 - (void)removeAllObjects {
-  dispatch_async(_queue, ^{
-    [_objects removeAllObjects];
-  });
+  dispatch_async(_queue, ^{ [_objects removeAllObjects]; });
 }
 
 - (NSUInteger)count {
   __block NSUInteger count;
-  dispatch_sync(_queue, ^{
-    count = _objects.count;
-  });
+  dispatch_sync(_queue, ^{ count = _objects.count; });
   return count;
 }
 
@@ -88,9 +76,7 @@
 
 - (NSDictionary *)dictionary {
   __block NSDictionary *dictionary;
-  dispatch_sync(_queue, ^{
-    dictionary = [_objects copy];
-  });
+  dispatch_sync(_queue, ^{ dictionary = [_objects copy]; });
   return dictionary;
 }
 

--- a/Firebase/Core/FIRMutableDictionary.m
+++ b/Firebase/Core/FIRMutableDictionary.m
@@ -36,31 +36,43 @@
 
 - (NSString *)description {
   __block NSString *description;
-  dispatch_sync(_queue, ^{ description = _objects.description; });
+  dispatch_sync(_queue, ^{
+    description = _objects.description;
+  });
   return description;
 }
 
 - (id)objectForKey:(id)key {
   __block id object;
-  dispatch_sync(_queue, ^{ object = _objects[key]; });
+  dispatch_sync(_queue, ^{
+    object = _objects[key];
+  });
   return object;
 }
 
 - (void)setObject:(id)object forKey:(id<NSCopying>)key {
-  dispatch_async(_queue, ^{ _objects[key] = object; });
+  dispatch_async(_queue, ^{
+    _objects[key] = object;
+  });
 }
 
 - (void)removeObjectForKey:(id)key {
-  dispatch_async(_queue, ^{ [_objects removeObjectForKey:key]; });
+  dispatch_async(_queue, ^{
+    [_objects removeObjectForKey:key];
+  });
 }
 
 - (void)removeAllObjects {
-  dispatch_async(_queue, ^{ [_objects removeAllObjects]; });
+  dispatch_async(_queue, ^{
+    [_objects removeAllObjects];
+  });
 }
 
 - (NSUInteger)count {
   __block NSUInteger count;
-  dispatch_sync(_queue, ^{ count = _objects.count; });
+  dispatch_sync(_queue, ^{
+    count = _objects.count;
+  });
   return count;
 }
 
@@ -76,7 +88,9 @@
 
 - (NSDictionary *)dictionary {
   __block NSDictionary *dictionary;
-  dispatch_sync(_queue, ^{ dictionary = [_objects copy]; });
+  dispatch_sync(_queue, ^{
+    dictionary = [_objects copy];
+  });
   return dictionary;
 }
 

--- a/Firebase/Core/FIRNetwork.m
+++ b/Firebase/Core/FIRNetwork.m
@@ -15,10 +15,10 @@
 #import "Private/FIRNetwork.h"
 #import "Private/FIRNetworkMessageCode.h"
 
+#import "Private/FIRLogger.h"
 #import "Private/FIRMutableDictionary.h"
 #import "Private/FIRNetworkConstants.h"
 #import "Private/FIRReachabilityChecker.h"
-#import "Private/FIRLogger.h"
 
 #import <GoogleToolboxForMac/GTMNSData+zlib.h>
 
@@ -46,7 +46,7 @@ static NSString *const kFIRNetworkPOSTRequestMethod = @"POST";
 /// Default constant string as a prefix for network logger.
 static NSString *const kFIRNetworkLogTag = @"Firebase/Network";
 
-@interface FIRNetwork ()<FIRReachabilityDelegate, FIRNetworkLoggerDelegate>
+@interface FIRNetwork () <FIRReachabilityDelegate, FIRNetworkLoggerDelegate>
 @end
 
 @implementation FIRNetwork {
@@ -65,10 +65,9 @@ static NSString *const kFIRNetworkLogTag = @"Firebase/Network";
   self = [super init];
   if (self) {
     // Setup reachability.
-    _reachability =
-        [[FIRReachabilityChecker alloc] initWithReachabilityDelegate:self
-                                                      loggerDelegate:self
-                                                            withHost:reachabilityHost];
+    _reachability = [[FIRReachabilityChecker alloc] initWithReachabilityDelegate:self
+                                                                  loggerDelegate:self
+                                                                        withHost:reachabilityHost];
     if (![_reachability start]) {
       return nil;
     }
@@ -169,7 +168,7 @@ static NSString *const kFIRNetworkLogTag = @"Firebase/Network";
   }
 
   [self firNetwork_logWithLevel:kFIRNetworkLogLevelDebug
-                       messageCode:kFIRNetworkMessageCodeNetwork000
+                    messageCode:kFIRNetworkMessageCodeNetwork000
                         message:@"Uploading data. Host"
                         context:url];
   _requests[requestID] = fetcher;
@@ -362,7 +361,8 @@ static NSString *FIRLogLevelDescriptionFromLogLevel(FIRNetworkLogLevel logLevel)
 }
 
 /// Returns a formatted string to be used for console logging.
-static NSString *FIRStringWithLogMessage(NSString *message, FIRNetworkLogLevel logLevel,
+static NSString *FIRStringWithLogMessage(NSString *message,
+                                         FIRNetworkLogLevel logLevel,
                                          NSArray *contexts) {
   if (!message) {
     message = @"(Message was nil)";

--- a/Firebase/Core/FIRNetwork.m
+++ b/Firebase/Core/FIRNetwork.m
@@ -68,7 +68,9 @@ static NSString *const kFIRNetworkLogTag = @"Firebase/Network";
     _reachability = [[FIRReachabilityChecker alloc] initWithReachabilityDelegate:self
                                                                   loggerDelegate:self
                                                                         withHost:reachabilityHost];
-    if (![_reachability start]) { return nil; }
+    if (![_reachability start]) {
+      return nil;
+    }
 
     _requests = [[FIRMutableDictionary alloc] init];
     _timeoutInterval = kFIRNetworkTimeOutInterval;
@@ -145,13 +147,17 @@ static NSString *const kFIRNetworkLogTag = @"Firebase/Network";
                   completionHandler:^(NSHTTPURLResponse *response, NSData *data,
                                       NSString *sessionID, NSError *error) {
                     FIRNetwork *strongSelf = weakSelf;
-                    if (!strongSelf) { return; }
+                    if (!strongSelf) {
+                      return;
+                    }
                     dispatch_queue_t queueToDispatch = queue ? queue : dispatch_get_main_queue();
                     dispatch_async(queueToDispatch, ^{
                       if (sessionID.length) {
                         [strongSelf->_requests removeObjectForKey:sessionID];
                       }
-                      if (handler) { handler(response, data, error); }
+                      if (handler) {
+                        handler(response, data, error);
+                      }
                     });
                   }];
   if (!requestID) {
@@ -204,11 +210,17 @@ static NSString *const kFIRNetworkLogTag = @"Firebase/Network";
                  completionHandler:^(NSHTTPURLResponse *response, NSData *data, NSString *sessionID,
                                      NSError *error) {
                    FIRNetwork *strongSelf = weakSelf;
-                   if (!strongSelf) { return; }
+                   if (!strongSelf) {
+                     return;
+                   }
                    dispatch_queue_t queueToDispatch = queue ? queue : dispatch_get_main_queue();
                    dispatch_async(queueToDispatch, ^{
-                     if (sessionID.length) { [strongSelf->_requests removeObjectForKey:sessionID]; }
-                     if (handler) { handler(response, data, error); }
+                     if (sessionID.length) {
+                       [strongSelf->_requests removeObjectForKey:sessionID];
+                     }
+                     if (handler) {
+                       handler(response, data, error);
+                     }
                    });
                  }];
 
@@ -277,7 +289,9 @@ static NSString *const kFIRNetworkLogTag = @"Firebase/Network";
                        contexts:@[ @(code), error ]];
   if (handler) {
     dispatch_queue_t queueToDispatch = queue ? queue : dispatch_get_main_queue();
-    dispatch_async(queueToDispatch, ^{ handler(nil, nil, error); });
+    dispatch_async(queueToDispatch, ^{
+      handler(nil, nil, error);
+    });
   }
 }
 
@@ -359,7 +373,9 @@ static NSString *FIRStringWithLogMessage(NSString *message,
       initWithFormat:@"<%@/%@> %@", kFIRNetworkLogTag, FIRLogLevelDescriptionFromLogLevel(logLevel),
                      message];
 
-  if (!contexts.count) { return result; }
+  if (!contexts.count) {
+    return result;
+  }
 
   NSMutableArray *formattedContexts = [[NSMutableArray alloc] init];
   for (id item in contexts) {

--- a/Firebase/Core/FIRNetwork.m
+++ b/Firebase/Core/FIRNetwork.m
@@ -68,9 +68,7 @@ static NSString *const kFIRNetworkLogTag = @"Firebase/Network";
     _reachability = [[FIRReachabilityChecker alloc] initWithReachabilityDelegate:self
                                                                   loggerDelegate:self
                                                                         withHost:reachabilityHost];
-    if (![_reachability start]) {
-      return nil;
-    }
+    if (![_reachability start]) { return nil; }
 
     _requests = [[FIRMutableDictionary alloc] init];
     _timeoutInterval = kFIRNetworkTimeOutInterval;
@@ -147,17 +145,13 @@ static NSString *const kFIRNetworkLogTag = @"Firebase/Network";
                   completionHandler:^(NSHTTPURLResponse *response, NSData *data,
                                       NSString *sessionID, NSError *error) {
                     FIRNetwork *strongSelf = weakSelf;
-                    if (!strongSelf) {
-                      return;
-                    }
+                    if (!strongSelf) { return; }
                     dispatch_queue_t queueToDispatch = queue ? queue : dispatch_get_main_queue();
                     dispatch_async(queueToDispatch, ^{
                       if (sessionID.length) {
                         [strongSelf->_requests removeObjectForKey:sessionID];
                       }
-                      if (handler) {
-                        handler(response, data, error);
-                      }
+                      if (handler) { handler(response, data, error); }
                     });
                   }];
   if (!requestID) {
@@ -210,17 +204,11 @@ static NSString *const kFIRNetworkLogTag = @"Firebase/Network";
                  completionHandler:^(NSHTTPURLResponse *response, NSData *data, NSString *sessionID,
                                      NSError *error) {
                    FIRNetwork *strongSelf = weakSelf;
-                   if (!strongSelf) {
-                     return;
-                   }
+                   if (!strongSelf) { return; }
                    dispatch_queue_t queueToDispatch = queue ? queue : dispatch_get_main_queue();
                    dispatch_async(queueToDispatch, ^{
-                     if (sessionID.length) {
-                       [strongSelf->_requests removeObjectForKey:sessionID];
-                     }
-                     if (handler) {
-                       handler(response, data, error);
-                     }
+                     if (sessionID.length) { [strongSelf->_requests removeObjectForKey:sessionID]; }
+                     if (handler) { handler(response, data, error); }
                    });
                  }];
 
@@ -289,9 +277,7 @@ static NSString *const kFIRNetworkLogTag = @"Firebase/Network";
                        contexts:@[ @(code), error ]];
   if (handler) {
     dispatch_queue_t queueToDispatch = queue ? queue : dispatch_get_main_queue();
-    dispatch_async(queueToDispatch, ^{
-      handler(nil, nil, error);
-    });
+    dispatch_async(queueToDispatch, ^{ handler(nil, nil, error); });
   }
 }
 
@@ -373,9 +359,7 @@ static NSString *FIRStringWithLogMessage(NSString *message,
       initWithFormat:@"<%@/%@> %@", kFIRNetworkLogTag, FIRLogLevelDescriptionFromLogLevel(logLevel),
                      message];
 
-  if (!contexts.count) {
-    return result;
-  }
+  if (!contexts.count) { return result; }
 
   NSMutableArray *formattedContexts = [[NSMutableArray alloc] init];
   for (id item in contexts) {

--- a/Firebase/Core/FIRNetworkConstants.m
+++ b/Firebase/Core/FIRNetworkConstants.m
@@ -21,7 +21,7 @@ NSString *const kFIRNetworkBackgroundSessionConfigIDPrefix =
 NSString *const kFIRNetworkApplicationSupportSubdirectory = @"Firebase/Network";
 NSString *const kFIRNetworkTempDirectoryName = @"FIRNetworkTemporaryDirectory";
 const NSTimeInterval kFIRNetworkTempFolderExpireTime = 60 * 60;  // 1 hour
-const NSTimeInterval kFIRNetworkTimeOutInterval = 60;  // 1 minute.
+const NSTimeInterval kFIRNetworkTimeOutInterval = 60;            // 1 minute.
 NSString *const kFIRNetworkReachabilityHost = @"app-measurement.com";
 NSString *const kFIRNetworkErrorContext = @"Context";
 

--- a/Firebase/Core/FIRNetworkURLSession.m
+++ b/Firebase/Core/FIRNetworkURLSession.m
@@ -16,10 +16,10 @@
 
 #import "Private/FIRNetworkURLSession.h"
 
+#import "Private/FIRLogger.h"
 #import "Private/FIRMutableDictionary.h"
 #import "Private/FIRNetworkConstants.h"
 #import "Private/FIRNetworkMessageCode.h"
-#import "Private/FIRLogger.h"
 
 @implementation FIRNetworkURLSession {
   /// The handler to be called when the request completes or error has occurs.
@@ -54,8 +54,7 @@
         NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
     NSString *applicationSupportDirectory = paths.firstObject;
     NSArray *tempPathComponents = @[
-      applicationSupportDirectory,
-      kFIRNetworkApplicationSupportSubdirectory,
+      applicationSupportDirectory, kFIRNetworkApplicationSupportSubdirectory,
       kFIRNetworkTempDirectoryName
     ];
     _networkDirectoryURL = [NSURL fileURLWithPathComponents:tempPathComponents];
@@ -432,18 +431,16 @@
 
 /// Creates a background session configuration with the session ID using the supported method.
 - (NSURLSessionConfiguration *)backgroundSessionConfigWithSessionID:(NSString *)sessionID {
-  #if (TARGET_OS_OSX && defined(MAC_OS_X_VERSION_10_10) &&          \
-      MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_10) ||   \
-      (TARGET_OS_IOS && defined(__IPHONE_8_0) &&                    \
-      __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0)
+#if (TARGET_OS_OSX && defined(MAC_OS_X_VERSION_10_10) &&         \
+     MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_10) || \
+    (TARGET_OS_IOS && defined(__IPHONE_8_0) && __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0)
 
   // iOS 8/10.10 builds require the new backgroundSessionConfiguration method name.
   return [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:sessionID];
 
-  #elif (TARGET_OS_OSX && defined(MAC_OS_X_VERSION_10_10) &&        \
-        MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_10) ||  \
-        (TARGET_OS_IOS && defined(__IPHONE_8_0) &&                  \
-        __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0)
+#elif (TARGET_OS_OSX && defined(MAC_OS_X_VERSION_10_10) &&        \
+       MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_10) || \
+    (TARGET_OS_IOS && defined(__IPHONE_8_0) && __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_8_0)
 
   // Do a runtime check to avoid a deprecation warning about using
   // +backgroundSessionConfiguration: on iOS 8.
@@ -456,10 +453,10 @@
     return [NSURLSessionConfiguration backgroundSessionConfiguration:sessionID];
   }
 
-  #else
+#else
   // Building with an SDK earlier than iOS 8/OS X 10.10.
   return [NSURLSessionConfiguration backgroundSessionConfiguration:sessionID];
-  #endif
+#endif
 }
 
 - (void)maybeRemoveTempFilesAtURL:(NSURL *)folderURL expiringTime:(NSTimeInterval)staleTime {
@@ -623,10 +620,8 @@
                     newRequest:(NSURLRequest *)request
              completionHandler:(void (^)(NSURLRequest *))completionHandler {
   NSArray *nonAllowedRedirectionCodes = @[
-    @(kFIRNetworkHTTPStatusCodeFound),
-    @(kFIRNetworkHTTPStatusCodeMovedPermanently),
-    @(kFIRNetworkHTTPStatusCodeMovedTemporarily),
-    @(kFIRNetworkHTTPStatusCodeMultipleChoices)
+    @(kFIRNetworkHTTPStatusCodeFound), @(kFIRNetworkHTTPStatusCodeMovedPermanently),
+    @(kFIRNetworkHTTPStatusCodeMovedTemporarily), @(kFIRNetworkHTTPStatusCodeMultipleChoices)
   ];
 
   // Allow those not in the non allowed list to be followed.
@@ -655,7 +650,7 @@
     [_loggerDelegate firNetwork_logWithLevel:kFIRNetworkLogLevelError
                                  messageCode:kFIRNetworkMessageCodeURLSession017
                                      message:@"Encounter network error. Code, error"
-                                    contexts:@[@(error.code), error]];
+                                    contexts:@[ @(error.code), error ]];
   }
 
   if (handler) {

--- a/Firebase/Core/FIRNetworkURLSession.m
+++ b/Firebase/Core/FIRNetworkURLSession.m
@@ -73,7 +73,9 @@
                             completionHandler:
                                 (FIRNetworkSystemCompletionHandler)systemCompletionHandler {
   // The session may not be FIRAnalytics background. Ignore those that do not have the prefix.
-  if (![sessionID hasPrefix:kFIRNetworkBackgroundSessionConfigIDPrefix]) { return; }
+  if (![sessionID hasPrefix:kFIRNetworkBackgroundSessionConfigIDPrefix]) {
+    return;
+  }
   FIRNetworkURLSession *fetcher = [self fetcherWithSessionIdentifier:sessionID];
   if (fetcher != nil) {
     [fetcher addSystemCompletionHandler:systemCompletionHandler forSession:sessionID];
@@ -416,7 +418,9 @@
   if (handler) {
     [systemCompletionHandlers removeObjectForKey:identifier];
 
-    dispatch_async(dispatch_get_main_queue(), ^{ handler(); });
+    dispatch_async(dispatch_get_main_queue(), ^{
+      handler();
+    });
   }
 }
 
@@ -456,7 +460,9 @@
 }
 
 - (void)maybeRemoveTempFilesAtURL:(NSURL *)folderURL expiringTime:(NSTimeInterval)staleTime {
-  if (!folderURL.absoluteString.length) { return; }
+  if (!folderURL.absoluteString.length) {
+    return;
+  }
 
   NSFileManager *fileManager = [NSFileManager defaultManager];
   NSError *error = nil;
@@ -476,23 +482,31 @@
     return;
   }
 
-  if (!directoryContent.count) { return; }
+  if (!directoryContent.count) {
+    return;
+  }
 
   NSTimeInterval now = [NSDate date].timeIntervalSince1970;
   for (NSURL *tempFile in directoryContent) {
     NSDate *creationDate;
     BOOL getCreationDate =
         [tempFile getResourceValue:&creationDate forKey:NSURLCreationDateKey error:NULL];
-    if (!getCreationDate) { continue; }
+    if (!getCreationDate) {
+      continue;
+    }
     NSTimeInterval creationTimeInterval = creationDate.timeIntervalSince1970;
-    if (fabs(now - creationTimeInterval) > staleTime) { [self removeTempItemAtURL:tempFile]; }
+    if (fabs(now - creationTimeInterval) > staleTime) {
+      [self removeTempItemAtURL:tempFile];
+    }
   }
 }
 
 /// Removes the temporary file written to disk for sending the request. It has to be cleaned up
 /// after the session is done.
 - (void)removeTempItemAtURL:(NSURL *)fileURL {
-  if (!fileURL.absoluteString.length) { return; }
+  if (!fileURL.absoluteString.length) {
+    return;
+  }
 
   NSFileManager *fileManager = [NSFileManager defaultManager];
   NSError *error = nil;
@@ -523,8 +537,9 @@
   static NSMapTable *sessionIDToFetcherMap;
 
   static dispatch_once_t sessionMapOnceToken;
-  dispatch_once(&sessionMapOnceToken,
-                ^{ sessionIDToFetcherMap = [NSMapTable strongToWeakObjectsMapTable]; });
+  dispatch_once(&sessionMapOnceToken, ^{
+    sessionIDToFetcherMap = [NSMapTable strongToWeakObjectsMapTable];
+  });
   return sessionIDToFetcherMap;
 }
 
@@ -534,8 +549,9 @@
   static FIRMutableDictionary *systemCompletionHandlers;
 
   static dispatch_once_t systemCompletionHandlerOnceToken;
-  dispatch_once(&systemCompletionHandlerOnceToken,
-                ^{ systemCompletionHandlers = [[FIRMutableDictionary alloc] init]; });
+  dispatch_once(&systemCompletionHandlerOnceToken, ^{
+    systemCompletionHandlers = [[FIRMutableDictionary alloc] init];
+  });
   return systemCompletionHandlers;
 }
 
@@ -551,7 +567,9 @@
   NSError *error = nil;
 
   // Create a temporary directory if it does not exist or was deleted.
-  if ([_networkDirectoryURL checkResourceIsReachableAndReturnError:&error]) { return YES; }
+  if ([_networkDirectoryURL checkResourceIsReachableAndReturnError:&error]) {
+    return YES;
+  }
 
   if (error && error.code != NSFileReadNoSuchFileError) {
     [_loggerDelegate
@@ -582,7 +600,9 @@
 }
 
 - (void)excludeFromBackupForURL:(NSURL *)url {
-  if (!url.path) { return; }
+  if (!url.path) {
+    return;
+  }
 
   // Set the iCloud exclusion attribute on the Documents URL.
   NSError *preventBackupError = nil;
@@ -613,7 +633,9 @@
   // Do not allow redirection if the response code is in the non-allowed list.
   NSURLRequest *newRequest = request;
 
-  if (response) { newRequest = nil; }
+  if (response) {
+    newRequest = nil;
+  }
 
   completionHandler(newRequest);
 }
@@ -632,7 +654,9 @@
   }
 
   if (handler) {
-    dispatch_async(dispatch_get_main_queue(), ^{ handler(response, data, _sessionID, error); });
+    dispatch_async(dispatch_get_main_queue(), ^{
+      handler(response, data, _sessionID, error);
+    });
   }
 }
 

--- a/Firebase/Core/FIRNetworkURLSession.m
+++ b/Firebase/Core/FIRNetworkURLSession.m
@@ -73,9 +73,7 @@
                             completionHandler:
                                 (FIRNetworkSystemCompletionHandler)systemCompletionHandler {
   // The session may not be FIRAnalytics background. Ignore those that do not have the prefix.
-  if (![sessionID hasPrefix:kFIRNetworkBackgroundSessionConfigIDPrefix]) {
-    return;
-  }
+  if (![sessionID hasPrefix:kFIRNetworkBackgroundSessionConfigIDPrefix]) { return; }
   FIRNetworkURLSession *fetcher = [self fetcherWithSessionIdentifier:sessionID];
   if (fetcher != nil) {
     [fetcher addSystemCompletionHandler:systemCompletionHandler forSession:sessionID];
@@ -418,9 +416,7 @@
   if (handler) {
     [systemCompletionHandlers removeObjectForKey:identifier];
 
-    dispatch_async(dispatch_get_main_queue(), ^{
-      handler();
-    });
+    dispatch_async(dispatch_get_main_queue(), ^{ handler(); });
   }
 }
 
@@ -460,9 +456,7 @@
 }
 
 - (void)maybeRemoveTempFilesAtURL:(NSURL *)folderURL expiringTime:(NSTimeInterval)staleTime {
-  if (!folderURL.absoluteString.length) {
-    return;
-  }
+  if (!folderURL.absoluteString.length) { return; }
 
   NSFileManager *fileManager = [NSFileManager defaultManager];
   NSError *error = nil;
@@ -482,31 +476,23 @@
     return;
   }
 
-  if (!directoryContent.count) {
-    return;
-  }
+  if (!directoryContent.count) { return; }
 
   NSTimeInterval now = [NSDate date].timeIntervalSince1970;
   for (NSURL *tempFile in directoryContent) {
     NSDate *creationDate;
     BOOL getCreationDate =
         [tempFile getResourceValue:&creationDate forKey:NSURLCreationDateKey error:NULL];
-    if (!getCreationDate) {
-      continue;
-    }
+    if (!getCreationDate) { continue; }
     NSTimeInterval creationTimeInterval = creationDate.timeIntervalSince1970;
-    if (fabs(now - creationTimeInterval) > staleTime) {
-      [self removeTempItemAtURL:tempFile];
-    }
+    if (fabs(now - creationTimeInterval) > staleTime) { [self removeTempItemAtURL:tempFile]; }
   }
 }
 
 /// Removes the temporary file written to disk for sending the request. It has to be cleaned up
 /// after the session is done.
 - (void)removeTempItemAtURL:(NSURL *)fileURL {
-  if (!fileURL.absoluteString.length) {
-    return;
-  }
+  if (!fileURL.absoluteString.length) { return; }
 
   NSFileManager *fileManager = [NSFileManager defaultManager];
   NSError *error = nil;
@@ -537,9 +523,8 @@
   static NSMapTable *sessionIDToFetcherMap;
 
   static dispatch_once_t sessionMapOnceToken;
-  dispatch_once(&sessionMapOnceToken, ^{
-    sessionIDToFetcherMap = [NSMapTable strongToWeakObjectsMapTable];
-  });
+  dispatch_once(&sessionMapOnceToken,
+                ^{ sessionIDToFetcherMap = [NSMapTable strongToWeakObjectsMapTable]; });
   return sessionIDToFetcherMap;
 }
 
@@ -549,9 +534,8 @@
   static FIRMutableDictionary *systemCompletionHandlers;
 
   static dispatch_once_t systemCompletionHandlerOnceToken;
-  dispatch_once(&systemCompletionHandlerOnceToken, ^{
-    systemCompletionHandlers = [[FIRMutableDictionary alloc] init];
-  });
+  dispatch_once(&systemCompletionHandlerOnceToken,
+                ^{ systemCompletionHandlers = [[FIRMutableDictionary alloc] init]; });
   return systemCompletionHandlers;
 }
 
@@ -567,9 +551,7 @@
   NSError *error = nil;
 
   // Create a temporary directory if it does not exist or was deleted.
-  if ([_networkDirectoryURL checkResourceIsReachableAndReturnError:&error]) {
-    return YES;
-  }
+  if ([_networkDirectoryURL checkResourceIsReachableAndReturnError:&error]) { return YES; }
 
   if (error && error.code != NSFileReadNoSuchFileError) {
     [_loggerDelegate
@@ -600,9 +582,7 @@
 }
 
 - (void)excludeFromBackupForURL:(NSURL *)url {
-  if (!url.path) {
-    return;
-  }
+  if (!url.path) { return; }
 
   // Set the iCloud exclusion attribute on the Documents URL.
   NSError *preventBackupError = nil;
@@ -633,9 +613,7 @@
   // Do not allow redirection if the response code is in the non-allowed list.
   NSURLRequest *newRequest = request;
 
-  if (response) {
-    newRequest = nil;
-  }
+  if (response) { newRequest = nil; }
 
   completionHandler(newRequest);
 }
@@ -654,9 +632,7 @@
   }
 
   if (handler) {
-    dispatch_async(dispatch_get_main_queue(), ^{
-      handler(response, data, _sessionID, error);
-    });
+    dispatch_async(dispatch_get_main_queue(), ^{ handler(response, data, _sessionID, error); });
   }
 }
 

--- a/Firebase/Core/FIROptions.m
+++ b/Firebase/Core/FIROptions.m
@@ -39,11 +39,10 @@ NSString *const kFIRIsAnalyticsEnabled = @"IS_ANALYTICS_ENABLED";
 NSString *const kFIRIsSignInEnabled = @"IS_SIGNIN_ENABLED";
 
 // Library version ID.
-NSString *const kFIRLibraryVersionID =
-    @"4"     // Major version (one or more digits)
-    @"00"    // Minor version (exactly 2 digits)
-    @"04"    // Build number (exactly 2 digits)
-    @"000";  // Fixed "000"
+NSString *const kFIRLibraryVersionID = @"4"     // Major version (one or more digits)
+                                       @"00"    // Minor version (exactly 2 digits)
+                                       @"04"    // Build number (exactly 2 digits)
+                                       @"000";  // Fixed "000"
 // Plist file name.
 NSString *const kServiceInfoFileName = @"GoogleService-Info";
 // Plist file type.
@@ -90,8 +89,7 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
     return nil;
   }
 
-  sDefaultOptions =
-      [[FIROptions alloc] initInternalWithOptionsDictionary:defaultOptionsDictionary];
+  sDefaultOptions = [[FIROptions alloc] initInternalWithOptionsDictionary:defaultOptionsDictionary];
   return sDefaultOptions;
 }
 
@@ -108,7 +106,8 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
   sDefaultOptionsDictionary = [NSDictionary dictionaryWithContentsOfFile:plistFilePath];
   if (sDefaultOptionsDictionary == nil) {
     FIRLogError(kFIRLoggerCore, @"I-COR000011", @"The configuration file is not a dictionary: "
-                @"'%@.%@'.", kServiceInfoFileName, kServiceInfoFileType);
+                                                @"'%@.%@'.",
+                kServiceInfoFileName, kServiceInfoFileType);
   }
   return sDefaultOptionsDictionary;
 }
@@ -205,7 +204,8 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
     _optionsDictionary = [[NSDictionary dictionaryWithContentsOfFile:plistPath] mutableCopy];
     if (_optionsDictionary == nil) {
       FIRLogError(kFIRLoggerCore, @"I-COR000014", @"The configuration file at %@ does not exist or "
-                  @"is not a well-formed plist file.", plistPath);
+                                                  @"is not a well-formed plist file.",
+                  plistPath);
       return nil;
     }
     // TODO: Do we want to validate the dictionary here? It says we do that already in
@@ -214,8 +214,7 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
   return self;
 }
 
-- (instancetype)initWithGoogleAppID:(NSString *)googleAppID
-                        GCMSenderID:(NSString *)GCMSenderID {
+- (instancetype)initWithGoogleAppID:(NSString *)googleAppID GCMSenderID:(NSString *)GCMSenderID {
   self = [super init];
   if (self) {
     NSMutableDictionary *mutableOptionsDict = [NSMutableDictionary dictionary];
@@ -369,9 +368,10 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
   dispatch_once(&_createAnalyticsOptionsDictionaryOnce, ^{
     NSMutableDictionary *tempAnalyticsOptions = [[NSMutableDictionary alloc] init];
     NSDictionary *mainInfoDictionary = [NSBundle mainBundle].infoDictionary;
-    NSArray *measurementKeys = @[ kFIRIsMeasurementEnabled,
-                                  kFIRIsAnalyticsCollectionEnabled,
-                                  kFIRIsAnalyticsCollectionDeactivated ];
+    NSArray *measurementKeys = @[
+      kFIRIsMeasurementEnabled, kFIRIsAnalyticsCollectionEnabled,
+      kFIRIsAnalyticsCollectionDeactivated
+    ];
     for (NSString *key in measurementKeys) {
       id value = mainInfoDictionary[key] ?: self.optionsDictionary[key] ?: nil;
       if (!value) {

--- a/Firebase/Core/FIROptions.m
+++ b/Firebase/Core/FIROptions.m
@@ -80,10 +80,14 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
 #pragma mark - Public only for internal class methods
 
 + (FIROptions *)defaultOptions {
-  if (sDefaultOptions != nil) { return sDefaultOptions; }
+  if (sDefaultOptions != nil) {
+    return sDefaultOptions;
+  }
 
   NSDictionary *defaultOptionsDictionary = [self defaultOptionsDictionary];
-  if (defaultOptionsDictionary == nil) { return nil; }
+  if (defaultOptionsDictionary == nil) {
+    return nil;
+  }
 
   sDefaultOptions = [[FIROptions alloc] initInternalWithOptionsDictionary:defaultOptionsDictionary];
   return sDefaultOptions;
@@ -92,9 +96,13 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
 #pragma mark - Private class methods
 
 + (NSDictionary *)defaultOptionsDictionary {
-  if (sDefaultOptionsDictionary != nil) { return sDefaultOptionsDictionary; }
+  if (sDefaultOptionsDictionary != nil) {
+    return sDefaultOptionsDictionary;
+  }
   NSString *plistFilePath = [FIROptions plistFilePathWithName:kServiceInfoFileName];
-  if (plistFilePath == nil) { return nil; }
+  if (plistFilePath == nil) {
+    return nil;
+  }
   sDefaultOptionsDictionary = [NSDictionary dictionaryWithContentsOfFile:plistFilePath];
   if (sDefaultOptionsDictionary == nil) {
     FIRLogError(kFIRLoggerCore, @"I-COR000011", @"The configuration file is not a dictionary: "
@@ -166,7 +174,9 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
     }
 
     // `bundleID` is a required property, default to the main `bundleIdentifier` if it's `nil`.
-    if (!bundleID) { bundleID = [[NSBundle mainBundle] bundleIdentifier]; }
+    if (!bundleID) {
+      bundleID = [[NSBundle mainBundle] bundleIdentifier];
+    }
 
     NSMutableDictionary *mutableOptionsDict = [NSMutableDictionary dictionary];
     [mutableOptionsDict setValue:googleAppID forKey:kFIRGoogleAppID];
@@ -364,7 +374,9 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
     ];
     for (NSString *key in measurementKeys) {
       id value = mainInfoDictionary[key] ?: self.optionsDictionary[key] ?: nil;
-      if (!value) { continue; }
+      if (!value) {
+        continue;
+      }
       tempAnalyticsOptions[key] = value;
     }
     _analyticsOptionsDictionary = tempAnalyticsOptions;
@@ -378,7 +390,9 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
  * be supported.
  */
 - (BOOL)isMeasurementEnabled {
-  if (self.isAnalyticsCollectionDeactivated) { return NO; }
+  if (self.isAnalyticsCollectionDeactivated) {
+    return NO;
+  }
   if (!self.analyticsOptionsDictionary[kFIRIsMeasurementEnabled]) {
     return YES;  // Enable Measurement by default when the key is not in the dictionary.
   }
@@ -386,7 +400,9 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
 }
 
 - (BOOL)isAnalyticsCollectionEnabled {
-  if (self.isAnalyticsCollectionDeactivated) { return NO; }
+  if (self.isAnalyticsCollectionDeactivated) {
+    return NO;
+  }
   if (!self.analyticsOptionsDictionary[kFIRIsAnalyticsCollectionEnabled]) {
     return self.isMeasurementEnabled;  // Fall back to older plist flag.
   }

--- a/Firebase/Core/FIROptions.m
+++ b/Firebase/Core/FIROptions.m
@@ -80,14 +80,10 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
 #pragma mark - Public only for internal class methods
 
 + (FIROptions *)defaultOptions {
-  if (sDefaultOptions != nil) {
-    return sDefaultOptions;
-  }
+  if (sDefaultOptions != nil) { return sDefaultOptions; }
 
   NSDictionary *defaultOptionsDictionary = [self defaultOptionsDictionary];
-  if (defaultOptionsDictionary == nil) {
-    return nil;
-  }
+  if (defaultOptionsDictionary == nil) { return nil; }
 
   sDefaultOptions = [[FIROptions alloc] initInternalWithOptionsDictionary:defaultOptionsDictionary];
   return sDefaultOptions;
@@ -96,13 +92,9 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
 #pragma mark - Private class methods
 
 + (NSDictionary *)defaultOptionsDictionary {
-  if (sDefaultOptionsDictionary != nil) {
-    return sDefaultOptionsDictionary;
-  }
+  if (sDefaultOptionsDictionary != nil) { return sDefaultOptionsDictionary; }
   NSString *plistFilePath = [FIROptions plistFilePathWithName:kServiceInfoFileName];
-  if (plistFilePath == nil) {
-    return nil;
-  }
+  if (plistFilePath == nil) { return nil; }
   sDefaultOptionsDictionary = [NSDictionary dictionaryWithContentsOfFile:plistFilePath];
   if (sDefaultOptionsDictionary == nil) {
     FIRLogError(kFIRLoggerCore, @"I-COR000011", @"The configuration file is not a dictionary: "
@@ -174,9 +166,7 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
     }
 
     // `bundleID` is a required property, default to the main `bundleIdentifier` if it's `nil`.
-    if (!bundleID) {
-      bundleID = [[NSBundle mainBundle] bundleIdentifier];
-    }
+    if (!bundleID) { bundleID = [[NSBundle mainBundle] bundleIdentifier]; }
 
     NSMutableDictionary *mutableOptionsDict = [NSMutableDictionary dictionary];
     [mutableOptionsDict setValue:googleAppID forKey:kFIRGoogleAppID];
@@ -374,9 +364,7 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
     ];
     for (NSString *key in measurementKeys) {
       id value = mainInfoDictionary[key] ?: self.optionsDictionary[key] ?: nil;
-      if (!value) {
-        continue;
-      }
+      if (!value) { continue; }
       tempAnalyticsOptions[key] = value;
     }
     _analyticsOptionsDictionary = tempAnalyticsOptions;
@@ -390,9 +378,7 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
  * be supported.
  */
 - (BOOL)isMeasurementEnabled {
-  if (self.isAnalyticsCollectionDeactivated) {
-    return NO;
-  }
+  if (self.isAnalyticsCollectionDeactivated) { return NO; }
   if (!self.analyticsOptionsDictionary[kFIRIsMeasurementEnabled]) {
     return YES;  // Enable Measurement by default when the key is not in the dictionary.
   }
@@ -400,9 +386,7 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
 }
 
 - (BOOL)isAnalyticsCollectionEnabled {
-  if (self.isAnalyticsCollectionDeactivated) {
-    return NO;
-  }
+  if (self.isAnalyticsCollectionDeactivated) { return NO; }
   if (!self.analyticsOptionsDictionary[kFIRIsAnalyticsCollectionEnabled]) {
     return self.isMeasurementEnabled;  // Fall back to older plist flag.
   }

--- a/Firebase/Core/FIRReachabilityChecker.m
+++ b/Firebase/Core/FIRReachabilityChecker.m
@@ -14,15 +14,16 @@
 
 #import <Foundation/Foundation.h>
 
-#import "Private/FIRReachabilityChecker.h"
 #import "Private/FIRReachabilityChecker+Internal.h"
+#import "Private/FIRReachabilityChecker.h"
 
+#import "Private/FIRLogger.h"
 #import "Private/FIRNetwork.h"
 #import "Private/FIRNetworkMessageCode.h"
-#import "Private/FIRLogger.h"
 
 static void ReachabilityCallback(SCNetworkReachabilityRef reachability,
-                                 SCNetworkReachabilityFlags flags, void *info);
+                                 SCNetworkReachabilityFlags flags,
+                                 void *info);
 
 static const struct FIRReachabilityApi kFIRDefaultReachabilityApi = {
     SCNetworkReachabilityCreateWithName,
@@ -78,11 +79,10 @@ static NSString *const kFIRReachabilityDisconnectedStatus = @"Disconnected";
 - (void)setReachabilityDelegate:(id<FIRReachabilityDelegate>)reachabilityDelegate {
   if (reachabilityDelegate &&
       (![(NSObject *)reachabilityDelegate conformsToProtocol:@protocol(FIRReachabilityDelegate)])) {
-    FIRLogError(
-        kFIRLoggerCore,
-        [NSString stringWithFormat:@"I-NET%06ld",
-        (long)kFIRNetworkMessageCodeReachabilityChecker005],
-        @"Reachability delegate doesn't conform to Reachability protocol.");
+    FIRLogError(kFIRLoggerCore,
+                [NSString stringWithFormat:@"I-NET%06ld",
+                                           (long)kFIRNetworkMessageCodeReachabilityChecker005],
+                @"Reachability delegate doesn't conform to Reachability protocol.");
     return;
   }
   reachabilityDelegate_ = reachabilityDelegate;
@@ -91,11 +91,10 @@ static NSString *const kFIRReachabilityDisconnectedStatus = @"Disconnected";
 - (void)setLoggerDelegate:(id<FIRNetworkLoggerDelegate>)loggerDelegate {
   if (loggerDelegate &&
       (![(NSObject *)loggerDelegate conformsToProtocol:@protocol(FIRNetworkLoggerDelegate)])) {
-    FIRLogError(
-        kFIRLoggerCore,
-        [NSString stringWithFormat:@"I-NET%06ld",
-        (long)kFIRNetworkMessageCodeReachabilityChecker006],
-        @"Reachability delegate doesn't conform to Logger protocol.");
+    FIRLogError(kFIRLoggerCore,
+                [NSString stringWithFormat:@"I-NET%06ld",
+                                           (long)kFIRNetworkMessageCodeReachabilityChecker006],
+                @"Reachability delegate doesn't conform to Logger protocol.");
     return;
   }
   loggerDelegate_ = loggerDelegate;
@@ -137,11 +136,11 @@ static NSString *const kFIRReachabilityDisconnectedStatus = @"Disconnected";
       return NO;
     }
     SCNetworkReachabilityContext context = {
-        0, /* version */
+        0,                       /* version */
         (__bridge void *)(self), /* info (passed as last parameter to reachability callback) */
-        NULL, /* retain */
-        NULL, /* release */
-        NULL /* copyDescription */
+        NULL,                    /* retain */
+        NULL,                    /* release */
+        NULL                     /* copyDescription */
     };
     if (!reachabilityApi_->setCallbackFn(reachability_, ReachabilityCallback, &context) ||
         !reachabilityApi_->scheduleWithRunLoopFn(reachability_, CFRunLoopGetMain(),
@@ -176,24 +175,24 @@ static NSString *const kFIRReachabilityDisconnectedStatus = @"Disconnected";
   if (flags & kSCNetworkReachabilityFlagsReachable) {
     // Reachable flag is set. Check further flags.
     if (!(flags & kSCNetworkReachabilityFlagsConnectionRequired)) {
-      // Connection required flag is not set, so we have connectivity.
-      #if TARGET_OS_IOS
+// Connection required flag is not set, so we have connectivity.
+#if TARGET_OS_IOS
       status = (flags & kSCNetworkReachabilityFlagsIsWWAN) ? kFIRReachabilityViaCellular
                                                            : kFIRReachabilityViaWifi;
-      #elif TARGET_OS_OSX
+#elif TARGET_OS_OSX
       status = kFIRReachabilityViaWifi;
-      #endif
+#endif
     } else if ((flags & (kSCNetworkReachabilityFlagsConnectionOnDemand |
                          kSCNetworkReachabilityFlagsConnectionOnTraffic)) &&
                !(flags & kSCNetworkReachabilityFlagsInterventionRequired)) {
-      // If the connection on demand or connection on traffic flag is set, and user intervention
-      // is not required, we have connectivity.
-      #if TARGET_OS_IOS
+// If the connection on demand or connection on traffic flag is set, and user intervention
+// is not required, we have connectivity.
+#if TARGET_OS_IOS
       status = (flags & kSCNetworkReachabilityFlagsIsWWAN) ? kFIRReachabilityViaCellular
                                                            : kFIRReachabilityViaWifi;
-      #elif TARGET_OS_OSX
+#elif TARGET_OS_OSX
       status = kFIRReachabilityViaWifi;
-      #endif
+#endif
     }
   }
   return status;
@@ -222,7 +221,8 @@ static NSString *const kFIRReachabilityDisconnectedStatus = @"Disconnected";
 @end
 
 static void ReachabilityCallback(SCNetworkReachabilityRef reachability,
-                                 SCNetworkReachabilityFlags flags, void *info) {
+                                 SCNetworkReachabilityFlags flags,
+                                 void *info) {
   FIRReachabilityChecker *checker = (__bridge FIRReachabilityChecker *)info;
   [checker reachabilityFlagsChanged:flags];
 }

--- a/Firebase/Core/FIRReachabilityChecker.m
+++ b/Firebase/Core/FIRReachabilityChecker.m
@@ -132,7 +132,9 @@ static NSString *const kFIRReachabilityDisconnectedStatus = @"Disconnected";
 - (BOOL)start {
   if (!reachability_) {
     reachability_ = reachabilityApi_->createWithNameFn(kCFAllocatorDefault, [host_ UTF8String]);
-    if (!reachability_) { return NO; }
+    if (!reachability_) {
+      return NO;
+    }
     SCNetworkReachabilityContext context = {
         0,                       /* version */
         (__bridge void *)(self), /* info (passed as last parameter to reachability callback) */

--- a/Firebase/Core/FIRReachabilityChecker.m
+++ b/Firebase/Core/FIRReachabilityChecker.m
@@ -132,9 +132,7 @@ static NSString *const kFIRReachabilityDisconnectedStatus = @"Disconnected";
 - (BOOL)start {
   if (!reachability_) {
     reachability_ = reachabilityApi_->createWithNameFn(kCFAllocatorDefault, [host_ UTF8String]);
-    if (!reachability_) {
-      return NO;
-    }
+    if (!reachability_) { return NO; }
     SCNetworkReachabilityContext context = {
         0,                       /* version */
         (__bridge void *)(self), /* info (passed as last parameter to reachability callback) */

--- a/Firebase/Core/FIRURLSchemeUtil.m
+++ b/Firebase/Core/FIRURLSchemeUtil.m
@@ -19,7 +19,7 @@
  * Regular expression to match the URL scheme for Google sign-in.
  */
 static NSString *const kFIRGoogleSignInURLSchemePattern =
-@"^com\\.googleusercontent\\.apps\\.\\d+-\\w+$";
+    @"^com\\.googleusercontent\\.apps\\.\\d+-\\w+$";
 
 BOOL fir_areURLSchemesValidForGoogleSignIn(NSArray *urlSchemes) {
   BOOL hasReversedClientID = NO;
@@ -37,7 +37,7 @@ BOOL fir_areURLSchemesValidForGoogleSignIn(NSArray *urlSchemes) {
   }
   if (!hasReversedClientID) {
     FIRLogInfo(kFIRLoggerCore, @"I-COR000021", @"A reversed client ID should be added as a URL "
-              @"scheme to enable Google sign-in.");
+                                               @"scheme to enable Google sign-in.");
   }
   return NO;
 }

--- a/Firebase/Core/FIRURLSchemeUtil.m
+++ b/Firebase/Core/FIRURLSchemeUtil.m
@@ -27,10 +27,14 @@ BOOL fir_areURLSchemesValidForGoogleSignIn(NSArray *urlSchemes) {
     if (!hasReversedClientID) {
       NSRange range = [urlScheme rangeOfString:kFIRGoogleSignInURLSchemePattern
                                        options:NSRegularExpressionSearch];
-      if (range.location != NSNotFound) { hasReversedClientID = YES; }
+      if (range.location != NSNotFound) {
+        hasReversedClientID = YES;
+      }
     }
   }
-  if (hasReversedClientID) { return YES; }
+  if (hasReversedClientID) {
+    return YES;
+  }
   if (!hasReversedClientID) {
     FIRLogInfo(kFIRLoggerCore, @"I-COR000021", @"A reversed client ID should be added as a URL "
                                                @"scheme to enable Google sign-in.");

--- a/Firebase/Core/FIRURLSchemeUtil.m
+++ b/Firebase/Core/FIRURLSchemeUtil.m
@@ -27,14 +27,10 @@ BOOL fir_areURLSchemesValidForGoogleSignIn(NSArray *urlSchemes) {
     if (!hasReversedClientID) {
       NSRange range = [urlScheme rangeOfString:kFIRGoogleSignInURLSchemePattern
                                        options:NSRegularExpressionSearch];
-      if (range.location != NSNotFound) {
-        hasReversedClientID = YES;
-      }
+      if (range.location != NSNotFound) { hasReversedClientID = YES; }
     }
   }
-  if (hasReversedClientID) {
-    return YES;
-  }
+  if (hasReversedClientID) { return YES; }
   if (!hasReversedClientID) {
     FIRLogInfo(kFIRLoggerCore, @"I-COR000021", @"A reversed client ID should be added as a URL "
                                                @"scheme to enable Google sign-in.");

--- a/Firebase/Core/Private/FIRAppAssociationRegistration.h
+++ b/Firebase/Core/Private/FIRAppAssociationRegistration.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
         registered for any given host/key pair, and the object shall be created on-the-fly when
         asked for.
  */
-@interface FIRAppAssociationRegistration<ObjectType> : NSObject
+@interface FIRAppAssociationRegistration <ObjectType> : NSObject
 
 /** @fn registeredObjectWithHost:key:creationBlock:
     @brief Retrieves the registered object with a particular host and key.

--- a/Firebase/Core/Private/FIRNetworkLoggerProtocol.h
+++ b/Firebase/Core/Private/FIRNetworkLoggerProtocol.h
@@ -16,8 +16,8 @@
 
 @import Foundation;
 
-#import "FIRNetworkMessageCode.h"
 #import "FIRLoggerLevel.h"
+#import "FIRNetworkMessageCode.h"
 
 /// The log levels used by FIRNetworkLogger.
 typedef NS_ENUM(NSInteger, FIRNetworkLogLevel) {
@@ -27,7 +27,7 @@ typedef NS_ENUM(NSInteger, FIRNetworkLogLevel) {
   kFIRNetworkLogLevelDebug = FIRLoggerLevelDebug,
 };
 
-@protocol FIRNetworkLoggerDelegate<NSObject>
+@protocol FIRNetworkLoggerDelegate <NSObject>
 
 @required
 /// Tells the delegate to log a message with an array of contexts and the log level.

--- a/Firebase/Core/Private/FIRNetworkURLSession.h
+++ b/Firebase/Core/Private/FIRNetworkURLSession.h
@@ -18,15 +18,18 @@
 
 #import "FIRNetworkLoggerProtocol.h"
 
-typedef void (^FIRNetworkCompletionHandler)(NSHTTPURLResponse *response, NSData *data,
+typedef void (^FIRNetworkCompletionHandler)(NSHTTPURLResponse *response,
+                                            NSData *data,
                                             NSError *error);
-typedef void (^FIRNetworkURLSessionCompletionHandler)(NSHTTPURLResponse *response, NSData *data,
-                                                      NSString *sessionID, NSError *error);
+typedef void (^FIRNetworkURLSessionCompletionHandler)(NSHTTPURLResponse *response,
+                                                      NSData *data,
+                                                      NSString *sessionID,
+                                                      NSError *error);
 typedef void (^FIRNetworkSystemCompletionHandler)(void);
 
 /// The protocol that uses NSURLSession for iOS >= 7.0 to handle requests and responses.
 @interface FIRNetworkURLSession
-    : NSObject<NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDownloadDelegate>
+    : NSObject <NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDownloadDelegate>
 
 /// Indicates whether the background network is enabled. Default value is NO.
 @property(nonatomic, getter=isBackgroundNetworkEnabled) BOOL backgroundNetworkEnabled;

--- a/Firebase/Core/Private/FIRReachabilityChecker.h
+++ b/Firebase/Core/Private/FIRReachabilityChecker.h
@@ -21,8 +21,8 @@
 typedef enum {
   kFIRReachabilityUnknown,  ///< Have not yet checked or been notified whether host is reachable.
   kFIRReachabilityNotReachable,  ///< Host is not reachable.
-  kFIRReachabilityViaWifi,  ///< Host is reachable via Wifi.
-  kFIRReachabilityViaCellular,  ///< Host is reachable via cellular.
+  kFIRReachabilityViaWifi,       ///< Host is reachable via Wifi.
+  kFIRReachabilityViaCellular,   ///< Host is reachable via cellular.
 } FIRReachabilityStatus;
 
 const NSString *FIRReachabilityStatusString(FIRReachabilityStatus status);

--- a/Firebase/Core/Public/FIRApp.h
+++ b/Firebase/Core/Public/FIRApp.h
@@ -75,8 +75,8 @@ FIR_SWIFT_NAME(FirebaseApp)
                Letters, Numbers and Underscore.
  * @param options The Firebase application options used to configure the services.
  */
-+ (void)configureWithName:(NSString *)name options:(FIROptions *)options
-    FIR_SWIFT_NAME(configure(name:options:));
++ (void)configureWithName:(NSString *)name
+                  options:(FIROptions *)options FIR_SWIFT_NAME(configure(name:options:));
 
 /**
  * Returns the default app, or nil if the default app does not exist.
@@ -94,13 +94,13 @@ FIR_SWIFT_NAME(FirebaseApp)
  * Returns the set of all extant FIRApp instances, or nil if there are no FIRApp instances. This
  * method is thread safe.
  */
-@property(class, readonly, nullable) NSDictionary <NSString *, FIRApp *> *allApps;
+@property(class, readonly, nullable) NSDictionary<NSString *, FIRApp *> *allApps;
 #else
 /**
  * Returns the set of all extant FIRApp instances, or nil if there are no FIRApp instances. This
  * method is thread safe.
  */
-+ (nullable NSDictionary <NSString *, FIRApp *> *)allApps FIR_SWIFT_NAME(allApps());
++ (nullable NSDictionary<NSString *, FIRApp *> *)allApps FIR_SWIFT_NAME(allApps());
 #endif  // defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 
 /**

--- a/Firebase/Core/Public/FIRConfiguration.h
+++ b/Firebase/Core/Public/FIRConfiguration.h
@@ -48,7 +48,6 @@ NS_ASSUME_NONNULL_BEGIN
 FIR_SWIFT_NAME(FirebaseConfiguration)
 @interface FIRConfiguration : NSObject
 
-
 #if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 /** Returns the shared configuration object. */
 @property(class, nonatomic, readonly) FIRConfiguration *sharedInstance FIR_SWIFT_NAME(shared);

--- a/Firebase/Core/Public/FIRCoreSwiftNameSupport.h
+++ b/Firebase/Core/Public/FIRCoreSwiftNameSupport.h
@@ -24,6 +24,6 @@
 #define FIR_SWIFT_NAME(X) NS_SWIFT_NAME(X)
 #else
 #define FIR_SWIFT_NAME(X)  // Intentionally blank.
-#endif  // #ifdef __IPHONE_9_3
+#endif                     // #ifdef __IPHONE_9_3
 
 #endif  // FIR_SWIFT_NAME

--- a/Firebase/Core/Public/FIROptions.h
+++ b/Firebase/Core/Public/FIROptions.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
  * This class provides constant fields of Google APIs.
  */
 FIR_SWIFT_NAME(FirebaseOptions)
-@interface FIROptions : NSObject<NSCopying>
+@interface FIROptions : NSObject <NSCopying>
 
 /**
  * Returns the default options.
@@ -105,9 +105,10 @@ FIR_SWIFT_NAME(FirebaseOptions)
                         databaseURL:(NSString *)databaseURL
                       storageBucket:(NSString *)storageBucket
                   deepLinkURLScheme:(NSString *)deepLinkURLScheme
-    DEPRECATED_MSG_ATTRIBUTE("Use `-[[FIROptions alloc] initWithGoogleAppID:GCMSenderID:]` "
-                             "(`FirebaseOptions(googleAppID:gcmSenderID:)` in Swift)` and property "
-                             "setters instead.");
+    DEPRECATED_MSG_ATTRIBUTE(
+        "Use `-[[FIROptions alloc] initWithGoogleAppID:GCMSenderID:]` "
+        "(`FirebaseOptions(googleAppID:gcmSenderID:)` in Swift)` and property "
+        "setters instead.");
 
 /**
  * Initializes a customized instance of FIROptions from the file at the given plist file path.

--- a/Firebase/Database/.clang-format
+++ b/Firebase/Database/.clang-format
@@ -1,0 +1,1 @@
+IndentWidth: 4

--- a/Firebase/Firebase/FirebaseCommunity.h
+++ b/Firebase/Firebase/FirebaseCommunity.h
@@ -15,55 +15,56 @@
  */
 
 #if !defined(__has_include)
-  #error "Firebase.h won't import anything if your compiler doesn't support __has_include. Please \
+#error \
+    "Firebase.h won't import anything if your compiler doesn't support __has_include. Please \
           import the headers individually."
 #else
-  #if __has_include(<FirebaseCommunity/FirebaseCore.h>)
-    #import <FirebaseCommunity/FirebaseCore.h>
-  #endif
+#if __has_include(<FirebaseCommunity / FirebaseCore.h>)
+#import <FirebaseCommunity/FirebaseCore.h>
+#endif
 
-  #if __has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
-    #import <FirebaseAnalytics/FirebaseAnalytics.h>
-  #endif
+#if __has_include(<FirebaseAnalytics / FirebaseAnalytics.h>)
+#import <FirebaseAnalytics/FirebaseAnalytics.h>
+#endif
 
-  #if __has_include(<FirebaseCommunity/FirebaseAuth.h>)
-    #import <FirebaseCommunity/FirebaseAuth.h>
-  #endif
+#if __has_include(<FirebaseCommunity / FirebaseAuth.h>)
+#import <FirebaseCommunity/FirebaseAuth.h>
+#endif
 
-  #if __has_include(<FirebaseCrash/FirebaseCrash.h>)
-    #import <FirebaseCrash/FirebaseCrash.h>
-  #endif
+#if __has_include(<FirebaseCrash / FirebaseCrash.h>)
+#import <FirebaseCrash/FirebaseCrash.h>
+#endif
 
-  #if __has_include(<FirebaseCommunity/FirebaseDatabase.h>)
-    #import <FirebaseCommunity/FirebaseDatabase.h>
-  #endif
+#if __has_include(<FirebaseCommunity / FirebaseDatabase.h>)
+#import <FirebaseCommunity/FirebaseDatabase.h>
+#endif
 
-  #if __has_include(<FirebaseDynamicLinks/FirebaseDynamicLinks.h>)
-    #import <FirebaseDynamicLinks/FirebaseDynamicLinks.h>
-  #endif
+#if __has_include(<FirebaseDynamicLinks / FirebaseDynamicLinks.h>)
+#import <FirebaseDynamicLinks/FirebaseDynamicLinks.h>
+#endif
 
-  #if __has_include(<Firebase/FirebaseInstanceID.h>)
-    #import <Firebase/FirebaseInstanceID.h>
-  #endif
+#if __has_include(<Firebase / FirebaseInstanceID.h>)
+#import <Firebase/FirebaseInstanceID.h>
+#endif
 
-  #if __has_include(<FirebaseInvites/FirebaseInvites.h>)
-    #import <FirebaseInvites/FirebaseInvites.h>
-  #endif
+#if __has_include(<FirebaseInvites / FirebaseInvites.h>)
+#import <FirebaseInvites/FirebaseInvites.h>
+#endif
 
-  #if __has_include(<FirebaseCommunity/FirebaseMessaging.h>)
-    #import <FirebaseCommunity/FirebaseMessaging.h>
-  #endif
+#if __has_include(<FirebaseCommunity / FirebaseMessaging.h>)
+#import <FirebaseCommunity/FirebaseMessaging.h>
+#endif
 
-  #if __has_include(<FirebaseRemoteConfig/FirebaseRemoteConfig.h>)
-    #import <FirebaseRemoteConfig/FirebaseRemoteConfig.h>
-  #endif
+#if __has_include(<FirebaseRemoteConfig / FirebaseRemoteConfig.h>)
+#import <FirebaseRemoteConfig/FirebaseRemoteConfig.h>
+#endif
 
-  #if __has_include(<FirebaseCommunity/FirebaseStorage.h>)
-    #import <FirebaseCommunity/FirebaseStorage.h>
-  #endif
+#if __has_include(<FirebaseCommunity / FirebaseStorage.h>)
+#import <FirebaseCommunity/FirebaseStorage.h>
+#endif
 
-  #if __has_include(<GoogleMobileAds/GoogleMobileAds.h>)
-    #import <GoogleMobileAds/GoogleMobileAds.h>
-  #endif
+#if __has_include(<GoogleMobileAds / GoogleMobileAds.h>)
+#import <GoogleMobileAds/GoogleMobileAds.h>
+#endif
 
 #endif  // defined(__has_include)

--- a/Firebase/Firebase/FirebaseCommunity.h
+++ b/Firebase/Firebase/FirebaseCommunity.h
@@ -15,56 +15,55 @@
  */
 
 #if !defined(__has_include)
-#error \
-    "Firebase.h won't import anything if your compiler doesn't support __has_include. Please \
+  #error "Firebase.h won't import anything if your compiler doesn't support __has_include. Please \
           import the headers individually."
 #else
-#if __has_include(<FirebaseCommunity / FirebaseCore.h>)
-#import <FirebaseCommunity/FirebaseCore.h>
-#endif
+  #if __has_include(<FirebaseCommunity/FirebaseCore.h>)
+    #import <FirebaseCommunity/FirebaseCore.h>
+  #endif
 
-#if __has_include(<FirebaseAnalytics / FirebaseAnalytics.h>)
-#import <FirebaseAnalytics/FirebaseAnalytics.h>
-#endif
+  #if __has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
+    #import <FirebaseAnalytics/FirebaseAnalytics.h>
+  #endif
 
-#if __has_include(<FirebaseCommunity / FirebaseAuth.h>)
-#import <FirebaseCommunity/FirebaseAuth.h>
-#endif
+  #if __has_include(<FirebaseCommunity/FirebaseAuth.h>)
+    #import <FirebaseCommunity/FirebaseAuth.h>
+  #endif
 
-#if __has_include(<FirebaseCrash / FirebaseCrash.h>)
-#import <FirebaseCrash/FirebaseCrash.h>
-#endif
+  #if __has_include(<FirebaseCrash/FirebaseCrash.h>)
+    #import <FirebaseCrash/FirebaseCrash.h>
+  #endif
 
-#if __has_include(<FirebaseCommunity / FirebaseDatabase.h>)
-#import <FirebaseCommunity/FirebaseDatabase.h>
-#endif
+  #if __has_include(<FirebaseCommunity/FirebaseDatabase.h>)
+    #import <FirebaseCommunity/FirebaseDatabase.h>
+  #endif
 
-#if __has_include(<FirebaseDynamicLinks / FirebaseDynamicLinks.h>)
-#import <FirebaseDynamicLinks/FirebaseDynamicLinks.h>
-#endif
+  #if __has_include(<FirebaseDynamicLinks/FirebaseDynamicLinks.h>)
+    #import <FirebaseDynamicLinks/FirebaseDynamicLinks.h>
+  #endif
 
-#if __has_include(<Firebase / FirebaseInstanceID.h>)
-#import <Firebase/FirebaseInstanceID.h>
-#endif
+  #if __has_include(<Firebase/FirebaseInstanceID.h>)
+    #import <Firebase/FirebaseInstanceID.h>
+  #endif
 
-#if __has_include(<FirebaseInvites / FirebaseInvites.h>)
-#import <FirebaseInvites/FirebaseInvites.h>
-#endif
+  #if __has_include(<FirebaseInvites/FirebaseInvites.h>)
+    #import <FirebaseInvites/FirebaseInvites.h>
+  #endif
 
-#if __has_include(<FirebaseCommunity / FirebaseMessaging.h>)
-#import <FirebaseCommunity/FirebaseMessaging.h>
-#endif
+  #if __has_include(<FirebaseCommunity/FirebaseMessaging.h>)
+    #import <FirebaseCommunity/FirebaseMessaging.h>
+  #endif
 
-#if __has_include(<FirebaseRemoteConfig / FirebaseRemoteConfig.h>)
-#import <FirebaseRemoteConfig/FirebaseRemoteConfig.h>
-#endif
+  #if __has_include(<FirebaseRemoteConfig/FirebaseRemoteConfig.h>)
+    #import <FirebaseRemoteConfig/FirebaseRemoteConfig.h>
+  #endif
 
-#if __has_include(<FirebaseCommunity / FirebaseStorage.h>)
-#import <FirebaseCommunity/FirebaseStorage.h>
-#endif
+  #if __has_include(<FirebaseCommunity/FirebaseStorage.h>)
+    #import <FirebaseCommunity/FirebaseStorage.h>
+  #endif
 
-#if __has_include(<GoogleMobileAds / GoogleMobileAds.h>)
-#import <GoogleMobileAds/GoogleMobileAds.h>
-#endif
+  #if __has_include(<GoogleMobileAds/GoogleMobileAds.h>)
+    #import <GoogleMobileAds/GoogleMobileAds.h>
+  #endif
 
 #endif  // defined(__has_include)

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+find ./Firebase \
+    -name 'third_party' -prune -o \
+    -name '*.[mh]' \
+    -not -name '*.pbobjc.*' \
+    -exec clang-format -style=file -i '{}' \;

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -7,6 +7,7 @@ find . \
     -name 'FirebaseCommunity.h' -prune -o \
     -name 'Messaging' -prune -o \
     -name 'Storage' -prune -o \
+    -name 'Pods' -prune -o \
     -name '*.[mh]' \
     -not -name '*.pbobjc.*' \
-    -exec clang-format -style=file -i '{}' \;
+    -print0 | xargs -0 clang-format -style=file -i \

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -1,14 +1,11 @@
 #!/bin/bash
-find ./Firebase \
+find . \
     -name 'third_party' -prune -o \
-    -name 'Firebase/Auth' -prune -o \
-    -name 'Example/Auth' -prune -o \
-    -name 'Firebase/Database' -prune -o \
-    -name 'Example/Database' -prune -o \
-    -name 'Firebase/Messaging' -prune -o \
-    -name 'Example/Messaging' -prune -o \
-    -name 'Firebase/Storage' -prune -o \
-    -name 'Example/Storage' -prune -o \
+    -name 'Auth' -prune -o \
+    -name 'AuthSamples' -prune -o \
+    -name 'Database' -prune -o \
+    -name 'Messaging' -prune -o \
+    -name 'Storage' -prune -o \
     -name '*.[mh]' \
     -not -name '*.pbobjc.*' \
     -exec clang-format -style=file -i '{}' \;

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 find ./Firebase \
     -name 'third_party' -prune -o \
+    -name 'Firebase/Auth' -prune -o \
+    -name 'Example/Auth' -prune -o \
+    -name 'Firebase/Database' -prune -o \
+    -name 'Example/Database' -prune -o \
+    -name 'Firebase/Messaging' -prune -o \
+    -name 'Example/Messaging' -prune -o \
+    -name 'Firebase/Storage' -prune -o \
+    -name 'Example/Storage' -prune -o \
     -name '*.[mh]' \
     -not -name '*.pbobjc.*' \
     -exec clang-format -style=file -i '{}' \;

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -4,6 +4,7 @@ find . \
     -name 'Auth' -prune -o \
     -name 'AuthSamples' -prune -o \
     -name 'Database' -prune -o \
+    -name 'Firebase' -prune -o \
     -name 'Messaging' -prune -o \
     -name 'Storage' -prune -o \
     -name '*.[mh]' \

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -10,4 +10,4 @@ find . \
     -name 'Pods' -prune -o \
     -name '*.[mh]' \
     -not -name '*.pbobjc.*' \
-    -print0 | xargs -0 clang-format -style=file -i \
+    -print0 | xargs -0 clang-format -style=file -i

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -4,7 +4,7 @@ find . \
     -name 'Auth' -prune -o \
     -name 'AuthSamples' -prune -o \
     -name 'Database' -prune -o \
-    -name 'Firebase' -prune -o \
+    -name 'FirebaseCommunity.h' -prune -o \
     -name 'Messaging' -prune -o \
     -name 'Storage' -prune -o \
     -name '*.[mh]' \


### PR DESCRIPTION
- Add .clang-format options files (thanks to @bklimt)
- Add scripts/style.sh to stylize the repo
  - Everything except Core is currently disabled
  - Other components can comment out to stylize their source

TBD: whether we want to continually check whole repo by running script on every commit or incrementally run git-clang-format on just the changes in each commit. Need to add CI to fully address #103.

cc: @bklimt @wilhuff 