### PR TITLE
Enable warnings in the CMake build

### DIFF
--- a/Firestore/CMakeLists.txt
+++ b/Firestore/CMakeLists.txt
@@ -36,27 +36,12 @@ if(APPLE)
   find_package(FirebaseCore REQUIRED)
 endif()
 
-# We use C++11
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+enable_testing()
+add_subdirectory(third_party/abseil-cpp)
+
+include(CompilerSetup)
 
 # Fully qualified imports, project wide
 include_directories(${FIREBASE_SOURCE_DIR})
 
-if(APPLE)
-  # CMake has no special support for Objective-C as a distinct language but enabling modules and
-  # other clang extensions would apply even to regular C++ sources which is nonportable. Keep these
-  # flags separate to avoid misuse.
-  set(
-    OBJC_FLAGS
-    -fobjc-arc
-    -fmodules
-    -fno-autolink
-    -F${FIREBASE_INSTALL_DIR}/Frameworks
-  )
-endif(APPLE)
-
-enable_testing()
-add_subdirectory(third_party/abseil-cpp)
 add_subdirectory(core)

--- a/Firestore/core/test/firebase/firestore/util/autoid_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/autoid_test.cc
@@ -25,8 +25,8 @@ using firebase::firestore::util::CreateAutoId;
 TEST(AutoId, IsSane) {
   for (int i = 0; i < 50; i++) {
     std::string auto_id = CreateAutoId();
-    EXPECT_EQ(20, auto_id.length());
-    for (int pos = 0; pos < 20; pos++) {
+    EXPECT_EQ(20u, auto_id.length());
+    for (size_t pos = 0; pos < 20; pos++) {
       char c = auto_id[pos];
       EXPECT_TRUE(isalpha(c) || isdigit(c))
           << "Should be printable ascii character: '" << c << "' in \""

--- a/Firestore/core/test/firebase/firestore/util/string_printf_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/string_printf_test.cc
@@ -64,7 +64,7 @@ TEST(StringPrintf, DontOverwriteErrno) {
 
 TEST(StringPrintf, LargeBuf) {
   // Check that the large buffer is handled correctly.
-  int n = 2048;
+  size_t n = 2048;
   char* buf = new char[n + 1];
   memset(buf, ' ', n);
   buf[n] = 0;

--- a/cmake/CompilerSetup.cmake
+++ b/cmake/CompilerSetup.cmake
@@ -1,0 +1,92 @@
+# Copyright 2018 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# C++ Compiler setup
+
+# We use C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(CLANG ON)
+endif()
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(GNU ON)
+endif()
+
+if(CLANG OR GNU)
+  set(
+    common_flags
+    -Wall -Wextra -Wconversion -Werror
+
+    # Be super pedantic about format strings
+    -Wformat
+
+    # Avoid use of uninitialized values
+    -Wuninitialized
+    -fno-common
+
+    # Delete unused things
+    -Wunused-function -Wunused-value -Wunused-variable
+
+    # Cut down on symbol clutter
+    # TODO(wilhuff) try -fvisibility=hidden
+    -fvisibility-inlines-hidden
+  )
+
+  set(
+    c_flags
+    -Wstrict-prototypes
+  )
+
+  if(CLANG)
+    list(
+      APPEND common_flags
+     -Wconditional-uninitialized -Werror=return-type -Winfinite-recursion -Wmove
+     -Wrange-loop-analysis -Wunreachable-code
+    )
+  endif()
+
+  foreach(flag ${common_flags} ${c_flags})
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${flag}")
+  endforeach()
+
+  foreach(flag ${common_flags})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
+  endforeach()
+endif()
+
+if(APPLE)
+  # CMake has no special support for Objective-C as a distinct language but
+  # enabling modules and other clang extensions would apply even to regular C++
+  # sources which is nonportable. Keep these flags separate to avoid misuse.
+  set(
+    OBJC_FLAGS
+    -Werror=deprecated-objc-isa-usage
+    -Werror=non-modular-include-in-framework-module
+    -Werror=objc-root-class
+
+    -Wblock-capture-autoreleasing
+    -Wimplicit-atomic-properties
+    -Wnon-modular-include-in-framework-module
+
+    -fobjc-arc
+    -fmodules
+    -fno-autolink
+
+    -F${FIREBASE_INSTALL_DIR}/Frameworks
+  )
+endif(APPLE)


### PR DESCRIPTION
... and fix warnings it turns up, mostly around signed/unsigned comparison/conversion.