### PR TITLE
Allowing field deletes using merge fields

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_FuzzTests_iOS.xcscheme
+++ b/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_FuzzTests_iOS.xcscheme
@@ -5,6 +5,19 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForRunning = "YES"
+            buildForTesting = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6EDD3AD120BF247500C33877"
+               BuildableName = "Firestore_FuzzTests_iOS.xctest"
+               BlueprintName = "Firestore_FuzzTests_iOS"
+               ReferencedContainer = "container:Firestore.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"

--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
@@ -274,11 +274,6 @@
     @"inner" : @{@"foo" : [FIRFieldValue fieldValueForServerTimestamp]},
     @"nested" : @{@"foo" : [FIRFieldValue fieldValueForServerTimestamp]}
   };
-  NSDictionary<NSString *, id> *finalData =
-      @{ @"untouched" : @YES,
-         @"foo" : @"bar",
-         @"inner" : @{},
-         @"nested" : @{@"untouched" : @YES} };
 
   [self writeDocumentRef:doc data:initialData];
 

--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
@@ -162,8 +162,10 @@
   NSDictionary<NSString *, id> *initialData = @{
     @"updated" : @NO,
   };
-  NSDictionary<NSString *, id> *mergeData =
-      @{@"time" : [FIRFieldValue fieldValueForServerTimestamp]};
+  NSDictionary<NSString *, id> *mergeData = @{
+    @"time" : [FIRFieldValue fieldValueForServerTimestamp],
+    @"nested" : @{@"time" : [FIRFieldValue fieldValueForServerTimestamp]}
+  };
 
   [self writeDocumentRef:doc data:initialData];
 
@@ -182,6 +184,7 @@
   FIRDocumentSnapshot *document = [self readDocumentForRef:doc];
   XCTAssertEqual(document[@"updated"], @NO);
   XCTAssertTrue([document[@"time"] isKindOfClass:[FIRTimestamp class]]);
