### PR TITLE
Refactor to allow injection of fakes, and take warnings seriously

### DIFF
--- a/GoogleDataLogger.podspec
+++ b/GoogleDataLogger.podspec
@@ -30,7 +30,9 @@ Shared library for iOS SDK data logging needs.
   s.dependency 'GoogleUtilities/Logger'
 
   s.pod_target_xcconfig = {
-    'GCC_C_LANGUAGE_STANDARD' => 'c99'
+    'GCC_C_LANGUAGE_STANDARD' => 'c99',
+    'GCC_TREAT_WARNINGS_AS_ERRORS' => 'YES',
+    'GCC_WARN_PEDANTIC' => 'YES',
   }
 
   # Test specs

--- a/GoogleDataLogger.podspec
+++ b/GoogleDataLogger.podspec
@@ -31,7 +31,7 @@ Shared library for iOS SDK data logging needs.
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
-    'GCC_TREAT_WARNINGS_AS_ERRORS' => 'YES',
+    'GCC_TREAT_WARNINGS_AS_ERRORS' => 'YES'
   }
 
   # Test specs

--- a/GoogleDataLogger.podspec
+++ b/GoogleDataLogger.podspec
@@ -32,7 +32,6 @@ Shared library for iOS SDK data logging needs.
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'GCC_TREAT_WARNINGS_AS_ERRORS' => 'YES',
-    'GCC_WARN_PEDANTIC' => 'YES',
   }
 
   # Test specs

--- a/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogStorage.m
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogStorage.m
@@ -57,6 +57,7 @@ static NSString *GDLStoragePath() {
     _storageQueue = dispatch_queue_create("com.google.GDLLogStorage", DISPATCH_QUEUE_SERIAL);
     _logHashToLogFile = [[NSMutableDictionary alloc] init];
     _logTargetToLogFileSet = [[NSMutableDictionary alloc] init];
+    _uploader = [GDLUploader sharedInstance];
   }
   return self;
 }
@@ -90,7 +91,7 @@ static NSString *GDLStoragePath() {
     // Check the QoS, if it's high priority, notify the log target that it has a high priority log.
     if (shortLivedLog.qosTier == GDLLogQoSFast) {
       NSSet<NSURL *> *allLogsForLogTarget = self.logTargetToLogFileSet[@(logTarget)];
-      [[GDLUploader sharedInstance] forceUploadLogs:allLogsForLogTarget target:logTarget];
+      [self.uploader forceUploadLogs:allLogsForLogTarget target:logTarget];
     }
 
     // Have the prioritizer prioritize the log, enforcing that they do not retain it.

--- a/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogWriter.m
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogWriter.m
@@ -41,6 +41,7 @@
   self = [super init];
   if (self) {
     _logWritingQueue = dispatch_queue_create("com.google.GDLLogWriter", DISPATCH_QUEUE_SERIAL);
+    _storageInstance = [GDLLogStorage sharedInstance];
   }
   return self;
 }
@@ -62,7 +63,7 @@
         return;
       }
     }
-    // TODO(mikehaney24): [[GDLLogStorage sharedInstance] storeLog:transformedLog];
+    [self.storageInstance storeLog:transformedLog];
   });
 }
 

--- a/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogger.m
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogger.m
@@ -15,23 +15,11 @@
  */
 
 #import "GDLLogger.h"
+#import "GDLLogger_Private.h"
 
 #import "GDLAssert.h"
 #import "GDLLogEvent.h"
 #import "GDLLogWriter.h"
-
-@interface GDLLogger ()
-
-/** The log mapping identifier that a GDLLogBackend will use to map the extension to proto. */
-@property(nonatomic) NSString *logMapID;
-
-/** The log transformers that will operate on logs logged by this logger. */
-@property(nonatomic) NSArray<id<GDLLogTransformer>> *logTransformers;
-
-/** The target backend of this logger. */
-@property(nonatomic) NSInteger logTarget;
-
-@end
 
 @implementation GDLLogger
 
@@ -45,6 +33,7 @@
     _logMapID = logMapID;
     _logTransformers = logTransformers;
     _logTarget = logTarget;
+    _logWriterInstance = [GDLLogWriter sharedInstance];
   }
   return self;
 }
@@ -53,14 +42,14 @@
   GDLAssert(logEvent, @"You can't log a nil event");
   GDLLogEvent *copiedLog = [logEvent copy];
   copiedLog.qosTier = GDLLogQoSTelemetry;
