### PR TITLE
Fix `string_view` referring to an out-of-scope string

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_Tests_iOS.xcscheme
+++ b/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_Tests_iOS.xcscheme
@@ -27,7 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableASanStackUseAfterReturn = "YES"
-      enableThreadSanitizer = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference

--- a/Firestore/Example/Tests/API/FSTAPIHelpers.mm
+++ b/Firestore/Example/Tests/API/FSTAPIHelpers.mm
@@ -20,6 +20,8 @@
 #import <FirebaseFirestore/FIRDocumentReference.h>
 #import <FirebaseFirestore/FIRSnapshotMetadata.h>
 
+#include <string>
+
 #import "Firestore/Source/API/FIRCollectionReference+Internal.h"
 #import "Firestore/Source/API/FIRDocumentReference+Internal.h"
 #import "Firestore/Source/API/FIRDocumentSnapshot+Internal.h"

--- a/Firestore/Example/Tests/API/FSTAPIHelpers.mm
+++ b/Firestore/Example/Tests/API/FSTAPIHelpers.mm
@@ -102,7 +102,7 @@ FIRQuerySnapshot *FSTTestQuerySnapshot(
                                                hasPendingWrites ? FSTDocumentStateLocalMutations
                                                                 : FSTDocumentStateSynced)];
     if (hasPendingWrites) {
-      const absl::string_view documentKey = util::StringFormat("%s/%s", path, key);
+      const std::string documentKey = util::StringFormat("%s/%s", path, key);
       mutatedKeys = mutatedKeys.insert(testutil::Key(documentKey));
     }
   }
@@ -118,7 +118,7 @@ FIRQuerySnapshot *FSTTestQuerySnapshot(
                                 changeWithDocument:docToAdd
                                               type:FSTDocumentViewChangeTypeAdded]];
     if (hasPendingWrites) {
-      const absl::string_view documentKey = util::StringFormat("%s/%s", path, key);
+      const std::string documentKey = util::StringFormat("%s/%s", path, key);
       mutatedKeys = mutatedKeys.insert(testutil::Key(documentKey));
     }
   }


### PR DESCRIPTION
The code in question looks like this:
```cpp
std::string make_string();
absl::string_view foo = make_string(); // Line 2
use_foo(foo);
```
The issue is that `string_view` is a non-owning wrapper. The return value of `make_string` goes out of scope and is destroyed right after line 2, and `foo` is left pointing to deallocated memory.

In this case, the fix is just to assign to a `std::string` directly. If a `string_view` is desirable, code must ensure that the `std::string` it wraps is valid as long as the view exists.

Introduced in #2029. Found running unit tests under ASan.
