### PR TITLE
add a warning message that the topic operation is suspended without a token

### DIFF
--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -680,6 +680,9 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
 #pragma mark - Topics
 
 + (NSString *)normalizeTopic:(NSString *)topic {
+  if (!topic.length) {
+    return nil;
+  }
   if (![FIRMessagingPubSub hasTopicsPrefix:topic]) {
     topic = [FIRMessagingPubSub addPrefixToTopic:topic];
   }
@@ -695,25 +698,24 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
 
 - (void)subscribeToTopic:(NSString *)topic
               completion:(nullable FIRMessagingTopicOperationCompletion)completion {
-  if (topic.length) {
-    NSString *normalizeTopic = [[self class ] normalizeTopic:topic];
-    if ([FIRMessagingPubSub hasTopicsPrefix:topic]) {
-      FIRMessagingLoggerWarn(kFIRMessagingMessageCodeTopicFormatIsDeprecated,
-                             @"Format '%@' is deprecated. Only '%@' should be used in "
-                             @"subscribeToTopic.", topic,
-                             [FIRMessagingPubSub removePrefixFromTopic:topic]);
-    }
-    if (normalizeTopic.length) {
-      [self.pubsub subscribeToTopic:normalizeTopic handler:completion];
-    } else {
-      FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging009,
-                              @"Cannot parse topic name %@. Will not subscribe.", topic);
-    }
-  } else {
-    FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging010,
-                            @"Cannot subscribe to topic: %@ with token: %@", topic,
-                            self.defaultFcmToken);
+  if ([FIRMessagingPubSub hasTopicsPrefix:topic]) {
+    FIRMessagingLoggerWarn(kFIRMessagingMessageCodeTopicFormatIsDeprecated,
+                           @"Format '%@' is deprecated. Only '%@' should be used in "
+                           @"subscribeToTopic.",
+                           topic, [FIRMessagingPubSub removePrefixFromTopic:topic]);
   }
+  if (!self.defaultFcmToken.length) {
+    FIRMessagingLoggerWarn(kFIRMessagingMessageCodeMessaging010,
+                           @"The subscription operation is suspended because you don't have a "
+                           @"token. The operation will resume once you get an FCM token.");
+  }
+  NSString *normalizeTopic = [[self class] normalizeTopic:topic];
+  if (normalizeTopic.length) {
+    [self.pubsub subscribeToTopic:normalizeTopic handler:completion];
+    return;
+  }
+  FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging009,
+                          @"Cannot parse topic name %@. Will not subscribe.", topic);
 }
 
 - (void)unsubscribeFromTopic:(NSString *)topic {
@@ -722,25 +724,24 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
 
 - (void)unsubscribeFromTopic:(NSString *)topic
                   completion:(nullable FIRMessagingTopicOperationCompletion)completion {
-  if (topic.length) {
-    NSString *normalizeTopic = [[self class] normalizeTopic:topic];
-    if ([FIRMessagingPubSub hasTopicsPrefix:topic]) {
-      FIRMessagingLoggerWarn(kFIRMessagingMessageCodeTopicFormatIsDeprecated,
-                             @"Format '%@' is deprecated. Only '%@' should be used in "
-                             @"unsubscribeFromTopic.", topic,
-                             [FIRMessagingPubSub removePrefixFromTopic:topic]);
-    }
-    if (normalizeTopic.length) {
-      [self.pubsub unsubscribeFromTopic:normalizeTopic handler:completion];
-    } else {
-      FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging011,
-                              @"Cannot parse topic name %@. Will not unsubscribe.", topic);
-    }
-  } else {
-    FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging012,
-                            @"Cannot unsubscribe to topic: %@ with token: %@", topic,
-                            self.defaultFcmToken);
+ if ([FIRMessagingPubSub hasTopicsPrefix:topic]) {
+    FIRMessagingLoggerWarn(kFIRMessagingMessageCodeTopicFormatIsDeprecated,
+                           @"Format '%@' is deprecated. Only '%@' should be used in "
+                           @"unsubscribeFromTopic.",
+                           topic, [FIRMessagingPubSub removePrefixFromTopic:topic]);
   }
+  if (!self.defaultFcmToken.length) {
+    FIRMessagingLoggerWarn(kFIRMessagingMessageCodeMessaging012,
+                           @"The unsubscription operation is suspended because you don't have a "
+                           @"token. The operation will resume once you get an FCM token.");
+  }
+  NSString *normalizeTopic = [[self class] normalizeTopic:topic];
+  if (normalizeTopic.length) {
+    [self.pubsub unsubscribeFromTopic:normalizeTopic handler:completion];
+    return;
+  }
+  FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging011,
+                          @"Cannot parse topic name %@. Will not unsubscribe.", topic);
 }
 
 #pragma mark - Send


### PR DESCRIPTION
When token is not available and developer is trying to subscribe/unsubscribe a topic, we should add a warning letting them know that the operation will be suspended. When developer gets a new token, the operation will resume with completion handler triggered.