### PR TITLE
[For review only] Minimize rereading of batches in [FSTLocalDocumentsView documentsMatchingCollectionQuery]

### DIFF
--- a/Firestore/Source/Local/FSTLocalDocumentsView.mm
+++ b/Firestore/Source/Local/FSTLocalDocumentsView.mm
@@ -113,15 +113,13 @@ NS_ASSUME_NONNULL_BEGIN
   // Query the remote documents and overlay mutations.
   // TODO(mikelehen): There may be significant overlap between the mutations affecting these
   // remote documents and the allMutationBatchesAffectingQuery mutations. Consider optimizing.
-  __block FSTDocumentDictionary *results = [self.remoteDocumentCache documentsMatchingQuery:query];
-  results = [self localDocuments:results];
-
-  // Now use the mutation queue to discover any other documents that may match the query after
-  // applying mutations.
-  DocumentKeySet matchingKeys;
-  NSArray<FSTMutationBatch *> *matchingMutationBatches =
+__block FSTDocumentDictionary *results = [self.remoteDocumentCache documentsMatchingQuery:query];
+  NSArray<FSTMutationBatch *> *matchingBatches =
       [self.mutationQueue allMutationBatchesAffectingQuery:query];
-  for (FSTMutationBatch *batch in matchingMutationBatches) {
+  results = [self localDocuments:results inBatches:matchingBatches];
+
+  DocumentKeySet matchingKeys;
+  for (FSTMutationBatch *batch in matchingBatches) {
     for (FSTMutation *mutation in batch.mutations) {
       // TODO(mikelehen): PERF: Check if this mutation actually affects the query to reduce work.
 
@@ -133,17 +131,16 @@ NS_ASSUME_NONNULL_BEGIN
   }
 
   // Now add in results for the matchingKeys.
-  FSTMaybeDocumentDictionary *matchingKeysDocs = [self documentsForKeys:matchingKeys];
+  FSTMaybeDocumentDictionary *matchingKeysDocs =
+    [self documentsForKeys:matchingKeys inBatches:matchingBatches];
   [matchingKeysDocs
       enumerateKeysAndObjectsUsingBlock:^(FSTDocumentKey *key, FSTMaybeDocument *doc, BOOL *stop) {
         if ([doc isKindOfClass:[FSTDocument class]]) {
           results = [results dictionaryBySettingObject:(FSTDocument *)doc forKey:key];
         }
       }];
-
-  // Finally, filter out any documents that don't actually match the query. Note that the extra
-  // reference here prevents ARC from deallocating the initial unfiltered results while we're
-  // enumerating them.
+  // Note that the extra reference here prevents ARC from deallocating the initial unfiltered
+  // results while we're enumerating them.
   FSTDocumentDictionary *unfiltered = results;
   [unfiltered
       enumerateKeysAndObjectsUsingBlock:^(FSTDocumentKey *key, FSTDocument *doc, BOOL *stop) {
@@ -151,7 +148,6 @@ NS_ASSUME_NONNULL_BEGIN
           results = [results dictionaryByRemovingObjectForKey:key];
         }
       }];
-
   return results;
 }
 

--- a/Firestore/Source/Local/FSTLocalDocumentsView.mm
+++ b/Firestore/Source/Local/FSTLocalDocumentsView.mm
@@ -111,9 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (FSTDocumentDictionary *)documentsMatchingCollectionQuery:(FSTQuery *)query {
   // Query the remote documents and overlay mutations.
-  // TODO(mikelehen): There may be significant overlap between the mutations affecting these
-  // remote documents and the allMutationBatchesAffectingQuery mutations. Consider optimizing.
-__block FSTDocumentDictionary *results = [self.remoteDocumentCache documentsMatchingQuery:query];
+  __block FSTDocumentDictionary *results = [self.remoteDocumentCache documentsMatchingQuery:query];
   NSArray<FSTMutationBatch *> *matchingBatches =
       [self.mutationQueue allMutationBatchesAffectingQuery:query];
   results = [self localDocuments:results inBatches:matchingBatches];


### PR DESCRIPTION
Gil, could you please take a quick look to see if this is equivalent to what you had in mind? This is not ready for the full review (I didn't copy some plumbing, it's basically just to verify the idea). This change brings significant performance improvements when querying for a lot of documents, so I'd like to double-check if there is actually a reason to be happy. Integration tests pass.