### PR TITLE
Firebase Storage: Allowing metadata to be cleared

### DIFF
--- a/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
@@ -454,6 +454,81 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 30;
     [self waitForExpectations];
 }
 
+- void
+assertMetadata(FIRStorageMetadata *actualMetadata,
+               NSString *expectedContentType,
+               NSDictionary *expectedCustomMetadata) {
+  XCTAssertEqualObjects(actualMetadata.cacheControl, @"cache-control");
+  XCTAssertEqualObjects(actualMetadata.contentDisposition, @"content-disposition");
+  XCTAssertEqualObjects(actualMetadata.contentEncoding, @"gzip");
+  XCTAssertEqualObjects(actualMetadata.contentLanguage, @"de");
+  XCTAssertEqualObjects(actualMetadata.contentType, expectedContentType);
+  for (id key in expectedCustomMetadata) {
+    XCTAssertEqualObjects([actualMetadata.customMetadata objectForKey:key],
+                          [expectedCustomMetadata objectForKey:key]);
+  }
+}
+
+- (void)testUpdateMetadata {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"testUpdateMetadata"];
+
+  FIRStorageReference *ref = [self.storage referenceWithPath:@"ios/public/1mb"];
+
+  // Update all available metadata
+  FIRStorageMetadata *metadata = [[FIRStorageMetadata alloc] init];
+  metadata.cacheControl = @"cache-control";
+  metadata.contentDisposition = @"content-disposition";
+  metadata.contentEncoding = @"gzip";
+  metadata.contentLanguage = @"de";
+  metadata.contentType = @"content-type-a";
+  metadata.customMetadata = @{@"a" : @"b"};
+
+  [ref updateMetadata:metadata
+           completion:^(FIRStorageMetadata *updatedMetadata, NSError *error) {
+             XCTAssertNil(error);
+             assertMetadata(updatedMetadata, @"content-type-a", @{@"a" : @"b"});
+
+             // Update a subset of the metadata using the existing object.
+             FIRStorageMetadata *metadata = updatedMetadata;
+             metadata.contentType = @"content-type-c";
+             metadata.customMetadata = @{@"c" : @"d"};
+
+             [ref updateMetadata:metadata
+                      completion:^(FIRStorageMetadata *updatedMetadata, NSError *error) {
+                        XCTAssertNil(error);
+                        assertMetadata(updatedMetadata, @"content-type-b",
+                                       @{@"a" : @"b", @"c" : @"d"});
+
+                        // Clear all metadata.
+                        FIRStorageMetadata *metadata = updatedMetadata;
+                        metadata.cacheControl = nil;
+                        metadata.contentDisposition = nil;
+                        metadata.contentEncoding = nil;
+                        metadata.contentLanguage = nil;
+                        metadata.contentType = nil;
+                        metadata.customMetadata = [NSDictionary dictionary];
+
+                        [ref updateMetadata:metadata
+                                 completion:^(FIRStorageMetadata *updatedMetadata, NSError *error) {
+                                   XCTAssertNil(error);
+                                   XCTAssertNil(updatedMetadata.cacheControl);
+                                   XCTAssertNil(updatedMetadata.contentDisposition);
+                                   XCTAssertEqualObjects(updatedMetadata.contentEncoding,
+                                                         @"identity");
+                                   XCTAssertNil(updatedMetadata.contentLanguage);
+                                   XCTAssertNil(updatedMetadata.contentType);
+                                   XCTAssertNil([updatedMetadata.customMetadata objectForKey:@"a"]);
+                                   XCTAssertNil([updatedMetadata.customMetadata objectForKey:@"c"]);
+                                   XCTAssertNil([updatedMetadata.customMetadata objectForKey:@"f"]);
+
+                                   [expectation fulfill];
+                                 }];
+                      }];
+           }];
+
+  [self waitForExpectations];
+}
+
 - (void)testUnauthenticatedResumeGetFile {
     XCTestExpectation *expectation =
       [self expectationWithDescription:@"testUnauthenticatedResumeGetFile"];

--- a/Example/Storage/Tests/Unit/FIRStorageMetadataTests.m
+++ b/Example/Storage/Tests/Unit/FIRStorageMetadataTests.m
@@ -244,20 +244,7 @@
   XCTAssertEqualObjects(metadata0, metadata1);
 }
 
