### PR TITLE
GULLogger: ignore a data race

### DIFF
--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -90,7 +90,7 @@ void GULLoggerForceDebug(void) {
   }
 }
 
-void GULSetLoggerLevel(GULLoggerLevel loggerLevel) {
+__attribute__((no_sanitize("thread"))) void GULSetLoggerLevel(GULLoggerLevel loggerLevel) {
   if (loggerLevel < GULLoggerLevelMin || loggerLevel > GULLoggerLevelMax) {
     GULLogError(kGULLoggerLogger, NO, @"I-COR000023", @"Invalid logger level, %ld",
                 (long)loggerLevel);


### PR DESCRIPTION
Thread sanitizer spots a data race in [`GULSetLoggerLevel`](https://github.com/firebase/firebase-ios-sdk/blob/master/GoogleUtilities/Logger/GULLogger.m#L105) (full error message [here](https://gist.github.com/var-const/e1f828ab76a9ee078a8cac2f0381e9f4)). This prevents a clean run of Firestore integration tests under TSan.

Following #1390, I'm simply making sanitizer ignore this function. However, note that in both C++ and C, a data race is undefined behavior (the compiler is free to produce code assuming the memory in question is never accessed from more than one thread). I don't know if Objective-C provides any stronger guarantees.