### PR TITLE
Enable FIRLogger to be weakly linked

### DIFF
--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -233,3 +233,16 @@ FIR_LOGGING_FUNCTION(Info)
 FIR_LOGGING_FUNCTION(Debug)
 
 #undef FIR_MAKE_LOGGER
+
+@implementation FIRLoggerWrapper
+
++(void) FIRLogBasicWrapper:(FIRLoggerLevel)level
+               withService:(FIRLoggerService) service
+                  withCode:(NSString *)messageCode
+               withMessage:(NSString *)message
+                  withArgs:(va_list) args
+{
+  FIRLogBasic(level, service, messageCode, message, args);
+}
+
+@end

--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -236,11 +236,11 @@ FIR_LOGGING_FUNCTION(Debug)
 
 @implementation FIRLoggerWrapper
 
-+(void) FIRLogBasicWrapper:(FIRLoggerLevel)level
-               withService:(FIRLoggerService) service
-                  withCode:(NSString *)messageCode
-               withMessage:(NSString *)message
-                  withArgs:(va_list) args
++(void) logWithLevel:(FIRLoggerLevel)level
+         withService:(FIRLoggerService)service
+            withCode:(NSString *)messageCode
+         withMessage:(NSString *)message
+            withArgs:(va_list) args
 {
   FIRLogBasic(level, service, messageCode, message, args);
 }

--- a/Firebase/Core/Private/FIRLogger.h
+++ b/Firebase/Core/Private/FIRLogger.h
@@ -135,11 +135,11 @@ extern void FIRLogDebug(FIRLoggerService service, NSString *messageCode, NSStrin
  *            string.
  */
 
-+(void) FIRLogBasicWrapper:(FIRLoggerLevel)level
-               withService:(FIRLoggerService)service
-                  withCode:(NSString *)messageCode
-               withMessage:(NSString *)message
-                  withArgs:(va_list)args;
++(void) logWithLevel:(FIRLoggerLevel)level
+         withService:(FIRLoggerService)service
+            withCode:(NSString *)messageCode
+         withMessage:(NSString *)message
+            withArgs:(va_list)args;
 
 @end
 

--- a/Firebase/Core/Private/FIRLogger.h
+++ b/Firebase/Core/Private/FIRLogger.h
@@ -120,4 +120,27 @@ extern void FIRLogDebug(FIRLoggerService service, NSString *messageCode, NSStrin
 } // extern "C"
 #endif // __cplusplus
 
+@interface FIRLoggerWrapper : NSObject
+
+/**
+ * Objective-C wrapper for FIRLogBasic to allow weak linking to FIRLogger
+ * (required) log level (one of the FIRLoggerLevel enum values).
+ * (required) service name of type FIRLoggerService.
+ * (required) message code starting with "I-" which means iOS, followed by a capitalized
+ *            three-character service identifier and a six digit integer message ID that is unique
+ *            within the service.
+ *            An example of the message code is @"I-COR000001".
+ * (required) message string which can be a format string.
+ * (optional) variable arguments list obtained from calling va_start, used when message is a format
+ *            string.
+ */
+
++(void) FIRLogBasicWrapper:(FIRLoggerLevel)level
+               withService:(FIRLoggerService)service
+                  withCode:(NSString *)messageCode
+               withMessage:(NSString *)message
+                  withArgs:(va_list)args;
+
+@end
+
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Add an Objective C wrapper for FIRLoggerBasic so that FIRLogger can be weakly linked.

This will allow FirebaseCommunity to use a recent version of InstanceID