### PR TITLE
Fix Firestore source errors under VS2017

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -610,8 +610,8 @@
 		546854A720A3681B004BDBD5 /* remote */ = {
 			isa = PBXGroup;
 			children = (
-				B6D1B68420E2AB1A00B35856 /* exponential_backoff_test.cc */,
 				546854A820A36867004BDBD5 /* datastore_test.cc */,
+				B6D1B68420E2AB1A00B35856 /* exponential_backoff_test.cc */,
 				61F72C5520BC48FD001A68CB /* serializer_test.cc */,
 			);
 			path = remote;
@@ -1750,7 +1750,6 @@
 				5492E03F2021401F00B64F25 /* FSTHelpers.mm in Sources */,
 				DE2EF0861F3D0B6E003D0CDC /* FSTImmutableSortedDictionary+Testing.m in Sources */,
 				DE2EF0871F3D0B6E003D0CDC /* FSTImmutableSortedSet+Testing.m in Sources */,
-				B6D1B68520E2AB1B00B35856 /* exponential_backoff_test.cc in Sources */,
 				5491BC721FB44593008B3588 /* FSTIntegrationTestCase.mm in Sources */,
 				5492E0A72021552D00B64F25 /* FSTLevelDBKeyTests.mm in Sources */,
 				5492E0A82021552D00B64F25 /* FSTLevelDBLocalStoreTests.mm in Sources */,
@@ -1808,6 +1807,7 @@
 				B6FB468E208F9BAB00554BA2 /* executor_libdispatch_test.mm in Sources */,
 				B6FB468F208F9BAE00554BA2 /* executor_std_test.cc in Sources */,
 				B6FB4690208F9BB300554BA2 /* executor_test.cc in Sources */,
+				B6D1B68520E2AB1B00B35856 /* exponential_backoff_test.cc in Sources */,
 				549CCA5720A36E1F00BCEB75 /* field_mask_test.cc in Sources */,
 				B686F2AF2023DDEE0028D6BE /* field_path_test.cc in Sources */,
 				54A0352620A3AED0003E0143 /* field_transform_test.mm in Sources */,

--- a/Firestore/core/src/firebase/firestore/immutable/sorted_map_iterator.h
+++ b/Firestore/core/src/firebase/firestore/immutable/sorted_map_iterator.h
@@ -119,7 +119,9 @@ class SortedMapIterator {
   pointer get() const {
     switch (tag_) {
       case Tag::Array:
-        return array_iter_;
+        // In the Microsoft STL, std::array::iterator is not a bare pointer so
+        // this takes the address of the result of operator*().
+        return &*array_iter_;
       case Tag::Tree:
         return tree_iter_.get();
     }

--- a/Firestore/core/src/firebase/firestore/util/bits.h
+++ b/Firestore/core/src/firebase/firestore/util/bits.h
@@ -24,12 +24,12 @@
 
 #include <cstdint>
 
-class Bits_Port32_Test;
-class Bits_Port64_Test;
-
 namespace firebase {
 namespace firestore {
 namespace util {
+
+class Bits_Port32_Test;
+class Bits_Port64_Test;
 
 class Bits {
  public:
@@ -81,9 +81,9 @@ inline int Bits::Log2FloorNonZero64(uint64_t n) {
   return 63 ^ __builtin_clzll(n);
 }
 
-#elif defined(COMPILER_MSVC)
+#elif defined(_MSC_VER)
 
-inline int Bits::Log2FloorNonZero(uint32 n) {
+inline int Bits::Log2FloorNonZero(uint32_t n) {
 #ifdef _M_IX86
   _asm {
     bsr ebx, n
@@ -95,7 +95,7 @@ inline int Bits::Log2FloorNonZero(uint32 n) {
 #endif
 }
 
-inline int Bits::Log2Floor(uint32 n) {
+inline int Bits::Log2Floor(uint32_t n) {
 #ifdef _M_IX86
   _asm {
     xor ebx, ebx
@@ -120,7 +120,7 @@ inline int Bits::Log2FloorNonZero64(uint64_t n) {
   return Bits::Log2FloorNonZero64_Portable(n);
 }
 
-#else  // !__GNUC__ && !COMPILER_MSVC
+#else  // !__GNUC__ && !_MSC_VER
 
 inline int Bits::Log2Floor64(uint64_t n) {
   return Bits::Log2Floor64_Portable(n);

--- a/Firestore/core/src/firebase/firestore/util/hard_assert.h
+++ b/Firestore/core/src/firebase/firestore/util/hard_assert.h
@@ -21,6 +21,12 @@
 
 #include "Firestore/core/src/firebase/firestore/util/string_format.h"
 
+#if defined(_MSC_VER)
+#define FIRESTORE_FUNCTION_NAME __FUNCSIG__
+#else
+#define FIRESTORE_FUNCTION_NAME __PRETTY_FUNCTION__
+#endif
+
 /**
  * Fails the current function if the given condition is false.
  *
@@ -30,14 +36,14 @@
  * @param format (optional) A format string suitable for util::StringFormat.
  * @param ... format arguments to pass to util::StringFormat.
  */
-#define HARD_ASSERT(condition, ...)                                       \
-  do {                                                                    \
-    if (!(condition)) {                                                   \
-      std::string _message =                                              \
-          firebase::firestore::util::StringFormat(__VA_ARGS__);           \
-      firebase::firestore::util::internal::Fail(                          \
-          __FILE__, __PRETTY_FUNCTION__, __LINE__, _message, #condition); \
-    }                                                                     \
+#define HARD_ASSERT(condition, ...)                                           \
+  do {                                                                        \
+    if (!(condition)) {                                                       \
+      std::string _message =                                                  \
+          firebase::firestore::util::StringFormat(__VA_ARGS__);               \
+      firebase::firestore::util::internal::Fail(                              \
+          __FILE__, FIRESTORE_FUNCTION_NAME, __LINE__, _message, #condition); \
+    }                                                                         \
   } while (0)
 
 /**
@@ -48,12 +54,12 @@
  * @param format A format string suitable for util::StringFormat.
  * @param ... format arguments to pass to util::StringFormat.
  */
-#define HARD_FAIL(...)                                                       \
-  do {                                                                       \
-    std::string _failure =                                                   \
-        firebase::firestore::util::StringFormat(__VA_ARGS__);                \
-    firebase::firestore::util::internal::Fail(__FILE__, __PRETTY_FUNCTION__, \
-                                              __LINE__, _failure);           \
+#define HARD_FAIL(...)                                          \
+  do {                                                          \
+    std::string _failure =                                      \
+        firebase::firestore::util::StringFormat(__VA_ARGS__);   \
+    firebase::firestore::util::internal::Fail(                  \
+        __FILE__, FIRESTORE_FUNCTION_NAME, __LINE__, _failure); \
   } while (0)
 
 /**

--- a/Firestore/core/src/firebase/firestore/util/hashing.h
+++ b/Firestore/core/src/firebase/firestore/util/hashing.h
@@ -82,7 +82,8 @@ struct has_std_hash {
  * `decltype(std::hash<T>{}(std::declval<T>()))`.
  */
 template <typename T>
-using std_hash_type = typename std::enable_if<has_std_hash<T>{}, size_t>::type;
+using std_hash_type =
+    typename std::enable_if<has_std_hash<T>::value, size_t>::type;
 
 /**
  * Combines a hash_value with whatever accumulated state there is so far.
@@ -151,9 +152,11 @@ auto RankedInvokeHash(const Range& range, HashChoice<2>)
   size_t size = 0;
   for (auto&& element : range) {
     ++size;
-    result = Combine(result, InvokeHash(element));
+    size_t piece = InvokeHash(element);
+    result = Combine(result, piece);
   }
-  result = Combine(result, size);
+  size_t size_hash = InvokeHash(size);
+  result = Combine(result, size_hash);
   return result;
 }
 

--- a/Firestore/core/src/firebase/firestore/util/status.cc
+++ b/Firestore/core/src/firebase/firestore/util/status.cc
@@ -100,18 +100,24 @@ static FirestoreErrorCode CodeForErrno(int errno_code) {
 #if defined(EISNAM)
     case EISNAM:  // Is a named type file
 #endif
-    case ENOTBLK:    // Block device required
-    case ENOTCONN:   // The socket is not connected
-    case EPIPE:      // Broken pipe
+#if defined(ENOTBLK)
+    case ENOTBLK:  // Block device required
+#endif
+    case ENOTCONN:  // The socket is not connected
+    case EPIPE:     // Broken pipe
+#if defined(ESHUTDOWN)
     case ESHUTDOWN:  // Cannot send after transport endpoint shutdown
-    case ETXTBSY:    // Text file busy
+#endif
+    case ETXTBSY:  // Text file busy
 #if defined(EUNATCH)
     case EUNATCH:  // Protocol driver not attached
 #endif
       return FirestoreErrorCode::FailedPrecondition;
 
-    case ENOSPC:   // No space left on device
-    case EDQUOT:   // Disk quota exceeded
+    case ENOSPC:  // No space left on device
+#if defined(EDQUOT)
+    case EDQUOT:  // Disk quota exceeded
+#endif
     case EMFILE:   // Too many open files
     case EMLINK:   // Too many links
     case ENFILE:   // Too many open files in system
@@ -119,7 +125,9 @@ static FirestoreErrorCode CodeForErrno(int errno_code) {
     case ENODATA:  // No message is available on the STREAM read queue
     case ENOMEM:   // Not enough space
     case ENOSR:    // No STREAM resources
-    case EUSERS:   // Too many users
+#if defined(EUSERS)
+    case EUSERS:  // Too many users
+#endif
       return FirestoreErrorCode::ResourceExhausted;
 
 #if defined(ECHRNG)
@@ -133,13 +141,17 @@ static FirestoreErrorCode CodeForErrno(int errno_code) {
 #if defined(ENOPKG)
     case ENOPKG:  // Package not installed
 #endif
-    case ENOSYS:           // Function not implemented
-    case ENOTSUP:          // Operation not supported
-    case EAFNOSUPPORT:     // Address family not supported
-    case EPFNOSUPPORT:     // Protocol family not supported
+    case ENOSYS:        // Function not implemented
+    case ENOTSUP:       // Operation not supported
+    case EAFNOSUPPORT:  // Address family not supported
+#if defined(EPFNOSUPPORT)
+    case EPFNOSUPPORT:  // Protocol family not supported
+#endif
     case EPROTONOSUPPORT:  // Protocol not supported
+#if defined(ESOCKTNOSUPPORT)
     case ESOCKTNOSUPPORT:  // Socket type not supported
-    case EXDEV:            // Improper link
+#endif
+    case EXDEV:  // Improper link
       return FirestoreErrorCode::Unimplemented;
 
     case EAGAIN:  // Resource temporarily unavailable
@@ -150,7 +162,9 @@ static FirestoreErrorCode CodeForErrno(int errno_code) {
     case ECONNABORTED:  // Connection aborted
     case ECONNRESET:    // Connection reset
     case EINTR:         // Interrupted function call
-    case EHOSTDOWN:     // Host is down
+#if defined(EHOSTDOWN)
+    case EHOSTDOWN:  // Host is down
+#endif
     case EHOSTUNREACH:  // Host is unreachable
     case ENETDOWN:      // Network is down
     case ENETRESET:     // Connection aborted by network
@@ -163,7 +177,9 @@ static FirestoreErrorCode CodeForErrno(int errno_code) {
       return FirestoreErrorCode::Unavailable;
 
     case EDEADLK:  // Resource deadlock avoided
-    case ESTALE:   // Stale file handle
+#if defined(ESTALE)
+    case ESTALE:  // Stale file handle
+#endif
       return FirestoreErrorCode::Aborted;
 
     case ECANCELED:  // Operation cancelled

--- a/Firestore/core/test/firebase/firestore/immutable/sorted_map_test.cc
+++ b/Firestore/core/test/firebase/firestore/immutable/sorted_map_test.cc
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+// Disable warnings in the MSVC standard library about the use of std::mismatch.
+// There's no guaranteed safe way to use it in C++11 but the test verifies that
+// our implementation matches the standard so we need to call it.
+#if defined(_MSC_VER)
+#define _SCL_SECURE_NO_WARNINGS 1
+#endif
+
 #include "Firestore/core/src/firebase/firestore/immutable/sorted_map.h"
 
 #include <numeric>

--- a/Firestore/core/test/firebase/firestore/util/strerror_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/strerror_test.cc
@@ -23,9 +23,20 @@ namespace firestore {
 namespace util {
 
 TEST(StrErrorTest, ValidErrorCode) {
+#if defined(_MSC_VER)
+#pragma warning(push)
+  // strerror is unsafe generally, but it's used here as the simplest possible
+  // reference implementation.
+#pragma warning(disable : 4996)
+#endif
+
   errno = EAGAIN;
   EXPECT_EQ(StrError(EINTR), strerror(EINTR));
   EXPECT_EQ(errno, EAGAIN);
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 }
 
 TEST(StrErrorTest, InvalidErrorCode) {


### PR DESCRIPTION
This fixes nearly all source-level errors that prevented a successful build there.

Note that I've rebased this out of a long commit chain that makes it possible actually test these changes on Windows in the interest of parallelizing reviews.