### PR TITLE
Suppress uninitialized read error under VS2017

### DIFF
--- a/Firestore/core/src/firebase/firestore/nanopb/reader.cc
+++ b/Firestore/core/src/firebase/firestore/nanopb/reader.cc
@@ -31,7 +31,7 @@ Reader Reader::Wrap(const uint8_t* bytes, size_t length) {
 }
 
 Tag Reader::ReadTag() {
-  Tag tag{};
+  Tag tag;
   if (!status_.ok()) return tag;
 
   bool eof;

--- a/Firestore/core/src/firebase/firestore/nanopb/reader.cc
+++ b/Firestore/core/src/firebase/firestore/nanopb/reader.cc
@@ -31,7 +31,7 @@ Reader Reader::Wrap(const uint8_t* bytes, size_t length) {
 }
 
 Tag Reader::ReadTag() {
-  Tag tag;
+  Tag tag{};
   if (!status_.ok()) return tag;
 
   bool eof;

--- a/Firestore/core/src/firebase/firestore/nanopb/tag.h
+++ b/Firestore/core/src/firebase/firestore/nanopb/tag.h
@@ -32,6 +32,12 @@ namespace nanopb {
  * google_firestore_v1beta1_Document_name_tag.
  */
 struct Tag {
+  Tag() {
+  }
+
+  Tag(pb_wire_type_t w, uint32_t f) : wire_type{w}, field_number{f} {
+  }
+
   pb_wire_type_t wire_type = PB_WT_VARINT;
   uint32_t field_number = 0u;
 };

--- a/Firestore/core/src/firebase/firestore/nanopb/tag.h
+++ b/Firestore/core/src/firebase/firestore/nanopb/tag.h
@@ -32,8 +32,8 @@ namespace nanopb {
  * google_firestore_v1beta1_Document_name_tag.
  */
 struct Tag {
-  pb_wire_type_t wire_type;
-  uint32_t field_number;
+  pb_wire_type_t wire_type = PB_WT_VARINT;
+  uint32_t field_number = 0u;
 };
 
 }  // namespace nanopb


### PR DESCRIPTION
Visual Studio flags use of this variable as an uninitialized read.

I think the issue is that `Tag` has managed to be a POD type, so it's not initialized.

An alternative would be to give a `Tag` a default constructor that initializes the fields to zero values explicitly.

WDYT?