### PR TITLE
Re-enable Messaging lints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ jobs:
         - ./scripts/if_changed.sh bundle exec pod lib lint FirebaseCore.podspec
         - ./scripts/if_changed.sh bundle exec pod lib lint FirebaseAuth.podspec
         - ./scripts/if_changed.sh bundle exec pod lib lint FirebaseDatabase.podspec
-#        - ./scripts/if_changed.sh bundle exec pod lib lint FirebaseMessaging.podspec
+        - ./scripts/if_changed.sh bundle exec pod lib lint FirebaseMessaging.podspec
         - ./scripts/if_changed.sh bundle exec pod lib lint FirebaseStorage.podspec
         - ./scripts/if_changed.sh bundle exec pod lib lint FirebaseFunctions.podspec
 
@@ -83,7 +83,7 @@ jobs:
         - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseAuth.podspec --use-libraries
         - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseDatabase.podspec --use-libraries
         # The Protobuf dependency of FirebaseMessaging has warnings with --use-libraries
-#        - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseMessaging.podspec --use-libraries --allow-warnings
+        - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseMessaging.podspec --use-libraries --allow-warnings
         - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseStorage.podspec --use-libraries
         - ./scripts/if_cron.sh bundle exec pod lib lint FirebaseFunctions.podspec --use-libraries
 


### PR DESCRIPTION
They were disabled in #1277 because of an unreleased Core change, but the Core version is public now.
