### PR TITLE
Fix for b/74357976 and some cleanup.

### DIFF
--- a/Firestore/Source/Auth/FSTCredentialsProvider.mm
+++ b/Firestore/Source/Auth/FSTCredentialsProvider.mm
@@ -121,6 +121,10 @@ NS_ASSUME_NONNULL_BEGIN
                                                    userInfo:errorInfo];
             completion(Token::Invalid(), cancelError);
           } else {
+            if (!token) {
+              // We use "" to represent the lack of a token in the C++ Token object.
+              token = @"";
+            }
             completion(Token(util::MakeStringView(token), self->_currentUser), error);
           }
         };

--- a/Firestore/Source/Auth/FSTEmptyCredentialsProvider.mm
+++ b/Firestore/Source/Auth/FSTEmptyCredentialsProvider.mm
@@ -31,8 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)getTokenForcingRefresh:(BOOL)forceRefresh
                     completion:(FSTVoidGetTokenResultBlock)completion {
-  // Invalid token will force the GRPC fallback to use default settings.
-  completion(Token::Invalid(), nil);
+  completion(Token::Token("", User::Unauthenticated()), nil);
 }
 
 - (void)setUserChangeListener:(nullable FSTVoidUserBlock)block {

--- a/Firestore/Source/Remote/FSTStream.mm
+++ b/Firestore/Source/Remote/FSTStream.mm
@@ -274,6 +274,7 @@ static const NSTimeInterval kIdleTimeout = 60.0;
 
 /** Add an access token to our RPC, after obtaining one from the credentials provider. */
 - (void)resumeStartWithToken:(const Token &)token error:(NSError *)error {
+  FSTAssert(token.is_valid(), @"resumeStartWithToken: called with invalid token.");
   [self.workerDispatchQueue verifyIsCurrentQueue];
 
   if (self.state == FSTStreamStateStopped) {
@@ -297,7 +298,7 @@ static const NSTimeInterval kIdleTimeout = 60.0;
 
   [FSTDatastore prepareHeadersForRPC:_rpc
                           databaseID:&self.databaseInfo->database_id()
-                               token:(token.is_valid() ? token.token() : absl::string_view())];
+                               token:(token.token())];
   FSTAssert(_callbackFilter == nil, @"GRX Filter must be nil");
   _callbackFilter = [[FSTCallbackFilter alloc] initWithStream:self];
   [_rpc startWithWriteable:_callbackFilter];

--- a/Firestore/core/src/firebase/firestore/auth/firebase_credentials_provider_apple.mm
+++ b/Firestore/core/src/firebase/firestore/auth/firebase_credentials_provider_apple.mm
@@ -96,7 +96,7 @@ void FirebaseCredentialsProvider::GetToken(bool force_refresh,
       // Cancel the request since the user changed while the request was
       // outstanding so the response is likely for a previous user (which
       // user, we can't be sure).
-      completion({"", User::Unauthenticated()},
+      completion(Token::Invalid(),
                  "getToken aborted due to user change.");
     } else {
       completion(

--- a/Firestore/core/src/firebase/firestore/auth/token.cc
+++ b/Firestore/core/src/firebase/firestore/auth/token.cc
@@ -22,6 +22,9 @@ namespace auth {
 
 Token::Token(const absl::string_view token, const User& user)
     : token_(token), user_(user), is_valid_(true) {
+  // We use "" to represent the absence of a token, which should
+  // be the case if the user is unauthenticated.
+  FIREBASE_ASSERT((!user_.is_authenticated()) == (token == ""));
 }
 
 Token::Token() : token_(), user_(User::Unauthenticated()), is_valid_(false) {

--- a/Firestore/core/src/firebase/firestore/auth/token.h
+++ b/Firestore/core/src/firebase/firestore/auth/token.h
@@ -44,7 +44,7 @@ class Token {
  public:
   Token(const absl::string_view token, const User& user);
 
-  /** The actual raw token. */
+  /** The actual raw token; will be "" if the user is unauthenticated. */
   const std::string& token() const {
     FIREBASE_ASSERT(is_valid_);
     return token_;
@@ -55,21 +55,22 @@ class Token {
    * state on disk, etc.).
    */
   const User& user() const {
+    FIREBASE_ASSERT(is_valid_);
     return user_;
   }
 
   /**
-   * Whether the token is a valid one.
+   * Whether this Token object is valid. All methods will throw if it's not.
    *
-   * ## Portability notes: Invalid token is the equivalent of nil in the iOS
-   * token implementation. We use value instead of pointer for Token instance in
-   * the C++ migration.
+   * ## Portability notes: An invalid Token is the equivalent of nil in the
+   * iOS token implementation. We use value instead of pointer for Token
+   * instances in the C++ migration.
    */
   bool is_valid() const {
     return is_valid_;
   }
 
-  /** Returns an invalid token. */
+  /** Returns an invalid Token. */
   static const Token& Invalid();
 
  private:

--- a/Firestore/core/src/firebase/firestore/util/string_apple.h
+++ b/Firestore/core/src/firebase/firestore/util/string_apple.h
@@ -23,6 +23,7 @@
 #import <Foundation/Foundation.h>
 
 #include "absl/strings/string_view.h"
+#include "Firestore/core/src/firebase/firestore/util/firebase_assert.h"
 
 namespace firebase {
 namespace firestore {
@@ -53,6 +54,9 @@ inline NSString* WrapNSString(const absl::string_view str) {
 // Creates an absl::string_view wrapper for the contents of the given
 // NSString.
 inline absl::string_view MakeStringView(NSString* str) {
+  // Avoid creating nullptr string_views since it's undefined behavior once
+  // we assign it to an std::string (https://stackoverflow.com/a/10771938).
+  FIREBASE_ASSERT(str != nil);
   return absl::string_view(
       [str UTF8String], [str lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
 }

--- a/Firestore/core/test/firebase/firestore/auth/token_test.cc
+++ b/Firestore/core/test/firebase/firestore/auth/token_test.cc
@@ -32,7 +32,7 @@ TEST(Token, Getter) {
 TEST(Token, InvalidToken) {
   const Token& token = Token::Invalid();
   EXPECT_ANY_THROW(token.token());
-  EXPECT_EQ(User::Unauthenticated(), token.user());
+  EXPECT_ANY_THROW(token.user());
   EXPECT_FALSE(token.is_valid());
 }
 


### PR DESCRIPTION
I'm not completely sure what the intention was but it seems like in the C++ port we ended up conflating nil GetTokenResult objects (when getToken() results in an error) with nil token strings inside a valid GetTokenResult object (for unauthenticated users). Additionally we were creating absl::string_views wrapping a nullptr in some cases, which seems to be questionable (https://stackoverflow.com/a/10771938)?

I've taken a stab at fixing this by:
1. Only using Token::Invalid() when getToken() results in an error.
2. Using a (valid) Token containing token="" for unauthenticated users.

I'm not sure if this is the best fix (not sure how we're deciding to deal with null things in C++), and it's not the most minimal fix, but it at least hopefully demonstrates the issue so we can decide how we actually want to fix it.

FYI- This commit is based off the 4.10.0 tag currently and won't merge cleanly to master.