### PR TITLE
podspec updates for Firebase 5

### DIFF
--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -62,7 +62,6 @@ supports email and password accounts, as well as several 3rd party authenticatio
   s.framework = 'SafariServices'
   s.framework = 'Security'
   s.dependency 'FirebaseCore', '~> 5.0'
-  s.ios.dependency 'FirebaseAnalytics', '~> 5.0'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
   s.dependency 'GoogleToolboxForMac/NSDictionary+URLArguments', '~> 2.1'
 end

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAuth'
-  s.version          = '4.6.1'
-  s.summary          = 'The official iOS client for Firebase Authentication'
+  s.version          = '5.0.0'
+  s.summary          = 'The official iOS client for Firebase Authentication (plus experimental support for macOS and tvOS)'
 
   s.description      = <<-DESC
 Firebase Authentication allows you to manage your own account system without any backend code. It
@@ -14,10 +14,10 @@ supports email and password accounts, as well as several 3rd party authenticatio
 
   s.source           = {
     :git => 'https://github.com/firebase/firebase-ios-sdk.git',
-    :tag => s.version.to_s
+    :tag => 'Auth-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '7.0'
+  s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
 
@@ -61,8 +61,8 @@ supports email and password accounts, as well as several 3rd party authenticatio
   }
   s.framework = 'SafariServices'
   s.framework = 'Security'
-  s.dependency 'FirebaseCore', '~> 4.0'
-  s.ios.dependency 'FirebaseAnalytics', '~> 4.0'
+  s.dependency 'FirebaseCore', '~> 5.0'
+  s.ios.dependency 'FirebaseAnalytics', '~> 5.0'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
   s.dependency 'GoogleToolboxForMac/NSDictionary+URLArguments', '~> 2.1'
 end

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCore'
-  s.version          = '4.0.20'
-  s.summary          = 'Firebase Core for iOS'
+  s.version          = '5.0.0'
+  s.summary          = 'Firebase Core for iOS (plus experimental support for macOS and tvOS)'
 
   s.description      = <<-DESC
 Firebase Core includes FIRApp and FIROptions which provide central configuration for other Firebase services.
