### PR TITLE
port C++ `DocumentKey` to `Remote/*`

### DIFF
--- a/Firestore/Example/Tests/Remote/FSTRemoteEventTests.mm
+++ b/Firestore/Example/Tests/Remote/FSTRemoteEventTests.mm
@@ -79,9 +79,9 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
   XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
-  XCTAssertEqual(event.documentUpdates.count, 2);
-  XCTAssertEqualObjects(event.documentUpdates[(FSTDocumentKey *)doc1.key], doc1);
-  XCTAssertEqualObjects(event.documentUpdates[(FSTDocumentKey *)doc2.key], doc2);
+  XCTAssertEqual(event.documentUpdates.size(), 2);
+  XCTAssertEqualObjects(event.documentUpdates.at(doc1.key), doc1);
+  XCTAssertEqualObjects(event.documentUpdates.at(doc2.key), doc2);
 
   XCTAssertEqual(event.targetChanges.count, 6);
 
@@ -143,8 +143,8 @@ NS_ASSUME_NONNULL_BEGIN
   XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
   // doc1 is ignored because it was part of an inactive target, but doc2 is in the changes
   // because it become active.
-  XCTAssertEqual(event.documentUpdates.count, 1);
-  XCTAssertEqualObjects(event.documentUpdates[(FSTDocumentKey *)doc2.key], doc2);
+  XCTAssertEqual(event.documentUpdates.size(), 1);
+  XCTAssertEqualObjects(event.documentUpdates.at(doc2.key), doc2);
 
   XCTAssertEqual(event.targetChanges.count, 1);
 }
@@ -170,7 +170,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTRemoteEvent *event = [aggregator remoteEvent];
   XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
   // doc1 is ignored because it was part of an inactive target
-  XCTAssertEqual(event.documentUpdates.count, 0);
+  XCTAssertEqual(event.documentUpdates.size(), 0);
 
   // Target 1 is ignored because it was removed
   XCTAssertEqual(event.targetChanges.count, 0);
@@ -213,10 +213,10 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
   XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
-  XCTAssertEqual(event.documentUpdates.count, 3);
-  XCTAssertEqualObjects(event.documentUpdates[(FSTDocumentKey *)doc1.key], doc1);
-  XCTAssertEqualObjects(event.documentUpdates[(FSTDocumentKey *)doc2.key], doc2);
-  XCTAssertEqualObjects(event.documentUpdates[(FSTDocumentKey *)doc3.key], doc3);
+  XCTAssertEqual(event.documentUpdates.size(), 3);
+  XCTAssertEqualObjects(event.documentUpdates.at(doc1.key), doc1);
+  XCTAssertEqualObjects(event.documentUpdates.at(doc2.key), doc2);
+  XCTAssertEqualObjects(event.documentUpdates.at(doc3.key), doc3);
 
   XCTAssertEqual(event.targetChanges.count, 1);
 
@@ -237,7 +237,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
   XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
-  XCTAssertEqual(event.documentUpdates.count, 0);
+  XCTAssertEqual(event.documentUpdates.size(), 0);
 
   XCTAssertEqual(event.targetChanges.count, 1);
 
@@ -265,8 +265,8 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
   XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
-  XCTAssertEqual(event.documentUpdates.count, 1);
-  XCTAssertEqualObjects(event.documentUpdates[(FSTDocumentKey *)doc1b.key], doc1b);
+  XCTAssertEqual(event.documentUpdates.size(), 1);
+  XCTAssertEqualObjects(event.documentUpdates.at(doc1b.key), doc1b);
 
   XCTAssertEqual(event.targetChanges.count, 2);
 
@@ -289,7 +289,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
   XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
-  XCTAssertEqual(event.documentUpdates.count, 0);
+  XCTAssertEqual(event.documentUpdates.size(), 0);
   XCTAssertEqual(event.targetChanges.count, 1);
   FSTTargetChange *targetChange = event.targetChanges[@1];
   XCTAssertEqualObjects(targetChange.mapping, [[FSTUpdateMapping alloc] init]);
