### PR TITLE
firebase-ios-sdk/1499: Restart streams on any token change.

### DIFF
--- a/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.mm
@@ -250,7 +250,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)changeUser:(const User &)user {
   _currentUser = user;
   [self.dispatchQueue dispatchSync:^{
-    [self.syncEngine userDidChange:user];
+    [self.syncEngine credentialDidChangeWithUser:user];
   }];
 }
 

--- a/Firestore/Source/Core/FSTSyncEngine.h
+++ b/Firestore/Source/Core/FSTSyncEngine.h
@@ -100,7 +100,7 @@ NS_ASSUME_NONNULL_BEGIN
                    updateBlock:(FSTTransactionBlock)updateBlock
                     completion:(FSTVoidIDErrorBlock)completion;
 
-- (void)userDidChange:(const firebase::firestore::auth::User &)user;
+- (void)credentialDidChangeWithUser:(const firebase::firestore::auth::User &)user;
 
 /** Applies an FSTOnlineState change to the sync engine and notifies any views of the change. */
 - (void)applyChangedOnlineState:(FSTOnlineState)onlineState;

--- a/Firestore/Source/Core/FSTSyncEngine.mm
+++ b/Firestore/Source/Core/FSTSyncEngine.mm
@@ -560,15 +560,18 @@ class LimboResolution {
   return _limboTargetsByKey;
 }
 
