### PR TITLE
Fix nullability analysis error in GULAppDelegateSwizzler

### DIFF
--- a/GoogleUtilities/AppDelegateSwizzler/Internal/GULAppDelegateSwizzler_Private.h
+++ b/GoogleUtilities/AppDelegateSwizzler/Internal/GULAppDelegateSwizzler_Private.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return the current UIApplication if in an app, or nil if in extension or if it doesn't exist.
  */
-+ (UIApplication *)sharedApplication;
++ (nullable UIApplication *)sharedApplication;
 
 /** ISA Swizzles the given appDelegate as the original app delegate would be.
  *


### PR DESCRIPTION
Mark the -sharedApplication method's return type as nullable.

Partial fix for https://github.com/firebase/firebase-ios-sdk/issues/1735