### PR TITLE
Port `SnapshotVersion` for the rest Firestore modulo

### DIFF
--- a/Firestore/Example/Tests/Integration/FSTDatastoreTests.mm
+++ b/Firestore/Example/Tests/Integration/FSTDatastoreTests.mm
@@ -25,7 +25,6 @@
 #import "Firestore/Source/API/FSTUserDataConverter.h"
 #import "Firestore/Source/Core/FSTFirestoreClient.h"
 #import "Firestore/Source/Core/FSTQuery.h"
-#import "Firestore/Source/Core/FSTSnapshotVersion.h"
 #import "Firestore/Source/Local/FSTQueryData.h"
 #import "Firestore/Source/Model/FSTDocumentKey.h"
 #import "Firestore/Source/Model/FSTFieldValue.h"

--- a/Firestore/Example/Tests/Local/FSTLocalSerializerTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLocalSerializerTests.mm
@@ -162,7 +162,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testEncodesQueryData {
   FSTQuery *query = FSTTestQuery("room");
   FSTTargetID targetID = 42;
-  const SnapshotVersion version = testutil::Version(1039);
+  SnapshotVersion version = testutil::Version(1039);
   NSData *resumeToken = FSTTestResumeTokenFromSnapshotVersion(1039);
 
   FSTQueryData *queryData = [[FSTQueryData alloc] initWithQuery:query

--- a/Firestore/Example/Tests/Local/FSTLocalSerializerTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLocalSerializerTests.mm
@@ -29,7 +29,6 @@
 #import "Firestore/Protos/objc/google/firestore/v1beta1/Write.pbobjc.h"
 #import "Firestore/Protos/objc/google/type/Latlng.pbobjc.h"
 #import "Firestore/Source/Core/FSTQuery.h"
-#import "Firestore/Source/Core/FSTSnapshotVersion.h"
 #import "Firestore/Source/Local/FSTQueryData.h"
 #import "Firestore/Source/Model/FSTDocument.h"
 #import "Firestore/Source/Model/FSTDocumentKey.h"
@@ -50,6 +49,7 @@ namespace testutil = firebase::firestore::testutil;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::FieldMask;
 using firebase::firestore::model::Precondition;
+using firebase::firestore::model::SnapshotVersion;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -162,7 +162,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testEncodesQueryData {
   FSTQuery *query = FSTTestQuery("room");
   FSTTargetID targetID = 42;
-  FSTSnapshotVersion *version = FSTTestVersion(1039);
+  const SnapshotVersion version = testutil::Version(1039);
   NSData *resumeToken = FSTTestResumeTokenFromSnapshotVersion(1039);
 
   FSTQueryData *queryData = [[FSTQueryData alloc] initWithQuery:query

--- a/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
@@ -41,8 +41,11 @@
 #import "Firestore/third_party/Immutable/Tests/FSTImmutableSortedSet+Testing.h"
 
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
+#include "Firestore/core/test/firebase/firestore/testutil/testutil.h"
 
+namespace testutil = firebase::firestore::testutil;
 using firebase::firestore::auth::User;
+using firebase::firestore::model::SnapshotVersion;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -50,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 FSTDocumentVersionDictionary *FSTVersionDictionary(FSTMutation *mutation,
                                                    FSTTestSnapshotVersion version) {
   FSTDocumentVersionDictionary *result = [FSTDocumentVersionDictionary documentVersionDictionary];
-  result = [result dictionaryBySettingObject:FSTTestVersion(version) forKey:mutation.key];
+  result = [result dictionaryBySettingObject:testutil::Version(version) forKey:mutation.key];
   return result;
 }
 
@@ -140,7 +143,7 @@ FSTDocumentVersionDictionary *FSTVersionDictionary(FSTMutation *mutation,
   FSTMutationBatch *batch = [self.batches firstObject];
   [self.batches removeObjectAtIndex:0];
   XCTAssertEqual(batch.mutations.count, 1, @"Acknowledging more than one mutation not supported.");
-  FSTSnapshotVersion *version = FSTTestVersion(documentVersion);
+  const SnapshotVersion version = testutil::Version(documentVersion);
   FSTMutationResult *mutationResult =
       [[FSTMutationResult alloc] initWithVersion:version transformResults:nil];
   FSTMutationBatchResult *result = [FSTMutationBatchResult resultWithBatch:batch
@@ -818,7 +821,7 @@ FSTDocumentVersionDictionary *FSTVersionDictionary(FSTMutation *mutation,
   NSMutableDictionary<FSTBoxedTargetID *, NSNumber *> *pendingResponses =
       [NSMutableDictionary dictionary];
   FSTWatchChangeAggregator *aggregator =
-      [[FSTWatchChangeAggregator alloc] initWithSnapshotVersion:FSTTestVersion(1000)
+      [[FSTWatchChangeAggregator alloc] initWithSnapshotVersion:testutil::Version(1000)
                                                   listenTargets:listens
                                          pendingTargetResponses:pendingResponses];
   [aggregator addWatchChanges:@[ watchChange ]];

--- a/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
@@ -143,7 +143,7 @@ FSTDocumentVersionDictionary *FSTVersionDictionary(FSTMutation *mutation,
   FSTMutationBatch *batch = [self.batches firstObject];
   [self.batches removeObjectAtIndex:0];
   XCTAssertEqual(batch.mutations.count, 1, @"Acknowledging more than one mutation not supported.");
-  const SnapshotVersion version = testutil::Version(documentVersion);
+  SnapshotVersion version = testutil::Version(documentVersion);
   FSTMutationResult *mutationResult =
       [[FSTMutationResult alloc] initWithVersion:version transformResults:nil];
   FSTMutationBatchResult *result = [FSTMutationBatchResult resultWithBatch:batch

--- a/Firestore/Example/Tests/Local/FSTQueryCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTQueryCacheTests.mm
@@ -130,9 +130,9 @@ NS_ASSUME_NONNULL_BEGIN
 
     FSTQueryData *result = [self.queryCache queryDataForQuery:_queryRooms];
     XCTAssertNotEqualObjects(queryData2.resumeToken, queryData1.resumeToken);
-    XCTAssertNotEqualObjects(queryData2.snapshotVersion, queryData1.snapshotVersion);
+    XCTAssertNotEqual(queryData2.snapshotVersion, queryData1.snapshotVersion);
     XCTAssertEqualObjects(result.resumeToken, queryData2.resumeToken);
-    XCTAssertEqualObjects(result.snapshotVersion, queryData2.snapshotVersion);
+    XCTAssertEqual(result.snapshotVersion, queryData2.snapshotVersion);
   });
 }
 
@@ -390,14 +390,14 @@ NS_ASSUME_NONNULL_BEGIN
 
     // Can set the snapshot version.
     [self.queryCache setLastRemoteSnapshotVersion:testutil::Version(42)];
-    XCTAssertEqualObjects([self.queryCache lastRemoteSnapshotVersion], testutil::Version(42));
+    XCTAssertEqual([self.queryCache lastRemoteSnapshotVersion], testutil::Version(42));
   });
 
   // Snapshot version persists restarts.
   self.queryCache = [self.persistence queryCache];
   self.persistence.run("testLastRemoteSnapshotVersion restart", [&]() {
     [self.queryCache start];
-    XCTAssertEqualObjects([self.queryCache lastRemoteSnapshotVersion], testutil::Version(42));
+    XCTAssertEqual([self.queryCache lastRemoteSnapshotVersion], testutil::Version(42));
   });
 }
 

--- a/Firestore/Example/Tests/Local/FSTQueryCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTQueryCacheTests.mm
@@ -19,7 +19,6 @@
 #include <set>
 
 #import "Firestore/Source/Core/FSTQuery.h"
-#import "Firestore/Source/Core/FSTSnapshotVersion.h"
 #import "Firestore/Source/Local/FSTEagerGarbageCollector.h"
 #import "Firestore/Source/Local/FSTPersistence.h"
 #import "Firestore/Source/Local/FSTQueryData.h"
@@ -32,6 +31,7 @@
 
 namespace testutil = firebase::firestore::testutil;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::SnapshotVersion;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -386,19 +386,18 @@ NS_ASSUME_NONNULL_BEGIN
   if ([self isTestBaseClass]) return;
 
   self.persistence.run("testLastRemoteSnapshotVersion", [&]() {
-    XCTAssertEqualObjects([self.queryCache lastRemoteSnapshotVersion],
-                          [FSTSnapshotVersion noVersion]);
+    XCTAssertEqual([self.queryCache lastRemoteSnapshotVersion], SnapshotVersion::None());
 
     // Can set the snapshot version.
-    [self.queryCache setLastRemoteSnapshotVersion:FSTTestVersion(42)];
-    XCTAssertEqualObjects([self.queryCache lastRemoteSnapshotVersion], FSTTestVersion(42));
+    [self.queryCache setLastRemoteSnapshotVersion:testutil::Version(42)];
+    XCTAssertEqualObjects([self.queryCache lastRemoteSnapshotVersion], testutil::Version(42));
   });
 
   // Snapshot version persists restarts.
   self.queryCache = [self.persistence queryCache];
   self.persistence.run("testLastRemoteSnapshotVersion restart", [&]() {
     [self.queryCache start];
-    XCTAssertEqualObjects([self.queryCache lastRemoteSnapshotVersion], FSTTestVersion(42));
+    XCTAssertEqualObjects([self.queryCache lastRemoteSnapshotVersion], testutil::Version(42));
   });
 }
 
@@ -424,7 +423,7 @@ NS_ASSUME_NONNULL_BEGIN
                                     targetID:targetID
                         listenSequenceNumber:sequenceNumber
                                      purpose:FSTQueryPurposeListen
-                             snapshotVersion:FSTTestVersion(version)
+                             snapshotVersion:testutil::Version(version)
                                  resumeToken:resumeToken];
 }
 

--- a/Firestore/Example/Tests/Model/FSTDocumentTests.mm
+++ b/Firestore/Example/Tests/Model/FSTDocumentTests.mm
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
       [FSTDocument documentWithData:data key:key version:version hasLocalMutations:NO];
 
   XCTAssertEqualObjects(doc.key, FSTTestDocKey(@"messages/first"));
-  XCTAssertEqualObjects(doc.version, version);
+  XCTAssertEqual(doc.version, version);
   XCTAssertEqualObjects(doc.data, data);
   XCTAssertEqual(doc.hasLocalMutations, NO);
 }

