### PR TITLE
Clean up warnings in leveldb_transaction.cc

### DIFF
--- a/Firestore/core/src/firebase/firestore/local/leveldb_transaction.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_transaction.h
@@ -154,14 +154,14 @@ class LevelDbTransaction {
    * Remove the database entry (if any) for "key".  It is not an error if "key"
    * did not exist in the database.
    */
-  void Delete(const absl::string_view& key);
+  void Delete(absl::string_view key);
 
 #if __OBJC__
   /**
    * Schedules the row identified by `key` to be set to the given protocol
    * buffer message when this transaction commits.
    */
-  void Put(const absl::string_view& key, GPBMessage* message) {
+  void Put(absl::string_view key, GPBMessage* message) {
     NSData* data = [message data];
     std::string key_string(key);
     mutations_[key_string] = std::string((const char*)data.bytes, data.length);
@@ -173,7 +173,7 @@ class LevelDbTransaction {
    * Schedules the row identified by `key` to be set to `value` when this
    * transaction commits.
    */
-  void Put(const absl::string_view& key, const absl::string_view& value);
+  void Put(absl::string_view key, absl::string_view value);
 
   /**
    * Sets the contents of `value` to the latest known value for the given key,
@@ -181,7 +181,7 @@ class LevelDbTransaction {
    * doesn't exist in leveldb, or it is scheduled for deletion in this
    * transaction, `Status::NotFound` is returned.
    */
-  leveldb::Status Get(const absl::string_view& key, std::string* value);
+  leveldb::Status Get(absl::string_view key, std::string* value);
 
   /**
    * Returns a new Iterator over the pending changes in this transaction, merged


### PR DESCRIPTION
  * absl::string_view should be passed by value
  * use absl::StrCat and friends for concatenation
  * use C++11 range-based for loops
  * avoid sign conversion