### PR TITLE
Fuzz test Serializer to decode FieldValue

### DIFF
--- a/Firestore/Example/FuzzTests/FSTFuzzTestsPrincipal.mm
+++ b/Firestore/Example/FuzzTests/FSTFuzzTestsPrincipal.mm
@@ -18,8 +18,10 @@
 
 #include "LibFuzzer/FuzzerDefs.h"
 
+#include "Firestore/core/src/firebase/firestore/model/database_id.h"
 #include "Firestore/core/src/firebase/firestore/remote/serializer.h"
 
+using firebase::firestore::model::DatabaseId;
 using firebase::firestore::remote::Serializer;
 
 namespace {
@@ -27,7 +29,12 @@ namespace {
 // Fuzz-test the deserialization process in Firestore. The Serializer reads raw
 // bytes and converts them to a model object.
 void FuzzTestDeserialization(const uint8_t *data, size_t size) {
-  // TODO(minafarid): fuzz-test Serializer.
+  DatabaseId database_id{"project", DatabaseId::kDefault};
+  Serializer serializer(database_id);
+
+  @try {
+    serializer.DecodeFieldValue(data, size);
+  } @catch (...) {}
 }
 
 // Contains the code to be fuzzed. Called by the fuzzing library with

--- a/Firestore/Example/FuzzTests/FSTFuzzTestsPrincipal.mm
+++ b/Firestore/Example/FuzzTests/FSTFuzzTestsPrincipal.mm
@@ -30,11 +30,15 @@ namespace {
 // bytes and converts them to a model object.
 void FuzzTestDeserialization(const uint8_t *data, size_t size) {
   DatabaseId database_id{"project", DatabaseId::kDefault};
-  Serializer serializer(database_id);
+  Serializer serializer{database_id};
 
   @try {
     serializer.DecodeFieldValue(data, size);
-  } @catch (...) {}
+  } @catch (...) {
+    // Caught exceptions are ignored because the input might be malformed and
+    // the deserialization might throw an error as intended. Fuzzing focuses on
+    // runtime errors that are detected by the sanitizers.
+  }
 }
 
 // Contains the code to be fuzzed. Called by the fuzzing library with


### PR DESCRIPTION
* Initialize a static Serializer object to be used in fuzz testing.
* Call `Serializer::DecodeFieldValue` with the fuzzing inputs.
