### PR TITLE
Remove Mutation tombstones

### DIFF
--- a/Firestore/Source/Local/FSTLevelDBMutationQueue.mm
+++ b/Firestore/Source/Local/FSTLevelDBMutationQueue.mm
@@ -327,29 +327,6 @@ using leveldb::WriteOptions;
   return [self decodedMutationBatch:it->value()];
 }
 
-- (NSArray<FSTMutationBatch *> *)allMutationBatchesThroughBatchID:(BatchId)batchID {
-  std::string userKey = LevelDbMutationKey::KeyPrefix(_userID);
-
-  auto it = _db.currentTransaction->NewIterator();
-  it->Seek(userKey);
-
-  NSMutableArray *result = [NSMutableArray array];
-  LevelDbMutationKey rowKey;
-  for (; it->Valid() && rowKey.Decode(it->key()); it->Next()) {
-    if (rowKey.user_id() != _userID) {
-      // End of this user's mutations
-      break;
-    } else if (rowKey.batch_id() > batchID) {
-      // This mutation is past what we're looking for
-      break;
-    }
-
-    [result addObject:[self decodedMutationBatch:it->value()]];
-  }
-
-  return result;
-}
-
 - (NSArray<FSTMutationBatch *> *)allMutationBatchesAffectingDocumentKey:
     (const DocumentKey &)documentKey {
   // Scan the document-mutation index starting with a prefix starting with the given documentKey.

--- a/Firestore/Source/Local/FSTMutationQueue.h
+++ b/Firestore/Source/Local/FSTMutationQueue.h
@@ -93,21 +93,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<FSTMutationBatch *> *)allMutationBatches;
 
 /**
- * Finds all mutations with a batchID less than or equal to the given batchID.
- *
- * Generally the caller should be asking for the next unacknowledged batchID and the number of
- * acknowledged batches should be very small when things are functioning well.
- *
- * @param batchID The batch to search through.
- *
- * @return an NSArray containing all batches with matching batchIDs.
- */
-// TODO(mcg): This should really return NSEnumerator and the caller should be adjusted to only
-// loop through these once.
-- (NSArray<FSTMutationBatch *> *)allMutationBatchesThroughBatchID:
-    (firebase::firestore::model::BatchId)batchID;
-
-/**
  * Finds all mutation batches that could @em possibly affect the given document key. Not all
  * mutations in a batch will necessarily affect the document key, so when looping through the
  * batch you'll need to check that the mutation itself matches the key.

--- a/Firestore/Source/Model/FSTMutationBatch.h
+++ b/Firestore/Source/Model/FSTMutationBatch.h
@@ -87,18 +87,6 @@ extern const firebase::firestore::model::BatchId kFSTBatchIDUnknown;
     applyToLocalDocument:(FSTMaybeDocument *_Nullable)maybeDoc
              documentKey:(const firebase::firestore::model::DocumentKey &)documentKey;
 
-/**
- * Returns YES if this mutation batch has already been removed from the mutation queue.
- *
- * Note that not all implementations of the FSTMutationQueue necessarily use tombstones as a part
- * of their implementation and generally speaking no code outside the mutation queues should really
- * care about this.
- */
-- (BOOL)isTombstone;
-
-/** Converts this batch to a tombstone. */
-- (FSTMutationBatch *)toTombstone;
-
 /** Returns the set of unique keys referenced by all mutations in the batch. */
 - (firebase::firestore::model::DocumentKeySet)keys;
 

--- a/Firestore/Source/Model/FSTMutationBatch.mm
+++ b/Firestore/Source/Model/FSTMutationBatch.mm
@@ -41,6 +41,7 @@ const BatchId kFSTBatchIDUnknown = -1;
 - (instancetype)initWithBatchID:(BatchId)batchID
                  localWriteTime:(FIRTimestamp *)localWriteTime
                       mutations:(NSArray<FSTMutation *> *)mutations {
+  HARD_ASSERT(mutations.count != 0, "Cannot create an empty mutation batch");
   self = [super init];
   if (self) {
     _batchID = batchID;
@@ -113,16 +114,6 @@ const BatchId kFSTBatchIDUnknown = -1;
     }
   }
   return maybeDoc;
-}
-
-- (BOOL)isTombstone {
-  return self.mutations.count == 0;
-}
-
-- (FSTMutationBatch *)toTombstone {
-  return [[FSTMutationBatch alloc] initWithBatchID:self.batchID
-                                    localWriteTime:self.localWriteTime
-                                         mutations:@[]];
 }
 
 // TODO(klimt): This could use NSMutableDictionary instead.


### PR DESCRIPTION
With held write acks gone, we no longer turn mutations into tombstones. This removes the code that handles this.

Port of firebase/firebase-js-sdk#1354