### PR TITLE
Directly validate collection and document paths

### DIFF
--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -292,6 +292,11 @@ extern "C" NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
   if (!collectionPath) {
     FSTThrowInvalidArgument(@"Collection path cannot be nil.");
   }
+  if ([collectionPath containsString:@"//"]) {
+    FSTThrowInvalidArgument(@"Invalid path (%@). Paths must not contain // in them.",
+                            collectionPath);
+  }
+
   [self ensureClientConfigured];
   const ResourcePath path = ResourcePath::FromString(util::MakeStringView(collectionPath));
   return [FIRCollectionReference referenceWithPath:path firestore:self];
@@ -301,6 +306,10 @@ extern "C" NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
   if (!documentPath) {
     FSTThrowInvalidArgument(@"Document path cannot be nil.");
   }
+  if ([documentPath containsString:@"//"]) {
+    FSTThrowInvalidArgument(@"Invalid path (%@). Paths must not contain // in them.", documentPath);
+  }
+
   [self ensureClientConfigured];
   const ResourcePath path = ResourcePath::FromString(util::MakeStringView(documentPath));
   return [FIRDocumentReference referenceWithPath:path firestore:self];


### PR DESCRIPTION
... instead of relying on HARD_ASSERTS in resource_path.cc to catch
them.

This fixes an integration test broken in #1304.