### PR TITLE
Fixed macOS conditional check.

### DIFF
--- a/Firestore/Source/Local/FSTLevelDB.mm
+++ b/Firestore/Source/Local/FSTLevelDB.mm
@@ -383,7 +383,7 @@ static const char *kReservedPathComponent = "firestore";
       NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
   return Path::FromNSString(directories[0]).AppendUtf8(kReservedPathComponent);
 
-#elif TARGET_OS_MAC
+#elif TARGET_OS_OSX
   std::string dotPrefixed = absl::StrCat(".", kReservedPathComponent);
   return Path::FromNSString(NSHomeDirectory()).AppendUtf8(dotPrefixed);
 

--- a/GoogleUtilities/CHANGELOG.md
+++ b/GoogleUtilities/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-- Fix `pod lib lint GoogleUtilities.podspec --use-libraries` regression. (#2130)
+- Fixed `pod lib lint GoogleUtilities.podspec --use-libraries` regression. (#2130)
+- Fixed macOS conditional check in UserDefaults. (#2245)
 
 # 5.3.6
 - Fix nullability issues. (#2079)

--- a/GoogleUtilities/Example/Tests/UserDefaults/GULUserDefaultsTests.m
+++ b/GoogleUtilities/Example/Tests/UserDefaults/GULUserDefaultsTests.m
@@ -432,7 +432,7 @@ static const NSTimeInterval kGULTestCaseTimeoutInterval = 10;
 }
 
 - (void)testSynchronizeToDisk {
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
   // `NSFileManager` has trouble reading the files in `~/Library` even though the
   // `removeItemAtPath:` call works. Watching Finder while stepping through this test shows that the
   // file does get created and removed properly. When using LLDB to call `fileExistsAtPath:` the
@@ -440,7 +440,7 @@ static const NSTimeInterval kGULTestCaseTimeoutInterval = 10;
   // test app is sandboxed and `NSFileManager` is refusing to read the directory.
   // TODO: Investigate the failure and re-enable this test.
   return;
-#endif  // TARGET_OS_MAC
+#endif  // TARGET_OS_OSX
   NSString *suiteName = [NSString stringWithFormat:@"another_test_suite"];
   NSString *filePath = [self filePathForPreferencesName:suiteName];
   NSFileManager *fileManager = [NSFileManager defaultManager];

--- a/GoogleUtilities/UserDefaults/GULUserDefaults.m
+++ b/GoogleUtilities/UserDefaults/GULUserDefaults.m
@@ -201,7 +201,7 @@ typedef NS_ENUM(NSInteger, GULUDMessageCode) {
 - (void)clearAllData {
   // On macOS, using `kCFPreferencesCurrentHost` will not set all the keys necessary to match
   // `NSUserDefaults`.
-#if TARGET_OS_MAC
+#if TARGET_OS_OSX
   CFStringRef host = kCFPreferencesAnyHost;
 #else
   CFStringRef host = kCFPreferencesCurrentHost;


### PR DESCRIPTION
Turns out `TARGET_OS_MAC` is 1 for both macOS *and* iOS, we should be using
`TARGET_OS_OSX` instead.

Tweet with some history: https://twitter.com/gparker/status/836341915037515778