### PR TITLE
Swizzles APNs token error app delegate method for faster turnaround.

### DIFF
--- a/Example/Auth/Tests/FIRAuthAPNSTokenManagerTests.m
+++ b/Example/Auth/Tests/FIRAuthAPNSTokenManagerTests.m
@@ -118,18 +118,20 @@ static const NSTimeInterval kExpectationTimeout = 1;
   // Add first callback, which is yet to be called.
   OCMExpect([_mockApplication registerForRemoteNotifications]);
   __block BOOL firstCallbackCalled = NO;
-  [_manager getTokenWithCallback:^(FIRAuthAPNSToken *_Nullable token) {
+  [_manager getTokenWithCallback:^(FIRAuthAPNSToken *_Nullable token, NSError *_Nullable error) {
     XCTAssertEqualObjects(token.data, _data);
     XCTAssertEqual(token.type, FIRAuthAPNSTokenTypeSandbox);
+    XCTAssertNil(error);
     firstCallbackCalled = YES;
   }];
   XCTAssertFalse(firstCallbackCalled);
 
   // Add second callback, which is yet to be called either.
   __block BOOL secondCallbackCalled = NO;
-  [_manager getTokenWithCallback:^(FIRAuthAPNSToken *_Nullable token) {
+  [_manager getTokenWithCallback:^(FIRAuthAPNSToken *_Nullable token, NSError *_Nullable error) {
     XCTAssertEqualObjects(token.data, _data);
     XCTAssertEqual(token.type, FIRAuthAPNSTokenTypeSandbox);
+    XCTAssertNil(error);
     secondCallbackCalled = YES;
   }];
   XCTAssertFalse(secondCallbackCalled);
@@ -149,9 +151,10 @@ static const NSTimeInterval kExpectationTimeout = 1;
 
   // Add third callback, which should be called back immediately.
   __block BOOL thirdCallbackCalled = NO;
-  [_manager getTokenWithCallback:^(FIRAuthAPNSToken *_Nullable token) {
+  [_manager getTokenWithCallback:^(FIRAuthAPNSToken *_Nullable token, NSError *_Nullable error) {
     XCTAssertEqualObjects(token.data, _data);
     XCTAssertEqual(token.type, FIRAuthAPNSTokenTypeSandbox);
+    XCTAssertNil(error);
     thirdCallbackCalled = YES;
   }];
   XCTAssertTrue(thirdCallbackCalled);
@@ -176,8 +179,9 @@ static const NSTimeInterval kExpectationTimeout = 1;
   // Add callback to time out.
   OCMExpect([_mockApplication registerForRemoteNotifications]);
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
-  [_manager getTokenWithCallback:^(FIRAuthAPNSToken *_Nullable token) {
+  [_manager getTokenWithCallback:^(FIRAuthAPNSToken *_Nullable token, NSError *_Nullable error) {
     XCTAssertNil(token);
+    XCTAssertNil(error);
     [expectation fulfill];
   }];
 
@@ -200,9 +204,10 @@ static const NSTimeInterval kExpectationTimeout = 1;
   [[[_mockApplication expect] ignoringNonObjectArgs] registerForRemoteNotificationTypes:0];
 #pragma clang diagnostic pop
   __block BOOL callbackCalled = NO;
-  [_manager getTokenWithCallback:^(FIRAuthAPNSToken *_Nullable token) {
+  [_manager getTokenWithCallback:^(FIRAuthAPNSToken *_Nullable token, NSError *_Nullable error) {
     XCTAssertEqualObjects(token.data, _data);
     XCTAssertNotEqual(token.type, FIRAuthAPNSTokenTypeUnknown);
+    XCTAssertNil(error);
     callbackCalled = YES;
   }];
   XCTAssertFalse(callbackCalled);

--- a/Example/Auth/Tests/FIRPhoneAuthProviderTests.m
+++ b/Example/Auth/Tests/FIRPhoneAuthProviderTests.m
@@ -274,7 +274,7 @@ static const NSTimeInterval kExpectationTimeout = 1;
       .andCallBlock1(^(FIRAuthNotificationForwardingCallback callback) { callback(YES); });
   OCMExpect([_mockAppCredentialManager credential]).andReturn(nil);
   OCMExpect([_mockAPNSTokenManager getTokenWithCallback:OCMOCK_ANY])
-      .andCallBlock1(^(FIRAuthAPNSTokenCallback callback) { callback(nil); });
+      .andCallBlock1(^(FIRAuthAPNSTokenCallback callback) { callback(nil, nil); });
   // Expect verify client request to the backend wth empty token.
   OCMExpect([_mockBackend verifyClient:[OCMArg any] callback:[OCMArg any]])
       .andCallBlock2(^(FIRVerifyClientRequest *request,
@@ -314,7 +314,7 @@ static const NSTimeInterval kExpectationTimeout = 1;
   FIRAuthAPNSToken *token = [[FIRAuthAPNSToken alloc] initWithData:data
                                                               type:FIRAuthAPNSTokenTypeProd];
   OCMExpect([_mockAPNSTokenManager getTokenWithCallback:OCMOCK_ANY])
-      .andCallBlock1(^(FIRAuthAPNSTokenCallback callback) { callback(token); });
+      .andCallBlock1(^(FIRAuthAPNSTokenCallback callback) { callback(token, nil); });
   // Expect verify client request to the backend.
   OCMExpect([_mockBackend verifyClient:[OCMArg any] callback:[OCMArg any]])
       .andCallBlock2(^(FIRVerifyClientRequest *request,
@@ -417,7 +417,7 @@ static const NSTimeInterval kExpectationTimeout = 1;
   });
 
   OCMExpect([_mockAPNSTokenManager getTokenWithCallback:OCMOCK_ANY])
-      .andCallBlock1(^(FIRAuthAPNSTokenCallback callback) { callback(token); });
+      .andCallBlock1(^(FIRAuthAPNSTokenCallback callback) { callback(token, nil); });
   // Expect verify client request to the backend.
   OCMExpect([_mockBackend verifyClient:[OCMArg any] callback:[OCMArg any]])
       .andCallBlock2(^(FIRVerifyClientRequest *request,
@@ -509,7 +509,7 @@ static const NSTimeInterval kExpectationTimeout = 1;
   });
 
   OCMExpect([_mockAPNSTokenManager getTokenWithCallback:OCMOCK_ANY])
-      .andCallBlock1(^(FIRAuthAPNSTokenCallback callback) { callback(token); });
+      .andCallBlock1(^(FIRAuthAPNSTokenCallback callback) { callback(token, nil); });
   // Expect verify client request to the backend.
   OCMExpect([_mockBackend verifyClient:[OCMArg any] callback:[OCMArg any]])
       .andCallBlock2(^(FIRVerifyClientRequest *request,

--- a/Firebase/Auth/Source/AuthProviders/Phone/FIRPhoneAuthProvider.m
+++ b/Firebase/Auth/Source/AuthProviders/Phone/FIRPhoneAuthProvider.m
@@ -169,7 +169,12 @@ typedef void (^FIRVerifyClientCallback)(FIRAuthAppCredential *_Nullable appCrede
     completion(_auth.appCredentialManager.credential, nil);
     return;
   }
-  [_auth.tokenManager getTokenWithCallback:^(FIRAuthAPNSToken *_Nullable token) {
+  [_auth.tokenManager getTokenWithCallback:^(FIRAuthAPNSToken *_Nullable token,
+                                             NSError *_Nullable error) {
+    if (!token) {
+      completion(nil, [FIRAuthErrorUtils missingAppTokenErrorWithUnderlyingError:error]);
+      return;
+    }
     FIRVerifyClientRequest *request =
         [[FIRVerifyClientRequest alloc] initWithAppToken:token.string
                                                isSandbox:token.type == FIRAuthAPNSTokenTypeSandbox

--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -971,6 +971,12 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
   });
 }
 
+- (void)handleAPNSTokenError:(NSError *)error {
+  dispatch_sync(FIRAuthGlobalWorkQueue(), ^{
+    [_tokenManager cancelWithError:error];
+  });
+}
+
 - (BOOL)canHandleNotification:(NSDictionary *)userInfo {
   __block BOOL result = NO;
   dispatch_sync(FIRAuthGlobalWorkQueue(), ^{

--- a/Firebase/Auth/Source/FIRAuthAPNSTokenManager.h
+++ b/Firebase/Auth/Source/FIRAuthAPNSTokenManager.h
@@ -24,8 +24,11 @@ NS_ASSUME_NONNULL_BEGIN
 /** @typedef FIRAuthAPNSTokenCallback
     @brief The type of block to receive an APNs token.
     @param token The APNs token if one is available.
+    @param error The error happened if any.
+    @remarks Both `token` and `error` being `nil` means the request timed-out.
  */
-typedef void (^FIRAuthAPNSTokenCallback)(FIRAuthAPNSToken *_Nullable token);
+typedef void (^FIRAuthAPNSTokenCallback)(FIRAuthAPNSToken *_Nullable token,
+                                         NSError *_Nullable error);
 
 /** @class FIRAuthAPNSTokenManager
     @brief A class to manage APNs token in memory.
@@ -63,6 +66,12 @@ typedef void (^FIRAuthAPNSTokenCallback)(FIRAuthAPNSToken *_Nullable token);
         becomes available, or when timeout occurs, whichever happens earlier.
  */
 - (void)getTokenWithCallback:(FIRAuthAPNSTokenCallback)callback;
+
+/** @fn cancelWithError:
+    @brief Cancels any pending `getTokenWithCallback:` request.
+    @param error The error to return.
+ */
+- (void)cancelWithError:(NSError *)error;
 
 @end
 

--- a/Firebase/Auth/Source/FIRAuthAppDelegateProxy.h
+++ b/Firebase/Auth/Source/FIRAuthAppDelegateProxy.h
@@ -30,6 +30,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setAPNSToken:(NSData *)token;
 
+/** @fn handleAPNSTokenError:
+    @brief Handles APNs device token error.
+    @param error The APNs device token error.
+ */
+- (void)handleAPNSTokenError:(NSError *)error;
+
 /** @fn canHandleNotification:
     @brief Checks whether the notification can be handled by the receiver, and handles it if so.
     @param notification The notification in question, which will be consumed if returns @c YES.

--- a/Firebase/Auth/Source/FIRAuthAppDelegateProxy.m
+++ b/Firebase/Auth/Source/FIRAuthAppDelegateProxy.m
@@ -82,6 +82,15 @@ static id noop(id object, SEL cmd, ...) {
                                                application:application
           didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
     }];
+    SEL failToRegisterRemoteNotificationSelector =
+        @selector(application:didFailToRegisterForRemoteNotificationsWithError:);
+    [self replaceSelector:failToRegisterRemoteNotificationSelector
+                withBlock:^(id object, UIApplication* application, NSError *error) {
+      [weakSelf object:object
+                                                  selector:failToRegisterRemoteNotificationSelector
+                                               application:application
+          didFailToRegisterForRemoteNotificationsWithError:error];
+    }];
     SEL receiveNotificationSelector = @selector(application:didReceiveRemoteNotification:);
     SEL receiveNotificationWithHandlerSelector =
         @selector(application:didReceiveRemoteNotification:fetchCompletionHandler:);
@@ -196,6 +205,22 @@ static id noop(id object, SEL cmd, ...) {
   if (originalImplementation && originalImplementation != &noop) {
     typedef void (*Implmentation)(id, SEL, UIApplication*, NSData *);
     ((Implmentation)originalImplementation)(object, selector, application, deviceToken);
+  }
+}
+
+- (void)object:(id)object
+                                            selector:(SEL)selector
+                                         application:(UIApplication *)application
+    didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+  if (object == _appDelegate) {
+    for (id<FIRAuthAppDelegateHandler> handler in [self handlers]) {
+      [handler handleAPNSTokenError:error];
+    }
+  }
+  IMP originalImplementation = [self originalImplementationForSelector:selector];
+  if (originalImplementation && originalImplementation != &noop) {
+    typedef void (*Implmentation)(id, SEL, UIApplication*, NSError *);
+    ((Implmentation)originalImplementation)(object, selector, application, error);
   }
 }
 

--- a/Firebase/Auth/Source/FIRAuthAppDelegateProxy.m
+++ b/Firebase/Auth/Source/FIRAuthAppDelegateProxy.m
@@ -219,7 +219,7 @@ static id noop(id object, SEL cmd, ...) {
   }
   IMP originalImplementation = [self originalImplementationForSelector:selector];
   if (originalImplementation && originalImplementation != &noop) {
-    typedef void (*Implmentation)(id, SEL, UIApplication*, NSError *);
+    typedef void (*Implmentation)(id, SEL, UIApplication *, NSError *);
     ((Implmentation)originalImplementation)(object, selector, application, error);
   }
 }

--- a/Firebase/Auth/Source/FIRAuthErrorUtils.h
+++ b/Firebase/Auth/Source/FIRAuthErrorUtils.h
@@ -425,11 +425,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSError *)quotaExceededErrorWithMessage:(nullable NSString *)message;
 
-/** @fn missingAppTokenError
+/** @fn missingAppTokenErrorWithUnderlyingError
     @brief Constructs an @c NSError with the @c FIRAuthErrorCodeMissingAppToken code.
+    @param underlyingError The underlying error, if any.
     @return The NSError instance associated with the given FIRAuthError.
  */
-+ (NSError *)missingAppTokenError;
++ (NSError *)missingAppTokenErrorWithUnderlyingError:(nullable NSError *)underlyingError;
 
 /** @fn notificationNotForwardedError
     @brief Constructs an @c NSError with the @c FIRAuthErrorCodeNotificationNotForwarded code.

--- a/Firebase/Auth/Source/FIRAuthErrorUtils.m
+++ b/Firebase/Auth/Source/FIRAuthErrorUtils.m
@@ -857,8 +857,9 @@ static NSString *const FIRAuthErrorCodeString(FIRAuthErrorCode code) {
   return [self errorWithCode:FIRAuthInternalErrorCodeQuotaExceeded message:message];
 }
 
-+ (NSError *)missingAppTokenError {
-  return [self errorWithCode:FIRAuthInternalErrorCodeMissingAppToken];
++ (NSError *)missingAppTokenErrorWithUnderlyingError:(nullable NSError *)underlyingError {
+  return [self errorWithCode:FIRAuthInternalErrorCodeMissingAppToken
+             underlyingError:underlyingError];
 }
 
 + (NSError *)notificationNotForwardedError {

--- a/Firebase/Auth/Source/RPCs/FIRAuthBackend.m
+++ b/Firebase/Auth/Source/RPCs/FIRAuthBackend.m
@@ -1023,7 +1023,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   }
 
   if ([shortErrorMessage isEqualToString:kMissingAppTokenErrorMessage]) {
-    return [FIRAuthErrorUtils missingAppTokenError];
+    return [FIRAuthErrorUtils missingAppTokenErrorWithUnderlyingError:nil];
   }
 
   if ([shortErrorMessage isEqualToString:kMissingAppCredentialErrorMessage]) {


### PR DESCRIPTION
Also removes the server request in case the token is missing.