### PR TITLE
Remove need for [FIRApp configure] in Messaging unit tests

### DIFF
--- a/Example/Messaging/App/iOS/FIRAppDelegate.m
+++ b/Example/Messaging/App/iOS/FIRAppDelegate.m
@@ -20,7 +20,6 @@
 
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-  [FIRApp configure];
   return YES;
 }
 

--- a/Example/Messaging/Sample/iOS/Messaging-Info.plist
+++ b/Example/Messaging/Sample/iOS/Messaging-Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>FirebaseMessagingAutoInitEnabled</key>
-	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -24,6 +22,8 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
+	<key>FirebaseMessagingAutoInitEnabled</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIBackgroundModes</key>

--- a/Example/Messaging/Tests/FIRMessagingLinkHandlingTest.m
+++ b/Example/Messaging/Tests/FIRMessagingLinkHandlingTest.m
@@ -18,14 +18,20 @@
 
 #import <OCMock/OCMock.h>
 
-#import <FirebaseCore/FIRApp.h>
+#import <FirebaseAnalyticsInterop/FIRAnalyticsInterop.h>
+#import <FirebaseCore/FIRAppInternal.h>
+#import <FirebaseInstanceID/FirebaseInstanceID.h>
+
 #import "FIRMessaging.h"
 #import "FIRMessagingConstants.h"
 #import "FIRMessagingTestNotificationUtilities.h"
 
 @interface FIRMessaging ()
 
-- (instancetype)initPrivately;
+- (void)start;
+- (instancetype)initWithAnalytics:(nullable id<FIRAnalyticsInterop>)analytics
+                   withInstanceID:(FIRInstanceID *)instanceID
+                 withUserDefaults:(NSUserDefaults *)defaults;
 - (NSURL *)linkURLFromMessage:(NSDictionary *)message;
 
 @end
@@ -40,7 +46,10 @@
 
 - (void)setUp {
   [super setUp];
-  _messaging = [FIRMessaging messaging];
+  _messaging = [[FIRMessaging alloc] initWithAnalytics:nil
+                                        withInstanceID:[FIRInstanceID instanceID]
+                                      withUserDefaults:[NSUserDefaults standardUserDefaults]];
+  [_messaging start];
 }
 
 - (void)tearDown {

--- a/Example/Messaging/Tests/FIRMessagingServiceTest.m
+++ b/Example/Messaging/Tests/FIRMessagingServiceTest.m
@@ -25,7 +25,9 @@
 #import "FIRMessagingTopicsCommon.h"
 #import "InternalHeaders/FIRMessagingInternalUtilities.h"
 #import "NSError+FIRMessaging.h"
+#import <FirebaseAnalyticsInterop/FIRAnalyticsInterop.h>
 #import <FirebaseCore/FIRAppInternal.h>
+#import <FirebaseInstanceID/FirebaseInstanceID.h>
 
 static NSString *const kFakeToken =
     @"fE1e1PZJFSQ:APA91bFAOjp1ahBWn9rTlbjArwBEm_"
@@ -33,7 +35,10 @@ static NSString *const kFakeToken =
     @"QGlCrTbxCFGzEUfvA3fGpGgIVQU2W6";
 
 @interface FIRMessaging () <FIRMessagingClientDelegate>
-
+- (void)start;
+- (instancetype)initWithAnalytics:(nullable id<FIRAnalyticsInterop>)analytics
+                   withInstanceID:(FIRInstanceID *)instanceID
+                 withUserDefaults:(NSUserDefaults *)defaults;
 @property(nonatomic, readwrite, strong) FIRMessagingClient *client;
 @property(nonatomic, readwrite, strong) FIRMessagingPubSub *pubsub;
 @property(nonatomic, readwrite, strong) NSString *defaultFcmToken;
@@ -56,9 +61,13 @@ static NSString *const kFakeToken =
 @implementation FIRMessagingServiceTest
 
 - (void)setUp {
-  _messaging = [FIRMessaging messaging];
+  _messaging = [[FIRMessaging alloc] initWithAnalytics:nil
+                                        withInstanceID:[FIRInstanceID instanceID]
+                                      withUserDefaults:[NSUserDefaults standardUserDefaults]];
+  [_messaging start];
   _messaging.defaultFcmToken = kFakeToken;
   _mockPubSub = OCMPartialMock(_messaging.pubsub);
+  [_mockPubSub setClient:nil];
   [super setUp];
 }
 
@@ -151,7 +160,7 @@ static NSString *const kFakeToken =
                    topic:@"/topics/hello-world"
                  options:nil
                  handler:^(NSError *error) {
-                   XCTAssertNil(error);
+                   XCTAssertNotNil(error);
                    XCTAssertEqual(kFIRMessagingErrorCodePubSubFIRMessagingNotSetup, error.code);
                  }];
 }

--- a/Example/Messaging/Tests/FIRMessagingTest.m
+++ b/Example/Messaging/Tests/FIRMessagingTest.m
@@ -18,6 +18,7 @@
 
 #import <OCMock/OCMock.h>
 
+#import <FirebaseAnalyticsInterop/FIRAnalyticsInterop.h>
 #import <FirebaseCore/FIRAppInternal.h>
 #import <FirebaseInstanceID/FirebaseInstanceID.h>
 
@@ -27,7 +28,10 @@
 extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
 
 @interface FIRMessaging ()
-
+- (void)start;
+- (instancetype)initWithAnalytics:(nullable id<FIRAnalyticsInterop>)analytics
+                   withInstanceID:(FIRInstanceID *)instanceID
+                 withUserDefaults:(NSUserDefaults *)defaults;
 @property(nonatomic, readwrite, strong) NSString *defaultFcmToken;
 @property(nonatomic, readwrite, strong) NSData *apnsTokenData;
 @property(nonatomic, readwrite, strong) FIRInstanceID *instanceID;
@@ -53,7 +57,10 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
 
 - (void)setUp {
   [super setUp];
-  _messaging = [FIRMessaging messaging];
+  _messaging = [[FIRMessaging alloc] initWithAnalytics:nil
+                                        withInstanceID:[FIRInstanceID instanceID]
+                                      withUserDefaults:[NSUserDefaults standardUserDefaults]];
+  [_messaging start];
   _mockFirebaseApp = OCMClassMock([FIRApp class]);
    OCMStub([_mockFirebaseApp defaultApp]).andReturn(_mockFirebaseApp);
   _mockInstanceID = OCMPartialMock(self.messaging.instanceID);


### PR DESCRIPTION
#1902 added an implicit dependency on the host app calling [FIRApp configure]

This PR removes that requirement.
Also fix `testSubscribeWithoutStart` which wasn't being executed properly before and only passing as a side effect of other tests.