### PR TITLE
Reimplement util::MakeString(NSString*)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,14 @@ add_alias(GTest::Main gtest_main)
 add_alias(GMock::GMock gmock)
 
 
+# Benchmark
+set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Firestore disabled")
+set(BENCHMARK_ENABLE_EXCEPTIONS OFF CACHE BOOL "Firestore disabled")
+set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "Firestore disabled")
+set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "Firestore disabled")
+add_external_subdirectory(benchmark)
+
+
 # Abseil-cpp
 # Force disable Abseil's tests, which don't compile under VS2017.
 set(old_build_testing ${BUILD_TESTING})

--- a/Firestore/Example/Benchmarks/CMakeLists.txt
+++ b/Firestore/Example/Benchmarks/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2017 Google
+# Copyright 2018 Google
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(Example/Benchmarks)
-add_subdirectory(Protos)
-add_subdirectory(core)
-add_subdirectory(fuzzing)
+cc_binary(
+  firebase_firestore_util_string_apple_benchmark
+  SOURCES
+    string_apple_benchmark.mm
+  DEPENDS
+    benchmark
+    benchmark_main
+    firebase_firestore_util_base_apple
+)

--- a/Firestore/Example/Benchmarks/string_apple_benchmark.mm
+++ b/Firestore/Example/Benchmarks/string_apple_benchmark.mm
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/util/string_apple.h"
+
+#include <string>
+
+#include "benchmark/benchmark.h"
+
+using firebase::firestore::util::MakeString;
+
+static void BM_MakeString(benchmark::State& state) {
+  NSString* source = [NSString stringWithCString:"hello world" encoding:NSUTF8StringEncoding];
+  for (auto _ : state) {
+    std::string actual = MakeString(source);
+  }
+}
+BENCHMARK(BM_MakeString);

--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		132E3E53179DE287D875F3F2 /* FSTLevelDBTransactionTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 132E36BB104830BD806351AC /* FSTLevelDBTransactionTests.mm */; };
 		132E3EE56C143B2C9ACB6187 /* FSTLevelDBBenchmarkTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 132E3BB3D5C42282B4ACFB20 /* FSTLevelDBBenchmarkTests.mm */; };
 		1CAA9012B25F975D445D5978 /* strerror_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 358C3B5FE573B1D60A4F7592 /* strerror_test.cc */; };
+		36FD4CE79613D18BC783C55B /* string_apple_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0EE5300F8233D14025EF0456 /* string_apple_test.mm */; };
 		3B843E4C1F3A182900548890 /* remote_store_spec_test.json in Resources */ = {isa = PBXBuildFile; fileRef = 3B843E4A1F3930A400548890 /* remote_store_spec_test.json */; };
 		4AA4ABE36065DB79CD76DD8D /* Pods_Firestore_Benchmarks_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F694C3CE4B77B3C0FA4BBA53 /* Pods_Firestore_Benchmarks_iOS.framework */; };
 		54131E9720ADE679001DF3FF /* string_format_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54131E9620ADE678001DF3FF /* string_format_test.cc */; };
@@ -283,6 +284,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0EE5300F8233D14025EF0456 /* string_apple_test.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = string_apple_test.mm; sourceTree = "<group>"; };
 		11984BA0A99D7A7ABA5B0D90 /* Pods-Firestore_Example_iOS-Firestore_SwiftTests_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_iOS-Firestore_SwiftTests_iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_iOS-Firestore_SwiftTests_iOS/Pods-Firestore_Example_iOS-Firestore_SwiftTests_iOS.release.xcconfig"; sourceTree = "<group>"; };
 		1277F98C20D2DF0867496976 /* Pods-Firestore_IntegrationTests_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_IntegrationTests_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_IntegrationTests_iOS/Pods-Firestore_IntegrationTests_iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		12F4357299652983A615F886 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
@@ -666,6 +668,7 @@
 				54A0352B20A3B3D7003E0143 /* status_test_util.h */,
 				54A0352D20A3B3D7003E0143 /* statusor_test.cc */,
 				358C3B5FE573B1D60A4F7592 /* strerror_test.cc */,
+				0EE5300F8233D14025EF0456 /* string_apple_test.mm */,
 				9CFD366B783AE27B9E79EE7A /* string_format_apple_test.mm */,
 				54131E9620ADE678001DF3FF /* string_format_test.cc */,
 				AB380CFC201A2EE200D97691 /* string_util_test.cc */,
@@ -1898,6 +1901,7 @@
 				54A0352F20A3B3D8003E0143 /* status_test.cc in Sources */,
 				54A0353020A3B3D8003E0143 /* statusor_test.cc in Sources */,
 				1CAA9012B25F975D445D5978 /* strerror_test.cc in Sources */,
