### PR TITLE
Remove unused shutdown methods

### DIFF
--- a/Firestore/Example/Tests/Local/FSTLevelDBQueryCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBQueryCacheTests.mm
@@ -42,7 +42,6 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)tearDown {
-  [self.queryCache shutdown];
   self.persistence = nil;
   self.queryCache = nil;
 

--- a/Firestore/Example/Tests/Local/FSTLevelDBRemoteDocumentCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBRemoteDocumentCacheTests.mm
@@ -58,7 +58,6 @@ static const char *kDummy = "1";
 }
 
 - (void)tearDown {
-  [self.remoteDocumentCache shutdown];
   self.remoteDocumentCache = nil;
   self.persistence = nil;
   _db = nil;

--- a/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
@@ -108,7 +108,6 @@ FSTDocumentVersionDictionary *FSTVersionDictionary(FSTMutation *mutation,
 
 /** Restarts the local store using the FSTNoOpGarbageCollector instead of the default. */
 - (void)restartWithNoopGarbageCollector {
-
   id<FSTGarbageCollector> garbageCollector = [[FSTNoOpGarbageCollector alloc] init];
   self.localStore = [[FSTLocalStore alloc] initWithPersistence:self.localStorePersistence
                                               garbageCollector:garbageCollector

--- a/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
@@ -88,7 +88,6 @@ FSTDocumentVersionDictionary *FSTVersionDictionary(FSTMutation *mutation,
 }
 
 - (void)tearDown {
-  [self.localStore shutdown];
   [self.localStorePersistence shutdown];
 
   [super tearDown];
@@ -109,7 +108,6 @@ FSTDocumentVersionDictionary *FSTVersionDictionary(FSTMutation *mutation,
 
 /** Restarts the local store using the FSTNoOpGarbageCollector instead of the default. */
 - (void)restartWithNoopGarbageCollector {
-  [self.localStore shutdown];
 
   id<FSTGarbageCollector> garbageCollector = [[FSTNoOpGarbageCollector alloc] init];
   self.localStore = [[FSTLocalStore alloc] initWithPersistence:self.localStorePersistence

--- a/Firestore/Example/Tests/Local/FSTMemoryQueryCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTMemoryQueryCacheTests.mm
@@ -42,7 +42,6 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)tearDown {
-  [self.queryCache shutdown];
   self.persistence = nil;
   self.queryCache = nil;
 

--- a/Firestore/Example/Tests/Local/FSTMemoryRemoteDocumentCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTMemoryRemoteDocumentCacheTests.mm
@@ -39,7 +39,6 @@
 }
 
 - (void)tearDown {
-  [self.remoteDocumentCache shutdown];
   self.persistence = nil;
   self.remoteDocumentCache = nil;
 

--- a/Firestore/Example/Tests/Local/FSTMutationQueueTests.mm
+++ b/Firestore/Example/Tests/Local/FSTMutationQueueTests.mm
@@ -40,7 +40,6 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation FSTMutationQueueTests
 
 - (void)tearDown {
-  [self.mutationQueue shutdown];
   [self.persistence shutdown];
   [super tearDown];
 }
@@ -143,7 +142,6 @@ NS_ASSUME_NONNULL_BEGIN
   XCTAssertEqual([self.mutationQueue highestAcknowledgedBatchID], batch2.batchID);
 
   // Restart the queue so that nextBatchID will be reset.
-  [self.mutationQueue shutdown];
   self.mutationQueue = [self.persistence mutationQueueForUser:User("user")];
 
   FSTWriteGroup *group = [self.persistence startGroupWithAction:@"Start MutationQueue"];

--- a/Firestore/Example/Tests/Local/FSTQueryCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTQueryCacheTests.mm
@@ -324,7 +324,6 @@ NS_ASSUME_NONNULL_BEGIN
   [self.persistence commitGroup:group];
 
   // Verify that the highestTargetID even survives restarts.
-  [self.queryCache shutdown];
   self.queryCache = [self.persistence queryCache];
   [self.queryCache start];
   XCTAssertEqual([self.queryCache highestListenSequenceNumber], 100);
@@ -374,7 +373,6 @@ NS_ASSUME_NONNULL_BEGIN
   XCTAssertEqual([self.queryCache highestTargetID], 42);
   [self.persistence commitGroup:group];
   // Verify that the highestTargetID even survives restarts.
-  [self.queryCache shutdown];
   self.queryCache = [self.persistence queryCache];
   [self.queryCache start];
   XCTAssertEqual([self.queryCache highestTargetID], 42);

--- a/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.mm
@@ -191,7 +191,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)shutdown {
   [self.dispatchQueue dispatchSync:^{
     [self.remoteStore shutdown];
-    [self.localStore shutdown];
   }];
 }
 

--- a/Firestore/Source/Core/FSTFirestoreClient.mm
+++ b/Firestore/Source/Core/FSTFirestoreClient.mm
@@ -241,7 +241,6 @@ NS_ASSUME_NONNULL_BEGIN
     self->_credentialsProvider->SetUserChangeListener(nullptr);
 
     [self.remoteStore shutdown];
-    [self.localStore shutdown];
     [self.persistence shutdown];
     if (completion) {
       [self.userDispatchQueue dispatchAsync:^{

--- a/Firestore/Source/Local/FSTLevelDBMutationQueue.mm
+++ b/Firestore/Source/Local/FSTLevelDBMutationQueue.mm
@@ -133,9 +133,6 @@ using leveldb::WriteOptions;
   self.metadata = metadata;
 }
 
-- (void)shutdown {
-}
-
 + (FSTBatchID)loadNextBatchIDFromDB:(std::shared_ptr<DB>)db {
   // TODO(gsoltis): implement Prev() and SeekToLast() on LevelDbTransaction::Iterator, then port
   // this to a transaction.

--- a/Firestore/Source/Local/FSTLevelDBQueryCache.mm
+++ b/Firestore/Source/Local/FSTLevelDBQueryCache.mm
@@ -144,9 +144,6 @@ using leveldb::Status;
   [group setMessage:self.metadata forKey:[FSTLevelDBTargetGlobalKey key]];
 }
 
-- (void)shutdown {
-}
-
 - (void)saveQueryData:(FSTQueryData *)queryData group:(FSTWriteGroup *)group {
   FSTTargetID targetID = queryData.targetID;
   std::string key = [FSTLevelDBTargetKey keyWithTargetID:targetID];

--- a/Firestore/Source/Local/FSTLevelDBRemoteDocumentCache.mm
+++ b/Firestore/Source/Local/FSTLevelDBRemoteDocumentCache.mm
@@ -58,9 +58,6 @@ using leveldb::Status;
   return self;
 }
 
-- (void)shutdown {
-}
-
 - (void)addEntry:(FSTMaybeDocument *)document group:(FSTWriteGroup *)group {
   std::string key = [self remoteDocumentKey:document.key];
   [group setMessage:[self.serializer encodedMaybeDocument:document] forKey:key];

--- a/Firestore/Source/Local/FSTLocalStore.h
+++ b/Firestore/Source/Local/FSTLocalStore.h
@@ -90,9 +90,6 @@ NS_ASSUME_NONNULL_BEGIN
 /** Performs any initial startup actions required by the local store. */
 - (void)start;
 
-/** Releases any open resources. */
-- (void)shutdown;
-
 /**
  * Tells the FSTLocalStore that the currently authenticated user has changed.
  *

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -164,9 +164,6 @@ NS_ASSUME_NONNULL_BEGIN
   self.listenSequence = [[FSTListenSequence alloc] initStartingAfter:sequenceNumber];
 }
 
-- (void)shutdown {
-}
-
 - (FSTMaybeDocumentDictionary *)userDidChange:(const User &)user {
   // Swap out the mutation queue, grabbing the pending mutation batches before and after.
   FSTWriteGroup *group = [self.persistence startGroupWithAction:@"OldBatches"];

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -166,7 +166,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)shutdown {
   [self.remoteDocumentCache shutdown];
-  [self.queryCache shutdown];
 }
 
 - (FSTMaybeDocumentDictionary *)userDidChange:(const User &)user {

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -165,7 +165,6 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)shutdown {
-  [self.remoteDocumentCache shutdown];
 }
 
 - (FSTMaybeDocumentDictionary *)userDidChange:(const User &)user {

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -165,7 +165,6 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)shutdown {
-  [self.mutationQueue shutdown];
   [self.remoteDocumentCache shutdown];
   [self.queryCache shutdown];
 }
@@ -176,7 +175,6 @@ NS_ASSUME_NONNULL_BEGIN
   NSArray<FSTMutationBatch *> *oldBatches = [self.mutationQueue allMutationBatches];
   [self.persistence commitGroup:group];
 
-  [self.mutationQueue shutdown];
   [self.garbageCollector removeGarbageSource:self.mutationQueue];
 
   self.mutationQueue = [self.persistence mutationQueueForUser:user];

--- a/Firestore/Source/Local/FSTMemoryMutationQueue.mm
+++ b/Firestore/Source/Local/FSTMemoryMutationQueue.mm
@@ -105,9 +105,6 @@ static const NSComparator NumberComparator = ^NSComparisonResult(NSNumber *left,
             @"highestAcknowledgedBatchID must be less than the nextBatchID");
 }
 
-- (void)shutdown {
-}
-
 - (BOOL)isEmpty {
   // If the queue has any entries at all, the first entry must not be a tombstone (otherwise it
   // would have been removed already).

--- a/Firestore/Source/Local/FSTMemoryQueryCache.mm
+++ b/Firestore/Source/Local/FSTMemoryQueryCache.mm
@@ -61,10 +61,6 @@ NS_ASSUME_NONNULL_BEGIN
   // Nothing to do.
 }
 
-- (void)shutdown {
-  // No resources to release.
-}
-
 - (FSTTargetID)highestTargetID {
   return _highestTargetID;
 }

--- a/Firestore/Source/Local/FSTMemoryRemoteDocumentCache.mm
+++ b/Firestore/Source/Local/FSTMemoryRemoteDocumentCache.mm
@@ -42,9 +42,6 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
-- (void)shutdown {
-}
-
 - (void)addEntry:(FSTMaybeDocument *)document group:(FSTWriteGroup *)group {
   self.docs = [self.docs dictionaryBySettingObject:document forKey:document.key];
 }

--- a/Firestore/Source/Local/FSTMutationQueue.h
+++ b/Firestore/Source/Local/FSTMutationQueue.h
@@ -44,9 +44,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)startWithGroup:(FSTWriteGroup *)group;
 
-/** Shuts this mutation queue down, closing open files, etc. */
-- (void)shutdown;
-
 /** Returns YES if this queue contains no mutation batches. */
 - (BOOL)isEmpty;
 

--- a/Firestore/Source/Local/FSTQueryCache.h
+++ b/Firestore/Source/Local/FSTQueryCache.h
@@ -41,9 +41,6 @@ NS_ASSUME_NONNULL_BEGIN
 /** Starts the query cache up. */
 - (void)start;
 
-/** Shuts this cache down, closing open files, etc. */
-- (void)shutdown;
-
 /**
  * Returns the highest target ID of any query in the cache. Typically called during startup to
  * seed a target ID generator and avoid collisions with existing queries. If there are no queries

--- a/Firestore/Source/Local/FSTRemoteDocumentCache.h
+++ b/Firestore/Source/Local/FSTRemoteDocumentCache.h
@@ -35,9 +35,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @protocol FSTRemoteDocumentCache <NSObject>
 
-/** Shuts this cache down, closing open files, etc. */
-- (void)shutdown;
-
 /**
  * Adds or replaces an entry in the cache.
  *


### PR DESCRIPTION
There was no longer logic in any of these shutdown methods, so now they are gone:
 - FSTRemoteDocumentCache
 - FSTQueryCache
 - FSTMutationQueue
 - FSTLocalStore

In particular, this makes it more obvious that none of the above own the persistence layer, as none of them were responsible for freeing resources associated with persistence.