### PR TITLE
Remove some usages of FSTWriteGroup

### DIFF
--- a/Firestore/Example/Tests/Local/FSTLevelDBMutationQueueTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBMutationQueueTests.mm
@@ -74,7 +74,7 @@ std::string MutationLikeKey(StringView table, StringView userID, FSTBatchID batc
   self.persistence = _db;
 
   FSTWriteGroup *group = [self.persistence startGroupWithAction:@"Start MutationQueue"];
-  [self.mutationQueue startWithGroup:group];
+  [self.mutationQueue start];
   [self.persistence commitGroup:group];
 }
 

--- a/Firestore/Example/Tests/Local/FSTMutationQueueTests.mm
+++ b/Firestore/Example/Tests/Local/FSTMutationQueueTests.mm
@@ -162,9 +162,7 @@ NS_ASSUME_NONNULL_BEGIN
   XCTAssertEqual(newBatch.batchID, batch1.batchID);
 
   // Restart the queue with one unacknowledged batch in it.
-  self.persistence.run([&]() {
-    [self.mutationQueue start];
-  });
+  self.persistence.run([&]() { [self.mutationQueue start]; });
 
   XCTAssertEqual([self.mutationQueue nextBatchID], newBatch.batchID + 1);
 
@@ -486,18 +484,15 @@ NS_ASSUME_NONNULL_BEGIN
   NSData *streamToken1 = [@"token1" dataUsingEncoding:NSUTF8StringEncoding];
   NSData *streamToken2 = [@"token2" dataUsingEncoding:NSUTF8StringEncoding];
 
-  self.persistence.run([&]() {
-    [self.mutationQueue setLastStreamToken:streamToken1];
-  });
+  self.persistence.run([&]() { [self.mutationQueue setLastStreamToken:streamToken1]; });
 
   FSTMutationBatch *batch1 = [self addMutationBatch];
   [self addMutationBatch];
 
   XCTAssertEqualObjects([self.mutationQueue lastStreamToken], streamToken1);
 
-  self.persistence.run([&]() {
-    [self.mutationQueue acknowledgeBatch:batch1 streamToken:streamToken2];
-  });
+  self.persistence.run(
+      [&]() { [self.mutationQueue acknowledgeBatch:batch1 streamToken:streamToken2]; });
 
   XCTAssertEqual(self.mutationQueue.highestAcknowledgedBatchID, batch1.batchID);
   XCTAssertEqualObjects([self.mutationQueue lastStreamToken], streamToken2);
@@ -544,9 +539,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 // TODO(gsoltis): delete this helper, just run it in a transaction directly
 - (void)acknowledgeBatch:(FSTMutationBatch *)batch {
-  self.persistence.run([&]() {
-    [self.mutationQueue acknowledgeBatch:batch streamToken:nil];
-  });
+  self.persistence.run([&]() { [self.mutationQueue acknowledgeBatch:batch streamToken:nil]; });
 }
 
 /**
@@ -554,9 +547,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 // TODO(gsoltis): delete this helper, just run it in a transaction directly
 - (void)removeMutationBatches:(NSArray<FSTMutationBatch *> *)batches {
-  self.persistence.run([&]() {
-    [self.mutationQueue removeMutationBatches:batches];
-  });
+  self.persistence.run([&]() { [self.mutationQueue removeMutationBatches:batches]; });
 }
 
 /** Returns the number of mutation batches in the mutation queue. */

--- a/Firestore/Example/Tests/Local/FSTMutationQueueTests.mm
+++ b/Firestore/Example/Tests/Local/FSTMutationQueueTests.mm
@@ -122,8 +122,8 @@ NS_ASSUME_NONNULL_BEGIN
   FSTMutationBatch *batch1 = [self addMutationBatch];
 
   FSTWriteGroup *group = [self.persistence startGroupWithAction:NSStringFromSelector(_cmd)];
-  [self.mutationQueue acknowledgeBatch:batch1 streamToken:nil group:group];
-  [self.mutationQueue removeMutationBatches:@[ batch1 ] group:group];
+  [self.mutationQueue acknowledgeBatch:batch1 streamToken:nil];
+  [self.mutationQueue removeMutationBatches:@[ batch1 ]];
 
   XCTAssertEqual([self batchCount], 0);
   XCTAssertEqual([self.mutationQueue highestAcknowledgedBatchID], batch1.batchID);
@@ -147,7 +147,7 @@ NS_ASSUME_NONNULL_BEGIN
   self.mutationQueue = [self.persistence mutationQueueForUser:User("user")];
 
   FSTWriteGroup *group = [self.persistence startGroupWithAction:@"Start MutationQueue"];
-  [self.mutationQueue startWithGroup:group];
+  [self.mutationQueue start];
   [self.persistence commitGroup:group];
 
   // Verify that on restart with an empty queue, nextBatchID falls to a lower value.
@@ -162,9 +162,9 @@ NS_ASSUME_NONNULL_BEGIN
   XCTAssertEqual(newBatch.batchID, batch1.batchID);
 
   // Restart the queue with one unacknowledged batch in it.
-  group = [self.persistence startGroupWithAction:@"Start MutationQueue"];
-  [self.mutationQueue startWithGroup:group];
-  [self.persistence commitGroup:group];
+  self.persistence.run([&]() {
+    [self.mutationQueue start];
+  });
 
   XCTAssertEqual([self.mutationQueue nextBatchID], newBatch.batchID + 1);
 
@@ -304,8 +304,7 @@ NS_ASSUME_NONNULL_BEGIN
   for (FSTMutation *mutation in mutations) {
     FSTMutationBatch *batch =
         [self.mutationQueue addMutationBatchWithWriteTime:[FIRTimestamp timestamp]
-                                                mutations:@[ mutation ]
-                                                    group:group];
+                                                mutations:@[ mutation ]];
     [batches addObject:batch];
   }
 
@@ -341,8 +340,7 @@ NS_ASSUME_NONNULL_BEGIN
   for (FSTMutation *mutation in mutations) {
     FSTMutationBatch *batch =
         [self.mutationQueue addMutationBatchWithWriteTime:[FIRTimestamp timestamp]
-                                                mutations:@[ mutation ]
-                                                    group:group];
+                                                mutations:@[ mutation ]];
     [batches addObject:batch];
   }
 
@@ -488,18 +486,18 @@ NS_ASSUME_NONNULL_BEGIN
   NSData *streamToken1 = [@"token1" dataUsingEncoding:NSUTF8StringEncoding];
   NSData *streamToken2 = [@"token2" dataUsingEncoding:NSUTF8StringEncoding];
 
-  FSTWriteGroup *group = [self.persistence startGroupWithAction:@"initial stream token"];
-  [self.mutationQueue setLastStreamToken:streamToken1 group:group];
-  [self.persistence commitGroup:group];
+  self.persistence.run([&]() {
+    [self.mutationQueue setLastStreamToken:streamToken1];
+  });
 
   FSTMutationBatch *batch1 = [self addMutationBatch];
   [self addMutationBatch];
 
   XCTAssertEqualObjects([self.mutationQueue lastStreamToken], streamToken1);
 
-  group = [self.persistence startGroupWithAction:@"acknowledgeBatchID"];
-  [self.mutationQueue acknowledgeBatch:batch1 streamToken:streamToken2 group:group];
-  [self.persistence commitGroup:group];
+  self.persistence.run([&]() {
+    [self.mutationQueue acknowledgeBatch:batch1 streamToken:streamToken2];
+  });
 
   XCTAssertEqual(self.mutationQueue.highestAcknowledgedBatchID, batch1.batchID);
   XCTAssertEqualObjects([self.mutationQueue lastStreamToken], streamToken2);
@@ -520,8 +518,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTWriteGroup *group = [self.persistence startGroupWithAction:@"New mutation batch"];
   FSTMutationBatch *batch =
       [self.mutationQueue addMutationBatchWithWriteTime:[FIRTimestamp timestamp]
-                                              mutations:@[ mutation ]
-                                                  group:group];
+                                              mutations:@[ mutation ]];
   [self.persistence commitGroup:group];
   return batch;
 }
@@ -545,19 +542,21 @@ NS_ASSUME_NONNULL_BEGIN
  * Calls -acknowledgeBatch:streamToken:group: on the mutation queue in a new group and commits the
  * the group.
  */
+// TODO(gsoltis): delete this helper, just run it in a transaction directly
 - (void)acknowledgeBatch:(FSTMutationBatch *)batch {
-  FSTWriteGroup *group = [self.persistence startGroupWithAction:@"Ack batchID"];
-  [self.mutationQueue acknowledgeBatch:batch streamToken:nil group:group];
-  [self.persistence commitGroup:group];
+  self.persistence.run([&]() {
+    [self.mutationQueue acknowledgeBatch:batch streamToken:nil];
+  });
 }
 
 /**
  * Calls -removeMutationBatches:group: on the mutation queue in a new group and commits the group.
  */
+// TODO(gsoltis): delete this helper, just run it in a transaction directly
 - (void)removeMutationBatches:(NSArray<FSTMutationBatch *> *)batches {
-  FSTWriteGroup *group = [self.persistence startGroupWithAction:@"Remove mutation batch"];
-  [self.mutationQueue removeMutationBatches:batches group:group];
-  [self.persistence commitGroup:group];
+  self.persistence.run([&]() {
+    [self.mutationQueue removeMutationBatches:batches];
+  });
 }
 
 /** Returns the number of mutation batches in the mutation queue. */

