### PR TITLE
FCM version function should return only the semantic version 

### DIFF
--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -709,12 +709,8 @@ NSString * const FIRMessagingRegistrationTokenRefreshedNotification =
 
 #pragma mark - IID dependencies
 
-// FIRMessagingInternalUtilities.h to see usage.
 + (NSString *)FIRMessagingSDKVersion {
-  NSString *semanticVersion = FIRMessagingCurrentLibraryVersion();
-  // Use prefix fcm for all FCM libs. This allows us to differentiate b/w
-  // the new and old FCM registrations.
-  return [NSString stringWithFormat:@"fcm-%@", semanticVersion];
+  return FIRMessagingCurrentLibraryVersion();
 }
 
 + (NSString *)FIRMessagingSDKCurrentLocale {


### PR DESCRIPTION
FCM SDK version function should only return the semantic version string instead of prefixing a "fcm-", this way IID can adjust the parameter prefix.