### PR TITLE
Make backoff account for already-elapsed time.

### DIFF
--- a/Firestore/Source/Remote/FSTExponentialBackoff.mm
+++ b/Firestore/Source/Remote/FSTExponentialBackoff.mm
@@ -18,6 +18,7 @@
 
 #include <random>
 
+#import "Firestore/Source/Util/FSTClasses.h"
 #import "Firestore/Source/Util/FSTDispatchQueue.h"
 
 #include "Firestore/core/src/firebase/firestore/util/log.h"
@@ -33,6 +34,7 @@ using firebase::firestore::util::SecureRandom;
 @property(nonatomic) NSTimeInterval initialDelay;
 @property(nonatomic) NSTimeInterval maxDelay;
 @property(nonatomic) NSTimeInterval currentBase;
+@property(nonatomic) NSTimeInterval lastAttemptTime;
 @property(nonatomic, strong, nullable) FSTDelayedCallback *timerCallback;
 @end
 
@@ -51,6 +53,7 @@ using firebase::firestore::util::SecureRandom;
     _initialDelay = initialDelay;
     _backoffFactor = backoffFactor;
     _maxDelay = maxDelay;
+    _lastAttemptTime = [[NSDate date] timeIntervalSince1970];
 
     [self reset];
   }
@@ -69,13 +72,32 @@ using firebase::firestore::util::SecureRandom;
   [self cancel];
 
   // First schedule the block using the current base (which may be 0 and should be honored as such).
-  NSTimeInterval delayWithJitter = _currentBase + [self jitterDelay];
+  NSTimeInterval desiredDelayWithJitter = _currentBase + [self jitterDelay];
+
+  // Guard against lastAttemptTime being in the future due to a clock change.
+  NSTimeInterval delaySoFar = MAX(0, [[NSDate date] timeIntervalSince1970] - self.lastAttemptTime);
+
+  // Guard against the backoff delay already being past.
+  NSTimeInterval remainingDelay = MAX(0, desiredDelayWithJitter - delaySoFar);
+
   if (_currentBase > 0) {
-    LOG_DEBUG("Backing off for %s seconds (base delay: %s seconds)", delayWithJitter, _currentBase);
+    LOG_DEBUG(
+        "Backing off for %s seconds ("
+        "base delay: %s seconds, "
+        "delay with jitter: %s seconds, "
+        "last attempt: %s seconds ago)",
+        remainingDelay, _currentBase, desiredDelayWithJitter, delaySoFar);
   }
 
-  self.timerCallback =
-      [self.dispatchQueue dispatchAfterDelay:delayWithJitter timerID:self.timerID block:block];
+  FSTWeakify(self);
+  self.timerCallback = [self.dispatchQueue dispatchAfterDelay:remainingDelay
+                                                      timerID:self.timerID
+                                                        block:^{
+                                                          FSTStrongify(self);
+                                                          self.lastAttemptTime =
+                                                              [[NSDate date] timeIntervalSince1970];
+                                                          block();
+                                                        }];
 
   // Apply backoff factor to determine next delay and ensure it is within bounds.
   _currentBase *= _backoffFactor;

--- a/Firestore/Source/Remote/FSTExponentialBackoff.mm
+++ b/Firestore/Source/Remote/FSTExponentialBackoff.mm
@@ -90,14 +90,16 @@ using firebase::firestore::util::SecureRandom;
   }
 
   FSTWeakify(self);
-  self.timerCallback = [self.dispatchQueue dispatchAfterDelay:remainingDelay
-                                                      timerID:self.timerID
-                                                        block:^{
-                                                          FSTStrongify(self);
-                                                          self.lastAttemptTime =
-                                                              [[NSDate date] timeIntervalSince1970];
-                                                          block();
-                                                        }];
+  self.timerCallback = [self.dispatchQueue
+      dispatchAfterDelay:remainingDelay
+                 timerID:self.timerID
+                   block:^{
+                     FSTStrongify(self);
+                     if (self) {
+                       self.lastAttemptTime = [[NSDate date] timeIntervalSince1970];
+                       block();
+                     }
+                   }];
 
   // Apply backoff factor to determine next delay and ensure it is within bounds.
   _currentBase *= _backoffFactor;


### PR DESCRIPTION
[Port of https://github.com/firebase/firebase-js-sdk/pull/1132]

Note: We actually have a not-yet-used c++ implementation of exponential backoff too.  I tried to update it, but it was hard. So I'm punting on that for the moment and will do that in a separate PR later.