### PR TITLE
Implement MemoryMutationQueue in C++

### DIFF
--- a/Firestore/Source/Local/FSTMemoryMutationQueue.mm
+++ b/Firestore/Source/Local/FSTMemoryMutationQueue.mm
@@ -18,7 +18,8 @@
 
 #import <Protobuf/GPBProtocolBuffers.h>
 
-#include <set>
+#include <memory>
+#include <vector>
 
 #import "Firestore/Protos/objc/firestore/local/Mutation.pbobjc.h"
 #import "Firestore/Source/Core/FSTQuery.h"
@@ -28,12 +29,15 @@
 
 #include "Firestore/core/src/firebase/firestore/immutable/sorted_set.h"
 #include "Firestore/core/src/firebase/firestore/local/document_reference.h"
+#include "Firestore/core/src/firebase/firestore/local/memory_mutation_queue.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/resource_path.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
+#include "absl/memory/memory.h"
 
 using firebase::firestore::immutable::SortedSet;
 using firebase::firestore::local::DocumentReference;
+using firebase::firestore::local::MemoryMutationQueue;
 using firebase::firestore::model::BatchId;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeySet;
@@ -41,319 +45,96 @@ using firebase::firestore::model::ResourcePath;
 
 NS_ASSUME_NONNULL_BEGIN
 
