### PR TITLE
Travis to avoid fuzz tests with tsan

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -238,7 +238,7 @@ case "$product-$method-$platform" in
 
     # Firestore_FuzzTests_iOS require a Clang that supports -fsanitize-coverage=trace-pc-guard
     # and cannot run with thread sanitizer.
-    if [[ "$xcode_major" -ge 9 ]] && ! [[ "$SANITIZERS" = *"tsan"* ]]; then
+    if [[ "$xcode_major" -ge 9 ]] && ! [[ -n "${SANITIZERS:-}" && "$SANITIZERS" = *"tsan"* ]]; then
       RunXcodebuild \
           -workspace 'Firestore/Example/Firestore.xcworkspace' \
           -scheme "Firestore_FuzzTests_iOS" \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -236,8 +236,9 @@ case "$product-$method-$platform" in
         "${xcb_flags[@]}" \
         build
 
-    # Firestore_FuzzTests_iOS require a Clang that supports -fsanitize-coverage=trace-pc-guard.
-    if [[ "$xcode_major" -ge 9 ]]; then
+    # Firestore_FuzzTests_iOS require a Clang that supports -fsanitize-coverage=trace-pc-guard
+    # and cannot run with thread sanitizer.
+    if [[ "$xcode_major" -ge 9 ]] && ! [[ "$SANITIZERS" = *"tsan"* ]]; then
       RunXcodebuild \
           -workspace 'Firestore/Example/Firestore.xcworkspace' \
           -scheme "Firestore_FuzzTests_iOS" \


### PR DESCRIPTION
Fuzz tests automatically enable ASAN which cannot be combined with TSAN. This PR avoids running fuzz tests when TSAN is enabled. Otherwise, some travis jobs like [this](https://travis-ci.org/firebase/firebase-ios-sdk/jobs/410988626) will fail.