### PR TITLE
Update CMake build instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,8 @@ DerivedData
 *~
 
 # Bundler
-.bundle
+/.bundle
+/vendor
 
 Carthage
 # Cocoapods recommends against adding the Pods directory to your .gitignore. See
@@ -66,6 +67,11 @@ Firestore/core/src/firebase/firestore/util/config.h
 .downloads
 Debug
 Release
+Ninja
+
+# CLion
+/cmake-build-debug
+/cmake-build-release
 
 # Visual Studio
 /.vs

--- a/CMAKE.md
+++ b/CMAKE.md
@@ -33,14 +33,14 @@ brew install ninja      # optional
 gem install cocoapods   # may need sudo
 ```
 
-Note that Cocoapods is only needed for its ruby library, no Podfiles actually
+Note that CocoaPods is only needed for its ruby library, no Podfiles actually
 need to be set up and no `pod install` is required for the CMake build.
 
 
 ### Ubuntu
 
-If you're on a relatively recent Linux the system provided CMake may be
-sufficent.
+If you're on a relatively recent Linux, the system-provided CMake may be
+sufficient.
 
 ```
 sudo apt-get install build-essential
@@ -83,7 +83,7 @@ might take a while.
 
 The basic shape of the build is to:
   * create and enter the build tree
-  * run cmake to prepare the build tree
+  * run CMake to prepare the build tree
   * build sources
   * run tests
 
@@ -99,12 +99,12 @@ cmake --build . --target test
 
 ### Useful flags to pass to CMake
 
-Standard CMake flags
+Standard CMake flags:
 
   * `-G Ninja` -- build with Ninja instead of the default.
   * `-DCMAKE_BUILD_TYPE=Release` -- optimized build
 
-Dependencies
+Dependencies:
 
   * `-DOPENSSL_ROOT_DIR=path/to/openssl` -- where to find a pre-built OpenSSL,
     if you prefer that over the default BoringSSL. See `FindOpenSSL.cmake` in

--- a/CMAKE.md
+++ b/CMAKE.md
@@ -75,8 +75,8 @@ choco install yasm
 CMake builds out-of source, so create a separate build directory for the target
 you want to work on.
 
-The first time you build it will download all dependencies of the project so it
-might take a while.
+The first time you build, it will download all dependencies of the project so
+it might take a while.
 
 
 ### Basic build

--- a/CMAKE.md
+++ b/CMAKE.md
@@ -6,8 +6,18 @@ CMake.
 ## Dependencies
 
 You need:
-  * A C++ compiler
-  * `cmake`
+
+  * A C++11 compiler
+  * CMake 3.9
+  * Ninja (optional)
+  * CocoaPods (macOS-only)
+
+For dependencies:
+
+  * Go
+  * Perl
+  * Yasm (Windows-only)
+
 
 ### macOS
 
@@ -19,18 +29,32 @@ needed for other package managers.
 
 ```
 brew install cmake
+brew install ninja      # optional
+gem install cocoapods   # may need sudo
 ```
+
+Note that Cocoapods is only needed for its ruby library, no Podfiles actually
+need to be set up and no `pod install` is required for the CMake build.
+
 
 ### Ubuntu
 
-Ubuntu Trusty includes CMake 2.8.12 which should be sufficient. Newer versions
-are fine too.
+If you're on a relatively recent Linux the system provided CMake may be
+sufficent.
 
 ```
+sudo apt-get install build-essential
 sudo apt-get install cmake
+sudo apt-get install ninja-build  # optional
+
+sudo apt-get install golang
 ```
 
 ### Windows
