### PR TITLE
add message ID to direct channel message

### DIFF
--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -115,16 +115,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
   return self;
 }
 
-- (instancetype)initWithMessage:(FIRMessagingRemoteMessage *)message {
-  self = [self init];
-  if (self) {
-    _appData = [message.appData copy];
-  }
-
-  return self;
-}
-
-@end
+end
 
 @interface FIRMessaging ()<FIRMessagingClientDelegate, FIRMessagingReceiverDelegate,
                            GULReachabilityDelegate>

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -115,7 +115,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
   return self;
 }
 
-end
+@end
 
 @interface FIRMessaging ()<FIRMessagingClientDelegate, FIRMessagingReceiverDelegate,
                            GULReachabilityDelegate>

--- a/Firebase/Messaging/FIRMessagingReceiver.m
+++ b/Firebase/Messaging/FIRMessagingReceiver.m
@@ -103,6 +103,7 @@ static int downstreamMessageID = 0;
   FIRMessagingRemoteMessage *wrappedMessage = [[FIRMessagingRemoteMessage alloc] init];
   // TODO: wrap title, body, badge and other fields
   wrappedMessage.appData = [message copy];
+  wrappedMessage.messageID = messageID;
   [self.delegate receiver:self receivedRemoteMessage:wrappedMessage];
 }
 

--- a/Firebase/Messaging/FIRMessaging_Private.h
+++ b/Firebase/Messaging/FIRMessaging_Private.h
@@ -30,6 +30,7 @@ FOUNDATION_EXPORT NSString *const kFIRMessagingUserDefaultsKeyAutoInitEnabled;
 
 @interface FIRMessagingRemoteMessage ()
 
+@property(nonatomic, copy) NSString *messageID;
 @property(nonatomic, strong) NSDictionary *appData;
 
 @end

--- a/Firebase/Messaging/Public/FIRMessaging.h
+++ b/Firebase/Messaging/Public/FIRMessaging.h
@@ -233,8 +233,11 @@ NS_SWIFT_NAME(MessagingMessageInfo)
 NS_SWIFT_NAME(MessagingRemoteMessage)
 @interface FIRMessagingRemoteMessage : NSObject
 
+/// The message ID of downstream message.
+@property(nonatomic, readonly, copy) NSString *messageID;
 /// The downstream message received by the application.
 @property(nonatomic, readonly, strong) NSDictionary *appData;
+
 @end
 
 @class FIRMessaging;


### PR DESCRIPTION
Also removed initWithMessage: method that is not used in source code and tests.