### PR TITLE
Adding a new topic subscription/unsubcription with completion handler method

### DIFF
--- a/Example/Messaging/Tests/FIRMessagingPendingTopicsListTest.m
+++ b/Example/Messaging/Tests/FIRMessagingPendingTopicsListTest.m
@@ -164,7 +164,7 @@ typedef void (^MockDelegateSubscriptionHandler)(NSString *topic,
         XCTAssertEqual(pendingTopics.numberOfBatches, 1);
         [batchSizeReductionExpectation fulfill];
       }
-      completion(FIRMessagingTopicOperationResultSucceeded, nil);
+      completion(nil);
     });
   };
 
@@ -197,7 +197,7 @@ typedef void (^MockDelegateSubscriptionHandler)(NSString *topic,
         FIRMessagingTopicOperationCompletion completion) {
     // Typically, our callbacks happen asynchronously, but to ensure resilience,
     // call back the operation on the same thread it was called in.
-    completion(FIRMessagingTopicOperationResultSucceeded, nil);
+    completion(nil);
   };
 
   self.alwaysReadyDelegate.updateHandler = ^{
@@ -238,10 +238,9 @@ typedef void (^MockDelegateSubscriptionHandler)(NSString *topic,
     // Add a 0.5 second delay to the completion, to give time to add a straggler before the batch
     // is completed
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)),
-                   dispatch_get_main_queue(),
-                   ^{
-      completion(FIRMessagingTopicOperationResultSucceeded, nil);
-    });
+                   dispatch_get_main_queue(), ^{
+                     completion(nil);
+                   });
   };
 
   // This is a normal topic, which should start fairly soon, but take a while to complete

--- a/Example/Messaging/Tests/FIRMessagingRegistrarTest.m
+++ b/Example/Messaging/Tests/FIRMessagingRegistrarTest.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-@import UIKit;
-@import XCTest;
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
 
 #import <OCMock/OCMock.h>
 

--- a/Example/Messaging/Tests/FIRMessagingRegistrarTest.m
+++ b/Example/Messaging/Tests/FIRMessagingRegistrarTest.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <UIKit/UIKit.h>
-#import <XCTest/XCTest.h>
+@import UIKit;
+@import XCTest;
 
 #import <OCMock/OCMock.h>
 
@@ -70,9 +70,8 @@ static NSString *const kSubscriptionID = @"sample-subscription-id-xyz";
                                   withToken:kFIRMessagingAppIDToken
                                     options:nil
                                shouldDelete:NO
-                                    handler:
-      ^(FIRMessagingTopicOperationResult result, NSError *error) {
-  }];
+                                    handler:^(NSError *error){
+                                    }];
 
   OCMVerify([self.mockPubsubRegistrar updateSubscriptionToTopic:[OCMArg isEqual:kTopicToSubscribeTo]
                                                       withToken:[OCMArg isEqual:kFIRMessagingAppIDToken]
@@ -85,27 +84,23 @@ static NSString *const kSubscriptionID = @"sample-subscription-id-xyz";
   [self stubCheckinService];
 
   __block FIRMessagingTopicOperationCompletion pubsubCompletion;
-  [[[self.mockPubsubRegistrar stub]
-      andDo:^(NSInvocation *invocation) {
-        pubsubCompletion(FIRMessagingTopicOperationResultSucceeded, nil);
-      }]
-      updateSubscriptionToTopic:kTopicToSubscribeTo
-                      withToken:kFIRMessagingAppIDToken
-                        options:nil
-                   shouldDelete:NO
-                        handler:[OCMArg checkWithBlock:^BOOL(id obj) {
-                          return (pubsubCompletion = obj) != nil;
-                        }]];
+  [[[self.mockPubsubRegistrar stub] andDo:^(NSInvocation *invocation) {
+    pubsubCompletion(nil);
+  }] updateSubscriptionToTopic:kTopicToSubscribeTo
+                     withToken:kFIRMessagingAppIDToken
+                       options:nil
+                  shouldDelete:NO
+                       handler:[OCMArg checkWithBlock:^BOOL(id obj) {
+                         return (pubsubCompletion = obj) != nil;
+                       }]];
 
   [self.registrar updateSubscriptionToTopic:kTopicToSubscribeTo
                                   withToken:kFIRMessagingAppIDToken
                                     options:nil
                                shouldDelete:NO
-                                    handler:
-      ^(FIRMessagingTopicOperationResult result, NSError *error) {
-    XCTAssertNil(error);
-    XCTAssertEqual(result, FIRMessagingTopicOperationResultSucceeded);
-  }];
+                                    handler:^(NSError *error) {
+                                      XCTAssertNil(error);
+                                    }];
 }
 
 - (void)testFailedUpdateSubscriptionWithNoCheckin {
@@ -116,11 +111,9 @@ static NSString *const kSubscriptionID = @"sample-subscription-id-xyz";
                                   withToken:kFIRMessagingAppIDToken
                                     options:nil
                                shouldDelete:NO
-                                    handler:
-      ^(FIRMessagingTopicOperationResult result, NSError *error) {
-    XCTAssertNotNil(error);
-    XCTAssertEqual(result, FIRMessagingTopicOperationResultError);
-  }];
+                                    handler:^(NSError *error) {
+                                      XCTAssertNotNil(error);
+                                    }];
 }
 
 #pragma mark - Private Helpers

