### PR TITLE
Swizzle additional user notifications method, and only swizzle if methods are implemented

### DIFF
--- a/Example/Messaging/App/iOS/NotificationsController.swift
+++ b/Example/Messaging/App/iOS/NotificationsController.swift
@@ -121,7 +121,6 @@ class NotificationsController: NSObject {
 // MARK: - UNUserNotificationCenterDelegate
 @available(iOS 10.0, *)
 extension NotificationsController: UNUserNotificationCenterDelegate {
-
   func userNotificationCenter(_ center: UNUserNotificationCenter,
                               willPresent notification: UNNotification,
                               withCompletionHandler completionHandler:
@@ -131,5 +130,12 @@ extension NotificationsController: UNUserNotificationCenterDelegate {
     let jsonString = notification.request.content.userInfo.jsonString ?? "{}"
     print("\(jsonString)")
     completionHandler([.alert, .badge, .sound])
+  }
+
+  func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+    print("Received notification response")
+    let jsonString = response.notification.request.content.userInfo.jsonString ?? "{}"
+    print("\(jsonString)")
+    completionHandler()
   }
 }


### PR DESCRIPTION
FCM's swizzling of the user notification center currently swizzles only one of the two optional delegate methods (`userNotificationCenter:willPresentNotification:withCompletionHandler:`), but not the other (`userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:`).

The `didReceiveNotificationResponse`, if implemented by the delegate, is the sole receiver of _all_ user action on a notification, including simply tapping on the notification itself. Prior to this change, if the developer had implemented `didReceiveNotificationResponse`, then FCM would not be able to collect this event for analytics.

Additionally, I changed the logic in `FIRMessagingRemoteNotificationsProxy` to check whether these methods are actually implemented before swizzling them. It was always swizzling, which meant it was adding an implementation if the method didn't exist. This would confuse iOS into thinking the developer did implement these methods and _NOT_ fall back to delivering the notifications to the application delegate.

With this change, if the developer did not implement these methods, then FCM will not swizzle those methods. That keeps the behavior true to what the developer intended.