### PR TITLE
Trivial/noop fix to the serializer

### DIFF
--- a/Firestore/core/src/firebase/firestore/remote/serializer.cc
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.cc
@@ -281,8 +281,8 @@ void EncodeObject(Writer* writer, const ObjectValue& object_value) {
   return writer->WriteNestedMessage([&object_value](Writer* writer) {
     // Write each FieldsEntry (i.e. key-value pair.)
     for (const auto& kv : object_value.internal_value) {
-      writer->WriteTag({PB_WT_STRING,
-                        google_firestore_v1beta1_MapValue_fields_tag});
+      writer->WriteTag(
+          {PB_WT_STRING, google_firestore_v1beta1_MapValue_fields_tag});
       writer->WriteNestedMessage(
           [&kv](Writer* writer) { return EncodeFieldsEntry(writer, kv); });
     }

--- a/Firestore/core/src/firebase/firestore/remote/serializer.cc
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.cc
@@ -282,7 +282,7 @@ void EncodeObject(Writer* writer, const ObjectValue& object_value) {
     // Write each FieldsEntry (i.e. key-value pair.)
     for (const auto& kv : object_value.internal_value) {
       writer->WriteTag({PB_WT_STRING,
-                        google_firestore_v1beta1_MapValue_FieldsEntry_key_tag});
+                        google_firestore_v1beta1_MapValue_fields_tag});
       writer->WriteNestedMessage(
           [&kv](Writer* writer) { return EncodeFieldsEntry(writer, kv); });
     }


### PR DESCRIPTION
Was using google_firestore_v1beta1_MapValue_FieldsEntry_key_tag to tag
the key/value pair. (But that tag should be used for the *key* of the
key/value pair, not the pair itself.) Switched to using
google_firestore_v1beta1_MapValue_fields_tag.

This previously worked anyways by coincidence. These two values happen
to be the same. (But it caused me all sorts of confusion as I adapted
this for Document contents.)