### PR TITLE
More macOS/static library prep

### DIFF
--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -2,16 +2,15 @@
 #source 'sso://cpdc-internal/spec'
 #source 'https://github.com/CocoaPods/Specs.git'
 
-# The next line is the forcing function for the Firebase pod. The Firebase
-# version's subspecs should depend on the component versions in their
-# corresponding podspec's.
-
-pod 'Firebase/Core', '5.0.0'
-
 use_frameworks!
 
 target 'Firestore_Example_iOS' do
   platform :ios, '8.0'
+
+  # The next line is the forcing function for the Firebase pod. The Firebase
+  # version's subspecs should depend on the component versions in their
+  # corresponding podspec's.
+  pod 'Firebase/Core', '5.0.0'
 
   pod 'FirebaseAuth', :path => '../../'
   pod 'FirebaseCore', :path => '../../'

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -17,7 +17,13 @@
 #import "Firestore/Example/Tests/Util/FSTIntegrationTestCase.h"
 
 #import <FirebaseCore/FIRLogger.h>
-#import <FirebaseFirestore/FirebaseFirestore-umbrella.h>
+#import <FirebaseFirestore/FIRCollectionReference.h>
+#import <FirebaseFirestore/FIRDocumentChange.h>
+#import <FirebaseFirestore/FIRDocumentReference.h>
+#import <FirebaseFirestore/FIRDocumentSnapshot.h>
+#import <FirebaseFirestore/FIRFirestoreSettings.h>
+#import <FirebaseFirestore/FIRQuerySnapshot.h>
+#import <FirebaseFirestore/FIRSnapshotMetadata.h>
 #import <GRPCClient/GRPCCall+ChannelArg.h>
 #import <GRPCClient/GRPCCall+Tests.h>
 


### PR DESCRIPTION
A few more changes required to build on macOS. The umbrella header change is also required to build Firestore as a static library.