### PR TITLE
Log style.sh clang-format version.

### DIFF
--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -25,7 +25,11 @@
 #   clang-format version 7.0.0 (tags/google/stable/2018-01-11)
 #   clang-format version google3-trunk (trunk r333779)
 version=$(clang-format --version)
-echo "Found: $version"
+
+# Log the version in non-interactive use as it can be useful in travis logs.
+if [[ ! -t 1 ]]; then
+  echo "Found: $version"
+fi
 
 # Remove leading "clang-format version"
 version="${version/*version /}"

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -25,6 +25,7 @@
 #   clang-format version 7.0.0 (tags/google/stable/2018-01-11)
 #   clang-format version google3-trunk (trunk r333779)
 version=$(clang-format --version)
+echo "Found: $version"
 
 # Remove leading "clang-format version"
 version="${version/*version /}"


### PR DESCRIPTION
Mostly I just want to create this PR to find out what travis is using...  but it may be useful to merge as well?

Travis output:
```
$ ./scripts/style.sh test-only $TRAVIS_COMMIT_RANGE
Found: clang-format version 7.0.0 (tags/google/stable/2018-04-24)
```