### PR TITLE
Fix cron build - FirebaseMessaging static library has warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,8 @@ jobs:
         - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseCore.podspec --use-libraries
         - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseAuth.podspec --use-libraries
         - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseDatabase.podspec --use-libraries
-        - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseMessaging.podspec --use-libraries
+        # The Protobuf dependency of FirebaseMessaging has warnings with --use-libraries
+        - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseMessaging.podspec --use-libraries --allow-warnings
         - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseStorage.podspec --use-libraries
         - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseFunctions.podspec --use-libraries
 


### PR DESCRIPTION
Don't fail the cron build because of: 

```
$ ./scripts/if_cron.sh bundle exec pod lib lint FirebaseMessaging.podspec --use-libraries
 -> FirebaseMessaging (3.0.0)
    - WARN  | xcodebuild:  Headers/Private/Protobuf/GPBWellKnownTypes.h:40:10: warning: non-portable path to file '<protobuf/Any.pbobjc.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
    - WARN  | xcodebuild:  Headers/Private/Protobuf/GPBWellKnownTypes.h:41:10: warning: non-portable path to file '<protobuf/Duration.pbobjc.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
    - WARN  | xcodebuild:  Headers/Private/Protobuf/GPBWellKnownTypes.h:42:10: warning: non-portable path to file '<protobuf/Timestamp.pbobjc.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
    - WARN  | xcodebuild:  Headers/Private/Protobuf/GPBProtocolBuffers.h:55:10: warning: non-portable path to file '<protobuf/Any.pbobjc.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
    - WARN  | xcodebuild:  Headers/Private/Protobuf/GPBProtocolBuffers.h:56:10: warning: non-portable path to file '<protobuf/Api.pbobjc.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
    - WARN  | xcodebuild:  Headers/Private/Protobuf/GPBProtocolBuffers.h:57:10: warning: non-portable path to file '<protobuf/Duration.pbobjc.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
    - WARN  | xcodebuild:  Headers/Private/Protobuf/GPBProtocolBuffers.h:58:10: warning: non-portable path to file '<protobuf/Empty.pbobjc.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
    - WARN  | xcodebuild:  Headers/Private/Protobuf/GPBProtocolBuffers.h:59:10: warning: non-portable path to file '<protobuf/FieldMask.pbobjc.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
    - WARN  | xcodebuild:  Headers/Private/Protobuf/GPBProtocolBuffers.h:60:10: warning: non-portable path to file '<protobuf/SourceContext.pbobjc.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
    - WARN  | xcodebuild:  Headers/Private/Protobuf/GPBProtocolBuffers.h:61:10: warning: non-portable path to file '<protobuf/Struct.pbobjc.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
    - WARN  | xcodebuild:  Headers/Private/Protobuf/GPBProtocolBuffers.h:62:10: warning: non-portable path to file '<protobuf/Timestamp.pbobjc.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
    - WARN  | xcodebuild:  Headers/Private/Protobuf/GPBProtocolBuffers.h:63:10: warning: non-portable path to file '<protobuf/Type.pbobjc.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
    - WARN  | xcodebuild:  Headers/Private/Protobuf/GPBProtocolBuffers.h:64:10: warning: non-portable path to file '<protobuf/Wrappers.pbobjc.h>'; specified path differs in case from file name on disk [-Wnonportable-include-path]
[!] FirebaseMessaging did not pass validation, due to 13 warnings (but you can use `--allow-warnings` to ignore them).
You can use the `--no-clean` option to inspect any issue.

```