### PR TITLE
Remove deprecated verify phone number

### DIFF
--- a/Example/Auth/Sample/MainViewController.m
+++ b/Example/Auth/Sample/MainViewController.m
@@ -574,14 +574,9 @@ NSString *const kCreateUserAccessibilityID = @"CreateUserAccessibilityID";
 static NSString *const kPhoneAuthSectionTitle = @"Phone Auth";
 
 /** @var kPhoneNumberSignInTitle
-    @brief The title for button to sign in with phone number.
- */
-static NSString *const kPhoneNumberSignInTitle = @"Sign in With Phone Number";
-
-/** @var kPhoneNumberSignInTitle
     @brief The title for button to sign in with phone number using reCAPTCHA.
  */
-static NSString *const kPhoneNumberSignInReCaptchaTitle = @"Sign in With Phone Number (reCAPTCHA)";
+static NSString *const kPhoneNumberSignInReCaptchaTitle = @"Sign in With Phone Number";
 
 /** @var kIsNewUserToggleTitle
     @brief The title for button to enable new or existing user toggle.
@@ -738,8 +733,6 @@ typedef enum {
       [StaticContentTableViewSection sectionWithTitle:kPhoneAuthSectionTitle cells:@[
         [StaticContentTableViewCell cellWithTitle:kPhoneNumberSignInReCaptchaTitle
                                            action:^{ [weakSelf signInWithPhoneNumberWithPrompt]; }],
-        [StaticContentTableViewCell cellWithTitle:kPhoneNumberSignInTitle
-                                           action:^{ [weakSelf signInWithPhoneNumber]; }],
         [StaticContentTableViewCell cellWithTitle:kUpdatePhoneNumber
                                            action:^{ [weakSelf updatePhoneNumberWithPrompt]; }],
         [StaticContentTableViewCell cellWithTitle:kLinkPhoneNumber
@@ -2850,37 +2843,6 @@ static NSDictionary<NSString *, NSString *> *parseURL(NSString *urlString) {
           }
           [self hideSpinner:^{
             [self showTypicalUIForUserUpdateResultsWithTitle:kCreateUserTitle error:error];
-          }];
-        }];
-      }];
-    }];
-  }];
-}
-
-/** @fn signInWithPhoneNumber
-    @brief Allows sign in with phone number.
- */
-- (void)signInWithPhoneNumber {
-  [self commonPhoneNumberInputWithTitle:@"Phone #" Completion:^(NSString *_Nullable phone) {
-    [self showSpinner:^{
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      [[AppManager phoneAuthProvider] verifyPhoneNumber:phone
-                                             completion:^(NSString *_Nullable verificationID,
-                                                          NSError *_Nullable error) {
-#pragma clang diagnostic pop
-        [self hideSpinner:^{
-          if (error) {
-            [self logFailure:@"failed to send verification code" error:error];
-            [self showMessagePrompt:error.localizedDescription];
-            return;
-          }
-          [self logSuccess:@"Code sent"];
-
-          [self commonPhoneNumberInputWithTitle:@"Code"
-                                     Completion:^(NSString *_Nullable verificationCode) {
-            [self commontPhoneVerificationWithVerificationID:verificationID
-                                            verificationCode:verificationCode];
           }];
         }];
       }];

--- a/Example/Auth/Tests/FIRPhoneAuthProviderTests.m
+++ b/Example/Auth/Tests/FIRPhoneAuthProviderTests.m
@@ -283,9 +283,16 @@ static const NSTimeInterval kExpectationTimeout = 2;
         number was provided.
  */
 - (void)testVerifyEmptyPhoneNumber {
+  id mockBundle = OCMClassMock([NSBundle class]);
+  OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
+  OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"])
+  .andReturn(@[ @{ @"CFBundleURLSchemes" : @[ kFakeReverseClientID ] } ]);
+  OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
   // Empty phone number is checked on the client side so no backend RPC is mocked.
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [_provider verifyPhoneNumber:@""
+                    UIDelegate:nil
                     completion:^(NSString *_Nullable verificationID, NSError *_Nullable error) {
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, FIRAuthErrorCodeMissingPhoneNumber);
@@ -299,6 +306,12 @@ static const NSTimeInterval kExpectationTimeout = 2;
         number was provided.
  */
 - (void)testVerifyInvalidPhoneNumber {
+  id mockBundle = OCMClassMock([NSBundle class]);
+  OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
+  OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"])
+  .andReturn(@[ @{ @"CFBundleURLSchemes" : @[ kFakeReverseClientID ] } ]);
+  OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
       .andCallBlock1(^(FIRAuthNotificationForwardingCallback callback) { callback(YES); });
   OCMStub([_mockAppCredentialManager credential])
@@ -316,6 +329,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [_provider verifyPhoneNumber:kTestPhoneNumber
+                    UIDelegate:nil
                     completion:^(NSString *_Nullable verificationID, NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
     XCTAssertNil(verificationID);
@@ -332,6 +346,12 @@ static const NSTimeInterval kExpectationTimeout = 2;
     @brief Tests a successful invocation of @c verifyPhoneNumber:completion:.
  */
 - (void)testVerifyPhoneNumber {
+  id mockBundle = OCMClassMock([NSBundle class]);
+  OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
+  OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"])
+  .andReturn(@[ @{ @"CFBundleURLSchemes" : @[ kFakeReverseClientID ] } ]);
+  OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
       .andCallBlock1(^(FIRAuthNotificationForwardingCallback callback) { callback(YES); });
   OCMStub([_mockAppCredentialManager credential])
@@ -351,6 +371,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [_provider verifyPhoneNumber:kTestPhoneNumber
+                    UIDelegate:nil
                     completion:^(NSString *_Nullable verificationID, NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
     XCTAssertNil(error);
@@ -368,6 +389,12 @@ static const NSTimeInterval kExpectationTimeout = 2;
         is disabled.
  */
 - (void)testVerifyPhoneNumberInTestMode {
+  id mockBundle = OCMClassMock([NSBundle class]);
+  OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
+  OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"])
+  .andReturn(@[ @{ @"CFBundleURLSchemes" : @[ kFakeReverseClientID ] } ]);
+  OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
   // Disable app verification.
   FIRAuthSettings *settings = [[FIRAuthSettings alloc] init];
   settings.appVerificationDisabledForTesting = YES;
@@ -389,6 +416,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [_provider verifyPhoneNumber:kTestPhoneNumber
+                    UIDelegate:nil
                     completion:^(NSString *_Nullable verificationID, NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
     XCTAssertNil(error);
@@ -406,6 +434,12 @@ static const NSTimeInterval kExpectationTimeout = 2;
         is disabled.
  */
 - (void)testVerifyPhoneNumberInTestModeFailure {
+  id mockBundle = OCMClassMock([NSBundle class]);
+  OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
+  OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"])
+  .andReturn(@[ @{ @"CFBundleURLSchemes" : @[ kFakeReverseClientID ] } ]);
+  OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
   // Disable app verification.
   FIRAuthSettings *settings = [[FIRAuthSettings alloc] init];
   settings.appVerificationDisabledForTesting = YES;
@@ -425,6 +459,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [_provider verifyPhoneNumber:kTestPhoneNumber
+                    UIDelegate:nil
                     completion:^(NSString *_Nullable verificationID, NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
     XCTAssertNil(verificationID);
@@ -901,10 +936,17 @@ static const NSTimeInterval kExpectationTimeout = 2;
     @brief Tests returning an error for the app failing to forward notification.
  */
 - (void)testNotForwardingNotification {
+  id mockBundle = OCMClassMock([NSBundle class]);
+  OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
+  OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"])
+  .andReturn(@[ @{ @"CFBundleURLSchemes" : @[ kFakeReverseClientID ] } ]);
+  OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
       .andCallBlock1(^(FIRAuthNotificationForwardingCallback callback) { callback(NO); });
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [_provider verifyPhoneNumber:kTestPhoneNumber
+                    UIDelegate:nil
                     completion:^(NSString *_Nullable verificationID, NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
     XCTAssertNil(verificationID);
@@ -919,19 +961,48 @@ static const NSTimeInterval kExpectationTimeout = 2;
     @brief Tests returning an error for the app failing to provide an APNS device token.
  */
 - (void)testMissingAPNSToken {
+  id mockBundle = OCMClassMock([NSBundle class]);
+  OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
+  OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"])
+      .andReturn(@[ @{ @"CFBundleURLSchemes" : @[ kFakeReverseClientID ] } ]);
+  OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  // Simulate missing app token error.
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
       .andCallBlock1(^(FIRAuthNotificationForwardingCallback callback) { callback(YES); });
   OCMExpect([_mockAppCredentialManager credential]).andReturn(nil);
   OCMExpect([_mockAPNSTokenManager getTokenWithCallback:OCMOCK_ANY])
-      .andCallBlock1(^(FIRAuthAPNSTokenCallback callback) { callback(nil, nil); });
-  // Expect verify client request to the backend wth empty token.
-  OCMExpect([_mockBackend verifyClient:[OCMArg any] callback:[OCMArg any]])
-      .andCallBlock2(^(FIRVerifyClientRequest *request,
-                       FIRVerifyClientResponseCallback callback) {
-    XCTAssertNil(request.appToken);
+      .andCallBlock1(^(FIRAuthAPNSTokenCallback callback) {
+    NSError *error = [NSError errorWithDomain:FIRAuthErrorDomain
+                                         code:FIRAuthErrorCodeMissingAppToken
+                                     userInfo:nil];
+    callback(nil, error);
+  });
+  OCMExpect([_mockBackend getProjectConfig:[OCMArg any] callback:[OCMArg any]])
+      .andCallBlock2(^(FIRGetProjectConfigRequest *request,
+                       FIRGetProjectConfigResponseCallback callback) {
+    XCTAssertNotNil(request);
     dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
-      // The backend is supposed to return an error.
-      callback(nil, [NSError errorWithDomain:FIRAuthErrorDomain
+      id mockGetProjectConfigResponse = OCMClassMock([FIRGetProjectConfigResponse class]);
+      OCMStub([mockGetProjectConfigResponse authorizedDomains]).
+          andReturn(@[ kFakeAuthorizedDomain]);
+      callback(mockGetProjectConfigResponse, nil);
+    });
+  });
+  id mockUIDelegate = OCMProtocolMock(@protocol(FIRAuthUIDelegate));
+
+  // Expect view controller presentation by UIDelegate.
+  OCMExpect([_mockURLPresenter presentURL:OCMOCK_ANY
+                               UIDelegate:mockUIDelegate
+                          callbackMatcher:OCMOCK_ANY
+                               completion:OCMOCK_ANY]).andDo(^(NSInvocation *invocation) {
+    __unsafe_unretained id unretainedArgument;
+    // Indices 0 and 1 indicate the hidden arguments self and _cmd.
+    // `completion` is at index 5
+    [invocation getArgument:&unretainedArgument atIndex:5];
+    FIRAuthURLPresentationCompletion completion = unretainedArgument;
+    dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+      completion(nil, [NSError errorWithDomain:FIRAuthErrorDomain
                                         code:FIRAuthErrorCodeMissingAppToken
                                     userInfo:nil]);
     });
@@ -939,23 +1010,28 @@ static const NSTimeInterval kExpectationTimeout = 2;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [_provider verifyPhoneNumber:kTestPhoneNumber
+                    UIDelegate:mockUIDelegate
                     completion:^(NSString *_Nullable verificationID, NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
-    XCTAssertNil(verificationID);
-    XCTAssertEqualObjects(error.domain, FIRAuthErrorDomain);
     XCTAssertEqual(error.code, FIRAuthErrorCodeMissingAppToken);
+    XCTAssertNil(verificationID);
     [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+  OCMVerifyAll(_mockBackend);
   OCMVerifyAll(_mockNotificationManager);
-  OCMVerifyAll(_mockAppCredentialManager);
-  OCMVerifyAll(_mockAPNSTokenManager);
 }
 
 /** @fn testVerifyClient
     @brief Tests verifying client before sending verification code.
  */
 - (void)testVerifyClient {
+  id mockBundle = OCMClassMock([NSBundle class]);
+  OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
+  OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"])
+  .andReturn(@[ @{ @"CFBundleURLSchemes" : @[ kFakeReverseClientID ] } ]);
+  OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
       .andCallBlock1(^(FIRAuthNotificationForwardingCallback callback) { callback(YES); });
   OCMExpect([_mockAppCredentialManager credential]).andReturn(nil);
@@ -1007,6 +1083,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [_provider verifyPhoneNumber:kTestPhoneNumber
+                    UIDelegate:nil
                     completion:^(NSString *_Nullable verificationID, NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
     XCTAssertNil(error);
@@ -1024,6 +1101,12 @@ static const NSTimeInterval kExpectationTimeout = 2;
     @brief Tests failed retry after failing to send verification code.
  */
 - (void)testSendVerificationCodeFailedRetry {
+  id mockBundle = OCMClassMock([NSBundle class]);
+  OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
+  OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"])
+  .andReturn(@[ @{ @"CFBundleURLSchemes" : @[ kFakeReverseClientID ] } ]);
+  OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
       .andCallBlock1(^(FIRAuthNotificationForwardingCallback callback) { callback(YES); });
 
@@ -1097,6 +1180,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [_provider verifyPhoneNumber:kTestPhoneNumber
+                    UIDelegate:nil
                     completion:^(NSString *_Nullable verificationID, NSError *_Nullable error) {
     XCTAssertTrue([NSThread isMainThread]);
     XCTAssertNil(verificationID);
@@ -1114,6 +1198,12 @@ static const NSTimeInterval kExpectationTimeout = 2;
     @brief Tests successful retry after failing to send verification code.
  */
 - (void)testSendVerificationCodeSuccessFulRetry {
+  id mockBundle = OCMClassMock([NSBundle class]);
+  OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
+  OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"])
+  .andReturn(@[ @{ @"CFBundleURLSchemes" : @[ kFakeReverseClientID ] } ]);
+  OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
       .andCallBlock1(^(FIRAuthNotificationForwardingCallback callback) { callback(YES); });
 
@@ -1189,6 +1279,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
   [_provider verifyPhoneNumber:kTestPhoneNumber
+                    UIDelegate:nil
                     completion:^(NSString *_Nullable verificationID, NSError *_Nullable error) {
     XCTAssertNil(error);
     XCTAssertEqualObjects(verificationID, kTestVerificationID);

--- a/Firebase/Auth/Source/AuthProviders/Phone/FIRPhoneAuthProvider.m
+++ b/Firebase/Auth/Source/AuthProviders/Phone/FIRPhoneAuthProvider.m
@@ -109,20 +109,6 @@ NSString *const kReCAPTCHAURLStringFormat = @"https://%@/__/auth/handler?";
 }
 
 - (void)verifyPhoneNumber:(NSString *)phoneNumber
-               completion:(nullable FIRVerificationResultCallback)completion {
-  dispatch_async(FIRAuthGlobalWorkQueue(), ^{
-    [self internalVerifyPhoneNumber:phoneNumber completion:^(NSString *_Nullable verificationID,
-                                                             NSError *_Nullable error) {
-      if (completion) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-          completion(verificationID, error);
-        });
-      }
-    }];
-  });
-}
-
-- (void)verifyPhoneNumber:(NSString *)phoneNumber
                UIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
                completion:(nullable FIRVerificationResultCallback)completion {
   if (![self isCallbackSchemeRegistered]) {

--- a/Firebase/Auth/Source/Public/FIRPhoneAuthProvider.h
+++ b/Firebase/Auth/Source/Public/FIRPhoneAuthProvider.h
@@ -61,32 +61,6 @@ NS_SWIFT_NAME(PhoneAuthProvider)
  */
 + (instancetype)providerWithAuth:(FIRAuth *)auth NS_SWIFT_NAME(provider(auth:));
 
-/** @fn verifyPhoneNumber:completion:
-    @brief Please use `verifyPhoneNumber:UIDelegate:completion:` instead.
-
-    @param phoneNumber The phone number to be verified.
-    @param completion The callback to be invoked when the verification flow is finished.
-
-    @remarks Possible error codes:
-
-        + `FIRAuthErrorCodeAppNotVerified` - Indicates that Firebase could not retrieve the
-            silent push notification and therefore could not verify your app.
-        + `FIRAuthErrorCodeInvalidAppCredential` - Indicates that The APNs device token provided
-            is either incorrect or does not match the private certificate uploaded to the Firebase
-            Console.
-        + `FIRAuthErrorCodeQuotaExceeded` - Indicates that the phone verification quota for this
-            project has been exceeded.
-        + `FIRAuthErrorCodeInvalidPhoneNumber` - Indicates that the phone number provided is
-            invalid.
-        + `FIRAuthErrorCodeMissingPhoneNumber` - Indicates that a phone number was not provided.
-        + `FIRAuthErrorCodeMissingAppToken` - Indicates that the APNs device token could not be
-            obtained. The app may not have set up remote notification correctly, or may fail to
-            forward the APNs device token to FIRAuth if app delegate swizzling is disabled.
- */
-- (void)verifyPhoneNumber:(NSString *)phoneNumber
-               completion:(nullable FIRVerificationResultCallback)completion
-    __attribute__((deprecated));
-
 /** @fn verifyPhoneNumber:UIDelegate:completion:
     @brief Starts the phone number authentication flow by sending a verifcation code to the
         specified phone number.


### PR DESCRIPTION
Removes the deprecated verifyPhoneNumber:completion: API in favor of verifyPhoneNumber:UIDelegate:completion:
