### PR TITLE
Add a schema migration that drops the query cache

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -1431,24 +1431,6 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Firestore_Tests_iOS/Pods-Firestore_Tests_iOS-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		5504F81EEBBEF943CA61D32C /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-Firestore_Example_iOS-SwiftBuildTest-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
 		6E622C7A20F52C8300B7E93A /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 12;
@@ -1637,8 +1619,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5495EB032040E90200EBA509 /* CodableGeoPointTests.swift in Sources */,
 				544A20EE20F6C10C004E52CD /* BasicCompileTests.swift in Sources */,
+				5495EB032040E90200EBA509 /* CodableGeoPointTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
@@ -90,7 +90,8 @@ using leveldb::Status;
     [FSTLevelDBMigrations runMigrationsWithDatabase:_db.get()];
 
     LevelDbTransaction transaction(_db.get(), "testSetsVersionNumber after");
-    FSTLevelDBSchemaVersion actual = [FSTLevelDBMigrations schemaVersionWithTransaction:&transaction];
+    FSTLevelDBSchemaVersion actual =
+        [FSTLevelDBMigrations schemaVersionWithTransaction:&transaction];
     XCTAssertGreaterThan(actual, 0, @"Expected to migrate to a schema version > 0");
   }
 }
@@ -183,7 +184,6 @@ using leveldb::Status;
     XCTAssertEqual(found_keys, std::vector<std::string>{});
   }
 }
-
 
 /**
  * Creates the name of a dummy entry to make sure the iteration is correctly bounded.

--- a/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
@@ -23,17 +23,22 @@
 #import "Firestore/Source/Local/FSTLevelDB.h"
 #import "Firestore/Source/Local/FSTLevelDBKey.h"
 #import "Firestore/Source/Local/FSTLevelDBMigrations.h"
+#import "Firestore/Source/Local/FSTLevelDBMutationQueue.h"
 #import "Firestore/Source/Local/FSTLevelDBQueryCache.h"
 
 #include "Firestore/core/src/firebase/firestore/util/ordered_code.h"
+#include "Firestore/core/src/firebase/firestore/util/status.h"
+#include "Firestore/core/test/firebase/firestore/testutil/testutil.h"
 #include "leveldb/db.h"
 
 #import "Firestore/Example/Tests/Local/FSTPersistenceTestHelpers.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+using firebase::firestore::FirestoreErrorCode;
 using firebase::firestore::local::LevelDbTransaction;
 using firebase::firestore::util::OrderedCode;
+using firebase::firestore::testutil::Key;
 using leveldb::DB;
 using leveldb::Options;
 using leveldb::Status;
@@ -94,11 +99,7 @@ using leveldb::Status;
     }
     // Add a dummy entry after the targets to make sure the iteration is correctly bounded.
     // Use a table that would sort logically right after that table 'target'.
-    std::string dummyKey;
-    // Magic number that indicates a table name follows. Needed to mimic the prefix to the target
-    // table.
-    OrderedCode::WriteSignedNumIncreasing(&dummyKey, 5);
-    OrderedCode::WriteString(&dummyKey, "targetA");
+    std::string dummyKey = [self dummyKeyForTable:"targetA"];
     transaction.Put(dummyKey, "dummy");
     transaction.Commit();
   }
@@ -110,6 +111,80 @@ using leveldb::Status;
     FSTPBTargetGlobal *metadata = [FSTLevelDBQueryCache readTargetMetadataFromDB:_db.get()];
     XCTAssertEqual(expected, metadata.targetCount, @"Failed to count all of the targets we added");
   }
+}
+
+#define ASSERT_NOT_FOUND(transaction, key)                \
+  do {                                                    \
+    std::string unused_result;                            \
+    Status status = transaction.Get(key, &unused_result); \
+    XCTAssertTrue(status.IsNotFound());                   \
+  } while (0)
+
+#define ASSERT_FOUND(transaction, key)                    \
+  do {                                                    \
+    std::string unused_result;                            \
+    Status status = transaction.Get(key, &unused_result); \
+    XCTAssertTrue(status.ok());                           \
+  } while (0)
+
+- (void)testDropsTheQueryCache {
+  NSString *userID = @"user";
+  FSTBatchID batchID = 1;
+  FSTTargetID targetID = 2;
+
+  FSTDocumentKey *key1 = Key("documents/1");
+  FSTDocumentKey *key2 = Key("documents/2");
+
+  std::string targetKeys[] = {
+      [FSTLevelDBTargetKey keyWithTargetID:targetID],
+      [FSTLevelDBTargetDocumentKey keyWithTargetID:targetID documentKey:key1],
+      [FSTLevelDBTargetDocumentKey keyWithTargetID:targetID documentKey:key2],
+      [FSTLevelDBDocumentTargetKey keyWithDocumentKey:key1 targetID:targetID],
+      [FSTLevelDBDocumentTargetKey keyWithDocumentKey:key2 targetID:targetID]};
+
+  std::string preservedKeys[] = {[self dummyKeyForTable:"targetA"],
+                                 [FSTLevelDBMutationQueueKey keyWithUserID:userID],
+                                 [FSTLevelDBMutationKey keyWithUserID:userID batchID:batchID]};
+
+  {
+    // Setup some targets to be counted in the migration.
+    LevelDbTransaction transaction(_db.get(), "testDropsTheQueryCache setup");
+    [FSTLevelDBMigrations runMigrationsWithTransaction:&transaction upToVersion:1];
+
+    for (const std::string &key : targetKeys) {
+      transaction.Put(key, "target");
+    }
+
+    for (const std::string &key : preservedKeys) {
+      transaction.Put(key, "preserved");
+    }
+    transaction.Commit();
+  }
+
+  {
+    LevelDbTransaction transaction(_db.get(), "testDropsTheQueryCache");
+    [FSTLevelDBMigrations runMigrationsWithTransaction:&transaction upToVersion:2];
+
+    for (const std::string &key : targetKeys) {
+      ASSERT_NOT_FOUND(transaction, key);
+    }
+
+    for (const std::string &key : preservedKeys) {
+      ASSERT_FOUND(transaction, key);
+    }
+  }
+}
+
+/**
+ * Creates the name of a dummy entry to make sure the iteration is correctly bounded.
+ */
+- (std::string)dummyKeyForTable:(const char *)tableName {
+  std::string dummyKey;
+  // Magic number that indicates a table name follows. Needed to mimic the prefix to the target
+  // table.
+  OrderedCode::WriteSignedNumIncreasing(&dummyKey, 5);
+  OrderedCode::WriteString(&dummyKey, tableName);
+  return dummyKey;
 }
 
 @end