+				36FD4CE79613D18BC783C55B /* string_apple_test.mm in Sources */,
 				0535C1B65DADAE1CE47FA3CA /* string_format_apple_test.mm in Sources */,
 				54131E9720ADE679001DF3FF /* string_format_test.cc in Sources */,
 				AB380CFE201A2F4500D97691 /* string_util_test.cc in Sources */,

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -88,6 +88,7 @@ cc_library(
     hard_assert_apple.mm
     log.h
     log_apple.mm
+    string_apple.cc
     string_apple.h
     string_format.cc
     string_format.h

--- a/Firestore/core/src/firebase/firestore/util/string_apple.cc
+++ b/Firestore/core/src/firebase/firestore/util/string_apple.cc
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/util/string_apple.h"
+
+#include <string>
+
+#include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+std::string MakeString(CFStringRef str) {
+  CFIndex num_chars = CFStringGetLength(str);
+  if (num_chars == 0) {
+    return {};
+  }
+
+  // In the first pass figure the size required. The size does not include the
+  // null terminator.
+  CFRange range{0, num_chars};
+  CFIndex num_bytes = 0;
+  CFIndex converted = CFStringGetBytes(str, range, kCFStringEncodingUTF8, 0u,
+                                       false, nullptr, 0, &num_bytes);
+  HARD_ASSERT(converted == num_chars);
+
+  std::string result(static_cast<size_t>(num_bytes), '\0');
+  CFIndex check_num_bytes = 0;
+  auto buffer = reinterpret_cast<UInt8*>(&result[0]);
+  converted = CFStringGetBytes(str, range, kCFStringEncodingUTF8, 0u, false,
+                               buffer, num_bytes, &check_num_bytes);
+  HARD_ASSERT(converted == num_chars);
+
+  return result;
+}
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/core/src/firebase/firestore/util/string_apple.cc
+++ b/Firestore/core/src/firebase/firestore/util/string_apple.cc
@@ -16,6 +16,8 @@
 
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 
+#if defined(__APPLE__)
+
 #include <string>
 
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
@@ -39,10 +41,9 @@ std::string MakeString(CFStringRef str) {
   HARD_ASSERT(converted == num_chars);
 
   std::string result(static_cast<size_t>(num_bytes), '\0');
-  CFIndex check_num_bytes = 0;
   auto buffer = reinterpret_cast<UInt8*>(&result[0]);
   converted = CFStringGetBytes(str, range, kCFStringEncodingUTF8, 0u, false,
-                               buffer, num_bytes, &check_num_bytes);
+                               buffer, num_bytes, nullptr);
   HARD_ASSERT(converted == num_chars);
 
   return result;
@@ -51,3 +52,5 @@ std::string MakeString(CFStringRef str) {
 }  // namespace util
 }  // namespace firestore
 }  // namespace firebase
+
+#endif  // defined(__APPLE__)

--- a/Firestore/core/src/firebase/firestore/util/string_apple.h
+++ b/Firestore/core/src/firebase/firestore/util/string_apple.h
@@ -17,10 +17,12 @@
 #ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_STRING_APPLE_H_
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_STRING_APPLE_H_
 
-// Everything in this header exists for compatibility with Objective-C.
-#if __OBJC__
+#if defined(__APPLE__)
+#import <CoreFoundation/CoreFoundation.h>
 
+#if defined(__OBJC__)
 #import <Foundation/Foundation.h>
+#endif
 
 #include <string>
 
