### PR TITLE
Bump version to 5.3.2 to rollback leak fixes

### DIFF
--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleUtilities'
-  s.version          = '5.3.1'
+  s.version          = '5.3.2'
   s.summary          = 'Google Utilities for iOS (plus community support for macOS and tvOS)'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Post submit testing found some issues caused by the #1922 in FirebaseAnalytics tests on ios 8.