--- a/Firestore/Example/Tests/Local/FSTQueryCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTQueryCacheTests.mm
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTWriteGroup *group = [self.persistence startGroupWithAction:@"SetAndReadQuery"];
   FSTQueryData *queryData = [self queryDataWithQuery:_queryRooms];
-  [self.queryCache addQueryData:queryData group:group];
+  [self.queryCache addQueryData:queryData];
 
   FSTQueryData *result = [self.queryCache queryDataForQuery:_queryRooms];
   XCTAssertEqualObjects(result.query, queryData.query);
@@ -91,25 +91,25 @@ NS_ASSUME_NONNULL_BEGIN
   XCTAssertEqualObjects(q1.canonicalID, q2.canonicalID);
 
   FSTQueryData *data1 = [self queryDataWithQuery:q1];
-  [self.queryCache addQueryData:data1 group:group];
+  [self.queryCache addQueryData:data1];
 
   // Using the other query should not return the query cache entry despite equal canonicalIDs.
   XCTAssertNil([self.queryCache queryDataForQuery:q2]);
   XCTAssertEqualObjects([self.queryCache queryDataForQuery:q1], data1);
 
   FSTQueryData *data2 = [self queryDataWithQuery:q2];
-  [self.queryCache addQueryData:data2 group:group];
+  [self.queryCache addQueryData:data2];
   XCTAssertEqual([self.queryCache count], 2);
 
   XCTAssertEqualObjects([self.queryCache queryDataForQuery:q1], data1);
   XCTAssertEqualObjects([self.queryCache queryDataForQuery:q2], data2);
 
-  [self.queryCache removeQueryData:data1 group:group];
+  [self.queryCache removeQueryData:data1];
   XCTAssertNil([self.queryCache queryDataForQuery:q1]);
   XCTAssertEqualObjects([self.queryCache queryDataForQuery:q2], data2);
   XCTAssertEqual([self.queryCache count], 1);
 
-  [self.queryCache removeQueryData:data2 group:group];
+  [self.queryCache removeQueryData:data2];
   XCTAssertNil([self.queryCache queryDataForQuery:q1]);
   XCTAssertNil([self.queryCache queryDataForQuery:q2]);
   XCTAssertEqual([self.queryCache count], 0);
@@ -122,11 +122,11 @@ NS_ASSUME_NONNULL_BEGIN
   FSTWriteGroup *group = [self.persistence startGroupWithAction:@"SetQueryToNewValue"];
   FSTQueryData *queryData1 =
       [self queryDataWithQuery:_queryRooms targetID:1 listenSequenceNumber:10 version:1];
-  [self.queryCache addQueryData:queryData1 group:group];
+  [self.queryCache addQueryData:queryData1];
 
   FSTQueryData *queryData2 =
       [self queryDataWithQuery:_queryRooms targetID:1 listenSequenceNumber:10 version:2];
-  [self.queryCache addQueryData:queryData2 group:group];
+  [self.queryCache addQueryData:queryData2];
 
   FSTQueryData *result = [self.queryCache queryDataForQuery:_queryRooms];
   XCTAssertNotEqualObjects(queryData2.resumeToken, queryData1.resumeToken);
@@ -141,9 +141,9 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTWriteGroup *group = [self.persistence startGroupWithAction:@"RemoveQuery"];
   FSTQueryData *queryData1 = [self queryDataWithQuery:_queryRooms];
-  [self.queryCache addQueryData:queryData1 group:group];
+  [self.queryCache addQueryData:queryData1];
 
-  [self.queryCache removeQueryData:queryData1 group:group];
+  [self.queryCache removeQueryData:queryData1];
 
   FSTQueryData *result = [self.queryCache queryDataForQuery:_queryRooms];
   XCTAssertNil(result);
@@ -157,7 +157,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQueryData *queryData = [self queryDataWithQuery:_queryRooms];
 
   // no-op, but make sure it doesn't throw.
-  XCTAssertNoThrow([self.queryCache removeQueryData:queryData group:group]);
+  XCTAssertNoThrow([self.queryCache removeQueryData:queryData]);
   [self.persistence commitGroup:group];
 }
 
@@ -167,17 +167,17 @@ NS_ASSUME_NONNULL_BEGIN
   FSTWriteGroup *group =
       [self.persistence startGroupWithAction:@"RemoveQueryRemovesMatchingKeysToo"];
   FSTQueryData *rooms = [self queryDataWithQuery:_queryRooms];
-  [self.queryCache addQueryData:rooms group:group];
+  [self.queryCache addQueryData:rooms];
 
   DocumentKey key1 = testutil::Key("rooms/foo");
   DocumentKey key2 = testutil::Key("rooms/bar");
-  [self addMatchingKey:key1 forTargetID:rooms.targetID group:group];
-  [self addMatchingKey:key2 forTargetID:rooms.targetID group:group];
+  [self addMatchingKey:key1 forTargetID:rooms.targetID];
+  [self addMatchingKey:key2 forTargetID:rooms.targetID];
 
   XCTAssertTrue([self.queryCache containsKey:key1]);
   XCTAssertTrue([self.queryCache containsKey:key2]);
 
-  [self.queryCache removeQueryData:rooms group:group];
+  [self.queryCache removeQueryData:rooms];
   XCTAssertFalse([self.queryCache containsKey:key1]);
   XCTAssertFalse([self.queryCache containsKey:key2]);
   [self.persistence commitGroup:group];
@@ -191,16 +191,16 @@ NS_ASSUME_NONNULL_BEGIN
 
   XCTAssertFalse([self.queryCache containsKey:key]);
 
-  [self addMatchingKey:key forTargetID:1 group:group];
+  [self addMatchingKey:key forTargetID:1];
   XCTAssertTrue([self.queryCache containsKey:key]);
 
-  [self addMatchingKey:key forTargetID:2 group:group];
+  [self addMatchingKey:key forTargetID:2];
   XCTAssertTrue([self.queryCache containsKey:key]);
 
-  [self removeMatchingKey:key forTargetID:1 group:group];
+  [self removeMatchingKey:key forTargetID:1];
   XCTAssertTrue([self.queryCache containsKey:key]);
 
-  [self removeMatchingKey:key forTargetID:2 group:group];
+  [self removeMatchingKey:key forTargetID:2];
   XCTAssertFalse([self.queryCache containsKey:key]);
   [self.persistence commitGroup:group];
 }
@@ -213,19 +213,19 @@ NS_ASSUME_NONNULL_BEGIN
   DocumentKey key2 = testutil::Key("foo/baz");
   DocumentKey key3 = testutil::Key("foo/blah");
 
-  [self addMatchingKey:key1 forTargetID:1 group:group];
-  [self addMatchingKey:key2 forTargetID:1 group:group];
-  [self addMatchingKey:key3 forTargetID:2 group:group];
+  [self addMatchingKey:key1 forTargetID:1];
+  [self addMatchingKey:key2 forTargetID:1];
+  [self addMatchingKey:key3 forTargetID:2];
   XCTAssertTrue([self.queryCache containsKey:key1]);
   XCTAssertTrue([self.queryCache containsKey:key2]);
   XCTAssertTrue([self.queryCache containsKey:key3]);
 
-  [self.queryCache removeMatchingKeysForTargetID:1 group:group];
+  [self.queryCache removeMatchingKeysForTargetID:1];
   XCTAssertFalse([self.queryCache containsKey:key1]);
   XCTAssertFalse([self.queryCache containsKey:key2]);
   XCTAssertTrue([self.queryCache containsKey:key3]);
 
-  [self.queryCache removeMatchingKeysForTargetID:2 group:group];
+  [self.queryCache removeMatchingKeysForTargetID:2];
   XCTAssertFalse([self.queryCache containsKey:key1]);
   XCTAssertFalse([self.queryCache containsKey:key2]);
   XCTAssertFalse([self.queryCache containsKey:key3]);
@@ -243,26 +243,26 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQueryData *rooms = [self queryDataWithQuery:FSTTestQuery("rooms")];
   DocumentKey room1 = testutil::Key("rooms/bar");
   DocumentKey room2 = testutil::Key("rooms/foo");
-  [self.queryCache addQueryData:rooms group:group];
-  [self addMatchingKey:room1 forTargetID:rooms.targetID group:group];
-  [self addMatchingKey:room2 forTargetID:rooms.targetID group:group];
+  [self.queryCache addQueryData:rooms];
+  [self addMatchingKey:room1 forTargetID:rooms.targetID];
+  [self addMatchingKey:room2 forTargetID:rooms.targetID];
 
   FSTQueryData *halls = [self queryDataWithQuery:FSTTestQuery("halls")];
   DocumentKey hall1 = testutil::Key("halls/bar");
   DocumentKey hall2 = testutil::Key("halls/foo");
-  [self.queryCache addQueryData:halls group:group];
-  [self addMatchingKey:hall1 forTargetID:halls.targetID group:group];
-  [self addMatchingKey:hall2 forTargetID:halls.targetID group:group];
+  [self.queryCache addQueryData:halls];
+  [self addMatchingKey:hall1 forTargetID:halls.targetID];
+  [self addMatchingKey:hall2 forTargetID:halls.targetID];
 
   XCTAssertEqual([garbageCollector collectGarbage], std::set<DocumentKey>({}));
 
