### PR TITLE
Don't write library version to NSUserDefaults

### DIFF
--- a/Firebase/Messaging/FIRMMessageCode.h
+++ b/Firebase/Messaging/FIRMMessageCode.h
@@ -21,7 +21,7 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingMessageCodeFIRApp000 = 1000,  // I-FCM001000
   kFIRMessagingMessageCodeFIRApp001 = 1001,  // I-FCM001001
   // FIRMessaging.m
-  kFIRMessagingMessageCodeMessaging000 = 2000,  // I-FCM002000
+  kFIRMessagingMessageCodeMessagingPrintLibraryVersion = 2000,  // I-FCM002000
   kFIRMessagingMessageCodeMessaging001 = 2001,  // I-FCM002001
   kFIRMessagingMessageCodeMessaging002 = 2002,  // I-FCM002002 - no longer used
   kFIRMessagingMessageCodeMessaging003 = 2003,  // I-FCM002003

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -187,8 +187,12 @@ NSString * const FIRMessagingRegistrationTokenRefreshedNotification =
 #pragma mark - Config
 
 - (void)start {
+  // Print the library version for logging.
+  NSString *currentLibraryVersion = FIRMessagingCurrentLibraryVersion();
+  FIRMessagingLoggerInfo(kFIRMessagingMessageCodeMessagingPrintLibraryVersion,
+                         @"FIRMessaging library version %@",
+                         currentLibraryVersion);
 
-  [self saveLibraryVersion];
   [self setupReceiver];
 
   NSString *hostname = kFIRMessagingReachabilityHostname;
@@ -242,14 +246,6 @@ NSString * const FIRMessagingRegistrationTokenRefreshedNotification =
              selector:@selector(applicationStateChanged)
                  name:UIApplicationDidEnterBackgroundNotification
                object:nil];
-}
-
-- (void)saveLibraryVersion {
-  NSString *currentLibraryVersion = FIRMessagingCurrentLibraryVersion();
-  [[NSUserDefaults standardUserDefaults] setObject:currentLibraryVersion
-                                            forKey:kFIRMessagingLibraryVersion];
-  FIRMessagingLoggerInfo(kFIRMessagingMessageCodeMessaging000, @"FIRMessaging library version %@",
-                         currentLibraryVersion);
 }
 
 - (void)setupReceiver {

--- a/Firebase/Messaging/FIRMessagingConstants.h
+++ b/Firebase/Messaging/FIRMessagingConstants.h
@@ -42,8 +42,6 @@ FOUNDATION_EXPORT NSString *const kFIRMessagingMessageSyncViaMCSKey;
 FOUNDATION_EXPORT NSString *const kFIRMessagingMessageSyncMessageTTLKey;
 FOUNDATION_EXPORT NSString *const kFIRMessagingMessageLinkKey;
 
-FOUNDATION_EXPORT NSString *const kFIRMessagingLibraryVersion;
-
 FOUNDATION_EXPORT NSString *const kFIRMessagingRemoteNotificationsProxyEnabledInfoPlistKey;
 
 FOUNDATION_EXPORT NSString *const kFIRMessagingApplicationSupportSubDirectory;

--- a/Firebase/Messaging/FIRMessagingConstants.m
+++ b/Firebase/Messaging/FIRMessagingConstants.m
@@ -35,8 +35,6 @@ NSString *const kFIRMessagingMessageSyncViaMCSKey = @"gcm." @"duplex";
 NSString *const kFIRMessagingMessageSyncMessageTTLKey = @"gcm." @"ttl";
 NSString *const kFIRMessagingMessageLinkKey = @"gcm." @"app_link";
 
-NSString *const kFIRMessagingLibraryVersion = @"FIRMessaging-version";
-
 NSString *const kFIRMessagingRemoteNotificationsProxyEnabledInfoPlistKey =
     @"FirebaseAppDelegateProxyEnabled";
 


### PR DESCRIPTION
This seems to be a holdover from some old code, and it's not being used anywhere in the component. Plus it's better not to be saving anything in `[NSUserDefaults standardUserDefaults]` as that is the developer/app's domain.

I kept the printing of the library version to the console, and renamed the messaging code while I was in there to be something meaningful ("000" → "PrintLibraryVersion").