### PR TITLE
Implement byteSize methods on lru delegates for use in GC threshold

### DIFF
--- a/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
@@ -645,7 +645,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   [self newTestResources];
 
-  size_t initialSize = [_gc onDiskSize];
+  size_t initialSize = [_gc byteSize];
 
   _persistence.run("fill cache", [&]() {
     // Simulate a bunch of ack'd mutations
@@ -655,7 +655,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
   });
 
-  size_t finalSize = [_gc onDiskSize];
+  size_t finalSize = [_gc byteSize];
   XCTAssertGreaterThan(finalSize, initialSize);
 
   [_persistence shutdown];

--- a/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
@@ -639,6 +639,28 @@ NS_ASSUME_NONNULL_BEGIN
   });
   [_persistence shutdown];
 }
+
+- (void)testGetsSize {
+  if ([self isTestBaseClass]) return;
+
+  [self newTestResources];
+
+  size_t initialSize = [_gc onDiskSize];
+
+  _persistence.run("fill cache", [&]() {
+    // Simulate a bunch of ack'd mutations
+    for (int i = 0; i < 50; i++) {
+      FSTDocument *doc = [self cacheADocumentInTransaction];
+      [self markDocumentEligibleForGCInTransaction:doc.key];
+    }
+  });
+
+  size_t finalSize = [_gc onDiskSize];
+  XCTAssertGreaterThan(finalSize, initialSize);
+
+  [_persistence shutdown];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Firestore/Source/Local/FSTLRUGarbageCollector.h
+++ b/Firestore/Source/Local/FSTLRUGarbageCollector.h
@@ -105,6 +105,6 @@ extern const firebase::firestore::model::ListenSequenceNumber kFSTListenSequence
 - (int)removeOrphanedDocumentsThroughSequenceNumber:
     (firebase::firestore::model::ListenSequenceNumber)sequenceNumber;
 
-- (size_t)onDiskSize;
+- (size_t)byteSize;
 
 @end

--- a/Firestore/Source/Local/FSTLRUGarbageCollector.h
+++ b/Firestore/Source/Local/FSTLRUGarbageCollector.h
@@ -61,6 +61,8 @@ extern const firebase::firestore::model::ListenSequenceNumber kFSTListenSequence
            (firebase::firestore::model::ListenSequenceNumber)sequenceNumber
                               liveQueries:(NSDictionary<NSNumber *, FSTQueryData *> *)liveQueries;
 
+- (size_t)byteSize;
+
 /** Access to the underlying LRU Garbage collector instance. */
 @property(strong, nonatomic, readonly) FSTLRUGarbageCollector *gc;
 
@@ -102,5 +104,7 @@ extern const firebase::firestore::model::ListenSequenceNumber kFSTListenSequence
  */
 - (int)removeOrphanedDocumentsThroughSequenceNumber:
     (firebase::firestore::model::ListenSequenceNumber)sequenceNumber;
+
+- (size_t)onDiskSize;
 
 @end

--- a/Firestore/Source/Local/FSTLRUGarbageCollector.mm
+++ b/Firestore/Source/Local/FSTLRUGarbageCollector.mm
@@ -119,4 +119,8 @@ class RollingSequenceNumberBuffer {
   return [_delegate removeOrphanedDocumentsThroughSequenceNumber:sequenceNumber];
 }
 
+- (size_t)onDiskSize {
+  return [_delegate byteSize];
+}
+
 @end

--- a/Firestore/Source/Local/FSTLRUGarbageCollector.mm
+++ b/Firestore/Source/Local/FSTLRUGarbageCollector.mm
@@ -119,7 +119,7 @@ class RollingSequenceNumberBuffer {
   return [_delegate removeOrphanedDocumentsThroughSequenceNumber:sequenceNumber];
 }
 
-- (size_t)onDiskSize {
+- (size_t)byteSize {
   return [_delegate byteSize];
 }
 

--- a/Firestore/Source/Local/FSTLevelDB.mm
+++ b/Firestore/Source/Local/FSTLevelDB.mm
@@ -16,8 +16,6 @@
 
 #import "Firestore/Source/Local/FSTLevelDB.h"
 
-#include <dirent.h>
-#include <sys/stat.h>
 #include <memory>
 #include <utility>
 
@@ -299,7 +297,7 @@ static const char *kReservedPathComponent = "firestore";
 }
 
 - (size_t)byteSize {
-  size_t count = 0;
+  off_t count = 0;
   auto iter = util::DirectoryIterator::Create(_directory);
   for (; iter->Valid(); iter->Next()) {
     off_t fileSize = util::FileSize(iter->file()).ValueOrDie();
@@ -307,6 +305,7 @@ static const char *kReservedPathComponent = "firestore";
   }
   HARD_ASSERT(iter->status().ok(), "Failed to iterate leveldb directory: %s",
               iter->status().error_message().c_str());
+  HARD_ASSERT(count <= SIZE_MAX, "Overflowed counting bytes cached");
   return count;
 }
 

--- a/Firestore/Source/Local/FSTMemoryMutationQueue.h
+++ b/Firestore/Source/Local/FSTMemoryMutationQueue.h
@@ -16,11 +16,12 @@
 
 #import <Foundation/Foundation.h>
 
-#import "Firestore/Source/Local/FSTLocalSerializer.h"
 #import "Firestore/Source/Local/FSTMemoryPersistence.h"
 #import "Firestore/Source/Local/FSTMutationQueue.h"
 
 NS_ASSUME_NONNULL_BEGIN
+
+@class FSTLocalSerializer;
 
 @interface FSTMemoryMutationQueue : NSObject <FSTMutationQueue>
 

--- a/Firestore/Source/Local/FSTMemoryMutationQueue.h
+++ b/Firestore/Source/Local/FSTMemoryMutationQueue.h
@@ -16,6 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import "Firestore/Source/Local/FSTLocalSerializer.h"
 #import "Firestore/Source/Local/FSTMemoryPersistence.h"
 #import "Firestore/Source/Local/FSTMutationQueue.h"
 
@@ -31,6 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
  * Checks to see if there are any references to a document with the given key.
  */
 - (BOOL)containsKey:(const firebase::firestore::model::DocumentKey &)key;
+
+- (size_t)byteSizeWithSerializer:(FSTLocalSerializer *)serializer;
 
 @end
 

--- a/Firestore/Source/Local/FSTMemoryMutationQueue.mm
+++ b/Firestore/Source/Local/FSTMemoryMutationQueue.mm
@@ -16,9 +16,10 @@
 
 #import "Firestore/Source/Local/FSTMemoryMutationQueue.h"
 
+#import <Protobuf/GPBProtocolBuffers.h>
+
 #include <set>
 
-#import <Protobuf/GPBProtocolBuffers.h>
 #import "Firestore/Protos/objc/firestore/local/Mutation.pbobjc.h"
 #import "Firestore/Source/Core/FSTQuery.h"
 #import "Firestore/Source/Local/FSTDocumentReference.h"

--- a/Firestore/Source/Local/FSTMemoryMutationQueue.mm
+++ b/Firestore/Source/Local/FSTMemoryMutationQueue.mm
@@ -18,6 +18,8 @@
 
 #include <set>
 
+#import <Protobuf/GPBProtocolBuffers.h>
+#import "Firestore/Protos/objc/firestore/local/Mutation.pbobjc.h"
 #import "Firestore/Source/Core/FSTQuery.h"
 #import "Firestore/Source/Local/FSTDocumentReference.h"
 #import "Firestore/Source/Local/FSTMemoryPersistence.h"
@@ -464,6 +466,14 @@ static const NSComparator NumberComparator = ^NSComparisonResult(NSNumber *left,
   NSInteger index = [self indexOfBatchID:batchID];
   HARD_ASSERT(index >= 0 && index < self.queue.count, "Batches must exist to be %s", action);
   return (NSUInteger)index;
+}
+
+- (size_t)byteSizeWithSerializer:(FSTLocalSerializer *)serializer {
+  __block size_t count = 0;
+  [self.queue enumerateObjectsUsingBlock:^(FSTMutationBatch *batch, NSUInteger idx, BOOL *stop) {
+    count += [[[serializer encodedMutationBatch:batch] data] length];
+  }];
+  return count;
 }
 
 @end

--- a/Firestore/Source/Local/FSTMemoryMutationQueue.mm
+++ b/Firestore/Source/Local/FSTMemoryMutationQueue.mm
@@ -470,10 +470,10 @@ static const NSComparator NumberComparator = ^NSComparisonResult(NSNumber *left,
 }
 
 - (size_t)byteSizeWithSerializer:(FSTLocalSerializer *)serializer {
-  __block size_t count = 0;
-  [self.queue enumerateObjectsUsingBlock:^(FSTMutationBatch *batch, NSUInteger idx, BOOL *stop) {
+  size_t count = 0;
+  for (FSTMutationBatch *batch in self.queue) {
     count += [[[serializer encodedMutationBatch:batch] data] length];
-  }];
+  };
   return count;
 }
 

--- a/Firestore/Source/Local/FSTMemoryPersistence.h
+++ b/Firestore/Source/Local/FSTMemoryPersistence.h
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 
 #import "Firestore/Source/Local/FSTLRUGarbageCollector.h"
+#import "Firestore/Source/Local/FSTLocalSerializer.h"
 #import "Firestore/Source/Local/FSTPersistence.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/types.h"
@@ -31,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)persistenceWithEagerGC;
 
