### PR TITLE
Add isEqual() and port DocumentReference array test.

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.m
@@ -680,6 +680,40 @@
   XCTAssertEqual(q.firestore, self.db);
 }
 
+- (void)testDocumentReferenceEquality {
+  FIRFirestore *firestore = self.db;
+  FIRDocumentReference *docRef = [firestore documentWithPath:@"foo/bar"];
+  XCTAssertEqualObjects([firestore documentWithPath:@"foo/bar"], docRef);
+  XCTAssertEqualObjects([docRef collectionWithPath:@"blah"].parent, docRef);
+
+  XCTAssertNotEqualObjects([firestore documentWithPath:@"foo/BAR"], docRef);
+
+  FIRFirestore *otherFirestore = [self firestore];
+  XCTAssertNotEqualObjects([otherFirestore documentWithPath:@"foo/bar"], docRef);
+}
+
+- (void)testQueryReferenceEquality {
+  FIRFirestore *firestore = self.db;
+  FIRQuery *query =
+      [[[firestore collectionWithPath:@"foo"] queryOrderedByField:@"bar"] queryWhereField:@"baz"
+                                                                                isEqualTo:@42];
+  FIRQuery *query2 =
+      [[[firestore collectionWithPath:@"foo"] queryOrderedByField:@"bar"] queryWhereField:@"baz"
+                                                                                isEqualTo:@42];
+  XCTAssertEqualObjects(query, query2);
+
+  FIRQuery *query3 =
+      [[[firestore collectionWithPath:@"foo"] queryOrderedByField:@"BAR"] queryWhereField:@"baz"
+                                                                                isEqualTo:@42];
+  XCTAssertNotEqualObjects(query, query3);
+
+  FIRFirestore *otherFirestore = [self firestore];
+  FIRQuery *query4 = [[[otherFirestore collectionWithPath:@"foo"] queryOrderedByField:@"bar"]
+      queryWhereField:@"baz"
+            isEqualTo:@42];
+  XCTAssertNotEqualObjects(query, query4);
+}
+
 - (void)testCanTraverseCollectionsAndDocuments {
   NSString *expected = @"a/b/c/d";
   // doc path from root Firestore.

--- a/Firestore/Example/Tests/Integration/API/FIRTypeTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRTypeTests.m
@@ -62,18 +62,13 @@
 }
 
 - (void)testCanReadAndWriteDocumentReferences {
-  // We can't use assertSuccessfulRoundtrip since FIRDocumentReference doesn't implement isEqual.
-  FIRDocumentReference *docRef = [self.db documentWithPath:@"rooms/eros"];
-  id data = @{ @"a" : @42, @"ref" : docRef };
-  [self writeDocumentRef:docRef data:data];
+  FIRDocumentReference *docRef = [self documentRef];
+  [self assertSuccessfulRoundtrip:@{ @"a" : @42, @"ref" : docRef }];
+}
 
-  FIRDocumentSnapshot *readDoc = [self readDocumentForRef:docRef];
-  XCTAssertTrue(readDoc.exists);
-
-  XCTAssertEqualObjects(readDoc[@"a"], data[@"a"]);
-  FIRDocumentReference *readDocRef = readDoc[@"ref"];
-  XCTAssertTrue([readDocRef isKindOfClass:[FIRDocumentReference class]]);
-  XCTAssertEqualObjects(readDocRef.path, docRef.path);
+- (void)testCanReadAndWriteDocumentReferencesInArrays {
+  FIRDocumentReference *docRef = [self documentRef];
+  [self assertSuccessfulRoundtrip:@{ @"a" : @42, @"refs" : @[ docRef ] }];
 }
 
 @end

--- a/Firestore/Source/API/FIRDocumentReference.m
+++ b/Firestore/Source/API/FIRDocumentReference.m
@@ -112,14 +112,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - NSObject Methods
 
