### PR TITLE
Schema migration to ensure sentinel rows exist

### DIFF
--- a/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
@@ -209,7 +209,7 @@ using SchemaVersion = LevelDbMigrations::SchemaVersion;
   ListenSequenceNumber old_sequence_number = 1;
   ListenSequenceNumber new_sequence_number = 2;
   std::string encoded_old_sequence_number =
-      LevelDbDocumentTargetKey::EncodeSentinel(old_sequence_number);
+      LevelDbDocumentTargetKey::EncodeSentinelValue(old_sequence_number);
   LevelDbMigrations::RunMigrations(_db.get(), 3);
   {
     std::string empty_buffer;
@@ -256,7 +256,7 @@ using SchemaVersion = LevelDbMigrations::SchemaVersion;
       // global
       ListenSequenceNumber expected_sequence_number =
           doc_number % 2 == 1 ? old_sequence_number : new_sequence_number;
-      ListenSequenceNumber sequence_number = LevelDbDocumentTargetKey::DecodeSentinel(buffer);
+      ListenSequenceNumber sequence_number = LevelDbDocumentTargetKey::DecodeSentinelValue(buffer);
       XCTAssertEqual(expected_sequence_number, sequence_number);
     }
     XCTAssertEqual(10, count);

--- a/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
@@ -27,6 +27,8 @@
 
 #include "Firestore/core/src/firebase/firestore/local/leveldb_key.h"
 #include "Firestore/core/src/firebase/firestore/local/leveldb_migrations.h"
+#include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
 #include "Firestore/core/src/firebase/firestore/util/ordered_code.h"
 #include "Firestore/core/src/firebase/firestore/util/status.h"
 #include "Firestore/core/test/firebase/firestore/testutil/testutil.h"
@@ -43,10 +45,14 @@ using firebase::firestore::local::LevelDbMigrations;
 using firebase::firestore::local::LevelDbMutationKey;
 using firebase::firestore::local::LevelDbMutationQueueKey;
 using firebase::firestore::local::LevelDbQueryTargetKey;
+using firebase::firestore::local::LevelDbRemoteDocumentKey;
 using firebase::firestore::local::LevelDbTargetDocumentKey;
+using firebase::firestore::local::LevelDbTargetGlobalKey;
 using firebase::firestore::local::LevelDbTargetKey;
 using firebase::firestore::local::LevelDbTransaction;
 using firebase::firestore::model::BatchId;
+using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::ListenSequenceNumber;
 using firebase::firestore::model::TargetId;
 using firebase::firestore::testutil::Key;
 using firebase::firestore::util::OrderedCode;
@@ -196,6 +202,64 @@ using SchemaVersion = LevelDbMigrations::SchemaVersion;
     }
 
     XCTAssertEqual(found_keys, std::vector<std::string>{});
+  }
+}
+
+- (void)testAddsSentinelRows {
+  ListenSequenceNumber old_sequence_number = 1;
+  ListenSequenceNumber new_sequence_number = 2;
+  std::string encoded_old_sequence_number =
+      LevelDbDocumentTargetKey::EncodeSentinel(old_sequence_number);
+  LevelDbMigrations::RunMigrations(_db.get(), 3);
+  {
+    std::string empty_buffer;
+    LevelDbTransaction transaction(_db.get(), "Setup");
+
+    // Set up target global
+    FSTPBTargetGlobal *metadata = [FSTLevelDBQueryCache readTargetMetadataFromDB:_db.get()];
+    // Expect that documents missing a row will get the new number
+    metadata.highestListenSequenceNumber = new_sequence_number;
+    transaction.Put(LevelDbTargetGlobalKey::Key(), metadata);
+
+    // Set up some documents (we only need the keys)
+    // For the odd ones, add sentinel rows.
+    for (int i = 0; i < 10; i++) {
+      DocumentKey key = DocumentKey::FromSegments({"docs", std::to_string(i)});
+      transaction.Put(LevelDbRemoteDocumentKey::Key(key), empty_buffer);
+      if (i % 2 == 1) {
+        std::string sentinel_key = LevelDbDocumentTargetKey::SentinelKey(key);
+        transaction.Put(sentinel_key, encoded_old_sequence_number);
+      }
+    }
+
+    transaction.Commit();
+  }
+
+  LevelDbMigrations::RunMigrations(_db.get(), 4);
+  {
+    LevelDbTransaction transaction(_db.get(), "Verify");
+    auto it = transaction.NewIterator();
+    std::string documents_prefix = LevelDbRemoteDocumentKey::KeyPrefix();
+    it->Seek(documents_prefix);
+    int count = 0;
+    LevelDbRemoteDocumentKey document_key;
+    std::string buffer;
+    for (; it->Valid() && absl::StartsWith(it->key(), documents_prefix); it->Next()) {
+      count++;
+      XCTAssertTrue(document_key.Decode(it->key()));
+      const DocumentKey &key = document_key.document_key();
+      std::string sentinel_key = LevelDbDocumentTargetKey::SentinelKey(key);
+      XCTAssertTrue(transaction.Get(sentinel_key, &buffer).ok());
+      int doc_number = atoi(key.path().last_segment().c_str());
+      // If the document number is odd, we expect the original old sequence number that we wrote.
+      // If it's even, we expect that the migration added the new sequence number from the target
+      // global
+      ListenSequenceNumber expected_sequence_number =
+          doc_number % 2 == 1 ? old_sequence_number : new_sequence_number;
+      ListenSequenceNumber sequence_number = LevelDbDocumentTargetKey::DecodeSentinel(buffer);
+      XCTAssertEqual(expected_sequence_number, sequence_number);
+    }
+    XCTAssertEqual(10, count);
   }
 }
 

