### PR TITLE
Force GTMSessionFetcher to not reuse NSURLSessions

### DIFF
--- a/Firebase/Auth/Source/RPCs/FIRAuthBackend.m
+++ b/Firebase/Auth/Source/RPCs/FIRAuthBackend.m
@@ -506,6 +506,10 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
     _fetcherService = [[GTMSessionFetcherService alloc] init];
     _fetcherService.userAgent = [FIRAuthBackend authUserAgent];
     _fetcherService.callbackQueue = FIRAuthGlobalWorkQueue();
+
+    // Avoid reusing the session to prevent
+    // https://github.com/firebase/firebase-ios-sdk/issues/1261
+    _fetcherService.reuseSession = NO;
   }
   return self;
 }
@@ -515,7 +519,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
                                           body:(NSData *)body
                                    contentType:(NSString *)contentType
                              completionHandler:(void (^)(NSData *_Nullable,
-                               NSError *_Nullable))handler {
+                                                         NSError *_Nullable))handler {
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:URL];
   [request setValue:contentType forHTTPHeaderField:@"Content-Type"];
   NSString *additionalFrameworkMarker = requestConfiguration.additionalFrameworkMarker ?:
@@ -536,7 +540,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   if (languageCode.length) {
     [request setValue:languageCode forHTTPHeaderField:kFirebaseLocalHeader];
   }
-  GTMSessionFetcher* fetcher = [_fetcherService fetcherWithRequest:request];
+  GTMSessionFetcher *fetcher = [_fetcherService fetcherWithRequest:request];
   fetcher.bodyData = body;
   [fetcher beginFetchWithCompletionHandler:handler];
 }


### PR DESCRIPTION
Hopefully work around #1261, which looks like a bug in GTMSessionFetcher's session reuse logic.