### PR TITLE
Core Breaking API Changes

### DIFF
--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -119,21 +119,11 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 }
 
 - (void)testConfigureWithCustomizedOptions {
-// valid customized options
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
-                                                       bundleID:kBundleID
-                                                    GCMSenderID:kGCMSenderID
-                                                         APIKey:kCustomizedAPIKey
-                                                       clientID:nil
-                                                     trackingID:nil
-                                                androidClientID:nil
-                                                    databaseURL:nil
-                                                  storageBucket:nil
-                                              deepLinkURLScheme:nil];
-#pragma clang diagnostic pop
+  // valid customized options
+  FIROptions *options =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+  options.bundleID = kBundleID;
+  options.APIKey = kCustomizedAPIKey;
   NSDictionary *expectedUserInfo =
       [self expectedUserInfoWithAppName:kFIRDefaultAppName isDefaultApp:YES];
   OCMExpect([self.notificationCenterMock postNotificationName:kFIRAppReadyToConfigureSDKNotification
@@ -194,21 +184,11 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   XCTAssertTrue([FIRApp allApps].count == 1);
   self.app = [FIRApp appNamed:kFIRTestAppName1];
 
-// Configure a different app with valid customized options
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  FIROptions *customizedOptions = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
-                                                                 bundleID:kBundleID
-                                                              GCMSenderID:kGCMSenderID
-                                                                   APIKey:kCustomizedAPIKey
-                                                                 clientID:nil
-                                                               trackingID:nil
-                                                          androidClientID:nil
-                                                              databaseURL:nil
-                                                            storageBucket:nil
-                                                        deepLinkURLScheme:nil];
-#pragma clang diagnostic pop
+  // Configure a different app with valid customized options
+  FIROptions *customizedOptions =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+  customizedOptions.bundleID = kBundleID;
+  customizedOptions.APIKey = kCustomizedAPIKey;
 
   NSDictionary *expectedUserInfo2 =
       [self expectedUserInfoWithAppName:kFIRTestAppName2 isDefaultApp:NO];

--- a/Example/Core/Tests/FIROptionsTest.m
+++ b/Example/Core/Tests/FIROptionsTest.m
@@ -81,51 +81,20 @@ extern NSString *const kFIRLibraryVersionID;
 }
 
 - (void)testInitCustomizedOptions {
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
-                                                       bundleID:kBundleID
-                                                    GCMSenderID:kGCMSenderID
-                                                         APIKey:kAPIKey
-                                                       clientID:kClientID
-                                                     trackingID:kTrackingID
-                                                androidClientID:(id _Nonnull)nil
-                                                    databaseURL:kDatabaseURL
-                                                  storageBucket:kStorageBucket
-                                              deepLinkURLScheme:kDeepLinkURLScheme];
-#pragma clang pop
-  [self assertOptionsMatchDefaults:options andProjectID:NO];
+  FIROptions *options =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+  options.androidClientID = kAndroidClientID;
+  options.APIKey = kAPIKey;
+  options.bundleID = kBundleID;
+  options.clientID = kClientID;
+  options.databaseURL = kDatabaseURL;
+  options.deepLinkURLScheme = kDeepLinkURLScheme;
+  options.projectID = kProjectID;
+  options.storageBucket = kStorageBucket;
+  options.trackingID = kTrackingID;
+  [self assertOptionsMatchDefaults:options andProjectID:YES];
   XCTAssertEqualObjects(options.deepLinkURLScheme, kDeepLinkURLScheme);
   XCTAssertFalse(options.usingOptionsFromDefaultPlist);
