### PR TITLE
Add MutationQueue interface

### DIFF
--- a/Firestore/Example/Tests/Local/FSTLevelDBMutationQueueTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLevelDBMutationQueueTests.mm
@@ -81,14 +81,10 @@ std::string MutationLikeKey(absl::string_view table, absl::string_view userID, B
   _db = [FSTPersistenceTestHelpers levelDBPersistence];
   [_db.referenceDelegate addInMemoryPins:&_additionalReferences];
 
-  // Cast should go away when FSTLevelDB is ported and contains a strongly typed method to get the
-  // mutation queue.
-  LevelDbMutationQueue *queue =
-      static_cast<LevelDbMutationQueue *>([[_db mutationQueueForUser:User("user")] mutationQueue]);
-  self.mutationQueue = queue;
+  self.mutationQueue = [_db mutationQueueForUser:User("user")].mutationQueue;
   self.persistence = _db;
 
-  self.persistence.run("Setup", [&]() { queue->Start(); });
+  self.persistence.run("Setup", [&]() { self.mutationQueue->Start(); });
 }
 
 - (void)testLoadNextBatchID_zeroWhenTotallyEmpty {

--- a/Firestore/Example/Tests/Local/FSTMemoryMutationQueueTests.mm
+++ b/Firestore/Example/Tests/Local/FSTMemoryMutationQueueTests.mm
@@ -43,7 +43,7 @@ using firebase::firestore::local::ReferenceSet;
 
   self.persistence = [FSTPersistenceTestHelpers eagerGCMemoryPersistence];
   [self.persistence.referenceDelegate addInMemoryPins:&_additionalReferences];
-  self.mutationQueue = [self.persistence mutationQueueForUser:User("user")];
+  self.mutationQueue = [self.persistence mutationQueueForUser:User("user")].mutationQueue;
 }
 
 @end

--- a/Firestore/Example/Tests/Local/FSTMutationQueueTests.h
+++ b/Firestore/Example/Tests/Local/FSTMutationQueueTests.h
@@ -16,22 +16,23 @@
 
 #import <XCTest/XCTest.h>
 
-@protocol FSTMutationQueue;
+#include "Firestore/core/src/firebase/firestore/local/mutation_queue.h"
+
 @protocol FSTPersistence;
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * These are tests for any implementation of the FSTMutationQueue protocol.
+ * These are tests for any implementation of the MutationQueue interface.
  *
- * To test a specific implementation of FSTMutationQueue:
+ * To test a specific implementation of MutationQueue:
  *
  * + Subclass FSTMutationQueueTests
  * + override -setUp, assigning to mutationQueue and persistence
  * + override -tearDown, cleaning up mutationQueue and persistence
  */
 @interface FSTMutationQueueTests : XCTestCase
-@property(nonatomic, strong, nullable) id<FSTMutationQueue> mutationQueue;
+@property(nonatomic, nullable) firebase::firestore::local::MutationQueue *mutationQueue;
 @property(nonatomic, strong, nullable) id<FSTPersistence> persistence;
 @end
 

--- a/Firestore/Example/Tests/Local/FSTMutationQueueTests.mm
+++ b/Firestore/Example/Tests/Local/FSTMutationQueueTests.mm
@@ -19,9 +19,9 @@
 #import <FirebaseFirestore/FIRTimestamp.h>
 
 #include <set>
+#include <vector>
 
 #import "Firestore/Source/Core/FSTQuery.h"
-#import "Firestore/Source/Local/FSTMutationQueue.h"
 #import "Firestore/Source/Local/FSTPersistence.h"
 #import "Firestore/Source/Model/FSTMutation.h"
 #import "Firestore/Source/Model/FSTMutationBatch.h"
@@ -50,6 +50,14 @@ NS_ASSUME_NONNULL_BEGIN
   [super tearDown];
 }
 
