### PR TITLE
Fix pod lib lint GoogleUtilities.podspec --use-libraries regression

### DIFF
--- a/GoogleUtilities/CHANGELOG.md
+++ b/GoogleUtilities/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- Fix `pod lib lint GoogleUtilities.podspec --use-libraries` regression. (#2130)
 
 # 5.3.6
 - Fix nullability issues. (#2079)
@@ -11,7 +12,7 @@
 
 # 5.3.4
 - Fixed a crash caused by unprotected access to sessions in
-  `GULNetworkURLSession` (#1964).
+  `GULNetworkURLSession`. (#1964)
 
 # 5.3.3
 - Fixed an issue where GoogleUtilities would leak instances of `NSURLSession`.

--- a/GoogleUtilities/Network/GULNetworkURLSession.m
+++ b/GoogleUtilities/Network/GULNetworkURLSession.m
@@ -37,6 +37,9 @@
 #pragma clang diagnostic ignored "-Wunguarded-availability"
   /// The session configuration. NSURLSessionConfiguration' is only available on iOS 7.0 or newer.
   NSURLSessionConfiguration *_sessionConfig;
+
+  /// The current NSURLSession.
+  NSURLSession *__weak _Nullable _URLSession;
 #pragma clang diagnostic pop
 
   /// The path to the directory where all temporary files are stored before uploading.
@@ -50,9 +53,6 @@
 
   /// The current request.
   NSURLRequest *_request;
-
-  /// The current NSURLSession.
-  NSURLSession *__weak _Nullable _URLSession;
 }
 
 #pragma mark - Init


### PR DESCRIPTION
We missed this new iOS 6 warning since we only run the --use-libraries tests in the daily cron job which has had other recurring failures.