### PR TITLE
Rename all the onlineStateChanged methods to applyOnlineStateChange.

### DIFF
--- a/Firestore/Example/Tests/Core/FSTEventManagerTests.m
+++ b/Firestore/Example/Tests/Core/FSTEventManagerTests.m
@@ -139,11 +139,11 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQueryListener *fakeListener = OCMClassMock([FSTQueryListener class]);
   NSMutableArray *events = [NSMutableArray array];
   OCMStub([fakeListener query]).andReturn(query);
-  OCMStub([fakeListener clientDidChangeOnlineState:FSTOnlineStateUnknown])
+  OCMStub([fakeListener applyOnlineStateChange:FSTOnlineStateUnknown])
       .andDo(^(NSInvocation *invocation) {
         [events addObject:@(FSTOnlineStateUnknown)];
       });
-  OCMStub([fakeListener clientDidChangeOnlineState:FSTOnlineStateHealthy])
+  OCMStub([fakeListener applyOnlineStateChange:FSTOnlineStateHealthy])
       .andDo(^(NSInvocation *invocation) {
         [events addObject:@(FSTOnlineStateHealthy)];
       });
@@ -154,7 +154,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   [eventManager addListener:fakeListener];
   XCTAssertEqualObjects(events, @[ @(FSTOnlineStateUnknown) ]);
-  [eventManager watchStreamDidChangeOnlineState:FSTOnlineStateHealthy];
+  [eventManager applyOnlineStateChange:FSTOnlineStateHealthy];
   XCTAssertEqualObjects(events, (@[ @(FSTOnlineStateUnknown), @(FSTOnlineStateHealthy) ]));
 }
 

--- a/Firestore/Example/Tests/Core/FSTEventManagerTests.m
+++ b/Firestore/Example/Tests/Core/FSTEventManagerTests.m
@@ -139,11 +139,11 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQueryListener *fakeListener = OCMClassMock([FSTQueryListener class]);
   NSMutableArray *events = [NSMutableArray array];
   OCMStub([fakeListener query]).andReturn(query);
-  OCMStub([fakeListener applyOnlineStateChange:FSTOnlineStateUnknown])
+  OCMStub([fakeListener applyChangedOnlineState:FSTOnlineStateUnknown])
       .andDo(^(NSInvocation *invocation) {
         [events addObject:@(FSTOnlineStateUnknown)];
       });
-  OCMStub([fakeListener applyOnlineStateChange:FSTOnlineStateHealthy])
+  OCMStub([fakeListener applyChangedOnlineState:FSTOnlineStateHealthy])
       .andDo(^(NSInvocation *invocation) {
         [events addObject:@(FSTOnlineStateHealthy)];
       });
@@ -154,7 +154,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   [eventManager addListener:fakeListener];
   XCTAssertEqualObjects(events, @[ @(FSTOnlineStateUnknown) ]);
-  [eventManager applyOnlineStateChange:FSTOnlineStateHealthy];
+  [eventManager applyChangedOnlineState:FSTOnlineStateHealthy];
   XCTAssertEqualObjects(events, (@[ @(FSTOnlineStateUnknown), @(FSTOnlineStateHealthy) ]));
 }
 

--- a/Firestore/Example/Tests/Core/FSTQueryListenerTests.m
+++ b/Firestore/Example/Tests/Core/FSTQueryListenerTests.m
@@ -340,10 +340,10 @@ NS_ASSUME_NONNULL_BEGIN
                           [FSTTargetChange changeWithDocuments:@[ doc1, doc2 ]
                                            currentStatusUpdate:FSTCurrentStatusUpdateMarkCurrent]);
 
-  [listener applyOnlineStateChange:FSTOnlineStateHealthy];  // no event
+  [listener applyChangedOnlineState:FSTOnlineStateHealthy];  // no event
   [listener queryDidChangeViewSnapshot:snap1];
