### PR TITLE
Simplify/normlaize CMake platform libraries

### DIFF
--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -116,6 +116,7 @@ check_symbol_exists(arc4random stdlib.h HAVE_ARC4RANDOM)
 cc_library(
   firebase_firestore_util_random_arc4random
   SOURCES
+    secure_random.h
     secure_random_arc4random.cc
 )
 
@@ -128,6 +129,7 @@ if(TARGET OpenSSL::Crypto)
   cc_library(
     firebase_firestore_util_random_openssl
     SOURCES
+      secure_random.h
       secure_random_openssl.cc
     DEPENDS
       OpenSSL::Crypto
@@ -166,7 +168,6 @@ cc_library(
     path.cc
     path.h
     range.h
-    secure_random.h
     status.cc
     status.h
     status_apple.mm

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -61,17 +61,11 @@ cc_library(
   EXCLUDE_FROM_ALL
 )
 
-if(APPLE)
-  set(
-    FIREBASE_FIRESTORE_UTIL_LOG
-    firebase_firestore_util_log_apple
-  )
-else()
-  set(
-    FIREBASE_FIRESTORE_UTIL_LOG
-    firebase_firestore_util_log_stdio
-  )
-endif()
+cc_select(
+  firebase_firestore_util_log
+  APPLE   firebase_firestore_util_log_apple
+  DEFAULT firebase_firestore_util_log_stdio
+)
 
 
 ## secure_random
@@ -98,22 +92,12 @@ if(TARGET OpenSSL::Crypto)
   )
 endif()
 
-if(HAVE_ARC4RANDOM)
-  set(
-    FIREBASE_FIRESTORE_UTIL_RANDOM
-    firebase_firestore_util_random_arc4random
-  )
+cc_select(
+  firebase_firestore_util_random
+  HAVE_ARC4RANDOM     firebase_firestore_util_random_arc4random
+  HAVE_OPENSSL_RAND_H firebase_firestore_util_random_openssl
+)
 
-elseif(HAVE_OPENSSL_RAND_H)
-  set(
-    FIREBASE_FIRESTORE_UTIL_RANDOM
-    firebase_firestore_util_random_openssl
-  )
-
-else()
-  message(FATAL_ERROR "No implementation for SecureRandom available.")
-
-endif()
 
 ## async queue
 
@@ -130,7 +114,7 @@ cc_library(
   DEPENDS
     absl_bad_optional_access
     absl_optional
-    ${FIREBASE_FIRESTORE_UTIL_LOG}
+    firebase_firestore_util_log
   EXCLUDE_FROM_ALL
 )
 
@@ -146,24 +130,15 @@ cc_library(
     absl_bad_optional_access
     absl_optional
     absl_strings
-    ${FIREBASE_FIRESTORE_UTIL_LOG}
+    firebase_firestore_util_log
   EXCLUDE_FROM_ALL
 )
-endif()
 
-if(HAVE_LIBDISPATCH)
-  set(
-    FIREBASE_FIRESTORE_UTIL_ASYNC
-    firebase_firestore_util_async_libdispatch
-  )
-
-else()
-  set(
-    FIREBASE_FIRESTORE_UTIL_ASYNC
-    firebase_firestore_util_async_std
-  )
-
-endif()
+cc_select(
+  firebase_firestore_util_async
+  HAVE_LIBDISPATCH firebase_firestore_util_async_libdispatch
+  DEFAULT          firebase_firestore_util_async_std
+)
 
 
 ## main library
@@ -207,8 +182,8 @@ cc_library(
     type_traits.h
   DEPENDS
     absl_base
+    firebase_firestore_util_async
     firebase_firestore_util_base
-    ${FIREBASE_FIRESTORE_UTIL_ASYNC}
-    ${FIREBASE_FIRESTORE_UTIL_LOG}
-    ${FIREBASE_FIRESTORE_UTIL_RANDOM}
+    firebase_firestore_util_log
+    firebase_firestore_util_random
 )

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -193,6 +193,7 @@ cc_library(
     secure_random.h
     status.cc
     status.h
+    status_apple.mm
     statusor.cc
     statusor.h
     statusor_internals.h
@@ -210,10 +211,3 @@ cc_library(
     ${FIREBASE_FIRESTORE_UTIL_LOG}
     ${FIREBASE_FIRESTORE_UTIL_RANDOM}
 )
-
-if(APPLE)
-  target_sources(
-    firebase_firestore_util PRIVATE
-    status_apple.mm
-  )
-endif()

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -120,8 +120,10 @@ endif()
 check_symbol_exists(dispatch_async_f dispatch/dispatch.h HAVE_LIBDISPATCH)
 
 cc_library(
-  firebase_firestore_util_executor_std
+  firebase_firestore_util_async_std
   SOURCES
+    async_queue.cc
+    async_queue.h
     executor_std.cc
     executor_std.h
     executor.h
@@ -132,10 +134,11 @@ cc_library(
   EXCLUDE_FROM_ALL
 )
 
-if(HAVE_LIBDISPATCH)
 cc_library(
-  firebase_firestore_util_executor_libdispatch
+  firebase_firestore_util_async_libdispatch
   SOURCES
+    async_queue.cc
+    async_queue.h
     executor_libdispatch.mm
     executor_libdispatch.h
     executor.h
@@ -150,14 +153,14 @@ endif()
 
 if(HAVE_LIBDISPATCH)
   set(
-    FIREBASE_FIRESTORE_UTIL_EXECUTOR
-    firebase_firestore_util_executor_libdispatch
+    FIREBASE_FIRESTORE_UTIL_ASYNC
+    firebase_firestore_util_async_libdispatch
   )
 
 else()
   set(
-    FIREBASE_FIRESTORE_UTIL_EXECUTOR
-    firebase_firestore_util_executor_std
+    FIREBASE_FIRESTORE_UTIL_ASYNC
+    firebase_firestore_util_async_std
   )
 
 endif()
@@ -173,8 +176,6 @@ configure_file(
 cc_library(
   firebase_firestore_util
   SOURCES
-    async_queue.cc
-    async_queue.h
     autoid.cc
     autoid.h
     bits.cc
@@ -207,7 +208,7 @@ cc_library(
   DEPENDS
     absl_base
     firebase_firestore_util_base
-    ${FIREBASE_FIRESTORE_UTIL_EXECUTOR}
+    ${FIREBASE_FIRESTORE_UTIL_ASYNC}
     ${FIREBASE_FIRESTORE_UTIL_LOG}
     ${FIREBASE_FIRESTORE_UTIL_RANDOM}
 )

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -30,76 +30,7 @@ cc_library(
 )
 
 
-## assert and log
-
-cc_library(
-  firebase_firestore_util_log_stdio
-  SOURCES
-    hard_assert_stdio.cc
-    hard_assert.h
-    log.h
-    log_stdio.cc
-  DEPENDS
-    firebase_firestore_util_base
-    absl_base
-  EXCLUDE_FROM_ALL
-)
-
-cc_library(
-  firebase_firestore_util_log_apple
-  SOURCES
-    hard_assert.h
-    hard_assert_apple.mm
-    log.h
-    log_apple.mm
-    string_apple.h
-  DEPENDS
-    FirebaseCore
-    GoogleUtilities
-    absl_strings
-    firebase_firestore_util_base
-  EXCLUDE_FROM_ALL
-)
-
-cc_select(
-  firebase_firestore_util_log
-  APPLE   firebase_firestore_util_log_apple
-  DEFAULT firebase_firestore_util_log_stdio
-)
-
-
-## secure_random
-
-check_symbol_exists(arc4random stdlib.h HAVE_ARC4RANDOM)
-cc_library(
-  firebase_firestore_util_random_arc4random
-  SOURCES
-    secure_random_arc4random.cc
-)
-
-if(TARGET OpenSSL::Crypto)
-  get_target_property(
-    CMAKE_REQUIRED_INCLUDES
-    OpenSSL::Crypto INTERFACE_INCLUDE_DIRECTORIES
-  )
-  check_include_files(openssl/rand.h HAVE_OPENSSL_RAND_H)
-  cc_library(
-    firebase_firestore_util_random_openssl
-    SOURCES
-      secure_random_openssl.cc
-    DEPENDS
-      OpenSSL::Crypto
-  )
-endif()
-
-cc_select(
-  firebase_firestore_util_random
-  HAVE_ARC4RANDOM     firebase_firestore_util_random_arc4random
-  HAVE_OPENSSL_RAND_H firebase_firestore_util_random_openssl
-)
-
-
-## async queue
+## async
 
 check_symbol_exists(dispatch_async_f dispatch/dispatch.h HAVE_LIBDISPATCH)
 
@@ -138,6 +69,75 @@ cc_select(
   firebase_firestore_util_async
   HAVE_LIBDISPATCH firebase_firestore_util_async_libdispatch
   DEFAULT          firebase_firestore_util_async_std
+)
+
+
+## log
+
+cc_library(
+  firebase_firestore_util_log_stdio
+  SOURCES
+    hard_assert_stdio.cc
+    hard_assert.h
+    log.h
+    log_stdio.cc
+  DEPENDS
+    firebase_firestore_util_base
+    absl_base
+  EXCLUDE_FROM_ALL
+)
+
+cc_library(
+  firebase_firestore_util_log_apple
+  SOURCES
+    hard_assert.h
+    hard_assert_apple.mm
+    log.h
+    log_apple.mm
+    string_apple.h
+  DEPENDS
+    FirebaseCore
+    GoogleUtilities
+    absl_strings
+    firebase_firestore_util_base
+  EXCLUDE_FROM_ALL
+)
+
+cc_select(
+  firebase_firestore_util_log
+  APPLE   firebase_firestore_util_log_apple
+  DEFAULT firebase_firestore_util_log_stdio
+)
+
+
+## random
+
+check_symbol_exists(arc4random stdlib.h HAVE_ARC4RANDOM)
+cc_library(
+  firebase_firestore_util_random_arc4random
+  SOURCES
+    secure_random_arc4random.cc
+)
+
+if(TARGET OpenSSL::Crypto)
+  get_target_property(
+    CMAKE_REQUIRED_INCLUDES
+    OpenSSL::Crypto INTERFACE_INCLUDE_DIRECTORIES
+  )
+  check_include_files(openssl/rand.h HAVE_OPENSSL_RAND_H)
+  cc_library(
+    firebase_firestore_util_random_openssl
+    SOURCES
+      secure_random_openssl.cc
+    DEPENDS
+      OpenSSL::Crypto
+  )
+endif()
+
+cc_select(
+  firebase_firestore_util_random
+  HAVE_ARC4RANDOM     firebase_firestore_util_random_arc4random
+  HAVE_OPENSSL_RAND_H firebase_firestore_util_random_openssl
 )
 
 

--- a/Firestore/core/test/firebase/firestore/remote/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/remote/CMakeLists.txt
@@ -22,5 +22,5 @@ cc_test(
     absl_base
     firebase_firestore_protos_libprotobuf
     firebase_firestore_remote
-    firebase_firestore_util_executor_std
+    firebase_firestore_util_async_std
 )

--- a/Firestore/core/test/firebase/firestore/remote/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/remote/CMakeLists.txt
@@ -20,12 +20,6 @@ cc_test(
     serializer_test.cc
   DEPENDS
     absl_base
-    # NB: Order is important. We need to include the ffp_libprotobuf library
-    # before ff_remote, or else we'll end up with nanopb's headers earlier in
-    # the include path than libprotobuf's, which makes using libprotobuf in the
-    # test quite difficult. (protoc doesn't generate full include paths, so it
-    # includes files like this: `#include google/proto/timestamp.pb.h` which
-    # exists in both the libprotobuf path and the nanopb path.
     firebase_firestore_protos_libprotobuf
     firebase_firestore_remote
     firebase_firestore_util_executor_std

--- a/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
@@ -133,21 +133,14 @@ cc_test(
     status_test_util.h
     statusor_test.cc
     strerror_test.cc
+    string_format_apple_test.mm
     string_format_test.cc
     string_util_test.cc
     string_win_test.cc
+    type_traits_apple_test.mm
   DEPENDS
     absl_base
     absl_strings
     firebase_firestore_util
     GMock::GMock
 )
-
-if(APPLE)
-  target_sources(
-    firebase_firestore_util_test
-    PUBLIC
-      string_format_apple_test.mm
-      type_traits_apple_test.mm
-  )
-endif()

--- a/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
@@ -63,57 +63,36 @@ if(HAVE_OPENSSL_RAND_H)
   )
 endif()
 
-## executors
+
+## async
 
 cc_test(
-  firebase_firestore_util_executor_std_test
+  firebase_firestore_util_async_std_test
   SOURCES
-    executor_test.h
-    executor_test.cc
-    executor_std_test.cc
-    async_tests_util.h
-  DEPENDS
-    firebase_firestore_util_executor_std
-)
-
-if(HAVE_LIBDISPATCH)
-  cc_test(
-    firebase_firestore_util_executor_libdispatch_test
-    SOURCES
-      executor_test.h
-      executor_test.cc
-      executor_libdispatch_test.mm
-      async_tests_util.h
-    DEPENDS
-      firebase_firestore_util_executor_libdispatch
-  )
-endif()
-
-## async queue
-
-cc_test(
-  firebase_firestore_util_async_queue_std_test
-  SOURCES
-    async_queue_test.h
-    async_queue_test.cc
     async_queue_std_test.cc
+    async_queue_test.cc
+    async_queue_test.h
     async_tests_util.h
+    executor_std_test.cc
+    executor_test.cc
+    executor_test.h
   DEPENDS
-    firebase_firestore_util_executor_std
-    firebase_firestore_util
+    firebase_firestore_util_async_std
 )
 
 if(HAVE_LIBDISPATCH)
   cc_test(
-    firebase_firestore_util_async_queue_libdispatch_test
+    firebase_firestore_util_async_libdispatch_test
     SOURCES
-      async_queue_test.h
-      async_queue_test.cc
       async_queue_libdispatch_test.mm
+      async_queue_test.cc
+      async_queue_test.h
       async_tests_util.h
+      executor_libdispatch_test.mm
+      executor_test.cc
+      executor_test.h
     DEPENDS
-    firebase_firestore_util_executor_libdispatch
-    firebase_firestore_util
+      firebase_firestore_util_async_libdispatch
   )
 endif()
 

--- a/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
@@ -19,50 +19,6 @@ if(NOT MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-format-zero-length")
 endif()
 
-## assert and log
-
-if(APPLE)
-  cc_test(
-    firebase_firestore_util_log_apple_test
-    SOURCES
-      hard_assert_test.cc
-      log_test.cc
-    DEPENDS
-      firebase_firestore_util_log_apple
-  )
-endif(APPLE)
-
-cc_test(
-  firebase_firestore_util_log_stdio_test
-  SOURCES
-    hard_assert_test.cc
-    log_test.cc
-  DEPENDS
-    firebase_firestore_util_log_stdio
-)
-
-## secure random
-
-if(HAVE_ARC4RANDOM)
-  cc_test(
-    firebase_firestore_util_random_arc4random_test
-    SOURCES
-      secure_random_test.cc
-    DEPENDS
-      firebase_firestore_util_random_arc4random
-  )
-endif()
-
-if(HAVE_OPENSSL_RAND_H)
-  cc_test(
-    firebase_firestore_util_random_openssl_test
-    SOURCES
-      secure_random_test.cc
-    DEPENDS
-      firebase_firestore_util_random_openssl
-  )
-endif()
-
 
 ## async
 
@@ -95,6 +51,53 @@ if(HAVE_LIBDISPATCH)
       firebase_firestore_util_async_libdispatch
   )
 endif()
+
+
+## log
+
+if(APPLE)
+  cc_test(
+    firebase_firestore_util_log_apple_test
+    SOURCES
+      hard_assert_test.cc
+      log_test.cc
+    DEPENDS
+      firebase_firestore_util_log_apple
+  )
+endif(APPLE)
+
+cc_test(
+  firebase_firestore_util_log_stdio_test
+  SOURCES
+    hard_assert_test.cc
+    log_test.cc
+  DEPENDS
+    firebase_firestore_util_log_stdio
+)
+
+
+## random
+
+if(HAVE_ARC4RANDOM)
+  cc_test(
+    firebase_firestore_util_random_arc4random_test
+    SOURCES
+      secure_random_test.cc
+    DEPENDS
+      firebase_firestore_util_random_arc4random
+  )
+endif()
+
+if(HAVE_OPENSSL_RAND_H)
+  cc_test(
+    firebase_firestore_util_random_openssl_test
+    SOURCES
+      secure_random_test.cc
+    DEPENDS
+      firebase_firestore_util_random_openssl
+  )
+endif()
+
 
 ## main library
 

--- a/cmake/cc_rules.cmake
+++ b/cmake/cc_rules.cmake
@@ -27,7 +27,8 @@ function(cc_library name)
   set(multi DEPENDS SOURCES)
   cmake_parse_arguments(ccl "${flag}" "" "${multi}" ${ARGN})
 
-  add_library(${name} ${ccl_SOURCES})
+  remove_objc_sources(sources ${ccl_SOURCES})
+  add_library(${name} ${sources})
   add_objc_flags(${name} ccl)
   target_include_directories(
     ${name}
@@ -62,7 +63,8 @@ function(cc_test name)
 
   list(APPEND cct_DEPENDS GTest::GTest GTest::Main)
 
-  add_executable(${name} ${cct_SOURCES})
+  remove_objc_sources(sources ${cct_SOURCES})
+  add_executable(${name} ${sources})
   add_objc_flags(${name} cct)
   add_test(${name} ${name})
 
@@ -82,10 +84,28 @@ function(cc_binary name)
   set(multi DEPENDS SOURCES)
   cmake_parse_arguments(ccb "" "" "${multi}" ${ARGN})
 
-  add_executable(${name} ${ccb_SOURCES})
+  remove_objc_sources(sources ${ccb_SOURCES})
+  add_executable(${name} ${sources})
+  add_objc_flags(${name} ccb)
 
   target_include_directories(${name} PUBLIC ${FIREBASE_SOURCE_DIR})
   target_link_libraries(${name} ${ccb_DEPENDS})
+endfunction()
+
+# remove_objc_sources(output_var sources...)
+#
+# Removes Objective-C/C++ sources from the given sources if not on an Apple
+# platform. Stores the resulting list in the variable named by `output_var`.
+function(remove_objc_sources output_var)
+  unset(sources)
+  foreach(source ${ARGN})
+    get_filename_component(ext ${source} EXT)
+    if(NOT APPLE AND ((ext STREQUAL ".m") OR (ext STREQUAL ".mm")))
+      continue()
+    endif()
+    list(APPEND sources ${source})
+  endforeach()
+  set(${output_var} ${sources} PARENT_SCOPE)
 endfunction()
 
 # add_objc_flags(target sources...)

--- a/cmake/cc_rules.cmake
+++ b/cmake/cc_rules.cmake
@@ -27,7 +27,7 @@ function(cc_library name)
   set(multi DEPENDS SOURCES)
   cmake_parse_arguments(ccl "${flag}" "" "${multi}" ${ARGN})
 
-  remove_objc_sources(sources ${ccl_SOURCES})
+  maybe_remove_objc_sources(sources ${ccl_SOURCES})
   add_library(${name} ${sources})
   add_objc_flags(${name} ccl)
   target_include_directories(
@@ -103,7 +103,7 @@ function(cc_test name)
 
   list(APPEND cct_DEPENDS GTest::GTest GTest::Main)
 
-  remove_objc_sources(sources ${cct_SOURCES})
+  maybe_remove_objc_sources(sources ${cct_SOURCES})
   add_executable(${name} ${sources})
   add_objc_flags(${name} cct)
   add_test(${name} ${name})
@@ -124,7 +124,7 @@ function(cc_binary name)
   set(multi DEPENDS SOURCES)
   cmake_parse_arguments(ccb "" "" "${multi}" ${ARGN})
 
-  remove_objc_sources(sources ${ccb_SOURCES})
+  maybe_remove_objc_sources(sources ${ccb_SOURCES})
   add_executable(${name} ${sources})
   add_objc_flags(${name} ccb)
 
@@ -132,11 +132,11 @@ function(cc_binary name)
   target_link_libraries(${name} ${ccb_DEPENDS})
 endfunction()
 
-# remove_objc_sources(output_var sources...)
+# maybe_remove_objc_sources(output_var sources...)
 #
 # Removes Objective-C/C++ sources from the given sources if not on an Apple
 # platform. Stores the resulting list in the variable named by `output_var`.
-function(remove_objc_sources output_var)
+function(maybe_remove_objc_sources output_var)
   unset(sources)
   foreach(source ${ARGN})
     get_filename_component(ext ${source} EXT)


### PR DESCRIPTION
Our current platform-specific libraries have a bunch of problems that this PR solves.

Added a `cc_select` rule, which declares a proper CMake INTERFACE library representing each portability grouping and makes the chosen implementation a dependency of the rule. This makes it possible to refer to these as regular library dependencies (including referring to them out of declaration order). This eliminates the special variables per-grouping, makes the choice much more concise to specify, and mirrors the way we can use `select()` in bazel/blaze.

Also added support for just directly using Objective-C++ sources in our libraries, filtering them out if they don't apply.

Finally, merged the async queue and executor libraries to fix the potential for confusion during testing on macOS: `firebase_firestore_util_async_std_test -> firebase_firestore_util -> firebase_firestore_util_executor_libdispatch`. We intend these libraries to be mutually exclusive and they shouldn't ever be linked into the same library.

Note that taken together these seem like a big change, but if you review a commit-at-a-time it makes more sense.