### PR TITLE
Fix trivial mem leak in the test suite

### DIFF
--- a/Firestore/core/test/firebase/firestore/remote/datastore_test.cc
+++ b/Firestore/core/test/firebase/firestore/remote/datastore_test.cc
@@ -25,4 +25,5 @@ TEST(Datastore, CanLinkToGrpc) {
   // libraries required for gRPC to work are actually linked correctly into the
   // test.
   grpc_init();
+  grpc_shutdown();
 }


### PR DESCRIPTION
Reduces noise while running valgrind so that I can see the leaks that
I'm introducing. :/