### PR TITLE
Fix warnings exposed by Xcode 9.1 in RTDB

### DIFF
--- a/Firebase/Core/FIRAppAssociationRegistration.m
+++ b/Firebase/Core/FIRAppAssociationRegistration.m
@@ -20,7 +20,7 @@
 
 + (nullable id)registeredObjectWithHost:(id)host
                                     key:(NSString *)key
-                          creationBlock:(id _Nullable (^)())creationBlock {
+                          creationBlock:(id _Nullable (^)(void))creationBlock {
   @synchronized(self) {
     SEL dictKey = @selector(registeredObjectWithHost:key:creationBlock:);
     NSMutableDictionary<NSString *, id> *objectsByKey = objc_getAssociatedObject(host, dictKey);

--- a/Firebase/Core/Private/FIRAppAssociationRegistration.h
+++ b/Firebase/Core/Private/FIRAppAssociationRegistration.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable ObjectType)registeredObjectWithHost:(id)host
                                             key:(NSString *)key
-                                  creationBlock:(ObjectType _Nullable (^)())creationBlock;
+                                  creationBlock:(ObjectType _Nullable (^)(void))creationBlock;
 
 @end
 

--- a/Firebase/Database/Core/Utilities/FIRRetryHelper.h
+++ b/Firebase/Database/Core/Utilities/FIRRetryHelper.h
@@ -24,7 +24,7 @@
                          retryExponent:(double)retryExponent
                           jitterFactor:(double)jitterFactor;
 
-- (void) retry:(void (^)())block;
+- (void) retry:(void (^)(void))block;
 
 - (void) cancel;
 

--- a/Firebase/Database/Core/Utilities/FIRRetryHelper.m
+++ b/Firebase/Database/Core/Utilities/FIRRetryHelper.m
@@ -20,13 +20,13 @@
 
 @interface FIRRetryHelperTask : NSObject
 
-@property (nonatomic, strong) void (^block)();
+@property (nonatomic, strong) void (^block)(void);
 
 @end
 
 @implementation FIRRetryHelperTask
 
-- (instancetype) initWithBlock:(void (^)())block {
+- (instancetype) initWithBlock:(void (^)(void))block {
     self = [super init];
     if (self != nil) {
         self->_block = [block copy];
@@ -86,7 +86,7 @@
     return self;
 }
 
-- (void) retry:(void (^)())block {
+- (void) retry:(void (^)(void))block {
     if (self.scheduledRetry != nil) {
         FFLog(@"I-RDB054001", @"Canceling existing retry attempt");
         [self.scheduledRetry cancel];


### PR DESCRIPTION
Context at https://stackoverflow.com/questions/44473146/this-function-declaration-is-not-a-prototype-warning-in-xcode-9