### PR TITLE
Add a warning message for topic subscription/unsubscription when token is not available

### DIFF
--- a/Example/Messaging/Tests/FIRMessagingPubSubTest.m
+++ b/Example/Messaging/Tests/FIRMessagingPubSubTest.m
@@ -78,4 +78,13 @@ static NSString *const kTopicName = @"topic-Name";
   XCTAssertTrue([FIRMessagingPubSub isValidTopicWithPrefix:topic]);
 }
 
+- (void)testRemoveTopicPrefix {
+    NSString *topic = [NSString stringWithFormat:@"/topics/%@", kTopicName];
+    topic = [FIRMessagingPubSub removePrefixFromTopic:topic];
+    XCTAssertEqualObjects(topic, kTopicName);
+    // if the topic doesn't have the prefix, should return topic itself.
+    topic = [FIRMessagingPubSub removePrefixFromTopic:kTopicName];
+    XCTAssertEqualObjects(topic, kTopicName);
+}
+
 @end

--- a/Example/Messaging/Tests/FIRMessagingServiceTest.m
+++ b/Example/Messaging/Tests/FIRMessagingServiceTest.m
@@ -239,35 +239,6 @@ static NSString *const kFakeToken =
   OCMVerifyAll(_mockPubSub);
 }
 
-- (void)testSubScriptionCompletionHandlerWithInvalidToken {
-  XCTestExpectation *subscriptionCompletionExpectation =
-      [self expectationWithDescription:@"Subscription is complete"];
-  _messaging.defaultFcmToken = nil;
-  [_messaging subscribeToTopic:@"news"
-                    completion:^(NSError *error) {
-                      XCTAssertNotNil(error);
-                      XCTAssertEqual(error.code, FIRMessagingErrorTokenNotAvailable);
-                      [subscriptionCompletionExpectation fulfill];
-                    }];
-  [self waitForExpectationsWithTimeout:0.2
-                               handler:^(NSError *_Nullable error){
-                               }];
-}
-
-- (void)testSubscriptionCompletionHandlerWithInvalidTopicName {
-  XCTestExpectation *subscriptionCompletionExpectation =
-      [self expectationWithDescription:@"Subscription is complete"];
-  [_messaging subscribeToTopic:@"!@#$%^&*()"
-                    completion:^(NSError *_Nullable error) {
-                      XCTAssertNotNil(error);
-                      XCTAssertEqual(error.code, FIRMessagingErrorInvalidTopicName);
-                      [subscriptionCompletionExpectation fulfill];
-                    }];
-  [self waitForExpectationsWithTimeout:0.2
-                               handler:^(NSError *_Nullable error){
-                               }];
-}
-
 - (void)testSubscriptionCompletionHandlerWithSuccess {
   OCMStub([_mockPubSub subscribeToTopic:[OCMArg any]
                                 handler:([OCMArg invokeBlockWithArgs:[NSNull null], nil])]);
@@ -278,35 +249,6 @@ static NSString *const kFakeToken =
                       XCTAssertNil(error);
                       [subscriptionCompletionExpectation fulfill];
                     }];
