### PR TITLE
Add public FIRAnalyticsConfiguration tests.

### DIFF
--- a/Example/Core/Tests/FIRAnalyticsConfigurationTest.m
+++ b/Example/Core/Tests/FIRAnalyticsConfigurationTest.m
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRTestCase.h"
+
+#import <FirebaseCore/FIRAnalyticsConfiguration+Internal.h>
+#import <FirebaseCore/FIRAnalyticsConfiguration.h>
+
+@interface FIRAnalyticsConfigurationTest : FIRTestCase
+/// A mock for [NSNotificationCenter defaultCenter].
+@property(nonatomic, strong) id notificationCenterMock;
+@end
+
+@implementation FIRAnalyticsConfigurationTest
+
+- (void)setUp {
+  [super setUp];
+  _notificationCenterMock = OCMPartialMock([NSNotificationCenter defaultCenter]);
+}
+
+- (void)tearDown {
+  [_notificationCenterMock stopMocking];
+  [super tearDown];
+}
+
+/// Test access to the shared instance.
+- (void)testSharedInstance {
+  FIRAnalyticsConfiguration *analyticsConfig = [FIRAnalyticsConfiguration sharedInstance];
+  XCTAssertNotNil(analyticsConfig);
+}
+
+/// Test that setting the minimum session interval on the singleton fires a notification.
+- (void)testMinimumSessionIntervalNotification {
+  FIRAnalyticsConfiguration *config = [FIRAnalyticsConfiguration sharedInstance];
+  [config setMinimumSessionInterval:2601];
+  NSString *notificationName = kFIRAnalyticsConfigurationSetMinimumSessionIntervalNotification;
+  OCMVerify([self.notificationCenterMock postNotificationName:notificationName
+                                                       object:config
+                                                     userInfo:@{
+                                                       notificationName : @2601
+                                                     }]);
+}
+
+/// Test that setting the minimum session timeout interval on the singleton fires a notification.
+- (void)testSessionTimeoutIntervalNotification {
+  FIRAnalyticsConfiguration *config = [FIRAnalyticsConfiguration sharedInstance];
+  [config setSessionTimeoutInterval:1000];
+  NSString *notificationName = kFIRAnalyticsConfigurationSetSessionTimeoutIntervalNotification;
+  OCMVerify([self.notificationCenterMock postNotificationName:notificationName
+                                                       object:config
+                                                     userInfo:@{
+                                                       notificationName : @1000
+                                                     }]);
+}
+
+- (void)testSettingAnalyticsCollectionEnabled {
+  // The ordering matters for these notifications.
+  [self.notificationCenterMock setExpectationOrderMatters:YES];
+
+  // Test setting to enabled.
+  FIRAnalyticsConfiguration *config = [FIRAnalyticsConfiguration sharedInstance];
+  NSString *notificationName = kFIRAnalyticsConfigurationSetEnabledNotification;
+  [config setAnalyticsCollectionEnabled:YES];
+  OCMVerify([self.notificationCenterMock postNotificationName:notificationName
+                                                       object:config
+                                                     userInfo:@{
+                                                       notificationName : @YES
+                                                     }]);
+
+  // Test setting to disabled.
+  [config setAnalyticsCollectionEnabled:NO];
+  OCMVerify([self.notificationCenterMock postNotificationName:notificationName
+                                                       object:config
+                                                     userInfo:@{
+                                                       notificationName : @NO
+                                                     }]);
+}
+
+- (void)testSettingAnalyticsCollectionPersistence {
+  id userDefaultsMock = OCMPartialMock([NSUserDefaults standardUserDefaults]);
+  FIRAnalyticsConfiguration *config = [FIRAnalyticsConfiguration sharedInstance];
+
+  // Test that defaults are written to when persistence is enabled.
+  [config setAnalyticsCollectionEnabled:YES persistSetting:YES];
+  OCMVerify([userDefaultsMock setObject:[NSNumber numberWithInteger:kFIRAnalyticsEnabledStateSetYes]
+                                 forKey:kFIRAPersistedConfigMeasurementEnabledStateKey]);
+
+  [config setAnalyticsCollectionEnabled:NO persistSetting:YES];
+  OCMVerify([userDefaultsMock setObject:[NSNumber numberWithInteger:kFIRAnalyticsEnabledStateSetNo]
+                                 forKey:kFIRAPersistedConfigMeasurementEnabledStateKey]);
+
+  // Test that defaults are not written to when persistence is disabled.
+  [config setAnalyticsCollectionEnabled:YES persistSetting:NO];
+  OCMReject([userDefaultsMock setObject:OCMOCK_ANY
+                                 forKey:kFIRAPersistedConfigMeasurementEnabledStateKey]);
+
+  [config setAnalyticsCollectionEnabled:NO persistSetting:NO];
+  OCMReject([userDefaultsMock setObject:OCMOCK_ANY
+                                 forKey:kFIRAPersistedConfigMeasurementEnabledStateKey]);
+
+  [userDefaultsMock stopMocking];
+}
+
+@end

