### PR TITLE
Ensure that FIRLogger functions are compiled as C

### DIFF
--- a/Firebase/Core/Private/FIRLogger.h
+++ b/Firebase/Core/Private/FIRLogger.h
@@ -88,6 +88,10 @@ extern void FIRLogBasic(FIRLoggerLevel level,
 #endif
 );
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 /**
  * The following functions accept the following parameters in order:
  * (required) service name of type FIRLoggerService.
@@ -111,5 +115,9 @@ extern void FIRLogInfo(FIRLoggerService service, NSString *messageCode, NSString
     NS_FORMAT_FUNCTION(3, 4);
 extern void FIRLogDebug(FIRLoggerService service, NSString *messageCode, NSString *message, ...)
     NS_FORMAT_FUNCTION(3, 4);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Wrap the FIRLogger functions in an extern "C" when being compiled as C++.