### PR TITLE
Fix GoogleUtilities nullability regressions

### DIFF
--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleUtilities'
-  s.version          = '5.3.5'
+  s.version          = '5.3.6'
   s.summary          = 'Google Utilities for iOS (plus community support for macOS and tvOS)'
 
   s.description      = <<-DESC

--- a/GoogleUtilities/CHANGELOG.md
+++ b/GoogleUtilities/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Unreleased
 
+# 5.3.6
+- Fix nullability issues. (#2079)
+
 # 5.3.5
 - Fixed an issue where GoogleUtilities would leak non-background URL sessions.
   (#2061)
-
 - Fixed a crash caused due to `NSURLConnection` delegates being wrapped in an
   `NSProxy`. (#1936)
 

--- a/GoogleUtilities/Network/GULNetworkURLSession.m
+++ b/GoogleUtilities/Network/GULNetworkURLSession.m
@@ -102,8 +102,8 @@
 
 /// Sends an async POST request using NSURLSession for iOS >= 7.0, and returns an ID of the
 /// connection.
-- (NSString *)sessionIDFromAsyncPOSTRequest:(NSURLRequest *)request
-                          completionHandler:(GULNetworkURLSessionCompletionHandler)handler
+- (nullable NSString *)sessionIDFromAsyncPOSTRequest:(NSURLRequest *)request
+                                   completionHandler:(GULNetworkURLSessionCompletionHandler)handler
     API_AVAILABLE(ios(7.0)) {
   // NSURLSessionUploadTask does not work with NSData in the background.
   // To avoid this issue, write the data to a temporary file to upload it.
@@ -180,8 +180,8 @@
 }
 
 /// Sends an async GET request using NSURLSession for iOS >= 7.0, and returns an ID of the session.
-- (NSString *)sessionIDFromAsyncGETRequest:(NSURLRequest *)request
-                         completionHandler:(GULNetworkURLSessionCompletionHandler)handler
+- (nullable NSString *)sessionIDFromAsyncGETRequest:(NSURLRequest *)request
+                                  completionHandler:(GULNetworkURLSessionCompletionHandler)handler
     API_AVAILABLE(ios(7.0)) {
   if (_backgroundNetworkEnabled) {
     _sessionConfig = [self backgroundSessionConfigWithSessionID:_sessionID];

--- a/GoogleUtilities/Network/Private/GULNetworkURLSession.h
+++ b/GoogleUtilities/Network/Private/GULNetworkURLSession.h
@@ -18,8 +18,10 @@
 
 #import "GULNetworkLoggerProtocol.h"
 
-typedef void (^GULNetworkCompletionHandler)(NSHTTPURLResponse *response,
-                                            NSData *data,
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^GULNetworkCompletionHandler)(NSHTTPURLResponse * _Nullable response,
+                                            NSData * _Nullable data,
                                             NSError *error);
 typedef void (^GULNetworkURLSessionCompletionHandler)(NSHTTPURLResponse *response,
                                                       NSData *data,
@@ -41,19 +43,20 @@ typedef void (^GULNetworkSystemCompletionHandler)(void);
                             completionHandler:(GULNetworkSystemCompletionHandler)completionHandler;
 
 /// Initializes with logger delegate.
-- (instancetype)initWithNetworkLoggerDelegate:(id<GULNetworkLoggerDelegate>)networkLoggerDelegate
+- (instancetype)initWithNetworkLoggerDelegate:(nullable id<GULNetworkLoggerDelegate>)networkLoggerDelegate
     NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
 
 /// Sends an asynchronous POST request and calls the provided completion handler when the request
 /// completes or when errors occur, and returns an ID of the session/connection.
-- (NSString *)sessionIDFromAsyncPOSTRequest:(NSURLRequest *)request
+- (nullable NSString *)sessionIDFromAsyncPOSTRequest:(NSURLRequest *)request
                           completionHandler:(GULNetworkURLSessionCompletionHandler)handler;
 
 /// Sends an asynchronous GET request and calls the provided completion handler when the request
 /// completes or when errors occur, and returns an ID of the session.
-- (NSString *)sessionIDFromAsyncGETRequest:(NSURLRequest *)request
+- (nullable NSString *)sessionIDFromAsyncGETRequest:(NSURLRequest *)request
                          completionHandler:(GULNetworkURLSessionCompletionHandler)handler;
 
+NS_ASSUME_NONNULL_END
 @end

--- a/GoogleUtilities/Network/Private/GULNetworkURLSession.h
+++ b/GoogleUtilities/Network/Private/GULNetworkURLSession.h
@@ -22,11 +22,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^GULNetworkCompletionHandler)(NSHTTPURLResponse *_Nullable response,
                                             NSData *_Nullable data,
-                                            NSError *error);
-typedef void (^GULNetworkURLSessionCompletionHandler)(NSHTTPURLResponse *response,
-                                                      NSData *data,
+                                            NSError *_Nullable error);
+typedef void (^GULNetworkURLSessionCompletionHandler)(NSHTTPURLResponse *_Nullable response,
+                                                      NSData *_Nullable data,
                                                       NSString *sessionID,
-                                                      NSError *error);
+                                                      NSError *_Nullable error);
 typedef void (^GULNetworkSystemCompletionHandler)(void);
 
 /// The protocol that uses NSURLSession for iOS >= 7.0 to handle requests and responses.

--- a/GoogleUtilities/Network/Private/GULNetworkURLSession.h
+++ b/GoogleUtilities/Network/Private/GULNetworkURLSession.h
@@ -20,8 +20,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^GULNetworkCompletionHandler)(NSHTTPURLResponse * _Nullable response,
-                                            NSData * _Nullable data,
+typedef void (^GULNetworkCompletionHandler)(NSHTTPURLResponse *_Nullable response,
+                                            NSData *_Nullable data,
                                             NSError *error);
 typedef void (^GULNetworkURLSessionCompletionHandler)(NSHTTPURLResponse *response,
                                                       NSData *data,
@@ -43,20 +43,20 @@ typedef void (^GULNetworkSystemCompletionHandler)(void);
                             completionHandler:(GULNetworkSystemCompletionHandler)completionHandler;
 
 /// Initializes with logger delegate.
-- (instancetype)initWithNetworkLoggerDelegate:(nullable id<GULNetworkLoggerDelegate>)networkLoggerDelegate
-    NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithNetworkLoggerDelegate:
+    (nullable id<GULNetworkLoggerDelegate>)networkLoggerDelegate NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
 
 /// Sends an asynchronous POST request and calls the provided completion handler when the request
 /// completes or when errors occur, and returns an ID of the session/connection.
 - (nullable NSString *)sessionIDFromAsyncPOSTRequest:(NSURLRequest *)request
-                          completionHandler:(GULNetworkURLSessionCompletionHandler)handler;
+                                   completionHandler:(GULNetworkURLSessionCompletionHandler)handler;
 
 /// Sends an asynchronous GET request and calls the provided completion handler when the request
 /// completes or when errors occur, and returns an ID of the session.
 - (nullable NSString *)sessionIDFromAsyncGETRequest:(NSURLRequest *)request
-                         completionHandler:(GULNetworkURLSessionCompletionHandler)handler;
+                                  completionHandler:(GULNetworkURLSessionCompletionHandler)handler;
 
 NS_ASSUME_NONNULL_END
 @end


### PR DESCRIPTION
For some reason, Xcode 9 catches these, but not Xcode 10.