### PR TITLE
Fix a wrong file name in README.md

### DIFF
--- a/Firestore/README.md
+++ b/Firestore/README.md
@@ -3,7 +3,7 @@
 ```
 $ cd Firestore/Example
 $ pod update
-$ open Firebase.xcworkspace
+$ open Firestore.xcworkspace
 Select the FirestoreTests scheme
 ⌘-u to build and run the unit tests
 ```


### PR DESCRIPTION
Firebase.xcworkspace exists in /Example while Firestore.xcworkspace exists in /Firestore/Example. We actually want the developer to open Firestore.xcworkspace.

Hey there! So you want to contribute to a Firebase SDK?
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here.
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help
    us make Firebase APIs better, please propose your change in a feature request so that we
    can discuss it together.
