### PR TITLE
Fix GoogleUtilities warnings in static library installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,9 +80,6 @@ jobs:
       before_install:
         - ./scripts/if_cron.sh ./scripts/install_prereqs.sh
       script:
-        # For GoogleUtilities, allow warnings for iOS 6 but not iOS 7.
-        - ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh GoogleUtilities.podspec --use-libraries --allow-warnings
-        - ./scripts/if_cron.sh sed -i -e "s/s.ios.deployment_target = '6.0'/s.ios.deployment_target = '7.0'/" GoogleUtilities.podspec
         - ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh GoogleUtilities.podspec --use-libraries
         - ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh FirebaseCore.podspec --use-libraries
         - ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh FirebaseAuth.podspec --use-libraries

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,15 +110,6 @@ jobs:
       script:
         - ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
 
-    - stage: test
-      osx_image: xcode8.3
-      env:
-        - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild XCODE_VERSION=8.3.3
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
-      script:
-        - ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
-
     # Community-supported platforms
 
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,15 @@ jobs:
       script:
         - ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
 
+    - stage: test
+      osx_image: xcode8.3
+      env:
+        - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild XCODE_VERSION=8.3.3
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        - ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
+
     # Community-supported platforms
 
     - stage: test

--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -16,6 +16,8 @@ other Google CocoaPods. They're not intended for direct public usage.
     :git => 'https://github.com/firebase/firebase-ios-sdk.git',
     :tag => 'Utilities-' + s.version.to_s
   }
+  # Technically GoogleUtilites requires iOS 7, but it supports a dependency pod with a minimum
+  # iOS 6, that will do runtime checking to avoid calling into GoogleUtilities.
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '10.0'

--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -594,7 +594,7 @@ static dispatch_once_t sProxyAppDelegateOnceToken;
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
 - (void)application:(UIApplication *)application
     handleEventsForBackgroundURLSession:(NSString *)identifier