-  [[GDLLogWriter sharedInstance] writeLog:copiedLog afterApplyingTransformers:_logTransformers];
+  [self.logWriterInstance writeLog:copiedLog afterApplyingTransformers:_logTransformers];
 }
 
 - (void)logDataEvent:(GDLLogEvent *)logEvent {
   GDLAssert(logEvent, @"You can't log a nil event");
   GDLAssert(logEvent.qosTier != GDLLogQoSTelemetry, @"Use -logTelemetryEvent, please.");
   GDLLogEvent *copiedLog = [logEvent copy];
-  [[GDLLogWriter sharedInstance] writeLog:copiedLog afterApplyingTransformers:_logTransformers];
+  [self.logWriterInstance writeLog:copiedLog afterApplyingTransformers:_logTransformers];
 }
 
 - (GDLLogEvent *)newEvent {

--- a/GoogleDataLogger/GoogleDataLogger/Classes/Private/GDLLogStorage_Private.h
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/Private/GDLLogStorage_Private.h
@@ -16,6 +16,8 @@
 
 #import "GDLLogStorage.h"
 
+@class GDLUploader;
+
 @interface GDLLogStorage ()
 
 /** The queue on which all storage work will occur. */
@@ -27,5 +29,8 @@
 /** A map of logTargets to a set of log hash values. */
 @property(nonatomic)
     NSMutableDictionary<NSNumber *, NSMutableSet<NSURL *> *> *logTargetToLogFileSet;
+
+/** The log uploader instance to use. */
+@property(nonatomic) GDLUploader *uploader;
 
 @end

--- a/GoogleDataLogger/GoogleDataLogger/Classes/Private/GDLLogWriter_Private.h
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/Private/GDLLogWriter_Private.h
@@ -16,9 +16,14 @@
 
 #import "GDLLogWriter.h"
 
+@class GDLLogStorage;
+
 @interface GDLLogWriter ()
 
 /** The queue on which all work will occur. */
 @property(nonatomic) dispatch_queue_t logWritingQueue;
+
+/** The log storage instance used to store logs. Should only be used to inject a testing fake. */
+@property(nonatomic) GDLLogStorage *storageInstance;
 
 @end

--- a/GoogleDataLogger/GoogleDataLogger/Classes/Private/GDLLogger_Private.h
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/Private/GDLLogger_Private.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <GoogleDataLogger/GDLLogger.h>
+
+@class GDLLogWriter;
+
+@interface GDLLogger ()
+
+/** The log mapping identifier that a GDLLogBackend will use to map the extension to proto. */
+@property(nonatomic) NSString *logMapID;
+
+/** The log transformers that will operate on logs logged by this logger. */
+@property(nonatomic) NSArray<id<GDLLogTransformer>> *logTransformers;
+
+/** The target backend of this logger. */
+@property(nonatomic) NSInteger logTarget;
+
+/** The log writer instance to used to write logs. Allows injecting a fake during testing. */
+@property(nonatomic) GDLLogWriter *logWriterInstance;
+
+@end

--- a/GoogleDataLogger/Tests/Fakes/GDLLogStorageFake.h
+++ b/GoogleDataLogger/Tests/Fakes/GDLLogStorageFake.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GDLLogStorage.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** A functionless fake that can be injected into classes that need it. */
+@interface GDLLogStorageFake : GDLLogStorage
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleDataLogger/Tests/Fakes/GDLLogStorageFake.m
+++ b/GoogleDataLogger/Tests/Fakes/GDLLogStorageFake.m
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GDLLogStorageFake.h"
+
+@implementation GDLLogStorageFake
+
+- (void)storeLog:(GDLLogEvent *)log {
+}
+
+@end

--- a/GoogleDataLogger/Tests/Fakes/GDLLogWriterFake.h
+++ b/GoogleDataLogger/Tests/Fakes/GDLLogWriterFake.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GDLLogWriter.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** A functionless fake that can be injected into classes that need it. */
+@interface GDLLogWriterFake : GDLLogWriter
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleDataLogger/Tests/Fakes/GDLLogWriterFake.m
+++ b/GoogleDataLogger/Tests/Fakes/GDLLogWriterFake.m
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GDLLogWriterFake.h"
+
+@implementation GDLLogWriterFake
+
+- (void)writeLog:(GDLLogEvent *)log
+    afterApplyingTransformers:(NSArray<id<GDLLogTransformer>> *)logTransformers {
+}
+
+@end

--- a/GoogleDataLogger/Tests/Fakes/GDLUploaderFake.h
+++ b/GoogleDataLogger/Tests/Fakes/GDLUploaderFake.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GDLUploader.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GDLUploaderFake : GDLUploader
+
+@property(nonatomic) BOOL forceUploadCalled;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleDataLogger/Tests/Fakes/GDLUploaderFake.m
+++ b/GoogleDataLogger/Tests/Fakes/GDLUploaderFake.m
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GDLUploaderFake.h"
+
+@implementation GDLUploaderFake
+
+- (void)forceUploadLogs:(NSSet<NSURL *> *)logFiles target:(NSInteger)logTarget {
+  self.forceUploadCalled = YES;
+}
+
+@end

--- a/GoogleDataLogger/Tests/GDLLogWriterTest.m
+++ b/GoogleDataLogger/Tests/GDLLogWriterTest.m
@@ -20,10 +20,12 @@
 
 #import "GDLLogEvent.h"
 #import "GDLLogExtensionTesterClasses.h"
+#import "GDLLogStorage.h"
 #import "GDLLogWriter.h"
 #import "GDLLogWriter_Private.h"
 
 #import "GDLAssertHelper.h"
+#import "GDLLogStorageFake.h"
 
 @interface GDLLogWriterTestNilingTransformer : NSObject <GDLLogTransformer>
 
@@ -54,6 +56,20 @@
 @end
 
 @implementation GDLLogWriterTest
+
+- (void)setUp {
+  [super setUp];
+  dispatch_sync([GDLLogWriter sharedInstance].logWritingQueue, ^{
+    [GDLLogWriter sharedInstance].storageInstance = [[GDLLogStorageFake alloc] init];
+  });
+}
+
+- (void)tearDown {
+  [super tearDown];
+  dispatch_sync([GDLLogWriter sharedInstance].logWritingQueue, ^{
+    [GDLLogWriter sharedInstance].storageInstance = [GDLLogStorage sharedInstance];
+  });
+}
 
 /** Tests the default initializer. */
 - (void)testInit {

--- a/GoogleDataLogger/Tests/GDLLogWriterTest.m
+++ b/GoogleDataLogger/Tests/GDLLogWriterTest.m
@@ -87,9 +87,6 @@
   GDLLogEvent *log = [[GDLLogEvent alloc] initWithLogMapID:@"1" logTarget:1];
   log.extension = [[GDLLogExtensionTesterSimple alloc] init];
   XCTAssertNoThrow([writer writeLog:log afterApplyingTransformers:nil]);
-  dispatch_sync(writer.logWritingQueue, ^{
-                    // TODO(mikehaney24): Assert that storage contains the log.
-                });
 }
 
 /** Tests writing a log with a transformer that nils out the log. */
@@ -100,9 +97,6 @@
   NSArray<id<GDLLogTransformer>> *transformers =
       @[ [[GDLLogWriterTestNilingTransformer alloc] init] ];
   XCTAssertNoThrow([writer writeLog:log afterApplyingTransformers:transformers]);
-  dispatch_sync(writer.logWritingQueue, ^{
-                    // TODO(mikehaney24): Assert that storage does not contain the log.
-                });
 }
 
 /** Tests writing a log with a transformer that creates a new log. */
