### PR TITLE
import `abseil::optional`

### DIFF
--- a/Firestore/third_party/abseil-cpp/absl/types/CMakeLists.txt
+++ b/Firestore/third_party/abseil-cpp/absl/types/CMakeLists.txt
@@ -14,12 +14,37 @@
 # limitations under the License.
 #
 
+list(APPEND TYPES_PUBLIC_HEADERS
+  "bad_optional_access.h"
+  "optional.h"
+)
 
+# optional library
+list(APPEND OPTIONAL_SRC
+  "optional.cc"
+)
 
-add_subdirectory(base)
-add_subdirectory(memory)
-add_subdirectory(meta)
-add_subdirectory(numeric)
-add_subdirectory(strings)
-add_subdirectory(types)
-add_subdirectory(utility)
+absl_library(
+  TARGET
+    absl_optional
+  SOURCES
+    ${OPTIONAL_SRC}
+  PUBLIC_LIBRARIES
+    absl::base
+  EXPORT_NAME
+    optional
+)
+
+set(BAD_OPTIONAL_ACCESS_SRC "bad_optional_access.cc")
+set(BAD_OPTIONAL_ACCESS_LIBRARIES absl::base)
+
+absl_library(
+  TARGET
+    absl_bad_optional_access
+  SOURCES
+    ${BAD_OPTIONAL_ACCESS_SRC}
+  PUBLIC_LIBRARIES
+    ${BAD_OPTIONAL_ACCESS_PUBLIC_LIBRARIES}
+  EXPORT_NAME
+    bad_optional_access
+)

--- a/Firestore/third_party/abseil-cpp/absl/utility/CMakeLists.txt
+++ b/Firestore/third_party/abseil-cpp/absl/utility/CMakeLists.txt
@@ -14,12 +14,13 @@
 # limitations under the License.
 #
 
+list(APPEND UTILITY_PUBLIC_HEADERS
+  "utility.h"
+)
 
-
-add_subdirectory(base)
-add_subdirectory(memory)
-add_subdirectory(meta)
-add_subdirectory(numeric)
-add_subdirectory(strings)
-add_subdirectory(types)
-add_subdirectory(utility)
+absl_header_library(
+  TARGET
+    absl_utility
+  EXPORT_NAME
+    utility
+)

--- a/Firestore/third_party/abseil-cpp/absl/utility/utility.h
+++ b/Firestore/third_party/abseil-cpp/absl/utility/utility.h
@@ -46,100 +46,9 @@
 
 #include "absl/base/config.h"
 #include "absl/base/internal/inline_variable.h"
