### PR TITLE
Remove no longer necessary FirebaseCommunity/Messaging workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,6 @@ To run the Database Integration tests, make your database authentication rules
 To run the Storage Integration tests, follow the instructions in
 [FIRStorageIntegrationTests.m](Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m).
 
-### Firebase Messaging
-
-To use Messaging, include `pod 'FirebaseInstanceID'` in your Podfile, in addition to
-`pod 'FirebaseCommunity/Messaging'`.
-
 #### Push Notifications
 
 Push notifications can only be delivered to specially provisioned App IDs in the developer portal.


### PR DESCRIPTION
With Firebase 4.7.0, open source pods integrate with the official release Firebase pods and FirebaseCommunity is gone,  so it's no longer to explicitly add FirebaseInstanceID to the Podfile since it's an explicit dependency of FirebaseMessaging.