### PR TITLE
Combine firebase_firestore_util_base and _log

### DIFF
--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -114,6 +114,7 @@ cc_library(
   SOURCES
     secure_random.h
     secure_random_arc4random.cc
+  EXCLUDE_FROM_ALL
 )
 
 if(TARGET OpenSSL::Crypto)
@@ -129,6 +130,7 @@ if(TARGET OpenSSL::Crypto)
       secure_random_openssl.cc
     DEPENDS
       OpenSSL::Crypto
+    EXCLUDE_FROM_ALL
   )
 endif()
 

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -76,7 +76,6 @@ cc_library(
     string_win.cc
     string_win.h
   DEPENDS
-    firebase_firestore_util_base
     absl_base
     absl_strings
   EXCLUDE_FROM_ALL
@@ -97,7 +96,6 @@ cc_library(
     GoogleUtilities
     absl_base
     absl_strings
-    firebase_firestore_util_base
   EXCLUDE_FROM_ALL
 )
 

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -19,16 +19,6 @@
 include(CheckSymbolExists)
 include(CheckIncludeFiles)
 
-cc_library(
-  firebase_firestore_util_base
-  SOURCES
-    string_format.cc
-    string_format.h
-  DEPENDS
-    absl_base
-    absl_strings
-)
-
 
 ## async
 
@@ -45,7 +35,7 @@ cc_library(
   DEPENDS
     absl_bad_optional_access
     absl_optional
-    firebase_firestore_util_log
+    firebase_firestore_util_base
   EXCLUDE_FROM_ALL
 )
 
@@ -61,7 +51,7 @@ cc_library(
     absl_bad_optional_access
     absl_optional
     absl_strings
-    firebase_firestore_util_log
+    firebase_firestore_util_base
   EXCLUDE_FROM_ALL
 )
 
@@ -72,41 +62,49 @@ cc_select(
 )
 
 
-## log
+## base
 
 cc_library(
-  firebase_firestore_util_log_stdio
+  firebase_firestore_util_base_stdio
   SOURCES
     hard_assert_stdio.cc
     hard_assert.h
     log.h
     log_stdio.cc
+    string_format.cc
+    string_format.h
+    string_win.cc
+    string_win.h
   DEPENDS
     firebase_firestore_util_base
     absl_base
+    absl_strings
   EXCLUDE_FROM_ALL
 )
 
 cc_library(
-  firebase_firestore_util_log_apple
+  firebase_firestore_util_base_apple
   SOURCES
     hard_assert.h
     hard_assert_apple.mm
     log.h
     log_apple.mm
     string_apple.h
+    string_format.cc
+    string_format.h
   DEPENDS
     FirebaseCore
     GoogleUtilities
+    absl_base
     absl_strings
     firebase_firestore_util_base
   EXCLUDE_FROM_ALL
 )
 
 cc_select(
-  firebase_firestore_util_log
-  APPLE   firebase_firestore_util_log_apple
-  DEFAULT firebase_firestore_util_log_stdio
+  firebase_firestore_util_base
+  APPLE   firebase_firestore_util_base_apple
+  DEFAULT firebase_firestore_util_base_stdio
 )
 
 
@@ -178,13 +176,10 @@ cc_library(
     strerror.h
     string_util.cc
     string_util.h
-    string_win.cc
-    string_win.h
     type_traits.h
   DEPENDS
     absl_base
     firebase_firestore_util_async
     firebase_firestore_util_base
-    firebase_firestore_util_log
     firebase_firestore_util_random
 )

--- a/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
@@ -53,26 +53,26 @@ if(HAVE_LIBDISPATCH)
 endif()
 
 
-## log
+## base
 
 if(APPLE)
   cc_test(
-    firebase_firestore_util_log_apple_test
+    firebase_firestore_util_base_apple_test
     SOURCES
       hard_assert_test.cc
       log_test.cc
     DEPENDS
-      firebase_firestore_util_log_apple
+      firebase_firestore_util_base_apple
   )
 endif(APPLE)
 
 cc_test(
-  firebase_firestore_util_log_stdio_test
+  firebase_firestore_util_base_stdio_test
   SOURCES
     hard_assert_test.cc
     log_test.cc
   DEPENDS
-    firebase_firestore_util_log_stdio
+    firebase_firestore_util_base_stdio
 )
 
 


### PR DESCRIPTION
I'll soon be adding `util_filesystem` that works similarly to and is a peer of `util_async` and `util_random`.

`util_filesystem_win` needs access to `string_win.{h,cc}` so these need to move out of the high-level `util` library. I can't make string_win part of the existing `util_base` target though because it uses `HARD_ASSERT`.

I don't see much value in keeping `util_base` and `util_log` separate and if I combine them I can move string_win into there.