### PR TITLE
Reduce singleton usage in FIRApp tests.

### DIFF
--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -48,9 +48,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 @interface FIRAppTest : FIRTestCase
 
 @property(nonatomic) id appClassMock;
-@property(nonatomic) id optionsInstanceMock;
 @property(nonatomic) id observerMock;
-@property(nonatomic) FIRApp *app;
 @property(nonatomic) NSNotificationCenter *notificationCenter;
 
 @end
@@ -62,7 +60,6 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   [FIROptions resetDefaultOptions];
   [FIRApp resetApps];
   _appClassMock = OCMClassMock([FIRApp class]);
-  _optionsInstanceMock = OCMPartialMock([FIROptions defaultOptions]);
   _observerMock = OCMObserverMock();
 
   // TODO: Remove all usages of defaultCenter in Core, then we can instantiate an instance here to
@@ -72,7 +69,6 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 
 - (void)tearDown {
   [_appClassMock stopMocking];
-  [_optionsInstanceMock stopMocking];
   [_notificationCenter removeObserver:_observerMock];
   _observerMock = nil;
   _notificationCenter = nil;
@@ -90,22 +86,23 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   XCTAssertNoThrow([FIRApp configure]);
   OCMVerifyAll(self.observerMock);
 
-  self.app = [FIRApp defaultApp];
-  XCTAssertNotNil(self.app);
-  XCTAssertEqualObjects(self.app.name, kFIRDefaultAppName);
-  XCTAssertEqualObjects(self.app.options.clientID, kClientID);
+  FIRApp *app = [FIRApp defaultApp];
+  XCTAssertNotNil(app);
+  XCTAssertEqualObjects(app.name, kFIRDefaultAppName);
+  XCTAssertEqualObjects(app.options.clientID, kClientID);
   XCTAssertTrue([FIRApp allApps].count == 1);
+}
 
-  // Test if options is nil
+- (void)testConfigureWithNoDefaultOptions {
   id optionsClassMock = OCMClassMock([FIROptions class]);
   OCMStub([optionsClassMock defaultOptions]).andReturn(nil);
   XCTAssertThrows([FIRApp configure]);
 }
 
 - (void)testConfigureWithOptions {
-// nil options
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
+  // Test `nil` options.
   XCTAssertThrows([FIRApp configureWithOptions:nil]);
 #pragma clang diagnostic pop
   XCTAssertTrue([FIRApp allApps].count == 0);
@@ -116,50 +113,35 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
                      notificationName:kFIRAppReadyToConfigureSDKNotification
                                object:[FIRApp class]
                              userInfo:expectedUserInfo];
-  // default options
-  XCTAssertNoThrow([FIRApp configureWithOptions:[FIROptions defaultOptions]]);
-  OCMVerifyAll(self.observerMock);
 
