### PR TITLE
Allow GoogleServices-Info.plist to configure Firestore integration tests

### DIFF
--- a/Firestore/Example/App/GoogleService-Info.plist
+++ b/Firestore/Example/App/GoogleService-Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>correct_api_key</string>
+	<key>TRACKING_ID</key>
+	<string>correct_tracking_id</string>
+	<key>CLIENT_ID</key>
+	<string>correct_client_id</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>correct_reversed_client_id</string>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:123:ios:123abc</string>
+	<key>GCM_SENDER_ID</key>
+	<string>correct_gcm_sender_id</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.google.FirebaseSDKTests</string>
+	<key>PROJECT_ID</key>
+	<string>abc-xyz-123</string>
+	<key>DATABASE_URL</key>
+	<string>https://abc-xyz-123.firebaseio.com</string>
+	<key>STORAGE_BUCKET</key>
+	<string>project-id-123.storage.firebase.com</string>
+</dict>
+</plist>

--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		54A0353020A3B3D8003E0143 /* statusor_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54A0352D20A3B3D7003E0143 /* statusor_test.cc */; };
 		54A0353520A3D8CB003E0143 /* iterator_adaptors_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54A0353420A3D8CB003E0143 /* iterator_adaptors_test.cc */; };
 		54C2294F1FECABAE007D065B /* log_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54C2294E1FECABAE007D065B /* log_test.cc */; };
+		54D400D42148BACE001D2BCC /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 54D400D32148BACE001D2BCC /* GoogleService-Info.plist */; };
 		54DA12A61F315EE100DD57A1 /* collection_spec_test.json in Resources */ = {isa = PBXBuildFile; fileRef = 54DA129C1F315EE100DD57A1 /* collection_spec_test.json */; };
 		54DA12A71F315EE100DD57A1 /* existence_filter_spec_test.json in Resources */ = {isa = PBXBuildFile; fileRef = 54DA129D1F315EE100DD57A1 /* existence_filter_spec_test.json */; };
 		54DA12A81F315EE100DD57A1 /* limbo_spec_test.json in Resources */ = {isa = PBXBuildFile; fileRef = 54DA129E1F315EE100DD57A1 /* limbo_spec_test.json */; };
@@ -406,6 +407,7 @@
 		54C2294E1FECABAE007D065B /* log_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = log_test.cc; sourceTree = "<group>"; };
 		54C9EDF12040E16300A969CD /* Firestore_SwiftTests_iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Firestore_SwiftTests_iOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		54C9EDF52040E16300A969CD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		54D400D32148BACE001D2BCC /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "App/GoogleService-Info.plist"; sourceTree = SOURCE_ROOT; };
 		54DA129C1F315EE100DD57A1 /* collection_spec_test.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = collection_spec_test.json; sourceTree = "<group>"; };
 		54DA129D1F315EE100DD57A1 /* existence_filter_spec_test.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = existence_filter_spec_test.json; sourceTree = "<group>"; };
 		54DA129E1F315EE100DD57A1 /* limbo_spec_test.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = limbo_spec_test.json; sourceTree = "<group>"; };
@@ -620,6 +622,7 @@
 			isa = PBXGroup;
 			children = (
 				6003F593195388D20070C39A /* iOS */,
+				54D400D32148BACE001D2BCC /* GoogleService-Info.plist */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -1441,6 +1444,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				54D400D42148BACE001D2BCC /* GoogleService-Info.plist in Resources */,
 				6003F5A9195388D20070C39A /* Images.xcassets in Resources */,
 				873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */,
 				71719F9F1E33DC2100824A3D /* LaunchScreen.storyboard in Resources */,

--- a/Firestore/Example/Tests/Integration/FSTDatastoreTests.mm
+++ b/Firestore/Example/Tests/Integration/FSTDatastoreTests.mm
@@ -159,11 +159,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setUp {
   [super setUp];
 
-  NSString *projectID = [[NSProcessInfo processInfo] environment][@"PROJECT_ID"];
-  if (!projectID) {
-    projectID = @"test-db";
-  }
-
+  NSString *projectID = [FSTIntegrationTestCase projectID];
   FIRFirestoreSettings *settings = [FSTIntegrationTestCase settings];
   if (!settings.sslEnabled) {
     [GRPCCall useInsecureConnectionsForHost:settings.host];

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -17,6 +17,7 @@
 #import "Firestore/Example/Tests/Util/FSTIntegrationTestCase.h"
 
 #import <FirebaseCore/FIRLogger.h>
+#import <FirebaseCore/FIROptions.h>
 #import <FirebaseFirestore/FIRCollectionReference.h>
 #import <FirebaseFirestore/FIRDocumentChange.h>
 #import <FirebaseFirestore/FIRDocumentReference.h>
@@ -64,6 +65,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong) FSTDispatchQueue *workerDispatchQueue;
 @end
 
+static NSString *defaultProjectId;
+static FIRFirestoreSettings *defaultSettings;
+
 @implementation FSTIntegrationTestCase {
   NSMutableArray<FIRFirestore *> *_firestores;
 }
@@ -103,46 +107,68 @@ NS_ASSUME_NONNULL_BEGIN
   return [self firestoreWithProjectID:[FSTIntegrationTestCase projectID]];
 }
 
