### PR TITLE
Migrate FSTOnlineState to C++ OnlineState

### DIFF
--- a/Firestore/Example/Tests/Core/FSTEventManagerTests.mm
+++ b/Firestore/Example/Tests/Core/FSTEventManagerTests.mm
@@ -26,7 +26,21 @@
 
 #import "Firestore/Example/Tests/Util/FSTHelpers.h"
 
+#include "Firestore/core/src/firebase/firestore/model/types.h"
+
+using firebase::firestore::model::OnlineState;
+
 NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Convertes an OnlineState to an NSNumber, usually for the purpose of additing
+ * it to an NSArray or similar container. There's no direct conversion from a
+ * strongly-typed enum to an integral type that could be passed to an NSNumber
+ * initializer.
+ */
+static NSNumber* ToNSNumber(OnlineState state) {
+  return @(static_cast<std::underlying_type<OnlineState>::type>(state));
+}
 
 // FSTEventManager implements this delegate privately
 @interface FSTEventManager () <FSTSyncEngineDelegate>
@@ -139,13 +153,13 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQueryListener *fakeListener = OCMClassMock([FSTQueryListener class]);
   NSMutableArray *events = [NSMutableArray array];
   OCMStub([fakeListener query]).andReturn(query);
-  OCMStub([fakeListener applyChangedOnlineState:FSTOnlineStateUnknown])
+  OCMStub([fakeListener applyChangedOnlineState:OnlineState::Unknown])
       .andDo(^(NSInvocation *invocation) {
-        [events addObject:@(FSTOnlineStateUnknown)];
+        [events addObject:@(static_cast<std::underlying_type<OnlineState>::type>(OnlineState::Unknown))];
       });
-  OCMStub([fakeListener applyChangedOnlineState:FSTOnlineStateOnline])
+  OCMStub([fakeListener applyChangedOnlineState:OnlineState::Online])
       .andDo(^(NSInvocation *invocation) {
-        [events addObject:@(FSTOnlineStateOnline)];
+        [events addObject:ToNSNumber(OnlineState::Online)];
       });
 
   FSTSyncEngine *syncEngineMock = OCMClassMock([FSTSyncEngine class]);
@@ -153,9 +167,9 @@ NS_ASSUME_NONNULL_BEGIN
   FSTEventManager *eventManager = [FSTEventManager eventManagerWithSyncEngine:syncEngineMock];
 
   [eventManager addListener:fakeListener];
-  XCTAssertEqualObjects(events, @[ @(FSTOnlineStateUnknown) ]);
-  [eventManager applyChangedOnlineState:FSTOnlineStateOnline];
-  XCTAssertEqualObjects(events, (@[ @(FSTOnlineStateUnknown), @(FSTOnlineStateOnline) ]));
+  XCTAssertEqualObjects(events, @[ ToNSNumber(OnlineState::Unknown) ]);
+  [eventManager applyChangedOnlineState:OnlineState::Online];
+  XCTAssertEqualObjects(events, (@[ ToNSNumber(OnlineState::Unknown), ToNSNumber(OnlineState::Online) ]));
 }
 
 @end

--- a/Firestore/Example/Tests/Core/FSTQueryListenerTests.mm
+++ b/Firestore/Example/Tests/Core/FSTQueryListenerTests.mm
@@ -27,11 +27,13 @@
 
 #import "Firestore/Example/Tests/Util/FSTHelpers.h"
 
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 #include "Firestore/core/src/firebase/firestore/util/executor_libdispatch.h"
 #include "absl/memory/memory.h"
 
-using firebase::firestore::util::internal::ExecutorLibdispatch;
 using firebase::firestore::model::DocumentKeySet;
+using firebase::firestore::model::OnlineState;
+using firebase::firestore::util::internal::ExecutorLibdispatch;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -338,10 +340,10 @@ NS_ASSUME_NONNULL_BEGIN
   FSTViewSnapshot *snap3 =
       FSTTestApplyChanges(view, @[], FSTTestTargetChangeAckDocuments({doc1.key, doc2.key}));
 
-  [listener applyChangedOnlineState:FSTOnlineStateOnline];  // no event
+  [listener applyChangedOnlineState:OnlineState::Online];  // no event
   [listener queryDidChangeViewSnapshot:snap1];
-  [listener applyChangedOnlineState:FSTOnlineStateUnknown];
-  [listener applyChangedOnlineState:FSTOnlineStateOnline];
+  [listener applyChangedOnlineState:OnlineState::Unknown];
+  [listener applyChangedOnlineState:OnlineState::Online];
   [listener queryDidChangeViewSnapshot:snap2];
   [listener queryDidChangeViewSnapshot:snap3];
 
@@ -377,11 +379,11 @@ NS_ASSUME_NONNULL_BEGIN
   FSTViewSnapshot *snap1 = FSTTestApplyChanges(view, @[ doc1 ], nil);
   FSTViewSnapshot *snap2 = FSTTestApplyChanges(view, @[ doc2 ], nil);
 
