### PR TITLE
Implement global resume token

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 - [fixed] Fixed an issue where changes to custom authentication claims did not
   take effect until you did a full sign-out and sign-in. (#1499)
+- [changed] Improved how Firestore handles idle queries to reduce the cost of
+  re-listening within 30 minutes.
 
 # v0.13.1
 - [fixed] Fixed an issue where `get(source:.Cache)` could throw an

--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -78,6 +78,10 @@ static NSString *const kBenchmarkTag = @"benchmark";
 
 NSString *const kNoLRUTag = @"no-lru";
 
+static NSString *Describe(NSData *data) {
+  return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+}
+
 @interface FSTSpecTests ()
 @property(nonatomic, strong) FSTSyncEngineTestDriver *driver;
 
@@ -660,7 +664,7 @@ NSString *const kNoLRUTag = @"no-lru";
       XCTAssertEqualObjects(actual.query, queryData.query);
       XCTAssertEqual(actual.targetID, queryData.targetID);
       XCTAssertEqual(actual.snapshotVersion, queryData.snapshotVersion);
-      XCTAssertEqualObjects(actual.resumeToken, queryData.resumeToken);
+      XCTAssertEqualObjects(Describe(actual.resumeToken), Describe(queryData.resumeToken));
     }
 
     [actualTargets removeObjectForKey:targetID];

