### PR TITLE
Fix a few more c++ build errors (rodete)

### DIFF
--- a/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
@@ -48,6 +48,7 @@ cc_test(
     string_util_test.cc
   DEPENDS
     firebase_firestore_util
+    absl_strings
 )
 
 if(APPLE)

--- a/Firestore/core/test/firebase/firestore/util/ordered_code_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/ordered_code_test.cc
@@ -26,9 +26,9 @@ namespace firebase {
 namespace firestore {
 namespace util {
 
-static std::string RandomString(SecureRandom* rnd, int len) {
+static std::string RandomString(SecureRandom* rnd, size_t len) {
   std::string x;
-  for (int i = 0; i < len; i++) {
+  for (size_t i = 0; i < len; i++) {
     x += static_cast<char>(rnd->Uniform(256));
   }
   return x;
@@ -340,7 +340,7 @@ TEST(OrderedCodeInvalidEncodingsTest, NonCanonical) {
 
   SecureRandom rnd;
 
-  for (int n = 2; n <= 9; ++n) {
+  for (size_t n = 2; n <= 9; ++n) {
     // The zero in non_minimal[1] is "redundant".
     std::string non_minimal = std::string(1, static_cast<char>(n - 1)) +
                               std::string(1, 0) + RandomString(&rnd, n - 2);
@@ -356,7 +356,7 @@ TEST(OrderedCodeInvalidEncodingsTest, NonCanonical) {
 #endif  // defined(NDEBUG)
   }
 
-  for (int n = 2; n <= 10; ++n) {
+  for (size_t n = 2; n <= 10; ++n) {
     // Header with 1 sign bit and n-1 size bits.
     std::string header =
         std::string(n / 8, '\xff') +
@@ -364,9 +364,10 @@ TEST(OrderedCodeInvalidEncodingsTest, NonCanonical) {
     // There are more than 7 zero bits between header bits and "payload".
     std::string non_minimal =
         header +
-        std::string(1,
-                    static_cast<char>(rnd.Uniform(256) & ~*header.rbegin())) +
-        RandomString(&rnd, n - static_cast<int>(header.length()) - 1);
+        std::string(
+            1, static_cast<char>(rnd.Uniform(256) & ~static_cast<unsigned int>(
+                                                        *header.rbegin()))) +
+        RandomString(&rnd, n - header.length() - 1);
     EXPECT_EQ(static_cast<size_t>(n), non_minimal.length());
 
     EXPECT_NE(OCWrite<int64_t>(0, INCREASING), non_minimal);
@@ -421,10 +422,10 @@ TEST(OrderedCodeString, EncodeDecode) {
   for (int i = 0; i < 1; ++i) {
     const Direction d = static_cast<Direction>(i);
 
-    for (int len = 0; len < 256; len++) {
+    for (size_t len = 0; len < 256; len++) {
       const std::string a = RandomString(&rnd, len);
       TestWriteRead(d, a);
-      for (int len2 = 0; len2 < 64; len2++) {
+      for (size_t len2 = 0; len2 < 64; len2++) {
         const std::string b = RandomString(&rnd, len2);
 
         TestWriteAppends(d, a, b);

--- a/Firestore/core/test/firebase/firestore/util/ordered_code_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/ordered_code_test.cc
@@ -342,8 +342,8 @@ TEST(OrderedCodeInvalidEncodingsTest, NonCanonical) {
 
   for (int n = 2; n <= 9; ++n) {
     // The zero in non_minimal[1] is "redundant".
-    std::string non_minimal =
-        std::string(1, static_cast<char>(n - 1)) + std::string(1, 0) + RandomString(&rnd, n - 2);
+    std::string non_minimal = std::string(1, static_cast<char>(n - 1)) +
+                              std::string(1, 0) + RandomString(&rnd, n - 2);
     EXPECT_EQ(static_cast<size_t>(n), non_minimal.length());
 
     EXPECT_NE(OCWrite<uint64_t>(0, INCREASING), non_minimal);
@@ -359,7 +359,8 @@ TEST(OrderedCodeInvalidEncodingsTest, NonCanonical) {
   for (int n = 2; n <= 10; ++n) {
     // Header with 1 sign bit and n-1 size bits.
     std::string header =
-        std::string(n / 8, static_cast<char>(0xff)) + std::string(1, static_cast<char>(0xff << (8 - (n % 8))));
+        std::string(n / 8, static_cast<char>(0xff)) +
+        std::string(1, static_cast<char>(0xff << (8 - (n % 8))));
     // There are more than 7 zero bits between header bits and "payload".
     std::string non_minimal =
         header +

--- a/Firestore/core/test/firebase/firestore/util/ordered_code_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/ordered_code_test.cc
@@ -225,7 +225,7 @@ TEST(OrderedCode, SkipToNextSpecialByte) {
     SecureRandom rnd;
     std::string x;
     while (x.size() < len) {
-      char c = 1 + static_cast<char>(rnd.Uniform(254));
+      char c = static_cast<char>(1 + rnd.Uniform(254));
       ASSERT_NE(c, 0);
       ASSERT_NE(c, 255);
       x += c;  // No 0 bytes, no 255 bytes
@@ -309,7 +309,7 @@ TEST(OrderedCodeInt64, Ordering) {
 // Returns the bitwise complement of s.
 static inline std::string StrNot(const std::string& s) {
   std::string result;
-  for (const char c : s) result.push_back(~c);
+  for (const char c : s) result.push_back(static_cast<char>(~c));
   return result;
 }
 
@@ -343,7 +343,7 @@ TEST(OrderedCodeInvalidEncodingsTest, NonCanonical) {
   for (int n = 2; n <= 9; ++n) {
     // The zero in non_minimal[1] is "redundant".
     std::string non_minimal =
-        std::string(1, n - 1) + std::string(1, 0) + RandomString(&rnd, n - 2);
+        std::string(1, static_cast<char>(n - 1)) + std::string(1, 0) + RandomString(&rnd, n - 2);
     EXPECT_EQ(static_cast<size_t>(n), non_minimal.length());
 
     EXPECT_NE(OCWrite<uint64_t>(0, INCREASING), non_minimal);
@@ -359,12 +359,12 @@ TEST(OrderedCodeInvalidEncodingsTest, NonCanonical) {
   for (int n = 2; n <= 10; ++n) {
     // Header with 1 sign bit and n-1 size bits.
     std::string header =
-        std::string(n / 8, 0xff) + std::string(1, 0xff << (8 - (n % 8)));
+        std::string(n / 8, static_cast<char>(0xff)) + std::string(1, static_cast<char>(0xff << (8 - (n % 8))));
     // There are more than 7 zero bits between header bits and "payload".
     std::string non_minimal =
         header +
         std::string(1,
-                    static_cast<char>(rnd.Uniform(256)) & ~*header.rbegin()) +
+                    static_cast<char>(rnd.Uniform(256) & ~*header.rbegin())) +
         RandomString(&rnd, n - static_cast<int>(header.length()) - 1);
     EXPECT_EQ(static_cast<size_t>(n), non_minimal.length());
 

--- a/Firestore/core/test/firebase/firestore/util/ordered_code_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/ordered_code_test.cc
@@ -359,7 +359,7 @@ TEST(OrderedCodeInvalidEncodingsTest, NonCanonical) {
   for (int n = 2; n <= 10; ++n) {
     // Header with 1 sign bit and n-1 size bits.
     std::string header =
-        std::string(n / 8, static_cast<char>(0xff)) +
+        std::string(n / 8, '\xff') +
         std::string(1, static_cast<char>(0xff << (8 - (n % 8))));
     // There are more than 7 zero bits between header bits and "payload".
     std::string non_minimal =


### PR DESCRIPTION
* Fix implicit conversions from ints to chars.

These conversions can alter the values, so the rodete compiler objects
with messages like:
```
error: conversion to ‘char’ from ‘int’ may alter its value
error: conversion to ‘char’ alters ‘int’ constant value
```
The second one in particular is slightly alarming, and results from
things like this: `char c = 0xff;`

However, this is contained within tests dealing with odd corner cases,
so I've just cast'd the problem away.  (i.e. `static_cast<char>(0xff)`)

* Add absl_strings to firebase_firestore_util_test dependencies

Required to link the test on rodete.