-- (BOOL)isEqual:(id)other {
+- (BOOL)isEqual:(nullable id)other {
   if (other == self) return YES;
   if (!other || ![[other class] isEqual:[self class]]) return NO;
 
   return [self isEqualToReference:other];
 }
 
-- (BOOL)isEqualToReference:(FIRDocumentReference *)reference {
+- (BOOL)isEqualToReference:(nullable FIRDocumentReference *)reference {
   if (self == reference) return YES;
   if (reference == nil) return NO;
   if (self.firestore != reference.firestore && ![self.firestore isEqual:reference.firestore])

--- a/Firestore/Source/API/FIRDocumentReference.m
+++ b/Firestore/Source/API/FIRDocumentReference.m
@@ -110,6 +110,32 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
+#pragma mark - NSObject Methods
+
+- (BOOL)isEqual:(id)other {
+  if (other == self) return YES;
+  if (!other || ![[other class] isEqual:[self class]]) return NO;
+
+  return [self isEqualToReference:other];
+}
+
+- (BOOL)isEqualToReference:(FIRDocumentReference *)reference {
+  if (self == reference) return YES;
+  if (reference == nil) return NO;
+  if (self.firestore != reference.firestore && ![self.firestore isEqual:reference.firestore])
+    return NO;
+  if (self.key != reference.key && ![self.key isEqualToKey:reference.key]) return NO;
+  return YES;
+}
+
+- (NSUInteger)hash {
+  NSUInteger hash = [self.firestore hash];
+  hash = hash * 31u + [self.key hash];
+  return hash;
+}
+
+#pragma mark - Public Methods
+
 - (NSString *)documentID {
   return [self.key.path lastSegment];
 }

--- a/Firestore/Source/API/FIRQuery.m
+++ b/Firestore/Source/API/FIRQuery.m
@@ -105,14 +105,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - NSObject Methods
 
-- (BOOL)isEqual:(id)other {
+- (BOOL)isEqual:(nullable id)other {
   if (other == self) return YES;
   if (!other || ![[other class] isEqual:[self class]]) return NO;
 
   return [self isEqualToQuery:other];
 }
 
-- (BOOL)isEqualToQuery:(FIRQuery *)query {
+- (BOOL)isEqualToQuery:(nullable FIRQuery *)query {
   if (self == query) return YES;
   if (query == nil) return NO;
   if (self.firestore != query.firestore && ![self.firestore isEqual:query.firestore]) return NO;

--- a/Firestore/Source/API/FIRQuery.m
+++ b/Firestore/Source/API/FIRQuery.m
@@ -93,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FIRQuery
 
-#pragma mark - Public Methods
+#pragma mark - Constructor Methods
 
 - (instancetype)initWithQuery:(FSTQuery *)query firestore:(FIRFirestore *)firestore {
   if (self = [super init]) {
@@ -102,6 +102,31 @@ NS_ASSUME_NONNULL_BEGIN
   }
   return self;
 }
+
+#pragma mark - NSObject Methods
+
+- (BOOL)isEqual:(id)other {
+  if (other == self) return YES;
+  if (!other || ![[other class] isEqual:[self class]]) return NO;
+
+  return [self isEqualToQuery:other];
+}
+
+- (BOOL)isEqualToQuery:(FIRQuery *)query {
+  if (self == query) return YES;
+  if (query == nil) return NO;
+  if (self.firestore != query.firestore && ![self.firestore isEqual:query.firestore]) return NO;
+  if (self.query != query.query && ![self.query isEqual:query.query]) return NO;
+  return YES;
+}
+
+- (NSUInteger)hash {
+  NSUInteger hash = [self.firestore hash];
+  hash = hash * 31u + [self.query hash];
+  return hash;
+}
+
+#pragma mark - Public Methods
 
 - (void)getDocumentsWithCompletion:(void (^)(FIRQuerySnapshot *_Nullable snapshot,
                                              NSError *_Nullable error))completion {


### PR DESCRIPTION
* Ports the test for the fix I made for Android for DocumentReference objects in arrays (bug not present in iOS).
* Implements isEqual on FIRQuery and FIRDocumentReference.
