### PR TITLE
Purge persistence cache if we can't load from it

### DIFF
--- a/Example/Database/Tests/Unit/FLevelDBStorageEngineTests.m
+++ b/Example/Database/Tests/Unit/FLevelDBStorageEngineTests.m
@@ -70,6 +70,16 @@
 #define MERGE_RECORD(__path, __merge, __writeId) \
     ([[FWriteRecord alloc] initWithPath:[FPath pathWithString:__path] merge:__merge writeId:__writeId])
 
+- (void)testRecocversFromBadCache {
+    NSString *dbPath = @"corrupted-db";
+    NSString *serverData = [[FLevelDBStorageEngine firebaseDir] stringByAppendingPathComponent:@"corrupted-db/server_data/CURRENT"];
+    [@"Corrupted" writeToFile:serverData atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    NSString *userData = [[FLevelDBStorageEngine firebaseDir] stringByAppendingPathComponent:@"corrupted-db/writes/CURRENT"];
+    [@"Corrupted" writeToFile:userData atomically:YES encoding:NSUTF8StringEncoding error:nil];
+    FLevelDBStorageEngine *db = [[FLevelDBStorageEngine alloc] initWithPath:dbPath];
+    XCTAssertNotNil(db);
+}
+
 - (void)testUserWriteIsPersisted {
     FLevelDBStorageEngine *engine = [self cleanStorageEngine];
     [engine saveUserOverwrite:SAMPLE_NODE atPath:[FPath pathWithString:@"foo/bar"] writeId:1];

--- a/Firebase/Database/Persistence/FLevelDBStorageEngine.h
+++ b/Firebase/Database/Persistence/FLevelDBStorageEngine.h
@@ -29,6 +29,8 @@
 
 @interface FLevelDBStorageEngine : NSObject<FStorageEngine>
 
++ (NSString *) firebaseDir;
+
 - (id)initWithPath:(NSString *)path;
 
 - (void)runLegacyMigration:(FRepoInfo *)info;

--- a/Firebase/Database/Persistence/FLevelDBStorageEngine.m
+++ b/Firebase/Database/Persistence/FLevelDBStorageEngine.m
@@ -188,7 +188,6 @@ static NSString* trackedQueryKeysKey(NSUInteger trackedQueryId, NSString *key) {
     if (!success) {
         [NSException raise:NSInternalInconsistencyException format:@"Failed to delete database files: %@", error];
     }
-
 }
 
 - (void)purgeEverything {
@@ -228,7 +227,7 @@ static NSString* trackedQueryKeysKey(NSUInteger trackedQueryId, NSString *key) {
 
     if (err) {
         FFWarn(@"I-RDB076017", @"Failed to read database persistence file '%@': %@",
-               dbName, [err description]);
+               dbName, [err localizedDescription]);
         err = nil;
 
         [self purgeDatabase:dbName];

--- a/Firebase/Database/Persistence/FLevelDBStorageEngine.m
+++ b/Firebase/Database/Persistence/FLevelDBStorageEngine.m
@@ -180,17 +180,22 @@ static NSString* trackedQueryKeysKey(NSUInteger trackedQueryId, NSString *key) {
     self.writesDB = [self createDB:kFWritesDBPath];
 }
 
+- (void)purgeDatabase:(NSString*) dbPath {
+    NSString *path = [self.basePath stringByAppendingPathComponent:dbPath];
+    NSError *error;
+    FFDebug(@"I-RDB076009", @"Deleting database at path %@", path);
+    BOOL success = [[NSFileManager defaultManager] removeItemAtPath:path error:&error];
+    if (!success) {
+        [NSException raise:NSInternalInconsistencyException format:@"Failed to delete database files: %@", error];
+    }
+
+}
+
 - (void)purgeEverything {
     [self close];
     [@[kFServerDBPath, kFWritesDBPath]
      enumerateObjectsUsingBlock:^(NSString *dbPath, NSUInteger idx, BOOL *stop) {
-         NSString *path = [self.basePath stringByAppendingPathComponent:dbPath];
-         NSError *error;
-         FFDebug(@"I-RDB076009", @"Deleting database at path %@", path);
-         BOOL success = [[NSFileManager defaultManager] removeItemAtPath:path error:&error];
-         if (!success) {
-             [NSException raise:NSInternalInconsistencyException format:@"Failed to delete database files: %@", error];
-         }
+         [self purgeDatabase:dbPath];
     }];
 
     [self openDatabases];
@@ -216,14 +221,25 @@ static NSString* trackedQueryKeysKey(NSUInteger trackedQueryId, NSString *key) {
     #endif
 }
 
-- (APLevelDB *)createDB:(NSString *)name {
+- (APLevelDB *)createDB:(NSString *)dbName {
     NSError *err = nil;
-    NSString *path = [self.basePath stringByAppendingPathComponent:name];
+    NSString *path = [self.basePath stringByAppendingPathComponent:dbName];
     APLevelDB *db = [APLevelDB levelDBWithPath:path error:&err];
-    if(err) {
-        NSString *reason = [NSString stringWithFormat:@"Error initializing persistence: %@", [err description]];
-        @throw [NSException exceptionWithName:@"FirebaseDatabasePersistenceFailure" reason:reason userInfo:nil];
+
+    if (err) {
+        FFWarn(@"I-RDB076017", @"Failed to read database persistence file '%@': %@",
+               dbName, [err description]);
+        err = nil;
+
+        [self purgeDatabase:dbName];
+        db = [APLevelDB levelDBWithPath:path error:&err];
+
+        if (err) {
+            NSString *reason = [NSString stringWithFormat:@"Error initializing persistence: %@", [err description]];
+            @throw [NSException exceptionWithName:@"FirebaseDatabasePersistenceFailure" reason:reason userInfo:nil];
+        }
     }
+
     return db;
 }
 

--- a/Firebase/Database/Persistence/FLevelDBStorageEngine.m
+++ b/Firebase/Database/Persistence/FLevelDBStorageEngine.m
@@ -183,7 +183,7 @@ static NSString* trackedQueryKeysKey(NSUInteger trackedQueryId, NSString *key) {
 - (void)purgeDatabase:(NSString*) dbPath {
     NSString *path = [self.basePath stringByAppendingPathComponent:dbPath];
     NSError *error;
-    FFDebug(@"I-RDB076009", @"Deleting database at path %@", path);
+    FFWarn(@"I-RDB076009", @"Deleting database at path %@", path);
     BOOL success = [[NSFileManager defaultManager] removeItemAtPath:path error:&error];
     if (!success) {
         [NSException raise:NSInternalInconsistencyException format:@"Failed to delete database files: %@", error];
@@ -226,10 +226,11 @@ static NSString* trackedQueryKeysKey(NSUInteger trackedQueryId, NSString *key) {
     APLevelDB *db = [APLevelDB levelDBWithPath:path error:&err];
 
     if (err) {
-        FFWarn(@"I-RDB076017", @"Failed to read database persistence file '%@': %@",
+        FFWarn(@"I-RDB076036", @"Failed to read database persistence file '%@': %@",
                dbName, [err localizedDescription]);
         err = nil;
 
+        // Delete the database and try again.
         [self purgeDatabase:dbName];
         db = [APLevelDB levelDBWithPath:path error:&err];
 


### PR DESCRIPTION
We currently fail the RTDB startup if the level DB cache is corrupted (https://github.com/firebase/firebase-ios-sdk/issues/144)

Since this is just a cache file, this PR introduces code that tries to deletes the invalid cache in order to recover. 

I have also tested this manually by corrupting the cache in the Simulator.