### PR TITLE
Implement FSTLevelDBMutationQueue in C++

### DIFF
--- a/Firestore/Source/Local/FSTLevelDBMutationQueue.h
+++ b/Firestore/Source/Local/FSTLevelDBMutationQueue.h
@@ -44,12 +44,6 @@ NS_ASSUME_NONNULL_BEGIN
                                    db:(FSTLevelDB *)db
                            serializer:(FSTLocalSerializer *)serializer;
 
-/**
- * Returns one larger than the largest batch ID that has been stored. If there are no mutations
- * returns 0. Note that batch IDs are global.
- */
-+ (firebase::firestore::model::BatchId)loadNextBatchIDFromDB:(leveldb::DB *)db;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Firestore/Source/Local/FSTLevelDBMutationQueue.mm
+++ b/Firestore/Source/Local/FSTLevelDBMutationQueue.mm
@@ -31,6 +31,7 @@
 
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
 #include "Firestore/core/src/firebase/firestore/local/leveldb_key.h"
+#include "Firestore/core/src/firebase/firestore/local/leveldb_mutation_queue.h"
 #include "Firestore/core/src/firebase/firestore/local/leveldb_transaction.h"
 #include "Firestore/core/src/firebase/firestore/local/leveldb_util.h"
 #include "Firestore/core/src/firebase/firestore/model/mutation_batch.h"
@@ -38,6 +39,7 @@
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 #include "Firestore/core/src/firebase/firestore/util/string_util.h"
+#include "absl/memory/memory.h"
 #include "absl/strings/match.h"
 #include "leveldb/db.h"
 #include "leveldb/write_batch.h"
@@ -49,8 +51,10 @@ using firebase::firestore::auth::User;
 using firebase::firestore::local::DescribeKey;
 using firebase::firestore::local::LevelDbDocumentMutationKey;
 using firebase::firestore::local::LevelDbMutationKey;
+using firebase::firestore::local::LevelDbMutationQueue;
 using firebase::firestore::local::LevelDbMutationQueueKey;
 using firebase::firestore::local::LevelDbTransaction;
+using firebase::firestore::local::LoadNextBatchIdFromDb;
 using firebase::firestore::local::MakeStringView;
 using firebase::firestore::model::BatchId;
 using firebase::firestore::model::kBatchIdUnknown;
@@ -65,34 +69,32 @@ using leveldb::Status;
 using leveldb::WriteBatch;
 using leveldb::WriteOptions;
 
+static NSArray<FSTMutationBatch *> *toNSArray(const std::vector<FSTMutationBatch *> &vec) {
+  NSMutableArray<FSTMutationBatch *> *copy = [NSMutableArray array];
+  for (auto &batch : vec) {
+    [copy addObject:batch];
+  }
+  return copy;
+}
+
 @interface FSTLevelDBMutationQueue ()
 
 - (instancetype)initWithUserID:(std::string)userID
                             db:(FSTLevelDB *)db
-                    serializer:(FSTLocalSerializer *)serializer NS_DESIGNATED_INITIALIZER;
-
-/**
- * Next value to use when assigning sequential IDs to each mutation batch.
- *
- * NOTE: There can only be one FSTLevelDBMutationQueue for a given db at a time, hence it is safe
- * to track nextBatchID as an instance-level property. Should we ever relax this constraint we'll
- * need to revisit this.
- */
-@property(nonatomic, assign) BatchId nextBatchID;
-
-/** A write-through cache copy of the metadata describing the current queue. */
-@property(nonatomic, strong, nullable) FSTPBMutationQueue *metadata;
-
-@property(nonatomic, strong, readonly) FSTLocalSerializer *serializer;
+                    serializer:(FSTLocalSerializer *)serializer
+                      delegate:(std::unique_ptr<LevelDbMutationQueue>)delegate
+    NS_DESIGNATED_INITIALIZER;
 
 @end
 
 @implementation FSTLevelDBMutationQueue {
   // This instance is owned by FSTLevelDB; avoid a retain cycle.
-  __weak FSTLevelDB *_db;
+  //__weak FSTLevelDB *_db;
 
   /** The normalized userID (e.g. nil UID => @"" userID) used in our LevelDB keys. */
-  std::string _userID;
+  // std::string _userID;
+
+  std::unique_ptr<LevelDbMutationQueue> _delegate;
 }
 
 + (instancetype)mutationQueueWithUser:(const User &)user
@@ -100,460 +102,80 @@ using leveldb::WriteOptions;
                            serializer:(FSTLocalSerializer *)serializer {
   std::string userID = user.is_authenticated() ? user.uid() : "";
 
-  return [[FSTLevelDBMutationQueue alloc] initWithUserID:std::move(userID)
-                                                      db:db
-                                              serializer:serializer];
+  return [[FSTLevelDBMutationQueue alloc]
+      initWithUserID:std::move(userID)
+                  db:db
+          serializer:serializer
+            delegate:absl::make_unique<LevelDbMutationQueue>(user, db, serializer)];
 }
 
 - (instancetype)initWithUserID:(std::string)userID
                             db:(FSTLevelDB *)db
