### PR TITLE
Add a boolean value on whether to use direct channel callback for all ios versions

### DIFF
--- a/Example/Messaging/Tests/FIRMessagingReceiverTest.m
+++ b/Example/Messaging/Tests/FIRMessagingReceiverTest.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google
+ * Copyright 2018 Google
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Example/Messaging/Tests/FIRMessagingReceiverTest.m
+++ b/Example/Messaging/Tests/FIRMessagingReceiverTest.m
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <OCMock/OCMock.h>
+
+#ifdef COCOAPODS
+#import <FirebaseInstanceID/FirebaseInstanceID.h>
+#else
+#import "googlemac/iPhone/InstanceID/Firebase/Lib/Source/FIRInstanceID.h"
+#endif
+#import "FIRMessaging.h"
+#import "FIRMessaging_Private.h"
+
+@interface FIRMessagingReceiverTest : XCTestCase
+@property(nonatomic, readonly, strong) FIRMessaging *messaging;
+
+@end
+
+@implementation FIRMessagingReceiverTest
+- (void)setUp {
+  [super setUp];
+
+  _messaging = [FIRMessaging messaging];
+  [[NSUserDefaults standardUserDefaults]
+      removePersistentDomainForName:[NSBundle mainBundle].bundleIdentifier];
+}
+
+- (void)tearDown {
+  [super tearDown];
+}
+
+- (void)testUseMessagingDelegate {
+  XCTAssertFalse(_messaging.useMessagingDelegateForDirectChannel);
+
+  _messaging.useMessagingDelegateForDirectChannel = YES;
+  XCTAssertTrue(_messaging.useMessagingDelegateForDirectChannel);
+}
+
+- (void)testUseMessagingDelegateFlagOverridedByPlistWithFalseValue {
+  id bundleMock = OCMPartialMock([NSBundle mainBundle]);
+  OCMStub([bundleMock objectForInfoDictionaryKey:kFIRMessagingPlistUseMessagingDelegate])
+      .andReturn(nil);
+  XCTAssertFalse(_messaging.useMessagingDelegateForDirectChannel);
+
+  [bundleMock stopMocking];
+}
+
+- (void)testUseMessagingDelegateFlagOverridedByPlistWithTrueValue {
+  id bundleMock = OCMPartialMock([NSBundle mainBundle]);
+  OCMStub([bundleMock objectForInfoDictionaryKey:kFIRMessagingPlistUseMessagingDelegate])
+      .andReturn(@YES);
+  XCTAssertTrue(_messaging.useMessagingDelegateForDirectChannel);
+
+  [bundleMock stopMocking];
+}
+@end

--- a/Example/Messaging/Tests/FIRMessagingReceiverTest.m
+++ b/Example/Messaging/Tests/FIRMessagingReceiverTest.m
@@ -37,10 +37,6 @@
       removePersistentDomainForName:[NSBundle mainBundle].bundleIdentifier];
 }
 
-- (void)tearDown {
-  [super tearDown];
-}
-
 - (void)testUseMessagingDelegate {
   XCTAssertFalse(_messaging.useMessagingDelegateForDirectChannel);
 

--- a/Example/Messaging/Tests/FIRMessagingReceiverTest.m
+++ b/Example/Messaging/Tests/FIRMessagingReceiverTest.m
@@ -18,11 +18,8 @@
 
 #import <OCMock/OCMock.h>
 
-#ifdef COCOAPODS
 #import <FirebaseInstanceID/FirebaseInstanceID.h>
-#else
-#import "googlemac/iPhone/InstanceID/Firebase/Lib/Source/FIRInstanceID.h"
-#endif
+
 #import "FIRMessaging.h"
 #import "FIRMessaging_Private.h"
 

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -621,6 +621,15 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
   }
 }
 
