### PR TITLE
Port user data handling to C++

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -298,8 +298,8 @@
 		132E3BB3D5C42282B4ACFB20 /* FSTLevelDBBenchmarkTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FSTLevelDBBenchmarkTests.mm; sourceTree = "<group>"; };
 		2A0CF41BA5AED6049B0BEB2C /* type_traits_apple_test.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; path = type_traits_apple_test.mm; sourceTree = "<group>"; };
 		2B50B3A0DF77100EEE887891 /* Pods_Firestore_Tests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Firestore_Tests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		332485C4DCC6BA0DBB5E31B7 /* leveldb_util_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = leveldb_util_test.cc; sourceTree = "<group>"; };
-		3564F6872205C4F7001D5436 /* grpc_stream_tester.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = grpc_stream_tester.cc; sourceTree = "<group>"; };
+		332485C4DCC6BA0DBB5E31B7 /* leveldb_util_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = leveldb_util_test.cc; sourceTree = "<group>"; };
+		3564F6872205C4F7001D5436 /* grpc_stream_tester.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = grpc_stream_tester.cc; sourceTree = "<group>"; };
 		358C3B5FE573B1D60A4F7592 /* strerror_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = strerror_test.cc; sourceTree = "<group>"; };
 		3B843E4A1F3930A400548890 /* remote_store_spec_test.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = remote_store_spec_test.json; sourceTree = "<group>"; };
 		3C81DE3772628FE297055662 /* Pods-Firestore_Example_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_iOS/Pods-Firestore_Example_iOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -812,26 +812,18 @@
 		6003F593195388D20070C39A /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				6003F594195388D20070C39A /* Supporting Files */,
 				6003F59C195388D20070C39A /* FIRAppDelegate.h */,
 				6003F59D195388D20070C39A /* FIRAppDelegate.m */,
 				6003F5A5195388D20070C39A /* FIRViewController.h */,
 				6003F5A6195388D20070C39A /* FIRViewController.m */,
+				6003F595195388D20070C39A /* Firestore-Info.plist */,
 				6003F5A8195388D20070C39A /* Images.xcassets */,
+				6003F596195388D20070C39A /* InfoPlist.strings */,
 				71719F9D1E33DC2100824A3D /* LaunchScreen.storyboard */,
 				873B8AEA1B1F5CCA007FD442 /* Main.storyboard */,
-			);
-			path = iOS;
-			sourceTree = "<group>";
-		};
-		6003F594195388D20070C39A /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				6003F595195388D20070C39A /* Firestore-Info.plist */,
-				6003F596195388D20070C39A /* InfoPlist.strings */,
 				6003F599195388D20070C39A /* main.m */,
 			);
