### PR TITLE
Add file I/O usage to Core documentation.

### DIFF
--- a/Firebase/Core/Public/FIRApp.h
+++ b/Firebase/Core/Public/FIRApp.h
@@ -52,7 +52,8 @@ NS_SWIFT_NAME(FirebaseApp)
 /**
  * Configures a default Firebase app. Raises an exception if any configuration step fails. The
  * default app is named "__FIRAPP_DEFAULT". This method should be called after the app is launched
- * and before using Firebase services. This method is thread safe.
+ * and before using Firebase services. This method is thread safe and contains synchronous file I/O
+ * (reading GoogleService-Info.plist from disk).
  */
 + (void)configure;
 

--- a/Firebase/Core/Public/FIROptions.h
+++ b/Firebase/Core/Public/FIROptions.h
@@ -25,7 +25,7 @@ NS_SWIFT_NAME(FirebaseOptions)
 @interface FIROptions : NSObject <NSCopying>
 
 /**
- * Returns the default options. The first time this is called it contains synchronously reads
+ * Returns the default options. The first time this is called it synchronously reads
  * GoogleService-Info.plist from disk.
  */
 + (nullable FIROptions *)defaultOptions NS_SWIFT_NAME(defaultOptions());

--- a/Firebase/Core/Public/FIROptions.h
+++ b/Firebase/Core/Public/FIROptions.h
@@ -25,8 +25,8 @@ NS_SWIFT_NAME(FirebaseOptions)
 @interface FIROptions : NSObject <NSCopying>
 
 /**
- * Returns the default options. This call contains synchronous file I/O (reading
- * GoogleService-Info.plist from disk).
+ * Returns the default options. The first time this is called it contains synchronously reads
+ * GoogleService-Info.plist from disk.
  */
 + (nullable FIROptions *)defaultOptions NS_SWIFT_NAME(defaultOptions());
 

--- a/Firebase/Core/Public/FIROptions.h
+++ b/Firebase/Core/Public/FIROptions.h
@@ -25,7 +25,8 @@ NS_SWIFT_NAME(FirebaseOptions)
 @interface FIROptions : NSObject <NSCopying>
 
 /**
- * Returns the default options.
+ * Returns the default options. This call contains synchronous file I/O (reading
+ * GoogleService-Info.plist from disk).
  */
 + (nullable FIROptions *)defaultOptions NS_SWIFT_NAME(defaultOptions());
 
@@ -109,7 +110,8 @@ NS_SWIFT_NAME(FirebaseOptions)
         "setters instead.");
 
 /**
- * Initializes a customized instance of FIROptions from the file at the given plist file path.
+ * Initializes a customized instance of FIROptions from the file at the given plist file path. This
+ * will read the file synchronously from disk.
  * For example,
  * NSString *filePath =
  *     [[NSBundle mainBundle] pathForResource:@"GoogleService-Info" ofType:@"plist"];


### PR DESCRIPTION
This notifies developers that synchronous file I/O occurs on certain calls to `FIRApp` and `FIROptions`.