### PR TITLE
Create Status objects from errno

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 /* Begin PBXBuildFile section */
 		0535C1B65DADAE1CE47FA3CA /* string_format_apple_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9CFD366B783AE27B9E79EE7A /* string_format_apple_test.mm */; };
 		132E3E53179DE287D875F3F2 /* FSTLevelDBTransactionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 132E36BB104830BD806351AC /* FSTLevelDBTransactionTests.mm */; };
+		1CAA9012B25F975D445D5978 /* strerror_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 358C3B5FE573B1D60A4F7592 /* strerror_test.cc */; };
 		3B843E4C1F3A182900548890 /* remote_store_spec_test.json in Resources */ = {isa = PBXBuildFile; fileRef = 3B843E4A1F3930A400548890 /* remote_store_spec_test.json */; };
 		54131E9720ADE679001DF3FF /* string_format_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54131E9620ADE678001DF3FF /* string_format_test.cc */; };
 		54511E8E209805F8005BD28F /* hashing_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54511E8D209805F8005BD28F /* hashing_test.cc */; };
@@ -255,6 +256,7 @@
 		132E36BB104830BD806351AC /* FSTLevelDBTransactionTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FSTLevelDBTransactionTests.mm; sourceTree = "<group>"; };
 		2A0CF41BA5AED6049B0BEB2C /* type_traits_apple_test.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = type_traits_apple_test.mm; sourceTree = "<group>"; };
 		2B50B3A0DF77100EEE887891 /* Pods_Firestore_Tests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Firestore_Tests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		358C3B5FE573B1D60A4F7592 /* strerror_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = strerror_test.cc; sourceTree = "<group>"; };
 		379B34A1536045869826D82A /* Pods_Firestore_Example_iOS_SwiftBuildTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Firestore_Example_iOS_SwiftBuildTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B843E4A1F3930A400548890 /* remote_store_spec_test.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = remote_store_spec_test.json; sourceTree = "<group>"; };
 		3C81DE3772628FE297055662 /* Pods-Firestore_Example_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_iOS/Pods-Firestore_Example_iOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -562,6 +564,7 @@
 				54A0352C20A3B3D7003E0143 /* status_test.cc */,
 				54A0352B20A3B3D7003E0143 /* status_test_util.h */,
 				54A0352D20A3B3D7003E0143 /* statusor_test.cc */,
+				358C3B5FE573B1D60A4F7592 /* strerror_test.cc */,
 				9CFD366B783AE27B9E79EE7A /* string_format_apple_test.mm */,
 				54131E9620ADE678001DF3FF /* string_format_test.cc */,
 				AB380CFC201A2EE200D97691 /* string_util_test.cc */,
@@ -1563,6 +1566,7 @@
 				549CCA5020A36DBC00BCEB75 /* sorted_set_test.cc in Sources */,
 				54A0352F20A3B3D8003E0143 /* status_test.cc in Sources */,
 				54A0353020A3B3D8003E0143 /* statusor_test.cc in Sources */,
+				1CAA9012B25F975D445D5978 /* strerror_test.cc in Sources */,
 				0535C1B65DADAE1CE47FA3CA /* string_format_apple_test.mm in Sources */,
 				54131E9720ADE679001DF3FF /* string_format_test.cc in Sources */,
 				AB380CFE201A2F4500D97691 /* string_util_test.cc in Sources */,

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -210,3 +210,10 @@ cc_library(
     ${FIREBASE_FIRESTORE_UTIL_LOG}
     ${FIREBASE_FIRESTORE_UTIL_RANDOM}
 )
