### PR TITLE
Move Auth notification constant into Core.

### DIFF
--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -1035,6 +1035,9 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
     [self scheduleAutoTokenRefresh];
   }
   NSMutableDictionary *internalNotificationParameters = [NSMutableDictionary dictionary];
+  if (self.app) {
+    internalNotificationParameters[FIRAuthStateDidChangeInternalNotificationAppKey] = self.app;
+  }
   if (token.length) {
     internalNotificationParameters[FIRAuthStateDidChangeInternalNotificationTokenKey] = token;
   }

--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -68,11 +68,6 @@
 
 #pragma mark - Constants
 
-NSString *const FIRAuthStateDidChangeInternalNotification =
-    @"FIRAuthStateDidChangeInternalNotification";
-NSString *const FIRAuthStateDidChangeInternalNotificationTokenKey =
-    @"FIRAuthStateDidChangeInternalNotificationTokenKey";
-
 #if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 const NSNotificationName FIRAuthStateDidChangeNotification = @"FIRAuthStateDidChangeNotification";
 #else

--- a/Firebase/Auth/Source/FIRAuth_Internal.h
+++ b/Firebase/Auth/Source/FIRAuth_Internal.h
@@ -28,22 +28,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/** @var FIRAuthStateDidChangeInternalNotification
-    @brief The name of the @c NSNotificationCenter notification which is posted when the auth state
-        changes (e.g. a new token has been produced, a user logs in or out). The object parameter of
-        the notification is a dictionary possibly containing the key:
-        @c FIRAuthStateDidChangeInternalNotificationTokenKey (the new access token.) If it does not
-        contain this key it indicates a sign-out event took place.
- */
-extern NSString *const FIRAuthStateDidChangeInternalNotification;
-
-/** @var FIRAuthStateDidChangeInternalNotificationTokenKey
-    @brief A key present in the dictionary object parameter of the
-        @c FIRAuthStateDidChangeInternalNotification notification. The value associated with this
-        key will contain the new access token.
- */
-extern NSString *const FIRAuthStateDidChangeInternalNotificationTokenKey;
-
 @interface FIRAuth ()
 
 /** @property requestConfiguration

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -51,6 +51,12 @@ NSString *const kFIRAppDiagnosticsFIRAppKey = @"FIRApp";
 NSString *const kFIRAppDiagnosticsSDKNameKey = @"SDKName";
 NSString *const kFIRAppDiagnosticsSDKVersionKey = @"SDKVersion";
 
+// Auth internal notification notification and key.
+NSString *const FIRAuthStateDidChangeInternalNotification =
+    @"FIRAuthStateDidChangeInternalNotification";
+NSString *const FIRAuthStateDidChangeInternalNotificationTokenKey =
+    @"FIRAuthStateDidChangeInternalNotificationTokenKey";
+
 /**
  * The URL to download plist files.
  */

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -54,6 +54,8 @@ NSString *const kFIRAppDiagnosticsSDKVersionKey = @"SDKVersion";
 // Auth internal notification notification and key.
 NSString *const FIRAuthStateDidChangeInternalNotification =
     @"FIRAuthStateDidChangeInternalNotification";
+NSString *const FIRAuthStateDidChangeInternalNotificationAppKey =
+    @"FIRAuthStateDidChangeInternalNotificationAppKey";
 NSString *const FIRAuthStateDidChangeInternalNotificationTokenKey =
     @"FIRAuthStateDidChangeInternalNotificationTokenKey";
 

--- a/Firebase/Core/Private/FIRAppInternal.h
+++ b/Firebase/Core/Private/FIRAppInternal.h
@@ -76,6 +76,13 @@ extern NSString *const FIRAuthStateDidChangeInternalNotification;
  */
 extern NSString *const FIRAuthStateDidChangeInternalNotificationTokenKey;
 
+/** @var FIRAuthStateDidChangeInternalNotificationAppKey
+ @brief A key present in the dictionary object parameter of the
+ @c FIRAuthStateDidChangeInternalNotification notification. The value associated with this
+ key will contain the FIRApp associated with the auth instance.
+ */
+extern NSString *const FIRAuthStateDidChangeInternalNotificationAppKey;
+
 /** @typedef FIRTokenCallback
     @brief The type of block which gets called when a token is ready.
  */