+  XCTAssertTrue([document[@"nested.time"] isKindOfClass:[FIRTimestamp class]]);
 }
 
 - (void)testCanDeleteFieldUsingMerge {
@@ -216,6 +219,86 @@
   XCTAssertNil(document[@"foo"]);
   XCTAssertEqual(document[@"nested.untouched"], @YES);
   XCTAssertNil(document[@"nested.foo"]);
+}
+
+- (void)testCanDeleteFieldUsingMergeFields {
+  FIRDocumentReference *doc = [[self.db collectionWithPath:@"rooms"] documentWithAutoID];
+
+  NSDictionary<NSString *, id> *initialData = @{
+    @"untouched" : @YES,
+    @"foo" : @"bar",
+    @"inner" : @{@"removed" : @YES, @"foo" : @"bar"},
+    @"nested" : @{@"untouched" : @YES, @"foo" : @"bar"}
+  };
+  NSDictionary<NSString *, id> *mergeData = @{
+    @"foo" : [FIRFieldValue fieldValueForDelete],
+    @"inner" : @{@"foo" : [FIRFieldValue fieldValueForDelete]},
+    @"nested" : @{
+      @"untouched" : [FIRFieldValue fieldValueForDelete],
+      @"foo" : [FIRFieldValue fieldValueForDelete]
+    }
+  };
+  NSDictionary<NSString *, id> *finalData =
+      @{ @"untouched" : @YES,
+         @"inner" : @{},
+         @"nested" : @{@"untouched" : @YES} };
+
+  [self writeDocumentRef:doc data:initialData];
+
+  XCTestExpectation *completed =
+      [self expectationWithDescription:@"testCanMergeDataWithAnExistingDocumentUsingSet"];
+
+  [doc setData:mergeData
+      mergeFields:@[ @"foo", @"inner", @"nested.foo" ]
+       completion:^(NSError *error) {
+         XCTAssertNil(error);
+         [completed fulfill];
+       }];
+
+  [self awaitExpectations];
+
+  FIRDocumentSnapshot *document = [self readDocumentForRef:doc];
+  XCTAssertEqualObjects([document data], finalData);
+}
+
+- (void)testCanSetServerTimestampsUsingMergeFields {
+  FIRDocumentReference *doc = [[self.db collectionWithPath:@"rooms"] documentWithAutoID];
+
+  NSDictionary<NSString *, id> *initialData = @{
+    @"untouched" : @YES,
+    @"foo" : @"bar",
+    @"nested" : @{@"untouched" : @YES, @"foo" : @"bar"}
+  };
+  NSDictionary<NSString *, id> *mergeData = @{
+    @"foo" : [FIRFieldValue fieldValueForServerTimestamp],
+    @"inner" : @{@"foo" : [FIRFieldValue fieldValueForServerTimestamp]},
+    @"nested" : @{@"foo" : [FIRFieldValue fieldValueForServerTimestamp]}
+  };
+  NSDictionary<NSString *, id> *finalData =
+      @{ @"untouched" : @YES,
+         @"foo" : @"bar",
+         @"inner" : @{},
+         @"nested" : @{@"untouched" : @YES} };
+
+  [self writeDocumentRef:doc data:initialData];
+
+  XCTestExpectation *completed =
+      [self expectationWithDescription:@"testCanMergeDataWithAnExistingDocumentUsingSet"];
+
+  [doc setData:mergeData
+      mergeFields:@[ @"foo", @"inner", @"nested.foo" ]
+       completion:^(NSError *error) {
+         XCTAssertNil(error);
+         [completed fulfill];
+       }];
+
+  [self awaitExpectations];
+
+  FIRDocumentSnapshot *document = [self readDocumentForRef:doc];
+  XCTAssertTrue([document exists]);
+  XCTAssertTrue([document[@"foo"] isKindOfClass:[FIRTimestamp class]]);
+  XCTAssertTrue([document[@"inner.foo"] isKindOfClass:[FIRTimestamp class]]);
+  XCTAssertTrue([document[@"nested.foo"] isKindOfClass:[FIRTimestamp class]]);
 }
 
 - (void)testMergeReplacesArrays {

--- a/Firestore/Source/API/FSTUserDataConverter.mm
+++ b/Firestore/Source/API/FSTUserDataConverter.mm
@@ -335,13 +335,13 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
 }
 
 - (BOOL)containsFieldPath:(const FieldPath &)fieldPath {
-  for (FieldPath field : *_fieldMask) {
+  for (const FieldPath &field : *_fieldMask) {
     if (fieldPath.IsPrefixOf(field)) {
       return YES;
     }
   }
 
-  for (FieldTransform fieldTransform : *_fieldTransforms) {
+  for (const FieldTransform &fieldTransform : *_fieldTransforms) {
     if (fieldPath.IsPrefixOf(fieldTransform.path())) {
       return YES;
     }

--- a/Firestore/Source/API/FSTUserDataConverter.mm
+++ b/Firestore/Source/API/FSTUserDataConverter.mm
@@ -218,6 +218,9 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
 /** Returns true for the non-query parse contexts (Set, MergeSet and Update) */
 - (BOOL)isWrite;
 
+/** Returns 'YES' if 'fieldPath' was traversed when creating this context. */
+- (BOOL)containsFieldPath:(const FieldPath &)fieldPath;
+
 - (const FieldPath *)path;
 
 - (const std::vector<FieldPath> *)fieldMask;
@@ -329,6 +332,22 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
     default:
       FSTThrowInvalidArgument(@"Unexpected case for FSTUserDataSource: %d", self.dataSource);
   }
+}
+
+- (BOOL)containsFieldPath:(const FieldPath &)fieldPath {
+  for (FieldPath field : *_fieldMask) {
+    if (fieldPath.IsPrefixOf(field)) {
+      return YES;
+    }
+  }
+
+  for (FieldTransform fieldTransform : *_fieldTransforms) {
+    if (fieldPath.IsPrefixOf(fieldTransform.path())) {
+      return YES;
+    }
+  }
+
+  return NO;
 }
 
 - (void)validatePath {
@@ -444,7 +463,8 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
             @"All elements in mergeFields: must be NSStrings or FIRFieldPaths.");
       }
 
-      if ([updateData valueForPath:path] == nil) {
+      // Verify that all elements specified in the field mask are part of the parsed context.
+      if (![context containsFieldPath:path]) {
         FSTThrowInvalidArgument(
             @"Field '%s' is specified in your field mask but missing from your input data.",
             path.CanonicalString().c_str());


### PR DESCRIPTION
The validation for set(data, mergeFields:...) rejected field paths that pointed to field deletes/transforms since these are stripped from the update data. This PR checks the field mask (for field deletes) and the list of field transforms (for server timestamps) to validate mergeFields.

This is a port of https://github.com/FirebasePrivate/firebase-android-sdk/pull/2