### PR TITLE
Speed up source checks in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 
 script:
   - ./scripts/check_whitespace.sh
-  - "! git grep -EL --name-only 'Copyright [0-9]{4}.*Google' | grep -v third_party | egrep '\\.(m|h|cc|mm|c)$'"
+  - ./scripts/check_copyright.sh $TRAVIS_COMMIT_RANGE
   - ./scripts/style.sh test-only # Validate clang-format compliance
   - |
     if [ $SKIP_FIREBASE != 1 ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ before_install:
     fi
 
 script:
-  # Fail on trailing whitespace in non-binary, non-generated-nanopb files
-  - "! git grep -I ' $' ':(exclude)Firestore/Protos/nanopb'"
+  - ./scripts/check_whitespace.sh
   - "! git grep -EL --name-only 'Copyright [0-9]{4}.*Google' | grep -v third_party | egrep '\\.(m|h|cc|mm|c)$'"
   - ./scripts/style.sh test-only # Validate clang-format compliance
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,9 @@ script:
       ./test.sh
     fi
   - |
+    # Google C++ style compliance
     if [ $SKIP_FIRESTORE != 1 ]; then
-      ./scripts/lint.sh # Google C++ style compliance
+      ./scripts/lint.sh $TRAVIS_COMMIT_RANGE
     fi
   - |
     if [ $SKIP_FIRESTORE != 1 ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
 script:
   - ./scripts/check_whitespace.sh
   - ./scripts/check_copyright.sh $TRAVIS_COMMIT_RANGE
-  - ./scripts/style.sh test-only # Validate clang-format compliance
+  - ./scripts/style.sh test-only $TRAVIS_COMMIT_RANGE
   - |
     if [ $SKIP_FIREBASE != 1 ]; then
       ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 
 script:
   - ./scripts/check_whitespace.sh
-  - ./scripts/check_copyright.sh $TRAVIS_COMMIT_RANGE
+  - ./scripts/check_copyright.sh
   - ./scripts/style.sh test-only $TRAVIS_COMMIT_RANGE
   - |
     # Google C++ style compliance

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,13 +34,14 @@ script:
   - ./scripts/check_copyright.sh $TRAVIS_COMMIT_RANGE
   - ./scripts/style.sh test-only $TRAVIS_COMMIT_RANGE
   - |
-    if [ $SKIP_FIREBASE != 1 ]; then
-      ./test.sh
-    fi
-  - |
     # Google C++ style compliance
     if [ $SKIP_FIRESTORE != 1 ]; then
       ./scripts/lint.sh $TRAVIS_COMMIT_RANGE
+    fi
+
+  - |
+    if [ $SKIP_FIREBASE != 1 ]; then
+      ./test.sh
     fi
   - |
     if [ $SKIP_FIRESTORE != 1 ]; then

--- a/scripts/check_copyright.sh
+++ b/scripts/check_copyright.sh
@@ -21,10 +21,6 @@ options=(
   'Copyright [0-9]{4}.*Google'
 )
 
-# Allow a revision range to be specified on the command-line, e.g.
-# $TRAVIS_COMMIT_RANGE
-options+=("$@")
-
 git grep "${options[@]}" \
     -- '*.'{c,cc,h,m,mm,sh,swift} \
     ':(exclude)**/third_party/**'

--- a/scripts/check_copyright.sh
+++ b/scripts/check_copyright.sh
@@ -1,0 +1,35 @@
+# Copyright 2018 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Check source files for copyright notices
+
+options=(
+  -E  # Use extended regexps
+  -I  # Exclude binary files
+  -L  # Show files that don't have a match
+  'Copyright [0-9]{4}.*Google'
+)
+
+# Allow a revision range to be specified on the command-line, e.g.
+# $TRAVIS_COMMIT_RANGE
+options+=("$@")
+
+git grep "${options[@]}" \
+    -- '*.'{c,cc,h,m,mm,sh,swift} \
+    ':(exclude)**/third_party/**'
+if [[ $? == 0 ]]; then
+  echo "ERROR: Missing copyright notices in the files above. Please fix."
+  exit 1
+fi
+

--- a/scripts/check_whitespace.sh
+++ b/scripts/check_whitespace.sh
@@ -1,0 +1,37 @@
+# Copyright 2018 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fail on an trailing whitespace characters, excluding
+#   * binary files (-I)
+#   * nanopb-generated files
+#
+# Note: specifying revisions we care about makes this go slower than just
+# grepping through the whole repo.
+options=(
+  -n  # show line numbers
+  -I  # exclude binary files
+  ' $'
+)
+
+# Allow a revision range to be specified on the command-line, e.g.
+# $TRAVIS_COMMIT_RANGE
+options+=("$@")
+
+git grep "${options[@]}" \
+    -- ':(exclude)Firestore/Protos/nanopb'
+if [[ $? == 0 ]]; then
+  echo "ERROR: Trailing whitespace found in the files above. Please fix."
+  exit 1
+fi
+

--- a/scripts/check_whitespace.sh
+++ b/scripts/check_whitespace.sh
@@ -24,10 +24,6 @@ options=(
   ' $'
 )
 
-# Allow a revision range to be specified on the command-line, e.g.
-# $TRAVIS_COMMIT_RANGE
-options+=("$@")
-
 git grep "${options[@]}" \
     -- ':(exclude)Firestore/Protos/nanopb'
 if [[ $? == 0 ]]; then

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -12,7 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find Firestore/core \( \
-  -name \*.h -o \
-  -name \*.cc \) -print0 \
+# Lints C++ files for conformance with the Google C++ style guide
+
+options=(
+    -z    # \0 terminate output
+)
+
+if [[ $# -gt 0 ]]; then
+  # Interpret any command-line argument as a revision range
+  command=(git diff --name-only)
+  options+=("$@")
+
+else
+  # Default to operating on all files that match the pattern
+  command=(git ls-files)
+fi
+
+
+"${command[@]}" "${options[@]}" \
+    -- 'Firestore/core/**/*.'{h,cc} \
   | xargs -0 python scripts/cpplint.py --quiet

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -23,8 +23,12 @@
 
 system=$(uname -s)
 
-if [[ $(clang-format --version) != *"version 6"* ]]; then
-  echo "Please upgrade to clang-format version 6."
+version=$(clang-format --version)
+version="${version/*version /}"
+version="${version/.*/}"
+if [[ "$version" != 6 && "$version" != 7 ]]; then
+  # Allow an older clang-format to accommodate Travis version skew.
+  echo "Please upgrade to clang-format version 7."
   echo "If it's installed via homebrew you can run: brew upgrade clang-format"
   exit 1
 fi


### PR DESCRIPTION
Use revision ranges in all source checking commands. Cumulative time for all checks down from 16s to 0.3s.

Other cleanup:
  * Factor out scripts so they can be tested stand-alone
  * Group all source checks first to fail builds without building