### PR TITLE
Add Xcode 10 travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: osx
-osx_image: xcode9.4
+osx_image: xcode10
 language: objective-c
 cache:
   - bundler
@@ -33,8 +33,6 @@ jobs:
       env:
         - PROJECT=Firebase PLATFORM=iOS METHOD=xcodebuild
       before_install:
-        - npm install ios-sim -g
-        - ios-sim start --devicetypeid "com.apple.CoreSimulator.SimDeviceType.iPhone-8-Plus, 11.3"
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
         - ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
@@ -115,6 +113,36 @@ jobs:
         - travis_wait ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh FirebaseFirestore.podspec --use-libraries --allow-warnings --no-subspecs
 
     # Alternative platforms
+
+    # Xcode 9
+    - stage: test
+      osx_image: xcode9.4
+      env:
+        - PROJECT=Firebase PLATFORM=iOS METHOD=xcodebuild
+      before_install:
+        - npm install ios-sim -g
+        - ios-sim start --devicetypeid "com.apple.CoreSimulator.SimDeviceType.iPhone-8-Plus, 11.3"
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        - ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
+
+    - stage: test
+      osx_image: xcode9.4
+      env:
+        - PROJECT=InAppMessagingDisplay PLATFORM=iOS METHOD=xcodebuild
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        - ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
+
+    - stage: test
+      osx_image: xcode9.4
+      env:
+        - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        - ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
 
     - stage: test
       env:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -236,7 +236,6 @@ case "$product-$method-$platform" in
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
         -scheme 'FiamDisplaySwiftExample' \
         "${xcb_flags[@]}" \
-        -destination 'platform=iOS Simulator,name=iPad Air' \
         build \
         test
 
@@ -249,7 +248,6 @@ case "$product-$method-$platform" in
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
         -scheme 'FiamDisplaySwiftExample' \
         "${xcb_flags[@]}" \
-      #  -destination 'platform=iOS Simulator,name=iPad Air' \
         build \
         test
     ;;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -236,7 +236,7 @@ case "$product-$method-$platform" in
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
         -scheme 'FiamDisplaySwiftExample' \
         "${xcb_flags[@]}" \
-        -destination 'platform=iOS Simulator,name=iPad Air 2' \
+        -destination 'platform=iOS Simulator,name=iPad Pro (9.7-inch)' \
         build \
         test
 
@@ -249,7 +249,7 @@ case "$product-$method-$platform" in
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
         -scheme 'FiamDisplaySwiftExample' \
         "${xcb_flags[@]}" \
-        -destination 'platform=iOS Simulator,name=iPad Air 2' \
+        -destination 'platform=iOS Simulator,name=iPad Pro (9.7-inch)' \
         build \
         test
     ;;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -231,7 +231,9 @@ case "$product-$method-$platform" in
     ;;
 
   InAppMessagingDisplay-xcodebuild-iOS)
-    # Run UI tests on both iPad and iphone simultors
+    # Run UI tests on both iPad and iphone simulators
+    # TODO: Running two destinations from one xcodebuild command stopped working with XCode 10.
+    # Consider separating static library tests to a separate job.
     RunXcodebuild \
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
         -scheme 'FiamDisplaySwiftExample' \
@@ -251,7 +253,7 @@ case "$product-$method-$platform" in
     sed -i -e 's/use_frameworks/\#use_frameworks/' Podfile
     pod update --no-repo-update
     cd ../..
-    # Run UI tests on both iPad and iphone simultors
+    # Run UI tests on both iPad and iphone simulators
     RunXcodebuild \
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
         -scheme 'FiamDisplaySwiftExample' \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -85,7 +85,7 @@ case "$platform" in
   iOS)
     xcb_flags=(
       -sdk 'iphonesimulator'
-      -destination 'platform=iOS Simulator,name=iPhone 8'
+      -destination 'platform=iOS Simulator,name=iPhone 7'
     )
     ;;
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -236,6 +236,7 @@ case "$product-$method-$platform" in
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
         -scheme 'FiamDisplaySwiftExample' \
         "${xcb_flags[@]}" \