+
+- (void)setUseMessagingDelegateForDirectChannel:(BOOL)useMessagingDelegateForDirectChannel {
+  self.receiver.useDirectChannel = useMessagingDelegateForDirectChannel;
+}
+
+- (BOOL)useMessagingDelegateForDirectChannel {
+  return self.receiver.useDirectChannel;
+}
+
 #pragma mark - Application State Changes
 
 - (void)applicationStateChanged {

--- a/Firebase/Messaging/FIRMessagingReceiver.h
+++ b/Firebase/Messaging/FIRMessagingReceiver.h
@@ -25,7 +25,10 @@
 
 @end
 
-
 @interface FIRMessagingReceiver : NSObject <FIRMessagingDataMessageManagerDelegate>
+
 @property(nonatomic, weak, nullable) id<FIRMessagingReceiverDelegate> delegate;
+/// Whether to use direct channel for direct channel message callback handler in all iOS versions.
+@property(nonatomic, assign) BOOL useDirectChannel;
+
 @end

--- a/Firebase/Messaging/FIRMessagingReceiver.m
+++ b/Firebase/Messaging/FIRMessagingReceiver.m
@@ -46,17 +46,12 @@ static int downstreamMessageID = 0;
   }
 
   NSInteger majorOSVersion = [[GULAppEnvironmentUtil systemVersion] integerValue];
-  if (majorOSVersion >= 10) {
-    // iOS 10 and above
+  if (majorOSVersion >= 10 || self.useDirectChannel) {
+    // iOS 10 and above or use direct channel is enabled.
     [self scheduleIos10NotificationForMessage:message withIdentifier:messageID];
   } else {
-    // iOS 9 and below
-    if (self.useDirectChannel) {
-      [self scheduleIos10NotificationForMessage:message withIdentifier:messageID];
-    } else {
-      // Post notification directly to AppDelegate handlers. This is valid pre-iOS 10.
-      [self scheduleNotificationForMessage:message];
-    }
+    // Post notification directly to AppDelegate handlers. This is valid pre-iOS 10.
+    [self scheduleNotificationForMessage:message];
   }
 }
 

--- a/Firebase/Messaging/FIRMessagingReceiver.m
+++ b/Firebase/Messaging/FIRMessagingReceiver.m
@@ -18,6 +18,8 @@
 
 #import <UIKit/UIKit.h>
 
+#import <GoogleUtilities/GULAppEnvironmentUtil.h>
+
 #import "FIRMessaging.h"
 #import "FIRMessagingLogger.h"
 #import "FIRMessagingUtilities.h"
@@ -32,11 +34,6 @@ NSString *const kFIRMessagingUserDefaultsKeyUseMessagingDelegate =
 NSString *const kFIRMessagingPlistUseMessagingDelegate =
     @"FirebaseMessagingUseMessagingDelegateForDirectChannel";
 
-// Copied from Apple's header in case it is missing in some cases.
-#ifndef NSFoundationVersionNumber_iOS_9_x_Max
-#define NSFoundationVersionNumber_iOS_9_x_Max 1299
-#endif
-
 static int downstreamMessageID = 0;
 
 @implementation FIRMessagingReceiver
@@ -48,7 +45,8 @@ static int downstreamMessageID = 0;
     messageID = [[self class] nextMessageID];
   }
 
