### PR TITLE
Use new filesystem routines in FSTLevelDB

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -1672,10 +1672,14 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Firestore_IntegrationTests_iOS/Pods-Firestore_IntegrationTests_iOS-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/leveldb-library/leveldb.framework",
+				"${BUILT_PRODUCTS_DIR}/GoogleTest/GoogleTest.framework",
 				"${BUILT_PRODUCTS_DIR}/OCMock/OCMock.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/leveldb.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleTest.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMock.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		B6FB468E208F9BAB00554BA2 /* executor_libdispatch_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6FB4689208F9B9100554BA2 /* executor_libdispatch_test.mm */; };
 		B6FB468F208F9BAE00554BA2 /* executor_std_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = B6FB4687208F9B9100554BA2 /* executor_std_test.cc */; };
 		B6FB4690208F9BB300554BA2 /* executor_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = B6FB4688208F9B9100554BA2 /* executor_test.cc */; };
+		BEE0294A23AB993E5DE0E946 /* leveldb_util_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 332485C4DCC6BA0DBB5E31B7 /* leveldb_util_test.cc */; };
 		C1AA536F90A0A576CA2816EB /* Pods_Firestore_Example_iOS_Firestore_SwiftTests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB92EB03E3F92485023F64ED /* Pods_Firestore_Example_iOS_Firestore_SwiftTests_iOS.framework */; };
 		C482E724F4B10968417C3F78 /* Pods_Firestore_FuzzTests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B79CA87A1A01FC5329031C9B /* Pods_Firestore_FuzzTests_iOS.framework */; };
 		C80B10E79CDD7EF7843C321E /* type_traits_apple_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2A0CF41BA5AED6049B0BEB2C /* type_traits_apple_test.mm */; };
@@ -293,6 +294,7 @@
 		132E3BB3D5C42282B4ACFB20 /* FSTLevelDBBenchmarkTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FSTLevelDBBenchmarkTests.mm; sourceTree = "<group>"; };
 		2A0CF41BA5AED6049B0BEB2C /* type_traits_apple_test.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; path = type_traits_apple_test.mm; sourceTree = "<group>"; };
 		2B50B3A0DF77100EEE887891 /* Pods_Firestore_Tests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Firestore_Tests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		332485C4DCC6BA0DBB5E31B7 /* leveldb_util_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = leveldb_util_test.cc; sourceTree = "<group>"; };
 		358C3B5FE573B1D60A4F7592 /* strerror_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = strerror_test.cc; sourceTree = "<group>"; };
 		3B843E4A1F3930A400548890 /* remote_store_spec_test.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = remote_store_spec_test.json; sourceTree = "<group>"; };
 		3C81DE3772628FE297055662 /* Pods-Firestore_Example_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_iOS/Pods-Firestore_Example_iOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -712,6 +714,7 @@
 			isa = PBXGroup;
 			children = (
 				54995F6E205B6E12004EFFA0 /* leveldb_key_test.cc */,
+				332485C4DCC6BA0DBB5E31B7 /* leveldb_util_test.cc */,
 				F8043813A5D16963EC02B182 /* local_serializer_test.cc */,
 			);
 			path = local;
@@ -1884,6 +1887,7 @@
 				54A0353520A3D8CB003E0143 /* iterator_adaptors_test.cc in Sources */,
 				618BBEAE20B89AAC00B5BCE7 /* latlng.pb.cc in Sources */,
 				54995F6F205B6E12004EFFA0 /* leveldb_key_test.cc in Sources */,
+				BEE0294A23AB993E5DE0E946 /* leveldb_util_test.cc in Sources */,
 				020AFD89BB40E5175838BB76 /* local_serializer_test.cc in Sources */,
 				54C2294F1FECABAE007D065B /* log_test.cc in Sources */,
 				618BBEA720B89AAC00B5BCE7 /* maybe_document.pb.cc in Sources */,

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -21,10 +21,11 @@ target 'Firestore_Example_iOS' do
   target 'Firestore_Tests_iOS' do
     inherit! :search_paths
 