-static const NSComparator NumberComparator = ^NSComparisonResult(NSNumber *left, NSNumber *right) {
-  return [left compare:right];
-};
-
-@interface FSTMemoryMutationQueue ()
-
-/**
- * A FIFO queue of all mutations to apply to the backend. Mutations are added to the end of the
- * queue as they're written, and removed from the front of the queue as the mutations become
- * visible or are rejected.
- *
- * When successfully applied, mutations must be acknowledged by the write stream and made visible
- * on the watch stream. It's possible for the watch stream to fall behind in which case the batches
- * at the head of the queue will be acknowledged but held until the watch stream sees the changes.
- *
- * If a batch is rejected while there are held write acknowledgements at the head of the queue
- * the rejected batch is converted to a tombstone: its mutations are removed but the batch remains
- * in the queue. This maintains a simple consecutive ordering of batches in the queue.
- *
- * Once the held write acknowledgements become visible they are removed from the head of the queue
- * along with any tombstones that follow.
- */
-@property(nonatomic, strong, readonly) NSMutableArray<FSTMutationBatch *> *queue;
-
-/** The next value to use when assigning sequential IDs to each mutation batch. */
-@property(nonatomic, assign) BatchId nextBatchID;
-
-/**
- * The last received stream token from the server, used to acknowledge which responses the client
- * has processed. Stream tokens are opaque checkpoint markers whose only real value is their
- * inclusion in the next request.
- */
-@property(nonatomic, strong, nullable) NSData *lastStreamToken;
-
-@end
-
-using DocumentReferenceSet = SortedSet<DocumentReference, DocumentReference::ByKey>;
+static NSArray<FSTMutationBatch *> *toNSArray(const std::vector<FSTMutationBatch *> &vec) {
+  NSMutableArray<FSTMutationBatch *> *copy = [NSMutableArray array];
+  for (auto &batch : vec) {
+    [copy addObject:batch];
+  }
+  return copy;
+}
 
 @implementation FSTMemoryMutationQueue {
-  FSTMemoryPersistence *_persistence;
-  /** An ordered mapping between documents and the mutation batch IDs. */
-  DocumentReferenceSet _batchesByDocumentKey;
+  std::unique_ptr<MemoryMutationQueue> _delegate;
 }
 
 - (instancetype)initWithPersistence:(FSTMemoryPersistence *)persistence {
   if (self = [super init]) {
-    _persistence = persistence;
-    _queue = [NSMutableArray array];
-
-    _nextBatchID = 1;
+    _delegate = absl::make_unique<MemoryMutationQueue>(persistence);
   }
   return self;
+}
+
+- (void)setLastStreamToken:(NSData *_Nullable)streamToken {
+  _delegate->set_last_stream_token(streamToken);
+}
+
+- (NSData *_Nullable)lastStreamToken {
+  return _delegate->last_stream_token();
 }
 
 #pragma mark - FSTMutationQueue implementation
 
 - (void)start {
-  // Note: The queue may be shutdown / started multiple times, since we maintain the queue for the
-  // duration of the app session in case a user logs out / back in. To behave like the
-  // LevelDB-backed MutationQueue (and accommodate tests that expect as much), we reset nextBatchID
-  // if the queue is empty.
-  if (self.isEmpty) {
-    self.nextBatchID = 1;
-  }
+  _delegate->Start();
 }
 
 - (BOOL)isEmpty {
-  // If the queue has any entries at all, the first entry must not be a tombstone (otherwise it
-  // would have been removed already).
-  return self.queue.count == 0;
+  return _delegate->is_empty();
 }
 
 - (void)acknowledgeBatch:(FSTMutationBatch *)batch streamToken:(nullable NSData *)streamToken {
-  NSMutableArray<FSTMutationBatch *> *queue = self.queue;
-
-  BatchId batchID = batch.batchID;
-
-  NSInteger batchIndex = [self indexOfExistingBatchID:batchID action:@"acknowledged"];
-  HARD_ASSERT(batchIndex == 0, "Can only acknowledge the first batch in the mutation queue");
-
-  // Verify that the batch in the queue is the one to be acknowledged.
-  FSTMutationBatch *check = queue[(NSUInteger)batchIndex];
-  HARD_ASSERT(batchID == check.batchID, "Queue ordering failure: expected batch %s, got batch %s",
-              batchID, check.batchID);
-
-  self.lastStreamToken = streamToken;
+  _delegate->AcknowledgeBatch(batch, streamToken);
 }
 
 - (FSTMutationBatch *)addMutationBatchWithWriteTime:(FIRTimestamp *)localWriteTime
                                           mutations:(NSArray<FSTMutation *> *)mutations {
-  HARD_ASSERT(mutations.count > 0, "Mutation batches should not be empty");
-
-  BatchId batchID = self.nextBatchID;
-  self.nextBatchID += 1;
-
-  NSMutableArray<FSTMutationBatch *> *queue = self.queue;
-  if (queue.count > 0) {
-    FSTMutationBatch *prior = queue[queue.count - 1];
-    HARD_ASSERT(prior.batchID < batchID,
-                "Mutation batchIDs must be monotonically increasing order");
-  }
-
-  FSTMutationBatch *batch = [[FSTMutationBatch alloc] initWithBatchID:batchID
-                                                       localWriteTime:localWriteTime
-                                                            mutations:mutations];
-  [queue addObject:batch];
-
-  // Track references by document key.
-  for (FSTMutation *mutation in batch.mutations) {
-    _batchesByDocumentKey = _batchesByDocumentKey.insert(DocumentReference{mutation.key, batchID});
-  }
-
-  return batch;
+  return _delegate->AddMutationBatch(localWriteTime, mutations);
 }
 
 - (nullable FSTMutationBatch *)lookupMutationBatch:(BatchId)batchID {
-  NSMutableArray<FSTMutationBatch *> *queue = self.queue;
-
-  NSInteger index = [self indexOfBatchID:batchID];
-  if (index < 0 || index >= queue.count) {
-    return nil;
-  }
-
-  FSTMutationBatch *batch = queue[(NSUInteger)index];
-  HARD_ASSERT(batch.batchID == batchID, "If found batch must match");
-  return batch;
+  return _delegate->LookupMutationBatch(batchID);
 }
 
 - (nullable FSTMutationBatch *)nextMutationBatchAfterBatchID:(BatchId)batchID {
-  NSMutableArray<FSTMutationBatch *> *queue = self.queue;
-
-  BatchId nextBatchID = batchID + 1;
-
-  // The requested batchID may still be out of range so normalize it to the start of the queue.
-  NSInteger rawIndex = [self indexOfBatchID:nextBatchID];
-  NSUInteger index = rawIndex < 0 ? 0 : (NSUInteger)rawIndex;
-  return queue.count > index ? queue[index] : nil;
+  return _delegate->NextMutationBatchAfterBatchId(batchID);
 }
 
 - (NSArray<FSTMutationBatch *> *)allMutationBatches {
-  return [[self queue] copy];
+  return toNSArray(_delegate->AllMutationBatches());
 }
 
 - (NSArray<FSTMutationBatch *> *)allMutationBatchesAffectingDocumentKey:
     (const DocumentKey &)documentKey {
-  NSMutableArray<FSTMutationBatch *> *result = [NSMutableArray array];
-
-  DocumentReference start{documentKey, 0};
-  for (const auto &reference : _batchesByDocumentKey.values_from(start)) {
-    if (documentKey != reference.key()) break;
-
-    FSTMutationBatch *batch = [self lookupMutationBatch:reference.ref_id()];
-    HARD_ASSERT(batch, "Batches in the index must exist in the main table");
-    [result addObject:batch];
-  }
-
-  return result;
+  return toNSArray(_delegate->AllMutationBatchesAffectingDocumentKey(documentKey));
 }
 
 - (NSArray<FSTMutationBatch *> *)allMutationBatchesAffectingDocumentKeys:
     (const DocumentKeySet &)documentKeys {
-  // First find the set of affected batch IDs.
-  std::set<BatchId> batchIDs;
-  for (const DocumentKey &key : documentKeys) {
-    DocumentReference start{key, 0};
-
-    for (const auto &reference : _batchesByDocumentKey.values_from(start)) {
-      if (key != reference.key()) break;
-
-      batchIDs.insert(reference.ref_id());
-    }
-  }
-
-  return [self allMutationBatchesWithBatchIDs:batchIDs];
+  return toNSArray(_delegate->AllMutationBatchesAffectingDocumentKeys(documentKeys));
 }
 
 - (NSArray<FSTMutationBatch *> *)allMutationBatchesAffectingQuery:(FSTQuery *)query {
-  // Use the query path as a prefix for testing if a document matches the query.
-  const ResourcePath &prefix = query.path;
-  size_t immediateChildrenPathLength = prefix.size() + 1;
-
-  // Construct a document reference for actually scanning the index. Unlike the prefix, the document
-  // key in this reference must have an even number of segments. The empty segment can be used as
-  // a suffix of the query path because it precedes all other segments in an ordered traversal.
-  ResourcePath startPath = query.path;
-  if (!DocumentKey::IsDocumentKey(startPath)) {
-    startPath = startPath.Append("");
-  }
-  DocumentReference start{DocumentKey{startPath}, 0};
-
-  // Find unique batchIDs referenced by all documents potentially matching the query.
-  std::set<BatchId> uniqueBatchIDs;
-  for (const auto &reference : _batchesByDocumentKey.values_from(start)) {
-    const ResourcePath &rowKeyPath = reference.key().path();
-    if (!prefix.IsPrefixOf(rowKeyPath)) {
-      break;
-    }
-
-    // Rows with document keys more than one segment longer than the query path can't be matches.
-    // For example, a query on 'rooms' can't match the document /rooms/abc/messages/xyx.
-    // TODO(mcg): we'll need a different scanner when we implement ancestor queries.
-    if (rowKeyPath.size() != immediateChildrenPathLength) {
-      continue;
-    }
-
-    uniqueBatchIDs.insert(reference.ref_id());
-  };
-
-  return [self allMutationBatchesWithBatchIDs:uniqueBatchIDs];
-}
-
-/**
- * Constructs an array of matching batches, sorted by batchID to ensure that multiple mutations
- * affecting the same document key are applied in order.
- */
-- (NSArray<FSTMutationBatch *> *)allMutationBatchesWithBatchIDs:
-    (const std::set<BatchId> &)batchIDs {
-  NSMutableArray<FSTMutationBatch *> *result = [NSMutableArray array];
-  for (BatchId batchID : batchIDs) {
-    FSTMutationBatch *batch = [self lookupMutationBatch:batchID];
-    if (batch) {
-      [result addObject:batch];
-    }
-  };
-
-  return result;
+  return toNSArray(_delegate->AllMutationBatchesAffectingQuery(query));
 }
 
 - (void)removeMutationBatch:(FSTMutationBatch *)batch {
-  NSMutableArray<FSTMutationBatch *> *queue = self.queue;
-  BatchId batchID = batch.batchID;
-
-  // Find the position of the first batch for removal. This need not be the first entry in the
-  // queue.
-  NSUInteger batchIndex = [self indexOfExistingBatchID:batchID action:@"removed"];
-  HARD_ASSERT(batchIndex == 0, "Can only remove the first entry of the mutation queue");
-
-  [queue removeObjectAtIndex:0];
-
-  // Remove entries from the index too.
-  for (FSTMutation *mutation in batch.mutations) {
-    const DocumentKey &key = mutation.key;
-    [_persistence.referenceDelegate removeMutationReference:key];
-
-    DocumentReference reference{key, batchID};
-    _batchesByDocumentKey = _batchesByDocumentKey.erase(reference);
-  }
+  _delegate->RemoveMutationBatch(batch);
 }
 
 - (void)performConsistencyCheck {
-  if (self.queue.count == 0) {
-    HARD_ASSERT(_batchesByDocumentKey.empty(),
-                "Document leak -- detected dangling mutation references when queue is empty.");
-  }
+  _delegate->PerformConsistencyCheck();
 }
 
 #pragma mark - FSTGarbageSource implementation
 
 - (BOOL)containsKey:(const DocumentKey &)key {
-  // Create a reference with a zero ID as the start position to find any document reference with
-  // this key.
-  DocumentReference reference{key, 0};
-
-  auto range = _batchesByDocumentKey.values_from(reference);
-  auto begin = range.begin();
-  return begin != range.end() && begin->key() == key;
+  return _delegate->ContainsKey(key);
 }
 
 #pragma mark - Helpers
 
