### PR TITLE
Fixes an incorrect assumption of Auth server error message.

### DIFF
--- a/Example/Auth/Tests/FIRGetOOBConfirmationCodeResponseTests.m
+++ b/Example/Auth/Tests/FIRGetOOBConfirmationCodeResponseTests.m
@@ -86,7 +86,7 @@ static NSString *const kMissingAndroidPackageNameErrorMessage = @"MISSING_ANDROI
     @brief This is the error message the server will respond with if the domain of the continue URL
         specified is not whitelisted in the firebase console.
  */
-static NSString *const kUnauthorizedDomainErrorMessage = @"ERROR_UNAUTHORIZED_DOMAIN";
+static NSString *const kUnauthorizedDomainErrorMessage = @"UNAUTHORIZED_DOMAIN";
 
 /** @var kInvalidRecipientEmailErrorMessage
     @brief This is the prefix for the error message the server responds with if the recipient email

--- a/Firebase/Auth/Source/RPCs/FIRAuthBackend.m
+++ b/Firebase/Auth/Source/RPCs/FIRAuthBackend.m
@@ -267,7 +267,7 @@ static NSString *const kMissingAndroidPackageNameErrorMessage = @"MISSING_ANDROI
     @brief This is the error message the server will respond with if the domain of the continue URL
         specified is not whitelisted in the firebase console.
  */
-static NSString *const kUnauthorizedDomainErrorMessage = @"ERROR_UNAUTHORIZED_DOMAIN";
+static NSString *const kUnauthorizedDomainErrorMessage = @"UNAUTHORIZED_DOMAIN";
 
 /** @var kInvalidContinueURIErrorMessage
     @brief This is the error message the server will respond with if the continue URL provided in


### PR DESCRIPTION
Also allows the Auth sample app to test all combination of `handleCodeInApp` and continue URL.
