### PR TITLE
Treat ABORTED writes as retryable

### DIFF
--- a/Firestore/Example/Tests/SpecTests/json/write_spec_test.json
+++ b/Firestore/Example/Tests/SpecTests/json/write_spec_test.json
@@ -5797,112 +5797,6 @@
       }
     ]
   },
-  "Writes that fail with code aborted are rejected": {
-    "describeName": "Writes:",
-    "itName": "Writes that fail with code aborted are rejected",
-    "tags": [],
-    "config": {
-      "useGarbageCollection": true,
-      "numClients": 1
-    },
-    "steps": [
-      {
-        "userListen": [
-          2,
-          {
-            "path": "collection/key",
-            "filters": [],
-            "orderBys": []
-          }
-        ],
-        "stateExpect": {
-          "activeTargets": {
-            "2": {
-              "query": {
-                "path": "collection/key",
-                "filters": [],
-                "orderBys": []
-              },
-              "resumeToken": ""
-            }
-          }
-        }
-      },
-      {
-        "userSet": [
-          "collection/key",
-          {
-            "foo": "bar"
-          }
-        ],
-        "expect": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "added": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": true
-          }
-        ]
-      },
-      {
-        "failWrite": {
-          "error": {
-            "code": 10
-          }
-        },
-        "stateExpect": {
-          "userCallbacks": {
-            "acknowledgedDocs": [],
-            "rejectedDocs": [
-              "collection/key"
-            ]
-          }
-        },
-        "expect": [
-          {
-            "query": {
-              "path": "collection/key",
-              "filters": [],
-              "orderBys": []
-            },
-            "removed": [
-              {
-                "key": "collection/key",
-                "version": 0,
-                "value": {
-                  "foo": "bar"
-                },
-                "options": {
-                  "hasLocalMutations": true,
-                  "hasCommittedMutations": false
-                }
-              }
-            ],
-            "errorCode": 0,
-            "fromCache": true,
-            "hasPendingWrites": false
-          }
-        ]
-      }
-    ]
-  },
   "Writes that fail with code out-of-range are rejected": {
     "describeName": "Writes:",
     "itName": "Writes that fail with code out-of-range are rejected",
@@ -6292,6 +6186,157 @@
           },
           "keepInQueue": true
         }
