### PR TITLE
Multiple fuzz testing targets

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_FuzzTests_iOS.xcscheme
+++ b/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_FuzzTests_iOS.xcscheme
@@ -7,8 +7,11 @@
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
+            buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForTesting = "YES">
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "6EDD3AD120BF247500C33877"
@@ -50,6 +53,22 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6EDD3AD120BF247500C33877"
+            BuildableName = "Firestore_FuzzTests_iOS.xctest"
+            BlueprintName = "Firestore_FuzzTests_iOS"
+            ReferencedContainer = "container:Firestore.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "FUZZING_TARGET"
+            value = "$(FUZZING_TARGET)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_FuzzTests_iOS.xcscheme
+++ b/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_FuzzTests_iOS.xcscheme
@@ -7,11 +7,7 @@
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForTesting = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "6EDD3AD120BF247500C33877"
@@ -53,15 +49,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "6EDD3AD120BF247500C33877"
-            BuildableName = "Firestore_FuzzTests_iOS.xctest"
-            BlueprintName = "Firestore_FuzzTests_iOS"
-            ReferencedContainer = "container:Firestore.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "FUZZING_TARGET"

--- a/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_FuzzTests_iOS.xcscheme
+++ b/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_FuzzTests_iOS.xcscheme
@@ -7,6 +7,7 @@
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
+            buildForRunning = "YES"
             buildForTesting = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"

--- a/Firestore/Example/FuzzTests/FSTFuzzTestsPrincipal.mm
+++ b/Firestore/Example/FuzzTests/FSTFuzzTestsPrincipal.mm
@@ -72,10 +72,9 @@ FuzzingTarget GetFuzzingTarget() {
     return FuzzingTarget::kNone;
   }
 
-  // Convert fuzzing_target_env to an std::string after verifying it is not null
-  // and match to a fuzzing target.
+  // Convert fuzzing_target_env to std::string after verifying it is not null.
   std::string fuzzing_target{fuzzing_target_env};
