### PR TITLE
Eliminate redundant gtest dependency.

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -53,12 +53,12 @@ endfunction()
 # )
 #
 # Defines a new test executable target with the given target name, sources, and
-# dependencies.  Implicitly adds DEPENDS on GTest::GTest and GTest::Main.
+# dependencies.  Implicitly adds DEPENDS on GTest::Main.
 function(cc_test name)
   set(multi DEPENDS SOURCES)
   cmake_parse_arguments(cct "" "" "${multi}" ${ARGN})
 
-  list(APPEND cct_DEPENDS GTest::GTest GTest::Main)
+  list(APPEND cct_DEPENDS GTest::Main)
 
   add_executable(${name} ${cct_SOURCES})
   add_objc_flags(${name} cct)


### PR DESCRIPTION
googletest/CMakeLists.txt (which defines the gtest and gtest_main target
libraries) suggests that 'User tests should link with one of them'.