### PR TITLE
Port Query::testNaNFilter() from java

### DIFF
--- a/Firestore/core/test/firebase/firestore/core/query_test.cc
+++ b/Firestore/core/test/firebase/firestore/core/query_test.cc
@@ -16,6 +16,8 @@
 
 #include "Firestore/core/src/firebase/firestore/core/query.h"
 
+#include <cmath>
+
 #include "Firestore/core/src/firebase/firestore/model/document.h"
 #include "Firestore/core/src/firebase/firestore/model/field_path.h"
 #include "Firestore/core/src/firebase/firestore/model/field_value.h"
@@ -95,6 +97,26 @@ TEST(QueryTest, PrimitiveValueFilter) {
   EXPECT_FALSE(query2.Matches(doc3));
   EXPECT_FALSE(query2.Matches(doc4));
   EXPECT_FALSE(query2.Matches(doc5));
+}
+
+TEST(QueryTest, NanFilter) {
+  Query query = Query::AtPath(ResourcePath::FromString("collection"))
+                    .Filter(Filter("sort", "==", NAN));
+
+  Document doc1 = Doc("collection/1", 0, {{"sort", FieldValue::NanValue()}});
+  Document doc2 =
+      Doc("collection/2", 0, {{"sort", FieldValue::IntegerValue(2)}});
+  Document doc3 =
+      Doc("collection/3", 0, {{"sort", FieldValue::DoubleValue(3.1)}});
+  Document doc4 = Doc("collection/4", 0, {{"sort", FieldValue::FalseValue()}});
+  Document doc5 =
+      Doc("collection/5", 0, {{"sort", FieldValue::StringValue("string")}});
+
+  EXPECT_TRUE(query.Matches(doc1));
+  EXPECT_FALSE(query.Matches(doc2));
+  EXPECT_FALSE(query.Matches(doc3));
+  EXPECT_FALSE(query.Matches(doc4));
+  EXPECT_FALSE(query.Matches(doc5));
 }
 
 }  // namespace core

--- a/Firestore/core/test/firebase/firestore/testutil/testutil.h
+++ b/Firestore/core/test/firebase/firestore/testutil/testutil.h
@@ -111,6 +111,12 @@ inline std::shared_ptr<core::Filter> Filter(absl::string_view key,
   return Filter(key, op, model::FieldValue::IntegerValue(value));
 }
 
+inline std::shared_ptr<core::Filter> Filter(absl::string_view key,
+                                            absl::string_view op,
+                                            float value) {
+  return Filter(key, op, model::FieldValue::DoubleValue(value));
+}
+
 // Add a non-inline function to make this library buildable.
 // TODO(zxu123): remove once there is non-inline function.
 void dummy();


### PR DESCRIPTION
Note that this works even though we haven't ported the NanFilter class
yet. (The RelationFilter handles nan's just fine. Though also doesn't
restrict nan's in cases where they shouldn't be used, i.e. anything
except equality.)