### PR TITLE
FirebaseAnalyticsInterop is cross-platform

### DIFF
--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -28,7 +28,7 @@ Firebase Dynamic Links are deep links that enhance user experience and increase 
   s.weak_framework = 'WebKit'
   s.dependency 'FirebaseCore', '~> 5.1'
   s.ios.dependency 'FirebaseAnalytics', '~> 5.1'
-  s.ios.dependency 'FirebaseAnalyticsInterop', '~> 1.0'
+  s.dependency 'FirebaseAnalyticsInterop', '~> 1.0'
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -37,7 +37,7 @@ device, and it is completely free.
       'FIRMessaging_LIB_VERSION=' + String(s.version)
   }
   s.framework = 'SystemConfiguration'
-  s.ios.dependency 'FirebaseAnalyticsInterop', '~> 1.1'
+  s.dependency 'FirebaseAnalyticsInterop', '~> 1.1'
   s.dependency 'FirebaseCore', '~> 5.1'
   s.dependency 'FirebaseInstanceID', '~> 3.0'
   s.dependency 'GoogleUtilities/Reachability', '~> 5.2'


### PR DESCRIPTION
While FirebaseAnalytics only exists on iOS, FirebaseAnalyticsInterop is supported on iOS, tvOS, and macOS.

This change is purely a clean-up since DynamicLinks and Messaging are currently only supported on iOS.