### PR TITLE
Allow clang-format to find Firestore/Source/Auth

### DIFF
--- a/Firestore/Source/Auth/FSTCredentialsProvider.h
+++ b/Firestore/Source/Auth/FSTCredentialsProvider.h
@@ -66,7 +66,7 @@ typedef void (^FSTVoidUserBlock)(FSTUser *user);
 #pragma mark - FSTCredentialsProvider
 
 /** Provides methods for getting the uid and token for the current user and listen for changes. */
-@protocol FSTCredentialsProvider<NSObject>
+@protocol FSTCredentialsProvider <NSObject>
 
 /** Requests token for the current user, optionally forcing a refreshed token to be fetched. */
 - (void)getTokenForcingRefresh:(BOOL)forceRefresh completion:(FSTVoidGetTokenResultBlock)completion;
@@ -95,7 +95,7 @@ typedef void (^FSTVoidUserBlock)(FSTUser *user);
  * backing our internal worker queue and the callbacks from FIRAuth will be executed on an
  * arbitrary different thread.
  */
-@interface FSTFirebaseCredentialsProvider : NSObject<FSTCredentialsProvider>
+@interface FSTFirebaseCredentialsProvider : NSObject <FSTCredentialsProvider>
 
 /**
  * Initializes a new FSTFirebaseCredentialsProvider.

--- a/Firestore/Source/Auth/FSTCredentialsProvider.m
+++ b/Firestore/Source/Auth/FSTCredentialsProvider.m
@@ -23,10 +23,10 @@
 #import <GRPCClient/GRPCCall.h>
 
 #import "FIRFirestoreErrors.h"
+#import "Firestore/Source/Auth/FSTUser.h"
 #import "Firestore/Source/Util/FSTAssert.h"
 #import "Firestore/Source/Util/FSTClasses.h"
 #import "Firestore/Source/Util/FSTDispatchQueue.h"
-#import "Firestore/Source/Auth/FSTUser.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -108,24 +108,24 @@ NS_ASSUME_NONNULL_BEGIN
   // FIRFirestoreErrorCodeAborted error) if there is a user change while the request is outstanding.
   int initialUserCounter = self.userCounter;
 
-  void (^getTokenCallback)(NSString *, NSError *) = ^(NSString *_Nullable token,
-                                                      NSError *_Nullable error) {
-    @synchronized(self) {
-      if (initialUserCounter != self.userCounter) {
-        // Cancel the request since the user changed while the request was outstanding so the
-        // response is likely for a previous user (which user, we can't be sure).
-        NSDictionary *errorInfo = @{ @"details" : @"getToken aborted due to user change." };
-        NSError *cancelError = [NSError errorWithDomain:FIRFirestoreErrorDomain
-                                                   code:FIRFirestoreErrorCodeAborted
-                                               userInfo:errorInfo];
-        completion(nil, cancelError);
-      } else {
-        FSTGetTokenResult *result =
-            [[FSTGetTokenResult alloc] initWithUser:self.currentUser token:token];
-        completion(result, error);
-      }
-    };
-  };
+  void (^getTokenCallback)(NSString *, NSError *) =
+      ^(NSString *_Nullable token, NSError *_Nullable error) {
+        @synchronized(self) {
+          if (initialUserCounter != self.userCounter) {
+            // Cancel the request since the user changed while the request was outstanding so the
+            // response is likely for a previous user (which user, we can't be sure).
+            NSDictionary *errorInfo = @{@"details" : @"getToken aborted due to user change."};
+            NSError *cancelError = [NSError errorWithDomain:FIRFirestoreErrorDomain
+                                                       code:FIRFirestoreErrorCodeAborted
+                                                   userInfo:errorInfo];
+            completion(nil, cancelError);
+          } else {
+            FSTGetTokenResult *result =
+                [[FSTGetTokenResult alloc] initWithUser:self.currentUser token:token];
+            completion(result, error);
+          }
+        };
+      };
 
   [self.app getTokenForcingRefresh:forceRefresh withCallback:getTokenCallback];
 }

--- a/Firestore/Source/Auth/FSTEmptyCredentialsProvider.h
+++ b/Firestore/Source/Auth/FSTEmptyCredentialsProvider.h
@@ -21,7 +21,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** `FSTEmptyCredentialsProvider` always yields an empty token. */
-@interface FSTEmptyCredentialsProvider : NSObject<FSTCredentialsProvider>
+@interface FSTEmptyCredentialsProvider : NSObject <FSTCredentialsProvider>
 
 @end
 

