### PR TITLE
Forward declare FIRDatabaseReference.

### DIFF
--- a/Firebase/Database/Api/Private/FIRDataSnapshot_Private.h
+++ b/Firebase/Database/Api/Private/FIRDataSnapshot_Private.h
@@ -17,6 +17,8 @@
 #import "FIndexedNode.h"
 #import "FTypedefs_Private.h"
 
+@class FIRDatabaseReference;
+
 @interface FIRDataSnapshot ()
 
 // in _Private for testing purposes


### PR DESCRIPTION
This causes a compilation error in some situations internally.