### PR TITLE
Assign the default app before posting notifications.

### DIFF
--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -178,12 +178,12 @@ static NSMutableDictionary *sLibraryVersions;
 
   @synchronized(self) {
     FIRApp *app = [[FIRApp alloc] initInstanceWithName:name options:options];
-    [FIRApp addAppToAppDictionary:app];
-    [FIRApp sendNotificationsToSDKs:app];
-
     if (app.isDefaultApp) {
       sDefaultApp = app;
     }
+
+    [FIRApp addAppToAppDictionary:app];
+    [FIRApp sendNotificationsToSDKs:app];
   }
 }
 


### PR DESCRIPTION
Although SDKs being configured should access the app through the
dictionary being passed in (and soon the `FIRCoreConfigurable`
protocol), the default app should be assigned before notifying SDKs
that Core is ready.