### PR TITLE
fix a bug caught by asan failure

### DIFF
--- a/Firestore/core/src/firebase/firestore/model/field_value.cc
+++ b/Firestore/core/src/firebase/firestore/model/field_value.cc
@@ -183,12 +183,12 @@ FieldValue FieldValue::Set(const FieldPath& field_path,
   } else {
     ObjectValue::Map copy = CopyExcept(object_map, child_name);
     const auto iter = object_map.find(child_name);
-    if (iter == copy.end() || iter->second.type() != Type::Object) {
+    if (iter == object_map.end() || iter->second.type() != Type::Object) {
       copy[child_name] = FieldValue::ObjectValueFromMap({}).Set(
           field_path.PopFirst(), std::move(value));
     } else {
-      copy[child_name] = object_map.at(child_name)
-                             .Set(field_path.PopFirst(), std::move(value));
+      copy[child_name] =
+          iter->second.Set(field_path.PopFirst(), std::move(value));
     }
     return FieldValue::ObjectValueFromMap(std::move(copy));
   }


### PR DESCRIPTION
Should check `object_map.end()` instead of `copy.end()` after a suggested refactoring. Interestingly, the unset memory matches the empty object `FieldValue` and thus test still pass even with the bug, if not checking unallocated memory access...