### PR TITLE
Remove sleep that works around over-aggressive snapshot validation in tests

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
@@ -257,11 +257,6 @@
   querySnap = [self.eventAccumulator awaitEventWithName:@"offline event with isFromCache=YES"];
   XCTAssertEqual(querySnap.metadata.isFromCache, YES);
 
-  // TODO(b/70631617): There's currently a backend bug that prevents us from using a resume token
-  // right away (against hexa at least). So we sleep. :-( :-( Anything over ~10ms seems to be
-  // sufficient.
-  [NSThread sleepForTimeInterval:0.2f];
-
   [self enableNetwork];
   querySnap = [self.eventAccumulator awaitEventWithName:@"back online event with isFromCache=NO"];
   XCTAssertEqual(querySnap.metadata.isFromCache, NO);


### PR DESCRIPTION
The issue has already been fixed and we are now running integration test with actual server instead of hexa.