### PR TITLE
improve logging when subscription failed

### DIFF
--- a/Firebase/Messaging/FIRMMessageCode.h
+++ b/Firebase/Messaging/FIRMMessageCode.h
@@ -172,7 +172,7 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingMessageCodeTopicOption001 = 17001,  // I-FCM017001
   kFIRMessagingMessageCodeTopicOption002 = 17002,  // I-FCM017002
   kFIRMessagingMessageCodeTopicOptionTopicEncodingFailed = 17003,  // I-FCM017003
-  kFIRMessagingMessageCodeTopicOpeartionEmptyResponse = 17004,  // I-FCM017004
+  kFIRMessagingMessageCodeTopicOperationEmptyResponse = 17004,  // I-FCM017004
   // FIRMessagingUtilities.m
   kFIRMessagingMessageCodeUtilities000 = 18000,  // I-FCM018000
   kFIRMessagingMessageCodeUtilities001 = 18001,  // I-FCM018001

--- a/Firebase/Messaging/FIRMMessageCode.h
+++ b/Firebase/Messaging/FIRMMessageCode.h
@@ -172,6 +172,7 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingMessageCodeTopicOption001 = 17001,  // I-FCM017001
   kFIRMessagingMessageCodeTopicOption002 = 17002,  // I-FCM017002
   kFIRMessagingMessageCodeTopicOptionTopicEncodingFailed = 17003,  // I-FCM017003
+  kFIRMessagingMessageCodeTopicOpeartionEmptyResponse = 17004,  // I-FCM017004
   // FIRMessagingUtilities.m
   kFIRMessagingMessageCodeUtilities000 = 18000,  // I-FCM018000
   kFIRMessagingMessageCodeUtilities001 = 18001,  // I-FCM018001

--- a/Firebase/Messaging/FIRMessagingTopicOperation.m
+++ b/Firebase/Messaging/FIRMessagingTopicOperation.m
@@ -226,7 +226,7 @@ NSString *FIRMessagingSubscriptionsServer() {
     }
     NSString *response = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     if (response.length == 0) {
-      FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTopicOpeartionEmptyResponse,
+      FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTopicOperationEmptyResponse,
                               @"Invalid registration response - zero length.");
       [self finishWithError:[NSError errorWithFCMErrorCode:kFIRMessagingErrorCodeUnknown]];
       return;

--- a/Firebase/Messaging/FIRMessagingTopicOperation.m
+++ b/Firebase/Messaging/FIRMessagingTopicOperation.m
@@ -226,6 +226,8 @@ NSString *FIRMessagingSubscriptionsServer() {
     }
     NSString *response = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     if (response.length == 0) {
+      FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTopicOption002,
+                              @"Invalid registration response %@", response);
       [self finishWithError:[NSError errorWithFCMErrorCode:kFIRMessagingErrorCodeUnknown]];
       return;
     }
@@ -233,7 +235,7 @@ NSString *FIRMessagingSubscriptionsServer() {
     _FIRMessagingDevAssert(parts.count, @"Invalid registration response");
     if (![parts[0] isEqualToString:@"token"] || parts.count <= 1) {
       FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTopicOption002,
-                              @"Invalid registration request, response");
+                              @"Invalid registration response %@", response);
       [self finishWithError:[NSError errorWithFCMErrorCode:kFIRMessagingErrorCodeUnknown]];
       return;
     }

--- a/Firebase/Messaging/FIRMessagingTopicOperation.m
+++ b/Firebase/Messaging/FIRMessagingTopicOperation.m
@@ -226,8 +226,8 @@ NSString *FIRMessagingSubscriptionsServer() {
     }
     NSString *response = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     if (response.length == 0) {
-      FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTopicOption002,
-                              @"Invalid registration response %@", response);
+      FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTopicOpeartionEmptyResponse,
+                              @"Invalid registration response - zero length.");
       [self finishWithError:[NSError errorWithFCMErrorCode:kFIRMessagingErrorCodeUnknown]];
       return;
     }


### PR DESCRIPTION
When subscription failed, we used to log only a plain message which is not helpful if we want to debug server issues.
