### PR TITLE
Fix building of objc protos

### DIFF
--- a/Firestore/Protos/CMakeLists.txt
+++ b/Firestore/Protos/CMakeLists.txt
@@ -33,6 +33,14 @@ set(
   google/rpc/status
   google/type/latlng
 )
+# Full filenames (i.e. with the .proto) from within the proto directory,
+# excluding anything in google/protobuf
+foreach(root ${PROTO_FILE_ROOTS})
+  list(
+    APPEND PROTO_FILES
+    ${OUTPUT_DIR}/protos/${root}.proto
+  )
+endforeach()
 
 # Filename "roots" (i.e. without the .proto) from within the proto directory,
 # from the google/protobuf package.
@@ -44,6 +52,14 @@ set(
   google/protobuf/timestamp
   google/protobuf/wrappers
 )
+# Full filenames (i.e. with the .proto) from within the proto directory, from
+# the google/protobuf package.
+foreach(root ${WELL_KNOWN_PROTO_FILE_ROOTS})
+  list(
+    APPEND WELL_KNOWN_PROTO_FILES
+    ${OUTPUT_DIR}/protos/${root}.proto
+  )
+endforeach()
 
 # Populate NANOPB_GENERATED_SOURCES with the list of nanopb-generated sources.
 # The nanopb runtime does not include the well-known protos so we have to build
@@ -68,6 +84,27 @@ foreach(root ${PROTO_FILE_ROOTS})
   )
 endforeach()
 
+# Converts a snake_case string to a CamelCase string.
+#
+# Input string must start and end with a lower case character, and must not
+# have multiple consecutive underscores.
+function(snake_case_to_camel_case str var)
+  # prepend an underscore (to avoid special casing the first char)
+  set(str "_${str}")
+  while(TRUE)
+    string(FIND ${str} "_" pos)
+    if(${pos} EQUAL "-1")
+      break()
+    endif()
+    MATH(EXPR pos "${pos}+1")
+    string(SUBSTRING ${str} "${pos}" 1 lower_char)
+    string(TOUPPER ${lower_char} upper_char)
+    string(REPLACE  "_${lower_char}" ${upper_char} str ${str})
+  endwhile()
+
+  set(${var} ${str} PARENT_SCOPE)
+endfunction()
+
 # Populate PROTOBUF_OBJC_GENERATED_SOURCES with the list of libprotobuf
 # Objective-C sources. These are used by the old Objective-C implementation
 # that we're replacing.
@@ -83,10 +120,24 @@ set(
   ${OUTPUT_DIR}/objc/google/firestore/v1beta1/Firestore.pbrpc.m
 )
 foreach(root ${PROTO_FILE_ROOTS})
+  get_filename_component(dir ${root} DIRECTORY)
+  get_filename_component(fname ${root} NAME)
+
+  # protoc converts the filename from snake case to camel case, so we must do
+  # that too.
+  if(${fname} STREQUAL "http")
+    # Hack: Something, somewhere is causing protoc to special case 'http' and
+    # convert it to HTTP (rather than Http) for objc. So we'll special case it
+    # here too.
+    set(fname "HTTP")
+  else()
+    snake_case_to_camel_case(${fname} fname)
+  endif()
+
   list(
     APPEND PROTOBUF_OBJC_GENERATED_SOURCES
-    ${OUTPUT_DIR}/objc/${root}.pbobjc.h
-    ${OUTPUT_DIR}/objc/${root}.pbobjc.m
+    ${OUTPUT_DIR}/objc/${dir}/${fname}.pbobjc.h
+    ${OUTPUT_DIR}/objc/${dir}/${fname}.pbobjc.m
   )
 endforeach()
 
