### PR TITLE
Fix fuzzer build under Xcode 10

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -1506,7 +1506,7 @@
 				"${BUILT_PRODUCTS_DIR}/BoringSSL/openssl.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
-				"${BUILT_PRODUCTS_DIR}/Protobuf/Protobuf.framework",
+				"${BUILT_PRODUCTS_DIR}/Protobuf-iOS8.0/Protobuf.framework",
 				"${BUILT_PRODUCTS_DIR}/gRPC/GRPCClient.framework",
 				"${BUILT_PRODUCTS_DIR}/gRPC-C++/grpcpp.framework",
 				"${BUILT_PRODUCTS_DIR}/gRPC-Core/grpc.framework",
@@ -1618,7 +1618,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Firestore_FuzzTests_iOS/Pods-Firestore_FuzzTests_iOS-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Protobuf/Protobuf.framework",
+				"${BUILT_PRODUCTS_DIR}/Protobuf-iOS9.0/Protobuf.framework",
 				"${BUILT_PRODUCTS_DIR}/LibFuzzer/LibFuzzer.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -1753,7 +1753,7 @@
 				"${BUILT_PRODUCTS_DIR}/BoringSSL/openssl.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
-				"${BUILT_PRODUCTS_DIR}/Protobuf/Protobuf.framework",
+				"${BUILT_PRODUCTS_DIR}/Protobuf-iOS8.0/Protobuf.framework",
 				"${BUILT_PRODUCTS_DIR}/gRPC/GRPCClient.framework",
 				"${BUILT_PRODUCTS_DIR}/gRPC-C++/grpcpp.framework",
 				"${BUILT_PRODUCTS_DIR}/gRPC-Core/grpc.framework",

--- a/Firestore/Example/LibFuzzer.podspec
+++ b/Firestore/Example/LibFuzzer.podspec
@@ -28,6 +28,10 @@ Pod::Spec.new do |s|
   s.license             = { :type => 'BSD-Like' }
   s.authors             = 'LLVM Team'
 
+  # LibFuzzer uses thread_local which does not appear to be supported before
+  # iOS 9.
+  s.ios.deployment_target = '9.0'
+
   # Check out only libFuzzer folder.
   s.source              = {
     :svn => 'https://llvm.org/svn/llvm-project/compiler-rt/trunk/lib/fuzzer'

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -49,6 +49,7 @@ target 'Firestore_Example_iOS' do
 
   target 'Firestore_FuzzTests_iOS' do
     inherit! :search_paths
+    platform :ios, '9.0'
 
     pod 'LibFuzzer', :podspec => 'LibFuzzer.podspec'
     pod '!ProtoCompiler'


### PR DESCRIPTION
LibFuzzer uses thread_local, which isn't available until iOS 9.0
    
This fixes builds under Xcode 10, where the linker is finally enforcing
that running this binary on iOS 8 wouldn't work.