### PR TITLE
Enhance the log storage class

### DIFF
--- a/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogStorage.h
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogStorage.h
@@ -47,10 +47,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Removes a set of log fields specified by their filenames.
  *
- * @param logFiles The set of log files to remove.
+ * @param logHashes The set of log files to remove.
  * @param logTarget The log target the log files correspond to.
  */
-- (void)removeLogFiles:(NSSet<NSURL *> *)logFiles logTarget:(NSNumber *)logTarget;
+- (void)removeLogs:(NSSet<NSNumber *> *)logHashes logTarget:(NSNumber *)logTarget;
 
 /** Converts a set of log hashes to a set of log files.
  *

--- a/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogStorage.h
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogStorage.h
@@ -45,6 +45,20 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)removeLog:(NSNumber *)logHash logTarget:(NSNumber *)logTarget;
 
+/** Removes a set of log fields specified by their filenames.
+ *
+ * @param logFiles The set of log files to remove.
+ * @param logTarget The log target the log files correspond to.
+ */
+- (void)removeLogFiles:(NSSet<NSURL *> *)logFiles logTarget:(NSNumber *)logTarget;
+
+/** Converts a set of log hashes to a set of log files.
+ *
+ * @param logHashes A set of log hashes to get the files of.
+ * @return A set of equivalent length, containing all the filenames corresponding to the hashes.
+ */
+- (NSSet<NSURL *> *)logHashesToFiles:(NSSet<NSNumber *> *)logHashes;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogStorage.m
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/GDLLogStorage.m
@@ -125,7 +125,7 @@ static NSString *GDLStoragePath() {
 }
 
 - (void)removeLogs:(NSSet<NSNumber *> *)logHashes logTarget:(NSNumber *)logTarget {
-  dispatch_async(_storageQueue, ^{
+  dispatch_sync(_storageQueue, ^{
     for (NSNumber *logHash in logHashes) {
       [self removeLog:logHash logTarget:logTarget];
     }

--- a/GoogleDataLogger/GoogleDataLogger/Classes/GDLRegistrar.m
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/GDLRegistrar.m
@@ -33,13 +33,13 @@
   self = [super init];
   if (self) {
     _logTargetToPrioritizer = [[NSMutableDictionary alloc] init];
-    _logTargetToBackend = [[NSMutableDictionary alloc] init];
+    _logTargetToUploader = [[NSMutableDictionary alloc] init];
   }
   return self;
 }
 
 - (void)registerBackend:(id<GDLLogUploader>)backend forLogTarget:(GDLLogTarget)logTarget {
-  self.logTargetToBackend[@(logTarget)] = backend;
+  self.logTargetToUploader[@(logTarget)] = backend;
 }
 
 - (void)registerLogPrioritizer:(id<GDLLogPrioritizer>)prioritizer

--- a/GoogleDataLogger/GoogleDataLogger/Classes/GDLUploadCoordinator.h
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/GDLUploadCoordinator.h
@@ -33,8 +33,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Forces the backend specified by the target to upload the provided set of logs. This should only
  * ever happen when the QoS tier of a log requires it.
+ *
+ * @param logHashes The set of log hashes to force upload.
+ * @param logTarget The log target that should force an upload.
  */
-- (void)forceUploadLogs:(NSSet<NSURL *> *)logFiles target:(GDLLogTarget)logTarget;
+- (void)forceUploadLogs:(NSSet<NSNumber *> *)logHashes target:(GDLLogTarget)logTarget;
 
 @end
 

--- a/GoogleDataLogger/GoogleDataLogger/Classes/GDLUploadCoordinator.m
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/GDLUploadCoordinator.m
@@ -29,7 +29,7 @@
   return sharedUploader;
 }
 
-- (void)forceUploadLogs:(NSSet<NSURL *> *)logFiles target:(GDLLogTarget)logTarget {
+- (void)forceUploadLogs:(NSSet<NSNumber *> *)logHashes target:(GDLLogTarget)logTarget {
   // Ask the prioritizer of the target for some logs
 }
 

--- a/GoogleDataLogger/GoogleDataLogger/Classes/Private/GDLLogStorage_Private.h
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/Private/GDLLogStorage_Private.h
@@ -28,7 +28,7 @@
 
 /** A map of logTargets to a set of log hash values. */
 @property(nonatomic)
-    NSMutableDictionary<NSNumber *, NSMutableSet<NSURL *> *> *logTargetToLogFileSet;
+    NSMutableDictionary<NSNumber *, NSMutableSet<NSNumber *> *> *logTargetToLogHashSet;
 
 /** The log uploader instance to use. */
 @property(nonatomic) GDLUploadCoordinator *uploader;

--- a/GoogleDataLogger/GoogleDataLogger/Classes/Private/GDLRegistrar_Private.h
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/Private/GDLRegistrar_Private.h
@@ -19,7 +19,7 @@
 @interface GDLRegistrar ()
 
 /** A map of logTargets to backend implementations. */
-@property(nonatomic) NSMutableDictionary<NSNumber *, id<GDLLogUploader>> *logTargetToBackend;
+@property(nonatomic) NSMutableDictionary<NSNumber *, id<GDLLogUploader>> *logTargetToUploader;
 
 /** A map of logTargets to prioritizer implementations. */
 @property(nonatomic) NSMutableDictionary<NSNumber *, id<GDLLogPrioritizer>> *logTargetToPrioritizer;

--- a/GoogleDataLogger/GoogleDataLogger/Classes/Public/GDLLogTargets.h
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/Public/GDLLogTargets.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google
+ * Copyright 2019 Google
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
-#import "GDLTestUploader.h"
+#import <Foundation/Foundation.h>
 
-@implementation GDLTestUploader
+/** The list of targets supported by the shared logging infrastructure. If adding a new target,
+ * please use the previous value +1, and increment GDLLogTargetLast by 1.
+ */
+typedef NS_ENUM(NSInteger, GDLLogTarget) {
 
-- (void)uploadLogs:(NSSet<NSURL *> *)logFiles onComplete:(GDLUploaderCompletionBlock)onComplete {
-  if (_uploadLogsBlock) {
-    _uploadLogsBlock(logFiles, onComplete);
-  } else if (onComplete) {
-    onComplete(kGDLLogTargetCCT, [GDLClock snapshot], nil);
-  }
-}
+  /** The CCT log target. */
+  kGDLLogTargetCCT = 1000,
 
-@end
+  GDLLogTargetLast = 1001
+};

--- a/GoogleDataLogger/GoogleDataLogger/Classes/Public/GDLLogUploader.h
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/Public/GDLLogUploader.h
@@ -23,8 +23,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** A convenient typedef to define the block to be called upon completion of an upload to the
  * backend.
+ *
+ * target: The log target that was uploading.
+ * nextUploadAttemptUTC: The desired next upload attempt time.
+ * uploadError: Populated with any upload error. If non-nil, a retry will be attempted.
  */
-typedef void (^GDLUploaderCompletionBlock)(GDLLogTarget target, GDLClock *nextUploadAttemptUTC, NSSet<NSURL *> *_Nullable successfulUploads);
+typedef void (^GDLUploaderCompletionBlock)(GDLLogTarget target,
+                                           GDLClock *nextUploadAttemptUTC,
+                                           NSError *_Nullable uploadError);
 
 /** This protocol defines the common interface for logging backend implementations. */
 @protocol GDLLogUploader <NSObject>

--- a/GoogleDataLogger/GoogleDataLogger/Classes/Public/GDLLogUploader.h
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/Public/GDLLogUploader.h
@@ -16,13 +16,15 @@
 
 #import <Foundation/Foundation.h>
 
+#import <GoogleDataLogger/GDLClock.h>
+#import <GoogleDataLogger/GDLLogTargets.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 /** A convenient typedef to define the block to be called upon completion of an upload to the
  * backend.
  */
-typedef void (^GDLBackendCompletionBlock)(NSSet<NSURL *> *_Nullable successfulUploads,
-                                          NSSet<NSURL *> *_Nullable unsuccessfulUploads);
+typedef void (^GDLUploaderCompletionBlock)(GDLLogTarget target, GDLClock *nextUploadAttemptUTC, NSSet<NSURL *> *_Nullable successfulUploads);
 
 /** This protocol defines the common interface for logging backend implementations. */
 @protocol GDLLogUploader <NSObject>
@@ -36,7 +38,7 @@ typedef void (^GDLBackendCompletionBlock)(NSSet<NSURL *> *_Nullable successfulUp
  *   - successfulUploads: The set of filenames uploaded successfully.
  *   - unsuccessfulUploads: The set of filenames not uploaded successfully.
  */
-- (void)uploadLogs:(NSSet<NSURL *> *)logFiles onComplete:(GDLBackendCompletionBlock)onComplete;
+- (void)uploadLogs:(NSSet<NSURL *> *)logFiles onComplete:(GDLUploaderCompletionBlock)onComplete;
 
 @end
 

--- a/GoogleDataLogger/GoogleDataLogger/Classes/Public/GDLRegistrar.h
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/Public/GDLRegistrar.h
@@ -18,15 +18,9 @@
 
 #import <GoogleDataLogger/GDLLogPrioritizer.h>
 #import <GoogleDataLogger/GDLLogUploader.h>
+#import <GoogleDataLogger/GDLLogTargets.h>
 
 NS_ASSUME_NONNULL_BEGIN
-
-/** The list of targets supported by the shared logging infrastructure. */
-typedef NS_ENUM(NSInteger, GDLLogTarget) {
-
-  /** The CCT log target. */
-  kGDLLogTargetCCT = 1000
-};
 
 /** Manages the registration of log targets with the logging SDK. */
 @interface GDLRegistrar : NSObject

--- a/GoogleDataLogger/GoogleDataLogger/Classes/Public/GDLRegistrar.h
+++ b/GoogleDataLogger/GoogleDataLogger/Classes/Public/GDLRegistrar.h
@@ -17,8 +17,8 @@
 #import <Foundation/Foundation.h>
 
 #import <GoogleDataLogger/GDLLogPrioritizer.h>
-#import <GoogleDataLogger/GDLLogUploader.h>
 #import <GoogleDataLogger/GDLLogTargets.h>
+#import <GoogleDataLogger/GDLLogUploader.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/GoogleDataLogger/Tests/Unit/Categories/GDLLogStorage+Testing.m
+++ b/GoogleDataLogger/Tests/Unit/Categories/GDLLogStorage+Testing.m
@@ -20,7 +20,7 @@
 
 - (void)reset {
   dispatch_sync(self.storageQueue, ^{
-    [self.logTargetToLogFileSet removeAllObjects];
+    [self.logTargetToLogHashSet removeAllObjects];
     [self.logHashToLogFile removeAllObjects];
   });
 }

--- a/GoogleDataLogger/Tests/Unit/Categories/GDLRegistrar+Testing.m
+++ b/GoogleDataLogger/Tests/Unit/Categories/GDLRegistrar+Testing.m
@@ -22,7 +22,7 @@
 
 - (void)reset {
   [self.logTargetToPrioritizer removeAllObjects];
-  [self.logTargetToBackend removeAllObjects];
+  [self.logTargetToUploader removeAllObjects];
 }
 
 @end

--- a/GoogleDataLogger/Tests/Unit/GDLLogStorageTest.m
+++ b/GoogleDataLogger/Tests/Unit/GDLLogStorageTest.m
@@ -87,7 +87,7 @@ static NSInteger logTarget = 1337;
   }
   dispatch_sync([GDLLogStorage sharedInstance].storageQueue, ^{
     XCTAssertEqual([GDLLogStorage sharedInstance].logHashToLogFile.count, 1);
-    XCTAssertEqual([GDLLogStorage sharedInstance].logTargetToLogFileSet[@(logTarget)].count, 1);
+    XCTAssertEqual([GDLLogStorage sharedInstance].logTargetToLogHashSet[@(logTarget)].count, 1);
     NSURL *logFile = [GDLLogStorage sharedInstance].logHashToLogFile[@(logHash)];
     XCTAssertNotNil(logFile);
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:logFile.path]);
@@ -116,7 +116,7 @@ static NSInteger logTarget = 1337;
   dispatch_sync([GDLLogStorage sharedInstance].storageQueue, ^{
     XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:logFile.path]);
     XCTAssertEqual([GDLLogStorage sharedInstance].logHashToLogFile.count, 0);
-    XCTAssertEqual([GDLLogStorage sharedInstance].logTargetToLogFileSet[@(logTarget)].count, 0);
+    XCTAssertEqual([GDLLogStorage sharedInstance].logTargetToLogHashSet[@(logTarget)].count, 0);
   });
 }
 
@@ -143,7 +143,7 @@ static NSInteger logTarget = 1337;
   }
   dispatch_sync([GDLLogStorage sharedInstance].storageQueue, ^{
     XCTAssertEqual([GDLLogStorage sharedInstance].logHashToLogFile.count, 3);
-    XCTAssertEqual([GDLLogStorage sharedInstance].logTargetToLogFileSet[@(logTarget)].count, 3);
+    XCTAssertEqual([GDLLogStorage sharedInstance].logTargetToLogHashSet[@(logTarget)].count, 3);
 
     NSURL *log1File = [GDLLogStorage sharedInstance].logHashToLogFile[@(log1Hash)];
     XCTAssertNotNil(log1File);
@@ -196,7 +196,7 @@ static NSInteger logTarget = 1337;
   dispatch_sync([GDLLogStorage sharedInstance].storageQueue, ^{
     XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:logFile.path]);
     XCTAssertEqual([GDLLogStorage sharedInstance].logHashToLogFile.count, 0);
-    XCTAssertEqual([GDLLogStorage sharedInstance].logTargetToLogFileSet[@(logTarget)].count, 0);
+    XCTAssertEqual([GDLLogStorage sharedInstance].logTargetToLogHashSet[@(logTarget)].count, 0);
   });
 }
 
