### PR TITLE
Move core/types.h to model to prevent dependency cycle

### DIFF
--- a/Firestore/core/src/firebase/firestore/core/target_id_generator.cc
+++ b/Firestore/core/src/firebase/firestore/core/target_id_generator.cc
@@ -16,6 +16,8 @@
 
 #include "Firestore/core/src/firebase/firestore/core/target_id_generator.h"
 
+using firebase::firestore::model::TargetId;
+
 namespace firebase {
 namespace firestore {
 namespace core {

--- a/Firestore/core/src/firebase/firestore/core/target_id_generator.h
+++ b/Firestore/core/src/firebase/firestore/core/target_id_generator.h
@@ -17,7 +17,7 @@
 #ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_TARGET_ID_GENERATOR_H_
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_TARGET_ID_GENERATOR_H_
 
-#include "Firestore/core/src/firebase/firestore/core/types.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 namespace firebase {
 namespace firestore {
@@ -48,7 +48,7 @@ class TargetIdGenerator {
    * @param after An ID to start at. Every call to NextId returns a larger id.
    * @return An instance of TargetIdGenerator.
    */
-  static TargetIdGenerator LocalStoreTargetIdGenerator(TargetId after) {
+  static TargetIdGenerator LocalStoreTargetIdGenerator(model::TargetId after) {
     return TargetIdGenerator(TargetIdGeneratorId::LocalStore, after);
   }
 
@@ -58,7 +58,7 @@ class TargetIdGenerator {
    * @param after An ID to start at. Every call to NextId returns a larger id.
    * @return An instance of TargetIdGenerator.
    */
-  static TargetIdGenerator SyncEngineTargetIdGenerator(TargetId after) {
+  static TargetIdGenerator SyncEngineTargetIdGenerator(model::TargetId after) {
     return TargetIdGenerator(TargetIdGeneratorId::SyncEngine, after);
   }
 
@@ -66,12 +66,12 @@ class TargetIdGenerator {
     return generator_id_;
   }
 
-  TargetId NextId();
+  model::TargetId NextId();
 
  private:
-  TargetIdGenerator(TargetIdGeneratorId generator_id, TargetId after);
+  TargetIdGenerator(TargetIdGeneratorId generator_id, model::TargetId after);
   TargetIdGeneratorId generator_id_;
-  TargetId previous_id_;
+  model::TargetId previous_id_;
 
   static const int kReservedBits = 1;
 };

--- a/Firestore/core/src/firebase/firestore/model/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/model/CMakeLists.txt
@@ -36,6 +36,7 @@ cc_library(
     snapshot_version.h
     timestamp.cc
     timestamp.h
+    types.h
   DEPENDS
     absl_strings
     firebase_firestore_util

--- a/Firestore/core/src/firebase/firestore/model/types.h
+++ b/Firestore/core/src/firebase/firestore/model/types.h
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_TYPES_H_
-#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_TYPES_H_
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_MODEL_TYPES_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_MODEL_TYPES_H_
 
 #include <stdint.h>
 
 namespace firebase {
 namespace firestore {
-namespace core {
+namespace model {
 
 typedef int32_t TargetId;
 
-}  // namespace core
+}  // namespace model
 }  // namespace firestore
 }  // namespace firebase
 
-#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_TYPES_H_
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_MODEL_TYPES_H_


### PR DESCRIPTION
This prevents a core -> local -> core dependency