### PR TITLE
Rewrite Path to use native path character type

### DIFF
--- a/Firestore/core/src/firebase/firestore/util/path.cc
+++ b/Firestore/core/src/firebase/firestore/util/path.cc
@@ -16,6 +16,8 @@
 
 #include "Firestore/core/src/firebase/firestore/util/path.h"
 
+#include <algorithm>
+
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 #include "Firestore/core/src/firebase/firestore/util/string_win.h"
 #include "absl/strings/ascii.h"

--- a/Firestore/core/src/firebase/firestore/util/path.cc
+++ b/Firestore/core/src/firebase/firestore/util/path.cc
@@ -16,6 +16,8 @@
 
 #include "Firestore/core/src/firebase/firestore/util/path.h"
 
+#include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
+#include "Firestore/core/src/firebase/firestore/util/string_win.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/string_view.h"
 
@@ -23,87 +25,214 @@ namespace firebase {
 namespace firestore {
 namespace util {
 
+constexpr size_t Path::npos;
+constexpr Path::char_type Path::kPreferredSeparator;
+
 namespace {
 
-static constexpr absl::string_view::size_type npos = absl::string_view::npos;
-
-/** Returns the given path with its leading drive letter removed. */
-inline absl::string_view StripDriveLetter(absl::string_view path) {
+/**
+ * Returns the offset within the given path that skips the leading drive letter.
+ * If there is no drive letter, returns zero.
+ */
+size_t StripDriveLetter(const Path::char_type* path, size_t size) {
 #if defined(_WIN32)
-  if (path.size() >= 2 && path[1] == ':' && absl::ascii_isalpha(path[0])) {
-    return path.substr(2);
+  if (size >= 2 && path[1] == L':') {
+    wchar_t drive_letter = path[0];
+    if (drive_letter <= 0xFF &&
+        absl::ascii_isalpha(static_cast<unsigned char>(drive_letter))) {
+      return 2;
+    }
   }
-  return path;
+  return 0;
 
 #else
-  return path;
+  (void)path;
+  (void)size;
+  return 0;
 #endif  // defined(_WIN32)
 }
 
 /** Returns true if the given character is a pathname separator. */
-inline bool IsSeparator(char c) {
+inline bool IsSeparator(Path::char_type c) {
 #if defined(_WIN32)
-  return c == '/' || c == '\\';
+  return c == L'/' || c == L'\\';
 #else
   return c == '/';
 #endif  // defined(_WIN32)
 }
 
+bool IsAbsolute(const Path::char_type* path, size_t size) {
+  size_t offset = StripDriveLetter(path, size);
+  return size >= offset && IsSeparator(path[offset]);
+}
+
+size_t LastNonSeparator(const Path::char_type* path, size_t size) {
+  if (size == 0) return Path::npos;
+
+  size_t i = size;
+  for (; i-- > 0;) {
+    if (!IsSeparator(path[i])) {
+      return i;
+    }
+  }
+  return Path::npos;
+}
+
+size_t LastSeparator(const Path::char_type* path, size_t size) {
+  if (size == 0) return Path::npos;
+
+  size_t i = size;
+  for (; i-- > 0;) {
+    if (IsSeparator(path[i])) {
+      return i;
+    }
+  }
+  return Path::npos;
+}
+
 }  // namespace
 
-absl::string_view Path::Basename(absl::string_view pathname) {
-  size_t slash = pathname.find_last_of('/');
+Path Path::FromUtf8(absl::string_view utf8_pathname) {
+#if defined(_WIN32)
+  return Path{Utf8ToNative(utf8_pathname)};
 
+#else
+  return Path{std::string{utf8_pathname}};
+#endif  // defined(_WIN32)
+}
+
+#if defined(_WIN32)
+Path Path::FromUtf16(const wchar_t* path, size_t size) {
+  return Path{string_type{path, size}};
+}
+#endif
+
+#if defined(_WIN32)
+std::string Path::ToString() const {
+  return NativeToUtf8(pathname_);
+}
+#else
+const std::string& Path::ToString() const {
+  return pathname_;
+}
+#endif  // defined(_WIN32)
+
+Path Path::Basename() const {
+  size_t slash = LastSeparator(c_str(), size());
   if (slash == npos) {
     // No path separator found => the whole string.
-    return pathname;
+    return *this;
   }
 
   // Otherwise everything after the slash is the basename (even if empty string)
-  return pathname.substr(slash + 1);
+  size_t start = slash + 1;
+  return Path{pathname_.substr(start)};
 }
 
-absl::string_view Path::Dirname(absl::string_view pathname) {
-  size_t last_slash = pathname.find_last_of('/');
-
+Path Path::Dirname() const {
+  size_t last_slash = LastSeparator(c_str(), size());
   if (last_slash == npos) {
     // No path separator found => empty string. Conformance with POSIX would
     // have us return "." here.
-    return pathname.substr(0, 0);
+    return Path{string_type{}};
   }
 
   // Collapse runs of slashes.
-  size_t nonslash = pathname.find_last_not_of('/', last_slash);
-  if (nonslash == npos) {
+  size_t non_slash = LastNonSeparator(c_str(), last_slash);
+  if (non_slash == npos) {
     // All characters preceding the last path separator are slashes
-    return pathname.substr(0, 1);
+    return Path{pathname_.substr(0, 1)};
   }
 
-  last_slash = nonslash + 1;
-
   // Otherwise everything up to the slash is the parent directory
-  return pathname.substr(0, last_slash);
+  last_slash = non_slash + 1;
+  return Path{pathname_.substr(0, last_slash)};
 }
 
-bool Path::IsAbsolute(absl::string_view path) {
-  path = StripDriveLetter(path);
-  return !path.empty() && IsSeparator(path.front());
+bool Path::IsAbsolute() const {
+  return util::IsAbsolute(c_str(), size());
 }
 
-void Path::JoinAppend(std::string* base, absl::string_view path) {
-  if (IsAbsolute(path)) {
-    base->assign(path.data(), path.size());
+Path Path::AppendUtf8(absl::string_view path) const {
+  Path result{*this};
+  result.MutableAppendUtf8(path);
+  return result;
+}
+
+void Path::MutableAppendSegment(const char_type* path, size_t size) {
+  if (util::IsAbsolute(path, size)) {
+    pathname_.assign(path, size);
 
   } else {
-    size_t nonslash = base->find_last_not_of('/');
-    if (nonslash != npos) {
-      base->resize(nonslash + 1);
-      base->push_back('/');
+    size_t non_slash = LastNonSeparator(pathname_.c_str(), pathname_.size());
+    if (non_slash != npos) {
+      pathname_.resize(non_slash + 1);
+      pathname_.push_back(kPreferredSeparator);
     }
 
     // If path started with a slash we'd treat it as absolute above
-    base->append(path.data(), path.size());
+    pathname_.append(path, size);
   }
+}
+
+void Path::MutableAppendSegmentUtf8(absl::string_view path) {
+#if defined(_WIN32)
+  Path segment = Path::FromUtf8(path);
+  MutableAppendSegment(segment.c_str(), segment.size());
+
+#else
+  MutableAppendSegment(path.data(), path.size());
+#endif
+}
+
+#if defined(_WIN32)
+Path::string_type Path::CanonicalPath() const {
+  if (pathname_.empty()) {
+    return pathname_;
+  }
+
+  // Remove trailing separators, but take care not to remove the trailing slash
+  // in a root path name (which can have a drive letter).
+  std::wstring copy{pathname_};
+  size_t min = StripDriveLetter(copy.c_str(), copy.size());
+  if (min < copy.size() && IsSeparator(copy[min])) {
+    min += 1;
+  }
+
+  size_t non_slash = LastNonSeparator(copy.c_str(), copy.size());
+  if (non_slash != npos) {
+    size_t last_slash = std::max(non_slash + 1, min);
+    copy.resize(last_slash);
+  }
+
+  // Convert separators to canonical separators.
+  std::replace(copy.begin(), copy.end(), L'/', kPreferredSeparator);
+
+  // Convert to lowercase. This relies on C++11 semantics of std::basic_string,
+  // namely that:
+  //   * s.c_str(), s.data(), and &s[0] are all aliases for each other;
+  //   * strings are always contiguous and null terminated; and
+  //   * Accessing s[s.size()] is valid and is the null terminator.
+  errno_t error = _wcslwr_s(&copy[0], copy.size() + 1);
+  HARD_ASSERT(error == 0);
+
+  return copy;
+}
+
+#else
+absl::string_view Path::CanonicalPath() const {
+  size_t non_slash = LastNonSeparator(c_str(), size());
+  if (non_slash == npos) {
+    return pathname_;
+  }
+
+  size_t last_slash = non_slash + 1;
+  return absl::string_view{c_str(), last_slash};
+}
+#endif  // defined(_WIN32)
+
+bool operator==(const Path& lhs, const Path& rhs) {
+  return lhs.CanonicalPath() == rhs.CanonicalPath();
 }
 
 }  // namespace util

--- a/Firestore/core/src/firebase/firestore/util/path.h
+++ b/Firestore/core/src/firebase/firestore/util/path.h
@@ -42,15 +42,11 @@ class Path {
  public:
 #if defined(_WIN32)
   using char_type = wchar_t;
-  using string_type = std::wstring;
-
-  static constexpr char_type kPreferredSeparator = L'\\';
 #else
   using char_type = char;
-  using string_type = std::string;
+#endif
 
-  static constexpr char_type kPreferredSeparator = '/';
-#endif  // defined(_WIN32)
+  using string_type = std::basic_string<char_type>;
 
   static constexpr size_t npos = static_cast<size_t>(-1);
 
@@ -92,9 +88,9 @@ class Path {
   }
 
 #if defined(_WIN32)
-  std::string ToString() const;
+  std::string ToUtf8String() const;
 #else
-  const std::string& ToString() const;
+  const std::string& ToUtf8String() const;
 #endif  // defined(_WIN32)
 
 #if defined(__OBJC__)
@@ -164,15 +160,9 @@ class Path {
   }
 
  private:
-  explicit Path(string_type&& native_pathname) {
-    pathname_ = std::move(native_pathname);
+  explicit Path(string_type&& native_pathname)
+      : pathname_{std::move(native_pathname)} {
   }
-
-#if defined(_WIN32)
-  string_type CanonicalPath() const;
-#else
-  absl::string_view CanonicalPath() const;
-#endif
 
   /**
    * If `path` is relative, appends it to `*this`. If `path` is absolute,
@@ -194,11 +184,11 @@ class Path {
    */
   template <typename P1, typename... P>
   void MutableAppendUtf8(const P1& path, const P&... rest) {
-    MutableAppendSegmentUtf8(path);
+    MutableAppendUtf8Segment(path);
     MutableAppendUtf8(rest...);
   }
-  void MutableAppendSegmentUtf8(absl::string_view path);
-  void MutableAppendSegmentUtf8(const Path& path) {
+  void MutableAppendUtf8Segment(absl::string_view path);
+  void MutableAppendUtf8Segment(const Path& path) {
     // Allow existing Paths to be passed to Path::JoinUtf8.
     MutableAppendSegment(path.c_str(), path.size());
   }

--- a/Firestore/core/src/firebase/firestore/util/path.h
+++ b/Firestore/core/src/firebase/firestore/util/path.h
@@ -20,37 +20,129 @@
 #include <string>
 #include <utility>
 
+#include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 #include "absl/strings/string_view.h"
 
 namespace firebase {
 namespace firestore {
 namespace util {
 
-struct Path {
-  /**
-   * Returns the unqualified trailing part of the pathname, e.g. "c" for
-   * "/a/b/c".
-   */
-  static absl::string_view Basename(absl::string_view pathname);
+/**
+ * An immutable native pathname string. Paths can be absolute or relative. Paths
+ * internally maintain their filesystem-native encoding.
+ *
+ * The intent of the API is that high-level code generally just uses UTF-8-
+ * encoded string-literals or strings for the segments and constructs a
+ * filesystem-native Path using APIs like Path::JoinUtf8.
+ *
+ * Lower level code may need to construct derived Paths from values obtained
+ * from the filesystem that already are in the right encoding.
+ */
+class Path {
+ public:
+#if defined(_WIN32)
+  using char_type = wchar_t;
+  using string_type = std::wstring;
+
+  static constexpr char_type kPreferredSeparator = L'\\';
+#else
+  using char_type = char;
+  using string_type = std::string;
+
+  static constexpr char_type kPreferredSeparator = '/';
+#endif  // defined(_WIN32)
+
+  static constexpr size_t npos = static_cast<size_t>(-1);
 
   /**
-   * Returns the parent directory name, e.g. "/a/b" for "/a/b/c".
+   * Creates a new Path from a UTF-8-encoded pathname.
+   */
+  static Path FromUtf8(absl::string_view utf8_pathname);
+
+#if defined(_WIN32)
+  /**
+   * Creates a new Path from a UTF-16-encoded pathname.
+   */
+  // absl::wstring_view does not exist :-(.
+  static Path FromUtf16(const wchar_t* begin, size_t size);
+#endif
+
+#if defined(__OBJC__)
+  /**
+   * Creates a new Path from the given NSString pathname.
+   */
+  static Path FromNSString(NSString* path) {
+    return FromUtf8(MakeStringView(path));
+  }
+#endif
+
+  Path() {
+  }
+
+  const string_type& native_value() const {
+    return pathname_;
+  }
+
+  const char_type* c_str() const {
+    return pathname_.c_str();
+  }
+
+  size_t size() const {
+    return pathname_.size();
+  }
+
+#if defined(_WIN32)
+  std::string ToString() const;
+#else
+  const std::string& ToString() const;
+#endif  // defined(_WIN32)
+
+#if defined(__OBJC__)
+  NSString* ToNSString() const {
+    return WrapNSString(native_value());
+  }
+#endif
+
+  /**
+   * Returns a new Path containing the unqualified trailing part of this path,
+   * e.g. "c" for "/a/b/c".
+   */
+  Path Basename() const;
+
+  /**
+   * Returns a new Path containing the parent directory of this path, e.g.
+   * "/a/b" for "/a/b/c".
    *
    * Note:
    *   * Trailing slashes are treated as a separator between an empty path
-   *     segment and the dirname, so Dirname("/a/b/c/") is "/a/b/c".
+   *     segment and the dirname, so the Dirname of "/a/b/c/" is "/a/b/c".
    *   * Runs of more than one slash are treated as a single separator, so
-   *     Dirname("/a/b//c") is "/a/b".
-   *   * Paths are not canonicalized, so Dirname("/a//b//c") is "/a//b".
-   *   * Presently only UNIX style paths are supported (but compilation
-   *     intentionally fails on Windows to prompt implementation there).
+   *     the Dirname of "/a/b//c" is "/a/b".
+   *   * Paths are not canonicalized, so the Dirname of "/a//b//c" is "/a//b".
    */
-  static absl::string_view Dirname(absl::string_view pathname);
+  Path Dirname() const;
 
   /**
-   * Returns true if the given `pathname` is an absolute path.
+   * Returns true if this Path is an absolute path.
    */
-  static bool IsAbsolute(absl::string_view pathname);
+  bool IsAbsolute() const;
+
+  /**
+   * Returns a new Path with the given UTF-8 encoded path segment appended,
+   * as if by calling `Append(Path::FromUtf8(path))`.
+   */
+  Path AppendUtf8(absl::string_view path) const;
+  Path AppendUtf8(const char* path, size_t size) const {
+    return AppendUtf8(absl::string_view{path, size});
+  }
+
+#if defined(_WIN32)
+  Path AppendUtf16(const wchar_t* path, size_t size) const {
+    Path result{*this};
+    result.MutableAppendSegment(path, size);
+    return result;
+  }
+#endif
 
   /**
    * Returns the paths separated by path separators.
@@ -59,39 +151,72 @@ struct Path {
    *     value. Otherwise the first argument is copied.
    * @param paths The rest of the path segments.
    */
-  template <typename S1, typename... SA>
-  static std::string Join(S1&& base, const SA&... paths) {
-    std::string result{std::forward<S1>(base)};
-    JoinAppend(&result, paths...);
+  template <typename P1, typename... PA>
+  static Path JoinUtf8(P1&& base, const PA&... paths) {
+    Path result = Path::FromUtf8(base);
+    result.MutableAppendUtf8(paths...);
     return result;
   }
 
-  /**
-   * Returns the paths separated by path separators.
-   */
-  static std::string Join() {
-    return {};
+  friend bool operator==(const Path& lhs, const Path& rhs);
+  friend bool operator!=(const Path& lhs, const Path& rhs) {
+    return !(lhs == rhs);
   }
 
  private:
+  explicit Path(string_type&& native_pathname) {
+    pathname_ = std::move(native_pathname);
+  }
+
+#if defined(_WIN32)
+  string_type CanonicalPath() const;
+#else
+  absl::string_view CanonicalPath() const;
+#endif
+
   /**
-   * Joins the given base path with a suffix. If `path` is relative, appends it
-   * to the given base path. If `path` is absolute, replaces `base`.
+   * If `path` is relative, appends it to `*this`. If `path` is absolute,
+   * replaces `*this`.
    */
-  static void JoinAppend(std::string* base, absl::string_view path);
-
-  template <typename... S>
-  static void JoinAppend(std::string* base,
-                         absl::string_view path,
-                         const S&... rest) {
-    JoinAppend(base, path);
-    JoinAppend(base, rest...);
+  template <typename... P>
+  void MutableAppend(const Path& path, const P&... rest) {
+    MutableAppendSegment(path.c_str(), path.size());
+    MutableAppend(rest...);
   }
-
-  static void JoinAppend(std::string* base) {
+  void MutableAppend() {
     // Recursive base case; nothing to do.
-    (void)base;
   }
+  void MutableAppendSegment(const char_type* path, size_t size);
+
+  /**
+   * If `path` is relative, appends it to `*this`. If `path` is absolute,
+   * replaces `*this`.
+   */
+  template <typename P1, typename... P>
+  void MutableAppendUtf8(const P1& path, const P&... rest) {
+    MutableAppendSegmentUtf8(path);
+    MutableAppendUtf8(rest...);
+  }
+  void MutableAppendSegmentUtf8(absl::string_view path);
+  void MutableAppendSegmentUtf8(const Path& path) {
+    // Allow existing Paths to be passed to Path::JoinUtf8.
+    MutableAppendSegment(path.c_str(), path.size());
+  }
+  void MutableAppendUtf8() {
+    // Recursive base case; nothing to do.
+  }
+
+  /**
+   * Returns a copy of the given path.
+   *
+   * This non-public variant of FromUtf8 allows JoinUtf8 to take a Path as its
+   * first argument.
+   */
+  static Path FromUtf8(const Path& path) {
+    return path;
+  }
+
+  string_type pathname_;
 };
 
 }  // namespace util

--- a/Firestore/core/test/firebase/firestore/util/path_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/path_test.cc
@@ -58,9 +58,46 @@ namespace util {
 //   * POSIX is more complicated than we need
 //   * std::filesystem is still too experimental (as of 2018-06-05)
 
-#define EXPECT_BASENAME_EQ(expected, source)                  \
-  do {                                                        \
-    EXPECT_EQ(std::string{expected}, Path::Basename(source)); \
+#define EXPECT_PATH_EQ(expected, actual)         \
+  do {                                           \
+    EXPECT_EQ(Path::FromUtf8(expected), actual); \
+  } while (0)
+
+#define EXPECT_PATH_EQ2(expected, actual)                        \
+  do {                                                           \
+    EXPECT_EQ(Path::FromUtf8(expected), Path::FromUtf8(actual)); \
+  } while (0)
+
+#define EXPECT_PATH_NE2(expected, actual)                        \
+  do {                                                           \
+    EXPECT_NE(Path::FromUtf8(expected), Path::FromUtf8(actual)); \
+  } while (0)
+
+TEST(PathTest, Equals) {
+  EXPECT_PATH_EQ2("", "");
+  EXPECT_PATH_EQ2("/", "/");
+  EXPECT_PATH_EQ2("a", "a/");  // Trailing slashes removed
+
+  EXPECT_PATH_NE2("", "/");
+  EXPECT_PATH_NE2("/", "a");
+  EXPECT_PATH_NE2("/a", "a");
+  EXPECT_PATH_NE2("/a", "/b");
+  EXPECT_PATH_NE2("/a", "/aa");
+  EXPECT_PATH_NE2("/a/b", "/a/");
+  EXPECT_PATH_NE2("/a/b", "/a//b");  // Internal slashes not removed
+
+#if defined(_WIN32)
+  EXPECT_PATH_EQ2("/", "\\");
+  EXPECT_PATH_EQ2("c:", "C:");
+  EXPECT_PATH_EQ2("C:/", "C:\\");
+  EXPECT_PATH_EQ2("c:\\", "C:\\");
+  EXPECT_PATH_EQ2("c:\\", "C:\\\\/\\");
+#endif
+}
+
+#define EXPECT_BASENAME_EQ(expected, source)                     \
+  do {                                                           \
+    EXPECT_PATH_EQ(expected, Path::FromUtf8(source).Basename()); \
   } while (0)
 
 TEST(Path, Basename_NoSeparator) {
@@ -118,9 +155,9 @@ TEST(Path, Basename_RelativePath) {
   EXPECT_BASENAME_EQ("b", "a//.//b");
 }
 
-#define EXPECT_DIRNAME_EQ(expected, source)                  \
-  do {                                                       \
-    EXPECT_EQ(std::string{expected}, Path::Dirname(source)); \
+#define EXPECT_DIRNAME_EQ(expected, source)                     \
+  do {                                                          \
+    EXPECT_PATH_EQ(expected, Path::FromUtf8(source).Dirname()); \
   } while (0)
 
 TEST(Path, Dirname_NoSeparator) {
@@ -184,55 +221,62 @@ TEST(Path, Dirname_RelativePath) {
 }
 
 TEST(Path, IsAbsolute) {
-  EXPECT_FALSE(Path::IsAbsolute(""));
-  EXPECT_TRUE(Path::IsAbsolute("/"));
-  EXPECT_TRUE(Path::IsAbsolute("//"));
-  EXPECT_TRUE(Path::IsAbsolute("/foo"));
-  EXPECT_FALSE(Path::IsAbsolute("foo"));
-  EXPECT_FALSE(Path::IsAbsolute("foo/bar"));
+  EXPECT_FALSE(Path::FromUtf8("").IsAbsolute());
+  EXPECT_TRUE(Path::FromUtf8("/").IsAbsolute());
+  EXPECT_TRUE(Path::FromUtf8("//").IsAbsolute());
+  EXPECT_TRUE(Path::FromUtf8("/foo").IsAbsolute());
+  EXPECT_FALSE(Path::FromUtf8("foo").IsAbsolute());
+  EXPECT_FALSE(Path::FromUtf8("foo/bar").IsAbsolute());
 }
 
 TEST(Path, Join_Absolute) {
-  EXPECT_EQ("/", Path::Join("/"));
+  EXPECT_PATH_EQ("/", Path::JoinUtf8("/"));
 
-  EXPECT_EQ("/", Path::Join("", "/"));
-  EXPECT_EQ("/", Path::Join("a", "/"));
-  EXPECT_EQ("/b", Path::Join("a", "/b"));
+  EXPECT_PATH_EQ("/", Path::JoinUtf8("", "/"));
+  EXPECT_PATH_EQ("/", Path::JoinUtf8("a", "/"));
+  EXPECT_PATH_EQ("/b", Path::JoinUtf8("a", "/b"));
 
   // Alternate root names should be preserved.
-  EXPECT_EQ("//", Path::Join("a", "//"));
-  EXPECT_EQ("//b", Path::Join("a", "//b"));
-  EXPECT_EQ("///b///", Path::Join("a", "///b///"));
+  EXPECT_PATH_EQ("//", Path::JoinUtf8("a", "//"));
+  EXPECT_PATH_EQ("//b", Path::JoinUtf8("a", "//b"));
+  EXPECT_PATH_EQ("///b///", Path::JoinUtf8("a", "///b///"));
 
-  EXPECT_EQ("/", Path::Join("/", "/"));
-  EXPECT_EQ("/b", Path::Join("/", "/b"));
-  EXPECT_EQ("//b", Path::Join("//host/a", "//b"));
-  EXPECT_EQ("//b", Path::Join("//host/a/", "//b"));
+  EXPECT_PATH_EQ("/", Path::JoinUtf8("/", "/"));
+  EXPECT_PATH_EQ("/b", Path::JoinUtf8("/", "/b"));
+  EXPECT_PATH_EQ("//b", Path::JoinUtf8("//host/a", "//b"));
+  EXPECT_PATH_EQ("//b", Path::JoinUtf8("//host/a/", "//b"));
 
-  EXPECT_EQ("/", Path::Join("/", ""));
-  EXPECT_EQ("/a", Path::Join("/", "a"));
-  EXPECT_EQ("/a/b/c", Path::Join("/", "a", "b", "c"));
-  EXPECT_EQ("/a/", Path::Join("/", "a/"));
-  EXPECT_EQ("/.", Path::Join("/", "."));
-  EXPECT_EQ("/..", Path::Join("/", ".."));
+  EXPECT_PATH_EQ("/", Path::JoinUtf8("/", ""));
+  EXPECT_PATH_EQ("/a", Path::JoinUtf8("/", "a"));
+  EXPECT_PATH_EQ("/a/b/c", Path::JoinUtf8("/", "a", "b", "c"));
+  EXPECT_PATH_EQ("/a/", Path::JoinUtf8("/", "a/"));
+  EXPECT_PATH_EQ("/.", Path::JoinUtf8("/", "."));
+  EXPECT_PATH_EQ("/..", Path::JoinUtf8("/", ".."));
 }
 
 TEST(Path, Join_Relative) {
-  EXPECT_EQ("", Path::Join(""));
+  EXPECT_PATH_EQ("", Path::JoinUtf8(""));
 
-  EXPECT_EQ("", Path::Join("", "", "", ""));
-  EXPECT_EQ("a/b/c", Path::Join("a/b", "c"));
-  EXPECT_EQ("/c/d", Path::Join("a/b", "/c", "d"));
-  EXPECT_EQ("/c/d", Path::Join("a/b/", "/c", "d"));
+  EXPECT_PATH_EQ("", Path::JoinUtf8("", "", "", ""));
+  EXPECT_PATH_EQ("a/b/c", Path::JoinUtf8("a/b", "c"));
+  EXPECT_PATH_EQ("/c/d", Path::JoinUtf8("a/b", "/c", "d"));
+  EXPECT_PATH_EQ("/c/d", Path::JoinUtf8("a/b/", "/c", "d"));
 }
 
 TEST(Path, Join_Types) {
-  EXPECT_EQ("a/b", Path::Join(absl::string_view{"a"}, "b"));
-  EXPECT_EQ("a/b", Path::Join(std::string{"a"}, "b"));
+  EXPECT_PATH_EQ("a/b", Path::JoinUtf8(absl::string_view{"a"}, "b"));
+  EXPECT_PATH_EQ("a/b", Path::JoinUtf8(std::string{"a"}, "b"));
 
   std::string a_string{"a"};
-  EXPECT_EQ("a/b", Path::Join(a_string, "b"));
-  EXPECT_EQ("a", a_string);
+  EXPECT_PATH_EQ("a/b", Path::JoinUtf8(a_string, "b"));
+  EXPECT_PATH_EQ("a", Path::JoinUtf8(a_string));
+
+  EXPECT_PATH_EQ("a/b/c/d", Path::JoinUtf8(a_string, "b", Path::FromUtf8("c"),
+                                           absl::string_view{"d"}));
+
+  EXPECT_PATH_EQ("a/b/c/d",
+                 Path::JoinUtf8(Path::FromUtf8("a"), "b", Path::FromUtf8("c"),
+                                absl::string_view{"d"}));
 }
 
 }  // namespace util

--- a/Firestore/core/test/firebase/firestore/util/path_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/path_test.cc
@@ -100,7 +100,7 @@ TEST(PathTest, Equals) {
     EXPECT_PATH_EQ(expected, Path::FromUtf8(source).Basename()); \
   } while (0)
 
-TEST(Path, Basename_NoSeparator) {
+TEST(PathTest, Basename_NoSeparator) {
   // POSIX would require all of these to be ".".
   // python and libc++ agree this is "".
   EXPECT_BASENAME_EQ("", "");
@@ -110,7 +110,7 @@ TEST(Path, Basename_NoSeparator) {
   EXPECT_BASENAME_EQ("..", "..");
 }
 
-TEST(Path, Basename_LeadingSlash) {
+TEST(PathTest, Basename_LeadingSlash) {
   EXPECT_BASENAME_EQ("", "/");
   EXPECT_BASENAME_EQ("", "///");
   EXPECT_BASENAME_EQ("a", "/a");
@@ -121,7 +121,7 @@ TEST(Path, Basename_LeadingSlash) {
   EXPECT_BASENAME_EQ("..", "//..");
 }
 
-TEST(Path, Basename_IntermediateSlash) {
+TEST(PathTest, Basename_IntermediateSlash) {
   EXPECT_BASENAME_EQ("b", "/a/b");
   EXPECT_BASENAME_EQ("b", "/a//b");
   EXPECT_BASENAME_EQ("b", "//a/b");
@@ -132,7 +132,7 @@ TEST(Path, Basename_IntermediateSlash) {
   EXPECT_BASENAME_EQ("b", "//a/.//b");
 }
 
-TEST(Path, Basename_TrailingSlash) {
+TEST(PathTest, Basename_TrailingSlash) {
   // python: "a/b//" => ""
   // POSIX: "a/b//" => "b"
   // libc++ path::filename(): "a/b//" => "." (cppreference suggests "")
@@ -145,7 +145,7 @@ TEST(Path, Basename_TrailingSlash) {
   EXPECT_BASENAME_EQ("", "//a//b//");
 }
 
-TEST(Path, Basename_RelativePath) {
+TEST(PathTest, Basename_RelativePath) {
   EXPECT_BASENAME_EQ("b", "a/b");
   EXPECT_BASENAME_EQ("b", "a//b");
 
@@ -160,7 +160,7 @@ TEST(Path, Basename_RelativePath) {
     EXPECT_PATH_EQ(expected, Path::FromUtf8(source).Dirname()); \
   } while (0)
 
-TEST(Path, Dirname_NoSeparator) {
+TEST(PathTest, Dirname_NoSeparator) {
   // POSIX would require all of these to be ".".
   // python and libc++ agree this is "".
   EXPECT_DIRNAME_EQ("", "");
@@ -170,7 +170,7 @@ TEST(Path, Dirname_NoSeparator) {
   EXPECT_DIRNAME_EQ("", "..");
 }
 
-TEST(Path, Dirname_LeadingSlash) {
+TEST(PathTest, Dirname_LeadingSlash) {
   // POSIX says all "/".
   // python starts with "/" but does not strip trailing slashes.
   // libc++ path::parent_path() considers all of these be "", though
@@ -186,7 +186,7 @@ TEST(Path, Dirname_LeadingSlash) {
   EXPECT_DIRNAME_EQ("/", "//..");
 }
 
-TEST(Path, Dirname_IntermediateSlash) {
+TEST(PathTest, Dirname_IntermediateSlash) {
   EXPECT_DIRNAME_EQ("/a", "/a/b");
   EXPECT_DIRNAME_EQ("/a", "/a//b");
   EXPECT_DIRNAME_EQ("//a", "//a/b");
@@ -197,7 +197,7 @@ TEST(Path, Dirname_IntermediateSlash) {
   EXPECT_DIRNAME_EQ("//a/.", "//a/.//b");
 }
 
-TEST(Path, Dirname_TrailingSlash) {
+TEST(PathTest, Dirname_TrailingSlash) {
   // POSIX demands stripping trailing slashes before computing dirname, while
   // python and libc++ effectively seem to consider the path to contain an empty
   // path segment there.
@@ -210,7 +210,7 @@ TEST(Path, Dirname_TrailingSlash) {
   EXPECT_DIRNAME_EQ("//a//b", "//a//b//");
 }
 
-TEST(Path, Dirname_RelativePath) {
+TEST(PathTest, Dirname_RelativePath) {
   EXPECT_DIRNAME_EQ("a", "a/b");
   EXPECT_DIRNAME_EQ("a", "a//b");
 
@@ -220,7 +220,7 @@ TEST(Path, Dirname_RelativePath) {
   EXPECT_DIRNAME_EQ("a//.", "a//.//b");
 }
 
-TEST(Path, IsAbsolute) {
+TEST(PathTest, IsAbsolute) {
   EXPECT_FALSE(Path::FromUtf8("").IsAbsolute());
   EXPECT_TRUE(Path::FromUtf8("/").IsAbsolute());
   EXPECT_TRUE(Path::FromUtf8("//").IsAbsolute());
@@ -229,7 +229,7 @@ TEST(Path, IsAbsolute) {
   EXPECT_FALSE(Path::FromUtf8("foo/bar").IsAbsolute());
 }
 
-TEST(Path, Join_Absolute) {
+TEST(PathTest, Join_Absolute) {
   EXPECT_PATH_EQ("/", Path::JoinUtf8("/"));
 
   EXPECT_PATH_EQ("/", Path::JoinUtf8("", "/"));
@@ -254,7 +254,7 @@ TEST(Path, Join_Absolute) {
   EXPECT_PATH_EQ("/..", Path::JoinUtf8("/", ".."));
 }
 
-TEST(Path, Join_Relative) {
+TEST(PathTest, Join_Relative) {
   EXPECT_PATH_EQ("", Path::JoinUtf8(""));
 
   EXPECT_PATH_EQ("", Path::JoinUtf8("", "", "", ""));
@@ -263,7 +263,7 @@ TEST(Path, Join_Relative) {
   EXPECT_PATH_EQ("/c/d", Path::JoinUtf8("a/b/", "/c", "d"));
 }
 
-TEST(Path, Join_Types) {
+TEST(PathTest, Join_Types) {
   EXPECT_PATH_EQ("a/b", Path::JoinUtf8(absl::string_view{"a"}, "b"));
   EXPECT_PATH_EQ("a/b", Path::JoinUtf8(std::string{"a"}, "b"));
 


### PR DESCRIPTION
Paths now hold their platform-specific string values. On Windows, portable pathnames are UTF-16 stored in `wchar_t` arrays, but there's no `absl::wstring_view`, so filesystem APIs can't be designed to operate on `absl::string_view`.

Also, using `string_view` doesn't really save any copies in practice. For example, I need `Dirname` to create directories recursively and that needs a null-terminated string for each `mkdir` call, forcing the caller to copy.

Another option would be to have both `Path` and `PathView`. This would avoid all unnecessary copies at the expense of a more complicated implementation. Since we don't use the filesystem that intensively I'm okay with just keeping this simpler.