### PR TITLE
Add void's to eliminate Xcode 9.1 warnings in FCM

### DIFF
--- a/Firebase/Messaging/FIRMessagingLogger.h
+++ b/Firebase/Messaging/FIRMessagingLogger.h
@@ -64,4 +64,4 @@
  *
  * @return the shared FIRMessagingLogger instance
  */
-FIRMessagingLogger *FIRMessagingSharedLogger();
+FIRMessagingLogger *FIRMessagingSharedLogger(void);

--- a/Firebase/Messaging/FIRMessagingLogger.m
+++ b/Firebase/Messaging/FIRMessagingLogger.m
@@ -82,7 +82,7 @@
 
 @end
 
-FIRMessagingLogger *FIRMessagingSharedLogger() {
+FIRMessagingLogger *FIRMessagingSharedLogger(void) {
   static dispatch_once_t onceToken;
   static FIRMessagingLogger *logger;
   dispatch_once(&onceToken, ^{

--- a/Firebase/Messaging/FIRMessagingRemoteNotificationsProxy.m
+++ b/Firebase/Messaging/FIRMessagingRemoteNotificationsProxy.m
@@ -509,7 +509,7 @@ void FCM_swizzle_willPresentNotificationWithHandler(
   FIRMessagingRemoteNotificationsProxy *proxy = [FIRMessagingRemoteNotificationsProxy sharedProxy];
   IMP original_imp = [proxy originalImplementationForSelector:_cmd];
 
-  void (^callOriginalMethodIfAvailable)() = ^{
+  void (^callOriginalMethodIfAvailable)(void) = ^{
     if (original_imp) {
       ((void (*)(id, SEL, id, id, void (^)(NSUInteger)))original_imp)(
           self, _cmd, center, notification, handler);
@@ -569,12 +569,12 @@ void FCM_swizzle_willPresentNotificationWithHandler(
  * parameter types from the swizzling implementation.
  */
 void FCM_swizzle_didReceiveNotificationResponseWithHandler(
-    id self, SEL _cmd, id center, id response, void (^handler)()) {
+    id self, SEL _cmd, id center, id response, void (^handler)(void)) {
 
   FIRMessagingRemoteNotificationsProxy *proxy = [FIRMessagingRemoteNotificationsProxy sharedProxy];
   IMP original_imp = [proxy originalImplementationForSelector:_cmd];
 
-  void (^callOriginalMethodIfAvailable)() = ^{
+  void (^callOriginalMethodIfAvailable)(void) = ^{
     if (original_imp) {
       ((void (*)(id, SEL, id, id, void (^)(void)))original_imp)(
           self, _cmd, center, response, handler);

--- a/Firebase/Messaging/FIRMessagingUtilities.h
+++ b/Firebase/Messaging/FIRMessagingUtilities.h
@@ -43,12 +43,12 @@ FOUNDATION_EXPORT void FIRMessagingSetLastStreamId(GPBMessage *proto, int sid);
 
 #pragma mark - Time
 
-FOUNDATION_EXPORT int64_t FIRMessagingCurrentTimestampInSeconds();
-FOUNDATION_EXPORT int64_t FIRMessagingCurrentTimestampInMilliseconds();
+FOUNDATION_EXPORT int64_t FIRMessagingCurrentTimestampInSeconds(void);
+FOUNDATION_EXPORT int64_t FIRMessagingCurrentTimestampInMilliseconds(void);
 
 #pragma mark - App Info
 
-FOUNDATION_EXPORT NSString *FIRMessagingCurrentAppVersion();
-FOUNDATION_EXPORT NSString *FIRMessagingAppIdentifier();
+FOUNDATION_EXPORT NSString *FIRMessagingCurrentAppVersion(void);
+FOUNDATION_EXPORT NSString *FIRMessagingAppIdentifier(void);
 
-FOUNDATION_EXPORT uint64_t FIRMessagingGetFreeDiskSpaceInMB();
+FOUNDATION_EXPORT uint64_t FIRMessagingGetFreeDiskSpaceInMB(void);

--- a/Firebase/Messaging/FIRMessagingUtilities.m
+++ b/Firebase/Messaging/FIRMessagingUtilities.m
@@ -127,17 +127,17 @@ void FIRMessagingSetLastStreamId(GPBMessage *proto, int sid) {
 
 #pragma mark - Time
 
-int64_t FIRMessagingCurrentTimestampInSeconds() {
+int64_t FIRMessagingCurrentTimestampInSeconds(void) {
   return (int64_t)[[NSDate date] timeIntervalSince1970];
 }
 
-int64_t FIRMessagingCurrentTimestampInMilliseconds() {
+int64_t FIRMessagingCurrentTimestampInMilliseconds(void) {
   return (int64_t)(FIRMessagingCurrentTimestampInSeconds() * 1000.0);
 }
 
 #pragma mark - App Info
 
-NSString *FIRMessagingCurrentAppVersion() {
+NSString *FIRMessagingCurrentAppVersion(void) {
   NSString *version = [[NSBundle mainBundle] infoDictionary][@"CFBundleShortVersionString"];
   if (![version length]) {
     FIRMessagingLoggerError(kFIRMessagingMessageCodeUtilities000,
@@ -147,11 +147,11 @@ NSString *FIRMessagingCurrentAppVersion() {
   return version;
 }
 
-NSString *FIRMessagingAppIdentifier() {
+NSString *FIRMessagingAppIdentifier(void) {
   return [[NSBundle mainBundle] bundleIdentifier];
 }
 
-uint64_t FIRMessagingGetFreeDiskSpaceInMB() {
+uint64_t FIRMessagingGetFreeDiskSpaceInMB(void) {
   NSError *error;
   NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
 

--- a/Firebase/Messaging/FIRMessagingVersionUtilities.h
+++ b/Firebase/Messaging/FIRMessagingVersionUtilities.h
@@ -24,12 +24,12 @@
  *  Some example semantic versions are 1.0.1, 2.1.0, 2.1.1, 2.2.0-alpha1, 2.2.1-beta1
  */
 
-FOUNDATION_EXPORT NSString *FIRMessagingCurrentLibraryVersion();
+FOUNDATION_EXPORT NSString *FIRMessagingCurrentLibraryVersion(void);
 /// Returns the current Major version of FIRMessaging library.
-FOUNDATION_EXPORT int FIRMessagingCurrentLibraryVersionMajor();
+FOUNDATION_EXPORT int FIRMessagingCurrentLibraryVersionMajor(void);
 /// Returns the current Minor version of FIRMessaging library.
-FOUNDATION_EXPORT int FIRMessagingCurrentLibraryVersionMinor();
+FOUNDATION_EXPORT int FIRMessagingCurrentLibraryVersionMinor(void);
 /// Returns the current Patch version of FIRMessaging library.
-FOUNDATION_EXPORT int FIRMessagingCurrentLibraryVersionPatch();
+FOUNDATION_EXPORT int FIRMessagingCurrentLibraryVersionPatch(void);
 /// Returns YES if current library version is `beta` else NO.
-FOUNDATION_EXPORT BOOL FIRMessagingCurrentLibraryVersionIsBeta();
+FOUNDATION_EXPORT BOOL FIRMessagingCurrentLibraryVersionIsBeta(void);

--- a/Firebase/Messaging/FIRMessagingVersionUtilities.m
+++ b/Firebase/Messaging/FIRMessagingVersionUtilities.m
@@ -31,7 +31,7 @@ static int minorVersion;
 static int patchVersion;
 static int betaVersion;
 
-void FIRMessagingParseCurrentLibraryVersion() {
+void FIRMessagingParseCurrentLibraryVersion(void) {
   static NSArray *allVersions;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
@@ -61,27 +61,27 @@ void FIRMessagingParseCurrentLibraryVersion() {
   });
 }
 
-NSString *FIRMessagingCurrentLibraryVersion() {
+NSString *FIRMessagingCurrentLibraryVersion(void) {
   FIRMessagingParseCurrentLibraryVersion();
   return libraryVersion;
 }
 
-int FIRMessagingCurrentLibraryVersionMajor() {
+int FIRMessagingCurrentLibraryVersionMajor(void) {
   FIRMessagingParseCurrentLibraryVersion();
   return majorVersion;
 }
 
-int FIRMessagingCurrentLibraryVersionMinor() {
+int FIRMessagingCurrentLibraryVersionMinor(void) {
   FIRMessagingParseCurrentLibraryVersion();
   return minorVersion;
 }
 
-int FIRMessagingCurrentLibraryVersionPatch() {
+int FIRMessagingCurrentLibraryVersionPatch(void) {
   FIRMessagingParseCurrentLibraryVersion();
   return patchVersion;
 }
 
-BOOL FIRMessagingCurrentLibraryVersionIsBeta() {
+BOOL FIRMessagingCurrentLibraryVersionIsBeta(void) {
   FIRMessagingParseCurrentLibraryVersion();
   return betaVersion > 0;
 }


### PR DESCRIPTION
Four warnings still remain for API mismatches.