--- a/Firestore/Example/Tests/SpecTests/json/listen_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/listen_spec_test.json
@@ -4060,7 +4060,7 @@
   "Persists global resume tokens on unlisten": {
     "describeName": "Listens:",
     "itName": "Persists global resume tokens on unlisten",
-    "tags": ["no-ios"],
+    "tags": [],
     "config": {
       "useGarbageCollection": false,
       "numClients": 1
@@ -4248,7 +4248,7 @@
   "Omits global resume tokens for a short while": {
     "describeName": "Listens:",
     "itName": "Omits global resume tokens for a short while",
-    "tags": ["no-ios"],
+    "tags": [],
     "config": {
       "useGarbageCollection": false,
       "numClients": 1
@@ -4423,7 +4423,7 @@
   "Persists global resume tokens if the snapshot is old enough": {
     "describeName": "Listens:",
     "itName": "Persists global resume tokens if the snapshot is old enough",
-    "tags": ["no-ios"],
+    "tags": [],
     "config": {
       "useGarbageCollection": false,
       "numClients": 1

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -52,6 +52,14 @@ using firebase::firestore::model::DocumentVersionMap;
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * The maximum time to leave a resume token buffered without writing it out. This value is
+ * arbitrary: it's long enough to avoid several writes (possibly indefinitely if updates come more
+ * frequently than this) but short enough that restarting after crashing will still have a pretty
+ * recent resume token.
+ */
+static const int64_t kResumeTokenMaxAgeMicros = 5 * 60 * 1000 * 1000;  // 5 minutes
+
 @interface FSTLocalStore ()
 
 /** Manages our in-memory or durable persistence. */
@@ -276,11 +284,15 @@ NS_ASSUME_NONNULL_BEGIN
       // than documents that were previously removed from this target.
       NSData *resumeToken = change.resumeToken;
       if (resumeToken.length > 0) {
+        FSTQueryData *oldQueryData = queryData;
         queryData = [queryData queryDataByReplacingSnapshotVersion:remoteEvent.snapshotVersion
                                                        resumeToken:resumeToken
                                                     sequenceNumber:sequenceNumber];
         self.targetIDs[boxedTargetID] = queryData;
-        [self.queryCache updateQueryData:queryData];
+
+        if ([self shouldPersistQueryData:queryData oldQueryData:oldQueryData change:change]) {
+          [self.queryCache updateQueryData:queryData];
+        }
       }
     }
 
@@ -337,6 +349,42 @@ NS_ASSUME_NONNULL_BEGIN
   });
 }
 
+/**
+ * Returns YES if the newQueryData should be persisted during an update of an active target.
+ * QueryData should always be persisted when a target is being released and should not call this
+ * function.
+ *
+ * While the target is active, QueryData updates can be omitted when nothing about the target has
+ * changed except metadata like the resume token or snapshot version. Occasionally it's worth the
+ * extra write to prevent these values from getting too stale after a crash, but this doesn't have
+ * to be too frequent.
+ */
+- (BOOL)shouldPersistQueryData:(FSTQueryData *)newQueryData
+                  oldQueryData:(FSTQueryData *)oldQueryData
+                        change:(FSTTargetChange *)change {
+  // Avoid clearing any existing value
+  if (newQueryData.resumeToken.length == 0) return NO;
+
+  // Any resume token is interesting if there isn't one already.
+  if (oldQueryData.resumeToken.length == 0) return YES;
+
+  // Don't allow resume token changes to be buffered indefinitely. This allows us to be reasonably
+  // up-to-date after a crash and avoids needing to loop over all active queries on shutdown.
+  // Especially in the browser we may not get time to do anything interesting while the current
+  // tab is closing.
+  int64_t timeDelta =
+      newQueryData.snapshotVersion.ToMicroseconds() - oldQueryData.snapshotVersion.ToMicroseconds();
+  if (timeDelta >= kResumeTokenMaxAgeMicros) return YES;
+
+  // Otherwise if the only thing that has changed about a target is its resume token it's not
+  // worth persisting. Note that the RemoteStore keeps an in-memory view of the currently active
+  // targets which includes the current resume token, so stream failure or user changes will still
+  // use an up-to-date resume token regardless of what we do here.
+  size_t changes = change.addedDocuments.size() + change.modifiedDocuments.size() +
+                   change.removedDocuments.size();
+  return changes > 0;
+}
+
 - (void)notifyLocalViewChanges:(NSArray<FSTLocalViewChanges *> *)viewChanges {
   self.persistence.run("NotifyLocalViewChanges", [&]() {
     FSTReferenceSet *localViewReferences = self.localViewReferences;
@@ -390,9 +438,22 @@ NS_ASSUME_NONNULL_BEGIN
     FSTQueryData *queryData = [self.queryCache queryDataForQuery:query];
     HARD_ASSERT(queryData, "Tried to release nonexistent query: %s", query);
 
-    [self.localViewReferences removeReferencesForID:queryData.targetID];
+    FSTTargetID targetID = queryData.targetID;
+    FSTBoxedTargetID *boxedTargetID = @(targetID);
+
+    FSTQueryData *cachedQueryData = self.targetIDs[boxedTargetID];
+    if (cachedQueryData.snapshotVersion > queryData.snapshotVersion) {
+      // If we've been avoiding persisting the resumeToken (see shouldPersistQueryData for
+      // conditions and rationale) we need to persist the token now because there will no
+      // longer be an in-memory version to fall back on.
+      queryData = cachedQueryData;
+      [self.queryCache updateQueryData:queryData];
+    }
+
+    [self.localViewReferences removeReferencesForID:targetID];
+    [self.targetIDs removeObjectForKey:boxedTargetID];
     [self.persistence.referenceDelegate removeTarget:queryData];
-    [self.targetIDs removeObjectForKey:@(queryData.targetID)];
+    [self.targetIDs removeObjectForKey:boxedTargetID];
 
     // If this was the last watch target, then we won't get any more watch snapshots, so we should
     // release any held batch results.

--- a/Firestore/core/src/firebase/firestore/model/snapshot_version.cc
+++ b/Firestore/core/src/firebase/firestore/model/snapshot_version.cc
@@ -16,6 +16,8 @@
 
 #include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 
+#include <chrono>  // NOLINT(build/c++11)
+
 namespace firebase {
 namespace firestore {
 namespace model {
@@ -27,6 +29,17 @@ SnapshotVersion::SnapshotVersion(const Timestamp& timestamp)
 const SnapshotVersion& SnapshotVersion::None() {
   static const SnapshotVersion kNone(Timestamp{});
   return kNone;
+}
+
+int64_t SnapshotVersion::ToMicroseconds() const {
+  namespace chr = std::chrono;
+
+  auto second_part =
+      chr::duration_cast<chr::microseconds>(chr::seconds(timestamp_.seconds()));
+  auto nanosecond_part = chr::duration_cast<chr::microseconds>(
+      chr::nanoseconds(timestamp_.nanoseconds()));
+  auto result = second_part + nanosecond_part;
+  return static_cast<int64_t>(result.count());
 }
 
 }  // namespace model

--- a/Firestore/core/src/firebase/firestore/model/snapshot_version.h
+++ b/Firestore/core/src/firebase/firestore/model/snapshot_version.h
@@ -43,6 +43,9 @@ class SnapshotVersion {
   /** Creates a new version that is smaller than all other versions. */
   static const SnapshotVersion& None();
 
+  /** Returns a number representation of the version. */
+  int64_t ToMicroseconds() const;
+
 #if __OBJC__
   size_t Hash() const {
     return std::hash<Timestamp>{}(timestamp_);


### PR DESCRIPTION
Port of firebase/firebase-js-sdk#1052

Watch sends us a periodic heartbeat with an updated resume token that applies to [all active targets](https://github.com/googleapis/googleapis/blob/201d7be7f9da925df93bc52f8108963284f61aed/google/firestore/v1beta1/firestore.proto#L672) by sending us an empty list of target ids.

Our current implementation in the `FSTWatchChangeAggregator` loops over the target ids in the change so in this case we fail to take any action. If a client has been listening to a query that sees no changes for more than thirty minutes we'll fail to persist any resume token updates
during that period.

This change:
  * Implements special handling in the `FSTWatchChangeAggregator` for the empty target IDs list
  * Adds a filter in the local store to prevent heartbeat resume token updates from being written out more than once every five minutes
  * Adds logic on unlisten to ensure that we don't lose a token.

Note that while a query is active, the in-memory state is updated, so any incidental re-listens that happen as a result of stream loss or re-auth will always use an up-to-date token.