-  [self removeMatchingKey:room1 forTargetID:rooms.targetID group:group];
+  [self removeMatchingKey:room1 forTargetID:rooms.targetID];
   XCTAssertEqual([garbageCollector collectGarbage], std::set<DocumentKey>({room1}));
 
-  [self.queryCache removeQueryData:rooms group:group];
+  [self.queryCache removeQueryData:rooms];
   XCTAssertEqual([garbageCollector collectGarbage], std::set<DocumentKey>({room2}));
 
-  [self.queryCache removeMatchingKeysForTargetID:halls.targetID group:group];
+  [self.queryCache removeMatchingKeysForTargetID:halls.targetID];
   XCTAssertEqual([garbageCollector collectGarbage], std::set<DocumentKey>({hall1, hall2}));
   [self.persistence commitGroup:group];
 }
@@ -275,14 +275,14 @@ NS_ASSUME_NONNULL_BEGIN
   DocumentKey key2 = testutil::Key("foo/baz");
   DocumentKey key3 = testutil::Key("foo/blah");
 
-  [self addMatchingKey:key1 forTargetID:1 group:group];
-  [self addMatchingKey:key2 forTargetID:1 group:group];
-  [self addMatchingKey:key3 forTargetID:2 group:group];
+  [self addMatchingKey:key1 forTargetID:1];
+  [self addMatchingKey:key2 forTargetID:1];
+  [self addMatchingKey:key3 forTargetID:2];
 
   FSTAssertEqualSets([self.queryCache matchingKeysForTargetID:1], (@[ key1, key2 ]));
   FSTAssertEqualSets([self.queryCache matchingKeysForTargetID:2], @[ key3 ]);
 
-  [self addMatchingKey:key1 forTargetID:2 group:group];
+  [self addMatchingKey:key1 forTargetID:2];
   FSTAssertEqualSets([self.queryCache matchingKeysForTargetID:1], (@[ key1, key2 ]));
   FSTAssertEqualSets([self.queryCache matchingKeysForTargetID:2], (@[ key1, key3 ]));
   [self.persistence commitGroup:group];
@@ -296,16 +296,16 @@ NS_ASSUME_NONNULL_BEGIN
                                                     targetID:1
                                         listenSequenceNumber:10
                                                      purpose:FSTQueryPurposeListen];
-  [self.queryCache addQueryData:query1 group:group];
+  [self.queryCache addQueryData:query1];
   FSTQueryData *query2 = [[FSTQueryData alloc] initWithQuery:FSTTestQuery("halls")
                                                     targetID:2
                                         listenSequenceNumber:20
                                                      purpose:FSTQueryPurposeListen];
-  [self.queryCache addQueryData:query2 group:group];
+  [self.queryCache addQueryData:query2];
   XCTAssertEqual([self.queryCache highestListenSequenceNumber], 20);
 
   // TargetIDs never come down.
-  [self.queryCache removeQueryData:query2 group:group];
+  [self.queryCache removeQueryData:query2];
   XCTAssertEqual([self.queryCache highestListenSequenceNumber], 20);
 
   // A query with an empty result set still counts.
@@ -313,13 +313,13 @@ NS_ASSUME_NONNULL_BEGIN
                                                     targetID:42
                                         listenSequenceNumber:100
                                                      purpose:FSTQueryPurposeListen];
-  [self.queryCache addQueryData:query3 group:group];
+  [self.queryCache addQueryData:query3];
   XCTAssertEqual([self.queryCache highestListenSequenceNumber], 100);
 
-  [self.queryCache removeQueryData:query1 group:group];
+  [self.queryCache removeQueryData:query1];
   XCTAssertEqual([self.queryCache highestListenSequenceNumber], 100);
 
-  [self.queryCache removeQueryData:query3 group:group];
+  [self.queryCache removeQueryData:query3];
   XCTAssertEqual([self.queryCache highestListenSequenceNumber], 100);
   [self.persistence commitGroup:group];
 
@@ -342,21 +342,21 @@ NS_ASSUME_NONNULL_BEGIN
                                                      purpose:FSTQueryPurposeListen];
   DocumentKey key1 = testutil::Key("rooms/bar");
   DocumentKey key2 = testutil::Key("rooms/foo");
-  [self.queryCache addQueryData:query1 group:group];
-  [self addMatchingKey:key1 forTargetID:1 group:group];
-  [self addMatchingKey:key2 forTargetID:1 group:group];
+  [self.queryCache addQueryData:query1];
+  [self addMatchingKey:key1 forTargetID:1];
+  [self addMatchingKey:key2 forTargetID:1];
 
   FSTQueryData *query2 = [[FSTQueryData alloc] initWithQuery:FSTTestQuery("halls")
                                                     targetID:2
                                         listenSequenceNumber:20
                                                      purpose:FSTQueryPurposeListen];
   DocumentKey key3 = testutil::Key("halls/foo");
-  [self.queryCache addQueryData:query2 group:group];
-  [self addMatchingKey:key3 forTargetID:2 group:group];
+  [self.queryCache addQueryData:query2];
+  [self addMatchingKey:key3 forTargetID:2];
   XCTAssertEqual([self.queryCache highestTargetID], 2);
 
   // TargetIDs never come down.
-  [self.queryCache removeQueryData:query2 group:group];
+  [self.queryCache removeQueryData:query2];
   XCTAssertEqual([self.queryCache highestTargetID], 2);
 
   // A query with an empty result set still counts.
@@ -364,13 +364,13 @@ NS_ASSUME_NONNULL_BEGIN
                                                     targetID:42
                                         listenSequenceNumber:100
                                                      purpose:FSTQueryPurposeListen];
-  [self.queryCache addQueryData:query3 group:group];
+  [self.queryCache addQueryData:query3];
   XCTAssertEqual([self.queryCache highestTargetID], 42);
 
-  [self.queryCache removeQueryData:query1 group:group];
+  [self.queryCache removeQueryData:query1];
   XCTAssertEqual([self.queryCache highestTargetID], 42);
 
-  [self.queryCache removeQueryData:query3 group:group];
+  [self.queryCache removeQueryData:query3];
   XCTAssertEqual([self.queryCache highestTargetID], 42);
   [self.persistence commitGroup:group];
   // Verify that the highestTargetID even survives restarts.
@@ -388,7 +388,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   // Can set the snapshot version.
   FSTWriteGroup *group = [self.persistence startGroupWithAction:@"setLastRemoteSnapshotVersion"];
-  [self.queryCache setLastRemoteSnapshotVersion:FSTTestVersion(42) group:group];
+  [self.queryCache setLastRemoteSnapshotVersion:FSTTestVersion(42)];
   [self.persistence commitGroup:group];
   XCTAssertEqualObjects([self.queryCache lastRemoteSnapshotVersion], FSTTestVersion(42));
 
@@ -425,19 +425,17 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)addMatchingKey:(const DocumentKey &)key
-           forTargetID:(FSTTargetID)targetID
-                 group:(FSTWriteGroup *)group {
+           forTargetID:(FSTTargetID)targetID {
   FSTDocumentKeySet *keys = [FSTDocumentKeySet keySet];
   keys = [keys setByAddingObject:key];
-  [self.queryCache addMatchingKeys:keys forTargetID:targetID group:group];
+  [self.queryCache addMatchingKeys:keys forTargetID:targetID];
 }
 
 - (void)removeMatchingKey:(const DocumentKey &)key
-              forTargetID:(FSTTargetID)targetID
-                    group:(FSTWriteGroup *)group {
+              forTargetID:(FSTTargetID)targetID {
   FSTDocumentKeySet *keys = [FSTDocumentKeySet keySet];
   keys = [keys setByAddingObject:key];
-  [self.queryCache removeMatchingKeys:keys forTargetID:targetID group:group];
+  [self.queryCache removeMatchingKeys:keys forTargetID:targetID];
 }
 
 @end

--- a/Firestore/Example/Tests/Local/FSTQueryCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTQueryCacheTests.mm
@@ -424,15 +424,13 @@ NS_ASSUME_NONNULL_BEGIN
                                  resumeToken:resumeToken];
 }
 
