### PR TITLE
Fix FSTLocalDocumentsView to allow multiple mutations while offline

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased (firestore-api-changes)
+# Unreleased
 - [changed] Removed the includeMetadataChanges property in FIRDocumentListenOptions
   to avoid confusion with the factory method of the same name.
 - [changed] Added a commit method that takes no completion handler to FIRWriteBatch.
@@ -13,6 +13,8 @@
   `true` if the SDK loses its connection to the backend. A new event with
   `snapshot.metadata.isFromCache` set to false will be raised once the
   connection is restored and the query is in sync with the backend again.
+- [fixed] Multiple offline mutations now properly reflected in retrieved
+  documents. Previously, only the last mutation would be visible. (#643)
 
 # v0.9.4
 - [changed] Firestore no longer has a direct dependency on FirebaseAuth.

--- a/Firestore/Example/Tests/Integration/API/FIRQueryTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRQueryTests.m
@@ -275,4 +275,28 @@
   [registration remove];
 }
 
+- (void)testCanHaveMultipleMutationsWhileOffline {
+  FIRCollectionReference *col = [self collectionRef];
+
+  // set a few docs to known values
+  NSDictionary *initialDocs = @{
+    @"doc1": @{@"key1": @"value1"},
+    @"doc2": @{@"key2": @"value2"}
+  };
+  [self writeAllDocuments:initialDocs toCollection:col];
+
+  // go offline for the rest of this test
+  [self disableNetwork];
+
+  // apply *multiple* mutations while offline
+  [[col documentWithPath:@"doc1"] setData:@{@"key1b": @"value1b"}];
+  [[col documentWithPath:@"doc2"] setData:@{@"key2b": @"value2b"}];
+
+  FIRQuerySnapshot *result = [self readDocumentSetForRef:col];
+  XCTAssertEqualObjects(FIRQuerySnapshotGetData(result), (@[
+        @{@"key1b": @"value1b"},
+        @{@"key2b": @"value2b"},
+        ]));
+}
+
 @end

--- a/Firestore/Example/Tests/Integration/API/FIRQueryTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRQueryTests.m
@@ -279,24 +279,23 @@
   FIRCollectionReference *col = [self collectionRef];
 
   // set a few docs to known values
-  NSDictionary *initialDocs = @{
-    @"doc1": @{@"key1": @"value1"},
-    @"doc2": @{@"key2": @"value2"}
-  };
+  NSDictionary *initialDocs =
+      @{ @"doc1" : @{@"key1" : @"value1"},
+         @"doc2" : @{@"key2" : @"value2"} };
   [self writeAllDocuments:initialDocs toCollection:col];
 
   // go offline for the rest of this test
   [self disableNetwork];
 
   // apply *multiple* mutations while offline
-  [[col documentWithPath:@"doc1"] setData:@{@"key1b": @"value1b"}];
-  [[col documentWithPath:@"doc2"] setData:@{@"key2b": @"value2b"}];
+  [[col documentWithPath:@"doc1"] setData:@{@"key1b" : @"value1b"}];
+  [[col documentWithPath:@"doc2"] setData:@{@"key2b" : @"value2b"}];
 
   FIRQuerySnapshot *result = [self readDocumentSetForRef:col];
   XCTAssertEqualObjects(FIRQuerySnapshotGetData(result), (@[
-        @{@"key1b": @"value1b"},
-        @{@"key2b": @"value2b"},
-        ]));
+                          @{@"key1b" : @"value1b"},
+                          @{@"key2b" : @"value2b"},
+                        ]));
 }
 
 @end

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -18,7 +18,6 @@
 
 #import <FirebaseCore/FIRLogger.h>
 #import <FirebaseFirestore/FirebaseFirestore-umbrella.h>
-#import <Firestore/Source/Core/FSTFirestoreClient.h>
 #import <GRPCClient/GRPCCall+ChannelArg.h>
 #import <GRPCClient/GRPCCall+Tests.h>
 
@@ -26,6 +25,7 @@
 
 #import "Firestore/Source/API/FIRFirestore+Internal.h"
 #import "Firestore/Source/Auth/FSTEmptyCredentialsProvider.h"
+#import "Firestore/Source/Core/FSTFirestoreClient.h"
 #import "Firestore/Source/Local/FSTLevelDB.h"
 #import "Firestore/Source/Model/FSTDatabaseID.h"
 #import "Firestore/Source/Util/FSTDispatchQueue.h"

--- a/Firestore/Source/Local/FSTLocalDocumentsView.m
+++ b/Firestore/Source/Local/FSTLocalDocumentsView.m
@@ -167,9 +167,9 @@ NS_ASSUME_NONNULL_BEGIN
                                                  BOOL *stop) {
     FSTMaybeDocument *mutatedDoc = [self localDocument:remoteDocument key:key];
     if ([mutatedDoc isKindOfClass:[FSTDeletedDocument class]]) {
-      result = [documents dictionaryByRemovingObjectForKey:key];
+      result = [result dictionaryByRemovingObjectForKey:key];
     } else if ([mutatedDoc isKindOfClass:[FSTDocument class]]) {
-      result = [documents dictionaryBySettingObject:(FSTDocument *)mutatedDoc forKey:key];
+      result = [result dictionaryBySettingObject:(FSTDocument *)mutatedDoc forKey:key];
     } else {
       FSTFail(@"Unknown document: %@", mutatedDoc);
     }


### PR DESCRIPTION
Previously, only the last mutation would actually be visible. (Mutations would not actually be discarded, but you wouldn't be able to actually see them until the client came online again.)