-  [listener applyOnlineStateChange:FSTOnlineStateUnknown];
-  [listener applyOnlineStateChange:FSTOnlineStateHealthy];
+  [listener applyChangedOnlineState:FSTOnlineStateUnknown];
+  [listener applyChangedOnlineState:FSTOnlineStateHealthy];
   [listener queryDidChangeViewSnapshot:snap2];
   [listener queryDidChangeViewSnapshot:snap3];
 
@@ -379,12 +379,12 @@ NS_ASSUME_NONNULL_BEGIN
   FSTViewSnapshot *snap1 = FSTTestApplyChanges(view, @[ doc1 ], nil);
   FSTViewSnapshot *snap2 = FSTTestApplyChanges(view, @[ doc2 ], nil);
 
-  [listener applyOnlineStateChange:FSTOnlineStateHealthy];      // no event
-  [listener queryDidChangeViewSnapshot:snap1];                  // no event
-  [listener applyOnlineStateChange:FSTOnlineStateFailed];       // event
-  [listener applyOnlineStateChange:FSTOnlineStateUnknown];      // no event
-  [listener applyOnlineStateChange:FSTOnlineStateFailed];       // no event
-  [listener queryDidChangeViewSnapshot:snap2];                  // another event
+  [listener applyChangedOnlineState:FSTOnlineStateHealthy];  // no event
+  [listener queryDidChangeViewSnapshot:snap1];               // no event
+  [listener applyChangedOnlineState:FSTOnlineStateFailed];   // event
+  [listener applyChangedOnlineState:FSTOnlineStateUnknown];  // no event
+  [listener applyChangedOnlineState:FSTOnlineStateFailed];   // no event
+  [listener queryDidChangeViewSnapshot:snap2];               // another event
 
   FSTDocumentViewChange *change1 =
       [FSTDocumentViewChange changeWithDocument:doc1 type:FSTDocumentViewChangeTypeAdded];
@@ -419,9 +419,9 @@ NS_ASSUME_NONNULL_BEGIN
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:[FSTDocumentKeySet keySet]];
   FSTViewSnapshot *snap1 = FSTTestApplyChanges(view, @[], nil);
 
-  [listener applyOnlineStateChange:FSTOnlineStateHealthy];      // no event
-  [listener queryDidChangeViewSnapshot:snap1];                  // no event
-  [listener applyOnlineStateChange:FSTOnlineStateFailed];       // event
+  [listener applyChangedOnlineState:FSTOnlineStateHealthy];  // no event
+  [listener queryDidChangeViewSnapshot:snap1];               // no event
+  [listener applyChangedOnlineState:FSTOnlineStateFailed];   // event
 
   FSTViewSnapshot *expectedSnap = [[FSTViewSnapshot alloc]
          initWithQuery:query
@@ -445,8 +445,8 @@ NS_ASSUME_NONNULL_BEGIN
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:[FSTDocumentKeySet keySet]];
   FSTViewSnapshot *snap1 = FSTTestApplyChanges(view, @[], nil);
 
-  [listener applyOnlineStateChange:FSTOnlineStateFailed];      // no event
-  [listener queryDidChangeViewSnapshot:snap1];                 // event
+  [listener applyChangedOnlineState:FSTOnlineStateFailed];  // no event
+  [listener queryDidChangeViewSnapshot:snap1];              // event
 
   FSTViewSnapshot *expectedSnap = [[FSTViewSnapshot alloc]
          initWithQuery:query

--- a/Firestore/Example/Tests/Core/FSTQueryListenerTests.m
+++ b/Firestore/Example/Tests/Core/FSTQueryListenerTests.m
@@ -340,10 +340,10 @@ NS_ASSUME_NONNULL_BEGIN
                           [FSTTargetChange changeWithDocuments:@[ doc1, doc2 ]
                                            currentStatusUpdate:FSTCurrentStatusUpdateMarkCurrent]);
 