--- a/Firebase/Core/Private/FIRAppInternal.h
+++ b/Firebase/Core/Private/FIRAppInternal.h
@@ -60,6 +60,22 @@ extern NSString *const kFIRAppIsDefaultAppKey;
 extern NSString *const kFIRAppNameKey;
 extern NSString *const kFIRGoogleAppIDKey;
 
+/** @var FIRAuthStateDidChangeInternalNotification
+ @brief The name of the @c NSNotificationCenter notification which is posted when the auth state
+ changes (e.g. a new token has been produced, a user logs in or out). The object parameter of
+ the notification is a dictionary possibly containing the key:
+ @c FIRAuthStateDidChangeInternalNotificationTokenKey (the new access token.) If it does not
+ contain this key it indicates a sign-out event took place.
+ */
+extern NSString *const FIRAuthStateDidChangeInternalNotification;
+
+/** @var FIRAuthStateDidChangeInternalNotificationTokenKey
+ @brief A key present in the dictionary object parameter of the
+ @c FIRAuthStateDidChangeInternalNotification notification. The value associated with this
+ key will contain the new access token.
+ */
+extern NSString *const FIRAuthStateDidChangeInternalNotificationTokenKey;
+
 /** @typedef FIRTokenCallback
     @brief The type of block which gets called when a token is ready.
  */

--- a/Firebase/Database/Login/FAuthTokenProvider.h
+++ b/Firebase/Database/Login/FAuthTokenProvider.h
@@ -19,6 +19,8 @@
 #import "FTypedefs.h"
 #import "FTypedefs_Private.h"
 
+@class FIRApp;
+
 @protocol FAuthTokenProvider <NSObject>
 
 - (void) fetchTokenForcingRefresh:(BOOL)forceRefresh withCallback:(fbt_void_nsstring_nserror)callback;
@@ -29,7 +31,7 @@
 
 @interface FAuthTokenProvider : NSObject
 
-+ (id<FAuthTokenProvider>) authTokenProviderForApp:(id)app;
++ (id<FAuthTokenProvider>) authTokenProviderForApp:(FIRApp *)app;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Firebase/Database/Login/FAuthTokenProvider.m
+++ b/Firebase/Database/Login/FAuthTokenProvider.m
@@ -16,32 +16,17 @@
 
 #import "FAuthTokenProvider.h"
 #import "FUtilities.h"
+#import "FIRAppInternal.h"
 #import "FIRLogger.h"
 #import "FIRDatabaseQuery_Private.h"
 #import "FIRNoopAuthTokenProvider.h"
-
-static NSString *const FIRAuthStateDidChangeInternalNotification = @"FIRAuthStateDidChangeInternalNotification";
-static NSString *const FIRAuthStateDidChangeInternalNotificationTokenKey = @"FIRAuthStateDidChangeInternalNotificationTokenKey";
-
-
-/**
- * This is a hack that defines all the methods we need from FIRFirebaseApp. At runtime we use reflection to get an
- * actual instance of FIRFirebaseApp. Since protocols don't carry any runtime information and selectors are invoked
- * by name we can write code against this protocol as long as the method signatures of FIRFirebaseApp don't change.
- */
-@protocol FIRFirebaseAppLike <NSObject>
-
-- (void)getTokenForcingRefresh:(BOOL)forceRefresh withCallback:(void (^)(NSString *_Nullable token, NSError *_Nullable error))callback;
-
-@end
-
 
 /**
  * This is a hack that defines all the methods we need from FIRAuth.
  */
 @protocol FIRFirebaseAuthLike <NSObject>
 
-- (id<FIRFirebaseAppLike>) app;
+- (FIRApp *) app;
 
 @end
 
@@ -49,18 +34,18 @@ static NSString *const FIRAuthStateDidChangeInternalNotificationTokenKey = @"FIR
  * This is a hack that copies the definitions of Firebase Auth error codes. If the error codes change in the original code, this
  * will break at runtime due to undefined behavior!
  */
