### PR TITLE
Remove logic to expire last notification analytics settings after a set time interval

### DIFF
--- a/Firebase/InAppMessaging/Analytics/FIRIAMAnalyticsEventLoggerImpl.h
+++ b/Firebase/InAppMessaging/Analytics/FIRIAMAnalyticsEventLoggerImpl.h
@@ -36,13 +36,10 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param userDefaults needed for tracking upload timing info persistently.If nil, using
  *    NSUserDefaults standardUserDefaults. It's defined as a parameter to help with
  *    unit testing mocking
- *  @param conversionExpiresInSeconds specifies the time-length in seconds when we stop
- *    attribution conversions for a prior fiam message click from analytics perspective
  */
 - (instancetype)initWithClearcutLogger:(FIRIAMClearcutLogger *)ctLogger
                       usingTimeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher
                      usingUserDefaults:(nullable NSUserDefaults *)userDefaults
-                     conversionExpires:(long)conversionExpiresInSeconds
                              analytics:(nullable id<FIRAnalyticsInterop>)analytics;
 @end
 NS_ASSUME_NONNULL_END

--- a/Firebase/InAppMessaging/Runtime/FIRIAMRuntimeManager.m
+++ b/Firebase/InAppMessaging/Runtime/FIRIAMRuntimeManager.m
@@ -319,7 +319,6 @@ static NSString *const kFirebaseInAppMessagingAutoDataCollectionKey =
       initWithClearcutLogger:clearcutLogger
             usingTimeFetcher:timeFetcher
            usingUserDefaults:nil
-           conversionExpires:settings.conversionTrackingExpiresInSeconds
                    analytics:[FIRInAppMessaging inAppMessaging].analytics];
 
   FIRIAMSDKModeManager *sdkModeManager =

--- a/Firebase/InAppMessaging/Runtime/FIRIAMSDKSettings.h
+++ b/Firebase/InAppMessaging/Runtime/FIRIAMSDKSettings.h
@@ -43,9 +43,6 @@ NS_ASSUME_NONNULL_BEGIN
 // clearcut strategy
 @property(nonatomic, strong) FIRIAMClearcutStrategy *clearcutStrategy;
 
-// how long, in seconds, we stop attributing conversions for a clicked message
-@property(nonatomic) long conversionTrackingExpiresInSeconds;
-
 // The global flag at whole Firebase level for automatic data collection. On FIAM SDK startup,
 // it would be retreived from FIRApp's corresponding setting.
 @property(nonatomic, getter=isFirebaseAutoDataCollectionEnabled)

--- a/Firebase/InAppMessaging/Runtime/FIRIAMSDKSettings.m
+++ b/Firebase/InAppMessaging/Runtime/FIRIAMSDKSettings.m
@@ -21,16 +21,15 @@
 - (NSString *)description {
   return
       [NSString stringWithFormat:@"APIServer:%@;ProjectNumber:%@; API_Key:%@;Clearcut Server:%@; "
-                                  "Fetch Minimal Internval:%lu seconds; Activity Logger Max:%lu; "
-                                  "Foreground Display Trigger Minimal Interval:%lu seconds; "
-                                  "Stop conversion tracking in %ld seconds;\n"
+                                  "Fetch Minimal Interval:%lu seconds; Activity Logger Max:%lu; "
+                                  "Foreground Display Trigger Minimal Interval:%lu seconds;\n"
                                   "Clearcut strategy:%@;Global Firebase auto data collection %@\n",
                                  self.apiServerHost, self.firebaseProjectNumber, self.apiKey,
                                  self.clearcutServerHost,
                                  (unsigned long)(self.fetchMinIntervalInMinutes * 60),
                                  (unsigned long)self.loggerMaxCountBeforeReduce,
                                  (unsigned long)(self.appFGRenderMinIntervalInMinutes * 60),
-                                 self.conversionTrackingExpiresInSeconds, self.clearcutStrategy,
+                                 self.clearcutStrategy,
                                  self.firebaseAutoDataCollectionEnabled ? @"enabled" : @"disabled"];
 }
 @end

--- a/Firebase/InAppMessaging/Runtime/FIRInAppMessaging+Bootstrap.m
+++ b/Firebase/InAppMessaging/Runtime/FIRInAppMessaging+Bootstrap.m
@@ -96,9 +96,6 @@ static NSString *_fiamServerHostName = @"firebaseinappmessaging.googleapis.com";
   _sdkSetting.loggerSizeAfterReduce = 50;
   _sdkSetting.appFGRenderMinIntervalInMinutes = 24 * 60;  // render at most one message from
                                                           // app-foreground trigger every 24 hours
-  _sdkSetting.conversionTrackingExpiresInSeconds =
-      7 * 24 * 3600;  // conversion attribution
-                      // for a message click expires in 7 days
   _sdkSetting.loggerInVerboseMode = NO;
 
   // TODO: once Firebase Core supports sending notifications at global Firebase level setting

--- a/Interop/Analytics/Public/FIRAnalyticsInterop.h
+++ b/Interop/Analytics/Public/FIRAnalyticsInterop.h
@@ -48,12 +48,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// Sets user property.
 - (void)setUserPropertyWithOrigin:(NSString *)origin name:(NSString *)name value:(id)value;
 
-// Get the lastNotification if it's associated with origin.
-- (void)checkLastNotificationForOrigin:(NSString *)origin
-                                 queue:(dispatch_queue_t)queue
-                              callback:
-                                  (void (^)(NSString *_Nullable))currentLastNotificationProperty;
-
 /// Registers an Analytics listener for the given origin.
 - (void)registerAnalyticsListener:(id<FIRAnalyticsInteropListener>)listener
                        withOrigin:(NSString *)origin;


### PR DESCRIPTION
See discussion in cl/230837222.

Previously we had logic to expire the `lastNotification` event after a certain period of time, to invalidate the last notification for conversion tracking purposes.

This PR removes that logic to be consistent with the Android SDK.