### PR TITLE
Fix Travis fuzz testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -185,7 +185,8 @@ jobs:
       before_install:
         - ./scripts/if_cron.sh ./scripts/install_prereqs.sh
       script:
-        - ./scripts/if_cron.sh ./scripts/fuzzing_ci.sh
+        # The travis_wait is necessary because fuzzing runs for 40 minutes.
+        - travis_wait 45 ./scripts/if_cron.sh ./scripts/fuzzing_ci.sh
 
     # TODO(varconst): UBSan for CMake. UBSan failures are non-fatal by default,
     # need to make them fatal for the purposes of the test run.

--- a/scripts/fuzzing_ci.sh
+++ b/scripts/fuzzing_ci.sh
@@ -22,9 +22,6 @@
 
 # Total time allowed for fuzzing in seconds (40 minutes for now).
 readonly ALLOWED_TIME=2400
-# Maximum time allowed for a target. Set to 9.5 minutes because travis kills
-# jobs when they do not produce an output for 10 minutes.
-readonly MAX_TIME_PER_TARGET=570
 
 # An invalid target that is used to retrieve the list of available targets in
 # the returned error message.
@@ -99,12 +96,6 @@ for i in "${!all_fuzzing_targets[@]}"; do
   if [[ "${i}" -eq "${todays_primary_target}" ]]; then
     fuzzing_duration="${primary_target_time}"
   fi
-
-  # Do not fuzz more than the max allowed time.
-  if [[ "${fuzzing_duration}" -gt "${MAX_TIME_PER_TARGET}" ]]; then
-    fuzzing_duration="${MAX_TIME_PER_TARGET}"
-  fi
-
   fuzzing_target="${all_fuzzing_targets[${i}]}"
 
   echo "Running fuzzing target ${fuzzing_target} for ${fuzzing_duration} seconds..."

--- a/scripts/fuzzing_ci.sh
+++ b/scripts/fuzzing_ci.sh
@@ -22,6 +22,9 @@
 
 # Total time allowed for fuzzing in seconds (40 minutes for now).
 readonly ALLOWED_TIME=2400
+# Maximum time allowed for a target. Set to 9.5 minutes because travis kills
+# jobs when they do not produce an output for 10 minutes.
+readonly MAX_TIME_PER_TARGET=570
 
 # An invalid target that is used to retrieve the list of available targets in
 # the returned error message.
@@ -96,6 +99,12 @@ for i in "${!all_fuzzing_targets[@]}"; do
   if [[ "${i}" -eq "${todays_primary_target}" ]]; then
     fuzzing_duration="${primary_target_time}"
   fi
+
+  # Do not fuzz more than the max allowed time.
+  if [[ "${fuzzing_duration}" -gt "${MAX_TIME_PER_TARGET}" ]]; then
+    fuzzing_duration="${MAX_TIME_PER_TARGET}"
+  fi
+
   fuzzing_target="${all_fuzzing_targets[${i}]}"
 
   echo "Running fuzzing target ${fuzzing_target} for ${fuzzing_duration} seconds..."


### PR DESCRIPTION
* Travis kills jobs if they did not produce any output for 10 minutes, so we cannot run fuzzing for longer than 10 minutes.
* We can print out the fuzzing logs, but travis limits the logs to 4 mb (which we will definitely exceed is most fuzzing targets because we print assertion error messages).
* We limit the `FUZZING_DURATION` to 570 seconds (9.5 minutes) in the `/scripts/fuzzing_ci.sh` script.