### PR TITLE
Should always query the latest checkin info from InstanceID

### DIFF
--- a/Firebase/Messaging/FIRMessagingClient.m
+++ b/Firebase/Messaging/FIRMessagingClient.m
@@ -185,7 +185,6 @@ static NSUInteger FIRMessagingServerPort() {
     handler(error);
   };
 
-  [self.registrar tryToLoadValidCheckinInfo];
   [self.registrar updateSubscriptionToTopic:topic
                                   withToken:token
                                     options:options
@@ -266,7 +265,6 @@ static NSUInteger FIRMessagingServerPort() {
   }
   self.lastDisconnectedTimestamp = FIRMessagingCurrentTimestampInMilliseconds();
   self.connectHandler = handler;
-  [self.registrar tryToLoadValidCheckinInfo];
   [self connect];
 }
 
@@ -279,21 +277,17 @@ static NSUInteger FIRMessagingServerPort() {
   }
 
   self.stayConnected = YES;
-  BOOL isRegistrationComplete = [self.registrar hasValidCheckinInfo];
-
-  if (!isRegistrationComplete) {
-    if (![self.registrar tryToLoadValidCheckinInfo]) {
-      // Checkin info is not available. This may be due to the checkin still being fetched.
-      if (self.connectHandler) {
-        NSError *error = [NSError errorWithFCMErrorCode:kFIRMessagingErrorCodeMissingDeviceID];
-        self.connectHandler(error);
-      }
-      FIRMessagingLoggerDebug(kFIRMessagingMessageCodeClient009,
-                              @"Failed to connect to MCS. No deviceID and secret found.");
-      // Return for now. If checkin is, in fact, retrieved, the
-      // |kFIRMessagingCheckinFetchedNotification| will be fired.
-      return;
+  if (![self.registrar tryToLoadValidCheckinInfo]) {
+    // Checkin info is not available. This may be due to the checkin still being fetched.
+    if (self.connectHandler) {
+      NSError *error = [NSError errorWithFCMErrorCode:kFIRMessagingErrorCodeMissingDeviceID];
+      self.connectHandler(error);
     }
+    FIRMessagingLoggerDebug(kFIRMessagingMessageCodeClient009,
+                            @"Failed to connect to MCS. No deviceID and secret found.");
+    // Return for now. If checkin is, in fact, retrieved, the
+    // |kFIRMessagingCheckinFetchedNotification| will be fired.
+    return;
   }
   [self setupConnectionAndConnect];
 }

--- a/Firebase/Messaging/FIRMessagingRegistrar.m
+++ b/Firebase/Messaging/FIRMessagingRegistrar.m
@@ -45,6 +45,8 @@
   self = [super init];
   if (self) {
     _checkinService = [[FIRMessagingCheckinService alloc] init];
+    // TODO(chliangGoogle): Merge pubsubRegistrar with Registrar as it is hard to track how many
+    // checkinService instances by separating classes too often.
     _pubsubRegistrar = [[FIRMessagingPubSubRegistrar alloc] initWithCheckinService:_checkinService];
   }
   return self;
@@ -53,9 +55,7 @@
 #pragma mark - Checkin
 
 - (BOOL)tryToLoadValidCheckinInfo {
-  if (![self.checkinService hasValidCheckinInfo]) {
-    [self.checkinService tryToLoadPrefetchedCheckinPreferences];
-  }
+  [self.checkinService tryToLoadPrefetchedCheckinPreferences];
   return [self.checkinService hasValidCheckinInfo];
 }
 


### PR DESCRIPTION
This fixes a bug that when we delete IID, IID refreshes new checkin info and FCM stops querying the checkin if checkin exists. And this causes FCM using staled checkin info and not able to receive data message.

There was a check to see if a valid checkin info existed before query checkin. This is not a proper check because when checkin is refreshed, checkin info do existed, but we still need to perform the query to get the latest checkin. So remove the check.

Also remove some extra tryToLoadValidCheckinInfo check since the function it's called after that will trigger the tryToLoadValidCheckinInfo check anyway.