### PR TITLE
Port `SnapshotVersion` for `Local`

### DIFF
--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -600,7 +600,7 @@ static NSString *const kNoIOSTag = @"no-ios";
     FSTQueryData *actual = actualTargets[targetID];
     XCTAssertEqualObjects(actual.query, queryData.query);
     XCTAssertEqual(actual.targetID, queryData.targetID);
-    XCTAssertEqualObjects(actual.snapshotVersion, queryData.snapshotVersion);
+    XCTAssertEqual(actual.snapshotVersion, queryData.snapshotVersion);
     XCTAssertEqualObjects(actual.resumeToken, queryData.resumeToken);
 
     [actualTargets removeObjectForKey:targetID];

--- a/Firestore/Source/Local/FSTLevelDBQueryCache.mm
+++ b/Firestore/Source/Local/FSTLevelDBQueryCache.mm
@@ -28,6 +28,7 @@
 #import "Firestore/Source/Util/FSTAssert.h"
 
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 #include "absl/strings/match.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -35,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 using firebase::firestore::local::LevelDbTransaction;
 using Firestore::StringView;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::SnapshotVersion;
 using leveldb::DB;
 using leveldb::Slice;
 using leveldb::Status;
@@ -55,7 +57,7 @@ using leveldb::Status;
    * The last received snapshot version. This is part of `metadata` but we store it separately to
    * avoid extra conversion to/from GPBTimestamp.
    */
-  FSTSnapshotVersion *_lastRemoteSnapshotVersion;
+  SnapshotVersion _lastRemoteSnapshotVersion;
 }
 
 + (nullable FSTPBTargetGlobal *)readTargetMetadataWithTransaction:
@@ -135,11 +137,11 @@ using leveldb::Status;
   return self.metadata.highestListenSequenceNumber;
 }
 
