### PR TITLE
Enable Core Unit Tests to run in a Release config

### DIFF
--- a/Example/Core/Tests/FIRLoggerTest.m
+++ b/Example/Core/Tests/FIRLoggerTest.m
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifdef DEBUG
+// The tests depend upon library methods only built with #ifdef DEBUG
+
 #import "FIRTestCase.h"
 
 #import <FirebaseCore/FIRLogger.h>
@@ -267,3 +270,4 @@ static NSString *const kMessageCode = @"I-COR000001";
 }
 
 @end
+#endif


### PR DESCRIPTION
FIRLoggerTests depend on C functions in FIRLogger only built with #ifdef DEBUG

Addresses internal b/77335272