### PR TITLE
Fixes Auth URL presenter:

### DIFF
--- a/Firebase/Auth/Source/Public/FIRPhoneAuthProvider.h
+++ b/Firebase/Auth/Source/Public/FIRPhoneAuthProvider.h
@@ -90,7 +90,8 @@ FIR_SWIFT_NAME(PhoneAuthProvider)
     @brief Starts the phone number authentication flow by sending a verifcation code to the
         specified phone number.
     @param phoneNumber The phone number to be verified.
-    @param UIDelegate An object used to present the SFSafariViewController.
+    @param UIDelegate An object used to present the SFSafariViewController. The object is retained
+        by this method until the completion block is executed.
     @param completion The callback to be invoked when the verification flow is finished.
     @remarks Possible error codes:
     <ul>


### PR DESCRIPTION
- kinda works on iOS 8-;
- calls back with cancellation error correctly on 'Done' button;
- cleans up upon completion.
