### PR TITLE
Standardize cross module imports with angle bracket syntax

### DIFF
--- a/Example/Analytics_Tests_iOS/Analytics_Tests_iOS.m
+++ b/Example/Analytics_Tests_iOS/Analytics_Tests_iOS.m
@@ -21,17 +21,19 @@
 @implementation Analytics_Tests_iOS
 
 - (void)setUp {
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
+  [super setUp];
+  // Put setup code here. This method is called before the invocation of each test method in the
+  // class.
 }
 
 - (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
+  // Put teardown code here. This method is called after the invocation of each test method in the
+  // class.
+  [super tearDown];
 }
 
 - (void)testExample {
-    // Replace with a real test if we ever want to do Analytics unit tests here.
+  // Replace with a real test if we ever want to do Analytics unit tests here.
 }
 
 @end

--- a/Example/Auth/ApiTests/FirebaseAuthApiTests.m
+++ b/Example/Auth/ApiTests/FirebaseAuthApiTests.m
@@ -17,7 +17,7 @@
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
-#import "FIRApp.h"
+#import <FirebaseCore/FIRApp.h>
 #import "FirebaseAuth.h"
 #import "AuthCredentials.h"
 

--- a/Example/Auth/EarlGreyTests/FirebaseAuthEarlGreyTests.m
+++ b/Example/Auth/EarlGreyTests/FirebaseAuthEarlGreyTests.m
@@ -18,7 +18,7 @@
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
-#import "FIRApp.h"
+#import <FirebaseCore/FIRApp.h>
 #import "FirebaseAuth.h"
 
 #ifdef NO_NETWORK

--- a/Example/Auth/Sample/AppManager.m
+++ b/Example/Auth/Sample/AppManager.m
@@ -16,7 +16,7 @@
 
 #import "AppManager.h"
 
-#import "FIRApp.h"
+#import <FirebaseCore/FIRApp.h>
 #import "FIRPhoneAuthProvider.h"
 #import "FirebaseAuth.h"
 

--- a/Example/Auth/Sample/GoogleAuthProvider.m
+++ b/Example/Auth/Sample/GoogleAuthProvider.m
@@ -19,8 +19,8 @@
 #import <GoogleSignIn/GoogleSignIn.h>
 
 #import "AppManager.h"
-#import "FIRApp.h"
-#import "FIROptions.h"
+#import <FirebaseCore/FIRApp.h>
+#import <FirebaseCore/FIROptions.h>
 #import "FIRGoogleAuthProvider.h"
 #import "ApplicationDelegate.h"
 

--- a/Example/Auth/Sample/SettingsViewController.m
+++ b/Example/Auth/Sample/SettingsViewController.m
@@ -19,13 +19,13 @@
 #import <objc/runtime.h>
 
 #import "AppManager.h"
-#import "FIRApp.h"
+#import <FirebaseCore/FIRApp.h>
 #import "FIRAuth_Internal.h"
 #import "FIRAuthAPNSToken.h"
 #import "FIRAuthAPNSTokenManager.h"
 #import "FIRAuthAppCredential.h"
 #import "FIRAuthAppCredentialManager.h"
-#import "FIROptions.h"
+#import <FirebaseCore/FIROptions.h>
 #import "FirebaseAuth.h"
 #import "StaticContentTableViewManager.h"
 #import "UIViewController+Alerts.h"

--- a/Example/Auth/Tests/FIRPhoneAuthProviderTests.m
+++ b/Example/Auth/Tests/FIRPhoneAuthProviderTests.m
@@ -20,7 +20,7 @@
 
 #import "FIRAuth.h"
 #import "FIRPhoneAuthProvider.h"
-#import "FIRApp.h"
+#import <FirebaseCore/FIRApp.h>
 #import "FIRAuth_Internal.h"
 #import "FIRAuthAPNSToken.h"
 #import "FIRAuthAPNSTokenManager.h"
@@ -38,7 +38,7 @@
 #import "FIRGetProjectConfigResponse.h"
 #import "FIRSendVerificationCodeRequest.h"
 #import "FIRSendVerificationCodeResponse.h"
-#import "FIROptions.h"
+#import <FirebaseCore/FIROptions.h>
 #import "FIRVerifyClientRequest.h"
 #import "FIRVerifyClientResponse.h"
 #import "OCMStubRecorder+FIRAuthUnitTests.h"

--- a/Example/Database/Tests/Helpers/FTestHelpers.m
+++ b/Example/Database/Tests/Helpers/FTestHelpers.m
@@ -16,8 +16,8 @@
 
 #import "FTestHelpers.h"
 #import "FConstants.h"
