### PR TITLE
Add FirAuthUrlPresenter

### DIFF
--- a/AuthSamples/Samples.xcodeproj/project.pbxproj
+++ b/AuthSamples/Samples.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		52C975C71EE10B1304EBBEB2 /* Pods_SwiftSample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BC8C39EF1F42A0C750FF5186 /* Pods_SwiftSample.framework */; };
 		569C3F4E18627674CABE02AE /* Pods_EarlGreyTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AEE2E563FADF8C3382956B4F /* Pods_EarlGreyTests.framework */; };
 		67AFFB52FF0FC4668D92F2E4 /* Pods_Sample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5FE06BD9AA795DFBA9EFAAD /* Pods_Sample.framework */; };
+		7E04ACA41F565EA900788114 /* FIRAuthURLPresenterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E04ACA31F565EA900788114 /* FIRAuthURLPresenterTests.m */; };
 		7E9969EE1F4E277900627C2B /* FIRGetProjectConfigRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E9969EC1F4E277900627C2B /* FIRGetProjectConfigRequestTests.m */; };
 		7EDFD35B1F0EA29200B29DC5 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7EDFD35D1F0EA29200B29DC5 /* Localizable.strings */; };
 		7EEEFEE61F4E4F75000FF966 /* FIRGetProjectConfigResponseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7EEA8ADD1F4E4E840014A23B /* FIRGetProjectConfigResponseTests.m */; };
@@ -183,6 +184,7 @@
 		4FFAD3F37BC4D7CEF0CAD579 /* Pods_FirebaseAuthUnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FirebaseAuthUnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		57150555A6B03949ECB58AD9 /* Pods-TestApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestApp.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TestApp/Pods-TestApp.debug.xcconfig"; sourceTree = "<group>"; };
 		6EC09307D636721EAAB89BB2 /* Pods_ApiTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ApiTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7E04ACA31F565EA900788114 /* FIRAuthURLPresenterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FIRAuthURLPresenterTests.m; path = ../../Example/Auth/Tests/FIRAuthURLPresenterTests.m; sourceTree = "<group>"; };
 		7E0BC64A1F199D86008BE4E0 /* fr-FR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "fr-FR"; path = "fr-FR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		7E0BC64E1F19A77C008BE4E0 /* ru-RU */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ru-RU"; path = "ru-RU.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		7E9969EC1F4E277900627C2B /* FIRGetProjectConfigRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FIRGetProjectConfigRequestTests.m; path = ../../Example/Auth/Tests/FIRGetProjectConfigRequestTests.m; sourceTree = "<group>"; };
@@ -557,6 +559,7 @@
 				DE5371B21EA7E89D000DA57F /* Tests-Info.plist */,
 				7E9969EC1F4E277900627C2B /* FIRGetProjectConfigRequestTests.m */,
 				7EEA8ADD1F4E4E840014A23B /* FIRGetProjectConfigResponseTests.m */,
+				7E04ACA31F565EA900788114 /* FIRAuthURLPresenterTests.m */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -1332,6 +1335,7 @@
 				DECEA56E1EBBED1200273585 /* FIRAuthAppCredentialManagerTests.m in Sources */,
 				DE5371DE1EA7E89D000DA57F /* OCMStubRecorder+FIRAuthUnitTests.m in Sources */,
 				DE5371DC1EA7E89D000DA57F /* FIRVerifyPhoneNumberRequestTests.m in Sources */,
+				7E04ACA41F565EA900788114 /* FIRAuthURLPresenterTests.m in Sources */,
 				DE5371B51EA7E89D000DA57F /* FIRAuthAppCredentialTests.m in Sources */,
 				DE5371CE1EA7E89D000DA57F /* FIRSetAccountInfoRequestTests.m in Sources */,
 				DE5371D41EA7E89D000DA57F /* FIRVerifyAssertionRequestTests.m in Sources */,

--- a/Example/Auth/Tests/FIRAuthURLPresenterTests.m
+++ b/Example/Auth/Tests/FIRAuthURLPresenterTests.m
@@ -41,25 +41,24 @@ static NSTimeInterval kExpectationTimeout = 1;
   NSURL *presenterURL = [NSURL URLWithString:@"https://presenter.url"];
   FIRAuthURLPresenter *presenter = [[FIRAuthURLPresenter alloc] init];
 
