### PR TITLE
b/78539022: Fix test at risk of range violation errors depending on time-of-day.

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRCursorTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRCursorTests.mm
@@ -216,32 +216,29 @@ FIRTimestamp *TimestampWithMicros(int64_t seconds, int32_t micros) {
 }
 
 - (void)testTimestampsCanBePassedToQueriesInWhereClause {
-  FIRTimestamp *currentTimestamp = [FIRTimestamp timestamp];
-  int64_t seconds = currentTimestamp.seconds;
-  int32_t micros = currentTimestamp.nanoseconds / 1000;
   FIRCollectionReference *testCollection = [self collectionRefWithDocuments:@{
     @"a" : @{
-      @"timestamp" : TimestampWithMicros(seconds, micros + 2),
+      @"timestamp" : TimestampWithMicros(100, 7),
     },
     @"b" : @{
-      @"timestamp" : TimestampWithMicros(seconds, micros - 1),
+      @"timestamp" : TimestampWithMicros(100, 4),
     },
     @"c" : @{
-      @"timestamp" : TimestampWithMicros(seconds, micros + 3),
+      @"timestamp" : TimestampWithMicros(100, 8),
     },
     @"d" : @{
-      @"timestamp" : TimestampWithMicros(seconds, micros),
+      @"timestamp" : TimestampWithMicros(100, 5),
     },
     @"e" : @{
-      @"timestamp" : TimestampWithMicros(seconds, micros + 1),
+      @"timestamp" : TimestampWithMicros(100, 6),
     }
   }];
 
-  FIRQuerySnapshot *querySnapshot = [self
-      readDocumentSetForRef:[[testCollection queryWhereField:@"timestamp"
-                                      isGreaterThanOrEqualTo:TimestampWithMicros(seconds, micros)]
-                                queryWhereField:@"timestamp"
-                                     isLessThan:TimestampWithMicros(seconds, micros + 3)]];
+  FIRQuerySnapshot *querySnapshot =
+      [self readDocumentSetForRef:[[testCollection queryWhereField:@"timestamp"
+                                            isGreaterThanOrEqualTo:TimestampWithMicros(100, 5)]
+                                      queryWhereField:@"timestamp"
+                                           isLessThan:TimestampWithMicros(100, 8)]];
   XCTAssertEqualObjects(FIRQuerySnapshotGetIDs(querySnapshot), (@[ @"d", @"e", @"a" ]));
 }
 


### PR DESCRIPTION
"micros" could underflow or overflow if the test was run at the wrong time... So I Reworked the test with hardcoded timestamps (based on if micros was "5") as I don't think making it time-dependent gains us interesting additional coverage.