### PR TITLE
Removing FirebaseStorage.downloadURL

### DIFF
--- a/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
@@ -392,10 +392,21 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 30;
 
   FIRStorageReference *ref = [self.storage referenceWithPath:@"ios/public/1mb"];
 
+  // Download URL format is
+  // "https://firebasestorage.googleapis.com/v0/b/{bucket}/o/{path}?alt=media&token={token}"
+  NSString *downloadURLPattern =
+      @"^https:\\/\\/firebasestorage.googleapis.com\\/v0\\/b\\/[^\\/]*\\/o\\/"
+      @"ios%2Fpublic%2F1mb\\?alt=media&token=[a-z0-9-]*$";
+
   [ref downloadURLWithCompletion:^(NSURL *downloadURL, NSError *error) {
     XCTAssertNil(error);
-    XCTAssertTrue(
-        [[downloadURL absoluteString] hasPrefix:@"https://firebasestorage.googleapis.com/"]);
+    NSRegularExpression *testRegex =
+        [NSRegularExpression regularExpressionWithPattern:downloadURLPattern options:0 error:nil];
+    NSString *urlString = [downloadURL absoluteString];
+    XCTAssertEqual([testRegex numberOfMatchesInString:urlString
+                                              options:0
+                                                range:NSMakeRange(0, [urlString length])],
+                   1);
     [expectation fulfill];
   }];
 

--- a/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import <FirebaseStorage/FIRStorageMetadata.h>
 #import <XCTest/XCTest.h>
-#import <math.h>
-
 #import "FirebaseStorage.h"
 
 #import <FirebaseCore/FIRApp.h>
@@ -381,7 +378,7 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 30;
   /// Only allow 1kB size, which is smaller than our file
   [ref dataWithMaxSize:1 * 1024
             completion:^(NSData *data, NSError *error) {
-              XCTAssertNil(nil);
+              XCTAssertNil(data);
               XCTAssertEqual(error.code, FIRStorageErrorCodeDownloadSizeExceeded);
               [expectation fulfill];
             }];

--- a/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
@@ -381,10 +381,26 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 30;
   /// Only allow 1kB size, which is smaller than our file
   [ref dataWithMaxSize:1 * 1024
             completion:^(NSData *data, NSError *error) {
-              XCTAssertEqual(data, nil);
+              XCTAssertNil(nil);
               XCTAssertEqual(error.code, FIRStorageErrorCodeDownloadSizeExceeded);
               [expectation fulfill];
             }];
+
+  [self waitForExpectations];
+}
+
+- (void)testUnauthenticatedSimpleGetDownloadURL {
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"testUnauthenticatedSimpleGetDownloadURL"];
+
+  FIRStorageReference *ref = [self.storage referenceWithPath:@"ios/public/1mb"];
+
+  [ref downloadURLWithCompletion:^(NSURL *downloadURL, NSError *error) {
+    XCTAssertNil(error);
+    XCTAssertTrue(
+        [[downloadURL absoluteString] hasPrefix:@"https://firebasestorage.googleapis.com/"]);
+    [expectation fulfill];
+  }];
 
   [self waitForExpectations];
 }

--- a/Example/Storage/Tests/Unit/FIRStorageMetadataTests.m
+++ b/Example/Storage/Tests/Unit/FIRStorageMetadataTests.m
@@ -90,7 +90,7 @@
   };
   FIRStorageMetadata *metadata = [[FIRStorageMetadata alloc] initWithDictionary:metaDict];
   NSDictionary *dictRepresentation = [metadata dictionaryRepresentation];
