### PR TITLE
Cpp/fix auth token string nocopy

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -4,6 +4,13 @@
   "offline", causing getDocument() calls to resolve with cached results, rather
   than continuing to wait.
 
+# v0.10.3
+- [fixed] Fixed a regression in the 4.10.0 Firebase iOS SDK release that
+  prevented the SDK from communicating with the backend before successfully
+  authenticating via Firebase Authentication or after unauthenticating and
+  re-authenticating. Reads and writes would silently be executed locally
+  but not sent to the backend.
+
 # v0.10.2
 - [changed] When you delete a FirebaseApp, the associated Firestore instances
   are now also deleted (#683).

--- a/Firestore/Source/Local/FSTLevelDBMutationQueue.mm
+++ b/Firestore/Source/Local/FSTLevelDBMutationQueue.mm
@@ -94,7 +94,7 @@ static ReadOptions StandardReadOptions() {
 + (instancetype)mutationQueueWithUser:(const User &)user
                                    db:(std::shared_ptr<DB>)db
                            serializer:(FSTLocalSerializer *)serializer {
-  NSString *userID = user.is_authenticated() ? util::WrapNSStringNoCopy(user.uid()) : @"";
+  NSString *userID = user.is_authenticated() ? util::WrapNSString(user.uid()) : @"";
 
   return [[FSTLevelDBMutationQueue alloc] initWithUserID:userID db:db serializer:serializer];
 }
@@ -103,7 +103,7 @@ static ReadOptions StandardReadOptions() {
                             db:(std::shared_ptr<DB>)db
                     serializer:(FSTLocalSerializer *)serializer {
   if (self = [super init]) {
-    _userID = userID;
+    _userID = [userID copy];
     _db = db;
     _serializer = serializer;
   }

--- a/Firestore/Source/Remote/FSTDatastore.mm
+++ b/Firestore/Source/Remote/FSTDatastore.mm
@@ -319,7 +319,8 @@ typedef GRPCProtoCall * (^RPCFactory)(void);
             [FSTDatastore
                 prepareHeadersForRPC:rpc
                           databaseID:&self.databaseInfo->database_id()
-                               token:(result.is_valid() ? result.token() : absl::string_view())];
+                               token:(result.user().is_authenticated() ? result.token()
+                                                                       : absl::string_view())];
             [rpc start];
           }
         }];

--- a/Firestore/Source/Remote/FSTDatastore.mm
+++ b/Firestore/Source/Remote/FSTDatastore.mm
@@ -97,7 +97,7 @@ typedef GRPCProtoCall * (^RPCFactory)(void);
                          credentials:(CredentialsProvider *)credentials {
   if (self = [super init]) {
     _databaseInfo = databaseInfo;
-    NSString *host = util::WrapNSStringNoCopy(databaseInfo->host());
+    NSString *host = util::WrapNSString(databaseInfo->host());
     if (!databaseInfo->ssl_enabled()) {
       GRPCHost *hostConfig = [GRPCHost hostWithAddress:host];
       hostConfig.secure = NO;

--- a/Firestore/Source/Remote/FSTSerializerBeta.mm
+++ b/Firestore/Source/Remote/FSTSerializerBeta.mm
@@ -152,8 +152,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (FSTResourcePath *)encodedResourcePathForDatabaseID:(const DatabaseId *)databaseID {
   return [FSTResourcePath pathWithSegments:@[
-    @"projects", util::WrapNSStringNoCopy(databaseID->project_id()), @"databases",
-    util::WrapNSStringNoCopy(databaseID->database_id())
+    @"projects", util::WrapNSString(databaseID->project_id()), @"databases",
+    util::WrapNSString(databaseID->database_id())
   ]];
 }
 

--- a/Firestore/Source/Remote/FSTStream.mm
+++ b/Firestore/Source/Remote/FSTStream.mm
@@ -297,9 +297,10 @@ static const NSTimeInterval kIdleTimeout = 60.0;
   _rpc = [self createRPCWithRequestsWriter:self.requestsWriter];
   [_rpc setResponseDispatchQueue:self.workerDispatchQueue.queue];
 
-  [FSTDatastore prepareHeadersForRPC:_rpc
-                          databaseID:&self.databaseInfo->database_id()
-                               token:(token.is_valid() ? token.token() : absl::string_view())];
+  [FSTDatastore
+      prepareHeadersForRPC:_rpc
+                databaseID:&self.databaseInfo->database_id()
+                     token:(token.user().is_authenticated() ? token.token() : absl::string_view())];
   FSTAssert(_callbackFilter == nil, @"GRX Filter must be nil");
   _callbackFilter = [[FSTCallbackFilter alloc] initWithStream:self];
   [_rpc startWithWriteable:_callbackFilter];

--- a/Firestore/Source/Remote/FSTStream.mm
+++ b/Firestore/Source/Remote/FSTStream.mm
@@ -632,7 +632,7 @@ static const NSTimeInterval kIdleTimeout = 60.0;
 }
 
 - (GRPCCall *)createRPCWithRequestsWriter:(GRXWriter *)requestsWriter {
-  return [[GRPCCall alloc] initWithHost:util::WrapNSStringNoCopy(self.databaseInfo->host())
+  return [[GRPCCall alloc] initWithHost:util::WrapNSString(self.databaseInfo->host())
                                    path:@"/google.firestore.v1beta1.Firestore/Listen"
                          requestsWriter:requestsWriter];
 }
@@ -717,7 +717,7 @@ static const NSTimeInterval kIdleTimeout = 60.0;
 }
 
 - (GRPCCall *)createRPCWithRequestsWriter:(GRXWriter *)requestsWriter {
-  return [[GRPCCall alloc] initWithHost:util::WrapNSStringNoCopy(self.databaseInfo->host())
+  return [[GRPCCall alloc] initWithHost:util::WrapNSString(self.databaseInfo->host())
                                    path:@"/google.firestore.v1beta1.Firestore/Write"
                          requestsWriter:requestsWriter];
 }


### PR DESCRIPTION
Patch of fix #893 and #890 to master

* Copy all C++ strings to NSString where they're not obviously safe.
* Minimal fix for b/74357976.