### PR TITLE
Migrate [LevelDBKey descriptionForKey:] to DescribeKey()

### DIFF
--- a/Firestore/Example/Tests/Local/FSTLevelDBKeyTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBKeyTests.mm
@@ -22,11 +22,13 @@
 
 #import "Firestore/Example/Tests/Util/FSTHelpers.h"
 
+#include "Firestore/core/src/firebase/firestore/local/leveldb_key.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 #include "Firestore/core/test/firebase/firestore/testutil/testutil.h"
 
 namespace util = firebase::firestore::util;
 namespace testutil = firebase::firestore::testutil;
+using firebase::firestore::local::DescribeKey;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -61,22 +63,12 @@ static std::string DocTargetKey(NSString *key, FSTTargetID targetID) {
   return [FSTLevelDBDocumentTargetKey keyWithDocumentKey:FSTTestDocKey(key) targetID:targetID];
 }
 
-/**
- * Asserts that the description for given key is equal to the expected description.
- *
- * @param key A StringView of a textual key
- * @param key An NSString that [FSTLevelDBKey descriptionForKey:] is expected to produce.
- */
-#define FSTAssertExpectedKeyDescription(key, expectedDescription) \
-  XCTAssertEqualObjects([FSTLevelDBKey descriptionForKey:(key)], (expectedDescription))
-
 #define FSTAssertKeyLessThan(left, right)                                           \
   do {                                                                              \
     std::string leftKey = (left);                                                   \
     std::string rightKey = (right);                                                 \
-    XCTAssertLessThan(leftKey.compare(right), 0, @"Expected %@ to be less than %@", \
-                      [FSTLevelDBKey descriptionForKey:leftKey],                    \
-                      [FSTLevelDBKey descriptionForKey:rightKey]);                  \
+    XCTAssertLessThan(leftKey.compare(right), 0, @"Expected %s to be less than %s", \
+                      DescribeKey(leftKey).c_str(), DescribeKey(rightKey).c_str()); \
   } while (0)
 
 @implementation FSTLevelDBKeyTests
@@ -113,24 +105,6 @@ static std::string DocTargetKey(NSString *key, FSTTargetID targetID) {
     XCTAssertEqual(key.userID, user);
     XCTAssertEqual(key.batchID, batchID);
   }