--- a/Example/Messaging/Tests/FIRMessagingServiceTest.m
+++ b/Example/Messaging/Tests/FIRMessagingServiceTest.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-@import UIKit;
-@import XCTest;
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
 
 #import <OCMock/OCMock.h>
 

--- a/Example/Messaging/Tests/FIRMessagingServiceTest.m
+++ b/Example/Messaging/Tests/FIRMessagingServiceTest.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <UIKit/UIKit.h>
-#import <XCTest/XCTest.h>
+@import UIKit;
+@import XCTest;
 
 #import <OCMock/OCMock.h>
 
@@ -71,8 +71,8 @@
   [service.pubsub subscribeWithToken:token
                                topic:topic
                              options:nil
-                             handler:^(FIRMessagingTopicOperationResult result, NSError *error) {
-                               // not a nil block
+                             handler:^(NSError *error){
+                                 // not a nil block
                              }];
 
   // should call updateSubscription
@@ -112,7 +112,7 @@
   [messaging.pubsub unsubscribeWithToken:token
                                    topic:topic
                                  options:nil
-                                 handler:^(FIRMessagingTopicOperationResult result, NSError *error){
+                                 handler:^(NSError *error){
 
                                  }];
 
@@ -128,15 +128,14 @@
  *  Test using PubSub without explicitly starting FIRMessagingService.
  */
 - (void)testSubscribeWithoutStart {
-  [[[FIRMessaging messaging] pubsub] subscribeWithToken:@"abcdef1234"
-                                                  topic:@"/topics/hello-world"
-                                                options:nil
-                                                handler:
-      ^(FIRMessagingTopicOperationResult result, NSError *error) {
-    XCTAssertNil(error);
-    XCTAssertEqual(kFIRMessagingErrorCodePubSubFIRMessagingNotSetup,
-                   error.code);
-  }];
+  [[[FIRMessaging messaging] pubsub]
+      subscribeWithToken:@"abcdef1234"
+                   topic:@"/topics/hello-world"
+                 options:nil
+                 handler:^(NSError *error) {
+                   XCTAssertNil(error);
+                   XCTAssertEqual(kFIRMessagingErrorCodePubSubFIRMessagingNotSetup, error.code);
+                 }];
 }
 
 // TODO(chliangGoogle) Investigate why invalid token can't throw assertion but the rest can under
@@ -150,10 +149,9 @@
     [messaging.pubsub subscribeWithToken:@"abcdef1234"
                                    topic:nil
                                  options:nil
-                                 handler:
-     ^(FIRMessagingTopicOperationResult result, NSError *error) {
-       XCTFail(@"Should not invoke the handler");
-     }];
+                                 handler:^(NSError *error) {
+                                   XCTFail(@"Should not invoke the handler");
+                                 }];
   }
   @catch (NSException *exception) {
     [exceptionExpectation fulfill];
@@ -174,10 +172,9 @@
     [messaging.pubsub unsubscribeWithToken:@"abcdef1234"
                                      topic:nil
                                    options:nil
-                                   handler:
-        ^(FIRMessagingTopicOperationResult result, NSError *error) {
-      XCTFail(@"Should not invoke the handler");
-    }];
+                                   handler:^(NSError *error) {
+                                     XCTFail(@"Should not invoke the handler");
+                                   }];
   }
   @catch (NSException *exception) {
     [exceptionExpectation fulfill];

--- a/Firebase/Messaging/FIRMessagingClient.h
+++ b/Firebase/Messaging/FIRMessagingClient.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "FIRMessagingTopicsCommon.h"
+#import "FIRMessaging.h"
 
 @class FIRReachabilityChecker;
 @class GPBMessage;

--- a/Firebase/Messaging/FIRMessagingClient.m
+++ b/Firebase/Messaging/FIRMessagingClient.m
@@ -16,11 +16,7 @@
 
 #import "FIRMessagingClient.h"
 
-#ifdef COCOAPODS
-#import "FIRReachabilityChecker.h"
-#else
-#import "third_party/firebase/ios/Source/FirebaseCore/Library/Private/FIRReachabilityChecker.h"
-#endif
+#import <FirebaseCore/FIRReachabilityChecker.h>
 
 #import "FIRMessaging.h"
 #import "FIRMessagingConnection.h"

--- a/Firebase/Messaging/FIRMessagingClient.m
+++ b/Firebase/Messaging/FIRMessagingClient.m
@@ -16,8 +16,13 @@
 
 #import "FIRMessagingClient.h"
 
-#import <FirebaseCore/FIRReachabilityChecker.h>
+#ifdef COCOAPODS
+#import "FIRReachabilityChecker.h"
+#else
+#import "third_party/firebase/ios/Source/FirebaseCore/Library/Private/FIRReachabilityChecker.h"
+#endif
 
+#import "FIRMessaging.h"
 #import "FIRMessagingConnection.h"
 #import "FIRMessagingConstants.h"
 #import "FIRMessagingDataMessageManager.h"
@@ -168,8 +173,7 @@ static NSUInteger FIRMessagingServerPort() {
 
   _FIRMessagingDevAssert(handler != nil, @"Invalid handler to FIRMessaging subscribe");
 
-  FIRMessagingTopicOperationCompletion completion =
-      ^void(FIRMessagingTopicOperationResult result, NSError * error) {
+  FIRMessagingTopicOperationCompletion completion = ^void(NSError *error) {
     if (error) {
       FIRMessagingLoggerError(kFIRMessagingMessageCodeClient001, @"Failed to subscribe to topic %@",
                               error);
@@ -182,7 +186,7 @@ static NSUInteger FIRMessagingServerPort() {
                                @"Successfully subscribed to topic %@", topic);
       }
     }
-    handler(result, error);
+    handler(error);
   };
 
   [self.registrar tryToLoadValidCheckinInfo];

--- a/Firebase/Messaging/FIRMessagingPendingTopicsList.h
+++ b/Firebase/Messaging/FIRMessagingPendingTopicsList.h
@@ -16,6 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import "FIRMessaging.h"
 #import "FIRMessagingTopicsCommon.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Firebase/Messaging/FIRMessagingPubSub.h
+++ b/Firebase/Messaging/FIRMessagingPubSub.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "FIRMessagingTopicsCommon.h"
+#import "FIRMessaging.h"
 
 @class FIRMessagingClient;
 @class FIRMessagingPubSubCache;

--- a/Firebase/Messaging/FIRMessagingPubSub.m
+++ b/Firebase/Messaging/FIRMessagingPubSub.m
@@ -60,8 +60,7 @@ static NSString *const kPendingSubscriptionsListKey =
   _FIRMessagingDevAssert([token length], @"FIRMessaging error no token specified");
   _FIRMessagingDevAssert([topic length], @"FIRMessaging error Invalid empty topic specified");
   if (!self.client) {
-    handler(FIRMessagingTopicOperationResultError,
-            [NSError errorWithFCMErrorCode:kFIRMessagingErrorCodePubSubFIRMessagingNotSetup]);
+    handler([NSError errorWithFCMErrorCode:kFIRMessagingErrorCodePubSubFIRMessagingNotSetup]);
     return;
   }
 
@@ -75,8 +74,7 @@ static NSString *const kPendingSubscriptionsListKey =
   if (![[self class] isValidTopicWithPrefix:topic]) {
     FIRMessagingLoggerError(kFIRMessagingMessageCodePubSub000,
                             @"Invalid FIRMessaging Pubsub topic %@", topic);
-    handler(FIRMessagingTopicOperationResultError,
-            [NSError errorWithFCMErrorCode:kFIRMessagingErrorCodePubSubInvalidTopic]);
+    handler([NSError errorWithFCMErrorCode:kFIRMessagingErrorCodePubSubInvalidTopic]);
     return;
   }
 
@@ -93,11 +91,9 @@ static NSString *const kPendingSubscriptionsListKey =
                                      topic:topic
                                    options:options
                               shouldDelete:NO
-                                   handler:
-      ^void(FIRMessagingTopicOperationResult result, NSError * error) {
-
-    handler(result, error);
-  }];
+                                   handler:^void(NSError *error) {
+                                     handler(error);
+                                   }];
 }
 
 - (void)unsubscribeWithToken:(NSString *)token
