### PR TITLE
Fix build under linux/gcc

### DIFF
--- a/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
@@ -184,6 +184,7 @@ cc_library(
     absl_base
     absl_strings
     firebase_firestore_auth
+    firebase_firestore_core
     firebase_firestore_remote
     firebase_firestore_util
     grpc++


### PR DESCRIPTION
grpc_stream_tester.cc relies on f:f:model::DatabaseId, but wasn't
depending on it within the cc_library f_f_remote_test_util rule, causing
the build to fail. (Presumably, a mac specific library indirectly pulls
this in.)