### PR TITLE
Inject infoDictionary to fix flakey tests.

### DIFF
--- a/Example/Core/Tests/FIROptionsTest.m
+++ b/Example/Core/Tests/FIROptionsTest.m
@@ -25,7 +25,8 @@ extern NSString *const kFIRLibraryVersionID;
 
 @interface FIROptions (Test)
 
-@property(nonatomic, readonly) NSDictionary *analyticsOptionsDictionary;
+- (nullable NSDictionary *)analyticsOptionsDictionaryWithInfoDictionary:
+    (nullable NSDictionary *)infoDictionary;
 
 @end
 
@@ -263,22 +264,20 @@ extern NSString *const kFIRLibraryVersionID;
 }
 
 - (void)testAnalyticsOptions {
-  id mainBundleMock = OCMPartialMock([NSBundle mainBundle]);
-
   // No keys anywhere.
   NSDictionary *optionsDictionary = nil;
   FIROptions *options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   NSDictionary *mainDictionary = nil;
-  OCMExpect([mainBundleMock infoDictionary]).andReturn(mainDictionary);
   NSDictionary *expectedAnalyticsOptions = @{};
-  XCTAssertEqualObjects(options.analyticsOptionsDictionary, expectedAnalyticsOptions);
+  NSDictionary *analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:nil];
+  XCTAssertEqualObjects(analyticsOptions, expectedAnalyticsOptions);
 
   optionsDictionary = @{};
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   mainDictionary = @{};
-  OCMExpect([mainBundleMock infoDictionary]).andReturn(mainDictionary);
   expectedAnalyticsOptions = @{};
-  XCTAssertEqualObjects(options.analyticsOptionsDictionary, expectedAnalyticsOptions);
+  analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:mainDictionary];
+  XCTAssertEqualObjects(analyticsOptions, expectedAnalyticsOptions);
 
   // Main has no keys.
   optionsDictionary = @{
@@ -288,9 +287,9 @@ extern NSString *const kFIRLibraryVersionID;
   };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   mainDictionary = @{};
-  OCMExpect([mainBundleMock infoDictionary]).andReturn(mainDictionary);
   expectedAnalyticsOptions = optionsDictionary;
-  XCTAssertEqualObjects(options.analyticsOptionsDictionary, expectedAnalyticsOptions);
+  analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:mainDictionary];
+  XCTAssertEqualObjects(analyticsOptions, expectedAnalyticsOptions);
 
   // Main overrides all the keys.
   optionsDictionary = @{
@@ -304,9 +303,9 @@ extern NSString *const kFIRLibraryVersionID;
     kFIRIsAnalyticsCollectionEnabled : @NO,
     kFIRIsMeasurementEnabled : @NO
   };
-  OCMExpect([mainBundleMock infoDictionary]).andReturn(mainDictionary);
   expectedAnalyticsOptions = mainDictionary;
-  XCTAssertEqualObjects(options.analyticsOptionsDictionary, expectedAnalyticsOptions);
+  analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:mainDictionary];
+  XCTAssertEqualObjects(analyticsOptions, expectedAnalyticsOptions);
 
   // Keys exist only in main.
   optionsDictionary = @{};
@@ -316,9 +315,9 @@ extern NSString *const kFIRLibraryVersionID;
     kFIRIsAnalyticsCollectionEnabled : @YES,
     kFIRIsMeasurementEnabled : @YES
   };
-  OCMExpect([mainBundleMock infoDictionary]).andReturn(mainDictionary);
   expectedAnalyticsOptions = mainDictionary;
-  XCTAssertEqualObjects(options.analyticsOptionsDictionary, expectedAnalyticsOptions);
+  analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:mainDictionary];
+  XCTAssertEqualObjects(analyticsOptions, expectedAnalyticsOptions);
 
   // Main overrides single keys.
   optionsDictionary = @{
@@ -328,13 +327,13 @@ extern NSString *const kFIRLibraryVersionID;
   };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   mainDictionary = @{ kFIRIsAnalyticsCollectionDeactivated : @NO };
-  OCMExpect([mainBundleMock infoDictionary]).andReturn(mainDictionary);
   expectedAnalyticsOptions = @{
     kFIRIsAnalyticsCollectionDeactivated : @NO,  // override
     kFIRIsAnalyticsCollectionEnabled : @YES,
     kFIRIsMeasurementEnabled : @YES
   };
