### PR TITLE
Fix preserving query cache metadata

### DIFF
--- a/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
@@ -82,7 +82,6 @@ NS_ASSUME_NONNULL_BEGIN
   _documentCache = [_persistence remoteDocumentCache];
   _mutationQueue = [_persistence mutationQueueForUser:_user];
   _initialSequenceNumber = _persistence.run("start querycache", [&]() -> FSTListenSequenceNumber {
-    [_queryCache start];
     [_mutationQueue start];
     _gc = ((id<FSTLRUDelegate>)_persistence.referenceDelegate).gc;
     return _persistence.currentSequenceNumber;

--- a/Firestore/Example/Tests/Local/FSTLevelDBLRUGarbageCollectorTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBLRUGarbageCollectorTests.mm
@@ -14,9 +14,21 @@
  * limitations under the License.
  */
 
-#import <Firestore/Source/Local/FSTLevelDB.h>
 #import "Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.h"
+
+#import "Firestore/Source/Core/FSTQuery.h"
+#import "Firestore/Source/Local/FSTLevelDB.h"
+#import "Firestore/Source/Local/FSTLevelDBQueryCache.h"
+#import "Firestore/Source/Local/FSTLocalSerializer.h"
+#import "Firestore/Source/Local/FSTQueryData.h"
+#import "Firestore/Source/Remote/FSTSerializerBeta.h"
 #import "Firestore/Example/Tests/Local/FSTPersistenceTestHelpers.h"
+
+#include "Firestore/core/src/firebase/firestore/model/database_id.h"
+#include "Firestore/core/src/firebase/firestore/model/resource_path.h"
+
+using firebase::firestore::model::DatabaseId;
+using firebase::firestore::model::ResourcePath;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -25,8 +37,51 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FSTLevelDBLRUGarbageCollectorTests
 
-- (id<FSTPersistence>)newPersistence {
+- (FSTLevelDB *)newPersistence {
   return [FSTPersistenceTestHelpers levelDBPersistence];
+}
+
+- (void)testHighestSequenceNumberPersisted {
+  DatabaseId database_id{"p", "d"};
+
+  FSTSerializerBeta *remoteSerializer = [[FSTSerializerBeta alloc] initWithDatabaseID:&database_id];
+  FSTLocalSerializer *serializer =
+          [[FSTLocalSerializer alloc] initWithRemoteSerializer:remoteSerializer];
+  NSString *dir = [FSTPersistenceTestHelpers levelDBDir];
+
+  FSTLevelDB *db1 = [[FSTLevelDB alloc] initWithDirectory:dir serializer:serializer];
+  NSError *error;
+  [db1 start:&error];
+  XCTAssertNil(error);
+  FSTLevelDBQueryCache *queryCache = db1.run("setup first db", [&]() -> FSTLevelDBQueryCache * {
+    FSTLevelDBQueryCache *queryCache = [db1 queryCache];
+    [queryCache start];
+    return queryCache;
+  });
+
+  XCTAssertEqual(0, queryCache.highestListenSequenceNumber);
+
+  FSTListenSequenceNumber expected = 1234;
+  db1.run("add query data", [&]() {
+    FSTQuery *query = [FSTQuery queryWithPath:ResourcePath{"some", "path"}];
+    FSTQueryData *queryData = [[FSTQueryData alloc] initWithQuery:query
+                                                         targetID:1
+                                             listenSequenceNumber:expected
+                                                          purpose:FSTQueryPurposeListen];
+    [queryCache addQueryData:queryData];
+  });
+
+  [db1 shutdown];
+  db1 = nil;
+
+  FSTLevelDB *db2 = [[FSTLevelDB alloc] initWithDirectory:dir serializer:serializer];
+  [db2 start:&error];
+  XCTAssertNil(error);
+  db2.run("verify sequence number", [&]() {
+    // We should remember the previous sequence number, and the next transaction should
+    // have a higher one.
+    XCTAssertGreaterThan(db2.currentSequenceNumber, expected);
+  });
 }
 
 @end

--- a/Firestore/Example/Tests/Local/FSTLevelDBLRUGarbageCollectorTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBLRUGarbageCollectorTests.mm
@@ -14,21 +14,9 @@
  * limitations under the License.
  */
 
+#import <Firestore/Source/Local/FSTLevelDB.h>
 #import "Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.h"
-
-#import "Firestore/Source/Core/FSTQuery.h"
-#import "Firestore/Source/Local/FSTLevelDB.h"
-#import "Firestore/Source/Local/FSTLevelDBQueryCache.h"
-#import "Firestore/Source/Local/FSTLocalSerializer.h"
-#import "Firestore/Source/Local/FSTQueryData.h"
-#import "Firestore/Source/Remote/FSTSerializerBeta.h"
 #import "Firestore/Example/Tests/Local/FSTPersistenceTestHelpers.h"
-
-#include "Firestore/core/src/firebase/firestore/model/database_id.h"
-#include "Firestore/core/src/firebase/firestore/model/resource_path.h"
-
-using firebase::firestore::model::DatabaseId;
-using firebase::firestore::model::ResourcePath;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -37,51 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FSTLevelDBLRUGarbageCollectorTests
 
-- (FSTLevelDB *)newPersistence {
+- (id<FSTPersistence>)newPersistence {
   return [FSTPersistenceTestHelpers levelDBPersistence];
-}
-
-- (void)testHighestSequenceNumberPersisted {
-  DatabaseId database_id{"p", "d"};
-
-  FSTSerializerBeta *remoteSerializer = [[FSTSerializerBeta alloc] initWithDatabaseID:&database_id];
-  FSTLocalSerializer *serializer =
-          [[FSTLocalSerializer alloc] initWithRemoteSerializer:remoteSerializer];
-  NSString *dir = [FSTPersistenceTestHelpers levelDBDir];
-
-  FSTLevelDB *db1 = [[FSTLevelDB alloc] initWithDirectory:dir serializer:serializer];
-  NSError *error;
-  [db1 start:&error];
-  XCTAssertNil(error);
-  FSTLevelDBQueryCache *queryCache = db1.run("setup first db", [&]() -> FSTLevelDBQueryCache * {
-    FSTLevelDBQueryCache *queryCache = [db1 queryCache];
-    [queryCache start];
-    return queryCache;
-  });
-
-  XCTAssertEqual(0, queryCache.highestListenSequenceNumber);
-
-  FSTListenSequenceNumber expected = 1234;
-  db1.run("add query data", [&]() {
-    FSTQuery *query = [FSTQuery queryWithPath:ResourcePath{"some", "path"}];
-    FSTQueryData *queryData = [[FSTQueryData alloc] initWithQuery:query
-                                                         targetID:1
-                                             listenSequenceNumber:expected
-                                                          purpose:FSTQueryPurposeListen];
-    [queryCache addQueryData:queryData];
-  });
-
-  [db1 shutdown];
-  db1 = nil;
-
-  FSTLevelDB *db2 = [[FSTLevelDB alloc] initWithDirectory:dir serializer:serializer];
-  [db2 start:&error];
-  XCTAssertNil(error);
-  db2.run("verify sequence number", [&]() {
-    // We should remember the previous sequence number, and the next transaction should
-    // have a higher one.
-    XCTAssertGreaterThan(db2.currentSequenceNumber, expected);
-  });
 }
 
 @end

--- a/Firestore/Example/Tests/Local/FSTLevelDBQueryCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBQueryCacheTests.mm
@@ -16,10 +16,24 @@
 
 #import "Firestore/Source/Local/FSTLevelDBQueryCache.h"
 
+#import "Firestore/Source/Core/FSTQuery.h"
 #import "Firestore/Source/Local/FSTLevelDB.h"
+#import "Firestore/Source/Local/FSTLocalSerializer.h"
+#import "Firestore/Source/Local/FSTQueryData.h"
+#import "Firestore/Source/Remote/FSTSerializerBeta.h"
 
 #import "Firestore/Example/Tests/Local/FSTPersistenceTestHelpers.h"
 #import "Firestore/Example/Tests/Local/FSTQueryCacheTests.h"
+
+#include "Firestore/core/include/firebase/firestore/timestamp.h"
+#include "Firestore/core/src/firebase/firestore/model/database_id.h"
+#include "Firestore/core/src/firebase/firestore/model/resource_path.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
+
+using firebase::Timestamp;
+using firebase::firestore::model::DatabaseId;
+using firebase::firestore::model::ResourcePath;
+using firebase::firestore::model::SnapshotVersion;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -38,13 +52,71 @@ NS_ASSUME_NONNULL_BEGIN
 
   self.persistence = [FSTPersistenceTestHelpers levelDBPersistence];
   self.queryCache = [self.persistence queryCache];
-  [self.queryCache start];
 }
 
 - (void)tearDown {
   [super tearDown];
   self.persistence = nil;
   self.queryCache = nil;
+}
+
+- (void)testMetadataPersistedAcrossRestarts {
+  [self.persistence shutdown];
+  self.persistence = nil;
+
+  DatabaseId database_id{"p", "d"};
+
+  FSTSerializerBeta *remoteSerializer = [[FSTSerializerBeta alloc] initWithDatabaseID:&database_id];
+  FSTLocalSerializer *serializer =
+          [[FSTLocalSerializer alloc] initWithRemoteSerializer:remoteSerializer];
+  NSString *dir = [FSTPersistenceTestHelpers levelDBDir];
+
+  FSTLevelDB *db1 = [[FSTLevelDB alloc] initWithDirectory:dir serializer:serializer];
+  NSError *error;
+  [db1 start:&error];
+  XCTAssertNil(error);
+  FSTLevelDBQueryCache *queryCache = db1.run("setup first db", [&]() -> FSTLevelDBQueryCache * {
+    FSTLevelDBQueryCache *queryCache = [db1 queryCache];
+    return queryCache;
+  });
+
+  XCTAssertEqual(0, queryCache.highestListenSequenceNumber);
+  XCTAssertEqual(0, queryCache.highestTargetID);
+  SnapshotVersion versionZero;
+  XCTAssertEqual(versionZero, queryCache.lastRemoteSnapshotVersion);
+
+  FSTListenSequenceNumber minimumSequenceNumber = 1234;
+  FSTTargetID lastTargetId = 5;
+  SnapshotVersion lastVersion(Timestamp(1, 2));
+
+  db1.run("add query data", [&]() {
+    FSTQuery *query = [FSTQuery queryWithPath:ResourcePath{"some", "path"}];
+    FSTQueryData *queryData = [[FSTQueryData alloc] initWithQuery:query
+                                                         targetID:lastTargetId
+                                             listenSequenceNumber:minimumSequenceNumber
+                                                          purpose:FSTQueryPurposeListen];
+    [queryCache addQueryData:queryData];
+    [queryCache setLastRemoteSnapshotVersion:lastVersion];
+  });
+
+  [db1 shutdown];
+  db1 = nil;
+
+  FSTLevelDB *db2 = [[FSTLevelDB alloc] initWithDirectory:dir serializer:serializer];
+  [db2 start:&error];
+  XCTAssertNil(error);
+  FSTLevelDBQueryCache *queryCache2 = db2.run("verify sequence number", [&]() -> FSTLevelDBQueryCache * {
+    // We should remember the previous sequence number, and the next transaction should
+    // have a higher one.
+    XCTAssertGreaterThan(db2.currentSequenceNumber, minimumSequenceNumber);
+    return [db2 queryCache];
+  });
+
+  XCTAssertEqual(lastTargetId, queryCache2.highestTargetID);
+  XCTAssertEqual(lastVersion, queryCache2.lastRemoteSnapshotVersion);
+
+  [db2 shutdown];
+  db2 = nil;
 }
 
 @end

--- a/Firestore/Example/Tests/Local/FSTLevelDBQueryCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBQueryCacheTests.mm
@@ -68,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   FSTSerializerBeta *remoteSerializer = [[FSTSerializerBeta alloc] initWithDatabaseID:&database_id];
   FSTLocalSerializer *serializer =
-          [[FSTLocalSerializer alloc] initWithRemoteSerializer:remoteSerializer];
+      [[FSTLocalSerializer alloc] initWithRemoteSerializer:remoteSerializer];
   NSString *dir = [FSTPersistenceTestHelpers levelDBDir];
 
   FSTLevelDB *db1 = [[FSTLevelDB alloc] initWithDirectory:dir serializer:serializer];
@@ -105,12 +105,13 @@ NS_ASSUME_NONNULL_BEGIN
   FSTLevelDB *db2 = [[FSTLevelDB alloc] initWithDirectory:dir serializer:serializer];
   [db2 start:&error];
   XCTAssertNil(error);
-  FSTLevelDBQueryCache *queryCache2 = db2.run("verify sequence number", [&]() -> FSTLevelDBQueryCache * {
-    // We should remember the previous sequence number, and the next transaction should
-    // have a higher one.
-    XCTAssertGreaterThan(db2.currentSequenceNumber, minimumSequenceNumber);
-    return [db2 queryCache];
-  });
+  FSTLevelDBQueryCache *queryCache2 =
+      db2.run("verify sequence number", [&]() -> FSTLevelDBQueryCache * {
+        // We should remember the previous sequence number, and the next transaction should
+        // have a higher one.
+        XCTAssertGreaterThan(db2.currentSequenceNumber, minimumSequenceNumber);
+        return [db2 queryCache];
+      });
 
   XCTAssertEqual(lastTargetId, queryCache2.highestTargetID);
   XCTAssertEqual(lastVersion, queryCache2.lastRemoteSnapshotVersion);

--- a/Firestore/Example/Tests/Local/FSTLevelDBQueryCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBQueryCacheTests.mm
@@ -64,14 +64,9 @@ NS_ASSUME_NONNULL_BEGIN
   [self.persistence shutdown];
   self.persistence = nil;
 
-  DatabaseId database_id{"p", "d"};
-
-  FSTSerializerBeta *remoteSerializer = [[FSTSerializerBeta alloc] initWithDatabaseID:&database_id];
-  FSTLocalSerializer *serializer =
-      [[FSTLocalSerializer alloc] initWithRemoteSerializer:remoteSerializer];
   NSString *dir = [FSTPersistenceTestHelpers levelDBDir];
 
-  FSTLevelDB *db1 = [[FSTLevelDB alloc] initWithDirectory:dir serializer:serializer];
+  FSTLevelDB *db1 = [FSTPersistenceTestHelpers levelDBPersistenceWithDir:dir];
   NSError *error;
   [db1 start:&error];
   XCTAssertNil(error);
@@ -102,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
   [db1 shutdown];
   db1 = nil;
 
-  FSTLevelDB *db2 = [[FSTLevelDB alloc] initWithDirectory:dir serializer:serializer];
+  FSTLevelDB *db2 = [FSTPersistenceTestHelpers levelDBPersistenceWithDir:dir];
   [db2 start:&error];
   XCTAssertNil(error);
   FSTLevelDBQueryCache *queryCache2 =

--- a/Firestore/Example/Tests/Local/FSTLevelDBQueryCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBQueryCacheTests.mm
@@ -67,13 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
   NSString *dir = [FSTPersistenceTestHelpers levelDBDir];
 
   FSTLevelDB *db1 = [FSTPersistenceTestHelpers levelDBPersistenceWithDir:dir];
-  NSError *error;
-  [db1 start:&error];
-  XCTAssertNil(error);
-  FSTLevelDBQueryCache *queryCache = db1.run("setup first db", [&]() -> FSTLevelDBQueryCache * {
-    FSTLevelDBQueryCache *queryCache = [db1 queryCache];
-    return queryCache;
-  });
+  FSTLevelDBQueryCache *queryCache = [db1 queryCache];
 
   XCTAssertEqual(0, queryCache.highestListenSequenceNumber);
   XCTAssertEqual(0, queryCache.highestTargetID);
@@ -98,16 +92,13 @@ NS_ASSUME_NONNULL_BEGIN
   db1 = nil;
 
   FSTLevelDB *db2 = [FSTPersistenceTestHelpers levelDBPersistenceWithDir:dir];
-  [db2 start:&error];
-  XCTAssertNil(error);
-  FSTLevelDBQueryCache *queryCache2 =
-      db2.run("verify sequence number", [&]() -> FSTLevelDBQueryCache * {
-        // We should remember the previous sequence number, and the next transaction should
-        // have a higher one.
-        XCTAssertGreaterThan(db2.currentSequenceNumber, minimumSequenceNumber);
-        return [db2 queryCache];
-      });
+  db2.run("verify sequence number", [&]() {
+    // We should remember the previous sequence number, and the next transaction should
+    // have a higher one.
+    XCTAssertGreaterThan(db2.currentSequenceNumber, minimumSequenceNumber);
+  });
 
+  FSTLevelDBQueryCache *queryCache2 = [db2 queryCache];
   XCTAssertEqual(lastTargetId, queryCache2.highestTargetID);
   XCTAssertEqual(lastVersion, queryCache2.lastRemoteSnapshotVersion);
 

--- a/Firestore/Example/Tests/Local/FSTMemoryQueryCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTMemoryQueryCacheTests.mm
@@ -38,7 +38,6 @@ NS_ASSUME_NONNULL_BEGIN
 
   self.persistence = [FSTPersistenceTestHelpers eagerGCMemoryPersistence];
   self.queryCache = [self.persistence queryCache];
-  [self.queryCache start];
 }
 
 - (void)tearDown {

--- a/Firestore/Example/Tests/Local/FSTPersistenceTestHelpers.h
+++ b/Firestore/Example/Tests/Local/FSTPersistenceTestHelpers.h
@@ -39,6 +39,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (FSTLevelDB *)levelDBPersistence;
 
+/**
+ * Creates and starts a new FSTLevelDB instance for testing. Does not delete any data
+ * present in the given directory. As a consequence, the resulting databse is not guaranteed
+ * to be empty.
+ */
++ (FSTLevelDB *)levelDBPersistenceWithDir:(NSString *)dir;
+
 /** Creates and starts a new FSTMemoryPersistence instance for testing. */
 + (FSTMemoryPersistence *)eagerGCMemoryPersistence;
 

--- a/Firestore/Example/Tests/Local/FSTPersistenceTestHelpers.mm
+++ b/Firestore/Example/Tests/Local/FSTPersistenceTestHelpers.mm
@@ -46,11 +46,10 @@ NS_ASSUME_NONNULL_BEGIN
   return dir;
 }
 
-+ (FSTLevelDB *)levelDBPersistence {
++ (FSTLevelDB *)levelDBPersistenceWithDir:(NSString *)dir {
   // This owns the DatabaseIds since we do not have FirestoreClient instance to own them.
   static DatabaseId database_id{"p", "d"};
 
-  NSString *dir = [self levelDBDir];
   FSTSerializerBeta *remoteSerializer = [[FSTSerializerBeta alloc] initWithDatabaseID:&database_id];
   FSTLocalSerializer *serializer =
       [[FSTLocalSerializer alloc] initWithRemoteSerializer:remoteSerializer];
@@ -63,6 +62,10 @@ NS_ASSUME_NONNULL_BEGIN
   }
 
   return db;
+}
+
++ (FSTLevelDB *)levelDBPersistence {
+  return [self levelDBPersistenceWithDir:[self levelDBDir]];
 }
 
 + (FSTMemoryPersistence *)eagerGCMemoryPersistence {

--- a/Firestore/Example/Tests/Local/FSTQueryCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTQueryCacheTests.mm
@@ -291,13 +291,6 @@ NS_ASSUME_NONNULL_BEGIN
     [self.queryCache removeQueryData:query3];
     XCTAssertEqual([self.queryCache highestListenSequenceNumber], 100);
   });
-
-  // Verify that the highestTargetID even survives restarts.
-  self.persistence.run("testHighestListenSequenceNumber restart", [&]() {
-    self.queryCache = [self.persistence queryCache];
-    [self.queryCache start];
-    XCTAssertEqual([self.queryCache highestListenSequenceNumber], 100);
-  });
 }
 
 - (void)testHighestTargetID {
@@ -343,13 +336,6 @@ NS_ASSUME_NONNULL_BEGIN
     [self.queryCache removeQueryData:query3];
     XCTAssertEqual([self.queryCache highestTargetID], 42);
   });
