### PR TITLE
use instanceIDForTest for instance init in unit tests

### DIFF
--- a/Example/Messaging/Tests/FIRMessagingTest.m
+++ b/Example/Messaging/Tests/FIRMessagingTest.m
@@ -51,7 +51,6 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
 @property(nonatomic, readonly, strong) FIRMessaging *messaging;
 @property(nonatomic, readwrite, strong) id mockMessaging;
 @property(nonatomic, readwrite, strong) id mockInstanceID;
-@property(nonatomic, readwrite, strong) id realInstanceID;
 @property(nonatomic, readwrite, strong) id mockFirebaseApp;
 
 @end
@@ -65,8 +64,6 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
   _mockFirebaseApp = OCMClassMock([FIRApp class]);
    OCMStub([_mockFirebaseApp defaultApp]).andReturn(_mockFirebaseApp);
   _mockInstanceID = OCMPartialMock(self.messaging.instanceID);
-  _realInstanceID = self.messaging.instanceID;
-  self.messaging.instanceID = self.mockInstanceID;
   [[NSUserDefaults standardUserDefaults]
       removePersistentDomainForName:[NSBundle mainBundle].bundleIdentifier];
 }
@@ -74,7 +71,6 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
 - (void)tearDown {
   self.messaging.shouldEstablishDirectChannel = NO;
   self.messaging.defaultFcmToken = nil;
-  self.messaging.instanceID = self.realInstanceID;
   self.messaging.apnsTokenData = nil;
   [_mockMessaging stopMocking];
   [_mockInstanceID stopMocking];

--- a/Example/Messaging/Tests/FIRMessagingTest.m
+++ b/Example/Messaging/Tests/FIRMessagingTest.m
@@ -26,6 +26,12 @@
 
 extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
 
+@interface FIRInstanceID (ExposedForTest)
+
++ (FIRInstanceID *)instanceIDForTests;
+
+@end
+
 @interface FIRMessaging ()
 + (FIRMessaging *)messagingForTests;
 
@@ -55,6 +61,7 @@ extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
 - (void)setUp {
   [super setUp];
   _messaging = [FIRMessaging messagingForTests];
+  _messaging.instanceID = [FIRInstanceID instanceIDForTests];
   _mockFirebaseApp = OCMClassMock([FIRApp class]);
    OCMStub([_mockFirebaseApp defaultApp]).andReturn(_mockFirebaseApp);
   _mockInstanceID = OCMPartialMock(self.messaging.instanceID);

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,6 +1,10 @@
-# Uncomment the next two lines for pre-release testing
+# Uncomment the next two lines for pre-release testing on internal repo
 #source 'sso://cpdc-internal/firebase'
 #source 'https://github.com/CocoaPods/Specs.git'
+
+# Uncomment the next two lines for pre-release testing on public repo
+source 'https://github.com/Firebase/SpecsStaging.git'
+source 'https://github.com/CocoaPods/Specs.git'
 
 use_frameworks!
 

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -39,7 +39,7 @@ device, and it is completely free.
   s.framework = 'SystemConfiguration'
   s.dependency 'FirebaseAnalyticsInterop', '~> 1.1'
   s.dependency 'FirebaseCore', '~> 5.1'
-  s.dependency 'FirebaseInstanceID', '~> 3.0'
+  s.dependency 'FirebaseInstanceID', '~> 3.4'
   s.dependency 'GoogleUtilities/Reachability', '~> 5.2'
   s.dependency 'GoogleUtilities/Environment', '~> 5.2'
   s.dependency 'Protobuf', '~> 3.1'

--- a/scripts/pod_lib_lint.sh
+++ b/scripts/pod_lib_lint.sh
@@ -37,7 +37,7 @@ fi
 # or Core APIs change. GoogleUtilities.podspec and FirebaseCore.podspec should be
 # manually pushed to a temporary Specs repo. See
 # https://guides.cocoapods.org/making/private-cocoapods.
-ALT_SOURCES="--sources=https://github.com/paulb777/Specs.git,https://github.com/CocoaPods/Specs.git"
+ALT_SOURCES="--sources=https://github.com/Firebase/SpecsStaging.git,https://github.com/CocoaPods/Specs.git"
 
 podspec="$1"
 if [[ $# -gt 1 ]]; then


### PR DESCRIPTION
Original init method for unit test could return nil object with the new component model.