### PR TITLE
gRPC: add the ability to use a custom SSL certificate in integration tests

### DIFF
--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -166,7 +166,8 @@ static FIRFirestoreSettings *defaultSettings;
          "setup_integration_tests.py to properly configure testing SSL certificates.");
   }
   [GRPCCall useTestCertsPath:certsPath testName:@"test_cert_2" forHost:defaultSettings.host];
-  GrpcConnection::UseTestCertificate([certsPath cStringUsingEncoding:NSASCIIStringEncoding], "test_cert_2");
+  GrpcConnection::UseTestCertificate([certsPath cStringUsingEncoding:NSASCIIStringEncoding],
+                                     "test_cert_2");
 }
 
 + (NSString *)projectID {

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -36,6 +36,7 @@
 
 #include "Firestore/core/src/firebase/firestore/auth/empty_credentials_provider.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
+#include "Firestore/core/src/firebase/firestore/remote/grpc_connection.h"
 #include "Firestore/core/src/firebase/firestore/util/autoid.h"
 #include "Firestore/core/src/firebase/firestore/util/filesystem.h"
 #include "Firestore/core/src/firebase/firestore/util/path.h"
@@ -57,6 +58,7 @@ using firebase::firestore::auth::CredentialsProvider;
 using firebase::firestore::auth::EmptyCredentialsProvider;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::testutil::AppForUnitTesting;
+using firebase::firestore::remote::GrpcConnection;
 using firebase::firestore::util::CreateAutoId;
 using firebase::firestore::util::Path;
 using firebase::firestore::util::Status;
@@ -164,6 +166,7 @@ static FIRFirestoreSettings *defaultSettings;
          "setup_integration_tests.py to properly configure testing SSL certificates.");
   }
   [GRPCCall useTestCertsPath:certsPath testName:@"test_cert_2" forHost:defaultSettings.host];
+  GrpcConnection::SetTestCertificatePath([certsPath cStringUsingEncoding:NSASCIIStringEncoding]);
 }
 
 + (NSString *)projectID {

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -166,7 +166,7 @@ static FIRFirestoreSettings *defaultSettings;
          "setup_integration_tests.py to properly configure testing SSL certificates.");
   }
   [GRPCCall useTestCertsPath:certsPath testName:@"test_cert_2" forHost:defaultSettings.host];
