### PR TITLE
Reduce size of model::FieldValue

### DIFF
--- a/Firestore/core/src/firebase/firestore/model/field_value.cc
+++ b/Firestore/core/src/firebase/firestore/model/field_value.cc
@@ -468,8 +468,7 @@ void FieldValue::SwitchTo(const Type type) {
     case Type::Object:
       object_value_.~unique_ptr<ObjectValue>();
       break;
-    default: {
-    }  // The other types where there is nothing to worry about.
+    default: {}  // The other types where there is nothing to worry about.
   }
   tag_ = type;
   // Must call constructor explicitly for any non-POD type to initialize.
@@ -507,8 +506,7 @@ void FieldValue::SwitchTo(const Type type) {
       new (&object_value_)
           std::unique_ptr<ObjectValue>(absl::make_unique<ObjectValue>());
       break;
-    default: {
-    }  // The other types where there is nothing to worry about.
+    default: {}  // The other types where there is nothing to worry about.
   }
 }
 

--- a/Firestore/core/src/firebase/firestore/model/field_value.cc
+++ b/Firestore/core/src/firebase/firestore/model/field_value.cc
@@ -97,7 +97,7 @@ FieldValue& FieldValue::operator=(const FieldValue& value) {
       *reference_value_ = *value.reference_value_;
       break;
     case Type::GeoPoint:
-      geo_point_value_ = value.geo_point_value_;
+      *geo_point_value_ = *value.geo_point_value_;
       break;
     case Type::Array: {
       // copy-and-swap
@@ -344,7 +344,7 @@ FieldValue FieldValue::FromReference(DocumentKey&& value,
 FieldValue FieldValue::FromGeoPoint(const GeoPoint& value) {
   FieldValue result;
   result.SwitchTo(Type::GeoPoint);
-  result.geo_point_value_ = value;
+  *result.geo_point_value_ = value;
   return result;
 }
 
@@ -423,7 +423,7 @@ bool operator<(const FieldValue& lhs, const FieldValue& rhs) {
               lhs.reference_value_->reference <
                   rhs.reference_value_->reference);
     case Type::GeoPoint:
-      return lhs.geo_point_value_ < rhs.geo_point_value_;
+      return *lhs.geo_point_value_ < *rhs.geo_point_value_;
     case Type::Array:
       return *lhs.array_value_ < *rhs.array_value_;
     case Type::Object:
@@ -459,7 +459,7 @@ void FieldValue::SwitchTo(const Type type) {
       reference_value_.~unique_ptr<ReferenceValue>();
       break;
     case Type::GeoPoint:
-      geo_point_value_.~GeoPoint();
+      geo_point_value_.~unique_ptr<GeoPoint>();
       break;
     case Type::Array:
       array_value_.~unique_ptr<std::vector<FieldValue>>();
@@ -495,7 +495,8 @@ void FieldValue::SwitchTo(const Type type) {
           std::unique_ptr<ReferenceValue>(absl::make_unique<ReferenceValue>());
       break;
     case Type::GeoPoint:
-      new (&geo_point_value_) GeoPoint();
+      new (&geo_point_value_)
+          std::unique_ptr<GeoPoint>(absl::make_unique<GeoPoint>());
       break;
     case Type::Array:
       new (&array_value_) std::unique_ptr<std::vector<FieldValue>>(

--- a/Firestore/core/src/firebase/firestore/model/field_value.cc
+++ b/Firestore/core/src/firebase/firestore/model/field_value.cc
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cmath>
 #include <memory>
+#include <new>
 #include <utility>
 #include <vector>
 

--- a/Firestore/core/src/firebase/firestore/model/field_value.h
+++ b/Firestore/core/src/firebase/firestore/model/field_value.h
@@ -137,9 +137,9 @@ class FieldValue {
     return string_value_;
   }
 
-  ObjectValue object_value() const {
+  const ObjectValue& object_value() const {
     HARD_ASSERT(tag_ == Type::Object);
-    return ObjectValue{object_value_};
+    return *object_value_;
   }
 
   /**
@@ -221,7 +221,7 @@ class FieldValue {
     firebase::firestore::model::ReferenceValue reference_value_;
     GeoPoint geo_point_value_;
     std::vector<FieldValue> array_value_;
-    ObjectValue object_value_;
+    std::unique_ptr<ObjectValue> object_value_;
   };
 };
 

--- a/Firestore/core/src/firebase/firestore/model/field_value.h
+++ b/Firestore/core/src/firebase/firestore/model/field_value.h
@@ -214,7 +214,7 @@ class FieldValue {
     int64_t integer_value_;
     double double_value_;
     Timestamp timestamp_value_;
-    ServerTimestamp server_timestamp_value_;
+    std::unique_ptr<ServerTimestamp> server_timestamp_value_;
     std::string string_value_;
     std::vector<uint8_t> blob_value_;
     // Qualified name to avoid conflict with the member function of same name.

--- a/Firestore/core/src/firebase/firestore/model/field_value.h
+++ b/Firestore/core/src/firebase/firestore/model/field_value.h
@@ -219,7 +219,7 @@ class FieldValue {
     std::unique_ptr<std::string> string_value_;
     std::unique_ptr<std::vector<uint8_t>> blob_value_;
     std::unique_ptr<ReferenceValue> reference_value_;
-    GeoPoint geo_point_value_;
+    std::unique_ptr<GeoPoint> geo_point_value_;
     std::unique_ptr<std::vector<FieldValue>> array_value_;
     std::unique_ptr<ObjectValue> object_value_;
   };

--- a/Firestore/core/src/firebase/firestore/model/field_value.h
+++ b/Firestore/core/src/firebase/firestore/model/field_value.h
@@ -217,7 +217,7 @@ class FieldValue {
     std::unique_ptr<ServerTimestamp> server_timestamp_value_;
     // TODO(rsgowman): Change unique_ptr<std::string> to nanopb::String?
     std::unique_ptr<std::string> string_value_;
-    std::vector<uint8_t> blob_value_;
+    std::unique_ptr<std::vector<uint8_t>> blob_value_;
     // Qualified name to avoid conflict with the member function of same name.
     firebase::firestore::model::ReferenceValue reference_value_;
     GeoPoint geo_point_value_;

--- a/Firestore/core/src/firebase/firestore/model/field_value.h
+++ b/Firestore/core/src/firebase/firestore/model/field_value.h
@@ -129,7 +129,7 @@ class FieldValue {
 
   Timestamp timestamp_value() const {
     HARD_ASSERT(tag_ == Type::Timestamp);
-    return timestamp_value_;
+    return *timestamp_value_;
   }
 
   const std::string& string_value() const {
@@ -213,7 +213,7 @@ class FieldValue {
     bool boolean_value_;
     int64_t integer_value_;
     double double_value_;
-    Timestamp timestamp_value_;
+    std::unique_ptr<Timestamp> timestamp_value_;
     std::unique_ptr<ServerTimestamp> server_timestamp_value_;
     // TODO(rsgowman): Change unique_ptr<std::string> to nanopb::String?
     std::unique_ptr<std::string> string_value_;

--- a/Firestore/core/src/firebase/firestore/model/field_value.h
+++ b/Firestore/core/src/firebase/firestore/model/field_value.h
@@ -218,8 +218,7 @@ class FieldValue {
     // TODO(rsgowman): Change unique_ptr<std::string> to nanopb::String?
     std::unique_ptr<std::string> string_value_;
     std::unique_ptr<std::vector<uint8_t>> blob_value_;
-    // Qualified name to avoid conflict with the member function of same name.
-    firebase::firestore::model::ReferenceValue reference_value_;
+    std::unique_ptr<ReferenceValue> reference_value_;
     GeoPoint geo_point_value_;
     std::vector<FieldValue> array_value_;
     std::unique_ptr<ObjectValue> object_value_;

--- a/Firestore/core/src/firebase/firestore/model/field_value.h
+++ b/Firestore/core/src/firebase/firestore/model/field_value.h
@@ -134,7 +134,7 @@ class FieldValue {
 
   const std::string& string_value() const {
     HARD_ASSERT(tag_ == Type::String);
-    return string_value_;
+    return *string_value_;
   }
 
   const ObjectValue& object_value() const {
@@ -215,7 +215,8 @@ class FieldValue {
     double double_value_;
     Timestamp timestamp_value_;
     std::unique_ptr<ServerTimestamp> server_timestamp_value_;
-    std::string string_value_;
+    // TODO(rsgowman): Change unique_ptr<std::string> to nanopb::String?
+    std::unique_ptr<std::string> string_value_;
     std::vector<uint8_t> blob_value_;
     // Qualified name to avoid conflict with the member function of same name.
     firebase::firestore::model::ReferenceValue reference_value_;

--- a/Firestore/core/src/firebase/firestore/model/field_value.h
+++ b/Firestore/core/src/firebase/firestore/model/field_value.h
@@ -220,7 +220,7 @@ class FieldValue {
     std::unique_ptr<std::vector<uint8_t>> blob_value_;
     std::unique_ptr<ReferenceValue> reference_value_;
     GeoPoint geo_point_value_;
-    std::vector<FieldValue> array_value_;
+    std::unique_ptr<std::vector<FieldValue>> array_value_;
     std::unique_ptr<ObjectValue> object_value_;
   };
 };

--- a/Firestore/core/test/firebase/firestore/model/field_value_test.cc
+++ b/Firestore/core/test/firebase/firestore/model/field_value_test.cc
@@ -578,7 +578,7 @@ TEST(FieldValue, IsSmallish) {
   // We expect the FV to use 4 bytes to track the type of the union, plus 8
   // bytes for the union contents themselves. The other 4 is for padding. We
   // want to keep FV as small as possible.
-  EXPECT_LE(sizeof(FieldValue), 4 + 4 + 8);
+  EXPECT_LE(sizeof(FieldValue), 2 * sizeof(void*));
 }
 
 }  //  namespace model

--- a/Firestore/core/test/firebase/firestore/model/field_value_test.cc
+++ b/Firestore/core/test/firebase/firestore/model/field_value_test.cc
@@ -574,6 +574,13 @@ TEST(FieldValue, GetNothing) {
   EXPECT_EQ(absl::nullopt, value.Get(testutil::Field("a.a")));
 }
 
+TEST(FieldValue, IsSmallish) {
+  // We expect the FV to use 4 bytes to track the type of the union, plus 8
+  // bytes for the union contents themselves. The other 4 is for padding. We
+  // want to keep FV as small as possible.
+  EXPECT_LE(sizeof(FieldValue), 4 + 4 + 8);
+}
+
 }  //  namespace model
 }  //  namespace firestore
 }  //  namespace firebase


### PR DESCRIPTION
Replaced the following fields within the FieldValue union with (unique) pointers instead:
* object_value_ (48 bytes)
* server_timestamp_value_ (40)
* string_value_ (32)
* blob_value_ (24)
* reference_value_ (24)
* array_value_ (24)
* timestamp_value_ (16)
* geo_point_value_ (16)

sizeof(FieldValue): 56 -> 16 bytes.