### PR TITLE
Changed FDL to use compatible __typeof__() operator.

### DIFF
--- a/Firebase/DynamicLinks/FIRDLDefaultRetrievalProcessV2.m
+++ b/Firebase/DynamicLinks/FIRDLDefaultRetrievalProcessV2.m
@@ -123,11 +123,11 @@ NS_ASSUME_NONNULL_BEGIN
   }
   NSURL *uniqueMatchLinkToCheck = [self uniqueMatchLinkToCheck];
 
-  __weak typeof(self) weakSelf = self;
+  __weak __typeof__(self) weakSelf = self;
   FIRPostInstallAttributionCompletionHandler completionHandler =
       ^(NSDictionary *_Nullable dynamicLinkParameters, NSString *_Nullable matchMessage,
         NSError *_Nullable error) {
-        typeof(self) strongSelf = weakSelf;
+        __typeof__(self) strongSelf = weakSelf;
         if (!strongSelf) {
           return;
         }

--- a/Firebase/DynamicLinks/FIRDynamicLinks.m
+++ b/Firebase/DynamicLinks/FIRDynamicLinks.m
@@ -422,10 +422,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)handleUniversalLink:(NSURL *)universalLinkURL
                  completion:(FIRDynamicLinkUniversalLinkHandler)completion {
   if ([self matchesShortLinkFormat:universalLinkURL]) {
-    __weak typeof(self) weakSelf = self;
+    __weak __typeof__(self) weakSelf = self;
     [self resolveShortLink:universalLinkURL
                 completion:^(NSURL *url, NSError *error) {
-                  typeof(self) strongSelf = weakSelf;
+                  __typeof__(self) strongSelf = weakSelf;
                   if (strongSelf) {
                     FIRDynamicLink *dynamicLink = [strongSelf dynamicLinkFromCustomSchemeURL:url];
                     dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
typeof() is not supported in some C language dialects which causes
issues when integrating FDL in projects that do use non-GNU compiler modes.

For example, this causes problems when building in some versions of Unity
https://github.com/firebase/quickstart-unity/issues/228
