### PR TITLE
Replace `DocumentListenOptions` with a simple boolean.

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+- [changed] Replaced the `DocumentListenOptions` object with a simple boolean.
+  Instead of calling
+  `addSnapshotListener(options: DocumentListenOptions.includeMetadataChanges(true))`
+  call `addSnapshotListener(includeMetadataChanges:true)`.
 
 # v0.11.0
 - [fixed] Fixed a regression in the Firebase iOS SDK release 4.11.0 that could

--- a/Firestore/Example/SwiftBuildTest/main.swift
+++ b/Firestore/Example/SwiftBuildTest/main.swift
@@ -251,6 +251,19 @@ func listenToDocument(at docRef: DocumentReference) {
   listener.remove()
 }
 
+func listenToDocumentWithMetadataChanges(at docRef: DocumentReference) {
+  let listener = docRef.addSnapshotListener(includeMetadataChanges: true) { document, error in
+    if let document = document {
+      if document.metadata.hasPendingWrites {
+        print("Has pending writes")
+      }
+    }
+  }
+
+  // Unsubscribe.
+  listener.remove()
+}
+
 func listenToDocuments(matching query: Query) {
   let listener = query.addSnapshotListener { snap, error in
     if let error = error {
@@ -326,7 +339,6 @@ func transactions() {
 func types() {
   let _: CollectionReference
   let _: DocumentChange
-  let _: DocumentListenOptions
   let _: DocumentReference
   let _: DocumentSnapshot
   let _: FieldPath

--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
@@ -370,11 +370,8 @@
   __block XCTestExpectation *dataCompletion;
   __block int callbacks = 0;
 
-  FIRDocumentListenOptions *options =
-      [[FIRDocumentListenOptions options] includeMetadataChanges:YES];
-
   id<FIRListenerRegistration> listenerRegistration =
-      [docRef addSnapshotListenerWithOptions:options
+  [docRef addSnapshotListenerWithIncludeMetadataChanges:YES
                                     listener:^(FIRDocumentSnapshot *_Nullable doc, NSError *error) {
                                       callbacks++;
 
@@ -458,11 +455,8 @@
   __block XCTestExpectation *changeCompletion;
   __block int callbacks = 0;
 
-  FIRDocumentListenOptions *options =
-      [[FIRDocumentListenOptions options] includeMetadataChanges:YES];
-
   id<FIRListenerRegistration> listenerRegistration =
-      [docRef addSnapshotListenerWithOptions:options
+      [docRef addSnapshotListenerWithIncludeMetadataChanges:YES
                                     listener:^(FIRDocumentSnapshot *_Nullable doc, NSError *error) {
                                       callbacks++;
 
@@ -548,15 +542,12 @@
 
   [self writeDocumentRef:docRef data:initialData];
 
-  FIRDocumentListenOptions *options =
-      [[FIRDocumentListenOptions options] includeMetadataChanges:YES];
-
   XCTestExpectation *initialCompletion = [self expectationWithDescription:@"initial data"];
   __block XCTestExpectation *changeCompletion;
   __block int callbacks = 0;
 
   id<FIRListenerRegistration> listenerRegistration =
-      [docRef addSnapshotListenerWithOptions:options
+      [docRef addSnapshotListenerWithIncludeMetadataChanges:YES
                                     listener:^(FIRDocumentSnapshot *_Nullable doc, NSError *error) {
                                       callbacks++;
 

--- a/Firestore/Example/Tests/Integration/API/FIRWriteBatchTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRWriteBatchTests.mm
@@ -249,7 +249,7 @@
   FIRDocumentReference *doc = [self documentRef];
   FSTEventAccumulator *accumulator = [FSTEventAccumulator accumulatorForTest:self];
   [doc
-      addSnapshotListenerWithOptions:[[FIRDocumentListenOptions options] includeMetadataChanges:YES]
+      addSnapshotListenerWithIncludeMetadataChanges:YES
                             listener:accumulator.valueEventHandler];
   FIRDocumentSnapshot *initialSnap = [accumulator awaitEventWithName:@"initial event"];
   XCTAssertFalse(initialSnap.exists);

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -245,7 +245,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"listener"];
   id<FIRListenerRegistration> listener = [ref
-      addSnapshotListenerWithOptions:[[FIRDocumentListenOptions options] includeMetadataChanges:YES]
+      addSnapshotListenerWithIncludeMetadataChanges:YES
                             listener:^(FIRDocumentSnapshot *snapshot, NSError *error) {
                               XCTAssertNil(error);
                               if (!requireOnline || !snapshot.metadata.fromCache) {

--- a/Firestore/Source/Public/FIRDocumentReference.h
+++ b/Firestore/Source/Public/FIRDocumentReference.h
@@ -25,29 +25,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Options for use with `[FIRDocumentReference addSnapshotListener]` to control the behavior of the
- * snapshot listener.
- */
-NS_SWIFT_NAME(DocumentListenOptions)
-@interface FIRDocumentListenOptions : NSObject
-
-+ (instancetype)options NS_SWIFT_UNAVAILABLE("Use initializer");
-
-- (instancetype)init;
-
-/**
- * Sets the includeMetadataChanges option which controls whether metadata-only changes (i.e. only
- * `FIRDocumentSnapshot.metadata` changed) should trigger snapshot events. Default is NO.
- *
- * @param includeMetadataChanges Whether to raise events for metadata-only changes.
- * @return The receiver is returned for optional method chaining.
- */
-- (instancetype)includeMetadataChanges:(BOOL)includeMetadataChanges
-    NS_SWIFT_NAME(includeMetadataChanges(_:));
-
-@end
-
 typedef void (^FIRDocumentSnapshotBlock)(FIRDocumentSnapshot *_Nullable snapshot,
                                          NSError *_Nullable error);
 
@@ -208,16 +185,17 @@ NS_SWIFT_NAME(DocumentReference)
 /**
  * Attaches a listener for DocumentSnapshot events.
  *
- * @param options Options controlling the listener behavior.
+ * @param includeMetadataChanges Whether metadata-only changes (i.e. only
+ *     `FIRDocumentSnapshot.metadata` changed) should trigger snapshot events.
  * @param listener The listener to attach.
  *
  * @return A FIRListenerRegistration that can be used to remove this listener.
  */
 // clang-format off
-- (id<FIRListenerRegistration>)addSnapshotListenerWithOptions:
-                                   (nullable FIRDocumentListenOptions *)options
-                                                     listener:(FIRDocumentSnapshotBlock)listener
-    NS_SWIFT_NAME(addSnapshotListener(options:listener:));
+- (id<FIRListenerRegistration>)
+addSnapshotListenerWithIncludeMetadataChanges:(BOOL)includeMetadataChanges
+                                     listener:(FIRDocumentSnapshotBlock)listener
+    NS_SWIFT_NAME(addSnapshotListener(includeMetadataChanges:listener:));
 // clang-format on
 
 @end

--- a/Firestore/Source/Public/FIRSnapshotMetadata.h
+++ b/Firestore/Source/Public/FIRSnapshotMetadata.h
@@ -27,16 +27,16 @@ NS_SWIFT_NAME(SnapshotMetadata)
 /**
  * Returns YES if the snapshot contains the result of local writes (e.g. set() or update() calls)
  * that have not yet been committed to the backend. If your listener has opted into metadata updates
- * (via `FIRDocumentListenOptions` or `FIRQueryListenOptions`) you will receive another snapshot
- * with `hasPendingWrites` equal to NO once the writes have been committed to the backend.
+ * (via `includeMetadataChanges:YES`) you will receive another snapshot with `hasPendingWrites`
+ * equal to NO once the writes have been committed to the backend.
  */
 @property(nonatomic, assign, readonly, getter=hasPendingWrites) BOOL pendingWrites;
 
 /**
  * Returns YES if the snapshot was created from cached data rather than guaranteed up-to-date server
- * data. If your listener has opted into metadata updates (via `FIRDocumentListenOptions` or
- * `FIRQueryListenOptions`) you will receive another snapshot with `isFromCache` equal to NO once
- * the client has received up-to-date data from the backend.
+ * data. If your listener has opted into metadata updates (via `includeMetadataChanges:YES`) you
+ * will receive another snapshot with `isFromCache` equal to NO once the client has received
+ * up-to-date data from the backend.
  */
 @property(nonatomic, assign, readonly, getter=isFromCache) BOOL fromCache;
 


### PR DESCRIPTION
Instead of calling

  `addSnapshotListener(options: DocumentListenOptions.includeMetadataChanges(true))`

call

  `addSnapshotListener(includeMetadataChanges:true)`