### PR TITLE
Port `SnapshotVersion` for `Remote`

### DIFF
--- a/Firestore/Example/Tests/Integration/FSTStreamTests.mm
+++ b/Firestore/Example/Tests/Integration/FSTStreamTests.mm
@@ -29,12 +29,14 @@
 #include "Firestore/core/src/firebase/firestore/auth/empty_credentials_provider.h"
 #include "Firestore/core/src/firebase/firestore/core/database_info.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 
 namespace util = firebase::firestore::util;
 using firebase::firestore::auth::EmptyCredentialsProvider;
 using firebase::firestore::core::DatabaseInfo;
 using firebase::firestore::model::DatabaseId;
+using firebase::firestore::model::SnapshotVersion;
 
 /** Exposes otherwise private methods for testing. */
 @interface FSTStream (Testing)
@@ -101,13 +103,13 @@ using firebase::firestore::model::DatabaseId;
 }
 
 - (void)watchStreamDidChange:(FSTWatchChange *)change
-             snapshotVersion:(FSTSnapshotVersion *)snapshotVersion {
+             snapshotVersion:(const SnapshotVersion &)snapshotVersion {
   [_states addObject:@"watchStreamDidChange"];
   [_expectation fulfill];
   _expectation = nil;
 }
 
-- (void)writeStreamDidReceiveResponseWithVersion:(FSTSnapshotVersion *)commitVersion
+- (void)writeStreamDidReceiveResponseWithVersion:(const SnapshotVersion &)commitVersion
                                  mutationResults:(NSArray<FSTMutationResult *> *)results {
   [_states addObject:@"writeStreamDidReceiveResponseWithVersion"];
   [_expectation fulfill];

--- a/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.mm
+++ b/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.mm
@@ -58,6 +58,7 @@
 
 namespace testutil = firebase::firestore::testutil;
 namespace util = firebase::firestore::util;
+using firebase::Timestamp;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::FieldMask;
 using firebase::firestore::model::FieldTransform;
@@ -424,8 +425,7 @@ NS_ASSUME_NONNULL_BEGIN
                              precondition:Precondition::UpdateTime(testutil::Version(4))];
   GCFSWrite *proto = [GCFSWrite message];
   proto.update = [self.serializer encodedDocumentWithFields:mutation.value key:mutation.key];
-  proto.currentDocument.updateTime =
-      [self.serializer encodedTimestamp:[[FIRTimestamp alloc] initWithSeconds:0 nanoseconds:4000]];
+  proto.currentDocument.updateTime = [self.serializer encodedTimestamp:Timestamp{0, 4000}];
 
   [self assertRoundTripForMutation:mutation proto:proto];
 }

--- a/Firestore/Example/Tests/SpecTests/FSTMockDatastore.h
+++ b/Firestore/Example/Tests/SpecTests/FSTMockDatastore.h
@@ -18,6 +18,8 @@
 
 #import "Firestore/Source/Remote/FSTDatastore.h"
 
+@class FSTSnapshotVersion;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface FSTMockDatastore : FSTDatastore

--- a/Firestore/Source/Core/FSTSyncEngine.mm
+++ b/Firestore/Source/Core/FSTSyncEngine.mm
@@ -45,11 +45,13 @@
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
 #include "Firestore/core/src/firebase/firestore/core/target_id_generator.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 
 using firebase::firestore::auth::HashUser;
 using firebase::firestore::auth::User;
 using firebase::firestore::core::TargetIdGenerator;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -347,9 +349,9 @@ static const FSTListenSequenceNumber kIrrelevantSequenceNumber = -1;
         [NSMutableDictionary dictionary];
     FSTDeletedDocument *doc =
         [FSTDeletedDocument documentWithKey:limboKey version:[FSTSnapshotVersion noVersion]];
