### PR TITLE
Temporarily disable Messaging pod lints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
         - ./scripts/if_changed.sh bundle exec pod lib lint FirebaseCore.podspec
         - ./scripts/if_changed.sh bundle exec pod lib lint FirebaseAuth.podspec
         - ./scripts/if_changed.sh bundle exec pod lib lint FirebaseDatabase.podspec
-        - ./scripts/if_changed.sh bundle exec pod lib lint FirebaseMessaging.podspec
+#        - ./scripts/if_changed.sh bundle exec pod lib lint FirebaseMessaging.podspec
         - ./scripts/if_changed.sh bundle exec pod lib lint FirebaseStorage.podspec
         - ./scripts/if_changed.sh bundle exec pod lib lint FirebaseFunctions.podspec
 
@@ -83,7 +83,7 @@ jobs:
         - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseAuth.podspec --use-libraries
         - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseDatabase.podspec --use-libraries
         # The Protobuf dependency of FirebaseMessaging has warnings with --use-libraries
-        - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseMessaging.podspec --use-libraries --allow-warnings
+#        - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseMessaging.podspec --use-libraries --allow-warnings
         - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseStorage.podspec --use-libraries
         - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseFunctions.podspec --use-libraries
 


### PR DESCRIPTION
There's an unreleased change in Core that Messaging relies on, but Travis currently pulls in the publicly released version of Core causing the linting to fail. This should be re-enabled once either a) Core is released, or b) we support pointing to local pods for dependencies on Travis - whichever of the two come first.

An issue will be opened to re-enable the linting.