-  [listener applyChangedOnlineState:FSTOnlineStateOnline];   // no event
+  [listener applyChangedOnlineState:OnlineState::Online];   // no event
   [listener queryDidChangeViewSnapshot:snap1];               // no event
-  [listener applyChangedOnlineState:FSTOnlineStateOffline];  // event
-  [listener applyChangedOnlineState:FSTOnlineStateUnknown];  // no event
-  [listener applyChangedOnlineState:FSTOnlineStateOffline];  // no event
+  [listener applyChangedOnlineState:OnlineState::Offline];  // event
+  [listener applyChangedOnlineState:OnlineState::Unknown];  // no event
+  [listener applyChangedOnlineState:OnlineState::Offline];  // no event
   [listener queryDidChangeViewSnapshot:snap2];               // another event
 
   FSTDocumentViewChange *change1 =
@@ -417,9 +419,9 @@ NS_ASSUME_NONNULL_BEGIN
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
   FSTViewSnapshot *snap1 = FSTTestApplyChanges(view, @[], nil);
 
-  [listener applyChangedOnlineState:FSTOnlineStateOnline];   // no event
+  [listener applyChangedOnlineState:OnlineState::Online];   // no event
   [listener queryDidChangeViewSnapshot:snap1];               // no event
-  [listener applyChangedOnlineState:FSTOnlineStateOffline];  // event
+  [listener applyChangedOnlineState:OnlineState::Offline];  // event
 
   FSTViewSnapshot *expectedSnap = [[FSTViewSnapshot alloc]
          initWithQuery:query
@@ -443,7 +445,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
   FSTViewSnapshot *snap1 = FSTTestApplyChanges(view, @[], nil);
 
-  [listener applyChangedOnlineState:FSTOnlineStateOffline];  // no event
+  [listener applyChangedOnlineState:OnlineState::Offline];  // no event
   [listener queryDidChangeViewSnapshot:snap1];               // event
 
   FSTViewSnapshot *expectedSnap = [[FSTViewSnapshot alloc]

--- a/Firestore/Example/Tests/SpecTests/FSTMockDatastore.h
+++ b/Firestore/Example/Tests/SpecTests/FSTMockDatastore.h
@@ -19,6 +19,7 @@
 #import "Firestore/Source/Remote/FSTDatastore.h"
 
 #include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.mm
@@ -50,6 +50,7 @@ using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
+using firebase::firestore::model::OnlineState;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -180,7 +181,7 @@ NS_ASSUME_NONNULL_BEGIN
   return _currentUser;
 }
 
-- (void)applyChangedOnlineState:(FSTOnlineState)onlineState {
+- (void)applyChangedOnlineState:(OnlineState)onlineState {
   [self.syncEngine applyChangedOnlineState:onlineState];
   [self.eventManager applyChangedOnlineState:onlineState];
 }

--- a/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.mm
@@ -48,9 +48,9 @@ using firebase::firestore::auth::User;
 using firebase::firestore::core::DatabaseInfo;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::OnlineState;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
-using firebase::firestore::model::OnlineState;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/Source/Core/FSTEventManager.h
+++ b/Firestore/Source/Core/FSTEventManager.h
@@ -20,6 +20,7 @@
 #import "Firestore/Source/Remote/FSTRemoteStore.h"
 
 #include "Firestore/core/src/firebase/firestore/model/types.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 @class FSTQuery;
 @class FSTSyncEngine;
@@ -63,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)queryDidChangeViewSnapshot:(FSTViewSnapshot *)snapshot;
 - (void)queryDidError:(NSError *)error;
-- (void)applyChangedOnlineState:(FSTOnlineState)onlineState;
+- (void)applyChangedOnlineState:(firebase::firestore::model::OnlineState)onlineState;
 
 @property(nonatomic, strong, readonly) FSTQuery *query;
 

--- a/Firestore/Source/Core/FSTEventManager.mm
+++ b/Firestore/Source/Core/FSTEventManager.mm
@@ -22,8 +22,8 @@
 
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 
-using firebase::firestore::model::TargetId;
 using firebase::firestore::model::OnlineState;
+using firebase::firestore::model::TargetId;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/Source/Core/FSTEventManager.mm
+++ b/Firestore/Source/Core/FSTEventManager.mm
@@ -23,6 +23,7 @@
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 
 using firebase::firestore::model::TargetId;
+using firebase::firestore::model::OnlineState;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -97,7 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, assign, readwrite) BOOL raisedInitialEvent;
 
 /** The last online state this query listener got. */
-@property(nonatomic, assign, readwrite) FSTOnlineState onlineState;
+@property(nonatomic, assign, readwrite) OnlineState onlineState;
 
 /** The FSTViewSnapshotHandler associated with this query listener. */
 @property(nonatomic, copy, nullable) FSTViewSnapshotHandler viewSnapshotHandler;
@@ -154,7 +155,7 @@ NS_ASSUME_NONNULL_BEGIN
   self.viewSnapshotHandler(nil, error);
 }
 
