### PR TITLE
APNs token handling improvements.

### DIFF
--- a/AuthSamples/Sample/SettingsViewController.m
+++ b/AuthSamples/Sample/SettingsViewController.m
@@ -113,20 +113,6 @@ static NSString *truncatedString(NSString *string, NSUInteger length) {
                                     [string substringFromIndex:string.length - half]];
 }
 
-/** @fn hexString
-    @brief Converts a piece of data into a hexadecimal string.
-    @param data The raw data.
-    @return The hexadecimal string representation of the data.
- */
-static NSString *hexString(NSData *data) {
-  NSMutableString *string = [NSMutableString stringWithCapacity:data.length * 2];
-  const unsigned char *bytes = data.bytes;
-  for (int idx = 0; idx < data.length; ++idx) {
-    [string appendFormat:@"%02X", (int)bytes[idx]];
-  }
-  return string;
-}
-
 @implementation SettingsViewController
 
 - (void)viewDidLoad {
@@ -273,7 +259,7 @@ static NSString *hexString(NSData *data) {
     return @"";
   }
   return [NSString stringWithFormat:@"%@(%@)",
-                                    truncatedString(hexString(token.data), 19),
+                                    truncatedString(token.string, 19),
                                     token.type == FIRAuthAPNSTokenTypeProd ? @"P" : @"S"];
 }
 
@@ -287,7 +273,7 @@ static NSString *hexString(NSData *data) {
   }
   NSString *tokenType = token.type == FIRAuthAPNSTokenTypeProd ? @"Production" : @"Sandbox";
   NSString *message = [NSString stringWithFormat:@"token: %@\ntype: %@",
-                                                 hexString(token.data), tokenType];
+                                                 token.string, tokenType];
   [self showMessagePromptWithTitle:@"Clear APNs Token?"
                            message:message
                   showCancelButton:YES

--- a/Example/Auth/Tests/FIRAuthAPNSTokenTests.m
+++ b/Example/Auth/Tests/FIRAuthAPNSTokenTests.m
@@ -27,14 +27,15 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 @implementation FIRAuthAPNSTokenTests
 
-/** @fn testInitializer
-    @brief Tests the initializer of the class.
+/** @fn testProperties
+    @brief Tests the properties of the class.
  */
-- (void)testInitializer {
+- (void)testProperties {
   NSData *data = [@"asdf" dataUsingEncoding:NSUTF8StringEncoding];
   FIRAuthAPNSToken *token = [[FIRAuthAPNSToken alloc] initWithData:data
                                                               type:FIRAuthAPNSTokenTypeProd];
   XCTAssertEqualObjects(token.data, data);
+  XCTAssertEqualObjects(token.string, @"61736466");
   XCTAssertEqual(token.type, FIRAuthAPNSTokenTypeProd);
 }
 

--- a/Example/Auth/Tests/FIRPhoneAuthProviderTests.m
+++ b/Example/Auth/Tests/FIRPhoneAuthProviderTests.m
@@ -280,12 +280,25 @@ static const NSTimeInterval kExpectationTimeout = 1;
   OCMExpect([_mockAppCredentialManager credential]).andReturn(nil);
   OCMExpect([_mockAPNSTokenManager getTokenWithCallback:OCMOCK_ANY])
       .andCallBlock1(^(FIRAuthAPNSTokenCallback callback) { callback(nil); });
+  // Expect verify client request to the backend wth empty token.
+  OCMExpect([_mockBackend verifyClient:[OCMArg any] callback:[OCMArg any]])
+      .andCallBlock2(^(FIRVerifyClientRequest *request,
+                       FIRVerifyClientResponseCallback callback) {
+    XCTAssertNil(request.appToken);
+    dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+      // The backend is supposed to return an error.
+      callback(nil, [NSError errorWithDomain:FIRAuthErrorDomain
+                                        code:FIRAuthErrorCodeMissingAppToken
+                                    userInfo:nil]);
+    });
+  });
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [_provider verifyPhoneNumber:kTestPhoneNumber
                     completion:^(NSString *_Nullable verificationID, NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
     XCTAssertNil(verificationID);
+    XCTAssertEqualObjects(error.domain, FIRAuthErrorDomain);
     XCTAssertEqual(error.code, FIRAuthErrorCodeMissingAppToken);
     [expectation fulfill];
   }];

