### PR TITLE
Prevent clang-format from merging short functions into a single line

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,3 +5,4 @@ AllowAllParametersOfDeclarationOnNextLine: true
 ObjCSpaceBeforeProtocolList: true
 SpacesInContainerLiterals: true
 PointerAlignment: Right
+AllowShortFunctionsOnASingleLine: None

--- a/Example/Core/App/macOS/main.m
+++ b/Example/Core/App/macOS/main.m
@@ -16,4 +16,6 @@
 
 #import <Cocoa/Cocoa.h>
 
-int main(int argc, const char* argv[]) { return NSApplicationMain(argc, argv); }
+int main(int argc, const char* argv[]) {
+  return NSApplicationMain(argc, argv);
+}

--- a/Example/Core/Tests/FIRAppAssociationRegistrationUnitTests.m
+++ b/Example/Core/Tests/FIRAppAssociationRegistrationUnitTests.m
@@ -34,7 +34,9 @@ static NSString *kKey2 = @"key2";
 /** @var gCreateNewObject
     @brief A block that returns a new object everytime it is called.
  */
-static id _Nullable (^gCreateNewObject)() = ^id _Nullable() { return [[NSObject alloc] init]; };
+static id _Nullable (^gCreateNewObject)() = ^id _Nullable() {
+  return [[NSObject alloc] init];
+};
 
 /** @class FIRAppAssociationRegistrationTests
     @brief Tests for @c FIRAppAssociationRegistration

--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -564,7 +564,9 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 - (void)testAuthGetUID {
   [FIRApp configure];
 
-  [FIRApp defaultApp].getUIDImplementation = ^NSString * { return @"highlander"; };
+  [FIRApp defaultApp].getUIDImplementation = ^NSString * {
+    return @"highlander";
+  };
   XCTAssertEqual([[FIRApp defaultApp] getUID], @"highlander");
 }
 

--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -166,11 +166,17 @@ void FIRResetLogger() {
   [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFIRPersistedDebugModeKey];
 }
 
-aslclient getFIRLoggerClient() { return sFIRLoggerClient; }
+aslclient getFIRLoggerClient() {
+  return sFIRLoggerClient;
+}
 
-dispatch_queue_t getFIRClientQueue() { return sFIRClientQueue; }
+dispatch_queue_t getFIRClientQueue() {
+  return sFIRClientQueue;
+}
 
-BOOL getFIRLoggerDebugMode() { return sFIRLoggerDebugMode; }
+BOOL getFIRLoggerDebugMode() {
+  return sFIRLoggerDebugMode;
+}
 #endif
 
 void FIRLogBasic(FIRLoggerLevel level,


### PR DESCRIPTION
Consider this as a feature request :-).