-#import "FIRApp.h"
-#import "FIROptions.h"
+#import <FirebaseCore/FIRApp.h>
+#import <FirebaseCore/FIROptions.h>
 #import "FIRDatabaseConfig_Private.h"
 #import "FTestAuthTokenGenerator.h"
 

--- a/Example/Database/Tests/Integration/FData.m
+++ b/Example/Database/Tests/Integration/FData.m
@@ -18,10 +18,10 @@
 #import "FTestHelpers.h"
 #import "FEventTester.h"
 #import "FTupleEventTypeString.h"
-#import "FIRApp.h"
+#import <FirebaseCore/FIRApp.h>
 #import "FIRDatabaseQuery_Private.h"
 #import "FIRDatabaseConfig_Private.h"
-#import "FIROptions.h"
+#import <FirebaseCore/FIROptions.h>
 #import "FRepo_Private.h"
 #import <limits.h>
 

--- a/Example/Database/Tests/Integration/FIRDatabaseTests.m
+++ b/Example/Database/Tests/Integration/FIRDatabaseTests.m
@@ -22,7 +22,7 @@
 #import "FIRDatabaseReference_Private.h"
 #import "FIRDatabase.h"
 #import "FIRDatabaseConfig_Private.h"
-#import "FIROptions.h"
+#import <FirebaseCore/FIROptions.h>
 #import "FTestHelpers.h"
 #import "FMockStorageEngine.h"
 #import "FTestBase.h"

--- a/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
@@ -18,8 +18,8 @@
 
 #import "FirebaseStorage.h"
 
-#import "FIRApp.h"
-#import "FIROptions.h"
+#import <FirebaseCore/FIRApp.h>
+#import <FirebaseCore/FIROptions.h>
 
 NSTimeInterval kFIRStorageIntegrationTestTimeout = 30;
 

--- a/Example/Storage/Tests/Unit/FIRStorageTestHelpers.h
+++ b/Example/Storage/Tests/Unit/FIRStorageTestHelpers.h
@@ -18,8 +18,8 @@
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
-#import "FIRApp.h"
-#import "FIROptions.h"
+#import <FirebaseCore/FIRApp.h>
+#import <FirebaseCore/FIROptions.h>
 
 #import "FIRStorageConstants.h"
 #import "FIRStorageConstants_Private.h"

--- a/Firebase/Auth/Source/AuthProviders/Phone/FIRPhoneAuthProvider.m
+++ b/Firebase/Auth/Source/AuthProviders/Phone/FIRPhoneAuthProvider.m
@@ -18,9 +18,9 @@
 
 #import <GoogleToolboxForMac/GTMNSDictionary+URLArguments.h>
 
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 #import "FIRPhoneAuthCredential_Internal.h"
-#import "FIRApp.h"
+#import <FirebaseCore/FIRApp.h>
 #import "FIRAuthAPNSToken.h"
 #import "FIRAuthAPNSTokenManager.h"
 #import "FIRAuthAppCredential.h"
@@ -32,7 +32,7 @@
 #import "FIRAuthErrorUtils.h"
 #import "FIRAuthBackend.h"
 #import "FirebaseAuthVersion.h"
-#import "FIROptions.h"
+#import <FirebaseCore/FIROptions.h>
 #import "FIRGetProjectConfigRequest.h"
 #import "FIRGetProjectConfigResponse.h"
 #import "FIRSendVerificationCodeRequest.h"

--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -18,10 +18,11 @@
 
 #import "FIRAuth_Internal.h"
 
-#import "FIRAppAssociationRegistration.h"
+#import <FirebaseCore/FIRAppAssociationRegistration.h>
 #import <FirebaseCore/FIRAppInternal.h>
-#import "FIROptions.h"
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
+#import <FirebaseCore/FIROptions.h>
+
 #import "AuthProviders/EmailPassword/FIREmailPasswordAuthCredential.h"
 #import "FIRAdditionalUserInfo_Internal.h"
 #import "FIRAuthCredential_Internal.h"

--- a/Firebase/Auth/Source/FIRAuthAPNSTokenManager.m
+++ b/Firebase/Auth/Source/FIRAuthAPNSTokenManager.m
@@ -16,7 +16,7 @@
 
 #import "FIRAuthAPNSTokenManager.h"
 
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 #import "FIRAuthAPNSToken.h"
 #import "FIRAuthGlobalWorkQueue.h"
 

--- a/Firebase/Auth/Source/FIRAuthNotificationManager.m
+++ b/Firebase/Auth/Source/FIRAuthNotificationManager.m
@@ -16,7 +16,7 @@
 
 #import "FIRAuthNotificationManager.h"
 
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 #import "FIRAuthAppCredential.h"
 #import "FIRAuthAppCredentialManager.h"
 #import "FIRAuthGlobalWorkQueue.h"

