### PR TITLE
Add absl_strings to firebase_firestore_util_test dependencies

### DIFF
--- a/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
@@ -49,6 +49,7 @@ cc_test(
     string_util_test.cc
   DEPENDS
     absl_base
+    absl_strings
     firebase_firestore_util
     gmock
 )


### PR DESCRIPTION
Required to link the test on rodete.