+
+if(APPLE)
+  target_sources(
+    firebase_firestore_util PRIVATE
+    status_apple.mm
+  )
+endif()

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -198,6 +198,8 @@ cc_library(
     statusor.cc
     statusor.h
     statusor_internals.h
+    strerror.cc
+    strerror.h
     string_util.cc
     string_util.h
     type_traits.h

--- a/Firestore/core/src/firebase/firestore/util/status.cc
+++ b/Firestore/core/src/firebase/firestore/util/status.cc
@@ -16,6 +16,9 @@
 
 #include "Firestore/core/src/firebase/firestore/util/status.h"
 
+#include <cerrno>
+
+#include "Firestore/core/src/firebase/firestore/util/strerror.h"
 #include "Firestore/core/src/firebase/firestore/util/string_format.h"
 
 namespace firebase {
@@ -27,6 +30,153 @@ Status::Status(FirestoreErrorCode code, absl::string_view msg) {
   state_ = std::unique_ptr<State>(new State);
   state_->code = code;
   state_->msg = static_cast<std::string>(msg);
+}
+
+Status Status::FromErrno(int errno_code, absl::string_view msg) {
+  FirestoreErrorCode canonical_code = CodeForErrno(errno_code);
+  return Status{canonical_code,
+                util::StringFormat("%s (errno %s: %s)", msg, errno_code,
+                                   StrError(errno_code))};
+}
+
+FirestoreErrorCode Status::CodeForErrno(int errno_code) {
+  switch (errno_code) {
+    case 0:
+      return FirestoreErrorCode::Ok;
+
+      // Internal canonical mappings call these failed preconditions, but for
+      // our purposes these must indicate an internal error in file handling.
+    case EBADF:  // Invalid file descriptor
+#if defined(EBADFD)
+    case EBADFD:  // File descriptor in bad state
+#endif
+      return FirestoreErrorCode::Internal;
+
+    case EINVAL:        // Invalid argument
+    case ENAMETOOLONG:  // Filename too long
+    case E2BIG:         // Argument list too long
+    case EDESTADDRREQ:  // Destination address required
+    case EDOM:          // Mathematics argument out of domain of function
+    case EFAULT:        // Bad address
+    case EILSEQ:        // Illegal byte sequence
+    case ENOPROTOOPT:   // Protocol not available
+    case ENOSTR:        // Not a STREAM
+    case ENOTSOCK:      // Not a socket
+    case ENOTTY:        // Inappropriate I/O control operation
+    case EPROTOTYPE:    // Protocol wrong type for socket
+    case ESPIPE:        // Invalid seek
+      return FirestoreErrorCode::InvalidArgument;
+
+    case ETIMEDOUT:  // Connection timed out
+    case ETIME:      // Timer expired
+      return FirestoreErrorCode::DeadlineExceeded;
+
+    case ENODEV:  // No such device
+    case ENOENT:  // No such file or directory
+#if defined(ENOMEDIUM)
+    case ENOMEDIUM:  // No medium found
+#endif
+    case ENXIO:  // No such device or address
+    case ESRCH:  // No such process
+      return FirestoreErrorCode::NotFound;
+
+    case EEXIST:         // File exists
+    case EADDRNOTAVAIL:  // Address not available
+    case EALREADY:       // Connection already in progress
+#if defined(ENOTUNIQ)
+    case ENOTUNIQ:  // Name not unique on network
+#endif
+      return FirestoreErrorCode::AlreadyExists;
+
+    case EPERM:   // Operation not permitted
+    case EACCES:  // Permission denied
+#if defined(ENOKEY)
+    case ENOKEY:  // Required key not available
+#endif
+    case EROFS:  // Read only file system
+      return FirestoreErrorCode::PermissionDenied;
+
+    case ENOTEMPTY:   // Directory not empty
+    case EISDIR:      // Is a directory
+    case ENOTDIR:     // Not a directory
+    case EADDRINUSE:  // Address already in use
+    case EBUSY:       // Device or resource busy
+    case ECHILD:      // No child processes
+    case EISCONN:     // Socket is connected
+#if defined(EISNAM)
+    case EISNAM:  // Is a named type file
+#endif
+    case ENOTBLK:    // Block device required
+    case ENOTCONN:   // The socket is not connected
+    case EPIPE:      // Broken pipe
+    case ESHUTDOWN:  // Cannot send after transport endpoint shutdown
+    case ETXTBSY:    // Text file busy
+#if defined(EUNATCH)
+    case EUNATCH:  // Protocol driver not attached
+#endif
+      return FirestoreErrorCode::FailedPrecondition;
+
+    case ENOSPC:   // No space left on device
+    case EDQUOT:   // Disk quota exceeded
+    case EMFILE:   // Too many open files
+    case EMLINK:   // Too many links
+    case ENFILE:   // Too many open files in system
+    case ENOBUFS:  // No buffer space available
+    case ENODATA:  // No message is available on the STREAM read queue
+    case ENOMEM:   // Not enough space
+    case ENOSR:    // No STREAM resources
+    case EUSERS:   // Too many users
+      return FirestoreErrorCode::ResourceExhausted;
+
+#if defined(ECHRNG)
+    case ECHRNG:  // Channel number out of range
+#endif
+    case EFBIG:      // File too large
+    case EOVERFLOW:  // Value too large to be stored in data type
+    case ERANGE:     // Result too large
+      return FirestoreErrorCode::OutOfRange;
+
+#if defined(ENOPKG)
+    case ENOPKG:  // Package not installed
+#endif
+    case ENOSYS:           // Function not implemented
+    case ENOTSUP:          // Operation not supported
+    case EAFNOSUPPORT:     // Address family not supported
+    case EPFNOSUPPORT:     // Protocol family not supported
+    case EPROTONOSUPPORT:  // Protocol not supported
+    case ESOCKTNOSUPPORT:  // Socket type not supported
+    case EXDEV:            // Improper link
+      return FirestoreErrorCode::Unimplemented;
+
+    case EAGAIN:  // Resource temporarily unavailable
+#if defined(ECOMM)
+    case ECOMM:  // Communication error on send
+#endif
+    case ECONNREFUSED:  // Connection refused
+    case ECONNABORTED:  // Connection aborted
+    case ECONNRESET:    // Connection reset
+    case EINTR:         // Interrupted function call
+    case EHOSTDOWN:     // Host is down
+    case EHOSTUNREACH:  // Host is unreachable
+    case ENETDOWN:      // Network is down
+    case ENETRESET:     // Connection aborted by network
+    case ENETUNREACH:   // Network unreachable
+    case ENOLCK:        // No locks available
+    case ENOLINK:       // Link has been severed
+#if defined(ENONET)
+    case ENONET:  // Machine is not on the network
+#endif
+      return FirestoreErrorCode::Unavailable;
+
+    case EDEADLK:  // Resource deadlock avoided
+    case ESTALE:   // Stale file handle
+      return FirestoreErrorCode::Aborted;
+
+    case ECANCELED:  // Operation cancelled
+      return FirestoreErrorCode::Cancelled;
+
+    default: { return FirestoreErrorCode::Unknown; }
+  }
 }
 
 void Status::Update(const Status& new_status) {

--- a/Firestore/core/src/firebase/firestore/util/status.cc
+++ b/Firestore/core/src/firebase/firestore/util/status.cc
@@ -32,14 +32,8 @@ Status::Status(FirestoreErrorCode code, absl::string_view msg) {
   state_->msg = static_cast<std::string>(msg);
 }
 
-Status Status::FromErrno(int errno_code, absl::string_view msg) {
-  FirestoreErrorCode canonical_code = CodeForErrno(errno_code);
-  return Status{canonical_code,
-                util::StringFormat("%s (errno %s: %s)", msg, errno_code,
-                                   StrError(errno_code))};
-}
-
-FirestoreErrorCode Status::CodeForErrno(int errno_code) {
+/// Returns the Canonical error code for the given errno value.
+static FirestoreErrorCode CodeForErrno(int errno_code) {
   switch (errno_code) {
     case 0:
       return FirestoreErrorCode::Ok;
@@ -177,6 +171,13 @@ FirestoreErrorCode Status::CodeForErrno(int errno_code) {
 
     default: { return FirestoreErrorCode::Unknown; }
   }
+}
+
+Status Status::FromErrno(int errno_code, absl::string_view msg) {
+  FirestoreErrorCode canonical_code = CodeForErrno(errno_code);
+  return Status{canonical_code,
+                util::StringFormat("%s (errno %s: %s)", msg, errno_code,
+                                   StrError(errno_code))};
 }
 
 void Status::Update(const Status& new_status) {

--- a/Firestore/core/src/firebase/firestore/util/status.h
+++ b/Firestore/core/src/firebase/firestore/util/status.h
@@ -50,11 +50,8 @@ class ABSL_MUST_USE_RESULT Status {
     return Status();
   }
 
-  /// Creates a status object from
+  /// Creates a status object from the given errno error code and message.
   static Status FromErrno(int errno_code, absl::string_view msg);
-
-  /// Returns the Canonical error code for the given errno value.
-  static FirestoreErrorCode CodeForErrno(int errno_code);
 
 #if defined(__OBJC__)
   static Status FromNSError(NSError* error);

--- a/Firestore/core/src/firebase/firestore/util/status.h
+++ b/Firestore/core/src/firebase/firestore/util/status.h
@@ -50,6 +50,16 @@ class ABSL_MUST_USE_RESULT Status {
     return Status();
   }
 
+  /// Creates a status object from
+  static Status FromErrno(int errno_code, absl::string_view msg);
+
+  /// Returns the Canonical error code for the given errno value.
+  static FirestoreErrorCode CodeForErrno(int errno_code);
+
+#if defined(__OBJC__)
+  static Status FromNSError(NSError* error);
+#endif  // defined(__OBJC__)
+
   /// Returns true iff the status indicates success.
   bool ok() const {
     return (state_ == nullptr);

--- a/Firestore/core/src/firebase/firestore/util/status_apple.mm
+++ b/Firestore/core/src/firebase/firestore/util/status_apple.mm
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015, 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/util/status.h"
+
+#include <cerrno>
+
+#include "Firestore/core/src/firebase/firestore/util/string_format.h"
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+Status Status::FromNSError(NSError* error) {
+  NSError* original = error;
+
+  while (error) {
+    if ([error.domain isEqualToString:NSPOSIXErrorDomain]) {
+      return FromErrno(static_cast<int>(error.code),
+                       MakeStringView(original.localizedDescription));
+    }
+
+    error = error.userInfo[NSUnderlyingErrorKey];
+  }
+
+  return Status{FirestoreErrorCode::Unknown,
+                StringFormat("Unknown error: %s", original)};
+}
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/core/src/firebase/firestore/util/statusor.h
+++ b/Firestore/core/src/firebase/firestore/util/statusor.h
@@ -59,7 +59,8 @@
 //
 //  StatusOr<Foo*> FooFactory::MakeNewFoo(int arg) {
 //    if (arg <= 0) {
-//      return tensorflow::InvalidArgument("Arg must be positive");
+//      return Status(FirestoreErrorCode::InvalidArgument,
+//                    "Arg must be positive");
 //    } else {
 //      return new Foo(arg);
 //    }
@@ -149,7 +150,7 @@ class ABSL_MUST_USE_RESULT StatusOr
   //
   // REQUIRES: !status.ok(). This requirement is DCHECKed.
   // In optimized builds, passing Status::OK() here will have the effect
-  // of passing tensorflow::error::INTERNAL as a fallback.
+  // of passing FirestoreErrorCode::Internal as a fallback.
   StatusOr(const Status& status);  // NOLINT: allow non-explicit 1-param ctor
   StatusOr& operator=(const Status& status);
 

--- a/Firestore/core/src/firebase/firestore/util/strerror.cc
+++ b/Firestore/core/src/firebase/firestore/util/strerror.cc
@@ -29,17 +29,17 @@
 #include <cstring>
 
 #if defined(_WIN32)
-#  define HAVE_STRERROR_S 1
+#define HAVE_STRERROR_S 1
 
 #elif defined(__GLIBC__)
-#  if (_POSIX_C_SOURCE >= 200112L) && !_GNU_SOURCE
-#    define HAVE_POSIX_STRERROR_R 1
-#  else
-#    define HAVE_GNU_STRERROR_R 1
-#  endif
+#if (_POSIX_C_SOURCE >= 200112L) && !_GNU_SOURCE
+#define HAVE_POSIX_STRERROR_R 1
+#else
+#define HAVE_GNU_STRERROR_R 1
+#endif
 
 #else
-#  define HAVE_POSIX_STRERROR_R 1
+#define HAVE_POSIX_STRERROR_R 1
 
 #endif
 

--- a/Firestore/core/src/firebase/firestore/util/strerror.cc
+++ b/Firestore/core/src/firebase/firestore/util/strerror.cc
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Implementation note:
+//
+// This is ported from //base/strerror.cc, with several local modifications:
+//
+//   * Removed non-portable optimization around to use sys_errlist where
+//     available without warnings.
+//   * Added __attribute__((unused)) to compile with -Wno-unused-functions.
+//   * Conformed to style/lint rules.
+
+#include "Firestore/core/src/firebase/firestore/util/strerror.h"
+
+#include <cerrno>
+#include <cstdio>
+#if defined(_WIN32)
+#include <cstring>
+#endif
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+namespace {
+
+#if !defined(_WIN32)
+#if defined(__GNUC__)
+#define POSSIBLY_UNUSED __attribute__((unused))
+#else
+#define POSSIBLY_UNUSED
+#endif
+
+// Only one of these overloads will be used in any given build, as determined by
+// the return type of strerror_r(): char* (for GNU), or int (for XSI).  See 'man
+// strerror_r' for more details.
+POSSIBLY_UNUSED const char* StrErrorR(char* (*strerror_r)(int, char*, size_t),
+                                      int errnum,
+                                      char* buf,
+                                      size_t buflen) {
+  return strerror_r(errnum, buf, buflen);
+}
+
+POSSIBLY_UNUSED const char* StrErrorR(int (*strerror_r)(int, char*, size_t),
+                                      int errnum,
+                                      char* buf,
+                                      size_t buflen) {
+  if (strerror_r(errnum, buf, buflen)) {
+    *buf = '\0';
+  }
+  return buf;
+}
+#endif  // !defined(_WIN32)
+
+inline const char* StrErrorAdaptor(int errnum, char* buf, size_t buflen) {
+#if defined(_WIN32)
+  int rc = strerror_s(buf, buflen, errnum);
+  buf[buflen - 1] = '\0';  // guarantee NUL termination
+
+  if (rc == 0 && strcmp(buf, "Unknown error") == 0) {
+    *buf = '\0';
+  }
+  return buf;
+
+#elif defined(__GLIBC__) || defined(__APPLE__)
+  return StrErrorR(strerror_r, errnum, buf, buflen);
+#endif  // defined(_WIN32)
+}
+
+}  // namespace
+
+std::string StrError(int errnum) {
+  const int saved_errno = errno;
+
+  char buf[100];
+  const char* str = StrErrorAdaptor(errnum, buf, sizeof buf);
+  if (*str == '\0') {
+    snprintf(buf, sizeof buf, "Unknown error %d", errnum);
+    str = buf;
+  }
+
+  errno = saved_errno;
+  return str;
+}
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/core/src/firebase/firestore/util/strerror.h
+++ b/Firestore/core/src/firebase/firestore/util/strerror.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_STRERROR_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_STRERROR_H_
+
+#include <string>
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+// A portable and thread-safe alternative to strerror().
+// Returns a human-readable string describing the given POSIX error
+// code. If the error code is not translatable, the string will be
+// "Unknown error nnn". errno will not be modified by this call.
+std::string StrError(int errnum);
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_STRERROR_H_

--- a/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
@@ -129,6 +129,7 @@ cc_test(
     status_test.cc
     status_test_util.h
     statusor_test.cc
+    strerror_test.cc
     string_format_test.cc
     string_util_test.cc
   DEPENDS

--- a/Firestore/core/test/firebase/firestore/util/status_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/status_test.cc
@@ -16,7 +16,10 @@
 
 #include "Firestore/core/src/firebase/firestore/util/status.h"
 
+#include <cerrno>
+
 #include "Firestore/core/test/firebase/firestore/util/status_test_util.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace firebase {
@@ -85,21 +88,29 @@ TEST(Status, EqualsSame) {
 }
 
 TEST(Status, EqualsCopy) {
-  const Status a(FirestoreErrorCode::InvalidArgument, "Invalid");
-  const Status b = a;
+  Status a(FirestoreErrorCode::InvalidArgument, "Invalid");
+  Status b = a;
   ASSERT_EQ(a, b);
 }
 
 TEST(Status, EqualsDifferentCode) {
-  const Status a(FirestoreErrorCode::InvalidArgument, "message");
-  const Status b(FirestoreErrorCode::Internal, "message");
+  Status a(FirestoreErrorCode::InvalidArgument, "message");
+  Status b(FirestoreErrorCode::Internal, "message");
   ASSERT_NE(a, b);
 }
 
 TEST(Status, EqualsDifferentMessage) {
-  const Status a(FirestoreErrorCode::InvalidArgument, "message");
-  const Status b(FirestoreErrorCode::InvalidArgument, "another");
+  Status a(FirestoreErrorCode::InvalidArgument, "message");
+  Status b(FirestoreErrorCode::InvalidArgument, "another");
   ASSERT_NE(a, b);
+}
+
+TEST(Status, FromErrno) {
+  Status a = Status::FromErrno(EEXIST, "Cannot write file");
+  ASSERT_THAT(
+      a.ToString(),
+      testing::MatchesRegex(
+          "Already exists: Cannot write file \\(errno .*: File exists\\)"));
 }
 
 }  // namespace util

--- a/Firestore/core/test/firebase/firestore/util/status_test_util.h
+++ b/Firestore/core/test/firebase/firestore/util/status_test_util.h
@@ -38,7 +38,7 @@ inline testing::AssertionResult Equal(Status expected, Status actual) {
 }  // namespace firestore
 }  // namespace firebase
 
-// Macros for testing the results of functions that return tensorflow::Status.
+// Macros for testing the results of functions that return util::Status.
 #define EXPECT_OK(statement)                      \
   EXPECT_TRUE(::firebase::firestore::util::Equal( \
       ::firebase::firestore::util::Status::OK(), (statement)));
@@ -50,6 +50,6 @@ inline testing::AssertionResult Equal(Status expected, Status actual) {
 // provide much value (when they fail, they would just print the OK status
 // which conveys no more information than EXPECT_FALSE(status.ok());
 // If you want to check for particular errors, a better alternative is:
-// EXPECT_EQ(..expected tensorflow::error::Code..., status.code());
+// EXPECT_EQ(..expected FirestoreErrorCode..., status.code());
 
 #endif  // FIRESTORE_CORE_TEST_FIREBASE_FIRESTORE_UTIL_STATUS_TEST_UTIL_H_

--- a/Firestore/core/test/firebase/firestore/util/status_test_util.h
+++ b/Firestore/core/test/firebase/firestore/util/status_test_util.h
@@ -20,11 +20,31 @@
 #include "Firestore/core/src/firebase/firestore/util/status.h"
 #include "gtest/gtest.h"
 
+namespace firebase {
+namespace firestore {
+namespace util {
+
+inline testing::AssertionResult Equal(Status expected, Status actual) {
+  if (expected != actual) {
+    return testing::AssertionFailure()
+           << "Should have seen status " << expected.ToString() << " but got "
+           << actual.ToString();
+  }
+
+  return testing::AssertionSuccess();
+}
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase
+
 // Macros for testing the results of functions that return tensorflow::Status.
-#define EXPECT_OK(statement) \
-  EXPECT_EQ(::firebase::firestore::util::Status::OK(), (statement))
-#define ASSERT_OK(statement) \
-  ASSERT_EQ(::firebase::firestore::util::Status::OK(), (statement))
+#define EXPECT_OK(statement)                      \
+  EXPECT_TRUE(::firebase::firestore::util::Equal( \
+      ::firebase::firestore::util::Status::OK(), (statement)));
+#define ASSERT_OK(statement)                      \
+  ASSERT_TRUE(::firebase::firestore::util::Equal( \
+      ::firebase::firestore::util::Status::OK(), (statement)));
 
 // There are no EXPECT_NOT_OK/ASSERT_NOT_OK macros since they would not
 // provide much value (when they fail, they would just print the OK status

--- a/Firestore/core/test/firebase/firestore/util/strerror_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/strerror_test.cc
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/util/strerror.h"
+
+#include "gtest/gtest.h"
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+TEST(StrErrorTest, ValidErrorCode) {
+  errno = EAGAIN;
+  EXPECT_EQ(StrError(EINTR), strerror(EINTR));
+  EXPECT_EQ(errno, EAGAIN);
+}
+
+TEST(StrErrorTest, InvalidErrorCode) {
+  errno = EBUSY;
+  EXPECT_EQ(StrError(-1), "Unknown error -1");
+  EXPECT_EQ(errno, EBUSY);
+}
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase


### PR DESCRIPTION
This change:
  * Adds `StrError`, a port of `//base/strerror`.
  * Adds `Status::FromErrno`, which seems like a reasonable path forward without requiring us to bring in the google3-internal (and deprecated) concept of error spaces.
  * Adds `Status::FromNSError`, which is useful for converting errors from e.g. `NSFileManager` to canonical codes.