### PR TITLE
Running Clang Format

### DIFF
--- a/Example/Core/Tests/FIRComponentContainerTest.m
+++ b/Example/Core/Tests/FIRComponentContainerTest.m
@@ -55,7 +55,7 @@
 }
 
 - (void)testComponentsPopulatedOnInit {
-  FIRComponentContainer *container = [self containerWithRegistrants:@ [[FIRTestClass class]]];
+  FIRComponentContainer *container = [self containerWithRegistrants:@[ [FIRTestClass class] ]];
 
   // Verify that the block is stored.
   NSString *protocolName = NSStringFromProtocol(@protocol(FIRTestProtocol));
@@ -66,7 +66,8 @@
 #pragma mark - Caching Tests
 
 - (void)testInstanceCached {
-  FIRComponentContainer *container = [self containerWithRegistrants:@ [[FIRTestClassCached class]]];
+  FIRComponentContainer *container =
+      [self containerWithRegistrants:@[ [FIRTestClassCached class] ]];
 
   // Fetch an instance for `FIRTestProtocolCached`, then fetch it again to assert it's cached.
   id<FIRTestProtocolCached> instance1 = FIR_COMPONENT(FIRTestProtocolCached, container);
@@ -77,7 +78,7 @@
 }
 
 - (void)testInstanceNotCached {
-  FIRComponentContainer *container = [self containerWithRegistrants:@ [[FIRTestClass class]]];
+  FIRComponentContainer *container = [self containerWithRegistrants:@[ [FIRTestClass class] ]];
 
   // Retrieve an instance from the container, then fetch it again and ensure it's not the same
   // instance.
@@ -89,9 +90,9 @@
 }
 
 - (void)testRemoveAllCachedInstances {
-  FIRComponentContainer *container =
-      [self containerWithRegistrants:@ [[FIRTestClass class], [FIRTestClassCached class],
-                                        [FIRTestClassEagerCached class]]];
+  FIRComponentContainer *container = [self containerWithRegistrants:@[
+    [FIRTestClass class], [FIRTestClassCached class], [FIRTestClassEagerCached class]
+  ]];
 
   // Retrieve an instance of FIRTestClassCached to ensure it's cached.
   id<FIRTestProtocolCached> cachedInstance1 = FIR_COMPONENT(FIRTestProtocolCached, container);
@@ -120,7 +121,7 @@
   // implementation for `FIRTestProtocolEagerCached` and requires eager instantiation as well as
   // caching so the test can verify it was eagerly instantiated.
   FIRComponentContainer *container =
-      [self containerWithRegistrants:@ [[FIRTestClassEagerCached class]]];
+      [self containerWithRegistrants:@[ [FIRTestClassEagerCached class] ]];
   NSString *protocolName = NSStringFromProtocol(@protocol(FIRTestProtocolEagerCached));
   XCTAssertNotNil(container.cachedInstances[protocolName]);
 }
@@ -134,7 +135,7 @@
   // change in the future.
   // TODO(wilsonryan): Assert that the log gets called warning that it's already been registered.
   FIRComponentContainer *container =
-      [self containerWithRegistrants:@ [[FIRTestClass class], [FIRTestClassDuplicate class]]];
+      [self containerWithRegistrants:@[ [FIRTestClass class], [FIRTestClassDuplicate class] ]];
   XCTAssert(container.components.count == 1);
 }
 

--- a/Example/Core/Tests/FIROptionsTest.m
+++ b/Example/Core/Tests/FIROptionsTest.m
@@ -288,7 +288,7 @@ extern NSString *const kFIRLibraryVersionID;
     kFIRIsMeasurementEnabled : @YES
   };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
-  mainDictionary = @{kFIRIsAnalyticsCollectionDeactivated : @NO};
+  mainDictionary = @{ kFIRIsAnalyticsCollectionDeactivated : @NO };
   expectedAnalyticsOptions = @{
     kFIRIsAnalyticsCollectionDeactivated : @NO,  // override
     kFIRIsAnalyticsCollectionEnabled : @YES,
@@ -303,7 +303,7 @@ extern NSString *const kFIRLibraryVersionID;
     kFIRIsMeasurementEnabled : @YES
   };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
-  mainDictionary = @{kFIRIsAnalyticsCollectionEnabled : @NO};
+  mainDictionary = @{ kFIRIsAnalyticsCollectionEnabled : @NO };
   expectedAnalyticsOptions = @{
     kFIRIsAnalyticsCollectionDeactivated : @YES,
     kFIRIsAnalyticsCollectionEnabled : @NO,  // override
@@ -318,7 +318,7 @@ extern NSString *const kFIRLibraryVersionID;
     kFIRIsMeasurementEnabled : @YES
   };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
-  mainDictionary = @{kFIRIsMeasurementEnabled : @NO};
+  mainDictionary = @{ kFIRIsMeasurementEnabled : @NO };
   expectedAnalyticsOptions = @{
     kFIRIsAnalyticsCollectionDeactivated : @YES,
     kFIRIsAnalyticsCollectionEnabled : @YES,
@@ -509,25 +509,25 @@ extern NSString *const kFIRLibraryVersionID;
   XCTAssertFalse([options isAnalyticsCollectionExpicitlySet]);
 
   // Test deactivation flag.
-  optionsDictionary = @{kFIRIsAnalyticsCollectionDeactivated : @YES};
+  optionsDictionary = @{ kFIRIsAnalyticsCollectionDeactivated : @YES };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:@{}];
   XCTAssertTrue([options isAnalyticsCollectionExpicitlySet]);
 
   // If "deactivated" == NO, that doesn't mean it's explicitly set / enabled so it should be treated
   // as if it's not set.
-  optionsDictionary = @{kFIRIsAnalyticsCollectionDeactivated : @NO};
+  optionsDictionary = @{ kFIRIsAnalyticsCollectionDeactivated : @NO };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:@{}];
   XCTAssertFalse([options isAnalyticsCollectionExpicitlySet]);
 
   // Test the collection enabled flag.
-  optionsDictionary = @{kFIRIsAnalyticsCollectionEnabled : @YES};
+  optionsDictionary = @{ kFIRIsAnalyticsCollectionEnabled : @YES };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:@{}];
   XCTAssertTrue([options isAnalyticsCollectionExpicitlySet]);
 
-  optionsDictionary = @{kFIRIsAnalyticsCollectionEnabled : @NO};
+  optionsDictionary = @{ kFIRIsAnalyticsCollectionEnabled : @NO };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:@{}];
   XCTAssertTrue([options isAnalyticsCollectionExpicitlySet]);
@@ -547,8 +547,8 @@ extern NSString *const kFIRLibraryVersionID;
 
   // For good measure, a combination of all 3 (even if they conflict).
   optionsDictionary =
-      @{kFIRIsAnalyticsCollectionDeactivated : @YES,
-        kFIRIsAnalyticsCollectionEnabled : @YES};
+      @{ kFIRIsAnalyticsCollectionDeactivated : @YES,
+         kFIRIsAnalyticsCollectionEnabled : @YES };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:@{
     kFIRIsMeasurementEnabled : @NO

--- a/Example/Storage/Tests/Unit/FIRStorageMetadataTests.m
+++ b/Example/Storage/Tests/Unit/FIRStorageMetadataTests.m
@@ -253,7 +253,7 @@
 
   NSDictionary *update = [metadata updatedMetadata];
 
-  NSDictionary *expectedUpdate = @{kFIRStorageMetadataCustomMetadata : @{}};
+  NSDictionary *expectedUpdate = @{ kFIRStorageMetadataCustomMetadata : @{} };
   XCTAssertEqualObjects(update, expectedUpdate);
 }
 

--- a/Firebase/Core/Private/FIRAppAssociationRegistration.h
+++ b/Firebase/Core/Private/FIRAppAssociationRegistration.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
         registered for any given host/key pair, and the object shall be created on-the-fly when
         asked for.
  */
