### PR TITLE
Remove unused static logging variable.

### DIFF
--- a/Example/Core/Tests/FIRLoggerTest.m
+++ b/Example/Core/Tests/FIRLoggerTest.m
@@ -37,10 +37,6 @@ extern dispatch_queue_t getFIRClientQueue(void);
 
 extern BOOL getFIRLoggerDebugMode(void);
 
-// Define the message format again to make sure the format doesn't accidentally change.
-static NSString *const kCorrectASLMessageFormat =
-    @"$((Time)(J.3)) $(Sender)[$(PID)] <$((Level)(str))> $Message";
-
 static NSString *const kMessageCode = @"I-COR000001";
 
 @interface FIRLoggerTest : FIRTestCase

--- a/Example/Core/Tests/FIRLoggerTest.m
+++ b/Example/Core/Tests/FIRLoggerTest.m
@@ -29,8 +29,6 @@ extern NSString *const kFIRPersistedDebugModeKey;
 
 extern const char *kFIRLoggerASLClientFacilityName;
 
-extern const char *kFIRLoggerCustomASLMessageFormat;
-
 extern void FIRResetLogger(void);
 
 extern aslclient getFIRLoggerClient(void);
@@ -71,10 +69,6 @@ static NSString *const kMessageCode = @"I-COR000001";
 
 // Test some stable variables to make sure they weren't accidently changed.
 - (void)testStableVariables {
-  // kFIRLoggerCustomASLMessageFormat.
-  XCTAssertEqualObjects(kCorrectASLMessageFormat,
-                        [NSString stringWithUTF8String:kFIRLoggerCustomASLMessageFormat]);
-
   // Strings of type FIRLoggerServices.
   XCTAssertEqualObjects(kFIRLoggerABTesting, @"[Firebase/ABTesting]");
   XCTAssertEqualObjects(kFIRLoggerAdMob, @"[Firebase/AdMob]");

--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -54,10 +54,6 @@ NSString *const kFIRPersistedDebugModeKey = @"/google/firebase/debug_mode";
 /// ASL client facility name used by FIRLogger.
 const char *kFIRLoggerASLClientFacilityName = "com.firebase.app.logger";
 
-/// Message format used by ASL client that matches format of NSLog.
-const char *kFIRLoggerCustomASLMessageFormat =
-    "$((Time)(J.3)) $(Sender)[$(PID)] <$((Level)(str))> $Message";
-
 /// Keys for the number of errors and warnings logged.
 NSString *const kFIRLoggerErrorCountKey = @"/google/firebase/count_of_errors_logged";
 NSString *const kFIRLoggerWarningCountKey = @"/google/firebase/count_of_warnings_logged";


### PR DESCRIPTION
This was previously used in an iOS 7 comparison that was removed in
Firebase version 5.0.0.