### PR TITLE
Rewrite Path to use native path character type

### DIFF
--- a/Firestore/core/src/firebase/firestore/util/path.cc
+++ b/Firestore/core/src/firebase/firestore/util/path.cc
@@ -16,6 +16,7 @@
 
 #include "Firestore/core/src/firebase/firestore/util/path.h"
 
+#include "Firestore/core/src/firebase/firestore/util/string_win.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/string_view.h"
 
@@ -23,86 +24,152 @@ namespace firebase {
 namespace firestore {
 namespace util {
 
+constexpr size_t Path::npos;
+constexpr Path::char_type Path::kPreferredSeparator;
+
 namespace {
 
-static constexpr absl::string_view::size_type npos = absl::string_view::npos;
-
-/** Returns the given path with its leading drive letter removed. */
-inline absl::string_view StripDriveLetter(absl::string_view path) {
+/**
+ * Returns the offset within the given path that skips the leading drive letter.
+ * If there is no drive letter, returns zero.
+ */
+size_t StripDriveLetter(const Path::char_type* path, size_t size) {
 #if defined(_WIN32)
-  if (path.size() >= 2 && path[1] == ':' && absl::ascii_isalpha(path[0])) {
-    return path.substr(2);
+  if (size >= 2 && path[1] == L':' && absl::ascii_isalpha(path[0])) {
+    return 2;
   }
-  return path;
+  return 0;
 
 #else
-  return path;
+  (void)path;
+  (void)size;
+  return 0;
 #endif  // defined(_WIN32)
 }
 
 /** Returns true if the given character is a pathname separator. */
-inline bool IsSeparator(char c) {
+inline bool IsSeparator(Path::char_type c) {
 #if defined(_WIN32)
-  return c == '/' || c == '\\';
+  return c == L'/' || c == L'\\';
 #else
   return c == '/';
 #endif  // defined(_WIN32)
 }
 
+bool IsAbsolute(const Path::char_type* path, size_t size) {
+  size_t offset = StripDriveLetter(path, size);
+  return size >= offset && IsSeparator(path[offset]);
+}
+
+size_t LastNonSeparator(const Path::char_type* path, size_t size) {
+  if (size == 0) return Path::npos;
+
+  size_t i = size;
+  for (; i-- > 0;) {
+    if (!IsSeparator(path[i])) {
+      return i;
+    }
+  }
+  return Path::npos;
+}
+
+size_t LastSeparator(const Path::char_type* path, size_t size) {
+  if (size == 0) return Path::npos;
+
+  size_t i = size;
+  for (; i-- > 0;) {
+    if (IsSeparator(path[i])) {
+      return i;
+    }
+  }
+  return Path::npos;
+}
+
 }  // namespace
 
-absl::string_view Path::Basename(absl::string_view pathname) {
-  size_t slash = pathname.find_last_of('/');
+Path Path::FromUtf8(absl::string_view utf8_pathname) {
+#if defined(_WIN32)
+  return Path{Utf8ToNative(utf8_pathname)};
 
+#else
+  return Path{std::string{utf8_pathname}};
+#endif  // defined(_WIN32)
+}
+
+#if defined(_WIN32)
+std::string Path::ToString() const {
+  return NativeToUtf8(pathname_);
+}
+#else
+const std::string& Path::ToString() const {
+  return pathname_;
+}
+#endif  // defined(_WIN32)
+
+Path Path::Basename() const {
+  size_t slash = LastSeparator(c_str(), size());
   if (slash == npos) {
     // No path separator found => the whole string.
-    return pathname;
+    return *this;
   }
 
   // Otherwise everything after the slash is the basename (even if empty string)
-  return pathname.substr(slash + 1);
+  size_t start = slash + 1;
+  return Path{pathname_.substr(start)};
 }
 
-absl::string_view Path::Dirname(absl::string_view pathname) {
-  size_t last_slash = pathname.find_last_of('/');
-
+Path Path::Dirname() const {
+  size_t last_slash = LastSeparator(c_str(), size());
   if (last_slash == npos) {
     // No path separator found => empty string. Conformance with POSIX would
     // have us return "." here.
-    return pathname.substr(0, 0);
+    return Path{string_type{}};
   }
 
   // Collapse runs of slashes.
-  size_t nonslash = pathname.find_last_not_of('/', last_slash);
-  if (nonslash == npos) {
+  size_t non_slash = LastNonSeparator(c_str(), last_slash);
+  if (non_slash == npos) {
     // All characters preceding the last path separator are slashes
-    return pathname.substr(0, 1);
+    return Path{pathname_.substr(0, 1)};
   }
 
-  last_slash = nonslash + 1;
-
   // Otherwise everything up to the slash is the parent directory
-  return pathname.substr(0, last_slash);
+  last_slash = non_slash + 1;
+  return Path{pathname_.substr(0, last_slash)};
 }
 
-bool Path::IsAbsolute(absl::string_view path) {
-  path = StripDriveLetter(path);
-  return !path.empty() && IsSeparator(path.front());
+bool Path::IsAbsolute() const {
+  return util::IsAbsolute(c_str(), size());
 }
 
-void Path::JoinAppend(std::string* base, absl::string_view path) {
-  if (IsAbsolute(path)) {
-    base->assign(path.data(), path.size());
+Path Path::AppendUtf8(absl::string_view path) const {
+#if defined(_WIN32)
+  return Append(Path::FromUtf8(path));
+
+#else
+  Path result{*this};
+  result.MutableAppend(path.data(), path.size());
+  return result;
+#endif  // _WIN32
+}
+
+void Path::MutableAppend(const Path& path) {
+  MutableAppend(path.c_str(), path.size());
+}
+
+void Path::MutableAppend(const char_type* path, size_t size) {
+  if (util::IsAbsolute(path, size)) {
+    pathname_.assign(path, size);
 
   } else {
-    size_t nonslash = base->find_last_not_of('/');
-    if (nonslash != npos) {
-      base->resize(nonslash + 1);
-      base->push_back('/');
+    size_t non_slash = LastNonSeparator(pathname_.c_str(), pathname_.size());
+    if (non_slash != npos) {
+      pathname_.resize(non_slash + 1);
+      pathname_.push_back(kPreferredSeparator);
     }
 
     // If path started with a slash we'd treat it as absolute above
-    base->append(path.data(), path.size());
+    pathname_.append(path, size);
   }
 }
 


### PR DESCRIPTION
Paths now hold their platform-specific string values. On Windows, portable pathnames are UTF-16 stored in `wchar_t` arrays, but there's no `absl::wstring_view`, so filesystem APIs can't be designed to operate on `absl::string_view`.

I could have split this into a `PathView` class to make it possible to create a view, but having implemented the filesystem gunk, it doesn't really save that many copies in practice so it's just not worth the overhead of implementation. Since we don't use the filesystem APIs intensively a few extra copies for a simpler implementation is worth it.