### PR TITLE
Pin gRPC-C++ version to exactly 0.0.5

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -54,7 +54,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
 
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
   s.dependency 'FirebaseCore', '~> 5.1'
-  s.dependency 'gRPC-C++', '0.0.3'
+  s.dependency 'gRPC-C++', '0.0.5'
   s.dependency 'leveldb-library', '~> 1.20'
   s.dependency 'Protobuf', '~> 3.1'
   s.dependency 'nanopb', '~> 0.3.8'

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -54,7 +54,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
 
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
   s.dependency 'FirebaseCore', '~> 5.1'
-  s.dependency 'gRPC-C++', '~> 0.0.3'
+  s.dependency 'gRPC-C++', '0.0.3'
   s.dependency 'leveldb-library', '~> 1.20'
   s.dependency 'Protobuf', '~> 3.1'
   s.dependency 'nanopb', '~> 0.3.8'


### PR DESCRIPTION
While gRPC-C++ is in its 0.* versions, any new version could potentially contain breaking changes. Make sure we only upgrade at our own pace.