--- a/Firebase/Auth/Source/FIRUser.m
+++ b/Firebase/Auth/Source/FIRUser.m
@@ -37,7 +37,7 @@
 #import "FIRGetAccountInfoResponse.h"
 #import "FIRGetOOBConfirmationCodeRequest.h"
 #import "FIRGetOOBConfirmationCodeResponse.h"
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 #import "FIRSecureTokenService.h"
 #import "FIRSetAccountInfoRequest.h"
 #import "FIRSetAccountInfoResponse.h"

--- a/Firebase/Database/Api/FIRDatabase.m
+++ b/Firebase/Database/Api/FIRDatabase.m
@@ -28,7 +28,7 @@
 #import "FRepoInfo.h"
 #import "FIRDatabaseConfig.h"
 #import "FIRDatabaseReference_Private.h"
-#import "FIROptions.h"
+#import <FirebaseCore/FIROptions.h>
 
 @interface FIRDatabase ()
 @property (nonatomic, strong) FRepoInfo *repoInfo;

--- a/Firebase/Database/Api/FIRDatabaseConfig.m
+++ b/Firebase/Database/Api/FIRDatabaseConfig.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "FIRApp.h"
+#import <FirebaseCore/FIRApp.h>
 #import "FIRDatabaseConfig.h"
 #import "FIRDatabaseConfig_Private.h"
 #import "FIRNoopAuthTokenProvider.h"

--- a/Firebase/Database/Core/FPersistentConnection.m
+++ b/Firebase/Database/Core/FPersistentConnection.m
@@ -15,7 +15,7 @@
  */
 #import <Foundation/Foundation.h>
 
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 #import <SystemConfiguration/SystemConfiguration.h>
 #import <netinet/in.h>
 #import <dlfcn.h>

--- a/Firebase/Database/Core/FRepo.m
+++ b/Firebase/Database/Core/FRepo.m
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 #import <dlfcn.h>
 #import "FRepo.h"
 #import "FSnapshotUtilities.h"

--- a/Firebase/Database/Core/FRepoManager.m
+++ b/Firebase/Database/Core/FRepoManager.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 #import "FRepoManager.h"
 #import "FRepo.h"
 #import "FIRDatabaseQuery_Private.h"

--- a/Firebase/Database/Core/FSyncTree.m
+++ b/Firebase/Database/Core/FSyncTree.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 #import "FSyncTree.h"
 #import "FListenProvider.h"
 #import "FWriteTree.h"

--- a/Firebase/Database/Core/Utilities/FIRRetryHelper.m
+++ b/Firebase/Database/Core/Utilities/FIRRetryHelper.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 #import "FIRRetryHelper.h"
 #import "FUtilities.h"
 

--- a/Firebase/Database/Core/View/FChildEventRegistration.m
+++ b/Firebase/Database/Core/View/FChildEventRegistration.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 #import "FChildEventRegistration.h"
 #import "FIRDatabaseQuery_Private.h"
 #import "FQueryParams.h"

--- a/Firebase/Database/Core/View/FValueEventRegistration.m
+++ b/Firebase/Database/Core/View/FValueEventRegistration.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 #import "FValueEventRegistration.h"
 #import "FIRDatabaseQuery_Private.h"
 #import "FQueryParams.h"

--- a/Firebase/Database/FIRDatabaseReference.m
+++ b/Firebase/Database/FIRDatabaseReference.m
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#import "FIRApp.h"
+#import <FirebaseCore/FIRApp.h>
 #import "FIRDatabaseReference.h"
-#import "FIROptions.h"
+#import <FirebaseCore/FIROptions.h>
 #import "FUtilities.h"
 #import "FNextPushId.h"
 #import "FIRDatabaseQuery_Private.h"

--- a/Firebase/Database/Persistence/FLevelDBStorageEngine.m
+++ b/Firebase/Database/Persistence/FLevelDBStorageEngine.m
@@ -18,7 +18,7 @@
 
 #import "FLevelDBStorageEngine.h"
 
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 #import "APLevelDB.h"
 #import "FSnapshotUtilities.h"
 #import "FWriteRecord.h"

--- a/Firebase/Database/Persistence/FPersistenceManager.m
+++ b/Firebase/Database/Persistence/FPersistenceManager.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 #import "FPersistenceManager.h"
 #import "FLevelDBStorageEngine.h"
 #import "FCacheNode.h"

--- a/Firebase/Database/Persistence/FTrackedQueryManager.m
+++ b/Firebase/Database/Persistence/FTrackedQueryManager.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 #import "FTrackedQueryManager.h"
 #import "FImmutableTree.h"
 #import "FLevelDBStorageEngine.h"