-                      completionHandler:(void (^)())completionHandler {
+                      completionHandler:(void (^)())completionHandler API_AVAILABLE(ios(7.0)) {
 #pragma clang diagnostic pop
   NSValue *handleBackgroundSessionPointer =
       objc_getAssociatedObject(self, &kGULHandleBackgroundSessionIMPKey);

--- a/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
@@ -187,10 +187,12 @@ static BOOL HasEmbeddedMobileProvision() {
       ![enableSandboxCheck boolValue]) {
     return NO;
   }
-
-  NSURL *appStoreReceiptURL = [NSBundle mainBundle].appStoreReceiptURL;
-  NSString *appStoreReceiptFileName = appStoreReceiptURL.lastPathComponent;
-  return [appStoreReceiptFileName isEqualToString:kFIRAIdentitySandboxReceiptFileName];
+  if (@available(iOS 7.0, *)) {
+    NSURL *appStoreReceiptURL = [NSBundle mainBundle].appStoreReceiptURL;
+    NSString *appStoreReceiptFileName = appStoreReceiptURL.lastPathComponent;
+    return [appStoreReceiptFileName isEqualToString:kFIRAIdentitySandboxReceiptFileName];
+  }
+  return NO;
 }
 
 + (BOOL)isSimulator {

--- a/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
@@ -188,7 +188,8 @@ static BOOL HasEmbeddedMobileProvision() {
     return NO;
   }
 // The #else is for pre Xcode 9 where @available is not yet implemented.
-#if defined(TARGET_OS_TV) || defined(TARGET_OS_OSX) || defined(__IPHONE_11_0)
+#if defined(__has_feature) && defined(__has_attribute)
+#if __has_attribute(availability)
   if (@available(iOS 7.0, *)) {
 #else
   if ([[UIDevice currentDevice].systemVersion integerValue] >= 7) {
@@ -197,6 +198,7 @@ static BOOL HasEmbeddedMobileProvision() {
     NSString *appStoreReceiptFileName = appStoreReceiptURL.lastPathComponent;
     return [appStoreReceiptFileName isEqualToString:kFIRAIdentitySandboxReceiptFileName];
   }
+#endif
   return NO;
 }
 

--- a/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
@@ -187,7 +187,12 @@ static BOOL HasEmbeddedMobileProvision() {
       ![enableSandboxCheck boolValue]) {
     return NO;
   }
+// The #else is for pre Xcode 9 where @available is not yet implemented.
+#if defined(TARGET_OS_TV) || defined(TARGET_OS_OSX) || defined(__IPHONE_11_0)
   if (@available(iOS 7.0, *)) {
+#else
+  if ([[UIDevice currentDevice].systemVersion integerValue] >= 7) {
+#endif
     NSURL *appStoreReceiptURL = [NSBundle mainBundle].appStoreReceiptURL;
     NSString *appStoreReceiptFileName = appStoreReceiptURL.lastPathComponent;
     return [appStoreReceiptFileName isEqualToString:kFIRAIdentitySandboxReceiptFileName];

--- a/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
@@ -188,8 +188,7 @@ static BOOL HasEmbeddedMobileProvision() {
     return NO;
   }
 // The #else is for pre Xcode 9 where @available is not yet implemented.
-#if defined(__has_feature) && defined(__has_attribute)
-#if __has_attribute(availability)
+#if __has_builtin(__builtin_available)
   if (@available(iOS 7.0, *)) {
 #else
   if ([[UIDevice currentDevice].systemVersion integerValue] >= 7) {
@@ -198,7 +197,6 @@ static BOOL HasEmbeddedMobileProvision() {
     NSString *appStoreReceiptFileName = appStoreReceiptURL.lastPathComponent;
     return [appStoreReceiptFileName isEqualToString:kFIRAIdentitySandboxReceiptFileName];
   }
-#endif
   return NO;
 }
 

--- a/GoogleUtilities/Network/GULNetworkURLSession.m
+++ b/GoogleUtilities/Network/GULNetworkURLSession.m
@@ -92,7 +92,8 @@
 /// Sends an async POST request using NSURLSession for iOS >= 7.0, and returns an ID of the
 /// connection.
 - (NSString *)sessionIDFromAsyncPOSTRequest:(NSURLRequest *)request
-                          completionHandler:(GULNetworkURLSessionCompletionHandler)handler  API_AVAILABLE(ios(7.0)) {
+                          completionHandler:(GULNetworkURLSessionCompletionHandler)handler
+    API_AVAILABLE(ios(7.0)) {
   // NSURLSessionUploadTask does not work with NSData in the background.
   // To avoid this issue, write the data to a temporary file to upload it.
   // Make a temporary file with the data subset.
@@ -169,7 +170,8 @@
 
 /// Sends an async GET request using NSURLSession for iOS >= 7.0, and returns an ID of the session.
 - (NSString *)sessionIDFromAsyncGETRequest:(NSURLRequest *)request
-                         completionHandler:(GULNetworkURLSessionCompletionHandler)handler  API_AVAILABLE(ios(7.0)) {
+                         completionHandler:(GULNetworkURLSessionCompletionHandler)handler
+    API_AVAILABLE(ios(7.0)) {
   if (_backgroundNetworkEnabled) {
     _sessionConfig = [self backgroundSessionConfigWithSessionID:_sessionID];
   } else {
@@ -215,7 +217,7 @@
 /// be called with the downloaded data.
 - (void)URLSession:(NSURLSession *)session
                  downloadTask:(NSURLSessionDownloadTask *)task
-didFinishDownloadingToURL:(NSURL *)url  API_AVAILABLE(ios(7.0)){
+    didFinishDownloadingToURL:(NSURL *)url API_AVAILABLE(ios(7.0)) {
   if (!url.path) {
     [_loggerDelegate
         GULNetwork_logWithLevel:kGULNetworkLogLevelError
@@ -238,7 +240,8 @@ didFinishDownloadingToURL:(NSURL *)url  API_AVAILABLE(ios(7.0)){
 }
 
 #if TARGET_OS_IOS || TARGET_OS_TV
-- (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session  API_AVAILABLE(ios(7.0)){
+- (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session
+    API_AVAILABLE(ios(7.0)) {
   [_loggerDelegate GULNetwork_logWithLevel:kGULNetworkLogLevelDebug
                                messageCode:kGULNetworkMessageCodeURLSession003
                                    message:@"Background session finished"
@@ -249,7 +252,7 @@ didFinishDownloadingToURL:(NSURL *)url  API_AVAILABLE(ios(7.0)){
 
 - (void)URLSession:(NSURLSession *)session
                     task:(NSURLSessionTask *)task
-didCompleteWithError:(NSError *)error  API_AVAILABLE(ios(7.0)){
+    didCompleteWithError:(NSError *)error API_AVAILABLE(ios(7.0)) {
   // Avoid any chance of recursive behavior leading to it being used repeatedly.
   GULNetworkURLSessionCompletionHandler handler = _completionHandler;
   _completionHandler = nil;
@@ -284,7 +287,8 @@ didCompleteWithError:(NSError *)error  API_AVAILABLE(ios(7.0)){
                    task:(NSURLSessionTask *)task
     didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
       completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition,
-                                  NSURLCredential *credential))completionHandler  API_AVAILABLE(ios(7.0)){
+                                  NSURLCredential *credential))completionHandler
+    API_AVAILABLE(ios(7.0)) {
   // The handling is modeled after GTMSessionFetcher.
   if ([challenge.protectionSpace.authenticationMethod
           isEqualToString:NSURLAuthenticationMethodServerTrust]) {
@@ -427,7 +431,8 @@ didCompleteWithError:(NSError *)error  API_AVAILABLE(ios(7.0)){
 }
 
 /// Creates a background session configuration with the session ID using the supported method.
-- (NSURLSessionConfiguration *)backgroundSessionConfigWithSessionID:(NSString *)sessionID  API_AVAILABLE(ios(7.0)){
+- (NSURLSessionConfiguration *)backgroundSessionConfigWithSessionID:(NSString *)sessionID
+    API_AVAILABLE(ios(7.0)) {
 #if (TARGET_OS_OSX && defined(MAC_OS_X_VERSION_10_10) &&         \
      MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_10) || \
     TARGET_OS_TV ||                                              \
@@ -619,7 +624,7 @@ didCompleteWithError:(NSError *)error  API_AVAILABLE(ios(7.0)){
                           task:(NSURLSessionTask *)task
     willPerformHTTPRedirection:(NSHTTPURLResponse *)response
                     newRequest:(NSURLRequest *)request
- completionHandler:(void (^)(NSURLRequest *))completionHandler  API_AVAILABLE(ios(7.0)){
+             completionHandler:(void (^)(NSURLRequest *))completionHandler API_AVAILABLE(ios(7.0)) {
   NSArray *nonAllowedRedirectionCodes = @[
     @(kGULNetworkHTTPStatusCodeFound), @(kGULNetworkHTTPStatusCodeMovedPermanently),
     @(kGULNetworkHTTPStatusCodeMovedTemporarily), @(kGULNetworkHTTPStatusCodeMultipleChoices)
@@ -662,7 +667,7 @@ didCompleteWithError:(NSError *)error  API_AVAILABLE(ios(7.0)){
 }
 
 - (void)populateSessionConfig:(NSURLSessionConfiguration *)sessionConfig
-                  withRequest:(NSURLRequest *)request  API_AVAILABLE(ios(7.0)) {
+                  withRequest:(NSURLRequest *)request API_AVAILABLE(ios(7.0)) {
   sessionConfig.HTTPAdditionalHeaders = request.allHTTPHeaderFields;
   sessionConfig.timeoutIntervalForRequest = request.timeoutInterval;
   sessionConfig.timeoutIntervalForResource = request.timeoutInterval;

--- a/GoogleUtilities/Network/GULNetworkURLSession.m
+++ b/GoogleUtilities/Network/GULNetworkURLSession.m
@@ -29,7 +29,7 @@
   NSString *_sessionID;
 
   /// The session configuration.
-  NSURLSessionConfiguration *_sessionConfig;
+  id _sessionConfig;  // 'NSURLSessionConfiguration' is only available on iOS 7.0 or newer
 
   /// The path to the directory where all temporary files are stored before uploading.
   NSURL *_networkDirectoryURL;
@@ -92,7 +92,7 @@
 /// Sends an async POST request using NSURLSession for iOS >= 7.0, and returns an ID of the
 /// connection.
 - (NSString *)sessionIDFromAsyncPOSTRequest:(NSURLRequest *)request
-                          completionHandler:(GULNetworkURLSessionCompletionHandler)handler {
+                          completionHandler:(GULNetworkURLSessionCompletionHandler)handler  API_AVAILABLE(ios(7.0)) {
   // NSURLSessionUploadTask does not work with NSData in the background.
   // To avoid this issue, write the data to a temporary file to upload it.
   // Make a temporary file with the data subset.
@@ -137,7 +137,7 @@
     // If we cannot write to file, just send it in the foreground.
     _sessionConfig = [NSURLSessionConfiguration defaultSessionConfiguration];
     [self populateSessionConfig:_sessionConfig withRequest:request];
-    _sessionConfig.URLCache = nil;
+    ((NSURLSessionConfiguration *)_sessionConfig).URLCache = nil;
     session = [NSURLSession sessionWithConfiguration:_sessionConfig
                                             delegate:self
                                        delegateQueue:[NSOperationQueue mainQueue]];
@@ -169,7 +169,7 @@
 
 /// Sends an async GET request using NSURLSession for iOS >= 7.0, and returns an ID of the session.
 - (NSString *)sessionIDFromAsyncGETRequest:(NSURLRequest *)request
-                         completionHandler:(GULNetworkURLSessionCompletionHandler)handler {
+                         completionHandler:(GULNetworkURLSessionCompletionHandler)handler  API_AVAILABLE(ios(7.0)) {
   if (_backgroundNetworkEnabled) {
     _sessionConfig = [self backgroundSessionConfigWithSessionID:_sessionID];
   } else {
@@ -179,7 +179,7 @@
   [self populateSessionConfig:_sessionConfig withRequest:request];
 
   // Do not cache the GET request.
-  _sessionConfig.URLCache = nil;
+  ((NSURLSessionConfiguration *)_sessionConfig).URLCache = nil;
 
   NSURLSession *session = [NSURLSession sessionWithConfiguration:_sessionConfig
                                                         delegate:self
@@ -215,7 +215,7 @@
 /// be called with the downloaded data.
 - (void)URLSession:(NSURLSession *)session
                  downloadTask:(NSURLSessionDownloadTask *)task
-    didFinishDownloadingToURL:(NSURL *)url {
+didFinishDownloadingToURL:(NSURL *)url  API_AVAILABLE(ios(7.0)){
   if (!url.path) {
     [_loggerDelegate
         GULNetwork_logWithLevel:kGULNetworkLogLevelError
@@ -238,7 +238,7 @@
 }
 
 #if TARGET_OS_IOS || TARGET_OS_TV
-- (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session {
+- (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session  API_AVAILABLE(ios(7.0)){
   [_loggerDelegate GULNetwork_logWithLevel:kGULNetworkLogLevelDebug
                                messageCode:kGULNetworkMessageCodeURLSession003
                                    message:@"Background session finished"
@@ -249,7 +249,7 @@
 
 - (void)URLSession:(NSURLSession *)session
                     task:(NSURLSessionTask *)task
-    didCompleteWithError:(NSError *)error {
+didCompleteWithError:(NSError *)error  API_AVAILABLE(ios(7.0)){
   // Avoid any chance of recursive behavior leading to it being used repeatedly.
   GULNetworkURLSessionCompletionHandler handler = _completionHandler;
   _completionHandler = nil;
@@ -284,7 +284,7 @@
                    task:(NSURLSessionTask *)task
     didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
       completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition,
-                                  NSURLCredential *credential))completionHandler {
+                                  NSURLCredential *credential))completionHandler  API_AVAILABLE(ios(7.0)){
   // The handling is modeled after GTMSessionFetcher.
   if ([challenge.protectionSpace.authenticationMethod
           isEqualToString:NSURLAuthenticationMethodServerTrust]) {
@@ -427,7 +427,7 @@
 }
 
 /// Creates a background session configuration with the session ID using the supported method.
-- (NSURLSessionConfiguration *)backgroundSessionConfigWithSessionID:(NSString *)sessionID {
+- (NSURLSessionConfiguration *)backgroundSessionConfigWithSessionID:(NSString *)sessionID  API_AVAILABLE(ios(7.0)){
 #if (TARGET_OS_OSX && defined(MAC_OS_X_VERSION_10_10) &&         \
      MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_10) || \
     TARGET_OS_TV ||                                              \
@@ -619,7 +619,7 @@
                           task:(NSURLSessionTask *)task
     willPerformHTTPRedirection:(NSHTTPURLResponse *)response
                     newRequest:(NSURLRequest *)request
-             completionHandler:(void (^)(NSURLRequest *))completionHandler {
+ completionHandler:(void (^)(NSURLRequest *))completionHandler  API_AVAILABLE(ios(7.0)){
   NSArray *nonAllowedRedirectionCodes = @[
     @(kGULNetworkHTTPStatusCodeFound), @(kGULNetworkHTTPStatusCodeMovedPermanently),
     @(kGULNetworkHTTPStatusCodeMovedTemporarily), @(kGULNetworkHTTPStatusCodeMultipleChoices)
@@ -662,7 +662,7 @@
 }
 
 - (void)populateSessionConfig:(NSURLSessionConfiguration *)sessionConfig
-                  withRequest:(NSURLRequest *)request {
+                  withRequest:(NSURLRequest *)request  API_AVAILABLE(ios(7.0)) {
   sessionConfig.HTTPAdditionalHeaders = request.allHTTPHeaderFields;
   sessionConfig.timeoutIntervalForRequest = request.timeoutInterval;
   sessionConfig.timeoutIntervalForResource = request.timeoutInterval;

--- a/GoogleUtilities/Network/GULNetworkURLSession.m
+++ b/GoogleUtilities/Network/GULNetworkURLSession.m
@@ -28,8 +28,11 @@
   /// Session ID generated randomly with a fixed prefix.
   NSString *_sessionID;
 
-  /// The session configuration.
-  id _sessionConfig;  // 'NSURLSessionConfiguration' is only available on iOS 7.0 or newer
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+  /// The session configuration. NSURLSessionConfiguration' is only available on iOS 7.0 or newer.
+  NSURLSessionConfiguration *_sessionConfig;
+#pragma pop
 
   /// The path to the directory where all temporary files are stored before uploading.
   NSURL *_networkDirectoryURL;
@@ -138,7 +141,7 @@
     // If we cannot write to file, just send it in the foreground.
     _sessionConfig = [NSURLSessionConfiguration defaultSessionConfiguration];
     [self populateSessionConfig:_sessionConfig withRequest:request];
-    ((NSURLSessionConfiguration *)_sessionConfig).URLCache = nil;
+    _sessionConfig.URLCache = nil;
     session = [NSURLSession sessionWithConfiguration:_sessionConfig
                                             delegate:self
                                        delegateQueue:[NSOperationQueue mainQueue]];
@@ -181,7 +184,7 @@
   [self populateSessionConfig:_sessionConfig withRequest:request];
 
   // Do not cache the GET request.
-  ((NSURLSessionConfiguration *)_sessionConfig).URLCache = nil;
+  _sessionConfig.URLCache = nil;
 
   NSURLSession *session = [NSURLSession sessionWithConfiguration:_sessionConfig
                                                         delegate:self


### PR DESCRIPTION
Fix #1829.  

If `use_frameworks!` was not included in a Podfile and a static library build is done, Xcode uses the minimum iOS version of 6 to build GoogleUtilities generating several warnings for iOS 7 APIs.  This PR adds `@availability` checks to eliminate the warnings.

Also drop Xcode 8 testing since Xcode 8 doesn't support `@availability` and we dropped pre-Xcode 8 support in July when the AppStore started requiring Xcode 9 for submissions.

There is a client requirement to be installable for iOS 6 despite its functionality gaps.