-  XCTAssertNotNil(dictRepresentation, );
+  XCTAssertNotNil(dictRepresentation);
   XCTAssertEqualObjects(dictRepresentation[kFIRStorageMetadataBucket],
                         metaDict[kFIRStorageMetadataBucket]);
   XCTAssertEqualObjects(dictRepresentation[kFIRStorageMetadataCacheControl],

--- a/Example/Storage/Tests/Unit/FIRStorageMetadataTests.m
+++ b/Example/Storage/Tests/Unit/FIRStorageMetadataTests.m
@@ -16,6 +16,7 @@
 #import <XCTest/XCTest.h>
 
 #import "FIRStorageGetDownloadURLTask.h"
+#import "FIRStorageGetDownloadURLTask_Private.h"
 #import "FIRStorageMetadata.h"
 #import "FIRStorageMetadata_Private.h"
 #import "FIRStorageUtils.h"

--- a/Firebase/Storage/CHANGELOG.md
+++ b/Firebase/Storage/CHANGELOG.md
@@ -1,5 +1,9 @@
+# v3.0.0
+- [removed] Removed `downloadURLs` property on `StorageMetadata`. Use `StorageReference.downloadURL(completion:)` to obtain a current download URL.
+- [changed] The `maxOperationRetryTime` timeout now applies to calls to `StorageReference.getMetadata(completion:)`.
+
 # v2.2.0
-- [changed] Deprecated `downloadURLs` property on `StorageMetadata`. Use `StorageReference.downloadURLWithCompletion()` to obtain a current download URL.
+- [changed] Deprecated `downloadURLs` property on `StorageMetadata`. Use `StorageReference.downloadURL(completion:)` to obtain a current download URL.
 
 # v2.1.3
 - [changed] Addresses CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF warnings that surface in newer versions of Xcode and CocoaPods.

--- a/Firebase/Storage/CHANGELOG.md
+++ b/Firebase/Storage/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v3.0.0
 - [removed] Removed `downloadURLs` property on `StorageMetadata`. Use `StorageReference.downloadURL(completion:)` to obtain a current download URL.
-- [changed] The `maxOperationRetryTime` timeout now applies to calls to `StorageReference.getMetadata(completion:)`.
+- [changed] The `maxOperationRetryTime` timeout now applies to calls to `StorageReference.getMetadata(completion:)` and `StorageReference.updateMetadata(completion:)`. These calls previously used the `maxDownloadRetryTime` and `maxUploadRetryTime` timeouts.
 
 # v2.2.0
 - [changed] Deprecated `downloadURLs` property on `StorageMetadata`. Use `StorageReference.downloadURL(completion:)` to obtain a current download URL.

--- a/Firebase/Storage/FIRStorageErrors.m
+++ b/Firebase/Storage/FIRStorageErrors.m
@@ -181,4 +181,10 @@
   return [FIRStorageErrors errorWithCode:FIRStorageErrorCodeUnknown infoDictionary:dict];
 }
 
++ (NSError *)errorWithCustomMessage:(NSString *)errorMessage {
+  return [NSError errorWithDomain:FIRStorageErrorDomain
+                             code:FIRStorageErrorCodeUnknown
+                         userInfo:@{NSLocalizedDescriptionKey : errorMessage}];
+}
+
 @end

--- a/Firebase/Storage/FIRStorageErrors.m
+++ b/Firebase/Storage/FIRStorageErrors.m
@@ -170,4 +170,15 @@
   return clientError;
 }
 
++ (NSError *)errorWithInvalidRequest:(NSData *)request {
+  NSString *requestString = [[NSString alloc] initWithData:request encoding:NSUTF8StringEncoding];
+  NSString *invalidDataString =
+      [NSString stringWithFormat:kFIRStorageInvalidDataFormat, requestString];
+  NSDictionary *dict;
+  if (invalidDataString.length > 0) {
+    dict = @{NSLocalizedFailureReasonErrorKey : invalidDataString};
+  }
+  return [FIRStorageErrors errorWithCode:FIRStorageErrorCodeUnknown infoDictionary:dict];
+}
+
 @end

--- a/Firebase/Storage/FIRStorageGetDownloadURLTask.m
+++ b/Firebase/Storage/FIRStorageGetDownloadURLTask.m
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 #import "FIRStorageGetDownloadURLTask.h"
-#import <UIKit/UIKit.h>
 
 #import "FIRStorageConstants.h"
