### PR TITLE
Fix Firestore compilation under Xcode < 9.2

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 		B6FB4690208F9BB300554BA2 /* executor_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = B6FB4688208F9B9100554BA2 /* executor_test.cc */; };
 		BF219E98F1C5A1DAEB5EEC86 /* Pods_Firestore_Example_iOS_SwiftBuildTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 379B34A1536045869826D82A /* Pods_Firestore_Example_iOS_SwiftBuildTest.framework */; };
 		C1AA536F90A0A576CA2816EB /* Pods_Firestore_Example_iOS_Firestore_SwiftTests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB92EB03E3F92485023F64ED /* Pods_Firestore_Example_iOS_Firestore_SwiftTests_iOS.framework */; };
+		C80B10E79CDD7EF7843C321E /* type_traits_apple_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2A0CF41BA5AED6049B0BEB2C /* type_traits_apple_test.mm */; };
 		C8D3CE2343E53223E6487F2C /* Pods_Firestore_Example_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5918805E993304321A05E82B /* Pods_Firestore_Example_iOS.framework */; };
 		DE03B2D41F2149D600A30B9C /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F5AF195388D20070C39A /* XCTest.framework */; };
 		DE03B2D51F2149D600A30B9C /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
@@ -251,6 +252,7 @@
 		1277F98C20D2DF0867496976 /* Pods-Firestore_IntegrationTests_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_IntegrationTests_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_IntegrationTests_iOS/Pods-Firestore_IntegrationTests_iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		12F4357299652983A615F886 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		132E36BB104830BD806351AC /* FSTLevelDBTransactionTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FSTLevelDBTransactionTests.mm; sourceTree = "<group>"; };
+		2A0CF41BA5AED6049B0BEB2C /* type_traits_apple_test.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = type_traits_apple_test.mm; sourceTree = "<group>"; };
 		2B50B3A0DF77100EEE887891 /* Pods_Firestore_Tests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Firestore_Tests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		379B34A1536045869826D82A /* Pods_Firestore_Example_iOS_SwiftBuildTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Firestore_Example_iOS_SwiftBuildTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B843E4A1F3930A400548890 /* remote_store_spec_test.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = remote_store_spec_test.json; sourceTree = "<group>"; };
@@ -560,6 +562,7 @@
 				54A0352D20A3B3D7003E0143 /* statusor_test.cc */,
 				54131E9620ADE678001DF3FF /* string_format_test.cc */,
 				AB380CFC201A2EE200D97691 /* string_util_test.cc */,
+				2A0CF41BA5AED6049B0BEB2C /* type_traits_apple_test.mm */,
 			);
 			path = util;
 			sourceTree = "<group>";
@@ -1565,6 +1568,7 @@
 				ABC1D7E12023A40C00BA84F0 /* token_test.cc in Sources */,
 				54A0352720A3AED0003E0143 /* transform_operations_test.mm in Sources */,
 				549CCA5120A36DBC00BCEB75 /* tree_sorted_map_test.cc in Sources */,
+				C80B10E79CDD7EF7843C321E /* type_traits_apple_test.mm in Sources */,
 				ABC1D7DE2023A05300BA84F0 /* user_test.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		0535C1B65DADAE1CE47FA3CA /* string_format_apple_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9CFD366B783AE27B9E79EE7A /* string_format_apple_test.mm */; };
 		132E3E53179DE287D875F3F2 /* FSTLevelDBTransactionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 132E36BB104830BD806351AC /* FSTLevelDBTransactionTests.mm */; };
 		3B843E4C1F3A182900548890 /* remote_store_spec_test.json in Resources */ = {isa = PBXBuildFile; fileRef = 3B843E4A1F3930A400548890 /* remote_store_spec_test.json */; };
 		54131E9720ADE679001DF3FF /* string_format_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54131E9620ADE678001DF3FF /* string_format_test.cc */; };