-  XCTestExpectation *callbackMatcherExpectation =
-      [self expectationWithDescription:@"callbackMatcher callback"];
-  FIRAuthURLCallbackMatcher callbackMatcher = ^BOOL(NSURL *_Nonnull callbackURL) {
-    XCTAssertEqualObjects(callbackURL, presenterURL);
-    NSLog(@"callback matcher");
-    [callbackMatcherExpectation fulfill];
-    return YES;
-  };
-
-  XCTestExpectation *completionBlockExpectation =
-      [self expectationWithDescription:@"completion callback"];
-  FIRAuthURLPresentationCompletion completionBlock = ^(NSURL *_Nullable callbackURL,
-                                                       NSError *_Nullable error) {
-    XCTAssertEqualObjects(callbackURL, presenterURL);
-    XCTAssertNil(error);
-    [completionBlockExpectation fulfill];
-  };
-
   if ([SFSafariViewController class]) {
+    XCTestExpectation *callbackMatcherExpectation =
+        [self expectationWithDescription:@"callbackMatcher callback"];
+    FIRAuthURLCallbackMatcher callbackMatcher = ^BOOL(NSURL *_Nonnull callbackURL) {
+      XCTAssertEqualObjects(callbackURL, presenterURL);
+      [callbackMatcherExpectation fulfill];
+      return YES;
+    };
+
+    XCTestExpectation *completionBlockExpectation =
+        [self expectationWithDescription:@"completion callback"];
+    FIRAuthURLPresentationCompletion completionBlock = ^(NSURL *_Nullable callbackURL,
+                                                         NSError *_Nullable error) {
+      XCTAssertEqualObjects(callbackURL, presenterURL);
+      XCTAssertNil(error);
+      [completionBlockExpectation fulfill];
+    };
+
     id presenterArg = [OCMArg isKindOfClass:[SFSafariViewController class]];
     OCMExpect([mockUIDelegate presentViewController:presenterArg
                                            animated:YES
@@ -94,9 +93,8 @@ static NSTimeInterval kExpectationTimeout = 1;
                UIDelegate:mockUIDelegate
           callbackMatcher:callbackMatcher
                completion:completionBlock];
-
     OCMVerifyAll(mockUIDelegate);
-    [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+    [self waitForExpectationsWithTimeout:3 handler:nil];
   }
 }
 
@@ -107,63 +105,65 @@ static NSTimeInterval kExpectationTimeout = 1;
   NSURL *presenterURL = [NSURL URLWithString:@"https://presenter.url"];
   FIRAuthURLPresenter *presenter = [[FIRAuthURLPresenter alloc] init];
 
-  XCTestExpectation *callbackMatcherExpectation =
-      [self expectationWithDescription:@"callbackMatcher callback"];
-  FIRAuthURLCallbackMatcher callbackMatcher = ^BOOL(NSURL *_Nonnull callbackURL) {
-    XCTAssertEqualObjects(callbackURL, presenterURL);
-    [callbackMatcherExpectation fulfill];
-    return YES;
-  };
-
-  XCTestExpectation *completionBlockExpectation =
-      [self expectationWithDescription:@"completion callback"];
-  FIRAuthURLPresentationCompletion completionBlock = ^(NSURL *_Nullable callbackURL,
-                                                       NSError *_Nullable error) {
-    XCTAssertEqualObjects(callbackURL, presenterURL);
-    XCTAssertNil(error);
-    [completionBlockExpectation fulfill];
-  };
-  id mockViewController =
-      OCMPartialMock([UIApplication sharedApplication].keyWindow.rootViewController);
   if ([SFSafariViewController class]) {
-    id presenterArg = [OCMArg isKindOfClass:[SFSafariViewController class]];
-    OCMExpect([mockViewController presentViewController:presenterArg
-                                               animated:[OCMArg any]
-                                             completion:[OCMArg any]]).
-        andDo(^(NSInvocation *invocation) {
-      __unsafe_unretained id unretainedArgument;
-      // Indices 0 and 1 indicate the hidden arguments self and _cmd.
-      // `presentViewController` is at index 2.
-      [invocation getArgument:&unretainedArgument atIndex:2];
-      SFSafariViewController *viewController = unretainedArgument;
-      XCTAssertEqual(viewController.delegate, presenter);
-      id mockedViewController = OCMPartialMock(viewController);
-      OCMExpect([mockedViewController dismissViewControllerAnimated:OCMOCK_ANY
-                                                         completion:OCMOCK_ANY]).
+    XCTestExpectation *callbackMatcherExpectation =
+        [self expectationWithDescription:@"callbackMatcher callback"];
+    FIRAuthURLCallbackMatcher callbackMatcher = ^BOOL(NSURL *_Nonnull callbackURL) {
+      XCTAssertEqualObjects(callbackURL, presenterURL);
+      [callbackMatcherExpectation fulfill];
+      return YES;
+    };
+
+    XCTestExpectation *completionBlockExpectation =
+        [self expectationWithDescription:@"completion callback"];
+    FIRAuthURLPresentationCompletion completionBlock = ^(NSURL *_Nullable callbackURL,
+                                                         NSError *_Nullable error) {
+      XCTAssertEqualObjects(callbackURL, presenterURL);
+      XCTAssertNil(error);
+      [completionBlockExpectation fulfill];
+    };
+    id mockViewController =
+        OCMPartialMock([UIApplication sharedApplication].keyWindow.rootViewController);
+    if ([SFSafariViewController class]) {
+      id presenterArg = [OCMArg isKindOfClass:[SFSafariViewController class]];
+      OCMExpect([mockViewController presentViewController:presenterArg
+                                                 animated:[OCMArg any]
+                                               completion:[OCMArg any]]).
           andDo(^(NSInvocation *invocation) {
         __unsafe_unretained id unretainedArgument;
         // Indices 0 and 1 indicate the hidden arguments self and _cmd.
-        // `completion` is at index 3.
-        [invocation getArgument:&unretainedArgument atIndex:3];
+        // `presentViewController` is at index 2.
+        [invocation getArgument:&unretainedArgument atIndex:2];
+        SFSafariViewController *viewController = unretainedArgument;
+        XCTAssertEqual(viewController.delegate, presenter);
+        id mockedViewController = OCMPartialMock(viewController);
+        OCMExpect([mockedViewController dismissViewControllerAnimated:OCMOCK_ANY
+                                                           completion:OCMOCK_ANY]).
+            andDo(^(NSInvocation *invocation) {
+          __unsafe_unretained id unretainedArgument;
+          // Indices 0 and 1 indicate the hidden arguments self and _cmd.
+          // `completion` is at index 3.
+          [invocation getArgument:&unretainedArgument atIndex:3];
 
-        void (^finishBlock)() = unretainedArgument;
-        finishBlock();
-      });
+          void (^finishBlock)() = unretainedArgument;
+          finishBlock();
+        });
 
-      dispatch_async(dispatch_get_main_queue(), ^{
-        [presenter canHandleURL:presenterURL];
-        OCMVerifyAll(mockedViewController);
+        dispatch_async(dispatch_get_main_queue(), ^{
+          [presenter canHandleURL:presenterURL];
+          OCMVerifyAll(mockedViewController);
+        });
       });
-    });
+    }
+
+    [presenter presentURL:presenterURL
+               UIDelegate:nil
+          callbackMatcher:callbackMatcher
+               completion:completionBlock];
+
+    OCMVerifyAll(mockViewController);
+    [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
   }
-
-  [presenter presentURL:presenterURL
-             UIDelegate:nil
-        callbackMatcher:callbackMatcher
-             completion:completionBlock];
-
-  OCMVerifyAll(mockViewController);
-  [self waitForExpectationsWithTimeout:3 handler:nil];
 }
 
 @end

--- a/Example/Auth/Tests/FIRAuthURLPresenterTests.m
+++ b/Example/Auth/Tests/FIRAuthURLPresenterTests.m
@@ -166,5 +166,4 @@ static NSTimeInterval kExpectationTimeout = 1;
   [self waitForExpectationsWithTimeout:3 handler:nil];
 }
 
-
 @end

