### PR TITLE
Adding NS_SWIFT_NAME for FIRListenerRegistration

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [fixed] Add an NS_SWIFT_NAME for FIRSnapshotMetadata
+- [fixed] Add an NS_SWIFT_NAME for FIRSnapshotMetadata and FIRListenerRegistration
 
 # 2017-10-03 -- v0.8.0
 - Initial public release.

--- a/Firestore/Example/SwiftBuildTest/main.swift
+++ b/Firestore/Example/SwiftBuildTest/main.swift
@@ -292,6 +292,7 @@ func types() {
     let _: QueryListenOptions;
     let _: Query;
     let _: QuerySnapshot;
+    let _: SetOptions;
     let _: SnapshotMetadata;
     let _: Transaction;
     let _: WriteBatch;

--- a/Firestore/Example/SwiftBuildTest/main.swift
+++ b/Firestore/Example/SwiftBuildTest/main.swift
@@ -274,10 +274,6 @@ func transactions() {
 }
 
 func types() {
-    // Just highlighting the types of everything, though devs can/will often omit them.
-    // This list comes from:
-    //
-    //   grep -r ^FIR_SWIFT_NAME Firestore/Source/Public | sed 's/.*(/let _: /; s/)/;/'
     let _: CollectionReference;
     let _: DocumentChange;
     let _: DocumentListenOptions;

--- a/Firestore/Example/SwiftBuildTest/main.swift
+++ b/Firestore/Example/SwiftBuildTest/main.swift
@@ -288,6 +288,7 @@ func types() {
     let _: Firestore;
     let _: FirestoreSettings;
     let _: GeoPoint;
+    let _: ListenerRegistration;
     let _: QueryListenOptions;
     let _: Query;
     let _: QuerySnapshot;

--- a/Firestore/Source/Public/FIRListenerRegistration.h
+++ b/Firestore/Source/Public/FIRListenerRegistration.h
@@ -16,9 +16,12 @@
 
 #import <Foundation/Foundation.h>
 
+#import "FIRFirestoreSwiftNameSupport.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /** Represents a listener that can be removed by calling remove. */
+FIR_SWIFT_NAME(ListenerRegistration)
 @protocol FIRListenerRegistration <NSObject>
 
 /**

--- a/Firestore/Source/Public/FIRSetOptions.h
+++ b/Firestore/Source/Public/FIRSetOptions.h
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import "FIRFirestoreSwiftNameSupport.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -24,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
  * `FIRWriteBatch` and `FIRTransaction` can be configured to perform granular merges instead
  * of overwriting the target documents in their entirety.
  */
-NS_SWIFT_NAME(SetOptions)
+FIR_SWIFT_NAME(SetOptions)
 @interface FIRSetOptions : NSObject
 
 /**   */


### PR DESCRIPTION
Adding the last missing NS_SWIFT_NAME. This, along with https://github.com/firebase/firebase-ios-sdk/commit/4dd7ec8e4d6243820d4f877ccfd76c5b4a076dd5, is a breaking change.