### PR TITLE
Release listener references on remove in FSTListenerRegistration

### DIFF
--- a/Firestore/Source/API/FIRListenerRegistration.m
+++ b/Firestore/Source/API/FIRListenerRegistration.m
@@ -50,6 +50,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)remove {
   [self.asyncListener mute];
   [self.client removeListener:self.internalListener];
+    _internalListener = nil;
+    _asyncListener = nil;
 }
 
 @end

--- a/Firestore/Source/API/FIRListenerRegistration.m
+++ b/Firestore/Source/API/FIRListenerRegistration.m
@@ -50,8 +50,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)remove {
   [self.asyncListener mute];
   [self.client removeListener:self.internalListener];
-    _internalListener = nil;
-    _asyncListener = nil;
+  _internalListener = nil;
+  _asyncListener = nil;
 }
 
 @end


### PR DESCRIPTION
When the listener registration holds references to the internal listener and async listener, getting a Firestore document creates a retain cycle that shows up in the Xcode Memory Graph. Setting them to nil when the listener is removed should break the cycle.
