### PR TITLE
Restore SafariServices framework

### DIFF
--- a/Firebase/Auth/CHANGELOG.md
+++ b/Firebase/Auth/CHANGELOG.md
@@ -1,6 +1,13 @@
-# v5.1.0
-- Adds `FIRAuthErrorCodeMalformedJWT`, which is raised on JWT token parsing
+# v5.0.5
+- Restore SafariServices framework dependency (#2002).
+
+# v5.0.4
+- Fix analyzer issues (#1740).
+
+# v5.0.3
+- Adds `FIRAuthErrorCodeMalformedJWT`, which is raised on JWT token parsing.
   failures during auth operations (#1436).
+- Migrate to use FirebaseAuthInterop interfaces to access FirebaseAuth (#1501).
 
 # v5.0.2
 - Fix an issue where JWT date timestamps weren't parsed correctly. (#1319)

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -60,7 +60,8 @@ supports email and password accounts, as well as several 3rd party authenticatio
       'FIRAuth_VERSION=' + s.version.to_s +
       ' FIRAuth_MINOR_VERSION=' + s.version.to_s.split(".")[0] + "." + s.version.to_s.split(".")[1]
   }
-  s.frameworks = 'SafariServices', 'Security'
+  s.framework = 'Security'
+  s.ios.framework = 'SafariServices'
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
   s.dependency 'FirebaseCore', '~> 5.1'
   s.dependency 'GoogleUtilities/Environment', '~> 5.2'

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -60,8 +60,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
       'FIRAuth_VERSION=' + s.version.to_s +
       ' FIRAuth_MINOR_VERSION=' + s.version.to_s.split(".")[0] + "." + s.version.to_s.split(".")[1]
   }
-  s.framework = 'SafariServices'
-  s.framework = 'Security'
+  s.frameworks = 'SafariServices', 'Security'
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
   s.dependency 'FirebaseCore', '~> 5.1'
   s.dependency 'GoogleUtilities/Environment', '~> 5.2'

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -27,9 +27,7 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   s.source_files = 'Firebase/Core/**/*.[mh]'
   s.public_header_files = 'Firebase/Core/Public/*.h', 'Firebase/Core/Private/*.h'
   s.private_header_files = 'Firebase/Core/Private/*.h'
-  s.frameworks = [
-    'Foundation'
-  ]
+  s.framework = 'Foundation'
   s.dependency 'GoogleUtilities/Logger', '~> 5.2'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -30,7 +30,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
     base_dir + 'third_party/SocketRocket/fbase64.c'
   s.public_header_files = base_dir + 'Public/*.h'
   s.libraries = ['c++', 'icucore']
-  s.frameworks = ['CFNetwork', 'Security', 'SystemConfiguration']
+  s.frameworks = 'CFNetwork', 'Security', 'SystemConfiguration'
   s.dependency 'leveldb-library', '~> 1.18'
   s.dependency 'FirebaseCore', '~> 5.0'
   s.pod_target_xcconfig = {

--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -24,11 +24,7 @@ Firebase Dynamic Links are deep links that enhance user experience and increase 
 
   s.source_files = 'Firebase/DynamicLinks/**/*.[mh]'
   s.public_header_files = 'Firebase/DynamicLinks/Public/*.h'
-  s.frameworks = [
-    'AssetsLibrary',
-    'MessageUI',
-    'QuartzCore',
-  ]
+  s.frameworks = 'AssetsLibrary', 'MessageUI', 'QuartzCore'
   s.weak_framework = 'WebKit'
   s.dependency 'FirebaseCore', '~> 5.1'
   s.ios.dependency 'FirebaseAnalytics', '~> 5.1'


### PR DESCRIPTION
In the Firebase 5.0.0, we lost the SafariServices framework from FirebaseAuth because of an overwrite in the updated podspec.

The issue was reported at https://groups.google.com/forum/#!msg/firebase-talk/oJadY1uGSWY/eWZVoox1CAAJ

- This PR restores the framework.
- Makes all podspec frameworks follow the [docs](https://guides.cocoapods.org/syntax/podspec.html#frameworks).
- Updates Auth release notes (including a few previous missed ones).

I confirmed that the generated Pod targets have the right framework dependencies. As expected, only FirebaseAuth is changed and corrected.
