### PR TITLE
fix Firestore C++ g3 build

### DIFF
--- a/Firestore/core/src/firebase/firestore/model/field_path.cc
+++ b/Firestore/core/src/firebase/firestore/model/field_path.cc
@@ -69,7 +69,8 @@ struct JoinEscaped {
       escaped.push_back('`');
     }
     return escaped;
-  };
+  }
+
   template <typename T>
   void operator()(T* out, const std::string& segment) {
     out->append(escaped_segment(segment));

--- a/Firestore/core/src/firebase/firestore/model/field_path.cc
+++ b/Firestore/core/src/firebase/firestore/model/field_path.cc
@@ -59,6 +59,22 @@ bool IsValidIdentifier(const std::string& segment) {
   return true;
 }
 
+/** A custom formatter to be used with absl::StrJoin(). */
+struct JoinEscaped {
+  static std::string escaped_segment(const std::string& segment) {
+    auto escaped = absl::StrReplaceAll(segment, {{"\\", "\\\\"}, {"`", "\\`"}});
+    const bool needs_escaping = !IsValidIdentifier(escaped);
+    if (needs_escaping) {
+      escaped.insert(escaped.begin(), '`');
+      escaped.push_back('`');
+    }
+    return escaped;
+  };
+  template <typename T>
+  void operator()(T* out, const std::string& segment) {
+    out->append(escaped_segment(segment));
+  }
+};
 }  // namespace
 
 FieldPath FieldPath::FromServerFormat(const absl::string_view path) {
@@ -143,20 +159,7 @@ bool FieldPath::IsKeyFieldPath() const {
 }
 
 std::string FieldPath::CanonicalString() const {
-  const auto escaped_segment = [](const std::string& segment) {
-    auto escaped = absl::StrReplaceAll(segment, {{"\\", "\\\\"}, {"`", "\\`"}});
-    const bool needs_escaping = !IsValidIdentifier(escaped);
-    if (needs_escaping) {
-      escaped.insert(escaped.begin(), '`');
-      escaped.push_back('`');
-    }
-    return escaped;
-  };
-  return absl::StrJoin(
-      begin(), end(), ".",
-      [escaped_segment](std::string* out, const std::string& segment) {
-        out->append(escaped_segment(segment));
-      });
+  return absl::StrJoin(begin(), end(), ".", JoinEscaped());
 }
 
 }  // namespace model

--- a/Firestore/core/src/firebase/firestore/util/comparison.cc
+++ b/Firestore/core/src/firebase/firestore/util/comparison.cc
@@ -19,11 +19,10 @@
 #include <cmath>
 #include <limits>
 
-using std::isnan;
-
 namespace firebase {
 namespace firestore {
 namespace util {
+using std::isnan;
 
 bool Comparator<absl::string_view>::operator()(absl::string_view left,
                                                absl::string_view right) const {


### PR DESCRIPTION
Resolve conflict w.r.t. string and isnan().

This is not yet the change to make the FieldPath portable but a first step to make it build. The change w.r.t. STLPort will be in subsequent PRs.