+
+You need [Visual Studio](https://visualstudio.microsoft.com/vs/). The 2017
+Community edition building for x64 gets regular testing. We're working on
+support for Visual Studio 2015.
 
 An easy way to get development tools is via [Chocolatey](https://chocolatey.org/).
 
@@ -39,46 +63,68 @@ version.
 
 ```
 choco install cmake.portable
+choco install ninja  # optional
+
+choco install activeperl
+choco install golang
+choco install yasm
 ```
 
-## Setup
+## Building
 
 CMake builds out-of source, so create a separate build directory for the target
 you want to work on.
+
+The first time you build it will download all dependencies of the project so it
+might take a while.
+
+
+### Basic build
+
+The basic shape of the build is to:
+  * create and enter the build tree
+  * run cmake to prepare the build tree
+  * build sources
+  * run tests
+
+On most systems that looks like this:
 
 ```
 mkdir build
 cd build
 cmake ..
-```
-
-You only need to do this once.
-
-## Initial Build
-
-The first build will download, compile all dependencies of the project, and run
-an initial battery of tests.
-
-To perform the initial build, you can use CMake
-
-```
 cmake --build .
+cmake --build . --target test
 ```
 
-or use the underlying build system, e.g.
+### Useful flags to pass to CMake
+
+Standard CMake flags
+
+  * `-G Ninja` -- build with Ninja instead of the default.
+  * `-DCMAKE_BUILD_TYPE=Release` -- optimized build
+
+Dependencies
+
+  * `-DOPENSSL_ROOT_DIR=path/to/openssl` -- where to find a pre-built OpenSSL,
+    if you prefer that over the default BoringSSL. See `FindOpenSSL.cmake` in
+    your CMake distribution.
+  * `-DZLIB_ROOT=path/to/zlib` -- where to find a pre-built zlib, if you prefer
+    that. See `FindZLIB.cmake` in your CMake distribution.
+
+Firebase-specific goodies:
+
+  * `-DFIREBASE_DOWNLOAD_DIR:PATH=.downloads` -- put downloaded files outside
+    the build tree.
+  * `-DWITH_ASAN=ON` -- enable the address sanitizer (Clang, GCC)
+  * `-DWITH_TSAN=ON` -- enable the thread sanitizer (Clang, GCC)
+  * `-DWITH_UBSAN=ON` -- enable the undefined behavior sanitizer (Clang, GCC)
+
+For example:
 
 ```
-make -j all
-```
-
-## Working with a Project
-
-Once the initial build has completed, you can work with a specific subproject
-to make changes and test just that project in isolation.
-
-For example, to work with just Firestore,
-
-```
-cd build/Firestore
-make -j all test
+mkdir build
+cd build
+cmake -G Ninja -DFIREBASE_DOWNLOAD_DIR:PATH=.downloads ..
+ninja && ninja test
 ```

--- a/cmake/podspec_rules.cmake
+++ b/cmake/podspec_rules.cmake
@@ -27,9 +27,16 @@ macro(podspec_framework PODSPEC_FILE)
     get_filename_component(_properties_file ${PODSPEC_FILE} NAME_WE)
     set(_properties_file ${_properties_file}.cmake)
 
+    # Use bundler only if the current source tree has it set up. Otherwise fall
+    # back on the system ruby setup, which may have cocoapods installed.
+    set(pdf_runner ruby)
+    if(EXISTS ${FIREBASE_SOURCE_DIR}/.bundle)
+      set(pdf_runner bundle exec)
+    endif()
+
     execute_process(
       COMMAND
-        bundle exec
+        ${psf_runner}
         ${FIREBASE_SOURCE_DIR}/cmake/podspec_cmake.rb
         ${PODSPEC_FILE}
         ${CMAKE_CURRENT_BINARY_DIR}/${_properties_file}

--- a/cmake/podspec_rules.cmake
+++ b/cmake/podspec_rules.cmake
@@ -28,10 +28,10 @@ macro(podspec_framework PODSPEC_FILE)
     set(_properties_file ${_properties_file}.cmake)
 
     # Use bundler only if the current source tree has it set up. Otherwise fall
-    # back on the system ruby setup, which may have cocoapods installed.
-    set(pdf_runner ruby)
+    # back on the system ruby setup, which may have CocoaPods installed.
+    set(psf_runner ruby)
     if(EXISTS ${FIREBASE_SOURCE_DIR}/.bundle)
-      set(pdf_runner bundle exec)
+      set(psf_runner bundle exec)
     endif()
 
     execute_process(


### PR DESCRIPTION
Also, remove the need to use `bundler` when cocoapods is available system-wide.

/cc @a-maurice