### PR TITLE
Fix implicit retain self warnings

### DIFF
--- a/Firestore/Source/Auth/FSTCredentialsProvider.mm
+++ b/Firestore/Source/Auth/FSTCredentialsProvider.mm
@@ -86,12 +86,12 @@ NS_ASSUME_NONNULL_BEGIN
 
                       NSString *userID = userInfo[FIRAuthStateDidChangeInternalNotificationUIDKey];
                       User newUser = User(userID);
-                      if (newUser != _currentUser) {
-                        _currentUser = newUser;
+                      if (newUser != self->_currentUser) {
+                        self->_currentUser = newUser;
                         self.userCounter++;
                         FSTVoidUserBlock listenerBlock = self.userChangeListener;
                         if (listenerBlock) {
-                          listenerBlock(_currentUser);
+                          listenerBlock(self->_currentUser);
                         }
                       }
                     }
@@ -121,7 +121,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                    userInfo:errorInfo];
             completion(Token::Invalid(), cancelError);
           } else {
-            completion(Token(util::MakeStringView(token), _currentUser), error);
+            completion(Token(util::MakeStringView(token), self->_currentUser), error);
           }
         };
       };

--- a/Firestore/Source/Remote/FSTRemoteStore.mm
+++ b/Firestore/Source/Remote/FSTRemoteStore.mm
@@ -507,10 +507,10 @@ static const int kOnlineAttemptsBeforeFailure = 2;
                                  FSTBoxedTargetID *target, FSTTargetChange *change, BOOL *stop) {
     NSData *resumeToken = change.resumeToken;
     if (resumeToken.length > 0) {
-      FSTQueryData *queryData = _listenTargets[target];
+      FSTQueryData *queryData = self->_listenTargets[target];
       // A watched target might have been removed already.
       if (queryData) {
-        _listenTargets[target] =
+        self->_listenTargets[target] =
             [queryData queryDataByReplacingSnapshotVersion:change.snapshotVersion
                                                resumeToken:resumeToken];
       }

--- a/Firestore/Source/Remote/FSTRemoteStore.mm
+++ b/Firestore/Source/Remote/FSTRemoteStore.mm
@@ -33,6 +33,7 @@
 #import "Firestore/Source/Remote/FSTStream.h"
 #import "Firestore/Source/Remote/FSTWatchChange.h"
 #import "Firestore/Source/Util/FSTAssert.h"
+#import "Firestore/Source/Util/FSTClasses.h"
 #import "Firestore/Source/Util/FSTLogger.h"
 
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
@@ -503,8 +504,13 @@ static const int kOnlineAttemptsBeforeFailure = 2;
 
   // Update in-memory resume tokens. FSTLocalStore will update the persistent view of these when
   // applying the completed FSTRemoteEvent.
+  FSTWeakify(self);
   [remoteEvent.targetChanges enumerateKeysAndObjectsUsingBlock:^(
                                  FSTBoxedTargetID *target, FSTTargetChange *change, BOOL *stop) {
+    FSTStrongify(self);
+    if (!self) {
+      return;
+    }
     NSData *resumeToken = change.resumeToken;
     if (resumeToken.length > 0) {
       FSTQueryData *queryData = self->_listenTargets[target];

--- a/Firestore/Source/Remote/FSTRemoteStore.mm
+++ b/Firestore/Source/Remote/FSTRemoteStore.mm
@@ -504,13 +504,8 @@ static const int kOnlineAttemptsBeforeFailure = 2;
 
   // Update in-memory resume tokens. FSTLocalStore will update the persistent view of these when
   // applying the completed FSTRemoteEvent.
-  FSTWeakify(self);
   [remoteEvent.targetChanges enumerateKeysAndObjectsUsingBlock:^(
                                  FSTBoxedTargetID *target, FSTTargetChange *change, BOOL *stop) {
-    FSTStrongify(self);
-    if (!self) {
-      return;
-    }
     NSData *resumeToken = change.resumeToken;
     if (resumeToken.length > 0) {
       FSTQueryData *queryData = self->_listenTargets[target];

--- a/Firestore/Source/Remote/FSTRemoteStore.mm
+++ b/Firestore/Source/Remote/FSTRemoteStore.mm
@@ -33,7 +33,6 @@
 #import "Firestore/Source/Remote/FSTStream.h"
 #import "Firestore/Source/Remote/FSTWatchChange.h"
 #import "Firestore/Source/Util/FSTAssert.h"
-#import "Firestore/Source/Util/FSTClasses.h"
 #import "Firestore/Source/Util/FSTLogger.h"
 
 #include "Firestore/core/src/firebase/firestore/auth/user.h"

--- a/Firestore/Source/Util/FSTAsyncQueryListener.mm
+++ b/Firestore/Source/Util/FSTAsyncQueryListener.mm
@@ -16,6 +16,7 @@
 
 #import "Firestore/Source/Util/FSTAsyncQueryListener.h"
 
+#import "Firestore/Source/Util/FSTClasses.h"
 #import "Firestore/Source/Util/FSTDispatchQueue.h"
 
 @implementation FSTAsyncQueryListener {
@@ -34,8 +35,18 @@
 }
 
 - (FSTViewSnapshotHandler)asyncSnapshotHandler {
+  FSTWeakify(self);
   return ^(FSTViewSnapshot *_Nullable snapshot, NSError *_Nullable error) {
+    FSTStrongify(self);
+    if (!self) {
+      return;
+    }
+    FSTWeakify(self);
     [self->_dispatchQueue dispatchAsync:^{
+      FSTStrongify(self);
+      if (!self) {
+        return;
+      }
       if (!self->_muted) {
         self->_snapshotHandler(snapshot, error);
       }

--- a/Firestore/Source/Util/FSTAsyncQueryListener.mm
+++ b/Firestore/Source/Util/FSTAsyncQueryListener.mm
@@ -35,9 +35,9 @@
 
 - (FSTViewSnapshotHandler)asyncSnapshotHandler {
   return ^(FSTViewSnapshot *_Nullable snapshot, NSError *_Nullable error) {
-    [_dispatchQueue dispatchAsync:^{
-      if (!_muted) {
-        _snapshotHandler(snapshot, error);
+    [self->_dispatchQueue dispatchAsync:^{
+      if (!self->_muted) {
+        self->_snapshotHandler(snapshot, error);
       }
     }];
   };


### PR DESCRIPTION
Xcode has starting warning about us implicitly retaining self references
within blocks. (Some of these instances could cause retain cycles.)

This PR addresses these issues.