### PR TITLE
Save schema version on downgrade, add test to verify

### DIFF
--- a/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBMigrationsTests.mm
@@ -95,20 +95,14 @@ using SchemaVersion = LevelDbMigrations::SchemaVersion;
 }
 
 - (void)testSetsVersionNumber {
-  {
-    LevelDbTransaction transaction(_db.get(), "testSetsVersionNumber before");
-    SchemaVersion initial = LevelDbMigrations::ReadSchemaVersion(&transaction);
-    XCTAssertEqual(0, initial, "No version should be equivalent to 0");
-  }
+  SchemaVersion initial = LevelDbMigrations::ReadSchemaVersion(_db.get());
+  XCTAssertEqual(0, initial, "No version should be equivalent to 0");
 
-  {
-    // Pick an arbitrary high migration number and migrate to it.
-    LevelDbMigrations::RunMigrations(_db.get());
+  // Pick an arbitrary high migration number and migrate to it.
+  LevelDbMigrations::RunMigrations(_db.get());
 
-    LevelDbTransaction transaction(_db.get(), "testSetsVersionNumber after");
-    SchemaVersion actual = LevelDbMigrations::ReadSchemaVersion(&transaction);
-    XCTAssertGreaterThan(actual, 0, @"Expected to migrate to a schema version > 0");
-  }
+  SchemaVersion actual = LevelDbMigrations::ReadSchemaVersion(_db.get());
+  XCTAssertGreaterThan(actual, 0, @"Expected to migrate to a schema version > 0");
 }
 
 #define ASSERT_NOT_FOUND(transaction, key)                \
@@ -364,6 +358,25 @@ using SchemaVersion = LevelDbMigrations::SchemaVersion;
     XCTAssertTrue(
         transaction.Get(LevelDbDocumentMutationKey::Key("bar", testWritePending, 4), &buffer).ok());
   }
+}
+
+- (void)testCanDowngrade {
+  // First, run all of the migrations
+  LevelDbMigrations::RunMigrations(_db.get());
+
+  LevelDbMigrations::SchemaVersion latestVersion = LevelDbMigrations::ReadSchemaVersion(_db.get());
+
+  // Downgrade to an early version.
+  LevelDbMigrations::SchemaVersion downgradeVersion = 1;
+  LevelDbMigrations::RunMigrations(_db.get(), downgradeVersion);
+  LevelDbMigrations::SchemaVersion postDowngradeVersion =
+      LevelDbMigrations::ReadSchemaVersion(_db.get());
+  XCTAssertEqual(downgradeVersion, postDowngradeVersion);
+
+  // Verify that we can upgrade again to the latest version.
+  LevelDbMigrations::RunMigrations(_db.get());
+  LevelDbMigrations::SchemaVersion finalVersion = LevelDbMigrations::ReadSchemaVersion(_db.get());
+  XCTAssertEqual(finalVersion, latestVersion);
 }
 
 /**

--- a/Firestore/core/src/firebase/firestore/local/leveldb_migrations.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_migrations.cc
@@ -245,7 +245,7 @@ void EnsureSentinelRows(leveldb::DB* db) {
 
 LevelDbMigrations::SchemaVersion LevelDbMigrations::ReadSchemaVersion(
     leveldb::DB* db) {
-  LevelDbTransaction transaction(db, "ReadSchemaVersion");
+  LevelDbTransaction transaction(db, "Read schema version");
   std::string key = LevelDbVersionKey::Key();
   std::string version_string;
   Status status = transaction.Get(key, &version_string);
@@ -263,7 +263,7 @@ void LevelDbMigrations::RunMigrations(leveldb::DB* db) {
 void LevelDbMigrations::RunMigrations(leveldb::DB* db,
                                       SchemaVersion to_version) {
   SchemaVersion from_version = ReadSchemaVersion(db);
-  // If this is a downgrade, just save the downgrade version so
+  // If this is a downgrade, just save the downgrade version so we can
   // detect it when we go to upgrade again, allowing us to rerun the
   // data migrations.
   if (from_version > to_version) {

--- a/Firestore/core/src/firebase/firestore/local/leveldb_migrations.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_migrations.cc
@@ -244,10 +244,11 @@ void EnsureSentinelRows(leveldb::DB* db) {
 }  // namespace
 
 LevelDbMigrations::SchemaVersion LevelDbMigrations::ReadSchemaVersion(
-    LevelDbTransaction* transaction) {
+    leveldb::DB* db) {
+  LevelDbTransaction transaction(db, "ReadSchemaVersion");
   std::string key = LevelDbVersionKey::Key();
   std::string version_string;
-  Status status = transaction->Get(key, &version_string);
+  Status status = transaction.Get(key, &version_string);
   if (status.IsNotFound()) {
     return 0;
   } else {
@@ -261,8 +262,16 @@ void LevelDbMigrations::RunMigrations(leveldb::DB* db) {
 
 void LevelDbMigrations::RunMigrations(leveldb::DB* db,
                                       SchemaVersion to_version) {
-  LevelDbTransaction transaction{db, "Read schema version"};
-  SchemaVersion from_version = ReadSchemaVersion(&transaction);
+  SchemaVersion from_version = ReadSchemaVersion(db);
+  // If this is a downgrade, just save the downgrade version so
+  // detect it when we go to upgrade again, allowing us to rerun the
+  // data migrations.
+  if (from_version > to_version) {
+    LevelDbTransaction transaction(db, "Save downgrade version");
+    SaveVersion(to_version, &transaction);
+    transaction.Commit();
+    return;
+  }
 
   // This must run unconditionally because schema migrations were added to iOS
   // after the first release. There may be clients that have never run any

--- a/Firestore/core/src/firebase/firestore/local/leveldb_migrations.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_migrations.h
@@ -34,7 +34,7 @@ class LevelDbMigrations {
   /**
    * Returns the current version of the schema for the given database
    */
-  static SchemaVersion ReadSchemaVersion(LevelDbTransaction* transaction);
+  static SchemaVersion ReadSchemaVersion(leveldb::DB* db);
 
   /**
    * Runs any migrations needed to bring the given database up to the current


### PR DESCRIPTION
Due to the nature of leveldb, our existing migrations are idempotent already. As with other platforms, this is not a guarantee that they will always be, but in general the issue is largely the same as with migrating protobufs. 