### PR TITLE
Fix double parsing on 32 bit devices.

### DIFF
--- a/Firebase/Database/Persistence/FLevelDBStorageEngine.m
+++ b/Firebase/Database/Persistence/FLevelDBStorageEngine.m
@@ -687,7 +687,7 @@ static NSString* trackedQueryKeysKey(NSUInteger trackedQueryId, NSString *key) {
                 NSString *doubleString = [value stringValue];
                 return [NSNumber numberWithDouble:[doubleString doubleValue]];
             } else {
-                return [NSNumber numberWithLong:[value longValue]];
+                return [NSNumber numberWithLongLong:[value longLongValue]];
             }
         }
     }


### PR DESCRIPTION
This should take care of #326 where 32 bit devices overflow on `long` values.