@@ -401,6 +402,7 @@
 		74ACEC3603BE58B57A7E8D4C /* Pods-Firestore_Example_iOS-SwiftBuildTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_iOS-SwiftBuildTest.release.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_iOS-SwiftBuildTest/Pods-Firestore_Example_iOS-SwiftBuildTest.release.xcconfig"; sourceTree = "<group>"; };
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		8E002F4AD5D9B6197C940847 /* Firestore.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Firestore.podspec; path = ../Firestore.podspec; sourceTree = "<group>"; };
+		9CFD366B783AE27B9E79EE7A /* string_format_apple_test.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = string_format_apple_test.mm; sourceTree = "<group>"; };
 		AB356EF6200EA5EB0089B766 /* field_value_test.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = field_value_test.cc; sourceTree = "<group>"; };
 		AB380CF82019382300D97691 /* target_id_generator_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = target_id_generator_test.cc; sourceTree = "<group>"; };
 		AB380CFC201A2EE200D97691 /* string_util_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_util_test.cc; sourceTree = "<group>"; };
@@ -560,6 +562,7 @@
 				54A0352C20A3B3D7003E0143 /* status_test.cc */,
 				54A0352B20A3B3D7003E0143 /* status_test_util.h */,
 				54A0352D20A3B3D7003E0143 /* statusor_test.cc */,
+				9CFD366B783AE27B9E79EE7A /* string_format_apple_test.mm */,
 				54131E9620ADE678001DF3FF /* string_format_test.cc */,
 				AB380CFC201A2EE200D97691 /* string_util_test.cc */,
 				2A0CF41BA5AED6049B0BEB2C /* type_traits_apple_test.mm */,
@@ -1560,6 +1563,7 @@
 				549CCA5020A36DBC00BCEB75 /* sorted_set_test.cc in Sources */,
 				54A0352F20A3B3D8003E0143 /* status_test.cc in Sources */,
 				54A0353020A3B3D8003E0143 /* statusor_test.cc in Sources */,
+				0535C1B65DADAE1CE47FA3CA /* string_format_apple_test.mm in Sources */,
 				54131E9720ADE679001DF3FF /* string_format_test.cc in Sources */,
 				AB380CFE201A2F4500D97691 /* string_util_test.cc in Sources */,
 				AB380CFB2019388600D97691 /* target_id_generator_test.cc in Sources */,