--- a/Firebase/Auth/Source/AuthProviders/Phone/FIRPhoneAuthProvider.m
+++ b/Firebase/Auth/Source/AuthProviders/Phone/FIRPhoneAuthProvider.m
@@ -168,22 +168,9 @@ typedef void (^FIRVerifyClientCallback)(FIRAuthAppCredential *_Nullable appCrede
     completion(_auth.appCredentialManager.credential, nil);
     return;
   }
-  [_auth.tokenManager getTokenWithCallback:^(FIRAuthAPNSToken * _Nullable token) {
-    if (!token) {
-      completion(nil, [FIRAuthErrorUtils missingAppTokenError]);
-      return;
-    }
-
-    // Convert token data to hex string.
-    NSUInteger capacity = token.data.length * 2;
-    NSMutableString *tokenString = [NSMutableString stringWithCapacity:capacity];
-    const unsigned char *tokenData = token.data.bytes;
-    for (int idx = 0; idx < token.data.length; ++idx) {
-      [tokenString appendFormat:@"%02X", (int)tokenData[idx]];
-    }
-
+  [_auth.tokenManager getTokenWithCallback:^(FIRAuthAPNSToken *_Nullable token) {
     FIRVerifyClientRequest *request =
-        [[FIRVerifyClientRequest alloc] initWithAppToken:tokenString
+        [[FIRVerifyClientRequest alloc] initWithAppToken:token.string
                                                isSandbox:token.type == FIRAuthAPNSTokenTypeSandbox
                                                   APIKey:_auth.APIKey];
     [FIRAuthBackend verifyClient:request callback:^(FIRVerifyClientResponse *_Nullable response,

--- a/Firebase/Auth/Source/FIRAuthAPNSToken.h
+++ b/Firebase/Auth/Source/FIRAuthAPNSToken.h
@@ -30,6 +30,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, strong, readonly) NSData *data;
 
+/** @property string
+    @brief The uppercase hexadecimal string form of the APNs token data.
+ */
+@property(nonatomic, strong, readonly) NSString *string;
+
 /** @property type
     @brief The APNs token type.
  */

--- a/Firebase/Auth/Source/FIRAuthAPNSToken.m
+++ b/Firebase/Auth/Source/FIRAuthAPNSToken.m
@@ -18,7 +18,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@implementation FIRAuthAPNSToken
+@implementation FIRAuthAPNSToken {
+  /** @var _string
+      @brief The lazy-initialized string form of the token data.
+   */
+  NSString *_string;
+}
 
 - (instancetype)initWithData:(NSData *)data type:(FIRAuthAPNSTokenType)type {
   self = [super init];
@@ -27,6 +32,19 @@ NS_ASSUME_NONNULL_BEGIN
     _type = type;
   }
   return self;
+}
+
+- (NSString *)string {
+  if (!_string) {
+    NSUInteger capacity = _data.length * 2;
+    NSMutableString *tokenString = [NSMutableString stringWithCapacity:capacity];
+    const unsigned char *tokenData = _data.bytes;
+    for (int idx = 0; idx < _data.length; ++idx) {
+      [tokenString appendFormat:@"%02X", (int)tokenData[idx]];
+    }
+    _string = tokenString;
+  }
+  return _string;
 }
 
 @end

--- a/Firebase/Auth/Source/RPCs/FIRAuthBackend.m
+++ b/Firebase/Auth/Source/RPCs/FIRAuthBackend.m
@@ -270,15 +270,21 @@ static NSString *const kInvalidSessionInfoErrorMessage = @"INVALID_SESSION_INFO"
  */
 static NSString *const kSessionExpiredErrorMessage = @"SESSION_EXPIRED";
 
-/** @var kMissingAppCredentialErrorMessage
+/** @var kMissingAppTokenErrorMessage
     @brief This is the error message the server will respond with if the APNS token is missing in a
         verifyClient request.
  */
-static NSString *const kMissingAppCredentialErrorMessage = @"MISSING_APP_CREDENTIAL";
+static NSString *const kMissingAppTokenErrorMessage = @"MISSING_IOS_APP_TOKEN";
 
 /** @var kMissingAppCredentialErrorMessage
-    @brief This is the error message the server will respond with if the APNS token in a
-        verifyClient request is invalid.
+    @brief This is the error message the server will respond with if the app token is missing in a
+        sendVerificationCode request.
+ */
+static NSString *const kMissingAppCredentialErrorMessage = @"MISSING_APP_CREDENTIAL";
+
+/** @var kInvalidAppCredentialErrorMessage
+    @brief This is the error message the server will respond with if the app credential in a
+        sendVerificationCode request is invalid.
  */
 static NSString *const kInvalidAppCredentialErrorMessage = @"INVALID_APP_CREDENTIAL";
 
@@ -915,6 +921,10 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
 
   if ([shortErrorMessage isEqualToString:kSessionExpiredErrorMessage]) {
     return [FIRAuthErrorUtils sessionExpiredErrorWithMessage:serverDetailErrorMessage];
+  }
+
+  if ([shortErrorMessage isEqualToString:kMissingAppTokenErrorMessage]) {
+    return [FIRAuthErrorUtils missingAppTokenError];
   }
 
   if ([shortErrorMessage isEqualToString:kMissingAppCredentialErrorMessage]) {

--- a/Firebase/Auth/Source/RPCs/FIRVerifyClientRequest.h
+++ b/Firebase/Auth/Source/RPCs/FIRVerifyClientRequest.h
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
     @param isSandbox The flag indicating whether or not the app token provided is for Sandbox or
         Production.
  */
-- (nullable instancetype)initWithAppToken:(NSString *)appToken
+- (nullable instancetype)initWithAppToken:(nullable NSString *)appToken
                                 isSandbox:(BOOL)isSandbox
                                    APIKey:(NSString *)APIKey NS_DESIGNATED_INITIALIZER;
 

--- a/Firebase/Auth/Source/RPCs/FIRVerifyClientRequest.m
+++ b/Firebase/Auth/Source/RPCs/FIRVerifyClientRequest.m
@@ -36,7 +36,7 @@ static NSString *const kIsSandboxKey = @"isSandbox";
 
 @implementation FIRVerifyClientRequest
 
-- (nullable instancetype)initWithAppToken:(NSString *)appToken
+- (nullable instancetype)initWithAppToken:(nullable NSString *)appToken
                                 isSandbox:(BOOL)isSandbox
                                    APIKey:(NSString *)APIKey {
   self = [super initWithEndpoint:kVerifyClientEndpoint APIKey:APIKey];
@@ -47,7 +47,7 @@ static NSString *const kIsSandboxKey = @"isSandbox";
   return self;
 }
 
-- (nullable id)unencodedHTTPRequestBodyWithError:(NSError *__autoreleasing  _Nullable *)error {
+- (nullable id)unencodedHTTPRequestBodyWithError:(NSError *__autoreleasing _Nullable *)error {
   NSMutableDictionary *postBody = [NSMutableDictionary dictionary];
   if (_appToken) {
     postBody[kAPPTokenKey] = _appToken;


### PR DESCRIPTION
- Calls VerifyClient without token anyway if the APNs token cannot be retrieved.
  This allows server to use discretion if needed in future. The developer will
  receive the same error as before.
- Moves token formatting code to the token class itself to make the main logic
  in the provider class more clear. This also eliminates duplicated code in the
  sample app.