### PR TITLE
Remove Deprecations from FIRConfiguration.

### DIFF
--- a/Firebase/Core/Public/FIRConfiguration.h
+++ b/Firebase/Core/Public/FIRConfiguration.h
@@ -19,25 +19,6 @@
 #import "FIRAnalyticsConfiguration.h"
 #import "FIRLoggerLevel.h"
 
-/**
- * The log levels used by FIRConfiguration.
- */
-typedef NS_ENUM(NSInteger, FIRLogLevel) {
-  /** Error */
-  kFIRLogLevelError __deprecated = 0,
-  /** Warning */
-  kFIRLogLevelWarning __deprecated,
-  /** Info */
-  kFIRLogLevelInfo __deprecated,
-  /** Debug */
-  kFIRLogLevelDebug __deprecated,
-  /** Assert */
-  kFIRLogLevelAssert __deprecated,
-  /** Max */
-  kFIRLogLevelMax __deprecated = kFIRLogLevelAssert
-} DEPRECATED_MSG_ATTRIBUTE(
-    "Use -FIRDebugEnabled and -FIRDebugDisabled or setLoggerLevel. See FIRApp.h for more details.");
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -47,20 +28,11 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(FirebaseConfiguration)
 @interface FIRConfiguration : NSObject
 
-#if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 /** Returns the shared configuration object. */
 @property(class, nonatomic, readonly) FIRConfiguration *sharedInstance NS_SWIFT_NAME(shared);
-#else
-/** Returns the shared configuration object. */
-+ (FIRConfiguration *)sharedInstance NS_SWIFT_NAME(shared());
-#endif  // defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 
 /** The configuration class for Firebase Analytics. */
 @property(nonatomic, readwrite) FIRAnalyticsConfiguration *analyticsConfiguration;
-
-/** Global log level. Defaults to kFIRLogLevelError. */
-@property(nonatomic, readwrite, assign) FIRLogLevel logLevel DEPRECATED_MSG_ATTRIBUTE(
-    "Use -FIRDebugEnabled and -FIRDebugDisabled or setLoggerLevel. See FIRApp.h for more details.");
 
 /**
  * Sets the logging level for internal Firebase logging. Firebase will only log messages


### PR DESCRIPTION
Removes `FIRLogLevel`, the property, and Xcode 7 support (non-class property version of the singleton).
 