-@interface FIRAppAssociationRegistration<ObjectType> : NSObject
+@interface FIRAppAssociationRegistration <ObjectType> : NSObject
 
 /** @fn registeredObjectWithHost:key:creationBlock:
     @brief Retrieves the registered object with a particular host and key.

--- a/Firebase/Core/Private/FIRComponentType.h
+++ b/Firebase/Core/Private/FIRComponentType.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Do not use directly. A placeholder type in order to provide a macro that will warn users of
 /// mis-matched protocols.
 NS_SWIFT_NAME(ComponentType)
-@interface FIRComponentType<__covariant T> : NSObject
+@interface FIRComponentType <__covariant T> : NSObject
 
 /// Do not use directly. A factory method to retrieve an instance that provides a specific
 /// functionality.

--- a/Firebase/InAppMessagingDisplay/Banner/FIDBannerViewController.h
+++ b/Firebase/InAppMessagingDisplay/Banner/FIDBannerViewController.h
@@ -26,10 +26,9 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface FIDBannerViewController : FIDBaseRenderingViewController
 + (FIDBannerViewController *)
-    instantiateViewControllerWithResourceBundle:(NSBundle *)resourceBundle
-                                 displayMessage:(FIRInAppMessagingBannerDisplay *)bannerMessage
-                                displayDelegate:
-                                    (id<FIRInAppMessagingDisplayDelegate>)displayDelegate
-                                    timeFetcher:(id<FIDTimeFetcher>)timeFetcher;
+instantiateViewControllerWithResourceBundle:(NSBundle *)resourceBundle
+                             displayMessage:(FIRInAppMessagingBannerDisplay *)bannerMessage
+                            displayDelegate:(id<FIRInAppMessagingDisplayDelegate>)displayDelegate
+                                timeFetcher:(id<FIDTimeFetcher>)timeFetcher;
 @end
 NS_ASSUME_NONNULL_END

--- a/Firebase/InAppMessagingDisplay/Banner/FIDBannerViewController.m
+++ b/Firebase/InAppMessagingDisplay/Banner/FIDBannerViewController.m
@@ -62,11 +62,10 @@ static const CGFloat kSwipeUpThreshold = -10.0f;
 @implementation FIDBannerViewController
 
 + (FIDBannerViewController *)
-    instantiateViewControllerWithResourceBundle:(NSBundle *)resourceBundle
-                                 displayMessage:(FIRInAppMessagingBannerDisplay *)bannerMessage
-                                displayDelegate:
-                                    (id<FIRInAppMessagingDisplayDelegate>)displayDelegate
-                                    timeFetcher:(id<FIDTimeFetcher>)timeFetcher {
+instantiateViewControllerWithResourceBundle:(NSBundle *)resourceBundle
+                             displayMessage:(FIRInAppMessagingBannerDisplay *)bannerMessage
+                            displayDelegate:(id<FIRInAppMessagingDisplayDelegate>)displayDelegate
+                                timeFetcher:(id<FIDTimeFetcher>)timeFetcher {
   UIStoryboard *storyboard =
       [UIStoryboard storyboardWithName:@"FIRInAppMessageDisplayStoryboard" bundle:resourceBundle];
 

--- a/Firebase/InAppMessagingDisplay/FIRIAMDefaultDisplayImpl.m
+++ b/Firebase/InAppMessagingDisplay/FIRIAMDefaultDisplayImpl.m
@@ -143,10 +143,9 @@
   });
 }
 
-+ (void)displayImageOnlyViewWithMessageDefinition:
-            (FIRInAppMessagingImageOnlyDisplay *)imageOnlyMessage
-                                  displayDelegate:
-                                      (id<FIRInAppMessagingDisplayDelegate>)displayDelegate {
++ (void)
+displayImageOnlyViewWithMessageDefinition:(FIRInAppMessagingImageOnlyDisplay *)imageOnlyMessage
+                          displayDelegate:(id<FIRInAppMessagingDisplayDelegate>)displayDelegate {
   NSBundle *resourceBundle = [self getViewResourceBundle];
 
   if (resourceBundle == nil) {

--- a/Firebase/InAppMessagingDisplay/ImageOnly/FIDImageOnlyViewController.h
+++ b/Firebase/InAppMessagingDisplay/ImageOnly/FIDImageOnlyViewController.h
@@ -25,11 +25,9 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface FIDImageOnlyViewController : FIDBaseRenderingViewController
 + (FIDImageOnlyViewController *)
-    instantiateViewControllerWithResourceBundle:(NSBundle *)resourceBundle
-                                 displayMessage:
-                                     (FIRInAppMessagingImageOnlyDisplay *)imageOnlyMessage
-                                displayDelegate:
-                                    (id<FIRInAppMessagingDisplayDelegate>)displayDelegate
-                                    timeFetcher:(id<FIDTimeFetcher>)timeFetcher;
+instantiateViewControllerWithResourceBundle:(NSBundle *)resourceBundle
+                             displayMessage:(FIRInAppMessagingImageOnlyDisplay *)imageOnlyMessage
+                            displayDelegate:(id<FIRInAppMessagingDisplayDelegate>)displayDelegate
+                                timeFetcher:(id<FIDTimeFetcher>)timeFetcher;
 @end
 NS_ASSUME_NONNULL_END

--- a/Firebase/InAppMessagingDisplay/ImageOnly/FIDImageOnlyViewController.m
+++ b/Firebase/InAppMessagingDisplay/ImageOnly/FIDImageOnlyViewController.m
@@ -31,12 +31,10 @@
 @implementation FIDImageOnlyViewController
 
 + (FIDImageOnlyViewController *)
-    instantiateViewControllerWithResourceBundle:(NSBundle *)resourceBundle
-                                 displayMessage:
-                                     (FIRInAppMessagingImageOnlyDisplay *)imageOnlyMessage
-                                displayDelegate:
-                                    (id<FIRInAppMessagingDisplayDelegate>)displayDelegate
-                                    timeFetcher:(id<FIDTimeFetcher>)timeFetcher {
+instantiateViewControllerWithResourceBundle:(NSBundle *)resourceBundle
+                             displayMessage:(FIRInAppMessagingImageOnlyDisplay *)imageOnlyMessage
+                            displayDelegate:(id<FIRInAppMessagingDisplayDelegate>)displayDelegate
+                                timeFetcher:(id<FIDTimeFetcher>)timeFetcher {
   UIStoryboard *storyboard =
       [UIStoryboard storyboardWithName:@"FIRInAppMessageDisplayStoryboard" bundle:resourceBundle];
 

--- a/Firebase/InAppMessagingDisplay/Modal/FIDModalViewController.h
+++ b/Firebase/InAppMessagingDisplay/Modal/FIDModalViewController.h
@@ -24,10 +24,9 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface FIDModalViewController : FIDBaseRenderingViewController
 + (FIDModalViewController *)
-    instantiateViewControllerWithResourceBundle:(NSBundle *)resourceBundle
-                                 displayMessage:(FIRInAppMessagingModalDisplay *)modalMessage
-                                displayDelegate:
-                                    (id<FIRInAppMessagingDisplayDelegate>)displayDelegate
-                                    timeFetcher:(id<FIDTimeFetcher>)timeFetcher;
+instantiateViewControllerWithResourceBundle:(NSBundle *)resourceBundle
+                             displayMessage:(FIRInAppMessagingModalDisplay *)modalMessage
+                            displayDelegate:(id<FIRInAppMessagingDisplayDelegate>)displayDelegate
+                                timeFetcher:(id<FIDTimeFetcher>)timeFetcher;
 @end
 NS_ASSUME_NONNULL_END

--- a/Firebase/InAppMessagingDisplay/Modal/FIDModalViewController.m
+++ b/Firebase/InAppMessagingDisplay/Modal/FIDModalViewController.m
@@ -71,11 +71,10 @@ static CGFloat LandScapePaddingBetweenImageAndTextColumn = 24;
 @implementation FIDModalViewController
 
 + (FIDModalViewController *)
-    instantiateViewControllerWithResourceBundle:(NSBundle *)resourceBundle
-                                 displayMessage:(FIRInAppMessagingModalDisplay *)modalMessage
-                                displayDelegate:
-                                    (id<FIRInAppMessagingDisplayDelegate>)displayDelegate
-                                    timeFetcher:(id<FIDTimeFetcher>)timeFetcher {
+instantiateViewControllerWithResourceBundle:(NSBundle *)resourceBundle
+                             displayMessage:(FIRInAppMessagingModalDisplay *)modalMessage
+                            displayDelegate:(id<FIRInAppMessagingDisplayDelegate>)displayDelegate
+                                timeFetcher:(id<FIDTimeFetcher>)timeFetcher {
   UIStoryboard *storyboard =
       [UIStoryboard storyboardWithName:@"FIRInAppMessageDisplayStoryboard" bundle:resourceBundle];
 

--- a/Firebase/Storage/FIRStorageReference.m
+++ b/Firebase/Storage/FIRStorageReference.m
@@ -272,9 +272,10 @@
             handler:^(FIRStorageTaskSnapshot *_Nonnull snapshot) {
               FIRStorageDownloadTask *task = snapshot.task;
               if (task.progress.totalUnitCount > size || task.progress.completedUnitCount > size) {
-                NSDictionary *infoDictionary =
-                    @{@"totalSize" : @(task.progress.totalUnitCount),
-                      @"maxAllowedSize" : @(size)};
+                NSDictionary *infoDictionary = @{
+                  @"totalSize" : @(task.progress.totalUnitCount),
+                  @"maxAllowedSize" : @(size)
+                };
                 NSError *error =
                     [FIRStorageErrors errorWithCode:FIRStorageErrorCodeDownloadSizeExceeded
                                      infoDictionary:infoDictionary];

--- a/Firestore/Example/Tests/API/FIRDocumentSnapshotTests.mm
+++ b/Firestore/Example/Tests/API/FIRDocumentSnapshotTests.mm
@@ -28,14 +28,14 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation FIRDocumentSnapshotTests
 
 - (void)testEquals {
-  FIRDocumentSnapshot *base = FSTTestDocSnapshot("rooms/foo", 1, @{@"a" : @1}, NO, NO);
-  FIRDocumentSnapshot *baseDup = FSTTestDocSnapshot("rooms/foo", 1, @{@"a" : @1}, NO, NO);
+  FIRDocumentSnapshot *base = FSTTestDocSnapshot("rooms/foo", 1, @{ @"a" : @1 }, NO, NO);
+  FIRDocumentSnapshot *baseDup = FSTTestDocSnapshot("rooms/foo", 1, @{ @"a" : @1 }, NO, NO);
   FIRDocumentSnapshot *nilData = FSTTestDocSnapshot("rooms/foo", 1, nil, NO, NO);
   FIRDocumentSnapshot *nilDataDup = FSTTestDocSnapshot("rooms/foo", 1, nil, NO, NO);
-  FIRDocumentSnapshot *differentPath = FSTTestDocSnapshot("rooms/bar", 1, @{@"a" : @1}, NO, NO);
-  FIRDocumentSnapshot *differentData = FSTTestDocSnapshot("rooms/bar", 1, @{@"b" : @1}, NO, NO);
-  FIRDocumentSnapshot *hasMutations = FSTTestDocSnapshot("rooms/bar", 1, @{@"a" : @1}, YES, NO);
-  FIRDocumentSnapshot *fromCache = FSTTestDocSnapshot("rooms/bar", 1, @{@"a" : @1}, NO, YES);
+  FIRDocumentSnapshot *differentPath = FSTTestDocSnapshot("rooms/bar", 1, @{ @"a" : @1 }, NO, NO);
+  FIRDocumentSnapshot *differentData = FSTTestDocSnapshot("rooms/bar", 1, @{ @"b" : @1 }, NO, NO);
+  FIRDocumentSnapshot *hasMutations = FSTTestDocSnapshot("rooms/bar", 1, @{ @"a" : @1 }, YES, NO);
+  FIRDocumentSnapshot *fromCache = FSTTestDocSnapshot("rooms/bar", 1, @{ @"a" : @1 }, NO, YES);
   XCTAssertEqualObjects(base, baseDup);
   XCTAssertEqualObjects(nilData, nilDataDup);
   XCTAssertNotEqualObjects(base, nilData);

--- a/Firestore/Example/Tests/API/FIRQuerySnapshotTests.mm
+++ b/Firestore/Example/Tests/API/FIRQuerySnapshotTests.mm
@@ -50,15 +50,16 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation FIRQuerySnapshotTests
 
 - (void)testEquals {
-  FIRQuerySnapshot *foo = FSTTestQuerySnapshot("foo", @{}, @{@"a" : @{@"a" : @1}}, YES, NO);
-  FIRQuerySnapshot *fooDup = FSTTestQuerySnapshot("foo", @{}, @{@"a" : @{@"a" : @1}}, YES, NO);
+  FIRQuerySnapshot *foo = FSTTestQuerySnapshot("foo", @{}, @{ @"a" : @{@"a" : @1} }, YES, NO);
+  FIRQuerySnapshot *fooDup = FSTTestQuerySnapshot("foo", @{}, @{ @"a" : @{@"a" : @1} }, YES, NO);
   FIRQuerySnapshot *differentPath = FSTTestQuerySnapshot("bar", @{},
-                                                         @{@"a" : @{@"a" : @1}}, YES, NO);
+                                                         @{ @"a" : @{@"a" : @1} }, YES, NO);
   FIRQuerySnapshot *differentDoc = FSTTestQuerySnapshot("foo",
-                                                        @{@"a" : @{@"b" : @1}}, @{}, YES, NO);
+                                                        @{ @"a" : @{@"b" : @1} }, @{}, YES, NO);
   FIRQuerySnapshot *noPendingWrites = FSTTestQuerySnapshot("foo", @{},
-                                                           @{@"a" : @{@"a" : @1}}, NO, NO);
-  FIRQuerySnapshot *fromCache = FSTTestQuerySnapshot("foo", @{}, @{@"a" : @{@"a" : @1}}, YES, YES);
+                                                           @{ @"a" : @{@"a" : @1} }, NO, NO);
+  FIRQuerySnapshot *fromCache = FSTTestQuerySnapshot("foo", @{},
+                                                     @{ @"a" : @{@"a" : @1} }, YES, YES);
   XCTAssertEqualObjects(foo, fooDup);
   XCTAssertNotEqualObjects(foo, differentPath);
   XCTAssertNotEqualObjects(foo, differentDoc);

--- a/Firestore/Example/Tests/Core/FSTQueryTests.mm
+++ b/Firestore/Example/Tests/Core/FSTQueryTests.mm
@@ -129,10 +129,10 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQuery *query2 =
       [FSTTestQuery("collection") queryByAddingFilter:FSTTestFilter("sort", @"<=", @(2))];
 
-  FSTDocument *doc1 = FSTTestDoc("collection/1", 0, @{@"sort" : @1}, NO);
-  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{@"sort" : @2}, NO);
-  FSTDocument *doc3 = FSTTestDoc("collection/3", 0, @{@"sort" : @3}, NO);
-  FSTDocument *doc4 = FSTTestDoc("collection/4", 0, @{@"sort" : @NO}, NO);
+  FSTDocument *doc1 = FSTTestDoc("collection/1", 0, @{ @"sort" : @1 }, NO);
+  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{ @"sort" : @2 }, NO);
+  FSTDocument *doc3 = FSTTestDoc("collection/3", 0, @{ @"sort" : @3 }, NO);
+  FSTDocument *doc4 = FSTTestDoc("collection/4", 0, @{ @"sort" : @NO }, NO);
   FSTDocument *doc5 = FSTTestDoc("collection/5", 0, @{@"sort" : @"string"}, NO);
   FSTDocument *doc6 = FSTTestDoc("collection/6", 0, @{}, NO);
 
@@ -156,25 +156,25 @@ NS_ASSUME_NONNULL_BEGIN
       queryByAddingFilter:FSTTestFilter("array", @"array_contains", @42)];
 
   // not an array.
-  FSTDocument *doc = FSTTestDoc("collection/1", 0, @{@"array" : @1}, NO);
+  FSTDocument *doc = FSTTestDoc("collection/1", 0, @{ @"array" : @1 }, NO);
   XCTAssertFalse([query matchesDocument:doc]);
 
   // empty array.
-  doc = FSTTestDoc("collection/1", 0, @{@"array" : @[]}, NO);
+  doc = FSTTestDoc("collection/1", 0, @{ @"array" : @[] }, NO);
   XCTAssertFalse([query matchesDocument:doc]);
 
   // array without element (and make sure it doesn't match in a nested field or a different field).
   doc = FSTTestDoc(
       "collection/1", 0,
-      @{@"array" : @[ @41, @"42",
-                      @{@"a" : @42,
-                        @"b" : @[ @42 ]} ],
-        @"different" : @[ @42 ]},
+      @{ @"array" : @[ @41, @"42",
+                       @{ @"a" : @42,
+                          @"b" : @[ @42 ] } ],
+         @"different" : @[ @42 ] },
       NO);
   XCTAssertFalse([query matchesDocument:doc]);
 
   // array with element.
-  doc = FSTTestDoc("collection/1", 0, @{@"array" : @[ @1, @"2", @42, @{@"a" : @1} ]}, NO);
+  doc = FSTTestDoc("collection/1", 0, @{ @"array" : @[ @1, @"2", @42, @{ @"a" : @1 } ] }, NO);
   XCTAssertTrue([query matchesDocument:doc]);
 }
 
@@ -182,23 +182,23 @@ NS_ASSUME_NONNULL_BEGIN
   // Search for arrays containing the object { a: [42] }
   FSTQuery *query =
       [FSTTestQuery("collection") queryByAddingFilter:FSTTestFilter("array", @"array_contains",
-                                                                    @{@"a" : @[ @42 ]})];
+                                                                    @{ @"a" : @[ @42 ] })];
 
   // array without element.
   FSTDocument *doc = FSTTestDoc("collection/1", 0, @{
     @"array" : @[
-      @{@"a" : @42},
-      @{@"a" : @[ @42, @43 ]},
-      @{@"b" : @[ @42 ]},
-      @{@"a" : @[ @42 ],
-        @"b" : @42}
+      @{ @"a" : @42 },
+      @{ @"a" : @[ @42, @43 ] },
+      @{ @"b" : @[ @42 ] },
+      @{ @"a" : @[ @42 ],
+         @"b" : @42 }
     ]
   },
                                 NO);
   XCTAssertFalse([query matchesDocument:doc]);
 
   // array with element.
-  doc = FSTTestDoc("collection/1", 0, @{@"array" : @[ @1, @"2", @42, @{@"a" : @[ @42 ]} ]}, NO);
+  doc = FSTTestDoc("collection/1", 0, @{ @"array" : @[ @1, @"2", @42, @{ @"a" : @[ @42 ] } ] }, NO);
   XCTAssertTrue([query matchesDocument:doc]);
 }
 
@@ -206,9 +206,9 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQuery *query =
       [FSTTestQuery("collection") queryByAddingFilter:FSTTestFilter("sort", @"==", [NSNull null])];
   FSTDocument *doc1 = FSTTestDoc("collection/1", 0, @{@"sort" : [NSNull null]}, NO);
-  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{@"sort" : @2}, NO);
-  FSTDocument *doc3 = FSTTestDoc("collection/2", 0, @{@"sort" : @3.1}, NO);
-  FSTDocument *doc4 = FSTTestDoc("collection/4", 0, @{@"sort" : @NO}, NO);
+  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{ @"sort" : @2 }, NO);
+  FSTDocument *doc3 = FSTTestDoc("collection/2", 0, @{ @"sort" : @3.1 }, NO);
+  FSTDocument *doc4 = FSTTestDoc("collection/4", 0, @{ @"sort" : @NO }, NO);
   FSTDocument *doc5 = FSTTestDoc("collection/5", 0, @{@"sort" : @"string"}, NO);
 
   XCTAssertTrue([query matchesDocument:doc1]);
@@ -221,10 +221,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testNanFilter {
   FSTQuery *query =
       [FSTTestQuery("collection") queryByAddingFilter:FSTTestFilter("sort", @"==", @(NAN))];
-  FSTDocument *doc1 = FSTTestDoc("collection/1", 0, @{@"sort" : @(NAN)}, NO);
-  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{@"sort" : @2}, NO);
-  FSTDocument *doc3 = FSTTestDoc("collection/2", 0, @{@"sort" : @3.1}, NO);
-  FSTDocument *doc4 = FSTTestDoc("collection/4", 0, @{@"sort" : @NO}, NO);
+  FSTDocument *doc1 = FSTTestDoc("collection/1", 0, @{ @"sort" : @(NAN) }, NO);
+  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{ @"sort" : @2 }, NO);
+  FSTDocument *doc3 = FSTTestDoc("collection/2", 0, @{ @"sort" : @3.1 }, NO);
+  FSTDocument *doc4 = FSTTestDoc("collection/4", 0, @{ @"sort" : @NO }, NO);
   FSTDocument *doc5 = FSTTestDoc("collection/5", 0, @{@"sort" : @"string"}, NO);
 
   XCTAssertTrue([query matchesDocument:doc1]);
@@ -240,13 +240,13 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQuery *query2 =
       [FSTTestQuery("collection") queryByAddingFilter:FSTTestFilter("sort", @">=", @(2))];
 
-  FSTDocument *doc1 = FSTTestDoc("collection/1", 0, @{@"sort" : @2}, NO);
-  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{@"sort" : @[]}, NO);
-  FSTDocument *doc3 = FSTTestDoc("collection/3", 0, @{@"sort" : @[ @1 ]}, NO);
-  FSTDocument *doc4 = FSTTestDoc("collection/4", 0, @{@"sort" : @{@"foo" : @2}}, NO);
-  FSTDocument *doc5 = FSTTestDoc("collection/5", 0, @{@"sort" : @{@"foo" : @"bar"}}, NO);
-  FSTDocument *doc6 = FSTTestDoc("collection/6", 0, @{@"sort" : @{}}, NO);  // no sort field
-  FSTDocument *doc7 = FSTTestDoc("collection/7", 0, @{@"sort" : @[ @3, @1 ]}, NO);
+  FSTDocument *doc1 = FSTTestDoc("collection/1", 0, @{ @"sort" : @2 }, NO);
+  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{ @"sort" : @[] }, NO);
+  FSTDocument *doc3 = FSTTestDoc("collection/3", 0, @{ @"sort" : @[ @1 ] }, NO);
+  FSTDocument *doc4 = FSTTestDoc("collection/4", 0, @{ @"sort" : @{@"foo" : @2} }, NO);
+  FSTDocument *doc5 = FSTTestDoc("collection/5", 0, @{ @"sort" : @{@"foo" : @"bar"} }, NO);
+  FSTDocument *doc6 = FSTTestDoc("collection/6", 0, @{ @"sort" : @{} }, NO);  // no sort field
+  FSTDocument *doc7 = FSTTestDoc("collection/7", 0, @{ @"sort" : @[ @3, @1 ] }, NO);
 
   XCTAssertTrue([query1 matchesDocument:doc1]);
   XCTAssertFalse([query1 matchesDocument:doc2]);
@@ -270,11 +270,11 @@ NS_ASSUME_NONNULL_BEGIN
       queryByAddingSortOrder:[FSTSortOrder sortOrderWithFieldPath:testutil::Field("sort")
                                                         ascending:YES]];
 
-  FSTDocument *doc1 = FSTTestDoc("collection/1", 0, @{@"sort" : @2}, NO);
-  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{@"sort" : @[]}, NO);
-  FSTDocument *doc3 = FSTTestDoc("collection/3", 0, @{@"sort" : @[ @1 ]}, NO);
-  FSTDocument *doc4 = FSTTestDoc("collection/4", 0, @{@"sort" : @{@"foo" : @2}}, NO);
-  FSTDocument *doc5 = FSTTestDoc("collection/5", 0, @{@"sort" : @{@"foo" : @"bar"}}, NO);
+  FSTDocument *doc1 = FSTTestDoc("collection/1", 0, @{ @"sort" : @2 }, NO);
+  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{ @"sort" : @[] }, NO);
+  FSTDocument *doc3 = FSTTestDoc("collection/3", 0, @{ @"sort" : @[ @1 ] }, NO);
+  FSTDocument *doc4 = FSTTestDoc("collection/4", 0, @{ @"sort" : @{@"foo" : @2} }, NO);
+  FSTDocument *doc5 = FSTTestDoc("collection/5", 0, @{ @"sort" : @{@"foo" : @"bar"} }, NO);
   FSTDocument *doc6 = FSTTestDoc("collection/6", 0, @{}, NO);
 
   XCTAssertTrue([query1 matchesDocument:doc1]);
@@ -287,7 +287,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testFiltersBasedOnArrayValue {
   FSTQuery *baseQuery = FSTTestQuery("collection");
-  FSTDocument *doc1 = FSTTestDoc("collection/doc", 0, @{@"tags" : @[ @"foo", @1, @YES ]}, NO);
+  FSTDocument *doc1 = FSTTestDoc("collection/doc", 0, @{ @"tags" : @[ @"foo", @1, @YES ] }, NO);
 
   NSArray<FSTFilter *> *matchingFilters = @[ FSTTestFilter("tags", @"==", @[ @"foo", @1, @YES ]) ];
 
@@ -310,19 +310,19 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQuery *baseQuery = FSTTestQuery("collection");
   FSTDocument *doc1 =
       FSTTestDoc("collection/doc", 0,
-                 @{@"tags" : @{@"foo" : @"foo", @"a" : @0, @"b" : @YES, @"c" : @(NAN)}}, NO);
+                 @{ @"tags" : @{@"foo" : @"foo", @"a" : @0, @"b" : @YES, @"c" : @(NAN)} }, NO);
 
   NSArray<FSTFilter *> *matchingFilters = @[
     FSTTestFilter("tags", @"==",
-                  @{@"foo" : @"foo",
-                    @"a" : @0,
-                    @"b" : @YES,
-                    @"c" : @(NAN)}),
+                  @{ @"foo" : @"foo",
+                     @"a" : @0,
+                     @"b" : @YES,
+                     @"c" : @(NAN) }),
     FSTTestFilter("tags", @"==",
-                  @{@"b" : @YES,
-                    @"a" : @0,
-                    @"foo" : @"foo",
-                    @"c" : @(NAN)}),
+                  @{ @"b" : @YES,
+                     @"a" : @0,
+                     @"foo" : @"foo",
+                     @"c" : @(NAN) }),
     FSTTestFilter("tags.foo", @"==", @"foo")
   ];
 

--- a/Firestore/Example/Tests/Core/FSTViewTests.mm
+++ b/Firestore/Example/Tests/Core/FSTViewTests.mm
@@ -136,11 +136,11 @@ NS_ASSUME_NONNULL_BEGIN
   query = [query queryByAddingFilter:filter];
 
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
-  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/1", 0, @{@"sort" : @1}, NO);
-  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/2", 0, @{@"sort" : @2}, NO);
-  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/3", 0, @{@"sort" : @3}, NO);
+  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/1", 0, @{ @"sort" : @1 }, NO);
+  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/2", 0, @{ @"sort" : @2 }, NO);
+  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/3", 0, @{ @"sort" : @3 }, NO);
   FSTDocument *doc4 = FSTTestDoc("rooms/eros/messages/4", 0, @{}, NO);  // no sort, no match
-  FSTDocument *doc5 = FSTTestDoc("rooms/eros/messages/5", 0, @{@"sort" : @1}, NO);
+  FSTDocument *doc5 = FSTTestDoc("rooms/eros/messages/5", 0, @{ @"sort" : @1 }, NO);
 
   FSTViewSnapshot *snapshot = FSTTestApplyChanges(view, @[ doc1, doc2, doc3, doc4, doc5 ], nil);
 
@@ -168,9 +168,9 @@ NS_ASSUME_NONNULL_BEGIN
   query = [query queryByAddingFilter:filter];
 
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
-  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/1", 0, @{@"sort" : @1}, NO);
-  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/2", 0, @{@"sort" : @3}, NO);
-  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/3", 0, @{@"sort" : @2}, NO);
+  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/1", 0, @{ @"sort" : @1 }, NO);
+  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/2", 0, @{ @"sort" : @3 }, NO);
+  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/3", 0, @{ @"sort" : @2 }, NO);
   FSTDocument *doc4 = FSTTestDoc("rooms/eros/messages/4", 0, @{}, NO);
 
   FSTViewSnapshot *snapshot = FSTTestApplyChanges(view, @[ doc1, doc2, doc3, doc4 ], nil);
@@ -179,9 +179,9 @@ NS_ASSUME_NONNULL_BEGIN
 
   XCTAssertEqualObjects(snapshot.documents.arrayValue, (@[ doc1, doc3 ]));
 
-  FSTDocument *newDoc2 = FSTTestDoc("rooms/eros/messages/2", 1, @{@"sort" : @2}, NO);
-  FSTDocument *newDoc3 = FSTTestDoc("rooms/eros/messages/3", 1, @{@"sort" : @3}, NO);
-  FSTDocument *newDoc4 = FSTTestDoc("rooms/eros/messages/4", 1, @{@"sort" : @0}, NO);
+  FSTDocument *newDoc2 = FSTTestDoc("rooms/eros/messages/2", 1, @{ @"sort" : @2 }, NO);
+  FSTDocument *newDoc3 = FSTTestDoc("rooms/eros/messages/3", 1, @{ @"sort" : @3 }, NO);
+  FSTDocument *newDoc4 = FSTTestDoc("rooms/eros/messages/4", 1, @{ @"sort" : @0 }, NO);
 
   snapshot = FSTTestApplyChanges(view, @[ newDoc2, newDoc3, newDoc4 ], nil);
 
@@ -237,10 +237,10 @@ NS_ASSUME_NONNULL_BEGIN
   query = [query queryBySettingLimit:2];
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
-  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/1", 0, @{@"num" : @1}, NO);
-  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/2", 0, @{@"num" : @2}, NO);
-  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/3", 0, @{@"num" : @3}, NO);
-  FSTDocument *doc4 = FSTTestDoc("rooms/eros/messages/4", 0, @{@"num" : @4}, NO);
+  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/1", 0, @{ @"num" : @1 }, NO);
+  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/2", 0, @{ @"num" : @2 }, NO);
+  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/3", 0, @{ @"num" : @3 }, NO);
+  FSTDocument *doc4 = FSTTestDoc("rooms/eros/messages/4", 0, @{ @"num" : @4 }, NO);
 
   // initial state
   FSTTestApplyChanges(view, @[ doc1, doc2 ], nil);
@@ -249,7 +249,7 @@ NS_ASSUME_NONNULL_BEGIN
   // doc2 will be modified + removed = removed
   // doc3 will be added
   // doc4 will be added + removed = nothing
-  doc2 = FSTTestDoc("rooms/eros/messages/2", 1, @{@"num" : @5}, NO);
+  doc2 = FSTTestDoc("rooms/eros/messages/2", 1, @{ @"num" : @5 }, NO);
   FSTViewDocumentChanges *viewDocChanges =
       [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc2, doc3, doc4 ])];
   XCTAssertTrue(viewDocChanges.needsRefill);
@@ -378,9 +378,9 @@ NS_ASSUME_NONNULL_BEGIN
       [query queryByAddingSortOrder:[FSTSortOrder sortOrderWithFieldPath:testutil::Field("order")
                                                                ascending:YES]];
   query = [query queryBySettingLimit:2];
-  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{@"order" : @1}, NO);
-  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{@"order" : @2}, NO);
-  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/2", 0, @{@"order" : @3}, NO);
+  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{ @"order" : @1 }, NO);
+  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{ @"order" : @2 }, NO);
+  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/2", 0, @{ @"order" : @3 }, NO);
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   // Start with a full view.
@@ -392,7 +392,7 @@ NS_ASSUME_NONNULL_BEGIN
   [view applyChangesToDocuments:changes];
 
   // Move one of the docs.
-  doc2 = FSTTestDoc("rooms/eros/messages/1", 1, @{@"order" : @2000}, NO);
+  doc2 = FSTTestDoc("rooms/eros/messages/1", 1, @{ @"order" : @2000 }, NO);
   changes = [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc2 ])];
   [self assertDocSet:changes.documentSet containsDocs:@[ doc1, doc2 ]];
   XCTAssertTrue(changes.needsRefill);
@@ -412,11 +412,11 @@ NS_ASSUME_NONNULL_BEGIN
       [query queryByAddingSortOrder:[FSTSortOrder sortOrderWithFieldPath:testutil::Field("order")
                                                                ascending:YES]];
   query = [query queryBySettingLimit:3];
-  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{@"order" : @1}, NO);
-  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{@"order" : @2}, NO);
-  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/2", 0, @{@"order" : @3}, NO);
-  FSTDocument *doc4 = FSTTestDoc("rooms/eros/messages/3", 0, @{@"order" : @4}, NO);
-  FSTDocument *doc5 = FSTTestDoc("rooms/eros/messages/4", 0, @{@"order" : @5}, NO);
+  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{ @"order" : @1 }, NO);
+  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{ @"order" : @2 }, NO);
+  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/2", 0, @{ @"order" : @3 }, NO);
+  FSTDocument *doc4 = FSTTestDoc("rooms/eros/messages/3", 0, @{ @"order" : @4 }, NO);
+  FSTDocument *doc5 = FSTTestDoc("rooms/eros/messages/4", 0, @{ @"order" : @5 }, NO);
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   // Start with a full view.
@@ -428,7 +428,7 @@ NS_ASSUME_NONNULL_BEGIN
   [view applyChangesToDocuments:changes];
 
   // Move one of the docs.
-  doc1 = FSTTestDoc("rooms/eros/messages/0", 1, @{@"order" : @3}, NO);
+  doc1 = FSTTestDoc("rooms/eros/messages/0", 1, @{ @"order" : @3 }, NO);
   changes = [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc1 ])];
   [self assertDocSet:changes.documentSet containsDocs:@[ doc2, doc3, doc1 ]];
   XCTAssertFalse(changes.needsRefill);
@@ -442,11 +442,11 @@ NS_ASSUME_NONNULL_BEGIN
       [query queryByAddingSortOrder:[FSTSortOrder sortOrderWithFieldPath:testutil::Field("order")
                                                                ascending:YES]];
   query = [query queryBySettingLimit:3];
-  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{@"order" : @1}, NO);
-  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{@"order" : @2}, NO);
-  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/2", 0, @{@"order" : @3}, NO);
-  FSTDocument *doc4 = FSTTestDoc("rooms/eros/messages/3", 0, @{@"order" : @4}, NO);
-  FSTDocument *doc5 = FSTTestDoc("rooms/eros/messages/4", 0, @{@"order" : @5}, NO);
+  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{ @"order" : @1 }, NO);
+  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{ @"order" : @2 }, NO);
+  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/2", 0, @{ @"order" : @3 }, NO);
+  FSTDocument *doc4 = FSTTestDoc("rooms/eros/messages/3", 0, @{ @"order" : @4 }, NO);
+  FSTDocument *doc5 = FSTTestDoc("rooms/eros/messages/4", 0, @{ @"order" : @5 }, NO);
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   // Start with a full view.
@@ -458,7 +458,7 @@ NS_ASSUME_NONNULL_BEGIN
   [view applyChangesToDocuments:changes];
 
   // Move one of the docs.
-  doc4 = FSTTestDoc("rooms/eros/messages/3", 1, @{@"order" : @6}, NO);
+  doc4 = FSTTestDoc("rooms/eros/messages/3", 1, @{ @"order" : @6 }, NO);
   changes = [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc4 ])];
   [self assertDocSet:changes.documentSet containsDocs:@[ doc1, doc2, doc3 ]];
   XCTAssertFalse(changes.needsRefill);

--- a/Firestore/Example/Tests/Integration/API/FIRArrayTransformTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRArrayTransformTests.mm
@@ -78,39 +78,39 @@
                     data:@{
                       @"array" : [FIRFieldValue fieldValueForArrayUnion:@[ @1, @2 ]]
                     }];
-  id expected = @{@"array" : @[ @1, @2 ]};
+  id expected = @{ @"array" : @[ @1, @2 ] };
   XCTAssertEqualObjects([_accumulator awaitLocalEvent].data, expected);
   XCTAssertEqualObjects([_accumulator awaitRemoteEvent].data, expected);
 }
 
 - (void)testAppendToArrayViaUpdate {
-  [self writeInitialData:@{@"array" : @[ @1, @3 ]}];
+  [self writeInitialData:@{ @"array" : @[ @1, @3 ] }];
 
   [self updateDocumentRef:_docRef
                      data:@{
                        @"array" : [FIRFieldValue fieldValueForArrayUnion:@[ @2, @1, @4 ]]
                      }];
 
-  id expected = @{@"array" : @[ @1, @3, @2, @4 ]};
+  id expected = @{ @"array" : @[ @1, @3, @2, @4 ] };
   XCTAssertEqualObjects([_accumulator awaitLocalEvent].data, expected);
   XCTAssertEqualObjects([_accumulator awaitRemoteEvent].data, expected);
 }
 
 - (void)testAppendToArrayViaMergeSet {
-  [self writeInitialData:@{@"array" : @[ @1, @3 ]}];
+  [self writeInitialData:@{ @"array" : @[ @1, @3 ] }];
 
   [self mergeDocumentRef:_docRef
                     data:@{
                       @"array" : [FIRFieldValue fieldValueForArrayUnion:@[ @2, @1, @4 ]]
                     }];
 
-  id expected = @{@"array" : @[ @1, @3, @2, @4 ]};
+  id expected = @{ @"array" : @[ @1, @3, @2, @4 ] };
   XCTAssertEqualObjects([_accumulator awaitLocalEvent].data, expected);
   XCTAssertEqualObjects([_accumulator awaitRemoteEvent].data, expected);
 }
 
 - (void)testAppendObjectToArrayViaUpdate {
-  [self writeInitialData:@{@"array" : @[ @{@"a" : @"hi"} ]}];
+  [self writeInitialData:@{ @"array" : @[ @{@"a" : @"hi"} ] }];
 
   [self updateDocumentRef:_docRef
                      data:@{
@@ -118,46 +118,46 @@
                            fieldValueForArrayUnion:@[ @{@"a" : @"hi"}, @{@"a" : @"bye"} ]]
                      }];
 
-  id expected = @{@"array" : @[ @{@"a" : @"hi"}, @{@"a" : @"bye"} ]};
+  id expected = @{ @"array" : @[ @{@"a" : @"hi"}, @{@"a" : @"bye"} ] };
   XCTAssertEqualObjects([_accumulator awaitLocalEvent].data, expected);
   XCTAssertEqualObjects([_accumulator awaitRemoteEvent].data, expected);
 }
 
 - (void)testRemoveFromArrayViaUpdate {
-  [self writeInitialData:@{@"array" : @[ @1, @3, @1, @3 ]}];
+  [self writeInitialData:@{ @"array" : @[ @1, @3, @1, @3 ] }];
 
   [self updateDocumentRef:_docRef
                      data:@{
                        @"array" : [FIRFieldValue fieldValueForArrayRemove:@[ @1, @4 ]]
                      }];
 
-  id expected = @{@"array" : @[ @3, @3 ]};
+  id expected = @{ @"array" : @[ @3, @3 ] };
   XCTAssertEqualObjects([_accumulator awaitLocalEvent].data, expected);
   XCTAssertEqualObjects([_accumulator awaitRemoteEvent].data, expected);
 }
 
 - (void)testRemoveFromArrayViaMergeSet {
-  [self writeInitialData:@{@"array" : @[ @1, @3, @1, @3 ]}];
+  [self writeInitialData:@{ @"array" : @[ @1, @3, @1, @3 ] }];
 
   [self mergeDocumentRef:_docRef
                     data:@{
                       @"array" : [FIRFieldValue fieldValueForArrayRemove:@[ @1, @4 ]]
                     }];
 
-  id expected = @{@"array" : @[ @3, @3 ]};
+  id expected = @{ @"array" : @[ @3, @3 ] };
   XCTAssertEqualObjects([_accumulator awaitLocalEvent].data, expected);
   XCTAssertEqualObjects([_accumulator awaitRemoteEvent].data, expected);
 }
 
 - (void)testRemoveObjectFromArrayViaUpdate {
-  [self writeInitialData:@{@"array" : @[ @{@"a" : @"hi"}, @{@"a" : @"bye"} ]}];
+  [self writeInitialData:@{ @"array" : @[ @{@"a" : @"hi"}, @{@"a" : @"bye"} ] }];
 
   [self updateDocumentRef:_docRef
                      data:@{
                        @"array" : [FIRFieldValue fieldValueForArrayRemove:@[ @{@"a" : @"hi"} ]]
                      }];
 
-  id expected = @{@"array" : @[ @{@"a" : @"bye"} ]};
+  id expected = @{ @"array" : @[ @{@"a" : @"bye"} ] };
   XCTAssertEqualObjects([_accumulator awaitLocalEvent].data, expected);
   XCTAssertEqualObjects([_accumulator awaitRemoteEvent].data, expected);
 }
@@ -206,7 +206,7 @@
                     data:@{
                       @"array" : [FIRFieldValue fieldValueForArrayUnion:@[ @1, @2 ]]
                     }];
-  id expected = @{@"array" : @[ @1, @2 ]};
+  id expected = @{ @"array" : @[ @1, @2 ] };
   XCTAssertEqualObjects([self getFromCache].data, expected);
 }
 
@@ -239,13 +239,13 @@
                     }];
 
   // Document will be cached but we'll be missing 42.
-  id expected = @{@"array" : @[ @1, @2 ]};
+  id expected = @{ @"array" : @[ @1, @2 ] };
   XCTAssertEqualObjects([self getFromCache].data, expected);
 }
 
 - (void)testServerApplicationOfArrayUnionUpdateWithCachedBaseDoc {
   // Cache a document with an array.
-  [self writeDocumentRef:_docRef data:@{@"array" : @[ @42 ]}];
+  [self writeDocumentRef:_docRef data:@{ @"array" : @[ @42 ] }];
 
   [self updateDocumentRef:_docRef
                      data:@{
@@ -253,13 +253,13 @@
                      }];
 
   // Should have merged the update with the cached doc.
-  id expected = @{@"array" : @[ @42, @1, @2 ]};
+  id expected = @{ @"array" : @[ @42, @1, @2 ] };
   XCTAssertEqualObjects([self getFromCache].data, expected);
 }
 
 - (void)testServerApplicationOfArrayRemoveUpdateWithCachedBaseDoc {
   // Cache a document with an array.
-  [self writeDocumentRef:_docRef data:@{@"array" : @[ @42, @1, @2 ]}];
+  [self writeDocumentRef:_docRef data:@{ @"array" : @[ @42, @1, @2 ] }];
 
   [self updateDocumentRef:_docRef
                      data:@{
@@ -267,7 +267,7 @@
                      }];
 
   // Should have merged the update with the cached doc.
-  id expected = @{@"array" : @[ @42 ]};
+  id expected = @{ @"array" : @[ @42 ] };
   XCTAssertEqualObjects([self getFromCache].data, expected);
 }
 @end

--- a/Firestore/Example/Tests/Integration/API/FIRCursorTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRCursorTests.mm
@@ -72,20 +72,20 @@
   FIRQuerySnapshot *querySnapshot =
       [self readDocumentSetForRef:[query queryStartingAtDocument:snapshot]];
   XCTAssertEqualObjects(FIRQuerySnapshotGetData(querySnapshot), (@[
-                          @{@"v" : @"c",
-                            @"sort" : @2.0},
-                          @{@"v" : @"d",
-                            @"sort" : @2.0}
+                          @{ @"v" : @"c",
+                             @"sort" : @2.0 },
+                          @{ @"v" : @"d",
+                             @"sort" : @2.0 }
                         ]));
 
   querySnapshot = [self readDocumentSetForRef:[query queryEndingBeforeDocument:snapshot]];
   XCTAssertEqualObjects(FIRQuerySnapshotGetData(querySnapshot), (@[
-                          @{@"v" : @"e",
-                            @"sort" : @0.0},
-                          @{@"v" : @"a",
-                            @"sort" : @1.0},
-                          @{@"v" : @"b",
-                            @"sort" : @2.0}
+                          @{ @"v" : @"e",
+                             @"sort" : @0.0 },
+                          @{ @"v" : @"a",
+                             @"sort" : @1.0 },
+                          @{ @"v" : @"b",
+                             @"sort" : @2.0 }
                         ]));
 }
 
@@ -103,20 +103,20 @@
   FIRQuerySnapshot *querySnapshot =
       [self readDocumentSetForRef:[query queryStartingAtValues:@[ @2.0 ]]];
   XCTAssertEqualObjects(FIRQuerySnapshotGetData(querySnapshot), (@[
-                          @{@"v" : @"b",
-                            @"sort" : @2.0},
-                          @{@"v" : @"c",
-                            @"sort" : @2.0},
-                          @{@"v" : @"d",
-                            @"sort" : @2.0}
+                          @{ @"v" : @"b",
+                             @"sort" : @2.0 },
+                          @{ @"v" : @"c",
+                             @"sort" : @2.0 },
+                          @{ @"v" : @"d",
+                             @"sort" : @2.0 }
                         ]));
 
   querySnapshot = [self readDocumentSetForRef:[query queryEndingBeforeValues:@[ @2.0 ]]];
   XCTAssertEqualObjects(FIRQuerySnapshotGetData(querySnapshot), (@[
-                          @{@"v" : @"e",
-                            @"sort" : @0.0},
-                          @{@"v" : @"a",
-                            @"sort" : @1.0}
+                          @{ @"v" : @"e",
+                             @"sort" : @0.0 },
+                          @{ @"v" : @"a",
+                             @"sort" : @1.0 }
                         ]));
 }
 
@@ -178,18 +178,18 @@
 
   FIRQuerySnapshot *snapshot = [self readDocumentSetForRef:[query queryStartingAtValues:@[ @2.0 ]]];
   XCTAssertEqualObjects(FIRQuerySnapshotGetData(snapshot), (@[
-                          @{@"v" : @"c",
-                            @"sort" : @2.0},
-                          @{@"v" : @"b",
-                            @"sort" : @2.0},
-                          @{@"v" : @"a",
-                            @"sort" : @1.0},
-                          @{@"v" : @"e",
-                            @"sort" : @0.0}
+                          @{ @"v" : @"c",
+                             @"sort" : @2.0 },
+                          @{ @"v" : @"b",
+                             @"sort" : @2.0 },
+                          @{ @"v" : @"a",
+                             @"sort" : @1.0 },
+                          @{ @"v" : @"e",
+                             @"sort" : @0.0 }
                         ]));
 
   snapshot = [self readDocumentSetForRef:[query queryEndingBeforeValues:@[ @2.0 ]]];
-  XCTAssertEqualObjects(FIRQuerySnapshotGetData(snapshot), (@[ @{@"v" : @"d", @"sort" : @3.0} ]));
+  XCTAssertEqualObjects(FIRQuerySnapshotGetData(snapshot), (@[ @{ @"v" : @"d", @"sort" : @3.0 } ]));
 }
 
 FIRTimestamp *TimestampWithMicros(int64_t seconds, int32_t micros) {

--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
@@ -31,13 +31,13 @@
 - (void)testCanUpdateAnExistingDocument {
   FIRDocumentReference *doc = [self.db documentWithPath:@"rooms/eros"];
   NSDictionary<NSString *, id> *initialData =
-      @{@"desc" : @"Description",
-        @"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"}};
+      @{ @"desc" : @"Description",
+         @"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"} };
   NSDictionary<NSString *, id> *updateData =
       @{@"desc" : @"NewDescription", @"owner.email" : @"new@xyz.com"};
   NSDictionary<NSString *, id> *finalData =
-      @{@"desc" : @"NewDescription",
-        @"owner" : @{@"name" : @"Jonny", @"email" : @"new@xyz.com"}};
+      @{ @"desc" : @"NewDescription",
+         @"owner" : @{@"name" : @"Jonny", @"email" : @"new@xyz.com"} };
 
   [self writeDocumentRef:doc data:initialData];
 
@@ -57,13 +57,13 @@
 - (void)testCanDeleteAFieldWithAnUpdate {
   FIRDocumentReference *doc = [self.db documentWithPath:@"rooms/eros"];
   NSDictionary<NSString *, id> *initialData =
-      @{@"desc" : @"Description",
-        @"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"}};
+      @{ @"desc" : @"Description",
+         @"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"} };
   NSDictionary<NSString *, id> *updateData =
       @{@"owner.email" : [FIRFieldValue fieldValueForDelete]};
   NSDictionary<NSString *, id> *finalData =
-      @{@"desc" : @"Description",
-        @"owner" : @{@"name" : @"Jonny"}};
+      @{ @"desc" : @"Description",
+         @"owner" : @{@"name" : @"Jonny"} };
 
   [self writeDocumentRef:doc data:initialData];
   [self updateDocumentRef:doc data:updateData];
@@ -111,8 +111,8 @@
   FIRDocumentReference *doc = [[self.db collectionWithPath:@"rooms"] documentWithAutoID];
 
   NSDictionary<NSString *, id> *initialData =
-      @{@"desc" : @"Description",
-        @"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"}};
+      @{ @"desc" : @"Description",
+         @"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"} };
   NSDictionary<NSString *, id> *udpateData = @{@"desc" : @"NewDescription"};
 
   [self writeDocumentRef:doc data:initialData];
@@ -125,12 +125,13 @@
 - (void)testCanMergeDataWithAnExistingDocumentUsingSet {
   FIRDocumentReference *doc = [[self.db collectionWithPath:@"rooms"] documentWithAutoID];
 
-  NSDictionary<NSString *, id> *initialData =
-      @{@"desc" : @"Description",
-        @"owner.data" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"}};
+  NSDictionary<NSString *, id> *initialData = @{
+    @"desc" : @"Description",
+    @"owner.data" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"}
+  };
   NSDictionary<NSString *, id> *mergeData =
-      @{@"updated" : @YES,
-        @"owner.data" : @{@"name" : @"Sebastian"}};
+      @{ @"updated" : @YES,
+         @"owner.data" : @{@"name" : @"Sebastian"} };
   NSDictionary<NSString *, id> *finalData = @{
     @"desc" : @"Description",
     @"updated" : @YES,
@@ -189,10 +190,11 @@
 - (void)testCanDeleteFieldUsingMerge {
   FIRDocumentReference *doc = [[self.db collectionWithPath:@"rooms"] documentWithAutoID];
 
-  NSDictionary<NSString *, id> *initialData =
-      @{@"untouched" : @YES,
-        @"foo" : @"bar",
-        @"nested" : @{@"untouched" : @YES, @"foo" : @"bar"}};
+  NSDictionary<NSString *, id> *initialData = @{
+    @"untouched" : @YES,
+    @"foo" : @"bar",
+    @"nested" : @{@"untouched" : @YES, @"foo" : @"bar"}
+  };
   NSDictionary<NSString *, id> *mergeData = @{
     @"foo" : [FIRFieldValue fieldValueForDelete],
     @"nested" : @{@"foo" : [FIRFieldValue fieldValueForDelete]}
@@ -237,9 +239,9 @@
     }
   };
   NSDictionary<NSString *, id> *finalData =
-      @{@"untouched" : @YES,
-        @"inner" : @{},
-        @"nested" : @{@"untouched" : @YES}};
+      @{ @"untouched" : @YES,
+         @"inner" : @{},
+         @"nested" : @{@"untouched" : @YES} };
 
   [self writeDocumentRef:doc data:initialData];
 
@@ -262,10 +264,11 @@
 - (void)testCanSetServerTimestampsUsingMergeFields {
   FIRDocumentReference *doc = [[self.db collectionWithPath:@"rooms"] documentWithAutoID];
 
-  NSDictionary<NSString *, id> *initialData =
-      @{@"untouched" : @YES,
-        @"foo" : @"bar",
-        @"nested" : @{@"untouched" : @YES, @"foo" : @"bar"}};
+  NSDictionary<NSString *, id> *initialData = @{
+    @"untouched" : @YES,
+    @"foo" : @"bar",
+    @"nested" : @{@"untouched" : @YES, @"foo" : @"bar"}
+  };
   NSDictionary<NSString *, id> *mergeData = @{
     @"foo" : [FIRFieldValue fieldValueForServerTimestamp],
     @"inner" : @{@"foo" : [FIRFieldValue fieldValueForServerTimestamp]},
@@ -303,9 +306,9 @@
     @"mapInArray" : @[ @{@"data" : @"old"} ]
   };
   NSDictionary<NSString *, id> *mergeData =
-      @{@"data" : @"new",
-        @"topLevel" : @[ @"new" ],
-        @"mapInArray" : @[ @{@"data" : @"new"} ]};
+      @{ @"data" : @"new",
+         @"topLevel" : @[ @"new" ],
+         @"mapInArray" : @[ @{@"data" : @"new"} ] };
   NSDictionary<NSString *, id> *finalData = @{
     @"untouched" : @YES,
     @"data" : @"new",
@@ -343,8 +346,8 @@
   FIRDocumentReference *doc = [[self.db collectionWithPath:@"rooms"] documentWithAutoID];
 
   NSDictionary<NSString *, id> *initialData =
-      @{@"desc" : @"Description",
-        @"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"}};
+      @{ @"desc" : @"Description",
+         @"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"} };
 
   NSDictionary<NSString *, id> *finalData = @{@"desc" : @"Description", @"owner" : @"Sebastian"};
 
@@ -370,8 +373,8 @@
   FIRDocumentReference *doc = [[self.db collectionWithPath:@"rooms"] documentWithAutoID];
 
   NSDictionary<NSString *, id> *initialData =
-      @{@"desc" : @"Description",
-        @"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"}};
+      @{ @"desc" : @"Description",
+         @"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"} };
 
   NSDictionary<NSString *, id> *finalData = @{@"desc" : @"Description", @"owner" : @"Sebastian"};
 
@@ -397,8 +400,8 @@
   FIRDocumentReference *doc = [[self.db collectionWithPath:@"rooms"] documentWithAutoID];
 
   NSDictionary<NSString *, id> *initialData =
-      @{@"desc" : @"Description",
-        @"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"}};
+      @{ @"desc" : @"Description",
+         @"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"} };
 
   NSDictionary<NSString *, id> *finalData = @{@"desc" : @"Description", @"owner" : @"Sebastian"};
 
@@ -424,8 +427,8 @@
   FIRDocumentReference *doc = [[self.db collectionWithPath:@"rooms"] documentWithAutoID];
 
   NSDictionary<NSString *, id> *initialData =
-      @{@"desc" : @"Description",
-        @"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"}};
+      @{ @"desc" : @"Description",
+         @"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"} };
 
   NSDictionary<NSString *, id> *finalData = initialData;
 
@@ -451,12 +454,13 @@
   FIRDocumentReference *doc = [[self.db collectionWithPath:@"rooms"] documentWithAutoID];
 
   NSDictionary<NSString *, id> *initialData =
-      @{@"desc" : @"Description",
-        @"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"}};
+      @{ @"desc" : @"Description",
+         @"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"} };
 
-  NSDictionary<NSString *, id> *finalData =
-      @{@"desc" : @"Description",
-        @"owner" : @{@"name" : @"Sebastian", @"email" : @"new@xyz.com"}};
+  NSDictionary<NSString *, id> *finalData = @{
+    @"desc" : @"Description",
+    @"owner" : @{@"name" : @"Sebastian", @"email" : @"new@xyz.com"}
+  };
 
   [self writeDocumentRef:doc data:initialData];
 
@@ -481,13 +485,13 @@
 
 - (void)testAddingToACollectionYieldsTheCorrectDocumentReference {
   FIRCollectionReference *coll = [self.db collectionWithPath:@"collection"];
-  FIRDocumentReference *ref = [coll addDocumentWithData:@{@"foo" : @1}];
+  FIRDocumentReference *ref = [coll addDocumentWithData:@{ @"foo" : @1 }];
 
   XCTestExpectation *getCompletion = [self expectationWithDescription:@"getData"];
   [ref getDocumentWithCompletion:^(FIRDocumentSnapshot *_Nullable document,
                                    NSError *_Nullable error) {
     XCTAssertNil(error);
-    XCTAssertEqualObjects(document.data, (@{@"foo" : @1}));
+    XCTAssertEqualObjects(document.data, (@{ @"foo" : @1 }));
 
     [getCompletion fulfill];
   }];
@@ -568,7 +572,7 @@
           [emptyCompletion fulfill];
 
         } else if (callbacks == 2) {
-          XCTAssertEqualObjects(doc.data, (@{@"a" : @1}));
+          XCTAssertEqualObjects(doc.data, (@{ @"a" : @1 }));
           XCTAssertEqual(doc.metadata.hasPendingWrites, YES);
           [dataCompletion fulfill];
 
@@ -580,7 +584,7 @@
   [self awaitExpectations];
   dataCompletion = [self expectationWithDescription:@"data snapshot"];
 
-  [docRef setData:@{@"a" : @1}];
+  [docRef setData:@{ @"a" : @1 }];
   [self awaitExpectations];
 
   [listenerRegistration remove];
@@ -605,11 +609,11 @@
                                                [emptyCompletion fulfill];
 
                                              } else if (callbacks == 2) {
-                                               XCTAssertEqualObjects(doc.data, (@{@"a" : @1}));
+                                               XCTAssertEqualObjects(doc.data, (@{ @"a" : @1 }));
                                                XCTAssertEqual(doc.metadata.hasPendingWrites, YES);
 
                                              } else if (callbacks == 3) {
-                                               XCTAssertEqualObjects(doc.data, (@{@"a" : @1}));
+                                               XCTAssertEqualObjects(doc.data, (@{ @"a" : @1 }));
                                                XCTAssertEqual(doc.metadata.hasPendingWrites, NO);
                                                [dataCompletion fulfill];
 
@@ -621,7 +625,7 @@
   [self awaitExpectations];
   dataCompletion = [self expectationWithDescription:@"data snapshot"];
 
-  [docRef setData:@{@"a" : @1}];
+  [docRef setData:@{ @"a" : @1 }];
   [self awaitExpectations];
 
   [listenerRegistration remove];
@@ -630,8 +634,8 @@
 - (void)testDocumentSnapshotEvents_forChange {
   FIRDocumentReference *docRef = [[self.db collectionWithPath:@"rooms"] documentWithAutoID];
 
-  NSDictionary<NSString *, id> *initialData = @{@"a" : @1};
-  NSDictionary<NSString *, id> *changedData = @{@"b" : @2};
+  NSDictionary<NSString *, id> *initialData = @{ @"a" : @1 };
+  NSDictionary<NSString *, id> *changedData = @{ @"b" : @2 };
 
   [self writeDocumentRef:docRef data:initialData];
 
@@ -670,8 +674,8 @@
 - (void)testDocumentSnapshotEvents_forChangeIncludingMetadata {
   FIRDocumentReference *docRef = [[self.db collectionWithPath:@"rooms"] documentWithAutoID];
 
-  NSDictionary<NSString *, id> *initialData = @{@"a" : @1};
-  NSDictionary<NSString *, id> *changedData = @{@"b" : @2};
+  NSDictionary<NSString *, id> *initialData = @{ @"a" : @1 };
+  NSDictionary<NSString *, id> *changedData = @{ @"b" : @2 };
 
   [self writeDocumentRef:docRef data:initialData];
 
@@ -724,7 +728,7 @@
 - (void)testDocumentSnapshotEvents_forDelete {
   FIRDocumentReference *docRef = [[self.db collectionWithPath:@"rooms"] documentWithAutoID];
 
-  NSDictionary<NSString *, id> *initialData = @{@"a" : @1};
+  NSDictionary<NSString *, id> *initialData = @{ @"a" : @1 };
 
   [self writeDocumentRef:docRef data:initialData];
 
@@ -763,7 +767,7 @@
 - (void)testDocumentSnapshotEvents_forDeleteIncludingMetadata {
   FIRDocumentReference *docRef = [[self.db collectionWithPath:@"rooms"] documentWithAutoID];
 
-  NSDictionary<NSString *, id> *initialData = @{@"a" : @1};
+  NSDictionary<NSString *, id> *initialData = @{ @"a" : @1 };
 
   [self writeDocumentRef:docRef data:initialData];
 
@@ -812,7 +816,7 @@
   FIRCollectionReference *roomsRef = [self collectionRef];
   FIRDocumentReference *docRef = [roomsRef documentWithAutoID];
 
-  NSDictionary<NSString *, id> *newData = @{@"a" : @1};
+  NSDictionary<NSString *, id> *newData = @{ @"a" : @1 };
 
   XCTestExpectation *emptyCompletion = [self expectationWithDescription:@"empty snapshot"];
   __block XCTestExpectation *changeCompletion;
@@ -851,8 +855,8 @@
   FIRCollectionReference *roomsRef = [self collectionRef];
   FIRDocumentReference *docRef = [roomsRef documentWithAutoID];
 
-  NSDictionary<NSString *, id> *initialData = @{@"a" : @1};
-  NSDictionary<NSString *, id> *changedData = @{@"b" : @2};
+  NSDictionary<NSString *, id> *initialData = @{ @"a" : @1 };
+  NSDictionary<NSString *, id> *changedData = @{ @"b" : @2 };
 
   [self writeDocumentRef:docRef data:initialData];
 
@@ -894,7 +898,7 @@
   FIRCollectionReference *roomsRef = [self collectionRef];
   FIRDocumentReference *docRef = [roomsRef documentWithAutoID];
 
-  NSDictionary<NSString *, id> *initialData = @{@"a" : @1};
+  NSDictionary<NSString *, id> *initialData = @{ @"a" : @1 };
 
   [self writeDocumentRef:docRef data:initialData];
 
@@ -1008,7 +1012,7 @@
 
   [self writeDocumentRef:doc data:@{@"a.b" : @"old", @"c.d" : @"old"}];
 
-  [self updateDocumentRef:doc data:@{[[FIRFieldPath alloc] initWithFields:@[ @"a.b" ]] : @"new"}];
+  [self updateDocumentRef:doc data:@{ [[FIRFieldPath alloc] initWithFields:@[ @"a.b" ]] : @"new" }];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"testUpdateFieldsWithDots"];
 

--- a/Firestore/Example/Tests/Integration/API/FIRFieldsTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRFieldsTests.mm
@@ -27,7 +27,7 @@
 @end
 
 NSDictionary<NSString *, id> *testDataWithTimestamps(FIRTimestamp *timestamp) {
-  return @{@"timestamp" : timestamp, @"nested" : @{@"timestamp2" : timestamp}};
+  return @{ @"timestamp" : timestamp, @"nested" : @{@"timestamp2" : timestamp} };
 }
 
 @implementation FIRFieldsTests
@@ -71,7 +71,7 @@ NSDictionary<NSString *, id> *testDataWithTimestamps(FIRTimestamp *timestamp) {
 
   FIRDocumentReference *doc = [self documentRef];
   [self writeDocumentRef:doc data:testData];
-  [self updateDocumentRef:doc data:@{@"metadata.deep.field" : @100, @"metadata.added" : @200}];
+  [self updateDocumentRef:doc data:@{ @"metadata.deep.field" : @100, @"metadata.added" : @200 }];
 
   FIRDocumentSnapshot *result = [self readDocumentForRef:doc];
   XCTAssertEqualObjects(
@@ -166,7 +166,7 @@ NSDictionary<NSString *, id> *testDataWithTimestamps(FIRTimestamp *timestamp) {
                      }];
 
   FIRDocumentSnapshot *result = [self readDocumentForRef:doc];
-  XCTAssertEqualObjects(result.data, (@{@"a" : @"field 1", @"b.dot" : @100, @"c\\slash" : @200}));
+  XCTAssertEqualObjects(result.data, (@{ @"a" : @"field 1", @"b.dot" : @100, @"c\\slash" : @200 }));
 }
 
 - (void)testFieldsWithSpecialCharsCanBeUsedInQueryFilters {
@@ -228,8 +228,8 @@ NSDictionary<NSString *, id> *testDataWithTimestamps(FIRTimestamp *timestamp) {
 - (FIRDocumentSnapshot *)snapshotWithTimestamps:(FIRTimestamp *)timestamp {
   FIRDocumentReference *doc = [self documentRef];
   NSDictionary<NSString *, id> *data =
-      @{@"timestamp" : timestamp,
-        @"nested" : @{@"timestamp2" : timestamp}};
+      @{ @"timestamp" : timestamp,
+         @"nested" : @{@"timestamp2" : timestamp} };
   [self writeDocumentRef:doc data:data];
   return [self readDocumentForRef:doc];
 }

--- a/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
@@ -51,10 +51,10 @@
                                       queryLimitedTo:2]];
 
   XCTAssertEqualObjects(FIRQuerySnapshotGetData(snapshot), (@[
-                          @{@"k" : @"d",
-                            @"sort" : @2},
-                          @{@"k" : @"c",
-                            @"sort" : @1}
+                          @{ @"k" : @"d",
+                             @"sort" : @2 },
+                          @{ @"k" : @"c",
+                             @"sort" : @1 }
                         ]));
 }
 
@@ -88,8 +88,8 @@
                                             isEqualTo:@(NAN)]];
 
   XCTAssertEqualObjects(FIRQuerySnapshotGetData(results), (@[
-                          @{@"null" : [NSNull null],
-                            @"nan" : @(NAN)}
+                          @{ @"null" : [NSNull null],
+                             @"nan" : @(NAN) }
                         ]));
 }
 
@@ -136,7 +136,7 @@
   FIRQuerySnapshot *results =
       [self readDocumentSetForRef:[collRef queryWhereField:@"inf" isEqualTo:@(INFINITY)]];
 
-  XCTAssertEqualObjects(FIRQuerySnapshotGetData(results), (@[ @{@"inf" : @(INFINITY)} ]));
+  XCTAssertEqualObjects(FIRQuerySnapshotGetData(results), (@[ @{ @"inf" : @(INFINITY) } ]));
 }
 
 - (void)testCanExplicitlySortByDocumentID {
@@ -250,7 +250,7 @@
                                            listener:self.eventAccumulator.valueEventHandler];
 
   FIRQuerySnapshot *querySnap = [self.eventAccumulator awaitEventWithName:@"initial event"];
-  XCTAssertEqualObjects(FIRQuerySnapshotGetData(querySnap), @[ @{@"foo" : @1} ]);
+  XCTAssertEqualObjects(FIRQuerySnapshotGetData(querySnap), @[ @{ @"foo" : @1 } ]);
   XCTAssertEqual(querySnap.metadata.isFromCache, NO);
 
   [self disableNetwork];
@@ -273,7 +273,9 @@
   FIRCollectionReference *col = [self collectionRef];
 
   // set a few docs to known values
-  NSDictionary *initialDocs = @{@"doc1" : @{@"key1" : @"value1"}, @"doc2" : @{@"key2" : @"value2"}};
+  NSDictionary *initialDocs =
+      @{ @"doc1" : @{@"key1" : @"value1"},
+         @"doc2" : @{@"key2" : @"value2"} };
   [self writeAllDocuments:initialDocs toCollection:col];
 
   // go offline for the rest of this test
@@ -295,7 +297,7 @@
     @"a" : @{@"array" : @[ @42 ]},
     @"b" : @{@"array" : @[ @"a", @42, @"c" ]},
     @"c" : @{@"array" : @[ @41.999, @"42",
-                           @{@"a" : @[ @42 ]} ]},
+                           @{ @"a" : @[ @42 ] } ]},
     @"d" : @{@"array" : @[ @42 ], @"array2" : @[ @"bingo" ]}
   };
   FIRCollectionReference *collection = [self collectionRefWithDocuments:testDocs];
@@ -304,10 +306,10 @@
   FIRQuerySnapshot *snapshot =
       [self readDocumentSetForRef:[collection queryWhereField:@"array" arrayContains:@42]];
   XCTAssertEqualObjects(FIRQuerySnapshotGetData(snapshot), (@[
-                          @{@"array" : @[ @42 ]},
-                          @{@"array" : @[ @"a", @42, @"c" ]},
-                          @{@"array" : @[ @42 ],
-                            @"array2" : @[ @"bingo" ]}
+                          @{ @"array" : @[ @42 ] },
+                          @{ @"array" : @[ @"a", @42, @"c" ] },
+                          @{ @"array" : @[ @42 ],
+                             @"array2" : @[ @"bingo" ] }
                         ]));
 
   // NOTE: The backend doesn't currently support null, NaN, objects, or arrays, so there isn't much

--- a/Firestore/Example/Tests/Integration/API/FIRServerTimestampTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRServerTimestampTests.mm
@@ -55,7 +55,7 @@
   };
 
   // Base and update data used for update tests.
-  _initialData = @{@"a" : @42};
+  _initialData = @{ @"a" : @42 };
   _updateData = @{
     @"when" : [FIRFieldValue fieldValueForServerTimestamp],
     @"deep" : @{@"when" : [FIRFieldValue fieldValueForServerTimestamp]}
@@ -80,7 +80,7 @@
 
 /** Returns the expected data, with the specified timestamp substituted in. */
 - (NSDictionary *)expectedDataWithTimestamp:(nullable id)timestamp {
-  return @{@"a" : @42, @"when" : timestamp, @"deep" : @{@"when" : timestamp}};
+  return @{ @"a" : @42, @"when" : timestamp, @"deep" : @{@"when" : timestamp} };
 }
 
 /** Writes _initialData and waits for the corresponding snapshot. */
