### PR TITLE
Move library registration to +initialize.

### DIFF
--- a/Firebase/Core/FIROptions.m
+++ b/Firebase/Core/FIROptions.m
@@ -109,7 +109,7 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
 
 #pragma mark - Private class methods
 
-+ (void)load {
++ (void)initialize {
   // Report FirebaseCore version for useragent string
   NSRange major = NSMakeRange(0, 1);
   NSRange minor = NSMakeRange(1, 2);


### PR DESCRIPTION
In the future this could be moved to lazily register in a `dispatch_once` block upon `firebaseUserAgent` being called, but this is a quick fix for now. 