### PR TITLE
Remove no longer needed MutationBatch methods

### DIFF
--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -184,9 +184,6 @@ static const int64_t kResumeTokenMaxAgeSeconds = 5 * 60;  // 5 minutes
     FSTMutationBatch *toReject = [self.mutationQueue lookupMutationBatch:batchID];
     HARD_ASSERT(toReject, "Attempt to reject nonexistent batch!");
 
-    BatchId lastAcked = [self.mutationQueue highestAcknowledgedBatchID];
-    HARD_ASSERT(batchID > lastAcked, "Acknowledged batches can't be rejected.");
-
     [self.mutationQueue removeMutationBatch:toReject];
     [self.mutationQueue performConsistencyCheck];
 

--- a/Firestore/Source/Local/FSTMutationQueue.h
+++ b/Firestore/Source/Local/FSTMutationQueue.h
@@ -53,12 +53,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (firebase::firestore::model::BatchId)nextBatchID;
 
-/**
- * Returns the highest batchID that has been acknowledged. If no batches have been acknowledged
- * or if there are no batches in the queue this can return kFSTBatchIDUnknown.
- */
-- (firebase::firestore::model::BatchId)highestAcknowledgedBatchID;
-
 /** Acknowledges the given batch. */
 - (void)acknowledgeBatch:(FSTMutationBatch *)batch streamToken:(nullable NSData *)streamToken;
 
@@ -91,21 +85,6 @@ NS_ASSUME_NONNULL_BEGIN
 // TODO(mikelehen): PERF: Current consumer only needs mutated keys; if we can provide that
 // cheaply, we should replace this.
 - (NSArray<FSTMutationBatch *> *)allMutationBatches;
-
-/**
- * Finds all mutations with a batchID less than or equal to the given batchID.
- *
- * Generally the caller should be asking for the next unacknowledged batchID and the number of
- * acknowledged batches should be very small when things are functioning well.
- *
- * @param batchID The batch to search through.
- *
- * @return an NSArray containing all batches with matching batchIDs.
- */
-// TODO(mcg): This should really return NSEnumerator and the caller should be adjusted to only
-// loop through these once.
-- (NSArray<FSTMutationBatch *> *)allMutationBatchesThroughBatchID:
-    (firebase::firestore::model::BatchId)batchID;
 
 /**
  * Finds all mutation batches that could @em possibly affect the given document key. Not all


### PR DESCRIPTION
Port of https://github.com/firebase/firebase-android-sdk/pull/40/files

Removes allMutationBatchesThroughBatchID and highestAcknowledgedBatchID.