### PR TITLE
Increase timeout for testDispatchAfterDelay

### DIFF
--- a/Example/Auth/Tests/FIRAuthDispatcherTests.m
+++ b/Example/Auth/Tests/FIRAuthDispatcherTests.m
@@ -32,7 +32,7 @@ NSTimeInterval kTestDelay = 0.1;
 /** @var kExpectationTimeout
     @brief The maximum time waiting for expectations to fulfill.
  */
-static const NSTimeInterval kExpectationTimeout = 2;
+static const NSTimeInterval kExpectationTimeout = 3;
 
 id<OS_dispatch_queue> testWorkQueue;
 


### PR DESCRIPTION
The testDispatchAfterDelay test has flaked three times today in the mac travis tests. Try increasing the timeout.