### PR TITLE
Removes canHandleURL from FIRAuthInternal

### DIFF
--- a/Example/Auth/Tests/FIRPhoneAuthProviderTests.m
+++ b/Example/Auth/Tests/FIRPhoneAuthProviderTests.m
@@ -314,7 +314,9 @@ static const NSTimeInterval kExpectationTimeout = 1;
       NSMutableString *fakeRedirectURLString =
           [NSMutableString stringWithString:kFakeRedirectURLStringWithoutReCAPTCHAToken];
       [fakeRedirectURLString appendString:kFakeReCAPTCHAToken];
-      [[_mockAuth authURLPresenter] canHandleURL:[NSURL URLWithString:fakeRedirectURLString]];
+
+      OCMExpect([_mockAuth canHandleURL:OCMOCK_ANY]).andReturn([[_mockAuth authURLPresenter]
+          canHandleURL:[NSURL URLWithString:fakeRedirectURLString]]);
     });
     // Expect view controller dismissal by UIDelegate.
     OCMExpect([mockUIDelegate dismissViewControllerAnimated:OCMOCK_ANY completion:OCMOCK_ANY]).

--- a/Example/Auth/Tests/FIRPhoneAuthProviderTests.m
+++ b/Example/Auth/Tests/FIRPhoneAuthProviderTests.m
@@ -314,9 +314,10 @@ static const NSTimeInterval kExpectationTimeout = 1;
       NSMutableString *fakeRedirectURLString =
           [NSMutableString stringWithString:kFakeRedirectURLStringWithoutReCAPTCHAToken];
       [fakeRedirectURLString appendString:kFakeReCAPTCHAToken];
-
-      OCMExpect([_mockAuth canHandleURL:OCMOCK_ANY]).andReturn([[_mockAuth authURLPresenter]
-          canHandleURL:[NSURL URLWithString:fakeRedirectURLString]]);
+      OCMExpect([_mockAuth canHandleURL:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
+        [[_mockAuth authURLPresenter] canHandleURL:[NSURL URLWithString:fakeRedirectURLString]];
+      });
+      [_mockAuth canHandleURL:[NSURL URLWithString:fakeRedirectURLString]];
     });
     // Expect view controller dismissal by UIDelegate.
     OCMExpect([mockUIDelegate dismissViewControllerAnimated:OCMOCK_ANY completion:OCMOCK_ANY]).

--- a/Firebase/Auth/Source/FIRAuth_Internal.h
+++ b/Firebase/Auth/Source/FIRAuth_Internal.h
@@ -124,18 +124,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)signOutByForceWithUserID:(NSString *)userID error:(NSError *_Nullable *_Nullable)error;
 
-/** @fn canHandleURL:
-    @brief Whether the specific URL is handled by @c FIRAuth .
-    @param url The URL received by the application delegate from any of the openURL method.
-    @return Whether or the URL is handled. YES means the URL is for Firebase Auth
-        so the caller should ignore the URL from further processing, and NO means the
-        the URL is for the app (or another libaray) so the caller should continue handling
-        this URL as usual.
-    @remarks If swizzling is disabled, URLs received by the application delegate must be forwarded
-        to this method for phone number auth to work.
- */
-- (BOOL)canHandleURL:(nonnull NSURL *)url;
-
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Removes canHandleURL from FIRAuthInternal and makes small modification to FIRPhoneAuthProvider unit test.