-  GrpcConnection::SetTestCertificatePath([certsPath cStringUsingEncoding:NSASCIIStringEncoding]);
+  GrpcConnection::UseTestCertificate([certsPath cStringUsingEncoding:NSASCIIStringEncoding], "test_cert_2");
 }
 
 + (NSString *)projectID {

--- a/Firestore/core/src/firebase/firestore/remote/grpc_connection.h
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_connection.h
@@ -18,6 +18,7 @@
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_REMOTE_GRPC_CONNECTION_H_
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "Firestore/core/src/firebase/firestore/auth/token.h"
@@ -79,14 +80,25 @@ class GrpcConnection {
   void Unregister(GrpcCall* call);
 
   /**
-   * For tests only: allows using a custom certificate to talk to the backend.
+   * For tests only: use a custom root certificate file and the given SSL
+   * target name for all connections. Call before creating any streams or calls.
    */
-  static void SetTestCertificatePath(const std::string& path) {
-    test_certificate_path_ = path;
-  }
+  static void UseTestCertificate(absl::string_view certificate_path,
+                                 absl::string_view target_name);
+
+  /**
+   * For tests only: don't use SSL, send all traffic unencrypted. Call before
+   * creating any streams or calls. Overrides a test certificate.
+   */
+  static void UseInsecureChannel();
 
  private:
-  static std::string test_certificate_path_;
+  struct TestCredentials {
+    std::string certificate_path;
+    std::string target_name;
+    bool use_insecure_channel = false;
+  };
+  static TestCredentials* test_credentials_;
 
   std::unique_ptr<grpc::ClientContext> CreateContext(
       const auth::Token& credential) const;

--- a/Firestore/core/src/firebase/firestore/remote/grpc_connection.h
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_connection.h
@@ -78,6 +78,9 @@ class GrpcConnection {
   void Register(GrpcCall* call);
   void Unregister(GrpcCall* call);
 
+  /**
+   * For tests only: allows using a custom certificate to talk to the backend.
+   */
   static void SetTestCertificatePath(const std::string& path) {
     test_certificate_path_ = path;
   }

--- a/Firestore/core/src/firebase/firestore/remote/grpc_connection.h
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_connection.h
@@ -78,7 +78,13 @@ class GrpcConnection {
   void Register(GrpcCall* call);
   void Unregister(GrpcCall* call);
 
+  static void SetTestCertificatePath(const std::string& path) {
+    test_certificate_path_ = path;
+  }
+
  private:
+  static std::string test_certificate_path_;
+
   std::unique_ptr<grpc::ClientContext> CreateContext(
       const auth::Token& credential) const;
   std::shared_ptr<grpc::Channel> CreateChannel() const;

--- a/Firestore/core/src/firebase/firestore/remote/grpc_connection.mm
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_connection.mm
@@ -129,7 +129,7 @@ std::shared_ptr<grpc::Channel> GrpcConnection::CreateChannel() const {
                                grpc::InsecureChannelCredentials());
   }
 
-  std::fstream cert_file{test_credentials_->certificate_path};
+  std::ifstream cert_file{test_credentials_->certificate_path};
   HARD_ASSERT(cert_file.good(),
               StringFormat("Unable to open root certificates at file path %s",
                            test_credentials_->certificate_path)
@@ -217,8 +217,10 @@ void GrpcConnection::Unregister(GrpcCall* call) {
     test_credentials_ = new TestCredentials{};
   }
 
-  test_credentials_->certificate_path = certificate_path.data();
-  test_credentials_->target_name = target_name.data();
+  test_credentials_->certificate_path =
+      std::string{certificate_path.data(), certificate_path.size()};
+  test_credentials_->target_name =
+      std::string{target_name.data(), target_name.size()};
   // TODO(varconst): hostname if necessary.
 }
 

--- a/Firestore/core/src/firebase/firestore/remote/grpc_connection.mm
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_connection.mm
@@ -17,6 +17,8 @@
 #include "Firestore/core/src/firebase/firestore/remote/grpc_connection.h"
 
 #include <algorithm>
+#include <fstream>
+#include <sstream>
 #include <string>
 #include <utility>
 
@@ -51,6 +53,8 @@ std::string MakeString(absl::string_view view) {
 }
 
 }  // namespace
+
+std::string GrpcConnection::test_certificate_path_;
 
 GrpcConnection::GrpcConnection(const DatabaseInfo& database_info,
                                util::AsyncQueue* worker_queue,
@@ -114,9 +118,21 @@ void GrpcConnection::EnsureActiveStub() {
 }
 
 std::shared_ptr<grpc::Channel> GrpcConnection::CreateChannel() const {
-  return grpc::CreateChannel(
-      database_info_->host(),
-      grpc::SslCredentials(grpc::SslCredentialsOptions()));
+  if (test_certificate_path_.empty()) {
+    return grpc::CreateChannel(
+        database_info_->host(),
+        grpc::SslCredentials(grpc::SslCredentialsOptions()));
+  }
+
+  std::fstream cert_file{test_certificate_path_};
+  std::stringstream cert_buffer;
+  cert_buffer << cert_file.rdbuf();
+  grpc::SslCredentialsOptions options;
+  options.pem_root_certs = cert_buffer.str();
+  grpc::ChannelArguments args;
+  args.SetSslTargetNameOverride("test_cert_2");
+  return grpc::CreateCustomChannel(database_info_->host(),
+                                   grpc::SslCredentials(options), args);
 }
 
 std::unique_ptr<GrpcStream> GrpcConnection::CreateStream(

--- a/Firestore/core/src/firebase/firestore/remote/grpc_connection.mm
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_connection.mm
@@ -132,7 +132,8 @@ std::shared_ptr<grpc::Channel> GrpcConnection::CreateChannel() const {
   std::fstream cert_file{test_credentials_->certificate_path};
   HARD_ASSERT(cert_file.good(),
               StringFormat("Unable to open root certificates at file path %s",
-                           test_credentials_->certificate_path).c_str());
+                           test_credentials_->certificate_path)
+                  .c_str());
   std::stringstream cert_buffer;
   cert_buffer << cert_file.rdbuf();
   grpc::SslCredentialsOptions options;


### PR DESCRIPTION
This closely mimics the way it is currently done in Objective-C gRPC client by simply using a static string that contains a file path.