-- (FSTSnapshotVersion *)lastRemoteSnapshotVersion {
+- (const SnapshotVersion &)lastRemoteSnapshotVersion {
   return _lastRemoteSnapshotVersion;
 }
 
-- (void)setLastRemoteSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion {
+- (void)setLastRemoteSnapshotVersion:(const SnapshotVersion &)snapshotVersion {
   _lastRemoteSnapshotVersion = snapshotVersion;
   self.metadata.lastRemoteSnapshotVersion = [self.serializer encodedVersion:snapshotVersion];
   _db.currentTransaction->Put([FSTLevelDBTargetGlobalKey key], self.metadata);

--- a/Firestore/Source/Local/FSTLevelDBQueryCache.mm
+++ b/Firestore/Source/Local/FSTLevelDBQueryCache.mm
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 #import "Firestore/Protos/objc/firestore/local/Target.pbobjc.h"
 #import "Firestore/Source/Core/FSTQuery.h"
@@ -141,9 +142,10 @@ using leveldb::Status;
   return _lastRemoteSnapshotVersion;
 }
 
-- (void)setLastRemoteSnapshotVersion:(const SnapshotVersion &)snapshotVersion {
-  _lastRemoteSnapshotVersion = snapshotVersion;
-  self.metadata.lastRemoteSnapshotVersion = [self.serializer encodedVersion:snapshotVersion];
+- (void)setLastRemoteSnapshotVersion:(SnapshotVersion)snapshotVersion {
+  _lastRemoteSnapshotVersion = std::move(snapshotVersion);
+  self.metadata.lastRemoteSnapshotVersion =
+      [self.serializer encodedVersion:_lastRemoteSnapshotVersion];
   _db.currentTransaction->Put([FSTLevelDBTargetGlobalKey key], self.metadata);
 }
 

--- a/Firestore/Source/Local/FSTLocalDocumentsView.mm
+++ b/Firestore/Source/Local/FSTLocalDocumentsView.mm
@@ -17,7 +17,6 @@
 #import "Firestore/Source/Local/FSTLocalDocumentsView.h"
 
 #import "Firestore/Source/Core/FSTQuery.h"
-#import "Firestore/Source/Core/FSTSnapshotVersion.h"
 #import "Firestore/Source/Local/FSTMutationQueue.h"
 #import "Firestore/Source/Local/FSTRemoteDocumentCache.h"
 #import "Firestore/Source/Model/FSTDocument.h"
@@ -28,9 +27,11 @@
 
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/resource_path.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::ResourcePath;
+using firebase::firestore::model::SnapshotVersion;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -71,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
     FSTMaybeDocument *maybeDoc = [self documentForKey:key];
     // TODO(http://b/32275378): Don't conflate missing / deleted.
     if (!maybeDoc) {
-      maybeDoc = [FSTDeletedDocument documentWithKey:key version:[FSTSnapshotVersion noVersion]];
+      maybeDoc = [FSTDeletedDocument documentWithKey:key version:SnapshotVersion::None()];
     }
     results = [results dictionaryBySettingObject:maybeDoc forKey:key];
   }

--- a/Firestore/Source/Local/FSTLocalSerializer.h
+++ b/Firestore/Source/Local/FSTLocalSerializer.h
@@ -16,11 +16,12 @@
 
 #import <Foundation/Foundation.h>
 
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
+
 @class FSTMaybeDocument;
 @class FSTMutationBatch;
 @class FSTQueryData;
 @class FSTSerializerBeta;
-@class FSTSnapshotVersion;
 
 @class FSTPBMaybeDocument;
 @class FSTPBTarget;
@@ -61,11 +62,11 @@ NS_ASSUME_NONNULL_BEGIN
 /** Decodes an FSTPBTarget proto from local storage into an FSTQueryData model. */
 - (FSTQueryData *)decodedQueryData:(FSTPBTarget *)target;
 
-/** Encodes an FSTSnapshotVersion model into a GPBTimestamp proto. */
-- (GPBTimestamp *)encodedVersion:(FSTSnapshotVersion *)version;
+/** Encodes a SnapshotVersion model into a GPBTimestamp proto. */
+- (GPBTimestamp *)encodedVersion:(const firebase::firestore::model::SnapshotVersion &)version;
 
-/** Decodes a GPBTimestamp proto into a FSTSnapshotVersion model. */
-- (FSTSnapshotVersion *)decodedVersion:(GPBTimestamp *)version;
+/** Decodes a GPBTimestamp proto into a SnapshotVersion model. */
+- (firebase::firestore::model::SnapshotVersion)decodedVersion:(GPBTimestamp *)version;
 
 @end
 

--- a/Firestore/Source/Local/FSTLocalSerializer.mm
+++ b/Firestore/Source/Local/FSTLocalSerializer.mm
@@ -31,8 +31,10 @@
 #import "Firestore/Source/Util/FSTAssert.h"
 
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::SnapshotVersion;
 
 @interface FSTLocalSerializer ()
 
@@ -100,7 +102,7 @@ using firebase::firestore::model::DocumentKey;
 
   FSTObjectValue *data = [remoteSerializer decodedFields:document.fields];
   const DocumentKey key = [remoteSerializer decodedDocumentKey:document.name];
-  FSTSnapshotVersion *version = [remoteSerializer decodedVersion:document.updateTime];
+  const SnapshotVersion version = [remoteSerializer decodedVersion:document.updateTime];
   return [FSTDocument documentWithData:data key:key version:version hasLocalMutations:NO];
 }
 
@@ -119,7 +121,7 @@ using firebase::firestore::model::DocumentKey;
   FSTSerializerBeta *remoteSerializer = self.remoteSerializer;
 
   const DocumentKey key = [remoteSerializer decodedDocumentKey:proto.name];
-  FSTSnapshotVersion *version = [remoteSerializer decodedVersion:proto.readTime];
+  const SnapshotVersion version = [remoteSerializer decodedVersion:proto.readTime];
   return [FSTDeletedDocument documentWithKey:key version:version];
 }
 
@@ -181,7 +183,7 @@ using firebase::firestore::model::DocumentKey;
 
   FSTTargetID targetID = target.targetId;
   FSTListenSequenceNumber sequenceNumber = target.lastListenSequenceNumber;
-  FSTSnapshotVersion *version = [remoteSerializer decodedVersion:target.snapshotVersion];
+  SnapshotVersion version = [remoteSerializer decodedVersion:target.snapshotVersion];
   NSData *resumeToken = target.resumeToken;
 
   FSTQuery *query;
