### PR TITLE
Port the feedback from the Java port

### DIFF
--- a/Firestore/Source/Core/FSTSyncEngine.mm
+++ b/Firestore/Source/Core/FSTSyncEngine.mm
@@ -303,8 +303,7 @@ static const FSTListenSequenceNumber kIrrelevantSequenceNumber = -1;
     if (iter == self->_limboKeysByTarget.end()) {
       FSTQueryView *qv = self.queryViewsByTarget[targetID];
       FSTAssert(qv, @"Missing queryview for non-limbo query: %i", [targetID intValue]);
-      [remoteEvent filterUpdatesFromTargetChange:targetChange
-                               existingDocuments:qv.view.syncedDocuments];
+      [targetChange.mapping filterUpdatesUsingExistingKeys:qv.view.syncedDocuments];
     } else {
       [remoteEvent synthesizeDeleteForLimboTargetChange:targetChange key:iter->second];
     }

--- a/Firestore/Source/Remote/FSTRemoteEvent.h
+++ b/Firestore/Source/Remote/FSTRemoteEvent.h
@@ -43,6 +43,14 @@ NS_ASSUME_NONNULL_BEGIN
  * base class.
  */
 @interface FSTTargetMapping : NSObject
+
+/**
+ * Strips out mapping changes that aren't actually changes. That is, if the document already
+ * existed in the target, and is being added in the target, and this is not a reset, we can
+ * skip doing the work to associate the document with the target because it has already been done.
+ */
+- (void)filterUpdatesUsingExistingKeys:(FSTDocumentKeySet *)existingKeys;
+
 @end
 
 #pragma mark - FSTResetMapping
@@ -183,14 +191,6 @@ initWithSnapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVer
 
 - (void)synthesizeDeleteForLimboTargetChange:(FSTTargetChange *)targetChange
                                          key:(const firebase::firestore::model::DocumentKey &)key;
-
-/**
- * Strips out mapping changes that aren't actually changes. That is, if the document already
- * existed in the target, and is being added in the target, and this is not a reset, we can
- * skip doing the work to associate the document with the target because it has already been done.
- */
-- (void)filterUpdatesFromTargetChange:(FSTTargetChange *)targetChange
-                    existingDocuments:(FSTDocumentKeySet *)existingDocuments;
 
 @end
 

--- a/Firestore/Source/Remote/FSTRemoteEvent.mm
+++ b/Firestore/Source/Remote/FSTRemoteEvent.mm
@@ -319,7 +319,7 @@ initWithSnapshotVersion:(SnapshotVersion)snapshotVersion
     // However, if the document doesn't exist and the current marker arrives, the document is
     // not present in the snapshot and our normal view handling would consider the document to
     // remain in limbo indefinitely because there are no updates to the document. To avoid this,
-    // we specially handle this just this case here: synthesizing a delete.
+    // we specially handle this case here: synthesizing a delete.
     //
     // TODO(dimond): Ideally we would have an explicit lookup query instead resulting in an
     // explicit delete message and we could remove this special logic.


### PR DESCRIPTION
Moves filtering of updates onto the `FSTTargetMapping` subclasses. 
Splits the tests of synthesized deletes and update filtering into a few different tests for each of the specific cases.