### PR TITLE
Fix a warning that shows up in Xcode 9

### DIFF
--- a/Firebase/Core/Private/FIRAppInternal.h
+++ b/Firebase/Core/Private/FIRAppInternal.h
@@ -99,7 +99,7 @@ typedef void (^FIRAppGetTokenImplementation)(BOOL forceRefresh, FIRTokenCallback
 /** @typedef FIRAppGetUID
     @brief The type of block which can provide an implementation for the @c getUID method.
  */
-typedef NSString *_Nullable (^FIRAppGetUIDImplementation)();
+typedef NSString *_Nullable (^FIRAppGetUIDImplementation)(void);
 
 @interface FIRApp ()
 


### PR DESCRIPTION
See https://stackoverflow.com/questions/44473146/this-function-declaration-is-not-a-prototype-warning-in-xcode-9 for context