### PR TITLE
Add a lint check for const references to absl::string_view

### DIFF
--- a/Firestore/Example/Tests/Local/FSTLevelDBTransactionTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBTransactionTests.mm
@@ -225,7 +225,7 @@ using leveldb::WriteOptions;
   it->Seek("key_0");
   for (int i = 0; i < 4; ++i) {
     XCTAssertTrue(it->Valid());
-    const absl::string_view &key = it->key();
+    absl::string_view key = it->key();
     std::string expected = "key_" + std::to_string(i);
     XCTAssertEqual(expected, key);
     transaction.Delete(key);

--- a/Firestore/Source/Local/FSTLevelDBQueryCache.mm
+++ b/Firestore/Source/Local/FSTLevelDBQueryCache.mm
@@ -56,10 +56,9 @@ using leveldb::Status;
 
 namespace {
 
-ListenSequenceNumber ReadSequenceNumber(const absl::string_view &slice) {
+ListenSequenceNumber ReadSequenceNumber(absl::string_view slice) {
   ListenSequenceNumber decoded;
-  absl::string_view tmp(slice.data(), slice.size());
-  if (!OrderedCode::ReadSignedNumIncreasing(&tmp, &decoded)) {
+  if (!OrderedCode::ReadSignedNumIncreasing(&slice, &decoded)) {
     HARD_FAIL("Failed to read sequence number from a sentinel row");
   }
   return decoded;

--- a/Firestore/core/src/firebase/firestore/util/comparison.cc
+++ b/Firestore/core/src/firebase/firestore/util/comparison.cc
@@ -26,7 +26,7 @@ namespace firestore {
 namespace util {
 
 bool Comparator<absl::string_view>::operator()(
-    const absl::string_view& left, const absl::string_view& right) const {
+    absl::string_view left, absl::string_view right) const {
   // TODO(wilhuff): truncation aware comparison
   return left < right;
 }

--- a/Firestore/core/src/firebase/firestore/util/comparison.cc
+++ b/Firestore/core/src/firebase/firestore/util/comparison.cc
@@ -25,8 +25,8 @@ namespace firebase {
 namespace firestore {
 namespace util {
 
-bool Comparator<absl::string_view>::operator()(
-    absl::string_view left, absl::string_view right) const {
+bool Comparator<absl::string_view>::operator()(absl::string_view left,
+                                               absl::string_view right) const {
   // TODO(wilhuff): truncation aware comparison
   return left < right;
 }

--- a/Firestore/core/src/firebase/firestore/util/comparison.h
+++ b/Firestore/core/src/firebase/firestore/util/comparison.h
@@ -82,8 +82,8 @@ struct Comparator {
 /** Compares two strings. */
 template <>
 struct Comparator<absl::string_view> {
-  bool operator()(const absl::string_view& left,
-                  const absl::string_view& right) const;
+  bool operator()(absl::string_view left,
+                  absl::string_view right) const;
 };
 
 template <>

--- a/Firestore/core/src/firebase/firestore/util/comparison.h
+++ b/Firestore/core/src/firebase/firestore/util/comparison.h
@@ -82,8 +82,7 @@ struct Comparator {
 /** Compares two strings. */
 template <>
 struct Comparator<absl::string_view> {
-  bool operator()(absl::string_view left,
-                  absl::string_view right) const;
+  bool operator()(absl::string_view left, absl::string_view right) const;
 };
 
 template <>

--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -5025,6 +5025,14 @@ def IsInitializerList(clean_lines, linenum):
   return False
 
 
+def CheckForStringViewReferences(filename, clean_lines, linenum, error):
+  line = clean_lines.elided[linenum]
+  match = Search(r'const absl::string_view(?:\s*&)', line)
+  if match:
+    error(filename, linenum, 'runtime/references', 5,
+          'Avoid const references to absl::string_view; just pass by value.')
+
+
 def CheckForNonConstReference(filename, clean_lines, linenum,
                               nesting_state, error):
   """Check for non-const references.
@@ -5824,6 +5832,7 @@ def ProcessLine(filename, file_extension, clean_lines, line,
   CheckStyle(filename, clean_lines, line, file_extension, nesting_state, error)
   CheckLanguage(filename, clean_lines, line, file_extension, include_state,
                 nesting_state, error)
+  CheckForStringViewReferences(filename, clean_lines, line, error)
   CheckForNonConstReference(filename, clean_lines, line, nesting_state, error)
   CheckForNonStandardConstructs(filename, clean_lines, line,
                                 nesting_state, error)


### PR DESCRIPTION
In the spirit of automating myself out of a job.