### PR TITLE
Explicitly specify the default constructor to FieldPath

### DIFF
--- a/Firestore/core/src/firebase/firestore/model/field_path.h
+++ b/Firestore/core/src/firebase/firestore/model/field_path.h
@@ -36,7 +36,8 @@ namespace model {
 class FieldPath : public impl::BasePath<FieldPath> {
  public:
   // Note: Xcode 8.2 requires explicit specification of the constructor.
-  FieldPath() : impl::BasePath<FieldPath>() {}
+  FieldPath() : impl::BasePath<FieldPath>() {
+  }
 
   /** Constructs the path from segments. */
   template <typename IterT>

--- a/Firestore/core/src/firebase/firestore/model/field_path.h
+++ b/Firestore/core/src/firebase/firestore/model/field_path.h
@@ -35,7 +35,9 @@ namespace model {
  */
 class FieldPath : public impl::BasePath<FieldPath> {
  public:
-  FieldPath() = default;
+  // Note: Xcode 8.2 requires explicit specification of the constructor.
+  FieldPath() : impl::BasePath<FieldPath>() {}
+
   /** Constructs the path from segments. */
   template <typename IterT>
   FieldPath(const IterT begin, const IterT end) : BasePath{begin, end} {


### PR DESCRIPTION
Xcode prior to 8.3 does not accept an explicitly defaulted constructor
(`= default`) for the purposes of default initializing a const object.

This fixes a build failure under Xcode 8.2:

Firestore/core/src/firebase/firestore/model/field_path.cc:144:26: error: default initialization of an object of const type 'const firebase::firestore::model::FieldPath' without a user-provided default constructor
  static const FieldPath empty_path;