--- a/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
@@ -142,6 +142,7 @@ using leveldb::Status;
       [FSTLevelDBDocumentTargetKey keyWithDocumentKey:key1 targetID:targetID],
       [FSTLevelDBDocumentTargetKey keyWithDocumentKey:key2 targetID:targetID]};
 
+  // Keys that should not be modified by the dropping the query cache
   std::string preservedKeys[] = {[self dummyKeyForTable:"targetA"],
                                  [FSTLevelDBMutationQueueKey keyWithUserID:userID],
                                  [FSTLevelDBMutationKey keyWithUserID:userID batchID:batchID]};
@@ -154,7 +155,6 @@ using leveldb::Status;
     for (const std::string &key : targetKeys) {
       transaction.Put(key, "target");
     }
-
     for (const std::string &key : preservedKeys) {
       transaction.Put(key, "preserved");
     }
@@ -168,7 +168,6 @@ using leveldb::Status;
     for (const std::string &key : targetKeys) {
       ASSERT_NOT_FOUND(transaction, key);
     }
-
     for (const std::string &key : preservedKeys) {
       ASSERT_FOUND(transaction, key);
     }

--- a/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
@@ -123,12 +123,16 @@ using leveldb::Status;
       [FSTLevelDBTargetDocumentKey keyWithTargetID:targetID documentKey:key1],
       [FSTLevelDBTargetDocumentKey keyWithTargetID:targetID documentKey:key2],
       [FSTLevelDBDocumentTargetKey keyWithDocumentKey:key1 targetID:targetID],
