### PR TITLE
Fix iteration past end in LevelDBTransaction::Iterator

### DIFF
--- a/Firestore/core/src/firebase/firestore/local/leveldb_transaction.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_transaction.cc
@@ -123,7 +123,7 @@ void LevelDbTransaction::Iterator::AdvanceLDB() {
 void LevelDbTransaction::Iterator::Next() {
   FIREBASE_ASSERT_MESSAGE(Valid(), "Next() called on invalid iterator");
   bool advanced = SyncToTransaction();
-  if (!advanced) {
+  if (!advanced && is_valid_) {
     if (is_mutation_) {
       // A mutation might be shadowing leveldb. If so, advance both.
       if (db_iter_->Valid() && db_iter_->key() == mutations_iter_->first) {


### PR DESCRIPTION
Change Next() to avoid advancing past the end of either iterator by only
advancing if !advanced and if the iterator is still valid.

If Next() is called after the last entry is deleted, SyncToTransaction()
returns false indicating it hasn't advanced but at that point is_valid_
is false. Previously Next() would then attempt to advance one of the
underlying iterators and if it was the mutations_iter_ would advance
past the end, which would cause the next UpdateCurrent() to dereference
random memory.