-  XCTAssertEqualObjects(options.analyticsOptionsDictionary, expectedAnalyticsOptions);
+  analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:mainDictionary];
+  XCTAssertEqualObjects(analyticsOptions, expectedAnalyticsOptions);
 
   optionsDictionary = @{
     kFIRIsAnalyticsCollectionDeactivated : @YES,
@@ -343,13 +342,13 @@ extern NSString *const kFIRLibraryVersionID;
   };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   mainDictionary = @{ kFIRIsAnalyticsCollectionEnabled : @NO };
-  OCMExpect([mainBundleMock infoDictionary]).andReturn(mainDictionary);
   expectedAnalyticsOptions = @{
     kFIRIsAnalyticsCollectionDeactivated : @YES,
     kFIRIsAnalyticsCollectionEnabled : @NO,  // override
     kFIRIsMeasurementEnabled : @YES
   };
-  XCTAssertEqualObjects(options.analyticsOptionsDictionary, expectedAnalyticsOptions);
+  analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:mainDictionary];
+  XCTAssertEqualObjects(analyticsOptions, expectedAnalyticsOptions);
 
   optionsDictionary = @{
     kFIRIsAnalyticsCollectionDeactivated : @YES,
@@ -358,18 +357,18 @@ extern NSString *const kFIRLibraryVersionID;
   };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   mainDictionary = @{ kFIRIsMeasurementEnabled : @NO };
-  OCMExpect([mainBundleMock infoDictionary]).andReturn(mainDictionary);
   expectedAnalyticsOptions = @{
     kFIRIsAnalyticsCollectionDeactivated : @YES,
     kFIRIsAnalyticsCollectionEnabled : @YES,
     kFIRIsMeasurementEnabled : @NO  // override
   };
