### PR TITLE
Add error handler for serializer (for deserializing cases)

### DIFF
--- a/Firestore/core/src/firebase/firestore/remote/serializer.cc
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.cc
@@ -26,6 +26,7 @@
 
 #include "Firestore/Protos/nanopb/google/firestore/v1beta1/document.pb.h"
 #include "Firestore/core/src/firebase/firestore/util/firebase_assert.h"
+#include "Firestore/core/src/firebase/firestore/util/string_printf.h"
 
 namespace firebase {
 namespace firestore {
@@ -34,6 +35,8 @@ namespace remote {
 using firebase::firestore::model::FieldValue;
 using firebase::firestore::model::ObjectValue;
 using firebase::firestore::util::Status;
+using firebase::firestore::util::StatusOr;
+using firebase::firestore::util::StringPrintf;
 
 namespace {
 
@@ -43,7 +46,7 @@ class Reader;
 
 void EncodeObject(Writer* writer, const ObjectValue& object_value);
 
-ObjectValue DecodeObject(Reader* reader);
+ObjectValue::Map DecodeObject(Reader* reader);
 
 /**
  * Represents a nanopb tag.
@@ -196,6 +199,14 @@ class Reader {
     return stream_.bytes_left;
   }
 
+  Status status() const {
+    return status_;
+  }
+
+  void set_status(Status status) {
+    status_ = status;
+  }
+
  private:
   /**
    * Creates a new Reader, based on the given nanopb pb_istream_t. Note that
@@ -219,6 +230,8 @@ class Reader {
    * @return The decoded varint as a uint64_t.
    */
   uint64_t ReadVarint();
+
+  Status status_ = Status::OK();
 
   pb_istream_t stream_;
 };
@@ -270,12 +283,19 @@ void Writer::WriteTag(Tag tag) {
 
 Tag Reader::ReadTag() {
   Tag tag;
+  if (!status_.ok()) return tag;
+
   bool eof;
   bool ok = pb_decode_tag(&stream_, &tag.wire_type, &tag.field_number, &eof);
-  if (!ok || eof) {
-    // TODO(rsgowman): figure out error handling
-    abort();
+  if (!ok) {
+    status_ =
+        Status(FirestoreErrorCode::InvalidArgument, PB_GET_ERROR(&stream_));
+    return tag;
   }
+
+  // nanopb code always returns a false status when setting eof.
+  FIREBASE_ASSERT_MESSAGE(!eof, "nanopb set both ok status and eof to true");
+
   return tag;
 }
 
@@ -301,10 +321,12 @@ void Writer::WriteVarint(uint64_t value) {
  * @return The decoded varint as a uint64_t.
  */
 uint64_t Reader::ReadVarint() {
-  uint64_t varint_value;
+  if (!status_.ok()) return false;
+
+  uint64_t varint_value = 0;
   if (!pb_decode_varint(&stream_, &varint_value)) {
-    // TODO(rsgowman): figure out error handling
-    abort();
+    status_ =
+        Status(FirestoreErrorCode::InvalidArgument, PB_GET_ERROR(&stream_));
   }
   return varint_value;
 }
@@ -315,9 +337,11 @@ void Writer::WriteNull() {
 
 void Reader::ReadNull() {
   uint64_t varint = ReadVarint();
+  if (!status_.ok()) return;
+
   if (varint != google_protobuf_NullValue_NULL_VALUE) {
-    // TODO(rsgowman): figure out error handling
-    abort();
+    status_ = Status(FirestoreErrorCode::InvalidArgument,
+                     "Input proto bytes cannot be parsed (invalid null value)");
   }
 }
 
@@ -327,14 +351,18 @@ void Writer::WriteBool(bool bool_value) {
 
 bool Reader::ReadBool() {
   uint64_t varint = ReadVarint();
+  if (!status_.ok()) return false;
+
   switch (varint) {
     case 0:
       return false;
     case 1:
       return true;
     default:
-      // TODO(rsgowman): figure out error handling
-      abort();
+      status_ =
+          Status(FirestoreErrorCode::InvalidArgument,
+                 "Input proto bytes cannot be parsed (invalid bool value)");
+      return false;
   }
 }
 
@@ -357,17 +385,23 @@ void Writer::WriteString(const std::string& string_value) {
 }
 
 std::string Reader::ReadString() {
+  if (!status_.ok()) return "";
+
   pb_istream_t substream;
   if (!pb_make_string_substream(&stream_, &substream)) {
-    // TODO(rsgowman): figure out error handling
-    abort();
+    status_ =
+        Status(FirestoreErrorCode::InvalidArgument, PB_GET_ERROR(&stream_));
+    pb_close_string_substream(&stream_, &substream);
+    return "";
   }
 
   std::string result(substream.bytes_left, '\0');
   if (!pb_read(&substream, reinterpret_cast<pb_byte_t*>(&result[0]),
                substream.bytes_left)) {
-    // TODO(rsgowman): figure out error handling
-    abort();
+    status_ =
+        Status(FirestoreErrorCode::InvalidArgument, PB_GET_ERROR(&stream_));
+    pb_close_string_substream(&stream_, &substream);
+    return "";
   }
 
   // NB: future versions of nanopb read the remaining characters out of the
@@ -375,10 +409,9 @@ std::string Reader::ReadString() {
   // check within pb_close_string_substream. Unfortunately, that's not present
   // in the current version (0.38).  We'll make a stronger assertion and check
   // to make sure there *are* no remaining characters in the substream.
-  if (substream.bytes_left != 0) {
-    // TODO(rsgowman): figure out error handling
-    abort();
-  }
+  FIREBASE_ASSERT_MESSAGE(
+      substream.bytes_left == 0,
+      "Bytes remaining in substream after supposedly reading all of them.");
 
   pb_close_string_substream(&stream_, &substream);
 
@@ -431,28 +464,51 @@ void EncodeFieldValueImpl(Writer* writer, const FieldValue& field_value) {
 
 FieldValue DecodeFieldValueImpl(Reader* reader) {
   Tag tag = reader->ReadTag();
+  if (!reader->status().ok()) return FieldValue::NullValue();
 
   // Ensure the tag matches the wire type
-  // TODO(rsgowman): figure out error handling
   switch (tag.field_number) {
     case google_firestore_v1beta1_Value_null_value_tag:
     case google_firestore_v1beta1_Value_boolean_value_tag:
     case google_firestore_v1beta1_Value_integer_value_tag:
       if (tag.wire_type != PB_WT_VARINT) {
-        abort();
+        reader->set_status(
+            Status(FirestoreErrorCode::InvalidArgument,
+                   "Input proto bytes cannot be parsed (mismatch between "
+                   "the wiretype and the field number (tag))"));
       }
       break;
 
     case google_firestore_v1beta1_Value_string_value_tag:
     case google_firestore_v1beta1_Value_map_value_tag:
       if (tag.wire_type != PB_WT_STRING) {
-        abort();
+        reader->set_status(
+            Status(FirestoreErrorCode::InvalidArgument,
+                   "Input proto bytes cannot be parsed (mismatch between "
+                   "the wiretype and the field number (tag))"));
       }
       break;
 
     default:
-      abort();
+      // We could get here for one of two reasons; either because the input
+      // bytes are corrupt, or because we're attempting to parse a tag that we
+      // haven't implemented yet. Long term, the latter reason should become
+      // less likely (especially in production), so we'll assume former. (But
+      // we'll also temporarily add a DEV assert to catch the latter when in dev
+      // mode.)
+      // TODO(rsgowman): Remove the 'DEV' assert once we're confident we've
+      // handled all the tags in the protos.
+      FIREBASE_DEV_ASSERT_MESSAGE(
+          false, StringPrintf("Unhandled message field number (tag): %i. (Or "
+                              "possibly corrupt input bytes)",
+                              tag.field_number)
+                     .c_str());
+      reader->set_status(Status(
+          FirestoreErrorCode::InvalidArgument,
+          "Input proto bytes cannot be parsed (invalid field number (tag))"));
   }
+
+  if (!reader->status().ok()) return FieldValue::NullValue();
 
   switch (tag.field_number) {
     case google_firestore_v1beta1_Value_null_value_tag:
@@ -465,12 +521,15 @@ FieldValue DecodeFieldValueImpl(Reader* reader) {
     case google_firestore_v1beta1_Value_string_value_tag:
       return FieldValue::StringValue(reader->ReadString());
     case google_firestore_v1beta1_Value_map_value_tag:
-      return FieldValue::ObjectValueFromMap(
-          DecodeObject(reader).internal_value);
+      return FieldValue::ObjectValueFromMap(DecodeObject(reader));
 
     default:
-      // TODO(rsgowman): figure out error handling
-      abort();
+      // This indicates an internal error as we've already ensured that this is
+      // a valid field_number.
+      FIREBASE_ASSERT_MESSAGE(
+          false,
+          "Somehow got an unexpected field number (tag) after verifying that "
+          "the field number was expected.");
   }
 }
 
@@ -533,24 +592,33 @@ template <typename T>
 T Reader::ReadNestedMessage(const std::function<T(Reader*)>& read_message_fn) {
   // Implementation note: This is roughly modeled on pb_decode_delimited,
   // adjusted to account for the oneof in FieldValue.
+
+  if (!status_.ok()) return T();
+
   pb_istream_t raw_substream;
   if (!pb_make_string_substream(&stream_, &raw_substream)) {
-    // TODO(rsgowman): figure out error handling
-    abort();
+    status_ =
+        Status(FirestoreErrorCode::InvalidArgument, PB_GET_ERROR(&stream_));
+    pb_close_string_substream(&stream_, &raw_substream);
+    return T();
   }
   Reader substream(raw_substream);
 
+  // If this fails, we *won't* return right away so that we can cleanup the
+  // substream (although technically, that turns out not to matter; no resource
+  // leaks occur if we don't do this.)
   T message = read_message_fn(&substream);
+  status_ = substream.status();
 
   // NB: future versions of nanopb read the remaining characters out of the
   // substream (and return false if that fails) as an additional safety
   // check within pb_close_string_substream. Unfortunately, that's not present
   // in the current version (0.38).  We'll make a stronger assertion and check
   // to make sure there *are* no remaining characters in the substream.
-  if (substream.bytes_left() != 0) {
-    // TODO(rsgowman): figure out error handling
-    abort();
-  }
+  FIREBASE_ASSERT_MESSAGE(
+      substream.bytes_left() == 0,
+      "Bytes remaining in substream after supposedly reading all of them.");
+
   pb_close_string_substream(&stream_, &substream.stream_);
 
   return message;
@@ -591,6 +659,7 @@ void EncodeFieldsEntry(Writer* writer, const ObjectValue::Map::value_type& kv) {
 
 ObjectValue::Map::value_type DecodeFieldsEntry(Reader* reader) {
   Tag tag = reader->ReadTag();
+  if (!reader->status().ok()) return ObjectValue::Map::value_type();
 
   // TODO(rsgowman): figure out error handling: We can do better than a failed
   // assertion.
@@ -600,6 +669,7 @@ ObjectValue::Map::value_type DecodeFieldsEntry(Reader* reader) {
   std::string key = reader->ReadString();
 
   tag = reader->ReadTag();
+  if (!reader->status().ok()) return ObjectValue::Map::value_type();
   FIREBASE_ASSERT(tag.field_number ==
                   google_firestore_v1beta1_MapValue_FieldsEntry_value_tag);
   FIREBASE_ASSERT(tag.wire_type == PB_WT_STRING);
@@ -607,7 +677,7 @@ ObjectValue::Map::value_type DecodeFieldsEntry(Reader* reader) {
   FieldValue value =
       reader->ReadNestedMessage<FieldValue>(DecodeFieldValueImpl);
 
-  return {key, value};
+  return ObjectValue::Map::value_type{key, value};
 }
 
 void EncodeObject(Writer* writer, const ObjectValue& object_value) {
@@ -622,12 +692,17 @@ void EncodeObject(Writer* writer, const ObjectValue& object_value) {
   });
 }
 
-ObjectValue DecodeObject(Reader* reader) {
-  ObjectValue::Map internal_value = reader->ReadNestedMessage<ObjectValue::Map>(
+ObjectValue::Map DecodeObject(Reader* reader) {
+  if (!reader->status().ok()) return ObjectValue::Map();
+
+  return reader->ReadNestedMessage<ObjectValue::Map>(
       [](Reader* reader) -> ObjectValue::Map {
         ObjectValue::Map result;
+        if (!reader->status().ok()) return result;
+
         while (reader->bytes_left()) {
           Tag tag = reader->ReadTag();
+          if (!reader->status().ok()) return result;
           FIREBASE_ASSERT(tag.field_number ==
                           google_firestore_v1beta1_MapValue_fields_tag);
           FIREBASE_ASSERT(tag.wire_type == PB_WT_STRING);
@@ -640,6 +715,7 @@ ObjectValue DecodeObject(Reader* reader) {
           // map.
           // TODO(rsgowman): figure out error handling: We can do better than a
           // failed assertion.
+          if (!reader->status().ok()) return result;
           FIREBASE_ASSERT(result.find(fv.first) == result.end());
 
           // Add this key,fieldvalue to the results map.
@@ -647,7 +723,6 @@ ObjectValue DecodeObject(Reader* reader) {
         }
         return result;
       });
-  return ObjectValue{internal_value};
 }
 
 }  // namespace
@@ -659,9 +734,15 @@ Status Serializer::EncodeFieldValue(const FieldValue& field_value,
   return writer.status();
 }
 
-FieldValue Serializer::DecodeFieldValue(const uint8_t* bytes, size_t length) {
+StatusOr<FieldValue> Serializer::DecodeFieldValue(const uint8_t* bytes,
+                                                  size_t length) {
   Reader reader = Reader::Wrap(bytes, length);
-  return DecodeFieldValueImpl(&reader);
+  FieldValue fv = DecodeFieldValueImpl(&reader);
+  if (reader.status().ok()) {
+    return fv;
+  } else {
+    return reader.status();
+  }
 }
 
 }  // namespace remote

--- a/Firestore/core/src/firebase/firestore/remote/serializer.cc
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.cc
@@ -26,7 +26,6 @@
 
 #include "Firestore/Protos/nanopb/google/firestore/v1beta1/document.pb.h"
 #include "Firestore/core/src/firebase/firestore/util/firebase_assert.h"
-#include "Firestore/core/src/firebase/firestore/util/string_printf.h"
 
 namespace firebase {
 namespace firestore {
@@ -36,7 +35,6 @@ using firebase::firestore::model::FieldValue;
 using firebase::firestore::model::ObjectValue;
 using firebase::firestore::util::Status;
 using firebase::firestore::util::StatusOr;
-using firebase::firestore::util::StringPrintf;
 
 namespace {
 
@@ -321,7 +319,7 @@ void Writer::WriteVarint(uint64_t value) {
  * @return The decoded varint as a uint64_t.
  */
 uint64_t Reader::ReadVarint() {
-  if (!status_.ok()) return false;
+  if (!status_.ok()) return 0;
 
   uint64_t varint_value = 0;
   if (!pb_decode_varint(&stream_, &varint_value)) {
@@ -499,10 +497,10 @@ FieldValue DecodeFieldValueImpl(Reader* reader) {
       // TODO(rsgowman): Remove the 'DEV' assert once we're confident we've
       // handled all the tags in the protos.
       FIREBASE_DEV_ASSERT_MESSAGE(
-          false, StringPrintf("Unhandled message field number (tag): %i. (Or "
-                              "possibly corrupt input bytes)",
-                              tag.field_number)
-                     .c_str());
+          false,
+          "Unhandled message field number (tag): %i. (Or possibly "
+          "corrupt input bytes)",
+          tag.field_number);
       reader->set_status(Status(
           FirestoreErrorCode::InvalidArgument,
           "Input proto bytes cannot be parsed (invalid field number (tag))"));

--- a/Firestore/core/src/firebase/firestore/remote/serializer.cc
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.cc
@@ -285,8 +285,7 @@ Tag Reader::ReadTag() {
 
   bool eof;
   if (!pb_decode_tag(&stream_, &tag.wire_type, &tag.field_number, &eof)) {
-    status_ =
-        Status(FirestoreErrorCode::DataLoss, PB_GET_ERROR(&stream_));
+    status_ = Status(FirestoreErrorCode::DataLoss, PB_GET_ERROR(&stream_));
     return tag;
   }
 
@@ -322,8 +321,7 @@ uint64_t Reader::ReadVarint() {
 
   uint64_t varint_value = 0;
   if (!pb_decode_varint(&stream_, &varint_value)) {
-    status_ =
-        Status(FirestoreErrorCode::DataLoss, PB_GET_ERROR(&stream_));
+    status_ = Status(FirestoreErrorCode::DataLoss, PB_GET_ERROR(&stream_));
   }
   return varint_value;
 }
@@ -386,8 +384,7 @@ std::string Reader::ReadString() {
 
   pb_istream_t substream;
   if (!pb_make_string_substream(&stream_, &substream)) {
-    status_ =
-        Status(FirestoreErrorCode::DataLoss, PB_GET_ERROR(&stream_));
+    status_ = Status(FirestoreErrorCode::DataLoss, PB_GET_ERROR(&stream_));
     pb_close_string_substream(&stream_, &substream);
     return "";
   }
@@ -395,8 +392,7 @@ std::string Reader::ReadString() {
   std::string result(substream.bytes_left, '\0');
   if (!pb_read(&substream, reinterpret_cast<pb_byte_t*>(&result[0]),
                substream.bytes_left)) {
-    status_ =
-        Status(FirestoreErrorCode::DataLoss, PB_GET_ERROR(&stream_));
+    status_ = Status(FirestoreErrorCode::DataLoss, PB_GET_ERROR(&stream_));
     pb_close_string_substream(&stream_, &substream);
     return "";
   }
@@ -594,8 +590,7 @@ T Reader::ReadNestedMessage(const std::function<T(Reader*)>& read_message_fn) {
 
   pb_istream_t raw_substream;
   if (!pb_make_string_substream(&stream_, &raw_substream)) {
-    status_ =
-        Status(FirestoreErrorCode::DataLoss, PB_GET_ERROR(&stream_));
+    status_ = Status(FirestoreErrorCode::DataLoss, PB_GET_ERROR(&stream_));
     pb_close_string_substream(&stream_, &raw_substream);
     return T();
   }

--- a/Firestore/core/src/firebase/firestore/remote/serializer.h
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.h
@@ -24,6 +24,7 @@
 #include "Firestore/core/src/firebase/firestore/model/field_value.h"
 #include "Firestore/core/src/firebase/firestore/util/firebase_assert.h"
 #include "Firestore/core/src/firebase/firestore/util/status.h"
+#include "Firestore/core/src/firebase/firestore/util/statusor.h"
 #include "absl/base/attributes.h"
 
 namespace firebase {
@@ -66,8 +67,9 @@ class Serializer {
    * @param field_value the model to convert.
    * @param[out] out_bytes A buffer to place the output. The bytes will be
    * appended to this vector.
+   * @return A Status, which if not ok(), indicates what went wrong. Note that
+   * errors during encoding generally indicate a serious/fatal error.
    */
-  // TODO(rsgowman): error handling, incl return code.
   // TODO(rsgowman): If we never support any output except to a vector, it may
   // make sense to have Serializer own the vector and provide an accessor rather
   // than asking the user to create it first.
@@ -80,20 +82,22 @@ class Serializer {
    *
    * @param bytes The bytes to convert. It's assumed that exactly all of the
    * bytes will be used by this conversion.
-   * @return The model equivalent of the bytes.
+   * @return The model equivalent of the bytes or a Status indicating
+   * what went wrong.
    */
-  // TODO(rsgowman): error handling.
-  model::FieldValue DecodeFieldValue(const uint8_t* bytes, size_t length);
+  util::StatusOr<model::FieldValue> DecodeFieldValue(const uint8_t* bytes,
+                                                     size_t length);
 
   /**
    * @brief Converts from bytes to the model FieldValue format.
    *
    * @param bytes The bytes to convert. It's assumed that exactly all of the
    * bytes will be used by this conversion.
-   * @return The model equivalent of the bytes.
+   * @return The model equivalent of the bytes or a Status indicating
+   * what went wrong.
    */
-  // TODO(rsgowman): error handling.
-  model::FieldValue DecodeFieldValue(const std::vector<uint8_t>& bytes) {
+  util::StatusOr<model::FieldValue> DecodeFieldValue(
+      const std::vector<uint8_t>& bytes) {
     return DecodeFieldValue(bytes.data(), bytes.size());
   }
 

--- a/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
+++ b/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
@@ -322,6 +322,21 @@ TEST_F(SerializerTest, BadStringValue) {
       Status(FirestoreErrorCode::InvalidArgument, "ignored"), bytes);
 }
 
+TEST_F(SerializerTest, BadStringValue2) {
+  std::vector<uint8_t> bytes;
+  Status status =
+      serializer.EncodeFieldValue(FieldValue::StringValue("a"), &bytes);
+  EXPECT_TRUE(status.ok());
+
+  // Mutate that bytes: Claim that the string length is 5 instead of 1.
+  // (The first two bytes are used by the encoded tag.)
+  EXPECT_EQ(bytes[2], 1);
+  bytes[2] = 5;
+
+  ExpectFailedStatusDuringDecode(
+      Status(FirestoreErrorCode::InvalidArgument, "ignored"), bytes);
+}
+
 TEST_F(SerializerTest, BadTag) {
   // The google::firestore::v1beta1::Value value_type oneof currently has tags
   // up to 18. For this test, we'll pick a tag that's unlikely to be added in

--- a/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
+++ b/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
@@ -283,7 +283,7 @@ TEST_F(SerializerTest, BadNullValue) {
       0x01,  // invalid null value. (0 is only valid null value)
   };
   ExpectFailedStatusDuringDecode(
-      Status(FirestoreErrorCode::InvalidArgument, "ignored"), bytes);
+      Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
 TEST_F(SerializerTest, BadBoolValue) {
@@ -292,7 +292,7 @@ TEST_F(SerializerTest, BadBoolValue) {
       0x02,  // invalid value for a bool. (Valid values are 0,1)
   };
   ExpectFailedStatusDuringDecode(
-      Status(FirestoreErrorCode::InvalidArgument, "ignored"), bytes);
+      Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
 TEST_F(SerializerTest, BadIntegerValue) {
@@ -307,7 +307,7 @@ TEST_F(SerializerTest, BadIntegerValue) {
   };
   // clang-format on
   ExpectFailedStatusDuringDecode(
-      Status(FirestoreErrorCode::InvalidArgument, "ignored"), bytes);
+      Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
 TEST_F(SerializerTest, BadStringValue) {
@@ -319,7 +319,7 @@ TEST_F(SerializerTest, BadStringValue) {
   };
   // clang-format on
   ExpectFailedStatusDuringDecode(
-      Status(FirestoreErrorCode::InvalidArgument, "ignored"), bytes);
+      Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
 TEST_F(SerializerTest, BadStringValue2) {
@@ -334,7 +334,7 @@ TEST_F(SerializerTest, BadStringValue2) {
   bytes[2] = 5;
 
   ExpectFailedStatusDuringDecode(
-      Status(FirestoreErrorCode::InvalidArgument, "ignored"), bytes);
+      Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
 TEST_F(SerializerTest, BadTag) {
@@ -351,14 +351,14 @@ TEST_F(SerializerTest, BadTag) {
   // clang-format on
 #if defined(NDEBUG)
   ExpectFailedStatusDuringDecode(
-      Status(FirestoreErrorCode::InvalidArgument, "ignored"), bytes);
+      Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 #else
   // The behaviour is *temporarily* slightly different during debug mode; this
   // will cause a failed assertion rather than a failed status.
   // TODO(rsgowman): Remove this path once it's removed from serializer.cc.
   // (Hint: search for FIREBASE_DEV_ASSERT_MESSAGE)
   EXPECT_ANY_THROW(ExpectFailedStatusDuringDecode(
-      Status(FirestoreErrorCode::InvalidArgument, "ignored"), bytes));
+      Status(FirestoreErrorCode::DataLoss, "ignored"), bytes));
 #endif
 }
 
@@ -370,7 +370,7 @@ TEST_F(SerializerTest, TagVarintWiretypeStringMismatch) {
       0x01,  // true
   };
   ExpectFailedStatusDuringDecode(
-      Status(FirestoreErrorCode::InvalidArgument, "ignored"), bytes);
+      Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
 TEST_F(SerializerTest, TagStringWiretypeVarintMismatch) {
@@ -382,7 +382,7 @@ TEST_F(SerializerTest, TagStringWiretypeVarintMismatch) {
   };
   // clang-format on
   ExpectFailedStatusDuringDecode(
-      Status(FirestoreErrorCode::InvalidArgument, "ignored"), bytes);
+      Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
 TEST_F(SerializerTest, IncompleteFieldValue) {
@@ -391,13 +391,13 @@ TEST_F(SerializerTest, IncompleteFieldValue) {
              // Note: Missing '0' for the value
   };
   ExpectFailedStatusDuringDecode(
-      Status(FirestoreErrorCode::InvalidArgument, "ignored"), bytes);
+      Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
 TEST_F(SerializerTest, IncompleteTag) {
   std::vector<uint8_t> bytes{};
   ExpectFailedStatusDuringDecode(
-      Status(FirestoreErrorCode::InvalidArgument, "ignored"), bytes);
+      Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
 // TODO(rsgowman): Test [en|de]coding multiple protos into the same output

--- a/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
+++ b/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
@@ -344,22 +344,21 @@ TEST_F(SerializerTest, BadTag) {
   // Specifically 31.
   // clang-format off
   std::vector<uint8_t> bytes{
-      0xF8, 0x01,  // represents field number 31 encoded as a varint
+      0xf8, 0x01,  // represents field number 31 encoded as a varint
                    // There's no payload here, which is also invalid, but we
                    // won't get that far.
   };
   // clang-format on
-#if defined(NDEBUG)
-  ExpectFailedStatusDuringDecode(
-      Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
-#else
-  // The behaviour is *temporarily* slightly different during debug mode; this
-  // will cause a failed assertion rather than a failed status.
-  // TODO(rsgowman): Remove this path once it's removed from serializer.cc.
-  // (Hint: search for FIREBASE_DEV_ASSERT_MESSAGE)
+
+  // TODO(rsgowman): The behaviour is *temporarily* slightly different during
+  // development; this will cause a failed assertion rather than a failed
+  // status. Remove this EXPECT_ANY_THROW statement (and reenable the
+  // following commented out statement) once the corresponding assert has been
+  // removed from serializer.cc.
   EXPECT_ANY_THROW(ExpectFailedStatusDuringDecode(
       Status(FirestoreErrorCode::DataLoss, "ignored"), bytes));
-#endif
+  //ExpectFailedStatusDuringDecode(
+  //    Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
 TEST_F(SerializerTest, TagVarintWiretypeStringMismatch) {
@@ -395,7 +394,7 @@ TEST_F(SerializerTest, IncompleteFieldValue) {
 }
 
 TEST_F(SerializerTest, IncompleteTag) {
-  std::vector<uint8_t> bytes{};
+  std::vector<uint8_t> bytes;
   ExpectFailedStatusDuringDecode(
       Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }

--- a/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
+++ b/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
@@ -131,9 +131,9 @@ class SerializerTest : public ::testing::Test {
   }
 
   std::vector<uint8_t> ExpectSuccessfullyEncodedFieldValue(
-      Serializer& serializer, const FieldValue& fv) {
+      Serializer* serializer, const FieldValue& fv) {
     std::vector<uint8_t> bytes;
-    Status status = serializer.EncodeFieldValue(fv, &bytes);
+    Status status = serializer->EncodeFieldValue(fv, &bytes);
     EXPECT_OK(status);
     return bytes;
   }
@@ -382,7 +382,7 @@ TEST_F(SerializerTest, BadStringValue2) {
 
 TEST_F(SerializerTest, BadStringValue4) {
   std::vector<uint8_t> bytes = ExpectSuccessfullyEncodedFieldValue(
-      serializer, FieldValue::StringValue("a"));
+      &serializer, FieldValue::StringValue("a"));
 
   // Claim that the string length is 5 instead of 1. (The first two bytes are
   // used by the encoded tag.)


### PR DESCRIPTION
This is more interesting than the serializing case, as we should expect
to see occasional corruption of our input byte vector.