### PR TITLE
 Remove unnecessary notification flag

### DIFF
--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -721,6 +721,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   id configurationMock = OCMClassMock([FIRAnalyticsConfiguration class]);
   OCMStub([configurationMock sharedInstance]).andReturn(configurationMock);
   OCMStub([configurationMock setAnalyticsCollectionEnabled:OCMOCK_ANY persistSetting:OCMOCK_ANY]);
+  OCMStub([self.optionsInstanceMock isAnalyticsCollectionExpicitlySet]).andReturn(NO);
 
   // Ensure Analytics is set after the global flag is set.
   [[FIRApp defaultApp] setDataCollectionDefaultEnabled:YES];

--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -23,9 +23,6 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 
 @interface FIRApp (TestInternal)
 
-@property(nonatomic) BOOL alreadySentConfigureNotification;
-@property(nonatomic) BOOL alreadySentDeleteNotification;
-
 + (void)resetApps;
 - (instancetype)initInstanceWithName:(NSString *)name options:(FIROptions *)options;
 - (BOOL)configureCore;
@@ -98,7 +95,6 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   XCTAssertEqualObjects(self.app.name, kFIRDefaultAppName);
   XCTAssertEqualObjects(self.app.options.clientID, kClientID);
   XCTAssertTrue([FIRApp allApps].count == 1);
-  XCTAssertTrue(self.app.alreadySentConfigureNotification);
 
   // Test if options is nil
   id optionsClassMock = OCMClassMock([FIROptions class]);
@@ -268,7 +264,6 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   }];
 
   OCMVerifyAll(self.observerMock);
-  XCTAssertTrue(self.app.alreadySentDeleteNotification);
   XCTAssertTrue([FIRApp allApps].count == 0);
 }
 
@@ -726,7 +721,6 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   id configurationMock = OCMClassMock([FIRAnalyticsConfiguration class]);
   OCMStub([configurationMock sharedInstance]).andReturn(configurationMock);
   OCMStub([configurationMock setAnalyticsCollectionEnabled:OCMOCK_ANY persistSetting:OCMOCK_ANY]);
-  OCMStub([self.optionsInstanceMock isAnalyticsCollectionExpicitlySet]).andReturn(NO);
 
   // Ensure Analytics is set after the global flag is set.
   [[FIRApp defaultApp] setDataCollectionDefaultEnabled:YES];

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -143,8 +143,7 @@ static NSMutableDictionary *sLibraryVersions;
 + (void)configureDefaultAppWithOptions:(FIROptions *)options
                   sendingNotifications:(BOOL)sendNotifications {
   if (sDefaultApp) {
-    [NSException raise:kFirebaseCoreErrorDomain
-                format:@"Default app has already been configured."];
+    [NSException raise:kFirebaseCoreErrorDomain format:@"Default app has already been configured."];
   }
   @synchronized(self) {
     FIRLogDebug(kFIRLoggerCore, @"I-COR000001", @"Configuring the default app.");

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -143,9 +143,6 @@ static NSMutableDictionary *sLibraryVersions;
 + (void)configureDefaultAppWithOptions:(FIROptions *)options
                   sendingNotifications:(BOOL)sendNotifications {
   if (sDefaultApp) {
-    // FIRApp sets up FirebaseAnalytics and does plist validation, but does not cause it
-    // to fire notifications. So, if the default app already exists, but has not sent out
-    // configuration notifications, then continue re-initializing it.
     [NSException raise:kFirebaseCoreErrorDomain
                 format:@"Default app has already been configured."];
   }

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -85,10 +85,6 @@ static NSMutableArray<Class<FIRCoreConfigurable>> *gRegisteredAsConfigurable;
 
 @interface FIRApp ()
 
-@property(nonatomic) BOOL alreadySentConfigureNotification;
-
-@property(nonatomic) BOOL alreadySentDeleteNotification;
-
 #ifdef DEBUG
 @property(nonatomic) BOOL alreadyOutputDataCollectionFlag;
 #endif  // DEBUG
@@ -150,19 +146,14 @@ static NSMutableDictionary *sLibraryVersions;
     // FIRApp sets up FirebaseAnalytics and does plist validation, but does not cause it
     // to fire notifications. So, if the default app already exists, but has not sent out
     // configuration notifications, then continue re-initializing it.
-    if (!sendNotifications || sDefaultApp.alreadySentConfigureNotification) {
-      [NSException raise:kFirebaseCoreErrorDomain
-                  format:@"Default app has already been configured."];
-    }
+    [NSException raise:kFirebaseCoreErrorDomain
+                format:@"Default app has already been configured."];
   }
   @synchronized(self) {
     FIRLogDebug(kFIRLoggerCore, @"I-COR000001", @"Configuring the default app.");
     sDefaultApp = [[FIRApp alloc] initInstanceWithName:kFIRDefaultAppName options:options];
     [FIRApp addAppToAppDictionary:sDefaultApp];
-    if (!sDefaultApp.alreadySentConfigureNotification && sendNotifications) {
-      [FIRApp sendNotificationsToSDKs:sDefaultApp];
-      sDefaultApp.alreadySentConfigureNotification = YES;
-    }
+    [FIRApp sendNotificationsToSDKs:sDefaultApp];
   }
 }
 
@@ -196,10 +187,7 @@ static NSMutableDictionary *sLibraryVersions;
     FIRLogDebug(kFIRLoggerCore, @"I-COR000002", @"Configuring app named %@", name);
     FIRApp *app = [[FIRApp alloc] initInstanceWithName:name options:options];
     [FIRApp addAppToAppDictionary:app];
-    if (!app.alreadySentConfigureNotification) {
-      [FIRApp sendNotificationsToSDKs:app];
-      app.alreadySentConfigureNotification = YES;
-    }
+    [FIRApp sendNotificationsToSDKs:app];
   }
 }
 
@@ -259,13 +247,10 @@ static NSMutableDictionary *sLibraryVersions;
       if ([self.name isEqualToString:kFIRDefaultAppName]) {
         sDefaultApp = nil;
       }
-      if (!self.alreadySentDeleteNotification) {
-        NSDictionary *appInfoDict = @{kFIRAppNameKey : self.name};
-        [[NSNotificationCenter defaultCenter] postNotificationName:kFIRAppDeleteNotification
-                                                            object:[self class]
-                                                          userInfo:appInfoDict];
-        self.alreadySentDeleteNotification = YES;
-      }
+      NSDictionary *appInfoDict = @{kFIRAppNameKey : self.name};
+      [[NSNotificationCenter defaultCenter] postNotificationName:kFIRAppDeleteNotification
+                                                          object:[self class]
+                                                        userInfo:appInfoDict];
       completion(YES);
     } else {
       FIRLogError(kFIRLoggerCore, @"I-COR000007", @"App does not exist.");
@@ -296,10 +281,6 @@ static NSMutableDictionary *sLibraryVersions;
     _options.editingLocked = YES;
     _isDefaultApp = [name isEqualToString:kFIRDefaultAppName];
     _container = [[FIRComponentContainer alloc] initWithApp:self];
-
-    FIRApp *app = sAllApps[name];
-    _alreadySentConfigureNotification = app.alreadySentConfigureNotification;
-    _alreadySentDeleteNotification = app.alreadySentDeleteNotification;
   }
   return self;
 }


### PR DESCRIPTION
This was added when the Google pod could configure Firebase but the
Google pod is deprecated and can only work with Firebase 3.X. These
flags and conditional checks can be safely removed.