### PR TITLE
Fix warnings exposed by Xcode 9.1 in Firestore source

### DIFF
--- a/Firestore/Source/Core/FSTTypes.h
+++ b/Firestore/Source/Core/FSTTypes.h
@@ -32,7 +32,7 @@ typedef NSNumber FSTBoxedTargetID;
  * FSTVoidBlock is a block that's called when a specific event happens but that otherwise has
  * no information associated with it.
  */
-typedef void (^FSTVoidBlock)();
+typedef void (^FSTVoidBlock)(void);
 
 /**
  * FSTVoidErrorBlock is a block that gets an error, if one occurred.

--- a/Firestore/Source/Remote/FSTDatastore.m
+++ b/Firestore/Source/Remote/FSTDatastore.m
@@ -62,7 +62,7 @@ static NSString *const kXGoogAPIClientHeader = @"x-goog-api-client";
 static NSString *const kGoogleCloudResourcePrefix = @"google-cloud-resource-prefix";
 
 /** Function typedef used to create RPCs. */
-typedef GRPCProtoCall * (^RPCFactory)();
+typedef GRPCProtoCall * (^RPCFactory)(void);
 
 #pragma mark - FSTStream
 
@@ -417,7 +417,7 @@ typedef NS_ENUM(NSInteger, FSTStreamState) {
                 }];
 }
 
-- (void)invokeRPCWithFactory:(GRPCProtoCall * (^)())rpcFactory
+- (void)invokeRPCWithFactory:(GRPCProtoCall * (^)(void))rpcFactory
                 errorHandler:(FSTVoidErrorBlock)errorHandler {
   // TODO(mikelehen): We should force a refresh if the previous RPC failed due to an expired token,
   // but I'm not sure how to detect that right now. http://b/32762461

--- a/Firestore/Source/Remote/FSTExponentialBackoff.h
+++ b/Firestore/Source/Remote/FSTExponentialBackoff.h
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param block The block to run.
  */
-- (void)backoffAndRunBlock:(void (^)())block;
+- (void)backoffAndRunBlock:(void (^)(void))block;
 
 @end
 

--- a/Firestore/Source/Remote/FSTExponentialBackoff.m
+++ b/Firestore/Source/Remote/FSTExponentialBackoff.m
@@ -68,7 +68,7 @@
   _currentBase = _maxDelay;
 }
 
-- (void)backoffAndRunBlock:(void (^)())block {
+- (void)backoffAndRunBlock:(void (^)(void))block {
   // First schedule the block using the current base (which may be 0 and should be honored as such).
   NSTimeInterval delayWithJitter = _currentBase + [self jitterDelay];
   if (_currentBase > 0) {

--- a/Firestore/Source/Util/FSTDispatchQueue.h
+++ b/Firestore/Source/Util/FSTDispatchQueue.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param block The block to run.
  */
-- (void)dispatchAsync:(void (^)())block;
+- (void)dispatchAsync:(void (^)(void))block;
 
 /**
  * Unlike dispatchAsync: this method does not require you to dispatch to a different queue than
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param block The block to run.
  */
-- (void)dispatchAsyncAllowingSameQueue:(void (^)())block;
+- (void)dispatchAsyncAllowingSameQueue:(void (^)(void))block;
 
 /** The underlying wrapped dispatch_queue_t */
 @property(nonatomic, strong, readonly) dispatch_queue_t queue;

--- a/Firestore/Source/Util/FSTDispatchQueue.m
+++ b/Firestore/Source/Util/FSTDispatchQueue.m
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
             [self targetQueueLabel], [self currentQueueLabel]);
 }
 
-- (void)dispatchAsync:(void (^)())block {
+- (void)dispatchAsync:(void (^)(void))block {
   FSTAssert(![self onTargetQueue],
             @"dispatchAsync called when we are already running on target dispatch queue '%@'",
             [self targetQueueLabel]);
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
   dispatch_async(self.queue, block);
 }
 
-- (void)dispatchAsyncAllowingSameQueue:(void (^)())block {
+- (void)dispatchAsyncAllowingSameQueue:(void (^)(void))block {
   dispatch_async(self.queue, block);
 }
 


### PR DESCRIPTION
Fix “This function declaration is not a prototype” warning in Xcode 9.1

More context at https://stackoverflow.com/questions/44473146/this-function-declaration-is-not-a-prototype-warning-in-xcode-9