@@ -194,6 +245,8 @@ add_custom_command(
     ${CMAKE_CURRENT_SOURCE_DIR}/nanopb_cpp_generator.py
     ${NANOPB_PYTHON}
     ${PROTOBUF_PYTHON}
+    ${PROTO_FILES}
+    ${WELL_KNOWN_PROTO_FILES}
 )
 
 add_custom_target(
@@ -213,8 +266,10 @@ add_custom_command(
       ${PROTO_INCLUDES}
   VERBATIM
   DEPENDS
+    grpc_objective_c_plugin
     protoc
     ${CMAKE_CURRENT_SOURCE_DIR}/build_protos.py
+    ${PROTO_FILES}
 )
 
 add_custom_target(
@@ -238,6 +293,7 @@ add_custom_command(
     grpc_objective_c_plugin
     protoc
     ${CMAKE_CURRENT_SOURCE_DIR}/build_protos.py
+    ${PROTO_FILES}
 )
 
 add_custom_target(

--- a/Firestore/Protos/CMakeLists.txt
+++ b/Firestore/Protos/CMakeLists.txt
@@ -266,7 +266,6 @@ add_custom_command(
       ${PROTO_INCLUDES}
   VERBATIM
   DEPENDS
-    grpc_objective_c_plugin
     protoc
     ${CMAKE_CURRENT_SOURCE_DIR}/build_protos.py
     ${PROTO_FILES}

--- a/Firestore/Protos/README.md
+++ b/Firestore/Protos/README.md
@@ -2,22 +2,16 @@
 
 First, make sure you have necessary prereqs for building:
 ```
-brew install automake libtool protobuf
+brew install automake libtool protobuf golang
 ```
 
-Take a nap while that completes. Then, build protobuf and nanopb:
+Take a nap while that completes. Then, build the protos:
 ```
 cd firebase-ios-sdk
 mkdir -p build
 cd build
 cmake ..
-make -j protobuf nanopb
-```
-
-Next, build the protos:
-```
-cd firebase-ios-sdk/Firestore/Protos
-./build_protos.py
+make -j generate_protos
 ```
 
 Verify diffs, make sure tests still pass, and create a PR.

--- a/Firestore/Protos/objc/google/firestore/v1beta1/Firestore.pbrpc.h
+++ b/Firestore/Protos/objc/google/firestore/v1beta1/Firestore.pbrpc.h
@@ -14,57 +14,61 @@
  * limitations under the License.
  */
 
-#if !GPB_GRPC_FORWARD_DECLARE_MESSAGE_PROTO
+#if !defined(GPB_GRPC_FORWARD_DECLARE_MESSAGE_PROTO) || !GPB_GRPC_FORWARD_DECLARE_MESSAGE_PROTO
 #import "Firestore.pbobjc.h"
 #endif
 
+#if !defined(GPB_GRPC_PROTOCOL_ONLY) || !GPB_GRPC_PROTOCOL_ONLY
 #import <ProtoRPC/ProtoService.h>
 #import <ProtoRPC/ProtoRPC.h>
 #import <RxLibrary/GRXWriteable.h>
 #import <RxLibrary/GRXWriter.h>
+#endif
 
-#if GPB_GRPC_FORWARD_DECLARE_MESSAGE_PROTO
-  @class GCFSBatchGetDocumentsRequest;
-  @class GCFSBatchGetDocumentsResponse;
-  @class GCFSBeginTransactionRequest;
-  @class GCFSBeginTransactionResponse;
-  @class GCFSCommitRequest;
-  @class GCFSCommitResponse;
-  @class GCFSCreateDocumentRequest;
-  @class GCFSDeleteDocumentRequest;
-  @class GCFSDocument;
-  @class GCFSGetDocumentRequest;
-  @class GCFSListCollectionIdsRequest;
-  @class GCFSListCollectionIdsResponse;
-  @class GCFSListDocumentsRequest;
-  @class GCFSListDocumentsResponse;
-  @class GCFSListenRequest;
-  @class GCFSListenResponse;
-  @class GCFSRollbackRequest;
-  @class GCFSRunQueryRequest;
-  @class GCFSRunQueryResponse;
-  @class GCFSUpdateDocumentRequest;
-  @class GCFSWriteRequest;
-  @class GCFSWriteResponse;
-  @class GPBEmpty;
-#else
+@class GCFSBatchGetDocumentsRequest;
+@class GCFSBatchGetDocumentsResponse;
+@class GCFSBeginTransactionRequest;
+@class GCFSBeginTransactionResponse;
+@class GCFSCommitRequest;
+@class GCFSCommitResponse;
+@class GCFSCreateDocumentRequest;
+@class GCFSDeleteDocumentRequest;
+@class GCFSDocument;
+@class GCFSGetDocumentRequest;
+@class GCFSListCollectionIdsRequest;
+@class GCFSListCollectionIdsResponse;
+@class GCFSListDocumentsRequest;
+@class GCFSListDocumentsResponse;
+@class GCFSListenRequest;
+@class GCFSListenResponse;
+@class GCFSRollbackRequest;
+@class GCFSRunQueryRequest;
+@class GCFSRunQueryResponse;
+@class GCFSUpdateDocumentRequest;
+@class GCFSWriteRequest;
+@class GCFSWriteResponse;
+@class GPBEmpty;
+
+#if !defined(GPB_GRPC_FORWARD_DECLARE_MESSAGE_PROTO) || !GPB_GRPC_FORWARD_DECLARE_MESSAGE_PROTO
   #import "Annotations.pbobjc.h"
   #import "Common.pbobjc.h"
   #import "Document.pbobjc.h"
   #import "Query.pbobjc.h"
   #import "Write.pbobjc.h"
-  #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
-    #import <Protobuf/Empty.pbobjc.h>
-  #else
-    #import "Empty.pbobjc.h"
-  #endif
-  #if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
-    #import <Protobuf/Timestamp.pbobjc.h>
-  #else
-    #import "Timestamp.pbobjc.h"
-  #endif
+#if defined(GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS) && GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
+  #import <Protobuf/Empty.pbobjc.h>
+#else
+  #import "Empty.pbobjc.h"
+#endif
+#if defined(GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS) && GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
+  #import <Protobuf/Timestamp.pbobjc.h>
+#else
+  #import "Timestamp.pbobjc.h"
+#endif
   #import "Status.pbobjc.h"
 #endif
+
+@class GRPCProtoCall;
 
 
 NS_ASSUME_NONNULL_BEGIN
@@ -248,6 +252,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+
+#if !defined(GPB_GRPC_PROTOCOL_ONLY) || !GPB_GRPC_PROTOCOL_ONLY
 /**
  * Basic service implementation, over gRPC, that only does
  * marshalling and parsing.
@@ -256,5 +262,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithHost:(NSString *)host NS_DESIGNATED_INITIALIZER;
 + (instancetype)serviceWithHost:(NSString *)host;
 @end
+#endif
 
 NS_ASSUME_NONNULL_END
+

--- a/Firestore/Protos/objc/google/firestore/v1beta1/Firestore.pbrpc.m
+++ b/Firestore/Protos/objc/google/firestore/v1beta1/Firestore.pbrpc.m
@@ -14,25 +14,26 @@
  * limitations under the License.
  */
 
+#if !defined(GPB_GRPC_PROTOCOL_ONLY) || !GPB_GRPC_PROTOCOL_ONLY
 #import "Firestore.pbrpc.h"
 #import "Firestore.pbobjc.h"
-
 #import <ProtoRPC/ProtoRPC.h>
 #import <RxLibrary/GRXWriter+Immediate.h>
+
 #import "Annotations.pbobjc.h"
 #import "Common.pbobjc.h"
 #import "Document.pbobjc.h"
 #import "Query.pbobjc.h"
 #import "Write.pbobjc.h"
-#if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
-  #import <Protobuf/Empty.pbobjc.h>
+#if defined(GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS) && GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
+#import <Protobuf/Empty.pbobjc.h>
 #else
-  #import "Empty.pbobjc.h"
+#import "Empty.pbobjc.h"
 #endif
-#if GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
-  #import <Protobuf/Timestamp.pbobjc.h>
+#if defined(GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS) && GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS
+#import <Protobuf/Timestamp.pbobjc.h>
 #else
-  #import "Timestamp.pbobjc.h"
+#import "Timestamp.pbobjc.h"
 #endif
 #import "Status.pbobjc.h"
 
@@ -40,7 +41,10 @@
 
 // Designated initializer
 - (instancetype)initWithHost:(NSString *)host {
-  return (self = [super initWithHost:host packageName:@"google.firestore.v1beta1" serviceName:@"Firestore"]);
+  self = [super initWithHost:host
+                 packageName:@"google.firestore.v1beta1"
+                 serviceName:@"Firestore"];
+  return self;
 }
 
 // Override superclass initializer to disallow different package and service names.
@@ -50,10 +54,13 @@
   return [self initWithHost:host];
 }
 
+#pragma mark - Class Methods
+
 + (instancetype)serviceWithHost:(NSString *)host {
   return [[self alloc] initWithHost:host];
 }
 
+#pragma mark - Method Implementations
 
 #pragma mark GetDocument(GetDocumentRequest) returns (Document)
 
@@ -296,3 +303,4 @@
         responsesWriteable:[GRXWriteable writeableWithSingleHandler:handler]];
 }
 @end
+#endif

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -272,7 +272,7 @@ case "$product-$method-$platform" in
 
     echo "Building cmake build ..."
     cpus=$(sysctl -n hw.ncpu)
-    (cd build; env make -j $cpus all)
+    (cd build; env make -j $cpus all generate_protos)
     (cd build; env CTEST_OUTPUT_ON_FAILURE=1 make -j $cpus test)
     ;;
 


### PR DESCRIPTION
All proto targets (objc, cpp, nanopb) now depend on the proto sources,
so they'll be rebuilt if the proto sources change.

Also updated Firestore/Protos/README.md to reflect recent changes.

Also update travis config to build the protos. (Previously, cpp and
nanopb were rebuilt, since they're used in the cmake build. But objc was
not since it's not actually depended on by anything in cmake.)

Also rebuild the objc protos.