### PR TITLE
Fuzz testing uses protoc from a pod dependency

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -1584,10 +1584,12 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Firestore_FuzzTests_iOS/Pods-Firestore_FuzzTests_iOS-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Protobuf/Protobuf.framework",
 				"${BUILT_PRODUCTS_DIR}/LibFuzzer/LibFuzzer.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Protobuf.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/LibFuzzer.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Firestore/Example/FuzzTests/FuzzingResources/Serializer/Corpus/ConvertTextToBinary.sh
+++ b/Firestore/Example/FuzzTests/FuzzingResources/Serializer/Corpus/ConvertTextToBinary.sh
@@ -49,13 +49,10 @@ for text_proto_file in "${text_protos_dir}"/*; do
   fi
 
   # Run the conversion.
-  # TODO(minafarid): This conversion relies on protoc as built by the cmake
-  # build. Switch this to using a pod dependency of protoc.
   echo "Converting file: ${file_name} (type: ${message_type})"
   echo "${file_content}" \
-    | "${SRCROOT}/../../build/external/protobuf/src/protobuf-build/src/protoc" \
+    | "${SRCROOT}/Pods/!ProtoCompiler/protoc" \
     -I"${SRCROOT}/../../Firestore/Protos/protos" \
-    -I"${SRCROOT}/../../build/external/protobuf/src/protobuf/src" \
     --encode=google.firestore.v1beta1."${message_type}" \
     google/firestore/v1beta1/document.proto > "${binary_protos_dir}/${file_name}"
 done

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -45,5 +45,6 @@ target 'Firestore_Example_iOS' do
     inherit! :search_paths
 
     pod 'LibFuzzer', :podspec => 'LibFuzzer.podspec'
+    pod '!ProtoCompiler'
   end
 end


### PR DESCRIPTION
* Added `! ProtoCompiler` as a Pod dependency to use the `protoc` binary.
* Modified the `ConvertTextToBinary.sh` script to use the `protoc` binary from the Pod.
* Removed an unused src for protos.