### PR TITLE
Reset simulators before each xcodebuild

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -69,6 +69,12 @@ fi
 # Runs xcodebuild with the given flags, piping output to xcpretty
 # If xcodebuild fails with known error codes, retries once.
 function RunXcodebuild() {
+  # Workaround simulator flake introduced with Xcode 10.1.
+  # TODO: Investigate performance implications and impact of only resetting
+  #       necessary devices and skipping for macOS.
+  xcrun simctl erase all
+  xcrun simctl boot all
+
   xcodebuild "$@" | xcpretty; result=$?
   if [[ $result == 65 ]]; then
     echo "xcodebuild exited with 65, retrying" 1>&2

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -74,7 +74,6 @@ function RunXcodebuild() {
   #       necessary devices and skipping for macOS.
   xcrun simctl shutdown all
   xcrun simctl erase all
-  xcrun simctl boot all
 
   xcodebuild "$@" | xcpretty; result=$?
   if [[ $result == 65 ]]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -72,6 +72,7 @@ function RunXcodebuild() {
   # Workaround simulator flake introduced with Xcode 10.1.
   # TODO: Investigate performance implications and impact of only resetting
   #       necessary devices and skipping for macOS.
+  xcrun simctl shutdown all
   xcrun simctl erase all
   xcrun simctl boot all
 

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -21,12 +21,6 @@
 
 bundle install
 
-# Workaround simulator flake introduced with Xcode 10.1.
-# TODO: Investigate performance implications and impact of only resetting
-#       necessary devices and skipping for macOS.
-xcrun simctl erase all
-xcrun simctl boot all
-
 case "$PROJECT-$PLATFORM-$METHOD" in
   Firebase-iOS-xcodebuild)
     gem install xcpretty


### PR DESCRIPTION
Follow on to #2276. The `ROCKRemoteProxy` flake still occurred when resetting for travis job run.  Trying a reset for each xcodebuild now.