### PR TITLE
Ignoring stream messages for closed streams

### DIFF
--- a/Firestore/Source/Remote/FSTStream.m
+++ b/Firestore/Source/Remote/FSTStream.m
@@ -542,9 +542,10 @@ static const NSTimeInterval kIdleTimeout = 60.0;
   FSTWeakify(self);
   [self.workerDispatchQueue dispatchAsync:^{
     FSTStrongify(self);
-    if (!self || self.state == FSTStreamStateStopped) {
-      return;
+    if (!self || ![self isStarted]) {
+      FSTLog(@"%@ Ignoring stream message from inactive stream.", NSStringFromClass([self class]));
     }
+
     if (!self.messageReceived) {
       self.messageReceived = YES;
       if ([FIRFirestore isLoggingEnabled]) {


### PR DESCRIPTION
This is a follow-up PR to https://github.com/firebase/firebase-ios-sdk/pull/510.

I believe the race condition also exists for stream messages in general (and not just stream closes). While it is unlikely that we will receive a stream message from a stream we deemed idle, we should still suppress all callbacks as we do on the Web and Android.