@@ -137,11 +137,10 @@
 /** Runs a transaction block. */
 - (void)runTransactionBlock:(void (^)(FIRTransaction *transaction))transactionBlock {
   XCTestExpectation *expectation = [self expectationWithDescription:@"transaction complete"];
-  [_docRef.firestore
-      runTransactionWithBlock:^id(FIRTransaction *transaction, NSError **pError) {
-        transactionBlock(transaction);
-        return nil;
-      }
+  [_docRef.firestore runTransactionWithBlock:^id(FIRTransaction *transaction, NSError **pError) {
+    transactionBlock(transaction);
+    return nil;
+  }
       completion:^(id result, NSError *error) {
         XCTAssertNil(error);
         [expectation fulfill];
@@ -245,7 +244,7 @@
       [localSnapshot valueForField:@"a" serverTimestampBehavior:FIRServerTimestampBehaviorPrevious],
       @42);
 
-  [_docRef updateData:@{@"a" : @1337}];
+  [_docRef updateData:@{ @"a" : @1337 }];
   localSnapshot = [_accumulator awaitLocalEvent];
   XCTAssertEqualObjects([localSnapshot valueForField:@"a"], @1337);
 
@@ -291,11 +290,10 @@
 
 - (void)testServerTimestampsFailViaTransactionUpdateOnNonexistentDocument {
   XCTestExpectation *expectation = [self expectationWithDescription:@"transaction complete"];
-  [_docRef.firestore
-      runTransactionWithBlock:^id(FIRTransaction *transaction, NSError **pError) {
-        [transaction updateData:_updateData forDocument:_docRef];
-        return nil;
-      }
+  [_docRef.firestore runTransactionWithBlock:^id(FIRTransaction *transaction, NSError **pError) {
+    [transaction updateData:_updateData forDocument:_docRef];
+    return nil;
+  }
       completion:^(id result, NSError *error) {
         XCTAssertNotNil(error);
         XCTAssertEqualObjects(error.domain, FIRFirestoreErrorDomain);

--- a/Firestore/Example/Tests/Integration/API/FIRTypeTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRTypeTests.mm
@@ -35,11 +35,14 @@
 }
 
 - (void)testCanReadAndWriteNullFields {
-  [self assertSuccessfulRoundtrip:@{@"a" : @1, @"b" : [NSNull null]}];
+  [self assertSuccessfulRoundtrip:@{ @"a" : @1, @"b" : [NSNull null] }];
 }
 
 - (void)testCanReadAndWriteArrayFields {
-  [self assertSuccessfulRoundtrip:@{@"array" : @[ @1, @"foo", @{@"deep" : @YES}, [NSNull null] ]}];
+  [self assertSuccessfulRoundtrip:@{
+    @"array" : @[ @1, @"foo",
+                  @{ @"deep" : @YES }, [NSNull null] ]
+  }];
 }
 
 - (void)testCanReadAndWriteBlobFields {
@@ -74,12 +77,12 @@
 
 - (void)testCanReadAndWriteDocumentReferences {
   FIRDocumentReference *docRef = [self documentRef];
-  [self assertSuccessfulRoundtrip:@{@"a" : @42, @"ref" : docRef}];
+  [self assertSuccessfulRoundtrip:@{ @"a" : @42, @"ref" : docRef }];
 }
 
 - (void)testCanReadAndWriteDocumentReferencesInArrays {
   FIRDocumentReference *docRef = [self documentRef];
-  [self assertSuccessfulRoundtrip:@{@"a" : @42, @"refs" : @[ docRef ]}];
+  [self assertSuccessfulRoundtrip:@{ @"a" : @42, @"refs" : @[ docRef ] }];
 }
 
 @end

--- a/Firestore/Example/Tests/Integration/API/FIRValidationTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRValidationTests.mm
@@ -50,7 +50,7 @@
 
 - (void)testChangingSettingsAfterUseFails {
   FIRFirestoreSettings *settings = self.db.settings;
-  [[self.db documentWithPath:@"foo/bar"] setData:@{@"a" : @42}];
+  [[self.db documentWithPath:@"foo/bar"] setData:@{ @"a" : @42 }];
   settings.host = @"example.com";
   FSTAssertThrows(self.db.settings = settings,
                   @"Firestore instance has already been started and its settings can no longer be "
@@ -76,13 +76,13 @@
                                         }],
                   @"Transaction block cannot be nil.");
 
-  FSTAssertThrows([self.db
-                      runTransactionWithBlock:^id(FIRTransaction *transaction, NSError **pError) {
-                        XCTFail(@"Transaction block shouldn't run.");
-                        return nil;
-                      }
-                                   completion:nil],
-                  @"Transaction completion block cannot be nil.");
+  FSTAssertThrows(
+      [self.db runTransactionWithBlock:^id(FIRTransaction *transaction, NSError **pError) {
+        XCTFail(@"Transaction block shouldn't run.");
+        return nil;
+      }
+                            completion:nil],
+      @"Transaction completion block cannot be nil.");
 }
 
 #pragma mark - Collection and Document Path Validation
@@ -171,7 +171,7 @@
 }
 
 - (void)testWritesWithIndirectlyNestedArraysSucceed {
-  NSDictionary<NSString *, id> *data = @{@"nested-array" : @[ @1, @{@"foo" : @[ @2 ]} ]};
+  NSDictionary<NSString *, id> *data = @{ @"nested-array" : @[ @1, @{ @"foo" : @[ @2 ] } ] };
 
   FIRDocumentReference *ref = [self documentRef];
   FIRDocumentReference *ref2 = [self documentRef];
@@ -209,13 +209,12 @@
   [self awaitExpectations];
 
   XCTestExpectation *transactionDone = [self expectationWithDescription:@"transaction done"];
-  [ref.firestore
-      runTransactionWithBlock:^id(FIRTransaction *transaction, NSError **pError) {
-        // Note ref2 does not exist at this point so set that and update ref.
-        [transaction updateData:data forDocument:ref];
-        [transaction setData:data forDocument:ref2];
-        return nil;
-      }
+  [ref.firestore runTransactionWithBlock:^id(FIRTransaction *transaction, NSError **pError) {
+    // Note ref2 does not exist at this point so set that and update ref.
+    [transaction updateData:data forDocument:ref];
+    [transaction setData:data forDocument:ref2];
+    return nil;
+  }
       completion:^(id result, NSError *error) {
         // ends up being a no-op transaction.
         XCTAssertNil(error);
@@ -303,7 +302,7 @@
   XCTAssertNotEqual(db1, db2);
 
   NSString *reason = @"Provided document reference is from a different Firestore instance.";
-  id data = @{@"foo" : @1};
+  id data = @{ @"foo" : @1 };
   FIRDocumentReference *badRef = [db2 documentWithPath:@"foo/bar"];
   FIRWriteBatch *batch = [db1 batch];
   FSTAssertThrows([batch setData:data forDocument:badRef], reason);
@@ -318,19 +317,18 @@
   XCTAssertNotEqual(db1, db2);
 
   NSString *reason = @"Provided document reference is from a different Firestore instance.";
-  id data = @{@"foo" : @1};
+  id data = @{ @"foo" : @1 };
   FIRDocumentReference *badRef = [db2 documentWithPath:@"foo/bar"];
 
   XCTestExpectation *transactionDone = [self expectationWithDescription:@"transaction done"];
-  [db1
-      runTransactionWithBlock:^id(FIRTransaction *txn, NSError **pError) {
-        FSTAssertThrows([txn getDocument:badRef error:nil], reason);
-        FSTAssertThrows([txn setData:data forDocument:badRef], reason);
-        FSTAssertThrows([txn setData:data forDocument:badRef merge:YES], reason);
-        FSTAssertThrows([txn updateData:data forDocument:badRef], reason);
-        FSTAssertThrows([txn deleteDocument:badRef], reason);
-        return nil;
-      }
+  [db1 runTransactionWithBlock:^id(FIRTransaction *txn, NSError **pError) {
+    FSTAssertThrows([txn getDocument:badRef error:nil], reason);
+    FSTAssertThrows([txn setData:data forDocument:badRef], reason);
+    FSTAssertThrows([txn setData:data forDocument:badRef merge:YES], reason);
+    FSTAssertThrows([txn updateData:data forDocument:badRef], reason);
+    FSTAssertThrows([txn deleteDocument:badRef], reason);
+    return nil;
+  }
       completion:^(id result, NSError *error) {
         // ends up being a no-op transaction.
         XCTAssertNil(error);
@@ -619,16 +617,15 @@
   }
 
   XCTestExpectation *transactionDone = [self expectationWithDescription:@"transaction done"];
-  [ref.firestore
-      runTransactionWithBlock:^id(FIRTransaction *transaction, NSError **pError) {
-        if (includeSets) {
-          FSTAssertThrows([transaction setData:data forDocument:ref], reason, @"for %@", data);
-        }
-        if (includeUpdates) {
-          FSTAssertThrows([transaction updateData:data forDocument:ref], reason, @"for %@", data);
-        }
-        return nil;
-      }
+  [ref.firestore runTransactionWithBlock:^id(FIRTransaction *transaction, NSError **pError) {
+    if (includeSets) {
+      FSTAssertThrows([transaction setData:data forDocument:ref], reason, @"for %@", data);
+    }
+    if (includeUpdates) {
+      FSTAssertThrows([transaction updateData:data forDocument:ref], reason, @"for %@", data);
+    }
+    return nil;
+  }
       completion:^(id result, NSError *error) {
         // ends up being a no-op transaction.
         XCTAssertNil(error);
@@ -655,7 +652,7 @@
 - (void)expectFieldPath:(NSString *)fieldPath toFailWithReason:(NSString *)reason {
   // Get an arbitrary snapshot we can use for testing.
   FIRDocumentReference *docRef = [self documentRef];
-  [self writeDocumentRef:docRef data:@{@"test" : @1}];
+  [self writeDocumentRef:docRef data:@{ @"test" : @1 }];
   FIRDocumentSnapshot *snapshot = [self readDocumentForRef:docRef];
 
   // Update paths.

--- a/Firestore/Example/Tests/Integration/API/FIRWriteBatchTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRWriteBatchTests.mm
@@ -81,8 +81,8 @@
   FIRDocumentReference *doc = [self documentRef];
   XCTestExpectation *batchExpectation = [self expectationWithDescription:@"batch written"];
   FIRWriteBatch *batch = [doc.firestore batch];
-  [batch setData:@{@"a" : @"b", @"nested" : @{@"a" : @"b"}} forDocument:doc];
-  [batch setData:@{@"c" : @"d", @"nested" : @{@"c" : @"d"}} forDocument:doc merge:YES];
+  [batch setData:@{ @"a" : @"b", @"nested" : @{@"a" : @"b"} } forDocument:doc];
+  [batch setData:@{ @"c" : @"d", @"nested" : @{@"c" : @"d"} } forDocument:doc merge:YES];
   [batch commitWithCompletion:^(NSError *error) {
     XCTAssertNil(error);
     [batchExpectation fulfill];
@@ -90,11 +90,11 @@
   [self awaitExpectations];
   FIRDocumentSnapshot *snapshot = [self readDocumentForRef:doc];
   XCTAssertTrue(snapshot.exists);
-  XCTAssertEqualObjects(snapshot.data,
-                        (
-                            @{@"a" : @"b",
-                              @"c" : @"d",
-                              @"nested" : @{@"a" : @"b", @"c" : @"d"}}));
+  XCTAssertEqualObjects(
+      snapshot.data, (
+                         @{ @"a" : @"b",
+                            @"c" : @"d",
+                            @"nested" : @{@"a" : @"b", @"c" : @"d"} }));
 }
 
 - (void)testUpdateDocuments {
@@ -102,7 +102,7 @@
   [self writeDocumentRef:doc data:@{@"foo" : @"bar"}];
   XCTestExpectation *batchExpectation = [self expectationWithDescription:@"batch written"];
   FIRWriteBatch *batch = [doc.firestore batch];
-  [batch updateData:@{@"baz" : @42} forDocument:doc];
+  [batch updateData:@{ @"baz" : @42 } forDocument:doc];
   [batch commitWithCompletion:^(NSError *error) {
     XCTAssertNil(error);
     [batchExpectation fulfill];
@@ -110,14 +110,14 @@
   [self awaitExpectations];
   FIRDocumentSnapshot *snapshot = [self readDocumentForRef:doc];
   XCTAssertTrue(snapshot.exists);
-  XCTAssertEqualObjects(snapshot.data, (@{@"foo" : @"bar", @"baz" : @42}));
+  XCTAssertEqualObjects(snapshot.data, (@{ @"foo" : @"bar", @"baz" : @42 }));
 }
 
 - (void)testCannotUpdateNonexistentDocuments {
   FIRDocumentReference *doc = [self documentRef];
   XCTestExpectation *batchExpectation = [self expectationWithDescription:@"batch written"];
   FIRWriteBatch *batch = [doc.firestore batch];
-  [batch updateData:@{@"baz" : @42} forDocument:doc];
+  [batch updateData:@{ @"baz" : @42 } forDocument:doc];
   [batch commitWithCompletion:^(NSError *error) {
     XCTAssertNotNil(error);
     [batchExpectation fulfill];
@@ -158,8 +158,8 @@
   // Atomically write two documents.
   XCTestExpectation *expectation = [self expectationWithDescription:@"batch written"];
   FIRWriteBatch *batch = [collection.firestore batch];
-  [batch setData:@{@"a" : @1} forDocument:docA];
-  [batch setData:@{@"b" : @2} forDocument:docB];
+  [batch setData:@{ @"a" : @1 } forDocument:docA];
+  [batch setData:@{ @"b" : @2 } forDocument:docB];
   [batch commitWithCompletion:^(NSError *_Nullable error) {
     XCTAssertNil(error);
     [expectation fulfill];
@@ -167,11 +167,11 @@
 
   FIRQuerySnapshot *localSnap = [accumulator awaitEventWithName:@"local event"];
   XCTAssertTrue(localSnap.metadata.hasPendingWrites);
-  XCTAssertEqualObjects(FIRQuerySnapshotGetData(localSnap), (@[ @{@"a" : @1}, @{@"b" : @2} ]));
+  XCTAssertEqualObjects(FIRQuerySnapshotGetData(localSnap), (@[ @{ @"a" : @1 }, @{ @"b" : @2 } ]));
 
   FIRQuerySnapshot *serverSnap = [accumulator awaitEventWithName:@"server event"];
   XCTAssertFalse(serverSnap.metadata.hasPendingWrites);
-  XCTAssertEqualObjects(FIRQuerySnapshotGetData(serverSnap), (@[ @{@"a" : @1}, @{@"b" : @2} ]));
+  XCTAssertEqualObjects(FIRQuerySnapshotGetData(serverSnap), (@[ @{ @"a" : @1 }, @{ @"b" : @2 } ]));
 }
 
 - (void)testBatchesFailAtomicallyRaisingCorrectEvents {
@@ -187,8 +187,8 @@
   // Atomically write 1 document and update a nonexistent document.
   XCTestExpectation *expectation = [self expectationWithDescription:@"batch failed"];
   FIRWriteBatch *batch = [collection.firestore batch];
-  [batch setData:@{@"a" : @1} forDocument:docA];
-  [batch updateData:@{@"b" : @2} forDocument:docB];
+  [batch setData:@{ @"a" : @1 } forDocument:docA];
+  [batch updateData:@{ @"b" : @2 } forDocument:docB];
   [batch commitWithCompletion:^(NSError *_Nullable error) {
     XCTAssertNotNil(error);
     XCTAssertEqualObjects(error.domain, FIRFirestoreErrorDomain);
@@ -199,7 +199,7 @@
   // Local event with the set document.
   FIRQuerySnapshot *localSnap = [accumulator awaitEventWithName:@"local event"];
   XCTAssertTrue(localSnap.metadata.hasPendingWrites);
-  XCTAssertEqualObjects(FIRQuerySnapshotGetData(localSnap), (@[ @{@"a" : @1} ]));
+  XCTAssertEqualObjects(FIRQuerySnapshotGetData(localSnap), (@[ @{ @"a" : @1 } ]));
 
   // Server event with the set reverted.
   FIRQuerySnapshot *serverSnap = [accumulator awaitEventWithName:@"server event"];
@@ -250,7 +250,7 @@
   XCTestExpectation *expectation = [self expectationWithDescription:@"batch written"];
   FIRWriteBatch *batch = [doc.firestore batch];
   [batch deleteDocument:doc];
-  [batch setData:@{@"a" : @1, @"b" : @1, @"when" : @"when"} forDocument:doc];
+  [batch setData:@{ @"a" : @1, @"b" : @1, @"when" : @"when" } forDocument:doc];
   [batch updateData:@{
     @"b" : @2,
     @"when" : [FIRFieldValue fieldValueForServerTimestamp]
@@ -263,12 +263,12 @@
 
   FIRDocumentSnapshot *localSnap = [accumulator awaitEventWithName:@"local event"];
   XCTAssertTrue(localSnap.metadata.hasPendingWrites);
-  XCTAssertEqualObjects(localSnap.data, (@{@"a" : @1, @"b" : @2, @"when" : [NSNull null]}));
+  XCTAssertEqualObjects(localSnap.data, (@{ @"a" : @1, @"b" : @2, @"when" : [NSNull null] }));
 
   FIRDocumentSnapshot *serverSnap = [accumulator awaitEventWithName:@"server event"];
   XCTAssertFalse(serverSnap.metadata.hasPendingWrites);
   NSDate *when = serverSnap[@"when"];
-  XCTAssertEqualObjects(serverSnap.data, (@{@"a" : @1, @"b" : @2, @"when" : when}));
+  XCTAssertEqualObjects(serverSnap.data, (@{ @"a" : @1, @"b" : @2, @"when" : when }));
 }
 
 - (void)testUpdateFieldsWithDots {
@@ -277,7 +277,10 @@
   XCTestExpectation *expectation = [self expectationWithDescription:@"testUpdateFieldsWithDots"];
   FIRWriteBatch *batch = [doc.firestore batch];
   [batch setData:@{@"a.b" : @"old", @"c.d" : @"old"} forDocument:doc];
-  [batch updateData:@{[[FIRFieldPath alloc] initWithFields:@[ @"a.b" ]] : @"new"} forDocument:doc];
+  [batch updateData:@{
+    [[FIRFieldPath alloc] initWithFields:@[ @"a.b" ]] : @"new"
+  }
+        forDocument:doc];
 
   [batch commitWithCompletion:^(NSError *_Nullable error) {
     XCTAssertNil(error);

--- a/Firestore/Example/Tests/Integration/FSTTransactionTests.mm
+++ b/Firestore/Example/Tests/Integration/FSTTransactionTests.mm
@@ -31,15 +31,14 @@
 - (void)xtestGetDocuments {
   FIRFirestore *firestore = [self firestore];
   FIRDocumentReference *doc = [[firestore collectionWithPath:@"spaces"] documentWithAutoID];
-  [self writeDocumentRef:doc data:@{@"foo" : @1, @"desc" : @"Stuff", @"owner" : @"Jonny"}];
+  [self writeDocumentRef:doc data:@{ @"foo" : @1, @"desc" : @"Stuff", @"owner" : @"Jonny" }];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"transaction"];
-  [firestore
-      runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
-        [transaction getDocument:doc error:error];
-        XCTAssertNil(*error);
-        return @YES;
-      }
+  [firestore runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
+    [transaction getDocument:doc error:error];
+    XCTAssertNil(*error);
+    return @YES;
+  }
       completion:^(id _Nullable result, NSError *_Nullable error) {
         XCTAssertNil(result);
         // We currently require every document read to also be written.
@@ -58,11 +57,10 @@
   XCTAssertEqualObjects(@"bar", snapshot[@"foo"]);
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"transaction"];
-  [firestore
-      runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
-        [transaction deleteDocument:doc];
-        return @YES;
-      }
+  [firestore runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
+    [transaction deleteDocument:doc];
+    return @YES;
+  }
       completion:^(id _Nullable result, NSError *_Nullable error) {
         XCTAssertEqualObjects(@YES, result);
         XCTAssertNil(error);
@@ -79,14 +77,13 @@
   FIRDocumentReference *doc = [[firestore collectionWithPath:@"towns"] documentWithAutoID];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"transaction"];
-  [firestore
-      runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
-        FIRDocumentSnapshot *snapshot = [transaction getDocument:doc error:error];
-        XCTAssertNil(*error);
-        XCTAssertFalse(snapshot.exists);
-        [transaction setData:@{@"foo" : @"bar"} forDocument:doc];
-        return @YES;
-      }
+  [firestore runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
+    FIRDocumentSnapshot *snapshot = [transaction getDocument:doc error:error];
+    XCTAssertNil(*error);
+    XCTAssertFalse(snapshot.exists);
+    [transaction setData:@{@"foo" : @"bar"} forDocument:doc];
+    return @YES;
+  }
       completion:^(id _Nullable result, NSError *_Nullable error) {
         XCTAssertEqualObjects(@YES, result);
         XCTAssertNil(error);
@@ -104,14 +101,13 @@
   FIRDocumentReference *doc = [[firestore collectionWithPath:@"towns"] documentWithAutoID];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"transaction"];
-  [firestore
-      runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
-        FIRDocumentSnapshot *snapshot = [transaction getDocument:doc error:error];
-        XCTAssertNil(*error);
-        XCTAssertFalse(snapshot.exists);
-        [transaction updateData:@{@"foo" : @"bar"} forDocument:doc];
-        return @YES;
-      }
+  [firestore runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
+    FIRDocumentSnapshot *snapshot = [transaction getDocument:doc error:error];
+    XCTAssertNil(*error);
+    XCTAssertFalse(snapshot.exists);
+    [transaction updateData:@{@"foo" : @"bar"} forDocument:doc];
+    return @YES;
+  }
       completion:^(id _Nullable result, NSError *_Nullable error) {
         XCTAssertNil(result);
         XCTAssertNotNil(error);
@@ -130,16 +126,15 @@
   [self writeDocumentRef:doc data:@{@"foo" : @"bar"}];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"transaction"];
-  [firestore
-      runTransactionWithBlock:^id(FIRTransaction *transaction, NSError **error) {
-        FIRDocumentSnapshot *snapshot = [transaction getDocument:doc error:error];
-        XCTAssertNil(*error);
-        XCTAssertTrue(snapshot.exists);
-        [transaction deleteDocument:doc];
-        // Since we deleted the doc, the update will fail
-        [transaction updateData:@{@"foo" : @"bar"} forDocument:doc];
-        return @YES;
-      }
+  [firestore runTransactionWithBlock:^id(FIRTransaction *transaction, NSError **error) {
+    FIRDocumentSnapshot *snapshot = [transaction getDocument:doc error:error];
+    XCTAssertNil(*error);
+    XCTAssertTrue(snapshot.exists);
+    [transaction deleteDocument:doc];
+    // Since we deleted the doc, the update will fail
+    [transaction updateData:@{@"foo" : @"bar"} forDocument:doc];
+    return @YES;
+  }
       completion:^(id _Nullable result, NSError *_Nullable error) {
         XCTAssertNil(result);
         XCTAssertNotNil(error);
@@ -158,17 +153,16 @@
   [self writeDocumentRef:doc data:@{@"foo" : @"bar"}];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"transaction"];
-  [firestore
-      runTransactionWithBlock:^id(FIRTransaction *transaction, NSError **error) {
-        FIRDocumentSnapshot *snapshot = [transaction getDocument:doc error:error];
-        XCTAssertNil(*error);
-        XCTAssertTrue(snapshot.exists);
-        [transaction deleteDocument:doc];
-        // TODO(dimond): In theory this should work, but it's complex to make it work, so instead we
-        // just let the transaction fail and verify it's unsupported for now
-        [transaction setData:@{@"foo" : @"new-bar"} forDocument:doc];
-        return @YES;
-      }
+  [firestore runTransactionWithBlock:^id(FIRTransaction *transaction, NSError **error) {
+    FIRDocumentSnapshot *snapshot = [transaction getDocument:doc error:error];
+    XCTAssertNil(*error);
+    XCTAssertTrue(snapshot.exists);
+    [transaction deleteDocument:doc];
+    // TODO(dimond): In theory this should work, but it's complex to make it work, so instead we
+    // just let the transaction fail and verify it's unsupported for now
+    [transaction setData:@{@"foo" : @"new-bar"} forDocument:doc];
+    return @YES;
+  }
       completion:^(id _Nullable result, NSError *_Nullable error) {
         XCTAssertNil(result);
         XCTAssertNotNil(error);
@@ -186,12 +180,11 @@
   FIRDocumentReference *doc = [[firestore collectionWithPath:@"towns"] documentWithAutoID];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"transaction"];
-  [firestore
-      runTransactionWithBlock:^id(FIRTransaction *transaction, NSError **error) {
-        [transaction setData:@{@"a" : @"b"} forDocument:doc];
-        [transaction setData:@{@"c" : @"d"} forDocument:doc];
-        return @YES;
-      }
+  [firestore runTransactionWithBlock:^id(FIRTransaction *transaction, NSError **error) {
+    [transaction setData:@{@"a" : @"b"} forDocument:doc];
+    [transaction setData:@{@"c" : @"d"} forDocument:doc];
+    return @YES;
+  }
       completion:^(id _Nullable result, NSError *_Nullable error) {
         XCTAssertEqualObjects(@YES, result);
         XCTAssertNil(error);
@@ -208,12 +201,11 @@
   FIRDocumentReference *doc = [[firestore collectionWithPath:@"towns"] documentWithAutoID];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"transaction"];
-  [firestore
-      runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
-        [transaction setData:@{@"a" : @"b", @"nested" : @{@"a" : @"b"}} forDocument:doc];
-        [transaction setData:@{@"c" : @"d", @"nested" : @{@"c" : @"d"}} forDocument:doc merge:YES];
-        return @YES;
-      }
+  [firestore runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
+    [transaction setData:@{ @"a" : @"b", @"nested" : @{@"a" : @"b"} } forDocument:doc];
+    [transaction setData:@{ @"c" : @"d", @"nested" : @{@"c" : @"d"} } forDocument:doc merge:YES];
+    return @YES;
+  }
       completion:^(id _Nullable result, NSError *_Nullable error) {
         XCTAssertEqualObjects(@YES, result);
         XCTAssertNil(error);
@@ -222,11 +214,11 @@
   [self awaitExpectations];
 
   FIRDocumentSnapshot *snapshot = [self readDocumentForRef:doc];
-  XCTAssertEqualObjects(snapshot.data,
-                        (
-                            @{@"a" : @"b",
-                              @"c" : @"d",
-                              @"nested" : @{@"a" : @"b", @"c" : @"d"}}));
+  XCTAssertEqualObjects(
+      snapshot.data, (
+                         @{ @"a" : @"b",
+                            @"c" : @"d",
+                            @"nested" : @{@"a" : @"b", @"c" : @"d"} }));
 }
 
 - (void)testCannotUpdateNonExistentDocument {
@@ -234,11 +226,10 @@
   FIRDocumentReference *doc = [[firestore collectionWithPath:@"towns"] documentWithAutoID];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"transaction"];
-  [firestore
-      runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
-        [transaction updateData:@{@"foo" : @"bar"} forDocument:doc];
-        return nil;
-      }
+  [firestore runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
+    [transaction updateData:@{@"foo" : @"bar"} forDocument:doc];
+    return nil;
+  }
       completion:^(id _Nullable result, NSError *_Nullable error) {
         XCTAssertNotNil(error);
         [expectation fulfill];
@@ -256,30 +247,29 @@
 
   FIRFirestore *firestore = [self firestore];
   FIRDocumentReference *doc = [[firestore collectionWithPath:@"counters"] documentWithAutoID];
-  [self writeDocumentRef:doc data:@{@"count" : @(5.0)}];
+  [self writeDocumentRef:doc data:@{ @"count" : @(5.0) }];
 
   // Make 3 transactions that will all increment.
   int total = 3;
   for (int i = 0; i < total; i++) {
     XCTestExpectation *expectation = [self expectationWithDescription:@"transaction"];
-    [firestore
-        runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
-          FIRDocumentSnapshot *snapshot = [transaction getDocument:doc error:error];
-          XCTAssertNil(*error);
-          int32_t nowStarted = OSAtomicIncrement32(&started);
-          // Once all of the transactions have read, allow the first write.
-          if (nowStarted == total) {
-            dispatch_semaphore_signal(writeBarrier);
-          }
+    [firestore runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
+      FIRDocumentSnapshot *snapshot = [transaction getDocument:doc error:error];
+      XCTAssertNil(*error);
+      int32_t nowStarted = OSAtomicIncrement32(&started);
+      // Once all of the transactions have read, allow the first write.
+      if (nowStarted == total) {
+        dispatch_semaphore_signal(writeBarrier);
+      }
 
-          dispatch_semaphore_wait(writeBarrier, DISPATCH_TIME_FOREVER);
-          // Refill the barrier so that the other transactions and retries succeed.
-          dispatch_semaphore_signal(writeBarrier);
+      dispatch_semaphore_wait(writeBarrier, DISPATCH_TIME_FOREVER);
+      // Refill the barrier so that the other transactions and retries succeed.
+      dispatch_semaphore_signal(writeBarrier);
 
-          double newCount = ((NSNumber *)snapshot[@"count"]).doubleValue + 1.0;
-          [transaction setData:@{@"count" : @(newCount)} forDocument:doc];
-          return @YES;
-        }
+      double newCount = ((NSNumber *)snapshot[@"count"]).doubleValue + 1.0;
+      [transaction setData:@{ @"count" : @(newCount) } forDocument:doc];
+      return @YES;
+    }
         completion:^(id _Nullable result, NSError *_Nullable error) {
           [expectation fulfill];
         }];
@@ -298,30 +288,29 @@
 
   FIRFirestore *firestore = [self firestore];
   FIRDocumentReference *doc = [[firestore collectionWithPath:@"counters"] documentWithAutoID];
-  [self writeDocumentRef:doc data:@{@"count" : @(5.0), @"other" : @"yes"}];
+  [self writeDocumentRef:doc data:@{ @"count" : @(5.0), @"other" : @"yes" }];
 
   // Make 3 transactions that will all increment.
   int total = 3;
   for (int i = 0; i < total; i++) {
     XCTestExpectation *expectation = [self expectationWithDescription:@"transaction"];
-    [firestore
-        runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
-          FIRDocumentSnapshot *snapshot = [transaction getDocument:doc error:error];
-          XCTAssertNil(*error);
-          int32_t nowStarted = OSAtomicIncrement32(&started);
-          // Once all of the transactions have read, allow the first write.
-          if (nowStarted == total) {
-            dispatch_semaphore_signal(writeBarrier);
-          }
+    [firestore runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
+      FIRDocumentSnapshot *snapshot = [transaction getDocument:doc error:error];
+      XCTAssertNil(*error);
+      int32_t nowStarted = OSAtomicIncrement32(&started);
+      // Once all of the transactions have read, allow the first write.
+      if (nowStarted == total) {
+        dispatch_semaphore_signal(writeBarrier);
+      }
 
-          dispatch_semaphore_wait(writeBarrier, DISPATCH_TIME_FOREVER);
-          // Refill the barrier so that the other transactions and retries succeed.
-          dispatch_semaphore_signal(writeBarrier);
+      dispatch_semaphore_wait(writeBarrier, DISPATCH_TIME_FOREVER);
+      // Refill the barrier so that the other transactions and retries succeed.
+      dispatch_semaphore_signal(writeBarrier);
 
-          double newCount = ((NSNumber *)snapshot[@"count"]).doubleValue + 1.0;
-          [transaction updateData:@{@"count" : @(newCount)} forDocument:doc];
-          return @YES;
-        }
+      double newCount = ((NSNumber *)snapshot[@"count"]).doubleValue + 1.0;
+      [transaction updateData:@{ @"count" : @(newCount) } forDocument:doc];
+      return @YES;
+    }
         completion:^(id _Nullable result, NSError *_Nullable error) {
           [expectation fulfill];
         }];
@@ -341,32 +330,31 @@
   FIRDocumentReference *doc1 = [[firestore collectionWithPath:@"counters"] documentWithAutoID];
   FIRDocumentReference *doc2 = [[firestore collectionWithPath:@"counters"] documentWithAutoID];
 
-  [self writeDocumentRef:doc1 data:@{@"count" : @(15.0)}];
+  [self writeDocumentRef:doc1 data:@{ @"count" : @(15.0) }];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"transaction"];
-  [firestore
-      runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
-        // Get the first doc.
-        [transaction getDocument:doc1 error:error];
-        XCTAssertNil(*error);
-        // Do a write outside of the transaction. The first time the
-        // transaction is tried, this will bump the version, which
-        // will cause the write to doc2 to fail. The second time, it
-        // will be a no-op and not bump the version.
-        dispatch_semaphore_t writeSemaphore = dispatch_semaphore_create(0);
-        [doc1 setData:@{
-          @"count" : @(1234)
-        }
-            completion:^(NSError *_Nullable error) {
-              dispatch_semaphore_signal(writeSemaphore);
-            }];
-        // We can block on it, because transactions run on a background queue.
-        dispatch_semaphore_wait(writeSemaphore, DISPATCH_TIME_FOREVER);
-        // Now try to update the other doc from within the transaction.
-        // This should fail once, because we read 15 earlier.
-        [transaction setData:@{@"count" : @(16)} forDocument:doc2];
-        return nil;
-      }
+  [firestore runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
+    // Get the first doc.
+    [transaction getDocument:doc1 error:error];
+    XCTAssertNil(*error);
+    // Do a write outside of the transaction. The first time the
+    // transaction is tried, this will bump the version, which
+    // will cause the write to doc2 to fail. The second time, it
+    // will be a no-op and not bump the version.
+    dispatch_semaphore_t writeSemaphore = dispatch_semaphore_create(0);
+    [doc1 setData:@{
+      @"count" : @(1234)
+    }
+        completion:^(NSError *_Nullable error) {
+          dispatch_semaphore_signal(writeSemaphore);
+        }];
+    // We can block on it, because transactions run on a background queue.
+    dispatch_semaphore_wait(writeSemaphore, DISPATCH_TIME_FOREVER);
+    // Now try to update the other doc from within the transaction.
+    // This should fail once, because we read 15 earlier.
+    [transaction setData:@{ @"count" : @(16) } forDocument:doc2];
+    return nil;
+  }
       completion:^(id _Nullable result, NSError *_Nullable error) {
         // We currently require every document read to also be written.
         // TODO(b/34879758): Add this check back once we drop that.
@@ -387,33 +375,32 @@
 - (void)testReadingADocTwiceWithDifferentVersions {
   FIRFirestore *firestore = [self firestore];
   FIRDocumentReference *doc = [[firestore collectionWithPath:@"counters"] documentWithAutoID];
-  [self writeDocumentRef:doc data:@{@"count" : @(15.0)}];
+  [self writeDocumentRef:doc data:@{ @"count" : @(15.0) }];
   XCTestExpectation *expectation = [self expectationWithDescription:@"transaction"];
-  [firestore
-      runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
-        // Get the doc once.
-        FIRDocumentSnapshot *snapshot = [transaction getDocument:doc error:error];
-        XCTAssertNil(*error);
-        XCTAssertEqualObjects(@(15), snapshot[@"count"]);
-        // Do a write outside of the transaction.
-        dispatch_semaphore_t writeSemaphore = dispatch_semaphore_create(0);
-        [doc setData:@{
-          @"count" : @(1234)
-        }
-            completion:^(NSError *_Nullable error) {
-              dispatch_semaphore_signal(writeSemaphore);
-            }];
-        // We can block on it, because transactions run on a background queue.
-        dispatch_semaphore_wait(writeSemaphore, DISPATCH_TIME_FOREVER);
-        // Get the doc again in the transaction with the new version.
-        snapshot = [transaction getDocument:doc error:error];
-        // The get itself will fail, because we already read an earlier version of this document.
-        // TODO(klimt): Perhaps we shouldn't fail reads for this, but should wait and fail the
-        // whole transaction? It's an edge-case anyway, as developers shouldn't be reading the same
-        // do multiple times. But they need to handle read errors anyway.
-        XCTAssertNotNil(*error);
-        return nil;
-      }
+  [firestore runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
+    // Get the doc once.
+    FIRDocumentSnapshot *snapshot = [transaction getDocument:doc error:error];
+    XCTAssertNil(*error);
+    XCTAssertEqualObjects(@(15), snapshot[@"count"]);
+    // Do a write outside of the transaction.
+    dispatch_semaphore_t writeSemaphore = dispatch_semaphore_create(0);
+    [doc setData:@{
+      @"count" : @(1234)
+    }
+        completion:^(NSError *_Nullable error) {
+          dispatch_semaphore_signal(writeSemaphore);
+        }];
+    // We can block on it, because transactions run on a background queue.
+    dispatch_semaphore_wait(writeSemaphore, DISPATCH_TIME_FOREVER);
+    // Get the doc again in the transaction with the new version.
+    snapshot = [transaction getDocument:doc error:error];
+    // The get itself will fail, because we already read an earlier version of this document.
+    // TODO(klimt): Perhaps we shouldn't fail reads for this, but should wait and fail the
+    // whole transaction? It's an edge-case anyway, as developers shouldn't be reading the same
+    // do multiple times. But they need to handle read errors anyway.
+    XCTAssertNotNil(*error);
+    return nil;
+  }
       completion:^(id _Nullable result, NSError *_Nullable error) {
         [expectation fulfill];
       }];
@@ -430,13 +417,12 @@
   FIRDocumentReference *doc = [[firestore collectionWithPath:@"foo"] documentWithAutoID];
   [self writeDocumentRef:doc data:@{@"foo" : @"bar"}];
   XCTestExpectation *expectation = [self expectationWithDescription:@"transaction"];
-  [firestore
-      runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
-        FIRDocumentSnapshot *snapshot = [transaction getDocument:doc error:error];
-        XCTAssertTrue(snapshot.exists);
-        XCTAssertNil(*error);
-        return nil;
-      }
+  [firestore runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
+    FIRDocumentSnapshot *snapshot = [transaction getDocument:doc error:error];
+    XCTAssertTrue(snapshot.exists);
+    XCTAssertNil(*error);
+    return nil;
+  }
       completion:^(id _Nullable result, NSError *_Nullable error) {
         XCTAssertNotNil(error);
         [expectation fulfill];
@@ -447,10 +433,9 @@
 - (void)testSuccessWithNoTransactionOperations {
   FIRFirestore *firestore = [self firestore];
   XCTestExpectation *expectation = [self expectationWithDescription:@"transaction"];
-  [firestore
-      runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
-        return @"yes";
-      }
+  [firestore runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
+    return @"yes";
+  }
       completion:^(id _Nullable result, NSError *_Nullable error) {
         XCTAssertEqualObjects(@"yes", result);
         XCTAssertNil(error);
@@ -464,15 +449,14 @@
   FIRDocumentReference *doc = [[firestore collectionWithPath:@"towns"] documentWithAutoID];
   __block volatile int32_t count = 0;
   XCTestExpectation *expectation = [self expectationWithDescription:@"transaction"];
-  [firestore
-      runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
-        OSAtomicIncrement32(&count);
-        [transaction setData:@{@"foo" : @"bar"} forDocument:doc];
-        if (error) {
-          *error = [NSError errorWithDomain:NSCocoaErrorDomain code:35 userInfo:@{}];
-        }
-        return nil;
-      }
+  [firestore runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
+    OSAtomicIncrement32(&count);
+    [transaction setData:@{@"foo" : @"bar"} forDocument:doc];
+    if (error) {
+      *error = [NSError errorWithDomain:NSCocoaErrorDomain code:35 userInfo:@{}];
+    }
+    return nil;
+  }
       completion:^(id _Nullable result, NSError *_Nullable error) {
         XCTAssertNil(result);
         XCTAssertNotNil(error);

--- a/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
@@ -68,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   _previousTargetID = 500;
   _previousDocNum = 10;
-  _testValue = FSTTestObjectValue(@{@"baz" : @YES, @"ok" : @"fine"});
+  _testValue = FSTTestObjectValue(@{ @"baz" : @YES, @"ok" : @"fine" });
   NSString *bigString = [@"" stringByPaddingToLength:4096 withString:@"a" startingAtIndex:0];
   _bigObjectValue = FSTTestObjectValue(@{@"BigProperty" : bigString});
   _user = User("user");
@@ -620,7 +620,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   // Finally, do the garbage collection, up to but not including the removal of middleTarget
   NSDictionary<NSNumber *, FSTQueryData *> *liveQueries =
-      @{@(oldestTarget.targetID) : oldestTarget};
+      @{ @(oldestTarget.targetID) : oldestTarget };
   int queriesRemoved = [self removeQueriesThroughSequenceNumber:upperBound liveQueries:liveQueries];
   XCTAssertEqual(1, queriesRemoved, @"Expected to remove newest target");
   int docsRemoved = [self removeOrphanedDocumentsThroughSequenceNumber:upperBound];

--- a/Firestore/Example/Tests/Local/FSTLocalSerializerTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLocalSerializerTests.mm
@@ -80,12 +80,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)testEncodesMutationBatch {
-  FSTMutation *set = FSTTestSetMutation(@"foo/bar", @{@"a" : @"b", @"num" : @1});
+  FSTMutation *set = FSTTestSetMutation(@"foo/bar", @{ @"a" : @"b", @"num" : @1 });
   FSTMutation *patch = [[FSTPatchMutation alloc] initWithKey:FSTTestDocKey(@"bar/baz")
                                                    fieldMask:FieldMask{testutil::Field("a")}
                                                        value:FSTTestObjectValue(
-                                                                 @{@"a" : @"b",
-                                                                   @"num" : @1})
+                                                                 @{ @"a" : @"b",
+                                                                    @"num" : @1 })
                                                 precondition:Precondition::Exists(true)];
   FSTMutation *del = FSTTestDeleteMutation(@"baz/quux");
   FIRTimestamp *writeTime = [FIRTimestamp timestamp];

--- a/Firestore/Example/Tests/Local/FSTMutationQueueTests.mm
+++ b/Firestore/Example/Tests/Local/FSTMutationQueueTests.mm
@@ -287,17 +287,17 @@ NS_ASSUME_NONNULL_BEGIN
   self.persistence.run("testAllMutationBatchesAffectingDocumentKey", [&]() {
     NSArray<FSTMutation *> *mutations = @[
       FSTTestSetMutation(@"foi/bar",
-                         @{@"a" : @1}),
+                         @{ @"a" : @1 }),
       FSTTestSetMutation(@"foo/bar",
-                         @{@"a" : @1}),
+                         @{ @"a" : @1 }),
       FSTTestPatchMutation("foo/bar",
-                           @{@"b" : @1}, {}),
+                           @{ @"b" : @1 }, {}),
       FSTTestSetMutation(@"foo/bar/suffix/key",
-                         @{@"a" : @1}),
+                         @{ @"a" : @1 }),
       FSTTestSetMutation(@"foo/baz",
-                         @{@"a" : @1}),
+                         @{ @"a" : @1 }),
       FSTTestSetMutation(@"food/bar",
-                         @{@"a" : @1})
+                         @{ @"a" : @1 })
     ];
 
     // Store all the mutations.
@@ -323,17 +323,17 @@ NS_ASSUME_NONNULL_BEGIN
   self.persistence.run("testAllMutationBatchesAffectingDocumentKey", [&]() {
     NSArray<FSTMutation *> *mutations = @[
       FSTTestSetMutation(@"fob/bar",
-                         @{@"a" : @1}),
+                         @{ @"a" : @1 }),
       FSTTestSetMutation(@"foo/bar",
-                         @{@"a" : @1}),
+                         @{ @"a" : @1 }),
       FSTTestPatchMutation("foo/bar",
-                           @{@"b" : @1}, {}),
+                           @{ @"b" : @1 }, {}),
       FSTTestSetMutation(@"foo/bar/suffix/key",
-                         @{@"a" : @1}),
+                         @{ @"a" : @1 }),
       FSTTestSetMutation(@"foo/baz",
-                         @{@"a" : @1}),
+                         @{ @"a" : @1 }),
       FSTTestSetMutation(@"food/bar",
-                         @{@"a" : @1})
+                         @{ @"a" : @1 })
     ];
 
     // Store all the mutations.
@@ -364,20 +364,20 @@ NS_ASSUME_NONNULL_BEGIN
   self.persistence.run("testAllMutationBatchesAffectingDocumentKeys_handlesOverlap", [&]() {
     NSArray<FSTMutation *> *group1 = @[
       FSTTestSetMutation(@"foo/bar",
-                         @{@"a" : @1}),
+                         @{ @"a" : @1 }),
       FSTTestSetMutation(@"foo/baz",
-                         @{@"a" : @1}),
+                         @{ @"a" : @1 }),
     ];
     FSTMutationBatch *batch1 =
         [self.mutationQueue addMutationBatchWithWriteTime:[FIRTimestamp timestamp]
                                                 mutations:group1];
 
-    NSArray<FSTMutation *> *group2 = @[ FSTTestSetMutation(@"food/bar", @{@"a" : @1}) ];
+    NSArray<FSTMutation *> *group2 = @[ FSTTestSetMutation(@"food/bar", @{ @"a" : @1 }) ];
     [self.mutationQueue addMutationBatchWithWriteTime:[FIRTimestamp timestamp] mutations:group2];
 
     NSArray<FSTMutation *> *group3 = @[
       FSTTestSetMutation(@"foo/bar",
-                         @{@"b" : @1}),
+                         @{ @"b" : @1 }),
     ];
     FSTMutationBatch *batch3 =
         [self.mutationQueue addMutationBatchWithWriteTime:[FIRTimestamp timestamp]
@@ -402,17 +402,17 @@ NS_ASSUME_NONNULL_BEGIN
   self.persistence.run("testAllMutationBatchesAffectingQuery", [&]() {
     NSArray<FSTMutation *> *mutations = @[
       FSTTestSetMutation(@"fob/bar",
-                         @{@"a" : @1}),
+                         @{ @"a" : @1 }),
       FSTTestSetMutation(@"foo/bar",
-                         @{@"a" : @1}),
+                         @{ @"a" : @1 }),
       FSTTestPatchMutation("foo/bar",
-                           @{@"b" : @1}, {}),
+                           @{ @"b" : @1 }, {}),
       FSTTestSetMutation(@"foo/bar/suffix/key",
-                         @{@"a" : @1}),
+                         @{ @"a" : @1 }),
       FSTTestSetMutation(@"foo/baz",
-                         @{@"a" : @1}),
+                         @{ @"a" : @1 }),
       FSTTestSetMutation(@"food/bar",
-                         @{@"a" : @1})
+                         @{ @"a" : @1 })
     ];
 
     // Store all the mutations.
@@ -520,7 +520,7 @@ NS_ASSUME_NONNULL_BEGIN
  * mutations.
  */
 - (FSTMutationBatch *)addMutationBatchWithKey:(NSString *)key {
-  FSTSetMutation *mutation = FSTTestSetMutation(key, @{@"a" : @1});
+  FSTSetMutation *mutation = FSTTestSetMutation(key, @{ @"a" : @1 });
 
   FSTMutationBatch *batch =
       [self.mutationQueue addMutationBatchWithWriteTime:[FIRTimestamp timestamp]

--- a/Firestore/Example/Tests/Local/FSTRemoteDocumentCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTRemoteDocumentCacheTests.mm
@@ -45,7 +45,7 @@ static const int kVersion = 42;
   [super setUp];
 
   // essentially a constant, but can't be a compile-time one.
-  _kDocData = @{@"a" : @1, @"b" : @2};
+  _kDocData = @{ @"a" : @1, @"b" : @2 };
 }
 
 - (void)tearDown {
@@ -98,7 +98,7 @@ static const int kVersion = 42;
 
   self.persistence.run("testSetDocumentToNewValue", [&]() {
     [self setTestDocumentAtPath:kDocPath];
-    FSTDocument *newDoc = FSTTestDoc(kDocPath, kVersion, @{@"data" : @2}, NO);
+    FSTDocument *newDoc = FSTTestDoc(kDocPath, kVersion, @{ @"data" : @2 }, NO);
     [self.remoteDocumentCache addEntry:newDoc];
     XCTAssertEqualObjects([self.remoteDocumentCache entryForKey:testutil::Key(kDocPath)], newDoc);
   });

--- a/Firestore/Example/Tests/Model/FSTDocumentSetTests.mm
+++ b/Firestore/Example/Tests/Model/FSTDocumentSetTests.mm
@@ -38,9 +38,9 @@ NS_ASSUME_NONNULL_BEGIN
   [super setUp];
 
   _comp = FSTTestDocComparator("sort");
-  _doc1 = FSTTestDoc("docs/1", 0, @{@"sort" : @2}, NO);
-  _doc2 = FSTTestDoc("docs/2", 0, @{@"sort" : @3}, NO);
-  _doc3 = FSTTestDoc("docs/3", 0, @{@"sort" : @1}, NO);
+  _doc1 = FSTTestDoc("docs/1", 0, @{ @"sort" : @2 }, NO);
+  _doc2 = FSTTestDoc("docs/2", 0, @{ @"sort" : @3 }, NO);
+  _doc3 = FSTTestDoc("docs/3", 0, @{ @"sort" : @1 }, NO);
 }
 
 - (void)testCount {
@@ -97,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testUpdates {
   FSTDocumentSet *set = FSTTestDocSet(_comp, @[ _doc1, _doc2, _doc3 ]);
 
-  FSTDocument *doc2Prime = FSTTestDoc("docs/2", 0, @{@"sort" : @9}, NO);
+  FSTDocument *doc2Prime = FSTTestDoc("docs/2", 0, @{ @"sort" : @9 }, NO);
 
   set = [set documentSetByAddingDocument:doc2Prime];
   XCTAssertEqual([set count], 3);
@@ -106,7 +106,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)testAddsDocsWithEqualComparisonValues {
-  FSTDocument *doc4 = FSTTestDoc("docs/4", 0, @{@"sort" : @2}, NO);
+  FSTDocument *doc4 = FSTTestDoc("docs/4", 0, @{ @"sort" : @2 }, NO);
 
   FSTDocumentSet *set = FSTTestDocSet(_comp, @[ _doc1, doc4 ]);
   XCTAssertEqualObjects([[set documentEnumerator] allObjects], (@[ _doc1, doc4 ]));

--- a/Firestore/Example/Tests/Model/FSTDocumentTests.mm
+++ b/Firestore/Example/Tests/Model/FSTDocumentTests.mm
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testConstructor {
   DocumentKey key = testutil::Key("messages/first");
   SnapshotVersion version = testutil::Version(1);
-  FSTObjectValue *data = FSTTestObjectValue(@{@"a" : @1});
+  FSTObjectValue *data = FSTTestObjectValue(@{ @"a" : @1 });
   FSTDocument *doc =
       [FSTDocument documentWithData:data key:key version:version hasLocalMutations:NO];
 
@@ -67,30 +67,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testIsEqual {
   XCTAssertEqualObjects(FSTTestDoc("messages/first", 1,
-                                   @{@"a" : @1}, NO),
+                                   @{ @"a" : @1 }, NO),
                         FSTTestDoc("messages/first", 1,
-                                   @{@"a" : @1}, NO));
+                                   @{ @"a" : @1 }, NO));
   XCTAssertNotEqualObjects(FSTTestDoc("messages/first", 1,
-                                      @{@"a" : @1}, NO),
+                                      @{ @"a" : @1 }, NO),
                            FSTTestDoc("messages/first", 1,
-                                      @{@"b" : @1}, NO));
+                                      @{ @"b" : @1 }, NO));
   XCTAssertNotEqualObjects(FSTTestDoc("messages/first", 1,
-                                      @{@"a" : @1}, NO),
+                                      @{ @"a" : @1 }, NO),
                            FSTTestDoc("messages/second", 1,
-                                      @{@"b" : @1}, NO));
+                                      @{ @"b" : @1 }, NO));
   XCTAssertNotEqualObjects(FSTTestDoc("messages/first", 1,
-                                      @{@"a" : @1}, NO),
+                                      @{ @"a" : @1 }, NO),
                            FSTTestDoc("messages/first", 2,
-                                      @{@"a" : @1}, NO));
+                                      @{ @"a" : @1 }, NO));
   XCTAssertNotEqualObjects(FSTTestDoc("messages/first", 1,
-                                      @{@"a" : @1}, NO),
+                                      @{ @"a" : @1 }, NO),
                            FSTTestDoc("messages/first", 1,
-                                      @{@"a" : @1}, YES));
+                                      @{ @"a" : @1 }, YES));
 
   XCTAssertEqualObjects(FSTTestDoc("messages/first", 1,
-                                   @{@"a" : @1}, YES),
+                                   @{ @"a" : @1 }, YES),
                         FSTTestDoc("messages/first", 1,
-                                   @{@"a" : @1}, 5));
+                                   @{ @"a" : @1 }, 5));
 }
 
 @end

--- a/Firestore/Example/Tests/Model/FSTFieldValueTests.mm
+++ b/Firestore/Example/Tests/Model/FSTFieldValueTests.mm
@@ -270,10 +270,10 @@ union DoubleBits {
 
 - (void)testWrapsSimpleObjects {
   FSTObjectValue *actual = FSTTestObjectValue(
-      @{@"a" : @"foo",
-        @"b" : @(1L),
-        @"c" : @YES,
-        @"d" : [NSNull null]});
+      @{ @"a" : @"foo",
+         @"b" : @(1L),
+         @"c" : @YES,
+         @"d" : [NSNull null] });
   FSTObjectValue *expected = [[FSTObjectValue alloc] initWithDictionary:@{
     @"a" : [FSTStringValue stringValue:@"foo"],
     @"b" : [FSTIntegerValue integerValue:1LL],
@@ -284,7 +284,7 @@ union DoubleBits {
 }
 
 - (void)testWrapsNestedObjects {
-  FSTObjectValue *actual = FSTTestObjectValue(@{@"a" : @{@"b" : @{@"c" : @"foo"}, @"d" : @YES}});
+  FSTObjectValue *actual = FSTTestObjectValue(@{ @"a" : @{@"b" : @{@"c" : @"foo"}, @"d" : @YES} });
   FSTObjectValue *expected = [[FSTObjectValue alloc] initWithDictionary:@{
     @"a" : [[FSTObjectValue alloc] initWithDictionary:@{
       @"b" :
@@ -296,7 +296,7 @@ union DoubleBits {
 }
 
 - (void)testExtractsFields {
-  FSTObjectValue *obj = FSTTestObjectValue(@{@"foo" : @{@"a" : @YES, @"b" : @"string"}});
+  FSTObjectValue *obj = FSTTestObjectValue(@{ @"foo" : @{@"a" : @YES, @"b" : @"string"} });
   FSTAssertIsKindOfClass(obj, FSTObjectValue);
 
   FSTAssertIsKindOfClass([obj valueForPath:testutil::Field("foo")], FSTObjectValue);
@@ -332,7 +332,7 @@ union DoubleBits {
   mod = [old objectBySettingValue:FSTTestFieldValue(@1) forPath:testutil::Field("b")];
   XCTAssertNotEqual(old, mod);
   XCTAssertEqualObjects(old, FSTTestFieldValue(@{@"a" : @"mod"}));
-  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{@"a" : @"mod", @"b" : @1}));
+  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{ @"a" : @"mod", @"b" : @1 }));
 }
 
 - (void)testImplicitlyCreatesObjects {
@@ -342,72 +342,73 @@ union DoubleBits {
   XCTAssertNotEqual(old, mod);
   XCTAssertEqualObjects(old, FSTTestFieldValue(@{@"a" : @"old"}));
   XCTAssertEqualObjects(mod, FSTTestFieldValue(
-                                 @{@"a" : @"old",
-                                   @"b" : @{@"c" : @{@"d" : @"mod"}}}));
+                                 @{ @"a" : @"old",
+                                    @"b" : @{@"c" : @{@"d" : @"mod"}} }));
 }
 
 - (void)testCanOverwritePrimitivesWithObjects {
-  FSTObjectValue *old = FSTTestObjectValue(@{@"a" : @{@"b" : @"old"}});
+  FSTObjectValue *old = FSTTestObjectValue(@{ @"a" : @{@"b" : @"old"} });
   FSTObjectValue *mod =
       [old objectBySettingValue:FSTTestFieldValue(@{@"b" : @"mod"}) forPath:testutil::Field("a")];
   XCTAssertNotEqual(old, mod);
-  XCTAssertEqualObjects(old, FSTTestFieldValue(@{@"a" : @{@"b" : @"old"}}));
-  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{@"a" : @{@"b" : @"mod"}}));
+  XCTAssertEqualObjects(old, FSTTestFieldValue(@{ @"a" : @{@"b" : @"old"} }));
+  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{ @"a" : @{@"b" : @"mod"} }));
 }
 
 - (void)testAddsToNestedObjects {
-  FSTObjectValue *old = FSTTestObjectValue(@{@"a" : @{@"b" : @"old"}});
+  FSTObjectValue *old = FSTTestObjectValue(@{ @"a" : @{@"b" : @"old"} });
   FSTObjectValue *mod =
       [old objectBySettingValue:FSTTestFieldValue(@"mod") forPath:testutil::Field("a.c")];
   XCTAssertNotEqual(old, mod);
-  XCTAssertEqualObjects(old, FSTTestFieldValue(@{@"a" : @{@"b" : @"old"}}));
-  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{@"a" : @{@"b" : @"old", @"c" : @"mod"}}));
+  XCTAssertEqualObjects(old, FSTTestFieldValue(@{ @"a" : @{@"b" : @"old"} }));
+  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{ @"a" : @{@"b" : @"old", @"c" : @"mod"} }));
 }
 
 - (void)testDeletesKeys {
-  FSTObjectValue *old = FSTTestObjectValue(@{@"a" : @1, @"b" : @2});
+  FSTObjectValue *old = FSTTestObjectValue(@{ @"a" : @1, @"b" : @2 });
   FSTObjectValue *mod = [old objectByDeletingPath:testutil::Field("a")];
   XCTAssertNotEqual(old, mod);
-  XCTAssertEqualObjects(old, FSTTestFieldValue(@{@"a" : @1, @"b" : @2}));
-  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{@"b" : @2}));
+  XCTAssertEqualObjects(old, FSTTestFieldValue(@{ @"a" : @1, @"b" : @2 }));
+  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{ @"b" : @2 }));
 
   FSTObjectValue *empty = [mod objectByDeletingPath:testutil::Field("b")];
   XCTAssertNotEqual(mod, empty);
-  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{@"b" : @2}));
+  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{ @"b" : @2 }));
   XCTAssertEqualObjects(empty, FSTTestFieldValue(@{}));
 }
 
 - (void)testDeletesHandleMissingKeys {
-  FSTObjectValue *old = FSTTestObjectValue(@{@"a" : @{@"b" : @1, @"c" : @2}});
+  FSTObjectValue *old = FSTTestObjectValue(@{ @"a" : @{@"b" : @1, @"c" : @2} });
   FSTObjectValue *mod = [old objectByDeletingPath:testutil::Field("b")];
   XCTAssertEqualObjects(old, mod);
-  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{@"a" : @{@"b" : @1, @"c" : @2}}));
+  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{ @"a" : @{@"b" : @1, @"c" : @2} }));
 
   mod = [old objectByDeletingPath:testutil::Field("a.d")];
   XCTAssertEqualObjects(old, mod);
