### PR TITLE
Port Mutation Batch API from Android/Web

### DIFF
--- a/Firestore/Source/Local/FSTLocalDocumentsView.mm
+++ b/Firestore/Source/Local/FSTLocalDocumentsView.mm
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
                                     inBatches:(NSArray<FSTMutationBatch *> *)batches {
   FSTMaybeDocument *_Nullable document = [self.remoteDocumentCache entryForKey:key];
   for (FSTMutationBatch *batch in batches) {
-    document = [batch applyTo:document documentKey:key];
+    document = [batch applyToLocalDocument:document documentKey:key];
   }
 
   return document;
@@ -129,8 +129,9 @@ NS_ASSUME_NONNULL_BEGIN
       FSTDocumentKey *key = static_cast<FSTDocumentKey *>(mutation.key);
       // baseDoc may be nil for the documents that weren't yet written to the backend.
       FSTMaybeDocument *baseDoc = results[key];
-      FSTMaybeDocument *mutatedDoc =
-          [mutation applyTo:baseDoc baseDocument:baseDoc localWriteTime:batch.localWriteTime];
+      FSTMaybeDocument *mutatedDoc = [mutation applyToLocalDocument:baseDoc
+                                                       baseDocument:baseDoc
+                                                     localWriteTime:batch.localWriteTime];
 
       if (!mutatedDoc || [mutatedDoc isKindOfClass:[FSTDeletedDocument class]]) {
         results = [results dictionaryByRemovingObjectForKey:key];

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -552,7 +552,7 @@ static const int64_t kResumeTokenMaxAgeSeconds = 5 * 60;  // 5 minutes
                 "docVersions should contain every doc in the write.");
     const SnapshotVersion &ackVersion = ackVersionIter->second;
     if (!doc || doc.version < ackVersion) {
-      doc = [batch applyTo:doc documentKey:docKey mutationBatchResult:batchResult];
+      doc = [batch applyToRemoteDocument:doc documentKey:docKey mutationBatchResult:batchResult];
       if (!doc) {
         HARD_ASSERT(!remoteDoc, "Mutation batch %s applied to document %s resulted in nil.", batch,
                     remoteDoc);

--- a/Firestore/Source/Model/FSTMutation.h
+++ b/Firestore/Source/Model/FSTMutation.h
@@ -79,15 +79,11 @@ NS_ASSUME_NONNULL_BEGIN
     NS_DESIGNATED_INITIALIZER;
 
 /**
- * Applies this mutation to the given FSTDocument, FSTDeletedDocument or nil, if we don't have
- * information about this document. Both the input and returned documents can be nil.
+ * Applies this mutation to the given FSTDocument, FSTDeletedDocument or nil for the purposes of
+ * computing a new remote document. Both the input and returned documents can be nil.
  *
  * @param maybeDoc The current state of the document to mutate. The input document should be nil if
  * it does not currently exist.
- * @param baseDoc The state of the document prior to this mutation batch. The input document should
- * be nil if it the document did not exist.
- * @param localWriteTime A timestamp indicating the local write time of the batch this mutation is
- * a part of.
  * @param mutationResult Optional result info from the backend. If omitted, it's assumed that
  * this is merely a local (latency-compensated) application, and the resulting document will
  * have its hasLocalMutations flag set.
@@ -122,18 +118,23 @@ NS_ASSUME_NONNULL_BEGIN
  * apply the transform if the prior mutation resulted in an FSTDocument (always true for an
  * FSTSetMutation, but not necessarily for an FSTPatchMutation).
  */
-- (nullable FSTMaybeDocument *)applyTo:(nullable FSTMaybeDocument *)maybeDoc
-                          baseDocument:(nullable FSTMaybeDocument *)baseDoc
-                        localWriteTime:(FIRTimestamp *)localWriteTime
-                        mutationResult:(nullable FSTMutationResult *)mutationResult;
+- (nullable FSTMaybeDocument *)applyToRemoteDocument:(nullable FSTMaybeDocument *)maybeDoc
+                                      mutationResult:(FSTMutationResult *)mutationResult;
 
 /**
- * A helper version of applyTo for applying mutations locally (without a mutation result from the
- * backend).
+ * Applies this mutation to the given MaybeDocument for the purposes of computing the new local view
+ * of a document. Both the input and returned documents can be null.
+ *
+ * @param maybeDoc The current state of the document to mutate. The input document should be nil if
+ * it does not currently exist.
+ * @param baseDoc The state of the document prior to this mutation batch. The input document should
+ * be nil if it the document did not exist.
+ * @param localWriteTime A timestamp indicating the local write time of the batch this mutation is
+ * a part of.
  */
-- (nullable FSTMaybeDocument *)applyTo:(nullable FSTMaybeDocument *)maybeDoc
-                          baseDocument:(nullable FSTMaybeDocument *)baseDoc
-                        localWriteTime:(nullable FIRTimestamp *)localWriteTime;
+- (nullable FSTMaybeDocument *)applyToLocalDocument:(nullable FSTMaybeDocument *)maybeDoc
+                                       baseDocument:(nullable FSTMaybeDocument *)baseDoc
+                                     localWriteTime:(FIRTimestamp *)localWriteTime;
 
 - (const firebase::firestore::model::DocumentKey &)key;
 

--- a/Firestore/Source/Model/FSTMutationBatch.h
+++ b/Firestore/Source/Model/FSTMutationBatch.h
@@ -65,7 +65,8 @@ extern const firebase::firestore::model::BatchId kFSTBatchIDUnknown;
 - (id)init NS_UNAVAILABLE;
 
 /**
- * Applies all the mutations in this FSTMutationBatch to the specified document.
+ * Applies all the mutations in this FSTMutationBatch to the specified document to create a new
+ * remote document.
  *
  * @param maybeDoc The document to apply mutations to.
  * @param documentKey The key of the document to apply mutations to.
@@ -73,16 +74,18 @@ extern const firebase::firestore::model::BatchId kFSTBatchIDUnknown;
  *   it's assumed that this is a local (latency-compensated) application and documents will have
  *   their hasLocalMutations flag set.
  */
-- (FSTMaybeDocument *_Nullable)applyTo:(FSTMaybeDocument *_Nullable)maybeDoc
-                           documentKey:(const firebase::firestore::model::DocumentKey &)documentKey
-                   mutationBatchResult:(FSTMutationBatchResult *_Nullable)mutationBatchResult;
+- (FSTMaybeDocument *_Nullable)
+    applyToRemoteDocument:(FSTMaybeDocument *_Nullable)maybeDoc
+              documentKey:(const firebase::firestore::model::DocumentKey &)documentKey
+      mutationBatchResult:(FSTMutationBatchResult *_Nullable)mutationBatchResult;
 
 /**
  * A helper version of applyTo for applying mutations locally (without a mutation batch result from
  * the backend).
  */
-- (FSTMaybeDocument *_Nullable)applyTo:(FSTMaybeDocument *_Nullable)maybeDoc
-                           documentKey:(const firebase::firestore::model::DocumentKey &)documentKey;
+- (FSTMaybeDocument *_Nullable)
+    applyToLocalDocument:(FSTMaybeDocument *_Nullable)maybeDoc
+             documentKey:(const firebase::firestore::model::DocumentKey &)documentKey;
 
 /**
  * Returns YES if this mutation batch has already been removed from the mutation queue.


### PR DESCRIPTION
This PR is meant to align the internal APIs for applying mutations with Android/Web. There is some code duplication now, some of which will go away in the held write acks port. In general, I went with the "least amount of work" approach with the PR, as lots of the internal logic will change soon.