### PR TITLE
Offline get() improvements.

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -3,6 +3,10 @@
   take effect until you did a full sign-out and sign-in. (#1499)
 - [changed] Improved how Firestore handles idle queries to reduce the cost of
   re-listening within 30 minutes.
+- [fixed] Fixed an issue where the first `get()` call made after being offline
+  could incorrectly return cached data without attempting to reach the backend.
+- [changed] Changed `get()` to only make 1 attempt to reach the backend before
+  returning cached data, potentially reducing delays while offline.
 
 # v0.13.1
 - [fixed] Fixed an issue where `get(source:.Cache)` could throw an

--- a/Firestore/Example/Tests/SpecTests/json/offline_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/offline_spec_test.json
@@ -37,15 +37,6 @@
             "message": "Simulated Backend Error"
           },
           "runBackoffTimer": true
-        }
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
         },
         "expect": [
           {
@@ -115,15 +106,6 @@
         "watchAck": [
           2
         ]
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
-        }
       },
       {
         "watchStreamClose": {
@@ -216,15 +198,6 @@
             "message": "Simulated Backend Error"
           },
           "runBackoffTimer": true
-        }
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
         },
         "expect": [
           {
@@ -281,15 +254,6 @@
               "resumeToken": ""
             }
           }
-        }
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
         }
       },
       {
@@ -420,15 +384,6 @@
               "resumeToken": "resume-token-1000"
             }
           }
-        }
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
         }
       },
       {
@@ -658,15 +613,6 @@
               "resumeToken": "resume-token-1001"
             }
           }
-        }
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
         }
       },
       {
@@ -955,15 +901,6 @@
               "resumeToken": ""
             }
           }
-        }
-      },
-      {
-        "watchStreamClose": {
-          "error": {
-            "code": 14,
-            "message": "Simulated Backend Error"
-          },
-          "runBackoffTimer": true
         }
       },
       {

--- a/Firestore/Example/Tests/SpecTests/json/remote_store_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/remote_store_spec_test.json
@@ -517,7 +517,19 @@
             "message": "Simulated Backend Error"
           },
           "runBackoffTimer": true
-        }
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ]
       },
       {
         "watchAck": [
@@ -618,6 +630,18 @@
           },
           "runBackoffTimer": false
         },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ],
         "stateExpect": {
           "activeTargets": {}
         }

--- a/Firestore/Source/Remote/FSTOnlineStateTracker.mm
+++ b/Firestore/Source/Remote/FSTOnlineStateTracker.mm
@@ -27,7 +27,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 // To deal with transient failures, we allow multiple stream attempts before giving up and
 // transitioning from OnlineState Unknown to Offline.
-static const int kMaxWatchStreamFailures = 2;
+// TODO(mikelehen): This used to be set to 2 as a mitigation for b/66228394. @jdimond thinks that
+// bug is sufficiently fixed so that we can set this back to 1. If that works okay, we could
+// potentially remove this logic entirely.
+static const int kMaxWatchStreamFailures = 1;
 
 // To deal with stream attempts that don't succeed or fail in a timely manner, we have a
 // timeout for OnlineState to reach Online or Offline. If the timeout is reached, we transition

--- a/Firestore/Source/Remote/FSTRemoteStore.mm
+++ b/Firestore/Source/Remote/FSTRemoteStore.mm
@@ -252,13 +252,20 @@ static const int kMaxPendingWrites = 10;
 - (void)stopListeningToTargetID:(TargetId)targetID {
   FSTBoxedTargetID *targetKey = @(targetID);
   FSTQueryData *queryData = self.listenTargets[targetKey];
-  HARD_ASSERT(queryData, "unlistenToTarget: target not currently watched: %s", targetKey);
+  HARD_ASSERT(queryData, "stopListeningToTargetID: target not currently watched: %s", targetKey);
 
   [self.listenTargets removeObjectForKey:targetKey];
   if ([self isNetworkEnabled] && [self.watchStream isOpen]) {
     [self sendUnwatchRequestForTargetID:targetKey];
-    if ([self.listenTargets count] == 0) {
+  }
+  if ([self.listenTargets count] == 0) {
+    if ([self isNetworkEnabled] && [self.watchStream isOpen]) {
       [self.watchStream markIdle];
+    } else {
+      // Revert to OnlineState::Unknown if the watch stream is not open and we have no listeners,
+      // since without any listens to send we cannot confirm if the stream is healthy and upgrade
+      // to OnlineState::Online.
+      [self.onlineStateTracker updateState:OnlineState::Unknown];
     }
   }
 }


### PR DESCRIPTION
[Port of https://github.com/firebase/firebase-js-sdk/pull/1133]

1. Changed MAX_WATCH_STREAM_FAILURES to 1 per conversation with @wilhuff and
   @jdimond.
2. Fixed a "race" where when a get() triggered a watch stream error, we'd
   restart the stream, then get() would remove its listener, and so we had no
   listener left once the watch stream was "opened". Without a listen to send
   we'd be stuck in Offline state (even though we should be Unknown whenever
   we have no listens to send), resulting in the next get() returning data
   from cache without even attempting to reach the backend.