### PR TITLE
 Partial [en|de]coding of QueryData via the local serializer

### DIFF
--- a/Firestore/core/src/firebase/firestore/core/query.h
+++ b/Firestore/core/src/firebase/firestore/core/query.h
@@ -69,6 +69,11 @@ class Query {
   /** Returns true if the document matches the constraints of this query. */
   bool Matches(const model::Document& doc) const;
 
+  /** Returns true if this Query is for a specific document. */
+  bool IsDocumentQuery() const {
+    return model::DocumentKey::IsDocumentKey(path_) && filters_.empty();
+  }
+
   /**
    * Returns a copy of this Query object with the additional specified filter.
    */

--- a/Firestore/core/src/firebase/firestore/core/query.h
+++ b/Firestore/core/src/firebase/firestore/core/query.h
@@ -57,6 +57,11 @@ class Query {
     return path_;
   }
 
+  /** The filters on the documents returned by the query. */
+  const std::vector<std::shared_ptr<core::Filter>>& filters() const {
+    return filters_;
+  }
+
   /** Returns true if the document matches the constraints of this query. */
   bool Matches(const model::Document& doc) const;
 
@@ -66,8 +71,6 @@ class Query {
   Query Filter(std::shared_ptr<core::Filter> filter) const;
 
  private:
-  friend bool operator==(const Query& lhs, const Query& rhs);
-
   bool MatchesPath(const model::Document& doc) const;
   bool MatchesFilters(const model::Document& doc) const;
   bool MatchesOrderBy(const model::Document& doc) const;
@@ -87,7 +90,7 @@ inline bool operator==(const Query& lhs, const Query& rhs) {
   // TODO(rsgowman): check orderby (once it exists)
   // TODO(rsgowman): check startat (once it exists)
   // TODO(rsgowman): check endat (once it exists)
-  return lhs.path() == rhs.path() && lhs.filters_ == rhs.filters_;
+  return lhs.path() == rhs.path() && lhs.filters() == rhs.filters();
 }
 
 inline bool operator!=(const Query& lhs, const Query& rhs) {

--- a/Firestore/core/src/firebase/firestore/core/query.h
+++ b/Firestore/core/src/firebase/firestore/core/query.h
@@ -45,6 +45,10 @@ class Query {
     return Query(std::move(path), {});
   }
 
+  static Query Invalid() {
+    return Query::AtPath(model::ResourcePath::Empty());
+  }
+
   /** Initializes a query with all of its components directly. */
   Query(model::ResourcePath path,
         std::vector<std::shared_ptr<core::Filter>>
@@ -76,13 +80,13 @@ class Query {
   bool MatchesOrderBy(const model::Document& doc) const;
   bool MatchesBounds(const model::Document& doc) const;
 
-  const model::ResourcePath path_;
+  model::ResourcePath path_;
 
   // Filters are shared across related Query instance. i.e. when you call
   // Query::Filter(f), a new Query instance is created that contains all of the
   // existing filters, plus the new one. (Both Query and Filter objects are
   // immutable.) Filters are not shared across unrelated Query instances.
-  const std::vector<std::shared_ptr<core::Filter>> filters_;
+  std::vector<std::shared_ptr<core::Filter>> filters_;
 };
 
 inline bool operator==(const Query& lhs, const Query& rhs) {

--- a/Firestore/core/src/firebase/firestore/local/local_serializer.cc
+++ b/Firestore/core/src/firebase/firestore/local/local_serializer.cc
@@ -271,7 +271,7 @@ util::StatusOr<QueryData> LocalSerializer::DecodeQueryData(
 QueryData LocalSerializer::DecodeQueryData(Reader* reader) const {
   if (!reader->status().ok()) return QueryData::Invalid();
 
-  int64_t target_id;
+  int64_t target_id = 0;
   SnapshotVersion version = SnapshotVersion::None();
   std::vector<uint8_t> resume_token;
   Query query = Query::Invalid();

--- a/Firestore/core/src/firebase/firestore/local/local_serializer.cc
+++ b/Firestore/core/src/firebase/firestore/local/local_serializer.cc
@@ -21,7 +21,9 @@
 #include <utility>
 
 #include "Firestore/Protos/nanopb/firestore/local/maybe_document.nanopb.h"
+#include "Firestore/Protos/nanopb/firestore/local/target.nanopb.h"
 #include "Firestore/Protos/nanopb/google/firestore/v1beta1/document.nanopb.h"
+#include "Firestore/core/src/firebase/firestore/core/query.h"
 #include "Firestore/core/src/firebase/firestore/model/field_value.h"
 #include "Firestore/core/src/firebase/firestore/model/no_document.h"
 #include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
@@ -32,12 +34,13 @@ namespace firebase {
 namespace firestore {
 namespace local {
 
-using firebase::firestore::model::ObjectValue;
-using firebase::firestore::model::SnapshotVersion;
-using firebase::firestore::nanopb::Reader;
-using firebase::firestore::nanopb::Tag;
-using firebase::firestore::nanopb::Writer;
-using firebase::firestore::util::Status;
+using core::Query;
+using model::ObjectValue;
+using model::SnapshotVersion;
+using nanopb::Reader;
+using nanopb::Tag;
+using nanopb::Writer;
+using util::Status;
 
 Status LocalSerializer::EncodeMaybeDocument(
     const model::MaybeDocument& document,
@@ -206,6 +209,110 @@ std::unique_ptr<model::NoDocument> LocalSerializer::DecodeNoDocument(
 
   return absl::make_unique<model::NoDocument>(rpc_serializer_.DecodeKey(name),
                                               version);
+}
+
+util::Status LocalSerializer::EncodeQueryData(const QueryData& query_data, std::vector<uint8_t>* out_bytes) const {
+  HARD_ASSERT(QueryPurpose::kListen == query_data.purpose(), "Only queries with purpose %s may be stored, got %s", QueryPurpose::kListen, query_data.purpose());
+  Writer writer = Writer::Wrap(out_bytes);
+  EncodeQueryData(&writer, query_data);
+  return writer.status();
+}
+
+void LocalSerializer::EncodeQueryData(Writer* writer, const QueryData& query_data) const {
+  if (!writer->status().ok()) return;
+
+  writer->WriteTag({PB_WT_VARINT, firestore_client_Target_target_id_tag});
+  writer->WriteInteger(query_data.target_id());
+
+  writer->WriteTag({PB_WT_STRING, firestore_client_Target_snapshot_version_tag});
+  writer->WriteNestedMessage([&](Writer* writer) {
+    rpc_serializer_.EncodeTimestamp(writer, query_data.snapshot_version().timestamp());
+  });
+
+  writer->WriteTag({PB_WT_STRING, firestore_client_Target_resume_token_tag});
+  writer->WriteBytes(query_data.resume_token());
+
+  const Query& query = query_data.query();
+  if (query.IsDocumentQuery()) {
+    // TODO(rsgowman): Implement. Probably like this (once EncodeDocumentsTarget
+    // exists):
+    /*
+    writer->WriteTag({PB_WT_STRING, firestore_client_Target_documents_tag});
+    writer->WriteNestedMessage([&](Writer* writer) {
+      rpc_serializer_.EncodeDocumentsTarget(writer, query);
+    });
+    */
+    abort();
+  } else {
+    writer->WriteTag({PB_WT_STRING, firestore_client_Target_query_tag});
+    writer->WriteNestedMessage([&](Writer* writer) {
+      rpc_serializer_.EncodeQueryTarget(writer, query);
+    });
+  }
+}
+
+util::StatusOr<QueryData> LocalSerializer::DecodeQueryData(
+    const uint8_t* bytes, size_t length) const {
+  Reader reader = Reader::Wrap(bytes, length);
+  QueryData query_data = DecodeQueryData(&reader);
+  if (reader.status().ok()) {
+    return query_data;
+  } else {
+    return reader.status();
+  }
+}
+
+QueryData LocalSerializer::DecodeQueryData(Reader* reader) const {
+  if (!reader->status().ok()) return QueryData::Invalid();
+
+  int64_t target_id;
+  SnapshotVersion version = SnapshotVersion::None();
+  std::vector<uint8_t> resume_token;
+  Query query = Query::Invalid();
+
+  while (reader->bytes_left()) {
+    Tag tag = reader->ReadTag();
+    if (!reader->status().ok()) return QueryData::Invalid();
+
+    switch (tag.field_number) {
+      case firestore_client_Target_target_id_tag:
+        if (!reader->RequireWireType(PB_WT_VARINT, tag)) return QueryData::Invalid();
+        target_id = reader->ReadInteger();
+        break;
+
+      case firestore_client_Target_snapshot_version_tag:
+        if (!reader->RequireWireType(PB_WT_STRING, tag)) return QueryData::Invalid();
+        version = SnapshotVersion{reader->ReadNestedMessage<Timestamp>(
+            rpc_serializer_.DecodeTimestamp)};
+        break;
+
+      case firestore_client_Target_resume_token_tag:
+        if (!reader->RequireWireType(PB_WT_STRING, tag)) return QueryData::Invalid();
+        resume_token = reader->ReadBytes();
+        break;
+
+      case firestore_client_Target_query_tag:
+        if (!reader->RequireWireType(PB_WT_STRING, tag)) return QueryData::Invalid();
+        // TODO(rsgowman): Clear 'documents' field (since query and documents
+        // are part of a 'oneof').
+        query = reader->ReadNestedMessage<Query>(rpc_serializer_.DecodeQueryTarget);
+        break;
+
+      case firestore_client_Target_documents_tag:
+        if (!reader->RequireWireType(PB_WT_STRING, tag)) return QueryData::Invalid();
+        // Clear 'query' field (since query and documents are part of a 'oneof')
+        query = Query::Invalid();
+        // TODO(rsgowman): Implement.
+        abort();
+
+      default:
+        // Unknown tag. According to the proto spec, we need to ignore these.
+        reader->SkipField(tag);
+        break;
+    }
+  }
+
+  return QueryData(std::move(query), target_id, QueryPurpose::kListen, std::move(version), std::move(resume_token));
 }
 
 }  // namespace local

--- a/Firestore/core/src/firebase/firestore/local/local_serializer.h
+++ b/Firestore/core/src/firebase/firestore/local/local_serializer.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <vector>
 
+#include "Firestore/core/src/firebase/firestore/local/query_data.h"
 #include "Firestore/core/src/firebase/firestore/model/document.h"
 #include "Firestore/core/src/firebase/firestore/model/maybe_document.h"
 #include "Firestore/core/src/firebase/firestore/model/no_document.h"
@@ -88,6 +89,45 @@ class LocalSerializer {
     return DecodeMaybeDocument(bytes.data(), bytes.size());
   }
 
+  /**
+   * @brief Encodes a QueryData to the equivalent bytes, representing a
+   * ::firestore::proto::Target, for local storage.
+   *
+   * @param[out] out_bytes A buffer to place the output. The bytes will be
+   * appended to this vector.
+   * @return A Status, which if not ok(), indicates what went wrong. Note that
+   * errors during encoding generally indicate a serious/fatal error.
+   */
+  // TODO(rsgowman): If we never support any output except to a vector, it may
+  // make sense to have LocalSerializer own the vector and provide an accessor
+  // rather than asking the user to create it first.
+  util::Status EncodeQueryData(const QueryData& query_data,
+                               std::vector<uint8_t>* out_bytes) const;
+
+  /**
+   * @brief Decodes bytes representing a ::firestore::proto::Target proto to the
+   * equivalent QueryData.
+   *
+   * @param bytes The bytes to convert. It's assumed that exactly all of the
+   * bytes will be used by this conversion.
+   * @return The QueryData equivalent of the bytes or a Status indicating what
+   * went wrong.
+   */
+  util::StatusOr<QueryData> DecodeQueryData(const uint8_t* bytes, size_t length) const;
+
+  /**
+   * @brief Decodes bytes representing a ::firestore::proto::Target proto to the
+   * equivalent QueryData.
+   *
+   * @param bytes The bytes to convert. It's assumed that exactly all of the
+   * bytes will be used by this conversion.
+   * @return The QueryData equivalent of the bytes or a Status indicating what
+   * went wrong.
+   */
+  util::StatusOr<QueryData> DecodeQueryData(const std::vector<uint8_t>& bytes) const {
+    return DecodeQueryData(bytes.data(), bytes.size());
+  }
+
  private:
   void EncodeMaybeDocument(nanopb::Writer* writer,
                            const model::MaybeDocument& maybe_doc) const;
@@ -106,6 +146,9 @@ class LocalSerializer {
 
   std::unique_ptr<model::NoDocument> DecodeNoDocument(
       nanopb::Reader* reader) const;
+
+  void EncodeQueryData(nanopb::Writer* writer, const QueryData& query_data) const;
+  QueryData DecodeQueryData(nanopb::Reader* reader) const;
 
   const remote::Serializer& rpc_serializer_;
 };

--- a/Firestore/core/src/firebase/firestore/local/local_serializer.h
+++ b/Firestore/core/src/firebase/firestore/local/local_serializer.h
@@ -113,7 +113,8 @@ class LocalSerializer {
    * @return The QueryData equivalent of the bytes or a Status indicating what
    * went wrong.
    */
-  util::StatusOr<QueryData> DecodeQueryData(const uint8_t* bytes, size_t length) const;
+  util::StatusOr<QueryData> DecodeQueryData(const uint8_t* bytes,
+                                            size_t length) const;
 
   /**
    * @brief Decodes bytes representing a ::firestore::proto::Target proto to the
@@ -124,7 +125,8 @@ class LocalSerializer {
    * @return The QueryData equivalent of the bytes or a Status indicating what
    * went wrong.
    */
-  util::StatusOr<QueryData> DecodeQueryData(const std::vector<uint8_t>& bytes) const {
+  util::StatusOr<QueryData> DecodeQueryData(
+      const std::vector<uint8_t>& bytes) const {
     return DecodeQueryData(bytes.data(), bytes.size());
   }
 
@@ -147,7 +149,8 @@ class LocalSerializer {
   std::unique_ptr<model::NoDocument> DecodeNoDocument(
       nanopb::Reader* reader) const;
 
-  void EncodeQueryData(nanopb::Writer* writer, const QueryData& query_data) const;
+  void EncodeQueryData(nanopb::Writer* writer,
+                       const QueryData& query_data) const;
   QueryData DecodeQueryData(nanopb::Reader* reader) const;
 
   const remote::Serializer& rpc_serializer_;

--- a/Firestore/core/src/firebase/firestore/local/query_data.cc
+++ b/Firestore/core/src/firebase/firestore/local/query_data.cc
@@ -48,16 +48,9 @@ QueryData::QueryData(const Query& query, int target_id, QueryPurpose purpose)
 }
 */
 
-QueryData::QueryData()
-    : query_(Query::Invalid()),
-      target_id_(-1),
-      purpose_(QueryPurpose::kListen),
-      snapshot_version_(SnapshotVersion::None()),
-      resume_token_({}) {
-}
-
 QueryData QueryData::Invalid() {
-  return QueryData();
+  return QueryData(Query::Invalid(), /*target_id=*/-1, QueryPurpose::kListen,
+                   SnapshotVersion(SnapshotVersion::None()), {});
 }
 
 QueryData QueryData::Copy(SnapshotVersion&& snapshot_version,

--- a/Firestore/core/src/firebase/firestore/local/query_data.cc
+++ b/Firestore/core/src/firebase/firestore/local/query_data.cc
@@ -23,16 +23,16 @@ namespace local {
 using core::Query;
 using model::SnapshotVersion;
 
-QueryData::QueryData(const Query& query,
+QueryData::QueryData(Query&& query,
                      int target_id,
                      QueryPurpose purpose,
-                     const SnapshotVersion& snapshot_version,
-                     const std::vector<uint8_t>& resume_token)
-    : query_(&query),
+                     SnapshotVersion&& snapshot_version,
+                     std::vector<uint8_t>&& resume_token)
+    : query_(std::move(query)),
       target_id_(target_id),
       purpose_(purpose),
-      snapshot_version_(&snapshot_version),
-      resume_token_(&resume_token) {
+      snapshot_version_(std::move(snapshot_version)),
+      resume_token_(std::move(resume_token)) {
 }
 
 // TODO(rsgowman): Implement once WatchStream::EmptyResumeToken exists.
@@ -46,10 +46,9 @@ QueryData::QueryData(const Query& query, int target_id, QueryPurpose purpose)
 }
 */
 
-QueryData QueryData::Copy(const SnapshotVersion& snapshot_version,
-                          const std::vector<uint8_t>& resume_token) const {
-  return QueryData(*query_, target_id_, purpose_, snapshot_version,
-                   resume_token);
+QueryData QueryData::Copy(SnapshotVersion&& snapshot_version,
+                          std::vector<uint8_t>&& resume_token) const {
+  return QueryData(Query(query_), target_id_, purpose_, std::move(snapshot_version), std::move(resume_token));
 }
 
 }  // namespace local

--- a/Firestore/core/src/firebase/firestore/local/query_data.cc
+++ b/Firestore/core/src/firebase/firestore/local/query_data.cc
@@ -46,6 +46,13 @@ QueryData::QueryData(const Query& query, int target_id, QueryPurpose purpose)
 }
 */
 
+QueryData::QueryData() : query_(Query::Invalid()), target_id_(-1), purpose_(QueryPurpose::kListen), snapshot_version_(SnapshotVersion::None()), resume_token_({}) {
+}
+
+QueryData QueryData::Invalid() {
+  return QueryData();
+}
+
 QueryData QueryData::Copy(SnapshotVersion&& snapshot_version,
                           std::vector<uint8_t>&& resume_token) const {
   return QueryData(Query(query_), target_id_, purpose_, std::move(snapshot_version), std::move(resume_token));

--- a/Firestore/core/src/firebase/firestore/local/query_data.cc
+++ b/Firestore/core/src/firebase/firestore/local/query_data.cc
@@ -16,6 +16,8 @@
 
 #include "Firestore/core/src/firebase/firestore/local/query_data.h"
 
+#include <utility>
+
 namespace firebase {
 namespace firestore {
 namespace local {
@@ -46,7 +48,12 @@ QueryData::QueryData(const Query& query, int target_id, QueryPurpose purpose)
 }
 */
 
-QueryData::QueryData() : query_(Query::Invalid()), target_id_(-1), purpose_(QueryPurpose::kListen), snapshot_version_(SnapshotVersion::None()), resume_token_({}) {
+QueryData::QueryData()
+    : query_(Query::Invalid()),
+      target_id_(-1),
+      purpose_(QueryPurpose::kListen),
+      snapshot_version_(SnapshotVersion::None()),
+      resume_token_({}) {
 }
 
 QueryData QueryData::Invalid() {
@@ -55,7 +62,8 @@ QueryData QueryData::Invalid() {
 
 QueryData QueryData::Copy(SnapshotVersion&& snapshot_version,
                           std::vector<uint8_t>&& resume_token) const {
-  return QueryData(Query(query_), target_id_, purpose_, std::move(snapshot_version), std::move(resume_token));
+  return QueryData(Query(query_), target_id_, purpose_,
+                   std::move(snapshot_version), std::move(resume_token));
 }
 
 }  // namespace local

--- a/Firestore/core/src/firebase/firestore/local/query_data.h
+++ b/Firestore/core/src/firebase/firestore/local/query_data.h
@@ -73,6 +73,21 @@ class QueryData {
   // TODO(rsgowman): Define once WatchStream::EmptyResumeToken exists.
   // QueryData(const core::Query& query, int target_id, QueryPurpose purpose);
 
+  /**
+   * Constructs an invalid QueryData. Reading any properties of the returned
+   * value is undefined; you must reassign to this instance before it will
+   * become useful.
+   *
+   * This exists to allow QueryData to work with stl containers.
+   */
+  QueryData();
+
+  /**
+   * Constructs an invalid QueryData. Reading any properties of the returned
+   * value is undefined.
+   */
+  static QueryData Invalid();
+
   const core::Query& query() const {
     return query_;
   }

--- a/Firestore/core/src/firebase/firestore/local/query_data.h
+++ b/Firestore/core/src/firebase/firestore/local/query_data.h
@@ -60,11 +60,11 @@ class QueryData {
    *     data that matches the query. The resume token essentially identifies a
    *     point in time from which the server should resume sending results.
    */
-  QueryData(const core::Query& query,
+  QueryData(core::Query&& query,
             int target_id,
             QueryPurpose purpose,
-            const model::SnapshotVersion& snapshot_version,
-            const std::vector<uint8_t>& resume_token);
+            model::SnapshotVersion&& snapshot_version,
+            std::vector<uint8_t>&& resume_token);
 
   /**
    * Convenience constructor for use when creating a QueryData for the first
@@ -74,7 +74,7 @@ class QueryData {
   // QueryData(const core::Query& query, int target_id, QueryPurpose purpose);
 
   const core::Query& query() const {
-    return *query_;
+    return query_;
   }
 
   int target_id() const {
@@ -86,22 +86,22 @@ class QueryData {
   }
 
   const model::SnapshotVersion& snapshot_version() const {
-    return *snapshot_version_;
+    return snapshot_version_;
   }
 
   const std::vector<uint8_t>& resume_token() const {
-    return *resume_token_;
+    return resume_token_;
   }
 
-  QueryData Copy(const model::SnapshotVersion& snapshot_version,
-                 const std::vector<uint8_t>& resume_token) const;
+  QueryData Copy(model::SnapshotVersion&& snapshot_version,
+                 std::vector<uint8_t>&& resume_token) const;
 
  private:
-  const core::Query* query_;
+  const core::Query query_;
   int target_id_;
   QueryPurpose purpose_;
-  const model::SnapshotVersion* snapshot_version_;
-  const std::vector<uint8_t>* resume_token_;
+  const model::SnapshotVersion snapshot_version_;
+  const std::vector<uint8_t> resume_token_;
 };
 
 inline bool operator==(const QueryData& lhs, const QueryData& rhs) {

--- a/Firestore/core/src/firebase/firestore/local/query_data.h
+++ b/Firestore/core/src/firebase/firestore/local/query_data.h
@@ -75,15 +75,6 @@ class QueryData {
 
   /**
    * Constructs an invalid QueryData. Reading any properties of the returned
-   * value is undefined; you must reassign to this instance before it will
-   * become useful.
-   *
-   * This exists to allow QueryData to work with stl containers.
-   */
-  QueryData();
-
-  /**
-   * Constructs an invalid QueryData. Reading any properties of the returned
    * value is undefined.
    */
   static QueryData Invalid();

--- a/Firestore/core/src/firebase/firestore/model/resource_path.h
+++ b/Firestore/core/src/firebase/firestore/model/resource_path.h
@@ -49,6 +49,8 @@ class ResourcePath : public impl::BasePath<ResourcePath> {
    */
   static ResourcePath FromString(absl::string_view path);
 
+  static ResourcePath Empty() { return ResourcePath{}; }
+
   /** Returns a standardized string representation of this path. */
   std::string CanonicalString() const;
 

--- a/Firestore/core/src/firebase/firestore/model/resource_path.h
+++ b/Firestore/core/src/firebase/firestore/model/resource_path.h
@@ -49,7 +49,9 @@ class ResourcePath : public impl::BasePath<ResourcePath> {
    */
   static ResourcePath FromString(absl::string_view path);
 
-  static ResourcePath Empty() { return ResourcePath{}; }
+  static ResourcePath Empty() {
+    return ResourcePath{};
+  }
 
   /** Returns a standardized string representation of this path. */
   std::string CanonicalString() const;

--- a/Firestore/core/src/firebase/firestore/nanopb/reader.cc
+++ b/Firestore/core/src/firebase/firestore/nanopb/reader.cc
@@ -146,6 +146,13 @@ std::string Reader::ReadString() {
   return result;
 }
 
+std::vector<uint8_t> Reader::ReadBytes() {
+  std::string bytes = ReadString();
+  if (!status_.ok()) return {};
+
+  return std::vector<uint8_t>(bytes.begin(), bytes.end());
+}
+
 void Reader::SkipField(const Tag& tag) {
   if (!status_.ok()) return;
 

--- a/Firestore/core/src/firebase/firestore/nanopb/reader.h
+++ b/Firestore/core/src/firebase/firestore/nanopb/reader.h
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <vector>
 
 #include "Firestore/core/include/firebase/firestore/firestore_errors.h"
 #include "Firestore/core/src/firebase/firestore/nanopb/tag.h"
@@ -81,6 +82,8 @@ class Reader {
   std::int64_t ReadInteger();
 
   std::string ReadString();
+
+  std::vector<uint8_t> ReadBytes();
 
   /**
    * Reads a message and its length.

--- a/Firestore/core/src/firebase/firestore/nanopb/writer.cc
+++ b/Firestore/core/src/firebase/firestore/nanopb/writer.cc
@@ -105,6 +105,16 @@ void Writer::WriteString(const std::string& string_value) {
   }
 }
 
+void Writer::WriteBytes(const std::vector<uint8_t>& bytes) {
+  if (!status_.ok()) return;
+
+  if (!pb_encode_string(
+          &stream_, reinterpret_cast<const pb_byte_t*>(bytes.data()),
+          bytes.size())) {
+    HARD_FAIL(PB_GET_ERROR(&stream_));
+  }
+}
+
 void Writer::WriteNestedMessage(
     const std::function<void(Writer*)>& write_message_fn) {
   if (!status_.ok()) return;

--- a/Firestore/core/src/firebase/firestore/nanopb/writer.cc
+++ b/Firestore/core/src/firebase/firestore/nanopb/writer.cc
@@ -108,9 +108,9 @@ void Writer::WriteString(const std::string& string_value) {
 void Writer::WriteBytes(const std::vector<uint8_t>& bytes) {
   if (!status_.ok()) return;
 
-  if (!pb_encode_string(
-          &stream_, reinterpret_cast<const pb_byte_t*>(bytes.data()),
-          bytes.size())) {
+  if (!pb_encode_string(&stream_,
+                        reinterpret_cast<const pb_byte_t*>(bytes.data()),
+                        bytes.size())) {
     HARD_FAIL(PB_GET_ERROR(&stream_));
   }
 }

--- a/Firestore/core/src/firebase/firestore/nanopb/writer.h
+++ b/Firestore/core/src/firebase/firestore/nanopb/writer.h
@@ -79,6 +79,7 @@ class Writer {
   void WriteInteger(std::int64_t integer_value);
 
   void WriteString(const std::string& string_value);
+  void WriteBytes(const std::vector<uint8_t>& bytes);
 
   /**
    * Writes a message and its length.

--- a/Firestore/core/src/firebase/firestore/remote/serializer.cc
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.cc
@@ -228,12 +228,12 @@ StructuredQuery::CollectionSelector DecodeCollectionSelector(Reader* reader) {
     Tag tag = reader->ReadTag();
     if (!reader->status().ok()) return StructuredQuery::CollectionSelector{};
     switch (tag.field_number) {
-      case google_firestore_v1beta1_StructuredQuery_CollectionSelector_collection_id_tag:
+      case google_firestore_v1beta1_StructuredQuery_CollectionSelector_collection_id_tag:  // NOLINT(whitespace/line_length)
         if (!reader->RequireWireType(PB_WT_STRING, tag))
           return StructuredQuery::CollectionSelector{};
         collection_selector.collection_id = reader->ReadString();
         break;
-      case google_firestore_v1beta1_StructuredQuery_CollectionSelector_all_descendants_tag:
+      case google_firestore_v1beta1_StructuredQuery_CollectionSelector_all_descendants_tag:  // NOLINT(whitespace/line_length)
         if (!reader->RequireWireType(PB_WT_VARINT, tag))
           return StructuredQuery::CollectionSelector{};
         collection_selector.all_descendants = reader->ReadBool();
@@ -634,7 +634,7 @@ void Serializer::EncodeQueryTarget(Writer* writer,
       writer->WriteNestedMessage([&](Writer* writer) {
         writer->WriteTag(
             {PB_WT_STRING,
-             google_firestore_v1beta1_StructuredQuery_CollectionSelector_collection_id_tag});
+             google_firestore_v1beta1_StructuredQuery_CollectionSelector_collection_id_tag});  // NOLINT(whitespace/line_length)
         writer->WriteString(collection_id);
       });
     }

--- a/Firestore/core/src/firebase/firestore/remote/serializer.cc
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.cc
@@ -45,6 +45,7 @@ namespace remote {
 
 using firebase::Timestamp;
 using firebase::TimestampInternal;
+using firebase::firestore::core::Query;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::Document;
 using firebase::firestore::model::DocumentKey;
@@ -60,11 +61,9 @@ using firebase::firestore::nanopb::Writer;
 using firebase::firestore::util::Status;
 using firebase::firestore::util::StatusOr;
 
-namespace {
 
-ObjectValue::Map DecodeMapValue(Reader* reader);
-
-void EncodeTimestamp(Writer* writer, const Timestamp& timestamp_value) {
+// TODO(rsgowman): Move this down below the anon namespace
+void Serializer::EncodeTimestamp(Writer* writer, const Timestamp& timestamp_value) {
   google_protobuf_Timestamp timestamp_proto =
       google_protobuf_Timestamp_init_zero;
   timestamp_proto.seconds = timestamp_value.seconds();
@@ -72,6 +71,25 @@ void EncodeTimestamp(Writer* writer, const Timestamp& timestamp_value) {
   writer->WriteNanopbMessage(google_protobuf_Timestamp_fields,
                              &timestamp_proto);
 }
+
+namespace {
+
+ObjectValue::Map DecodeMapValue(Reader* reader);
+
+// There's no f:f::model equivalent of StructuredQuery, so we'll create our
+// own struct for decoding. We could use nanopb's struct, but it's slightly
+// inconvenient since it's a fixed size (so uses callbacks to represent
+// strings, repeated fields, etc.)
+struct StructuredQuery {
+  struct CollectionSelector {
+    std::string collection_id;
+    bool all_descendants;
+  };
+  // TODO(rsgowman): other submessages
+
+  std::vector<CollectionSelector> from;
+  // TODO(rsgowman): other fields
+};
 
 ObjectValue::Map::value_type DecodeFieldsEntry(Reader* reader,
                                                uint32_t key_tag,
@@ -204,7 +222,53 @@ ResourcePath ExtractLocalPathFromResourceName(
   return resource_name.PopFirst(5);
 }
 
+StructuredQuery::CollectionSelector DecodeCollectionSelector(Reader* reader) {
+  StructuredQuery::CollectionSelector collection_selector{};
+  while (reader->bytes_left()) {
+    Tag tag = reader->ReadTag();
+    if (!reader->status().ok()) return StructuredQuery::CollectionSelector{};
+    switch (tag.field_number) {
+      case google_firestore_v1beta1_StructuredQuery_CollectionSelector_collection_id_tag:
+        if (!reader->RequireWireType(PB_WT_STRING, tag)) return StructuredQuery::CollectionSelector{};
+        collection_selector.collection_id = reader->ReadString();
+        break;
+      case google_firestore_v1beta1_StructuredQuery_CollectionSelector_all_descendants_tag:
+        if (!reader->RequireWireType(PB_WT_VARINT, tag)) return StructuredQuery::CollectionSelector{};
+        collection_selector.all_descendants = reader->ReadBool();
+        break;
+      default:
+        // Unknown tag. According to the proto spec, we need to ignore these.
+        reader->SkipField(tag);
+    }
+  }
+  return collection_selector;
+}
+
+StructuredQuery DecodeStructuredQuery(Reader* reader) {
+  StructuredQuery query{};
+
+  while (reader->bytes_left()) {
+    Tag tag = reader->ReadTag();
+    if (!reader->status().ok()) return StructuredQuery{};
+    switch (tag.field_number) {
+      case google_firestore_v1beta1_StructuredQuery_from_tag:
+        if (!reader->RequireWireType(PB_WT_STRING, tag)) return StructuredQuery{};
+        query.from.push_back(reader->ReadNestedMessage<StructuredQuery::CollectionSelector>(DecodeCollectionSelector));
+        break;
+      // TODO(rsgowman): decode other fields
+      default:
+        // Unknown tag. According to the proto spec, we need to ignore these.
+        reader->SkipField(tag);
+    }
+  }
+  return query;
+}
+
 }  // namespace
+
+Serializer::Serializer(const firebase::firestore::model::DatabaseId& database_id)
+    : database_id_(database_id), database_name_(EncodeDatabaseId(database_id).CanonicalString()) {
+}
 
 Status Serializer::EncodeFieldValue(const FieldValue& field_value,
                                     std::vector<uint8_t>* out_bytes) {
@@ -523,6 +587,113 @@ std::unique_ptr<Document> Serializer::DecodeDocument(Reader* reader) const {
   return absl::make_unique<Document>(
       FieldValue::ObjectValueFromMap(fields_internal), DecodeKey(name), version,
       /*has_local_modifications=*/false);
+}
+
+util::Status Serializer::EncodeQueryTarget(
+    const core::Query& query,
+    std::vector<uint8_t>* out_bytes) const {
+  Writer writer = Writer::Wrap(out_bytes);
+  EncodeQueryTarget(&writer, query);
+  return writer.status();
+}
+
+void Serializer::EncodeQueryTarget(Writer* writer, const core::Query& query) const {
+  if (!writer->status().ok()) return;
+
+  // Dissect the path into parent, collection_id and optional key filter.
+  std::string collection_id;
+  if (query.path().empty()) {
+    writer->WriteTag({PB_WT_STRING, google_firestore_v1beta1_Target_QueryTarget_parent_tag});
+    writer->WriteString(EncodeQueryPath(ResourcePath::Empty()));
+  } else {
+    ResourcePath path = query.path();
+    HARD_ASSERT(path.size() % 2 != 0, "Document queries with filters are not supported.");
+    writer->WriteTag({PB_WT_STRING, google_firestore_v1beta1_Target_QueryTarget_parent_tag});
+    writer->WriteString(EncodeQueryPath(path.PopLast()));
+
+    collection_id = path.last_segment();
+  }
+
+  writer->WriteTag({PB_WT_STRING, google_firestore_v1beta1_Target_QueryTarget_structured_query_tag});
+  writer->WriteNestedMessage([&](Writer* writer) {
+    if (!collection_id.empty()) {
+      writer->WriteTag({PB_WT_STRING, google_firestore_v1beta1_StructuredQuery_from_tag});
+      writer->WriteNestedMessage([&](Writer* writer) {
+        writer->WriteTag({PB_WT_STRING, google_firestore_v1beta1_StructuredQuery_CollectionSelector_collection_id_tag});
+        writer->WriteString(collection_id);
+      });
+    }
+
+    // Encode the filters.
+    if (!query.filters().empty()) {
+      // TODO(rsgowman): Implement
+      abort();
+    }
+
+    // TODO(rsgowman): Encode the orders.
+    // TODO(rsgowman): Encode the limit.
+    // TODO(rsgowman): Encode the startat.
+    // TODO(rsgowman): Encode the endat.
+  });
+}
+
+ResourcePath DecodeQueryPath(absl::string_view name) {
+  ResourcePath resource = DecodeResourceName(name);
+  if (resource.size() == 4) {
+    // Path missing the trailing documents path segment, indicating an empty
+    // path.
+    return ResourcePath::Empty();
+  } else {
+    return ExtractLocalPathFromResourceName(resource);
+  }
+}
+
+Query Serializer::DecodeQueryTarget(nanopb::Reader* reader) {
+  if (!reader->status().ok()) return Query::Invalid();
+
+  ResourcePath path = ResourcePath::Empty();
+  StructuredQuery query{};
+
+  while (reader->bytes_left()) {
+    Tag tag = reader->ReadTag();
+    if (!reader->status().ok()) return Query::Invalid();
+    switch (tag.field_number) {
+      case google_firestore_v1beta1_Target_QueryTarget_parent_tag:
+        if (!reader->RequireWireType(PB_WT_STRING, tag)) return Query::Invalid();
+        path = DecodeQueryPath(reader->ReadString());
+        break;
+
+      case google_firestore_v1beta1_Target_QueryTarget_structured_query_tag: {
+        if (!reader->RequireWireType(PB_WT_STRING, tag)) return Query::Invalid();
+        query = reader->ReadNestedMessage<StructuredQuery>(DecodeStructuredQuery);
+        break;
+      }
+    }
+  }
+
+  int from_count = query.from.size();
+  if (from_count > 0) {
+    HARD_ASSERT(from_count == 1, "StructuredQuery.from with more than one collection is not supported.");
+
+    path = path.Append(query.from[0].collection_id);
+  }
+
+  // TODO(rsgowman): Dencode the filters.
+  // TODO(rsgowman): Dencode the orders.
+  // TODO(rsgowman): Dencode the limit.
+  // TODO(rsgowman): Dencode the startat.
+  // TODO(rsgowman): Dencode the endat.
+
+  return Query(path, {});
+}
+
+std::string Serializer::EncodeQueryPath(const ResourcePath& path) const {
+  if (path.empty()) {
+    // If the path is empty, the backend requires we leave off the /documents at
+    // the end.
+    return database_name_;
+  }
+  return EncodeResourceName(database_id_, path);
 }
 
 void Serializer::EncodeMapValue(Writer* writer,

--- a/Firestore/core/src/firebase/firestore/remote/serializer.cc
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.cc
@@ -61,6 +61,20 @@ using firebase::firestore::nanopb::Writer;
 using firebase::firestore::util::Status;
 using firebase::firestore::util::StatusOr;
 
+// Aliases for nanopb's equivalent of google::firestore::v1beta1. This shorten
+// the symbols and allows them to fit on one line.
+namespace v1beta1 {
+
+constexpr uint32_t StructuredQuery_CollectionSelector_collection_id_tag =
+    // NOLINTNEXTLINE(whitespace/line_length)
+    google_firestore_v1beta1_StructuredQuery_CollectionSelector_collection_id_tag;
+
+constexpr uint32_t StructuredQuery_CollectionSelector_all_descendants_tag =
+    // NOLINTNEXTLINE(whitespace/line_length)
+    google_firestore_v1beta1_StructuredQuery_CollectionSelector_all_descendants_tag;
+
+}  // namespace v1beta1
+
 // TODO(rsgowman): Move this down below the anon namespace
 void Serializer::EncodeTimestamp(Writer* writer,
                                  const Timestamp& timestamp_value) {
@@ -228,12 +242,12 @@ StructuredQuery::CollectionSelector DecodeCollectionSelector(Reader* reader) {
     Tag tag = reader->ReadTag();
     if (!reader->status().ok()) return StructuredQuery::CollectionSelector{};
     switch (tag.field_number) {
-      case google_firestore_v1beta1_StructuredQuery_CollectionSelector_collection_id_tag:  // NOLINT(whitespace/line_length)
+      case v1beta1::StructuredQuery_CollectionSelector_collection_id_tag:
         if (!reader->RequireWireType(PB_WT_STRING, tag))
           return StructuredQuery::CollectionSelector{};
         collection_selector.collection_id = reader->ReadString();
         break;
-      case google_firestore_v1beta1_StructuredQuery_CollectionSelector_all_descendants_tag:  // NOLINT(whitespace/line_length)
+      case v1beta1::StructuredQuery_CollectionSelector_all_descendants_tag:
         if (!reader->RequireWireType(PB_WT_VARINT, tag))
           return StructuredQuery::CollectionSelector{};
         collection_selector.all_descendants = reader->ReadBool();
@@ -634,7 +648,7 @@ void Serializer::EncodeQueryTarget(Writer* writer,
       writer->WriteNestedMessage([&](Writer* writer) {
         writer->WriteTag(
             {PB_WT_STRING,
-             google_firestore_v1beta1_StructuredQuery_CollectionSelector_collection_id_tag});  // NOLINT(whitespace/line_length)
+             v1beta1::StructuredQuery_CollectionSelector_collection_id_tag});
         writer->WriteString(collection_id);
       });
     }

--- a/Firestore/core/src/firebase/firestore/remote/serializer.h
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.h
@@ -65,7 +65,8 @@ class Serializer {
    * @param database_id Must remain valid for the lifetime of this Serializer
    * object.
    */
-  explicit Serializer(const firebase::firestore::model::DatabaseId& database_id);
+  explicit Serializer(
+      const firebase::firestore::model::DatabaseId& database_id);
 
   /**
    * @brief Converts the FieldValue model passed into bytes.
@@ -171,9 +172,8 @@ class Serializer {
    * @return A Status, which if not ok(), indicates what went wrong. Note that
    * errors during encoding generally indicate a serious/fatal error.
    */
-  util::Status EncodeQueryTarget(
-      const core::Query& query,
-      std::vector<uint8_t>* out_bytes) const;
+  util::Status EncodeQueryTarget(const core::Query& query,
+                                 std::vector<uint8_t>* out_bytes) const;
 
   std::unique_ptr<model::Document> DecodeDocument(nanopb::Reader* reader) const;
 
@@ -186,11 +186,13 @@ class Serializer {
   static void EncodeVersion(nanopb::Writer* writer,
                             const model::SnapshotVersion& version);
 
-  static void EncodeTimestamp(nanopb::Writer* writer, const Timestamp& timestamp_value);
+  static void EncodeTimestamp(nanopb::Writer* writer,
+                              const Timestamp& timestamp_value);
   static Timestamp DecodeTimestamp(nanopb::Reader* reader);
   static model::FieldValue DecodeFieldValue(nanopb::Reader* reader);
 
-  void EncodeQueryTarget(nanopb::Writer* writer, const core::Query& query) const;
+  void EncodeQueryTarget(nanopb::Writer* writer,
+                         const core::Query& query) const;
   static core::Query DecodeQueryTarget(nanopb::Reader* reader);
 
  private:
@@ -211,8 +213,8 @@ class Serializer {
   static void EncodeFieldValue(nanopb::Writer* writer,
                                const model::FieldValue& field_value);
 
-
-  void EncodeQueryPath(nanopb::Writer* writer, const model::ResourcePath& path) const;
+  void EncodeQueryPath(nanopb::Writer* writer,
+                       const model::ResourcePath& path) const;
   std::string EncodeQueryPath(const model::ResourcePath& path) const;
 
   const model::DatabaseId& database_id_;

--- a/Firestore/core/src/firebase/firestore/remote/serializer.h
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 
+#include "Firestore/core/src/firebase/firestore/core/query.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
 #include "Firestore/core/src/firebase/firestore/model/document.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
@@ -64,9 +65,7 @@ class Serializer {
    * @param database_id Must remain valid for the lifetime of this Serializer
    * object.
    */
-  explicit Serializer(const firebase::firestore::model::DatabaseId& database_id)
-      : database_id_(database_id) {
-  }
+  explicit Serializer(const firebase::firestore::model::DatabaseId& database_id);
 
   /**
    * @brief Converts the FieldValue model passed into bytes.
@@ -163,6 +162,19 @@ class Serializer {
     return DecodeMaybeDocument(bytes.data(), bytes.size());
   }
 
+  /**
+   * @brief Converts the Query into bytes, representing a
+   * firestore::v1beta1::Target::QueryTarget.
+   *
+   * @param[out] out_bytes A buffer to place the output. The bytes will be
+   * appended to this vector.
+   * @return A Status, which if not ok(), indicates what went wrong. Note that
+   * errors during encoding generally indicate a serious/fatal error.
+   */
+  util::Status EncodeQueryTarget(
+      const core::Query& query,
+      std::vector<uint8_t>* out_bytes) const;
+
   std::unique_ptr<model::Document> DecodeDocument(nanopb::Reader* reader) const;
 
   static void EncodeObjectMap(nanopb::Writer* writer,
@@ -174,8 +186,12 @@ class Serializer {
   static void EncodeVersion(nanopb::Writer* writer,
                             const model::SnapshotVersion& version);
 
+  static void EncodeTimestamp(nanopb::Writer* writer, const Timestamp& timestamp_value);
   static Timestamp DecodeTimestamp(nanopb::Reader* reader);
   static model::FieldValue DecodeFieldValue(nanopb::Reader* reader);
+
+  void EncodeQueryTarget(nanopb::Writer* writer, const core::Query& query) const;
+  static core::Query DecodeQueryTarget(nanopb::Reader* reader);
 
  private:
   void EncodeDocument(nanopb::Writer* writer,
@@ -195,7 +211,12 @@ class Serializer {
   static void EncodeFieldValue(nanopb::Writer* writer,
                                const model::FieldValue& field_value);
 
-  const firebase::firestore::model::DatabaseId& database_id_;
+
+  void EncodeQueryPath(nanopb::Writer* writer, const model::ResourcePath& path) const;
+  std::string EncodeQueryPath(const model::ResourcePath& path) const;
+
+  const model::DatabaseId& database_id_;
+  const std::string database_name_;
 };
 
 }  // namespace remote

--- a/Firestore/core/test/firebase/firestore/local/local_serializer_test.cc
+++ b/Firestore/core/test/firebase/firestore/local/local_serializer_test.cc
@@ -17,6 +17,10 @@
 #include "Firestore/core/src/firebase/firestore/local/local_serializer.h"
 
 #include "Firestore/Protos/cpp/firestore/local/maybe_document.pb.h"
+#include "Firestore/Protos/cpp/firestore/local/target.pb.h"
+#include "Firestore/Protos/cpp/google/firestore/v1beta1/firestore.pb.h"
+#include "Firestore/core/src/firebase/firestore/core/query.h"
+#include "Firestore/core/src/firebase/firestore/local/query_data.h"
 #include "Firestore/core/src/firebase/firestore/model/field_value.h"
 #include "Firestore/core/src/firebase/firestore/model/maybe_document.h"
 #include "Firestore/core/src/firebase/firestore/model/no_document.h"
@@ -27,21 +31,24 @@
 #include "google/protobuf/util/message_differencer.h"
 #include "gtest/gtest.h"
 
-namespace local = firebase::firestore::local;
-namespace remote = firebase::firestore::remote;
-namespace v1beta1 = google::firestore::v1beta1;
+namespace firebase {
+namespace firestore {
+namespace local {
 
-using firebase::firestore::model::DatabaseId;
-using firebase::firestore::model::Document;
-using firebase::firestore::model::DocumentKey;
-using firebase::firestore::model::MaybeDocument;
-using firebase::firestore::model::NoDocument;
-using firebase::firestore::model::SnapshotVersion;
-using firebase::firestore::testutil::DeletedDoc;
-using firebase::firestore::testutil::Doc;
-using firebase::firestore::util::Status;
-using firebase::firestore::util::StatusOr;
-using google::protobuf::util::MessageDifferencer;
+namespace v1beta1 = google::firestore::v1beta1;
+using core::Query;
+using model::DatabaseId;
+using model::Document;
+using model::DocumentKey;
+using model::MaybeDocument;
+using model::NoDocument;
+using model::SnapshotVersion;
+using testutil::DeletedDoc;
+using testutil::Doc;
+using testutil::Query;
+using util::Status;
+using util::StatusOr;
+using ::google::protobuf::util::MessageDifferencer;
 
 // TODO(rsgowman): This is copied from remote/serializer_tests.cc. Refactor.
 #define EXPECT_OK(status) EXPECT_TRUE(StatusOk(status))
@@ -58,7 +65,7 @@ class LocalSerializerTest : public ::testing::Test {
   local::LocalSerializer serializer;
 
   void ExpectRoundTrip(const MaybeDocument& model,
-                       const firestore::client::MaybeDocument& proto,
+                       const ::firestore::client::MaybeDocument& proto,
                        MaybeDocument::Type type) {
     // First, serialize model with our (nanopb based) serializer, then
     // deserialize the resulting bytes with libprotobuf and ensure the result is
@@ -69,6 +76,19 @@ class LocalSerializerTest : public ::testing::Test {
     // bytes with our (nanopb based) deserializer and ensure the result is the
     // same as the expected model.
     ExpectDeserializationRoundTrip(model, proto, type);
+  }
+
+  void ExpectRoundTrip(const QueryData& query_data,
+                       const ::firestore::client::Target& proto) {
+    // First, serialize model with our (nanopb based) serializer, then
+    // deserialize the resulting bytes with libprotobuf and ensure the result is
+    // the same as the expected proto.
+    ExpectSerializationRoundTrip(query_data, proto);
+
+    // Next, serialize proto with libprotobuf, then deserialize the resulting
+    // bytes with our (nanopb based) deserializer and ensure the result is the
+    // same as the expected model.
+    ExpectDeserializationRoundTrip(query_data, proto);
   }
 
   /**
@@ -100,11 +120,11 @@ class LocalSerializerTest : public ::testing::Test {
  private:
   void ExpectSerializationRoundTrip(
       const MaybeDocument& model,
-      const firestore::client::MaybeDocument& proto,
+      const ::firestore::client::MaybeDocument& proto,
       MaybeDocument::Type type) {
     EXPECT_EQ(type, model.type());
     std::vector<uint8_t> bytes = EncodeMaybeDocument(&serializer, model);
-    firestore::client::MaybeDocument actual_proto;
+    ::firestore::client::MaybeDocument actual_proto;
     bool ok = actual_proto.ParseFromArray(bytes.data(),
                                           static_cast<int>(bytes.size()));
     EXPECT_TRUE(ok);
@@ -113,7 +133,7 @@ class LocalSerializerTest : public ::testing::Test {
 
   void ExpectDeserializationRoundTrip(
       const MaybeDocument& model,
-      const firestore::client::MaybeDocument& proto,
+      const ::firestore::client::MaybeDocument& proto,
       MaybeDocument::Type type) {
     std::vector<uint8_t> bytes(proto.ByteSizeLong());
     bool status =
@@ -136,6 +156,38 @@ class LocalSerializerTest : public ::testing::Test {
     return bytes;
   }
 
+  void ExpectSerializationRoundTrip(
+      const QueryData& query_data,
+      const ::firestore::client::Target& proto) {
+    std::vector<uint8_t> bytes = EncodeQueryData(&serializer, query_data);
+    ::firestore::client::Target actual_proto;
+    bool ok = actual_proto.ParseFromArray(bytes.data(),
+                                          static_cast<int>(bytes.size()));
+    EXPECT_TRUE(ok);
+    EXPECT_TRUE(msg_diff.Compare(proto, actual_proto)) << message_differences;
+  }
+
+  void ExpectDeserializationRoundTrip(
+      const QueryData& query_data,
+      const ::firestore::client::Target& proto) {
+    std::vector<uint8_t> bytes(proto.ByteSizeLong());
+    bool status = proto.SerializeToArray(bytes.data(), static_cast<int>(bytes.size()));
+    EXPECT_TRUE(status);
+    StatusOr<QueryData> actual_query_data_status = serializer.DecodeQueryData(bytes);
+    EXPECT_OK(actual_query_data_status);
+    QueryData actual_query_data = std::move(actual_query_data_status).ValueOrDie();
+
+    EXPECT_EQ(query_data, actual_query_data);
+  }
+
+  std::vector<uint8_t> EncodeQueryData(local::LocalSerializer* serializer, const QueryData& query_data) {
+    std::vector<uint8_t> bytes;
+    EXPECT_EQ(query_data.purpose(), QueryPurpose::kListen);
+    Status status = serializer->EncodeQueryData(query_data, &bytes);
+    EXPECT_OK(status);
+    return bytes;
+  }
+
   std::string message_differences;
   MessageDifferencer msg_diff;
 };
@@ -143,7 +195,7 @@ class LocalSerializerTest : public ::testing::Test {
 TEST_F(LocalSerializerTest, EncodesDocumentAsMaybeDocument) {
   Document doc = Doc("some/path", /*version=*/42);
 
-  firestore::client::MaybeDocument maybe_doc_proto;
+  ::firestore::client::MaybeDocument maybe_doc_proto;
   maybe_doc_proto.mutable_document()->set_name(
       "projects/p/databases/d/documents/some/path");
   maybe_doc_proto.mutable_document()->mutable_update_time()->set_seconds(0);
@@ -155,7 +207,7 @@ TEST_F(LocalSerializerTest, EncodesDocumentAsMaybeDocument) {
 TEST_F(LocalSerializerTest, EncodesNoDocumentAsMaybeDocument) {
   NoDocument no_doc = DeletedDoc("some/path", /*version=*/42);
 
-  firestore::client::MaybeDocument maybe_doc_proto;
+  ::firestore::client::MaybeDocument maybe_doc_proto;
   maybe_doc_proto.mutable_no_document()->set_name(
       "projects/p/databases/d/documents/some/path");
   maybe_doc_proto.mutable_no_document()->mutable_read_time()->set_seconds(0);
@@ -163,3 +215,34 @@ TEST_F(LocalSerializerTest, EncodesNoDocumentAsMaybeDocument) {
 
   ExpectRoundTrip(no_doc, maybe_doc_proto, no_doc.type());
 }
+
+TEST_F(LocalSerializerTest, EncodesQueryData) {
+  core::Query query = testutil::Query("room");
+  int target_id = 42;
+  SnapshotVersion version = testutil::Version(1039);
+  std::vector<uint8_t> resume_token = testutil::ResumeToken(1039);
+
+  QueryData query_data(core::Query(query), target_id, QueryPurpose::kListen, SnapshotVersion(version), std::vector<uint8_t>(resume_token));
+
+  // Let the RPC serializer test various permutations of query serialization.
+  std::vector<uint8_t> query_target_bytes;
+  util::Status status = remote_serializer.EncodeQueryTarget(query_data.query(), &query_target_bytes);
+  EXPECT_OK(status);
+  v1beta1::Target::QueryTarget queryTargetProto;
+  bool ok = queryTargetProto.ParseFromArray(query_target_bytes.data(), static_cast<int>(query_target_bytes.size()));
+  EXPECT_TRUE(ok);
+
+  ::firestore::client::Target expected;
+  expected.set_target_id(target_id);
+  expected.mutable_snapshot_version()->set_nanos(1039000);
+  expected.set_resume_token(resume_token.data(), resume_token.size());
+  v1beta1::Target::QueryTarget* query_proto = expected.mutable_query();
+  query_proto->set_parent(queryTargetProto.parent());
+  *query_proto->mutable_structured_query() = queryTargetProto.structured_query();
+
+  ExpectRoundTrip(query_data, expected);
+}
+
+}  // namespace local
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/core/test/firebase/firestore/testutil/testutil.h
+++ b/Firestore/core/test/firebase/firestore/testutil/testutil.h
@@ -22,8 +22,10 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "Firestore/core/include/firebase/firestore/timestamp.h"
+#include "Firestore/core/src/firebase/firestore/core/query.h"
 #include "Firestore/core/src/firebase/firestore/core/relation_filter.h"
 #include "Firestore/core/src/firebase/firestore/model/document.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
@@ -115,6 +117,25 @@ inline std::shared_ptr<core::Filter> Filter(absl::string_view key,
                                             absl::string_view op,
                                             double value) {
   return Filter(key, op, model::FieldValue::DoubleValue(value));
+}
+
+inline core::Query Query(absl::string_view path) {
+  return core::Query::AtPath(Resource(path));
+}
+
+inline std::vector<uint8_t> ResumeToken(long snapshot_version) {
+  if (snapshot_version == 0) {
+    // TODO(rsgowman): The other platforms return null here, though I'm not sure
+    // if they ever rely on that. I suspect it'd be sufficient to return '{}'.
+    // But for now, we'll just abort() until we hit a test case that actually
+    // makes use of this.
+    abort();
+  }
+
+  std::string snapshot_string = std::string("snapshot-") + std::to_string(snapshot_version);
+  std::vector<uint8_t> result;
+  result.insert(result.end(), snapshot_string.begin(), snapshot_string.end());
+  return result;
 }
 
 // Add a non-inline function to make this library buildable.

--- a/Firestore/core/test/firebase/firestore/testutil/testutil.h
+++ b/Firestore/core/test/firebase/firestore/testutil/testutil.h
@@ -123,7 +123,7 @@ inline core::Query Query(absl::string_view path) {
   return core::Query::AtPath(Resource(path));
 }
 
-inline std::vector<uint8_t> ResumeToken(long snapshot_version) {
+inline std::vector<uint8_t> ResumeToken(int64_t snapshot_version) {
   if (snapshot_version == 0) {
     // TODO(rsgowman): The other platforms return null here, though I'm not sure
     // if they ever rely on that. I suspect it'd be sufficient to return '{}'.
@@ -132,7 +132,8 @@ inline std::vector<uint8_t> ResumeToken(long snapshot_version) {
     abort();
   }
 
-  std::string snapshot_string = std::string("snapshot-") + std::to_string(snapshot_version);
+  std::string snapshot_string =
+      std::string("snapshot-") + std::to_string(snapshot_version);
   std::vector<uint8_t> result;
   result.insert(result.end(), snapshot_string.begin(), snapshot_string.end());
   return result;

--- a/Firestore/core/test/firebase/firestore/testutil/testutil.h
+++ b/Firestore/core/test/firebase/firestore/testutil/testutil.h
@@ -134,9 +134,7 @@ inline std::vector<uint8_t> ResumeToken(int64_t snapshot_version) {
 
   std::string snapshot_string =
       std::string("snapshot-") + std::to_string(snapshot_version);
-  std::vector<uint8_t> result;
-  result.insert(result.end(), snapshot_string.begin(), snapshot_string.end());
-  return result;
+  return {snapshot_string.begin(), snapshot_string.end()};
 }
 
 // Add a non-inline function to make this library buildable.


### PR DESCRIPTION
Only a single (narrow) path is supported. i.e. the only QueryData that
can be encoded/decoded is the one in the test. Straying from the path
leads to abort()s.