### PR TITLE
Define a Firestore C++ Blob type

### DIFF
--- a/Firestore/core/src/firebase/firestore/model/blob.h
+++ b/Firestore/core/src/firebase/firestore/model/blob.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_MODEL_BLOB_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_MODEL_BLOB_H_
+
+#include <cstdint>
+#include <vector>
+
+namespace firebase {
+namespace firestore {
+namespace model {
+
+// TODO(wilhuff): perhaps absl::Span<uint8_t> would be better?
+using Blob = std::vector<uint8_t>;
+
+}  // namespace model
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_MODEL_BLOB_H_

--- a/Firestore/core/src/firebase/firestore/model/field_value.cc
+++ b/Firestore/core/src/firebase/firestore/model/field_value.cc
@@ -107,7 +107,7 @@ FieldValue& FieldValue::operator=(const FieldValue& value) {
       break;
     case Type::Blob: {
       // copy-and-swap
-      std::vector<uint8_t> tmp = value.blob_value_;
+      Blob tmp = value.blob_value_;
       std::swap(blob_value_, tmp);
       break;
     }
@@ -322,7 +322,7 @@ FieldValue FieldValue::StringValue(std::string&& value) {
 FieldValue FieldValue::BlobValue(const uint8_t* source, size_t size) {
   FieldValue result;
   result.SwitchTo(Type::Blob);
-  std::vector<uint8_t> copy(source, source + size);
+  Blob copy(source, source + size);
   std::swap(result.blob_value_, copy);
   return result;
 }
@@ -488,7 +488,7 @@ void FieldValue::SwitchTo(const Type type) {
       break;
     case Type::Blob:
       // Do not even bother to allocate a new array of size 0.
-      new (&blob_value_) std::vector<uint8_t>();
+      new (&blob_value_) Blob();
       break;
     case Type::Reference:
       // Qualified name to avoid conflict with the member function of same name.

--- a/Firestore/core/src/firebase/firestore/model/field_value.h
+++ b/Firestore/core/src/firebase/firestore/model/field_value.h
@@ -25,6 +25,7 @@
 
 #include "Firestore/core/include/firebase/firestore/geo_point.h"
 #include "Firestore/core/include/firebase/firestore/timestamp.h"
+#include "Firestore/core/src/firebase/firestore/model/blob.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/field_path.h"
@@ -207,7 +208,7 @@ class FieldValue {
     Timestamp timestamp_value_;
     ServerTimestamp server_timestamp_value_;
     std::string string_value_;
-    std::vector<uint8_t> blob_value_;
+    Blob blob_value_;
     // Qualified name to avoid conflict with the member function of same name.
     firebase::firestore::model::ReferenceValue reference_value_;
     GeoPoint geo_point_value_;


### PR DESCRIPTION
Don't use it as the buffer type for the Serializer, since Blobs are logically immutable and Serializer buffers must be mutable.

I think we probably want to make a wrapper for blobs that enforces immutability, but can't do that yet because of the way comparison works. I'll revisit once I clean that up too.