### PR TITLE
Fix broken build under linux

### DIFF
--- a/Firestore/CMakeLists.txt
+++ b/Firestore/CMakeLists.txt
@@ -148,20 +148,22 @@ podspec_framework(
   ${FIREBASE_SOURCE_DIR}/FirebaseAuthInterop.podspec
 )
 
-# FirebaseAuthInterop has no source files but CMake can't build frameworks that don't
-# have sources. Generate an inconsequential source file so that the library can
-# be linked.
-file(
-  WRITE ${CMAKE_CURRENT_BINARY_DIR}/FirebaseAuthInteropDummy.c
-  "// generated file for header-only CMake support.
-  __attribute__((unused))
-  static void FirebaseAuthInteropFakeSymbol() {}
-  "
-)
-target_sources(
-  FirebaseAuthInterop
-  PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/FirebaseAuthInteropDummy.c
-)
+if(APPLE)
+  # FirebaseAuthInterop has no source files but CMake can't build frameworks
+  # that don't have sources. Generate an inconsequential source file so that
+  # the library can be linked.
+  file(
+    WRITE ${CMAKE_CURRENT_BINARY_DIR}/FirebaseAuthInteropDummy.c
+    "// generated file for header-only CMake support.
+    __attribute__((unused))
+    static void FirebaseAuthInteropFakeSymbol() {}
+    "
+  )
+  target_sources(
+    FirebaseAuthInterop
+    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/FirebaseAuthInteropDummy.c
+  )
+endif()
 
 
 # Superbuild installed results


### PR DESCRIPTION
FirebaseAuthInterop isn't defined as a target under linux (since it
comes from the podfiles) so defining a source file for the target causes
cmake to error.