-			name = "Supporting Files";
+			path = iOS;
 			sourceTree = "<group>";
 		};
 		6003F5B5195388D20070C39A /* Tests */ = {
@@ -1877,7 +1869,6 @@
 				B6FB467D208E9D3C00554BA2 /* async_queue_test.cc in Sources */,
 				54740A581FC914F000713A1A /* autoid_test.cc in Sources */,
 				AB380D02201BC69F00D97691 /* bits_test.cc in Sources */,
-				B646EE6121224220001A1F18 /* buffered_writer_test.cc in Sources */,
 				618BBEA920B89AAC00B5BCE7 /* common.pb.cc in Sources */,
 				548DB929200D59F600E00ABC /* comparison_test.cc in Sources */,
 				ABC1D7DC2023A04B00BA84F0 /* credentials_provider_test.cc in Sources */,

--- a/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
@@ -20,6 +20,7 @@
 
 #include <unordered_set>
 
+#import "FIRTimestamp.h"
 #import "Firestore/Example/Tests/Util/FSTHelpers.h"
 #import "Firestore/Source/Local/FSTLRUGarbageCollector.h"
 #import "Firestore/Source/Local/FSTMutationQueue.h"

--- a/Firestore/Example/Tests/Util/FSTHelpers.mm
+++ b/Firestore/Example/Tests/Util/FSTHelpers.mm
@@ -56,6 +56,7 @@
 
 namespace testutil = firebase::firestore::testutil;
 namespace util = firebase::firestore::util;
+using firebase::firestore::core::ParsedUpdateData;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeySet;
@@ -263,11 +264,10 @@ FSTPatchMutation *FSTTestPatchMutation(const absl::string_view path,
 FSTTransformMutation *FSTTestTransformMutation(NSString *path, NSDictionary<NSString *, id> *data) {
   FSTDocumentKey *key = [FSTDocumentKey keyWithPath:testutil::Resource(util::MakeString(path))];
   FSTUserDataConverter *converter = FSTTestUserDataConverter();
-  FSTParsedUpdateData *result = [converter parsedUpdateData:data];
-  HARD_ASSERT(result.data.value.count == 0,
+  ParsedUpdateData result = [converter parsedUpdateData:data];
+  HARD_ASSERT(result.data().value.count == 0,
               "FSTTestTransformMutation() only expects transforms; no other data");
-  return [[FSTTransformMutation alloc] initWithKey:key
-                                   fieldTransforms:std::move(result.fieldTransforms)];
+  return [[FSTTransformMutation alloc] initWithKey:key fieldTransforms:result.field_transforms()];
 }
 
 FSTDeleteMutation *FSTTestDeleteMutation(NSString *path) {

--- a/Firestore/Source/API/FIRDocumentReference.mm
+++ b/Firestore/Source/API/FIRDocumentReference.mm
@@ -46,6 +46,7 @@
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 
 namespace util = firebase::firestore::util;
+using firebase::firestore::core::ParsedSetData;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::Precondition;
 using firebase::firestore::model::ResourcePath;
@@ -137,21 +138,21 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setData:(NSDictionary<NSString *, id> *)documentData
           merge:(BOOL)merge
      completion:(nullable void (^)(NSError *_Nullable error))completion {
-  FSTParsedSetData *parsed =
+  ParsedSetData parsed =
       merge ? [self.firestore.dataConverter parsedMergeData:documentData fieldMask:nil]
             : [self.firestore.dataConverter parsedSetData:documentData];
   return [self.firestore.client
-      writeMutations:[parsed mutationsWithKey:self.key precondition:Precondition::None()]
+      writeMutations:std::move(parsed).ToMutations(self.key, Precondition::None())
           completion:completion];
 }
 
 - (void)setData:(NSDictionary<NSString *, id> *)documentData
     mergeFields:(NSArray<id> *)mergeFields
      completion:(nullable void (^)(NSError *_Nullable error))completion {
-  FSTParsedSetData *parsed =
+  ParsedSetData parsed =
       [self.firestore.dataConverter parsedMergeData:documentData fieldMask:mergeFields];
   return [self.firestore.client
-      writeMutations:[parsed mutationsWithKey:self.key precondition:Precondition::None()]
+      writeMutations:std::move(parsed).ToMutations(self.key, Precondition::None())
           completion:completion];
 }
 

--- a/Firestore/Source/API/FIRDocumentReference.mm
+++ b/Firestore/Source/API/FIRDocumentReference.mm
@@ -47,6 +47,7 @@
 
 namespace util = firebase::firestore::util;
 using firebase::firestore::core::ParsedSetData;
+using firebase::firestore::core::ParsedUpdateData;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::Precondition;
 using firebase::firestore::model::ResourcePath;
@@ -162,9 +163,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)updateData:(NSDictionary<id, id> *)fields
         completion:(nullable void (^)(NSError *_Nullable error))completion {
-  FSTParsedUpdateData *parsed = [self.firestore.dataConverter parsedUpdateData:fields];
+  ParsedUpdateData parsed = [self.firestore.dataConverter parsedUpdateData:fields];
   return [self.firestore.client
-      writeMutations:[parsed mutationsWithKey:self.key precondition:Precondition::Exists(true)]
+      writeMutations:std::move(parsed).ToMutations(self.key, Precondition::Exists(true))
           completion:completion];
 }
 

--- a/Firestore/Source/API/FIRTransaction.mm
+++ b/Firestore/Source/API/FIRTransaction.mm
@@ -30,6 +30,7 @@
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 
 using firebase::firestore::core::ParsedSetData;
+using firebase::firestore::core::ParsedUpdateData;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -92,8 +93,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (FIRTransaction *)updateData:(NSDictionary<id, id> *)fields
                    forDocument:(FIRDocumentReference *)document {
   [self validateReference:document];
-  FSTParsedUpdateData *parsed = [self.firestore.dataConverter parsedUpdateData:fields];
-  [self.internalTransaction updateData:parsed forDocument:document.key];
+  ParsedUpdateData parsed = [self.firestore.dataConverter parsedUpdateData:fields];
+  [self.internalTransaction updateData:std::move(parsed) forDocument:document.key];
   return self;
 }
 

--- a/Firestore/Source/API/FIRWriteBatch.mm
+++ b/Firestore/Source/API/FIRWriteBatch.mm
@@ -29,6 +29,7 @@
 #include "Firestore/core/src/firebase/firestore/model/precondition.h"
 
 using firebase::firestore::core::ParsedSetData;
+using firebase::firestore::core::ParsedUpdateData;
 using firebase::firestore::model::Precondition;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -96,9 +97,9 @@ NS_ASSUME_NONNULL_BEGIN
                   forDocument:(FIRDocumentReference *)document {
   [self verifyNotCommitted];
   [self validateReference:document];
-  FSTParsedUpdateData *parsed = [self.firestore.dataConverter parsedUpdateData:fields];
-  [self.mutations addObjectsFromArray:[parsed mutationsWithKey:document.key
-                                                  precondition:Precondition::Exists(true)]];
+  ParsedUpdateData parsed = [self.firestore.dataConverter parsedUpdateData:fields];
+  [self.mutations
+      addObjectsFromArray:std::move(parsed).ToMutations(document.key, Precondition::Exists(true))];
   return self;
 }
 

--- a/Firestore/Source/API/FIRWriteBatch.mm
+++ b/Firestore/Source/API/FIRWriteBatch.mm
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
-#import "Firestore/Source/API/FIRWriteBatch+Internal.h"
+#import "FIRWriteBatch.h"
+
+#include <utility>
 
 #import "Firestore/Source/API/FIRDocumentReference+Internal.h"
 #import "Firestore/Source/API/FIRFirestore+Internal.h"
+#import "Firestore/Source/API/FIRWriteBatch+Internal.h"
 #import "Firestore/Source/API/FSTUserDataConverter.h"
 #import "Firestore/Source/Core/FSTFirestoreClient.h"
 #import "Firestore/Source/Model/FSTMutation.h"
@@ -25,6 +28,7 @@
 
 #include "Firestore/core/src/firebase/firestore/model/precondition.h"
 
+using firebase::firestore::core::ParsedSetData;
 using firebase::firestore::model::Precondition;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -70,11 +74,10 @@ NS_ASSUME_NONNULL_BEGIN
                      merge:(BOOL)merge {
   [self verifyNotCommitted];
   [self validateReference:document];
-  FSTParsedSetData *parsed = merge
-                                 ? [self.firestore.dataConverter parsedMergeData:data fieldMask:nil]
-                                 : [self.firestore.dataConverter parsedSetData:data];
+  ParsedSetData parsed = merge ? [self.firestore.dataConverter parsedMergeData:data fieldMask:nil]
+                               : [self.firestore.dataConverter parsedSetData:data];
   [self.mutations
-      addObjectsFromArray:[parsed mutationsWithKey:document.key precondition:Precondition::None()]];
+      addObjectsFromArray:std::move(parsed).ToMutations(document.key, Precondition::None())];
   return self;
 }
 
@@ -83,10 +86,9 @@ NS_ASSUME_NONNULL_BEGIN
                mergeFields:(NSArray<id> *)mergeFields {
   [self verifyNotCommitted];
   [self validateReference:document];
-  FSTParsedSetData *parsed =
-      [self.firestore.dataConverter parsedMergeData:data fieldMask:mergeFields];
+  ParsedSetData parsed = [self.firestore.dataConverter parsedMergeData:data fieldMask:mergeFields];
   [self.mutations
-      addObjectsFromArray:[parsed mutationsWithKey:document.key precondition:Precondition::None()]];
+      addObjectsFromArray:std::move(parsed).ToMutations(document.key, Precondition::None())];
   return self;
 }
 

--- a/Firestore/Source/API/FSTUserDataConverter.h
+++ b/Firestore/Source/API/FSTUserDataConverter.h
@@ -31,32 +31,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/** The result of parsing "update" data (i.e. for an updateData call). */
-@interface FSTParsedUpdateData : NSObject
-
-- (instancetype)init NS_UNAVAILABLE;
-
-- (instancetype)initWithData:(FSTObjectValue *)data
-                   fieldMask:(firebase::firestore::model::FieldMask)fieldMask
-             fieldTransforms:
-                 (std::vector<firebase::firestore::model::FieldTransform>)fieldTransforms
-    NS_DESIGNATED_INITIALIZER;
-
-- (const firebase::firestore::model::FieldMask &)fieldMask;
-- (const std::vector<firebase::firestore::model::FieldTransform> &)fieldTransforms;
-
-@property(nonatomic, strong, readonly) FSTObjectValue *data;
-
-/**
- * Converts the parsed update data into 1 or 2 mutations (depending on whether there are any
- * field transforms) using the specified document key and precondition.
- */
-- (NSArray<FSTMutation *> *)mutationsWithKey:(const firebase::firestore::model::DocumentKey &)key
-                                precondition:
-                                    (const firebase::firestore::model::Precondition &)precondition;
-
-@end
-
 /**
  * An internal representation of FIRDocumentReference, representing a key in a specific database.
  * This is necessary because keys assume a database from context (usually the current one).
@@ -103,7 +77,7 @@ typedef id _Nullable (^FSTPreConverterBlock)(id _Nullable);
                                                   fieldMask:(nullable NSArray<id> *)fieldMask;
 
 /** Parse update data from an updateData call. */
-- (FSTParsedUpdateData *)parsedUpdateData:(id)input;
+- (firebase::firestore::core::ParsedUpdateData)parsedUpdateData:(id)input;
 
 /** Parse a "query value" (e.g. value in a where filter or a value in a cursor bound). */
 - (FSTFieldValue *)parsedQueryValue:(id)input;

--- a/Firestore/Source/API/FSTUserDataConverter.h
+++ b/Firestore/Source/API/FSTUserDataConverter.h
@@ -18,6 +18,7 @@
 
 #include <vector>
 
+#include "Firestore/core/src/firebase/firestore/core/user_data.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/field_mask.h"
@@ -29,37 +30,6 @@
 @class FSTMutation;
 
 NS_ASSUME_NONNULL_BEGIN
-
-/** The result of parsing document data (e.g. for a setData call). */
-@interface FSTParsedSetData : NSObject
-
-- (instancetype)init NS_UNAVAILABLE;
-
-- (instancetype)initWithData:(FSTObjectValue *)data
-             fieldTransforms:
-                 (std::vector<firebase::firestore::model::FieldTransform>)fieldTransforms
-    NS_DESIGNATED_INITIALIZER;
-
-- (instancetype)initWithData:(FSTObjectValue *)data
-                   fieldMask:(firebase::firestore::model::FieldMask)fieldMask
-             fieldTransforms:
-                 (std::vector<firebase::firestore::model::FieldTransform>)fieldTransforms
-    NS_DESIGNATED_INITIALIZER;
-
-- (const std::vector<firebase::firestore::model::FieldTransform> &)fieldTransforms;
-
-@property(nonatomic, strong, readonly) FSTObjectValue *data;
-@property(nonatomic, assign, readonly) BOOL isPatch;
-
-/**
- * Converts the parsed document data into 1 or 2 mutations (depending on whether there are any
- * field transforms) using the specified document key and precondition.
- */
-- (NSArray<FSTMutation *> *)mutationsWithKey:(const firebase::firestore::model::DocumentKey &)key
-                                precondition:
-                                    (const firebase::firestore::model::Precondition &)precondition;
-
-@end
 
 /** The result of parsing "update" data (i.e. for an updateData call). */
 @interface FSTParsedUpdateData : NSObject
@@ -126,10 +96,11 @@ typedef id _Nullable (^FSTPreConverterBlock)(id _Nullable);
                       preConverter:(FSTPreConverterBlock)preConverter NS_DESIGNATED_INITIALIZER;
 
 /** Parse document data from a non-merge setData call.*/
-- (FSTParsedSetData *)parsedSetData:(id)input;
+- (firebase::firestore::core::ParsedSetData)parsedSetData:(id)input;
 
 /** Parse document data from a setData call with `merge:YES`. */
-- (FSTParsedSetData *)parsedMergeData:(id)input fieldMask:(nullable NSArray<id> *)fieldMask;
+- (firebase::firestore::core::ParsedSetData)parsedMergeData:(id)input
+                                                  fieldMask:(nullable NSArray<id> *)fieldMask;
 
 /** Parse update data from an updateData call. */
 - (FSTParsedUpdateData *)parsedUpdateData:(id)input;

--- a/Firestore/Source/API/FSTUserDataConverter.mm
+++ b/Firestore/Source/API/FSTUserDataConverter.mm
@@ -448,41 +448,6 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return [FSTReferenceValue referenceValue:reference.key databaseID:self.databaseID];
 
-  } else if ([input isKindOfClass:[FIRFieldValue class]]) {
-    if ([input isKindOfClass:[FSTDeleteFieldValue class]]) {
-      if (context.data_source() == UserDataSource::MergeSet) {
-        return nil;
-      } else if (context.data_source() == UserDataSource::Update) {
-        HARD_ASSERT(context.path()->size() > 0,
-                    "FieldValue.delete() at the top level should have already been handled.");
-        FSTThrowInvalidArgument(
-            @"FieldValue.delete() can only appear at the top level of your update data%s",
-            context.FieldDescription().c_str());
-      } else {
-        // We shouldn't encounter delete sentinels for queries or non-merge setData calls.
-        FSTThrowInvalidArgument(
-            @"FieldValue.delete() can only be used with updateData() and setData() with "
-            @"merge: true.");
-      }
-    } else if ([input isKindOfClass:[FSTServerTimestampFieldValue class]]) {
-      if (!context.write()) {
-        FSTThrowInvalidArgument(
-            @"FieldValue.serverTimestamp() can only be used with setData() and updateData().");
-      }
-      if (!context.path()) {
-        FSTThrowInvalidArgument(
-            @"FieldValue.serverTimestamp() is not currently supported inside arrays%s",
-            context.FieldDescription().c_str());
-      }
-      context.AddToFieldTransforms(*context.path(), absl::make_unique<ServerTimestampTransform>(
-                                                        ServerTimestampTransform::Get()));
-
-      // Return nil so this value is omitted from the parsed result.
-      return nil;
-    } else {
-      HARD_FAIL("Unknown FIRFieldValue type: %s", NSStringFromClass([input class]));
-    }
-
   } else {
     FSTThrowInvalidArgument(@"Unsupported type: %@%s", NSStringFromClass([input class]),
                             context.FieldDescription().c_str());

--- a/Firestore/Source/API/FSTUserDataConverter.mm
+++ b/Firestore/Source/API/FSTUserDataConverter.mm
@@ -48,6 +48,9 @@
 namespace util = firebase::firestore::util;
 using firebase::firestore::core::ParsedSetData;
 using firebase::firestore::core::ParsedUpdateData;
+using firebase::firestore::core::ParseContext;
+using firebase::firestore::core::ParseResult;
+using firebase::firestore::core::UserDataSource;
 using firebase::firestore::model::ArrayTransform;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentKey;
@@ -59,242 +62,6 @@ using firebase::firestore::model::ServerTimestampTransform;
 using firebase::firestore::model::TransformOperation;
 
 NS_ASSUME_NONNULL_BEGIN
-
-static const char *RESERVED_FIELD_DESIGNATOR = "__";
-
-/**
- * Represents what type of API method provided the data being parsed; useful for determining which
- * error conditions apply during parsing and providing better error messages.
- */
-typedef NS_ENUM(NSInteger, FSTUserDataSource) {
-  FSTUserDataSourceSet,
-  FSTUserDataSourceMergeSet,
-  FSTUserDataSourceUpdate,
-  /**
-   * Indicates the source is a where clause, cursor bound, arrayUnion() element, etc. In particular,
-   * this will result in [FSTParseContext isWrite] returning NO.
-   */
-  FSTUserDataSourceArgument,
-};
-
-#pragma mark - FSTParseContext
-
-/**
- * A "context" object passed around while parsing user data.
- */
-@interface FSTParseContext : NSObject
-
-/** Whether or not this context corresponds to an element of an array. */
-@property(nonatomic, assign, readonly, getter=isArrayElement) BOOL arrayElement;
-
-/**
- * What type of API method provided the data being parsed; useful for determining which error
- * conditions apply during parsing and providing better error messages.
- */
-@property(nonatomic, assign) FSTUserDataSource dataSource;
-
-- (instancetype)init NS_UNAVAILABLE;
-/**
- * Initializes a FSTParseContext with the given source and path.
- *
- * @param dataSource Indicates what kind of API method this data came from.
- * @param path A path within the object being parsed. This could be an empty path (in which case
- *   the context represents the root of the data being parsed), or a nonempty path (indicating the
- *   context represents a nested location within the data).
- *
- * TODO(b/34871131): We don't support array paths right now, so path can be nullptr to indicate
- * the context represents any location within an array (in which case certain features will not work
- * and errors will be somewhat compromised).
- */
-- (instancetype)initWithSource:(FSTUserDataSource)dataSource
-                          path:(std::unique_ptr<FieldPath>)path
-                  arrayElement:(BOOL)arrayElement
-               fieldTransforms:(std::shared_ptr<std::vector<FieldTransform>>)fieldTransforms
-                     fieldMask:(std::shared_ptr<std::vector<FieldPath>>)fieldMask
-    NS_DESIGNATED_INITIALIZER;
-
-// Helpers to get a FSTParseContext for a child field.
-- (instancetype)contextForField:(NSString *)fieldName;
-- (instancetype)contextForFieldPath:(const FieldPath &)fieldPath;
-- (instancetype)contextForArrayIndex:(NSUInteger)index;
-
-/** Returns true for the non-query parse contexts (Set, MergeSet and Update) */
-- (BOOL)isWrite;
-
-/** Returns 'YES' if 'fieldPath' was traversed when creating this context. */
-- (BOOL)containsFieldPath:(const FieldPath &)fieldPath;
-
-- (const FieldPath *)path;
-
-- (const std::vector<FieldPath> *)fieldMask;
-
-- (void)appendToFieldMaskWithFieldPath:(FieldPath)fieldPath;
-
-- (const std::vector<FieldTransform> *)fieldTransforms;
-
-- (void)appendToFieldTransformsWithFieldPath:(FieldPath)fieldPath
-                          transformOperation:
-                              (std::unique_ptr<TransformOperation>)transformOperation;
-@end
-
-@implementation FSTParseContext {
-  /** The current path being parsed. */
-  // TODO(b/34871131): path should never be nullptr, but we don't support array paths right now.
-  std::unique_ptr<FieldPath> _path;
-  // _fieldMask and _fieldTransforms are shared across all active context objects to accumulate the
-  // result. For example, the result of calling any of contextForField, contextForFieldPath and
-  // contextForArrayIndex shares the ownership of _fieldMask and _fieldTransforms.
-  std::shared_ptr<std::vector<FieldPath>> _fieldMask;
-  std::shared_ptr<std::vector<FieldTransform>> _fieldTransforms;
-}
-
-+ (instancetype)contextWithSource:(FSTUserDataSource)dataSource
-                             path:(std::unique_ptr<FieldPath>)path {
-  FSTParseContext *context =
-      [[FSTParseContext alloc] initWithSource:dataSource
-                                         path:std::move(path)
-                                 arrayElement:NO
-                              fieldTransforms:std::make_shared<std::vector<FieldTransform>>()
-                                    fieldMask:std::make_shared<std::vector<FieldPath>>()];
-  [context validatePath];
-  return context;
-}
-
-- (instancetype)initWithSource:(FSTUserDataSource)dataSource
-                          path:(std::unique_ptr<FieldPath>)path
-                  arrayElement:(BOOL)arrayElement
-               fieldTransforms:(std::shared_ptr<std::vector<FieldTransform>>)fieldTransforms
-                     fieldMask:(std::shared_ptr<std::vector<FieldPath>>)fieldMask {
-  if (self = [super init]) {
-    _dataSource = dataSource;
-    _path = std::move(path);
-    _arrayElement = arrayElement;
-    _fieldTransforms = std::move(fieldTransforms);
-    _fieldMask = std::move(fieldMask);
-  }
-  return self;
-}
-
-- (instancetype)contextForField:(NSString *)fieldName {
-  std::unique_ptr<FieldPath> path;
-  if (_path) {
-    path = absl::make_unique<FieldPath>(_path->Append(util::MakeString(fieldName)));
-  }
-  FSTParseContext *context = [[FSTParseContext alloc] initWithSource:self.dataSource
-                                                                path:std::move(path)
-                                                        arrayElement:NO
-                                                     fieldTransforms:_fieldTransforms
-                                                           fieldMask:_fieldMask];
-  [context validatePathSegment:util::MakeString(fieldName)];
-  return context;
-}
-
-- (instancetype)contextForFieldPath:(const FieldPath &)fieldPath {
-  std::unique_ptr<FieldPath> path;
-  if (_path) {
-    path = absl::make_unique<FieldPath>(_path->Append(fieldPath));
-  }
-  FSTParseContext *context = [[FSTParseContext alloc] initWithSource:self.dataSource
-                                                                path:std::move(path)
-                                                        arrayElement:NO
-                                                     fieldTransforms:_fieldTransforms
-                                                           fieldMask:_fieldMask];
-  [context validatePath];
-  return context;
-}
-
-- (instancetype)contextForArrayIndex:(NSUInteger)index {
-  // TODO(b/34871131): We don't support array paths right now; so make path nil.
-  return [[FSTParseContext alloc] initWithSource:self.dataSource
-                                            path:nil
-                                    arrayElement:YES
-                                 fieldTransforms:_fieldTransforms
-                                       fieldMask:_fieldMask];
-}
-
-/**
- * Returns a string that can be appended to error messages indicating what field caused the error.
- */
-- (NSString *)fieldDescription {
-  // TODO(b/34871131): Remove nil check once we have proper paths for fields within arrays.
-  if (!_path || _path->empty()) {
-    return @"";
-  } else {
-    return [NSString stringWithFormat:@" (found in field %s)", _path->CanonicalString().c_str()];
-  }
-}
-
-- (BOOL)isWrite {
-  switch (self.dataSource) {
-    case FSTUserDataSourceSet:       // Falls through.
-    case FSTUserDataSourceMergeSet:  // Falls through.
-    case FSTUserDataSourceUpdate:
-      return YES;
-    case FSTUserDataSourceArgument:
-      return NO;
-    default:
-      FSTThrowInvalidArgument(@"Unexpected case for FSTUserDataSource: %d", self.dataSource);
-  }
-}
-
-- (BOOL)containsFieldPath:(const FieldPath &)fieldPath {
-  for (const FieldPath &field : *_fieldMask) {
-    if (fieldPath.IsPrefixOf(field)) {
-      return YES;
-    }
-  }
-
-  for (const FieldTransform &fieldTransform : *_fieldTransforms) {
-    if (fieldPath.IsPrefixOf(fieldTransform.path())) {
-      return YES;
-    }
-  }
-
-  return NO;
-}
-
-- (void)validatePath {
-  // TODO(b/34871131): Remove nil check once we have proper paths for fields within arrays.
-  if (_path == nullptr) {
-    return;
-  }
-  for (const std::string &segment : *_path) {
-    [self validatePathSegment:segment];
-  }
-}
-
-- (void)validatePathSegment:(absl::string_view)segment {
-  absl::string_view designator{RESERVED_FIELD_DESIGNATOR};
-  if ([self isWrite] && absl::StartsWith(segment, designator) &&
-      absl::EndsWith(segment, designator)) {
-    FSTThrowInvalidArgument(@"Document fields cannot begin and end with %s%@",
-                            RESERVED_FIELD_DESIGNATOR, [self fieldDescription]);
-  }
-}
-
-- (const FieldPath *)path {
-  return _path.get();
-}
-
-- (const std::vector<FieldPath> *)fieldMask {
-  return _fieldMask.get();
-}
-
-- (void)appendToFieldMaskWithFieldPath:(FieldPath)fieldPath {
-  _fieldMask->push_back(std::move(fieldPath));
-}
-
-- (const std::vector<FieldTransform> *)fieldTransforms {
-  return _fieldTransforms.get();
-}
-
-- (void)appendToFieldTransformsWithFieldPath:(FieldPath)fieldPath
-                          transformOperation:
-                              (std::unique_ptr<TransformOperation>)transformOperation {
-  _fieldTransforms->emplace_back(std::move(fieldPath), std::move(transformOperation));
-}
-
-@end
 
 #pragma mark - FSTDocumentKeyReference
 
@@ -344,17 +111,14 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
     FSTThrowInvalidArgument(@"Data to be written must be an NSDictionary.");
   }
 
