### PR TITLE
Move to NSProcessInfo for systemVersion.

### DIFF
--- a/Firebase/Core/third_party/FIRAppEnvironmentUtil.m
+++ b/Firebase/Core/third_party/FIRAppEnvironmentUtil.m
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 #import <Foundation/Foundation.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
-#import <UIKit/UIKit.h>
-#endif
 
 #import "FIRAppEnvironmentUtil.h"
 
@@ -207,11 +204,7 @@ static BOOL isAppEncrypted() {
 }
 
 + (NSString *)systemVersion {
-  #if TARGET_OS_IOS || TARGET_OS_TV
-  return [UIDevice currentDevice].systemVersion;
-  #elif TARGET_OS_OSX
   return [NSProcessInfo processInfo].operatingSystemVersionString;
-  #endif
 }
 
 + (BOOL)isAppExtension {


### PR DESCRIPTION
When supporting iOS 8 and above, we can now safely use NSProcessInfo
on iOS as well as the Mac. This removes a dependency on UIKit for Core.