### PR TITLE
Add spec test support for target-scoped resume tokens

### DIFF
--- a/Firestore/Example/Tests/SpecTests/FSTMockDatastore.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTMockDatastore.mm
@@ -138,7 +138,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Helper methods.
 
-- (void)writeWatchChange:(FSTWatchChange *)change snapshotVersion:(const SnapshotVersion &)snap {
+- (void)writeWatchChange:(FSTWatchChange *)change snapshotVersion:(SnapshotVersion)snap {
   if ([change isKindOfClass:[FSTWatchTargetChange class]]) {
     FSTWatchTargetChange *targetChange = (FSTWatchTargetChange *)change;
     if (targetChange.cause) {
@@ -151,6 +151,11 @@ NS_ASSUME_NONNULL_BEGIN
         }
         [self.activeTargets removeObjectForKey:targetID];
       }
+    }
+    if ([targetChange.targetIDs count] != 0) {
+      // If the list of target IDs is not empty, we reset the snapshot version to NONE as
+      // done in `FSTSerializerBeta.versionFromListenResponse:`.
+      snap = SnapshotVersion::None();
     }
   }
   [self.delegate watchStreamDidChange:change snapshotVersion:snap];

--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -194,25 +194,25 @@ static NSString *const kNoIOSTag = @"no-ios";
   [self.driver writeUserMutation:FSTTestDeleteMutation(key)];
 }
 
