### PR TITLE
Carthage: update the name of certificates bundle

### DIFF
--- a/Carthage.md
+++ b/Carthage.md
@@ -63,7 +63,7 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseStorageBinary.jso
     into the Xcode project and make sure they're added to the
     `Copy Bundle Resources` Build Phase :
     - For Firestore:
-        - ./Carthage/Build/iOS/FirebaseFirestore.framework/gRPCCertificates.bundle
+        - ./Carthage/Build/iOS/FirebaseFirestore.framework/gRPCCertificates-Firestore.bundle
     - For Invites:
         - ./Carthage/Build/iOS/FirebaseInvites.framework/GoogleSignIn.bundle
         - ./Carthage/Build/iOS/FirebaseInvites.framework/GPPACLPickerResources.bundle


### PR DESCRIPTION
To accommodate for release 5.14.0.