### PR TITLE
Fix b/119570746: Transaction get returns nil if document does not exist

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Unreleased
-- [changed] `Transaction.getDocument()` now returns a non-nil
+- [changed] `Transaction.getDocument()` has been changed to return a non-nil
   `DocumentSnapshot` with `exists` equal to `false` if the document does not
-  exist (instead of returning a nil DocumentSnapshot).
+  exist (instead of returning a nil DocumentSnapshot). Code that was previously
+  doing `if (snapshot) { ... }` must be changed to
+  `if (snapshot.exists) { ... }`.
 
 # v0.16.1
 - [fixed] Offline persistence now properly records schema downgrades. This is a

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+- [changed] `Transaction.getDocument()` now returns a non-nil
+  `DocumentSnapshot` with `exists` equal to `false` if the document does not
+  exist (instead of returning a nil DocumentSnapshot).
 
 # v0.16.1
 - [fixed] Offline persistence now properly records schema downgrades. This is a

--- a/Firestore/Example/Tests/Integration/FSTTransactionTests.mm
+++ b/Firestore/Example/Tests/Integration/FSTTransactionTests.mm
@@ -81,6 +81,7 @@
       runTransactionWithBlock:^id _Nullable(FIRTransaction *transaction, NSError **error) {
         FIRDocumentSnapshot *snapshot = [transaction getDocument:doc error:error];
         XCTAssertNil(*error);
+        XCTAssertNotNil(snapshot);
         XCTAssertFalse(snapshot.exists);
         [transaction setData:@{@"foo" : @"bar"} forDocument:doc];
         return @YES;

--- a/Firestore/Source/API/FIRTransaction.mm
+++ b/Firestore/Source/API/FIRTransaction.mm
@@ -119,7 +119,15 @@ NS_ASSUME_NONNULL_BEGIN
                     HARD_ASSERT(documents.count == 1,
                                 "Mismatch in docs returned from document lookup.");
                     FSTMaybeDocument *internalDoc = documents.firstObject;
-                    if ([internalDoc isKindOfClass:[FSTDocument class]]) {
+                    if ([internalDoc isKindOfClass:[FSTDeletedDocument class]]) {
+                      FIRDocumentSnapshot *doc =
+                          [FIRDocumentSnapshot snapshotWithFirestore:self.firestore
+                                                         documentKey:document.key
+                                                            document:nil
+                                                           fromCache:NO
+                                                    hasPendingWrites:NO];
+                      completion(doc, nil);
+                    } else if ([internalDoc isKindOfClass:[FSTDocument class]]) {
                       FIRDocumentSnapshot *doc =
                           [FIRDocumentSnapshot snapshotWithFirestore:self.firestore
                                                          documentKey:internalDoc.key
@@ -127,8 +135,6 @@ NS_ASSUME_NONNULL_BEGIN
                                                            fromCache:NO
                                                     hasPendingWrites:NO];
                       completion(doc, nil);
-                    } else if ([internalDoc isKindOfClass:[FSTDeletedDocument class]]) {
-                      completion(nil, nil);
                     } else {
                       HARD_FAIL("BatchGetDocumentsRequest returned unexpected document type: %s",
                                 NSStringFromClass([internalDoc class]));


### PR DESCRIPTION
This makes the iOS behavior match Web and Android, returning a non-nil
snapshot with exists=false, rather than a nil snapshot.

NOTE: This is a potentially breaking change and the intention is to avoid merging it until we're ready to release Firestore 1.x.