### PR TITLE
Fix leaks in Firestore

### DIFF
--- a/Firestore/Source/Local/FSTLRUGarbageCollector.mm
+++ b/Firestore/Source/Local/FSTLRUGarbageCollector.mm
@@ -81,7 +81,7 @@ class RollingSequenceNumberBuffer {
 };
 
 @implementation FSTLRUGarbageCollector {
-  id<FSTLRUDelegate> _delegate;
+  __weak id<FSTLRUDelegate> _delegate;
   LruParams _params;
 }
 

--- a/Firestore/Source/Local/FSTLevelDBMutationQueue.mm
+++ b/Firestore/Source/Local/FSTLevelDBMutationQueue.mm
@@ -86,7 +86,8 @@ using leveldb::WriteOptions;
 @end
 
 @implementation FSTLevelDBMutationQueue {
-  FSTLevelDB *_db;
+  // This instance is owned by FSTLevelDB; avoid a retain cycle.
+  __weak FSTLevelDB *_db;
 
   /** The normalized userID (e.g. nil UID => @"" userID) used in our LevelDB keys. */
   std::string _userID;

--- a/Firestore/Source/Local/FSTLevelDBQueryCache.mm
+++ b/Firestore/Source/Local/FSTLevelDBQueryCache.mm
@@ -62,7 +62,8 @@ using leveldb::Status;
 @end
 
 @implementation FSTLevelDBQueryCache {
-  FSTLevelDB *_db;
+  // This instance is owned by FSTLevelDB; avoid a retain cycle.
+  __weak FSTLevelDB *_db;
 
   /**
    * The last received snapshot version. This is part of `metadata` but we store it separately to

--- a/Firestore/core/src/firebase/firestore/remote/remote_objc_bridge.h
+++ b/Firestore/core/src/firebase/firestore/remote/remote_objc_bridge.h
@@ -185,7 +185,7 @@ class WatchStreamDelegate {
   void NotifyDelegateOnClose(const util::Status& status);
 
  private:
-  id<FSTWatchStreamDelegate> delegate_;
+  __weak id<FSTWatchStreamDelegate> delegate_;
 };
 
 /** A C++ bridge that invokes methods on an `FSTWriteStreamDelegate`. */
@@ -202,7 +202,7 @@ class WriteStreamDelegate {
   void NotifyDelegateOnClose(const util::Status& status);
 
  private:
-  id<FSTWriteStreamDelegate> delegate_;
+  __weak id<FSTWriteStreamDelegate> delegate_;
 };
 
 }  // namespace bridge


### PR DESCRIPTION
This fixes a few minor leaks:

  * In leveldb/lru gc, a retain cycle that would leak once over the lifetime of the app
  * In the streams, a retain cycle that would leak once per stream creation (enableNetwork/identity change--not per reconnect)
  * In the SCNetworkReachability monitor, we failed to CFRelease the ref, which would leak once over the lifetime of the app

Unit tests and Integration tests now pass cleanly under Instruments.

None of these appear related to #2189, but I couldn't reproduce that specific leak over the course of multiple runs.