### PR TITLE
Firestore Travis: ensure CTest outputs the log on failure.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -171,7 +171,7 @@ case "$product-$method-$platform" in
 
     echo "Building cmake build ..."
     cpus=$(sysctl -n hw.ncpu)
-    (cd build; make -j $cpus all)
+    (cd build; env CTEST_OUTPUT_ON_FAILURE=1 make -j $cpus all)
     ;;
 
   *)


### PR DESCRIPTION
In CMake build of Firestore, configure CTest so that upon failure, it
prints out the full log of the failing test(s).
