### PR TITLE
Move -Wreorder to cxxflag (instead of common, which impacts cflags)

### DIFF
--- a/cmake/compiler_setup.cmake
+++ b/cmake/compiler_setup.cmake
@@ -37,8 +37,6 @@ if(CXX_CLANG OR CXX_GNU)
     -Wuninitialized
     -fno-common
 
-    -Wreorder -Werror=reorder
-
     # Delete unused things
     -Wunused-function -Wunused-value -Wunused-variable
   )
@@ -49,6 +47,8 @@ if(CXX_CLANG OR CXX_GNU)
     # Cut down on symbol clutter
     # TODO(wilhuff) try -fvisibility=hidden
     -fvisibility-inlines-hidden
+
+    -Wreorder -Werror=reorder
   )
 
   set(


### PR DESCRIPTION
-Wreorder is not a valid cflag on at least linux/gcc.