-  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{@"a" : @{@"b" : @1, @"c" : @2}}));
+  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{ @"a" : @{@"b" : @1, @"c" : @2} }));
 
   mod = [old objectByDeletingPath:testutil::Field("a.b.c")];
   XCTAssertEqualObjects(old, mod);
-  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{@"a" : @{@"b" : @1, @"c" : @2}}));
+  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{ @"a" : @{@"b" : @1, @"c" : @2} }));
 }
 
 - (void)testDeletesNestedKeys {
-  FSTObjectValue *old = FSTTestObjectValue(@{@"a" : @{@"b" : @1, @"c" : @{@"d" : @2, @"e" : @3}}});
+  FSTObjectValue *old = FSTTestObjectValue(
+      @{ @"a" : @{@"b" : @1, @"c" : @{@"d" : @2, @"e" : @3}} });
   FSTObjectValue *mod = [old objectByDeletingPath:testutil::Field("a.c.d")];
   XCTAssertNotEqual(old, mod);
   XCTAssertEqualObjects(old, FSTTestFieldValue(
-                                 @{@"a" : @{@"b" : @1, @"c" : @{@"d" : @2, @"e" : @3}}}));
-  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{@"a" : @{@"b" : @1, @"c" : @{@"e" : @3}}}));
+                                 @{ @"a" : @{@"b" : @1, @"c" : @{@"d" : @2, @"e" : @3}} }));
+  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{ @"a" : @{@"b" : @1, @"c" : @{@"e" : @3}} }));
 
   old = mod;
   mod = [old objectByDeletingPath:testutil::Field("a.c")];
