### PR TITLE
Fix protobuf/nanopb builds on Windows

### DIFF
--- a/cmake/FindNanopb.cmake
+++ b/cmake/FindNanopb.cmake
@@ -24,7 +24,7 @@ find_path(
 find_library(
   NANOPB_LIBRARY
   NAMES protobuf-nanopb protobuf-nanopbd
-  HINTS ${BINARY_DIR}/src/nanopb
+  HINTS ${BINARY_DIR}/src/nanopb-build
 )
 
 find_package_handle_standard_args(

--- a/cmake/FindProtobuf.cmake
+++ b/cmake/FindProtobuf.cmake
@@ -23,14 +23,14 @@ find_path(
 
 find_library(
   PROTOBUF_LIBRARY
-  NAMES libprotobuf.a
-  HINTS ${BINARY_DIR}/src/protobuf-build/src/.libs/
+  NAMES protobuf protobufd
+  HINTS ${BINARY_DIR}/src/protobuf-build
 )
 
 find_library(
   PROTOBUFLITE_LIBRARY
-  NAMES libprotobuf-lite.a
-  HINTS ${BINARY_DIR}/src/protobuf-build/src/.libs/
+  NAMES protobuf-lite protobuf-lited
+  HINTS ${BINARY_DIR}/src/protobuf-build
 )
 
 find_package_handle_standard_args(

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -33,6 +33,17 @@ else()
     -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
     -DgRPC_BUILD_TESTS:BOOL=OFF
     -DBUILD_SHARED_LIBS:BOOL=OFF
+
+    # TODO(rsgowman): We're currently building nanopb twice; once via grpc, and
+    # once via nanopb. The version from grpc is the one that actually ends up
+    # being used. We need to fix this such that either:
+    #   a) we instruct grpc to use our nanopb
+    #   b) we rely on grpc's nanopb instead of using our own.
+    # For now, we'll pass in the necessary nanopb cflags into grpc. (We require
+    # 16 bit fields. Without explicitly requesting this, nanopb uses 8 bit
+    # fields.)
+    -DCMAKE_C_FLAGS=-DPB_FIELD_16BIT
+    -DCMAKE_CXX_FLAGS=-DPB_FIELD_16BIT
   )
 
   # zlib can be built by grpc but we can avoid it on platforms that provide it
@@ -68,15 +79,8 @@ else()
 
     PREFIX ${PROJECT_BINARY_DIR}/external/grpc
 
-    # TODO(rsgowman): We're currently building nanopb twice; once via grpc, and
-    # once via nanopb. The version from grpc is the one that actually ends up
-    # being used. We need to fix this such that either:
-    # a) we instruct grpc to use our nanopb
-    # b) we rely on grpc's nanopb instead of using our own.
-    # For now, we'll pass in the necessary nanopb cflags into grpc. (We require
-    # 16 bit fields. Without explicitly requesting this, nanopb uses 8 bit
-    # fields.)
-    CMAKE_ARGS ${CMAKE_ARGS};-DCMAKE_C_FLAGS=-DPB_FIELD_16BIT;DCMAKE_CXX_FLAGS=-DPB_FIELD_16BIT
+    CMAKE_ARGS
+      ${CMAKE_ARGS}
 
     BUILD_COMMAND
       ${CMAKE_COMMAND} --build . --target grpc

--- a/cmake/external/nanopb.cmake
+++ b/cmake/external/nanopb.cmake
@@ -14,7 +14,7 @@ include(ExternalProject)
 
 set(
   NANOPB_PROTOC_BIN
-  ${FIREBASE_INSTALL_DIR}/external/protobuf/src/protobuf-build/src/protoc
+  ${FIREBASE_INSTALL_DIR}/external/protobuf/src/protobuf-build/protoc
 )
 
 ExternalProject_Add(

--- a/cmake/external/nanopb.cmake
+++ b/cmake/external/nanopb.cmake
@@ -23,42 +23,20 @@ ExternalProject_Add(
     protobuf
 
   DOWNLOAD_DIR ${PROJECT_BINARY_DIR}/downloads
-  URL https://github.com/nanopb/nanopb/archive/nanopb-0.3.8.tar.gz
-  URL_HASH SHA256=f192c7c7cc036be36babc303b7d2315d4f62e2fe4be28c172cfed4cfa0ed5f22
+  URL https://github.com/nanopb/nanopb/archive/nanopb-0.3.9.1.tar.gz
+  URL_HASH SHA256=67460d0c0ad331ef4d5369ad337056d0cd2f900c94887628d287eb56c69324bc
 
   BUILD_IN_SOURCE ON
 
   PREFIX ${PROJECT_BINARY_DIR}/external/nanopb
 
-  # Note for (not yet released) nanopb 0.4.0: nanopb will (likely) switch to
-  # cmake for the protoc plugin. Set these additional cmake variables to use
-  # it.
-  #   -Dnanopb_BUILD_GENERATOR:BOOL=ON
-  #   -Dnanopb_PROTOC_PATH:STRING=${FIREBASE_INSTALL_DIR}/external/protobuf/src/protobuf-build/src/protoc
   CMAKE_ARGS
     -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
     -DBUILD_SHARED_LIBS:BOOL=OFF
-
-  BUILD_COMMAND
-  COMMAND
-    ${CMAKE_COMMAND} --build .
-  # NB: The following additional command is only necessary to regenerate the
-  # nanopb proto files.
-  COMMAND
-    make -C <SOURCE_DIR>/generator/proto
-
-  # nanopb relies on $PATH for the location of protoc. cmake makes it difficult
-  # to adjust the path, so we'll just patch the build files with the exact
-  # location of protoc.
-  #
-  # NB: cmake sometimes runs the patch command multiple times in the same src
-  # dir, so we need to make sure this is idempotent. (eg 'make && make clean &&
-  # make')
-  PATCH_COMMAND
-    grep ${NANOPB_PROTOC_BIN} ./generator/proto/Makefile
-      || perl -i -pe s,protoc,${NANOPB_PROTOC_BIN},g
-           ./CMakeLists.txt ./generator/proto/Makefile
+    -Dnanopb_BUILD_GENERATOR:BOOL=ON
+    -Dnanopb_PROTOC_PATH:STRING=${NANOPB_PROTOC_BIN}
 
   UPDATE_COMMAND ""
+  TEST_COMMAND ""
   INSTALL_COMMAND ""
 )

--- a/cmake/external/nanopb.cmake
+++ b/cmake/external/nanopb.cmake
@@ -1,4 +1,6 @@
-# Copyright 2018 Google # # Licensed under the Apache License, Version 2.0 (the "License");
+# Copyright 2018 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #

--- a/cmake/external/nanopb.cmake
+++ b/cmake/external/nanopb.cmake
@@ -14,7 +14,7 @@ include(ExternalProject)
 
 set(
   NANOPB_PROTOC_BIN
-  ${FIREBASE_INSTALL_DIR}/external/protobuf/src/protobuf-build/protoc
+  ${FIREBASE_INSTALL_DIR}/external/protobuf/src/protobuf-build/${CMAKE_CFG_INTDIR}/protoc
 )
 
 ExternalProject_Add(

--- a/cmake/external/nanopb.cmake
+++ b/cmake/external/nanopb.cmake
@@ -26,8 +26,6 @@ ExternalProject_Add(
   URL https://github.com/nanopb/nanopb/archive/nanopb-0.3.9.1.tar.gz
   URL_HASH SHA256=67460d0c0ad331ef4d5369ad337056d0cd2f900c94887628d287eb56c69324bc
 
-  BUILD_IN_SOURCE ON
-
   PREFIX ${PROJECT_BINARY_DIR}/external/nanopb
 
   CMAKE_ARGS

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -24,8 +24,18 @@ ExternalProject_Add(
 
   PREFIX ${PROJECT_BINARY_DIR}/external/protobuf
 
+  # protobuf ships CMake files but not at the root of the repo, which confuses
+  # CMake by default. Unfortunately when you override CONFIGURE_COMMAND like
+  # this, CMake no longer automatically plumbs in CMAKE_ARGS and friends so
+  # those need to be manually passed in this command line.
+  CONFIGURE_COMMAND
+    ${CMAKE_COMMAND}
+      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+      -DCMAKE_INSTALL_PREFIX:PATH=${FIREBASE_INSTALL_DIR}
+      -Dprotobuf_BUILD_TESTS=OFF
+      ${PROJECT_BINARY_DIR}/external/protobuf/src/protobuf/cmake
+
   UPDATE_COMMAND ""
-  CONFIGURE_COMMAND cd <SOURCE_DIR> && ./autogen.sh
-    COMMAND <SOURCE_DIR>/configure --prefix=${PREFIX}
+  TEST_COMMAND ""
   INSTALL_COMMAND ""
 )


### PR DESCRIPTION
This includes:
  * Build protobuf with cmake instead of autotools
  * Build the nanopb protoc plugin with cmake
  * Windows build compatibility changes