### PR TITLE
Don't look up TargetId in notifyLocalViewChanges

### DIFF
--- a/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
@@ -710,7 +710,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, NO));
   FSTAssertContains(FSTTestDoc("foo/baz", 0, @{@"foo" : @"baz"}, YES));
 
-  [self notifyLocalViewChanges:FSTTestViewChanges(query, @[ @"foo/bar", @"foo/baz" ], @[])];
+  [self notifyLocalViewChanges:FSTTestViewChanges(targetID, @[ @"foo/bar", @"foo/baz" ], @[])];
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, NO),
                                                   @[], @[ @(targetID) ])];
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(FSTTestDoc("foo/baz", 2, @{@"foo" : @"baz"}, NO),
@@ -720,7 +720,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, NO));
   FSTAssertContains(FSTTestDoc("foo/baz", 2, @{@"foo" : @"baz"}, NO));
 
-  [self notifyLocalViewChanges:FSTTestViewChanges(query, @[], @[ @"foo/bar", @"foo/baz" ])];
+  [self notifyLocalViewChanges:FSTTestViewChanges(targetID, @[], @[ @"foo/bar", @"foo/baz" ])];
   [self.localStore releaseQuery:query];
   [self collectGarbage];
 

--- a/Firestore/Example/Tests/Util/FSTHelpers.h
+++ b/Firestore/Example/Tests/Util/FSTHelpers.h
@@ -295,7 +295,7 @@ FSTRemoteEvent *FSTTestUpdateRemoteEvent(FSTMaybeDocument *doc,
                                          NSArray<NSNumber *> *removedFromTargets);
 
 /** Creates a test view changes. */
