### PR TITLE
Rename the generated byte array containing gRPC root certificates

### DIFF
--- a/Firestore/core/src/firebase/firestore/remote/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/remote/CMakeLists.txt
@@ -51,8 +51,8 @@ add_custom_command(
         --output_header=grpc_root_certificates_generated.h
         --output_source=grpc_root_certificates_generated.cc
         --cpp_namespace=firebase::firestore::remote
-        --array=grpc_root_certificates
-        --array_size=grpc_root_certificates_size
+        --array=grpc_root_certificates_generated_data
+        --array_size=grpc_root_certificates_generated_size
         ${FIREBASE_EXTERNAL_SOURCE_DIR}/grpc/etc/roots.pem
     DEPENDS
     ${FIREBASE_EXTERNAL_SOURCE_DIR}/grpc/etc/roots.pem

--- a/Firestore/core/src/firebase/firestore/remote/grpc_root_certificate_finder_generated.cc
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_root_certificate_finder_generated.cc
@@ -29,8 +29,8 @@ namespace firestore {
 namespace remote {
 
 std::string LoadGrpcRootCertificate() {
-  return {reinterpret_cast<const char*>(grpc_root_certificates),
-          grpc_root_certificates_size};
+  return {reinterpret_cast<const char*>(grpc_root_certificates_generated_data),
+          grpc_root_certificates_generated_size};
 }
 
 }  // namespace remote


### PR DESCRIPTION
For reasons of style compliance.