### PR TITLE
GoogleUtilities 5.3.5

### DIFF
--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleUtilities'
-  s.version          = '5.3.4'
+  s.version          = '5.3.5'
   s.summary          = 'Google Utilities for iOS (plus community support for macOS and tvOS)'
 
   s.description      = <<-DESC

--- a/GoogleUtilities/CHANGELOG.md
+++ b/GoogleUtilities/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+
+# 5.3.5
 - Fixed an issue where GoogleUtilities would leak non-background URL sessions.
   (#2061)
 


### PR DESCRIPTION
Release fixes for FirebasePerformance crash(#1936) and a memory leak (#2061)

Merging this is contingent upon #2053 merging.