-- (void)doWatchAck:(NSArray<NSNumber *> *)ackedTargets snapshot:(NSNumber *)watchSnapshot {
+- (void)doWatchAck:(NSArray<NSNumber *> *)ackedTargets {
   FSTWatchTargetChange *change =
       [FSTWatchTargetChange changeWithState:FSTWatchTargetChangeStateAdded
                                   targetIDs:ackedTargets
                                       cause:nil];
-  [self.driver receiveWatchChange:change snapshotVersion:[self parseVersion:watchSnapshot]];
+  [self.driver receiveWatchChange:change snapshotVersion:SnapshotVersion::None()];
 }
 
-- (void)doWatchCurrent:(NSArray<id> *)currentSpec snapshot:(NSNumber *)watchSnapshot {
+- (void)doWatchCurrent:(NSArray<id> *)currentSpec {
   NSArray<NSNumber *> *currentTargets = currentSpec[0];
   NSData *resumeToken = [currentSpec[1] dataUsingEncoding:NSUTF8StringEncoding];
   FSTWatchTargetChange *change =
       [FSTWatchTargetChange changeWithState:FSTWatchTargetChangeStateCurrent
                                   targetIDs:currentTargets
                                 resumeToken:resumeToken];
-  [self.driver receiveWatchChange:change snapshotVersion:[self parseVersion:watchSnapshot]];
+  [self.driver receiveWatchChange:change snapshotVersion:SnapshotVersion::None()];
 }
 
-- (void)doWatchRemove:(NSDictionary *)watchRemoveSpec snapshot:(NSNumber *)watchSnapshot {
+- (void)doWatchRemove:(NSDictionary *)watchRemoveSpec {
   NSError *error = nil;
   NSDictionary *cause = watchRemoveSpec[@"cause"];
   if (cause) {
@@ -226,19 +226,16 @@ static NSString *const kNoIOSTag = @"no-ios";
       [FSTWatchTargetChange changeWithState:FSTWatchTargetChangeStateRemoved
                                   targetIDs:watchRemoveSpec[@"targetIds"]
                                       cause:error];
-  [self.driver receiveWatchChange:change snapshotVersion:[self parseVersion:watchSnapshot]];
+  [self.driver receiveWatchChange:change snapshotVersion:SnapshotVersion::None()];
   // Unlike web, the FSTMockDatastore detects a watch removal with cause and will remove active
   // targets
 }
 
-- (void)doWatchEntity:(NSDictionary *)watchEntity snapshot:(NSNumber *_Nullable)watchSnapshot {
+- (void)doWatchEntity:(NSDictionary *)watchEntity {
   if (watchEntity[@"docs"]) {
     HARD_ASSERT(!watchEntity[@"doc"], "Exactly one of |doc| or |docs| needs to be set.");
-    int count = 0;
     NSArray *docs = watchEntity[@"docs"];
     for (NSDictionary *doc in docs) {
-      count++;
-      bool isLast = (count == docs.count);
       NSMutableDictionary *watchSpec = [NSMutableDictionary dictionary];
       watchSpec[@"doc"] = doc;
       if (watchEntity[@"targets"]) {
@@ -247,11 +244,7 @@ static NSString *const kNoIOSTag = @"no-ios";
       if (watchEntity[@"removedTargets"]) {
         watchSpec[@"removedTargets"] = watchEntity[@"removedTargets"];
       }
-      NSNumber *_Nullable version = nil;
-      if (isLast) {
-        version = watchSnapshot;
-      }
-      [self doWatchEntity:watchSpec snapshot:version];
+      [self doWatchEntity:watchSpec];
     }
   } else if (watchEntity[@"doc"]) {
     NSArray *docSpec = watchEntity[@"doc"];
@@ -270,7 +263,7 @@ static NSString *const kNoIOSTag = @"no-ios";
                                                 removedTargetIDs:watchEntity[@"removedTargets"]
                                                      documentKey:doc.key
                                                         document:doc];
-    [self.driver receiveWatchChange:change snapshotVersion:[self parseVersion:watchSnapshot]];
+    [self.driver receiveWatchChange:change snapshotVersion:SnapshotVersion::None()];
   } else if (watchEntity[@"key"]) {
     FSTDocumentKey *docKey = FSTTestDocKey(watchEntity[@"key"]);
     FSTWatchChange *change =
@@ -278,13 +271,13 @@ static NSString *const kNoIOSTag = @"no-ios";
                                                 removedTargetIDs:watchEntity[@"removedTargets"]
                                                      documentKey:docKey
                                                         document:nil];
-    [self.driver receiveWatchChange:change snapshotVersion:[self parseVersion:watchSnapshot]];
+    [self.driver receiveWatchChange:change snapshotVersion:SnapshotVersion::None()];
   } else {
     HARD_FAIL("Either key, doc or docs must be set.");
   }
 }
 
-- (void)doWatchFilter:(NSArray *)watchFilter snapshot:(NSNumber *_Nullable)watchSnapshot {
+- (void)doWatchFilter:(NSArray *)watchFilter {
   NSArray<NSNumber *> *targets = watchFilter[0];
   HARD_ASSERT(targets.count == 1, "ExistenceFilters currently support exactly one target only.");
 
@@ -294,15 +287,29 @@ static NSString *const kNoIOSTag = @"no-ios";
   FSTExistenceFilter *filter = [FSTExistenceFilter filterWithCount:keyCount];
   FSTExistenceFilterWatchChange *change =
       [FSTExistenceFilterWatchChange changeWithFilter:filter targetID:targets[0].intValue];
-  [self.driver receiveWatchChange:change snapshotVersion:[self parseVersion:watchSnapshot]];
+  [self.driver receiveWatchChange:change snapshotVersion:SnapshotVersion::None()];
 }
 
-- (void)doWatchReset:(NSArray<NSNumber *> *)watchReset snapshot:(NSNumber *_Nullable)watchSnapshot {
+- (void)doWatchReset:(NSArray<NSNumber *> *)watchReset {
   FSTWatchTargetChange *change =
       [FSTWatchTargetChange changeWithState:FSTWatchTargetChangeStateReset
                                   targetIDs:watchReset
                                       cause:nil];
-  [self.driver receiveWatchChange:change snapshotVersion:[self parseVersion:watchSnapshot]];
+  [self.driver receiveWatchChange:change snapshotVersion:SnapshotVersion::None()];
+}
+
+- (void)doWatchSnapshot:(NSDictionary *)watchSnapshot {
+  // The client will only respond to watchSnapshots if they are on a target change with an empty
+  // set of target IDs.
+  NSArray<NSNumber *> *targetIDs =
+      watchSnapshot[@"targetIds"] ? watchSnapshot[@"targetIds"] : [NSArray array];
+  NSData *resumeToken = [watchSnapshot[@"resumeToken"] dataUsingEncoding:NSUTF8StringEncoding];
+  FSTWatchTargetChange *change =
+      [FSTWatchTargetChange changeWithState:FSTWatchTargetChangeStateNoChange
+                                  targetIDs:targetIDs
+                                resumeToken:resumeToken];
+  [self.driver receiveWatchChange:change
+                  snapshotVersion:[self parseVersion:watchSnapshot[@"version"]]];
 }
 
 - (void)doWatchStreamClose:(NSDictionary *)closeSpec {
@@ -415,17 +422,19 @@ static NSString *const kNoIOSTag = @"no-ios";
   } else if (step[@"userDelete"]) {
     [self doDelete:step[@"userDelete"]];
   } else if (step[@"watchAck"]) {
-    [self doWatchAck:step[@"watchAck"] snapshot:step[@"watchSnapshot"]];
+    [self doWatchAck:step[@"watchAck"]];
   } else if (step[@"watchCurrent"]) {
-    [self doWatchCurrent:step[@"watchCurrent"] snapshot:step[@"watchSnapshot"]];
+    [self doWatchCurrent:step[@"watchCurrent"]];
   } else if (step[@"watchRemove"]) {
-    [self doWatchRemove:step[@"watchRemove"] snapshot:step[@"watchSnapshot"]];
+    [self doWatchRemove:step[@"watchRemove"]];
   } else if (step[@"watchEntity"]) {
-    [self doWatchEntity:step[@"watchEntity"] snapshot:step[@"watchSnapshot"]];
+    [self doWatchEntity:step[@"watchEntity"]];
   } else if (step[@"watchFilter"]) {
-    [self doWatchFilter:step[@"watchFilter"] snapshot:step[@"watchSnapshot"]];
+    [self doWatchFilter:step[@"watchFilter"]];
   } else if (step[@"watchReset"]) {
-    [self doWatchReset:step[@"watchReset"] snapshot:step[@"watchSnapshot"]];
+    [self doWatchReset:step[@"watchReset"]];
+  } else if (step[@"watchSnapshot"]) {
+    [self doWatchSnapshot:step[@"watchSnapshot"]];
   } else if (step[@"watchStreamClose"]) {
     [self doWatchStreamClose:step[@"watchStreamClose"]];
   } else if (step[@"watchProto"]) {

--- a/Firestore/Example/Tests/SpecTests/json/collection_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/collection_spec_test.json
@@ -56,8 +56,12 @@
             2
           ],
           "resume-token-1001"
-        ],
-        "watchSnapshot": 1001,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001
+        },
         "expect": [
           {
             "query": {

--- a/Firestore/Example/Tests/SpecTests/json/existence_filter_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/existence_filter_spec_test.json
@@ -56,8 +56,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -86,8 +90,12 @@
             2
           ],
           "collection/1"
-        ],
-        "watchSnapshot": 2000
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        }
       }
     ]
   },
@@ -132,8 +140,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "expect": [
           {
             "query": {
@@ -169,8 +181,12 @@
             2
           ],
           "collection/1"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "expect": [
           {
             "query": {
@@ -236,8 +252,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "expect": [
           {
             "query": {
@@ -257,8 +277,12 @@
             2
           ],
           "collection/1"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "expect": [
           {
             "query": {
@@ -331,8 +355,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -436,8 +464,12 @@
             2
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "expect": [
           {
             "query": {
@@ -517,8 +549,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -554,8 +590,12 @@
             2
           ],
           "collection/1"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "expect": [
           {
             "query": {
@@ -615,8 +655,12 @@
             2
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "stateExpect": {
           "limboDocs": [
             "collection/2"
@@ -652,8 +696,12 @@
             1
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "stateExpect": {
           "limboDocs": [],
           "activeTargets": {
@@ -755,8 +803,12 @@
             2
           ],
           "existence-filter-resume-token"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -818,8 +870,12 @@
             2
           ],
           "collection/1"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "expect": [
           {
             "query": {
@@ -879,8 +935,12 @@
             2
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "stateExpect": {
           "limboDocs": [
             "collection/2"
@@ -916,8 +976,12 @@
             1
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "stateExpect": {
           "limboDocs": [],
           "activeTargets": {
@@ -1012,8 +1076,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -1059,8 +1127,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
         },
-        "watchSnapshot": 2000,
         "expect": [
           {
             "query": {
@@ -1143,8 +1215,12 @@
             2
           ],
           "resume-token-3000"
-        ],
-        "watchSnapshot": 3000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 3000
+        },
         "expect": [
           {
             "query": {
@@ -1226,8 +1302,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -1255,8 +1335,12 @@
           [
             2
           ]
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "expect": [
           {
             "query": {
@@ -1345,8 +1429,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -1382,8 +1470,12 @@
             2
           ],
           "collection/1"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "expect": [
           {
             "query": {
@@ -1443,8 +1535,12 @@
             2
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "stateExpect": {
           "limboDocs": [
             "collection/2"
@@ -1491,7 +1587,6 @@
           },
           "limboDocs": []
         },
-        "watchSnapshot": 3000,
         "expect": [
           {
             "query": {

--- a/Firestore/Example/Tests/SpecTests/json/limbo_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/limbo_spec_test.json
@@ -56,8 +56,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -91,8 +95,12 @@
             2
           ],
           "resume-token-1001"
-        ],
-        "watchSnapshot": 1001,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001
+        },
         "stateExpect": {
           "limboDocs": [
             "collection/a"
@@ -140,8 +148,12 @@
             1
           ],
           "resume-token-2"
-        ],
-        "watchSnapshot": 1002,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1002
+        },
         "stateExpect": {
           "limboDocs": [],
           "activeTargets": {
@@ -236,8 +248,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -271,8 +287,12 @@
             2
           ],
           "resume-token-1001"
-        ],
-        "watchSnapshot": 1001,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001
+        },
         "stateExpect": {
           "limboDocs": [
             "collection/a"
@@ -327,8 +347,12 @@
             1
           ],
           "resume-token-1002"
-        ],
-        "watchSnapshot": 1002,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1002
+        },
         "stateExpect": {
           "limboDocs": [],
           "activeTargets": {
@@ -435,8 +459,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -476,8 +504,12 @@
             2
           ],
           "resume-token-1001"
-        ],
-        "watchSnapshot": 1001,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001
+        },
         "stateExpect": {
           "limboDocs": [
             "collection/a"
@@ -553,8 +585,12 @@
             1
           ],
           "resume-token-1002"
-        ],
-        "watchSnapshot": 1002,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1002
+        },
         "stateExpect": {
           "limboDocs": [],
           "activeTargets": {
@@ -673,8 +709,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -762,8 +802,12 @@
             2
           ],
           "resume-token-1001"
-        ],
-        "watchSnapshot": 1001,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001
+        },
         "stateExpect": {
           "limboDocs": [
             "collection/a"
@@ -859,8 +903,12 @@
             4
           ],
           "resume-token-1002"
-        ],
-        "watchSnapshot": 1002,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1002
+        },
         "stateExpect": {
           "limboDocs": [],
           "activeTargets": {
@@ -953,8 +1001,12 @@
             1
           ],
           "resume-token-1003"
-        ],
-        "watchSnapshot": 1003
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1003
+        }
       }
     ]
   },
@@ -1022,8 +1074,12 @@
             2
           ],
           "resume-token-1002"
-        ],
-        "watchSnapshot": 1002,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1002
+        },
         "expect": [
           {
             "query": {
@@ -1059,8 +1115,12 @@
           "removedTargets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 1003
         },
-        "watchSnapshot": 1003,
         "stateExpect": {
           "limboDocs": [
             "collection/b"
@@ -1108,8 +1168,12 @@
             1
           ],
           "resume-token-1004"
-        ],
-        "watchSnapshot": 1004,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1004
+        },
         "stateExpect": {
           "limboDocs": [],
           "activeTargets": {
@@ -1213,8 +1277,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -1352,8 +1420,12 @@
             4
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "expect": [
           {
             "query": {
@@ -1479,8 +1551,12 @@
             1
           ],
           "resume-token-3000"
-        ],
-        "watchSnapshot": 3000
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 3000
+        }
       },
       {
         "watchEntity": {
@@ -1514,8 +1590,12 @@
           "targets": [
             4
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 4000
         },
-        "watchSnapshot": 4000,
         "expect": [
           {
             "query": {

--- a/Firestore/Example/Tests/SpecTests/json/limit_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/limit_spec_test.json
@@ -65,8 +65,12 @@
             2
           ],
           "resume-token-1001"
-        ],
-        "watchSnapshot": 1001,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001
+        },
         "expect": [
           {
             "query": {
@@ -127,8 +131,12 @@
           "removedTargets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 1002
         },
-        "watchSnapshot": 1002,
         "expect": [
           {
             "query": {
@@ -229,8 +237,12 @@
             2
           ],
           "resume-token-1002"
-        ],
-        "watchSnapshot": 1002,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1002
+        },
         "expect": [
           {
             "query": {
@@ -295,8 +307,12 @@
             2
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "stateExpect": {
           "limboDocs": [
             "collection/a"
@@ -346,8 +362,12 @@
             1
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "stateExpect": {
           "limboDocs": [],
           "activeTargets": {
@@ -462,8 +482,12 @@
             2
           ],
           "resume-token-1001"
-        ],
-        "watchSnapshot": 1001,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001
+        },
         "expect": [
           {
             "query": {
@@ -516,8 +540,12 @@
           "removedTargets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 1002
         },
-        "watchSnapshot": 1002,
         "stateExpect": {
           "limboDocs": [],
           "activeTargets": {
@@ -701,8 +729,12 @@
             4
           ],
           "resume-token-1001"
-        ],
-        "watchSnapshot": 1001,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001
+        },
         "expect": [
           {
             "query": {
@@ -783,8 +815,12 @@
           "removedTargets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 1002
         },
-        "watchSnapshot": 1002,
         "stateExpect": {
           "limboDocs": [],
           "activeTargets": {
@@ -928,8 +964,12 @@
             2
           ],
           "resume-token-1001"
-        ],
-        "watchSnapshot": 1001,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001
+        },
         "expect": [
           {
             "query": {
@@ -1081,8 +1121,12 @@
             4
           ],
           "resume-token-1005"
-        ],
-        "watchSnapshot": 1005,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1005
+        },
         "expect": [
           {
             "query": {
@@ -1160,8 +1204,12 @@
             2
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "stateExpect": {
           "limboDocs": [
             "collection/a",
@@ -1228,8 +1276,12 @@
             1
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "stateExpect": {
           "limboDocs": [
             "collection/b",
@@ -1340,8 +1392,12 @@
             3
           ],
           "resume-token-2001"
-        ],
-        "watchSnapshot": 2001,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2001
+        },
         "stateExpect": {
           "limboDocs": [
             "collection/c",
@@ -1452,8 +1508,12 @@
             5
           ],
           "resume-token-2002"
-        ],
-        "watchSnapshot": 2002,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2002
+        },
         "stateExpect": {
           "limboDocs": [
             "collection/d"
@@ -1555,8 +1615,12 @@
             7
           ],
           "resume-token-2003"
-        ],
-        "watchSnapshot": 2003,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2003
+        },
         "stateExpect": {
           "limboDocs": [],
           "activeTargets": {

--- a/Firestore/Example/Tests/SpecTests/json/listen_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/listen_spec_test.json
@@ -2,7 +2,10 @@
   "Contents of query are cleared when listen is removed.": {
     "describeName": "Listens:",
     "itName": "Contents of query are cleared when listen is removed.",
-    "tags": [],
+    "tags": [
+      "no-lru"
+    ],
+    "comment": "Explicitly tests eager GC behavior",
     "config": {
       "useGarbageCollection": true
     },
@@ -56,8 +59,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -174,8 +181,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -212,8 +223,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
         },
-        "watchSnapshot": 2000,
         "expect": [
           {
             "query": {
@@ -373,8 +388,12 @@
       {
         "watchAck": [
           6
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -476,8 +495,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -559,7 +582,7 @@
   "Does not raise event for initial document delete": {
     "describeName": "Listens:",
     "itName": "Does not raise event for initial document delete",
-    "tags": [""],
+    "tags": [],
     "config": {
       "useGarbageCollection": true
     },
@@ -603,8 +626,12 @@
           "removedTargets": [
             2
           ]
-        },
-        "watchSnapshot": 1000
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        }
       },
       {
         "watchCurrent": [
@@ -612,8 +639,12 @@
             2
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "expect": [
           {
             "query": {
@@ -833,8 +864,12 @@
             4
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "expect": [
           {
             "query": {
@@ -916,8 +951,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -954,8 +993,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
         },
-        "watchSnapshot": 2000,
         "expect": [
           {
             "query": {
@@ -1068,8 +1111,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        }
       },
       {
         "watchEntity": {
@@ -1085,8 +1132,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
         },
-        "watchSnapshot": 2000,
         "expect": [
           {
             "query": {
@@ -1159,8 +1210,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -1197,8 +1252,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
         },
-        "watchSnapshot": 2000,
         "expect": [
           {
             "query": {
@@ -1298,8 +1357,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        }
       },
       {
         "watchEntity": {
@@ -1315,8 +1378,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
         },
-        "watchSnapshot": 2000,
         "expect": [
           {
             "query": {
@@ -1402,8 +1469,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -1531,8 +1602,12 @@
             4
           ],
           "resume-token-4000"
-        ],
-        "watchSnapshot": 4000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 4000
+        },
         "expect": [
           {
             "query": {
@@ -1638,8 +1713,12 @@
             2
           ],
           "resume-token-5000"
-        ],
-        "watchSnapshot": 5000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 5000
+        },
         "expect": [
           {
             "query": {
@@ -1748,8 +1827,12 @@
             4
           ],
           "resume-token-6000"
-        ],
-        "watchSnapshot": 6000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 6000
+        },
         "expect": [
           {
             "query": {
@@ -1823,8 +1906,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -1909,8 +1996,12 @@
             2
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "expect": [
           {
             "query": {
@@ -1999,8 +2090,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -2167,8 +2262,12 @@
             4
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "expect": [
           {
             "query": {
@@ -2313,8 +2412,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -2425,8 +2528,12 @@
             2
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "expect": [
           {
             "query": {
@@ -2508,8 +2615,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -2559,8 +2670,12 @@
           "targets": [
             2
           ]
-        },
-        "watchSnapshot": 2000
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        }
       },
       {
         "watchRemove": {
@@ -2663,8 +2778,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
         },
-        "watchSnapshot": 1000,
         "expect": [
           {
             "query": {
@@ -2693,8 +2812,12 @@
             2
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "expect": [
           {
             "query": {
@@ -2760,6 +2883,230 @@
             ],
             "errorCode": 0,
             "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ]
+      }
+    ]
+  },
+  "Persists resume token sent with target": {
+    "describeName": "Listens:",
+    "itName": "Persists resume token sent with target",
+    "tags": [
+      "exclusive"
+    ],
+    "config": {
+      "useGarbageCollection": false
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            [
+              "collection/a",
+              2000,
+              {
+                "key": "a"
+              }
+            ]
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000,
+          "targetIds": [
+            2
+          ],
+          "resumeToken": "resume-token-2000"
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              [
+                "collection/a",
+                2000,
+                {
+                  "key": "a"
+                }
+              ]
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {}
+        }
+      },
+      {
+        "watchRemove": {
+          "targetIds": [
+            2
+          ]
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": "resume-token-2000"
+            }
+          }
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              [
+                "collection/a",
+                2000,
+                {
+                  "key": "a"
+                }
+              ]
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-3000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 3000
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "errorCode": 0,
+            "fromCache": false,
             "hasPendingWrites": false
           }
         ]

--- a/Firestore/Example/Tests/SpecTests/json/offline_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/offline_spec_test.json
@@ -176,7 +176,10 @@
   "Removing all listeners delays \"Offline\" status on next listen": {
     "describeName": "Offline:",
     "itName": "Removing all listeners delays \"Offline\" status on next listen",
-    "tags": [],
+    "tags": [
+      "no-lru"
+    ],
+    "comment": "Marked as no-lru because when a listen is re-added, it gets a new target id rather than reusing one",
     "config": {
       "useGarbageCollection": true
     },
@@ -366,8 +369,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -460,8 +467,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -534,8 +545,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -569,8 +584,12 @@
             2
           ],
           "resume-token-1001"
-        ],
-        "watchSnapshot": 1001,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001
+        },
         "stateExpect": {
           "limboDocs": [
             "collection/a"
@@ -673,8 +692,12 @@
             2
           ],
           "resume-token-1001"
-        ],
-        "watchSnapshot": 1001
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001
+        }
       },
       {
         "watchAck": [
@@ -695,8 +718,12 @@
             1
           ],
           "resume-token-1001"
-        ],
-        "watchSnapshot": 1001,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001
+        },
         "expect": [
           {
             "query": {
@@ -824,8 +851,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {

--- a/Firestore/Example/Tests/SpecTests/json/orderby_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/orderby_spec_test.json
@@ -119,8 +119,12 @@
             2
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "expect": [
           {
             "query": {

--- a/Firestore/Example/Tests/SpecTests/json/persistence_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/persistence_spec_test.json
@@ -196,8 +196,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -331,8 +335,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -697,8 +705,12 @@
             2
           ],
           "resume-token-500"
-        ],
-        "watchSnapshot": 500,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 500
+        },
         "expect": [
           {
             "query": {

--- a/Firestore/Example/Tests/SpecTests/json/remote_store_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/remote_store_spec_test.json
@@ -91,8 +91,12 @@
             2
           ],
           "resume-token"
-        ],
-        "watchSnapshot": 1000
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        }
       },
       {
         "watchRemove": {
@@ -128,8 +132,12 @@
             2
           ],
           "resume-token-1001"
-        ],
-        "watchSnapshot": 1001,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001
+        },
         "expect": [
           {
             "query": {
@@ -316,8 +324,12 @@
             2
           ],
           "resume-token"
-        ],
-        "watchSnapshot": 1000
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        }
       },
       {
         "watchRemove": {
@@ -353,8 +365,12 @@
             2
           ],
           "resume-token-1001"
-        ],
-        "watchSnapshot": 1001
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001
+        }
       },
       {
         "watchRemove": {
@@ -390,8 +406,12 @@
             2
           ],
           "resume-token-1001"
-        ],
-        "watchSnapshot": 1001
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001
+        }
       },
       {
         "watchRemove": {
@@ -427,8 +447,12 @@
             2
           ],
           "resume-token-1001"
-        ],
-        "watchSnapshot": 1001,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001
+        },
         "expect": [
           {
             "query": {
@@ -519,8 +543,12 @@
             2
           ],
           "resume-token-1001"
-        ],
-        "watchSnapshot": 1001,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001
+        },
         "expect": [
           {
             "query": {

--- a/Firestore/Example/Tests/SpecTests/json/resume_token_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/resume_token_spec_test.json
@@ -56,8 +56,12 @@
             2
           ],
           "custom-query-resume-token"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -160,8 +164,12 @@
             2
           ],
           "custom-query-resume-token"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -243,8 +251,12 @@
       {
         "watchAck": [
           2
-        ],
-        "watchSnapshot": 1001
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1001
+        }
       }
     ]
   }

--- a/Firestore/Example/Tests/SpecTests/json/write_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/write_spec_test.json
@@ -63,8 +63,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -138,8 +142,12 @@
           "targets": [
             2
           ]
-        },
-        "watchSnapshot": 2000
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        }
       },
       {
         "writeAck": {
@@ -212,8 +220,12 @@
           "targets": [
             2
           ]
-        },
-        "watchSnapshot": 3000
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 3000
+        }
       },
       {
         "writeAck": {
@@ -301,8 +313,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -369,8 +385,12 @@
           "targets": [
             2
           ]
-        },
-        "watchSnapshot": 2000
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        }
       },
       {
         "writeAck": {
@@ -458,8 +478,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -526,8 +550,12 @@
           "targets": [
             2
           ]
-        },
-        "watchSnapshot": 10000
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 10000
+        }
       },
       {
         "writeAck": {
@@ -615,8 +643,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -689,8 +721,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
         },
-        "watchSnapshot": 2000,
         "expect": [
           {
             "query": {
@@ -772,8 +808,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -846,8 +886,12 @@
           "targets": [
             2
           ]
-        },
-        "watchSnapshot": 2000
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        }
       },
       {
         "watchEntity": {
@@ -870,8 +914,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 3000
         },
-        "watchSnapshot": 3000,
         "expect": [
           {
             "query": {
@@ -1421,8 +1469,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
         },
-        "watchSnapshot": 1000,
         "expect": [
           {
             "query": {
@@ -1465,8 +1517,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
         },
-        "watchSnapshot": 2000,
         "expect": [
           {
             "query": {
@@ -1509,8 +1565,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 3000
         },
-        "watchSnapshot": 3000,
         "expect": [
           {
             "query": {
@@ -1553,8 +1613,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 4000
         },
-        "watchSnapshot": 4000,
         "expect": [
           {
             "query": {
@@ -1597,8 +1661,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 5000
         },
-        "watchSnapshot": 5000,
         "expect": [
           {
             "query": {
@@ -1641,8 +1709,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 6000
         },
-        "watchSnapshot": 6000,
         "expect": [
           {
             "query": {
@@ -1685,8 +1757,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 7000
         },
-        "watchSnapshot": 7000,
         "expect": [
           {
             "query": {
@@ -1729,8 +1805,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 8000
         },
-        "watchSnapshot": 8000,
         "expect": [
           {
             "query": {
@@ -1773,8 +1853,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 9000
         },
-        "watchSnapshot": 9000,
         "expect": [
           {
             "query": {
@@ -1817,8 +1901,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 10000
         },
-        "watchSnapshot": 10000,
         "expect": [
           {
             "query": {
@@ -1861,8 +1949,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 11000
         },
-        "watchSnapshot": 11000,
         "expect": [
           {
             "query": {
@@ -1905,8 +1997,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 12000
         },
-        "watchSnapshot": 12000,
         "expect": [
           {
             "query": {
@@ -1949,8 +2045,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 13000
         },
-        "watchSnapshot": 13000,
         "expect": [
           {
             "query": {
@@ -1993,8 +2093,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 14000
         },
-        "watchSnapshot": 14000,
         "expect": [
           {
             "query": {
@@ -2037,8 +2141,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 15000
         },
-        "watchSnapshot": 15000,
         "expect": [
           {
             "query": {
@@ -3058,8 +3166,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -3191,8 +3303,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
         },
-        "watchSnapshot": 2000,
         "expect": [
           {
             "query": {
@@ -3266,8 +3382,12 @@
             2
           ],
           "resume-token-500"
-        ],
-        "watchSnapshot": 500,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 500
+        },
         "expect": [
           {
             "query": {
@@ -3374,8 +3494,12 @@
           "targets": [
             2
           ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
         },
-        "watchSnapshot": 2000,
         "expect": [
           {
             "query": {
@@ -3456,8 +3580,12 @@
             2
           ],
           "resume-token-500"
-        ],
-        "watchSnapshot": 500,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 500
+        },
         "expect": [
           {
             "query": {
@@ -3573,8 +3701,12 @@
             2
           ],
           "resume-token-2000"
-        ],
-        "watchSnapshot": 2000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        },
         "expect": [
           {
             "query": {
@@ -3602,7 +3734,10 @@
   "Held writes are released when there are no queries left.": {
     "describeName": "Writes:",
     "itName": "Held writes are released when there are no queries left.",
-    "tags": [],
+    "tags": [
+      "no-lru"
+    ],
+    "comment": "This test expects a new target id for a new listen, but without eager gc, the same target id is reused",
     "config": {
       "useGarbageCollection": true
     },
@@ -3648,8 +3783,12 @@
             2
           ],
           "resume-token-500"
-        ],
-        "watchSnapshot": 500,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 500
+        },
         "expect": [
           {
             "query": {
@@ -4735,8 +4874,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -4862,8 +5005,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -4989,8 +5136,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -5116,8 +5267,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -5243,8 +5398,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -5370,8 +5529,12 @@
             2
           ],
           "resume-token-1000"
-        ],
-        "watchSnapshot": 1000,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000
+        },
         "expect": [
           {
             "query": {
@@ -5456,8 +5619,12 @@
             2
           ],
           "resume-token-500"
-        ],
-        "watchSnapshot": 500,
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 500
+        },
         "expect": [
           {
             "query": {
@@ -5534,8 +5701,12 @@
           "targets": [
             2
           ]
-        },
-        "watchSnapshot": 2000
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000
+        }
       },
       {
         "writeAck": {


### PR DESCRIPTION
This PR changes the spec tests to treat watch snapshots as separate messages, which allows us to apply resume token on a per-target basis.

Port of firebase/firebase-js-sdk#969 /  https://github.com/FirebasePrivate/firebase-android-sdk/pull/95

This also pulls in Greg's recent Spec test changes that haven't been ported (this are comment/tag-only changes in the generated JSON).