### PR TITLE
Fix warning on FSTTargetMapping mentioned in #1210

### DIFF
--- a/Firestore/Source/Remote/FSTRemoteEvent.mm
+++ b/Firestore/Source/Remote/FSTRemoteEvent.mm
@@ -54,6 +54,10 @@ NS_ASSUME_NONNULL_BEGIN
   @throw FSTAbstractMethodException();  // NOLINT
 }
 
+- (void)filterUpdatesUsingExistingKeys:(FSTDocumentKeySet *)existingKeys {
+  // No-op by default. Only update mappings can reasonably filter updates.
+}
+
 @end
 
 #pragma mark - FSTResetMapping
@@ -102,10 +106,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)removeDocumentKey:(const DocumentKey &)documentKey {
   self.documents = [self.documents setByRemovingObject:documentKey];
-}
-
-- (void)filterUpdatesUsingExistingKeys:(FSTDocumentKeySet *)existingKeys {
-  // No-op. Resets are not filtered.
 }
 
 @end

--- a/Firestore/Source/Remote/FSTRemoteEvent.mm
+++ b/Firestore/Source/Remote/FSTRemoteEvent.mm
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)filterUpdatesUsingExistingKeys:(FSTDocumentKeySet *)existingKeys {
-  // No-op by default. Only update mappings can reasonably filter updates.
+  @throw FSTAbstractMethodException();  // NOLINT
 }
 
 @end
@@ -106,6 +106,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)removeDocumentKey:(const DocumentKey &)documentKey {
   self.documents = [self.documents setByRemovingObject:documentKey];
+}
+
+- (void)filterUpdatesUsingExistingKeys:(FSTDocumentKeySet *)existingKeys {
+  // No-op. Resets are not filtered.
 }
 
 @end


### PR DESCRIPTION
method definition for 'filterUpdatesUsingExistingKeys:' not found

There are no abstract methods in Objective-C so the base class needs an
implementation. 