+- (void)assertEqualVectors:(std::vector<FSTMutationBatch *>)
+                      left:(std::vector<FSTMutationBatch *>)right {
+  XCTAssertEqual(left.size(), right.size(), @"Vector length mismatch");
+  for (int i = 0; i < left.size(); i++) {
+    XCTAssertEqualObjects(left[i], right[i]);
+  }
+}
+
 /**
  * Xcode will run tests from any class that extends XCTestCase, but this doesn't work for
  * FSTMutationQueueTests since it is incomplete without the implementations supplied by its
@@ -64,21 +72,21 @@ NS_ASSUME_NONNULL_BEGIN
 
   self.persistence.run("testCountBatches", [&]() {
     XCTAssertEqual(0, [self batchCount]);
-    XCTAssertTrue([self.mutationQueue isEmpty]);
+    XCTAssertTrue(self.mutationQueue->IsEmpty());
 
     FSTMutationBatch *batch1 = [self addMutationBatch];
     XCTAssertEqual(1, [self batchCount]);
-    XCTAssertFalse([self.mutationQueue isEmpty]);
+    XCTAssertFalse(self.mutationQueue->IsEmpty());
 
     FSTMutationBatch *batch2 = [self addMutationBatch];
     XCTAssertEqual(2, [self batchCount]);
 
-    [self.mutationQueue removeMutationBatch:batch1];
+    self.mutationQueue->RemoveMutationBatch(batch1);
     XCTAssertEqual(1, [self batchCount]);
 
-    [self.mutationQueue removeMutationBatch:batch2];
+    self.mutationQueue->RemoveMutationBatch(batch2);
     XCTAssertEqual(0, [self batchCount]);
-    XCTAssertTrue([self.mutationQueue isEmpty]);
+    XCTAssertTrue(self.mutationQueue->IsEmpty());
   });
 }
 
@@ -97,17 +105,17 @@ NS_ASSUME_NONNULL_BEGIN
 
     XCTAssertEqual([self batchCount], 3);
 
-    [self.mutationQueue acknowledgeBatch:batch1 streamToken:nil];
-    [self.mutationQueue removeMutationBatch:batch1];
+    self.mutationQueue->AcknowledgeBatch(batch1, nil);
+    self.mutationQueue->RemoveMutationBatch(batch1);
     XCTAssertEqual([self batchCount], 2);
 
-    [self.mutationQueue acknowledgeBatch:batch2 streamToken:nil];
+    self.mutationQueue->AcknowledgeBatch(batch2, nil);
     XCTAssertEqual([self batchCount], 2);
 
-    [self.mutationQueue removeMutationBatch:batch2];
+    self.mutationQueue->RemoveMutationBatch(batch2);
     XCTAssertEqual([self batchCount], 1);
 
-    [self.mutationQueue removeMutationBatch:batch3];
+    self.mutationQueue->RemoveMutationBatch(batch3);
     XCTAssertEqual([self batchCount], 0);
   });
 }
@@ -118,8 +126,8 @@ NS_ASSUME_NONNULL_BEGIN
   self.persistence.run("testAcknowledgeThenRemove", [&]() {
     FSTMutationBatch *batch1 = [self addMutationBatch];
 
-    [self.mutationQueue acknowledgeBatch:batch1 streamToken:nil];
-    [self.mutationQueue removeMutationBatch:batch1];
+    self.mutationQueue->AcknowledgeBatch(batch1, nil);
+    self.mutationQueue->RemoveMutationBatch(batch1);
 
     XCTAssertEqual([self batchCount], 0);
   });
@@ -130,26 +138,26 @@ NS_ASSUME_NONNULL_BEGIN
 
   // Searching on an empty queue should not find a non-existent batch
   self.persistence.run("testLookupMutationBatch", [&]() {
-    FSTMutationBatch *notFound = [self.mutationQueue lookupMutationBatch:42];
+    FSTMutationBatch *notFound = self.mutationQueue->LookupMutationBatch(42);
     XCTAssertNil(notFound);
 
-    NSMutableArray<FSTMutationBatch *> *batches = [self createBatches:10];
-    NSArray<FSTMutationBatch *> *removed = [self removeFirstBatches:3 inBatches:batches];
+    std::vector<FSTMutationBatch *> batches = [self createBatches:10];
+    std::vector<FSTMutationBatch *> removed = [self removeFirstBatches:3 inBatches:&batches];
 
     // After removing, a batch should not be found
-    for (NSUInteger i = 0; i < removed.count; i++) {
-      notFound = [self.mutationQueue lookupMutationBatch:removed[i].batchID];
+    for (NSUInteger i = 0; i < removed.size(); i++) {
+      notFound = self.mutationQueue->LookupMutationBatch(removed[i].batchID);
       XCTAssertNil(notFound);
     }
 
     // Remaining entries should still be found
-    for (FSTMutationBatch *batch in batches) {
-      FSTMutationBatch *found = [self.mutationQueue lookupMutationBatch:batch.batchID];
+    for (FSTMutationBatch *batch : batches) {
+      FSTMutationBatch *found = self.mutationQueue->LookupMutationBatch(batch.batchID);
       XCTAssertEqual(found.batchID, batch.batchID);
     }
 
     // Even on a nonempty queue searching should not find a non-existent batch
-    notFound = [self.mutationQueue lookupMutationBatch:42];
+    notFound = self.mutationQueue->LookupMutationBatch(42);
     XCTAssertNil(notFound);
   });
 }
@@ -158,29 +166,29 @@ NS_ASSUME_NONNULL_BEGIN
   if ([self isTestBaseClass]) return;
 
   self.persistence.run("testNextMutationBatchAfterBatchID", [&]() {
-    NSMutableArray<FSTMutationBatch *> *batches = [self createBatches:10];
-    NSArray<FSTMutationBatch *> *removed = [self removeFirstBatches:3 inBatches:batches];
+    std::vector<FSTMutationBatch *> batches = [self createBatches:10];
+    std::vector<FSTMutationBatch *> removed = [self removeFirstBatches:3 inBatches:&batches];
 
-    for (NSUInteger i = 0; i < batches.count - 1; i++) {
+    for (NSUInteger i = 0; i < batches.size() - 1; i++) {
       FSTMutationBatch *current = batches[i];
       FSTMutationBatch *next = batches[i + 1];
-      FSTMutationBatch *found = [self.mutationQueue nextMutationBatchAfterBatchID:current.batchID];
+      FSTMutationBatch *found = self.mutationQueue->NextMutationBatchAfterBatchId(current.batchID);
       XCTAssertEqual(found.batchID, next.batchID);
     }
 
-    for (NSUInteger i = 0; i < removed.count; i++) {
+    for (NSUInteger i = 0; i < removed.size(); i++) {
       FSTMutationBatch *current = removed[i];
       FSTMutationBatch *next = batches[0];
-      FSTMutationBatch *found = [self.mutationQueue nextMutationBatchAfterBatchID:current.batchID];
+      FSTMutationBatch *found = self.mutationQueue->NextMutationBatchAfterBatchId(current.batchID);
       XCTAssertEqual(found.batchID, next.batchID);
     }
 
     FSTMutationBatch *first = batches[0];
-    FSTMutationBatch *found = [self.mutationQueue nextMutationBatchAfterBatchID:first.batchID - 42];
+    FSTMutationBatch *found = self.mutationQueue->NextMutationBatchAfterBatchId(first.batchID - 42);
     XCTAssertEqual(found.batchID, first.batchID);
 
-    FSTMutationBatch *last = batches[batches.count - 1];
-    FSTMutationBatch *notFound = [self.mutationQueue nextMutationBatchAfterBatchID:last.batchID];
+    FSTMutationBatch *last = batches[batches.size() - 1];
+    FSTMutationBatch *notFound = self.mutationQueue->NextMutationBatchAfterBatchId(last.batchID);
     XCTAssertNil(notFound);
   });
 }
@@ -200,16 +208,15 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableArray<FSTMutationBatch *> *batches = [NSMutableArray array];
     for (FSTMutation *mutation in mutations) {
       FSTMutationBatch *batch =
-          [self.mutationQueue addMutationBatchWithWriteTime:[FIRTimestamp timestamp]
-                                                  mutations:@[ mutation ]];
+          self.mutationQueue->AddMutationBatch([FIRTimestamp timestamp], @[ mutation ]);
       [batches addObject:batch];
     }
 
-    NSArray<FSTMutationBatch *> *expected = @[ batches[1], batches[2] ];
-    NSArray<FSTMutationBatch *> *matches =
-        [self.mutationQueue allMutationBatchesAffectingDocumentKey:testutil::Key("foo/bar")];
+    std::vector<FSTMutationBatch *> expected{batches[1], batches[2]};
+    std::vector<FSTMutationBatch *> matches =
+        self.mutationQueue->AllMutationBatchesAffectingDocumentKey(testutil::Key("foo/bar"));
 
-    XCTAssertEqualObjects(matches, expected);
+    [self assertEqualVectors:matches:expected];
   });
 }
 
@@ -228,8 +235,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableArray<FSTMutationBatch *> *batches = [NSMutableArray array];
     for (FSTMutation *mutation in mutations) {
       FSTMutationBatch *batch =
-          [self.mutationQueue addMutationBatchWithWriteTime:[FIRTimestamp timestamp]
-                                                  mutations:@[ mutation ]];
+          self.mutationQueue->AddMutationBatch([FIRTimestamp timestamp], @[ mutation ]);
       [batches addObject:batch];
     }
 
@@ -238,11 +244,11 @@ NS_ASSUME_NONNULL_BEGIN
         Key("foo/baz"),
     };
 
-    NSArray<FSTMutationBatch *> *expected = @[ batches[1], batches[2], batches[4] ];
-    NSArray<FSTMutationBatch *> *matches =
-        [self.mutationQueue allMutationBatchesAffectingDocumentKeys:keys];
+    std::vector<FSTMutationBatch *> expected{batches[1], batches[2], batches[4]};
+    std::vector<FSTMutationBatch *> matches =
+        self.mutationQueue->AllMutationBatchesAffectingDocumentKeys(keys);
 
-    XCTAssertEqualObjects(matches, expected);
+    [self assertEqualVectors:matches:expected];
   });
 }
 
@@ -255,29 +261,27 @@ NS_ASSUME_NONNULL_BEGIN
       FSTTestSetMutation(@"foo/baz", @{@"a" : @1}),
     ];
     FSTMutationBatch *batch1 =
-        [self.mutationQueue addMutationBatchWithWriteTime:[FIRTimestamp timestamp]
-                                                mutations:group1];
+        self.mutationQueue->AddMutationBatch([FIRTimestamp timestamp], group1);
 
     NSArray<FSTMutation *> *group2 = @[ FSTTestSetMutation(@"food/bar", @{@"a" : @1}) ];
-    [self.mutationQueue addMutationBatchWithWriteTime:[FIRTimestamp timestamp] mutations:group2];
+    self.mutationQueue->AddMutationBatch([FIRTimestamp timestamp], group2);
 
     NSArray<FSTMutation *> *group3 = @[
       FSTTestSetMutation(@"foo/bar", @{@"b" : @1}),
     ];
     FSTMutationBatch *batch3 =
-        [self.mutationQueue addMutationBatchWithWriteTime:[FIRTimestamp timestamp]
-                                                mutations:group3];
+        self.mutationQueue->AddMutationBatch([FIRTimestamp timestamp], group3);
 
     DocumentKeySet keys{
         Key("foo/bar"),
         Key("foo/baz"),
     };
 
-    NSArray<FSTMutationBatch *> *expected = @[ batch1, batch3 ];
-    NSArray<FSTMutationBatch *> *matches =
-        [self.mutationQueue allMutationBatchesAffectingDocumentKeys:keys];
+    std::vector<FSTMutationBatch *> expected{batch1, batch3};
+    std::vector<FSTMutationBatch *> matches =
+        self.mutationQueue->AllMutationBatchesAffectingDocumentKeys(keys);
 
-    XCTAssertEqualObjects(matches, expected);
+    [self assertEqualVectors:matches:expected];
   });
 }
 
@@ -296,17 +300,16 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableArray<FSTMutationBatch *> *batches = [NSMutableArray array];
     for (FSTMutation *mutation in mutations) {
       FSTMutationBatch *batch =
-          [self.mutationQueue addMutationBatchWithWriteTime:[FIRTimestamp timestamp]
-                                                  mutations:@[ mutation ]];
+          self.mutationQueue->AddMutationBatch([FIRTimestamp timestamp], @[ mutation ]);
       [batches addObject:batch];
     }
 
-    NSArray<FSTMutationBatch *> *expected = @[ batches[1], batches[2], batches[4] ];
+    std::vector<FSTMutationBatch *> expected = {batches[1], batches[2], batches[4]};
     FSTQuery *query = FSTTestQuery("foo");
-    NSArray<FSTMutationBatch *> *matches =
-        [self.mutationQueue allMutationBatchesAffectingQuery:query];
+    std::vector<FSTMutationBatch *> matches =
+        self.mutationQueue->AllMutationBatchesAffectingQuery(query);
 
-    XCTAssertEqualObjects(matches, expected);
+    [self assertEqualVectors:matches:expected];
   });
 }
 
@@ -314,57 +317,58 @@ NS_ASSUME_NONNULL_BEGIN
   if ([self isTestBaseClass]) return;
 
   self.persistence.run("testRemoveMutationBatches", [&]() {
-    NSMutableArray<FSTMutationBatch *> *batches = [self createBatches:10];
+    std::vector<FSTMutationBatch *> batches = [self createBatches:10];
 
-    [self.mutationQueue removeMutationBatch:batches[0]];
-    [batches removeObjectAtIndex:0];
+    self.mutationQueue->RemoveMutationBatch(batches[0]);
+    batches.erase(batches.begin());
 
     XCTAssertEqual([self batchCount], 9);
 
-    NSArray<FSTMutationBatch *> *found;
+    std::vector<FSTMutationBatch *> found;
 
-    found = [self.mutationQueue allMutationBatches];
-    XCTAssertEqualObjects(found, batches);
-    XCTAssertEqual(found.count, 9);
+    found = self.mutationQueue->AllMutationBatches();
+    [self assertEqualVectors:found:batches];
+    XCTAssertEqual(found.size(), 9);
 
-    [self.mutationQueue removeMutationBatch:batches[0]];
-    [self.mutationQueue removeMutationBatch:batches[1]];
-    [self.mutationQueue removeMutationBatch:batches[2]];
-    [batches removeObjectsInRange:NSMakeRange(0, 3)];
+    self.mutationQueue->RemoveMutationBatch(batches[0]);
+    self.mutationQueue->RemoveMutationBatch(batches[1]);
+    self.mutationQueue->RemoveMutationBatch(batches[2]);
+    for (int i = 0; i < 3; i++) {
+      batches.erase(batches.begin());
+    }
     XCTAssertEqual([self batchCount], 6);
 
-    found = [self.mutationQueue allMutationBatches];
-    XCTAssertEqualObjects(found, batches);
-    XCTAssertEqual(found.count, 6);
+    found = self.mutationQueue->AllMutationBatches();
+    [self assertEqualVectors:found:batches];
+    XCTAssertEqual(found.size(), 6);
 
-    [self.mutationQueue removeMutationBatch:batches[0]];
-    [batches removeObjectAtIndex:0];
+    self.mutationQueue->RemoveMutationBatch(batches[0]);
+    batches.erase(batches.begin());
     XCTAssertEqual([self batchCount], 5);
 
-    found = [self.mutationQueue allMutationBatches];
-    XCTAssertEqualObjects(found, batches);
-    XCTAssertEqual(found.count, 5);
+    found = self.mutationQueue->AllMutationBatches();
+    [self assertEqualVectors:found:batches];
+    XCTAssertEqual(found.size(), 5);
 
-    [self.mutationQueue removeMutationBatch:batches[0]];
-    [batches removeObjectAtIndex:0];
+    self.mutationQueue->RemoveMutationBatch(batches[0]);
+    batches.erase(batches.begin());
     XCTAssertEqual([self batchCount], 4);
 
-    [self.mutationQueue removeMutationBatch:batches[0]];
-    [batches removeObjectAtIndex:0];
+    self.mutationQueue->RemoveMutationBatch(batches[0]);
+    batches.erase(batches.begin());
     XCTAssertEqual([self batchCount], 3);
 
-    found = [self.mutationQueue allMutationBatches];
-    XCTAssertEqualObjects(found, batches);
-    XCTAssertEqual(found.count, 3);
-    XCTAssertFalse([self.mutationQueue isEmpty]);
+    found = self.mutationQueue->AllMutationBatches();
+    [self assertEqualVectors:found:batches];
+    XCTAssertEqual(found.size(), 3);
+    XCTAssertFalse(self.mutationQueue->IsEmpty());
 
-    for (FSTMutationBatch *batch in batches) {
-      [self.mutationQueue removeMutationBatch:batch];
+    for (FSTMutationBatch *batch : batches) {
+      self.mutationQueue->RemoveMutationBatch(batch);
     }
-    found = [self.mutationQueue allMutationBatches];
-    XCTAssertEqualObjects(found, @[]);
-    XCTAssertEqual(found.count, 0);
-    XCTAssertTrue([self.mutationQueue isEmpty]);
+    found = self.mutationQueue->AllMutationBatches();
+    XCTAssertEqual(found.size(), 0);
+    XCTAssertTrue(self.mutationQueue->IsEmpty());
   });
 }
 
@@ -375,15 +379,15 @@ NS_ASSUME_NONNULL_BEGIN
   NSData *streamToken2 = [@"token2" dataUsingEncoding:NSUTF8StringEncoding];
 
   self.persistence.run("testStreamToken", [&]() {
-    [self.mutationQueue setLastStreamToken:streamToken1];
+    self.mutationQueue->SetLastStreamToken(streamToken1);
 
     FSTMutationBatch *batch1 = [self addMutationBatch];
     [self addMutationBatch];
 
-    XCTAssertEqualObjects([self.mutationQueue lastStreamToken], streamToken1);
+    XCTAssertEqualObjects(self.mutationQueue->GetLastStreamToken(), streamToken1);
 
-    [self.mutationQueue acknowledgeBatch:batch1 streamToken:streamToken2];
-    XCTAssertEqualObjects([self.mutationQueue lastStreamToken], streamToken2);
+    self.mutationQueue->AcknowledgeBatch(batch1, streamToken2);
+    XCTAssertEqualObjects(self.mutationQueue->GetLastStreamToken(), streamToken2);
   });
 }
 
@@ -402,21 +406,21 @@ NS_ASSUME_NONNULL_BEGIN
   FSTSetMutation *mutation = FSTTestSetMutation(key, @{@"a" : @1});
 
   FSTMutationBatch *batch =
-      [self.mutationQueue addMutationBatchWithWriteTime:[FIRTimestamp timestamp]
-                                              mutations:@[ mutation ]];
+      self.mutationQueue->AddMutationBatch([FIRTimestamp timestamp], @[ mutation ]);
   return batch;
+  return nil;
 }
 
 /**
  * Creates an array of batches containing @a number dummy FSTMutationBatches. Each has a different
  * batchID.
  */
