### PR TITLE
Fix issue @morganchen12 discovered where we weren't properly creating FIRQueryDocumentSnapshot instances.

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.m
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.m
@@ -611,6 +611,7 @@
 
         } else if (callbacks == 2) {
           XCTAssertEqual(docSet.count, 1);
+          XCTAssertTrue([docSet.documents[0] isKindOfClass:[FIRQueryDocumentSnapshot class]]);
           XCTAssertEqualObjects(docSet.documents[0].data, newData);
           XCTAssertEqual(docSet.documents[0].metadata.hasPendingWrites, YES);
           [changeCompletion fulfill];

--- a/Firestore/Source/API/FIRDocumentSnapshot.m
+++ b/Firestore/Source/API/FIRDocumentSnapshot.m
@@ -51,10 +51,10 @@ NS_ASSUME_NONNULL_BEGIN
                           documentKey:(FSTDocumentKey *)documentKey
                              document:(nullable FSTDocument *)document
                             fromCache:(BOOL)fromCache {
-  return [[FIRDocumentSnapshot alloc] initWithFirestore:firestore
-                                            documentKey:documentKey
-                                               document:document
-                                              fromCache:fromCache];
+  return [[[self class] alloc] initWithFirestore:firestore
+                                     documentKey:documentKey
+                                        document:document
+                                       fromCache:fromCache];
 }
 
 @end


### PR DESCRIPTION
Cherry-pick of da506b86bc7eedb7de7764033477252ea383a4f6.