-#include "absl/base/internal/invoke.h"
 #include "absl/meta/type_traits.h"
 
 namespace absl {
-
-// integer_sequence
-//
-// Class template representing a compile-time integer sequence. An instantiation
-// of `integer_sequence<T, Ints...>` has a sequence of integers encoded in its
-// type through its template arguments (which is a common need when
-// working with C++11 variadic templates). `absl::integer_sequence` is designed
-// to be a drop-in replacement for C++14's `std::integer_sequence`.
-//
-// Example:
-//
-//   template< class T, T... Ints >
-//   void user_function(integer_sequence<T, Ints...>);
-//
-//   int main()
-//   {
-//     // user_function's `T` will be deduced to `int` and `Ints...`
-//     // will be deduced to `0, 1, 2, 3, 4`.
-//     user_function(make_integer_sequence<int, 5>());
-//   }
-template <typename T, T... Ints>
-struct integer_sequence {
-  using value_type = T;
-  static constexpr size_t size() noexcept { return sizeof...(Ints); }
-};
-
-// index_sequence
-//
-// A helper template for an `integer_sequence` of `size_t`,
-// `absl::index_sequence` is designed to be a drop-in replacement for C++14's
-// `std::index_sequence`.
-template <size_t... Ints>
-using index_sequence = integer_sequence<size_t, Ints...>;
-
-namespace utility_internal {
-
-template <typename Seq, size_t SeqSize, size_t Rem>
-struct Extend;
-
-// Note that SeqSize == sizeof...(Ints). It's passed explicitly for efficiency.
-template <typename T, T... Ints, size_t SeqSize>
-struct Extend<integer_sequence<T, Ints...>, SeqSize, 0> {
-  using type = integer_sequence<T, Ints..., (Ints + SeqSize)...>;
-};
-
-template <typename T, T... Ints, size_t SeqSize>
-struct Extend<integer_sequence<T, Ints...>, SeqSize, 1> {
-  using type = integer_sequence<T, Ints..., (Ints + SeqSize)..., 2 * SeqSize>;
-};
-
-// Recursion helper for 'make_integer_sequence<T, N>'.
-// 'Gen<T, N>::type' is an alias for 'integer_sequence<T, 0, 1, ... N-1>'.
-template <typename T, size_t N>
-struct Gen {
-  using type =
-      typename Extend<typename Gen<T, N / 2>::type, N / 2, N % 2>::type;
-};
-
-template <typename T>
-struct Gen<T, 0> {
-  using type = integer_sequence<T>;
-};
-
-}  // namespace utility_internal
-
-// Compile-time sequences of integers
-
-// make_integer_sequence
-//
-// This template alias is equivalent to
-// `integer_sequence<int, 0, 1, ..., N-1>`, and is designed to be a drop-in
-// replacement for C++14's `std::make_integer_sequence`.
-template <typename T, T N>
-using make_integer_sequence = typename utility_internal::Gen<T, N>::type;
-
-// make_index_sequence
-//
-// This template alias is equivalent to `index_sequence<0, 1, ..., N-1>`,
-// and is designed to be a drop-in replacement for C++14's
-// `std::make_index_sequence`.
-template <size_t N>
-using make_index_sequence = make_integer_sequence<size_t, N>;
-
-// index_sequence_for
-//
-// Converts a typename pack into an index sequence of the same length, and
-// is designed to be a drop-in replacement for C++14's
-// `std::index_sequence_for()`
-template <typename... Ts>
-using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
 
 // Tag types
 
@@ -160,27 +69,6 @@ struct in_place_t {};
 ABSL_INTERNAL_INLINE_CONSTEXPR(in_place_t, in_place, {});
 
 #endif  // ABSL_HAVE_STD_OPTIONAL
-
-#ifdef ABSL_HAVE_STD_ANY
-using std::in_place_type_t;
-#else
-
-// in_place_type_t
-//
-// Tag type used for in-place construction when the type to construct needs to
-// be specified, such as with `absl::any`, designed to be a drop-in replacement
-// for C++17's `std::in_place_type_t`.
-template <typename T>
-struct in_place_type_t {};
-#endif  // ABSL_HAVE_STD_ANY
-
-// in_place_index_t
-//
-// Tag type used for in-place construction when the type to construct needs to
-// be specified, such as with `absl::any`, designed to be a drop-in replacement
-// for C++17's `std::in_place_index_t`.
-template <size_t I>
-struct in_place_index_t {};
 
 // Constexpr move and forward
 
@@ -203,62 +91,6 @@ constexpr T&& forward(
   return static_cast<T&&>(t);
 }
 
-namespace utility_internal {
-// Helper method for expanding tuple into a called method.
-template <typename Functor, typename Tuple, std::size_t... Indexes>
-auto apply_helper(Functor&& functor, Tuple&& t, index_sequence<Indexes...>)
-    -> decltype(absl::base_internal::Invoke(
-        absl::forward<Functor>(functor),
-        std::get<Indexes>(absl::forward<Tuple>(t))...)) {
-  return absl::base_internal::Invoke(
-      absl::forward<Functor>(functor),
-      std::get<Indexes>(absl::forward<Tuple>(t))...);
-}
-
-}  // namespace utility_internal
-
-// apply
-//
-// Invokes a Callable using elements of a tuple as its arguments.
-// Each element of the tuple corresponds to an argument of the call (in order).
-// Both the Callable argument and the tuple argument are perfect-forwarded.
-// For member-function Callables, the first tuple element acts as the `this`
-// pointer. `absl::apply` is designed to be a drop-in replacement for C++17's
-// `std::apply`. Unlike C++17's `std::apply`, this is not currently `constexpr`.
-//
-// Example:
-//
-//   class Foo{void Bar(int);};
-//   void user_function(int, std::string);
-//   void user_function(std::unique_ptr<Foo>);
-//
-//   int main()
-//   {
-//       std::tuple<int, std::string> tuple1(42, "bar");
-//       // Invokes the user function overload on int, std::string.
-//       absl::apply(&user_function, tuple1);
-//
-//       auto foo = absl::make_unique<Foo>();
-//       std::tuple<Foo*, int> tuple2(foo.get(), 42);
-//       // Invokes the method Bar on foo with one argument 42.
-//       absl::apply(&Foo::Bar, foo.get(), 42);
-//
-//       std::tuple<std::unique_ptr<Foo>> tuple3(absl::make_unique<Foo>());
-//       // Invokes the user function that takes ownership of the unique
-//       // pointer.
-//       absl::apply(&user_function, std::move(tuple));
-//   }
-template <typename Functor, typename Tuple>
-auto apply(Functor&& functor, Tuple&& t)
-    -> decltype(utility_internal::apply_helper(
-        absl::forward<Functor>(functor), absl::forward<Tuple>(t),
-        absl::make_index_sequence<std::tuple_size<
-            typename std::remove_reference<Tuple>::type>::value>{})) {
-  return utility_internal::apply_helper(
-      absl::forward<Functor>(functor), absl::forward<Tuple>(t),
-      absl::make_index_sequence<std::tuple_size<
-          typename std::remove_reference<Tuple>::type>::value>{});
-}
 }  // namespace absl
 
 #endif  // ABSL_UTILITY_UTILITY_H_


### PR DESCRIPTION
Based on abseil version `bf7fc99`, the same version as the other imported abseil libraries.

Will eventually merge to `master`; right now into the branch `abseil-mirror` for easy review.