### PR TITLE
Enforce field initialization order

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -81,6 +81,8 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
         Firestore/core/src/firebase/firestore/util/config.h
   CMD
 
+  s.compiler_flags = '$(inherited) -Wreorder -Werror=reorder'
+
   s.subspec 'abseil-cpp' do |ss|
     ss.preserve_path = [
       'Firestore/third_party/abseil-cpp/absl'

--- a/Firestore/Source/Local/FSTLRUGarbageCollector.mm
+++ b/Firestore/Source/Local/FSTLRUGarbageCollector.mm
@@ -34,7 +34,7 @@ const ListenSequenceNumber kFSTListenSequenceNumberInvalid = -1;
 class RollingSequenceNumberBuffer {
  public:
   explicit RollingSequenceNumberBuffer(size_t max_elements)
-      : max_elements_(max_elements), queue_(std::priority_queue<ListenSequenceNumber>()) {
+      : queue_(std::priority_queue<ListenSequenceNumber>()), max_elements_(max_elements) {
   }
 
   RollingSequenceNumberBuffer(const RollingSequenceNumberBuffer &other) = delete;

--- a/Firestore/core/src/firebase/firestore/remote/datastore.mm
+++ b/Firestore/core/src/firebase/firestore/remote/datastore.mm
@@ -88,7 +88,7 @@ Datastore::Datastore(const DatabaseInfo &database_info,
       rpc_executor_{CreateExecutor()},
       grpc_connection_{database_info, worker_queue, &grpc_queue_},
       serializer_bridge_{serializer} {
-    rpc_executor_->Execute([this] { PollGrpcQueue(); });
+  rpc_executor_->Execute([this] { PollGrpcQueue(); });
 }
 
 void Datastore::Shutdown() {

--- a/Firestore/core/src/firebase/firestore/remote/datastore.mm
+++ b/Firestore/core/src/firebase/firestore/remote/datastore.mm
@@ -83,12 +83,12 @@ Datastore::Datastore(const DatabaseInfo &database_info,
                      AsyncQueue *worker_queue,
                      CredentialsProvider *credentials,
                      FSTSerializerBeta *serializer)
-    : grpc_connection_{database_info, worker_queue, &grpc_queue_},
-      worker_queue_{worker_queue},
+    : worker_queue_{worker_queue},
       credentials_{credentials},
       rpc_executor_{CreateExecutor()},
+      grpc_connection_{database_info, worker_queue, &grpc_queue_},
       serializer_bridge_{serializer} {
-  rpc_executor_->Execute([this] { PollGrpcQueue(); });
+    rpc_executor_->Execute([this] { PollGrpcQueue(); });
 }
 
 void Datastore::Shutdown() {

--- a/Firestore/core/src/firebase/firestore/remote/grpc_stream.cc
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_stream.cc
@@ -86,8 +86,8 @@ GrpcStream::GrpcStream(
     AsyncQueue* worker_queue)
     : context_{std::move(context)},
       call_{std::move(call)},
-      observer_{observer},
-      worker_queue_{worker_queue} {
+      worker_queue_{worker_queue},
+      observer_{observer} {
 }
 
 GrpcStream::~GrpcStream() {

--- a/Firestore/core/src/firebase/firestore/remote/stream.mm
+++ b/Firestore/core/src/firebase/firestore/remote/stream.mm
@@ -57,11 +57,11 @@ Stream::Stream(AsyncQueue* worker_queue,
                GrpcConnection* grpc_connection,
                TimerId backoff_timer_id,
                TimerId idle_timer_id)
-    : worker_queue_{worker_queue},
+    : backoff_{worker_queue, backoff_timer_id, kBackoffFactor,
+        kBackoffInitialDelay, kBackoffMaxDelay},
       credentials_provider_{credentials_provider},
+      worker_queue_{worker_queue},
       grpc_connection_{grpc_connection},
-      backoff_{worker_queue, backoff_timer_id, kBackoffFactor,
-               kBackoffInitialDelay, kBackoffMaxDelay},
       idle_timer_id_{idle_timer_id} {
 }
 

--- a/Firestore/core/src/firebase/firestore/remote/stream.mm
+++ b/Firestore/core/src/firebase/firestore/remote/stream.mm
@@ -58,7 +58,7 @@ Stream::Stream(AsyncQueue* worker_queue,
                TimerId backoff_timer_id,
                TimerId idle_timer_id)
     : backoff_{worker_queue, backoff_timer_id, kBackoffFactor,
-        kBackoffInitialDelay, kBackoffMaxDelay},
+               kBackoffInitialDelay, kBackoffMaxDelay},
       credentials_provider_{credentials_provider},
       worker_queue_{worker_queue},
       grpc_connection_{grpc_connection},

--- a/cmake/compiler_setup.cmake
+++ b/cmake/compiler_setup.cmake
@@ -37,6 +37,8 @@ if(CXX_CLANG OR CXX_GNU)
     -Wuninitialized
     -fno-common
 
+    -Wreorder -Werror=reorder
+
     # Delete unused things
     -Wunused-function -Wunused-value -Wunused-variable
   )


### PR DESCRIPTION
This is enforced via CI in some cases, so make it enforced in all of Firestore.