### PR TITLE
Fixes decoding WriteResults for deletes (with no updateTime).

### DIFF
--- a/Firestore/Source/Remote/FSTSerializerBeta.mm
+++ b/Firestore/Source/Remote/FSTSerializerBeta.mm
@@ -673,7 +673,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (FSTMutationResult *)decodedMutationResult:(GCFSWriteResult *)mutation {
   // NOTE: Deletes don't have an updateTime.
   absl::optional<SnapshotVersion> version;
-  if (mutation.updateTime) {
+  if (mutation.hasUpdateTime) {
     version = [self decodedVersion:mutation.updateTime];
   }
   NSMutableArray *_Nullable transformResults = nil;


### PR DESCRIPTION
This should resolve #1591.  We were inadvertantly decoding the WriteResult as
having an updateTime of 0 which caused it to be older than the version of the
document in the RemoteDocumentsCache. Therefore we kept the old version in
the cache instead of persisting the deleted document. This caused the document
to reappear in the query results until we resolved it via a limbo resolution.

FYI- I tried to write a spec test but:
1. A writeAck step has only a single version number that's used for both the WriteResponse commitTime as well as the WriteResult updateTime (https://github.com/firebase/firebase-ios-sdk/blob/af0e5fca4c2c236c08df499e16f8a7fc6c0126f9/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm#L325).
2. The iOS spec tests test at the model layer instead of the proto layer (they construct a FSTMutationResult rather than GCFSWriteResult) and so I can't exercise the code with the bug anyway.

But I added serializer tests (which were completely missing for decodedMutationResult).