-    pod 'leveldb-library'
-    pod 'OCMock'
     pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
     pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
+
+    pod 'OCMock'
+    pod 'leveldb-library'
   end
 
   target 'Firestore_Benchmarks_iOS' do
@@ -36,7 +37,10 @@ target 'Firestore_Example_iOS' do
   target 'Firestore_IntegrationTests_iOS' do
     inherit! :search_paths
 
+    pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
+
     pod 'OCMock'
+    pod 'leveldb-library'
   end
 
   target 'Firestore_SwiftTests_iOS' do

--- a/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
@@ -49,6 +49,7 @@ using firebase::firestore::model::BatchId;
 using firebase::firestore::model::TargetId;
 using firebase::firestore::testutil::Key;
 using firebase::firestore::util::OrderedCode;
+using firebase::firestore::util::Path;
 using leveldb::DB;
 using leveldb::Options;
 using leveldb::Status;
@@ -65,9 +66,9 @@ using leveldb::Status;
   options.error_if_exists = true;
   options.create_if_missing = true;
 
-  NSString *dir = [FSTPersistenceTestHelpers levelDBDir];
+  Path dir = [FSTPersistenceTestHelpers levelDBDir];
   DB *db;
-  Status status = DB::Open(options, [dir UTF8String], &db);
+  Status status = DB::Open(options, dir.ToUtf8String(), &db);
   XCTAssert(status.ok(), @"Failed to create db: %s", status.ToString().c_str());
   _db.reset(db);
 }

--- a/Firestore/Example/Tests/Local/FSTLevelDBQueryCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBQueryCacheTests.mm
@@ -36,6 +36,7 @@ using firebase::firestore::model::ListenSequenceNumber;
 using firebase::firestore::model::ResourcePath;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
+using firebase::firestore::util::Path;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -66,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
   [self.persistence shutdown];
   self.persistence = nil;
 
-  NSString *dir = [FSTPersistenceTestHelpers levelDBDir];
+  Path dir = [FSTPersistenceTestHelpers levelDBDir];
 
   FSTLevelDB *db1 = [FSTPersistenceTestHelpers levelDBPersistenceWithDir:dir];
   FSTLevelDBQueryCache *queryCache = [db1 queryCache];

--- a/Firestore/Example/Tests/Local/FSTLevelDBTransactionTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBTransactionTests.mm
@@ -34,13 +34,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+using firebase::firestore::local::LevelDbMutationKey;
+using firebase::firestore::local::LevelDbTransaction;
+using firebase::firestore::util::Path;
 using leveldb::DB;
 using leveldb::Options;
 using leveldb::ReadOptions;
-using leveldb::WriteOptions;
 using leveldb::Status;
-using firebase::firestore::local::LevelDbMutationKey;
-using firebase::firestore::local::LevelDbTransaction;
+using leveldb::WriteOptions;
 
 @interface FSTLevelDBTransactionTests : XCTestCase
 @end
@@ -54,9 +55,9 @@ using firebase::firestore::local::LevelDbTransaction;
   options.error_if_exists = true;
   options.create_if_missing = true;
 
-  NSString *dir = [FSTPersistenceTestHelpers levelDBDir];
+  Path dir = [FSTPersistenceTestHelpers levelDBDir];
   DB *db;
-  Status status = DB::Open(options, [dir UTF8String], &db);
+  Status status = DB::Open(options, dir.ToUtf8String(), &db);
   XCTAssert(status.ok(), @"Failed to create db: %s", status.ToString().c_str());
   _db.reset(db);
 }

--- a/Firestore/Example/Tests/Local/FSTPersistenceTestHelpers.h
+++ b/Firestore/Example/Tests/Local/FSTPersistenceTestHelpers.h
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+#include "Firestore/core/src/firebase/firestore/util/path.h"
+
 @class FSTLevelDB;
 @class FSTMemoryPersistence;
 
@@ -27,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @return The directory where a leveldb instance can store data files. Any files that existed
  * there will be deleted first.
  */