-  FSTParseContext *context =
-      [FSTParseContext contextWithSource:FSTUserDataSourceMergeSet
-                                    path:absl::make_unique<FieldPath>(FieldPath::EmptyPath())];
-  FSTObjectValue *updateData = (FSTObjectValue *)[self parseData:input context:context];
+  ParseResult result{UserDataSource::MergeSet};
 
-  FieldMask convertedFieldMask;
-  std::vector<FieldTransform> convertedFieldTransform;
+  FSTObjectValue *updateData =
+      (FSTObjectValue *)[self parseData:input context:result.RootContext()];
 
   if (fieldMask) {
-    __block std::vector<FieldPath> fieldMaskPaths;
-    [fieldMask enumerateObjectsUsingBlock:^(id fieldPath, NSUInteger idx, BOOL *stop) {
+    std::vector<FieldPath> fieldMaskPaths;
+    for (id fieldPath in fieldMask) {
       FieldPath path;
 
       if ([fieldPath isKindOfClass:[NSString class]]) {
@@ -367,27 +131,20 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
       }
 
       // Verify that all elements specified in the field mask are part of the parsed context.
-      if (![context containsFieldPath:path]) {
+      if (!result.Contains(path)) {
         FSTThrowInvalidArgument(
             @"Field '%s' is specified in your field mask but missing from your input data.",
             path.CanonicalString().c_str());
       }
 
       fieldMaskPaths.push_back(path);
-    }];
-    convertedFieldMask = FieldMask(fieldMaskPaths);
-    std::copy_if(context.fieldTransforms->begin(), context.fieldTransforms->end(),
-                 std::back_inserter(convertedFieldTransform),
-                 [&](const FieldTransform &fieldTransform) {
-                   return convertedFieldMask.covers(fieldTransform.path());
-                 });
-  } else {
-    convertedFieldMask = FieldMask{*context.fieldMask};
-    convertedFieldTransform = *context.fieldTransforms;
-  }
+    }
 
-  return ParsedSetData{updateData, std::move(convertedFieldMask),
-                       std::move(convertedFieldTransform)};
+    return std::move(result).MergeData(updateData, FieldMask{std::move(fieldMaskPaths)});
+
+  } else {
+    return std::move(result).MergeData(updateData);
+  }
 }
 
 - (ParsedSetData)parsedSetData:(id)input {
@@ -397,12 +154,10 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
     FSTThrowInvalidArgument(@"Data to be written must be an NSDictionary.");
   }
 