+        -destination 'platform=iOS Simulator,name=iPad Air 2' \
         build \
         test
 
@@ -248,6 +249,7 @@ case "$product-$method-$platform" in
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
         -scheme 'FiamDisplaySwiftExample' \
         "${xcb_flags[@]}" \
+        -destination 'platform=iOS Simulator,name=iPad Air 2' \
         build \
         test
     ;;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -249,7 +249,7 @@ case "$product-$method-$platform" in
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
         -scheme 'FiamDisplaySwiftExample' \
         "${xcb_flags[@]}" \
-        -destination 'platform=iOS Simulator,name=iPad Air' \
+      #  -destination 'platform=iOS Simulator,name=iPad Air' \
         build \
         test
     ;;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -85,7 +85,7 @@ case "$platform" in
   iOS)
     xcb_flags=(
       -sdk 'iphonesimulator'
-      -destination 'platform=iOS Simulator,name=iPhone 7'
+      -destination 'platform=iOS Simulator,name=iPhone 8'
     )
     ;;
 
@@ -236,6 +236,13 @@ case "$product-$method-$platform" in
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
         -scheme 'FiamDisplaySwiftExample' \
         "${xcb_flags[@]}" \
+        build \
+        test
+
+      RunXcodebuild \
+        -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
+        -scheme 'FiamDisplaySwiftExample' \
+        -sdk 'iphonesimulator' \
         -destination 'platform=iOS Simulator,name=iPad Pro (9.7-inch)' \
         build \
         test
@@ -249,6 +256,13 @@ case "$product-$method-$platform" in
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
         -scheme 'FiamDisplaySwiftExample' \
         "${xcb_flags[@]}" \
+        build \
+        test
+
+      RunXcodebuild \
+        -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
+        -scheme 'FiamDisplaySwiftExample' \
+        -sdk 'iphonesimulator' \
         -destination 'platform=iOS Simulator,name=iPad Pro (9.7-inch)' \
         build \
         test

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -231,8 +231,8 @@ case "$product-$method-$platform" in
     ;;
 
   InAppMessagingDisplay-xcodebuild-iOS)
-    # Run UI tests on both iPad and iphone simulators
-    # TODO: Running two destinations from one xcodebuild command stopped working with XCode 10.
+    # Run UI tests on both iPad and iPhone simulators
+    # TODO: Running two destinations from one xcodebuild command stopped working with Xcode 10.
     # Consider separating static library tests to a separate job.
     RunXcodebuild \
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
@@ -253,7 +253,7 @@ case "$product-$method-$platform" in
     sed -i -e 's/use_frameworks/\#use_frameworks/' Podfile
     pod update --no-repo-update
     cd ../..
-    # Run UI tests on both iPad and iphone simulators
+    # Run UI tests on both iPad and iPhone simulators
     RunXcodebuild \
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
         -scheme 'FiamDisplaySwiftExample' \

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -61,7 +61,7 @@ if [[ "$system" == "Darwin" ]]; then
   version="${version/*version /}"
   # Allow an older swiftformat because travis isn't running High Sierra yet
   # and the formula hasn't been updated in a while on Sierra :-/.
-  if [[ "$version" != "0.32.0" && "$version" != "0.33"* ]]; then
+  if [[ "$version" != "0.32.0" && "$version" != "0.33"* && "$version" != "0.35"* ]]; then
     echo "Version $version installed. Please upgrade to at least swiftformat 0.33.8"
     echo "If it's installed via homebrew you can run: brew upgrade swiftformat"
     exit 1


### PR DESCRIPTION
- Convert travis to Xcode 10 as the primary testing target.
- Add three jobs for continued Xcode 9 testing.
- Split InAppMessaging tests, since simulators fail to start with Xcode 10 and travis and multiple targets invoked from one xcodebuild command.