-
-  FIROptions *options2 =
-      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
-  options2.APIKey = kAPIKey;
-  options2.bundleID = kBundleID;
-  options2.clientID = kClientID;
-  options2.databaseURL = kDatabaseURL;
-  options2.deepLinkURLScheme = kDeepLinkURLScheme;
-  options2.projectID = kProjectID;
-  options2.storageBucket = kStorageBucket;
-  options2.trackingID = kTrackingID;
-  [self assertOptionsMatchDefaults:options2 andProjectID:YES];
-  XCTAssertEqualObjects(options2.deepLinkURLScheme, kDeepLinkURLScheme);
-  XCTAssertFalse(options.usingOptionsFromDefaultPlist);
-
-// nil GoogleAppID should throw an exception
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  XCTAssertThrows([[FIROptions alloc] initWithGoogleAppID:nil
-                                                 bundleID:kBundleID
-                                              GCMSenderID:kGCMSenderID
-                                                   APIKey:kCustomizedAPIKey
-                                                 clientID:nil
-                                               trackingID:nil
-                                          androidClientID:nil
-                                              databaseURL:nil
-                                            storageBucket:nil
-                                        deepLinkURLScheme:nil]);
-#pragma clang diagnostic pop
 }
 
 - (void)testInitWithContentsOfFile {
@@ -239,16 +208,9 @@ extern NSString *const kFIRLibraryVersionID;
   XCTAssertEqualObjects(newOptions.deepLinkURLScheme, kDeepLinkURLScheme);
 
   // customized options
-  FIROptions *customizedOptions = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
-                                                                 bundleID:kBundleID
-                                                              GCMSenderID:kGCMSenderID
-                                                                   APIKey:kAPIKey
-                                                                 clientID:kClientID
-                                                               trackingID:kTrackingID
-                                                          androidClientID:(id _Nonnull)nil
-                                                              databaseURL:kDatabaseURL
-                                                            storageBucket:kStorageBucket
-                                                        deepLinkURLScheme:kDeepLinkURLScheme];
+  FIROptions *customizedOptions =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+  customizedOptions.deepLinkURLScheme = kDeepLinkURLScheme;
   FIROptions *copyCustomizedOptions = [customizedOptions copy];
   [copyCustomizedOptions setDeepLinkURLScheme:kNewDeepLinkURLScheme];
   XCTAssertEqualObjects(customizedOptions.deepLinkURLScheme, kDeepLinkURLScheme);

--- a/Example/Core/Tests/FIROptionsTest.m
+++ b/Example/Core/Tests/FIROptionsTest.m
@@ -83,7 +83,6 @@ extern NSString *const kFIRLibraryVersionID;
 - (void)testInitCustomizedOptions {
   FIROptions *options =
       [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
-  options.androidClientID = kAndroidClientID;
   options.APIKey = kAPIKey;
   options.bundleID = kBundleID;
   options.clientID = kClientID;

--- a/Example/Core/Tests/FIRTestCase.m
+++ b/Example/Core/Tests/FIRTestCase.m
@@ -14,6 +14,7 @@
 
 #import "FIRTestCase.h"
 
+NSString *const kAndroidClientID = @"correct_android_client_id";
 NSString *const kAPIKey = @"correct_api_key";
 NSString *const kCustomizedAPIKey = @"customized_api_key";
 NSString *const kClientID = @"correct_client_id";

--- a/Firebase/Core/CHANGELOG.md
+++ b/Firebase/Core/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [changed] Removed dependency on UIKit.
+- [changed] Removed `UIKit` import from `FIRApp.h`.
 - [changed] Removed deprecated methods.
 
 # 2018-03-06 -- v4.0.16 -- M22

--- a/Firebase/Core/CHANGELOG.md
+++ b/Firebase/Core/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+- [changed] Removed dependency on UIKit.
+- [changed] Removed deprecated methods.
 
 # 2018-03-06 -- v4.0.16 -- M22
 - [changed] Addresses CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF warnings that surface in newer versions of Xcode and CocoaPods.

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -133,23 +133,6 @@ static NSMutableDictionary *sLibraryVersions;
       [FIRApp sendNotificationsToSDKs:sDefaultApp];
       sDefaultApp.alreadySentConfigureNotification = YES;
     }
-
-    if (![FIRAppEnvironmentUtil isFromAppStore]) {
-      // Support for iOS 7 has been deprecated, but will continue to function for the time being.
-      // Log a notice for developers who are still targeting iOS 7 as the minimum OS version
-      // supported.
-      dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
-        NSDictionary<NSString *, id> *info = [[NSBundle mainBundle] infoDictionary];
-
-        NSString *minVersion = info[@"MinimumOSVersion"];
-        if ([minVersion hasPrefix:@"7."]) {
-          FIRLogNotice(kFIRLoggerCore, @"I-COR000026",
-                       @"Support for iOS 7 is deprecated and will "
-                       @"stop working in the future. Please upgrade your app to target iOS 8 or "
-                       @"above.");
-        }
-      });
-    }
   }
 }
 

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -298,13 +298,6 @@ static NSMutableDictionary *sLibraryVersions;
     return NO;
   }
 
-  if (NSClassFromString(@"FIRAppIndexing") != nil) {
-    FIRLogDebug(kFIRLoggerCore, @"I-COR000024",
-                @"Firebase App Indexing on iOS is deprecated. "
-                @"You don't need to take any action at this time. Learn more about Firebase App "
-                @"Indexing at https://firebase.google.com/docs/app-indexing/.");
-  }
-
   // Initialize the Analytics once there is a valid options under default app. Analytics should
   // always initialize first by itself before the other SDKs.
   if ([self.name isEqualToString:kFIRDefaultAppName]) {

--- a/Firebase/Core/FIRConfiguration.m
+++ b/Firebase/Core/FIRConfiguration.m
@@ -35,12 +35,6 @@ extern void FIRSetLoggerLevel(FIRLoggerLevel loggerLevel);
   return self;
 }
 