-
-  // Verify that the highestTargetID even survives restarts.
-  self.persistence.run("testHighestTargetID restart", [&]() {
-    self.queryCache = [self.persistence queryCache];
-    [self.queryCache start];
-    XCTAssertEqual([self.queryCache highestTargetID], 42);
-  });
 }
 
 - (void)testLastRemoteSnapshotVersion {
@@ -360,13 +346,6 @@ NS_ASSUME_NONNULL_BEGIN
 
     // Can set the snapshot version.
     [self.queryCache setLastRemoteSnapshotVersion:testutil::Version(42)];
-    XCTAssertEqual([self.queryCache lastRemoteSnapshotVersion], testutil::Version(42));
-  });
-
-  // Snapshot version persists restarts.
-  self.queryCache = [self.persistence queryCache];
-  self.persistence.run("testLastRemoteSnapshotVersion restart", [&]() {
-    [self.queryCache start];
     XCTAssertEqual([self.queryCache lastRemoteSnapshotVersion], testutil::Version(42));
   });
 }

--- a/Firestore/Source/Local/FSTLevelDBQueryCache.h
+++ b/Firestore/Source/Local/FSTLevelDBQueryCache.h
@@ -53,6 +53,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDB:(FSTLevelDB *)db
                 serializer:(FSTLocalSerializer *)serializer NS_DESIGNATED_INITIALIZER;
 
