### PR TITLE
Eliminate duplicate symbol in CocoaPods -all_load build

### DIFF
--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -228,7 +228,7 @@ void FIRLogBasic(FIRLoggerLevel level,
 #endif
   NSString *logMsg = [[NSString alloc] initWithFormat:message arguments:args_ptr];
   logMsg = [NSString
-      stringWithFormat:@"%s - %@[%@] %@", FirebaseVersionString, service, messageCode, logMsg];
+      stringWithFormat:@"%s - %@[%@] %@", FIRVersionString, service, messageCode, logMsg];
   dispatch_async(sFIRClientQueue, ^{
     asl_log(sFIRLoggerClient, NULL, level, "%s", logMsg.UTF8String);
   });

--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -227,8 +227,8 @@ void FIRLogBasic(FIRLoggerLevel level,
   NSCAssert(numberOfMatches == 1, @"Incorrect message code format.");
 #endif
   NSString *logMsg = [[NSString alloc] initWithFormat:message arguments:args_ptr];
-  logMsg = [NSString
-      stringWithFormat:@"%s - %@[%@] %@", FIRVersionString, service, messageCode, logMsg];
+  logMsg =
+      [NSString stringWithFormat:@"%s - %@[%@] %@", FIRVersionString, service, messageCode, logMsg];
   dispatch_async(sFIRClientQueue, ^{
     asl_log(sFIRLoggerClient, NULL, level, "%s", logMsg.UTF8String);
   });

--- a/Firebase/Core/FIRVersion.m
+++ b/Firebase/Core/FIRVersion.m
@@ -29,8 +29,5 @@
 #define STR(x) STR_EXPAND(x)
 #define STR_EXPAND(x) #x
 
-const unsigned char *const FirebaseVersionString =
-    (const unsigned char *const)STR(Firebase_VERSION);
-
-const unsigned char *const FirebaseCoreVersionString =
-    (const unsigned char *const)STR(FIRCore_VERSION);
+const unsigned char *const FIRVersionString = (const unsigned char *const)STR(Firebase_VERSION);
+const unsigned char *const FIRCoreVersionString = (const unsigned char *const)STR(FIRCore_VERSION);

--- a/Firebase/Core/Private/FIRVersion.h
+++ b/Firebase/Core/Private/FIRVersion.h
@@ -17,7 +17,7 @@
 #import <Foundation/Foundation.h>
 
 /** The version of the Firebase SDK. */
-FOUNDATION_EXPORT const unsigned char *const FirebaseVersionString;
+FOUNDATION_EXPORT const unsigned char *const FIRVersionString;
 
 /** The version of the FirebaseCore Component. */
-FOUNDATION_EXPORT const unsigned char *const FirebaseCoreVersionString;
+FOUNDATION_EXPORT const unsigned char *const FIRCoreVersionString;

--- a/Firestore/Source/API/FIRFirestoreVersion.h
+++ b/Firestore/Source/API/FIRFirestoreVersion.h
@@ -19,4 +19,4 @@
 #import <Foundation/Foundation.h>
 
 /** Version string for the Firebase Firestore SDK. */
-FOUNDATION_EXPORT const unsigned char *const FirebaseFirestoreVersionString;
+FOUNDATION_EXPORT const unsigned char *const FIRFirestoreVersionString;

--- a/Firestore/Source/API/FIRFirestoreVersion.mm
+++ b/Firestore/Source/API/FIRFirestoreVersion.mm
@@ -27,5 +27,5 @@
 #define STR(x) STR_EXPAND(x)
 #define STR_EXPAND(x) #x
 
-extern "C" const unsigned char *const FirebaseFirestoreVersionString =
+extern "C" const unsigned char *const FIRFirestoreVersionString =
     (const unsigned char *const)STR(FIRFirestore_VERSION);

--- a/Firestore/Source/Remote/FSTDatastore.mm
+++ b/Firestore/Source/Remote/FSTDatastore.mm
@@ -185,7 +185,7 @@ typedef GRPCProtoCall * (^RPCFactory)(void);
   // version as a macro, so it would be hardcoded based on version we have at compile time of
   // the Firestore library, rather than the version available at runtime/at compile time by the
   // user of the library.
-  return [NSString stringWithFormat:@"gl-objc/ fire/%s grpc/", FirebaseFirestoreVersionString];
+  return [NSString stringWithFormat:@"gl-objc/ fire/%s grpc/", FIRFirestoreVersionString];
 }
 
 /** Returns the string to be used as google-cloud-resource-prefix header value. */


### PR DESCRIPTION
When FirebaseCore and FirebaseFirestore were built with `-all_load` in `Other Linker Flags`, a duplicate symbol would be generated like (see below). 

This is the result of CocoaPods generating a C file with the symbol {pod_name}VersionString defined. Both FirebaseCore and FirebaseFirestore had another definition of that symbol. This PR renames that symbol to FIR{component}VersionString.

This is internal issue b/79210503.

```
duplicate symbol _FirebaseFirestoreVersionString in:
    /Users/paulbeusterien/Library/Developer/Xcode/DerivedData/InvitesExample-enffqvylwclnvzempzhnwxxyzblj/Build/Products/Debug-iphonesimulator/FirebaseFirestore/FirebaseFirestore.framework/FirebaseFirestore(FIRFirestoreVersion.o)
    /Users/paulbeusterien/Library/Developer/Xcode/DerivedData/InvitesExample-enffqvylwclnvzempzhnwxxyzblj/Build/Products/Debug-iphonesimulator/FirebaseFirestore/FirebaseFirestore.framework/FirebaseFirestore(FirebaseFirestore_vers.o)
ld: 1 duplicate symbol for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```