### PR TITLE
Fix analyze issues in Firestore

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 		C482E724F4B10968417C3F78 /* Pods_Firestore_FuzzTests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B79CA87A1A01FC5329031C9B /* Pods_Firestore_FuzzTests_iOS.framework */; };
 		C80B10E79CDD7EF7843C321E /* type_traits_apple_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2A0CF41BA5AED6049B0BEB2C /* type_traits_apple_test.mm */; };
 		C8D3CE2343E53223E6487F2C /* Pods_Firestore_Example_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5918805E993304321A05E82B /* Pods_Firestore_Example_iOS.framework */; };
+		CA989C0E6020C372A62B7062 /* testutil.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54A0352820A3B3BD003E0143 /* testutil.cc */; };
 		D5B25CBF07F65E885C9D68AB /* perf_spec_test.json in Resources */ = {isa = PBXBuildFile; fileRef = D5B2593BCB52957D62F1C9D3 /* perf_spec_test.json */; };
 		D94A1862B8FB778225DB54A1 /* filesystem_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = F51859B394D01C0C507282F1 /* filesystem_test.cc */; };
 		DD5976A45071455FF3FE74B8 /* string_win_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 79507DF8378D3C42F5B36268 /* string_win_test.cc */; };
@@ -225,6 +226,7 @@
 		DE2EF0861F3D0B6E003D0CDC /* FSTImmutableSortedDictionary+Testing.m in Sources */ = {isa = PBXBuildFile; fileRef = DE2EF0801F3D0B6E003D0CDC /* FSTImmutableSortedDictionary+Testing.m */; };
 		DE2EF0871F3D0B6E003D0CDC /* FSTImmutableSortedSet+Testing.m in Sources */ = {isa = PBXBuildFile; fileRef = DE2EF0821F3D0B6E003D0CDC /* FSTImmutableSortedSet+Testing.m */; };
 		DE2EF0881F3D0B6E003D0CDC /* FSTTreeSortedDictionaryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DE2EF0841F3D0B6E003D0CDC /* FSTTreeSortedDictionaryTests.m */; };
+		EBFC611B1BF195D0EC710AF4 /* app_testing.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5467FB07203E6A44009C9584 /* app_testing.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1870,6 +1872,7 @@
 				B6FB467D208E9D3C00554BA2 /* async_queue_test.cc in Sources */,
 				54740A581FC914F000713A1A /* autoid_test.cc in Sources */,
 				AB380D02201BC69F00D97691 /* bits_test.cc in Sources */,
+				B646EE6121224220001A1F18 /* buffered_writer_test.cc in Sources */,
 				618BBEA920B89AAC00B5BCE7 /* common.pb.cc in Sources */,
 				548DB929200D59F600E00ABC /* comparison_test.cc in Sources */,
 				ABC1D7DC2023A04B00BA84F0 /* credentials_provider_test.cc in Sources */,
@@ -1885,7 +1888,6 @@
 				B6FB4690208F9BB300554BA2 /* executor_test.cc in Sources */,
 				B6D1B68520E2AB1B00B35856 /* exponential_backoff_test.cc in Sources */,
 				549CCA5720A36E1F00BCEB75 /* field_mask_test.cc in Sources */,
-				B646EE6121224220001A1F18 /* buffered_writer_test.cc in Sources */,
 				B686F2AF2023DDEE0028D6BE /* field_path_test.cc in Sources */,
 				54A0352620A3AED0003E0143 /* field_transform_test.mm in Sources */,
 				AB356EF7200EA5EB0089B766 /* field_value_test.cc in Sources */,
@@ -1972,6 +1974,8 @@
 				5492E081202154EC00B64F25 /* FSTStreamTests.mm in Sources */,
 				5492E07F202154EC00B64F25 /* FSTTransactionTests.mm in Sources */,
 				5492E0442021457E00B64F25 /* XCTestCase+Await.mm in Sources */,
