### PR TITLE
 Handle deserializing BatchGetDocumentsResponse error case...

### DIFF
--- a/Firestore/core/src/firebase/firestore/remote/serializer.cc
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.cc
@@ -583,9 +583,10 @@ std::unique_ptr<MaybeDocument> Serializer::DecodeBatchGetDocumentsResponse(
   } else if (!missing.empty()) {
     return absl::make_unique<NoDocument>(DecodeKey(missing), read_time);
   } else {
-    // Neither 'found' nor 'missing' fields were set.
-    // TODO(rsgowman): Handle the error case.
-    abort();
+    reader->set_status(Status(FirestoreErrorCode::DataLoss,
+                              "Invalid BatchGetDocumentsReponse message: "
+                              "Neither 'found' nor 'missing' fields set."));
+    return nullptr;
   }
 }
 

--- a/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
+++ b/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
@@ -723,14 +723,10 @@ TEST_F(SerializerTest, DecodesNoDocument) {
 }
 
 TEST_F(SerializerTest, DecodeMaybeDocWithoutFoundOrMissingSetShouldFail) {
-  google::firestore::v1beta1::BatchGetDocumentsResponse proto;
-  google::protobuf::Timestamp* read_time_proto = proto.mutable_read_time();
-  read_time_proto->set_seconds(1234);
-  read_time_proto->set_nanos(5678);
+  v1beta1::BatchGetDocumentsResponse proto;
 
-  size_t size = proto.ByteSizeLong();
-  std::vector<uint8_t> bytes(size);
-  bool status = proto.SerializeToArray(bytes.data(), size);
+  std::vector<uint8_t> bytes(proto.ByteSizeLong());
+  bool status = proto.SerializeToArray(bytes.data(), bytes.size());
   EXPECT_TRUE(status);
 
   ExpectFailedStatusDuringMaybeDocumentDecode(

--- a/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
+++ b/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
@@ -146,8 +146,8 @@ class SerializerTest : public ::testing::Test {
    *
    * @param status the expected (failed) status. Only the code() is verified.
    */
-  void ExpectFailedStatusDuringDecode(Status status,
-                                      const std::vector<uint8_t>& bytes) {
+  void ExpectFailedStatusDuringFieldValueDecode(
+      Status status, const std::vector<uint8_t>& bytes) {
     StatusOr<FieldValue> bad_status = serializer.DecodeFieldValue(bytes);
     ASSERT_NOT_OK(bad_status);
     EXPECT_EQ(status.code(), bad_status.status().code());
@@ -473,7 +473,7 @@ TEST_F(SerializerTest, BadNullValue) {
   // Alter the null value from 0 to 1.
   Mutate(&bytes[1], /*expected_initial_value=*/0, /*new_value=*/1);
 
-  ExpectFailedStatusDuringDecode(
+  ExpectFailedStatusDuringFieldValueDecode(
       Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
@@ -484,7 +484,7 @@ TEST_F(SerializerTest, BadBoolValue) {
   // Alter the bool value from 1 to 2. (Value values are 0,1)
   Mutate(&bytes[1], /*expected_initial_value=*/1, /*new_value=*/2);
 
-  ExpectFailedStatusDuringDecode(
+  ExpectFailedStatusDuringFieldValueDecode(
       Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
@@ -503,7 +503,7 @@ TEST_F(SerializerTest, BadIntegerValue) {
   bytes.resize(12);
   bytes[11] = 0x7f;
 
-  ExpectFailedStatusDuringDecode(
+  ExpectFailedStatusDuringFieldValueDecode(
       Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
@@ -515,7 +515,7 @@ TEST_F(SerializerTest, BadStringValue) {
   // used by the encoded tag.)
   Mutate(&bytes[2], /*expected_initial_value=*/1, /*new_value=*/5);
 
-  ExpectFailedStatusDuringDecode(
+  ExpectFailedStatusDuringFieldValueDecode(
       Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
@@ -526,7 +526,7 @@ TEST_F(SerializerTest, BadTimestampValue_TooLarge) {
   // Add some time, which should push us above the maximum allowed timestamp.
   Mutate(&bytes[4], 0x82, 0x83);
 
-  ExpectFailedStatusDuringDecode(
+  ExpectFailedStatusDuringFieldValueDecode(
       Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
@@ -537,7 +537,7 @@ TEST_F(SerializerTest, BadTimestampValue_TooSmall) {
   // Remove some time, which should push us below the minimum allowed timestamp.
   Mutate(&bytes[4], 0x92, 0x91);
 
-  ExpectFailedStatusDuringDecode(
+  ExpectFailedStatusDuringFieldValueDecode(
       Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
@@ -556,9 +556,9 @@ TEST_F(SerializerTest, BadTag) {
   // status. Remove this EXPECT_ANY_THROW statement (and reenable the
   // following commented out statement) once the corresponding assert has been
   // removed from serializer.cc.
-  EXPECT_ANY_THROW(ExpectFailedStatusDuringDecode(
+  EXPECT_ANY_THROW(ExpectFailedStatusDuringFieldValueDecode(
       Status(FirestoreErrorCode::DataLoss, "ignored"), bytes));
-  // ExpectFailedStatusDuringDecode(
+  // ExpectFailedStatusDuringFieldValueDecode(
   //    Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
@@ -571,7 +571,7 @@ TEST_F(SerializerTest, TagVarintWiretypeStringMismatch) {
   // would do.)
   Mutate(&bytes[0], /*expected_initial_value=*/0x08, /*new_value=*/0x0a);
 
-  ExpectFailedStatusDuringDecode(
+  ExpectFailedStatusDuringFieldValueDecode(
       Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
@@ -582,7 +582,7 @@ TEST_F(SerializerTest, TagStringWiretypeVarintMismatch) {
   // 0x88 represents a string value encoded as a varint.
   Mutate(&bytes[0], /*expected_initial_value=*/0x8a, /*new_value=*/0x88);
 
-  ExpectFailedStatusDuringDecode(
+  ExpectFailedStatusDuringFieldValueDecode(
       Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
@@ -595,13 +595,13 @@ TEST_F(SerializerTest, IncompleteFieldValue) {
   ASSERT_EQ(0x00, bytes[1]);
   bytes.pop_back();
 
-  ExpectFailedStatusDuringDecode(
+  ExpectFailedStatusDuringFieldValueDecode(
       Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
 TEST_F(SerializerTest, IncompleteTag) {
   std::vector<uint8_t> bytes;
-  ExpectFailedStatusDuringDecode(
+  ExpectFailedStatusDuringFieldValueDecode(
       Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 


### PR DESCRIPTION
... where neither 'found' nor 'missing' fields set.