### PR TITLE
Use CMake to build LevelDB

### DIFF
--- a/Firestore/CMakeLists.txt
+++ b/Firestore/CMakeLists.txt
@@ -38,11 +38,6 @@ include(cc_rules)
 include(podspec_rules)
 
 
-# External packages
-find_package(LevelDB REQUIRED)
-find_package(ZLIB)
-
-
 # Googletest
 add_subdirectory(
   ${FIREBASE_BINARY_DIR}/src/googletest
@@ -61,6 +56,7 @@ add_subdirectory(
 
 
 # gRPC
+find_package(ZLIB)
 if(ZLIB_FOUND)
   set(gRPC_ZLIB_PROVIDER package CACHE STRING "Use external ZLIB")
 endif()
@@ -100,6 +96,19 @@ if(NOT ZLIB_FOUND)
       $<BUILD_INTERFACE:${FIREBASE_BINARY_DIR}/src/grpc/third_party/zlib>
   )
 endif()
+
+
+# LevelDB
+set(LEVELDB_BUILD_TESTS OFF CACHE BOOL "Firestore disabled")
+set(LEVELDB_BUILD_BENCHMARKS OFF CACHE BOOL "Firestore disabled")
+set(LEVELDB_INSTALL OFF CACHE BOOL "Firestore disabled")
+add_subdirectory(
+  ${FIREBASE_BINARY_DIR}/src/leveldb
+  ${FIREBASE_BINARY_DIR}/src/leveldb-build
+  EXCLUDE_FROM_ALL
+)
+
+add_alias(LevelDB::LevelDB leveldb)
 
 
 # nanopb

--- a/cmake/external/leveldb.cmake
+++ b/cmake/external/leveldb.cmake
@@ -18,60 +18,30 @@ if(TARGET leveldb)
   return()
 endif()
 
-if(WIN32 OR LEVELDB_ROOT)
-  # If the user has supplied a LEVELDB_ROOT then just use it. Add an empty
-  # custom target so that the superbuild depdendencies don't all have to be
-  # conditional.
+if(WIN32)
+  # Unfortunately, LevelDB does not build on Windows (yet). See:
   #
-  # Also, unfortunately, LevelDB does not build on Windows (yet)
-  # See:
-  #   https://github.com/google/leveldb/issues/363
-  #   https://github.com/google/leveldb/issues/466
+  #   * https://github.com/google/leveldb/issues/363
+  #   * https://github.com/google/leveldb/issues/466
   add_custom_target(leveldb)
   return()
 endif()
 
-
-# Clean up warning output to reduce noise in the build
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-  set(
-    LEVELDB_CXX_FLAGS "\
-      -Wno-deprecated-declarations"
-  )
-endif()
-
-# Map CMake compiler configuration down onto the leveldb Makefile
-set(
-  LEVELDB_OPT "\
-    $<$<CONFIG:Debug>:${CMAKE_CXX_FLAGS_DEBUG}> \
-    $<$<CONFIG:Release>:${CMAKE_CXX_FLAGS_RELEASE}>"
-)
+# CMake support was added after the 1.20 release
+set(commit 6caf73ad9dae0ee91873bcb39554537b85163770)  # master@{2018-07-14}
 
 ExternalProject_Add(
   leveldb
 
   DOWNLOAD_DIR ${FIREBASE_DOWNLOAD_DIR}
-  DOWNLOAD_NAME leveldb-v1.20.tar.gz
-  URL https://github.com/google/leveldb/archive/v1.20.tar.gz
-  URL_HASH SHA256=f5abe8b5b209c2f36560b75f32ce61412f39a2922f7045ae764a2c23335b6664
+  DOWNLOAD_NAME leveldb-${commit}.tar.gz
+  URL https://github.com/google/leveldb/archive/${commit}.tar.gz
+  URL_HASH SHA256=255e3283556aff81e337a951c5f5579f5b98b63d5f345db9e97a1f7563f54f9e
 
-  PREFIX ${FIREBASE_BINARY_DIR}
+  PREFIX ${PROJECT_BINARY_DIR}
 
-  # LevelDB's configuration is done in the Makefile
   CONFIGURE_COMMAND ""
-
-  # The Makefile-based build of leveldb does not support building
-  # out-of-source.
-  BUILD_IN_SOURCE ON
-
-  # Only build the leveldb library skipping the tools and in-memory
-  # implementation we don't use.
-  BUILD_COMMAND
-    env CXXFLAGS=${LEVELDB_CXX_FLAGS} OPT=${LEVELDB_OPT}
-      make -j out-static/libleveldb.a
-
-  INSTALL_DIR ${FIREBASE_INSTALL_DIR}
-
-  INSTALL_COMMAND ""
-  TEST_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
 )


### PR DESCRIPTION
CMake support landed in google/leveldb:master a while ago.

This cuts down on the nasty cmake to make bridge and makes it possible to use LevelDB on Windows when that lands.