-  [self waitForExpectationsWithTimeout:0.2
-                               handler:^(NSError *_Nullable error){
-                               }];
-}
-
-- (void)testUnsubscribeCompletionHandlerWithInvalidToken {
-  XCTestExpectation *unsubscriptionCompletionExpectation =
-      [self expectationWithDescription:@"Unsubscription is complete"];
-  _messaging.defaultFcmToken = nil;
-  [_messaging unsubscribeFromTopic:@""
-                        completion:^(NSError *error) {
-                          XCTAssertNotNil(error);
-                          XCTAssertEqual(error.code, FIRMessagingErrorTokenNotAvailable);
-                          [unsubscriptionCompletionExpectation fulfill];
-                        }];
-  [self waitForExpectationsWithTimeout:0.2
-                               handler:^(NSError *_Nullable error){
-                               }];
-}
-
-- (void)testUnsubscribeCompletionHandlerWithInvalidTopic {
-  XCTestExpectation *unsubscriptionCompletionExpectation =
-      [self expectationWithDescription:@"Unsubscription is complete"];
-  [_messaging unsubscribeFromTopic:@"!@#$%^&*()"
-                        completion:^(NSError *error) {
-                          XCTAssertNotNil(error);
-                          XCTAssertEqual(error.code, FIRMessagingErrorInvalidTopicName);
-                          [unsubscriptionCompletionExpectation fulfill];
-                        }];
   [self waitForExpectationsWithTimeout:0.2
                                handler:^(NSError *_Nullable error){
                                }];

--- a/Example/Messaging/Tests/FIRMessagingServiceTest.m
+++ b/Example/Messaging/Tests/FIRMessagingServiceTest.m
@@ -26,6 +26,11 @@
 #import "InternalHeaders/FIRMessagingInternalUtilities.h"
 #import "NSError+FIRMessaging.h"
 
+static NSString *const kFakeToken =
+    @"fE1e1PZJFSQ:APA91bFAOjp1ahBWn9rTlbjArwBEm_"
+    @"yUTTzK6dhIvLqzqqCSabaa4TQVM0pGTmF6r7tmMHPe6VYiGMHuCwJFgj5v97xl78sUNMLwuPPhoci8z_"
+    @"QGlCrTbxCFGzEUfvA3fGpGgIVQU2W6";
+
 @interface FIRMessaging () <FIRMessagingClientDelegate>
 
 @property(nonatomic, readwrite, strong) FIRMessagingClient *client;
@@ -40,22 +45,35 @@
 
 @end
 
-
-@interface FIRMessagingServiceTest : XCTestCase
+@interface FIRMessagingServiceTest : XCTestCase {
+  FIRMessaging *_messaging;
+  id _mockPubSub;
+}
 
 @end
 
 @implementation FIRMessagingServiceTest
 
+- (void)setUp {
+  _messaging = [FIRMessaging messaging];
+  _messaging.defaultFcmToken = kFakeToken;
+  _mockPubSub = OCMPartialMock(_messaging.pubsub);
+  [super setUp];
+}
+
+- (void)tearDown {
+  [_mockPubSub stopMocking];
+  [super tearDown];
+}
+
 - (void)testSubscribe {
   id mockClient = OCMClassMock([FIRMessagingClient class]);
-  FIRMessaging *service = [FIRMessaging messaging];
-  [service setClient:mockClient];
-  [service.pubsub setClient:mockClient];
+  [_messaging setClient:mockClient];
+  [_mockPubSub setClient:mockClient];
 
   XCTestExpectation *subscribeExpectation =
       [self expectationWithDescription:@"Should call subscribe on FIRMessagingClient"];
-  NSString *token = @"abcdefghijklmn";
+  NSString *token = kFakeToken;
   NSString *topic = @"/topics/some-random-topic";
 
   [[[mockClient stub]
@@ -68,12 +86,12 @@
                      shouldDelete:NO
                           handler:OCMOCK_ANY];
 
-  [service.pubsub subscribeWithToken:token
-                               topic:topic
-                             options:nil
-                             handler:^(NSError *error){
-                                 // not a nil block
-                             }];
+  [_mockPubSub subscribeWithToken:token
+                            topic:topic
+                          options:nil
+                          handler:^(NSError *error){
+                              // not a nil block
+                          }];
 
   // should call updateSubscription
   [self waitForExpectationsWithTimeout:0.1
@@ -85,14 +103,13 @@
 
 - (void)testUnsubscribe {
   id mockClient = OCMClassMock([FIRMessagingClient class]);
-  FIRMessaging *messaging = [FIRMessaging messaging];
-  [messaging setClient:mockClient];
-  [messaging.pubsub setClient:mockClient];
+  [_messaging setClient:mockClient];
+  [_mockPubSub setClient:mockClient];
 
   XCTestExpectation *subscribeExpectation =
       [self expectationWithDescription:@"Should call unsubscribe on FIRMessagingClient"];
 
-  NSString *token = @"abcdefghijklmn";
+  NSString *token = kFakeToken;
   NSString *topic = @"/topics/some-random-topic";
 
   [[[mockClient stub] andDo:^(NSInvocation *invocation) {
@@ -109,12 +126,12 @@
                      shouldDelete:YES
                           handler:OCMOCK_ANY];
 
-  [messaging.pubsub unsubscribeWithToken:token
-                                   topic:topic
-                                 options:nil
-                                 handler:^(NSError *error){
+  [_mockPubSub unsubscribeWithToken:token
+                              topic:topic
+                            options:nil
+                            handler:^(NSError *error){
 
-                                 }];
+                            }];
 
   // should call updateSubscription
   [self waitForExpectationsWithTimeout:0.1
@@ -128,8 +145,8 @@
  *  Test using PubSub without explicitly starting FIRMessagingService.
  */
 - (void)testSubscribeWithoutStart {
-  [[[FIRMessaging messaging] pubsub]
-      subscribeWithToken:@"abcdef1234"
+  [_mockPubSub
+      subscribeWithToken:kFakeToken
                    topic:@"/topics/hello-world"
                  options:nil
                  handler:^(NSError *error) {
@@ -141,19 +158,18 @@
 // TODO(chliangGoogle) Investigate why invalid token can't throw assertion but the rest can under
 // release build.
 - (void)testSubscribeWithInvalidTopic {
-  FIRMessaging *messaging = [FIRMessaging messaging];
 
   XCTestExpectation *exceptionExpectation =
   [self expectationWithDescription:@"Should throw exception for invalid token"];
   @try {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
-    [messaging.pubsub subscribeWithToken:@"abcdef1234"
-                                   topic:nil
-                                 options:nil
-                                 handler:^(NSError *error) {
-                                   XCTFail(@"Should not invoke the handler");
-                                 }];
+    [_mockPubSub subscribeWithToken:kFakeToken
+                              topic:nil
+                            options:nil
+                            handler:^(NSError *error) {
+                              XCTFail(@"Should not invoke the handler");
+                            }];
 #pragma clang diagnostic pop
   }
   @catch (NSException *exception) {
@@ -167,19 +183,17 @@
 }
 
 - (void)testUnsubscribeWithInvalidTopic {
-  FIRMessaging *messaging = [FIRMessaging messaging];
-
   XCTestExpectation *exceptionExpectation =
       [self expectationWithDescription:@"Should throw exception for invalid token"];
   @try {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
-    [messaging.pubsub unsubscribeWithToken:@"abcdef1234"
-                                     topic:nil
-                                   options:nil
-                                   handler:^(NSError *error) {
-                                     XCTFail(@"Should not invoke the handler");
-                                   }];
+    [_mockPubSub unsubscribeWithToken:kFakeToken
+                                topic:nil
+                              options:nil
+                              handler:^(NSError *error) {
+                                XCTFail(@"Should not invoke the handler");
+                              }];
 #pragma clang diagnostic pop
   }
   @catch (NSException *exception) {
@@ -193,68 +207,124 @@
 }
 
 - (void)testSubscribeWithNoTopicPrefix {
-  FIRMessaging *messaging = [FIRMessaging messaging];
-  FIRMessagingPubSub *pubSub = messaging.pubsub;
-  id mockPubSub = OCMClassMock([FIRMessagingPubSub class]);
 
   NSString *topicName = @"topicWithoutPrefix";
   NSString *topicNameWithPrefix = [FIRMessagingPubSub addPrefixToTopic:topicName];
-  messaging.pubsub = mockPubSub;
-  messaging.defaultFcmToken = @"fake-default-token";
-  OCMExpect([messaging.pubsub subscribeToTopic:[OCMArg isEqual:topicNameWithPrefix]
-                                       handler:[OCMArg any]]);
-  [messaging subscribeToTopic:topicName];
-  OCMVerifyAll(mockPubSub);
-  // Need to swap back since it's a singleton and hence will live beyond the scope of this test.
-  messaging.pubsub = pubSub;
+  OCMExpect(
+      [_mockPubSub subscribeToTopic:[OCMArg isEqual:topicNameWithPrefix] handler:[OCMArg any]]);
+  [_messaging subscribeToTopic:topicName];
+  OCMVerifyAll(_mockPubSub);
 }
 
 - (void)testSubscribeWithTopicPrefix {
-  FIRMessaging *messaging = [FIRMessaging messaging];
-  FIRMessagingPubSub *pubSub = messaging.pubsub;
-  id mockPubSub = OCMClassMock([FIRMessagingPubSub class]);
-
   NSString *topicName = @"/topics/topicWithoutPrefix";
-  messaging.pubsub = mockPubSub;
-  messaging.defaultFcmToken = @"fake-default-token";
-  OCMExpect([messaging.pubsub subscribeToTopic:[OCMArg isEqual:topicName] handler:[OCMArg any]]);
-  [messaging subscribeToTopic:topicName];
-  OCMVerifyAll(mockPubSub);
-  // Need to swap back since it's a singleton and hence will live beyond the scope of this test.
-  messaging.pubsub = pubSub;
+  OCMExpect([_mockPubSub subscribeToTopic:[OCMArg isEqual:topicName] handler:[OCMArg any]]);
+  [_messaging subscribeToTopic:topicName];
+  OCMVerifyAll(_mockPubSub);
 }
 
 - (void)testUnsubscribeWithNoTopicPrefix {
-  FIRMessaging *messaging = [FIRMessaging messaging];
-  FIRMessagingPubSub *pubSub = messaging.pubsub;
-  id mockPubSub = OCMClassMock([FIRMessagingPubSub class]);
-
   NSString *topicName = @"topicWithoutPrefix";
   NSString *topicNameWithPrefix = [FIRMessagingPubSub addPrefixToTopic:topicName];
-  messaging.pubsub = mockPubSub;
-  messaging.defaultFcmToken = @"fake-default-token";
-  OCMExpect([messaging.pubsub unsubscribeFromTopic:[OCMArg isEqual:topicNameWithPrefix]
-                                           handler:[OCMArg any]]);
-  [messaging unsubscribeFromTopic:topicName];
-  OCMVerifyAll(mockPubSub);
-  // Need to swap back since it's a singleton and hence will live beyond the scope of this test.
-  messaging.pubsub = pubSub;
+  OCMExpect(
+      [_mockPubSub unsubscribeFromTopic:[OCMArg isEqual:topicNameWithPrefix] handler:[OCMArg any]]);
+  [_messaging unsubscribeFromTopic:topicName];
+  OCMVerifyAll(_mockPubSub);
 }
 
 - (void)testUnsubscribeWithTopicPrefix {
-  FIRMessaging *messaging = [FIRMessaging messaging];
-  FIRMessagingPubSub *pubSub = messaging.pubsub;
-  id mockPubSub = OCMClassMock([FIRMessagingPubSub class]);
-
   NSString *topicName = @"/topics/topicWithPrefix";
-  messaging.pubsub = mockPubSub;
-  messaging.defaultFcmToken = @"fake-default-token";
-  OCMExpect([messaging.pubsub unsubscribeFromTopic:[OCMArg isEqual:topicName]
-                                           handler:[OCMArg any]]);
-  [messaging unsubscribeFromTopic:topicName];
-  OCMVerifyAll(mockPubSub);
-  // Need to swap back since it's a singleton and hence will live beyond the scope of this test.
-  messaging.pubsub = pubSub;
+  OCMExpect([_mockPubSub unsubscribeFromTopic:[OCMArg isEqual:topicName] handler:[OCMArg any]]);
+  [_messaging unsubscribeFromTopic:topicName];
+  OCMVerifyAll(_mockPubSub);
+}
+
+- (void)testSubScriptionCompletionHandlerWithInvalidToken {
+  XCTestExpectation *subscriptionCompletionExpectation =
+      [self expectationWithDescription:@"Subscription is complete"];
+  _messaging.defaultFcmToken = nil;
+  [_messaging subscribeToTopic:@"news"
+                    completion:^(NSError *error) {
+                      XCTAssertNotNil(error);
+                      XCTAssertEqual(error.code, FIRMessagingErrorTokenNotAvailable);
+                      [subscriptionCompletionExpectation fulfill];
+                    }];
+  [self waitForExpectationsWithTimeout:0.2
+                               handler:^(NSError *_Nullable error){
+                               }];
+}
+
+- (void)testSubscriptionCompletionHandlerWithInvalidTopicName {
+  XCTestExpectation *subscriptionCompletionExpectation =
+      [self expectationWithDescription:@"Subscription is complete"];
+  [_messaging subscribeToTopic:@"!@#$%^&*()"
+                    completion:^(NSError *_Nullable error) {
+                      XCTAssertNotNil(error);
+                      XCTAssertEqual(error.code, FIRMessagingErrorInvalidTopicName);
+                      [subscriptionCompletionExpectation fulfill];
+                    }];
+  [self waitForExpectationsWithTimeout:0.2
+                               handler:^(NSError *_Nullable error){
+                               }];
+}
+
+- (void)testSubscriptionCompletionHandlerWithSuccess {
+  OCMStub([_mockPubSub subscribeToTopic:[OCMArg any]
+                                handler:([OCMArg invokeBlockWithArgs:[NSNull null], nil])]);
+  XCTestExpectation *subscriptionCompletionExpectation =
+      [self expectationWithDescription:@"Subscription is complete"];
+  [_messaging subscribeToTopic:@"news"
+                    completion:^(NSError *error) {
+                      XCTAssertNil(error);
+                      [subscriptionCompletionExpectation fulfill];
+                    }];
+  [self waitForExpectationsWithTimeout:0.2
+                               handler:^(NSError *_Nullable error){
+                               }];
+}
+
+- (void)testUnsubscribeCompletionHandlerWithInvalidToken {
+  XCTestExpectation *unsubscriptionCompletionExpectation =
+      [self expectationWithDescription:@"Unsubscription is complete"];
+  _messaging.defaultFcmToken = nil;
+  [_messaging unsubscribeFromTopic:@""
+                        completion:^(NSError *error) {
+                          XCTAssertNotNil(error);
+                          XCTAssertEqual(error.code, FIRMessagingErrorTokenNotAvailable);
+                          [unsubscriptionCompletionExpectation fulfill];
+                        }];
+  [self waitForExpectationsWithTimeout:0.2
+                               handler:^(NSError *_Nullable error){
+                               }];
+}
+
+- (void)testUnsubscribeCompletionHandlerWithInvalidTopic {
+  XCTestExpectation *unsubscriptionCompletionExpectation =
+      [self expectationWithDescription:@"Unsubscription is complete"];
+  [_messaging unsubscribeFromTopic:@"!@#$%^&*()"
+                        completion:^(NSError *error) {
+                          XCTAssertNotNil(error);
+                          XCTAssertEqual(error.code, FIRMessagingErrorInvalidTopicName);
+                          [unsubscriptionCompletionExpectation fulfill];
+                        }];
+  [self waitForExpectationsWithTimeout:0.2
+                               handler:^(NSError *_Nullable error){
+                               }];
+}
+
+- (void)testUnsubscribeCompletionHandlerWithSuccess {
+  OCMStub([_mockPubSub unsubscribeFromTopic:[OCMArg any]
+                                    handler:([OCMArg invokeBlockWithArgs:[NSNull null], nil])]);
+  XCTestExpectation *unsubscriptionCompletionExpectation =
+      [self expectationWithDescription:@"Unsubscription is complete"];
+  [_messaging unsubscribeFromTopic:@"news"
+                        completion:^(NSError *_Nullable error) {
+                          XCTAssertNil(error);
+                          [unsubscriptionCompletionExpectation fulfill];
+                        }];
+  [self waitForExpectationsWithTimeout:0.2
+                               handler:^(NSError *_Nullable error){
+                               }];
 }
 
 - (void)testFIRMessagingSDKVersionInFIRMessagingService {

--- a/Firebase/Core/CHANGELOG.md
+++ b/Firebase/Core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 2018-06-19 -- v5.0.4 -- M28
 - [fixed] Fixed a thread sanitizer error (#1390)
-- [fixed] Updated FirebaseCore.podspec so that it works with coocoapod-packager. (#1378)
+- [fixed] Updated FirebaseCore.podspec so that it works with cocoapods-packager. (#1378)
 
 # 2018-05-29 -- v5.0.2 -- M26
 - [changed] Delayed library registration call from `+load` to `+initialize`. (#1305)

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -700,7 +700,8 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
     if ([FIRMessagingPubSub hasTopicsPrefix:topic]) {
       FIRMessagingLoggerWarn(kFIRMessagingMessageCodeTopicFormatIsDeprecated,
                              @"Format '%@' is deprecated. Only '%@' should be used in "
-                             @"subscribeToTopic.", topic, normalizeTopic);
+                             @"subscribeToTopic.", topic,
+                             [FIRMessagingPubSub removePrefixFromTopic:topic]);
     }
     if (normalizeTopic.length) {
       [self.pubsub subscribeToTopic:normalizeTopic handler:completion];
@@ -726,7 +727,8 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
     if ([FIRMessagingPubSub hasTopicsPrefix:topic]) {
       FIRMessagingLoggerWarn(kFIRMessagingMessageCodeTopicFormatIsDeprecated,
                              @"Format '%@' is deprecated. Only '%@' should be used in "
-                             @"unsubscribeFromTopic.", topic, normalizeTopic);
+                             @"unsubscribeFromTopic.", topic,
+                             [FIRMessagingPubSub removePrefixFromTopic:topic]);
     }
     if (normalizeTopic.length) {
       [self.pubsub unsubscribeFromTopic:normalizeTopic handler:completion];

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -695,7 +695,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
 
 - (void)subscribeToTopic:(NSString *)topic
               completion:(nullable FIRMessagingTopicOperationCompletion)completion {
-  if (self.defaultFcmToken.length && topic.length) {
+  if (topic.length) {
     NSString *normalizeTopic = [[self class ] normalizeTopic:topic];
     if ([FIRMessagingPubSub hasTopicsPrefix:topic]) {
       FIRMessagingLoggerWarn(kFIRMessagingMessageCodeTopicFormatIsDeprecated,
@@ -721,7 +721,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
 
 - (void)unsubscribeFromTopic:(NSString *)topic
                   completion:(nullable FIRMessagingTopicOperationCompletion)completion {
-  if (self.defaultFcmToken.length && topic.length) {
+  if (topic.length) {
     NSString *normalizeTopic = [[self class] normalizeTopic:topic];
     if ([FIRMessagingPubSub hasTopicsPrefix:topic]) {
       FIRMessagingLoggerWarn(kFIRMessagingMessageCodeTopicFormatIsDeprecated,

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -706,7 +706,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
                            topic, [FIRMessagingPubSub removePrefixFromTopic:topic]);
   }
   if (!self.defaultFcmToken.length) {
-    FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging010,
+    FIRMessagingLoggerWarn(kFIRMessagingMessageCodeMessaging010,
                             @"The subscription operation is suspended because you don't have a "
                             @"token. The operation will resume once you get an FCM token.");
   }
@@ -725,14 +725,14 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
 
 - (void)unsubscribeFromTopic:(NSString *)topic
                   completion:(nullable FIRMessagingTopicOperationCompletion)completion {
- if ([FIRMessagingPubSub hasTopicsPrefix:topic]) {
+  if ([FIRMessagingPubSub hasTopicsPrefix:topic]) {
     FIRMessagingLoggerWarn(kFIRMessagingMessageCodeTopicFormatIsDeprecated,
                            @"Format '%@' is deprecated. Only '%@' should be used in "
                            @"unsubscribeFromTopic.",
                            topic, [FIRMessagingPubSub removePrefixFromTopic:topic]);
   }
   if (!self.defaultFcmToken.length) {
-    FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging012,
+    FIRMessagingLoggerWarn(kFIRMessagingMessageCodeMessaging012,
                             @"The unsubscription operation is suspended because you don't have a "
                             @"token. The operation will resume once you get an FCM token.");
   }

--- a/Firebase/Messaging/FIRMessagingPubSub.h
+++ b/Firebase/Messaging/FIRMessagingPubSub.h
@@ -139,6 +139,15 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)addPrefixToTopic:(NSString *)topic;
 
 /**
+ *  Removes the "/topics/" prefix from the topic.
+ *
+ *  @param topic The topic to remove the prefix from.
+ *
+ *  @return The new topic name with the "/topics/" prefix removed.
+ */
++ (NSString *)removePrefixFromTopic:(NSString *)topic;
+
+/**
  *  Check if the topic name has "/topics/" prefix.
  *
  *  @param topic The topic name to verify.

--- a/Firebase/Messaging/FIRMessagingPubSub.m
+++ b/Firebase/Messaging/FIRMessagingPubSub.m
@@ -231,6 +231,14 @@ static NSString *const kTopicRegexPattern = @"/topics/([a-zA-Z0-9-_.~%]+)";
   }
 }
 
++ (NSString *)removePrefixFromTopic:(NSString *)topic {
+  if ([self hasTopicsPrefix:topic]) {
+    return [topic substringFromIndex:kTopicsPrefix.length];
+  } else {
+    return [topic copy];
+  }
+}
+
 + (BOOL)hasTopicsPrefix:(NSString *)topic {
   return [topic hasPrefix:kTopicsPrefix];
 }

--- a/Firebase/Messaging/Public/FIRMessaging.h
+++ b/Firebase/Messaging/Public/FIRMessaging.h
@@ -189,6 +189,12 @@ typedef NS_ENUM(NSUInteger, FIRMessagingError) {
 
   /// Some parameters of the request were invalid.
   FIRMessagingErrorInvalidRequest = 7,
+
+  /// Token is not available for topic subscription/unsubscription.
+  FIRMessagingErrorTokenNotAvailable = 8,
+
+  /// Topic name is invalid for subscription/unsubscription.
+  FIRMessagingErrorInvalidTopicName = 9,
 } NS_SWIFT_NAME(MessagingError);
 
 /// Status for the downstream message received by the app.

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -51,17 +51,23 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.dependency 'gRPC-ProtoRPC', '~> 1.0'
   s.dependency 'leveldb-library', '~> 1.18'
   s.dependency 'Protobuf', '~> 3.1'
+  s.dependency 'nanopb', '~> 0.3.8'
 
   s.frameworks = 'MobileCoreServices'
   s.library = 'c++'
   s.pod_target_xcconfig = {
-    'GCC_PREPROCESSOR_DEFINITIONS' => 'GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1 ' +
-      'FIRFirestore_VERSION=' + s.version.to_s + ' PB_FIELD_16BIT',
+    'GCC_PREPROCESSOR_DEFINITIONS' =>
+      "FIRFirestore_VERSION=#{s.version} " +
+      'GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1 ' +
+      # The nanopb pod sets these defs, so we must too. (We *do* require 16bit
+      # (or larger) fields, so we'd have to set at least PB_FIELD_16BIT
+      # anyways.)
+      'PB_FIELD_32BIT=1 PB_NO_PACKED_STRUCTS=1',
     'HEADER_SEARCH_PATHS' =>
       '"${PODS_TARGET_SRCROOT}" ' +
       '"${PODS_TARGET_SRCROOT}/Firestore/third_party/abseil-cpp" ' +
       '"${PODS_ROOT}/nanopb" ' +
-      '"${PODS_TARGET_SRCROOT}/Firestore/Protos/nanopb"'
+      '"${PODS_TARGET_SRCROOT}/Firestore/Protos/nanopb"',
   }
 
   s.prepare_command = <<-CMD

--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -147,6 +147,19 @@
 		6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
 		6003F5BA195388D20070C39A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6003F5B8195388D20070C39A /* InfoPlist.strings */; };
 		6161B5032047140C00A99DBB /* FIRFirestoreSourceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6161B5012047140400A99DBB /* FIRFirestoreSourceTests.mm */; };
+		618BBEA620B89AAC00B5BCE7 /* target.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618BBE7D20B89AAC00B5BCE7 /* target.pb.cc */; };
+		618BBEA720B89AAC00B5BCE7 /* maybe_document.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618BBE7E20B89AAC00B5BCE7 /* maybe_document.pb.cc */; };
+		618BBEA820B89AAC00B5BCE7 /* mutation.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618BBE8220B89AAC00B5BCE7 /* mutation.pb.cc */; };
+		618BBEA920B89AAC00B5BCE7 /* common.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618BBE8820B89AAC00B5BCE7 /* common.pb.cc */; };
+		618BBEAA20B89AAC00B5BCE7 /* firestore.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618BBE8A20B89AAC00B5BCE7 /* firestore.pb.cc */; };
+		618BBEAB20B89AAC00B5BCE7 /* query.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618BBE8C20B89AAC00B5BCE7 /* query.pb.cc */; };
+		618BBEAC20B89AAC00B5BCE7 /* document.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618BBE8E20B89AAC00B5BCE7 /* document.pb.cc */; };
+		618BBEAD20B89AAC00B5BCE7 /* write.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618BBE8F20B89AAC00B5BCE7 /* write.pb.cc */; };
+		618BBEAE20B89AAC00B5BCE7 /* latlng.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618BBE9220B89AAC00B5BCE7 /* latlng.pb.cc */; };
+		618BBEAF20B89AAC00B5BCE7 /* annotations.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618BBE9520B89AAC00B5BCE7 /* annotations.pb.cc */; };
+		618BBEB020B89AAC00B5BCE7 /* http.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618BBE9720B89AAC00B5BCE7 /* http.pb.cc */; };
+		618BBEB120B89AAC00B5BCE7 /* status.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618BBE9920B89AAC00B5BCE7 /* status.pb.cc */; };
+		61F72C5620BC48FD001A68CB /* serializer_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 61F72C5520BC48FD001A68CB /* serializer_test.cc */; };
 		6EDD3B4620BF247500C33877 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6EDD3B4820BF247500C33877 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
 		6EDD3B4920BF247500C33877 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F5AF195388D20070C39A /* XCTest.framework */; };
@@ -274,7 +287,7 @@
 		3B843E4A1F3930A400548890 /* remote_store_spec_test.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = remote_store_spec_test.json; sourceTree = "<group>"; };
 		3C81DE3772628FE297055662 /* Pods-Firestore_Example_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_iOS/Pods-Firestore_Example_iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		3F0992A4B83C60841C52E960 /* Pods-Firestore_Example_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_iOS/Pods-Firestore_Example_iOS.release.xcconfig"; sourceTree = "<group>"; };
-		403DBF6EFB541DFD01582AA3 /* path_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = path_test.cc; sourceTree = "<group>"; };
+		403DBF6EFB541DFD01582AA3 /* path_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = path_test.cc; sourceTree = "<group>"; };
 		444B7AB3F5A2929070CB1363 /* hard_assert_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = hard_assert_test.cc; sourceTree = "<group>"; };
 		54131E9620ADE678001DF3FF /* string_format_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_format_test.cc; sourceTree = "<group>"; };
 		54511E8D209805F8005BD28F /* hashing_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = hashing_test.cc; sourceTree = "<group>"; };
@@ -411,6 +424,31 @@
 		6003F5B7195388D20070C39A /* Tests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Tests-Info.plist"; sourceTree = "<group>"; };
 		6003F5B9195388D20070C39A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		6161B5012047140400A99DBB /* FIRFirestoreSourceTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FIRFirestoreSourceTests.mm; sourceTree = "<group>"; };
+		618BBE7D20B89AAC00B5BCE7 /* target.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = target.pb.cc; sourceTree = "<group>"; };
+		618BBE7E20B89AAC00B5BCE7 /* maybe_document.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = maybe_document.pb.cc; sourceTree = "<group>"; };
+		618BBE7F20B89AAC00B5BCE7 /* target.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = target.pb.h; sourceTree = "<group>"; };
+		618BBE8020B89AAC00B5BCE7 /* maybe_document.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = maybe_document.pb.h; sourceTree = "<group>"; };
+		618BBE8120B89AAC00B5BCE7 /* mutation.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mutation.pb.h; sourceTree = "<group>"; };
+		618BBE8220B89AAC00B5BCE7 /* mutation.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = mutation.pb.cc; sourceTree = "<group>"; };
+		618BBE8620B89AAC00B5BCE7 /* query.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = query.pb.h; sourceTree = "<group>"; };
+		618BBE8720B89AAC00B5BCE7 /* common.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.pb.h; sourceTree = "<group>"; };
+		618BBE8820B89AAC00B5BCE7 /* common.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = common.pb.cc; sourceTree = "<group>"; };
+		618BBE8920B89AAC00B5BCE7 /* firestore.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = firestore.pb.h; sourceTree = "<group>"; };
+		618BBE8A20B89AAC00B5BCE7 /* firestore.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = firestore.pb.cc; sourceTree = "<group>"; };
+		618BBE8B20B89AAC00B5BCE7 /* write.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = write.pb.h; sourceTree = "<group>"; };
+		618BBE8C20B89AAC00B5BCE7 /* query.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = query.pb.cc; sourceTree = "<group>"; };
+		618BBE8D20B89AAC00B5BCE7 /* document.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = document.pb.h; sourceTree = "<group>"; };
+		618BBE8E20B89AAC00B5BCE7 /* document.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = document.pb.cc; sourceTree = "<group>"; };
+		618BBE8F20B89AAC00B5BCE7 /* write.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = write.pb.cc; sourceTree = "<group>"; };
+		618BBE9120B89AAC00B5BCE7 /* latlng.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = latlng.pb.h; sourceTree = "<group>"; };
+		618BBE9220B89AAC00B5BCE7 /* latlng.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = latlng.pb.cc; sourceTree = "<group>"; };
+		618BBE9420B89AAC00B5BCE7 /* http.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = http.pb.h; sourceTree = "<group>"; };
+		618BBE9520B89AAC00B5BCE7 /* annotations.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = annotations.pb.cc; sourceTree = "<group>"; };
+		618BBE9620B89AAC00B5BCE7 /* annotations.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = annotations.pb.h; sourceTree = "<group>"; };
+		618BBE9720B89AAC00B5BCE7 /* http.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = http.pb.cc; sourceTree = "<group>"; };
+		618BBE9920B89AAC00B5BCE7 /* status.pb.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = status.pb.cc; sourceTree = "<group>"; };
+		618BBE9A20B89AAC00B5BCE7 /* status.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = status.pb.h; sourceTree = "<group>"; };
+		61F72C5520BC48FD001A68CB /* serializer_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = serializer_test.cc; sourceTree = "<group>"; };
 		69E6C311558EC77729A16CF1 /* Pods-Firestore_Example_iOS-Firestore_SwiftTests_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_iOS-Firestore_SwiftTests_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_iOS-Firestore_SwiftTests_iOS/Pods-Firestore_Example_iOS-Firestore_SwiftTests_iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		6EDD3B5B20BF247500C33877 /* Firestore_FuzzTests_iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Firestore_FuzzTests_iOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6EDD3B5C20BF247500C33877 /* Firestore_FuzzTests_iOS-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Firestore_FuzzTests_iOS-Info.plist"; sourceTree = "<group>"; };
@@ -567,6 +605,7 @@
 			isa = PBXGroup;
 			children = (
 				546854A820A36867004BDBD5 /* datastore_test.cc */,
+				61F72C5520BC48FD001A68CB /* serializer_test.cc */,
 			);
 			path = remote;
 			sourceTree = "<group>";
@@ -665,6 +704,7 @@
 		6003F581195388D10070C39A = {
 			isa = PBXGroup;
 			children = (
+				618BBE7A20B89AAC00B5BCE7 /* CoreTestsProtos */,
 				6EDD3B5D20BF24A700C33877 /* FuzzTests */,
 				543B4F0520A91E4B001F506D /* App */,
 				60FF7A9C1954A5C5007DD14C /* Podspec Metadata */,
@@ -767,6 +807,102 @@
 				D3CC3DC5338DCAF43A211155 /* README.md */,
 			);
 			name = "Podspec Metadata";
+			sourceTree = "<group>";
+		};
+		618BBE7A20B89AAC00B5BCE7 /* CoreTestsProtos */ = {
+			isa = PBXGroup;
+			children = (
+				618BBE7B20B89AAC00B5BCE7 /* firestore */,
+				618BBE8320B89AAC00B5BCE7 /* google */,
+			);
+			name = CoreTestsProtos;
+			path = ../Protos/cpp;
+			sourceTree = "<group>";
+		};
+		618BBE7B20B89AAC00B5BCE7 /* firestore */ = {
+			isa = PBXGroup;
+			children = (
+				618BBE7C20B89AAC00B5BCE7 /* local */,
+			);
+			path = firestore;
+			sourceTree = "<group>";
+		};
+		618BBE7C20B89AAC00B5BCE7 /* local */ = {
+			isa = PBXGroup;
+			children = (
+				618BBE7E20B89AAC00B5BCE7 /* maybe_document.pb.cc */,
+				618BBE8020B89AAC00B5BCE7 /* maybe_document.pb.h */,
+				618BBE8220B89AAC00B5BCE7 /* mutation.pb.cc */,
+				618BBE8120B89AAC00B5BCE7 /* mutation.pb.h */,
+				618BBE7D20B89AAC00B5BCE7 /* target.pb.cc */,
+				618BBE7F20B89AAC00B5BCE7 /* target.pb.h */,
+			);
+			path = local;
+			sourceTree = "<group>";
+		};
+		618BBE8320B89AAC00B5BCE7 /* google */ = {
+			isa = PBXGroup;
+			children = (
+				618BBE9320B89AAC00B5BCE7 /* api */,
+				618BBE8420B89AAC00B5BCE7 /* firestore */,
+				618BBE9820B89AAC00B5BCE7 /* rpc */,
+				618BBE9020B89AAC00B5BCE7 /* type */,
+			);
+			path = google;
+			sourceTree = "<group>";
+		};
+		618BBE8420B89AAC00B5BCE7 /* firestore */ = {
+			isa = PBXGroup;
+			children = (
+				618BBE8520B89AAC00B5BCE7 /* v1beta1 */,
+			);
+			path = firestore;
+			sourceTree = "<group>";
+		};
+		618BBE8520B89AAC00B5BCE7 /* v1beta1 */ = {
+			isa = PBXGroup;
+			children = (
+				618BBE8820B89AAC00B5BCE7 /* common.pb.cc */,
+				618BBE8720B89AAC00B5BCE7 /* common.pb.h */,
+				618BBE8E20B89AAC00B5BCE7 /* document.pb.cc */,
+				618BBE8D20B89AAC00B5BCE7 /* document.pb.h */,
+				618BBE8A20B89AAC00B5BCE7 /* firestore.pb.cc */,
+				618BBE8920B89AAC00B5BCE7 /* firestore.pb.h */,
+				618BBE8C20B89AAC00B5BCE7 /* query.pb.cc */,
+				618BBE8620B89AAC00B5BCE7 /* query.pb.h */,
+				618BBE8F20B89AAC00B5BCE7 /* write.pb.cc */,
+				618BBE8B20B89AAC00B5BCE7 /* write.pb.h */,
+			);
+			path = v1beta1;
+			sourceTree = "<group>";
+		};
+		618BBE9020B89AAC00B5BCE7 /* type */ = {
+			isa = PBXGroup;
+			children = (
+				618BBE9220B89AAC00B5BCE7 /* latlng.pb.cc */,
+				618BBE9120B89AAC00B5BCE7 /* latlng.pb.h */,
+			);
+			path = type;
+			sourceTree = "<group>";
+		};
+		618BBE9320B89AAC00B5BCE7 /* api */ = {
+			isa = PBXGroup;
+			children = (
+				618BBE9520B89AAC00B5BCE7 /* annotations.pb.cc */,
+				618BBE9620B89AAC00B5BCE7 /* annotations.pb.h */,
+				618BBE9720B89AAC00B5BCE7 /* http.pb.cc */,
+				618BBE9420B89AAC00B5BCE7 /* http.pb.h */,
+			);
+			path = api;
+			sourceTree = "<group>";
+		};
+		618BBE9820B89AAC00B5BCE7 /* rpc */ = {
+			isa = PBXGroup;
+			children = (
+				618BBE9920B89AAC00B5BCE7 /* status.pb.cc */,
+				618BBE9A20B89AAC00B5BCE7 /* status.pb.h */,
+			);
+			path = rpc;
 			sourceTree = "<group>";
 		};
 		6EDD3B5D20BF24A700C33877 /* FuzzTests */ = {
@@ -1360,12 +1496,14 @@
 				"${BUILT_PRODUCTS_DIR}/leveldb-library/leveldb.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleTest/GoogleTest.framework",
 				"${BUILT_PRODUCTS_DIR}/OCMock/OCMock.framework",
+				"${BUILT_PRODUCTS_DIR}/ProtobufCpp/ProtobufCpp.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/leveldb.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleTest.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMock.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ProtobufCpp.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1639,6 +1777,7 @@
 				5492E0CA2021557E00B64F25 /* FSTWatchChangeTests.mm in Sources */,
 				5492E0AB2021552D00B64F25 /* StringViewTests.mm in Sources */,
 				5492E03C2021401F00B64F25 /* XCTestCase+Await.mm in Sources */,
+				618BBEAF20B89AAC00B5BCE7 /* annotations.pb.cc in Sources */,
 				5467FB08203E6A44009C9584 /* app_testing.mm in Sources */,
 				54EB764D202277B30088B8F3 /* array_sorted_map_test.cc in Sources */,
 				B6FB4684208EA0EC00554BA2 /* async_queue_libdispatch_test.mm in Sources */,
@@ -1646,11 +1785,13 @@
 				B6FB467D208E9D3C00554BA2 /* async_queue_test.cc in Sources */,
 				54740A581FC914F000713A1A /* autoid_test.cc in Sources */,
 				AB380D02201BC69F00D97691 /* bits_test.cc in Sources */,
+				618BBEA920B89AAC00B5BCE7 /* common.pb.cc in Sources */,
 				548DB929200D59F600E00ABC /* comparison_test.cc in Sources */,
 				ABC1D7DC2023A04B00BA84F0 /* credentials_provider_test.cc in Sources */,
 				ABE6637A201FA81900ED349A /* database_id_test.cc in Sources */,
 				AB38D93020236E21000A432D /* database_info_test.cc in Sources */,
 				546854AA20A36867004BDBD5 /* datastore_test.cc in Sources */,
+				618BBEAC20B89AAC00B5BCE7 /* document.pb.cc in Sources */,
 				B6152AD7202A53CB000E5744 /* document_key_test.cc in Sources */,
 				AB6B908420322E4D00CC290A /* document_test.cc in Sources */,
 				ABC1D7DD2023A04F00BA84F0 /* empty_credentials_provider_test.cc in Sources */,
@@ -1662,28 +1803,37 @@
 				54A0352620A3AED0003E0143 /* field_transform_test.mm in Sources */,
 				AB356EF7200EA5EB0089B766 /* field_value_test.cc in Sources */,
 				ABC1D7E42024AFDE00BA84F0 /* firebase_credentials_provider_test.mm in Sources */,
+				618BBEAA20B89AAC00B5BCE7 /* firestore.pb.cc in Sources */,
 				AB7BAB342012B519001E0872 /* geo_point_test.cc in Sources */,
 				73FE5066020EF9B2892C86BF /* hard_assert_test.cc in Sources */,
 				54511E8E209805F8005BD28F /* hashing_test.cc in Sources */,
+				618BBEB020B89AAC00B5BCE7 /* http.pb.cc in Sources */,
 				54A0353520A3D8CB003E0143 /* iterator_adaptors_test.cc in Sources */,
+				618BBEAE20B89AAC00B5BCE7 /* latlng.pb.cc in Sources */,
 				54995F6F205B6E12004EFFA0 /* leveldb_key_test.cc in Sources */,
 				54C2294F1FECABAE007D065B /* log_test.cc in Sources */,
+				618BBEA720B89AAC00B5BCE7 /* maybe_document.pb.cc in Sources */,
 				AB6B908620322E6D00CC290A /* maybe_document_test.cc in Sources */,
+				618BBEA820B89AAC00B5BCE7 /* mutation.pb.cc in Sources */,
 				AB6B908820322E8800CC290A /* no_document_test.cc in Sources */,
 				AB380D04201BC6E400D97691 /* ordered_code_test.cc in Sources */,
 				5A080105CCBFDB6BF3F3772D /* path_test.cc in Sources */,
 				549CCA5920A36E1F00BCEB75 /* precondition_test.cc in Sources */,
+				618BBEAB20B89AAC00B5BCE7 /* query.pb.cc in Sources */,
 				B686F2B22025000D0028D6BE /* resource_path_test.cc in Sources */,
 				54740A571FC914BA00713A1A /* secure_random_test.cc in Sources */,
+				61F72C5620BC48FD001A68CB /* serializer_test.cc in Sources */,
 				ABA495BB202B7E80008A7851 /* snapshot_version_test.cc in Sources */,
 				549CCA5220A36DBC00BCEB75 /* sorted_map_test.cc in Sources */,
 				549CCA5020A36DBC00BCEB75 /* sorted_set_test.cc in Sources */,
+				618BBEB120B89AAC00B5BCE7 /* status.pb.cc in Sources */,
 				54A0352F20A3B3D8003E0143 /* status_test.cc in Sources */,
 				54A0353020A3B3D8003E0143 /* statusor_test.cc in Sources */,
 				1CAA9012B25F975D445D5978 /* strerror_test.cc in Sources */,
 				0535C1B65DADAE1CE47FA3CA /* string_format_apple_test.mm in Sources */,
 				54131E9720ADE679001DF3FF /* string_format_test.cc in Sources */,
 				AB380CFE201A2F4500D97691 /* string_util_test.cc in Sources */,
+				618BBEA620B89AAC00B5BCE7 /* target.pb.cc in Sources */,
 				AB380CFB2019388600D97691 /* target_id_generator_test.cc in Sources */,
 				54A0352A20A3B3BD003E0143 /* testutil.cc in Sources */,
 				ABF6506C201131F8005F2C74 /* timestamp_test.cc in Sources */,
@@ -1692,6 +1842,7 @@
 				549CCA5120A36DBC00BCEB75 /* tree_sorted_map_test.cc in Sources */,
 				C80B10E79CDD7EF7843C321E /* type_traits_apple_test.mm in Sources */,
 				ABC1D7DE2023A05300BA84F0 /* user_test.cc in Sources */,
+				618BBEAD20B89AAC00B5BCE7 /* write.pb.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1924,6 +2075,7 @@
 				HEADER_SEARCH_PATHS = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1957,6 +2109,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				OTHER_CFLAGS = "";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -2036,10 +2189,61 @@
 					"\"${PODS_ROOT}/GoogleTest/googlemock/include\"",
 					"\"${PODS_ROOT}/GoogleTest/googletest/include\"",
 					"\"${PODS_ROOT}/leveldb-library/include\"",
+					"\"${PODS_ROOT}/../../../Firestore/Protos/cpp\"",
+					"\"${PODS_ROOT}/ProtobufCpp/src\"",
 				);
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/GoogleTest/GoogleTest.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/OCMock/OCMock.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/ProtobufCpp/ProtobufCpp.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/leveldb-library/leveldb.framework/Headers\"",
+					"$(inherited)",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/BoringSSL/openssl.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/FirebaseAuth/FirebaseAuth.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/FirebaseCore/FirebaseCore.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/FirebaseFirestore/FirebaseFirestore.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/GoogleToolboxForMac/GoogleToolboxForMac.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/Protobuf/Protobuf.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/gRPC-Core/grpc.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/gRPC-ProtoRPC/ProtoRPC.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/gRPC-RxLibrary/RxLibrary.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/gRPC/GRPCClient.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/leveldb-library/leveldb.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/nanopb/nanopb.framework/Headers\"",
+					"-isystem",
+					"\"${PODS_ROOT}/Headers/Public\"",
+					"-isystem",
+					"\"${PODS_ROOT}/Headers/Public/Firebase\"",
+					"-isystem",
+					"\"${PODS_ROOT}/Headers/Public/FirebaseAnalytics\"",
+					"-isystem",
+					"\"${PODS_ROOT}/Headers/Public/FirebaseInstanceID\"",
+					"-DPB_FIELD_32BIT",
+					"-DPB_NO_PACKED_STRUCTS=1",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYSTEM_HEADER_SEARCH_PATHS = "\"${PODS_ROOT}/nanopb\"";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Firestore_Example_iOS.app/Firestore_Example_iOS";
 				WRAPPER_EXTENSION = xctest;
 			};
@@ -2070,10 +2274,61 @@
 					"\"${PODS_ROOT}/GoogleTest/googlemock/include\"",
 					"\"${PODS_ROOT}/GoogleTest/googletest/include\"",
 					"\"${PODS_ROOT}/leveldb-library/include\"",
+					"\"${PODS_ROOT}/../../../Firestore/Protos/cpp\"",
+					"\"${PODS_ROOT}/ProtobufCpp/src\"",
 				);
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/GoogleTest/GoogleTest.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/OCMock/OCMock.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/ProtobufCpp/ProtobufCpp.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/leveldb-library/leveldb.framework/Headers\"",
+					"$(inherited)",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/BoringSSL/openssl.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/FirebaseAuth/FirebaseAuth.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/FirebaseCore/FirebaseCore.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/FirebaseFirestore/FirebaseFirestore.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/GoogleToolboxForMac/GoogleToolboxForMac.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/Protobuf/Protobuf.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/gRPC-Core/grpc.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/gRPC-ProtoRPC/ProtoRPC.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/gRPC-RxLibrary/RxLibrary.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/gRPC/GRPCClient.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/leveldb-library/leveldb.framework/Headers\"",
+					"-iquote",
+					"\"${PODS_CONFIGURATION_BUILD_DIR}/nanopb/nanopb.framework/Headers\"",
+					"-isystem",
+					"\"${PODS_ROOT}/Headers/Public\"",
+					"-isystem",
+					"\"${PODS_ROOT}/Headers/Public/Firebase\"",
+					"-isystem",
+					"\"${PODS_ROOT}/Headers/Public/FirebaseAnalytics\"",
+					"-isystem",
+					"\"${PODS_ROOT}/Headers/Public/FirebaseInstanceID\"",
+					"-DPB_FIELD_32BIT",
+					"-DPB_NO_PACKED_STRUCTS=1",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SYSTEM_HEADER_SEARCH_PATHS = "\"${PODS_ROOT}/nanopb\"";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Firestore_Example_iOS.app/Firestore_Example_iOS";
 				WRAPPER_EXTENSION = xctest;
 			};

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -22,6 +22,7 @@ target 'Firestore_Example_iOS' do
     pod 'leveldb-library'
     pod 'OCMock'
     pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
+    pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
   end
 
   target 'Firestore_IntegrationTests_iOS' do

--- a/Firestore/Example/ProtobufCpp.podspec
+++ b/Firestore/Example/ProtobufCpp.podspec
@@ -1,0 +1,74 @@
+# Copyright 2018 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A Private podspec for Protobuf which exposes the C++ headers (rather than
+# only the Obj-C headers). Suitable only for use inside this source tree.
+
+Pod::Spec.new do |s|
+  s.name             = 'ProtobufCpp'
+  s.version          = '3.5.2'
+  s.summary          = 'Protocol Buffers v.3 runtime library for C++.'
+  s.homepage         = 'https://github.com/google/protobuf'
+  s.license          = '3-Clause BSD License'
+  s.authors          = { 'The Protocol Buffers contributors' => 'protobuf@googlegroups.com' }
+  s.cocoapods_version = '>= 1.0'
+
+  s.source           = {
+    :git => 'https://github.com/google/protobuf.git',
+    :tag => "v#{s.version}"
+  }
+
+  s.source_files = 'src/**/*.{h,cc}'
+  s.exclude_files = # skip test files. (Yes, the test files are intermixed with
+                    # the source. No there doesn't seem to be a common/simple
+                    # pattern we could use to exclude them; 'test' appears in
+                    # various places throughout the file names and also in a
+                    # non-test file. So, we'll exclude all files that either
+                    # start with 'test' or include test and have a previous
+                    # character that isn't "y" (so that bytestream isn't
+                    # matched.))
+                    'src/**/test*.*',
+                    'src/**/*[^y]test*.*',
+                    'src/**/testing/**',
+                    'src/**/mock*',
+                    # skip the javascript handling code.
+                    'src/**/js/**',
+                    # skip the protoc compiler
+                    'src/google/protobuf/compiler/**/*'
+
+  s.header_mappings_dir = 'src/'
+
+  # Set a CPP symbol so the code knows to use framework imports.
+  s.pod_target_xcconfig = {
+    'GCC_PREPROCESSOR_DEFINITIONS' =>
+      '$(inherited) ' +
+      'GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1 ' +
+      'HAVE_PTHREAD=1',
+    'HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/ProtobufCpp/src"',
+
+    # Cocoapods flattens header imports, leading to much anguish.  The
+    # following two statements work around this.
+    # - https://github.com/CocoaPods/CocoaPods/issues/1437
+    'USE_HEADERMAP' => 'NO',
+    'ALWAYS_SEARCH_USER_PATHS' => 'NO',
+  }
+
+  # Disable warnings that upstream does not concern itself with
+  s.compiler_flags = '$(inherited) ' +
+    '-Wno-comma ' +
+    '-Wno-shorten-64-to-32'
+
+  s.requires_arc = false
+  s.library = 'c++'
+end

--- a/Firestore/Source/Remote/FSTDatastore.mm
+++ b/Firestore/Source/Remote/FSTDatastore.mm
@@ -240,7 +240,7 @@ typedef GRPCProtoCall * (^RPCFactory)(void);
                          error = [FSTDatastore firestoreErrorForError:error];
                          [self.workerDispatchQueue dispatchAsync:^{
                            if (error != nil && error.code == FIRFirestoreErrorCodeUnauthenticated) {
-                             _credentials->InvalidateToken();
+                             self->_credentials->InvalidateToken();
                            }
                            LOG_DEBUG("RPC CommitRequest completed. Error: %s", error);
                            [FSTDatastore logHeadersForRPC:rpc RPCName:@"CommitRequest"];
@@ -277,7 +277,7 @@ typedef GRPCProtoCall * (^RPCFactory)(void);
                                  if (error) {
                                    LOG_DEBUG("RPC BatchGetDocuments completed. Error: %s", error);
                                    if (error.code == FIRFirestoreErrorCodeUnauthenticated) {
-                                     _credentials->InvalidateToken();
+                                     self->_credentials->InvalidateToken();
                                    }
                                    [FSTDatastore logHeadersForRPC:rpc RPCName:@"BatchGetDocuments"];
                                    completion(nil, error);

--- a/Firestore/core/src/firebase/firestore/nanopb/reader.cc
+++ b/Firestore/core/src/firebase/firestore/nanopb/reader.cc
@@ -110,14 +110,13 @@ std::string Reader::ReadString() {
   pb_istream_t substream;
   if (!pb_make_string_substream(&stream_, &substream)) {
     status_ = Status(FirestoreErrorCode::DataLoss, PB_GET_ERROR(&stream_));
-    pb_close_string_substream(&stream_, &substream);
     return "";
   }
 
   std::string result(substream.bytes_left, '\0');
   if (!pb_read(&substream, reinterpret_cast<pb_byte_t*>(&result[0]),
                substream.bytes_left)) {
-    status_ = Status(FirestoreErrorCode::DataLoss, PB_GET_ERROR(&stream_));
+    status_ = Status(FirestoreErrorCode::DataLoss, PB_GET_ERROR(&substream));
     pb_close_string_substream(&stream_, &substream);
     return "";
   }

--- a/Firestore/core/src/firebase/firestore/nanopb/reader.h
+++ b/Firestore/core/src/firebase/firestore/nanopb/reader.h
@@ -150,7 +150,6 @@ T Reader::ReadNestedMessage(const std::function<T(Reader*)>& read_message_fn) {
   if (!pb_make_string_substream(&stream_, &raw_substream)) {
     status_ =
         util::Status(FirestoreErrorCode::DataLoss, PB_GET_ERROR(&stream_));
-    pb_close_string_substream(&stream_, &raw_substream);
     return read_message_fn(this);
   }
   Reader substream(raw_substream);

--- a/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
+++ b/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
@@ -656,7 +656,7 @@ TEST_F(SerializerTest, BadFieldValueTagWithOtherValidTagsPresent) {
   // Craft the bytes. boolean_value has a smaller tag, so it'll get encoded
   // first, normally implying integer_value should "win". Except that
   // integer_value isn't a valid tag, so it should be ignored here.
-  google_firestore_v1beta1_Value_Fake crafty_value{false, int64_t{42}};
+  google_firestore_v1beta1_Value_Fake crafty_value{true, int64_t{42}};
   std::vector<uint8_t> bytes(128);
   pb_ostream_t stream = pb_ostream_from_buffer(bytes.data(), bytes.size());
   pb_encode(&stream, google_firestore_v1beta1_Value_fields_Fake, &crafty_value);
@@ -664,11 +664,12 @@ TEST_F(SerializerTest, BadFieldValueTagWithOtherValidTagsPresent) {
 
   // Decode the bytes into the model
   StatusOr<FieldValue> actual_model_status = serializer.DecodeFieldValue(bytes);
+  Status s = actual_model_status.status();
   EXPECT_OK(actual_model_status);
   FieldValue actual_model = actual_model_status.ValueOrDie();
 
   // Ensure the decoded model is as expected.
-  FieldValue expected_model = FieldValue::BooleanValue(false);
+  FieldValue expected_model = FieldValue::BooleanValue(true);
   EXPECT_EQ(FieldValue::Type::Boolean, actual_model.type());
   EXPECT_EQ(expected_model, actual_model);
 }

--- a/scripts/check_test_inclusion.py
+++ b/scripts/check_test_inclusion.py
@@ -26,8 +26,6 @@ import sys
 
 # Tests that are known not to compile in Xcode and can't be added there.
 EXCLUDED = frozenset([
-    # b/79496027
-    "Firestore/core/test/firebase/firestore/remote/serializer_test.cc",
 ])
 
 

--- a/scripts/sync_project.rb
+++ b/scripts/sync_project.rb
@@ -50,15 +50,13 @@ def sync_firestore()
     'CMakeLists.txt',
     'InfoPlist.strings',
     '*.plist',
-
-    # b/79496027
-    'Firestore/core/test/firebase/firestore/remote/serializer_test.cc',
   ]
 
   # Folder groups in the Xcode project that contain tests.
   s.test_groups = [
     'Tests',
     'CoreTests',
+    'CoreTestsProtos',
     'SwiftTests',
   ]
 
@@ -66,6 +64,7 @@ def sync_firestore()
     t.source_files = [
       'Firestore/Example/Tests/**',
       'Firestore/core/test/**',
+      'Firestore/Protos/cpp/**',
       'Firestore/third_party/Immutable/Tests/**',
     ]
     t.exclude_files = [


### PR DESCRIPTION
Add a warning message, letting dev know that the operation is suspended when token is not available and it will resume once the token is retrieved.

We will leave the API change outside this CL.