--- a/Firebase/Database/Realtime/FConnection.m
+++ b/Firebase/Database/Realtime/FConnection.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 #import "FConnection.h"
 #import "FConstants.h"
 

--- a/Firebase/Database/Realtime/FWebSocketConnection.m
+++ b/Firebase/Database/Realtime/FWebSocketConnection.m
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 #import "FWebSocketConnection.h"
 #import "FConstants.h"
 #import "FIRDatabaseReference.h"

--- a/Firebase/Database/Utilities/FUtilities.m
+++ b/Firebase/Database/Utilities/FUtilities.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 #import "FUtilities.h"
 #import "FStringUtilities.h"
 #import "FConstants.h"

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -37,7 +37,7 @@
 #import "FIRMessagingUtilities.h"
 #import "FIRMessagingVersionUtilities.h"
 
-#import "FIRReachabilityChecker.h"
+#import <FirebaseCore/FIRReachabilityChecker.h>
 
 #import "NSError+FIRMessaging.h"
 

--- a/Firebase/Messaging/FIRMessagingClient.m
+++ b/Firebase/Messaging/FIRMessagingClient.m
@@ -16,6 +16,8 @@
 
 #import "FIRMessagingClient.h"
 
+#import <FirebaseCore/FIRReachabilityChecker.h>
+
 #import "FIRMessagingConnection.h"
 #import "FIRMessagingConstants.h"
 #import "FIRMessagingDataMessageManager.h"
@@ -25,7 +27,6 @@
 #import "FIRMessagingRmqManager.h"
 #import "FIRMessagingTopicsCommon.h"
 #import "FIRMessagingUtilities.h"
-#import "FIRReachabilityChecker.h"
 #import "NSError+FIRMessaging.h"
 
 static const NSTimeInterval kConnectTimeoutInterval = 40.0;

--- a/Firebase/Messaging/FIRMessagingLogger.m
+++ b/Firebase/Messaging/FIRMessagingLogger.m
@@ -16,7 +16,7 @@
 
 #import "FIRMessagingLogger.h"
 
-#import "FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 
 @implementation FIRMessagingLogger
 

--- a/Firebase/Storage/FIRStorage.m
+++ b/Firebase/Storage/FIRStorage.m
@@ -22,8 +22,8 @@
 #import "FIRStorageUtils.h"
 #import "FIRStorage_Private.h"
 
-#import "FIRApp.h"
-#import "FIROptions.h"
+#import <FirebaseCore/FIRApp.h>
+#import <FirebaseCore/FIROptions.h>
 
 #import <GTMSessionFetcher/GTMSessionFetcher.h>
 #import <GTMSessionFetcher/GTMSessionFetcherLogging.h>

--- a/Firebase/Storage/FIRStorageReference.m
+++ b/Firebase/Storage/FIRStorageReference.m
@@ -28,8 +28,8 @@
 #import "FIRStorageUtils.h"
 #import "FIRStorage_Private.h"
 
-#import "FIRApp.h"
-#import "FIROptions.h"
+#import <FirebaseCore/FIRApp.h>
+#import <FirebaseCore/FIROptions.h>
 
 #import <GTMSessionFetcher/GTMSessionFetcher.h>
 #import "GTMSessionFetcherService.h"

--- a/Firebase/Storage/FIRStorageTokenAuthorizer.m
+++ b/Firebase/Storage/FIRStorageTokenAuthorizer.m
@@ -22,8 +22,8 @@
 
 #import "FirebaseStorage.h"
 
-#import "FIRApp.h"
-#import "FIROptions.h"
+#import <FirebaseCore/FIRApp.h>
+#import <FirebaseCore/FIROptions.h>
 
 @implementation FIRStorageTokenAuthorizer {
  @private

--- a/Firestore/Source/Remote/FSTStream.m
+++ b/Firestore/Source/Remote/FSTStream.m
@@ -516,7 +516,7 @@ static const NSTimeInterval kIdleTimeout = 60.0;
 - (void)handleStreamClose:(nullable NSError *)error {
   FSTLog(@"%@ %p close: %@", NSStringFromClass([self class]), (__bridge void *)self, error);
 
-  if (![self isStarted]) {   // The stream could have already been closed by the idle close timer.
+  if (![self isStarted]) {  // The stream could have already been closed by the idle close timer.
     FSTLog(@"%@ Ignoring server close for already closed stream.", NSStringFromClass([self class]));
     return;
   }


### PR DESCRIPTION
- Qualify all cross-pod imports of FirebaseCore headers
- style for a few recent PRs

cc: @protocol86 @schmidt-sebastian @OleksiyA @wilhuff 