@@ -29,6 +31,19 @@
 namespace firebase {
 namespace firestore {
 namespace util {
+
+/**
+ * Returns a copy of the given CFString (or NSString) encoded in UTF-8.
+ */
+std::string MakeString(CFStringRef str);
+
+inline CFStringRef MakeCFString(absl::string_view contents) {
+  auto bytes = reinterpret_cast<const UInt8*>(contents.data());
+  return CFStringCreateWithBytes(kCFAllocatorDefault, bytes, contents.size(),
+                                 kCFStringEncodingUTF8, false);
+}
+
+#if defined(__OBJC__)
 
 // Translates a C string to the equivalent NSString without making a copy.
 inline NSString* WrapNSStringNoCopy(const char* c_str) {
@@ -61,14 +76,21 @@ inline absl::string_view MakeStringView(NSString* str) {
 
 // Creates a std::string wrapper for the contents of the given NSString.
 inline std::string MakeString(NSString* str) {
+  CFStringRef cf_str = (__bridge CFStringRef)str;
+  return MakeString(cf_str);
+}
+
+// Creates a std::string wrapper for the contents of the given NSString.
+inline std::string MakeStringOld(NSString* str) {
   return std::string([str UTF8String],
                      [str lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
 }
+
+#endif  // defined(__OBJC__)
 
 }  // namespace util
 }  // namespace firestore
 }  // namespace firebase
 
-#endif  // __OBJC__
-
+#endif  // defined(__APPLE__)
 #endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_STRING_APPLE_H_

--- a/Firestore/core/src/firebase/firestore/util/string_apple.h
+++ b/Firestore/core/src/firebase/firestore/util/string_apple.h
@@ -80,12 +80,6 @@ inline std::string MakeString(NSString* str) {
   return MakeString(cf_str);
 }
 
-// Creates a std::string wrapper for the contents of the given NSString.
-inline std::string MakeStringOld(NSString* str) {
-  return std::string([str UTF8String],
-                     [str lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
-}
-
 #endif  // defined(__OBJC__)
 
 }  // namespace util

--- a/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
@@ -61,6 +61,7 @@ if(APPLE)
     SOURCES
       hard_assert_test.cc
       log_test.cc
+      string_apple_test.mm
     DEPENDS
       firebase_firestore_util_base_apple
   )

--- a/Firestore/core/test/firebase/firestore/util/string_apple_test.mm
+++ b/Firestore/core/test/firebase/firestore/util/string_apple_test.mm
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/util/string_apple.h"
+
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+class StringAppleTest : public testing::Test {
+ protected:
+  std::vector<std::string> StringTestCases() {
+    return std::vector<std::string>{
+        "",
+        "a",
+        "abc def",
+        u8"æ",
+        // Note: Each one of the three embedded universal character names
+        // (\u-escaped) maps to three chars, so the total length of the string
+        // literal is 10 (ignoring the terminating null), and the resulting
+        // string literal is the same as
+        // '\0\xed\x9f\xbf\xee\x80\x80\xef\xbf\xbf'". The size of 10 must be
+        // added, or else std::string will see the \0 at the start and assume
+        // that's the end of the string.
+        {u8"\0\ud7ff\ue000\uffff", 10},
+        {"\0\xed\x9f\xbf\xee\x80\x80\xef\xbf\xbf", 10},
+        u8"(╯°□°）╯︵ ┻━┻",
+    };
+  }
+};
+
+TEST_F(StringAppleTest, MakeStringFromCFStringRef) {
+  for (const std::string& string_value : StringTestCases()) {
+    CFStringRef cf_string = MakeCFString(string_value);
+    std::string actual = MakeString(cf_string);
+    EXPECT_EQ(string_value, actual);
+    CFRelease(cf_string);
+  }
+}
+
+TEST_F(StringAppleTest, MakeStringFromNSString) {
+  for (const std::string& string_value : StringTestCases()) {
+    NSString* ns_string = WrapNSString(string_value);
+    std::string actual = MakeString(ns_string);
+    EXPECT_EQ(string_value, actual);
+  }
+}
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase

--- a/cmake/external/benchmark.cmake
+++ b/cmake/external/benchmark.cmake
@@ -12,21 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.1)
-project(Firebase-download C CXX)
+include(ExternalProject)
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+if(TARGET benchmark)
+  return()
+endif()
 
-set(
-  FIREBASE_DOWNLOAD_DIR
-  ${PROJECT_BINARY_DIR}/downloads
-  CACHE PATH "Where to store downloaded files"
+set(commit v1.4.1)
+
+ExternalProject_Add(
+  benchmark
+
+  DOWNLOAD_DIR ${FIREBASE_DOWNLOAD_DIR}
+  DOWNLOAD_NAME benchmark-${commit}.tar.gz
+  URL https://github.com/google/benchmark/archive/${commit}.tar.gz
+  URL_HASH SHA256=f8e525db3c42efc9c7f3bc5176a8fa893a9a9920bbd08cef30fb56a51854d60d
+
+  PREFIX ${PROJECT_BINARY_DIR}
+
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND     ""
+  INSTALL_COMMAND   ""
+  TEST_COMMAND      ""
 )
-
-include(benchmark)
-include(googletest)
-include(grpc)
-include(leveldb)
-include(nanopb)
-include(protobuf)
-include(libfuzzer)


### PR DESCRIPTION
It turns out that `-[NSString UTF8String]` is almost assuredly copying the data into an autoreleased `NSData` and then returning a pointer into that buffer rather than exposing any internal state.

This change reimplements MakeString by bridging to CFString and then using CFString functions to copy directly into a std::string, saving a copy. Also, added a benchmark to show that this really works. Indeed, before:

```
Running Release/Firestore/Example/Benchmarks/firebase_firestore_util_string_apple_benchmark
Run on (8 X 2900 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 8388K (x1)
-----------------------------------------------------
Benchmark              Time           CPU Iterations
-----------------------------------------------------
BM_MakeString         63 ns         63 ns   86984076
```
After:
```
BM_MakeString         30 ns         30 ns  187703856
```

Besides the speedup, this also makes it possible to manipulate Objective-C strings from straight C++.