### PR TITLE
Add log to warn users of iOS 7 deprecation.

### DIFF
--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -131,6 +131,21 @@ static FIRApp *sDefaultApp;
       [FIRApp sendNotificationsToSDKs:sDefaultApp];
       sDefaultApp.alreadySentConfigureNotification = YES;
     }
+
+#if DEBUG
+    // Support for iOS 7 has been deprecated, but will continue to function for the time being. Log
+    // a warning for developers who are still targeting iOS 7 as the minimum OS version supported.
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
+      NSDictionary<NSString *, id> *info = [[NSBundle mainBundle] infoDictionary];
+
+      NSString *minVersion = info[@"MinimumOSVersion"];
+      if ([minVersion hasPrefix:@"7."]) {
+        FIRLogNotice(kFIRLoggerCore, @"I-COR000026", @"Support for iOS 7 is deprecated and will "
+                     @"stop working in the future. Please upgrade your app to target iOS 8 or "
+                     @"above.");
+      }
+    });
+#endif  // DEBUG
   }
 }
 

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -134,7 +134,7 @@ static FIRApp *sDefaultApp;
 
 #if DEBUG
     // Support for iOS 7 has been deprecated, but will continue to function for the time being. Log
-    // a warning for developers who are still targeting iOS 7 as the minimum OS version supported.
+    // a notice for developers who are still targeting iOS 7 as the minimum OS version supported.
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
       NSDictionary<NSString *, id> *info = [[NSBundle mainBundle] infoDictionary];
 


### PR DESCRIPTION
This matches the [prerequisites](https://firebase.google.com/docs/ios/setup#prerequisites) on our site for people that may have missed it.