### PR TITLE
Deprecates SignInWithCredential

### DIFF
--- a/Firebase/Auth/Source/Public/FIRAuth.h
+++ b/Firebase/Auth/Source/Public/FIRAuth.h
@@ -426,11 +426,12 @@ NS_SWIFT_NAME(Auth)
                             completion:(nullable FIRAuthDataResultCallback)completion;
 
 /** @fn signInWithCredential:completion:
-    @brief Convenience method for `signInAndRetrieveDataWithCredential:completion:` This method
+    @brief Please use `signInAndRetrieveDataWithCredential:completion:` instead. This method
         doesn't return additional identity provider data.
  */
 - (void)signInWithCredential:(FIRAuthCredential *)credential
-                  completion:(nullable FIRAuthResultCallback)completion;
+                  completion:(nullable FIRAuthResultCallback)completion __attribute__((deprecated));
+;
 
 /** @fn signInAndRetrieveDataWithCredential:completion:
     @brief Asynchronously signs in to Firebase with the given 3rd-party credentials (e.g. a Facebook


### PR DESCRIPTION
This method will be removed in the next breaking change following Google I/O 2018.