### PR TITLE
Add Crashlytics and Fabric to Firebase umbrella header.

### DIFF
--- a/Firebase/Firebase/FirebaseCommunity.h
+++ b/Firebase/Firebase/FirebaseCommunity.h
@@ -66,4 +66,12 @@
     #import <GoogleMobileAds/GoogleMobileAds.h>
   #endif
 
+  #if __has_include(<Fabric/Fabric.h>)
+    #import <Fabric/Fabric.h>
+  #endif
+
+  #if __has_include(<Crashlytics/Crashlytics.h>)
+    #import <Crashlytics/Crashlytics.h>
+  #endif
+
 #endif  // defined(__has_include)


### PR DESCRIPTION
This will prevent users from having to specifically import Fabric or
Crashlytics into their projects when already importing Firebase.