### PR TITLE
Factor out a universal build script

### DIFF
--- a/Firestore/test.sh
+++ b/Firestore/test.sh
@@ -13,54 +13,8 @@
 
 set -euo pipefail
 
-FIRESTORE_DIR=$(dirname "${BASH_SOURCE[0]}")
+firestore_dir=$(dirname "${BASH_SOURCE[0]}")
+scripts_dir="$firestore_dir/../scripts"
 
-test_iOS() {
-  xcodebuild \
-    -workspace "$FIRESTORE_DIR/Example/Firestore.xcworkspace" \
-    -scheme Firestore_Tests \
-    -sdk iphonesimulator \
-    -destination 'platform=iOS Simulator,name=iPhone 7' \
-    build \
-    test \
-    ONLY_ACTIVE_ARCH=YES \
-    CODE_SIGNING_REQUIRED=NO \
-    | xcpretty
-
-  xcodebuild \
-    -workspace "$FIRESTORE_DIR/Example/Firestore.xcworkspace" \
-    -scheme SwiftBuildTest \
-    -sdk iphonesimulator \
-    -destination 'platform=iOS Simulator,name=iPhone 7' \
-    build \
-    ONLY_ACTIVE_ARCH=YES \
-    CODE_SIGNING_REQUIRED=NO \
-    | xcpretty
-}
-
-test_CMake() {
-  echo "cpu core: $(sysctl -n hw.ncpu)"
-  echo "prepare cmake build" && \
-    mkdir -p build && \
-    cd build && \
-    cmake .. || \
-    exit 1
-
-  echo "cmake build and test" && \
-    make -j $(sysctl -n hw.ncpu) all || \
-    exit 2
-}
-
-test_iOS; RESULT=$?
-if [[ $RESULT == 65 ]]; then
-  echo "xcodebuild exited with 65, retrying"
-  sleep 5
-
-  test_iOS; RESULT=$?
-fi
-
-if [ $RESULT != 0 ]; then exit $RESULT; fi
-
-test_CMake; RESULT=$?
-
-if [ $RESULT != 0 ]; then exit $RESULT; fi
+$scripts_dir/build.sh Firestore iOS
+$scripts_dir/build.sh Firestore macOS cmake

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# USAGE: build.sh product [platform] [method]
+#
+# Builds the given product for the given platform using the given build method
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  cat 1>&2 <<EOF
+USAGE: $0 product [platform] [method]
+
+product can be one of:
+  Firebase
+  Firestore
+
+platform can be one of:
+  iOS (default)
+  macOS
+  tvOS
+
+method can be one of:
+  xcodebuild (default)
+  cmake
+EOF
+  exit 1
+fi
+
+product="$1"
+
+platform="iOS"
+if [[ $# -gt 1 ]]; then
+  platform="$2"
+fi
+
+method="xcodebuild"
+if [[ $# -gt 2 ]]; then
+  method="$3"
+fi
+
+echo "Building $product for $platform using $method"
+
+# Runs xcodebuild with the given flags, piping output to xcpretty
+# If xcodebuild fails with known error codes, retries once.
+function RunXcodebuild() {
+  xcodebuild "$@" | xcpretty; result=$?
+  if [[ $result == 65 ]]; then
+    echo "xcodebuild exited with 65, retrying" 1>&2
+    sleep 5
+
+    xcodebuild "$@" | xcpretty; result=$?
+  fi
+  if [[ $result != 0 ]]; then
+    exit $result
+  fi
+}
+
+# Compute standard flags for all platforms
+case "$platform" in
+  iOS)
+    xcb_flags=(
+      -sdk 'iphonesimulator'
+      -destination 'platform=iOS Simulator,name=iPhone 7'
+    )
+    ;;
+
+  macOS)
+    xcb_flags=(
+      -sdk 'macosx'
+      -destination 'platform=OS X,arch=x86_64'
+    )
+    ;;
+
+  tvOS)
+    xcb_flags=(
+      -sdk "appletvsimulator"
+      -destination 'platform=tvOS Simulator,name=Apple TV'
+    )
+    ;;
+
+  *)
+    echo "Unknown platform '$platform'" 1>&2
+    exit 1
+    ;;
+esac
+
+xcb_flags+=(
+  ONLY_ACTIVE_ARCH=YES
+  CODE_SIGNING_REQUIRED=NO
+)
+
+case "$product-$method-$platform" in
+  Firebase-xcodebuild-*)
+    RunXcodebuild \
+        -workspace 'Example/Firebase.xcworkspace' \
+        -scheme "AllUnitTests_$platform" \
+        "${xcb_flags[@]}" \
+        build \
+        test
+    ;;
+
+  Firestore-xcodebuild-iOS)
+    RunXcodebuild \
+        -workspace 'Firestore/Example/Firestore.xcworkspace' \
+        -scheme 'Firestore_Tests' \
+        "${xcb_flags[@]}" \
+        build \
+        test
+
+    RunXcodebuild \
+        -workspace 'Firestore/Example/Firestore.xcworkspace' \
+        -scheme 'SwiftBuildTest' \
+        "${xcb_flags[@]}" \
+        build
+    ;;
+
+  Firestore-cmake-macOS)
+    test -d build || mkdir build
+    echo "Preparing cmake build ..."
+    (cd build; cmake ..)
+
+    echo "Building cmake build ..."
+    cpus=$(sysctl -n hw.ncpu)
+    (cd build; make -j $cpus all)
+    ;;
+
+  *)
+    echo "Don't know how to build this product-platform-method combination" 1>&2
+    echo "  product=$product" 1>&2
+    echo "  platform=$platform" 1>&2
+    echo "  method=$method" 1>&2
+    exit 1
+    ;;
+esac