-+ (NSString *)levelDBDir;
++ (firebase::firestore::util::Path)levelDBDir;
 
 /**
  * Creates and starts a new FSTLevelDB instance for testing, destroying any previous contents
@@ -44,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
  * present in the given directory. As a consequence, the resulting databse is not guaranteed
  * to be empty.
  */
-+ (FSTLevelDB *)levelDBPersistenceWithDir:(NSString *)dir;
++ (FSTLevelDB *)levelDBPersistenceWithDir:(firebase::firestore::util::Path)dir;
 
 /** Creates and starts a new FSTMemoryPersistence instance for testing. */
 + (FSTMemoryPersistence *)eagerGCMemoryPersistence;

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -34,7 +34,10 @@
 #include "Firestore/core/src/firebase/firestore/auth/empty_credentials_provider.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
 #include "Firestore/core/src/firebase/firestore/util/autoid.h"
+#include "Firestore/core/src/firebase/firestore/util/filesystem.h"
+#include "Firestore/core/src/firebase/firestore/util/path.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
+#include "Firestore/core/test/firebase/firestore/util/status_test_util.h"
 #include "absl/memory/memory.h"
 
 #import "Firestore/Source/API/FIRFirestore+Internal.h"
@@ -49,6 +52,8 @@ using firebase::firestore::auth::CredentialsProvider;
 using firebase::firestore::auth::EmptyCredentialsProvider;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::util::CreateAutoId;
+using firebase::firestore::util::Path;
+using firebase::firestore::util::Status;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -86,14 +91,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)clearPersistence {
-  NSString *levelDBDir = [FSTLevelDB documentsDirectory];
-  NSError *error;
-  if (![[NSFileManager defaultManager] removeItemAtPath:levelDBDir error:&error]) {
-    // file not found is okay.
-    XCTAssertTrue(
-        [error.domain isEqualToString:NSCocoaErrorDomain] && error.code == NSFileNoSuchFileError,
-        @"Failed to clear LevelDB Persistence: %@", error);
-  }
+  Path levelDBDir = [FSTLevelDB documentsDirectory];
+  Status status = util::RecursivelyDelete(levelDBDir);
+  ASSERT_OK(status);
 }
 
 - (FIRFirestore *)firestore {

--- a/Firestore/Source/Local/FSTLevelDB.h
+++ b/Firestore/Source/Local/FSTLevelDB.h
@@ -23,6 +23,8 @@
 #import "Firestore/Source/Local/FSTPersistence.h"
 #include "Firestore/core/src/firebase/firestore/core/database_info.h"
 #include "Firestore/core/src/firebase/firestore/local/leveldb_transaction.h"
+#include "Firestore/core/src/firebase/firestore/util/path.h"
+#include "Firestore/core/src/firebase/firestore/util/status.h"
 #include "leveldb/db.h"
 
 @class FSTLocalSerializer;
@@ -37,13 +39,13 @@ NS_ASSUME_NONNULL_BEGIN
  * Initializes the LevelDB in the given directory. Note that all expensive startup work including
  * opening any database files is deferred until -[FSTPersistence start] is called.
  */
-- (instancetype)initWithDirectory:(NSString *)directory
+- (instancetype)initWithDirectory:(firebase::firestore::util::Path)directory
                        serializer:(FSTLocalSerializer *)serializer NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)init __attribute__((unavailable("Use -initWithDirectory: instead.")));
+- (instancetype)init NS_UNAVAILABLE;
 
 /** Finds a suitable directory to serve as the root of all Firestore local storage. */
-+ (NSString *)documentsDirectory;
++ (firebase::firestore::util::Path)documentsDirectory;
 
 /**
  * Computes a unique storage directory for the given identifying components of local storage.
@@ -53,9 +55,9 @@ NS_ASSUME_NONNULL_BEGIN
  *     will be created. Usually just +[FSTLevelDB documentsDir].
  * @return A storage directory unique to the instance identified by databaseInfo.
  */
