### PR TITLE
shouldEstablishDirectChannel cannot be replaced by isDirectChannelEst…

### DIFF
--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -124,9 +124,7 @@ static NSString *const kFIRMessagingPlistAutoInitEnabled =
 @end
 
 @interface FIRMessaging ()<FIRMessagingClientDelegate, FIRMessagingReceiverDelegate,
-                           FIRReachabilityDelegate> {
-  BOOL _shouldEstablishDirectChannel;
-}
+                           FIRReachabilityDelegate>
 
 // FIRApp properties
 @property(nonatomic, readwrite, copy) NSString *fcmSenderID;

--- a/Firebase/Messaging/Public/FIRMessaging.h
+++ b/Firebase/Messaging/Public/FIRMessaging.h
@@ -291,7 +291,12 @@ NS_SWIFT_NAME(Messaging)
  *  receiving non-APNS, data-only messages in foregrounded apps.
  *  Default is `NO`.
  */
-@property(nonatomic, assign, getter=isDirectChannelEstablished) BOOL shouldEstablishDirectChannel;
+@property(nonatomic) BOOL shouldEstablishDirectChannel;
+
+/**
+ *  Returns `YES` if the direct channel to the FCM server is active, and `NO` otherwise.
+ */
+@property(nonatomic, readonly) BOOL isDirectChannelEstablished;
 
 /**
  *  FIRMessaging


### PR DESCRIPTION
…ablished as it represents whether user "should" connect instead of whether user "is" connected
