### PR TITLE
Refactor nanopb decoding methods

### DIFF
--- a/Firestore/core/src/firebase/firestore/nanopb/reader.cc
+++ b/Firestore/core/src/firebase/firestore/nanopb/reader.cc
@@ -46,6 +46,18 @@ Tag Reader::ReadTag() {
   return tag;
 }
 
+bool Reader::RequireWireType(pb_wire_type_t wire_type, Tag tag) {
+  if (!status_.ok()) return false;
+  if (wire_type != tag.wire_type) {
+    set_status(
+        Status(FirestoreErrorCode::DataLoss,
+               "Input proto bytes cannot be parsed (mismatch between "
+               "the wiretype and the field number (tag))"));
+    return false;
+  }
+  return true;
+}
+
 void Reader::ReadNanopbMessage(const pb_field_t fields[], void* dest_struct) {
   if (!status_.ok()) return;
 

--- a/Firestore/core/src/firebase/firestore/nanopb/reader.cc
+++ b/Firestore/core/src/firebase/firestore/nanopb/reader.cc
@@ -49,10 +49,9 @@ Tag Reader::ReadTag() {
 bool Reader::RequireWireType(pb_wire_type_t wire_type, Tag tag) {
   if (!status_.ok()) return false;
   if (wire_type != tag.wire_type) {
-    set_status(
-        Status(FirestoreErrorCode::DataLoss,
-               "Input proto bytes cannot be parsed (mismatch between "
-               "the wiretype and the field number (tag))"));
+    set_status(Status(FirestoreErrorCode::DataLoss,
+                      "Input proto bytes cannot be parsed (mismatch between "
+                      "the wiretype and the field number (tag))"));
     return false;
   }
   return true;

--- a/Firestore/core/src/firebase/firestore/nanopb/reader.h
+++ b/Firestore/core/src/firebase/firestore/nanopb/reader.h
@@ -58,6 +58,16 @@ class Reader {
   Tag ReadTag();
 
   /**
+   * Ensures the specified tag is of the specified type. If not, then
+   * Reader::status() will return a non-ok value (with the code set to
+   * FirestoreErrorCode::DataLoss).
+   *
+   * @return Convenience indicator for success. (If false, then status() will
+   * return a non-ok value.)
+   */
+  bool RequireWireType(pb_wire_type_t wire_type, Tag tag);
+
+  /**
    * Reads a nanopb message from the input stream.
    *
    * This essentially wraps calls to nanopb's pb_decode() method. If we didn't

--- a/Firestore/core/src/firebase/firestore/remote/serializer.cc
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.cc
@@ -122,34 +122,40 @@ FieldValue DecodeFieldValueImpl(Reader* reader) {
     // Ensure the tag matches the wire type
     switch (tag.field_number) {
       case google_firestore_v1beta1_Value_null_value_tag:
-        if (!reader->RequireWireType(PB_WT_VARINT, tag)) return FieldValue::NullValue();
+        if (!reader->RequireWireType(PB_WT_VARINT, tag))
+          return FieldValue::NullValue();
         reader->ReadNull();
         result = FieldValue::NullValue();
         break;
 
       case google_firestore_v1beta1_Value_boolean_value_tag:
-        if (!reader->RequireWireType(PB_WT_VARINT, tag)) return FieldValue::NullValue();
+        if (!reader->RequireWireType(PB_WT_VARINT, tag))
+          return FieldValue::NullValue();
         result = FieldValue::BooleanValue(reader->ReadBool());
         break;
 
       case google_firestore_v1beta1_Value_integer_value_tag:
-        if (!reader->RequireWireType(PB_WT_VARINT, tag)) return FieldValue::NullValue();
+        if (!reader->RequireWireType(PB_WT_VARINT, tag))
+          return FieldValue::NullValue();
         result = FieldValue::IntegerValue(reader->ReadInteger());
         break;
 
       case google_firestore_v1beta1_Value_string_value_tag:
-        if (!reader->RequireWireType(PB_WT_STRING, tag)) return FieldValue::NullValue();
+        if (!reader->RequireWireType(PB_WT_STRING, tag))
+          return FieldValue::NullValue();
         result = FieldValue::StringValue(reader->ReadString());
         break;
 
       case google_firestore_v1beta1_Value_timestamp_value_tag:
-        if (!reader->RequireWireType(PB_WT_STRING, tag)) return FieldValue::NullValue();
+        if (!reader->RequireWireType(PB_WT_STRING, tag))
+          return FieldValue::NullValue();
         result = FieldValue::TimestampValue(
             reader->ReadNestedMessage<Timestamp>(DecodeTimestamp));
         break;
 
       case google_firestore_v1beta1_Value_map_value_tag:
-        if (!reader->RequireWireType(PB_WT_STRING, tag)) return FieldValue::NullValue();
+        if (!reader->RequireWireType(PB_WT_STRING, tag))
+          return FieldValue::NullValue();
         // TODO(rsgowman): We should merge the existing map (if any) with the
         // newly parsed map.
         result = FieldValue::ObjectValueFromMap(

--- a/Firestore/core/src/firebase/firestore/remote/serializer.cc
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.cc
@@ -466,22 +466,15 @@ std::unique_ptr<MaybeDocument> Serializer::DecodeBatchGetDocumentsResponse(
         missing = reader->ReadString();
         break;
 
-      case google_firestore_v1beta1_BatchGetDocumentsResponse_transaction_tag:
-        if (!reader->RequireWireType(PB_WT_STRING, tag)) return nullptr;
-        // This field is ignored by the client sdk, but we still need to extract
-        // it.
-        // TODO(rsgowman) switch this to reader->SkipField() (or whatever we end
-        // up calling it) once that exists. Possibly group this with other
-        // ignored and/or unknown fields
-        reader->ReadString();
-        break;
-
       case google_firestore_v1beta1_BatchGetDocumentsResponse_read_time_tag:
         if (!reader->RequireWireType(PB_WT_STRING, tag)) return nullptr;
         read_time = SnapshotVersion{
             reader->ReadNestedMessage<Timestamp>(DecodeTimestamp)};
         break;
 
+      case google_firestore_v1beta1_BatchGetDocumentsResponse_transaction_tag:
+        // This field is ignored by the client sdk, but we still need to extract
+        // it.
       default:
         // Unknown tag. According to the proto spec, we need to ignore these.
         reader->SkipField(tag);


### PR DESCRIPTION
Rather than decoding the type, and then the contents, decode them both at once.