### PR TITLE
Better mocking for Core Unit Tests

### DIFF
--- a/Example/Core/Tests/FIRAnalyticsConfigurationTest.m
+++ b/Example/Core/Tests/FIRAnalyticsConfigurationTest.m
@@ -20,19 +20,25 @@
 #import <FirebaseCore/FIRAnalyticsConfiguration.h>
 
 @interface FIRAnalyticsConfigurationTest : FIRTestCase
-/// A mock for [NSNotificationCenter defaultCenter].
-@property(nonatomic, strong) id notificationCenterMock;
+/// An observer for NSNotificationCenter.
+@property(nonatomic, strong) id observerMock;
+
+@property(nonatomic, strong) NSNotificationCenter *notificationCenter;
 @end
 
 @implementation FIRAnalyticsConfigurationTest
 
 - (void)setUp {
   [super setUp];
-  _notificationCenterMock = OCMPartialMock([NSNotificationCenter defaultCenter]);
+
+  _observerMock = OCMObserverMock();
+  _notificationCenter = [NSNotificationCenter defaultCenter];
 }
 
 - (void)tearDown {
-  [_notificationCenterMock stopMocking];
+  _observerMock = nil;
+  _notificationCenter = nil;
+
   [super tearDown];
 }
 
@@ -44,49 +50,69 @@
 
 /// Test that setting the minimum session interval on the singleton fires a notification.
 - (void)testMinimumSessionIntervalNotification {
+  // Set up the expectation for the notification.
   FIRAnalyticsConfiguration *config = [FIRAnalyticsConfiguration sharedInstance];
-  [config setMinimumSessionInterval:2601];
   NSString *notificationName = kFIRAnalyticsConfigurationSetMinimumSessionIntervalNotification;
-  OCMVerify([self.notificationCenterMock postNotificationName:notificationName
-                                                       object:config
-                                                     userInfo:@{
-                                                       notificationName : @2601
-                                                     }]);
+  [self expectNotificationForObserver:self.observerMock
+                     notificationName:notificationName
+                               object:config
+                             userInfo:@{
+                               notificationName : @2601
+                             }];
+
+  // Trigger the notification.
+  [config setMinimumSessionInterval:2601];
+
+  // Verify the observer mock.
+  OCMVerifyAll(self.observerMock);
 }
 
 /// Test that setting the minimum session timeout interval on the singleton fires a notification.
 - (void)testSessionTimeoutIntervalNotification {
+  // Set up the expectation for the notification.
   FIRAnalyticsConfiguration *config = [FIRAnalyticsConfiguration sharedInstance];
-  [config setSessionTimeoutInterval:1000];
   NSString *notificationName = kFIRAnalyticsConfigurationSetSessionTimeoutIntervalNotification;
-  OCMVerify([self.notificationCenterMock postNotificationName:notificationName
-                                                       object:config
-                                                     userInfo:@{
-                                                       notificationName : @1000
-                                                     }]);
+  [self expectNotificationForObserver:self.observerMock
+                     notificationName:notificationName
+                               object:config
+                             userInfo:@{
+                               notificationName : @1000
+                             }];
+
+  // Trigger the notification.
+  [config setSessionTimeoutInterval:1000];
+
+  /// Verify the observer mock.
+  OCMVerifyAll(self.observerMock);
 }
 
 - (void)testSettingAnalyticsCollectionEnabled {
-  // The ordering matters for these notifications.
-  [self.notificationCenterMock setExpectationOrderMatters:YES];
-
-  // Test setting to enabled.
+  // Test setting to enabled. The ordering matters for these notifications.
   FIRAnalyticsConfiguration *config = [FIRAnalyticsConfiguration sharedInstance];
   NSString *notificationName = kFIRAnalyticsConfigurationSetEnabledNotification;
+  [self.notificationCenter addMockObserver:self.observerMock name:notificationName object:config];
+
+  [self.observerMock setExpectationOrderMatters:YES];
+  [[self.observerMock expect] notificationWithName:notificationName
+                                            object:config
+                                          userInfo:@{
+                                            notificationName : @YES
+                                          }];
+
+  // Test setting to enabled.
   [config setAnalyticsCollectionEnabled:YES];
-  OCMVerify([self.notificationCenterMock postNotificationName:notificationName
-                                                       object:config
-                                                     userInfo:@{
-                                                       notificationName : @YES
-                                                     }]);
+
+  // Expect the second notification.
+  [[self.observerMock expect] notificationWithName:notificationName
+                                            object:config
+                                          userInfo:@{
+                                            notificationName : @NO
+                                          }];
 
   // Test setting to disabled.
   [config setAnalyticsCollectionEnabled:NO];
-  OCMVerify([self.notificationCenterMock postNotificationName:notificationName
-                                                       object:config
-                                                     userInfo:@{
-                                                       notificationName : @NO
-                                                     }]);
+
+  OCMVerifyAll(self.observerMock);
 }
 
 - (void)testSettingAnalyticsCollectionPersistence {
@@ -112,6 +138,16 @@
                                  forKey:kFIRAPersistedConfigMeasurementEnabledStateKey]);
 
   [userDefaultsMock stopMocking];
+}
+
+#pragma mark - Private Test Helpers
+
+- (void)expectNotificationForObserver:(id)observer
+                     notificationName:(NSNotificationName)name
+                               object:(nullable id)object
+                             userInfo:(nullable NSDictionary *)userInfo {
+  [self.notificationCenter addMockObserver:self.observerMock name:name object:object];
+  [[observer expect] notificationWithName:name object:object userInfo:userInfo];
 }
 
 @end

