### PR TITLE
Create testing infrastructure that simplifies catching exceptions in dispatch_queues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ cache:
   - bundler
   - cocoapods
 
-rvm: 2.3.1
-
 jobs:
   include:
     - stage: checks

--- a/GoogleDataLogger/GoogleDataLogger/Classes/GDLAssert.m
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/GDLAssert.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google
+ * Copyright 2019 Google
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataLogger/GoogleDataLogger/Classes/GDLAssert.m
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/GDLAssert.m
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GDLAssert.h"
+
+GDLAssertionBlock GDLAssertionBlockToRunInsteadOfNSAssert(void) {
+  // This class is only compiled in by unit tests, and this should fail quickly in optimized builds.
+  Class GDLAssertClass = NSClassFromString(@"GDLAssertHelper");
+  if (__builtin_expect(!!GDLAssertClass, 0)) {
+    SEL assertionBlockSEL = NSSelectorFromString(@"assertionBlock");
+    if (assertionBlockSEL) {
+      IMP assertionBlockIMP = [GDLAssertClass methodForSelector:assertionBlockSEL];
+      if (assertionBlockIMP) {
+        GDLAssertionBlock assertionBlock =
+            ((GDLAssertionBlock(*)(id, SEL))assertionBlockIMP)(GDLAssertClass, assertionBlockSEL);
+        if (assertionBlock) {
+          return assertionBlock;
+        }
+      }
+    }
+  }
+  return NULL;
+}

--- a/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogEvent.m
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogEvent.m
@@ -16,13 +16,14 @@
 
 #import <GoogleDataLogger/GDLLogEvent.h>
 