+/** Starts the query cache up. */
+- (void)start;
+
 - (void)enumerateOrphanedDocumentsUsingBlock:
     (void (^)(const firebase::firestore::model::DocumentKey &docKey,
               FSTListenSequenceNumber sequenceNumber,

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -115,7 +115,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)start {
   [self startMutationQueue];
-  [self startQueryCache];
+  FSTTargetID targetID = [self.queryCache highestTargetID];
+  _targetIDGenerator = TargetIdGenerator::LocalStoreTargetIdGenerator(targetID);
 }
 
 - (void)startMutationQueue {
@@ -140,13 +141,6 @@ NS_ASSUME_NONNULL_BEGIN
       }
     }
   });
-}
-
-- (void)startQueryCache {
-  [self.queryCache start];
-
-  FSTTargetID targetID = [self.queryCache highestTargetID];
-  _targetIDGenerator = TargetIdGenerator::LocalStoreTargetIdGenerator(targetID);
 }
 
 - (FSTMaybeDocumentDictionary *)userDidChange:(const User &)user {

--- a/Firestore/Source/Local/FSTMemoryQueryCache.mm
+++ b/Firestore/Source/Local/FSTMemoryQueryCache.mm
@@ -66,10 +66,6 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - FSTQueryCache implementation
 #pragma mark Query tracking
 
-- (void)start {
-  // Nothing to do.
-}
-
 - (FSTTargetID)highestTargetID {
   return _highestTargetID;
 }

--- a/Firestore/Source/Local/FSTQueryCache.h
+++ b/Firestore/Source/Local/FSTQueryCache.h
@@ -37,9 +37,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @protocol FSTQueryCache <NSObject>
 
-/** Starts the query cache up. */
-- (void)start;
-
 /**
  * Returns the highest target ID of any query in the cache. Typically called during startup to
  * seed a target ID generator and avoid collisions with existing queries. If there are no queries


### PR DESCRIPTION
In my LRU change, I broke `FSTQueryCache` initialization while simultaneously altering the code so the tests for this feature still passed. This happened because `FSTLevelDB` started returning the same instance of `FSTLevelDBQueryCache` each time `queryCache` was called, rather than creating a new one. I noticed the error in attempting to port the code. 

So, I have rewritten the tests for restarting the persistence layer, made them specific to `FSTLevelDBQueryCache`, as well as fixed the bug.

Base branch is `lru`.