### PR TITLE
Encode the topic name when subscribing

### DIFF
--- a/Firebase/Messaging/FIRMMessageCode.h
+++ b/Firebase/Messaging/FIRMMessageCode.h
@@ -166,6 +166,7 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingMessageCodeTopicOption000 = 17000,  // I-FCM017000
   kFIRMessagingMessageCodeTopicOption001 = 17001,  // I-FCM017001
   kFIRMessagingMessageCodeTopicOption002 = 17002,  // I-FCM017002
+  kFIRMessagingMessageCodeTopicOptionTopicEncodingFailed = 17003,  // I-FCM017003
   // FIRMessagingUtilities.m
   kFIRMessagingMessageCodeUtilities000 = 18000,  // I-FCM018000
   kFIRMessagingMessageCodeUtilities001 = 18001,  // I-FCM018001

--- a/Firebase/Messaging/FIRMessagingTopicOperation.m
+++ b/Firebase/Messaging/FIRMessagingTopicOperation.m
@@ -165,6 +165,11 @@ NSString *FIRMessagingSubscriptionsServer() {
   [request setValue:appIdentifier forHTTPHeaderField:@"app"];
   [request setValue:self.checkinService.versionInfo forHTTPHeaderField:@"info"];
 
+  // Topic can contain special characters (like `%`) so encode the value.
+  NSCharacterSet *characterSet = [NSCharacterSet URLQueryAllowedCharacterSet];
+  NSString *encodedTopic =
+      [self.topic stringByAddingPercentEncodingWithAllowedCharacters:characterSet];
+
   NSMutableString *content = [NSMutableString stringWithFormat:
                               @"sender=%@&app=%@&device=%@&"
                               @"app_ver=%@&X-gcm.topic=%@&X-scope=%@",
@@ -172,8 +177,8 @@ NSString *FIRMessagingSubscriptionsServer() {
                               appIdentifier,
                               deviceAuthID,
                               FIRMessagingCurrentAppVersion(),
-                              self.topic,
-                              self.topic];
+                              encodedTopic,
+                              encodedTopic];
 
   if (self.action == FIRMessagingTopicActionUnsubscribe) {
     [content appendString:@"&delete=true"];

--- a/Firebase/Messaging/FIRMessagingTopicOperation.m
+++ b/Firebase/Messaging/FIRMessagingTopicOperation.m
@@ -169,6 +169,14 @@ NSString *FIRMessagingSubscriptionsServer() {
   NSCharacterSet *characterSet = [NSCharacterSet URLQueryAllowedCharacterSet];
   NSString *encodedTopic =
       [self.topic stringByAddingPercentEncodingWithAllowedCharacters:characterSet];
+  if (encodedTopic == nil) {
+    // The transformation was somehow not possible, so use the original topic.
+    FIRMessagingLoggerWarn(kFIRMessagingMessageCodeTopicOptionTopicEncodingFailed,
+                           @"Unable to encode the topic '%@' during topic subscription change. "
+                           @"Please ensure that the topic name contains only valid characters.",
+                           self.topic);
+    encodedTopic = self.topic;
+  }
 
   NSMutableString *content = [NSMutableString stringWithFormat:
                               @"sender=%@&app=%@&device=%@&"


### PR DESCRIPTION
This should address the issue filed at: https://github.com/firebase/quickstart-ios/issues/242, where a topic name containing a `%` character was failing. It turns out that the topic name was never being url-encoded.