### PR TITLE
Remove UIKit dependency in FIRApp.

### DIFF
--- a/Firebase/Core/Public/FIRApp.h
+++ b/Firebase/Core/Public/FIRApp.h
@@ -16,11 +16,6 @@
 
 #import <Foundation/Foundation.h>
 
-#if TARGET_OS_IOS
-// TODO: Remove UIKit import on next breaking change release
-#import <UIKit/UIKit.h>
-#endif
-
 @class FIROptions;
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
This can be removed at the next breaking change.

```
Test Suite 'All tests' passed at 2018-02-14 12:16:24.406.
	 Executed 401 tests, with 0 failures (0 unexpected) in 16.931 (18.144) seconds
```