-+ (NSString *)storageDirectoryForDatabaseInfo:
-                  (const firebase::firestore::core::DatabaseInfo &)databaseInfo
-                           documentsDirectory:(NSString *)documentsDirectory;
++ (firebase::firestore::util::Path)
+    storageDirectoryForDatabaseInfo:(const firebase::firestore::core::DatabaseInfo &)databaseInfo
+                 documentsDirectory:(const firebase::firestore::util::Path &)documentsDirectory;
 
 /**
  * Starts LevelDB-backed persistent storage by opening the database files, creating the DB if it
@@ -64,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
  * The leveldb directory is created relative to the appropriate document storage directory for the
  * platform: NSDocumentDirectory on iOS or $HOME/.firestore on macOS.
  */
-- (BOOL)start:(NSError **)error;
+- (firebase::firestore::util::Status)start;
 
 // What follows is the Objective-C++ extension to the API.
 /**

--- a/Firestore/Source/Local/FSTLevelDB.h
+++ b/Firestore/Source/Local/FSTLevelDB.h
@@ -68,35 +68,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (firebase::firestore::util::Status)start;
 
-// What follows is the Objective-C++ extension to the API.
 /**
  * @return A standard set of read options
  */
 + (const leveldb::ReadOptions)standardReadOptions;
-
-/**
- * Creates an NSError based on the given status if the status is not ok.
- *
- * @param status The status of the preceding LevelDB operation.
- * @param description A printf-style format string describing what kind of failure happened if
- *     @a status is not ok. Additional parameters are substituted into the placeholders in this
- *     format string.
- *
- * @return An NSError with its localizedDescription composed from the description format and its
- *     localizedFailureReason composed from any error message embedded in @a status.
- */
-+ (nullable NSError *)errorWithStatus:(leveldb::Status)status
-                          description:(NSString *)description, ... NS_FORMAT_FUNCTION(2, 3);
-
-/**
- * Converts the given @a status to an NSString describing the status condition, suitable for
- * logging or inclusion in an NSError.
- *
- * @param status The status of the preceding LevelDB operation.
- *
- * @return An NSString describing the status (even if the status was ok).
- */
-+ (NSString *)descriptionOfStatus:(leveldb::Status)status;
 
 /** The native db pointer, allocated during start. */
 @property(nonatomic, assign, readonly) leveldb::DB *ptr;

--- a/Firestore/Source/Local/FSTLevelDB.mm
+++ b/Firestore/Source/Local/FSTLevelDB.mm
@@ -29,26 +29,33 @@
 #import "Firestore/Source/Local/FSTReferenceSet.h"
 #import "Firestore/Source/Remote/FSTSerializerBeta.h"
 
+#include "Firestore/core/include/firebase/firestore/firestore_errors.h"
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
 #include "Firestore/core/src/firebase/firestore/core/database_info.h"
 #include "Firestore/core/src/firebase/firestore/local/leveldb_key.h"
 #include "Firestore/core/src/firebase/firestore/local/leveldb_transaction.h"
+#include "Firestore/core/src/firebase/firestore/local/leveldb_util.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/resource_path.h"
+#include "Firestore/core/src/firebase/firestore/util/filesystem.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 #include "Firestore/core/src/firebase/firestore/util/ordered_code.h"
+#include "Firestore/core/src/firebase/firestore/util/statusor.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 #include "Firestore/core/src/firebase/firestore/util/string_util.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
 #include "leveldb/db.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 namespace util = firebase::firestore::util;
+using firebase::firestore::FirestoreErrorCode;
 using firebase::firestore::auth::User;
 using firebase::firestore::core::DatabaseInfo;
+using firebase::firestore::local::ConvertStatus;
 using firebase::firestore::local::LevelDbDocumentMutationKey;
 using firebase::firestore::local::LevelDbDocumentTargetKey;
 using firebase::firestore::local::LevelDbMutationKey;
@@ -58,13 +65,16 @@ using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::ListenSequenceNumber;
 using firebase::firestore::model::ResourcePath;
 using firebase::firestore::util::OrderedCode;
+using firebase::firestore::util::Path;
+using firebase::firestore::util::Status;
+using firebase::firestore::util::StatusOr;
+using firebase::firestore::util::StringFormat;
 using leveldb::DB;
 using leveldb::Options;
 using leveldb::ReadOptions;