-  self.app = [FIRApp defaultApp];
-  XCTAssertNotNil(self.app);
-  XCTAssertEqualObjects(self.app.name, kFIRDefaultAppName);
-  XCTAssertEqualObjects(self.app.options.clientID, kClientID);
-  XCTAssertTrue([FIRApp allApps].count == 1);
-}
-
-- (void)testConfigureWithCustomizedOptions {
-  // valid customized options
+  // Use a valid instance of options.
   FIROptions *options =
       [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
-  options.bundleID = kBundleID;
-  options.APIKey = kCustomizedAPIKey;
-  NSDictionary *expectedUserInfo =
-      [self expectedUserInfoWithAppName:kFIRDefaultAppName isDefaultApp:YES];
-  [self expectNotificationForObserver:self.observerMock
-                     notificationName:kFIRAppReadyToConfigureSDKNotification
-                               object:[FIRApp class]
-                             userInfo:expectedUserInfo];
-
+  options.clientID = kClientID;
   XCTAssertNoThrow([FIRApp configureWithOptions:options]);
   OCMVerifyAll(self.observerMock);
 
-  self.app = [FIRApp defaultApp];
-  XCTAssertNotNil(self.app);
-  XCTAssertEqualObjects(self.app.name, kFIRDefaultAppName);
-  XCTAssertEqualObjects(self.app.options.googleAppID, kGoogleAppID);
-  XCTAssertEqualObjects(self.app.options.APIKey, kCustomizedAPIKey);
+  // Verify the default app instance is created.
+  FIRApp *app = [FIRApp defaultApp];
+  XCTAssertNotNil(app);
+  XCTAssertEqualObjects(app.name, kFIRDefaultAppName);
+  XCTAssertEqualObjects(app.options.googleAppID, kGoogleAppID);
+  XCTAssertEqualObjects(app.options.GCMSenderID, kGCMSenderID);
+  XCTAssertEqualObjects(app.options.clientID, kClientID);
   XCTAssertTrue([FIRApp allApps].count == 1);
 }
 
 - (void)testConfigureWithNameAndOptions {
+  FIROptions *options =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+  options.clientID = kClientID;
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
-  XCTAssertThrows([FIRApp configureWithName:nil options:[FIROptions defaultOptions]]);
+  XCTAssertThrows([FIRApp configureWithName:nil options:options]);
   XCTAssertThrows([FIRApp configureWithName:kFIRTestAppName1 options:nil]);
 #pragma clang diagnostic pop
-  XCTAssertThrows([FIRApp configureWithName:@"" options:[FIROptions defaultOptions]]);
-  XCTAssertThrows(
-      [FIRApp configureWithName:kFIRDefaultAppName options:[FIROptions defaultOptions]]);
+  XCTAssertThrows([FIRApp configureWithName:@"" options:options]);
   XCTAssertTrue([FIRApp allApps].count == 0);
 
   NSDictionary *expectedUserInfo =
@@ -168,23 +150,23 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
                      notificationName:kFIRAppReadyToConfigureSDKNotification
                                object:[FIRApp class]
                              userInfo:expectedUserInfo];
-  XCTAssertNoThrow([FIRApp configureWithName:kFIRTestAppName1 options:[FIROptions defaultOptions]]);
+  XCTAssertNoThrow([FIRApp configureWithName:kFIRTestAppName1 options:options]);
   OCMVerifyAll(self.observerMock);
 
   XCTAssertTrue([FIRApp allApps].count == 1);
-  self.app = [FIRApp appNamed:kFIRTestAppName1];
-  XCTAssertNotNil(self.app);
-  XCTAssertEqualObjects(self.app.name, kFIRTestAppName1);
-  XCTAssertEqualObjects(self.app.options.clientID, kClientID);
+  FIRApp *app = [FIRApp appNamed:kFIRTestAppName1];
+  XCTAssertNotNil(app);
+  XCTAssertEqualObjects(app.name, kFIRTestAppName1);
+  XCTAssertEqualObjects(app.options.clientID, kClientID);
 
   // Configure the same app again should throw an exception.
-  XCTAssertThrows([FIRApp configureWithName:kFIRTestAppName1 options:[FIROptions defaultOptions]]);
+  XCTAssertThrows([FIRApp configureWithName:kFIRTestAppName1 options:options]);
 }
 
