### PR TITLE
Change CredentialsProvider::TokenListener to use StatusOr<Token>

### DIFF
--- a/Firestore/Source/Remote/FSTDatastore.mm
+++ b/Firestore/Source/Remote/FSTDatastore.mm
@@ -306,10 +306,9 @@ typedef GRPCProtoCall * (^RPCFactory)(void);
   // but I'm not sure how to detect that right now. http://b/32762461
   _credentials->GetToken(
       /*force_refresh=*/false, [self, rpcFactory, errorHandler](util::StatusOr<Token> result) {
-        NSError *error = util::WrapNSError(result.status());
         [self.workerDispatchQueue dispatchAsyncAllowingSameQueue:^{
-          if (error) {
-            errorHandler(error);
+          if (!result.ok()) {
+            errorHandler(util::MakeNSError(result.status()));
           } else {
             GRPCProtoCall *rpc = rpcFactory();
             const Token &token = result.ValueOrDie();

--- a/Firestore/Source/Remote/FSTDatastore.mm
+++ b/Firestore/Source/Remote/FSTDatastore.mm
@@ -305,20 +305,19 @@ typedef GRPCProtoCall * (^RPCFactory)(void);
   // TODO(mikelehen): We should force a refresh if the previous RPC failed due to an expired token,
   // but I'm not sure how to detect that right now. http://b/32762461
   _credentials->GetToken(
-      /*force_refresh=*/false,
-      [self, rpcFactory, errorHandler](Token result, const int64_t error_code,
-                                       const absl::string_view error_msg) {
-        NSError *error = util::WrapNSError(error_code, error_msg);
+      /*force_refresh=*/false, [self, rpcFactory, errorHandler](util::StatusOr<Token> result) {
+        NSError *error = util::WrapNSError(result.status());
         [self.workerDispatchQueue dispatchAsyncAllowingSameQueue:^{
           if (error) {
             errorHandler(error);
           } else {
             GRPCProtoCall *rpc = rpcFactory();
+            const Token &token = result.ValueOrDie();
             [FSTDatastore
                 prepareHeadersForRPC:rpc
                           databaseID:&self.databaseInfo->database_id()
-                               token:(result.user().is_authenticated() ? result.token()
-                                                                       : absl::string_view())];
+                               token:(token.user().is_authenticated() ? token.token()
+                                                                      : absl::string_view())];
             [rpc start];
           }
         }];

--- a/Firestore/Source/Remote/FSTStream.mm
+++ b/Firestore/Source/Remote/FSTStream.mm
@@ -265,17 +265,15 @@ static const NSTimeInterval kIdleTimeout = 60.0;
   _delegate = delegate;
 
   _credentials->GetToken(
-      /*force_refresh=*/false,
-      [self](Token result, const int64_t error_code, const absl::string_view error_msg) {
-        NSError *error = util::WrapNSError(error_code, error_msg);
+      /*force_refresh=*/false, [self](util::StatusOr<Token> result) {
         [self.workerDispatchQueue dispatchAsyncAllowingSameQueue:^{
-          [self resumeStartWithToken:result error:error];
+          [self resumeStartWithToken:result];
         }];
       });
 }
 
 /** Add an access token to our RPC, after obtaining one from the credentials provider. */
-- (void)resumeStartWithToken:(const Token &)token error:(NSError *)error {
+- (void)resumeStartWithToken:(const util::StatusOr<Token> &)result {
   [self.workerDispatchQueue verifyIsCurrentQueue];
 
   if (self.state == FSTStreamStateStopped) {
@@ -287,9 +285,9 @@ static const NSTimeInterval kIdleTimeout = 60.0;
 
   // TODO(mikelehen): We should force a refresh if the previous RPC failed due to an expired token,
   // but I'm not sure how to detect that right now. http://b/32762461
-  if (error) {
+  if (!result.ok()) {
     // RPC has not been started yet, so just invoke higher-level close handler.
-    [self handleStreamClose:error];
+    [self handleStreamClose:util::WrapNSError(result.status())];
     return;
   }
 
@@ -297,6 +295,7 @@ static const NSTimeInterval kIdleTimeout = 60.0;
   _rpc = [self createRPCWithRequestsWriter:self.requestsWriter];
   [_rpc setResponseDispatchQueue:self.workerDispatchQueue.queue];
 
+  const Token &token = result.ValueOrDie();
   [FSTDatastore
       prepareHeadersForRPC:_rpc
                 databaseID:&self.databaseInfo->database_id()

--- a/Firestore/Source/Remote/FSTStream.mm
+++ b/Firestore/Source/Remote/FSTStream.mm
@@ -287,7 +287,7 @@ static const NSTimeInterval kIdleTimeout = 60.0;
   // but I'm not sure how to detect that right now. http://b/32762461
   if (!result.ok()) {
     // RPC has not been started yet, so just invoke higher-level close handler.
-    [self handleStreamClose:util::WrapNSError(result.status())];
+    [self handleStreamClose:util::MakeNSError(result.status())];
     return;
   }
 

--- a/Firestore/core/src/firebase/firestore/auth/credentials_provider.h
+++ b/Firestore/core/src/firebase/firestore/auth/credentials_provider.h
@@ -23,6 +23,7 @@
 #include "Firestore/core/include/firebase/firestore/firestore_errors.h"
 #include "Firestore/core/src/firebase/firestore/auth/token.h"
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
+#include "Firestore/core/src/firebase/firestore/util/statusor.h"
 #include "absl/strings/string_view.h"
 
 namespace firebase {
@@ -30,12 +31,7 @@ namespace firestore {
 namespace auth {
 
 // `TokenErrorListener` is a listener that gets a token or an error.
-// token: An auth token as a string, or nullptr if error occurred.
-// error_code: The error code if one occurred, or else FirestoreErrorCode::Ok.
-// error_msg: The error if one occurred, or else nullptr.
-typedef std::function<void(
-    Token token, const int64_t error_code, const absl::string_view error_msg)>
-    TokenListener;
+typedef std::function<void(util::StatusOr<Token>)> TokenListener;
 
 // Listener notified with a User change.
 typedef std::function<void(User user)> UserChangeListener;

--- a/Firestore/core/src/firebase/firestore/auth/empty_credentials_provider.cc
+++ b/Firestore/core/src/firebase/firestore/auth/empty_credentials_provider.cc
@@ -27,7 +27,7 @@ void EmptyCredentialsProvider::GetToken(bool force_refresh,
   UNUSED(force_refresh);
   if (completion) {
     // Invalid token will force the GRPC fallback to use default settings.
-    completion(Token::Invalid(), FirestoreErrorCode::Ok, "");
+    completion(Token::Invalid());
   }
 }
 

--- a/Firestore/core/src/firebase/firestore/auth/empty_credentials_provider.cc
+++ b/Firestore/core/src/firebase/firestore/auth/empty_credentials_provider.cc
@@ -26,7 +26,8 @@ void EmptyCredentialsProvider::GetToken(bool force_refresh,
                                         TokenListener completion) {
   UNUSED(force_refresh);
   if (completion) {
-    // Unauthenticated token will force the GRPC fallback to use default settings.
+    // Unauthenticated token will force the GRPC fallback to use default
+    // settings.
     completion(Token::Unauthenticated());
   }
 }

--- a/Firestore/core/src/firebase/firestore/auth/empty_credentials_provider.cc
+++ b/Firestore/core/src/firebase/firestore/auth/empty_credentials_provider.cc
@@ -26,8 +26,8 @@ void EmptyCredentialsProvider::GetToken(bool force_refresh,
                                         TokenListener completion) {
   UNUSED(force_refresh);
   if (completion) {
-    // Invalid token will force the GRPC fallback to use default settings.
-    completion(Token::Invalid());
+    // Unauthenticated token will force the GRPC fallback to use default settings.
+    completion(Token::Unauthenticated());
   }
 }
 

--- a/Firestore/core/src/firebase/firestore/auth/firebase_credentials_provider_apple.mm
+++ b/Firestore/core/src/firebase/firestore/auth/firebase_credentials_provider_apple.mm
@@ -87,38 +87,38 @@ void FirebaseCredentialsProvider::GetToken(bool force_refresh,
   int initial_user_counter = contents_->user_counter;
 
   std::weak_ptr<Contents> weak_contents = contents_;
-  void (^get_token_callback)(NSString*, NSError*) = ^(
-      NSString* _Nullable token, NSError* _Nullable error) {
-    std::shared_ptr<Contents> contents = weak_contents.lock();
-    if (!contents) {
-      return;
-    }
+  void (^get_token_callback)(NSString*, NSError*) =
+      ^(NSString* _Nullable token, NSError* _Nullable error) {
+        std::shared_ptr<Contents> contents = weak_contents.lock();
+        if (!contents) {
+          return;
+        }
 
-    std::unique_lock<std::mutex> lock(contents->mutex);
-    if (initial_user_counter != contents->user_counter) {
-      // Cancel the request since the user changed while the request was
-      // outstanding so the response is likely for a previous user (which
-      // user, we can't be sure).
-      completion(util::Status(FirestoreErrorCode::Aborted,
-                              "getToken aborted due to user change."));
-    } else {
-      if (error == nil) {
-        if (token != nil) {
-          completion(Token{util::MakeStringView(token), contents->current_user});
+        std::unique_lock<std::mutex> lock(contents->mutex);
+        if (initial_user_counter != contents->user_counter) {
+          // Cancel the request since the user changed while the request was
+          // outstanding so the response is likely for a previous user (which
+          // user, we can't be sure).
+          completion(util::Status(FirestoreErrorCode::Aborted,
+                                  "getToken aborted due to user change."));
         } else {
-          completion(Token::Unauthenticated());
+          if (error == nil) {
+            if (token != nil) {
+              completion(
+                  Token{util::MakeStringView(token), contents->current_user});
+            } else {
+              completion(Token::Unauthenticated());
+            }
+          } else {
+            FirestoreErrorCode error_code = FirestoreErrorCode::Unknown;
+            if (error.domain == FIRFirestoreErrorDomain) {
+              error_code = static_cast<FirestoreErrorCode>(error.code);
+            }
+            completion(util::Status(
+                error_code, util::MakeStringView(error.localizedDescription)));
+          }
         }
-      } else {
-        FirestoreErrorCode error_code = FirestoreErrorCode::Unknown;
-        if (error.domain == FIRFirestoreErrorDomain) {
-          error_code = static_cast<FirestoreErrorCode>(error.code);
-        }
-        completion(
-            util::Status(error_code,
-                         util::MakeStringView(error.localizedDescription)));
-      }
-    }
-  };
+      };
 
   [contents_->app getTokenForcingRefresh:force_refresh
                             withCallback:get_token_callback];

--- a/Firestore/core/src/firebase/firestore/auth/firebase_credentials_provider_apple.mm
+++ b/Firestore/core/src/firebase/firestore/auth/firebase_credentials_provider_apple.mm
@@ -103,14 +103,18 @@ void FirebaseCredentialsProvider::GetToken(bool force_refresh,
                               "getToken aborted due to user change."));
     } else {
       if (error == nil) {
-        completion(Token{util::MakeStringView(token), contents->current_user});
+        if (token != nil) {
+          completion(Token{util::MakeStringView(token), contents->current_user});
+        } else {
+          completion(Token::Unauthenticated());
+        }
       } else {
         FirestoreErrorCode error_code = FirestoreErrorCode::Unknown;
         if (error.domain == FIRFirestoreErrorDomain) {
           error_code = static_cast<FirestoreErrorCode>(error.code);
         }
         completion(
-            util::Status(FirestoreErrorCode::Unknown,
+            util::Status(error_code,
                          util::MakeStringView(error.localizedDescription)));
       }
     }

--- a/Firestore/core/src/firebase/firestore/auth/token.cc
+++ b/Firestore/core/src/firebase/firestore/auth/token.cc
@@ -25,7 +25,8 @@ Token::Token(const absl::string_view token, const User& user)
 }
 
 const Token& Token::Unauthenticated() {
-  static const Token kUnauthenticatedToken(absl::string_view(), User::Unauthenticated());
+  static const Token kUnauthenticatedToken(absl::string_view(),
+                                           User::Unauthenticated());
   return kUnauthenticatedToken;
 }
 

--- a/Firestore/core/src/firebase/firestore/auth/token.cc
+++ b/Firestore/core/src/firebase/firestore/auth/token.cc
@@ -21,15 +21,15 @@ namespace firestore {
 namespace auth {
 
 Token::Token(const absl::string_view token, const User& user)
-    : token_(token), user_(user), is_valid_(true) {
+    : token_(token), user_(user) {
 }
 
-Token::Token() : token_(), user_(User::Unauthenticated()), is_valid_(false) {
+Token::Token() : token_(), user_(User::Unauthenticated()) {
 }
 
-const Token& Token::Invalid() {
-  static const Token kInvalidToken;
-  return kInvalidToken;
+const Token& Token::Unauthenticated() {
+  static const Token kUnauthenticatedToken;
+  return kUnauthenticatedToken;
 }
 
 }  // namespace auth

--- a/Firestore/core/src/firebase/firestore/auth/token.cc
+++ b/Firestore/core/src/firebase/firestore/auth/token.cc
@@ -24,11 +24,8 @@ Token::Token(const absl::string_view token, const User& user)
     : token_(token), user_(user) {
 }
 
-Token::Token() : token_(), user_(User::Unauthenticated()) {
-}
-
 const Token& Token::Unauthenticated() {
-  static const Token kUnauthenticatedToken;
+  static const Token kUnauthenticatedToken(absl::string_view(), User::Unauthenticated());
   return kUnauthenticatedToken;
 }
 

--- a/Firestore/core/src/firebase/firestore/auth/token.h
+++ b/Firestore/core/src/firebase/firestore/auth/token.h
@@ -58,12 +58,16 @@ class Token {
     return user_;
   }
 
-  /** Returns a token for an unauthenticated user. */
+  /**
+   * Returns a token for an unauthenticated user.
+   *
+   * ## Portability notes: An unauthenticated token is the equivalent of
+   * nil/null in the iOS/TypeScript token implementation. We use a reference
+   * instead of a pointer for Token instances in the C++ migration.
+   */
   static const Token& Unauthenticated();
 
  private:
-  Token();
-
   const std::string token_;
   const User user_;
 };

--- a/Firestore/core/src/firebase/firestore/auth/token.h
+++ b/Firestore/core/src/firebase/firestore/auth/token.h
@@ -46,7 +46,7 @@ class Token {
 
   /** The actual raw token. */
   const std::string& token() const {
-    FIREBASE_ASSERT(is_valid_);
+    FIREBASE_ASSERT(user_.is_authenticated());
     return token_;
   }
 
@@ -58,26 +58,14 @@ class Token {
     return user_;
   }
 
-  /**
-   * Whether the token is a valid one.
-   *
-   * ## Portability notes: Invalid token is the equivalent of nil in the iOS
-   * token implementation. We use value instead of pointer for Token instance in
-   * the C++ migration.
-   */
-  bool is_valid() const {
-    return is_valid_;
-  }
-
-  /** Returns an invalid token. */
-  static const Token& Invalid();
+  /** Returns a token for an unauthenticated user. */
+  static const Token& Unauthenticated();
 
  private:
   Token();
 
   const std::string token_;
   const User user_;
-  const bool is_valid_;
 };
 
 }  // namespace auth

--- a/Firestore/core/src/firebase/firestore/util/error_apple.h
+++ b/Firestore/core/src/firebase/firestore/util/error_apple.h
@@ -24,6 +24,7 @@
 
 #include "Firestore/Source/Public/FIRFirestoreErrors.h"  // for FIRFirestoreErrorDomain
 #include "Firestore/core/include/firebase/firestore/firestore_errors.h"
+#include "Firestore/core/src/firebase/firestore/util/status.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 #include "absl/strings/string_view.h"
 
@@ -41,6 +42,10 @@ inline NSError* WrapNSError(const int64_t error_code,
       errorWithDomain:FIRFirestoreErrorDomain
                  code:error_code
              userInfo:@{NSLocalizedDescriptionKey : WrapNSString(error_msg)}];
+}
+
+inline NSError* WrapNSError(const util::Status& status) {
+  return WrapNSError(status.code(), status.error_message());
 }
 
 }  // namespace util

--- a/Firestore/core/src/firebase/firestore/util/error_apple.h
+++ b/Firestore/core/src/firebase/firestore/util/error_apple.h
@@ -33,7 +33,7 @@ namespace firestore {
 namespace util {
 
 // Translates a set of error_code and error_msg to an NSError.
-inline NSError* WrapNSError(const int64_t error_code,
+inline NSError* MakeNSError(const int64_t error_code,
                             const absl::string_view error_msg) {
   if (error_code == FirestoreErrorCode::Ok) {
     return nil;
@@ -44,8 +44,8 @@ inline NSError* WrapNSError(const int64_t error_code,
              userInfo:@{NSLocalizedDescriptionKey : WrapNSString(error_msg)}];
 }
 
-inline NSError* WrapNSError(const util::Status& status) {
-  return WrapNSError(status.code(), status.error_message());
+inline NSError* MakeNSError(const util::Status& status) {
+  return MakeNSError(status.code(), status.error_message());
 }
 
 }  // namespace util

--- a/Firestore/core/test/firebase/firestore/auth/credentials_provider_test.cc
+++ b/Firestore/core/test/firebase/firestore/auth/credentials_provider_test.cc
@@ -16,6 +16,7 @@
 
 #include "Firestore/core/src/firebase/firestore/auth/credentials_provider.h"
 
+#include "Firestore/core/src/firebase/firestore/util/statusor.h"
 #include "gtest/gtest.h"
 
 namespace firebase {
@@ -25,11 +26,8 @@ namespace auth {
 #define UNUSED(x) (void)(x)
 
 TEST(CredentialsProvider, Typedef) {
-  TokenListener token_listener = [](Token token, const int64_t error_code,
-                                    const absl::string_view error_msg) {
+  TokenListener token_listener = [](util::StatusOr<Token> token) {
     UNUSED(token);
-    UNUSED(error_code);
-    UNUSED(error_msg);
   };
   EXPECT_NE(nullptr, token_listener);
   EXPECT_TRUE(token_listener);

--- a/Firestore/core/test/firebase/firestore/auth/empty_credentials_provider_test.cc
+++ b/Firestore/core/test/firebase/firestore/auth/empty_credentials_provider_test.cc
@@ -26,18 +26,13 @@ namespace auth {
 TEST(EmptyCredentialsProvider, GetToken) {
   EmptyCredentialsProvider credentials_provider;
   credentials_provider.GetToken(
-      /*force_refresh=*/true, [](util::StatusOr<Token> token) {
-        EXPECT_TRUE(token.ok());
-        EXPECT_FALSE(token.ValueOrDie().is_valid());
-        const User& user = token.ValueOrDie().user();
+      /*force_refresh=*/true, [](util::StatusOr<Token> result) {
+        EXPECT_TRUE(result.ok());
+        const Token& token = result.ValueOrDie();
+        EXPECT_ANY_THROW(token.token());
+        const User& user = result.ValueOrDie().user();
         EXPECT_EQ("", user.uid());
         EXPECT_FALSE(user.is_authenticated());
-        // TODO(rsgowman): the next two statements just test the implementation
-        // of StatusOr, so aren't useful here anymore. However, I'm keeping them
-        // for one more commit, since it will shortly not be possible for a
-        // StatusOr<Token> to be ok() while the token itself is not is_valid()
-        EXPECT_EQ(FirestoreErrorCode::Ok, token.status().code());
-        EXPECT_EQ("", token.status().error_message());
       });
 }
 

--- a/Firestore/core/test/firebase/firestore/auth/empty_credentials_provider_test.cc
+++ b/Firestore/core/test/firebase/firestore/auth/empty_credentials_provider_test.cc
@@ -30,7 +30,7 @@ TEST(EmptyCredentialsProvider, GetToken) {
         EXPECT_TRUE(result.ok());
         const Token& token = result.ValueOrDie();
         EXPECT_ANY_THROW(token.token());
-        const User& user = result.ValueOrDie().user();
+        const User& user = token.user();
         EXPECT_EQ("", user.uid());
         EXPECT_FALSE(user.is_authenticated());
       });

--- a/Firestore/core/test/firebase/firestore/auth/firebase_credentials_provider_test.mm
+++ b/Firestore/core/test/firebase/firestore/auth/firebase_credentials_provider_test.mm
@@ -20,6 +20,7 @@
 #import <FirebaseCore/FIRAppInternal.h>
 #import <FirebaseCore/FIROptionsInternal.h>
 
+#include "Firestore/core/src/firebase/firestore/util/statusor.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 #include "Firestore/core/test/firebase/firestore/testutil/app_testing.h"
 
@@ -42,14 +43,13 @@ TEST(FirebaseCredentialsProviderTest, GetTokenUnauthenticated) {
 
   FirebaseCredentialsProvider credentials_provider(app);
   credentials_provider.GetToken(
-      /*force_refresh=*/true, [](Token token, const int64_t error_code,
-                                 const absl::string_view error_msg) {
+      /*force_refresh=*/true, [](util::StatusOr<Token> result) {
+        EXPECT_TRUE(result.ok());
+        const Token& token = result.ValueOrDie();
         EXPECT_EQ("", token.token());
         const User& user = token.user();
         EXPECT_EQ("", user.uid());
         EXPECT_FALSE(user.is_authenticated());
-        EXPECT_EQ(FirestoreErrorCode::Ok, error_code) << error_code;
-        EXPECT_EQ("", error_msg) << error_msg;
       });
 }
 
@@ -58,14 +58,13 @@ TEST(FirebaseCredentialsProviderTest, GetToken) {
 
   FirebaseCredentialsProvider credentials_provider(app);
   credentials_provider.GetToken(
-      /*force_refresh=*/true, [](Token token, const int64_t error_code,
-                                 const absl::string_view error_msg) {
+      /*force_refresh=*/true, [](util::StatusOr<Token> result) {
+        EXPECT_TRUE(result.ok());
+        const Token& token = result.ValueOrDie();
         EXPECT_EQ("", token.token());
         const User& user = token.user();
         EXPECT_EQ("fake uid", user.uid());
         EXPECT_TRUE(user.is_authenticated());
-        EXPECT_EQ(FirestoreErrorCode::Ok, error_code) << error_code;
-        EXPECT_EQ("", error_msg) << error_msg;
       });
 }
 

--- a/Firestore/core/test/firebase/firestore/auth/firebase_credentials_provider_test.mm
+++ b/Firestore/core/test/firebase/firestore/auth/firebase_credentials_provider_test.mm
@@ -46,7 +46,7 @@ TEST(FirebaseCredentialsProviderTest, GetTokenUnauthenticated) {
       /*force_refresh=*/true, [](util::StatusOr<Token> result) {
         EXPECT_TRUE(result.ok());
         const Token& token = result.ValueOrDie();
-        EXPECT_EQ("", token.token());
+        EXPECT_ANY_THROW(token.token());
         const User& user = token.user();
         EXPECT_EQ("", user.uid());
         EXPECT_FALSE(user.is_authenticated());

--- a/Firestore/core/test/firebase/firestore/auth/firebase_credentials_provider_test.mm
+++ b/Firestore/core/test/firebase/firestore/auth/firebase_credentials_provider_test.mm
@@ -31,7 +31,8 @@ namespace firebase {
 namespace firestore {
 namespace auth {
 
-FIRApp* AppWithFakeUidAndToken(NSString* _Nullable uid, NSString* _Nullable token) {
+FIRApp* AppWithFakeUidAndToken(NSString* _Nullable uid,
+                               NSString* _Nullable token) {
   FIRApp* app = testutil::AppForUnitTesting();
   app.getUIDImplementation = ^NSString* {
     return uid;
@@ -45,7 +46,6 @@ FIRApp* AppWithFakeUidAndToken(NSString* _Nullable uid, NSString* _Nullable toke
 FIRApp* AppWithFakeUid(NSString* _Nullable uid) {
   return AppWithFakeUidAndToken(uid, uid == nil ? nil : @"default token");
 }
-
 
 TEST(FirebaseCredentialsProviderTest, GetTokenUnauthenticated) {
   FIRApp* app = AppWithFakeUid(nil);

--- a/Firestore/core/test/firebase/firestore/auth/token_test.cc
+++ b/Firestore/core/test/firebase/firestore/auth/token_test.cc
@@ -26,14 +26,12 @@ TEST(Token, Getter) {
   Token token("token", User("abc"));
   EXPECT_EQ("token", token.token());
   EXPECT_EQ(User("abc"), token.user());
-  EXPECT_TRUE(token.is_valid());
 }
 
-TEST(Token, InvalidToken) {
-  const Token& token = Token::Invalid();
+TEST(Token, UnauthenticatedToken) {
+  const Token& token = Token::Unauthenticated();
   EXPECT_ANY_THROW(token.token());
   EXPECT_EQ(User::Unauthenticated(), token.user());
-  EXPECT_FALSE(token.is_valid());
 }
 
 }  // namespace auth


### PR DESCRIPTION
Rather than a token plus error code/msg.

This eliminates the concept of an "invalid" token, though an unauthenticated token is still possible.