### PR TITLE
Test Core's build version matches FIROption version

### DIFF
--- a/Example/Core/Tests/FIROptionsTest.m
+++ b/Example/Core/Tests/FIROptionsTest.m
@@ -17,6 +17,7 @@
 #import <FirebaseCore/FIRAppInternal.h>
 #import <FirebaseCore/FIRBundleUtil.h>
 #import <FirebaseCore/FIROptionsInternal.h>
+#import <FirebaseCore/FIRVersion.h>
 
 extern NSString *const kFIRIsMeasurementEnabled;
 extern NSString *const kFIRIsAnalyticsCollectionEnabled;
@@ -435,6 +436,15 @@ extern NSString *const kFIRLibraryVersionID;
                                             options:0
                                               range:NSMakeRange(0, kFIRLibraryVersionID.length)];
   XCTAssertEqual(numberOfMatches, 1, @"Incorrect library version format.");
+}
+
+- (void)testVersionConsistency {
+  const char *versionString = [kFIRLibraryVersionID UTF8String];
+  int major = versionString[0] - '0';
+  int minor = (versionString[1] - '0')  * 10 + versionString[2] - '0';
+  int patch = (versionString[3] - '0')  * 10 + versionString[4] - '0';
+  NSString *str = [NSString stringWithFormat:@"%d.%d.%d", major, minor, patch];
+  XCTAssertEqualObjects(str, [NSString stringWithUTF8String:(const char *)FIRCoreVersionString]);
 }
 
 @end

--- a/Example/Core/Tests/FIROptionsTest.m
+++ b/Example/Core/Tests/FIROptionsTest.m
@@ -441,8 +441,8 @@ extern NSString *const kFIRLibraryVersionID;
 - (void)testVersionConsistency {
   const char *versionString = [kFIRLibraryVersionID UTF8String];
   int major = versionString[0] - '0';
-  int minor = (versionString[1] - '0')  * 10 + versionString[2] - '0';
-  int patch = (versionString[3] - '0')  * 10 + versionString[4] - '0';
+  int minor = (versionString[1] - '0') * 10 + versionString[2] - '0';
+  int patch = (versionString[3] - '0') * 10 + versionString[4] - '0';
   NSString *str = [NSString stringWithFormat:@"%d.%d.%d", major, minor, patch];
   XCTAssertEqualObjects(str, [NSString stringWithUTF8String:(const char *)FIRCoreVersionString]);
 }

--- a/Firebase/Core/FIROptions.m
+++ b/Firebase/Core/FIROptions.m
@@ -41,9 +41,9 @@ NSString *const kFIRIsSignInEnabled = @"IS_SIGNIN_ENABLED";
 
 // Library version ID.
 NSString *const kFIRLibraryVersionID =
-    @"4"     // Major version (one or more digits)
+    @"5"     // Major version (one or more digits)
     @"00"    // Minor version (exactly 2 digits)
-    @"20"    // Build number (exactly 2 digits)
+    @"00"    // Build number (exactly 2 digits)
     @"000";  // Fixed "000"
 // Plist file name.
 NSString *const kServiceInfoFileName = @"GoogleService-Info";


### PR DESCRIPTION
Also update FIROption version that was not done in the 5.0.0 release.

There will be a conflict when 5.0.1 merges in.