### PR TITLE
Bump sequence numbers when receiving a new resume token

### DIFF
--- a/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
@@ -808,6 +808,7 @@ FSTDocumentVersionDictionary *FSTVersionDictionary(FSTMutation *mutation,
 
   FSTQuery *query = FSTTestQuery("foo/bar");
   FSTQueryData *queryData = [self.localStore allocateQuery:query];
+  FSTListenSequenceNumber initialSequenceNumber = queryData.sequenceNumber;
   FSTBoxedTargetID *targetID = @(queryData.targetID);
   NSData *resumeToken = FSTTestResumeTokenFromSnapshotVersion(1000);
 
@@ -834,6 +835,10 @@ FSTDocumentVersionDictionary *FSTVersionDictionary(FSTMutation *mutation,
   // Should come back with the same resume token
   FSTQueryData *queryData2 = [self.localStore allocateQuery:query];
   XCTAssertEqualObjects(queryData2.resumeToken, resumeToken);
+
+  // The sequence number should have been bumped when we saved the new resume token.
+  FSTListenSequenceNumber newSequenceNumber = queryData2.sequenceNumber;
+  XCTAssertGreaterThan(newSequenceNumber, initialSequenceNumber);
 }
 
 - (void)testRemoteDocumentKeysForTarget {

--- a/Firestore/Example/Tests/SpecTests/FSTMockDatastore.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTMockDatastore.mm
@@ -121,7 +121,8 @@ NS_ASSUME_NONNULL_BEGIN
   self.datastore.watchStreamRequestCount += 1;
   // Snapshot version is ignored on the wire
   FSTQueryData *sentQueryData = [query queryDataByReplacingSnapshotVersion:SnapshotVersion::None()
-                                                               resumeToken:query.resumeToken];
+                                                               resumeToken:query.resumeToken
+                                                            sequenceNumber:query.sequenceNumber];
   self.activeTargets[@(query.targetID)] = sentQueryData;
 }
 

--- a/Firestore/Source/Local/FSTQueryData.h
+++ b/Firestore/Source/Local/FSTQueryData.h
@@ -54,7 +54,8 @@ typedef NS_ENUM(NSInteger, FSTQueryPurpose) {
 
 - (instancetype)init NS_UNAVAILABLE;
 
-/** Creates a new query data instance with an updated snapshot version, resume token, and sequence number. */
+/** Creates a new query data instance with an updated snapshot version, resume token, and sequence
+ * number. */
 - (instancetype)queryDataByReplacingSnapshotVersion:
                     (firebase::firestore::model::SnapshotVersion)snapshotVersion
                                         resumeToken:(NSData *)resumeToken

--- a/Firestore/Source/Local/FSTQueryData.h
+++ b/Firestore/Source/Local/FSTQueryData.h
@@ -54,8 +54,10 @@ typedef NS_ENUM(NSInteger, FSTQueryPurpose) {
 
 - (instancetype)init NS_UNAVAILABLE;
 
-/** Creates a new query data instance with an updated snapshot version, resume token, and sequence
- * number. */
+/**
+ * Creates a new query data instance with an updated snapshot version, resume token, and sequence
+ * number.
+ */
 - (instancetype)queryDataByReplacingSnapshotVersion:
                     (firebase::firestore::model::SnapshotVersion)snapshotVersion
                                         resumeToken:(NSData *)resumeToken

--- a/Firestore/Source/Local/FSTQueryData.h
+++ b/Firestore/Source/Local/FSTQueryData.h
@@ -54,10 +54,11 @@ typedef NS_ENUM(NSInteger, FSTQueryPurpose) {
 
 - (instancetype)init NS_UNAVAILABLE;
 
-/** Creates a new query data instance with an updated snapshot version and resume token. */
+/** Creates a new query data instance with an updated snapshot version, resume token, and sequence number. */
 - (instancetype)queryDataByReplacingSnapshotVersion:
                     (firebase::firestore::model::SnapshotVersion)snapshotVersion
-                                        resumeToken:(NSData *)resumeToken;
+                                        resumeToken:(NSData *)resumeToken
+                                     sequenceNumber:(FSTListenSequenceNumber)sequenceNumber;
 
 /** The latest snapshot version seen for this target. */
 - (const firebase::firestore::model::SnapshotVersion &)snapshotVersion;

--- a/Firestore/Source/Local/FSTQueryData.mm
+++ b/Firestore/Source/Local/FSTQueryData.mm
@@ -95,10 +95,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)queryDataByReplacingSnapshotVersion:(SnapshotVersion)snapshotVersion
-                                        resumeToken:(NSData *)resumeToken {
+                                        resumeToken:(NSData *)resumeToken
+                                     sequenceNumber:(FSTListenSequenceNumber)sequenceNumber {
   return [[FSTQueryData alloc] initWithQuery:self.query
                                     targetID:self.targetID
-                        listenSequenceNumber:self.sequenceNumber
+                        listenSequenceNumber:sequenceNumber
                                      purpose:self.purpose
                              snapshotVersion:std::move(snapshotVersion)
                                  resumeToken:resumeToken];

--- a/Firestore/Source/Remote/FSTRemoteStore.mm
+++ b/Firestore/Source/Remote/FSTRemoteStore.mm
@@ -448,7 +448,8 @@ static const int kMaxPendingWrites = 10;
       if (queryData) {
         self->_listenTargets[target] =
             [queryData queryDataByReplacingSnapshotVersion:change.snapshotVersion
-                                               resumeToken:resumeToken];
+                                               resumeToken:resumeToken
+                                            sequenceNumber:queryData.sequenceNumber];
       }
     }
   }];


### PR DESCRIPTION
This PR is a part of the LRU garbage collection work. Ensure that we write a new sequence number when we get a new resume token for a target.