--- a/Example/Auth/Tests/FIRAuthURLPresenterTests.m
+++ b/Example/Auth/Tests/FIRAuthURLPresenterTests.m
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <SafariServices/SafariServices.h>
+#import <XCTest/XCTest.h>
+
+#import "FIRAuthURLPresenter.h"
+#import "FIRAuthUIDelegate.h"
+#import <OCMock/OCMock.h>
+
+/** @var kExpectationTimeout
+    @brief The maximum time waiting for expectations to fulfill.
+ */
+static NSTimeInterval kExpectationTimeout = 1;
+
+@interface FIRAuthURLPresenterTests : XCTestCase
+
+@end
+
+@implementation FIRAuthURLPresenterTests
+
+/** @fn testFIRAuthURLPresenterNonNilUIDelegate
+    @brief Tests @c FIRAuthURLPresenter class showing UI with a non-nil UIDelegate.
+ */
+- (void)testFIRAuthURLPresenterNonNilUIDelegate {
+ id mockUIDelegate = OCMProtocolMock(@protocol(FIRAuthUIDelegate));
+  NSURL *presenterURL = [NSURL URLWithString:@"https://presenter.url"];
+  FIRAuthURLPresenter *presenter = [[FIRAuthURLPresenter alloc] init];
+
+  XCTestExpectation *callbackMatcherExpectation =
+      [self expectationWithDescription:@"callbackMatcher callback"];
+  FIRAuthURLCallbackMatcher callbackMatcher = ^BOOL(NSURL *_Nonnull callbackURL) {
+    XCTAssertEqualObjects(callbackURL, presenterURL);
+    NSLog(@"callback matcher");
+    [callbackMatcherExpectation fulfill];
+    return YES;
+  };
+
+  XCTestExpectation *completionBlockExpectation =
+      [self expectationWithDescription:@"completion callback"];
+  FIRAuthURLPresentationCompletion completionBlock = ^(NSURL *_Nullable callbackURL,
+                                                       NSError *_Nullable error) {
+    XCTAssertEqualObjects(callbackURL, presenterURL);
+    XCTAssertNil(error);
+    [completionBlockExpectation fulfill];
+  };
+
+  if ([SFSafariViewController class]) {
+    id presenterArg = [OCMArg isKindOfClass:[SFSafariViewController class]];
+    OCMExpect([mockUIDelegate presentViewController:presenterArg
+                                           animated:YES
+                                         completion:nil]).andDo(^(NSInvocation *invocation) {
+      __unsafe_unretained id unretainedArgument;
+      // Indices 0 and 1 indicate the hidden arguments self and _cmd.
+      // `presentViewController` is at index 2.
+      [invocation getArgument:&unretainedArgument atIndex:2];
+
+      SFSafariViewController *viewController = unretainedArgument;
+      XCTAssertEqual(viewController.delegate, presenter);
+      id mockedViewController = OCMPartialMock(viewController);
+      OCMExpect([mockedViewController dismissViewControllerAnimated:OCMOCK_ANY
+                                                         completion:OCMOCK_ANY]).
+          andDo(^(NSInvocation *invocation) {
+        __unsafe_unretained id unretainedArgument;
+        // Indices 0 and 1 indicate the hidden arguments self and _cmd.
+        // `completion` is at index 3.
+        [invocation getArgument:&unretainedArgument atIndex:3];
+
+        void (^finishBlock)() = unretainedArgument;
+        finishBlock();
+      });
+
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [presenter canHandleURL:presenterURL];
+        OCMVerifyAll(mockedViewController);
+      });
+    });
+
+    [presenter presentURL:presenterURL
+               UIDelegate:mockUIDelegate
+          callbackMatcher:callbackMatcher
+               completion:completionBlock];
+
+    OCMVerifyAll(mockUIDelegate);
+    [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+  }
+}
+
+/** @fn testFIRAuthURLPresenterNilUIDelegate
+    @brief Tests @c FIRAuthURLPresenter class showing UI with a nil UIDelegate.
+ */
+- (void)testFIRAuthURLPresenterNilUIDelegate {
+  NSURL *presenterURL = [NSURL URLWithString:@"https://presenter.url"];
+  FIRAuthURLPresenter *presenter = [[FIRAuthURLPresenter alloc] init];
+
+  XCTestExpectation *callbackMatcherExpectation =
+      [self expectationWithDescription:@"callbackMatcher callback"];
+  FIRAuthURLCallbackMatcher callbackMatcher = ^BOOL(NSURL *_Nonnull callbackURL) {
+    XCTAssertEqualObjects(callbackURL, presenterURL);
+    [callbackMatcherExpectation fulfill];
+    return YES;
+  };
+
+  XCTestExpectation *completionBlockExpectation =
+      [self expectationWithDescription:@"completion callback"];
+  FIRAuthURLPresentationCompletion completionBlock = ^(NSURL *_Nullable callbackURL,
+                                                       NSError *_Nullable error) {
+    XCTAssertEqualObjects(callbackURL, presenterURL);
+    XCTAssertNil(error);
+    [completionBlockExpectation fulfill];
+  };
+  id mockViewController =
+      OCMPartialMock([UIApplication sharedApplication].keyWindow.rootViewController);
+  if ([SFSafariViewController class]) {
+    id presenterArg = [OCMArg isKindOfClass:[SFSafariViewController class]];
+    OCMExpect([mockViewController presentViewController:presenterArg
+                                               animated:[OCMArg any]
+                                             completion:[OCMArg any]]).
+        andDo(^(NSInvocation *invocation) {
+      __unsafe_unretained id unretainedArgument;
+      // Indices 0 and 1 indicate the hidden arguments self and _cmd.
+      // `presentViewController` is at index 2.
+      [invocation getArgument:&unretainedArgument atIndex:2];
+      SFSafariViewController *viewController = unretainedArgument;
+      XCTAssertEqual(viewController.delegate, presenter);
+      id mockedViewController = OCMPartialMock(viewController);
+      OCMExpect([mockedViewController dismissViewControllerAnimated:OCMOCK_ANY
+                                                         completion:OCMOCK_ANY]).
+          andDo(^(NSInvocation *invocation) {
+        __unsafe_unretained id unretainedArgument;
+        // Indices 0 and 1 indicate the hidden arguments self and _cmd.
+        // `completion` is at index 3.
+        [invocation getArgument:&unretainedArgument atIndex:3];
+
+        void (^finishBlock)() = unretainedArgument;
+        finishBlock();
+      });
+
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [presenter canHandleURL:presenterURL];
+        OCMVerifyAll(mockedViewController);
+      });
+    });
+  }
+
+  [presenter presentURL:presenterURL
+             UIDelegate:nil
+        callbackMatcher:callbackMatcher
+             completion:completionBlock];
+
+  OCMVerifyAll(mockViewController);
+  [self waitForExpectationsWithTimeout:3 handler:nil];
+}
+
+
+@end

--- a/Example/Auth/Tests/FIRGetProjectConfigRequestTests.m
+++ b/Example/Auth/Tests/FIRGetProjectConfigRequestTests.m
@@ -87,7 +87,7 @@ static NSString *gAPIHost = @"www.googleapis.com";
                                                    gAPIHost,
                                                    kGetProjectConfigEndPoint,
                                                    kTestAPIKey];
-  XCTAssertTrue([URLString isEqualToString:[request requestURL]]);
+  XCTAssertEqualObjects(URLString, [request requestURL].absoluteString);
 }
 
 @end

--- a/Example/Firebase.xcodeproj/project.pbxproj
+++ b/Example/Firebase.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		79A15731AA31012CD937CF3A /* Pods_Core_Example_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CAD129FFEC477E1129AE6AA1 /* Pods_Core_Example_iOS.framework */; };
 		7A02646DEF386689CCFB9011 /* Pods_Core_Tests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE6C9DD139E1FD21DC0F1082 /* Pods_Core_Tests_iOS.framework */; };
 		7AE9A7433F2BD9A52022AC71 /* Pods_Messaging_Tests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F902A29FA956ADD762F6921 /* Pods_Messaging_Tests_iOS.framework */; };
+		7E9485421F578AC4005A3939 /* FIRAuthURLPresenterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E94853F1F578A9D005A3939 /* FIRAuthURLPresenterTests.m */; };
 		960665EC1C5F7A0E843A354F /* Pods_Database_Tests_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 97768125F45377F35CA86EDC /* Pods_Database_Tests_macOS.framework */; };
 		AFAF36F51EC28C25004BDEE5 /* Shared.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AFAF36F41EC28C25004BDEE5 /* Shared.xcassets */; };
 		AFAF36F61EC28C25004BDEE5 /* Shared.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AFAF36F41EC28C25004BDEE5 /* Shared.xcassets */; };
@@ -739,6 +740,7 @@
 		6F7376F39846E902979416D4 /* Pods_Database_Example_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Database_Example_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6FAA689FDCBD3261300292D5 /* Pods-Database_IntegrationTests_macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Database_IntegrationTests_macOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Database_IntegrationTests_macOS/Pods-Database_IntegrationTests_macOS.debug.xcconfig"; sourceTree = "<group>"; };
 		73B480AA654FC97FA72C6293 /* Pods_Storage_Example_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Storage_Example_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7E94853F1F578A9D005A3939 /* FIRAuthURLPresenterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FIRAuthURLPresenterTests.m; sourceTree = "<group>"; };
 		81E83B5ABAE219234F213B27 /* Pods_Database_Tests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Database_Tests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8496034D8156555C5FCF8F14 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		862CC98282A6123508E8CA49 /* Pods-Database_Example_macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Database_Example_macOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Database_Example_macOS/Pods-Database_Example_macOS.release.xcconfig"; sourceTree = "<group>"; };
@@ -1690,6 +1692,7 @@
 		DE9314F91E86C6FF0083EDBF /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				7E94853F1F578A9D005A3939 /* FIRAuthURLPresenterTests.m */,
 				DE750DB51EB3DD4000A75E47 /* FIRAuthAPNSTokenManagerTests.m */,
 				DE750DB61EB3DD4000A75E47 /* FIRAuthAPNSTokenTests.m */,
 				DE750DB71EB3DD4000A75E47 /* FIRAuthAppCredentialManagerTests.m */,
@@ -4187,6 +4190,7 @@
 				D9B0D4201F578F7200A567C2 /* FIRGetProjectConfigResponseTests.m in Sources */,
 				DE9315711E86C71C0083EDBF /* FIRSetAccountInfoResponseTests.m in Sources */,
 				DE93155F1E86C71C0083EDBF /* FIRAuthTests.m in Sources */,
