### PR TITLE
 Ignore events on inactive streams

### DIFF
--- a/Firestore/Source/Remote/FSTStream.mm
+++ b/Firestore/Source/Remote/FSTStream.mm
@@ -548,6 +548,7 @@ static const NSTimeInterval kIdleTimeout = 60.0;
     FSTStrongify(self);
     if (![self isStarted]) {
       FSTLog(@"%@ Ignoring stream message from inactive stream.", NSStringFromClass([self class]));
+      return;
     }
 
     if (!self.messageReceived) {


### PR DESCRIPTION
Actually ignore events on inactive streams, rather than just logging that we're going to.

Other delegate methods already have checks. This one has a check, but previously ignored it other than logging.

I believe this should fix https://github.com/firebase/firebase-ios-sdk/issues/772