### PR TITLE
UnlinkFromFacebook and UnlinkFromEmailPassword both accidentally unlink from Google

### DIFF
--- a/Example/Auth/Sample/MainViewController.m
+++ b/Example/Auth/Sample/MainViewController.m
@@ -861,11 +861,11 @@ typedef enum {
         }],
         [StaticContentTableViewCell cellWithTitle:kUnlinkFromFacebook
                                            action:^{
-          [weakSelf unlinkFromProvider:FIRGoogleAuthProviderID completion:nil];
+          [weakSelf unlinkFromProvider:FIRFacebookAuthProviderID completion:nil];
         }],
         [StaticContentTableViewCell cellWithTitle:kUnlinkFromEmailPassword
                                            action:^{
-          [weakSelf unlinkFromProvider:FIRGoogleAuthProviderID completion:nil];
+          [weakSelf unlinkFromProvider:FIREmailAuthProviderID completion:nil];
         }]
       ]],
       [StaticContentTableViewSection sectionWithTitle:kSectionTitleApp cells:@[


### PR DESCRIPTION
UnlinkFromFacebook and UnlinkFromEmailPassword both accidentally unlink from Google