### PR TITLE
Revert "Fully qualify protoc-generated outputs (#626)"

### DIFF
--- a/Firestore/Protos/FrameworkMaker.xcodeproj/project.pbxproj
+++ b/Firestore/Protos/FrameworkMaker.xcodeproj/project.pbxproj
@@ -201,7 +201,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-FrameworkMaker_iOS/Pods-FrameworkMaker_iOS-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/gRPC/gRPCCertificates.bundle",
+				"$PODS_CONFIGURATION_BUILD_DIR/gRPC/gRPCCertificates.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (

--- a/Firestore/Protos/build-protos.sh
+++ b/Firestore/Protos/build-protos.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
 
 # Copyright 2017 Google
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#
 #      http://www.apache.org/licenses/LICENSE-2.0
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,31 +14,6 @@
 # Run this script from firebase-ios-sdk/Firestore/Protos to regnenerate the
 # Objective C files from the protos.
 
-set -euo pipefail
-
-function StartCopyright() {
-  local filename="$1"
-
-  cat > $filename <<EOF
-/*
- * Copyright 2017 Google
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-EOF
-}
-
 # pod update to install protoc and the gRPC plugin compiler.
 rm -rf Pods
 rm Podfile.lock
@@ -50,18 +22,10 @@ pod update
 # Generate the objective C files from the protos.
 ./Pods/!ProtoCompiler/protoc --plugin=protoc-gen-grpc=Pods/\!ProtoCompiler-gRPCPlugin/grpc_objective_c_plugin -I protos --objc_out=objc --grpc_out=objc `find protos -name *.proto -print | xargs`
 
-# Adjust imports in the protos to make them compile
+# CocoaPods does not like paths in library imports, flatten them.
 
 for i in `find objc  -name "*.[mh]"` ; do
-  StartCopyright $i.tmp
-
-  sed '
-    s,#import "\(.*\.pbobjc.h\),#import "Firestore/Protos/objc/\1,;
-    s,#import "\(.*\.pbrpc.h\),#import "Firestore/Protos/objc/\1,;
-    s,  *$,,
-  ' $i >> $i.tmp
-
-  mv $i.tmp $i
+  perl -i -pe 's#import ".*/#import "#' $i;
 done
 
 # Remove the unnecessary extensionRegistry functions.
@@ -72,8 +36,5 @@ done
 
 # Remove non-buildable code from Annotations.pbobjc.*.
 
-StartCopyright objc/google/api/Annotations.pbobjc.m
-echo "static int annotations_stub  __attribute__((unused,used)) = 0;" >> objc/google/api/Annotations.pbobjc.m
-
-StartCopyright objc/google/api/Annotations.pbobjc.h
-echo "// Empty stub file" >> objc/google/api/Annotations.pbobjc.h
+echo "static int annotations_stub  __attribute__((unused,used)) = 0;" > objc/google/api/Annotations.pbobjc.m
+echo "// Empty stub file" > objc/google/api/Annotations.pbobjc.h

--- a/Firestore/Protos/objc/firestore/local/MaybeDocument.pbobjc.m
+++ b/Firestore/Protos/objc/firestore/local/MaybeDocument.pbobjc.m
@@ -32,12 +32,12 @@
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
  #import <Protobuf/Timestamp.pbobjc.h>
 #else
- #import "Firestore/Protos/objc/google/protobuf/Timestamp.pbobjc.h"
+ #import "Timestamp.pbobjc.h"
 #endif
 
- #import "Firestore/Protos/objc/firestore/local/MaybeDocument.pbobjc.h"
- #import "Firestore/Protos/objc/google/firestore/v1beta1/Document.pbobjc.h"
- #import "Firestore/Protos/objc/google/api/Annotations.pbobjc.h"
+ #import "MaybeDocument.pbobjc.h"
+ #import "Document.pbobjc.h"
+ #import "Annotations.pbobjc.h"
 // @@protoc_insertion_point(imports)
 
 #pragma clang diagnostic push

--- a/Firestore/Protos/objc/firestore/local/Mutation.pbobjc.m
+++ b/Firestore/Protos/objc/firestore/local/Mutation.pbobjc.m
@@ -32,12 +32,12 @@
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
  #import <Protobuf/Timestamp.pbobjc.h>
 #else
- #import "Firestore/Protos/objc/google/protobuf/Timestamp.pbobjc.h"
+ #import "Timestamp.pbobjc.h"
 #endif
 
- #import "Firestore/Protos/objc/firestore/local/Mutation.pbobjc.h"
- #import "Firestore/Protos/objc/google/firestore/v1beta1/Write.pbobjc.h"
- #import "Firestore/Protos/objc/google/api/Annotations.pbobjc.h"
+ #import "Mutation.pbobjc.h"
+ #import "Write.pbobjc.h"
+ #import "Annotations.pbobjc.h"
 // @@protoc_insertion_point(imports)
 
 #pragma clang diagnostic push

--- a/Firestore/Protos/objc/firestore/local/Target.pbobjc.m
+++ b/Firestore/Protos/objc/firestore/local/Target.pbobjc.m
@@ -32,12 +32,12 @@
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
  #import <Protobuf/Timestamp.pbobjc.h>
 #else
- #import "Firestore/Protos/objc/google/protobuf/Timestamp.pbobjc.h"
+ #import "Timestamp.pbobjc.h"
 #endif
 
- #import "Firestore/Protos/objc/firestore/local/Target.pbobjc.h"
- #import "Firestore/Protos/objc/google/firestore/v1beta1/Firestore.pbobjc.h"
- #import "Firestore/Protos/objc/google/api/Annotations.pbobjc.h"
+ #import "Target.pbobjc.h"
+ #import "Firestore.pbobjc.h"
+ #import "Annotations.pbobjc.h"
 // @@protoc_insertion_point(imports)
 
 #pragma clang diagnostic push

--- a/Firestore/Protos/objc/google/api/HTTP.pbobjc.m
+++ b/Firestore/Protos/objc/google/api/HTTP.pbobjc.m
@@ -29,7 +29,7 @@
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
 
- #import "Firestore/Protos/objc/google/api/HTTP.pbobjc.h"
+ #import "HTTP.pbobjc.h"
 // @@protoc_insertion_point(imports)
 
 #pragma clang diagnostic push

--- a/Firestore/Protos/objc/google/firestore/v1beta1/Common.pbobjc.m
+++ b/Firestore/Protos/objc/google/firestore/v1beta1/Common.pbobjc.m
@@ -32,11 +32,11 @@
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
  #import <Protobuf/Timestamp.pbobjc.h>
 #else
- #import "Firestore/Protos/objc/google/protobuf/Timestamp.pbobjc.h"
+ #import "Timestamp.pbobjc.h"
 #endif
 
- #import "Firestore/Protos/objc/google/firestore/v1beta1/Common.pbobjc.h"
- #import "Firestore/Protos/objc/google/api/Annotations.pbobjc.h"
+ #import "Common.pbobjc.h"
+ #import "Annotations.pbobjc.h"
 // @@protoc_insertion_point(imports)
 
 #pragma clang diagnostic push

--- a/Firestore/Protos/objc/google/firestore/v1beta1/Document.pbobjc.m
+++ b/Firestore/Protos/objc/google/firestore/v1beta1/Document.pbobjc.m
@@ -33,13 +33,13 @@
  #import <Protobuf/Struct.pbobjc.h>
  #import <Protobuf/Timestamp.pbobjc.h>
 #else
- #import "Firestore/Protos/objc/google/protobuf/Struct.pbobjc.h"
- #import "Firestore/Protos/objc/google/protobuf/Timestamp.pbobjc.h"
+ #import "Struct.pbobjc.h"
+ #import "Timestamp.pbobjc.h"
 #endif
 
- #import "Firestore/Protos/objc/google/firestore/v1beta1/Document.pbobjc.h"
- #import "Firestore/Protos/objc/google/api/Annotations.pbobjc.h"
- #import "Firestore/Protos/objc/google/type/Latlng.pbobjc.h"
+ #import "Document.pbobjc.h"
+ #import "Annotations.pbobjc.h"
+ #import "Latlng.pbobjc.h"
 // @@protoc_insertion_point(imports)
 
 #pragma clang diagnostic push

--- a/Firestore/Protos/objc/google/firestore/v1beta1/Firestore.pbobjc.m
+++ b/Firestore/Protos/objc/google/firestore/v1beta1/Firestore.pbobjc.m
@@ -33,17 +33,17 @@
  #import <Protobuf/Empty.pbobjc.h>
  #import <Protobuf/Timestamp.pbobjc.h>
 #else
- #import "Firestore/Protos/objc/google/protobuf/Empty.pbobjc.h"
- #import "Firestore/Protos/objc/google/protobuf/Timestamp.pbobjc.h"
+ #import "Empty.pbobjc.h"
+ #import "Timestamp.pbobjc.h"
 #endif
 
- #import "Firestore/Protos/objc/google/firestore/v1beta1/Firestore.pbobjc.h"
- #import "Firestore/Protos/objc/google/api/Annotations.pbobjc.h"
- #import "Firestore/Protos/objc/google/firestore/v1beta1/Common.pbobjc.h"
- #import "Firestore/Protos/objc/google/firestore/v1beta1/Document.pbobjc.h"
- #import "Firestore/Protos/objc/google/firestore/v1beta1/Query.pbobjc.h"
- #import "Firestore/Protos/objc/google/firestore/v1beta1/Write.pbobjc.h"
- #import "Firestore/Protos/objc/google/rpc/Status.pbobjc.h"
+ #import "Firestore.pbobjc.h"
+ #import "Annotations.pbobjc.h"
+ #import "Common.pbobjc.h"
+ #import "Document.pbobjc.h"
+ #import "Query.pbobjc.h"
+ #import "Write.pbobjc.h"
+ #import "Status.pbobjc.h"
 // @@protoc_insertion_point(imports)
 
 #pragma clang diagnostic push

--- a/Firestore/Protos/objc/google/firestore/v1beta1/Firestore.pbrpc.h
+++ b/Firestore/Protos/objc/google/firestore/v1beta1/Firestore.pbrpc.h
@@ -14,57 +14,29 @@
  * limitations under the License.
  */
 
-#if !GPB_GRPC_FORWARD_DECLARE_MESSAGE_PROTO
 #import "Firestore/Protos/objc/google/firestore/v1beta1/Firestore.pbobjc.h"
-#endif
 
 #import <ProtoRPC/ProtoService.h>
 #import <ProtoRPC/ProtoRPC.h>
 #import <RxLibrary/GRXWriteable.h>
 #import <RxLibrary/GRXWriter.h>
 
-#if GPB_GRPC_FORWARD_DECLARE_MESSAGE_PROTO
-  @class GCFSBatchGetDocumentsRequest;
-  @class GCFSBatchGetDocumentsResponse;
-  @class GCFSBeginTransactionRequest;
-  @class GCFSBeginTransactionResponse;
-  @class GCFSCommitRequest;
-  @class GCFSCommitResponse;
-  @class GCFSCreateDocumentRequest;
-  @class GCFSDeleteDocumentRequest;
-  @class GCFSDocument;
-  @class GCFSGetDocumentRequest;
-  @class GCFSListCollectionIdsRequest;
-  @class GCFSListCollectionIdsResponse;
-  @class GCFSListDocumentsRequest;
-  @class GCFSListDocumentsResponse;
-  @class GCFSListenRequest;
-  @class GCFSListenResponse;
-  @class GCFSRollbackRequest;
-  @class GCFSRunQueryRequest;
-  @class GCFSRunQueryResponse;
-  @class GCFSUpdateDocumentRequest;
-  @class GCFSWriteRequest;
-  @class GCFSWriteResponse;
-  @class GPBEmpty;
+#import "Firestore/Protos/objc/google/api/Annotations.pbobjc.h"
+#import "Firestore/Protos/objc/google/firestore/v1beta1/Common.pbobjc.h"
+#import "Firestore/Protos/objc/google/firestore/v1beta1/Document.pbobjc.h"
+#import "Firestore/Protos/objc/google/firestore/v1beta1/Query.pbobjc.h"
+#import "Firestore/Protos/objc/google/firestore/v1beta1/Write.pbobjc.h"
+#if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
+  #import <Protobuf/Empty.pbobjc.h>
 #else
-  #import "Firestore/Protos/objc/google/api/Annotations.pbobjc.h"
-  #import "Firestore/Protos/objc/google/firestore/v1beta1/Common.pbobjc.h"
-  #import "Firestore/Protos/objc/google/firestore/v1beta1/Document.pbobjc.h"
-  #import "Firestore/Protos/objc/google/firestore/v1beta1/Query.pbobjc.h"
-  #import "Firestore/Protos/objc/google/firestore/v1beta1/Write.pbobjc.h"
-  #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
-    #import <Protobuf/Empty.pbobjc.h>
-  #else
-    #import "Firestore/Protos/objc/google/protobuf/Empty.pbobjc.h"
-  #endif
-  #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
-    #import <Protobuf/Timestamp.pbobjc.h>
-  #else
-    #import "Firestore/Protos/objc/google/protobuf/Timestamp.pbobjc.h"
-  #endif
-  #import "Firestore/Protos/objc/google/rpc/Status.pbobjc.h"
+  #import "Empty.pbobjc.h"
 #endif
+#if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
+  #import <Protobuf/Timestamp.pbobjc.h>
+#else
+  #import "Timestamp.pbobjc.h"
+#endif
+#import "Firestore/Protos/objc/google/rpc/Status.pbobjc.h"
 
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Firestore/Protos/objc/google/firestore/v1beta1/Firestore.pbrpc.m
+++ b/Firestore/Protos/objc/google/firestore/v1beta1/Firestore.pbrpc.m
@@ -15,26 +15,9 @@
  */
 
 #import "Firestore/Protos/objc/google/firestore/v1beta1/Firestore.pbrpc.h"
-#import "Firestore/Protos/objc/google/firestore/v1beta1/Firestore.pbobjc.h"
 
 #import <ProtoRPC/ProtoRPC.h>
 #import <RxLibrary/GRXWriter+Immediate.h>
-#import "Firestore/Protos/objc/google/api/Annotations.pbobjc.h"
-#import "Firestore/Protos/objc/google/firestore/v1beta1/Common.pbobjc.h"
-#import "Firestore/Protos/objc/google/firestore/v1beta1/Document.pbobjc.h"
-#import "Firestore/Protos/objc/google/firestore/v1beta1/Query.pbobjc.h"
-#import "Firestore/Protos/objc/google/firestore/v1beta1/Write.pbobjc.h"
-#if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
-  #import <Protobuf/Empty.pbobjc.h>
-#else
-  #import "Firestore/Protos/objc/google/protobuf/Empty.pbobjc.h"
-#endif
-#if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
-  #import <Protobuf/Timestamp.pbobjc.h>
-#else
-  #import "Firestore/Protos/objc/google/protobuf/Timestamp.pbobjc.h"
-#endif
-#import "Firestore/Protos/objc/google/rpc/Status.pbobjc.h"
 
 @implementation GCFSFirestore
 

--- a/Firestore/Protos/objc/google/firestore/v1beta1/Query.pbobjc.m
+++ b/Firestore/Protos/objc/google/firestore/v1beta1/Query.pbobjc.m
@@ -32,12 +32,12 @@
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
  #import <Protobuf/Wrappers.pbobjc.h>
 #else
- #import "Firestore/Protos/objc/google/protobuf/Wrappers.pbobjc.h"
+ #import "Wrappers.pbobjc.h"
 #endif
 
- #import "Firestore/Protos/objc/google/firestore/v1beta1/Query.pbobjc.h"
- #import "Firestore/Protos/objc/google/api/Annotations.pbobjc.h"
- #import "Firestore/Protos/objc/google/firestore/v1beta1/Document.pbobjc.h"
+ #import "Query.pbobjc.h"
+ #import "Annotations.pbobjc.h"
+ #import "Document.pbobjc.h"
 // @@protoc_insertion_point(imports)
 
 #pragma clang diagnostic push

--- a/Firestore/Protos/objc/google/firestore/v1beta1/Write.pbobjc.m
+++ b/Firestore/Protos/objc/google/firestore/v1beta1/Write.pbobjc.m
@@ -32,13 +32,13 @@
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
  #import <Protobuf/Timestamp.pbobjc.h>
 #else
- #import "Firestore/Protos/objc/google/protobuf/Timestamp.pbobjc.h"
+ #import "Timestamp.pbobjc.h"
 #endif
 
- #import "Firestore/Protos/objc/google/firestore/v1beta1/Write.pbobjc.h"
- #import "Firestore/Protos/objc/google/api/Annotations.pbobjc.h"
- #import "Firestore/Protos/objc/google/firestore/v1beta1/Common.pbobjc.h"
- #import "Firestore/Protos/objc/google/firestore/v1beta1/Document.pbobjc.h"
+ #import "Write.pbobjc.h"
+ #import "Annotations.pbobjc.h"
+ #import "Common.pbobjc.h"
+ #import "Document.pbobjc.h"
 // @@protoc_insertion_point(imports)
 
 #pragma clang diagnostic push

--- a/Firestore/Protos/objc/google/rpc/Status.pbobjc.m
+++ b/Firestore/Protos/objc/google/rpc/Status.pbobjc.m
@@ -32,10 +32,10 @@
 #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
  #import <Protobuf/Any.pbobjc.h>
 #else
- #import "Firestore/Protos/objc/google/protobuf/Any.pbobjc.h"
+ #import "Any.pbobjc.h"
 #endif
 
- #import "Firestore/Protos/objc/google/rpc/Status.pbobjc.h"
+ #import "Status.pbobjc.h"
 // @@protoc_insertion_point(imports)
 
 #pragma clang diagnostic push

--- a/Firestore/Protos/objc/google/type/Latlng.pbobjc.m
+++ b/Firestore/Protos/objc/google/type/Latlng.pbobjc.m
@@ -29,7 +29,7 @@
  #import "GPBProtocolBuffers_RuntimeSupport.h"
 #endif
 
- #import "Firestore/Protos/objc/google/type/Latlng.pbobjc.h"
+ #import "Latlng.pbobjc.h"
 // @@protoc_insertion_point(imports)
 
 #pragma clang diagnostic push


### PR DESCRIPTION
This reverts commit bc74670afec651c3f912cb6b7e54f5b68bd507f5.

#626 broke the import into google3 where the build doesn't use framework imports.