### PR TITLE
Fix optimized build missing symbol issue

### DIFF
--- a/Firestore/core/src/firebase/firestore/util/status.cc
+++ b/Firestore/core/src/firebase/firestore/util/status.cc
@@ -116,11 +116,6 @@ void Status::IgnoreError() const {
   // no-op
 }
 
-std::ostream& operator<<(std::ostream& os, const Status& x) {
-  os << x.ToString();
-  return os;
-}
-
 std::string StatusCheckOpHelperOutOfLine(const Status& v, const char* msg) {
   FIREBASE_ASSERT(!v.ok());
   std::string r("Non-OK-status: ");

--- a/Firestore/core/src/firebase/firestore/util/status.h
+++ b/Firestore/core/src/firebase/firestore/util/status.h
@@ -119,8 +119,6 @@ inline bool Status::operator!=(const Status& x) const {
   return !(*this == x);
 }
 
-std::ostream& operator<<(std::ostream& os, const Status& x);
-
 typedef std::function<void(const Status&)> StatusCallback;
 
 extern std::string StatusCheckOpHelperOutOfLine(const Status& v,


### PR DESCRIPTION
Fix undefined symbol build issue on optimized internal build
```

Undefined symbols for architecture x86_64:
  "std::__1::basic_ostream<char, std::__1::char_traits<char> >& std::__1::operator<<<char, std::__1::char_traits<char>, std::__1::allocator<char> >(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
      firebase::firestore::util::operator<<(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, firebase::firestore::util::Status const&) in libutil.a(status_4f26d5dc4d6a6a2916fcdabc61c4b805.o)
ld: symbol(s) not found for architecture x86_64
```