### PR TITLE
remove deprecated data message callback 

### DIFF
--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -807,11 +807,6 @@ FIRInstanceIDAPNSTokenType FIRIIDAPNSTokenTypeFromAPNSTokenType(FIRMessagingAPNS
 #pragma clang diagnostic ignored "-Wunguarded-availability"
     [self.delegate messaging:self didReceiveMessage:remoteMessage];
 #pragma pop
-  } else if ([self.delegate respondsToSelector:@selector(applicationReceivedRemoteMessage:)]) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [self.delegate applicationReceivedRemoteMessage:remoteMessage];
-#pragma clang diagnostic pop
   } else {
     // Delegate methods weren't implemented, so messages are being dropped, log a warning
     FIRMessagingLoggerWarn(kFIRMessagingMessageCodeRemoteMessageDelegateMethodNotImplemented,

--- a/Firebase/Messaging/FIRMessagingRemoteNotificationsProxy.m
+++ b/Firebase/Messaging/FIRMessagingRemoteNotificationsProxy.m
@@ -30,6 +30,7 @@ static NSString *kUserNotificationWillPresentSelectorString =
     @"userNotificationCenter:willPresentNotification:withCompletionHandler:";
 static NSString *kUserNotificationDidReceiveResponseSelectorString =
     @"userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:";
+static NSString *kReceiveDataMessageSelectorString = @"messaging:didReceiveMessage:";
 
 @interface FIRMessagingRemoteNotificationsProxy ()
 
@@ -141,9 +142,6 @@ static NSString *kUserNotificationDidReceiveResponseSelectorString =
   SEL remoteNotificationWithFetchHandlerSelector =
       @selector(application:didReceiveRemoteNotification:fetchCompletionHandler:);
 
-  // For data message from MCS.
-  SEL receiveDataMessageSelector = NSSelectorFromString(@"applicationReceivedRemoteMessage:");
-
   // For recording when APNS tokens are registered (or fail to register)
   SEL registerForAPNSFailSelector =
       @selector(application:didFailToRegisterForRemoteNotificationsWithError:);
@@ -172,11 +170,13 @@ static NSString *kUserNotificationDidReceiveResponseSelectorString =
     didSwizzleAppDelegate = YES;
   }
 
+  // For data message from MCS.
+  SEL receiveDataMessageSelector = NSSelectorFromString(kReceiveDataMessageSelectorString);
   if ([appDelegate respondsToSelector:receiveDataMessageSelector]) {
     [self swizzleSelector:receiveDataMessageSelector
-                  inClass:appDelegateClass
-       withImplementation:(IMP)FCM_swizzle_applicationReceivedRemoteMessage
-               inProtocol:@protocol(UIApplicationDelegate)];
+                   inClass:appDelegateClass
+        withImplementation:(IMP)FCM_swizzle_messagingDidReceiveMessage
+                inProtocol:@protocol(UIApplicationDelegate)];
     didSwizzleAppDelegate = YES;
   }
 
@@ -669,14 +669,15 @@ id userInfoFromNotification(id notification) {
   return notificationUserInfo;
 }
 
-void FCM_swizzle_applicationReceivedRemoteMessage(
-    id self, SEL _cmd, FIRMessagingRemoteMessage *remoteMessage) {
+void FCM_swizzle_applicationReceivedRemoteMessage(id self, SEL _cmd, FIRMessaging *message,
+                                                  FIRMessagingRemoteMessage *remoteMessage) {
   [[FIRMessaging messaging] appDidReceiveMessage:remoteMessage.appData];
 
   IMP original_imp =
       [[FIRMessagingRemoteNotificationsProxy sharedProxy] originalImplementationForSelector:_cmd];
   if (original_imp) {
-    ((void (*)(id, SEL, FIRMessagingRemoteMessage *))original_imp)(self, _cmd, remoteMessage);
+    ((void (*)(id, SEL, FIRMessaging *, FIRMessagingRemoteMessage *))original_imp)(
+        self, _cmd, message, remoteMessage);
   }
 }
 

--- a/Firebase/Messaging/FIRMessagingRemoteNotificationsProxy.m
+++ b/Firebase/Messaging/FIRMessagingRemoteNotificationsProxy.m
@@ -669,8 +669,8 @@ id userInfoFromNotification(id notification) {
   return notificationUserInfo;
 }
 
-void FCM_swizzle_applicationReceivedRemoteMessage(id self, SEL _cmd, FIRMessaging *message,
-                                                  FIRMessagingRemoteMessage *remoteMessage) {
+void FCM_swizzle_messagingDidReceiveMessage(id self, SEL _cmd, FIRMessaging *message,
+                                            FIRMessagingRemoteMessage *remoteMessage) {
   [[FIRMessaging messaging] appDidReceiveMessage:remoteMessage.appData];
 
   IMP original_imp =

--- a/Firebase/Messaging/Public/FIRMessaging.h
+++ b/Firebase/Messaging/Public/FIRMessaging.h
@@ -276,11 +276,6 @@ NS_SWIFT_NAME(MessagingDelegate)
     NS_SWIFT_NAME(messaging(_:didReceive:))
     __IOS_AVAILABLE(10.0);
 
-/// The callback to handle data message received via FCM for devices running iOS 10 or above.
-- (void)applicationReceivedRemoteMessage:(FIRMessagingRemoteMessage *)remoteMessage
-    NS_SWIFT_NAME(application(received:))
-    __deprecated_msg("Use FIRMessagingDelegate’s -messaging:didReceiveMessage:");
-
 @end
 
 /**


### PR DESCRIPTION
Remove the deprecated data message callback.

Also fix the issue swizzling was not setup properly for recommended data message callback. When swizzling is enabled, the recommended data message callback should trigger message tracking.