### PR TITLE
Don't fail travis tests if a binary file has a trailing space

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - bundle exec pod install --project-directory=Firestore/Example --no-repo-update
 
 script:
-  - "! git grep ' $'" # Fail on trailing whitespace
+  - "! git grep -I ' $'" # Fail on trailing whitespace in non-binary files
   - ./test.sh
   - pod lib lint FirebaseCommunity.podspec --verbose | tail -40
 


### PR DESCRIPTION
The -I option to `git grep` indicates to skip binary files.  A introduced png file in #396 was causing at travis failure.