### PR TITLE
Prevent the comment in the prepare_command from interfering

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -70,9 +70,9 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
       '"${PODS_TARGET_SRCROOT}/Firestore/Protos/nanopb"',
   }
 
+  # Generate a version of the config.h header suitable for building with
+  # CocoaPods.
   s.prepare_command = <<-CMD
-    # Generate a version of the config.h header suitable for building with
-    # CocoaPods.
     sed '/^#cmakedefine/ d' \
         Firestore/core/src/firebase/firestore/util/config.h.in > \
         Firestore/core/src/firebase/firestore/util/config.h


### PR DESCRIPTION
Under recent cocoapods I've seen this cause the sed command to be
commented out and not run.