### PR TITLE
Try recommended stability improvements and restoring pod lib lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,16 +31,14 @@ jobs:
       env:
         - PROJECT=Firebase PLATFORM=iOS
       before_install:
-        # Add next line back with updated DeviceUDID for xcode9.1 if stability
-        # issues with simulator:
-        # - open -a "simulator" --args -CurrentDeviceUDID ABBD7191-486B-462F-80B4-AE08C5820DA1
+        - npm install ios-sim -g
+        - ios-sim start --devicetypeid "com.apple.CoreSimulator.SimDeviceType.iPhone-7, 10.2"
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
         - ./scripts/if_changed.sh ./scripts/pod_install.sh
       script:
         - ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
-        # Disabled because of url validation failures on April 20, 2018
-        #- ./scripts/if_changed.sh bundle exec pod lib lint FirebaseCore.podspec
+        - ./scripts/if_changed.sh bundle exec pod lib lint FirebaseCore.podspec
 
         # TODO - Uncomment subsequent lines once FirebaseCore source repo is in public Specs repo
         #  - bundle exec pod lib lint FirebaseAuth.podspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
         - PROJECT=Firebase PLATFORM=iOS
       before_install:
         - npm install ios-sim -g
-        - ios-sim start --devicetypeid "com.apple.CoreSimulator.SimDeviceType.iPhone-7, 10.2"
+        - ios-sim start --devicetypeid "com.apple.CoreSimulator.SimDeviceType.iPhone-7, 11.3"
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
         - ./scripts/if_changed.sh ./scripts/pod_install.sh
       script:


### PR DESCRIPTION
From Dominic at Travis support:

Thanks for the update and sending these instances of your issue.

To hopefully prevent this from happening, could you try to pre-start the simulator as soon as possible in your build e.g. as the first line in the "before_install" of your .travis.yml file?

Here's a snippet that should do it:


before_install:
  - npm install ios-sim -g
  - ios-sim start --devicetypeid "com.apple.CoreSimulator.SimDeviceType.iPhone-7, 10.2"


Note that you'll need to replace the device type id and iOS version with the one you need in your build. This way the simulator will have more time to warm up and it will possibly make your builds more stable.