### PR TITLE
Avoid closing unintialized substreams 

### DIFF
--- a/Firestore/core/src/firebase/firestore/nanopb/reader.cc
+++ b/Firestore/core/src/firebase/firestore/nanopb/reader.cc
@@ -110,14 +110,13 @@ std::string Reader::ReadString() {
   pb_istream_t substream;
   if (!pb_make_string_substream(&stream_, &substream)) {
     status_ = Status(FirestoreErrorCode::DataLoss, PB_GET_ERROR(&stream_));
-    pb_close_string_substream(&stream_, &substream);
     return "";
   }
 
   std::string result(substream.bytes_left, '\0');
   if (!pb_read(&substream, reinterpret_cast<pb_byte_t*>(&result[0]),
                substream.bytes_left)) {
-    status_ = Status(FirestoreErrorCode::DataLoss, PB_GET_ERROR(&stream_));
+    status_ = Status(FirestoreErrorCode::DataLoss, PB_GET_ERROR(&substream));
     pb_close_string_substream(&stream_, &substream);
     return "";
   }

--- a/Firestore/core/src/firebase/firestore/nanopb/reader.h
+++ b/Firestore/core/src/firebase/firestore/nanopb/reader.h
@@ -150,7 +150,6 @@ T Reader::ReadNestedMessage(const std::function<T(Reader*)>& read_message_fn) {
   if (!pb_make_string_substream(&stream_, &raw_substream)) {
     status_ =
         util::Status(FirestoreErrorCode::DataLoss, PB_GET_ERROR(&stream_));
-    pb_close_string_substream(&stream_, &raw_substream);
     return read_message_fn(this);
   }
   Reader substream(raw_substream);

--- a/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
+++ b/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
@@ -584,14 +584,6 @@ TEST_F(SerializerTest, BadStringValue) {
       Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
-TEST_F(SerializerTest, BadStringValue_Malformed) {
-  // Malformed bytes with a string tag.
-  std::std::vector<uint8_t> bytes{0x8a, 0x01};
-
-  ExpectFailedStatusDuringFieldValueDecode(
-      Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
-}
-
 TEST_F(SerializerTest, BadTimestampValue_TooLarge) {
   std::vector<uint8_t> bytes = EncodeFieldValue(
       &serializer, FieldValue::TimestampValue(TimestampInternal::Max()));

--- a/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
+++ b/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
@@ -584,6 +584,14 @@ TEST_F(SerializerTest, BadStringValue) {
       Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
 }
 
+TEST_F(SerializerTest, BadStringValue_Malformed) {
+  // Malformed bytes with a string tag.
+  std::std::vector<uint8_t> bytes{0x8a, 0x01};
+
+  ExpectFailedStatusDuringFieldValueDecode(
+      Status(FirestoreErrorCode::DataLoss, "ignored"), bytes);
+}
+
 TEST_F(SerializerTest, BadTimestampValue_TooLarge) {
   std::vector<uint8_t> bytes = EncodeFieldValue(
       &serializer, FieldValue::TimestampValue(TimestampInternal::Max()));


### PR DESCRIPTION
* A substream should not be closed if `pb_make_string_substream()` failed to create it and returned false.
* Fixed a potential wrong error message.