### PR TITLE
Add informative error to JWT parse failures

### DIFF
--- a/Example/Auth/Tests/FIRAuthTests.m
+++ b/Example/Auth/Tests/FIRAuthTests.m
@@ -1863,16 +1863,17 @@ static const NSTimeInterval kWaitInterval = .5;
   [self waitForSignInWithAccessToken:kTestAccessToken
                               APIKey:kTestAPIKey
                           completion:nil];
-    NSString *kTestAPIKey2 = @"fakeAPIKey2";
-    FIRUser *user2 = [FIRAuth auth].currentUser;
-    user2.requestConfiguration = [[FIRAuthRequestConfiguration alloc]initWithAPIKey:kTestAPIKey2];
-    OCMExpect([_mockBackend getAccountInfo:[OCMArg any] callback:[OCMArg any]])
-      .andDispatchError2([FIRAuthErrorUtils networkErrorWithUnderlyingError:[NSError new]]);
-    XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
-    [[FIRAuth auth] updateCurrentUser:user2 completion:^(NSError *_Nullable error) {
-      XCTAssertEqual(error.code, FIRAuthErrorCodeNetworkError);
-      [expectation fulfill];
-    }];
+  NSString *kTestAPIKey2 = @"fakeAPIKey2";
+  FIRUser *user2 = [FIRAuth auth].currentUser;
+  user2.requestConfiguration = [[FIRAuthRequestConfiguration alloc]initWithAPIKey:kTestAPIKey2];
+  NSError *underlyingError = [NSError errorWithDomain:@"Test Error" code:1 userInfo:nil];
+  OCMExpect([_mockBackend getAccountInfo:[OCMArg any] callback:[OCMArg any]])
+    .andDispatchError2([FIRAuthErrorUtils networkErrorWithUnderlyingError:underlyingError]);
+  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+  [[FIRAuth auth] updateCurrentUser:user2 completion:^(NSError *_Nullable error) {
+    XCTAssertEqual(error.code, FIRAuthErrorCodeNetworkError);
+    [expectation fulfill];
+  }];
   [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
   OCMVerifyAll(_mockBackend);
 }

--- a/Example/Auth/Tests/FIRPhoneAuthProviderTests.m
+++ b/Example/Auth/Tests/FIRPhoneAuthProviderTests.m
@@ -453,7 +453,8 @@ static const NSTimeInterval kExpectationTimeout = 2;
     // Assert that the app credential is nil when in test mode.
     XCTAssertNil(request.appCredential);
     dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
-      callback(nil, [FIRAuthErrorUtils networkErrorWithUnderlyingError:[NSError new]]);
+      NSError *underlying = [NSError errorWithDomain:@"Test Error" code:1 userInfo:nil];
+      callback(nil, [FIRAuthErrorUtils networkErrorWithUnderlyingError:underlying]);
     });
   });
 

--- a/Example/Auth/Tests/FIRUserTests.m
+++ b/Example/Auth/Tests/FIRUserTests.m
@@ -1151,8 +1151,8 @@ static const NSTimeInterval kExpectationTimeout = 2;
       XCTAssertEqualObjects(request.APIKey, kAPIKey);
 
       dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
-
-        callback(nil, [FIRAuthErrorUtils networkErrorWithUnderlyingError:[NSError new]]);
+        NSError *underlying = [NSError errorWithDomain:@"Test Error" code:1 userInfo:nil];
+        callback(nil, [FIRAuthErrorUtils networkErrorWithUnderlyingError:underlying]);
       });
     });
     [user getIDTokenResultForcingRefresh:YES

--- a/Firebase/Auth/Source/FIRAuthErrorUtils.h
+++ b/Firebase/Auth/Source/FIRAuthErrorUtils.h
@@ -85,6 +85,19 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSError *)unexpectedErrorResponseWithDeserializedResponse:(id)deserializedResponse;
 
