### PR TITLE
Make sure we actually drop the sentinel rows

### DIFF
--- a/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.h
+++ b/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.h
@@ -24,6 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id<FSTPersistence>)newPersistence;
 
+@property(nonatomic, strong) id<FSTPersistence> persistence;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Firestore/Example/Tests/Local/FSTLevelDBLRUGarbageCollectorTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBLRUGarbageCollectorTests.mm
@@ -14,9 +14,17 @@
  * limitations under the License.
  */
 
+#include <string>
+
 #import "Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.h"
+
 #import "Firestore/Example/Tests/Local/FSTPersistenceTestHelpers.h"
 #import "Firestore/Source/Local/FSTLevelDB.h"
+#include "Firestore/core/src/firebase/firestore/local/leveldb_key.h"
+#include "Firestore/core/src/firebase/firestore/model/document_key.h"
+
+using firebase::firestore::local::LevelDbDocumentTargetKey;
+using firebase::firestore::model::DocumentKey;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -27,6 +35,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id<FSTPersistence>)newPersistence {
   return [FSTPersistenceTestHelpers levelDBPersistence];
+}
+
+- (BOOL)sentinelExists:(const DocumentKey &)key {
+  FSTLevelDB *db = (FSTLevelDB *)self.persistence;
+  std::string sentinelKey = LevelDbDocumentTargetKey::SentinelKey(key);
+  std::string unusedValue;
+  return !db.currentTransaction->Get(sentinelKey, &unusedValue).IsNotFound();
 }
 
 @end

--- a/Firestore/Example/Tests/Local/FSTMemoryLRUGarbageCollectorTests.mm
+++ b/Firestore/Example/Tests/Local/FSTMemoryLRUGarbageCollectorTests.mm
@@ -18,6 +18,9 @@
 
 #import "Firestore/Example/Tests/Local/FSTPersistenceTestHelpers.h"
 #import "Firestore/Source/Local/FSTMemoryPersistence.h"
+#include "Firestore/core/src/firebase/firestore/model/document_key.h"
+
+using firebase::firestore::model::DocumentKey;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,6 +31,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id<FSTPersistence>)newPersistence {
   return [FSTPersistenceTestHelpers lruMemoryPersistence];
+}
+
+- (BOOL)sentinelExists:(const DocumentKey &)key {
+  FSTMemoryLRUReferenceDelegate *delegate =
+      (FSTMemoryLRUReferenceDelegate *)self.persistence.referenceDelegate;
+  return [delegate isPinnedAtSequenceNumber:0 document:key];
 }
 
 @end

--- a/Firestore/Source/Local/FSTLevelDB.mm
+++ b/Firestore/Source/Local/FSTLevelDB.mm
@@ -212,10 +212,15 @@ static const char *kReservedPathComponent = "firestore";
       if (![self isPinned:docKey]) {
         count++;
         [self->_db.remoteDocumentCache removeEntryForKey:docKey];
+        [self removeSentinel:docKey];
       }
     }
   }];
   return count;
+}
+
+- (void)removeSentinel:(const DocumentKey &)key {
+  _db.currentTransaction->Delete(LevelDbDocumentTargetKey::SentinelKey(key));
 }
 
 - (int)removeTargetsThroughSequenceNumber:(ListenSequenceNumber)sequenceNumber

--- a/Firestore/Source/Local/FSTMemoryPersistence.mm
+++ b/Firestore/Source/Local/FSTMemoryPersistence.mm
@@ -19,6 +19,7 @@
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #import "Firestore/Source/Core/FSTListenSequence.h"
 #import "Firestore/Source/Local/FSTMemoryMutationQueue.h"