@@ -108,8 +104,7 @@ static NSString *const kPendingSubscriptionsListKey =
   _FIRMessagingDevAssert([topic length], @"FIRMessaging error Invalid empty topic specified");
 
   if (!self.client) {
-    handler(FIRMessagingTopicOperationResultError,
-            [NSError errorWithFCMErrorCode:kFIRMessagingErrorCodePubSubFIRMessagingNotSetup]);
+    handler([NSError errorWithFCMErrorCode:kFIRMessagingErrorCodePubSubFIRMessagingNotSetup]);
     return;
   }
 
@@ -122,8 +117,7 @@ static NSString *const kPendingSubscriptionsListKey =
   if (![[self class] isValidTopicWithPrefix:topic]) {
     FIRMessagingLoggerError(kFIRMessagingMessageCodePubSub002,
                             @"Invalid FIRMessaging Pubsub topic %@", topic);
-    handler(FIRMessagingTopicOperationResultError,
-            [NSError errorWithFCMErrorCode:kFIRMessagingErrorCodePubSubInvalidTopic]);
+    handler([NSError errorWithFCMErrorCode:kFIRMessagingErrorCodePubSubInvalidTopic]);
     return;
   }
   if (![self verifyPubSubOptions:options]) {
@@ -139,11 +133,9 @@ static NSString *const kPendingSubscriptionsListKey =
                                      topic:topic
                                    options:options
                               shouldDelete:YES
-                                   handler:
-      ^void(FIRMessagingTopicOperationResult result, NSError * error) {
-
-    handler(result, error);
-  }];
+                                   handler:^void(NSError *error) {
+                                     handler(error);
+                                   }];
 }
 
 - (void)subscribeToTopic:(NSString *)topic

