### PR TITLE
Fix app launch MCS connection issue

### DIFF
--- a/Firebase/Messaging/FIRMessagingClient.m
+++ b/Firebase/Messaging/FIRMessagingClient.m
@@ -17,6 +17,7 @@
 #import "FIRMessagingClient.h"
 
 #import "FIRMessagingConnection.h"
+#import "FIRMessagingConstants.h"
 #import "FIRMessagingDataMessageManager.h"
 #import "FIRMessagingDefines.h"
 #import "FIRMessagingLogger.h"
@@ -117,6 +118,11 @@ static NSUInteger FIRMessagingServerPort() {
     _rmq2Manager = rmq2Manager;
     _registrar = [[FIRMessagingRegistrar alloc] init];
     _connectionTimeoutInterval = kConnectTimeoutInterval;
+    // Listen for checkin fetch notifications, as
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(checkinFetched:)
+                                                 name:kFIRMessagingCheckinFetchedNotification
+                                               object:nil];
   }
   return self;
 }
@@ -135,6 +141,8 @@ static NSUInteger FIRMessagingServerPort() {
 
   _FIRMessagingDevAssert(self.connection.state == kFIRMessagingConnectionNotConnected, @"Did not disconnect");
   [NSObject cancelPreviousPerformRequestsWithTarget:self];
+
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (void)cancelAllRequests {
@@ -273,12 +281,15 @@ static NSUInteger FIRMessagingServerPort() {
 
   if (!isRegistrationComplete) {
     if (![self.registrar tryToLoadValidCheckinInfo]) {
+      // Checkin info is not available. This may be due to the checkin still being fetched.
       if (self.connectHandler) {
         NSError *error = [NSError errorWithFCMErrorCode:kFIRMessagingErrorCodeMissingDeviceID];
         self.connectHandler(error);
       }
       FIRMessagingLoggerDebug(kFIRMessagingMessageCodeClient009,
                               @"Failed to connect to MCS. No deviceID and secret found.");
+      // Return for now. If checkin is, in fact, retrieved, the
+      // |kFIRMessagingCheckinFetchedNotification| will be fired.
       return;
     }
   }
@@ -316,6 +327,14 @@ static NSUInteger FIRMessagingServerPort() {
   self.connectHandler = nil;
 }
 
+#pragma mark - Checkin Notification
+- (void)checkinFetched:(NSNotification *)notification {
+  // A failed checkin may have been the reason for the connection failure. Attempt a connection
+  // if the checkin fetched notification is fired.
+  if (self.stayConnected && !self.isConnected) {
+    [self connect];
+  }
+}
 
 #pragma mark - Messages
 
@@ -465,9 +484,10 @@ static NSUInteger FIRMessagingServerPort() {
     FIRMessagingConnectCompletionHandler handler = [self.connectHandler copy];
     // disconnect before issuing a callback
     [self disconnectWithTryToConnectLater:YES];
-    NSError *error = [NSError errorWithDomain:@"No internet available, cannot connect to FIRMessaging"
-                                         code:kFIRMessagingErrorCodeNetwork
-                                     userInfo:nil];
+    NSError *error =
+        [NSError errorWithDomain:@"No internet available, cannot connect to FIRMessaging"
+                            code:kFIRMessagingErrorCodeNetwork
+                        userInfo:nil];
     if (handler) {
       handler(error);
       self.connectHandler = nil;

--- a/Firebase/Messaging/FIRMessagingClient.m
+++ b/Firebase/Messaging/FIRMessagingClient.m
@@ -118,7 +118,8 @@ static NSUInteger FIRMessagingServerPort() {
     _rmq2Manager = rmq2Manager;
     _registrar = [[FIRMessagingRegistrar alloc] init];
     _connectionTimeoutInterval = kConnectTimeoutInterval;
-    // Listen for checkin fetch notifications, as
+    // Listen for checkin fetch notifications, as connecting to MCS may have failed due to
+    // missing checkin info (while it was being fetched).
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(checkinFetched:)
                                                  name:kFIRMessagingCheckinFetchedNotification

--- a/Firebase/Messaging/FIRMessagingConstants.h
+++ b/Firebase/Messaging/FIRMessagingConstants.h
@@ -47,6 +47,7 @@ FOUNDATION_EXPORT NSString *const kFIRMessagingRemoteNotificationsProxyEnabledIn
 FOUNDATION_EXPORT NSString *const kFIRMessagingApplicationSupportSubDirectory;
 
 // Notifications
+FOUNDATION_EXPORT NSString *const kFIRMessagingCheckinFetchedNotification;
 FOUNDATION_EXPORT NSString *const kFIRMessagingAPNSTokenNotification;
 FOUNDATION_EXPORT NSString *const kFIRMessagingFCMTokenNotification;
 FOUNDATION_EXPORT NSString *const kFIRMessagingInstanceIDTokenRefreshNotification __deprecated_msg("Use kFIRMessagingRegistrationTokenRefreshNotification instead");

--- a/Firebase/Messaging/FIRMessagingConstants.m
+++ b/Firebase/Messaging/FIRMessagingConstants.m
@@ -41,6 +41,7 @@ NSString *const kFIRMessagingRemoteNotificationsProxyEnabledInfoPlistKey =
 NSString *const kFIRMessagingApplicationSupportSubDirectory = @"Google/FirebaseMessaging";
 
 // Notifications
+NSString *const kFIRMessagingCheckinFetchedNotification = @"com.google.gcm.notif-checkin-fetched";
 NSString *const kFIRMessagingAPNSTokenNotification = @"com.firebase.iid.notif.apns-token";
 NSString *const kFIRMessagingFCMTokenNotification = @"com.firebase.iid.notif.fcm-token";
 NSString *const kFIRMessagingInstanceIDTokenRefreshNotification =


### PR DESCRIPTION
This fixes a bug in the automatic direct channel logic, where a failure to get checkin info from the Instance ID SDK was resulting in a non-retrying failure, causing the automatic connection logic to not retry connecting. Checkin info is fetched once every 24 hours (since the last time the app was launched).

A listener is added for a new notification that will be fired from Instance ID. When that notification is fired, `FIRMessagingClient` will re-attempt to connect.