--- a/Firestore/Source/Remote/FSTSerializerBeta.mm
+++ b/Firestore/Source/Remote/FSTSerializerBeta.mm
@@ -921,7 +921,7 @@ NS_ASSUME_NONNULL_BEGIN
   } else if ([filter isKindOfClass:[FSTNullFilter class]]) {
     proto.unaryFilter.op = GCFSStructuredQuery_UnaryFilter_Operator_IsNull;
   } else {
-    HARD_FAIL("Unrecognized filter: %s", static_cast<id>(filter));
+    HARD_FAIL("Unrecognized filter: %s", filter);
   }
   return proto;
 }

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -200,6 +200,7 @@ cc_library(
     statusor_internals.h
     string_util.cc
     string_util.h
+    type_traits.h
   DEPENDS
     absl_base
     firebase_firestore_util_base

--- a/Firestore/core/src/firebase/firestore/util/hashing.h
+++ b/Firestore/core/src/firebase/firestore/util/hashing.h
@@ -18,6 +18,7 @@
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_HASHING_H_
 
 #include <iterator>
+#include <string>
 #include <type_traits>
 
 namespace firebase {
@@ -47,6 +48,39 @@ namespace util {
 // TODO(wilhuff): Replace this with whatever Abseil releases.
 
 namespace impl {
+
+/**
+ * A type trait that identifies whether or not std::hash is available for a
+ * given type.
+ *
+ * This type should not be necessary since specialization failure on an
+ * expression like `decltype(std::hash<K>{}(value)` should be enough to disable
+ * overloads that require `std::hash` to be defined but unfortunately some
+ * standard libraries ship with std::hash defined for all types that only
+ * fail later (e.g. via static_assert). One such implementation is the libc++
+ * that ships with Xcode 8.3.3, which is a supported platform.
+ */
+template <typename T>
+struct has_std_hash {
+  // There may be other types for which std::hash is defined but they don't
+  // matter for our purposes.
+  static const bool value = std::is_arithmetic<T>{} || std::is_pointer<T>{} ||
+                            std::is_same<T, std::string>{};
+
+  constexpr operator bool() const {
+    return value;
+  }
+};
+
+/**
+ * A type that's equivalent to size_t if std::hash<T> is defined or a compile
+ * error otherwise.
+ *
+ * This is effectively just a safe implementation of
+ * `decltype(std::hash<T>{}(std::declval<T>()))`.
+ */
+template <typename T>
+using std_hash_type = typename std::enable_if<has_std_hash<T>{}, size_t>::type;
 
 /**
  * Combines a hash_value with whatever accumulated state there is so far.
@@ -100,8 +134,7 @@ auto RankedInvokeHash(const K& value, HashChoice<0>) -> decltype(value.Hash()) {
  * @return The result of `std::hash<K>{}(value)`
  */
 template <typename K>
-auto RankedInvokeHash(const K& value, HashChoice<1>)
-    -> decltype(std::hash<K>{}(value)) {
+std_hash_type<K> RankedInvokeHash(const K& value, HashChoice<1>) {
   return std::hash<K>{}(value);
 }
 

--- a/Firestore/core/src/firebase/firestore/util/hashing.h
+++ b/Firestore/core/src/firebase/firestore/util/hashing.h
@@ -64,8 +64,10 @@ template <typename T>
 struct has_std_hash {
   // There may be other types for which std::hash is defined but they don't
   // matter for our purposes.
-  static const bool value = std::is_arithmetic<T>{} || std::is_pointer<T>{} ||
-                            std::is_same<T, std::string>{};
+  enum {
+    value = std::is_arithmetic<T>{} || std::is_pointer<T>{} ||
+            std::is_same<T, std::string>{}
+  };
 
   constexpr operator bool() const {
     return value;

--- a/Firestore/core/src/firebase/firestore/util/string_format.h
+++ b/Firestore/core/src/firebase/firestore/util/string_format.h
@@ -44,7 +44,7 @@ template <int I>
 struct FormatChoice : FormatChoice<I + 1> {};
 
 template <>
-struct FormatChoice<4> {};
+struct FormatChoice<5> {};
 
 }  // namespace internal
 
@@ -86,9 +86,10 @@ class FormatArg : public absl::AlphaNum {
   /**
    * Creates a FormatArg from any pointer to an object derived from NSObject.
    */
-  template <typename T,
-            typename = typename std::enable_if<is_objective_c_class<T>{}>::type>
-  FormatArg(T* object, internal::FormatChoice<0>)
+  template <
+      typename T,
+      typename = typename std::enable_if<is_objective_c_pointer<T>{}>::type>
+  FormatArg(T object, internal::FormatChoice<1>)
       : AlphaNum{MakeStringView([object description])} {
   }
 
@@ -96,19 +97,8 @@ class FormatArg : public absl::AlphaNum {
    * Creates a FormatArg from any Objective-C Class type. Objective-C Class
    * types are a special struct that aren't of a type derived from NSObject.
    */
-  FormatArg(Class object, internal::FormatChoice<0>)
+  FormatArg(Class object, internal::FormatChoice<1>)
       : AlphaNum{MakeStringView(NSStringFromClass(object))} {
-  }
-
-  /**
-   * Creates a FormatArg from any id pointer. Note that instances of `id<Foo>`
-   * (which means "pointer conforming to the protocol Foo") do not match this
-   * without first casting to type `id`. There's no way to express a template of
-   * `id<T>` since `id<Foo>` isn't actually a C++ template and `id` isn't a
-   * parameterized C++ class.
-   */
-  FormatArg(id object, internal::FormatChoice<0>)
-      : AlphaNum{MakeStringView([object description])} {
   }
 #endif
 
@@ -117,7 +107,7 @@ class FormatArg : public absl::AlphaNum {
    * handled specially to avoid ambiguity with generic pointers, which are
    * handled differently.
    */
-  FormatArg(std::nullptr_t, internal::FormatChoice<1>) : AlphaNum{"null"} {
+  FormatArg(std::nullptr_t, internal::FormatChoice<2>) : AlphaNum{"null"} {
   }
 
   /**
@@ -125,7 +115,7 @@ class FormatArg : public absl::AlphaNum {
    * handled specially to avoid ambiguity with generic pointers, which are
    * handled differently.
    */
-  FormatArg(const char* string_value, internal::FormatChoice<2>)
+  FormatArg(const char* string_value, internal::FormatChoice<3>)
       : AlphaNum{string_value == nullptr ? "null" : string_value} {
   }
 
@@ -134,7 +124,7 @@ class FormatArg : public absl::AlphaNum {
    * hexidecimal integer literal.
    */
   template <typename T>
-  FormatArg(T* pointer_value, internal::FormatChoice<3>)
+  FormatArg(T* pointer_value, internal::FormatChoice<4>)
       : AlphaNum{absl::Hex{reinterpret_cast<uintptr_t>(pointer_value)}} {
   }
 
@@ -143,7 +133,7 @@ class FormatArg : public absl::AlphaNum {
    * absl::AlphaNum accepts.
    */
   template <typename T>
-  FormatArg(T&& value, internal::FormatChoice<4>)
+  FormatArg(T&& value, internal::FormatChoice<5>)
       : AlphaNum{std::forward<T>(value)} {
   }
 };

--- a/Firestore/core/src/firebase/firestore/util/string_format.h
+++ b/Firestore/core/src/firebase/firestore/util/string_format.h
@@ -22,6 +22,7 @@
 #include <utility>
 
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
+#include "Firestore/core/src/firebase/firestore/util/type_traits.h"
 #include "absl/base/attributes.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
@@ -85,9 +86,8 @@ class FormatArg : public absl::AlphaNum {
   /**
    * Creates a FormatArg from any pointer to an object derived from NSObject.
    */
-  template <
-      typename T,
-      typename = typename std::enable_if<std::is_base_of<NSObject, T>{}>::type>
+  template <typename T,
+            typename = typename std::enable_if<is_objective_c_class<T>{}>::type>
   FormatArg(T* object, internal::FormatChoice<0>)
       : AlphaNum{MakeStringView([object description])} {
   }

--- a/Firestore/core/src/firebase/firestore/util/type_traits.h
+++ b/Firestore/core/src/firebase/firestore/util/type_traits.h
@@ -34,8 +34,12 @@ namespace util {
  * class.
  *
  * is_objective_c_class<NSObject>::value == true
- * is_objective_c_class<id>::value == true
+ * is_objective_c_class<NSArray<NSString*>>::value == true
  *
+ * // id is a pointer to an Objective-C object, not an Objective-C class.
+ * is_objective_c_class<id>::value == false
+ *
+ * // fundamental types and C++ classes are not Objective-C classes.
  * is_objective_c_class<int>::value == false
  * is_objective_c_class<std::string>::value == false
  */
@@ -70,9 +74,6 @@ struct is_objective_c_class {
     return value;
   }
 };
-
-template <>
-struct is_objective_c_class<id> : public std::true_type {};
 
 #endif  // __OBJC__
 

--- a/Firestore/core/src/firebase/firestore/util/type_traits.h
+++ b/Firestore/core/src/firebase/firestore/util/type_traits.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_TYPE_TRAITS_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_TYPE_TRAITS_H_
+
+#if __OBJC__
+#import <objc/objc.h>  // for id
+#endif
+
+#include <type_traits>
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+#if __OBJC__
+
+/**
+ * A type trait that identifies whether or not the given type is an Objective-C
+ * class.
+ *
+ * is_objective_c_class<NSObject>::value == true
+ * is_objective_c_class<id>::value == true
+ *
+ * is_objective_c_class<int>::value == false
+ * is_objective_c_class<std::string>::value == false
+ */
+template <typename T>
+struct is_objective_c_class {
+ private:
+  using yes_type = char (&)[10];
+  using no_type = char (&)[1];
+
+  /**
+   * A non-existent function declared to produce a pointer to type T (which is
+   * consistent with the way Objective-C objects are referenced).
+   *
+   * Note that there is no definition for this function but that's okay because
+   * we only need it to reason about the function's type at compile type.
+   */
+  static T* Instance();
+
+  static yes_type Choose(id value);
+  static no_type Choose(...);
+
+ public:
+  using value_type = bool;
+
+  enum { value = sizeof(Choose(Instance())) == sizeof(yes_type) };
+
+  constexpr operator bool() const {
+    return value;
+  }
+
+  constexpr bool operator()() const {
+    return value;
+  }
+};
+
+template <>
+struct is_objective_c_class<id> : public std::true_type {};
+
+#endif  // __OBJC__
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_TYPE_TRAITS_H_

--- a/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
@@ -137,3 +137,11 @@ cc_test(
     firebase_firestore_util
     gmock
 )
+
+if(APPLE)
+  target_sources(
+    firebase_firestore_util_test
+    PUBLIC
+      type_traits_apple_test.mm
+  )
+endif()

--- a/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
@@ -142,6 +142,7 @@ if(APPLE)
   target_sources(
     firebase_firestore_util_test
     PUBLIC
+      string_format_apple_test.mm
       type_traits_apple_test.mm
   )
 endif()

--- a/Firestore/core/test/firebase/firestore/util/hashing_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/hashing_test.cc
@@ -16,6 +16,9 @@
 
 #include "Firestore/core/src/firebase/firestore/util/hashing.h"
 
+#include <map>
+#include <string>
+
 #include "absl/strings/string_view.h"
 #include "gtest/gtest.h"
 
@@ -28,6 +31,21 @@ struct HasHashMember {
     return 42;
   }
 };
+
+TEST(HashingTest, HasStdHash) {
+  EXPECT_TRUE(impl::has_std_hash<float>::value);
+  EXPECT_TRUE(impl::has_std_hash<double>::value);
+  EXPECT_TRUE(impl::has_std_hash<int>::value);
+  EXPECT_TRUE(impl::has_std_hash<int64_t>::value);
+  EXPECT_TRUE(impl::has_std_hash<std::string>::value);
+  EXPECT_TRUE(impl::has_std_hash<void*>::value);
+  EXPECT_TRUE(impl::has_std_hash<const char*>::value);
+
+  struct Foo {};
+  EXPECT_FALSE(impl::has_std_hash<Foo>::value);
+  EXPECT_FALSE(impl::has_std_hash<absl::string_view>::value);
+  EXPECT_FALSE((impl::has_std_hash<std::map<std::string, std::string>>::value));
+}
 
 TEST(HashingTest, Int) {
   ASSERT_EQ(std::hash<int>{}(0), Hash(0));

--- a/Firestore/core/test/firebase/firestore/util/string_format_apple_test.mm
+++ b/Firestore/core/test/firebase/firestore/util/string_format_apple_test.mm
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/util/string_format.h"
+
+#import <Foundation/NSString.h>
+
+#include "gtest/gtest.h"
+
+@interface FSTDescribable : NSObject
+@end
+
+@implementation FSTDescribable
+
+- (NSString*)description {
+  return @"description";
+}
+
+@end
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+TEST(StringFormatTest, NSString) {
+  EXPECT_EQ("Hello World", StringFormat("Hello %s", @"World"));
+
+  NSString* hello = [NSString stringWithUTF8String:"Hello"];
+  EXPECT_EQ("Hello World", StringFormat("%s World", hello));
+
+  // NOLINTNEXTLINE false positive on "string"
+  NSMutableString* world = [NSMutableString string];
+  [world appendString:@"World"];
+  EXPECT_EQ("Hello World", StringFormat("Hello %s", world));
+}
+
+TEST(StringFormatTest, FSTDescribable) {
+  FSTDescribable* desc = [[FSTDescribable alloc] init];
+  EXPECT_EQ("Hello description", StringFormat("Hello %s", desc));
+
+  id desc_id = desc;
+  EXPECT_EQ("Hello description", StringFormat("Hello %s", desc_id));
+}
+
+}  //  namespace util
+}  //  namespace firestore
+}  //  namespace firebase

--- a/Firestore/core/test/firebase/firestore/util/type_traits_apple_test.mm
+++ b/Firestore/core/test/firebase/firestore/util/type_traits_apple_test.mm
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/util/type_traits.h"
+
+#import <Foundation/NSObject.h>
+#import <Foundation/NSString.h>
+
+#include "gtest/gtest.h"
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+TEST(TypeTraitsTest, IsObjectiveCClass) {
+  static_assert(is_objective_c_class<id>{}, "id");
+
+  static_assert(is_objective_c_class<NSObject>{}, "NSObject");
+  static_assert(is_objective_c_class<NSString>{}, "NSString");
+  static_assert(!is_objective_c_class<int>{}, "int");
+  static_assert(!is_objective_c_class<void>{}, "void");
+
+  struct Foo {};
+  static_assert(!is_objective_c_class<Foo>{}, "Foo");
+}
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/core/test/firebase/firestore/util/type_traits_apple_test.mm
+++ b/Firestore/core/test/firebase/firestore/util/type_traits_apple_test.mm
@@ -26,22 +26,23 @@ namespace firebase {
 namespace firestore {
 namespace util {
 
-TEST(TypeTraitsTest, IsObjectiveCClass) {
-  static_assert(is_objective_c_class<NSObject>{}, "NSObject");
-  static_assert(is_objective_c_class<NSString>{}, "NSString");
-  static_assert(is_objective_c_class<NSArray<NSString*>>{},
+TEST(TypeTraitsTest, IsObjectiveCPointer) {
+  static_assert(is_objective_c_pointer<NSObject*>{}, "NSObject");
+  static_assert(is_objective_c_pointer<NSString*>{}, "NSString");
+  static_assert(is_objective_c_pointer<NSArray<NSString*>*>{},
                 "NSArray<NSString*>");
 
-  static_assert(!is_objective_c_class<int*>{}, "int*");
-  static_assert(!is_objective_c_class<void*>{}, "void*");
-  static_assert(!is_objective_c_class<int>{}, "int");
-  static_assert(!is_objective_c_class<void>{}, "void");
+  static_assert(is_objective_c_pointer<id>{}, "id");
+  static_assert(is_objective_c_pointer<id<NSCopying>>{}, "id<NSCopying>");
+
+  static_assert(!is_objective_c_pointer<int*>{}, "int*");
+  static_assert(!is_objective_c_pointer<void*>{}, "void*");
+  static_assert(!is_objective_c_pointer<int>{}, "int");
+  static_assert(!is_objective_c_pointer<void>{}, "void");
 
   struct Foo {};
-  static_assert(!is_objective_c_class<Foo>{}, "Foo");
-
-  static_assert(!is_objective_c_class<id>{}, "id");
-  static_assert(!is_objective_c_class<id<NSCopying>>{}, "id<NSCopying>");
+  static_assert(!is_objective_c_pointer<Foo>{}, "Foo");
+  static_assert(!is_objective_c_pointer<Foo*>{}, "Foo");
 }
 
 }  // namespace util

--- a/Firestore/core/test/firebase/firestore/util/type_traits_apple_test.mm
+++ b/Firestore/core/test/firebase/firestore/util/type_traits_apple_test.mm
@@ -16,6 +16,7 @@
 
 #include "Firestore/core/src/firebase/firestore/util/type_traits.h"
 
+#import <Foundation/NSArray.h>
 #import <Foundation/NSObject.h>
 #import <Foundation/NSString.h>
 
@@ -26,15 +27,21 @@ namespace firestore {
 namespace util {
 
 TEST(TypeTraitsTest, IsObjectiveCClass) {
-  static_assert(is_objective_c_class<id>{}, "id");
-
   static_assert(is_objective_c_class<NSObject>{}, "NSObject");
   static_assert(is_objective_c_class<NSString>{}, "NSString");
+  static_assert(is_objective_c_class<NSArray<NSString*>>{},
+                "NSArray<NSString*>");
+
+  static_assert(!is_objective_c_class<int*>{}, "int*");
+  static_assert(!is_objective_c_class<void*>{}, "void*");
   static_assert(!is_objective_c_class<int>{}, "int");
   static_assert(!is_objective_c_class<void>{}, "void");
 
   struct Foo {};
   static_assert(!is_objective_c_class<Foo>{}, "Foo");
+
+  static_assert(!is_objective_c_class<id>{}, "id");
+  static_assert(!is_objective_c_class<id<NSCopying>>{}, "id<NSCopying>");
 }
 
 }  // namespace util


### PR DESCRIPTION
A number of template-related errors have crept into the Firestore C++ codebase that happened to work in Xcode 9.3 and 9.4 but don't work on earlier versions.

Tested with Xcode 8.3.3 and 9.2.

Fixes #1366.