### PR TITLE
Migrate FSTTargetID to C++ TargetId

### DIFF
--- a/Firestore/Example/Benchmarks/FSTLevelDBBenchmarkTests.mm
+++ b/Firestore/Example/Benchmarks/FSTLevelDBBenchmarkTests.mm
@@ -28,12 +28,14 @@
 
 #include "Firestore/core/src/firebase/firestore/local/leveldb_key.h"
 #include "Firestore/core/src/firebase/firestore/local/leveldb_transaction.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 using firebase::firestore::local::LevelDbTargetDocumentKey;
 using firebase::firestore::local::LevelDbTransaction;
 using firebase::firestore::model::DatabaseId;
+using firebase::firestore::model::TargetId;
 
 namespace {
 
@@ -113,7 +115,7 @@ class LevelDBFixture : public benchmark::Fixture {
  protected:
   void WriteIndex(LevelDbTransaction &txn, FSTDocumentKey *docKey) {
     // Arbitrary target ID
-    FSTTargetID targetID = 1;
+    TargetId targetID = 1;
     txn.Put(LevelDbDocumentTargetKey::Key(docKey, targetID), emptyBuffer_);
     txn.Put(LevelDbTargetDocumentKey::Key(targetID, docKey), emptyBuffer_);
   }

--- a/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
@@ -36,18 +36,20 @@
 #include "Firestore/core/src/firebase/firestore/model/precondition.h"
 #include "Firestore/core/test/firebase/firestore/testutil/testutil.h"
 #include "absl/strings/str_cat.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 using firebase::firestore::auth::User;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeyHash;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::Precondition;
+using firebase::firestore::model::TargetId;
 namespace testutil = firebase::firestore::testutil;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation FSTLRUGarbageCollectorTests {
-  FSTTargetID _previousTargetID;
+  TargetId _previousTargetID;
   int _previousDocNum;
   FSTObjectValue *_testValue;
   FSTObjectValue *_bigObjectValue;
@@ -121,7 +123,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (FSTQueryData *)nextTestQuery {
-  FSTTargetID targetID = ++_previousTargetID;
+  TargetId targetID = ++_previousTargetID;
   FSTListenSequenceNumber listenSequenceNumber = _persistence.currentSequenceNumber;
   FSTQuery *query = FSTTestQuery(absl::StrCat("path", targetID));
   return [[FSTQueryData alloc] initWithQuery:query
@@ -175,11 +177,11 @@ NS_ASSUME_NONNULL_BEGIN
   [_persistence.referenceDelegate removeMutationReference:docKey];
 }
 
-- (void)addDocument:(const DocumentKey &)docKey toTarget:(FSTTargetID)targetId {
+- (void)addDocument:(const DocumentKey &)docKey toTarget:(TargetId)targetId {
   [_queryCache addMatchingKeys:DocumentKeySet{docKey} forTargetID:targetId];
 }
 
-- (void)removeDocument:(const DocumentKey &)docKey fromTarget:(FSTTargetID)targetId {
+- (void)removeDocument:(const DocumentKey &)docKey fromTarget:(TargetId)targetId {
   [_queryCache removeMatchingKeys:DocumentKeySet{docKey} forTargetID:targetId];
 }
 

--- a/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
@@ -34,9 +34,9 @@
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
 #include "Firestore/core/src/firebase/firestore/model/precondition.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 #include "Firestore/core/test/firebase/firestore/testutil/testutil.h"
 #include "absl/strings/str_cat.h"
-#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 using firebase::firestore::auth::User;
 using firebase::firestore::model::DocumentKey;

--- a/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
@@ -38,13 +38,13 @@
 #include "Firestore/core/test/firebase/firestore/testutil/testutil.h"
 #include "absl/strings/str_cat.h"
 
+namespace testutil = firebase::firestore::testutil;
 using firebase::firestore::auth::User;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeyHash;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::Precondition;
 using firebase::firestore::model::TargetId;
-namespace testutil = firebase::firestore::testutil;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
@@ -45,12 +45,12 @@ using firebase::firestore::local::LevelDbQueryTargetKey;
 using firebase::firestore::local::LevelDbTargetDocumentKey;
 using firebase::firestore::local::LevelDbTargetKey;
 using firebase::firestore::local::LevelDbTransaction;
-using firebase::firestore::util::OrderedCode;
+using firebase::firestore::model::TargetId;
 using firebase::firestore::testutil::Key;
+using firebase::firestore::util::OrderedCode;
 using leveldb::DB;
 using leveldb::Options;
 using leveldb::Status;
-using firebase::firestore::model::TargetId;
 
 @interface FSTLevelDBMigrationsTests : XCTestCase
 @end

--- a/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
@@ -50,6 +50,7 @@ using firebase::firestore::testutil::Key;
 using leveldb::DB;
 using leveldb::Options;
 using leveldb::Status;
+using firebase::firestore::model::TargetId;
 
 @interface FSTLevelDBMigrationsTests : XCTestCase
 @end
@@ -119,7 +120,7 @@ using leveldb::Status;
 - (void)testDropsTheQueryCache {
   std::string userID{"user"};
   FSTBatchID batchID = 1;
-  FSTTargetID targetID = 2;
+  TargetId targetID = 2;
 
   FSTDocumentKey *key1 = Key("documents/1");
   FSTDocumentKey *key2 = Key("documents/2");

--- a/Firestore/Example/Tests/Local/FSTLevelDBQueryCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBQueryCacheTests.mm
@@ -34,6 +34,7 @@ using firebase::Timestamp;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::ResourcePath;
 using firebase::firestore::model::SnapshotVersion;
+using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -75,7 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
   XCTAssertEqual(versionZero, queryCache.lastRemoteSnapshotVersion);
 
   FSTListenSequenceNumber minimumSequenceNumber = 1234;
-  FSTTargetID lastTargetId = 5;
+  TargetId lastTargetId = 5;
   SnapshotVersion lastVersion(Timestamp(1, 2));
 
   db1.run("add query data", [&]() {

--- a/Firestore/Example/Tests/Local/FSTLocalSerializerTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLocalSerializerTests.mm
@@ -50,6 +50,7 @@ using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::FieldMask;
 using firebase::firestore::model::Precondition;
 using firebase::firestore::model::SnapshotVersion;
+using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -161,7 +162,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testEncodesQueryData {
   FSTQuery *query = FSTTestQuery("room");
-  FSTTargetID targetID = 42;
+  TargetId targetID = 42;
   SnapshotVersion version = testutil::Version(1039);
   NSData *resumeToken = FSTTestResumeTokenFromSnapshotVersion(1039);
 

--- a/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
@@ -46,6 +46,7 @@ namespace testutil = firebase::firestore::testutil;
 using firebase::firestore::auth::User;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::DocumentKeySet;
+using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -56,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, strong, readonly) NSMutableArray<FSTMutationBatch *> *batches;
 @property(nonatomic, strong, readwrite, nullable) FSTMaybeDocumentDictionary *lastChanges;
-@property(nonatomic, assign, readwrite) FSTTargetID lastTargetID;
+@property(nonatomic, assign, readwrite) TargetId lastTargetID;
 
 @end
 
@@ -144,7 +145,7 @@ NS_ASSUME_NONNULL_BEGIN
   self.lastChanges = [self.localStore rejectBatchID:batch.batchID];
 }
 
-- (FSTTargetID)allocateQuery:(FSTQuery *)query {
+- (TargetId)allocateQuery:(FSTQuery *)query {
   FSTQueryData *queryData = [self.localStore allocateQuery:query];
   self.lastTargetID = queryData.targetID;
   return queryData.targetID;
@@ -240,7 +241,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, YES));
 
   FSTQuery *query = FSTTestQuery("foo");
-  FSTTargetID targetID = [self allocateQuery:query];
+  TargetId targetID = [self allocateQuery:query];
 
   [self
       applyRemoteEvent:FSTTestUpdateRemoteEvent(FSTTestDoc("foo/bar", 2, @{@"it" : @"changed"}, NO),
@@ -254,7 +255,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   // Start a query that requires acks to be held.
   FSTQuery *query = FSTTestQuery("foo");
-  FSTTargetID targetID = [self allocateQuery:query];
+  TargetId targetID = [self allocateQuery:query];
 
   [self writeMutation:FSTTestSetMutation(@"foo/bar", @{@"foo" : @"bar"})];
   FSTAssertChanged(@[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, YES) ]);
@@ -285,7 +286,7 @@ NS_ASSUME_NONNULL_BEGIN
   if ([self isTestBaseClass]) return;
 
   FSTQuery *query = FSTTestQuery("foo");
-  FSTTargetID targetID = [self allocateQuery:query];
+  TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(FSTTestDeletedDoc("foo/bar", 2), @[ @(targetID) ],
                                                   @[])];
@@ -318,7 +319,7 @@ NS_ASSUME_NONNULL_BEGIN
   if ([self isTestBaseClass]) return;
 
   FSTQuery *query = FSTTestQuery("foo");
-  FSTTargetID targetID = [self allocateQuery:query];
+  TargetId targetID = [self allocateQuery:query];
 
   [self writeMutation:FSTTestSetMutation(@"foo/bar", @{@"foo" : @"bar"})];
   FSTAssertChanged(@[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, YES) ]);
@@ -334,7 +335,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   // Start a query that requires acks to be held.
   FSTQuery *query = FSTTestQuery("foo");
-  FSTTargetID targetID = [self allocateQuery:query];
+  TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestAddedRemoteEvent(FSTTestDoc("foo/bar", 2, @{@"it" : @"base"}, NO),
                                                  @[ @(targetID) ])];
@@ -377,7 +378,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTAssertNotContains(@"foo/bar");
 
   FSTQuery *query = FSTTestQuery("foo");
-  FSTTargetID targetID = [self allocateQuery:query];
+  TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestAddedRemoteEvent(FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, NO),
                                                  @[ @(targetID) ])];
@@ -410,7 +411,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTAssertNotContains(@"foo/bar");
 
   FSTQuery *query = FSTTestQuery("foo");
-  FSTTargetID targetID = [self allocateQuery:query];
+  TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, NO),
                                                   @[ @(targetID) ], @[])];
@@ -437,7 +438,7 @@ NS_ASSUME_NONNULL_BEGIN
   if ([self isTestBaseClass]) return;
 
   FSTQuery *query = FSTTestQuery("foo");
-  FSTTargetID targetID = [self allocateQuery:query];
+  TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, NO),
                                                   @[ @(targetID) ], @[])];
