### PR TITLE
Warn when topic format is incorrect.

### DIFF
--- a/Firebase/Messaging/FIRMMessageCode.h
+++ b/Firebase/Messaging/FIRMMessageCode.h
@@ -27,8 +27,8 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingMessageCodeMessaging003 = 2003,  // I-FCM002003
   kFIRMessagingMessageCodeMessaging004 = 2004,  // I-FCM002004
   kFIRMessagingMessageCodeMessaging005 = 2005,  // I-FCM002005
-  kFIRMessagingMessageCodeMessaging006 = 2006,  // I-FCM002006 - no longer used
-  kFIRMessagingMessageCodeMessaging007 = 2007,  // I-FCM002007 - no longer used
+  kFIRMessagingMessageCodeMessaging006 = 2006,  // I-FCM002006
+  kFIRMessagingMessageCodeMessaging007 = 2007,  // I-FCM002007
   kFIRMessagingMessageCodeMessaging008 = 2008,  // I-FCM002008 - no longer used
   kFIRMessagingMessageCodeMessaging009 = 2009,  // I-FCM002009
   kFIRMessagingMessageCodeMessaging010 = 2010,  // I-FCM002010

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -684,6 +684,11 @@ static NSString *const kFIRMessagingPlistAutoInitEnabled =
               completion:(nullable FIRMessagingTopicOperationCompletion)completion {
   if (self.defaultFcmToken.length && topic.length) {
     NSString *normalizeTopic = [[self class ] normalizeTopic:topic];
+    if ([FIRMessagingPubSub hasTopicsPrefix:topic]) {
+      FIRMessagingLoggerWarn(kFIRMessagingMessageCodeMessaging006,
+                             @"Format '%@' is deprecated. Only '%@' should be used in "
+                             @"subscribeToTopic.", topic, normalizeTopic);
+    }
     if (normalizeTopic.length) {
       [self.pubsub subscribeToTopic:normalizeTopic handler:completion];
     } else {
@@ -705,6 +710,11 @@ static NSString *const kFIRMessagingPlistAutoInitEnabled =
                   completion:(nullable FIRMessagingTopicOperationCompletion)completion {
   if (self.defaultFcmToken.length && topic.length) {
     NSString *normalizeTopic = [[self class] normalizeTopic:topic];
+    if ([FIRMessagingPubSub hasTopicsPrefix:topic]) {
+      FIRMessagingLoggerWarn(kFIRMessagingMessageCodeMessaging007,
+                             @"Format '%@' is deprecated. Only '%@' should be used in "
+                             @"unsubscribeFromTopic.", topic, normalizeTopic);
+    }
     if (normalizeTopic.length) {
       [self.pubsub unsubscribeFromTopic:normalizeTopic handler:completion];
     } else {


### PR DESCRIPTION
When subscribeToTopic or unsubscribeFromTopic are called, they should
not be passed in with the prefix "/topic/". Calling those functions with
a string prefixed with "/topic/" will now print a warning.