-+ (instancetype)persistenceWithLRUGC;
++ (instancetype)persistenceWithLRUGCAndSerializer:(FSTLocalSerializer *)serializer;
 
 @end
 
@@ -50,7 +51,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FSTMemoryLRUReferenceDelegate
     : NSObject <FSTReferenceDelegate, FSTLRUDelegate, FSTTransactional>
 
-- (instancetype)initWithPersistence:(FSTMemoryPersistence *)persistence;
+- (instancetype)initWithPersistence:(FSTMemoryPersistence *)persistence
+                         serializer:(FSTLocalSerializer *)serializer;
 
 - (BOOL)isPinnedAtSequenceNumber:(firebase::firestore::model::ListenSequenceNumber)upperBound
                         document:(const firebase::firestore::model::DocumentKey &)key;

--- a/Firestore/Source/Local/FSTMemoryQueryCache.h
+++ b/Firestore/Source/Local/FSTMemoryQueryCache.h
@@ -16,6 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import "Firestore/Source/Local/FSTLocalSerializer.h"
 #import "Firestore/Source/Local/FSTQueryCache.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -31,6 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithPersistence:(FSTMemoryPersistence *)persistence NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
+
+- (size_t)byteSizeWithSerializer:(FSTLocalSerializer *)serializer;
 
 @end
 

