### PR TITLE
Prevent prevalent Xcode 10.1 simulator flake

### DIFF
--- a/scripts/if_changed.sh
+++ b/scripts/if_changed.sh
@@ -78,7 +78,7 @@ fi
 # Always rebuild if Travis configuration and/or build scripts changed.
 check_changes '^.travis.yml'
 check_changes '^Gemfile.lock'
-check_changes '^scripts/(build|if_changed).sh'
+check_changes '^scripts/(build|if_changed|install_prereqs).sh'
 
 if [[ "$run" == true ]]; then
   "$@"

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -21,6 +21,12 @@
 
 bundle install
 
+# Workaround simulator flake introduced with Xcode 10.1.
+# TODO: Investigate performance implications and impact of only resetting
+#       necessary devices and skipping for macOS.
+xcrun simctl erase all
+xcrun simctl boot all
+
 case "$PROJECT-$PLATFORM-$METHOD" in
   Firebase-iOS-xcodebuild)
     gem install xcpretty


### PR DESCRIPTION
When travis moved from Xcode 10.0 to 10.1, we started getting the following flake in something around 10% of all subjobs.  

The first travis run passed without a substantial slowdown.  I'd like to try this for a week or so, and if it continues to work, follow up with fine tuning.

```
2019-01-03 16:42:24.097 xcodebuild[5587:18556] *** Assertion failure in ROCKRemoteProxy * _Nullable rock_XPCObjectToROCKRemoteProxy(xpc_object_t  _Nonnull __strong, ROCKSessionManager * _Nonnull __strong, NSError * _Nullable __autoreleasing * _Nullable)(), /BuildRoot/Library/Caches/com.apple.xbs/Sources/ROCKit/ROCKit-24/ROCKit/ROCKRemoteProxy+ROCK.m:97
** INTERNAL ERROR: Uncaught exception **
Uncaught Exception: Invalid parameter not satisfying: sessionManager
Stack:
Invalid connection: com.apple.coresymbolicationd
  0   __exceptionPreprocess (in CoreFoundation)
  1   objc_exception_throw (in libobjc.A.dylib)
  2   +[NSException raise:format:arguments:] (in CoreFoundation)
  3   -[NSAssertionHandler handleFailureInFunction:file:lineNumber:description:] (in Foundation)
  4   rock_XPCObjectToROCKRemoteProxy (in ROCKit)
  5   rock_NSDictionaryDeserializer (in ROCKit)
  6   rock_XPCObjectToNSObject (in ROCKit)
  7   __rock_XPCObjectToNSDictionary_block_invoke (in ROCKit)
  8   _xpc_dictionary_apply_apply (in libxpc.dylib)
  9   _xpc_dictionary_apply_node_f (in libxpc.dylib)
 10   xpc_dictionary_apply (in libxpc.dylib)
 11   rock_XPCObjectToNSDictionary (in ROCKit)
 12   rock_XPCObjectToNSError (in ROCKit)
 13   simservice_send_request_sync (in CoreSimulatorUtilities)
 14   -[SimDevice _onBootstrapQueue_shutdownWithError:] (in CoreSimulator)
 15   __64-[SimDevice shutdownAsyncWithCompletionQueue:completionHandler:]_block_invoke (in CoreSimulator)
 16   __67-[SimDevice bootstrapQueueAsync:completionQueue:completionHandler:]_block_invoke (in CoreSimulator)
 17   _dispatch_call_block_and_release (in libdispatch.dylib)
 18   _dispatch_client_callout (in libdispatch.dylib)
 19   _dispatch_queue_serial_drain (in libdispatch.dylib)
 20   _dispatch_queue_invoke (in libdispatch.dylib)
 21   _dispatch_root_queue_drain_deferred_wlh (in libdispatch.dylib)
 22   _dispatch_workloop_worker_thread (in libdispatch.dylib)
 23   _pthread_wqthread (in libsystem_pthread.dylib)
 24   start_wqthread (in libsystem_pthread.dylib)
./scripts/build.sh: line 71:  5587 Abort trap: 6           xcodebuild "$@"
      5588 Done                    | xcpretty
The command "./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM" exited with 134.
```