### PR TITLE
Removes unused label from sample app

### DIFF
--- a/Example/Auth/Sample/MainViewController.m
+++ b/Example/Auth/Sample/MainViewController.m
@@ -79,11 +79,6 @@ static NSString *const kUserInfoButtonText = @"[Show User Info]";
  */
 static NSString *const kSetPhotoURLText = @"Set Photo url";
 
-/** @var kSignInButtonText
-    @brief The text of the "Sign In" button.
- */
-static NSString *const kSignInButtonText = @"Sign In (HEADFUL)";
-
 /** @var kSignInGoogleButtonText
     @brief The text of the "Google SignIn" button.
  */


### PR DESCRIPTION
Removes the headful sign-in label from the Sample App as it is no longer in use.