### PR TITLE
Replace uses of absl::string_view in constructor parameters with std::string

### DIFF
--- a/Firestore/Example/Benchmarks/string_apple_benchmark.mm
+++ b/Firestore/Example/Benchmarks/string_apple_benchmark.mm
@@ -21,11 +21,22 @@
 #include "benchmark/benchmark.h"
 
 using firebase::firestore::util::MakeString;
+using firebase::firestore::util::MakeStringView;
 
 static void BM_MakeString(benchmark::State& state) {
   NSString* source = [NSString stringWithCString:"hello world" encoding:NSUTF8StringEncoding];
   for (auto _ : state) {
     std::string actual = MakeString(source);
+    (void)actual;
   }
 }
 BENCHMARK(BM_MakeString);
+
+static void BM_MakeStringView(benchmark::State& state) {
+  NSString* source = [NSString stringWithCString:"hello world" encoding:NSUTF8StringEncoding];
+  for (auto _ : state) {
+    absl::string_view actual = MakeStringView(source);
+    (void)actual;
+  }
+}
+BENCHMARK(BM_MakeStringView);

--- a/Firestore/Example/Tests/API/FSTAPIHelpers.mm
+++ b/Firestore/Example/Tests/API/FSTAPIHelpers.mm
@@ -91,17 +91,15 @@ FIRQuerySnapshot *FSTTestQuerySnapshot(
       [FIRSnapshotMetadata snapshotMetadataWithPendingWrites:hasPendingWrites fromCache:fromCache];
   FSTDocumentSet *oldDocuments = FSTTestDocSet(FSTDocumentComparatorByKey, @[]);
   for (NSString *key in oldDocs) {
-    oldDocuments = [oldDocuments
-        documentSetByAddingDocument:FSTTestDoc(util::MakeStringView([NSString
-                                                   stringWithFormat:@"%s/%@", path.data(), key]),
-                                               1, oldDocs[key], hasPendingWrites)];
+    oldDocuments =
+        [oldDocuments documentSetByAddingDocument:FSTTestDoc(util::StringFormat("%s/%s", path, key),
+                                                             1, oldDocs[key], hasPendingWrites)];
   }
   FSTDocumentSet *newDocuments = oldDocuments;
   NSArray<FSTDocumentViewChange *> *documentChanges = [NSArray array];
   for (NSString *key in docsToAdd) {
     FSTDocument *docToAdd =
-        FSTTestDoc(util::MakeStringView([NSString stringWithFormat:@"%s/%@", path.data(), key]), 1,
-                   docsToAdd[key], hasPendingWrites);
+        FSTTestDoc(util::StringFormat("%s/%s", path, key), 1, docsToAdd[key], hasPendingWrites);
     newDocuments = [newDocuments documentSetByAddingDocument:docToAdd];
     documentChanges = [documentChanges
         arrayByAddingObject:[FSTDocumentViewChange

--- a/Firestore/Example/Tests/Integration/FSTDatastoreTests.mm
+++ b/Firestore/Example/Tests/Integration/FSTDatastoreTests.mm
@@ -168,10 +168,10 @@ NS_ASSUME_NONNULL_BEGIN
     [GRPCCall useInsecureConnectionsForHost:settings.host];
   }
 
-  DatabaseId database_id(util::MakeStringView(projectID), DatabaseId::kDefault);
+  DatabaseId database_id(util::MakeString(projectID), DatabaseId::kDefault);
 
-  _databaseInfo = DatabaseInfo(database_id, "test-key", util::MakeStringView(settings.host),
-                               settings.sslEnabled);
+  _databaseInfo =
+      DatabaseInfo(database_id, "test-key", util::MakeString(settings.host), settings.sslEnabled);
 
   _testWorkerQueue = [FSTDispatchQueue
       queueWith:dispatch_queue_create("com.google.firestore.FSTDatastoreTestsWorkerQueue",

--- a/Firestore/Example/Tests/Integration/FSTStreamTests.mm
+++ b/Firestore/Example/Tests/Integration/FSTStreamTests.mm
@@ -159,8 +159,8 @@ using firebase::firestore::model::SnapshotVersion;
   _testQueue = dispatch_queue_create("FSTStreamTestWorkerQueue", DISPATCH_QUEUE_SERIAL);
   _workerDispatchQueue = [[FSTDispatchQueue alloc] initWithQueue:_testQueue];
 
-  _databaseInfo = DatabaseInfo(database_id, "test-key", util::MakeStringView(settings.host),
-                               settings.sslEnabled);
+  _databaseInfo =
+      DatabaseInfo(database_id, "test-key", util::MakeString(settings.host), settings.sslEnabled);
 
   _delegate = [[FSTStreamStatusDelegate alloc] initWithTestCase:self queue:_workerDispatchQueue];
 

--- a/Firestore/Example/Tests/Integration/FSTStreamTests.mm
+++ b/Firestore/Example/Tests/Integration/FSTStreamTests.mm
@@ -153,7 +153,7 @@ using firebase::firestore::model::SnapshotVersion;
   [super setUp];
 
   FIRFirestoreSettings *settings = [FSTIntegrationTestCase settings];
-  DatabaseId database_id(util::MakeStringView([FSTIntegrationTestCase projectID]),
+  DatabaseId database_id(util::MakeString([FSTIntegrationTestCase projectID]),
                          DatabaseId::kDefault);
 
   _testQueue = dispatch_queue_create("FSTStreamTestWorkerQueue", DISPATCH_QUEUE_SERIAL);

--- a/Firestore/Example/Tests/Util/FSTHelpers.h
+++ b/Firestore/Example/Tests/Util/FSTHelpers.h
@@ -16,6 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
+#include <string>
 #include <vector>
 
 #import "Firestore/Source/Core/FSTTypes.h"
@@ -235,9 +236,7 @@ FSTDeletedDocument *FSTTestDeletedDoc(const absl::string_view path, FSTTestSnaps
 /**
  * A convenience method for creating a document reference from a path string.
  */
-FSTDocumentKeyReference *FSTTestRef(const absl::string_view projectID,
-                                    const absl::string_view databaseID,
-                                    NSString *path);
+FSTDocumentKeyReference *FSTTestRef(std::string projectID, std::string databaseID, NSString *path);
 
 /** A convenience method for creating a query for the given path (without any other filters). */
 FSTQuery *FSTTestQuery(const absl::string_view path);

--- a/Firestore/Example/Tests/Util/FSTHelpers.mm
+++ b/Firestore/Example/Tests/Util/FSTHelpers.mm
@@ -165,12 +165,10 @@ FSTDeletedDocument *FSTTestDeletedDoc(const absl::string_view path,
   return [FSTDeletedDocument documentWithKey:key version:testutil::Version(version)];
 }
 
-FSTDocumentKeyReference *FSTTestRef(const absl::string_view projectID,
-                                    const absl::string_view database,
-                                    NSString *path) {
+FSTDocumentKeyReference *FSTTestRef(std::string projectID, std::string database, NSString *path) {
   // This owns the DatabaseIds since we do not have FirestoreClient instance to own them.
   static std::list<DatabaseId> database_ids;
-  database_ids.emplace_back(projectID, database);
+  database_ids.emplace_back(std::move(projectID), std::move(database));
   return [[FSTDocumentKeyReference alloc] initWithKey:FSTTestDocKey(path)
                                            databaseID:&database_ids.back()];
 }

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -154,7 +154,7 @@ NS_ASSUME_NONNULL_BEGIN
   std::unique_ptr<CredentialsProvider> credentials_provider =
       absl::make_unique<firebase::firestore::auth::EmptyCredentialsProvider>();
 
-  FIRFirestore *firestore = [[FIRFirestore alloc] initWithProjectID:util::MakeStringView(projectID)
+  FIRFirestore *firestore = [[FIRFirestore alloc] initWithProjectID:util::MakeString(projectID)
                                                            database:DatabaseId::kDefault
                                                      persistenceKey:persistenceKey
                                                 credentialsProvider:std::move(credentials_provider)

--- a/Firestore/Source/API/FIRFirestore+Internal.h
+++ b/Firestore/Source/API/FIRFirestore+Internal.h
@@ -17,6 +17,7 @@
 #import "FIRFirestore.h"
 
 #include <memory>
+#include <string>
 
 #include "Firestore/core/src/firebase/firestore/auth/credentials_provider.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
@@ -34,8 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
  * Initializes a Firestore object with all the required parameters directly. This exists so that
  * tests can create FIRFirestore objects without needing FIRApp.
  */
-- (instancetype)initWithProjectID:(const absl::string_view)projectID
-                         database:(const absl::string_view)database
+- (instancetype)initWithProjectID:(std::string)projectID
+                         database:(std::string)database
                    persistenceKey:(NSString *)persistenceKey
               credentialsProvider:(std::unique_ptr<firebase::firestore::auth::CredentialsProvider>)
                                       credentialsProvider

--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -251,8 +251,8 @@ extern "C" NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
             "follow these steps, YOUR APP MAY BREAK.");
       }
 
-      const DatabaseInfo database_info(*self.databaseID, util::MakeStringView(_persistenceKey),
-                                       util::MakeStringView(_settings.host), _settings.sslEnabled);
+      const DatabaseInfo database_info(*self.databaseID, util::MakeString(_persistenceKey),
+                                       util::MakeString(_settings.host), _settings.sslEnabled);
 
       std::unique_ptr<Executor> userExecutor =
           absl::make_unique<ExecutorLibdispatch>(_settings.dispatchQueue);

--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -23,6 +23,7 @@
 #import <FirebaseCore/FIROptions.h>
 
 #include <memory>
+#include <string>
 #include <utility>
 
 #import "FIRFirestoreSettings.h"
@@ -158,14 +159,14 @@ extern "C" NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
   return [provider firestoreForDatabase:database];
 }
 
-- (instancetype)initWithProjectID:(const absl::string_view)projectID
-                         database:(const absl::string_view)database
+- (instancetype)initWithProjectID:(std::string)projectID
+                         database:(std::string)database
                    persistenceKey:(NSString *)persistenceKey
               credentialsProvider:(std::unique_ptr<CredentialsProvider>)credentialsProvider
               workerDispatchQueue:(FSTDispatchQueue *)workerDispatchQueue
                       firebaseApp:(FIRApp *)app {
   if (self = [super init]) {
-    _databaseID = DatabaseId(projectID, database);
+    _databaseID = DatabaseId{std::move(projectID), std::move(database)};
     FSTPreConverterBlock block = ^id _Nullable(id _Nullable input) {
       if ([input isKindOfClass:[FIRDocumentReference class]]) {
         FIRDocumentReference *documentReference = (FIRDocumentReference *)input;

--- a/Firestore/Source/API/FSTFirestoreComponent.mm
+++ b/Firestore/Source/API/FSTFirestoreComponent.mm
@@ -89,8 +89,8 @@ NS_ASSUME_NONNULL_BEGIN
 
       NSString *persistenceKey = self.app.name;
       NSString *projectID = self.app.options.projectID;
-      firestore = [[FIRFirestore alloc] initWithProjectID:util::MakeStringView(projectID)
-                                                 database:util::MakeStringView(database)
+      firestore = [[FIRFirestore alloc] initWithProjectID:util::MakeString(projectID)
+                                                 database:util::MakeString(database)
                                            persistenceKey:persistenceKey
                                       credentialsProvider:std::move(credentials_provider)
                                       workerDispatchQueue:workerDispatchQueue

--- a/Firestore/core/src/firebase/firestore/auth/firebase_credentials_provider_apple.mm
+++ b/Firestore/core/src/firebase/firestore/auth/firebase_credentials_provider_apple.mm
@@ -91,38 +91,37 @@ void FirebaseCredentialsProvider::GetToken(TokenListener completion) {
   int initial_user_counter = contents_->user_counter;
 
   std::weak_ptr<Contents> weak_contents = contents_;
-  void (^get_token_callback)(NSString*, NSError*) =
-      ^(NSString* _Nullable token, NSError* _Nullable error) {
-        std::shared_ptr<Contents> contents = weak_contents.lock();
-        if (!contents) {
-          return;
-        }
+  void (^get_token_callback)(NSString*, NSError*) = ^(
+      NSString* _Nullable token, NSError* _Nullable error) {
+    std::shared_ptr<Contents> contents = weak_contents.lock();
+    if (!contents) {
+      return;
+    }
 
-        std::unique_lock<std::mutex> lock(contents->mutex);
-        if (initial_user_counter != contents->user_counter) {
-          // Cancel the request since the user changed while the request was
-          // outstanding so the response is likely for a previous user (which
-          // user, we can't be sure).
-          completion(util::Status(FirestoreErrorCode::Aborted,
-                                  "getToken aborted due to user change."));
+    std::unique_lock<std::mutex> lock(contents->mutex);
+    if (initial_user_counter != contents->user_counter) {
+      // Cancel the request since the user changed while the request was
+      // outstanding so the response is likely for a previous user (which
+      // user, we can't be sure).
+      completion(util::Status(FirestoreErrorCode::Aborted,
+                              "getToken aborted due to user change."));
+    } else {
+      if (error == nil) {
+        if (token != nil) {
+          completion(Token{util::MakeString(token), contents->current_user});
         } else {
-          if (error == nil) {
-            if (token != nil) {
-              completion(
-                  Token{util::MakeStringView(token), contents->current_user});
-            } else {
-              completion(Token::Unauthenticated());
-            }
-          } else {
-            FirestoreErrorCode error_code = FirestoreErrorCode::Unknown;
-            if (error.domain == FIRFirestoreErrorDomain) {
-              error_code = static_cast<FirestoreErrorCode>(error.code);
-            }
-            completion(util::Status(
-                error_code, util::MakeStringView(error.localizedDescription)));
-          }
+          completion(Token::Unauthenticated());
         }
-      };
+      } else {
+        FirestoreErrorCode error_code = FirestoreErrorCode::Unknown;
+        if (error.domain == FIRFirestoreErrorDomain) {
+          error_code = static_cast<FirestoreErrorCode>(error.code);
+        }
+        completion(util::Status(error_code,
+                                util::MakeString(error.localizedDescription)));
+      }
+    }
+  };
 
   // TODO(wilhuff): Need a better abstraction over a missing auth provider.
   if (contents_->auth) {

--- a/Firestore/core/src/firebase/firestore/auth/token.cc
+++ b/Firestore/core/src/firebase/firestore/auth/token.cc
@@ -16,16 +16,18 @@
 
 #include "Firestore/core/src/firebase/firestore/auth/token.h"
 
+#include <utility>
+
 namespace firebase {
 namespace firestore {
 namespace auth {
 
-Token::Token(const absl::string_view token, const User& user)
-    : token_(token), user_(user) {
+Token::Token(std::string token, User user)
+    : token_{std::move(token)}, user_{std::move(user)} {
 }
 
 const Token& Token::Unauthenticated() {
-  static const Token kUnauthenticatedToken(absl::string_view(),
+  static const Token kUnauthenticatedToken(std::string{},
                                            User::Unauthenticated());
   return kUnauthenticatedToken;
 }

--- a/Firestore/core/src/firebase/firestore/auth/token.h
+++ b/Firestore/core/src/firebase/firestore/auth/token.h
@@ -42,7 +42,7 @@ namespace auth {
 // TODO(zxu123): Make this support token-type for desktop workflow.
 class Token {
  public:
-  Token(absl::string_view token, const User& user);
+  Token(std::string token, User user);
 
   /** The actual raw token. */
   const std::string& token() const {

--- a/Firestore/core/src/firebase/firestore/auth/user.cc
+++ b/Firestore/core/src/firebase/firestore/auth/user.cc
@@ -16,17 +16,19 @@
 
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
 
+#include <utility>
+
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 
 namespace firebase {
 namespace firestore {
 namespace auth {
 
-User::User() : is_authenticated_(false) {
+User::User() : is_authenticated_{false} {
 }
 
-User::User(const absl::string_view uid) : uid_(uid), is_authenticated_(true) {
-  HARD_ASSERT(!uid.empty());
+User::User(std::string uid) : uid_{std::move(uid)}, is_authenticated_{true} {
+  HARD_ASSERT(!uid_.empty());
 }
 
 const User& User::Unauthenticated() {

--- a/Firestore/core/src/firebase/firestore/auth/user.h
+++ b/Firestore/core/src/firebase/firestore/auth/user.h
@@ -41,7 +41,7 @@ class User {
   User();
 
   /** Construct an authenticated user with the given UID. */
-  explicit User(absl::string_view uid);
+  explicit User(std::string uid);
 
   const std::string& uid() const {
     return uid_;
@@ -65,7 +65,7 @@ class User {
     if (uid == nil) {
       return Unauthenticated();
     } else {
-      return User(util::MakeStringView(uid));
+      return User{util::MakeString(uid)};
     }
   }
 #endif  // defined(__OBJC__)

--- a/Firestore/core/src/firebase/firestore/core/database_info.cc
+++ b/Firestore/core/src/firebase/firestore/core/database_info.cc
@@ -16,19 +16,21 @@
 
 #include "Firestore/core/src/firebase/firestore/core/database_info.h"
 
+#include <utility>
+
 namespace firebase {
 namespace firestore {
 namespace core {
 
 DatabaseInfo::DatabaseInfo(
     const firebase::firestore::model::DatabaseId& database_id,
-    const absl::string_view persistence_key,
-    const absl::string_view host,
+    std::string persistence_key,
+    std::string host,
     bool ssl_enabled)
-    : database_id_(database_id),
-      persistence_key_(persistence_key),
-      host_(host),
-      ssl_enabled_(ssl_enabled) {
+    : database_id_{database_id},
+      persistence_key_{std::move(persistence_key)},
+      host_{std::move(host)},
+      ssl_enabled_{ssl_enabled} {
 }
 
 }  // namespace core

--- a/Firestore/core/src/firebase/firestore/core/database_info.h
+++ b/Firestore/core/src/firebase/firestore/core/database_info.h
@@ -20,7 +20,6 @@
 #include <string>
 
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
-#include "absl/strings/string_view.h"
 
 namespace firebase {
 namespace firestore {
@@ -45,8 +44,8 @@ class DatabaseInfo {
    * @param ssl_enabled Whether to use SSL when connecting.
    */
   DatabaseInfo(const firebase::firestore::model::DatabaseId& database_id,
-               absl::string_view persistence_key,
-               absl::string_view host,
+               std::string persistence_key,
+               std::string host,
                bool ssl_enabled);
 
   const firebase::firestore::model::DatabaseId& database_id() const {

--- a/Firestore/core/src/firebase/firestore/model/database_id.cc
+++ b/Firestore/core/src/firebase/firestore/model/database_id.cc
@@ -16,6 +16,8 @@
 
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
 
+#include <utility>
+
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 
 namespace firebase {
@@ -24,11 +26,10 @@ namespace model {
 
 constexpr const char* DatabaseId::kDefault;
 
-DatabaseId::DatabaseId(const absl::string_view project_id,
-                       const absl::string_view database_id)
-    : project_id_(project_id), database_id_(database_id) {
-  HARD_ASSERT(!project_id.empty());
-  HARD_ASSERT(!database_id.empty());
+DatabaseId::DatabaseId(std::string project_id, std::string database_id)
+    : project_id_{std::move(project_id)}, database_id_{std::move(database_id)} {
+  HARD_ASSERT(!project_id_.empty());
+  HARD_ASSERT(!database_id_.empty());
 }
 
 }  // namespace model

--- a/Firestore/core/src/firebase/firestore/model/database_id.h
+++ b/Firestore/core/src/firebase/firestore/model/database_id.h
@@ -45,7 +45,7 @@ class DatabaseId {
    * @param project_id The project for the database.
    * @param database_id The database in the project to use.
    */
-  DatabaseId(absl::string_view project_id, absl::string_view database_id);
+  DatabaseId(std::string project_id, std::string database_id);
 
   const std::string& project_id() const {
     return project_id_;


### PR DESCRIPTION
Many of our types, especially ones written early on in the C++ migration, take string-like parameters as `absl::string_view`, which allows the widest range of possible values in, including views of `NSString`.

However, benchmarking in #1673 has shown that wrapping an `NSString` with an `absl::string_view` turns out not to be a cheap operation at all so this latitude isn't actually helping.

Meanwhile, using `absl::string_view` for these parameters forces a copy from all callers, even if the caller could naturally move a `std::string` into the new value.

This PR cleans up all the types that were using `MakeStringView` of an `NSString` to just `MakeString` and changes the implementations to just take `std::string` by value. There are plenty of other usages of `MakeStringView` that I'll address separately. This is only the usages that required changing the parameters as well as the arguments passed in.