### PR TITLE
Fix nullability warning with new Messaging API

### DIFF
--- a/Firebase/Messaging/Public/FIRMessaging.h
+++ b/Firebase/Messaging/Public/FIRMessaging.h
@@ -476,7 +476,7 @@ NS_SWIFT_NAME(Messaging)
  *                     In case of success, nil error is returned. Otherwise, an
  *                     appropriate error object is returned.
  */
-- (void)subscribeToTopic:(NSString *)topic
+- (void)subscribeToTopic:(nonnull NSString *)topic
               completion:(nullable FIRMessagingTopicOperationCompletion)completion;
 
 /**
@@ -494,7 +494,7 @@ NS_SWIFT_NAME(Messaging)
  *                     In case of success, nil error is returned. Otherwise, an
  *                     appropriate error object is returned.
  */
-- (void)unsubscribeFromTopic:(NSString *)topic
+- (void)unsubscribeFromTopic:(nonnull NSString *)topic
                   completion:(nullable FIRMessagingTopicOperationCompletion)completion;
 
 #pragma mark - Upstream


### PR DESCRIPTION
The internal header had `NS_ASSUME_NONNULL_BEGIN/END` but the public header does not.