### PR TITLE
Update Core info for M21.1

### DIFF
--- a/Firebase/Core/CHANGELOG.md
+++ b/Firebase/Core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# v4.0.14 -- M21.1
 - [changed] Removed AppKit dependency for community macOS build.
 
 # 2017-11-30 -- v4.0.12 -- M20.2

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCore'
-  s.version          = '4.0.13'
+  s.version          = '4.0.14'
   s.summary          = 'Firebase Core for iOS'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Update missing version bump for M21.1 for FirebaseCore.