### PR TITLE
Fix Core version requirement.

### DIFF
--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -62,7 +62,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
   s.framework = 'SafariServices'
   s.framework = 'Security'
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
-  s.dependency 'FirebaseCore', '~> 5.0'
+  s.dependency 'FirebaseCore', '~> 5.1'
   s.dependency 'GoogleUtilities/Environment', '~> 5.2'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
 end

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -49,7 +49,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.public_header_files = 'Firestore/Source/Public/*.h'
 
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
-  s.dependency 'FirebaseCore', '~> 5.0'
+  s.dependency 'FirebaseCore', '~> 5.1'
   s.dependency 'gRPC-ProtoRPC', '~> 1.0'
   s.dependency 'gRPC-C++', '~> 0.0.3'
   s.dependency 'leveldb-library', '~> 1.20'

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -30,7 +30,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   s.osx.framework = 'CoreServices'
 
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
-  s.dependency 'FirebaseCore', '~> 5.0'
+  s.dependency 'FirebaseCore', '~> 5.1'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
   s.pod_target_xcconfig = {
     'GCC_PREPROCESSOR_DEFINITIONS' =>


### PR DESCRIPTION
These pods depend on FirebaseCore's interop APIs that were introduced
in FirebaseCore version 5.1. This wasn't picked up before since
CocoaPods automatically matched the largest minor version available but
the podspec should accurately represent the version requirements.