### PR TITLE
Adding new error code to topic format error

### DIFF
--- a/Firebase/Messaging/FIRMMessageCode.h
+++ b/Firebase/Messaging/FIRMMessageCode.h
@@ -27,8 +27,8 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingMessageCodeMessaging003 = 2003,  // I-FCM002003
   kFIRMessagingMessageCodeMessaging004 = 2004,  // I-FCM002004
   kFIRMessagingMessageCodeMessaging005 = 2005,  // I-FCM002005
-  kFIRMessagingMessageCodeMessaging006 = 2006,  // I-FCM002006
-  kFIRMessagingMessageCodeMessaging007 = 2007,  // I-FCM002007
+  kFIRMessagingMessageCodeMessaging006 = 2006,  // I-FCM002006 - no longer used
+  kFIRMessagingMessageCodeMessaging007 = 2007,  // I-FCM002007 - no longer used
   kFIRMessagingMessageCodeMessaging008 = 2008,  // I-FCM002008 - no longer used
   kFIRMessagingMessageCodeMessaging009 = 2009,  // I-FCM002009
   kFIRMessagingMessageCodeMessaging010 = 2010,  // I-FCM002010
@@ -45,6 +45,7 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingMessageCodeSenderIDNotSuppliedForTokenDelete = 2021, // I-FCM002021
   kFIRMessagingMessageCodeAPNSTokenNotAvailableDuringTokenFetch = 2022, // I-FCM002022
   kFIRMessagingMessageCodeTokenDelegateMethodsNotImplemented = 2023, // I-FCM002023
+  kFIRMessagingMessageCodeTopicFormatIsDeprecated = 2024,
   // FIRMessagingClient.m
   kFIRMessagingMessageCodeClient000 = 4000,  // I-FCM004000
   kFIRMessagingMessageCodeClient001 = 4001,  // I-FCM004001

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -694,7 +694,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
   if (self.defaultFcmToken.length && topic.length) {
     NSString *normalizeTopic = [[self class ] normalizeTopic:topic];
     if ([FIRMessagingPubSub hasTopicsPrefix:topic]) {
-      FIRMessagingLoggerWarn(kFIRMessagingMessageCodeMessaging006,
+      FIRMessagingLoggerWarn(kFIRMessagingMessageCodeTopicFormatIsDeprecated,
                              @"Format '%@' is deprecated. Only '%@' should be used in "
                              @"subscribeToTopic.", topic, normalizeTopic);
     }
@@ -720,7 +720,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
   if (self.defaultFcmToken.length && topic.length) {
     NSString *normalizeTopic = [[self class] normalizeTopic:topic];
     if ([FIRMessagingPubSub hasTopicsPrefix:topic]) {
-      FIRMessagingLoggerWarn(kFIRMessagingMessageCodeMessaging007,
+      FIRMessagingLoggerWarn(kFIRMessagingMessageCodeTopicFormatIsDeprecated,
                              @"Format '%@' is deprecated. Only '%@' should be used in "
                              @"unsubscribeFromTopic.", topic, normalizeTopic);
     }

--- a/Firebase/Messaging/FIRMessagingContextManagerService.m
+++ b/Firebase/Messaging/FIRMessagingContextManagerService.m
@@ -172,8 +172,10 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
   if (userInfo.count) {
     notification.userInfo = userInfo;
   }
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [[UIApplication sharedApplication] scheduleLocalNotification:notification];
+#pragma clang diagnostic pop
 }
 
 + (NSDictionary *)parseDataFromMessage:(NSDictionary *)message {


### PR DESCRIPTION
Minor: Add a macro to suppress deprecated warning 

I only added one error code for both because it's essentially one call with callback, one without, so having two error codes for this add no extra debug information.