### PR TITLE
Reorganize cmake dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,16 +47,5 @@ set(
 
 enable_testing()
 
-# These are ordered by a topological sort on DEPENDS attributes. This is
-# required because CMake fails the build if you have a DEPENDS on a target that
-# does not exist yet.
-include(external/GoogleUtilities)
-include(external/FirebaseCore)
-include(external/googletest)
-include(external/zlib)
-include(external/leveldb)
-include(external/protobuf)
-include(external/nanopb)
-include(external/c-ares)
-include(external/grpc)
+include(ExternalProject)
 include(external/firestore)

--- a/cmake/CompilerSetup.cmake
+++ b/cmake/CompilerSetup.cmake
@@ -96,4 +96,4 @@ if(APPLE)
 
     -F${FIREBASE_INSTALL_DIR}/Frameworks
   )
-endif(APPLE)
+endif()

--- a/cmake/external/FirebaseCore.cmake
+++ b/cmake/external/FirebaseCore.cmake
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(xcodebuild)
+
 if(TARGET FirebaseCore)
   return()
 endif()
-
-include(xcodebuild)
 
 if(APPLE)
   # FirebaseCore is only available as a CocoaPod build.

--- a/cmake/external/FirebaseCore.cmake
+++ b/cmake/external/FirebaseCore.cmake
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if(TARGET FirebaseCore)
+  return()
+endif()
+
 include(xcodebuild)
 
 if(APPLE)

--- a/cmake/external/GoogleUtilities.cmake
+++ b/cmake/external/GoogleUtilities.cmake
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if(TARGET GoogleUtilities)
+  return()
+endif()
+
 include(xcodebuild)
 
 if(APPLE)

--- a/cmake/external/GoogleUtilities.cmake
+++ b/cmake/external/GoogleUtilities.cmake
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(xcodebuild)
+
 if(TARGET GoogleUtilities)
   return()
 endif()
-
-include(xcodebuild)
 
 if(APPLE)
   # GoogleUtilities is only available as a CocoaPod build.

--- a/cmake/external/c-ares.cmake
+++ b/cmake/external/c-ares.cmake
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(ExternalProject)
+
 if(TARGET c-ares)
   return()
 endif()

