### PR TITLE
Adds the missing FIRActionCodeOperationRecoverEmail.

### DIFF
--- a/AuthSamples/Sample/MainViewController.m
+++ b/AuthSamples/Sample/MainViewController.m
@@ -844,7 +844,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
     return YES;
   }
   if ([mode isEqualToString:kVerifyEmailAction]) {
-    [self showMessagePromptWithTitle:@"Verify Email?"
+    [self showMessagePromptWithTitle:@"Tap OK to verify email"
                              message:actionCode
                     showCancelButton:YES
                           completion:^(BOOL userPressedOK, NSString *_Nullable userInput) {

--- a/AuthSamples/Sample/MainViewController.m
+++ b/AuthSamples/Sample/MainViewController.m
@@ -822,6 +822,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
     [self showTextInputPromptWithMessage:@"New Password:"
                          completionBlock:^(BOOL userPressedOK, NSString *_Nullable newPassword) {
       if (!userPressedOK || !newPassword.length) {
+        [UIPasteboard generalPasteboard].string = actionCode;
         return;
       }
       [self showSpinner:^() {
@@ -843,8 +844,8 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
     return YES;
   }
   if ([mode isEqualToString:kVerifyEmailAction]) {
-    [self showMessagePromptWithTitle:@"Verify Email"
-                             message:@"Proceed?"
+    [self showMessagePromptWithTitle:@"Verify Email?"
+                             message:actionCode
                     showCancelButton:YES
                           completion:^(BOOL userPressedOK, NSString *_Nullable userInput) {
       if (!userPressedOK) {
@@ -2178,10 +2179,14 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
           }
           [self logSuccess:@"Check action code succeeded."];
           NSString *email = [info dataForKey:FIRActionCodeEmailKey];
+          NSString *fromEmail = [info dataForKey:FIRActionCodeFromEmailKey];
+          NSString *message =
+              fromEmail ? [NSString stringWithFormat:@"%@ -> %@", fromEmail, email] : email;
           NSString *operation = [self nameForActionCodeOperation:info.operation];
-          NSString *infoMessage =
-            [[NSString alloc] initWithFormat:@"Email: %@\n Operation: %@", email, operation];
-          [self showMessagePrompt:infoMessage];
+          [self showMessagePromptWithTitle:operation
+                                   message:message
+                          showCancelButton:NO
+                                completion:nil];
         }];
       }];
     }];
@@ -2252,6 +2257,8 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
   switch (operation) {
   case FIRActionCodeOperationVerifyEmail:
     return @"Verify Email";
+  case FIRActionCodeOperationRecoverEmail:
+    return @"Recover Email";
   case FIRActionCodeOperationPasswordReset:
     return @"Password Reset";
   case FIRActionCodeOperationUnknown:

--- a/Firebase/Auth/CHANGELOG.md
+++ b/Firebase/Auth/CHANGELOG.md
@@ -2,7 +2,8 @@
 - Allows the app to handle continue URL natively, e.g., from password reset
   email.
 - Allows the app to set language code, e.g., for sending password reset email.
-- Fixes an issue that user's phone number does not persist on client.
+- Fixes an issue that user's phone number did not persist on client.
+- Fixes an issue that recover email action code type was reported as unknown.
 - Improves app start-up time by moving initialization off from the main
   thread.
 - Better reports missing email error when creating a new password user.

--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -104,9 +104,20 @@ static NSString *const kUserKey = @"%@_firebase_user";
 static NSString *const kMissingEmailInvalidParameterExceptionReason =
     @"The email used to initiate password reset cannot be nil.";
 
+/** @var kPasswordResetRequestType
+    @brief The action code type value for resetting password in the checking action code response.
+ */
 static NSString *const kPasswordResetRequestType = @"PASSWORD_RESET";
 
+/** @var kVerifyEmailRequestType
+    @brief The action code type value for verifying email in the checking action code response.
+ */
 static NSString *const kVerifyEmailRequestType = @"VERIFY_EMAIL";
+
+/** @var kRecoverEmailRequestType
+    @brief The action code type value for recovering email in the checking action code response.
+ */
+static NSString *const kRecoverEmailRequestType = @"RECOVER_EMAIL";
 
 /** @var kMissingPasswordReason
     @brief The reason why the @c FIRAuthErrorCodeWeakPassword error is thrown.
@@ -173,6 +184,9 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
   }
   if ([requestType isEqualToString:kVerifyEmailRequestType]) {
     return FIRActionCodeOperationVerifyEmail;
+  }
+  if ([requestType isEqualToString:kRecoverEmailRequestType]) {
+    return FIRActionCodeOperationRecoverEmail;
   }
   return FIRActionCodeOperationUnknown;
 }

--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -105,17 +105,17 @@ static NSString *const kMissingEmailInvalidParameterExceptionReason =
     @"The email used to initiate password reset cannot be nil.";
 
 /** @var kPasswordResetRequestType
-    @brief The action code type value for resetting password in the checking action code response.
+    @brief The action code type value for resetting password in the check action code response.
  */
 static NSString *const kPasswordResetRequestType = @"PASSWORD_RESET";
 
 /** @var kVerifyEmailRequestType
-    @brief The action code type value for verifying email in the checking action code response.
+    @brief The action code type value for verifying email in the check action code response.
  */
 static NSString *const kVerifyEmailRequestType = @"VERIFY_EMAIL";
 
 /** @var kRecoverEmailRequestType
-    @brief The action code type value for recovering email in the checking action code response.
+    @brief The action code type value for recovering email in the check action code response.
  */
 static NSString *const kRecoverEmailRequestType = @"RECOVER_EMAIL";
 

--- a/Firebase/Auth/Source/Public/FIRAuth.h
+++ b/Firebase/Auth/Source/Public/FIRAuth.h
@@ -186,7 +186,11 @@ typedef NS_ENUM(NSInteger, FIRActionCodeOperation) {
     FIRActionCodeOperationPasswordReset = 1,
 
     /** Action code for verify email operation. */
-    FIRActionCodeOperationVerifyEmail = 2
+    FIRActionCodeOperationVerifyEmail = 2,
+
+    /** Action code for recover email operation. */
+    FIRActionCodeOperationRecoverEmail = 3,
+
 } FIR_SWIFT_NAME(ActionCodeOperation);
 
 /**


### PR DESCRIPTION
Also allow in-app action code handling to cancel and leave the code in pasteboard.