@@ -206,11 +208,11 @@ using firebase::firestore::model::DocumentKey;
                                  resumeToken:resumeToken];
 }
 
-- (GPBTimestamp *)encodedVersion:(FSTSnapshotVersion *)version {
+- (GPBTimestamp *)encodedVersion:(const SnapshotVersion &)version {
   return [self.remoteSerializer encodedVersion:version];
 }
 
-- (FSTSnapshotVersion *)decodedVersion:(GPBTimestamp *)version {
+- (SnapshotVersion)decodedVersion:(GPBTimestamp *)version {
   return [self.remoteSerializer decodedVersion:version];
 }
 

--- a/Firestore/Source/Local/FSTLocalSerializer.mm
+++ b/Firestore/Source/Local/FSTLocalSerializer.mm
@@ -183,7 +183,7 @@ using firebase::firestore::model::SnapshotVersion;
 
   FSTTargetID targetID = target.targetId;
   FSTListenSequenceNumber sequenceNumber = target.lastListenSequenceNumber;
-  SnapshotVersion version = [remoteSerializer decodedVersion:target.snapshotVersion];
+  const SnapshotVersion version = [remoteSerializer decodedVersion:target.snapshotVersion];
   NSData *resumeToken = target.resumeToken;
 
   FSTQuery *query;

--- a/Firestore/Source/Local/FSTLocalStore.h
+++ b/Firestore/Source/Local/FSTLocalStore.h
@@ -23,6 +23,7 @@
 
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 
 @class FSTLocalViewChanges;
 @class FSTLocalWriteResult;
@@ -141,7 +142,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Returns the last consistent snapshot processed (used by the RemoteStore to determine whether to
  * buffer incoming snapshots from the backend).
  */
-- (FSTSnapshotVersion *)lastRemoteSnapshotVersion;
+- (const firebase::firestore::model::SnapshotVersion &)lastRemoteSnapshotVersion;
 
 /**
  * Updates the "ground-state" (remote) documents. We assume that the remote event reflects any

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -21,7 +21,6 @@
 #import "FIRTimestamp.h"
 #import "Firestore/Source/Core/FSTListenSequence.h"
 #import "Firestore/Source/Core/FSTQuery.h"
-#import "Firestore/Source/Core/FSTSnapshotVersion.h"
 #import "Firestore/Source/Local/FSTGarbageCollector.h"
 #import "Firestore/Source/Local/FSTLocalDocumentsView.h"
 #import "Firestore/Source/Local/FSTLocalViewChanges.h"
@@ -313,8 +312,8 @@ NS_ASSUME_NONNULL_BEGIN
       // Make sure we don't apply an old document version to the remote cache, though we
       // make an exception for SnapshotVersion::None() which can happen for manufactured
       // events (e.g. in the case of a limbo document resolution failing).
-      if (!existingDoc || [doc.version isEqual:[FSTSnapshotVersion noVersion]] ||
-          [doc.version compare:existingDoc.version] != NSOrderedAscending) {
+      if (!existingDoc || SnapshotVersion{doc.version} == SnapshotVersion::None() ||
+          SnapshotVersion{doc.version} >= SnapshotVersion{existingDoc.version}) {
         [self.remoteDocumentCache addEntry:doc];
       } else {
         FSTLog(
@@ -331,12 +330,14 @@ NS_ASSUME_NONNULL_BEGIN
     // HACK: The only reason we allow omitting snapshot version is so we can synthesize remote
     // events when we get permission denied errors while trying to resolve the state of a locally
     // cached document that is in limbo.
-    FSTSnapshotVersion *lastRemoteVersion = [self.queryCache lastRemoteSnapshotVersion];
-    FSTSnapshotVersion *remoteVersion = remoteEvent.snapshotVersion;
-    if (![remoteVersion isEqual:[FSTSnapshotVersion noVersion]]) {
-      FSTAssert([remoteVersion compare:lastRemoteVersion] != NSOrderedAscending,
-                @"Watch stream reverted to previous snapshot?? (%@ < %@)", remoteVersion,
-                lastRemoteVersion);
+    const SnapshotVersion &lastRemoteVersion = [self.queryCache lastRemoteSnapshotVersion];
+    // TODO(zxu): convert to reference once SnapshotVersion is used in RemoteEvent.
+    const SnapshotVersion remoteVersion = remoteEvent.snapshotVersion;
+    if (remoteVersion != SnapshotVersion::None()) {
+      FSTAssert(remoteVersion >= lastRemoteVersion,
+                @"Watch stream reverted to previous snapshot?? (%s < %s)",
+                remoteVersion.timestamp().ToString().c_str(),
+                lastRemoteVersion.timestamp().ToString().c_str());
       [self.queryCache setLastRemoteSnapshotVersion:remoteVersion];
     }
 
@@ -514,9 +515,12 @@ NS_ASSUME_NONNULL_BEGIN
   [docKeys enumerateObjectsUsingBlock:^(FSTDocumentKey *docKey, BOOL *stop) {
     FSTMaybeDocument *_Nullable remoteDoc = [self.remoteDocumentCache entryForKey:docKey];
     FSTMaybeDocument *_Nullable doc = remoteDoc;
-    FSTSnapshotVersion *ackVersion = batchResult.docVersions[docKey];
-    FSTAssert(ackVersion, @"docVersions should contain every doc in the write.");
-    if (!doc || [doc.version compare:ackVersion] == NSOrderedAscending) {
+    // TODO(zxu): Once ported to use C++ version of FSTMutationBatchResult, we should be able to
+    // check ackVersion instead, which will be an absl::optional type.
+    FSTAssert(batchResult.docVersions[docKey],
+              @"docVersions should contain every doc in the write.");
+    SnapshotVersion ackVersion = batchResult.docVersions[docKey];
+    if (!doc || SnapshotVersion{doc.version} < ackVersion) {
       doc = [batch applyTo:doc documentKey:docKey mutationBatchResult:batchResult];
       if (!doc) {
         FSTAssert(!remoteDoc, @"Mutation batch %@ applied to document %@ resulted in nil.", batch,

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -330,7 +330,7 @@ NS_ASSUME_NONNULL_BEGIN
     // HACK: The only reason we allow omitting snapshot version is so we can synthesize remote
     // events when we get permission denied errors while trying to resolve the state of a locally
     // cached document that is in limbo.
-    const SnapshotVersion lastRemoteVersion = [self.queryCache lastRemoteSnapshotVersion];
+    const SnapshotVersion& lastRemoteVersion = [self.queryCache lastRemoteSnapshotVersion];
     const SnapshotVersion remoteVersion = remoteEvent.snapshotVersion;
     if (remoteVersion != SnapshotVersion::None()) {
       FSTAssert(remoteVersion >= lastRemoteVersion,

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -21,7 +21,6 @@
 #import "FIRTimestamp.h"
 #import "Firestore/Source/Core/FSTListenSequence.h"
 #import "Firestore/Source/Core/FSTQuery.h"
-#import "Firestore/Source/Core/FSTSnapshotVersion.h"
 #import "Firestore/Source/Local/FSTGarbageCollector.h"
 #import "Firestore/Source/Local/FSTLocalDocumentsView.h"
 #import "Firestore/Source/Local/FSTLocalViewChanges.h"
@@ -43,11 +42,12 @@
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
 #include "Firestore/core/src/firebase/firestore/core/target_id_generator.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 
 using firebase::firestore::auth::User;
-using firebase::firestore::model::DocumentKey;
 using firebase::firestore::core::TargetIdGenerator;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::SnapshotVersion;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -256,7 +256,7 @@ NS_ASSUME_NONNULL_BEGIN
                        [&]() { [self.mutationQueue setLastStreamToken:streamToken]; });
 }
 
-- (FSTSnapshotVersion *)lastRemoteSnapshotVersion {
+- (const SnapshotVersion &)lastRemoteSnapshotVersion {
   return [self.queryCache lastRemoteSnapshotVersion];
 }
 
@@ -310,10 +310,10 @@ NS_ASSUME_NONNULL_BEGIN
       changedDocKeys = [changedDocKeys setByAddingObject:key];
       FSTMaybeDocument *existingDoc = [self.remoteDocumentCache entryForKey:key];
       // Make sure we don't apply an old document version to the remote cache, though we
-      // make an exception for [SnapshotVersion noVersion] which can happen for manufactured
+      // make an exception for SnapshotVersion::None() which can happen for manufactured
       // events (e.g. in the case of a limbo document resolution failing).
-      if (!existingDoc || [doc.version isEqual:[FSTSnapshotVersion noVersion]] ||
-          [doc.version compare:existingDoc.version] != NSOrderedAscending) {
+      if (!existingDoc || SnapshotVersion{doc.version} == SnapshotVersion::None() ||
+          doc.version >= existingDoc.version) {
         [self.remoteDocumentCache addEntry:doc];
       } else {
         FSTLog(
@@ -330,12 +330,13 @@ NS_ASSUME_NONNULL_BEGIN
     // HACK: The only reason we allow omitting snapshot version is so we can synthesize remote
     // events when we get permission denied errors while trying to resolve the state of a locally
     // cached document that is in limbo.
-    FSTSnapshotVersion *lastRemoteVersion = [self.queryCache lastRemoteSnapshotVersion];
-    FSTSnapshotVersion *remoteVersion = remoteEvent.snapshotVersion;
-    if (![remoteVersion isEqual:[FSTSnapshotVersion noVersion]]) {
-      FSTAssert([remoteVersion compare:lastRemoteVersion] != NSOrderedAscending,
-                @"Watch stream reverted to previous snapshot?? (%@ < %@)", remoteVersion,
-                lastRemoteVersion);
+    const SnapshotVersion lastRemoteVersion = [self.queryCache lastRemoteSnapshotVersion];
+    const SnapshotVersion remoteVersion = remoteEvent.snapshotVersion;
+    if (remoteVersion != SnapshotVersion::None()) {
+      FSTAssert(remoteVersion >= lastRemoteVersion,
+                @"Watch stream reverted to previous snapshot?? (%s < %s)",
+                remoteVersion.timestamp().ToString().c_str(),
+                lastRemoteVersion.timestamp().ToString().c_str());
       [self.queryCache setLastRemoteSnapshotVersion:remoteVersion];
     }
 
@@ -466,13 +467,12 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-- (BOOL)isRemoteUpToVersion:(FSTSnapshotVersion *)version {
+- (BOOL)isRemoteUpToVersion:(const SnapshotVersion &)version {
   // If there are no watch targets, then we won't get remote snapshots, and are always "up-to-date."
-  return [version compare:self.queryCache.lastRemoteSnapshotVersion] != NSOrderedDescending ||
-         self.targetIDs.count == 0;
+  return version <= self.queryCache.lastRemoteSnapshotVersion || self.targetIDs.count == 0;
 }
 
-- (BOOL)shouldHoldBatchResultWithVersion:(FSTSnapshotVersion *)version {
+- (BOOL)shouldHoldBatchResultWithVersion:(const SnapshotVersion &)version {
   // Check if watcher isn't up to date or prior results are already held.
   return ![self isRemoteUpToVersion:version] || self.heldBatchResults.count > 0;
 }
@@ -514,9 +514,12 @@ NS_ASSUME_NONNULL_BEGIN
   [docKeys enumerateObjectsUsingBlock:^(FSTDocumentKey *docKey, BOOL *stop) {
     FSTMaybeDocument *_Nullable remoteDoc = [self.remoteDocumentCache entryForKey:docKey];
     FSTMaybeDocument *_Nullable doc = remoteDoc;
-    FSTSnapshotVersion *ackVersion = batchResult.docVersions[docKey];
-    FSTAssert(ackVersion, @"docVersions should contain every doc in the write.");
-    if (!doc || [doc.version compare:ackVersion] == NSOrderedAscending) {
+    // TODO(zxu): Once ported to use C++ version of FSTMutationBatchResult, we should be able to
+    // check ackVersion instead.
+    FSTAssert(batchResult.docVersions[docKey],
+              @"docVersions should contain every doc in the write.");
+    SnapshotVersion ackVersion = batchResult.docVersions[docKey];
+    if (!doc || SnapshotVersion{doc.version} < ackVersion) {
       doc = [batch applyTo:doc documentKey:docKey mutationBatchResult:batchResult];
       if (!doc) {
         FSTAssert(!remoteDoc, @"Mutation batch %@ applied to document %@ resulted in nil.", batch,

--- a/Firestore/Source/Local/FSTMemoryQueryCache.mm
+++ b/Firestore/Source/Local/FSTMemoryQueryCache.mm
@@ -17,11 +17,13 @@
 #import "Firestore/Source/Local/FSTMemoryQueryCache.h"
 
 #import "Firestore/Source/Core/FSTQuery.h"
-#import "Firestore/Source/Core/FSTSnapshotVersion.h"
 #import "Firestore/Source/Local/FSTQueryData.h"
 #import "Firestore/Source/Local/FSTReferenceSet.h"
 
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
+
+using firebase::firestore::model::SnapshotVersion;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -38,18 +40,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, assign) FSTListenSequenceNumber highestListenSequenceNumber;
 
-/** The last received snapshot version. */
-@property(nonatomic, strong) FSTSnapshotVersion *lastRemoteSnapshotVersion;
-
 @end
 
-@implementation FSTMemoryQueryCache
+@implementation FSTMemoryQueryCache {
+  /** The last received snapshot version. */
+  SnapshotVersion _lastRemoteSnapshotVersion;
+}
 
 - (instancetype)init {
   if (self = [super init]) {
     _queries = [NSMutableDictionary dictionary];
     _references = [[FSTReferenceSet alloc] init];
-    _lastRemoteSnapshotVersion = [FSTSnapshotVersion noVersion];
+    _lastRemoteSnapshotVersion = SnapshotVersion::None();
   }
   return self;
 }
@@ -69,14 +71,13 @@ NS_ASSUME_NONNULL_BEGIN
   return _highestListenSequenceNumber;
 }
 
-/*- (FSTSnapshotVersion *)lastRemoteSnapshotVersion {
+- (const SnapshotVersion &)lastRemoteSnapshotVersion {
   return _lastRemoteSnapshotVersion;
 }
 
-- (void)setLastRemoteSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
-                               group:(FSTWriteGroup *)group {
+- (void)setLastRemoteSnapshotVersion:(const SnapshotVersion &)snapshotVersion {
   _lastRemoteSnapshotVersion = snapshotVersion;
-}*/
+}
 
 - (void)addQueryData:(FSTQueryData *)queryData {
   self.queries[queryData.query] = queryData;

--- a/Firestore/Source/Local/FSTMemoryQueryCache.mm
+++ b/Firestore/Source/Local/FSTMemoryQueryCache.mm
@@ -16,6 +16,8 @@
 
 #import "Firestore/Source/Local/FSTMemoryQueryCache.h"
 
+#include <utility>
+
 #import "Firestore/Source/Core/FSTQuery.h"
 #import "Firestore/Source/Local/FSTQueryData.h"
 #import "Firestore/Source/Local/FSTReferenceSet.h"
@@ -75,8 +77,8 @@ NS_ASSUME_NONNULL_BEGIN
   return _lastRemoteSnapshotVersion;
 }
 
