### PR TITLE
Add a C++ native StringFormat

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 /* Begin PBXBuildFile section */
 		132E3E53179DE287D875F3F2 /* FSTLevelDBTransactionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 132E36BB104830BD806351AC /* FSTLevelDBTransactionTests.mm */; };
 		3B843E4C1F3A182900548890 /* remote_store_spec_test.json in Resources */ = {isa = PBXBuildFile; fileRef = 3B843E4A1F3930A400548890 /* remote_store_spec_test.json */; };
+		54131E9720ADE679001DF3FF /* string_format_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54131E9620ADE678001DF3FF /* string_format_test.cc */; };
 		5436F32420008FAD006E51E3 /* string_printf_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 5436F32320008FAD006E51E3 /* string_printf_test.cc */; };
 		54511E8E209805F8005BD28F /* hashing_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54511E8D209805F8005BD28F /* hashing_test.cc */; };
 		5467FB01203E5717009C9584 /* FIRFirestoreTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5467FAFF203E56F8009C9584 /* FIRFirestoreTests.mm */; };
@@ -257,6 +258,7 @@
 		3B843E4A1F3930A400548890 /* remote_store_spec_test.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = remote_store_spec_test.json; sourceTree = "<group>"; };
 		3C81DE3772628FE297055662 /* Pods-Firestore_Example_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_iOS/Pods-Firestore_Example_iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		3F0992A4B83C60841C52E960 /* Pods-Firestore_Example_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_iOS/Pods-Firestore_Example_iOS.release.xcconfig"; sourceTree = "<group>"; };
+		54131E9620ADE678001DF3FF /* string_format_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_format_test.cc; sourceTree = "<group>"; };
 		5436F32320008FAD006E51E3 /* string_printf_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_printf_test.cc; sourceTree = "<group>"; };
 		54511E8D209805F8005BD28F /* hashing_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = hashing_test.cc; sourceTree = "<group>"; };
 		5467FAFF203E56F8009C9584 /* FIRFirestoreTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FIRFirestoreTests.mm; sourceTree = "<group>"; };
@@ -560,6 +562,7 @@
 				54A0352B20A3B3D7003E0143 /* status_test_util.h */,
 				54A0352C20A3B3D7003E0143 /* status_test.cc */,
 				54A0352D20A3B3D7003E0143 /* statusor_test.cc */,
+				54131E9620ADE678001DF3FF /* string_format_test.cc */,
 				5436F32320008FAD006E51E3 /* string_printf_test.cc */,
 				AB380CFC201A2EE200D97691 /* string_util_test.cc */,
 			);
@@ -1474,6 +1477,7 @@
 				B686F2B22025000D0028D6BE /* resource_path_test.cc in Sources */,
 				5492E0CA2021557E00B64F25 /* FSTWatchChangeTests.mm in Sources */,
 				5492E063202154B900B64F25 /* FSTViewSnapshotTest.mm in Sources */,
+				54131E9720ADE679001DF3FF /* string_format_test.cc in Sources */,
 				5492E058202154AB00B64F25 /* FSTAPIHelpers.mm in Sources */,
 				AB380CFB2019388600D97691 /* target_id_generator_test.cc in Sources */,
 				5492E0A82021552D00B64F25 /* FSTLevelDBLocalStoreTests.mm in Sources */,

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -22,10 +22,13 @@ include(CheckIncludeFiles)
 cc_library(
   firebase_firestore_util_base
   SOURCES
+    string_format.cc
+    string_format.h
     string_printf.cc
     string_printf.h
   DEPENDS
     absl_base
+    absl_strings
 )
 
 ## assert and log

--- a/Firestore/core/src/firebase/firestore/util/status.cc
+++ b/Firestore/core/src/firebase/firestore/util/status.cc
@@ -16,7 +16,7 @@
 
 #include "Firestore/core/src/firebase/firestore/util/status.h"
 
