### PR TITLE
First pass of Auth breaking changes

### DIFF
--- a/Example/Auth/Sample/MainViewController.m
+++ b/Example/Auth/Sample/MainViewController.m
@@ -143,7 +143,7 @@ static NSString *const kSignInEmailPasswordButtonText = @"Sign in with Email/Pas
     @brief The text of the "Email/Password SignIn (AuthDataResult)" button.
  */
 static NSString *const kSignInEmailPasswordAuthDataResultButtonText =
-    @"Sign in with Email/Password (AuthDataReult)";
+    @"Sign in with Email/Password (Deprecated)";
 
 /** @var kSignInWithCustomTokenButtonText
     @brief The text of the "Sign In (BYOAuth)" button.
@@ -154,7 +154,7 @@ static NSString *const kSignInWithCustomTokenButtonText = @"Sign In (BYOAuth)";
     @brief The text of the "Sign In with Custom Token (Auth Result)" button.
  */
 static NSString *const kSignInWithCustomAuthResultTokenButtonText = @"Sign In with Custom Token"
-    " (Auth Result)";
+    " (Deprecated)";
 
 /** @var kSignInAnonymouslyButtonText
     @brief The text of the "Sign In Anonymously" button.
@@ -165,7 +165,7 @@ static NSString *const kSignInAnonymouslyButtonText = @"Sign In Anonymously";
     @brief The text of the "Sign In Anonymously (AuthDataResult)" button.
  */
 static NSString *const kSignInAnonymouslyWithAuthResultButtonText =
-    @"Sign In Anonymously (AuthDataResult)";
+    @"Sign In Anonymously (Deprecated)";
 
 /** @var kSignedInAlertTitle
     @brief The text of the "Sign In Succeeded" alert.
@@ -1040,7 +1040,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
       [self logFailedTest:@"The test needs a valid credential to continue."];
       return;
     }
-    [[AppManager auth] signInWithCredential:credential completion:^(FIRUser *_Nullable user,
+    [[AppManager auth] signInWithCredential:credential completion:^(FIRAuthDataResult *_Nullable result,
                                                                     NSError *_Nullable error) {
       if (error) {
         [self logFailure:@"sign-in with provider failed" error:error];
@@ -1193,7 +1193,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
     FIRAuthCredential *credential = [FIREmailAuthProvider credentialWithEmail:kFakeEmail
                                                                      password:kFakePassword];
     [auth signInWithCredential:credential
-                     completion:^(FIRUser *_Nullable user,
+                     completion:^(FIRAuthDataResult *_Nullable result,
                                   NSError *_Nullable error) {
       if (error) {
         [self logFailure:@"sign-in with Email/Password failed" error:error];
@@ -1226,11 +1226,13 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
     return;
   }
   [auth signOut:NULL];
-  [self signInAnonymouslyWithCallback:^(FIRUser *_Nullable user, NSError *_Nullable error) {
-    if (user) {
-      NSString *anonymousUID = user.uid;
-      [self signInAnonymouslyWithCallback:^(FIRUser *_Nullable user, NSError *_Nullable error) {
-        if (![user.uid isEqual:anonymousUID]) {
+  [self signInAnonymouslyWithCallback:^(FIRAuthDataResult *_Nullable result,
+                                        NSError *_Nullable error) {
+    if (result.user) {
+      NSString *anonymousUID = result.user.uid;
+      [self signInAnonymouslyWithCallback:^(FIRAuthDataResult *_Nullable user,
+                                            NSError *_Nullable error) {
+        if (![result.user.uid isEqual:anonymousUID]) {
           [self logFailedTest:@"Consecutive anonymous sign-ins should yeild the same User ID"];
           return;
         }
@@ -1244,13 +1246,13 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
     @brief Performs anonymous sign in and then executes callback.
     @param callback The callback to be executed.
  */