-typedef NS_ENUM(NSUInteger, FIRErrorCode) {
-    /*! @var FIRErrorCodeNoAuth
+typedef NS_ENUM(NSUInteger, FIRMockErrorCode) {
+    /*! @var FIRMockErrorCodeNoAuth
      @brief Represents the case where an auth-related message was sent to a @c FIRFirebaseApp
      instance which has no associated @c FIRAuth instance.
      */
-    FIRErrorCodeNoAuth,
+    FIRMockErrorCodeNoAuth,
 
-    /*! @var FIRErrorCodeNoSignedInUser
+    /*! @var FIRMockErrorCodeNoSignedInUser
      @brief Represents the case where an attempt was made to fetch a token when there is no signed
      in user.
      */
-    FIRErrorCodeNoSignedInUser,
+    FIRMockErrorCodeNoSignedInUser,
 };
 
 
@@ -68,13 +53,13 @@ typedef NS_ENUM(NSUInteger, FIRErrorCode) {
 
 @property (nonatomic, copy) fbt_void_nsstring listener;
 
-@property (nonatomic, weak) id<FIRFirebaseAppLike> app;
+@property (nonatomic, weak) FIRApp *app;
 
 @end
 
 @implementation FAuthStateListenerWrapper
 
-- (instancetype) initWithListener:(fbt_void_nsstring)listener app:(id<FIRFirebaseAppLike>)app {
+- (instancetype) initWithListener:(fbt_void_nsstring)listener app:(FIRApp *)app {
     self = [super init];
     if (self != nil) {
         self->_listener = listener;
@@ -107,17 +92,17 @@ typedef NS_ENUM(NSUInteger, FIRErrorCode) {
 
 @interface FIRFirebaseAuthTokenProvider : NSObject <FAuthTokenProvider>
 
-@property (nonatomic, strong) id<FIRFirebaseAppLike> app;
+@property (nonatomic, strong) FIRApp *app;
 /** Strong references to the auth listeners as they are only weak in FIRFirebaseApp */
 @property (nonatomic, strong) NSMutableArray *authListeners;
 
-- (instancetype) initWithFirebaseApp:(id<FIRFirebaseAppLike>)app;
+- (instancetype) initWithFirebaseApp:(FIRApp *)app;
 
 @end
 
 @implementation FIRFirebaseAuthTokenProvider
 
-- (instancetype) initWithFirebaseApp:(id<FIRFirebaseAppLike>)app {
+- (instancetype) initWithFirebaseApp:(FIRApp *)app {
     self = [super init];
     if (self != nil) {
         self->_app = app;
@@ -131,10 +116,10 @@ typedef NS_ENUM(NSUInteger, FIRErrorCode) {
     [self.app getTokenForcingRefresh:forceRefresh withCallback:^(NSString * _Nullable token, NSError * _Nullable error) {
         dispatch_async([FIRDatabaseQuery sharedQueue], ^{
             if (error != nil) {
-                if (error.code == FIRErrorCodeNoAuth) {
+                if (error.code == FIRMockErrorCodeNoAuth) {
                     FFLog(@"I-RDB073001", @"Firebase Auth is not configured, not going to use authentication.");
                     callback(nil, nil);
-                } else if (error.code == FIRErrorCodeNoSignedInUser) {
+                } else if (error.code == FIRMockErrorCodeNoSignedInUser) {
                     // No signed in user is an expected case, callback as success with no token
                     callback(nil, nil);
                 } else {

--- a/Firebase/Database/Public/FIRDatabase.h
+++ b/Firebase/Database/Public/FIRDatabase.h
@@ -51,7 +51,7 @@ FIR_SWIFT_NAME(Database)
  * @param app The FIRApp to get a FIRDatabase for.
  * @return A FIRDatabase instance.
  */
-+ (FIRDatabase *) databaseForApp:(FIRApp*)app FIR_SWIFT_NAME(database(app:));
++ (FIRDatabase *) databaseForApp:(FIRApp *)app FIR_SWIFT_NAME(database(app:));
 
 /** The FIRApp instance to which this FIRDatabase belongs. */
 @property (weak, readonly, nonatomic) FIRApp *app;


### PR DESCRIPTION
SDKs that want to listen for the internal Auth notifications needed
to copy the notification strings to their own SDK instead of relying
on Auth's definition in order to avoid a dependency on Auth. By moving
them to Core, SDKs can use the constants without taking on another
dependency.