### PR TITLE
Fix FSTTimerID strings in spec tests to match constants used in web.

### DIFF
--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -335,11 +335,11 @@ static NSString *const kNoIOSTag = @"no-ios";
     timerID = FSTTimerIDAll;
   } else if ([timer isEqualToString:@"listen_stream_idle"]) {
     timerID = FSTTimerIDListenStreamIdle;
-  } else if ([timer isEqualToString:@"listen_stream_connection"]) {
+  } else if ([timer isEqualToString:@"listen_stream_connection_backoff"]) {
     timerID = FSTTimerIDListenStreamConnectionBackoff;
   } else if ([timer isEqualToString:@"write_stream_idle"]) {
     timerID = FSTTimerIDWriteStreamIdle;
-  } else if ([timer isEqualToString:@"write_stream_connection"]) {
+  } else if ([timer isEqualToString:@"write_stream_connection_backoff"]) {
     timerID = FSTTimerIDWriteStreamConnectionBackoff;
   } else if ([timer isEqualToString:@"online_state_timeout"]) {
     timerID = FSTTimerIDOnlineStateTimeout;


### PR DESCRIPTION
I renamed these during code review iterations but missed the string constants.  Fortunately we would have noticed when we actually used them in a spec test (the method would throw and fail the test).