-- (NSMutableArray<FSTMutationBatch *> *)createBatches:(int)number {
-  NSMutableArray<FSTMutationBatch *> *batches = [NSMutableArray array];
+- (std::vector<FSTMutationBatch *>)createBatches:(int)number {
+  std::vector<FSTMutationBatch *> batches;
 
   for (int i = 0; i < number; i++) {
     FSTMutationBatch *batch = [self addMutationBatch];
-    [batches addObject:batch];
+    batches.push_back(batch);
   }
 
   return batches;
@@ -424,7 +428,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Returns the number of mutation batches in the mutation queue. */
 - (NSUInteger)batchCount {
-  return [self.mutationQueue allMutationBatches].count;
+  return self.mutationQueue->AllMutationBatches().size();
 }
 
 /**
@@ -434,15 +438,15 @@ NS_ASSUME_NONNULL_BEGIN
  * @param batches The array to mutate, removing entries from it.
  * @return A new array containing all the entries that were removed from @a batches.
  */
-- (NSArray<FSTMutationBatch *> *)removeFirstBatches:(NSUInteger)n
-                                          inBatches:(NSMutableArray<FSTMutationBatch *> *)batches {
-  NSArray<FSTMutationBatch *> *removed = [batches subarrayWithRange:NSMakeRange(0, n)];
-  [batches removeObjectsInRange:NSMakeRange(0, n)];
-
-  [removed enumerateObjectsUsingBlock:^(FSTMutationBatch *batch, NSUInteger idx, BOOL *stop) {
-    [self.mutationQueue removeMutationBatch:batch];
-  }];
-
+- (std::vector<FSTMutationBatch *>)removeFirstBatches:(NSUInteger)n
+                                            inBatches:(std::vector<FSTMutationBatch *> *)batches {
+  std::vector<FSTMutationBatch *> removed;
+  for (int i = 0; i < n; i++) {
+    FSTMutationBatch *batch = *batches->begin();
+    removed.push_back(batch);
+    batches->erase(batches->begin());
+    self.mutationQueue->RemoveMutationBatch(batch);
+  }
   return removed;
 }
 

--- a/Firestore/Example/Tests/Local/FSTMutationQueueTests.mm
+++ b/Firestore/Example/Tests/Local/FSTMutationQueueTests.mm
@@ -50,7 +50,8 @@ NS_ASSUME_NONNULL_BEGIN
   [super tearDown];
 }
 
-- (void)assertVector:(std::vector<FSTMutationBatch *>)actual matchesExpected:(std::vector<FSTMutationBatch *>)expected {
+- (void)assertVector:(std::vector<FSTMutationBatch *>)actual
+     matchesExpected:(std::vector<FSTMutationBatch *>)expected {
   XCTAssertEqual(actual.size(), expected.size(), @"Vector length mismatch");
   for (int i = 0; i < expected.size(); i++) {
     XCTAssertEqualObjects(actual[i], expected[i]);

--- a/Firestore/Example/Tests/Local/FSTMutationQueueTests.mm
+++ b/Firestore/Example/Tests/Local/FSTMutationQueueTests.mm
@@ -50,11 +50,10 @@ NS_ASSUME_NONNULL_BEGIN
   [super tearDown];
 }
 
-- (void)assertEqualVectors:(std::vector<FSTMutationBatch *>)
-                      left:(std::vector<FSTMutationBatch *>)right {
-  XCTAssertEqual(left.size(), right.size(), @"Vector length mismatch");
-  for (int i = 0; i < left.size(); i++) {
-    XCTAssertEqualObjects(left[i], right[i]);
+- (void)assertVector:(std::vector<FSTMutationBatch *>)actual matchesExpected:(std::vector<FSTMutationBatch *>)expected {
+  XCTAssertEqual(actual.size(), expected.size(), @"Vector length mismatch");
+  for (int i = 0; i < expected.size(); i++) {
+    XCTAssertEqualObjects(actual[i], expected[i]);
   }
 }
 
@@ -216,7 +215,7 @@ NS_ASSUME_NONNULL_BEGIN
     std::vector<FSTMutationBatch *> matches =
         self.mutationQueue->AllMutationBatchesAffectingDocumentKey(testutil::Key("foo/bar"));
 
-    [self assertEqualVectors:matches:expected];
+    [self assertVector:matches matchesExpected:expected];
   });
 }
 
@@ -248,7 +247,7 @@ NS_ASSUME_NONNULL_BEGIN
     std::vector<FSTMutationBatch *> matches =
         self.mutationQueue->AllMutationBatchesAffectingDocumentKeys(keys);
 
-    [self assertEqualVectors:matches:expected];
+    [self assertVector:matches matchesExpected:expected];
   });
 }
 
