### PR TITLE
Enumerator using generic. Cleaner for .. in .. loop in Swift

### DIFF
--- a/Firebase/Database/Api/FIRDataSnapshot.m
+++ b/Firebase/Database/Api/FIRDataSnapshot.m
@@ -87,7 +87,7 @@
     return [self.node.node numChildren];
 }
 
-- (NSEnumerator *) children {
+- (NSEnumerator<FIRDataSnapshot *> *) children {
     return [[FTransformedEnumerator alloc] initWithEnumerator:self.node.childEnumerator andTransform:^id(FNamedNode *node) {
         FIRDatabaseReference *childRef = [self.ref child:node.name];
         return [[FIRDataSnapshot alloc] initWithRef:childRef indexedNode:[FIndexedNode indexedNodeWithNode:node.node]];

--- a/Firebase/Database/Api/FIRMutableData.m
+++ b/Firebase/Database/Api/FIRMutableData.m
@@ -110,7 +110,7 @@
     return [self.data getNode:self.prefixPath];
 }
 
-- (NSEnumerator *) children {
+- (NSEnumerator<FIRMutableData *> *) children {
     FIndexedNode *indexedNode = [FIndexedNode indexedNodeWithNode:self.nodeValue];
     return [[FTransformedEnumerator alloc] initWithEnumerator:[indexedNode childEnumerator] andTransform:^id(FNamedNode *node) {
         FPath* childPath = [self.prefixPath childFromString:node.name];

--- a/Firebase/Database/Public/FIRDataSnapshot.h
+++ b/Firebase/Database/Public/FIRDataSnapshot.h
@@ -134,7 +134,7 @@ FIR_SWIFT_NAME(DataSnapshot)
  *
  * @return An NSEnumerator of the children.
  */
-@property (strong, readonly, nonatomic) NSEnumerator* children;
+@property (strong, readonly, nonatomic) NSEnumerator<FIRDataSnapshot *>* children;
 
 /**
  * The priority of the data in this FIRDataSnapshot.

--- a/Firebase/Database/Public/FIRMutableData.h
+++ b/Firebase/Database/Public/FIRMutableData.h
@@ -116,7 +116,7 @@ FIR_SWIFT_NAME(MutableData)
  * Note that this enumerator operates on an immutable copy of the child list. So, you can modify the instance
  * during iteration, but the new additions will not be visible until you get a new enumerator.
  */
-@property (readonly, nonatomic, strong) NSEnumerator* children;
+@property (readonly, nonatomic, strong) NSEnumerator<FIRMutableData *>* children;
 
 
 /**


### PR DESCRIPTION
So 
for childSnapshot in snapshot.children {
you don't need to cast each child. Each cild is already known as DataSnapshot
