### PR TITLE
Configure Messaging for default FIRApp only.

### DIFF
--- a/Firebase/Messaging/FIRMMessageCode.h
+++ b/Firebase/Messaging/FIRMMessageCode.h
@@ -19,6 +19,7 @@
 typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   // FIRMessaging+FIRApp.m
   kFIRMessagingMessageCodeFIRApp000 = 1000,  // I-FCM001000
+  kFIRMessagingMessageCodeFIRApp001 = 1001,  // I-FCM001001
   // FIRMessaging.m
   kFIRMessagingMessageCodeMessaging000 = 2000,  // I-FCM002000
   kFIRMessagingMessageCodeMessaging001 = 2001,  // I-FCM002001

--- a/Firebase/Messaging/FIRMessaging+FIRApp.m
+++ b/Firebase/Messaging/FIRMessaging+FIRApp.m
@@ -44,6 +44,14 @@
 
 + (void)didReceiveConfigureSDKNotification:(NSNotification *)notification {
   NSDictionary *appInfoDict = notification.userInfo;
+  NSNumber *isDefaultApp = appInfoDict[kFIRAppIsDefaultAppKey];
+  if (![isDefaultApp boolValue]) {
+    // Only configure for the default FIRApp.
+    FIRMessagingLoggerDebug(kFIRMessagingMessageCodeFIRApp001,
+                            @"Firebase Messaging only works with the default app.");
+    return;
+  }
+
   NSString *appName = appInfoDict[kFIRAppNameKey];
   FIRApp *app = [FIRApp appNamed:appName];
   [[FIRMessaging messaging] configureMessaging:app];


### PR DESCRIPTION
Currently Messaging will use the most recent FIRApp configured which
isn't obvious. This will limit it to only the default FIRApp.