### PR TITLE
Mikelehen completion waiter

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRQueryTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRQueryTests.m
@@ -227,12 +227,8 @@
   FIRQuerySnapshot *querySnap = [self.eventAccumulator awaitEventWithName:@"initial event"];
   XCTAssertEqualObjects(FIRQuerySnapshotGetData(querySnap), @[ @{ @"foo" : @1 } ]);
   XCTAssertEqual(querySnap.metadata.isFromCache, NO);
-  XCTestExpectation *networkDisabled = [self expectationWithDescription:@"disable network"];
-  [collection.firestore.client disableNetworkWithCompletion:^(NSError *error) {
-    [networkDisabled fulfill];
-  }];
-  [self awaitExpectations];
 
+  [self disableNetwork];
   querySnap = [self.eventAccumulator awaitEventWithName:@"offline event with isFromCache=YES"];
   XCTAssertEqual(querySnap.metadata.isFromCache, YES);
 
@@ -241,12 +237,7 @@
   // sufficient.
   [NSThread sleepForTimeInterval:0.2f];
 
-  XCTestExpectation *networkEnabled = [self expectationWithDescription:@"enable network"];
-  [collection.firestore.client enableNetworkWithCompletion:^(NSError *error) {
-    [networkEnabled fulfill];
-  }];
-  [self awaitExpectations];
-
+  [self enableNetwork];
   querySnap = [self.eventAccumulator awaitEventWithName:@"back online event with isFromCache=NO"];
   XCTAssertEqual(querySnap.metadata.isFromCache, NO);
 }

--- a/Firestore/Example/Tests/Integration/API/FIRServerTimestampTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRServerTimestampTests.m
@@ -167,18 +167,6 @@
   [self awaitExpectations];
 }
 
-/** Disables the network synchronously. */
-- (void)disableNetwork {
-  [_docRef.firestore.client disableNetworkWithCompletion:_accumulator.errorEventHandler];
-  [_accumulator awaitEventWithName:@"Disconnect event."];
-}
-
-/** Enables the network synchronously. */
-- (void)enableNetwork {
-  [_docRef.firestore.client enableNetworkWithCompletion:_accumulator.errorEventHandler];
-  [_accumulator awaitEventWithName:@"Reconnect event."];
-}
-
 #pragma mark - Test Cases
 
 - (void)testServerTimestampsWorkViaSet {

--- a/Firestore/Example/Tests/Integration/API/FIRWriteBatchTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRWriteBatchTests.m
@@ -47,6 +47,12 @@
   FIRWriteBatch *batch2 = [doc.firestore batch];
   [batch2 setData:@{@"cc" : @"dd"} forDocument:doc];
   [batch2 commit];
+
+  // TODO(b/70631617): There's currently a backend bug that prevents us from using a resume token
+  // right away (against hexa at least). So we sleep. :-( :-( Anything over ~10ms seems to be
+  // sufficient.
+  [NSThread sleepForTimeInterval:0.2f];
+
   FIRDocumentSnapshot *snapshot2 = [self readDocumentForRef:doc];
   XCTAssertTrue(snapshot2.exists);
   XCTAssertEqualObjects(snapshot2.data, @{@"cc" : @"dd"});

--- a/Firestore/Example/Tests/Util/FSTEventAccumulator.h
+++ b/Firestore/Example/Tests/Util/FSTEventAccumulator.h
@@ -24,7 +24,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^FSTValueEventHandler)(id _Nullable, NSError *_Nullable error);
-typedef void (^FSTErrorEventHandler)(NSError *_Nullable error);
 
 @interface FSTEventAccumulator : NSObject
 
@@ -37,7 +36,6 @@ typedef void (^FSTErrorEventHandler)(NSError *_Nullable error);
 - (NSArray<id> *)awaitEvents:(NSUInteger)events name:(NSString *)name;
 
 @property(nonatomic, strong, readonly) FSTValueEventHandler valueEventHandler;
-@property(nonatomic, strong, readonly) FSTErrorEventHandler errorEventHandler;
 
 @end
 

--- a/Firestore/Example/Tests/Util/FSTEventAccumulator.m
+++ b/Firestore/Example/Tests/Util/FSTEventAccumulator.m
@@ -68,7 +68,6 @@ NS_ASSUME_NONNULL_BEGIN
   return events[0];
 }
 