-  XCTAssertEqualObjects(old, FSTTestFieldValue(@{@"a" : @{@"b" : @1, @"c" : @{@"e" : @3}}}));
-  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{@"a" : @{@"b" : @1}}));
+  XCTAssertEqualObjects(old, FSTTestFieldValue(@{ @"a" : @{@"b" : @1, @"c" : @{@"e" : @3}} }));
+  XCTAssertEqualObjects(mod, FSTTestFieldValue(@{ @"a" : @{@"b" : @1} }));
 
   old = mod;
   mod = [old objectByDeletingPath:testutil::Field("a")];
-  XCTAssertEqualObjects(old, FSTTestFieldValue(@{@"a" : @{@"b" : @1}}));
+  XCTAssertEqualObjects(old, FSTTestFieldValue(@{ @"a" : @{@"b" : @1} }));
   XCTAssertEqualObjects(mod, FSTTestFieldValue(@{}));
 }
 
@@ -471,20 +472,20 @@ union DoubleBits {
     @[ FSTTestFieldValue(@[ @"foo", @"bar", @"baz" ]) ], @[ FSTTestFieldValue(@[ @"foo" ]) ],
     @[
       FSTTestFieldValue(
-          @{@"bar" : @1,
-            @"foo" : @2}),
+          @{ @"bar" : @1,
+             @"foo" : @2 }),
       FSTTestFieldValue(
-          @{@"foo" : @2,
-            @"bar" : @1})
+          @{ @"foo" : @2,
+             @"bar" : @1 })
     ],
     @[ FSTTestFieldValue(
-        @{@"bar" : @2,
-          @"foo" : @1}) ],
+        @{ @"bar" : @2,
+           @"foo" : @1 }) ],
     @[ FSTTestFieldValue(
-        @{@"bar" : @1,
-          @"foo" : @1}) ],
+        @{ @"bar" : @1,
+           @"foo" : @1 }) ],
     @[ FSTTestFieldValue(
-        @{@"foo" : @1}) ]
+        @{ @"foo" : @1 }) ]
   ];
 
   FSTAssertEqualityGroups(groups);