@@ -331,9 +331,9 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
   XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
-  XCTAssertEqual(event.documentUpdates.count, 2);
-  XCTAssertEqualObjects(event.documentUpdates[(FSTDocumentKey *)doc1.key], doc1);
-  XCTAssertEqualObjects(event.documentUpdates[(FSTDocumentKey *)doc2.key], doc2);
+  XCTAssertEqual(event.documentUpdates.size(), 2);
+  XCTAssertEqualObjects(event.documentUpdates.at(doc1.key), doc1);
+  XCTAssertEqualObjects(event.documentUpdates.at(doc2.key), doc2);
 
   // target 1 and 3 are affected (1 because of re-add), target 2 is not because of remove
   XCTAssertEqual(event.targetChanges.count, 2);
@@ -364,7 +364,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
   XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
-  XCTAssertEqual(event.documentUpdates.count, 0);
+  XCTAssertEqual(event.documentUpdates.size(), 0);
   XCTAssertEqual(event.targetChanges.count, 1);
   XCTAssertEqualObjects(event.targetChanges[@1].mapping, [[FSTUpdateMapping alloc] init]);
   XCTAssertEqual(event.targetChanges[@1].currentStatusUpdate, FSTCurrentStatusUpdateNone);
@@ -386,7 +386,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
   XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
-  XCTAssertEqual(event.documentUpdates.count, 0);
+  XCTAssertEqual(event.documentUpdates.size(), 0);
   XCTAssertEqual(event.targetChanges.count, 0);
   XCTAssertEqual(aggregator.existenceFilters.count, 2);
   XCTAssertEqual(aggregator.existenceFilters[@1], filter1);
@@ -418,9 +418,9 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
   XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
-  XCTAssertEqual(event.documentUpdates.count, 2);
-  XCTAssertEqualObjects(event.documentUpdates[(FSTDocumentKey *)doc1.key], doc1);
-  XCTAssertEqualObjects(event.documentUpdates[(FSTDocumentKey *)doc2.key], doc2);
+  XCTAssertEqual(event.documentUpdates.size(), 2);
+  XCTAssertEqualObjects(event.documentUpdates.at(doc1.key), doc1);
+  XCTAssertEqualObjects(event.documentUpdates.at(doc2.key), doc2);
 
   XCTAssertEqual(event.targetChanges.count, 1);
 
@@ -465,22 +465,22 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
   XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
-  XCTAssertEqual(event.documentUpdates.count, 2);
-  XCTAssertEqualObjects(event.documentUpdates[(FSTDocumentKey *)doc1.key], doc1);
-  XCTAssertEqualObjects(event.documentUpdates[(FSTDocumentKey *)doc2.key], doc2);
+  XCTAssertEqual(event.documentUpdates.size(), 2);
+  XCTAssertEqualObjects(event.documentUpdates.at(doc1.key), doc1);
+  XCTAssertEqualObjects(event.documentUpdates.at(doc2.key), doc2);
 
   // Update doc1
   [event addDocumentUpdate:deletedDoc1];
   [event addDocumentUpdate:doc3];
 
   XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
-  XCTAssertEqual(event.documentUpdates.count, 3);
+  XCTAssertEqual(event.documentUpdates.size(), 3);
   // doc1 is replaced
-  XCTAssertEqualObjects(event.documentUpdates[(FSTDocumentKey *)doc1.key], deletedDoc1);
+  XCTAssertEqualObjects(event.documentUpdates.at(doc1.key), deletedDoc1);
   // doc2 is untouched
-  XCTAssertEqualObjects(event.documentUpdates[(FSTDocumentKey *)doc2.key], doc2);
+  XCTAssertEqualObjects(event.documentUpdates.at(doc2.key), doc2);
   // doc3 is new
-  XCTAssertEqualObjects(event.documentUpdates[(FSTDocumentKey *)doc3.key], doc3);
+  XCTAssertEqualObjects(event.documentUpdates.at(doc3.key), doc3);
 
   // Target is unchanged
   XCTAssertEqual(event.targetChanges.count, 1);