-  [listener clientDidChangeOnlineState:FSTOnlineStateHealthy];  // no event
+  [listener applyOnlineStateChange:FSTOnlineStateHealthy];  // no event
   [listener queryDidChangeViewSnapshot:snap1];
-  [listener clientDidChangeOnlineState:FSTOnlineStateUnknown];
-  [listener clientDidChangeOnlineState:FSTOnlineStateHealthy];
+  [listener applyOnlineStateChange:FSTOnlineStateUnknown];
+  [listener applyOnlineStateChange:FSTOnlineStateHealthy];
   [listener queryDidChangeViewSnapshot:snap2];
   [listener queryDidChangeViewSnapshot:snap3];
 
@@ -379,11 +379,11 @@ NS_ASSUME_NONNULL_BEGIN
   FSTViewSnapshot *snap1 = FSTTestApplyChanges(view, @[ doc1 ], nil);
   FSTViewSnapshot *snap2 = FSTTestApplyChanges(view, @[ doc2 ], nil);
 
-  [listener clientDidChangeOnlineState:FSTOnlineStateHealthy];  // no event
+  [listener applyOnlineStateChange:FSTOnlineStateHealthy];      // no event
   [listener queryDidChangeViewSnapshot:snap1];                  // no event
-  [listener clientDidChangeOnlineState:FSTOnlineStateFailed];   // event
-  [listener clientDidChangeOnlineState:FSTOnlineStateUnknown];  // no event
-  [listener clientDidChangeOnlineState:FSTOnlineStateFailed];   // no event
+  [listener applyOnlineStateChange:FSTOnlineStateFailed];       // event
+  [listener applyOnlineStateChange:FSTOnlineStateUnknown];      // no event
+  [listener applyOnlineStateChange:FSTOnlineStateFailed];       // no event
   [listener queryDidChangeViewSnapshot:snap2];                  // another event
 
   FSTDocumentViewChange *change1 =
@@ -419,9 +419,9 @@ NS_ASSUME_NONNULL_BEGIN
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:[FSTDocumentKeySet keySet]];
   FSTViewSnapshot *snap1 = FSTTestApplyChanges(view, @[], nil);
 
-  [listener clientDidChangeOnlineState:FSTOnlineStateHealthy];  // no event
+  [listener applyOnlineStateChange:FSTOnlineStateHealthy];      // no event
   [listener queryDidChangeViewSnapshot:snap1];                  // no event
-  [listener clientDidChangeOnlineState:FSTOnlineStateFailed];   // event
+  [listener applyOnlineStateChange:FSTOnlineStateFailed];       // event
 
   FSTViewSnapshot *expectedSnap = [[FSTViewSnapshot alloc]
          initWithQuery:query
@@ -445,7 +445,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:[FSTDocumentKeySet keySet]];
   FSTViewSnapshot *snap1 = FSTTestApplyChanges(view, @[], nil);
 
