### PR TITLE
Temporary fix for Messaging's data collection bit

### DIFF
--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -176,7 +176,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
 
     // TODO: Remove this once the race condition with FIRApp configuring and InstanceID
     //       is fixed. This must be fixed before Core's flag becomes public.
-    _isGlobalAutomaticDataCollectionEnabled = YES;
+    _globalAutomaticDataCollectionEnabled = YES;
   }
   return self;
 }

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -173,6 +173,10 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
     _loggedMessageIDs = [NSMutableSet set];
     _instanceID = instanceID;
     _messagingUserDefaults = defaults;
+      
+    // TODO: Remove this once the race condition with FIRApp configuring and InstanceID
+    //       is fixed. This must be fixed before Core's flag becomes public.
+    _isGlobalAutomaticDataCollectionEnabled = YES;
   }
   return self;
 }

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -173,7 +173,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
     _loggedMessageIDs = [NSMutableSet set];
     _instanceID = instanceID;
     _messagingUserDefaults = defaults;
-      
+
     // TODO: Remove this once the race condition with FIRApp configuring and InstanceID
     //       is fixed. This must be fixed before Core's flag becomes public.
     _isGlobalAutomaticDataCollectionEnabled = YES;


### PR DESCRIPTION
This ensures that existing behavior still works - InstanceID can sometimes fetch stored values before `FirebaseApp.configure()` is called, causing the global flag to be `NO`. Will file an issue shortly.