### PR TITLE
Adds AuthDataResult to anonymous sign in

### DIFF
--- a/Example/Auth/Sample/MainViewController.m
+++ b/Example/Auth/Sample/MainViewController.m
@@ -121,6 +121,12 @@ static NSString *const kSignInWithCustomTokenButtonText = @"Sign In (BYOAuth)";
  */
 static NSString *const kSignInAnonymouslyButtonText = @"Sign In Anonymously";
 
+/** @var kSignInAnonymouslyWithAuthResultButtonText
+    @brief The text of the "Sign In Anonymously (AuthDataResult)" button.
+ */
+static NSString *const kSignInAnonymouslyWithAuthResultButtonText =
+    @"Sign In Anonymously (AuthDataResult)";
+
 /** @var kSignedInAlertTitle
     @brief The text of the "Sign In Succeeded" alert.
  */
@@ -707,6 +713,8 @@ typedef enum {
                                            action:^{ [weakSelf signInWithCustomToken]; }],
         [StaticContentTableViewCell cellWithTitle:kSignInAnonymouslyButtonText
                                            action:^{ [weakSelf signInAnonymously]; }],
+        [StaticContentTableViewCell cellWithTitle:kSignInAnonymouslyWithAuthResultButtonText
+                                           action:^{ [weakSelf signInAnonymouslyAuthDataResult]; }],
         [StaticContentTableViewCell cellWithTitle:kGitHubSignInButtonText
                                            action:^{ [weakSelf signInWithGitHub]; }],
         [StaticContentTableViewCell cellWithTitle:kSignOutButtonText
@@ -2781,6 +2789,24 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
       [self logFailure:@"sign-in anonymously failed" error:error];
     } else {
       [self logSuccess:@"sign-in anonymously succeeded."];
+    }
+    [self showTypicalUIForUserUpdateResultsWithTitle:kSignInAnonymouslyButtonText error:error];
+  }];
+}
+
+/** @fn signInAnonymouslyAuthDataResult
+    @brief Signs in as an anonymous user, recieveing an auth result containing a signed in user upon
+        success.
+ */
+- (void)signInAnonymouslyAuthDataResult {
+  [[AppManager auth] signInAnonymouslyAndRetrieveDataWithCompletion:
+      ^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error) {
+    if (error) {
+      [self logFailure:@"sign-in anonymously failed" error:error];
+    }
+    else {
+      [self logSuccess:@"sign-in anonymously succeeded."];
+      [self log:[NSString stringWithFormat:@"User ID : %@", authResult.user.uid]];
     }
     [self showTypicalUIForUserUpdateResultsWithTitle:kSignInAnonymouslyButtonText error:error];
   }];

--- a/Example/Auth/Sample/MainViewController.m
+++ b/Example/Auth/Sample/MainViewController.m
@@ -2795,7 +2795,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
 }
 
 /** @fn signInAnonymouslyAuthDataResult
-    @brief Signs in as an anonymous user, recieveing an auth result containing a signed in user upon
+    @brief Signs in as an anonymous user, receiving an auth result containing a signed in user upon
         success.
  */
 - (void)signInAnonymouslyAuthDataResult {

--- a/Example/Auth/Sample/MainViewController.m
+++ b/Example/Auth/Sample/MainViewController.m
@@ -2803,8 +2803,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
       ^(FIRAuthDataResult *_Nullable authResult, NSError *_Nullable error) {
     if (error) {
       [self logFailure:@"sign-in anonymously failed" error:error];
-    }
-    else {
+    } else {
       [self logSuccess:@"sign-in anonymously succeeded."];
       [self log:[NSString stringWithFormat:@"User ID : %@", authResult.user.uid]];
     }

--- a/Firebase/Auth/Source/FIRAdditionalUserInfo.m
+++ b/Firebase/Auth/Source/FIRAdditionalUserInfo.m
@@ -50,7 +50,7 @@ static NSString *const kNewUserKey = @"newUser";
                                 isNewUser:verifyAssertionResponse.isNewUser];
 }
 