-/**
- * Finds the index of the given batchID in the mutation queue. This operation is O(1).
- *
- * @return The computed index of the batch with the given batchID, based on the state of the
- *     queue. Note this index can negative if the requested batchID has already been removed from
- *     the queue or past the end of the queue if the batchID is larger than the last added batch.
- */
-- (NSInteger)indexOfBatchID:(BatchId)batchID {
-  NSMutableArray<FSTMutationBatch *> *queue = self.queue;
-  NSUInteger count = queue.count;
-  if (count == 0) {
-    // As an index this is past the end of the queue
-    return 0;
-  }
-
-  // Examine the front of the queue to figure out the difference between the batchID and indexes
-  // in the array. Note that since the queue is ordered by batchID, if the first batch has a larger
-  // batchID then the requested batchID doesn't exist in the queue.
-  FSTMutationBatch *firstBatch = queue[0];
-  BatchId firstBatchID = firstBatch.batchID;
-  return batchID - firstBatchID;
-}
-
-/**
- * Finds the index of the given batchID in the mutation queue and asserts that the resulting
- * index is within the bounds of the queue.
- *
- * @param batchID The batchID to search for
- * @param action A description of what the caller is doing, phrased in passive form (e.g.
- *     "acknowledged" in a routine that acknowledges batches).
- */
-- (NSUInteger)indexOfExistingBatchID:(BatchId)batchID action:(NSString *)action {
-  NSInteger index = [self indexOfBatchID:batchID];
-  HARD_ASSERT(index >= 0 && index < self.queue.count, "Batches must exist to be %s", action);
-  return (NSUInteger)index;
-}
-
 - (size_t)byteSizeWithSerializer:(FSTLocalSerializer *)serializer {
-  size_t count = 0;
-  for (FSTMutationBatch *batch in self.queue) {
-    count += [[serializer encodedMutationBatch:batch] serializedSize];
-  };
-  return count;
+  return _delegate->CalculateByteSize(serializer);
 }
 
 @end