-- (void)applyChangedOnlineState:(FSTOnlineState)onlineState {
+- (void)applyChangedOnlineState:(OnlineState)onlineState {
   self.onlineState = onlineState;
   if (self.snapshot && !self.raisedInitialEvent &&
       [self shouldRaiseInitialEventForSnapshot:self.snapshot onlineState:onlineState]) {
@@ -163,7 +164,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)shouldRaiseInitialEventForSnapshot:(FSTViewSnapshot *)snapshot
-                               onlineState:(FSTOnlineState)onlineState {
+                               onlineState:(OnlineState)onlineState {
   HARD_ASSERT(!self.raisedInitialEvent,
               "Determining whether to raise initial event, but already had first event.");
 
@@ -174,7 +175,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   // NOTE: We consider OnlineState.Unknown as online (it should become Offline or Online if we
   // wait long enough).
-  BOOL maybeOnline = onlineState != FSTOnlineStateOffline;
+  BOOL maybeOnline = onlineState != OnlineState::Offline;
   // Don't raise the event if we're online, aren't synced yet (checked
   // above) and are waiting for a sync.
   if (self.options.waitForSyncWhenOnline && maybeOnline) {
@@ -183,7 +184,7 @@ NS_ASSUME_NONNULL_BEGIN
   }
 
   // Raise data from cache if we have any documents or we are offline
-  return !snapshot.documents.isEmpty || onlineState == FSTOnlineStateOffline;
+  return !snapshot.documents.isEmpty || onlineState == OnlineState::Offline;
 }
 
 - (BOOL)shouldRaiseEventForSnapshot:(FSTViewSnapshot *)snapshot {
@@ -239,7 +240,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, readonly) FSTSyncEngine *syncEngine;
 @property(nonatomic, strong, readonly)
     NSMutableDictionary<FSTQuery *, FSTQueryListenersInfo *> *queries;
-@property(nonatomic, assign) FSTOnlineState onlineState;
+@property(nonatomic, assign) OnlineState onlineState;
 
 @end
 
@@ -324,7 +325,7 @@ NS_ASSUME_NONNULL_BEGIN
   [self.queries removeObjectForKey:query];
 }
 
-- (void)applyChangedOnlineState:(FSTOnlineState)onlineState {
+- (void)applyChangedOnlineState:(OnlineState)onlineState {
   self.onlineState = onlineState;
   for (FSTQueryListenersInfo *info in self.queries.objectEnumerator) {
     for (FSTQueryListener *listener in info.listeners) {

--- a/Firestore/Source/Core/FSTFirestoreClient.h
+++ b/Firestore/Source/Core/FSTFirestoreClient.h
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 #include <memory>
 
+#import "Firestore/Source/Core/FSTTypes.h"
 #import "Firestore/Source/Core/FSTViewSnapshot.h"
 #import "Firestore/Source/Remote/FSTRemoteStore.h"
 

--- a/Firestore/Source/Core/FSTFirestoreClient.mm
+++ b/Firestore/Source/Core/FSTFirestoreClient.mm
@@ -56,9 +56,8 @@ using firebase::firestore::auth::User;
 using firebase::firestore::core::DatabaseInfo;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentKeySet;
-
-using firebase::firestore::util::internal::Executor;
 using firebase::firestore::model::OnlineState;
+using firebase::firestore::util::internal::Executor;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/Source/Core/FSTFirestoreClient.mm
+++ b/Firestore/Source/Core/FSTFirestoreClient.mm
@@ -58,6 +58,7 @@ using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentKeySet;
 
 using firebase::firestore::util::internal::Executor;
+using firebase::firestore::model::OnlineState;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -221,7 +222,7 @@ NS_ASSUME_NONNULL_BEGIN
   [self.syncEngine credentialDidChangeWithUser:user];
 }
 
-- (void)applyChangedOnlineState:(FSTOnlineState)onlineState {
+- (void)applyChangedOnlineState:(OnlineState)onlineState {
   [self.syncEngine applyChangedOnlineState:onlineState];
   [self.eventManager applyChangedOnlineState:onlineState];
 }

--- a/Firestore/Source/Core/FSTSyncEngine.h
+++ b/Firestore/Source/Core/FSTSyncEngine.h
@@ -16,6 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import "Firestore/Source/Core/FSTTypes.h"
 #import "Firestore/Source/Remote/FSTRemoteStore.h"
 
 #include "Firestore/core/src/firebase/firestore/auth/user.h"

--- a/Firestore/Source/Core/FSTSyncEngine.h
+++ b/Firestore/Source/Core/FSTSyncEngine.h
@@ -20,6 +20,7 @@
 
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
 #include "Firestore/core/src/firebase/firestore/model/types.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 @class FSTDispatchQueue;
 @class FSTLocalStore;
@@ -102,8 +103,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)credentialDidChangeWithUser:(const firebase::firestore::auth::User &)user;
 
-/** Applies an FSTOnlineState change to the sync engine and notifies any views of the change. */
-- (void)applyChangedOnlineState:(FSTOnlineState)onlineState;
+/** Applies an firebase::firestore::model::OnlineState change to the sync engine and notifies any views of the change. */
+- (void)applyChangedOnlineState:(firebase::firestore::model::OnlineState)onlineState;
 
 @end
 

--- a/Firestore/Source/Core/FSTSyncEngine.mm
+++ b/Firestore/Source/Core/FSTSyncEngine.mm
@@ -53,9 +53,9 @@ using firebase::firestore::model::BatchId;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::ListenSequenceNumber;
+using firebase::firestore::model::OnlineState;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
-using firebase::firestore::model::OnlineState;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/Source/Core/FSTSyncEngine.mm
+++ b/Firestore/Source/Core/FSTSyncEngine.mm
@@ -55,6 +55,7 @@ using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::ListenSequenceNumber;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
+using firebase::firestore::model::OnlineState;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -346,7 +347,7 @@ class LimboResolution {
   [self emitNewSnapshotsWithChanges:changes remoteEvent:remoteEvent];
 }
 
-- (void)applyChangedOnlineState:(FSTOnlineState)onlineState {
+- (void)applyChangedOnlineState:(OnlineState)onlineState {
   NSMutableArray<FSTViewSnapshot *> *newViewSnapshots = [NSMutableArray array];
   [self.queryViewsByQuery
       enumerateKeysAndObjectsUsingBlock:^(FSTQuery *query, FSTQueryView *queryView, BOOL *stop) {

--- a/Firestore/Source/Core/FSTTypes.h
+++ b/Firestore/Source/Core/FSTTypes.h
@@ -58,34 +58,4 @@ typedef void (^FSTVoidMaybeDocumentArrayErrorBlock)(
 typedef void (^FSTTransactionBlock)(FSTTransaction *transaction,
                                     void (^completion)(id _Nullable, NSError *_Nullable));
 
-/**
- * Describes the online state of the Firestore client. Note that this does not indicate whether
- * or not the remote store is trying to connect or not. This is primarily used by the View /
- * EventManager code to change their behavior while offline (e.g. get() calls shouldn't wait for
- * data from the server and snapshot events should set metadata.isFromCache=true).
- */
-typedef NS_ENUM(NSUInteger, FSTOnlineState) {
-  /**
-   * The Firestore client is in an unknown online state. This means the client is either not
-   * actively trying to establish a connection or it is currently trying to establish a connection,
-   * but it has not succeeded or failed yet. Higher-level components should not operate in
-   * offline mode.
-   */
-  FSTOnlineStateUnknown,
-
-  /**
-   * The client is connected and the connections are healthy. This state is reached after a
-   * successful connection and there has been at least one successful message received from the
-   * backends.
-   */
-  FSTOnlineStateOnline,
-
-  /**
-   * The client is either trying to establish a connection but failing, or it has been explicitly
-   * marked offline via a call to `disableNetwork`. Higher-level components should operate in
-   * offline mode.
-   */
-  FSTOnlineStateOffline
-};
-
 NS_ASSUME_NONNULL_END

--- a/Firestore/Source/Core/FSTTypes.h
+++ b/Firestore/Source/Core/FSTTypes.h
@@ -16,8 +16,6 @@
 
 #import <Foundation/Foundation.h>
 
-#include "Firestore/core/src/firebase/firestore/model/types.h"
-
 NS_ASSUME_NONNULL_BEGIN
 
 @class FSTMaybeDocument;

--- a/Firestore/Source/Core/FSTView.h
+++ b/Firestore/Source/Core/FSTView.h
@@ -16,11 +16,11 @@
 
 #import <Foundation/Foundation.h>
 
-#import "Firestore/Source/Core/FSTTypes.h"
 #import "Firestore/Source/Model/FSTDocumentDictionary.h"
 
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 @class FSTDocumentSet;
 @class FSTDocumentViewChangeSet;
@@ -144,10 +144,10 @@ typedef NS_ENUM(NSInteger, FSTLimboDocumentChangeType) {
                               targetChange:(nullable FSTTargetChange *)targetChange;
 
 /**
- * Applies an FSTOnlineState change to the view, potentially generating an FSTViewChange if the
+ * Applies an firebase::firestore::model::OnlineState change to the view, potentially generating an FSTViewChange if the
  * view's syncState changes as a result.
  */
-- (FSTViewChange *)applyChangedOnlineState:(FSTOnlineState)onlineState;
+- (FSTViewChange *)applyChangedOnlineState:(firebase::firestore::model::OnlineState)onlineState;
 
 /**
  * The set of remote documents that the server has told us belongs to the target associated with

--- a/Firestore/Source/Core/FSTView.h
+++ b/Firestore/Source/Core/FSTView.h
@@ -144,7 +144,7 @@ typedef NS_ENUM(NSInteger, FSTLimboDocumentChangeType) {
                               targetChange:(nullable FSTTargetChange *)targetChange;
 
 /**
- * Applies an firebase::firestore::model::OnlineState change to the view, potentially generating an FSTViewChange if the
+ * Applies an OnlineState change to the view, potentially generating an FSTViewChange if the
  * view's syncState changes as a result.
  */
 - (FSTViewChange *)applyChangedOnlineState:(firebase::firestore::model::OnlineState)onlineState;

--- a/Firestore/Source/Core/FSTView.mm
+++ b/Firestore/Source/Core/FSTView.mm
@@ -30,6 +30,7 @@
 
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeySet;
+using firebase::firestore::model::OnlineState;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -355,8 +356,8 @@ static NSComparisonResult FSTCompareDocumentViewChangeTypes(FSTDocumentViewChang
   }
 }
 
-- (FSTViewChange *)applyChangedOnlineState:(FSTOnlineState)onlineState {
-  if (self.isCurrent && onlineState == FSTOnlineStateOffline) {
+- (FSTViewChange *)applyChangedOnlineState:(OnlineState)onlineState {
+  if (self.isCurrent && onlineState == OnlineState::Offline) {
     // If we're offline, set `current` to NO and then call applyChanges to refresh our syncState
     // and generate an FSTViewChange as appropriate. We are guaranteed to get a new FSTTargetChange
     // that sets `current` back to YES once the client is back online.

--- a/Firestore/Source/Remote/FSTOnlineStateTracker.h
+++ b/Firestore/Source/Remote/FSTOnlineStateTracker.h
@@ -25,13 +25,13 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * A component used by the FSTRemoteStore to track the firebase::firestore::model::OnlineState (that is, whether or not the
+ * A component used by the FSTRemoteStore to track the OnlineState (that is, whether or not the
  * client as a whole should be considered to be online or offline), implementing the appropriate
  * heuristics.
  *
  * In particular, when the client is trying to connect to the backend, we allow up to
  * kMaxWatchStreamFailures within kOnlineStateTimeout for a connection to succeed. If we have too
- * many failures or the timeout elapses, then we set the firebase::firestore::model::OnlineState to Offline, and
+ * many failures or the timeout elapses, then we set the OnlineState to Offline, and
  * the client will behave as if it is offline (getDocument() calls will return cached data, etc.).
  */
 @interface FSTOnlineStateTracker : NSObject
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Called by FSTRemoteStore when a watch stream is started (including on each backoff attempt).
  *
- * If this is the first attempt, it sets the firebase::firestore::model::OnlineState to Unknown and starts the
+ * If this is the first attempt, it sets the OnlineState to Unknown and starts the
  * onlineStateTimer.
  */
 - (void)handleWatchStreamStart;
@@ -54,14 +54,14 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Called by FSTRemoteStore when a watch stream fails.
  *
- * Updates our firebase::firestore::model::OnlineState as appropriate. The first failure moves us to OnlineState::Unknown.
+ * Updates our OnlineState as appropriate. The first failure moves us to OnlineState::Unknown.
  * We then may allow multiple failures (based on kMaxWatchStreamFailures) before we actually
  * transition to OnlineState::Offline.
  */
 - (void)handleWatchStreamFailure:(NSError *)error;
 
 /**
- * Explicitly sets the firebase::firestore::model::OnlineState to the specified state.
+ * Explicitly sets the OnlineState to the specified state.
  *
  * Note that this resets the timers / failure counters, etc. used by our Offline heuristics, so
  * it must not be used in place of handleWatchStreamStart and handleWatchStreamFailure.

--- a/Firestore/Source/Remote/FSTOnlineStateTracker.h
+++ b/Firestore/Source/Remote/FSTOnlineStateTracker.h
@@ -16,7 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import "Firestore/Source/Core/FSTTypes.h"
+
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 
 @class FSTDispatchQueue;
 @protocol FSTOnlineStateDelegate;
@@ -24,13 +25,13 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * A component used by the FSTRemoteStore to track the FSTOnlineState (that is, whether or not the
+ * A component used by the FSTRemoteStore to track the firebase::firestore::model::OnlineState (that is, whether or not the
  * client as a whole should be considered to be online or offline), implementing the appropriate
  * heuristics.
  *
  * In particular, when the client is trying to connect to the backend, we allow up to
  * kMaxWatchStreamFailures within kOnlineStateTimeout for a connection to succeed. If we have too
- * many failures or the timeout elapses, then we set the FSTOnlineState to Offline, and
+ * many failures or the timeout elapses, then we set the firebase::firestore::model::OnlineState to Offline, and
  * the client will behave as if it is offline (getDocument() calls will return cached data, etc.).
  */
 @interface FSTOnlineStateTracker : NSObject
@@ -39,13 +40,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 
-/** A delegate to be notified on FSTOnlineState changes. */
+/** A delegate to be notified on firebase::firestore::model::OnlineState changes. */
 @property(nonatomic, weak) id<FSTOnlineStateDelegate> onlineStateDelegate;
 
 /**
  * Called by FSTRemoteStore when a watch stream is started (including on each backoff attempt).
  *
- * If this is the first attempt, it sets the FSTOnlineState to Unknown and starts the
+ * If this is the first attempt, it sets the firebase::firestore::model::OnlineState to Unknown and starts the
  * onlineStateTimer.
  */
 - (void)handleWatchStreamStart;
@@ -53,19 +54,19 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Called by FSTRemoteStore when a watch stream fails.
  *
- * Updates our FSTOnlineState as appropriate. The first failure moves us to FSTOnlineStateUnknown.
+ * Updates our firebase::firestore::model::OnlineState as appropriate. The first failure moves us to OnlineState::Unknown.
  * We then may allow multiple failures (based on kMaxWatchStreamFailures) before we actually
- * transition to FSTOnlineStateOffline.
+ * transition to OnlineState::Offline.
  */
 - (void)handleWatchStreamFailure:(NSError *)error;
 
 /**
- * Explicitly sets the FSTOnlineState to the specified state.
+ * Explicitly sets the firebase::firestore::model::OnlineState to the specified state.
  *
  * Note that this resets the timers / failure counters, etc. used by our Offline heuristics, so
  * it must not be used in place of handleWatchStreamStart and handleWatchStreamFailure.
  */
-- (void)updateState:(FSTOnlineState)newState;
+- (void)updateState:(firebase::firestore::model::OnlineState)newState;
 
 @end
 

--- a/Firestore/Source/Remote/FSTOnlineStateTracker.mm
+++ b/Firestore/Source/Remote/FSTOnlineStateTracker.mm
@@ -21,30 +21,32 @@
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 #include "Firestore/core/src/firebase/firestore/util/log.h"
 
+using firebase::firestore::model::OnlineState;
+
 NS_ASSUME_NONNULL_BEGIN
 
 // To deal with transient failures, we allow multiple stream attempts before giving up and
-// transitioning from FSTOnlineState Unknown to Offline.
+// transitioning from OnlineState Unknown to Offline.
 static const int kMaxWatchStreamFailures = 2;
 
 // To deal with stream attempts that don't succeed or fail in a timely manner, we have a
-// timeout for FSTOnlineState to reach Online or Offline. If the timeout is reached, we transition
+// timeout for OnlineState to reach Online or Offline. If the timeout is reached, we transition
 // to Offline rather than waiting indefinitely.
 static const NSTimeInterval kOnlineStateTimeout = 10;
 
 @interface FSTOnlineStateTracker ()
 
-/** The current FSTOnlineState. */
-@property(nonatomic, assign) FSTOnlineState state;
+/** The current OnlineState. */
+@property(nonatomic, assign) OnlineState state;
 
 /**
  * A count of consecutive failures to open the stream. If it reaches the maximum defined by
- * kMaxWatchStreamFailures, we'll revert to FSTOnlineStateOffline.
+ * kMaxWatchStreamFailures, we'll revert to OnlineState::Offline.
  */
 @property(nonatomic, assign) int watchStreamFailures;
 
 /**
- * A timer that elapses after kOnlineStateTimeout, at which point we transition from FSTOnlineState
+ * A timer that elapses after kOnlineStateTimeout, at which point we transition from OnlineState
  * Unknown to Offline without waiting for the stream to actually fail (kMaxWatchStreamFailures
  * times).
  */
@@ -65,7 +67,7 @@ static const NSTimeInterval kOnlineStateTimeout = 10;
 - (instancetype)initWithWorkerDispatchQueue:(FSTDispatchQueue *)queue {
   if (self = [super init]) {
     _queue = queue;
-    _state = FSTOnlineStateUnknown;
+    _state = OnlineState::Unknown;
     _shouldWarnClientIsOffline = YES;
   }
   return self;
@@ -73,7 +75,7 @@ static const NSTimeInterval kOnlineStateTimeout = 10;
 
 - (void)handleWatchStreamStart {
   if (self.watchStreamFailures == 0) {
-    [self setAndBroadcastState:FSTOnlineStateUnknown];
+    [self setAndBroadcastState:OnlineState::Unknown];
 
     HARD_ASSERT(!self.onlineStateTimer, "onlineStateTimer shouldn't be started yet");
     self.onlineStateTimer = [self.queue
@@ -82,13 +84,13 @@ static const NSTimeInterval kOnlineStateTimeout = 10;
                      block:^{
                        self.onlineStateTimer = nil;
                        HARD_ASSERT(
-                           self.state == FSTOnlineStateUnknown,
+                           self.state == OnlineState::Unknown,
                            "Timer should be canceled if we transitioned to a different state.");
                        [self logClientOfflineWarningIfNecessaryWithReason:
                                  [NSString
                                      stringWithFormat:@"Backend didn't respond within %f seconds.",
                                                       kOnlineStateTimeout]];
-                       [self setAndBroadcastState:FSTOnlineStateOffline];
+                       [self setAndBroadcastState:OnlineState::Offline];
 
                        // NOTE: handleWatchStreamFailure will continue to increment
                        // watchStreamFailures even though we are already marked Offline but this is
@@ -98,10 +100,10 @@ static const NSTimeInterval kOnlineStateTimeout = 10;
 }
 
 - (void)handleWatchStreamFailure:(NSError *)error {
-  if (self.state == FSTOnlineStateOnline) {
-    [self setAndBroadcastState:FSTOnlineStateUnknown];
+  if (self.state == OnlineState::Online) {
+    [self setAndBroadcastState:OnlineState::Unknown];
 
-    // To get to FSTOnlineStateOnline, updateState: must have been called which would have reset
+    // To get to OnlineState::Online, updateState: must have been called which would have reset
     // our heuristics.
     HARD_ASSERT(self.watchStreamFailures == 0, "watchStreamFailures must be 0");
     HARD_ASSERT(!self.onlineStateTimer, "onlineStateTimer must be nil");
@@ -112,16 +114,16 @@ static const NSTimeInterval kOnlineStateTimeout = 10;
       [self logClientOfflineWarningIfNecessaryWithReason:
                 [NSString stringWithFormat:@"Connection failed %d times. Most recent error: %@",
                                            kMaxWatchStreamFailures, error]];
-      [self setAndBroadcastState:FSTOnlineStateOffline];
+      [self setAndBroadcastState:OnlineState::Offline];
     }
   }
 }
 
-- (void)updateState:(FSTOnlineState)newState {
+- (void)updateState:(OnlineState)newState {
   [self clearOnlineStateTimer];
   self.watchStreamFailures = 0;
 
-  if (newState == FSTOnlineStateOnline) {
+  if (newState == OnlineState::Online) {
     // We've connected to watch at least once. Don't warn the developer about being offline going
     // forward.
     self.shouldWarnClientIsOffline = NO;
@@ -130,7 +132,7 @@ static const NSTimeInterval kOnlineStateTimeout = 10;
   [self setAndBroadcastState:newState];
 }
 
-- (void)setAndBroadcastState:(FSTOnlineState)newState {
+- (void)setAndBroadcastState:(OnlineState)newState {
   if (newState != self.state) {
     self.state = newState;
     [self.onlineStateDelegate applyChangedOnlineState:newState];

--- a/Firestore/Source/Remote/FSTRemoteStore.h
+++ b/Firestore/Source/Remote/FSTRemoteStore.h
@@ -16,10 +16,10 @@
 
 #import <Foundation/Foundation.h>
 
-#import "Firestore/Source/Core/FSTTypes.h"
 #import "Firestore/Source/Remote/FSTRemoteEvent.h"
 
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 #include "Firestore/core/src/firebase/firestore/model/types.h"
 
 @class FSTDatastore;
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol FSTOnlineStateDelegate <NSObject>
 
 /** Called whenever the online state of the watch stream changes */
-- (void)applyChangedOnlineState:(FSTOnlineState)onlineState;
+- (void)applyChangedOnlineState:(firebase::firestore::model::OnlineState)onlineState;
 
 @end
 

--- a/Firestore/Source/Remote/FSTRemoteStore.mm
+++ b/Firestore/Source/Remote/FSTRemoteStore.mm
@@ -46,6 +46,7 @@ using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
+using firebase::firestore::model::OnlineState;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -158,7 +159,7 @@ static const int kMaxPendingWrites = 10;
   if ([self shouldStartWatchStream]) {
     [self startWatchStream];
   } else {
-    [self.onlineStateTracker updateState:FSTOnlineStateUnknown];
+    [self.onlineStateTracker updateState:OnlineState::Unknown];
   }
 
   [self fillWritePipeline];  // This may start the writeStream.
@@ -166,11 +167,11 @@ static const int kMaxPendingWrites = 10;
 
 - (void)disableNetwork {
   [self disableNetworkInternal];
-  // Set the FSTOnlineState to Offline so get()s return from cache, etc.
-  [self.onlineStateTracker updateState:FSTOnlineStateOffline];
+  // Set the OnlineState to Offline so get()s return from cache, etc.
+  [self.onlineStateTracker updateState:OnlineState::Offline];
 }
 
-/** Disables the network, setting the FSTOnlineState to the specified targetOnlineState. */
+/** Disables the network, setting the OnlineState to the specified targetOnlineState. */
 - (void)disableNetworkInternal {
   if ([self isNetworkEnabled]) {
     // NOTE: We're guaranteed not to get any further events from these streams (not even a close
@@ -191,9 +192,9 @@ static const int kMaxPendingWrites = 10;
 - (void)shutdown {
   LOG_DEBUG("FSTRemoteStore %s shutting down", (__bridge void *)self);
   [self disableNetworkInternal];
-  // Set the FSTOnlineState to Unknown (rather than Offline) to avoid potentially triggering
+  // Set the OnlineState to Unknown (rather than Offline) to avoid potentially triggering
   // spurious listener events with cached data, etc.
-  [self.onlineStateTracker updateState:FSTOnlineStateUnknown];
+  [self.onlineStateTracker updateState:OnlineState::Unknown];
 }
 
 - (void)credentialDidChange {
@@ -203,7 +204,7 @@ static const int kMaxPendingWrites = 10;
     // (since mutations are per-user).
     LOG_DEBUG("FSTRemoteStore %s restarting streams for new credential", (__bridge void *)self);
     [self disableNetworkInternal];
-    [self.onlineStateTracker updateState:FSTOnlineStateUnknown];
+    [self.onlineStateTracker updateState:OnlineState::Unknown];
     [self enableNetwork];
   }
 }
@@ -278,7 +279,7 @@ static const int kMaxPendingWrites = 10;
 - (void)watchStreamDidChange:(FSTWatchChange *)change
              snapshotVersion:(const SnapshotVersion &)snapshotVersion {
   // Mark the connection as Online because we got a message from the server.
-  [self.onlineStateTracker updateState:FSTOnlineStateOnline];
+  [self.onlineStateTracker updateState:OnlineState::Online];
 
   if ([change isKindOfClass:[FSTWatchTargetChange class]]) {
     FSTWatchTargetChange *watchTargetChange = (FSTWatchTargetChange *)change;
@@ -323,7 +324,7 @@ static const int kMaxPendingWrites = 10;
   } else {
     // We don't need to restart the watch stream because there are no active targets. The online
     // state is set to unknown because there is no active attempt at establishing a connection.
-    [self.onlineStateTracker updateState:FSTOnlineStateUnknown];
+    [self.onlineStateTracker updateState:OnlineState::Unknown];
   }
 }
 

--- a/Firestore/Source/Remote/FSTRemoteStore.mm
+++ b/Firestore/Source/Remote/FSTRemoteStore.mm
@@ -44,9 +44,9 @@ using firebase::firestore::auth::User;
 using firebase::firestore::model::BatchId;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeySet;
+using firebase::firestore::model::OnlineState;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
-using firebase::firestore::model::OnlineState;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/Source/Util/FSTDispatchQueue.h
+++ b/Firestore/Source/Util/FSTDispatchQueue.h
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+#include "Firestore/core/src/firebase/firestore/model/types.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -37,7 +39,7 @@ typedef NS_ENUM(NSInteger, FSTTimerID) {
   FSTTimerIDWriteStreamConnectionBackoff,
 
   /**
-   * A timer used in FSTOnlineStateTracker to transition from FSTOnlineState Unknown to Offline
+   * A timer used in FSTOnlineStateTracker to transition from firebase::firestore::model::OnlineState Unknown to Offline
    * after a set timeout, rather than waiting indefinitely for success or failure.
    */
   FSTTimerIDOnlineStateTimeout

--- a/Firestore/Source/Util/FSTDispatchQueue.h
+++ b/Firestore/Source/Util/FSTDispatchQueue.h
@@ -39,7 +39,7 @@ typedef NS_ENUM(NSInteger, FSTTimerID) {
   FSTTimerIDWriteStreamConnectionBackoff,
 
   /**
-   * A timer used in FSTOnlineStateTracker to transition from firebase::firestore::model::OnlineState Unknown to Offline
+   * A timer used in FSTOnlineStateTracker to transition from OnlineState Unknown to Offline
    * after a set timeout, rather than waiting indefinitely for success or failure.
    */
   FSTTimerIDOnlineStateTimeout

--- a/Firestore/core/src/firebase/firestore/model/types.h
+++ b/Firestore/core/src/firebase/firestore/model/types.h
@@ -42,6 +42,37 @@ using ListenSequenceNumber = int64_t;
  */
 using TargetId = int32_t;
 
+/**
+ * Describes the online state of the Firestore client. Note that this does not
+ * indicate whether or not the remote store is trying to connect or not. This is
+ * primarily used by the View / EventManager code to change their behavior while
+ * offline (e.g. get() calls shouldn't wait for data from the server and
+ * snapshot events should set metadata.isFromCache=true).
+ */
+enum class OnlineState {
+  /**
+   * The Firestore client is in an unknown online state. This means the client
+   * is either not actively trying to establish a connection or it is currently
+   * trying to establish a connection, but it has not succeeded or failed yet.
+   * Higher-level components should not operate in offline mode.
+   */
+  Unknown,
+
+  /**
+   * The client is connected and the connections are healthy. This state is
+   * reached after a successful connection and there has been at least one
+   * successful message received from the backends.
+   */
+  Online,
+
+  /**
+   * The client is either trying to establish a connection but failing, or it
+   * has been explicitly marked offline via a call to `disableNetwork`.
+   * Higher-level components should operate in offline mode.
+   */
+  Offline
+};
+
 }  // namespace model
 }  // namespace firestore
 }  // namespace firebase


### PR DESCRIPTION
This is a mostly mechanical change that gets rid of an Objective-C type.

This concludes the migration of C++-interesting types from `FSTTypes.h`.