### PR TITLE
Make missing analytics a warning instead of error

### DIFF
--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -331,7 +331,7 @@ static NSMutableDictionary *sLibraryVersions;
   if ([self.name isEqualToString:kFIRDefaultAppName]) {
     Class firAnalyticsClass = NSClassFromString(@"FIRAnalytics");
     if (!firAnalyticsClass) {
-      FIRLogError(kFIRLoggerCore, @"I-COR000022", @"Firebase Analytics is not available.");
+      FIRLogWarning(kFIRLoggerCore, @"I-COR000022", @"Firebase Analytics is not available.");
     } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundeclared-selector"

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -332,9 +332,8 @@ static NSMutableDictionary *sLibraryVersions;
     Class firAnalyticsClass = NSClassFromString(@"FIRAnalytics");
     if (!firAnalyticsClass) {
       FIRLogWarning(kFIRLoggerCore, @"I-COR000022",
-                    @"Firebase Analytics is not available. To add "
-                    @"it, include Firebase/Core in the Podfile or add "
-                    @"FirebaseAnalytics.framework to the Link Build Phase");
+                    @"Firebase Analytics is not available. To add it, include Firebase/Core in the "
+                    @"Podfile or add FirebaseAnalytics.framework to the Link Build Phase");
     } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundeclared-selector"

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -331,7 +331,9 @@ static NSMutableDictionary *sLibraryVersions;
   if ([self.name isEqualToString:kFIRDefaultAppName]) {
     Class firAnalyticsClass = NSClassFromString(@"FIRAnalytics");
     if (!firAnalyticsClass) {
-      FIRLogWarning(kFIRLoggerCore, @"I-COR000022", @"Firebase Analytics is not available.");
+      FIRLogWarning(kFIRLoggerCore, @"I-COR000022", @"Firebase Analytics is not available. To add "
+                                    @"it, include Firebase/Core in the Podfile or add "
+                                    @"FirebaseAnalytics.framework to the Link Build Phase");
     } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundeclared-selector"

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -331,9 +331,10 @@ static NSMutableDictionary *sLibraryVersions;
   if ([self.name isEqualToString:kFIRDefaultAppName]) {
     Class firAnalyticsClass = NSClassFromString(@"FIRAnalytics");
     if (!firAnalyticsClass) {
-      FIRLogWarning(kFIRLoggerCore, @"I-COR000022", @"Firebase Analytics is not available. To add "
-                                    @"it, include Firebase/Core in the Podfile or add "
-                                    @"FirebaseAnalytics.framework to the Link Build Phase");
+      FIRLogWarning(kFIRLoggerCore, @"I-COR000022",
+                    @"Firebase Analytics is not available. To add "
+                    @"it, include Firebase/Core in the Podfile or add "
+                    @"FirebaseAnalytics.framework to the Link Build Phase");
     } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundeclared-selector"


### PR DESCRIPTION
To reduce confusion on questions like https://stackoverflow.com/questions/51627290/5-4-1-firebase-corei-cor000022-firebase-analytics-is-not-available/51737237