--- a/Firestore/core/src/firebase/firestore/local/memory_mutation_queue.h
+++ b/Firestore/core/src/firebase/firestore/local/memory_mutation_queue.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_MEMORY_MUTATION_QUEUE_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_MEMORY_MUTATION_QUEUE_H_
+
+#if !defined(__OBJC__)
+#error "For now, this file must only be included by ObjC source files."
+#endif  // !defined(__OBJC__)
+
+#import <Foundation/Foundation.h>
+
+#include <set>
+#include <vector>
+
+#import "Firestore/Source/Public/FIRTimestamp.h"
+
+#include "Firestore/core/src/firebase/firestore/immutable/sorted_set.h"
+#include "Firestore/core/src/firebase/firestore/local/document_reference.h"
+#include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
+
+@class FSTLocalSerializer;
+@class FSTMemoryPersistence;
+@class FSTMutation;
+@class FSTMutationBatch;
+@class FSTQuery;
+
+NS_ASSUME_NONNULL_BEGIN
+
+namespace firebase {
+namespace firestore {
+namespace local {
+
+class MemoryMutationQueue {
+  using DocumentReferenceSet = immutable::SortedSet<DocumentReference, DocumentReference::ByKey>;
+ public:
+  explicit MemoryMutationQueue(FSTMemoryPersistence* persistence);
+
+  void Start();
+
+  bool is_empty() {
+    // If the queue has any entries at all, the first entry must not be a tombstone (otherwise it
+    // would have been removed already).
+    return queue_.size() == 0;
+  }
+
+  void AcknowledgeBatch(FSTMutationBatch* batch, NSData*_Nullable stream_token);
+  FSTMutationBatch* AddMutationBatch(FIRTimestamp* local_write_time, NSArray<FSTMutation *>* mutations);
+
+  void RemoveMutationBatch(FSTMutationBatch* batch);
+
+  const std::vector<FSTMutationBatch *>& AllMutationBatches() { return queue_; }
+
+  std::vector<FSTMutationBatch *> AllMutationBatchesAffectingDocumentKeys(const model::DocumentKeySet& document_keys);
+
+  std::vector<FSTMutationBatch *> AllMutationBatchesAffectingDocumentKey(const model::DocumentKey& key);
+
+  std::vector<FSTMutationBatch *> AllMutationBatchesAffectingQuery(FSTQuery* query);
+
+  FSTMutationBatch*_Nullable LookupMutationBatch(model::BatchId batch_id);
+
+  FSTMutationBatch*_Nullable NextMutationBatchAfterBatchId(model::BatchId batch_id);
+
+  void PerformConsistencyCheck();
+
+  bool ContainsKey(const model::DocumentKey& key);
+
+  size_t CalculateByteSize(FSTLocalSerializer* serializer);
+
+  NSData*_Nullable last_stream_token() { return last_stream_token_; }
+  void set_last_stream_token(NSData* token) { last_stream_token_ = token; }
+ private:
+  std::vector<FSTMutationBatch *> AllMutationBatchesWithIds(const std::set<model::BatchId>& batch_ids);
+
+  /**
+   * Finds the index of the given batchID in the mutation queue. This operation is O(1).
+   *
+   * @return The computed index of the batch with the given BatchID, based on the state of the
+   *     queue. Note this index can negative if the requested BatchID has already been removed from
+   *     the queue or past the end of the queue if the BatchID is larger than the last added batch.
+   */
+  int IndexOfBatchId(model::BatchId batch_id);
+
+  FSTMemoryPersistence* persistence_;
+  /**
+   * A FIFO queue of all mutations to apply to the backend. Mutations are added to the end of the
+   * queue as they're written, and removed from the front of the queue as the mutations become
+   * visible or are rejected.
+   *
+   * When successfully applied, mutations must be acknowledged by the write stream and made visible
+   * on the watch stream. It's possible for the watch stream to fall behind in which case the batches
+   * at the head of the queue will be acknowledged but held until the watch stream sees the changes.
+   *
+   * If a batch is rejected while there are held write acknowledgements at the head of the queue
+   * the rejected batch is converted to a tombstone: its mutations are removed but the batch remains
+   * in the queue. This maintains a simple consecutive ordering of batches in the queue.
+   *
+   * Once the held write acknowledgements become visible they are removed from the head of the queue
+   * along with any tombstones that follow.
+   */
+  // TODO(gsoltis): more efficient data structure?
+  std::vector<FSTMutationBatch *> queue_;
+
+  /** The next value to use when assigning sequential IDs to each mutation batch. */
+  model::BatchId next_batch_id_;
+  /**
+   * The last received stream token from the server, used to acknowledge which responses the client
+   * has processed. Stream tokens are opaque checkpoint markers whose only real value is their
+   * inclusion in the next request.
+   */
+  NSData*_Nullable last_stream_token_;
+  /** An ordered mapping between documents and the mutation batch IDs. */
+  DocumentReferenceSet batches_by_document_key_;
+};
+
+}  // namespace local
+}  // namespace firestore
+}  // namespace firebase
+
+NS_ASSUME_NONNULL_END
+
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_MEMORY_MUTATION_QUEUE_H_

