### PR TITLE
Adding the MD5 hash to FIRStorageMetadata

### DIFF
--- a/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <FirebaseCommunity/FIRStorageMetadata.h>
 #import <XCTest/XCTest.h>
 #import <math.h>
 
@@ -463,6 +464,7 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 30;
   XCTAssertEqualObjects(actualMetadata.contentEncoding, @"gzip");
   XCTAssertEqualObjects(actualMetadata.contentLanguage, @"de");
   XCTAssertEqualObjects(actualMetadata.contentType, expectedContentType);
+  XCTAssertTrue([actualMetadata.md5Hash length] == 24);
   for (NSString *key in expectedCustomMetadata) {
     XCTAssertEqualObjects([actualMetadata.customMetadata objectForKey:key],
                           [expectedCustomMetadata objectForKey:key]);
@@ -475,6 +477,7 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 30;
   XCTAssertEqualObjects(actualMetadata.contentEncoding, @"identity");
   XCTAssertNil(actualMetadata.contentLanguage);
   XCTAssertNil(actualMetadata.contentType);
+  XCTAssertTrue([actualMetadata.md5Hash length] == 24);
   XCTAssertNil([actualMetadata.customMetadata objectForKey:@"a"]);
   XCTAssertNil([actualMetadata.customMetadata objectForKey:@"c"]);
   XCTAssertNil([actualMetadata.customMetadata objectForKey:@"f"]);

--- a/Example/Storage/Tests/Unit/FIRStorageMetadataTests.m
+++ b/Example/Storage/Tests/Unit/FIRStorageMetadataTests.m
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <FirebaseCommunity/FIRStorageMetadata.h>
 #import <XCTest/XCTest.h>
 
 #import "FIRStorageMetadata.h"
@@ -44,6 +45,7 @@
     kFIRStorageMetadataName : @"path/to/object",
     kFIRStorageMetadataTimeCreated : @"1992-08-07T17:22:53.108Z",
     kFIRStorageMetadataUpdated : @"2016-03-01T20:16:01.673Z",
+    kFIRStorageMetadataMd5Hash : @"d41d8cd98f00b204e9800998ecf8427e",
     kFIRStorageMetadataSize : @1337
   };
   FIRStorageMetadata *metadata = [[FIRStorageMetadata alloc] initWithDictionary:metaDict];
@@ -55,6 +57,7 @@
   XCTAssertEqualObjects(metadata.contentEncoding, metaDict[kFIRStorageMetadataContentEncoding], );
   XCTAssertEqualObjects(metadata.contentType, metaDict[kFIRStorageMetadataContentType]);
   XCTAssertEqualObjects(metadata.customMetadata, metaDict[kFIRStorageMetadataCustomMetadata]);
+  XCTAssertEqualObjects(metadata.md5Hash, metaDict[kFIRStorageMetadataMd5Hash]);
   NSString *URLFormat = @"https://firebasestorage.googleapis.com/v0/b/%@/o/%@?alt=media&token=%@";
   NSString *URLString = [NSString
       stringWithFormat:URLFormat, metaDict[kFIRStorageMetadataBucket],
@@ -89,6 +92,7 @@
     kFIRStorageMetadataName : @"path/to/object",
     kFIRStorageMetadataTimeCreated : @"1992-08-07T17:22:53.108Z",
     kFIRStorageMetadataUpdated : @"2016-03-01T20:16:01.673Z",
+    kFIRStorageMetadataMd5Hash : @"d41d8cd98f00b204e9800998ecf8427e",
     kFIRStorageMetadataSize : @1337
   };
   FIRStorageMetadata *metadata = [[FIRStorageMetadata alloc] initWithDictionary:metaDict];
@@ -122,6 +126,8 @@
                         metaDict[kFIRStorageMetadataUpdated]);
   XCTAssertEqualObjects(dictRepresentation[kFIRStorageMetadataSize],
                         metaDict[kFIRStorageMetadataSize]);
+  XCTAssertEqualObjects(dictRepresentation[kFIRStorageMetadataMd5Hash],
+                        metaDict[kFIRStorageMetadataMd5Hash]);
 }
 
 - (void)testInitialzeNoDownloadTokensGetToken {
@@ -226,6 +232,7 @@
   NSDictionary *metaDict = @{
     kFIRStorageMetadataBucket : @"bucket",
     kFIRStorageMetadataName : @"path/to/object",
+    kFIRStorageMetadataMd5Hash : @"d41d8cd98f00b204e9800998ecf8427e",
   };
   FIRStorageMetadata *metadata0 = [[FIRStorageMetadata alloc] initWithDictionary:metaDict];
   FIRStorageMetadata *metadata1 = [[FIRStorageMetadata alloc] initWithDictionary:metaDict];
@@ -233,10 +240,23 @@
   XCTAssertEqualObjects(metadata0, metadata1);
 }
 