@@ -463,7 +464,7 @@ NS_ASSUME_NONNULL_BEGIN
   if ([self isTestBaseClass]) return;
 
   FSTQuery *query = FSTTestQuery("foo");
-  FSTTargetID targetID = [self allocateQuery:query];
+  TargetId targetID = [self allocateQuery:query];
 
   [self writeMutation:FSTTestDeleteMutation(@"foo/bar")];
   FSTAssertRemoved(@[ @"foo/bar" ]);
@@ -491,7 +492,7 @@ NS_ASSUME_NONNULL_BEGIN
   if ([self isTestBaseClass]) return;
 
   FSTQuery *query = FSTTestQuery("foo");
-  FSTTargetID targetID = [self allocateQuery:query];
+  TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, NO),
                                                   @[ @(targetID) ], @[])];
@@ -524,7 +525,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, YES));
 
   FSTQuery *query = FSTTestQuery("foo");
-  FSTTargetID targetID = [self allocateQuery:query];
+  TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, NO),
                                                   @[ @(targetID) ], @[])];
@@ -631,7 +632,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (![self gcIsEager]) return;
 
   FSTQuery *query = FSTTestQuery("foo");
-  FSTTargetID targetID = [self allocateQuery:query];
+  TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestAddedRemoteEvent(FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, NO),
                                                  @[ @(targetID) ])];
@@ -648,7 +649,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (![self gcIsEager]) return;
 
   FSTQuery *query = FSTTestQuery("foo");
-  FSTTargetID targetID = [self allocateQuery:query];
+  TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(FSTTestDoc("foo/bar", 0, @{@"foo" : @"old"}, NO),
                                                   @[ @(targetID) ], @[])];
@@ -683,7 +684,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (![self gcIsEager]) return;
 
   FSTQuery *query = FSTTestQuery("foo");
-  FSTTargetID targetID = [self allocateQuery:query];
+  TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(FSTTestDoc("foo/bar", 0, @{@"foo" : @"old"}, NO),
                                                   @[ @(targetID) ], @[])];
@@ -718,7 +719,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (![self gcIsEager]) return;
 
   FSTQuery *query = FSTTestQuery("foo");
-  FSTTargetID targetID = [self allocateQuery:query];
+  TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestAddedRemoteEvent(FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, NO),
                                                  @[ @(targetID) ])];
@@ -749,7 +750,7 @@ NS_ASSUME_NONNULL_BEGIN
   if ([self isTestBaseClass]) return;
   if (![self gcIsEager]) return;
 
-  FSTTargetID targetID = 321;
+  TargetId targetID = 321;
   [self applyRemoteEvent:FSTTestUpdateRemoteEventWithLimboTargets(FSTTestDoc("foo/bar", 1, @{}, NO),
                                                                   @[], @[], @[ @(targetID) ])];
 

--- a/Firestore/Example/Tests/Local/FSTQueryCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTQueryCacheTests.mm
@@ -33,13 +33,14 @@ namespace testutil = firebase::firestore::testutil;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::DocumentKeySet;
+using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation FSTQueryCacheTests {
   FSTQuery *_queryRooms;
   FSTListenSequenceNumber _previousSequenceNumber;
-  FSTTargetID _previousTargetID;
+  TargetId _previousTargetID;
   FSTTestSnapshotVersion _previousSnapshotVersion;
 }
 
@@ -363,7 +364,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (FSTQueryData *)queryDataWithQuery:(FSTQuery *)query
-                            targetID:(FSTTargetID)targetID
+                            targetID:(TargetId)targetID
                 listenSequenceNumber:(FSTListenSequenceNumber)sequenceNumber
                              version:(FSTTestSnapshotVersion)version {
   NSData *resumeToken = FSTTestResumeTokenFromSnapshotVersion(version);
@@ -375,12 +376,12 @@ NS_ASSUME_NONNULL_BEGIN
                                  resumeToken:resumeToken];
 }
 
