### PR TITLE
Catch failures from pod lib lint in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 script:
   - "! git grep -I ' $'" # Fail on trailing whitespace in non-binary files
   - ./test.sh
-  - pod lib lint FirebaseCommunity.podspec --verbose | tail -40
+  - pod lib lint FirebaseCommunity.podspec
 
 branches:
   only:


### PR DESCRIPTION
Travis was logging `pod lib lint`, but not marking the run as a failure, because the tail command reset the command's return code.