### PR TITLE
Fix static analysis warning in Core.

### DIFF
--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -106,7 +106,7 @@ static NSMutableDictionary *sLibraryVersions;
     // Read the Info.plist to see if the flag is set. At this point we can't check any user defaults
     // since the app isn't configured at all, so only rely on the Info.plist value.
     NSNumber *collectionEnabledPlistValue = [[self class] readDataCollectionSwitchFromPlist];
-    if (!collectionEnabledPlistValue || [collectionEnabledPlistValue boolValue]) {
+    if (collectionEnabledPlistValue == nil || [collectionEnabledPlistValue boolValue]) {
       [[NSNotificationCenter defaultCenter]
           postNotificationName:kFIRAppDiagnosticsNotification
                         object:nil


### PR DESCRIPTION
Explicitly check for `nil` instead of using the `!` operator on the pointer.