### PR TITLE
Wrong Bundle ID should be a visible error

### DIFF
--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -400,7 +400,7 @@ static FIRApp *sDefaultApp;
   // backward compatibility.
   if (expectedBundleID != nil &&
       ![FIRBundleUtil hasBundleIdentifier:expectedBundleID inBundles:bundles]) {
-    FIRLogInfo(kFIRLoggerCore, @"I-COR000008",
+    FIRLogError(kFIRLoggerCore, @"I-COR000008",
                @"The project's Bundle ID is inconsistent with "
                @"either the Bundle ID in '%@.%@', or the Bundle ID in the options if you are "
                @"using a customized options. To ensure that everything can be configured "


### PR DESCRIPTION
There should be a visible error when the Bundle ID is not correctly configured in the project. It was (inadvertently?) converted to an (off-by-default) Info message around January 2017.

Thanks to @ryanwilson for helping to track this down.