### PR TITLE
Add pathname manipulation utilities

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		54DA12AE1F315EE100DD57A1 /* resume_token_spec_test.json in Resources */ = {isa = PBXBuildFile; fileRef = 54DA12A41F315EE100DD57A1 /* resume_token_spec_test.json */; };
 		54DA12AF1F315EE100DD57A1 /* write_spec_test.json in Resources */ = {isa = PBXBuildFile; fileRef = 54DA12A51F315EE100DD57A1 /* write_spec_test.json */; };
 		54EB764D202277B30088B8F3 /* array_sorted_map_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54EB764C202277B30088B8F3 /* array_sorted_map_test.cc */; };
+		5A080105CCBFDB6BF3F3772D /* path_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 403DBF6EFB541DFD01582AA3 /* path_test.cc */; };
 		5D405BE298CE4692CB00790A /* Pods_Firestore_Tests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B50B3A0DF77100EEE887891 /* Pods_Firestore_Tests_iOS.framework */; };
 		6003F58E195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F590195388D20070C39A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58F195388D20070C39A /* CoreGraphics.framework */; };
@@ -259,6 +260,7 @@
 		3B843E4A1F3930A400548890 /* remote_store_spec_test.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = remote_store_spec_test.json; sourceTree = "<group>"; };
 		3C81DE3772628FE297055662 /* Pods-Firestore_Example_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_iOS/Pods-Firestore_Example_iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		3F0992A4B83C60841C52E960 /* Pods-Firestore_Example_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_iOS/Pods-Firestore_Example_iOS.release.xcconfig"; sourceTree = "<group>"; };
+		403DBF6EFB541DFD01582AA3 /* path_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = path_test.cc; sourceTree = "<group>"; };
 		444B7AB3F5A2929070CB1363 /* hard_assert_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = hard_assert_test.cc; sourceTree = "<group>"; };
 		54131E9620ADE678001DF3FF /* string_format_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_format_test.cc; sourceTree = "<group>"; };
 		54511E8D209805F8005BD28F /* hashing_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = hashing_test.cc; sourceTree = "<group>"; };
@@ -558,6 +560,7 @@
 				54A0353420A3D8CB003E0143 /* iterator_adaptors_test.cc */,
 				54C2294E1FECABAE007D065B /* log_test.cc */,
 				AB380D03201BC6E400D97691 /* ordered_code_test.cc */,
+				403DBF6EFB541DFD01582AA3 /* path_test.cc */,
 				54740A531FC913E500713A1A /* secure_random_test.cc */,
 				54A0352C20A3B3D7003E0143 /* status_test.cc */,
 				54A0352B20A3B3D7003E0143 /* status_test_util.h */,
@@ -1555,6 +1558,7 @@
 				AB6B908620322E6D00CC290A /* maybe_document_test.cc in Sources */,
 				AB6B908820322E8800CC290A /* no_document_test.cc in Sources */,
 				AB380D04201BC6E400D97691 /* ordered_code_test.cc in Sources */,
