### PR TITLE
Consistent specification of preprocessor options in podspecs to work with the CocoaPods packager

### DIFF
--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -33,7 +33,8 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   ]
   s.dependency 'GoogleToolboxForMac/NSData+zlib', '~> 2.1'
   s.pod_target_xcconfig = {
-    'OTHER_CFLAGS' => '-fno-autolink ' +
-      '-DFIRCore_VERSION=' + s.version.to_s + ' -DFirebase_VERSION=5.1.0'
+    'OTHER_CFLAGS' => '-fno-autolink',
+    'GCC_PREPROCESSOR_DEFINITIONS' =>
+      'FIRCore_VERSION=' + s.version.to_s + ' Firebase_VERSION=5.1.0'
   }
 end

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -61,7 +61,8 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
       '"${PODS_TARGET_SRCROOT}/Firestore/third_party/abseil-cpp" ' +
       '"${PODS_ROOT}/nanopb" ' +
       '"${PODS_TARGET_SRCROOT}/Firestore/Protos/nanopb"',
-    'OTHER_CFLAGS' => '-DFIRFirestore_VERSION=' + s.version.to_s + ' -DPB_FIELD_16BIT'
+    'GCC_PREPROCESSOR_DEFINITIONS' =>
+      'FIRFirestore_VERSION=' + s.version.to_s + ' PB_FIELD_16BIT'
   }
 
   s.prepare_command = <<-CMD

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -55,14 +55,13 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.frameworks = 'MobileCoreServices'
   s.library = 'c++'
   s.pod_target_xcconfig = {
-    'GCC_PREPROCESSOR_DEFINITIONS' => 'GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1 ',
+    'GCC_PREPROCESSOR_DEFINITIONS' => 'GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1 ' +
+      'FIRFirestore_VERSION=' + s.version.to_s + ' PB_FIELD_16BIT',
     'HEADER_SEARCH_PATHS' =>
       '"${PODS_TARGET_SRCROOT}" ' +
       '"${PODS_TARGET_SRCROOT}/Firestore/third_party/abseil-cpp" ' +
       '"${PODS_ROOT}/nanopb" ' +
-      '"${PODS_TARGET_SRCROOT}/Firestore/Protos/nanopb"',
-    'GCC_PREPROCESSOR_DEFINITIONS' =>
-      'FIRFirestore_VERSION=' + s.version.to_s + ' PB_FIELD_16BIT'
+      '"${PODS_TARGET_SRCROOT}/Firestore/Protos/nanopb"'
   }
 
   s.prepare_command = <<-CMD


### PR DESCRIPTION
Fix #1369.

The CocoaPods [packager](https://github.com/CocoaPods/cocoapods-packager) does not process preprocessor flags specified in `OTHER_CFLAGS` and will fail to build. FirebaseCore should be consistent and define them in `GCC_PREPROCESSOR_DEFINITIONS` anyways.