### PR TITLE
Migrate nearly all usages of MakeStringView to MakeString

### DIFF
--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -131,11 +131,11 @@ NSString *const kNoLRUTag = @"no-lru";
 
 - (nullable FSTQuery *)parseQuery:(id)querySpec {
   if ([querySpec isKindOfClass:[NSString class]]) {
-    return FSTTestQuery(util::MakeStringView((NSString *)querySpec));
+    return FSTTestQuery(util::MakeString((NSString *)querySpec));
   } else if ([querySpec isKindOfClass:[NSDictionary class]]) {
     NSDictionary *queryDict = (NSDictionary *)querySpec;
     NSString *path = queryDict[@"path"];
-    __block FSTQuery *query = FSTTestQuery(util::MakeStringView(path));
+    __block FSTQuery *query = FSTTestQuery(util::MakeString(path));
     if (queryDict[@"limit"]) {
       NSNumber *limit = queryDict[@"limit"];
       query = [query queryBySettingLimit:limit.integerValue];
@@ -144,16 +144,16 @@ NSString *const kNoLRUTag = @"no-lru";
       NSArray *filters = queryDict[@"filters"];
       [filters enumerateObjectsUsingBlock:^(NSArray *_Nonnull filter, NSUInteger idx,
                                             BOOL *_Nonnull stop) {
-        query = [query queryByAddingFilter:FSTTestFilter(util::MakeStringView(filter[0]), filter[1],
-                                                         filter[2])];
+        query = [query
+            queryByAddingFilter:FSTTestFilter(util::MakeString(filter[0]), filter[1], filter[2])];
       }];
     }
     if (queryDict[@"orderBys"]) {
       NSArray *orderBys = queryDict[@"orderBys"];
       [orderBys enumerateObjectsUsingBlock:^(NSArray *_Nonnull orderBy, NSUInteger idx,
                                              BOOL *_Nonnull stop) {
-        query = [query
-            queryByAddingSortOrder:FSTTestOrderBy(util::MakeStringView(orderBy[0]), orderBy[1])];
+        query =
+            [query queryByAddingSortOrder:FSTTestOrderBy(util::MakeString(orderBy[0]), orderBy[1])];
       }];
     }
     return query;
@@ -176,7 +176,7 @@ NSString *const kNoLRUTag = @"no-lru";
   }
   NSNumber *version = change[1];
   XCTAssert([change[0] isKindOfClass:[NSString class]]);
-  FSTDocument *doc = FSTTestDoc(util::MakeStringView((NSString *)change[0]), version.longLongValue,
+  FSTDocument *doc = FSTTestDoc(util::MakeString((NSString *)change[0]), version.longLongValue,
                                 change[2], hasMutations);
   return [FSTDocumentViewChange changeWithDocument:doc type:type];
 }
@@ -202,7 +202,7 @@ NSString *const kNoLRUTag = @"no-lru";
 
 - (void)doPatch:(NSArray *)patchSpec {
   [self.driver
-      writeUserMutation:FSTTestPatchMutation(util::MakeStringView(patchSpec[0]), patchSpec[1], {})];
+      writeUserMutation:FSTTestPatchMutation(util::MakeString(patchSpec[0]), patchSpec[1], {})];
 }
 
 - (void)doDelete:(NSString *)key {

--- a/Firestore/Example/Tests/Util/FSTHelpers.mm
+++ b/Firestore/Example/Tests/Util/FSTHelpers.mm
@@ -243,7 +243,7 @@ FSTPatchMutation *FSTTestPatchMutation(const absl::string_view path,
   __block FSTObjectValue *objectValue = [FSTObjectValue objectValue];
   __block std::vector<FieldPath> fieldMaskPaths;
   [values enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, BOOL *stop) {
-    const FieldPath path = testutil::Field(util::MakeStringView(key));
+    const FieldPath path = testutil::Field(util::MakeString(key));
     fieldMaskPaths.push_back(path);
     if (![value isEqual:kDeleteSentinel]) {
       FSTFieldValue *parsedValue = FSTTestFieldValue(value);
@@ -260,7 +260,7 @@ FSTPatchMutation *FSTTestPatchMutation(const absl::string_view path,
 }
 
 FSTTransformMutation *FSTTestTransformMutation(NSString *path, NSDictionary<NSString *, id> *data) {
-  FSTDocumentKey *key = [FSTDocumentKey keyWithPath:testutil::Resource(util::MakeStringView(path))];
+  FSTDocumentKey *key = [FSTDocumentKey keyWithPath:testutil::Resource(util::MakeString(path))];
   FSTUserDataConverter *converter = FSTTestUserDataConverter();
   FSTParsedUpdateData *result = [converter parsedUpdateData:data];
   HARD_ASSERT(result.data.value.count == 0,
@@ -448,11 +448,11 @@ FSTLocalViewChanges *FSTTestViewChanges(FSTTargetID targetID,
                                         NSArray<NSString *> *removedKeys) {
   DocumentKeySet added;
   for (NSString *keyPath in addedKeys) {
-    added = added.insert(testutil::Key(util::MakeStringView(keyPath)));
+    added = added.insert(testutil::Key(util::MakeString(keyPath)));
   }
   DocumentKeySet removed;
   for (NSString *keyPath in removedKeys) {
-    removed = removed.insert(testutil::Key(util::MakeStringView(keyPath)));
+    removed = removed.insert(testutil::Key(util::MakeString(keyPath)));
   }
   return [FSTLocalViewChanges changesForTarget:targetID
                                      addedKeys:std::move(added)

--- a/Firestore/Source/API/FIRCollectionReference.mm
+++ b/Firestore/Source/API/FIRCollectionReference.mm
@@ -112,7 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (!documentPath) {
     FSTThrowInvalidArgument(@"Document path cannot be nil.");
   }
-  const ResourcePath subPath = ResourcePath::FromString(util::MakeStringView(documentPath));
+  const ResourcePath subPath = ResourcePath::FromString(util::MakeString(documentPath));
   const ResourcePath path = self.query.path.Append(subPath);
   return [FIRDocumentReference referenceWithPath:path firestore:self.firestore];
 }

--- a/Firestore/Source/API/FIRDocumentReference.mm
+++ b/Firestore/Source/API/FIRDocumentReference.mm
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (!collectionPath) {
     FSTThrowInvalidArgument(@"Collection path cannot be nil.");
   }
-  const ResourcePath subPath = ResourcePath::FromString(util::MakeStringView(collectionPath));
+  const ResourcePath subPath = ResourcePath::FromString(util::MakeString(collectionPath));
   const ResourcePath path = self.key.path().Append(subPath);
   return [FIRCollectionReference referenceWithPath:path firestore:self.firestore];
 }

--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -276,7 +276,7 @@ extern "C" NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
   }
 
   [self ensureClientConfigured];
-  const ResourcePath path = ResourcePath::FromString(util::MakeStringView(collectionPath));
+  const ResourcePath path = ResourcePath::FromString(util::MakeString(collectionPath));
   return [FIRCollectionReference referenceWithPath:path firestore:self];
 }
 
@@ -289,7 +289,7 @@ extern "C" NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
   }
 
   [self ensureClientConfigured];
-  const ResourcePath path = ResourcePath::FromString(util::MakeStringView(documentPath));
+  const ResourcePath path = ResourcePath::FromString(util::MakeString(documentPath));
   return [FIRDocumentReference referenceWithPath:path firestore:self];
 }
 

--- a/Firestore/Source/API/FSTFirestoreComponent.mm
+++ b/Firestore/Source/API/FSTFirestoreComponent.mm
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (!firestore) {
       std::string queue_name{"com.google.firebase.firestore"};
       if (!self.app.isDefaultApp) {
-        absl::StrAppend(&queue_name, ".", util::MakeStringView(self.app.name));
+        absl::StrAppend(&queue_name, ".", util::MakeString(self.app.name));
       }
       FSTDispatchQueue *workerDispatchQueue = [FSTDispatchQueue
           queueWith:dispatch_queue_create(queue_name.c_str(), DISPATCH_QUEUE_SERIAL)];

--- a/Firestore/Source/API/FSTUserDataConverter.mm
+++ b/Firestore/Source/API/FSTUserDataConverter.mm
@@ -282,7 +282,7 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
                                                         arrayElement:NO
                                                      fieldTransforms:_fieldTransforms
                                                            fieldMask:_fieldMask];
-  [context validatePathSegment:util::MakeStringView(fieldName)];
+  [context validatePathSegment:util::MakeString(fieldName)];
   return context;
 }
 

--- a/Firestore/Source/Local/FSTLevelDBQueryCache.mm
+++ b/Firestore/Source/Local/FSTLevelDBQueryCache.mm
@@ -46,8 +46,8 @@ using firebase::firestore::local::LevelDbTransaction;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::SnapshotVersion;
+using firebase::firestore::util::MakeString;
 using firebase::firestore::util::OrderedCode;
-using firebase::firestore::util::MakeStringView;
 using leveldb::DB;
 using leveldb::Slice;
 using leveldb::Status;
@@ -241,7 +241,7 @@ FSTListenSequenceNumber ReadSequenceNumber(const absl::string_view &slice) {
 
   NSString *canonicalID = queryData.query.canonicalID;
   std::string indexKey =
-      LevelDbQueryTargetKey::Key(MakeStringView(canonicalID), queryData.targetID);
+      LevelDbQueryTargetKey::Key(MakeString(canonicalID), queryData.targetID);
   std::string emptyBuffer;
   _db.currentTransaction->Put(indexKey, emptyBuffer);
 
@@ -267,7 +267,7 @@ FSTListenSequenceNumber ReadSequenceNumber(const absl::string_view &slice) {
   _db.currentTransaction->Delete(key);
 
   std::string indexKey =
-      LevelDbQueryTargetKey::Key(MakeStringView(queryData.query.canonicalID), targetID);
+      LevelDbQueryTargetKey::Key(MakeString(queryData.query.canonicalID), targetID);
   _db.currentTransaction->Delete(indexKey);
   self.metadata.targetCount -= 1;
   _db.currentTransaction->Put(LevelDbTargetGlobalKey::Key(), self.metadata);
@@ -315,7 +315,7 @@ FSTListenSequenceNumber ReadSequenceNumber(const absl::string_view &slice) {
   // Scan the query-target index starting with a prefix starting with the given query's canonicalID.
   // Note that this is a scan rather than a get because canonicalIDs are not required to be unique
   // per target.
-  absl::string_view canonicalID = MakeStringView(query.canonicalID);
+  std::string canonicalID = MakeString(query.canonicalID);
   auto indexItererator = _db.currentTransaction->NewIterator();
   std::string indexPrefix = LevelDbQueryTargetKey::KeyPrefix(canonicalID);
   indexItererator->Seek(indexPrefix);

--- a/Firestore/Source/Model/FSTDocumentKey.mm
+++ b/Firestore/Source/Model/FSTDocumentKey.mm
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (instancetype)keyWithPathString:(NSString *)resourcePath {
-  return [FSTDocumentKey keyWithPath:ResourcePath::FromString(util::MakeStringView(resourcePath))];
+  return [FSTDocumentKey keyWithPath:ResourcePath::FromString(util::MakeString(resourcePath))];
 }
 
 /** Designated initializer. */

--- a/Firestore/Source/Model/FSTFieldValue.mm
+++ b/Firestore/Source/Model/FSTFieldValue.mm
@@ -356,7 +356,7 @@ template <>
 struct Comparator<NSString *> {
   bool operator()(NSString *left, NSString *right) const {
     Comparator<absl::string_view> lessThan;
-    return lessThan(MakeStringView(left), MakeStringView(right));
+    return lessThan(MakeString(left), MakeString(right));
   }
 };
 

--- a/Firestore/Source/Remote/FSTSerializerBeta.mm
+++ b/Firestore/Source/Remote/FSTSerializerBeta.mm
@@ -144,7 +144,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (ResourcePath)decodedResourcePathWithDatabaseID:(NSString *)name {
-  const ResourcePath path = ResourcePath::FromString(util::MakeStringView(name));
+  const ResourcePath path = ResourcePath::FromString(util::MakeString(name));
   HARD_ASSERT([self validQualifiedResourcePath:path], "Tried to deserialize invalid key %s",
               path.CanonicalString());
   return path;
@@ -568,7 +568,7 @@ NS_ASSUME_NONNULL_BEGIN
   std::vector<FieldPath> fields;
   fields.reserve(fieldMask.fieldPathsArray_Count);
   for (NSString *path in fieldMask.fieldPathsArray) {
-    fields.push_back(FieldPath::FromServerFormat(util::MakeStringView(path)));
+    fields.push_back(FieldPath::FromServerFormat(util::MakeString(path)));
   }
   return FieldMask(std::move(fields));
 }
@@ -627,7 +627,7 @@ NS_ASSUME_NONNULL_BEGIN
             proto.setToServerValue == GCFSDocumentTransform_FieldTransform_ServerValue_RequestTime,
             "Unknown transform setToServerValue: %s", proto.setToServerValue);
         fieldTransforms.emplace_back(
-            FieldPath::FromServerFormat(util::MakeStringView(proto.fieldPath)),
+            FieldPath::FromServerFormat(util::MakeString(proto.fieldPath)),
             absl::make_unique<ServerTimestampTransform>(ServerTimestampTransform::Get()));
         break;
       }
@@ -636,7 +636,7 @@ NS_ASSUME_NONNULL_BEGIN
         std::vector<FSTFieldValue *> elements =
             [self decodedArrayTransformElements:proto.appendMissingElements];
         fieldTransforms.emplace_back(
-            FieldPath::FromServerFormat(util::MakeStringView(proto.fieldPath)),
+            FieldPath::FromServerFormat(util::MakeString(proto.fieldPath)),
             absl::make_unique<ArrayTransform>(TransformOperation::Type::ArrayUnion,
                                               std::move(elements)));
         break;
@@ -646,7 +646,7 @@ NS_ASSUME_NONNULL_BEGIN
         std::vector<FSTFieldValue *> elements =
             [self decodedArrayTransformElements:proto.removeAllFromArray_p];
         fieldTransforms.emplace_back(
-            FieldPath::FromServerFormat(util::MakeStringView(proto.fieldPath)),
+            FieldPath::FromServerFormat(util::MakeString(proto.fieldPath)),
             absl::make_unique<ArrayTransform>(TransformOperation::Type::ArrayRemove,
                                               std::move(elements)));
         break;

--- a/Firestore/core/src/firebase/firestore/auth/firebase_credentials_provider_apple.mm
+++ b/Firestore/core/src/firebase/firestore/auth/firebase_credentials_provider_apple.mm
@@ -117,8 +117,8 @@ void FirebaseCredentialsProvider::GetToken(TokenListener completion) {
         if (error.domain == FIRFirestoreErrorDomain) {
           error_code = static_cast<FirestoreErrorCode>(error.code);
         }
-        completion(util::Status(error_code,
-                                util::MakeString(error.localizedDescription)));
+        completion(util::Status(
+            error_code, util::MakeString(error.localizedDescription)));
       }
     }
   };

