### PR TITLE
Fix Firestore podspec overlay build

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -31,7 +31,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.source_files = [
     'Firestore/Source/**/*',
     'Firestore/Port/**/*',
-    'Firestore/Protos/nanopb/**/*.[hm]',
+    'Firestore/Protos/nanopb/**/*.[hc]',
     'Firestore/Protos/objc/**/*.[hm]',
     'Firestore/core/include/**/*.{h,cc,mm}',
     'Firestore/core/src/**/*.{h,cc,mm}',

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -31,6 +31,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.source_files = [
     'Firestore/Source/**/*',
     'Firestore/Port/**/*',
+    'Firestore/Protos/nanopb/**/*.[hm]',
     'Firestore/Protos/objc/**/*.[hm]',
     'Firestore/core/include/**/*.{h,cc,mm}',
     'Firestore/core/src/**/*.{h,cc,mm}',

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -68,7 +68,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
       '"${PODS_TARGET_SRCROOT}/Firestore/third_party/abseil-cpp" ' +
       '"${PODS_ROOT}/nanopb" ' +
       '"${PODS_TARGET_SRCROOT}/Firestore/Protos/nanopb"',
-    'OTHER_CFLAGS' => '-DFIRFirestore_VERSION=' + s.version.to_s + " -DPB_FIELD_16BIT"
+    'OTHER_CFLAGS' => '-DFIRFirestore_VERSION=' + s.version.to_s + ' -DPB_FIELD_16BIT'
   }
 
   s.prepare_command = <<-CMD

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -68,7 +68,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
       '"${PODS_TARGET_SRCROOT}/Firestore/third_party/abseil-cpp" ' +
       '"${PODS_ROOT}/nanopb" ' +
       '"${PODS_TARGET_SRCROOT}/Firestore/Protos/nanopb"',
-    'OTHER_CFLAGS' => '-DFIRFirestore_VERSION=' + s.version.to_s
+    'OTHER_CFLAGS' => '-DFIRFirestore_VERSION=' + s.version.to_s + " -DPB_FIELD_16BIT"
   }
 
   s.prepare_command = <<-CMD


### PR DESCRIPTION
Add missing nanopb directory to podspec.  
Otherwise imports of headers in Protos/nanopb fail to compile.