### PR TITLE
Adjusts header imports in Auth sample to avoid FirebaseCore.h

### DIFF
--- a/AuthSamples/Sample/AppManager.m
+++ b/AuthSamples/Sample/AppManager.m
@@ -16,9 +16,9 @@
 
 #import "AppManager.h"
 
-#import "FirebaseAuth.h"
-#import "FirebaseCore.h"
+#import "FIRApp.h"
 #import "FIRPhoneAuthProvider.h"
+#import "FirebaseAuth.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AuthSamples/Sample/SettingsViewController.m
+++ b/AuthSamples/Sample/SettingsViewController.m
@@ -19,13 +19,14 @@
 #import <objc/runtime.h>
 
 #import "AppManager.h"
+#import "FIRApp.h"
 #import "FIRAuth_Internal.h"
 #import "FIRAuthAPNSToken.h"
 #import "FIRAuthAPNSTokenManager.h"
 #import "FIRAuthAppCredential.h"
 #import "FIRAuthAppCredentialManager.h"
+#import "FIROptions.h"
 #import "FirebaseAuth.h"
-#import "FirebaseCore.h"
 #import "StaticContentTableViewManager.h"
 #import "UIViewController+Alerts.h"
 


### PR DESCRIPTION
Because the umbrella header isn't accessible in other build environment.

