### PR TITLE
Match previous systemVersion functionality

### DIFF
--- a/Example/Core/Tests/FIRAppEnvironmentUtilTest.m
+++ b/Example/Core/Tests/FIRAppEnvironmentUtilTest.m
@@ -1,0 +1,67 @@
+// Copyright 2018 Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+#import <FirebaseCore/FIRAppEnvironmentUtil.h>
+
+#import "FIRTestCase.h"
+
+@interface FIRAppEnvironmentUtilTest : FIRTestCase
+
+@property(nonatomic) id processInfoMock;
+
+@end
+
+@implementation FIRAppEnvironmentUtilTest
+
+- (void)setUp {
+  [super setUp];
+
+  _processInfoMock = OCMPartialMock([NSProcessInfo processInfo]);
+}
+
+- (void)tearDown {
+  [super tearDown];
+
+  [_processInfoMock stopMocking];
+}
+
+- (void)testSystemVersionInfoMajorOnly {
+  NSOperatingSystemVersion osTen = { .majorVersion = 10, .minorVersion = 0, .patchVersion = 0 };
+  OCMStub([self.processInfoMock operatingSystemVersion]).andReturn(osTen);
+
+  XCTAssertTrue([[FIRAppEnvironmentUtil systemVersion] isEqualToString:@"10"]);
+}
+
+- (void)testSystemVersionInfoMajorMinor {
+  NSOperatingSystemVersion osTenTwo = { .majorVersion = 10, .minorVersion = 2, .patchVersion = 0 };
+  OCMStub([self.processInfoMock operatingSystemVersion]).andReturn(osTenTwo);
+
+  XCTAssertTrue([[FIRAppEnvironmentUtil systemVersion] isEqualToString:@"10.2"]);
+}
+
+- (void)testSystemVersionInfoMajorMinorPatch {
+  NSOperatingSystemVersion osTenTwoOne = {
+    .majorVersion = 10,
+    .minorVersion = 2,
+    .patchVersion = 1
+  };
+  OCMStub([self.processInfoMock operatingSystemVersion]).andReturn(osTenTwoOne);
+
+  XCTAssertTrue([[FIRAppEnvironmentUtil systemVersion] isEqualToString:@"10.2.1"]);
+}
+
+@end

--- a/Example/Core/Tests/FIRAppEnvironmentUtilTest.m
+++ b/Example/Core/Tests/FIRAppEnvironmentUtilTest.m
@@ -40,25 +40,21 @@
 }
 
 - (void)testSystemVersionInfoMajorOnly {
-  NSOperatingSystemVersion osTen = { .majorVersion = 10, .minorVersion = 0, .patchVersion = 0 };
+  NSOperatingSystemVersion osTen = {.majorVersion = 10, .minorVersion = 0, .patchVersion = 0};
   OCMStub([self.processInfoMock operatingSystemVersion]).andReturn(osTen);
 
   XCTAssertTrue([[FIRAppEnvironmentUtil systemVersion] isEqualToString:@"10"]);
 }
 
 - (void)testSystemVersionInfoMajorMinor {
-  NSOperatingSystemVersion osTenTwo = { .majorVersion = 10, .minorVersion = 2, .patchVersion = 0 };
+  NSOperatingSystemVersion osTenTwo = {.majorVersion = 10, .minorVersion = 2, .patchVersion = 0};
   OCMStub([self.processInfoMock operatingSystemVersion]).andReturn(osTenTwo);
 
   XCTAssertTrue([[FIRAppEnvironmentUtil systemVersion] isEqualToString:@"10.2"]);
 }
 
 - (void)testSystemVersionInfoMajorMinorPatch {
-  NSOperatingSystemVersion osTenTwoOne = {
-    .majorVersion = 10,
-    .minorVersion = 2,
-    .patchVersion = 1
-  };
+  NSOperatingSystemVersion osTenTwoOne = {.majorVersion = 10, .minorVersion = 2, .patchVersion = 1};
   OCMStub([self.processInfoMock operatingSystemVersion]).andReturn(osTenTwoOne);
 
   XCTAssertTrue([[FIRAppEnvironmentUtil systemVersion] isEqualToString:@"10.2.1"]);

--- a/Example/Firebase.xcodeproj/project.pbxproj
+++ b/Example/Firebase.xcodeproj/project.pbxproj
@@ -339,6 +339,9 @@
 		DE47C142207ACAA900B1AEDF /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = DE47C13B207ACAA900B1AEDF /* main.m */; };
 		DE47C143207ACAA900B1AEDF /* FIRAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DE47C13C207ACAA900B1AEDF /* FIRAppDelegate.m */; };
 		DE47C144207ACAA900B1AEDF /* FIRViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DE47C13D207ACAA900B1AEDF /* FIRViewController.m */; };
