### PR TITLE
Port subset of Mutations

### DIFF
--- a/Firestore/core/src/firebase/firestore/model/mutation.cc
+++ b/Firestore/core/src/firebase/firestore/model/mutation.cc
@@ -55,8 +55,8 @@ SetMutation::SetMutation(DocumentKey&& key,
       value_(std::move(value)) {
 }
 
-std::shared_ptr<const MaybeDocument> SetMutation::ApplyToRemoteDocument(
-    const std::shared_ptr<const MaybeDocument>& maybe_doc,
+MaybeDocumentPtr SetMutation::ApplyToRemoteDocument(
+    const MaybeDocumentPtr& maybe_doc,
     const MutationResult& mutation_result) const {
   VerifyKeyMatches(maybe_doc.get());
 
@@ -71,8 +71,8 @@ std::shared_ptr<const MaybeDocument> SetMutation::ApplyToRemoteDocument(
                                      DocumentState::kCommittedMutations);
 }
 
-std::shared_ptr<const MaybeDocument> SetMutation::ApplyToLocalView(
-    const std::shared_ptr<const MaybeDocument>& maybe_doc,
+MaybeDocumentPtr SetMutation::ApplyToLocalView(
+    const MaybeDocumentPtr& maybe_doc,
     const MaybeDocument*,
     const Timestamp&) const {
   VerifyKeyMatches(maybe_doc.get());
@@ -95,8 +95,8 @@ PatchMutation::PatchMutation(DocumentKey&& key,
       mask_(std::move(mask)) {
 }
 
-std::shared_ptr<const MaybeDocument> PatchMutation::ApplyToRemoteDocument(
-    const std::shared_ptr<const MaybeDocument>& maybe_doc,
+MaybeDocumentPtr PatchMutation::ApplyToRemoteDocument(
+    const MaybeDocumentPtr& maybe_doc,
     const MutationResult& mutation_result) const {
   VerifyKeyMatches(maybe_doc.get());
   HARD_ASSERT(mutation_result.transform_results() == nullptr,
@@ -122,8 +122,8 @@ std::shared_ptr<const MaybeDocument> PatchMutation::ApplyToRemoteDocument(
                                      DocumentState::kCommittedMutations);
 }
 
-std::shared_ptr<const MaybeDocument> PatchMutation::ApplyToLocalView(
-    const std::shared_ptr<const MaybeDocument>& maybe_doc,
+MaybeDocumentPtr PatchMutation::ApplyToLocalView(
+    const MaybeDocumentPtr& maybe_doc,
     const MaybeDocument*,
     const Timestamp&) const {
   VerifyKeyMatches(maybe_doc.get());
@@ -165,15 +165,15 @@ DeleteMutation::DeleteMutation(DocumentKey&& key, Precondition&& precondition)
     : Mutation(std::move(key), std::move(precondition)) {
 }
 
-std::shared_ptr<const MaybeDocument> DeleteMutation::ApplyToRemoteDocument(
-    const std::shared_ptr<const MaybeDocument>& /*maybe_doc*/,
+MaybeDocumentPtr DeleteMutation::ApplyToRemoteDocument(
+    const MaybeDocumentPtr& /*maybe_doc*/,
     const MutationResult& /*mutation_result*/) const {
   // TODO(rsgowman): Implement.
   abort();
 }
 
-std::shared_ptr<const MaybeDocument> DeleteMutation::ApplyToLocalView(
-    const std::shared_ptr<const MaybeDocument>& maybe_doc,
+MaybeDocumentPtr DeleteMutation::ApplyToLocalView(
+    const MaybeDocumentPtr& maybe_doc,
     const MaybeDocument*,
     const Timestamp&) const {
   VerifyKeyMatches(maybe_doc.get());

--- a/Firestore/core/src/firebase/firestore/model/mutation.cc
+++ b/Firestore/core/src/firebase/firestore/model/mutation.cc
@@ -20,6 +20,7 @@
 
 #include "Firestore/core/src/firebase/firestore/model/document.h"
 #include "Firestore/core/src/firebase/firestore/model/field_path.h"
+#include "Firestore/core/src/firebase/firestore/model/no_document.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 
 namespace firebase {
@@ -157,6 +158,31 @@ FieldValue PatchMutation::PatchObject(FieldValue obj) const {
     }
   }
   return obj;
+}
+
+DeleteMutation::DeleteMutation(DocumentKey&& key, Precondition&& precondition)
+    : Mutation(std::move(key), std::move(precondition)) {
+}
+
+std::shared_ptr<const MaybeDocument> DeleteMutation::ApplyToRemoteDocument(
+    const std::shared_ptr<const MaybeDocument>& /*maybe_doc*/,
+    const MutationResult& /*mutation_result*/) const {
+  // TODO(rsgowman): Implement.
+  abort();
+}
+
+std::shared_ptr<const MaybeDocument> DeleteMutation::ApplyToLocalView(
+    const std::shared_ptr<const MaybeDocument>& maybe_doc,
+    const MaybeDocument*,
+    const Timestamp&) const {
+  VerifyKeyMatches(maybe_doc.get());
+
+  if (!precondition().IsValidFor(maybe_doc.get())) {
+    return maybe_doc;
+  }
+
+  return absl::make_unique<NoDocument>(key(), SnapshotVersion::None(),
+                                       /*hasCommittedMutations=*/false);
 }
 
 }  // namespace model

--- a/Firestore/core/src/firebase/firestore/model/mutation.cc
+++ b/Firestore/core/src/firebase/firestore/model/mutation.cc
@@ -16,6 +16,7 @@
 
 #include "Firestore/core/src/firebase/firestore/model/mutation.h"
 
+#include <cstdlib>
 #include <utility>
 
 #include "Firestore/core/src/firebase/firestore/model/document.h"

--- a/Firestore/core/src/firebase/firestore/model/mutation.h
+++ b/Firestore/core/src/firebase/firestore/model/mutation.h
@@ -18,8 +18,8 @@
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_MODEL_MUTATION_H_
 
 #include <memory>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/field_mask.h"

--- a/Firestore/core/src/firebase/firestore/model/mutation.h
+++ b/Firestore/core/src/firebase/firestore/model/mutation.h
@@ -18,6 +18,8 @@
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_MODEL_MUTATION_H_
 
 #include <memory>
+#include <vector>
+#include <utility>
 
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/field_mask.h"
@@ -29,6 +31,54 @@
 namespace firebase {
 namespace firestore {
 namespace model {
+
+/**
+ * The result of applying a mutation to the server. This is a model of the
+ * WriteResult proto message.
+ *
+ * Note that MutationResult does not name which document was mutated. The
+ * association is implied positionally: for each entry in the array of
+ * Mutations, there's a corresponding entry in the array of MutationResults.
+ */
+class MutationResult {
+ public:
+  MutationResult(
+      SnapshotVersion&& version,
+      const std::shared_ptr<const std::vector<FieldValue>>& transform_results)
+      : version_(std::move(version)),
+        transform_results_(std::move(transform_results)) {
+  }
+
+  /**
+   * The version at which the mutation was committed.
+   *
+   * - For most operations, this is the update_time in the WriteResult.
+   * - For deletes, it is the commit_time of the WriteResponse (because
+   *   deletes are not stored and have no update_time).
+   *
+   * Note that these versions can be different: No-op writes will not change
+   * the update_time even though the commit_time advances.
+   */
+  const SnapshotVersion& version() const {
+    return version_;
+  }
+
+  /**
+   * The resulting fields returned from the backend after a TransformMutation
+   * has been committed.  Contains one FieldValue for each FieldTransform
+   * that was in the mutation.
+   *
+   * Will be null if the mutation was not a TransformMutation.
+   */
+  const std::shared_ptr<const std::vector<FieldValue>>& transform_results()
+      const {
+    return transform_results_;
+  }
+
+ private:
+  const SnapshotVersion version_;
+  const std::shared_ptr<const std::vector<FieldValue>> transform_results_;
+};
 
 /**
  * Represents a Mutation of a document. Different subclasses of Mutation will
@@ -85,7 +135,24 @@ class Mutation {
     return precondition_;
   }
 
-  // TODO(rsgowman): ApplyToRemoteDocument()
+  /**
+   * Applies this mutation to the given MaybeDocument for the purposes of
+   * computing a new remote document. If the input document doesn't match the
+   * expected state (e.g. it is null or outdated), an `UnknownDocument` can be
+   * returned.
+   *
+   * @param maybe_doc The document to mutate. The input document can be nullptr
+   *     if the client has no knowledge of the pre-mutation state of the
+   *     document.
+   * @param mutation_result The result of applying the mutation from the
+   *     backend.
+   * @return The mutated document. The returned document may be an
+   *     UnknownDocument if the mutation could not be applied to the locally
+   *     cached base document.
+   */
+  virtual std::shared_ptr<const MaybeDocument> ApplyToRemoteDocument(
+      const std::shared_ptr<const MaybeDocument>& maybe_doc,
+      const MutationResult& mutation_result) const = 0;
 
   /**
    * Applies this mutation to the given MaybeDocument for the purposes of
@@ -131,7 +198,9 @@ class SetMutation : public Mutation {
               FieldValue&& value,
               Precondition&& precondition);
 
-  // TODO(rsgowman): ApplyToRemoteDocument()
+  std::shared_ptr<const MaybeDocument> ApplyToRemoteDocument(
+      const std::shared_ptr<const MaybeDocument>& maybe_doc,
+      const MutationResult& mutation_result) const override;
 
   std::shared_ptr<const MaybeDocument> ApplyToLocalView(
       const std::shared_ptr<const MaybeDocument>& maybe_doc,
@@ -162,7 +231,9 @@ class PatchMutation : public Mutation {
                 FieldMask&& mask,
                 Precondition&& precondition);
 
-  // TODO(rsgowman): ApplyToRemoteDocument()
+  std::shared_ptr<const MaybeDocument> ApplyToRemoteDocument(
+      const std::shared_ptr<const MaybeDocument>& maybe_doc,
+      const MutationResult& mutation_result) const override;
 
   std::shared_ptr<const MaybeDocument> ApplyToLocalView(
       const std::shared_ptr<const MaybeDocument>& maybe_doc,

--- a/Firestore/core/src/firebase/firestore/model/mutation.h
+++ b/Firestore/core/src/firebase/firestore/model/mutation.h
@@ -32,6 +32,8 @@ namespace firebase {
 namespace firestore {
 namespace model {
 
+using MaybeDocumentPtr = std::shared_ptr<const MaybeDocument>;
+
 /**
  * The result of applying a mutation to the server. This is a model of the
  * WriteResult proto message.
@@ -150,8 +152,8 @@ class Mutation {
    *     UnknownDocument if the mutation could not be applied to the locally
    *     cached base document.
    */
-  virtual std::shared_ptr<const MaybeDocument> ApplyToRemoteDocument(
-      const std::shared_ptr<const MaybeDocument>& maybe_doc,
+  virtual MaybeDocumentPtr ApplyToRemoteDocument(
+      const MaybeDocumentPtr& maybe_doc,
       const MutationResult& mutation_result) const = 0;
 
   /**
@@ -171,8 +173,8 @@ class Mutation {
    *     only if maybe_doc was nullptr and the mutation would not create a new
    *     document.
    */
-  virtual std::shared_ptr<const MaybeDocument> ApplyToLocalView(
-      const std::shared_ptr<const MaybeDocument>& maybe_doc,
+  virtual MaybeDocumentPtr ApplyToLocalView(
+      const MaybeDocumentPtr& maybe_doc,
       const MaybeDocument* base_doc,
       const Timestamp& local_write_time) const = 0;
 
@@ -198,12 +200,12 @@ class SetMutation : public Mutation {
               FieldValue&& value,
               Precondition&& precondition);
 
-  std::shared_ptr<const MaybeDocument> ApplyToRemoteDocument(
-      const std::shared_ptr<const MaybeDocument>& maybe_doc,
+  MaybeDocumentPtr ApplyToRemoteDocument(
+      const MaybeDocumentPtr& maybe_doc,
       const MutationResult& mutation_result) const override;
 
-  std::shared_ptr<const MaybeDocument> ApplyToLocalView(
-      const std::shared_ptr<const MaybeDocument>& maybe_doc,
+  MaybeDocumentPtr ApplyToLocalView(
+      const MaybeDocumentPtr& maybe_doc,
       const MaybeDocument* base_doc,
       const Timestamp& local_write_time) const override;
 
@@ -231,12 +233,12 @@ class PatchMutation : public Mutation {
                 FieldMask&& mask,
                 Precondition&& precondition);
 
-  std::shared_ptr<const MaybeDocument> ApplyToRemoteDocument(
-      const std::shared_ptr<const MaybeDocument>& maybe_doc,
+  MaybeDocumentPtr ApplyToRemoteDocument(
+      const MaybeDocumentPtr& maybe_doc,
       const MutationResult& mutation_result) const override;
 
-  std::shared_ptr<const MaybeDocument> ApplyToLocalView(
-      const std::shared_ptr<const MaybeDocument>& maybe_doc,
+  MaybeDocumentPtr ApplyToLocalView(
+      const MaybeDocumentPtr& maybe_doc,
       const MaybeDocument* base_doc,
       const Timestamp& local_write_time) const override;
 
@@ -253,12 +255,12 @@ class DeleteMutation : public Mutation {
  public:
   DeleteMutation(DocumentKey&& key, Precondition&& precondition);
 
-  std::shared_ptr<const MaybeDocument> ApplyToRemoteDocument(
-      const std::shared_ptr<const MaybeDocument>& maybe_doc,
+  MaybeDocumentPtr ApplyToRemoteDocument(
+      const MaybeDocumentPtr& maybe_doc,
       const MutationResult& mutation_result) const override;
 
-  std::shared_ptr<const MaybeDocument> ApplyToLocalView(
-      const std::shared_ptr<const MaybeDocument>& maybe_doc,
+  MaybeDocumentPtr ApplyToLocalView(
+      const MaybeDocumentPtr& maybe_doc,
       const MaybeDocument* base_doc,
       const Timestamp& local_write_time) const override;
 };

--- a/Firestore/core/src/firebase/firestore/model/mutation.h
+++ b/Firestore/core/src/firebase/firestore/model/mutation.h
@@ -248,6 +248,21 @@ class PatchMutation : public Mutation {
   const FieldMask mask_;
 };
 
+/** Represents a Delete operation. */
+class DeleteMutation : public Mutation {
+ public:
+  DeleteMutation(DocumentKey&& key, Precondition&& precondition);
+
+  std::shared_ptr<const MaybeDocument> ApplyToRemoteDocument(
+      const std::shared_ptr<const MaybeDocument>& maybe_doc,
+      const MutationResult& mutation_result) const override;
+
+  std::shared_ptr<const MaybeDocument> ApplyToLocalView(
+      const std::shared_ptr<const MaybeDocument>& maybe_doc,
+      const MaybeDocument* base_doc,
+      const Timestamp& local_write_time) const override;
+};
+
 }  // namespace model
 }  // namespace firestore
 }  // namespace firebase

--- a/Firestore/core/test/firebase/firestore/model/mutation_test.cc
+++ b/Firestore/core/test/firebase/firestore/model/mutation_test.cc
@@ -30,6 +30,7 @@ namespace model {
 using testutil::DeletedDoc;
 using testutil::Doc;
 using testutil::Field;
+using testutil::MutationResult;
 using testutil::PatchMutation;
 using testutil::SetMutation;
 
@@ -224,7 +225,18 @@ TEST(Mutation, DeleteDeletes) {
 }
 
 TEST(Mutation, SetWithMutationResult) {
-  // TODO(rsgowman)
+  auto base_doc = std::make_shared<Document>(
+      Doc("collection/key", 0, {{"foo", FieldValue::FromString("bar")}}));
+
+  std::unique_ptr<Mutation> set = SetMutation(
+      "collection/key", {{"foo", FieldValue::FromString("new-bar")}});
+  std::shared_ptr<const MaybeDocument> set_doc =
+      set->ApplyToRemoteDocument(base_doc, MutationResult(4));
+
+  ASSERT_TRUE(set_doc);
+  EXPECT_EQ(*set_doc.get(), Doc("collection/key", 4,
+                                {{"foo", FieldValue::FromString("new-bar")}},
+                                DocumentState::kCommittedMutations));
 }
 
 TEST(Mutation, PatchWithMutationResult) {

--- a/Firestore/core/test/firebase/firestore/model/mutation_test.cc
+++ b/Firestore/core/test/firebase/firestore/model/mutation_test.cc
@@ -146,6 +146,95 @@ TEST(Mutation, PatchesPrimitiveValue) {
           DocumentState::kLocalMutations));
 }
 
+TEST(Mutation, PatchingDeletedDocumentsDoesNothing) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, AppliesLocalServerTimestampTransformsToDocuments) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, CreatesArrayUnionTransform) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, AppliesLocalArrayUnionTransformToMissingField) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, AppliesLocalArrayUnionTransformToNonArrayField) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, AppliesLocalArrayUnionTransformWithNonExistingElements) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, AppliesLocalArrayUnionTransformWithExistingElements) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, AppliesLocalArrayUnionTransformWithDuplicateExistingElements) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, AppliesLocalArrayUnionTransformWithDuplicateUnionElements) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, AppliesLocalArrayUnionTransformWithNonPrimitiveElements) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation,
+     AppliesLocalArrayUnionTransformWithPartiallyOverlappingElements) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, AppliesLocalArrayRemoveTransformToMissingField) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, AppliesLocalArrayRemoveTransformToNonArrayField) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, AppliesLocalArrayRemoveTransformWithNonExistingElements) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, AppliesLocalArrayRemoveTransformWithExistingElements) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, AppliesLocalArrayRemoveTransformWithNonPrimitiveElements) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, AppliesServerAckedServerTimestampTransformsToDocuments) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, AppliesServerAckedArrayTransformsToDocuments) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, DeleteDeletes) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, SetWithMutationResult) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, PatchWithMutationResult) {
+  // TODO(rsgowman)
+}
+
+TEST(Mutation, Transitions) {
+  // TODO(rsgowman)
+}
+
 }  // namespace model
 }  // namespace firestore
 }  // namespace firebase

