### PR TITLE
Fix the race condition of global data flag and fcm auto init enabled flag

### DIFF
--- a/Example/Messaging/Tests/FIRMessagingTest.m
+++ b/Example/Messaging/Tests/FIRMessagingTest.m
@@ -17,7 +17,10 @@
 #import <XCTest/XCTest.h>
 
 #import <OCMock/OCMock.h>
+
 #import <FirebaseInstanceID/FirebaseInstanceID.h>
+#import "FIRAppInternal.h"
+#import "FIROptionsInternal.h"
 
 #import "FIRMessaging.h"
 #import "FIRMessaging_Private.h"
@@ -44,6 +47,7 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
 @property(nonatomic, readonly, strong) FIRMessaging *messaging;
 @property(nonatomic, readwrite, strong) id mockMessaging;
 @property(nonatomic, readwrite, strong) id mockInstanceID;
+@property(nonatomic, readwrite, strong) id mockFirebaseApp;
 
 @end
 
@@ -51,8 +55,12 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
 
 - (void)setUp {
   [super setUp];
+  _mockFirebaseApp = OCMClassMock([FIRApp class]);
+  OCMStub([_mockFirebaseApp defaultApp]).andReturn(_mockFirebaseApp);
+
   _messaging = [[FIRMessaging alloc] initWithInstanceID:[FIRInstanceID instanceID]
                                            userDefaults:[NSUserDefaults standardUserDefaults]];
+
   _mockMessaging = OCMPartialMock(self.messaging);
   _mockInstanceID = OCMPartialMock(self.messaging.instanceID);
   self.messaging.instanceID = _mockInstanceID;
@@ -63,6 +71,7 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
 - (void)tearDown {
   [_mockMessaging stopMocking];
   [_mockInstanceID stopMocking];
+  [_mockFirebaseApp stopMocking];
   [super tearDown];
 }
 
@@ -76,7 +85,7 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
 }
 
 - (void)testAutoInitEnableFlagOverrideGlobalTrue {
-  OCMStub([self.mockMessaging isGlobalAutomaticDataCollectionEnabled]).andReturn(YES);
+  OCMStub([_mockFirebaseApp isAutomaticDataCollectionEnabled]).andReturn(YES);
   id bundleMock = OCMPartialMock([NSBundle mainBundle]);
   OCMStub([bundleMock objectForInfoDictionaryKey:kFIRMessagingPlistAutoInitEnabled]).andReturn(nil);
   XCTAssertTrue(self.messaging.isAutoInitEnabled);
@@ -87,7 +96,7 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
 }
 
 - (void)testAutoInitEnableFlagOverrideGlobalFalse {
-  OCMStub([self.mockMessaging isGlobalAutomaticDataCollectionEnabled]).andReturn(YES);
+  OCMStub([_mockFirebaseApp isAutomaticDataCollectionEnabled]).andReturn(YES);
   id bundleMock = OCMPartialMock([NSBundle mainBundle]);
   OCMStub([bundleMock objectForInfoDictionaryKey:kFIRMessagingPlistAutoInitEnabled]).andReturn(nil);
   XCTAssertTrue(self.messaging.isAutoInitEnabled);
@@ -98,7 +107,7 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
 }
 
 - (void)testAutoInitEnableGlobalDefaultTrue {
-  OCMStub([self.mockMessaging isGlobalAutomaticDataCollectionEnabled]).andReturn(YES);
+  OCMStub([_mockFirebaseApp isAutomaticDataCollectionEnabled]).andReturn(YES);
   id bundleMock = OCMPartialMock([NSBundle mainBundle]);
   OCMStub([bundleMock objectForInfoDictionaryKey:kFIRMessagingPlistAutoInitEnabled]).andReturn(nil);
 
@@ -107,7 +116,7 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
 }
 
 - (void)testAutoInitEnableGlobalDefaultFalse {
-  OCMStub([self.mockMessaging isGlobalAutomaticDataCollectionEnabled]).andReturn(NO);
+  OCMStub([_mockFirebaseApp isAutomaticDataCollectionEnabled]).andReturn(NO);
   id bundleMock = OCMPartialMock([NSBundle mainBundle]);
   OCMStub([bundleMock objectForInfoDictionaryKey:kFIRMessagingPlistAutoInitEnabled]).andReturn(nil);
 

--- a/Example/Messaging/Tests/FIRMessagingTest.m
+++ b/Example/Messaging/Tests/FIRMessagingTest.m
@@ -18,9 +18,9 @@
 
 #import <OCMock/OCMock.h>
 
+#import <FirebaseCore/FIRAppInternal.h>
+#import <FirebaseCore/FIROptionsInternal.h>
 #import <FirebaseInstanceID/FirebaseInstanceID.h>
-#import "FIRAppInternal.h"
-#import "FIROptionsInternal.h"
 
 #import "FIRMessaging.h"
 #import "FIRMessaging_Private.h"

--- a/Example/Messaging/Tests/FIRMessagingTest.m
+++ b/Example/Messaging/Tests/FIRMessagingTest.m
@@ -19,7 +19,6 @@
 #import <OCMock/OCMock.h>
 
 #import <FirebaseCore/FIRAppInternal.h>
-#import <FirebaseCore/FIROptionsInternal.h>
 #import <FirebaseInstanceID/FirebaseInstanceID.h>
 
 #import "FIRMessaging.h"

--- a/Example/Messaging/Tests/FIRMessagingTest.m
+++ b/Example/Messaging/Tests/FIRMessagingTest.m
@@ -59,7 +59,6 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
 
   _messaging = [[FIRMessaging alloc] initWithInstanceID:[FIRInstanceID instanceID]
                                            userDefaults:[NSUserDefaults standardUserDefaults]];
-
   _mockMessaging = OCMPartialMock(self.messaging);
   _mockInstanceID = OCMPartialMock(self.messaging.instanceID);
   self.messaging.instanceID = _mockInstanceID;

--- a/Firebase/Messaging/FIRMessaging+FIRApp.m
+++ b/Firebase/Messaging/FIRMessaging+FIRApp.m
@@ -26,12 +26,6 @@
 #import "FIRMessagingVersionUtilities.h"
 #import "FIRMessaging_Private.h"
 
-@interface FIRMessaging ()
-
-@property(nonatomic, readwrite, strong) NSString *fcmSenderID;
-
-@end
-
 @implementation FIRMessaging (FIRApp)
 
 + (void)load {
@@ -58,22 +52,6 @@
 }
 
 - (void)configureMessaging:(FIRApp *)app {
-  FIROptions *options = app.options;
-  NSError *error;
-  if (!options.GCMSenderID.length) {
-    error =
-        [FIRApp errorForSubspecConfigurationFailureWithDomain:kFirebaseCloudMessagingErrorDomain
-                                                    errorCode:FIRErrorCodeCloudMessagingFailed
-                                                      service:kFIRServiceMessaging
-                                                       reason:@"Google Sender ID must not be nil"
-                                                              @" or empty."];
-    [self exitApp:app withError:error];
-    return;
-  }
-
-  self.fcmSenderID = [options.GCMSenderID copy];
-  self.globalAutomaticDataCollectionEnabled = [app isAutomaticDataCollectionEnabled];
-
   // Swizzle remote-notification-related methods (app delegate and UNUserNotificationCenter)
   if ([FIRMessagingRemoteNotificationsProxy canSwizzleMethods]) {
     NSString *docsURLString = @"https://firebase.google.com/docs/cloud-messaging/ios/client"

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -129,7 +129,6 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
                            FIRReachabilityDelegate>
 
 // FIRApp properties
-@property(nonatomic, readwrite, copy) NSString *fcmSenderID;
 @property(nonatomic, readwrite, strong) NSData *apnsTokenData;
 @property(nonatomic, readwrite, strong) NSString *defaultFcmToken;
 
@@ -175,7 +174,6 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
     _loggedMessageIDs = [NSMutableSet set];
     _instanceID = instanceID;
     _messagingUserDefaults = defaults;
-    _fcmSenderID = [FIRApp defaultApp].options.GCMSenderID;
   }
   return self;
 }

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -36,6 +36,8 @@
 #import "FIRMessagingUtilities.h"
 #import "FIRMessagingVersionUtilities.h"
 
+#import <FirebaseCore/FIRAppInternal.h>
+#import <FirebaseCore/FIROptionsInternal.h>
 #import <FirebaseCore/FIRReachabilityChecker.h>
 #import <FirebaseInstanceID/FirebaseInstanceID.h>
 
@@ -173,10 +175,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
     _loggedMessageIDs = [NSMutableSet set];
     _instanceID = instanceID;
     _messagingUserDefaults = defaults;
-
-    // TODO: Remove this once the race condition with FIRApp configuring and InstanceID
-    //       is fixed. This must be fixed before Core's flag becomes public.
-    _globalAutomaticDataCollectionEnabled = YES;
+    _fcmSenderID = [FIRApp defaultApp].options.GCMSenderID;
   }
   return self;
 }