--- a/Example/Firebase.xcodeproj/project.pbxproj
+++ b/Example/Firebase.xcodeproj/project.pbxproj
@@ -580,6 +580,9 @@
 		ED8C81092088EFA20093EB8A /* GTMHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = ED8C80FF2088EFA20093EB8A /* GTMHTTPServer.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		ED8C810A2088EFA20093EB8A /* GTMHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = ED8C80FF2088EFA20093EB8A /* GTMHTTPServer.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		ED8C810B2088EFA20093EB8A /* GTMHTTPServer.m in Sources */ = {isa = PBXBuildFile; fileRef = ED8C80FF2088EFA20093EB8A /* GTMHTTPServer.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		EDD43AA420BF7C7B005EBB36 /* FIRAnalyticsConfigurationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = EDD43AA320BF7C7B005EBB36 /* FIRAnalyticsConfigurationTest.m */; };
+		EDD43AA520BF7C7B005EBB36 /* FIRAnalyticsConfigurationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = EDD43AA320BF7C7B005EBB36 /* FIRAnalyticsConfigurationTest.m */; };
+		EDD43AA620BF7C7B005EBB36 /* FIRAnalyticsConfigurationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = EDD43AA320BF7C7B005EBB36 /* FIRAnalyticsConfigurationTest.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1257,6 +1260,7 @@
 		ED8C80FC2088EFA20093EB8A /* FIRReachabilityCheckerTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FIRReachabilityCheckerTest.m; sourceTree = "<group>"; };
 		ED8C80FE2088EFA20093EB8A /* GTMHTTPServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GTMHTTPServer.h; sourceTree = "<group>"; };
 		ED8C80FF2088EFA20093EB8A /* GTMHTTPServer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GTMHTTPServer.m; sourceTree = "<group>"; };
+		EDD43AA320BF7C7B005EBB36 /* FIRAnalyticsConfigurationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FIRAnalyticsConfigurationTest.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2265,6 +2269,7 @@
 				ED8C80FB2088EFA10093EB8A /* FIRNetworkTest.m */,
 				ED8C80FC2088EFA20093EB8A /* FIRReachabilityCheckerTest.m */,
 				ED8C80FD2088EFA20093EB8A /* third_party */,
+				EDD43AA320BF7C7B005EBB36 /* FIRAnalyticsConfigurationTest.m */,
 				DE4B26DE20855F1F0030A38C /* FIRAppEnvironmentUtilTest.m */,
 				DEE14D7B1E844677006FA992 /* FIRTestCase.h */,
 				DEE14D751E844677006FA992 /* FIRAppAssociationRegistrationUnitTests.m */,
@@ -3622,6 +3627,7 @@
 				D064E6B31ED9B31C001956DF /* FIROptionsTest.m in Sources */,
 				ED8C810A2088EFA20093EB8A /* GTMHTTPServer.m in Sources */,
 				D064E6B41ED9B31C001956DF /* FIRBundleUtilTest.m in Sources */,
+				EDD43AA520BF7C7B005EBB36 /* FIRAnalyticsConfigurationTest.m in Sources */,
 				D064E6B51ED9B31C001956DF /* FIRTestCase.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4080,6 +4086,7 @@
 				DEAAD3D81FBA34250053BF48 /* FIRConfigurationTest.m in Sources */,
 				ED8C810B2088EFA20093EB8A /* GTMHTTPServer.m in Sources */,
 				DEAAD3DB1FBA34250053BF48 /* FIRTestCase.m in Sources */,
+				EDD43AA620BF7C7B005EBB36 /* FIRAnalyticsConfigurationTest.m in Sources */,
 				DEAAD3D71FBA34250053BF48 /* FIRBundleUtilTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4163,6 +4170,7 @@
 				DEE14D931E84468D006FA992 /* FIROptionsTest.m in Sources */,
 				ED8C81092088EFA20093EB8A /* GTMHTTPServer.m in Sources */,
 				DEE14D901E84468D006FA992 /* FIRBundleUtilTest.m in Sources */,
+				EDD43AA420BF7C7B005EBB36 /* FIRAnalyticsConfigurationTest.m in Sources */,
 				DEE14D941E84468D006FA992 /* FIRTestCase.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
This class should eventually be moved outside of Core, but for now let's make the tests self-reliant and open source.