### PR TITLE
Fix build on linux due to isnan not being present.

### DIFF
--- a/Firestore/core/src/firebase/firestore/geo_point.cc
+++ b/Firestore/core/src/firebase/firestore/geo_point.cc
@@ -20,6 +20,8 @@
 
 #include "Firestore/core/src/firebase/firestore/util/firebase_assert.h"
 
+using std::isnan;
+
 namespace firebase {
 namespace firestore {
 

--- a/Firestore/core/src/firebase/firestore/util/comparison.cc
+++ b/Firestore/core/src/firebase/firestore/util/comparison.cc
@@ -19,6 +19,8 @@
 #include <cmath>
 #include <limits>
 
+using std::isnan;
+
 namespace firebase {
 namespace firestore {
 namespace util {


### PR DESCRIPTION
Since we now include cmath rather than math.h, isnan is now named
std::isnan.