### PR TITLE
Move to file storage for log counting.

### DIFF
--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -222,13 +222,13 @@ NSString *FIRLoggerPathInCachesByAppending(NSString *pathToAppend) {
   if (directories.count == 0) {
     return nil;
   }
-  NSString *cacheDir = directories[0];
+  NSString *cacheDir = directories.firstObject;
   return [cacheDir stringByAppendingPathComponent:pathToAppend];
 }
 
 /**
- * Read an integer from the specific file, returning kFIRLoggerCountFileNotFound if the file doesn't
- * exist.
+ * Reads an integer from the specific file, returning kFIRLoggerCountFileNotFound if the file
+ * doesn't exist.
  */
 NSInteger FIRReadIntegerFromFile(NSString *filePath) {
   if (!filePath.length) {
@@ -246,7 +246,7 @@ NSInteger FIRReadIntegerFromFile(NSString *filePath) {
 }
 
 /**
- * Read an integer from the specific file, returning YES if the write was successful.
+ * Reads an integer from the specific file, returning YES if the write was successful.
  */
 BOOL FIRWriteIntegerToFile(NSInteger value, NSString *filePath) {
   if (!filePath.length) {

--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -231,7 +231,7 @@ NSString *FIRLoggerPathInCachesByAppending(NSString *pathToAppend) {
  * exist.
  */
 NSInteger FIRReadIntegerFromFile(NSString *filePath) {
-  if (filePath == nil) {
+  if (!filePath.length) {
     return kFIRLoggerCountFileNotFound;
   }
 
@@ -249,7 +249,7 @@ NSInteger FIRReadIntegerFromFile(NSString *filePath) {
  * Read an integer from the specific file, returning YES if the write was successful.
  */
 BOOL FIRWriteIntegerToFile(NSInteger value, NSString *filePath) {
-  if (filePath == nil) {
+  if (!filePath.length) {
     return NO;
   }
 
@@ -266,7 +266,7 @@ BOOL FIRWriteIntegerToFile(NSInteger value, NSString *filePath) {
 }
 
 /**
- * Return the number of errors logged since last being reset. Note: this synchronously reads a file
+ * Returns the number of errors logged since last being reset. Note: this synchronously reads a file
  * on the same queue that logging occurs.
  */
 NSInteger FIRNumberOfErrorsLogged(void) {
@@ -286,7 +286,7 @@ NSInteger FIRNumberOfErrorsLogged(void) {
 }
 
 /**
- * Return the number of warnings logged since last being reset. Note: this synchronously reads a
+ * Returns the number of warnings logged since last being reset. Note: this synchronously reads a
  * file on the same queue that logging occurs.
  */
 NSInteger FIRNumberOfWarningsLogged(void) {
@@ -306,7 +306,7 @@ NSInteger FIRNumberOfWarningsLogged(void) {
 }
 
 /**
- * Reset the number of issues logged (warnings and errors).
+ * Resets the number of issues logged (warnings and errors).
  */
 BOOL FIRResetNumberOfIssuesLogged(void) {
   NSString *errorCountPath = FIRLoggerPathInCachesByAppending(kFIRLoggerErrorCountFileName);

--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -354,22 +354,18 @@ void FIRLogBasic(FIRLoggerLevel level,
     asl_log(sFIRLoggerClient, NULL, level, "%s", logMsg.UTF8String);
 
     // Keep count of how many errors and warnings are triggered.
+    NSString *path;
     if (level == FIRLoggerLevelError) {
-      NSString *path = FIRLoggerPathInCachesByAppending(kFIRLoggerErrorCountFileName);
-      NSInteger currentValue = FIRReadIntegerFromFile(path);
-      if (currentValue == kFIRLoggerCountFileNotFound) {
-        FIRWriteIntegerToFile(1, path);
-      } else {
-        FIRWriteIntegerToFile(currentValue + 1, path);
-      }
+      path = FIRLoggerPathInCachesByAppending(kFIRLoggerErrorCountFileName);
     } else if (level == FIRLoggerLevelWarning) {
-      NSString *path = FIRLoggerPathInCachesByAppending(kFIRLoggerWarningCountFileName);
-      NSInteger currentValue = FIRReadIntegerFromFile(path);
-      if (currentValue == kFIRLoggerCountFileNotFound) {
-        FIRWriteIntegerToFile(1, path);
-      } else {
-        FIRWriteIntegerToFile(currentValue + 1, path);
-      }
+      path = FIRLoggerPathInCachesByAppending(kFIRLoggerWarningCountFileName);
+    }
+
+    NSInteger currentValue = FIRReadIntegerFromFile(path);
+    if (currentValue == kFIRLoggerCountFileNotFound) {
+      FIRWriteIntegerToFile(1, path);
+    } else {
+      FIRWriteIntegerToFile(currentValue + 1, path);
     }
   });
 }

--- a/Firebase/Core/Private/FIRLogger.h
+++ b/Firebase/Core/Private/FIRLogger.h
@@ -43,14 +43,14 @@ extern FIRLoggerService kFIRLoggerStorage;
 extern FIRLoggerService kFIRLoggerSwizzler;
 
 /**
- * The key used to store the logger's error count.
+ * The file name used to store the logger's error count. This is appended from the Caches directory.
  */
-extern NSString *const kFIRLoggerErrorCountKey;
+extern NSString *const kFIRLoggerErrorCountFileName;
 
 /**
- * The key used to store the logger's warning count.
+ * The file name used to store the logger's warning count.
  */
-extern NSString *const kFIRLoggerWarningCountKey;
+extern NSString *const kFIRLoggerWarningCountFileName;
 
 #ifdef __cplusplus
 extern "C" {
@@ -84,7 +84,7 @@ NSInteger FIRNumberOfWarningsLogged(void);
 /**
  * Reset number of errors and warnings that have been logged to 0.
  */
-void FIRResetNumberOfIssuesLogged(void);
+BOOL FIRResetNumberOfIssuesLogged(void);
 
 /**
  * Checks if the specified logger level is loggable given the current settings.


### PR DESCRIPTION
This prevents issues with writing to User Defaults on (or off) the main thread.