### PR TITLE
Comply with c99 standard

### DIFF
--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -55,6 +55,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
     'Firebase/Auth/CHANGELOG.md'
   ]
   s.pod_target_xcconfig = {
+    'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'GCC_PREPROCESSOR_DEFINITIONS' =>
       'FIRAuth_VERSION=' + s.version.to_s +
       ' FIRAuth_MINOR_VERSION=' + s.version.to_s.split(".")[0] + "." + s.version.to_s.split(".")[1]

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -32,8 +32,9 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   ]
   s.dependency 'GoogleUtilities/Logger', '~> 5.2'
   s.pod_target_xcconfig = {
-    'OTHER_CFLAGS' => '-fno-autolink',
+    'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'GCC_PREPROCESSOR_DEFINITIONS' =>
-      'FIRCore_VERSION=' + s.version.to_s + ' Firebase_VERSION=5.10.0'
+      'FIRCore_VERSION=' + s.version.to_s + ' Firebase_VERSION=5.10.0',
+    'OTHER_CFLAGS' => '-fno-autolink'
   }
 end

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -34,6 +34,8 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.dependency 'leveldb-library', '~> 1.18'
   s.dependency 'FirebaseCore', '~> 5.0'
   s.pod_target_xcconfig = {
+    'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'GCC_PREPROCESSOR_DEFINITIONS' =>
-      'FIRDatabase_VERSION=' + s.version.to_s }
+      'FIRDatabase_VERSION=' + s.version.to_s
+  }
 end

--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -35,8 +35,9 @@ Firebase Dynamic Links are deep links that enhance user experience and increase 
   s.ios.dependency 'FirebaseAnalyticsInterop', '~> 1.0'
 
   s.pod_target_xcconfig = {
-    'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"/Firebase',
+    'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'GCC_PREPROCESSOR_DEFINITIONS' => 'FIRDynamicLinks_VERSION=' + s.version.to_s +
-                                      ' FIRDynamicLinks3P GIN_SCION_LOGGING'
+                                      ' FIRDynamicLinks3P GIN_SCION_LOGGING',
+    'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"/Firebase'
   }
 end

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -60,6 +60,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.frameworks = 'MobileCoreServices', 'SystemConfiguration'
   s.library = 'c++'
   s.pod_target_xcconfig = {
+    'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'GCC_PREPROCESSOR_DEFINITIONS' =>
       "FIRFirestore_VERSION=#{s.version} " +
       'GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1 ' +

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -26,4 +26,8 @@ iOS SDK for Cloud Functions for Firebase.
 
   s.dependency 'FirebaseCore', '~> 5.0'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
+
+  s.pod_target_xcconfig = {
+    'GCC_C_LANGUAGE_STANDARD' => 'c99'
+  }
 end

--- a/FirebaseInAppMessagingDisplay.podspec
+++ b/FirebaseInAppMessagingDisplay.podspec
@@ -33,7 +33,9 @@ Firebase In-App Messaging SDK.
                                    base_dir + 'Resources/*.png']
   }
 
-  s.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' =>
+  s.pod_target_xcconfig = {
+    'GCC_C_LANGUAGE_STANDARD' => 'c99',
+    'GCC_PREPROCESSOR_DEFINITIONS' =>
       '$(inherited) ' +
       'FIRInAppMessagingDisplay_LIB_VERSION=' + String(s.version)
   }

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -31,6 +31,7 @@ device, and it is completely free.
   s.public_header_files = base_dir + 'Public/*.h'
   s.library = 'sqlite3'
   s.pod_target_xcconfig = {
+    'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'GCC_PREPROCESSOR_DEFINITIONS' =>
       'GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1 ' +
       'FIRMessaging_LIB_VERSION=' + String(s.version)

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -33,6 +33,8 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   s.dependency 'FirebaseCore', '~> 5.1'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
   s.pod_target_xcconfig = {
+    'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'GCC_PREPROCESSOR_DEFINITIONS' =>
-      'FIRStorage_VERSION=' + s.version.to_s }
+      'FIRStorage_VERSION=' + s.version.to_s
+  }
 end

--- a/scripts/if_changed.sh
+++ b/scripts/if_changed.sh
@@ -59,7 +59,7 @@ else
       ;;
 
     Firestore-xcodebuild|Firestore-pod-lib-lint)
-      check_changes '^Firestore'
+      check_changes '^(Firestore|FirebaseFirestore.podspec|FirebaseFirestoreSwift.podspec)'
       ;;
 
     Firestore-cmake)


### PR DESCRIPTION
Fix #1983

Enforce c99 compliance for Unity compatibility and future portability

Also:
- Sort pod_target_xcconfig keys
- Fix formatting
- Trigger travis for Firestore podspec changes