### PR TITLE
Updated the Carthage installation instructions

### DIFF
--- a/Carthage.md
+++ b/Carthage.md
@@ -28,7 +28,7 @@ more details and additional installation methods.
 
 - Create a Cartfile with a **subset** of the following components - choosing the
 Firebase components that you want to include in your app. Note that
-**FirebaseAnalytics** must always be included.
+**FirebaseAnalyticsBinary** must always be included.
 ```
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseABTestingBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAdMobBinary.json"
@@ -57,8 +57,8 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseStorageBinary.jso
 - Use Finder to open `Carthage/Build/iOS`.
 - Copy the contents into the top level of your Xcode project and make sure
     they're added to the right build target(s).
-- Add the -ObjC flag to "Other Linker Flags".
-- Make sure that the build target(s) includes your project's `GoogleService-Info.plist`.
+- Add `$(OTHER_LDFLAGS) -ObjC` flag to "Other Linker Flags" in "Build Settings".
+- Make sure that the build target(s) includes your project's `GoogleService-Info.plist` ([how to download config file](https://support.google.com/firebase/answer/7015592))
 - [Delete Firebase.framework from the Link Binary With Libraries Build Phase](https://github.com/firebase/firebase-ios-sdk/issues/911#issuecomment-372455235).
 - If you're including a Firebase component that has resources, copy its bundles
     into the Xcode project and make sure they're added to the


### PR DESCRIPTION
This PR is about improving the documentation regarding integrating Firebase with Carthage.

Changes:
- There were two inaccuracies in the documentation that I fixed. 
- I also added a link to a support page that explains how to download the config file.