--- a/Firestore/core/src/firebase/firestore/local/memory_mutation_queue.mm
+++ b/Firestore/core/src/firebase/firestore/local/memory_mutation_queue.mm
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/local/document_reference.h"
+#include "Firestore/core/src/firebase/firestore/local/memory_mutation_queue.h"
+#include "Firestore/core/src/firebase/firestore/model/resource_path.h"
+#include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
+#import "Firestore/Protos/objc/firestore/local/Mutation.pbobjc.h"
+#import "Firestore/Source/Core/FSTQuery.h"
+#import "Firestore/Source/Local/FSTLocalSerializer.h"
+#import "Firestore/Source/Local/FSTMemoryPersistence.h"
+#import "Firestore/Source/Model/FSTMutation.h"
+#import "Firestore/Source/Model/FSTMutationBatch.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+namespace firebase {
+namespace firestore {
+namespace local {
+
+using model::BatchId;
+using model::DocumentKey;
+using model::DocumentKeySet;
+using model::ResourcePath;
+
+MemoryMutationQueue::MemoryMutationQueue(FSTMemoryPersistence* persistence) : persistence_(persistence), next_batch_id_(1) {}
+
+void MemoryMutationQueue::AcknowledgeBatch(FSTMutationBatch *batch, NSData*_Nullable stream_token) {
+  HARD_ASSERT(queue_.size() > 0, "Cannot acknowledge batch on an empty queue");
+
+  // Guaranteed to exist, due to above assert
+  FSTMutationBatch* check = queue_[0];
+  // Verify that the batch in the queue is the one to be acknowledged.
+  HARD_ASSERT(batch.batchID == check.batchID, "Queue ordering failure: expected batch %s, got batch %s",
+          batch.batchID, check.batchID);
+  last_stream_token_ = stream_token;
+}
+
+void MemoryMutationQueue::Start() {
+  // Note: The queue may be shutdown / started multiple times, since we maintain the queue for the
+  // duration of the app session in case a user logs out / back in. To behave like the
+  // LevelDB-backed MutationQueue (and accommodate tests that expect as much), we reset nextBatchID
+  // if the queue is empty.
+  if (is_empty()) {
+    next_batch_id_ = 1;
+  }
+}
+
+FSTMutationBatch* MemoryMutationQueue::AddMutationBatch(FIRTimestamp* local_write_time, NSArray<FSTMutation *> *mutations) {
+  HARD_ASSERT(mutations.count > 0, "Mutation batches should not be empty");
+
+  BatchId batch_id = next_batch_id_;
+  next_batch_id_++;
+
+  if (queue_.size() > 0) {
+    FSTMutationBatch* prior = queue_[queue_.size() - 1];
+    HARD_ASSERT(prior.batchID < batch_id,
+            "Mutation batchIDs must be monotonically increasing order");
+  }
+
+  FSTMutationBatch *batch = [[FSTMutationBatch alloc] initWithBatchID:batch_id
+                                                       localWriteTime:local_write_time
+                                                            mutations:mutations];
+  queue_.push_back(batch);
+
+  // Track references by document key.
+  for (FSTMutation *mutation in batch.mutations) {
+    batches_by_document_key_ = batches_by_document_key_.insert(DocumentReference{mutation.key, batch_id});
+  }
+
+  return batch;
+}
+
+void MemoryMutationQueue::RemoveMutationBatch(FSTMutationBatch* batch) {
+  // Can only remove the first batch
+  HARD_ASSERT(queue_.size() > 0, "Trying to remove batch from empty queue");
+  FSTMutationBatch* head = queue_[0];
+  HARD_ASSERT(head.batchID == batch.batchID, "Can only remove the first entry of the mutation queue");
+
+  queue_.erase(queue_.begin());
+
+  // Remove entries from the index too.
+  for (FSTMutation* mutation in batch.mutations) {
+    const DocumentKey& key = mutation.key;
+    [persistence_.referenceDelegate removeMutationReference:key];
+
+    DocumentReference reference{key, batch.batchID};
+    batches_by_document_key_ = batches_by_document_key_.erase(reference);
+  }
+
+}
+
+std::vector<FSTMutationBatch *> MemoryMutationQueue::AllMutationBatchesAffectingDocumentKeys(const DocumentKeySet& document_keys) {
+  // First find the set of affected batch IDs.
+  std::set<BatchId> batch_ids;
+  for (const DocumentKey& key : document_keys) {
+    DocumentReference start{key, 0};
+
+    for (const auto &reference : batches_by_document_key_.values_from(start)) {
+      if (key != reference.key()) break;
+
+      batch_ids.insert(reference.ref_id());
+    }
+  }
+
+  return AllMutationBatchesWithIds(batch_ids);
+}
+
+std::vector<FSTMutationBatch *> MemoryMutationQueue::AllMutationBatchesAffectingDocumentKey(const DocumentKey& key) {
+  std::vector<FSTMutationBatch *> result;
+
+  DocumentReference start{key, 0};
+  for (const auto& reference : batches_by_document_key_.values_from(start)) {
+    if (key != reference.key()) break;
+
+    FSTMutationBatch* batch = LookupMutationBatch(reference.ref_id());
+    HARD_ASSERT(batch, "Batches in the index must exist in the main table");
+    result.push_back(batch);
+  }
+  return result;
+}
+
+std::vector<FSTMutationBatch *> MemoryMutationQueue::AllMutationBatchesAffectingQuery(FSTQuery* query) {
+  // Use the query path as a prefix for testing if a document matches the query.
+  const ResourcePath& prefix = query.path;
+  size_t immediate_children_path_length = prefix.size() + 1;
+
+  // Construct a document reference for actually scanning the index. Unlike the prefix, the document
+  // key in this reference must have an even number of segments. The empty segment can be used as
+  // a suffix of the query path because it precedes all other segments in an ordered traversal.
+  ResourcePath start_path = query.path;
+  if (!DocumentKey::IsDocumentKey(start_path)) {
+    start_path = start_path.Append("");
+  }
+  DocumentReference start{DocumentKey{start_path}, 0};
+
+  // Find unique batchIDs referenced by all documents potentially matching the query.
+  std::set<BatchId> unique_batch_ids;
+  for (const auto& reference : batches_by_document_key_.values_from(start)) {
+    const ResourcePath& row_key_path = reference.key().path();
+    if (!prefix.IsPrefixOf(row_key_path)) {
+      break;
+    }
+
+    // Rows with document keys more than one segment longer than the query path can't be matches.
+    // For example, a query on 'rooms' can't match the document /rooms/abc/messages/xyx.
+    // TODO(mcg): we'll need a different scanner when we implement ancestor queries.
+    if (row_key_path.size() != immediate_children_path_length) {
+      continue;
+    }
+
+    unique_batch_ids.insert(reference.ref_id());
+  };
+
+  return AllMutationBatchesWithIds(unique_batch_ids);
+}
+
+FSTMutationBatch*_Nullable MemoryMutationQueue::NextMutationBatchAfterBatchId(BatchId batch_id) {
+  BatchId next_batch_id = batch_id + 1;
+
+  // The requested batchID may still be out of range so normalize it to the start of the queue.
+  int raw_index = IndexOfBatchId(next_batch_id);
+  int index = raw_index < 0 ? 0 : raw_index;
+  return queue_.size() > index ? queue_[index] : nil;
+}
+
+FSTMutationBatch *_Nullable MemoryMutationQueue::LookupMutationBatch(BatchId batch_id) {
+  if (queue_.size() == 0) {
+    return nil;
+  }
+
+  int index = IndexOfBatchId(batch_id);
+  if (index < 0 || index >= queue_.size()) {
+    return nil;
+  }
+
+  FSTMutationBatch* batch = queue_[index];
+  HARD_ASSERT(batch.batchID == batch_id, "If found batch must match");
+  return batch;
+}
+
+void MemoryMutationQueue::PerformConsistencyCheck() {
+  if (queue_.size() == 0) {
+    HARD_ASSERT(batches_by_document_key_.empty(),
+            "Document leak -- detected dangling mutation references when queue is empty.");
+  }
+}
+
+bool MemoryMutationQueue::ContainsKey(const model::DocumentKey& key) {
+  // Create a reference with a zero ID as the start position to find any document reference with
+  // this key.
+  DocumentReference reference{key, 0};
+
+  auto range = batches_by_document_key_.values_from(reference);
+  auto begin = range.begin();
+  return begin != range.end() && begin->key() == key;
+}
+
+size_t MemoryMutationQueue::CalculateByteSize(FSTLocalSerializer* serializer) {
+  size_t count = 0;
+  for (const auto& batch : queue_) {
+    count += [[serializer encodedMutationBatch:batch] serializedSize];
+  };
+  return count;
+}
+
+std::vector<FSTMutationBatch *> MemoryMutationQueue::AllMutationBatchesWithIds(const std::set<BatchId>& batch_ids) {
+  std::vector<FSTMutationBatch *> result;
+  for (BatchId batch_id : batch_ids) {
+    FSTMutationBatch *batch = LookupMutationBatch(batch_id);
+    if (batch) {
+      result.push_back(batch);
+    }
+  }
+
+  return result;
+}
+
+int MemoryMutationQueue::IndexOfBatchId(BatchId batch_id) {
+  if (queue_.size() == 0) {
+    // As an index this is past the end of the queue
+    return 0;
+  }
+
+  // Examine the front of the queue to figure out the difference between the batchID and indexes
+  // in the array. Note that since the queue is ordered by batchID, if the first batch has a larger
+  // batchID then the requested batchID doesn't exist in the queue.
+  FSTMutationBatch *first_batch = queue_[0];
+  return batch_id - first_batch.batchID;
+}
+
+}  // namespace local
+}  // namespace firestore
+}  // namespace firebase
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Implements `FSTMemoryMutationQueue` in terms of a C++ delegate. This is the first step in porting `FSTMutationQueue`.