### PR TITLE
Temporary fix for Messaging's data collection bit (#1334)

### DIFF
--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -173,6 +173,10 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
     _loggedMessageIDs = [NSMutableSet set];
     _instanceID = instanceID;
     _messagingUserDefaults = defaults;
+
+    // TODO: Remove this once the race condition with FIRApp configuring and InstanceID
+    //       is fixed. This must be fixed before Core's flag becomes public.
+    _globalAutomaticDataCollectionEnabled = YES;
   }
   return self;
 }


### PR DESCRIPTION
* Temporary fix for Messaging's data collection bit

This ensures that existing behavior still works - InstanceID can sometimes fetch stored values before `FirebaseApp.configure()` is called, causing the global flag to be `NO`. Will file an issue shortly.

* Remove extra whitespaces

Thanks, GitHub editor.

* Fix method being called