--- a/Firestore/Source/Local/FSTLevelDB.mm
+++ b/Firestore/Source/Local/FSTLevelDB.mm
@@ -229,9 +229,8 @@ static const char *kReservedPathComponent = "firestore";
 }
 
 - (void)writeSentinelForKey:(const DocumentKey &)key {
-  std::string encodedSequenceNumber;
-  OrderedCode::WriteSignedNumIncreasing(&encodedSequenceNumber, [self currentSequenceNumber]);
   std::string sentinelKey = LevelDbDocumentTargetKey::SentinelKey(key);
+  std::string encodedSequenceNumber = LevelDbDocumentTargetKey::EncodeSentinel([self currentSequenceNumber]);
   _db.currentTransaction->Put(sentinelKey, encodedSequenceNumber);
 }
 

--- a/Firestore/Source/Local/FSTLevelDB.mm
+++ b/Firestore/Source/Local/FSTLevelDB.mm
@@ -230,7 +230,8 @@ static const char *kReservedPathComponent = "firestore";
 
 - (void)writeSentinelForKey:(const DocumentKey &)key {
   std::string sentinelKey = LevelDbDocumentTargetKey::SentinelKey(key);
-  std::string encodedSequenceNumber = LevelDbDocumentTargetKey::EncodeSentinel([self currentSequenceNumber]);
+  std::string encodedSequenceNumber =
+      LevelDbDocumentTargetKey::EncodeSentinel([self currentSequenceNumber]);
   _db.currentTransaction->Put(sentinelKey, encodedSequenceNumber);
 }
 

--- a/Firestore/Source/Local/FSTLevelDB.mm
+++ b/Firestore/Source/Local/FSTLevelDB.mm
@@ -236,7 +236,7 @@ static const char *kReservedPathComponent = "firestore";
 - (void)writeSentinelForKey:(const DocumentKey &)key {
   std::string sentinelKey = LevelDbDocumentTargetKey::SentinelKey(key);
   std::string encodedSequenceNumber =
-      LevelDbDocumentTargetKey::EncodeSentinel([self currentSequenceNumber]);
+      LevelDbDocumentTargetKey::EncodeSentinelValue([self currentSequenceNumber]);
   _db.currentTransaction->Put(sentinelKey, encodedSequenceNumber);
 }
 

--- a/Firestore/Source/Local/FSTLevelDBQueryCache.mm
+++ b/Firestore/Source/Local/FSTLevelDBQueryCache.mm
@@ -30,7 +30,6 @@
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
-#include "Firestore/core/src/firebase/firestore/util/ordered_code.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 #include "absl/strings/match.h"
 
@@ -49,22 +48,9 @@ using firebase::firestore::model::ListenSequenceNumber;
 using firebase::firestore::model::SnapshotVersion;
 using firebase::firestore::model::TargetId;
 using firebase::firestore::util::MakeString;
-using firebase::firestore::util::OrderedCode;
 using leveldb::DB;
 using leveldb::Slice;
 using leveldb::Status;
