### PR TITLE
Remove unnecessary OCMock Podfile dependencies

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -41,12 +41,10 @@ target 'Database_Example_iOS' do
 
   target 'Database_Tests_iOS' do
     inherit! :search_paths
-    pod 'OCMock'
   end
 
   target 'Database_IntegrationTests_iOS' do
     inherit! :search_paths
-    pod 'OCMock'
   end
 end
 
@@ -113,7 +111,6 @@ target 'Storage_Example_iOS' do
 
   target 'Storage_IntegrationTests_iOS' do
     inherit! :search_paths
-    pod 'OCMock'
   end
 end
 
@@ -173,12 +170,10 @@ target 'Database_Example_macOS' do
 
   target 'Database_Tests_macOS' do
     inherit! :search_paths
-    pod 'OCMock'
   end
 
   target 'Database_IntegrationTests_macOS' do
     inherit! :search_paths
-    pod 'OCMock'
   end
 end
 
@@ -194,7 +189,6 @@ target 'Storage_Example_macOS' do
 
   target 'Storage_IntegrationTests_macOS' do
     inherit! :search_paths
-    pod 'OCMock'
   end
 end
 
@@ -225,13 +219,11 @@ target 'Database_Example_tvOS' do
 
   target 'Database_Tests_tvOS' do
     inherit! :search_paths
-    pod 'OCMock'
   end
 
 # TODO
 # target 'Database_IntegrationTests_tvOS' do
 #    inherit! :search_paths
-#    pod 'OCMock'
 #  end
 end
 
@@ -248,6 +240,5 @@ target 'Storage_Example_tvOS' do
 #TODO Storage_IntegrationTests_tvOS
 #  target 'Storage_IntegrationTests_tvOS' do
 #    inherit! :search_paths
-#    pod 'OCMock'
 #  end
 end


### PR DESCRIPTION
The cron travis tests are getting strange failures where the Storage iOS integration tests are pulling in the mac Cocoa.h when building OCMock.

It turns out that the integration tests do not even need OCMock. Similarly, none of the Database tests use OCMock.