-- (void)setLastRemoteSnapshotVersion:(const SnapshotVersion &)snapshotVersion {
-  _lastRemoteSnapshotVersion = snapshotVersion;
+- (void)setLastRemoteSnapshotVersion:(SnapshotVersion)snapshotVersion {
+  _lastRemoteSnapshotVersion = std::move(snapshotVersion);
 }
 
 - (void)addQueryData:(FSTQueryData *)queryData {

--- a/Firestore/Source/Local/FSTQueryCache.h
+++ b/Firestore/Source/Local/FSTQueryCache.h
@@ -70,8 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param snapshotVersion The new snapshot version.
  */
-- (void)setLastRemoteSnapshotVersion:
-    (const firebase::firestore::model::SnapshotVersion &)snapshotVersion;
+- (void)setLastRemoteSnapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVersion;
 
 /**
  * Adds an entry in the cache.

--- a/Firestore/Source/Local/FSTQueryCache.h
+++ b/Firestore/Source/Local/FSTQueryCache.h
@@ -20,11 +20,12 @@
 #import "Firestore/Source/Local/FSTGarbageCollector.h"
 #import "Firestore/Source/Model/FSTDocumentKeySet.h"
 
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
+
 @class FSTDocumentSet;
 @class FSTMaybeDocument;
 @class FSTQuery;
 @class FSTQueryData;
-@class FSTSnapshotVersion;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -61,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * This is updated whenever our we get a TargetChange with a read_time and empty target_ids.
  */
-- (FSTSnapshotVersion *)lastRemoteSnapshotVersion;
+- (const firebase::firestore::model::SnapshotVersion &)lastRemoteSnapshotVersion;
 
 /**
  * Set the snapshot version representing the last consistent snapshot received from the backend.
@@ -69,7 +70,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param snapshotVersion The new snapshot version.
  */
-- (void)setLastRemoteSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion;
+- (void)setLastRemoteSnapshotVersion:
+    (const firebase::firestore::model::SnapshotVersion &)snapshotVersion;
 
 /**
  * Adds an entry in the cache.

--- a/Firestore/Source/Local/FSTQueryData.h
+++ b/Firestore/Source/Local/FSTQueryData.h
@@ -18,8 +18,9 @@
 
 #import "Firestore/Source/Core/FSTTypes.h"
 
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
+
 @class FSTQuery;
-@class FSTSnapshotVersion;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -42,7 +43,7 @@ typedef NS_ENUM(NSInteger, FSTQueryPurpose) {
                      targetID:(FSTTargetID)targetID
          listenSequenceNumber:(FSTListenSequenceNumber)sequenceNumber
                       purpose:(FSTQueryPurpose)purpose
-              snapshotVersion:(FSTSnapshotVersion *)snapshotVersion
+              snapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVersion
                   resumeToken:(NSData *)resumeToken NS_DESIGNATED_INITIALIZER;
 
 /** Convenience initializer for use when creating an FSTQueryData for the first time. */
@@ -54,8 +55,12 @@ typedef NS_ENUM(NSInteger, FSTQueryPurpose) {
 - (instancetype)init NS_UNAVAILABLE;
 
 /** Creates a new query data instance with an updated snapshot version and resume token. */
-- (instancetype)queryDataByReplacingSnapshotVersion:(FSTSnapshotVersion *)snapshotVersion
+- (instancetype)queryDataByReplacingSnapshotVersion:
+                    (firebase::firestore::model::SnapshotVersion)snapshotVersion
                                         resumeToken:(NSData *)resumeToken;
+
+/** The latest snapshot version seen for this target. */
+- (const firebase::firestore::model::SnapshotVersion &)snapshotVersion;
 
 /** The query being listened to. */
 @property(nonatomic, strong, readonly) FSTQuery *query;
@@ -70,9 +75,6 @@ typedef NS_ENUM(NSInteger, FSTQueryPurpose) {
 
 /** The purpose of the query. */
 @property(nonatomic, assign, readonly) FSTQueryPurpose purpose;
-
-/** The latest snapshot version seen for this target. */
-@property(nonatomic, strong, readonly) FSTSnapshotVersion *snapshotVersion;
 
 /**
  * An opaque, server-assigned token that allows watching a query to be resumed after disconnecting

--- a/Firestore/core/src/firebase/firestore/model/snapshot_version.h
+++ b/Firestore/core/src/firebase/firestore/model/snapshot_version.h
@@ -44,7 +44,7 @@ class SnapshotVersion {
   static const SnapshotVersion& None();
 
 #if defined(__OBJC__)
-  SnapshotVersion() : timestamp_{} {
+  SnapshotVersion() {
   }
 
   SnapshotVersion(FSTSnapshotVersion* version)  // NOLINT(runtime/explicit)

--- a/Firestore/core/src/firebase/firestore/model/snapshot_version.h
+++ b/Firestore/core/src/firebase/firestore/model/snapshot_version.h
@@ -44,6 +44,9 @@ class SnapshotVersion {
   static const SnapshotVersion& None();
 
 #if defined(__OBJC__)
+  SnapshotVersion() : timestamp_{} {
+  }
+
   SnapshotVersion(FSTSnapshotVersion* version)  // NOLINT(runtime/explicit)
       : timestamp_{version.timestamp.seconds, version.timestamp.nanoseconds} {
   }


### PR DESCRIPTION
### Discussion
This is part of the C++ migration. Replace `FSTSnapshotVersion` by C++ `SnapshotVersion` in the `Local` modulo.

### Testing
Integration and unit test pass.

### API Changes
n/a