-#import "FIRStorageMetadata_Private.h"
 #import "FIRStorageTask_Private.h"
 #import "FIRStorageUtils.h"
 

--- a/Firebase/Storage/FIRStorageGetDownloadURLTask.m
+++ b/Firebase/Storage/FIRStorageGetDownloadURLTask.m
@@ -93,7 +93,7 @@
             [FIRStorageGetDownloadURLTask downloadURLFromMetadataDictionary:responseDictionary];
         if (!downloadURL) {
           self.error =
-              [FIRStorageErrors errorWithCustomMessage:@"Failed to retrieve a download URL"];
+              [FIRStorageErrors errorWithCustomMessage:@"Failed to retrieve a download URL."];
         }
       } else {
         self.error = [FIRStorageErrors errorWithInvalidRequest:data];

--- a/Firebase/Storage/FIRStorageGetDownloadURLTask.m
+++ b/Firebase/Storage/FIRStorageGetDownloadURLTask.m
@@ -1,4 +1,4 @@
-// Copyright 2017 Google
+// Copyright 2018 Google
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "FIRStorageGetMetadataTask.h"
+#import "FIRStorageGetDownloadURLTask.h"
+#import <UIKit/UIKit.h>
 
 #import "FIRStorageConstants.h"
 #import "FIRStorageMetadata_Private.h"
@@ -21,9 +22,9 @@
 
 #import "FirebaseStorage.h"
 
-@implementation FIRStorageGetMetadataTask {
+@implementation FIRStorageGetDownloadURLTask {
  @private
-  FIRStorageVoidMetadataError _completion;
+  FIRStorageVoidURLError _completion;
 }
 
 @synthesize fetcher = _fetcher;
@@ -31,7 +32,7 @@
 
 - (instancetype)initWithReference:(FIRStorageReference *)reference
                    fetcherService:(GTMSessionFetcherService *)service
-                       completion:(FIRStorageVoidMetadataError)completion {
+                       completion:(FIRStorageVoidURLError)completion {
   self = [super initWithReference:reference fetcherService:service];
   if (self) {
     _completion = [completion copy];
@@ -43,22 +44,44 @@
   [_fetcher stopFetching];
 }
 
++ (NSURL *)downloadURLFromMetadataDictionary:(NSDictionary *)dictionary {
+  NSString *downloadTokens = dictionary[kFIRStorageMetadataDownloadTokens];
+
+  if (downloadTokens && downloadTokens.length > 0) {
+    NSArray<NSString *> *downloadTokenArray = [downloadTokens componentsSeparatedByString:@","];
+    NSString *bucket = dictionary[kFIRStorageMetadataBucket];
+    NSString *path = dictionary[kFIRStorageMetadataName];
+    NSString *fullPath = [NSString stringWithFormat:kFIRStorageFullPathFormat, bucket,
+                                                    [FIRStorageUtils GCSEscapedString:path]];
+
+    NSURLComponents *components = [[NSURLComponents alloc] init];
+    components.scheme = kFIRStorageScheme;
+    components.host = kFIRStorageHost;
+    components.percentEncodedPath = fullPath;
+    components.query = [NSString stringWithFormat:@"alt=media&token=%@", downloadTokenArray[0]];
+
+    return [components URL];
+  }
+
+  return nil;
+}
+
 - (void)enqueue {
   NSMutableURLRequest *request = [self.baseRequest mutableCopy];
   request.HTTPMethod = @"GET";
   request.timeoutInterval = self.reference.storage.maxDownloadRetryTime;
 
-  FIRStorageVoidMetadataError callback = _completion;
+  FIRStorageVoidURLError callback = _completion;
   _completion = nil;
 
   GTMSessionFetcher *fetcher = [self.fetcherService fetcherWithRequest:request];
   _fetcher = fetcher;
-  fetcher.comment = @"GetMetadataTask";
+  fetcher.comment = @"DownloadURLTask";
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
   _fetcherCompletion = ^(NSData *data, NSError *error) {
-    FIRStorageMetadata *metadata;
+    NSURL *downloadURL;
     if (error) {
       if (!self.error) {
         self.error = [FIRStorageErrors errorWithServerError:error reference:self.reference];
@@ -66,21 +89,22 @@
     } else {
       NSDictionary *responseDictionary = [NSDictionary frs_dictionaryFromJSONData:data];
       if (responseDictionary != nil) {
-        metadata = [[FIRStorageMetadata alloc] initWithDictionary:responseDictionary];
-        [metadata setType:FIRStorageMetadataTypeFile];
+        downloadURL =
+            [FIRStorageGetDownloadURLTask downloadURLFromMetadataDictionary:responseDictionary];
       } else {
         self.error = [FIRStorageErrors errorWithInvalidRequest:data];
       }
     }
 
     if (callback) {
-      callback(metadata, self.error);
+      callback(downloadURL, self.error);
     }
+
     self->_fetcherCompletion = nil;
   };
 #pragma clang diagnostic pop
 
-  __weak FIRStorageGetMetadataTask *weakSelf = self;
+  __weak FIRStorageGetDownloadURLTask *weakSelf = self;
   [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
     weakSelf.fetcherCompletion(data, error);
   }];

--- a/Firebase/Storage/FIRStorageGetMetadataTask.m
+++ b/Firebase/Storage/FIRStorageGetMetadataTask.m
@@ -46,7 +46,7 @@
 - (void)enqueue {
   NSMutableURLRequest *request = [self.baseRequest mutableCopy];
   request.HTTPMethod = @"GET";
-  request.timeoutInterval = self.reference.storage.maxDownloadRetryTime;
+  request.timeoutInterval = self.reference.storage.maxOperationRetryTime;
 
   FIRStorageVoidMetadataError callback = _completion;
   _completion = nil;

--- a/Firebase/Storage/FIRStorageReference.m
+++ b/Firebase/Storage/FIRStorageReference.m
@@ -17,6 +17,7 @@
 #import "FIRStorageConstants_Private.h"
 #import "FIRStorageDeleteTask.h"
 #import "FIRStorageDownloadTask_Private.h"
+#import "FIRStorageGetDownloadURLTask.h"
 #import "FIRStorageGetMetadataTask.h"
 #import "FIRStorageMetadata_Private.h"
 #import "FIRStorageReference_Private.h"
@@ -319,16 +320,11 @@
 }
 
 - (void)downloadURLWithCompletion:(FIRStorageVoidURLError)completion {
-  dispatch_queue_t callbackQueue = _storage.fetcherServiceForApp.callbackQueue;
-  if (!callbackQueue) {
-    callbackQueue = dispatch_get_main_queue();
-  }
-
-  return [self metadataWithCompletion:^(FIRStorageMetadata *metadata, NSError *error) {
-    dispatch_async(callbackQueue, ^{
-      completion(metadata.downloadURL, error);
-    });
-  }];
+  FIRStorageGetDownloadURLTask *task =
+      [[FIRStorageGetDownloadURLTask alloc] initWithReference:self
+                                               fetcherService:_storage.fetcherServiceForApp
+                                                   completion:completion];
+  [task enqueue];
 }
 
 #pragma mark - Metadata Operations

--- a/Firebase/Storage/FIRStorageUpdateMetadataTask.m
+++ b/Firebase/Storage/FIRStorageUpdateMetadataTask.m
@@ -48,7 +48,7 @@
   NSDictionary *updateDictionary = [_updateMetadata updatedMetadata];
   NSData *updateData = [NSData frs_dataFromJSONDictionary:updateDictionary];
   request.HTTPMethod = @"PATCH";
-  request.timeoutInterval = self.reference.storage.maxUploadRetryTime;
+  request.timeoutInterval = self.reference.storage.maxOperationRetryTime;
   request.HTTPBody = updateData;
   NSString *typeString = @"application/json; charset=UTF-8";
   [request setValue:typeString forHTTPHeaderField:@"Content-Type"];

--- a/Firebase/Storage/FIRStorageUploadTask.m
+++ b/Firebase/Storage/FIRStorageUploadTask.m
@@ -154,14 +154,7 @@
       [metadata setType:FIRStorageMetadataTypeFile];
       self.metadata = metadata;
     } else {
-      NSString *returnedData = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-      NSString *invalidDataString =
-          [NSString stringWithFormat:kFIRStorageInvalidDataFormat, returnedData];
-      NSDictionary *dict;
-      if (invalidDataString.length > 0) {
-        dict = @{NSLocalizedFailureReasonErrorKey : invalidDataString};
-      }
-      self.error = [FIRStorageErrors errorWithCode:FIRStorageErrorCodeUnknown infoDictionary:dict];
+      self.error = [FIRStorageErrors errorWithInvalidRequest:data];
     }
 
     [self fireHandlersForStatus:FIRStorageTaskStatusSuccess snapshot:self.snapshot];

--- a/Firebase/Storage/Private/FIRStorageConstants_Private.h
+++ b/Firebase/Storage/Private/FIRStorageConstants_Private.h
@@ -55,7 +55,6 @@ FOUNDATION_EXPORT NSString *const kFIRStorageMetadataContentLanguage;
 FOUNDATION_EXPORT NSString *const kFIRStorageMetadataContentType;
 FOUNDATION_EXPORT NSString *const kFIRStorageMetadataCustomMetadata;
 FOUNDATION_EXPORT NSString *const kFIRStorageMetadataSize;
-FOUNDATION_EXPORT NSString *const kFIRStorageMetadataDownloadURLs;
 FOUNDATION_EXPORT NSString *const kFIRStorageMetadataGeneration;
 FOUNDATION_EXPORT NSString *const kFIRStorageMetadataMetageneration;
 FOUNDATION_EXPORT NSString *const kFIRStorageMetadataTimeCreated;

--- a/Firebase/Storage/Private/FIRStorageErrors.h
+++ b/Firebase/Storage/Private/FIRStorageErrors.h
@@ -57,6 +57,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSError *)errorWithInvalidRequest:(NSData *)request;
 
+/**
+ * Creates a Firebase Storage error with a custom error message.
+ *
+ * @param errorMessage A custom error message.
+ * @return Returns the corresponding Firebase Storage error.
+ */
++ (NSError *)errorWithCustomMessage:(NSString *)errorMessage;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Firebase/Storage/Private/FIRStorageErrors.h
+++ b/Firebase/Storage/Private/FIRStorageErrors.h
@@ -44,10 +44,18 @@ NS_ASSUME_NONNULL_BEGIN
  * Creates a Firebase Storage error from a specific GCS error and FIRStorageReference.
  * @param error Server error to wrap and return as a Firebase Storage error.
  * @param reference FIRStorageReference which provides context about the request being made.
- * @return Returns an Firebase Storage error, or nil if no error is provided.
+ * @return Returns a Firebase Storage error, or nil if no error is provided.
  */
 + (nullable NSError *)errorWithServerError:(nullable NSError *)error
                                  reference:(nullable FIRStorageReference *)reference;
+
+/**
+ * Creates a Firebase Storage error from an invalid request.
+ *
+ * @param request The NSData representation of the invalid user request.
+ * @return Returns the corresponding Firebase Storage error.
+ */
++ (NSError *)errorWithInvalidRequest:(NSData *)request;
 
 @end
 

--- a/Firebase/Storage/Private/FIRStorageGetDownloadURLTask.h
+++ b/Firebase/Storage/Private/FIRStorageGetDownloadURLTask.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRStorageTask.h"
+
+@class GTMSessionFetcherService;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Task which provides the ability to get a download URL for an object in Firebase Storage.
+ */
+@interface FIRStorageGetDownloadURLTask : FIRStorageTask <FIRStorageTaskManagement>
+
+- (instancetype)initWithReference:(FIRStorageReference *)reference
+                   fetcherService:(GTMSessionFetcherService *)service
+                       completion:(FIRStorageVoidURLError)completion;
+
+// Visible for testing.
++ (NSURL *)downloadURLFromMetadataDictionary:(NSDictionary *)dictionary;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Firebase/Storage/Private/FIRStorageGetDownloadURLTask_Private.h
+++ b/Firebase/Storage/Private/FIRStorageGetDownloadURLTask_Private.h
@@ -23,7 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface FIRStorageGetDownloadURLTask ()
 
-+ (NSURL *)downloadURLFromMetadataDictionary:(NSDictionary *)dictionary;
+/** Extracts a download URL from the StorageMetadata dictonary representation. */
++ (nullable NSURL *)downloadURLFromMetadataDictionary:(NSDictionary *)dictionary;
 
 @end
 

--- a/Firebase/Storage/Private/FIRStorageGetDownloadURLTask_Private.h
+++ b/Firebase/Storage/Private/FIRStorageGetDownloadURLTask_Private.h
@@ -14,20 +14,16 @@
  * limitations under the License.
  */
 
-#import "FIRStorageTask.h"
-
-@class GTMSessionFetcherService;
+#import "FIRStorageGetDownloadURLTask.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Task which provides the ability to get a download URL for an object in Firebase Storage.
  */
-@interface FIRStorageGetDownloadURLTask : FIRStorageTask <FIRStorageTaskManagement>
+@interface FIRStorageGetDownloadURLTask ()
 
-- (instancetype)initWithReference:(FIRStorageReference *)reference
-                   fetcherService:(GTMSessionFetcherService *)service
-                       completion:(FIRStorageVoidURLError)completion;
++ (NSURL *)downloadURLFromMetadataDictionary:(NSDictionary *)dictionary;
 
 @end
 

--- a/Firebase/Storage/Public/FIRStorageMetadata.h
+++ b/Firebase/Storage/Public/FIRStorageMetadata.h
@@ -113,12 +113,6 @@ NS_SWIFT_NAME(StorageMetadata)
 @property(strong, nonatomic, readonly, nullable) FIRStorageReference *storageReference;
 
 /**
- * An array containing all download URLs available for the object.
- */
-@property(strong, nonatomic, readonly, nullable) NSArray<NSURL *> *downloadURLs __deprecated_msg(
-    "Use `StorageReference.downloadURLWithCompletion()` to obtain a current download URL.");
-
-/**
  * Creates an instanece of FIRStorageMetadata from the contents of a dictionary.
  * @return An instance of FIRStorageMetadata that represents the contents of a dictionary.
  */
@@ -140,14 +134,6 @@ NS_SWIFT_NAME(StorageMetadata)
  * Determines if the current metadata represents a "folder".
  */
 @property(readonly, getter=isFolder) BOOL folder;
-
-/**
- * Retrieves a download URL for the given object, or nil if none exist.
- * Note that if there are many valid download tokens, this will always return the first
- * valid token created.
- */
-- (nullable NSURL *)downloadURL __deprecated_msg(
-    "Use `StorageReference.downloadURLWithCompletion()` to obtain a current download URL.");
 
 @end
 

--- a/Firestore/Example/Tests/Local/FSTMutationQueueTests.mm
+++ b/Firestore/Example/Tests/Local/FSTMutationQueueTests.mm
@@ -246,7 +246,6 @@ NS_ASSUME_NONNULL_BEGIN
         return newBatches;
       });
   self.persistence.run("testNextMutationBatchAfterBatchIDSkipsAcknowledgedBatches", [&]() {
-
     [self.mutationQueue acknowledgeBatch:batches[0] streamToken:nil];
     XCTAssertEqualObjects([self.mutationQueue nextMutationBatchAfterBatchID:kFSTBatchIDUnknown],
                           batches[1]);


### PR DESCRIPTION
This PR removes download URL handling from FIRStorageMetadata and adds a new Download URL Task that is then used in FIRStorageReference. 