### PR TITLE
Partially revert "Update CHANGELOG for Firestore v0.14.0 (#2025)"

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 # v0.14.0
 - [fixed] Fixed compilation in C99 and C++11 modes without GNU extensions.
-- [changed] Moved from Objective-C gRPC framework to gRPC C++. If you're
-  manually tracking dependencies, the `gRPC`, `gRPC-ProtoRPC`, and
-  `gRPC-RxLibrary` frameworks have been replaced with `gRPC-C++`. While we
-  don't anticipate any issues, please [report any issues with network
-  behavior](https://github.com/firebase/firebase-ios-sdk/issues/new) you
-  experience. (#1968)
 
 # v0.13.6
 - [changed] Internal improvements.


### PR DESCRIPTION
This removes the changelog entry that describes our migration to
gRPC-C++.