### PR TITLE
Remove predecessor{Key,Object,Document} etc

### DIFF
--- a/Firestore/Example/Tests/Model/FSTDocumentSetTests.mm
+++ b/Firestore/Example/Tests/Model/FSTDocumentSetTests.mm
@@ -79,14 +79,6 @@ NS_ASSUME_NONNULL_BEGIN
   XCTAssertEqualObjects([[set documentEnumerator] allObjects], (@[ _doc3, _doc1, _doc2 ]));
 }
 
-- (void)testPredecessorDocumentForKey {
-  FSTDocumentSet *set = FSTTestDocSet(_comp, @[ _doc1, _doc2, _doc3 ]);
-
-  XCTAssertNil([set predecessorDocumentForKey:_doc3.key]);
-  XCTAssertEqualObjects([set predecessorDocumentForKey:_doc1.key], _doc3);
-  XCTAssertEqualObjects([set predecessorDocumentForKey:_doc2.key], _doc1);
-}
-
 - (void)testDeletes {
   FSTDocumentSet *set = FSTTestDocSet(_comp, @[ _doc1, _doc2, _doc3 ]);
 

--- a/Firestore/Source/Model/FSTDocumentSet.h
+++ b/Firestore/Source/Model/FSTDocumentSet.h
@@ -59,16 +59,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (FSTDocument *_Nullable)lastDocument;
 
 /**
- * Returns the document previous to the document associated with the given key in the set according
- * to its built in ordering. Returns nil if the document associated with the given key is the
- * first document.
- *
- * @param key A key that must be present in the DocumentSet.
- * @throws NSInvalidArgumentException if key is not present.
- */
-- (FSTDocument *_Nullable)predecessorDocumentForKey:(FSTDocumentKey *)key;
-
-/**
  * Returns the index of the document with the provided key in the document set. Returns NSNotFound
  * if the key is not present.
  */

--- a/Firestore/Source/Model/FSTDocumentSet.mm
+++ b/Firestore/Source/Model/FSTDocumentSet.mm
@@ -135,16 +135,6 @@ typedef FSTImmutableSortedSet<FSTDocument *> SetType;
   return [self.sortedSet lastObject];
 }
 
