### PR TITLE
Add a cc_library to the CMake build

### DIFF
--- a/Firestore/core/src/firebase/firestore/remote/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/remote/CMakeLists.txt
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(
+cc_library(
   firebase_firestore_remote
-  datastore.h
-  datastore.cc
-)
-target_link_libraries(
-  firebase_firestore_remote
-  grpc::grpc
+  SOURCES
+    datastore.h
+    datastore.cc
+  DEPENDS
+    grpc::grpc
 )

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -50,11 +50,6 @@ cc_library(
   DEPENDS
     FirebaseCore
 )
-target_compile_options(
-  firebase_firestore_util_apple
-  PRIVATE
-  ${OBJC_FLAGS}
-)
 
 # Export a dependency on the correct logging library for this platform. All
 # buildable libraries are built and tested but only the best fit is exported.

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -16,69 +16,66 @@
 # libraries in here are an implementation detail of making this a
 # mutli-platform build.
 
-add_library(
+cc_library(
   firebase_firestore_util_base
-  secure_random_arc4random.cc
-  string_printf.cc
-)
-target_link_libraries(
-  firebase_firestore_util_base
-  PUBLIC
-  absl_base
+  SOURCES
+    secure_random.h
+    secure_random_arc4random.cc
+    string_printf.cc
+    string_printf.h
+  DEPENDS
+    absl_base
 )
 
+## assert and log
+
 # stdio-dependent bits can be built and tested everywhere
-add_library(
+cc_library(
   firebase_firestore_util_stdio
-  assert_stdio.cc
-  log_stdio.cc
-)
-target_link_libraries(
-  firebase_firestore_util_stdio
-  PUBLIC
-  firebase_firestore_util_base
+  SOURCES
+    assert_stdio.cc
+    log_stdio.cc
+  DEPENDS
+    firebase_firestore_util_base
+    absl_base
 )
 
 # apple-dependent bits can only built and tested on apple plaforms
-if(APPLE)
-  add_library(
-    firebase_firestore_util_apple
+cc_library(
+  firebase_firestore_util_apple
+  SOURCES
     assert_apple.mm
     log_apple.mm
-  )
-  target_compile_options(
-    firebase_firestore_util_apple
-    PRIVATE
-    ${OBJC_FLAGS}
-  )
-  target_link_libraries(
-    firebase_firestore_util_apple
-    PUBLIC
+    string_apple.h
+  DEPENDS
     FirebaseCore
-  )
-endif(APPLE)
-
-add_library(
-  firebase_firestore_util
-  autoid.cc
+)
+target_compile_options(
+  firebase_firestore_util_apple
+  PRIVATE
+  ${OBJC_FLAGS}
 )
 
 # Export a dependency on the correct logging library for this platform. All
 # buildable libraries are built and tested but only the best fit is exported.
 if(APPLE)
-  target_link_libraries(
-    firebase_firestore_util
-    PUBLIC
-    firebase_firestore_util_apple
-    firebase_firestore_util_base
-  )
+  list(APPEND UTIL_DEPENDS firebase_firestore_util_apple)
+else()
+  list(APPEND UTIL_DEPENDS firebase_firestore_util_stdio)
+endif()
 
-else(NOT APPLE)
-  target_link_libraries(
-    firebase_firestore_util
-    PUBLIC
-    firebase_firestore_util_stdio
-    firebase_firestore_util_base
-  )
 
-endif(APPLE)
+## main library
+
+cc_library(
+  firebase_firestore_util
+  SOURCES
+    autoid.cc
+    autoid.h
+    firebase_assert.h
+    log.h
+  DEPENDS
+    ${UTIL_DEPENDS}
+    firebase_firestore_util_base
+    absl_base
+)

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -38,6 +38,7 @@ cc_library(
   DEPENDS
     firebase_firestore_util_base
     absl_base
+  EXCLUDE_FROM_ALL
 )
 
 # apple-dependent bits can only built and tested on apple plaforms
@@ -49,6 +50,7 @@ cc_library(
     string_apple.h
   DEPENDS
     FirebaseCore
+  EXCLUDE_FROM_ALL
 )
 
 # Export a dependency on the correct logging library for this platform. All

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -29,7 +29,6 @@ cc_library(
 
 ## assert and log
 
-# stdio-dependent bits can be built and tested everywhere
 cc_library(
   firebase_firestore_util_stdio
   SOURCES
@@ -41,7 +40,6 @@ cc_library(
   EXCLUDE_FROM_ALL
 )
 
-# apple-dependent bits can only built and tested on apple plaforms
 cc_library(
   firebase_firestore_util_apple
   SOURCES

--- a/Firestore/core/test/firebase/firestore/remote/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/remote/CMakeLists.txt
@@ -14,9 +14,8 @@
 
 cc_test(
   firebase_firestore_remote_test
-  datastore_test.cc
-)
-target_link_libraries(
-  firebase_firestore_remote_test
-  firebase_firestore_remote
+  SOURCES
+    datastore_test.cc
+  DEPENDS
+    firebase_firestore_remote
 )

--- a/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
@@ -16,6 +16,7 @@ cc_test(
   firebase_firestore_util_test
   SOURCES
     autoid_test.cc
+    secure_random_test.cc
     string_printf_test.cc
   DEPENDS
     firebase_firestore_util

--- a/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
@@ -14,33 +14,29 @@
 
 cc_test(
   firebase_firestore_util_test
-  autoid_test.cc
-  secure_random_test.cc
-  string_printf_test.cc
-)
-target_link_libraries(
-  firebase_firestore_util_test
-  firebase_firestore_util
+  SOURCES
+    autoid_test.cc
+    string_printf_test.cc
+  DEPENDS
+    firebase_firestore_util
 )
 
 if(APPLE)
   cc_test(
     firebase_firestore_util_apple_test
-    assert_test.cc
-    log_test.cc
-  )
-  target_link_libraries(
-    firebase_firestore_util_apple_test
-    firebase_firestore_util_apple
+    SOURCES
+      assert_test.cc
+      log_test.cc
+    DEPENDS
+      firebase_firestore_util_apple
   )
 endif(APPLE)
 
 cc_test(
   firebase_firestore_util_stdio_test
-  assert_test.cc
-  log_test.cc
-)
-target_link_libraries(
-  firebase_firestore_util_stdio_test
-  firebase_firestore_util_stdio
+  SOURCES
+    assert_test.cc
+    log_test.cc
+  DEPENDS
+    firebase_firestore_util_stdio
 )

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -22,8 +22,9 @@ include(CMakeParseArguments)
 #
 # Defines a new library target with the given target name, sources, and dependencies.
 function(cc_library name)
+  set(flag EXCLUDE_FROM_ALL)
   set(multi DEPENDS SOURCES)
-  cmake_parse_arguments(ccl "" "" "${multi}" ${ARGN})
+  cmake_parse_arguments(ccl "${flag}" "" "${multi}" ${ARGN})
 
   add_library(
     ${name}
@@ -35,6 +36,13 @@ function(cc_library name)
     PUBLIC
     ${ccl_DEPENDS}
   )
+
+  if(ccl_EXCLUDE_FROM_ALL)
+    set_property(
+      TARGET ${name}
+      PROPERTY EXCLUDE_FROM_ALL ON
+    )
+  endif()
 
 endfunction()
 

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -12,16 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Defines a new test executable and does all the things we want done with
-# tests:
+include(CMakeParseArguments)
+
+# cc_test(
+#   target
+#   SOURCES sources...
+#   DEPENDS libraries...
+# )
 #
-#   * add_executable (with the given arguments)
-#   * add_Test - defines a test with the same name
-#   * declares that the test links against gtest
-#   * adds the executable as a dependency of the `check` target.
+# Defines a new test executable target with the given target name, sources, and
+# dependencies.  Implicitly adds DEPENDS on GTest::GTest and GTest::Main.
 function(cc_test name)
-  add_executable(${name} ${ARGN})
+  set(multi DEPENDS SOURCES)
+  cmake_parse_arguments(cct "" "" "${multi}" ${ARGN})
+
+  list(APPEND cct_DEPENDS GTest::GTest GTest::Main)
+
+  add_executable(${name} ${cct_SOURCES})
   add_test(${name} ${name})
 
-  target_link_libraries(${name} GTest::GTest GTest::Main)
+  target_link_libraries(${name} ${cct_DEPENDS})
 endfunction()

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -29,6 +29,7 @@ function(cc_library name)
     ${name}
     ${ccl_SOURCES}
   )
+  add_objc_flags(${name} ccl)
   target_link_libraries(
     ${name}
     PUBLIC
@@ -52,7 +53,31 @@ function(cc_test name)
   list(APPEND cct_DEPENDS GTest::GTest GTest::Main)
 
   add_executable(${name} ${cct_SOURCES})
+  add_objc_flags(${name} cct)
   add_test(${name} ${name})
 
   target_link_libraries(${name} ${cct_DEPENDS})
+endfunction()
+
+# add_objc_flags(target sources...)
+#
+# Adds OBJC_FLAGS to the compile options of the given target if any of the
+# sources have filenames that indicate they are are Objective-C.
+function(add_objc_flags target)
+  set(_has_objc OFF)
+
+  foreach(source ${ARGN})
+    get_filename_component(ext ${source} EXT)
+    if((ext STREQUAL ".m") OR (ext STREQUAL ".mm"))
+      set(_has_objc ON)
+    endif()
+  endforeach()
+
+  if(_has_objc)
+    target_compile_options(
+      ${target}
+      PRIVATE
+      ${OBJC_FLAGS}
+    )
+  endif()
 endfunction()

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -14,6 +14,29 @@
 
 include(CMakeParseArguments)
 
+# cc_library(
+#   target
+#   SOURCES sources...
+#   DEPENDS libraries...
+# )
+#
+# Defines a new library target with the given target name, sources, and dependencies.
+function(cc_library name)
+  set(multi DEPENDS SOURCES)
+  cmake_parse_arguments(ccl "" "" "${multi}" ${ARGN})
+
+  add_library(
+    ${name}
+    ${ccl_SOURCES}
+  )
+  target_link_libraries(
+    ${name}
+    PUBLIC
+    ${ccl_DEPENDS}
+  )
+
+endfunction()
+
 # cc_test(
 #   target
 #   SOURCES sources...


### PR DESCRIPTION
The idea here is to reduce the verbosity of creating CMake rules and to ensure they're uniform and to simplify how platform-specific libraries are declared (so that I can declare more of them).