### PR TITLE
Queue Storage Tasks on separate queue

### DIFF
--- a/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
@@ -198,6 +198,26 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 30;
   [self waitForExpectations];
 }
 
+- (void)testUnauthenticatedSimplePutDataInBackgroundQueue {
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"testUnauthenticatedSimplePutDataInBackgroundQueue"];
+  FIRStorageReference *ref = [self.storage referenceWithPath:@"ios/public/testBytesUpload"];
+
+  NSData *data = [@"Hello World" dataUsingEncoding:NSUTF8StringEncoding];
+
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    [ref putData:data
+          metadata:nil
+        completion:^(FIRStorageMetadata *metadata, NSError *error) {
+          XCTAssertNotNil(metadata, "Metadata should not be nil");
+          XCTAssertNil(error, "Error should be nil");
+          [expectation fulfill];
+        }];
+  });
+
+  [self waitForExpectations];
+}
+
 - (void)testUnauthenticatedSimplePutEmptyData {
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"testUnauthenticatedSimplePutEmptyData"];
@@ -365,6 +385,24 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 30;
               XCTAssertNil(error, "Error should be nil");
               [expectation fulfill];
             }];
+
+  [self waitForExpectations];
+}
+
+- (void)testUnauthenticatedSimpleGetDataInBackgroundQueue {
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"testUnauthenticatedSimpleGetDataInBackgroundQueue"];
+
+  FIRStorageReference *ref = [self.storage referenceWithPath:@"ios/public/1mb"];
+
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    [ref dataWithMaxSize:1 * 1024 * 1024
+              completion:^(NSData *data, NSError *error) {
+                XCTAssertNotNil(data, "Data should not be nil");
+                XCTAssertNil(error, "Error should be nil");
+                [expectation fulfill];
+              }];
+  });
 
   [self waitForExpectations];
 }
@@ -613,6 +651,57 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 30;
   [self waitForExpectations];
   XCTAssertEqual(INT_MAX, resumeAtBytes);
   XCTAssertEqualWithAccuracy(sqrt(INT_MAX - 499), computationResult, 0.1);
+}
+
+- (void)testUnauthenticatedResumeGetFileInBackgroundQueue {
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"testUnauthenticatedResumeGetFileInBackgroundQueue"];
+
+  FIRStorageReference *ref = [self.storage referenceWithPath:@"ios/public/1mb"];
+
+  NSURL *tmpDirURL = [NSURL fileURLWithPath:NSTemporaryDirectory()];
+  NSURL *fileURL =
+      [[tmpDirURL URLByAppendingPathComponent:@"hello"] URLByAppendingPathExtension:@"txt"];
+
+  __block long resumeAtBytes = 256 * 1024;
+  __block long downloadedBytes = 0;
+  __block double computationResult = 0;
+
+  FIRStorageDownloadTask *task = [ref writeToFile:fileURL];
+
+  [task observeStatus:FIRStorageTaskStatusSuccess
+              handler:^(FIRStorageTaskSnapshot *snapshot) {
+                XCTAssertEqualObjects([snapshot description], @"<State: Success>");
+                [expectation fulfill];
+              }];
+
+  [task observeStatus:FIRStorageTaskStatusProgress
+              handler:^(FIRStorageTaskSnapshot *_Nonnull snapshot) {
+                XCTAssertTrue([[snapshot description] containsString:@"State: Progress"] ||
+                              [[snapshot description] containsString:@"State: Resume"]);
+                NSProgress *progress = snapshot.progress;
+                XCTAssertGreaterThanOrEqual(progress.completedUnitCount, downloadedBytes);
+                downloadedBytes = progress.completedUnitCount;
+                if (progress.completedUnitCount > resumeAtBytes) {
+                  NSLog(@"Pausing");
+                  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                    [task pause];
+                  });
+                  resumeAtBytes = INT_MAX;
+                }
+              }];
+
+  [task observeStatus:FIRStorageTaskStatusPause
+              handler:^(FIRStorageTaskSnapshot *snapshot) {
+                XCTAssertEqualObjects([snapshot description], @"<State: Paused>");
+                NSLog(@"Resuming");
+                dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                  [task resume];
+                });
+              }];
+
+  [self waitForExpectations];
+  XCTAssertEqual(INT_MAX, resumeAtBytes);
 }
 
 - (void)waitForExpectations {

--- a/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
@@ -665,7 +665,6 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 30;
 
   __block long resumeAtBytes = 256 * 1024;
   __block long downloadedBytes = 0;
-  __block double computationResult = 0;
 
   FIRStorageDownloadTask *task = [ref writeToFile:fileURL];
 

--- a/Example/Storage/Tests/Unit/FIRStorageDeleteTests.m
+++ b/Example/Storage/Tests/Unit/FIRStorageDeleteTests.m
@@ -18,6 +18,7 @@
 @interface FIRStorageDeleteTests : XCTestCase
 
 @property(strong, nonatomic) GTMSessionFetcherService *fetcherService;
+@property(nonatomic) dispatch_queue_t dispatchQueue;
 @property(strong, nonatomic) FIRStorageMetadata *metadata;
 @property(strong, nonatomic) FIRStorage *storage;
 @property(strong, nonatomic) id mockApp;
@@ -44,6 +45,8 @@
       [[FIRStorageTokenAuthorizer alloc] initWithGoogleAppID:@"dummyAppID"
                                               fetcherService:self.fetcherService
                                                 authProvider:nil];
+
+  self.dispatchQueue = dispatch_queue_create("Test dispatch queue", DISPATCH_QUEUE_SERIAL);
 
   self.storage = [FIRStorage storageForApp:self.mockApp];
 }
@@ -76,6 +79,7 @@
   FIRStorageReference *ref = [[FIRStorageReference alloc] initWithStorage:self.storage path:path];
   FIRStorageDeleteTask *task = [[FIRStorageDeleteTask alloc] initWithReference:ref
                                                                 fetcherService:self.fetcherService
+                                                                 dispatchQueue:self.dispatchQueue
                                                                     completion:^(NSError *error) {
                                                                       [expectation fulfill];
                                                                     }];