@@ -13,10 +13,10 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
 
   s.source           = {
     :git => 'https://github.com/firebase/firebase-ios-sdk.git',
-    :tag => s.version.to_s
+    :tag => 'Core-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '7.0'
+  s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
 
@@ -34,6 +34,6 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   s.dependency 'GoogleToolboxForMac/NSData+zlib', '~> 2.1'
   s.pod_target_xcconfig = {
     'OTHER_CFLAGS' => '-fno-autolink ' +
-      '-DFIRCore_VERSION=' + s.version.to_s + ' -DFirebase_VERSION=4.13.0'
+      '-DFIRCore_VERSION=' + s.version.to_s + ' -DFirebase_VERSION=5.0.0'
   }
 end

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -33,7 +33,6 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.frameworks = ['CFNetwork', 'Security', 'SystemConfiguration']
   s.dependency 'leveldb-library', '~> 1.18'
   s.dependency 'FirebaseCore', '~> 5.0'
-  s.ios.dependency 'FirebaseAnalytics', '~> 5.0'
   s.pod_target_xcconfig = {
     'GCC_PREPROCESSOR_DEFINITIONS' =>
       'FIRDatabase_VERSION=' + s.version.to_s }

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseDatabase'
-  s.version          = '4.1.5'
-  s.summary          = 'Firebase Open Source Libraries for iOS.'
+  s.version          = '5.0.0'
+  s.summary          = 'Firebase Open Source Libraries for iOS (plus experimental support for macOS and tvOS)'
 
   s.description      = <<-DESC
 Simplify your iOS development, grow your user base, and monetize more effectively with Firebase.
@@ -13,10 +13,10 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
 
   s.source           = {
     :git => 'https://github.com/firebase/firebase-ios-sdk.git',
-    :tag => s.version.to_s
+    :tag => 'Database-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '7.0'
+  s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
 
@@ -32,8 +32,8 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.libraries = ['c++', 'icucore']
   s.frameworks = ['CFNetwork', 'Security', 'SystemConfiguration']
   s.dependency 'leveldb-library', '~> 1.18'
-  s.dependency 'FirebaseCore', '~> 4.0'
-  s.ios.dependency 'FirebaseAnalytics', '~> 4.0'
+  s.dependency 'FirebaseCore', '~> 5.0'
+  s.ios.dependency 'FirebaseAnalytics', '~> 5.0'
   s.pod_target_xcconfig = {
     'GCC_PREPROCESSOR_DEFINITIONS' =>
       'FIRDatabase_VERSION=' + s.version.to_s }

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -1,14 +1,6 @@
-#
-# Be sure to run `pod lib lint FirebaseFirestore.podspec' to ensure this is a
-# valid spec before submitting.
-#
-# Any lines starting with a # are optional, but their use is encouraged
-# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
-#
-
 Pod::Spec.new do |s|
   s.name             = 'FirebaseFirestore'
-  s.version          = '0.11.0'
+  s.version          = '0.12.0'
   s.summary          = 'Google Cloud Firestore for iOS'
 
   s.description      = <<-DESC
@@ -19,10 +11,12 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.license          = { :type => 'Apache', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
 
-  s.source           = { :git => 'https://github.com/TBD/Firestore.git', :tag => s.version.to_s }
-  # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
+  s.source           = {
+    :git => 'https://github.com/firebase/firebase-ios-sdk.git',
+    :tag => 'Firestore-' + s.version.to_s
+  }
 
-  s.ios.deployment_target = '7.0'
+  s.ios.deployment_target = '8.0'
 
   s.cocoapods_version = '>= 1.4.0'
   s.static_framework = true
@@ -53,8 +47,8 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   ]
   s.public_header_files = 'Firestore/Source/Public/*.h'
 
-  s.ios.dependency 'FirebaseAnalytics', '~> 4.0'
-  s.dependency 'FirebaseCore', '~> 4.0'
+  s.ios.dependency 'FirebaseAnalytics', '~> 5.0'
+  s.dependency 'FirebaseCore', '~> 5.0'
   s.dependency 'gRPC-ProtoRPC', '~> 1.0'
   s.dependency 'leveldb-library', '~> 1.18'
   s.dependency 'Protobuf', '~> 3.1'

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -47,7 +47,6 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   ]
   s.public_header_files = 'Firestore/Source/Public/*.h'
 
-  s.ios.dependency 'FirebaseAnalytics', '~> 5.0'
   s.dependency 'FirebaseCore', '~> 5.0'
   s.dependency 'gRPC-ProtoRPC', '~> 1.0'
   s.dependency 'leveldb-library', '~> 1.18'

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -1,14 +1,6 @@
-#
-# Be sure to run `pod lib lint FirebaseFunctions.podspec' to ensure this is a
-# valid spec before submitting.
-#
-# Any lines starting with a # are optional, but their use is encouraged
-# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
-#
-
 Pod::Spec.new do |s|
   s.name             = 'FirebaseFunctions'
-  s.version          = '1.0.0'
+  s.version          = '2.0.0'
   s.summary          = 'Cloud Functions for Firebase iOS SDK.'
 
   s.description      = <<-DESC
@@ -16,8 +8,12 @@ iOS SDK for Cloud Functions for Firebase.
                        DESC
 
   s.homepage         = 'https://developers.google.com/'
+  s.license          = { :type => 'Apache', :file => 'LICENSE' }
   s.authors          = 'Google, Inc.'
-  s.source           = { :git => 'https://github.com/TBD/FirebaseFunctions.git', :tag => s.version.to_s }
+  s.source           = {
+    :git => 'https://github.com/firebase/firebase-ios-sdk.git',
+    :tag => 'Functions-' + s.version.to_s
+  }
 
   s.ios.deployment_target = '8.0'
 
@@ -28,6 +24,6 @@ iOS SDK for Cloud Functions for Firebase.
   s.source_files = 'Functions/FirebaseFunctions/**/*'
   s.public_header_files = 'Functions/FirebaseFunctions/Public/*.h'
 
-  s.dependency 'FirebaseCore', '~> 4.0'
+  s.dependency 'FirebaseCore', '~> 5.0'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
 end

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -38,7 +38,6 @@ device, and it is completely free.
   s.framework = 'AddressBook'
   s.framework = 'SystemConfiguration'
   s.dependency 'FirebaseCore', '~> 5.0'
-  s.ios.dependency 'FirebaseAnalytics', '~> 5.0'
   s.dependency 'FirebaseInstanceID', '~> 3.0'
   s.dependency 'GoogleToolboxForMac/Logger', '~> 2.1'
   s.dependency 'Protobuf', '~> 3.1'

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseMessaging'
-  s.version          = '2.2.0'
+  s.version          = '3.0.0'
   s.summary          = 'Firebase Messaging for iOS'
 
   s.description      = <<-DESC
@@ -16,11 +16,10 @@ device, and it is completely free.
 
   s.source           = {
     :git => 'https://github.com/firebase/firebase-ios-sdk.git',
-    :tag => s.version.to_s
+    :tag => 'Messaging-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.10'
+  s.ios.deployment_target = '8.0'
 
   s.cocoapods_version = '>= 1.4.0'
   s.static_framework = true
@@ -38,9 +37,9 @@ device, and it is completely free.
   }
   s.framework = 'AddressBook'
   s.framework = 'SystemConfiguration'
-  s.dependency 'FirebaseCore', '~> 4.0'
-  s.ios.dependency 'FirebaseAnalytics', '~> 4.0'
-  s.dependency 'FirebaseInstanceID', '~> 2.0'
+  s.dependency 'FirebaseCore', '~> 5.0'
+  s.ios.dependency 'FirebaseAnalytics', '~> 5.0'
+  s.dependency 'FirebaseInstanceID', '~> 3.0'
   s.dependency 'GoogleToolboxForMac/Logger', '~> 2.1'
   s.dependency 'Protobuf', '~> 3.1'
 end

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseStorage'
-  s.version          = '2.2.0'
-  s.summary          = 'Firebase Storage for iOS'
+  s.version          = '3.0.0'
+  s.summary          = 'Firebase Storage for iOS (plus experimental support for macOS and tvOS)'
 
   s.description      = <<-DESC
 Firebase Storage provides robust, secure file uploads and downloads from Firebase SDKs, powered by Google Cloud Storage.
@@ -13,10 +13,10 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
 
   s.source           = {
     :git => 'https://github.com/firebase/firebase-ios-sdk.git',
-    :tag => s.version.to_s
+    :tag => 'Storage-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '7.0'
+  s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
 
@@ -29,8 +29,8 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   s.ios.framework = 'MobileCoreServices'
   s.osx.framework = 'CoreServices'
 
-  s.dependency 'FirebaseCore', '~> 4.0'
-  s.ios.dependency 'FirebaseAnalytics', '~> 4.0'
+  s.dependency 'FirebaseCore', '~> 5.0'
+  s.ios.dependency 'FirebaseAnalytics', '~> 5.0'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
   s.pod_target_xcconfig = {
     'GCC_PREPROCESSOR_DEFINITIONS' =>

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -30,7 +30,6 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   s.osx.framework = 'CoreServices'
 
   s.dependency 'FirebaseCore', '~> 5.0'
-  s.ios.dependency 'FirebaseAnalytics', '~> 5.0'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
   s.pod_target_xcconfig = {
     'GCC_PREPROCESSOR_DEFINITIONS' =>


### PR DESCRIPTION
Update the seven podspecs for Firebase 5

They're deployed for internal testing at https://cpdc-eap.git.corp.google.com/io2018/ along with preliminary versions of the Firebase, FirebaseAnalytics, and FirebaseInstanceID pods.

To try out, update Podfile with 
```
source 'sso://cpdc-eap/io2018'
source 'https://github.com/CocoaPods/Specs.git'
```