### PR TITLE
Fix changelog

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+
+# v0.12.2
 - [fixed] Fixed an issue where `FirestoreSettings` would accept a concurrent
   dispatch queue, but this configuration would trigger an assertion failure.
   Passing a concurrent dispatch queue should now work correctly (#988).


### PR DESCRIPTION
We released v0.12.2 (as part of Firebase 5.1.0) but didn't adjust the changelog entry.