### PR TITLE
Clean up FIRBundleUtil.

### DIFF
--- a/Firebase/Core/FIRBundleUtil.m
+++ b/Firebase/Core/FIRBundleUtil.m
@@ -45,14 +45,6 @@
   return result;
 }
 
-+ (NSSet *)relevantBundleIdentifiers {
-  NSMutableSet *result = [[NSMutableSet alloc] init];
-  for (NSBundle *bundle in [[self class] relevantBundles]) {
-    [result addObject:[bundle bundleIdentifier]];
-  }
-  return result;
-}
-
 + (BOOL)hasBundleIdentifier:(NSString *)bundleIdentifier inBundles:(NSArray *)bundles {
   for (NSBundle *bundle in bundles) {
     if ([bundle.bundleIdentifier isEqualToString:bundleIdentifier]) {

--- a/Firebase/Core/Private/FIRBundleUtil.h
+++ b/Firebase/Core/Private/FIRBundleUtil.h
@@ -45,11 +45,6 @@
 + (NSArray *)relevantURLSchemes;
 
 /**
- * Finds bundle identifiers in all relevant bundles, starting with those from [NSBundle mainBundle].
- */
-+ (NSSet *)relevantBundleIdentifiers;
-
-/**
  * Checks if the bundle identifier exists in the given bundles.
  */
 + (BOOL)hasBundleIdentifier:(NSString *)bundleIdentifier inBundles:(NSArray *)bundles;


### PR DESCRIPTION
Remove `relevantBundleIdentifiers` method that isn't used anywhere.