### PR TITLE
Enable -Wcomma for our build; disable it for abseil.

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -35,7 +35,6 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
     'Firestore/core/include/**/*.{h,cc,mm}',
     'Firestore/core/src/**/*.{h,cc,mm}',
     'Firestore/third_party/Immutable/*.[mh]',
-    'Firestore/third_party/abseil-cpp/**/*.{h,cc}'
   ]
   s.requires_arc = [
     'Firestore/Source/**/*',
@@ -45,7 +44,6 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.exclude_files = [
     'Firestore/Port/*test.cc',
     'Firestore/third_party/Immutable/Tests/**',
-    'Firestore/third_party/abseil-cpp/**/*_test.{h,cc}',
 
     # Exclude alternate implementations for other platforms
     'Firestore/core/src/firebase/firestore/util/assert_stdio.cc',
@@ -79,4 +77,20 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
         Firestore/core/src/firebase/firestore/util/config.h.in > \
         Firestore/core/src/firebase/firestore/util/config.h
   CMD
+
+  s.subspec 'abseil-cpp' do |ss|
+    ss.source_files = [
+      'Firestore/third_party/abseil-cpp/**/*.{h,cc}'
+    ]
+    ss.exclude_files = [
+      'Firestore/third_party/abseil-cpp/**/*_test.{h,cc}',
+    ]
+
+    # NB: don't include absl/**/*.h, as that would include absl/*/internal/*.h.
+    ss.public_header_files = 'Firestore/third_party/abseil-cpp/absl/*/*.h'
+    ss.header_mappings_dir = 'Firestore/third_party/abseil-cpp'
+
+    ss.library = 'c++'
+    ss.compiler_flags = '$(inherited) ' + '-Wno-comma'
+  end
 end

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -79,16 +79,15 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   CMD
 
   s.subspec 'abseil-cpp' do |ss|
+    ss.preserve_path = [
+      'Firestore/third_party/abseil-cpp/absl'
+    ]
     ss.source_files = [
-      'Firestore/third_party/abseil-cpp/**/*.{h,cc}'
+      'Firestore/third_party/abseil-cpp/**/*.cc'
     ]
     ss.exclude_files = [
-      'Firestore/third_party/abseil-cpp/**/*_test.{h,cc}',
+      'Firestore/third_party/abseil-cpp/**/*_test.cc',
     ]
-
-    # NB: don't include absl/**/*.h, as that would include absl/*/internal/*.h.
-    ss.public_header_files = 'Firestore/third_party/abseil-cpp/absl/*/*.h'
-    ss.header_mappings_dir = 'Firestore/third_party/abseil-cpp'
 
     ss.library = 'c++'
     ss.compiler_flags = '$(inherited) ' + '-Wno-comma'

--- a/Firestore/core/src/firebase/firestore/remote/serializer.cc
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.cc
@@ -25,6 +25,18 @@ namespace remote {
 
 using firebase::firestore::model::FieldValue;
 
+// TODO: DO NOT SUBMIT. This code exists solely to generate an error (via the
+// -Wcomma flag) and should be removed before we submit. Uncomment this to see
+// the error. (Treated as a non-fatal warning by xcode, but treated as fatal by
+// cmake due to -Werror.
+/*
+void GenerateCompilerError() {
+  int x = 0;
+  int y = 0;
+  x++, y++;  // Compiler warning due to -Wcomma here.
+}
+*/
+
 Serializer::TypedValue Serializer::EncodeFieldValue(
     const FieldValue& field_value) {
   Serializer::TypedValue proto_value{

--- a/Firestore/core/src/firebase/firestore/remote/serializer.cc
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.cc
@@ -25,18 +25,6 @@ namespace remote {
 
 using firebase::firestore::model::FieldValue;
 
-// TODO: DO NOT SUBMIT. This code exists solely to generate an error (via the
-// -Wcomma flag) and should be removed before we submit. Uncomment this to see
-// the error. (Treated as a non-fatal warning by xcode, but treated as fatal by
-// cmake due to -Werror.
-/*
-void GenerateCompilerError() {
-  int x = 0;
-  int y = 0;
-  x++, y++;  // Compiler warning due to -Wcomma here.
-}
-*/
-
 Serializer::TypedValue Serializer::EncodeFieldValue(
     const FieldValue& field_value) {
   Serializer::TypedValue proto_value{

--- a/cmake/CompilerSetup.cmake
+++ b/cmake/CompilerSetup.cmake
@@ -32,6 +32,9 @@ if(CLANG OR GNU)
     common_flags
     -Wall -Wextra -Werror
 
+    # Detect possible misuse of comma operator.
+    -Wcomma
+
     # Be super pedantic about format strings
     -Wformat
 

--- a/cmake/CompilerSetup.cmake
+++ b/cmake/CompilerSetup.cmake
@@ -32,9 +32,6 @@ if(CLANG OR GNU)
     common_flags
     -Wall -Wextra -Werror
 
-    # Detect possible misuse of comma operator.
-    -Wcomma
-
     # Be super pedantic about format strings
     -Wformat
 
@@ -64,6 +61,9 @@ if(CLANG OR GNU)
       APPEND common_flags
      -Wconditional-uninitialized -Werror=return-type -Winfinite-recursion -Wmove
      -Wrange-loop-analysis -Wunreachable-code
+
+     # Options added to match apple recommended project settings
+     -Wcomma
     )
   endif()
 


### PR DESCRIPTION
In order to use different cflags for abseil, this patch splits it out into a subspec within the pod.

The cmake side of things "just works" since Firestore/CMakeLists.txt includes abseil before setting our compiler flags.

Clang's doc on -Wcomma: http://clang.llvm.org/docs/DiagnosticsReference.html#wcomma (which isn't terribly useful).

A more useful discussion on -Wcomma from the code review that added it: https://reviews.llvm.org/D3976