### PR TITLE
Using deferred init to ensure that we init FEmptyNode only once

### DIFF
--- a/Firebase/Database/Snapshot/FEmptyNode.m
+++ b/Firebase/Database/Snapshot/FEmptyNode.m
@@ -21,9 +21,10 @@
 
 + (id<FNode>) emptyNode {
     static FChildrenNode* empty = nil;
-    if (empty == nil) {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
         empty = [[FChildrenNode alloc] init];
-    }
+    });
     return empty;
 }
 @end


### PR DESCRIPTION
This is intended to reduce the crashes reported in https://github.com/firebase/firebase-ios-sdk/issues/281