@@ -543,17 +544,17 @@ union DoubleBits {
 
     // Objects
     @[
-      @{@"bar" : @0}
+      @{ @"bar" : @0 }
     ],
     @[
-      @{@"bar" : @0,
-        @"foo" : @1}
+      @{ @"bar" : @0,
+         @"foo" : @1 }
     ],
     @[
-      @{@"foo" : @1}
+      @{ @"foo" : @1 }
     ],
     @[
-      @{@"foo" : @2}
+      @{ @"foo" : @2 }
     ],
     @[ @{@"foo" : @"0"} ]
   ];
@@ -564,7 +565,7 @@ union DoubleBits {
 
 - (void)testValue {
   NSDate *date = [NSDate date];
-  id input = @{@"array" : @[ @1, date ], @"obj" : @{@"date" : date, @"string" : @"hi"}};
+  id input = @{ @"array" : @[ @1, date ], @"obj" : @{@"date" : date, @"string" : @"hi"} };
   FSTObjectValue *value = FSTTestObjectValue(input);
   id output = [value value];
   {

--- a/Firestore/Example/Tests/Model/FSTMutationTests.mm
+++ b/Firestore/Example/Tests/Model/FSTMutationTests.mm
@@ -67,19 +67,19 @@ using firebase::firestore::model::TransformOperation;
 }
 
 - (void)testAppliesPatchesToDocuments {
-  NSDictionary *docData = @{@"foo" : @{@"bar" : @"bar-value"}, @"baz" : @"baz-value"};
+  NSDictionary *docData = @{ @"foo" : @{@"bar" : @"bar-value"}, @"baz" : @"baz-value" };
   FSTDocument *baseDoc = FSTTestDoc("collection/key", 0, docData, NO);
 
   FSTMutation *patch = FSTTestPatchMutation("collection/key", @{@"foo.bar" : @"new-bar-value"}, {});
   FSTMaybeDocument *patchedDoc =
       [patch applyTo:baseDoc baseDocument:baseDoc localWriteTime:_timestamp];
 
-  NSDictionary *expectedData = @{@"foo" : @{@"bar" : @"new-bar-value"}, @"baz" : @"baz-value"};
+  NSDictionary *expectedData = @{ @"foo" : @{@"bar" : @"new-bar-value"}, @"baz" : @"baz-value" };
   XCTAssertEqualObjects(patchedDoc, FSTTestDoc("collection/key", 0, expectedData, YES));
 }
 
 - (void)testDeletesValuesFromTheFieldMask {
-  NSDictionary *docData = @{@"foo" : @{@"bar" : @"bar-value", @"baz" : @"baz-value"}};
+  NSDictionary *docData = @{ @"foo" : @{@"bar" : @"bar-value", @"baz" : @"baz-value"} };
   FSTDocument *baseDoc = FSTTestDoc("collection/key", 0, docData, NO);
 
   DocumentKey key = testutil::Key("collection/key");
@@ -90,7 +90,7 @@ using firebase::firestore::model::TransformOperation;
   FSTMaybeDocument *patchedDoc =
       [patch applyTo:baseDoc baseDocument:baseDoc localWriteTime:_timestamp];
 
-  NSDictionary *expectedData = @{@"foo" : @{@"baz" : @"baz-value"}};
+  NSDictionary *expectedData = @{ @"foo" : @{@"baz" : @"baz-value"} };
   XCTAssertEqualObjects(patchedDoc, FSTTestDoc("collection/key", 0, expectedData, YES));
 }
 
@@ -102,7 +102,7 @@ using firebase::firestore::model::TransformOperation;
   FSTMaybeDocument *patchedDoc =
       [patch applyTo:baseDoc baseDocument:baseDoc localWriteTime:_timestamp];
 
-  NSDictionary *expectedData = @{@"foo" : @{@"bar" : @"new-bar-value"}, @"baz" : @"baz-value"};
+  NSDictionary *expectedData = @{ @"foo" : @{@"bar" : @"new-bar-value"}, @"baz" : @"baz-value" };
   XCTAssertEqualObjects(patchedDoc, FSTTestDoc("collection/key", 0, expectedData, YES));
 }
 
@@ -115,7 +115,7 @@ using firebase::firestore::model::TransformOperation;
 }
 
 - (void)testAppliesLocalServerTimestampTransformToDocuments {
-  NSDictionary *docData = @{@"foo" : @{@"bar" : @"bar-value"}, @"baz" : @"baz-value"};
+  NSDictionary *docData = @{ @"foo" : @{@"bar" : @"bar-value"}, @"baz" : @"baz-value" };
   FSTDocument *baseDoc = FSTTestDoc("collection/key", 0, docData, NO);
 
   FSTMutation *transform = FSTTestTransformMutation(
@@ -125,8 +125,8 @@ using firebase::firestore::model::TransformOperation;
 
   // Server timestamps aren't parsed, so we manually insert it.
   FSTObjectValue *expectedData = FSTTestObjectValue(
-      @{@"foo" : @{@"bar" : @"<server-timestamp>"},
-        @"baz" : @"baz-value"});
+      @{ @"foo" : @{@"bar" : @"<server-timestamp>"},
+         @"baz" : @"baz-value" });
   expectedData =
       [expectedData objectBySettingValue:[FSTServerTimestampValue
                                              serverTimestampValueWithLocalWriteTime:_timestamp
@@ -148,7 +148,7 @@ using firebase::firestore::model::TransformOperation;
     @"foo" : [FIRFieldValue fieldValueForArrayUnion:@[ @"tag" ]],
     @"bar.baz" :
         [FIRFieldValue fieldValueForArrayUnion:@[ @YES,
-                                                  @{@"nested" : @{@"a" : @[ @1, @2 ]}} ]]
+                                                  @{ @"nested" : @{@"a" : @[ @1, @2 ]} } ]]
   });
   XCTAssertEqual(transform.fieldTransforms.size(), 2);
 
