### PR TITLE
Expose network management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ Podfile.lock
 
 # CMake
 .downloads
+.idea/

--- a/Firestore/Example/SwiftBuildTest/main.swift
+++ b/Firestore/Example/SwiftBuildTest/main.swift
@@ -39,6 +39,8 @@ func main() {
 
     listenToDocuments(matching: query);
 
+    enableDisableNetwork(db: db);
+
     types();
 }
 
@@ -128,6 +130,23 @@ func writeDocument(at docRef: DocumentReference) {
         }
 
         print("Set complete!")
+    }
+}
+
+func enableDisableNetwork(db db: Firestore) {
+    // closure syntax
+    db.disableNetwork(completion: { (error) in
+        if let e = error {
+            print("Uh oh! \(e)")
+            return
+        }
+    })
+    // trailing block syntax
+    db.enableNetwork { (error) in
+        if let e = error {
+            print("Uh oh! \(e)")
+            return
+        }
     }
 }
 

--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.m
@@ -860,7 +860,7 @@
           [writeEpectation fulfill];
         }];
 
-    [firestore.client enableNetworkWithCompletion:^(NSError *error) {
+    [firestore enableNetworkWithCompletion:^(NSError *error) {
       XCTAssertNil(error);
       [networkExpectation fulfill];
     }];
@@ -911,7 +911,7 @@
       // Verify that we are reading from cache.
       XCTAssertTrue(snapshot.metadata.fromCache);
       XCTAssertEqualObjects(snapshot.data, data);
-      [firestore.client enableNetworkWithCompletion:^(NSError *error) {
+      [firestore enableNetworkWithCompletion:^(NSError *error) {
         [networkExpectation fulfill];
       }];
     }];

--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.m
@@ -17,6 +17,7 @@
 @import FirebaseFirestore;
 
 #import <XCTest/XCTest.h>
+#import <FirebaseFirestore/FIRFirestore.h>
 
 #import "Firestore/Example/Tests/Util/FSTIntegrationTestCase.h"
 #import "Firestore/Source/API/FIRFirestore+Internal.h"
@@ -936,6 +937,27 @@
   [self readSnapshotForRef:[self documentRef] requireOnline:YES];
   [self waitForIdleFirestore:firestore];
   [self readSnapshotForRef:[self documentRef] requireOnline:YES];
+}
+
+- (void)testCanDisableNetwork {
+  FIRDocumentReference *doc = [self documentRef];
+  FIRFirestore *firestore = doc.firestore;
+
+  [firestore enableNetworkWithCompletion:
+          [self completionForExpectationWithName:@"Enable network"]];
+  [self awaitExpectations];
+  [firestore enableNetworkWithCompletion:
+          [self completionForExpectationWithName:@"Enable network again"]];
+  [self awaitExpectations];
+  [firestore disableNetworkWithCompletion:
+          [self completionForExpectationWithName:@"Disable network"]];
+  [self awaitExpectations];
+  [firestore disableNetworkWithCompletion:
+          [self completionForExpectationWithName:@"Disable network again"]];
+  [self awaitExpectations];
+  [firestore enableNetworkWithCompletion:
+          [self completionForExpectationWithName:@"Final enable network"]];
+  [self awaitExpectations];
 }
 
 @end

--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.m
@@ -851,7 +851,7 @@
   FIRFirestore *firestore = doc.firestore;
   NSDictionary<NSString *, id> *data = @{@"a" : @"b"};
 
-  [firestore.client disableNetworkWithCompletion:^(NSError *error) {
+  [firestore disableNetworkWithCompletion:^(NSError *error) {
     XCTAssertNil(error);
 
     [doc setData:data
@@ -890,7 +890,7 @@
 
   __weak FIRDocumentReference *weakDoc = doc;
 
-  [firestore.client disableNetworkWithCompletion:^(NSError *error) {
+  [firestore disableNetworkWithCompletion:^(NSError *error) {
     XCTAssertNil(error);
     [doc setData:data
         completion:^(NSError *_Nullable error) {

--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.m
@@ -16,8 +16,8 @@
 
 @import FirebaseFirestore;
 
-#import <XCTest/XCTest.h>
 #import <FirebaseFirestore/FIRFirestore.h>
+#import <XCTest/XCTest.h>
 
 #import "Firestore/Example/Tests/Util/FSTIntegrationTestCase.h"
 #import "Firestore/Source/API/FIRFirestore+Internal.h"
@@ -943,20 +943,20 @@
   FIRDocumentReference *doc = [self documentRef];
   FIRFirestore *firestore = doc.firestore;
 
-  [firestore enableNetworkWithCompletion:
-          [self completionForExpectationWithName:@"Enable network"]];
+  [firestore enableNetworkWithCompletion:[self completionForExpectationWithName:@"Enable network"]];
   [self awaitExpectations];
-  [firestore enableNetworkWithCompletion:
-          [self completionForExpectationWithName:@"Enable network again"]];
+  [firestore
+      enableNetworkWithCompletion:[self completionForExpectationWithName:@"Enable network again"]];
   [self awaitExpectations];
-  [firestore disableNetworkWithCompletion:
-          [self completionForExpectationWithName:@"Disable network"]];
+  [firestore
+      disableNetworkWithCompletion:[self completionForExpectationWithName:@"Disable network"]];
   [self awaitExpectations];
-  [firestore disableNetworkWithCompletion:
-          [self completionForExpectationWithName:@"Disable network again"]];
+  [firestore
+      disableNetworkWithCompletion:[self
+                                       completionForExpectationWithName:@"Disable network again"]];
   [self awaitExpectations];
-  [firestore enableNetworkWithCompletion:
-          [self completionForExpectationWithName:@"Final enable network"]];
+  [firestore
+      enableNetworkWithCompletion:[self completionForExpectationWithName:@"Final enable network"]];
   [self awaitExpectations];
 }
 

--- a/Firestore/Example/Tests/Integration/API/FIRListenerRegistrationTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRListenerRegistrationTests.m
@@ -128,35 +128,4 @@
   [two remove];
 }
 
-- (void)testWatchSurvivesNetworkDisconnect {
-  XCTestExpectation *testExpectiation =
-      [self expectationWithDescription:@"testWatchSurvivesNetworkDisconnect"];
-
-  FIRCollectionReference *collectionRef = [self collectionRef];
-  FIRDocumentReference *docRef = [collectionRef documentWithAutoID];
-
-  FIRFirestore *firestore = collectionRef.firestore;
-
-  FIRQueryListenOptions *options = [[[FIRQueryListenOptions options]
-      includeDocumentMetadataChanges:YES] includeQueryMetadataChanges:YES];
-
-  [collectionRef addSnapshotListenerWithOptions:options
-                                       listener:^(FIRQuerySnapshot *snapshot, NSError *error) {
-                                         XCTAssertNil(error);
-                                         if (!snapshot.empty && !snapshot.metadata.fromCache) {
-                                           [testExpectiation fulfill];
-                                         }
-                                       }];
-
-  [firestore disableNetworkWithCompletion:^(NSError *error) {
-    XCTAssertNil(error);
-    [docRef setData:@{@"foo" : @"bar"}];
-    [firestore enableNetworkWithCompletion:^(NSError *error) {
-      XCTAssertNil(error);
-    }];
-  }];
-
-  [self awaitExpectations];
-}
-
 @end

--- a/Firestore/Example/Tests/Integration/API/FIRListenerRegistrationTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRListenerRegistrationTests.m
@@ -148,7 +148,7 @@
                                          }
                                        }];
 
-  [firestore.client disableNetworkWithCompletion:^(NSError *error) {
+  [firestore disableNetworkWithCompletion:^(NSError *error) {
     XCTAssertNil(error);
     [docRef setData:@{@"foo" : @"bar"}];
     [firestore enableNetworkWithCompletion:^(NSError *error) {

--- a/Firestore/Example/Tests/Integration/API/FIRListenerRegistrationTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRListenerRegistrationTests.m
@@ -151,7 +151,7 @@
   [firestore.client disableNetworkWithCompletion:^(NSError *error) {
     XCTAssertNil(error);
     [docRef setData:@{@"foo" : @"bar"}];
-    [firestore.client enableNetworkWithCompletion:^(NSError *error) {
+    [firestore enableNetworkWithCompletion:^(NSError *error) {
       XCTAssertNil(error);
     }];
   }];

--- a/Firestore/Example/Tests/Integration/API/FIRQueryTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRQueryTests.m
@@ -214,7 +214,7 @@
 
 - (void)testWatchSurvivesNetworkDisconnect {
   XCTestExpectation *testExpectiation =
-          [self expectationWithDescription:@"testWatchSurvivesNetworkDisconnect"];
+      [self expectationWithDescription:@"testWatchSurvivesNetworkDisconnect"];
 
   FIRCollectionReference *collectionRef = [self collectionRef];
   FIRDocumentReference *docRef = [collectionRef documentWithAutoID];
@@ -222,22 +222,22 @@
   FIRFirestore *firestore = collectionRef.firestore;
 
   FIRQueryListenOptions *options = [[[FIRQueryListenOptions options]
-          includeDocumentMetadataChanges:YES] includeQueryMetadataChanges:YES];
+      includeDocumentMetadataChanges:YES] includeQueryMetadataChanges:YES];
 
   [collectionRef addSnapshotListenerWithOptions:options
                                        listener:^(FIRQuerySnapshot *snapshot, NSError *error) {
-                                           XCTAssertNil(error);
-                                           if (!snapshot.empty && !snapshot.metadata.fromCache) {
-                                             [testExpectiation fulfill];
-                                           }
+                                         XCTAssertNil(error);
+                                         if (!snapshot.empty && !snapshot.metadata.fromCache) {
+                                           [testExpectiation fulfill];
+                                         }
                                        }];
 
   [firestore disableNetworkWithCompletion:^(NSError *error) {
+    XCTAssertNil(error);
+    [docRef setData:@{@"foo" : @"bar"}];
+    [firestore enableNetworkWithCompletion:^(NSError *error) {
       XCTAssertNil(error);
-      [docRef setData:@{@"foo": @"bar"}];
-      [firestore enableNetworkWithCompletion:^(NSError *error) {
-          XCTAssertNil(error);
-      }];
+    }];
   }];
 
   [self awaitExpectations];

--- a/Firestore/Example/Tests/Integration/API/FIRQueryTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRQueryTests.m
@@ -211,4 +211,35 @@
   XCTAssertEqualObjects(FIRQuerySnapshotGetData(docs), (@[ testDocs[@"ab"], testDocs[@"ba"] ]));
 }
 
+- (void)testWatchSurvivesNetworkDisconnect {
+  XCTestExpectation *testExpectiation =
+  [self expectationWithDescription:@"testWatchSurvivesNetworkDisconnect"];
+  
+  FIRCollectionReference *collectionRef = [self collectionRef];
+  FIRDocumentReference *docRef = [collectionRef documentWithAutoID];
+  
+  FIRFirestore *firestore = collectionRef.firestore;
+  
+  FIRQueryListenOptions *options = [[[FIRQueryListenOptions options]
+                                     includeDocumentMetadataChanges:YES] includeQueryMetadataChanges:YES];
+  
+  [collectionRef addSnapshotListenerWithOptions:options
+                                       listener:^(FIRQuerySnapshot *snapshot, NSError *error) {
+                                         XCTAssertNil(error);
+                                         if (!snapshot.empty && !snapshot.metadata.fromCache) {
+                                           [testExpectiation fulfill];
+                                         }
+                                       }];
+  
+  [firestore disableNetworkWithCompletion:^(NSError *error) {
+    XCTAssertNil(error);
+    [docRef setData:@{@"foo" : @"bar"}];
+    [firestore enableNetworkWithCompletion:^(NSError *error) {
+      XCTAssertNil(error);
+    }];
+  }];
+  
+  [self awaitExpectations];
+}
+
 @end

--- a/Firestore/Source/API/FIRFirestore.m
+++ b/Firestore/Source/API/FIRFirestore.m
@@ -280,13 +280,13 @@ NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
 }
 
 - (void)enableNetworkWithCompletion:(nullable void (^)(NSError *_Nullable error))completion {
-    [self firestoreWithConfiguredClient];
-    [self.client enableNetworkWithCompletion:completion];
+  [self firestoreWithConfiguredClient];
+  [self.client enableNetworkWithCompletion:completion];
 }
 
-- (void)disableNetworkWithCompletion:(nullable void (^)(NSError * _Nullable))completion {
-    [self firestoreWithConfiguredClient];
-    [self.client disableNetworkWithCompletion:completion];
+- (void)disableNetworkWithCompletion:(nullable void (^)(NSError *_Nullable))completion {
+  [self firestoreWithConfiguredClient];
+  [self.client disableNetworkWithCompletion:completion];
 }
 
 @end

--- a/Firestore/Source/API/FIRFirestore.m
+++ b/Firestore/Source/API/FIRFirestore.m
@@ -279,6 +279,16 @@ NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
   FIRSetLoggerLevel(logging ? FIRLoggerLevelDebug : FIRLoggerLevelNotice);
 }
 
+- (void)enableNetworkWithCompletion:(void (^ _Nullable)(NSError *_Nullable error))completion {
+    [self firestoreWithConfiguredClient];
+    [self.client enableNetworkWithCompletion:completion];
+}
+
+- (void)disableNetworkWithCompletion:(void (^ _Nullable)(NSError * _Nullable))completion {
+    [self firestoreWithConfiguredClient];
+    [self.client disableNetworkWithCompletion:completion];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Firestore/Source/API/FIRFirestore.m
+++ b/Firestore/Source/API/FIRFirestore.m
@@ -279,12 +279,12 @@ NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
   FIRSetLoggerLevel(logging ? FIRLoggerLevelDebug : FIRLoggerLevelNotice);
 }
 
-- (void)enableNetworkWithCompletion:(void (^ _Nullable)(NSError *_Nullable error))completion {
+- (void)enableNetworkWithCompletion:(nullable void (^)(NSError *_Nullable error))completion {
     [self firestoreWithConfiguredClient];
     [self.client enableNetworkWithCompletion:completion];
 }
 
-- (void)disableNetworkWithCompletion:(void (^ _Nullable)(NSError * _Nullable))completion {
+- (void)disableNetworkWithCompletion:(nullable void (^)(NSError * _Nullable))completion {
     [self firestoreWithConfiguredClient];
     [self.client disableNetworkWithCompletion:completion];
 }

--- a/Firestore/Source/Public/FIRFirestore.h
+++ b/Firestore/Source/Public/FIRFirestore.h
@@ -139,6 +139,21 @@ NS_SWIFT_NAME(Firestore)
 + (void)enableLogging:(BOOL)logging
     DEPRECATED_MSG_ATTRIBUTE("Use FIRSetLoggerLevel(FIRLoggerLevelDebug) to enable logging");
 
+
+#pragma mark - Network
+
+/**
+ * Enables usage of the network by this Firestore instance. Completion block, if provided,
+ * will be called once network uasge has been enabled.
+ */
+- (void)enableNetworkWithCompletion:(void (^ _Nullable)(NSError *_Nullable error))completion;
+
+/**
+ * Disables usage of the network by this Firestore instance. Completion block, if provided,
+ * will be called once network usage has been disabled.
+ */
+- (void)disableNetworkWithCompletion:(void (^ _Nullable)(NSError *_Nullable error))completion;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Firestore/Source/Public/FIRFirestore.h
+++ b/Firestore/Source/Public/FIRFirestore.h
@@ -143,14 +143,17 @@ NS_SWIFT_NAME(Firestore)
 #pragma mark - Network
 
 /**
- * Enables usage of the network by this Firestore instance. Completion block, if provided,
- * will be called once network uasge has been enabled.
+ * Re-enables usage of the network by this Firestore instance after a prior call to
+ * disableNetworkWithCompletion. Completion block, if provided, will be called once network uasge
+ * has been enabled.
  */
 - (void)enableNetworkWithCompletion:(void (^ _Nullable)(NSError *_Nullable error))completion;
 
 /**
- * Disables usage of the network by this Firestore instance. Completion block, if provided,
- * will be called once network usage has been disabled.
+ * Disables usage of the network by this Firestore instance. It can be re-enabled by via
+ * enableNetworkWithCompletion. While the network is disabled, any snapshot listeners or get calls
+ * will return results from cache, and any write operations will be queued until the network is
+ * restored. The completion block, if provided, will be called once network usage has been disabled.
  */
 - (void)disableNetworkWithCompletion:(void (^ _Nullable)(NSError *_Nullable error))completion;
 

--- a/Firestore/Source/Public/FIRFirestore.h
+++ b/Firestore/Source/Public/FIRFirestore.h
@@ -144,18 +144,18 @@ NS_SWIFT_NAME(Firestore)
 
 /**
  * Re-enables usage of the network by this Firestore instance after a prior call to
- * disableNetworkWithCompletion. Completion block, if provided, will be called once network uasge
+ * `disableNetworkWithCompletion`. Completion block, if provided, will be called once network uasge
  * has been enabled.
  */
-- (void)enableNetworkWithCompletion:(void (^ _Nullable)(NSError *_Nullable error))completion;
+- (void)enableNetworkWithCompletion:(nullable void (^)(NSError *_Nullable error))completion;
 
 /**
  * Disables usage of the network by this Firestore instance. It can be re-enabled by via
- * enableNetworkWithCompletion. While the network is disabled, any snapshot listeners or get calls
+ * `enableNetworkWithCompletion`. While the network is disabled, any snapshot listeners or get calls
  * will return results from cache, and any write operations will be queued until the network is
  * restored. The completion block, if provided, will be called once network usage has been disabled.
  */
-- (void)disableNetworkWithCompletion:(void (^ _Nullable)(NSError *_Nullable error))completion;
+- (void)disableNetworkWithCompletion:(nullable void (^)(NSError *_Nullable error))completion;
 
 @end
 

--- a/Firestore/Source/Public/FIRFirestore.h
+++ b/Firestore/Source/Public/FIRFirestore.h
@@ -152,7 +152,7 @@ NS_SWIFT_NAME(Firestore)
 /**
  * Disables usage of the network by this Firestore instance. It can be re-enabled by via
  * `enableNetworkWithCompletion`. While the network is disabled, any snapshot listeners or get calls
- * will return results from cache, and any write operations will be queued until the network is
+ * will return results from cache and any write operations will be queued until the network is
  * restored. The completion block, if provided, will be called once network usage has been disabled.
  */
 - (void)disableNetworkWithCompletion:(nullable void (^)(NSError *_Nullable error))completion;

--- a/Firestore/Source/Public/FIRFirestore.h
+++ b/Firestore/Source/Public/FIRFirestore.h
@@ -139,7 +139,6 @@ NS_SWIFT_NAME(Firestore)
 + (void)enableLogging:(BOOL)logging
     DEPRECATED_MSG_ATTRIBUTE("Use FIRSetLoggerLevel(FIRLoggerLevelDebug) to enable logging");
 
-
 #pragma mark - Network
 
 /**

--- a/Firestore/Source/Remote/FSTRemoteStore.m
+++ b/Firestore/Source/Remote/FSTRemoteStore.m
@@ -165,18 +165,18 @@ static const int kOnlineAttemptsBeforeFailure = 2;
  * onlineStateHandler as appropriate.
  */
 - (void)updateOnlineState:(FSTOnlineState)newState {
-    // Update and broadcast the new state.
+  // Update and broadcast the new state.
   if (newState != self.watchStreamOnlineState) {
     if (newState == FSTOnlineStateHealthy) {
       // We've connected to watch at least once. Don't warn the developer about being offline going
       // forward.
       self.shouldWarnOffline = NO;
     } else if (newState == FSTOnlineStateUnknown) {
-      // The state is set to unknown when a healthy stream is closed (e.g. due to a token timeout) or
-      // when we have no active listens and therefore there's no need to start the stream. Assuming
-      // there is (possibly in the future) an active listen, then we will eventually move to state
-      // Online or Failed, but we always want to make at least kOnlineAttemptsBeforeFailure attempts
-      // before failing, so we reset the count here.
+      // The state is set to unknown when a healthy stream is closed (e.g. due to a token timeout)
+      // or when we have no active listens and therefore there's no need to start the stream.
+      // Assuming there is (possibly in the future) an active listen, then we will eventually move
+      // to state Online or Failed, but we always want to make at least kOnlineAttemptsBeforeFailure
+      // attempts before failing, so we reset the count here.
       self.watchStreamFailures = 0;
     }
     self.watchStreamOnlineState = newState;

--- a/Firestore/Source/Remote/FSTRemoteStore.m
+++ b/Firestore/Source/Remote/FSTRemoteStore.m
@@ -210,8 +210,9 @@ static const int kOnlineAttemptsBeforeFailure = 2;
 }
 
 - (void)enableNetwork {
-  FSTAssert(self.watchStream == nil, @"enableNetwork: called with non-null watchStream.");
-  FSTAssert(self.writeStream == nil, @"enableNetwork: called with non-null writeStream.");
+  if ([self isNetworkEnabled]) {
+    return;
+  }
 
   // Create new streams (but note they're not started yet).
   self.watchStream = [self.datastore createWatchStream];
@@ -231,6 +232,9 @@ static const int kOnlineAttemptsBeforeFailure = 2;
 }
 
 - (void)disableNetwork {
+  if (![self isNetworkEnabled]) {
+    return;
+  }
   [self updateAndNotifyAboutOnlineState:FSTOnlineStateFailed];
 
   // NOTE: We're guaranteed not to get any further events from these streams (not even a close


### PR DESCRIPTION
Add `enableNetworkWithCompletion` and `disableNetworkWithCompletion` to the public interface for `FIRFirestore`.

b/70348588