### PR TITLE
Move #2034 into 5.12.0

### DIFF
--- a/Firebase/Core/CHANGELOG.md
+++ b/Firebase/Core/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
-- [fixed] Fixed static analysis warning for improper `nil` comparison. (#2034)
 
 # 2018-10-31 -- v5.1.7 -- M37
+- [fixed] Fixed static analysis warning for improper `nil` comparison. (#2034)
 - [changed] Assign the default app before posting notifications. (#2024)
 - [changed] Remove unnecessary notification flag. (#1993)
 - [changed] Wrap diagnostics notification in collection flag check. (#1979)


### PR DESCRIPTION
This is part of merging master to the release branch instead of cherry-picking some release fixes to keep future merging cleaner.