### PR TITLE
Add Status::CausedBy

### DIFF
--- a/Firestore/core/src/firebase/firestore/util/status.cc
+++ b/Firestore/core/src/firebase/firestore/util/status.cc
@@ -37,7 +37,7 @@ void Status::Update(const Status& new_status) {
 }
 
 Status& Status::CausedBy(const Status& cause) {
-  if (cause.ok()) {
+  if (cause.ok() || this == &cause) {
     return *this;
   }
 

--- a/Firestore/core/src/firebase/firestore/util/status.cc
+++ b/Firestore/core/src/firebase/firestore/util/status.cc
@@ -36,6 +36,20 @@ void Status::Update(const Status& new_status) {
   }
 }
 
+Status& Status::CausedBy(const Status& cause) {
+  if (cause.ok()) {
+    return *this;
+  }
+
+  if (ok()) {
+    *this = cause;
+    return *this;
+  }
+
+  absl::StrAppend(&state_->msg, ": ", cause.error_message());
+  return *this;
+}
+
 void Status::SlowCopyFrom(const State* src) {
   if (src == nullptr) {
     state_ = nullptr;

--- a/Firestore/core/src/firebase/firestore/util/status.h
+++ b/Firestore/core/src/firebase/firestore/util/status.h
@@ -92,6 +92,11 @@ class ABSL_MUST_USE_RESULT Status {
   ///   `overall_status.Update(new_status);`
   void Update(const Status& new_status);
 
+  /// \brief Adds the message in the given cause to this Status.
+  ///
+  /// \return *this
+  Status& CausedBy(const Status& cause);
+
   /// \brief Return a string representation of this status suitable for
   /// printing. Returns the string `"OK"` for success.
   std::string ToString() const;

--- a/Firestore/core/test/firebase/firestore/util/status_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/status_test.cc
@@ -150,6 +150,12 @@ TEST(Status, CausedBy_Chain) {
             result.ToString());
 }
 
+TEST(Status, CauseBy_Self) {
+  Status not_found(FirestoreErrorCode::NotFound, "file not found");
+  Status result = not_found.CausedBy(not_found);
+  EXPECT_EQ(not_found, result);
+}
+
 }  // namespace util
 }  // namespace firestore
 }  // namespace firebase

--- a/Firestore/core/test/firebase/firestore/util/status_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/status_test.cc
@@ -37,7 +37,7 @@ TEST(Status, OK) {
   EXPECT_TRUE(s.ok());
 }
 
-TEST(DeathStatus, CheckOK) {
+TEST(Status, DeathCheckOK) {
   Status status(FirestoreErrorCode::InvalidArgument, "Invalid");
   ASSERT_ANY_THROW(STATUS_CHECK_OK(status));
 }
@@ -111,6 +111,43 @@ TEST(Status, FromErrno) {
       a.ToString(),
       testing::MatchesRegex(
           "Already exists: Cannot write file \\(errno .*: File exists\\)"));
+}
+
+TEST(Status, CausedBy_OK) {
+  Status result = Status::OK();
+  result.CausedBy(Status::OK());
+  EXPECT_EQ(Status::OK(), result);
+}
+
+TEST(Status, CausedBy_CauseOK) {
+  Status not_found(FirestoreErrorCode::NotFound, "file not found");
+
+  Status result = not_found;
+  result.CausedBy(Status::OK());
+  EXPECT_EQ(not_found, result);
+}
+
+TEST(Status, CausedBy_OuterOK) {
+  Status not_found(FirestoreErrorCode::NotFound, "file not found");
+
+  Status result = Status::OK();
+  result.CausedBy(not_found);
+  EXPECT_EQ(not_found, result);
+}
+
+TEST(Status, CausedBy_Chain) {
+  Status not_found(FirestoreErrorCode::NotFound, "file not found");
+  Status not_ready(FirestoreErrorCode::FailedPrecondition, "DB not ready");
+
+  Status result = not_ready;
+  result.CausedBy(not_found);
+  EXPECT_NE(not_found, result);
+  EXPECT_NE(not_ready, result);
+
+  // Outer should prevail
+  EXPECT_EQ(not_ready.code(), result.code());
+  EXPECT_EQ("Failed precondition: DB not ready: file not found",
+            result.ToString());
 }
 
 }  // namespace util


### PR DESCRIPTION
This makes it easy to wrap an underlying error in a higher-level one,
similar to the way Java exception chaining works.

Note that this intentionally diverges from upstream. The intent is that
this expresses a high-level concern so we can migrate to some common
status if one is ever released.

This is a follow-up to #1620.