-  if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_9_x_Max) {
+  NSInteger majorOSVersion = [[GULAppEnvironmentUtil systemVersion] integerValue];
+  if (majorOSVersion >= 10) {
     // iOS 10 and above
     [self scheduleIos10NotificationForMessage:message withIdentifier:messageID];
   } else {

--- a/Firebase/Messaging/FIRMessaging_Private.h
+++ b/Firebase/Messaging/FIRMessaging_Private.h
@@ -27,6 +27,8 @@ typedef NS_ENUM(int8_t, FIRMessagingNetworkStatus) {
 
 FOUNDATION_EXPORT NSString *const kFIRMessagingPlistAutoInitEnabled;
 FOUNDATION_EXPORT NSString *const kFIRMessagingUserDefaultsKeyAutoInitEnabled;
+FOUNDATION_EXPORT NSString *const kFIRMessagingUserDefaultsKeyUseMessagingDelegate;
+FOUNDATION_EXPORT NSString *const kFIRMessagingPlistUseMessagingDelegate;
 
 @interface FIRMessagingRemoteMessage ()
 

--- a/Firebase/Messaging/Public/FIRMessaging.h
+++ b/Firebase/Messaging/Public/FIRMessaging.h
@@ -260,9 +260,11 @@ NS_SWIFT_NAME(MessagingDelegate)
     didReceiveRegistrationToken:(NSString *)fcmToken
     NS_SWIFT_NAME(messaging(_:didReceiveRegistrationToken:));
 
-/// This method is called on iOS 10 devices to handle data messages received via FCM through its
-/// direct channel (not via APNS). For iOS 9 and below, the FCM data message is delivered via the
-/// UIApplicationDelegate's -application:didReceiveRemoteNotification: method.
+/// This method is called on iOS 10+ devices to handle data messages received via FCM
+/// direct channel (not via APNS). For iOS 9 and below, the direct channel data message
+/// is handled by the UIApplicationDelegate's -application:didReceiveRemoteNotification: method.
+/// You can enable all direct channel data messages to be delivered in FIRMessagingDelegate
+/// by setting the flag `useMessagingDelegateForDirectMessages` to true.
 - (void)messaging:(FIRMessaging *)messaging
     didReceiveMessage:(FIRMessagingRemoteMessage *)remoteMessage
     NS_SWIFT_NAME(messaging(_:didReceive:))
@@ -277,14 +279,14 @@ NS_SWIFT_NAME(MessagingDelegate)
  *  registration token from FIRInstanceID. This token authorizes an
  *  app server to send messages to an app instance.
  *
- *  In order to receive FIRMessaging messages, declare `application:didReceiveRemoteNotification:`.
+ *  In order to receive FIRMessaging messages, declare
+ *  `application:didReceiveRemoteNotification::fetchCompletionHandler:`.
  */
 NS_SWIFT_NAME(Messaging)
 @interface FIRMessaging : NSObject
 
 /**
- * Delegate to handle FCM token refreshes, and remote data messages received via FCM for devices
- * running iOS 10 or above.
+ * Delegate to handle FCM token refreshes, and remote data messages received via FCM direct channel.
  */
 @property(nonatomic, weak, nullable) id<FIRMessagingDelegate> delegate;
 
@@ -300,6 +302,22 @@ NS_SWIFT_NAME(Messaging)
  *  Returns `YES` if the direct channel to the FCM server is active, and `NO` otherwise.
  */
 @property(nonatomic, readonly) BOOL isDirectChannelEstablished;
+
+/*
+ * Whether direct channel message should only use FIRMessagingDelegate messaging(_:didReceive:)
+ * for message delivery callback. The default value is false. If you need to change
+ * the default, set FirebaseMessagingUseMessagingDelegateForDirectChannel to true in
+ * your application’s Info.plist.
+ *
+ * If false, the message via direct channel for iOS 9 and below is still delivered in
+ * `-UIApplicationDelegate application(_:didReceiveRemoteNotification:fetchCompletionHandler:)`,
+ * and the FIRMessagingRemoteMessage object and its associated data will be unavailable.
+ * For iOS 10 and above, it is still delivered in `FIRMessagingDelegate messaging(_:didReceive:)`.
+ *
+ * If true, the data message sent by direct channel will be delivered via
+ * `FIRMessagingDelegate messaging(_:didReceive:)` and across all iOS versions.
+ */
+@property(nonatomic, assign) BOOL useMessagingDelegateForDirectChannel;
 
 /**
  *  FIRMessaging
@@ -413,7 +431,7 @@ NS_SWIFT_NAME(Messaging)
     NS_SWIFT_NAME(deleteFCMToken(forSenderID:completion:));
 
 
-#pragma mark - Connect
+#pragma mark - FCM Direct Channel 
 
 /**
  *  Create a FIRMessaging data connection which will be used to send the data notifications

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -39,5 +39,6 @@ device, and it is completely free.
   s.dependency 'FirebaseCore', '~> 5.0'
   s.dependency 'FirebaseInstanceID', '~> 3.0'
   s.dependency 'GoogleUtilities/Reachability', '~> 5.2'
+  s.dependency 'GoogleUtilities/Environment', '~> 5.2'
   s.dependency 'Protobuf', '~> 3.1'
 end


### PR DESCRIPTION
Add a new boolean value that control whether to use direct channel callback for all iOS versions. This partially resolves the issue #1409. 

We are separating the callback between apns and direct channel. Right now for iOS 10 and above, direct channel message delivered at FIRMessagingDelegate, while for iOS 9 and below, they were delivered at UIApplicationDelegate. To not break existing behavior, if user likes to receive direct channel callback using FIRMessagingDelegate instead of UIApplicationDelegate for all ios versions, they can now set the boolean value useMessagingDelegateForDirectChannel to true.