### PR TITLE
Convert cmake build to (mostly) use urls rather than git clones

### DIFF
--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -17,6 +17,8 @@ include(ExternalProject)
 ExternalProject_Add(
   googletest
 
+  DOWNLOAD_DIR ${PROJECT_BINARY_DIR}/downloads
+  DOWNLOAD_NAME googletest-1.8.0.tar.gz
   URL https://github.com/google/googletest/archive/release-1.8.0.tar.gz
   URL_HASH MD5=16877098823401d1bf2ed7891d7dce36
 

--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -13,18 +13,12 @@
 # limitations under the License.
 
 include(ExternalProject)
-include(ExternalProjectFlags)
-
-ExternalProject_GitSource(
-  GOOGLETEST_GIT
-  GIT_REPOSITORY "https://github.com/google/googletest.git"
-  GIT_TAG "release-1.8.0"
-)
 
 ExternalProject_Add(
   googletest
 
-  ${GOOGLETEST_GIT}
+  URL https://github.com/google/googletest/archive/release-1.8.0.tar.gz
+  URL_HASH MD5=16877098823401d1bf2ed7891d7dce36
 
   PREFIX ${PROJECT_BINARY_DIR}/external/googletest
 

--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -20,7 +20,7 @@ ExternalProject_Add(
   DOWNLOAD_DIR ${PROJECT_BINARY_DIR}/downloads
   DOWNLOAD_NAME googletest-1.8.0.tar.gz
   URL https://github.com/google/googletest/archive/release-1.8.0.tar.gz
-  URL_HASH MD5=16877098823401d1bf2ed7891d7dce36
+  URL_HASH SHA256=58a6f4277ca2bc8565222b3bbd58a177609e9c488e8a72649359ba51450db7d8
 
   PREFIX ${PROJECT_BINARY_DIR}/external/googletest
 

--- a/cmake/external/leveldb.cmake
+++ b/cmake/external/leveldb.cmake
@@ -44,6 +44,8 @@ else()
   ExternalProject_Add(
     leveldb
 
+    DOWNLOAD_DIR ${PROJECT_BINARY_DIR}/downloads
+    DOWNLOAD_NAME leveldb-v1.20.tar.gz
     URL https://github.com/google/leveldb/archive/v1.20.tar.gz
     URL_HASH MD5=298b5bddf12c675d6345784261302252
 

--- a/cmake/external/leveldb.cmake
+++ b/cmake/external/leveldb.cmake
@@ -47,7 +47,7 @@ else()
     DOWNLOAD_DIR ${PROJECT_BINARY_DIR}/downloads
     DOWNLOAD_NAME leveldb-v1.20.tar.gz
     URL https://github.com/google/leveldb/archive/v1.20.tar.gz
-    URL_HASH MD5=298b5bddf12c675d6345784261302252
+    URL_HASH SHA256=f5abe8b5b209c2f36560b75f32ce61412f39a2922f7045ae764a2c23335b6664
 
     PREFIX ${PROJECT_BINARY_DIR}/external/leveldb
 

--- a/cmake/external/leveldb.cmake
+++ b/cmake/external/leveldb.cmake
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 include(ExternalProject)
-include(ExternalProjectFlags)
 
 if(WIN32 OR LEVELDB_ROOT)
   # If the user has supplied a LEVELDB_ROOT then just use it. Add an empty
@@ -42,16 +41,11 @@ else()
       $<$<CONFIG:Release>:${CMAKE_CXX_FLAGS_RELEASE}>"
   )
 
-  ExternalProject_GitSource(
-    LEVELDB_GIT
-    GIT_REPOSITORY "https://github.com/google/leveldb.git"
-    GIT_TAG "v1.20"
-  )
-
   ExternalProject_Add(
     leveldb
 
-    ${LEVELDB_GIT}
+    URL https://github.com/google/leveldb/archive/v1.20.tar.gz
+    URL_HASH MD5=298b5bddf12c675d6345784261302252
 
     PREFIX ${PROJECT_BINARY_DIR}/external/leveldb
 

--- a/cmake/external/nanopb.cmake
+++ b/cmake/external/nanopb.cmake
@@ -24,7 +24,7 @@ ExternalProject_Add(
 
   DOWNLOAD_DIR ${PROJECT_BINARY_DIR}/downloads
   URL https://github.com/nanopb/nanopb/archive/nanopb-0.3.8.tar.gz
-  URL_HASH MD5=c1dcfe49ced36227167dca0f6bcad703
+  URL_HASH SHA256=f192c7c7cc036be36babc303b7d2315d4f62e2fe4be28c172cfed4cfa0ed5f22
 
   BUILD_IN_SOURCE ON
 

--- a/cmake/external/nanopb.cmake
+++ b/cmake/external/nanopb.cmake
@@ -11,13 +11,6 @@
 # limitations under the License.
 
 include(ExternalProject)
-include(ExternalProjectFlags)
-
-ExternalProject_GitSource(
-  NANOPB_GIT
-  GIT_REPOSITORY "https://github.com/nanopb/nanopb.git"
-  GIT_TAG "0.3.8"
-)
 
 set(
   NANOPB_PROTOC_BIN
@@ -29,7 +22,8 @@ ExternalProject_Add(
   DEPENDS
     protobuf
 
-  ${NANOPB_GIT}
+  URL https://github.com/nanopb/nanopb/archive/nanopb-0.3.8.tar.gz
+  URL_HASH MD5=c1dcfe49ced36227167dca0f6bcad703
 
   BUILD_IN_SOURCE ON
 

--- a/cmake/external/nanopb.cmake
+++ b/cmake/external/nanopb.cmake
@@ -22,6 +22,7 @@ ExternalProject_Add(
   DEPENDS
     protobuf
 
+  DOWNLOAD_DIR ${PROJECT_BINARY_DIR}/downloads
   URL https://github.com/nanopb/nanopb/archive/nanopb-0.3.8.tar.gz
   URL_HASH MD5=c1dcfe49ced36227167dca0f6bcad703
 

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -13,18 +13,12 @@
 # limitations under the License.
 
 include(ExternalProject)
-include(ExternalProjectFlags)
-
-ExternalProject_GitSource(
-  PROTOBUF_GIT
-  GIT_REPOSITORY "https://github.com/google/protobuf.git"
-  GIT_TAG "v3.5.1.1"
-)
 
 ExternalProject_Add(
   protobuf
 
-  ${PROTOBUF_GIT}
+  URL https://github.com/google/protobuf/archive/v3.5.1.1.tar.gz
+  URL_HASH MD5=5005003ae6b94773c4bbca87a644b131
 
   PREFIX ${PROJECT_BINARY_DIR}/external/protobuf
 

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -17,6 +17,8 @@ include(ExternalProject)
 ExternalProject_Add(
   protobuf
 
+  DOWNLOAD_DIR ${PROJECT_BINARY_DIR}/downloads
+  DOWNLOAD_NAME protobuf-v3.5.11.tar.gz
   URL https://github.com/google/protobuf/archive/v3.5.1.1.tar.gz
   URL_HASH MD5=5005003ae6b94773c4bbca87a644b131
 

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -20,7 +20,7 @@ ExternalProject_Add(
   DOWNLOAD_DIR ${PROJECT_BINARY_DIR}/downloads
   DOWNLOAD_NAME protobuf-v3.5.11.tar.gz
   URL https://github.com/google/protobuf/archive/v3.5.1.1.tar.gz
-  URL_HASH MD5=5005003ae6b94773c4bbca87a644b131
+  URL_HASH SHA256=56b5d9e1ab2bf4f5736c4cfba9f4981fbc6976246721e7ded5602fbaee6d6869
 
   PREFIX ${PROJECT_BINARY_DIR}/external/protobuf
 


### PR DESCRIPTION
Exception: grpc. Due to it's use of git submodules, it's not completely
trivial to convert it (though probably wouldn't be too much more work.)

This reduces the build time and *might* help address build failures on travis.

