### PR TITLE
FIRAppInternal.h is a published private header

### DIFF
--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -19,7 +19,7 @@
 #import "FIRAuth_Internal.h"
 
 #import "FIRAppAssociationRegistration.h"
-#import "FIRAppInternal.h"
+#import <FirebaseCore/FIRAppInternal.h>
 #import "FIROptions.h"
 #import "FIRLogger.h"
 #import "AuthProviders/EmailPassword/FIREmailPasswordAuthCredential.h"

--- a/Firebase/Database/Api/FIRDatabase.m
+++ b/Firebase/Database/Api/FIRDatabase.m
@@ -15,8 +15,10 @@
  */
 
 #import <Foundation/Foundation.h>
-#import "FIRAppInternal.h"
-#import "FIRLogger.h"
+
+#import <FirebaseCore/FIRAppInternal.h>
+#import <FirebaseCore/FIRLogger.h>
+
 #import "FIRDatabase.h"
 #import "FIRDatabase_Private.h"
 #import "FIRDatabaseQuery_Private.h"

--- a/Firebase/Database/Login/FAuthTokenProvider.m
+++ b/Firebase/Database/Login/FAuthTokenProvider.m
@@ -16,8 +16,8 @@
 
 #import "FAuthTokenProvider.h"
 #import "FUtilities.h"
-#import "FIRAppInternal.h"
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRAppInternal.h>
+#import <FirebaseCore/FIRLogger.h>
 #import "FIRDatabaseQuery_Private.h"
 #import "FIRNoopAuthTokenProvider.h"
 

--- a/Firebase/Messaging/FIRMessaging+FIRApp.m
+++ b/Firebase/Messaging/FIRMessaging+FIRApp.m
@@ -16,8 +16,8 @@
 
 #import "FIRMessaging+FIRApp.h"
 
-#import "FIRAppInternal.h"
-#import "FIROptionsInternal.h"
+#import <FirebaseCore/FIRAppInternal.h>
+#import <FirebaseCore/FIROptionsInternal.h>
 
 #import "FIRMessagingConstants.h"
 #import "FIRMessagingLogger.h"

--- a/Firebase/Storage/FIRStorageTokenAuthorizer.m
+++ b/Firebase/Storage/FIRStorageTokenAuthorizer.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "FIRAppInternal.h"
+#import <FirebaseCore/FIRAppInternal.h>
 
 #import "FIRStorageTokenAuthorizer.h"
 

--- a/Firestore/Source/Auth/FSTCredentialsProvider.m
+++ b/Firestore/Source/Auth/FSTCredentialsProvider.m
@@ -19,10 +19,8 @@
 #import <FirebaseAuth/FIRAuth.h>
 #import <FirebaseAuth/FIRUser.h>
 #import <FirebaseCore/FIRApp.h>
+#import <FirebaseCore/FIRAppInternal.h>
 #import <GRPCClient/GRPCCall.h>
-
-// This is not an exported header so it's not visible via FirebaseCommunity
-#import "Firebase/Core/Private/FIRAppInternal.h"
 
 #import "FIRFirestoreErrors.h"
 #import "Firestore/Source/Util/FSTAssert.h"

--- a/Firestore/Source/Public/FIRQuery.h
+++ b/Firestore/Source/Public/FIRQuery.h
@@ -394,8 +394,7 @@ NS_SWIFT_NAME(Query)
  *
  * @return The created `FIRQuery`.
  */
-- (FIRQuery *)queryEndingAtDocument:(FIRDocumentSnapshot *)document
-    NS_SWIFT_NAME(end(atDocument:));
+- (FIRQuery *)queryEndingAtDocument:(FIRDocumentSnapshot *)document NS_SWIFT_NAME(end(atDocument:));
 
 /**
  * Creates and returns a new `FIRQuery` that ends at the provided fields relative to the order of

--- a/Firestore/test/core/util/autoid_test.cc
+++ b/Firestore/test/core/util/autoid_test.cc
@@ -27,8 +27,7 @@ TEST(AutoId, IsSane) {
     for (int pos = 0; pos < 20; pos++) {
       char c = auto_id[pos];
       EXPECT_TRUE(isalpha(c) || isdigit(c))
-          << "Should be printable ascii character: '" << c << "' in \"" << auto_id
-          << "\"";
+          << "Should be printable ascii character: '" << c << "' in \"" << auto_id << "\"";
     }
   }
 }


### PR DESCRIPTION
Standardize imports of FIRAppInternal.h since it is now a published private header from Core

@salqadri  discovered the reference from Firestore was breaking the build when it was brought it to the Podfile via 

` pod 'FirebaseFirestore', :git => 'https://github.com/firebase/firebase-ios-sdk.git', :branch => 'master'`

Also fix a few other FirebaseCore privates and two style issues.