-- (FSTDocument *_Nullable)predecessorDocumentForKey:(FSTDocumentKey *)key {
-  FSTDocument *doc = [self.index objectForKey:key];
-  if (!doc) {
-    @throw [NSException exceptionWithName:NSInvalidArgumentException
-                                   reason:[NSString stringWithFormat:@"Key %@ does not exist", key]
-                                 userInfo:nil];
-  }
-  return [self.sortedSet predecessorObject:doc];
-}
-
 - (NSUInteger)indexOfKey:(FSTDocumentKey *)key {
   FSTDocument *doc = [self.index objectForKey:key];
   return doc ? [self.sortedSet indexOfObject:doc] : NSNotFound;

--- a/Firestore/core/test/firebase/firestore/immutable/array_sorted_map_test.cc
+++ b/Firestore/core/test/firebase/firestore/immutable/array_sorted_map_test.cc
@@ -301,8 +301,6 @@ TEST(ArraySortedMap, BalanceProblem) {
   ASSERT_SEQ_EQ(Pairs(Sorted(to_insert)), map);
 }
 
-// TODO(wilhuff): PredecessorKey
-
 // TODO(wilhuff): Iterators
 
 // TODO(wilhuff): IndexOf

--- a/Firestore/third_party/Immutable/FSTArraySortedDictionary.m
+++ b/Firestore/third_party/Immutable/FSTArraySortedDictionary.m
@@ -142,19 +142,6 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-- (nullable id)predecessorKey:(id)key {
-  NSInteger pos = [self findKey:key];
-  if (pos == NSNotFound) {
-    [NSException raise:NSInternalInconsistencyException
-                format:@"Can't get predecessor key for non-existent key"];
-    return nil;
-  } else if (pos == 0) {
-    return nil;
-  } else {
-    return self.keys[pos - 1];
-  }
-}
-
 - (NSUInteger)indexOfKey:(id)key {
   return [self findKey:key];
 }

--- a/Firestore/third_party/Immutable/FSTImmutableSortedDictionary.h
+++ b/Firestore/third_party/Immutable/FSTImmutableSortedDictionary.h
@@ -71,14 +71,6 @@ extern const int kSortedDictionaryArrayToRBTreeSizeThreshold;
 - (ValueType)objectForKeyedSubscript:(KeyType)key;
 
 /**
- * Gets the key before the given key in sorted order.
- *
- * @param key The key to look before.
- * @return The key before the given one.
- */
-- (nullable KeyType)predecessorKey:(KeyType)key;
-
-/**
  * Returns the index of the key or NSNotFound if the key is not found.
  *
  * @param key The key to return the index for.

--- a/Firestore/third_party/Immutable/FSTImmutableSortedDictionary.m
+++ b/Firestore/third_party/Immutable/FSTImmutableSortedDictionary.m
@@ -82,10 +82,6 @@ const int kSortedDictionaryArrayToRBTreeSizeThreshold = 25;
   return [self objectForKey:key];
 }
 
-- (nullable id)predecessorKey:(id)key {
-  @throw FSTAbstractMethodException();  // NOLINT
-}
-
 - (NSUInteger)indexOfKey:(id)key {
   @throw FSTAbstractMethodException();  // NOLINT
 }

--- a/Firestore/third_party/Immutable/FSTImmutableSortedSet.h
+++ b/Firestore/third_party/Immutable/FSTImmutableSortedSet.h
@@ -23,8 +23,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSUInteger)count;
 - (BOOL)isEmpty;
 
-- (KeyType)predecessorObject:(KeyType)entry;
-
 /**
  * Returns the index of the object or NSNotFound if the object is not found.
  *

--- a/Firestore/third_party/Immutable/FSTImmutableSortedSet.m
+++ b/Firestore/third_party/Immutable/FSTImmutableSortedSet.m
@@ -76,10 +76,6 @@ NS_ASSUME_NONNULL_BEGIN
   return [self.dictionary maxKey];
 }
 
-- (id)predecessorObject:(id)entry {
-  return [self.dictionary predecessorKey:entry];
-}
-
 - (NSUInteger)indexOfObject:(id)object {
   return [self.dictionary indexOfKey:object];
 }

--- a/Firestore/third_party/Immutable/FSTTreeSortedDictionary.m
+++ b/Firestore/third_party/Immutable/FSTTreeSortedDictionary.m
@@ -87,36 +87,6 @@ NS_ASSUME_NONNULL_BEGIN
   return nil;
 }
 
-- (nullable id)predecessorKey:(id)key {
-  NSComparisonResult cmp;
-  id<FSTLLRBNode> node = self.root;
-  id<FSTLLRBNode> rightParent = nil;
-  while (![node isEmpty]) {
-    cmp = self.comparator(key, node.key);
-    if (cmp == NSOrderedSame) {
-      if (![node.left isEmpty]) {
-        node = node.left;
-        while (![node.right isEmpty]) {
-          node = node.right;
-        }
-        return node.key;
-      } else if (rightParent != nil) {
-        return rightParent.key;
-      } else {
-        return nil;
-      }
-    } else if (cmp == NSOrderedAscending) {
-      node = node.left;
-    } else if (cmp == NSOrderedDescending) {
-      rightParent = node;
-      node = node.right;
-    }
-  }
-  @throw [NSException exceptionWithName:@"NonexistentKey"
-                                 reason:@"getPredecessorKey called with nonexistent key."
-                               userInfo:@{@"key" : [key description]}];
-}
-
 - (NSUInteger)indexOfKey:(id)key {
   NSUInteger prunedNodes = 0;
   id<FSTLLRBNode> node = self.root;

--- a/Firestore/third_party/Immutable/Tests/FSTArraySortedDictionaryTests.m
+++ b/Firestore/third_party/Immutable/Tests/FSTArraySortedDictionaryTests.m
@@ -252,25 +252,6 @@
   XCTAssertEqual((int)next, (int)toInsert.count, @"Check we traversed all of the items");
 }
 
-- (void)testPredecessorKey {
-  FSTArraySortedDictionary *map =
-      [[FSTArraySortedDictionary alloc] initWithComparator:[self defaultComparator]];
-  map = [map dictionaryBySettingObject:@1 forKey:@1];
-  map = [map dictionaryBySettingObject:@50 forKey:@50];
-  map = [map dictionaryBySettingObject:@3 forKey:@3];
-  map = [map dictionaryBySettingObject:@4 forKey:@4];
-  map = [map dictionaryBySettingObject:@7 forKey:@7];
-  map = [map dictionaryBySettingObject:@9 forKey:@9];
-
-  XCTAssertNil([map predecessorKey:@1], @"First object doesn't have a predecessor");
-  XCTAssertEqualObjects([map predecessorKey:@3], @1, @"@1");
-  XCTAssertEqualObjects([map predecessorKey:@4], @3, @"@3");
-  XCTAssertEqualObjects([map predecessorKey:@7], @4, @"@4");
-  XCTAssertEqualObjects([map predecessorKey:@9], @7, @"@7");
-  XCTAssertEqualObjects([map predecessorKey:@50], @9, @"@9");
-  XCTAssertThrows([map predecessorKey:@777], @"Expect exception about nonexistent key");
-}
-
 // This is a macro instead of a method so that the failures show on the proper lines.
 #define ASSERT_ENUMERATOR(enumerator, start, end, step)                                   \
   do {                                                                                    \

--- a/Firestore/third_party/Immutable/Tests/FSTTreeSortedDictionaryTests.m
+++ b/Firestore/third_party/Immutable/Tests/FSTTreeSortedDictionaryTests.m
@@ -437,25 +437,6 @@
   }
 }
 
-- (void)testPredecessorKey {
-  FSTTreeSortedDictionary *map =
-      [[FSTTreeSortedDictionary alloc] initWithComparator:[self defaultComparator]];
-  map = [map dictionaryBySettingObject:@1 forKey:@1];
-  map = [map dictionaryBySettingObject:@50 forKey:@50];
-  map = [map dictionaryBySettingObject:@3 forKey:@3];
-  map = [map dictionaryBySettingObject:@4 forKey:@4];
-  map = [map dictionaryBySettingObject:@7 forKey:@7];
-  map = [map dictionaryBySettingObject:@9 forKey:@9];
-
-  XCTAssertNil([map predecessorKey:@1], @"First object doesn't have a predecessor");
-  XCTAssertEqualObjects([map predecessorKey:@3], @1, @"@1");
-  XCTAssertEqualObjects([map predecessorKey:@4], @3, @"@3");
-  XCTAssertEqualObjects([map predecessorKey:@7], @4, @"@4");
-  XCTAssertEqualObjects([map predecessorKey:@9], @7, @"@7");
-  XCTAssertEqualObjects([map predecessorKey:@50], @9, @"@9");
-  XCTAssertThrows([map predecessorKey:@777], @"Expect exception about nonexistent key");
-}
-
 // This is a macro instead of a method so that the failures show on the proper lines.
 #define ASSERT_ENUMERATOR(enumerator, start, end, step)                                   \
   do {                                                                                    \


### PR DESCRIPTION
This is dead code.

I think it was probably useful in the RTDB because of the way it notified of changes, but we give changes with indexes in Firestore so I think we don't need it.

Do we need to keep this? More importantly, do we need to port it to C++?