### PR TITLE
Make FirebaseCredentialsProvider tolerate a missing FirebaseAuth

### DIFF
--- a/Firestore/core/src/firebase/firestore/auth/firebase_credentials_provider_apple.mm
+++ b/Firestore/core/src/firebase/firestore/auth/firebase_credentials_provider_apple.mm
@@ -124,8 +124,15 @@ void FirebaseCredentialsProvider::GetToken(TokenListener completion) {
         }
       };
 
-  [contents_->auth getTokenForcingRefresh:contents_->force_refresh
-                             withCallback:get_token_callback];
+  // TODO(wilhuff): Need a better abstraction over a missing auth provider.
+  if (contents_->auth) {
+    [contents_->auth getTokenForcingRefresh:contents_->force_refresh
+                               withCallback:get_token_callback];
+  } else {
+    // If there's no Auth provider, call back immediately with a nil
+    // (unauthenticated) token.
+    get_token_callback(nil, nil);
+  }
   contents_->force_refresh = false;
 }
 

--- a/Firestore/core/test/firebase/firestore/auth/firebase_credentials_provider_test.mm
+++ b/Firestore/core/test/firebase/firestore/auth/firebase_credentials_provider_test.mm
@@ -23,6 +23,10 @@
 #import <FirebaseCore/FIRComponentContainerInternal.h>
 #import <FirebaseCore/FIROptionsInternal.h>
 
+#include <chrono>  // NOLINT(build/c++11)
+#include <future>  // NOLINT(build/c++11)
+#include <memory>
+
 #include "Firestore/core/src/firebase/firestore/util/statusor.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 #include "Firestore/core/test/firebase/firestore/testutil/app_testing.h"
@@ -30,7 +34,7 @@
 #include "gtest/gtest.h"
 
 /// A fake class to handle Auth interaction.
-@interface FSTAuthFake : NSObject<FIRAuthInterop>
+@interface FSTAuthFake : NSObject <FIRAuthInterop>
 @property(nonatomic, nullable, strong, readonly) NSString* token;
 @property(nonatomic, nullable, strong, readonly) NSString* uid;
 @property(nonatomic, readonly) BOOL forceRefreshTriggered;
@@ -69,6 +73,32 @@
 namespace firebase {
 namespace firestore {
 namespace auth {
+
+// Simulates the case where Firebase/Firestore is installed in the project but
+// Firebase/Auth is not available.
+TEST(FirebaseCredentialsProviderTest, GetTokenNoProvider) {
+  auto token_promise = std::make_shared<std::promise<Token>>();
+
+  FIRApp* app = testutil::AppForUnitTesting();
+  FirebaseCredentialsProvider credentials_provider(app, nil);
+  credentials_provider.GetToken([token_promise](util::StatusOr<Token> result) {
+    EXPECT_TRUE(result.ok());
+    const Token& token = result.ValueOrDie();
+    EXPECT_ANY_THROW(token.token());
+    const User& user = token.user();
+    EXPECT_EQ("", user.uid());
+    EXPECT_FALSE(user.is_authenticated());
+
+    // TODO(wilhuff): convert between !result.ok() and a failed promise.
+    token_promise->set_value(token);
+  });
+
+  // TODO(wilhuff): generalize this pattern or make util::Await for non-void
+  // futures.
+  auto kTimeout = std::chrono::seconds(5);
+  auto token_future = token_promise->get_future();
+  ASSERT_EQ(std::future_status::ready, token_future.wait_for(kTimeout));
+}
 
 TEST(FirebaseCredentialsProviderTest, GetTokenUnauthenticated) {
   FIRApp* app = testutil::AppForUnitTesting();


### PR DESCRIPTION
If a user depends on Firebase/Firestore without depending on Firebase/Auth the `auth` instance we get is `nil`. `nil`-dispatch is still in effect here so the observed behavior is that Firestore cannot connect because we never get a token.

This should address the "Couldn't connect to Firestore backend" issues observed reproducing our fix for #1591 at master.

This implementation is intentionally minimal to make it palatable to the release that we're assembling right now. Further work is required on master to make this better over the long term.