--- a/cmake/external/c-ares.cmake
+++ b/cmake/external/c-ares.cmake
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(ExternalProject)
+if(TARGET c-ares)
+  return()
+endif()
 
 ExternalProject_Add(
   c-ares

--- a/cmake/external/firestore.cmake
+++ b/cmake/external/firestore.cmake
@@ -12,16 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(ExternalProject)
+if(TARGET Firestore)
+  return()
+endif()
+
+include(external/FirebaseCore)
+include(external/GoogleUtilities)
+include(external/googletest)
+include(external/grpc)
+include(external/leveldb)
+include(external/nanopb)
+include(external/protobuf)
 
 ExternalProject_Add(
   Firestore
   DEPENDS
     FirebaseCore
+    GoogleUtilities
     googletest
-    leveldb
     grpc
+    leveldb
     nanopb
+    protobuf
 
   # Lay the binary directory out as if this were a subproject. This makes it
   # possible to build and test in it directly.

--- a/cmake/external/firestore.cmake
+++ b/cmake/external/firestore.cmake
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(TARGET Firestore)
-  return()
-endif()
-
+include(ExternalProject)
 include(external/FirebaseCore)
 include(external/GoogleUtilities)
 include(external/googletest)
@@ -23,6 +20,10 @@ include(external/grpc)
 include(external/leveldb)
 include(external/nanopb)
 include(external/protobuf)
+
+if(TARGET Firestore)
+  return()
+endif()
 
 ExternalProject_Add(
   Firestore

--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(ExternalProject)
+
 if(TARGET googletest)
   return()
 endif()

--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(ExternalProject)
+if(TARGET googletest)
+  return()
+endif()
 
 ExternalProject_Add(
   googletest

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -19,112 +19,110 @@ if(GRPC_ROOT)
   # If the user has supplied a GRPC_ROOT then just use it. Add an empty custom
   # target so that the superbuild dependencies still work.
   add_custom_target(grpc)
+  return()
+endif()
 
-else()
-  set(
-    GIT_SUBMODULES
-    third_party/boringssl
-  )
+set(
+  GIT_SUBMODULES
+  third_party/boringssl
+)
 
-  set(
-    CMAKE_ARGS
-    -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
-    -DBUILD_SHARED_LIBS:BOOL=OFF
-    -DgRPC_BUILD_TESTS:BOOL=OFF
+set(
+  CMAKE_ARGS
+  -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+  -DBUILD_SHARED_LIBS:BOOL=OFF
+  -DgRPC_BUILD_TESTS:BOOL=OFF
 
-    # TODO(rsgowman): We're currently building nanopb twice; once via grpc, and
-    # once via nanopb. The version from grpc is the one that actually ends up
-    # being used. We need to fix this such that either:
-    #   a) we instruct grpc to use our nanopb
-    #   b) we rely on grpc's nanopb instead of using our own.
-    # For now, we'll pass in the necessary nanopb cflags into grpc. (We require
-    # 16 bit fields. Without explicitly requesting this, nanopb uses 8 bit
-    # fields.)
-    -DCMAKE_C_FLAGS=-DPB_FIELD_16BIT
-    -DCMAKE_CXX_FLAGS=-DPB_FIELD_16BIT
-  )
+  # TODO(rsgowman): We're currently building nanopb twice; once via grpc, and
+  # once via nanopb. The version from grpc is the one that actually ends up
+  # being used. We need to fix this such that either:
+  #   a) we instruct grpc to use our nanopb
+  #   b) we rely on grpc's nanopb instead of using our own.
+  # For now, we'll pass in the necessary nanopb cflags into grpc. (We require
+  # 16 bit fields. Without explicitly requesting this, nanopb uses 8 bit
+  # fields.)
+  -DCMAKE_C_FLAGS=-DPB_FIELD_16BIT
+  -DCMAKE_CXX_FLAGS=-DPB_FIELD_16BIT
+)
 
 
-  ## c-ares
-  if(NOT c-ares_DIR)
-    set(c-ares_DIR ${FIREBASE_INSTALL_DIR}/lib/cmake/c-ares)
+## c-ares
+if(NOT c-ares_DIR)
+  set(c-ares_DIR ${FIREBASE_INSTALL_DIR}/lib/cmake/c-ares)
+endif()
+
+list(
+  APPEND CMAKE_ARGS
+  -DgRPC_CARES_PROVIDER:STRING=package
+  -Dc-ares_DIR:PATH=${c-ares_DIR}
+)
+
+
+## protobuf
+
+# Unlike other dependencies of gRPC, we control the protobuf version because we
+# have checked-in protoc outputs that must match the runtime.
+
+# The location where protobuf-config.cmake will be installed varies by platform
+if(NOT Protobuf_DIR)
+  if(WIN32)
+    set(Protobuf_DIR "${FIREBASE_INSTALL_DIR}/cmake")
+  else()
+    set(Protobuf_DIR "${FIREBASE_INSTALL_DIR}/lib/cmake/protobuf")
   endif()
+endif()
 
+list(
+  APPEND CMAKE_ARGS
+  -DgRPC_PROTOBUF_PROVIDER:STRING=package
+  -DgRPC_PROTOBUF_PACKAGE_TYPE:STRING=CONFIG
+  -DProtobuf_DIR:PATH=${Protobuf_DIR}
+)
+
+
+## zlib
+
+# cmake/external/zlib.cmake figures out whether or not to build zlib. Either
+# way, from the gRPC build's point of view it's a package.
+list(
+  APPEND CMAKE_ARGS
+  -DgRPC_ZLIB_PROVIDER:STRING=package
+)
+if(ZLIB_FOUND)
+  # Propagate possible user configuration to FindZLIB.cmake in the sub-build.
   list(
     APPEND CMAKE_ARGS
-    -DgRPC_CARES_PROVIDER:STRING=package
-    -Dc-ares_DIR:PATH=${c-ares_DIR}
+    -DZLIB_INCLUDE_DIR=${ZLIB_INCLUDE_DIR}
+    -DZLIB_LIBRARY=${ZLIB_LIBRARY}
   )
+endif()
 
 
-  ## protobuf
+ExternalProject_GitSource(
+  GRPC_GIT
+  GIT_REPOSITORY "https://github.com/grpc/grpc.git"
+  GIT_TAG "v1.8.3"
+  GIT_SUBMODULES ${GIT_SUBMODULES}
+)
 
-  # Unlike other dependencies of gRPC, we control the protobuf version because we
-  # have checked-in protoc outputs that must match the runtime.
+ExternalProject_Add(
+  grpc
+  DEPENDS
+    c-ares
+    protobuf
+    zlib
 
-  # The location where protobuf-config.cmake will be installed varies by platform
-  if(NOT Protobuf_DIR)
-    if(WIN32)
-      set(Protobuf_DIR "${FIREBASE_INSTALL_DIR}/cmake")
-    else()
-      set(Protobuf_DIR "${FIREBASE_INSTALL_DIR}/lib/cmake/protobuf")
-    endif()
-  endif()
+  ${GRPC_GIT}
 
-  list(
-    APPEND CMAKE_ARGS
-    -DgRPC_PROTOBUF_PROVIDER:STRING=package
-    -DgRPC_PROTOBUF_PACKAGE_TYPE:STRING=CONFIG
-    -DProtobuf_DIR:PATH=${Protobuf_DIR}
-  )
+  PREFIX ${PROJECT_BINARY_DIR}/external/grpc
 
+  CMAKE_ARGS
+    ${CMAKE_ARGS}
 
-  ## zlib
+  BUILD_COMMAND
+    ${CMAKE_COMMAND} --build . --target grpc
 
-  # cmake/external/zlib.cmake figures out whether or not to build zlib. Either
-  # way, from the gRPC build's point of view it's a package.
-  list(
-    APPEND CMAKE_ARGS
-    -DgRPC_ZLIB_PROVIDER:STRING=package
-  )
-  if(ZLIB_FOUND)
-    # Propagate possible user configuration to FindZLIB.cmake in the sub-build.
-    list(
-      APPEND CMAKE_ARGS
-      -DZLIB_INCLUDE_DIR=${ZLIB_INCLUDE_DIR}
-      -DZLIB_LIBRARY=${ZLIB_LIBRARY}
-    )
-  endif()
-
-
-  ExternalProject_GitSource(
-    GRPC_GIT
-    GIT_REPOSITORY "https://github.com/grpc/grpc.git"
-    GIT_TAG "v1.8.3"
-    GIT_SUBMODULES ${GIT_SUBMODULES}
-  )
-
-  ExternalProject_Add(
-    grpc
-    DEPENDS
-      c-ares
-      protobuf
-      zlib
-
-    ${GRPC_GIT}
-
-    PREFIX ${PROJECT_BINARY_DIR}/external/grpc
-
-    CMAKE_ARGS
-      ${CMAKE_ARGS}
-
-    BUILD_COMMAND
-      ${CMAKE_COMMAND} --build . --target grpc
-
-    UPDATE_COMMAND ""
-    TEST_COMMAND ""
-    INSTALL_COMMAND ""
-  )
-
-endif(GRPC_ROOT)
-
+  UPDATE_COMMAND ""
+  TEST_COMMAND ""
+  INSTALL_COMMAND ""
+)

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(TARGET grpc)
-  return()
-endif()
-
+include(ExternalProject)
 include(ExternalProjectFlags)
 include(external/c-ares)
 include(external/protobuf)
 include(external/zlib)
+
+if(TARGET grpc)
+  return()
+endif()
 
 if(GRPC_ROOT)
   # If the user has supplied a GRPC_ROOT then just use it. Add an empty custom

--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -12,8 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(ExternalProject)
+if(TARGET grpc)
+  return()
+endif()
+
 include(ExternalProjectFlags)
+include(external/c-ares)
+include(external/protobuf)
+include(external/zlib)
 
 if(GRPC_ROOT)
   # If the user has supplied a GRPC_ROOT then just use it. Add an empty custom

--- a/cmake/external/leveldb.cmake
+++ b/cmake/external/leveldb.cmake
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(ExternalProject)
+if(TARGET leveldb)
+  return()
+endif()
 
 if(WIN32 OR LEVELDB_ROOT)
   # If the user has supplied a LEVELDB_ROOT then just use it. Add an empty

--- a/cmake/external/leveldb.cmake
+++ b/cmake/external/leveldb.cmake
@@ -24,50 +24,50 @@ if(WIN32 OR LEVELDB_ROOT)
   #   https://github.com/google/leveldb/issues/363
   #   https://github.com/google/leveldb/issues/466
   add_custom_target(leveldb)
+  return()
+endif()
 
-else()
-  # Clean up warning output to reduce noise in the build
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-    set(
-      LEVELDB_CXX_FLAGS "\
-        -Wno-deprecated-declarations"
-    )
-  endif()
 
-  # Map CMake compiler configuration down onto the leveldb Makefile
+# Clean up warning output to reduce noise in the build
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
   set(
-    LEVELDB_OPT "\
-      $<$<CONFIG:Debug>:${CMAKE_CXX_FLAGS_DEBUG}> \
-      $<$<CONFIG:Release>:${CMAKE_CXX_FLAGS_RELEASE}>"
+    LEVELDB_CXX_FLAGS "\
+      -Wno-deprecated-declarations"
   )
+endif()
 
-  ExternalProject_Add(
-    leveldb
+# Map CMake compiler configuration down onto the leveldb Makefile
+set(
+  LEVELDB_OPT "\
+    $<$<CONFIG:Debug>:${CMAKE_CXX_FLAGS_DEBUG}> \
+    $<$<CONFIG:Release>:${CMAKE_CXX_FLAGS_RELEASE}>"
+)
 
-    DOWNLOAD_DIR ${FIREBASE_DOWNLOAD_DIR}
-    DOWNLOAD_NAME leveldb-v1.20.tar.gz
-    URL https://github.com/google/leveldb/archive/v1.20.tar.gz
-    URL_HASH SHA256=f5abe8b5b209c2f36560b75f32ce61412f39a2922f7045ae764a2c23335b6664
+ExternalProject_Add(
+  leveldb
 
-    PREFIX ${FIREBASE_BINARY_DIR}/external/leveldb
+  DOWNLOAD_DIR ${FIREBASE_DOWNLOAD_DIR}
+  DOWNLOAD_NAME leveldb-v1.20.tar.gz
+  URL https://github.com/google/leveldb/archive/v1.20.tar.gz
+  URL_HASH SHA256=f5abe8b5b209c2f36560b75f32ce61412f39a2922f7045ae764a2c23335b6664
 
-    # LevelDB's configuration is done in the Makefile
-    CONFIGURE_COMMAND ""
+  PREFIX ${FIREBASE_BINARY_DIR}/external/leveldb
 
-    # The Makefile-based build of leveldb does not support building
-    # out-of-source.
-    BUILD_IN_SOURCE ON
+  # LevelDB's configuration is done in the Makefile
+  CONFIGURE_COMMAND ""
 
-    # Only build the leveldb library skipping the tools and in-memory
-    # implementation we don't use.
-    BUILD_COMMAND
-      env CXXFLAGS=${LEVELDB_CXX_FLAGS} OPT=${LEVELDB_OPT}
-        make -j out-static/libleveldb.a
+  # The Makefile-based build of leveldb does not support building
+  # out-of-source.
+  BUILD_IN_SOURCE ON
 
-    INSTALL_DIR ${FIREBASE_INSTALL_DIR}
+  # Only build the leveldb library skipping the tools and in-memory
+  # implementation we don't use.
+  BUILD_COMMAND
+    env CXXFLAGS=${LEVELDB_CXX_FLAGS} OPT=${LEVELDB_OPT}
+      make -j out-static/libleveldb.a
 
-    INSTALL_COMMAND ""
-    TEST_COMMAND ""
-  )
+  INSTALL_DIR ${FIREBASE_INSTALL_DIR}
 
-endif(WIN32 OR LEVELDB_ROOT)
+  INSTALL_COMMAND ""
+  TEST_COMMAND ""
+)

--- a/cmake/external/leveldb.cmake
+++ b/cmake/external/leveldb.cmake
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(ExternalProject)
+
 if(TARGET leveldb)
   return()
 endif()

--- a/cmake/external/nanopb.cmake
+++ b/cmake/external/nanopb.cmake
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(ExternalProject)
+if(TARGET nanopb)
+  return()
+endif()
+
+include(external/protobuf)
 
 set(NANOPB_PROTOC_BIN ${FIREBASE_INSTALL_DIR}/bin/protoc)
 

--- a/cmake/external/nanopb.cmake
+++ b/cmake/external/nanopb.cmake
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(ExternalProject)
+include(external/protobuf)
+
 if(TARGET nanopb)
   return()
 endif()
-
-include(external/protobuf)
 
 set(NANOPB_PROTOC_BIN ${FIREBASE_INSTALL_DIR}/bin/protoc)
 

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(ExternalProject)
+
 if(TARGET protobuf)
   return()
 endif()

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(ExternalProject)
+if(TARGET protobuf)
+  return()
+endif()
 
 # Protubuf has CMake support, but includes it in a `cmake` subdirectory, which
 # does not work with CMake's ExternalProject by default. CMake 3.7 added

--- a/cmake/external/zlib.cmake
+++ b/cmake/external/zlib.cmake
@@ -18,23 +18,23 @@ include(ExternalProject)
 find_package(ZLIB)
 if(ZLIB_FOUND)
   add_custom_target(zlib)
-
-else()
-  ExternalProject_Add(
-    zlib
-
-    DOWNLOAD_DIR ${FIREBASE_DOWNLOAD_DIR}
-    DOWNLOAD_NAME zlib-v1.2.11.tar.gz
-    URL https://github.com/madler/zlib/archive/v1.2.11.tar.gz
-    URL_HASH SHA256=629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff
-
-    PREFIX ${PROJECT_BINARY_DIR}/external/zlib
-
-    CMAKE_ARGS
-      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
-      -DCMAKE_INSTALL_PREFIX:STRING=${FIREBASE_INSTALL_DIR}
-      -DBUILD_SHARED_LIBS:BOOL=OFF
-
-    TEST_COMMAND ""
-  )
+  return()
 endif()
+
+ExternalProject_Add(
+  zlib
+
+  DOWNLOAD_DIR ${FIREBASE_DOWNLOAD_DIR}
+  DOWNLOAD_NAME zlib-v1.2.11.tar.gz
+  URL https://github.com/madler/zlib/archive/v1.2.11.tar.gz
+  URL_HASH SHA256=629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff
+
+  PREFIX ${PROJECT_BINARY_DIR}/external/zlib
+
+  CMAKE_ARGS
+    -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+    -DCMAKE_INSTALL_PREFIX:STRING=${FIREBASE_INSTALL_DIR}
+    -DBUILD_SHARED_LIBS:BOOL=OFF
+
+  TEST_COMMAND ""
+)

--- a/cmake/external/zlib.cmake
+++ b/cmake/external/zlib.cmake
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(ExternalProject)
+if(TARGET zlib)
+  return()
+endif()
 
 # Use a system- or user-supplied zlib if available
 find_package(ZLIB)

--- a/cmake/external/zlib.cmake
+++ b/cmake/external/zlib.cmake
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(ExternalProject)
+
 if(TARGET zlib)
   return()
 endif()


### PR DESCRIPTION
This change fixes two long-standing issues that have bugged me:

  * The top-level CMakeLists.txt needed to keep the included modules in topologically sorted order
  * Some of the modules had nearly all of their logic in an else branch

The difference is best examined with a whitespace insensitive diff, e.g. with

https://github.com/firebase/firebase-ios-sdk/compare/wilhuff/cmake-reorg?w=1