### PR TITLE
Remove nearly all usages of WrapNSStringNoCopy

### DIFF
--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -128,11 +128,11 @@ extern "C" NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
                          @"Failed to get FirebaseApp instance. Please call FirebaseApp.configure() "
                          @"before using Firestore");
   }
-  return [self firestoreForApp:app database:util::WrapNSStringNoCopy(DatabaseId::kDefault)];
+  return [self firestoreForApp:app database:util::WrapNSString(DatabaseId::kDefault)];
 }
 
 + (instancetype)firestoreForApp:(FIRApp *)app {
-  return [self firestoreForApp:app database:util::WrapNSStringNoCopy(DatabaseId::kDefault)];
+  return [self firestoreForApp:app database:util::WrapNSString(DatabaseId::kDefault)];
 }
 
 // TODO(b/62410906): make this public

--- a/Firestore/Source/Core/FSTQuery.mm
+++ b/Firestore/Source/Core/FSTQuery.mm
@@ -753,7 +753,8 @@ NSString *FSTStringFromQueryRelationOperator(FSTRelationFilterOperator filterOpe
     return _canonicalID;
   }
 
-  NSMutableString *canonicalID = [util::WrapNSStringNoCopy(_path.CanonicalString()) mutableCopy];
+  NSMutableString *canonicalID = [NSMutableString string];
+  [canonicalID appendFormat:@"%s", _path.CanonicalString().c_str()];
 
   // Add filters.
   [canonicalID appendString:@"|f:"];

--- a/Firestore/Source/Local/FSTLevelDB.mm
+++ b/Firestore/Source/Local/FSTLevelDB.mm
@@ -114,10 +114,10 @@ using leveldb::WriteOptions;
   // projectIDs are DNS-compatible names and cannot contain dots so there's
   // no danger of collisions.
   NSString *directory = documentsDirectory;
-  directory = [directory
-      stringByAppendingPathComponent:util::WrapNSStringNoCopy(databaseInfo.persistence_key())];
+  directory =
+      [directory stringByAppendingPathComponent:util::WrapNSString(databaseInfo.persistence_key())];
 
-  NSString *segment = util::WrapNSStringNoCopy(databaseInfo.database_id().project_id());
+  NSString *segment = util::WrapNSString(databaseInfo.database_id().project_id());
   if (!databaseInfo.database_id().IsDefaultDatabase()) {
     segment = [NSString
         stringWithFormat:@"%@.%s", segment, databaseInfo.database_id().database_id().c_str()];

--- a/Firestore/Source/Model/FSTFieldValue.mm
+++ b/Firestore/Source/Model/FSTFieldValue.mm
@@ -690,13 +690,12 @@ static NSComparisonResult CompareBytes(NSData *left, NSData *right) {
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
   if ([other isKindOfClass:[FSTReferenceValue class]]) {
     FSTReferenceValue *ref = (FSTReferenceValue *)other;
-    NSComparisonResult cmp = [util::WrapNSStringNoCopy(self.databaseID->project_id())
-        compare:util::WrapNSStringNoCopy(ref.databaseID->project_id())];
+    NSComparisonResult cmp =
+        WrapCompare(self.databaseID->project_id(), ref.databaseID->project_id());
     if (cmp != NSOrderedSame) {
       return cmp;
     }
-    cmp = [util::WrapNSStringNoCopy(self.databaseID->database_id())
-        compare:util::WrapNSStringNoCopy(ref.databaseID->database_id())];
+    cmp = WrapCompare(self.databaseID->database_id(), ref.databaseID->database_id());
     return cmp != NSOrderedSame ? cmp : [self.key compare:ref.key];
   } else {
     return [self defaultCompare:other];

--- a/Firestore/core/src/firebase/firestore/util/comparison.cc
+++ b/Firestore/core/src/firebase/firestore/util/comparison.cc
@@ -31,6 +31,12 @@ bool Comparator<absl::string_view>::operator()(
   return left < right;
 }
 
+bool Comparator<std::string>::operator()(const std::string& left,
+                                         const std::string& right) const {
+  // TODO(wilhuff): truncation aware comparison
+  return left < right;
+}
+
 bool Comparator<double>::operator()(double left, double right) const {
   // NaN sorts equal to itself and before any other number.
   if (left < right) {

--- a/Firestore/core/src/firebase/firestore/util/comparison.h
+++ b/Firestore/core/src/firebase/firestore/util/comparison.h
@@ -86,6 +86,11 @@ struct Comparator<absl::string_view> {
                   const absl::string_view& right) const;
 };
 
+template <>
+struct Comparator<std::string> {
+  bool operator()(const std::string& left, const std::string& right) const;
+};
+
 /** Compares two bools: false < true. */
 template <>
 struct Comparator<bool> : public std::less<bool> {};

--- a/Firestore/core/src/firebase/firestore/util/hard_assert_apple.mm
+++ b/Firestore/core/src/firebase/firestore/util/hard_assert_apple.mm
@@ -32,8 +32,8 @@ void Fail(const char* file,
           const int line,
           const std::string& message) {
   [[NSAssertionHandler currentHandler]
-      handleFailureInFunction:WrapNSStringNoCopy(func)
-                         file:WrapNSStringNoCopy(file)
+      handleFailureInFunction:WrapNSString(func)
+                         file:WrapNSString(file)
                    lineNumber:line
                   description:@"FIRESTORE INTERNAL ASSERTION FAILED: %s",
                               message.c_str()];


### PR DESCRIPTION
There are few classes of change in here:

  * Just use `WrapNSString` in cases that happen rarely (e.g. once on startup)
  * Convert utilities that previously used `NSString` to use `absl::string_view` or `std::string` (e.g. comparison)

The last remaining usage is in `- (nullable FSTFieldValue *)valueForPath:(const FieldPath &)fieldPath` where it's used to generate a key for looking up a value in an NSDictionary. I'll be removing this usage once I finalize the conversion from `FSTFieldValue` to `model::FieldValue`.