--- a/Firestore/Example/Tests/Model/FSTDocumentTests.mm
+++ b/Firestore/Example/Tests/Model/FSTDocumentTests.mm
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testConstructor {
   DocumentKey key = testutil::Key("messages/first");
-  const SnapshotVersion version = testutil::Version(1);
+  SnapshotVersion version = testutil::Version(1);
   FSTObjectValue *data = FSTTestObjectValue(@{ @"a" : @1 });
   FSTDocument *doc =
       [FSTDocument documentWithData:data key:key version:version hasLocalMutations:NO];
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testExtractsFields {
   DocumentKey key = testutil::Key("rooms/eros");
-  const SnapshotVersion version = testutil::Version(1);
+  SnapshotVersion version = testutil::Version(1);
   FSTObjectValue *data = FSTTestObjectValue(@{
     @"desc" : @"Discuss all the project related stuff",
     @"owner" : @{@"name" : @"Jonny", @"title" : @"scallywag"}

--- a/Firestore/Example/Tests/Model/FSTDocumentTests.mm
+++ b/Firestore/Example/Tests/Model/FSTDocumentTests.mm
@@ -18,7 +18,6 @@
 
 #import <XCTest/XCTest.h>
 
-#import "Firestore/Source/Core/FSTSnapshotVersion.h"
 #import "Firestore/Source/Model/FSTFieldValue.h"
 
 #import "Firestore/Example/Tests/Util/FSTHelpers.h"
@@ -28,6 +27,7 @@
 
 namespace testutil = firebase::firestore::testutil;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::SnapshotVersion;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testConstructor {
   DocumentKey key = testutil::Key("messages/first");
-  FSTSnapshotVersion *version = FSTTestVersion(1);
+  const SnapshotVersion version = testutil::Version(1);
   FSTObjectValue *data = FSTTestObjectValue(@{ @"a" : @1 });
   FSTDocument *doc =
       [FSTDocument documentWithData:data key:key version:version hasLocalMutations:NO];
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testExtractsFields {
   DocumentKey key = testutil::Key("rooms/eros");
-  FSTSnapshotVersion *version = FSTTestVersion(1);
+  const SnapshotVersion version = testutil::Version(1);
   FSTObjectValue *data = FSTTestObjectValue(@{
     @"desc" : @"Discuss all the project related stuff",
     @"owner" : @{@"name" : @"Jonny", @"title" : @"scallywag"}

--- a/Firestore/Example/Tests/Model/FSTMutationTests.mm
+++ b/Firestore/Example/Tests/Model/FSTMutationTests.mm
@@ -135,7 +135,7 @@ using firebase::firestore::model::TransformOperation;
 
   FSTDocument *expectedDoc = [FSTDocument documentWithData:expectedData
                                                        key:FSTTestDocKey(@"collection/key")
-                                                   version:FSTTestVersion(0)
+                                                   version:testutil::Version(0)
                                          hasLocalMutations:YES];
 
   XCTAssertEqualObjects(transformedDoc, expectedDoc);
@@ -301,7 +301,7 @@ using firebase::firestore::model::TransformOperation;
 
   FSTDocument *expectedDoc = [FSTDocument documentWithData:FSTTestObjectValue(expectedData)
                                                        key:FSTTestDocKey(@"collection/key")
-                                                   version:FSTTestVersion(0)
+                                                   version:testutil::Version(0)
                                          hasLocalMutations:YES];
 
   XCTAssertEqualObjects(transformedDoc, expectedDoc);
@@ -315,7 +315,7 @@ using firebase::firestore::model::TransformOperation;
       @"collection/key", @{@"foo.bar" : [FIRFieldValue fieldValueForServerTimestamp]});
 
   FSTMutationResult *mutationResult = [[FSTMutationResult alloc]
-       initWithVersion:FSTTestVersion(1)
+       initWithVersion:testutil::Version(1)
       transformResults:@[ [FSTTimestampValue timestampValue:_timestamp] ]];
 
   FSTMaybeDocument *transformedDoc = [transform applyTo:baseDoc
@@ -340,7 +340,7 @@ using firebase::firestore::model::TransformOperation;
 
   // Server just sends null transform results for array operations.
   FSTMutationResult *mutationResult = [[FSTMutationResult alloc]
-       initWithVersion:FSTTestVersion(1)
+       initWithVersion:testutil::Version(1)
       transformResults:@[ [FSTNullValue nullValue], [FSTNullValue nullValue] ]];
 
   FSTMaybeDocument *transformedDoc = [transform applyTo:baseDoc
@@ -368,7 +368,7 @@ using firebase::firestore::model::TransformOperation;
 
   FSTMutation *set = FSTTestSetMutation(@"collection/key", @{@"foo" : @"new-bar"});
   FSTMutationResult *mutationResult =
-      [[FSTMutationResult alloc] initWithVersion:FSTTestVersion(4) transformResults:nil];
+      [[FSTMutationResult alloc] initWithVersion:testutil::Version(4) transformResults:nil];
   FSTMaybeDocument *setDoc = [set applyTo:baseDoc
                              baseDocument:baseDoc
                            localWriteTime:_timestamp
@@ -384,7 +384,7 @@ using firebase::firestore::model::TransformOperation;
 
   FSTMutation *patch = FSTTestPatchMutation("collection/key", @{@"foo" : @"new-bar"}, {});
   FSTMutationResult *mutationResult =
-      [[FSTMutationResult alloc] initWithVersion:FSTTestVersion(4) transformResults:nil];
+      [[FSTMutationResult alloc] initWithVersion:testutil::Version(4) transformResults:nil];
   FSTMaybeDocument *patchedDoc = [patch applyTo:baseDoc
                                    baseDocument:baseDoc
                                  localWriteTime:_timestamp
@@ -394,15 +394,15 @@ using firebase::firestore::model::TransformOperation;
   XCTAssertEqualObjects(patchedDoc, FSTTestDoc("collection/key", 0, expectedData, NO));
 }
 
-#define ASSERT_VERSION_TRANSITION(mutation, base, expected)                                 \
-  do {                                                                                      \
-    FSTMutationResult *mutationResult =                                                     \
-        [[FSTMutationResult alloc] initWithVersion:FSTTestVersion(0) transformResults:nil]; \
-    FSTMaybeDocument *actual = [mutation applyTo:base                                       \
-                                    baseDocument:base                                       \
-                                  localWriteTime:_timestamp                                 \
-                                  mutationResult:mutationResult];                           \
-    XCTAssertEqualObjects(actual, expected);                                                \
+#define ASSERT_VERSION_TRANSITION(mutation, base, expected)                                    \
+  do {                                                                                         \
+    FSTMutationResult *mutationResult =                                                        \
+        [[FSTMutationResult alloc] initWithVersion:testutil::Version(0) transformResults:nil]; \
+    FSTMaybeDocument *actual = [mutation applyTo:base                                          \
+                                    baseDocument:base                                          \
+                                  localWriteTime:_timestamp                                    \
+                                  mutationResult:mutationResult];                              \
+    XCTAssertEqualObjects(actual, expected);                                                   \
   } while (0);
 
 /**

--- a/Firestore/Example/Tests/Remote/FSTRemoteEventTests.mm
+++ b/Firestore/Example/Tests/Remote/FSTRemoteEventTests.mm
@@ -28,6 +28,9 @@
 #import "Firestore/Example/Tests/Remote/FSTWatchChange+Testing.h"
 #import "Firestore/Example/Tests/Util/FSTHelpers.h"
 
+#include "Firestore/core/test/firebase/firestore/testutil/testutil.h"
+
+namespace testutil = firebase::firestore::testutil;
 using firebase::firestore::model::DocumentKey;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -55,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
     listens[targetID] = dummyQueryData;
   }
   FSTWatchChangeAggregator *aggregator =
-      [[FSTWatchChangeAggregator alloc] initWithSnapshotVersion:FSTTestVersion(3)
+      [[FSTWatchChangeAggregator alloc] initWithSnapshotVersion:testutil::Version(3)
                                                   listenTargets:listens
                                          pendingTargetResponses:outstanding];
   [aggregator addWatchChanges:watchChanges];
@@ -81,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                              changes:@[ change1, change2 ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
+  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 2);
   XCTAssertEqualObjects(event.documentUpdates.at(doc1.key), doc1);
   XCTAssertEqualObjects(event.documentUpdates.at(doc2.key), doc2);
@@ -143,7 +146,7 @@ NS_ASSUME_NONNULL_BEGIN
                       outstanding:pendingResponses
                           changes:@[ change1, change2, change3, change4 ]];
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
+  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
   // doc1 is ignored because it was part of an inactive target, but doc2 is in the changes
   // because it become active.
   XCTAssertEqual(event.documentUpdates.size(), 1);
@@ -171,7 +174,7 @@ NS_ASSUME_NONNULL_BEGIN
       [self aggregatorWithTargets:@[] outstanding:pendingResponses changes:@[ change1, change2 ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
+  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
   // doc1 is ignored because it was part of an inactive target
   XCTAssertEqual(event.documentUpdates.size(), 0);
 
@@ -215,7 +218,7 @@ NS_ASSUME_NONNULL_BEGIN
                           changes:@[ change1, change2, change3, change4, change5 ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
+  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 3);
   XCTAssertEqualObjects(event.documentUpdates.at(doc1.key), doc1);
   XCTAssertEqualObjects(event.documentUpdates.at(doc2.key), doc2);
@@ -239,7 +242,7 @@ NS_ASSUME_NONNULL_BEGIN
       [self aggregatorWithTargets:@[ @1 ] outstanding:_noPendingResponses changes:@[ change ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
+  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 0);
 
   XCTAssertEqual(event.targetChanges.count, 1);
@@ -267,7 +270,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                              changes:@[ change1, change2 ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
+  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 1);
   XCTAssertEqualObjects(event.documentUpdates.at(doc1b.key), doc1b);
 
@@ -291,7 +294,7 @@ NS_ASSUME_NONNULL_BEGIN
       [self aggregatorWithTargets:@[ @1 ] outstanding:_noPendingResponses changes:@[ change ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
+  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 0);
   XCTAssertEqual(event.targetChanges.count, 1);
   FSTTargetChange *targetChange = event.targetChanges[@1];
@@ -333,7 +336,7 @@ NS_ASSUME_NONNULL_BEGIN
                           changes:@[ change1, change2, change3, change4, change5, change6 ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
+  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 2);
   XCTAssertEqualObjects(event.documentUpdates.at(doc1.key), doc1);
   XCTAssertEqualObjects(event.documentUpdates.at(doc2.key), doc2);
@@ -366,7 +369,7 @@ NS_ASSUME_NONNULL_BEGIN
       [self aggregatorWithTargets:@[ @1 ] outstanding:_noPendingResponses changes:@[ change ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
+  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 0);
   XCTAssertEqual(event.targetChanges.count, 1);
   XCTAssertEqualObjects(event.targetChanges[@1].mapping, [[FSTUpdateMapping alloc] init]);
@@ -388,7 +391,7 @@ NS_ASSUME_NONNULL_BEGIN
                           changes:@[ change1, change2, change3 ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
+  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 0);
   XCTAssertEqual(event.targetChanges.count, 0);
   XCTAssertEqual(aggregator.existenceFilters.count, 2);
@@ -420,7 +423,7 @@ NS_ASSUME_NONNULL_BEGIN
                           changes:@[ change1, change2, change3 ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
+  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 2);
   XCTAssertEqualObjects(event.documentUpdates.at(doc1.key), doc1);
   XCTAssertEqualObjects(event.documentUpdates.at(doc2.key), doc2);
@@ -430,7 +433,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTUpdateMapping *mapping1 =
       [FSTUpdateMapping mappingWithAddedDocuments:@[ doc1, doc2 ] removedDocuments:@[]];
   XCTAssertEqualObjects(event.targetChanges[@1].mapping, mapping1);
-  XCTAssertEqualObjects(event.targetChanges[@1].snapshotVersion, FSTTestVersion(3));
+  XCTAssertEqualObjects(event.targetChanges[@1].snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.targetChanges[@1].currentStatusUpdate, FSTCurrentStatusUpdateMarkCurrent);
   XCTAssertEqualObjects(event.targetChanges[@1].resumeToken, _resumeToken1);
 
@@ -439,7 +442,7 @@ NS_ASSUME_NONNULL_BEGIN
   // Mapping is reset
   XCTAssertEqualObjects(event.targetChanges[@1].mapping, [[FSTResetMapping alloc] init]);
   // Reset the resume snapshot
-  XCTAssertEqualObjects(event.targetChanges[@1].snapshotVersion, FSTTestVersion(0));
+  XCTAssertEqualObjects(event.targetChanges[@1].snapshotVersion, testutil::Version(0));
   // Target needs to be set to not current
   XCTAssertEqual(event.targetChanges[@1].currentStatusUpdate, FSTCurrentStatusUpdateMarkNotCurrent);
   XCTAssertEqual(event.targetChanges[@1].resumeToken.length, 0);
@@ -448,7 +451,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testDocumentUpdate {
   FSTDocument *doc1 = FSTTestDoc("docs/1", 1, @{ @"value" : @1 }, NO);
   FSTDeletedDocument *deletedDoc1 =
-      [FSTDeletedDocument documentWithKey:doc1.key version:FSTTestVersion(3)];
+      [FSTDeletedDocument documentWithKey:doc1.key version:testutil::Version(3)];
   FSTDocument *doc2 = FSTTestDoc("docs/2", 2, @{ @"value" : @2 }, NO);
   FSTDocument *doc3 = FSTTestDoc("docs/3", 3, @{ @"value" : @3 }, NO);
 
@@ -467,7 +470,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                              changes:@[ change1, change2 ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
+  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 2);
   XCTAssertEqualObjects(event.documentUpdates.at(doc1.key), doc1);
   XCTAssertEqualObjects(event.documentUpdates.at(doc2.key), doc2);
@@ -476,7 +479,7 @@ NS_ASSUME_NONNULL_BEGIN
   [event addDocumentUpdate:deletedDoc1];
   [event addDocumentUpdate:doc3];
 
-  XCTAssertEqualObjects(event.snapshotVersion, FSTTestVersion(3));
+  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 3);
   // doc1 is replaced
   XCTAssertEqualObjects(event.documentUpdates.at(doc1.key), deletedDoc1);
@@ -511,12 +514,12 @@ NS_ASSUME_NONNULL_BEGIN
   FSTUpdateMapping *mapping1 =
       [FSTUpdateMapping mappingWithAddedDocuments:@[] removedDocuments:@[]];
   XCTAssertEqualObjects(event.targetChanges[@1].mapping, mapping1);
-  XCTAssertEqualObjects(event.targetChanges[@1].snapshotVersion, FSTTestVersion(3));
+  XCTAssertEqualObjects(event.targetChanges[@1].snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.targetChanges[@1].currentStatusUpdate, FSTCurrentStatusUpdateMarkCurrent);
   XCTAssertEqualObjects(event.targetChanges[@1].resumeToken, _resumeToken1);
 
   XCTAssertEqualObjects(event.targetChanges[@2].mapping, mapping1);
-  XCTAssertEqualObjects(event.targetChanges[@2].snapshotVersion, FSTTestVersion(3));
+  XCTAssertEqualObjects(event.targetChanges[@2].snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.targetChanges[@2].currentStatusUpdate, FSTCurrentStatusUpdateMarkCurrent);
   XCTAssertEqualObjects(event.targetChanges[@2].resumeToken, resumeToken2);
 }
@@ -544,12 +547,12 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTResetMapping *mapping1 = [FSTResetMapping mappingWithDocuments:@[]];
   XCTAssertEqualObjects(event.targetChanges[@1].mapping, mapping1);
-  XCTAssertEqualObjects(event.targetChanges[@1].snapshotVersion, FSTTestVersion(3));
+  XCTAssertEqualObjects(event.targetChanges[@1].snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.targetChanges[@1].currentStatusUpdate, FSTCurrentStatusUpdateMarkCurrent);
   XCTAssertEqualObjects(event.targetChanges[@1].resumeToken, resumeToken2);
 
   XCTAssertEqualObjects(event.targetChanges[@2].mapping, mapping1);
-  XCTAssertEqualObjects(event.targetChanges[@2].snapshotVersion, FSTTestVersion(3));
+  XCTAssertEqualObjects(event.targetChanges[@2].snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.targetChanges[@2].currentStatusUpdate, FSTCurrentStatusUpdateNone);
   XCTAssertEqualObjects(event.targetChanges[@2].resumeToken, resumeToken3);
 }

--- a/Firestore/Example/Tests/Remote/FSTRemoteEventTests.mm
+++ b/Firestore/Example/Tests/Remote/FSTRemoteEventTests.mm
@@ -679,7 +679,7 @@ NS_ASSUME_NONNULL_BEGIN
                                listenSequenceNumber:1000
                                             purpose:FSTQueryPurposeLimboResolution];
   FSTWatchChangeAggregator *aggregator =
-      [[FSTWatchChangeAggregator alloc] initWithSnapshotVersion:FSTTestVersion(3)
+      [[FSTWatchChangeAggregator alloc] initWithSnapshotVersion:testutil::Version(3)
                                                   listenTargets:listens
                                          pendingTargetResponses:@{}];
 

--- a/Firestore/Example/Tests/Remote/FSTRemoteEventTests.mm
+++ b/Firestore/Example/Tests/Remote/FSTRemoteEventTests.mm
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                              changes:@[ change1, change2 ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
+  XCTAssertEqual(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 2);
   XCTAssertEqualObjects(event.documentUpdates.at(doc1.key), doc1);
   XCTAssertEqualObjects(event.documentUpdates.at(doc2.key), doc2);
@@ -146,7 +146,7 @@ NS_ASSUME_NONNULL_BEGIN
                       outstanding:pendingResponses
                           changes:@[ change1, change2, change3, change4 ]];
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
+  XCTAssertEqual(event.snapshotVersion, testutil::Version(3));
   // doc1 is ignored because it was part of an inactive target, but doc2 is in the changes
   // because it become active.
   XCTAssertEqual(event.documentUpdates.size(), 1);
@@ -174,7 +174,7 @@ NS_ASSUME_NONNULL_BEGIN
       [self aggregatorWithTargets:@[] outstanding:pendingResponses changes:@[ change1, change2 ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
+  XCTAssertEqual(event.snapshotVersion, testutil::Version(3));
   // doc1 is ignored because it was part of an inactive target
   XCTAssertEqual(event.documentUpdates.size(), 0);
 
@@ -218,7 +218,7 @@ NS_ASSUME_NONNULL_BEGIN
                           changes:@[ change1, change2, change3, change4, change5 ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
+  XCTAssertEqual(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 3);
   XCTAssertEqualObjects(event.documentUpdates.at(doc1.key), doc1);
   XCTAssertEqualObjects(event.documentUpdates.at(doc2.key), doc2);
@@ -242,7 +242,7 @@ NS_ASSUME_NONNULL_BEGIN
       [self aggregatorWithTargets:@[ @1 ] outstanding:_noPendingResponses changes:@[ change ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
+  XCTAssertEqual(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 0);
 
   XCTAssertEqual(event.targetChanges.count, 1);
@@ -270,7 +270,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                              changes:@[ change1, change2 ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
+  XCTAssertEqual(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 1);
   XCTAssertEqualObjects(event.documentUpdates.at(doc1b.key), doc1b);
 
@@ -294,7 +294,7 @@ NS_ASSUME_NONNULL_BEGIN
       [self aggregatorWithTargets:@[ @1 ] outstanding:_noPendingResponses changes:@[ change ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
+  XCTAssertEqual(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 0);
   XCTAssertEqual(event.targetChanges.count, 1);
   FSTTargetChange *targetChange = event.targetChanges[@1];
@@ -336,7 +336,7 @@ NS_ASSUME_NONNULL_BEGIN
                           changes:@[ change1, change2, change3, change4, change5, change6 ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
+  XCTAssertEqual(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 2);
   XCTAssertEqualObjects(event.documentUpdates.at(doc1.key), doc1);
   XCTAssertEqualObjects(event.documentUpdates.at(doc2.key), doc2);
@@ -369,7 +369,7 @@ NS_ASSUME_NONNULL_BEGIN
       [self aggregatorWithTargets:@[ @1 ] outstanding:_noPendingResponses changes:@[ change ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
+  XCTAssertEqual(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 0);
   XCTAssertEqual(event.targetChanges.count, 1);
   XCTAssertEqualObjects(event.targetChanges[@1].mapping, [[FSTUpdateMapping alloc] init]);
@@ -391,7 +391,7 @@ NS_ASSUME_NONNULL_BEGIN
                           changes:@[ change1, change2, change3 ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
+  XCTAssertEqual(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 0);
   XCTAssertEqual(event.targetChanges.count, 0);
   XCTAssertEqual(aggregator.existenceFilters.count, 2);
@@ -423,7 +423,7 @@ NS_ASSUME_NONNULL_BEGIN
                           changes:@[ change1, change2, change3 ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
+  XCTAssertEqual(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 2);
   XCTAssertEqualObjects(event.documentUpdates.at(doc1.key), doc1);
   XCTAssertEqualObjects(event.documentUpdates.at(doc2.key), doc2);
@@ -433,7 +433,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTUpdateMapping *mapping1 =
       [FSTUpdateMapping mappingWithAddedDocuments:@[ doc1, doc2 ] removedDocuments:@[]];
   XCTAssertEqualObjects(event.targetChanges[@1].mapping, mapping1);
-  XCTAssertEqualObjects(event.targetChanges[@1].snapshotVersion, testutil::Version(3));
+  XCTAssertEqual(event.targetChanges[@1].snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.targetChanges[@1].currentStatusUpdate, FSTCurrentStatusUpdateMarkCurrent);
   XCTAssertEqualObjects(event.targetChanges[@1].resumeToken, _resumeToken1);
 
@@ -442,7 +442,7 @@ NS_ASSUME_NONNULL_BEGIN
   // Mapping is reset
   XCTAssertEqualObjects(event.targetChanges[@1].mapping, [[FSTResetMapping alloc] init]);
   // Reset the resume snapshot
-  XCTAssertEqualObjects(event.targetChanges[@1].snapshotVersion, testutil::Version(0));
+  XCTAssertEqual(event.targetChanges[@1].snapshotVersion, testutil::Version(0));
   // Target needs to be set to not current
   XCTAssertEqual(event.targetChanges[@1].currentStatusUpdate, FSTCurrentStatusUpdateMarkNotCurrent);
   XCTAssertEqual(event.targetChanges[@1].resumeToken.length, 0);
@@ -470,7 +470,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                              changes:@[ change1, change2 ]];
 
   FSTRemoteEvent *event = [aggregator remoteEvent];
-  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
+  XCTAssertEqual(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 2);
   XCTAssertEqualObjects(event.documentUpdates.at(doc1.key), doc1);
   XCTAssertEqualObjects(event.documentUpdates.at(doc2.key), doc2);
@@ -479,7 +479,7 @@ NS_ASSUME_NONNULL_BEGIN
   [event addDocumentUpdate:deletedDoc1];
   [event addDocumentUpdate:doc3];
 
-  XCTAssertEqualObjects(event.snapshotVersion, testutil::Version(3));
+  XCTAssertEqual(event.snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.documentUpdates.size(), 3);
   // doc1 is replaced
   XCTAssertEqualObjects(event.documentUpdates.at(doc1.key), deletedDoc1);
@@ -514,12 +514,12 @@ NS_ASSUME_NONNULL_BEGIN
   FSTUpdateMapping *mapping1 =
       [FSTUpdateMapping mappingWithAddedDocuments:@[] removedDocuments:@[]];
   XCTAssertEqualObjects(event.targetChanges[@1].mapping, mapping1);
-  XCTAssertEqualObjects(event.targetChanges[@1].snapshotVersion, testutil::Version(3));
+  XCTAssertEqual(event.targetChanges[@1].snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.targetChanges[@1].currentStatusUpdate, FSTCurrentStatusUpdateMarkCurrent);
   XCTAssertEqualObjects(event.targetChanges[@1].resumeToken, _resumeToken1);
 
   XCTAssertEqualObjects(event.targetChanges[@2].mapping, mapping1);
-  XCTAssertEqualObjects(event.targetChanges[@2].snapshotVersion, testutil::Version(3));
+  XCTAssertEqual(event.targetChanges[@2].snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.targetChanges[@2].currentStatusUpdate, FSTCurrentStatusUpdateMarkCurrent);
   XCTAssertEqualObjects(event.targetChanges[@2].resumeToken, resumeToken2);
 }
@@ -547,12 +547,12 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTResetMapping *mapping1 = [FSTResetMapping mappingWithDocuments:@[]];
   XCTAssertEqualObjects(event.targetChanges[@1].mapping, mapping1);
-  XCTAssertEqualObjects(event.targetChanges[@1].snapshotVersion, testutil::Version(3));
+  XCTAssertEqual(event.targetChanges[@1].snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.targetChanges[@1].currentStatusUpdate, FSTCurrentStatusUpdateMarkCurrent);
   XCTAssertEqualObjects(event.targetChanges[@1].resumeToken, resumeToken2);
 
   XCTAssertEqualObjects(event.targetChanges[@2].mapping, mapping1);
-  XCTAssertEqualObjects(event.targetChanges[@2].snapshotVersion, testutil::Version(3));
+  XCTAssertEqual(event.targetChanges[@2].snapshotVersion, testutil::Version(3));
   XCTAssertEqual(event.targetChanges[@2].currentStatusUpdate, FSTCurrentStatusUpdateNone);
   XCTAssertEqualObjects(event.targetChanges[@2].resumeToken, resumeToken3);
 }

--- a/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.mm
+++ b/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.mm
@@ -37,7 +37,6 @@
 #import "Firestore/Protos/objc/google/type/Latlng.pbobjc.h"
 #import "Firestore/Source/API/FIRFieldValue+Internal.h"
 #import "Firestore/Source/Core/FSTQuery.h"
-#import "Firestore/Source/Core/FSTSnapshotVersion.h"
 #import "Firestore/Source/Local/FSTQueryData.h"
 #import "Firestore/Source/Model/FSTDocument.h"
 #import "Firestore/Source/Model/FSTDocumentKey.h"
@@ -63,6 +62,7 @@ using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::FieldMask;
 using firebase::firestore::model::FieldTransform;
 using firebase::firestore::model::Precondition;
+using firebase::firestore::model::SnapshotVersion;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -708,7 +708,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                    targetID:1
                                        listenSequenceNumber:0
                                                     purpose:FSTQueryPurposeListen
-                                            snapshotVersion:[FSTSnapshotVersion noVersion]
+                                            snapshotVersion:SnapshotVersion::None()
                                                 resumeToken:FSTTestData(1, 2, 3, -1)];
 
   GCFSTarget *expected = [GCFSTarget message];
@@ -729,7 +729,7 @@ NS_ASSUME_NONNULL_BEGIN
                                     targetID:1
                         listenSequenceNumber:0
                                      purpose:FSTQueryPurposeListen
-                             snapshotVersion:[FSTSnapshotVersion noVersion]
+                             snapshotVersion:SnapshotVersion::None()
                                  resumeToken:[NSData data]];
 }
 

--- a/Firestore/Example/Tests/SpecTests/FSTMockDatastore.h
+++ b/Firestore/Example/Tests/SpecTests/FSTMockDatastore.h
@@ -18,7 +18,7 @@
 
 #import "Firestore/Source/Remote/FSTDatastore.h"
 
-@class FSTSnapshotVersion;
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -43,11 +43,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Injects an Added WatchChange that marks the given targetIDs current. */
 - (void)writeWatchCurrentWithTargetIDs:(NSArray<FSTBoxedTargetID *> *)targetIDs
-                       snapshotVersion:(FSTSnapshotVersion *)snapshotVersion
+                       snapshotVersion:
+                           (const firebase::firestore::model::SnapshotVersion &)snapshotVersion
                            resumeToken:(NSData *)resumeToken;
 
 /** Injects a WatchChange as though it had come from the backend. */
-- (void)writeWatchChange:(FSTWatchChange *)change snapshotVersion:(FSTSnapshotVersion *)snap;
+- (void)writeWatchChange:(FSTWatchChange *)change
+         snapshotVersion:(const firebase::firestore::model::SnapshotVersion &)snap;
 
 /** Injects a stream failure as though it had come from the backend. */
 - (void)failWatchStreamWithError:(NSError *)error;
@@ -69,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (int)writesSent;
 
 /** Injects a write ack as though it had come from the backend in response to a write. */
-- (void)ackWriteWithVersion:(FSTSnapshotVersion *)commitVersion
+- (void)ackWriteWithVersion:(const firebase::firestore::model::SnapshotVersion &)commitVersion
             mutationResults:(NSArray<FSTMutationResult *> *)results;
 
 /** Injects a stream failure as though it had come from the backend. */

--- a/Firestore/Example/Tests/SpecTests/FSTMockDatastore.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTMockDatastore.mm
@@ -16,7 +16,6 @@
 
 #import "Firestore/Example/Tests/SpecTests/FSTMockDatastore.h"
 
-#import "Firestore/Source/Core/FSTSnapshotVersion.h"
 #import "Firestore/Source/Local/FSTQueryData.h"
 #import "Firestore/Source/Model/FSTMutation.h"
 #import "Firestore/Source/Remote/FSTSerializerBeta.h"
@@ -36,6 +35,7 @@ using firebase::firestore::auth::CredentialsProvider;
 using firebase::firestore::auth::EmptyCredentialsProvider;
 using firebase::firestore::core::DatabaseInfo;
 using firebase::firestore::model::DatabaseId;
+using firebase::firestore::model::SnapshotVersion;
 
 @class GRPCProtoCall;
 
@@ -120,9 +120,8 @@ NS_ASSUME_NONNULL_BEGIN
   FSTLog(@"watchQuery: %d: %@", query.targetID, query.query);
   self.datastore.watchStreamRequestCount += 1;
   // Snapshot version is ignored on the wire
-  FSTQueryData *sentQueryData =
-      [query queryDataByReplacingSnapshotVersion:[FSTSnapshotVersion noVersion]
-                                     resumeToken:query.resumeToken];
+  FSTQueryData *sentQueryData = [query queryDataByReplacingSnapshotVersion:SnapshotVersion::None()
+                                                               resumeToken:query.resumeToken];
   self.activeTargets[@(query.targetID)] = sentQueryData;
 }
 
@@ -138,7 +137,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Helper methods.
 
-- (void)writeWatchChange:(FSTWatchChange *)change snapshotVersion:(FSTSnapshotVersion *)snap {
+- (void)writeWatchChange:(FSTWatchChange *)change snapshotVersion:(const SnapshotVersion &)snap {
   if ([change isKindOfClass:[FSTWatchTargetChange class]]) {
     FSTWatchTargetChange *targetChange = (FSTWatchTargetChange *)change;
     if (targetChange.cause) {
@@ -242,7 +241,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Helper methods.
 
 /** Injects a write ack as though it had come from the backend in response to a write. */
-- (void)ackWriteWithVersion:(FSTSnapshotVersion *)commitVersion
+- (void)ackWriteWithVersion:(const SnapshotVersion &)commitVersion
             mutationResults:(NSArray<FSTMutationResult *> *)results {
   [self.delegate writeStreamDidReceiveResponseWithVersion:commitVersion mutationResults:results];
 }
@@ -326,7 +325,7 @@ NS_ASSUME_NONNULL_BEGIN
   return [self.writeStream sentMutationsCount];
 }
 
-- (void)ackWriteWithVersion:(FSTSnapshotVersion *)commitVersion
+- (void)ackWriteWithVersion:(const SnapshotVersion &)commitVersion
             mutationResults:(NSArray<FSTMutationResult *> *)results {
   [self.writeStream ackWriteWithVersion:commitVersion mutationResults:results];
 }
@@ -340,11 +339,11 @@ NS_ASSUME_NONNULL_BEGIN
       [FSTWatchTargetChange changeWithState:FSTWatchTargetChangeStateAdded
                                   targetIDs:targetIDs
                                       cause:nil];
-  [self writeWatchChange:change snapshotVersion:[FSTSnapshotVersion noVersion]];
+  [self writeWatchChange:change snapshotVersion:SnapshotVersion::None()];
 }
 
 - (void)writeWatchCurrentWithTargetIDs:(NSArray<FSTBoxedTargetID *> *)targetIDs
-                       snapshotVersion:(FSTSnapshotVersion *)snapshotVersion
+                       snapshotVersion:(const SnapshotVersion &)snapshotVersion
                            resumeToken:(NSData *)resumeToken {
   FSTWatchTargetChange *change =
       [FSTWatchTargetChange changeWithState:FSTWatchTargetChangeStateCurrent
@@ -353,7 +352,7 @@ NS_ASSUME_NONNULL_BEGIN
   [self writeWatchChange:change snapshotVersion:snapshotVersion];
 }
 
-- (void)writeWatchChange:(FSTWatchChange *)change snapshotVersion:(FSTSnapshotVersion *)snap {
+- (void)writeWatchChange:(FSTWatchChange *)change snapshotVersion:(const SnapshotVersion &)snap {
   [self.watchStream writeWatchChange:change snapshotVersion:snap];
 }
 

--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -24,7 +24,6 @@
 
 #import "Firestore/Source/Core/FSTEventManager.h"
 #import "Firestore/Source/Core/FSTQuery.h"
-#import "Firestore/Source/Core/FSTSnapshotVersion.h"
 #import "Firestore/Source/Local/FSTEagerGarbageCollector.h"
 #import "Firestore/Source/Local/FSTNoOpGarbageCollector.h"
 #import "Firestore/Source/Local/FSTPersistence.h"
@@ -46,11 +45,15 @@
 
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
+#include "Firestore/core/test/firebase/firestore/testutil/testutil.h"
 
+namespace testutil = firebase::firestore::testutil;
 namespace util = firebase::firestore::util;
 using firebase::firestore::auth::User;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -145,8 +148,8 @@ static NSString *const kNoIOSTag = @"no-ios";
   }
 }
 
-- (FSTSnapshotVersion *)parseVersion:(NSNumber *_Nullable)version {
-  return FSTTestVersion(version.longLongValue);
+- (SnapshotVersion)parseVersion:(NSNumber *_Nullable)version {
+  return testutil::Version(version.longLongValue);
 }
 
 - (FSTDocumentViewChange *)parseChange:(NSArray *)change ofType:(FSTDocumentViewChangeType)type {
@@ -254,9 +257,11 @@ static NSString *const kNoIOSTag = @"no-ios";
     NSArray *docSpec = watchEntity[@"doc"];
     FSTDocumentKey *key = FSTTestDocKey(docSpec[0]);
     FSTObjectValue *value = FSTTestObjectValue(docSpec[2]);
-    FSTSnapshotVersion *version = [self parseVersion:docSpec[1]];
-    FSTMaybeDocument *doc =
-        [FSTDocument documentWithData:value key:key version:version hasLocalMutations:NO];
+    SnapshotVersion version = [self parseVersion:docSpec[1]];
+    FSTMaybeDocument *doc = [FSTDocument documentWithData:value
+                                                      key:key
+                                                  version:std::move(version)
+                                        hasLocalMutations:NO];
     FSTWatchChange *change =
         [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:watchEntity[@"targets"]
                                                 removedTargetIDs:watchEntity[@"removedTargets"]
@@ -309,7 +314,7 @@ static NSString *const kNoIOSTag = @"no-ios";
 }
 
 - (void)doWriteAck:(NSDictionary *)spec {
-  FSTSnapshotVersion *version = [self parseVersion:spec[@"version"]];
+  const SnapshotVersion version = [self parseVersion:spec[@"version"]];
   NSNumber *expectUserCallback = spec[@"expectUserCallback"];
 
   FSTMutationResult *mutationResult =
@@ -550,7 +555,7 @@ static NSString *const kNoIOSTag = @"no-ios";
                                        targetID:targetID
                            listenSequenceNumber:0
                                         purpose:FSTQueryPurposeListen
-                                snapshotVersion:[FSTSnapshotVersion noVersion]
+                                snapshotVersion:SnapshotVersion::None()
                                     resumeToken:resumeToken];
       }];
       self.driver.expectedActiveTargets = expectedActiveTargets;

--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -314,7 +314,7 @@ static NSString *const kNoIOSTag = @"no-ios";
 }
 
 - (void)doWriteAck:(NSDictionary *)spec {
-  const SnapshotVersion version = [self parseVersion:spec[@"version"]];
+  SnapshotVersion version = [self parseVersion:spec[@"version"]];
   NSNumber *expectUserCallback = spec[@"expectUserCallback"];
 
   FSTMutationResult *mutationResult =

--- a/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.h
+++ b/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.h
@@ -26,7 +26,6 @@
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
-#include "absl/types/optional.h"
 
 @class FSTDocumentKey;
 @class FSTMutation;

--- a/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.h
+++ b/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.h
@@ -25,13 +25,14 @@
 
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
+#include "absl/types/optional.h"
 
 @class FSTDocumentKey;
 @class FSTMutation;
 @class FSTMutationResult;
 @class FSTQuery;
 @class FSTQueryData;
-@class FSTSnapshotVersion;
 @class FSTViewSnapshot;
 @class FSTWatchChange;
 @protocol FSTGarbageCollector;
@@ -150,7 +151,7 @@ typedef std::unordered_map<firebase::firestore::auth::User,
  *      simulating the server having sent a complete snapshot.
  */
 - (void)receiveWatchChange:(FSTWatchChange *)change
-           snapshotVersion:(FSTSnapshotVersion *_Nullable)snapshot;
+           snapshotVersion:(const firebase::firestore::model::SnapshotVersion &)snapshot;
 
 /**
  * Delivers a watch stream error as if the Streaming Watch backend has generated some kind of error.
@@ -195,7 +196,8 @@ typedef std::unordered_map<firebase::firestore::auth::User,
  *     the mutation. Snapshot versions must be monotonically increasing.
  * @param mutationResults The mutation results for the write that is being acked.
  */
-- (FSTOutstandingWrite *)receiveWriteAckWithVersion:(FSTSnapshotVersion *)commitVersion
+- (FSTOutstandingWrite *)receiveWriteAckWithVersion:
+                             (const firebase::firestore::model::SnapshotVersion &)commitVersion
                                     mutationResults:(NSArray<FSTMutationResult *> *)mutationResults;
 
 /**

--- a/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.mm
@@ -24,7 +24,6 @@
 
 #import "Firestore/Source/Core/FSTEventManager.h"
 #import "Firestore/Source/Core/FSTQuery.h"
-#import "Firestore/Source/Core/FSTSnapshotVersion.h"
 #import "Firestore/Source/Core/FSTSyncEngine.h"
 #import "Firestore/Source/Local/FSTLocalStore.h"
 #import "Firestore/Source/Local/FSTPersistence.h"
@@ -49,6 +48,7 @@ using firebase::firestore::auth::User;
 using firebase::firestore::core::DatabaseInfo;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -243,7 +243,7 @@ NS_ASSUME_NONNULL_BEGIN
   }];
 }
 
-- (FSTOutstandingWrite *)receiveWriteAckWithVersion:(FSTSnapshotVersion *)commitVersion
+- (FSTOutstandingWrite *)receiveWriteAckWithVersion:(const SnapshotVersion &)commitVersion
                                     mutationResults:
                                         (NSArray<FSTMutationResult *> *)mutationResults {
   FSTOutstandingWrite *write = [self currentOutstandingWrites].firstObject;
@@ -333,7 +333,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)receiveWatchChange:(FSTWatchChange *)change
-           snapshotVersion:(FSTSnapshotVersion *_Nullable)snapshot {
+           snapshotVersion:(const SnapshotVersion &)snapshot {
   [self.dispatchQueue dispatchSync:^{
     [self.datastore writeWatchChange:change snapshotVersion:snapshot];
   }];

--- a/Firestore/Example/Tests/Util/FSTHelpers.h
+++ b/Firestore/Example/Tests/Util/FSTHelpers.h
@@ -40,7 +40,6 @@
 @class FSTQuery;
 @class FSTRemoteEvent;
 @class FSTSetMutation;
-@class FSTSnapshotVersion;
 @class FSTSortOrder;
 @class FSTTargetChange;
 @class FIRTimestamp;
@@ -187,9 +186,6 @@ FSTDocumentKeySet *FSTTestDocKeySet(NSArray<FSTDocumentKey *> *keys);
 
 /** Allow tests to just use an int literal for versions. */
 typedef int64_t FSTTestSnapshotVersion;
-
-/** A convenience method for creating snapshot versions for tests. */
-FSTSnapshotVersion *FSTTestVersion(FSTTestSnapshotVersion version);
 
 /** A convenience method for creating docs for tests. */
 FSTDocument *FSTTestDoc(const absl::string_view path,

--- a/Firestore/Example/Tests/Util/FSTHelpers.mm
+++ b/Firestore/Example/Tests/Util/FSTHelpers.mm
@@ -29,7 +29,6 @@
 #import "Firestore/Source/API/FIRFieldPath+Internal.h"
 #import "Firestore/Source/API/FSTUserDataConverter.h"
 #import "Firestore/Source/Core/FSTQuery.h"
-#import "Firestore/Source/Core/FSTSnapshotVersion.h"
 #import "Firestore/Source/Core/FSTView.h"
 #import "Firestore/Source/Core/FSTViewSnapshot.h"
 #import "Firestore/Source/Local/FSTLocalViewChanges.h"
@@ -72,9 +71,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** A string sentinel that can be used with FSTTestPatchMutation() to mark a field for deletion. */
 static NSString *const kDeleteSentinel = @"<DELETE>";
-
-static const int kMicrosPerSec = 1000000;
-static const int kMillisPerSec = 1000;
 
 FIRTimestamp *FSTTestTimestamp(int year, int month, int day, int hour, int minute, int second) {
   NSDate *date = FSTTestDate(year, month, day, hour, minute, second);
@@ -158,14 +154,6 @@ FSTDocumentKeySet *FSTTestDocKeySet(NSArray<FSTDocumentKey *> *keys) {
   return result;
 }
 
-FSTSnapshotVersion *FSTTestVersion(FSTTestSnapshotVersion versionMicroseconds) {
-  int64_t seconds = versionMicroseconds / kMicrosPerSec;
-  int32_t nanos = (int32_t)(versionMicroseconds % kMicrosPerSec) * kMillisPerSec;
-
-  FIRTimestamp *timestamp = [[FIRTimestamp alloc] initWithSeconds:seconds nanoseconds:nanos];
-  return [FSTSnapshotVersion versionWithTimestamp:timestamp];
-}
-
 FSTDocument *FSTTestDoc(const absl::string_view path,
                         FSTTestSnapshotVersion version,
                         NSDictionary<NSString *, id> *data,
@@ -173,14 +161,14 @@ FSTDocument *FSTTestDoc(const absl::string_view path,
   DocumentKey key = testutil::Key(path);
   return [FSTDocument documentWithData:FSTTestObjectValue(data)
                                    key:key
-                               version:FSTTestVersion(version)
+                               version:testutil::Version(version)
                      hasLocalMutations:hasMutations];
 }
 
 FSTDeletedDocument *FSTTestDeletedDoc(const absl::string_view path,
                                       FSTTestSnapshotVersion version) {
   DocumentKey key = testutil::Key(path);
-  return [FSTDeletedDocument documentWithKey:key version:FSTTestVersion(version)];
+  return [FSTDeletedDocument documentWithKey:key version:testutil::Version(version)];
 }
 
 FSTDocumentKeyReference *FSTTestRef(const absl::string_view projectID,

--- a/Firestore/Source/API/FSTUserDataConverter.h
+++ b/Firestore/Source/API/FSTUserDataConverter.h
@@ -27,7 +27,6 @@
 @class FSTObjectValue;
 @class FSTFieldValue;
 @class FSTMutation;
-@class FSTSnapshotVersion;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/Source/Core/FSTSyncEngine.mm
+++ b/Firestore/Source/Core/FSTSyncEngine.mm
@@ -24,7 +24,6 @@
 
 #import "FIRFirestoreErrors.h"
 #import "Firestore/Source/Core/FSTQuery.h"
-#import "Firestore/Source/Core/FSTSnapshotVersion.h"
 #import "Firestore/Source/Core/FSTTransaction.h"
 #import "Firestore/Source/Core/FSTView.h"
 #import "Firestore/Source/Core/FSTViewSnapshot.h"
@@ -348,7 +347,7 @@ static const FSTListenSequenceNumber kIrrelevantSequenceNumber = -1;
     NSMutableDictionary<NSNumber *, FSTTargetChange *> *targetChanges =
         [NSMutableDictionary dictionary];
     FSTDeletedDocument *doc =
-        [FSTDeletedDocument documentWithKey:limboKey version:[FSTSnapshotVersion noVersion]];
+        [FSTDeletedDocument documentWithKey:limboKey version:SnapshotVersion::None()];
     FSTRemoteEvent *event = [[FSTRemoteEvent alloc] initWithSnapshotVersion:SnapshotVersion::None()
                                                               targetChanges:targetChanges
                                                             documentUpdates:{{limboKey, doc}}];

--- a/Firestore/Source/Local/FSTLocalSerializer.mm
+++ b/Firestore/Source/Local/FSTLocalSerializer.mm
@@ -103,8 +103,8 @@ using firebase::firestore::model::SnapshotVersion;
   FSTSerializerBeta *remoteSerializer = self.remoteSerializer;
 
   FSTObjectValue *data = [remoteSerializer decodedFields:document.fields];
-  const DocumentKey key = [remoteSerializer decodedDocumentKey:document.name];
-  const SnapshotVersion version = [remoteSerializer decodedVersion:document.updateTime];
+  DocumentKey key = [remoteSerializer decodedDocumentKey:document.name];
+  SnapshotVersion version = [remoteSerializer decodedVersion:document.updateTime];
   return [FSTDocument documentWithData:data key:key version:version hasLocalMutations:NO];
 }
 
@@ -122,8 +122,8 @@ using firebase::firestore::model::SnapshotVersion;
 - (FSTDeletedDocument *)decodedDeletedDocument:(FSTPBNoDocument *)proto {
   FSTSerializerBeta *remoteSerializer = self.remoteSerializer;
 
-  const DocumentKey key = [remoteSerializer decodedDocumentKey:proto.name];
-  const SnapshotVersion version = [remoteSerializer decodedVersion:proto.readTime];
+  DocumentKey key = [remoteSerializer decodedDocumentKey:proto.name];
+  SnapshotVersion version = [remoteSerializer decodedVersion:proto.readTime];
   return [FSTDeletedDocument documentWithKey:key version:version];
 }
 
@@ -188,7 +188,7 @@ using firebase::firestore::model::SnapshotVersion;
 
   FSTTargetID targetID = target.targetId;
   FSTListenSequenceNumber sequenceNumber = target.lastListenSequenceNumber;
-  const SnapshotVersion version = [remoteSerializer decodedVersion:target.snapshotVersion];
+  SnapshotVersion version = [remoteSerializer decodedVersion:target.snapshotVersion];
   NSData *resumeToken = target.resumeToken;
 
   FSTQuery *query;

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -318,8 +318,9 @@ NS_ASSUME_NONNULL_BEGIN
       } else {
         FSTLog(
             @"FSTLocalStore Ignoring outdated watch update for %s. "
-             "Current version: %@  Watch version: %@",
-            key.ToString().c_str(), existingDoc.version, doc.version);
+             "Current version: %s  Watch version: %s",
+            key.ToString().c_str(), existingDoc.version.timestamp().ToString().c_str(),
+            doc.version.timestamp().ToString().c_str());
       }
 
       // The document might be garbage because it was unreferenced by everything.

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -331,8 +331,7 @@ NS_ASSUME_NONNULL_BEGIN
     // events when we get permission denied errors while trying to resolve the state of a locally
     // cached document that is in limbo.
     const SnapshotVersion &lastRemoteVersion = [self.queryCache lastRemoteSnapshotVersion];
-    // TODO(zxu): convert to reference once SnapshotVersion is used in RemoteEvent.
-    const SnapshotVersion remoteVersion = remoteEvent.snapshotVersion;
+    const SnapshotVersion &remoteVersion = remoteEvent.snapshotVersion;
     if (remoteVersion != SnapshotVersion::None()) {
       FSTAssert(remoteVersion >= lastRemoteVersion,
                 @"Watch stream reverted to previous snapshot?? (%s < %s)",

--- a/Firestore/Source/Local/FSTQueryData.mm
+++ b/Firestore/Source/Local/FSTQueryData.mm
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTQueryData *other = (FSTQueryData *)object;
   return [self.query isEqual:other.query] && self.targetID == other.targetID &&
-         self.purpose == other.purpose && [self.snapshotVersion isEqual:other.snapshotVersion] &&
+         self.purpose == other.purpose && snapshotVersion == other.snapshotVersion &&
          [self.resumeToken isEqual:other.resumeToken];
 }
 

--- a/Firestore/Source/Local/FSTQueryData.mm
+++ b/Firestore/Source/Local/FSTQueryData.mm
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTQueryData *other = (FSTQueryData *)object;
   return [self.query isEqual:other.query] && self.targetID == other.targetID &&
-         self.purpose == other.purpose && snapshotVersion == other.snapshotVersion &&
+         self.purpose == other.purpose && self.snapshotVersion == other.snapshotVersion &&
          [self.resumeToken isEqual:other.resumeToken];
 }
 

--- a/Firestore/Source/Model/FSTDocument.h
+++ b/Firestore/Source/Model/FSTDocument.h
@@ -18,10 +18,10 @@
 
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/field_path.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 
 @class FSTFieldValue;
 @class FSTObjectValue;
-@class FSTSnapshotVersion;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -32,14 +32,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FSTMaybeDocument : NSObject <NSCopying>
 - (id)init __attribute__((unavailable("Abstract base class")));
 - (const firebase::firestore::model::DocumentKey &)key;
-
-@property(nonatomic, readonly) FSTSnapshotVersion *version;
+- (const firebase::firestore::model::SnapshotVersion &)version;
 @end
 
 @interface FSTDocument : FSTMaybeDocument
 + (instancetype)documentWithData:(FSTObjectValue *)data
                              key:(firebase::firestore::model::DocumentKey)key
-                         version:(FSTSnapshotVersion *)version
+                         version:(firebase::firestore::model::SnapshotVersion)version
                hasLocalMutations:(BOOL)mutations;
 
 - (nullable FSTFieldValue *)fieldForPath:(const firebase::firestore::model::FieldPath &)path;
@@ -51,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FSTDeletedDocument : FSTMaybeDocument
 + (instancetype)documentWithKey:(firebase::firestore::model::DocumentKey)key
-                        version:(FSTSnapshotVersion *)version;
+                        version:(firebase::firestore::model::SnapshotVersion)version;
 @end
 
 /** An NSComparator suitable for comparing docs using only their keys. */

--- a/Firestore/Source/Model/FSTMutation.h
+++ b/Firestore/Source/Model/FSTMutation.h
@@ -24,13 +24,15 @@
 #include "Firestore/core/src/firebase/firestore/model/field_path.h"
 #include "Firestore/core/src/firebase/firestore/model/field_transform.h"
 #include "Firestore/core/src/firebase/firestore/model/precondition.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 #include "Firestore/core/src/firebase/firestore/model/transform_operations.h"
+
+#include "absl/types/optional.h"
 
 @class FSTDocument;
 @class FSTFieldValue;
 @class FSTMaybeDocument;
 @class FSTObjectValue;
-@class FSTSnapshotVersion;
 @class FIRTimestamp;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -40,12 +42,12 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FSTMutationResult : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithVersion:(FSTSnapshotVersion *_Nullable)version
+- (instancetype)initWithVersion:(absl::optional<firebase::firestore::model::SnapshotVersion>)version
                transformResults:(NSArray<FSTFieldValue *> *_Nullable)transformResults
     NS_DESIGNATED_INITIALIZER;
 
 /** The version at which the mutation was committed or null for a delete. */
-@property(nonatomic, strong, readonly, nullable) FSTSnapshotVersion *version;
+- (const absl::optional<firebase::firestore::model::SnapshotVersion> &)version;
 
 /**
  * The resulting fields returned from the backend after a FSTTransformMutation has been committed.

--- a/Firestore/Source/Model/FSTMutationBatch.h
+++ b/Firestore/Source/Model/FSTMutationBatch.h
@@ -21,12 +21,12 @@
 #import "Firestore/Source/Model/FSTDocumentVersionDictionary.h"
 
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 
 @class FSTMutation;
 @class FIRTimestamp;
 @class FSTMutationResult;
 @class FSTMutationBatchResult;
-@class FSTSnapshotVersion;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -106,12 +106,13 @@ extern const FSTBatchID kFSTBatchIDUnknown;
  * (as docVersions).
  */
 + (instancetype)resultWithBatch:(FSTMutationBatch *)batch
-                  commitVersion:(FSTSnapshotVersion *)commitVersion
+                  commitVersion:(firebase::firestore::model::SnapshotVersion)commitVersion
                 mutationResults:(NSArray<FSTMutationResult *> *)mutationResults
                     streamToken:(nullable NSData *)streamToken;
 
+- (const firebase::firestore::model::SnapshotVersion &)commitVersion;
+
 @property(nonatomic, strong, readonly) FSTMutationBatch *batch;
-@property(nonatomic, strong, readonly) FSTSnapshotVersion *commitVersion;
 @property(nonatomic, strong, readonly) NSArray<FSTMutationResult *> *mutationResults;
 @property(nonatomic, strong, readonly, nullable) NSData *streamToken;
 @property(nonatomic, strong, readonly) FSTDocumentVersionDictionary *docVersions;

--- a/Firestore/Source/Remote/FSTRemoteStore.mm
+++ b/Firestore/Source/Remote/FSTRemoteStore.mm
@@ -317,7 +317,7 @@ static const int kMaxPendingWrites = 10;
     // using a resume token).
     [self.accumulatedChanges addObject:change];
     if (snapshotVersion == SnapshotVersion::None() ||
-        snapshotVersion < SnapshotVersion{[self.localStore lastRemoteSnapshotVersion]}) {
+        snapshotVersion < [self.localStore lastRemoteSnapshotVersion]) {
       return;
     }
 

--- a/Firestore/core/src/firebase/firestore/model/precondition.h
+++ b/Firestore/core/src/firebase/firestore/model/precondition.h
@@ -21,7 +21,6 @@
 
 #if defined(__OBJC__)
 #import "FIRTimestamp.h"
-#import "Firestore/Source/Core/FSTSnapshotVersion.h"
 #import "Firestore/Source/Model/FSTDocument.h"
 #include "Firestore/core/include/firebase/firestore/timestamp.h"
 #endif  // defined(__OBJC__)


### PR DESCRIPTION
### Discussion
This is part of the C++ migration. Replace `FSTSnapshotVersion` by C++ SnapshotVersion in the rest of all modulo except in `FSTDocumentVersionDictionary` which require `FSTImmutableSortedDictionary` equivalent.

```
git grep FSTSnapshotVersion
Firestore/Source/Core/FSTSnapshotVersion.h:@interface FSTSnapshotVersion : NSObject <NSCopying>
Firestore/Source/Core/FSTSnapshotVersion.h:- (NSComparisonResult)compare:(FSTSnapshotVersion *)other;
Firestore/Source/Core/FSTSnapshotVersion.mm:#import "Firestore/Source/Core/FSTSnapshotVersion.h"
Firestore/Source/Core/FSTSnapshotVersion.mm:@implementation FSTSnapshotVersion
Firestore/Source/Core/FSTSnapshotVersion.mm:  static FSTSnapshotVersion *min;
Firestore/Source/Core/FSTSnapshotVersion.mm:    min = [FSTSnapshotVersion versionWithTimestamp:timestamp];
Firestore/Source/Core/FSTSnapshotVersion.mm:  return [[FSTSnapshotVersion alloc] initWithTimestamp:timestamp];
Firestore/Source/Core/FSTSnapshotVersion.mm:  if (![object isKindOfClass:[FSTSnapshotVersion class]]) {
Firestore/Source/Core/FSTSnapshotVersion.mm:  return [self.timestamp isEqual:((FSTSnapshotVersion *)object).timestamp];
Firestore/Source/Core/FSTSnapshotVersion.mm:  return [NSString stringWithFormat:@"<FSTSnapshotVersion: %@>", self.timestamp];
Firestore/Source/Core/FSTSnapshotVersion.mm:- (NSComparisonResult)compare:(FSTSnapshotVersion *)other {
Firestore/Source/Model/FSTDocumentVersionDictionary.h:@class FSTSnapshotVersion;
Firestore/Source/Model/FSTDocumentVersionDictionary.h:typedef FSTImmutableSortedDictionary<FSTDocumentKey *, FSTSnapshotVersion *>
Firestore/Source/Model/FSTDocumentVersionDictionary.mm:#import "Firestore/Source/Core/FSTSnapshotVersion.h"
Firestore/core/src/firebase/firestore/model/snapshot_version.h:#import "Firestore/Source/Core/FSTSnapshotVersion.h"
Firestore/core/src/firebase/firestore/model/snapshot_version.h:  SnapshotVersion(FSTSnapshotVersion* version)  // NOLINT(runtime/explicit)
Firestore/core/src/firebase/firestore/model/snapshot_version.h:  operator FSTSnapshotVersion*() const {
Firestore/core/src/firebase/firestore/model/snapshot_version.h:      return [FSTSnapshotVersion noVersion];
Firestore/core/src/firebase/firestore/model/snapshot_version.h:      return [FSTSnapshotVersion
```

### Testing
Integration and unit test pass.

### API Changes
n/a