+				EBFC611B1BF195D0EC710AF4 /* app_testing.mm in Sources */,
+				CA989C0E6020C372A62B7062 /* testutil.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Firestore/Example/Tests/Integration/FSTTransactionTests.mm
+++ b/Firestore/Example/Tests/Integration/FSTTransactionTests.mm
@@ -468,7 +468,9 @@
       runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
         OSAtomicIncrement32(&count);
         [transaction setData:@{@"foo" : @"bar"} forDocument:doc];
-        *error = [NSError errorWithDomain:NSCocoaErrorDomain code:35 userInfo:@{}];
+        if (error) {
+          *error = [NSError errorWithDomain:NSCocoaErrorDomain code:35 userInfo:@{}];
+        }
         return nil;
       }
       completion:^(id _Nullable result, NSError *_Nullable error) {

--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -397,7 +397,7 @@ static NSString *Describe(NSData *data) {
   [self.driver enableNetwork];
 }
 
-- (void)doChangeUser:(id)UID {
+- (void)doChangeUser:(nullable id)UID {
   if ([UID isEqual:[NSNull null]]) {
     UID = nil;
   }

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -37,7 +37,9 @@
 #include "Firestore/core/src/firebase/firestore/util/filesystem.h"
 #include "Firestore/core/src/firebase/firestore/util/path.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
+#include "Firestore/core/test/firebase/firestore/testutil/app_testing.h"
 #include "Firestore/core/test/firebase/firestore/util/status_test_util.h"
+
 #include "absl/memory/memory.h"
 
 #import "Firestore/Source/API/FIRFirestore+Internal.h"
@@ -51,6 +53,7 @@ namespace util = firebase::firestore::util;
 using firebase::firestore::auth::CredentialsProvider;
 using firebase::firestore::auth::EmptyCredentialsProvider;
 using firebase::firestore::model::DatabaseId;
+using firebase::firestore::testutil::AppForUnitTesting;
 using firebase::firestore::util::CreateAutoId;
 using firebase::firestore::util::Path;
 using firebase::firestore::util::Status;
@@ -149,8 +152,8 @@ NS_ASSUME_NONNULL_BEGIN
       queueWith:dispatch_queue_create("com.google.firebase.firestore", DISPATCH_QUEUE_SERIAL)];
 
   FIRSetLoggerLevel(FIRLoggerLevelDebug);
-  // HACK: FIRFirestore expects a non-nil app, but for tests we cheat.
-  FIRApp *app = nil;
+
+  FIRApp *app = AppForUnitTesting();
   std::unique_ptr<CredentialsProvider> credentials_provider =
       absl::make_unique<firebase::firestore::auth::EmptyCredentialsProvider>();
 

--- a/Firestore/Source/API/FIRListenerRegistration.mm
+++ b/Firestore/Source/API/FIRListenerRegistration.mm
@@ -27,10 +27,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, readonly) FSTFirestoreClient *client;
 
 /** The async listener that is used to mute events synchronously. */
-@property(nonatomic, strong, readonly) FSTAsyncQueryListener *asyncListener;
+@property(nonatomic, strong, readonly, nullable) FSTAsyncQueryListener *asyncListener;
 
 /** The internal FSTQueryListener that can be used to unlisten the query. */
-@property(nonatomic, strong, readwrite) FSTQueryListener *internalListener;
+@property(nonatomic, strong, readwrite, nullable) FSTQueryListener *internalListener;
 
 @end
 

--- a/Firestore/Source/API/FSTUserDataConverter.mm
+++ b/Firestore/Source/API/FSTUserDataConverter.mm
@@ -699,7 +699,7 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
  *
  * @return The parsed value.
  */
