### PR TITLE
Split add and update queryData

### DIFF
--- a/Firestore/Source/Local/FSTLevelDBQueryCache.mm
+++ b/Firestore/Source/Local/FSTLevelDBQueryCache.mm
@@ -118,31 +118,50 @@ static ReadOptions GetStandardReadOptions() {
   _db.reset();
 }
 
-- (void)addQueryData:(FSTQueryData *)queryData group:(FSTWriteGroup *)group {
+- (void)saveQueryData:(FSTQueryData *)queryData group:(FSTWriteGroup *)group {
   FSTTargetID targetID = queryData.targetID;
   std::string key = [FSTLevelDBTargetKey keyWithTargetID:targetID];
   [group setMessage:[self.serializer encodedQueryData:queryData] forKey:key];
+}
+
+- (void)saveMetadataInGroup:(FSTWriteGroup *)group {
+  [group setMessage:self.metadata forKey:[FSTLevelDBTargetGlobalKey key]];
+}
+
+- (BOOL)updateMetadataForQueryData:(FSTQueryData *)queryData {
+  BOOL updatedMetadata = NO;
+
+  if (queryData.targetID > self.metadata.highestTargetId) {
+    self.metadata.highestTargetId = queryData.targetID;
+    updatedMetadata = YES;
+  }
+
+  if (queryData.sequenceNumber > self.metadata.highestListenSequenceNumber) {
+    self.metadata.highestListenSequenceNumber = queryData.sequenceNumber;
+    updatedMetadata = YES;
+  }
+  return updatedMetadata;
+}
+
+- (void)addQueryData:(FSTQueryData *)queryData group:(FSTWriteGroup *)group {
+  [self saveQueryData:queryData group:group];
 
   NSString *canonicalID = queryData.query.canonicalID;
   std::string indexKey =
-      [FSTLevelDBQueryTargetKey keyWithCanonicalID:canonicalID targetID:targetID];
+      [FSTLevelDBQueryTargetKey keyWithCanonicalID:canonicalID targetID:queryData.targetID];
   std::string emptyBuffer;
   [group setData:emptyBuffer forKey:indexKey];
 
-  BOOL saveMetadata = NO;
-  FSTPBTargetGlobal *metadata = self.metadata;
-  if (targetID > metadata.highestTargetId) {
-    metadata.highestTargetId = targetID;
-    saveMetadata = YES;
-  }
+  // TODO(gsoltis): update count of queries
+  [self updateMetadataForQueryData:queryData];
+  [self saveMetadataInGroup:group];
+}
 
-  if (queryData.sequenceNumber > metadata.highestListenSequenceNumber) {
-    metadata.highestListenSequenceNumber = queryData.sequenceNumber;
-    saveMetadata = YES;
-  }
+- (void)updateQueryData:(FSTQueryData *)queryData group:(FSTWriteGroup *)group {
+  [self saveQueryData:queryData group:group];
 
-  if (saveMetadata) {
-    [group setMessage:metadata forKey:[FSTLevelDBTargetGlobalKey key]];
+  if ([self updateMetadataForQueryData:queryData]) {
+    [self saveMetadataInGroup:group];
   }
 }
 


### PR DESCRIPTION
Do Not Merge.

First part of splitting add and update query data on FSTQueryCache. Allows for tracking of query cache size in metadata.