-- (void)userDidChange:(const User &)user {
+- (void)credentialDidChangeWithUser:(const firebase::firestore::auth::User &)user {
+  BOOL userChanged = (_currentUser != user);
   _currentUser = user;
 
-  // Notify local store and emit any resulting events from swapping out the mutation queue.
-  FSTMaybeDocumentDictionary *changes = [self.localStore userDidChange:user];
-  [self emitNewSnapshotsWithChanges:changes remoteEvent:nil];
+  if (userChanged) {
+    // Notify local store and emit any resulting events from swapping out the mutation queue.
+    FSTMaybeDocumentDictionary *changes = [self.localStore userDidChange:user];
+    [self emitNewSnapshotsWithChanges:changes remoteEvent:nil];
+  }
 
   // Notify remote store so it can restart its streams.
-  [self.remoteStore userDidChange:user];
+  [self.remoteStore credentialDidChange];
 }
 
 - (firebase::firestore::model::DocumentKeySet)remoteKeysForTarget:(FSTBoxedTargetID *)targetId {

--- a/Firestore/Source/Remote/FSTRemoteStore.h
+++ b/Firestore/Source/Remote/FSTRemoteStore.h
@@ -129,7 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
  * In response the remote store tears down streams and clears up any tracked operations that should
  * not persist across users. Restarts the streams if appropriate.
  */
-- (void)userDidChange:(const firebase::firestore::auth::User &)user;
+- (void)credentialDidChange;
 
 /** Listens to the target identified by the given FSTQueryData. */
 - (void)listenToTargetWithQueryData:(FSTQueryData *)queryData;

--- a/Firestore/Source/Remote/FSTRemoteStore.mm
+++ b/Firestore/Source/Remote/FSTRemoteStore.mm
@@ -209,12 +209,12 @@ static const int kMaxPendingWrites = 10;
   [self.onlineStateTracker updateState:FSTOnlineStateUnknown];
 }
 
-- (void)userDidChange:(const User &)user {
-  LOG_DEBUG("FSTRemoteStore %s changing users: %s", (__bridge void *)self, user.uid());
+- (void)credentialDidChange {
   if ([self isNetworkEnabled]) {
     // Tear down and re-create our network streams. This will ensure we get a fresh auth token
     // for the new user and re-fill the write pipeline with new mutations from the LocalStore
     // (since mutations are per-user).
+    LOG_DEBUG("FSTRemoteStore %s restarting streams for new credential", (__bridge void *)self);
     [self disableNetworkInternal];
     [self.onlineStateTracker updateState:FSTOnlineStateUnknown];
     [self enableNetwork];

--- a/Firestore/core/src/firebase/firestore/auth/credentials_provider.cc
+++ b/Firestore/core/src/firebase/firestore/auth/credentials_provider.cc
@@ -20,7 +20,7 @@ namespace firebase {
 namespace firestore {
 namespace auth {
 
-CredentialsProvider::CredentialsProvider() : user_change_listener_(nullptr) {
+CredentialsProvider::CredentialsProvider() : change_listener_(nullptr) {
 }
 
 CredentialsProvider::~CredentialsProvider() {

--- a/Firestore/core/src/firebase/firestore/auth/credentials_provider.h
+++ b/Firestore/core/src/firebase/firestore/auth/credentials_provider.h
@@ -33,8 +33,8 @@ namespace auth {
 // `TokenErrorListener` is a listener that gets a token or an error.
 using TokenListener = std::function<void(util::StatusOr<Token>)>;
 
-// Listener notified with a User change.
-using UserChangeListener = std::function<void(User user)>;
+// Listener notified with a credential change.
+using CredentialChangeListener = std::function<void(User user)>;
 
 /**
  * Provides methods for getting the uid and token for the current user and
@@ -56,22 +56,24 @@ class CredentialsProvider {
   virtual void InvalidateToken() = 0;
 
   /**
-   * Sets the listener to be notified of user changes (sign-in / sign-out). It
-   * is immediately called once with the initial user.
+   * Sets the listener to be notified of credential changes (sign-in /
+   * sign-out, token changes). It is immediately called once with the initial
+   * user.
    *
    * Call with nullptr to remove previous listener.
    */
-  virtual void SetUserChangeListener(UserChangeListener listener) = 0;
+  virtual void SetCredentialChangeListener(
+      CredentialChangeListener changeListener) = 0;
 
  protected:
   /**
-   * A listener to be notified of user changes (sign-in / sign-out). It is
-   * immediately called once with the initial user.
+   * A listener to be notified of credential changes (sign-in / sign-out, token
+   * changes). It is immediately called once with the initial user.
    *
    * Note that this block will be called back on an arbitrary thread that is not
    * the normal Firestore worker thread.
    */
-  UserChangeListener user_change_listener_;
+  CredentialChangeListener change_listener_;
 };
 
 }  // namespace auth

--- a/Firestore/core/src/firebase/firestore/auth/empty_credentials_provider.cc
+++ b/Firestore/core/src/firebase/firestore/auth/empty_credentials_provider.cc
@@ -28,10 +28,10 @@ void EmptyCredentialsProvider::GetToken(TokenListener completion) {
   }
 }
 
-void EmptyCredentialsProvider::SetUserChangeListener(
-    UserChangeListener listener) {
-  if (listener) {
-    listener(User::Unauthenticated());
+void EmptyCredentialsProvider::SetCredentialChangeListener(
+    CredentialChangeListener changeListener) {
+  if (changeListener) {
+    changeListener(User::Unauthenticated());
   }
 }
 

--- a/Firestore/core/src/firebase/firestore/auth/empty_credentials_provider.h
+++ b/Firestore/core/src/firebase/firestore/auth/empty_credentials_provider.h
@@ -28,7 +28,8 @@ class EmptyCredentialsProvider : public CredentialsProvider {
  public:
   void GetToken(TokenListener completion) override;
   void InvalidateToken() override;
-  void SetUserChangeListener(UserChangeListener listener) override;
+  void SetCredentialChangeListener(
+      CredentialChangeListener changeListener) override;
 };
 
 }  // namespace auth

--- a/Firestore/core/src/firebase/firestore/auth/firebase_credentials_provider_apple.h
+++ b/Firestore/core/src/firebase/firestore/auth/firebase_credentials_provider_apple.h
@@ -43,9 +43,9 @@ namespace auth {
  * `FirebaseCredentialsProvider` uses Firebase Auth via `FIRApp` to get an auth
  * token.
  *
- * NOTE: To simplify the implementation, it requires that you set
- * `userChangeListener` with a non-`nil` value no more than once and don't call
- * `getTokenForcingRefresh:` after setting it to `nil`.
+ * NOTE: To simplify the implementation, it requires that you call
+ * `SetCredentialChangeListener()` with a non-nullptr value no more than once
+ * and don't call `GetToken()` after setting it to `nullptr`.
  *
  * This class must be implemented in a thread-safe manner since it is accessed
  * from the thread backing our internal worker queue and the callbacks from
@@ -70,7 +70,8 @@ class FirebaseCredentialsProvider : public CredentialsProvider {
 
   void GetToken(TokenListener completion) override;
 
-  void SetUserChangeListener(UserChangeListener listener) override;
+  void SetCredentialChangeListener(
+      CredentialChangeListener changeListener) override;
 
   void InvalidateToken() override;
 
@@ -96,10 +97,10 @@ class FirebaseCredentialsProvider : public CredentialsProvider {
     User current_user;
 
     /**
-     * Counter used to detect if the user changed while a
-     * -getTokenForcingRefresh: request was outstanding.
+     * Counter used to detect if the token changed while a GetToken() request
+     * was outstanding.
      */
-    int user_counter = 0;
+    int token_counter = 0;
 
     std::mutex mutex;
 

--- a/Firestore/core/test/firebase/firestore/auth/credentials_provider_test.cc
+++ b/Firestore/core/test/firebase/firestore/auth/credentials_provider_test.cc
@@ -36,7 +36,9 @@ TEST(CredentialsProvider, Typedef) {
   EXPECT_EQ(nullptr, token_listener);
   EXPECT_FALSE(token_listener);
 
-  UserChangeListener user_change_listener = [](User user) { UNUSED(user); };
+  CredentialChangeListener user_change_listener = [](User user) {
+    UNUSED(user);
+  };
   EXPECT_NE(nullptr, user_change_listener);
   EXPECT_TRUE(user_change_listener);
 

--- a/Firestore/core/test/firebase/firestore/auth/empty_credentials_provider_test.cc
+++ b/Firestore/core/test/firebase/firestore/auth/empty_credentials_provider_test.cc
@@ -37,12 +37,12 @@ TEST(EmptyCredentialsProvider, GetToken) {
 
 TEST(EmptyCredentialsProvider, SetListener) {
   EmptyCredentialsProvider credentials_provider;
-  credentials_provider.SetUserChangeListener([](User user) {
+  credentials_provider.SetCredentialChangeListener([](User user) {
     EXPECT_EQ("", user.uid());
     EXPECT_FALSE(user.is_authenticated());
   });
 
-  credentials_provider.SetUserChangeListener(nullptr);
+  credentials_provider.SetCredentialChangeListener(nullptr);
 }
 
 TEST(EmptyCredentialsProvider, InvalidateToken) {

--- a/Firestore/core/test/firebase/firestore/auth/firebase_credentials_provider_test.mm
+++ b/Firestore/core/test/firebase/firestore/auth/firebase_credentials_provider_test.mm
@@ -134,12 +134,12 @@ TEST(FirebaseCredentialsProviderTest, SetListener) {
   FSTAuthFake* auth =
       [[FSTAuthFake alloc] initWithToken:@"default token" uid:@"fake uid"];
   FirebaseCredentialsProvider credentials_provider(app, auth);
-  credentials_provider.SetUserChangeListener([](User user) {
+  credentials_provider.SetCredentialChangeListener([](User user) {
     EXPECT_EQ("fake uid", user.uid());
     EXPECT_TRUE(user.is_authenticated());
   });
 
-  credentials_provider.SetUserChangeListener(nullptr);
+  credentials_provider.SetCredentialChangeListener(nullptr);
 }
 
 TEST(FirebaseCredentialsProviderTest, InvalidateToken) {


### PR DESCRIPTION
[Port of https://github.com/firebase/firebase-js-sdk/pull/1120]

Fixes #1499.

This reworks our "user listener" into a "credential change listener" that
fires on any token change, even if the User did not change. This allows
us to restart our streams (but not switch mutation queues, etc.) on token
changes.