### PR TITLE
Listen sequence numbers

### DIFF
--- a/Firestore/Example/Tests/Local/FSTLocalSerializerTests.m
+++ b/Firestore/Example/Tests/Local/FSTLocalSerializerTests.m
@@ -157,6 +157,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTQueryData *queryData = [[FSTQueryData alloc] initWithQuery:query
                                                        targetID:targetID
+                                           listenSequenceNumber:10
                                                         purpose:FSTQueryPurposeListen
                                                 snapshotVersion:version
                                                     resumeToken:resumeToken];
@@ -166,6 +167,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTPBTarget *expected = [FSTPBTarget message];
   expected.targetId = targetID;
+  expected.lastListenSequenceNumber = 10;
   expected.snapshotVersion.nanos = 1039000;
   expected.resumeToken = [resumeToken copy];
   expected.query.parent = queryTarget.parent;

--- a/Firestore/Example/Tests/Local/FSTQueryCacheTests.m
+++ b/Firestore/Example/Tests/Local/FSTQueryCacheTests.m
@@ -56,7 +56,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testSetAndReadAQuery {
   if ([self isTestBaseClass]) return;
 
-  FSTQueryData *queryData = [self queryDataWithQuery:_queryRooms targetID:1 version:1];
+  FSTQueryData *queryData =
+      [self queryDataWithQuery:_queryRooms targetID:1 listenSequenceNumber:1 version:1];
   [self addQueryData:queryData];
 
   FSTQueryData *result = [self.queryCache queryDataForQuery:_queryRooms];
@@ -74,14 +75,14 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQuery *q2 = [FSTTestQuery(@"a") queryByAddingFilter:FSTTestFilter(@"foo", @"==", @"1")];
   XCTAssertEqualObjects(q1.canonicalID, q2.canonicalID);
 
-  FSTQueryData *data1 = [self queryDataWithQuery:q1 targetID:1 version:1];
+  FSTQueryData *data1 = [self queryDataWithQuery:q1 targetID:1 listenSequenceNumber:1 version:1];
   [self addQueryData:data1];
 
   // Using the other query should not return the query cache entry despite equal canonicalIDs.
   XCTAssertNil([self.queryCache queryDataForQuery:q2]);
   XCTAssertEqualObjects([self.queryCache queryDataForQuery:q1], data1);
 
-  FSTQueryData *data2 = [self queryDataWithQuery:q2 targetID:2 version:1];
+  FSTQueryData *data2 = [self queryDataWithQuery:q2 targetID:2 listenSequenceNumber:2 version:1];
   [self addQueryData:data2];
 
   XCTAssertEqualObjects([self.queryCache queryDataForQuery:q1], data1);
@@ -99,10 +100,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testSetQueryToNewValue {
   if ([self isTestBaseClass]) return;
 
-  FSTQueryData *queryData1 = [self queryDataWithQuery:_queryRooms targetID:1 version:1];
+  FSTQueryData *queryData1 =
+      [self queryDataWithQuery:_queryRooms targetID:1 listenSequenceNumber:1 version:1];
   [self addQueryData:queryData1];
 
-  FSTQueryData *queryData2 = [self queryDataWithQuery:_queryRooms targetID:1 version:2];
+  FSTQueryData *queryData2 =
+      [self queryDataWithQuery:_queryRooms targetID:1 listenSequenceNumber:1 version:2];
   [self addQueryData:queryData2];
 
   FSTQueryData *result = [self.queryCache queryDataForQuery:_queryRooms];
@@ -115,7 +118,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testRemoveQuery {
   if ([self isTestBaseClass]) return;
 
-  FSTQueryData *queryData1 = [self queryDataWithQuery:_queryRooms targetID:1 version:1];
+  FSTQueryData *queryData1 =
+      [self queryDataWithQuery:_queryRooms targetID:1 listenSequenceNumber:1 version:1];
   [self addQueryData:queryData1];
 
   [self removeQueryData:queryData1];
@@ -127,7 +131,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testRemoveNonExistentQuery {
   if ([self isTestBaseClass]) return;
 
-  FSTQueryData *queryData = [self queryDataWithQuery:_queryRooms targetID:1 version:1];
+  FSTQueryData *queryData =
+      [self queryDataWithQuery:_queryRooms targetID:1 listenSequenceNumber:1 version:1];
 
   // no-op, but make sure it doesn't throw.
   XCTAssertNoThrow([self removeQueryData:queryData]);
@@ -136,7 +141,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testRemoveQueryRemovesMatchingKeysToo {
   if ([self isTestBaseClass]) return;
 
-  FSTQueryData *rooms = [self queryDataWithQuery:_queryRooms targetID:1 version:1];
+  FSTQueryData *rooms =
+      [self queryDataWithQuery:_queryRooms targetID:1 listenSequenceNumber:1 version:1];
   [self addQueryData:rooms];
 
   FSTDocumentKey *key1 = FSTTestDocKey(@"rooms/foo");
@@ -204,14 +210,16 @@ NS_ASSUME_NONNULL_BEGIN
   [garbageCollector addGarbageSource:self.queryCache];
   FSTAssertEqualSets([garbageCollector collectGarbage], @[]);
 
-  FSTQueryData *rooms = [self queryDataWithQuery:FSTTestQuery(@"rooms") targetID:1 version:1];
+  FSTQueryData *rooms =
+      [self queryDataWithQuery:FSTTestQuery(@"rooms") targetID:1 listenSequenceNumber:1 version:1];
   FSTDocumentKey *room1 = FSTTestDocKey(@"rooms/bar");
   FSTDocumentKey *room2 = FSTTestDocKey(@"rooms/foo");
   [self addQueryData:rooms];
   [self addMatchingKey:room1 forTargetID:rooms.targetID];
   [self addMatchingKey:room2 forTargetID:rooms.targetID];
 
-  FSTQueryData *halls = [self queryDataWithQuery:FSTTestQuery(@"halls") targetID:2 version:1];
+  FSTQueryData *halls =
+      [self queryDataWithQuery:FSTTestQuery(@"halls") targetID:2 listenSequenceNumber:2 version:1];
   FSTDocumentKey *hall1 = FSTTestDocKey(@"halls/bar");
   FSTDocumentKey *hall2 = FSTTestDocKey(@"halls/foo");
   [self addQueryData:halls];
@@ -249,6 +257,46 @@ NS_ASSUME_NONNULL_BEGIN
   FSTAssertEqualSets([self.queryCache matchingKeysForTargetID:2], (@[ key1, key3 ]));
 }
 
+- (void)testHighestListenSequenceNumber {
+  if ([self isTestBaseClass]) return;
+
+  FSTQueryData *query1 = [[FSTQueryData alloc] initWithQuery:FSTTestQuery(@"rooms")
+                                                    targetID:1
+                                        listenSequenceNumber:10
+                                                     purpose:FSTQueryPurposeListen];
+  [self addQueryData:query1];
+  FSTQueryData *query2 = [[FSTQueryData alloc] initWithQuery:FSTTestQuery(@"halls")
+                                                    targetID:2
+                                        listenSequenceNumber:20
+                                                     purpose:FSTQueryPurposeListen];
+  [self addQueryData:query2];
+  XCTAssertEqual([self.queryCache highestListenSequenceNumber], 20);
+
+  // TargetIDs never come down.
+  [self removeQueryData:query2];
+  XCTAssertEqual([self.queryCache highestListenSequenceNumber], 20);
+
+  // A query with an empty result set still counts.
+  FSTQueryData *query3 = [[FSTQueryData alloc] initWithQuery:FSTTestQuery(@"garages")
+                                                    targetID:42
+                                        listenSequenceNumber:100
+                                                     purpose:FSTQueryPurposeListen];
+  [self addQueryData:query3];
+  XCTAssertEqual([self.queryCache highestListenSequenceNumber], 100);
+
+  [self removeQueryData:query1];
+  XCTAssertEqual([self.queryCache highestListenSequenceNumber], 100);
+
+  [self removeQueryData:query3];
+  XCTAssertEqual([self.queryCache highestListenSequenceNumber], 100);
+
+  // Verify that the highestTargetID even survives restarts.
+  [self.queryCache shutdown];
+  self.queryCache = [self.persistence queryCache];
+  [self.queryCache start];
+  XCTAssertEqual([self.queryCache highestListenSequenceNumber], 100);
+}
+
 - (void)testHighestTargetID {
   if ([self isTestBaseClass]) return;
 
@@ -256,6 +304,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTQueryData *query1 = [[FSTQueryData alloc] initWithQuery:FSTTestQuery(@"rooms")
                                                     targetID:1
+                                        listenSequenceNumber:10
                                                      purpose:FSTQueryPurposeListen];
   FSTDocumentKey *key1 = FSTTestDocKey(@"rooms/bar");
   FSTDocumentKey *key2 = FSTTestDocKey(@"rooms/foo");
@@ -265,6 +314,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTQueryData *query2 = [[FSTQueryData alloc] initWithQuery:FSTTestQuery(@"halls")
                                                     targetID:2
+                                        listenSequenceNumber:20
                                                      purpose:FSTQueryPurposeListen];
   FSTDocumentKey *key3 = FSTTestDocKey(@"halls/foo");
   [self addQueryData:query2];
@@ -278,6 +328,7 @@ NS_ASSUME_NONNULL_BEGIN
   // A query with an empty result set still counts.
   FSTQueryData *query3 = [[FSTQueryData alloc] initWithQuery:FSTTestQuery(@"garages")
                                                     targetID:42
+                                        listenSequenceNumber:100
                                                      purpose:FSTQueryPurposeListen];
   [self addQueryData:query3];
   XCTAssertEqual([self.queryCache highestTargetID], 42);
@@ -321,10 +372,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (FSTQueryData *)queryDataWithQuery:(FSTQuery *)query
                             targetID:(FSTTargetID)targetID
+                listenSequenceNumber:(FSTListenSequenceNumber)sequenceNumber
                              version:(FSTTestSnapshotVersion)version {
   NSData *resumeToken = FSTTestResumeTokenFromSnapshotVersion(version);
   return [[FSTQueryData alloc] initWithQuery:query
                                     targetID:targetID
+                        listenSequenceNumber:sequenceNumber
                                      purpose:FSTQueryPurposeListen
                              snapshotVersion:FSTTestVersion(version)
                                  resumeToken:resumeToken];

--- a/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.m
+++ b/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.m
@@ -396,20 +396,25 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testEncodesListenRequestLabels {
   FSTQuery *query = FSTTestQuery(@"collection/key");
-  FSTQueryData *queryData =
-      [[FSTQueryData alloc] initWithQuery:query targetID:2 purpose:FSTQueryPurposeListen];
+  FSTQueryData *queryData = [[FSTQueryData alloc] initWithQuery:query
+                                                       targetID:2
+                                           listenSequenceNumber:2
+                                                        purpose:FSTQueryPurposeListen];
 
   NSDictionary<NSString *, NSString *> *result =
       [self.serializer encodedListenRequestLabelsForQueryData:queryData];
   XCTAssertNil(result);
 
-  queryData =
-      [[FSTQueryData alloc] initWithQuery:query targetID:2 purpose:FSTQueryPurposeLimboResolution];
+  queryData = [[FSTQueryData alloc] initWithQuery:query
+                                         targetID:2
+                             listenSequenceNumber:2
+                                          purpose:FSTQueryPurposeLimboResolution];
   result = [self.serializer encodedListenRequestLabelsForQueryData:queryData];
   XCTAssertEqualObjects(result, @{@"goog-listen-tags" : @"limbo-document"});
 
   queryData = [[FSTQueryData alloc] initWithQuery:query
                                          targetID:2
+                             listenSequenceNumber:2
                                           purpose:FSTQueryPurposeExistenceFilterMismatch];
   result = [self.serializer encodedListenRequestLabelsForQueryData:queryData];
   XCTAssertEqualObjects(result, @{@"goog-listen-tags" : @"existence-filter-mismatch"});
@@ -627,6 +632,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQuery *q = FSTTestQuery(@"docs");
   FSTQueryData *model = [[FSTQueryData alloc] initWithQuery:q
                                                    targetID:1
+                                       listenSequenceNumber:0
                                                     purpose:FSTQueryPurposeListen
                                             snapshotVersion:[FSTSnapshotVersion noVersion]
                                                 resumeToken:FSTTestData(1, 2, 3, -1)];
@@ -647,6 +653,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (FSTQueryData *)queryDataForQuery:(FSTQuery *)query {
   return [[FSTQueryData alloc] initWithQuery:query
                                     targetID:1
+                        listenSequenceNumber:0
                                      purpose:FSTQueryPurposeListen
                              snapshotVersion:[FSTSnapshotVersion noVersion]
                                  resumeToken:[NSData data]];

--- a/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.m
+++ b/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.m
@@ -398,7 +398,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQuery *query = FSTTestQuery(@"collection/key");
   FSTQueryData *queryData = [[FSTQueryData alloc] initWithQuery:query
                                                        targetID:2
-                                           listenSequenceNumber:2
+                                           listenSequenceNumber:3
                                                         purpose:FSTQueryPurposeListen];
 
   NSDictionary<NSString *, NSString *> *result =
@@ -407,14 +407,14 @@ NS_ASSUME_NONNULL_BEGIN
 
   queryData = [[FSTQueryData alloc] initWithQuery:query
                                          targetID:2
-                             listenSequenceNumber:2
+                             listenSequenceNumber:3
                                           purpose:FSTQueryPurposeLimboResolution];
   result = [self.serializer encodedListenRequestLabelsForQueryData:queryData];
   XCTAssertEqualObjects(result, @{@"goog-listen-tags" : @"limbo-document"});
 
   queryData = [[FSTQueryData alloc] initWithQuery:query
                                          targetID:2
-                             listenSequenceNumber:2
+                             listenSequenceNumber:3
                                           purpose:FSTQueryPurposeExistenceFilterMismatch];
   result = [self.serializer encodedListenRequestLabelsForQueryData:queryData];
   XCTAssertEqualObjects(result, @{@"goog-listen-tags" : @"existence-filter-mismatch"});

--- a/Firestore/Example/Tests/SpecTests/FSTMockDatastore.m
+++ b/Firestore/Example/Tests/SpecTests/FSTMockDatastore.m
@@ -109,6 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)watchQuery:(FSTQueryData *)query {
+  // TODO(gsoltis): sequence number?
   FSTLog(@"watchQuery: %d: %@", query.targetID, query.query);
   self.datastore.watchStreamRequestCount += 1;
   // Snapshot version is ignored on the wire

--- a/Firestore/Example/Tests/SpecTests/FSTMockDatastore.m
+++ b/Firestore/Example/Tests/SpecTests/FSTMockDatastore.m
@@ -109,7 +109,6 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)watchQuery:(FSTQueryData *)query {
-  // TODO(gsoltis): sequence number?
   FSTLog(@"watchQuery: %d: %@", query.targetID, query.query);
   self.datastore.watchStreamRequestCount += 1;
   // Snapshot version is ignored on the wire

--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.m
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.m
@@ -503,6 +503,7 @@ static NSString *const kNoIOSTag = @"no-ios";
         expectedActiveTargets[@(targetID)] =
             [[FSTQueryData alloc] initWithQuery:query
                                        targetID:targetID
+                           listenSequenceNumber:0
                                         purpose:FSTQueryPurposeListen
                                 snapshotVersion:[FSTSnapshotVersion noVersion]
                                     resumeToken:resumeToken];

--- a/Firestore/Source/Core/FSTListenSequence.h
+++ b/Firestore/Source/Core/FSTListenSequence.h
@@ -1,0 +1,17 @@
+#import <Foundation/Foundation.h>
+
+#import "FSTTypes.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FSTListenSequence : NSObject
+
+- (instancetype)initStartingAfter:(FSTListenSequenceNumber)after NS_DESIGNATED_INITIALIZER;
+
+- (id)init __attribute__((unavailable("Use a static constructor method")));
+
+- (FSTListenSequenceNumber)next;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Firestore/Source/Core/FSTListenSequence.h
+++ b/Firestore/Source/Core/FSTListenSequence.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initStartingAfter:(FSTListenSequenceNumber)after NS_DESIGNATED_INITIALIZER;
 
-- (id)init __attribute__((unavailable("Use a static constructor method")));
+- (id)init __attribute__((unavailable("Use initStartingAfter:")));
 
 - (FSTListenSequenceNumber)next;
 

--- a/Firestore/Source/Core/FSTListenSequence.h
+++ b/Firestore/Source/Core/FSTListenSequence.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google
+ * Copyright 2018 Google
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initStartingAfter:(FSTListenSequenceNumber)after NS_DESIGNATED_INITIALIZER;
 
-- (id)init __attribute__((unavailable("Use initStartingAfter:")));
+- (id)init NS_UNAVAILABLE;
 
 - (FSTListenSequenceNumber)next;
 

--- a/Firestore/Source/Core/FSTListenSequence.h
+++ b/Firestore/Source/Core/FSTListenSequence.h
@@ -1,9 +1,29 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #import <Foundation/Foundation.h>
 
 #import "FSTTypes.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * FSTListenSequence is a monotonic sequence. It is initialized with a minimum value to
+ * exceed. All subsequent calls to next will return increasing values.
+ */
 @interface FSTListenSequence : NSObject
 
 - (instancetype)initStartingAfter:(FSTListenSequenceNumber)after NS_DESIGNATED_INITIALIZER;

--- a/Firestore/Source/Core/FSTListenSequence.m
+++ b/Firestore/Source/Core/FSTListenSequence.m
@@ -1,0 +1,34 @@
+#import "FSTListenSequence.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark - FSTListenSequence
+
+@interface FSTListenSequence () {
+  FSTListenSequenceNumber _previousSequenceNumber;
+}
+
+@end
+
+@implementation FSTListenSequence
+
+#pragma mark - Constructors
+
+- (instancetype)initStartingAfter:(FSTListenSequenceNumber)after {
+  self = [super init];
+  if (self) {
+    _previousSequenceNumber = after;
+  }
+  return self;
+}
+
+#pragma mark - Public methods
+
+- (FSTListenSequenceNumber)next {
+  _previousSequenceNumber++;
+  return _previousSequenceNumber;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Firestore/Source/Core/FSTSyncEngine.m
+++ b/Firestore/Source/Core/FSTSyncEngine.m
@@ -43,6 +43,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// Limbo documents don't use persistence, and are eagerly GC'd. So, listens for them don't need
+// real sequence numbers.
 static const FSTListenSequenceNumber kIrrelevantSequenceNumber = -1;
 
 #pragma mark - FSTQueryView

--- a/Firestore/Source/Core/FSTSyncEngine.m
+++ b/Firestore/Source/Core/FSTSyncEngine.m
@@ -43,6 +43,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+static const FSTListenSequenceNumber kIrrelevantSequenceNumber = -1;
+
 #pragma mark - FSTQueryView
 
 /**
@@ -490,6 +492,7 @@ NS_ASSUME_NONNULL_BEGIN
     FSTQuery *query = [FSTQuery queryWithPath:key.path];
     FSTQueryData *queryData = [[FSTQueryData alloc] initWithQuery:query
                                                          targetID:limboTargetID
+                                             listenSequenceNumber:kIrrelevantSequenceNumber
                                                           purpose:FSTQueryPurposeLimboResolution];
     self.limboKeysByTarget[@(limboTargetID)] = key;
     [self.remoteStore listenToTargetWithQueryData:queryData];

--- a/Firestore/Source/Core/FSTTypes.h
+++ b/Firestore/Source/Core/FSTTypes.h
@@ -26,6 +26,8 @@ typedef int32_t FSTBatchID;
 
 typedef int32_t FSTTargetID;
 
+typedef int64_t FSTListenSequenceNumber;
+
 typedef NSNumber FSTBoxedTargetID;
 
 /**

--- a/Firestore/Source/Local/FSTLocalSerializer.m
+++ b/Firestore/Source/Local/FSTLocalSerializer.m
@@ -156,6 +156,7 @@
 
   FSTPBTarget *proto = [FSTPBTarget message];
   proto.targetId = queryData.targetID;
+  proto.lastListenSequenceNumber = queryData.sequenceNumber;
   proto.snapshotVersion = [remoteSerializer encodedVersion:queryData.snapshotVersion];
   proto.resumeToken = queryData.resumeToken;
 
@@ -173,6 +174,7 @@
   FSTSerializerBeta *remoteSerializer = self.remoteSerializer;
 
   FSTTargetID targetID = target.targetId;
+  FSTListenSequenceNumber sequenceNumber = target.lastListenSequenceNumber;
   FSTSnapshotVersion *version = [remoteSerializer decodedVersion:target.snapshotVersion];
   NSData *resumeToken = target.resumeToken;
 
@@ -192,6 +194,7 @@
 
   return [[FSTQueryData alloc] initWithQuery:query
                                     targetID:targetID
+                        listenSequenceNumber:sequenceNumber
                                      purpose:FSTQueryPurposeListen
                              snapshotVersion:version
                                  resumeToken:resumeToken];

--- a/Firestore/Source/Local/FSTLocalStore.m
+++ b/Firestore/Source/Local/FSTLocalStore.m
@@ -16,6 +16,7 @@
 
 #import "Firestore/Source/Local/FSTLocalStore.h"
 
+#import "FSTListenSequence.h"
 #import "Firestore/Source/Auth/FSTUser.h"
 #import "Firestore/Source/Core/FSTQuery.h"
 #import "Firestore/Source/Core/FSTSnapshotVersion.h"
@@ -75,6 +76,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Used to generate targetIDs for queries tracked locally. */
 @property(nonatomic, strong) FSTTargetIDGenerator *targetIDGenerator;
+
+@property(nonatomic, strong) FSTListenSequence *listenSequence;
 
 /**
  * A heldBatchResult is a mutation batch result (from a write acknowledgement) that arrived before
@@ -148,6 +151,8 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTTargetID targetID = [self.queryCache highestTargetID];
   self.targetIDGenerator = [FSTTargetIDGenerator generatorForLocalStoreStartingAfterID:targetID];
+  FSTListenSequenceNumber sequenceNumber = [self.queryCache highestListenSequenceNumber];
+  self.listenSequence = [[FSTListenSequence alloc] initStartingAfter:sequenceNumber];
 }
 
 - (void)shutdown {
@@ -380,6 +385,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (FSTQueryData *)allocateQuery:(FSTQuery *)query {
   FSTQueryData *cached = [self.queryCache queryDataForQuery:query];
   FSTTargetID targetID;
+  FSTListenSequenceNumber sequenceNumber = [self.listenSequence next];
   if (cached) {
     // This query has been listened to previously, so reuse the previous targetID.
     // TODO(mcg): freshen last accessed date?
@@ -388,8 +394,10 @@ NS_ASSUME_NONNULL_BEGIN
     FSTWriteGroup *group = [self.persistence startGroupWithAction:@"Allocate query"];
 
     targetID = [self.targetIDGenerator nextID];
-    cached =
-        [[FSTQueryData alloc] initWithQuery:query targetID:targetID purpose:FSTQueryPurposeListen];
+    cached = [[FSTQueryData alloc] initWithQuery:query
+                                        targetID:targetID
+                            listenSequenceNumber:sequenceNumber
+                                         purpose:FSTQueryPurposeListen];
     [self.queryCache addQueryData:cached group:group];
 
     [self.persistence commitGroup:group];

--- a/Firestore/Source/Local/FSTLocalStore.m
+++ b/Firestore/Source/Local/FSTLocalStore.m
@@ -16,8 +16,8 @@
 
 #import "Firestore/Source/Local/FSTLocalStore.h"
 
-#import "FSTListenSequence.h"
 #import "Firestore/Source/Auth/FSTUser.h"
+#import "Firestore/Source/Core/FSTListenSequence.h"
 #import "Firestore/Source/Core/FSTQuery.h"
 #import "Firestore/Source/Core/FSTSnapshotVersion.h"
 #import "Firestore/Source/Core/FSTTargetIDGenerator.h"

--- a/Firestore/Source/Local/FSTMemoryQueryCache.m
+++ b/Firestore/Source/Local/FSTMemoryQueryCache.m
@@ -34,6 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
 /** The highest numbered target ID encountered. */
 @property(nonatomic, assign) FSTTargetID highestTargetID;
 
+@property(nonatomic, assign) FSTListenSequenceNumber highestListenSequenceNumber;
+
 @end
 
 @implementation FSTMemoryQueryCache {
@@ -65,6 +67,10 @@ NS_ASSUME_NONNULL_BEGIN
   return _highestTargetID;
 }
 
+- (FSTListenSequenceNumber)highestListenSequenceNumber {
+  return _highestListenSequenceNumber;
+}
+
 - (FSTSnapshotVersion *)lastRemoteSnapshotVersion {
   return _lastRemoteSnapshotVersion;
 }
@@ -78,6 +84,9 @@ NS_ASSUME_NONNULL_BEGIN
   self.queries[queryData.query] = queryData;
   if (queryData.targetID > self.highestTargetID) {
     self.highestTargetID = queryData.targetID;
+  }
+  if (queryData.sequenceNumber > self.highestListenSequenceNumber) {
+    self.highestListenSequenceNumber = queryData.sequenceNumber;
   }
 }
 

--- a/Firestore/Source/Local/FSTQueryCache.h
+++ b/Firestore/Source/Local/FSTQueryCache.h
@@ -52,6 +52,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (FSTTargetID)highestTargetID;
 
+- (FSTListenSequenceNumber)highestListenSequenceNumber;
+
 /**
  * A global snapshot version representing the last consistent snapshot we received from the
  * backend. This is monotonically increasing and any snapshots received from the backend prior to

--- a/Firestore/Source/Local/FSTQueryCache.h
+++ b/Firestore/Source/Local/FSTQueryCache.h
@@ -52,6 +52,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (FSTTargetID)highestTargetID;
 
+/**
+ * Returns the highest listen sequence number of any query seen by the cache.
+ */
 - (FSTListenSequenceNumber)highestListenSequenceNumber;
 
 /**

--- a/Firestore/Source/Local/FSTQueryData.h
+++ b/Firestore/Source/Local/FSTQueryData.h
@@ -40,6 +40,7 @@ typedef NS_ENUM(NSInteger, FSTQueryPurpose) {
 
 - (instancetype)initWithQuery:(FSTQuery *)query
                      targetID:(FSTTargetID)targetID
+         listenSequenceNumber:(FSTListenSequenceNumber)sequenceNumber
                       purpose:(FSTQueryPurpose)purpose
               snapshotVersion:(FSTSnapshotVersion *)snapshotVersion
                   resumeToken:(NSData *)resumeToken NS_DESIGNATED_INITIALIZER;
@@ -47,6 +48,7 @@ typedef NS_ENUM(NSInteger, FSTQueryPurpose) {
 /** Convenience initializer for use when creating an FSTQueryData for the first time. */
 - (instancetype)initWithQuery:(FSTQuery *)query
                      targetID:(FSTTargetID)targetID
+         listenSequenceNumber:(FSTListenSequenceNumber)sequenceNumber
                       purpose:(FSTQueryPurpose)purpose;
 
 - (instancetype)init NS_UNAVAILABLE;
@@ -63,6 +65,8 @@ typedef NS_ENUM(NSInteger, FSTQueryPurpose) {
  * the FSTSyncEngine for limbo queries.
  */
 @property(nonatomic, assign, readonly) FSTTargetID targetID;
+
+@property(nonatomic, assign, readonly) FSTListenSequenceNumber sequenceNumber;
 
 /** The purpose of the query. */
 @property(nonatomic, assign, readonly) FSTQueryPurpose purpose;

--- a/Firestore/Source/Local/FSTQueryData.m
+++ b/Firestore/Source/Local/FSTQueryData.m
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithQuery:(FSTQuery *)query
                      targetID:(FSTTargetID)targetID
+         listenSequenceNumber:(FSTListenSequenceNumber)sequenceNumber
                       purpose:(FSTQueryPurpose)purpose
               snapshotVersion:(FSTSnapshotVersion *)snapshotVersion
                   resumeToken:(NSData *)resumeToken {
@@ -32,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (self) {
     _query = query;
     _targetID = targetID;
+    _sequenceNumber = sequenceNumber;
     _purpose = purpose;
     _snapshotVersion = snapshotVersion;
     _resumeToken = [resumeToken copy];
@@ -41,9 +43,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithQuery:(FSTQuery *)query
                      targetID:(FSTTargetID)targetID
+         listenSequenceNumber:(FSTListenSequenceNumber)sequenceNumber
                       purpose:(FSTQueryPurpose)purpose {
   return [self initWithQuery:query
                     targetID:targetID
+        listenSequenceNumber:sequenceNumber
                      purpose:purpose
              snapshotVersion:[FSTSnapshotVersion noVersion]
                  resumeToken:[NSData data]];
@@ -83,6 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
                                         resumeToken:(NSData *)resumeToken {
   return [[FSTQueryData alloc] initWithQuery:self.query
                                     targetID:self.targetID
+                        listenSequenceNumber:self.sequenceNumber
                                      purpose:self.purpose
                              snapshotVersion:snapshotVersion
                                  resumeToken:resumeToken];

--- a/Firestore/Source/Remote/FSTRemoteStore.m
+++ b/Firestore/Source/Remote/FSTRemoteStore.m
@@ -468,8 +468,10 @@ static const int kOnlineAttemptsBeforeFailure = 2;
         [remoteEvent handleExistenceFilterMismatchForTargetID:target];
 
         // Clear the resume token for the query, since we're in a known mismatch state.
-        queryData =
-            [[FSTQueryData alloc] initWithQuery:query targetID:targetID purpose:queryData.purpose];
+        queryData = [[FSTQueryData alloc] initWithQuery:query
+                                               targetID:targetID
+                                   listenSequenceNumber:queryData.sequenceNumber
+                                                purpose:queryData.purpose];
         self.listenTargets[target] = queryData;
 
         // Cause a hard reset by unwatching and rewatching immediately, but deliberately don't
@@ -483,6 +485,7 @@ static const int kOnlineAttemptsBeforeFailure = 2;
         FSTQueryData *requestQueryData =
             [[FSTQueryData alloc] initWithQuery:query
                                        targetID:targetID
+                           listenSequenceNumber:queryData.sequenceNumber
                                         purpose:FSTQueryPurposeExistenceFilterMismatch];
         [self sendWatchRequestWithQueryData:requestQueryData];
       }


### PR DESCRIPTION
Adds sequence numbers to queries. Includes marshaling back and forth from a proto. Also, levelDB query cache will now remember and persist the highest sequence number it has seen.

This is a stepping stone towards garbage collection and allows us to start ordering queries.