### PR TITLE
Add a couple of new small Functions APIs.

### DIFF
--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseFunctions'
-  s.version          = '2.0.1'
+  s.version          = '2.0.0'
   s.summary          = 'Cloud Functions for Firebase iOS SDK.'
 
   s.description      = <<-DESC

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseFunctions'
-  s.version          = '2.0.0'
+  s.version          = '2.0.1'
   s.summary          = 'Cloud Functions for Firebase iOS SDK.'
 
   s.description      = <<-DESC

--- a/Functions/CHANGELOG.md
+++ b/Functions/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v2.1.0
+- Add an constructor to set the region.
+
 # v2.0.0
 - Remove FIR prefix on FIRFunctionsErrorCode in Swift.
 

--- a/Functions/CHANGELOG.md
+++ b/Functions/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v2.1.0
-- Add an constructor to set the region.
+- Add a constructor to set the region.
+- Add a method to set a Cloud Functions emulator origin to use, for testing.
 
 # v2.0.0
 - Remove FIR prefix on FIRFunctionsErrorCode in Swift.

--- a/Functions/Example/Tests/FIRFunctionsTests.m
+++ b/Functions/Example/Tests/FIRFunctionsTests.m
@@ -33,17 +33,13 @@
 }
 
 - (void)testURLWithName {
-  // TODO(klimt): Add this test back when we add the constructor back.
-  /*
   id app = [[FUNFakeApp alloc] initWithProjectID:@"my-project"];
   FIRFunctions *functions = [FIRFunctions functionsForApp:app region:@"my-region"];
   NSString *url = [functions URLWithName:@"my-endpoint"];
   XCTAssertEqualObjects(@"https://my-region-my-project.cloudfunctions.net/my-endpoint", url);
-  */
 
-  id app = [[FUNFakeApp alloc] initWithProjectID:@"my-project"];
-  FIRFunctions *functions = [FIRFunctions functionsForApp:app];
-  NSString *url = [functions URLWithName:@"my-endpoint"];
+  functions = [FIRFunctions functionsForApp:app];
+  url = [functions URLWithName:@"my-endpoint"];
   XCTAssertEqualObjects(@"https://us-central1-my-project.cloudfunctions.net/my-endpoint", url);
 }
 

--- a/Functions/FirebaseFunctions/Public/FIRFunctions.h
+++ b/Functions/FirebaseFunctions/Public/FIRFunctions.h
@@ -61,6 +61,13 @@ NS_SWIFT_NAME(Functions)
  */
 - (FIRHTTPSCallable *)HTTPSCallableWithName:(NSString *)name NS_SWIFT_NAME(httpsCallable(_:));
 
+/**
+ * Changes this instance to point to a Cloud Functions emulator running locally.
+ * See https://firebase.google.com/docs/functions/local-emulator
+ * @param origin The origin of the local emulator, such as "http://localhost:5005".
+ */
+- (void)useFunctionsEmulatorOrigin:(NSString *)origin NS_SWIFT_NAME(useFunctionsEmulator(origin:));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Functions/FirebaseFunctions/Public/FIRFunctions.h
+++ b/Functions/FirebaseFunctions/Public/FIRFunctions.h
@@ -42,7 +42,7 @@ NS_SWIFT_NAME(Functions)
  * Creates a Cloud Functions client with the default app and given region.
  * @param region The region for the http trigger, such as "us-central1".
  */
-// + (instancetype)functionsForRegion:(NSString *)region NS_SWIFT_NAME(functions(region:));
++ (instancetype)functionsForRegion:(NSString *)region NS_SWIFT_NAME(functions(region:));
 
 /**
  * Creates a Cloud Functions client with the given app and region.
@@ -51,8 +51,8 @@ NS_SWIFT_NAME(Functions)
  */
 // clang-format off
 // because it incorrectly breaks this NS_SWIFT_NAME.
-// + (instancetype)functionsForApp:(FIRApp *)app
-//                         region:(NSString *)region NS_SWIFT_NAME(functions(app:region:));
++ (instancetype)functionsForApp:(FIRApp *)app
+                         region:(NSString *)region NS_SWIFT_NAME(functions(app:region:));
 // clang-format on
 
 /**


### PR DESCRIPTION
- Add a Functions constructor that allows setting a Cloud Functions region.
- Add a method to set an Cloud Functions emulator origin to use for local testing.
- Update the change log.
- Update the version number for the next release.