-// This is deprecated, use setLoggerLevel instead.
-- (void)setLogLevel:(FIRLogLevel)logLevel {
-  NSAssert(logLevel <= kFIRLogLevelMax, @"Invalid log level, %ld", (long)logLevel);
-  _logLevel = logLevel;
-}
-
 - (void)setLoggerLevel:(FIRLoggerLevel)loggerLevel {
   NSAssert(loggerLevel <= FIRLoggerLevelMax && loggerLevel >= FIRLoggerLevelMin,
            @"Invalid logger level, %ld", (long)loggerLevel);

--- a/Firebase/Core/FIROptions.m
+++ b/Firebase/Core/FIROptions.m
@@ -194,45 +194,6 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
 
 #pragma mark - Public instance methods
 
-- (instancetype)initWithGoogleAppID:(NSString *)googleAppID
-                           bundleID:(NSString *)bundleID
-                        GCMSenderID:(NSString *)GCMSenderID
-                             APIKey:(NSString *)APIKey
-                           clientID:(NSString *)clientID
-                         trackingID:(NSString *)trackingID
-                    androidClientID:(NSString *)androidClientID
-                        databaseURL:(NSString *)databaseURL
-                      storageBucket:(NSString *)storageBucket
-                  deepLinkURLScheme:(NSString *)deepLinkURLScheme {
-  self = [super init];
-  if (self) {
-    if (!googleAppID) {
-      [NSException raise:kFirebaseCoreErrorDomain format:@"Please specify a valid Google App ID."];
-    } else if (!GCMSenderID) {
-      [NSException raise:kFirebaseCoreErrorDomain format:@"Please specify a valid GCM Sender ID."];
-    }
-
-    // `bundleID` is a required property, default to the main `bundleIdentifier` if it's `nil`.
-    if (!bundleID) {
-      bundleID = [[NSBundle mainBundle] bundleIdentifier];
-    }
-
-    NSMutableDictionary *mutableOptionsDict = [NSMutableDictionary dictionary];
-    [mutableOptionsDict setValue:googleAppID forKey:kFIRGoogleAppID];
-    [mutableOptionsDict setValue:bundleID forKey:kFIRBundleID];
-    [mutableOptionsDict setValue:GCMSenderID forKey:kFIRGCMSenderID];
-    [mutableOptionsDict setValue:APIKey forKey:kFIRAPIKey];
-    [mutableOptionsDict setValue:clientID forKey:kFIRClientID];
-    [mutableOptionsDict setValue:trackingID forKey:kFIRTrackingID];
-    [mutableOptionsDict setValue:androidClientID forKey:kFIRAndroidClientID];
-    [mutableOptionsDict setValue:databaseURL forKey:kFIRDatabaseURL];
-    [mutableOptionsDict setValue:storageBucket forKey:kFIRStorageBucket];
-    self.optionsDictionary = mutableOptionsDict;
-    self.deepLinkURLScheme = deepLinkURLScheme;
-  }
-  return self;
-}
-
 - (instancetype)initWithContentsOfFile:(NSString *)plistPath {
   self = [super init];
   if (self) {

--- a/Firebase/Core/Public/FIRApp.h
+++ b/Firebase/Core/Public/FIRApp.h
@@ -16,11 +16,6 @@
 
 #import <Foundation/Foundation.h>
 
-#if TARGET_OS_IOS
-// TODO: Remove UIKit import on next breaking change release
-#import <UIKit/UIKit.h>
-#endif
-
 @class FIROptions;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Firebase/Core/Public/FIRApp.h
+++ b/Firebase/Core/Public/FIRApp.h
@@ -90,19 +90,11 @@ NS_SWIFT_NAME(FirebaseApp)
  */
 + (nullable FIRApp *)appNamed:(NSString *)name NS_SWIFT_NAME(app(name:));
 
-#if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 /**
  * Returns the set of all extant FIRApp instances, or nil if there are no FIRApp instances. This
  * method is thread safe.
  */
 @property(class, readonly, nullable) NSDictionary<NSString *, FIRApp *> *allApps;
-#else
-/**
- * Returns the set of all extant FIRApp instances, or nil if there are no FIRApp instances. This
- * method is thread safe.
- */
-+ (nullable NSDictionary<NSString *, FIRApp *> *)allApps NS_SWIFT_NAME(allApps());
-#endif  // defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 
 /**
  * Cleans up the current FIRApp, freeing associated data and returning its name to the pool for

--- a/Firebase/Core/Public/FIRConfiguration.h
+++ b/Firebase/Core/Public/FIRConfiguration.h
@@ -19,25 +19,6 @@
 #import "FIRAnalyticsConfiguration.h"
 #import "FIRLoggerLevel.h"
 
-/**
- * The log levels used by FIRConfiguration.
- */
-typedef NS_ENUM(NSInteger, FIRLogLevel) {
-  /** Error */
-  kFIRLogLevelError __deprecated = 0,
-  /** Warning */
-  kFIRLogLevelWarning __deprecated,
-  /** Info */
-  kFIRLogLevelInfo __deprecated,
-  /** Debug */
-  kFIRLogLevelDebug __deprecated,
-  /** Assert */
-  kFIRLogLevelAssert __deprecated,
-  /** Max */
-  kFIRLogLevelMax __deprecated = kFIRLogLevelAssert
-} DEPRECATED_MSG_ATTRIBUTE(
-    "Use -FIRDebugEnabled and -FIRDebugDisabled or setLoggerLevel. See FIRApp.h for more details.");
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -47,20 +28,11 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(FirebaseConfiguration)
 @interface FIRConfiguration : NSObject
 
-#if defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 /** Returns the shared configuration object. */
 @property(class, nonatomic, readonly) FIRConfiguration *sharedInstance NS_SWIFT_NAME(shared);
-#else
-/** Returns the shared configuration object. */
-+ (FIRConfiguration *)sharedInstance NS_SWIFT_NAME(shared());
-#endif  // defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 
 /** The configuration class for Firebase Analytics. */
 @property(nonatomic, readwrite) FIRAnalyticsConfiguration *analyticsConfiguration;
-
-/** Global log level. Defaults to kFIRLogLevelError. */
-@property(nonatomic, readwrite, assign) FIRLogLevel logLevel DEPRECATED_MSG_ATTRIBUTE(
-    "Use -FIRDebugEnabled and -FIRDebugDisabled or setLoggerLevel. See FIRApp.h for more details.");
 
 /**
  * Sets the logging level for internal Firebase logging. Firebase will only log messages

--- a/Firebase/Core/Public/FIROptions.h
+++ b/Firebase/Core/Public/FIROptions.h
@@ -91,25 +91,6 @@ NS_SWIFT_NAME(FirebaseOptions)
 @property(nonatomic, copy, nullable) NSString *storageBucket;
 
 /**
- * Initializes a customized instance of FIROptions with keys. googleAppID, bundleID and GCMSenderID
- * are required. Other keys may required for configuring specific services.
- */
-- (instancetype)initWithGoogleAppID:(NSString *)googleAppID
-                           bundleID:(NSString *)bundleID
-                        GCMSenderID:(NSString *)GCMSenderID
-                             APIKey:(NSString *)APIKey
-                           clientID:(NSString *)clientID
-                         trackingID:(NSString *)trackingID
-                    androidClientID:(NSString *)androidClientID
-                        databaseURL:(NSString *)databaseURL
-                      storageBucket:(NSString *)storageBucket
-                  deepLinkURLScheme:(NSString *)deepLinkURLScheme
-    DEPRECATED_MSG_ATTRIBUTE(
-        "Use `-[[FIROptions alloc] initWithGoogleAppID:GCMSenderID:]` "
-        "(`FirebaseOptions(googleAppID:gcmSenderID:)` in Swift)` and property "
-        "setters instead.");
-
-/**
  * Initializes a customized instance of FIROptions from the file at the given plist file path. This
  * will read the file synchronously from disk.
  * For example,

--- a/Firebase/Core/third_party/FIRAppEnvironmentUtil.m
+++ b/Firebase/Core/third_party/FIRAppEnvironmentUtil.m
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 #import <Foundation/Foundation.h>
-#if TARGET_OS_IOS || TARGET_OS_TV
-#import <UIKit/UIKit.h>
-#endif
 
 #import "FIRAppEnvironmentUtil.h"
 
@@ -207,11 +204,7 @@ static BOOL isAppEncrypted() {
 }
 
 + (NSString *)systemVersion {
-  #if TARGET_OS_IOS || TARGET_OS_TV
-  return [UIDevice currentDevice].systemVersion;
-  #elif TARGET_OS_OSX
   return [NSProcessInfo processInfo].operatingSystemVersionString;
-  #endif
 }
 
 + (BOOL)isAppExtension {


### PR DESCRIPTION
This change introduces breaking changes for the next major Firebase release. It removes deprecated methods, the dependency on UIKit, and removes Xcode 7 support.