@@ -281,14 +280,14 @@ NS_ASSUME_NONNULL_BEGIN
     std::vector<FSTMutationBatch *> matches =
         self.mutationQueue->AllMutationBatchesAffectingDocumentKeys(keys);
 
-    [self assertEqualVectors:matches:expected];
+    [self assertVector:matches matchesExpected:expected];
   });
 }
 
 - (void)testAllMutationBatchesAffectingQuery {
   if ([self isTestBaseClass]) return;
 
-  self.persistence.run("testAllMutationBatchesAffectingQuery", [&]() {
+  self.persistence.run("testAllMutationBa˛tchesAffectingQuery", [&]() {
     NSArray<FSTMutation *> *mutations = @[
       FSTTestSetMutation(@"fob/bar", @{@"a" : @1}), FSTTestSetMutation(@"foo/bar", @{@"a" : @1}),
       FSTTestPatchMutation("foo/bar", @{@"b" : @1}, {}),
@@ -309,7 +308,7 @@ NS_ASSUME_NONNULL_BEGIN
     std::vector<FSTMutationBatch *> matches =
         self.mutationQueue->AllMutationBatchesAffectingQuery(query);
 
-    [self assertEqualVectors:matches:expected];
+    [self assertVector:matches matchesExpected:expected];
   });
 }
 
@@ -327,7 +326,7 @@ NS_ASSUME_NONNULL_BEGIN
     std::vector<FSTMutationBatch *> found;
 
     found = self.mutationQueue->AllMutationBatches();
-    [self assertEqualVectors:found:batches];
+    [self assertVector:found matchesExpected:batches];
     XCTAssertEqual(found.size(), 9);
 
     self.mutationQueue->RemoveMutationBatch(batches[0]);
@@ -339,7 +338,7 @@ NS_ASSUME_NONNULL_BEGIN
     XCTAssertEqual([self batchCount], 6);
 
     found = self.mutationQueue->AllMutationBatches();
-    [self assertEqualVectors:found:batches];
+    [self assertVector:found matchesExpected:batches];
     XCTAssertEqual(found.size(), 6);
 
     self.mutationQueue->RemoveMutationBatch(batches[0]);
@@ -347,7 +346,7 @@ NS_ASSUME_NONNULL_BEGIN
     XCTAssertEqual([self batchCount], 5);
 
     found = self.mutationQueue->AllMutationBatches();
-    [self assertEqualVectors:found:batches];
+    [self assertVector:found matchesExpected:batches];
     XCTAssertEqual(found.size(), 5);
 
     self.mutationQueue->RemoveMutationBatch(batches[0]);
@@ -359,7 +358,7 @@ NS_ASSUME_NONNULL_BEGIN
     XCTAssertEqual([self batchCount], 3);
 
     found = self.mutationQueue->AllMutationBatches();
-    [self assertEqualVectors:found:batches];
+    [self assertVector:found matchesExpected:batches];
     XCTAssertEqual(found.size(), 3);
     XCTAssertFalse(self.mutationQueue->IsEmpty());
 

--- a/Firestore/Source/Local/FSTLevelDBMutationQueue.h
+++ b/Firestore/Source/Local/FSTLevelDBMutationQueue.h
@@ -21,6 +21,7 @@
 #import "Firestore/Source/Local/FSTMutationQueue.h"
 
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
+#include "Firestore/core/src/firebase/firestore/local/leveldb_mutation_queue.h"
 #include "Firestore/core/src/firebase/firestore/model/types.h"
 #include "leveldb/db.h"
 
@@ -43,6 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)mutationQueueWithUser:(const firebase::firestore::auth::User &)user
                                    db:(FSTLevelDB *)db
                            serializer:(FSTLocalSerializer *)serializer;
+
+- (firebase::firestore::local::LevelDbMutationQueue *)mutationQueue;
 
 @end
 

--- a/Firestore/Source/Local/FSTLevelDBMutationQueue.mm
+++ b/Firestore/Source/Local/FSTLevelDBMutationQueue.mm
@@ -172,6 +172,10 @@ static NSArray<FSTMutationBatch *> *toNSArray(const std::vector<FSTMutationBatch
   _delegate->PerformConsistencyCheck();
 }
 
+- (LevelDbMutationQueue *)mutationQueue {
+  return _delegate.get();
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Firestore/Source/Local/FSTMemoryMutationQueue.mm
+++ b/Firestore/Source/Local/FSTMemoryMutationQueue.mm
@@ -137,6 +137,10 @@ static NSArray<FSTMutationBatch *> *toNSArray(const std::vector<FSTMutationBatch
   return _delegate->CalculateByteSize(serializer);
 }
 
+- (MemoryMutationQueue *)mutationQueue {
+  return _delegate.get();
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Firestore/Source/Local/FSTMemoryMutationQueue.mm
+++ b/Firestore/Source/Local/FSTMemoryMutationQueue.mm
@@ -53,6 +53,12 @@ static NSArray<FSTMutationBatch *> *toNSArray(const std::vector<FSTMutationBatch
   return copy;
 }
 
+@interface FSTMemoryMutationQueue ()
+
+- (MemoryMutationQueue *)mutationQueue;
+
+@end
+
 @implementation FSTMemoryMutationQueue {
   std::unique_ptr<MemoryMutationQueue> _delegate;
 }

--- a/Firestore/Source/Local/FSTMutationQueue.h
+++ b/Firestore/Source/Local/FSTMutationQueue.h
@@ -16,6 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
+#include "Firestore/core/src/firebase/firestore/local/mutation_queue.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
 #include "Firestore/core/src/firebase/firestore/model/types.h"
@@ -123,6 +124,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Performs a consistency check, examining the mutation queue for any leaks, if possible. */
 - (void)performConsistencyCheck;
+
+// Visible for testing
+- (firebase::firestore::local::MutationQueue *)mutationQueue;
 
 @end
 

--- a/Firestore/core/src/firebase/firestore/local/leveldb_mutation_queue.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_mutation_queue.h
@@ -31,6 +31,7 @@
 
 #include "Firestore/core/src/firebase/firestore/auth/user.h"
 #include "Firestore/core/src/firebase/firestore/local/leveldb_key.h"
+#include "Firestore/core/src/firebase/firestore/local/mutation_queue.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
 #include "Firestore/core/src/firebase/firestore/model/types.h"
@@ -56,7 +57,7 @@ namespace local {
  */
 model::BatchId LoadNextBatchIdFromDb(leveldb::DB* db);
 
-class LevelDbMutationQueue {
+class LevelDbMutationQueue : public MutationQueue {
  public:
   LevelDbMutationQueue(const auth::User& user,
                        FSTLevelDB* db,
@@ -64,37 +65,38 @@ class LevelDbMutationQueue {
 
   void Start();
 
-  bool IsEmpty();
+  bool IsEmpty() override;
 
   void AcknowledgeBatch(FSTMutationBatch* batch,
-                        NSData* _Nullable stream_token);
+                        NSData* _Nullable stream_token) override;
 
   FSTMutationBatch* AddMutationBatch(FIRTimestamp* local_write_time,
-                                     NSArray<FSTMutation*>* mutations);
+                                     NSArray<FSTMutation*>* mutations) override;
 
-  void RemoveMutationBatch(FSTMutationBatch* batch);
+  void RemoveMutationBatch(FSTMutationBatch* batch) override;
 
   std::vector<FSTMutationBatch*> AllMutationBatches();
 
   std::vector<FSTMutationBatch*> AllMutationBatchesAffectingDocumentKeys(
-      const model::DocumentKeySet& document_keys);
+      const model::DocumentKeySet& document_keys) override;
 
   std::vector<FSTMutationBatch*> AllMutationBatchesAffectingDocumentKey(
-      const model::DocumentKey& key);
+      const model::DocumentKey& key) override;
 
   std::vector<FSTMutationBatch*> AllMutationBatchesAffectingQuery(
-      FSTQuery* query);
+      FSTQuery* query) override;
 
-  FSTMutationBatch* _Nullable LookupMutationBatch(model::BatchId batch_id);
+  FSTMutationBatch* _Nullable LookupMutationBatch(
+      model::BatchId batch_id) override;
 
   FSTMutationBatch* _Nullable NextMutationBatchAfterBatchId(
-      model::BatchId batch_id);
+      model::BatchId batch_id) override;
 
-  void PerformConsistencyCheck();
+  void PerformConsistencyCheck() override;
 
-  NSData* _Nullable GetLastStreamToken();
+  NSData* _Nullable GetLastStreamToken() override;
 
-  void SetLastStreamToken(NSData* _Nullable stream_token);
+  void SetLastStreamToken(NSData* _Nullable stream_token) override;
 
  private:
   /**

--- a/Firestore/core/src/firebase/firestore/local/leveldb_mutation_queue.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_mutation_queue.h
@@ -63,7 +63,7 @@ class LevelDbMutationQueue : public MutationQueue {
                        FSTLevelDB* db,
                        FSTLocalSerializer* serializer);
 
-  void Start();
+  void Start() override;
 
   bool IsEmpty() override;
 
@@ -75,7 +75,7 @@ class LevelDbMutationQueue : public MutationQueue {
 
   void RemoveMutationBatch(FSTMutationBatch* batch) override;
 
-  std::vector<FSTMutationBatch*> AllMutationBatches();
+  std::vector<FSTMutationBatch*> AllMutationBatches() override;
 
   std::vector<FSTMutationBatch*> AllMutationBatchesAffectingDocumentKeys(
       const model::DocumentKeySet& document_keys) override;

--- a/Firestore/core/src/firebase/firestore/local/memory_mutation_queue.h
+++ b/Firestore/core/src/firebase/firestore/local/memory_mutation_queue.h
@@ -30,6 +30,7 @@
 
 #include "Firestore/core/src/firebase/firestore/immutable/sorted_set.h"
 #include "Firestore/core/src/firebase/firestore/local/document_reference.h"
+#include "Firestore/core/src/firebase/firestore/local/mutation_queue.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
 #include "Firestore/core/src/firebase/firestore/model/types.h"
@@ -46,48 +47,49 @@ namespace firebase {
 namespace firestore {
 namespace local {
 
-class MemoryMutationQueue {
+class MemoryMutationQueue : public MutationQueue {
  public:
   explicit MemoryMutationQueue(FSTMemoryPersistence* persistence);
 
   void Start();
 
-  bool IsEmpty();
+  bool IsEmpty() override;
 
   void AcknowledgeBatch(FSTMutationBatch* batch,
-                        NSData* _Nullable stream_token);
+                        NSData* _Nullable stream_token) override;
 
   FSTMutationBatch* AddMutationBatch(FIRTimestamp* local_write_time,
-                                     NSArray<FSTMutation*>* mutations);
+                                     NSArray<FSTMutation*>* mutations) override;
 
-  void RemoveMutationBatch(FSTMutationBatch* batch);
+  void RemoveMutationBatch(FSTMutationBatch* batch) override;
 
-  const std::vector<FSTMutationBatch*>& AllMutationBatches() {
+  const std::vector<FSTMutationBatch*> AllMutationBatches() override {
     return queue_;
   }
 
   std::vector<FSTMutationBatch*> AllMutationBatchesAffectingDocumentKeys(
-      const model::DocumentKeySet& document_keys);
+      const model::DocumentKeySet& document_keys) override;
 
   std::vector<FSTMutationBatch*> AllMutationBatchesAffectingDocumentKey(
-      const model::DocumentKey& key);
+      const model::DocumentKey& key) override;
 
   std::vector<FSTMutationBatch*> AllMutationBatchesAffectingQuery(
-      FSTQuery* query);
+      FSTQuery* query) override;
 
-  FSTMutationBatch* _Nullable LookupMutationBatch(model::BatchId batch_id);
+  FSTMutationBatch* _Nullable LookupMutationBatch(
+      model::BatchId batch_id) override;
 
   FSTMutationBatch* _Nullable NextMutationBatchAfterBatchId(
-      model::BatchId batch_id);
+      model::BatchId batch_id) override;
 
-  void PerformConsistencyCheck();
+  void PerformConsistencyCheck() override;
 
   bool ContainsKey(const model::DocumentKey& key);
 
   size_t CalculateByteSize(FSTLocalSerializer* serializer);
 
-  NSData* _Nullable GetLastStreamToken();
-  void SetLastStreamToken(NSData* _Nullable token);
+  NSData* _Nullable GetLastStreamToken() override;
+  void SetLastStreamToken(NSData* _Nullable token) override;
 
  private:
   using DocumentReferenceSet =

--- a/Firestore/core/src/firebase/firestore/local/memory_mutation_queue.h
+++ b/Firestore/core/src/firebase/firestore/local/memory_mutation_queue.h
@@ -51,7 +51,7 @@ class MemoryMutationQueue : public MutationQueue {
  public:
   explicit MemoryMutationQueue(FSTMemoryPersistence* persistence);
 
-  void Start();
+  void Start() override;
 
   bool IsEmpty() override;
 
@@ -63,7 +63,7 @@ class MemoryMutationQueue : public MutationQueue {
 
   void RemoveMutationBatch(FSTMutationBatch* batch) override;
 
-  const std::vector<FSTMutationBatch*> AllMutationBatches() override {
+  std::vector<FSTMutationBatch*> AllMutationBatches() override {
     return queue_;
   }
 

--- a/Firestore/core/src/firebase/firestore/local/mutation_queue.h
+++ b/Firestore/core/src/firebase/firestore/local/mutation_queue.h
@@ -118,7 +118,7 @@ class MutationQueue {
   virtual std::vector<FSTMutationBatch*> AllMutationBatchesAffectingQuery(
       FSTQuery* query) = 0;
 
-  /** Loads the mutation batch with the given batchID. */
+  /** Loads the mutation batch with the given batch_id. */
   virtual FSTMutationBatch* _Nullable LookupMutationBatch(
       model::BatchId batch_id) = 0;
 
@@ -126,7 +126,7 @@ class MutationQueue {
    * Gets the first unacknowledged mutation batch after the passed in batchId in
    * the mutation queue or nil if empty.
    *
-   * @param batchID The batch to search after, or kBatchIdUnknown for the first
+   * @param batch_id The batch to search after, or kBatchIdUnknown for the first
    * mutation in the queue.
    *
    * @return the next mutation or nil if there wasn't one.

--- a/Firestore/core/src/firebase/firestore/local/mutation_queue.h
+++ b/Firestore/core/src/firebase/firestore/local/mutation_queue.h
@@ -47,8 +47,8 @@ class MutationQueue {
   }
 
   /**
-   * Starts the mutation queue, performing any initial reads that might be required to establish
-   * invariants, etc.
+   * Starts the mutation queue, performing any initial reads that might be
+   * required to establish invariants, etc.
    */
   virtual void Start() = 0;
 

--- a/Firestore/core/src/firebase/firestore/local/mutation_queue.h
+++ b/Firestore/core/src/firebase/firestore/local/mutation_queue.h
@@ -46,6 +46,12 @@ class MutationQueue {
   virtual ~MutationQueue() {
   }
 
+  /**
+   * Starts the mutation queue, performing any initial reads that might be required to establish
+   * invariants, etc.
+   */
+  virtual void Start() = 0;
+
   /** Returns true if this queue contains no mutation batches. */
   virtual bool IsEmpty() = 0;
 
@@ -69,7 +75,7 @@ class MutationQueue {
   /** Gets all mutation batches in the mutation queue. */
   // TODO(mikelehen): PERF: Current consumer only needs mutated keys; if we can
   // provide that cheaply, we should replace this.
-  virtual const std::vector<FSTMutationBatch*> AllMutationBatches() = 0;
+  virtual std::vector<FSTMutationBatch*> AllMutationBatches() = 0;
 
   /**
    * Finds all mutation batches that could @em possibly affect the given
@@ -134,8 +140,10 @@ class MutationQueue {
   virtual FSTMutationBatch* _Nullable NextMutationBatchAfterBatchId(
       model::BatchId batch_id) = 0;
 
-  /** Performs a consistency check, examining the mutation queue for any leaks,
-   * if possible. */
+  /**
+   * Performs a consistency check, examining the mutation queue for any leaks,
+   * if possible.
+   */
   virtual void PerformConsistencyCheck() = 0;
 
   /** Returns the current stream token for this mutation queue. */

--- a/Firestore/core/src/firebase/firestore/local/mutation_queue.h
+++ b/Firestore/core/src/firebase/firestore/local/mutation_queue.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_MUTATION_QUEUE_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_MUTATION_QUEUE_H_
+
+#if !defined(__OBJC__)
+#error "For now, this file must only be included by ObjC source files."
+#endif  // !defined(__OBJC__)
+
+#import <Foundation/Foundation.h>
+
+#include <vector>
+
+#include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
+#include "Firestore/core/src/firebase/firestore/model/types.h"
+
+@class FIRTimestamp;
+@class FSTMutation;
+@class FSTMutationBatch;
+@class FSTQuery;
+
+NS_ASSUME_NONNULL_BEGIN
+
+namespace firebase {
+namespace firestore {
+namespace local {
+
+/** A queue of mutations to apply to the remote store. */
+class MutationQueue {
+ public:
+  virtual ~MutationQueue() {
+  }
+
+  /** Returns true if this queue contains no mutation batches. */
+  virtual bool IsEmpty() = 0;
+
+  /** Acknowledges the given batch. */
+  virtual void AcknowledgeBatch(FSTMutationBatch* batch,
+          NSData* _Nullable stream_token) = 0;
+
+  /** Creates a new mutation batch and adds it to this mutation queue. */
+  virtual FSTMutationBatch* AddMutationBatch(FIRTimestamp* local_write_time,
+          NSArray<FSTMutation*>* mutations) = 0;
+
+  /**
+   * Removes the given mutation batch from the queue. This is useful in two circumstances:
+   *
+   * + Removing applied mutations from the head of the queue
+   * + Removing rejected mutations from anywhere in the queue
+   */
+  virtual void RemoveMutationBatch(FSTMutationBatch* batch) = 0;
+
+  /** Gets all mutation batches in the mutation queue. */
+  // TODO(mikelehen): PERF: Current consumer only needs mutated keys; if we can provide that
+  // cheaply, we should replace this.
+  virtual const std::vector<FSTMutationBatch*> AllMutationBatches() = 0;
+
+  /**
+   * Finds all mutation batches that could @em possibly affect the given document keys. Not all
+   * mutations in a batch will necessarily affect each key, so when looping through the batches you'll
+   * need to check that the mutation itself matches the key.
+   *
+   * Note that because of this requirement implementations are free to return mutation batches that
+   * don't contain any of the given document keys at all if it's convenient.
+   */
+  // TODO(mcg): This should really return an iterator
+  virtual std::vector<FSTMutationBatch*> AllMutationBatchesAffectingDocumentKeys(
+          const model::DocumentKeySet& document_keys) = 0;
+
+  /**
+   * Finds all mutation batches that could @em possibly affect the given document key. Not all
+   * mutations in a batch will necessarily affect the document key, so when looping through the
+   * batch you'll need to check that the mutation itself matches the key.
+   *
+   * Note that because of this requirement implementations are free to return mutation batches that
+   * don't contain the document key at all if it's convenient.
+   */
+  // TODO(mcg): This should really return an iterator
+  virtual std::vector<FSTMutationBatch*> AllMutationBatchesAffectingDocumentKey(
+          const model::DocumentKey& key) = 0;
+
+  /**
+   * Finds all mutation batches that could affect the results for the given query. Not all
+   * mutations in a batch will necessarily affect the query, so when looping through the batch
+   * you'll need to check that the mutation itself matches the query.
+   *
+   * Note that because of this requirement implementations are free to return mutation batches that
+   * don't match the query at all if it's convenient.
+   *
+   * NOTE: A FSTPatchMutation does not need to include all fields in the query filter criteria in
+   * order to be a match (but any fields it does contain do need to match).
+   */
+  // TODO(mikelehen): This should perhaps return an iterator, though I'm not sure we can avoid
+  // loading them all in memory.
+  virtual std::vector<FSTMutationBatch*> AllMutationBatchesAffectingQuery(
+          FSTQuery* query) = 0;
+
+  /** Loads the mutation batch with the given batchID. */
+  virtual FSTMutationBatch* _Nullable LookupMutationBatch(model::BatchId batch_id) = 0;
+
+  /**
+   * Gets the first unacknowledged mutation batch after the passed in batchId in the mutation queue
+   * or nil if empty.
+   *
+   * @param batchID The batch to search after, or kBatchIdUnknown for the first mutation in the
+   * queue.
+   *
+   * @return the next mutation or nil if there wasn't one.
+   */
+  virtual FSTMutationBatch* _Nullable NextMutationBatchAfterBatchId(
+          model::BatchId batch_id) = 0;
+
+  /** Performs a consistency check, examining the mutation queue for any leaks, if possible. */
+  virtual void PerformConsistencyCheck() = 0;
+
+  /** Returns the current stream token for this mutation queue. */
+  virtual NSData* _Nullable GetLastStreamToken() = 0;
+
+  /** Sets the stream token for this mutation queue. */
+  virtual void SetLastStreamToken(NSData* _Nullable stream_token) = 0;
+};
+
+}  // namespace local
+}  // namespace firestore
+}  // namespace firebase
+
+NS_ASSUME_NONNULL_END
+
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_MUTATION_QUEUE_H_

--- a/Firestore/core/src/firebase/firestore/local/mutation_queue.h
+++ b/Firestore/core/src/firebase/firestore/local/mutation_queue.h
@@ -51,14 +51,15 @@ class MutationQueue {
 
   /** Acknowledges the given batch. */
   virtual void AcknowledgeBatch(FSTMutationBatch* batch,
-          NSData* _Nullable stream_token) = 0;
+                                NSData* _Nullable stream_token) = 0;
 
   /** Creates a new mutation batch and adds it to this mutation queue. */
-  virtual FSTMutationBatch* AddMutationBatch(FIRTimestamp* local_write_time,
-          NSArray<FSTMutation*>* mutations) = 0;
+  virtual FSTMutationBatch* AddMutationBatch(
+      FIRTimestamp* local_write_time, NSArray<FSTMutation*>* mutations) = 0;
 
   /**
-   * Removes the given mutation batch from the queue. This is useful in two circumstances:
+   * Removes the given mutation batch from the queue. This is useful in two
+   * circumstances:
    *
    * + Removing applied mutations from the head of the queue
    * + Removing rejected mutations from anywhere in the queue
@@ -66,66 +67,75 @@ class MutationQueue {
   virtual void RemoveMutationBatch(FSTMutationBatch* batch) = 0;
 
   /** Gets all mutation batches in the mutation queue. */
-  // TODO(mikelehen): PERF: Current consumer only needs mutated keys; if we can provide that
-  // cheaply, we should replace this.
+  // TODO(mikelehen): PERF: Current consumer only needs mutated keys; if we can
+  // provide that cheaply, we should replace this.
   virtual const std::vector<FSTMutationBatch*> AllMutationBatches() = 0;
 
   /**
-   * Finds all mutation batches that could @em possibly affect the given document keys. Not all
-   * mutations in a batch will necessarily affect each key, so when looping through the batches you'll
-   * need to check that the mutation itself matches the key.
+   * Finds all mutation batches that could @em possibly affect the given
+   * document keys. Not all mutations in a batch will necessarily affect each
+   * key, so when looping through the batches you'll need to check that the
+   * mutation itself matches the key.
    *
-   * Note that because of this requirement implementations are free to return mutation batches that
-   * don't contain any of the given document keys at all if it's convenient.
+   * Note that because of this requirement implementations are free to return
+   * mutation batches that don't contain any of the given document keys at all
+   * if it's convenient.
    */
   // TODO(mcg): This should really return an iterator
-  virtual std::vector<FSTMutationBatch*> AllMutationBatchesAffectingDocumentKeys(
-          const model::DocumentKeySet& document_keys) = 0;
+  virtual std::vector<FSTMutationBatch*>
+  AllMutationBatchesAffectingDocumentKeys(
+      const model::DocumentKeySet& document_keys) = 0;
 
   /**
-   * Finds all mutation batches that could @em possibly affect the given document key. Not all
-   * mutations in a batch will necessarily affect the document key, so when looping through the
-   * batch you'll need to check that the mutation itself matches the key.
+   * Finds all mutation batches that could @em possibly affect the given
+   * document key. Not all mutations in a batch will necessarily affect the
+   * document key, so when looping through the batch you'll need to check that
+   * the mutation itself matches the key.
    *
-   * Note that because of this requirement implementations are free to return mutation batches that
-   * don't contain the document key at all if it's convenient.
+   * Note that because of this requirement implementations are free to return
+   * mutation batches that don't contain the document key at all if it's
+   * convenient.
    */
   // TODO(mcg): This should really return an iterator
   virtual std::vector<FSTMutationBatch*> AllMutationBatchesAffectingDocumentKey(
-          const model::DocumentKey& key) = 0;
+      const model::DocumentKey& key) = 0;
 
   /**
-   * Finds all mutation batches that could affect the results for the given query. Not all
-   * mutations in a batch will necessarily affect the query, so when looping through the batch
-   * you'll need to check that the mutation itself matches the query.
+   * Finds all mutation batches that could affect the results for the given
+   * query. Not all mutations in a batch will necessarily affect the query, so
+   * when looping through the batch you'll need to check that the mutation
+   * itself matches the query.
    *
-   * Note that because of this requirement implementations are free to return mutation batches that
-   * don't match the query at all if it's convenient.
+   * Note that because of this requirement implementations are free to return
+   * mutation batches that don't match the query at all if it's convenient.
    *
-   * NOTE: A FSTPatchMutation does not need to include all fields in the query filter criteria in
-   * order to be a match (but any fields it does contain do need to match).
+   * NOTE: A FSTPatchMutation does not need to include all fields in the query
+   * filter criteria in order to be a match (but any fields it does contain do
+   * need to match).
    */
-  // TODO(mikelehen): This should perhaps return an iterator, though I'm not sure we can avoid
-  // loading them all in memory.
+  // TODO(mikelehen): This should perhaps return an iterator, though I'm not
+  // sure we can avoid loading them all in memory.
   virtual std::vector<FSTMutationBatch*> AllMutationBatchesAffectingQuery(
-          FSTQuery* query) = 0;
+      FSTQuery* query) = 0;
 
   /** Loads the mutation batch with the given batchID. */
-  virtual FSTMutationBatch* _Nullable LookupMutationBatch(model::BatchId batch_id) = 0;
+  virtual FSTMutationBatch* _Nullable LookupMutationBatch(
+      model::BatchId batch_id) = 0;
 
   /**
-   * Gets the first unacknowledged mutation batch after the passed in batchId in the mutation queue
-   * or nil if empty.
+   * Gets the first unacknowledged mutation batch after the passed in batchId in
+   * the mutation queue or nil if empty.
    *
-   * @param batchID The batch to search after, or kBatchIdUnknown for the first mutation in the
-   * queue.
+   * @param batchID The batch to search after, or kBatchIdUnknown for the first
+   * mutation in the queue.
    *
    * @return the next mutation or nil if there wasn't one.
    */
   virtual FSTMutationBatch* _Nullable NextMutationBatchAfterBatchId(
-          model::BatchId batch_id) = 0;
+      model::BatchId batch_id) = 0;
 
-  /** Performs a consistency check, examining the mutation queue for any leaks, if possible. */
+  /** Performs a consistency check, examining the mutation queue for any leaks,
+   * if possible. */
   virtual void PerformConsistencyCheck() = 0;
 
   /** Returns the current stream token for this mutation queue. */


### PR DESCRIPTION
Adds the `MutationQueue` interface, a port of `FSTMutationQueue`. Ports the mutation queue tests to use the C++ interface. Does not port production usages of `FSTMutationQueue`, that will be in the next PR.