### PR TITLE
Disable autolink when building FirebaseCore

### DIFF
--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -26,9 +26,13 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   s.source_files = 'Firebase/Core/**/*.[mh]'
   s.public_header_files = 'Firebase/Core/Public/*.h', 'Firebase/Core/Private/*.h'
   s.private_header_files = 'Firebase/Core/Private/*.h'
-  s.framework = 'SystemConfiguration'
+  s.frameworks = [
+    'Foundation',
+    'SystemConfiguration'
+  ]
   s.dependency 'GoogleToolboxForMac/NSData+zlib', '~> 2.1'
   s.pod_target_xcconfig = {
-    'OTHER_CFLAGS' => '-DFIRCore_VERSION=' + s.version.to_s + ' -DFirebase_VERSION=4.8.0'
+    'OTHER_CFLAGS' => '-fno-autolink ' +
+      '-DFIRCore_VERSION=' + s.version.to_s + ' -DFirebase_VERSION=4.8.0'
   }
 end

--- a/cmake/FindFirebaseCore.cmake
+++ b/cmake/FindFirebaseCore.cmake
@@ -33,11 +33,10 @@ if(FIREBASECORE_FOUND)
     ${FIREBASECORE_LIBRARY}/PrivateHeaders
   )
 
-  # TODO(mcg): on iOS this should depend on UIKit.
   set(
     FIREBASECORE_LIBRARIES
     ${FIREBASECORE_LIBRARY}
-    "-framework AppKit"
+    "-framework Foundation"
   )
 
   if(NOT TARGET FirebaseCore)


### PR DESCRIPTION
This prevents the dependencies of FirebaseCore's dependencies from
bleeding into its interface.

The proximate benefit of avoiding this is that FirebaseCore no longer
ends up depending on ColorSync.framework which became a top-level system
framework in 10.13. This makes it possible to build against the
resulting FirebaseCore.framework on macOS 10.12 using Xcode 9 (with the
macOS 10.13 SDK).