-+ (NSString *)projectID {
++ (void)setUpDefaults {
+  defaultSettings = [[FIRFirestoreSettings alloc] init];
+  defaultSettings.persistenceEnabled = YES;
+  defaultSettings.timestampsInSnapshotsEnabled = YES;
+
+  // Check for a MobileHarness configuration, running against nightly or prod, which have live
+  // SSL certs.
   NSString *project = [[NSProcessInfo processInfo] environment][@"PROJECT_ID"];
-  if (!project) {
-    project = @"test-db";
+  NSString *host = [[NSProcessInfo processInfo] environment][@"DATASTORE_HOST"];
+  if (project && host) {
+    defaultProjectId = project;
+    defaultSettings.host = host;
+    return;
   }
-  return project;
+
+  // Check for configuration of a prod project via GoogleServices-Info.plist.
+  FIROptions *options = [FIROptions defaultOptions];
+  if (options && ![options.projectID isEqualToString:@"abc-xyz-123"]) {
+    defaultProjectId = options.projectID;
+    if (host) {
+      // Allow access to nightly or other hosts via this mechanism too.
+      defaultSettings.host = host;
+    }
+    return;
+  }
+
+  // Otherwise fall back on assuming Hexa on localhost.
+  defaultProjectId = @"test-db";
+  defaultSettings.host = @"localhost:8081";
+
+  // Hexa uses a self-signed cert: the first bundle location is used by bazel builds. The second is
+  // used for github clones.
+  NSString *certsPath =
+  [[NSBundle mainBundle] pathForResource:@"PlugIns/IntegrationTests.xctest/CAcert"
+                                  ofType:@"pem"];
+  if (certsPath == nil) {
+    certsPath = [[NSBundle bundleForClass:[self class]] pathForResource:@"CAcert" ofType:@"pem"];
+  }
+  unsigned long long fileSize =
+  [[[NSFileManager defaultManager] attributesOfItemAtPath:certsPath error:nil] fileSize];
+
+  if (fileSize == 0) {
+    NSLog(
+          @"The cert is not properly configured. Make sure setup_integration_tests.py "
+          "has been run.");
+  }
+  [GRPCCall useTestCertsPath:certsPath testName:@"test_cert_2" forHost:host];
+}
+
++ (NSString *)projectID {
+  if (!defaultProjectId) {
+    [self setUpDefaults];
+  }
+  return defaultProjectId;
 }
 
 + (FIRFirestoreSettings *)settings {
-  FIRFirestoreSettings *settings = [[FIRFirestoreSettings alloc] init];
-  NSString *host = [[NSProcessInfo processInfo] environment][@"DATASTORE_HOST"];
-  settings.sslEnabled = YES;
-  if (!host) {
-    // If host is nil, there is no GoogleService-Info.plist. Check if a hexa integration test
-    // configuration is configured. The first bundle location is used by bazel builds. The
-    // second is used for github clones.
-    host = @"localhost:8081";
-    settings.sslEnabled = YES;
-    NSString *certsPath =
-        [[NSBundle mainBundle] pathForResource:@"PlugIns/IntegrationTests.xctest/CAcert"
-                                        ofType:@"pem"];
-    if (certsPath == nil) {
-      certsPath = [[NSBundle bundleForClass:[self class]] pathForResource:@"CAcert" ofType:@"pem"];
-    }
-    unsigned long long fileSize =
-        [[[NSFileManager defaultManager] attributesOfItemAtPath:certsPath error:nil] fileSize];
-
-    if (fileSize == 0) {
-      NSLog(
-          @"The cert is not properly configured. Make sure setup_integration_tests.py "
-           "has been run.");
-    }
-    [GRPCCall useTestCertsPath:certsPath testName:@"test_cert_2" forHost:host];
+  if (!defaultSettings) {
+    [self setUpDefaults];
   }
-  settings.host = host;
-  settings.persistenceEnabled = YES;
-  settings.timestampsInSnapshotsEnabled = YES;
-  NSLog(@"Configured integration test for %@ with SSL: %@", settings.host,
-        settings.sslEnabled ? @"YES" : @"NO");
-  return settings;
+
+  return defaultSettings;
 }
 
 - (FIRFirestore *)firestoreWithProjectID:(NSString *)projectID {

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -155,7 +155,7 @@ static FIRFirestoreSettings *defaultSettings;
          "Alternatively, if you're a Googler with a Hexa preproduction environment, run "
          "setup_integration_tests.py to properly configure testing SSL certificates.");
   }
-  [GRPCCall useTestCertsPath:certsPath testName:@"test_cert_2" forHost:host];
+  [GRPCCall useTestCertsPath:certsPath testName:@"test_cert_2" forHost:defaultSettings.host];
 }
 
 + (NSString *)projectID {

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -140,18 +140,18 @@ static FIRFirestoreSettings *defaultSettings;
   // Hexa uses a self-signed cert: the first bundle location is used by bazel builds. The second is
   // used for github clones.
   NSString *certsPath =
-  [[NSBundle mainBundle] pathForResource:@"PlugIns/IntegrationTests.xctest/CAcert"
-                                  ofType:@"pem"];
+      [[NSBundle mainBundle] pathForResource:@"PlugIns/IntegrationTests.xctest/CAcert"
+                                      ofType:@"pem"];
   if (certsPath == nil) {
     certsPath = [[NSBundle bundleForClass:[self class]] pathForResource:@"CAcert" ofType:@"pem"];
   }
   unsigned long long fileSize =
-  [[[NSFileManager defaultManager] attributesOfItemAtPath:certsPath error:nil] fileSize];
+      [[[NSFileManager defaultManager] attributesOfItemAtPath:certsPath error:nil] fileSize];
 
   if (fileSize == 0) {
     NSLog(
-          @"The cert is not properly configured. Make sure setup_integration_tests.py "
-          "has been run.");
+        @"The cert is not properly configured. Make sure setup_integration_tests.py "
+         "has been run.");
   }
   [GRPCCall useTestCertsPath:certsPath testName:@"test_cert_2" forHost:host];
 }

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -150,8 +150,10 @@ static FIRFirestoreSettings *defaultSettings;
 
   if (fileSize == 0) {
     NSLog(
-        @"The cert is not properly configured. Make sure setup_integration_tests.py "
-         "has been run.");
+        @"Please set up a GoogleServices-Info.plist for Firestore in Firestore/Example/App using "
+         "instructions at <https://github.com/firebase/firebase-ios-sdk#running-sample-apps>. "
+         "Alternatively, if you're a Googler with a Hexa preproduction environment, run "
+         "setup_integration_tests.py to properly configure testing SSL certificates.");
   }
   [GRPCCall useTestCertsPath:certsPath testName:@"test_cert_2" forHost:host];
 }