-- (void)signInAnonymouslyWithCallback:(nullable FIRAuthResultCallback)callback {
+- (void)signInAnonymouslyWithCallback:(nullable FIRAuthDataResultCallback)callback {
   FIRAuth *auth = [AppManager auth];
   if (!auth) {
     [self logFailedTest:@"Could not obtain auth object."];
     return;
   }
-  [auth signInAnonymouslyWithCompletion:^(FIRUser *_Nullable user,
+  [auth signInAnonymouslyWithCompletion:^(FIRAuthDataResult *_Nullable result,
                                           NSError *_Nullable error) {
     if (error) {
       [self logFailure:@"sign-in anonymously failed" error:error];
@@ -1259,7 +1261,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
     }
     [self logSuccess:@"sign-in anonymously succeeded."];
     if (callback) {
-      callback(user, nil);
+      callback(result, nil);
     }
   }];
 }
@@ -1275,9 +1277,10 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
     return;
   }
   [auth signOut:NULL];
-  [self signInAnonymouslyWithCallback:^(FIRUser *_Nullable user, NSError *_Nullable error) {
-    if (user) {
-      NSString *anonymousUID = user.uid;
+  [self signInAnonymouslyWithCallback:^(FIRAuthDataResult *_Nullable result,
+                                        NSError *_Nullable error) {
+    if (result.user) {
+      NSString *anonymousUID = result.user.uid;
       [self showMessagePromptWithTitle:@"Sign In Instructions"
                                message:kUnlinkAccountMessagePrompt
                       showCancelButton:NO
@@ -1287,7 +1290,8 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
                                                  callback:^(FIRAuthCredential *credential,
                                                             NSError *error) {
           if (credential) {
-            [user linkWithCredential:credential completion:^(FIRUser *user, NSError *error) {
+            [result.user linkWithCredential:credential completion:^(FIRUser *user,
+                                                             NSError *error) {
               if (error) {
                 [self logFailure:@"link auth provider failed" error:error];
                 [self logFailedTest:@"Account needs to be linked to complete the test."];
@@ -1346,7 +1350,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
       }
       FIRAuth *auth = [AppManager auth];
       [auth signInWithCustomToken:customToken
-                       completion:^(FIRUser *_Nullable user, NSError *_Nullable error) {
+                       completion:^(FIRAuthDataResult *_Nullable result, NSError *_Nullable error) {
         if (error) {
           [self logFailure:@"sign-in with custom token failed" error:error];
           [self logFailedTest:@"A fresh custom token should succeed in signing-in."];
@@ -1364,7 +1368,8 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
           [self logSuccess:@"refresh token succeeded."];
           [auth signOut:NULL];
           [auth signInWithCustomToken:expiredCustomToken
-                           completion:^(FIRUser *_Nullable user, NSError *_Nullable error) {
+                           completion:^(FIRAuthDataResult *_Nullable result,
+                                        NSError *_Nullable error) {
             if (!error) {
               [self logSuccess:@"sign-in with custom token succeeded."];
               [self logFailedTest:@"sign-in with an expired custom token should NOT succeed."];
@@ -1372,7 +1377,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
             }
             [self logFailure:@"sign-in with custom token failed" error:error];
             [auth signInWithCustomToken:kInvalidCustomToken
-                             completion:^(FIRUser *_Nullable user,
+                             completion:^(FIRAuthDataResult *_Nullable result,
                                           NSError *_Nullable error) {
               if (!error) {
                 [self logSuccess:@"sign-in with custom token succeeded."];
@@ -1405,7 +1410,8 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
         return;
       }
       [[AppManager auth] signInWithCustomToken:customToken
-                                    completion:^(FIRUser *_Nullable user, NSError *_Nullable error) {
+                                    completion:^(FIRAuthDataResult *_Nullable user,
+                                                 NSError *_Nullable error) {
         if (error) {
           [self logFailure:@"sign-in with custom token failed" error:error];
           [self logFailedTest:@"A fresh custom token should succeed in signing-in."];
@@ -1435,7 +1441,8 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
         return;
       }
       [[AppManager auth] signInWithCustomToken:customToken
-                                    completion:^(FIRUser *_Nullable user, NSError *_Nullable error) {
+                                    completion:^(FIRAuthDataResult *_Nullable result,
+                                                 NSError *_Nullable error) {
         if (error) {
           [self logFailure:@"sign-in with custom token failed" error:error];
           [self logFailedTest:@"A fresh custom token should succeed in signing-in."];
@@ -1476,7 +1483,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
       FIRAuthCredential *credential =
         [FIREmailAuthProvider credentialWithEmail:kFakeEmail password:kFakePassword];
       [auth signInWithCredential:credential
-                       completion:^(FIRUser *_Nullable user,
+                       completion:^(FIRAuthDataResult *_Nullable user,
                                     NSError *_Nullable error) {
         if (error) {
           [self logFailure:@"sign-in with Email/Password failed" error:error];
@@ -1683,7 +1690,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
     @brief Invoked when "Sign in with Google" row is pressed.
  */
 - (void)signInGoogle {
-  [self signinWithProvider:[AuthProviders google] retrieveData:NO];
+  [self signinWithProvider:[AuthProviders google] retrieveData:YES];
 }
 
 /** @fn signInGoogleAndRetrieveData
@@ -1697,7 +1704,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
     @brief Invoked when "Sign in with Facebook" row is pressed.
  */
 - (void)signInFacebook {
-  [self signinWithProvider:[AuthProviders facebook] retrieveData:NO];
+  [self signinWithProvider:[AuthProviders facebook] retrieveData:YES];
 }
 
 /** @fn signInFacebookAndRetrieveData
@@ -1727,7 +1734,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
                                            password:password];
       [self showSpinner:^{
         [[AppManager auth] signInWithCredential:credential
-                                     completion:^(FIRUser *_Nullable user,
+                                     completion:^(FIRAuthDataResult *_Nullable result,
                                                   NSError *_Nullable error) {
           [self hideSpinner:^{
             if (error) {
@@ -2089,8 +2096,8 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
         }
         [self showTypicalUIForUserUpdateResultsWithTitle:@"Sign-In" error:error];
       };
-      FIRAuthResultCallback callback = ^(FIRUser *_Nullable user,
-                                         NSError *_Nullable error) {
+      FIRAuthDataResultCallback callback = ^(FIRAuthDataResult *_Nullable result,
+                                             NSError *_Nullable error) {
         completion(nil, error);
       };
       if (retrieveData) {
@@ -3096,7 +3103,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
                           FIRPhoneAuthCredential *credential =
                               error.userInfo[FIRAuthUpdatedCredentialKey];
                           [[AppManager auth] signInWithCredential:credential
-                                                       completion:^(FIRUser *_Nullable user,
+                                                       completion:^(FIRAuthDataResult *_Nullable result,
                                                                     NSError *_Nullable error) {
                             [self hideSpinner:^{
                               if (error) {
@@ -3149,12 +3156,13 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
     @brief Signs in as an anonymous user.
  */
 - (void)signInAnonymously {
-  [[AppManager auth] signInAnonymouslyWithCompletion:^(FIRUser *_Nullable user,
+  [[AppManager auth] signInAnonymouslyWithCompletion:^(FIRAuthDataResult *_Nullable result,
                                                        NSError *_Nullable error) {
     if (error) {
       [self logFailure:@"sign-in anonymously failed" error:error];
     } else {
       [self logSuccess:@"sign-in anonymously succeeded."];
+      [self log:[NSString stringWithFormat:@"User ID : %@", result.user.uid]];
     }
     [self showTypicalUIForUserUpdateResultsWithTitle:kSignInAnonymouslyButtonText error:error];
   }];
@@ -3190,8 +3198,9 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
     FIRAuthCredential *credential =
         [FIROAuthProvider credentialWithProviderID:FIRGitHubAuthProviderID accessToken:accessToken];
     if (credential) {
-        [[AppManager auth] signInWithCredential:credential completion:^(FIRUser *_Nullable user,
-                                                                        NSError *_Nullable error) {
+        [[AppManager auth] signInWithCredential:credential
+                                     completion:^(FIRAuthDataResult *_Nullable result,
+                                                  NSError *_Nullable error) {
           if (error) {
             [self logFailure:@"sign-in with provider failed" error:error];
           } else {
@@ -3338,7 +3347,8 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
 
 - (void)doSignInWithCustomToken:(NSString *_Nullable)userEnteredTokenText {
   [[AppManager auth] signInWithCustomToken:userEnteredTokenText
-                                completion:^(FIRUser *_Nullable user, NSError *_Nullable error) {
+                                completion:^(FIRAuthDataResult *_Nullable result,
+                                             NSError *_Nullable error) {
     if (error) {
       [self logFailure:@"sign-in with custom token failed" error:error];
       [self showMessagePromptWithTitle:kSignInErrorAlertTitle
@@ -3349,7 +3359,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
     }
     [self logSuccess:@"sign-in with custom token succeeded."];
     [self showMessagePromptWithTitle:kSignedInAlertTitle
-                             message:user.displayName
+                             message:result.user.displayName
                     showCancelButton:NO
                           completion:nil];
   }];

--- a/Example/Auth/Sample/MainViewController.m
+++ b/Example/Auth/Sample/MainViewController.m
@@ -1040,7 +1040,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
       [self logFailedTest:@"The test needs a valid credential to continue."];
       return;
     }
-    [[AppManager auth] signInWithCredential:credential completion:^(FIRAuthDataResult *_Nullable result,
+    [[AppManager auth] signInWithCredential:credential completion:^(FIRUser *_Nullable user,
                                                                     NSError *_Nullable error) {
       if (error) {
         [self logFailure:@"sign-in with provider failed" error:error];
@@ -1193,7 +1193,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
     FIRAuthCredential *credential = [FIREmailAuthProvider credentialWithEmail:kFakeEmail
                                                                      password:kFakePassword];
     [auth signInWithCredential:credential
-                     completion:^(FIRAuthDataResult *_Nullable result,
+                     completion:^(FIRUser *_Nullable user,
                                   NSError *_Nullable error) {
       if (error) {
         [self logFailure:@"sign-in with Email/Password failed" error:error];
@@ -1483,7 +1483,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
       FIRAuthCredential *credential =
         [FIREmailAuthProvider credentialWithEmail:kFakeEmail password:kFakePassword];
       [auth signInWithCredential:credential
-                       completion:^(FIRAuthDataResult *_Nullable user,
+                       completion:^(FIRUser *_Nullable user,
                                     NSError *_Nullable error) {
         if (error) {
           [self logFailure:@"sign-in with Email/Password failed" error:error];
@@ -1734,7 +1734,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
                                            password:password];
       [self showSpinner:^{
         [[AppManager auth] signInWithCredential:credential
-                                     completion:^(FIRAuthDataResult *_Nullable result,
+                                     completion:^(FIRUser *_Nullable user,
                                                   NSError *_Nullable error) {
           [self hideSpinner:^{
             if (error) {
@@ -2096,8 +2096,8 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
         }
         [self showTypicalUIForUserUpdateResultsWithTitle:@"Sign-In" error:error];
       };
-      FIRAuthDataResultCallback callback = ^(FIRAuthDataResult *_Nullable result,
-                                             NSError *_Nullable error) {
+      FIRAuthResultCallback callback = ^(FIRUser *_Nullable user,
+                                         NSError *_Nullable error) {
         completion(nil, error);
       };
       if (retrieveData) {
@@ -3103,7 +3103,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
                           FIRPhoneAuthCredential *credential =
                               error.userInfo[FIRAuthUpdatedCredentialKey];
                           [[AppManager auth] signInWithCredential:credential
-                                                       completion:^(FIRAuthDataResult *_Nullable result,
+                                                       completion:^(FIRUser *_Nullable user,
                                                                     NSError *_Nullable error) {
                             [self hideSpinner:^{
                               if (error) {
@@ -3199,7 +3199,7 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
         [FIROAuthProvider credentialWithProviderID:FIRGitHubAuthProviderID accessToken:accessToken];
     if (credential) {
         [[AppManager auth] signInWithCredential:credential
-                                     completion:^(FIRAuthDataResult *_Nullable result,
+                                     completion:^(FIRUser *_Nullable result,
                                                   NSError *_Nullable error) {
           if (error) {
             [self logFailure:@"sign-in with provider failed" error:error];

--- a/Example/Auth/Tests/FIRAuthTests.m
+++ b/Example/Auth/Tests/FIRAuthTests.m
@@ -562,10 +562,10 @@ static const NSTimeInterval kWaitInterval = .5;
       [[FIRPhoneAuthProvider provider] credentialWithVerificationID:kVerificationID
                                                    verificationCode:@""];
 
-  [[FIRAuth auth] signInWithCredential:credential completion:^(FIRAuthDataResult *_Nullable result,
+  [[FIRAuth auth] signInWithCredential:credential completion:^(FIRUser *_Nullable user,
                                                                NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    XCTAssertNil(result.user);
+    XCTAssertNil(user);
     XCTAssertEqual(error.code, FIRAuthErrorCodeMissingVerificationCode);
     [expectation fulfill];
   }];
@@ -584,10 +584,10 @@ static const NSTimeInterval kWaitInterval = .5;
       [[FIRPhoneAuthProvider provider] credentialWithVerificationID:@""
                                                    verificationCode:kVerificationCode];
 
-  [[FIRAuth auth] signInWithCredential:credential completion:^(FIRAuthDataResult *_Nullable result,
+  [[FIRAuth auth] signInWithCredential:credential completion:^(FIRUser *_Nullable user,
                                                                NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    XCTAssertNil(result.user);
+    XCTAssertNil(user);
     XCTAssertEqual(error.code, FIRAuthErrorCodeMissingVerificationID);
     [expectation fulfill];
   }];
@@ -1072,10 +1072,10 @@ static const NSTimeInterval kWaitInterval = .5;
   FIRAuthCredential *emailCredential =
       [FIREmailAuthProvider credentialWithEmail:kEmail link:kFakeEmailSignInlink];
   [[FIRAuth auth] signInWithCredential:emailCredential
-                            completion:^(FIRAuthDataResult *_Nullable result,
+                            completion:^(FIRUser *_Nullable user,
                                          NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    XCTAssertNil(result.user);
+    XCTAssertNil(user);
     XCTAssertEqual(error.code, FIRAuthErrorCodeUserDisabled);
     XCTAssertNotNil(error.userInfo[NSLocalizedDescriptionKey]);
     [expectation fulfill];
@@ -1109,10 +1109,10 @@ static const NSTimeInterval kWaitInterval = .5;
   FIRAuthCredential *emailCredential =
       [FIREmailAuthProvider credentialWithEmail:kEmail password:kFakePassword];
   [[FIRAuth auth] signInWithCredential:emailCredential
-                            completion:^(FIRAuthDataResult *_Nullable result,
+                            completion:^(FIRUser *_Nullable user,
                                          NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    [self assertUser:result.user];
+    [self assertUser:user];
     XCTAssertNil(error);
     [expectation fulfill];
   }];
@@ -1148,10 +1148,10 @@ static const NSTimeInterval kWaitInterval = .5;
       [FIREmailPasswordAuthProvider credentialWithEmail:kEmail password:kFakePassword];
 #pragma clang diagnostic pop
   [[FIRAuth auth] signInWithCredential:emailCredential
-                            completion:^(FIRAuthDataResult *_Nullable result,
+                            completion:^(FIRUser *_Nullable user,
                                         NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    [self assertUser:result.user];
+    [self assertUser:user];
     XCTAssertNil(error);
     [expectation fulfill];
   }];
@@ -1172,10 +1172,10 @@ static const NSTimeInterval kWaitInterval = .5;
   FIRAuthCredential *emailCredential =
       [FIREmailAuthProvider credentialWithEmail:kEmail password:kFakePassword];
   [[FIRAuth auth] signInWithCredential:emailCredential
-                            completion:^(FIRAuthDataResult *_Nullable result,
+                            completion:^(FIRUser *_Nullable user,
                                          NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    XCTAssertNil(result.user);
+    XCTAssertNil(user);
     XCTAssertEqual(error.code, FIRAuthErrorCodeUserDisabled);
     XCTAssertNotNil(error.userInfo[NSLocalizedDescriptionKey]);
     [expectation fulfill];
@@ -1198,7 +1198,7 @@ static const NSTimeInterval kWaitInterval = .5;
   FIRAuthCredential *emailCredential =
       [FIREmailAuthProvider credentialWithEmail:kEmail password:emptyString];
   [[FIRAuth auth] signInWithCredential:emailCredential
-                            completion:^(FIRAuthDataResult *_Nullable result, NSError *_Nullable error) {
+                            completion:^(FIRUser *_Nullable user, NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
     XCTAssertEqual(error.code, FIRAuthErrorCodeWrongPassword);
     [expectation fulfill];
@@ -1233,7 +1233,7 @@ static const NSTimeInterval kWaitInterval = .5;
   FIRAuthCredential *googleCredential =
       [FIRGoogleAuthProvider credentialWithIDToken:kGoogleIDToken accessToken:kGoogleAccessToken];
   [[FIRAuth auth] signInWithCredential:googleCredential
-                            completion:^(FIRAuthDataResult *_Nullable result,
+                            completion:^(FIRUser *_Nullable user,
                                          NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
     XCTAssertEqual(error.code, FIRAuthErrorCodeAccountExistsWithDifferentCredential);
@@ -1273,10 +1273,10 @@ static const NSTimeInterval kWaitInterval = .5;
   FIRAuthCredential *googleCredential =
       [FIRGoogleAuthProvider credentialWithIDToken:kGoogleIDToken accessToken:kGoogleAccessToken];
   [[FIRAuth auth] signInWithCredential:googleCredential
-                            completion:^(FIRAuthDataResult *_Nullable result,
+                            completion:^(FIRUser *_Nullable user,
                                          NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    [self assertUserGoogle:result.user];
+    [self assertUserGoogle:user];
     XCTAssertNil(error);
     [expectation fulfill];
   }];
@@ -1343,10 +1343,10 @@ static const NSTimeInterval kWaitInterval = .5;
   FIRAuthCredential *googleCredential =
       [FIRGoogleAuthProvider credentialWithIDToken:kGoogleIDToken accessToken:kGoogleAccessToken];
   [[FIRAuth auth] signInWithCredential:googleCredential
-                            completion:^(FIRAuthDataResult *_Nullable result,
+                            completion:^(FIRUser *_Nullable user,
                                          NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    XCTAssertNil(result.user);
+    XCTAssertNil(user);
     XCTAssertEqual(error.code, FIRAuthErrorCodeEmailAlreadyInUse);
     XCTAssertNotNil(error.userInfo[NSLocalizedDescriptionKey]);
     [expectation fulfill];

--- a/Example/Auth/Tests/FIRAuthTests.m
+++ b/Example/Auth/Tests/FIRAuthTests.m
@@ -562,10 +562,10 @@ static const NSTimeInterval kWaitInterval = .5;
       [[FIRPhoneAuthProvider provider] credentialWithVerificationID:kVerificationID
                                                    verificationCode:@""];
 
-  [[FIRAuth auth] signInWithCredential:credential completion:^(FIRUser *_Nullable user,
+  [[FIRAuth auth] signInWithCredential:credential completion:^(FIRAuthDataResult *_Nullable result,
                                                                NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    XCTAssertNil(user);
+    XCTAssertNil(result.user);
     XCTAssertEqual(error.code, FIRAuthErrorCodeMissingVerificationCode);
     [expectation fulfill];
   }];
@@ -584,10 +584,10 @@ static const NSTimeInterval kWaitInterval = .5;
       [[FIRPhoneAuthProvider provider] credentialWithVerificationID:@""
                                                    verificationCode:kVerificationCode];
 
-  [[FIRAuth auth] signInWithCredential:credential completion:^(FIRUser *_Nullable user,
+  [[FIRAuth auth] signInWithCredential:credential completion:^(FIRAuthDataResult *_Nullable result,
                                                                NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    XCTAssertNil(user);
+    XCTAssertNil(result.user);
     XCTAssertEqual(error.code, FIRAuthErrorCodeMissingVerificationID);
     [expectation fulfill];
   }];
@@ -712,10 +712,10 @@ static const NSTimeInterval kWaitInterval = .5;
   [[FIRAuth auth] signOut:NULL];
   [[FIRAuth auth] signInWithEmail:kEmail
                          password:kFakePassword
-                       completion:^(FIRUser *_Nullable user,
+                       completion:^(FIRAuthDataResult *_Nullable result,
                                     NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    [self assertUser:user];
+    [self assertUser:result.user];
     XCTAssertNil(error);
     [expectation fulfill];
   }];
@@ -734,10 +734,10 @@ static const NSTimeInterval kWaitInterval = .5;
   [[FIRAuth auth] signOut:NULL];
   [[FIRAuth auth] signInWithEmail:kEmail
                          password:kFakePassword
-                       completion:^(FIRUser *_Nullable user,
+                       completion:^(FIRAuthDataResult *_Nullable result,
                                     NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    XCTAssertNil(user);
+    XCTAssertNil(result.user);
     XCTAssertEqual(error.code, FIRAuthErrorCodeWrongPassword);
     XCTAssertNotNil(error.userInfo[NSLocalizedDescriptionKey]);
     [expectation fulfill];
@@ -1071,10 +1071,11 @@ static const NSTimeInterval kWaitInterval = .5;
   [[FIRAuth auth] signOut:NULL];
   FIRAuthCredential *emailCredential =
       [FIREmailAuthProvider credentialWithEmail:kEmail link:kFakeEmailSignInlink];
-  [[FIRAuth auth] signInWithCredential:emailCredential completion:^(FIRUser *_Nullable user,
-                                                                    NSError *_Nullable error) {
+  [[FIRAuth auth] signInWithCredential:emailCredential
+                            completion:^(FIRAuthDataResult *_Nullable result,
+                                         NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    XCTAssertNil(user);
+    XCTAssertNil(result.user);
     XCTAssertEqual(error.code, FIRAuthErrorCodeUserDisabled);
     XCTAssertNotNil(error.userInfo[NSLocalizedDescriptionKey]);
     [expectation fulfill];
@@ -1107,10 +1108,11 @@ static const NSTimeInterval kWaitInterval = .5;
   [[FIRAuth auth] signOut:NULL];
   FIRAuthCredential *emailCredential =
       [FIREmailAuthProvider credentialWithEmail:kEmail password:kFakePassword];
-  [[FIRAuth auth] signInWithCredential:emailCredential completion:^(FIRUser *_Nullable user,
-                                                                    NSError *_Nullable error) {
+  [[FIRAuth auth] signInWithCredential:emailCredential
+                            completion:^(FIRAuthDataResult *_Nullable result,
+                                         NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    [self assertUser:user];
+    [self assertUser:result.user];
     XCTAssertNil(error);
     [expectation fulfill];
   }];
@@ -1145,10 +1147,11 @@ static const NSTimeInterval kWaitInterval = .5;
   FIRAuthCredential *emailCredential =
       [FIREmailPasswordAuthProvider credentialWithEmail:kEmail password:kFakePassword];
 #pragma clang diagnostic pop
-  [[FIRAuth auth] signInWithCredential:emailCredential completion:^(FIRUser *_Nullable user,
-                                                                    NSError *_Nullable error) {
+  [[FIRAuth auth] signInWithCredential:emailCredential
+                            completion:^(FIRAuthDataResult *_Nullable result,
+                                        NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    [self assertUser:user];
+    [self assertUser:result.user];
     XCTAssertNil(error);
     [expectation fulfill];
   }];
@@ -1168,10 +1171,11 @@ static const NSTimeInterval kWaitInterval = .5;
   [[FIRAuth auth] signOut:NULL];
   FIRAuthCredential *emailCredential =
       [FIREmailAuthProvider credentialWithEmail:kEmail password:kFakePassword];
-  [[FIRAuth auth] signInWithCredential:emailCredential completion:^(FIRUser *_Nullable user,
-                                                                    NSError *_Nullable error) {
+  [[FIRAuth auth] signInWithCredential:emailCredential
+                            completion:^(FIRAuthDataResult *_Nullable result,
+                                         NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    XCTAssertNil(user);
+    XCTAssertNil(result.user);
     XCTAssertEqual(error.code, FIRAuthErrorCodeUserDisabled);
     XCTAssertNotNil(error.userInfo[NSLocalizedDescriptionKey]);
     [expectation fulfill];
@@ -1193,8 +1197,8 @@ static const NSTimeInterval kWaitInterval = .5;
   [[FIRAuth auth] signOut:NULL];
   FIRAuthCredential *emailCredential =
       [FIREmailAuthProvider credentialWithEmail:kEmail password:emptyString];
-  [[FIRAuth auth] signInWithCredential:emailCredential completion:^(FIRUser *_Nullable user,
-                                                                    NSError *_Nullable error) {
+  [[FIRAuth auth] signInWithCredential:emailCredential
+                            completion:^(FIRAuthDataResult *_Nullable result, NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
     XCTAssertEqual(error.code, FIRAuthErrorCodeWrongPassword);
     [expectation fulfill];
@@ -1228,8 +1232,9 @@ static const NSTimeInterval kWaitInterval = .5;
   [[FIRAuth auth] signOut:NULL];
   FIRAuthCredential *googleCredential =
       [FIRGoogleAuthProvider credentialWithIDToken:kGoogleIDToken accessToken:kGoogleAccessToken];
-  [[FIRAuth auth] signInWithCredential:googleCredential completion:^(FIRUser *_Nullable user,
-                                                                     NSError *_Nullable error) {
+  [[FIRAuth auth] signInWithCredential:googleCredential
+                            completion:^(FIRAuthDataResult *_Nullable result,
+                                         NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
     XCTAssertEqual(error.code, FIRAuthErrorCodeAccountExistsWithDifferentCredential);
     XCTAssertEqualObjects(error.userInfo[FIRAuthErrorUserInfoEmailKey], kEmail);
@@ -1267,10 +1272,11 @@ static const NSTimeInterval kWaitInterval = .5;
   [[FIRAuth auth] signOut:NULL];
   FIRAuthCredential *googleCredential =
       [FIRGoogleAuthProvider credentialWithIDToken:kGoogleIDToken accessToken:kGoogleAccessToken];
-  [[FIRAuth auth] signInWithCredential:googleCredential completion:^(FIRUser *_Nullable user,
-                                                                     NSError *_Nullable error) {
+  [[FIRAuth auth] signInWithCredential:googleCredential
+                            completion:^(FIRAuthDataResult *_Nullable result,
+                                         NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    [self assertUserGoogle:user];
+    [self assertUserGoogle:result.user];
     XCTAssertNil(error);
     [expectation fulfill];
   }];
@@ -1336,10 +1342,11 @@ static const NSTimeInterval kWaitInterval = .5;
   [[FIRAuth auth] signOut:NULL];
   FIRAuthCredential *googleCredential =
       [FIRGoogleAuthProvider credentialWithIDToken:kGoogleIDToken accessToken:kGoogleAccessToken];
-  [[FIRAuth auth] signInWithCredential:googleCredential  completion:^(FIRUser *_Nullable user,
-                                                                      NSError *_Nullable error) {
+  [[FIRAuth auth] signInWithCredential:googleCredential
+                            completion:^(FIRAuthDataResult *_Nullable result,
+                                         NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    XCTAssertNil(user);
+    XCTAssertNil(result.user);
     XCTAssertEqual(error.code, FIRAuthErrorCodeEmailAlreadyInUse);
     XCTAssertNotNil(error.userInfo[NSLocalizedDescriptionKey]);
     [expectation fulfill];
@@ -1369,10 +1376,10 @@ static const NSTimeInterval kWaitInterval = .5;
   [self expectGetAccountInfoAnonymous];
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [[FIRAuth auth] signOut:NULL];
-  [[FIRAuth auth] signInAnonymouslyWithCompletion:^(FIRUser *_Nullable user,
+  [[FIRAuth auth] signInAnonymouslyWithCompletion:^(FIRAuthDataResult *_Nullable result,
                                                     NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    [self assertUserAnonymous:user];
+    [self assertUserAnonymous:result.user];
     XCTAssertNil(error);
     [expectation fulfill];
   }];
@@ -1389,10 +1396,10 @@ static const NSTimeInterval kWaitInterval = .5;
       .andDispatchError2([FIRAuthErrorUtils operationNotAllowedErrorWithMessage:nil]);
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [[FIRAuth auth] signOut:NULL];
-  [[FIRAuth auth] signInAnonymouslyWithCompletion:^(FIRUser *_Nullable user,
+  [[FIRAuth auth] signInAnonymouslyWithCompletion:^(FIRAuthDataResult *_Nullable result,
                                                     NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    XCTAssertNil(user);
+    XCTAssertNil(result.user);
     XCTAssertEqual(error.code, FIRAuthErrorCodeOperationNotAllowed);
     XCTAssertNotNil(error.userInfo[NSLocalizedDescriptionKey]);
     [expectation fulfill];
@@ -1474,10 +1481,10 @@ static const NSTimeInterval kWaitInterval = .5;
   [self expectGetAccountInfo];
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [[FIRAuth auth] signOut:NULL];
-  [[FIRAuth auth] signInWithCustomToken:kCustomToken completion:^(FIRUser *_Nullable user,
+  [[FIRAuth auth] signInWithCustomToken:kCustomToken completion:^(FIRAuthDataResult *_Nullable result,
                                                                   NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    [self assertUser:user];
+    [self assertUser:result.user];
     XCTAssertNil(error);
     [expectation fulfill];
   }];
@@ -1494,10 +1501,11 @@ static const NSTimeInterval kWaitInterval = .5;
       .andDispatchError2([FIRAuthErrorUtils invalidCustomTokenErrorWithMessage:nil]);
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [[FIRAuth auth] signOut:NULL];
-  [[FIRAuth auth] signInWithCustomToken:kCustomToken completion:^(FIRUser *_Nullable user,
-                                                                  NSError *_Nullable error) {
+  [[FIRAuth auth] signInWithCustomToken:kCustomToken
+                             completion:^(FIRAuthDataResult *_Nullable result,
+                                          NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    XCTAssertNil(user);
+    XCTAssertNil(result.user);
     XCTAssertEqual(error.code, FIRAuthErrorCodeInvalidCustomToken);
     XCTAssertNotNil(error.userInfo[NSLocalizedDescriptionKey]);
     [expectation fulfill];
@@ -2434,13 +2442,14 @@ static const NSTimeInterval kWaitInterval = .5;
   });
   [self expectGetAccountInfoWithAccessToken:accessToken];
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
-  [[FIRAuth auth] signInWithEmail:kEmail password:kFakePassword completion:^(FIRUser *_Nullable user,
-                                                                             NSError *_Nullable error) {
+  [[FIRAuth auth] signInWithEmail:kEmail
+                         password:kFakePassword
+                       completion:^(FIRAuthDataResult *_Nullable result, NSError *_Nullable error) {
 
-    user.requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:APIKey];
+    result.user.requestConfiguration = [[FIRAuthRequestConfiguration alloc] initWithAPIKey:APIKey];
     [expectation fulfill];
     if (completion) {
-      completion(user, error);
+      completion(result.user, error);
     }
   }];
   [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];

--- a/Example/Auth/Tests/FIRUserTests.m
+++ b/Example/Auth/Tests/FIRUserTests.m
@@ -2244,11 +2244,12 @@ static const NSTimeInterval kExpectationTimeout = 2;
   });
   [self expectGetAccountInfoWithMockUserInfoResponse:mockUserInfoResponse];
   [[FIRAuth auth] signOut:NULL];
-  [[FIRAuth auth] signInWithEmail:kEmail password:kFakePassword completion:^(FIRUser *_Nullable user,
-                                                                             NSError *_Nullable error) {
-    XCTAssertNotNil(user);
+  [[FIRAuth auth] signInWithEmail:kEmail
+                         password:kFakePassword
+                       completion:^(FIRAuthDataResult *_Nullable result, NSError *_Nullable error) {
+    XCTAssertNotNil(result.user);
     XCTAssertNil(error);
-    completion(user);
+    completion(result.user);
   }];
 }
 

--- a/Firebase/Auth/Source/FIRAuth.m
+++ b/Firebase/Auth/Source/FIRAuth.m
@@ -692,13 +692,11 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
 }
 
 - (void)signInWithCredential:(FIRAuthCredential *)credential
-                  completion:(FIRAuthDataResultCallback)completion {
+                  completion:(FIRAuthResultCallback)completion {
   dispatch_async(FIRAuthGlobalWorkQueue(), ^{
-    FIRAuthDataResultCallback callback =
-        [self signInFlowAuthDataResultCallbackByDecoratingCallback:completion];
-    [self internalSignInAndRetrieveDataWithCredential:credential
-                                   isReauthentication:NO
-                                             callback:callback];
+    FIRAuthResultCallback callback =
+        [self signInFlowAuthResultCallbackByDecoratingCallback:completion];
+    [self internalSignInWithCredential:credential callback:callback];
   });
 }
 

--- a/Firebase/Auth/Source/Public/FIRAuth.h
+++ b/Firebase/Auth/Source/Public/FIRAuth.h
@@ -370,7 +370,7 @@ NS_SWIFT_NAME(Auth)
  */
 - (void)signInWithEmail:(NSString *)email
                password:(NSString *)password
-             completion:(nullable FIRAuthResultCallback)completion;
+             completion:(nullable FIRAuthDataResultCallback)completion;
 
 /** @fn signInWithEmail:link:completion:
     @brief Signs in using an email address and email sign-in link.
@@ -397,7 +397,7 @@ NS_SWIFT_NAME(Auth)
              completion:(nullable FIRAuthDataResultCallback)completion;
 
 /** @fn signInAndRetrieveDataWithEmail:password:completion:
-    @brief Signs in using an email address and password.
+    @brief Please use `signInWithEmail:password:completion:` instead.
 
     @param email The user's email address.
     @param password The user's password.
@@ -417,14 +417,11 @@ NS_SWIFT_NAME(Auth)
 
 
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods.
-
-    @remarks This method will only exist until the next major Firebase release following 4.x.x.
-        After the next major release the method `signInWithEmail:password:completion:` will support
-        the `FIRAuthDataResultCallback`.
  */
 - (void)signInAndRetrieveDataWithEmail:(NSString *)email
                               password:(NSString *)password
-                            completion:(nullable FIRAuthDataResultCallback)completion;
+                            completion:(nullable FIRAuthDataResultCallback)completion
+                                __attribute__((deprecated));
 
 /** @fn signInWithCredential:completion:
     @brief Please use `signInAndRetrieveDataWithCredential:completion:` instead. This method
@@ -473,10 +470,52 @@ NS_SWIFT_NAME(Auth)
 
 
 
-    @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods.
+    @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods
+ */
+- (void)signInWithCredential:(FIRAuthCredential *)credential
+                  completion:(nullable FIRAuthDataResultCallback)completion;
+
+/** @fn signInAndRetrieveDataWithCredential:completion:
+    @brief Please use signInWithCredential:completion: instead.
+
+    @param credential The credential supplied by the IdP.
+    @param completion Optionally; a block which is invoked when the sign in flow finishes, or is
+        canceled. Invoked asynchronously on the main thread in the future.
+
+    @remarks Possible error codes:
+
+        + `FIRAuthErrorCodeInvalidCredential` - Indicates the supplied credential is invalid.
+            This could happen if it has expired or it is malformed.
+        + `FIRAuthErrorCodeOperationNotAllowed` - Indicates that accounts
+            with the identity provider represented by the credential are not enabled.
+            Enable them in the Auth section of the Firebase console.
+        + `FIRAuthErrorCodeAccountExistsWithDifferentCredential` - Indicates the email asserted
+            by the credential (e.g. the email in a Facebook access token) is already in use by an
+            existing account, that cannot be authenticated with this sign-in method. Call
+            fetchProvidersForEmail for this user’s email and then prompt them to sign in with any of
+            the sign-in providers returned. This error will only be thrown if the "One account per
+            email address" setting is enabled in the Firebase console, under Auth settings.
+        + `FIRAuthErrorCodeUserDisabled` - Indicates the user's account is disabled.
+        + `FIRAuthErrorCodeWrongPassword` - Indicates the user attempted sign in with an
+            incorrect password, if credential is of the type EmailPasswordAuthCredential.
+        + `FIRAuthErrorCodeInvalidEmail` - Indicates the email address is malformed.
+        + `FIRAuthErrorCodeMissingVerificationID` - Indicates that the phone auth credential was
+            created with an empty verification ID.
+        + `FIRAuthErrorCodeMissingVerificationCode` - Indicates that the phone auth credential
+            was created with an empty verification code.
+        + `FIRAuthErrorCodeInvalidVerificationCode` - Indicates that the phone auth credential
+            was created with an invalid verification Code.
+        + `FIRAuthErrorCodeInvalidVerificationID` - Indicates that the phone auth credential was
+            created with an invalid verification ID.
+        + `FIRAuthErrorCodeSessionExpired` - Indicates that the SMS code has expired.
+
+
+
+    @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods
  */
 - (void)signInAndRetrieveDataWithCredential:(FIRAuthCredential *)credential
-                                 completion:(nullable FIRAuthDataResultCallback)completion;
+                                 completion:(nullable FIRAuthDataResultCallback)completion
+                                     __attribute__((deprecated));
 
 /** @fn signInAnonymouslyWithCompletion:
     @brief Asynchronously creates and becomes an anonymous user.
@@ -493,10 +532,10 @@ NS_SWIFT_NAME(Auth)
 
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods.
  */
-- (void)signInAnonymouslyWithCompletion:(nullable FIRAuthResultCallback)completion;
+- (void)signInAnonymouslyWithCompletion:(nullable FIRAuthDataResultCallback)completion;
 
 /** @fn signInAnonymouslyAndRetrieveDataWithCompletion:
-    @brief Asynchronously creates and becomes an anonymous user.
+    @brief `Please use sign signInAnonymouslyWithCompletion: insteead.`
     @param completion Optionally; a block which is invoked when the sign in finishes, or is
         canceled. Invoked asynchronously on the main thread in the future.
 
@@ -516,7 +555,7 @@ NS_SWIFT_NAME(Auth)
         `FIRAuthDataResultCallback`.
  */
 - (void)signInAnonymouslyAndRetrieveDataWithCompletion:
-    (nullable FIRAuthDataResultCallback)completion;
+    (nullable FIRAuthDataResultCallback)completion __attribute__((deprecated));
 
 /** @fn signInWithCustomToken:completion:
     @brief Asynchronously signs in to Firebase with the given Auth token.
@@ -537,10 +576,10 @@ NS_SWIFT_NAME(Auth)
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods.
  */
 - (void)signInWithCustomToken:(NSString *)token
-                   completion:(nullable FIRAuthResultCallback)completion;
+                   completion:(nullable FIRAuthDataResultCallback)completion;
 
 /** @fn signInAndRetrieveDataWithCustomToken:completion:
-    @brief Asynchronously signs in to Firebase with the given Auth token.
+    @brief Please use `signInWithCustomToken:completion:` instead.
 
     @param token A self-signed custom auth token.
     @param completion Optionally; a block which is invoked when the sign in finishes, or is
@@ -563,7 +602,8 @@ NS_SWIFT_NAME(Auth)
         support the `FIRAuthDataResultCallback`.
  */
 - (void)signInAndRetrieveDataWithCustomToken:(NSString *)token
-                                  completion:(nullable FIRAuthDataResultCallback)completion;
+                                  completion:(nullable FIRAuthDataResultCallback)completion
+                                      __attribute__((deprecated));
 
 
 /** @fn createUserWithEmail:password:completion:

--- a/Firebase/Auth/Source/Public/FIRAuth.h
+++ b/Firebase/Auth/Source/Public/FIRAuth.h
@@ -397,7 +397,8 @@ NS_SWIFT_NAME(Auth)
              completion:(nullable FIRAuthDataResultCallback)completion;
 
 /** @fn signInAndRetrieveDataWithEmail:password:completion:
-    @brief Please use `signInWithEmail:password:completion:` instead.
+    @brief Please use `signInWithEmail:password:completion:` for Objective-C or
+        `signIn(withEmail:password:completion:)` for Swift instead.
 
     @param email The user's email address.
     @param password The user's password.
@@ -424,13 +425,12 @@ NS_SWIFT_NAME(Auth)
                                 DEPRECATED_MSG_ATTRIBUTE(
                                       "signInAndRetrieveDataWithEmail:password:completion: is "
                                       "deprecated. Please use"
-                                      "signInWithEmail:password:completion: for Objective-C and"
+                                      " signInWithEmail:password:completion: for Objective-C or"
                                       " signIn(withEmail:password:completion:) for Swift instead.");
 
 /** @fn signInWithCredential:completion:
-    @brief Asynchronously signs in to Firebase with the given 3rd-party credentials (e.g. a Facebook
-        login Access Token, a Google ID Token/Access Token pair, etc.) and returns additional
-        identity provider data.
+    @brief Please use `signInAndRetrieveDataWithCredential:completion:` for Objective-C or
+        `signInAndRetrieveData(with:completion:)` for swift instead
 
     @param credential The credential supplied by the IdP.
     @param completion Optionally; a block which is invoked when the sign in flow finishes, or is
@@ -468,10 +468,17 @@ NS_SWIFT_NAME(Auth)
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods
  */
 - (void)signInWithCredential:(FIRAuthCredential *)credential
-                  completion:(nullable FIRAuthResultCallback)completion;
+                  completion:(nullable FIRAuthResultCallback)completion DEPRECATED_MSG_ATTRIBUTE(
+                                      "signInWithCredential:completion: is"
+                                      " deprecated. Please use"
+                                      " signInAndRetrieveDataWithCredential:completion: for"
+                                      " Objective-C or signInAndRetrieveData(with:completion:) for"
+                                      " Swift instead.");
 
 /** @fn signInAndRetrieveDataWithCredential:completion:
-    @brief Please use signInWithCredential:completion: instead.
+    @brief Asynchronously signs in to Firebase with the given 3rd-party credentials (e.g. a Facebook
+        login Access Token, a Google ID Token/Access Token pair, etc.) and returns additional
+        identity provider data.
 
     @param credential The credential supplied by the IdP.
     @param completion Optionally; a block which is invoked when the sign in flow finishes, or is
@@ -529,7 +536,8 @@ NS_SWIFT_NAME(Auth)
 - (void)signInAnonymouslyWithCompletion:(nullable FIRAuthDataResultCallback)completion;
 
 /** @fn signInAnonymouslyAndRetrieveDataWithCompletion:
-    @brief `Please use sign signInAnonymouslyWithCompletion: instead.`
+    @brief `Please use sign `signInAnonymouslyWithCompletion:` for Objective-C or
+        `signInAnonymously(Completion:)` for Swift instead.
     @param completion Optionally; a block which is invoked when the sign in finishes, or is
         canceled. Invoked asynchronously on the main thread in the future.
 
@@ -550,9 +558,9 @@ NS_SWIFT_NAME(Auth)
  */
 - (void)signInAnonymouslyAndRetrieveDataWithCompletion:
     (nullable FIRAuthDataResultCallback)completion
-        DEPRECATED_MSG_ATTRIBUTE("signInAnonymouslyAndRetrieveDataWithCompletion: is deprecated. "
-        "Please use signInAnonymouslyWithCompletion: for Objective-C and "
-        "signInAnonymously(Completion:) for swift instead.");
+        DEPRECATED_MSG_ATTRIBUTE("signInAnonymouslyAndRetrieveDataWithCompletion: is deprecated."
+        " Please use signInAnonymouslyWithCompletion: for Objective-C or"
+        " signInAnonymously(Completion:) for swift instead.");
 
 /** @fn signInWithCustomToken:completion:
     @brief Asynchronously signs in to Firebase with the given Auth token.
@@ -576,7 +584,8 @@ NS_SWIFT_NAME(Auth)
                    completion:(nullable FIRAuthDataResultCallback)completion;
 
 /** @fn signInAndRetrieveDataWithCustomToken:completion:
-    @brief Please use `signInWithCustomToken:completion:` instead.
+    @brief Please use `signInWithCustomToken:completion:` or `signIn(withCustomToken:completion:)`
+        for Swift instead.
 
     @param token A self-signed custom auth token.
     @param completion Optionally; a block which is invoked when the sign in finishes, or is
@@ -603,7 +612,7 @@ NS_SWIFT_NAME(Auth)
                                       DEPRECATED_MSG_ATTRIBUTE(
                                       "signInAndRetrieveDataWithCustomToken:completion: is"
                                       " deprecated. Please use signInWithCustomToken:completion:"
-                                      "for Objective-C and signIn(withCustomToken:completion:) for"
+                                      "for Objective-C or signIn(withCustomToken:completion:) for"
                                       " Swift instead.");
 
 /** @fn createUserWithEmail:password:completion:

--- a/Firebase/Auth/Source/Public/FIRAuth.h
+++ b/Firebase/Auth/Source/Public/FIRAuth.h
@@ -473,7 +473,7 @@ NS_SWIFT_NAME(Auth)
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods
  */
 - (void)signInWithCredential:(FIRAuthCredential *)credential
-                  completion:(nullable FIRAuthDataResultCallback)completion;
+                  completion:(nullable FIRAuthResultCallback)completion;
 
 /** @fn signInAndRetrieveDataWithCredential:completion:
     @brief Please use signInWithCredential:completion: instead.
@@ -514,8 +514,7 @@ NS_SWIFT_NAME(Auth)
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods
  */
 - (void)signInAndRetrieveDataWithCredential:(FIRAuthCredential *)credential
-                                 completion:(nullable FIRAuthDataResultCallback)completion
-                                     __attribute__((deprecated));
+                                 completion:(nullable FIRAuthDataResultCallback)completion;
 
 /** @fn signInAnonymouslyWithCompletion:
     @brief Asynchronously creates and becomes an anonymous user.

--- a/Firebase/Auth/Source/Public/FIRAuth.h
+++ b/Firebase/Auth/Source/Public/FIRAuth.h
@@ -421,18 +421,13 @@ NS_SWIFT_NAME(Auth)
 - (void)signInAndRetrieveDataWithEmail:(NSString *)email
                               password:(NSString *)password
                             completion:(nullable FIRAuthDataResultCallback)completion
-                                __attribute__((deprecated));
+                                DEPRECATED_MSG_ATTRIBUTE(
+                                      "signInAndRetrieveDataWithEmail:password:completion: is "
+                                      "deprecated. Please use"
+                                      "signInWithEmail:password:completion: for Objective-C and"
+                                      " signIn(withEmail:password:completion:) for Swift instead.");
 
 /** @fn signInWithCredential:completion:
-    @brief Please use `signInAndRetrieveDataWithCredential:completion:` instead. This method
-        doesn't return additional identity provider data.
- */
-- (void)signInWithCredential:(FIRAuthCredential *)credential
-                  completion:(nullable FIRAuthResultCallback)completion
-                      DEPRECATED_MSG_ATTRIBUTE("signInWithCredential: is deprecated. Please use "
-                          "signInAndRetrieveDataWithCredential:completion:` instead.");
-
-/** @fn signInAndRetrieveDataWithCredential:completion:
     @brief Asynchronously signs in to Firebase with the given 3rd-party credentials (e.g. a Facebook
         login Access Token, a Google ID Token/Access Token pair, etc.) and returns additional
         identity provider data.
@@ -534,7 +529,7 @@ NS_SWIFT_NAME(Auth)
 - (void)signInAnonymouslyWithCompletion:(nullable FIRAuthDataResultCallback)completion;
 
 /** @fn signInAnonymouslyAndRetrieveDataWithCompletion:
-    @brief `Please use sign signInAnonymouslyWithCompletion: insteead.`
+    @brief `Please use sign signInAnonymouslyWithCompletion: instead.`
     @param completion Optionally; a block which is invoked when the sign in finishes, or is
         canceled. Invoked asynchronously on the main thread in the future.
 
@@ -554,7 +549,10 @@ NS_SWIFT_NAME(Auth)
         `FIRAuthDataResultCallback`.
  */
 - (void)signInAnonymouslyAndRetrieveDataWithCompletion:
-    (nullable FIRAuthDataResultCallback)completion __attribute__((deprecated));
+    (nullable FIRAuthDataResultCallback)completion
+        DEPRECATED_MSG_ATTRIBUTE("signInAnonymouslyAndRetrieveDataWithCompletion: is deprecated. "
+        "Please use signInAnonymouslyWithCompletion: for Objective-C and "
+        "signInAnonymously(Completion:) for swift instead.");
 
 /** @fn signInWithCustomToken:completion:
     @brief Asynchronously signs in to Firebase with the given Auth token.
@@ -602,8 +600,11 @@ NS_SWIFT_NAME(Auth)
  */
 - (void)signInAndRetrieveDataWithCustomToken:(NSString *)token
                                   completion:(nullable FIRAuthDataResultCallback)completion
-                                      __attribute__((deprecated));
-
+                                      DEPRECATED_MSG_ATTRIBUTE(
+                                      "signInAndRetrieveDataWithCustomToken:completion: is"
+                                      " deprecated. Please use signInWithCustomToken:completion:"
+                                      "for Objective-C and signIn(withCustomToken:completion:) for"
+                                      " Swift instead.");
 
 /** @fn createUserWithEmail:password:completion:
     @brief Creates and, on success, signs in a user with the given email address and password.


### PR DESCRIPTION
Introduces first set of Auth breaking changes; adds the FIRAuthDataResult to most of the original authentication methods and deprecates the corresponding "AndRetrieve" methods. 