-- (FSTFieldValue *)parseScalarValue:(nullable id)input context:(FSTParseContext *)context {
+- (nullable FSTFieldValue *)parseScalarValue:(nullable id)input context:(FSTParseContext *)context {
   if (!input || [input isMemberOfClass:[NSNull class]]) {
     return [FSTNullValue nullValue];
 

--- a/Firestore/Source/Core/FSTQuery.h
+++ b/Firestore/Source/Core/FSTQuery.h
@@ -255,13 +255,13 @@ typedef NS_ENUM(NSInteger, FSTRelationFilterOperator) {
 
 /** Returns the field of the first filter on the receiver that's an inequality, or nullptr if none.
  */
-- (const firebase::firestore::model::FieldPath *)inequalityFilterField;
+- (nullable const firebase::firestore::model::FieldPath *)inequalityFilterField;
 
 /** Returns YES if the query has an arrayContains filter already. */
 - (BOOL)hasArrayContainsFilter;
 
 /** Returns the first field in an order-by constraint, or nullptr if none. */
-- (const firebase::firestore::model::FieldPath *)firstSortOrderField;
+- (nullable const firebase::firestore::model::FieldPath *)firstSortOrderField;
 
 /** The base path of the query. */
 - (const firebase::firestore::model::ResourcePath &)path;

--- a/Firestore/Source/Core/FSTQuery.mm
+++ b/Firestore/Source/Core/FSTQuery.mm
@@ -745,7 +745,7 @@ NSString *FSTStringFromQueryRelationOperator(FSTRelationFilterOperator filterOpe
   };
 }
 
-- (const FieldPath *)inequalityFilterField {
+- (nullable const FieldPath *)inequalityFilterField {
   for (FSTFilter *filter in self.filters) {
     if ([filter isKindOfClass:[FSTRelationFilter class]] &&
         ((FSTRelationFilter *)filter).isInequality) {
@@ -765,7 +765,7 @@ NSString *FSTStringFromQueryRelationOperator(FSTRelationFilterOperator filterOpe
   return NO;
 }
 
-- (const FieldPath *)firstSortOrderField {
+- (nullable const FieldPath *)firstSortOrderField {
   if (self.explicitSortOrders.count > 0) {
     return &self.explicitSortOrders.firstObject.field;
   }

--- a/Firestore/core/test/firebase/firestore/testutil/app_testing.h
+++ b/Firestore/core/test/firebase/firestore/testutil/app_testing.h
@@ -22,6 +22,7 @@
 #if __OBJC__
 
 @class FIRApp;
+@class FIROptions;
 
 namespace firebase {
 namespace firestore {

--- a/Firestore/third_party/Immutable/FSTTreeSortedDictionary.m
+++ b/Firestore/third_party/Immutable/FSTTreeSortedDictionary.m
@@ -228,10 +228,10 @@ void FreeBase12List(Base12List *list) {
   free(list);
 }
 
-+ (id<FSTLLRBNode>)buildBalancedTree:(NSArray *)keys
-                          dictionary:(NSDictionary *)dictionary
-                  subArrayStartIndex:(NSUInteger)startIndex
-                              length:(NSUInteger)length {
++ (nullable id<FSTLLRBNode>)buildBalancedTree:(NSArray *)keys
+                                   dictionary:(NSDictionary *)dictionary
+                           subArrayStartIndex:(NSUInteger)startIndex
+                                       length:(NSUInteger)length {
   length = MIN(keys.count - startIndex, length);  // Bound length by the actual length of the array
   if (length == 0) {
     return nil;
@@ -262,8 +262,8 @@ void FreeBase12List(Base12List *list) {
 }
 
 + (nullable id<FSTLLRBNode>)rootFrom12List:(Base12List *)base12List
-                          keyList:(NSArray *)keyList
-                       dictionary:(NSDictionary *)dictionary {
+                                   keyList:(NSArray *)keyList
+                                dictionary:(NSDictionary *)dictionary {
   __block FSTLLRBValueNode *root = nil;
   __block FSTLLRBValueNode *node = nil;
   __block NSUInteger index = keyList.count;

--- a/scripts/sync_project.rb
+++ b/scripts/sync_project.rb
@@ -84,6 +84,7 @@ def sync_firestore()
       'Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm',
       'Firestore/Example/Tests/Util/XCTestCase+Await.mm',
       'Firestore/Example/Tests/en.lproj/InfoPlist.strings',
+      'Firestore/core/test/firebase/firestore/testutil/**',
     ]
   end
 


### PR DESCRIPTION
Fixes #1743.

Note that some analyze errors remain in abseil-cpp sources. I'll see if we can get these fixed upstream.