-
-namespace {
-
-ListenSequenceNumber ReadSequenceNumber(const absl::string_view &slice) {
-  ListenSequenceNumber decoded;
-  absl::string_view tmp(slice.data(), slice.size());
-  if (!OrderedCode::ReadSignedNumIncreasing(&tmp, &decoded)) {
-    HARD_FAIL("Failed to read sequence number from a sentinel row");
-  }
-  return decoded;
-}
-}  // namespace
 
 @interface FSTLevelDBQueryCache ()
 
@@ -202,7 +188,7 @@ ListenSequenceNumber ReadSequenceNumber(const absl::string_view &slice) {
       }
       // set nextToReport to be this sequence number. It's the next one we might
       // report, if we don't find any targets for this document.
-      nextToReport = ReadSequenceNumber(it->value());
+      nextToReport = LevelDbDocumentTargetKey::DecodeSentinel(it->value());
       keyToReport = key.document_key();
     } else {
       // set nextToReport to be 0, we know we don't need to report this one since

--- a/Firestore/core/src/firebase/firestore/local/leveldb_key.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_key.cc
@@ -793,18 +793,17 @@ std::string LevelDbDocumentTargetKey::SentinelKey(
   return Key(document_key, kInvalidTargetId);
 }
 
-std::string LevelDbDocumentTargetKey::EncodeSentinel(
+std::string LevelDbDocumentTargetKey::EncodeSentinelValue(
     model::ListenSequenceNumber sequence_number) {
   std::string encoded;
   OrderedCode::WriteSignedNumIncreasing(&encoded, sequence_number);
   return encoded;
 }
 
-model::ListenSequenceNumber LevelDbDocumentTargetKey::DecodeSentinel(
-    const absl::string_view& slice) {
+model::ListenSequenceNumber LevelDbDocumentTargetKey::DecodeSentinelValue(
+    absl::string_view slice) {
   model::ListenSequenceNumber decoded;
-  absl::string_view tmp(slice.data(), slice.size());
-  if (!OrderedCode::ReadSignedNumIncreasing(&tmp, &decoded)) {
+  if (!OrderedCode::ReadSignedNumIncreasing(&slice, &decoded)) {
     HARD_FAIL("Failed to read sequence number from a sentinel row");
   }
   return decoded;

--- a/Firestore/core/src/firebase/firestore/local/leveldb_key.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_key.cc
@@ -793,6 +793,12 @@ std::string LevelDbDocumentTargetKey::SentinelKey(
   return Key(document_key, kInvalidTargetId);
 }
 
+std::string LevelDbDocumentTargetKey::EncodeSentinel(model::ListenSequenceNumber sequence_number) {
+  std::string encoded;
+  OrderedCode::WriteSignedNumIncreasing(&encoded, sequence_number);
+  return encoded;
+}
+
 bool LevelDbDocumentTargetKey::Decode(absl::string_view key) {
   Reader reader{key};
   reader.ReadTableNameMatching(kDocumentTargetsTable);

--- a/Firestore/core/src/firebase/firestore/local/leveldb_key.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_key.cc
@@ -793,10 +793,21 @@ std::string LevelDbDocumentTargetKey::SentinelKey(
   return Key(document_key, kInvalidTargetId);
 }
 
-std::string LevelDbDocumentTargetKey::EncodeSentinel(model::ListenSequenceNumber sequence_number) {
+std::string LevelDbDocumentTargetKey::EncodeSentinel(
+    model::ListenSequenceNumber sequence_number) {
   std::string encoded;
   OrderedCode::WriteSignedNumIncreasing(&encoded, sequence_number);
   return encoded;
+}
+
+model::ListenSequenceNumber LevelDbDocumentTargetKey::DecodeSentinel(
+    const absl::string_view& slice) {
+  model::ListenSequenceNumber decoded;
+  absl::string_view tmp(slice.data(), slice.size());
+  if (!OrderedCode::ReadSignedNumIncreasing(&tmp, &decoded)) {
+    HARD_FAIL("Failed to read sequence number from a sentinel row");
+  }
+  return decoded;
 }
 
 bool LevelDbDocumentTargetKey::Decode(absl::string_view key) {

--- a/Firestore/core/src/firebase/firestore/local/leveldb_key.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_key.h
@@ -419,14 +419,14 @@ class LevelDbDocumentTargetKey {
   /**
    * Given a sequence number, encodes it for storage in a sentinel row.
    */
-  static std::string EncodeSentinel(
-      const model::ListenSequenceNumber sequence_number);
+  static std::string EncodeSentinelValue(
+      model::ListenSequenceNumber sequence_number);
 
   /**
    * Given an encoded sentinel row, return the sequence number.
    */
-  static model::ListenSequenceNumber DecodeSentinel(
-      const absl::string_view& slice);
+  static model::ListenSequenceNumber DecodeSentinelValue(
+      absl::string_view slice);
 
   /**
    * Decodes the contents of a document target key, storing the decoded values

--- a/Firestore/core/src/firebase/firestore/local/leveldb_key.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_key.h
@@ -419,7 +419,14 @@ class LevelDbDocumentTargetKey {
   /**
    * Given a sequence number, encodes it for storage in a sentinel row.
    */
-  static std::string EncodeSentinel(const model::ListenSequenceNumber sequence_number);
+  static std::string EncodeSentinel(
+      const model::ListenSequenceNumber sequence_number);
+
+  /**
+   * Given an encoded sentinel row, return the sequence number.
+   */
+  static model::ListenSequenceNumber DecodeSentinel(
+      const absl::string_view& slice);
 
   /**
    * Decodes the contents of a document target key, storing the decoded values

--- a/Firestore/core/src/firebase/firestore/local/leveldb_key.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_key.h
@@ -417,6 +417,11 @@ class LevelDbDocumentTargetKey {
   static std::string SentinelKey(const model::DocumentKey& document_key);
 
   /**
+   * Given a sequence number, encodes it for storage in a sentinel row.
+   */
+  static std::string EncodeSentinel(const model::ListenSequenceNumber sequence_number);
+
+  /**
    * Decodes the contents of a document target key, storing the decoded values
    * in this instance.
    *

--- a/Firestore/core/src/firebase/firestore/local/leveldb_migrations.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_migrations.cc
@@ -155,7 +155,7 @@ void EnsureSentinelRows(leveldb::DB* db) {
   model::ListenSequenceNumber sequence_number =
       GetHighestSequenceNumber(&transaction);
   std::string sentinel_value =
-      LevelDbDocumentTargetKey::EncodeSentinel(sequence_number);
+      LevelDbDocumentTargetKey::EncodeSentinelValue(sequence_number);
 
   std::string documents_prefix = LevelDbRemoteDocumentKey::KeyPrefix();
   auto it = transaction.NewIterator();

--- a/Firestore/core/src/firebase/firestore/nanopb/reader.cc
+++ b/Firestore/core/src/firebase/firestore/nanopb/reader.cc
@@ -30,6 +30,12 @@ Reader Reader::Wrap(const uint8_t* bytes, size_t length) {
   return Reader{pb_istream_from_buffer(bytes, length)};
 }
 
+Reader Reader::Wrap(absl::string_view string_view) {
+  return Reader{pb_istream_from_buffer(
+          reinterpret_cast<const uint8_t*>(string_view.data()),
+          string_view.size())};
+}
+
 uint32_t Reader::ReadTag() {
   Tag tag;
   if (!status_.ok()) return 0;

--- a/Firestore/core/src/firebase/firestore/nanopb/reader.cc
+++ b/Firestore/core/src/firebase/firestore/nanopb/reader.cc
@@ -32,8 +32,8 @@ Reader Reader::Wrap(const uint8_t* bytes, size_t length) {
 
 Reader Reader::Wrap(absl::string_view string_view) {
   return Reader{pb_istream_from_buffer(
-          reinterpret_cast<const uint8_t*>(string_view.data()),
-          string_view.size())};
+      reinterpret_cast<const uint8_t*>(string_view.data()),
+      string_view.size())};
 }
 
 uint32_t Reader::ReadTag() {

--- a/Firestore/core/src/firebase/firestore/nanopb/reader.h
+++ b/Firestore/core/src/firebase/firestore/nanopb/reader.h
@@ -60,6 +60,15 @@ class Reader {
   static Reader Wrap(const uint8_t* bytes, size_t length);
 
   /**
+   * Creates an input stream from bytes backing the string_view. Note that
+   * the backing buffer must remain valid for the lifetime of this Reader.
+   *
+   * (This is roughly equivalent to the nanopb function
+   * pb_istream_from_buffer())
+   */
+  static Reader Wrap(absl::string_view);
+
+  /**
    * Reads a message type from the input stream.
    *
    * This essentially wraps calls to nanopb's pb_decode_tag() method.


### PR DESCRIPTION
Ensures that we have a sequence number written down for each document in the remote document cache. We already have the code to sequence numbers for new documents (via target updates, mutations, and limbo resolutions). However, we have never gone back to make sure existing documents have sequence numbers.

This migration will stamp the highest sequence number observed onto each remote document which does not yet have a sentinel row.