@@ -236,9 +237,14 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (int)removeOrphanedDocumentsThroughSequenceNumber:(ListenSequenceNumber)upperBound {
-  return [(FSTMemoryRemoteDocumentCache *)_persistence.remoteDocumentCache
-      removeOrphanedDocuments:self
-        throughSequenceNumber:upperBound];
+  std::vector<DocumentKey> removed =
+      [(FSTMemoryRemoteDocumentCache *)_persistence.remoteDocumentCache
+          removeOrphanedDocuments:self
+            throughSequenceNumber:upperBound];
+  for (auto it = removed.begin(); it != removed.end(); it++) {
+    _sequenceNumbers.erase(*it);
+  }
+  return removed.size();
 }
 
 - (void)addReference:(const DocumentKey &)key {

--- a/Firestore/Source/Local/FSTMemoryRemoteDocumentCache.h
+++ b/Firestore/Source/Local/FSTMemoryRemoteDocumentCache.h
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+#include <vector>
+
 #import "Firestore/Source/Local/FSTRemoteDocumentCache.h"
 
 #include "Firestore/core/src/firebase/firestore/model/types.h"
@@ -29,8 +31,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 
-- (int)removeOrphanedDocuments:(FSTMemoryLRUReferenceDelegate *)referenceDelegate
-         throughSequenceNumber:(firebase::firestore::model::ListenSequenceNumber)upperBound;
+- (std::vector<firebase::firestore::model::DocumentKey>)
+    removeOrphanedDocuments:(FSTMemoryLRUReferenceDelegate *)referenceDelegate
+      throughSequenceNumber:(firebase::firestore::model::ListenSequenceNumber)upperBound;
 
 - (size_t)byteSizeWithSerializer:(FSTLocalSerializer *)serializer;
 

--- a/Firestore/Source/Local/FSTMemoryRemoteDocumentCache.mm
+++ b/Firestore/Source/Local/FSTMemoryRemoteDocumentCache.mm
@@ -37,8 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 static size_t FSTDocumentKeyByteSize(FSTDocumentKey *key) {
   size_t count = 0;
-  for (auto it = key.path.begin(); it != key.path.end(); it++) {
-    count += (*it).size();
+  for (const auto &segment : key.path) {
+    count += segment.size();
   }
   return count;
 }
@@ -98,7 +98,7 @@ static size_t FSTDocumentKeyByteSize(FSTDocumentKey *key) {
 - (std::vector<DocumentKey>)removeOrphanedDocuments:
                                 (FSTMemoryLRUReferenceDelegate *)referenceDelegate
                               throughSequenceNumber:(ListenSequenceNumber)upperBound {
-  std::vector<DocumentKey> removed{};
+  std::vector<DocumentKey> removed;
   FSTMaybeDocumentDictionary *updatedDocs = self.docs;
   for (FSTDocumentKey *docKey in [self.docs keyEnumerator]) {
     if (![referenceDelegate isPinnedAtSequenceNumber:upperBound document:docKey]) {

--- a/Firestore/Source/Local/FSTMemoryRemoteDocumentCache.mm
+++ b/Firestore/Source/Local/FSTMemoryRemoteDocumentCache.mm
@@ -95,19 +95,19 @@ static size_t FSTDocumentKeyByteSize(FSTDocumentKey *key) {
   return result;
 }
 
-- (int)removeOrphanedDocuments:(FSTMemoryLRUReferenceDelegate *)referenceDelegate
-         throughSequenceNumber:(ListenSequenceNumber)upperBound {
-  int count = 0;
+- (std::vector<DocumentKey>)removeOrphanedDocuments:
+                                (FSTMemoryLRUReferenceDelegate *)referenceDelegate
+                              throughSequenceNumber:(ListenSequenceNumber)upperBound {
+  std::vector<DocumentKey> removed{};
   FSTMaybeDocumentDictionary *updatedDocs = self.docs;
   for (FSTDocumentKey *docKey in [self.docs keyEnumerator]) {
     if (![referenceDelegate isPinnedAtSequenceNumber:upperBound document:docKey]) {
       updatedDocs = [updatedDocs dictionaryByRemovingObjectForKey:docKey];
-      NSLog(@"Removing %@", docKey);
-      count++;
+      removed.push_back(DocumentKey{docKey});
     }
   }
   self.docs = updatedDocs;
-  return count;
+  return removed;
 }
 
 - (size_t)byteSizeWithSerializer:(FSTLocalSerializer *)serializer {


### PR DESCRIPTION
While working on a schema migration to add sentinel rows, I noticed we don't actually drop them, even after removing the associated document. I've fixed that, and updated the test to verify that the sentinel rows for the removed documents are gone.