### PR TITLE
Mikelehen/deleted doc source cache bug

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+- [fixed] Fixed an issue where `get(source:.Cache)` could throw an
+  "unrecognized selector" error if the SDK has previously cached the
+  non-existence of the document (#1632).
 
 # v0.13.0
 - [feature] Added `FieldValue.arrayUnion()` and `FieldValue.arrayRemove()` to

--- a/Firestore/Example/Tests/Integration/API/FIRFirestoreSourceTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRFirestoreSourceTests.mm
@@ -493,9 +493,7 @@
   // go offline for the rest of this test
   [self disableNetwork];
 
-  // attempt to get doc. Currently, this is expected to fail. In the future, we
-  // might consider adding support for negative cache hits so that we know
-  // certain documents *don't* exist.
+  // attempt to get doc. This will fail since there's nothing in cache.
   XCTestExpectation *getNonExistingDocCompletion =
       [self expectationWithDescription:@"getNonExistingDoc"];
   [doc getDocumentWithCompletion:^(FIRDocumentSnapshot *snapshot, NSError *error) {
@@ -505,6 +503,26 @@
     [getNonExistingDocCompletion fulfill];
   }];
   [self awaitExpectations];
+}
+
+// TODO(b/112267729): We should raise a fromCache=true event with a nonexistent snapshot, but
+// because the default source goes through a normal listener, we do not.
+- (void)xtestGetDeletedDocWhileOfflineWithDefaultSource {
+  FIRDocumentReference *doc = [self documentRef];
+
+  // delete the doc to get a deleted document into our cache.
+  [self deleteDocumentRef:doc];
+
+  // go offline for the rest of this test
+  [self disableNetwork];
+
+  // should get a FIRDocumentSnapshot with exists=false, fromCache=true
+  FIRDocumentSnapshot *snapshot = [self readDocumentForRef:doc source:FIRFirestoreSourceDefault];
+  XCTAssertNotNil(snapshot);
+  XCTAssertFalse(snapshot.exists);
+  XCTAssertNil(snapshot.data);
+  XCTAssertTrue(snapshot.metadata.fromCache);
+  XCTAssertFalse(snapshot.metadata.hasPendingWrites);
 }
 
 - (void)testGetNonExistingCollectionWhileOfflineWithDefaultSource {
@@ -524,9 +542,7 @@
 - (void)testGetNonExistingDocWhileOnlineCacheOnly {
   FIRDocumentReference *doc = [self documentRef];
 
-  // attempt to get doc. Currently, this is expected to fail. In the future, we
-  // might consider adding support for negative cache hits so that we know
-  // certain documents *don't* exist.
+  // attempt to get doc. This will fail since there's nothing in cache.
   XCTestExpectation *getNonExistingDocCompletion =
       [self expectationWithDescription:@"getNonExistingDoc"];
   [doc getDocumentWithSource:FIRFirestoreSourceCache
@@ -556,9 +572,7 @@
   // go offline for the rest of this test
   [self disableNetwork];
 
-  // attempt to get doc. Currently, this is expected to fail. In the future, we
-  // might consider adding support for negative cache hits so that we know
-  // certain documents *don't* exist.
+  // attempt to get doc. This will fail since there's nothing in cache.
   XCTestExpectation *getNonExistingDocCompletion =
       [self expectationWithDescription:@"getNonExistingDoc"];
   [doc getDocumentWithSource:FIRFirestoreSourceCache
@@ -569,6 +583,24 @@
                     [getNonExistingDocCompletion fulfill];
                   }];
   [self awaitExpectations];
+}
+
+- (void)testGetDeletedDocWhileOfflineCacheOnly {
+  FIRDocumentReference *doc = [self documentRef];
+
+  // delete the doc to get a deleted document into our cache.
+  [self deleteDocumentRef:doc];
+
+  // go offline for the rest of this test
+  [self disableNetwork];
+
+  // should get a FIRDocumentSnapshot with exists=false, fromCache=true
+  FIRDocumentSnapshot *snapshot = [self readDocumentForRef:doc source:FIRFirestoreSourceCache];
+  XCTAssertNotNil(snapshot);
+  XCTAssertFalse(snapshot.exists);
+  XCTAssertNil(snapshot.data);
+  XCTAssertTrue(snapshot.metadata.fromCache);
+  XCTAssertFalse(snapshot.metadata.hasPendingWrites);
 }
 
 - (void)testGetNonExistingCollectionWhileOfflineCacheOnly {

--- a/Firestore/Example/Tests/Integration/API/FIRFirestoreSourceTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRFirestoreSourceTests.mm
@@ -493,7 +493,7 @@
   // go offline for the rest of this test
   [self disableNetwork];
 
-  // attempt to get doc. This will fail since there's nothing in cache.
+  // Attempt to get doc. This will fail since there's nothing in cache.
   XCTestExpectation *getNonExistingDocCompletion =
       [self expectationWithDescription:@"getNonExistingDoc"];
   [doc getDocumentWithCompletion:^(FIRDocumentSnapshot *snapshot, NSError *error) {
@@ -510,13 +510,13 @@
 - (void)xtestGetDeletedDocWhileOfflineWithDefaultSource {
   FIRDocumentReference *doc = [self documentRef];
 
-  // delete the doc to get a deleted document into our cache.
+  // Delete the doc to get a deleted document into our cache.
   [self deleteDocumentRef:doc];
 
-  // go offline for the rest of this test
+  // Go offline for the rest of this test
   [self disableNetwork];
 
-  // should get a FIRDocumentSnapshot with exists=false, fromCache=true
+  // Should get a FIRDocumentSnapshot with exists=false, fromCache=true
   FIRDocumentSnapshot *snapshot = [self readDocumentForRef:doc source:FIRFirestoreSourceDefault];
   XCTAssertNotNil(snapshot);
   XCTAssertFalse(snapshot.exists);
@@ -542,7 +542,7 @@
 - (void)testGetNonExistingDocWhileOnlineCacheOnly {
   FIRDocumentReference *doc = [self documentRef];
 
-  // attempt to get doc. This will fail since there's nothing in cache.
+  // Attempt to get doc. This will fail since there's nothing in cache.
   XCTestExpectation *getNonExistingDocCompletion =
       [self expectationWithDescription:@"getNonExistingDoc"];
   [doc getDocumentWithSource:FIRFirestoreSourceCache
@@ -572,7 +572,7 @@
   // go offline for the rest of this test
   [self disableNetwork];
 
-  // attempt to get doc. This will fail since there's nothing in cache.
+  // Attempt to get doc. This will fail since there's nothing in cache.
   XCTestExpectation *getNonExistingDocCompletion =
       [self expectationWithDescription:@"getNonExistingDoc"];
   [doc getDocumentWithSource:FIRFirestoreSourceCache
@@ -588,13 +588,13 @@
 - (void)testGetDeletedDocWhileOfflineCacheOnly {
   FIRDocumentReference *doc = [self documentRef];
 
-  // delete the doc to get a deleted document into our cache.
+  // Delete the doc to get a deleted document into our cache.
   [self deleteDocumentRef:doc];
 
-  // go offline for the rest of this test
+  // Go offline for the rest of this test
   [self disableNetwork];
 
-  // should get a FIRDocumentSnapshot with exists=false, fromCache=true
+  // Should get a FIRDocumentSnapshot with exists=false, fromCache=true
   FIRDocumentSnapshot *snapshot = [self readDocumentForRef:doc source:FIRFirestoreSourceCache];
   XCTAssertNotNil(snapshot);
   XCTAssertFalse(snapshot.exists);

--- a/Firestore/Source/Core/FSTFirestoreClient.mm
+++ b/Firestore/Source/Core/FSTFirestoreClient.mm
@@ -281,9 +281,11 @@ NS_ASSUME_NONNULL_BEGIN
   [self.workerDispatchQueue dispatchAsync:^{
     FSTMaybeDocument *maybeDoc = [self.localStore readDocument:doc.key];
     if (maybeDoc) {
+      FSTDocument *_Nullable document =
+          ([maybeDoc isKindOfClass:[FSTDocument class]]) ? (FSTDocument *)maybeDoc : nil;
       completion([FIRDocumentSnapshot snapshotWithFirestore:doc.firestore
                                                 documentKey:doc.key
-                                                   document:(FSTDocument *)maybeDoc
+                                                   document:document
                                                   fromCache:YES],
                  nil);
     } else {


### PR DESCRIPTION
get with source='cache' was not properly handling cached deleted documents.
