### PR TITLE
Avoid using default FIROptions directly.

### DIFF
--- a/Firebase/DynamicLinks/FDLURLComponents/FIRDynamicLinkComponentsKeyProvider.h
+++ b/Firebase/DynamicLinks/FDLURLComponents/FIRDynamicLinkComponentsKeyProvider.h
@@ -16,12 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
-NS_ASSUME_NONNULL_BEGIN
-
 @interface FIRDynamicLinkComponentsKeyProvider : NSObject
 
-+ (NSString *)APIKey;
++ (nullable NSString *)APIKey;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/Firebase/DynamicLinks/FDLURLComponents/FIRDynamicLinkComponentsKeyProvider.m
+++ b/Firebase/DynamicLinks/FDLURLComponents/FIRDynamicLinkComponentsKeyProvider.m
@@ -16,21 +16,20 @@
 
 #import "DynamicLinks/FDLURLComponents/FIRDynamicLinkComponentsKeyProvider.h"
 
+#import <FirebaseCore/FIRAppInternal.h>
 #import <FirebaseCore/FIROptions.h>
-
-NS_ASSUME_NONNULL_BEGIN
 
 @implementation FIRDynamicLinkComponentsKeyProvider
 
-+ (NSString *)APIKey {
-  static NSString *apiKey;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    apiKey = [FIROptions defaultOptions].APIKey;
-  });
-  return apiKey;
++ (nullable NSString *)APIKey {
+  // If there's no default app, immediately return nil since reading from the default app will cause
+  // an error to be logged.
+  if (![FIRApp isDefaultAppConfigured]) {
+    return nil;
+  }
+
+  // FDL only supports the default app, use the options from it.
+  return [FIRApp defaultApp].options.APIKey;
 }
 
 @end
-
-NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Instead of using `[FIROptions defaultOptions]` we should be using
`FIRApp`'s options. This will allow developers to use custom `FIROptions`
instead of the default named info.plist.

This addresses #2112. 