### PR TITLE
Fixing the session identifier for non-default apps

### DIFF
--- a/Firebase/Database/Api/FIRDatabase.m
+++ b/Firebase/Database/Api/FIRDatabase.m
@@ -117,7 +117,7 @@ static const char *FIREBASE_SEMVER = (const char *)STR(FIRDatabase_VERSION);
             // default ("default") instead of the FIRApp default ("[DEFAULT]") so that we
             // preserve the default location used by the legacy Firebase SDK.
             NSString *sessionIdentifier = @"default";
-            if ([FIRApp isDefaultAppConfigured] && app == [FIRApp defaultApp]) {
+            if (![FIRApp isDefaultAppConfigured] || app != [FIRApp defaultApp]) {
                 sessionIdentifier = app.name;
             }
 


### PR DESCRIPTION
This fixes an issue with https://github.com/firebase/firebase-ios-sdk/commit/6e00706604c3452ad44fc401e4195e0462da1db1. 