### PR TITLE
Add Firebase Source to Header Search Path

### DIFF
--- a/Example/Firebase.xcodeproj/project.pbxproj
+++ b/Example/Firebase.xcodeproj/project.pbxproj
@@ -5023,7 +5023,6 @@
 		6003F5BD195388D20070C39A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -5057,6 +5056,13 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(SRC_ROOT)/../Firebase/**",
+					"$(SRC_ROOT)/../Firestore/**",
+					"$(SRC_ROOT)/../Functions/**",
+					"$(SRC_ROOT)/../GoogleUtilities/**",
+					"$(SRC_ROOT)/../Interop/**",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				ONLY_ACTIVE_ARCH = YES;
@@ -5068,7 +5074,6 @@
 		6003F5BE195388D20070C39A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -5095,6 +5100,13 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(SRC_ROOT)/../Firebase/**",
+					"$(SRC_ROOT)/../Firestore/**",
+					"$(SRC_ROOT)/../Functions/**",
+					"$(SRC_ROOT)/../GoogleUtilities/**",
+					"$(SRC_ROOT)/../Interop/**",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				SDKROOT = iphoneos;


### PR DESCRIPTION
This resolves the annoying Xcode errors that claim `FIRAppInternal.h` can't be found.

It also makes it *much* easier to "Jump to definition" now.