### PR TITLE
Move creation of FSTFilter objects to static create method on FSTFilter.

### DIFF
--- a/Firestore/Example/Tests/Core/FSTQueryTests.mm
+++ b/Firestore/Example/Tests/Core/FSTQueryTests.mm
@@ -287,20 +287,19 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQuery *baseQuery = FSTTestQuery("collection");
   FSTDocument *doc1 = FSTTestDoc("collection/doc", 0, @{ @"tags" : @[ @"foo", @1, @YES ] }, NO);
 
-  NSArray<id<FSTFilter>> *matchingFilters =
-      @[ FSTTestFilter("tags", @"==", @[ @"foo", @1, @YES ]) ];
+  NSArray<FSTFilter *> *matchingFilters = @[ FSTTestFilter("tags", @"==", @[ @"foo", @1, @YES ]) ];
 
-  NSArray<id<FSTFilter>> *nonMatchingFilters = @[
+  NSArray<FSTFilter *> *nonMatchingFilters = @[
     FSTTestFilter("tags", @"==", @"foo"),
     FSTTestFilter("tags", @"==", @[ @"foo", @1 ]),
     FSTTestFilter("tags", @"==", @[ @"foo", @YES, @1 ]),
   ];
 
-  for (id<FSTFilter> filter in matchingFilters) {
+  for (FSTFilter *filter in matchingFilters) {
     XCTAssertTrue([[baseQuery queryByAddingFilter:filter] matchesDocument:doc1]);
   }
 
-  for (id<FSTFilter> filter in nonMatchingFilters) {
+  for (FSTFilter *filter in nonMatchingFilters) {
     XCTAssertFalse([[baseQuery queryByAddingFilter:filter] matchesDocument:doc1]);
   }
 }
@@ -311,7 +310,7 @@ NS_ASSUME_NONNULL_BEGIN
       FSTTestDoc("collection/doc", 0,
                  @{ @"tags" : @{@"foo" : @"foo", @"a" : @0, @"b" : @YES, @"c" : @(NAN)} }, NO);
 
-  NSArray<id<FSTFilter>> *matchingFilters = @[
+  NSArray<FSTFilter *> *matchingFilters = @[
     FSTTestFilter("tags", @"==",
                   @{ @"foo" : @"foo",
                      @"a" : @0,
@@ -325,7 +324,7 @@ NS_ASSUME_NONNULL_BEGIN
     FSTTestFilter("tags.foo", @"==", @"foo")
   ];
 
-  NSArray<id<FSTFilter>> *nonMatchingFilters = @[
+  NSArray<FSTFilter *> *nonMatchingFilters = @[
     FSTTestFilter("tags", @"==", @"foo"), FSTTestFilter("tags", @"==", @{
       @"foo" : @"foo",
       @"a" : @0,
@@ -333,11 +332,11 @@ NS_ASSUME_NONNULL_BEGIN
     })
   ];
 
-  for (id<FSTFilter> filter in matchingFilters) {
+  for (FSTFilter *filter in matchingFilters) {
     XCTAssertTrue([[baseQuery queryByAddingFilter:filter] matchesDocument:doc1]);
   }
 
-  for (id<FSTFilter> filter in nonMatchingFilters) {
+  for (FSTFilter *filter in nonMatchingFilters) {
     XCTAssertFalse([[baseQuery queryByAddingFilter:filter] matchesDocument:doc1]);
   }
 }

--- a/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.mm
+++ b/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.mm
@@ -476,7 +476,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)testEncodesRelationFilter {
-  FSTRelationFilter *input = FSTTestFilter("item.part.top", @"==", @"food");
+  FSTRelationFilter *input = (FSTRelationFilter *)FSTTestFilter("item.part.top", @"==", @"food");
   GCFSStructuredQuery_Filter *actual = [self.serializer encodedRelationFilter:input];
 
   GCFSStructuredQuery_Filter *expected = [GCFSStructuredQuery_Filter message];
@@ -488,7 +488,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)testEncodesArrayContainsFilter {
-  FSTRelationFilter *input = FSTTestFilter("item.tags", @"array_contains", @"food");
+  FSTRelationFilter *input =
+      (FSTRelationFilter *)FSTTestFilter("item.tags", @"array_contains", @"food");
   GCFSStructuredQuery_Filter *actual = [self.serializer encodedRelationFilter:input];
 
   GCFSStructuredQuery_Filter *expected = [GCFSStructuredQuery_Filter message];

--- a/Firestore/Example/Tests/Util/FSTHelpers.h
+++ b/Firestore/Example/Tests/Util/FSTHelpers.h
@@ -34,6 +34,7 @@
 @class FSTDocumentKeyReference;
 @class FSTDocumentSet;
 @class FSTFieldValue;
+@class FSTFilter;
 @class FSTLocalViewChanges;
 @class FSTPatchMutation;
 @class FSTQuery;
@@ -46,7 +47,6 @@
 @class FSTView;
 @class FSTViewSnapshot;
 @class FSTObjectValue;
-@protocol FSTFilter;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -242,7 +242,7 @@ FSTQuery *FSTTestQuery(const absl::string_view path);
  * A convenience method to create a FSTFilter using a string representation for both field
  * and operator (<, <=, ==, >=, >, array_contains).
  */
-id<FSTFilter> FSTTestFilter(const absl::string_view field, NSString *op, id value);
+FSTFilter *FSTTestFilter(const absl::string_view field, NSString *op, id value);
 
 /** A convenience method for creating sort orders. */
 FSTSortOrder *FSTTestOrderBy(const absl::string_view field, NSString *direction);

--- a/Firestore/Example/Tests/Util/FSTHelpers.mm
+++ b/Firestore/Example/Tests/Util/FSTHelpers.mm
@@ -179,7 +179,7 @@ FSTQuery *FSTTestQuery(const absl::string_view path) {
   return [FSTQuery queryWithPath:testutil::Resource(path)];
 }
 
-id<FSTFilter> FSTTestFilter(const absl::string_view field, NSString *opString, id value) {
+FSTFilter *FSTTestFilter(const absl::string_view field, NSString *opString, id value) {
   const FieldPath path = testutil::Field(field);
   FSTRelationFilterOperator op;
   if ([opString isEqualToString:@"<"]) {
@@ -199,15 +199,8 @@ id<FSTFilter> FSTTestFilter(const absl::string_view field, NSString *opString, i
   }
 
   FSTFieldValue *data = FSTTestFieldValue(value);
-  if ([data isEqual:[FSTDoubleValue nanValue]]) {
-    HARD_ASSERT(op == FSTRelationFilterOperatorEqual, "Must use == with NAN.");
-    return [[FSTNanFilter alloc] initWithField:path];
-  } else if ([data isEqual:[FSTNullValue nullValue]]) {
-    HARD_ASSERT(op == FSTRelationFilterOperatorEqual, "Must use == with Null.");
-    return [[FSTNullFilter alloc] initWithField:path];
-  } else {
-    return [FSTRelationFilter filterWithField:path filterOperator:op value:data];
-  }
+
+  return [FSTFilter createWithField:path op:op value:data];
 }
 
 FSTSortOrder *FSTTestOrderBy(const absl::string_view field, NSString *direction) {

--- a/Firestore/Example/Tests/Util/FSTHelpers.mm
+++ b/Firestore/Example/Tests/Util/FSTHelpers.mm
@@ -200,7 +200,7 @@ FSTFilter *FSTTestFilter(const absl::string_view field, NSString *opString, id v
 
   FSTFieldValue *data = FSTTestFieldValue(value);
 
-  return [FSTFilter createWithField:path op:op value:data];
+  return [FSTFilter filterWithField:path filterOperator:op value:data];
 }
 
 FSTSortOrder *FSTTestOrderBy(const absl::string_view field, NSString *direction) {

--- a/Firestore/Source/API/FIRQuery.mm
+++ b/Firestore/Source/API/FIRQuery.mm
@@ -487,7 +487,8 @@ addSnapshotListenerInternalWithOptions:(FSTListenOptions *)internalOptions
     fieldValue = [self.firestore.dataConverter parsedQueryValue:value];
   }
 
-  FSTFilter *filter = [FSTFilter createWithField:fieldPath op:filterOperator value:fieldValue];
+  FSTFilter *filter =
+      [FSTFilter filterWithField:fieldPath filterOperator:filterOperator value:fieldValue];
 
   if ([filter isKindOfClass:[FSTRelationFilter class]]) {
     [self validateNewRelationFilter:(FSTRelationFilter *)filter];

--- a/Firestore/Source/API/FIRQuery.mm
+++ b/Firestore/Source/API/FIRQuery.mm
@@ -487,26 +487,12 @@ addSnapshotListenerInternalWithOptions:(FSTListenOptions *)internalOptions
     fieldValue = [self.firestore.dataConverter parsedQueryValue:value];
   }
 
-  id<FSTFilter> filter;
-  if ([fieldValue isEqual:[FSTNullValue nullValue]]) {
-    if (filterOperator != FSTRelationFilterOperatorEqual) {
-      FSTThrowInvalidUsage(@"InvalidQueryException",
-                           @"Invalid Query. You can only perform equality comparisons on nil / "
-                            "NSNull.");
-    }
-    filter = [[FSTNullFilter alloc] initWithField:fieldPath];
-  } else if ([fieldValue isEqual:[FSTDoubleValue nanValue]]) {
-    if (filterOperator != FSTRelationFilterOperatorEqual) {
-      FSTThrowInvalidUsage(@"InvalidQueryException",
-                           @"Invalid Query. You can only perform equality comparisons on NaN.");
-    }
-    filter = [[FSTNanFilter alloc] initWithField:fieldPath];
-  } else {
-    filter = [FSTRelationFilter filterWithField:fieldPath
-                                 filterOperator:filterOperator
-                                          value:fieldValue];
-    [self validateNewRelationFilter:filter];
+  FSTFilter *filter = [FSTFilter createWithField:fieldPath op:filterOperator value:fieldValue];
+
+  if ([filter isKindOfClass:[FSTRelationFilter class]]) {
+    [self validateNewRelationFilter:(FSTRelationFilter *)filter];
   }
+
   return [FIRQuery referenceWithQuery:[self.query queryByAddingFilter:filter]
                             firestore:self.firestore];
 }

--- a/Firestore/Source/Core/FSTQuery.h
+++ b/Firestore/Source/Core/FSTQuery.h
@@ -48,8 +48,8 @@ typedef NS_ENUM(NSInteger, FSTRelationFilterOperator) {
  * will return the appropriate FSTNullFilter or FSTNanFilter class instead of a
  * FSTRelationFilter.
  */
-+ (instancetype)createWithField:(const firebase::firestore::model::FieldPath &)field
-                             op:(FSTRelationFilterOperator)op
++ (instancetype)filterWithField:(const firebase::firestore::model::FieldPath &)field
+                 filterOperator:(FSTRelationFilterOperator)op
                           value:(FSTFieldValue *)value;
 
 /** Returns the field the Filter operates over. Abstract method. */
@@ -77,9 +77,9 @@ typedef NS_ENUM(NSInteger, FSTRelationFilterOperator) {
  * @param value A constant value to compare @a field to. The RHS of the expression.
  * @return A new instance of FSTRelationFilter.
  */
-+ (instancetype)filterWithField:(firebase::firestore::model::FieldPath)field
-                 filterOperator:(FSTRelationFilterOperator)filterOperator
-                          value:(FSTFieldValue *)value;
+- (instancetype)initWithField:(firebase::firestore::model::FieldPath)field
+               filterOperator:(FSTRelationFilterOperator)filterOperator
+                        value:(FSTFieldValue *)value;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Firestore/Source/Core/FSTQuery.h
+++ b/Firestore/Source/Core/FSTQuery.h
@@ -38,15 +38,27 @@ typedef NS_ENUM(NSInteger, FSTRelationFilterOperator) {
 };
 
 /** Interface used for all query filters. */
-@protocol FSTFilter <NSObject>
+@interface FSTFilter : NSObject
 
-/** Returns the field the Filter operates over. */
+/**
+ * Creates a filter for the provided path, operator, and value.
+ *
+ * Note that if the relational operator is FSTRelationFilterOperatorEqual and
+ * the value is [FSTNullValue nullValue] or [FSTDoubleValue nanValue], this
+ * will return the appropriate FSTNullFilter or FSTNanFilter class instead of a
+ * FSTRelationFilter.
+ */
++ (instancetype)createWithField:(const firebase::firestore::model::FieldPath &)field
+                             op:(FSTRelationFilterOperator)op
+                          value:(FSTFieldValue *)value;
+
+/** Returns the field the Filter operates over. Abstract method. */
 - (const firebase::firestore::model::FieldPath &)field;
 
-/** Returns true if a document matches the filter. */
+/** Returns true if a document matches the filter. Abstract method. */
 - (BOOL)matchesDocument:(FSTDocument *)document;
 
-/** A unique ID identifying the filter; used when serializing queries. */
+/** A unique ID identifying the filter; used when serializing queries. Abstract method. */
 - (NSString *)canonicalID;
 
 @end
@@ -55,7 +67,7 @@ typedef NS_ENUM(NSInteger, FSTRelationFilterOperator) {
  * FSTRelationFilter is a document filter constraint on a query with a single relation operator.
  * It is similar to NSComparisonPredicate, except customized for Firestore semantics.
  */
-@interface FSTRelationFilter : NSObject <FSTFilter>
+@interface FSTRelationFilter : FSTFilter
 
 /**
  * Creates a new constraint for filtering documents.
@@ -86,14 +98,14 @@ typedef NS_ENUM(NSInteger, FSTRelationFilterOperator) {
 @end
 
 /** Filter that matches NULL values. */
-@interface FSTNullFilter : NSObject <FSTFilter>
+@interface FSTNullFilter : FSTFilter
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithField:(firebase::firestore::model::FieldPath)field
     NS_DESIGNATED_INITIALIZER;
 @end
 
 /** Filter that matches NAN values. */
-@interface FSTNanFilter : NSObject <FSTFilter>
+@interface FSTNanFilter : FSTFilter
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithField:(firebase::firestore::model::FieldPath)field
     NS_DESIGNATED_INITIALIZER;
@@ -162,7 +174,7 @@ typedef NS_ENUM(NSInteger, FSTRelationFilterOperator) {
  * Initializes a query with all of its components directly.
  */
 - (instancetype)initWithPath:(firebase::firestore::model::ResourcePath)path
-                    filterBy:(NSArray<id<FSTFilter>> *)filters
+                    filterBy:(NSArray<FSTFilter *> *)filters
                      orderBy:(NSArray<FSTSortOrder *> *)sortOrders
                        limit:(NSInteger)limit
                      startAt:(nullable FSTBound *)startAtBound
@@ -198,7 +210,7 @@ typedef NS_ENUM(NSInteger, FSTRelationFilterOperator) {
  * @param filter The predicate to filter by.
  * @return the new FSTQuery.
  */
-- (instancetype)queryByAddingFilter:(id<FSTFilter>)filter;
+- (instancetype)queryByAddingFilter:(FSTFilter *)filter;
 
 /**
  * Creates a new FSTQuery with an additional ordering constraint.
@@ -255,7 +267,7 @@ typedef NS_ENUM(NSInteger, FSTRelationFilterOperator) {
 - (const firebase::firestore::model::ResourcePath &)path;
 
 /** The filters on the documents returned by the query. */
-@property(nonatomic, strong, readonly) NSArray<id<FSTFilter>> *filters;
+@property(nonatomic, strong, readonly) NSArray<FSTFilter *> *filters;
 
 /** The maximum number of results to return, or NSNotFound if no limit. */
 @property(nonatomic, assign, readonly) NSInteger limit;

--- a/Firestore/Source/Core/FSTQuery.mm
+++ b/Firestore/Source/Core/FSTQuery.mm
@@ -70,8 +70,8 @@ NSString *FSTStringFromQueryRelationOperator(FSTRelationFilterOperator filterOpe
 
 @implementation FSTFilter
 
-+ (instancetype)createWithField:(const FieldPath &)field
-                             op:(FSTRelationFilterOperator)op
++ (instancetype)filterWithField:(const FieldPath &)field
+                 filterOperator:(FSTRelationFilterOperator)op
                           value:(FSTFieldValue *)value {
   if ([value isEqual:[FSTNullValue nullValue]]) {
     if (op != FSTRelationFilterOperatorEqual) {
@@ -87,7 +87,7 @@ NSString *FSTStringFromQueryRelationOperator(FSTRelationFilterOperator filterOpe
     }
     return [[FSTNanFilter alloc] initWithField:field];
   } else {
-    return [FSTRelationFilter filterWithField:field filterOperator:op value:value];
+    return [[FSTRelationFilter alloc] initWithField:field filterOperator:op value:value];
   }
 }
 
@@ -137,14 +137,6 @@ NSString *FSTStringFromQueryRelationOperator(FSTRelationFilterOperator filterOpe
 @implementation FSTRelationFilter
 
 #pragma mark - Constructor methods
-
-+ (instancetype)filterWithField:(FieldPath)field
-                 filterOperator:(FSTRelationFilterOperator)filterOperator
-                          value:(FSTFieldValue *)value {
-  return [[FSTRelationFilter alloc] initWithField:std::move(field)
-                                   filterOperator:filterOperator
-                                            value:value];
-}
 
 - (instancetype)initWithField:(FieldPath)field
                filterOperator:(FSTRelationFilterOperator)filterOperator

--- a/Firestore/Source/Remote/FSTSerializerBeta.mm
+++ b/Firestore/Source/Remote/FSTSerializerBeta.mm
@@ -802,7 +802,7 @@ NS_ASSUME_NONNULL_BEGIN
     path = path.Append(util::MakeString(from.collectionId));
   }
 
-  NSArray<id<FSTFilter>> *filterBy;
+  NSArray<FSTFilter *> *filterBy;
   if (query.hasWhere) {
     filterBy = [self decodedFilters:query.where];
   } else {
@@ -841,14 +841,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark Filters
 
-- (GCFSStructuredQuery_Filter *_Nullable)encodedFilters:(NSArray<id<FSTFilter>> *)filters {
+- (GCFSStructuredQuery_Filter *_Nullable)encodedFilters:(NSArray<FSTFilter *> *)filters {
   if (filters.count == 0) {
     return nil;
   }
   NSMutableArray<GCFSStructuredQuery_Filter *> *protos = [NSMutableArray array];
-  for (id<FSTFilter> filter in filters) {
+  for (FSTFilter *filter in filters) {
     if ([filter isKindOfClass:[FSTRelationFilter class]]) {
-      [protos addObject:[self encodedRelationFilter:filter]];
+      [protos addObject:[self encodedRelationFilter:(FSTRelationFilter *)filter]];
     } else {
       [protos addObject:[self encodedUnaryFilter:filter]];
     }
@@ -864,8 +864,8 @@ NS_ASSUME_NONNULL_BEGIN
   return composite;
 }
 
-- (NSArray<id<FSTFilter>> *)decodedFilters:(GCFSStructuredQuery_Filter *)proto {
-  NSMutableArray<id<FSTFilter>> *result = [NSMutableArray array];
+- (NSArray<FSTFilter *> *)decodedFilters:(GCFSStructuredQuery_Filter *)proto {
+  NSMutableArray<FSTFilter *> *result = [NSMutableArray array];
 
   NSArray<GCFSStructuredQuery_Filter *> *filters;
   if (proto.filterTypeOneOfCase ==
@@ -913,7 +913,7 @@ NS_ASSUME_NONNULL_BEGIN
   return [FSTRelationFilter filterWithField:fieldPath filterOperator:filterOperator value:value];
 }
 
-- (GCFSStructuredQuery_Filter *)encodedUnaryFilter:(id<FSTFilter>)filter {
+- (GCFSStructuredQuery_Filter *)encodedUnaryFilter:(FSTFilter *)filter {
   GCFSStructuredQuery_Filter *proto = [GCFSStructuredQuery_Filter message];
   proto.unaryFilter.field = [self encodedFieldPath:filter.field];
   if ([filter isKindOfClass:[FSTNanFilter class]]) {
@@ -926,7 +926,7 @@ NS_ASSUME_NONNULL_BEGIN
   return proto;
 }
 
-- (id<FSTFilter>)decodedUnaryFilter:(GCFSStructuredQuery_UnaryFilter *)proto {
+- (FSTFilter *)decodedUnaryFilter:(GCFSStructuredQuery_UnaryFilter *)proto {
   FieldPath field = FieldPath::FromServerFormat(util::MakeString(proto.field.fieldPath));
   switch (proto.op) {
     case GCFSStructuredQuery_UnaryFilter_Operator_IsNan:


### PR DESCRIPTION
Rather than previously inlining it in the calling code. This is to unify
filter creation across platforms.

(This change involves altering FSTFilter from a protocol to an abstract
class.)