### PR TITLE
Allow FCMToken to be reset

### DIFF
--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -484,7 +484,7 @@ static NSString *const kFIRMessagingPlistAutoInitEnabled =
   [_messagingUserDefaults setBool:autoInitEnabled
                            forKey:kFIRMessagingUserDefaultsKeyAutoInitEnabled];
   if (!isFCMAutoInitEnabled && autoInitEnabled) {
-    self.defaultFcmToken = [self FCMToken];
+    self.defaultFcmToken = [self.instanceIDProxy token];
   }
 }
 
@@ -834,7 +834,7 @@ static NSString *const kFIRMessagingPlistAutoInitEnabled =
 #pragma mark - Notifications
 
 - (void)didReceiveDefaultInstanceIDToken:(NSNotification *)notification {
-  if (![notification.object isKindOfClass:[NSString class]]) {
+  if (notification.object && ![notification.object isKindOfClass:[NSString class]]) {
     FIRMessagingLoggerDebug(kFIRMessagingMessageCodeMessaging015,
                             @"Invalid default FCM token type %@",
                             NSStringFromClass([notification.object class]));


### PR DESCRIPTION
Allow FCMToken to be reset by IID to nil (before it must be a valid string). This is important when user deleteToken and deleteID, FCMToken should be reset as well.

When autoInitEnable is set back on, trigger token refresh directly without checking FCM token is nil. (Although we fixed the issue FCMToken can't be set to nil, but this just one step safer)