### PR TITLE
Fix Xcode 9 too complex error in build.swift

### DIFF
--- a/BuildFrameworks/build.swift
+++ b/BuildFrameworks/build.swift
@@ -140,7 +140,8 @@ func buildThin(framework: String, multiplatform: Bool, arch: String, multisdk: B
   let bitcode = (sdk == "iphoneos") ? ["OTHER_CFLAGS=\"" + "-fembed-bitcode\""] : []
   let args = standardOptions + ["ARCHS=" + arch, "BUILD_DIR=" + buildDir, "-sdk", sdk] + bitcode
   syncExec(command:"/usr/bin/xcodebuild", args:args)
-  return [buildDir + "/Release" + (multisdk ? "-\(sdk)" : "") + "/" + framework + schemeSuffix + "/lib" + framework + schemeSuffix + ".a"]
+  let sdk = multisdk ? "-\(sdk)" : ""
+  return [buildDir + "/Release" + sdk + "/" + framework + schemeSuffix + "/lib" + framework + schemeSuffix + ".a"]
 }
 
 func createFile(file: String, content: String) {


### PR DESCRIPTION
Fix #366 

The Xcode 9 Swift compiler is less tolerant of complex Swift errors than Xcode 8. This PR implements a  workaround.

Google the following to see multiple examples:
`./build.swift:143:10: error: expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions`