### PR TITLE
Don't drop empty object during merge

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -4,6 +4,8 @@
 - [changed] Changed `get()` to only make 1 attempt to reach the backend before
   returning cached data, potentially reducing delays while offline. Previously
   it would make 2 attempts, to work around a backend bug.
+- [fixed] Fixed an issue that caused us to drop empty objects from calls to
+  `setData(..., merge:true)`.
 
 # v0.13.3
 - [changed] Internal improvements.

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.h
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.h
@@ -90,6 +90,10 @@ extern "C" {
 
 - (void)mergeDocumentRef:(FIRDocumentReference *)ref data:(NSDictionary<NSString *, id> *)data;
 
+- (void)mergeDocumentRef:(FIRDocumentReference *)ref
+                    data:(NSDictionary<NSString *, id> *)data
+                  fields:(NSArray<id> *)fields;
+
 - (void)disableNetwork;
 
 - (void)enableNetwork;

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -331,6 +331,15 @@ static FIRFirestoreSettings *defaultSettings;
   [self awaitExpectations];
 }
 
+- (void)mergeDocumentRef:(FIRDocumentReference *)ref
+                    data:(NSDictionary<NSString *, id> *)data
+                  fields:(NSArray<id> *)fields {
+  [ref setData:data
+      mergeFields:fields
+       completion:[self completionForExpectationWithName:@"setDataWithMerge"]];
+  [self awaitExpectations];
+}
+
 - (void)disableNetwork {
   [self.db.client
       disableNetworkWithCompletion:[self completionForExpectationWithName:@"Disable Network."]];

--- a/Firestore/Source/API/FSTUserDataConverter.mm
+++ b/Firestore/Source/API/FSTUserDataConverter.mm
@@ -257,13 +257,22 @@ NS_ASSUME_NONNULL_BEGIN
 - (FSTFieldValue *)parseDictionary:(NSDictionary *)dict context:(ParseContext &&)context {
   NSMutableDictionary<NSString *, FSTFieldValue *> *result =
       [NSMutableDictionary dictionaryWithCapacity:dict.count];
-  [dict enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, BOOL *stop) {
-    FSTFieldValue *_Nullable parsedValue =
-        [self parseData:value context:context.ChildContext(util::MakeString(key))];
-    if (parsedValue) {
-      result[key] = parsedValue;
+
+  if ([dict count] == 0) {
+    const FieldPath *path = context.path();
+    if (path && !path->empty()) {
+      context.AddToFieldMask(*path);
     }
-  }];
+    return [FSTObjectValue objectValue];
+  } else {
+    [dict enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, BOOL *stop) {
+      FSTFieldValue *_Nullable parsedValue =
+          [self parseData:value context:context.ChildContext(util::MakeString(key))];
+      if (parsedValue) {
+        result[key] = parsedValue;
+      }
+    }];
+  }
   return [[FSTObjectValue alloc] initWithDictionary:result];
 }
 

--- a/Firestore/Source/Model/FSTMutation.mm
+++ b/Firestore/Source/Model/FSTMutation.mm
@@ -271,11 +271,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (FSTObjectValue *)patchObjectValue:(FSTObjectValue *)objectValue {
   FSTObjectValue *result = objectValue;
   for (const FieldPath &fieldPath : self.fieldMask) {
-    FSTFieldValue *newValue = [self.value valueForPath:fieldPath];
-    if (newValue) {
-      result = [result objectBySettingValue:newValue forPath:fieldPath];
-    } else {
-      result = [result objectByDeletingPath:fieldPath];
+    if (!fieldPath.empty()) {
+      FSTFieldValue *newValue = [self.value valueForPath:fieldPath];
+      if (newValue) {
+        result = [result objectBySettingValue:newValue forPath:fieldPath];
+      } else {
+        result = [result objectByDeletingPath:fieldPath];
+      }
     }
   }
   return result;


### PR DESCRIPTION
We currently drop empty objects when during set({merge: true}) since we only add leaf nodes to the field mask. We need to consider an empty object a leaf node.

Port of firebase/firebase-js-sdk#1202