### PR TITLE
Implement util::FileSize on Windows

### DIFF
--- a/Firestore/Source/Local/FSTLevelDB.mm
+++ b/Firestore/Source/Local/FSTLevelDB.mm
@@ -302,10 +302,10 @@ static const char *kReservedPathComponent = "firestore";
 }
 
 - (size_t)byteSize {
-  off_t count = 0;
+  int64_t count = 0;
   auto iter = util::DirectoryIterator::Create(_directory);
   for (; iter->Valid(); iter->Next()) {
-    off_t fileSize = util::FileSize(iter->file()).ValueOrDie();
+    int64_t fileSize = util::FileSize(iter->file()).ValueOrDie();
     count += fileSize;
   }
   HARD_ASSERT(iter->status().ok(), "Failed to iterate leveldb directory: %s",

--- a/Firestore/core/src/firebase/firestore/util/filesystem.h
+++ b/Firestore/core/src/firebase/firestore/util/filesystem.h
@@ -77,7 +77,7 @@ Path TempDir();
  * On success, returns the size in bytes of the file specified by
  * `path`.
  */
-StatusOr<off_t> FileSize(const Path& path);
+StatusOr<int64_t> FileSize(const Path& path);
 
 /**
  * Implements an iterator over the contents of a directory. Initializes to the

--- a/Firestore/core/src/firebase/firestore/util/filesystem_posix.cc
+++ b/Firestore/core/src/firebase/firestore/util/filesystem_posix.cc
@@ -95,13 +95,13 @@ Path TempDir() {
 }
 #endif  // !defined(__APPLE__)
 
-StatusOr<off_t> FileSize(const Path& path) {
+StatusOr<int64_t> FileSize(const Path& path) {
   struct stat st {};
   if (stat(path.c_str(), &st) == 0) {
-    return StatusOr<off_t>(st.st_size);
+    return st.st_size;
   } else {
-    return StatusOr<off_t>(Status::FromErrno(
-        errno, StringFormat("Failed to stat file: %s", path.ToUtf8String())));
+    return Status::FromErrno(
+        errno, StringFormat("Failed to stat file: %s", path.ToUtf8String()));
   }
 }
 

--- a/Firestore/core/src/firebase/firestore/util/filesystem_win.cc
+++ b/Firestore/core/src/firebase/firestore/util/filesystem_win.cc
@@ -56,6 +56,19 @@ Path TempDir() {
   return Path::FromUtf16(buffer, count);
 }
 
+StatusOr<int64_t> FileSize(const Path& path) {
+  WIN32_FILE_ATTRIBUTE_DATA attrs;
+  if (!::GetFileAttributesExW(path.c_str(), GetFileExInfoStandard, &attrs)) {
+    DWORD error = ::GetLastError();
+    return Status::FromLastError(error, path.ToUtf8String());
+  }
+
+  LARGE_INTEGER result{};
+  result.HighPart = attrs.nFileSizeHigh;
+  result.LowPart = attrs.nFileSizeLow;
+  return result.QuadPart;
+}
+
 namespace detail {
 
 Status CreateDir(const Path& path) {

--- a/Firestore/core/test/firebase/firestore/util/filesystem_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/filesystem_test.cc
@@ -249,7 +249,7 @@ TEST(FilesystemTest, FileSize) {
   Path file = Path::JoinUtf8(TempDir(), TestFilename());
   ASSERT_NOT_FOUND(FileSize(file).status());
   Touch(file);
-  StatusOr<off_t> result = FileSize(file);
+  StatusOr<int64_t> result = FileSize(file);
   ASSERT_OK(result.status());
   ASSERT_EQ(0, result.ValueOrDie());
 


### PR DESCRIPTION
Also convert FileSize to return size in an int64_t. off_t is
unconditionally defined as a long on Windows, which is 32 bits even
under Win64.