-  FSTParseContext *context =
-      [FSTParseContext contextWithSource:FSTUserDataSourceSet
-                                    path:absl::make_unique<FieldPath>(FieldPath::EmptyPath())];
-  FSTObjectValue *updateData = (FSTObjectValue *)[self parseData:input context:context];
+  ParseResult result{UserDataSource::Set};
+  FSTFieldValue *updateData = [self parseData:input context:result.RootContext()];
 
-  return ParsedSetData{updateData, *context.fieldTransforms};
+  return std::move(result).SetData((FSTObjectValue *)updateData);
 }
 
 - (ParsedUpdateData)parsedUpdateData:(id)input {
@@ -414,12 +169,11 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
 
   NSDictionary *dict = input;
 
-  __block std::vector<FieldPath> fieldMaskPaths;
   __block FSTObjectValue *updateData = [FSTObjectValue objectValue];
 
-  FSTParseContext *context =
-      [FSTParseContext contextWithSource:FSTUserDataSourceUpdate
-                                    path:absl::make_unique<FieldPath>(FieldPath::EmptyPath())];
+  ParseResult result{UserDataSource::Update};
+  ParseContext context = result.RootContext();
+  ParseContext *context_ptr = &context;
   [dict enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
     FieldPath path;
 
@@ -435,27 +189,26 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
     value = self.preConverter(value);
     if ([value isKindOfClass:[FSTDeleteFieldValue class]]) {
       // Add it to the field mask, but don't add anything to updateData.
-      fieldMaskPaths.push_back(path);
+      context_ptr->AddToFieldMask(std::move(path));
     } else {
       FSTFieldValue *_Nullable parsedValue =
-          [self parseData:value context:[context contextForFieldPath:path]];
+          [self parseData:value context:context_ptr->ChildContext(path)];
       if (parsedValue) {
-        fieldMaskPaths.push_back(path);
+        context_ptr->AddToFieldMask(path);
         updateData = [updateData objectBySettingValue:parsedValue forPath:path];
       }
     }
   }];
 
-  return ParsedUpdateData{updateData, FieldMask{fieldMaskPaths}, *context.fieldTransforms};
+  return std::move(result).UpdateData(updateData);
 }
 
 - (FSTFieldValue *)parsedQueryValue:(id)input {
-  FSTParseContext *context =
-      [FSTParseContext contextWithSource:FSTUserDataSourceArgument
-                                    path:absl::make_unique<FieldPath>(FieldPath::EmptyPath())];
-  FSTFieldValue *_Nullable parsed = [self parseData:input context:context];
+  ParseResult result{UserDataSource::Argument};
+
+  FSTFieldValue *_Nullable parsed = [self parseData:input context:result.RootContext()];
   HARD_ASSERT(parsed, "Parsed data should not be nil.");
-  HARD_ASSERT(context.fieldTransforms->empty(), "Field transforms should have been disallowed.");
+  HARD_ASSERT(result.field_transforms().empty(), "Field transforms should have been disallowed.");
   return parsed;
 }
 
@@ -469,44 +222,44 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
  * @return The parsed value, or nil if the value was a FieldValue sentinel that should not be
  *   included in the resulting parsed data.
  */