-      [FSTLevelDBDocumentTargetKey keyWithDocumentKey:key2 targetID:targetID]};
+      [FSTLevelDBDocumentTargetKey keyWithDocumentKey:key2 targetID:targetID],
+      [FSTLevelDBQueryTargetKey keyWithCanonicalID:"foo.bar.baz" targetID:targetID],
+  };
 
   // Keys that should not be modified by the dropping the query cache
-  std::string preservedKeys[] = {[self dummyKeyForTable:"targetA"],
-                                 [FSTLevelDBMutationQueueKey keyWithUserID:userID],
-                                 [FSTLevelDBMutationKey keyWithUserID:userID batchID:batchID]};
+  std::string preservedKeys[] = {
+      [self dummyKeyForTable:"targetA"],
+      [FSTLevelDBMutationQueueKey keyWithUserID:userID],
+      [FSTLevelDBMutationKey keyWithUserID:userID batchID:batchID],
+  };
 
   [FSTLevelDBMigrations runMigrationsWithDatabase:_db.get() upToVersion:2];
   {

--- a/Firestore/Source/Local/FSTLevelDB.mm
+++ b/Firestore/Source/Local/FSTLevelDB.mm
@@ -150,9 +150,7 @@ using leveldb::WriteOptions;
     return NO;
   }
   _ptr.reset(database);
-  LevelDbTransaction transaction(_ptr.get(), "Start LevelDB");
-  [FSTLevelDBMigrations runMigrationsWithTransaction:&transaction];
-  transaction.Commit();
+  [FSTLevelDBMigrations runMigrationsWithDatabase:_ptr.get()];
   return YES;
 }
 

--- a/Firestore/Source/Local/FSTLevelDBMigrations.h
+++ b/Firestore/Source/Local/FSTLevelDBMigrations.h
@@ -36,13 +36,13 @@ typedef int32_t FSTLevelDBSchemaVersion;
 /**
  * Runs any migrations needed to bring the given database up to the current schema version
  */
-+ (void)runMigrationsWithTransaction:(firebase::firestore::local::LevelDbTransaction *)transaction;
++ (void)runMigrationsWithDatabase:(leveldb::DB *)database;
 
 /**
  * Runs any migrations needed to bring the given database up to the given schema version
  */
-+ (void)runMigrationsWithTransaction:(firebase::firestore::local::LevelDbTransaction *)transaction
-                         upToVersion:(FSTLevelDBSchemaVersion)version;
++ (void)runMigrationsWithDatabase:(leveldb::DB *)database
+                      upToVersion:(FSTLevelDBSchemaVersion)version;
 
 @end
 

--- a/Firestore/Source/Local/FSTLevelDBMigrations.h
+++ b/Firestore/Source/Local/FSTLevelDBMigrations.h
@@ -38,6 +38,12 @@ typedef int32_t FSTLevelDBSchemaVersion;
  */
 + (void)runMigrationsWithTransaction:(firebase::firestore::local::LevelDbTransaction *)transaction;
 
+/**
+ * Runs any migrations needed to bring the given database up to the given schema version
+ */
++ (void)runMigrationsWithTransaction:(firebase::firestore::local::LevelDbTransaction *)transaction
+                         upToVersion:(FSTLevelDBSchemaVersion)version;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Firestore/Source/Local/FSTLevelDBMigrations.mm
+++ b/Firestore/Source/Local/FSTLevelDBMigrations.mm
@@ -88,46 +88,31 @@ static void AddTargetCount(LevelDbTransaction *transaction) {
 }
 
 /**
- * A class representing all migrations to prepare the LevelDB database for use.
- *
- * TODO(wilhuff): All the migrations should really be a part of this but to minimize the scope of
- * this change for now it's constrained to just the new one.
+ * Deletes everything in the database that has the given prefix.
  */