-using leveldb::Status;
 using leveldb::WriteOptions;
 
-static NSString *const kReservedPathComponent = @"firestore";
+static const char *kReservedPathComponent = "firestore";
 
 /**
  * Provides LRU functionality for leveldb persistence.
@@ -227,13 +237,13 @@ static NSString *const kReservedPathComponent = @"firestore";
 
 @interface FSTLevelDB ()
 
-@property(nonatomic, copy) NSString *directory;
 @property(nonatomic, assign, getter=isStarted) BOOL started;
 @property(nonatomic, strong, readonly) FSTLocalSerializer *serializer;
 
 @end
 
 @implementation FSTLevelDB {
+  Path _directory;
   std::unique_ptr<LevelDbTransaction> _transaction;
   std::unique_ptr<leveldb::DB> _ptr;
   FSTTransactionRunner _transactionRunner;
@@ -268,10 +278,9 @@ static NSString *const kReservedPathComponent = @"firestore";
   return users;
 }
 
-- (instancetype)initWithDirectory:(NSString *)directory
-                       serializer:(FSTLocalSerializer *)serializer {
+- (instancetype)initWithDirectory:(Path)directory serializer:(FSTLocalSerializer *)serializer {
   if (self = [super init]) {
-    _directory = [directory copy];
+    _directory = std::move(directory);
     _serializer = serializer;
     _queryCache = [[FSTLevelDBQueryCache alloc] initWithDB:self serializer:self.serializer];
     _referenceDelegate = [[FSTLevelDBLRUDelegate alloc] initWithPersistence:self];
@@ -292,15 +301,15 @@ static NSString *const kReservedPathComponent = @"firestore";
   return _transactionRunner;
 }
 
-+ (NSString *)documentsDirectory {
++ (Path)documentsDirectory {
 #if TARGET_OS_IPHONE
   NSArray<NSString *> *directories =
       NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-  return [directories[0] stringByAppendingPathComponent:kReservedPathComponent];
+  return Path::FromNSString(directories[0]).AppendUtf8(kReservedPathComponent);
 
 #elif TARGET_OS_MAC
-  NSString *dotPrefixed = [@"." stringByAppendingString:kReservedPathComponent];
-  return [NSHomeDirectory() stringByAppendingPathComponent:dotPrefixed];
+  std::string dotPrefixed = absl::StrCat(".", kReservedPathComponent);
+  return Path::FromNSString(NSHomeDirectory()).AppendUtf8(dotPrefixed);
 
 #else
 #error "local storage on tvOS"
@@ -310,8 +319,8 @@ static NSString *const kReservedPathComponent = @"firestore";
 #endif
 }
 
-+ (NSString *)storageDirectoryForDatabaseInfo:(const DatabaseInfo &)databaseInfo
-                           documentsDirectory:(NSString *)documentsDirectory {
++ (Path)storageDirectoryForDatabaseInfo:(const DatabaseInfo &)databaseInfo
+                     documentsDirectory:(const Path &)documentsDirectory {
   // Use two different path formats:
   //
   //   * persistenceKey / projectID . databaseID / name
@@ -319,100 +328,72 @@ static NSString *const kReservedPathComponent = @"firestore";
   //
   // projectIDs are DNS-compatible names and cannot contain dots so there's
   // no danger of collisions.
-  NSString *directory = documentsDirectory;
-  directory =
-      [directory stringByAppendingPathComponent:util::WrapNSString(databaseInfo.persistence_key())];
-
-  NSString *segment = util::WrapNSString(databaseInfo.database_id().project_id());
+  std::string project_key = databaseInfo.database_id().project_id();
   if (!databaseInfo.database_id().IsDefaultDatabase()) {
-    segment = [NSString
-        stringWithFormat:@"%@.%s", segment, databaseInfo.database_id().database_id().c_str()];
+    absl::StrAppend(&project_key, ".", databaseInfo.database_id().database_id());
   }
-  directory = [directory stringByAppendingPathComponent:segment];
 
   // Reserve one additional path component to allow multiple physical databases
-  directory = [directory stringByAppendingPathComponent:@"main"];
-  return directory;
+  return Path::JoinUtf8(documentsDirectory, databaseInfo.persistence_key(), project_key, "main");
 }
 
 #pragma mark - Startup
 
-- (BOOL)start:(NSError **)error {
+- (Status)start {
   HARD_ASSERT(!self.isStarted, "FSTLevelDB double-started!");
   self.started = YES;
-  NSString *directory = self.directory;
-  if (![self ensureDirectory:directory error:error]) {
-    return NO;
-  }
 
-  DB *database = [self createDBWithDirectory:directory error:error];
-  if (!database) {
-    return NO;
+  Status status = [self ensureDirectory:_directory];
+  if (!status.ok()) return status;
+
+  StatusOr<std::unique_ptr<DB>> database = [self createDBWithDirectory:_directory];
+  if (!database.status().ok()) {
+    return database.status();
   }
-  _ptr.reset(database);
+  _ptr = std::move(database).ValueOrDie();
+
   [FSTLevelDBMigrations runMigrationsWithDatabase:_ptr.get()];
   LevelDbTransaction transaction(_ptr.get(), "Start LevelDB");
   _users = [FSTLevelDB collectUserSet:&transaction];
   transaction.Commit();
   [_queryCache start];
   [_referenceDelegate start];
-  return YES;
+  return Status::OK();
 }
 
 /** Creates the directory at @a directory and marks it as excluded from iCloud backup. */
