### PR TITLE
Fix incorrect deprecation message

### DIFF
--- a/Firebase/Auth/Source/Public/FIREmailAuthProvider.h
+++ b/Firebase/Auth/Source/Public/FIREmailAuthProvider.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString *const FIREmailAuthProviderID NS_SWIFT_NAME(EmailAuthProviderID);
 
 /**
-    @brief please use `FIREmailAuthProviderID` instead.
+    @brief please use `EmailAuthProviderID` instead.
  */
 extern NSString *const FIREmailPasswordAuthProviderID __attribute__((deprecated));
 

--- a/Firebase/Auth/Source/Public/FIREmailAuthProvider.h
+++ b/Firebase/Auth/Source/Public/FIREmailAuthProvider.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString *const FIREmailAuthProviderID NS_SWIFT_NAME(EmailAuthProviderID);
 
 /**
-    @brief please use `EmailAuthProviderID` instead.
+    @brief Please use `FIREmailAuthProviderID` for Objective-C or `EmailAuthProviderID` for Swift instead.
  */
 extern NSString *const FIREmailPasswordAuthProviderID __attribute__((deprecated));
 


### PR DESCRIPTION
Hey there! So you want to contribute to a Firebase SDK?
Before you file this pull request, please read these guidelines:

Updating `Firebase/Auth` from version `3.10.0` to `4.8.1` in a Swift project caused an error along the lines of "`FIREmailPasswordAuthProviderID` was replaced by `FIREmailAuthProviderID `".

Making this change caused another error along the lines of "`FIREmailAuthProviderID ` was replaced by `EmailAuthProviderID `", hence this PR.

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here.
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help
    us make Firebase APIs better, please propose your change in a feature request so that we
    can discuss it together.
