### PR TITLE
ifdef out flaky Database Integration Tests

### DIFF
--- a/Example/Database/Tests/Integration/FData.m
+++ b/Example/Database/Tests/Integration/FData.m
@@ -742,6 +742,7 @@
     }];
 }
 
+#ifdef FLAKY_TEST
 - (void) testSettingANodeWithChildrenToAPrimitiveAndBack {
     // Can't tolerate stale data; so disable persistence.
     FTupleFirebase* tuple = [FTestHelpers getRandomNodePairWithoutPersistence];
@@ -827,6 +828,7 @@
 
     XCTAssertTrue(done, @"Properly finished");
 }
+#endif
 
 - (void) testWriteLeafRemoveLeafAddChildToRemovedNode {
     FTupleFirebase* refs = [FTestHelpers getRandomNodePair];
@@ -2188,6 +2190,7 @@
     XCTAssertTrue([result isEqualToNumber:toSet], @"Should get back same number");
 }
 
+#ifdef FLAKY_TEST
 - (void) testParentDeleteShadowsChildListeners {
     FTupleFirebase* refs = [FTestHelpers getRandomNodePair];
     FIRDatabaseReference * writer = refs.one;
@@ -2213,6 +2216,7 @@
     WAIT_FOR(done);
     [deleter removeAllObservers];
 }
+#endif
 
 - (void) testParentDeleteShadowsChildListenersWithNonDefaultQuery {
     FTupleFirebase* refs = [FTestHelpers getRandomNodePair];

--- a/Example/Database/Tests/Integration/FIRDatabaseQueryTests.m
+++ b/Example/Database/Tests/Integration/FIRDatabaseQueryTests.m
@@ -2465,7 +2465,7 @@
     WAIT_FOR(count == 3);
 }
 
-
+#ifdef FLAKY_TEST
 - (void) testListenForChildChangedWithLimitEnsureEventsFireProperly {
     FTupleFirebase* refs = [FTestHelpers getRandomNodePair];
     FIRDatabaseReference * writer = refs.one;
@@ -2502,6 +2502,7 @@
 
     WAIT_FOR(count == 3);
 }
+#endif
 
 - (void) testListenForChildRemovedWithLimitEnsureEventsFireProperly {
     FTupleFirebase* refs = [FTestHelpers getRandomNodePair];


### PR DESCRIPTION
Travis is failing repeatedly today on the Database Integration tests. This failure also came up a few weeks ago
```
Failing tests:
	-[FData testParentDeleteShadowsChildListenersWithNonDefaultQuery]
** TEST FAILED **
```
I saw this running locally:
```
Test Case '-[FData testParentDeleteShadowsChildListenersWithNonDefaultQuery]' started.

2018-09-11 17:20:49.288167-0700 Database_Example_iOS[47616:5115899] *** Assertion failure in -[XCTestCase(Failures) _enqueueFailureWithDescription:inFile:atLine:expected:breakWhenDequeued:](), /Library/Caches/com.apple.xbs/Sources/XCTest_Sim/XCTest-14100/Sources/XCTestFramework/Core/XCTestCase+Failures.m:60

2018-09-11 17:20:49.288482-0700 Database_Example_iOS[47616:5115899] *** Assertion failure in -[XCTestCase(Failures) _enqueueFailureWithDescription:inFile:atLine:expected:breakWhenDequeued:](), /Library/Caches/com.apple.xbs/Sources/XCTest_Sim/XCTest-14100/Sources/XCTestFramework/Core/XCTestCase+Failures.m:60

2018-09-11 17:20:49.291478-0700 Database_Example_iOS[47616:5115899] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Unable to report test assertion failure '((called) is false) failed: throwing "Unable to report test assertion failure '((called) is false) failed - Should only be hit once' from /Users/paulbeusterien/pure2/firebase-ios-sdk/Example/Database/Tests/Integration/FData.m:2202 because it was raised inside test case -[FData testParentDeleteShadowsChildListeners] which has no associated XCTestRun object. This may happen when test cases are constructed and invoked independently of standard XCTest infrastructure, or when the test has already finished." - Should only be hit once' from /Users/paulbeusterien/pure2/firebase-ios-sdk/Example/Database/Tests/Integration/FData.m:2202 because it was raised inside test case -[FData testParentDeleteShadowsChildListeners] which has no associated XCTestRun object. This may happen when test cases are constructed and invoked independently of standard XCTest infrastructure, or when the test has already finished.'
```
I also ifdef'd out two other tests that failed sporadically when running locally.

If travis passes and this pushes, I'll open an issue to fix these tests.