-FSTLocalViewChanges *FSTTestViewChanges(FSTQuery *query,
+FSTLocalViewChanges *FSTTestViewChanges(FSTTargetID targetID,
                                         NSArray<NSString *> *addedKeys,
                                         NSArray<NSString *> *removedKeys);
 

--- a/Firestore/Example/Tests/Util/FSTHelpers.mm
+++ b/Firestore/Example/Tests/Util/FSTHelpers.mm
@@ -430,7 +430,7 @@ NSData *_Nullable FSTTestResumeTokenFromSnapshotVersion(FSTTestSnapshotVersion s
   return [snapshotString dataUsingEncoding:NSUTF8StringEncoding];
 }
 
-FSTLocalViewChanges *FSTTestViewChanges(FSTQuery *query,
+FSTLocalViewChanges *FSTTestViewChanges(FSTTargetID targetID,
                                         NSArray<NSString *> *addedKeys,
                                         NSArray<NSString *> *removedKeys) {
   DocumentKeySet added;
@@ -441,9 +441,9 @@ FSTLocalViewChanges *FSTTestViewChanges(FSTQuery *query,
   for (NSString *keyPath in removedKeys) {
     removed = removed.insert(testutil::Key(util::MakeStringView(keyPath)));
   }
-  return [FSTLocalViewChanges changesForQuery:query
-                                    addedKeys:std::move(added)
-                                  removedKeys:std::move(removed)];
+  return [FSTLocalViewChanges changesForTarget:targetID
+                                     addedKeys:std::move(added)
+                                   removedKeys:std::move(removed)];
 }
 
 NS_ASSUME_NONNULL_END

--- a/Firestore/Source/Core/FSTSyncEngine.mm
+++ b/Firestore/Source/Core/FSTSyncEngine.mm
@@ -439,7 +439,8 @@ static const FSTListenSequenceNumber kIrrelevantSequenceNumber = -1;
         if (viewChange.snapshot) {
           [newSnapshots addObject:viewChange.snapshot];
           FSTLocalViewChanges *docChanges =
-              [FSTLocalViewChanges changesForViewSnapshot:viewChange.snapshot];
+              [FSTLocalViewChanges changesForViewSnapshot:viewChange.snapshot
+                                             withTargetID:queryView.targetID];
           [documentChangesInAllViews addObject:docChanges];
         }
       }];

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -352,15 +352,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)notifyLocalViewChanges:(NSArray<FSTLocalViewChanges *> *)viewChanges {
   self.persistence.run("NotifyLocalViewChanges", [&]() {
     FSTReferenceSet *localViewReferences = self.localViewReferences;
-    for (FSTLocalViewChanges *view in viewChanges) {
-      FSTQueryData *queryData = [self.queryCache queryDataForQuery:view.query];
-      HARD_ASSERT(queryData, "Local view changes contain unallocated query.");
-      FSTTargetID targetID = queryData.targetID;
-      for (const DocumentKey &key : view.removedKeys) {
-        [self->_persistence.referenceDelegate removeReference:key target:targetID];
-      }
-      [localViewReferences addReferencesToKeys:view.addedKeys forID:targetID];
-      [localViewReferences removeReferencesToKeys:view.removedKeys forID:targetID];
+    for (FSTLocalViewChanges *viewChange in viewChanges) {
+      [localViewReferences addReferencesToKeys:viewChange.addedKeys forID:viewChange.targetID];
+      [localViewReferences removeReferencesToKeys:viewChange.removedKeys forID:viewChange.targetID];
     }
   });
 }

--- a/Firestore/Source/Local/FSTLocalViewChanges.h
+++ b/Firestore/Source/Local/FSTLocalViewChanges.h
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import "Firestore/Source/Core/FSTTypes.h"
+
 #include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
 
 @class FSTDocumentSet;
@@ -33,15 +35,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface FSTLocalViewChanges : NSObject
 
-+ (instancetype)changesForQuery:(FSTQuery *)query
-                      addedKeys:(firebase::firestore::model::DocumentKeySet)addedKeys
-                    removedKeys:(firebase::firestore::model::DocumentKeySet)removedKeys;
++ (instancetype)changesForTarget:(FSTTargetID)targetID
+                       addedKeys:(firebase::firestore::model::DocumentKeySet)addedKeys
+                     removedKeys:(firebase::firestore::model::DocumentKeySet)removedKeys;
 
-+ (instancetype)changesForViewSnapshot:(FSTViewSnapshot *)viewSnapshot;
++ (instancetype)changesForViewSnapshot:(FSTViewSnapshot *)viewSnapshot
+                          withTargetID:(FSTTargetID)targetID;
 
 - (id)init NS_UNAVAILABLE;
 
-@property(nonatomic, strong, readonly) FSTQuery *query;
+@property(readonly) FSTTargetID targetID;
 
 - (const firebase::firestore::model::DocumentKeySet &)addedKeys;
 - (const firebase::firestore::model::DocumentKeySet &)removedKeys;

--- a/Firestore/Source/Local/FSTLocalViewChanges.mm
+++ b/Firestore/Source/Local/FSTLocalViewChanges.mm
@@ -18,6 +18,7 @@
 
 #include <utility>
 
+#import "FSTTypes.h"
 #import "Firestore/Source/Core/FSTViewSnapshot.h"
 #import "Firestore/Source/Model/FSTDocument.h"
 
@@ -26,9 +27,9 @@ using firebase::firestore::model::DocumentKeySet;
 NS_ASSUME_NONNULL_BEGIN
 
 @interface FSTLocalViewChanges ()
-- (instancetype)initWithQuery:(FSTQuery *)query
-                    addedKeys:(DocumentKeySet)addedKeys
-                  removedKeys:(DocumentKeySet)removedKeys NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithTarget:(FSTTargetID)targetID
+                     addedKeys:(DocumentKeySet)addedKeys
+                   removedKeys:(DocumentKeySet)removedKeys NS_DESIGNATED_INITIALIZER;
 @end
 
 @implementation FSTLocalViewChanges {
@@ -36,7 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
   DocumentKeySet _removedKeys;
 }
 
-+ (instancetype)changesForViewSnapshot:(FSTViewSnapshot *)viewSnapshot {
++ (instancetype)changesForViewSnapshot:(FSTViewSnapshot *)viewSnapshot
+                          withTargetID:(FSTTargetID)targetID {
   DocumentKeySet addedKeys;
   DocumentKeySet removedKeys;
 
@@ -56,25 +58,25 @@ NS_ASSUME_NONNULL_BEGIN
     }
   }
 
-  return [self changesForQuery:viewSnapshot.query
-                     addedKeys:std::move(addedKeys)
-                   removedKeys:std::move(removedKeys)];
+  return [self changesForTarget:targetID
+                      addedKeys:std::move(addedKeys)
+                    removedKeys:std::move(removedKeys)];
 }
 
-+ (instancetype)changesForQuery:(FSTQuery *)query
-                      addedKeys:(DocumentKeySet)addedKeys
-                    removedKeys:(DocumentKeySet)removedKeys {
-  return [[FSTLocalViewChanges alloc] initWithQuery:query
-                                          addedKeys:std::move(addedKeys)
-                                        removedKeys:std::move(removedKeys)];
++ (instancetype)changesForTarget:(FSTTargetID)targetID
+                       addedKeys:(DocumentKeySet)addedKeys
+                     removedKeys:(DocumentKeySet)removedKeys {
+  return [[FSTLocalViewChanges alloc] initWithTarget:targetID
+                                           addedKeys:std::move(addedKeys)
+                                         removedKeys:std::move(removedKeys)];
 }
 
-- (instancetype)initWithQuery:(FSTQuery *)query
-                    addedKeys:(DocumentKeySet)addedKeys
-                  removedKeys:(DocumentKeySet)removedKeys {
+- (instancetype)initWithTarget:(FSTTargetID)targetID
+                     addedKeys:(DocumentKeySet)addedKeys
+                   removedKeys:(DocumentKeySet)removedKeys {
   self = [super init];
   if (self) {
-    _query = query;
+    _targetID = targetID;
     _addedKeys = std::move(addedKeys);
     _removedKeys = std::move(removedKeys);
   }


### PR DESCRIPTION
Port of https://github.com/firebase/firebase-js-sdk/pull/1065

This PR removes a QueryData read from notifyLocalViewChanges. This read happened for every target update and was merely used to look up the target ID.