-  [listener clientDidChangeOnlineState:FSTOnlineStateFailed];  // no event
+  [listener applyOnlineStateChange:FSTOnlineStateFailed];      // no event
   [listener queryDidChangeViewSnapshot:snap1];                 // event
 
   FSTViewSnapshot *expectedSnap = [[FSTViewSnapshot alloc]

--- a/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.m
+++ b/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.m
@@ -139,9 +139,9 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
-- (void)watchStreamDidChangeOnlineState:(FSTOnlineState)onlineState {
+- (void)applyOnlineStateChange:(FSTOnlineState)onlineState {
   [self.syncEngine applyOnlineStateChange:onlineState];
-  [self.eventManager watchStreamDidChangeOnlineState:onlineState];
+  [self.eventManager applyOnlineStateChange:onlineState];
 }
 
 - (void)start {

--- a/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.m
+++ b/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.m
@@ -139,9 +139,9 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
-- (void)applyOnlineStateChange:(FSTOnlineState)onlineState {
-  [self.syncEngine applyOnlineStateChange:onlineState];
-  [self.eventManager applyOnlineStateChange:onlineState];
+- (void)applyChangedOnlineState:(FSTOnlineState)onlineState {
+  [self.syncEngine applyChangedOnlineState:onlineState];
+  [self.eventManager applyChangedOnlineState:onlineState];
 }
 
 - (void)start {

--- a/Firestore/Source/Core/FSTEventManager.h
+++ b/Firestore/Source/Core/FSTEventManager.h
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)queryDidChangeViewSnapshot:(FSTViewSnapshot *)snapshot;
 - (void)queryDidError:(NSError *)error;
-- (void)clientDidChangeOnlineState:(FSTOnlineState)onlineState;
+- (void)applyOnlineStateChange:(FSTOnlineState)onlineState;
 
 @property(nonatomic, strong, readonly) FSTQuery *query;
 

--- a/Firestore/Source/Core/FSTEventManager.h
+++ b/Firestore/Source/Core/FSTEventManager.h
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)queryDidChangeViewSnapshot:(FSTViewSnapshot *)snapshot;
 - (void)queryDidError:(NSError *)error;
-- (void)applyOnlineStateChange:(FSTOnlineState)onlineState;
+- (void)applyChangedOnlineState:(FSTOnlineState)onlineState;
 
 @property(nonatomic, strong, readonly) FSTQuery *query;
 

--- a/Firestore/Source/Core/FSTEventManager.m
+++ b/Firestore/Source/Core/FSTEventManager.m
@@ -151,7 +151,7 @@ NS_ASSUME_NONNULL_BEGIN
   self.viewSnapshotHandler(nil, error);
 }
 
-- (void)applyOnlineStateChange:(FSTOnlineState)onlineState {
+- (void)applyChangedOnlineState:(FSTOnlineState)onlineState {
   self.onlineState = onlineState;
   if (self.snapshot && !self.raisedInitialEvent &&
       [self shouldRaiseInitialEventForSnapshot:self.snapshot onlineState:onlineState]) {
@@ -268,7 +268,7 @@ NS_ASSUME_NONNULL_BEGIN
   }
   [queryInfo.listeners addObject:listener];
 
-  [listener applyOnlineStateChange:self.onlineState];
+  [listener applyChangedOnlineState:self.onlineState];
 
   if (queryInfo.viewSnapshot) {
     [listener queryDidChangeViewSnapshot:queryInfo.viewSnapshot];
@@ -321,11 +321,11 @@ NS_ASSUME_NONNULL_BEGIN
   [self.queries removeObjectForKey:query];
 }
 
-- (void)applyOnlineStateChange:(FSTOnlineState)onlineState {
+- (void)applyChangedOnlineState:(FSTOnlineState)onlineState {
   self.onlineState = onlineState;
   for (FSTQueryListenersInfo *info in self.queries.objectEnumerator) {
     for (FSTQueryListener *listener in info.listeners) {
-      [listener applyOnlineStateChange:onlineState];
+      [listener applyChangedOnlineState:onlineState];
     }
   }
 }

--- a/Firestore/Source/Core/FSTEventManager.m
+++ b/Firestore/Source/Core/FSTEventManager.m
@@ -151,7 +151,7 @@ NS_ASSUME_NONNULL_BEGIN
   self.viewSnapshotHandler(nil, error);
 }
 
-- (void)clientDidChangeOnlineState:(FSTOnlineState)onlineState {
+- (void)applyOnlineStateChange:(FSTOnlineState)onlineState {
   self.onlineState = onlineState;
   if (self.snapshot && !self.raisedInitialEvent &&
       [self shouldRaiseInitialEventForSnapshot:self.snapshot onlineState:onlineState]) {
@@ -268,7 +268,7 @@ NS_ASSUME_NONNULL_BEGIN
   }
   [queryInfo.listeners addObject:listener];
 
-  [listener clientDidChangeOnlineState:self.onlineState];
+  [listener applyOnlineStateChange:self.onlineState];
 
   if (queryInfo.viewSnapshot) {
     [listener queryDidChangeViewSnapshot:queryInfo.viewSnapshot];
@@ -321,11 +321,11 @@ NS_ASSUME_NONNULL_BEGIN
   [self.queries removeObjectForKey:query];
 }
 
-- (void)watchStreamDidChangeOnlineState:(FSTOnlineState)onlineState {
+- (void)applyOnlineStateChange:(FSTOnlineState)onlineState {
   self.onlineState = onlineState;
   for (FSTQueryListenersInfo *info in self.queries.objectEnumerator) {
     for (FSTQueryListener *listener in info.listeners) {
-      [listener clientDidChangeOnlineState:onlineState];
+      [listener applyOnlineStateChange:onlineState];
     }
   }
 }

--- a/Firestore/Source/Core/FSTFirestoreClient.m
+++ b/Firestore/Source/Core/FSTFirestoreClient.m
@@ -187,9 +187,9 @@ NS_ASSUME_NONNULL_BEGIN
   [self.syncEngine userDidChange:user];
 }
 
-- (void)applyOnlineStateChange:(FSTOnlineState)onlineState {
-  [self.syncEngine applyOnlineStateChange:onlineState];
-  [self.eventManager applyOnlineStateChange:onlineState];
+- (void)applyChangedOnlineState:(FSTOnlineState)onlineState {
+  [self.syncEngine applyChangedOnlineState:onlineState];
+  [self.eventManager applyChangedOnlineState:onlineState];
 }
 
 - (void)disableNetworkWithCompletion:(nullable FSTVoidErrorBlock)completion {

--- a/Firestore/Source/Core/FSTFirestoreClient.m
+++ b/Firestore/Source/Core/FSTFirestoreClient.m
@@ -187,9 +187,9 @@ NS_ASSUME_NONNULL_BEGIN
   [self.syncEngine userDidChange:user];
 }
 
-- (void)watchStreamDidChangeOnlineState:(FSTOnlineState)onlineState {
+- (void)applyOnlineStateChange:(FSTOnlineState)onlineState {
   [self.syncEngine applyOnlineStateChange:onlineState];
-  [self.eventManager watchStreamDidChangeOnlineState:onlineState];
+  [self.eventManager applyOnlineStateChange:onlineState];
 }
 
 - (void)disableNetworkWithCompletion:(nullable FSTVoidErrorBlock)completion {

--- a/Firestore/Source/Core/FSTSyncEngine.h
+++ b/Firestore/Source/Core/FSTSyncEngine.h
@@ -101,7 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)userDidChange:(FSTUser *)user;
 
 /** Applies an FSTOnlineState change to the sync engine and notifies any views of the change. */
-- (void)applyOnlineStateChange:(FSTOnlineState)onlineState;
+- (void)applyChangedOnlineState:(FSTOnlineState)onlineState;
 
 @end
 

--- a/Firestore/Source/Core/FSTSyncEngine.m
+++ b/Firestore/Source/Core/FSTSyncEngine.m
@@ -318,11 +318,11 @@ NS_ASSUME_NONNULL_BEGIN
   [self emitNewSnapshotsWithChanges:changes remoteEvent:remoteEvent];
 }
 
-- (void)applyOnlineStateChange:(FSTOnlineState)onlineState {
+- (void)applyChangedOnlineState:(FSTOnlineState)onlineState {
   NSMutableArray<FSTViewSnapshot *> *newViewSnapshots = [NSMutableArray array];
   [self.queryViewsByQuery
       enumerateKeysAndObjectsUsingBlock:^(FSTQuery *query, FSTQueryView *queryView, BOOL *stop) {
-        FSTViewChange *viewChange = [queryView.view applyOnlineStateChange:onlineState];
+        FSTViewChange *viewChange = [queryView.view applyChangedOnlineState:onlineState];
         FSTAssert(viewChange.limboChanges.count == 0,
                   @"OnlineState should not affect limbo documents.");
         if (viewChange.snapshot) {

--- a/Firestore/Source/Core/FSTView.h
+++ b/Firestore/Source/Core/FSTView.h
@@ -143,7 +143,7 @@ typedef NS_ENUM(NSInteger, FSTLimboDocumentChangeType) {
  * Applies an FSTOnlineState change to the view, potentially generating an FSTViewChange if the
  * view's syncState changes as a result.
  */
-- (FSTViewChange *)applyOnlineStateChange:(FSTOnlineState)onlineState;
+- (FSTViewChange *)applyChangedOnlineState:(FSTOnlineState)onlineState;
 
 @end
 

--- a/Firestore/Source/Core/FSTView.m
+++ b/Firestore/Source/Core/FSTView.m
@@ -330,7 +330,7 @@ static NSComparisonResult FSTCompareDocumentViewChangeTypes(FSTDocumentViewChang
   }
 }
 
-- (FSTViewChange *)applyOnlineStateChange:(FSTOnlineState)onlineState {
+- (FSTViewChange *)applyChangedOnlineState:(FSTOnlineState)onlineState {
   if (self.isCurrent && onlineState == FSTOnlineStateFailed) {
     // If we're offline, set `current` to NO and then call applyChanges to refresh our syncState
     // and generate an FSTViewChange as appropriate. We are guaranteed to get a new FSTTargetChange

--- a/Firestore/Source/Remote/FSTRemoteStore.h
+++ b/Firestore/Source/Remote/FSTRemoteStore.h
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol FSTOnlineStateDelegate <NSObject>
 
 /** Called whenever the online state of the watch stream changes */
-- (void)watchStreamDidChangeOnlineState:(FSTOnlineState)onlineState;
+- (void)applyOnlineStateChange:(FSTOnlineState)onlineState;
 
 @end
 

--- a/Firestore/Source/Remote/FSTRemoteStore.h
+++ b/Firestore/Source/Remote/FSTRemoteStore.h
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol FSTOnlineStateDelegate <NSObject>
 
 /** Called whenever the online state of the watch stream changes */
-- (void)applyOnlineStateChange:(FSTOnlineState)onlineState;
+- (void)applyChangedOnlineState:(FSTOnlineState)onlineState;
 
 @end
 

--- a/Firestore/Source/Remote/FSTRemoteStore.m
+++ b/Firestore/Source/Remote/FSTRemoteStore.m
@@ -181,7 +181,7 @@ static const int kOnlineAttemptsBeforeFailure = 2;
   // Update and broadcast the new state.
   if (newState != self.watchStreamOnlineState) {
     self.watchStreamOnlineState = newState;
-    [self.onlineStateDelegate applyOnlineStateChange:newState];
+    [self.onlineStateDelegate applyChangedOnlineState:newState];
   }
 }
 

--- a/Firestore/Source/Remote/FSTRemoteStore.m
+++ b/Firestore/Source/Remote/FSTRemoteStore.m
@@ -181,7 +181,7 @@ static const int kOnlineAttemptsBeforeFailure = 2;
   // Update and broadcast the new state.
   if (newState != self.watchStreamOnlineState) {
     self.watchStreamOnlineState = newState;
-    [self.onlineStateDelegate watchStreamDidChangeOnlineState:newState];
+    [self.onlineStateDelegate applyOnlineStateChange:newState];
   }
 }
 


### PR DESCRIPTION
FYI- I've gone with applyOnlineStateChange on iOS / Web (to be consistent with applyRemoteEvent, etc.) but handleOnlineStateChange on Android (to be consistent with handleListenEvent, etc.).  I'm not sure why the platforms diverged in naming but I don't want to try to clean it up in this PR.