+				7E9485421F578AC4005A3939 /* FIRAuthURLPresenterTests.m in Sources */,
 				DE750DBD1EB3DD5B00A75E47 /* FIRAuthAPNSTokenTests.m in Sources */,
 				DE0E5BBE1EA7D93500FAA825 /* FIRAuthAppDelegateProxyTests.m in Sources */,
 				DE0E5BBC1EA7D92E00FAA825 /* FIRVerifyClientResponseTests.m in Sources */,

--- a/Example/Firebase.xcodeproj/project.pbxproj
+++ b/Example/Firebase.xcodeproj/project.pbxproj
@@ -285,6 +285,10 @@
 		D0FE8A951ED9CAAE003F6722 /* FIRViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D0FE8A1C1ED9C6D2003F6722 /* FIRViewController.m */; };
 		D0FE8A961ED9CAAE003F6722 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = D0FE8A1D1ED9C6D2003F6722 /* main.m */; };
 		D22080FB4B7F4238FAC548D6 /* Pods_Auth_Tests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CECEF04E3B788FA2FA9B29F1 /* Pods_Auth_Tests_iOS.framework */; };
+		D9B0D41E1F578F6D00A567C2 /* FIRGetProjectConfigRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D92C82C61F578DF000D5EAFF /* FIRGetProjectConfigRequestTests.m */; };
+		D9B0D41F1F578F6E00A567C2 /* FIRGetProjectConfigRequestTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D92C82C61F578DF000D5EAFF /* FIRGetProjectConfigRequestTests.m */; };
+		D9B0D4201F578F7200A567C2 /* FIRGetProjectConfigResponseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D92C82C51F578DF000D5EAFF /* FIRGetProjectConfigResponseTests.m */; };
+		D9B0D4211F578F7300A567C2 /* FIRGetProjectConfigResponseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D92C82C51F578DF000D5EAFF /* FIRGetProjectConfigResponseTests.m */; };
 		DE0E5BBB1EA7D92E00FAA825 /* FIRVerifyClientRequestTest.m in Sources */ = {isa = PBXBuildFile; fileRef = DE0E5BB91EA7D92E00FAA825 /* FIRVerifyClientRequestTest.m */; };
 		DE0E5BBC1EA7D92E00FAA825 /* FIRVerifyClientResponseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DE0E5BBA1EA7D92E00FAA825 /* FIRVerifyClientResponseTests.m */; };
 		DE0E5BBD1EA7D93100FAA825 /* FIRAuthAppCredentialTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DE0E5BB51EA7D91C00FAA825 /* FIRAuthAppCredentialTests.m */; };
@@ -825,6 +829,8 @@
 		D0FE8A8C1ED9C87B003F6722 /* Database_IntegrationTests_macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Database_IntegrationTests_macOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4E15AD159B5F9FD595AD761 /* Pods-Auth_Example_macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Auth_Example_macOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Auth_Example_macOS/Pods-Auth_Example_macOS.debug.xcconfig"; sourceTree = "<group>"; };
 		D8324AEFAEEF81EEDE114E33 /* Pods-Auth_Tests_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Auth_Tests_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Auth_Tests_iOS/Pods-Auth_Tests_iOS.debug.xcconfig"; sourceTree = "<group>"; };
+		D92C82C51F578DF000D5EAFF /* FIRGetProjectConfigResponseTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FIRGetProjectConfigResponseTests.m; sourceTree = "<group>"; };
+		D92C82C61F578DF000D5EAFF /* FIRGetProjectConfigRequestTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FIRGetProjectConfigRequestTests.m; sourceTree = "<group>"; };
 		DAEC0C3CA3C043F584C0D281 /* Pods-Database_IntegrationTests_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Database_IntegrationTests_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Database_IntegrationTests_iOS/Pods-Database_IntegrationTests_iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		DE0E5BB51EA7D91C00FAA825 /* FIRAuthAppCredentialTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FIRAuthAppCredentialTests.m; sourceTree = "<group>"; };
 		DE0E5BB61EA7D91C00FAA825 /* FIRAuthAppDelegateProxyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FIRAuthAppDelegateProxyTests.m; sourceTree = "<group>"; };
@@ -1715,6 +1721,8 @@
 				DE93150C1E86C6FF0083EDBF /* FIRGetAccountInfoResponseTests.m */,
 				DE93150D1E86C6FF0083EDBF /* FIRGetOOBConfirmationCodeRequestTests.m */,
 				DE93150E1E86C6FF0083EDBF /* FIRGetOOBConfirmationCodeResponseTests.m */,
+				D92C82C61F578DF000D5EAFF /* FIRGetProjectConfigRequestTests.m */,
+				D92C82C51F578DF000D5EAFF /* FIRGetProjectConfigResponseTests.m */,
 				DE93150F1E86C6FF0083EDBF /* FIRGitHubAuthProviderTests.m */,
 				DE9315111E86C6FF0083EDBF /* FIRResetPasswordRequestTests.m */,
 				DE9315121E86C6FF0083EDBF /* FIRResetPasswordResponseTests.m */,
@@ -3918,8 +3926,10 @@
 				D01853B11EDAD364003A645C /* FIRSignUpNewUserRequestTests.m in Sources */,
 				D01853B21EDAD364003A645C /* FIRGetAccountInfoResponseTests.m in Sources */,
 				D01853B31EDAD364003A645C /* FIRSetAccountInfoRequestTests.m in Sources */,
+				D9B0D41F1F578F6E00A567C2 /* FIRGetProjectConfigRequestTests.m in Sources */,
 				D01853B41EDAD364003A645C /* FIRAuthAppCredentialTests.m in Sources */,
 				D01853B51EDAD364003A645C /* FIRAuthSerialTaskQueueTests.m in Sources */,
+				D9B0D4211F578F7300A567C2 /* FIRGetProjectConfigResponseTests.m in Sources */,
 				D01853B61EDAD364003A645C /* FIRApp+FIRAuthUnitTests.m in Sources */,
 				D01853B71EDAD364003A645C /* FIRSetAccountInfoResponseTests.m in Sources */,
 				D01853B81EDAD364003A645C /* FIRAuthTests.m in Sources */,
@@ -4131,6 +4141,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9B0D41E1F578F6D00A567C2 /* FIRGetProjectConfigRequestTests.m in Sources */,
 				DE9315691E86C71C0083EDBF /* FIRGetOOBConfirmationCodeResponseTests.m in Sources */,
 				DE9315661E86C71C0083EDBF /* FIRGetAccountInfoRequestTests.m in Sources */,
 				DE9315731E86C71C0083EDBF /* FIRSignUpNewUserResponseTests.m in Sources */,
@@ -4173,6 +4184,7 @@
 				DE0E5BBD1EA7D93100FAA825 /* FIRAuthAppCredentialTests.m in Sources */,
 				DE93155E1E86C71C0083EDBF /* FIRAuthSerialTaskQueueTests.m in Sources */,
 				DE9315581E86C71C0083EDBF /* FIRApp+FIRAuthUnitTests.m in Sources */,
+				D9B0D4201F578F7200A567C2 /* FIRGetProjectConfigResponseTests.m in Sources */,
 				DE9315711E86C71C0083EDBF /* FIRSetAccountInfoResponseTests.m in Sources */,
 				DE93155F1E86C71C0083EDBF /* FIRAuthTests.m in Sources */,
 				DE750DBD1EB3DD5B00A75E47 /* FIRAuthAPNSTokenTests.m in Sources */,

--- a/Firebase/Auth/FirebaseAuth.podspec
+++ b/Firebase/Auth/FirebaseAuth.podspec
@@ -31,6 +31,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
     'Source/**/FIRAuthAPNSTokenType.[mh]',
     'Source/**/FIRAuthAPNSToken.[mh]',
     'Source/**/FIRPhoneAuthCredential.[mh]',
