### PR TITLE
Copy all C++ strings to NSString where they're not obviously safe

### DIFF
--- a/Firestore/Source/Local/FSTLevelDBMutationQueue.mm
+++ b/Firestore/Source/Local/FSTLevelDBMutationQueue.mm
@@ -94,7 +94,7 @@ static ReadOptions StandardReadOptions() {
 + (instancetype)mutationQueueWithUser:(const User &)user
                                    db:(std::shared_ptr<DB>)db
                            serializer:(FSTLocalSerializer *)serializer {
-  NSString *userID = user.is_authenticated() ? util::WrapNSStringNoCopy(user.uid()) : @"";
+  NSString *userID = user.is_authenticated() ? util::WrapNSString(user.uid()) : @"";
 
   return [[FSTLevelDBMutationQueue alloc] initWithUserID:userID db:db serializer:serializer];
 }
@@ -103,7 +103,7 @@ static ReadOptions StandardReadOptions() {
                             db:(std::shared_ptr<DB>)db
                     serializer:(FSTLocalSerializer *)serializer {
   if (self = [super init]) {
-    _userID = userID;
+    _userID = [userID copy];
     _db = db;
     _serializer = serializer;
   }

--- a/Firestore/Source/Remote/FSTDatastore.mm
+++ b/Firestore/Source/Remote/FSTDatastore.mm
@@ -92,7 +92,7 @@ typedef GRPCProtoCall * (^RPCFactory)(void);
                          credentials:(id<FSTCredentialsProvider>)credentials {
   if (self = [super init]) {
     _databaseInfo = databaseInfo;
-    NSString *host = util::WrapNSStringNoCopy(databaseInfo->host());
+    NSString *host = util::WrapNSString(databaseInfo->host());
     if (!databaseInfo->ssl_enabled()) {
       GRPCHost *hostConfig = [GRPCHost hostWithAddress:host];
       hostConfig.secure = NO;

--- a/Firestore/Source/Remote/FSTSerializerBeta.mm
+++ b/Firestore/Source/Remote/FSTSerializerBeta.mm
@@ -149,8 +149,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (FSTResourcePath *)encodedResourcePathForDatabaseID:(const DatabaseId *)databaseID {
   return [FSTResourcePath pathWithSegments:@[
-    @"projects", util::WrapNSStringNoCopy(databaseID->project_id()), @"databases",
-    util::WrapNSStringNoCopy(databaseID->database_id())
+    @"projects", util::WrapNSString(databaseID->project_id()), @"databases",
+    util::WrapNSString(databaseID->database_id())
   ]];
 }
 

--- a/Firestore/Source/Remote/FSTStream.mm
+++ b/Firestore/Source/Remote/FSTStream.mm
@@ -629,7 +629,7 @@ static const NSTimeInterval kIdleTimeout = 60.0;
 }
 
 - (GRPCCall *)createRPCWithRequestsWriter:(GRXWriter *)requestsWriter {
-  return [[GRPCCall alloc] initWithHost:util::WrapNSStringNoCopy(self.databaseInfo->host())
+  return [[GRPCCall alloc] initWithHost:util::WrapNSString(self.databaseInfo->host())
                                    path:@"/google.firestore.v1beta1.Firestore/Listen"
                          requestsWriter:requestsWriter];
 }
@@ -714,7 +714,7 @@ static const NSTimeInterval kIdleTimeout = 60.0;
 }
 
 - (GRPCCall *)createRPCWithRequestsWriter:(GRXWriter *)requestsWriter {
-  return [[GRPCCall alloc] initWithHost:util::WrapNSStringNoCopy(self.databaseInfo->host())
+  return [[GRPCCall alloc] initWithHost:util::WrapNSString(self.databaseInfo->host())
                                    path:@"/google.firestore.v1beta1.Firestore/Write"
                          requestsWriter:requestsWriter];
 }


### PR DESCRIPTION
This fixes a known instance of memory corruption where in
FSTLevelDBMutationQueue, the NSString view was retained for later, and
the incorrect user was used, causing b/74381054.

gRPC does not necessarily copy its string arguments and if our hostname
were configured to a non-default one it's possible that we could corrupt
the host cache too.

All remaining usages of util::WrapNSStringNoCopy are obviously safe:
passed into logging or other known transient usages.