--- a/Firestore/Source/Local/FSTMemoryQueryCache.h
+++ b/Firestore/Source/Local/FSTMemoryQueryCache.h
@@ -16,11 +16,11 @@
 
 #import <Foundation/Foundation.h>
 
-#import "Firestore/Source/Local/FSTLocalSerializer.h"
 #import "Firestore/Source/Local/FSTQueryCache.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class FSTLocalSerializer;
 @class FSTMemoryPersistence;
 
 /**

--- a/Firestore/Source/Local/FSTMemoryQueryCache.mm
+++ b/Firestore/Source/Local/FSTMemoryQueryCache.mm
@@ -18,6 +18,8 @@
 
 #include <utility>
 
+#import <Protobuf/GPBProtocolBuffers.h>
+#import "Firestore/Protos/objc/firestore/local/Target.pbobjc.h"
 #import "Firestore/Source/Core/FSTQuery.h"
 #import "Firestore/Source/Local/FSTMemoryPersistence.h"
 #import "Firestore/Source/Local/FSTQueryData.h"
@@ -166,6 +168,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)containsKey:(const firebase::firestore::model::DocumentKey &)key {
   return [self.references containsKey:key];
+}
+
+- (size_t)byteSizeWithSerializer:(FSTLocalSerializer *)serializer {
+  __block size_t count = 0;
+  [self.queries
+      enumerateKeysAndObjectsUsingBlock:^(FSTQuery *key, FSTQueryData *queryData, BOOL *stop) {
+        count += [[[serializer encodedQueryData:queryData] data] length];
+      }];
+  return count;
 }
 
 @end

--- a/Firestore/Source/Local/FSTMemoryQueryCache.mm
+++ b/Firestore/Source/Local/FSTMemoryQueryCache.mm
@@ -16,9 +16,10 @@
 
 #import "Firestore/Source/Local/FSTMemoryQueryCache.h"
 
+#import <Protobuf/GPBProtocolBuffers.h>
+
 #include <utility>
 
-#import <Protobuf/GPBProtocolBuffers.h>
 #import "Firestore/Protos/objc/firestore/local/Target.pbobjc.h"
 #import "Firestore/Source/Core/FSTQuery.h"
 #import "Firestore/Source/Local/FSTMemoryPersistence.h"

--- a/Firestore/Source/Local/FSTMemoryRemoteDocumentCache.h
+++ b/Firestore/Source/Local/FSTMemoryRemoteDocumentCache.h
@@ -16,13 +16,13 @@
 
 #import <Foundation/Foundation.h>
 
-#import "Firestore/Source/Local/FSTLocalSerializer.h"
 #import "Firestore/Source/Local/FSTRemoteDocumentCache.h"
 
 #include "Firestore/core/src/firebase/firestore/model/types.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class FSTLocalSerializer;
 @class FSTMemoryLRUReferenceDelegate;
 
 @interface FSTMemoryRemoteDocumentCache : NSObject <FSTRemoteDocumentCache>

--- a/Firestore/Source/Local/FSTMemoryRemoteDocumentCache.h
+++ b/Firestore/Source/Local/FSTMemoryRemoteDocumentCache.h
@@ -16,6 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
+#import "Firestore/Source/Local/FSTLocalSerializer.h"
 #import "Firestore/Source/Local/FSTRemoteDocumentCache.h"
 
 #include "Firestore/core/src/firebase/firestore/model/types.h"
@@ -30,6 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (int)removeOrphanedDocuments:(FSTMemoryLRUReferenceDelegate *)referenceDelegate
          throughSequenceNumber:(firebase::firestore::model::ListenSequenceNumber)upperBound;
+
+- (size_t)byteSizeWithSerializer:(FSTLocalSerializer *)serializer;
 
 @end
 

--- a/Firestore/Source/Local/FSTMemoryRemoteDocumentCache.mm
+++ b/Firestore/Source/Local/FSTMemoryRemoteDocumentCache.mm
@@ -16,6 +16,8 @@
 
 #import "Firestore/Source/Local/FSTMemoryRemoteDocumentCache.h"
 
+#import <Protobuf/GPBProtocolBuffers.h>
+#import "Firestore/Protos/objc/firestore/local/MaybeDocument.pbobjc.h"
 #import "Firestore/Source/Core/FSTQuery.h"
 #import "Firestore/Source/Local/FSTMemoryPersistence.h"
 #import "Firestore/Source/Model/FSTDocument.h"
@@ -27,6 +29,17 @@ using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::ListenSequenceNumber;
 
 NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Returns the number of bytes in the given document key.
+ */
+static size_t FSTDocumentKeyByteSize(FSTDocumentKey *key) {
+  size_t count = 0;
+  for (auto it = key.path.begin(); it != key.path.end(); it++) {
+    count += (*it).size();
+  }
+  return count;
+}
 
 @interface FSTMemoryRemoteDocumentCache ()
 
@@ -92,6 +105,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
   }
   self.docs = updatedDocs;
+  return count;
+}
+
+- (size_t)byteSizeWithSerializer:(FSTLocalSerializer *)serializer {
+  __block size_t count = 0;
+  [self.docs
+      enumerateKeysAndObjectsUsingBlock:^(FSTDocumentKey *key, FSTMaybeDocument *doc, BOOL *stop) {
+        count += FSTDocumentKeyByteSize(key);
+        count += [[[serializer encodedMaybeDocument:doc] data] length];
+      }];
   return count;
 }
 

--- a/Firestore/Source/Local/FSTMemoryRemoteDocumentCache.mm
+++ b/Firestore/Source/Local/FSTMemoryRemoteDocumentCache.mm
@@ -31,7 +31,9 @@ using firebase::firestore::model::ListenSequenceNumber;
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * Returns the number of bytes in the given document key.
+ * Returns an estimate of the number of bytes used to store the given
+ * document key in memory. This is only an estimate and includes the size
+ * of the segments of the path, but not any object overhead or path separators.
  */
 static size_t FSTDocumentKeyByteSize(FSTDocumentKey *key) {
   size_t count = 0;


### PR DESCRIPTION
These methods will be used to determine if we should run LRU collection.