-  if (fuzzing_target.size() == 0) {
+  if (fuzzing_target.empty()) {
     LOG_WARN("No value provided for FUZZING_TARGET environment variable.");
     return FuzzingTarget::kNone;
   }

--- a/Firestore/Example/FuzzTests/FSTFuzzTestsPrincipal.mm
+++ b/Firestore/Example/FuzzTests/FSTFuzzTestsPrincipal.mm
@@ -21,19 +21,14 @@
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
 #include "Firestore/core/src/firebase/firestore/remote/serializer.h"
 #include "Firestore/core/src/firebase/firestore/util/log.h"
-#include "Firestore/core/src/firebase/firestore/util/string_format.h"
 
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::remote::Serializer;
-using firebase::firestore::util::StringFormat;
 
 namespace {
 
 // A list of targets to fuzz test.
-enum FuzzingTarget {
-  NONE = 0,
-  SERIALIZER = 1
-};
+enum FuzzingTarget { NONE = 0, SERIALIZER = 1 };
 
 // Directory to which crashing inputs are written. Must include the '/' at the
 // end because libFuzzer prepends this path to the crashing input file name.
@@ -66,8 +61,8 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 // Default target is NONE if the environment variable is empty, not set, or
 // could not be interpretted.
 FuzzingTarget GetFuzzingTarget() {
-  NSString *fuzzing_target_env = [[[NSProcessInfo processInfo] environment]
-                                  objectForKey:@"FUZZING_TARGET"];
+  NSString *fuzzing_target_env =
+      [[[NSProcessInfo processInfo] environment] objectForKey:@"FUZZING_TARGET"];
 
   if ([@"NONE" isEqualToString:fuzzing_target_env]) {
     return NONE;
@@ -106,7 +101,8 @@ int RunFuzzTestingMain() {
   // Set the dictionary and corpus locations according to the fuzzing target.
   switch (fuzzing_target) {
     case SERIALIZER:
-      dict_location = [resources_location stringByAppendingPathComponent:@"Serializer/serializer.dictionary"];
+      dict_location =
+          [resources_location stringByAppendingPathComponent:@"Serializer/serializer.dictionary"];
       corpus_location = @"FuzzTestsCorpus";
       break;
 
@@ -126,9 +122,8 @@ int RunFuzzTestingMain() {
   const char *corpus_arg = [corpus_path UTF8String];
 
   // The directory in which libFuzzer writes crashing inputs.
-  std::string prefix_arg = StringFormat("-artifact_prefix=%s", kCrashingInputsDirectory);
-  NSLog(@"prfix= %s", prefix_arg.c_str());
-  return 1;
+  const char *prefix_arg =
+      [[NSString stringWithFormat:@"-artifact_prefix=%s", kCrashingInputsDirectory] UTF8String];
 
   // Arguments to libFuzzer main() function should be added to this array,
   // e.g., dictionaries, corpus, number of runs, jobs, etc. The FuzzerDriver of
@@ -136,7 +131,7 @@ int RunFuzzTestingMain() {
   // modify it throughout the method.
   char *program_args[] = {
       const_cast<char *>("RunFuzzTestingMain"),  // First arg is program name.
-      const_cast<char *>(prefix_arg.c_str()),    // Crashing inputs directory.
+      const_cast<char *>(prefix_arg),            // Crashing inputs directory.
       const_cast<char *>(dict_arg),              // Dictionary arg.
       const_cast<char *>(corpus_arg)             // Corpus must be the last arg.
   };

--- a/Firestore/Example/FuzzTests/FSTFuzzTestsPrincipal.mm
+++ b/Firestore/Example/FuzzTests/FSTFuzzTestsPrincipal.mm
@@ -67,19 +67,25 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 FuzzingTarget GetFuzzingTarget() {
   char *fuzzing_target_env = std::getenv("FUZZING_TARGET");
 
-  if (fuzzing_target_env == NULL || strlen(fuzzing_target_env) == 0) {
+  if (fuzzing_target_env == nullptr) {
     LOG_WARN("No value provided for FUZZING_TARGET environment variable.");
     return FuzzingTarget::kNone;
   }
 
-  if (strcmp("NONE", fuzzing_target_env) == 0) {
+  // Convert fuzzing_target_env to an std::string after verifying it is not null
+  // and match to a fuzzing target.
+  std::string fuzzing_target{fuzzing_target_env};
+  if (fuzzing_target.size() == 0) {
+    LOG_WARN("No value provided for FUZZING_TARGET environment variable.");
     return FuzzingTarget::kNone;
   }
-  if (strcmp("SERIALIZER", fuzzing_target_env) == 0) {
+  if (fuzzing_target == "NONE") {
+    return FuzzingTarget::kNone;
+  }
+  if (fuzzing_target == "SERIALIZER") {
     return FuzzingTarget::kSerializer;
   }
-  // Value did not match any target.
-  LOG_WARN("Invalid fuzzing target: %s", std::string{fuzzing_target_env});
+  LOG_WARN("Invalid fuzzing target: %s", fuzzing_target);
   return FuzzingTarget::kNone;
 }
 

--- a/Firestore/Example/FuzzTests/FSTFuzzTestsPrincipal.mm
+++ b/Firestore/Example/FuzzTests/FSTFuzzTestsPrincipal.mm
@@ -33,7 +33,8 @@ enum FuzzingTarget { NONE = 0, SERIALIZER = 1 };
 
 // Directory to which crashing inputs are written. Must include the '/' at the
 // end because libFuzzer prepends this path to the crashing input file name.
-const char *kCrashingInputsDirectory = "/tmp/CrashingInputs/";
+// We write crashes to the temporary directory that is available to the iOS app.
+NSString *kCrashingInputsDirectory = NSTemporaryDirectory();
 
 // Fuzz-test the deserialization process in Firestore. The Serializer reads raw
 // bytes and converts them to a model object.
@@ -87,7 +88,7 @@ FuzzingTarget GetFuzzingTarget() {
 
 // Simulates calling the main() function of libFuzzer (FuzzerMain.cpp).
 // Uses GetFuzzingTarget() to get the fuzzing target and sets libFuzzer's args
-// accordingly. Writes any crashes to a /CrashingInputs folder.
+// accordingly.
 int RunFuzzTestingMain() {
   // Get the fuzzing target.
   FuzzingTarget fuzzing_target = GetFuzzingTarget();
@@ -126,7 +127,7 @@ int RunFuzzTestingMain() {
 
   // The directory in which libFuzzer writes crashing inputs.
   const char *prefix_arg =
-      [[NSString stringWithFormat:@"-artifact_prefix=%s", kCrashingInputsDirectory] UTF8String];
+      [[@"-artifact_prefix=" stringByAppendingString:kCrashingInputsDirectory] UTF8String];
 
   // Arguments to libFuzzer main() function should be added to this array,
   // e.g., dictionaries, corpus, number of runs, jobs, etc. The FuzzerDriver of


### PR DESCRIPTION
* Read the fuzzing target from a `FUZZING_TARGET` environment variable. Example usage:
```bash
xcodebuild \
  -workspace Firestore.xcworkspace \
  -scheme Firestore_FuzzTests_iOS \
  -destination 'platform=iOS Simulator,name=iPhone 8 Plus,OS=11.3' \
  FUZZING_TARGET='SERIALIZER' test
```

* Write crashing inputs to `NSTemporaryDirectory()`