-#include "Firestore/core/src/firebase/firestore/util/string_printf.h"
+#include "Firestore/core/src/firebase/firestore/util/string_format.h"
 
 namespace firebase {
 namespace firestore {
@@ -103,7 +103,7 @@ std::string Status::ToString() const {
         result = "Data loss";
         break;
       default:
-        result = StringPrintf("Unknown code(%d)", static_cast<int>(code()));
+        result = StringFormat("Unknown code(%s)", code());
         break;
     }
     result += ": ";

--- a/Firestore/core/src/firebase/firestore/util/string_format.cc
+++ b/Firestore/core/src/firebase/firestore/util/string_format.cc
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/util/string_format.h"
+
+namespace firebase {
+namespace firestore {
+namespace util {
+namespace internal {
+
+static const char* kMissing = "<missing>";
+static const char* kInvalid = "<invalid>";
+
+std::string StringFormatPieces(
+    const char* format, std::initializer_list<absl::string_view> pieces) {
+  std::string result;
+
+  const char* format_iter = format;
+  const char* format_end = format + strlen(format);
+  auto pieces_iter = pieces.begin();
+  auto pieces_end = pieces.end();
+
+  while (true) {
+    const char* percent_ptr = std::find(format_iter, format_end, '%');
+
+    // percent either points to the next format specifier or the end of the
+    // format string. Either is safe to append here:
+    result.append(format_iter, percent_ptr - format_iter);
+
+    if (percent_ptr == format_end) {
+      // No further pieces to format
+      break;
+    }
+
+    // Examine the specifier:
+    const char* spec_ptr = percent_ptr + 1;
+    if (spec_ptr == format_end) {
+      // Incomplete specifier, treat as a literal "%" and be done.
+      result.append("%", 1);
+      break;
+    }
+
+    char spec = *spec_ptr;
+    switch (spec) {
+      case '%':
+        // Pass through literal %.
+        result.append(spec_ptr, 1);
+        break;
+
+      case 's':
+        if (pieces_iter == pieces_end) {
+          result.append(kMissing);
+        } else {
+          // Pass a piece through
+          result.append(pieces_iter->data(), pieces_iter->size());
+          ++pieces_iter;
+        }
+        break;
+
+      default:
+        result.append(kInvalid);
+        break;
+    }
+
+    format_iter = spec_ptr + 1;
+  }
+
+  return result;
+}
+
+}  // namespace internal
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/core/src/firebase/firestore/util/string_format.h
+++ b/Firestore/core/src/firebase/firestore/util/string_format.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_STRING_FORMAT_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_STRING_FORMAT_H_
+
+#include <initializer_list>
+#include <string>
+#include <utility>
+
+#include "absl/base/attributes.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/string_view.h"
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+namespace internal {
+
+std::string StringFormatPieces(const char* format,
+                               std::initializer_list<absl::string_view> pieces);
+
+/**
+ * Explicit ranking for formatting choices. Only useful as an implementation
+ * detail of `FormatArg`.
+ */
+template <int I>
+struct FormatChoice : FormatChoice<I + 1> {};
+
+template <>
+struct FormatChoice<3> {};
+
+}  // namespace internal
+
+/**
+ * Acts as the main value parameter to StringFormat and related functions.
+ *
+ * Chooses a conversion to a text form in this order:
+ *   * If the value is exactly of `bool` type (without implicit conversions)
+ *     the text will the "true" or "false".
+ *   * If the value is of type `const char*`, the text will be the value
+ *     interpreted as a C string.
+ *   * If the value is any other pointer type, the text will be the hexidecimal
+ *     formatting of the value as an unsigned integer.
+ *   * Otherwise the value is interpreted as anything absl::AlphaNum accepts.
+ */
+class FormatArg : public absl::AlphaNum {
+ public:
+  template <typename T>
+  FormatArg(T&& value)  // NOLINT(runtime/explicit)
+      : FormatArg{std::forward<T>(value), internal::FormatChoice<0>{}} {
+  }
+
+ private:
+  /**
+   * Creates a FormatArg from a boolean value, representing the string
+   * "true" or "false".
+   *
+   * This overload only applies if the type of the argument is exactly `bool`.
+   * No implicit conversions to bool are accepted.
+   */
+  template <typename T,
+            typename = typename std::enable_if<std::is_same<bool, T>{}>::type>
+  FormatArg(T bool_value, internal::FormatChoice<0>)
+      : AlphaNum{bool_value ? "true" : "false"} {
+  }
+
+  /**
+   * Creates a FormatArg from a character string literal. This is
+   * handled specially to avoid ambiguity with generic pointers, which are
+   * handled differently.
+   */
+  FormatArg(const char* string_value, internal::FormatChoice<1>)
+      : AlphaNum{string_value} {
+  }
+
+  /**
+   * Creates a FormatArg from an arbitrary pointer, represented as a
+   * hexidecimal integer literal.
+   */
+  template <typename T>
+  FormatArg(T* pointer_value, internal::FormatChoice<2>)
+      : AlphaNum{absl::Hex{reinterpret_cast<uintptr_t>(pointer_value)}} {
+  }
+
+  /**
+   * As a final fallback, creates a FormatArg from any type of value that
+   * absl::AlphaNum accepts.
+   */
+  template <typename T>
+  FormatArg(T&& value, internal::FormatChoice<3>)
+      : AlphaNum{std::forward<T>(value)} {
+  }
+};
+
+/**
+ * Formats a string using a simplified printf-like formatting mechanism that
+ * does not rely on C varargs.
+ *
+ * The following format specifiers are recognized:
+ *   * "%%" - A literal "%"
+ *   * "%s" - The next parameter is copied through
+ */
+template <typename... FA>
+std::string StringFormat(const char* format, const FA&... args) {
+  return internal::StringFormatPieces(
+      format, {static_cast<const FormatArg&>(args).Piece()...});
+}
+
+inline std::string StringFormat() {
+  return {};
+}
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_STRING_FORMAT_H_

--- a/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
@@ -129,6 +129,7 @@ cc_test(
     status_test.cc
     status_test_util.h
     statusor_test.cc
+    string_format_test.cc
     string_printf_test.cc
     string_util_test.cc
   DEPENDS

--- a/Firestore/core/test/firebase/firestore/util/comparison_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/comparison_test.cc
@@ -16,11 +16,10 @@
 
 #include "Firestore/core/src/firebase/firestore/util/comparison.h"
 
-#include <cinttypes>
 #include <cmath>
 #include <limits>
 
-#include "Firestore/core/src/firebase/firestore/util/string_printf.h"
+#include "Firestore/core/src/firebase/firestore/util/string_format.h"
 #include "gtest/gtest.h"
 
 namespace firebase {
@@ -84,47 +83,47 @@ TEST(Comparison, DoubleCompare) {
   ASSERT_SAME(Compare<double>(-0, 0));
 }
 
-#define ASSERT_BIT_EQUALS(expected, actual)                 \
-  do {                                                      \
-    uint64_t expectedBits = DoubleBits(expected);           \
-    uint64_t actualBits = DoubleBits(actual);               \
-    if (expectedBits != actualBits) {                       \
-      std::string message = StringPrintf(                   \
-          "Expected <%f> to compare equal to <%f> "         \
-          "with bits <%" PRIu64 "> equal to <%" PRIu64 ">", \
-          actual, expected, actualBits, expectedBits);      \
-      FAIL() << message;                                    \
-    }                                                       \
+#define ASSERT_BIT_EQUALS(expected, actual)            \
+  do {                                                 \
+    uint64_t expectedBits = DoubleBits(expected);      \
+    uint64_t actualBits = DoubleBits(actual);          \
+    if (expectedBits != actualBits) {                  \
+      std::string message = StringFormat(              \
+          "Expected <%s> to compare equal to <%s> "    \
+          "with bits <%s> equal to <%s>",              \
+          actual, expected, actualBits, expectedBits); \
+      FAIL() << message;                               \
+    }                                                  \
   } while (0);
 
-#define ASSERT_MIXED_SAME(doubleValue, longValue)                              \
-  do {                                                                         \
-    ComparisonResult result = CompareMixedNumber(doubleValue, longValue);      \
-    if (result != ComparisonResult::Same) {                                    \
-      std::string message = StringPrintf(                                      \
-          "Expected <%f> to compare equal to <%lld>", doubleValue, longValue); \
-      FAIL() << message;                                                       \
-    }                                                                          \
+#define ASSERT_MIXED_SAME(doubleValue, longValue)                            \
+  do {                                                                       \
+    ComparisonResult result = CompareMixedNumber(doubleValue, longValue);    \
+    if (result != ComparisonResult::Same) {                                  \
+      std::string message = StringFormat(                                    \
+          "Expected <%s> to compare equal to <%s>", doubleValue, longValue); \
+      FAIL() << message;                                                     \
+    }                                                                        \
   } while (0);
 
-#define ASSERT_MIXED_DESCENDING(doubleValue, longValue)                        \
-  do {                                                                         \
-    ComparisonResult result = CompareMixedNumber(doubleValue, longValue);      \
-    if (result != ComparisonResult::Descending) {                              \
-      std::string message = StringPrintf(                                      \
-          "Expected <%f> to compare equal to <%lld>", doubleValue, longValue); \
-      FAIL() << message;                                                       \
-    }                                                                          \
+#define ASSERT_MIXED_DESCENDING(doubleValue, longValue)                      \
+  do {                                                                       \
+    ComparisonResult result = CompareMixedNumber(doubleValue, longValue);    \
+    if (result != ComparisonResult::Descending) {                            \
+      std::string message = StringFormat(                                    \
+          "Expected <%s> to compare equal to <%s>", doubleValue, longValue); \
+      FAIL() << message;                                                     \
+    }                                                                        \
   } while (0);
 
-#define ASSERT_MIXED_ASCENDING(doubleValue, longValue)                         \
-  do {                                                                         \
-    ComparisonResult result = CompareMixedNumber(doubleValue, longValue);      \
-    if (result != ComparisonResult::Ascending) {                               \
-      std::string message = StringPrintf(                                      \
-          "Expected <%f> to compare equal to <%lld>", doubleValue, longValue); \
-      FAIL() << message;                                                       \
-    }                                                                          \
+#define ASSERT_MIXED_ASCENDING(doubleValue, longValue)                       \
+  do {                                                                       \
+    ComparisonResult result = CompareMixedNumber(doubleValue, longValue);    \
+    if (result != ComparisonResult::Ascending) {                             \
+      std::string message = StringFormat(                                    \
+          "Expected <%s> to compare equal to <%s>", doubleValue, longValue); \
+      FAIL() << message;                                                     \
+    }                                                                        \
   } while (0);
 
 TEST(Comparison, MixedNumberCompare) {

--- a/Firestore/core/test/firebase/firestore/util/string_format_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/string_format_test.cc
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/util/string_format.h"
+
+#include "gtest/gtest.h"
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+TEST(StringFormatTest, Empty) {
+  EXPECT_EQ("", StringFormat(""));
+  EXPECT_EQ("", StringFormat("%s", std::string().c_str()));
+  EXPECT_EQ("", StringFormat("%s", ""));
+}
+
+TEST(StringFormatTest, String) {
+  std::string value = StringFormat("Hello %s", "World");
+  EXPECT_EQ("Hello World", value);
+}
+
+TEST(StringFormatTest, Int) {
+  std::string value = StringFormat("Hello %s", 123);
+  EXPECT_EQ("Hello 123", value);
+}
+
+TEST(StringFormatTest, Float) {
+  std::string value = StringFormat("Hello %s", 1.5);
+  EXPECT_EQ("Hello 1.5", value);
+}
+
+TEST(StringFormatTest, Bool) {
+  EXPECT_EQ("Hello true", StringFormat("Hello %s", true));
+  EXPECT_EQ("Hello false", StringFormat("Hello %s", false));
+}
+
+TEST(StringFormatTest, Pointer) {
+  // pointers implicitly convert to bool. Make sure this doesn't happen in
+  // this API.
+  int value = 4;
+  EXPECT_NE("Hello true", StringFormat("Hello %s", &value));
+}
+
+TEST(StringFormatTest, ToString) {
+  struct Foo {
+    std::string ToString() const {
+      return "Foo";
+    }
+  };
+
+  Foo foo;
+  EXPECT_EQ("Hello Foo", StringFormat("Hello %s", foo.ToString()));
+}
+
+TEST(StringFormatTest, Mixed) {
+  EXPECT_EQ("string=World, bool=true, int=42, float=1.5",
+            StringFormat("string=%s, bool=%s, int=%s, float=%s", "World", true,
+                         42, 1.5));
+}
+
+TEST(StringFormatTest, Invalid) {
+  EXPECT_EQ("Hello <invalid>", StringFormat("Hello %@", 42));
+}
+
+TEST(StringFormatTest, Missing) {
+  EXPECT_EQ("Hello <missing>", StringFormat("Hello %s"));
+}
+
+}  //  namespace util
+}  //  namespace firestore
+}  //  namespace firebase


### PR DESCRIPTION
The new StringFormat takes a simple format string but uses C++ varargs to avoid all the `.c_str()` values and `"%" PRId64` format specifiers.

This is a preparatory step for implementing `HARD_ASSERT` to match the other Firestore ports.

This does not use ostream-style formatters in the way that `CHECK` and `DCHECK` do within google3; rather there's still a vastly simplified format string. The result is something that will port easily to the Android and JS SDKs.

All uses of `StringPrintf` (except those in the implementation of `firebase_assert.h`) have been converted to the new form.

I attempted to make `FormatArg` automatically invoke `ToString()` if the value declared it, but was stymied by lifetime issues for the resulting string. This can't be done in the `FormatArg` constructor, but could be done in a separate helper invoked from the `StringFormat` template function. The `enable_if` magic to make this work started to trip me up though so I figured I'd review this as is before sinking any more time into it.