### PR TITLE
Disable Messaging build warnings

### DIFF
--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -404,7 +404,10 @@ NSString * const FIRMessagingRegistrationTokenRefreshedNotification =
     }];
 
   } else if ([appDelegate respondsToSelector:openURLWithOptionsSelector]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
     [appDelegate application:application openURL:url options:@{}];
+#pragma clang diagnostic pop
 
   // Similarly, |application:openURL:sourceApplication:annotation:| will also always be called, due
   // to the default swizzling done by FIRAAppDelegateProxy in Firebase Analytics
@@ -728,7 +731,10 @@ NSString * const FIRMessagingRegistrationTokenRefreshedNotification =
 - (void)receiver:(FIRMessagingReceiver *)receiver
       receivedRemoteMessage:(FIRMessagingRemoteMessage *)remoteMessage {
   if ([self.delegate respondsToSelector:@selector(messaging:didReceiveMessage:)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
     [self.delegate messaging:self didReceiveMessage:remoteMessage];
+#pragma pop
   } else if ([self.delegate respondsToSelector:@selector(applicationReceivedRemoteMessage:)]) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"

--- a/Firebase/Messaging/FIRMessagingContextManagerService.m
+++ b/Firebase/Messaging/FIRMessagingContextManagerService.m
@@ -144,7 +144,10 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
   if ([apsDictionary[kFIRMessagingContextManagerTitleKey] length]) {
     // |alertTitle| is iOS 8.2+, so check if we can set it
       if ([notification respondsToSelector:@selector(setAlertTitle:)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
       notification.alertTitle = apsDictionary[kFIRMessagingContextManagerTitleKey];
+#pragma pop
     }
   }
 

--- a/Firebase/Messaging/FIRMessagingRmq2PersistentStore.m
+++ b/Firebase/Messaging/FIRMessagingRmq2PersistentStore.m
@@ -104,7 +104,10 @@ typedef void(^FCMOutgoingRmqMessagesTableHandler)(int64_t rmqId, int8_t tag, NSD
 
 // Utility to create an NSString from a sqlite3 result code
 NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
   const char *errorStr = sqlite3_errstr(result);
+#pragma pop
   NSString *errorString = [NSString stringWithFormat:@"%d - %s", result, errorStr];
   return errorString;
 }


### PR DESCRIPTION
Don't use @available so it still builds on Xcode 8 unlike the reverted #546. 

Close #390