-// Override the valueEventHandler property
 - (void (^)(id _Nullable, NSError *_Nullable))valueEventHandler {
   return ^void(id _Nullable value, NSError *_Nullable error) {
     // We can't store nil in the _events array, but these are still interesting to tests so store
@@ -77,16 +76,6 @@ NS_ASSUME_NONNULL_BEGIN
 
     @synchronized(self) {
       [_events addObject:event];
-      [self checkFulfilled];
-    }
-  };
-}
-
-// Override the errorEventHandler property
-- (void (^)(NSError *_Nullable))errorEventHandler {
-  return ^void(NSError *_Nullable error) {
-    @synchronized(self) {
-      [_events addObject:[NSNull null]];
       [self checkFulfilled];
     }
   };

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.h
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.h
@@ -95,9 +95,6 @@ extern "C" {
  */
 - (void)waitUntil:(BOOL (^)())predicate;
 
-/** Returns a completion block that fulfills a newly-created expectation with the specified name. */
-- (FSTVoidErrorBlock)completionExpectationWithName:(NSString *)name;
-
 @property(nonatomic, strong) FIRFirestore *db;
 @property(nonatomic, strong) FSTEventAccumulator *eventAccumulator;
 @end

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.h
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#import <Firestore/Source/Core/FSTTypes.h>
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
@@ -82,6 +83,10 @@ extern "C" {
 
 - (void)deleteDocumentRef:(FIRDocumentReference *)ref;
 
+- (void)disableNetwork;
+
+- (void)enableNetwork;
+
 /**
  * "Blocks" the current thread/run loop until the block returns YES.
  * Should only be called on the main thread.
@@ -89,6 +94,9 @@ extern "C" {
  * test progress and make sure actions to be run on main thread are not blocked by this method.
  */
 - (void)waitUntil:(BOOL (^)())predicate;
+
+/** Returns a completion block that fulfills a newly-created expectation with the specified name. */
+- (FSTVoidErrorBlock)completionExpectationWithName:(NSString *)name;
 
 @property(nonatomic, strong) FIRFirestore *db;
 @property(nonatomic, strong) FSTEventAccumulator *eventAccumulator;

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -18,6 +18,7 @@
 
 #import <FirebaseCore/FIRLogger.h>
 #import <FirebaseFirestore/FirebaseFirestore-umbrella.h>
+#import <Firestore/Source/Core/FSTFirestoreClient.h>
 #import <GRPCClient/GRPCCall+ChannelArg.h>
 #import <GRPCClient/GRPCCall+Tests.h>
 
@@ -158,11 +159,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)shutdownFirestore:(FIRFirestore *)firestore {
-  XCTestExpectation *shutdownCompletion = [self expectationWithDescription:@"shutdown"];
-  [firestore shutdownWithCompletion:^(NSError *_Nullable error) {
-    XCTAssertNil(error);
-    [shutdownCompletion fulfill];
-  }];
+  [firestore shutdownWithCompletion:[self completionExpectationWithName:@"shutdown"]];
   [self awaitExpectations];
 }
 
@@ -261,31 +258,29 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)writeDocumentRef:(FIRDocumentReference *)ref data:(NSDictionary<NSString *, id> *)data {
-  XCTestExpectation *expectation = [self expectationWithDescription:@"setData"];
-  [ref setData:data
-      completion:^(NSError *_Nullable error) {
-        XCTAssertNil(error);
-        [expectation fulfill];
-      }];
+  [ref setData:data completion:[self completionExpectationWithName:@"setData"]];
   [self awaitExpectations];
 }
 
 - (void)updateDocumentRef:(FIRDocumentReference *)ref data:(NSDictionary<id, id> *)data {
-  XCTestExpectation *expectation = [self expectationWithDescription:@"updateData"];
-  [ref updateData:data
-       completion:^(NSError *_Nullable error) {
-         XCTAssertNil(error);
-         [expectation fulfill];
-       }];
+  [ref updateData:data completion:[self completionExpectationWithName:@"updateData"]];
   [self awaitExpectations];
 }
 
 - (void)deleteDocumentRef:(FIRDocumentReference *)ref {
-  XCTestExpectation *expectation = [self expectationWithDescription:@"deleteDocument"];
-  [ref deleteDocumentWithCompletion:^(NSError *_Nullable error) {
-    XCTAssertNil(error);
-    [expectation fulfill];
-  }];
+  [ref deleteDocumentWithCompletion:[self completionExpectationWithName:@"deleteDocument"]];
+  [self awaitExpectations];
+}
+
+- (void)disableNetwork {
+  [self.db.client
+      disableNetworkWithCompletion:[self completionExpectationWithName:@"Disable Network."]];
+  [self awaitExpectations];
+}
+
+- (void)enableNetwork {
+  [self.db.client
+      enableNetworkWithCompletion:[self completionExpectationWithName:@"Enable Network."]];
   [self awaitExpectations];
 }
 
@@ -300,6 +295,14 @@ NS_ASSUME_NONNULL_BEGIN
   if (!predicate()) {
     XCTFail(@"Timeout");
   }
+}
+
+- (FSTVoidErrorBlock)completionExpectationWithName:(NSString *)name {
+  XCTestExpectation *expectation = [self expectationWithDescription:name];
+  return ^(NSError *error) {
+    XCTAssertNil(error);
+    [expectation fulfill];
+  };
 }
 
 extern "C" NSArray<NSDictionary<NSString *, id> *> *FIRQuerySnapshotGetData(

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -159,7 +159,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)shutdownFirestore:(FIRFirestore *)firestore {
-  [firestore shutdownWithCompletion:[self completionBlockExpecting:@"shutdown"]];
+  [firestore shutdownWithCompletion:[self completionForExpectationWithName:@"shutdown"]];
   [self awaitExpectations];
 }
 