+- (void)testMetadataMd5Inequality {
+  NSDictionary *firstDict = @{
+    kFIRStorageMetadataMd5Hash : @"d41d8cd98f00b204e9800998ecf8427e",
+  };
+  NSDictionary *secondDict = @{
+    kFIRStorageMetadataMd5Hash : @"foo",
+  };
+  FIRStorageMetadata *firstMetadata = [[FIRStorageMetadata alloc] initWithDictionary:firstDict];
+  FIRStorageMetadata *secondMetadata = [[FIRStorageMetadata alloc] initWithDictionary:secondDict];
+  XCTAssertNotEqualObjects(firstMetadata, secondMetadata);
+}
+
 - (void)testMetadataCopy {
   NSDictionary *metaDict = @{
     kFIRStorageMetadataBucket : @"bucket",
     kFIRStorageMetadataName : @"path/to/object",
+    kFIRStorageMetadataMd5Hash : @"d41d8cd98f00b204e9800998ecf8427e",
   };
   FIRStorageMetadata *metadata0 = [[FIRStorageMetadata alloc] initWithDictionary:metaDict];
   FIRStorageMetadata *metadata1 = [metadata0 copy];

--- a/Firebase/Storage/FIRStorageConstants.m
+++ b/Firebase/Storage/FIRStorageConstants.m
@@ -63,6 +63,7 @@ NSString *const kFIRStorageMetadataTimeCreated = @"timeCreated";
 NSString *const kFIRStorageMetadataUpdated = @"updated";
 NSString *const kFIRStorageMetadataName = @"name";
 NSString *const kFIRStorageMetadataDownloadTokens = @"downloadTokens";
+NSString *const kFIRStorageMetadataMd5Hash = @"md5Hash";
 
 // TODO: add notification support
 NSString *const kFIRStorageTaskStatusResumeNotification =

--- a/Firebase/Storage/FIRStorageMetadata.m
+++ b/Firebase/Storage/FIRStorageMetadata.m
@@ -46,6 +46,7 @@
     _metageneration = [dictionary[kFIRStorageMetadataMetageneration] longLongValue];
     _timeCreated = [self dateFromRFC3339String:dictionary[kFIRStorageMetadataTimeCreated]];
     _updated = [self dateFromRFC3339String:dictionary[kFIRStorageMetadataUpdated]];
+    _md5Hash = dictionary[kFIRStorageMetadataMd5Hash];
     // GCS "name" is our path, our "name" is just the last path component of the path
     _path = dictionary[kFIRStorageMetadataName];
     _name = [_path lastPathComponent];
@@ -135,6 +136,10 @@
 
   if (_contentType) {
     metadataDictionary[kFIRStorageMetadataContentType] = _contentType;
+  }
+
+  if (_md5Hash) {
+    metadataDictionary[kFIRStorageMetadataMd5Hash] = _md5Hash;
   }
 
   if (_customMetadata) {

--- a/Firebase/Storage/Private/FIRStorageConstants_Private.h
+++ b/Firebase/Storage/Private/FIRStorageConstants_Private.h
@@ -62,6 +62,7 @@ FOUNDATION_EXPORT NSString *const kFIRStorageMetadataTimeCreated;
 FOUNDATION_EXPORT NSString *const kFIRStorageMetadataUpdated;
 FOUNDATION_EXPORT NSString *const kFIRStorageMetadataName;
 FOUNDATION_EXPORT NSString *const kFIRStorageMetadataDownloadTokens;
+FOUNDATION_EXPORT NSString *const kFIRStorageMetadataMd5Hash;
 
 FOUNDATION_EXPORT NSString *const kFIRStorageInvalidDataFormat;
 FOUNDATION_EXPORT NSString *const kFIRStorageInvalidObserverStatus;

--- a/Firebase/Storage/Public/FIRStorageMetadata.h
+++ b/Firebase/Storage/Public/FIRStorageMetadata.h
@@ -63,7 +63,7 @@ FIR_SWIFT_NAME(StorageMetadata)
 @property(copy, nonatomic, nullable) NSString *contentType;
 
 /**
- * The MD5Hash of the StorageReference object.
+ * MD5 hash of the data; encoded using base64.
  */
 @property(copy, nonatomic, nullable, readonly) NSString *md5Hash;
 

--- a/Firebase/Storage/Public/FIRStorageMetadata.h
+++ b/Firebase/Storage/Public/FIRStorageMetadata.h
@@ -63,6 +63,11 @@ FIR_SWIFT_NAME(StorageMetadata)
 @property(copy, nonatomic, nullable) NSString *contentType;
 
 /**
+ * The MD5Hash of the StorageReference object.
+ */
+@property(copy, nonatomic, nullable, readonly) NSString *md5Hash;
+
+/**
  * The content generation of this object. Used for object versioning.
  */
 @property(readonly) int64_t generation;


### PR DESCRIPTION
The MD5 Hash is part of the Android & Web implementation, but not exposed in iOS. 

This was already approved in the original API review.