### PR TITLE
Fix warnings exposed by Xcode 9.1 in Auth

### DIFF
--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -892,7 +892,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
   });
 }
 
-- (BOOL)signOut:(NSError *_Nullable *_Nullable)error {
+- (BOOL)signOut:(NSError *_Nullable __autoreleasing *_Nullable)error {
   __block BOOL result = YES;
   dispatch_sync(FIRAuthGlobalWorkQueue(), ^{
     if (!_currentUser) {

--- a/Firebase/Auth/Source/FIRAuthGlobalWorkQueue.h
+++ b/Firebase/Auth/Source/FIRAuthGlobalWorkQueue.h
@@ -26,6 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
         implementations that may involve contested code shall dispatch to this work queue as the
         first thing they do.
  */
-extern dispatch_queue_t FIRAuthGlobalWorkQueue();
+extern dispatch_queue_t FIRAuthGlobalWorkQueue(void);
 
 NS_ASSUME_NONNULL_END

--- a/Firebase/Auth/Source/FIRAuthURLPresenter.m
+++ b/Firebase/Auth/Source/FIRAuthURLPresenter.m
@@ -157,7 +157,7 @@ NS_ASSUME_NONNULL_BEGIN
   _UIDelegate = nil;
   FIRAuthURLPresentationCompletion completion = _completion;
   _completion = nil;
-  void (^finishBlock)() = ^() {
+  void (^finishBlock)(void) = ^() {
     _isPresenting = NO;
     completion(URL, error);
   };

--- a/Firebase/Core/FIRAppAssociationRegistration.m
+++ b/Firebase/Core/FIRAppAssociationRegistration.m
@@ -20,7 +20,7 @@
 
 + (nullable id)registeredObjectWithHost:(id)host
                                     key:(NSString *)key
-                          creationBlock:(id _Nullable (^)())creationBlock {
+                          creationBlock:(id _Nullable (^)(void))creationBlock {
   @synchronized(self) {
     SEL dictKey = @selector(registeredObjectWithHost:key:creationBlock:);
     NSMutableDictionary<NSString *, id> *objectsByKey = objc_getAssociatedObject(host, dictKey);

--- a/Firebase/Core/Private/FIRAppAssociationRegistration.h
+++ b/Firebase/Core/Private/FIRAppAssociationRegistration.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable ObjectType)registeredObjectWithHost:(id)host
                                             key:(NSString *)key
-                                  creationBlock:(ObjectType _Nullable (^)())creationBlock;
+                                  creationBlock:(ObjectType _Nullable (^)(void))creationBlock;
 
 @end
 


### PR DESCRIPTION
Removes new Xcode warnings in XCode 9.1 and still builds and runs on unit tests in Xcode 8.3

Warnings related to using iOS 9+ APIs remain.