### PR TITLE
Fix crash when loading gRPC certificates if a bundle is not found

### DIFF
--- a/Firestore/core/src/firebase/firestore/remote/grpc_root_certificate_finder_apple.mm
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_root_certificate_finder_apple.mm
@@ -37,20 +37,21 @@ using util::StringFormat;
 NSString* FindPathToCertificatesFile() {
   // Certificates file might be present in one of several bundles, based on
   // the environment.
-  NSArray<NSBundle*>* bundles = @[
-    // First, try to load certificates bundled by gRPC-C++ if available
-    // (pod versions 0.0.6+).
-    [NSBundle bundleWithIdentifier:@"org.cocoapods.grpcpp"],
-    // Fall back to the certificates bundled with Firestore if necessary.
-    [NSBundle bundleForClass:FSTFirestoreClient.class],
-    // Finally, users manually adding resources to the project may add the
-    // certificate to the main application bundle. Note that `mainBundle` is nil
-    // for unit tests of library projects, so it cannot fully substitute for
-    // checking framework bundles.
-    [NSBundle mainBundle],
-  ];
+  NSBundle* bundles[] = {
+      // First, try to load certificates bundled by gRPC-C++ if available
+      // (pod versions 0.0.6+).
+      [NSBundle bundleWithIdentifier:@"org.cocoapods.grpcpp"],
+      // Fall back to the certificates bundled with Firestore if necessary.
+      [NSBundle bundleForClass:FSTFirestoreClient.class],
+      // Finally, users manually adding resources to the project may add the
+      // certificate to the main application bundle. Note that `mainBundle` is
+      // nil
+      // for unit tests of library projects, so it cannot fully substitute for
+      // checking framework bundles.
+      [NSBundle mainBundle],
+  };
 
-  for (NSBundle* bundle in bundles) {
+  for (NSBundle* bundle : bundles) {
     if (!bundle) {
       continue;
     }


### PR DESCRIPTION
If a requested bundle is not found, `NSBundle` class method returns `nil`, which cannot be added to an `NSArray`, resulting in an exception.