+		DE4B26E020855F4C0030A38C /* FIRAppEnvironmentUtilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = DE4B26DE20855F1F0030A38C /* FIRAppEnvironmentUtilTest.m */; };
+		DE4B26E120855F500030A38C /* FIRAppEnvironmentUtilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = DE4B26DE20855F1F0030A38C /* FIRAppEnvironmentUtilTest.m */; };
+		DE4B26E220855F520030A38C /* FIRAppEnvironmentUtilTest.m in Sources */ = {isa = PBXBuildFile; fileRef = DE4B26DE20855F1F0030A38C /* FIRAppEnvironmentUtilTest.m */; };
 		DE750DBD1EB3DD5B00A75E47 /* FIRAuthAPNSTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DE750DB61EB3DD4000A75E47 /* FIRAuthAPNSTokenTests.m */; };
 		DE750DBE1EB3DD6800A75E47 /* FIRAuthAPNSTokenManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DE750DB51EB3DD4000A75E47 /* FIRAuthAPNSTokenManagerTests.m */; };
 		DE750DBF1EB3DD6C00A75E47 /* FIRAuthAppCredentialManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DE750DB71EB3DD4000A75E47 /* FIRAuthAppCredentialManagerTests.m */; };
@@ -1055,6 +1058,7 @@
 		DE47C13B207ACAA900B1AEDF /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		DE47C13C207ACAA900B1AEDF /* FIRAppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FIRAppDelegate.m; sourceTree = "<group>"; };
 		DE47C13D207ACAA900B1AEDF /* FIRViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FIRViewController.m; sourceTree = "<group>"; };
+		DE4B26DE20855F1F0030A38C /* FIRAppEnvironmentUtilTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FIRAppEnvironmentUtilTest.m; sourceTree = "<group>"; };
 		DE53893E1FBB62E100199FC2 /* Auth_Tests_tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Auth_Tests_tvOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE53894C1FBB635400199FC2 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		DE53894D1FBB635400199FC2 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -2273,6 +2277,7 @@
 		DEE14D741E844677006FA992 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				DE4B26DE20855F1F0030A38C /* FIRAppEnvironmentUtilTest.m */,
 				DEE14D7B1E844677006FA992 /* FIRTestCase.h */,
 				DEE14D751E844677006FA992 /* FIRAppAssociationRegistrationUnitTests.m */,
 				DEE14D761E844677006FA992 /* FIRAppTest.m */,
@@ -3642,6 +3647,7 @@
 				D064E6AF1ED9B31C001956DF /* FIRAppAssociationRegistrationUnitTests.m in Sources */,
 				D064E6B01ED9B31C001956DF /* FIRAppTest.m in Sources */,
 				D064E6B11ED9B31C001956DF /* FIRConfigurationTest.m in Sources */,
+				DE4B26E120855F500030A38C /* FIRAppEnvironmentUtilTest.m in Sources */,
 				D064E6B21ED9B31C001956DF /* FIRLoggerTest.m in Sources */,
 				D064E6B31ED9B31C001956DF /* FIROptionsTest.m in Sources */,
 				D064E6B41ED9B31C001956DF /* FIRBundleUtilTest.m in Sources */,
@@ -4096,6 +4102,7 @@
 				DEAAD3DA1FBA34250053BF48 /* FIROptionsTest.m in Sources */,
 				DEAAD3D51FBA34250053BF48 /* FIRAppAssociationRegistrationUnitTests.m in Sources */,
 				DEAAD3D91FBA34250053BF48 /* FIRLoggerTest.m in Sources */,
+				DE4B26E220855F520030A38C /* FIRAppEnvironmentUtilTest.m in Sources */,
 				DEAAD3D61FBA34250053BF48 /* FIRAppTest.m in Sources */,
 				DEAAD3D81FBA34250053BF48 /* FIRConfigurationTest.m in Sources */,
 				DEAAD3DB1FBA34250053BF48 /* FIRTestCase.m in Sources */,
@@ -4183,6 +4190,7 @@
 				DEE14D8E1E84468D006FA992 /* FIRAppAssociationRegistrationUnitTests.m in Sources */,
 				DEE14D8F1E84468D006FA992 /* FIRAppTest.m in Sources */,
 				DEE14D911E84468D006FA992 /* FIRConfigurationTest.m in Sources */,
+				DE4B26E020855F4C0030A38C /* FIRAppEnvironmentUtilTest.m in Sources */,
 				DEE14D921E84468D006FA992 /* FIRLoggerTest.m in Sources */,
 				DEE14D931E84468D006FA992 /* FIROptionsTest.m in Sources */,
 				DEE14D901E84468D006FA992 /* FIRBundleUtilTest.m in Sources */,

--- a/Firebase/Core/third_party/FIRAppEnvironmentUtil.m
+++ b/Firebase/Core/third_party/FIRAppEnvironmentUtil.m
@@ -204,7 +204,18 @@ static BOOL isAppEncrypted() {
 }
 
 + (NSString *)systemVersion {
-  return [NSProcessInfo processInfo].operatingSystemVersionString;
+  // Assemble the systemVersion, excluding any insignificant digits.
+  NSOperatingSystemVersion osVersion = [NSProcessInfo processInfo].operatingSystemVersion;
+  NSMutableString *versionString = [[NSMutableString alloc] initWithFormat:@"%ld", (long)osVersion.majorVersion];
+  if (osVersion.minorVersion != 0) {
+    [versionString appendFormat:@".%ld", (long)osVersion.minorVersion];
+  }
+
+  if (osVersion.patchVersion != 0) {
+    [versionString appendFormat:@".%ld", (long)osVersion.patchVersion];
+  }
+
+  return versionString;
 }
 
 + (BOOL)isAppExtension {


### PR DESCRIPTION
Since we moved to a new `systemVersion` implementation, we need to match the previous functionality's output.