--- a/test.sh
+++ b/test.sh
@@ -13,60 +13,9 @@
 
 set -eo pipefail
 
-test_iOS() {
-  xcodebuild \
-    -workspace Example/Firebase.xcworkspace \
-    -scheme AllUnitTests_iOS \
-    -sdk iphonesimulator \
-    -destination 'platform=iOS Simulator,name=iPhone 7' \
-    build \
-    test \
-    ONLY_ACTIVE_ARCH=YES \
-    CODE_SIGNING_REQUIRED=NO \
-    | xcpretty
-}
+top_dir=$(dirname "${BASH_SOURCE[0]}")
+scripts_dir="$top_dir/scripts"
 
-test_macOS() {
-  xcodebuild \
-    -workspace Example/Firebase.xcworkspace \
-    -scheme AllUnitTests_macOS \
-    -sdk macosx \
-    -destination 'platform=OS X,arch=x86_64' \
-    build \
-    test \
-    ONLY_ACTIVE_ARCH=YES \
-    CODE_SIGNING_REQUIRED=NO \
-    | xcpretty
-}
-
-test_tvOS() {
-  xcodebuild \
-    -workspace Example/Firebase.xcworkspace \
-    -scheme AllUnitTests_tvOS \
-    -sdk appletvsimulator \
-    -destination 'platform=tvOS Simulator,name=Apple TV' \
-    build \
-    test \
-    ONLY_ACTIVE_ARCH=YES \
-    CODE_SIGNING_REQUIRED=NO \
-    | xcpretty
-}
-
-test_iOS; RESULT=$?
-
-if [ $RESULT != 0 ]; then exit $RESULT; fi
-
-test_macOS; RESULT=$?
-
-if [ $RESULT == 65 ]; then
-  echo "xcodebuild exited with 65, retrying"
-  sleep 5
-
-  test_macOS; RESULT=$?
-fi
-
-if [ $RESULT != 0 ]; then exit $RESULT; fi
-
-test_tvOS; RESULT=$?
-
-if [ $RESULT != 0 ]; then exit $RESULT; fi
+$scripts_dir/build.sh Firebase iOS
+$scripts_dir/build.sh Firebase macOS
+$scripts_dir/build.sh Firebase tvOS


### PR DESCRIPTION
This is a preparatory step for getting higher resolution timing data out of travis and also for parallelizing the travis build.

For the moment this is functionally equivalent to what came before.