-  XCTAssertEqualObjects(options.analyticsOptionsDictionary, expectedAnalyticsOptions);
+  analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:mainDictionary];
+  XCTAssertEqualObjects(analyticsOptions, expectedAnalyticsOptions);
 }
 
 - (void)testAnalyticsOptions_combinatorial {
   // Complete combinatorial test.
-  id mainBundleMock = OCMPartialMock([NSBundle mainBundle]);
+
   // Possible values for the flags in the plist, where NSNull means the flag is not present.
   NSArray *values = @[ [NSNull null], @NO, @YES ];
 
@@ -398,6 +397,9 @@ extern NSString *const kFIRLibraryVersionID;
                 if (![optionsMeasurementEnabled isEqual:[NSNull null]]) {
                   optionsDictionary[kFIRIsMeasurementEnabled] = optionsMeasurementEnabled;
                 }
+
+                // Temporarily mock the mainBundle. This should be improved in the future to prevent
+                // collisions with other tests interacting with the mainBundle.
                 FIROptions *options =
                     [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
                 if (![uniqueOptionsCombinations containsObject:optionsDictionary]) {
@@ -415,7 +417,8 @@ extern NSString *const kFIRLibraryVersionID;
                 if (![mainMeasurementEnabled isEqual:[NSNull null]]) {
                   mainDictionary[kFIRIsMeasurementEnabled] = mainMeasurementEnabled;
                 }
-                OCMExpect([mainBundleMock infoDictionary]).andReturn(mainDictionary);
+
+                // Add mainDictionary to uniqueMainCombinations if it isn't included yet.
                 if (![uniqueMainCombinations containsObject:mainDictionary]) {
                   [uniqueMainCombinations addObject:mainDictionary];
                 }
@@ -427,7 +430,10 @@ extern NSString *const kFIRLibraryVersionID;
                 NSMutableDictionary *expectedAnalyticsOptions =
                     [[NSMutableDictionary alloc] initWithDictionary:optionsDictionary];
                 [expectedAnalyticsOptions addEntriesFromDictionary:mainDictionary];
-                XCTAssertEqualObjects(options.analyticsOptionsDictionary, expectedAnalyticsOptions);
+
+                NSDictionary *analyticsOptions =
+                    [options analyticsOptionsDictionaryWithInfoDictionary:mainDictionary];
+                XCTAssertEqualObjects(analyticsOptions, expectedAnalyticsOptions);
 
                 combinationCount++;
               }

--- a/Example/Core/Tests/FIROptionsTest.m
+++ b/Example/Core/Tests/FIROptionsTest.m
@@ -398,8 +398,6 @@ extern NSString *const kFIRLibraryVersionID;
                   optionsDictionary[kFIRIsMeasurementEnabled] = optionsMeasurementEnabled;
                 }
 
-                // Temporarily mock the mainBundle. This should be improved in the future to prevent
-                // collisions with other tests interacting with the mainBundle.
                 FIROptions *options =
                     [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
                 if (![uniqueOptionsCombinations containsObject:optionsDictionary]) {

--- a/Firebase/Core/FIROptions.m
+++ b/Firebase/Core/FIROptions.m
@@ -62,10 +62,18 @@ NSString *const kFIRExceptionBadModification =
 @property(nonatomic, readwrite) NSMutableDictionary *optionsDictionary;
 
 /**
- * Combination of analytics options from both the main plist and the GoogleService-Info.plist.
+ * Calls `analyticsOptionsDictionaryWithInfoDictionary:` using [NSBundle mainBundle].infoDictionary.
+ * It combines analytics options from both the infoDictionary and the GoogleService-Info.plist.
  * Values which are present in the main plist override values from the GoogleService-Info.plist.
  */
 @property(nonatomic, readonly) NSDictionary *analyticsOptionsDictionary;
+
+/**
+ * Combination of analytics options from both the infoDictionary and the GoogleService-Info.plist.
+ * Values which are present in the infoDictionary override values from the GoogleService-Info.plist.
+ */
+- (NSDictionary *)analyticsOptionsDictionaryWithInfoDictionary:
+    (NSDictionary *)infoDictionary;
 
 /**
  * Throw exception if editing is locked when attempting to modify an option.
@@ -346,16 +354,15 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
 
 #pragma mark - Internal instance methods
 
-- (NSDictionary *)analyticsOptionsDictionary {
+- (NSDictionary *)analyticsOptionsDictionaryWithInfoDictionary:(NSDictionary *)infoDictionary {
   dispatch_once(&_createAnalyticsOptionsDictionaryOnce, ^{
     NSMutableDictionary *tempAnalyticsOptions = [[NSMutableDictionary alloc] init];
-    NSDictionary *mainInfoDictionary = [NSBundle mainBundle].infoDictionary;
     NSArray *measurementKeys = @[
       kFIRIsMeasurementEnabled, kFIRIsAnalyticsCollectionEnabled,
       kFIRIsAnalyticsCollectionDeactivated
     ];
     for (NSString *key in measurementKeys) {
-      id value = mainInfoDictionary[key] ?: self.optionsDictionary[key] ?: nil;
+      id value = infoDictionary[key] ?: self.optionsDictionary[key] ?: nil;
       if (!value) {
         continue;
       }
@@ -364,6 +371,10 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
     _analyticsOptionsDictionary = tempAnalyticsOptions;
   });
   return _analyticsOptionsDictionary;
+}
+
+- (NSDictionary *)analyticsOptionsDictionary {
+  return [self analyticsOptionsDictionaryWithInfoDictionary:[NSBundle mainBundle].infoDictionary];
 }
 
 /**

--- a/Firebase/Core/FIROptions.m
+++ b/Firebase/Core/FIROptions.m
@@ -72,8 +72,7 @@ NSString *const kFIRExceptionBadModification =
  * Combination of analytics options from both the infoDictionary and the GoogleService-Info.plist.
  * Values which are present in the infoDictionary override values from the GoogleService-Info.plist.
  */
-- (NSDictionary *)analyticsOptionsDictionaryWithInfoDictionary:
-    (NSDictionary *)infoDictionary;
+- (NSDictionary *)analyticsOptionsDictionaryWithInfoDictionary:(NSDictionary *)infoDictionary;
 
 /**
  * Throw exception if editing is locked when attempting to modify an option.


### PR DESCRIPTION
Instead of relying on `[[NSBundle mainBundle] infoDictionary]` directly, create a new method to call directly from tests to inject a specific `infoDictionary`. The existing call will use `[[NSBundle mainBundle] infoDictionary]` so no functionality has changed.

This should fix issues with partial mocks with unit tests from #661 