### PR TITLE
Include a trailing /documents on root resource paths

### DIFF
--- a/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.mm
+++ b/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.mm
@@ -533,7 +533,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQueryData *model = [self queryDataForQuery:q];
 
   GCFSTarget *expected = [GCFSTarget message];
-  expected.query.parent = @"projects/p/databases/d";
+  expected.query.parent = @"projects/p/databases/d/documents";
   GCFSStructuredQuery_CollectionSelector *from = [GCFSStructuredQuery_CollectionSelector message];
   from.collectionId = @"messages";
   [expected.query.structuredQuery.fromArray addObject:from];
@@ -565,7 +565,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQueryData *model = [self queryDataForQuery:q];
 
   GCFSTarget *expected = [GCFSTarget message];
-  expected.query.parent = @"projects/p/databases/d";
+  expected.query.parent = @"projects/p/databases/d/documents";
   GCFSStructuredQuery_CollectionSelector *from = [GCFSStructuredQuery_CollectionSelector message];
   from.collectionId = @"docs";
   [expected.query.structuredQuery.fromArray addObject:from];
@@ -646,7 +646,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQueryData *model = [self queryDataForQuery:q];
 
   GCFSTarget *expected = [GCFSTarget message];
-  expected.query.parent = @"projects/p/databases/d";
+  expected.query.parent = @"projects/p/databases/d/documents";
   GCFSStructuredQuery_CollectionSelector *from = [GCFSStructuredQuery_CollectionSelector message];
   from.collectionId = @"docs";
   [expected.query.structuredQuery.fromArray addObject:from];
@@ -668,7 +668,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQueryData *model = [self queryDataForQuery:q];
 
   GCFSTarget *expected = [GCFSTarget message];
-  expected.query.parent = @"projects/p/databases/d";
+  expected.query.parent = @"projects/p/databases/d/documents";
   GCFSStructuredQuery_CollectionSelector *from = [GCFSStructuredQuery_CollectionSelector message];
   from.collectionId = @"docs";
   [expected.query.structuredQuery.fromArray addObject:from];
@@ -706,7 +706,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQueryData *model = [self queryDataForQuery:q];
 
   GCFSTarget *expected = [GCFSTarget message];
-  expected.query.parent = @"projects/p/databases/d";
+  expected.query.parent = @"projects/p/databases/d/documents";
   GCFSStructuredQuery_CollectionSelector *from = [GCFSStructuredQuery_CollectionSelector message];
   from.collectionId = @"docs";
   [expected.query.structuredQuery.fromArray addObject:from];
@@ -728,7 +728,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                 resumeToken:FSTTestData(1, 2, 3, -1)];
 
   GCFSTarget *expected = [GCFSTarget message];
-  expected.query.parent = @"projects/p/databases/d";
+  expected.query.parent = @"projects/p/databases/d/documents";
   GCFSStructuredQuery_CollectionSelector *from = [GCFSStructuredQuery_CollectionSelector message];
   from.collectionId = @"docs";
   [expected.query.structuredQuery.fromArray addObject:from];

--- a/Firestore/Source/Remote/FSTSerializerBeta.mm
+++ b/Firestore/Source/Remote/FSTSerializerBeta.mm
@@ -152,16 +152,15 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSString *)encodedQueryPath:(const ResourcePath &)path {
-  if (path.size() == 0) {
-    // If the path is empty, the backend requires we leave off the /documents at the end.
-    return [self encodedDatabaseID];
-  }
   return [self encodedResourcePathForDatabaseID:self.databaseID path:path];
 }
 
 - (ResourcePath)decodedQueryPath:(NSString *)name {
   const ResourcePath resource = [self decodedResourcePathWithDatabaseID:name];
   if (resource.size() == 4) {
+    // In v1beta1 queries for collections at the root did not have a trailing "/documents". In v1
+    // all resource paths contain "/documents". Preserve the ability to read the v1beta1 form for
+    // compatibility with queries persisted in the local query cache.
     return ResourcePath{};
   } else {
     return [self localResourcePathForQualifiedResourcePath:resource];

--- a/Firestore/core/src/firebase/firestore/remote/serializer.cc
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.cc
@@ -538,8 +538,10 @@ google_firestore_v1_Target_QueryTarget Serializer::EncodeQueryTarget(
 ResourcePath DecodeQueryPath(Reader* reader, absl::string_view name) {
   ResourcePath resource = DecodeResourceName(reader, name);
   if (resource.size() == 4) {
-    // Path missing the trailing documents path segment, indicating an empty
-    // path.
+    // In v1beta1 queries for collections at the root did not have a trailing
+    // "/documents". In v1 all resource paths contain "/documents". Preserve the
+    // ability to read the v1beta1 form for compatibility with queries persisted
+    // in the local query cache.
     return ResourcePath::Empty();
   } else {
     return ExtractLocalPathFromResourceName(reader, resource);
@@ -581,11 +583,6 @@ Query Serializer::DecodeQueryTarget(
 }
 
 std::string Serializer::EncodeQueryPath(const ResourcePath& path) const {
-  if (path.empty()) {
-    // If the path is empty, the backend requires we leave off the /documents at
-    // the end.
-    return database_name_;
-  }
   return EncodeResourceName(database_id_, path);
 }
 

--- a/Firestore/core/src/firebase/firestore/remote/serializer.cc
+++ b/Firestore/core/src/firebase/firestore/remote/serializer.cc
@@ -141,7 +141,7 @@ google_firestore_v1_MapValue EncodeMapValue(
 
   size_t count = object_value_map.size();
 
-  result.fields_count = count;
+  result.fields_count = static_cast<pb_size_t>(count);
   result.fields = MakeArray<google_firestore_v1_MapValue_FieldsEntry>(count);
 
   int i = 0;
@@ -406,7 +406,7 @@ google_firestore_v1_Document Serializer::EncodeDocument(
 
   // Encode Document.fields (unless it's empty)
   size_t count = object_value.internal_value.size();
-  result.fields_count = count;
+  result.fields_count = static_cast<pb_size_t>(count);
   result.fields = MakeArray<google_firestore_v1_Document_FieldsEntry>(count);
   int i = 0;
   for (const auto& kv : object_value.internal_value) {
@@ -512,7 +512,7 @@ google_firestore_v1_Target_QueryTarget Serializer::EncodeQueryTarget(
 
   if (!collection_id.empty()) {
     size_t count = 1;
-    result.structured_query.from_count = count;
+    result.structured_query.from_count = static_cast<pb_size_t>(count);
     result.structured_query.from =
         MakeArray<google_firestore_v1_StructuredQuery_CollectionSelector>(
             count);


### PR DESCRIPTION
This is required for v1 and accepted in v1beta1.

Port of https://github.com/firebase/firebase-js-sdk/pull/1473/commits/4cec9b1c8ca852aeaa0207b12561bd7563eab1fb.