--- a/Firestore/README.md
+++ b/Firestore/README.md
@@ -11,7 +11,7 @@
 
 ### Running Integration Tests
 
-  * [Set up a `GoogleServices-Info.plist`](/firebase/firebase-ios-sdk#running-sample-apps)
+  * [Set up a `GoogleServices-Info.plist`](//github.com/firebase/firebase-ios-sdk#running-sample-apps)
     file in `Firestore/Example/App`.
   * In Xcode select the Firestore_IntegrationTests_iOS scheme
   * ⌘-u to build and run the integration tests

--- a/Firestore/README.md
+++ b/Firestore/README.md
@@ -1,12 +1,20 @@
 ## Usage
 
-```
-$ cd Firestore/Example
-$ pod update
-$ open Firestore.xcworkspace
-Select the FirestoreTests scheme
-⌘-u to build and run the unit tests
-```
+  * Set up a workspace via CocoaPods
+    ```
+    $ cd Firestore/Example
+    $ pod update
+    $ open Firestore.xcworkspace
+    ```
+  * Select the Firestore_Tests_iOS scheme
+  * ⌘-u to build and run the unit tests
+
+### Running Integration Tests
+
+  * [Set up a `GoogleServices-Info.plist`](/firebase/firebase-ios-sdk#running-sample-apps)
+    file in `Firestore/Example/App`.
+  * In Xcode select the Firestore_IntegrationTests_iOS scheme
+  * ⌘-u to build and run the integration tests
 
 ### Building Protos
 


### PR DESCRIPTION
This brings iOS into line with the other platforms that also test against prod by default and brings Firestore iOS into line with the other iOS projects which require a similar configuration.