### PR TITLE
Fix new Xcode 9.3 warnings

### DIFF
--- a/Firebase/Core/FIRNetworkURLSession.m
+++ b/Firebase/Core/FIRNetworkURLSession.m
@@ -237,6 +237,7 @@
   }
 }
 
+#if TARGET_OS_IOS || TARGET_OS_TV
 - (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session {
   [_loggerDelegate firNetwork_logWithLevel:kFIRNetworkLogLevelDebug
                                messageCode:kFIRNetworkMessageCodeURLSession003
@@ -244,6 +245,7 @@
                                    context:session.configuration.identifier];
   [self callSystemCompletionHandler:session.configuration.identifier];
 }
+#endif
 
 - (void)URLSession:(NSURLSession *)session
                     task:(NSURLSessionTask *)task

--- a/Firebase/Database/FViewProcessor.m
+++ b/Firebase/Database/FViewProcessor.m
@@ -197,7 +197,8 @@
                                         serverCache:optCompleteCache
                                         accumulator:accumulator];
     } else {
-        [NSException raise:NSInternalInconsistencyException format:@"Unknown operation encountered %zd.", operation.type];
+        [NSException raise:NSInternalInconsistencyException
+                    format:@"Unknown operation encountered %ld.", (long)operation.type];
         return nil;
     }
 

--- a/Firebase/Messaging/FIRMessagingRmq2PersistentStore.m
+++ b/Firebase/Messaging/FIRMessagingRmq2PersistentStore.m
@@ -217,7 +217,8 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
       break;
 
     default:
-      errorMessage = [NSString stringWithFormat:@"Invalid directory type %zd", directory];
+      errorMessage = [NSString stringWithFormat:@"Invalid directory type %lu",
+                      (unsigned long)directory];
       FIRMessagingLoggerError(kFIRMessagingMessageCodeRmq2PersistentStoreInvalidRmqDirectory,
                               @"%@",
                               errorMessage);


### PR DESCRIPTION
Fix the following issues when running `pod lib lint` with Xcode 9.3:

```
 -> FirebaseCore (5.0.0)
    - WARN  | [OSX] xcodebuild:  FirebaseCore/Firebase/Core/FIRNetworkURLSession.m:240:1: warning: implementing unavailable method [-Wdeprecated-implementations]
    - NOTE  | [OSX] xcodebuild:  /Applications/Xcode9.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSURLSession.h:710:1: note: method 'URLSessionDidFinishEventsForBackgroundURLSession:' declared here
```

```
 -> FirebaseDatabase (5.0.0)
    - WARN  | [iOS] xcodebuild:  FirebaseDatabase/Firebase/Database/FViewProcessor.m:200:107: warning: enum values with underlying type 'NSInteger' should not be used as format arguments; add an explicit cast to 'long' instead [-Wformat]
```

```
 -> FirebaseMessaging (3.0.0)
    - WARN  | [iOS] xcodebuild:  FirebaseMessaging/Firebase/Messaging/FIRMessagingRmq2PersistentStore.m:220:80: warning: enum values with underlying type 'NSUInteger' should not be used as format arguments; add an explicit cast to 'unsigned long' instead [-Wformat]
```