### PR TITLE
Fix email-link-auth (issue #974)

### DIFF
--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -647,8 +647,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
 - (void)internalSignInWithEmail:(nonnull NSString *)email
                            link:(nonnull NSString *)link
                        callback:(nullable FIRAuthResultCallback)callback {
-  NSURLComponents *urlComponents = [NSURLComponents componentsWithString:link];
-  NSDictionary<NSString *, NSString *> *queryItems = FIRAuthParseURL(urlComponents.query);
+  NSDictionary<NSString *, NSString *> *queryItems = FIRAuthParseURL(link);
   NSString *actionCode = queryItems[@"oobCode"];
 
   FIREmailLinkSignInRequest *request =
@@ -1147,11 +1146,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
   if (link.length == 0) {
     return NO;
   }
-  NSURLComponents *urlComponents = [NSURLComponents componentsWithString:link];
-  if (!urlComponents.query) {
-    return NO;
-  }
-  NSDictionary<NSString *, NSString *> *queryItems = FIRAuthParseURL(urlComponents.query);
+  NSDictionary<NSString *, NSString *> *queryItems = FIRAuthParseURL(link);
 
   NSString *actionCode = queryItems[@"oobCode"];
   NSString *mode = queryItems[@"mode"];
@@ -1169,6 +1164,9 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
  */
 static NSDictionary<NSString *, NSString *> *FIRAuthParseURL(NSString *urlString) {
   NSString *linkURL = [NSURLComponents componentsWithString:urlString].query;
+  if (!linkURL) {
+    return @{};
+  }
   NSArray<NSString *> *URLComponents = [linkURL componentsSeparatedByString:@"&"];
   NSMutableDictionary<NSString *, NSString *> *queryItems =
       [[NSMutableDictionary alloc] initWithCapacity:URLComponents.count];


### PR DESCRIPTION
Fixes #974 
I don't expect anyone to actually accept this into release-4.11.0, but I don't know where this PR should actually go to.
I tested this to the following extent: after making this change, I can use isSigninLink: and get the expected results, and I can also sign in with the link. Both were broken before.