-- (nullable instancetype)initWithProviderID:(NSString *)providerID
+- (nullable instancetype)initWithProviderID:(nullable NSString *)providerID
                                     profile:(nullable NSDictionary<NSString *, NSObject *> *)profile
                                    username:(nullable NSString *)username
                                   isNewUser:(BOOL)isNewUser {

--- a/Firebase/Auth/Source/FIRAdditionalUserInfo_Internal.h
+++ b/Firebase/Auth/Source/FIRAdditionalUserInfo_Internal.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
     @param username The name of the user.
     @param isNewUser Indicates whether or not the current user was signed in for the first time.
  */
-- (nullable instancetype)initWithProviderID:(NSString *)providerID
+- (nullable instancetype)initWithProviderID:(nullable NSString *)providerID
                                     profile:(nullable NSDictionary<NSString *, NSObject *> *)profile
                                    username:(nullable NSString *)username
                                   isNewUser:(BOOL)isNewUser NS_DESIGNATED_INITIALIZER;

--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -676,6 +676,45 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
   }];
 }
 
+- (void)signInAnonymouslyAndRetrieveDataWithCompletion:(FIRAuthDataResultCallback)completion {
+  dispatch_async(FIRAuthGlobalWorkQueue(), ^{
+    FIRAuthDataResultCallback decoratedCallback =
+        [self signInFlowAuthDataResultCallbackByDecoratingCallback:completion];
+    if (_currentUser.anonymous) {
+      FIRAdditionalUserInfo *additionalUserInfo =
+          [[FIRAdditionalUserInfo alloc] initWithProviderID:nil
+                                                    profile:nil
+                                                   username:nil
+                                                  isNewUser:NO];
+      decoratedCallback([[FIRAuthDataResult alloc] initWithUser:_currentUser
+                                             additionalUserInfo:additionalUserInfo],
+                        nil);
+      return;
+    }
+    [self internalSignInAnonymouslyWithCompletion:^(FIRSignUpNewUserResponse *_Nullable response,
+                                                    NSError *_Nullable error) {
+      if (error) {
+        decoratedCallback(nil, error);
+        return;
+      }
+      [self completeSignInWithAccessToken:response.IDToken
+                accessTokenExpirationDate:response.approximateExpirationDate
+                             refreshToken:response.refreshToken
+                                anonymous:YES
+                                 callback:^(FIRUser *_Nullable user, NSError *_Nullable error) {
+        FIRAdditionalUserInfo *additionalUserInfo =
+          [[FIRAdditionalUserInfo alloc] initWithProviderID:nil
+                                                    profile:nil
+                                                   username:nil
+                                                  isNewUser:YES];
+        decoratedCallback([[FIRAuthDataResult alloc] initWithUser:user
+                                               additionalUserInfo:additionalUserInfo],
+                          nil);
+     }];
+    }];
+  });
+}
+
 - (void)signInAnonymouslyWithCompletion:(FIRAuthResultCallback)completion {
   dispatch_async(FIRAuthGlobalWorkQueue(), ^{
     FIRAuthResultCallback decoratedCallback =
@@ -684,11 +723,8 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
       decoratedCallback(_currentUser, nil);
       return;
     }
-    FIRSignUpNewUserRequest *request =
-        [[FIRSignUpNewUserRequest alloc]initWithRequestConfiguration:_requestConfiguration];
-    [FIRAuthBackend signUpNewUser:request
-                         callback:^(FIRSignUpNewUserResponse *_Nullable response,
-                                    NSError *_Nullable error) {
+    [self internalSignInAnonymouslyWithCompletion:^(FIRSignUpNewUserResponse *_Nullable response,
+                                                    NSError *_Nullable error) {
       if (error) {
         decoratedCallback(nil, error);
         return;
@@ -1091,6 +1127,23 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
   }];
 }
 #endif
+
+/** @fn internalSignInAnonymouslyWithCompletion:
+    @param completion A block which is invoked when the anonymous sign in request completes.
+ */
+- (void)internalSignInAnonymouslyWithCompletion:(FIRSignupNewUserCallback)completion {
+  FIRSignUpNewUserRequest *request =
+      [[FIRSignUpNewUserRequest alloc]initWithRequestConfiguration:_requestConfiguration];
+  [FIRAuthBackend signUpNewUser:request
+                       callback:^(FIRSignUpNewUserResponse *_Nullable response,
+                                  NSError *_Nullable error) {
+    if (error) {
+      completion(nil, error);
+      return;
+    }
+    completion(response, nil);
+  }];
+}
 
 /** @fn possiblyPostAuthStateChangeNotification
     @brief Posts the auth state change notificaton if current user's token has been changed.

--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -709,8 +709,8 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                                    username:nil
                                                   isNewUser:YES];
         FIRAuthDataResult *authDataResult =
-          [[FIRAuthDataResult alloc] initWithUser:user
-                               additionalUserInfo:additionalUserInfo];
+            [[FIRAuthDataResult alloc] initWithUser:user
+                                 additionalUserInfo:additionalUserInfo];
         decoratedCallback(authDataResult, nil);
      }];
     }];

--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -686,9 +686,10 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                                     profile:nil
                                                    username:nil
                                                   isNewUser:NO];
-      decoratedCallback([[FIRAuthDataResult alloc] initWithUser:_currentUser
-                                             additionalUserInfo:additionalUserInfo],
-                        nil);
+      FIRAuthDataResult *authDataResult =
+          [[FIRAuthDataResult alloc] initWithUser:_currentUser
+                               additionalUserInfo:additionalUserInfo];
+      decoratedCallback(authDataResult, nil);
       return;
     }
     [self internalSignInAnonymouslyWithCompletion:^(FIRSignUpNewUserResponse *_Nullable response,
@@ -707,9 +708,10 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                                     profile:nil
                                                    username:nil
                                                   isNewUser:YES];
-        decoratedCallback([[FIRAuthDataResult alloc] initWithUser:user
-                                               additionalUserInfo:additionalUserInfo],
-                          nil);
+        FIRAuthDataResult *authDataResult =
+          [[FIRAuthDataResult alloc] initWithUser:user
+                               additionalUserInfo:additionalUserInfo];
+        decoratedCallback(authDataResult, nil);
      }];
     }];
   });
@@ -1135,14 +1137,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
   FIRSignUpNewUserRequest *request =
       [[FIRSignUpNewUserRequest alloc]initWithRequestConfiguration:_requestConfiguration];
   [FIRAuthBackend signUpNewUser:request
-                       callback:^(FIRSignUpNewUserResponse *_Nullable response,
-                                  NSError *_Nullable error) {
-    if (error) {
-      completion(nil, error);
-      return;
-    }
-    completion(response, nil);
-  }];
+                       callback:completion];
 }
 
 /** @fn possiblyPostAuthStateChangeNotification

--- a/Firebase/Auth/Source/Public/FIRAuth.h
+++ b/Firebase/Auth/Source/Public/FIRAuth.h
@@ -408,6 +408,29 @@ FIR_SWIFT_NAME(Auth)
  */
 - (void)signInAnonymouslyWithCompletion:(nullable FIRAuthResultCallback)completion;
 
+/** @fn signInAnonymouslyAndRetrieveDataWithCompletion:
+    @brief Asynchronously creates and becomes an anonymous user.
+    @param completion Optionally; a block which is invoked when the sign in finishes, or is
+        canceled. Invoked asynchronously on the main thread in the future.
+
+    @remarks If there is already an anonymous user signed in, that user will be returned instead.
+        If there is any other existing user signed in, that user will be signed out.
+
+    @remarks Possible error codes:
+    <ul>
+        <li>@c FIRAuthErrorCodeOperationNotAllowed - Indicates that anonymous accounts are
+            not enabled. Enable them in the Auth section of the Firebase console.
+        </li>
+    </ul>
+
+    @remarks See @c FIRAuthErrors for a list of error codes that are common to all API methods.
+    @remarks This method will only exist until the next major Firebase release following 4.x.x.
+        After the next major release the method @c signInAnonymouslyWithCompletion will support the
+        @c FIRAuthDataResultCallback.
+ */
+- (void)signInAnonymouslyAndRetrieveDataWithCompletion:
+    (nullable FIRAuthDataResultCallback)completion;
+
 /** @fn signInWithCustomToken:completion:
     @brief Asynchronously signs in to Firebase with the given Auth token.
 


### PR DESCRIPTION
Adds `AuthDataResult` to the completion of anonymous sign as part of an effort to supplement all sign-in methods with `AdditionalUserInfo`.