+/** @fn malformedJWTErrorWithToken:underlyingError:
+    @brief Constructs an @c NSError with the code set to @c FIRAuthErrorCodeMalformedJWT and
+        populates the userInfo dictionary with an error message, the bad token, and an underlying
+        error that may have occurred when parsing.
+    @param token The token that failed to parse.
+    @param underlyingError The error that caused this error. If this parameter is nil, the
+        NSUnderlyingErrorKey value will not be set.
+    @remarks This error is returned when JWT parsing fails.
+    @returns An @c FIRAuthErrorCodeMalformedJWT error wrapping an underlying error, if available.
+ */
++ (NSError *)malformedJWTErrorWithToken:(NSString *)token
+                        underlyingError:(NSError *_Nullable)underlyingError;
+
 /** @fn unexpectedResponseWithData:underlyingError:
     @brief Constructs an @c NSError with the @c FIRAuthInternalErrorCodeUnexpectedResponse
         code, and a populated @c FIRAuthErrorUserInfoDataKey key in the @c NSError.userInfo

--- a/Firebase/Auth/Source/FIRAuthErrorUtils.m
+++ b/Firebase/Auth/Source/FIRAuthErrorUtils.m
@@ -413,6 +413,12 @@ static NSString *const kFIRAuthErrorMessageNullUser = @"A null user object was p
 static NSString *const kFIRAuthErrorMessageInternalError = @"An internal error has occurred, "
     "print and inspect the error details for more information.";
 
+/** @var kFIRAuthErrorMessageMalformedJWT
+    @brief Error message constant describing @c FIRAuthErrorCodeMalformedJWT errors.
+ */
+static NSString *const kFIRAuthErrorMessageMalformedJWT =
+    @"Failed to parse JWT. Check the userInfo dictionary for the full token.";
+
 /** @var FIRAuthErrorDescription
     @brief The error descrioption, based on the error code.
     @remarks No default case so that we get a compiler warning if a new value was added to the enum.
@@ -531,6 +537,8 @@ static NSString *FIRAuthErrorDescription(FIRAuthErrorCode code) {
       return kFIRAuthErrorMessageNullUser;
     case FIRAuthErrorCodeWebInternalError:
       return kFIRAuthErrorMessageWebInternalError;
+    case FIRAuthErrorCodeMalformedJWT:
+      return kFIRAuthErrorMessageMalformedJWT;
   }
 }
 
@@ -652,6 +660,8 @@ static NSString *const FIRAuthErrorCodeString(FIRAuthErrorCode code) {
       return @"ERROR_NULL_USER";
     case FIRAuthErrorCodeWebInternalError:
       return @"ERROR_WEB_INTERNAL_ERROR";
+    case FIRAuthErrorCodeMalformedJWT:
+      return @"ERROR_MALFORMED_JWT";
   }
 }
 
@@ -733,6 +743,18 @@ static NSString *const FIRAuthErrorCodeString(FIRAuthErrorCode code) {
   return [self errorWithCode:FIRAuthInternalErrorCodeUnexpectedErrorResponse userInfo:@{
     FIRAuthErrorUserInfoDeserializedResponseKey : deserializedResponse
   }];
+}
+
++ (NSError *)malformedJWTErrorWithToken:(NSString *)token
+                        underlyingError:(NSError *_Nullable)underlyingError {
+  NSMutableDictionary *userInfo =
+      [NSMutableDictionary dictionaryWithObject:kFIRAuthErrorMessageMalformedJWT
+                                         forKey:NSLocalizedDescriptionKey];
+  [userInfo setObject:token forKey:FIRAuthErrorUserInfoDataKey];
+  if (underlyingError != nil) {
+    [userInfo setObject:underlyingError forKey:NSUnderlyingErrorKey];
+  }
+  return [self errorWithCode:FIRAuthInternalErrorCodeMalformedJWT userInfo:[userInfo copy]];
 }
 
 + (NSError *)unexpectedResponseWithData:(NSData *)data

--- a/Firebase/Auth/Source/FIRAuthInternalErrors.h
+++ b/Firebase/Auth/Source/FIRAuthInternalErrors.h
@@ -376,6 +376,9 @@ typedef NS_ENUM(NSInteger, FIRAuthInternalErrorCode) {
   FIRAuthInternalErrorCodeNullUser =
       FIRAuthPublicErrorCodeFlag | FIRAuthErrorCodeNullUser,
 
+  FIRAuthInternalErrorCodeMalformedJWT =
+      FIRAuthPublicErrorCodeFlag | FIRAuthErrorCodeMalformedJWT,
+
   /** @var FIRAuthInternalErrorCodeRPCRequestEncodingError
       @brief Indicates an error encoding the RPC request.
       @remarks This is typically due to some sort of unexpected input value.

--- a/Firebase/Auth/Source/Public/FIRAuthErrors.h
+++ b/Firebase/Auth/Source/Public/FIRAuthErrors.h
@@ -311,6 +311,11 @@ typedef NS_ENUM(NSInteger, FIRAuthErrorCode) {
     /** Indicates an internal error occurred.
      */
     FIRAuthErrorCodeInternalError = 17999,
+
+    /** Raised when a JWT fails to parse correctly. May be accompanied by an underlying error
+        describing which step of the JWT parsing process failed.
+     */
+    FIRAuthErrorCodeMalformedJWT = 18000,
 } NS_SWIFT_NAME(AuthErrorCode);
 
 @end


### PR DESCRIPTION
- Fixes a potential crash when decoding malformed JWTs with less than three components.
- Improves error messaging when decoding JWTs.
- Removes deprecated usage of `[NSError new]` in tests.

~~Do not merge before #1448.~~

Pending API review.