### PR TITLE
ensure NSUserDefaults is synchronized after setting values

### DIFF
--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -484,6 +484,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
   BOOL isFCMAutoInitEnabled = [self isAutoInitEnabled];
   [_messagingUserDefaults setBool:autoInitEnabled
                            forKey:kFIRMessagingUserDefaultsKeyAutoInitEnabled];
+  [_messagingUserDefaults synchronize];
   if (!isFCMAutoInitEnabled && autoInitEnabled) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
This ensure the aync persist is complete before continue. This should fix the flakiness of integration tests. 