-- (void)testConfigureWithNameAndCustomizedOptions {
-  FIROptions *options = [FIROptions defaultOptions];
-  FIROptions *newOptions = [options copy];
-  newOptions.deepLinkURLScheme = kDeepLinkURLScheme;
+- (void)testConfigureWithMultipleApps {
+  FIROptions *options1 =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+  options1.deepLinkURLScheme = kDeepLinkURLScheme;
 
   // Set up notification center observer for verifying notifications.
   [self.notificationCenter addMockObserver:self.observerMock
@@ -196,15 +178,14 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   [[self.observerMock expect] notificationWithName:kFIRAppReadyToConfigureSDKNotification
                                             object:[FIRApp class]
                                           userInfo:expectedUserInfo1];
-  XCTAssertNoThrow([FIRApp configureWithName:kFIRTestAppName1 options:newOptions]);
+  XCTAssertNoThrow([FIRApp configureWithName:kFIRTestAppName1 options:options1]);
   XCTAssertTrue([FIRApp allApps].count == 1);
-  self.app = [FIRApp appNamed:kFIRTestAppName1];
 
-  // Configure a different app with valid customized options
-  FIROptions *customizedOptions =
+  // Configure a different app with valid customized options.
+  FIROptions *options2 =
       [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
-  customizedOptions.bundleID = kBundleID;
-  customizedOptions.APIKey = kCustomizedAPIKey;
+  options2.bundleID = kBundleID;
+  options2.APIKey = kCustomizedAPIKey;
 
   NSDictionary *expectedUserInfo2 =
       [self expectedUserInfoWithAppName:kFIRTestAppName2 isDefaultApp:NO];
@@ -213,15 +194,15 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
                                           userInfo:expectedUserInfo2];
 
   [self.observerMock setExpectationOrderMatters:YES];
-  XCTAssertNoThrow([FIRApp configureWithName:kFIRTestAppName2 options:customizedOptions]);
+  XCTAssertNoThrow([FIRApp configureWithName:kFIRTestAppName2 options:options2]);
   OCMVerifyAll(self.observerMock);
 
   XCTAssertTrue([FIRApp allApps].count == 2);
-  self.app = [FIRApp appNamed:kFIRTestAppName2];
-  XCTAssertNotNil(self.app);
-  XCTAssertEqualObjects(self.app.name, kFIRTestAppName2);
-  XCTAssertEqualObjects(self.app.options.googleAppID, kGoogleAppID);
-  XCTAssertEqualObjects(self.app.options.APIKey, kCustomizedAPIKey);
+  FIRApp *app = [FIRApp appNamed:kFIRTestAppName2];
+  XCTAssertNotNil(app);
+  XCTAssertEqualObjects(app.name, kFIRTestAppName2);
+  XCTAssertEqualObjects(app.options.googleAppID, kGoogleAppID);
+  XCTAssertEqualObjects(app.options.APIKey, kCustomizedAPIKey);
 }
 
 - (void)testValidName {
@@ -232,37 +213,45 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 }
 
 - (void)testDefaultApp {
-  self.app = [FIRApp defaultApp];
-  XCTAssertNil(self.app);
+  FIRApp *app = [FIRApp defaultApp];
+  XCTAssertNil(app);
 
   [FIRApp configure];
-  self.app = [FIRApp defaultApp];
-  XCTAssertEqualObjects(self.app.name, kFIRDefaultAppName);
-  XCTAssertEqualObjects(self.app.options.clientID, kClientID);
+  app = [FIRApp defaultApp];
+  XCTAssertEqualObjects(app.name, kFIRDefaultAppName);
+  XCTAssertEqualObjects(app.options.clientID, kClientID);
 }
 
 - (void)testAppNamed {
-  self.app = [FIRApp appNamed:kFIRTestAppName1];
-  XCTAssertNil(self.app);
+  FIRApp *app = [FIRApp appNamed:kFIRTestAppName1];
+  XCTAssertNil(app);
 
   [FIRApp configureWithName:kFIRTestAppName1 options:[FIROptions defaultOptions]];
-  self.app = [FIRApp appNamed:kFIRTestAppName1];
-  XCTAssertEqualObjects(self.app.name, kFIRTestAppName1);
-  XCTAssertEqualObjects(self.app.options.clientID, kClientID);
+  app = [FIRApp appNamed:kFIRTestAppName1];
+  XCTAssertEqualObjects(app.name, kFIRTestAppName1);
+  XCTAssertEqualObjects(app.options.clientID, kClientID);
 }
 
 - (void)testDeleteApp {
-  [FIRApp configure];
-  self.app = [FIRApp defaultApp];
+  NSString *name = NSStringFromSelector(_cmd);
+  FIROptions *options =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+  [FIRApp configureWithName:name options:options];
+  FIRApp *app = [FIRApp appNamed:name];
+  XCTAssertNotNil(app);
   XCTAssertTrue([FIRApp allApps].count == 1);
   [self expectNotificationForObserver:self.observerMock
                      notificationName:kFIRAppDeleteNotification
                                object:[FIRApp class]
                              userInfo:[OCMArg any]];
-  [self.app deleteApp:^(BOOL success) {
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Deleting the app should succeed."];
+  [app deleteApp:^(BOOL success) {
     XCTAssertTrue(success);
+    [expectation fulfill];
   }];
 
+  [self waitForExpectations:@[ expectation ] timeout:1];
   OCMVerifyAll(self.observerMock);
   XCTAssertTrue([FIRApp allApps].count == 0);
 }
@@ -331,25 +320,6 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
                   "'getTokenImplementation' block correctly.");
 }
 
-- (void)testModifyingOptionsThrows {
-  [FIRApp configure];
-  FIROptions *options = [[FIRApp defaultApp] options];
-  XCTAssertTrue(options.isEditingLocked);
-
-  // Modification to every property should result in an exception.
-  XCTAssertThrows(options.androidClientID = @"should_throw");
-  XCTAssertThrows(options.APIKey = @"should_throw");
-  XCTAssertThrows(options.bundleID = @"should_throw");
-  XCTAssertThrows(options.clientID = @"should_throw");
-  XCTAssertThrows(options.databaseURL = @"should_throw");
-  XCTAssertThrows(options.deepLinkURLScheme = @"should_throw");
-  XCTAssertThrows(options.GCMSenderID = @"should_throw");
-  XCTAssertThrows(options.googleAppID = @"should_throw");
-  XCTAssertThrows(options.projectID = @"should_throw");
-  XCTAssertThrows(options.storageBucket = @"should_throw");
-  XCTAssertThrows(options.trackingID = @"should_throw");
-}
-
 - (void)testOptionsLocking {
   FIROptions *options =
       [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
@@ -360,8 +330,9 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   XCTAssertFalse(options.isEditingLocked);
 
   // The options returned should be locked after configuring `FIRApp`.
-  [FIRApp configureWithOptions:options];
-  FIROptions *optionsCopy = [[FIRApp defaultApp] options];
+  NSString *name = NSStringFromSelector(_cmd);
+  [FIRApp configureWithName:name options:options];
+  FIROptions *optionsCopy = [[FIRApp appNamed:name] options];
   XCTAssertTrue(optionsCopy.isEditingLocked);
 }
 
@@ -411,16 +382,18 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 
 - (void)testAppIDValidationTrue {
   // Ensure that isAppIDValid matches validateAppID.
-  [FIRApp configure];
+  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:@"" GCMSenderID:@""];
+  FIRApp *app = [[FIRApp alloc] initInstanceWithName:NSStringFromSelector(_cmd) options:options];
   OCMStub([self.appClassMock validateAppID:[OCMArg any]]).andReturn(YES);
-  XCTAssertTrue([[FIRApp defaultApp] isAppIDValid]);
+  XCTAssertTrue([app isAppIDValid]);
 }
 
 - (void)testAppIDValidationFalse {
   // Ensure that isAppIDValid matches validateAppID.
-  [FIRApp configure];
+  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:@"" GCMSenderID:@""];
+  FIRApp *app = [[FIRApp alloc] initInstanceWithName:NSStringFromSelector(_cmd) options:options];
   OCMStub([self.appClassMock validateAppID:[OCMArg any]]).andReturn(NO);
-  XCTAssertFalse([[FIRApp defaultApp] isAppIDValid]);
+  XCTAssertFalse([app isAppIDValid]);
 }
 
 - (void)testAppIDPrefix {
@@ -576,85 +549,108 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 
 - (void)testGlobalDataCollectionNoFlags {
   // Test: No flags set.
-  [FIRApp configure];
+  NSString *name = NSStringFromSelector(_cmd);
+  FIROptions *options =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+  FIRApp *app = [[FIRApp alloc] initInstanceWithName:name options:options];
   OCMStub([self.appClassMock readDataCollectionSwitchFromPlist]).andReturn(nil);
   OCMStub([self.appClassMock readDataCollectionSwitchFromUserDefaultsForApp:OCMOCK_ANY])
       .andReturn(nil);
 
-  XCTAssertTrue([FIRApp defaultApp].isDataCollectionDefaultEnabled);
+  XCTAssertTrue(app.isDataCollectionDefaultEnabled);
 }
 
 - (void)testGlobalDataCollectionPlistSetEnabled {
   // Test: Plist set to enabled, no override.
-  [FIRApp configure];
+  NSString *name = NSStringFromSelector(_cmd);
+  FIROptions *options =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+  FIRApp *app = [[FIRApp alloc] initInstanceWithName:name options:options];
   OCMStub([self.appClassMock readDataCollectionSwitchFromPlist]).andReturn(@YES);
   OCMStub([self.appClassMock readDataCollectionSwitchFromUserDefaultsForApp:OCMOCK_ANY])
       .andReturn(nil);
 
-  XCTAssertTrue([FIRApp defaultApp].isDataCollectionDefaultEnabled);
+  XCTAssertTrue(app.isDataCollectionDefaultEnabled);
 }
 
 - (void)testGlobalDataCollectionPlistSetDisabled {
   // Test: Plist set to disabled, no override.
-  [FIRApp configure];
+  NSString *name = NSStringFromSelector(_cmd);
+  FIROptions *options =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+  FIRApp *app = [[FIRApp alloc] initInstanceWithName:name options:options];
   OCMStub([self.appClassMock readDataCollectionSwitchFromPlist]).andReturn(@NO);
   OCMStub([self.appClassMock readDataCollectionSwitchFromUserDefaultsForApp:OCMOCK_ANY])
       .andReturn(nil);
 
-  XCTAssertFalse([FIRApp defaultApp].isDataCollectionDefaultEnabled);
+  XCTAssertFalse(app.isDataCollectionDefaultEnabled);
 }
 
 - (void)testGlobalDataCollectionUserSpecifiedEnabled {
   // Test: User specified as enabled, no plist value.
-  [FIRApp configure];
+  NSString *name = NSStringFromSelector(_cmd);
+  FIROptions *options =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+  FIRApp *app = [[FIRApp alloc] initInstanceWithName:name options:options];
   OCMStub([self.appClassMock readDataCollectionSwitchFromPlist]).andReturn(nil);
   OCMStub([self.appClassMock readDataCollectionSwitchFromUserDefaultsForApp:OCMOCK_ANY])
       .andReturn(@YES);
 
-  XCTAssertTrue([FIRApp defaultApp].isDataCollectionDefaultEnabled);
+  XCTAssertTrue(app.isDataCollectionDefaultEnabled);
 }
 
 - (void)testGlobalDataCollectionUserSpecifiedDisabled {
   // Test: User specified as disabled, no plist value.
-  [FIRApp configure];
+  NSString *name = NSStringFromSelector(_cmd);
+  FIROptions *options =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+  FIRApp *app = [[FIRApp alloc] initInstanceWithName:name options:options];
   OCMStub([self.appClassMock readDataCollectionSwitchFromPlist]).andReturn(nil);
   OCMStub([self.appClassMock readDataCollectionSwitchFromUserDefaultsForApp:OCMOCK_ANY])
       .andReturn(@NO);
 
-  XCTAssertFalse([FIRApp defaultApp].isDataCollectionDefaultEnabled);
+  XCTAssertFalse(app.isDataCollectionDefaultEnabled);
 }
 
 - (void)testGlobalDataCollectionUserOverriddenEnabled {
   // Test: User specified as enabled, with plist set as disabled.
-  [FIRApp configure];
+  NSString *name = NSStringFromSelector(_cmd);
+  FIROptions *options =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+  FIRApp *app = [[FIRApp alloc] initInstanceWithName:name options:options];
   OCMStub([self.appClassMock readDataCollectionSwitchFromPlist]).andReturn(@NO);
   OCMStub([self.appClassMock readDataCollectionSwitchFromUserDefaultsForApp:OCMOCK_ANY])
       .andReturn(@YES);
 
-  XCTAssertTrue([FIRApp defaultApp].isDataCollectionDefaultEnabled);
+  XCTAssertTrue(app.isDataCollectionDefaultEnabled);
 }
 
 - (void)testGlobalDataCollectionUserOverriddenDisabled {
   // Test: User specified as disabled, with plist set as enabled.
-  [FIRApp configure];
+  NSString *name = NSStringFromSelector(_cmd);
+  FIROptions *options =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+  FIRApp *app = [[FIRApp alloc] initInstanceWithName:name options:options];
   OCMStub([self.appClassMock readDataCollectionSwitchFromPlist]).andReturn(@YES);
   OCMStub([self.appClassMock readDataCollectionSwitchFromUserDefaultsForApp:OCMOCK_ANY])
       .andReturn(@NO);
 
-  XCTAssertFalse([FIRApp defaultApp].isDataCollectionDefaultEnabled);
+  XCTAssertFalse(app.isDataCollectionDefaultEnabled);
 }
 
 - (void)testGlobalDataCollectionWriteToDefaults {
   id defaultsMock = OCMPartialMock([NSUserDefaults standardUserDefaults]);
-  [FIRApp configure];
-
-  FIRApp *app = [FIRApp defaultApp];
+  NSString *name = NSStringFromSelector(_cmd);
+  FIROptions *options =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+  [FIRApp configureWithName:name options:options];
+  FIRApp *app = [FIRApp appNamed:name];
   app.dataCollectionDefaultEnabled = YES;
   NSString *key =
       [NSString stringWithFormat:kFIRGlobalAppDataCollectionEnabledDefaultsKeyFormat, app.name];
   OCMVerify([defaultsMock setObject:@YES forKey:key]);
 
-  [FIRApp defaultApp].dataCollectionDefaultEnabled = NO;
+  app.dataCollectionDefaultEnabled = NO;
   OCMVerify([defaultsMock setObject:@NO forKey:key]);
 
   [defaultsMock stopMocking];
@@ -662,8 +658,11 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 
 - (void)testGlobalDataCollectionClearedAfterDelete {
   // Configure and disable data collection for the default FIRApp.
-  [FIRApp configure];
-  FIRApp *app = [FIRApp defaultApp];
+  NSString *name = NSStringFromSelector(_cmd);
+  FIROptions *options =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+  [FIRApp configureWithName:name options:options];
+  FIRApp *app = [FIRApp appNamed:name];
   app.dataCollectionDefaultEnabled = NO;
   XCTAssertFalse(app.isDataCollectionDefaultEnabled);
 
@@ -671,25 +670,26 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   XCTestExpectation *deleteFinished =
       [self expectationWithDescription:@"The app should successfully delete."];
   [app deleteApp:^(BOOL success) {
-    if (success) {
-      [deleteFinished fulfill];
-    }
+    XCTAssertTrue(success);
+    [deleteFinished fulfill];
   }];
 
   // Wait for the delete to complete.
   [self waitForExpectations:@[ deleteFinished ] timeout:1];
 
-  // Set up the default app again, and check the data collection flag.
-  [FIRApp configure];
-  XCTAssertTrue([FIRApp defaultApp].isDataCollectionDefaultEnabled);
+  // Set up an app with the same name again, and check the data collection flag.
+  [FIRApp configureWithName:name options:options];
+  XCTAssertTrue([FIRApp appNamed:name].isDataCollectionDefaultEnabled);
 }
 
 - (void)testGlobalDataCollectionNoDiagnosticsSent {
-  // Add an observer for the diagnostics notification - both with and without an object to ensure it
-  // catches it either way. Currently no object is sent, but in the future that could change.
-  [self.notificationCenter addMockObserver:self.observerMock
-                                      name:kFIRAppDiagnosticsNotification
-                                    object:nil];
+  FIROptions *options =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+  FIRApp *app = [[FIRApp alloc] initInstanceWithName:NSStringFromSelector(_cmd) options:options];
+  app.dataCollectionDefaultEnabled = NO;
+
+  // Add an observer for the diagnostics notification. Currently no object is sent, but in the
+  // future that could change so leave it as OCMOCK_ANY.
   [self.notificationCenter addMockObserver:self.observerMock
                                       name:kFIRAppDiagnosticsNotification
                                     object:OCMOCK_ANY];
@@ -704,7 +704,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   [FIRApp configure];
 
   NSError *error = [NSError errorWithDomain:@"com.firebase" code:42 userInfo:nil];
-  [[FIRApp defaultApp] sendLogsWithServiceName:@"Service" version:@"Version" error:error];
+  [app sendLogsWithServiceName:@"Service" version:@"Version" error:error];
 
   // The observer mock is strict and will raise an exception when an unexpected notification is
   // received.
@@ -716,35 +716,39 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 - (void)testAnalyticsSetByGlobalDataCollectionSwitch {
   // Test that the global data collection switch triggers setting Analytics when no explicit flag is
   // set.
-  [FIRApp configure];
+  id optionsMock = OCMClassMock([FIROptions class]);
+  OCMStub([optionsMock isAnalyticsCollectionExpicitlySet]).andReturn(NO);
+
+  // We need to use the default app name since Analytics only associates with the default app.
+  FIRApp *defaultApp = [[FIRApp alloc] initInstanceWithName:kFIRDefaultAppName options:optionsMock];
 
   id configurationMock = OCMClassMock([FIRAnalyticsConfiguration class]);
   OCMStub([configurationMock sharedInstance]).andReturn(configurationMock);
   OCMStub([configurationMock setAnalyticsCollectionEnabled:OCMOCK_ANY persistSetting:OCMOCK_ANY]);
-  OCMStub([self.optionsInstanceMock isAnalyticsCollectionExpicitlySet]).andReturn(NO);
 
-  // Ensure Analytics is set after the global flag is set.
-  [[FIRApp defaultApp] setDataCollectionDefaultEnabled:YES];
+  // Ensure Analytics is set after the global flag is set. It needs to
+  [defaultApp setDataCollectionDefaultEnabled:YES];
   OCMVerify([configurationMock setAnalyticsCollectionEnabled:YES persistSetting:NO]);
 
-  [[FIRApp defaultApp] setDataCollectionDefaultEnabled:NO];
+  [defaultApp setDataCollectionDefaultEnabled:NO];
   OCMVerify([configurationMock setAnalyticsCollectionEnabled:NO persistSetting:NO]);
 }
 
 - (void)testAnalyticsNotSetByGlobalDataCollectionSwitch {
   // Test that the global data collection switch doesn't override an explicitly set Analytics flag.
-  [FIRApp configure];
+  id optionsMock = OCMClassMock([FIROptions class]);
+  OCMStub([optionsMock isAnalyticsCollectionExpicitlySet]).andReturn(YES);
+  FIRApp *app = [[FIRApp alloc] initInstanceWithName:@"testAnalyticsNotSet" options:optionsMock];
 
   id configurationMock = OCMClassMock([FIRAnalyticsConfiguration class]);
   OCMStub([configurationMock sharedInstance]).andReturn(configurationMock);
   OCMStub([configurationMock setAnalyticsCollectionEnabled:OCMOCK_ANY persistSetting:OCMOCK_ANY]);
-  OCMStub([self.optionsInstanceMock isAnalyticsCollectionExpicitlySet]).andReturn(YES);
 
   // Reject any changes to Analytics when the data collection changes.
-  [[FIRApp defaultApp] setDataCollectionDefaultEnabled:YES];
+  [app setDataCollectionDefaultEnabled:YES];
   OCMReject([configurationMock setAnalyticsCollectionEnabled:OCMOCK_ANY persistSetting:OCMOCK_ANY]);
 
-  [[FIRApp defaultApp] setDataCollectionDefaultEnabled:NO];
+  [app setDataCollectionDefaultEnabled:NO];
   OCMReject([configurationMock setAnalyticsCollectionEnabled:OCMOCK_ANY persistSetting:OCMOCK_ANY]);
 }
 
@@ -760,7 +764,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   XCTAssertEqual([[FIRApp defaultApp] getUID], @"highlander");
 }
 
-- (void)testIsAppConfigured {
+- (void)testIsDefaultAppConfigured {
   // Ensure it's false before anything is configured.
   XCTAssertFalse([FIRApp isDefaultAppConfigured]);
 

--- a/Example/Core/Tests/FIROptionsTest.m
+++ b/Example/Core/Tests/FIROptionsTest.m
@@ -288,7 +288,7 @@ extern NSString *const kFIRLibraryVersionID;
     kFIRIsMeasurementEnabled : @YES
   };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
-  mainDictionary = @{kFIRIsAnalyticsCollectionDeactivated : @NO};
+  mainDictionary = @{ kFIRIsAnalyticsCollectionDeactivated : @NO };
   expectedAnalyticsOptions = @{
     kFIRIsAnalyticsCollectionDeactivated : @NO,  // override
     kFIRIsAnalyticsCollectionEnabled : @YES,
@@ -303,7 +303,7 @@ extern NSString *const kFIRLibraryVersionID;
     kFIRIsMeasurementEnabled : @YES
   };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
-  mainDictionary = @{kFIRIsAnalyticsCollectionEnabled : @NO};
+  mainDictionary = @{ kFIRIsAnalyticsCollectionEnabled : @NO };
   expectedAnalyticsOptions = @{
     kFIRIsAnalyticsCollectionDeactivated : @YES,
     kFIRIsAnalyticsCollectionEnabled : @NO,  // override
@@ -318,7 +318,7 @@ extern NSString *const kFIRLibraryVersionID;
     kFIRIsMeasurementEnabled : @YES
   };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
-  mainDictionary = @{kFIRIsMeasurementEnabled : @NO};
+  mainDictionary = @{ kFIRIsMeasurementEnabled : @NO };
   expectedAnalyticsOptions = @{
     kFIRIsAnalyticsCollectionDeactivated : @YES,
     kFIRIsAnalyticsCollectionEnabled : @YES,
@@ -509,25 +509,25 @@ extern NSString *const kFIRLibraryVersionID;
   XCTAssertFalse([options isAnalyticsCollectionExpicitlySet]);
 
   // Test deactivation flag.
-  optionsDictionary = @{kFIRIsAnalyticsCollectionDeactivated : @YES};
+  optionsDictionary = @{ kFIRIsAnalyticsCollectionDeactivated : @YES };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:@{}];
   XCTAssertTrue([options isAnalyticsCollectionExpicitlySet]);
 
   // If "deactivated" == NO, that doesn't mean it's explicitly set / enabled so it should be treated
   // as if it's not set.
-  optionsDictionary = @{kFIRIsAnalyticsCollectionDeactivated : @NO};
+  optionsDictionary = @{ kFIRIsAnalyticsCollectionDeactivated : @NO };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:@{}];
   XCTAssertFalse([options isAnalyticsCollectionExpicitlySet]);
 
   // Test the collection enabled flag.
-  optionsDictionary = @{kFIRIsAnalyticsCollectionEnabled : @YES};
+  optionsDictionary = @{ kFIRIsAnalyticsCollectionEnabled : @YES };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:@{}];
   XCTAssertTrue([options isAnalyticsCollectionExpicitlySet]);
 
-  optionsDictionary = @{kFIRIsAnalyticsCollectionEnabled : @NO};
+  optionsDictionary = @{ kFIRIsAnalyticsCollectionEnabled : @NO };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:@{}];
   XCTAssertTrue([options isAnalyticsCollectionExpicitlySet]);
@@ -547,13 +547,32 @@ extern NSString *const kFIRLibraryVersionID;
 
   // For good measure, a combination of all 3 (even if they conflict).
   optionsDictionary =
-      @{kFIRIsAnalyticsCollectionDeactivated : @YES,
-        kFIRIsAnalyticsCollectionEnabled : @YES};
+      @{ kFIRIsAnalyticsCollectionDeactivated : @YES,
+         kFIRIsAnalyticsCollectionEnabled : @YES };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:@{
     kFIRIsMeasurementEnabled : @NO
   }];
   XCTAssertTrue([options isAnalyticsCollectionExpicitlySet]);