@@ -258,27 +258,29 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)writeDocumentRef:(FIRDocumentReference *)ref data:(NSDictionary<NSString *, id> *)data {
-  [ref setData:data completion:[self completionBlockExpecting:@"setData"]];
+  [ref setData:data completion:[self completionForExpectationWithName:@"setData"]];
   [self awaitExpectations];
 }
 
 - (void)updateDocumentRef:(FIRDocumentReference *)ref data:(NSDictionary<id, id> *)data {
-  [ref updateData:data completion:[self completionBlockExpecting:@"updateData"]];
+  [ref updateData:data completion:[self completionForExpectationWithName:@"updateData"]];
   [self awaitExpectations];
 }
 
 - (void)deleteDocumentRef:(FIRDocumentReference *)ref {
-  [ref deleteDocumentWithCompletion:[self completionBlockExpecting:@"deleteDocument"]];
+  [ref deleteDocumentWithCompletion:[self completionForExpectationWithName:@"deleteDocument"]];
   [self awaitExpectations];
 }
 
 - (void)disableNetwork {
-  [self.db.client disableNetworkWithCompletion:[self completionBlockExpecting:@"Disable Network."]];
+  [self.db.client
+      disableNetworkWithCompletion:[self completionForExpectationWithName:@"Disable Network."]];
   [self awaitExpectations];
 }
 
 - (void)enableNetwork {
-  [self.db.client enableNetworkWithCompletion:[self completionBlockExpecting:@"Enable Network."]];
+  [self.db.client
+      enableNetworkWithCompletion:[self completionForExpectationWithName:@"Enable Network."]];
   [self awaitExpectations];
 }
 

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -159,7 +159,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)shutdownFirestore:(FIRFirestore *)firestore {
-  [firestore shutdownWithCompletion:[self completionExpectationWithName:@"shutdown"]];
+  [firestore shutdownWithCompletion:[self completionBlockExpecting:@"shutdown"]];
   [self awaitExpectations];
 }
 
@@ -258,29 +258,27 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)writeDocumentRef:(FIRDocumentReference *)ref data:(NSDictionary<NSString *, id> *)data {
-  [ref setData:data completion:[self completionExpectationWithName:@"setData"]];
+  [ref setData:data completion:[self completionBlockExpecting:@"setData"]];
   [self awaitExpectations];
 }
 
 - (void)updateDocumentRef:(FIRDocumentReference *)ref data:(NSDictionary<id, id> *)data {
-  [ref updateData:data completion:[self completionExpectationWithName:@"updateData"]];
+  [ref updateData:data completion:[self completionBlockExpecting:@"updateData"]];
   [self awaitExpectations];
 }
 
 - (void)deleteDocumentRef:(FIRDocumentReference *)ref {
-  [ref deleteDocumentWithCompletion:[self completionExpectationWithName:@"deleteDocument"]];
+  [ref deleteDocumentWithCompletion:[self completionBlockExpecting:@"deleteDocument"]];
   [self awaitExpectations];
 }
 
 - (void)disableNetwork {
-  [self.db.client
-      disableNetworkWithCompletion:[self completionExpectationWithName:@"Disable Network."]];
+  [self.db.client disableNetworkWithCompletion:[self completionBlockExpecting:@"Disable Network."]];
   [self awaitExpectations];
 }
 
 - (void)enableNetwork {
-  [self.db.client
-      enableNetworkWithCompletion:[self completionExpectationWithName:@"Enable Network."]];
+  [self.db.client enableNetworkWithCompletion:[self completionBlockExpecting:@"Enable Network."]];
   [self awaitExpectations];
 }
 