+				5A080105CCBFDB6BF3F3772D /* path_test.cc in Sources */,
 				549CCA5920A36E1F00BCEB75 /* precondition_test.cc in Sources */,
 				B686F2B22025000D0028D6BE /* resource_path_test.cc in Sources */,
 				54740A571FC914BA00713A1A /* secure_random_test.cc in Sources */,

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -191,6 +191,8 @@ cc_library(
     iterator_adaptors.h
     ordered_code.cc
     ordered_code.h
+    path.cc
+    path.h
     range.h
     secure_random.h
     status.cc

--- a/Firestore/core/src/firebase/firestore/util/path.cc
+++ b/Firestore/core/src/firebase/firestore/util/path.cc
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/util/path.h"
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+absl::string_view Path::Basename(absl::string_view pathname) {
+  size_t slash = pathname.find_last_of('/');
+
+  if (slash == absl::string_view::npos) {
+    // No path separator found => the whole string.
+    return pathname;
+  }
+
+  // Otherwise everything after the slash is the basename (even if empty string)
+  return pathname.substr(slash + 1);
+}
+
+absl::string_view Path::Dirname(absl::string_view pathname) {
+  size_t slash = pathname.find_last_of('/');
+
+  if (slash == absl::string_view::npos) {
+    // No path separator found => empty string. Conformance with POSIX would
+    // have us return "." here.
+    return pathname.substr(0, 0);
+  }
+
+  // Collapse runs of slashes.
+  size_t nonslash = pathname.find_last_not_of('/', slash);
+  if (nonslash == absl::string_view::npos) {
+    // All characters preceding the last path separator are slashes
+    return pathname.substr(0, 1);
+  }
+
+  slash = nonslash + 1;
+
+  // Otherwise everything up to the slash is the parent directory
+  return pathname.substr(0, slash);
+}
+
+bool Path::IsAbsolute(absl::string_view path) {
+#if defined(_WIN32)
+#error "Handle drive letters"
+
+#else
+  return !path.empty() && path.front() == '/';
+#endif
+}
+
+void Path::JoinAppend(std::string* base, absl::string_view path) {
+  if (IsAbsolute(path)) {
+    base->clear();
+    base->append(path.data(), path.size());
+
+  } else {
+    size_t nonslash = base->find_last_not_of('/');
+    if (nonslash != std::string::npos) {
+      base->resize(nonslash + 1);
+      base->push_back('/');
+    }
+
+    // If path started with a slash we'd treat it as absolute above
+    base->append(path.data(), path.size());
+  }
+}
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/core/src/firebase/firestore/util/path.cc
+++ b/Firestore/core/src/firebase/firestore/util/path.cc
@@ -33,25 +33,25 @@ absl::string_view Path::Basename(absl::string_view pathname) {
 }
 
 absl::string_view Path::Dirname(absl::string_view pathname) {
-  size_t slash = pathname.find_last_of('/');
+  size_t last_slash = pathname.find_last_of('/');
 
-  if (slash == absl::string_view::npos) {
+  if (last_slash == absl::string_view::npos) {
     // No path separator found => empty string. Conformance with POSIX would
     // have us return "." here.
     return pathname.substr(0, 0);
   }
 
   // Collapse runs of slashes.
-  size_t nonslash = pathname.find_last_not_of('/', slash);
+  size_t nonslash = pathname.find_last_not_of('/', last_slash);
   if (nonslash == absl::string_view::npos) {
     // All characters preceding the last path separator are slashes
     return pathname.substr(0, 1);
   }
 
-  slash = nonslash + 1;
+  last_slash = nonslash + 1;
 
   // Otherwise everything up to the slash is the parent directory
-  return pathname.substr(0, slash);
+  return pathname.substr(0, last_slash);
 }
 
 bool Path::IsAbsolute(absl::string_view path) {
@@ -65,8 +65,7 @@ bool Path::IsAbsolute(absl::string_view path) {
 
 void Path::JoinAppend(std::string* base, absl::string_view path) {
   if (IsAbsolute(path)) {
-    base->clear();
-    base->append(path.data(), path.size());
+    base->assign(path.data(), path.size());
 
   } else {
     size_t nonslash = base->find_last_not_of('/');

--- a/Firestore/core/src/firebase/firestore/util/path.h
+++ b/Firestore/core/src/firebase/firestore/util/path.h
@@ -28,12 +28,22 @@ namespace util {
 
 struct Path {
   /**
-   * Returns the unqualified trailing part of the pathname, e.g. "b" for "/a/b".
+   * Returns the unqualified trailing part of the pathname, e.g. "c" for
+   * "/a/b/c".
    */
   static absl::string_view Basename(absl::string_view pathname);
 
   /**
-   * Returns the parent directory name, e.g. "/a" for "/a/b".
+   * Returns the parent directory name, e.g. "/a/b" for "/a/b/c".
+   *
+   * Note:
+   *   * Trailing slashes are treated as a separator between an empty path
+   *     segment and the dirname, so Dirname("/a/b/c/") is "/a/b/c".
+   *   * Runs of more than one slash are treated as a single separator, so
+   *     Dirname("/a/b//c") is "/a/b".
+   *   * Paths are not canonicalized, so Dirname("/a//b//c") is "/a//b".
+   *   * Presently only UNIX style paths are supported (but compilation
+   *     intentionally fails on Windows to prompt implementation there).
    */
   static absl::string_view Dirname(absl::string_view pathname);
 
@@ -41,13 +51,6 @@ struct Path {
    * Returns true if the given `pathname` is an absolute path.
    */
   static bool IsAbsolute(absl::string_view pathname);
-
-  /**
-   * Returns the paths separated by path separators.
-   */
-  static std::string Join() {
-    return {};
-  }
 
   /**
    * Returns the paths separated by path separators.
@@ -63,18 +66,17 @@ struct Path {
     return result;
   }
 
- private:
   /**
-   * Joins the given base path with a suffix. If `path` is absolute, replaces
-   * `base`.
+   * Returns the paths separated by path separators.
    */
-  static void JoinAppend(std::string* base) {
-    (void)base;
+  static std::string Join() {
+    return {};
   }
 
+ private:
   /**
-   * Joins the given base path with a suffix. If `path` is absolute, replaces
-   * `base`.
+   * Joins the given base path with a suffix. If `path` is relative, appends it
+   * to the given base path. If `path` is absolute, replaces `base`.
    */
   static void JoinAppend(std::string* base, absl::string_view path);
 
@@ -84,6 +86,11 @@ struct Path {
                          const S&... rest) {
     JoinAppend(base, path);
     JoinAppend(base, rest...);
+  }
+
+  static void JoinAppend(std::string* base) {
+    // Recursive base case; nothing to do.
+    (void)base;
   }
 };
 

--- a/Firestore/core/src/firebase/firestore/util/path.h
+++ b/Firestore/core/src/firebase/firestore/util/path.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_PATH_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_PATH_H_
+
+#include <string>
+#include <utility>
+
+#include "absl/strings/string_view.h"
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+struct Path {
+  /**
+   * Returns the unqualified trailing part of the pathname, e.g. "b" for "/a/b".
+   */
+  static absl::string_view Basename(absl::string_view pathname);
+
+  /**
+   * Returns the parent directory name, e.g. "/a" for "/a/b".
+   */
+  static absl::string_view Dirname(absl::string_view pathname);
+
+  /**
+   * Returns true if the given `pathname` is an absolute path.
+   */
+  static bool IsAbsolute(absl::string_view pathname);
+
+  /**
+   * Returns the paths separated by path separators.
+   */
+  static std::string Join() {
+    return {};
+  }
+
+  /**
+   * Returns the paths separated by path separators.
+   *
+   * @param base If base is of type std::string&& the result is moved from this
+   *     value. Otherwise the first argument is copied.
+   * @param paths The rest of the path segments.
+   */
+  template <typename S1, typename... SA>
+  static std::string Join(S1&& base, const SA&... paths) {
+    std::string result{std::forward<S1>(base)};
+    JoinAppend(&result, paths...);
+    return result;
+  }
+
+ private:
+  /**
+   * Joins the given base path with a suffix. If `path` is absolute, replaces
+   * `base`.
+   */
+  static void JoinAppend(std::string* base) {
+    (void)base;
+  }
+
+  /**
+   * Joins the given base path with a suffix. If `path` is absolute, replaces
+   * `base`.
+   */
+  static void JoinAppend(std::string* base, absl::string_view path);
+
+  template <typename... S>
+  static void JoinAppend(std::string* base,
+                         absl::string_view path,
+                         const S&... rest) {
+    JoinAppend(base, path);
+    JoinAppend(base, rest...);
+  }
+};
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_PATH_H_

--- a/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
@@ -126,6 +126,7 @@ cc_test(
     hashing_test.cc
     iterator_adaptors_test.cc
     ordered_code_test.cc
+    path_test.cc
     status_test.cc
     status_test_util.h
     statusor_test.cc

--- a/Firestore/core/test/firebase/firestore/util/path_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/path_test.cc
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/util/path.h"
+
+#include "gtest/gtest.h"
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+#define EXPECT_BASENAME_EQ(expected, source)                  \
+  do {                                                        \
+    EXPECT_EQ(std::string{expected}, Path::Basename(source)); \
+  } while (0)
+
+TEST(Path, Basename_NoSeparator) {
+  // POSIX would require all of these to be ".".
+  // python and libc++ agree this is "".
+  EXPECT_BASENAME_EQ("", "");
+  EXPECT_BASENAME_EQ("a", "a");
+  EXPECT_BASENAME_EQ("foo", "foo");
+  EXPECT_BASENAME_EQ(".", ".");
+  EXPECT_BASENAME_EQ("..", "..");
+}
+
+TEST(Path, Basename_LeadingSlash) {
+  EXPECT_BASENAME_EQ("", "/");
+  EXPECT_BASENAME_EQ("", "///");
+  EXPECT_BASENAME_EQ("a", "/a");
+  EXPECT_BASENAME_EQ("a", "//a");
+
+  EXPECT_BASENAME_EQ(".", "/.");
+  EXPECT_BASENAME_EQ("..", "/..");
+  EXPECT_BASENAME_EQ("..", "//..");
+}
+
+TEST(Path, Basename_IntermediateSlash) {
+  EXPECT_BASENAME_EQ("b", "/a/b");
+  EXPECT_BASENAME_EQ("b", "/a//b");
+  EXPECT_BASENAME_EQ("b", "//a/b");
+  EXPECT_BASENAME_EQ("b", "//a//b");
+
+  EXPECT_BASENAME_EQ("b", "//..//b");
+  EXPECT_BASENAME_EQ("b", "//a/./b");
+  EXPECT_BASENAME_EQ("b", "//a/.//b");
+}
+
+TEST(Path, Basename_TrailingSlash) {
+  // POSIX: "a/b//" => "b"
+  // python: "a/b//" => ""
+  // libc++: "a/b//" => "." (cppreference: "")
+  EXPECT_BASENAME_EQ("", "/a/");
+  EXPECT_BASENAME_EQ("", "/a///");
+
+  EXPECT_BASENAME_EQ("", "/a/b/");
+  EXPECT_BASENAME_EQ("", "/a/b//");
+  EXPECT_BASENAME_EQ("", "/a//b//");
+  EXPECT_BASENAME_EQ("", "//a//b//");
+}
+
+TEST(Path, Basename_RelativePath) {
+  EXPECT_BASENAME_EQ("b", "a/b");
+  EXPECT_BASENAME_EQ("b", "a//b");
+
+  EXPECT_BASENAME_EQ("b", "..//b");
+  EXPECT_BASENAME_EQ("b", "a/./b");
+  EXPECT_BASENAME_EQ("b", "a/.//b");
+  EXPECT_BASENAME_EQ("b", "a//.//b");
+}
+
+#define EXPECT_DIRNAME_EQ(expected, source)                  \
+  do {                                                       \
+    EXPECT_EQ(std::string{expected}, Path::Dirname(source)); \
+  } while (0)
+
+TEST(Path, Dirname_NoSeparator) {
+  // POSIX would require all of these to be ".".
+  // python and libc++ agree this is "".
+  EXPECT_DIRNAME_EQ("", "");
+  EXPECT_DIRNAME_EQ("", "a");
+  EXPECT_DIRNAME_EQ("", "foo");
+  EXPECT_DIRNAME_EQ("", ".");
+  EXPECT_DIRNAME_EQ("", "..");
+}
+
+TEST(Path, Dirname_LeadingSlash) {
+  // POSIX says all "/".
+  // python starts with "/" but does not strip trailing slashes.
+  // libc++ considers all of these be "", though cppreference.com indicates
+  // this should be "/" in example output so this is likely a bug.
+  EXPECT_DIRNAME_EQ("/", "/");
+  EXPECT_DIRNAME_EQ("/", "///");
+  EXPECT_DIRNAME_EQ("/", "/a");
+  EXPECT_DIRNAME_EQ("/", "//a");
+
+  EXPECT_DIRNAME_EQ("/", "/.");
+  EXPECT_DIRNAME_EQ("/", "/..");
+  EXPECT_DIRNAME_EQ("/", "//..");
+}
+
+TEST(Path, Dirname_IntermediateSlash) {
+  EXPECT_DIRNAME_EQ("/a", "/a/b");
+  EXPECT_DIRNAME_EQ("/a", "/a//b");
+  EXPECT_DIRNAME_EQ("//a", "//a/b");
+  EXPECT_DIRNAME_EQ("//a", "//a//b");
+
+  EXPECT_DIRNAME_EQ("//..", "//..//b");
+  EXPECT_DIRNAME_EQ("//a/.", "//a/./b");
+  EXPECT_DIRNAME_EQ("//a/.", "//a/.//b");
+}
+
+TEST(Path, Dirname_TrailingSlash) {
+  // POSIX demands stripping trailing slashes before computing dirname, while
+  // python and libc++ effectively seem to consider the path to contain an empty
+  // path segment there.
+  EXPECT_DIRNAME_EQ("/a", "/a/");
+  EXPECT_DIRNAME_EQ("/a", "/a///");
+
+  EXPECT_DIRNAME_EQ("/a/b", "/a/b/");
+  EXPECT_DIRNAME_EQ("/a/b", "/a/b//");
+  EXPECT_DIRNAME_EQ("/a//b", "/a//b//");
+  EXPECT_DIRNAME_EQ("//a//b", "//a//b//");
+}
+
+TEST(Path, Dirname_RelativePath) {
+  EXPECT_DIRNAME_EQ("a", "a/b");
+  EXPECT_DIRNAME_EQ("a", "a//b");
+
+  EXPECT_DIRNAME_EQ("..", "..//b");
+  EXPECT_DIRNAME_EQ("a/.", "a/./b");
+  EXPECT_DIRNAME_EQ("a/.", "a/.//b");
+  EXPECT_DIRNAME_EQ("a//.", "a//.//b");
+}
+
+TEST(Path, IsAbsolute) {
+  EXPECT_FALSE(Path::IsAbsolute(""));
+  EXPECT_TRUE(Path::IsAbsolute("/"));
+  EXPECT_TRUE(Path::IsAbsolute("//"));
+  EXPECT_TRUE(Path::IsAbsolute("/foo"));
+  EXPECT_FALSE(Path::IsAbsolute("foo"));
+  EXPECT_FALSE(Path::IsAbsolute("foo/bar"));
+}
+
+TEST(Path, Join_Absolute) {
+  EXPECT_EQ("/", Path::Join("/"));
+
+  EXPECT_EQ("/", Path::Join("", "/"));
+  EXPECT_EQ("/", Path::Join("a", "/"));
+  EXPECT_EQ("/b", Path::Join("a", "/b"));
+
+  // Alternate root names should be preserved.
+  EXPECT_EQ("//", Path::Join("a", "//"));
+  EXPECT_EQ("//b", Path::Join("a", "//b"));
+  EXPECT_EQ("///b///", Path::Join("a", "///b///"));
+
+  EXPECT_EQ("/", Path::Join("/", "/"));
+  EXPECT_EQ("/b", Path::Join("/", "/b"));
+  EXPECT_EQ("//b", Path::Join("//host/a", "//b"));
+  EXPECT_EQ("//b", Path::Join("//host/a/", "//b"));
+
+  EXPECT_EQ("/", Path::Join("/", ""));
+  EXPECT_EQ("/a", Path::Join("/", "a"));
+  EXPECT_EQ("/a/b/c", Path::Join("/", "a", "b", "c"));
+  EXPECT_EQ("/a/", Path::Join("/", "a/"));
+  EXPECT_EQ("/.", Path::Join("/", "."));
+  EXPECT_EQ("/..", Path::Join("/", ".."));
+}
+
+TEST(Path, Join_Relative) {
+  EXPECT_EQ("", Path::Join(""));
+
+  EXPECT_EQ("", Path::Join("", "", "", ""));
+  EXPECT_EQ("a/b/c", Path::Join("a/b", "c"));
+  EXPECT_EQ("/c/d", Path::Join("a/b", "/c", "d"));
+}
+
+TEST(Path, Join_Types) {
+  EXPECT_EQ("a/b", Path::Join(absl::string_view{"a"}, "b"));
+  EXPECT_EQ("a/b", Path::Join(std::string{"a"}, "b"));
+
+  std::string a_string{"a"};
+  EXPECT_EQ("a/b", Path::Join(a_string, "b"));
+  EXPECT_EQ("a", a_string);
+}
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase


### PR DESCRIPTION
I can't believe it's 2018 and I'm writing this code, but here I am...

Note that `std::filesystem` is not available yet but no version of it has yet been released with Xcode. There is a version of `std::experimental::filesystem` available in llvm-6.0 that I kicked the tires on, but this doesn't really even matter because we're targeting C++11 systems.

I've chosen not to mirror the proposed standard primarily because it's significantly more complicated than I need. I just need to be able to put paths together and do the equivalent of `dirname(1)`.