+      }
+    ]
+  },
+  "Writes that fail with code aborted are retried": {
+    "describeName": "Writes:",
+    "itName": "Writes that fail with code aborted are retried",
+    "tags": [],
+    "config": {
+      "useGarbageCollection": true,
+      "numClients": 1
+    },
+    "steps": [
+      {
+        "userListen": [
+          2,
+          {
+            "path": "collection/key",
+            "filters": [],
+            "orderBys": []
+          }
+        ],
+        "stateExpect": {
+          "activeTargets": {
+            "2": {
+              "query": {
+                "path": "collection/key",
+                "filters": [],
+                "orderBys": []
+              },
+              "resumeToken": ""
+            }
+          }
+        }
+      },
+      {
+        "userSet": [
+          "collection/key",
+          {
+            "foo": "bar"
+          }
+        ],
+        "expect": [
+          {
+            "query": {
+              "path": "collection/key",
+              "filters": [],
+              "orderBys": []
+            },
+            "added": [
+              {
+                "key": "collection/key",
+                "version": 0,
+                "value": {
+                  "foo": "bar"
+                },
+                "options": {
+                  "hasLocalMutations": true,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": true,
+            "hasPendingWrites": true
+          }
+        ]
+      },
+      {
+        "failWrite": {
+          "error": {
+            "code": 10
+          },
+          "keepInQueue": true
+        }
+      },
+      {
+        "writeAck": {
+          "version": 1000
+        },
+        "stateExpect": {
+          "userCallbacks": {
+            "acknowledgedDocs": [
+              "collection/key"
+            ],
+            "rejectedDocs": []
+          }
+        }
+      },
+      {
+        "watchAck": [
+          2
+        ]
+      },
+      {
+        "watchEntity": {
+          "docs": [
+            {
+              "key": "collection/key",
+              "version": 1000,
+              "value": {
+                "foo": "bar"
+              },
+              "options": {
+                "hasLocalMutations": false,
+                "hasCommittedMutations": false
+              }
+            }
+          ],
+          "targets": [
+            2
+          ]
+        }
+      },
+      {
+        "watchCurrent": [
+          [
+            2
+          ],
+          "resume-token-1000"
+        ]
+      },
+      {
+        "watchSnapshot": {
+          "version": 1000,
+          "targetIds": []
+        },
+        "expect": [
+          {
+            "query": {
+              "path": "collection/key",
+              "filters": [],
+              "orderBys": []
+            },
+            "metadata": [
+              {
+                "key": "collection/key",
+                "version": 1000,
+                "value": {
+                  "foo": "bar"
+                },
+                "options": {
+                  "hasLocalMutations": false,
+                  "hasCommittedMutations": false
+                }
+              }
+            ],
+            "errorCode": 0,
+            "fromCache": false,
+            "hasPendingWrites": false
+          }
+        ]
       }
     ]
   },

--- a/Firestore/Source/Remote/FSTDatastore.h
+++ b/Firestore/Source/Remote/FSTDatastore.h
@@ -76,7 +76,25 @@ NS_ASSUME_NONNULL_BEGIN
 /** Returns YES if the given error is a GRPC ABORTED error. **/
 + (BOOL)isAbortedError:(NSError *)error;
 
-/** Returns YES if the given error indicates the RPC associated with it may not be retried. */
+/**
+ * Determines whether an error code represents a permanent error when received in response to a
+ * non-write operation.
+ *
+ * See +isPermanentWriteError for classifying write errors.
+ */
++ (BOOL)isPermanentError:(NSError *)error;
+
+/**
+ * Determines whether an error code represents a permanent error when received in response to a
+ * write operation.
+ *
+ * Write operations must be handled specially because as of b/119437764, ABORTED errors on the write
+ * stream should be retried too (even though ABORTED errors are not generally retryable).
+ *
+ * Note that during the initial handshake on the write stream an ABORTED error signals that we
+ * should discard our stream token (i.e. it is permanent). This means a handshake error should be
+ * classified with isPermanentError, above.
+ */
 + (BOOL)isPermanentWriteError:(NSError *)error;
 
 /** Looks up a list of documents in datastore. */

--- a/Firestore/Source/Remote/FSTDatastore.mm
+++ b/Firestore/Source/Remote/FSTDatastore.mm
@@ -144,9 +144,9 @@ NSString *const kGRPCErrorDomain = @"io.grpc";
   return error.code == FIRFirestoreErrorCodeAborted;
 }
 
-+ (BOOL)isPermanentWriteError:(NSError *)error {
++ (BOOL)isPermanentError:(NSError *)error {
   HARD_ASSERT([error.domain isEqualToString:FIRFirestoreErrorDomain],
-              "isPerminanteWriteError: only works with errors emitted by FSTDatastore.");
+              "isPermanentError: only works with errors emitted by FSTDatastore.");
   switch (error.code) {
     case FIRFirestoreErrorCodeCancelled:
     case FIRFirestoreErrorCodeUnknown:
@@ -154,8 +154,8 @@ NSString *const kGRPCErrorDomain = @"io.grpc";
     case FIRFirestoreErrorCodeResourceExhausted:
     case FIRFirestoreErrorCodeInternal:
     case FIRFirestoreErrorCodeUnavailable:
-    // Unauthenticated means something went wrong with our token and we need to retry with new
-    // credentials which will happen automatically.
+      // Unauthenticated means something went wrong with our token and we need to retry with new
+      // credentials which will happen automatically.
     case FIRFirestoreErrorCodeUnauthenticated:
       return NO;
     case FIRFirestoreErrorCodeInvalidArgument:
@@ -164,9 +164,9 @@ NSString *const kGRPCErrorDomain = @"io.grpc";
     case FIRFirestoreErrorCodePermissionDenied:
     case FIRFirestoreErrorCodeFailedPrecondition:
     case FIRFirestoreErrorCodeAborted:
-    // Aborted might be retried in some scenarios, but that is dependant on
-    // the context and should handled individually by the calling code.
-    // See https://cloud.google.com/apis/design/errors
+      // Aborted might be retried in some scenarios, but that is dependant on
+      // the context and should handled individually by the calling code.
+      // See https://cloud.google.com/apis/design/errors
     case FIRFirestoreErrorCodeOutOfRange:
     case FIRFirestoreErrorCodeUnimplemented:
     case FIRFirestoreErrorCodeDataLoss:
@@ -174,6 +174,10 @@ NSString *const kGRPCErrorDomain = @"io.grpc";
     default:
       return YES;
   }
+}
+
++ (BOOL)isPermanentWriteError:(NSError *)error {
+  return [self isPermanentError:error] && error.code != FIRFirestoreErrorCodeAborted;
 }
 
 - (void)commitMutations:(NSArray<FSTMutation *> *)mutations


### PR DESCRIPTION
This corresponds to a server-side change that will be released for the v1 protocol only (see b/119437764).

This is a port of firebase/firebase-js-sdk#1456.