### PR TITLE
Increase timeouts in attempt to eliminate travis flakes

### DIFF
--- a/InAppMessagingDisplay/Example/InAppMessagingDisplay-UITests/InAppMessagingDisplayImageOnlyViewUITests.swift
+++ b/InAppMessagingDisplay/Example/InAppMessagingDisplay-UITests/InAppMessagingDisplayImageOnlyViewUITests.swift
@@ -101,7 +101,7 @@ class InAppMessagingImageOnlyViewUITests: InAppMessagingDisplayUITestsBase {
       app.buttons["Low Dimension Image"].tap()
 
       // wait time longer due to large image
-      waitForElementToAppear(closeButton, 10)
+      waitForElementToAppear(closeButton, 15)
 
       XCTAssert(isElementExistentAndHavingSize(imageView))
       XCTAssert(isUIElementWithinUIWindow(imageView))
@@ -123,7 +123,7 @@ class InAppMessagingImageOnlyViewUITests: InAppMessagingDisplayUITestsBase {
       app.buttons["Wide Image"].tap()
 
       // wait time longer due to large image
-      waitForElementToAppear(closeButton, 10)
+      waitForElementToAppear(closeButton, 15)
 
       XCTAssert(isElementExistentAndHavingSize(imageView))
       XCTAssert(isUIElementWithinUIWindow(imageView))
@@ -145,7 +145,7 @@ class InAppMessagingImageOnlyViewUITests: InAppMessagingDisplayUITestsBase {
       app.buttons["Narrow Image"].tap()
 
       // wait time longer due to large image
-      waitForElementToAppear(closeButton, 10)
+      waitForElementToAppear(closeButton, 15)
 
       XCTAssert(isElementExistentAndHavingSize(imageView))
       XCTAssert(isUIElementWithinUIWindow(imageView))

--- a/InAppMessagingDisplay/Example/InAppMessagingDisplay-UITests/InAppMessagingDisplayImageOnlyViewUITests.swift
+++ b/InAppMessagingDisplay/Example/InAppMessagingDisplay-UITests/InAppMessagingDisplayImageOnlyViewUITests.swift
@@ -76,7 +76,7 @@ class InAppMessagingImageOnlyViewUITests: InAppMessagingDisplayUITestsBase {
       app.buttons["High Dimension Image"].tap()
 
       // wait time longer due to large image
-      waitForElementToAppear(closeButton, 10)
+      waitForElementToAppear(closeButton, 30)
 
       XCTAssert(isElementExistentAndHavingSize(imageView))
       XCTAssert(isUIElementWithinUIWindow(imageView))
@@ -101,7 +101,7 @@ class InAppMessagingImageOnlyViewUITests: InAppMessagingDisplayUITestsBase {
       app.buttons["Low Dimension Image"].tap()
 
       // wait time longer due to large image
-      waitForElementToAppear(closeButton, 15)
+      waitForElementToAppear(closeButton, 30)
 
       XCTAssert(isElementExistentAndHavingSize(imageView))
       XCTAssert(isUIElementWithinUIWindow(imageView))
@@ -123,7 +123,7 @@ class InAppMessagingImageOnlyViewUITests: InAppMessagingDisplayUITestsBase {
       app.buttons["Wide Image"].tap()
 
       // wait time longer due to large image
-      waitForElementToAppear(closeButton, 15)
+      waitForElementToAppear(closeButton, 30)
 
       XCTAssert(isElementExistentAndHavingSize(imageView))
       XCTAssert(isUIElementWithinUIWindow(imageView))
@@ -145,7 +145,7 @@ class InAppMessagingImageOnlyViewUITests: InAppMessagingDisplayUITestsBase {
       app.buttons["Narrow Image"].tap()
 
       // wait time longer due to large image
-      waitForElementToAppear(closeButton, 15)
+      waitForElementToAppear(closeButton, 30)
 
       XCTAssert(isElementExistentAndHavingSize(imageView))
       XCTAssert(isUIElementWithinUIWindow(imageView))

--- a/InAppMessagingDisplay/Example/InAppMessagingDisplay-UITests/InAppMessagingDisplayUITestsBase.swift
+++ b/InAppMessagingDisplay/Example/InAppMessagingDisplay-UITests/InAppMessagingDisplayUITestsBase.swift
@@ -19,13 +19,13 @@ import Foundation
 import XCTest
 
 class InAppMessagingDisplayUITestsBase: XCTestCase {
-  func waitForElementToAppear(_ element: XCUIElement, _ timeoutInSeconds: TimeInterval = 5) {
+  func waitForElementToAppear(_ element: XCUIElement, _ timeoutInSeconds: TimeInterval = 10) {
     let existsPredicate = NSPredicate(format: "exists == true")
     expectation(for: existsPredicate, evaluatedWith: element, handler: nil)
     waitForExpectations(timeout: timeoutInSeconds, handler: nil)
   }
 
-  func waitForElementToDisappear(_ element: XCUIElement, _ timeoutInSeconds: TimeInterval = 5) {
+  func waitForElementToDisappear(_ element: XCUIElement, _ timeoutInSeconds: TimeInterval = 10) {
     let existsPredicate = NSPredicate(format: "exists == false")
     expectation(for: existsPredicate, evaluatedWith: element, handler: nil)
     waitForExpectations(timeout: timeoutInSeconds, handler: nil)

--- a/InAppMessagingDisplay/Example/InAppMessagingDisplay-UITests/InAppMessagingDisplayUITestsBase.swift
+++ b/InAppMessagingDisplay/Example/InAppMessagingDisplay-UITests/InAppMessagingDisplayUITestsBase.swift
@@ -19,13 +19,13 @@ import Foundation
 import XCTest
 
 class InAppMessagingDisplayUITestsBase: XCTestCase {
-  func waitForElementToAppear(_ element: XCUIElement, _ timeoutInSeconds: TimeInterval = 10) {
+  func waitForElementToAppear(_ element: XCUIElement, _ timeoutInSeconds: TimeInterval = 20) {
     let existsPredicate = NSPredicate(format: "exists == true")
     expectation(for: existsPredicate, evaluatedWith: element, handler: nil)
     waitForExpectations(timeout: timeoutInSeconds, handler: nil)
   }
 
-  func waitForElementToDisappear(_ element: XCUIElement, _ timeoutInSeconds: TimeInterval = 10) {
+  func waitForElementToDisappear(_ element: XCUIElement, _ timeoutInSeconds: TimeInterval = 20) {
     let existsPredicate = NSPredicate(format: "exists == false")
     expectation(for: existsPredicate, evaluatedWith: element, handler: nil)
     waitForExpectations(timeout: timeoutInSeconds, handler: nil)


### PR DESCRIPTION
The total test time stayed between 29 and 30 minutes.