### PR TITLE
Refactor .travis.yml to only run branch builds for the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ script:
 branches:
   only:
     - master
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,7 @@ script:
   - "! git grep ' $'" # Fail on trailing whitespace
   - ./test.sh
   - pod lib lint FirebaseCommunity.podspec --verbose | tail -40
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
PR builds will be unaffected by this change, but this should free up the build queue for all projects under the firebase org

See same code from https://github.com/firebase/firebase-js-sdk

https://github.com/firebase/firebase-js-sdk/blob/cd49e2b733346c8767ec4182d98be2bbfd6bcf8d/.travis.yml#L46-L48