### PR TITLE
Adds exception for invalid parameter

### DIFF
--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -104,6 +104,14 @@ static NSString *const kUserKey = @"%@_firebase_user";
 static NSString *const kMissingEmailInvalidParameterExceptionReason =
     @"The email used to initiate password reset cannot be nil.";
 
+/** @var kHandleCodeInAppFalseExceptionReason
+    @brief The reason for @c invalidParameterException when the handleCodeInApp parameter is false
+        on the ActionCodeSettings object used to send the link for Email-link Authentication.
+ */
+static NSString *const kHandleCodeInAppFalseExceptionReason =
+    @"You must set handleCodeInApp in your ActionCodeSettings to true for Email-link "
+    "Authentication.";
+
 /** @var kPasswordResetRequestType
     @brief The action code type value for resetting password in the check action code response.
  */
@@ -1107,6 +1115,11 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
     if (!email) {
       [FIRAuthExceptionUtils raiseInvalidParameterExceptionWithReason:
           kMissingEmailInvalidParameterExceptionReason];
+    }
+
+    if (!actionCodeSettings.handleCodeInApp) {
+      [FIRAuthExceptionUtils raiseInvalidParameterExceptionWithReason:
+          kHandleCodeInAppFalseExceptionReason];
     }
     FIRGetOOBConfirmationCodeRequest *request =
         [FIRGetOOBConfirmationCodeRequest signInWithEmailLinkRequest:email

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -97,6 +97,9 @@ files=$(
     find . -type f
   fi
 ) | sed -E -n '
+# find . includes a leading "./" that git does not include
+s%^./%%
+
 # Build outputs
 \%/Pods/% d
 \%^./build/% d
@@ -114,7 +117,7 @@ files=$(
 \%/vendor/bundle/% d
 
 # Sources within the tree that are not subject to formatting
-\%^./(Example|Firebase)/(Auth|AuthSamples|Database|Messaging)/% d
+\%^(Example|Firebase)/(Auth|AuthSamples|Database|Messaging)/% d
 
 # Checked-in generated code
 \%\.pb(objc|rpc)\.% d


### PR DESCRIPTION
Adds exception for invalid parameter when handleCodeInApp is not set to true, because an authentication action should always be handled in the app.