@@ -164,7 +164,7 @@ using firebase::firestore::model::TransformOperation;
   XCTAssertEqual(second.path(), FieldPath({"bar", "baz"}));
   {
     std::vector<FSTFieldValue *> expectedElements {
-      FSTTestFieldValue(@YES), FSTTestFieldValue(@{@"nested" : @{@"a" : @[ @1, @2 ]}})
+      FSTTestFieldValue(@YES), FSTTestFieldValue(@{ @"nested" : @{@"a" : @[ @1, @2 ]} })
     };
     ArrayTransform expected(TransformOperation::Type::ArrayUnion, expectedElements);
     XCTAssertEqual(static_cast<const ArrayTransform &>(second.transformation()), expected);
@@ -190,101 +190,101 @@ using firebase::firestore::model::TransformOperation;
 
 - (void)testAppliesLocalArrayUnionTransformToMissingField {
   auto baseDoc = @{};
-  auto transform = @{@"missing" : [FIRFieldValue fieldValueForArrayUnion:@[ @1, @2 ]]};
-  auto expected = @{@"missing" : @[ @1, @2 ]};
+  auto transform = @{ @"missing" : [FIRFieldValue fieldValueForArrayUnion:@[ @1, @2 ]] };
+  auto expected = @{ @"missing" : @[ @1, @2 ] };
   [self transformBaseDoc:baseDoc with:transform expecting:expected];
 }
 
 - (void)testAppliesLocalArrayUnionTransformToNonArrayField {
-  auto baseDoc = @{@"non-array" : @42};
-  auto transform = @{@"non-array" : [FIRFieldValue fieldValueForArrayUnion:@[ @1, @2 ]]};
-  auto expected = @{@"non-array" : @[ @1, @2 ]};
+  auto baseDoc = @{ @"non-array" : @42 };
+  auto transform = @{ @"non-array" : [FIRFieldValue fieldValueForArrayUnion:@[ @1, @2 ]] };
+  auto expected = @{ @"non-array" : @[ @1, @2 ] };
   [self transformBaseDoc:baseDoc with:transform expecting:expected];
 }
 
 - (void)testAppliesLocalArrayUnionTransformWithNonExistingElements {
-  auto baseDoc = @{@"array" : @[ @1, @3 ]};
-  auto transform = @{@"array" : [FIRFieldValue fieldValueForArrayUnion:@[ @2, @4 ]]};
-  auto expected = @{@"array" : @[ @1, @3, @2, @4 ]};
+  auto baseDoc = @{ @"array" : @[ @1, @3 ] };
+  auto transform = @{ @"array" : [FIRFieldValue fieldValueForArrayUnion:@[ @2, @4 ]] };
+  auto expected = @{ @"array" : @[ @1, @3, @2, @4 ] };
   [self transformBaseDoc:baseDoc with:transform expecting:expected];
 }
 
 - (void)testAppliesLocalArrayUnionTransformWithExistingElements {
-  auto baseDoc = @{@"array" : @[ @1, @3 ]};
-  auto transform = @{@"array" : [FIRFieldValue fieldValueForArrayUnion:@[ @1, @3 ]]};
-  auto expected = @{@"array" : @[ @1, @3 ]};
+  auto baseDoc = @{ @"array" : @[ @1, @3 ] };
+  auto transform = @{ @"array" : [FIRFieldValue fieldValueForArrayUnion:@[ @1, @3 ]] };
+  auto expected = @{ @"array" : @[ @1, @3 ] };
   [self transformBaseDoc:baseDoc with:transform expecting:expected];
 }
 
 - (void)testAppliesLocalArrayUnionTransformWithDuplicateExistingElements {
   // Duplicate entries in your existing array should be preserved.
-  auto baseDoc = @{@"array" : @[ @1, @2, @2, @3 ]};
-  auto transform = @{@"array" : [FIRFieldValue fieldValueForArrayUnion:@[ @2 ]]};
-  auto expected = @{@"array" : @[ @1, @2, @2, @3 ]};
+  auto baseDoc = @{ @"array" : @[ @1, @2, @2, @3 ] };
+  auto transform = @{ @"array" : [FIRFieldValue fieldValueForArrayUnion:@[ @2 ]] };
+  auto expected = @{ @"array" : @[ @1, @2, @2, @3 ] };
   [self transformBaseDoc:baseDoc with:transform expecting:expected];
 }
 
 - (void)testAppliesLocalArrayUnionTransformWithDuplicateUnionElements {
   // Duplicate entries in your union array should only be added once.
-  auto baseDoc = @{@"array" : @[ @1, @3 ]};
-  auto transform = @{@"array" : [FIRFieldValue fieldValueForArrayUnion:@[ @2, @2 ]]};
-  auto expected = @{@"array" : @[ @1, @3, @2 ]};
+  auto baseDoc = @{ @"array" : @[ @1, @3 ] };
+  auto transform = @{ @"array" : [FIRFieldValue fieldValueForArrayUnion:@[ @2, @2 ]] };
+  auto expected = @{ @"array" : @[ @1, @3, @2 ] };
   [self transformBaseDoc:baseDoc with:transform expecting:expected];
 }
 
 - (void)testAppliesLocalArrayUnionTransformWithNonPrimitiveElements {
   // Union nested object values (one existing, one not).
-  auto baseDoc = @{@"array" : @[ @1, @{@"a" : @"b"} ]};
+  auto baseDoc = @{ @"array" : @[ @1, @{@"a" : @"b"} ] };
   auto transform =
-      @{@"array" : [FIRFieldValue fieldValueForArrayUnion:@[ @{@"a" : @"b"}, @{@"c" : @"d"} ]]};
-  auto expected = @{@"array" : @[ @1, @{@"a" : @"b"}, @{@"c" : @"d"} ]};
+      @{ @"array" : [FIRFieldValue fieldValueForArrayUnion:@[ @{@"a" : @"b"}, @{@"c" : @"d"} ]] };
+  auto expected = @{ @"array" : @[ @1, @{@"a" : @"b"}, @{@"c" : @"d"} ] };
   [self transformBaseDoc:baseDoc with:transform expecting:expected];
 }
 
 - (void)testAppliesLocalArrayUnionTransformWithPartiallyOverlappingElements {
   // Union objects that partially overlap an existing object.
-  auto baseDoc = @{@"array" : @[ @1, @{@"a" : @"b", @"c" : @"d"} ]};
+  auto baseDoc = @{ @"array" : @[ @1, @{@"a" : @"b", @"c" : @"d"} ] };
   auto transform =
-      @{@"array" : [FIRFieldValue fieldValueForArrayUnion:@[ @{@"a" : @"b"}, @{@"c" : @"d"} ]]};
+      @{ @"array" : [FIRFieldValue fieldValueForArrayUnion:@[ @{@"a" : @"b"}, @{@"c" : @"d"} ]] };
   auto expected =
-      @{@"array" : @[ @1, @{@"a" : @"b", @"c" : @"d"}, @{@"a" : @"b"}, @{@"c" : @"d"} ]};
+      @{ @"array" : @[ @1, @{@"a" : @"b", @"c" : @"d"}, @{@"a" : @"b"}, @{@"c" : @"d"} ] };
   [self transformBaseDoc:baseDoc with:transform expecting:expected];
 }
 
 - (void)testAppliesLocalArrayRemoveTransformToMissingField {
   auto baseDoc = @{};
-  auto transform = @{@"missing" : [FIRFieldValue fieldValueForArrayRemove:@[ @1, @2 ]]};
-  auto expected = @{@"missing" : @[]};
+  auto transform = @{ @"missing" : [FIRFieldValue fieldValueForArrayRemove:@[ @1, @2 ]] };
+  auto expected = @{ @"missing" : @[] };
   [self transformBaseDoc:baseDoc with:transform expecting:expected];
 }
 
 - (void)testAppliesLocalArrayRemoveTransformToNonArrayField {
-  auto baseDoc = @{@"non-array" : @42};
-  auto transform = @{@"non-array" : [FIRFieldValue fieldValueForArrayRemove:@[ @1, @2 ]]};
-  auto expected = @{@"non-array" : @[]};
+  auto baseDoc = @{ @"non-array" : @42 };
+  auto transform = @{ @"non-array" : [FIRFieldValue fieldValueForArrayRemove:@[ @1, @2 ]] };
+  auto expected = @{ @"non-array" : @[] };
   [self transformBaseDoc:baseDoc with:transform expecting:expected];
 }
 
 - (void)testAppliesLocalArrayRemoveTransformWithNonExistingElements {
-  auto baseDoc = @{@"array" : @[ @1, @3 ]};
-  auto transform = @{@"array" : [FIRFieldValue fieldValueForArrayRemove:@[ @2, @4 ]]};
-  auto expected = @{@"array" : @[ @1, @3 ]};
+  auto baseDoc = @{ @"array" : @[ @1, @3 ] };
+  auto transform = @{ @"array" : [FIRFieldValue fieldValueForArrayRemove:@[ @2, @4 ]] };
+  auto expected = @{ @"array" : @[ @1, @3 ] };
   [self transformBaseDoc:baseDoc with:transform expecting:expected];
 }
 
 - (void)testAppliesLocalArrayRemoveTransformWithExistingElements {
-  auto baseDoc = @{@"array" : @[ @1, @2, @3, @4 ]};
-  auto transform = @{@"array" : [FIRFieldValue fieldValueForArrayRemove:@[ @1, @3 ]]};
-  auto expected = @{@"array" : @[ @2, @4 ]};
+  auto baseDoc = @{ @"array" : @[ @1, @2, @3, @4 ] };
+  auto transform = @{ @"array" : [FIRFieldValue fieldValueForArrayRemove:@[ @1, @3 ]] };
+  auto expected = @{ @"array" : @[ @2, @4 ] };
   [self transformBaseDoc:baseDoc with:transform expecting:expected];
 }
 
 - (void)testAppliesLocalArrayRemoveTransformWithNonPrimitiveElements {
   // Remove nested object values (one existing, one not).
-  auto baseDoc = @{@"array" : @[ @1, @{@"a" : @"b"} ]};
+  auto baseDoc = @{ @"array" : @[ @1, @{@"a" : @"b"} ] };
   auto transform =
-      @{@"array" : [FIRFieldValue fieldValueForArrayRemove:@[ @{@"a" : @"b"}, @{@"c" : @"d"} ]]};
-  auto expected = @{@"array" : @[ @1 ]};
+      @{ @"array" : [FIRFieldValue fieldValueForArrayRemove:@[ @{@"a" : @"b"}, @{@"c" : @"d"} ]] };
+  auto expected = @{ @"array" : @[ @1 ] };
   [self transformBaseDoc:baseDoc with:transform expecting:expected];
 }
 
@@ -308,7 +308,7 @@ using firebase::firestore::model::TransformOperation;
 }
 
 - (void)testAppliesServerAckedServerTimestampTransformToDocuments {
-  NSDictionary *docData = @{@"foo" : @{@"bar" : @"bar-value"}, @"baz" : @"baz-value"};
+  NSDictionary *docData = @{ @"foo" : @{@"bar" : @"bar-value"}, @"baz" : @"baz-value" };
   FSTDocument *baseDoc = FSTTestDoc("collection/key", 0, docData, NO);
 
   FSTMutation *transform = FSTTestTransformMutation(
@@ -323,12 +323,14 @@ using firebase::firestore::model::TransformOperation;
                                          localWriteTime:_timestamp
                                          mutationResult:mutationResult];
 
-  NSDictionary *expectedData = @{@"foo" : @{@"bar" : _timestamp.dateValue}, @"baz" : @"baz-value"};
+  NSDictionary *expectedData =
+      @{ @"foo" : @{@"bar" : _timestamp.dateValue},
+         @"baz" : @"baz-value" };
   XCTAssertEqualObjects(transformedDoc, FSTTestDoc("collection/key", 0, expectedData, NO));
 }
 
 - (void)testAppliesServerAckedArrayTransformsToDocuments {
-  NSDictionary *docData = @{@"array_1" : @[ @1, @2 ], @"array_2" : @[ @"a", @"b" ]};
+  NSDictionary *docData = @{ @"array_1" : @[ @1, @2 ], @"array_2" : @[ @"a", @"b" ] };
   FSTDocument *baseDoc = FSTTestDoc("collection/key", 0, docData, NO);
 
   FSTMutation *transform = FSTTestTransformMutation(@"collection/key", @{
@@ -346,7 +348,7 @@ using firebase::firestore::model::TransformOperation;
                                          localWriteTime:_timestamp
                                          mutationResult:mutationResult];
 
-  NSDictionary *expectedData = @{@"array_1" : @[ @1, @2, @3 ], @"array_2" : @[ @"b" ]};
+  NSDictionary *expectedData = @{ @"array_1" : @[ @1, @2, @3 ], @"array_2" : @[ @"b" ] };
   XCTAssertEqualObjects(transformedDoc, FSTTestDoc("collection/key", 0, expectedData, NO));
 }
 

--- a/Firestore/Example/Tests/Remote/FSTDatastoreTests.mm
+++ b/Firestore/Example/Tests/Remote/FSTDatastoreTests.mm
@@ -33,12 +33,13 @@
   XCTAssertFalse([FSTDatastore isPermanentWriteError:error]);
 
   // From GRPCCall -startNextRead
-  error = [NSError errorWithDomain:FIRFirestoreErrorDomain
-                              code:FIRFirestoreErrorCodeResourceExhausted
-                          userInfo:@{
-                            NSLocalizedDescriptionKey :
-                                @"Client does not have enough memory to hold the server response."
-                          }];
+  error =
+      [NSError errorWithDomain:FIRFirestoreErrorDomain
+                          code:FIRFirestoreErrorCodeResourceExhausted
+                      userInfo:@{
+                        NSLocalizedDescriptionKey :
+                            @"Client does not have enough memory to hold the server response."
+                      }];
   XCTAssertFalse([FSTDatastore isPermanentWriteError:error]);
 
   // From GRPCCall -startWithWriteable

--- a/Firestore/Example/Tests/Remote/FSTRemoteEventTests.mm
+++ b/Firestore/Example/Tests/Remote/FSTRemoteEventTests.mm
@@ -104,11 +104,11 @@ NS_ASSUME_NONNULL_BEGIN
  * changes are FSTDocumentWatchChange and FSTWatchTargetChange.
  */
 - (FSTWatchChangeAggregator *)
-    aggregatorWithTargetMap:(NSDictionary<FSTBoxedTargetID *, FSTQueryData *> *)targetMap
-       outstandingResponses:
-           (nullable NSDictionary<FSTBoxedTargetID *, NSNumber *> *)outstandingResponses
-               existingKeys:(DocumentKeySet)existingKeys
-                    changes:(NSArray<FSTWatchChange *> *)watchChanges {
+aggregatorWithTargetMap:(NSDictionary<FSTBoxedTargetID *, FSTQueryData *> *)targetMap
+   outstandingResponses:
+       (nullable NSDictionary<FSTBoxedTargetID *, NSNumber *> *)outstandingResponses
+           existingKeys:(DocumentKeySet)existingKeys
+                changes:(NSArray<FSTWatchChange *> *)watchChanges {
   FSTWatchChangeAggregator *aggregator =
       [[FSTWatchChangeAggregator alloc] initWithTargetMetadataProvider:_targetMetadataProvider];
 
@@ -160,12 +160,12 @@ NS_ASSUME_NONNULL_BEGIN
  * changes are FSTDocumentWatchChange and FSTWatchTargetChange.
  */
 - (FSTRemoteEvent *)
-    remoteEventAtSnapshotVersion:(FSTTestSnapshotVersion)snapshotVersion
-                       targetMap:(NSDictionary<FSTBoxedTargetID *, FSTQueryData *> *)targetMap
-            outstandingResponses:
-                (nullable NSDictionary<FSTBoxedTargetID *, NSNumber *> *)outstandingResponses
-                    existingKeys:(DocumentKeySet)existingKeys
-                         changes:(NSArray<FSTWatchChange *> *)watchChanges {
+remoteEventAtSnapshotVersion:(FSTTestSnapshotVersion)snapshotVersion
+                   targetMap:(NSDictionary<FSTBoxedTargetID *, FSTQueryData *> *)targetMap
+        outstandingResponses:
+            (nullable NSDictionary<FSTBoxedTargetID *, NSNumber *> *)outstandingResponses
+                existingKeys:(DocumentKeySet)existingKeys
+                     changes:(NSArray<FSTWatchChange *> *)watchChanges {
   FSTWatchChangeAggregator *aggregator = [self aggregatorWithTargetMap:targetMap
                                                   outstandingResponses:outstandingResponses
                                                           existingKeys:existingKeys
@@ -179,13 +179,13 @@ NS_ASSUME_NONNULL_BEGIN
   NSDictionary<FSTBoxedTargetID *, FSTQueryData *> *targetMap =
       [self queryDataForTargets:@[ @1, @2, @3, @4, @5, @6 ]];
 
-  FSTDocument *existingDoc = FSTTestDoc("docs/1", 1, @{@"value" : @1}, NO);
+  FSTDocument *existingDoc = FSTTestDoc("docs/1", 1, @{ @"value" : @1 }, NO);
   FSTWatchChange *change1 = [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @1, @2, @3 ]
                                                                     removedTargetIDs:@[ @4, @5, @6 ]
                                                                          documentKey:existingDoc.key
                                                                             document:existingDoc];
 
-  FSTDocument *newDoc = FSTTestDoc("docs/2", 2, @{@"value" : @2}, NO);
+  FSTDocument *newDoc = FSTTestDoc("docs/2", 2, @{ @"value" : @2 }, NO);
   FSTWatchChange *change2 = [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @1, @4 ]
                                                                     removedTargetIDs:@[ @2, @6 ]
                                                                          documentKey:newDoc.key
@@ -238,7 +238,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testWillIgnoreEventsForPendingTargets {
   NSDictionary<FSTBoxedTargetID *, FSTQueryData *> *targetMap = [self queryDataForTargets:@[ @1 ]];
 
-  FSTDocument *doc1 = FSTTestDoc("docs/1", 1, @{@"value" : @1}, NO);
+  FSTDocument *doc1 = FSTTestDoc("docs/1", 1, @{ @"value" : @1 }, NO);
   FSTWatchChange *change1 = [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @1 ]
                                                                     removedTargetIDs:@[]
                                                                          documentKey:doc1.key
@@ -252,14 +252,14 @@ NS_ASSUME_NONNULL_BEGIN
                                                         targetIDs:@[ @1 ]
                                                             cause:nil];
 
-  FSTDocument *doc2 = FSTTestDoc("docs/2", 2, @{@"value" : @2}, NO);
+  FSTDocument *doc2 = FSTTestDoc("docs/2", 2, @{ @"value" : @2 }, NO);
   FSTWatchChange *change4 = [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @1 ]
                                                                     removedTargetIDs:@[]
                                                                          documentKey:doc2.key
                                                                             document:doc2];
 
   // We're waiting for the unwatch and watch ack
-  NSDictionary<NSNumber *, NSNumber *> *outstandingResponses = @{@1 : @2};
+  NSDictionary<NSNumber *, NSNumber *> *outstandingResponses = @{ @1 : @2 };
 
   FSTRemoteEvent *event =
       [self remoteEventAtSnapshotVersion:3
@@ -279,7 +279,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testWillIgnoreEventsForRemovedTargets {
   NSDictionary<FSTBoxedTargetID *, FSTQueryData *> *targetMap = [self queryDataForTargets:@[]];
 
-  FSTDocument *doc1 = FSTTestDoc("docs/1", 1, @{@"value" : @1}, NO);
+  FSTDocument *doc1 = FSTTestDoc("docs/1", 1, @{ @"value" : @1 }, NO);
   FSTWatchChange *change1 = [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @1 ]
                                                                     removedTargetIDs:@[]
                                                                          documentKey:doc1.key
@@ -290,7 +290,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                             cause:nil];
 
   // We're waiting for the unwatch ack
-  NSDictionary<NSNumber *, NSNumber *> *outstandingResponses = @{@1 : @1};
+  NSDictionary<NSNumber *, NSNumber *> *outstandingResponses = @{ @1 : @1 };
 
   FSTRemoteEvent *event = [self remoteEventAtSnapshotVersion:3
                                                    targetMap:targetMap
@@ -308,7 +308,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testWillKeepResetMappingEvenWithUpdates {
   NSDictionary<FSTBoxedTargetID *, FSTQueryData *> *targetMap = [self queryDataForTargets:@[ @1 ]];
 
-  FSTDocument *doc1 = FSTTestDoc("docs/1", 1, @{@"value" : @1}, NO);
+  FSTDocument *doc1 = FSTTestDoc("docs/1", 1, @{ @"value" : @1 }, NO);
   FSTWatchChange *change1 = [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @1 ]
                                                                     removedTargetIDs:@[]
                                                                          documentKey:doc1.key
@@ -319,13 +319,13 @@ NS_ASSUME_NONNULL_BEGIN
                                                             cause:nil];
 
   // Add doc2, doc3
-  FSTDocument *doc2 = FSTTestDoc("docs/2", 2, @{@"value" : @2}, NO);
+  FSTDocument *doc2 = FSTTestDoc("docs/2", 2, @{ @"value" : @2 }, NO);
   FSTWatchChange *change3 = [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @1 ]
                                                                     removedTargetIDs:@[]
                                                                          documentKey:doc2.key
                                                                             document:doc2];
 
-  FSTDocument *doc3 = FSTTestDoc("docs/3", 3, @{@"value" : @3}, NO);
+  FSTDocument *doc3 = FSTTestDoc("docs/3", 3, @{ @"value" : @3 }, NO);
   FSTWatchChange *change4 = [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @1 ]
                                                                     removedTargetIDs:@[]
                                                                          documentKey:doc3.key
@@ -387,13 +387,13 @@ NS_ASSUME_NONNULL_BEGIN
   NSDictionary<FSTBoxedTargetID *, FSTQueryData *> *targetMap =
       [self queryDataForTargets:@[ @1, @2 ]];
 
-  FSTDocument *doc1a = FSTTestDoc("docs/1", 1, @{@"value" : @1}, NO);
+  FSTDocument *doc1a = FSTTestDoc("docs/1", 1, @{ @"value" : @1 }, NO);
   FSTWatchChange *change1 = [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @1 ]
                                                                     removedTargetIDs:@[ @2 ]
                                                                          documentKey:doc1a.key
                                                                             document:doc1a];
 
-  FSTDocument *doc1b = FSTTestDoc("docs/1", 1, @{@"value" : @2}, NO);
+  FSTDocument *doc1b = FSTTestDoc("docs/1", 1, @{ @"value" : @2 }, NO);
   FSTWatchChange *change2 = [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @2 ]
                                                                     removedTargetIDs:@[ @1 ]
                                                                          documentKey:doc1b.key
@@ -444,7 +444,7 @@ NS_ASSUME_NONNULL_BEGIN
   NSDictionary<FSTBoxedTargetID *, FSTQueryData *> *targetMap =
       [self queryDataForTargets:@[ @1, @3 ]];
 
-  FSTDocument *doc1 = FSTTestDoc("docs/1", 1, @{@"value" : @1}, NO);
+  FSTDocument *doc1 = FSTTestDoc("docs/1", 1, @{ @"value" : @1 }, NO);
   FSTWatchChange *change1 = [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @1, @3 ]
                                                                     removedTargetIDs:@[ @2 ]
                                                                          documentKey:doc1.key
@@ -466,13 +466,13 @@ NS_ASSUME_NONNULL_BEGIN
                                                         targetIDs:@[ @1 ]
                                                             cause:nil];
 
-  FSTDocument *doc2 = FSTTestDoc("docs/2", 2, @{@"value" : @2}, NO);
+  FSTDocument *doc2 = FSTTestDoc("docs/2", 2, @{ @"value" : @2 }, NO);
   FSTWatchChange *change6 = [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @1 ]
                                                                     removedTargetIDs:@[ @3 ]
                                                                          documentKey:doc2.key
                                                                             document:doc2];
 
-  NSDictionary<NSNumber *, NSNumber *> *outstandingResponses = @{@1 : @2, @2 : @1};
+  NSDictionary<NSNumber *, NSNumber *> *outstandingResponses = @{ @1 : @2, @2 : @1 };
 
   FSTRemoteEvent *event =
       [self remoteEventAtSnapshotVersion:3
@@ -531,13 +531,13 @@ NS_ASSUME_NONNULL_BEGIN
   NSDictionary<FSTBoxedTargetID *, FSTQueryData *> *targetMap =
       [self queryDataForTargets:@[ @1, @2 ]];
 
-  FSTDocument *doc1 = FSTTestDoc("docs/1", 1, @{@"value" : @1}, NO);
+  FSTDocument *doc1 = FSTTestDoc("docs/1", 1, @{ @"value" : @1 }, NO);
   FSTWatchChange *change1 = [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @1 ]
                                                                     removedTargetIDs:@[]
                                                                          documentKey:doc1.key
                                                                             document:doc1];
 
-  FSTDocument *doc2 = FSTTestDoc("docs/2", 2, @{@"value" : @2}, NO);
+  FSTDocument *doc2 = FSTTestDoc("docs/2", 2, @{ @"value" : @2 }, NO);
   FSTWatchChange *change2 = [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @1 ]
                                                                     removedTargetIDs:@[]
                                                                          documentKey:doc2.key
@@ -602,7 +602,7 @@ NS_ASSUME_NONNULL_BEGIN
                                 resumeToken:_resumeToken1];
   [aggregator handleTargetChange:markCurrent];
 
-  FSTDocument *doc1 = FSTTestDoc("docs/1", 1, @{@"value" : @1}, NO);
+  FSTDocument *doc1 = FSTTestDoc("docs/1", 1, @{ @"value" : @1 }, NO);
   FSTDocumentWatchChange *addDoc = [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @1 ]
                                                                            removedTargetIDs:@[]
                                                                                 documentKey:doc1.key
@@ -633,13 +633,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testDocumentUpdate {
   NSDictionary<FSTBoxedTargetID *, FSTQueryData *> *targetMap = [self queryDataForTargets:@[ @1 ]];
 
-  FSTDocument *doc1 = FSTTestDoc("docs/1", 1, @{@"value" : @1}, NO);
+  FSTDocument *doc1 = FSTTestDoc("docs/1", 1, @{ @"value" : @1 }, NO);
   FSTWatchChange *change1 = [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @1 ]
                                                                     removedTargetIDs:@[]
                                                                          documentKey:doc1.key
                                                                             document:doc1];
 
-  FSTDocument *doc2 = FSTTestDoc("docs/2", 2, @{@"value" : @2}, NO);
+  FSTDocument *doc2 = FSTTestDoc("docs/2", 2, @{ @"value" : @2 }, NO);
   FSTWatchChange *change2 = [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @1 ]
                                                                     removedTargetIDs:@[]
                                                                          documentKey:doc2.key
@@ -669,7 +669,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                       document:deletedDoc1];
   [aggregator handleDocumentChange:change3];
 