-                    serializer:(FSTLocalSerializer *)serializer {
+                    serializer:(FSTLocalSerializer *)serializer
+                      delegate:(std::unique_ptr<LevelDbMutationQueue>)delegate {
   if (self = [super init]) {
-    _userID = std::move(userID);
-    _db = db;
-    _serializer = serializer;
+    _delegate = std::move(delegate);
   }
   return self;
 }
 
 - (void)start {
-  self.nextBatchID = [FSTLevelDBMutationQueue loadNextBatchIDFromDB:_db.ptr];
-
-  std::string key = [self keyForCurrentMutationQueue];
-  FSTPBMutationQueue *metadata = [self metadataForKey:key];
-  if (!metadata) {
-    metadata = [FSTPBMutationQueue message];
-  }
-  self.metadata = metadata;
-}
-
-+ (BatchId)loadNextBatchIDFromDB:(DB *)db {
-  // TODO(gsoltis): implement Prev() and SeekToLast() on LevelDbTransaction::Iterator, then port
-  // this to a transaction.
-  std::unique_ptr<Iterator> it(db->NewIterator(LevelDbTransaction::DefaultReadOptions()));
-
-  auto tableKey = LevelDbMutationKey::KeyPrefix();
-
-  LevelDbMutationKey rowKey;
-  BatchId maxBatchID = kBatchIdUnknown;
-
-  BOOL moreUserIDs = NO;
-  std::string nextUserID;
-
-  it->Seek(tableKey);
-  if (it->Valid() && rowKey.Decode(MakeStringView(it->key()))) {
-    moreUserIDs = YES;
-    nextUserID = rowKey.user_id();
-  }
-
-  // This loop assumes that nextUserId contains the next username at the start of the iteration.
-  while (moreUserIDs) {
-    // Compute the first key after the last mutation for nextUserID.
-    auto userEnd = LevelDbMutationKey::KeyPrefix(nextUserID);
-    userEnd = util::PrefixSuccessor(userEnd);
-
-    // Seek to that key with the intent of finding the boundary between nextUserID's mutations
-    // and the one after that (if any).
-    it->Seek(userEnd);
-
-    // At this point there are three possible cases to handle differently. Each case must prepare
-    // the next iteration (by assigning to nextUserID or setting moreUserIDs = NO) and seek the
-    // iterator to the last row in the current user's mutation sequence.
-    if (!it->Valid()) {
-      // The iterator is past the last row altogether (there are no additional userIDs and now
-      // rows in any table after mutations). The last row will have the highest batchID.
-      moreUserIDs = NO;
-      it->SeekToLast();
-
-    } else if (rowKey.Decode(MakeStringView(it->key()))) {
-      // The iterator is valid and the key decoded successfully so the next user was just decoded.
-      nextUserID = rowKey.user_id();
-      it->Prev();
-
-    } else {
-      // The iterator is past the end of the mutations table but there are other rows.
-      moreUserIDs = NO;
-      it->Prev();
-    }
-
-    // In all the cases above there was at least one row for the current user and each case has
-    // set things up such that iterator points to it.
-    if (!rowKey.Decode(MakeStringView(it->key()))) {
-      HARD_FAIL("There should have been a key previous to %s", userEnd);
-    }
-
-    if (rowKey.batch_id() > maxBatchID) {
-      maxBatchID = rowKey.batch_id();
-    }
-  }
-
-  return maxBatchID + 1;
+  _delegate->Start();
 }
 
 - (BOOL)isEmpty {
-  std::string userKey = LevelDbMutationKey::KeyPrefix(_userID);
-
-  auto it = _db.currentTransaction->NewIterator();
-  it->Seek(userKey);
-
-  BOOL empty = YES;
-  if (it->Valid() && absl::StartsWith(it->key(), userKey)) {
-    empty = NO;
-  }
-
-  return empty;
+  return _delegate->IsEmpty();
 }
 
 - (void)acknowledgeBatch:(FSTMutationBatch *)batch streamToken:(nullable NSData *)streamToken {
-  FSTPBMutationQueue *metadata = self.metadata;
-  metadata.lastStreamToken = streamToken;
-
-  _db.currentTransaction->Put([self keyForCurrentMutationQueue], metadata);
+  _delegate->AcknowledgeBatch(batch, streamToken);
 }
 
 - (nullable NSData *)lastStreamToken {
-  return self.metadata.lastStreamToken;
+  return _delegate->GetLastStreamToken();
 }
 
 - (void)setLastStreamToken:(nullable NSData *)streamToken {
-  FSTPBMutationQueue *metadata = self.metadata;
-  metadata.lastStreamToken = streamToken;
-
-  _db.currentTransaction->Put([self keyForCurrentMutationQueue], metadata);
-}
-
-- (std::string)keyForCurrentMutationQueue {
-  return LevelDbMutationQueueKey::Key(_userID);
-}
-
-- (nullable FSTPBMutationQueue *)metadataForKey:(const std::string &)key {
-  std::string value;
-  Status status = _db.currentTransaction->Get(key, &value);
-  if (status.ok()) {
-    return [self parsedMetadata:value];
-  } else if (status.IsNotFound()) {
-    return nil;
-  } else {
-    HARD_FAIL("metadataForKey: failed loading key %s with status: %s", key, status.ToString());
-  }
+  _delegate->SetLastStreamToken(streamToken);
 }
 
 - (FSTMutationBatch *)addMutationBatchWithWriteTime:(FIRTimestamp *)localWriteTime
                                           mutations:(NSArray<FSTMutation *> *)mutations {
-  BatchId batchID = self.nextBatchID;
-  self.nextBatchID += 1;
-
-  FSTMutationBatch *batch = [[FSTMutationBatch alloc] initWithBatchID:batchID
-                                                       localWriteTime:localWriteTime
-                                                            mutations:mutations];
-  std::string key = [self mutationKeyForBatch:batch];
-  _db.currentTransaction->Put(key, [self.serializer encodedMutationBatch:batch]);
-
-  // Store an empty value in the index which is equivalent to serializing a GPBEmpty message. In the
-  // future if we wanted to store some other kind of value here, we can parse these empty values as
-  // with some other protocol buffer (and the parser will see all default values).
-  std::string emptyBuffer;
-
-  for (FSTMutation *mutation in mutations) {
-    key = LevelDbDocumentMutationKey::Key(_userID, mutation.key, batchID);
-    _db.currentTransaction->Put(key, emptyBuffer);
-  }
-
-  return batch;
+  return _delegate->AddMutationBatch(localWriteTime, mutations);
 }
 
 - (nullable FSTMutationBatch *)lookupMutationBatch:(BatchId)batchID {
-  std::string key = [self mutationKeyForBatchID:batchID];
-
-  std::string value;
-  Status status = _db.currentTransaction->Get(key, &value);
-  if (!status.ok()) {
-    if (status.IsNotFound()) {
-      return nil;
-    }
-    HARD_FAIL("Lookup mutation batch (%s, %s) failed with status: %s", _userID, batchID,
-              status.ToString());
-  }
-
-  return [self decodedMutationBatch:value];
+  return _delegate->LookupMutationBatch(batchID);
 }
 
 - (nullable FSTMutationBatch *)nextMutationBatchAfterBatchID:(BatchId)batchID {
-  BatchId nextBatchID = batchID + 1;
-
-  std::string key = [self mutationKeyForBatchID:nextBatchID];
-  auto it = _db.currentTransaction->NewIterator();
-  it->Seek(key);
-
-  LevelDbMutationKey rowKey;
-  if (!it->Valid() || !rowKey.Decode(it->key())) {
-    // Past the last row in the DB or out of the mutations table
-    return nil;
-  }
-
-  if (rowKey.user_id() != _userID) {
-    // Jumped past the last mutation for this user
-    return nil;
-  }
-
-  HARD_ASSERT(rowKey.batch_id() >= nextBatchID, "Should have found mutation after %s", nextBatchID);
-  return [self decodedMutationBatch:it->value()];
+  return _delegate->NextMutationBatchAfterBatchId(batchID);
 }
 
 - (NSArray<FSTMutationBatch *> *)allMutationBatchesAffectingDocumentKey:
     (const DocumentKey &)documentKey {
-  // Scan the document-mutation index starting with a prefix starting with the given documentKey.
-  std::string indexPrefix = LevelDbDocumentMutationKey::KeyPrefix(_userID, documentKey.path());
-  auto indexIterator = _db.currentTransaction->NewIterator();
-  indexIterator->Seek(indexPrefix);
-
-  // Simultaneously scan the mutation queue. This works because each (key, batchID) pair is unique
-  // and ordered, so when scanning a table prefixed by exactly key, all the batchIDs encountered
-  // will be unique and in order.
-  std::string mutationsPrefix = LevelDbMutationKey::KeyPrefix(_userID);
-  auto mutationIterator = _db.currentTransaction->NewIterator();
-
-  NSMutableArray *result = [NSMutableArray array];
-  LevelDbDocumentMutationKey rowKey;
-  for (; indexIterator->Valid(); indexIterator->Next()) {
-    // Only consider rows matching exactly the specific key of interest. Index rows have this
-    // form (with markers in brackets):
-    //
-    // <User>user <Path>collection <Path>doc <BatchId>2 <Terminator>
-    // <User>user <Path>collection <Path>doc <BatchId>3 <Terminator>
-    // <User>user <Path>collection <Path>doc <Path>sub <Path>doc <BatchId>3 <Terminator>
-    //
-    // Note that Path markers sort after BatchId markers so this means that when searching for
-    // collection/doc, all the entries for it will be contiguous in the table, allowing a break
-    // after any mismatch.
-    if (!absl::StartsWith(indexIterator->key(), indexPrefix) ||
-        !rowKey.Decode(indexIterator->key()) || rowKey.document_key() != documentKey) {
-      break;
-    }
-
-    // Each row is a unique combination of key and batchID, so this foreign key reference can
-    // only occur once.
-    std::string mutationKey = LevelDbMutationKey::Key(_userID, rowKey.batch_id());
-    mutationIterator->Seek(mutationKey);
-    if (!mutationIterator->Valid() || mutationIterator->key() != mutationKey) {
-      HARD_FAIL("Dangling document-mutation reference found: "
-                "%s points to %s; seeking there found %s",
-                DescribeKey(indexIterator), DescribeKey(mutationKey),
-                DescribeKey(mutationIterator));
-    }
-
-    [result addObject:[self decodedMutationBatch:mutationIterator->value()]];
-  }
-  return result;
+  return toNSArray(_delegate->AllMutationBatchesAffectingDocumentKey(documentKey));
 }
 
 - (NSArray<FSTMutationBatch *> *)allMutationBatchesAffectingDocumentKeys:
     (const DocumentKeySet &)documentKeys {
-  // Take a pass through the document keys and collect the set of unique mutation batchIDs that
-  // affect them all. Some batches can affect more than one key.
-  std::set<BatchId> batchIDs;
-
-  auto indexIterator = _db.currentTransaction->NewIterator();
-  LevelDbDocumentMutationKey rowKey;
-  for (const DocumentKey &documentKey : documentKeys) {
-    std::string indexPrefix = LevelDbDocumentMutationKey::KeyPrefix(_userID, documentKey.path());
-    for (indexIterator->Seek(indexPrefix); indexIterator->Valid(); indexIterator->Next()) {
-      // Only consider rows matching exactly the specific key of interest. Index rows have this
-      // form (with markers in brackets):
-      //
-      // <User>user <Path>collection <Path>doc <BatchId>2 <Terminator>
-      // <User>user <Path>collection <Path>doc <BatchId>3 <Terminator>
-      // <User>user <Path>collection <Path>doc <Path>sub <Path>doc <BatchId>3 <Terminator>
-      //
-      // Note that Path markers sort after BatchId markers so this means that when searching for
-      // collection/doc, all the entries for it will be contiguous in the table, allowing a break
-      // after any mismatch.
-      if (!absl::StartsWith(indexIterator->key(), indexPrefix) ||
-          !rowKey.Decode(indexIterator->key()) || rowKey.document_key() != documentKey) {
-        break;
-      }
-
-      batchIDs.insert(rowKey.batch_id());
-    }
-  }
-
-  return [self allMutationBatchesWithBatchIDs:batchIDs];
+  return toNSArray(_delegate->AllMutationBatchesAffectingDocumentKeys(documentKeys));
 }
 
 - (NSArray<FSTMutationBatch *> *)allMutationBatchesAffectingQuery:(FSTQuery *)query {
-  HARD_ASSERT(![query isDocumentQuery], "Document queries shouldn't go down this path");
-
-  const ResourcePath &queryPath = query.path;
-  size_t immediateChildrenPathLength = queryPath.size() + 1;
-
-  // TODO(mcg): Actually implement a single-collection query
-  //
-  // This is actually executing an ancestor query, traversing the whole subtree below the
-  // collection which can be horrifically inefficient for some structures. The right way to
-  // solve this is to implement the full value index, but that's not in the cards in the near
-  // future so this is the best we can do for the moment.
-  //
-  // Since we don't yet index the actual properties in the mutations, our current approach is to
-  // just return all mutation batches that affect documents in the collection being queried.
-  //
-  // Unlike allMutationBatchesAffectingDocumentKey, this iteration will scan the document-mutation
-  // index for more than a single document so the associated batchIDs will be neither necessarily
-  // unique nor in order. This means an efficient simultaneous scan isn't possible.
-  std::string indexPrefix = LevelDbDocumentMutationKey::KeyPrefix(_userID, queryPath);
-  auto indexIterator = _db.currentTransaction->NewIterator();
-  indexIterator->Seek(indexPrefix);
-
-  LevelDbDocumentMutationKey rowKey;
-
-  // Collect up unique batchIDs encountered during a scan of the index. Use a set<BatchId> to
-  // accumulate batch IDs so they can be traversed in order in a scan of the main table.
-  //
-  // This method is faster than performing lookups of the keys with _db->Get and keeping a hash of
-  // batchIDs that have already been looked up. The performance difference is minor for small
-  // numbers of keys but > 30% faster for larger numbers of keys.
-  std::set<BatchId> uniqueBatchIDs;
-  for (; indexIterator->Valid(); indexIterator->Next()) {
-    if (!absl::StartsWith(indexIterator->key(), indexPrefix) ||
-        !rowKey.Decode(indexIterator->key())) {
-      break;
-    }
-
-    // Rows with document keys more than one segment longer than the query path can't be matches.
-    // For example, a query on 'rooms' can't match the document /rooms/abc/messages/xyx.
-    // TODO(mcg): we'll need a different scanner when we implement ancestor queries.
-    if (rowKey.document_key().path().size() != immediateChildrenPathLength) {
-      continue;
-    }
-
-    uniqueBatchIDs.insert(rowKey.batch_id());
-  }
-
-  return [self allMutationBatchesWithBatchIDs:uniqueBatchIDs];
-}
-
-/**
- * Constructs an array of matching batches, sorted by batchID to ensure that multiple mutations
- * affecting the same document key are applied in order.
- */
-- (NSArray<FSTMutationBatch *> *)allMutationBatchesWithBatchIDs:
-    (const std::set<BatchId> &)batchIDs {
-  NSMutableArray *result = [NSMutableArray array];
-
-  // Given an ordered set of unique batchIDs perform a skipping scan over the main table to find
-  // the mutation batches.
-  auto mutationIterator = _db.currentTransaction->NewIterator();
-  for (BatchId batchID : batchIDs) {
-    std::string mutationKey = LevelDbMutationKey::Key(_userID, batchID);
-    mutationIterator->Seek(mutationKey);
-    if (!mutationIterator->Valid() || mutationIterator->key() != mutationKey) {
-      HARD_FAIL("Dangling document-mutation reference found: "
-                "Missing batch %s; seeking there found %s",
-                DescribeKey(mutationKey), DescribeKey(mutationIterator));
-    }
-
-    [result addObject:[self decodedMutationBatch:mutationIterator->value()]];
-  }
-  return result;
+  return toNSArray(_delegate->AllMutationBatchesAffectingQuery(query));
 }
 
 - (NSArray<FSTMutationBatch *> *)allMutationBatches {
-  std::string userKey = LevelDbMutationKey::KeyPrefix(_userID);
-
-  auto it = _db.currentTransaction->NewIterator();
-  it->Seek(userKey);
-
-  NSMutableArray *result = [NSMutableArray array];
-  for (; it->Valid() && absl::StartsWith(it->key(), userKey); it->Next()) {
-    [result addObject:[self decodedMutationBatch:it->value()]];
-  }
-
-  return result;
+  return toNSArray(_delegate->AllMutationBatches());
 }
 
 - (void)removeMutationBatch:(FSTMutationBatch *)batch {
-  auto checkIterator = _db.currentTransaction->NewIterator();
-
-  BatchId batchID = batch.batchID;
-  std::string key = LevelDbMutationKey::Key(_userID, batchID);
-
-  // As a sanity check, verify that the mutation batch exists before deleting it.
-  checkIterator->Seek(key);
-  HARD_ASSERT(checkIterator->Valid(), "Mutation batch %s did not exist", DescribeKey(key));
-
-  HARD_ASSERT(key == checkIterator->key(), "Mutation batch %s not found; found %s",
-              DescribeKey(key), DescribeKey(checkIterator));
-
-  _db.currentTransaction->Delete(key);
-
-  for (FSTMutation *mutation in batch.mutations) {
-    key = LevelDbDocumentMutationKey::Key(_userID, mutation.key, batchID);
-    _db.currentTransaction->Delete(key);
-    [_db.referenceDelegate removeMutationReference:mutation.key];
-  }
+  _delegate->RemoveMutationBatch(batch);
 }
 
 - (void)performConsistencyCheck {
-  if (![self isEmpty]) {
-    return;
-  }
-
-  // Verify that there are no entries in the document-mutation index if the queue is empty.
-  std::string indexPrefix = LevelDbDocumentMutationKey::KeyPrefix(_userID);
-  auto indexIterator = _db.currentTransaction->NewIterator();
-  indexIterator->Seek(indexPrefix);
-
-  std::vector<std::string> danglingMutationReferences;
-
-  for (; indexIterator->Valid(); indexIterator->Next()) {
-    // Only consider rows matching this index prefix for the current user.
-    if (!absl::StartsWith(indexIterator->key(), indexPrefix)) {
-      break;
-    }
-
-    danglingMutationReferences.push_back(DescribeKey(indexIterator));
-  }
-
-  HARD_ASSERT(danglingMutationReferences.empty(),
-              "Document leak -- detected dangling mutation references when queue "
-              "is empty. Dangling keys: %s",
-              util::ToString(danglingMutationReferences));
-}
-
-- (std::string)mutationKeyForBatch:(FSTMutationBatch *)batch {
-  return LevelDbMutationKey::Key(_userID, batch.batchID);
-}
-
-- (std::string)mutationKeyForBatchID:(BatchId)batchID {
-  return LevelDbMutationKey::Key(_userID, batchID);
-}
-
-/** Parses the MutationQueue metadata from the given LevelDB row contents. */
-- (FSTPBMutationQueue *)parsedMetadata:(Slice)slice {
-  NSData *data = [[NSData alloc] initWithBytesNoCopy:(void *)slice.data()
-                                              length:slice.size()
-                                        freeWhenDone:NO];
-
-  NSError *error;
-  FSTPBMutationQueue *proto = [FSTPBMutationQueue parseFromData:data error:&error];
-  if (!proto) {
-    HARD_FAIL("FSTPBMutationQueue failed to parse: %s", error);
-  }
-
-  return proto;
-}
-
-- (FSTMutationBatch *)decodedMutationBatch:(absl::string_view)encoded {
-  NSData *data = [[NSData alloc] initWithBytesNoCopy:(void *)encoded.data()
-                                              length:encoded.size()
-                                        freeWhenDone:NO];
-
-  NSError *error;
-  FSTPBWriteBatch *proto = [FSTPBWriteBatch parseFromData:data error:&error];
-  if (!proto) {
-    HARD_FAIL("FSTPBMutationBatch failed to parse: %s", error);
-  }
-
-  return [self.serializer decodedMutationBatch:proto];
+  _delegate->PerformConsistencyCheck();
 }
 
 @end

--- a/Firestore/Source/Local/FSTMemoryMutationQueue.mm
+++ b/Firestore/Source/Local/FSTMemoryMutationQueue.mm
@@ -65,11 +65,11 @@ static NSArray<FSTMutationBatch *> *toNSArray(const std::vector<FSTMutationBatch
 }
 
 - (void)setLastStreamToken:(NSData *_Nullable)streamToken {
-  _delegate->set_last_stream_token(streamToken);
+  _delegate->SetLastStreamToken(streamToken);
 }
 
 - (NSData *_Nullable)lastStreamToken {
-  return _delegate->last_stream_token();
+  return _delegate->GetLastStreamToken();
 }
 
 #pragma mark - FSTMutationQueue implementation
@@ -79,7 +79,7 @@ static NSArray<FSTMutationBatch *> *toNSArray(const std::vector<FSTMutationBatch
 }
 
 - (BOOL)isEmpty {
-  return _delegate->is_empty();
+  return _delegate->IsEmpty();
 }
 
 - (void)acknowledgeBatch:(FSTMutationBatch *)batch streamToken:(nullable NSData *)streamToken {

--- a/Firestore/core/src/firebase/firestore/local/leveldb_mutation_queue.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_mutation_queue.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_LEVELDB_MUTATION_QUEUE_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_LEVELDB_MUTATION_QUEUE_H_
+
+#if !defined(__OBJC__)
+#error "For now, this file must only be included by ObjC source files."
+#endif  // !defined(__OBJC__)
+
+#import <Foundation/Foundation.h>
+
+#include <set>
+#include <string>
+#include <vector>
+
+#import "Firestore/Source/Public/FIRTimestamp.h"
+
+#include "Firestore/core/src/firebase/firestore/auth/user.h"
+#include "Firestore/core/src/firebase/firestore/local/leveldb_key.h"
+#include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
+#include "absl/strings/string_view.h"
+#include "leveldb/db.h"
+
+@class FSTLevelDB;
+@class FSTLocalSerializer;
+@class FSTMutation;
+@class FSTMutationBatch;
+@class FSTPBMutationQueue;
+@class FSTQuery;
+
+NS_ASSUME_NONNULL_BEGIN
+
+namespace firebase {
+namespace firestore {
+namespace local {
+
+/**
+ * Returns one larger than the largest batch ID that has been stored. If there
+ * are no mutations returns 0. Note that batch IDs are global.
+ */
+model::BatchId LoadNextBatchIdFromDb(leveldb::DB* db);
+
+class LevelDbMutationQueue {
+ public:
+  LevelDbMutationQueue(const auth::User& user,
+                       FSTLevelDB* db,
+                       FSTLocalSerializer* serializer);
+
+  void Start();
+
+  bool IsEmpty();
+
+  void AcknowledgeBatch(FSTMutationBatch* batch,
+                        NSData* _Nullable stream_token);
+
+  FSTMutationBatch* AddMutationBatch(FIRTimestamp* local_write_time,
+                                     NSArray<FSTMutation*>* mutations);
+
+  void RemoveMutationBatch(FSTMutationBatch* batch);
+
+  const std::vector<FSTMutationBatch*> AllMutationBatches();
+
+  std::vector<FSTMutationBatch*> AllMutationBatchesAffectingDocumentKeys(
+      const model::DocumentKeySet& document_keys);
+
+  std::vector<FSTMutationBatch*> AllMutationBatchesAffectingDocumentKey(
+      const model::DocumentKey& key);
+
+  std::vector<FSTMutationBatch*> AllMutationBatchesAffectingQuery(
+      FSTQuery* query);
+
+  FSTMutationBatch* _Nullable LookupMutationBatch(model::BatchId batch_id);
+
+  FSTMutationBatch* _Nullable NextMutationBatchAfterBatchId(
+      model::BatchId batch_id);
+
+  void PerformConsistencyCheck();
+
+  NSData* _Nullable GetLastStreamToken();
+
+  void SetLastStreamToken(NSData* _Nullable stream_token);
+
+ private:
+  /**
+   * Constructs a vector of matching batches, sorted by batchID to ensure that
+   * multiple mutations affecting the same document key are applied in order.
+   */
+  std::vector<FSTMutationBatch*> AllMutationBatchesWithIds(
+      const std::set<model::BatchId>& batch_ids);
+
+  std::string mutation_queue_key() {
+    return LevelDbMutationQueueKey::Key(user_id_);
+  }
+
+  std::string mutation_batch_key(model::BatchId batch_id) {
+    return LevelDbMutationKey::Key(user_id_, batch_id);
+  }
+
+  /** Parses the MutationQueue metadata from the given LevelDB row contents. */
+  FSTPBMutationQueue* _Nullable MetadataForKey(const std::string& key);
+
+  FSTMutationBatch* ParseMutationBatch(absl::string_view encoded);
+
+  // This instance is owned by FSTLevelDB; avoid a retain cycle.
+  __weak FSTLevelDB* db_;
+
+  FSTLocalSerializer* serializer_;
+
+  /**
+   * The normalized userID (e.g. nil UID => @"" userID) used in our LevelDB
+   * keys.
+   */
+  std::string user_id_;
+
+  /**
+   * Next value to use when assigning sequential IDs to each mutation batch.
+   *
+   * NOTE: There can only be one LevelDbMutationQueue for a given db at a time,
+   * hence it is safe to track next_batch_id_ as an instance-level property.
+   * Should we ever relax this constraint we'll need to revisit this.
+   */
+  model::BatchId next_batch_id_;
+
+  /**
+   * A write-through cache copy of the metadata describing the current queue.
+   */
+  FSTPBMutationQueue* _Nullable metadata_;
+};
+
+}  // namespace local
+}  // namespace firestore
+}  // namespace firebase
+
+NS_ASSUME_NONNULL_END
+
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_LEVELDB_MUTATION_QUEUE_H_

--- a/Firestore/core/src/firebase/firestore/local/leveldb_mutation_queue.mm
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_mutation_queue.mm
@@ -1,0 +1,519 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/local/leveldb_mutation_queue.h"
+
+#include <memory>
+
+#import "Firestore/Protos/objc/firestore/local/Mutation.pbobjc.h"
+#import "Firestore/Source/Core/FSTQuery.h"
+#import "Firestore/Source/Local/FSTLevelDB.h"
+#import "Firestore/Source/Local/FSTLocalSerializer.h"
+#import "Firestore/Source/Model/FSTMutation.h"
+#import "Firestore/Source/Model/FSTMutationBatch.h"
+
+#include "Firestore/core/src/firebase/firestore/local/leveldb_util.h"
+#include "Firestore/core/src/firebase/firestore/model/mutation_batch.h"
+#include "Firestore/core/src/firebase/firestore/model/resource_path.h"
+#include "Firestore/core/src/firebase/firestore/util/string_util.h"
+#include "absl/strings/match.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+namespace firebase {
+namespace firestore {
+namespace local {
+
+using auth::User;
+using leveldb::DB;
+using leveldb::Iterator;
+using leveldb::Status;
+using model::BatchId;
+using model::DocumentKey;
+using model::DocumentKeySet;
+using model::kBatchIdUnknown;
+using model::ResourcePath;
+
+BatchId LoadNextBatchIdFromDb(DB* db) {
+  // TODO(gsoltis): implement Prev() and SeekToLast() on
+  // LevelDbTransaction::Iterator, then port this to a transaction.
+  std::unique_ptr<Iterator> it(
+      db->NewIterator(LevelDbTransaction::DefaultReadOptions()));
+
+  auto table_key = LevelDbMutationKey::KeyPrefix();
+
+  LevelDbMutationKey row_key;
+  BatchId max_batch_id = kBatchIdUnknown;
+
+  BOOL more_user_ids = NO;
+  std::string next_user_id;
+
+  it->Seek(table_key);
+  if (it->Valid() && row_key.Decode(MakeStringView(it->key()))) {
+    more_user_ids = YES;
+    next_user_id = row_key.user_id();
+  }
+
+  // This loop assumes that nextUserId contains the next username at the start
+  // of the iteration.
+  while (more_user_ids) {
+    // Compute the first key after the last mutation for next_user_id.
+    auto user_end = LevelDbMutationKey::KeyPrefix(next_user_id);
+    user_end = util::PrefixSuccessor(user_end);
+
+    // Seek to that key with the intent of finding the boundary between
+    // next_user_id's mutations and the one after that (if any).
+    it->Seek(user_end);
+
+    // At this point there are three possible cases to handle differently. Each
+    // case must prepare the next iteration (by assigning to next_user_id or
+    // setting more_user_ids = NO) and seek the iterator to the last row in the
+    // current user's mutation sequence.
+    if (!it->Valid()) {
+      // The iterator is past the last row altogether (there are no additional
+      // userIDs and now rows in any table after mutations). The last row will
+      // have the highest batchID.
+      more_user_ids = NO;
+      it->SeekToLast();
+
+    } else if (row_key.Decode(MakeStringView(it->key()))) {
+      // The iterator is valid and the key decoded successfully so the next user
+      // was just decoded.
+      next_user_id = row_key.user_id();
+      it->Prev();
+
+    } else {
+      // The iterator is past the end of the mutations table but there are other
+      // rows.
+      more_user_ids = NO;
+      it->Prev();
+    }
+
+    // In all the cases above there was at least one row for the current user
+    // and each case has set things up such that iterator points to it.
+    if (!row_key.Decode(MakeStringView(it->key()))) {
+      HARD_FAIL("There should have been a key previous to %s", user_end);
+    }
+
+    if (row_key.batch_id() > max_batch_id) {
+      max_batch_id = row_key.batch_id();
+    }
+  }
+
+  return max_batch_id + 1;
+}
+
+LevelDbMutationQueue::LevelDbMutationQueue(const User& user,
+                                           FSTLevelDB* db,
+                                           FSTLocalSerializer* serializer)
+    : db_(db),
+      serializer_(serializer),
+      user_id_(user.is_authenticated() ? user.uid() : "") {
+}
+
+void LevelDbMutationQueue::Start() {
+  next_batch_id_ = LoadNextBatchIdFromDb(db_.ptr);
+
+  std::string key = mutation_queue_key();
+  FSTPBMutationQueue* metadata = MetadataForKey(key);
+  if (!metadata) {
+    metadata = [FSTPBMutationQueue message];
+  }
+  metadata_ = metadata;
+}
+
+bool LevelDbMutationQueue::IsEmpty() {
+  std::string user_key = LevelDbMutationKey::KeyPrefix(user_id_);
+
+  auto it = db_.currentTransaction->NewIterator();
+  it->Seek(user_key);
+
+  bool empty = true;
+  if (it->Valid() && absl::StartsWith(it->key(), user_key)) {
+    empty = false;
+  }
+  return empty;
+}
+
+void LevelDbMutationQueue::AcknowledgeBatch(FSTMutationBatch* batch,
+                                            NSData* _Nullable stream_token) {
+  SetLastStreamToken(stream_token);
+}
+
+FSTMutationBatch* LevelDbMutationQueue::AddMutationBatch(
+    FIRTimestamp* local_write_time, NSArray<FSTMutation*>* mutations) {
+  BatchId batch_id = next_batch_id_;
+  next_batch_id_++;
+
+  FSTMutationBatch* batch =
+      [[FSTMutationBatch alloc] initWithBatchID:batch_id
+                                 localWriteTime:local_write_time
+                                      mutations:mutations];
+  std::string key = mutation_batch_key(batch_id);
+  db_.currentTransaction->Put(key, [serializer_ encodedMutationBatch:batch]);
+
+  // Store an empty value in the index which is equivalent to serializing a
+  // GPBEmpty message. In the future if we wanted to store some other kind of
+  // value here, we can parse these empty values as with some other protocol
+  // buffer (and the parser will see all default values).
+  std::string empty_buffer;
+
+  for (FSTMutation* mutation in mutations) {
+    key = LevelDbDocumentMutationKey::Key(user_id_, mutation.key, batch_id);
+    db_.currentTransaction->Put(key, empty_buffer);
+  }
+
+  return batch;
+}
+
+void LevelDbMutationQueue::RemoveMutationBatch(FSTMutationBatch* batch) {
+  auto check_iterator = db_.currentTransaction->NewIterator();
+
+  BatchId batch_id = batch.batchID;
+  std::string key = mutation_batch_key(batch_id);
+
+  // As a sanity check, verify that the mutation batch exists before deleting
+  // it.
+  check_iterator->Seek(key);
+  HARD_ASSERT(check_iterator->Valid(), "Mutation batch %s did not exist",
+              DescribeKey(key));
+
+  HARD_ASSERT(key == check_iterator->key(),
+              "Mutation batch %s not found; found %s", DescribeKey(key),
+              DescribeKey(check_iterator->key()));
+
+  db_.currentTransaction->Delete(key);
+
+  for (FSTMutation* mutation in batch.mutations) {
+    key = LevelDbDocumentMutationKey::Key(user_id_, mutation.key, batch_id);
+    db_.currentTransaction->Delete(key);
+    [db_.referenceDelegate removeMutationReference:mutation.key];
+  }
+}
+
+const std::vector<FSTMutationBatch*>
+LevelDbMutationQueue::AllMutationBatches() {
+  std::string user_key = LevelDbMutationKey::KeyPrefix(user_id_);
+
+  auto it = db_.currentTransaction->NewIterator();
+  it->Seek(user_key);
+  std::vector<FSTMutationBatch*> result;
+  for (; it->Valid() && absl::StartsWith(it->key(), user_key); it->Next()) {
+    result.push_back(ParseMutationBatch(it->value()));
+  }
+  return result;
+}
+
+std::vector<FSTMutationBatch*>
+LevelDbMutationQueue::AllMutationBatchesAffectingDocumentKeys(
+    const DocumentKeySet& document_keys) {
+  // Take a pass through the document keys and collect the set of unique
+  // mutation batch_ids that affect them all. Some batches can affect more than
+  // one key.
+  std::set<BatchId> batch_ids;
+
+  auto index_iterator = db_.currentTransaction->NewIterator();
+  LevelDbDocumentMutationKey row_key;
+  for (const DocumentKey& document_key : document_keys) {
+    std::string index_prefix =
+        LevelDbDocumentMutationKey::KeyPrefix(user_id_, document_key.path());
+    for (index_iterator->Seek(index_prefix); index_iterator->Valid();
+         index_iterator->Next()) {
+      // Only consider rows matching exactly the specific key of interest. Index
+      // rows have this form (with markers in brackets):
+      //
+      // <User>user <Path>collection <Path>doc <BatchId>2 <Terminator>
+      // <User>user <Path>collection <Path>doc <BatchId>3 <Terminator>
+      // <User>user <Path>collection <Path>doc <Path>sub <Path>doc <BatchId>3
+      // <Terminator>
+      //
+      // Note that Path markers sort after BatchId markers so this means that
+      // when searching for collection/doc, all the entries for it will be
+      // contiguous in the table, allowing a break after any mismatch.
+      if (!absl::StartsWith(index_iterator->key(), index_prefix) ||
+          !row_key.Decode(index_iterator->key()) ||
+          row_key.document_key() != document_key) {
+        break;
+      }
+
+      batch_ids.insert(row_key.batch_id());
+    }
+  }
+
+  return AllMutationBatchesWithIds(batch_ids);
+}
+
+std::vector<FSTMutationBatch*>
+LevelDbMutationQueue::AllMutationBatchesAffectingDocumentKey(
+    const DocumentKey& key) {
+  // Scan the document-mutation index starting with a prefix starting with the
+  // given documentKey.
+  std::string index_prefix =
+      LevelDbDocumentMutationKey::KeyPrefix(user_id_, key.path());
+  auto index_iterator = db_.currentTransaction->NewIterator();
+  index_iterator->Seek(index_prefix);
+
+  // Simultaneously scan the mutation queue. This works because each (key,
+  // batchID) pair is unique and ordered, so when scanning a table prefixed by
+  // exactly key, all the batchIDs encountered will be unique and in order.
+  std::string mutations_prefix = LevelDbMutationKey::KeyPrefix(user_id_);
+  auto mutation_iterator = db_.currentTransaction->NewIterator();
+
+  std::vector<FSTMutationBatch*> result;
+  LevelDbDocumentMutationKey row_key;
+  for (; index_iterator->Valid(); index_iterator->Next()) {
+    // Only consider rows matching exactly the specific key of interest. Index
+    // rows have this form (with markers in brackets):
+    //
+    // <User>user <Path>collection <Path>doc <BatchId>2 <Terminator>
+    // <User>user <Path>collection <Path>doc <BatchId>3 <Terminator>
+    // <User>user <Path>collection <Path>doc <Path>sub <Path>doc <BatchId>3
+    // <Terminator>
+    //
+    // Note that Path markers sort after BatchId markers so this means that when
+    // searching for collection/doc, all the entries for it will be contiguous
+    // in the table, allowing a break after any mismatch.
+    if (!absl::StartsWith(index_iterator->key(), index_prefix) ||
+        !row_key.Decode(index_iterator->key()) ||
+        row_key.document_key() != key) {
+      break;
+    }
+
+    // Each row is a unique combination of key and batchID, so this foreign key
+    // reference can only occur once.
+    std::string mutation_key = mutation_batch_key(row_key.batch_id());
+    mutation_iterator->Seek(mutation_key);
+    if (!mutation_iterator->Valid() ||
+        mutation_iterator->key() != mutation_key) {
+      HARD_FAIL("Dangling document-mutation reference found: "
+                "%s points to %s; seeking there found %s",
+                DescribeKey(index_iterator), DescribeKey(mutation_key),
+                DescribeKey(mutation_iterator));
+    }
+
+    result.push_back(ParseMutationBatch(mutation_iterator->value()));
+  }
+  return result;
+}
+
+std::vector<FSTMutationBatch*>
+LevelDbMutationQueue::AllMutationBatchesAffectingQuery(FSTQuery* query) {
+  HARD_ASSERT(![query isDocumentQuery],
+              "Document queries shouldn't go down this path");
+
+  const ResourcePath& query_path = query.path;
+  size_t immediate_children_path_length = query_path.size() + 1;
+
+  // TODO(mcg): Actually implement a single-collection query
+  //
+  // This is actually executing an ancestor query, traversing the whole subtree
+  // below the collection which can be horrifically inefficient for some
+  // structures. The right way to solve this is to implement the full value
+  // index, but that's not in the cards in the near future so this is the best
+  // we can do for the moment.
+  //
+  // Since we don't yet index the actual properties in the mutations, our
+  // current approach is to just return all mutation batches that affect
+  // documents in the collection being queried.
+  //
+  // Unlike allMutationBatchesAffectingDocumentKey, this iteration will scan the
+  // document-mutation index for more than a single document so the associated
+  // batchIDs will be neither necessarily unique nor in order. This means an
+  // efficient simultaneous scan isn't possible.
+  std::string index_prefix =
+      LevelDbDocumentMutationKey::KeyPrefix(user_id_, query_path);
+  auto index_iterator = db_.currentTransaction->NewIterator();
+  index_iterator->Seek(index_prefix);
+
+  LevelDbDocumentMutationKey row_key;
+
+  // Collect up unique batchIDs encountered during a scan of the index. Use a
+  // set<BatchId> to accumulate batch IDs so they can be traversed in order in a
+  // scan of the main table.
+  //
+  // This method is faster than performing lookups of the keys with _db->Get and
+  // keeping a hash of batchIDs that have already been looked up. The
+  // performance difference is minor for small numbers of keys but > 30% faster
+  // for larger numbers of keys.
+  std::set<BatchId> unique_batch_ids;
+  for (; index_iterator->Valid(); index_iterator->Next()) {
+    if (!absl::StartsWith(index_iterator->key(), index_prefix) ||
+        !row_key.Decode(index_iterator->key())) {
+      break;
+    }
+
+    // Rows with document keys more than one segment longer than the query path
+    // can't be matches. For example, a query on 'rooms' can't match the
+    // document /rooms/abc/messages/xyx.
+    // TODO(mcg): we'll need a different scanner when we implement ancestor
+    // queries.
+    if (row_key.document_key().path().size() !=
+        immediate_children_path_length) {
+      continue;
+    }
+
+    unique_batch_ids.insert(row_key.batch_id());
+  }
+
+  return AllMutationBatchesWithIds(unique_batch_ids);
+}
+
+FSTMutationBatch* _Nullable LevelDbMutationQueue::LookupMutationBatch(
+    model::BatchId batch_id) {
+  std::string key = mutation_batch_key(batch_id);
+
+  std::string value;
+  Status status = db_.currentTransaction->Get(key, &value);
+  if (!status.ok()) {
+    if (status.IsNotFound()) {
+      return nil;
+    }
+    HARD_FAIL("Lookup mutation batch (%s, %s) failed with status: %s", user_id_,
+              batch_id, status.ToString());
+  }
+
+  return ParseMutationBatch(value);
+}
+
+FSTMutationBatch* _Nullable LevelDbMutationQueue::NextMutationBatchAfterBatchId(
+    model::BatchId batch_id) {
+  BatchId next_batch_id = batch_id + 1;
+
+  std::string key = mutation_batch_key(next_batch_id);
+  auto it = db_.currentTransaction->NewIterator();
+  it->Seek(key);
+
+  LevelDbMutationKey row_key;
+  if (!it->Valid() || !row_key.Decode(it->key())) {
+    // Past the last row in the DB or out of the mutations table
+    return nil;
+  }
+
+  if (row_key.user_id() != user_id_) {
+    // Jumped past the last mutation for this user
+    return nil;
+  }
+
+  HARD_ASSERT(row_key.batch_id() >= next_batch_id,
+              "Should have found mutation after %s", next_batch_id);
+  return ParseMutationBatch(it->value());
+}
+
+void LevelDbMutationQueue::PerformConsistencyCheck() {
+  if (!IsEmpty()) {
+    return;
+  }
+
+  // Verify that there are no entries in the document-mutation index if the
+  // queue is empty.
+  std::string index_prefix = LevelDbDocumentMutationKey::KeyPrefix(user_id_);
+  auto index_iterator = db_.currentTransaction->NewIterator();
+  index_iterator->Seek(index_prefix);
+
+  std::vector<std::string> dangling_mutation_references;
+
+  for (; index_iterator->Valid(); index_iterator->Next()) {
+    // Only consider rows matching this index prefix for the current user.
+    if (!absl::StartsWith(index_iterator->key(), index_prefix)) {
+      break;
+    }
+
+    dangling_mutation_references.push_back(DescribeKey(index_iterator));
+  }
+
+  HARD_ASSERT(
+      dangling_mutation_references.empty(),
+      "Document leak -- detected dangling mutation references when queue "
+      "is empty. Dangling keys: %s",
+      util::ToString(dangling_mutation_references));
+}
+
+NSData* _Nullable LevelDbMutationQueue::GetLastStreamToken() {
+  return metadata_.lastStreamToken;
+}
+
+void LevelDbMutationQueue::SetLastStreamToken(NSData* _Nullable stream_token) {
+  metadata_.lastStreamToken = stream_token;
+
+  db_.currentTransaction->Put(mutation_queue_key(), metadata_);
+}
+
+std::vector<FSTMutationBatch*> LevelDbMutationQueue::AllMutationBatchesWithIds(
+    const std::set<BatchId>& batch_ids) {
+  std::vector<FSTMutationBatch*> result;
+
+  // Given an ordered set of unique batchIDs perform a skipping scan over the
+  // main table to find the mutation batches.
+  auto mutation_iterator = db_.currentTransaction->NewIterator();
+  for (BatchId batch_id : batch_ids) {
+    std::string mutation_key = mutation_batch_key(batch_id);
+    mutation_iterator->Seek(mutation_key);
+    if (!mutation_iterator->Valid() ||
+        mutation_iterator->key() != mutation_key) {
+      HARD_FAIL("Dangling document-mutation reference found: "
+                "Missing batch %s; seeking there found %s",
+                DescribeKey(mutation_key), DescribeKey(mutation_iterator));
+    }
+
+    result.push_back(ParseMutationBatch(mutation_iterator->value()));
+  }
+  return result;
+}
+
+FSTPBMutationQueue* _Nullable LevelDbMutationQueue::MetadataForKey(
+    const std::string& key) {
+  std::string value;
+  Status status = db_.currentTransaction->Get(key, &value);
+  if (status.ok()) {
+    NSData* data = [[NSData alloc] initWithBytesNoCopy:(void*)value.data()
+                                                length:value.size()
+                                          freeWhenDone:NO];
+
+    NSError* error;
+    FSTPBMutationQueue* proto = [FSTPBMutationQueue parseFromData:data
+                                                            error:&error];
+    if (!proto) {
+      HARD_FAIL("FSTPBMutationQueue failed to parse: %s", error);
+    }
+    return proto;
+  } else if (status.IsNotFound()) {
+    return nil;
+  } else {
+    HARD_FAIL("MetadataForKey: failed loading key %s with status: %s", key,
+              status.ToString());
+  }
+}
+
+FSTMutationBatch* LevelDbMutationQueue::ParseMutationBatch(
+    absl::string_view encoded) {
+  NSData* data = [[NSData alloc] initWithBytesNoCopy:(void*)encoded.data()
+                                              length:encoded.size()
+                                        freeWhenDone:NO];
+
+  NSError* error;
+  FSTPBWriteBatch* proto = [FSTPBWriteBatch parseFromData:data error:&error];
+  if (!proto) {
+    HARD_FAIL("FSTPBMutationBatch failed to parse: %s", error);
+  }
+
+  return [serializer_ decodedMutationBatch:proto];
+}
+
+}  // namespace local
+}  // namespace firestore
+}  // namespace firebase
+
+NS_ASSUME_NONNULL_END

--- a/Firestore/core/src/firebase/firestore/local/memory_mutation_queue.h
+++ b/Firestore/core/src/firebase/firestore/local/memory_mutation_queue.h
@@ -52,11 +52,7 @@ class MemoryMutationQueue {
 
   void Start();
 
-  bool is_empty() {
-    // If the queue has any entries at all, the first entry must not be a
-    // tombstone (otherwise it would have been removed already).
-    return queue_.empty();
-  }
+  bool IsEmpty();
 
   void AcknowledgeBatch(FSTMutationBatch* batch,
                         NSData* _Nullable stream_token);
@@ -90,12 +86,8 @@ class MemoryMutationQueue {
 
   size_t CalculateByteSize(FSTLocalSerializer* serializer);
 
-  NSData* _Nullable last_stream_token() {
-    return last_stream_token_;
-  }
-  void set_last_stream_token(NSData* token) {
-    last_stream_token_ = token;
-  }
+  NSData* _Nullable GetLastStreamToken();
+  void SetLastStreamToken(NSData* _Nullable token);
 
  private:
   using DocumentReferenceSet =


### PR DESCRIPTION
This PR ports the leveldb mutation queue and delegates to it from the ObjC implementation. Note that I changed the name of a couple methods in the memory version as well, since they will need to line up in the next PR when the actual interface is ported.