--- a/Firestore/core/test/firebase/firestore/model/mutation_test.cc
+++ b/Firestore/core/test/firebase/firestore/model/mutation_test.cc
@@ -240,7 +240,18 @@ TEST(Mutation, SetWithMutationResult) {
 }
 
 TEST(Mutation, PatchWithMutationResult) {
-  // TODO(rsgowman)
+  auto base_doc = std::make_shared<Document>(
+      Doc("collection/key", 0, {{"foo", FieldValue::FromString("bar")}}));
+
+  std::unique_ptr<Mutation> patch = PatchMutation(
+      "collection/key", {{"foo", FieldValue::FromString("new-bar")}});
+  std::shared_ptr<const MaybeDocument> patch_doc =
+      patch->ApplyToRemoteDocument(base_doc, MutationResult(4));
+
+  ASSERT_TRUE(patch_doc);
+  EXPECT_EQ(*patch_doc.get(), Doc("collection/key", 4,
+                                  {{"foo", FieldValue::FromString("new-bar")}},
+                                  DocumentState::kCommittedMutations));
 }
 
 TEST(Mutation, Transitions) {

--- a/Firestore/core/test/firebase/firestore/model/mutation_test.cc
+++ b/Firestore/core/test/firebase/firestore/model/mutation_test.cc
@@ -221,7 +221,15 @@ TEST(Mutation, AppliesServerAckedArrayTransformsToDocuments) {
 }
 
 TEST(Mutation, DeleteDeletes) {
-  // TODO(rsgowman)
+  auto base_doc = std::make_shared<Document>(
+      Doc("collection/key", 0, {{"foo", FieldValue::FromString("bar")}}));
+
+  std::unique_ptr<Mutation> del = testutil::DeleteMutation("collection/key");
+  std::shared_ptr<const MaybeDocument> deleted_doc =
+      del->ApplyToLocalView(base_doc, base_doc.get(), Timestamp::Now());
+
+  ASSERT_TRUE(deleted_doc);
+  EXPECT_EQ(*deleted_doc.get(), testutil::DeletedDoc("collection/key", 0));
 }
 
 TEST(Mutation, SetWithMutationResult) {

--- a/Firestore/core/test/firebase/firestore/model/mutation_test.cc
+++ b/Firestore/core/test/firebase/firestore/model/mutation_test.cc
@@ -42,7 +42,7 @@ TEST(Mutation, AppliesSetsToDocuments) {
 
   std::unique_ptr<Mutation> set = SetMutation(
       "collection/key", {{"bar", FieldValue::FromString("bar-value")}});
-  std::shared_ptr<const MaybeDocument> set_doc =
+  MaybeDocumentPtr set_doc =
       set->ApplyToLocalView(base_doc, base_doc.get(), Timestamp::Now());
   ASSERT_NE(set_doc, nullptr);
   ASSERT_EQ(set_doc->type(), MaybeDocument::Type::Document);
@@ -60,7 +60,7 @@ TEST(Mutation, AppliesPatchToDocuments) {
 
   std::unique_ptr<Mutation> patch = PatchMutation(
       "collection/key", {{"foo.bar", FieldValue::FromString("new-bar-value")}});
-  std::shared_ptr<const MaybeDocument> local =
+  MaybeDocumentPtr local =
       patch->ApplyToLocalView(base_doc, base_doc.get(), Timestamp::Now());
   ASSERT_NE(local, nullptr);
   EXPECT_EQ(
@@ -78,7 +78,7 @@ TEST(Mutation, AppliesPatchWithMergeToDocuments) {
   std::unique_ptr<Mutation> upsert = PatchMutation(
       "collection/key", {{"foo.bar", FieldValue::FromString("new-bar-value")}},
       {Field("foo.bar")});
-  std::shared_ptr<const MaybeDocument> new_doc =
+  MaybeDocumentPtr new_doc =
       upsert->ApplyToLocalView(base_doc, base_doc.get(), Timestamp::Now());
   ASSERT_NE(new_doc, nullptr);
   EXPECT_EQ(
@@ -95,7 +95,7 @@ TEST(Mutation, AppliesPatchToNullDocWithMergeToDocuments) {
   std::unique_ptr<Mutation> upsert = PatchMutation(
       "collection/key", {{"foo.bar", FieldValue::FromString("new-bar-value")}},
       {Field("foo.bar")});
-  std::shared_ptr<const MaybeDocument> new_doc =
+  MaybeDocumentPtr new_doc =
       upsert->ApplyToLocalView(base_doc, base_doc.get(), Timestamp::Now());
   ASSERT_NE(new_doc, nullptr);
   EXPECT_EQ(
@@ -116,7 +116,7 @@ TEST(Mutation, DeletesValuesFromTheFieldMask) {
   std::unique_ptr<Mutation> patch =
       PatchMutation("collection/key", {}, {Field("foo.bar")});
 
-  std::shared_ptr<const MaybeDocument> patch_doc =
+  MaybeDocumentPtr patch_doc =
       patch->ApplyToLocalView(base_doc, base_doc.get(), Timestamp::Now());
   ASSERT_NE(patch_doc, nullptr);
   EXPECT_EQ(*patch_doc.get(),
@@ -135,7 +135,7 @@ TEST(Mutation, PatchesPrimitiveValue) {
   std::unique_ptr<Mutation> patch = PatchMutation(
       "collection/key", {{"foo.bar", FieldValue::FromString("new-bar-value")}});
 
-  std::shared_ptr<const MaybeDocument> patched_doc =
+  MaybeDocumentPtr patched_doc =
       patch->ApplyToLocalView(base_doc, base_doc.get(), Timestamp::Now());
   ASSERT_NE(patched_doc, nullptr);
   EXPECT_EQ(
@@ -225,7 +225,7 @@ TEST(Mutation, DeleteDeletes) {
       Doc("collection/key", 0, {{"foo", FieldValue::FromString("bar")}}));
 
   std::unique_ptr<Mutation> del = testutil::DeleteMutation("collection/key");
-  std::shared_ptr<const MaybeDocument> deleted_doc =
+  MaybeDocumentPtr deleted_doc =
       del->ApplyToLocalView(base_doc, base_doc.get(), Timestamp::Now());
 
   ASSERT_NE(deleted_doc, nullptr);
@@ -238,7 +238,7 @@ TEST(Mutation, SetWithMutationResult) {
 
   std::unique_ptr<Mutation> set = SetMutation(
       "collection/key", {{"foo", FieldValue::FromString("new-bar")}});
-  std::shared_ptr<const MaybeDocument> set_doc =
+  MaybeDocumentPtr set_doc =
       set->ApplyToRemoteDocument(base_doc, MutationResult(4));
 
   ASSERT_NE(set_doc, nullptr);
@@ -253,7 +253,7 @@ TEST(Mutation, PatchWithMutationResult) {
 
   std::unique_ptr<Mutation> patch = PatchMutation(
       "collection/key", {{"foo", FieldValue::FromString("new-bar")}});
-  std::shared_ptr<const MaybeDocument> patch_doc =
+  MaybeDocumentPtr patch_doc =
       patch->ApplyToRemoteDocument(base_doc, MutationResult(4));
 
   ASSERT_NE(patch_doc, nullptr);

--- a/Firestore/core/test/firebase/firestore/model/mutation_test.cc
+++ b/Firestore/core/test/firebase/firestore/model/mutation_test.cc
@@ -44,7 +44,7 @@ TEST(Mutation, AppliesSetsToDocuments) {
       "collection/key", {{"bar", FieldValue::FromString("bar-value")}});
   std::shared_ptr<const MaybeDocument> set_doc =
       set->ApplyToLocalView(base_doc, base_doc.get(), Timestamp::Now());
-  ASSERT_TRUE(set_doc);
+  ASSERT_NE(set_doc, nullptr);
   ASSERT_EQ(set_doc->type(), MaybeDocument::Type::Document);
   EXPECT_EQ(*set_doc.get(), Doc("collection/key", 0,
                                 {{"bar", FieldValue::FromString("bar-value")}},
@@ -62,7 +62,7 @@ TEST(Mutation, AppliesPatchToDocuments) {
       "collection/key", {{"foo.bar", FieldValue::FromString("new-bar-value")}});
   std::shared_ptr<const MaybeDocument> local =
       patch->ApplyToLocalView(base_doc, base_doc.get(), Timestamp::Now());
-  ASSERT_TRUE(local);
+  ASSERT_NE(local, nullptr);
   EXPECT_EQ(
       *local.get(),
       Doc("collection/key", 0,
@@ -80,7 +80,7 @@ TEST(Mutation, AppliesPatchWithMergeToDocuments) {
       {Field("foo.bar")});
   std::shared_ptr<const MaybeDocument> new_doc =
       upsert->ApplyToLocalView(base_doc, base_doc.get(), Timestamp::Now());
-  ASSERT_TRUE(new_doc);
+  ASSERT_NE(new_doc, nullptr);
   EXPECT_EQ(
       *new_doc.get(),
       Doc("collection/key", 0,
@@ -97,7 +97,7 @@ TEST(Mutation, AppliesPatchToNullDocWithMergeToDocuments) {
       {Field("foo.bar")});
   std::shared_ptr<const MaybeDocument> new_doc =
       upsert->ApplyToLocalView(base_doc, base_doc.get(), Timestamp::Now());
-  ASSERT_TRUE(new_doc);
+  ASSERT_NE(new_doc, nullptr);
   EXPECT_EQ(
       *new_doc.get(),
       Doc("collection/key", 0,
@@ -118,7 +118,7 @@ TEST(Mutation, DeletesValuesFromTheFieldMask) {
 
   std::shared_ptr<const MaybeDocument> patch_doc =
       patch->ApplyToLocalView(base_doc, base_doc.get(), Timestamp::Now());
-  ASSERT_TRUE(patch_doc);
+  ASSERT_NE(patch_doc, nullptr);
   EXPECT_EQ(*patch_doc.get(),
             Doc("collection/key", 0,
                 {{"foo", FieldValue::FromMap(
@@ -137,7 +137,7 @@ TEST(Mutation, PatchesPrimitiveValue) {
 
   std::shared_ptr<const MaybeDocument> patched_doc =
       patch->ApplyToLocalView(base_doc, base_doc.get(), Timestamp::Now());
-  ASSERT_TRUE(patched_doc);
+  ASSERT_NE(patched_doc, nullptr);
   EXPECT_EQ(
       *patched_doc.get(),
       Doc("collection/key", 0,
@@ -228,7 +228,7 @@ TEST(Mutation, DeleteDeletes) {
   std::shared_ptr<const MaybeDocument> deleted_doc =
       del->ApplyToLocalView(base_doc, base_doc.get(), Timestamp::Now());
 
-  ASSERT_TRUE(deleted_doc);
+  ASSERT_NE(deleted_doc, nullptr);
   EXPECT_EQ(*deleted_doc.get(), testutil::DeletedDoc("collection/key", 0));
 }
 
@@ -241,7 +241,7 @@ TEST(Mutation, SetWithMutationResult) {
   std::shared_ptr<const MaybeDocument> set_doc =
       set->ApplyToRemoteDocument(base_doc, MutationResult(4));
 
-  ASSERT_TRUE(set_doc);
+  ASSERT_NE(set_doc, nullptr);
   EXPECT_EQ(*set_doc.get(), Doc("collection/key", 4,
                                 {{"foo", FieldValue::FromString("new-bar")}},
                                 DocumentState::kCommittedMutations));
@@ -256,7 +256,7 @@ TEST(Mutation, PatchWithMutationResult) {
   std::shared_ptr<const MaybeDocument> patch_doc =
       patch->ApplyToRemoteDocument(base_doc, MutationResult(4));
 
-  ASSERT_TRUE(patch_doc);
+  ASSERT_NE(patch_doc, nullptr);
   EXPECT_EQ(*patch_doc.get(), Doc("collection/key", 4,
                                   {{"foo", FieldValue::FromString("new-bar")}},
                                   DocumentState::kCommittedMutations));

--- a/Firestore/core/test/firebase/firestore/testutil/testutil.h
+++ b/Firestore/core/test/firebase/firestore/testutil/testutil.h
@@ -152,6 +152,10 @@ inline std::unique_ptr<model::PatchMutation> PatchMutation(
   return PatchMutation(path, values, &update_mask);
 }
 
+inline model::MutationResult MutationResult(int64_t version) {
+  return model::MutationResult(Version(version), nullptr);
+}
+
 inline std::vector<uint8_t> ResumeToken(int64_t snapshot_version) {
   if (snapshot_version == 0) {
     // TODO(rsgowman): The other platforms return null here, though I'm not sure

--- a/Firestore/core/test/firebase/firestore/testutil/testutil.h
+++ b/Firestore/core/test/firebase/firestore/testutil/testutil.h
@@ -152,6 +152,12 @@ inline std::unique_ptr<model::PatchMutation> PatchMutation(
   return PatchMutation(path, values, &update_mask);
 }
 
+inline std::unique_ptr<model::DeleteMutation> DeleteMutation(
+    absl::string_view path) {
+  return absl::make_unique<model::DeleteMutation>(Key(path),
+                                                  model::Precondition::None());
+}
+
 inline model::MutationResult MutationResult(int64_t version) {
   return model::MutationResult(Version(version), nullptr);
 }


### PR DESCRIPTION
To enable completion of local serializer testing. Specifically ported:

SetMutation::ApplyToRemoteDocument()
PatchMutation::ApplyToRemoteDocument()
DeleteMutation::ApplyToLocalView()