@@ -295,14 +293,6 @@ NS_ASSUME_NONNULL_BEGIN
   if (!predicate()) {
     XCTFail(@"Timeout");
   }
-}
-
-- (FSTVoidErrorBlock)completionExpectationWithName:(NSString *)name {
-  XCTestExpectation *expectation = [self expectationWithDescription:name];
-  return ^(NSError *error) {
-    XCTAssertNil(error);
-    [expectation fulfill];
-  };
 }
 
 extern "C" NSArray<NSDictionary<NSString *, id> *> *FIRQuerySnapshotGetData(

--- a/Firestore/Example/Tests/Util/XCTestCase+Await.h
+++ b/Firestore/Example/Tests/Util/XCTestCase+Await.h
@@ -34,6 +34,6 @@
  * Returns a completion block that fulfills a newly-created expectation with the specified
  * description.
  */
-- (FSTVoidErrorBlock)completionBlockExpecting:(NSString *)expectationDescription;
+- (FSTVoidErrorBlock)completionForExpectationWithName:(NSString *)expectationName;
 
 @end

--- a/Firestore/Example/Tests/Util/XCTestCase+Await.h
+++ b/Firestore/Example/Tests/Util/XCTestCase+Await.h
@@ -32,7 +32,7 @@
 
 /**
  * Returns a completion block that fulfills a newly-created expectation with the specified
- * description.
+ * name.
  */
 - (FSTVoidErrorBlock)completionForExpectationWithName:(NSString *)expectationName;
 

--- a/Firestore/Example/Tests/Util/XCTestCase+Await.h
+++ b/Firestore/Example/Tests/Util/XCTestCase+Await.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#import <Firestore/Source/Core/FSTTypes.h>
 #import <XCTest/XCTest.h>
 
 @interface XCTestCase (Await)
@@ -28,5 +29,11 @@
  * Returns a reasonable timeout for testing against Firestore.
  */
 - (double)defaultExpectationWaitSeconds;
+
+/**
+ * Returns a completion block that fulfills a newly-created expectation with the specified
+ * description.
+ */
+- (FSTVoidErrorBlock)completionBlockExpecting:(NSString *)expectationDescription;
 
 @end

--- a/Firestore/Example/Tests/Util/XCTestCase+Await.m
+++ b/Firestore/Example/Tests/Util/XCTestCase+Await.m
@@ -35,4 +35,12 @@ static const double kExpectationWaitSeconds = 10.0;
   return kExpectationWaitSeconds;
 }
 
+- (FSTVoidErrorBlock)completionBlockExpecting:(NSString *)expectationDescription {
+  XCTestExpectation *expectation = [self expectationWithDescription:expectationDescription];
+  return ^(NSError *error) {
+    XCTAssertNil(error);
+    [expectation fulfill];
+  };
+}
+
 @end

--- a/Firestore/Example/Tests/Util/XCTestCase+Await.m
+++ b/Firestore/Example/Tests/Util/XCTestCase+Await.m
@@ -35,8 +35,8 @@ static const double kExpectationWaitSeconds = 10.0;
   return kExpectationWaitSeconds;
 }
 
-- (FSTVoidErrorBlock)completionBlockExpecting:(NSString *)expectationDescription {
-  XCTestExpectation *expectation = [self expectationWithDescription:expectationDescription];
+- (FSTVoidErrorBlock)completionForExpectationWithName:(NSString *)expectationName {
+  XCTestExpectation *expectation = [self expectationWithDescription:expectationName];
   return ^(NSError *error) {
     XCTAssertNil(error);
     [expectation fulfill];

--- a/Firestore/Source/Remote/FSTRemoteStore.m
+++ b/Firestore/Source/Remote/FSTRemoteStore.m
@@ -161,8 +161,8 @@ static const int kOnlineAttemptsBeforeFailure = 2;
 }
 
 /**
-  * Updates our OnlineState to the new state, updating local state and notifying the
-  * onlineStateHandler as appropriate.
+ * Updates our OnlineState to the new state, updating local state and notifying the
+ * onlineStateHandler as appropriate.
  */
 - (void)updateOnlineState:(FSTOnlineState)newState {
   if (newState == FSTOnlineStateHealthy) {


### PR DESCRIPTION
* Adds and uses `FSTIntegrationTestCase` helpers:
  * `completionExpectationWithName` returns a completion block that will fulfill an expectation when it is called (so you can call [self awaitExpectations] to await it).
  * `enableNetwork` / `disableNetwork` - synchronous wrappers around the underlying SDK calls.
* Removes the (no-longer-used) `errorEventHandler` on `FSTEventAccumulator`.