### PR TITLE
Fix GoogleUtilities so that it compiles in app extensions.

### DIFF
--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -72,6 +72,7 @@ other Google CocoaPods. They're not intended for direct public usage.
     adss.private_header_files = 'GoogleUtilities/AppDelegateSwizzler/Private/*.h'
     adss.dependency 'GoogleUtilities/Logger'
     adss.dependency 'GoogleUtilities/Network'
+    adss.dependency 'GoogleUtilities/Environment'
   end
 
   s.subspec 'ISASwizzler' do |iss|

--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -246,10 +246,6 @@ static dispatch_once_t sProxyAppDelegateOnceToken;
 
 #pragma mark - Create proxy
 
-/** Returns the current sharedApplication.
- *
- *  @return the current UIApplication if in an app, or nil if in extension or if it doesn't exist.
- */
 + (UIApplication *)sharedApplication {
   // YES if the bundle is an app extension.
   if ([[NSBundle mainBundle].bundlePath hasSuffix:@".appex"]) {

--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -16,6 +16,7 @@
 
 #if TARGET_OS_IOS
 
+#import <GoogleUtilities/GULAppEnvironmentUtil.h>
 #import <GoogleUtilities/GULLogger.h>
 #import <GoogleUtilities/GULMutableDictionary.h>
 #import "../Common/GULLoggerCodes.h"
@@ -249,8 +250,7 @@ static dispatch_once_t sProxyAppDelegateOnceToken;
 #pragma mark - Create proxy
 
 + (UIApplication *)sharedApplication {
-  // YES if the bundle is an app extension.
-  if ([[NSBundle mainBundle].bundlePath hasSuffix:@".appex"]) {
+  if ([GULAppEnvironmentUtil isAppExtension]) {
     return nil;
   }
   id sharedApplication = nil;

--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -113,7 +113,7 @@ static id<UIApplicationDelegate> gOriginalAppDelegate;
   if (_isObserving) {
     return;
   }
-  [[UIApplication sharedApplication]
+  [[GULAppDelegateSwizzler sharedApplication]
       addObserver:self
        forKeyPath:kGULAppDelegateKeyPath
           options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
@@ -136,7 +136,7 @@ static id<UIApplicationDelegate> gOriginalAppDelegate;
     if ([oldValue isEqual:gOriginalAppDelegate]) {
       gOriginalAppDelegate = nil;
       // Remove the observer. Parse it to NSObject to avoid warning.
-      [[UIApplication sharedApplication] removeObserver:self forKeyPath:kGULAppDelegateKeyPath];
+      [[GULAppDelegateSwizzler sharedApplication] removeObserver:self forKeyPath:kGULAppDelegateKeyPath];
       _isObserving = NO;
     }
   }
@@ -239,7 +239,7 @@ static dispatch_once_t sProxyAppDelegateOnceToken;
 
 + (void)proxyOriginalDelegate {
   dispatch_once(&sProxyAppDelegateOnceToken, ^{
-    id<UIApplicationDelegate> originalDelegate = [self sharedApplication].delegate;
+    id<UIApplicationDelegate> originalDelegate = [GULAppDelegateSwizzler sharedApplication].delegate;
     [GULAppDelegateSwizzler proxyAppDelegate:originalDelegate];
   });
 }
@@ -412,9 +412,9 @@ static dispatch_once_t sProxyAppDelegateOnceToken;
   // checks and caches them.
   // Register KVO only once. Otherwise, the observing method will be called as many times as
   // being registered.
-  id<UIApplicationDelegate> delegate = [UIApplication sharedApplication].delegate;
-  [UIApplication sharedApplication].delegate = nil;
-  [UIApplication sharedApplication].delegate = delegate;
+  id<UIApplicationDelegate> delegate = [GULAppDelegateSwizzler sharedApplication].delegate;
+  [GULAppDelegateSwizzler sharedApplication].delegate = nil;
+  [GULAppDelegateSwizzler sharedApplication].delegate = delegate;
   gOriginalAppDelegate = delegate;
   [[GULAppDelegateObserver sharedInstance] observeUIApplication];
 }

--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -681,10 +681,6 @@ static dispatch_once_t sProxyAppDelegateOnceToken;
   }
 }
 
-+ (id<UIApplicationDelegate>)originalDelegate {
-  return gOriginalAppDelegate;
-}
-
 #pragma mark - Methods to print correct debug logs
 
 + (NSString *)correctAppDelegateProxyKey {
@@ -709,6 +705,10 @@ static dispatch_once_t sProxyAppDelegateOnceToken;
 
 + (void)resetProxyOriginalDelegateOnceToken {
   sProxyAppDelegateOnceToken = 0;
+}
+
++ (id<UIApplicationDelegate>)originalDelegate {
+  return gOriginalAppDelegate;
 }
 
 #endif  // GUL_APP_DELEGATE_TESTING

--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -136,7 +136,8 @@ static id<UIApplicationDelegate> gOriginalAppDelegate;
     if ([oldValue isEqual:gOriginalAppDelegate]) {
       gOriginalAppDelegate = nil;
       // Remove the observer. Parse it to NSObject to avoid warning.
-      [[GULAppDelegateSwizzler sharedApplication] removeObserver:self forKeyPath:kGULAppDelegateKeyPath];
+      [[GULAppDelegateSwizzler sharedApplication] removeObserver:self
+                                                      forKeyPath:kGULAppDelegateKeyPath];
       _isObserving = NO;
     }
   }
@@ -239,7 +240,8 @@ static dispatch_once_t sProxyAppDelegateOnceToken;
 
 + (void)proxyOriginalDelegate {
   dispatch_once(&sProxyAppDelegateOnceToken, ^{
-    id<UIApplicationDelegate> originalDelegate = [GULAppDelegateSwizzler sharedApplication].delegate;
+    id<UIApplicationDelegate> originalDelegate =
+        [GULAppDelegateSwizzler sharedApplication].delegate;
     [GULAppDelegateSwizzler proxyAppDelegate:originalDelegate];
   });
 }

--- a/GoogleUtilities/AppDelegateSwizzler/Internal/GULAppDelegateSwizzler_Private.h
+++ b/GoogleUtilities/AppDelegateSwizzler/Internal/GULAppDelegateSwizzler_Private.h
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#ifdef GUL_APP_DELEGATE_TESTING
-
 #import <GoogleUtilities/GULAppDelegateSwizzler.h>
 #import <GoogleUtilities/GULMutableDictionary.h>
 
@@ -45,11 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (GULMutableDictionary *)interceptors;
 
-/** Returns the original app delegate that was proxied.
- *
- *  @return The original app delegate instance that was proxied.
- */
-+ (id<UIApplicationDelegate>)originalDelegate;
+#ifdef GUL_APP_DELEGATE_TESTING // Methods only used in tests.
 
 /** Deletes all the registered interceptors. */
 + (void)clearInterceptors;
@@ -57,8 +51,14 @@ NS_ASSUME_NONNULL_BEGIN
 /** Resets the token that prevents the app delegate proxy from being isa swizzled multiple times. */
 + (void)resetProxyOriginalDelegateOnceToken;
 
+/** Returns the original app delegate that was proxied.
+ *
+ *  @return The original app delegate instance that was proxied.
+ */
++ (id<UIApplicationDelegate>)originalDelegate;
+
+#endif // GUL_APP_DELEGATE_TESTING
+
 @end
 
 NS_ASSUME_NONNULL_END
-
-#endif

--- a/GoogleUtilities/AppDelegateSwizzler/Internal/GULAppDelegateSwizzler_Private.h
+++ b/GoogleUtilities/AppDelegateSwizzler/Internal/GULAppDelegateSwizzler_Private.h
@@ -19,9 +19,17 @@
 #import <GoogleUtilities/GULAppDelegateSwizzler.h>
 #import <GoogleUtilities/GULMutableDictionary.h>
 
+@class UIApplication;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface GULAppDelegateSwizzler ()
+
+/** Returns the current sharedApplication.
+ *
+ *  @return the current UIApplication if in an app, or nil if in extension or if it doesn't exist.
+ */
++ (UIApplication *)sharedApplication;
 
 /** ISA Swizzles the given appDelegate as the original app delegate would be.
  *

--- a/GoogleUtilities/AppDelegateSwizzler/Internal/GULAppDelegateSwizzler_Private.h
+++ b/GoogleUtilities/AppDelegateSwizzler/Internal/GULAppDelegateSwizzler_Private.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (GULMutableDictionary *)interceptors;
 
-#ifdef GUL_APP_DELEGATE_TESTING // Methods only used in tests.
+#ifdef GUL_APP_DELEGATE_TESTING  // Methods only used in tests.
 
 /** Deletes all the registered interceptors. */
 + (void)clearInterceptors;
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (id<UIApplicationDelegate>)originalDelegate;
 
-#endif // GUL_APP_DELEGATE_TESTING
+#endif  // GUL_APP_DELEGATE_TESTING
 
 @end
 

--- a/GoogleUtilities/AppDelegateSwizzler/Private/GULAppDelegateSwizzler.h
+++ b/GoogleUtilities/AppDelegateSwizzler/Private/GULAppDelegateSwizzler.h
@@ -46,8 +46,8 @@ typedef NSString *const GULAppDelegateInterceptorID;
  *  registering your interceptor. This method is safe to call multiple times (but it only proxies
  *  the app delegate once).
  */
-+ (void)proxyOriginalDelegate
-    NS_EXTENSION_UNAVAILABLE("App delegate proxy doesn't support extensions.");
++ (void)proxyOriginalDelegate NS_EXTENSION_UNAVAILABLE(
+    "App delegate proxy doesn't support extensions.");
 
 /** Indicates whether app delegate proxy is explicitly disabled or enabled. Enabled by default.
  *


### PR DESCRIPTION
This PR changes GULAppDelegateSwizzler so that `+[UIApplication sharedApplication]` is not called within app extensions.

Buganizer - b/112202764

