### PR TITLE
[BREAKING] Remove FIR prefix on FIRFunctionsErrorCode

### DIFF
--- a/Functions/FirebaseFunctions/Public/FIRError.h
+++ b/Functions/FirebaseFunctions/Public/FIRError.h
@@ -86,6 +86,6 @@ typedef NS_ENUM(NSInteger, FIRFunctionsErrorCode) {
   FIRFunctionsErrorCodeDataLoss = 15,
   /** The request does not have valid authentication credentials for the operation. */
   FIRFunctionsErrorCodeUnauthenticated = 16,
-};
+} NS_SWIFT_NAME(FunctionsErrorCode);
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
[THIS IS A BREAKING CHANGE]

The `FIR` prefix should be removed from `FIRFunctionsErrorCode`. This does just that.