--- a/Firebase/Messaging/FIRMessagingRegistrar.h
+++ b/Firebase/Messaging/FIRMessagingRegistrar.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+#import "FIRMessaging.h"
 #import "FIRMessagingCheckinService.h"
-#import "FIRMessagingTopicsCommon.h"
 
 @class FIRMessagingCheckinStore;
 @class FIRMessagingPubSubRegistrar;

--- a/Firebase/Messaging/FIRMessagingRegistrar.m
+++ b/Firebase/Messaging/FIRMessagingRegistrar.m
@@ -83,7 +83,7 @@
     FIRMessagingLoggerDebug(kFIRMessagingMessageCodeRegistrar000,
                             @"Device check in error, no auth credentials found");
     NSError *error = [NSError errorWithFCMErrorCode:kFIRMessagingErrorCodeMissingDeviceID];
-    handler(FIRMessagingTopicOperationResultError, error);
+    handler(error);
   }
 }
 

--- a/Firebase/Messaging/FIRMessagingTopicOperation.h
+++ b/Firebase/Messaging/FIRMessagingTopicOperation.h
@@ -16,6 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import "FIRMessaging.h"
 #import "FIRMessagingCheckinService.h"
 #import "FIRMessagingTopicsCommon.h"
 

--- a/Firebase/Messaging/FIRMessagingTopicsCommon.h
+++ b/Firebase/Messaging/FIRMessagingTopicsCommon.h
@@ -26,27 +26,4 @@ typedef NS_ENUM(NSInteger, FIRMessagingTopicAction) {
   FIRMessagingTopicActionUnsubscribe
 };
 
-/**
- * Represents the possible results of a topic operation.
- */
-typedef NS_ENUM(NSInteger, FIRMessagingTopicOperationResult) {
-  FIRMessagingTopicOperationResultSucceeded,
-  FIRMessagingTopicOperationResultError,
-  FIRMessagingTopicOperationResultCancelled,
-};
-
-/**
- *  Callback to invoke once the HTTP call to FIRMessaging backend for updating
- *  subscription finishes.
- *
- *  @param result         The result of the operation. If the result is
- *                        FIRMessagingTopicOperationResultError, the error parameter will be
- *                        non-nil.
- *  @param error          The error which occurred while updating the subscription topic
- *                        on the FIRMessaging server. This will be nil in case the operation
- *                        was successful, or if the operation was cancelled.
- */
-typedef void(^FIRMessagingTopicOperationCompletion)
-    (FIRMessagingTopicOperationResult result, NSError * _Nullable error);
-
 NS_ASSUME_NONNULL_END

