### PR TITLE
Remove deprecated token callback

### DIFF
--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -572,18 +572,16 @@ FIRInstanceIDAPNSTokenType FIRIIDAPNSTokenTypeFromAPNSTokenType(FIRMessagingAPNS
   [self validateDelegateConformsToTokenAvailabilityMethods];
 }
 
-// Check if the delegate conforms to either |didReceiveRegistrationToken:| or
-// |didRefreshRegistrationToken:|, and display a warning to the developer if not.
+// Check if the delegate conforms to either |didReceiveRegistrationToken:|,
+// and display a warning to the developer if not.
 // NOTE: Once |didReceiveRegistrationToken:| can be made a required method, this
 // check can be removed.
 - (void)validateDelegateConformsToTokenAvailabilityMethods {
   if (self.delegate &&
-      ![self.delegate respondsToSelector:@selector(messaging:didReceiveRegistrationToken:)] &&
-      ![self.delegate respondsToSelector:@selector(messaging:didRefreshRegistrationToken:)]) {
+      ![self.delegate respondsToSelector:@selector(messaging:didReceiveRegistrationToken:)]) {
     FIRMessagingLoggerWarn(kFIRMessagingMessageCodeTokenDelegateMethodsNotImplemented,
                            @"The object %@ does not respond to "
-                           @"-messaging:didReceiveRegistrationToken:, nor "
-                           @"-messaging:didRefreshRegistrationToken:. Please implement "
+                           @"-messaging:didReceiveRegistrationToken:. Please implement "
                            @"-messaging:didReceiveRegistrationToken: to be provided with an FCM "
                            @"token.", self.delegate.description);
   }
@@ -877,13 +875,6 @@ FIRInstanceIDAPNSTokenType FIRIIDAPNSTokenTypeFromAPNSTokenType(FIRMessagingAPNS
     if (self.defaultFcmToken && ![self.defaultFcmToken isEqualToString:oldToken]) {
       [self notifyDelegateOfFCMTokenAvailability];
     }
-    // Call deprecated refresh method, because it should still work (until it is removed).
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    if ([self.delegate respondsToSelector:@selector(messaging:didRefreshRegistrationToken:)]) {
-      [self.delegate messaging:self didRefreshRegistrationToken:token];
-    }
-#pragma clang diagnostic pop
     NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
     [center postNotificationName:FIRMessagingRegistrationTokenRefreshedNotification object:nil];
   }

--- a/Firebase/Messaging/Public/FIRMessaging.h
+++ b/Firebase/Messaging/Public/FIRMessaging.h
@@ -257,16 +257,8 @@ NS_SWIFT_NAME(MessagingDelegate)
 /// * Subscribing to any topics.
 - (void)messaging:(FIRMessaging *)messaging
     didReceiveRegistrationToken:(NSString *)fcmToken
-    NS_SWIFT_NAME(messaging(_:didReceiveRegistrationToken:));
-
-/// This method will be called whenever FCM receives a new, default FCM token for your
-/// Firebase project's Sender ID. This method is deprecated. Please use
-/// `messaging:didReceiveRegistrationToken:`.
-- (void)messaging:(FIRMessaging *)messaging
-    didRefreshRegistrationToken:(NSString *)fcmToken
-    NS_SWIFT_NAME(messaging(_:didRefreshRegistrationToken:))
-    __deprecated_msg("Please use messaging:didReceiveRegistrationToken:, which is called for both \
-                     current and refreshed tokens.");
+    NS_SWIFT_NAME(messaging(_:didReceiveRegistrationToken:))
+    __IOS_AVAILABLE(10.0);
 
 /// This method is called on iOS 10 devices to handle data messages received via FCM through its
 /// direct channel (not via APNS). For iOS 9 and below, the FCM data message is delivered via the


### PR DESCRIPTION
The deprecated token callback has been replaced by messaging:didReceiveRegistrationToken:.