### PR TITLE
Renaming .getMetdata() to .metadata()

### DIFF
--- a/Firebase/Storage/CHANGELOG.md
+++ b/Firebase/Storage/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v3.0.0
 - [removed] Removed `downloadURLs` property on `StorageMetadata`. Use `StorageReference.downloadURL(completion:)` to obtain a current download URL.
-- [changed] The `maxOperationRetryTime` timeout now applies to calls to `StorageReference.getMetadata(completion:)` and `StorageReference.updateMetadata(completion:)`. These calls previously used the `maxDownloadRetryTime` and `maxUploadRetryTime` timeouts.
+- [changed] `StorageReference.getMetadata(completion:)` was renamed to `StorageReference.metadata(completion:)`.
+- [changed] The `maxOperationRetryTime` timeout now applies to calls to `StorageReference.metadata(completion:)` and `StorageReference.updateMetadata(completion:)`. These calls previously used the `maxDownloadRetryTime` and `maxUploadRetryTime` timeouts.
 
 # v2.2.0
 - [changed] Deprecated `downloadURLs` property on `StorageMetadata`. Use `StorageReference.downloadURL(completion:)` to obtain a current download URL.

--- a/Firebase/Storage/Public/FIRStorageReference.h
+++ b/Firebase/Storage/Public/FIRStorageReference.h
@@ -228,7 +228,7 @@ NS_SWIFT_NAME(putData(_:metadata:));
  */
 - (void)metadataWithCompletion:
     (void (^)(FIRStorageMetadata *_Nullable metadata, NSError *_Nullable error))completion
-    NS_SWIFT_NAME(getMetadata(completion:));
+    NS_SWIFT_NAME(metadata(completion:));
 
 /**
  * Updates the metadata associated with an object at the current path.


### PR DESCRIPTION
As discussed in https://github.com/firebase/firebase-ios-sdk/pull/1055 to match the .downloadUrl semantics.