### PR TITLE
Fix Core CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF warnings

### DIFF
--- a/Firebase/Core/FIRMutableDictionary.m
+++ b/Firebase/Core/FIRMutableDictionary.m
@@ -37,7 +37,7 @@
 - (NSString *)description {
   __block NSString *description;
   dispatch_sync(_queue, ^{
-    description = _objects.description;
+    description = self->_objects.description;
   });
   return description;
 }
@@ -45,33 +45,33 @@
 - (id)objectForKey:(id)key {
   __block id object;
   dispatch_sync(_queue, ^{
-    object = _objects[key];
+    object = self->_objects[key];
   });
   return object;
 }
 
 - (void)setObject:(id)object forKey:(id<NSCopying>)key {
   dispatch_async(_queue, ^{
-    _objects[key] = object;
+    self->_objects[key] = object;
   });
 }
 
 - (void)removeObjectForKey:(id)key {
   dispatch_async(_queue, ^{
-    [_objects removeObjectForKey:key];
+    [self->_objects removeObjectForKey:key];
   });
 }
 
 - (void)removeAllObjects {
   dispatch_async(_queue, ^{
-    [_objects removeAllObjects];
+    [self->_objects removeAllObjects];
   });
 }
 
 - (NSUInteger)count {
   __block NSUInteger count;
   dispatch_sync(_queue, ^{
-    count = _objects.count;
+    count = self->_objects.count;
   });
   return count;
 }
@@ -89,7 +89,7 @@
 - (NSDictionary *)dictionary {
   __block NSDictionary *dictionary;
   dispatch_sync(_queue, ^{
-    dictionary = [_objects copy];
+    dictionary = [self->_objects copy];
   });
   return dictionary;
 }

--- a/Firebase/Core/FIRNetworkURLSession.m
+++ b/Firebase/Core/FIRNetworkURLSession.m
@@ -314,11 +314,11 @@
       if (allow) {
         completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
       } else {
-        [_loggerDelegate
+        [self->_loggerDelegate
             firNetwork_logWithLevel:kFIRNetworkLogLevelDebug
                         messageCode:kFIRNetworkMessageCodeURLSession007
                             message:@"Cancelling authentication challenge for host. Host"
-                            context:_request.URL];
+                            context:self->_request.URL];
         completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
       }
     };
@@ -344,10 +344,10 @@
       }
 
       if (trustError != errSecSuccess) {
-        [_loggerDelegate firNetwork_logWithLevel:kFIRNetworkLogLevelError
+        [self->_loggerDelegate firNetwork_logWithLevel:kFIRNetworkLogLevelError
                                      messageCode:kFIRNetworkMessageCodeURLSession008
                                          message:@"Cannot evaluate server trust. Error, host"
-                                        contexts:@[ @(trustError), _request.URL ]];
+                                        contexts:@[ @(trustError), self->_request.URL ]];
         shouldAllow = NO;
       } else {
         // Having a trust level "unspecified" by the user is the usual result, described at
@@ -651,7 +651,7 @@
 
   if (handler) {
     dispatch_async(dispatch_get_main_queue(), ^{
-      handler(response, data, _sessionID, error);
+      handler(response, data, self->_sessionID, error);
     });
   }
 }

--- a/Firebase/Core/FIRNetworkURLSession.m
+++ b/Firebase/Core/FIRNetworkURLSession.m
@@ -345,9 +345,9 @@
 
       if (trustError != errSecSuccess) {
         [self->_loggerDelegate firNetwork_logWithLevel:kFIRNetworkLogLevelError
-                                     messageCode:kFIRNetworkMessageCodeURLSession008
-                                         message:@"Cannot evaluate server trust. Error, host"
-                                        contexts:@[ @(trustError), self->_request.URL ]];
+                                           messageCode:kFIRNetworkMessageCodeURLSession008
+                                               message:@"Cannot evaluate server trust. Error, host"
+                                              contexts:@[ @(trustError), self->_request.URL ]];
         shouldAllow = NO;
       } else {
         // Having a trust level "unspecified" by the user is the usual result, described at

--- a/Firebase/Core/FIROptions.m
+++ b/Firebase/Core/FIROptions.m
@@ -367,7 +367,7 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
       }
       tempAnalyticsOptions[key] = value;
     }
-    _analyticsOptionsDictionary = tempAnalyticsOptions;
+    self->_analyticsOptionsDictionary = tempAnalyticsOptions;
   });
   return _analyticsOptionsDictionary;
 }


### PR DESCRIPTION
CocoaPods is moving to enable CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF by
default, so enabled it in the project and update the code accordingly.

Blocks within the library implementation direct touch ivars back properties
as part of updating state with doing the work the public access to the
property requires, so use self-> notation to make it an explicit
capture of self instead of an implicit one.

Description thanks to https://github.com/google/gtm-session-fetcher/pull/111

This change will need to be made beyond Core across Firebase open source.

cc: @schmidt-sebastian, @protocol86, @wilhuff, @chliangGoogle 