### PR TITLE
Add an NS_SWIFT_NAME for FIRSnapshotMetadata

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,2 +1,5 @@
+# Unreleased
+- [fixed] Add an NS_SWIFT_NAME for FIRSnapshotMetadata
+
 # 2017-10-03 -- v0.8.0
 - Initial public release.

--- a/Firestore/Example/SwiftBuildTest/main.swift
+++ b/Firestore/Example/SwiftBuildTest/main.swift
@@ -275,10 +275,23 @@ func transactions() {
 
 func types() {
     // Just highlighting the types of everything, though devs can/will often omit them.
-    let _: Firestore;
+    // This list comes from:
+    //
+    //   grep -r ^FIR_SWIFT_NAME Firestore/Source/Public | sed 's/.*(/let _: /; s/)/;/'
     let _: CollectionReference;
+    let _: DocumentChange;
+    let _: DocumentListenOptions;
     let _: DocumentReference;
-    let _: Query;
     let _: DocumentSnapshot;
+    let _: FieldPath;
+    let _: FieldValue;
+    let _: Firestore;
+    let _: FirestoreSettings;
+    let _: GeoPoint;
+    let _: QueryListenOptions;
+    let _: Query;
     let _: QuerySnapshot;
+    let _: SnapshotMetadata;
+    let _: Transaction;
+    let _: WriteBatch;
 }

--- a/Firestore/Source/Public/FIRSnapshotMetadata.h
+++ b/Firestore/Source/Public/FIRSnapshotMetadata.h
@@ -16,9 +16,12 @@
 
 #import <Foundation/Foundation.h>
 
+#import "FIRFirestoreSwiftNameSupport.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /** Metadata about a snapshot, describing the state of the snapshot. */
+FIR_SWIFT_NAME(SnapshotMetadata)
 @interface FIRSnapshotMetadata : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;


### PR DESCRIPTION
Fixes b/67332554

Note that this is a breaking change for Swift users of the API.