### PR TITLE
Options should be nullable for subscription

### DIFF
--- a/Example/Messaging/Tests/FIRMessagingServiceTest.m
+++ b/Example/Messaging/Tests/FIRMessagingServiceTest.m
@@ -146,12 +146,15 @@
   XCTestExpectation *exceptionExpectation =
   [self expectationWithDescription:@"Should throw exception for invalid token"];
   @try {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     [messaging.pubsub subscribeWithToken:@"abcdef1234"
                                    topic:nil
                                  options:nil
                                  handler:^(NSError *error) {
                                    XCTFail(@"Should not invoke the handler");
                                  }];
+#pragma clang diagnostic pop
   }
   @catch (NSException *exception) {
     [exceptionExpectation fulfill];
@@ -169,12 +172,15 @@
   XCTestExpectation *exceptionExpectation =
       [self expectationWithDescription:@"Should throw exception for invalid token"];
   @try {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
     [messaging.pubsub unsubscribeWithToken:@"abcdef1234"
                                      topic:nil
                                    options:nil
                                    handler:^(NSError *error) {
                                      XCTFail(@"Should not invoke the handler");
                                    }];
+#pragma clang diagnostic pop
   }
   @catch (NSException *exception) {
     [exceptionExpectation fulfill];

--- a/Firebase/Messaging/FIRMessagingPubSub.h
+++ b/Firebase/Messaging/FIRMessagingPubSub.h
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)subscribeWithToken:(NSString *)token
                      topic:(NSString *)topic
-                   options:(NSDictionary *)options
+                   options:(nullable NSDictionary *)options
                    handler:(FIRMessagingTopicOperationCompletion)handler;
 
 /**
@@ -92,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)unsubscribeWithToken:(NSString *)token
                        topic:(NSString *)topic
-                     options:(NSDictionary *)options
+                     options:(nullable NSDictionary *)options
                      handler:(FIRMessagingTopicOperationCompletion)handler;
 
 /**

--- a/Firebase/Messaging/FIRMessagingPubSub.m
+++ b/Firebase/Messaging/FIRMessagingPubSub.m
@@ -55,7 +55,7 @@ static NSString *const kPendingSubscriptionsListKey =
 
 - (void)subscribeWithToken:(NSString *)token
                      topic:(NSString *)topic
-                   options:(NSDictionary *)options
+                   options:(nullable NSDictionary *)options
                    handler:(FIRMessagingTopicOperationCompletion)handler {
   _FIRMessagingDevAssert([token length], @"FIRMessaging error no token specified");
   _FIRMessagingDevAssert([topic length], @"FIRMessaging error Invalid empty topic specified");
@@ -98,7 +98,7 @@ static NSString *const kPendingSubscriptionsListKey =
 
 - (void)unsubscribeWithToken:(NSString *)token
                        topic:(NSString *)topic
-                     options:(NSDictionary *)options
+                     options:(nullable NSDictionary *)options
                      handler:(FIRMessagingTopicOperationCompletion)handler {
   _FIRMessagingDevAssert([token length], @"FIRMessaging error no token specified");
   _FIRMessagingDevAssert([topic length], @"FIRMessaging error Invalid empty topic specified");

--- a/Firebase/Messaging/FIRMessagingPubSub.m
+++ b/Firebase/Messaging/FIRMessagingPubSub.m
@@ -55,7 +55,7 @@ static NSString *const kPendingSubscriptionsListKey =
 
 - (void)subscribeWithToken:(NSString *)token
                      topic:(NSString *)topic
-                   options:(nullable NSDictionary *)options
+                   options:(NSDictionary *)options
                    handler:(FIRMessagingTopicOperationCompletion)handler {
   _FIRMessagingDevAssert([token length], @"FIRMessaging error no token specified");
   _FIRMessagingDevAssert([topic length], @"FIRMessaging error Invalid empty topic specified");
@@ -98,7 +98,7 @@ static NSString *const kPendingSubscriptionsListKey =
 
 - (void)unsubscribeWithToken:(NSString *)token
                        topic:(NSString *)topic
-                     options:(nullable NSDictionary *)options
+                     options:(NSDictionary *)options
                      handler:(FIRMessagingTopicOperationCompletion)handler {
   _FIRMessagingDevAssert([token length], @"FIRMessaging error no token specified");
   _FIRMessagingDevAssert([topic length], @"FIRMessaging error Invalid empty topic specified");


### PR DESCRIPTION
Also ignore the nonnull warning when intentionally passing a nil parameter.