### PR TITLE
Fixes incorrect declaration of the init method

### DIFF
--- a/Firebase/Database/Public/FIRDatabase.h
+++ b/Firebase/Database/Public/FIRDatabase.h
@@ -35,7 +35,7 @@ NS_SWIFT_NAME(Database)
  *
  * @return An instancetype instance
 */
-+ (instancetype) init __attribute__((unavailable("use the database method instead")));
+- (instancetype) init __attribute__((unavailable("use the database method instead")));
 
 /**
  * Gets the instance of FIRDatabase for the default FIRApp.


### PR DESCRIPTION
Originally added by https://github.com/firebase/firebase-ios-sdk/pull/48 to prevent incorrect usage of `FIRDatabase`, but was incorrectly added as a class method rather than an instance method.