--- a/Example/Core/Tests/FIRAnalyticsConfigurationTest.m
+++ b/Example/Core/Tests/FIRAnalyticsConfigurationTest.m
@@ -50,18 +50,20 @@
 
 /// Test that setting the minimum session interval on the singleton fires a notification.
 - (void)testMinimumSessionIntervalNotification {
+  // Pick a value to set as the session interval and verify it's in the userInfo dictionary of the
+  // posted notification.
+  NSNumber *sessionInterval = @2601;
+
   // Set up the expectation for the notification.
   FIRAnalyticsConfiguration *config = [FIRAnalyticsConfiguration sharedInstance];
   NSString *notificationName = kFIRAnalyticsConfigurationSetMinimumSessionIntervalNotification;
   [self expectNotificationForObserver:self.observerMock
                      notificationName:notificationName
                                object:config
-                             userInfo:@{
-                               notificationName : @2601
-                             }];
+                             userInfo:@{notificationName : sessionInterval}];
 
   // Trigger the notification.
-  [config setMinimumSessionInterval:2601];
+  [config setMinimumSessionInterval:[sessionInterval integerValue]];
 
   // Verify the observer mock.
   OCMVerifyAll(self.observerMock);
@@ -69,18 +71,20 @@
 
 /// Test that setting the minimum session timeout interval on the singleton fires a notification.
 - (void)testSessionTimeoutIntervalNotification {
+  // Pick a value to set as the timeout interval and verify it's in the userInfo dictionary of the
+  // posted notification.
+  NSNumber *timeoutInterval = @1000;
+
   // Set up the expectation for the notification.
   FIRAnalyticsConfiguration *config = [FIRAnalyticsConfiguration sharedInstance];
   NSString *notificationName = kFIRAnalyticsConfigurationSetSessionTimeoutIntervalNotification;
   [self expectNotificationForObserver:self.observerMock
                      notificationName:notificationName
                                object:config
-                             userInfo:@{
-                               notificationName : @1000
-                             }];
+                             userInfo:@{notificationName : timeoutInterval}];
 
   // Trigger the notification.
-  [config setSessionTimeoutInterval:1000];
+  [config setSessionTimeoutInterval:[timeoutInterval integerValue]];
 
   /// Verify the observer mock.
   OCMVerifyAll(self.observerMock);

--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -64,6 +64,10 @@ static aslclient sFIRLoggerClient;
 
 static dispatch_queue_t sFIRClientQueue;
 
+/// NSUserDefaults that should be used to store and read variables. If nil, `standardUserDefaults`
+/// will be used.
+static NSUserDefaults *sFIRLoggerUserDefaults;
+
 static BOOL sFIRLoggerDebugMode;
 
 // The sFIRAnalyticsDebugMode flag is here to support the -FIRDebugEnabled/-FIRDebugDisabled
@@ -113,14 +117,17 @@ void FIRLoggerInitializeASL() {
     sFIRAnalyticsDebugMode = NO;
     sFIRLoggerMaximumLevel = FIRLoggerLevelNotice;
 
-    NSUserDefaults *userDefaults = [NSUserDefaults standardUserDefaults];
-    BOOL debugMode = [userDefaults boolForKey:kFIRPersistedDebugModeKey];
+    // Use the standard NSUserDefaults if it hasn't been explicitly set.
+    if (sFIRLoggerUserDefaults == nil) {
+      sFIRLoggerUserDefaults = [NSUserDefaults standardUserDefaults];
+    }
 
+    BOOL debugMode = [sFIRLoggerUserDefaults boolForKey:kFIRPersistedDebugModeKey];
     if ([arguments containsObject:kFIRDisableDebugModeApplicationArgument]) {  // Default mode
-      [userDefaults removeObjectForKey:kFIRPersistedDebugModeKey];
+      [sFIRLoggerUserDefaults removeObjectForKey:kFIRPersistedDebugModeKey];
     } else if ([arguments containsObject:kFIREnableDebugModeApplicationArgument] ||
                debugMode) {  // Debug mode
-      [userDefaults setBool:YES forKey:kFIRPersistedDebugModeKey];
+      [sFIRLoggerUserDefaults setBool:YES forKey:kFIRPersistedDebugModeKey];
       asl_set_filter(sFIRLoggerClient, ASL_FILTER_MASK_UPTO(ASL_LEVEL_DEBUG));
       sFIRLoggerDebugMode = YES;
     }
@@ -190,7 +197,12 @@ __attribute__((no_sanitize("thread"))) BOOL FIRIsLoggableLevel(FIRLoggerLevel lo
 #ifdef DEBUG
 void FIRResetLogger() {
   sFIRLoggerOnceToken = 0;
-  [[NSUserDefaults standardUserDefaults] removeObjectForKey:kFIRPersistedDebugModeKey];
+  [sFIRLoggerUserDefaults removeObjectForKey:kFIRPersistedDebugModeKey];
+  sFIRLoggerUserDefaults = nil;
+}
+
+void FIRSetLoggerUserDefaults(NSUserDefaults *defaults) {
+  sFIRLoggerUserDefaults = defaults;
 }
 
 aslclient getFIRLoggerClient() {


### PR DESCRIPTION
This includes NSNotificationCenter and NSUserDefaults to prevent
flaky tests and unit tests interfering with each other.
