### PR TITLE
Fixing XCTAssertEqual order

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.m
@@ -170,7 +170,7 @@
   [self awaitExpectations];
 
   FIRDocumentSnapshot *document = [self readDocumentForRef:doc];
-  XCTAssertEqual(@NO, document[@"updated"]);
+  XCTAssertEqual(document[@"updated"], @NO);
   XCTAssertTrue([document[@"time"] isKindOfClass:[NSDate class]]);
 }
 


### PR DESCRIPTION
Addressing Lint warning:

Incorrect XCTest assertion parameter order. The parameters should be inverted. See go/xctest-tips for more information.. Use // NOLINT or // NOLINTNEXTLINE to skip this (or any expected) lint error.
        //depot/google3/third_party/firebase/ios/Source/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.m:173