### PR TITLE
Update the GULObjectSwizzler to handle NSProxy objects

### DIFF
--- a/GoogleUtilities/CHANGELOG.md
+++ b/GoogleUtilities/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- Fixed a crash caused due to `NSURLConnection` delegates being wrapped in an
+  `NSProxy`. (#1936)
+
 # 5.3.4
 - Fixed a crash caused by unprotected access to sessions in
   `GULNetworkURLSession` (#1964).

--- a/GoogleUtilities/CHANGELOG.md
+++ b/GoogleUtilities/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Fixed a crash caused due to `NSURLConnection` delegates being wrapped in a
+- Fixed a crash caused due to `NSURLConnection` delegates being wrapped in an
   `NSProxy`. (#1936)
 
 # 5.3.4

--- a/GoogleUtilities/CHANGELOG.md
+++ b/GoogleUtilities/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Fixed a crash caused due to `NSURLConnection` delegates being wrapped in an
+- Fixed a crash caused due to `NSURLConnection` delegates being wrapped in a
   `NSProxy`. (#1936)
 
 # 5.3.4

--- a/GoogleUtilities/Example/Tests/Swizzler/GULObjectSwizzlerTest.m
+++ b/GoogleUtilities/Example/Tests/Swizzler/GULObjectSwizzlerTest.m
@@ -327,7 +327,7 @@
   // Someone else ISA Swizzles the same object after GULObjectSwizzler.
   Class originalClass = object_getClass(proxyObject);
   NSString *newClassName =
-  [NSString stringWithFormat:@"gul_test_%p_%@", proxyObject, NSStringFromClass(originalClass)];
+      [NSString stringWithFormat:@"gul_test_%p_%@", proxyObject, NSStringFromClass(originalClass)];
   Class generatedClass = objc_allocateClassPair(originalClass, newClassName.UTF8String, 0);
   objc_registerClassPair(generatedClass);
   object_setClass(proxyObject, generatedClass);

--- a/GoogleUtilities/Example/Tests/Swizzler/GULObjectSwizzlerTest.m
+++ b/GoogleUtilities/Example/Tests/Swizzler/GULObjectSwizzlerTest.m
@@ -30,7 +30,7 @@
   return @"SwizzledDonorDescription";
 }
 
-/** Used as a donor method to add a method that exists on superclass. */
+/** Used as a donor method to add a method that exists on the superclass. */
 - (NSString *)description {
   return @"SwizzledDescription";
 }
@@ -238,6 +238,7 @@
   XCTAssertEqualObjects(returnedObject, associatedObject);
 }
 
+/** Tests getting and setting an associated object with an invalid association type. */
 - (void)testSetGetAssociatedObjectWithoutProperAssociation {
   NSObject *object = [[NSObject alloc] init];
   NSDictionary *associatedObject = [[NSDictionary alloc] init];
@@ -247,6 +248,7 @@
   XCTAssertEqualObjects(returnedObject, associatedObject);
 }
 
+/** Tests using the GULObjectSwizzler to swizzle an object wrapped in an NSProxy. */
 - (void)testSwizzleProxiedObject {
   NSObject *object = [[NSObject alloc] init];
   GULProxy *proxyObject = [GULProxy proxyWithDelegate:object];
@@ -264,6 +266,7 @@
   XCTAssertNoThrow([proxyObject performSelector:@selector(gul_class)]);
 }
 
+/** Tests overriding a method that already exists on a proxied object works as expected. */
 - (void)testSwizzleProxiedObjectInvokesInjectedMethodWhenOverridingMethod {
   NSObject *object = [[NSObject alloc] init];
   GULProxy *proxyObject = [GULProxy proxyWithDelegate:object];
@@ -277,6 +280,7 @@
   XCTAssertEqual([proxyObject performSelector:@selector(description)], @"SwizzledDescription");
 }
 
+/** Tests adding a method that doesn't exist on a proxied object works as expected. */
 - (void)testSwizzleProxiedObjectInvokesInjectedMethodWhenAddingMethod {
   NSObject *object = [[NSObject alloc] init];
   GULProxy *proxyObject = [GULProxy proxyWithDelegate:object];
@@ -291,6 +295,7 @@
                  @"SwizzledDonorDescription");
 }
 
+/** Tests KVOing a proxy object that we've ISA Swizzled works as expected. */
 - (void)testRespondsToSelectorWorksEvenIfSwizzledProxyIsKVOd {
   NSObject *object = [[NSObject alloc] init];
   GULProxy *proxyObject = [GULProxy proxyWithDelegate:object];
@@ -314,6 +319,9 @@
                                forKeyPath:NSStringFromSelector(@selector(description))];
 }
 
