### PR TITLE
Add FirebaseFirestore.h to fix Firebase module in source build

### DIFF
--- a/Firestore/Source/Public/FirebaseFirestore.h
+++ b/Firestore/Source/Public/FirebaseFirestore.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCollectionReference.h"
+#import "FIRDocumentChange.h"
+#import "FIRDocumentReference.h"
+#import "FIRDocumentSnapshot.h"
+#import "FIRFieldPath.h"
+#import "FIRFieldValue.h"
+#import "FIRFirestore.h"
+#import "FIRFirestoreErrors.h"
+#import "FIRFirestoreSettings.h"
+#import "FIRGeoPoint.h"
+#import "FIRListenerRegistration.h"
+#import "FIRQuery.h"
+#import "FIRQuerySnapshot.h"
+#import "FIRSetOptions.h"
+#import "FIRSnapshotMetadata.h"
+#import "FIRTransaction.h"
+#import "FIRWriteBatch.h"


### PR DESCRIPTION
Add a second umbrella header so that the Firebase module will include the Firestore umbrella header in source builds.

Changing Firebase.h to check for Firestore-umbrella.h would not work because umbrella headers only get generated by CocoaPods when `use_frameworks!` is specified and the name of the umbrella header may or may not be qualified by a target if the Podfile specifies multiple Apple targets.

More details internally at b/70281259