### PR TITLE
Remove GTM dependency from FirebaseAuth

### DIFF
--- a/Example/Auth/Tests/FIRVerifyAssertionRequestTests.m
+++ b/Example/Auth/Tests/FIRVerifyAssertionRequestTests.m
@@ -22,7 +22,6 @@
 #import "FIRVerifyAssertionRequest.h"
 #import "FIRVerifyAssertionResponse.h"
 #import "FIRFakeBackendRPCIssuer.h"
-#import <GoogleToolboxForMac/GTMNSDictionary+URLArguments.h>
 
 /** @var kTestAPIKey
     @brief Fake API key used for testing.
@@ -189,14 +188,17 @@ static NSString *const kAutoCreateKey = @"autoCreate";
                                            NSError *_Nullable error) {
   }];
 
-  NSDictionary *postBody = @{
-    kProviderIDKey : kTestProviderID,
-    kProviderAccessTokenKey : kTestProviderAccessToken
-  };
-  NSString *postBodyArgs = [postBody gtm_httpArgumentsString];
+  NSArray<NSURLQueryItem *> *queryItems = @[
+      [NSURLQueryItem queryItemWithName:kProviderIDKey
+                                  value:kTestProviderID],
+      [NSURLQueryItem queryItemWithName:kProviderAccessTokenKey
+                                  value:kTestProviderAccessToken],
+  ];
+  NSURLComponents *components = [[NSURLComponents alloc] init];
+  [components setQueryItems:queryItems];
   XCTAssertEqualObjects(_RPCIssuer.requestURL.absoluteString, kExpectedAPIURL);
   XCTAssertNotNil(_RPCIssuer.decodedRequest[kPostBodyKey]);
-  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kPostBodyKey], postBodyArgs);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kPostBodyKey], [components query]);
   XCTAssertNil(_RPCIssuer.decodedRequest[kIDTokenKey]);
   XCTAssertNil(_RPCIssuer.decodedRequest[kReturnSecureTokenKey]);
   // Auto-create flag Should be true by default.
@@ -223,17 +225,23 @@ static NSString *const kAutoCreateKey = @"autoCreate";
                                            NSError *_Nullable error) {
   }];
 
-  NSDictionary *postBody = @{
-    kProviderIDKey : kTestProviderID,
-    kProviderIDTokenKey : kTestProviderIDToken,
-    kProviderAccessTokenKey : kTestProviderAccessToken,
-    kProviderOAuthTokenSecretKey : kTestProviderOAuthTokenSecret,
-    kInputEmailKey : kTestInputEmail
-  };
-  NSString *postBodyArgs = [postBody gtm_httpArgumentsString];
+  NSArray<NSURLQueryItem *> *queryItems = @[
+      [NSURLQueryItem queryItemWithName:kProviderIDKey
+                                  value:kTestProviderID],
+      [NSURLQueryItem queryItemWithName:kProviderIDTokenKey
+                                  value:kTestProviderIDToken],
+      [NSURLQueryItem queryItemWithName:kProviderAccessTokenKey
+                                  value:kTestProviderAccessToken],
+      [NSURLQueryItem queryItemWithName:kProviderOAuthTokenSecretKey
+                                  value:kTestProviderOAuthTokenSecret],
+      [NSURLQueryItem queryItemWithName:kInputEmailKey
+                                  value:kTestInputEmail],
+      ];
+  NSURLComponents *components = [[NSURLComponents alloc] init];
+  [components setQueryItems:queryItems];
   XCTAssertEqualObjects(_RPCIssuer.requestURL.absoluteString, kExpectedAPIURL);
   XCTAssertNotNil(_RPCIssuer.decodedRequest[kPostBodyKey]);
-  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kPostBodyKey], postBodyArgs);
+  XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kPostBodyKey], [components query]);
   XCTAssertEqualObjects(_RPCIssuer.decodedRequest[kIDTokenKey], kTestAccessToken);
   XCTAssertTrue([_RPCIssuer.decodedRequest[kReturnSecureTokenKey] boolValue]);
   XCTAssertFalse([_RPCIssuer.decodedRequest[kAutoCreateKey] boolValue]);

--- a/Firebase/Auth/Source/RPCs/FIRVerifyAssertionRequest.m
+++ b/Firebase/Auth/Source/RPCs/FIRVerifyAssertionRequest.m
@@ -16,9 +16,6 @@
 
 #import "FIRVerifyAssertionRequest.h"
 
-#import <GoogleToolboxForMac/GTMNSData+zlib.h>
-#import <GoogleToolboxForMac/GTMNSDictionary+URLArguments.h>
-
 /** @var kVerifyAssertionEndpoint
     @brief The "verifyAssertion" endpoint.
  */
@@ -95,16 +92,19 @@ static NSString *const kReturnSecureTokenKey = @"returnSecureToken";
 }
 
 - (nullable id)unencodedHTTPRequestBodyWithError:(NSError *_Nullable *_Nullable)error {
-  NSMutableDictionary *postBody = [@{
-    kProviderIDKey : _providerID,
-  } mutableCopy];
+  NSURLComponents *components = [[NSURLComponents alloc] init];
+  NSMutableArray<NSURLQueryItem *> *queryItems = [@[[NSURLQueryItem queryItemWithName:kProviderIDKey
+                                                                                value:_providerID]]
+                                                  mutableCopy];
 
   if (_providerIDToken) {
-    postBody[kProviderIDTokenKey] = _providerIDToken;
+    [queryItems addObject:[NSURLQueryItem queryItemWithName:kProviderIDTokenKey
+                                                      value:_providerIDToken]];
   }
 
   if (_providerAccessToken) {
-    postBody[kProviderAccessTokenKey] = _providerAccessToken;
+    [queryItems addObject:[NSURLQueryItem queryItemWithName:kProviderAccessTokenKey
+                                                      value:_providerAccessToken]];
   }
 
   if (!_providerIDToken && !_providerAccessToken) {
@@ -113,17 +113,19 @@ static NSString *const kReturnSecureTokenKey = @"returnSecureToken";
   }
 
   if (_providerOAuthTokenSecret) {
-    postBody[kProviderOAuthTokenSecretKey] = _providerOAuthTokenSecret;
+    [queryItems addObject:[NSURLQueryItem queryItemWithName:kProviderOAuthTokenSecretKey
+                                                      value:_providerOAuthTokenSecret]];
   }
 
   if (_inputEmail) {
-    postBody[kIdentifierKey] = _inputEmail;
+    [queryItems addObject:[NSURLQueryItem queryItemWithName:kIdentifierKey
+                                                      value:_inputEmail]];
   }
-
+  [components setQueryItems:queryItems];
   NSMutableDictionary *body = [@{
-    kRequestURIKey : @"http://localhost", // Unused by server, but required
-    kPostBodyKey : [postBody gtm_httpArgumentsString]
-  } mutableCopy];
+      kRequestURIKey : @"http://localhost", // Unused by server, but required
+      kPostBodyKey : [components query]
+      } mutableCopy];
 
   if (_pendingIDToken) {
     body[kPendingIDTokenKey] = _pendingIDToken;

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -64,5 +64,4 @@ supports email and password accounts, as well as several 3rd party authenticatio
   s.dependency 'FirebaseCore', '~> 4.0'
   s.ios.dependency 'FirebaseAnalytics', '~> 4.0'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
-  s.dependency 'GoogleToolboxForMac/NSDictionary+URLArguments', '~> 2.1'
 end


### PR DESCRIPTION
Now that URLComponents has been available since iOS7, GoogleToolboxForMac is no longer necessary for FirebaseAuth.  Thanks to @thomasvl for the suggestion.