### PR TITLE
Run fuzzing in the test stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -179,9 +179,9 @@ jobs:
         - ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
 
     # Run fuzz tests only on cron jobs.
-    - stage: fuzz_test
+    - stage: test
       env:
-        - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild
+        - PROJECT=Firestore PLATFORM=iOS METHOD=fuzz
       before_install:
         - ./scripts/if_cron.sh ./scripts/install_prereqs.sh
       script:

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -35,7 +35,7 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     bundle exec pod install --project-directory=GoogleUtilities/Example
     ;;
 
-  Firestore-*-xcodebuild)
+  Firestore-*-xcodebuild | Firestore-*-fuzz)
     gem install xcpretty
     bundle exec pod install --project-directory=Firestore/Example --repo-update
     ;;


### PR DESCRIPTION
Stages, even when cut off early with if_cron, still take about two
minutes to run. The fuzz_test stage was waiting for all tests to
complete before starting, which was artificially adding two minutes to
every build.

Use a different method to keep this visually distinct from the rest.