--- a/Firestore/core/src/firebase/firestore/util/path.h
+++ b/Firestore/core/src/firebase/firestore/util/path.h
@@ -68,7 +68,7 @@ class Path {
    * Creates a new Path from the given NSString pathname.
    */
   static Path FromNSString(NSString* path) {
-    return FromUtf8(MakeStringView(path));
+    return FromUtf8(MakeString(path));
   }
 #endif
 

--- a/Firestore/core/src/firebase/firestore/util/status_apple.mm
+++ b/Firestore/core/src/firebase/firestore/util/status_apple.mm
@@ -32,7 +32,7 @@ Status Status::FromNSError(NSError* error) {
   while (error) {
     if ([error.domain isEqualToString:NSPOSIXErrorDomain]) {
       return FromErrno(static_cast<int>(error.code),
-                       MakeStringView(original.localizedDescription));
+                       MakeString(original.localizedDescription));
     }
 
     error = error.userInfo[NSUnderlyingErrorKey];


### PR DESCRIPTION
... some usages remain.

In particular, there's a usage in `StringFormat` that's difficult to get rid of today because it's converting an Objective-C object to an `absl::string_view` during the FormatArg constructor. This works today because the backing byte array is autoreleased but doesn't work once the string_view is constructed from a `std::string`.

The way to fix is this to pre-convert everything in the context of the larger brace initializer expression, which would guarantee the lifetime of the string. Doing so would also allow us to automatically format objects that have a `ToString()` method. I'll handle this separately.