### PR TITLE
Unify the representation of the dotInfoConnected value to always be a…

### DIFF
--- a/Firebase/Database/Core/FRepo.m
+++ b/Firebase/Database/Core/FRepo.m
@@ -513,11 +513,11 @@
 }
 
 - (void)onConnect:(FPersistentConnection *)fpconnection {
-    [self updateInfo:kDotInfoConnected withValue:@true];
+    [self updateInfo:kDotInfoConnected withValue:@YES];
 }
 
 - (void)onDisconnect:(FPersistentConnection *)fpconnection {
-    [self updateInfo:kDotInfoConnected withValue:@false];
+    [self updateInfo:kDotInfoConnected withValue:@NO];
     [self runOnDisconnectEvents];
 }
 


### PR DESCRIPTION
Prior to this change, the `kDotInfoConnected` path was initialized with `@NO`, which is an `NSNumber` representing a constant `__NSCFBoolean` value.

The `onConnect` and `onDisconnect` methods in `FRepo.m` later on updated the value with `@true` and `@false` respectively. These values represent `__NSCFNumber`s wrapping `int` values: `1` and `0`.

This means that even thought the value is wrapped in an `NSNumber`, it changes it's type from being a boolean to later on being an int. 

This change unifies the representation so that the value is always represented by an `NSNumber` wrapping a boolean value.

 