### PR TITLE
Require official 1.4.0 for min CocoaPods version

### DIFF
--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -21,7 +21,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
 
-  s.cocoapods_version = '>= 1.4.0.beta.2'
+  s.cocoapods_version = '>= 1.4.0'
   s.static_framework = true
   s.prefix_header_file = false
 

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -20,7 +20,7 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
 
-  s.cocoapods_version = '>= 1.4.0.beta.2'
+  s.cocoapods_version = '>= 1.4.0'
   s.static_framework = true
   s.prefix_header_file = false
 

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -20,7 +20,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
 
-  s.cocoapods_version = '>= 1.4.0.beta.2'
+  s.cocoapods_version = '>= 1.4.0'
   s.static_framework = true
   s.prefix_header_file = false
 

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -24,7 +24,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
 
   s.ios.deployment_target = '7.0'
 
-  s.cocoapods_version = '>= 1.4.0.beta.2'
+  s.cocoapods_version = '>= 1.4.0'
   s.static_framework = true
   s.prefix_header_file = false
 

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -22,7 +22,7 @@ device, and it is completely free.
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.10'
 
-  s.cocoapods_version = '>= 1.4.0.beta.2'
+  s.cocoapods_version = '>= 1.4.0'
   s.static_framework = true
   s.prefix_header_file = false
 

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -20,7 +20,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
 
-  s.cocoapods_version = '>= 1.4.0.beta.2'
+  s.cocoapods_version = '>= 1.4.0'
   s.static_framework = true
   s.prefix_header_file = false
 


### PR DESCRIPTION
Now that 1.4.0 has been out for awhile, stop allowing beta usage