### PR TITLE
Fix some formatting issues.

### DIFF
--- a/Firestore/Source/Model/FSTDocumentKey.mm
+++ b/Firestore/Source/Model/FSTDocumentKey.mm
@@ -116,7 +116,6 @@ const NSComparator FSTDocumentKeyComparator =
       } else {
         return NSOrderedSame;
       }
-
     };
 
 NSString *const kDocumentKeyPath = @"__name__";

--- a/Functions/.clang-format
+++ b/Functions/.clang-format
@@ -1,7 +1,0 @@
-BasedOnStyle: Google
-ColumnLimit: 100
-BinPackParameters: false
-AllowAllParametersOfDeclarationOnNextLine: true
-ObjCSpaceBeforeProtocolList: false
-SpacesInContainerLiterals: true
-PointerAlignment: Right

--- a/Functions/Example/FirebaseFunctions/FIRAppDelegate.h
+++ b/Functions/Example/FirebaseFunctions/FIRAppDelegate.h
@@ -14,7 +14,7 @@
 
 @import UIKit;
 
-@interface FIRAppDelegate : UIResponder<UIApplicationDelegate>
+@interface FIRAppDelegate : UIResponder <UIApplicationDelegate>
 
 @property(strong, nonatomic) UIWindow *window;
 

--- a/Functions/FirebaseFunctions/Public/FIRHTTPSCallable.h
+++ b/Functions/FirebaseFunctions/Public/FIRHTTPSCallable.h
@@ -84,7 +84,8 @@ NS_SWIFT_NAME(HTTPSCallable)
 // clang-format off
 // because it incorrectly breaks this NS_SWIFT_NAME.
 - (void)callWithObject:(nullable id)data
-            completion:(void (^)(FIRHTTPSCallableResult *_Nullable result, NSError *_Nullable error))completion
+            completion:(void (^)(FIRHTTPSCallableResult *_Nullable result,
+                                 NSError *_Nullable error))completion
     NS_SWIFT_NAME(call(_:completion:));
 // clang-format on
 


### PR DESCRIPTION
1. Manually fixed a line line in Functions that was >100 chars with clang-format disabled.
2. Removed the custom .clang-format for Functions, which only affected one line.
3. Re-ran style.sh, which just removed one blank line in a Firestore file.