+#import "GDLAssert.h"
 #import "GDLLogEvent_Private.h"
 
 @implementation GDLLogEvent
 
 - (instancetype)initWithLogMapID:(NSString *)logMapID logTarget:(NSInteger)logTarget {
-  NSAssert(logMapID.length > 0, @"Please give a valid log map ID");
-  NSAssert(logTarget > 0, @"A log target cannot be negative or 0");
+  GDLAssert(logMapID.length > 0, @"Please give a valid log map ID");
+  GDLAssert(logTarget > 0, @"A log target cannot be negative or 0");
   self = [super init];
   if (self) {
     _logMapID = logMapID;

--- a/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogStorage.m
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogStorage.m
@@ -80,8 +80,8 @@ static NSString *GDLStoragePath() {
     // Write the extension bytes to disk, get a filename.
     NSAssert(shortLivedLog.extensionBytes, @"The log should have been serialized to bytes");
     NSAssert(shortLivedLog.extension == nil, @"The original log proto should be removed");
-    NSURL *logFile =
-        [self saveLogProtoToDisk:shortLivedLog.extensionBytes logHash:shortLivedLog.hash];
+    NSURL *logFile = [self saveLogProtoToDisk:shortLivedLog.extensionBytes
+                                      logHash:shortLivedLog.hash];
 
     // Add log to tracking collections.
     [self addLogToTrackingCollections:shortLivedLog logFile:logFile];
@@ -195,8 +195,8 @@ static NSString *const kGDLLogTargetToLogSetKey = @"logTargetToLogFileSetKey";
   GDLLogStorage *sharedInstance = [self.class sharedInstance];
   dispatch_sync(sharedInstance.storageQueue, ^{
     Class NSMutableDictionaryClass = [NSMutableDictionary class];
-    sharedInstance->_logHashToLogFile =
-        [aDecoder decodeObjectOfClass:NSMutableDictionaryClass forKey:kGDLLogHashToLogFileKey];
+    sharedInstance->_logHashToLogFile = [aDecoder decodeObjectOfClass:NSMutableDictionaryClass
+                                                               forKey:kGDLLogHashToLogFileKey];
     sharedInstance->_logTargetToLogFileSet =
         [aDecoder decodeObjectOfClass:NSMutableDictionaryClass forKey:kGDLLogTargetToLogSetKey];
   });

--- a/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogStorage.m
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogStorage.m
@@ -19,6 +19,7 @@
 
 #import <GoogleDataLogger/GDLLogPrioritizer.h>
 
+#import "GDLAssert.h"
 #import "GDLConsoleLogger.h"
 #import "GDLLogEvent_Private.h"
 #import "GDLRegistrar_Private.h"
@@ -75,11 +76,11 @@ static NSString *GDLStoragePath() {
     // Check that a log prioritizer is available for this logTarget.
     id<GDLLogPrioritizer> logPrioritizer =
         [GDLRegistrar sharedInstance].logTargetToPrioritizer[@(logTarget)];
-    NSAssert(logPrioritizer, @"There's no scorer registered for the given logTarget.");
+    GDLAssert(logPrioritizer, @"There's no scorer registered for the given logTarget.");
 
     // Write the extension bytes to disk, get a filename.
-    NSAssert(shortLivedLog.extensionBytes, @"The log should have been serialized to bytes");
-    NSAssert(shortLivedLog.extension == nil, @"The original log proto should be removed");
+    GDLAssert(shortLivedLog.extensionBytes, @"The log should have been serialized to bytes");
+    GDLAssert(shortLivedLog.extension == nil, @"The original log proto should be removed");
     NSURL *logFile = [self saveLogProtoToDisk:shortLivedLog.extensionBytes
                                       logHash:shortLivedLog.hash];
 
@@ -111,12 +112,12 @@ static NSString *GDLStoragePath() {
     // Remove from disk, first and foremost.
     NSError *error;
     [[NSFileManager defaultManager] removeItemAtURL:logFile error:&error];
-    NSAssert(error == nil, @"There was an error removing a logFile: %@", error);
+    GDLAssert(error == nil, @"There was an error removing a logFile: %@", error);
 
     // Remove from the tracking collections.
     [self.logHashToLogFile removeObjectForKey:logHash];
     NSMutableSet<NSURL *> *logFiles = self.logTargetToLogFileSet[logTarget];
-    NSAssert(logFiles, @"There wasn't a logSet for this logTarget.");
+    GDLAssert(logFiles, @"There wasn't a logSet for this logTarget.");
     [logFiles removeObject:logFile];
     // It's fine to not remove the set if it's empty.
   });

--- a/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogWriter.m
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogWriter.m
@@ -19,6 +19,7 @@
 
 #import <GoogleDataLogger/GDLLogTransformer.h>
 
+#import "GDLAssert.h"
 #import "GDLConsoleLogger.h"
 #import "GDLLogEvent_Private.h"
 #import "GDLLogStorage.h"
@@ -46,7 +47,7 @@
 
 - (void)writeLog:(GDLLogEvent *)log
     afterApplyingTransformers:(NSArray<id<GDLLogTransformer>> *)logTransformers {
-  NSAssert(log, @"You can't write a nil log");
+  GDLAssert(log, @"You can't write a nil log");
   dispatch_async(_logWritingQueue, ^{
     GDLLogEvent *transformedLog = log;
     for (id<GDLLogTransformer> transformer in logTransformers) {

--- a/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogger.m
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogger.m
@@ -16,6 +16,7 @@
 
 #import "GDLLogger.h"
 
+#import "GDLAssert.h"
 #import "GDLLogEvent.h"
 #import "GDLLogWriter.h"
 
@@ -39,8 +40,8 @@
                        logTarget:(NSInteger)logTarget {
   self = [super init];
   if (self) {
-    NSAssert(logMapID.length > 0, @"A log mapping ID cannot be nil or empty");
-    NSAssert(logTarget > 0, @"A log target cannot be negative or 0");
+    GDLAssert(logMapID.length > 0, @"A log mapping ID cannot be nil or empty");
+    GDLAssert(logTarget > 0, @"A log target cannot be negative or 0");
     _logMapID = logMapID;
     _logTransformers = logTransformers;
     _logTarget = logTarget;
@@ -49,13 +50,13 @@
 }
 
 - (void)logTelemetryEvent:(GDLLogEvent *)logEvent {
-  NSAssert(logEvent, @"You can't log a nil event");
+  GDLAssert(logEvent, @"You can't log a nil event");
   GDLLogEvent *copiedLog = [logEvent copy];
   [[GDLLogWriter sharedInstance] writeLog:copiedLog afterApplyingTransformers:_logTransformers];
 }
 
 - (void)logDataEvent:(GDLLogEvent *)logEvent {
-  NSAssert(logEvent, @"You can't log a nil event");
+  GDLAssert(logEvent, @"You can't log a nil event");
   GDLLogEvent *copiedLog = [logEvent copy];
   [[GDLLogWriter sharedInstance] writeLog:copiedLog afterApplyingTransformers:_logTransformers];
 }

--- a/GoogleDataLogger/GoogleDataLogger/Classes/Private/GDLAssert.h
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/Private/GDLAssert.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google
+ * Copyright 2019 Google
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,13 +27,15 @@ typedef void (^GDLAssertionBlock)(void);
  */
 FOUNDATION_EXTERN GDLAssertionBlock _Nullable GDLAssertionBlockToRunInsteadOfNSAssert(void);
 
+#if !defined(NS_BLOCK_ASSERTIONS)
+
 /** Asserts using NSAssert, unless a block was specified to be run instead.
  *
  * @param condition The condition you'd expect to be YES.
  */
 #define GDLAssert(condition, ...)                                                   \
   do {                                                                              \
-    if (__builtin_expect(!(condition), 0)) {                                       \
+    if (__builtin_expect(!(condition), 0)) {                                        \
       GDLAssertionBlock assertionBlock = GDLAssertionBlockToRunInsteadOfNSAssert(); \
       if (assertionBlock) {                                                         \
         assertionBlock();                                                           \
@@ -42,3 +44,11 @@ FOUNDATION_EXTERN GDLAssertionBlock _Nullable GDLAssertionBlockToRunInsteadOfNSA
       }                                                                             \
     }                                                                               \
   } while (0);
+
+#else
+
+#define GDLAssert(condition, ...) \
+  do {                            \
+  } while (0);
+
+#endif  // !defined(NS_BLOCK_ASSERTIONS)

--- a/GoogleDataLogger/GoogleDataLogger/Classes/Private/GDLAssert.h
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/Private/GDLAssert.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+/** A block type that could be run instead of NSAssert. No return type, no params. */
+typedef void (^GDLAssertionBlock)(void);
+
+/** Returns the result of executing a soft-linked method present in unit tests that allows a block
+ * to be run in lieu of a call to NSAssert. This helps ameliorate issues with catching exceptions
+ * that occur on a dispatch_queue.
+ *
+ * @return A block that can be run instead of calling NSAssert, or nil.
+ */
+FOUNDATION_EXTERN GDLAssertionBlock _Nullable GDLAssertionBlockToRunInsteadOfNSAssert(void);
+
+/** Asserts using NSAssert, unless a block was specified to be run instead.
+ *
+ * @param condition The condition you'd expect to be YES.
+ */
+#define GDLAssert(condition, ...)                                                   \
+  do {                                                                              \
+    if (__builtin_expect(!(condition), 0)) {                                       \
+      GDLAssertionBlock assertionBlock = GDLAssertionBlockToRunInsteadOfNSAssert(); \
+      if (assertionBlock) {                                                         \
+        assertionBlock();                                                           \
+      } else {                                                                      \
+        NSAssert(condition, __VA_ARGS__);                                           \
+      }                                                                             \
+    }                                                                               \
+  } while (0);

--- a/GoogleDataLogger/GoogleDataLogger/DependencyWrappers/GDLConsoleLogger.h
+++ b/GoogleDataLogger/GoogleDataLogger/DependencyWrappers/GDLConsoleLogger.h
@@ -16,6 +16,8 @@
 
 #import "GULLogger.h"
 
+#import "GDLAssert.h"
+
 /** The console logger prefix. */
 static GULLoggerService kGDLConsoleLogger = @"[GoogleDataLogger]";
 
@@ -64,4 +66,4 @@ FOUNDATION_EXTERN void GDLLogWarning(GDLMessageCode messageCode,
 #define GDLLogError(MESSAGE_CODE, MESSAGE_FORMAT, ...)                                          \
   GULLogError(kGDLConsoleLogger, YES, GDLMessageCodeEnumToString(MESSAGE_CODE), MESSAGE_FORMAT, \
               __VA_ARGS__);                                                                     \
-  NSAssert(NO, MESSAGE_FORMAT, __VA_ARGS__);
+  GDLAssert(NO, MESSAGE_FORMAT, __VA_ARGS__);

--- a/GoogleDataLogger/Tests/GDLLogEventTest.m
+++ b/GoogleDataLogger/Tests/GDLLogEventTest.m
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-#import <XCTest/XCTest.h>
+#import "GDLTestCase.h"
 
 #import <GoogleDataLogger/GDLLogEvent.h>
 
 #import "GDLLogEvent_Private.h"
 
-@interface GDLLogEventTest : XCTestCase
+@interface GDLLogEventTest : GDLTestCase
 
 @end
 

--- a/GoogleDataLogger/Tests/GDLLogStorageTest.m
+++ b/GoogleDataLogger/Tests/GDLLogStorageTest.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <XCTest/XCTest.h>
+#import "GDLTestCase.h"
 
 #import <GoogleDataLogger/GDLLogEvent.h>
 
@@ -32,7 +32,7 @@
 
 static NSInteger logTarget = 1337;
 
-@interface GDLLogStorageTest : XCTestCase
+@interface GDLLogStorageTest : GDLTestCase
 
 /** The test backend implementation. */
 @property(nullable, nonatomic) GDLTestBackend *testBackend;

--- a/GoogleDataLogger/Tests/GDLLogUploaderTest.m
+++ b/GoogleDataLogger/Tests/GDLLogUploaderTest.m
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-#import <XCTest/XCTest.h>
+#import "GDLTestCase.h"
 
 #import "GDLUploader.h"
 
-@interface GDLUploaderTest : XCTestCase
+@interface GDLUploaderTest : GDLTestCase
 
 @end
 

--- a/GoogleDataLogger/Tests/GDLLogWriterTest.m
+++ b/GoogleDataLogger/Tests/GDLLogWriterTest.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <XCTest/XCTest.h>
+#import "GDLTestCase.h"
 
 #import <GoogleDataLogger/GDLLogTransformer.h>
 
@@ -47,7 +47,7 @@
 
 @end
 
-@interface GDLLogWriterTest : XCTestCase
+@interface GDLLogWriterTest : GDLTestCase
 
 @end
 

--- a/GoogleDataLogger/Tests/GDLLoggerTest.m
+++ b/GoogleDataLogger/Tests/GDLLoggerTest.m
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-#import <XCTest/XCTest.h>
+#import "GDLTestCase.h"
 
 #import <GoogleDataLogger/GDLLogEvent.h>
 #import <GoogleDataLogger/GDLLogger.h>
 
 #import "GDLLogExtensionTesterClasses.h"
 
-@interface GDLLoggerTest : XCTestCase
+@interface GDLLoggerTest : GDLTestCase
 
 @end
 

--- a/GoogleDataLogger/Tests/GDLRegistrarTest.m
+++ b/GoogleDataLogger/Tests/GDLRegistrarTest.m
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-#import <XCTest/XCTest.h>
+#import "GDLTestCase.h"
 
 #import <GoogleDataLogger/GDLRegistrar.h>
 
-@interface GDLRegistrarTest : XCTestCase
+@interface GDLRegistrarTest : GDLTestCase
 
 @end
 

--- a/GoogleDataLogger/Tests/GDLTestCase.h
+++ b/GoogleDataLogger/Tests/GDLTestCase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google
+ * Copyright 2019 Google
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataLogger/Tests/GDLTestCase.h
+++ b/GoogleDataLogger/Tests/GDLTestCase.h
@@ -14,19 +14,15 @@
  * limitations under the License.
  */
 
-#import "GDLTestCase.h"
+#import <XCTest/XCTest.h>
 
-#import "GDLClock.h"
+#import "GDLAssertHelper.h"
 
-@interface GDLClockTest : GDLTestCase
+NS_ASSUME_NONNULL_BEGIN
 
-@end
-
-@implementation GDLClockTest
-
-/** Tests the default initializer. */
-- (void)testInit {
-  XCTAssertNotNil([[GDLClockTest alloc] init]);
-}
+/** This class defines shared testing infrastructure across all unit tests in GoogleDataLogger. */
+@interface GDLTestCase : XCTestCase
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleDataLogger/Tests/GDLTestCase.m
+++ b/GoogleDataLogger/Tests/GDLTestCase.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google
+ * Copyright 2019 Google
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataLogger/Tests/GDLTestCase.m
+++ b/GoogleDataLogger/Tests/GDLTestCase.m
@@ -16,17 +16,13 @@
 
 #import "GDLTestCase.h"
 
-#import "GDLClock.h"
+@implementation GDLTestCase
 
-@interface GDLClockTest : GDLTestCase
+- (void)setUp {
+}
 
-@end
-
-@implementation GDLClockTest
-
-/** Tests the default initializer. */
-- (void)testInit {
-  XCTAssertNotNil([[GDLClockTest alloc] init]);
+- (void)tearDown {
+  [GDLAssertHelper setAssertionBlock:nil];
 }
 
 @end

--- a/GoogleDataLogger/Tests/Helpers/GDLAssertHelper.h
+++ b/GoogleDataLogger/Tests/Helpers/GDLAssertHelper.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "GDLAssert.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** Allows the setting a block to be used in the GDLAssert macro instead of a call to NSAssert. */
+@interface GDLAssertHelper : NSObject
+
+/** A class property that can be run instead of NSAssert. */
+@property(class, nullable, nonatomic) GDLAssertionBlock assertionBlock;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleDataLogger/Tests/Helpers/GDLAssertHelper.m
+++ b/GoogleDataLogger/Tests/Helpers/GDLAssertHelper.m
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GDLAssertHelper.h"
+
+@implementation GDLAssertHelper
+
+// The backing store for the class variable assertionBlock.
+static GDLAssertionBlock gSharedAssertionBlock;
+
++ (GDLAssertionBlock)assertionBlock {
+  return gSharedAssertionBlock;
+}
+
++ (void)setAssertionBlock:(GDLAssertionBlock)assertionBlock {
+  gSharedAssertionBlock = assertionBlock;
+}
+
+@end


### PR DESCRIPTION
In storeLog:, an NSAssert is expected to be triggered in certain cases while running asynchronously on a dispatch_queue. Discovering the currentThread and overriding the NSAssertionHandler with a subclass is not feasible, because NSAsserts are frequently used in Foundation code and in unit tests (XCTestExpectation, for example). A mechanism was needed to know whether or not an error was being experienced, as it's expected for certain cases.

This PR creates a custom assert that allows the calling of a soft-linked block instead of an NSAssert, and an XCTestCase subclass to be used by all subclasses that automatically sets that block to nil at the end of every unit test.