-- (BOOL)ensureDirectory:(NSString *)directory error:(NSError **)error {
-  NSError *localError;
-  NSFileManager *files = [NSFileManager defaultManager];
-
-  BOOL success = [files createDirectoryAtPath:directory
-                  withIntermediateDirectories:YES
-                                   attributes:nil
-                                        error:&localError];
-  if (!success) {
-    *error =
-        [NSError errorWithDomain:FIRFirestoreErrorDomain
-                            code:FIRFirestoreErrorCodeInternal
-                        userInfo:@{
-                          NSLocalizedDescriptionKey : @"Failed to create persistence directory",
-                          NSUnderlyingErrorKey : localError
-                        }];
-    return NO;
+- (Status)ensureDirectory:(const Path &)directory {
+  Status status = util::RecursivelyCreateDir(directory);
+  if (!status.ok()) {
+    return Status{FirestoreErrorCode::Internal, "Failed to create persistence directory"}.CausedBy(
+        status);
   }
 
-  NSURL *dirURL = [NSURL fileURLWithPath:directory];
-  success = [dirURL setResourceValue:@YES forKey:NSURLIsExcludedFromBackupKey error:&localError];
-  if (!success) {
-    *error = [NSError errorWithDomain:FIRFirestoreErrorDomain
-                                 code:FIRFirestoreErrorCodeInternal
-                             userInfo:@{
-                               NSLocalizedDescriptionKey :
-                                   @"Failed mark persistence directory as excluded from backups",
-                               NSUnderlyingErrorKey : localError
-                             }];
-    return NO;
+  NSURL *dirURL = [NSURL fileURLWithPath:directory.ToNSString()];
+  NSError *localError = nil;
+  if (![dirURL setResourceValue:@YES forKey:NSURLIsExcludedFromBackupKey error:&localError]) {
+    return Status{FirestoreErrorCode::Internal,
+                  "Failed to mark persistence directory as excluded from backups"}
+        .CausedBy(Status::FromNSError(localError));
   }
 
-  return YES;
+  return Status::OK();
 }
 
 /** Opens the database within the given directory. */
-- (nullable DB *)createDBWithDirectory:(NSString *)directory error:(NSError **)error {
+- (StatusOr<std::unique_ptr<DB>>)createDBWithDirectory:(const Path &)directory {
   Options options;
   options.create_if_missing = true;
 
-  DB *database;
-  Status status = DB::Open(options, [directory UTF8String], &database);
+  DB *database = nullptr;
+  leveldb::Status status = DB::Open(options, directory.ToUtf8String(), &database);
   if (!status.ok()) {
-    if (error) {
-      NSString *name = [directory lastPathComponent];
-      *error =
-          [FSTLevelDB errorWithStatus:status
-                          description:@"Failed to create database %@ at path %@", name, directory];
-    }
-    return nullptr;
+    return Status{FirestoreErrorCode::Internal,
+                  StringFormat("Failed to open LevelDD database at %s", directory.ToUtf8String())}
+        .CausedBy(ConvertStatus(status));
   }
 
-  return database;
+  return std::unique_ptr<DB>(database);
 }
 
 - (LevelDbTransaction *)currentTransaction {

--- a/Firestore/Source/Local/FSTLevelDB.mm
+++ b/Firestore/Source/Local/FSTLevelDB.mm
@@ -443,34 +443,6 @@ static const char *kReservedPathComponent = "firestore";
   return [_referenceDelegate currentSequenceNumber];
 }
 
-#pragma mark - Error and Status
-
-+ (nullable NSError *)errorWithStatus:(Status)status description:(NSString *)description, ... {
-  if (status.ok()) {
-    return nil;
-  }
-
-  va_list args;
-  va_start(args, description);
-
-  NSString *message = [[NSString alloc] initWithFormat:description arguments:args];
-  NSString *reason = [self descriptionOfStatus:status];
-  NSError *result = [NSError errorWithDomain:FIRFirestoreErrorDomain
-                                        code:FIRFirestoreErrorCodeInternal
-                                    userInfo:@{
-                                      NSLocalizedDescriptionKey : message,
-                                      NSLocalizedFailureReasonErrorKey : reason
-                                    }];
-
-  va_end(args);
-
-  return result;
-}
-
-+ (NSString *)descriptionOfStatus:(Status)status {
-  return [NSString stringWithCString:status.ToString().c_str() encoding:NSUTF8StringEncoding];
-}
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Firestore/Source/Local/FSTMemoryPersistence.mm
+++ b/Firestore/Source/Local/FSTMemoryPersistence.mm
@@ -36,6 +36,7 @@ using firebase::firestore::auth::User;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeyHash;
 using firebase::firestore::model::ListenSequenceNumber;
+using firebase::firestore::util::Status;
 
 using MutationQueues = std::unordered_map<User, FSTMemoryMutationQueue *, HashUser>;
 
@@ -101,11 +102,11 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-- (BOOL)start:(NSError **)error {
+- (Status)start {
   // No durable state to read on startup.
   HARD_ASSERT(!self.isStarted, "FSTMemoryPersistence double-started!");
   self.started = YES;
-  return YES;
+  return Status::OK();
 }
 
 - (void)shutdown {

--- a/Firestore/Source/Local/FSTPersistence.h
+++ b/Firestore/Source/Local/FSTPersistence.h
@@ -20,13 +20,17 @@
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/types.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
+#include "Firestore/core/src/firebase/firestore/util/status.h"
 
 @class FSTDocumentKey;
+@class FSTQueryData;
+@class FSTReferenceSet;
 @protocol FSTMutationQueue;
 @protocol FSTQueryCache;
-@class FSTQueryData;
+@protocol FSTReferenceDelegate;
 @protocol FSTRemoteDocumentCache;
-@class FSTReferenceSet;
+
+struct FSTTransactionRunner;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -60,17 +64,14 @@ NS_ASSUME_NONNULL_BEGIN
  * FSTPersistence. The cost is that the FSTLocalStore needs to be slightly careful about the order
  * of its reads and writes in order to avoid relying on being able to read back uncommitted writes.
  */
-struct FSTTransactionRunner;
-@protocol FSTReferenceDelegate;
 @protocol FSTPersistence <NSObject>
 
 /**
  * Starts persistent storage, opening the database or similar.
  *
- * @param error An error object that will be populated if startup fails.
- * @return YES if persistent storage started successfully, NO otherwise.
+ * @return A Status object that will be populated with an error message if startup fails.
  */
-- (BOOL)start:(NSError **)error;
+- (firebase::firestore::util::Status)start;
 
 /** Releases any resources held during eager shutdown. */
 - (void)shutdown;

--- a/Firestore/core/src/firebase/firestore/local/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/local/CMakeLists.txt
@@ -20,6 +20,8 @@ if(HAVE_LEVELDB)
       leveldb_key.cc
       leveldb_transaction.h
       leveldb_transaction.cc
+      leveldb_util.h
+      leveldb_util.cc
     DEPENDS
       LevelDB::LevelDB
       absl_strings

--- a/Firestore/core/src/firebase/firestore/local/leveldb_util.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_util.cc
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/local/leveldb_util.h"
+
+#include "Firestore/core/include/firebase/firestore/firestore_errors.h"
+#include "absl/strings/str_cat.h"
+
+namespace firebase {
+namespace firestore {
+namespace local {
+
+namespace {
+
+FirestoreErrorCode ConvertStatusCode(const leveldb::Status& status) {
+  if (status.ok()) return FirestoreErrorCode::Ok;
+  if (status.IsNotFound()) return FirestoreErrorCode::NotFound;
+  if (status.IsCorruption()) return FirestoreErrorCode::DataLoss;
+  if (status.IsIOError()) return FirestoreErrorCode::Unavailable;
+  if (status.IsNotSupportedError()) return FirestoreErrorCode::Unimplemented;
+  if (status.IsInvalidArgument()) return FirestoreErrorCode::InvalidArgument;
+  return FirestoreErrorCode::Unknown;
+}
+
+}  // namespace
+
+util::Status ConvertStatus(const leveldb::Status& status) {
+  if (status.ok()) return util::Status::OK();
+
+  FirestoreErrorCode code = ConvertStatusCode(status);
+  return util::Status{code, absl::StrCat("LevelDB error: ", status.ToString())};
+}
+
+}  // namespace local
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/core/src/firebase/firestore/local/leveldb_util.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_util.h
@@ -19,8 +19,10 @@
 
 #include <string>
 
+#include "Firestore/core/src/firebase/firestore/util/status.h"
 #include "absl/strings/string_view.h"
 #include "leveldb/slice.h"
+#include "leveldb/status.h"
 
 namespace firebase {
 namespace firestore {
@@ -35,6 +37,9 @@ inline leveldb::Slice MakeSlice(absl::string_view view) {
 inline absl::string_view MakeStringView(leveldb::Slice slice) {
   return absl::string_view{slice.data(), slice.size()};
 }
+
+/** Converts the given LevelDB status to a Firestore status. */
+util::Status ConvertStatus(const leveldb::Status& status);
 
 }  // namespace local
 }  // namespace firestore

--- a/Firestore/core/test/firebase/firestore/local/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/local/CMakeLists.txt
@@ -17,6 +17,7 @@ if(HAVE_LEVELDB)
     firebase_firestore_local_persistence_leveldb_test
     SOURCES
       leveldb_key_test.cc
+      leveldb_util_test.cc
     DEPENDS
       firebase_firestore_local_persistence_leveldb
   )

--- a/Firestore/core/test/firebase/firestore/local/leveldb_util_test.cc
+++ b/Firestore/core/test/firebase/firestore/local/leveldb_util_test.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/local/leveldb_util.h"
+
+#include "gtest/gtest.h"
+
+namespace firebase {
+namespace firestore {
+namespace local {
+
+TEST(LevelDbUtilTest, ConvertsStatus) {
+  EXPECT_EQ(util::Status::OK(), ConvertStatus(leveldb::Status::OK()));
+
+  EXPECT_EQ(FirestoreErrorCode::NotFound,
+            ConvertStatus(leveldb::Status::NotFound("")).code());
+  EXPECT_EQ(FirestoreErrorCode::Unavailable,
+            ConvertStatus(leveldb::Status::IOError("")).code());
+}
+
+}  // namespace local
+}  // namespace firestore
+}  // namespace firebase


### PR DESCRIPTION
This is a stepping stone toward moving most of FSTLevelDB to C++. This PR focuses mostly on rearranging the callers of `-[FSTPersistence start]` to use `util::Status` and moves the guts to C++ where possible. 