### PR TITLE
 Silences unguarded availability warnings in Auth.

### DIFF
--- a/Example/Auth/Sample/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/Auth/Sample/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -140,6 +140,11 @@
       "scale" : "2x"
     },
     {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    },
+    {
       "idiom" : "mac",
       "size" : "16x16",
       "scale" : "1x"

--- a/Example/Auth/Sample/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/Auth/Sample/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -140,11 +140,6 @@
       "scale" : "2x"
     },
     {
-      "idiom" : "ios-marketing",
-      "size" : "1024x1024",
-      "scale" : "1x"
-    },
-    {
       "idiom" : "mac",
       "size" : "16x16",
       "scale" : "1x"

--- a/Example/Auth/Sample/MainViewController.m
+++ b/Example/Auth/Sample/MainViewController.m
@@ -2537,7 +2537,9 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
         if (error) {
           [self logFailure:@"failed to send verification code" error:error];
           [self showMessagePrompt:error.localizedDescription];
-          completion(error);
+          if (completion) {
+            completion(error);
+          }
           return;
         }
         [self logSuccess:@"Code sent"];

--- a/Firebase/Auth/Source/FIRAuthAppDelegateProxy.m
+++ b/Firebase/Auth/Source/FIRAuthAppDelegateProxy.m
@@ -40,6 +40,21 @@ static id noop(id object, SEL cmd, ...) {
 }
 #endif
 
+/** @fn isIOS9orLater
+    @brief Checks whether the iOS version is 9 or later.
+    @returns Whether the iOS version is 9 or later.
+ */
+static BOOL isIOS9orLater() {
+#if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
+  if (@available(iOS 9.0, *)) {
+    return YES;
+  }
+  return NO;
+#else
+  return &UIApplicationOpenURLOptionsAnnotationKey;  // the constant is only available on iOS 9+
+#endif
+}
+
 @implementation FIRAuthAppDelegateProxy {
   /** @var _appDelegate
       @brief The application delegate whose method is being swizzled.
@@ -119,7 +134,7 @@ static id noop(id object, SEL cmd, ...) {
     SEL openURLOptionsSelector = @selector(application:openURL:options:);
     SEL openURLAnnotationSelector = @selector(application:openURL:sourceApplication:annotation:);
     SEL handleOpenURLSelector = @selector(application:handleOpenURL:);
-    if (&UIApplicationOpenURLOptionsAnnotationKey &&  // the constant is only available on iOS 9+
+    if (isIOS9orLater() &&
         ([_appDelegate respondsToSelector:openURLOptionsSelector] ||
          (![_appDelegate respondsToSelector:openURLAnnotationSelector] &&
           ![_appDelegate respondsToSelector:handleOpenURLSelector]))) {

--- a/Firebase/Auth/Source/FIRAuthURLPresenter.m
+++ b/Firebase/Auth/Source/FIRAuthURLPresenter.m
@@ -30,6 +30,11 @@ NS_ASSUME_NONNULL_BEGIN
                                    FIRAuthWebViewControllerDelegate>
 @end
 
+// Disable unguarded availability warnings because SFSafariViewController is been used throughout
+// the code, including as an iVar, which cannot be simply excluded by @available check.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+
 @implementation FIRAuthURLPresenter {
   /** @var _isPresenting
       @brief Whether or not some web-based content is being presented.
@@ -175,6 +180,8 @@ NS_ASSUME_NONNULL_BEGIN
     finishBlock();
   }
 }
+
+#pragma clang diagnostic pop  // ignored "-Wunguarded-availability"
 
 @end
 


### PR DESCRIPTION
Also fixes a crash in the Auth sample app in an error case.

This addresses *Auth* part of #385 .