-- (nullable FSTFieldValue *)parseData:(id)input context:(FSTParseContext *)context {
+- (nullable FSTFieldValue *)parseData:(id)input context:(ParseContext &&)context {
   input = self.preConverter(input);
   if ([input isKindOfClass:[NSDictionary class]]) {
-    return [self parseDictionary:(NSDictionary *)input context:context];
+    return [self parseDictionary:(NSDictionary *)input context:std::move(context)];
 
   } else if ([input isKindOfClass:[FIRFieldValue class]]) {
     // FieldValues usually parse into transforms (except FieldValue.delete()) in which case we
     // do not want to include this field in our parsed data (as doing so will overwrite the field
     // directly prior to the transform trying to transform it). So we don't call appendToFieldMask
     // and we return nil as our parsing result.
-    [self parseSentinelFieldValue:(FIRFieldValue *)input context:context];
+    [self parseSentinelFieldValue:(FIRFieldValue *)input context:std::move(context)];
     return nil;
 
   } else {
-    // If context.path is nil we are already inside an array and we don't support field mask paths
+    // If context path is unset we are already inside an array and we don't support field mask paths
     // more granular than the top-level array.
-    if (context.path) {
-      [context appendToFieldMaskWithFieldPath:*context.path];
+    if (context.path()) {
+      context.AddToFieldMask(*context.path());
     }
 
     if ([input isKindOfClass:[NSArray class]]) {
       // TODO(b/34871131): Include the path containing the array in the error message.
-      if (context.isArrayElement) {
+      if (context.array_element()) {
         FSTThrowInvalidArgument(@"Nested arrays are not supported");
       }
-      return [self parseArray:(NSArray *)input context:context];
+      return [self parseArray:(NSArray *)input context:std::move(context)];
     } else {
-      return [self parseScalarValue:input context:context];
+      return [self parseScalarValue:input context:std::move(context)];
     }
   }
 }
 
-- (FSTFieldValue *)parseDictionary:(NSDictionary *)dict context:(FSTParseContext *)context {
+- (FSTFieldValue *)parseDictionary:(NSDictionary *)dict context:(ParseContext &&)context {
   NSMutableDictionary<NSString *, FSTFieldValue *> *result =
       [NSMutableDictionary dictionaryWithCapacity:dict.count];
   [dict enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, BOOL *stop) {
     FSTFieldValue *_Nullable parsedValue =
-        [self parseData:value context:[context contextForField:key]];
+        [self parseData:value context:context.ChildContext(util::MakeString(key))];
     if (parsedValue) {
       result[key] = parsedValue;
     }
@@ -514,11 +267,10 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
   return [[FSTObjectValue alloc] initWithDictionary:result];
 }
 
-- (FSTFieldValue *)parseArray:(NSArray *)array context:(FSTParseContext *)context {
+- (FSTFieldValue *)parseArray:(NSArray *)array context:(ParseContext &&)context {
   NSMutableArray<FSTFieldValue *> *result = [NSMutableArray arrayWithCapacity:array.count];
   [array enumerateObjectsUsingBlock:^(id entry, NSUInteger idx, BOOL *stop) {
-    FSTFieldValue *_Nullable parsedEntry =
-        [self parseData:entry context:[context contextForArrayIndex:idx]];
+    FSTFieldValue *_Nullable parsedEntry = [self parseData:entry context:context.ChildContext(idx)];
     if (!parsedEntry) {
       // Just include nulls in the array for fields being replaced with a sentinel.
       parsedEntry = [FSTNullValue nullValue];
@@ -532,56 +284,54 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
  * "Parses" the provided FIRFieldValue, adding any necessary transforms to
  * context.fieldTransforms.
  */
-- (void)parseSentinelFieldValue:(FIRFieldValue *)fieldValue context:(FSTParseContext *)context {
+- (void)parseSentinelFieldValue:(FIRFieldValue *)fieldValue context:(ParseContext &&)context {
   // Sentinels are only supported with writes, and not within arrays.
-  if (![context isWrite]) {
-    FSTThrowInvalidArgument(@"%@ can only be used with updateData() and setData()%@",
-                            fieldValue.methodName, [context fieldDescription]);
+  if (!context.write()) {
+    FSTThrowInvalidArgument(@"%@ can only be used with updateData() and setData()%s",
+                            fieldValue.methodName, context.FieldDescription().c_str());
   }
-  if (!context.path) {
+  if (!context.path()) {
     FSTThrowInvalidArgument(@"%@ is not currently supported inside arrays", fieldValue.methodName);
   }
 
   if ([fieldValue isKindOfClass:[FSTDeleteFieldValue class]]) {
-    if (context.dataSource == FSTUserDataSourceMergeSet) {
+    if (context.data_source() == UserDataSource::MergeSet) {
       // No transform to add for a delete, but we need to add it to our fieldMask so it gets
       // deleted.
-      [context appendToFieldMaskWithFieldPath:*context.path];
-    } else if (context.dataSource == FSTUserDataSourceUpdate) {
-      HARD_ASSERT(context.path->size() > 0,
+      context.AddToFieldMask(*context.path());
+
+    } else if (context.data_source() == UserDataSource::Update) {
+      HARD_ASSERT(context.path()->size() > 0,
                   "FieldValue.delete() at the top level should have already been handled.");
       FSTThrowInvalidArgument(
           @"FieldValue.delete() can only appear at the top level of your "
-           "update data%@",
-          [context fieldDescription]);
+           "update data%s",
+          context.FieldDescription().c_str());
     } else {
       // We shouldn't encounter delete sentinels for queries or non-merge setData calls.
       FSTThrowInvalidArgument(
           @"FieldValue.delete() can only be used with updateData() and setData() with "
-          @"merge:true%@",
-          [context fieldDescription]);
+          @"merge:true%s",
+          context.FieldDescription().c_str());
     }
 
   } else if ([fieldValue isKindOfClass:[FSTServerTimestampFieldValue class]]) {
-    [context appendToFieldTransformsWithFieldPath:*context.path
-                               transformOperation:absl::make_unique<ServerTimestampTransform>(
-                                                      ServerTimestampTransform::Get())];
+    context.AddToFieldTransforms(*context.path(), absl::make_unique<ServerTimestampTransform>(
+                                                      ServerTimestampTransform::Get()));
 
   } else if ([fieldValue isKindOfClass:[FSTArrayUnionFieldValue class]]) {
     std::vector<FSTFieldValue *> parsedElements =
         [self parseArrayTransformElements:((FSTArrayUnionFieldValue *)fieldValue).elements];
     auto array_union = absl::make_unique<ArrayTransform>(TransformOperation::Type::ArrayUnion,
                                                          std::move(parsedElements));
-    [context appendToFieldTransformsWithFieldPath:*context.path
-                               transformOperation:std::move(array_union)];
+    context.AddToFieldTransforms(*context.path(), std::move(array_union));
 
   } else if ([fieldValue isKindOfClass:[FSTArrayRemoveFieldValue class]]) {
     std::vector<FSTFieldValue *> parsedElements =
         [self parseArrayTransformElements:((FSTArrayRemoveFieldValue *)fieldValue).elements];
     auto array_remove = absl::make_unique<ArrayTransform>(TransformOperation::Type::ArrayRemove,
                                                           std::move(parsedElements));
-    [context appendToFieldTransformsWithFieldPath:*context.path
-                               transformOperation:std::move(array_remove)];
+    context.AddToFieldTransforms(*context.path(), std::move(array_remove));
 
   } else {
     HARD_FAIL("Unknown FIRFieldValue type: %s", NSStringFromClass([fieldValue class]));
@@ -598,7 +348,7 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
  *
  * @return The parsed value.
  */
-- (nullable FSTFieldValue *)parseScalarValue:(nullable id)input context:(FSTParseContext *)context {
+- (nullable FSTFieldValue *)parseScalarValue:(nullable id)input context:(ParseContext &&)context {
   if (!input || [input isMemberOfClass:[NSNull class]]) {
     return [FSTNullValue nullValue];
 
@@ -631,8 +381,9 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
           unsigned long long extended = [input unsignedLongLongValue];
 
           if (extended > LLONG_MAX) {
-            FSTThrowInvalidArgument(@"NSNumber (%llu) is too large%@",
-                                    [input unsignedLongLongValue], [context fieldDescription]);
+            FSTThrowInvalidArgument(@"NSNumber (%llu) is too large%s",
+                                    [input unsignedLongLongValue],
+                                    context.FieldDescription().c_str());
 
           } else {
             return [FSTIntegerValue integerValue:(int64_t)extended];
@@ -690,23 +441,23 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
     if (*reference.databaseID != *self.databaseID) {
       const DatabaseId *other = reference.databaseID;
       FSTThrowInvalidArgument(
-          @"Document Reference is for database %s/%s but should be for database %s/%s%@",
+          @"Document Reference is for database %s/%s but should be for database %s/%s%s",
           other->project_id().c_str(), other->database_id().c_str(),
           self.databaseID->project_id().c_str(), self.databaseID->database_id().c_str(),
-          [context fieldDescription]);
+          context.FieldDescription().c_str());
     }
     return [FSTReferenceValue referenceValue:reference.key databaseID:self.databaseID];
 
   } else if ([input isKindOfClass:[FIRFieldValue class]]) {
     if ([input isKindOfClass:[FSTDeleteFieldValue class]]) {
-      if (context.dataSource == FSTUserDataSourceMergeSet) {
+      if (context.data_source() == UserDataSource::MergeSet) {
         return nil;
-      } else if (context.dataSource == FSTUserDataSourceUpdate) {
-        HARD_ASSERT(context.path->size() > 0,
+      } else if (context.data_source() == UserDataSource::Update) {
+        HARD_ASSERT(context.path()->size() > 0,
                     "FieldValue.delete() at the top level should have already been handled.");
         FSTThrowInvalidArgument(
-            @"FieldValue.delete() can only appear at the top level of your update data%@",
-            [context fieldDescription]);
+            @"FieldValue.delete() can only appear at the top level of your update data%s",
+            context.FieldDescription().c_str());
       } else {
         // We shouldn't encounter delete sentinels for queries or non-merge setData calls.
         FSTThrowInvalidArgument(
@@ -714,18 +465,17 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
             @"merge: true.");
       }
     } else if ([input isKindOfClass:[FSTServerTimestampFieldValue class]]) {
-      if (![context isWrite]) {
+      if (!context.write()) {
         FSTThrowInvalidArgument(
             @"FieldValue.serverTimestamp() can only be used with setData() and updateData().");
       }
-      if (!context.path) {
+      if (!context.path()) {
         FSTThrowInvalidArgument(
-            @"FieldValue.serverTimestamp() is not currently supported inside arrays%@",
-            [context fieldDescription]);
+            @"FieldValue.serverTimestamp() is not currently supported inside arrays%s",
+            context.FieldDescription().c_str());
       }
-      [context appendToFieldTransformsWithFieldPath:*context.path
-                                 transformOperation:absl::make_unique<ServerTimestampTransform>(
-                                                        ServerTimestampTransform::Get())];
+      context.AddToFieldTransforms(*context.path(), absl::make_unique<ServerTimestampTransform>(
+                                                        ServerTimestampTransform::Get()));
 
       // Return nil so this value is omitted from the parsed result.
       return nil;
@@ -734,27 +484,27 @@ typedef NS_ENUM(NSInteger, FSTUserDataSource) {
     }
 
   } else {
-    FSTThrowInvalidArgument(@"Unsupported type: %@%@", NSStringFromClass([input class]),
-                            [context fieldDescription]);
+    FSTThrowInvalidArgument(@"Unsupported type: %@%s", NSStringFromClass([input class]),
+                            context.FieldDescription().c_str());
   }
 }
 
 - (std::vector<FSTFieldValue *>)parseArrayTransformElements:(NSArray<id> *)elements {
-  std::vector<FSTFieldValue *> results;
+  ParseResult result{UserDataSource::Argument};
+
+  std::vector<FSTFieldValue *> values;
   for (NSUInteger i = 0; i < elements.count; i++) {
     id element = elements[i];
     // Although array transforms are used with writes, the actual elements being unioned or removed
     // are not considered writes since they cannot contain any FieldValue sentinels, etc.
-    FSTParseContext *context =
-        [FSTParseContext contextWithSource:FSTUserDataSourceArgument
-                                      path:absl::make_unique<FieldPath>(FieldPath::EmptyPath())];
-    FSTFieldValue *parsedElement =
-        [self parseData:element context:[context contextForArrayIndex:i]];
-    HARD_ASSERT(parsedElement && context.fieldTransforms->size() == 0,
+    ParseContext context = result.RootContext();
+
+    FSTFieldValue *parsedElement = [self parseData:element context:context.ChildContext(i)];
+    HARD_ASSERT(parsedElement && result.field_transforms().size() == 0,
                 "Failed to properly parse array transform element: %s", element);
-    results.push_back(parsedElement);
+    values.push_back(parsedElement);
   }
-  return results;
+  return values;
 }
 
 @end

--- a/Firestore/Source/Core/FSTTransaction.h
+++ b/Firestore/Source/Core/FSTTransaction.h
@@ -20,12 +20,12 @@
 
 #import "Firestore/Source/Core/FSTTypes.h"
 
+#include "Firestore/core/src/firebase/firestore/core/user_data.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 
 @class FSTDatastore;
 @class FSTMaybeDocument;
 @class FSTObjectValue;
-@class FSTParsedSetData;
 @class FSTParsedUpdateData;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Stores mutation for the given key and set data, to be committed when commitWithCompletion is
  * called.
  */
-- (void)setData:(FSTParsedSetData *)data
+- (void)setData:(firebase::firestore::core::ParsedSetData &&)data
     forDocument:(const firebase::firestore::model::DocumentKey &)key;
 
 /**

--- a/Firestore/Source/Core/FSTTransaction.h
+++ b/Firestore/Source/Core/FSTTransaction.h
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Stores mutations for the given key and update data, to be committed when commitWithCompletion
  * is called.
  */
-- (void)updateData:(FSTParsedUpdateData *)data
+- (void)updateData:(firebase::firestore::core::ParsedUpdateData &&)data
        forDocument:(const firebase::firestore::model::DocumentKey &)key;
 
 /**

--- a/Firestore/Source/Core/FSTTransaction.mm
+++ b/Firestore/Source/Core/FSTTransaction.mm
@@ -36,6 +36,7 @@
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 
 using firebase::firestore::core::ParsedSetData;
+using firebase::firestore::core::ParsedUpdateData;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::Precondition;
 using firebase::firestore::model::SnapshotVersion;
@@ -185,14 +186,14 @@ NS_ASSUME_NONNULL_BEGIN
   [self writeMutations:std::move(data).ToMutations(key, [self preconditionForDocumentKey:key])];
 }
 
-- (void)updateData:(FSTParsedUpdateData *)data forDocument:(const DocumentKey &)key {
+- (void)updateData:(ParsedUpdateData &&)data forDocument:(const DocumentKey &)key {
   NSError *error = nil;
   const Precondition precondition = [self preconditionForUpdateWithDocumentKey:key error:&error];
   if (precondition.IsNone()) {
     HARD_ASSERT(error, "Got nil precondition, but error was not set");
     self.lastWriteError = error;
   } else {
-    [self writeMutations:[data mutationsWithKey:key precondition:precondition]];
+    [self writeMutations:std::move(data).ToMutations(key, precondition)];
   }
 }
 

--- a/Firestore/Source/Core/FSTTransaction.mm
+++ b/Firestore/Source/Core/FSTTransaction.mm
@@ -19,6 +19,7 @@
 #import <GRPCClient/GRPCCall.h>
 
 #include <map>
+#include <utility>
 #include <vector>
 
 #import "FIRFirestoreErrors.h"
@@ -34,6 +35,7 @@
 #include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 
+using firebase::firestore::core::ParsedSetData;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::Precondition;
 using firebase::firestore::model::SnapshotVersion;
@@ -179,9 +181,8 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-- (void)setData:(FSTParsedSetData *)data forDocument:(const DocumentKey &)key {
-  [self writeMutations:[data mutationsWithKey:key
-                                 precondition:[self preconditionForDocumentKey:key]]];
+- (void)setData:(ParsedSetData &&)data forDocument:(const DocumentKey &)key {
+  [self writeMutations:std::move(data).ToMutations(key, [self preconditionForDocumentKey:key])];
 }
 
 - (void)updateData:(FSTParsedUpdateData *)data forDocument:(const DocumentKey &)key {

--- a/Firestore/Source/Remote/FSTSerializerBeta.mm
+++ b/Firestore/Source/Remote/FSTSerializerBeta.mm
@@ -33,6 +33,7 @@
 
 #import "FIRFirestoreErrors.h"
 #import "FIRGeoPoint.h"
+#import "FIRTimestamp.h"
 #import "Firestore/Source/Core/FSTQuery.h"
 #import "Firestore/Source/Local/FSTQueryData.h"
 #import "Firestore/Source/Model/FSTDocument.h"

--- a/Firestore/core/src/firebase/firestore/core/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/core/CMakeLists.txt
@@ -25,6 +25,8 @@ cc_library(
     query.h
     relation_filter.cc
     relation_filter.h
+    user_data.h
+    user_data.mm
   DEPENDS
     absl_strings
     firebase_firestore_model

--- a/Firestore/core/src/firebase/firestore/core/user_data.h
+++ b/Firestore/core/src/firebase/firestore/core/user_data.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_USER_DATA_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_USER_DATA_H_
+
+#include <vector>
+
+#include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/field_mask.h"
+#include "Firestore/core/src/firebase/firestore/model/field_transform.h"
+#include "Firestore/core/src/firebase/firestore/model/precondition.h"
+
+@class FSTMutation;
+@class FSTObjectValue;
+
+namespace firebase {
+namespace firestore {
+namespace core {
+
+/** The result of parsing document data (e.g. for a setData call). */
+class ParsedSetData {
+ public:
+  ParsedSetData(FSTObjectValue* data,
+                std::vector<model::FieldTransform> field_transforms);
+  ParsedSetData(FSTObjectValue* data,
+                model::FieldMask field_mask,
+                std::vector<model::FieldTransform> field_transforms);
+
+  const std::vector<model::FieldTransform>& field_transforms() {
+    return field_transforms_;
+  }
+
+  FSTObjectValue* data() {
+    return data_;
+  }
+
+  bool patch() {
+    return patch_;
+  }
+
+  /**
+   * Converts the parsed document data into 1 or 2 mutations (depending on
+   * whether there are any field transforms) using the specified document key
+   * and precondition.
+   *
+   * This method consumes the values stored in the ParsedSetData
+   */
+  NSArray<FSTMutation*>* ToMutations(
+      const model::DocumentKey& key,
+      const model::Precondition& precondition) &&;
+
+ private:
+  FSTObjectValue* data_;
+  model::FieldMask field_mask_;
+  std::vector<model::FieldTransform> field_transforms_;
+  bool patch_;
+};
+
+}  // namespace core
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_USER_DATA_H_

--- a/Firestore/core/src/firebase/firestore/core/user_data.h
+++ b/Firestore/core/src/firebase/firestore/core/user_data.h
@@ -31,7 +31,7 @@ namespace firebase {
 namespace firestore {
 namespace core {
 
-/** The result of parsing document data (e.g. for a setData call). */
+/** The result of parsing document data (e.g. for a SetData call). */
 class ParsedSetData {
  public:
   ParsedSetData(FSTObjectValue* data,
@@ -39,18 +39,6 @@ class ParsedSetData {
   ParsedSetData(FSTObjectValue* data,
                 model::FieldMask field_mask,
                 std::vector<model::FieldTransform> field_transforms);
-
-  const std::vector<model::FieldTransform>& field_transforms() {
-    return field_transforms_;
-  }
-
-  FSTObjectValue* data() {
-    return data_;
-  }
-
-  bool patch() {
-    return patch_;
-  }
 
   /**
    * Converts the parsed document data into 1 or 2 mutations (depending on
@@ -68,6 +56,38 @@ class ParsedSetData {
   model::FieldMask field_mask_;
   std::vector<model::FieldTransform> field_transforms_;
   bool patch_;
+};
+
+/** The result of parsing "update" data (i.e. for an UpdateData call). */
+class ParsedUpdateData {
+ public:
+  ParsedUpdateData(FSTObjectValue* data,
+                   model::FieldMask field_mask,
+                   std::vector<model::FieldTransform> fieldTransforms);
+
+  FSTObjectValue* data() const {
+    return data_;
+  }
+
+  const std::vector<model::FieldTransform>& field_transforms() const {
+    return field_transforms_;
+  }
+
+  /**
+   * Converts the parsed update data into 1 or 2 mutations (depending on whether
+   * there are any field transforms) using the specified document key and
+   * precondition.
+   *
+   * This method consumes the values stored in the ParsedUpdateData
+   */
+  NSArray<FSTMutation*>* ToMutations(
+      const model::DocumentKey& key,
+      const model::Precondition& precondition) &&;
+
+ private:
+  FSTObjectValue* data_;
+  model::FieldMask field_mask_;
+  std::vector<model::FieldTransform> field_transforms_;
 };
 
 }  // namespace core

--- a/Firestore/core/src/firebase/firestore/core/user_data.h
+++ b/Firestore/core/src/firebase/firestore/core/user_data.h
@@ -17,10 +17,14 @@
 #ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_USER_DATA_H_
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_USER_DATA_H_
 
+#include <memory>
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/field_mask.h"
+#include "Firestore/core/src/firebase/firestore/model/field_path.h"
 #include "Firestore/core/src/firebase/firestore/model/field_transform.h"
 #include "Firestore/core/src/firebase/firestore/model/precondition.h"
 
@@ -30,6 +34,212 @@
 namespace firebase {
 namespace firestore {
 namespace core {
+
+/**
+ * Represents what type of API method provided the data being parsed; useful for
+ * determining which error conditions apply during parsing and providing better
+ * error messages.
+ */
+enum class UserDataSource {
+  /** The data comes from a regular Set operation, without merge. */
+  Set,
+  /** The data comes from a Set operation with merge enabled. */
+  MergeSet,
+  /** The data comes from an Update operation. */
+  Update,
+  /**
+   * Indicates the source is a where clause, cursor bound, array union element,
+   * etc. In particular, this will result in ParseContext.write() to return
+   * false.
+   */
+  Argument,
+};
+
+class ParseContext;
+class ParsedSetData;
+class ParsedUpdateData;
+
+/**
+ * Accumulates the side-effect results of parsing user input. These include:
+ *
+ *   * The field mask naming all the fields that have values.
+ *   * The transform operations that must be applied in the batch to implement
+ *     server-generated behavior. In the wire protocol these are encoded
+ *     separately from the Value.
+ */
+class ParseResult {
+ public:
+  /**
+   * @param data_source Indicates what kind of API method this data came from.
+   */
+  explicit ParseResult(UserDataSource data_source) : data_source_{data_source} {
+  }
+
+  /**
+   * Returns a new ParseContext representing the root of a user document.
+   */
+  ParseContext RootContext();
+
+  /**
+   * Returns `true` if `field_path` was traversed when creating this result.
+   */
+  bool Contains(const model::FieldPath& field_path) const;
+
+  /**
+   * Adds the given field_path to the FieldMask that this result is
+   * accumulating.
+   */
+  void AddToFieldMask(model::FieldPath field_path);
+
+  /**
+   * Adds a transformation for the given field path.
+   */
+  void AddToFieldTransforms(
+      model::FieldPath field_path,
+      std::unique_ptr<model::TransformOperation> transform_operation);
+
+  /**
+   * Returns the current list of transforms.
+   */
+  const std::vector<model::FieldTransform>& field_transforms() const {
+    return field_transforms_;
+  }
+
+  /**
+   * What type of API method provided the data being parsed; useful for
+   * determining which error conditions apply during parsing and providing
+   * better error messages.
+   */
+  UserDataSource data_source() const {
+    return data_source_;
+  }
+
+  /**
+   * Wraps the given `data` along with any accumulated field mask and transforms
+   * into a ParsedSetData representing a user-issued merge.
+   *
+   * @return ParsedSetData that has consumed the contents of this ParseResult.
+   */
+  ParsedSetData MergeData(FSTObjectValue* data) &&;
+
+  /**
+   * Wraps the given `data` and `user_field_mask` along with any accumulated
+   * transforms that are covered by the given field mask into a ParsedSetData
+   * that represents a user-issued merge.
+   *
+   * @param data The converted user data.
+   * @param user_field_mask The user-supplied field mask that masks out any
+   *     changes that have been accumulated so far.
+   *
+   * @return ParsedSetData that has consumed the contents of this ParseResult.
+   *     The field mask in the result will be the user_field_mask and only
+   *     transforms that are covered by the mask will be included.
+   */
+  ParsedSetData MergeData(FSTObjectValue* data,
+                          model::FieldMask user_field_mask) &&;
+
+  /**
+   * Wraps the given `data` along with any accumulated transforms into a
+   * ParsedSetData that represents a user-issued Set.
+   *
+   * @return ParsedSetData that has consumed the contents of this ParseResult.
+   */
+  ParsedSetData SetData(FSTObjectValue* data) &&;
+
+  /**
+   * Wraps the given `data` along with any accumulated field mask and transforms
+   * into a ParsedUpdateData that represents a user-issued Update.
+   *
+   * @return ParsedSetData that has consumed the contents of this ParseResult.
+   */
+  ParsedUpdateData UpdateData(FSTObjectValue* data) &&;
+
+ private:
+  friend class ParseContext;
+
+  UserDataSource data_source_;
+
+  // field_mask_ and field_transforms_ are shared across all active context
+  // objects to accumulate the result. All ChildContext objects append their
+  // results here.
+  std::vector<model::FieldPath> field_mask_;
+  std::vector<model::FieldTransform> field_transforms_;
+};
+
+/**
+ * A "context" object passed around while parsing user data. A Context
+ * represents a location within a user-supplied document.
+ */
+class ParseContext {
+ public:
+  /**
+   * Initializes a FSTParseContext with the given source and path.
+   *
+   * @param path A path within the object being parsed. This could be an empty
+   * path (in which case the context represents the root of the data being
+   * parsed), or a nonempty path (indicating the context represents a nested
+   * location within the data).
+   *
+   * TODO(b/34871131): We don't support array paths right now, so path can be
+   * nullptr to indicate the context represents any location within an array (in
+   * which case certain features will not work and errors will be somewhat
+   * compromised).
+   */
+  ParseContext(ParseResult* result,
+               std::unique_ptr<model::FieldPath> path,
+               bool array_element)
+      : result_{result}, path_{std::move(path)}, array_element_{array_element} {
+  }
+
+  /** Whether or not this context corresponds to an element of an array. */
+  bool array_element() const {
+    return array_element_;
+  }
+
+  /**
+   * What type of API method provided the data being parsed; useful for
+   * determining which error conditions apply during parsing and providing
+   * better error messages.
+   */
+  UserDataSource data_source() const {
+    return result_->data_source_;
+  }
+
+  const model::FieldPath* path() const {
+    return path_.get();
+  }
+
+  /**
+   * Returns true for the non-query parse contexts (Set, MergeSet and Update).
+   */
+  bool write() const;
+
+  std::string FieldDescription() const;
+
+  // Helpers to get a FSTParseContext for a child field.
+  ParseContext ChildContext(const std::string& field_name);
+  ParseContext ChildContext(const model::FieldPath& field_path);
+  ParseContext ChildContext(size_t array_index);
+
+  void AddToFieldMask(model::FieldPath field_path);
+
+  void AddToFieldTransforms(
+      model::FieldPath field_path,
+      std::unique_ptr<model::TransformOperation> transform_operation);
+
+ private:
+  void ValidatePath() const;
+  void ValidatePathSegment(absl::string_view segment) const;
+
+  ParseResult* result_;  // Non owning
+
+  /** The current path being parsed. */
+  // TODO(b/34871131): path should never be nullptr, but we don't support array
+  // paths right now.
+  std::unique_ptr<model::FieldPath> path_;
+
+  bool array_element_ = false;
+};
 
 /** The result of parsing document data (e.g. for a SetData call). */
 class ParsedSetData {

--- a/Firestore/core/src/firebase/firestore/core/user_data.mm
+++ b/Firestore/core/src/firebase/firestore/core/user_data.mm
@@ -19,6 +19,9 @@
 #include <utility>
 
 #import "Firestore/Source/Model/FSTMutation.h"
+#import "Firestore/Source/Util/FSTUsageValidation.h"
+
+#include "absl/strings/match.h"
 
 namespace firebase {
 namespace firestore {
@@ -26,8 +29,167 @@ namespace core {
 
 using model::DocumentKey;
 using model::FieldMask;
+using model::FieldPath;
 using model::FieldTransform;
 using model::Precondition;
+using model::TransformOperation;
+
+#pragma mark - ParseContext
+
+namespace {
+static const char* RESERVED_FIELD_DESIGNATOR = "__";
+
+}  // namespace
+
+ParseContext ParseContext::ChildContext(const std::string& field_name) {
+  std::unique_ptr<FieldPath> path;
+  if (path_) {
+    path = absl::make_unique<FieldPath>(path_->Append(field_name));
+  }
+
+  ParseContext context{result_, std::move(path), false};
+  context.ValidatePathSegment(field_name);
+  return context;
+}
+
+ParseContext ParseContext::ChildContext(const FieldPath& fieldPath) {
+  std::unique_ptr<FieldPath> path;
+  if (path_) {
+    path = absl::make_unique<FieldPath>(path_->Append(fieldPath));
+  }
+
+  ParseContext context{result_, std::move(path), false};
+  context.ValidatePath();
+  return context;
+}
+
+ParseContext ParseContext::ChildContext(size_t array_index) {
+  // TODO(b/34871131): We don't support array paths right now; make path null.
+  (void)array_index;
+  return {result_, /* path= */ nullptr, /* array_element= */ true};
+}
+
+/**
+ * Returns a string that can be appended to error messages indicating what field
+ * caused the error.
+ */
+std::string ParseContext::FieldDescription() const {
+  // TODO(b/34871131): Remove nullptr check once we have proper paths for fields
+  // within arrays.
+  if (!path_ || path_->empty()) {
+    return "";
+  } else {
+    return util::StringFormat(" (found in field %s)", path_->CanonicalString());
+  }
+}
+
+bool ParseContext::write() const {
+  switch (result_->data_source()) {
+    case UserDataSource::Set:       // Falls through.
+    case UserDataSource::MergeSet:  // Falls through.
+    case UserDataSource::Update:
+      return true;
+    case UserDataSource::Argument:
+      return false;
+    default:
+      FSTThrowInvalidArgument(@"Unexpected case for FSTUserDataSource: %d",
+                              result_->data_source());
+  }
+}
+
+void ParseContext::ValidatePath() const {
+  // TODO(b/34871131): Remove nullptr check once we have proper paths for fields
+  // within arrays.
+  if (!path_) {
+    return;
+  }
+  for (const std::string& segment : *path_) {
+    ValidatePathSegment(segment);
+  }
+}
+
+void ParseContext::ValidatePathSegment(absl::string_view segment) const {
+  absl::string_view designator{RESERVED_FIELD_DESIGNATOR};
+  if (write() && absl::StartsWith(segment, designator) &&
+      absl::EndsWith(segment, designator)) {
+    FSTThrowInvalidArgument(@"Document fields cannot begin and end with %s%s",
+                            RESERVED_FIELD_DESIGNATOR,
+                            FieldDescription().c_str());
+  }
+}
+
+void ParseContext::AddToFieldMask(FieldPath field_path) {
+  result_->AddToFieldMask(std::move(field_path));
+}
+
+void ParseContext::AddToFieldTransforms(
+    FieldPath field_path,
+    std::unique_ptr<TransformOperation> transform_operation) {
+  result_->AddToFieldTransforms(std::move(field_path),
+                                std::move(transform_operation));
+}
+
+#pragma mark - ParseResult
+
+ParseContext ParseResult::RootContext() {
+  return ParseContext{
+      this, absl::make_unique<FieldPath>(FieldPath::EmptyPath()), false};
+}
+
+bool ParseResult::Contains(const FieldPath& field_path) const {
+  for (const FieldPath& field : field_mask_) {
+    if (field_path.IsPrefixOf(field)) {
+      return true;
+    }
+  }
+
+  for (const FieldTransform& field_transform : field_transforms_) {
+    if (field_path.IsPrefixOf(field_transform.path())) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void ParseResult::AddToFieldMask(FieldPath field_path) {
+  field_mask_.push_back(std::move(field_path));
+}
+
+void ParseResult::AddToFieldTransforms(
+    FieldPath field_path,
+    std::unique_ptr<TransformOperation> transform_operation) {
+  field_transforms_.emplace_back(std::move(field_path),
+                                 std::move(transform_operation));
+}
+
+ParsedSetData ParseResult::MergeData(FSTObjectValue* data) && {
+  return ParsedSetData{data, FieldMask{std::move(field_mask_)},
+                       std::move(field_transforms_)};
+}
+
+ParsedSetData ParseResult::MergeData(FSTObjectValue* data,
+                                     model::FieldMask user_field_mask) && {
+  std::vector<FieldTransform> covered_field_transforms;
+
+  for (FieldTransform& field_transform : field_transforms_) {
+    if (user_field_mask.covers(field_transform.path())) {
+      covered_field_transforms.push_back(std::move(field_transform));
+    }
+  }
+
+  return ParsedSetData{data, std::move(user_field_mask),
+                       std::move(covered_field_transforms)};
+}
+
+ParsedSetData ParseResult::SetData(FSTObjectValue* data) && {
+  return ParsedSetData{data, std::move(field_transforms_)};
+}
+
+ParsedUpdateData ParseResult::UpdateData(FSTObjectValue* data) && {
+  return ParsedUpdateData{data, FieldMask{std::move(field_mask_)},
+                          std::move(field_transforms_)};
+}
 
 #pragma mark - ParsedSetData
 

--- a/Firestore/core/src/firebase/firestore/core/user_data.mm
+++ b/Firestore/core/src/firebase/firestore/core/user_data.mm
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/core/user_data.h"
+
+#include <utility>
+
+#import "Firestore/Source/Model/FSTMutation.h"
+
+namespace firebase {
+namespace firestore {
+namespace core {
+
+using model::DocumentKey;
+using model::FieldMask;
+using model::FieldTransform;
+using model::Precondition;
+
+ParsedSetData::ParsedSetData(FSTObjectValue* data,
+                             std::vector<FieldTransform> field_transforms)
+    : data_{data},
+      field_transforms_{std::move(field_transforms)},
+      patch_{false} {
+}
+
+ParsedSetData::ParsedSetData(FSTObjectValue* data,
+                             FieldMask field_mask,
+                             std::vector<FieldTransform> field_transforms)
+    : data_{data},
+      field_mask_{std::move(field_mask)},
+      field_transforms_{std::move(field_transforms)},
+      patch_{true} {
+}
+
+NSArray<FSTMutation*>* ParsedSetData::ToMutations(
+    const DocumentKey& key, const Precondition& precondition) && {
+  NSMutableArray<FSTMutation*>* mutations = [NSMutableArray array];
+  if (patch_) {
+    [mutations
+        addObject:[[FSTPatchMutation alloc] initWithKey:key
+                                              fieldMask:std::move(field_mask_)
+                                                  value:std::move(data_)
+                                           precondition:precondition]];
+  } else {
+    [mutations addObject:[[FSTSetMutation alloc] initWithKey:key
+                                                       value:std::move(data_)
+                                                precondition:precondition]];
+  }
+  if (!field_transforms_.empty()) {
+    [mutations
+        addObject:[[FSTTransformMutation alloc] initWithKey:key
+                                            fieldTransforms:field_transforms_]];
+  }
+  return mutations;
+}
+
+}  // namespace core
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/core/src/firebase/firestore/model/precondition.h
+++ b/Firestore/core/src/firebase/firestore/model/precondition.h
@@ -20,7 +20,6 @@
 #include <utility>
 
 #if defined(__OBJC__)
-#import "FIRTimestamp.h"
 #import "Firestore/Source/Model/FSTDocument.h"
 #include "Firestore/core/include/firebase/firestore/timestamp.h"
 #endif  // defined(__OBJC__)


### PR DESCRIPTION
There's a few high-level parts to this PR:

  * Ports FSTParsed{Set,Update}Data to C++
  * Ports FSTParseContext to C++
  * Splits ParseResult from ParseContext to make ownership easier to reason about
  * Moves shared user data bits into core to avoid a dependency cycle
  * Removes some dead code