### PR TITLE
WIP: Add a Travis build for Firestore as a static library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,19 @@ jobs:
       script:
         - ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
 
+    # Static libraries
+    - stage: test
+      env:
+        - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild VARIANT=static
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+
+        # Remove use_frameworks and remove swift-specific targets
+        - sed -i.bak '/^use_frameworks/ d; /^target.*Swift/,/end/ d' Firestore/Example/Podfile
+        - ./scripts/if_changed.sh ./scripts/pod_install.sh
+      script:
+        - ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
+
     # Community-supported platforms
 
     - stage: test

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -214,6 +214,12 @@ case "$product-$method-$platform" in
 
     RunXcodebuild \
         -workspace 'Firestore/Example/Firestore.xcworkspace' \
+        -scheme "Firestore_IntegrationTests_$platform" \
+        "${xcb_flags[@]}" \
+        build
+
+    RunXcodebuild \
+        -workspace 'Firestore/Example/Firestore.xcworkspace' \
         -scheme 'SwiftBuildTest' \
         "${xcb_flags[@]}" \
         build


### PR DESCRIPTION
Not yet for review

The `sed` command generates diff in the Podfile

```
--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -3,7 +3,6 @@
 # corresponding podspec's.
 pod 'Firebase/Core', '4.13.0'
 
-use_frameworks!
 
 pod 'FirebaseAuth', :path => '../../'
 pod 'FirebaseCore', :path => '../../'
@@ -28,14 +27,7 @@ target 'Firestore_IntegrationTests_iOS' do
   platform :ios, '8.0'
 end
 
-target 'Firestore_SwiftTests_iOS' do
-  platform :ios, '8.0'
-  pod 'FirebaseFirestoreSwift', :path => '../../'
-end
 
-target 'SwiftBuildTest' do
-  platform :ios, '8.0'
-end
 
 # Firestore includes both Objective-C and C++ code, and the Firestore tests
 # consist of both XCTest-based tests in Objective-C and GoogleTest-based tests
```