### PR TITLE
Offline get() improvements.

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -5,6 +5,11 @@
   take effect until you did a full sign-out and sign-in. (#1499)
 - [changed] Improved how Firestore handles idle queries to reduce the cost of
   re-listening within 30 minutes.
+- [fixed] Fixed an issue where the first `get()` call made after being offline
+  could incorrectly return cached data without attempting to reach the backend.
+- [changed] Changed `get()` to only make 1 attempt to reach the backend before
+  returning cached data, potentially reducing delays while offline. Previously
+  it would make 2 attempts, to work around a backend bug.
 
 # v0.13.1
 - [fixed] Fixed an issue where `get(source:.Cache)` could throw an

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Unreleased
+- [fixed] Fixed an issue where the first `get()` call made after being offline
+  could incorrectly return cached data without attempting to reach the backend.
+- [changed] Changed `get()` to only make 1 attempt to reach the backend before
+  returning cached data, potentially reducing delays while offline. Previously
+  it would make 2 attempts, to work around a backend bug.
 
 # v0.13.2
 - [fixed] Fixed an issue where changes to custom authentication claims did not
   take effect until you did a full sign-out and sign-in. (#1499)
 - [changed] Improved how Firestore handles idle queries to reduce the cost of
   re-listening within 30 minutes.
-- [fixed] Fixed an issue where the first `get()` call made after being offline
-  could incorrectly return cached data without attempting to reach the backend.
-- [changed] Changed `get()` to only make 1 attempt to reach the backend before
-  returning cached data, potentially reducing delays while offline. Previously
-  it would make 2 attempts, to work around a backend bug.
 
 # v0.13.1
 - [fixed] Fixed an issue where `get(source:.Cache)` could throw an

--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
@@ -1099,11 +1099,13 @@
   [self awaitExpectations];
 }
 
-- (void)testCantGetDocumentsWhileOffline {
+- (void)testCanGetDocumentsWhileOffline {
   FIRDocumentReference *doc = [self documentRef];
   FIRFirestore *firestore = doc.firestore;
   NSDictionary<NSString *, id> *data = @{@"a" : @"b"};
 
+  XCTestExpectation *failExpectation =
+      [self expectationWithDescription:@"offline read with no cached data"];
   XCTestExpectation *onlineExpectation = [self expectationWithDescription:@"online read"];
   XCTestExpectation *networkExpectation = [self expectationWithDescription:@"network online"];
 
@@ -1111,6 +1113,12 @@
 
   [firestore disableNetworkWithCompletion:^(NSError *error) {
     XCTAssertNil(error);
+
+    [doc getDocumentWithCompletion:^(FIRDocumentSnapshot *snapshot, NSError *error) {
+      XCTAssertNotNil(error);
+      [failExpectation fulfill];
+    }];
+
     [doc setData:data
         completion:^(NSError *_Nullable error) {
           XCTAssertNil(error);

--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -91,6 +91,7 @@ static NSString *Describe(NSData *data) {
 
 @implementation FSTSpecTests {
   BOOL _gcEnabled;
+  BOOL _networkEnabled;
 }
 
 - (id<FSTPersistence>)persistenceWithGCEnabled:(BOOL)GCEnabled {
@@ -390,10 +391,12 @@ static NSString *Describe(NSData *data) {
 }
 
 - (void)doDisableNetwork {
+  _networkEnabled = NO;
   [self.driver disableNetwork];
 }
 
 - (void)doEnableNetwork {
+  _networkEnabled = YES;
   [self.driver enableNetwork];
 }
 
@@ -642,6 +645,10 @@ static NSString *Describe(NSData *data) {
 }
 
 - (void)validateActiveTargets {
+  if (!_networkEnabled) {
+    return;
+  }
+
   // Create a copy so we can modify it in tests
   NSMutableDictionary<FSTBoxedTargetID *, FSTQueryData *> *actualTargets =
       [NSMutableDictionary dictionaryWithDictionary:self.driver.activeTargets];

--- a/Firestore/Example/Tests/SpecTests/json/offline_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/offline_spec_test.json
@@ -2,10 +2,7 @@
   "Empty queries are resolved if client goes offline": {
     "describeName": "Offline:",
     "itName": "Empty queries are resolved if client goes offline",
-    "tags": [
-      "no-android",
-      "no-ios"
-    ],
+    "tags": [],
     "config": {
       "useGarbageCollection": true,
       "numClients": 1
@@ -77,10 +74,7 @@
   "A successful message delays offline status": {
     "describeName": "Offline:",
     "itName": "A successful message delays offline status",
-    "tags": [
-      "no-android",
-      "no-ios"
-    ],
+    "tags": [],
     "config": {
       "useGarbageCollection": true,
       "numClients": 1
@@ -167,9 +161,7 @@
     "describeName": "Offline:",
     "itName": "Removing all listeners delays \"Offline\" status on next listen",
     "tags": [
-      "eager-gc",
-      "no-android",
-      "no-ios"
+      "eager-gc"
     ],
     "comment": "Marked as no-lru because when a listen is re-added, it gets a new target id rather than reusing one",
     "config": {
@@ -290,10 +282,7 @@
   "Queries revert to fromCache=true when offline.": {
     "describeName": "Offline:",
     "itName": "Queries revert to fromCache=true when offline.",
-    "tags": [
-      "no-android",
-      "no-ios"
-    ],
+    "tags": [],
     "config": {
       "useGarbageCollection": true,
       "numClients": 1
@@ -461,10 +450,7 @@
   "Queries with limbo documents handle going offline.": {
     "describeName": "Offline:",
     "itName": "Queries with limbo documents handle going offline.",
-    "tags": [
-      "no-android",
-      "no-ios"
-    ],
+    "tags": [],
     "config": {
       "useGarbageCollection": true,
       "numClients": 1
@@ -889,10 +875,7 @@
   "New queries return immediately with fromCache=true when offline due to stream failures.": {
     "describeName": "Offline:",
     "itName": "New queries return immediately with fromCache=true when offline due to stream failures.",
-    "tags": [
-      "no-android",
-      "no-ios"
-    ],
+    "tags": [],
     "config": {
       "useGarbageCollection": true,
       "numClients": 1
@@ -1072,6 +1055,118 @@
             "hasPendingWrites": false
           }
         ]
+      }
+    ]
+  },
+  "Queries return from cache when network disabled": {
+    "describeName": "Offline:",
+    "itName": "Queries return from cache when network disabled",
+    "tags": [],
+    "config": {
+      "useGarbageCollection": true,
+      "numClients": 1
+    },
+    "steps": [
+      {
+        "enableNetwork": false,
+        "stateExpect": {
+          "activeTargets": {},
+          "limboDocs": []
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {}
+        }
+      },
+      {
+        "userListen": [
+          4,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {
+            "4": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          4,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {}
+        }
       }
     ]
   }

--- a/Firestore/Example/Tests/SpecTests/json/offline_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/offline_spec_test.json
@@ -1061,7 +1061,7 @@
   "Queries return from cache when network disabled": {
     "describeName": "Offline:",
     "itName": "Queries return from cache when network disabled",
-    "tags": [],
+    "tags": ["eager-gc"],
     "config": {
       "useGarbageCollection": true,
       "numClients": 1

--- a/Firestore/Example/Tests/SpecTests/json/remote_store_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/remote_store_spec_test.json
@@ -482,10 +482,7 @@
   "Cleans up watch state correctly": {
     "describeName": "Remote store:",
     "itName": "Cleans up watch state correctly",
-    "tags": [
-      "no-android",
-      "no-ios"
-    ],
+    "tags": [],
     "config": {
       "useGarbageCollection": false,
       "numClients": 1

--- a/Firestore/Source/Remote/FSTOnlineStateTracker.mm
+++ b/Firestore/Source/Remote/FSTOnlineStateTracker.mm
@@ -27,7 +27,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 // To deal with transient failures, we allow multiple stream attempts before giving up and
 // transitioning from OnlineState Unknown to Offline.
-static const int kMaxWatchStreamFailures = 2;
+// TODO(mikelehen): This used to be set to 2 as a mitigation for b/66228394. @jdimond thinks that
+// bug is sufficiently fixed so that we can set this back to 1. If that works okay, we could
+// potentially remove this logic entirely.
+static const int kMaxWatchStreamFailures = 1;
 
 // To deal with stream attempts that don't succeed or fail in a timely manner, we have a
 // timeout for OnlineState to reach Online or Offline. If the timeout is reached, we transition

--- a/Firestore/Source/Remote/FSTRemoteStore.mm
+++ b/Firestore/Source/Remote/FSTRemoteStore.mm
@@ -259,13 +259,15 @@ static const int kMaxPendingWrites = 10;
     [self sendUnwatchRequestForTargetID:targetKey];
   }
   if ([self.listenTargets count] == 0) {
-    if ([self isNetworkEnabled] && [self.watchStream isOpen]) {
-      [self.watchStream markIdle];
-    } else if (self.isNetworkEnabled) {
-      // Revert to OnlineState::Unknown if the watch stream is not open and we have no listeners,
-      // since without any listens to send we cannot confirm if the stream is healthy and upgrade
-      // to OnlineState::Online.
-      [self.onlineStateTracker updateState:OnlineState::Unknown];
+    if ([self isNetworkEnabled]) {
+      if ([self.watchStream isOpen]) {
+        [self.watchStream markIdle];
+      } else {
+        // Revert to OnlineState::Unknown if the watch stream is not open and we have no listeners,
+        // since without any listens to send we cannot confirm if the stream is healthy and upgrade
+        // to OnlineState::Online.
+        [self.onlineStateTracker updateState:OnlineState::Unknown];
+      }
     }
   }
 }

--- a/Firestore/Source/Remote/FSTRemoteStore.mm
+++ b/Firestore/Source/Remote/FSTRemoteStore.mm
@@ -252,13 +252,20 @@ static const int kMaxPendingWrites = 10;
 - (void)stopListeningToTargetID:(TargetId)targetID {
   FSTBoxedTargetID *targetKey = @(targetID);
   FSTQueryData *queryData = self.listenTargets[targetKey];
-  HARD_ASSERT(queryData, "unlistenToTarget: target not currently watched: %s", targetKey);
+  HARD_ASSERT(queryData, "stopListeningToTargetID: target not currently watched: %s", targetKey);
 
   [self.listenTargets removeObjectForKey:targetKey];
   if ([self isNetworkEnabled] && [self.watchStream isOpen]) {
     [self sendUnwatchRequestForTargetID:targetKey];
-    if ([self.listenTargets count] == 0) {
+  }
+  if ([self.listenTargets count] == 0) {
+    if ([self isNetworkEnabled] && [self.watchStream isOpen]) {
       [self.watchStream markIdle];
+    } else if (self.isNetworkEnabled) {
+      // Revert to OnlineState::Unknown if the watch stream is not open and we have no listeners,
+      // since without any listens to send we cannot confirm if the stream is healthy and upgrade
+      // to OnlineState::Online.
+      [self.onlineStateTracker updateState:OnlineState::Unknown];
     }
   }
 }


### PR DESCRIPTION
[Port of https://github.com/firebase/firebase-js-sdk/pull/1197]

1. Changed MAX_WATCH_STREAM_FAILURES to 1 per conversation with @wilhuff and
   @jdimond.
2. Fixed a "race" where when a get() triggered a watch stream error, we'd
   restart the stream, then get() would remove its listener, and so we had no
   listener left once the watch stream was "opened". Without a listen to send
   we'd be stuck in Offline state (even though we should be Unknown whenever
   we have no listens to send), resulting in the next get() returning data
   from cache without even attempting to reach the backend.