### PR TITLE
C++: for immutable data structures, forbid ignoring result of insert/erase

### DIFF
--- a/Firestore/core/src/firebase/firestore/immutable/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/immutable/CMakeLists.txt
@@ -27,5 +27,6 @@ cc_library(
     sorted_set.h
     tree_sorted_map.h
   DEPENDS
+    absl_base
     firebase_firestore_util
 )

--- a/Firestore/core/src/firebase/firestore/immutable/sorted_map.h
+++ b/Firestore/core/src/firebase/firestore/immutable/sorted_map.h
@@ -25,6 +25,7 @@
 #include "Firestore/core/src/firebase/firestore/immutable/sorted_map_iterator.h"
 #include "Firestore/core/src/firebase/firestore/immutable/tree_sorted_map.h"
 #include "Firestore/core/src/firebase/firestore/util/comparison.h"
+#include "absl/base/attributes.h"
 
 namespace firebase {
 namespace firestore {
@@ -166,7 +167,7 @@ class SortedMap : public impl::SortedMapBase {
    * @param value The value to associate with the key.
    * @return A new dictionary with the added/updated value.
    */
-  SortedMap insert(const K& key, const V& value) const {
+  ABSL_MUST_USE_RESULT SortedMap insert(const K& key, const V& value) const {
     switch (tag_) {
       case Tag::Array:
         if (array_.size() >= kFixedSize) {
@@ -193,7 +194,7 @@ class SortedMap : public impl::SortedMapBase {
    * @param key The key to remove.
    * @return A new map without that value.
    */
-  SortedMap erase(const K& key) const {
+  ABSL_MUST_USE_RESULT SortedMap erase(const K& key) const {
     switch (tag_) {
       case Tag::Array:
         return SortedMap{array_.erase(key)};

--- a/Firestore/core/src/firebase/firestore/immutable/sorted_set.h
+++ b/Firestore/core/src/firebase/firestore/immutable/sorted_set.h
@@ -25,6 +25,7 @@
 #include "Firestore/core/src/firebase/firestore/util/comparison.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 #include "Firestore/core/src/firebase/firestore/util/hashing.h"
+#include "absl/base/attributes.h"
 
 namespace firebase {
 namespace firestore {
@@ -76,11 +77,11 @@ class SortedSet {
     return map_.size();
   }
 
-  SortedSet insert(const K& key) const {
+  ABSL_MUST_USE_RESULT SortedSet insert(const K& key) const {
     return SortedSet{map_.insert(key, {})};
   }
 
-  SortedSet erase(const K& key) const {
+  ABSL_MUST_USE_RESULT SortedSet erase(const K& key) const {
     return SortedSet{map_.erase(key)};
   }
 


### PR DESCRIPTION
I had a silly bug where I forgot to reassign an immutable set with the result of an `insert` operation, would have been happy if the compiler pointed it out sooner.