-- (void)testMetadataEmptyUpdate {
-  NSDictionary *oldMetadata = @{
-    kFIRStorageMetadataContentLanguage : @"old",
-    kFIRStorageMetadataCustomMetadata : @{@"foo" : @"old", @"bar" : @"old"}
-  };
-  FIRStorageMetadata *metadata = [[FIRStorageMetadata alloc] initWithDictionary:oldMetadata];
-
-  NSDictionary *update = [metadata updatedMetadata];
-
-  NSDictionary *expectedUpdate = @{ kFIRStorageMetadataCustomMetadata : @{} };
-  XCTAssertEqualObjects(update, expectedUpdate);
-}
-
-- (void)testMetadataFieldUpdate {
+- (void)testUpdatedMetadata {
   NSDictionary *oldMetadata = @{
     kFIRStorageMetadataContentLanguage : @"old",
     kFIRStorageMetadataCustomMetadata : @{@"foo" : @"old", @"bar" : @"old"}
@@ -275,7 +262,20 @@
   XCTAssertEqualObjects(update, expectedUpdate);
 }
 
-- (void)testMetadataFieldDelete {
+- (void)testUpdatedMetadataWithEmptyUpdate {
+    NSDictionary *oldMetadata = @{
+                                  kFIRStorageMetadataContentLanguage : @"old",
+                                  kFIRStorageMetadataCustomMetadata : @{@"foo" : @"old", @"bar" : @"old"}
+                                  };
+    FIRStorageMetadata *metadata = [[FIRStorageMetadata alloc] initWithDictionary:oldMetadata];
+
+    NSDictionary *update = [metadata updatedMetadata];
+
+    NSDictionary *expectedUpdate = @{ kFIRStorageMetadataCustomMetadata : @{} };
+    XCTAssertEqualObjects(update, expectedUpdate);
+}
+
+- (void)testUpdatedMetadataWithDelete {
   NSDictionary *oldMetadata = @{
     kFIRStorageMetadataContentLanguage : @"old",
     kFIRStorageMetadataCustomMetadata : @{@"foo" : @"old", @"bar" : @"old"}

--- a/Example/Storage/Tests/Unit/FIRStorageMetadataTests.m
+++ b/Example/Storage/Tests/Unit/FIRStorageMetadataTests.m
@@ -244,6 +244,55 @@
   XCTAssertEqualObjects(metadata0, metadata1);
 }
 
+- (void)testMetadataEmptyUpdate {
+  NSDictionary *oldMetadata = @{
+    kFIRStorageMetadataContentLanguage : @"old",
+    kFIRStorageMetadataCustomMetadata : @{@"foo" : @"old", @"bar" : @"old"}
+  };
+  FIRStorageMetadata *metadata = [[FIRStorageMetadata alloc] initWithDictionary:oldMetadata];
+
+  NSDictionary *update = [metadata updatedMetadata];
+
+  NSDictionary *expectedUpdate = @{ kFIRStorageMetadataCustomMetadata : @{} };
+  XCTAssertEqualObjects(update, expectedUpdate);
+}
+
+- (void)testMetadataFieldUpdate {
+  NSDictionary *oldMetadata = @{
+    kFIRStorageMetadataContentLanguage : @"old",
+    kFIRStorageMetadataCustomMetadata : @{@"foo" : @"old", @"bar" : @"old"}
+  };
+  FIRStorageMetadata *metadata = [[FIRStorageMetadata alloc] initWithDictionary:oldMetadata];
+  metadata.contentLanguage = @"new";
+  metadata.customMetadata = @{@"foo" : @"new", @"bar" : @"old"};
+
+  NSDictionary *update = [metadata updatedMetadata];
+
+  NSDictionary *expectedUpdate = @{
+    kFIRStorageMetadataContentLanguage : @"new",
+    kFIRStorageMetadataCustomMetadata : @{@"foo" : @"new"}
+  };
+  XCTAssertEqualObjects(update, expectedUpdate);
+}
+
+- (void)testMetadataFieldDelete {
+  NSDictionary *oldMetadata = @{
+    kFIRStorageMetadataContentLanguage : @"old",
+    kFIRStorageMetadataCustomMetadata : @{@"foo" : @"old", @"bar" : @"old"}
+  };
+  FIRStorageMetadata *metadata = [[FIRStorageMetadata alloc] initWithDictionary:oldMetadata];
+  metadata.contentLanguage = nil;
+  metadata.customMetadata = @{@"foo" : @"old"};
+
+  NSDictionary *update = [metadata updatedMetadata];
+
+  NSDictionary *expectedUpdate = @{
+    kFIRStorageMetadataContentLanguage : [NSNull null],
+    kFIRStorageMetadataCustomMetadata : @{@"bar" : [NSNull null]}
+  };
+  XCTAssertEqualObjects(update, expectedUpdate);
+}
+
 - (void)testMetadataHashEquality {
   NSDictionary *metaDict = @{
     kFIRStorageMetadataBucket : @"bucket",

--- a/Example/Storage/Tests/Unit/FIRStorageUpdateMetadataTests.m
+++ b/Example/Storage/Tests/Unit/FIRStorageUpdateMetadataTests.m
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import "FIRStorageMetadata_Private.h"
 #import "FIRStorageTestHelpers.h"
 #import "FIRStorageUpdateMetadataTask.h"
 
@@ -63,7 +64,7 @@
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
     XCTAssertEqualObjects(fetcher.request.URL, [FIRStorageTestHelpers objectURL]);
     XCTAssertEqualObjects(fetcher.request.HTTPMethod, @"PATCH");
-    NSData *bodyData = [NSData frs_dataFromJSONDictionary:[self.metadata dictionaryRepresentation]];
+    NSData *bodyData = [NSData frs_dataFromJSONDictionary:[self.metadata updatedMetadata]];
     XCTAssertEqualObjects(fetcher.request.HTTPBody, bodyData);
     NSDictionary *HTTPHeaders = fetcher.request.allHTTPHeaderFields;
     XCTAssertEqualObjects(HTTPHeaders[@"Content-Type"], @"application/json; charset=UTF-8");
@@ -75,6 +76,7 @@
                                    HTTPVersion:kHTTPVersion
                                   headerFields:nil];
     response(httpResponse, nil, nil);
+    self.fetcherService.testBlock = nil;
   };
 
   FIRStoragePath *path = [FIRStorageTestHelpers objectPath];

--- a/Firebase/Storage/FIRStorageMetadata.m
+++ b/Firebase/Storage/FIRStorageMetadata.m
@@ -31,6 +31,8 @@
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary {
   self = [super init];
   if (self) {
+    _initialMetadata = [dictionary copy];
+
     _bucket = dictionary[kFIRStorageMetadataBucket];
     _cacheControl = dictionary[kFIRStorageMetadataCacheControl];
     _contentDisposition = dictionary[kFIRStorageMetadataContentDisposition];
@@ -73,7 +75,10 @@
 #pragma mark - NSObject overrides
 
 - (instancetype)copyWithZone:(NSZone *)zone {
-  return [[[self class] allocWithZone:zone] initWithDictionary:[self dictionaryRepresentation]];
+  FIRStorageMetadata *clone =
+      [[[self class] allocWithZone:zone] initWithDictionary:[self dictionaryRepresentation]];
+  clone.initialMetadata = [self.initialMetadata copy];
+  return clone;
 }
 
 - (BOOL)isEqual:(id)object {
@@ -198,6 +203,36 @@
 
 - (nullable NSURL *)downloadURL {
   return [_downloadURLs firstObject];
+}
+
+#pragma mark - Private methods
+
++ (void)removeMatchingMetadata:(NSMutableDictionary *)metadata
+                   oldMetadata:(NSDictionary *)oldMetadata {
+  for (id metadataKey in [oldMetadata allKeys]) {
+    id oldValue = [oldMetadata objectForKey:metadataKey];
+    id newValue = [metadata objectForKey:metadataKey];
+
+    if (oldValue && !newValue) {
+      [metadata setObject:[NSNull null] forKey:metadataKey];
+    } else if ([oldValue isKindOfClass:[NSString class]] &&
+               [newValue isKindOfClass:[NSString class]]) {
+      if ([oldValue isEqualToString:newValue]) {
+        [metadata removeObjectForKey:metadataKey];
+      }
+    } else if ([oldValue isKindOfClass:[NSDictionary class]] &&
+               [newValue isKindOfClass:[NSDictionary class]]) {
+      NSMutableDictionary *nestedMetadata = [newValue mutableCopy];
+      [self removeMatchingMetadata:nestedMetadata oldMetadata:oldValue];
+      [metadata setObject:[nestedMetadata copy] forKey:metadataKey];
+    }
+  }
+}
+
+- (NSDictionary *)updatedMetadata {
+  NSMutableDictionary *metadataUpdate = [[self dictionaryRepresentation] mutableCopy];
+  [FIRStorageMetadata removeMatchingMetadata:metadataUpdate oldMetadata:_initialMetadata];
+  return [metadataUpdate copy];
 }
 
 #pragma mark - RFC 3339 conversions

--- a/Firebase/Storage/FIRStorageMetadata.m
+++ b/Firebase/Storage/FIRStorageMetadata.m
@@ -209,7 +209,7 @@
 
 + (void)removeMatchingMetadata:(NSMutableDictionary *)metadata
                    oldMetadata:(NSDictionary *)oldMetadata {
-  for (id metadataKey in [oldMetadata allKeys]) {
+  for (NSString* metadataKey in [oldMetadata allKeys]) {
     id oldValue = [oldMetadata objectForKey:metadataKey];
     id newValue = [metadata objectForKey:metadataKey];
 

--- a/Firebase/Storage/FIRStorageUpdateMetadataTask.m
+++ b/Firebase/Storage/FIRStorageUpdateMetadataTask.m
@@ -45,7 +45,7 @@
 
 - (void)enqueue {
   NSMutableURLRequest *request = [self.baseRequest mutableCopy];
-  NSDictionary *updateDictionary = [_updateMetadata dictionaryRepresentation];
+  NSDictionary *updateDictionary = [_updateMetadata updatedMetadata];
   NSData *updateData = [NSData frs_dataFromJSONDictionary:updateDictionary];
   request.HTTPMethod = @"PATCH";
   request.timeoutInterval = self.reference.storage.maxUploadRetryTime;

--- a/Firebase/Storage/Private/FIRStorageMetadata_Private.h
+++ b/Firebase/Storage/Private/FIRStorageMetadata_Private.h
@@ -15,6 +15,7 @@
  */
 
 #import "FIRStorageConstants_Private.h"
+#import "FIRStorageMetadata.h"
 
 @class FIRStorageReference;
 
@@ -34,7 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(readwrite) FIRStorageMetadataType type;
 
 /**
- * The original metadata representation received from the server.
+ * The original metadata representation received from the server or an empty dictionary
+ * if the metadata object was initialized by the user.
  */
 @property(copy, nonatomic) NSDictionary *initialMetadata;
 

--- a/Firebase/Storage/Private/FIRStorageMetadata_Private.h
+++ b/Firebase/Storage/Private/FIRStorageMetadata_Private.h
@@ -34,6 +34,24 @@ NS_ASSUME_NONNULL_BEGIN
 @property(readwrite) FIRStorageMetadataType type;
 
 /**
+ * The original metadata representation received from the server.
+ */
+@property(copy, nonatomic) NSDictionary *initialMetadata;
+
+/**
+ * Recursively removes entries in 'metadata' that are unmodified from 'oldMetadata'.
+ * Adds 'NSNull' for entries that only exist in oldMetadata.
+ */
++ (void)removeMatchingMetadata:(NSMutableDictionary *)metadata
+                   oldMetadata:(NSDictionary *)oldMetadata;
+
+/**
+ * Computes the updates between the state at initialization and the current state.
+ * Returns a dictionary with only the updated data. Removed keys are set to NSNull.
+ */
+- (NSDictionary *)updatedMetadata;
+
+/**
  * Returns an RFC3339 formatted date from a string.
  * @param dateString An NSString of the form: yyyy-MM-ddTHH:mm:ss.SSSZ.
  * @return An NSDate populated from the string or nil if conversion isn't possible.


### PR DESCRIPTION
This ports the recent change in Android to the iOS API and allows users to remove custom metadata.