+    'Source/**/FIRAuthDefaultUIDelegate.[mh]',
     'Source/**/FIRPhoneAuthProvider.[mh]'
   s.public_header_files = 'Source/Public/*.h'
   s.preserve_paths =

--- a/Firebase/Auth/Source/FIRAuthDefaultUIDelegate.m
+++ b/Firebase/Auth/Source/FIRAuthDefaultUIDelegate.m
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "FIRAuthUIDelegate.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FIRAuthDefaultUIDelegate : NSObject <FIRAuthUIDelegate>
+/** @fn defaultUIDelegate
+    @brief Unavailable. Please use initWithViewController:
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
+/** @fn initWithViewController:
+    @brief Initializes the instance with a view controller.
+    @param viewController The view controller as the presenting view controller in @c GOIUIDelegate.
+    @return The initialized instance.
+ */
+- (instancetype)initWithViewController:(UIViewController *)viewController NS_DESIGNATED_INITIALIZER;
+@end
+
+@implementation FIRAuthDefaultUIDelegate {
+  /** @var _viewController
+      @brief The presenting view controller.
+   */
+  UIViewController *_viewController;
+}
+
+- (instancetype)initWithViewController:(UIViewController *)viewController {
+  self = [super init];
+  if (self) {
+    _viewController = viewController;
+  }
+  return self;
+}
+
+id<FIRAuthUIDelegate> FIRAuthUIDelegateWithViewController(UIViewController *viewController) {
+  return [[FIRAuthDefaultUIDelegate alloc] initWithViewController:viewController];
+}
+
+- (void)presentViewController:(UIViewController *)viewControllerToPresent
+                     animated:(BOOL)flag
+                   completion:(nullable void (^)(void))completion {
+  [_viewController presentViewController:viewControllerToPresent
+                                animated:flag
+                              completion:completion];
+}
+
+- (void)dismissViewControllerAnimated:(BOOL)flag completion:(nullable void (^)(void))completion {
+  [_viewController dismissViewControllerAnimated:flag completion:completion];
+}
+
++ (id<FIRAuthUIDelegate>)defaultUIDelegate {
+  UIViewController *topViewController =
+      [UIApplication sharedApplication].keyWindow.rootViewController;
+  while (true){
+    if (topViewController.presentedViewController) {
+      topViewController = topViewController.presentedViewController;
+    } else if ([topViewController isKindOfClass:[UINavigationController class]]) {
+      UINavigationController *nav = (UINavigationController *)topViewController;
+      topViewController = nav.topViewController;
+    } else if ([topViewController isKindOfClass:[UITabBarController class]]) {
+      UITabBarController *tab = (UITabBarController *)topViewController;
+      topViewController = tab.selectedViewController;
+    } else {
+      break;
+    }
+  }
+  return FIRAuthUIDelegateWithViewController(topViewController);
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Firebase/Auth/Source/FIRAuthDefaultUIDelegate.m
+++ b/Firebase/Auth/Source/FIRAuthDefaultUIDelegate.m
@@ -49,10 +49,6 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
-id<FIRAuthUIDelegate> FIRAuthUIDelegateWithViewController(UIViewController *viewController) {
-  return [[FIRAuthDefaultUIDelegate alloc] initWithViewController:viewController];
-}
-
 - (void)presentViewController:(UIViewController *)viewControllerToPresent
                      animated:(BOOL)flag
                    completion:(nullable void (^)(void))completion {
@@ -81,7 +77,7 @@ id<FIRAuthUIDelegate> FIRAuthUIDelegateWithViewController(UIViewController *view
       break;
     }
   }
-  return FIRAuthUIDelegateWithViewController(topViewController);
+  return [[FIRAuthDefaultUIDelegate alloc] initWithViewController:topViewController];
 }
 
 @end

--- a/Firebase/Auth/Source/FIRAuthErrorUtils.h
+++ b/Firebase/Auth/Source/FIRAuthErrorUtils.h
@@ -451,6 +451,20 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSError *)captchaCheckFailedErrorWithMessage:(nullable NSString *)message;
 
+/** @fn webContextAlreadyPresentedErrorWithMessage:
+    @brief Constructs an @c NSError with the @c FIRAuthErrorCodeWebContextAlreadyPresented code.
+    @param message Error message from the backend, if any.
+    @return The NSError instance associated with the given FIRAuthError.
+ */
++ (NSError *)webContextAlreadyPresentedErrorWithMessage:(nullable NSString *)message;
+
+/** @fn webContextCancelledErrorWithMessage:
+    @brief Constructs an @c NSError with the @c FIRAuthErrorCodeWebContextCancelledcode.
+    @param message Error message from the backend, if any.
+    @return The NSError instance associated with the given FIRAuthError.
+ */
++ (NSError *)webContextCancelledErrorWithMessage:(nullable NSString *)message;
+
 /** @fn keychainErrorWithFunction:status:
     @brief Constructs an @c NSError with the @c FIRAuthErrorCodeKeychainError code.
     @param keychainFunction The keychain function which was invoked and yielded an unexpected

--- a/Firebase/Auth/Source/FIRAuthErrorUtils.m
+++ b/Firebase/Auth/Source/FIRAuthErrorUtils.m
@@ -345,6 +345,18 @@ static NSString *const kFIRAuthErrorMessageAppNotVerified = @"Firebase could not
 static NSString *const kFIRAuthErrorMessageCaptchaCheckFailed = @"The reCAPTCHA response token "
     "provided is either invalid, expired or already";
 
+/** @var kFIRAuthErrorMessageWebContextAlreadyPresented
+    @brief Message for @c FIRAuthErrorCodeWebContextAlreadyPresented error code.
+ */
+static NSString *const kFIRAuthErrorMessageWebContextAlreadyPresented = @"More than one URL "
+    "cannot be presented at the same time.";
+
+/** @var kFIRAuthErrorMessageWebContextCancelled
+    @brief Message for @c FIRAuthErrorCodeWebContextCancelled error code.
+ */
+static NSString *const kFIRAuthErrorMessageWebContextCancelled = @"The presented URL was "
+    "prematurely closed by the user.";
+
 /** @var kFIRAuthErrorMessageInternalError
     @brief Message for @c FIRAuthErrorCodeInternalError error code.
  */
@@ -455,6 +467,10 @@ static NSString *FIRAuthErrorDescription(FIRAuthErrorCode code) {
       return kFIRAuthErrorMessageAppNotVerified;
     case FIRAuthErrorCodeCaptchaCheckFailed:
       return kFIRAuthErrorMessageCaptchaCheckFailed;
+    case FIRAuthErrorCodeWebContextAlreadyPresented:
+      return kFIRAuthErrorMessageWebContextAlreadyPresented;
+    case FIRAuthErrorCodeWebContextCancelled:
+      return kFIRAuthErrorMessageWebContextCancelled;
   }
 }
 
@@ -562,6 +578,10 @@ static NSString *const FIRAuthErrorCodeString(FIRAuthErrorCode code) {
       return @"ERROR_APP_NOT_VERIFIED";
     case FIRAuthErrorCodeCaptchaCheckFailed:
       return @"ERROR_CAPTCHA_CHECK_FAILED";
+    case FIRAuthErrorCodeWebContextAlreadyPresented:
+      return @"ERROR_WEB_CONTEXT_ALREADY_PRESENTED";
+    case FIRAuthErrorCodeWebContextCancelled:
+      return @"ERROR_WEB_CONTEXT_CANCELLED";
   }
 }
 
