### PR TITLE
Update CHANGELOG for Firestore v1.0.1

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v1.0.1
+- [changed] Internal improvements.
+
 # v1.0.0
 - [changed] **Breaking change:** The `areTimestampsInSnapshotsEnabled` setting
   is now enabled by default. Timestamp fields that read from a


### PR DESCRIPTION
Spooling through history there's lots of porting work here but nothing interesting to a changelog consumer.