### PR TITLE
Bump GoogleUtilities patch version to publish #1595

### DIFF
--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleUtilities'
-  s.version          = '5.2.0'
+  s.version          = '5.2.1'
   s.summary          = 'Google Utilities for iOS (plus community support for macOS and tvOS)'
 
   s.description      = <<-DESC


### PR DESCRIPTION
After #1595 lands, I'll merge this PR, tag, and push GoogleUtilities 5.2.1