@@ -871,6 +891,14 @@ static NSString *const FIRAuthErrorCodeString(FIRAuthErrorCode code) {
 
 + (NSError *)captchaCheckFailedErrorWithMessage:(nullable NSString *)message {
   return [self errorWithCode:FIRAuthInternalErrorCodeCaptchaCheckFailed message:message];
+}
+
++ (NSError *)webContextAlreadyPresentedErrorWithMessage:(nullable NSString *)message {
+  return [self errorWithCode:FIRAuthInternalErrorCodeWebContextAlreadyPresented message:message];
+}
+
++ (NSError *)webContextCancelledErrorWithMessage:(nullable NSString *)message {
+  return [self errorWithCode:FIRAuthInternalErrorCodeWebContextCancelled message:message];
 }
 
 + (NSError *)keychainErrorWithFunction:(NSString *)keychainFunction status:(OSStatus)status {

--- a/Firebase/Auth/Source/FIRAuthErrorUtils.m
+++ b/Firebase/Auth/Source/FIRAuthErrorUtils.m
@@ -354,8 +354,8 @@ static NSString *const kFIRAuthErrorMessageWebContextAlreadyPresented = @"User i
 /** @var kFIRAuthErrorMessageWebContextCancelled
     @brief Message for @c FIRAuthErrorCodeWebContextCancelled error code.
  */
-static NSString *const kFIRAuthErrorMessageWebContextCancelled = @"The user cancelled the sign-in "
-    "flow.";
+static NSString *const kFIRAuthErrorMessageWebContextCancelled = @"The interaction was cancelled "
+    "by the user.";
 
 /** @var kFIRAuthErrorMessageInternalError
     @brief Message for @c FIRAuthErrorCodeInternalError error code.

--- a/Firebase/Auth/Source/FIRAuthErrorUtils.m
+++ b/Firebase/Auth/Source/FIRAuthErrorUtils.m
@@ -348,14 +348,14 @@ static NSString *const kFIRAuthErrorMessageCaptchaCheckFailed = @"The reCAPTCHA 
 /** @var kFIRAuthErrorMessageWebContextAlreadyPresented
     @brief Message for @c FIRAuthErrorCodeWebContextAlreadyPresented error code.
  */
-static NSString *const kFIRAuthErrorMessageWebContextAlreadyPresented = @"More than one URL "
-    "cannot be presented at the same time.";
+static NSString *const kFIRAuthErrorMessageWebContextAlreadyPresented = @"User interaction is "
+    "still ongoing, another view cannot be presented.";
 
 /** @var kFIRAuthErrorMessageWebContextCancelled
     @brief Message for @c FIRAuthErrorCodeWebContextCancelled error code.
  */
-static NSString *const kFIRAuthErrorMessageWebContextCancelled = @"The presented URL was "
-    "prematurely closed by the user.";
+static NSString *const kFIRAuthErrorMessageWebContextCancelled = @"The user cancelled the sign-in "
+    "flow.";
 
 /** @var kFIRAuthErrorMessageInternalError
     @brief Message for @c FIRAuthErrorCodeInternalError error code.

--- a/Firebase/Auth/Source/FIRAuthInternalErrors.h
+++ b/Firebase/Auth/Source/FIRAuthInternalErrors.h
@@ -322,6 +322,17 @@ typedef NS_ENUM(NSInteger, FIRAuthInternalErrorCode) {
   FIRAuthInternalErrorCodeQuotaExceeded =
       FIRAuthPublicErrorCodeFlag | FIRAuthErrorCodeQuotaExceeded,
 
+  /** Indicates that an attempt was made to present a new web context while one was already being
+        presented.
+   */
+  FIRAuthInternalErrorCodeWebContextAlreadyPresented =
+      FIRAuthPublicErrorCodeFlag | FIRAuthErrorCodeWebContextAlreadyPresented,
+
+  /** Indicates that the URL presentation was cancelled prematurely by the user.
+   */
+  FIRAuthInternalErrorCodeWebContextCancelled =
+      FIRAuthPublicErrorCodeFlag | FIRAuthErrorCodeWebContextCancelled,
+
   // The enum values between 17046 and 17051 are reserved and should NOT be used for new error
   // codes.
 

--- a/Firebase/Auth/Source/FIRAuthURLPresenter.h
+++ b/Firebase/Auth/Source/FIRAuthURLPresenter.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+@protocol FIRAuthUIDelegate;
+
+// SFSafariViewController only exists in iOS 9+ SDKs.
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000
+#define HAS_SAFARI_VIEW_CONTROLLER 1
+#endif
+
+/** @typedef FIRAuthURLPresentationCompletion
+    @brief The type of block invoked when the URLPresentation completes.
+    @param callbackURL The callback URL if the presentation ends with a matching callback.
+    @param error The error if the presentation fails to start or ends with an error.
+ */
+typedef void (^FIRAuthURLPresentationCompletion)(NSURL *_Nullable callbackURL,
+                                                 NSError *_Nullable error);
+
+/** @typedef FIRAuthCallbackMatcher
+    @brief The type of block invoked for checking whether a callback URL matches.
+    @param callbackURL The callback URL to check for match.
+    @return Whether or not the specific callback URL matches or not.
+ */
+typedef BOOL (^FIRAuthURLCallbackMatcher)(NSURL * _Nullable callbackURL);
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FIRAuthURLPresenter : NSObject
+
+/** @fn presentURL:UIDelegate:callbackMatcher:completion:
+    @brief Presents an URL to interact with user.
+    @param URL The URL to present.
+    @param UIDelegate The UI delegate to present view controller.
+    @param completion A block to be called either synchronously if the presentation fails to start,
+        or asynchronously in future on an unspecified thread once the presentation finishes.
+ */
+- (void)presentURL:(NSURL *)URL
+        UIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
+   callbackMatcher:(FIRAuthURLCallbackMatcher)callbackMatcher
+        completion:(FIRAuthURLPresentationCompletion)completion;
+
+/** @fn canHandleURL:
+    @brief Determines if a URL was produced by the currently presented URL.
+    @param URL The URL to handle.
+    @return Whether the URL could be handled or not.
+ */
+- (BOOL)canHandleURL:(NSURL *)URL;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Firebase/Auth/Source/FIRAuthURLPresenter.h
+++ b/Firebase/Auth/Source/FIRAuthURLPresenter.h
@@ -16,14 +16,9 @@
 
 #import <Foundation/Foundation.h>
 
-@protocol FIRAuthUIDelegate;
-
-// SFSafariViewController only exists in iOS 9+ SDKs.
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000
-#define HAS_SAFARI_VIEW_CONTROLLER 1
-#endif
-
 NS_ASSUME_NONNULL_BEGIN
+
+@protocol FIRAuthUIDelegate;
 
 /** @typedef FIRAuthURLPresentationCompletion
     @brief The type of block invoked when the URLPresentation completes.

--- a/Firebase/Auth/Source/FIRAuthURLPresenter.h
+++ b/Firebase/Auth/Source/FIRAuthURLPresenter.h
@@ -23,6 +23,8 @@
 #define HAS_SAFARI_VIEW_CONTROLLER 1
 #endif
 
+NS_ASSUME_NONNULL_BEGIN
+
 /** @typedef FIRAuthURLPresentationCompletion
     @brief The type of block invoked when the URLPresentation completes.
     @param callbackURL The callback URL if the presentation ends with a matching callback.
@@ -37,8 +39,6 @@ typedef void (^FIRAuthURLPresentationCompletion)(NSURL *_Nullable callbackURL,
     @return Whether or not the specific callback URL matches or not.
  */
 typedef BOOL (^FIRAuthURLCallbackMatcher)(NSURL * _Nullable callbackURL);
-
-NS_ASSUME_NONNULL_BEGIN
 
 @interface FIRAuthURLPresenter : NSObject
 

--- a/Firebase/Auth/Source/FIRAuthURLPresenter.m
+++ b/Firebase/Auth/Source/FIRAuthURLPresenter.m
@@ -84,18 +84,18 @@ NS_ASSUME_NONNULL_BEGIN
     @param URL The URL to display in the SFSafariViewController or WKWebView.
  */
 - (void)presentWebContextWithController:(id)controller URL:(NSURL *)URL {
-#if HAS_SAFARI_VIEW_CONTROLLER
-   if (_safariViewController) {
-    // Unable to start a new presentation on top of modal SFSVC presentation.
-    _completion(nil, [FIRAuthErrorUtils webContextAlreadyPresentedErrorWithMessage:nil]);
+  if ([SFSafariViewController class]) {
+    if (_safariViewController) {
+      // Unable to start a new presentation on top of modal SFSVC presentation.
+      _completion(nil, [FIRAuthErrorUtils webContextAlreadyPresentedErrorWithMessage:nil]);
+      return;
+    }
+    SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:URL];
+    _safariViewController = safariViewController;
+    _safariViewController.delegate = self;
+    [controller presentViewController:safariViewController animated:YES completion:nil];
     return;
   }
-  SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:URL];
-  _safariViewController = safariViewController;
-  _safariViewController.delegate = self;
-  [controller presentViewController:safariViewController animated:YES completion:nil];
-  return;
-#endif
 }
 
 #pragma mark - SFSafariViewControllerDelegate
@@ -118,17 +118,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)finishPresentationWithURL:(nullable NSURL *)URL
                             error:(nullable NSError *)error {
   FIRAuthURLPresentationCompletion completion = _completion;
-    void (^finishBlock)() = ^() {
-      completion(URL, nil);
-    };
-    _completion = nil;
-#if HAS_SAFARI_VIEW_CONTROLLER
+  void (^finishBlock)() = ^() {
+    completion(URL, nil);
+  };
+  _completion = nil;
+  if ([SFSafariViewController class]) {
     SFSafariViewController *safariViewController = _safariViewController;
     _safariViewController = nil;
     if (safariViewController) {
       [safariViewController dismissViewControllerAnimated:YES completion:finishBlock];
     }
-#endif
+  }
 }
 
 @end