-class LevelDbSchema {
- public:
-  explicit LevelDbSchema(leveldb::DB *db) : db_{db} {
-  }
-
-  void DropQueryCache();
-
- private:
-  void DeleteEverythingWithPrefix(const std::string &prefix);
-
-  leveldb::DB *db_;
-  std::unique_ptr<LevelDbTransaction> transaction_;
-};
-
-void LevelDbSchema::DropQueryCache() {
-  transaction_ = absl::make_unique<LevelDbTransaction>(db_, "Drop Query Cache");
-
-  DeleteEverythingWithPrefix([FSTLevelDBTargetKey keyPrefix]);
-  DeleteEverythingWithPrefix([FSTLevelDBDocumentTargetKey keyPrefix]);
-  DeleteEverythingWithPrefix([FSTLevelDBTargetDocumentKey keyPrefix]);
-
-  transaction_->Commit();
-}
-
-void LevelDbSchema::DeleteEverythingWithPrefix(const std::string &prefix) {
-  LevelDbTransaction reader(db_, "Reader");
+static void DeleteEverythingWithPrefix(const std::string &prefix, LevelDbTransaction *transaction) {
+  LevelDbTransaction reader(transaction->database(), "Reader");
   auto it = reader.NewIterator();
 
   for (it->Seek(prefix); it->Valid() && absl::StartsWith(it->key(), prefix); it->Next()) {
-    if (transaction_->changed_keys() >= 1000) {
-      transaction_->Commit();
-      transaction_ = absl::make_unique<LevelDbTransaction>(db_, "Drop Query Cache");
+    if (transaction->changed_keys() >= 1000) {
+      transaction->Commit();
+      transaction->Reuse();
     }
-    transaction_->Delete(it->key());
+    transaction->Delete(it->key());
   }
+}
+
+/**
+ * Drops the contents of the query cache. This prevents a device with a cache corrupted by
+ * https://github.com/firebase/firebase-ios-sdk/issues/1548 from issuing a resume token for
+ * the first query after upgrading. Without a resume token the server will re-send the entire
+ * query results, healing the cache.
+ */
+static void DropQueryCache(LevelDbTransaction *transaction) {
+  DeleteEverythingWithPrefix([FSTLevelDBTargetKey keyPrefix], transaction);
+  DeleteEverythingWithPrefix([FSTLevelDBDocumentTargetKey keyPrefix], transaction);
+  DeleteEverythingWithPrefix([FSTLevelDBTargetDocumentKey keyPrefix], transaction);
 }
 
 @implementation FSTLevelDBMigrations
@@ -167,8 +152,7 @@ void LevelDbSchema::DeleteEverythingWithPrefix(const std::string &prefix) {
     case 2:
       if (upToVersion < 2) break;
       if (currentVersion != 0) {
-        LevelDbSchema schema{transaction->database()};
-        schema.DropQueryCache();
+        DropQueryCache(transaction);
       }
       ABSL_FALLTHROUGH_INTENDED;
     default:

--- a/Firestore/Source/Local/FSTLevelDBMigrations.mm
+++ b/Firestore/Source/Local/FSTLevelDBMigrations.mm
@@ -63,7 +63,7 @@ static void SaveVersion(FSTLevelDBSchemaVersion version, LevelDbTransaction *tra
   transaction->Put(key, version_string);
 }
 
-static void DeleteEverythingWithPrefix(const std::string &prefix, leveldb::DB* db) {
+static void DeleteEverythingWithPrefix(const std::string &prefix, leveldb::DB *db) {
   bool more_deletes = true;
   while (more_deletes) {
     LevelDbTransaction transaction(db, "Delete everything with prefix");
@@ -83,7 +83,7 @@ static void DeleteEverythingWithPrefix(const std::string &prefix, leveldb::DB* d
 }
 
 /** Migration 3. */
-static void ClearQueryCache(leveldb::DB* db) {
+static void ClearQueryCache(leveldb::DB *db) {
   DeleteEverythingWithPrefix([FSTLevelDBTargetKey keyPrefix], db);
   DeleteEverythingWithPrefix([FSTLevelDBDocumentTargetKey keyPrefix], db);
   DeleteEverythingWithPrefix([FSTLevelDBTargetDocumentKey keyPrefix], db);

--- a/Firestore/Source/Local/FSTLevelDBMigrations.mm
+++ b/Firestore/Source/Local/FSTLevelDBMigrations.mm
@@ -30,7 +30,20 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-// Current version of the schema defined in this file.
+/**
+ * Schema version for the iOS client.
+ *
+ * Note that tables aren't a concept in LevelDB. They exist in our schema as just prefixes on keys.
+ * This means tables don't need to be created but they also can't easily be dropped and re-created.
+ *
+ * Migrations:
+ *   * Migration 1 used to ensure the target_global row existed, without clearing it. No longer
+ *     required because migration 3 unconditionally clears it.
+ *   * Migration 2 used to ensure that the target_global row had a correct count of targets. No
+ *     longer required because migration 3 deletes them all.
+ *   * Migration 3 deletes the entire query cache to deal with cache corruption related to
+ *     limbo resolution. Addresses https://github.com/firebase/firebase-ios-sdk/issues/1548.
+ */
 static FSTLevelDBSchemaVersion kSchemaVersion = 3;
 
 using firebase::firestore::local::LevelDbTransaction;
@@ -38,17 +51,6 @@ using leveldb::Iterator;
 using leveldb::Status;
 using leveldb::Slice;
 using leveldb::WriteOptions;
-
-/**
- * Ensures that the global singleton target metadata row exists in LevelDB.
- */
-static void EnsureTargetGlobal(LevelDbTransaction *transaction) {
-  FSTPBTargetGlobal *targetGlobal =
-      [FSTLevelDBQueryCache readTargetMetadataWithTransaction:transaction];
-  if (!targetGlobal) {
-    transaction->Put([FSTLevelDBTargetGlobalKey key], [FSTPBTargetGlobal message]);
-  }
-}
 
 /**
  * Save the given version number as the current version of the schema of the database.
@@ -61,73 +63,39 @@ static void SaveVersion(FSTLevelDBSchemaVersion version, LevelDbTransaction *tra
   transaction->Put(key, version_string);
 }
 
-/**
- * This function counts the number of targets that currently exist in the given db. It
- * then reads the target global row, adds the count to the metadata from that row, and writes
- * the metadata back.
- *
- * It assumes the metadata has already been written and is able to be read in this transaction.
- */
-static void AddTargetCount(LevelDbTransaction *transaction) {
-  auto it = transaction->NewIterator();
-  std::string start_key = [FSTLevelDBTargetKey keyPrefix];
-  it->Seek(start_key);
+static void DeleteEverythingWithPrefix(const std::string &prefix, leveldb::DB* db) {
+  bool more_deletes = true;
+  while (more_deletes) {
+    LevelDbTransaction transaction(db, "Delete everything with prefix");
+    auto it = transaction.NewIterator();
 
-  int32_t count = 0;
-  while (it->Valid() && absl::StartsWith(it->key(), start_key)) {
-    count++;
-    it->Next();
-  }
-
-  FSTPBTargetGlobal *targetGlobal =
-      [FSTLevelDBQueryCache readTargetMetadataWithTransaction:transaction];
-  HARD_ASSERT(targetGlobal != nil,
-              "We should have a metadata row as it was added in an earlier migration");
-  targetGlobal.targetCount = count;
-  transaction->Put([FSTLevelDBTargetGlobalKey key], targetGlobal);
-}
-
-/**
- * A class representing all migrations to prepare the LevelDB database for use.
- *
- * TODO(wilhuff): All the migrations should really be a part of this but to minimize the scope of
- * this change for now it's constrained to just the new one.
- */
-class LevelDbSchema {
- public:
-  explicit LevelDbSchema(leveldb::DB *db) : db_{db} {
-  }
-
-  void DropQueryCache();
-
- private:
-  void DeleteEverythingWithPrefix(const std::string &prefix);
-
-  leveldb::DB *db_;
-  std::unique_ptr<LevelDbTransaction> transaction_;
-};
-
-void LevelDbSchema::DropQueryCache() {
-  transaction_ = absl::make_unique<LevelDbTransaction>(db_, "Drop Query Cache");
-
-  DeleteEverythingWithPrefix([FSTLevelDBTargetKey keyPrefix]);
-  DeleteEverythingWithPrefix([FSTLevelDBDocumentTargetKey keyPrefix]);
-  DeleteEverythingWithPrefix([FSTLevelDBTargetDocumentKey keyPrefix]);
-
-  transaction_->Commit();
-}
-
-void LevelDbSchema::DeleteEverythingWithPrefix(const std::string &prefix) {
-  LevelDbTransaction reader(db_, "Reader");
-  auto it = reader.NewIterator();
-
-  for (it->Seek(prefix); it->Valid() && absl::StartsWith(it->key(), prefix); it->Next()) {
-    if (transaction_->changed_keys() >= 1000) {
-      transaction_->Commit();
-      transaction_ = absl::make_unique<LevelDbTransaction>(db_, "Drop Query Cache");
+    more_deletes = false;
+    for (it->Seek(prefix); it->Valid() && absl::StartsWith(it->key(), prefix); it->Next()) {
+      if (transaction.changed_keys() >= 1000) {
+        more_deletes = true;
+        break;
+      }
+      transaction.Delete(it->key());
     }
-    transaction_->Delete(it->key());
+
+    transaction.Commit();
   }
+}
+
+/** Migration 3. */
+static void ClearQueryCache(leveldb::DB* db) {
+  DeleteEverythingWithPrefix([FSTLevelDBTargetKey keyPrefix], db);
+  DeleteEverythingWithPrefix([FSTLevelDBDocumentTargetKey keyPrefix], db);
+  DeleteEverythingWithPrefix([FSTLevelDBTargetDocumentKey keyPrefix], db);
+  DeleteEverythingWithPrefix([FSTLevelDBQueryTargetKey keyPrefix], db);
+
+  LevelDbTransaction transaction(db, "Drop query cache");
+
+  // Reset the target global entry too (to reset the target count).
+  transaction.Put([FSTLevelDBTargetGlobalKey key], [FSTPBTargetGlobal message]);
+
+  SaveVersion(3, &transaction);
+  transaction.Commit();
 }
 
 @implementation FSTLevelDBMigrations
@@ -144,38 +112,19 @@ void LevelDbSchema::DeleteEverythingWithPrefix(const std::string &prefix) {
   }
 }
 
-+ (void)runMigrationsWithTransaction:(firebase::firestore::local::LevelDbTransaction *)transaction {
-  [self runMigrationsWithTransaction:transaction upToVersion:kSchemaVersion];
++ (void)runMigrationsWithDatabase:(leveldb::DB *)database {
+  [self runMigrationsWithDatabase:database upToVersion:kSchemaVersion];
 }
 
-+ (void)runMigrationsWithTransaction:(firebase::firestore::local::LevelDbTransaction *)transaction
-                         upToVersion:(FSTLevelDBSchemaVersion)upToVersion {
-  FSTLevelDBSchemaVersion currentVersion = [self schemaVersionWithTransaction:transaction];
-  // Each case in this switch statement intentionally falls through. This lets us
-  // start at the current schema version and apply any migrations that have not yet
-  // been applied, to bring us up to current, as defined by the kSchemaVersion constant.
-  switch (currentVersion) {
-    case 0:
-      if (upToVersion < 0) break;
-      EnsureTargetGlobal(transaction);
-      ABSL_FALLTHROUGH_INTENDED;
-    case 1:
-      // We're now guaranteed that the target global exists. We can safely add a count to it.
-      if (upToVersion < 1) break;
-      AddTargetCount(transaction);
-      ABSL_FALLTHROUGH_INTENDED;
-    case 2:
-      if (upToVersion < 2) break;
-      if (currentVersion != 0) {
-        LevelDbSchema schema{transaction->database()};
-        schema.DropQueryCache();
-      }
-      ABSL_FALLTHROUGH_INTENDED;
-    default:
-      break;
-  }
-  if (currentVersion < upToVersion) {
-    SaveVersion(upToVersion, transaction);
++ (void)runMigrationsWithDatabase:(leveldb::DB *)database
+                      upToVersion:(FSTLevelDBSchemaVersion)toVersion {
+  LevelDbTransaction transaction{database, "Read schema version"};
+  FSTLevelDBSchemaVersion fromVersion = [self schemaVersionWithTransaction:&transaction];
+
+  // This must run unconditionally because schema migrations were added to iOS after the first
+  // release. There may be clients that have never run any migrations that have existing targets.
+  if (fromVersion < 3 && toVersion >= 3) {
+    ClearQueryCache(database);
   }
 }
 

--- a/Firestore/core/src/firebase/firestore/local/leveldb_transaction.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_transaction.cc
@@ -219,6 +219,12 @@ void LevelDbTransaction::Commit() {
               ToString(), status.ToString());
 }
 
+void LevelDbTransaction::Reuse() {
+  mutations_.clear();
+  deletions_.clear();
+  version_ = 0;
+}
+
 std::string LevelDbTransaction::ToString() {
   std::string dest("<LevelDbTransaction " + label_ + ": ");
   int64_t changes = deletions_.size() + mutations_.size();

--- a/Firestore/core/src/firebase/firestore/local/leveldb_transaction.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_transaction.cc
@@ -219,12 +219,6 @@ void LevelDbTransaction::Commit() {
               ToString(), status.ToString());
 }
 
-void LevelDbTransaction::Reuse() {
-  mutations_.clear();
-  deletions_.clear();
-  version_ = 0;
-}
-
 std::string LevelDbTransaction::ToString() {
   std::string dest("<LevelDbTransaction " + label_ + ": ");
   int64_t changes = deletions_.size() + mutations_.size();

--- a/Firestore/core/src/firebase/firestore/local/leveldb_transaction.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_transaction.h
@@ -144,10 +144,6 @@ class LevelDbTransaction {
    */
   static const leveldb::WriteOptions& DefaultWriteOptions();
 
-  leveldb::DB* database() const {
-    return db_;
-  }
-
   size_t changed_keys() const {
     return mutations_.size() + deletions_.size();
   }

--- a/Firestore/core/src/firebase/firestore/local/leveldb_transaction.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_transaction.h
@@ -193,9 +193,15 @@ class LevelDbTransaction {
 
   /**
    * Commits the transaction. All pending changes are written. The transaction
-   * should not be used after calling this method.
+   * can be reused after calling this method by calling `Reuse()`.
    */
   void Commit();
+
+  /**
+   * After committing, resets the state of this transaction object so that it
+   * can be used again.
+   */
+  void Reuse();
 
   std::string ToString();
 

--- a/Firestore/core/src/firebase/firestore/local/leveldb_transaction.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_transaction.h
@@ -144,6 +144,14 @@ class LevelDbTransaction {
    */
   static const leveldb::WriteOptions& DefaultWriteOptions();
 
+  leveldb::DB* database() const {
+    return db_;
+  }
+
+  size_t changed_keys() {
+    return mutations_.size() + deletions_.size();
+  }
+
   /**
    * Remove the database entry (if any) for "key".  It is not an error if "key"
    * did not exist in the database.

--- a/Firestore/core/src/firebase/firestore/local/leveldb_transaction.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_transaction.h
@@ -193,15 +193,9 @@ class LevelDbTransaction {
 
   /**
    * Commits the transaction. All pending changes are written. The transaction
-   * can be reused after calling this method by calling `Reuse()`.
+   * should not be used after calling this method.
    */
   void Commit();
-
-  /**
-   * After committing, resets the state of this transaction object so that it
-   * can be used again.
-   */
-  void Reuse();
 
   std::string ToString();
 

--- a/Firestore/core/src/firebase/firestore/local/leveldb_transaction.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_transaction.h
@@ -148,7 +148,7 @@ class LevelDbTransaction {
     return db_;
   }
 
-  size_t changed_keys() {
+  size_t changed_keys() const {
     return mutations_.size() + deletions_.size();
   }
 


### PR DESCRIPTION
This is a force fix for potential existence filter mismatches caused by
firebase/firebase-ios-sdk#1548

The essential problem is that when resuming a query, the server is
allowed to forget deletes. If the number of incorrectly synthesized
deletes matches the number of server-forgotten deletes then the
existence filter can give a false positive, preventing the cache from
self healing.

Dropping the query cache clears any client-side resume token which
prevents a false positive existence filter mismatch.

Note that the remote document cache and mutation queues are unaffected
so any cached documents that do exist will still work while offline

Port of https://github.com/firebase/firebase-js-sdk/pull/1019