### PR TITLE
Only add nanopb proto headers to the -I path when depending on the nanopb protos

### DIFF
--- a/Firestore/CMakeLists.txt
+++ b/Firestore/CMakeLists.txt
@@ -64,8 +64,5 @@ include_directories(${FIREBASE_INSTALL_DIR})
 # Fully qualified imports, project wide
 include_directories(${FIREBASE_SOURCE_DIR})
 
-# Include nanopb generated sources
-include_directories(${FIREBASE_SOURCE_DIR}/Firestore/Protos/nanopb)
-
 add_subdirectory(core)
 add_subdirectory(Protos)

--- a/Firestore/Protos/CMakeLists.txt
+++ b/Firestore/Protos/CMakeLists.txt
@@ -43,3 +43,10 @@ target_compile_definitions(
   firebase_firestore_protos_nanopb PUBLIC
     -DPB_FIELD_16BIT
 )
+
+# TODO(rsgowman): this may be worth moving into cc_library, possibly via an
+# INCLUDE_DIRS or similar.
+target_include_directories(
+  firebase_firestore_protos_nanopb PUBLIC
+    ${FIREBASE_SOURCE_DIR}/Firestore/Protos/nanopb
+)


### PR DESCRIPTION
This is motivated by wanting to use libprotobuf in the project too, but
it's also sensible by itself.