### PR TITLE
Double auth unit test timeout to address travis flakiness

### DIFF
--- a/Example/Auth/Tests/FIRAuthAPNSTokenManagerTests.m
+++ b/Example/Auth/Tests/FIRAuthAPNSTokenManagerTests.m
@@ -31,7 +31,7 @@ static const NSTimeInterval kRegistrationTimeout = .5;
     @brief The test expectation timeout.
     @remarks This must be considerably greater than @c kVerificationTimeout .
  */
-static const NSTimeInterval kExpectationTimeout = 1;
+static const NSTimeInterval kExpectationTimeout = 2;
 
 /** @class FIRAuthLegacyUIApplication
     @brief A fake legacy (< iOS 7) UIApplication class.

--- a/Example/Auth/Tests/FIRAuthDispatcherTests.m
+++ b/Example/Auth/Tests/FIRAuthDispatcherTests.m
@@ -32,7 +32,7 @@ NSTimeInterval kTestDelay = 0.1;
 /** @var kExpectationTimeout
     @brief The maximum time waiting for expectations to fulfill.
  */
-static const NSTimeInterval kExpectationTimeout = 1;
+static const NSTimeInterval kExpectationTimeout = 2;
 
 id<OS_dispatch_queue> testWorkQueue;
 

--- a/Example/Auth/Tests/FIRAuthTests.m
+++ b/Example/Auth/Tests/FIRAuthTests.m
@@ -170,7 +170,7 @@ static NSString *const kVerificationID = @"55432";
 /** @var kExpectationTimeout
     @brief The maximum time waiting for expectations to fulfill.
  */
-static const NSTimeInterval kExpectationTimeout = 1;
+static const NSTimeInterval kExpectationTimeout = 2;
 
 /** @var kWaitInterval
     @brief The time waiting for background tasks to finish before continue when necessary.

--- a/Example/Auth/Tests/FIRAuthURLPresenterTests.m
+++ b/Example/Auth/Tests/FIRAuthURLPresenterTests.m
@@ -26,7 +26,7 @@
 /** @var kExpectationTimeout
     @brief The maximum time waiting for expectations to fulfill.
  */
-static NSTimeInterval kExpectationTimeout = 1;
+static NSTimeInterval kExpectationTimeout = 2;
 
 @interface FIRAuthDefaultUIDelegate : NSObject <FIRAuthUIDelegate>
 /** @fn defaultUIDelegate

--- a/Example/Auth/Tests/FIRPhoneAuthProviderTests.m
+++ b/Example/Auth/Tests/FIRPhoneAuthProviderTests.m
@@ -180,7 +180,7 @@ static const NSTimeInterval kTestTimeout = 5;
 /** @var kExpectationTimeout
     @brief The maximum time waiting for expectations to fulfill.
  */
-static const NSTimeInterval kExpectationTimeout = 1;
+static const NSTimeInterval kExpectationTimeout = 2;
 
 /** @class FIRPhoneAuthProviderTests
     @brief Tests for @c FIRPhoneAuthProvider

--- a/Example/Auth/Tests/FIRUserTests.m
+++ b/Example/Auth/Tests/FIRUserTests.m
@@ -231,7 +231,7 @@ static NSTimeInterval const  kLastSignInDateTimeIntervalInSeconds = 1505858583;
 /** @var kExpectationTimeout
     @brief The maximum time waiting for expectations to fulfill.
  */
-static const NSTimeInterval kExpectationTimeout = 1;
+static const NSTimeInterval kExpectationTimeout = 2;
 
 /** @class FIRUserTests
     @brief Tests for @c FIRUser .


### PR DESCRIPTION
Close #406

This timeout test failure has occurred twice again today. Most recently on #543's [travis run](https://travis-ci.org/firebase/firebase-ios-sdk/builds/313602740)

cc: @wilhuff 