### PR TITLE
Allow Precondition::IsValidFor to work with nullptr.

### DIFF
--- a/Firestore/core/src/firebase/firestore/model/precondition.cc
+++ b/Firestore/core/src/firebase/firestore/model/precondition.cc
@@ -45,16 +45,19 @@ Precondition Precondition::None() {
   return Precondition{Type::None, SnapshotVersion::None(), false};
 }
 
-bool Precondition::IsValidFor(const MaybeDocument& maybe_doc) const {
+bool Precondition::IsValidFor(const MaybeDocument* maybe_doc) const {
   switch (type_) {
     case Type::UpdateTime:
-      return maybe_doc.type() == MaybeDocument::Type::Document &&
-             maybe_doc.version() == update_time_;
+      return maybe_doc != nullptr &&
+             maybe_doc->type() == MaybeDocument::Type::Document &&
+             maybe_doc->version() == update_time_;
     case Type::Exists:
       if (exists_) {
-        return maybe_doc.type() == MaybeDocument::Type::Document;
+        return maybe_doc != nullptr &&
+               maybe_doc->type() == MaybeDocument::Type::Document;
       } else {
-        return maybe_doc.type() == MaybeDocument::Type::NoDocument;
+        return maybe_doc == nullptr ||
+               maybe_doc->type() == MaybeDocument::Type::NoDocument;
       }
     case Type::None:
       return true;

--- a/Firestore/core/src/firebase/firestore/model/precondition.h
+++ b/Firestore/core/src/firebase/firestore/model/precondition.h
@@ -58,7 +58,7 @@ class Precondition {
    * Returns true if the precondition is valid for the given document (and the
    * document is available).
    */
-  bool IsValidFor(const MaybeDocument& maybe_doc) const;
+  bool IsValidFor(const MaybeDocument* maybe_doc) const;
 
   /** Returns whether this Precondition represents no precondition. */
   bool IsNone() const {

--- a/Firestore/core/test/firebase/firestore/model/precondition_test.cc
+++ b/Firestore/core/test/firebase/firestore/model/precondition_test.cc
@@ -35,8 +35,9 @@ TEST(Precondition, None) {
 
   const NoDocument deleted_doc = testutil::DeletedDoc("foo/doc", 1234567);
   const Document doc = testutil::Doc("bar/doc", 7654321);
-  EXPECT_TRUE(none.IsValidFor(deleted_doc));
-  EXPECT_TRUE(none.IsValidFor(doc));
+  EXPECT_TRUE(none.IsValidFor(&deleted_doc));
+  EXPECT_TRUE(none.IsValidFor(&doc));
+  EXPECT_TRUE(none.IsValidFor(nullptr));
 }
 
 TEST(Precondition, Exists) {
@@ -51,10 +52,12 @@ TEST(Precondition, Exists) {
 
   const NoDocument deleted_doc = testutil::DeletedDoc("foo/doc", 1234567);
   const Document doc = testutil::Doc("bar/doc", 7654321);
-  EXPECT_FALSE(exists.IsValidFor(deleted_doc));
-  EXPECT_TRUE(exists.IsValidFor(doc));
-  EXPECT_TRUE(no_exists.IsValidFor(deleted_doc));
-  EXPECT_FALSE(no_exists.IsValidFor(doc));
+  EXPECT_FALSE(exists.IsValidFor(&deleted_doc));
+  EXPECT_TRUE(exists.IsValidFor(&doc));
+  EXPECT_FALSE(exists.IsValidFor(nullptr));
+  EXPECT_TRUE(no_exists.IsValidFor(&deleted_doc));
+  EXPECT_FALSE(no_exists.IsValidFor(&doc));
+  EXPECT_TRUE(no_exists.IsValidFor(nullptr));
 }
 
 TEST(Precondition, UpdateTime) {
@@ -67,9 +70,10 @@ TEST(Precondition, UpdateTime) {
   const NoDocument deleted_doc = testutil::DeletedDoc("foo/doc", 1234567);
   const Document not_match = testutil::Doc("bar/doc", 7654321);
   const Document match = testutil::Doc("baz/doc", 1234567);
-  EXPECT_FALSE(update_time.IsValidFor(deleted_doc));
-  EXPECT_FALSE(update_time.IsValidFor(not_match));
-  EXPECT_TRUE(update_time.IsValidFor(match));
+  EXPECT_FALSE(update_time.IsValidFor(&deleted_doc));
+  EXPECT_FALSE(update_time.IsValidFor(&not_match));
+  EXPECT_TRUE(update_time.IsValidFor(&match));
+  EXPECT_FALSE(update_time.IsValidFor(nullptr));
 }
 
 }  // namespace model


### PR DESCRIPTION
Required by the Mutation objects.