--- a/Firebase/Messaging/NSError+FIRMessaging.h
+++ b/Firebase/Messaging/NSError+FIRMessaging.h
@@ -56,6 +56,7 @@ typedef NS_ENUM(NSUInteger, FIRMessagingInternalErrorCode) {
   kFIRMessagingErrorCodePubSubAlreadyUnsubscribed = 3002,
   kFIRMessagingErrorCodePubSubInvalidTopic = 3003,
   kFIRMessagingErrorCodePubSubFIRMessagingNotSetup = 3004,
+  kFIRMessagingErrorCodePubSubOperationIsCancelled = 3005,
 };
 
 @interface NSError (FIRMessaging)

--- a/Firebase/Messaging/Public/FIRMessaging.h
+++ b/Firebase/Messaging/Public/FIRMessaging.h
@@ -23,9 +23,9 @@
  *  If the call fails we return the appropriate `error code`, described by
  *  `FIRMessagingError`.
  *
- *  @param FCMToken The valid registration token returned by FCM.
- *  @param error The error describing why a token request failed. The error code
- *               will match a value from the FIRMessagingError enumeration.
+ *  @param FCMToken  The valid registration token returned by FCM.
+ *  @param error     The error describing why a token request failed. The error code
+ *                   will match a value from the FIRMessagingError enumeration.
  */
 typedef void(^FIRMessagingFCMTokenFetchCompletion)(NSString * _Nullable FCMToken,
     NSError * _Nullable error)
@@ -44,6 +44,16 @@ typedef void(^FIRMessagingFCMTokenFetchCompletion)(NSString * _Nullable FCMToken
  */
 typedef void(^FIRMessagingDeleteFCMTokenCompletion)(NSError * _Nullable error)
     NS_SWIFT_NAME(MessagingDeleteFCMTokenCompletion);
+
+/**
+ *  Callback to invoke once the HTTP call to FIRMessaging backend for updating
+ *  subscription finishes.
+ *
+ *  @param error  The error which occurred while updating the subscription topic
+ *                on the FIRMessaging server. This will be nil in case the operation
+ *                was successful, or if the operation was cancelled.
+ */
+typedef void (^FIRMessagingTopicOperationCompletion)(NSError *_Nullable error);
 
 /**
  *  The completion handler invoked once the data connection with FIRMessaging is
@@ -459,11 +469,39 @@ NS_SWIFT_NAME(Messaging)
 - (void)subscribeToTopic:(nonnull NSString *)topic NS_SWIFT_NAME(subscribe(toTopic:));
 
 /**
+ *  Asynchronously subscribe to the topic. Adds to the pending list of topic operations.
+ *  Retry in case of failures. This makes a repeated attempt to subscribe to the topic
+ *  as compared to the `subscribe` method above which tries once.
+ *
+ *  @param topic       The topic name to subscribe to. Should be of the form
+ *                     `"/topics/<topic-name>"`.
+ *  @param completion  The completion that is invoked once the unsubscribe call ends.
+ *                     In case of success, nil error is returned. Otherwise, an
+ *                     appropriate error object is returned.
+ */
+- (void)subscribeToTopic:(NSString *)topic
+              completion:(nullable FIRMessagingTopicOperationCompletion)completion;
+
+/**
  *  Asynchronously unsubscribe from a topic.
  *
  *  @param topic The name of the topic, for example @"sports".
  */
 - (void)unsubscribeFromTopic:(nonnull NSString *)topic NS_SWIFT_NAME(unsubscribe(fromTopic:));
+
+/**
+ *  Asynchronously unsubscribe from the topic. Adds to the pending list of topic operations.
+ *  Retry in case of failures. This makes a repeated attempt to unsubscribe from the topic
+ *  as compared to the `unsubscribe` method above which tries once.
+ *
+ *  @param topic       The topic name to unsubscribe from. Should be of the form
+ *                     `"/topics/<topic-name>"`.
+ *  @param completion  The completion that is invoked once the unsubscribe call ends.
+ *                     In case of success, nil error is returned. Otherwise, an
+ *                     appropriate error object is returned.
+ */
+- (void)unsubscribeFromTopic:(NSString *)topic
+                  completion:(nullable FIRMessagingTopicOperationCompletion)completion;
 
 #pragma mark - Upstream
 


### PR DESCRIPTION
* These methods are pre-existed internally, we are exposing them to public.
* I simplify the completion to a NSError instead of enum results. I used an error code to specify the operation is canceled result.