### PR TITLE
Cleanup imports and isEqual

### DIFF
--- a/Firestore/Example/Tests/API/FIRCollectionReferenceTests.m
+++ b/Firestore/Example/Tests/API/FIRCollectionReferenceTests.m
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#import <XCTest/XCTest.h>
+#import <FirebaseFirestore/FIRCollectionReference.h>
 
-#import "FirebaseFirestore/FIRCollectionReference.h"
+#import <XCTest/XCTest.h>
 
 #import "Firestore/Example/Tests/API/FSTAPIHelpers.h"
 

--- a/Firestore/Example/Tests/API/FIRDocumentReferenceTests.m
+++ b/Firestore/Example/Tests/API/FIRDocumentReferenceTests.m
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#import <XCTest/XCTest.h>
+#import <FirebaseFirestore/FIRDocumentReference.h>
 
-#import "FirebaseFirestore/FIRDocumentReference.h"
+#import <XCTest/XCTest.h>
 
 #import "Firestore/Example/Tests/API/FSTAPIHelpers.h"
 

--- a/Firestore/Example/Tests/API/FIRDocumentSnapshotTests.m
+++ b/Firestore/Example/Tests/API/FIRDocumentSnapshotTests.m
@@ -30,11 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testEquals {
   FIRDocumentSnapshot *base = FSTTestDocSnapshot(@"rooms/foo", 1, @{ @"a" : @1 }, NO, NO);
   FIRDocumentSnapshot *baseDup = FSTTestDocSnapshot(@"rooms/foo", 1, @{ @"a" : @1 }, NO, NO);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
   FIRDocumentSnapshot *nilData = FSTTestDocSnapshot(@"rooms/foo", 1, nil, NO, NO);
   FIRDocumentSnapshot *nilDataDup = FSTTestDocSnapshot(@"rooms/foo", 1, nil, NO, NO);
-#pragma clang diagnostic pop
   FIRDocumentSnapshot *differentPath = FSTTestDocSnapshot(@"rooms/bar", 1, @{ @"a" : @1 }, NO, NO);
   FIRDocumentSnapshot *differentData = FSTTestDocSnapshot(@"rooms/bar", 1, @{ @"b" : @1 }, NO, NO);
   FIRDocumentSnapshot *hasMutations = FSTTestDocSnapshot(@"rooms/bar", 1, @{ @"a" : @1 }, YES, NO);

--- a/Firestore/Example/Tests/API/FIRDocumentSnapshotTests.m
+++ b/Firestore/Example/Tests/API/FIRDocumentSnapshotTests.m
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#import <XCTest/XCTest.h>
+#import <FirebaseFirestore/FIRDocumentSnapshot.h>
 
-#import "FirebaseFirestore/FIRDocumentSnapshot.h"
+#import <XCTest/XCTest.h>
 
 #import "Firestore/Example/Tests/API/FSTAPIHelpers.h"
 

--- a/Firestore/Example/Tests/API/FIRFieldPathTests.m
+++ b/Firestore/Example/Tests/API/FIRFieldPathTests.m
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+#import <FirebaseFirestore/FIRFieldPath.h>
+
 #import <XCTest/XCTest.h>
 
-#import "FirebaseFirestore/FIRFieldPath.h"
 #import "Firestore/Source/API/FIRFieldPath+Internal.h"
 #import "Firestore/Source/Model/FSTPath.h"
 

--- a/Firestore/Example/Tests/API/FIRFieldValueTests.m
+++ b/Firestore/Example/Tests/API/FIRFieldValueTests.m
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
-@import FirebaseFirestore;
+#import <FirebaseFirestore/FIRFieldValue.h>
 
 #import <XCTest/XCTest.h>
-
-#import "FirebaseFirestore/FIRFieldValue.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/Example/Tests/API/FIRGeoPointTests.m
+++ b/Firestore/Example/Tests/API/FIRGeoPointTests.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "FirebaseFirestore/FIRGeoPoint.h"
+#import <FirebaseFirestore/FIRGeoPoint.h>
 
 #import <XCTest/XCTest.h>
 

--- a/Firestore/Example/Tests/API/FIRQuerySnapshotTests.m
+++ b/Firestore/Example/Tests/API/FIRQuerySnapshotTests.m
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+#import <FirebaseFirestore/FIRQuerySnapshot.h>
+
 #import <XCTest/XCTest.h>
 
-#import "FirebaseFirestore/FIRQuerySnapshot.h"
 #import "Firestore/Source/Model/FSTPath.h"
 
 #import "Firestore/Example/Tests/API/FSTAPIHelpers.h"

--- a/Firestore/Example/Tests/API/FIRQueryTests.m
+++ b/Firestore/Example/Tests/API/FIRQueryTests.m
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+#import <FirebaseFirestore/FIRQuery.h>
+
 #import <XCTest/XCTest.h>
 
-#import "FirebaseFirestore/FIRQuery.h"
 #import "Firestore/Source/API/FIRQuery+Internal.h"
 #import "Firestore/Source/Core/FSTQuery.h"
 #import "Firestore/Source/Model/FSTPath.h"

--- a/Firestore/Example/Tests/API/FIRSnapshotMetadataTests.m
+++ b/Firestore/Example/Tests/API/FIRSnapshotMetadataTests.m
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+#import <FirebaseFirestore/FIRSnapshotMetadata.h>
+
 #import <XCTest/XCTest.h>
 
-#import "FirebaseFirestore/FIRSnapshotMetadata.h"
 #import "Firestore/Source/API/FIRSnapshotMetadata+Internal.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Firestore/Example/Tests/API/FSTAPIHelpers.h
+++ b/Firestore/Example/Tests/API/FSTAPIHelpers.h
@@ -16,12 +16,13 @@
 
 #import <Foundation/Foundation.h>
 
-#import "FirebaseFirestore/FIRCollectionReference.h"
-#import "FirebaseFirestore/FIRDocumentSnapshot.h"
-#import "FirebaseFirestore/FIRFirestore.h"
-#import "FirebaseFirestore/FIRQuerySnapshot.h"
-
 #import "Firestore/Example/Tests/Util/FSTHelpers.h"
+
+@class FIRCollectionReference;
+@class FIRDocumentReference;
+@class FIRDocumentSnapshot;
+@class FIRFirestore;
+@class FIRQuerySnapshot;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/Example/Tests/API/FSTAPIHelpers.h
+++ b/Firestore/Example/Tests/API/FSTAPIHelpers.h
@@ -36,7 +36,7 @@ FIRFirestore *FSTTestFirestore();
 /** A convenience method for creating a doc snapshot for tests. */
 FIRDocumentSnapshot *FSTTestDocSnapshot(NSString *path,
                                         FSTTestSnapshotVersion version,
-                                        NSDictionary<NSString *, id> *data,
+                                        NSDictionary<NSString *, id> *_Nullable data,
                                         BOOL hasMutations,
                                         BOOL fromCache);
 

--- a/Firestore/Example/Tests/API/FSTAPIHelpers.m
+++ b/Firestore/Example/Tests/API/FSTAPIHelpers.m
@@ -55,7 +55,7 @@ FIRFirestore *FSTTestFirestore() {
 
 FIRDocumentSnapshot *FSTTestDocSnapshot(NSString *path,
                                         FSTTestSnapshotVersion version,
-                                        NSDictionary<NSString *, id> *data,
+                                        NSDictionary<NSString *, id> *_Nullable data,
                                         BOOL hasMutations,
                                         BOOL fromCache) {
   FSTDocument *doc = data ? FSTTestDoc(path, version, data, hasMutations) : nil;

--- a/Firestore/Example/Tests/API/FSTAPIHelpers.m
+++ b/Firestore/Example/Tests/API/FSTAPIHelpers.m
@@ -16,8 +16,10 @@
 
 #import "Firestore/Example/Tests/API/FSTAPIHelpers.h"
 
-#import "FirebaseFirestore/FIRDocumentReference.h"
-#import "FirebaseFirestore/FIRSnapshotMetadata.h"
+#import <FirebaseFirestore/FIRDocumentChange.h>
+#import <FirebaseFirestore/FIRDocumentReference.h>
+#import <FirebaseFirestore/FIRSnapshotMetadata.h>
+
 #import "Firestore/Source/API/FIRCollectionReference+Internal.h"
 #import "Firestore/Source/API/FIRDocumentReference+Internal.h"
 #import "Firestore/Source/API/FIRDocumentSnapshot+Internal.h"

--- a/Firestore/Example/Tests/Model/FSTFieldValueTests.m
+++ b/Firestore/Example/Tests/Model/FSTFieldValueTests.m
@@ -16,9 +16,9 @@
 
 #import "Firestore/Source/Model/FSTFieldValue.h"
 
+#import <FirebaseFirestore/FIRGeoPoint.h>
 #import <XCTest/XCTest.h>
 
-#import "FirebaseFirestore/FIRGeoPoint.h"
 #import "Firestore/Source/API/FIRFirestore+Internal.h"
 #import "Firestore/Source/API/FSTUserDataConverter.h"
 #import "Firestore/Source/Core/FSTTimestamp.h"

--- a/Firestore/Example/Tests/Remote/FSTDatastoreTests.m
+++ b/Firestore/Example/Tests/Remote/FSTDatastoreTests.m
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#import "FirebaseFirestore/FIRFirestoreErrors.h"
 #import "Firestore/Source/Remote/FSTDatastore.h"
 
+#import <FirebaseFirestore/FIRFirestoreErrors.h>
 #import <GRPCClient/GRPCCall.h>
 #import <XCTest/XCTest.h>
 

--- a/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.m
+++ b/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.m
@@ -16,12 +16,12 @@
 
 #import "Firestore/Source/Remote/FSTSerializerBeta.h"
 
+#import <FirebaseFirestore/FIRFieldPath.h>
+#import <FirebaseFirestore/FIRFirestoreErrors.h>
+#import <FirebaseFirestore/FIRGeoPoint.h>
 #import <GRPCClient/GRPCCall.h>
 #import <XCTest/XCTest.h>
 
-#import "FirebaseFirestore/FIRFieldPath.h"
-#import "FirebaseFirestore/FIRFirestoreErrors.h"
-#import "FirebaseFirestore/FIRGeoPoint.h"
 #import "Firestore/Protos/objc/firestore/local/MaybeDocument.pbobjc.h"
 #import "Firestore/Protos/objc/firestore/local/Mutation.pbobjc.h"
 #import "Firestore/Protos/objc/google/firestore/v1beta1/Common.pbobjc.h"

--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.m
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.m
@@ -16,9 +16,9 @@
 
 #import "Firestore/Example/Tests/SpecTests/FSTSpecTests.h"
 
+#import <FirebaseFirestore/FIRFirestoreErrors.h>
 #import <GRPCClient/GRPCCall.h>
 
-#import "FirebaseFirestore/FIRFirestoreErrors.h"
 #import "Firestore/Source/Auth/FSTUser.h"
 #import "Firestore/Source/Core/FSTEventManager.h"
 #import "Firestore/Source/Core/FSTQuery.h"

--- a/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.m
+++ b/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.m
@@ -16,9 +16,9 @@
 
 #import "Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.h"
 
+#import <FirebaseFirestore/FIRFirestoreErrors.h>
 #import <GRPCClient/GRPCCall.h>
 
-#import "FirebaseFirestore/FIRFirestoreErrors.h"
 #import "Firestore/Source/Auth/FSTUser.h"
 #import "Firestore/Source/Core/FSTEventManager.h"
 #import "Firestore/Source/Core/FSTQuery.h"

--- a/Firestore/Example/Tests/Util/FSTHelpers.m
+++ b/Firestore/Example/Tests/Util/FSTHelpers.m
@@ -16,8 +16,9 @@
 
 #import "Firestore/Example/Tests/Util/FSTHelpers.h"
 
-#import "FirebaseFirestore/FIRFieldPath.h"
-#import "FirebaseFirestore/FIRGeoPoint.h"
+#import <FirebaseFirestore/FIRFieldPath.h>
+#import <FirebaseFirestore/FIRGeoPoint.h>
+
 #import "Firestore/Source/API/FIRFieldPath+Internal.h"
 #import "Firestore/Source/API/FSTUserDataConverter.h"
 #import "Firestore/Source/Core/FSTQuery.h"

--- a/Firestore/Source/API/FIRCollectionReference.mm
+++ b/Firestore/Source/API/FIRCollectionReference.mm
@@ -77,10 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isEqualToReference:(nullable FIRCollectionReference *)reference {
   if (self == reference) return YES;
   if (reference == nil) return NO;
-  if (self.firestore != reference.firestore && ![self.firestore isEqual:reference.firestore])
-    return NO;
-  if (self.query != reference.query && ![self.query isEqual:reference.query]) return NO;
-  return YES;
+  return [self.firestore isEqual:reference.firestore] && [self.query isEqual:reference.query];
 }
 
 - (NSUInteger)hash {

--- a/Firestore/Source/API/FIRDocumentChange+Internal.h
+++ b/Firestore/Source/API/FIRDocumentChange+Internal.h
@@ -16,6 +16,7 @@
 
 #import "FIRDocumentChange.h"
 
+@class FIRFirestore;
 @class FSTViewSnapshot;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Firestore/Source/API/FIRDocumentReference.m
+++ b/Firestore/Source/API/FIRDocumentReference.m
@@ -124,10 +124,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isEqualToReference:(nullable FIRDocumentReference *)reference {
   if (self == reference) return YES;
   if (reference == nil) return NO;
-  if (self.firestore != reference.firestore && ![self.firestore isEqual:reference.firestore])
-    return NO;
-  if (self.key != reference.key && ![self.key isEqualToKey:reference.key]) return NO;
-  return YES;
+  return [self.firestore isEqual:reference.firestore] && [self.key isEqualToKey:reference.key];
 }
 
 - (NSUInteger)hash {

--- a/Firestore/Source/API/FIRDocumentSnapshot.m
+++ b/Firestore/Source/API/FIRDocumentSnapshot.m
@@ -93,7 +93,8 @@ NS_ASSUME_NONNULL_BEGIN
 
   return [self.firestore isEqual:snapshot.firestore] &&
          [self.internalKey isEqual:snapshot.internalKey] &&
-         [self.internalDocument isEqual:snapshot.internalDocument] &&
+         (self.internalDocument == snapshot.internalDocument ||
+          [self.internalDocument isEqual:snapshot.internalDocument]) &&
          self.fromCache == snapshot.fromCache;
 }
 

--- a/Firestore/Source/API/FIRDocumentSnapshot.m
+++ b/Firestore/Source/API/FIRDocumentSnapshot.m
@@ -90,15 +90,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isEqualToSnapshot:(nullable FIRDocumentSnapshot *)snapshot {
   if (self == snapshot) return YES;
   if (snapshot == nil) return NO;
-  if (self.firestore != snapshot.firestore && ![self.firestore isEqual:snapshot.firestore])
-    return NO;
-  if (self.internalKey != snapshot.internalKey && ![self.internalKey isEqual:snapshot.internalKey])
-    return NO;
-  if (self.internalDocument != snapshot.internalDocument &&
-      ![self.internalDocument isEqual:snapshot.internalDocument])
-    return NO;
-  if (self.fromCache != snapshot.fromCache) return NO;
-  return YES;
+
+  return [self.firestore isEqual:snapshot.firestore] &&
+         [self.internalKey isEqual:snapshot.internalKey] &&
+         [self.internalDocument isEqual:snapshot.internalDocument] &&
+         self.fromCache == snapshot.fromCache;
 }
 
 - (NSUInteger)hash {

--- a/Firestore/Source/API/FIRQuery.m
+++ b/Firestore/Source/API/FIRQuery.m
@@ -115,9 +115,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isEqualToQuery:(nullable FIRQuery *)query {
   if (self == query) return YES;
   if (query == nil) return NO;
-  if (self.firestore != query.firestore && ![self.firestore isEqual:query.firestore]) return NO;
-  if (self.query != query.query && ![self.query isEqual:query.query]) return NO;
-  return YES;
+
+  return [self.firestore isEqual:query.firestore] && [self.query isEqual:query.query];
 }
 
 - (NSUInteger)hash {

--- a/Firestore/Source/API/FIRQuerySnapshot.m
+++ b/Firestore/Source/API/FIRQuerySnapshot.m
@@ -88,14 +88,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isEqualToSnapshot:(nullable FIRQuerySnapshot *)snapshot {
   if (self == snapshot) return YES;
   if (snapshot == nil) return NO;
-  if (self.firestore != snapshot.firestore && ![self.firestore isEqual:snapshot.firestore])
-    return NO;
-  if (self.originalQuery != snapshot.originalQuery &&
-      ![self.originalQuery isEqual:snapshot.originalQuery])
-    return NO;
-  if (self.snapshot != snapshot.snapshot && ![self.snapshot isEqual:snapshot.snapshot]) return NO;
-  if (self.metadata != snapshot.metadata && ![self.metadata isEqual:snapshot.metadata]) return NO;
-  return YES;
+
+  return [self.firestore isEqual:snapshot.firestore] &&
+         [self.originalQuery isEqual:snapshot.originalQuery] &&
+         [self.snapshot isEqual:snapshot.snapshot] && [self.metadata isEqual:snapshot.metadata];
 }
 
 - (NSUInteger)hash {

--- a/Firestore/Source/API/FIRSetOptions.m
+++ b/Firestore/Source/API/FIRSetOptions.m
@@ -39,8 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
   }
 
   FIRSetOptions *otherOptions = (FIRSetOptions *)other;
-
-  return otherOptions.merge != self.merge;
+  return otherOptions.merge == self.merge;
 }
 
 - (NSUInteger)hash {

--- a/Firestore/Source/API/FIRSnapshotMetadata.m
+++ b/Firestore/Source/API/FIRSnapshotMetadata.m
@@ -55,9 +55,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isEqualToMetadata:(nullable FIRSnapshotMetadata *)metadata {
   if (self == metadata) return YES;
   if (metadata == nil) return NO;
-  if (self.pendingWrites != metadata.pendingWrites) return NO;
-  if (self.fromCache != metadata.fromCache) return NO;
-  return YES;
+
+  return self.pendingWrites == metadata.pendingWrites && self.fromCache == metadata.fromCache;
 }
 
 - (NSUInteger)hash {


### PR DESCRIPTION
Clean up import order and type:

  * Tests should import the header of the class under test first
  * Framework imports should be in < > (i.e. those that import FirebaseFirestore/FIRFoo.h)
  * Group framework imports together
  * Use forward declarations where possible (Objective-C does not have the problems C++ does)

Also:

  * Simplify the isEqual implementations to just use `&&` instead of manually implementing short-circuiting
  * Remove pessimistic instance checks--self comparison is rare in practice
  * Fix equality in FIRSetOptions