### PR TITLE
Change base location for the LevelDB directory

### DIFF
--- a/Firestore/Source/Local/FSTLevelDB.h
+++ b/Firestore/Source/Local/FSTLevelDB.h
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
  * does not exist.
  *
  * The leveldb directory is created relative to the appropriate document storage directory for the
- * platform: NSDocumentDirectory on iOS or $HOME/.firestore on macOS.
+ * platform: NSApplicationSupportDirectory on iOS or $HOME/.firestore on macOS.
  */
 - (BOOL)start:(NSError **)error;
 

--- a/Firestore/Source/Local/FSTLevelDB.mm
+++ b/Firestore/Source/Local/FSTLevelDB.mm
@@ -82,7 +82,7 @@ using leveldb::WriteOptions;
 + (NSString *)documentsDirectory {
 #if TARGET_OS_IPHONE
   NSArray<NSString *> *directories =
-      NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+      NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
   return [directories[0] stringByAppendingPathComponent:kReservedPathComponent];
 
 #elif TARGET_OS_MAC


### PR DESCRIPTION
Proposing a change in the location where the LevelDB files are stored on iOS.

Today the base directory is `Documents/` and I'm proposing we change it to `Library/Application support`

Fixes #843