### PR TITLE
Removes deprecated getToken APIs

### DIFF
--- a/Firebase/Auth/Source/FIRUser.m
+++ b/Firebase/Auth/Source/FIRUser.m
@@ -776,13 +776,9 @@ static void callInMainThreadWithAuthDataResultAndError(
 }
 
 - (void)getIDTokenWithCompletion:(nullable FIRAuthTokenCallback)completion {
-  // |getTokenForcingRefresh:completion:| is also a public API so there is no need to dispatch to
+  // |getIDTokenForcingRefresh:completion:| is also a public API so there is no need to dispatch to
   // global work queue here.
   [self getIDTokenForcingRefresh:NO completion:completion];
-}
-
-- (void)getTokenWithCompletion:(nullable FIRAuthTokenCallback)completion {
-  [self getIDTokenWithCompletion:completion];
 }
 
 - (void)getIDTokenForcingRefresh:(BOOL)forceRefresh
@@ -896,11 +892,6 @@ static void callInMainThreadWithAuthDataResultAndError(
                                 signInProvider:tokenPayloadDictionary[@"sign_in_provider"]
                                         claims:tokenPayloadDictionary];
   return result;
-}
-
-- (void)getTokenForcingRefresh:(BOOL)forceRefresh
-                    completion:(nullable FIRAuthTokenCallback)completion {
-  [self getIDTokenForcingRefresh:forceRefresh completion:completion];
 }
 
 /** @fn internalGetTokenForcingRefresh:callback:

--- a/Firebase/Auth/Source/Public/FIRUser.h
+++ b/Firebase/Auth/Source/Public/FIRUser.h
@@ -305,17 +305,6 @@ NS_SWIFT_NAME(User)
 - (void)getIDTokenWithCompletion:(nullable FIRAuthTokenCallback)completion
     NS_SWIFT_NAME(getIDToken(completion:));
 
-/** @fn getTokenWithCompletion:
-    @brief Please use `getIDTokenWithCompletion:` instead.
-
-    @param completion Optionally; the block invoked when the token is available. Invoked
-        asynchronously on the main thread in the future.
-
-    @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods.
- */
-- (void)getTokenWithCompletion:(nullable FIRAuthTokenCallback)completion
-    NS_SWIFT_NAME(getToken(completion:)) __attribute__((deprecated));
-
 /** @fn getIDTokenForcingRefresh:completion:
     @brief Retrieves the Firebase authentication token, possibly refreshing it if it has expired.
 
@@ -331,23 +320,6 @@ NS_SWIFT_NAME(User)
  */
 - (void)getIDTokenForcingRefresh:(BOOL)forceRefresh
                       completion:(nullable FIRAuthTokenCallback)completion;
-
-/** @fn getTokenForcingRefresh:completion:
-    @brief Please use getIDTokenForcingRefresh:completion instead.
-
-    @param forceRefresh Forces a token refresh. Useful if the token becomes invalid for some reason
-        other than an expiration.
-    @param completion Optionally; the block invoked when the token is available. Invoked
-        asynchronously on the main thread in the future.
-
-    @remarks The authentication token will be refreshed (by making a network request) if it has
-        expired, or if `forceRefresh` is YES.
-
-    @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods.
- */
-- (void)getTokenForcingRefresh:(BOOL)forceRefresh
-                    completion:(nullable FIRAuthTokenCallback)completion
-                        __attribute__((deprecated));
 
 /** @fn linkWithCredential:completion:
     @brief Convenience method for `linkAndRetrieveDataWithCredential:completion:` This method


### PR DESCRIPTION
getToken:completion: and getTokenForcingRefresh:completion: have been deprecated for quite some time and will be removed in the next breaking change.