### PR TITLE
Remove sharedApplication, UIKit + AppKit dependency

### DIFF
--- a/Firebase/Core/third_party/FIRAppEnvironmentUtil.h
+++ b/Firebase/Core/third_party/FIRAppEnvironmentUtil.h
@@ -16,12 +16,6 @@
 
 #import <Foundation/Foundation.h>
 
-#if TARGET_OS_IOS
-#import <UIKit/UIKit.h>
-#elif TARGET_OS_OSX
-#import <AppKit/AppKit.h>
-#endif
-
 @interface FIRAppEnvironmentUtil : NSObject
 
 /// Indicates whether the app is from Apple Store or not. Returns NO if the app is on simulator,
@@ -45,13 +39,5 @@
 
 /// Indicates whether it is running inside an extension or an app.
 + (BOOL)isAppExtension;
-
-#if TARGET_OS_IOS
-/// Returns the [UIApplication sharedApplication] if it is running on an app, not an extension.
-+ (UIApplication *)sharedApplication;
-#elif TARGET_OS_OSX
-/// Returns the [NSApplication sharedApplication].
-+ (NSApplication *)sharedApplication;
-#endif
 
 @end

--- a/Firebase/Core/third_party/FIRAppEnvironmentUtil.m
+++ b/Firebase/Core/third_party/FIRAppEnvironmentUtil.m
@@ -204,11 +204,7 @@ static BOOL isAppEncrypted() {
 }
 
 + (NSString *)systemVersion {
-  #if TARGET_OS_IOS
-  return [UIDevice currentDevice].systemVersion;
-  #elif TARGET_OS_OSX
   return [NSProcessInfo processInfo].operatingSystemVersionString;
-  #endif
 }
 
 + (BOOL)isAppExtension {
@@ -220,25 +216,6 @@ static BOOL isAppEncrypted() {
   return NO;
   #endif
 }
-
-#if TARGET_OS_IOS
-+ (UIApplication *)sharedApplication {
-  if ([FIRAppEnvironmentUtil isAppExtension]) {
-    return nil;
-  }
-  id sharedApplication = nil;
-  Class uiApplicationClass = NSClassFromString(@"UIApplication");
-  if (uiApplicationClass &&
-      [uiApplicationClass respondsToSelector:(NSSelectorFromString(@"sharedApplication"))]) {
-    sharedApplication = [uiApplicationClass sharedApplication];
-  }
-  return sharedApplication;
-}
-#elif TARGET_OS_OSX
-+ (NSApplication *)sharedApplication {
-  return [NSApplication sharedApplication];
-}
-#endif
 
 #pragma mark - Helper methods
 


### PR DESCRIPTION
Since we're dropping iOS 7 support, we can move to NSProcessInfo for
iOS. 

cc @wilhuff 