--- a/Firebase/Auth/Source/FIRAuthURLPresenter.m
+++ b/Firebase/Auth/Source/FIRAuthURLPresenter.m
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRAuthURLPresenter.h"
+
+#import "FIRAuthErrorUtils.h"
+
+@import SafariServices;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FIRAuthURLPresenter () <SFSafariViewControllerDelegate>
+@end
+
+@implementation FIRAuthURLPresenter {
+  /** @var _callbackMatcher
+      @brief The callback URL matcher for the current presentation, if one is active.
+   */
+  FIRAuthURLCallbackMatcher _Nullable _callbackMatcher;
+
+  /** @var _safariViewController
+      @brief The SFSafariViewController used for the current presentation, if any.
+   */
+  SFSafariViewController *_Nullable _safariViewController;
+
+  /** @var _completion
+      @brief The completion handler for the current presentaion, if one is active.
+      @remarks This variable is also used as a flag to indicate a presentation is active.
+   */
+  FIRAuthURLPresentationCompletion _Nullable _completion;
+}
+
+- (void)presentURL:(NSURL *)URL
+        UIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
+   callbackMatcher:(FIRAuthURLCallbackMatcher)callbackMatcher
+        completion:(FIRAuthURLPresentationCompletion)completion {
+  _callbackMatcher = callbackMatcher;
+  _completion = completion;
+  // If a UIDelegate is not provided.
+  if (!UIDelegate) {
+    UIViewController *topViewController =
+        [UIApplication sharedApplication].keyWindow.rootViewController;
+    while (true){
+     if (topViewController.presentedViewController) {
+         topViewController = topViewController.presentedViewController;
+     } else if ([topViewController isKindOfClass:[UINavigationController class]]) {
+         UINavigationController *nav = (UINavigationController *)topViewController;
+         topViewController = nav.topViewController;
+     } else if ([topViewController isKindOfClass:[UITabBarController class]]) {
+         UITabBarController *tab = (UITabBarController *)topViewController;
+         topViewController = tab.selectedViewController;
+     } else {
+         break;
+     }
+    }
+    [self presentWebContextWithController:topViewController URL:URL];
+    return;
+  }
+  // If a valid UIDelegate is provided.
+  [self presentWebContextWithController:UIDelegate URL:URL];
+}
+
+- (BOOL)canHandleURL:(NSURL *)URL {
+  if (_callbackMatcher(URL)) {
+    _callbackMatcher = nil;
+    [self finishPresentationWithURL:URL error:nil];
+    return YES;
+  }
+  return NO;
+}
+
+/** @fn presentWebContextWithController:URL:
+    @brief Presents a SFSafariViewController or WKWebView to display the contents of the URL
+        provided.
+    @param controller The controller used to present the SFSafariViewController or WKWebView.
+    @param URL The URL to display in the SFSafariViewController or WKWebView.
+ */
+- (void)presentWebContextWithController:(id)controller URL:(NSURL *)URL {
+#if HAS_SAFARI_VIEW_CONTROLLER
+   if (_safariViewController) {
+    // Unable to start a new presentation on top of modal SFSVC presentation.
+    _completion(nil, [FIRAuthErrorUtils webContextAlreadyPresentedErrorWithMessage:nil]);
+    return;
+  }
+  SFSafariViewController *safariViewController = [[SFSafariViewController alloc] initWithURL:URL];
+  _safariViewController = safariViewController;
+  _safariViewController.delegate = self;
+  [controller presentViewController:safariViewController animated:YES completion:nil];
+  return;
+#endif
+}
+
+#pragma mark - SFSafariViewControllerDelegate
+
+- (void)safariViewControllerDidFinish:(SFSafariViewController *)controller {
+  if (controller == _safariViewController) {
+    _safariViewController = nil;
+    [self finishPresentationWithURL:nil
+                              error:[FIRAuthErrorUtils webContextCancelledErrorWithMessage:nil]];
+  }
+}
+
+#pragma mark - Private methods
+
+/** @fn finishPresentationWithURL:error:
+    @brief Finishes the presentation for a given URL, if any.
+    @param URL The URL to finish presenting.
+    @param error The error with which to finish presenting, if any.
+ */
+- (void)finishPresentationWithURL:(nullable NSURL *)URL
+                            error:(nullable NSError *)error {
+  FIRAuthURLPresentationCompletion completion = _completion;
+    void (^finishBlock)() = ^() {
+      completion(URL, nil);
+    };
+    _completion = nil;
+#if HAS_SAFARI_VIEW_CONTROLLER
+    SFSafariViewController *safariViewController = _safariViewController;
+    _safariViewController = nil;
+    if (safariViewController) {
+      [safariViewController dismissViewControllerAnimated:YES completion:finishBlock];
+    }
+#endif
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Firebase/Auth/Source/FIRAuthURLPresenter.m
+++ b/Firebase/Auth/Source/FIRAuthURLPresenter.m
@@ -17,10 +17,19 @@
 #import "FIRAuthURLPresenter.h"
 
 #import "FIRAuthErrorUtils.h"
+#import "FIRAuthUIDelegate.h"
 
 @import SafariServices;
 
 NS_ASSUME_NONNULL_BEGIN
+
+@interface FIRAuthDefaultUIDelegate : NSObject <FIRAuthUIDelegate>
+/** @fn defaultUIDelegate
+    @brief Returns a default FIRAuthUIDelegate object.
+    @return The default FIRAuthUIDelegate object.
+ */
++ (id<FIRAuthUIDelegate>)defaultUIDelegate;
+@end
 
 @interface FIRAuthURLPresenter () <SFSafariViewControllerDelegate>
 @end
@@ -51,22 +60,8 @@ NS_ASSUME_NONNULL_BEGIN
   _completion = completion;
   // If a UIDelegate is not provided.
   if (!UIDelegate) {
-    UIViewController *topViewController =
-        [UIApplication sharedApplication].keyWindow.rootViewController;
-    while (true){
-     if (topViewController.presentedViewController) {
-         topViewController = topViewController.presentedViewController;
-     } else if ([topViewController isKindOfClass:[UINavigationController class]]) {
-         UINavigationController *nav = (UINavigationController *)topViewController;
-         topViewController = nav.topViewController;
-     } else if ([topViewController isKindOfClass:[UITabBarController class]]) {
-         UITabBarController *tab = (UITabBarController *)topViewController;
-         topViewController = tab.selectedViewController;
-     } else {
-         break;
-     }
-    }
-    [self presentWebContextWithController:topViewController URL:URL];
+    id<FIRAuthUIDelegate> delegate = [FIRAuthDefaultUIDelegate defaultUIDelegate];
+    [self presentWebContextWithController:delegate URL:URL];
     return;
   }
   // If a valid UIDelegate is provided.

--- a/Firebase/Auth/Source/FIRAuthURLPresenter.m
+++ b/Firebase/Auth/Source/FIRAuthURLPresenter.m
@@ -63,14 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
         completion:(FIRAuthURLPresentationCompletion)completion {
   _callbackMatcher = callbackMatcher;
   _completion = completion;
-  _UIDelegate = UIDelegate;
-  // If a UIDelegate is not provided.
-  if (!_UIDelegate) {
-    _UIDelegate = [FIRAuthDefaultUIDelegate defaultUIDelegate];
-    [self presentWebContextWithController:_UIDelegate URL:URL];
-    return;
-  }
-  // If a valid UIDelegate is provided.
+  _UIDelegate = UIDelegate ?: [FIRAuthDefaultUIDelegate defaultUIDelegate];
   [self presentWebContextWithController:_UIDelegate URL:URL];
 }
 

--- a/Firebase/Auth/Source/FIRAuthURLPresenter.m
+++ b/Firebase/Auth/Source/FIRAuthURLPresenter.m
@@ -45,6 +45,11 @@ NS_ASSUME_NONNULL_BEGIN
    */
   SFSafariViewController *_Nullable _safariViewController;
 
+  /** @var _UIDelegate
+      @brief The UIDelegate used to present the SFSafariViewController.
+   */
+  id<FIRAuthUIDelegate> _UIDelegate;
+
   /** @var _completion
       @brief The completion handler for the current presentaion, if one is active.
       @remarks This variable is also used as a flag to indicate a presentation is active.
@@ -58,14 +63,15 @@ NS_ASSUME_NONNULL_BEGIN
         completion:(FIRAuthURLPresentationCompletion)completion {
   _callbackMatcher = callbackMatcher;
   _completion = completion;
+  _UIDelegate = UIDelegate;
   // If a UIDelegate is not provided.
-  if (!UIDelegate) {
-    id<FIRAuthUIDelegate> delegate = [FIRAuthDefaultUIDelegate defaultUIDelegate];
-    [self presentWebContextWithController:delegate URL:URL];
+  if (!_UIDelegate) {
+    _UIDelegate = [FIRAuthDefaultUIDelegate defaultUIDelegate];
+    [self presentWebContextWithController:_UIDelegate URL:URL];
     return;
   }
   // If a valid UIDelegate is provided.
-  [self presentWebContextWithController:UIDelegate URL:URL];
+  [self presentWebContextWithController:_UIDelegate URL:URL];
 }
 
 - (BOOL)canHandleURL:(NSURL *)URL {
@@ -103,6 +109,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)safariViewControllerDidFinish:(SFSafariViewController *)controller {
   if (controller == _safariViewController) {
     _safariViewController = nil;
+    //TODO:Ensure that the SFSafariViewController is actually removed from the screen before
+    //invoking finishPresentationWithURL:error:
     [self finishPresentationWithURL:nil
                               error:[FIRAuthErrorUtils webContextCancelledErrorWithMessage:nil]];
   }
@@ -126,7 +134,7 @@ NS_ASSUME_NONNULL_BEGIN
     SFSafariViewController *safariViewController = _safariViewController;
     _safariViewController = nil;
     if (safariViewController) {
-      [safariViewController dismissViewControllerAnimated:YES completion:finishBlock];
+      [_UIDelegate dismissViewControllerAnimated:YES completion:finishBlock];
     }
   }
 }

--- a/Firebase/Auth/Source/Public/FIRAuthErrors.h
+++ b/Firebase/Auth/Source/Public/FIRAuthErrors.h
@@ -276,6 +276,15 @@ typedef NS_ENUM(NSInteger, FIRAuthErrorCode) {
      */
     FIRAuthErrorCodeCaptchaCheckFailed = 17056,
 
+    /** Indicates that an attempt was made to present a new web context while one was already being
+        presented.
+     */
+    FIRAuthErrorCodeWebContextAlreadyPresented = 17057,
+
+    /** Indicates that the URL presentation was cancelled prematurely by the user.
+     */
+    FIRAuthErrorCodeWebContextCancelled = 17058,
+
     /** Indicates an error occurred while attempting to access the keychain.
      */
     FIRAuthErrorCodeKeychainError = 17995,

--- a/Firebase/Auth/Source/Public/FIRAuthUIDelegate.h
+++ b/Firebase/Auth/Source/Public/FIRAuthUIDelegate.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** @protocol FIRAuthUIDelegate
+    @brief A protocol to handle user interface interactions for Firebase Auth.
+*/
+
+@protocol FIRAuthUIDelegate  <NSObject>
+
+/** @fn presentViewController:animated:completion:
+    @brief If implemented, this method will be invoked when Firebase Auth needs to display a view
+        controller.
+    @param viewControllerToPresent The view controller to be presented.
+    @param flag Decides whether the view controller presentation should be animated or not.
+    @param completion The block to execute after the presentation finishes. This block has no return
+        value and takes no parameters.
+*/
+- (void)presentViewController:(UIViewController *)viewControllerToPresent
+                     animated:(BOOL)flag
+                   completion:(void (^ _Nullable)(void))completion;
+
+/** @fn dismissViewControllerAnimated:completion:
+    @brief If implemented, this method will be invoked when Firebase Auth needs to display a view
+        controller.
+    @param flag Decides whether removing the view controller should be animated or not.
+    @param completion The block to execute after the presentation finishes. This block has no return
+        value and takes no parameters.
+*/
+- (void)dismissViewControllerAnimated:(BOOL)flag completion:(void (^ _Nullable)(void))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Firebase/Messaging/FIRMMessageCode.h
+++ b/Firebase/Messaging/FIRMMessageCode.h
@@ -166,6 +166,7 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingMessageCodeTopicOption000 = 17000,  // I-FCM017000
   kFIRMessagingMessageCodeTopicOption001 = 17001,  // I-FCM017001
   kFIRMessagingMessageCodeTopicOption002 = 17002,  // I-FCM017002
+  kFIRMessagingMessageCodeTopicOptionTopicEncodingFailed = 17003,  // I-FCM017003
   // FIRMessagingUtilities.m
   kFIRMessagingMessageCodeUtilities000 = 18000,  // I-FCM018000
   kFIRMessagingMessageCodeUtilities001 = 18001,  // I-FCM018001

--- a/FirebaseCommunity.podspec
+++ b/FirebaseCommunity.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCommunity'
-  s.version          = '0.1.0'
+  s.version          = '0.1.1'
   s.summary          = 'Firebase Open Source Libraries for iOS.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Adds FIRAuthURLPresenter which allows Firebase Auth to present a URL using SFSafariViewController.  Support for UIWebView will be added in a later diff.