### PR TITLE
Use -[GRPCCall setResponseDispatchQueue]

### DIFF
--- a/Firestore/Example/Tests/Integration/FSTStreamTests.mm
+++ b/Firestore/Example/Tests/Integration/FSTStreamTests.mm
@@ -203,7 +203,9 @@ using firebase::firestore::model::DatabaseId;
   }];
 
   // Simulate a final callback from GRPC
-  [watchStream writesFinishedWithError:nil];
+  [_workerDispatchQueue dispatchAsync:^{
+    [watchStream writesFinishedWithError:nil];
+  }];
 
   [self verifyDelegateObservedStates:@[ @"watchStreamDidOpen" ]];
 }
@@ -225,7 +227,9 @@ using firebase::firestore::model::DatabaseId;
   }];
 
   // Simulate a final callback from GRPC
-  [writeStream writesFinishedWithError:nil];
+  [_workerDispatchQueue dispatchAsync:^{
+    [writeStream writesFinishedWithError:nil];
+  }];
 
   [self verifyDelegateObservedStates:@[ @"writeStreamDidOpen" ]];
 }

--- a/Firestore/Example/Tests/Integration/FSTStreamTests.mm
+++ b/Firestore/Example/Tests/Integration/FSTStreamTests.mm
@@ -16,6 +16,8 @@
 
 #import <XCTest/XCTest.h>
 
+#import <GRPCClient/GRPCCall.h>
+
 #import <FirebaseFirestore/FIRFirestoreSettings.h>
 
 #import "Firestore/Example/Tests/Util/FSTHelpers.h"
@@ -36,7 +38,7 @@ using firebase::firestore::model::DatabaseId;
 
 /** Exposes otherwise private methods for testing. */
 @interface FSTStream (Testing)
-- (void)writesFinishedWithError:(NSError *_Nullable)error;
+@property(nonatomic, strong, readwrite) id<GRXWriteable> callbackFilter;
 @end
 
 /**
@@ -204,7 +206,7 @@ using firebase::firestore::model::DatabaseId;
 
   // Simulate a final callback from GRPC
   [_workerDispatchQueue dispatchAsync:^{
-    [watchStream writesFinishedWithError:nil];
+    [watchStream.callbackFilter writesFinishedWithError:nil];
   }];
 
   [self verifyDelegateObservedStates:@[ @"watchStreamDidOpen" ]];
@@ -228,7 +230,7 @@ using firebase::firestore::model::DatabaseId;
 
   // Simulate a final callback from GRPC
   [_workerDispatchQueue dispatchAsync:^{
-    [writeStream writesFinishedWithError:nil];
+    [writeStream.callbackFilter writesFinishedWithError:nil];
   }];
 
   [self verifyDelegateObservedStates:@[ @"writeStreamDidOpen" ]];

--- a/Firestore/Source/Remote/FSTStream.mm
+++ b/Firestore/Source/Remote/FSTStream.mm
@@ -149,7 +149,12 @@ typedef NS_ENUM(NSInteger, FSTStreamState) {
 
 #pragma mark - FSTCallbackFilter
 
-/** Filter class that allows disabling of GRPC callbacks. */
+/**
+ * Implements callbacks from gRPC via the GRXWriteable protocol. This is separate from the main
+ * FSTStream to allow the stream to be stopped externally (either by the user or via idle timer)
+ * and be able to completely prevent any subsequent events from gRPC from calling back into the
+ * FSTSTream.
+ */
 @interface FSTCallbackFilter : NSObject <GRXWriteable>
 
 - (instancetype)initWithStream:(FSTStream *)stream NS_DESIGNATED_INITIALIZER;
@@ -544,7 +549,7 @@ static const NSTimeInterval kIdleTimeout = 60.0;
  * `[call setResponseDispatchQueue:self.workerDispatchQueue.queue]` on the GRPCCall before starting
  * the RPC.
  */
-- (void)writeValue:(id)value __used {
+- (void)writeValue:(id)value {
   [self.workerDispatchQueue verifyIsCurrentQueue];
   FSTAssert([self isStarted], @"writeValue: called for stopped stream.");
 


### PR DESCRIPTION
... to dispatch GRPC callbacks directly onto the Firestore worker queue.
This saves a double-dispatch and simplifies our logic.