### PR TITLE
Document minimum CocoaPods version for BuildFrameworks

### DIFF
--- a/BuildFrameworks/README.md
+++ b/BuildFrameworks/README.md
@@ -11,6 +11,12 @@ CocoaPods](https://cocoapods.org/pods/Firebase) and
 
 ## Usage
 
+The CocoaPods version must be at least 1.3.1.
+
+```
+$ pod --version
+```
+
 ```
 $ ./build.swift -f FirebaseAuth -f FirebaseMessaging ....
 ```


### PR DESCRIPTION
To help avoid  #271