### PR TITLE
Fixing potential race in ServerTimestamp tests

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRServerTimestampTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRServerTimestampTests.m
@@ -101,15 +101,19 @@
 
 /** Waits for a snapshot with local writes. */
 - (FIRDocumentSnapshot *)waitForLocalEvent {
-  FIRDocumentSnapshot *snapshot = [_accumulator awaitEventWithName:@"Local event."];
-  XCTAssertTrue(snapshot.metadata.hasPendingWrites);
+  FIRDocumentSnapshot *snapshot;
+  do {
+    snapshot = [_accumulator awaitEventWithName:@"Local event."];
+  } while (!snapshot.metadata.hasPendingWrites);
   return snapshot;
 }
 
 /** Waits for a snapshot that has no pending writes */
 - (FIRDocumentSnapshot *)waitForRemoteEvent {
-  FIRDocumentSnapshot *snapshot = [_accumulator awaitEventWithName:@"Remote event."];
-  XCTAssertFalse(snapshot.metadata.hasPendingWrites);
+  FIRDocumentSnapshot *snapshot;
+  do {
+    snapshot = [_accumulator awaitEventWithName:@"Remote event."];
+  } while (snapshot.metadata.hasPendingWrites);
   return snapshot;
 }
 

--- a/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.m
+++ b/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.m
@@ -267,8 +267,7 @@ NS_ASSUME_NONNULL_BEGIN
     @"i" : @1,
     @"n" : [NSNull null],
     @"s" : @"foo",
-    @"a" : @[ @2, @"bar",
-              @{ @"b" : @NO } ],
+    @"a" : @[ @2, @"bar", @{@"b" : @NO} ],
     @"o" : @{
       @"d" : @100,
       @"nested" : @{@"e" : @(LLONG_MIN)},

--- a/Firestore/Source/API/FIRFirestore.m
+++ b/Firestore/Source/API/FIRFirestore.m
@@ -158,14 +158,14 @@ NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
 }
 
 - (FIRFirestoreSettings *)settings {
-  @synchronized (self) {
+  @synchronized(self) {
     // Disallow mutation of our internal settings
     return [_settings copy];
   }
 }
 
 - (void)setSettings:(FIRFirestoreSettings *)settings {
-  @synchronized (self) {
+  @synchronized(self) {
     // As a special exception, don't throw if the same settings are passed repeatedly. This should
     // make it more friendly to create a Firestore instance.
     if (_client && ![_settings isEqual:settings]) {
@@ -187,17 +187,17 @@ NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
 }
 
 - (void)ensureClientConfigured {
-  @synchronized (self) {
+  @synchronized(self) {
     if (!_client) {
       // These values are validated elsewhere; this is just double-checking:
       FSTAssert(_settings.host, @"FirestoreSettings.host cannot be nil.");
       FSTAssert(_settings.dispatchQueue, @"FirestoreSettings.dispatchQueue cannot be nil.");
 
       FSTDatabaseInfo *databaseInfo =
-      [FSTDatabaseInfo databaseInfoWithDatabaseID:_databaseID
-                                   persistenceKey:_persistenceKey
-                                             host:_settings.host
-                                       sslEnabled:_settings.sslEnabled];
+          [FSTDatabaseInfo databaseInfoWithDatabaseID:_databaseID
+                                       persistenceKey:_persistenceKey
+                                                 host:_settings.host
+                                           sslEnabled:_settings.sslEnabled];
 
       FSTDispatchQueue *userDispatchQueue = [FSTDispatchQueue queueWith:_settings.dispatchQueue];
 
@@ -280,7 +280,7 @@ NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
 
 - (void)shutdownWithCompletion:(nullable void (^)(NSError *_Nullable error))completion {
   FSTFirestoreClient *client;
-  @synchronized (self) {
+  @synchronized(self) {
     client = _client;
     _client = nil;
   }


### PR DESCRIPTION
This ports the changes from Android, as we cannot guarantee how many events a series of offline writes produces.
 
The rest of this PR is running ./scripts/style.sh