### PR TITLE
Ensure auto-connect logic is always in main thread

### DIFF
--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -545,6 +545,13 @@ NSString * const FIRMessagingRegistrationTokenRefreshedNotification =
 }
 
 - (void)updateAutomaticClientConnection {
+  if (![NSThread isMainThread]) {
+    // Call this method from the main thread
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self updateAutomaticClientConnection];
+    });
+    return;
+  }
   BOOL shouldBeConnected = [self shouldBeConnectedAutomatically];
   if (shouldBeConnected && !self.client.isConnected) {
     [self.client connectWithHandler:^(NSError *error) {


### PR DESCRIPTION
This addresses #125, where a developer is setting `.shouldEstablishDirectChannel` in a background thread, and getting a main thread sanitization issue in Xcode 9.