-  FSTDocument *updatedDoc2 = FSTTestDoc("docs/2", 3, @{@"value" : @2}, NO);
+  FSTDocument *updatedDoc2 = FSTTestDoc("docs/2", 3, @{ @"value" : @2 }, NO);
   FSTDocumentWatchChange *change4 =
       [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @1 ]
                                               removedTargetIDs:@[]
@@ -677,7 +677,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                       document:updatedDoc2];
   [aggregator handleDocumentChange:change4];
 
-  FSTDocument *doc3 = FSTTestDoc("docs/3", 3, @{@"value" : @3}, NO);
+  FSTDocument *doc3 = FSTTestDoc("docs/3", 3, @{ @"value" : @3 }, NO);
   FSTDocumentWatchChange *change5 =
       [[FSTDocumentWatchChange alloc] initWithUpdatedTargetIDs:@[ @1 ]
                                               removedTargetIDs:@[]

--- a/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.mm
+++ b/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.mm
@@ -289,7 +289,7 @@ NS_ASSUME_NONNULL_BEGIN
     @"n" : [NSNull null],
     @"s" : @"foo",
     @"a" : @[ @2, @"bar",
-              @{@"b" : @NO} ],
+              @{ @"b" : @NO } ],
     @"o" : @{
       @"d" : @100,
       @"nested" : @{@"e" : @(LLONG_MIN)},
@@ -339,7 +339,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)testEncodesSetMutation {
-  FSTSetMutation *mutation = FSTTestSetMutation(@"docs/1", @{@"a" : @"b", @"num" : @1});
+  FSTSetMutation *mutation = FSTTestSetMutation(@"docs/1", @{ @"a" : @"b", @"num" : @1 });
   GCFSWrite *proto = [GCFSWrite message];
   proto.update = [self.serializer encodedDocumentWithFields:mutation.value key:mutation.key];
 
@@ -349,9 +349,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testEncodesPatchMutation {
   FSTPatchMutation *mutation =
       FSTTestPatchMutation("docs/1",
-                           @{@"a" : @"b",
-                             @"num" : @1,
-                             @"some.de\\\\ep.th\\ing'" : @2},
+                           @{ @"a" : @"b",
+                              @"num" : @1,
+                              @"some.de\\\\ep.th\\ing'" : @2 },
                            {});
   GCFSWrite *proto = [GCFSWrite message];
   proto.update = [self.serializer encodedDocumentWithFields:mutation.value key:mutation.key];
@@ -388,7 +388,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTTransformMutation *mutation = FSTTestTransformMutation(@"docs/1", @{
     @"a" : [FIRFieldValue fieldValueForArrayUnion:@[ @"a", @2 ]],
     @"bar.baz" : [FIRFieldValue fieldValueForArrayRemove:@[
-      @{@"x" : @1}
+      @{ @"x" : @1 }
     ]]
   });
   GCFSWrite *proto = [GCFSWrite message];
@@ -408,7 +408,7 @@ NS_ASSUME_NONNULL_BEGIN
   arrayRemove.fieldPath = @"bar.baz";
   arrayRemove.removeAllFromArray_p = [GCFSArrayValue message];
   NSMutableArray *removeElements = arrayRemove.removeAllFromArray_p.valuesArray;
-  [removeElements addObject:[self.serializer encodedFieldValue:FSTTestFieldValue(@{@"x" : @1})]];
+  [removeElements addObject:[self.serializer encodedFieldValue:FSTTestFieldValue(@{ @"x" : @1 })]];
   [proto.transform.fieldTransformsArray addObject:arrayRemove];
 
   proto.currentDocument.exists = YES;
@@ -420,8 +420,8 @@ NS_ASSUME_NONNULL_BEGIN
   FSTSetMutation *mutation =
       [[FSTSetMutation alloc] initWithKey:FSTTestDocKey(@"foo/bar")
                                     value:FSTTestObjectValue(
-                                              @{@"a" : @"b",
-                                                @"num" : @1})
+                                              @{ @"a" : @"b",
+                                                 @"num" : @1 })
                              precondition:Precondition::UpdateTime(testutil::Version(4))];
   GCFSWrite *proto = [GCFSWrite message];
   proto.update = [self.serializer encodedDocumentWithFields:mutation.value key:mutation.key];

--- a/Firestore/Example/Tests/Util/FSTEventAccumulator.h
+++ b/Firestore/Example/Tests/Util/FSTEventAccumulator.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^FSTValueEventHandler)(id _Nullable, NSError *_Nullable error);
 
-@interface FSTEventAccumulator<EventType> : NSObject
+@interface FSTEventAccumulator <EventType> : NSObject
 
 + (instancetype)accumulatorForTest:(XCTestCase *)testCase;
 

--- a/Firestore/Source/API/FIRDocumentReference.mm
+++ b/Firestore/Source/API/FIRDocumentReference.mm
@@ -251,16 +251,16 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (id<FIRListenerRegistration>)
-    addSnapshotListenerWithIncludeMetadataChanges:(BOOL)includeMetadataChanges
-                                         listener:(FIRDocumentSnapshotBlock)listener {
+addSnapshotListenerWithIncludeMetadataChanges:(BOOL)includeMetadataChanges
+                                     listener:(FIRDocumentSnapshotBlock)listener {
   FSTListenOptions *options =
       [self internalOptionsForIncludeMetadataChanges:includeMetadataChanges];
   return [self addSnapshotListenerInternalWithOptions:options listener:listener];
 }
 
 - (id<FIRListenerRegistration>)
-    addSnapshotListenerInternalWithOptions:(FSTListenOptions *)internalOptions
-                                  listener:(FIRDocumentSnapshotBlock)listener {
+addSnapshotListenerInternalWithOptions:(FSTListenOptions *)internalOptions
+                              listener:(FIRDocumentSnapshotBlock)listener {
   FIRFirestore *firestore = self.firestore;
   FSTQuery *query = [FSTQuery queryWithPath:self.key.path()];
   const DocumentKey key = self.key;

--- a/Firestore/Source/API/FIRQuery.mm
+++ b/Firestore/Source/API/FIRQuery.mm
@@ -153,15 +153,15 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (id<FIRListenerRegistration>)
-    addSnapshotListenerWithIncludeMetadataChanges:(BOOL)includeMetadataChanges
-                                         listener:(FIRQuerySnapshotBlock)listener {
+addSnapshotListenerWithIncludeMetadataChanges:(BOOL)includeMetadataChanges
+                                     listener:(FIRQuerySnapshotBlock)listener {
   auto options = [self internalOptionsForIncludeMetadataChanges:includeMetadataChanges];
   return [self addSnapshotListenerInternalWithOptions:options listener:listener];
 }
 
 - (id<FIRListenerRegistration>)
-    addSnapshotListenerInternalWithOptions:(FSTListenOptions *)internalOptions
-                                  listener:(FIRQuerySnapshotBlock)listener {
+addSnapshotListenerInternalWithOptions:(FSTListenOptions *)internalOptions
+                              listener:(FIRQuerySnapshotBlock)listener {
   FIRFirestore *firestore = self.firestore;
   FSTQuery *query = self.query;
 

--- a/Firestore/Source/Core/FSTFirestoreClient.h
+++ b/Firestore/Source/Core/FSTFirestoreClient.h
@@ -55,14 +55,13 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * All callbacks and events will be triggered on the provided userExecutor.
  */
-+ (instancetype)clientWithDatabaseInfo:(const firebase::firestore::core::DatabaseInfo &)databaseInfo
-                        usePersistence:(BOOL)usePersistence
-                   credentialsProvider:(firebase::firestore::auth::CredentialsProvider *)
-                                           credentialsProvider  // no passing ownership
-                          userExecutor:
-                              (std::unique_ptr<firebase::firestore::util::internal::Executor>)
-                                  userExecutor
-                   workerDispatchQueue:(FSTDispatchQueue *)workerDispatchQueue;
++ (instancetype)
+clientWithDatabaseInfo:(const firebase::firestore::core::DatabaseInfo &)databaseInfo
+        usePersistence:(BOOL)usePersistence
+   credentialsProvider:(firebase::firestore::auth::CredentialsProvider *)
+                           credentialsProvider  // no passing ownership
+          userExecutor:(std::unique_ptr<firebase::firestore::util::internal::Executor>)userExecutor
+   workerDispatchQueue:(FSTDispatchQueue *)workerDispatchQueue;
 
 - (instancetype)init __attribute__((unavailable("Use static constructor method.")));
 

--- a/Firestore/Source/Core/FSTTransaction.mm
+++ b/Firestore/Source/Core/FSTTransaction.mm
@@ -95,12 +95,13 @@ NS_ASSUME_NONNULL_BEGIN
     return YES;
   } else {
     if (error) {
-      *error = [NSError errorWithDomain:FIRFirestoreErrorDomain
-                                   code:FIRFirestoreErrorCodeFailedPrecondition
-                               userInfo:@{
-                                 NSLocalizedDescriptionKey :
-                                     @"A document cannot be read twice within a single transaction."
-                               }];
+      *error =
+          [NSError errorWithDomain:FIRFirestoreErrorDomain
+                              code:FIRFirestoreErrorCodeFailedPrecondition
+                          userInfo:@{
+                            NSLocalizedDescriptionKey :
+                                @"A document cannot be read twice within a single transaction."
+                          }];
     }
     return NO;
   }

--- a/Firestore/Source/Local/FSTLevelDB.h
+++ b/Firestore/Source/Local/FSTLevelDB.h
@@ -56,8 +56,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @return A storage directory unique to the instance identified by databaseInfo.
  */
 + (firebase::firestore::util::Path)
-    storageDirectoryForDatabaseInfo:(const firebase::firestore::core::DatabaseInfo &)databaseInfo
-                 documentsDirectory:(const firebase::firestore::util::Path &)documentsDirectory;
+storageDirectoryForDatabaseInfo:(const firebase::firestore::core::DatabaseInfo &)databaseInfo
+             documentsDirectory:(const firebase::firestore::util::Path &)documentsDirectory;
 
 /**
  * Starts LevelDB-backed persistent storage by opening the database files, creating the DB if it

--- a/Firestore/Source/Local/FSTQueryData.h
+++ b/Firestore/Source/Local/FSTQueryData.h
@@ -58,10 +58,10 @@ typedef NS_ENUM(NSInteger, FSTQueryPurpose) {
  * number.
  */
 - (instancetype)
-    queryDataByReplacingSnapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVersion
-                            resumeToken:(NSData *)resumeToken
-                         sequenceNumber:
-                             (firebase::firestore::model::ListenSequenceNumber)sequenceNumber;
+queryDataByReplacingSnapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVersion
+                        resumeToken:(NSData *)resumeToken
+                     sequenceNumber:
+                         (firebase::firestore::model::ListenSequenceNumber)sequenceNumber;
 
 /** The latest snapshot version seen for this target. */
 - (const firebase::firestore::model::SnapshotVersion &)snapshotVersion;

--- a/Firestore/Source/Model/FSTFieldValue.h
+++ b/Firestore/Source/Model/FSTFieldValue.h
@@ -86,7 +86,7 @@ typedef NS_ENUM(NSInteger, FSTServerTimestampBehavior) {
  *  - Array
  *  - Object
  */
-@interface FSTFieldValue<__covariant T> : NSObject
+@interface FSTFieldValue <__covariant T> : NSObject
 
 /** Returns the FSTTypeOrder for this value. */
 - (FSTTypeOrder)typeOrder;

--- a/Firestore/Source/Model/FSTMutation.mm
+++ b/Firestore/Source/Model/FSTMutation.mm
@@ -383,8 +383,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @return The transform results array.
  */
 - (NSArray<FSTFieldValue *> *)
-    serverTransformResultsWithBaseDocument:(nullable FSTMaybeDocument *)baseDocument
-                    serverTransformResults:(NSArray<FSTFieldValue *> *)serverTransformResults {
+serverTransformResultsWithBaseDocument:(nullable FSTMaybeDocument *)baseDocument
+                serverTransformResults:(NSArray<FSTFieldValue *> *)serverTransformResults {
   NSMutableArray<FSTFieldValue *> *transformResults = [NSMutableArray array];
   HARD_ASSERT(self.fieldTransforms.size() == serverTransformResults.count,
               "server transform result count (%s) should match field transforms count (%s)",

--- a/Firestore/Source/Remote/FSTRemoteEvent.h
+++ b/Firestore/Source/Remote/FSTRemoteEvent.h
@@ -121,17 +121,16 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FSTRemoteEvent : NSObject
 
 - (instancetype)
-    initWithSnapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVersion
-              targetChanges:
-                  (std::unordered_map<firebase::firestore::model::TargetId, FSTTargetChange *>)
-                      targetChanges
-           targetMismatches:
-               (std::unordered_set<firebase::firestore::model::TargetId>)targetMismatches
-            documentUpdates:
-                (std::unordered_map<firebase::firestore::model::DocumentKey,
-                                    FSTMaybeDocument *,
-                                    firebase::firestore::model::DocumentKeyHash>)documentUpdates
-             limboDocuments:(firebase::firestore::model::DocumentKeySet)limboDocuments;
+initWithSnapshotVersion:(firebase::firestore::model::SnapshotVersion)snapshotVersion
+          targetChanges:
+              (std::unordered_map<firebase::firestore::model::TargetId, FSTTargetChange *>)
+                  targetChanges
+       targetMismatches:(std::unordered_set<firebase::firestore::model::TargetId>)targetMismatches
+        documentUpdates:
+            (std::unordered_map<firebase::firestore::model::DocumentKey,
+                                FSTMaybeDocument *,
+                                firebase::firestore::model::DocumentKeyHash>)documentUpdates
+         limboDocuments:(firebase::firestore::model::DocumentKeySet)limboDocuments;
 
 /** The snapshot version this event brings us up to. */
 - (const firebase::firestore::model::SnapshotVersion &)snapshotVersion;

--- a/Firestore/Source/Remote/FSTRemoteEvent.mm
+++ b/Firestore/Source/Remote/FSTRemoteEvent.mm
@@ -251,12 +251,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)
-    initWithSnapshotVersion:(SnapshotVersion)snapshotVersion
-              targetChanges:(std::unordered_map<TargetId, FSTTargetChange *>)targetChanges
-           targetMismatches:(std::unordered_set<TargetId>)targetMismatches
-            documentUpdates:(std::unordered_map<DocumentKey, FSTMaybeDocument *, DocumentKeyHash>)
-                                documentUpdates
-             limboDocuments:(DocumentKeySet)limboDocuments {
+initWithSnapshotVersion:(SnapshotVersion)snapshotVersion
+          targetChanges:(std::unordered_map<TargetId, FSTTargetChange *>)targetChanges
+       targetMismatches:(std::unordered_set<TargetId>)targetMismatches
+        documentUpdates:
+            (std::unordered_map<DocumentKey, FSTMaybeDocument *, DocumentKeyHash>)documentUpdates
+         limboDocuments:(DocumentKeySet)limboDocuments {
   self = [super init];
   if (self) {
     _snapshotVersion = std::move(snapshotVersion);

--- a/Firestore/Source/Remote/FSTStream.h
+++ b/Firestore/Source/Remote/FSTStream.h
@@ -87,7 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * See https://github.com/grpc/grpc/issues/10957 for the kinds of things we're trying to avoid.
  */
-@interface FSTStream<__covariant FSTStreamDelegate> : NSObject
+@interface FSTStream <__covariant FSTStreamDelegate> : NSObject
 
 - (instancetype)initWithDatabase:(const firebase::firestore::core::DatabaseInfo *)database
              workerDispatchQueue:(FSTDispatchQueue *)workerDispatchQueue

--- a/Firestore/core/test/firebase/firestore/auth/firebase_credentials_provider_test.mm
+++ b/Firestore/core/test/firebase/firestore/auth/firebase_credentials_provider_test.mm
@@ -34,7 +34,7 @@
 #include "gtest/gtest.h"
 
 /// A fake class to handle Auth interaction.
-@interface FSTAuthFake : NSObject <FIRAuthInterop>
+@interface FSTAuthFake : NSObject<FIRAuthInterop>
 @property(nonatomic, nullable, strong, readonly) NSString* token;
 @property(nonatomic, nullable, strong, readonly) NSString* uid;
 @property(nonatomic, readonly) BOOL forceRefreshTriggered;

--- a/Functions/Example/IntegrationTests/FIRIntegrationTests.m
+++ b/Functions/Example/IntegrationTests/FIRIntegrationTests.m
@@ -168,7 +168,7 @@
         XCTAssertNotNil(error);
         XCTAssertEqual(FIRFunctionsErrorCodeOutOfRange, error.code);
         XCTAssertEqualObjects(@"explicit nope", error.userInfo[NSLocalizedDescriptionKey]);
-        NSDictionary *expectedDetails = @{@"start" : @10, @"end" : @20, @"long" : @30L};
+        NSDictionary *expectedDetails = @{ @"start" : @10, @"end" : @20, @"long" : @30L };
         XCTAssertEqualObjects(expectedDetails, error.userInfo[FIRFunctionsErrorDetailsKey]);
         [expectation fulfill];
       }];

--- a/Functions/Example/Tests/FUNSerializerTests.m
+++ b/Functions/Example/Tests/FUNSerializerTests.m
@@ -186,7 +186,7 @@
 }
 
 - (void)testEncodeMap {
-  NSDictionary *input = @{@"foo" : @1, @"bar" : @"hello", @"baz" : @[ @3, @4L ]};
+  NSDictionary *input = @{ @"foo" : @1, @"bar" : @"hello", @"baz" : @[ @3, @4L ] };
   NSDictionary *expected = @{
     @"foo" : @1,
     @"bar" : @"hello",
@@ -212,7 +212,7 @@
       }
     ]
   };
-  NSDictionary *expected = @{@"foo" : @1, @"bar" : @"hello", @"baz" : @[ @3, @4L ]};
+  NSDictionary *expected = @{ @"foo" : @1, @"bar" : @"hello", @"baz" : @[ @3, @4L ] };
   FUNSerializer *serializer = [[FUNSerializer alloc] init];
   NSError *error = nil;
   XCTAssertEqualObjects(expected, [serializer decode:input error:&error]);

--- a/GoogleUtilities/AppDelegateSwizzler/Private/GULAppDelegateSwizzler.h
+++ b/GoogleUtilities/AppDelegateSwizzler/Private/GULAppDelegateSwizzler.h
@@ -46,8 +46,8 @@ typedef NSString *const GULAppDelegateInterceptorID;
  *  registering your interceptor. This method is safe to call multiple times (but it only proxies
  *  the app delegate once).
  */
-+ (void)proxyOriginalDelegate NS_EXTENSION_UNAVAILABLE(
-    "App delegate proxy doesn't support extensions.");
++ (void)proxyOriginalDelegate
+    NS_EXTENSION_UNAVAILABLE("App delegate proxy doesn't support extensions.");
 
 /** Indicates whether app delegate proxy is explicitly disabled or enabled. Enabled by default.
  *

--- a/GoogleUtilities/Example/Tests/Swizzler/GULAppDelegateSwizzlerTest.m
+++ b/GoogleUtilities/Example/Tests/Swizzler/GULAppDelegateSwizzlerTest.m
@@ -671,7 +671,7 @@ static BOOL gRespondsToHandleBackgroundSession;
  * the Google flag is not present. */
 - (void)testAppProxyPlistFlag_FirebaseEnabled {
   // Set proxy enabled to YES.
-  NSDictionary *mainDictionary = @{kGULFirebaseAppDelegateProxyEnabledPlistKey : @(YES)};
+  NSDictionary *mainDictionary = @{ kGULFirebaseAppDelegateProxyEnabledPlistKey : @(YES) };
   id mainBundleMock = OCMPartialMock([NSBundle mainBundle]);
   [[[mainBundleMock expect] andReturn:mainDictionary] infoDictionary];
 
@@ -683,7 +683,7 @@ static BOOL gRespondsToHandleBackgroundSession;
  * Firebase flag is not present. */
 - (void)testAppProxyPlistFlag_GoogleEnabled {
   // Set proxy enabled to YES.
-  NSDictionary *mainDictionary = @{kGULGoogleAppDelegateProxyEnabledPlistKey : @(YES)};
+  NSDictionary *mainDictionary = @{ kGULGoogleAppDelegateProxyEnabledPlistKey : @(YES) };
   id mainBundleMock = OCMPartialMock([NSBundle mainBundle]);
   [[[mainBundleMock expect] andReturn:mainDictionary] infoDictionary];
 
@@ -719,7 +719,7 @@ static BOOL gRespondsToHandleBackgroundSession;
  * flag is not present. */
 - (void)testAppProxyPlist_FirebaseDisableFlag {
   // Set proxy enabled to NO.
-  NSDictionary *mainDictionary = @{kGULFirebaseAppDelegateProxyEnabledPlistKey : @(NO)};
+  NSDictionary *mainDictionary = @{ kGULFirebaseAppDelegateProxyEnabledPlistKey : @(NO) };
   id mainBundleMock = OCMPartialMock([NSBundle mainBundle]);
   [[[mainBundleMock expect] andReturn:mainDictionary] infoDictionary];
 
@@ -731,7 +731,7 @@ static BOOL gRespondsToHandleBackgroundSession;
  * flag is not present. */
 - (void)testAppProxyPlist_GoogleDisableFlag {
   // Set proxy enabled to NO.
-  NSDictionary *mainDictionary = @{kGULGoogleAppDelegateProxyEnabledPlistKey : @(NO)};
+  NSDictionary *mainDictionary = @{ kGULGoogleAppDelegateProxyEnabledPlistKey : @(NO) };
   id mainBundleMock = OCMPartialMock([NSBundle mainBundle]);
   [[[mainBundleMock expect] andReturn:mainDictionary] infoDictionary];
 
@@ -787,7 +787,7 @@ static BOOL gRespondsToHandleBackgroundSession;
 /** Tests that the App Delegate is not proxied when it is disabled. */
 - (void)testAppDelegateIsNotProxiedWhenDisabled {
   // Set proxy enabled to NO.
-  NSDictionary *mainDictionary = @{kGULFirebaseAppDelegateProxyEnabledPlistKey : @(NO)};
+  NSDictionary *mainDictionary = @{ kGULFirebaseAppDelegateProxyEnabledPlistKey : @(NO) };
   id mainBundleMock = OCMPartialMock([NSBundle mainBundle]);
   [[[mainBundleMock stub] andReturn:mainDictionary] infoDictionary];
   XCTAssertFalse([GULAppDelegateSwizzler isAppDelegateProxyEnabled]);


### PR DESCRIPTION
This reformats Firestore based on the output of:

```
clang-format --version
clang-format version 7.0.0 (tags/google/stable/2018-01-11)
```

