### PR TITLE
Move isDefaultAppConfigured to public API for FIRApp

### DIFF
--- a/Firebase/Core/Private/FIRAppInternal.h
+++ b/Firebase/Core/Private/FIRAppInternal.h
@@ -130,11 +130,6 @@ typedef NSString *_Nullable (^FIRAppGetUIDImplementation)(void);
                                                    service:(NSString *)service
                                                     reason:(NSString *)reason;
 /**
- * Checks if the default app is configured without trying to configure it.
- */
-+ (BOOL)isDefaultAppConfigured;
-
-/**
  * Registers a given third-party library with the given version number to be reported for
  * analyitcs.
  *

--- a/Firebase/Core/Public/FIRApp.h
+++ b/Firebase/Core/Public/FIRApp.h
@@ -85,6 +85,11 @@ NS_SWIFT_NAME(FirebaseApp)
 + (nullable FIRApp *)defaultApp NS_SWIFT_NAME(app());
 
 /**
+ * Checks if the default app is configured without trying to configure it.
+ */
++ (BOOL)isDefaultAppConfigured;
+
+/**
  * Returns a previously created FIRApp instance with the given name, or nil if no such app exists.
  * This method is thread safe.
  */


### PR DESCRIPTION
This change moves `isDefaultConfigured` into `FIRApp`'s public API

Why this is desirable:

[Flutterfire](https://github.com/flutter/plugins/blob/master/FlutterFire.md) plugins want to register the default app when the application launches. However, to prevent an exception when using multiple plugins they need to avoid calling`[FIRApp configure]` multiple times. To do this, they check if `[FIRApp defaultApp]` is `nil`. Unfortunately, it produces a spurious log message.

> The default Firebase app has not yet been configured. Add `[FIRApp configure];` (`FirebaseApp.configure()` in Swift) to your application initialization.

Having access to the `isDefaultAppConfigured` API would allow Flutterfire plugins to determine whether the default app is configured without calling `[FIRApp defaultApp]`, avoiding the confusing log message.

The alternative is that a mechanism could be developed for each plugin to determine if the default app has been configured by a plugin already. If there are third-party plugins that also want to talk to Firebase, they'll all need to use this mechanism to avoid the error message.