-- (void)addMatchingKey:(const DocumentKey &)key forTargetID:(FSTTargetID)targetID {
+- (void)addMatchingKey:(const DocumentKey &)key forTargetID:(TargetId)targetID {
   DocumentKeySet keys{key};
   [self.queryCache addMatchingKeys:keys forTargetID:targetID];
 }
 
-- (void)removeMatchingKey:(const DocumentKey &)key forTargetID:(FSTTargetID)targetID {
+- (void)removeMatchingKey:(const DocumentKey &)key forTargetID:(TargetId)targetID {
   DocumentKeySet keys{key};
   [self.queryCache removeMatchingKeys:keys forTargetID:targetID];
 }

--- a/Firestore/Example/Tests/Local/FSTQueryCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTQueryCacheTests.mm
@@ -31,8 +31,8 @@
 
 namespace testutil = firebase::firestore::testutil;
 using firebase::firestore::model::DocumentKey;
-using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::DocumentKeySet;
+using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Firestore/Example/Tests/SpecTests/FSTMockDatastore.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTMockDatastore.mm
@@ -36,6 +36,7 @@ using firebase::firestore::auth::EmptyCredentialsProvider;
 using firebase::firestore::core::DatabaseInfo;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::SnapshotVersion;
+using firebase::firestore::model::TargetId;
 
 @class GRPCProtoCall;
 
@@ -126,7 +127,7 @@ NS_ASSUME_NONNULL_BEGIN
   self.activeTargets[@(query.targetID)] = sentQueryData;
 }
 
-- (void)unwatchTargetID:(FSTTargetID)targetID {
+- (void)unwatchTargetID:(TargetId)targetID {
   LOG_DEBUG("unwatchTargetID: %s", targetID);
   [self.activeTargets removeObjectForKey:@(targetID)];
 }

--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -53,6 +53,7 @@ using firebase::firestore::auth::User;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
+using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -185,9 +186,9 @@ NSString *const kNoLRUTag = @"no-lru";
 
 - (void)doListen:(NSArray *)listenSpec {
   FSTQuery *query = [self parseQuery:listenSpec[1]];
-  FSTTargetID actualID = [self.driver addUserListenerWithQuery:query];
+  TargetId actualID = [self.driver addUserListenerWithQuery:query];
 
-  FSTTargetID expectedID = [listenSpec[0] intValue];
+  TargetId expectedID = [listenSpec[0] intValue];
   XCTAssertEqual(actualID, expectedID, @"targetID assigned to listen");
 }
 
@@ -579,7 +580,7 @@ NSString *const kNoLRUTag = @"no-lru";
       [expected[@"activeTargets"] enumerateKeysAndObjectsUsingBlock:^(NSString *targetIDString,
                                                                       NSDictionary *queryData,
                                                                       BOOL *stop) {
-        FSTTargetID targetID = [targetIDString intValue];
+        TargetId targetID = [targetIDString intValue];
         FSTQuery *query = [self parseQuery:queryData[@"query"]];
         NSData *resumeToken = [queryData[@"resumeToken"] dataUsingEncoding:NSUTF8StringEncoding];
         // TODO(mcg): populate the purpose of the target once it's possible to encode that in the

--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -53,7 +53,6 @@ using firebase::firestore::auth::User;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
-using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.h
+++ b/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.h
@@ -26,6 +26,7 @@
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 @class FSTDocumentKey;
 @class FSTMutation;
@@ -123,7 +124,7 @@ typedef std::unordered_map<firebase::firestore::auth::User,
  * @param query A valid query to execute against the backend.
  * @return The target ID assigned by the system to track the query.
  */
-- (FSTTargetID)addUserListenerWithQuery:(FSTQuery *)query;
+- (firebase::firestore::model::TargetId)addUserListenerWithQuery:(FSTQuery *)query;
 
 /**
  * Removes a listener from the FSTSyncEngine as if the user had removed a listener corresponding

--- a/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.mm
@@ -50,7 +50,6 @@ using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
-using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.mm
@@ -50,6 +50,7 @@ using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
+using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -309,7 +310,7 @@ NS_ASSUME_NONNULL_BEGIN
   return result;
 }
 
-- (FSTTargetID)addUserListenerWithQuery:(FSTQuery *)query {
+- (TargetId)addUserListenerWithQuery:(FSTQuery *)query {
   // TODO(dimond): Allow customizing listen options in spec tests
   // TODO(dimond): Change spec tests to verify isFromCache on snapshots
   FSTListenOptions *options = [[FSTListenOptions alloc] initWithIncludeQueryMetadataChanges:YES
@@ -326,7 +327,7 @@ NS_ASSUME_NONNULL_BEGIN
         [self.events addObject:event];
       }];
   self.queryListeners[query] = listener;
-  __block FSTTargetID targetID;
+  __block TargetId targetID;
   [self.dispatchQueue dispatchSync:^{
     targetID = [self.eventManager addListener:listener];
   }];

--- a/Firestore/Example/Tests/Util/FSTHelpers.h
+++ b/Firestore/Example/Tests/Util/FSTHelpers.h
@@ -27,6 +27,7 @@
 #include "Firestore/core/src/firebase/firestore/model/field_value.h"
 #include "Firestore/core/src/firebase/firestore/model/resource_path.h"
 #include "absl/strings/string_view.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 @class FIRGeoPoint;
 @class FSTDeleteMutation;
@@ -304,7 +305,7 @@ FSTRemoteEvent *FSTTestUpdateRemoteEventWithLimboTargets(FSTMaybeDocument *doc,
                                                          NSArray<NSNumber *> *limboTargets);
 
 /** Creates a test view changes. */
-FSTLocalViewChanges *FSTTestViewChanges(FSTTargetID targetID,
+FSTLocalViewChanges *FSTTestViewChanges(firebase::firestore::model::TargetId targetID,
                                         NSArray<NSString *> *addedKeys,
                                         NSArray<NSString *> *removedKeys);
 

--- a/Firestore/Example/Tests/Util/FSTHelpers.h
+++ b/Firestore/Example/Tests/Util/FSTHelpers.h
@@ -26,8 +26,8 @@
 #include "Firestore/core/src/firebase/firestore/model/field_path.h"
 #include "Firestore/core/src/firebase/firestore/model/field_value.h"
 #include "Firestore/core/src/firebase/firestore/model/resource_path.h"
-#include "absl/strings/string_view.h"
 #include "Firestore/core/src/firebase/firestore/model/types.h"
+#include "absl/strings/string_view.h"
 
 @class FIRGeoPoint;
 @class FSTDeleteMutation;

--- a/Firestore/Example/Tests/Util/FSTHelpers.mm
+++ b/Firestore/Example/Tests/Util/FSTHelpers.mm
@@ -54,8 +54,8 @@
 #include "Firestore/core/test/firebase/firestore/testutil/testutil.h"
 #include "absl/memory/memory.h"
 
-namespace util = firebase::firestore::util;
 namespace testutil = firebase::firestore::testutil;
+namespace util = firebase::firestore::util;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeySet;
@@ -67,8 +67,8 @@ using firebase::firestore::model::Precondition;
 using firebase::firestore::model::ResourcePath;
 using firebase::firestore::model::ServerTimestampTransform;
 using firebase::firestore::model::SnapshotVersion;
-using firebase::firestore::model::TransformOperation;
 using firebase::firestore::model::TargetId;
+using firebase::firestore::model::TransformOperation;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/Example/Tests/Util/FSTHelpers.mm
+++ b/Firestore/Example/Tests/Util/FSTHelpers.mm
@@ -68,6 +68,7 @@ using firebase::firestore::model::ResourcePath;
 using firebase::firestore::model::ServerTimestampTransform;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TransformOperation;
+using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -291,8 +292,8 @@ FSTViewSnapshot *_Nullable FSTTestApplyChanges(FSTView *view,
 }
 
 @implementation FSTTestTargetMetadataProvider {
-  std::unordered_map<FSTTargetID, DocumentKeySet> _syncedKeys;
-  std::unordered_map<FSTTargetID, FSTQueryData *> _queryData;
+  std::unordered_map<TargetId, DocumentKeySet> _syncedKeys;
+  std::unordered_map<TargetId, FSTQueryData *> _queryData;
 }
 
 + (instancetype)providerWithSingleResultForKey:(DocumentKey)documentKey
@@ -443,7 +444,7 @@ NSData *_Nullable FSTTestResumeTokenFromSnapshotVersion(FSTTestSnapshotVersion s
   return [snapshotString dataUsingEncoding:NSUTF8StringEncoding];
 }
 
-FSTLocalViewChanges *FSTTestViewChanges(FSTTargetID targetID,
+FSTLocalViewChanges *FSTTestViewChanges(TargetId targetID,
                                         NSArray<NSString *> *addedKeys,
                                         NSArray<NSString *> *removedKeys) {
   DocumentKeySet added;

--- a/Firestore/Source/Core/FSTEventManager.h
+++ b/Firestore/Source/Core/FSTEventManager.h
@@ -20,6 +20,8 @@
 #import "Firestore/Source/Core/FSTViewSnapshot.h"
 #import "Firestore/Source/Remote/FSTRemoteStore.h"
 
+#include "Firestore/core/src/firebase/firestore/model/types.h"
+
 @class FSTQuery;
 @class FSTSyncEngine;
 
@@ -80,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init __attribute__((unavailable("Use static constructor method.")));
 
-- (FSTTargetID)addListener:(FSTQueryListener *)listener;
+- (firebase::firestore::model::TargetId)addListener:(FSTQueryListener *)listener;
 - (void)removeListener:(FSTQueryListener *)listener;
 
 @end

--- a/Firestore/Source/Core/FSTEventManager.mm
+++ b/Firestore/Source/Core/FSTEventManager.mm
@@ -22,6 +22,8 @@
 
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 
+using firebase::firestore::model::TargetId;
+
 NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - FSTListenOptions
@@ -65,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface FSTQueryListenersInfo : NSObject
 @property(nonatomic, strong, nullable, readwrite) FSTViewSnapshot *viewSnapshot;
-@property(nonatomic, assign, readwrite) FSTTargetID targetID;
+@property(nonatomic, assign, readwrite) TargetId targetID;
 @property(nonatomic, strong, readonly) NSMutableArray<FSTQueryListener *> *listeners;
 @end
 
@@ -257,7 +259,7 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
-- (FSTTargetID)addListener:(FSTQueryListener *)listener {
+- (TargetId)addListener:(FSTQueryListener *)listener {
   FSTQuery *query = listener.query;
   BOOL firstListen = NO;
 

--- a/Firestore/Source/Core/FSTSyncEngine.h
+++ b/Firestore/Source/Core/FSTSyncEngine.h
@@ -20,6 +20,7 @@
 #import "Firestore/Source/Remote/FSTRemoteStore.h"
 
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 @class FSTDispatchQueue;
 @class FSTLocalStore;
@@ -74,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return the target ID assigned to the query.
  */
-- (FSTTargetID)listenToQuery:(FSTQuery *)query;
+- (firebase::firestore::model::TargetId)listenToQuery:(FSTQuery *)query;
 
 /** Stops listening to a query previously listened to via listenToQuery:. */
 - (void)stopListeningToQuery:(FSTQuery *)query;

--- a/Firestore/Source/Core/FSTSyncEngine.mm
+++ b/Firestore/Source/Core/FSTSyncEngine.mm
@@ -50,9 +50,8 @@ using firebase::firestore::auth::HashUser;
 using firebase::firestore::auth::User;
 using firebase::firestore::core::TargetIdGenerator;
 using firebase::firestore::model::DocumentKey;
-using firebase::firestore::model::SnapshotVersion;
-using firebase::firestore::model::TargetId;
 using firebase::firestore::model::DocumentKeySet;
+using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Firestore/Source/Core/FSTSyncEngine.mm
+++ b/Firestore/Source/Core/FSTSyncEngine.mm
@@ -53,6 +53,7 @@ using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
 using firebase::firestore::model::DocumentKeySet;
+using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -69,7 +70,7 @@ static const FSTListenSequenceNumber kIrrelevantSequenceNumber = -1;
 @interface FSTQueryView : NSObject
 
 - (instancetype)initWithQuery:(FSTQuery *)query
-                     targetID:(FSTTargetID)targetID
+                     targetID:(TargetId)targetID
                   resumeToken:(NSData *)resumeToken
                          view:(FSTView *)view NS_DESIGNATED_INITIALIZER;
 
@@ -79,7 +80,7 @@ static const FSTListenSequenceNumber kIrrelevantSequenceNumber = -1;
 @property(nonatomic, strong, readonly) FSTQuery *query;
 
 /** The targetID created by the client that is used in the watch stream to identify this query. */
-@property(nonatomic, assign, readonly) FSTTargetID targetID;
+@property(nonatomic, assign, readonly) TargetId targetID;
 
 /**
  * An identifier from the datastore backend that indicates the last state of the results that
@@ -100,7 +101,7 @@ static const FSTListenSequenceNumber kIrrelevantSequenceNumber = -1;
 @implementation FSTQueryView
 
 - (instancetype)initWithQuery:(FSTQuery *)query
-                     targetID:(FSTTargetID)targetID
+                     targetID:(TargetId)targetID
                   resumeToken:(NSData *)resumeToken
                          view:(FSTView *)view {
   if (self = [super init]) {
@@ -159,7 +160,7 @@ class LimboResolution {
 @end
 
 @implementation FSTSyncEngine {
-  /** Used for creating the FSTTargetIDs for the listens used to resolve limbo documents. */
+  /** Used for creating the TargetId for the listens used to resolve limbo documents. */
   TargetIdGenerator _targetIdGenerator;
 
   /** Stores user completion blocks, indexed by user and FSTBatchID. */
@@ -198,7 +199,7 @@ class LimboResolution {
   return self;
 }
 
-- (FSTTargetID)listenToQuery:(FSTQuery *)query {
+- (TargetId)listenToQuery:(FSTQuery *)query {
   [self assertDelegateExistsForSelector:_cmd];
   HARD_ASSERT(self.queryViewsByQuery[query] == nil, "We already listen to query: %s", query);
 
@@ -313,7 +314,7 @@ class LimboResolution {
 
   // Update `receivedDocument` as appropriate for any limbo targets.
   for (const auto &entry : remoteEvent.targetChanges) {
-    FSTTargetID targetID = entry.first;
+    TargetId targetID = entry.first;
     FSTTargetChange *change = entry.second;
     const auto iter = _limboResolutionsByTarget.find(targetID);
     if (iter != _limboResolutionsByTarget.end()) {
@@ -502,7 +503,7 @@ class LimboResolution {
 
 /** Updates the limbo document state for the given targetID. */
 - (void)updateTrackedLimboDocumentsWithChanges:(NSArray<FSTLimboDocumentChange *> *)limboChanges
-                                      targetID:(FSTTargetID)targetID {
+                                      targetID:(TargetId)targetID {
   for (FSTLimboDocumentChange *limboChange in limboChanges) {
     switch (limboChange.type) {
       case FSTLimboDocumentChangeTypeAdded:

--- a/Firestore/Source/Core/FSTTypes.h
+++ b/Firestore/Source/Core/FSTTypes.h
@@ -26,8 +26,6 @@ NS_ASSUME_NONNULL_BEGIN
 /** FSTBatchID is a locally assigned ID for a batch of mutations that have been applied. */
 typedef firebase::firestore::model::BatchId FSTBatchID;
 
-typedef firebase::firestore::model::TargetId FSTTargetID;
-
 typedef int64_t FSTListenSequenceNumber;
 
 typedef NSNumber FSTBoxedTargetID;

--- a/Firestore/Source/Local/FSTDocumentReference.h
+++ b/Firestore/Source/Local/FSTDocumentReference.h
@@ -25,8 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
  * An immutable value used to keep track of an association between some referencing target or batch
  * and a document key that the target or batch references.
  *
- * A reference can be from either listen targets (identified by their firebase::firestore::model::TargetId) or mutation
- * batches (identified by their FSTBatchID). See FSTGarbageCollector for more details.
+ * A reference can be from either listen targets (identified by their TargetId) or mutation batches
+ * (identified by their FSTBatchID). See FSTGarbageCollector for more details.
  *
  * Not to be confused with FIRDocumentReference.
  */
@@ -42,8 +42,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (const firebase::firestore::model::DocumentKey &)key;
 
 /**
- * The targetID of a referring target or the batchID of a referring mutation batch. (Which this
- * is depends upon which FSTReferenceSet this reference is a part of.)
+ * The targetID of a referring target or the batchID of a referring mutation batch. (Which this is
+ * depends upon which FSTReferenceSet this reference is a part of.)
  */
 @property(nonatomic, assign, readonly) int32_t ID;
 

--- a/Firestore/Source/Local/FSTDocumentReference.h
+++ b/Firestore/Source/Local/FSTDocumentReference.h
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -24,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  * An immutable value used to keep track of an association between some referencing target or batch
  * and a document key that the target or batch references.
  *
- * A reference can be from either listen targets (identified by their FSTTargetID) or mutation
+ * A reference can be from either listen targets (identified by their firebase::firestore::model::TargetId) or mutation
  * batches (identified by their FSTBatchID). See FSTGarbageCollector for more details.
  *
  * Not to be confused with FIRDocumentReference.

--- a/Firestore/Source/Local/FSTLevelDBQueryCache.mm
+++ b/Firestore/Source/Local/FSTLevelDBQueryCache.mm
@@ -51,6 +51,7 @@ using firebase::firestore::util::OrderedCode;
 using leveldb::DB;
 using leveldb::Slice;
 using leveldb::Status;
+using firebase::firestore::model::TargetId;
 
 namespace {
 
@@ -150,7 +151,7 @@ FSTListenSequenceNumber ReadSequenceNumber(const absl::string_view &slice) {
 
 #pragma mark - FSTQueryCache implementation
 
-- (FSTTargetID)highestTargetID {
+- (TargetId)highestTargetID {
   return self.metadata.highestTargetId;
 }
 
@@ -216,7 +217,7 @@ FSTListenSequenceNumber ReadSequenceNumber(const absl::string_view &slice) {
 }
 
 - (void)saveQueryData:(FSTQueryData *)queryData {
-  FSTTargetID targetID = queryData.targetID;
+  TargetId targetID = queryData.targetID;
   std::string key = LevelDbTargetKey::Key(targetID);
   _db.currentTransaction->Put(key, [self.serializer encodedQueryData:queryData]);
 }
@@ -258,7 +259,7 @@ FSTListenSequenceNumber ReadSequenceNumber(const absl::string_view &slice) {
 }
 
 - (void)removeQueryData:(FSTQueryData *)queryData {
-  FSTTargetID targetID = queryData.targetID;
+  TargetId targetID = queryData.targetID;
 
   [self removeMatchingKeysForTargetID:targetID];
 
@@ -358,7 +359,7 @@ FSTListenSequenceNumber ReadSequenceNumber(const absl::string_view &slice) {
 
 #pragma mark Matching Key tracking
 
-- (void)addMatchingKeys:(const DocumentKeySet &)keys forTargetID:(FSTTargetID)targetID {
+- (void)addMatchingKeys:(const DocumentKeySet &)keys forTargetID:(TargetId)targetID {
   // Store an empty value in the index which is equivalent to serializing a GPBEmpty message. In the
   // future if we wanted to store some other kind of value here, we can parse these empty values as
   // with some other protocol buffer (and the parser will see all default values).
@@ -371,7 +372,7 @@ FSTListenSequenceNumber ReadSequenceNumber(const absl::string_view &slice) {
   };
 }
 
-- (void)removeMatchingKeys:(const DocumentKeySet &)keys forTargetID:(FSTTargetID)targetID {
+- (void)removeMatchingKeys:(const DocumentKeySet &)keys forTargetID:(TargetId)targetID {
   for (const DocumentKey &key : keys) {
     self->_db.currentTransaction->Delete(LevelDbTargetDocumentKey::Key(targetID, key));
     self->_db.currentTransaction->Delete(LevelDbDocumentTargetKey::Key(key, targetID));
@@ -379,7 +380,7 @@ FSTListenSequenceNumber ReadSequenceNumber(const absl::string_view &slice) {
   }
 }
 
-- (void)removeMatchingKeysForTargetID:(FSTTargetID)targetID {
+- (void)removeMatchingKeysForTargetID:(TargetId)targetID {
   std::string indexPrefix = LevelDbTargetDocumentKey::KeyPrefix(targetID);
   auto indexIterator = _db.currentTransaction->NewIterator();
   indexIterator->Seek(indexPrefix);
@@ -400,7 +401,7 @@ FSTListenSequenceNumber ReadSequenceNumber(const absl::string_view &slice) {
   }
 }
 
-- (DocumentKeySet)matchingKeysForTargetID:(FSTTargetID)targetID {
+- (DocumentKeySet)matchingKeysForTargetID:(TargetId)targetID {
   std::string indexPrefix = LevelDbTargetDocumentKey::KeyPrefix(targetID);
   auto indexIterator = _db.currentTransaction->NewIterator();
   indexIterator->Seek(indexPrefix);

--- a/Firestore/Source/Local/FSTLevelDBQueryCache.mm
+++ b/Firestore/Source/Local/FSTLevelDBQueryCache.mm
@@ -46,12 +46,12 @@ using firebase::firestore::local::LevelDbTransaction;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::SnapshotVersion;
+using firebase::firestore::model::TargetId;
 using firebase::firestore::util::MakeString;
 using firebase::firestore::util::OrderedCode;
 using leveldb::DB;
 using leveldb::Slice;
 using leveldb::Status;
-using firebase::firestore::model::TargetId;
 
 namespace {
 

--- a/Firestore/Source/Local/FSTLocalSerializer.mm
+++ b/Firestore/Source/Local/FSTLocalSerializer.mm
@@ -38,6 +38,7 @@
 using firebase::Timestamp;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::SnapshotVersion;
+using firebase::firestore::model::TargetId;
 
 @interface FSTLocalSerializer ()
 
@@ -187,7 +188,7 @@ using firebase::firestore::model::SnapshotVersion;
 - (FSTQueryData *)decodedQueryData:(FSTPBTarget *)target {
   FSTSerializerBeta *remoteSerializer = self.remoteSerializer;
 
-  FSTTargetID targetID = target.targetId;
+  TargetId targetID = target.targetId;
   FSTListenSequenceNumber sequenceNumber = target.lastListenSequenceNumber;
   SnapshotVersion version = [remoteSerializer decodedVersion:target.snapshotVersion];
   NSData *resumeToken = target.resumeToken;

--- a/Firestore/Source/Local/FSTLocalStore.h
+++ b/Firestore/Source/Local/FSTLocalStore.h
@@ -23,6 +23,7 @@
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
 #include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 @class FSTLocalViewChanges;
 @class FSTLocalWriteResult;
@@ -149,7 +150,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Returns the keys of the documents that are associated with the given targetID in the remote
  * table.
  */
-- (firebase::firestore::model::DocumentKeySet)remoteDocumentKeysForTarget:(FSTTargetID)targetID;
+- (firebase::firestore::model::DocumentKeySet)remoteDocumentKeysForTarget:(firebase::firestore::model::TargetId)targetID;
 
 /**
  * Assigns @a query an internal ID so that its results can be pinned so they don't get GC'd.

--- a/Firestore/Source/Local/FSTLocalStore.h
+++ b/Firestore/Source/Local/FSTLocalStore.h
@@ -150,7 +150,8 @@ NS_ASSUME_NONNULL_BEGIN
  * Returns the keys of the documents that are associated with the given targetID in the remote
  * table.
  */
-- (firebase::firestore::model::DocumentKeySet)remoteDocumentKeysForTarget:(firebase::firestore::model::TargetId)targetID;
+- (firebase::firestore::model::DocumentKeySet)remoteDocumentKeysForTarget:
+    (firebase::firestore::model::TargetId)targetID;
 
 /**
  * Assigns @a query an internal ID so that its results can be pinned so they don't get GC'd.

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -46,9 +46,9 @@
 using firebase::firestore::auth::User;
 using firebase::firestore::core::TargetIdGenerator;
 using firebase::firestore::model::DocumentKey;
-using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::DocumentVersionMap;
+using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -49,6 +49,7 @@ using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::DocumentVersionMap;
+using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -115,7 +116,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)start {
   [self startMutationQueue];
-  FSTTargetID targetID = [self.queryCache highestTargetID];
+  TargetId targetID = [self.queryCache highestTargetID];
   _targetIDGenerator = TargetIdGenerator::LocalStoreTargetIdGenerator(targetID);
 }
 
@@ -243,7 +244,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     DocumentKeySet authoritativeUpdates;
     for (const auto &entry : remoteEvent.targetChanges) {
-      FSTTargetID targetID = entry.first;
+      TargetId targetID = entry.first;
       FSTBoxedTargetID *boxedTargetID = @(targetID);
       FSTTargetChange *change = entry.second;
 
@@ -408,7 +409,7 @@ NS_ASSUME_NONNULL_BEGIN
   });
 }
 
-- (DocumentKeySet)remoteDocumentKeysForTarget:(FSTTargetID)targetID {
+- (DocumentKeySet)remoteDocumentKeysForTarget:(TargetId)targetID {
   return self.persistence.run("RemoteDocumentKeysForTarget", [&]() -> DocumentKeySet {
     return [self.queryCache matchingKeysForTargetID:targetID];
   });

--- a/Firestore/Source/Local/FSTLocalViewChanges.h
+++ b/Firestore/Source/Local/FSTLocalViewChanges.h
@@ -19,6 +19,7 @@
 #import "Firestore/Source/Core/FSTTypes.h"
 
 #include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 @class FSTDocumentSet;
 @class FSTMutation;
@@ -35,16 +36,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface FSTLocalViewChanges : NSObject
 
-+ (instancetype)changesForTarget:(FSTTargetID)targetID
++ (instancetype)changesForTarget:(firebase::firestore::model::TargetId)targetID
                        addedKeys:(firebase::firestore::model::DocumentKeySet)addedKeys
                      removedKeys:(firebase::firestore::model::DocumentKeySet)removedKeys;
 
 + (instancetype)changesForViewSnapshot:(FSTViewSnapshot *)viewSnapshot
-                          withTargetID:(FSTTargetID)targetID;
+                          withTargetID:(firebase::firestore::model::TargetId)targetID;
 
 - (id)init NS_UNAVAILABLE;
 
-@property(readonly) FSTTargetID targetID;
+@property(readonly) firebase::firestore::model::TargetId targetID;
 
 - (const firebase::firestore::model::DocumentKeySet &)addedKeys;
 - (const firebase::firestore::model::DocumentKeySet &)removedKeys;

--- a/Firestore/Source/Local/FSTLocalViewChanges.mm
+++ b/Firestore/Source/Local/FSTLocalViewChanges.mm
@@ -22,11 +22,12 @@
 #import "Firestore/Source/Model/FSTDocument.h"
 
 using firebase::firestore::model::DocumentKeySet;
+using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface FSTLocalViewChanges ()
-- (instancetype)initWithTarget:(FSTTargetID)targetID
+- (instancetype)initWithTarget:(TargetId)targetID
                      addedKeys:(DocumentKeySet)addedKeys
                    removedKeys:(DocumentKeySet)removedKeys NS_DESIGNATED_INITIALIZER;
 @end
@@ -37,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (instancetype)changesForViewSnapshot:(FSTViewSnapshot *)viewSnapshot
-                          withTargetID:(FSTTargetID)targetID {
+                          withTargetID:(TargetId)targetID {
   DocumentKeySet addedKeys;
   DocumentKeySet removedKeys;
 
@@ -62,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
                     removedKeys:std::move(removedKeys)];
 }
 
-+ (instancetype)changesForTarget:(FSTTargetID)targetID
++ (instancetype)changesForTarget:(TargetId)targetID
                        addedKeys:(DocumentKeySet)addedKeys
                      removedKeys:(DocumentKeySet)removedKeys {
   return [[FSTLocalViewChanges alloc] initWithTarget:targetID
@@ -70,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
                                          removedKeys:std::move(removedKeys)];
 }
 
-- (instancetype)initWithTarget:(FSTTargetID)targetID
+- (instancetype)initWithTarget:(TargetId)targetID
                      addedKeys:(DocumentKeySet)addedKeys
                    removedKeys:(DocumentKeySet)removedKeys {
   self = [super init];

--- a/Firestore/Source/Local/FSTMemoryQueryCache.mm
+++ b/Firestore/Source/Local/FSTMemoryQueryCache.mm
@@ -29,6 +29,7 @@
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -41,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, readonly) FSTReferenceSet *references;
 
 /** The highest numbered target ID encountered. */
-@property(nonatomic, assign) FSTTargetID highestTargetID;
+@property(nonatomic, assign) TargetId highestTargetID;
 
 @property(nonatomic, assign) FSTListenSequenceNumber highestListenSequenceNumber;
 
@@ -66,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - FSTQueryCache implementation
 #pragma mark Query tracking
 
-- (FSTTargetID)highestTargetID {
+- (TargetId)highestTargetID {
   return _highestTargetID;
 }
 
@@ -140,25 +141,25 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark Reference tracking
 
-- (void)addMatchingKeys:(const DocumentKeySet &)keys forTargetID:(FSTTargetID)targetID {
+- (void)addMatchingKeys:(const DocumentKeySet &)keys forTargetID:(TargetId)targetID {
   [self.references addReferencesToKeys:keys forID:targetID];
   for (const DocumentKey &key : keys) {
     [_persistence.referenceDelegate addReference:key];
   }
 }
 
-- (void)removeMatchingKeys:(const DocumentKeySet &)keys forTargetID:(FSTTargetID)targetID {
+- (void)removeMatchingKeys:(const DocumentKeySet &)keys forTargetID:(TargetId)targetID {
   [self.references removeReferencesToKeys:keys forID:targetID];
   for (const DocumentKey &key : keys) {
     [_persistence.referenceDelegate removeReference:key];
   }
 }
 
-- (void)removeMatchingKeysForTargetID:(FSTTargetID)targetID {
+- (void)removeMatchingKeysForTargetID:(TargetId)targetID {
   [self.references removeReferencesForID:targetID];
 }
 
-- (DocumentKeySet)matchingKeysForTargetID:(FSTTargetID)targetID {
+- (DocumentKeySet)matchingKeysForTargetID:(TargetId)targetID {
   return [self.references referencedKeysForID:targetID];
 }
 

--- a/Firestore/Source/Local/FSTQueryCache.h
+++ b/Firestore/Source/Local/FSTQueryCache.h
@@ -20,6 +20,7 @@
 
 #include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
 #include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 @class FSTDocumentSet;
 @class FSTMaybeDocument;
@@ -42,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  * seed a target ID generator and avoid collisions with existing queries. If there are no queries
  * in the cache, returns zero.
  */
-- (FSTTargetID)highestTargetID;
+- (firebase::firestore::model::TargetId)highestTargetID;
 
 /**
  * Returns the highest listen sequence number of any query seen by the cache.
@@ -107,16 +108,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Adds the given document keys to cached query results of the given target ID. */
 - (void)addMatchingKeys:(const firebase::firestore::model::DocumentKeySet &)keys
-            forTargetID:(FSTTargetID)targetID;
+            forTargetID:(firebase::firestore::model::TargetId)targetID;
 
 /** Removes the given document keys from the cached query results of the given target ID. */
 - (void)removeMatchingKeys:(const firebase::firestore::model::DocumentKeySet &)keys
-               forTargetID:(FSTTargetID)targetID;
+               forTargetID:(firebase::firestore::model::TargetId)targetID;
 
 /** Removes all the keys in the query results of the given target ID. */
-- (void)removeMatchingKeysForTargetID:(FSTTargetID)targetID;
+- (void)removeMatchingKeysForTargetID:(firebase::firestore::model::TargetId)targetID;
 
-- (firebase::firestore::model::DocumentKeySet)matchingKeysForTargetID:(FSTTargetID)targetID;
+- (firebase::firestore::model::DocumentKeySet)matchingKeysForTargetID:(firebase::firestore::model::TargetId)targetID;
 
 /**
  * Checks to see if there are any references to a document with the given key.

--- a/Firestore/Source/Local/FSTQueryCache.h
+++ b/Firestore/Source/Local/FSTQueryCache.h
@@ -117,7 +117,8 @@ NS_ASSUME_NONNULL_BEGIN
 /** Removes all the keys in the query results of the given target ID. */
 - (void)removeMatchingKeysForTargetID:(firebase::firestore::model::TargetId)targetID;
 
-- (firebase::firestore::model::DocumentKeySet)matchingKeysForTargetID:(firebase::firestore::model::TargetId)targetID;
+- (firebase::firestore::model::DocumentKeySet)matchingKeysForTargetID:
+    (firebase::firestore::model::TargetId)targetID;
 
 /**
  * Checks to see if there are any references to a document with the given key.

--- a/Firestore/Source/Local/FSTQueryData.h
+++ b/Firestore/Source/Local/FSTQueryData.h
@@ -19,6 +19,7 @@
 #import "Firestore/Source/Core/FSTTypes.h"
 
 #include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 @class FSTQuery;
 
@@ -40,7 +41,7 @@ typedef NS_ENUM(NSInteger, FSTQueryPurpose) {
 @interface FSTQueryData : NSObject
 
 - (instancetype)initWithQuery:(FSTQuery *)query
-                     targetID:(FSTTargetID)targetID
+                     targetID:(firebase::firestore::model::TargetId)targetID
          listenSequenceNumber:(FSTListenSequenceNumber)sequenceNumber
                       purpose:(FSTQueryPurpose)purpose
               snapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVersion
@@ -48,7 +49,7 @@ typedef NS_ENUM(NSInteger, FSTQueryPurpose) {
 
 /** Convenience initializer for use when creating an FSTQueryData for the first time. */
 - (instancetype)initWithQuery:(FSTQuery *)query
-                     targetID:(FSTTargetID)targetID
+                     targetID:(firebase::firestore::model::TargetId)targetID
          listenSequenceNumber:(FSTListenSequenceNumber)sequenceNumber
                       purpose:(FSTQueryPurpose)purpose;
 
@@ -73,7 +74,7 @@ typedef NS_ENUM(NSInteger, FSTQueryPurpose) {
  * The targetID to which the query corresponds, assigned by the FSTLocalStore for user queries or
  * the FSTSyncEngine for limbo queries.
  */
-@property(nonatomic, assign, readonly) FSTTargetID targetID;
+@property(nonatomic, assign, readonly) firebase::firestore::model::TargetId targetID;
 
 @property(nonatomic, assign, readonly) FSTListenSequenceNumber sequenceNumber;
 

--- a/Firestore/Source/Local/FSTQueryData.mm
+++ b/Firestore/Source/Local/FSTQueryData.mm
@@ -24,6 +24,7 @@
 #include "Firestore/core/src/firebase/firestore/util/hashing.h"
 
 using firebase::firestore::model::SnapshotVersion;
+using firebase::firestore::model::TargetId;
 namespace util = firebase::firestore::util;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -33,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithQuery:(FSTQuery *)query
-                     targetID:(FSTTargetID)targetID
+                     targetID:(TargetId)targetID
          listenSequenceNumber:(FSTListenSequenceNumber)sequenceNumber
                       purpose:(FSTQueryPurpose)purpose
               snapshotVersion:(SnapshotVersion)snapshotVersion
@@ -51,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithQuery:(FSTQuery *)query
-                     targetID:(FSTTargetID)targetID
+                     targetID:(TargetId)targetID
          listenSequenceNumber:(FSTListenSequenceNumber)sequenceNumber
                       purpose:(FSTQueryPurpose)purpose {
   return [self initWithQuery:query

--- a/Firestore/Source/Local/FSTQueryData.mm
+++ b/Firestore/Source/Local/FSTQueryData.mm
@@ -23,9 +23,9 @@
 #include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 #include "Firestore/core/src/firebase/firestore/util/hashing.h"
 
+namespace util = firebase::firestore::util;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
-namespace util = firebase::firestore::util;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/Source/Remote/FSTRemoteEvent.h
+++ b/Firestore/Source/Remote/FSTRemoteEvent.h
@@ -27,6 +27,7 @@
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
 #include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 @class FSTDocument;
 @class FSTExistenceFilter;
@@ -122,8 +123,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)
     initWithSnapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVersion
-              targetChanges:(std::unordered_map<FSTTargetID, FSTTargetChange *>)targetChanges
-           targetMismatches:(std::unordered_set<FSTTargetID>)targetMismatches
+              targetChanges:(std::unordered_map<firebase::firestore::model::TargetId, FSTTargetChange *>)targetChanges
+           targetMismatches:(std::unordered_set<firebase::firestore::model::TargetId>)targetMismatches
             documentUpdates:
                 (std::unordered_map<firebase::firestore::model::DocumentKey,
                                     FSTMaybeDocument *,
@@ -139,13 +140,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (const firebase::firestore::model::DocumentKeySet &)limboDocumentChanges;
 
 /** A map from target to changes to the target. See TargetChange. */
-- (const std::unordered_map<FSTTargetID, FSTTargetChange *> &)targetChanges;
+- (const std::unordered_map<firebase::firestore::model::TargetId, FSTTargetChange *> &)targetChanges;
 
 /**
  * A set of targets that is known to be inconsistent. Listens for these targets should be
  * re-established without resume tokens.
  */
-- (const std::unordered_set<FSTTargetID> &)targetMismatches;
+- (const std::unordered_set<firebase::firestore::model::TargetId> &)targetMismatches;
 
 /**
  * A set of which documents have changed or been deleted, along with the doc's new values (if not
@@ -177,7 +178,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)handleTargetChange:(FSTWatchTargetChange *)targetChange;
 
 /** Removes the in-memory state for the provided target. */
-- (void)removeTarget:(FSTTargetID)targetID;
+- (void)removeTarget:(firebase::firestore::model::TargetId)targetID;
 
 /**
  * Handles existence filters and synthesizes deletes for filter mismatches. Targets that are

--- a/Firestore/Source/Remote/FSTRemoteEvent.h
+++ b/Firestore/Source/Remote/FSTRemoteEvent.h
@@ -123,8 +123,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)
     initWithSnapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVersion
-              targetChanges:(std::unordered_map<firebase::firestore::model::TargetId, FSTTargetChange *>)targetChanges
-           targetMismatches:(std::unordered_set<firebase::firestore::model::TargetId>)targetMismatches
+              targetChanges:
+                  (std::unordered_map<firebase::firestore::model::TargetId, FSTTargetChange *>)
+                      targetChanges
+           targetMismatches:
+               (std::unordered_set<firebase::firestore::model::TargetId>)targetMismatches
             documentUpdates:
                 (std::unordered_map<firebase::firestore::model::DocumentKey,
                                     FSTMaybeDocument *,
@@ -140,7 +143,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (const firebase::firestore::model::DocumentKeySet &)limboDocumentChanges;
 
 /** A map from target to changes to the target. See TargetChange. */
-- (const std::unordered_map<firebase::firestore::model::TargetId, FSTTargetChange *> &)targetChanges;
+- (const std::unordered_map<firebase::firestore::model::TargetId, FSTTargetChange *> &)
+    targetChanges;
 
 /**
  * A set of targets that is known to be inconsistent. Listens for these targets should be

--- a/Firestore/Source/Remote/FSTRemoteEvent.mm
+++ b/Firestore/Source/Remote/FSTRemoteEvent.mm
@@ -39,8 +39,8 @@ using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeyHash;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::SnapshotVersion;
-using firebase::firestore::util::Hash;
 using firebase::firestore::model::TargetId;
+using firebase::firestore::util::Hash;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/Source/Remote/FSTRemoteStore.h
+++ b/Firestore/Source/Remote/FSTRemoteStore.h
@@ -20,6 +20,7 @@
 #import "Firestore/Source/Remote/FSTRemoteEvent.h"
 
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 @class FSTDatastore;
 @class FSTLocalStore;
@@ -135,7 +136,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)listenToTargetWithQueryData:(FSTQueryData *)queryData;
 
 /** Stops listening to the target with the given target ID. */
-- (void)stopListeningToTargetID:(FSTTargetID)targetID;
+- (void)stopListeningToTargetID:(firebase::firestore::model::TargetId)targetID;
 
 /**
  * Tells the FSTRemoteStore that there are new mutations to process in the queue. This is typically

--- a/Firestore/Source/Remote/FSTRemoteStore.mm
+++ b/Firestore/Source/Remote/FSTRemoteStore.mm
@@ -44,6 +44,7 @@ using firebase::firestore::auth::User;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::DocumentKeySet;
+using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -250,7 +251,7 @@ static const int kMaxPendingWrites = 10;
   [self.watchStream watchQuery:queryData];
 }
 
-- (void)stopListeningToTargetID:(FSTTargetID)targetID {
+- (void)stopListeningToTargetID:(TargetId)targetID {
   FSTBoxedTargetID *targetKey = @(targetID);
   FSTQueryData *queryData = self.listenTargets[targetKey];
   HARD_ASSERT(queryData, "unlistenToTarget: target not currently watched: %s", targetKey);
@@ -369,7 +370,7 @@ static const int kMaxPendingWrites = 10;
   }
 
   // Re-establish listens for the targets that have been invalidated by existence filter mismatches.
-  for (FSTTargetID targetID : remoteEvent.targetMismatches) {
+  for (TargetId targetID : remoteEvent.targetMismatches) {
     FSTQueryData *queryData = self.listenTargets[@(targetID)];
 
     if (!queryData) {

--- a/Firestore/Source/Remote/FSTRemoteStore.mm
+++ b/Firestore/Source/Remote/FSTRemoteStore.mm
@@ -42,8 +42,8 @@
 namespace util = firebase::firestore::util;
 using firebase::firestore::auth::User;
 using firebase::firestore::model::DocumentKey;
-using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::DocumentKeySet;
+using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Firestore/Source/Remote/FSTSerializerBeta.mm
+++ b/Firestore/Source/Remote/FSTSerializerBeta.mm
@@ -67,8 +67,8 @@ using firebase::firestore::model::Precondition;
 using firebase::firestore::model::ResourcePath;
 using firebase::firestore::model::ServerTimestampTransform;
 using firebase::firestore::model::SnapshotVersion;
-using firebase::firestore::model::TransformOperation;
 using firebase::firestore::model::TargetId;
+using firebase::firestore::model::TransformOperation;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/Source/Remote/FSTSerializerBeta.mm
+++ b/Firestore/Source/Remote/FSTSerializerBeta.mm
@@ -68,6 +68,7 @@ using firebase::firestore::model::ResourcePath;
 using firebase::firestore::model::ServerTimestampTransform;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TransformOperation;
+using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -1183,7 +1184,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (FSTExistenceFilterWatchChange *)decodedExistenceFilterWatchChange:(GCFSExistenceFilter *)filter {
   // TODO(dimond): implement existence filter parsing
   FSTExistenceFilter *existenceFilter = [FSTExistenceFilter filterWithCount:filter.count];
-  FSTTargetID targetID = filter.targetId;
+  TargetId targetID = filter.targetId;
   return [FSTExistenceFilterWatchChange changeWithFilter:existenceFilter targetID:targetID];
 }
 

--- a/Firestore/Source/Remote/FSTStream.h
+++ b/Firestore/Source/Remote/FSTStream.h
@@ -22,6 +22,7 @@
 #include "Firestore/core/src/firebase/firestore/auth/credentials_provider.h"
 #include "Firestore/core/src/firebase/firestore/core/database_info.h"
 #include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 @class FSTDispatchQueue;
 @class FSTMutation;
@@ -230,7 +231,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)watchQuery:(FSTQueryData *)query;
 
 /** Unregisters interest in the results of the query associated with the given target ID. */
-- (void)unwatchTargetID:(FSTTargetID)targetID;
+- (void)unwatchTargetID:(firebase::firestore::model::TargetId)targetID;
 
 @end
 

--- a/Firestore/Source/Remote/FSTStream.mm
+++ b/Firestore/Source/Remote/FSTStream.mm
@@ -46,6 +46,7 @@ using firebase::firestore::auth::Token;
 using firebase::firestore::core::DatabaseInfo;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::SnapshotVersion;
+using firebase::firestore::model::TargetId;
 
 /**
  * Initial backoff time in seconds after an error.
@@ -668,7 +669,7 @@ static const NSTimeInterval kIdleTimeout = 60.0;
   [self writeRequest:request];
 }
 
-- (void)unwatchTargetID:(FSTTargetID)targetID {
+- (void)unwatchTargetID:(TargetId)targetID {
   HARD_ASSERT([self isOpen], "Not yet open");
   [self.workerDispatchQueue verifyIsCurrentQueue];
 

--- a/Firestore/Source/Remote/FSTWatchChange.h
+++ b/Firestore/Source/Remote/FSTWatchChange.h
@@ -19,6 +19,7 @@
 #import "Firestore/Source/Core/FSTTypes.h"
 
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 @class FSTExistenceFilter;
 @class FSTMaybeDocument;
@@ -70,12 +71,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface FSTExistenceFilterWatchChange : FSTWatchChange
 
-+ (instancetype)changeWithFilter:(FSTExistenceFilter *)filter targetID:(FSTTargetID)targetID;
++ (instancetype)changeWithFilter:(FSTExistenceFilter *)filter targetID:(firebase::firestore::model::TargetId)targetID;
 
 - (instancetype)init NS_UNAVAILABLE;
 
 @property(nonatomic, strong, readonly) FSTExistenceFilter *filter;
-@property(nonatomic, assign, readonly) FSTTargetID targetID;
+@property(nonatomic, assign, readonly) firebase::firestore::model::TargetId targetID;
 @end
 
 /** FSTWatchTargetChangeState is the kind of change that happened to the watch target. */

--- a/Firestore/Source/Remote/FSTWatchChange.h
+++ b/Firestore/Source/Remote/FSTWatchChange.h
@@ -71,7 +71,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface FSTExistenceFilterWatchChange : FSTWatchChange
 
-+ (instancetype)changeWithFilter:(FSTExistenceFilter *)filter targetID:(firebase::firestore::model::TargetId)targetID;
++ (instancetype)changeWithFilter:(FSTExistenceFilter *)filter
+                        targetID:(firebase::firestore::model::TargetId)targetID;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/Firestore/Source/Remote/FSTWatchChange.mm
+++ b/Firestore/Source/Remote/FSTWatchChange.mm
@@ -24,6 +24,7 @@
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -80,17 +81,17 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FSTExistenceFilterWatchChange ()
 
 - (instancetype)initWithFilter:(FSTExistenceFilter *)filter
-                      targetID:(FSTTargetID)targetID NS_DESIGNATED_INITIALIZER;
+                      targetID:(TargetId)targetID NS_DESIGNATED_INITIALIZER;
 
 @end
 
 @implementation FSTExistenceFilterWatchChange
 
-+ (instancetype)changeWithFilter:(FSTExistenceFilter *)filter targetID:(FSTTargetID)targetID {
++ (instancetype)changeWithFilter:(FSTExistenceFilter *)filter targetID:(TargetId)targetID {
   return [[FSTExistenceFilterWatchChange alloc] initWithFilter:filter targetID:targetID];
 }
 
-- (instancetype)initWithFilter:(FSTExistenceFilter *)filter targetID:(FSTTargetID)targetID {
+- (instancetype)initWithFilter:(FSTExistenceFilter *)filter targetID:(TargetId)targetID {
   self = [super init];
   if (self) {
     _filter = filter;


### PR DESCRIPTION
This is a mostly mechanical change that gets rid of an Objective-C type.