+/** Tests that -[NSObjectProtocol resopondsToSelector:] works as expected after someone else ISA
+ *  swizzles a proxy object that we've also ISA Swizzled.
+ */
 - (void)testRespondsToSelectorWorksEvenIfSwizzledProxyISASwizzledBySomeoneElse {
   NSObject *object = [[NSObject alloc] init];
   GULProxy *proxyObject = [GULProxy proxyWithDelegate:object];

--- a/GoogleUtilities/Example/Tests/Swizzler/GULObjectSwizzlerTest.m
+++ b/GoogleUtilities/Example/Tests/Swizzler/GULObjectSwizzlerTest.m
@@ -256,11 +256,12 @@
 
   XCTAssertNotEqual(object_getClass(proxyObject), [GULProxy class]);
   XCTAssertTrue([object_getClass(proxyObject) isSubclassOfClass:[GULProxy class]]);
-  XCTAssertNoThrow([proxyObject performSelector:@selector(gul_objectSwizzler)]);
-  XCTAssertNoThrow([proxyObject performSelector:@selector(gul_class)]);
 
-  Class proxyObjectClass = object_getClass(proxyObject);
-  XCTAssertTrue([proxyObjectClass instancesRespondToSelector:@selector(gul_class)]);
+  XCTAssertTrue([proxyObject respondsToSelector:@selector(gul_objectSwizzler)]);
+  XCTAssertNoThrow([proxyObject performSelector:@selector(gul_objectSwizzler)]);
+
+  XCTAssertTrue([proxyObject respondsToSelector:@selector(gul_class)]);
+  XCTAssertNoThrow([proxyObject performSelector:@selector(gul_class)]);
 }
 
 - (void)testSwizzleProxiedObjectInvokesInjectedMethodWhenOverridingMethod {

--- a/GoogleUtilities/Example/Tests/Swizzler/GULObjectSwizzlerTest.m
+++ b/GoogleUtilities/Example/Tests/Swizzler/GULObjectSwizzlerTest.m
@@ -249,7 +249,7 @@
 
 - (void)testSwizzleProxiedObject {
   NSObject *object = [[NSObject alloc] init];
-  GULProxy *proxyObject = [GULProxy proxyWithTarget:object];
+  GULProxy *proxyObject = [GULProxy proxyWithDelegate:object];
   GULObjectSwizzler *swizzler = [[GULObjectSwizzler alloc] initWithObject:proxyObject];
 
   XCTAssertNoThrow([swizzler swizzle]);
@@ -266,7 +266,7 @@
 
 - (void)testSwizzleProxiedObjectInvokesInjectedMethodWhenOverridingMethod {
   NSObject *object = [[NSObject alloc] init];
-  GULProxy *proxyObject = [GULProxy proxyWithTarget:object];
+  GULProxy *proxyObject = [GULProxy proxyWithDelegate:object];
 
   GULObjectSwizzler *swizzler = [[GULObjectSwizzler alloc] initWithObject:proxyObject];
   [swizzler copySelector:@selector(description)
@@ -279,7 +279,7 @@
 
 - (void)testSwizzleProxiedObjectInvokesInjectedMethodWhenAddingMethod {
   NSObject *object = [[NSObject alloc] init];
-  GULProxy *proxyObject = [GULProxy proxyWithTarget:object];
+  GULProxy *proxyObject = [GULProxy proxyWithDelegate:object];
 
   GULObjectSwizzler *swizzler = [[GULObjectSwizzler alloc] initWithObject:proxyObject];
   [swizzler copySelector:@selector(donorDescription)

--- a/GoogleUtilities/Example/Tests/Swizzler/GULObjectSwizzlerTest.m
+++ b/GoogleUtilities/Example/Tests/Swizzler/GULObjectSwizzlerTest.m
@@ -303,7 +303,8 @@
 
   [(NSObject *)proxyObject addObserver:self
                             forKeyPath:NSStringFromSelector(@selector(description))
-                               options:0 context:NULL];
+                               options:0
+                               context:NULL];
 
   XCTAssertTrue([proxyObject respondsToSelector:@selector(donorDescription)]);
   XCTAssertEqual([proxyObject performSelector:@selector(donorDescription)],
@@ -325,8 +326,8 @@
 
   // Someone else ISA Swizzles the same object after GULObjectSwizzler.
   Class originalClass = object_getClass(proxyObject);
-  NSString *newClassName = [NSString stringWithFormat:@"gul_test_%p_%@", proxyObject,
-                            NSStringFromClass(originalClass)];
+  NSString *newClassName =
+  [NSString stringWithFormat:@"gul_test_%p_%@", proxyObject, NSStringFromClass(originalClass)];
   Class generatedClass = objc_allocateClassPair(originalClass, newClassName.UTF8String, 0);
   objc_registerClassPair(generatedClass);
   object_setClass(proxyObject, generatedClass);

--- a/GoogleUtilities/Example/Tests/Swizzler/GULObjectSwizzlerTest.m
+++ b/GoogleUtilities/Example/Tests/Swizzler/GULObjectSwizzlerTest.m
@@ -16,8 +16,8 @@
 #import <objc/runtime.h>
 
 #import <GoogleUtilities/GULObjectSwizzler.h>
-#import <GoogleUtilities/GULSwizzledObject.h>
 #import <GoogleUtilities/GULProxy.h>
+#import <GoogleUtilities/GULSwizzledObject.h>
 
 @interface GULObjectSwizzlerTest : XCTestCase
 

--- a/GoogleUtilities/ISASwizzler/GULObjectSwizzler.m
+++ b/GoogleUtilities/ISASwizzler/GULObjectSwizzler.m
@@ -154,4 +154,8 @@
   objc_disposeClassPair(_generatedClass);
 }
 
+- (BOOL)isSwizzlingProxyObject {
+  return [_swizzledObject isProxy];
+}
+
 @end

--- a/GoogleUtilities/ISASwizzler/GULObjectSwizzler.m
+++ b/GoogleUtilities/ISASwizzler/GULObjectSwizzler.m
@@ -80,7 +80,7 @@
     __strong id swizzledObject = object;
     if (swizzledObject) {
       _swizzledObject = swizzledObject;
-      _originalClass = [swizzledObject class];
+      _originalClass = object_getClass(object);
       NSString *newClassName = [NSString
           stringWithFormat:@"fir_%p_%@", swizzledObject, NSStringFromClass(_originalClass)];
       _generatedClass = objc_allocateClassPair(_originalClass, newClassName.UTF8String, 0);
@@ -134,7 +134,7 @@
 
     [GULSwizzledObject copyDonorSelectorsUsingObjectSwizzler:self];
 
-    NSAssert(_originalClass == [_swizzledObject class],
+    NSAssert(_originalClass == object_getClass(swizzledObject),
              @"The original class is not the reported class now.");
     NSAssert(class_getInstanceSize(_originalClass) == class_getInstanceSize(_generatedClass),
              @"The instance size of the generated class must be equal to the original class.");

--- a/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
+++ b/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
@@ -29,13 +29,12 @@ NSString *kSwizzlerAssociatedObjectKey = @"gul_objectSwizzler";
   [objectSwizzler copySelector:@selector(gul_objectSwizzler) fromClass:self isClassSelector:NO];
   [objectSwizzler copySelector:@selector(gul_class) fromClass:self isClassSelector:NO];
 
-  // This is needed because NSProxy objects ususally override
-  // -[NSObjectProtocol respondsToSelector:] and ask this question to the underlying object.
-  // Since we don't swizzle the underlying object but swizzle the proxy, when someone calls
-  // -[NSObjectProtocol respondsToSelector:] on the proxy, the answer ends up being NO even if we
-  // added new methods to the subclass through ISA Swizzling. To solve that, we override
-  // -[NSObjectProtocol respondsToSelector:] in such a way that takes into account the fact that
-  // we've added new methods.
+  // This is needed because NSProxy objects usually override -[NSObjectProtocol respondsToSelector:]
+  // and ask this question to the underlying object. Since we don't swizzle the underlying object
+  // but swizzle the proxy, when someone calls -[NSObjectProtocol respondsToSelector:] on the proxy,
+  // the answer ends up being NO even if we added new methods to the subclass through ISA Swizzling.
+  // To solve that, we override -[NSObjectProtocol respondsToSelector:] in such a way that takes
+  // into account the fact that we've added new methods.
   if ([objectSwizzler isSwizzlingProxyObject]) {
     [objectSwizzler copySelector:@selector(respondsToSelector:) fromClass:self isClassSelector:NO];
   }
@@ -58,8 +57,8 @@ NSString *kSwizzlerAssociatedObjectKey = @"gul_objectSwizzler";
 
 // Only added to a class when we detect it is a proxy.
 - (BOOL)respondsToSelector:(SEL)aSelector {
-  Class selfClass = object_getClass(self);
-  return [selfClass instancesRespondToSelector:aSelector] || [super respondsToSelector:aSelector];
+  Class gulClass = [[self gul_objectSwizzler] generatedClass];
+  return [gulClass instancesRespondToSelector:aSelector] || [super respondsToSelector:aSelector];
 }
 
 @end

--- a/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
+++ b/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
@@ -14,8 +14,8 @@
 
 #import <objc/runtime.h>
 
-#import "Private/GULSwizzledObject.h"
 #import "Private/GULObjectSwizzler.h"
+#import "Private/GULSwizzledObject.h"
 
 NSString *kSwizzlerAssociatedObjectKey = @"gul_objectSwizzler";
 

--- a/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
+++ b/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <objc/runtime.h>
+
 #import "Private/GULSwizzledObject.h"
 #import "Private/GULObjectSwizzler.h"
 
@@ -26,6 +28,17 @@ NSString *kSwizzlerAssociatedObjectKey = @"gul_objectSwizzler";
 + (void)copyDonorSelectorsUsingObjectSwizzler:(GULObjectSwizzler *)objectSwizzler {
   [objectSwizzler copySelector:@selector(gul_objectSwizzler) fromClass:self isClassSelector:NO];
   [objectSwizzler copySelector:@selector(gul_class) fromClass:self isClassSelector:NO];
+
+  // This is needed because NSProxy objects ususally override
+  // -[NSObjectProtocol respondsToSelector:] and ask this question to the underlying object.
+  // Since we don't swizzle the underlying object but swizzle the proxy, when someone calls
+  // -[NSObjectProtocol respondsToSelector:] on the proxy, the answer ends up being NO even if we
+  // added new methods to the subclass through ISA Swizzling. To solve that, we override
+  // -[NSObjectProtocol respondsToSelector:] in such a way that takes into account the fact that
+  // we've added new methods.
+  if ([objectSwizzler isSwizzlingProxyObject]) {
+    [objectSwizzler copySelector:@selector(respondsToSelector:) fromClass:self isClassSelector:NO];
+  }
 }
 
 - (instancetype)init {
@@ -41,6 +54,12 @@ NSString *kSwizzlerAssociatedObjectKey = @"gul_objectSwizzler";
 
 - (Class)gul_class {
   return [[self gul_objectSwizzler] generatedClass];
+}
+
+// Only added to a class when we detect it is a proxy.
+- (BOOL)respondsToSelector:(SEL)aSelector {
+  Class selfClass = object_getClass(self);
+  return [selfClass instancesRespondToSelector:aSelector] || [super respondsToSelector:aSelector];
 }
 
 @end

--- a/GoogleUtilities/ISASwizzler/Private/GULObjectSwizzler.h
+++ b/GoogleUtilities/ISASwizzler/Private/GULObjectSwizzler.h
@@ -116,7 +116,7 @@ typedef OBJC_ENUM(uintptr_t, GUL_ASSOCIATION){
 - (void)swizzle;
 
 /** @return The value of -[objectBeingSwizzled isProxy] */
- - (BOOL)isSwizzlingProxyObject;
+- (BOOL)isSwizzlingProxyObject;
 
 @end
 

--- a/GoogleUtilities/ISASwizzler/Private/GULObjectSwizzler.h
+++ b/GoogleUtilities/ISASwizzler/Private/GULObjectSwizzler.h
@@ -115,6 +115,9 @@ typedef OBJC_ENUM(uintptr_t, GUL_ASSOCIATION){
  *  the class pair. */
 - (void)swizzle;
 
+/** @return The value of -[objectBeingSwizzled isProxy] */
+ - (BOOL)isSwizzlingProxyObject;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/GoogleUtilities/SwizzlerTestHelpers/GULProxy.h
+++ b/GoogleUtilities/SwizzlerTestHelpers/GULProxy.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface GULProxy : NSProxy
+
++ (instancetype)proxyWithTarget:(id)target;
+
+@end

--- a/GoogleUtilities/SwizzlerTestHelpers/GULProxy.h
+++ b/GoogleUtilities/SwizzlerTestHelpers/GULProxy.h
@@ -16,8 +16,9 @@
 
 #import <Foundation/Foundation.h>
 
+/** An example NSProxy that could be used to wrap an object that we have to ISA Swizzle. */
 @interface GULProxy : NSProxy
 
-+ (instancetype)proxyWithTarget:(id)target;
++ (instancetype)proxyWithDelegate:(id)delegate;
 
 @end

--- a/GoogleUtilities/SwizzlerTestHelpers/GULProxy.m
+++ b/GoogleUtilities/SwizzlerTestHelpers/GULProxy.m
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GULProxy.h"
+
+@interface GULProxy ()
+
+@property(nonatomic, strong) id target;
+
+@end
+
+@implementation GULProxy
+
+- (instancetype)initWithTarget:(id)target {
+  _target = target;
+  return self;
+}
+
++ (instancetype)proxyWithTarget:(id)target {
+  return [[GULProxy alloc] initWithTarget:target];
+}
+
+- (id)forwardingTargetForSelector:(SEL)selector {
+  return _target;
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation {
+  if (_target != nil) {
+    [invocation setTarget:_target];
+    [invocation invoke];
+  }
+}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)selector {
+  return [NSObject instanceMethodSignatureForSelector:@selector(init)];
+}
+
+- (BOOL)respondsToSelector:(SEL)aSelector {
+  return [_target respondsToSelector:aSelector];
+}
+
+- (BOOL)isEqual:(id)object {
+  return [_target isEqual:object];
+}
+
+- (NSUInteger)hash {
+  return [_target hash];
+}
+
+- (Class)superclass {
+  return [_target superclass];
+}
+
+- (Class)class {
+  return [_target class];
+}
+
+- (BOOL)isKindOfClass:(Class)aClass {
+  return [_target isKindOfClass:aClass];
+}
+
+- (BOOL)isMemberOfClass:(Class)aClass {
+  return [_target isMemberOfClass:aClass];
+}
+
+- (BOOL)conformsToProtocol:(Protocol *)aProtocol {
+  return [_target conformsToProtocol:aProtocol];
+}
+
+- (BOOL)isProxy {
+  return YES;
+}
+
+- (NSString *)description {
+  return [_target description];
+}
+- (NSString *)debugDescription {
+  return [_target debugDescription];
+}
+
+@end

--- a/GoogleUtilities/SwizzlerTestHelpers/GULProxy.m
+++ b/GoogleUtilities/SwizzlerTestHelpers/GULProxy.m
@@ -64,11 +64,11 @@
   return [_delegateObject superclass];
 }
 
-- (Class)class {
+- (Class) class {
   return [_delegateObject class];
 }
 
-- (BOOL)isKindOfClass:(Class)aClass {
+    - (BOOL)isKindOfClass : (Class)aClass {
   return [_delegateObject isKindOfClass:aClass];
 }
 

--- a/GoogleUtilities/SwizzlerTestHelpers/GULProxy.m
+++ b/GoogleUtilities/SwizzlerTestHelpers/GULProxy.m
@@ -18,66 +18,66 @@
 
 @interface GULProxy ()
 
-@property(nonatomic, strong) id target;
+@property(nonatomic, strong) id delegateObject;
 
 @end
 
 @implementation GULProxy
 
-- (instancetype)initWithTarget:(id)target {
-  _target = target;
+- (instancetype)initWithDelegate:(id)delegate {
+  _delegateObject = delegate;
   return self;
 }
 
-+ (instancetype)proxyWithTarget:(id)target {
-  return [[GULProxy alloc] initWithTarget:target];
++ (instancetype)proxyWithDelegate:(id)delegate {
+  return [[GULProxy alloc] initWithDelegate:delegate];
 }
 
 - (id)forwardingTargetForSelector:(SEL)selector {
-  return _target;
+  return _delegateObject;
 }
 
 - (void)forwardInvocation:(NSInvocation *)invocation {
-  if (_target != nil) {
-    [invocation setTarget:_target];
+  if (_delegateObject != nil) {
+    [invocation setTarget:_delegateObject];
     [invocation invoke];
   }
 }
 
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)selector {
-  return [NSObject instanceMethodSignatureForSelector:@selector(init)];
+  return [_delegateObject instanceMethodSignatureForSelector:selector];
 }
 
 - (BOOL)respondsToSelector:(SEL)aSelector {
-  return [_target respondsToSelector:aSelector];
+  return [_delegateObject respondsToSelector:aSelector];
 }
 
 - (BOOL)isEqual:(id)object {
-  return [_target isEqual:object];
+  return [_delegateObject isEqual:object];
 }
 
 - (NSUInteger)hash {
-  return [_target hash];
+  return [_delegateObject hash];
 }
 
 - (Class)superclass {
-  return [_target superclass];
+  return [_delegateObject superclass];
 }
 
 - (Class)class {
-  return [_target class];
+  return [_delegateObject class];
 }
 
 - (BOOL)isKindOfClass:(Class)aClass {
-  return [_target isKindOfClass:aClass];
+  return [_delegateObject isKindOfClass:aClass];
 }
 
 - (BOOL)isMemberOfClass:(Class)aClass {
-  return [_target isMemberOfClass:aClass];
+  return [_delegateObject isMemberOfClass:aClass];
 }
 
 - (BOOL)conformsToProtocol:(Protocol *)aProtocol {
-  return [_target conformsToProtocol:aProtocol];
+  return [_delegateObject conformsToProtocol:aProtocol];
 }
 
 - (BOOL)isProxy {
@@ -85,10 +85,10 @@
 }
 
 - (NSString *)description {
-  return [_target description];
+  return [_delegateObject description];
 }
 - (NSString *)debugDescription {
-  return [_target debugDescription];
+  return [_delegateObject debugDescription];
 }
 
 @end

--- a/GoogleUtilities/SwizzlerTestHelpers/GULProxy.m
+++ b/GoogleUtilities/SwizzlerTestHelpers/GULProxy.m
@@ -87,6 +87,7 @@
 - (NSString *)description {
   return [_delegateObject description];
 }
+
 - (NSString *)debugDescription {
   return [_delegateObject debugDescription];
 }


### PR DESCRIPTION
A fix for: https://github.com/firebase/firebase-ios-sdk/issues/1936

GULObjectSwizzler couldn't currently handle ISA Swizzling NSProxy objects - this PR adds logic that deals with that and unit tests that would've failed if this logic weren't present.

The way this is done:
1. Stop depending on the `-[NSObjectProtocol class]` method to determine the class and use a runtime C function as the ObjC method is probably overriden to hide the fact that it is a proxy.
2. If it's a proxy, also swizzle the `-[NSObjectProtocol respondsToSelector:]` method to take into account the new methods we might've added.

Side note: It'd be so nice if there were a canonical way to access the underlying object(s) from an NSProxy.