### PR TITLE
Handle errors after Phone Number Linking

### DIFF
--- a/Firebase/Auth/Source/FIRUser.m
+++ b/Firebase/Auth/Source/FIRUser.m
@@ -659,6 +659,12 @@ static void callInMainThreadWithAuthDataResultAndError(
       // Get account info to update cached user info.
       [self getAccountInfoRefreshingCache:^(FIRGetAccountInfoResponseUser *_Nullable user,
                                             NSError *_Nullable error) {
+        if (error) {
+          [self signOutIfTokenIsInvalidWithError:error];
+          completion(error);
+          return;
+        }
+        _anonymous = NO;
         if (![self updateKeychain:&error]) {
           completion(error);
           return;


### PR DESCRIPTION
Handles possible errors after linking phone number.
Also sets anonymous ivar to NO if linking succeeded; if there is an error while storing the user in the keychain after linking the ivar is left as NO since the user in memory would no longer be an anonymous user.


Fixes issue #421