### PR TITLE
Restore iOS7 to GoogleUtilities

### DIFF
--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -19,7 +19,7 @@ other Google CocoaPods. They're not intended for direct public usage.
 #    :tag => 'Utilities-' + s.version.to_s
     :tag => 'pre-5.3-' + s.version.to_s
   }
-  s.ios.deployment_target = '6.0'
+  s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'
 

--- a/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
@@ -19,6 +19,10 @@
 #import <mach-o/dyld.h>
 #import <sys/utsname.h>
 
+#if TARGET_OS_IOS || TARGET_OS_TV
+#import <UIKit/UIKit.h>
+#endif
+
 /// The encryption info struct and constants are missing from the iPhoneSimulator SDK, but not from
 /// the iPhoneOS or Mac OS X SDKs. Since one doesn't ever ship a Simulator binary, we'll just
 /// provide the definitions here.
@@ -212,15 +216,11 @@ static BOOL HasEmbeddedMobileProvision() {
 }
 
 + (NSString *)systemVersion {
-  // Assemble the systemVersion, excluding the patch version if it's 0.
-  NSOperatingSystemVersion osVersion = [NSProcessInfo processInfo].operatingSystemVersion;
-  NSMutableString *versionString = [[NSMutableString alloc]
-      initWithFormat:@"%ld.%ld", (long)osVersion.majorVersion, (long)osVersion.minorVersion];
-  if (osVersion.patchVersion != 0) {
-    [versionString appendFormat:@".%ld", (long)osVersion.patchVersion];
-  }
-
-  return versionString;
+  #if TARGET_OS_IOS || TARGET_OS_TV
+  return [UIDevice currentDevice].systemVersion;
+  #elif TARGET_OS_OSX
+  return [NSProcessInfo processInfo].operatingSystemVersionString;
+  #endif
 }
 
 + (BOOL)isAppExtension {

--- a/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
@@ -19,7 +19,7 @@
 #import <mach-o/dyld.h>
 #import <sys/utsname.h>
 
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS
 #import <UIKit/UIKit.h>
 #endif
 
@@ -216,11 +216,18 @@ static BOOL HasEmbeddedMobileProvision() {
 }
 
 + (NSString *)systemVersion {
-  #if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS
   return [UIDevice currentDevice].systemVersion;
-  #elif TARGET_OS_OSX
-  return [NSProcessInfo processInfo].operatingSystemVersionString;
-  #endif
+#elif TARGET_OS_OSX || TARGET_OS_TV
+  // Assemble the systemVersion, excluding the patch version if it's 0.
+  NSOperatingSystemVersion osVersion = [NSProcessInfo processInfo].operatingSystemVersion;
+  NSMutableString *versionString = [[NSMutableString alloc]
+      initWithFormat:@"%ld.%ld", (long)osVersion.majorVersion, (long)osVersion.minorVersion];
+  if (osVersion.patchVersion != 0) {
+    [versionString appendFormat:@".%ld", (long)osVersion.patchVersion];
+  }
+  return versionString;
+#endif
 }
 
 + (BOOL)isAppExtension {

--- a/GoogleUtilities/Example/Tests/Environment/GULAppEnvironmentUtilTest.m
+++ b/GoogleUtilities/Example/Tests/Environment/GULAppEnvironmentUtilTest.m
@@ -38,6 +38,9 @@
   [_processInfoMock stopMocking];
 }
 
+// Remove the #if when iOS can remove iOS 7 support and also use processInfo instead of UIKit.
+#if TARGET_OS_OSX || TARGET_OS_TV
+
 - (void)testSystemVersionInfoMajorOnly {
   NSOperatingSystemVersion osTen = {.majorVersion = 10, .minorVersion = 0, .patchVersion = 0};
   OCMStub([self.processInfoMock operatingSystemVersion]).andReturn(osTen);
@@ -58,5 +61,6 @@
 
   XCTAssertTrue([[GULAppEnvironmentUtil systemVersion] isEqualToString:@"10.2.1"]);
 }
+#endif
 
 @end

--- a/GoogleUtilities/Network/GULNetworkURLSession.m
+++ b/GoogleUtilities/Network/GULNetworkURLSession.m
@@ -445,7 +445,10 @@
   if ([NSURLSessionConfiguration
           respondsToSelector:@selector(backgroundSessionConfigurationWithIdentifier:)]) {
     // Running on iOS 8+/OS X 10.10+.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
     return [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:sessionID];
+#pragma clang diagnostic pop
   } else {
     // Running on iOS 7/OS X 10.9.
     return [NSURLSessionConfiguration backgroundSessionConfiguration:sessionID];


### PR DESCRIPTION
And disable iOS6 since it has many more unresolved errors 
- see  `pod lib lint GoogleUtilities.podspec --use-libraries` (or b/111429140)

The `--use-libraries` option is necessary because frameworks default to a minimum iOS version of 8.

This was caught in the nightly cron travis testing.