+}
+
+- (void)testModifyingOptionsThrows {
+  FIROptions *options =
+      [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+  options.editingLocked = YES;
+
+  // Modification to every property should result in an exception.
+  XCTAssertThrows(options.androidClientID = @"should_throw");
+  XCTAssertThrows(options.APIKey = @"should_throw");
+  XCTAssertThrows(options.bundleID = @"should_throw");
+  XCTAssertThrows(options.clientID = @"should_throw");
+  XCTAssertThrows(options.databaseURL = @"should_throw");
+  XCTAssertThrows(options.deepLinkURLScheme = @"should_throw");
+  XCTAssertThrows(options.GCMSenderID = @"should_throw");
+  XCTAssertThrows(options.googleAppID = @"should_throw");
+  XCTAssertThrows(options.projectID = @"should_throw");
+  XCTAssertThrows(options.storageBucket = @"should_throw");
+  XCTAssertThrows(options.trackingID = @"should_throw");
 }
 
 - (void)testVersionFormat {

--- a/Example/Core/Tests/FIROptionsTest.m
+++ b/Example/Core/Tests/FIROptionsTest.m
@@ -288,7 +288,7 @@ extern NSString *const kFIRLibraryVersionID;
     kFIRIsMeasurementEnabled : @YES
   };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
-  mainDictionary = @{ kFIRIsAnalyticsCollectionDeactivated : @NO };
+  mainDictionary = @{kFIRIsAnalyticsCollectionDeactivated : @NO};
   expectedAnalyticsOptions = @{
     kFIRIsAnalyticsCollectionDeactivated : @NO,  // override
     kFIRIsAnalyticsCollectionEnabled : @YES,
@@ -303,7 +303,7 @@ extern NSString *const kFIRLibraryVersionID;
     kFIRIsMeasurementEnabled : @YES
   };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
-  mainDictionary = @{ kFIRIsAnalyticsCollectionEnabled : @NO };
+  mainDictionary = @{kFIRIsAnalyticsCollectionEnabled : @NO};
   expectedAnalyticsOptions = @{
     kFIRIsAnalyticsCollectionDeactivated : @YES,
     kFIRIsAnalyticsCollectionEnabled : @NO,  // override
@@ -318,7 +318,7 @@ extern NSString *const kFIRLibraryVersionID;
     kFIRIsMeasurementEnabled : @YES
   };
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
-  mainDictionary = @{ kFIRIsMeasurementEnabled : @NO };
+  mainDictionary = @{kFIRIsMeasurementEnabled : @NO};
   expectedAnalyticsOptions = @{
     kFIRIsAnalyticsCollectionDeactivated : @YES,
     kFIRIsAnalyticsCollectionEnabled : @YES,
@@ -509,25 +509,25 @@ extern NSString *const kFIRLibraryVersionID;
   XCTAssertFalse([options isAnalyticsCollectionExpicitlySet]);
 
   // Test deactivation flag.
-  optionsDictionary = @{ kFIRIsAnalyticsCollectionDeactivated : @YES };
+  optionsDictionary = @{kFIRIsAnalyticsCollectionDeactivated : @YES};
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:@{}];
   XCTAssertTrue([options isAnalyticsCollectionExpicitlySet]);
 
   // If "deactivated" == NO, that doesn't mean it's explicitly set / enabled so it should be treated
   // as if it's not set.
-  optionsDictionary = @{ kFIRIsAnalyticsCollectionDeactivated : @NO };
+  optionsDictionary = @{kFIRIsAnalyticsCollectionDeactivated : @NO};
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:@{}];
   XCTAssertFalse([options isAnalyticsCollectionExpicitlySet]);
 
   // Test the collection enabled flag.