-- (void)addMatchingKey:(const DocumentKey &)key
-           forTargetID:(FSTTargetID)targetID {
+- (void)addMatchingKey:(const DocumentKey &)key forTargetID:(FSTTargetID)targetID {
   FSTDocumentKeySet *keys = [FSTDocumentKeySet keySet];
   keys = [keys setByAddingObject:key];
   [self.queryCache addMatchingKeys:keys forTargetID:targetID];
 }
 
-- (void)removeMatchingKey:(const DocumentKey &)key
-              forTargetID:(FSTTargetID)targetID {
+- (void)removeMatchingKey:(const DocumentKey &)key forTargetID:(FSTTargetID)targetID {
   FSTDocumentKeySet *keys = [FSTDocumentKeySet keySet];
   keys = [keys setByAddingObject:key];
   [self.queryCache removeMatchingKeys:keys forTargetID:targetID];

--- a/Firestore/Example/Tests/Local/FSTRemoteDocumentCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTRemoteDocumentCacheTests.mm
@@ -132,6 +132,7 @@ static const int kVersion = 42;
 }
 
 #pragma mark - Helpers
+// TODO(gsoltis): reevaluate if any of these helpers are still needed
 
 - (FSTDocument *)setTestDocumentAtPath:(const absl::string_view)path {
   FSTDocument *doc = FSTTestDoc(path, kVersion, _kDocData, NO);
@@ -141,7 +142,7 @@ static const int kVersion = 42;
 
 - (void)addEntry:(FSTMaybeDocument *)maybeDoc {
   FSTWriteGroup *group = [self.persistence startGroupWithAction:@"addEntry"];
-  [self.remoteDocumentCache addEntry:maybeDoc group:group];
+  [self.remoteDocumentCache addEntry:maybeDoc];
   [self.persistence commitGroup:group];
 }
 
@@ -154,7 +155,7 @@ static const int kVersion = 42;
 
 - (void)removeEntryAtPath:(const absl::string_view)path {
   FSTWriteGroup *group = [self.persistence startGroupWithAction:@"removeEntryAtPath"];
-  [self.remoteDocumentCache removeEntryForKey:testutil::Key(path) group:group];
+  [self.remoteDocumentCache removeEntryForKey:testutil::Key(path)];
   [self.persistence commitGroup:group];
 }
 

--- a/Firestore/Example/Tests/Local/FSTRemoteDocumentChangeBufferTests.mm
+++ b/Firestore/Example/Tests/Local/FSTRemoteDocumentChangeBufferTests.mm
@@ -48,11 +48,11 @@ NS_ASSUME_NONNULL_BEGIN
   // Add a couple initial items to the cache.
   FSTWriteGroup *group = [_db startGroupWithAction:@"Add initial docs."];
   _kInitialADoc = FSTTestDoc("coll/a", 42, @{@"test" : @"data"}, NO);
-  [_remoteDocumentCache addEntry:_kInitialADoc group:group];
+  [_remoteDocumentCache addEntry:_kInitialADoc];
 
   _kInitialBDoc =
       [FSTDeletedDocument documentWithKey:FSTTestDocKey(@"coll/b") version:FSTTestVersion(314)];
-  [_remoteDocumentCache addEntry:_kInitialBDoc group:group];
+  [_remoteDocumentCache addEntry:_kInitialBDoc];
   [_db commitGroup:group];
 
   _remoteDocumentBuffer =

--- a/Firestore/Source/Local/FSTLevelDBMutationQueue.mm
+++ b/Firestore/Source/Local/FSTLevelDBMutationQueue.mm
@@ -216,8 +216,7 @@ using leveldb::WriteOptions;
   return self.metadata.lastAcknowledgedBatchId;
 }
 
-- (void)acknowledgeBatch:(FSTMutationBatch *)batch
-             streamToken:(nullable NSData *)streamToken {
+- (void)acknowledgeBatch:(FSTMutationBatch *)batch streamToken:(nullable NSData *)streamToken {
   FSTBatchID batchID = batch.batchID;
   FSTAssert(batchID > self.highestAcknowledgedBatchID,
             @"Mutation batchIDs must be acknowledged in order");

--- a/Firestore/Source/Local/FSTLevelDBMutationQueue.mm
+++ b/Firestore/Source/Local/FSTLevelDBMutationQueue.mm
@@ -28,7 +28,6 @@
 #import "Firestore/Source/Local/FSTLevelDB.h"
 #import "Firestore/Source/Local/FSTLevelDBKey.h"
 #import "Firestore/Source/Local/FSTLocalSerializer.h"
-#import "Firestore/Source/Local/FSTWriteGroup.h"
 #import "Firestore/Source/Model/FSTMutation.h"
 #import "Firestore/Source/Model/FSTMutationBatch.h"
 #import "Firestore/Source/Util/FSTAssert.h"
@@ -104,7 +103,7 @@ using leveldb::WriteOptions;
   return self;
 }
 
-- (void)startWithGroup:(__unused FSTWriteGroup *)group {
+- (void)start {
   FSTBatchID nextBatchID = [FSTLevelDBMutationQueue loadNextBatchIDFromDB:_db.ptr];
 
   // On restart, nextBatchId may end up lower than lastAcknowledgedBatchId since it's computed from
@@ -218,8 +217,7 @@ using leveldb::WriteOptions;
 }
 
 - (void)acknowledgeBatch:(FSTMutationBatch *)batch
-             streamToken:(nullable NSData *)streamToken
-                   group:(__unused FSTWriteGroup *)group {
+             streamToken:(nullable NSData *)streamToken {
   FSTBatchID batchID = batch.batchID;
   FSTAssert(batchID > self.highestAcknowledgedBatchID,
             @"Mutation batchIDs must be acknowledged in order");
@@ -235,7 +233,7 @@ using leveldb::WriteOptions;
   return self.metadata.lastStreamToken;
 }
 
-- (void)setLastStreamToken:(nullable NSData *)streamToken group:(__unused FSTWriteGroup *)group {
+- (void)setLastStreamToken:(nullable NSData *)streamToken {
   FSTPBMutationQueue *metadata = self.metadata;
   metadata.lastStreamToken = streamToken;
 
@@ -260,8 +258,7 @@ using leveldb::WriteOptions;
 }
 
 - (FSTMutationBatch *)addMutationBatchWithWriteTime:(FIRTimestamp *)localWriteTime
-                                          mutations:(NSArray<FSTMutation *> *)mutations
-                                              group:(__unused FSTWriteGroup *)group {
+                                          mutations:(NSArray<FSTMutation *> *)mutations {
   FSTBatchID batchID = self.nextBatchID;
   self.nextBatchID += 1;
 
@@ -492,7 +489,7 @@ using leveldb::WriteOptions;
   return result;
 }
 
-- (void)removeMutationBatches:(NSArray<FSTMutationBatch *> *)batches group:(__unused FSTWriteGroup *)group {
+- (void)removeMutationBatches:(NSArray<FSTMutationBatch *> *)batches {
   NSString *userID = self.userID;
   id<FSTGarbageCollector> garbageCollector = self.garbageCollector;
 

--- a/Firestore/Source/Local/FSTLevelDBQueryCache.mm
+++ b/Firestore/Source/Local/FSTLevelDBQueryCache.mm
@@ -283,24 +283,28 @@ using leveldb::Status;
 
 #pragma mark Matching Key tracking
 
-- (void)addMatchingKeys:(FSTDocumentKeySet *)keys
-            forTargetID:(FSTTargetID)targetID {
+- (void)addMatchingKeys:(FSTDocumentKeySet *)keys forTargetID:(FSTTargetID)targetID {
   // Store an empty value in the index which is equivalent to serializing a GPBEmpty message. In the
   // future if we wanted to store some other kind of value here, we can parse these empty values as
   // with some other protocol buffer (and the parser will see all default values).
   std::string emptyBuffer;
 
   [keys enumerateObjectsUsingBlock:^(FSTDocumentKey *documentKey, BOOL *stop) {
-    self->_db.currentTransaction->Put([FSTLevelDBTargetDocumentKey keyWithTargetID:targetID documentKey:documentKey], emptyBuffer);
-    self->_db.currentTransaction->Put([FSTLevelDBDocumentTargetKey keyWithDocumentKey:documentKey targetID:targetID], emptyBuffer);
+    self->_db.currentTransaction->Put(
+        [FSTLevelDBTargetDocumentKey keyWithTargetID:targetID documentKey:documentKey],
+        emptyBuffer);
+    self->_db.currentTransaction->Put(
+        [FSTLevelDBDocumentTargetKey keyWithDocumentKey:documentKey targetID:targetID],
+        emptyBuffer);
   }];
 }
 
-- (void)removeMatchingKeys:(FSTDocumentKeySet *)keys
-               forTargetID:(FSTTargetID)targetID {
+- (void)removeMatchingKeys:(FSTDocumentKeySet *)keys forTargetID:(FSTTargetID)targetID {
   [keys enumerateObjectsUsingBlock:^(FSTDocumentKey *key, BOOL *stop) {
-    self->_db.currentTransaction->Delete([FSTLevelDBTargetDocumentKey keyWithTargetID:targetID documentKey:key]);
-    self->_db.currentTransaction->Delete([FSTLevelDBDocumentTargetKey keyWithDocumentKey:key targetID:targetID]);
+    self->_db.currentTransaction->Delete(
+        [FSTLevelDBTargetDocumentKey keyWithTargetID:targetID documentKey:key]);
+    self->_db.currentTransaction->Delete(
+        [FSTLevelDBDocumentTargetKey keyWithDocumentKey:key targetID:targetID]);
     [self.garbageCollector addPotentialGarbageKey:key];
   }];
 }
@@ -322,8 +326,8 @@ using leveldb::Status;
 
     // Delete both index rows
     _db.currentTransaction->Delete(indexKey);
-    _db.currentTransaction->Delete([FSTLevelDBDocumentTargetKey keyWithDocumentKey:documentKey
-                                                                          targetID:targetID]);
+    _db.currentTransaction->Delete(
+        [FSTLevelDBDocumentTargetKey keyWithDocumentKey:documentKey targetID:targetID]);
     [self.garbageCollector addPotentialGarbageKey:documentKey];
   }
 }

--- a/Firestore/Source/Local/FSTLevelDBQueryCache.mm
+++ b/Firestore/Source/Local/FSTLevelDBQueryCache.mm
@@ -148,13 +148,8 @@ using leveldb::Status;
 - (void)saveQueryData:(FSTQueryData *)queryData {
   FSTTargetID targetID = queryData.targetID;
   std::string key = [FSTLevelDBTargetKey keyWithTargetID:targetID];
-  //[group setMessage:[self.serializer encodedQueryData:queryData] forKey:key];
   _db.currentTransaction->Put(key, [self.serializer encodedQueryData:queryData]);
 }
-
-/*- (void)saveMetadataInGroup:(FSTWriteGroup *)group {
-  [group setMessage:self.metadata forKey:[FSTLevelDBTargetGlobalKey key]];
-}*/
 
 - (BOOL)updateMetadataForQueryData:(FSTQueryData *)queryData {
   BOOL updatedMetadata = NO;

--- a/Firestore/Source/Local/FSTLevelDBQueryCache.mm
+++ b/Firestore/Source/Local/FSTLevelDBQueryCache.mm
@@ -22,7 +22,6 @@
 #import "Firestore/Source/Local/FSTLevelDBKey.h"
 #import "Firestore/Source/Local/FSTLocalSerializer.h"
 #import "Firestore/Source/Local/FSTQueryData.h"
-#import "Firestore/Source/Local/FSTWriteGroup.h"
 #import "Firestore/Source/Util/FSTAssert.h"
 #include "absl/strings/match.h"
 
@@ -137,25 +136,25 @@ using leveldb::Status;
   return _lastRemoteSnapshotVersion;
 }
 
-- (void)setLastRemoteSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
-                               group:(FSTWriteGroup *)group {
+- (void)setLastRemoteSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion {
   _lastRemoteSnapshotVersion = snapshotVersion;
   self.metadata.lastRemoteSnapshotVersion = [self.serializer encodedVersion:snapshotVersion];
-  [group setMessage:self.metadata forKey:[FSTLevelDBTargetGlobalKey key]];
+  _db.currentTransaction->Put([FSTLevelDBTargetGlobalKey key], self.metadata);
 }
 
 - (void)shutdown {
 }
 
-- (void)saveQueryData:(FSTQueryData *)queryData group:(FSTWriteGroup *)group {
+- (void)saveQueryData:(FSTQueryData *)queryData {
   FSTTargetID targetID = queryData.targetID;
   std::string key = [FSTLevelDBTargetKey keyWithTargetID:targetID];
-  [group setMessage:[self.serializer encodedQueryData:queryData] forKey:key];
+  //[group setMessage:[self.serializer encodedQueryData:queryData] forKey:key];
+  _db.currentTransaction->Put(key, [self.serializer encodedQueryData:queryData]);
 }
 
-- (void)saveMetadataInGroup:(FSTWriteGroup *)group {
+/*- (void)saveMetadataInGroup:(FSTWriteGroup *)group {
   [group setMessage:self.metadata forKey:[FSTLevelDBTargetGlobalKey key]];
-}
+}*/
 
 - (BOOL)updateMetadataForQueryData:(FSTQueryData *)queryData {
   BOOL updatedMetadata = NO;
@@ -172,41 +171,41 @@ using leveldb::Status;
   return updatedMetadata;
 }
 
-- (void)addQueryData:(FSTQueryData *)queryData group:(FSTWriteGroup *)group {
-  [self saveQueryData:queryData group:group];
+- (void)addQueryData:(FSTQueryData *)queryData {
+  [self saveQueryData:queryData];
 
   NSString *canonicalID = queryData.query.canonicalID;
   std::string indexKey =
       [FSTLevelDBQueryTargetKey keyWithCanonicalID:canonicalID targetID:queryData.targetID];
   std::string emptyBuffer;
-  [group setData:emptyBuffer forKey:indexKey];
+  _db.currentTransaction->Put(indexKey, emptyBuffer);
 
   self.metadata.targetCount += 1;
   [self updateMetadataForQueryData:queryData];
-  [self saveMetadataInGroup:group];
+  _db.currentTransaction->Put([FSTLevelDBTargetGlobalKey key], self.metadata);
 }
 
-- (void)updateQueryData:(FSTQueryData *)queryData group:(FSTWriteGroup *)group {
-  [self saveQueryData:queryData group:group];
+- (void)updateQueryData:(FSTQueryData *)queryData {
+  [self saveQueryData:queryData];
 
   if ([self updateMetadataForQueryData:queryData]) {
-    [self saveMetadataInGroup:group];
+    _db.currentTransaction->Put([FSTLevelDBTargetGlobalKey key], self.metadata);
   }
 }
 
-- (void)removeQueryData:(FSTQueryData *)queryData group:(FSTWriteGroup *)group {
+- (void)removeQueryData:(FSTQueryData *)queryData {
   FSTTargetID targetID = queryData.targetID;
 
-  [self removeMatchingKeysForTargetID:targetID group:group];
+  [self removeMatchingKeysForTargetID:targetID];
 
   std::string key = [FSTLevelDBTargetKey keyWithTargetID:targetID];
-  [group removeMessageForKey:key];
+  _db.currentTransaction->Delete(key);
 
   std::string indexKey =
       [FSTLevelDBQueryTargetKey keyWithCanonicalID:queryData.query.canonicalID targetID:targetID];
-  [group removeMessageForKey:indexKey];
+  _db.currentTransaction->Delete(indexKey);
   self.metadata.targetCount -= 1;
-  [self saveMetadataInGroup:group];
+  _db.currentTransaction->Put([FSTLevelDBTargetGlobalKey key], self.metadata);
 }
 
 - (int32_t)count {
@@ -285,34 +284,28 @@ using leveldb::Status;
 #pragma mark Matching Key tracking
 
 - (void)addMatchingKeys:(FSTDocumentKeySet *)keys
-            forTargetID:(FSTTargetID)targetID
-                  group:(FSTWriteGroup *)group {
+            forTargetID:(FSTTargetID)targetID {
   // Store an empty value in the index which is equivalent to serializing a GPBEmpty message. In the
   // future if we wanted to store some other kind of value here, we can parse these empty values as
   // with some other protocol buffer (and the parser will see all default values).
   std::string emptyBuffer;
 
   [keys enumerateObjectsUsingBlock:^(FSTDocumentKey *documentKey, BOOL *stop) {
-    [group setData:emptyBuffer
-            forKey:[FSTLevelDBTargetDocumentKey keyWithTargetID:targetID documentKey:documentKey]];
-    [group setData:emptyBuffer
-            forKey:[FSTLevelDBDocumentTargetKey keyWithDocumentKey:documentKey targetID:targetID]];
+    self->_db.currentTransaction->Put([FSTLevelDBTargetDocumentKey keyWithTargetID:targetID documentKey:documentKey], emptyBuffer);
+    self->_db.currentTransaction->Put([FSTLevelDBDocumentTargetKey keyWithDocumentKey:documentKey targetID:targetID], emptyBuffer);
   }];
 }
 
 - (void)removeMatchingKeys:(FSTDocumentKeySet *)keys
-               forTargetID:(FSTTargetID)targetID
-                     group:(FSTWriteGroup *)group {
+               forTargetID:(FSTTargetID)targetID {
   [keys enumerateObjectsUsingBlock:^(FSTDocumentKey *key, BOOL *stop) {
-    [group
-        removeMessageForKey:[FSTLevelDBTargetDocumentKey keyWithTargetID:targetID documentKey:key]];
-    [group
-        removeMessageForKey:[FSTLevelDBDocumentTargetKey keyWithDocumentKey:key targetID:targetID]];
+    self->_db.currentTransaction->Delete([FSTLevelDBTargetDocumentKey keyWithTargetID:targetID documentKey:key]);
+    self->_db.currentTransaction->Delete([FSTLevelDBDocumentTargetKey keyWithDocumentKey:key targetID:targetID]);
     [self.garbageCollector addPotentialGarbageKey:key];
   }];
 }
 
-- (void)removeMatchingKeysForTargetID:(FSTTargetID)targetID group:(FSTWriteGroup *)group {
+- (void)removeMatchingKeysForTargetID:(FSTTargetID)targetID {
   std::string indexPrefix = [FSTLevelDBTargetDocumentKey keyPrefixWithTargetID:targetID];
   auto indexIterator = _db.currentTransaction->NewIterator();
   indexIterator->Seek(indexPrefix);
@@ -328,9 +321,9 @@ using leveldb::Status;
     const DocumentKey &documentKey = rowKey.documentKey;
 
     // Delete both index rows
-    [group removeMessageForKey:indexKey];
-    [group removeMessageForKey:[FSTLevelDBDocumentTargetKey keyWithDocumentKey:documentKey
-                                                                      targetID:targetID]];
+    _db.currentTransaction->Delete(indexKey);
+    _db.currentTransaction->Delete([FSTLevelDBDocumentTargetKey keyWithDocumentKey:documentKey
+                                                                          targetID:targetID]);
     [self.garbageCollector addPotentialGarbageKey:documentKey];
   }
 }

--- a/Firestore/Source/Local/FSTLevelDBRemoteDocumentCache.mm
+++ b/Firestore/Source/Local/FSTLevelDBRemoteDocumentCache.mm
@@ -61,14 +61,14 @@ using leveldb::Status;
 - (void)shutdown {
 }
 
-- (void)addEntry:(FSTMaybeDocument *)document group:(FSTWriteGroup *)group {
+- (void)addEntry:(FSTMaybeDocument *)document group:(__unused FSTWriteGroup *)group {
   std::string key = [self remoteDocumentKey:document.key];
-  [group setMessage:[self.serializer encodedMaybeDocument:document] forKey:key];
+  _db.currentTransaction->Put(key, [self.serializer encodedMaybeDocument:document]);
 }
 
-- (void)removeEntryForKey:(const DocumentKey &)documentKey group:(FSTWriteGroup *)group {
+- (void)removeEntryForKey:(const DocumentKey &)documentKey group:(__unused FSTWriteGroup *)group {
   std::string key = [self remoteDocumentKey:documentKey];
-  [group removeMessageForKey:key];
+  _db.currentTransaction->Delete(key);
 }
 
 - (nullable FSTMaybeDocument *)entryForKey:(const DocumentKey &)documentKey {

--- a/Firestore/Source/Local/FSTLevelDBRemoteDocumentCache.mm
+++ b/Firestore/Source/Local/FSTLevelDBRemoteDocumentCache.mm
@@ -25,7 +25,6 @@
 #import "Firestore/Source/Local/FSTLevelDB.h"
 #import "Firestore/Source/Local/FSTLevelDBKey.h"
 #import "Firestore/Source/Local/FSTLocalSerializer.h"
-#import "Firestore/Source/Local/FSTWriteGroup.h"
 #import "Firestore/Source/Model/FSTDocument.h"
 #import "Firestore/Source/Model/FSTDocumentDictionary.h"
 #import "Firestore/Source/Model/FSTDocumentSet.h"
@@ -61,12 +60,12 @@ using leveldb::Status;
 - (void)shutdown {
 }
 
-- (void)addEntry:(FSTMaybeDocument *)document group:(__unused FSTWriteGroup *)group {
+- (void)addEntry:(FSTMaybeDocument *)document {
   std::string key = [self remoteDocumentKey:document.key];
   _db.currentTransaction->Put(key, [self.serializer encodedMaybeDocument:document]);
 }
 
-- (void)removeEntryForKey:(const DocumentKey &)documentKey group:(__unused FSTWriteGroup *)group {
+- (void)removeEntryForKey:(const DocumentKey &)documentKey {
   std::string key = [self remoteDocumentKey:documentKey];
   _db.currentTransaction->Delete(key);
 }

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -301,13 +301,13 @@ NS_ASSUME_NONNULL_BEGIN
       // First make sure that all references are deleted.
       if ([mapping isKindOfClass:[FSTResetMapping class]]) {
         FSTResetMapping *reset = (FSTResetMapping *)mapping;
-        [queryCache removeMatchingKeysForTargetID:targetID group:group];
-        [queryCache addMatchingKeys:reset.documents forTargetID:targetID group:group];
+        [queryCache removeMatchingKeysForTargetID:targetID];
+        [queryCache addMatchingKeys:reset.documents forTargetID:targetID];
 
       } else if ([mapping isKindOfClass:[FSTUpdateMapping class]]) {
         FSTUpdateMapping *update = (FSTUpdateMapping *)mapping;
-        [queryCache removeMatchingKeys:update.removedDocuments forTargetID:targetID group:group];
-        [queryCache addMatchingKeys:update.addedDocuments forTargetID:targetID group:group];
+        [queryCache removeMatchingKeys:update.removedDocuments forTargetID:targetID];
+        [queryCache addMatchingKeys:update.addedDocuments forTargetID:targetID];
 
       } else {
         FSTFail(@"Unknown mapping type: %@", mapping);
@@ -320,7 +320,7 @@ NS_ASSUME_NONNULL_BEGIN
       queryData = [queryData queryDataByReplacingSnapshotVersion:change.snapshotVersion
                                                      resumeToken:resumeToken];
       self.targetIDs[targetIDNumber] = queryData;
-      [self.queryCache updateQueryData:queryData group:group];
+      [self.queryCache updateQueryData:queryData];
     }
   }];
 
@@ -358,7 +358,7 @@ NS_ASSUME_NONNULL_BEGIN
     FSTAssert([remoteVersion compare:lastRemoteVersion] != NSOrderedAscending,
               @"Watch stream reverted to previous snapshot?? (%@ < %@)", remoteVersion,
               lastRemoteVersion);
-    [self.queryCache setLastRemoteSnapshotVersion:remoteVersion group:group];
+    [self.queryCache setLastRemoteSnapshotVersion:remoteVersion];
   }
 
   FSTDocumentKeySet *releasedWriteKeys =
@@ -419,7 +419,7 @@ NS_ASSUME_NONNULL_BEGIN
                                         targetID:targetID
                             listenSequenceNumber:sequenceNumber
                                          purpose:FSTQueryPurposeListen];
-    [self.queryCache addQueryData:cached group:group];
+    [self.queryCache addQueryData:cached];
   }
   [self.persistence commitGroup:group];
   // Sanity check to ensure that even when resuming a query it's not currently active.
@@ -438,7 +438,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   [self.localViewReferences removeReferencesForID:queryData.targetID];
   if (self.garbageCollector.isEager) {
-    [self.queryCache removeQueryData:queryData group:group];
+    [self.queryCache removeQueryData:queryData];
   }
   [self.targetIDs removeObjectForKey:@(queryData.targetID)];
 

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -133,7 +133,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)startMutationQueue {
   FSTWriteGroup *group = [self.persistence startGroupWithAction:@"Start MutationQueue"];
-  [self.mutationQueue startWithGroup:group];
+  [self.mutationQueue start];
 
   // If we have any leftover mutation batch results from a prior run, just drop them.
   // TODO(http://b/33446471): We probably need to repopulate heldBatchResults or similar instead,
@@ -149,7 +149,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (batches.count > 0) {
       // NOTE: This could be more efficient if we had a removeBatchesThroughBatchID, but this set
       // should be very small and this code should go away eventually.
-      [self.mutationQueue removeMutationBatches:batches group:group];
+      [self.mutationQueue removeMutationBatches:batches];
     }
   }
   [self.persistence commitGroup:group];
@@ -211,8 +211,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTWriteGroup *group = [self.persistence startGroupWithAction:@"Locally write mutations"];
   FIRTimestamp *localWriteTime = [FIRTimestamp timestamp];
   FSTMutationBatch *batch = [self.mutationQueue addMutationBatchWithWriteTime:localWriteTime
-                                                                    mutations:mutations
-                                                                        group:group];
+                                                                    mutations:mutations];
   FSTDocumentKeySet *keys = [batch keys];
   FSTMaybeDocumentDictionary *changedDocuments = [self.localDocuments documentsForKeys:keys];
   [self.persistence commitGroup:group];
@@ -224,8 +223,7 @@ NS_ASSUME_NONNULL_BEGIN
   id<FSTMutationQueue> mutationQueue = self.mutationQueue;
 
   [mutationQueue acknowledgeBatch:batchResult.batch
-                      streamToken:batchResult.streamToken
-                            group:group];
+                      streamToken:batchResult.streamToken];
 
   FSTDocumentKeySet *affected;
   if ([self shouldHoldBatchResultWithVersion:batchResult.commitVersion]) {
@@ -273,7 +271,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setLastStreamToken:(nullable NSData *)streamToken {
   FSTWriteGroup *group = [self.persistence startGroupWithAction:@"Set stream token"];
 
-  [self.mutationQueue setLastStreamToken:streamToken group:group];
+  [self.mutationQueue setLastStreamToken:streamToken];
   [self.persistence commitGroup:group];
 }
 
@@ -550,7 +548,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
   }
 
-  [self.mutationQueue removeMutationBatches:batches group:group];
+  [self.mutationQueue removeMutationBatches:batches];
 
   return affectedDocs;
 }

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -210,8 +210,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (FSTLocalWriteResult *)locallyWriteMutations:(NSArray<FSTMutation *> *)mutations {
   FSTWriteGroup *group = [self.persistence startGroupWithAction:@"Locally write mutations"];
   FIRTimestamp *localWriteTime = [FIRTimestamp timestamp];
-  FSTMutationBatch *batch = [self.mutationQueue addMutationBatchWithWriteTime:localWriteTime
-                                                                    mutations:mutations];
+  FSTMutationBatch *batch =
+      [self.mutationQueue addMutationBatchWithWriteTime:localWriteTime mutations:mutations];
   FSTDocumentKeySet *keys = [batch keys];
   FSTMaybeDocumentDictionary *changedDocuments = [self.localDocuments documentsForKeys:keys];
   [self.persistence commitGroup:group];
@@ -222,8 +222,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTWriteGroup *group = [self.persistence startGroupWithAction:@"Acknowledge batch"];
   id<FSTMutationQueue> mutationQueue = self.mutationQueue;
 
-  [mutationQueue acknowledgeBatch:batchResult.batch
-                      streamToken:batchResult.streamToken];
+  [mutationQueue acknowledgeBatch:batchResult.batch streamToken:batchResult.streamToken];
 
   FSTDocumentKeySet *affected;
   if ([self shouldHoldBatchResultWithVersion:batchResult.commitVersion]) {

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -477,7 +477,7 @@ NS_ASSUME_NONNULL_BEGIN
   std::set<DocumentKey> garbage = [self.garbageCollector collectGarbage];
   if (garbage.size() > 0) {
     for (const DocumentKey &key : garbage) {
-      [self.remoteDocumentCache removeEntryForKey:key group:group];
+      [self.remoteDocumentCache removeEntryForKey:key];
     }
   }
   [self.persistence commitGroup:group];

--- a/Firestore/Source/Local/FSTMemoryMutationQueue.mm
+++ b/Firestore/Source/Local/FSTMemoryMutationQueue.mm
@@ -92,7 +92,7 @@ static const NSComparator NumberComparator = ^NSComparisonResult(NSNumber *left,
 
 #pragma mark - FSTMutationQueue implementation
 
-- (void)startWithGroup:(FSTWriteGroup *)group {
+- (void)start {
   // Note: The queue may be shutdown / started multiple times, since we maintain the queue for the
   // duration of the app session in case a user logs out / back in. To behave like the
   // LevelDB-backed MutationQueue (and accommodate tests that expect as much), we reset nextBatchID
@@ -119,8 +119,7 @@ static const NSComparator NumberComparator = ^NSComparisonResult(NSNumber *left,
 }
 
 - (void)acknowledgeBatch:(FSTMutationBatch *)batch
-             streamToken:(nullable NSData *)streamToken
-                   group:(__unused FSTWriteGroup *)group {
+             streamToken:(nullable NSData *)streamToken {
   NSMutableArray<FSTMutationBatch *> *queue = self.queue;
 
   FSTBatchID batchID = batch.batchID;
@@ -139,13 +138,8 @@ static const NSComparator NumberComparator = ^NSComparisonResult(NSNumber *left,
   self.lastStreamToken = streamToken;
 }
 
-- (void)setLastStreamToken:(nullable NSData *)streamToken group:(__unused FSTWriteGroup *)group {
-  self.lastStreamToken = streamToken;
-}
-
 - (FSTMutationBatch *)addMutationBatchWithWriteTime:(FIRTimestamp *)localWriteTime
-                                          mutations:(NSArray<FSTMutation *> *)mutations
-                                              group:(FSTWriteGroup *)group {
+                                          mutations:(NSArray<FSTMutation *> *)mutations {
   FSTAssert(mutations.count > 0, @"Mutation batches should not be empty");
 
   FSTBatchID batchID = self.nextBatchID;
@@ -299,7 +293,7 @@ static const NSComparator NumberComparator = ^NSComparisonResult(NSNumber *left,
   return result;
 }
 
-- (void)removeMutationBatches:(NSArray<FSTMutationBatch *> *)batches group:(FSTWriteGroup *)group {
+- (void)removeMutationBatches:(NSArray<FSTMutationBatch *> *)batches {
   NSUInteger batchCount = batches.count;
   FSTAssert(batchCount > 0, @"Should not remove mutations when none exist.");
 

--- a/Firestore/Source/Local/FSTMemoryMutationQueue.mm
+++ b/Firestore/Source/Local/FSTMemoryMutationQueue.mm
@@ -118,8 +118,7 @@ static const NSComparator NumberComparator = ^NSComparisonResult(NSNumber *left,
   return _highestAcknowledgedBatchID;
 }
 
-- (void)acknowledgeBatch:(FSTMutationBatch *)batch
-             streamToken:(nullable NSData *)streamToken {
+- (void)acknowledgeBatch:(FSTMutationBatch *)batch streamToken:(nullable NSData *)streamToken {
   NSMutableArray<FSTMutationBatch *> *queue = self.queue;
 
   FSTBatchID batchID = batch.batchID;

--- a/Firestore/Source/Local/FSTMemoryQueryCache.mm
+++ b/Firestore/Source/Local/FSTMemoryQueryCache.mm
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FSTMemoryQueryCache {
   /** The last received snapshot version. */
-  //FSTSnapshotVersion *_lastRemoteSnapshotVersion;
+  // FSTSnapshotVersion *_lastRemoteSnapshotVersion;
 }
 
 - (instancetype)init {
@@ -119,13 +119,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark Reference tracking
 
-- (void)addMatchingKeys:(FSTDocumentKeySet *)keys
-            forTargetID:(FSTTargetID)targetID {
+- (void)addMatchingKeys:(FSTDocumentKeySet *)keys forTargetID:(FSTTargetID)targetID {
   [self.references addReferencesToKeys:keys forID:targetID];
 }
 
-- (void)removeMatchingKeys:(FSTDocumentKeySet *)keys
-               forTargetID:(FSTTargetID)targetID {
+- (void)removeMatchingKeys:(FSTDocumentKeySet *)keys forTargetID:(FSTTargetID)targetID {
   [self.references removeReferencesToKeys:keys forID:targetID];
 }
 

--- a/Firestore/Source/Local/FSTMemoryQueryCache.mm
+++ b/Firestore/Source/Local/FSTMemoryQueryCache.mm
@@ -38,14 +38,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, assign) FSTListenSequenceNumber highestListenSequenceNumber;
 
+/** The last received snapshot version. */
 @property(nonatomic, strong) FSTSnapshotVersion *lastRemoteSnapshotVersion;
 
 @end
 
-@implementation FSTMemoryQueryCache {
-  /** The last received snapshot version. */
-  // FSTSnapshotVersion *_lastRemoteSnapshotVersion;
-}
+@implementation FSTMemoryQueryCache
 
 - (instancetype)init {
   if (self = [super init]) {

--- a/Firestore/Source/Local/FSTMemoryQueryCache.mm
+++ b/Firestore/Source/Local/FSTMemoryQueryCache.mm
@@ -38,11 +38,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, assign) FSTListenSequenceNumber highestListenSequenceNumber;
 
+@property(nonatomic, strong) FSTSnapshotVersion *lastRemoteSnapshotVersion;
+
 @end
 
 @implementation FSTMemoryQueryCache {
   /** The last received snapshot version. */
-  FSTSnapshotVersion *_lastRemoteSnapshotVersion;
+  //FSTSnapshotVersion *_lastRemoteSnapshotVersion;
 }
 
 - (instancetype)init {
@@ -73,16 +75,16 @@ NS_ASSUME_NONNULL_BEGIN
   return _highestListenSequenceNumber;
 }
 
-- (FSTSnapshotVersion *)lastRemoteSnapshotVersion {
+/*- (FSTSnapshotVersion *)lastRemoteSnapshotVersion {
   return _lastRemoteSnapshotVersion;
 }
 
 - (void)setLastRemoteSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
                                group:(FSTWriteGroup *)group {
   _lastRemoteSnapshotVersion = snapshotVersion;
-}
+}*/
 
-- (void)addQueryData:(FSTQueryData *)queryData group:(__unused FSTWriteGroup *)group {
+- (void)addQueryData:(FSTQueryData *)queryData {
   self.queries[queryData.query] = queryData;
   if (queryData.targetID > self.highestTargetID) {
     self.highestTargetID = queryData.targetID;
@@ -92,7 +94,7 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-- (void)updateQueryData:(FSTQueryData *)queryData group:(FSTWriteGroup *)group {
+- (void)updateQueryData:(FSTQueryData *)queryData {
   self.queries[queryData.query] = queryData;
   if (queryData.targetID > self.highestTargetID) {
     self.highestTargetID = queryData.targetID;
@@ -106,7 +108,7 @@ NS_ASSUME_NONNULL_BEGIN
   return (int32_t)[self.queries count];
 }
 
-- (void)removeQueryData:(FSTQueryData *)queryData group:(__unused FSTWriteGroup *)group {
+- (void)removeQueryData:(FSTQueryData *)queryData {
   [self.queries removeObjectForKey:queryData.query];
   [self.references removeReferencesForID:queryData.targetID];
 }
@@ -118,18 +120,16 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Reference tracking
 
 - (void)addMatchingKeys:(FSTDocumentKeySet *)keys
-            forTargetID:(FSTTargetID)targetID
-                  group:(__unused FSTWriteGroup *)group {
+            forTargetID:(FSTTargetID)targetID {
   [self.references addReferencesToKeys:keys forID:targetID];
 }
 
 - (void)removeMatchingKeys:(FSTDocumentKeySet *)keys
-               forTargetID:(FSTTargetID)targetID
-                     group:(__unused FSTWriteGroup *)group {
+               forTargetID:(FSTTargetID)targetID {
   [self.references removeReferencesToKeys:keys forID:targetID];
 }
 
-- (void)removeMatchingKeysForTargetID:(FSTTargetID)targetID group:(__unused FSTWriteGroup *)group {
+- (void)removeMatchingKeysForTargetID:(FSTTargetID)targetID {
   [self.references removeReferencesForID:targetID];
 }
 

--- a/Firestore/Source/Local/FSTMemoryRemoteDocumentCache.mm
+++ b/Firestore/Source/Local/FSTMemoryRemoteDocumentCache.mm
@@ -45,11 +45,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)shutdown {
 }
 
-- (void)addEntry:(FSTMaybeDocument *)document group:(FSTWriteGroup *)group {
+- (void)addEntry:(FSTMaybeDocument *)document {
   self.docs = [self.docs dictionaryBySettingObject:document forKey:document.key];
 }
 
-- (void)removeEntryForKey:(const DocumentKey &)key group:(FSTWriteGroup *)group {
+- (void)removeEntryForKey:(const DocumentKey &)key {
   self.docs = [self.docs dictionaryByRemovingObjectForKey:key];
 }
 

--- a/Firestore/Source/Local/FSTMutationQueue.h
+++ b/Firestore/Source/Local/FSTMutationQueue.h
@@ -25,7 +25,6 @@
 @class FSTMutationBatch;
 @class FSTQuery;
 @class FIRTimestamp;
-@class FSTWriteGroup;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -42,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
  * than nextBatchID. This prevents the local store from creating new batches that the mutation
  * queue would consider erroneously acknowledged.
  */
-- (void)startWithGroup:(FSTWriteGroup *)group;
+- (void)start;
 
 /** Shuts this mutation queue down, closing open files, etc. */
 - (void)shutdown;
@@ -66,19 +65,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Acknowledges the given batch. */
 - (void)acknowledgeBatch:(FSTMutationBatch *)batch
-             streamToken:(nullable NSData *)streamToken
-                   group:(FSTWriteGroup *)group;
+             streamToken:(nullable NSData *)streamToken;
 
 /** Returns the current stream token for this mutation queue. */
 - (nullable NSData *)lastStreamToken;
 
 /** Sets the stream token for this mutation queue. */
-- (void)setLastStreamToken:(nullable NSData *)streamToken group:(FSTWriteGroup *)group;
+- (void)setLastStreamToken:(nullable NSData *)streamToken;
 
 /** Creates a new mutation batch and adds it to this mutation queue. */
 - (FSTMutationBatch *)addMutationBatchWithWriteTime:(FIRTimestamp *)localWriteTime
-                                          mutations:(NSArray<FSTMutation *> *)mutations
-                                              group:(FSTWriteGroup *)group;
+                                          mutations:(NSArray<FSTMutation *> *)mutations;
 
 /** Loads the mutation batch with the given batchID. */
 - (nullable FSTMutationBatch *)lookupMutationBatch:(FSTBatchID)batchID;
@@ -150,7 +147,7 @@ NS_ASSUME_NONNULL_BEGIN
  * In both cases, the array of mutations to remove must be a contiguous range of batchIds. This is
  * most easily accomplished by loading mutations with @a -allMutationBatchesThroughBatchID:.
  */
-- (void)removeMutationBatches:(NSArray<FSTMutationBatch *> *)batches group:(FSTWriteGroup *)group;
+- (void)removeMutationBatches:(NSArray<FSTMutationBatch *> *)batches;
 
 /** Performs a consistency check, examining the mutation queue for any leaks, if possible. */
 - (void)performConsistencyCheck;

--- a/Firestore/Source/Local/FSTMutationQueue.h
+++ b/Firestore/Source/Local/FSTMutationQueue.h
@@ -64,8 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (FSTBatchID)highestAcknowledgedBatchID;
 
 /** Acknowledges the given batch. */
-- (void)acknowledgeBatch:(FSTMutationBatch *)batch
-             streamToken:(nullable NSData *)streamToken;
+- (void)acknowledgeBatch:(FSTMutationBatch *)batch streamToken:(nullable NSData *)streamToken;
 
 /** Returns the current stream token for this mutation queue. */
 - (nullable NSData *)lastStreamToken;

--- a/Firestore/Source/Local/FSTPersistence.h
+++ b/Firestore/Source/Local/FSTPersistence.h
@@ -136,7 +136,7 @@ struct FSTTransactionRunner {
    */
 
   template <typename F>
-  auto operator()(F block) ->
+  auto operator() (F block) const ->
       typename std::enable_if<std::is_void<decltype(block())>::value, void>::type {
     __strong id<FSTTransactional> strongDb = _db;
     if (!strongDb && _expect_db) {

--- a/Firestore/Source/Local/FSTPersistence.h
+++ b/Firestore/Source/Local/FSTPersistence.h
@@ -136,7 +136,7 @@ struct FSTTransactionRunner {
    */
 
   template <typename F>
-  auto operator() (F block) const ->
+  auto operator()(F block) const ->
       typename std::enable_if<std::is_void<decltype(block())>::value, void>::type {
     __strong id<FSTTransactional> strongDb = _db;
     if (!strongDb && _expect_db) {

--- a/Firestore/Source/Local/FSTQueryCache.h
+++ b/Firestore/Source/Local/FSTQueryCache.h
@@ -24,7 +24,6 @@
 @class FSTMaybeDocument;
 @class FSTQuery;
 @class FSTQueryData;
-@class FSTWriteGroup;
 @class FSTSnapshotVersion;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -73,8 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param snapshotVersion The new snapshot version.
  */
-- (void)setLastRemoteSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
-                               group:(FSTWriteGroup *)group;
+- (void)setLastRemoteSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion;
 
 /**
  * Adds an entry in the cache.
@@ -83,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param queryData A new FSTQueryData instance to put in the cache.
  */
-- (void)addQueryData:(FSTQueryData *)queryData group:(FSTWriteGroup *)group;
+- (void)addQueryData:(FSTQueryData *)queryData;
 
 /**
  * Updates an entry in the cache.
@@ -92,10 +90,10 @@ NS_ASSUME_NONNULL_BEGIN
  * and it will be replaced.
  * @param queryData An FSTQueryData instance to replace an existing entry in the cache
  */
-- (void)updateQueryData:(FSTQueryData *)queryData group:(FSTWriteGroup *)group;
+- (void)updateQueryData:(FSTQueryData *)queryData;
 
 /** Removes the cached entry for the given query data (no-op if no entry exists). */
-- (void)removeQueryData:(FSTQueryData *)queryData group:(FSTWriteGroup *)group;
+- (void)removeQueryData:(FSTQueryData *)queryData;
 
 /** Returns the number of targets cached. */
 - (int32_t)count;
@@ -110,16 +108,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Adds the given document keys to cached query results of the given target ID. */
 - (void)addMatchingKeys:(FSTDocumentKeySet *)keys
-            forTargetID:(FSTTargetID)targetID
-                  group:(FSTWriteGroup *)group;
+            forTargetID:(FSTTargetID)targetID;
 
 /** Removes the given document keys from the cached query results of the given target ID. */
 - (void)removeMatchingKeys:(FSTDocumentKeySet *)keys
-               forTargetID:(FSTTargetID)targetID
-                     group:(FSTWriteGroup *)group;
+               forTargetID:(FSTTargetID)targetID;
 
 /** Removes all the keys in the query results of the given target ID. */
-- (void)removeMatchingKeysForTargetID:(FSTTargetID)targetID group:(FSTWriteGroup *)group;
+- (void)removeMatchingKeysForTargetID:(FSTTargetID)targetID;
 
 - (FSTDocumentKeySet *)matchingKeysForTargetID:(FSTTargetID)targetID;
 

--- a/Firestore/Source/Local/FSTQueryCache.h
+++ b/Firestore/Source/Local/FSTQueryCache.h
@@ -107,12 +107,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable FSTQueryData *)queryDataForQuery:(FSTQuery *)query;
 
 /** Adds the given document keys to cached query results of the given target ID. */
-- (void)addMatchingKeys:(FSTDocumentKeySet *)keys
-            forTargetID:(FSTTargetID)targetID;
+- (void)addMatchingKeys:(FSTDocumentKeySet *)keys forTargetID:(FSTTargetID)targetID;
 
 /** Removes the given document keys from the cached query results of the given target ID. */
-- (void)removeMatchingKeys:(FSTDocumentKeySet *)keys
-               forTargetID:(FSTTargetID)targetID;
+- (void)removeMatchingKeys:(FSTDocumentKeySet *)keys forTargetID:(FSTTargetID)targetID;
 
 /** Removes all the keys in the query results of the given target ID. */
 - (void)removeMatchingKeysForTargetID:(FSTTargetID)targetID;

--- a/Firestore/Source/Local/FSTRemoteDocumentCache.h
+++ b/Firestore/Source/Local/FSTRemoteDocumentCache.h
@@ -22,7 +22,6 @@
 
 @class FSTMaybeDocument;
 @class FSTQuery;
-@class FSTWriteGroup;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -46,11 +45,10 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param maybeDocument A FSTDocument or FSTDeletedDocument to put in the cache.
  */
-- (void)addEntry:(FSTMaybeDocument *)maybeDocument group:(FSTWriteGroup *)group;
+- (void)addEntry:(FSTMaybeDocument *)maybeDocument;
 
 /** Removes the cached entry for the given key (no-op if no entry exists). */
-- (void)removeEntryForKey:(const firebase::firestore::model::DocumentKey &)documentKey
-                    group:(FSTWriteGroup *)group;
+- (void)removeEntryForKey:(const firebase::firestore::model::DocumentKey &)documentKey;
 
 /**
  * Looks up an entry in the cache.

--- a/Firestore/Source/Local/FSTRemoteDocumentChangeBuffer.mm
+++ b/Firestore/Source/Local/FSTRemoteDocumentChangeBuffer.mm
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
   [self assertValid];
 
   for (const auto &kv : *_changes) {
-    [self.remoteDocumentCache addEntry:kv.second group:group];
+    [self.remoteDocumentCache addEntry:kv.second];
   }
 
   // We should not be used to buffer any more changes.


### PR DESCRIPTION
Removes usages of `FSTWriteGroup` in `FSTMutationQueue`, `FSTQueryCache`, and `FSTRemoteDocumentCache` APIs.

The changes are mostly mechanical at this stage, although there is some consideration in the tests for what operations should be lumped into a single transaction vs changing the meaning of the test by inspecting results before committing. Theoretically, only tests that involve restarting some component should need to rely on committing changes before inspecting. 