--- a/Firestore/Source/API/FIRTransaction.mm
+++ b/Firestore/Source/API/FIRTransaction.mm
@@ -94,7 +94,7 @@ NS_ASSUME_NONNULL_BEGIN
                               NSError *_Nullable error))completion {
   [self validateReference:document];
   [self.internalTransaction
-      lookupDocumentsForKeys:@[ document.key ]
+      lookupDocumentsForKeys:{document.key}
                   completion:^(NSArray<FSTMaybeDocument *> *_Nullable documents,
                                NSError *_Nullable error) {
                     if (error) {

--- a/Firestore/Source/Core/FSTSyncEngine.mm
+++ b/Firestore/Source/Core/FSTSyncEngine.mm
@@ -298,7 +298,7 @@ static const FSTListenSequenceNumber kIrrelevantSequenceNumber = -1;
                                  FSTTargetChange *_Nonnull targetChange, BOOL *_Nonnull stop) {
     FSTDocumentKey *limboKey = self.limboKeysByTarget[targetID];
     if (limboKey && targetChange.currentStatusUpdate == FSTCurrentStatusUpdateMarkCurrent &&
-        remoteEvent.documentUpdates[limboKey] == nil) {
+        remoteEvent.documentUpdates.find(limboKey) == remoteEvent.documentUpdates.end()) {
       // When listening to a query the server responds with a snapshot containing documents
       // matching the query and a current marker telling us we're now in sync. It's possible for
       // these to arrive as separate remote events or as a single remote event. For a document
@@ -361,11 +361,9 @@ static const FSTListenSequenceNumber kIrrelevantSequenceNumber = -1;
         [NSMutableDictionary dictionary];
     FSTDeletedDocument *doc =
         [FSTDeletedDocument documentWithKey:limboKey version:[FSTSnapshotVersion noVersion]];
-    NSMutableDictionary<FSTDocumentKey *, FSTMaybeDocument *> *docUpdate =
-        [NSMutableDictionary dictionaryWithObject:doc forKey:limboKey];
     FSTRemoteEvent *event = [FSTRemoteEvent eventWithSnapshotVersion:[FSTSnapshotVersion noVersion]
                                                        targetChanges:targetChanges
-                                                     documentUpdates:docUpdate];
+                                                     documentUpdates:{{limboKey, doc}}];
     [self applyRemoteEvent:event];
   } else {
     FSTQueryView *queryView = self.queryViewsByTarget[targetID];

--- a/Firestore/Source/Core/FSTTransaction.h
+++ b/Firestore/Source/Core/FSTTransaction.h
@@ -16,7 +16,11 @@
 
 #import <Foundation/Foundation.h>
 
+#include <vector>
+
 #import "Firestore/Source/Core/FSTTypes.h"
+
+#include "Firestore/core/src/firebase/firestore/model/document_key.h"
 
 @class FIRSetOptions;
 @class FSTDatastore;
@@ -42,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Takes a set of keys and asynchronously attempts to fetch all the documents from the backend,
  * ignoring any local changes.
  */
-- (void)lookupDocumentsForKeys:(NSArray<FSTDocumentKey *> *)keys
+- (void)lookupDocumentsForKeys:(const std::vector<firebase::firestore::model::DocumentKey> &)keys
                     completion:(FSTVoidMaybeDocumentArrayErrorBlock)completion;
 
 /**

--- a/Firestore/Source/Core/FSTTransaction.mm
+++ b/Firestore/Source/Core/FSTTransaction.mm
@@ -16,6 +16,8 @@
 
 #import "Firestore/Source/Core/FSTTransaction.h"
 
+#include <vector>
+
 #import <GRPCClient/GRPCCall.h>
 
 #import "FIRFirestoreErrors.h"
@@ -31,6 +33,8 @@
 #import "Firestore/Source/Util/FSTUsageValidation.h"
 
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
+
+using firebase::firestore::model::DocumentKey;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -99,7 +103,7 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-- (void)lookupDocumentsForKeys:(NSArray<FSTDocumentKey *> *)keys
+- (void)lookupDocumentsForKeys:(const std::vector<DocumentKey> &)keys
                     completion:(FSTVoidMaybeDocumentArrayErrorBlock)completion {
   [self ensureCommitNotCalled];
   if (self.mutations.count) {

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -42,9 +42,11 @@
 
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
 #include "Firestore/core/src/firebase/firestore/core/target_id_generator.h"
+#include "Firestore/core/src/firebase/firestore/model/document_key.h"
 
 using firebase::firestore::auth::User;
 using firebase::firestore::core::TargetIdGenerator;
+using firebase::firestore::model::DocumentKey;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -318,28 +320,29 @@ NS_ASSUME_NONNULL_BEGIN
   }];
 
   // TODO(klimt): This could probably be an NSMutableDictionary.
-  __block FSTDocumentKeySet *changedDocKeys = [FSTDocumentKeySet keySet];
-  [remoteEvent.documentUpdates
-      enumerateKeysAndObjectsUsingBlock:^(FSTDocumentKey *key, FSTMaybeDocument *doc, BOOL *stop) {
-        changedDocKeys = [changedDocKeys setByAddingObject:key];
-        FSTMaybeDocument *existingDoc = [remoteDocuments entryForKey:key];
-        // Make sure we don't apply an old document version to the remote cache, though we
-        // make an exception for [SnapshotVersion noVersion] which can happen for manufactured
-        // events (e.g. in the case of a limbo document resolution failing).
-        if (!existingDoc || [doc.version isEqual:[FSTSnapshotVersion noVersion]] ||
-            [doc.version compare:existingDoc.version] != NSOrderedAscending) {
-          [remoteDocuments addEntry:doc];
-        } else {
-          FSTLog(
-              @"FSTLocalStore Ignoring outdated watch update for %@. "
-               "Current version: %@  Watch version: %@",
-              key, existingDoc.version, doc.version);
-        }
+  FSTDocumentKeySet *changedDocKeys = [FSTDocumentKeySet keySet];
+  for (const auto &kv : remoteEvent.documentUpdates) {
+    const DocumentKey &key = kv.first;
+    FSTMaybeDocument *doc = kv.second;
+    changedDocKeys = [changedDocKeys setByAddingObject:key];
+    FSTMaybeDocument *existingDoc = [remoteDocuments entryForKey:key];
+    // Make sure we don't apply an old document version to the remote cache, though we
+    // make an exception for [SnapshotVersion noVersion] which can happen for manufactured
+    // events (e.g. in the case of a limbo document resolution failing).
+    if (!existingDoc || [doc.version isEqual:[FSTSnapshotVersion noVersion]] ||
+        [doc.version compare:existingDoc.version] != NSOrderedAscending) {
+      [remoteDocuments addEntry:doc];
+    } else {
+      FSTLog(
+          @"FSTLocalStore Ignoring outdated watch update for %s. "
+           "Current version: %@  Watch version: %@",
+          key.ToString().c_str(), existingDoc.version, doc.version);
+    }
 
-        // The document might be garbage because it was unreferenced by everything.
-        // Make sure to mark it as garbage if it is...
-        [self.garbageCollector addPotentialGarbageKey:key];
-      }];
+    // The document might be garbage because it was unreferenced by everything.
+    // Make sure to mark it as garbage if it is...
+    [self.garbageCollector addPotentialGarbageKey:key];
+  }
 
   // HACK: The only reason we allow omitting snapshot version is so we can synthesize remote events
   // when we get permission denied errors while trying to resolve the state of a locally cached

--- a/Firestore/Source/Remote/FSTDatastore.h
+++ b/Firestore/Source/Remote/FSTDatastore.h
@@ -90,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
                        token:(const absl::string_view)token;
 
 /** Looks up a list of documents in datastore. */
-- (void)lookupDocuments:(const std::vector<firebase::firestore::model::DocumentKey>)keys
+- (void)lookupDocuments:(const std::vector<firebase::firestore::model::DocumentKey> &)keys
              completion:(FSTVoidMaybeDocumentArrayErrorBlock)completion;
 
 /** Commits data to datastore. */

--- a/Firestore/Source/Remote/FSTDatastore.h
+++ b/Firestore/Source/Remote/FSTDatastore.h
@@ -16,14 +16,16 @@
 
 #import <Foundation/Foundation.h>
 
+#include <vector>
+
 #import "Firestore/Source/Core/FSTTypes.h"
 
 #include "Firestore/core/src/firebase/firestore/auth/credentials_provider.h"
 #include "Firestore/core/src/firebase/firestore/core/database_info.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
+#include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "absl/strings/string_view.h"
 
-@class FSTDocumentKey;
 @class FSTDispatchQueue;
 @class FSTMutation;
 @class FSTMutationResult;
@@ -88,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
                        token:(const absl::string_view)token;
 
 /** Looks up a list of documents in datastore. */
-- (void)lookupDocuments:(NSArray<FSTDocumentKey *> *)keys
+- (void)lookupDocuments:(const std::vector<firebase::firestore::model::DocumentKey>)keys
              completion:(FSTVoidMaybeDocumentArrayErrorBlock)completion;
 
 /** Commits data to datastore. */

--- a/Firestore/Source/Remote/FSTDatastore.mm
+++ b/Firestore/Source/Remote/FSTDatastore.mm
@@ -16,6 +16,8 @@
 
 #import "Firestore/Source/Remote/FSTDatastore.h"
 
+#include <vector>
+
 #import <GRPCClient/GRPCCall+OAuth2.h>
 #import <ProtoRPC/ProtoRPC.h>
 
@@ -24,7 +26,6 @@
 #import "Firestore/Source/API/FIRFirestoreVersion.h"
 #import "Firestore/Source/Local/FSTLocalStore.h"
 #import "Firestore/Source/Model/FSTDocument.h"
-#import "Firestore/Source/Model/FSTDocumentKey.h"
 #import "Firestore/Source/Model/FSTMutation.h"
 #import "Firestore/Source/Remote/FSTSerializerBeta.h"
 #import "Firestore/Source/Remote/FSTStream.h"
@@ -38,6 +39,7 @@
 #include "Firestore/core/src/firebase/firestore/auth/token.h"
 #include "Firestore/core/src/firebase/firestore/core/database_info.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
+#include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/util/error_apple.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 
@@ -46,6 +48,7 @@ using firebase::firestore::auth::CredentialsProvider;
 using firebase::firestore::auth::Token;
 using firebase::firestore::core::DatabaseInfo;
 using firebase::firestore::model::DatabaseId;
+using firebase::firestore::model::DocumentKey;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -245,11 +248,11 @@ typedef GRPCProtoCall * (^RPCFactory)(void);
   [self invokeRPCWithFactory:rpcFactory errorHandler:completion];
 }
 
-- (void)lookupDocuments:(NSArray<FSTDocumentKey *> *)keys
+- (void)lookupDocuments:(const std::vector<DocumentKey>)keys
              completion:(FSTVoidMaybeDocumentArrayErrorBlock)completion {
   GCFSBatchGetDocumentsRequest *request = [GCFSBatchGetDocumentsRequest message];
   request.database = [self.serializer encodedDatabaseID];
-  for (FSTDocumentKey *key in keys) {
+  for (const DocumentKey &key : keys) {
     [request.documentsArray addObject:[self.serializer encodedDocumentKey:key]];
   }
 
@@ -282,9 +285,9 @@ typedef GRPCProtoCall * (^RPCFactory)(void);
                                    [FSTDatastore logHeadersForRPC:rpc RPCName:@"BatchGetDocuments"];
                                    FSTAssert(!response, @"Got response after done.");
                                    NSMutableArray<FSTMaybeDocument *> *docs =
-                                       [NSMutableArray arrayWithCapacity:keys.count];
-                                   for (FSTDocumentKey *key in keys) {
-                                     [docs addObject:results[key]];
+                                       [NSMutableArray arrayWithCapacity:keys.size()];
+                                   for (const DocumentKey &key : keys) {
+                                     [docs addObject:results[(FSTDocumentKey *)key]];
                                    }
                                    completion(docs, nil);
                                  }

--- a/Firestore/Source/Remote/FSTDatastore.mm
+++ b/Firestore/Source/Remote/FSTDatastore.mm
@@ -287,7 +287,7 @@ typedef GRPCProtoCall * (^RPCFactory)(void);
                                    NSMutableArray<FSTMaybeDocument *> *docs =
                                        [NSMutableArray arrayWithCapacity:keys.size()];
                                    for (const DocumentKey &key : keys) {
-                                     [docs addObject:results[(FSTDocumentKey *)key]];
+                                     [docs addObject:results[static_cast<FSTDocumentKey *>(key)]];
                                    }
                                    completion(docs, nil);
                                  }

--- a/Firestore/Source/Remote/FSTDatastore.mm
+++ b/Firestore/Source/Remote/FSTDatastore.mm
@@ -248,7 +248,7 @@ typedef GRPCProtoCall * (^RPCFactory)(void);
   [self invokeRPCWithFactory:rpcFactory errorHandler:completion];
 }
 
-- (void)lookupDocuments:(const std::vector<DocumentKey>)keys
+- (void)lookupDocuments:(const std::vector<DocumentKey> &)keys
              completion:(FSTVoidMaybeDocumentArrayErrorBlock)completion {
   GCFSBatchGetDocumentsRequest *request = [GCFSBatchGetDocumentsRequest message];
   request.database = [self.serializer encodedDatabaseID];
@@ -258,6 +258,7 @@ typedef GRPCProtoCall * (^RPCFactory)(void);
 
   __block FSTMaybeDocumentDictionary *results =
       [FSTMaybeDocumentDictionary maybeDocumentDictionary];
+  const std::vector<DocumentKey> inputKeys = keys;
 
   RPCFactory rpcFactory = ^GRPCProtoCall * {
     __block GRPCProtoCall *rpc = [self.service
@@ -285,8 +286,8 @@ typedef GRPCProtoCall * (^RPCFactory)(void);
                                    [FSTDatastore logHeadersForRPC:rpc RPCName:@"BatchGetDocuments"];
                                    FSTAssert(!response, @"Got response after done.");
                                    NSMutableArray<FSTMaybeDocument *> *docs =
-                                       [NSMutableArray arrayWithCapacity:keys.size()];
-                                   for (const DocumentKey &key : keys) {
+                                       [NSMutableArray arrayWithCapacity:inputKeys.size()];
+                                   for (const DocumentKey &key : inputKeys) {
                                      [docs addObject:results[static_cast<FSTDocumentKey *>(key)]];
                                    }
                                    completion(docs, nil);

--- a/Firestore/Source/Remote/FSTRemoteEvent.h
+++ b/Firestore/Source/Remote/FSTRemoteEvent.h
@@ -16,12 +16,15 @@
 
 #import <Foundation/Foundation.h>
 
+#include <map>
+
 #import "Firestore/Source/Core/FSTTypes.h"
 #import "Firestore/Source/Model/FSTDocumentDictionary.h"
 #import "Firestore/Source/Model/FSTDocumentKeySet.h"
 
+#include "Firestore/core/src/firebase/firestore/model/document_key.h"
+
 @class FSTDocument;
-@class FSTDocumentKey;
 @class FSTExistenceFilter;
 @class FSTMaybeDocument;
 @class FSTSnapshotVersion;
@@ -148,7 +151,7 @@ typedef NS_ENUM(NSUInteger, FSTCurrentStatusUpdate) {
 eventWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
            targetChanges:(NSMutableDictionary<NSNumber *, FSTTargetChange *> *)targetChanges
          documentUpdates:
-             (NSMutableDictionary<FSTDocumentKey *, FSTMaybeDocument *> *)documentUpdates;
+             (std::map<firebase::firestore::model::DocumentKey, FSTMaybeDocument *>)documentUpdates;
 
 /** The snapshot version this event brings us up to. */
 @property(nonatomic, strong, readonly) FSTSnapshotVersion *snapshotVersion;
@@ -161,8 +164,7 @@ eventWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
  * A set of which documents have changed or been deleted, along with the doc's new values
  * (if not deleted).
  */
-@property(nonatomic, strong, readonly)
-    NSDictionary<FSTDocumentKey *, FSTMaybeDocument *> *documentUpdates;
+- (const std::map<firebase::firestore::model::DocumentKey, FSTMaybeDocument *> &)documentUpdates;
 
 /** Adds a document update to this remote event */
 - (void)addDocumentUpdate:(FSTMaybeDocument *)document;

--- a/Firestore/Source/Remote/FSTRemoteStore.mm
+++ b/Firestore/Source/Remote/FSTRemoteStore.mm
@@ -24,7 +24,6 @@
 #import "Firestore/Source/Local/FSTLocalStore.h"
 #import "Firestore/Source/Local/FSTQueryData.h"
 #import "Firestore/Source/Model/FSTDocument.h"
-#import "Firestore/Source/Model/FSTDocumentKey.h"
 #import "Firestore/Source/Model/FSTMutation.h"
 #import "Firestore/Source/Model/FSTMutationBatch.h"
 #import "Firestore/Source/Remote/FSTDatastore.h"
@@ -37,10 +36,12 @@
 #import "Firestore/Source/Util/FSTLogger.h"
 
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
+#include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 
 namespace util = firebase::firestore::util;
 using firebase::firestore::auth::User;
+using firebase::firestore::model::DocumentKey;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -382,7 +383,7 @@ static const int kMaxPendingWrites = 10;
         // updates. Without applying a deleted document there might be another query that will
         // raise this document as part of a snapshot until it is resolved, essentially exposing
         // inconsistency between queries
-        FSTDocumentKey *key = [FSTDocumentKey keyWithPath:query.path];
+        const DocumentKey key{query.path};
         FSTDeletedDocument *deletedDoc =
             [FSTDeletedDocument documentWithKey:key version:snapshotVersion];
         [remoteEvent addDocumentUpdate:deletedDoc];

--- a/Firestore/Source/Remote/FSTSerializerBeta.h
+++ b/Firestore/Source/Remote/FSTSerializerBeta.h
@@ -17,8 +17,8 @@
 #import <Foundation/Foundation.h>
 
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
+#include "Firestore/core/src/firebase/firestore/model/document_key.h"
 
-@class FSTDocumentKey;
 @class FSTFieldValue;
 @class FSTMaybeDocument;
 @class FSTMutation;
@@ -70,8 +70,8 @@ NS_ASSUME_NONNULL_BEGIN
 /** Returns the database ID, such as `projects/{project id}/databases/{database_id}`. */
 - (NSString *)encodedDatabaseID;
 
-- (NSString *)encodedDocumentKey:(FSTDocumentKey *)key;
-- (FSTDocumentKey *)decodedDocumentKey:(NSString *)key;
+- (NSString *)encodedDocumentKey:(const firebase::firestore::model::DocumentKey &)key;
+- (firebase::firestore::model::DocumentKey)decodedDocumentKey:(NSString *)key;
 
 - (GCFSValue *)encodedFieldValue:(FSTFieldValue *)fieldValue;
 - (FSTFieldValue *)decodedFieldValue:(GCFSValue *)valueProto;
@@ -95,7 +95,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (FSTWatchChange *)decodedWatchChange:(GCFSListenResponse *)watchChange;
 - (FSTSnapshotVersion *)versionFromListenResponse:(GCFSListenResponse *)watchChange;
 
-- (GCFSDocument *)encodedDocumentWithFields:(FSTObjectValue *)objectValue key:(FSTDocumentKey *)key;
+- (GCFSDocument *)encodedDocumentWithFields:(FSTObjectValue *)objectValue
+                                        key:(const firebase::firestore::model::DocumentKey &)key;
 
 /**
  * Encodes an FSTObjectValue into a dictionary.

--- a/Firestore/Source/Remote/FSTWatchChange.h
+++ b/Firestore/Source/Remote/FSTWatchChange.h
@@ -18,7 +18,8 @@
 
 #import "Firestore/Source/Core/FSTTypes.h"
 
-@class FSTDocumentKey;
+#include "Firestore/core/src/firebase/firestore/model/document_key.h"
+
 @class FSTExistenceFilter;
 @class FSTMaybeDocument;
 @class FSTSnapshotVersion;
@@ -41,20 +42,20 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithUpdatedTargetIDs:(NSArray<NSNumber *> *)updatedTargetIDs
                         removedTargetIDs:(NSArray<NSNumber *> *)removedTargetIDs
-                             documentKey:(FSTDocumentKey *)documentKey
+                             documentKey:(firebase::firestore::model::DocumentKey)documentKey
                                 document:(nullable FSTMaybeDocument *)document
     NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
+
+/** The key of the document for this change. */
+- (const firebase::firestore::model::DocumentKey &)documentKey;
 
 /** The new document applies to all of these targets. */
 @property(nonatomic, strong, readonly) NSArray<NSNumber *> *updatedTargetIDs;
 
 /** The new document is removed from all of these targets. */
 @property(nonatomic, strong, readonly) NSArray<NSNumber *> *removedTargetIDs;
-
-/** The key of the document for this change. */
-@property(nonatomic, strong, readonly) FSTDocumentKey *documentKey;
 
 /**
  * The new document or DeletedDocument if it was deleted. Is null if the document went out of

--- a/Firestore/Source/Remote/FSTWatchChange.mm
+++ b/Firestore/Source/Remote/FSTWatchChange.mm
@@ -16,29 +16,40 @@
 
 #import "Firestore/Source/Remote/FSTWatchChange.h"
 
+#include <utility>
+
 #import "Firestore/Source/Model/FSTDocument.h"
-#import "Firestore/Source/Model/FSTDocumentKey.h"
 #import "Firestore/Source/Remote/FSTExistenceFilter.h"
+
+#include "Firestore/core/src/firebase/firestore/model/document_key.h"
+
+using firebase::firestore::model::DocumentKey;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation FSTWatchChange
 @end
 
-@implementation FSTDocumentWatchChange
+@implementation FSTDocumentWatchChange {
+  DocumentKey _documentKey;
+}
 
 - (instancetype)initWithUpdatedTargetIDs:(NSArray<NSNumber *> *)updatedTargetIDs
                         removedTargetIDs:(NSArray<NSNumber *> *)removedTargetIDs
-                             documentKey:(FSTDocumentKey *)documentKey
+                             documentKey:(DocumentKey)documentKey
                                 document:(nullable FSTMaybeDocument *)document {
   self = [super init];
   if (self) {
     _updatedTargetIDs = updatedTargetIDs;
     _removedTargetIDs = removedTargetIDs;
-    _documentKey = documentKey;
+    _documentKey = std::move(documentKey);
     _document = document;
   }
   return self;
+}
+
+- (const firebase::firestore::model::DocumentKey &)documentKey {
+  return _documentKey;
 }
 
 - (BOOL)isEqual:(id)other {
@@ -59,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSUInteger)hash {
   NSUInteger hash = self.updatedTargetIDs.hash;
   hash = hash * 31 + self.removedTargetIDs.hash;
-  hash = hash * 31 + self.documentKey.hash;
+  hash = hash * 31 + std::hash<std::string>{}(self.documentKey.ToString());
   hash = hash * 31 + self.document.hash;
   return hash;
 }


### PR DESCRIPTION
### Discussion
Part of the C++ migration. Now `FSTDocumentKey` is replaced by `firebase::firestore::model::DocumentKey` in `Remote/*`.

### Testing
unit and integration tests pass.

### API Changes
n/a