-  optionsDictionary = @{ kFIRIsAnalyticsCollectionEnabled : @YES };
+  optionsDictionary = @{kFIRIsAnalyticsCollectionEnabled : @YES};
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:@{}];
   XCTAssertTrue([options isAnalyticsCollectionExpicitlySet]);
 
-  optionsDictionary = @{ kFIRIsAnalyticsCollectionEnabled : @NO };
+  optionsDictionary = @{kFIRIsAnalyticsCollectionEnabled : @NO};
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:@{}];
   XCTAssertTrue([options isAnalyticsCollectionExpicitlySet]);
@@ -547,8 +547,8 @@ extern NSString *const kFIRLibraryVersionID;
 
   // For good measure, a combination of all 3 (even if they conflict).
   optionsDictionary =
-      @{ kFIRIsAnalyticsCollectionDeactivated : @YES,
-         kFIRIsAnalyticsCollectionEnabled : @YES };
+      @{kFIRIsAnalyticsCollectionDeactivated : @YES,
+        kFIRIsAnalyticsCollectionEnabled : @YES};
   options = [[FIROptions alloc] initInternalWithOptionsDictionary:optionsDictionary];
   analyticsOptions = [options analyticsOptionsDictionaryWithInfoDictionary:@{
     kFIRIsMeasurementEnabled : @NO

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -148,7 +148,6 @@ static NSMutableDictionary *sLibraryVersions;
     [NSException raise:kFirebaseCoreErrorDomain format:@"Name cannot be empty."];
   }
 
-  BOOL isDefaultApp = NO;
   if ([name isEqualToString:kFIRDefaultAppName]) {
     if (sDefaultApp) {
       [NSException raise:kFirebaseCoreErrorDomain
@@ -156,7 +155,6 @@ static NSMutableDictionary *sLibraryVersions;
     }
 
     FIRLogDebug(kFIRLoggerCore, @"I-COR000001", @"Configuring the default app.");
-    isDefaultApp = YES;
   } else {
     // Validate the app name and ensure it hasn't been configured already.
     for (NSUInteger charIndex = 0; charIndex < name.length; charIndex++) {
@@ -183,7 +181,7 @@ static NSMutableDictionary *sLibraryVersions;
     [FIRApp addAppToAppDictionary:app];
     [FIRApp sendNotificationsToSDKs:app];
 
-    if (isDefaultApp) {
+    if (app.isDefaultApp) {
       sDefaultApp = app;
     }
   }

--- a/Firebase/Core/Private/FIRAppInternal.h
+++ b/Firebase/Core/Private/FIRAppInternal.h
@@ -130,7 +130,7 @@ typedef NSString *_Nullable (^FIRAppGetUIDImplementation)(void);
 @interface FIRApp ()
 
 /**
- * A flag indicating if this is the default app.
+ * A flag indicating if this is the default app (has the default app name).
  */
 @property(nonatomic, readonly) BOOL isDefaultApp;
 


### PR DESCRIPTION
There have been some issues while creating new tests where there is a conflict with mocks of `FIRApp` and `FIROptions`. Instead of relying on internal static variables we should try to use new instances of `FIRApp` and `FIROptions` where possible. Any usages of the singletons and `configure` methods should be explicitly to test those methods.

This also combines the logic of initializing the default app and a custom app with name and options, since they do the same thing but one assigns the static variable `sDefaultApp` and one does not.