### PR TITLE
Held Write Ack Removal Spec Tests

### DIFF
--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -174,18 +174,19 @@ static NSString *Describe(NSData *data) {
   return testutil::Version(version.longLongValue);
 }
 
-- (FSTDocumentViewChange *)parseChange:(NSArray *)change ofType:(FSTDocumentViewChangeType)type {
-  BOOL hasMutations = NO;
-  for (NSUInteger i = 3; i < change.count; ++i) {
-    if ([change[i] isEqual:@"local"]) {
-      hasMutations = YES;
-    }
-  }
-  NSNumber *version = change[1];
-  XCTAssert([change[0] isKindOfClass:[NSString class]]);
-  FSTDocument *doc =
-      FSTTestDoc(util::MakeString((NSString *)change[0]), version.longLongValue, change[2],
-                 hasMutations ? FSTDocumentStateLocalMutations : FSTDocumentStateSynced);
+- (FSTDocumentViewChange *)parseChange:(NSDictionary *)jsonDoc
+                                ofType:(FSTDocumentViewChangeType)type {
+  NSNumber *version = jsonDoc[@"version"];
+  NSDictionary *options = jsonDoc[@"options"];
+  FSTDocumentState documentState = [options[@"hasLocalMutations"] isEqualToNumber:@YES]
+                                       ? FSTDocumentStateLocalMutations
+                                       : ([options[@"hasCommittedMutations"] isEqualToNumber:@YES]
+                                              ? FSTDocumentStateCommittedMutations
+                                              : FSTDocumentStateSynced);
+
+  XCTAssert([jsonDoc[@"key"] isKindOfClass:[NSString class]]);
+  FSTDocument *doc = FSTTestDoc(util::MakeString((NSString *)jsonDoc[@"key"]),
+                                version.longLongValue, jsonDoc[@"value"], documentState);
   return [FSTDocumentViewChange changeWithDocument:doc type:type];
 }
 
@@ -270,11 +271,12 @@ static NSString *Describe(NSData *data) {
       [self doWatchEntity:watchSpec];
     }
   } else if (watchEntity[@"doc"]) {
-    NSArray *docSpec = watchEntity[@"doc"];
-    FSTDocumentKey *key = FSTTestDocKey(docSpec[0]);
-    FSTObjectValue *_Nullable value =
-        [docSpec[2] isKindOfClass:[NSNull class]] ? nil : FSTTestObjectValue(docSpec[2]);
-    SnapshotVersion version = [self parseVersion:docSpec[1]];
+    NSDictionary *docSpec = watchEntity[@"doc"];
+    FSTDocumentKey *key = FSTTestDocKey(docSpec[@"key"]);
+    FSTObjectValue *_Nullable value = [docSpec[@"value"] isKindOfClass:[NSNull class]]
+                                          ? nil
+                                          : FSTTestObjectValue(docSpec[@"value"]);
+    SnapshotVersion version = [self parseVersion:docSpec[@"version"]];
     FSTMaybeDocument *doc = value ? [FSTDocument documentWithData:value
                                                               key:key
                                                           version:std::move(version)
@@ -493,22 +495,22 @@ static NSString *Describe(NSData *data) {
   } else {
     NSMutableArray *expectedChanges = [NSMutableArray array];
     NSMutableArray *removed = expected[@"removed"];
-    for (NSArray *changeSpec in removed) {
+    for (NSDictionary *changeSpec in removed) {
       [expectedChanges
           addObject:[self parseChange:changeSpec ofType:FSTDocumentViewChangeTypeRemoved]];
     }
     NSMutableArray *added = expected[@"added"];
-    for (NSArray *changeSpec in added) {
+    for (NSDictionary *changeSpec in added) {
       [expectedChanges
           addObject:[self parseChange:changeSpec ofType:FSTDocumentViewChangeTypeAdded]];
     }
     NSMutableArray *modified = expected[@"modified"];
-    for (NSArray *changeSpec in modified) {
+    for (NSDictionary *changeSpec in modified) {
       [expectedChanges
           addObject:[self parseChange:changeSpec ofType:FSTDocumentViewChangeTypeModified]];
     }
     NSMutableArray *metadata = expected[@"metadata"];
-    for (NSArray *changeSpec in metadata) {
+    for (NSDictionary *changeSpec in metadata) {
       [expectedChanges
           addObject:[self parseChange:changeSpec ofType:FSTDocumentViewChangeTypeMetadata]];
     }

--- a/Firestore/Example/Tests/SpecTests/json/collection_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/collection_spec_test.json
@@ -38,13 +38,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/key",
-              1000,
-              {
+            {
+              "key": "collection/key",
+              "version": 1000,
+              "value": {
                 "foo": "bar"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -61,7 +65,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         },
         "expect": [
           {
@@ -71,13 +76,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                1000,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "foo": "bar"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -133,14 +142,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,

--- a/Firestore/Example/Tests/SpecTests/json/existence_filter_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/existence_filter_spec_test.json
@@ -38,13 +38,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/1",
-              1000,
-              {
+            {
+              "key": "collection/1",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -61,7 +65,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -71,13 +76,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/1",
-                1000,
-                {
+              {
+                "key": "collection/1",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -95,7 +104,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         }
       }
     ]
@@ -146,7 +156,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -164,13 +175,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/1",
-              2000,
-              {
+            {
+              "key": "collection/1",
+              "version": 2000,
+              "value": {
                 "v": 2
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -187,7 +202,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -197,13 +213,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/1",
-                2000,
-                {
+              {
+                "key": "collection/1",
+                "version": 2000,
+                "value": {
                   "v": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -259,7 +279,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -284,7 +305,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -340,13 +362,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/1",
-              2000,
-              {
+            {
+              "key": "collection/1",
+              "version": 2000,
+              "value": {
                 "v": 2
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -363,7 +389,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -373,13 +400,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/1",
-                2000,
-                {
+              {
+                "key": "collection/1",
+                "version": 2000,
+                "value": {
                   "v": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -429,13 +460,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/1",
-                2000,
-                {
+              {
+                "key": "collection/1",
+                "version": 2000,
+                "value": {
                   "v": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -472,7 +507,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -528,20 +564,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/1",
-              1000,
-              {
+            {
+              "key": "collection/1",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/2",
-              1000,
-              {
+            },
+            {
+              "key": "collection/2",
+              "version": 1000,
+              "value": {
                 "v": 2
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -558,7 +602,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -568,20 +613,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/1",
-                1000,
-                {
+              {
+                "key": "collection/1",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/2",
-                1000,
-                {
+              },
+              {
+                "key": "collection/2",
+                "version": 1000,
+                "value": {
                   "v": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -599,7 +652,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -641,13 +695,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/1",
-              1000,
-              {
+            {
+              "key": "collection/1",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -664,7 +722,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -705,7 +764,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [],
@@ -728,13 +788,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/2",
-                1000,
-                {
+              {
+                "key": "collection/2",
+                "version": 1000,
+                "value": {
                   "v": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -783,20 +847,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/1",
-              1000,
-              {
+            {
+              "key": "collection/1",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/2",
-              1000,
-              {
+            },
+            {
+              "key": "collection/2",
+              "version": 1000,
+              "value": {
                 "v": 2
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -813,7 +885,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -823,20 +896,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/1",
-                1000,
-                {
+              {
+                "key": "collection/1",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/2",
-                1000,
-                {
+              },
+              {
+                "key": "collection/2",
+                "version": 1000,
+                "value": {
                   "v": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -880,7 +961,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -922,13 +1004,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/1",
-              1000,
-              {
+            {
+              "key": "collection/1",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -945,7 +1031,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -986,7 +1073,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [],
@@ -1009,13 +1097,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/2",
-                1000,
-                {
+              {
+                "key": "collection/2",
+                "version": 1000,
+                "value": {
                   "v": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1064,13 +1156,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/1",
-              1000,
-              {
+            {
+              "key": "collection/1",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1087,7 +1183,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1097,13 +1194,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/1",
-                1000,
-                {
+              {
+                "key": "collection/1",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1123,13 +1224,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/3",
-              3000,
-              {
+            {
+              "key": "collection/3",
+              "version": 3000,
+              "value": {
                 "v": 3
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1138,7 +1243,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1148,13 +1254,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/3",
-                3000,
-                {
+              {
+                "key": "collection/3",
+                "version": 3000,
+                "value": {
                   "v": 3
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1189,27 +1299,39 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/1",
-              1000,
-              {
+            {
+              "key": "collection/1",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/2",
-              2000,
-              {
+            },
+            {
+              "key": "collection/2",
+              "version": 2000,
+              "value": {
                 "v": 2
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/3",
-              3000,
-              {
+            },
+            {
+              "key": "collection/3",
+              "version": 3000,
+              "value": {
                 "v": 3
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1226,7 +1348,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 3000
+          "version": 3000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1236,13 +1359,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/2",
-                2000,
-                {
+              {
+                "key": "collection/2",
+                "version": 2000,
+                "value": {
                   "v": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1291,13 +1418,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1314,7 +1445,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1324,13 +1456,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1347,7 +1483,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1357,13 +1494,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1412,20 +1553,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/1",
-              1000,
-              {
+            {
+              "key": "collection/1",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/2",
-              1000,
-              {
+            },
+            {
+              "key": "collection/2",
+              "version": 1000,
+              "value": {
                 "v": 2
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1442,7 +1591,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1452,20 +1602,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/1",
-                1000,
-                {
+              {
+                "key": "collection/1",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/2",
-                1000,
-                {
+              },
+              {
+                "key": "collection/2",
+                "version": 1000,
+                "value": {
                   "v": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1483,7 +1641,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1525,13 +1684,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/1",
-              1000,
-              {
+            {
+              "key": "collection/1",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1548,7 +1711,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -1604,13 +1768,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/2",
-                1000,
-                {
+              {
+                "key": "collection/2",
+                "version": 1000,
+                "value": {
                   "v": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,

--- a/Firestore/Example/Tests/SpecTests/json/limbo_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/limbo_spec_test.json
@@ -38,13 +38,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -61,7 +65,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -71,13 +76,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -100,7 +109,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -153,7 +163,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002
+          "version": 1002,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [],
@@ -176,13 +187,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -231,13 +246,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -254,7 +273,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -264,13 +284,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -293,7 +317,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -353,7 +378,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002
+          "version": 1002,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [],
@@ -376,13 +402,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -443,13 +473,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -466,7 +500,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -482,13 +517,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -511,7 +550,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -569,13 +609,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             1
@@ -592,7 +636,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002
+          "version": 1002,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [],
@@ -627,13 +672,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -694,13 +743,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -717,7 +770,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -733,13 +787,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -810,7 +868,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -887,13 +946,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             1,
@@ -911,7 +974,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002
+          "version": 1002,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [],
@@ -960,13 +1024,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -985,13 +1053,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1009,7 +1081,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1003
+          "version": 1003,
+          "targetIds": []
         }
       }
     ]
@@ -1053,20 +1126,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/b",
-              1001,
-              {
+            },
+            {
+              "key": "collection/b",
+              "version": 1001,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1083,7 +1164,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002
+          "version": 1002,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1093,20 +1175,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/b",
-                1001,
-                {
+              },
+              {
+                "key": "collection/b",
+                "version": 1001,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1124,7 +1214,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1003
+          "version": 1003,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -1177,7 +1268,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1004
+          "version": 1004,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [],
@@ -1200,13 +1292,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/b",
-                1001,
-                {
+              {
+                "key": "collection/b",
+                "version": 1001,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1255,22 +1351,30 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "include": true,
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/b",
-              1000,
-              {
+            },
+            {
+              "key": "collection/b",
+              "version": 1000,
+              "value": {
                 "include": true,
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1287,7 +1391,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1297,22 +1402,30 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "include": true,
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/b",
-                1000,
-                {
+              },
+              {
+                "key": "collection/b",
+                "version": 1000,
+                "value": {
                   "include": true,
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1383,14 +1496,18 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "include": true,
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1406,14 +1523,18 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "include": true,
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             4
@@ -1430,7 +1551,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1474,24 +1596,32 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                1000,
-                {
+              {
+                "key": "collection/b",
+                "version": 1000,
+                "value": {
                   "include": true,
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "removed": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "include": true,
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1537,14 +1667,18 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              1000,
-              {
+            {
+              "key": "collection/b",
+              "version": 1000,
+              "value": {
                 "include": true,
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             1
@@ -1553,7 +1687,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         }
       },
       {
@@ -1566,20 +1701,25 @@
       },
       {
         "watchSnapshot": {
-          "version": 3000
+          "version": 3000,
+          "targetIds": []
         }
       },
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "include": true,
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "removedTargets": [
             4
@@ -1589,14 +1729,18 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              1000,
-              {
+            {
+              "key": "collection/b",
+              "version": 1000,
+              "value": {
                 "include": true,
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             4
@@ -1605,7 +1749,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 4000
+          "version": 4000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1688,22 +1833,30 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "include": true,
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/b",
-              1000,
-              {
+            },
+            {
+              "key": "collection/b",
+              "version": 1000,
+              "value": {
                 "include": true,
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1720,7 +1873,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1730,22 +1884,30 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "include": true,
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/b",
-                1000,
-                {
+              },
+              {
+                "key": "collection/b",
+                "version": 1000,
+                "value": {
                   "include": true,
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1816,14 +1978,18 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "include": true,
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1839,14 +2005,18 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "include": true,
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             4
@@ -1863,7 +2033,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1907,24 +2078,32 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                1000,
-                {
+              {
+                "key": "collection/b",
+                "version": 1000,
+                "value": {
                   "include": true,
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "removed": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "include": true,
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1969,7 +2148,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         }
       },
       {
@@ -1982,7 +2162,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 3000
+          "version": 3000,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [],
@@ -2019,14 +2200,18 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/b",
-                1000,
-                {
+              {
+                "key": "collection/b",
+                "version": 1000,
+                "value": {
                   "include": true,
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2037,14 +2222,18 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "include": true,
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "removedTargets": [
             4
@@ -2053,7 +2242,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 4000
+          "version": 4000,
+          "targetIds": []
         }
       }
     ]
@@ -2128,20 +2318,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/b",
-              1001,
-              {
+            },
+            {
+              "key": "collection/b",
+              "version": 1001,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -2160,7 +2358,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002
+          "version": 1002,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -2174,20 +2373,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/b",
-                1001,
-                {
+              },
+              {
+                "key": "collection/b",
+                "version": 1001,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2211,7 +2418,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1003
+          "version": 1003,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -2275,7 +2483,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1004
+          "version": 1004,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [],
@@ -2302,13 +2511,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/b",
-                1001,
-                {
+              {
+                "key": "collection/b",
+                "version": 1001,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2389,20 +2602,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/b",
-              1001,
-              {
+            },
+            {
+              "key": "collection/b",
+              "version": 1001,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -2421,7 +2642,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000000
+          "version": 1000000,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -2435,20 +2657,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/b",
-                1001,
-                {
+              },
+              {
+                "key": "collection/b",
+                "version": 1001,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2472,7 +2702,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000000
+          "version": 2000000,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -2566,7 +2797,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 3000000
+          "version": 3000000,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -2610,7 +2842,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 4000000
+          "version": 4000000,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [],
@@ -2633,13 +2866,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/b",
-                1001,
-                {
+              {
+                "key": "collection/b",
+                "version": 1001,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2700,27 +2937,39 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/b",
-              1001,
-              {
+            },
+            {
+              "key": "collection/b",
+              "version": 1001,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/c",
-              1002,
-              {
+            },
+            {
+              "key": "collection/c",
+              "version": 1002,
+              "value": {
                 "key": "c"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -2739,7 +2988,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000000
+          "version": 1000000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2749,27 +2999,39 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/b",
-                1001,
-                {
+              },
+              {
+                "key": "collection/b",
+                "version": 1001,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/c",
-                1002,
-                {
+              },
+              {
+                "key": "collection/c",
+                "version": 1002,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2798,7 +3060,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000000
+          "version": 2000000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2923,7 +3186,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 3000000
+          "version": 3000000,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -2976,7 +3240,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 3000000
+          "version": 3000000,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -3013,13 +3278,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/b",
-                1001,
-                {
+              {
+                "key": "collection/b",
+                "version": 1001,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3073,7 +3342,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 5000000
+          "version": 5000000,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -3117,7 +3387,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 6000000
+          "version": 6000000,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [],
@@ -3140,13 +3411,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/c",
-                1002,
-                {
+              {
+                "key": "collection/c",
+                "version": 1002,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,

--- a/Firestore/Example/Tests/SpecTests/json/limit_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/limit_spec_test.json
@@ -40,20 +40,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/c",
-              1001,
-              {
+            },
+            {
+              "key": "collection/c",
+              "version": 1001,
+              "value": {
                 "key": "c"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -70,7 +78,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         },
         "expect": [
           {
@@ -81,20 +90,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/c",
-                1001,
-                {
+              },
+              {
+                "key": "collection/c",
+                "version": 1001,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -105,13 +122,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              1002,
-              {
+            {
+              "key": "collection/b",
+              "version": 1002,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -121,13 +142,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/c",
-              1001,
-              {
+            {
+              "key": "collection/c",
+              "version": 1001,
+              "value": {
                 "key": "c"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "removedTargets": [
             2
@@ -136,7 +161,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002
+          "version": 1002,
+          "targetIds": []
         },
         "expect": [
           {
@@ -147,25 +173,238 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                1002,
-                {
+              {
+                "key": "collection/b",
+                "version": 1002,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "removed": [
-              [
-                "collection/c",
-                1001,
-                {
+              {
+                "key": "collection/c",
+                "version": 1001,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
+      }
+    ]
+  },
+  "Documents outside of limit don't raise hasPendingWrites": {
+    "describeName": "Limits:",
+    "itName": "Documents outside of limit don't raise hasPendingWrites",
+    "tags": [],
+    "config": {
+      "useGarbageCollection": false,
+      "numClients": 1
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "limit": 2,
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "limit": 2,
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
+                "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            },
+            {
+              "key": "collection/b",
+              "version": 1000,
+              "value": {
+                "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000,
+          "targetIds": []
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "limit": 2,
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
+                  "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/b",
+                "version": 1000,
+                "value": {
+                  "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "userUnlisten": [
+          2,
+          {
+            "path": "collection",
+            "limit": 2,
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {}
+        }
+      },
+      {
+        "userSet": [
+          "collection/c",
+          {
+            "key": "c"
+          }
+        ]
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "limit": 2,
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "limit": 2,
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "limit": 2,
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
+                  "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/b",
+                "version": 1000,
+                "value": {
+                  "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
             "hasPendingWrites": false
           }
         ]
@@ -213,20 +452,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/b",
-              1001,
-              {
+            },
+            {
+              "key": "collection/b",
+              "version": 1001,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -243,7 +490,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002
+          "version": 1002,
+          "targetIds": []
         },
         "expect": [
           {
@@ -254,20 +502,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/b",
-                1001,
-                {
+              },
+              {
+                "key": "collection/b",
+                "version": 1001,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -283,20 +539,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              1001,
-              {
+            {
+              "key": "collection/b",
+              "version": 1001,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/c",
-              1002,
-              {
+            },
+            {
+              "key": "collection/c",
+              "version": 1002,
+              "value": {
                 "key": "c"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -313,7 +577,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -368,7 +633,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [],
@@ -393,22 +659,30 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/c",
-                1002,
-                {
+              {
+                "key": "collection/c",
+                "version": 1002,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "removed": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -459,20 +733,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/c",
-              1001,
-              {
+            },
+            {
+              "key": "collection/c",
+              "version": 1001,
+              "value": {
                 "key": "c"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -489,7 +771,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         },
         "expect": [
           {
@@ -500,20 +783,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/c",
-                1001,
-                {
+              },
+              {
+                "key": "collection/c",
+                "version": 1001,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -524,13 +815,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              1002,
-              {
+            {
+              "key": "collection/b",
+              "version": 1002,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -547,7 +842,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002
+          "version": 1002,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [],
@@ -572,22 +868,30 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                1002,
-                {
+              {
+                "key": "collection/b",
+                "version": 1002,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "removed": [
-              [
-                "collection/c",
-                1001,
-                {
+              {
+                "key": "collection/c",
+                "version": 1001,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -676,20 +980,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/c",
-              1001,
-              {
+            },
+            {
+              "key": "collection/c",
+              "version": 1001,
+              "value": {
                 "key": "c"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -699,20 +1011,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/c",
-              1001,
-              {
+            },
+            {
+              "key": "collection/c",
+              "version": 1001,
+              "value": {
                 "key": "c"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             4
@@ -737,7 +1057,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         },
         "expect": [
           {
@@ -748,20 +1069,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/c",
-                1001,
-                {
+              },
+              {
+                "key": "collection/c",
+                "version": 1001,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -775,20 +1104,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/c",
-                1001,
-                {
+              },
+              {
+                "key": "collection/c",
+                "version": 1001,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -799,13 +1136,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              1002,
-              {
+            {
+              "key": "collection/b",
+              "version": 1002,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2,
@@ -823,7 +1164,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002
+          "version": 1002,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [],
@@ -857,22 +1199,30 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                1002,
-                {
+              {
+                "key": "collection/b",
+                "version": 1002,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "removed": [
-              [
-                "collection/c",
-                1001,
-                {
+              {
+                "key": "collection/c",
+                "version": 1001,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -886,13 +1236,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                1002,
-                {
+              {
+                "key": "collection/b",
+                "version": 1002,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -943,20 +1297,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/b",
-              1001,
-              {
+            },
+            {
+              "key": "collection/b",
+              "version": 1001,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -973,7 +1335,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         },
         "expect": [
           {
@@ -984,20 +1347,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/b",
-                1001,
-                {
+              },
+              {
+                "key": "collection/b",
+                "version": 1001,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1043,20 +1414,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/b",
-                1001,
-                {
+              },
+              {
+                "key": "collection/b",
+                "version": 1001,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1072,48 +1451,72 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/b",
-              1001,
-              {
+            },
+            {
+              "key": "collection/b",
+              "version": 1001,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/c",
-              1002,
-              {
+            },
+            {
+              "key": "collection/c",
+              "version": 1002,
+              "value": {
                 "key": "c"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/d",
-              1003,
-              {
+            },
+            {
+              "key": "collection/d",
+              "version": 1003,
+              "value": {
                 "key": "d"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/e",
-              1004,
-              {
+            },
+            {
+              "key": "collection/e",
+              "version": 1004,
+              "value": {
                 "key": "e"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/f",
-              1005,
-              {
+            },
+            {
+              "key": "collection/f",
+              "version": 1005,
+              "value": {
                 "key": "f"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             4
@@ -1130,7 +1533,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1005
+          "version": 1005,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1140,34 +1544,50 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/c",
-                1002,
-                {
+              {
+                "key": "collection/c",
+                "version": 1002,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/d",
-                1003,
-                {
+              },
+              {
+                "key": "collection/d",
+                "version": 1003,
+                "value": {
                   "key": "d"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/e",
-                1004,
-                {
+              },
+              {
+                "key": "collection/e",
+                "version": 1004,
+                "value": {
                   "key": "e"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/f",
-                1005,
-                {
+              },
+              {
+                "key": "collection/f",
+                "version": 1005,
+                "value": {
                   "key": "f"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1183,20 +1603,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/e",
-              1004,
-              {
+            {
+              "key": "collection/e",
+              "version": 1004,
+              "value": {
                 "key": "e"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/f",
-              1005,
-              {
+            },
+            {
+              "key": "collection/f",
+              "version": 1005,
+              "value": {
                 "key": "f"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1213,7 +1641,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -1285,7 +1714,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -1336,13 +1766,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1356,22 +1790,30 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/c",
-                1002,
-                {
+              {
+                "key": "collection/c",
+                "version": 1002,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "removed": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1401,7 +1843,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2001
+          "version": 2001,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -1452,13 +1895,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/b",
-                1001,
-                {
+              {
+                "key": "collection/b",
+                "version": 1001,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1472,22 +1919,30 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/d",
-                1003,
-                {
+              {
+                "key": "collection/d",
+                "version": 1003,
+                "value": {
                   "key": "d"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "removed": [
-              [
-                "collection/b",
-                1001,
-                {
+              {
+                "key": "collection/b",
+                "version": 1001,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1517,7 +1972,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2002
+          "version": 2002,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -1559,13 +2015,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/c",
-                1002,
-                {
+              {
+                "key": "collection/c",
+                "version": 1002,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1579,22 +2039,30 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/e",
-                1004,
-                {
+              {
+                "key": "collection/e",
+                "version": 1004,
+                "value": {
                   "key": "e"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "removed": [
-              [
-                "collection/c",
-                1002,
-                {
+              {
+                "key": "collection/c",
+                "version": 1002,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1624,7 +2092,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2003
+          "version": 2003,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [],
@@ -1656,13 +2125,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/d",
-                1003,
-                {
+              {
+                "key": "collection/d",
+                "version": 1003,
+                "value": {
                   "key": "d"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1676,22 +2149,30 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/f",
-                1005,
-                {
+              {
+                "key": "collection/f",
+                "version": 1005,
+                "value": {
                   "key": "f"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "removed": [
-              [
-                "collection/d",
-                1003,
-                {
+              {
+                "key": "collection/d",
+                "version": 1003,
+                "value": {
                   "key": "d"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1784,20 +2265,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/c",
-              1001,
-              {
+            },
+            {
+              "key": "collection/c",
+              "version": 1001,
+              "value": {
                 "key": "c"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1816,7 +2305,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -1831,20 +2321,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/c",
-                1001,
-                {
+              },
+              {
+                "key": "collection/c",
+                "version": 1001,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1860,13 +2358,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              1002,
-              {
+            {
+              "key": "collection/b",
+              "version": 1002,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1877,13 +2379,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/c",
-              1001,
-              {
+            {
+              "key": "collection/c",
+              "version": 1001,
+              "value": {
                 "key": "c"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "removedTargets": [
             2
@@ -1893,7 +2399,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002
+          "version": 1002,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -1908,22 +2415,30 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                1002,
-                {
+              {
+                "key": "collection/b",
+                "version": 1002,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "removed": [
-              [
-                "collection/c",
-                1001,
-                {
+              {
+                "key": "collection/c",
+                "version": 1001,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2010,20 +2525,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              1001,
-              {
+            {
+              "key": "collection/b",
+              "version": 1001,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/c",
-              1002,
-              {
+            },
+            {
+              "key": "collection/c",
+              "version": 1002,
+              "value": {
                 "key": "c"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -2042,7 +2565,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1002
+          "version": 1002,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -2057,20 +2581,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                1001,
-                {
+              {
+                "key": "collection/b",
+                "version": 1001,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/c",
-                1002,
-                {
+              },
+              {
+                "key": "collection/c",
+                "version": 1002,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2103,23 +2635,30 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "key": "a"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "removed": [
-              [
-                "collection/c",
-                1002,
-                {
+              {
+                "key": "collection/c",
+                "version": 1002,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2141,13 +2680,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1003,
-              {
+            {
+              "key": "collection/a",
+              "version": 1003,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -2158,13 +2701,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/c",
-              1002,
-              {
+            {
+              "key": "collection/c",
+              "version": 1002,
+              "value": {
                 "key": "c"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "removedTargets": [
             2
@@ -2174,7 +2721,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1003
+          "version": 1003,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -2189,13 +2737,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a",
-                1003,
-                {
+              {
+                "key": "collection/a",
+                "version": 1003,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,

--- a/Firestore/Example/Tests/SpecTests/json/listen_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/listen_spec_test.json
@@ -41,13 +41,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -64,7 +68,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -74,13 +79,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -164,13 +173,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -187,7 +200,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -197,13 +211,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -214,13 +232,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              2000,
-              {
+            {
+              "key": "collection/b",
+              "version": 2000,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -229,7 +251,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -239,13 +262,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                2000,
-                {
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -375,13 +402,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection2/a",
-              1000,
-              {
+            {
+              "key": "collection2/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             4
@@ -395,7 +426,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -415,19 +447,255 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection2/a",
-                1000,
-                {
+              {
+                "key": "collection2/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
             "hasPendingWrites": false
           }
         ]
+      }
+    ]
+  },
+  "Doesn't include unknown documents in cached result": {
+    "describeName": "Listens:",
+    "itName": "Doesn't include unknown documents in cached result",
+    "tags": [],
+    "config": {
+      "useGarbageCollection": true,
+      "numClients": 1
+    },
+    "steps": [
+      {
+        "userSet": [
+          "collection/exists",
+          {
+            "key": "a"
+          }
+        ]
+      },
+      {
+        "userPatch": [
+          "collection/unknown",
+          {
+            "key": "b"
+          }
+        ]
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/exists",
+                "version": 0,
+                "value": {
+                  "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true
+          }
+        ]
+      }
+    ]
+  },
+  "Doesn't raise 'hasPendingWrites' for deletes": {
+    "describeName": "Listens:",
+    "itName": "Doesn't raise 'hasPendingWrites' for deletes",
+    "tags": [],
+    "config": {
+      "useGarbageCollection": true,
+      "numClients": 1
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "version": 0,
+              "value": {
+                "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000,
+          "targetIds": []
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
+                  "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "userDelete": "collection/a",
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
+                  "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "writeAck": {
+          "version": 2000
+        },
+        "stateExpect": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": []
+          }
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "version": 2000,
+              "value": null
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000,
+          "targetIds": []
+        }
       }
     ]
   },
@@ -473,20 +741,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "a": true
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/b",
-              1000,
-              {
+            },
+            {
+              "key": "collection/b",
+              "version": 1000,
+              "value": {
                 "b": true
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -503,7 +779,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -513,13 +790,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "a": true
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -567,13 +848,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "a": true
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -622,11 +907,11 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              null
-            ]
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": null
+            }
           ],
           "removedTargets": [
             2
@@ -635,7 +920,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         }
       },
       {
@@ -648,7 +934,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -834,7 +1121,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -925,13 +1213,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection1/a",
-              1000,
-              {
+            {
+              "key": "collection1/a",
+              "version": 1000,
+              "value": {
                 "a": true
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -941,13 +1233,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection2/a",
-              1001,
-              {
+            {
+              "key": "collection2/a",
+              "version": 1001,
+              "value": {
                 "b": true
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             4
@@ -998,7 +1294,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1008,13 +1305,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection2/a",
-                1001,
-                {
+              {
+                "key": "collection2/a",
+                "version": 1001,
+                "value": {
                   "b": true
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1063,13 +1364,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "v": "v1000"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1086,7 +1391,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1096,13 +1402,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "v": "v1000"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1113,13 +1423,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              2000,
-              {
+            {
+              "key": "collection/a",
+              "version": 2000,
+              "value": {
                 "v": "v2000"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1128,7 +1442,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1138,13 +1453,17 @@
               "orderBys": []
             },
             "modified": [
-              [
-                "collection/a",
-                2000,
-                {
+              {
+                "key": "collection/a",
+                "version": 2000,
+                "value": {
                   "v": "v2000"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1201,13 +1520,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                2000,
-                {
+              {
+                "key": "collection/a",
+                "version": 2000,
+                "value": {
                   "v": "v2000"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1223,13 +1546,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "v": "v1000"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1246,19 +1573,24 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         }
       },
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              2000,
-              {
+            {
+              "key": "collection/a",
+              "version": 2000,
+              "value": {
                 "v": "v2000"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1267,7 +1599,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1325,13 +1658,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "v": "v1000"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1348,7 +1685,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1358,13 +1696,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "v": "v1000"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1375,13 +1717,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              2000,
-              {
+            {
+              "key": "collection/a",
+              "version": 2000,
+              "value": {
                 "v": "v2000"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1390,7 +1736,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1400,13 +1747,17 @@
               "orderBys": []
             },
             "modified": [
-              [
-                "collection/a",
-                2000,
-                {
+              {
+                "key": "collection/a",
+                "version": 2000,
+                "value": {
                   "v": "v2000"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1450,13 +1801,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                2000,
-                {
+              {
+                "key": "collection/a",
+                "version": 2000,
+                "value": {
                   "v": "v2000"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1472,13 +1827,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "v": "v1000"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1495,19 +1854,24 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         }
       },
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              2000,
-              {
+            {
+              "key": "collection/a",
+              "version": 2000,
+              "value": {
                 "v": "v2000"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1516,7 +1880,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1584,14 +1949,18 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "v": "v1000",
                 "visible": true
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1608,7 +1977,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1624,14 +1994,18 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "v": "v1000",
                   "visible": true
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1694,14 +2068,18 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "v": "v1000",
                   "visible": true
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1717,14 +2095,18 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              3000,
-              {
+            {
+              "key": "collection/a",
+              "version": 3000,
+              "value": {
                 "v": "v3000",
                 "visible": false
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             4
@@ -1741,7 +2123,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 4000
+          "version": 4000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1751,14 +2134,18 @@
               "orderBys": []
             },
             "modified": [
-              [
-                "collection/a",
-                3000,
-                {
+              {
+                "key": "collection/a",
+                "version": 3000,
+                "value": {
                   "v": "v3000",
                   "visible": false
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1828,14 +2215,18 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              2000,
-              {
+            {
+              "key": "collection/a",
+              "version": 2000,
+              "value": {
                 "v": "v2000",
                 "visible": false
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "removedTargets": [
             2
@@ -1852,7 +2243,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 5000
+          "version": 5000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1928,14 +2320,18 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                3000,
-                {
+              {
+                "key": "collection/a",
+                "version": 3000,
+                "value": {
                   "v": "v3000",
                   "visible": false
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1966,7 +2362,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 6000
+          "version": 6000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2034,14 +2431,18 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "v": "v1000",
                 "visible": true
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -2058,7 +2459,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2074,14 +2476,18 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "v": "v1000",
                   "visible": true
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2144,14 +2550,18 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "v": "v1000",
                   "visible": true
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2167,11 +2577,11 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              3000,
-              null
-            ]
+            {
+              "key": "collection/a",
+              "version": 3000,
+              "value": null
+            }
           ],
           "removedTargets": [
             4
@@ -2188,7 +2598,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 4000
+          "version": 4000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2198,14 +2609,18 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "v": "v1000",
                   "visible": true
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2275,14 +2690,18 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              2000,
-              {
+            {
+              "key": "collection/a",
+              "version": 2000,
+              "value": {
                 "v": "v2000",
                 "visible": false
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "removedTargets": [
             2
@@ -2299,7 +2718,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 5000
+          "version": 5000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2391,7 +2811,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 6000
+          "version": 6000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2400,6 +2821,247 @@
               "filters": [],
               "orderBys": []
             },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
+      }
+    ]
+  },
+  "Waits until Watch catches up to local deletes ": {
+    "describeName": "Listens:",
+    "itName": "Waits until Watch catches up to local deletes ",
+    "tags": [],
+    "config": {
+      "useGarbageCollection": true,
+      "numClients": 1
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
+                "v": "1"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000,
+          "targetIds": []
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
+                  "v": "1"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "userDelete": "collection/a",
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "removed": [
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
+                  "v": "1"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "version": 2000,
+              "value": {
+                "v": "2"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000,
+          "targetIds": []
+        }
+      },
+      {
+        "writeAck": {
+          "version": 4000
+        },
+        "stateExpect": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/a"
+            ],
+            "rejectedDocs": []
+          }
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "version": 3000,
+              "value": {
+                "v": "3"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 3000,
+          "targetIds": []
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "version": 5000,
+              "value": {
+                "v": "5"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 5000,
+          "targetIds": []
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/a",
+                "version": 5000,
+                "value": {
+                  "v": "5"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
             "errorCode": 0,
             "fromCache": false,
             "hasPendingWrites": false
@@ -2459,13 +3121,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -2482,7 +3148,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2498,13 +3165,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2515,11 +3186,11 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              2000,
-              null
-            ]
+            {
+              "key": "collection/a",
+              "version": 2000,
+              "value": null
+            }
           ],
           "removedTargets": [
             2
@@ -2537,7 +3208,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2553,13 +3225,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2623,13 +3299,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             4
@@ -2646,7 +3326,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 3000
+          "version": 3000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2656,13 +3337,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2712,13 +3397,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -2735,7 +3424,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2745,13 +3435,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2802,13 +3496,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              2000,
-              {
+            {
+              "key": "collection/b",
+              "version": 2000,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -2825,7 +3523,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2835,13 +3534,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                2000,
-                {
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2890,20 +3593,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/b",
-              1000,
-              {
+            },
+            {
+              "key": "collection/b",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -2920,7 +3631,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2930,20 +3642,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/b",
-                1000,
-                {
+              },
+              {
+                "key": "collection/b",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -3000,20 +3720,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/b",
-                1000,
-                {
+              },
+              {
+                "key": "collection/b",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3063,13 +3791,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3092,7 +3824,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -3102,13 +3835,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -3165,13 +3902,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                1000,
-                {
+              {
+                "key": "collection/b",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3220,13 +3961,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -3243,7 +3988,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -3253,13 +3999,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -3316,13 +4066,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3338,11 +4092,11 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              2000,
-              null
-            ]
+            {
+              "key": "collection/a",
+              "version": 2000,
+              "value": null
+            }
           ],
           "removedTargets": [
             2
@@ -3359,7 +4113,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -3369,13 +4124,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -3424,13 +4183,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -3447,7 +4210,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -3457,13 +4221,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -3487,13 +4255,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              2000,
-              {
+            {
+              "key": "collection/b",
+              "version": 2000,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -3502,7 +4274,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         }
       },
       {
@@ -3541,13 +4314,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3596,13 +4373,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -3611,7 +4392,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -3621,13 +4403,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3645,7 +4431,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -3702,13 +4489,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3819,7 +4610,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -3890,7 +4682,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -3908,13 +4701,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              2000,
-              {
+            {
+              "key": "collection/a",
+              "version": 2000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -3932,7 +4729,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -3942,13 +4740,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                2000,
-                {
+              {
+                "key": "collection/a",
+                "version": 2000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -4005,13 +4807,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                2000,
-                {
+              {
+                "key": "collection/a",
+                "version": 2000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4042,7 +4848,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 3000
+          "version": 3000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -4098,13 +4905,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -4121,7 +4932,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -4131,13 +4943,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -4201,13 +5017,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4230,7 +5050,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 3000
+          "version": 3000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -4288,13 +5109,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -4311,7 +5136,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -4321,13 +5147,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -4378,13 +5208,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4407,7 +5241,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 3000
+          "version": 3000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -4465,13 +5300,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -4488,7 +5327,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -4498,13 +5338,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -4555,13 +5399,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4584,7 +5432,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 300002000
+          "version": 300002000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -4674,13 +5523,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -4690,7 +5543,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -4704,13 +5558,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4734,7 +5592,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -4809,13 +5668,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -4834,7 +5697,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -4844,13 +5708,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -4892,13 +5760,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -4940,13 +5812,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -4962,13 +5838,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              2000,
-              {
+            {
+              "key": "collection/b",
+              "version": 2000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -4978,7 +5858,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -4988,13 +5869,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                2000,
-                {
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5013,13 +5898,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                2000,
-                {
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5038,13 +5927,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                2000,
-                {
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5125,13 +6018,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -5150,7 +6047,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 100
+          "version": 100,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -5164,13 +6062,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5186,13 +6088,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              2000,
-              {
+            {
+              "key": "collection/b",
+              "version": 2000,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -5202,7 +6108,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -5235,20 +6142,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/b",
-                2000,
-                {
+              },
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5260,13 +6175,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/c",
-              3000,
-              {
+            {
+              "key": "collection/c",
+              "version": 3000,
+              "value": {
                 "key": "c"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -5276,7 +6195,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 3000
+          "version": 3000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -5286,13 +6206,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/c",
-                3000,
-                {
+              {
+                "key": "collection/c",
+                "version": 3000,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5311,13 +6235,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                2000,
-                {
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5330,13 +6258,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/c",
-                3000,
-                {
+              {
+                "key": "collection/c",
+                "version": 3000,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5451,13 +6383,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -5476,7 +6412,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -5494,13 +6431,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5519,13 +6460,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5589,13 +6534,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -5614,7 +6563,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -5624,13 +6574,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5672,13 +6626,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5717,13 +6675,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              2000,
-              {
+            {
+              "key": "collection/b",
+              "version": 2000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -5733,7 +6695,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -5747,13 +6710,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                2000,
-                {
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5858,13 +6825,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -5883,7 +6854,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -5897,13 +6869,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5974,13 +6950,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -6014,13 +6994,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              2000,
-              {
+            {
+              "key": "collection/b",
+              "version": 2000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -6039,7 +7023,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -6053,13 +7038,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                2000,
-                {
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -6325,7 +7314,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -6437,7 +7427,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -6531,7 +7522,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -6617,7 +7609,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -6844,7 +7837,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -6982,7 +7976,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "clientIndex": 2
       },
@@ -7110,7 +8105,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -7145,13 +8141,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              2000,
-              {
+            {
+              "key": "collection/a",
+              "version": 2000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -7161,7 +8161,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -7175,13 +8176,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                2000,
-                {
+              {
+                "key": "collection/a",
+                "version": 2000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -7389,13 +8394,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -7414,7 +8423,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -7428,13 +8438,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -7476,13 +8490,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -7533,13 +8551,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              2000,
-              {
+            {
+              "key": "collection/b",
+              "version": 2000,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -7558,7 +8580,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -7568,13 +8591,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                2000,
-                {
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -7593,13 +8620,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                2000,
-                {
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -7660,13 +8691,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -7685,7 +8720,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -7695,13 +8731,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -7747,13 +8787,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -7804,13 +8848,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              2000,
-              {
+            {
+              "key": "collection/b",
+              "version": 2000,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -7829,7 +8877,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "clientIndex": 1
       },
@@ -7843,13 +8892,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                2000,
-                {
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -7910,13 +8963,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -7935,7 +8992,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -7945,13 +9003,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -7993,13 +9055,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -8036,13 +9102,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              2000,
-              {
+            {
+              "key": "collection/b",
+              "version": 2000,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -8061,7 +9131,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -8071,13 +9142,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                2000,
-                {
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -8097,13 +9172,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/c",
-              3000,
-              {
+            {
+              "key": "collection/c",
+              "version": 3000,
+              "value": {
                 "key": "c"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -8113,7 +9192,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 3000
+          "version": 3000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -8123,13 +9203,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/c",
-                3000,
-                {
+              {
+                "key": "collection/c",
+                "version": 3000,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -8155,20 +9239,368 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                2000,
-                {
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/c",
-                3000,
-                {
+              },
+              {
+                "key": "collection/c",
+                "version": 3000,
+                "value": {
                   "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ],
+        "clientIndex": 0
+      }
+    ]
+  },
+  "Query bounces between primaries": {
+    "describeName": "Listens:",
+    "itName": "Query bounces between primaries",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "useGarbageCollection": false,
+      "numClients": 3
+    },
+    "steps": [
+      {
+        "drainQueue": true,
+        "stateExpect": {
+          "isPrimary": true
+        },
+        "clientIndex": 1
+      },
+      {
+        "drainQueue": true,
+        "clientIndex": 0
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        },
+        "clientIndex": 0
+      },
+      {
+        "drainQueue": true,
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        },
+        "clientIndex": 1
+      },
+      {
+        "watchAck": [
+          2
+        ],
+        "clientIndex": 1
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
+                "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        },
+        "clientIndex": 1
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ],
+        "clientIndex": 1
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000,
+          "targetIds": []
+        },
+        "clientIndex": 1
+      },
+      {
+        "drainQueue": true,
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
+                  "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ],
+        "clientIndex": 0
+      },
+      {
+        "drainQueue": true,
+        "clientIndex": 2
+      },
+      {
+        "applyClientState": {
+          "primary": true
+        },
+        "stateExpect": {
+          "isPrimary": true,
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        },
+        "clientIndex": 2
+      },
+      {
+        "drainQueue": true,
+        "clientIndex": 1
+      },
+      {
+        "runTimer": "client_metadata_refresh",
+        "stateExpect": {
+          "isPrimary": false
+        },
+        "clientIndex": 1
+      },
+      {
+        "drainQueue": true,
+        "clientIndex": 2
+      },
+      {
+        "watchAck": [
+          2
+        ],
+        "clientIndex": 2
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/b",
+              "version": 2000,
+              "value": {
+                "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        },
+        "clientIndex": 2
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ],
+        "clientIndex": 2
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000,
+          "targetIds": []
+        },
+        "clientIndex": 2
+      },
+      {
+        "drainQueue": true,
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
+                  "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ],
+        "clientIndex": 0
+      },
+      {
+        "drainQueue": true,
+        "clientIndex": 1
+      },
+      {
+        "applyClientState": {
+          "primary": true
+        },
+        "stateExpect": {
+          "isPrimary": true,
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": "resume-token-2000"
+            }
+          }
+        },
+        "clientIndex": 1
+      },
+      {
+        "watchAck": [
+          2
+        ],
+        "clientIndex": 1
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/c",
+              "version": 3000,
+              "value": {
+                "key": "c"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        },
+        "clientIndex": 1
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ],
+        "clientIndex": 1
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000,
+          "targetIds": []
+        },
+        "clientIndex": 1
+      },
+      {
+        "drainQueue": true,
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/c",
+                "version": 3000,
+                "value": {
+                  "key": "c"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -8266,13 +9698,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -8291,7 +9727,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -8320,13 +9757,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -8345,7 +9786,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -8355,13 +9797,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -8442,13 +9888,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -8467,7 +9917,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "clientIndex": 0
       },
@@ -8481,13 +9932,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -8534,13 +9989,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              2000,
-              {
+            {
+              "key": "collection/b",
+              "version": 2000,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -8559,7 +10018,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "clientIndex": 2
       },
@@ -8573,13 +10033,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                2000,
-                {
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
                   "key": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -8587,6 +10051,212 @@
           }
         ],
         "clientIndex": 1
+      }
+    ]
+  },
+  "Previous primary immediately regains primary lease": {
+    "describeName": "Listens:",
+    "itName": "Previous primary immediately regains primary lease",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "useGarbageCollection": false,
+      "numClients": 2
+    },
+    "steps": [
+      {
+        "drainQueue": true,
+        "clientIndex": 0
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        },
+        "clientIndex": 0
+      },
+      {
+        "watchAck": [
+          2
+        ],
+        "clientIndex": 0
+      },
+      {
+        "watchEntity": {
+          "docs": [],
+          "targets": [
+            2
+          ]
+        },
+        "clientIndex": 0
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ],
+        "clientIndex": 0
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000,
+          "targetIds": []
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ],
+        "clientIndex": 0
+      },
+      {
+        "drainQueue": true,
+        "clientIndex": 1
+      },
+      {
+        "applyClientState": {
+          "primary": true
+        },
+        "stateExpect": {
+          "isPrimary": true,
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        },
+        "clientIndex": 1
+      },
+      {
+        "watchAck": [
+          2
+        ],
+        "clientIndex": 1
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "version": 2000,
+              "value": {
+                "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        },
+        "clientIndex": 1
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ],
+        "clientIndex": 1
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000,
+          "targetIds": []
+        },
+        "clientIndex": 1
+      },
+      {
+        "shutdown": true,
+        "stateExpect": {
+          "activeTargets": {},
+          "limboDocs": []
+        },
+        "clientIndex": 1
+      },
+      {
+        "drainQueue": true,
+        "stateExpect": {
+          "isPrimary": true
+        },
+        "clientIndex": 0
+      },
+      {
+        "runTimer": "client_metadata_refresh",
+        "stateExpect": {
+          "isPrimary": true,
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": "resume-token-2000"
+            }
+          }
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/a",
+                "version": 2000,
+                "value": {
+                  "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ],
+        "clientIndex": 0
       }
     ]
   }

--- a/Firestore/Example/Tests/SpecTests/json/offline_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/offline_spec_test.json
@@ -318,13 +318,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -341,7 +345,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -351,13 +356,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -430,7 +439,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -486,13 +496,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -509,7 +523,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -519,13 +534,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -548,7 +567,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         },
         "stateExpect": {
           "limboDocs": [
@@ -647,7 +667,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         }
       },
       {
@@ -673,7 +694,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         },
         "expect": [
           {
@@ -683,13 +705,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -784,13 +810,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -807,7 +837,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -817,13 +848,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1061,7 +1096,9 @@
   "Queries return from cache when network disabled": {
     "describeName": "Offline:",
     "itName": "Queries return from cache when network disabled",
-    "tags": ["eager-gc"],
+    "tags": [
+      "eager-gc"
+    ],
     "config": {
       "useGarbageCollection": true,
       "numClients": 1

--- a/Firestore/Example/Tests/SpecTests/json/orderby_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/orderby_spec_test.json
@@ -77,15 +77,18 @@
               ]
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "key": "a",
                   "sort": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -101,13 +104,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              1001,
-              {
+            {
+              "key": "collection/b",
+              "version": 1001,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -124,7 +131,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -139,15 +147,18 @@
               ]
             },
             "added": [
-              [
-                "collection/b",
-                1001,
-                {
+              {
+                "key": "collection/b",
+                "version": 1001,
+                "value": {
                   "key": "b",
                   "sort": 2
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -206,22 +217,30 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              0,
-              {
+            {
+              "key": "collection/a",
+              "version": 0,
+              "value": {
                 "key": "a",
                 "sort": 2
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/b",
-              1001,
-              {
+            },
+            {
+              "key": "collection/b",
+              "version": 1001,
+              "value": {
                 "key": "b",
                 "sort": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -238,7 +257,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -253,22 +273,30 @@
               ]
             },
             "added": [
-              [
-                "collection/b",
-                1001,
-                {
+              {
+                "key": "collection/b",
+                "version": 1001,
+                "value": {
                   "key": "b",
                   "sort": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/a",
-                0,
-                {
+              },
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "key": "a",
                   "sort": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -345,22 +373,30 @@
               ]
             },
             "added": [
-              [
-                "collection/b",
-                1001,
-                {
+              {
+                "key": "collection/b",
+                "version": 1001,
+                "value": {
                   "key": "b",
                   "sort": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/a",
-                0,
-                {
+              },
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "key": "a",
                   "sort": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -391,7 +427,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {

--- a/Firestore/Example/Tests/SpecTests/json/persistence_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/persistence_spec_test.json
@@ -112,22 +112,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key1",
-                0,
-                {
+              {
+                "key": "collection/key1",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ],
-              [
-                "collection/key2",
-                0,
-                {
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/key2",
+                "version": 0,
+                "value": {
                   "baz": "quu"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -178,13 +184,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/key",
-              1000,
-              {
+            {
+              "key": "collection/key",
+              "version": 1000,
+              "value": {
                 "foo": "bar"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -201,7 +211,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -211,13 +222,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                1000,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "foo": "bar"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -261,13 +276,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                1000,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "foo": "bar"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -316,13 +335,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/key",
-              1000,
-              {
+            {
+              "key": "collection/key",
+              "version": 1000,
+              "value": {
                 "foo": "bar"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -339,7 +362,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -349,13 +373,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                1000,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "foo": "bar"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -405,13 +433,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                1000,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "foo": "bar"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -480,13 +512,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "foo": "bar"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": true
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -709,13 +745,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "users/existing",
-              0,
-              {
+            {
+              "key": "users/existing",
+              "version": 0,
+              "value": {
                 "uid": "existing"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -732,7 +772,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 500
+          "version": 500,
+          "targetIds": []
         },
         "expect": [
           {
@@ -742,13 +783,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "users/existing",
-                0,
-                {
+              {
+                "key": "users/existing",
+                "version": 0,
+                "value": {
                   "uid": "existing"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -771,14 +816,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "users/anon",
-                0,
-                {
+              {
+                "key": "users/anon",
+                "version": 0,
+                "value": {
                   "uid": "anon"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -808,14 +856,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "users/anon",
-                0,
-                {
+              {
+                "key": "users/anon",
+                "version": 0,
+                "value": {
                   "uid": "anon"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -838,14 +889,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "users/user1",
-                0,
-                {
+              {
+                "key": "users/user1",
+                "version": 0,
+                "value": {
                   "uid": "user1"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -863,24 +917,30 @@
               "orderBys": []
             },
             "added": [
-              [
-                "users/anon",
-                0,
-                {
+              {
+                "key": "users/anon",
+                "version": 0,
+                "value": {
                   "uid": "anon"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "removed": [
-              [
-                "users/user1",
-                0,
-                {
+              {
+                "key": "users/user1",
+                "version": 0,
+                "value": {
                   "uid": "user1"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,

--- a/Firestore/Example/Tests/SpecTests/json/remote_store_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/remote_store_spec_test.json
@@ -73,13 +73,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -96,7 +100,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         }
       },
       {
@@ -114,13 +119,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -137,7 +146,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         },
         "expect": [
           {
@@ -147,13 +157,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -307,13 +321,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -330,7 +348,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         }
       },
       {
@@ -348,13 +367,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              1000,
-              {
+            {
+              "key": "collection/b",
+              "version": 1000,
+              "value": {
                 "key": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -371,7 +394,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         }
       },
       {
@@ -389,13 +413,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/c",
-              1000,
-              {
+            {
+              "key": "collection/c",
+              "version": 1000,
+              "value": {
                 "key": "c"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -412,7 +440,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         }
       },
       {
@@ -430,13 +459,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/d",
-              1000,
-              {
+            {
+              "key": "collection/d",
+              "version": 1000,
+              "value": {
                 "key": "d"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -453,7 +486,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         },
         "expect": [
           {
@@ -463,13 +497,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/d",
-                1000,
-                {
+              {
+                "key": "collection/d",
+                "version": 1000,
+                "value": {
                   "key": "d"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -539,13 +577,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -562,7 +604,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         },
         "expect": [
           {
@@ -572,13 +615,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,

--- a/Firestore/Example/Tests/SpecTests/json/resume_token_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/resume_token_spec_test.json
@@ -38,13 +38,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -61,7 +65,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -71,13 +76,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -147,13 +156,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "key": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -170,7 +183,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -180,13 +194,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -236,13 +254,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "key": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -257,7 +279,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1001
+          "version": 1001,
+          "targetIds": []
         }
       }
     ]

--- a/Firestore/Example/Tests/SpecTests/json/write_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/write_spec_test.json
@@ -38,20 +38,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/b",
-              500,
-              {
+            },
+            {
+              "key": "collection/b",
+              "version": 500,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -68,7 +76,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -78,20 +87,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/b",
-                500,
-                {
+              },
+              {
+                "key": "collection/b",
+                "version": 500,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -114,14 +131,17 @@
               "orderBys": []
             },
             "modified": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "v": 2
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -132,13 +152,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              2000,
-              {
+            {
+              "key": "collection/a",
+              "version": 2000,
+              "value": {
                 "v": 2
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -147,7 +171,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         }
       },
       {
@@ -170,13 +195,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a",
-                2000,
-                {
+              {
+                "key": "collection/a",
+                "version": 2000,
+                "value": {
                   "v": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -199,14 +228,17 @@
               "orderBys": []
             },
             "modified": [
-              [
-                "collection/b",
-                500,
-                {
+              {
+                "key": "collection/b",
+                "version": 500,
+                "value": {
                   "v": 2
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -217,13 +249,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              2500,
-              {
+            {
+              "key": "collection/b",
+              "version": 2500,
+              "value": {
                 "v": 2
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -232,12 +268,13 @@
       },
       {
         "watchSnapshot": {
-          "version": 3000
+          "version": 3000,
+          "targetIds": []
         }
       },
       {
         "writeAck": {
-          "version": 3000
+          "version": 2500
         },
         "stateExpect": {
           "userCallbacks": {
@@ -255,13 +292,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/b",
-                2500,
-                {
+              {
+                "key": "collection/b",
+                "version": 2500,
+                "value": {
                   "v": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -310,13 +351,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/key",
-              1000,
-              {
+            {
+              "key": "collection/key",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -333,7 +378,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -343,13 +389,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                1000,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -372,14 +422,17 @@
               "orderBys": []
             },
             "modified": [
-              [
-                "collection/key",
-                1000,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "v": 2
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -390,13 +443,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/key",
-              2000,
-              {
+            {
+              "key": "collection/key",
+              "version": 2000,
+              "value": {
                 "v": 2
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -405,7 +462,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         }
       },
       {
@@ -428,13 +486,332 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/key",
-                2000,
-                {
+              {
+                "key": "collection/key",
+                "version": 2000,
+                "value": {
                   "v": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
+      }
+    ]
+  },
+  "Raises snapshot with 'hasPendingWrites' for unacknowledged write": {
+    "describeName": "Writes:",
+    "itName": "Raises snapshot with 'hasPendingWrites' for unacknowledged write",
+    "tags": [],
+    "config": {
+      "useGarbageCollection": false,
+      "numClients": 1
+    },
+    "steps": [
+      {
+        "userSet": [
+          "collection/doc",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/doc",
+                "version": 0,
+                "value": {
+                  "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true
+          }
+        ]
+      }
+    ]
+  },
+  "Doesn't raise 'hasPendingWrites' for committed write and new listen": {
+    "describeName": "Writes:",
+    "itName": "Doesn't raise 'hasPendingWrites' for committed write and new listen",
+    "tags": [],
+    "config": {
+      "useGarbageCollection": false,
+      "numClients": 1
+    },
+    "steps": [
+      {
+        "userSet": [
+          "collection/doc",
+          {
+            "v": 1
+          }
+        ]
+      },
+      {
+        "writeAck": {
+          "version": 1000
+        },
+        "stateExpect": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/doc"
+            ],
+            "rejectedDocs": []
+          }
+        }
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/doc",
+                "version": 1000,
+                "value": {
+                  "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": true
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ]
+      }
+    ]
+  },
+  "Doesn't raise event for document with pending patch": {
+    "describeName": "Writes:",
+    "itName": "Doesn't raise event for document with pending patch",
+    "tags": [],
+    "config": {
+      "useGarbageCollection": false,
+      "numClients": 1
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-250"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 250,
+          "targetIds": []
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "userPatch": [
+          "collection/doc",
+          {
+            "v": 2
+          }
+        ]
+      },
+      {
+        "writeAck": {
+          "version": 1000
+        },
+        "stateExpect": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/doc"
+            ],
+            "rejectedDocs": []
+          }
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/doc",
+              "version": 500,
+              "value": {
+                "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 500,
+          "targetIds": []
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/doc",
+              "version": 1000,
+              "value": {
+                "v": 2
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000,
+          "targetIds": []
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/doc",
+                "version": 1000,
+                "value": {
+                  "v": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -483,13 +860,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/key",
-              1000,
-              {
+            {
+              "key": "collection/key",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -506,7 +887,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -516,13 +898,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                1000,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -545,14 +931,17 @@
               "orderBys": []
             },
             "modified": [
-              [
-                "collection/key",
-                1000,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "v": 2
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -563,13 +952,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/key",
-              10000,
-              {
+            {
+              "key": "collection/key",
+              "version": 10000,
+              "value": {
                 "v": 3
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -578,7 +971,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 10000
+          "version": 10000,
+          "targetIds": []
         }
       },
       {
@@ -601,13 +995,17 @@
               "orderBys": []
             },
             "modified": [
-              [
-                "collection/key",
-                10000,
-                {
+              {
+                "key": "collection/key",
+                "version": 10000,
+                "value": {
                   "v": 3
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -656,13 +1054,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/key",
-              1000,
-              {
+            {
+              "key": "collection/key",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -679,7 +1081,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -689,13 +1092,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                1000,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -718,14 +1125,17 @@
               "orderBys": []
             },
             "modified": [
-              [
-                "collection/key",
-                1000,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "v": 2
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -749,13 +1159,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/key",
-              2000,
-              {
+            {
+              "key": "collection/key",
+              "version": 2000,
+              "value": {
                 "v": 2
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -764,7 +1178,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -774,13 +1189,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/key",
-                2000,
-                {
+              {
+                "key": "collection/key",
+                "version": 2000,
+                "value": {
                   "v": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -829,13 +1248,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/key",
-              1000,
-              {
+            {
+              "key": "collection/key",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -852,7 +1275,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -862,13 +1286,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                1000,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -891,14 +1319,17 @@
               "orderBys": []
             },
             "modified": [
-              [
-                "collection/key",
-                1000,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "v": 3
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -922,13 +1353,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/key",
-              2000,
-              {
+            {
+              "key": "collection/key",
+              "version": 2000,
+              "value": {
                 "v": 2
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -937,26 +1372,35 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         }
       },
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              3000,
-              {
+            {
+              "key": "collection/b",
+              "version": 3000,
+              "value": {
                 "doc": "b"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/key",
-              3000,
-              {
+            },
+            {
+              "key": "collection/key",
+              "version": 3000,
+              "value": {
                 "v": 3
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -965,7 +1409,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 3000
+          "version": 3000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -975,22 +1420,329 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                3000,
-                {
+              {
+                "key": "collection/b",
+                "version": 3000,
+                "value": {
                   "doc": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "metadata": [
-              [
-                "collection/key",
-                3000,
-                {
+              {
+                "key": "collection/key",
+                "version": 3000,
+                "value": {
                   "v": 3
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
+      }
+    ]
+  },
+  "Local patch is applied to query until watch catches up": {
+    "describeName": "Writes:",
+    "itName": "Local patch is applied to query until watch catches up",
+    "tags": [],
+    "config": {
+      "useGarbageCollection": false,
+      "numClients": 1
+    },
+    "steps": [
+      {
+        "userSet": [
+          "collection/doc",
+          {
+            "local": 1
+          }
+        ]
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/doc",
+                "version": 0,
+                "value": {
+                  "local": 1
+                },
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true
+          }
+        ]
+      },
+      {
+        "writeAck": {
+          "version": 1000
+        },
+        "stateExpect": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/doc"
+            ],
+            "rejectedDocs": []
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/doc",
+              "version": 2000,
+              "value": {
+                "local": 1,
+                "remote": 2
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000,
+          "targetIds": []
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "modified": [
+              {
+                "key": "collection/doc",
+                "version": 2000,
+                "value": {
+                  "local": 1,
+                  "remote": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
+      },
+      {
+        "userPatch": [
+          "collection/doc",
+          {
+            "local": 5
+          }
+        ],
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "modified": [
+              {
+                "key": "collection/doc",
+                "version": 2000,
+                "value": {
+                  "local": 5,
+                  "remote": 2
+                },
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true
+          }
+        ]
+      },
+      {
+        "writeAck": {
+          "version": 5000
+        },
+        "stateExpect": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/doc"
+            ],
+            "rejectedDocs": []
+          }
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/doc",
+              "version": 3000,
+              "value": {
+                "local": 1,
+                "remote": 3
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": true
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 3000,
+          "targetIds": []
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/doc",
+              "version": 4000,
+              "value": {
+                "local": 1,
+                "remote": 4
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": true
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 4000,
+          "targetIds": []
+        }
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/doc",
+              "version": 5000,
+              "value": {
+                "local": 5,
+                "remote": 5
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchSnapshot": {
+          "version": 5000,
+          "targetIds": []
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "modified": [
+              {
+                "key": "collection/doc",
+                "version": 5000,
+                "value": {
+                  "local": 5,
+                  "remote": 5
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1059,14 +1811,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a0",
-                0,
-                {
+              {
+                "key": "collection/a0",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1089,14 +1844,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a1",
-                0,
-                {
+              {
+                "key": "collection/a1",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1119,14 +1877,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a2",
-                0,
-                {
+              {
+                "key": "collection/a2",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1149,14 +1910,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a3",
-                0,
-                {
+              {
+                "key": "collection/a3",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1179,14 +1943,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a4",
-                0,
-                {
+              {
+                "key": "collection/a4",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1209,14 +1976,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a5",
-                0,
-                {
+              {
+                "key": "collection/a5",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1239,14 +2009,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a6",
-                0,
-                {
+              {
+                "key": "collection/a6",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1269,14 +2042,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a7",
-                0,
-                {
+              {
+                "key": "collection/a7",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1299,14 +2075,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a8",
-                0,
-                {
+              {
+                "key": "collection/a8",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1329,14 +2108,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a9",
-                0,
-                {
+              {
+                "key": "collection/a9",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1359,14 +2141,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a10",
-                0,
-                {
+              {
+                "key": "collection/a10",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1389,14 +2174,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a11",
-                0,
-                {
+              {
+                "key": "collection/a11",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1419,14 +2207,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a12",
-                0,
-                {
+              {
+                "key": "collection/a12",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1449,14 +2240,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a13",
-                0,
-                {
+              {
+                "key": "collection/a13",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1479,14 +2273,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a14",
-                0,
-                {
+              {
+                "key": "collection/a14",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -1513,13 +2310,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a0",
-              1000,
-              {
+            {
+              "key": "collection/a0",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1528,7 +2329,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1538,13 +2340,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a0",
-                1000,
-                {
+              {
+                "key": "collection/a0",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1568,13 +2374,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a1",
-              2000,
-              {
+            {
+              "key": "collection/a1",
+              "version": 2000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1583,7 +2393,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1593,13 +2404,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a1",
-                2000,
-                {
+              {
+                "key": "collection/a1",
+                "version": 2000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1623,13 +2438,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a2",
-              3000,
-              {
+            {
+              "key": "collection/a2",
+              "version": 3000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1638,7 +2457,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 3000
+          "version": 3000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1648,13 +2468,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a2",
-                3000,
-                {
+              {
+                "key": "collection/a2",
+                "version": 3000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1678,13 +2502,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a3",
-              4000,
-              {
+            {
+              "key": "collection/a3",
+              "version": 4000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1693,7 +2521,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 4000
+          "version": 4000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1703,13 +2532,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a3",
-                4000,
-                {
+              {
+                "key": "collection/a3",
+                "version": 4000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1733,13 +2566,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a4",
-              5000,
-              {
+            {
+              "key": "collection/a4",
+              "version": 5000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1748,7 +2585,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 5000
+          "version": 5000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1758,13 +2596,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a4",
-                5000,
-                {
+              {
+                "key": "collection/a4",
+                "version": 5000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1788,13 +2630,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a5",
-              6000,
-              {
+            {
+              "key": "collection/a5",
+              "version": 6000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1803,7 +2649,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 6000
+          "version": 6000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1813,13 +2660,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a5",
-                6000,
-                {
+              {
+                "key": "collection/a5",
+                "version": 6000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1843,13 +2694,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a6",
-              7000,
-              {
+            {
+              "key": "collection/a6",
+              "version": 7000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1858,7 +2713,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 7000
+          "version": 7000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1868,13 +2724,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a6",
-                7000,
-                {
+              {
+                "key": "collection/a6",
+                "version": 7000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1898,13 +2758,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a7",
-              8000,
-              {
+            {
+              "key": "collection/a7",
+              "version": 8000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1913,7 +2777,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 8000
+          "version": 8000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1923,13 +2788,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a7",
-                8000,
-                {
+              {
+                "key": "collection/a7",
+                "version": 8000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -1953,13 +2822,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a8",
-              9000,
-              {
+            {
+              "key": "collection/a8",
+              "version": 9000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -1968,7 +2841,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 9000
+          "version": 9000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -1978,13 +2852,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a8",
-                9000,
-                {
+              {
+                "key": "collection/a8",
+                "version": 9000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2008,13 +2886,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a9",
-              10000,
-              {
+            {
+              "key": "collection/a9",
+              "version": 10000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -2023,7 +2905,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 10000
+          "version": 10000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2033,13 +2916,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a9",
-                10000,
-                {
+              {
+                "key": "collection/a9",
+                "version": 10000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2063,13 +2950,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a10",
-              11000,
-              {
+            {
+              "key": "collection/a10",
+              "version": 11000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -2078,7 +2969,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 11000
+          "version": 11000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2088,13 +2980,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a10",
-                11000,
-                {
+              {
+                "key": "collection/a10",
+                "version": 11000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2118,13 +3014,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a11",
-              12000,
-              {
+            {
+              "key": "collection/a11",
+              "version": 12000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -2133,7 +3033,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 12000
+          "version": 12000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2143,13 +3044,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a11",
-                12000,
-                {
+              {
+                "key": "collection/a11",
+                "version": 12000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2173,13 +3078,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a12",
-              13000,
-              {
+            {
+              "key": "collection/a12",
+              "version": 13000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -2188,7 +3097,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 13000
+          "version": 13000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2198,13 +3108,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a12",
-                13000,
-                {
+              {
+                "key": "collection/a12",
+                "version": 13000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2228,13 +3142,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a13",
-              14000,
-              {
+            {
+              "key": "collection/a13",
+              "version": 14000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -2243,7 +3161,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 14000
+          "version": 14000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2253,13 +3172,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a13",
-                14000,
-                {
+              {
+                "key": "collection/a13",
+                "version": 14000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2283,13 +3206,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a14",
-              15000,
-              {
+            {
+              "key": "collection/a14",
+              "version": 15000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -2298,7 +3225,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 15000
+          "version": 15000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -2308,13 +3236,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a14",
-                15000,
-                {
+              {
+                "key": "collection/a14",
+                "version": 15000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -2370,14 +3302,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a0",
-                0,
-                {
+              {
+                "key": "collection/a0",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2400,14 +3335,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a1",
-                0,
-                {
+              {
+                "key": "collection/a1",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2430,14 +3368,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a2",
-                0,
-                {
+              {
+                "key": "collection/a2",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2460,14 +3401,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a3",
-                0,
-                {
+              {
+                "key": "collection/a3",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2490,14 +3434,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a4",
-                0,
-                {
+              {
+                "key": "collection/a4",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2520,14 +3467,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a5",
-                0,
-                {
+              {
+                "key": "collection/a5",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2550,14 +3500,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a6",
-                0,
-                {
+              {
+                "key": "collection/a6",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2580,14 +3533,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a7",
-                0,
-                {
+              {
+                "key": "collection/a7",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2610,14 +3566,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a8",
-                0,
-                {
+              {
+                "key": "collection/a8",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2640,14 +3599,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a9",
-                0,
-                {
+              {
+                "key": "collection/a9",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2670,14 +3632,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a10",
-                0,
-                {
+              {
+                "key": "collection/a10",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2700,14 +3665,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a11",
-                0,
-                {
+              {
+                "key": "collection/a11",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2730,14 +3698,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a12",
-                0,
-                {
+              {
+                "key": "collection/a12",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2760,14 +3731,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a13",
-                0,
-                {
+              {
+                "key": "collection/a13",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2790,14 +3764,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a14",
-                0,
-                {
+              {
+                "key": "collection/a14",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2830,14 +3807,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a0",
-                0,
-                {
+              {
+                "key": "collection/a0",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2867,14 +3847,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a1",
-                0,
-                {
+              {
+                "key": "collection/a1",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2904,14 +3887,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a2",
-                0,
-                {
+              {
+                "key": "collection/a2",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2941,14 +3927,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a3",
-                0,
-                {
+              {
+                "key": "collection/a3",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -2978,14 +3967,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a4",
-                0,
-                {
+              {
+                "key": "collection/a4",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3015,14 +4007,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a5",
-                0,
-                {
+              {
+                "key": "collection/a5",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3052,14 +4047,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a6",
-                0,
-                {
+              {
+                "key": "collection/a6",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3089,14 +4087,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a7",
-                0,
-                {
+              {
+                "key": "collection/a7",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3126,14 +4127,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a8",
-                0,
-                {
+              {
+                "key": "collection/a8",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3163,14 +4167,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a9",
-                0,
-                {
+              {
+                "key": "collection/a9",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3200,14 +4207,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a10",
-                0,
-                {
+              {
+                "key": "collection/a10",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3237,14 +4247,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a11",
-                0,
-                {
+              {
+                "key": "collection/a11",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3274,14 +4287,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a12",
-                0,
-                {
+              {
+                "key": "collection/a12",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3311,14 +4327,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a13",
-                0,
-                {
+              {
+                "key": "collection/a13",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3349,14 +4368,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a14",
-                0,
-                {
+              {
+                "key": "collection/a14",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -3405,13 +4427,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -3428,7 +4454,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -3438,13 +4465,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -3467,14 +4498,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                0,
-                {
+              {
+                "key": "collection/b",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -3510,14 +4544,17 @@
               "orderBys": []
             },
             "modified": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "v": 2
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -3547,13 +4584,17 @@
               "orderBys": []
             },
             "modified": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -3564,13 +4605,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/b",
-              2000,
-              {
+            {
+              "key": "collection/b",
+              "version": 2000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -3579,7 +4624,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -3589,13 +4635,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/b",
-                2000,
-                {
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -3605,9 +4655,9 @@
       }
     ]
   },
-  "Held writes are not re-sent.": {
+  "Writes are not re-sent.": {
     "describeName": "Writes:",
-    "itName": "Held writes are not re-sent.",
+    "itName": "Writes are not re-sent.",
     "tags": [],
     "config": {
       "useGarbageCollection": true,
@@ -3659,7 +4709,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 500
+          "version": 500,
+          "targetIds": []
         },
         "expect": [
           {
@@ -3689,14 +4740,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -3732,14 +4786,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                0,
-                {
+              {
+                "key": "collection/b",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -3763,20 +4820,28 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ],
-            [
-              "collection/b",
-              2000,
-              {
+            },
+            {
+              "key": "collection/b",
+              "version": 2000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -3785,7 +4850,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -3795,20 +4861,28 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ],
-              [
-                "collection/b",
-                2000,
-                {
+              },
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -3818,9 +4892,9 @@
       }
     ]
   },
-  "Held writes are not re-sent after disable/enable network.": {
+  "Writes are not re-sent after disable/enable network.": {
     "describeName": "Writes:",
-    "itName": "Held writes are not re-sent after disable/enable network.",
+    "itName": "Writes are not re-sent after disable/enable network.",
     "tags": [],
     "config": {
       "useGarbageCollection": true,
@@ -3872,7 +4946,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 500
+          "version": 500,
+          "targetIds": []
         },
         "expect": [
           {
@@ -3902,14 +4977,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -3975,13 +5053,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -3998,7 +5080,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -4008,13 +5091,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -4024,13 +5111,13 @@
       }
     ]
   },
-  "Held writes are released when there are no queries left.": {
+  "Writes are released when there are no queries left": {
     "describeName": "Writes:",
-    "itName": "Held writes are released when there are no queries left.",
+    "itName": "Writes are released when there are no queries left",
     "tags": [
       "eager-gc"
     ],
-    "comment": "This test expects a new target id for a new listen, but without eager gc, the same target id is reused",
+    "comment": "This test verifies that committed mutations are eligible for garbage collection on target removal",
     "config": {
       "useGarbageCollection": true,
       "numClients": 1
@@ -4081,7 +5168,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 500
+          "version": 500,
+          "targetIds": []
         },
         "expect": [
           {
@@ -4111,14 +5199,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -4222,14 +5313,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4259,14 +5353,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4322,14 +5419,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4359,14 +5459,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4422,14 +5525,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4459,14 +5565,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4522,14 +5631,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4559,14 +5671,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4622,14 +5737,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4659,14 +5777,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4722,14 +5843,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4759,14 +5883,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4822,14 +5949,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4859,14 +5989,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4922,14 +6055,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -4959,14 +6095,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -5022,14 +6161,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -5059,14 +6201,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -5122,14 +6267,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -5193,14 +6341,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -5237,13 +6388,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/key",
-              0,
-              {
+            {
+              "key": "collection/key",
+              "version": 1000,
+              "value": {
                 "foo": "bar"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -5260,7 +6415,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -5270,13 +6426,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "foo": "bar"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5332,14 +6492,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -5376,13 +6539,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/key",
-              0,
-              {
+            {
+              "key": "collection/key",
+              "version": 1000,
+              "value": {
                 "foo": "bar"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -5399,7 +6566,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -5409,13 +6577,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "foo": "bar"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5471,14 +6643,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -5515,13 +6690,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/key",
-              0,
-              {
+            {
+              "key": "collection/key",
+              "version": 1000,
+              "value": {
                 "foo": "bar"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -5538,7 +6717,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -5548,13 +6728,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "foo": "bar"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5610,14 +6794,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -5654,13 +6841,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/key",
-              0,
-              {
+            {
+              "key": "collection/key",
+              "version": 1000,
+              "value": {
                 "foo": "bar"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -5677,7 +6868,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -5687,13 +6879,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "foo": "bar"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5749,14 +6945,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -5793,13 +6992,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/key",
-              0,
-              {
+            {
+              "key": "collection/key",
+              "version": 1000,
+              "value": {
                 "foo": "bar"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -5816,7 +7019,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -5826,13 +7030,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "foo": "bar"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -5888,14 +7096,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
                   "foo": "bar"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -5932,13 +7143,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/key",
-              0,
-              {
+            {
+              "key": "collection/key",
+              "version": 1000,
+              "value": {
                 "foo": "bar"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -5955,7 +7170,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -5965,13 +7181,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/key",
-                0,
-                {
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
                   "foo": "bar"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -6020,16 +7240,20 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/doc",
-              1000,
-              {
+            {
+              "key": "collection/doc",
+              "version": 1000,
+              "value": {
                 "a": {
                   "b": 2
                 },
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -6046,7 +7270,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 500
+          "version": 500,
+          "targetIds": []
         },
         "expect": [
           {
@@ -6056,16 +7281,20 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/doc",
-                1000,
-                {
+              {
+                "key": "collection/doc",
+                "version": 1000,
+                "value": {
                   "a": {
                     "b": 2
                   },
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -6089,17 +7318,20 @@
               "orderBys": []
             },
             "modified": [
-              [
-                "collection/doc",
-                1000,
-                {
+              {
+                "key": "collection/doc",
+                "version": 1000,
+                "value": {
                   "a": {
                     "b": 2
                   },
                   "v": 2
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -6110,16 +7342,20 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/doc",
-              2000,
-              {
+            {
+              "key": "collection/doc",
+              "version": 2000,
+              "value": {
                 "a": {
                   "b": 2
                 },
                 "v": 2
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -6128,7 +7364,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 2000
+          "version": 2000,
+          "targetIds": []
         }
       },
       {
@@ -6151,16 +7388,20 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/doc",
-                2000,
-                {
+              {
+                "key": "collection/doc",
+                "version": 2000,
+                "value": {
                   "a": {
                     "b": 2
                   },
                   "v": 2
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -6458,7 +7699,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 500
+          "version": 500,
+          "targetIds": []
         },
         "expect": [
           {
@@ -6489,14 +7731,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -6538,14 +7783,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -6573,14 +7821,17 @@
               "orderBys": []
             },
             "modified": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 2
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -6599,14 +7850,17 @@
               "orderBys": []
             },
             "modified": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 2
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -6630,14 +7884,17 @@
               "orderBys": []
             },
             "modified": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 3
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -6656,14 +7913,17 @@
               "orderBys": []
             },
             "modified": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 3
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -6744,7 +8004,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 500
+          "version": 500,
+          "targetIds": []
         },
         "expect": [
           {
@@ -6814,14 +8075,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -6840,14 +8104,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -6865,13 +8132,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -6881,7 +8152,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -6891,13 +8163,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -6924,13 +8200,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -7005,7 +8285,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 500
+          "version": 500,
+          "targetIds": []
         },
         "expect": [
           {
@@ -7075,14 +8356,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -7101,14 +8385,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -7131,14 +8418,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -7165,14 +8455,17 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -7183,9 +8476,9 @@
       }
     ]
   },
-  "Held write is released by primary client": {
+  "Writes are released by primary client": {
     "describeName": "Writes:",
-    "itName": "Held write is released by primary client",
+    "itName": "Writes are released by primary client",
     "tags": [
       "multi-client"
     ],
@@ -7247,7 +8540,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 500
+          "version": 500,
+          "targetIds": []
         },
         "expect": [
           {
@@ -7286,14 +8580,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -7310,58 +8607,6 @@
       },
       {
         "drainQueue": true,
-        "clientIndex": 1
-      },
-      {
-        "drainQueue": true,
-        "clientIndex": 0
-      },
-      {
-        "watchEntity": {
-          "docs": [
-            [
-              "collection/a",
-              1000,
-              {
-                "v": 1
-              }
-            ]
-          ],
-          "targets": [
-            2
-          ]
-        },
-        "clientIndex": 0
-      },
-      {
-        "watchSnapshot": {
-          "version": 2000
-        },
-        "expect": [
-          {
-            "query": {
-              "path": "collection",
-              "filters": [],
-              "orderBys": []
-            },
-            "metadata": [
-              [
-                "collection/a",
-                1000,
-                {
-                  "v": 1
-                }
-              ]
-            ],
-            "errorCode": 0,
-            "fromCache": false,
-            "hasPendingWrites": false
-          }
-        ],
-        "clientIndex": 0
-      },
-      {
-        "drainQueue": true,
         "stateExpect": {
           "userCallbacks": {
             "acknowledgedDocs": [
@@ -7371,6 +8616,400 @@
           }
         },
         "clientIndex": 1
+      },
+      {
+        "drainQueue": true,
+        "clientIndex": 0
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
+                "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        },
+        "clientIndex": 0
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000,
+          "targetIds": []
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "metadata": [
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
+                  "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ],
+        "clientIndex": 0
+      }
+    ]
+  },
+  "Writes are held during primary failover": {
+    "describeName": "Writes:",
+    "itName": "Writes are held during primary failover",
+    "tags": [
+      "multi-client"
+    ],
+    "config": {
+      "useGarbageCollection": false,
+      "numClients": 2
+    },
+    "steps": [
+      {
+        "drainQueue": true,
+        "clientIndex": 0
+      },
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        },
+        "clientIndex": 0
+      },
+      {
+        "userSet": [
+          "collection/doc",
+          {
+            "v": 1
+          }
+        ],
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/doc",
+                "version": 0,
+                "value": {
+                  "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true
+          }
+        ],
+        "clientIndex": 0
+      },
+      {
+        "watchAck": [
+          2
+        ],
+        "clientIndex": 0
+      },
+      {
+        "watchEntity": {
+          "docs": [],
+          "targets": [
+            2
+          ]
+        },
+        "clientIndex": 0
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ],
+        "clientIndex": 0
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000,
+          "targetIds": []
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": true
+          }
+        ],
+        "clientIndex": 0
+      },
+      {
+        "writeAck": {
+          "version": 2000
+        },
+        "stateExpect": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/doc"
+            ],
+            "rejectedDocs": []
+          }
+        },
+        "clientIndex": 0
+      },
+      {
+        "drainQueue": true,
+        "clientIndex": 1
+      },
+      {
+        "applyClientState": {
+          "primary": true
+        },
+        "stateExpect": {
+          "isPrimary": true,
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": "resume-token-1000"
+            }
+          }
+        },
+        "clientIndex": 1
+      },
+      {
+        "userListen": [
+          4,
+          {
+            "path": "collection/doc",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": "resume-token-1000"
+            },
+            "4": {
+              "query": {
+                "path": "collection/doc",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection/doc",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/doc",
+                "version": 2000,
+                "value": {
+                  "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": true
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": false
+          }
+        ],
+        "clientIndex": 1
+      },
+      {
+        "watchAck": [
+          2
+        ],
+        "clientIndex": 1
+      },
+      {
+        "watchAck": [
+          4
+        ],
+        "clientIndex": 1
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/doc",
+              "version": 2000,
+              "value": {
+                "v": 1
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2,
+            4
+          ]
+        },
+        "clientIndex": 1
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-2000"
+        ],
+        "clientIndex": 1
+      },
+      {
+        "watchCurrent": [
+          [
+            4
+          ],
+          "resume-token-2000"
+        ],
+        "clientIndex": 1
+      },
+      {
+        "watchSnapshot": {
+          "version": 2000,
+          "targetIds": []
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection/doc",
+              "filters": [],
+              "orderBys": []
+            },
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ],
+        "clientIndex": 1
+      },
+      {
+        "drainQueue": true,
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            },
+            "4": {
+              "query": {
+                "path": "collection/doc",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        },
+        "clientIndex": 0
+      },
+      {
+        "runTimer": "client_metadata_refresh",
+        "stateExpect": {
+          "isPrimary": false
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection",
+              "filters": [],
+              "orderBys": []
+            },
+            "metadata": [
+              {
+                "key": "collection/doc",
+                "version": 2000,
+                "value": {
+                  "v": 1
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ],
+        "clientIndex": 0
       }
     ]
   },
@@ -7868,14 +9507,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -7921,14 +9563,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -7952,14 +9597,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                0,
-                {
+              {
+                "key": "collection/b",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -7978,14 +9626,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                0,
-                {
+              {
+                "key": "collection/b",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -8004,22 +9655,28 @@
               "orderBys": []
             },
             "removed": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ],
-              [
-                "collection/b",
-                0,
-                {
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/b",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -8043,14 +9700,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/c",
-                0,
-                {
+              {
+                "key": "collection/c",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -8073,32 +9733,41 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/c",
-                0,
-                {
+              {
+                "key": "collection/c",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "removed": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ],
-              [
-                "collection/b",
-                0,
-                {
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/b",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -8117,32 +9786,41 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ],
-              [
-                "collection/b",
-                0,
-                {
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/b",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "removed": [
-              [
-                "collection/c",
-                0,
-                {
+              {
+                "key": "collection/c",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -8165,32 +9843,41 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ],
-              [
-                "collection/b",
-                0,
-                {
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              },
+              {
+                "key": "collection/b",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "removed": [
-              [
-                "collection/c",
-                0,
-                {
+              {
+                "key": "collection/c",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -8279,14 +9966,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -8328,14 +10018,17 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/b",
-                0,
-                {
+              {
+                "key": "collection/b",
+                "version": 0,
+                "value": {
                   "v": 1
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
@@ -8406,20 +10099,43 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 0,
+                "value": {
                   "k": "a"
                 },
-                "local"
-              ]
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
             ],
             "errorCode": 0,
             "fromCache": true,
             "hasPendingWrites": true
           }
         ],
+        "clientIndex": 1
+      },
+      {
+        "drainQueue": true,
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        },
+        "clientIndex": 0
+      },
+      {
+        "drainQueue": true,
         "clientIndex": 1
       },
       {
@@ -8446,13 +10162,17 @@
       {
         "watchEntity": {
           "docs": [
-            [
-              "collection/a",
-              1000,
-              {
+            {
+              "key": "collection/a",
+              "version": 1000,
+              "value": {
                 "k": "a"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
               }
-            ]
+            }
           ],
           "targets": [
             2
@@ -8471,7 +10191,8 @@
       },
       {
         "watchSnapshot": {
-          "version": 1000
+          "version": 1000,
+          "targetIds": []
         },
         "expect": [
           {
@@ -8481,13 +10202,17 @@
               "orderBys": []
             },
             "metadata": [
-              [
-                "collection/a",
-                1000,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "k": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": false,
@@ -8911,20 +10636,28 @@
               "orderBys": []
             },
             "added": [
-              [
-                "collection/a",
-                0,
-                {
+              {
+                "key": "collection/a",
+                "version": 1000,
+                "value": {
                   "k": "a"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": true
                 }
-              ],
-              [
-                "collection/b",
-                0,
-                {
+              },
+              {
+                "key": "collection/b",
+                "version": 2000,
+                "value": {
                   "k": "b"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": true
                 }
-              ]
+              }
             ],
             "errorCode": 0,
             "fromCache": true,

--- a/Firestore/Source/Local/FSTReferenceSet.h
+++ b/Firestore/Source/Local/FSTReferenceSet.h
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
                          forID:(int)ID;
 
 /** Clears all references with a given ID. Calls -removeReferenceToKey: for each key removed. */
-- (void)removeReferencesForID:(int)ID;
+- (firebase::firestore::model::DocumentKeySet)removeReferencesForID:(int)ID;
 
 /** Clears all references for all IDs. */
 - (void)removeAllReferences;

--- a/Firestore/Source/Local/FSTReferenceSet.mm
+++ b/Firestore/Source/Local/FSTReferenceSet.mm
@@ -86,17 +86,20 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-- (void)removeReferencesForID:(int)ID {
+- (DocumentKeySet)removeReferencesForID:(int)ID {
   FSTDocumentReference *start =
       [[FSTDocumentReference alloc] initWithKey:DocumentKey::Empty() ID:ID];
   FSTDocumentReference *end =
       [[FSTDocumentReference alloc] initWithKey:DocumentKey::Empty() ID:(ID + 1)];
 
+  __block DocumentKeySet keys;
   [self.referencesByID enumerateObjectsFrom:start
                                          to:end
                                  usingBlock:^(FSTDocumentReference *reference, BOOL *stop) {
                                    [self removeReference:reference];
+                                   keys = keys.insert(reference.key);
                                  }];
+  return keys;
 }
 
 - (void)removeAllReferences {


### PR DESCRIPTION
This imports the Spec test from Web and ports the test runner's held write acks changes.

It also:
1) Fixes a bug in the Held Write Acks branch (some bug also fixed in pending PR https://github.com/firebase/firebase-ios-sdk/pull/2008)
2) Adds logic back to local store to remove references for mutations that matched a query target. This broke two spec tests without held write acks and was not all that fun to track down...

Because of 2, I am sending this to Gil.