### PR TITLE
Fixing return type of verifySnapshotWithResolvedTimestamps

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRServerTimestampTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRServerTimestampTests.m
@@ -142,7 +142,7 @@
 }
 
 /** Verifies a snapshot containing _setData but with resolved server timestamps. */
-- (id)verifySnapshotWithResolvedTimestamps:(FIRDocumentSnapshot *)snapshot {
+- (void)verifySnapshotWithResolvedTimestamps:(FIRDocumentSnapshot *)snapshot {
   XCTAssertTrue(snapshot.exists);
   NSDate *when = snapshot[@"when"];
   XCTAssertTrue([when isKindOfClass:[NSDate class]]);


### PR DESCRIPTION
This should address a crash that happens when a debugger is attached.