@@ -479,7 +478,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
   }
 
   // If none of above exists, we default to the global switch that comes from FIRApp.
-  return self.isGlobalAutomaticDataCollectionEnabled;
+  return [[FIRApp defaultApp] isAutomaticDataCollectionEnabled];
 }
 
 - (void)setAutoInitEnabled:(BOOL)autoInitEnabled {

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -37,7 +37,6 @@
 #import "FIRMessagingVersionUtilities.h"
 
 #import <FirebaseCore/FIRAppInternal.h>
-#import <FirebaseCore/FIROptionsInternal.h>
 #import <FirebaseCore/FIRReachabilityChecker.h>
 #import <FirebaseInstanceID/FirebaseInstanceID.h>
 

--- a/Firebase/Messaging/FIRMessaging_Private.h
+++ b/Firebase/Messaging/FIRMessaging_Private.h
@@ -38,9 +38,6 @@ FOUNDATION_EXPORT NSString *const kFIRMessagingUserDefaultsKeyAutoInitEnabled;
 
 #pragma mark - Private API
 
-// The data collection flag from Core.
-@property(nonatomic, readwrite, getter=isGlobalAutomaticDataCollectionEnabled) BOOL globalAutomaticDataCollectionEnabled;
-
 - (NSString *)defaultFcmToken;
 - (FIRMessagingClient *)client;
 - (FIRMessagingPubSub *)pubsub;


### PR DESCRIPTION
There's a race condition when fcm is reading global data flag  before global data flag is set in the FIRMessaging+FIRApp category class.
Fix it by reading the global data flag from FIRApp directly. 

Also remove FCMSenderID completely because it is not used in FCM, but instanceID only.