### PR TITLE
Add explicit Functions umbrella

### DIFF
--- a/Functions/FirebaseFunctions/Public/FirebaseFunctions.h
+++ b/Functions/FirebaseFunctions/Public/FirebaseFunctions.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRError.h"
+#import "FIRFunctions.h"
+#import "FIRHTTPSCallable.h"


### PR DESCRIPTION
Add an explicit Functions umbrella header so that Functions is included in the Firebase module.

Fixes internal issue: b/78594146