### PR TITLE
Include UID when sending (internal) auth state change notifications

### DIFF
--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -1297,6 +1297,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
   if (token.length) {
     internalNotificationParameters[FIRAuthStateDidChangeInternalNotificationTokenKey] = token;
   }
+  internalNotificationParameters[FIRAuthStateDidChangeInternalNotificationUIDKey] = _currentUser.uid;
   NSNotificationCenter *notifications = [NSNotificationCenter defaultCenter];
   dispatch_async(dispatch_get_main_queue(), ^{
     [notifications postNotificationName:FIRAuthStateDidChangeInternalNotification

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -60,6 +60,8 @@ NSString *const FIRAuthStateDidChangeInternalNotificationAppKey =
     @"FIRAuthStateDidChangeInternalNotificationAppKey";
 NSString *const FIRAuthStateDidChangeInternalNotificationTokenKey =
     @"FIRAuthStateDidChangeInternalNotificationTokenKey";
+NSString *const FIRAuthStateDidChangeInternalNotificationUIDKey =
+    @"FIRAuthStateDidChangeInternalNotificationUIDKey";
 
 /**
  * The URL to download plist files.

--- a/Firebase/Core/Private/FIRAppInternal.h
+++ b/Firebase/Core/Private/FIRAppInternal.h
@@ -86,7 +86,7 @@ extern NSString *const FIRAuthStateDidChangeInternalNotificationAppKey;
 /** @var FIRAuthStateDidChangeInternalNotificationUIDKey
  @brief A key present in the dictionary object parameter of the
  @c FIRAuthStateDidChangeInternalNotification notification. The value associated with this
- key will contain the new user's UID.
+ key will contain the new user's UID (or nil if there is no longer a user signed in).
  */
 extern NSString *const FIRAuthStateDidChangeInternalNotificationUIDKey;
 

--- a/Firebase/Core/Private/FIRAppInternal.h
+++ b/Firebase/Core/Private/FIRAppInternal.h
@@ -83,6 +83,13 @@ extern NSString *const FIRAuthStateDidChangeInternalNotificationTokenKey;
  */
 extern NSString *const FIRAuthStateDidChangeInternalNotificationAppKey;
 
+/** @var FIRAuthStateDidChangeInternalNotificationUIDKey
+ @brief A key present in the dictionary object parameter of the
+ @c FIRAuthStateDidChangeInternalNotification notification. The value associated with this
+ key will contain the new user's UID.
+ */
+extern NSString *const FIRAuthStateDidChangeInternalNotificationUIDKey;
+
 /** @typedef FIRTokenCallback
     @brief The type of block which gets called when a token is ready.
  */


### PR DESCRIPTION
This is to allow firestore to not require an explicit dependency on
auth.

(See https://github.com/firebase/firebase-ios-sdk/pull/505 for more context.)