### PR TITLE
Tweak array-contains test for partial object matches.

### DIFF
--- a/Firestore/Example/Tests/Core/FSTQueryTests.mm
+++ b/Firestore/Example/Tests/Core/FSTQueryTests.mm
@@ -185,14 +185,16 @@ NS_ASSUME_NONNULL_BEGIN
                                                                     @{ @"a" : @[ @42 ] })];
 
   // array without element.
-  FSTDocument *doc = FSTTestDoc(
-      "collection/1", 0,
-      @{ @"array" : @[
-        @{ @"a" : @42 },
-        @{ @"a" : @[ @42, @43 ] },
-        @{ @"b" : @[ @42 ] }
-      ] },
-      NO);
+  FSTDocument *doc = FSTTestDoc("collection/1", 0, @{
+    @"array" : @[
+      @{ @"a" : @42 },
+      @{ @"a" : @[ @42, @43 ] },
+      @{ @"b" : @[ @42 ] },
+      @{ @"a" : @[ @42 ],
+         @"b" : @42 }
+    ]
+  },
+                                NO);
   XCTAssertFalse([query matchesDocument:doc]);
 
   // array with element.

--- a/Firestore/Example/Tests/Core/FSTQueryTests.mm
+++ b/Firestore/Example/Tests/Core/FSTQueryTests.mm
@@ -187,11 +187,11 @@ NS_ASSUME_NONNULL_BEGIN
   // array without element.
   FSTDocument *doc = FSTTestDoc("collection/1", 0, @{
     @"array" : @[
-      @{ @"a" : @42 },
-      @{ @"a" : @[ @42, @43 ] },
-      @{ @"b" : @[ @42 ] },
-      @{ @"a" : @[ @42 ],
-         @"b" : @42 }
+      @{@"a" : @42},
+      @{@"a" : @[ @42, @43 ]},
+      @{@"b" : @[ @42 ]},
+      @{@"a" : @[ @42 ],
+        @"b" : @42}
     ]
   },
                                 NO);


### PR DESCRIPTION
Ensure b/112521956 cannot happen (makes sure we don't partially match against objects in the array)

[port of https://github.com/firebase/firebase-js-sdk/pull/1115]