### PR TITLE
Delete unnecessary umbrella header import

### DIFF
--- a/Example/Auth/Tests/FIRAuthTests.m
+++ b/Example/Auth/Tests/FIRAuthTests.m
@@ -18,7 +18,6 @@
 
 #import <XCTest/XCTest.h>
 
-#import <FirebaseAuth/FirebaseAuth.h>
 #import <FirebaseAuthInterop/FIRAuthInterop.h>
 #import <FirebaseCore/FIRAppInternal.h>
 #import <FirebaseCore/FIRComponent.h>


### PR DESCRIPTION
The header is unnecessary and causes issues with internal build systems.