@@ -237,7 +237,7 @@ static NSInteger logTarget = 1337;
   dispatch_sync([GDLLogStorage sharedInstance].storageQueue, ^{
     XCTAssertTrue(self.uploaderFake.forceUploadCalled);
     XCTAssertEqual([GDLLogStorage sharedInstance].logHashToLogFile.count, 1);
-    XCTAssertEqual([GDLLogStorage sharedInstance].logTargetToLogFileSet[@(logTarget)].count, 1);
+    XCTAssertEqual([GDLLogStorage sharedInstance].logTargetToLogHashSet[@(logTarget)].count, 1);
     NSURL *logFile = [GDLLogStorage sharedInstance].logHashToLogFile[@(logHash)];
     XCTAssertNotNil(logFile);
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:logFile.path]);

--- a/GoogleDataLogger/Tests/Unit/Helpers/GDLTestUploader.h
+++ b/GoogleDataLogger/Tests/Unit/Helpers/GDLTestUploader.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** A block that can be ran in -uploadLogs:onComplete:. */
 @property(nullable, nonatomic) void (^uploadLogsBlock)
-    (NSSet<NSURL *> *logFiles, GDLBackendCompletionBlock completionBlock);
+    (NSSet<NSURL *> *logFiles, GDLUploaderCompletionBlock completionBlock);
 
 @end
 


### PR DESCRIPTION
- Rename fields related to the previous notion of 'backends' to 'uploaders'.
- Add the ability to delete a set of logs by filename, and a conversion method for hashes to files.
- Change the log storage removeLogs method to be log hashes instead of URLs
- Style, and change the completion block to include an error
- Change to sync, since async to adding more async created race condition
- Test new storage methods
- Fix coordinator method declarations