### PR TITLE
Disable -Wrange-loop-analysis for abseil

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -90,6 +90,6 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
     ]
 
     ss.library = 'c++'
-    ss.compiler_flags = '$(inherited) ' + '-Wno-comma'
+    ss.compiler_flags = '$(inherited) ' + '-Wno-comma -Wno-range-loop-analysis'
   end
 end

--- a/Firestore/core/src/firebase/firestore/remote/serializer.cc
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.cc
@@ -23,15 +23,6 @@ namespace firebase {
 namespace firestore {
 namespace remote {
 
-/* TODO: remove this method. Included to trigger a -Wrange-loop-analysis warning. */
-#include <initializer_list>
-#include <absl/strings/string_view.h>
-size_t WRangeLoopAnalysis(std::initializer_list<absl::string_view> pieces) {
-  size_t total_size = 0;
-  for (const absl::string_view piece : pieces) total_size += piece.size();
-  return total_size;
-}
-
 using firebase::firestore::model::FieldValue;
 
 Serializer::TypedValue Serializer::EncodeFieldValue(

--- a/Firestore/core/src/firebase/firestore/remote/serializer.cc
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.cc
@@ -23,6 +23,15 @@ namespace firebase {
 namespace firestore {
 namespace remote {
 
+/* TODO: remove this method. Included to trigger a -Wrange-loop-analysis warning. */
+#include <initializer_list>
+#include <absl/strings/string_view.h>
+size_t WRangeLoopAnalysis(std::initializer_list<absl::string_view> pieces) {
+  size_t total_size = 0;
+  for (const absl::string_view piece : pieces) total_size += piece.size();
+  return total_size;
+}
+
 using firebase::firestore::model::FieldValue;
 
 Serializer::TypedValue Serializer::EncodeFieldValue(


### PR DESCRIPTION
absl includes code like this:
```
void fn(std::initializer_list<absl::string_view> pieces) {
  ...
  for (const absl::string_view piece : pieces) total_size += piece.size();
```

clang objects, suggesting that a reference should be used instead, i.e.:
```
  for (const absl::string_view& piece : pieces) total_size += piece.size();
```

But:
a) we don't want to touch absl code
b) string_views are cheap to copy (and absl recommends copying
string_views rather than taking references as it may result in smaller
code)
c) some brief, naive benchmarking suggests there's no significant
different in this case (i.e. (b) is correct.)

Note that -Wrange-loop-analysis is already exlicitly enabled in our
cmake build.