@@ -92,6 +96,7 @@
   FIRStorageReference *ref = [[FIRStorageReference alloc] initWithStorage:self.storage path:path];
   FIRStorageDeleteTask *task = [[FIRStorageDeleteTask alloc] initWithReference:ref
                                                                 fetcherService:self.fetcherService
+                                                                 dispatchQueue:self.dispatchQueue
                                                                     completion:^(NSError *error) {
                                                                       XCTAssertEqual(error, nil);
                                                                       [expectation fulfill];
@@ -111,6 +116,7 @@
   FIRStorageDeleteTask *task = [[FIRStorageDeleteTask alloc]
       initWithReference:ref
          fetcherService:self.fetcherService
+          dispatchQueue:self.dispatchQueue
              completion:^(NSError *error) {
                XCTAssertEqual(error.code, FIRStorageErrorCodeUnauthenticated);
                [expectation fulfill];
@@ -130,6 +136,7 @@
   FIRStorageDeleteTask *task = [[FIRStorageDeleteTask alloc]
       initWithReference:ref
          fetcherService:self.fetcherService
+          dispatchQueue:self.dispatchQueue
              completion:^(NSError *error) {
                XCTAssertEqual(error.code, FIRStorageErrorCodeUnauthorized);
                [expectation fulfill];
@@ -149,6 +156,7 @@
   FIRStorageDeleteTask *task = [[FIRStorageDeleteTask alloc]
       initWithReference:ref
          fetcherService:self.fetcherService
+          dispatchQueue:self.dispatchQueue
              completion:^(NSError *error) {
                XCTAssertEqual(error.code, FIRStorageErrorCodeObjectNotFound);
                [expectation fulfill];

--- a/Example/Storage/Tests/Unit/FIRStorageGetMetadataTests.m
+++ b/Example/Storage/Tests/Unit/FIRStorageGetMetadataTests.m
@@ -18,6 +18,7 @@
 @interface FIRStorageGetMetadataTests : XCTestCase
 
 @property(strong, nonatomic) GTMSessionFetcherService *fetcherService;
+@property(nonatomic) dispatch_queue_t dispatchQueue;
 @property(strong, nonatomic) FIRStorageMetadata *metadata;
 @property(strong, nonatomic) FIRStorage *storage;
 @property(strong, nonatomic) id mockApp;
@@ -44,6 +45,8 @@
       [[FIRStorageTokenAuthorizer alloc] initWithGoogleAppID:@"dummyAppID"
                                               fetcherService:self.fetcherService
                                                 authProvider:nil];
+
+  self.dispatchQueue = dispatch_queue_create("Test dispatch queue", DISPATCH_QUEUE_SERIAL);
 
   self.storage = [FIRStorage storageForApp:self.mockApp];
 }
@@ -77,6 +80,7 @@
   FIRStorageGetMetadataTask *task = [[FIRStorageGetMetadataTask alloc]
       initWithReference:ref
          fetcherService:self.fetcherService
+          dispatchQueue:self.dispatchQueue
              completion:^(FIRStorageMetadata *metadata, NSError *error) {
                [expectation fulfill];
              }];
@@ -94,6 +98,7 @@
   FIRStorageGetMetadataTask *task = [[FIRStorageGetMetadataTask alloc]
       initWithReference:ref
          fetcherService:self.fetcherService
+          dispatchQueue:self.dispatchQueue
              completion:^(FIRStorageMetadata *metadata, NSError *error) {
                XCTAssertEqualObjects(self.metadata.bucket, metadata.bucket);
                XCTAssertEqualObjects(self.metadata.name, metadata.name);
@@ -115,6 +120,7 @@
   FIRStorageGetMetadataTask *task = [[FIRStorageGetMetadataTask alloc]
       initWithReference:ref
          fetcherService:self.fetcherService
+          dispatchQueue:self.dispatchQueue
              completion:^(FIRStorageMetadata *metadata, NSError *error) {
                XCTAssertEqual(metadata, nil);
                XCTAssertEqual(error.code, FIRStorageErrorCodeUnauthenticated);
@@ -135,6 +141,7 @@
   FIRStorageGetMetadataTask *task = [[FIRStorageGetMetadataTask alloc]
       initWithReference:ref
          fetcherService:self.fetcherService
+          dispatchQueue:self.dispatchQueue
              completion:^(FIRStorageMetadata *metadata, NSError *error) {
                XCTAssertEqual(metadata, nil);
                XCTAssertEqual(error.code, FIRStorageErrorCodeUnauthorized);
@@ -155,6 +162,7 @@
   FIRStorageGetMetadataTask *task = [[FIRStorageGetMetadataTask alloc]
       initWithReference:ref
          fetcherService:self.fetcherService
+          dispatchQueue:self.dispatchQueue
              completion:^(FIRStorageMetadata *metadata, NSError *error) {
                XCTAssertEqual(metadata, nil);
                XCTAssertEqual(error.code, FIRStorageErrorCodeObjectNotFound);
@@ -175,6 +183,7 @@
   FIRStorageGetMetadataTask *task = [[FIRStorageGetMetadataTask alloc]
       initWithReference:ref
          fetcherService:self.fetcherService
+          dispatchQueue:self.dispatchQueue
              completion:^(FIRStorageMetadata *metadata, NSError *error) {
                XCTAssertEqual(metadata, nil);
                XCTAssertEqual(error.code, FIRStorageErrorCodeUnknown);

--- a/Example/Storage/Tests/Unit/FIRStorageUpdateMetadataTests.m
+++ b/Example/Storage/Tests/Unit/FIRStorageUpdateMetadataTests.m
@@ -19,6 +19,7 @@
 @interface FIRStorageUpdateMetadataTests : XCTestCase
 
 @property(strong, nonatomic) GTMSessionFetcherService *fetcherService;
+@property(nonatomic) dispatch_queue_t dispatchQueue;
 @property(strong, nonatomic) FIRStorageMetadata *metadata;
 @property(strong, nonatomic) FIRStorage *storage;
 @property(strong, nonatomic) id mockApp;
@@ -45,6 +46,8 @@
       [[FIRStorageTokenAuthorizer alloc] initWithGoogleAppID:@"dummyAppID"
                                               fetcherService:self.fetcherService
                                                 authProvider:nil];
+
+  self.dispatchQueue = dispatch_queue_create("Test dispatch queue", DISPATCH_QUEUE_SERIAL);
 
   self.storage = [FIRStorage storageForApp:self.mockApp];
 }
@@ -84,6 +87,7 @@
   FIRStorageUpdateMetadataTask *task = [[FIRStorageUpdateMetadataTask alloc]
       initWithReference:ref
          fetcherService:self.fetcherService
+          dispatchQueue:self.dispatchQueue
                metadata:self.metadata
              completion:^(FIRStorageMetadata *_Nullable metadata, NSError *_Nullable error) {
                [expectation fulfill];
@@ -102,6 +106,7 @@
   FIRStorageUpdateMetadataTask *task = [[FIRStorageUpdateMetadataTask alloc]
       initWithReference:ref
          fetcherService:self.fetcherService
+          dispatchQueue:self.dispatchQueue
                metadata:self.metadata
              completion:^(FIRStorageMetadata *_Nullable metadata, NSError *_Nullable error) {
                XCTAssertEqualObjects(self.metadata.bucket, metadata.bucket);
@@ -124,6 +129,7 @@
   FIRStorageUpdateMetadataTask *task = [[FIRStorageUpdateMetadataTask alloc]
       initWithReference:ref
          fetcherService:self.fetcherService
+          dispatchQueue:self.dispatchQueue
                metadata:self.metadata
              completion:^(FIRStorageMetadata *_Nullable metadata, NSError *_Nullable error) {
                XCTAssertNil(metadata);
@@ -145,6 +151,7 @@
   FIRStorageUpdateMetadataTask *task = [[FIRStorageUpdateMetadataTask alloc]
       initWithReference:ref
          fetcherService:self.fetcherService
+          dispatchQueue:self.dispatchQueue
                metadata:self.metadata
              completion:^(FIRStorageMetadata *_Nullable metadata, NSError *_Nullable error) {
                XCTAssertNil(metadata);
@@ -166,6 +173,7 @@
   FIRStorageUpdateMetadataTask *task = [[FIRStorageUpdateMetadataTask alloc]
       initWithReference:ref
          fetcherService:self.fetcherService
+          dispatchQueue:self.dispatchQueue
                metadata:self.metadata
              completion:^(FIRStorageMetadata *_Nullable metadata, NSError *_Nullable error) {
                XCTAssertNil(metadata);
@@ -187,6 +195,7 @@
   FIRStorageUpdateMetadataTask *task = [[FIRStorageUpdateMetadataTask alloc]
       initWithReference:ref
          fetcherService:self.fetcherService
+          dispatchQueue:self.dispatchQueue
                metadata:self.metadata
              completion:^(FIRStorageMetadata *_Nullable metadata, NSError *_Nullable error) {
                XCTAssertNil(metadata);

--- a/Firebase/Storage/FIRStorage.m
+++ b/Firebase/Storage/FIRStorage.m
@@ -149,6 +149,7 @@ static GTMSessionFetcherRetryBlock _retryWhenOffline;
     _app = app;
     _auth = auth;
     _storageBucket = bucket;
+    _dispatchQueue = dispatch_queue_create("com.google.firebase.storage", DISPATCH_QUEUE_SERIAL);
     _fetcherServiceForApp = [FIRStorage fetcherServiceForApp:_app bucket:bucket auth:auth];
     _maxDownloadRetryTime = 600.0;
     _maxOperationRetryTime = 120.0;

--- a/Firebase/Storage/FIRStorageDownloadTask.m
+++ b/Firebase/Storage/FIRStorageDownloadTask.m
@@ -74,8 +74,8 @@
     }
 
     [fetcher setResumeDataBlock:^(NSData *data) {
-      if (data) {
-        FIRStorageDownloadTask *strong = weakSelf;
+      FIRStorageDownloadTask *strong = weakSelf;
+      if (strong && data) {
         strong->_downloadData = data;
       }
     }];

--- a/Firebase/Storage/FIRStorageDownloadTask.m
+++ b/Firebase/Storage/FIRStorageDownloadTask.m
@@ -27,8 +27,9 @@
 
 - (instancetype)initWithReference:(FIRStorageReference *)reference
                    fetcherService:(GTMSessionFetcherService *)service
+                    dispatchQueue:(dispatch_queue_t)queue
                              file:(nullable NSURL *)fileURL {
-  self = [super initWithReference:reference fetcherService:service];
+  self = [super initWithReference:reference fetcherService:service dispatchQueue:queue];
   if (self) {
     _fileURL = [fileURL copy];
     _progress = [NSProgress progressWithTotalUnitCount:0];
@@ -45,97 +46,102 @@
 }
 
 - (void)enqueueWithData:(nullable NSData *)resumeData {
-  NSAssert([NSThread isMainThread],
-           @"Download attempting to execute on non main queue! Please "
-           @"only execute this method on the main queue.");
-  self.state = FIRStorageTaskStateQueueing;
-  NSMutableURLRequest *request = [self.baseRequest mutableCopy];
-  request.HTTPMethod = @"GET";
-  request.timeoutInterval = self.reference.storage.maxDownloadRetryTime;
-  NSURLComponents *components =
-      [NSURLComponents componentsWithURL:request.URL resolvingAgainstBaseURL:NO];
-  [components setQuery:@"alt=media"];
-  request.URL = components.URL;
-
-  GTMSessionFetcher *fetcher;
-  if (resumeData) {
-    fetcher = [GTMSessionFetcher fetcherWithDownloadResumeData:resumeData];
-    fetcher.comment = @"Resuming DownloadTask";
-  } else {
-    fetcher = [self.fetcherService fetcherWithRequest:request];
-    fetcher.comment = @"Starting DownloadTask";
-  }
-
   __weak FIRStorageDownloadTask *weakSelf = self;
 
-  [fetcher setResumeDataBlock:^(NSData *data) {
-    if (data) {
-      FIRStorageDownloadTask *strongSelf = weakSelf;
-      strongSelf->_downloadData = data;
-    }
-  }];
+  [self dispatchAsync:^() {
+    FIRStorageDownloadTask *strongSelf = weakSelf;
 
-  fetcher.maxRetryInterval = self.reference.storage.maxDownloadRetryTime;
-
-  if (_fileURL) {
-    // Handle file downloads
-    [fetcher setDestinationFileURL:_fileURL];
-    [fetcher setDownloadProgressBlock:^(int64_t bytesWritten, int64_t totalBytesWritten,
-                                        int64_t totalBytesExpectedToWrite) {
-      weakSelf.state = FIRStorageTaskStateProgress;
-      weakSelf.progress.completedUnitCount = totalBytesWritten;
-      weakSelf.progress.totalUnitCount = totalBytesExpectedToWrite;
-      FIRStorageTaskSnapshot *snapshot = weakSelf.snapshot;
-      [weakSelf fireHandlersForStatus:FIRStorageTaskStatusProgress snapshot:snapshot];
-      weakSelf.state = FIRStorageTaskStateRunning;
-    }];
-  } else {
-    // Handle data downloads
-    [fetcher setReceivedProgressBlock:^(int64_t bytesWritten, int64_t totalBytesWritten) {
-      weakSelf.state = FIRStorageTaskStateProgress;
-      weakSelf.progress.completedUnitCount = totalBytesWritten;
-      int64_t totalLength = [[weakSelf.fetcher response] expectedContentLength];
-      weakSelf.progress.totalUnitCount = totalLength;
-      FIRStorageTaskSnapshot *snapshot = weakSelf.snapshot;
-      [weakSelf fireHandlersForStatus:FIRStorageTaskStatusProgress snapshot:snapshot];
-      weakSelf.state = FIRStorageTaskStateRunning;
-    }];
-  }
-
-  _fetcher = fetcher;
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-retain-cycles"
-  _fetcherCompletion = ^(NSData *data, NSError *error) {
-    // Fire last progress updates
-    [self fireHandlersForStatus:FIRStorageTaskStatusProgress snapshot:self.snapshot];
-
-    // Handle potential issues with download
-    if (error) {
-      self.state = FIRStorageTaskStateFailed;
-      self.error = [FIRStorageErrors errorWithServerError:error reference:self.reference];
-      [self fireHandlersForStatus:FIRStorageTaskStatusFailure snapshot:self.snapshot];
-      [self removeAllObservers];
-      self->_fetcherCompletion = nil;
+    if (!strongSelf) {
       return;
     }
 
-    // Download completed successfully, fire completion callbacks
-    self.state = FIRStorageTaskStateSuccess;
+    strongSelf.state = FIRStorageTaskStateQueueing;
+    NSMutableURLRequest *request = [strongSelf.baseRequest mutableCopy];
+    request.HTTPMethod = @"GET";
+    request.timeoutInterval = strongSelf.reference.storage.maxDownloadRetryTime;
+    NSURLComponents *components =
+        [NSURLComponents componentsWithURL:request.URL resolvingAgainstBaseURL:NO];
+    [components setQuery:@"alt=media"];
+    request.URL = components.URL;
 
-    if (data) {
-      self->_downloadData = data;
+    GTMSessionFetcher *fetcher;
+    if (resumeData) {
+      fetcher = [GTMSessionFetcher fetcherWithDownloadResumeData:resumeData];
+      fetcher.comment = @"Resuming DownloadTask";
+    } else {
+      fetcher = [strongSelf.fetcherService fetcherWithRequest:request];
+      fetcher.comment = @"Starting DownloadTask";
     }
 
-    [self fireHandlersForStatus:FIRStorageTaskStatusSuccess snapshot:self.snapshot];
-    [self removeAllObservers];
-    self->_fetcherCompletion = nil;
-  };
+    [fetcher setResumeDataBlock:^(NSData *data) {
+      if (data) {
+        FIRStorageDownloadTask *strong = weakSelf;
+        strong->_downloadData = data;
+      }
+    }];
+
+    fetcher.maxRetryInterval = strongSelf.reference.storage.maxDownloadRetryTime;
+
+    if (strongSelf->_fileURL) {
+      // Handle file downloads
+      [fetcher setDestinationFileURL:strongSelf->_fileURL];
+      [fetcher setDownloadProgressBlock:^(int64_t bytesWritten, int64_t totalBytesWritten,
+                                          int64_t totalBytesExpectedToWrite) {
+        weakSelf.state = FIRStorageTaskStateProgress;
+        weakSelf.progress.completedUnitCount = totalBytesWritten;
+        weakSelf.progress.totalUnitCount = totalBytesExpectedToWrite;
+        FIRStorageTaskSnapshot *snapshot = weakSelf.snapshot;
+        [weakSelf fireHandlersForStatus:FIRStorageTaskStatusProgress snapshot:snapshot];
+        weakSelf.state = FIRStorageTaskStateRunning;
+      }];
+    } else {
+      // Handle data downloads
+      [fetcher setReceivedProgressBlock:^(int64_t bytesWritten, int64_t totalBytesWritten) {
+        weakSelf.state = FIRStorageTaskStateProgress;
+        weakSelf.progress.completedUnitCount = totalBytesWritten;
+        int64_t totalLength = [[weakSelf.fetcher response] expectedContentLength];
+        weakSelf.progress.totalUnitCount = totalLength;
+        FIRStorageTaskSnapshot *snapshot = weakSelf.snapshot;
+        [weakSelf fireHandlersForStatus:FIRStorageTaskStatusProgress snapshot:snapshot];
+        weakSelf.state = FIRStorageTaskStateRunning;
+      }];
+    }
+
+    strongSelf->_fetcher = fetcher;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+    strongSelf->_fetcherCompletion = ^(NSData *data, NSError *error) {
+      // Fire last progress updates
+      [self fireHandlersForStatus:FIRStorageTaskStatusProgress snapshot:self.snapshot];
+
+      // Handle potential issues with download
+      if (error) {
+        self.state = FIRStorageTaskStateFailed;
+        self.error = [FIRStorageErrors errorWithServerError:error reference:self.reference];
+        [self fireHandlersForStatus:FIRStorageTaskStatusFailure snapshot:self.snapshot];
+        [self removeAllObservers];
+        self->_fetcherCompletion = nil;
+        return;
+      }
+
+      // Download completed successfully, fire completion callbacks
+      self.state = FIRStorageTaskStateSuccess;
+
+      if (data) {
+        self->_downloadData = data;
+      }
+
+      [self fireHandlersForStatus:FIRStorageTaskStatusSuccess snapshot:self.snapshot];
+      [self removeAllObservers];
+      self->_fetcherCompletion = nil;
+    };
 #pragma clang diagnostic pop
 
-  self.state = FIRStorageTaskStateRunning;
-  [self.fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-    weakSelf.fetcherCompletion(data, error);
+    strongSelf.state = FIRStorageTaskStateRunning;
+    [strongSelf.fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
+      weakSelf.fetcherCompletion(data, error);
+    }];
   }];
 }
 
@@ -147,37 +153,37 @@
 }
 
 - (void)cancelWithError:(NSError *)error {
-  NSAssert([NSThread isMainThread],
-           @"Cancel attempting to execute on non main queue! Please only "
-           @"execute this method on the main queue.");
-  self.state = FIRStorageTaskStateCancelled;
-  [self.fetcher stopFetching];
-  self.error = error;
-  [self fireHandlersForStatus:FIRStorageTaskStatusFailure snapshot:self.snapshot];
+  __weak FIRStorageDownloadTask *weakSelf = self;
+  [self dispatchAsync:^() {
+    weakSelf.state = FIRStorageTaskStateCancelled;
+    [weakSelf.fetcher stopFetching];
+    weakSelf.error = error;
+    [weakSelf fireHandlersForStatus:FIRStorageTaskStatusFailure snapshot:weakSelf.snapshot];
+  }];
 }
 
 - (void)pause {
-  NSAssert([NSThread isMainThread],
-           @"Pause attempting to execute on non main queue! Please only "
-           @"execute this method on the main queue.");
-  self.state = FIRStorageTaskStatePausing;
-  [self.fetcher stopFetching];
-  // Give the resume callback a chance to run (if scheduled)
-  [self.fetcher waitForCompletionWithTimeout:0.001];
-  self.state = FIRStorageTaskStatePaused;
-  FIRStorageTaskSnapshot *snapshot = self.snapshot;
-  [self fireHandlersForStatus:FIRStorageTaskStatusPause snapshot:snapshot];
+  __weak FIRStorageDownloadTask *weakSelf = self;
+  [self dispatchAsync:^() {
+    weakSelf.state = FIRStorageTaskStatePausing;
+    [weakSelf.fetcher stopFetching];
+    // Give the resume callback a chance to run (if scheduled)
+    [weakSelf.fetcher waitForCompletionWithTimeout:0.001];
+    weakSelf.state = FIRStorageTaskStatePaused;
+    FIRStorageTaskSnapshot *snapshot = weakSelf.snapshot;
+    [weakSelf fireHandlersForStatus:FIRStorageTaskStatusPause snapshot:snapshot];
+  }];
 }
 
 - (void)resume {
-  NSAssert([NSThread isMainThread],
-           @"Resume attempting to execute on non main queue! Please only "
-           @"execute this method on the main queue.");
-  self.state = FIRStorageTaskStateResuming;
-  FIRStorageTaskSnapshot *snapshot = self.snapshot;
-  [self fireHandlersForStatus:FIRStorageTaskStatusResume snapshot:snapshot];
-  self.state = FIRStorageTaskStateRunning;
-  [self enqueueWithData:_downloadData];
+  __weak FIRStorageDownloadTask *weakSelf = self;
+  [self dispatchAsync:^() {
+    weakSelf.state = FIRStorageTaskStateResuming;
+    FIRStorageTaskSnapshot *snapshot = weakSelf.snapshot;
+    [weakSelf fireHandlersForStatus:FIRStorageTaskStatusResume snapshot:snapshot];
+    weakSelf.state = FIRStorageTaskStateRunning;
+    [weakSelf enqueueWithData:weakSelf.downloadData];
+  }];
 }
 
 @end

--- a/Firebase/Storage/FIRStorageGetDownloadURLTask.m
+++ b/Firebase/Storage/FIRStorageGetDownloadURLTask.m
@@ -26,8 +26,9 @@
 
 - (instancetype)initWithReference:(FIRStorageReference *)reference
                    fetcherService:(GTMSessionFetcherService *)service
+                    dispatchQueue:(dispatch_queue_t)queue
                        completion:(FIRStorageVoidURLError)completion {
-  self = [super initWithReference:reference fetcherService:service];
+  self = [super initWithReference:reference fetcherService:service dispatchQueue:queue];
   if (self) {
     _completion = [completion copy];
   }
@@ -67,51 +68,59 @@
 }
 
 - (void)enqueue {
-  NSMutableURLRequest *request = [self.baseRequest mutableCopy];
-  request.HTTPMethod = @"GET";
-  request.timeoutInterval = self.reference.storage.maxOperationRetryTime;
+  __weak FIRStorageGetDownloadURLTask *weakSelf = self;
 
-  FIRStorageVoidURLError callback = _completion;
-  _completion = nil;
+  [self dispatchAsync:^() {
+    FIRStorageGetDownloadURLTask *strongSelf = weakSelf;
 
-  GTMSessionFetcher *fetcher = [self.fetcherService fetcherWithRequest:request];
-  _fetcher = fetcher;
-  fetcher.comment = @"GetDownloadURLTask";
+    if (!strongSelf) {
+      return;
+    }
+
+    NSMutableURLRequest *request = [strongSelf.baseRequest mutableCopy];
+    request.HTTPMethod = @"GET";
+    request.timeoutInterval = strongSelf.reference.storage.maxOperationRetryTime;
+
+    FIRStorageVoidURLError callback = strongSelf->_completion;
+    strongSelf->_completion = nil;
+
+    GTMSessionFetcher *fetcher = [strongSelf.fetcherService fetcherWithRequest:request];
+    strongSelf->_fetcher = fetcher;
+    fetcher.comment = @"GetDownloadURLTask";
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
-  _fetcherCompletion = ^(NSData *data, NSError *error) {
-    NSURL *downloadURL;
-    if (error) {
-      if (!self.error) {
-        self.error = [FIRStorageErrors errorWithServerError:error reference:self.reference];
-      }
-    } else {
-      NSDictionary *responseDictionary = [NSDictionary frs_dictionaryFromJSONData:data];
-      if (responseDictionary != nil) {
-        downloadURL =
-            [FIRStorageGetDownloadURLTask downloadURLFromMetadataDictionary:responseDictionary];
-        if (!downloadURL) {
-          self.error =
-              [FIRStorageErrors errorWithCustomMessage:@"Failed to retrieve a download URL."];
+    strongSelf->_fetcherCompletion = ^(NSData *data, NSError *error) {
+      NSURL *downloadURL;
+      if (error) {
+        if (!self.error) {
+          self.error = [FIRStorageErrors errorWithServerError:error reference:self.reference];
         }
       } else {
-        self.error = [FIRStorageErrors errorWithInvalidRequest:data];
+        NSDictionary *responseDictionary = [NSDictionary frs_dictionaryFromJSONData:data];
+        if (responseDictionary != nil) {
+          downloadURL =
+              [FIRStorageGetDownloadURLTask downloadURLFromMetadataDictionary:responseDictionary];
+          if (!downloadURL) {
+            self.error =
+                [FIRStorageErrors errorWithCustomMessage:@"Failed to retrieve a download URL."];
+          }
+        } else {
+          self.error = [FIRStorageErrors errorWithInvalidRequest:data];
+        }
       }
-    }
 
-    if (callback) {
-      callback(downloadURL, self.error);
-    }
+      if (callback) {
+        callback(downloadURL, self.error);
+      }
 
-    self->_fetcherCompletion = nil;
-  };
+      self->_fetcherCompletion = nil;
+    };
 #pragma clang diagnostic pop
-
-  __weak FIRStorageGetDownloadURLTask *weakSelf = self;
-  [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-    weakSelf.fetcherCompletion(data, error);
+    [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
+      weakSelf.fetcherCompletion(data, error);
+    }];
   }];
-}
+};
 
 @end

--- a/Firebase/Storage/FIRStorageGetMetadataTask.m
+++ b/Firebase/Storage/FIRStorageGetMetadataTask.m
@@ -31,8 +31,9 @@
 
 - (instancetype)initWithReference:(FIRStorageReference *)reference
                    fetcherService:(GTMSessionFetcherService *)service
+                    dispatchQueue:(dispatch_queue_t)queue
                        completion:(FIRStorageVoidMetadataError)completion {
-  self = [super initWithReference:reference fetcherService:service];
+  self = [super initWithReference:reference fetcherService:service dispatchQueue:queue];
   if (self) {
     _completion = [completion copy];
   }
@@ -44,45 +45,54 @@
 }
 
 - (void)enqueue {
-  NSMutableURLRequest *request = [self.baseRequest mutableCopy];
-  request.HTTPMethod = @"GET";
-  request.timeoutInterval = self.reference.storage.maxOperationRetryTime;
+  __weak FIRStorageGetMetadataTask *weakSelf = self;
 
-  FIRStorageVoidMetadataError callback = _completion;
-  _completion = nil;
+  [self dispatchAsync:^() {
+      FIRStorageGetMetadataTask* strongSelf = weakSelf;
 
-  GTMSessionFetcher *fetcher = [self.fetcherService fetcherWithRequest:request];
-  _fetcher = fetcher;
-  fetcher.comment = @"GetMetadataTask";
+    if (!strongSelf) {
+      return;
+    }
+
+    NSMutableURLRequest *request = [strongSelf.baseRequest mutableCopy];
+    request.HTTPMethod = @"GET";
+    request.timeoutInterval = strongSelf.reference.storage.maxOperationRetryTime;
+
+    FIRStorageVoidMetadataError callback = strongSelf->_completion;
+    strongSelf->_completion = nil;
+
+    GTMSessionFetcher *fetcher = [strongSelf.fetcherService fetcherWithRequest:request];
+    strongSelf->_fetcher = fetcher;
+    fetcher.comment = @"GetMetadataTask";
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
-  _fetcherCompletion = ^(NSData *data, NSError *error) {
-    FIRStorageMetadata *metadata;
-    if (error) {
-      if (!self.error) {
-        self.error = [FIRStorageErrors errorWithServerError:error reference:self.reference];
-      }
-    } else {
-      NSDictionary *responseDictionary = [NSDictionary frs_dictionaryFromJSONData:data];
-      if (responseDictionary != nil) {
-        metadata = [[FIRStorageMetadata alloc] initWithDictionary:responseDictionary];
-        [metadata setType:FIRStorageMetadataTypeFile];
+    strongSelf->_fetcherCompletion = ^(NSData *data, NSError *error) {
+      FIRStorageMetadata *metadata;
+      if (error) {
+        if (!self.error) {
+          self.error = [FIRStorageErrors errorWithServerError:error reference:self.reference];
+        }
       } else {
-        self.error = [FIRStorageErrors errorWithInvalidRequest:data];
+        NSDictionary *responseDictionary = [NSDictionary frs_dictionaryFromJSONData:data];
+        if (responseDictionary != nil) {
+          metadata = [[FIRStorageMetadata alloc] initWithDictionary:responseDictionary];
+          [metadata setType:FIRStorageMetadataTypeFile];
+        } else {
+          self.error = [FIRStorageErrors errorWithInvalidRequest:data];
+        }
       }
-    }
 
-    if (callback) {
-      callback(metadata, self.error);
-    }
-    self->_fetcherCompletion = nil;
-  };
+      if (callback) {
+        callback(metadata, self.error);
+      }
+      self->_fetcherCompletion = nil;
+    };
 #pragma clang diagnostic pop
 
-  __weak FIRStorageGetMetadataTask *weakSelf = self;
-  [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-    weakSelf.fetcherCompletion(data, error);
+    [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
+      weakSelf.fetcherCompletion(data, error);
+    }];
   }];
 }
 

--- a/Firebase/Storage/FIRStorageGetMetadataTask.m
+++ b/Firebase/Storage/FIRStorageGetMetadataTask.m
@@ -48,7 +48,7 @@
   __weak FIRStorageGetMetadataTask *weakSelf = self;
 
   [self dispatchAsync:^() {
-      FIRStorageGetMetadataTask* strongSelf = weakSelf;
+    FIRStorageGetMetadataTask *strongSelf = weakSelf;
 
     if (!strongSelf) {
       return;

--- a/Firebase/Storage/FIRStorageObservableTask.m
+++ b/Firebase/Storage/FIRStorageObservableTask.m
@@ -31,8 +31,9 @@
 @synthesize state = _state;
 
 - (instancetype)initWithReference:(FIRStorageReference *)reference
-                   fetcherService:(GTMSessionFetcherService *)service {
-  self = [super initWithReference:reference fetcherService:service];
+                   fetcherService:(GTMSessionFetcherService *)service
+                    dispatchQueue:(dispatch_queue_t)queue {
+  self = [super initWithReference:reference fetcherService:service dispatchQueue:queue];
   if (self) {
     _pauseHandlers = [[NSMutableDictionary alloc] init];
     _resumeHandlers = [[NSMutableDictionary alloc] init];

--- a/Firebase/Storage/FIRStorageReference.m
+++ b/Firebase/Storage/FIRStorageReference.m
@@ -167,6 +167,7 @@
   FIRStorageUploadTask *task =
       [[FIRStorageUploadTask alloc] initWithReference:self
                                        fetcherService:_storage.fetcherServiceForApp
+                                        dispatchQueue:_storage.dispatchQueue
                                                  data:uploadData
                                              metadata:metadata];
 
@@ -214,6 +215,7 @@
   FIRStorageUploadTask *task =
       [[FIRStorageUploadTask alloc] initWithReference:self
                                        fetcherService:_storage.fetcherServiceForApp
+                                        dispatchQueue:_storage.dispatchQueue
                                                  file:fileURL
                                              metadata:metadata];
 
@@ -247,6 +249,7 @@
   FIRStorageDownloadTask *task =
       [[FIRStorageDownloadTask alloc] initWithReference:self
                                          fetcherService:_storage.fetcherServiceForApp
+                                          dispatchQueue:_storage.dispatchQueue
                                                    file:nil];
 
   dispatch_queue_t callbackQueue = _storage.fetcherServiceForApp.callbackQueue;
@@ -294,6 +297,7 @@
   FIRStorageDownloadTask *task =
       [[FIRStorageDownloadTask alloc] initWithReference:self
                                          fetcherService:_storage.fetcherServiceForApp
+                                          dispatchQueue:_storage.dispatchQueue
                                                    file:fileURL];
   if (completion) {
     dispatch_queue_t callbackQueue = _storage.fetcherServiceForApp.callbackQueue;
@@ -322,6 +326,7 @@
   FIRStorageGetDownloadURLTask *task =
       [[FIRStorageGetDownloadURLTask alloc] initWithReference:self
                                                fetcherService:_storage.fetcherServiceForApp
+                                                dispatchQueue:_storage.dispatchQueue
                                                    completion:completion];
   [task enqueue];
 }
@@ -332,6 +337,7 @@
   FIRStorageGetMetadataTask *task =
       [[FIRStorageGetMetadataTask alloc] initWithReference:self
                                             fetcherService:_storage.fetcherServiceForApp
+                                             dispatchQueue:_storage.dispatchQueue
                                                 completion:completion];
   [task enqueue];
 }
@@ -341,6 +347,7 @@
   FIRStorageUpdateMetadataTask *task =
       [[FIRStorageUpdateMetadataTask alloc] initWithReference:self
                                                fetcherService:_storage.fetcherServiceForApp
+                                                dispatchQueue:_storage.dispatchQueue
                                                      metadata:metadata
                                                    completion:completion];
   [task enqueue];
@@ -352,6 +359,7 @@
   FIRStorageDeleteTask *task =
       [[FIRStorageDeleteTask alloc] initWithReference:self
                                        fetcherService:_storage.fetcherServiceForApp
+                                        dispatchQueue:_storage.dispatchQueue
                                            completion:completion];
   [task enqueue];
 }

--- a/Firebase/Storage/FIRStorageTask.m
+++ b/Firebase/Storage/FIRStorageTask.m
@@ -26,6 +26,12 @@
 
 @implementation FIRStorageTask
 
+- (instancetype)init {
+  @throw [NSException exceptionWithName:@"Attempt to call unavailable initializer."
+                                 reason:@"init unavailable, use designated initializer"
+                               userInfo:nil];
+}
+
 - (instancetype)initWithReference:(FIRStorageReference *)reference
                    fetcherService:(GTMSessionFetcherService *)service
                     dispatchQueue:(dispatch_queue_t)queue {

--- a/Firebase/Storage/FIRStorageTask.m
+++ b/Firebase/Storage/FIRStorageTask.m
@@ -26,22 +26,16 @@
 
 @implementation FIRStorageTask
 
-- (instancetype)init {
-  FIRStorage *storage = [FIRStorage storage];
-  FIRStorageReference *reference = [storage reference];
-  FIRStorageTask *task =
-      [self initWithReference:reference fetcherService:storage.fetcherServiceForApp];
-  return task;
-}
-
 - (instancetype)initWithReference:(FIRStorageReference *)reference
-                   fetcherService:(GTMSessionFetcherService *)service {
+                   fetcherService:(GTMSessionFetcherService *)service
+                    dispatchQueue:(dispatch_queue_t)queue {
   self = [super init];
   if (self) {
     _reference = reference;
     _baseRequest = [FIRStorageUtils defaultRequestForPath:reference.path];
     _fetcherService = service;
     _fetcherService.maxRetryInterval = _reference.storage.maxOperationRetryTime;
+    _dispatchQueue = queue;
   }
   return self;
 }
@@ -59,6 +53,10 @@
                                                error:[self.error copy]];
     return snapshot;
   }
+}
+
+- (void)dispatchAsync:(void (^)(void))block {
+  dispatch_async(self.dispatchQueue, block);
 }
 
 @end

--- a/Firebase/Storage/FIRStorageUpdateMetadataTask.m
+++ b/Firebase/Storage/FIRStorageUpdateMetadataTask.m
@@ -48,7 +48,7 @@
   __weak FIRStorageUpdateMetadataTask *weakSelf = self;
 
   [self dispatchAsync:^() {
-      FIRStorageUpdateMetadataTask* strongSelf = weakSelf;
+    FIRStorageUpdateMetadataTask *strongSelf = weakSelf;
 
     if (!strongSelf) {
       return;

--- a/Firebase/Storage/FIRStorageUpdateMetadataTask.m
+++ b/Firebase/Storage/FIRStorageUpdateMetadataTask.m
@@ -29,9 +29,10 @@
 
 - (instancetype)initWithReference:(FIRStorageReference *)reference
                    fetcherService:(GTMSessionFetcherService *)service
+                    dispatchQueue:(dispatch_queue_t)queue
                          metadata:(FIRStorageMetadata *)metadata
                        completion:(FIRStorageVoidMetadataError)completion {
-  self = [super initWithReference:reference fetcherService:service];
+  self = [super initWithReference:reference fetcherService:service dispatchQueue:queue];
   if (self) {
     _updateMetadata = [metadata copy];
     _completion = [completion copy];
@@ -44,53 +45,62 @@
 }
 
 - (void)enqueue {
-  NSMutableURLRequest *request = [self.baseRequest mutableCopy];
-  NSDictionary *updateDictionary = [_updateMetadata updatedMetadata];
-  NSData *updateData = [NSData frs_dataFromJSONDictionary:updateDictionary];
-  request.HTTPMethod = @"PATCH";
-  request.timeoutInterval = self.reference.storage.maxOperationRetryTime;
-  request.HTTPBody = updateData;
-  NSString *typeString = @"application/json; charset=UTF-8";
-  [request setValue:typeString forHTTPHeaderField:@"Content-Type"];
-  NSString *lengthString = [NSString stringWithFormat:@"%zu", (unsigned long)[updateData length]];
-  [request setValue:lengthString forHTTPHeaderField:@"Content-Length"];
+  __weak FIRStorageUpdateMetadataTask *weakSelf = self;
 
-  FIRStorageVoidMetadataError callback = _completion;
-  _completion = nil;
+  [self dispatchAsync:^() {
+      FIRStorageUpdateMetadataTask* strongSelf = weakSelf;
 
-  GTMSessionFetcher *fetcher = [self.fetcherService fetcherWithRequest:request];
-  _fetcher = fetcher;
+    if (!strongSelf) {
+      return;
+    }
+
+    NSMutableURLRequest *request = [strongSelf.baseRequest mutableCopy];
+    NSDictionary *updateDictionary = [strongSelf->_updateMetadata updatedMetadata];
+    NSData *updateData = [NSData frs_dataFromJSONDictionary:updateDictionary];
+    request.HTTPMethod = @"PATCH";
+    request.timeoutInterval = strongSelf.reference.storage.maxOperationRetryTime;
+    request.HTTPBody = updateData;
+    NSString *typeString = @"application/json; charset=UTF-8";
+    [request setValue:typeString forHTTPHeaderField:@"Content-Type"];
+    NSString *lengthString = [NSString stringWithFormat:@"%zu", (unsigned long)[updateData length]];
+    [request setValue:lengthString forHTTPHeaderField:@"Content-Length"];
+
+    FIRStorageVoidMetadataError callback = strongSelf->_completion;
+    strongSelf->_completion = nil;
+
+    GTMSessionFetcher *fetcher = [strongSelf.fetcherService fetcherWithRequest:request];
+    strongSelf->_fetcher = fetcher;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
-  _fetcherCompletion = ^(NSData *data, NSError *error) {
-    FIRStorageMetadata *metadata;
-    if (error) {
-      if (!self.error) {
-        self.error = [FIRStorageErrors errorWithServerError:error reference:self.reference];
-      }
-    } else {
-      NSDictionary *responseDictionary = [NSDictionary frs_dictionaryFromJSONData:data];
-      if (responseDictionary) {
-        metadata = [[FIRStorageMetadata alloc] initWithDictionary:responseDictionary];
-        [metadata setType:FIRStorageMetadataTypeFile];
+    strongSelf->_fetcherCompletion = ^(NSData *data, NSError *error) {
+      FIRStorageMetadata *metadata;
+      if (error) {
+        if (!self.error) {
+          self.error = [FIRStorageErrors errorWithServerError:error reference:self.reference];
+        }
       } else {
-        self.error = [FIRStorageErrors errorWithInvalidRequest:data];
+        NSDictionary *responseDictionary = [NSDictionary frs_dictionaryFromJSONData:data];
+        if (responseDictionary) {
+          metadata = [[FIRStorageMetadata alloc] initWithDictionary:responseDictionary];
+          [metadata setType:FIRStorageMetadataTypeFile];
+        } else {
+          self.error = [FIRStorageErrors errorWithInvalidRequest:data];
+        }
       }
-    }
 
-    if (callback) {
-      callback(metadata, self.error);
-    }
-    self->_fetcherCompletion = nil;
-  };
+      if (callback) {
+        callback(metadata, self.error);
+      }
+      self->_fetcherCompletion = nil;
+    };
 #pragma clang diagnostic pop
 
-  fetcher.comment = @"UpdateMetadataTask";
+    fetcher.comment = @"UpdateMetadataTask";
 
-  __weak FIRStorageUpdateMetadataTask *weakSelf = self;
-  [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
-    weakSelf.fetcherCompletion(data, error);
+    [fetcher beginFetchWithCompletionHandler:^(NSData *data, NSError *error) {
+      weakSelf.fetcherCompletion(data, error);
+    }];
   }];
 }
 

--- a/Firebase/Storage/Private/FIRStorageDeleteTask.h
+++ b/Firebase/Storage/Private/FIRStorageDeleteTask.h
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithReference:(FIRStorageReference *)reference
                    fetcherService:(GTMSessionFetcherService *)service
+                    dispatchQueue:(dispatch_queue_t)queue
                        completion:(FIRStorageVoidError)completion;
 
 @end

--- a/Firebase/Storage/Private/FIRStorageDownloadTask_Private.h
+++ b/Firebase/Storage/Private/FIRStorageDownloadTask_Private.h
@@ -34,11 +34,13 @@ NS_ASSUME_NONNULL_BEGIN
  * Initializes a download task with a base FIRStorageReference and GTMSessionFetcherService.
  * @param reference The base FIRStorageReference which fetchers use for configuration.
  * @param service The GTMSessionFetcherService which will create fetchers.
+ * @param queue The shared queue to use for all Storage operations.
  * @param fileURL The system URL to download to. If nil, download in memory as bytes.
  * @return Returns an instance of FIRStorageDownloadTask
  */
 - (instancetype)initWithReference:(FIRStorageReference *)reference
                    fetcherService:(GTMSessionFetcherService *)service
+                    dispatchQueue:(dispatch_queue_t)queue
                              file:(nullable NSURL *)fileURL;
 
 /**

--- a/Firebase/Storage/Private/FIRStorageGetDownloadURLTask.h
+++ b/Firebase/Storage/Private/FIRStorageGetDownloadURLTask.h
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithReference:(FIRStorageReference *)reference
                    fetcherService:(GTMSessionFetcherService *)service
+                    dispatchQueue:(dispatch_queue_t)queue
                        completion:(FIRStorageVoidURLError)completion;
 
 @end

--- a/Firebase/Storage/Private/FIRStorageGetMetadataTask.h
+++ b/Firebase/Storage/Private/FIRStorageGetMetadataTask.h
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithReference:(FIRStorageReference *)reference
                    fetcherService:(GTMSessionFetcherService *)service
+                    dispatchQueue:(dispatch_queue_t)queue
                        completion:(FIRStorageVoidMetadataError)completion;
 
 @end

--- a/Firebase/Storage/Private/FIRStorageObservableTask_Private.h
+++ b/Firebase/Storage/Private/FIRStorageObservableTask_Private.h
@@ -27,10 +27,12 @@ NS_ASSUME_NONNULL_BEGIN
  * @param reference A FIRStorageReference the task will be performed on.
  * @param service A GTMSessionFetcherService which provides the fetchers and configuration for
  * requests.
+ * @param queue The shared queue to use for all Storage operations.
  * @return A new FIRStorageTask representing the current task.
  */
 - (instancetype)initWithReference:(FIRStorageReference *)reference
-                   fetcherService:(GTMSessionFetcherService *)service;
+                   fetcherService:(GTMSessionFetcherService *)service
+                    dispatchQueue:(dispatch_queue_t)queue;
 
 /**
  * Raise events for a given task status by passing along a snapshot of existing task state.

--- a/Firebase/Storage/Private/FIRStorageTask_Private.h
+++ b/Firebase/Storage/Private/FIRStorageTask_Private.h
@@ -54,6 +54,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(strong, nonatomic) FIRStorageReference *reference;
 
+/**
+ * A serial queue for all storage operations.
+ */
+@property(nonatomic, readonly) dispatch_queue_t dispatchQueue;
+
 @property(strong, readwrite, nonatomic, nonnull) FIRStorageTaskSnapshot *snapshot;
 
 @property(readonly, copy, nonatomic) NSURLRequest *baseRequest;
@@ -64,15 +69,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(readonly, copy) GTMSessionFetcherCompletionHandler fetcherCompletion;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
  * Creates a new FIRStorageTask initialized with a FIRStorageReference and GTMSessionFetcherService.
  * @param reference A FIRStorageReference the task will be performed on.
  * @param service A GTMSessionFetcherService which provides the fetchers and configuration for
  * requests.
+ * @param queue The shared queue to use for all Storage operations.
  * @return A new FIRStorageTask representing the current task.
  */
 - (instancetype)initWithReference:(FIRStorageReference *)reference
-                   fetcherService:(GTMSessionFetcherService *)service NS_DESIGNATED_INITIALIZER;
+                   fetcherService:(GTMSessionFetcherService *)service
+                    dispatchQueue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
+
+/** Dispatches a block on the shared Storage queue. */
+- (void)dispatchAsync:(void (^)(void))block;
 
 @end
 

--- a/Firebase/Storage/Private/FIRStorageUpdateMetadataTask.h
+++ b/Firebase/Storage/Private/FIRStorageUpdateMetadataTask.h
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithReference:(FIRStorageReference *)reference
                    fetcherService:(GTMSessionFetcherService *)service
+                    dispatchQueue:(dispatch_queue_t)queue
                          metadata:(FIRStorageMetadata *)metadata
                        completion:(FIRStorageVoidMetadataError)completion;
 

--- a/Firebase/Storage/Private/FIRStorageUploadTask_Private.h
+++ b/Firebase/Storage/Private/FIRStorageUploadTask_Private.h
@@ -44,11 +44,13 @@ NS_ASSUME_NONNULL_BEGIN
  * Initializes an upload task with a base FIRStorageReference and GTMSessionFetcherService.
  * @param reference The base FIRStorageReference which fetchers use for configuration.
  * @param service The GTMSessionFetcherService which will create fetchers.
+ * @param queue The shared queue to use for all Storage operations.
  * @param uploadData The NSData object to be uploaded.
  * @return Returns an instance of FIRStorageUploadTask.
  */
 - (instancetype)initWithReference:(FIRStorageReference *)reference
                    fetcherService:(GTMSessionFetcherService *)service
+                    dispatchQueue:(dispatch_queue_t)queue
                              data:(NSData *)uploadData
                          metadata:(FIRStorageMetadata *)metadata;
 
@@ -56,11 +58,13 @@ NS_ASSUME_NONNULL_BEGIN
  * Initializes an upload task with a base FIRStorageReference and GTMSessionFetcherService.
  * @param reference The base FIRStorageReference which fetchers use for configuration.
  * @param service The GTMSessionFetcherService which will create fetchers.
+ * @param queue The shared queue to use for all Storage operations.
  * @param fileURL The system file URL to upload from.
  * @return Returns an instance of FIRStorageUploadTask.
  */
 - (instancetype)initWithReference:(FIRStorageReference *)reference
                    fetcherService:(GTMSessionFetcherService *)service
+                    dispatchQueue:(dispatch_queue_t)queue
                              file:(NSURL *)fileURL
                          metadata:(FIRStorageMetadata *)metadata;
 

--- a/Firebase/Storage/Private/FIRStorage_Private.h
+++ b/Firebase/Storage/Private/FIRStorage_Private.h
@@ -25,6 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(strong, nonatomic) GTMSessionFetcherService *fetcherServiceForApp;
 
+@property(nonatomic, readonly) dispatch_queue_t dispatchQueue;
+
 @property(strong, nonatomic) NSString *storageBucket;
 
 /**


### PR DESCRIPTION
Instead of enforcing that all operations happen on the main queue, this changes the storage SDK to internally queue all operations on a serial queue.

Fixes https://github.com/firebase/firebase-ios-sdk/issues/1888
Fixes https://github.com/firebase/firebase-ios-sdk/issues/1302