### PR TITLE
Disable another test that depended on broken pre-iOS 11 small doubles

### DIFF
--- a/Example/Database/Tests/Unit/FLevelDBStorageEngineTests.m
+++ b/Example/Database/Tests/Unit/FLevelDBStorageEngineTests.m
@@ -468,6 +468,12 @@
 }
 
 - (void)testExtremeDoublesAsUserWrites {
+#ifdef TARGET_OS_IOS
+    if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion == 11) {
+        // NSJSONSerialization on iOS 11 correctly serializes small and large doubles.
+        return;
+    }
+#endif
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     id<FNode> tinyDouble = NODE(@(2.225073858507201e-308));
 


### PR DESCRIPTION
Another test started failing in Xcode 9 beta 4. Please confirm that it's the same situation as the last bug you fixed.