### PR TITLE
Fix CMake build and lint warnings in field_value.cc

### DIFF
--- a/Firestore/core/src/firebase/firestore/model/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/model/CMakeLists.txt
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(
+cc_library(
   firebase_firestore_model
-  field_value.cc
-)
-target_link_libraries(
-  firebase_firestore_model
-  firebase_firestore_util
+  SOURCES
+    field_value.cc
+  DEPENDS
+    firebase_firestore_util
 )

--- a/Firestore/core/src/firebase/firestore/model/field_value.cc
+++ b/Firestore/core/src/firebase/firestore/model/field_value.cc
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "Firestore/core/src/firebase/firestore/util/firebase_assert.h"
@@ -159,7 +160,7 @@ void FieldValue::SwitchTo(const Type type) {
     case Type::Array:
       array_value_.~vector();
       break;
-    default:;  // The other types where there is nothing to worry about.
+    default: {}  // The other types where there is nothing to worry about.
   }
   tag_ = type;
   // Must call constructor explicitly for any non-POD type to initialize.
@@ -167,7 +168,7 @@ void FieldValue::SwitchTo(const Type type) {
     case Type::Array:
       new (&array_value_) std::vector<const FieldValue>();
       break;
-    default:;  // The other types where there is nothing to worry about.
+    default: {}  // The other types where there is nothing to worry about.
   }
 }
 

--- a/Firestore/core/test/firebase/firestore/model/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/model/CMakeLists.txt
@@ -14,9 +14,8 @@
 
 cc_test(
   firebase_firestore_model_test
-  field_value_test.cc
-)
-target_link_libraries(
-  firebase_firestore_model_test
-  firebase_firestore_model
+  SOURCES
+    field_value_test.cc
+  DEPENDS
+    firebase_firestore_model
 )


### PR DESCRIPTION
Fixes these cpplint warnings:

Firestore/core/src/firebase/firestore/model/field_value.cc:162:  Semicolon defining empty statement. Use {} instead.  [whitespace/semicolon] [5]
Firestore/core/src/firebase/firestore/model/field_value.cc:170:  Semicolon defining empty statement. Use {} instead.  [whitespace/semicolon] [5]
Firestore/core/src/firebase/firestore/model/field_value.cc:126:  Add #include <utility> for swap  [build/include_what_you_use] [4]