### PR TITLE
Use C99-compatible __typeof__ instead of typeof

### DIFF
--- a/Firestore/Source/Core/FSTFirestoreClient.mm
+++ b/Firestore/Source/Core/FSTFirestoreClient.mm
@@ -129,10 +129,10 @@ NS_ASSUME_NONNULL_BEGIN
 
     auto userPromise = std::make_shared<std::promise<User>>();
 
-    __weak typeof(self) weakSelf = self;
+    __weak __typeof__(self) weakSelf = self;
     auto credentialChangeListener = [initialized = false, userPromise, weakSelf,
                                      workerDispatchQueue](User user) mutable {
-      typeof(self) strongSelf = weakSelf;
+      __typeof__(self) strongSelf = weakSelf;
       if (!strongSelf) return;
 
       if (!initialized) {

--- a/Firestore/Source/Util/FSTClasses.h
+++ b/Firestore/Source/Util/FSTClasses.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 // original.
 #define FSTStrongify(var)                                                           \
   _Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Wshadow\"") \
-      __strong __typeof__(var) var = fstWeakPointerTo##var;                             \
+      __strong __typeof__(var) var = fstWeakPointerTo##var;                         \
   _Pragma("clang diagnostic pop")
 
 NS_ASSUME_NONNULL_END

--- a/Firestore/Source/Util/FSTClasses.h
+++ b/Firestore/Source/Util/FSTClasses.h
@@ -28,13 +28,13 @@ NS_ASSUME_NONNULL_BEGIN
                         userInfo:nil];
 
 // Declare a weak pointer to the given variable
-#define FSTWeakify(var) __weak typeof(var) fstWeakPointerTo##var = var;
+#define FSTWeakify(var) __weak __typeof__(var) fstWeakPointerTo##var = var;
 
 // Declare a strong pointer to a variable that's been FSTWeakified. This creates a shadow of the
 // original.
 #define FSTStrongify(var)                                                           \
   _Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Wshadow\"") \
-      __strong typeof(var) var = fstWeakPointerTo##var;                             \
+      __strong __typeof__(var) var = fstWeakPointerTo##var;                             \
   _Pragma("clang diagnostic pop")
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
`typeof` is only defined if you compile with GNU extensions, while
`__typeof__` is always available.

This is the Firestore equivalent of #1982.

Note that Firestore won't yet build in this mode because among other
things the Objective-C gRPC still uses `typeof`. Once we eliminate that
dependency this might become possible.