### PR TITLE
Increase expectation timeout to 25 seconds.

### DIFF
--- a/Firestore/Example/Tests/Util/XCTestCase+Await.mm
+++ b/Firestore/Example/Tests/Util/XCTestCase+Await.mm
@@ -18,7 +18,9 @@
 
 #import <Foundation/Foundation.h>
 
-static const double kExpectationWaitSeconds = 10.0;
+// TODO(b/72864027): Reduce this to 10 seconds again once we've resolved issues with Query
+// Conformance Tests flakiness or gotten answers from GRPC about reconnect delays.
+static const double kExpectationWaitSeconds = 25.0;
 
 @implementation XCTestCase (Await)
 


### PR DESCRIPTION
I'm doing this to:
1) Experimentally see if it improves the flakiness we've been seeing in the Query Conformance Tests.
2) Insulate us from the fact that GRPC seems to take a /minimum/ of 10 seconds to reconnect (at least in some cases) after a connection failure.

I've opened b/72864027 to revisit this in the future.