-}
-
-- (void)testMutationKeyDescription {
-  FSTAssertExpectedKeyDescription([FSTLevelDBMutationKey keyPrefix], @"[mutation: incomplete key]");
-
-  FSTAssertExpectedKeyDescription([FSTLevelDBMutationKey keyPrefixWithUserID:@"user1"],
-                                  @"[mutation: userID=user1 incomplete key]");
-
-  auto key = [FSTLevelDBMutationKey keyWithUserID:@"user1" batchID:42];
-  FSTAssertExpectedKeyDescription(key, @"[mutation: userID=user1 batchID=42]");
-
-  FSTAssertExpectedKeyDescription(key + " extra",
-                                  @"[mutation: userID=user1 batchID=42 invalid "
-                                  @"key=<hW11dGF0aW9uAAGNdXNlcjEAAYqqgCBleHRyYQ==>]");
-
-  // Truncate the key so that it's missing its terminator.
-  key.resize(key.size() - 1);
-  FSTAssertExpectedKeyDescription(key, @"[mutation: userID=user1 batchID=42 incomplete key]");
 }
 
 - (void)testDocumentMutationKeyPrefixing {
@@ -198,34 +172,12 @@ static std::string DocTargetKey(NSString *key, FSTTargetID targetID) {
   FSTAssertKeyLessThan(DocMutationKey(@"1", @"foo/bar", 0), DocMutationKey(@"1", @"foo/bar", 1));
 }
 
-- (void)testDocumentMutationKeyDescription {
-  FSTAssertExpectedKeyDescription([FSTLevelDBDocumentMutationKey keyPrefix],
-                                  @"[document_mutation: incomplete key]");
-
-  FSTAssertExpectedKeyDescription([FSTLevelDBDocumentMutationKey keyPrefixWithUserID:@"user1"],
-                                  @"[document_mutation: userID=user1 incomplete key]");
-
-  auto key = [FSTLevelDBDocumentMutationKey keyPrefixWithUserID:@"user1"
-                                                   resourcePath:testutil::Resource("foo/bar")];
-  FSTAssertExpectedKeyDescription(key,
-                                  @"[document_mutation: userID=user1 key=foo/bar incomplete key]");
-
-  key = [FSTLevelDBDocumentMutationKey keyWithUserID:@"user1"
-                                         documentKey:FSTTestDocKey(@"foo/bar")
-                                             batchID:42];
-  FSTAssertExpectedKeyDescription(key, @"[document_mutation: userID=user1 key=foo/bar batchID=42]");
-}
-
 - (void)testTargetGlobalKeyEncodeDecodeCycle {
   FSTLevelDBTargetGlobalKey *key = [[FSTLevelDBTargetGlobalKey alloc] init];
 
   auto encoded = [FSTLevelDBTargetGlobalKey key];
   BOOL ok = [key decodeKey:encoded];
   XCTAssertTrue(ok);
-}
-
-- (void)testTargetGlobalKeyDescription {
-  FSTAssertExpectedKeyDescription([FSTLevelDBTargetGlobalKey key], @"[target_global:]");
 }
 
 - (void)testTargetKeyEncodeDecodeCycle {
@@ -238,11 +190,6 @@ static std::string DocTargetKey(NSString *key, FSTTargetID targetID) {
   XCTAssertEqual(key.targetID, targetID);
 }
 
-- (void)testTargetKeyDescription {
-  FSTAssertExpectedKeyDescription([FSTLevelDBTargetKey keyWithTargetID:42],
-                                  @"[target: targetID=42]");
-}
-
 - (void)testQueryTargetKeyEncodeDecodeCycle {
   FSTLevelDBQueryTargetKey *key = [[FSTLevelDBQueryTargetKey alloc] init];
   std::string canonicalID("foo");
@@ -253,11 +200,6 @@ static std::string DocTargetKey(NSString *key, FSTTargetID targetID) {
   XCTAssertTrue(ok);
   XCTAssertEqual(key.canonicalID, canonicalID);
   XCTAssertEqual(key.targetID, targetID);
-}
-
-- (void)testQueryKeyDescription {
-  FSTAssertExpectedKeyDescription([FSTLevelDBQueryTargetKey keyWithCanonicalID:"foo" targetID:42],
-                                  @"[query_target: canonicalID=foo targetID=42]");
 }
 
 - (void)testTargetDocumentKeyEncodeDecodeCycle {
@@ -287,8 +229,6 @@ static std::string DocTargetKey(NSString *key, FSTTargetID targetID) {
 
 - (void)testTargetDocumentKeyDescription {
   auto key = [FSTLevelDBTargetDocumentKey keyWithTargetID:42 documentKey:FSTTestDocKey(@"foo/bar")];
-  XCTAssertEqualObjects([FSTLevelDBKey descriptionForKey:key],
-                        @"[target_document: targetID=42 key=foo/bar]");
 }
 
 - (void)testDocumentTargetKeyEncodeDecodeCycle {
@@ -300,12 +240,6 @@ static std::string DocTargetKey(NSString *key, FSTTargetID targetID) {
   XCTAssertTrue(ok);
   XCTAssertEqualObjects(key.documentKey, FSTTestDocKey(@"foo/bar"));
   XCTAssertEqual(key.targetID, 42);
-}
-
-- (void)testDocumentTargetKeyDescription {
-  auto key = [FSTLevelDBDocumentTargetKey keyWithDocumentKey:FSTTestDocKey(@"foo/bar") targetID:42];
-  XCTAssertEqualObjects([FSTLevelDBKey descriptionForKey:key],
-                        @"[document_target: key=foo/bar targetID=42]");
 }
 
 - (void)testDocumentTargetKeyOrdering {
@@ -353,12 +287,6 @@ static std::string DocTargetKey(NSString *key, FSTTargetID targetID) {
     XCTAssertTrue(ok);
     XCTAssertEqualObjects(key.documentKey, FSTTestDocKey(path));
   }
-}
-
-- (void)testRemoteDocumentKeyDescription {
-  FSTAssertExpectedKeyDescription(
-      [FSTLevelDBRemoteDocumentKey keyWithDocumentKey:FSTTestDocKey(@"foo/bar/baz/quux")],
-      @"[remote_document: key=foo/bar/baz/quux]");
 }
 
 @end

--- a/Firestore/Source/Local/FSTLevelDBKey.h
+++ b/Firestore/Source/Local/FSTLevelDBKey.h
@@ -70,17 +70,6 @@ NS_ASSUME_NONNULL_BEGIN
 //   - tableName: string = "remote_document"
 //   - path: ResourcePath
 
-/** Helpers for any LevelDB key. */
-@interface FSTLevelDBKey : NSObject
-
-/**
- * Parses the given key and returns a human readable description of its contents, suitable for
- * error messages and logging.
- */
-+ (NSString *)descriptionForKey:(Firestore::StringView)key;
-
-@end
-
 /** A key to a singleton row storing the version of the schema. */
 @interface FSTLevelDBVersionKey : NSObject
 

--- a/Firestore/Source/Local/FSTLevelDBKey.mm
+++ b/Firestore/Source/Local/FSTLevelDBKey.mm
@@ -113,27 +113,6 @@ void WriteComponentLabel(std::string *dest, FSTComponentLabel label) {
 /**
  * Reads a component label from the given key contents.
  *
- * If the read is unsuccessful, returns NO, and changes none of its arguments.
- *
- * If the read is successful, returns YES, contents will be updated to the next unread byte, and
- * label will be set to the decoded label value.
- */
-BOOL ReadComponentLabel(leveldb::Slice *contents, FSTComponentLabel *label) {
-  int64_t rawResult = 0;
-  absl::string_view tmp(contents->data(), contents->size());
-  if (OrderedCode::ReadSignedNumIncreasing(&tmp, &rawResult)) {
-    if (rawResult >= FSTComponentLabelTerminator && rawResult <= FSTComponentLabelUnknown) {
-      *label = static_cast<FSTComponentLabel>(rawResult);
-      *contents = leveldb::Slice(tmp.data(), tmp.size());
-      return YES;
-    }
-  }
-  return NO;
-}
-
-/**
- * Reads a component label from the given key contents.
- *
  * If the read is unsuccessful or if the read was successful but the label that was read did not
  * match the expectedLabel returns NO and changes none of its arguments.
  *
@@ -361,101 +340,7 @@ inline BOOL ReadUserID(Slice *contents, std::string *userID) {
   return ReadLabeledString(contents, FSTComponentLabelUserID, userID);
 }
 
-/** Returns a base64-encoded string for an invalid key, used for debug-friendly description text. */
-NSString *InvalidKey(const Slice &key) {
-  NSData *keyData =
-      [[NSData alloc] initWithBytesNoCopy:(void *)key.data() length:key.size() freeWhenDone:NO];
-  return [keyData base64EncodedStringWithOptions:0];
-}
-
 }  // namespace
-
-@implementation FSTLevelDBKey
-
-+ (NSString *)descriptionForKey:(StringView)key {
-  Slice contents = key;
-  BOOL isTerminated = NO;
-
-  NSMutableString *description = [NSMutableString string];
-  [description appendString:@"["];
-  while (contents.size() > 0) {
-    Slice tmp = contents;
-    FSTComponentLabel label = FSTComponentLabelUnknown;
-    if (!ReadComponentLabel(&tmp, &label)) {
-      break;
-    }
-
-    if (label == FSTComponentLabelTerminator) {
-      isTerminated = YES;
-      contents = tmp;
-      break;
-    }
-
-    // Reset tmp since all the different read routines expect to see the separator first
-    tmp = contents;
-
-    if (label == FSTComponentLabelPathSegment) {
-      FSTDocumentKey *documentKey = nil;
-      if (!ReadDocumentKey(&tmp, &documentKey)) {
-        break;
-      }
-      [description appendFormat:@" key=%s", documentKey.path.CanonicalString().c_str()];
-
-    } else if (label == FSTComponentLabelTableName) {
-      std::string table;
-      if (!ReadLabeledString(&tmp, FSTComponentLabelTableName, &table)) {
-        break;
-      }
-      [description appendFormat:@"%s:", table.c_str()];
-
-    } else if (label == FSTComponentLabelBatchID) {
-      FSTBatchID batchID;
-      if (!ReadBatchID(&tmp, &batchID)) {
-        break;
-      }
-      [description appendFormat:@" batchID=%d", batchID];
-
-    } else if (label == FSTComponentLabelCanonicalID) {
-      std::string canonicalID;
-      if (!ReadCanonicalID(&tmp, &canonicalID)) {
-        break;
-      }
-      [description appendFormat:@" canonicalID=%s", canonicalID.c_str()];
-
-    } else if (label == FSTComponentLabelTargetID) {
-      FSTTargetID targetID;
-      if (!ReadTargetID(&tmp, &targetID)) {
-        break;
-      }
-      [description appendFormat:@" targetID=%d", targetID];
-
-    } else if (label == FSTComponentLabelUserID) {
-      std::string userID;
-      if (!ReadUserID(&tmp, &userID)) {
-        break;
-      }
-      [description appendFormat:@" userID=%s", userID.c_str()];
-
-    } else {
-      [description appendFormat:@" unknown label=%d", (int)label];
-      break;
-    }
-
-    contents = tmp;
-  }
-
-  if (contents.size() > 0) {
-    [description appendFormat:@" invalid key=<%@>", InvalidKey(key)];
-
-  } else if (!isTerminated) {
-    [description appendFormat:@" incomplete key"];
-  }
-
-  [description appendString:@"]"];
-  return description;
-}
-
-@end
 
 @implementation FSTLevelDBVersionKey
 

--- a/Firestore/core/src/firebase/firestore/local/leveldb_key.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_key.cc
@@ -539,7 +539,7 @@ class Writer {
 
 }  // namespace
 
-std::string Describe(leveldb::Slice key) {
+std::string DescribeKey(leveldb::Slice key) {
   Reader reader{key};
   return reader.Describe();
 }

--- a/Firestore/core/src/firebase/firestore/local/leveldb_key.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_key.cc
@@ -544,6 +544,18 @@ std::string DescribeKey(leveldb::Slice key) {
   return reader.Describe();
 }
 
+std::string DescribeKey(absl::string_view key) {
+  return DescribeKey(MakeSlice(key));
+}
+
+std::string DescribeKey(const std::string& key) {
+  return DescribeKey(leveldb::Slice{key});
+}
+
+std::string DescribeKey(const char* key) {
+  return DescribeKey(leveldb::Slice{key});
+}
+
 std::string LevelDbVersionKey::Key() {
   Writer writer;
   writer.WriteTableName(kVersionGlobalTable);

--- a/Firestore/core/src/firebase/firestore/local/leveldb_key.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_key.cc
@@ -35,16 +35,16 @@ namespace local {
 
 namespace {
 
-const char *kVersionGlobalTable = "version";
-const char *kMutationsTable = "mutation";
-const char *kDocumentMutationsTable = "document_mutation";
-const char *kMutationQueuesTable = "mutation_queue";
-const char *kTargetGlobalTable = "target_global";
-const char *kTargetsTable = "target";
-const char *kQueryTargetsTable = "query_target";
-const char *kTargetDocumentsTable = "target_document";
-const char *kDocumentTargetsTable = "document_target";
-const char *kRemoteDocumentsTable = "remote_document";
+const char* kVersionGlobalTable = "version";
+const char* kMutationsTable = "mutation";
+const char* kDocumentMutationsTable = "document_mutation";
+const char* kMutationQueuesTable = "mutation_queue";
+const char* kTargetGlobalTable = "target_global";
+const char* kTargetsTable = "target";
+const char* kQueryTargetsTable = "query_target";
+const char* kTargetDocumentsTable = "target_document";
+const char* kDocumentTargetsTable = "document_target";
+const char* kRemoteDocumentsTable = "remote_document";
 
 /**
  * Labels for the components of keys. These serve to make keys self-describing.
@@ -133,7 +133,7 @@ class Reader {
    */
   std::string Describe();
 
-  void ReadTableNameMatching(const char *expected_table_name) {
+  void ReadTableNameMatching(const char* expected_table_name) {
     if (!ReadLabeledStringMatching(ComponentLabel::TableName,
                                    expected_table_name)) {
       Fail();
@@ -331,7 +331,7 @@ class Reader {
    */
   ABSL_MUST_USE_RESULT
   bool ReadLabeledStringMatching(ComponentLabel expected_label,
-                                 const char *expected_value) {
+                                 const char* expected_value) {
     std::string value = ReadLabeledString(expected_label);
     if (ok_) {
       // Value mismatch does not constitute a failure:
@@ -479,7 +479,7 @@ class Writer {
     OrderedCode::WriteSignedNumIncreasing(&dest_, ComponentLabel::Terminator);
   }
 
-  void WriteTableName(const char *table_name) {
+  void WriteTableName(const char* table_name) {
     WriteLabeledString(ComponentLabel::TableName, table_name);
   }
 
@@ -504,8 +504,8 @@ class Writer {
    * ComponentLabel::PathSegment component label and a string containing the
    * path segment.
    */
-  void WriteResourcePath(const ResourcePath &path) {
-    for (const auto &segment : path) {
+  void WriteResourcePath(const ResourcePath& path) {
+    for (const auto& segment : path) {
       WriteComponentLabel(ComponentLabel::PathSegment);
       OrderedCode::WriteString(&dest_, segment);
     }
@@ -597,7 +597,7 @@ std::string LevelDbDocumentMutationKey::KeyPrefix(absl::string_view user_id) {
 }
 
 std::string LevelDbDocumentMutationKey::KeyPrefix(
-    absl::string_view user_id, const ResourcePath &resource_path) {
+    absl::string_view user_id, const ResourcePath& resource_path) {
   Writer writer;
   writer.WriteTableName(kDocumentMutationsTable);
   writer.WriteUserId(user_id);
@@ -606,7 +606,7 @@ std::string LevelDbDocumentMutationKey::KeyPrefix(
 }
 
 std::string LevelDbDocumentMutationKey::Key(absl::string_view user_id,
-                                            const DocumentKey &document_key,
+                                            const DocumentKey& document_key,
                                             model::BatchId batch_id) {
   Writer writer;
   writer.WriteTableName(kDocumentMutationsTable);
@@ -731,7 +731,7 @@ std::string LevelDbTargetDocumentKey::KeyPrefix(model::TargetId target_id) {
 }
 
 std::string LevelDbTargetDocumentKey::Key(model::TargetId target_id,
-                                          const DocumentKey &document_key) {
+                                          const DocumentKey& document_key) {
   Writer writer;
   writer.WriteTableName(kTargetDocumentsTable);
   writer.WriteTargetId(target_id);
@@ -756,14 +756,14 @@ std::string LevelDbDocumentTargetKey::KeyPrefix() {
 }
 
 std::string LevelDbDocumentTargetKey::KeyPrefix(
-    const ResourcePath &resource_path) {
+    const ResourcePath& resource_path) {
   Writer writer;
   writer.WriteTableName(kDocumentTargetsTable);
   writer.WriteResourcePath(resource_path);
   return writer.result();
 }
 
-std::string LevelDbDocumentTargetKey::Key(const DocumentKey &document_key,
+std::string LevelDbDocumentTargetKey::Key(const DocumentKey& document_key,
                                           model::TargetId target_id) {
   Writer writer;
   writer.WriteTableName(kDocumentTargetsTable);
@@ -789,14 +789,14 @@ std::string LevelDbRemoteDocumentKey::KeyPrefix() {
 }
 
 std::string LevelDbRemoteDocumentKey::KeyPrefix(
-    const ResourcePath &resource_path) {
+    const ResourcePath& resource_path) {
   Writer writer;
   writer.WriteTableName(kRemoteDocumentsTable);
   writer.WriteResourcePath(resource_path);
   return writer.result();
 }
 
-std::string LevelDbRemoteDocumentKey::Key(const DocumentKey &key) {
+std::string LevelDbRemoteDocumentKey::Key(const DocumentKey& key) {
   Writer writer;
   writer.WriteTableName(kRemoteDocumentsTable);
   writer.WriteResourcePath(key.path());

--- a/Firestore/core/src/firebase/firestore/local/leveldb_key.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_key.h
@@ -82,7 +82,7 @@ namespace local {
  * Parses the given key and returns a human readable description of its
  * contents, suitable for error messages and logging.
  */
-std::string Describe(leveldb::Slice key);
+std::string DescribeKey(leveldb::Slice key);
 
 /** A key to a singleton row storing the version of the schema. */
 class LevelDbVersionKey {

--- a/Firestore/core/src/firebase/firestore/local/leveldb_key.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_key.h
@@ -83,6 +83,9 @@ namespace local {
  * contents, suitable for error messages and logging.
  */
 std::string DescribeKey(leveldb::Slice key);
+std::string DescribeKey(absl::string_view key);
+std::string DescribeKey(const std::string& key);
+std::string DescribeKey(const char* key);
 
 /** A key to a singleton row storing the version of the schema. */
 class LevelDbVersionKey {

--- a/Firestore/core/src/firebase/firestore/local/leveldb_transaction.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_transaction.cc
@@ -226,12 +226,12 @@ std::string LevelDbTransaction::ToString() {
   dest += std::to_string(changes) + " changes ";
   std::string items;  // accumulator for individual changes.
   for (auto it = deletions_.begin(); it != deletions_.end(); it++) {
-    items += "\n  - Delete " + Describe(*it);
+    items += "\n  - Delete " + DescribeKey(*it);
   }
   for (auto it = mutations_.begin(); it != mutations_.end(); it++) {
     int64_t change_bytes = it->second.length();
     bytes += change_bytes;
-    items += "\n  - Put " + Describe(it->first) + " (" +
+    items += "\n  - Put " + DescribeKey(it->first) + " (" +
              std::to_string(change_bytes) + " bytes)";
   }
   dest += "(" + std::to_string(bytes) + " bytes):" + items + ">";

--- a/Firestore/core/src/firebase/firestore/local/leveldb_transaction.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_transaction.cc
@@ -134,10 +134,6 @@ void LevelDbTransaction::Iterator::Next() {
   }
 }
 
-bool LevelDbTransaction::Iterator::Valid() {
-  return is_valid_;
-}
-
 LevelDbTransaction::LevelDbTransaction(DB* db,
                                        absl::string_view label,
                                        const ReadOptions& read_options,
@@ -236,6 +232,15 @@ std::string LevelDbTransaction::ToString() {
   }
   dest += "(" + std::to_string(bytes) + " bytes):" + items + ">";
   return dest;
+}
+
+std::string DescribeKey(
+    const std::unique_ptr<LevelDbTransaction::Iterator>& iterator) {
+  if (iterator->Valid()) {
+    return DescribeKey(iterator->key());
+  } else {
+    return "the end of the table";
+  }
 }
 
 }  // namespace local

--- a/Firestore/core/src/firebase/firestore/local/leveldb_transaction.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_transaction.h
@@ -56,7 +56,9 @@ class LevelDbTransaction {
     /**
      * Returns true if this iterator points to an entry
      */
-    bool Valid();
+    bool Valid() {
+      return is_valid_;
+    }
 
     /**
      * Seeks this iterator to the first key equal to or greater than the given
@@ -204,6 +206,13 @@ class LevelDbTransaction {
   int32_t version_;
   std::string label_;
 };
+
+/**
+ * Returns a description of the current key if the iterator is Valid, otherwise
+ * the string "the end of the table."
+ */
+std::string DescribeKey(
+    const std::unique_ptr<LevelDbTransaction::Iterator>& iterator);
 
 }  // namespace local
 }  // namespace firestore

--- a/Firestore/core/src/firebase/firestore/util/string_util.h
+++ b/Firestore/core/src/firebase/firestore/util/string_util.h
@@ -65,6 +65,23 @@ std::string PrefixSuccessor(absl::string_view prefix);
  */
 std::string ImmediateSuccessor(absl::string_view s);
 
+/**
+ * Returns a string description of the contents of the given collection.
+ */
+template <typename Container>
+std::string ToString(const Container& container) {
+  std::string result;
+  result.append("[");
+  const char* sep = "";
+  for (auto&& item : container) {
+    result.append(sep);
+    result.append(item);
+    sep = ", ";
+  }
+  result.append("]");
+  return result;
+}
+
 }  // namespace util
 }  // namespace firestore
 }  // namespace firebase

--- a/Firestore/core/test/firebase/firestore/local/leveldb_key_test.cc
+++ b/Firestore/core/test/firebase/firestore/local/leveldb_key_test.cc
@@ -65,7 +65,7 @@ std::string DocTargetKey(absl::string_view key, TargetId target_id) {
  * produce.
  */
 #define AssertExpectedKeyDescription(expected_description, key) \
-  ASSERT_EQ((expected_description), Describe(key))
+  ASSERT_EQ((expected_description), DescribeKey(key))
 
 TEST(LevelDbMutationKeyTest, Prefixing) {
   auto tableKey = LevelDbMutationKey::KeyPrefix();
@@ -280,7 +280,7 @@ TEST(TargetDocumentKeyTest, Ordering) {
 
 TEST(TargetDocumentKeyTest, Description) {
   auto key = LevelDbTargetDocumentKey::Key(42, testutil::Key("foo/bar"));
-  ASSERT_EQ("[target_document: target_id=42 key=foo/bar]", Describe(key));
+  ASSERT_EQ("[target_document: target_id=42 key=foo/bar]", DescribeKey(key));
 }
 
 TEST(DocumentTargetKeyTest, EncodeDecodeCycle) {
@@ -295,7 +295,7 @@ TEST(DocumentTargetKeyTest, EncodeDecodeCycle) {
 
 TEST(DocumentTargetKeyTest, Description) {
   auto key = LevelDbDocumentTargetKey::Key(testutil::Key("foo/bar"), 42);
-  ASSERT_EQ("[document_target: key=foo/bar target_id=42]", Describe(key));
+  ASSERT_EQ("[document_target: key=foo/bar target_id=42]", DescribeKey(key));
 }
 
 TEST(DocumentTargetKeyTest, Ordering) {

--- a/Firestore/core/test/firebase/firestore/local/leveldb_key_test.cc
+++ b/Firestore/core/test/firebase/firestore/local/leveldb_key_test.cc
@@ -61,8 +61,7 @@ std::string DocTargetKey(absl::string_view key, TargetId target_id) {
  * description.
  *
  * @param key A StringView of a textual key
- * @param key An NSString that [LevelDbKey descriptionForKey:] is expected to
- * produce.
+ * @param key An string that `Describe(key)` is expected to produce.
  */
 #define AssertExpectedKeyDescription(expected_description, key) \
   ASSERT_EQ((expected_description), DescribeKey(key))


### PR DESCRIPTION
Note, this PR looks like it deletes a ton of code, but it was actually copied/reworked during #937. This PR completes the migration of this method and deletes the old copy.