@@ -113,9 +107,6 @@
   NSArray<id<GDLLogTransformer>> *transformers =
       @[ [[GDLLogWriterTestNewLogTransformer alloc] init] ];
   XCTAssertNoThrow([writer writeLog:log afterApplyingTransformers:transformers]);
-  dispatch_sync(writer.logWritingQueue, ^{
-                    // TODO(mikehaney24): Assert that storage contains the new log.
-                });
 }
 
 /** Tests that using a transformer without transform: implemented throws. */
@@ -131,9 +122,6 @@
   }];
   [writer writeLog:log afterApplyingTransformers:transformers];
   [self waitForExpectations:@[ errorExpectation ] timeout:5.0];
-  dispatch_sync(writer.logWritingQueue, ^{
-                    // TODO(mikehaney24): Assert that storage contains the new log.
-                });
 }
 
 /** Tests that writing a nil log throws. */

--- a/GoogleDataLogger/Tests/GDLLoggerTest.m
+++ b/GoogleDataLogger/Tests/GDLLoggerTest.m
@@ -19,7 +19,10 @@
 #import <GoogleDataLogger/GDLLogEvent.h>
 #import <GoogleDataLogger/GDLLogger.h>
 
+#import "GDLLogger_Private.h"
+
 #import "GDLLogExtensionTesterClasses.h"
+#import "GDLLogWriterFake.h"
 
 @interface GDLLoggerTest : GDLTestCase
 
@@ -36,6 +39,7 @@
 /** Tests logging a telemetry event. */
 - (void)testLogTelemetryEvent {
   GDLLogger *logger = [[GDLLogger alloc] initWithLogMapID:@"1" logTransformers:nil logTarget:1];
+  logger.logWriterInstance = [[GDLLogWriterFake alloc] init];
   GDLLogEvent *event = [logger newEvent];
   event.extension = [[GDLLogExtensionTesterSimple alloc] init];
   XCTAssertNoThrow([logger logTelemetryEvent:event]);
@@ -44,6 +48,7 @@
 /** Tests logging a data event. */
 - (void)testLogDataEvent {
   GDLLogger *logger = [[GDLLogger alloc] initWithLogMapID:@"1" logTransformers:nil logTarget:1];
+  logger.logWriterInstance = [[GDLLogWriterFake alloc] init];
   GDLLogEvent *event = [logger newEvent];
   event.extension = [[GDLLogExtensionTesterSimple alloc] init];
   XCTAssertNoThrow([logger logDataEvent:event]);


### PR DESCRIPTION
Some classes have been refactored to allow the injecting of a fake. This has the benefit of allowing tests to be more hermetic without using mocks or swizzling, while also making it easier to refactor the library to move away from the singleton architecture, if that's desirable in the future.

We also make the generated project treat all warnings as errors, and to warn_pedantic.