### PR TITLE
remove the token check for topic subscription/unsubscription

### DIFF
--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -695,7 +695,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
 
 - (void)subscribeToTopic:(NSString *)topic
               completion:(nullable FIRMessagingTopicOperationCompletion)completion {
-  if (self.defaultFcmToken.length && topic.length) {
+  if (topic.length) {
     NSString *normalizeTopic = [[self class ] normalizeTopic:topic];
     if ([FIRMessagingPubSub hasTopicsPrefix:topic]) {
       FIRMessagingLoggerWarn(kFIRMessagingMessageCodeTopicFormatIsDeprecated,
@@ -721,7 +721,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
 
 - (void)unsubscribeFromTopic:(NSString *)topic
                   completion:(nullable FIRMessagingTopicOperationCompletion)completion {
-  if (self.defaultFcmToken.length && topic.length) {
+  if (topic.length) {
     NSString *normalizeTopic = [[self class] normalizeTopic:topic];
     if ([FIRMessagingPubSub hasTopicsPrefix:topic]) {
       FIRMessagingLoggerWarn(kFIRMessagingMessageCodeTopicFormatIsDeprecated,


### PR DESCRIPTION
Client had a feature that it queues up the topic requests when token is not available. And when token is regenerated, client will sync all pending topic requests and send them to server. This is consistent with Android.

Apparently this feature exists, but we did a unnecessary checking if token doesn't exist, client simply returns without queue up topic requests.

