### PR TITLE
Remove over-aggressive closeWithFinalState: delegate assert.

### DIFF
--- a/Firestore/Source/Remote/FSTStream.m
+++ b/Firestore/Source/Remote/FSTStream.m
@@ -343,9 +343,6 @@ static const NSTimeInterval kIdleTimeout = 60.0;
 - (void)closeWithFinalState:(FSTStreamState)finalState error:(nullable NSError *)error {
   FSTAssert(finalState == FSTStreamStateError || error == nil,
             @"Can't provide an error when not in an error state.");
-  FSTAssert(self.delegate,
-            @"closeWithFinalState should only be called for a started stream that has an active "
-            @"delegate.");
 
   [self.workerDispatchQueue verifyIsCurrentQueue];
   [self cancelIdleCheck];


### PR DESCRIPTION
Fixes #596.  closeWithFinalState: asserted delegate != nil, but that is not true if when
startWithdelegate: was called we entered backoff (performBackoffWithDelegate:)
and so self.delegate did not get assigned yet.

We could rework the code to make the assertion hold, but per offline
discussion this assert doesn't represent an invariant that we care about
maintaining and so I'm just removing it.