### PR TITLE
Remove rvm specification from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ cache:
   - bundler
   - cocoapods
 
-rvm: 2.3.1
-
 jobs:
   include:
     - stage: checks


### PR DESCRIPTION
Attempt to fix bundle failure error showing up in recent travis builds:

```
$ bundle --version
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/rubygems.rb:241:in `bin_path': can't find gem bundler (>= 0.a) (Gem::GemNotFoundException)
	from /usr/local/bin/bundle:22:in `<main>'
```