### PR TITLE
Log pending writes when we disable the network

### DIFF
--- a/Firestore/Source/Remote/FSTRemoteStore.m
+++ b/Firestore/Source/Remote/FSTRemoteStore.m
@@ -540,7 +540,7 @@ static const int kOnlineAttemptsBeforeFailure = 2;
 
 - (void)cleanUpWriteStreamState {
   self.lastBatchSeen = kFSTBatchIDUnknown;
-  FSTLog(@"Stopping write stream with %i pending writes", [self.pendingWrites count]);
+  FSTLog(@"Stopping write stream with %lu pending writes", (unsigned long)[self.pendingWrites count]);
   [self.pendingWrites removeAllObjects];
 }
 

--- a/Firestore/Source/Remote/FSTRemoteStore.m
+++ b/Firestore/Source/Remote/FSTRemoteStore.m
@@ -540,6 +540,7 @@ static const int kOnlineAttemptsBeforeFailure = 2;
 
 - (void)cleanUpWriteStreamState {
   self.lastBatchSeen = kFSTBatchIDUnknown;
+  FSTLog(@"Stopping write stream with %i pending writes", [self.pendingWrites count]);
   [self.pendingWrites removeAllObjects];
 }
 

--- a/Firestore/Source/Remote/FSTRemoteStore.m
+++ b/Firestore/Source/Remote/FSTRemoteStore.m
@@ -540,7 +540,8 @@ static const int kOnlineAttemptsBeforeFailure = 2;
 
 - (void)cleanUpWriteStreamState {
   self.lastBatchSeen = kFSTBatchIDUnknown;
-  FSTLog(@"Stopping write stream with %lu pending writes", (unsigned long)[self.pendingWrites count]);
+  FSTLog(@"Stopping write stream with %lu pending writes",
+         (unsigned long)[self.pendingWrites count]);
   [self.pendingWrites removeAllObjects];
 }
 


### PR DESCRIPTION
Add log line to log pending writes remaining when the network is disabled. Requested by API review.