-    FSTRemoteEvent *event = [FSTRemoteEvent eventWithSnapshotVersion:[FSTSnapshotVersion noVersion]
-                                                       targetChanges:targetChanges
-                                                     documentUpdates:{{limboKey, doc}}];
+    FSTRemoteEvent *event = [[FSTRemoteEvent alloc] initWithSnapshotVersion:SnapshotVersion::None()
+                                                              targetChanges:targetChanges
+                                                            documentUpdates:{{limboKey, doc}}];
     [self applyRemoteEvent:event];
   } else {
     FSTQueryView *queryView = self.queryViewsByTarget[@(targetID)];

--- a/Firestore/Source/Remote/FSTDatastore.h
+++ b/Firestore/Source/Remote/FSTDatastore.h
@@ -31,7 +31,6 @@
 @class FSTMutationResult;
 @class FSTQueryData;
 @class FSTSerializerBeta;
-@class FSTSnapshotVersion;
 @class FSTWatchChange;
 @class FSTWatchStream;
 @class FSTWriteStream;

--- a/Firestore/Source/Remote/FSTRemoteEvent.h
+++ b/Firestore/Source/Remote/FSTRemoteEvent.h
@@ -23,11 +23,11 @@
 #import "Firestore/Source/Model/FSTDocumentKeySet.h"
 
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 
 @class FSTDocument;
 @class FSTExistenceFilter;
 @class FSTMaybeDocument;
-@class FSTSnapshotVersion;
 @class FSTWatchChange;
 @class FSTQueryData;
 
@@ -115,6 +115,12 @@ typedef NS_ENUM(NSUInteger, FSTCurrentStatusUpdate) {
                 currentStatusUpdate:(FSTCurrentStatusUpdate)currentStatusUpdate;
 
 /**
+ * The snapshot version representing the last state at which this target received a consistent
+ * snapshot from the backend.
+ */
+- (const firebase::firestore::model::SnapshotVersion &)snapshotVersion;
+
+/**
  * The new "current" (synced) status of this target. Set to CurrentStatusUpdateNone if the status
  * should not be updated. Note "current" has special meaning for in the RPC protocol that implies
  * that a target is both up-to-date and consistent with the rest of the watch stream.
@@ -123,12 +129,6 @@ typedef NS_ENUM(NSUInteger, FSTCurrentStatusUpdate) {
 
 /** A set of changes to documents in this target. */
 @property(nonatomic, strong, readonly) FSTTargetMapping *mapping;
-
-/**
- * The snapshot version representing the last state at which this target received a consistent
- * snapshot from the backend.
- */
-@property(nonatomic, strong, readonly) FSTSnapshotVersion *snapshotVersion;
 
 /**
  * An opaque, server-assigned token that allows watching a query to be resumed after disconnecting
@@ -148,13 +148,13 @@ typedef NS_ENUM(NSUInteger, FSTCurrentStatusUpdate) {
 @interface FSTRemoteEvent : NSObject
 
 + (instancetype)
-eventWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
+eventWithSnapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVersion
            targetChanges:(NSMutableDictionary<NSNumber *, FSTTargetChange *> *)targetChanges
          documentUpdates:
              (std::map<firebase::firestore::model::DocumentKey, FSTMaybeDocument *>)documentUpdates;
 
 /** The snapshot version this event brings us up to. */
-@property(nonatomic, strong, readonly) FSTSnapshotVersion *snapshotVersion;
+- (const firebase::firestore::model::SnapshotVersion &)snapshotVersion;
 
 /** A map from target to changes to the target. See TargetChange. */
 @property(nonatomic, strong, readonly)
@@ -194,7 +194,7 @@ eventWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
 @interface FSTWatchChangeAggregator : NSObject
 
 - (instancetype)
-initWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
+initWithSnapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVersion
           listenTargets:(NSDictionary<FSTBoxedTargetID *, FSTQueryData *> *)listenTargets
  pendingTargetResponses:(NSDictionary<FSTBoxedTargetID *, NSNumber *> *)pendingTargetResponses
     NS_DESIGNATED_INITIALIZER;

--- a/Firestore/Source/Remote/FSTRemoteEvent.h
+++ b/Firestore/Source/Remote/FSTRemoteEvent.h
@@ -28,6 +28,7 @@
 @class FSTDocument;
 @class FSTExistenceFilter;
 @class FSTMaybeDocument;
+@class FSTSnapshotVersion;
 @class FSTWatchChange;
 @class FSTQueryData;
 
@@ -154,13 +155,13 @@ typedef NS_ENUM(NSUInteger, FSTCurrentStatusUpdate) {
 @interface FSTRemoteEvent : NSObject
 
 + (instancetype)
-eventWithSnapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVersion
+eventWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
            targetChanges:(NSMutableDictionary<NSNumber *, FSTTargetChange *> *)targetChanges
          documentUpdates:
              (std::map<firebase::firestore::model::DocumentKey, FSTMaybeDocument *>)documentUpdates;
 
 /** The snapshot version this event brings us up to. */
-- (const firebase::firestore::model::SnapshotVersion &)snapshotVersion;
+@property(nonatomic, strong, readonly) FSTSnapshotVersion *snapshotVersion;
 
 /** A map from target to changes to the target. See TargetChange. */
 @property(nonatomic, strong, readonly)
@@ -200,7 +201,7 @@ eventWithSnapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVe
 @interface FSTWatchChangeAggregator : NSObject
 
 - (instancetype)
-initWithSnapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVersion
+initWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
           listenTargets:(NSDictionary<FSTBoxedTargetID *, FSTQueryData *> *)listenTargets
  pendingTargetResponses:(NSDictionary<FSTBoxedTargetID *, NSNumber *> *)pendingTargetResponses
     NS_DESIGNATED_INITIALIZER;

--- a/Firestore/Source/Remote/FSTRemoteEvent.h
+++ b/Firestore/Source/Remote/FSTRemoteEvent.h
@@ -28,7 +28,6 @@
 @class FSTDocument;
 @class FSTExistenceFilter;
 @class FSTMaybeDocument;
-@class FSTSnapshotVersion;
 @class FSTWatchChange;
 @class FSTQueryData;
 
@@ -155,13 +154,13 @@ typedef NS_ENUM(NSUInteger, FSTCurrentStatusUpdate) {
 @interface FSTRemoteEvent : NSObject
 
 + (instancetype)
-eventWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
+eventWithSnapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVersion
            targetChanges:(NSMutableDictionary<NSNumber *, FSTTargetChange *> *)targetChanges
          documentUpdates:
              (std::map<firebase::firestore::model::DocumentKey, FSTMaybeDocument *>)documentUpdates;
 
 /** The snapshot version this event brings us up to. */
-@property(nonatomic, strong, readonly) FSTSnapshotVersion *snapshotVersion;
+- (const firebase::firestore::model::SnapshotVersion &)snapshotVersion;
 
 /** A map from target to changes to the target. See TargetChange. */
 @property(nonatomic, strong, readonly)
@@ -201,7 +200,7 @@ eventWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
 @interface FSTWatchChangeAggregator : NSObject
 
 - (instancetype)
-initWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
+initWithSnapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVersion
           listenTargets:(NSDictionary<FSTBoxedTargetID *, FSTQueryData *> *)listenTargets
  pendingTargetResponses:(NSDictionary<FSTBoxedTargetID *, NSNumber *> *)pendingTargetResponses
     NS_DESIGNATED_INITIALIZER;

--- a/Firestore/Source/Remote/FSTRemoteEvent.h
+++ b/Firestore/Source/Remote/FSTRemoteEvent.h
@@ -107,18 +107,18 @@ typedef NS_ENUM(NSUInteger, FSTCurrentStatusUpdate) {
 @interface FSTTargetChange : NSObject
 
 /**
+ * Creates a new target change with the given SnapshotVersion.
+ */
+- (instancetype)initWithSnapshotVersion:
+    (firebase::firestore::model::SnapshotVersion)snapshotVersion;
+
+/**
  * Creates a new target change with the given documents. Instances of FSTDocument are considered
  * added. Instance of FSTDeletedDocument are considered removed. This is intended primarily for
  * testing.
  */
 + (instancetype)changeWithDocuments:(NSArray<FSTMaybeDocument *> *)docs
                 currentStatusUpdate:(FSTCurrentStatusUpdate)currentStatusUpdate;
-
-/**
- * Creates a new target change with the given SnapshotVersion.
- */
-+ (instancetype)changeWithSnapshotVersion:
-    (firebase::firestore::model::SnapshotVersion)snapshotVersion;
 
 /**
  * The snapshot version representing the last state at which this target received a consistent
@@ -153,11 +153,11 @@ typedef NS_ENUM(NSUInteger, FSTCurrentStatusUpdate) {
  */
 @interface FSTRemoteEvent : NSObject
 
-+ (instancetype)
-eventWithSnapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVersion
-           targetChanges:(NSMutableDictionary<NSNumber *, FSTTargetChange *> *)targetChanges
-         documentUpdates:
-             (std::map<firebase::firestore::model::DocumentKey, FSTMaybeDocument *>)documentUpdates;
+- (instancetype)
+initWithSnapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVersion
+          targetChanges:(NSMutableDictionary<NSNumber *, FSTTargetChange *> *)targetChanges
+        documentUpdates:
+            (std::map<firebase::firestore::model::DocumentKey, FSTMaybeDocument *>)documentUpdates;
 
 /** The snapshot version this event brings us up to. */
 - (const firebase::firestore::model::SnapshotVersion &)snapshotVersion;

--- a/Firestore/Source/Remote/FSTRemoteEvent.h
+++ b/Firestore/Source/Remote/FSTRemoteEvent.h
@@ -115,6 +115,12 @@ typedef NS_ENUM(NSUInteger, FSTCurrentStatusUpdate) {
                 currentStatusUpdate:(FSTCurrentStatusUpdate)currentStatusUpdate;
 
 /**
+ * Creates a new target change with the given SnapshotVersion.
+ */
++ (instancetype)changeWithSnapshotVersion:
+    (firebase::firestore::model::SnapshotVersion)snapshotVersion;
+
+/**
  * The snapshot version representing the last state at which this target received a consistent
  * snapshot from the backend.
  */

--- a/Firestore/Source/Remote/FSTRemoteEvent.mm
+++ b/Firestore/Source/Remote/FSTRemoteEvent.mm
@@ -196,6 +196,10 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
+- (const firebase::firestore::model::SnapshotVersion &)snapshotVersion {
+  return _snapshotVersion;
+}
+
 + (instancetype)changeWithDocuments:(NSArray<FSTMaybeDocument *> *)docs
                 currentStatusUpdate:(FSTCurrentStatusUpdate)currentStatusUpdate {
   FSTUpdateMapping *mapping = [[FSTUpdateMapping alloc] init];
@@ -217,8 +221,15 @@ NS_ASSUME_NONNULL_BEGIN
               currentStatusUpdate:(FSTCurrentStatusUpdate)currentStatusUpdate {
   FSTTargetChange *change = [[FSTTargetChange alloc] init];
   change.mapping = mapping;
-  change._snapshotVersion = std::move(snapshotVersion);
+  change->_snapshotVersion = std::move(snapshotVersion);
   change.currentStatusUpdate = currentStatusUpdate;
+  return change;
+}
+
++ (instancetype)changeWithSnapshotVersion:
+    (firebase::firestore::model::SnapshotVersion)snapshotVersion {
+  FSTTargetChange *change = [[FSTTargetChange alloc] init];
+  change->_snapshotVersion = std::move(snapshotVersion);
   return change;
 }
 
@@ -259,6 +270,7 @@ initWithSnapshotVersion:(SnapshotVersion)snapshotVersion
   std::map<DocumentKey, FSTMaybeDocument *> _documentUpdates;
   SnapshotVersion _snapshotVersion;
 }
+
 + (instancetype)
 eventWithSnapshotVersion:(SnapshotVersion)snapshotVersion
            targetChanges:(NSMutableDictionary<NSNumber *, FSTTargetChange *> *)targetChanges
@@ -328,6 +340,10 @@ eventWithSnapshotVersion:(SnapshotVersion)snapshotVersion
 
 - (const std::map<DocumentKey, FSTMaybeDocument *> &)documentUpdates {
   return _documentUpdates;
+}
+
+- (const firebase::firestore::model::SnapshotVersion &)snapshotVersion {
+  return _snapshotVersion;
 }
 
 /** Adds a document update to this remote event */
@@ -407,9 +423,7 @@ initWithSnapshotVersion:(SnapshotVersion)snapshotVersion
 - (FSTTargetChange *)targetChangeForTargetID:(FSTBoxedTargetID *)targetID {
   FSTTargetChange *change = self.targetChanges[targetID];
   if (!change) {
-    change = [[FSTTargetChange alloc] init];
-    change._snapshotVersion = _snapshotVersion;
-    self.targetChanges[targetID] = change;
+    self.targetChanges[targetID] = [FSTTargetChange changeWithSnapshotVersion:_snapshotVersion];
   }
   return change;
 }

--- a/Firestore/Source/Remote/FSTRemoteEvent.mm
+++ b/Firestore/Source/Remote/FSTRemoteEvent.mm
@@ -423,7 +423,8 @@ initWithSnapshotVersion:(SnapshotVersion)snapshotVersion
 - (FSTTargetChange *)targetChangeForTargetID:(FSTBoxedTargetID *)targetID {
   FSTTargetChange *change = self.targetChanges[targetID];
   if (!change) {
-    self.targetChanges[targetID] = [FSTTargetChange changeWithSnapshotVersion:_snapshotVersion];
+    change = [FSTTargetChange changeWithSnapshotVersion:_snapshotVersion];
+    self.targetChanges[targetID] = change;
   }
   return change;
 }

--- a/Firestore/Source/Remote/FSTRemoteEvent.mm
+++ b/Firestore/Source/Remote/FSTRemoteEvent.mm
@@ -196,7 +196,14 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
-- (const firebase::firestore::model::SnapshotVersion &)snapshotVersion {
+- (instancetype)initWithSnapshotVersion:(SnapshotVersion)snapshotVersion {
+  if (self = [self init]) {
+    _snapshotVersion = std::move(snapshotVersion);
+  }
+  return self;
+}
+
+- (const SnapshotVersion &)snapshotVersion {
   return _snapshotVersion;
 }
 
@@ -223,13 +230,6 @@ NS_ASSUME_NONNULL_BEGIN
   change.mapping = mapping;
   change->_snapshotVersion = std::move(snapshotVersion);
   change.currentStatusUpdate = currentStatusUpdate;
-  return change;
-}
-
-+ (instancetype)changeWithSnapshotVersion:
-    (firebase::firestore::model::SnapshotVersion)snapshotVersion {
-  FSTTargetChange *change = [[FSTTargetChange alloc] init];
-  change->_snapshotVersion = std::move(snapshotVersion);
   return change;
 }
 
@@ -269,15 +269,6 @@ initWithSnapshotVersion:(SnapshotVersion)snapshotVersion
 @implementation FSTRemoteEvent {
   std::map<DocumentKey, FSTMaybeDocument *> _documentUpdates;
   SnapshotVersion _snapshotVersion;
-}
-
-+ (instancetype)
-eventWithSnapshotVersion:(SnapshotVersion)snapshotVersion
-           targetChanges:(NSMutableDictionary<NSNumber *, FSTTargetChange *> *)targetChanges
-         documentUpdates:(std::map<DocumentKey, FSTMaybeDocument *>)documentUpdates {
-  return [[FSTRemoteEvent alloc] initWithSnapshotVersion:std::move(snapshotVersion)
-                                           targetChanges:targetChanges
-                                         documentUpdates:std::move(documentUpdates)];
 }
 
 - (instancetype)initWithSnapshotVersion:(SnapshotVersion)snapshotVersion
@@ -342,7 +333,7 @@ eventWithSnapshotVersion:(SnapshotVersion)snapshotVersion
   return _documentUpdates;
 }
 
-- (const firebase::firestore::model::SnapshotVersion &)snapshotVersion {
+- (const SnapshotVersion &)snapshotVersion {
   return _snapshotVersion;
 }
 
@@ -423,7 +414,7 @@ initWithSnapshotVersion:(SnapshotVersion)snapshotVersion
 - (FSTTargetChange *)targetChangeForTargetID:(FSTBoxedTargetID *)targetID {
   FSTTargetChange *change = self.targetChanges[targetID];
   if (!change) {
-    change = [FSTTargetChange changeWithSnapshotVersion:_snapshotVersion];
+    change = [[FSTTargetChange alloc] initWithSnapshotVersion:_snapshotVersion];
     self.targetChanges[targetID] = change;
   }
   return change;
@@ -573,9 +564,9 @@ initWithSnapshotVersion:(SnapshotVersion)snapshotVersion
 
   // Mark this aggregator as frozen so no further modifications are made.
   self.frozen = YES;
-  return [FSTRemoteEvent eventWithSnapshotVersion:_snapshotVersion
-                                    targetChanges:targetChanges
-                                  documentUpdates:_documentUpdates];
+  return [[FSTRemoteEvent alloc] initWithSnapshotVersion:_snapshotVersion
+                                           targetChanges:targetChanges
+                                         documentUpdates:_documentUpdates];
 }
 
 @end

--- a/Firestore/Source/Remote/FSTRemoteEvent.mm
+++ b/Firestore/Source/Remote/FSTRemoteEvent.mm
@@ -19,7 +19,6 @@
 #include <map>
 #include <utility>
 
-#import "Firestore/Source/Core/FSTSnapshotVersion.h"
 #import "Firestore/Source/Model/FSTDocument.h"
 #import "Firestore/Source/Remote/FSTWatchChange.h"
 #import "Firestore/Source/Util/FSTAssert.h"
@@ -29,6 +28,7 @@
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::SnapshotVersion;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -181,11 +181,12 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FSTTargetChange ()
 @property(nonatomic, assign) FSTCurrentStatusUpdate currentStatusUpdate;
 @property(nonatomic, strong, nullable) FSTTargetMapping *mapping;
-@property(nonatomic, strong) FSTSnapshotVersion *snapshotVersion;
 @property(nonatomic, strong) NSData *resumeToken;
 @end
 
-@implementation FSTTargetChange
+@implementation FSTTargetChange {
+  SnapshotVersion _snapshotVersion;
+}
 
 - (instancetype)init {
   if (self = [super init]) {
@@ -212,11 +213,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (instancetype)changeWithMapping:(FSTTargetMapping *)mapping
-                  snapshotVersion:(FSTSnapshotVersion *)snapshotVersion
+                  snapshotVersion:(SnapshotVersion)snapshotVersion
               currentStatusUpdate:(FSTCurrentStatusUpdate)currentStatusUpdate {
   FSTTargetChange *change = [[FSTTargetChange alloc] init];
   change.mapping = mapping;
-  change.snapshotVersion = snapshotVersion;
+  change._snapshotVersion = std::move(snapshotVersion);
   change.currentStatusUpdate = currentStatusUpdate;
   return change;
 }
@@ -248,33 +249,32 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)
-initWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
+initWithSnapshotVersion:(SnapshotVersion)snapshotVersion
           targetChanges:(NSMutableDictionary<FSTBoxedTargetID *, FSTTargetChange *> *)targetChanges
         documentUpdates:(std::map<DocumentKey, FSTMaybeDocument *>)documentUpdates;
-
-@property(nonatomic, strong) FSTSnapshotVersion *snapshotVersion;
 
 @end
 
 @implementation FSTRemoteEvent {
   std::map<DocumentKey, FSTMaybeDocument *> _documentUpdates;
+  SnapshotVersion _snapshotVersion;
 }
 + (instancetype)
-eventWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
+eventWithSnapshotVersion:(SnapshotVersion)snapshotVersion
            targetChanges:(NSMutableDictionary<NSNumber *, FSTTargetChange *> *)targetChanges
          documentUpdates:(std::map<DocumentKey, FSTMaybeDocument *>)documentUpdates {
-  return [[FSTRemoteEvent alloc] initWithSnapshotVersion:snapshotVersion
+  return [[FSTRemoteEvent alloc] initWithSnapshotVersion:std::move(snapshotVersion)
                                            targetChanges:targetChanges
                                          documentUpdates:std::move(documentUpdates)];
 }
 
-- (instancetype)initWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
+- (instancetype)initWithSnapshotVersion:(SnapshotVersion)snapshotVersion
                           targetChanges:
                               (NSMutableDictionary<NSNumber *, FSTTargetChange *> *)targetChanges
                         documentUpdates:(std::map<DocumentKey, FSTMaybeDocument *>)documentUpdates {
   self = [super init];
   if (self) {
-    _snapshotVersion = snapshotVersion;
+    _snapshotVersion = std::move(snapshotVersion);
     _targetChanges = targetChanges;
     _documentUpdates = std::move(documentUpdates);
   }
@@ -350,7 +350,7 @@ eventWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
   // TODO(dimond): keep track of reset targets not to raise.
   FSTTargetChange *targetChange =
       [FSTTargetChange changeWithMapping:[[FSTResetMapping alloc] init]
-                         snapshotVersion:[FSTSnapshotVersion noVersion]
+                         snapshotVersion:SnapshotVersion::None()
                      currentStatusUpdate:FSTCurrentStatusUpdateMarkNotCurrent];
   _targetChanges[targetID] = targetChange;
 }
@@ -360,9 +360,6 @@ eventWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
 #pragma mark - FSTWatchChangeAggregator
 
 @interface FSTWatchChangeAggregator ()
-
-/** The snapshot version for every target change this creates. */
-@property(nonatomic, strong, readonly) FSTSnapshotVersion *snapshotVersion;
 
 /** Keeps track of the current target mappings */
 @property(nonatomic, strong, readonly)
@@ -381,15 +378,17 @@ eventWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
   NSMutableDictionary<FSTBoxedTargetID *, FSTExistenceFilter *> *_existenceFilters;
   /** Keeps track of document to update */
   std::map<DocumentKey, FSTMaybeDocument *> _documentUpdates;
+  /** The snapshot version for every target change this creates. */
+  SnapshotVersion _snapshotVersion;
 }
 
 - (instancetype)
-initWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
+initWithSnapshotVersion:(SnapshotVersion)snapshotVersion
           listenTargets:(NSDictionary<FSTBoxedTargetID *, FSTQueryData *> *)listenTargets
  pendingTargetResponses:(NSDictionary<FSTBoxedTargetID *, NSNumber *> *)pendingTargetResponses {
   self = [super init];
   if (self) {
-    _snapshotVersion = snapshotVersion;
+    _snapshotVersion = std::move(snapshotVersion);
 
     _frozen = NO;
     _targetChanges = [NSMutableDictionary dictionary];
@@ -409,7 +408,7 @@ initWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
   FSTTargetChange *change = self.targetChanges[targetID];
   if (!change) {
     change = [[FSTTargetChange alloc] init];
-    change.snapshotVersion = self.snapshotVersion;
+    change._snapshotVersion = _snapshotVersion;
     self.targetChanges[targetID] = change;
   }
   return change;
@@ -559,7 +558,7 @@ initWithSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
 
   // Mark this aggregator as frozen so no further modifications are made.
   self.frozen = YES;
-  return [FSTRemoteEvent eventWithSnapshotVersion:self.snapshotVersion
+  return [FSTRemoteEvent eventWithSnapshotVersion:_snapshotVersion
                                     targetChanges:targetChanges
                                   documentUpdates:_documentUpdates];
 }

--- a/Firestore/Source/Remote/FSTRemoteStore.mm
+++ b/Firestore/Source/Remote/FSTRemoteStore.mm
@@ -42,6 +42,7 @@
 namespace util = firebase::firestore::util;
 using firebase::firestore::auth::User;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::SnapshotVersion;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -316,7 +317,8 @@ static const int kMaxPendingWrites = 10;
     // using a resume token).
     [self.accumulatedChanges addObject:change];
     if (snapshotVersion == SnapshotVersion::None() ||
-        snapshotVersion < [self.localStore lastRemoteSnapshotVersion]) {
+        snapshotVersion <
+            static_cast<SnapshotVersion>([self.localStore lastRemoteSnapshotVersion])) {
       return;
     }
 

--- a/Firestore/Source/Remote/FSTRemoteStore.mm
+++ b/Firestore/Source/Remote/FSTRemoteStore.mm
@@ -317,8 +317,7 @@ static const int kMaxPendingWrites = 10;
     // using a resume token).
     [self.accumulatedChanges addObject:change];
     if (snapshotVersion == SnapshotVersion::None() ||
-        snapshotVersion <
-            static_cast<SnapshotVersion>([self.localStore lastRemoteSnapshotVersion])) {
+        snapshotVersion < SnapshotVersion{[self.localStore lastRemoteSnapshotVersion]}) {
       return;
     }
 

--- a/Firestore/Source/Remote/FSTRemoteStore.mm
+++ b/Firestore/Source/Remote/FSTRemoteStore.mm
@@ -19,7 +19,6 @@
 #include <cinttypes>
 
 #import "Firestore/Source/Core/FSTQuery.h"
-#import "Firestore/Source/Core/FSTSnapshotVersion.h"
 #import "Firestore/Source/Core/FSTTransaction.h"
 #import "Firestore/Source/Local/FSTLocalStore.h"
 #import "Firestore/Source/Local/FSTQueryData.h"
@@ -37,6 +36,7 @@
 
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 
 namespace util = firebase::firestore::util;
@@ -299,7 +299,7 @@ static const int kMaxPendingWrites = 10;
 }
 
 - (void)watchStreamDidChange:(FSTWatchChange *)change
-             snapshotVersion:(FSTSnapshotVersion *)snapshotVersion {
+             snapshotVersion:(const SnapshotVersion &)snapshotVersion {
   // Mark the connection as Online because we got a message from the server.
   [self.onlineStateTracker updateState:FSTOnlineStateOnline];
 
@@ -315,10 +315,8 @@ static const int kMaxPendingWrites = 10;
     // older than a previous snapshot we've processed (can happen after we resume a target
     // using a resume token).
     [self.accumulatedChanges addObject:change];
-    FSTAssert(snapshotVersion, @"snapshotVersion must not be nil.");
-    if ([snapshotVersion isEqual:[FSTSnapshotVersion noVersion]] ||
-        [snapshotVersion compare:[self.localStore lastRemoteSnapshotVersion]] ==
-            NSOrderedAscending) {
+    if (snapshotVersion == SnapshotVersion::None() ||
+        snapshotVersion < [self.localStore lastRemoteSnapshotVersion]) {
       return;
     }
 
@@ -354,7 +352,7 @@ static const int kMaxPendingWrites = 10;
  * on to the SyncEngine.
  */
 - (void)processBatchedWatchChanges:(NSArray<FSTWatchChange *> *)changes
-                   snapshotVersion:(FSTSnapshotVersion *)snapshotVersion {
+                   snapshotVersion:(const SnapshotVersion &)snapshotVersion {
   FSTWatchChangeAggregator *aggregator =
       [[FSTWatchChangeAggregator alloc] initWithSnapshotVersion:snapshotVersion
                                                   listenTargets:self.listenTargets
@@ -566,7 +564,7 @@ static const int kMaxPendingWrites = 10;
 }
 
 /** Handles a successful StreamingWriteResponse from the server that contains a mutation result. */
-- (void)writeStreamDidReceiveResponseWithVersion:(FSTSnapshotVersion *)commitVersion
+- (void)writeStreamDidReceiveResponseWithVersion:(const SnapshotVersion &)commitVersion
                                  mutationResults:(NSArray<FSTMutationResult *> *)results {
   // This is a response to a write containing mutations and should be correlated to the first
   // pending write.

--- a/Firestore/Source/Remote/FSTSerializerBeta.h
+++ b/Firestore/Source/Remote/FSTSerializerBeta.h
@@ -18,6 +18,7 @@
 
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 
 @class FSTFieldValue;
 @class FSTMaybeDocument;
@@ -27,7 +28,6 @@
 @class FSTObjectValue;
 @class FSTQuery;
 @class FSTQueryData;
-@class FSTSnapshotVersion;
 @class FIRTimestamp;
 @class FSTWatchChange;
 
@@ -64,8 +64,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (GPBTimestamp *)encodedTimestamp:(FIRTimestamp *)timestamp;
 - (FIRTimestamp *)decodedTimestamp:(GPBTimestamp *)timestamp;
 
-- (GPBTimestamp *)encodedVersion:(FSTSnapshotVersion *)version;
-- (FSTSnapshotVersion *)decodedVersion:(GPBTimestamp *)version;
+- (GPBTimestamp *)encodedVersion:(const firebase::firestore::model::SnapshotVersion &)version;
+- (firebase::firestore::model::SnapshotVersion)decodedVersion:(GPBTimestamp *)version;
 
 /** Returns the database ID, such as `projects/{project id}/databases/{database_id}`. */
 - (NSString *)encodedDatabaseID;
@@ -93,7 +93,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (FSTQuery *)decodedQueryFromQueryTarget:(GCFSTarget_QueryTarget *)target;
 
 - (FSTWatchChange *)decodedWatchChange:(GCFSListenResponse *)watchChange;
-- (FSTSnapshotVersion *)versionFromListenResponse:(GCFSListenResponse *)watchChange;
+- (firebase::firestore::model::SnapshotVersion)versionFromListenResponse:
+    (GCFSListenResponse *)watchChange;
 
 - (GCFSDocument *)encodedDocumentWithFields:(FSTObjectValue *)objectValue
                                         key:(const firebase::firestore::model::DocumentKey &)key;

--- a/Firestore/Source/Remote/FSTSerializerBeta.h
+++ b/Firestore/Source/Remote/FSTSerializerBeta.h
@@ -16,6 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
+#include "Firestore/core/include/firebase/firestore/timestamp.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
@@ -28,7 +29,6 @@
 @class FSTObjectValue;
 @class FSTQuery;
 @class FSTQueryData;
-@class FIRTimestamp;
 @class FSTWatchChange;
 
 @class GCFSBatchGetDocumentsResponse;
@@ -61,8 +61,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDatabaseID:(const firebase::firestore::model::DatabaseId *)databaseID
     NS_DESIGNATED_INITIALIZER;
 
-- (GPBTimestamp *)encodedTimestamp:(FIRTimestamp *)timestamp;
-- (FIRTimestamp *)decodedTimestamp:(GPBTimestamp *)timestamp;
+- (GPBTimestamp *)encodedTimestamp:(const firebase::Timestamp &)timestamp;
+- (firebase::Timestamp)decodedTimestamp:(GPBTimestamp *)timestamp;
 
 - (GPBTimestamp *)encodedVersion:(const firebase::firestore::model::SnapshotVersion &)version;
 - (firebase::firestore::model::SnapshotVersion)decodedVersion:(GPBTimestamp *)version;

--- a/Firestore/Source/Remote/FSTSerializerBeta.mm
+++ b/Firestore/Source/Remote/FSTSerializerBeta.mm
@@ -672,7 +672,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (FSTMutationResult *)decodedMutationResult:(GCFSWriteResult *)mutation {
   // NOTE: Deletes don't have an updateTime.
-  absl::optional<SnapshotVersion> version = absl::nullopt;
+  absl::optional<SnapshotVersion> version;
   if (mutation.updateTime) {
     version = [self decodedVersion:mutation.updateTime];
   }

--- a/Firestore/Source/Remote/FSTStream.h
+++ b/Firestore/Source/Remote/FSTStream.h
@@ -21,13 +21,13 @@
 
 #include "Firestore/core/src/firebase/firestore/auth/credentials_provider.h"
 #include "Firestore/core/src/firebase/firestore/core/database_info.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 
 @class FSTDispatchQueue;
 @class FSTMutation;
 @class FSTMutationResult;
 @class FSTQueryData;
 @class FSTSerializerBeta;
-@class FSTSnapshotVersion;
 @class FSTWatchChange;
 @class FSTWatchStream;
 @class FSTWriteStream;
@@ -179,7 +179,7 @@ NS_ASSUME_NONNULL_BEGIN
  * WatchChange responses sent back by the server.
  */
 - (void)watchStreamDidChange:(FSTWatchChange *)change
-             snapshotVersion:(FSTSnapshotVersion *)snapshotVersion;
+             snapshotVersion:(const firebase::firestore::model::SnapshotVersion &)snapshotVersion;
 
 /**
  * Called by the FSTWatchStream when the underlying streaming RPC is interrupted for whatever
@@ -250,7 +250,8 @@ NS_ASSUME_NONNULL_BEGIN
  * Called by the FSTWriteStream upon receiving a StreamingWriteResponse from the server that
  * contains mutation results.
  */
-- (void)writeStreamDidReceiveResponseWithVersion:(FSTSnapshotVersion *)commitVersion
+- (void)writeStreamDidReceiveResponseWithVersion:
+            (const firebase::firestore::model::SnapshotVersion &)commitVersion
                                  mutationResults:(NSArray<FSTMutationResult *> *)results;
 
 /**

--- a/Firestore/Source/Remote/FSTStream.mm
+++ b/Firestore/Source/Remote/FSTStream.mm
@@ -36,6 +36,7 @@
 #include "Firestore/core/src/firebase/firestore/auth/token.h"
 #include "Firestore/core/src/firebase/firestore/core/database_info.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 #include "Firestore/core/src/firebase/firestore/util/error_apple.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 
@@ -44,6 +45,7 @@ using firebase::firestore::auth::CredentialsProvider;
 using firebase::firestore::auth::Token;
 using firebase::firestore::core::DatabaseInfo;
 using firebase::firestore::model::DatabaseId;
+using firebase::firestore::model::SnapshotVersion;
 
 /**
  * Initial backoff time in seconds after an error.

--- a/Firestore/Source/Remote/FSTStream.mm
+++ b/Firestore/Source/Remote/FSTStream.mm
@@ -691,7 +691,7 @@ static const NSTimeInterval kIdleTimeout = 60.0;
   [self.backoff reset];
 
   FSTWatchChange *change = [_serializer decodedWatchChange:proto];
-  FSTSnapshotVersion *snap = [_serializer versionFromListenResponse:proto];
+  SnapshotVersion snap = [_serializer versionFromListenResponse:proto];
   [self.delegate watchStreamDidChange:change snapshotVersion:snap];
 }
 
@@ -807,7 +807,7 @@ static const NSTimeInterval kIdleTimeout = 60.0;
     // might be causing an error we want to back off from.
     [self.backoff reset];
 
-    FSTSnapshotVersion *commitVersion = [_serializer decodedVersion:response.commitTime];
+    SnapshotVersion commitVersion = [_serializer decodedVersion:response.commitTime];
     NSMutableArray<GCFSWriteResult *> *protos = response.writeResultsArray;
     NSMutableArray<FSTMutationResult *> *results = [NSMutableArray arrayWithCapacity:protos.count];
     for (GCFSWriteResult *proto in protos) {

--- a/Firestore/Source/Remote/FSTWatchChange.h
+++ b/Firestore/Source/Remote/FSTWatchChange.h
@@ -22,7 +22,6 @@
 
 @class FSTExistenceFilter;
 @class FSTMaybeDocument;
-@class FSTSnapshotVersion;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/core/src/firebase/firestore/model/snapshot_version.h
+++ b/Firestore/core/src/firebase/firestore/model/snapshot_version.h
@@ -44,7 +44,7 @@ class SnapshotVersion {
   static const SnapshotVersion& None();
 
 #if defined(__OBJC__)
-  SnapshotVersion() : timestamp_{} {
+  SnapshotVersion() {
   }
 
   SnapshotVersion(FSTSnapshotVersion* version)  // NOLINT(runtime/explicit)

--- a/Firestore/core/src/firebase/firestore/model/snapshot_version.h
+++ b/Firestore/core/src/firebase/firestore/model/snapshot_version.h
@@ -44,6 +44,9 @@ class SnapshotVersion {
   static const SnapshotVersion& None();
 
 #if defined(__OBJC__)
+  SnapshotVersion() : timestamp_{} {
+  }
+
   SnapshotVersion(FSTSnapshotVersion* version)  // NOLINT(runtime/explicit)
       : timestamp_{version.timestamp.seconds, version.timestamp.nanoseconds} {
   }


### PR DESCRIPTION
### Discussion
This is part of the C++ migration. Replace `FSTSnapshotVersion` by C++ `SnapshotVersion` in the `Remote` modulo.

### Testing
Integration and unit test pass.

### API Changes
n/a
