### PR TITLE
Update FirebaseCore deps to 5.2

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -19,7 +19,7 @@ target 'Core_Example_iOS' do
   # The next line is the forcing function for the Firebase pod. The Firebase
   # version's subspecs should depend on the component versions in their
   # corresponding podspec's.
-  pod 'Firebase/CoreOnly', '5.15.0'
+  pod 'Firebase/CoreOnly', '5.15.990'
 
   target 'Core_Tests_iOS' do
     inherit! :search_paths

--- a/Firebase/Core/FIROptions.m
+++ b/Firebase/Core/FIROptions.m
@@ -41,8 +41,8 @@ NSString *const kFIRIsSignInEnabled = @"IS_SIGNIN_ENABLED";
 
 // Library version ID.
 NSString *const kFIRLibraryVersionID = @"5"     // Major version (one or more digits)
-                                       @"01"    // Minor version (exactly 2 digits)
-                                       @"10"    // Build number (exactly 2 digits)
+                                       @"02"    // Minor version (exactly 2 digits)
+                                       @"00"    // Build number (exactly 2 digits)
                                        @"000";  // Fixed "000"
 // Plist file name.
 NSString *const kServiceInfoFileName = @"GoogleService-Info";

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -63,7 +63,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
   s.framework = 'Security'
   s.ios.framework = 'SafariServices'
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
-  s.dependency 'FirebaseCore', '~> 5.1'
+  s.dependency 'FirebaseCore', '~> 5.2'
   s.dependency 'GoogleUtilities/Environment', '~> 5.2'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
 end

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCore'
-  s.version          = '5.1.10'
+  s.version          = '5.2.0'
   s.summary          = 'Firebase Core for iOS (plus community support for macOS and tvOS)'
 
   s.description      = <<-DESC

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -33,7 +33,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.frameworks = 'CFNetwork', 'Security', 'SystemConfiguration'
   s.dependency 'leveldb-library', '~> 1.18'
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
-  s.dependency 'FirebaseCore', '~> 5.1'
+  s.dependency 'FirebaseCore', '~> 5.2'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'GCC_PREPROCESSOR_DEFINITIONS' =>

--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -26,7 +26,7 @@ Firebase Dynamic Links are deep links that enhance user experience and increase 
   s.public_header_files = 'Firebase/DynamicLinks/Public/*.h'
   s.frameworks = 'AssetsLibrary', 'MessageUI', 'QuartzCore'
   s.weak_framework = 'WebKit'
-  s.dependency 'FirebaseCore', '~> 5.1'
+  s.dependency 'FirebaseCore', '~> 5.2'
   s.ios.dependency 'FirebaseAnalytics', '~> 5.1'
   s.dependency 'FirebaseAnalyticsInterop', '~> 1.0'
 

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -53,7 +53,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.resource_bundles = { 'gRPCCertificates-Firestore' => ['Firestore/etc/roots.pem'] }
 
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
-  s.dependency 'FirebaseCore', '~> 5.1'
+  s.dependency 'FirebaseCore', '~> 5.2'
   s.dependency 'gRPC-C++', '0.0.5'
   s.dependency 'leveldb-library', '~> 1.20'
   s.dependency 'Protobuf', '~> 3.1'

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -25,7 +25,7 @@ iOS SDK for Cloud Functions for Firebase.
   s.public_header_files = 'Functions/FirebaseFunctions/Public/*.h'
 
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
-  s.dependency 'FirebaseCore', '~> 5.1'
+  s.dependency 'FirebaseCore', '~> 5.2'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
 
   s.pod_target_xcconfig = {

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -38,7 +38,7 @@ device, and it is completely free.
   }
   s.framework = 'SystemConfiguration'
   s.dependency 'FirebaseAnalyticsInterop', '~> 1.1'
-  s.dependency 'FirebaseCore', '~> 5.1'
+  s.dependency 'FirebaseCore', '~> 5.2'
   s.dependency 'FirebaseInstanceID', '~> 3.4'
   s.dependency 'GoogleUtilities/Reachability', '~> 5.2'
   s.dependency 'GoogleUtilities/Environment', '~> 5.2'

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -30,7 +30,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   s.osx.framework = 'CoreServices'
 
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
-  s.dependency 'FirebaseCore', '~> 5.1'
+  s.dependency 'FirebaseCore', '~> 5.2'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -1,6 +1,10 @@
-# Uncomment the next two lines for pre-release testing
+# Uncomment the next two lines for pre-release testing on internal repo
 #source 'sso://cpdc-internal/firebase'
 #source 'https://github.com/CocoaPods/Specs.git'
+
+# Uncomment the next two lines for pre-release testing on public repo
+source 'https://github.com/Firebase/SpecsStaging.git'
+source 'https://github.com/CocoaPods/Specs.git'
 
 use_frameworks!
 

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -10,7 +10,7 @@ target 'Firestore_Example_iOS' do
   # The next line is the forcing function for the Firebase pod. The Firebase
   # version's subspecs should depend on the component versions in their
   # corresponding podspec's.
-  pod 'Firebase/CoreOnly', '5.15.0'
+  pod 'Firebase/CoreOnly', '5.15.990'
 
   pod 'FirebaseAuth', :path => '../../'
   pod 'FirebaseAuthInterop', :path => '../../'


### PR DESCRIPTION
Note that 5.15.990 is a test only version of the Firebase pod temporarily deployed in https://github.com/firebase/SpecsStaging and intended to be used for development CI until 5.16.0 is public.