### PR TITLE
Fixes error handling when parsing tokens.

### DIFF
--- a/Firebase/Auth/Source/FIRUser.m
+++ b/Firebase/Auth/Source/FIRUser.m
@@ -843,7 +843,7 @@ static void callInMainThreadWithAuthDataResultAndError(
         "error" out parameter.
  */
 - (FIRAuthTokenResult *)parseIDToken:(NSString *)token error:(NSError **)error {
-  error = nil;
+  *error = nil;
   NSArray *tokenStringArray = [token componentsSeparatedByString:@"."];
   // The token payload is always the second index of the array.
   NSMutableString *tokenPayload = [[NSMutableString alloc] initWithString:tokenStringArray[1]];
@@ -863,7 +863,7 @@ static void callInMainThreadWithAuthDataResultAndError(
       [NSJSONSerialization JSONObjectWithData:decodedTokenPayloadData
                                       options:NSJSONReadingMutableContainers|NSJSONReadingAllowFragments
                                         error:error];
-  if (error) {
+  if (*error) {
     return nil;
   }
 


### PR DESCRIPTION
Fixes error handling when parsing ID Tokens. Ideally the token parsing should never generate an error.  This is in the unlikely event that one does occur.