### PR TITLE
Fix crash in `ExecutorLibdispatch` when running unit tests

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_Tests_iOS.xcscheme
+++ b/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_Tests_iOS.xcscheme
@@ -26,6 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableASanStackUseAfterReturn = "YES"
+      enableThreadSanitizer = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference

--- a/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_Tests_iOS.xcscheme
+++ b/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_Tests_iOS.xcscheme
@@ -26,8 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      enableASanStackUseAfterReturn = "YES"
-      enableThreadSanitizer = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference

--- a/Firestore/core/src/firebase/firestore/util/executor_libdispatch.h
+++ b/Firestore/core/src/firebase/firestore/util/executor_libdispatch.h
@@ -56,6 +56,7 @@ class TimeSlot;
 class ExecutorLibdispatch : public Executor {
  public:
   explicit ExecutorLibdispatch(dispatch_queue_t dispatch_queue);
+  ~ExecutorLibdispatch();
 
   bool IsCurrentExecutor() const override;
   std::string CurrentExecutorName() const override;

--- a/Firestore/core/src/firebase/firestore/util/executor_libdispatch.mm
+++ b/Firestore/core/src/firebase/firestore/util/executor_libdispatch.mm
@@ -193,6 +193,16 @@ ExecutorLibdispatch::ExecutorLibdispatch(const dispatch_queue_t dispatch_queue)
     : dispatch_queue_{dispatch_queue} {
 }
 
+ExecutorLibdispatch::~ExecutorLibdispatch() {
+  RunSynchronized(this, [this] {
+    // Make sure any leftover timeslots don't try to access the executor after
+    // it's destroyed.
+    for (TimeSlot* leftover_slot : schedule_) {
+      leftover_slot->MarkDone();
+    }
+  });
+}
+
 bool ExecutorLibdispatch::IsCurrentExecutor() const {
   return GetCurrentQueueLabel() == GetQueueLabel(dispatch_queue());
 }


### PR DESCRIPTION
The original idea was for the destructor of `ExecutorLibdispatch` to turn any scheduled operations into no-ops (because whatever is scheduled in libdispatch cannot be truly canceled). This was removed in #1240; looking at the discussion, apparently the rationale was this _"classes that schedule delayed operations are already supposed to clear them on shutdown, so clearing them one more time is redundant and may mask logic errors"_. However, it looks like this situation can be easily triggered when running unit tests by just setting a breakpoint -- it will lead to a `TimeSlot`'s execution that tries to access the executor after it's already destroyed.