--- a/Firestore/Source/Auth/FSTUser.h
+++ b/Firestore/Source/Auth/FSTUser.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Simple wrapper around a nullable UID. Mostly exists to make code more readable and for use as
  * a key in dictionaries (since keys cannot be nil).
  */
-@interface FSTUser : NSObject<NSCopying>
+@interface FSTUser : NSObject <NSCopying>
 
 /** Returns an FSTUser with a nil UID. */
 + (instancetype)unauthenticatedUser;

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -11,7 +11,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find . -type f | sed -E -n '
+# Usage:
+# ./scripts/style.sh [branch-name | filenames]
+#
+# With no arguments, formats all eligible files in the repo
+# Pass a branch name to format all eligible files changed since that branch
+# Pass a specific file or directory name to format just files found there
+#
+# Commonly
+# ./scripts/style.sh master
+
+set -euo pipefail
+
+(
+  if [[ $# -gt 0 ]]; then
+    if git rev-parse "$1" -- >& /dev/null; then
+      # Argument was a branch name show files changed since that branch
+      git diff --name-only --relative
+    else
+      # Otherwise assume the passed things are files or directories
+      find "$@" -type f
+    fi
+  else
+    # Do everything by default
+    find . -type f
+  fi
+) | sed -E -n '
 # Build outputs
 /\/Pods\// d
 /^.\/build\// d

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -38,19 +38,19 @@ set -euo pipefail
   fi
 ) | sed -E -n '
 # Build outputs
-/\/Pods\// d
-/^.\/build\// d
+\%/Pods/% d
+\%^./build/% d
 
 # Sources controlled outside this tree
-/\/third_party\// d
-/\/Firestore\/Port\// d
+\%/third_party/% d
+\%/Firestore/Port/% d
 
 # Sources within the tree that are not subject to formatting
-/^.\/(Example|Firebase)\/(Auth|AuthSamples|Database|Messaging)\// d
+\%^./(Example|Firebase)/(Auth|AuthSamples|Database|Messaging)/% d
 
 # Checked-in generated code
-/\.pb(objc|rpc)\./ d
+\%\.pb(objc|rpc)\.% d
 
 # Format C-ish sources only
-/\.(h|m|mm|cc)$/ p
+\%\.(h|m|mm|cc)$% p
 ' | xargs clang-format -style=file -i

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -11,16 +11,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find . \
-    -name 'third_party' -prune -o \
-    -name 'Auth' -prune -o \
-    -name 'AuthSamples' -prune -o \
-    -name 'Database' -prune -o \
-    -name 'FirebaseCommunity.h' -prune -o \
-    -name 'Messaging' -prune -o \
-    -name 'Pods' -prune -o \
-    -path '*/Firestore/Port/*' -prune -o \
-    \( -name '*.[mh]' -o -name '*.mm' -o -name '*.cc' \) \
-    -not -name '*.pbobjc.*' \
-    -not -name '*.pbrpc.*' \
-    -print0 | xargs -0 clang-format -style=file -i
+find . -type f | sed -E -n '
+# Build outputs
+/\/Pods\// d
+/^.\/build\// d
+
+# Sources controlled outside this tree
+/\/third_party\// d
+/\/Firestore\/Port\// d
+
+# Sources within the tree that are not subject to formatting
+/^.\/(Example|Firebase)\/(Auth|AuthSamples|Database|Messaging)\// d
+
+# Checked-in generated code
+/\.pb(objc|rpc)\./ d
+
+# Format C-ish sources only
+/\.(h|m|mm|cc)$/ p
+' | xargs clang-format -style=file -i


### PR DESCRIPTION
Change `scripts/style.sh` to filter out excluded sources more precisely.

Also add the ability to format just specific files or files changed since some branch.

Fixes [b/69924409](http://b/69924409).

/cc @rsgowman 