### PR TITLE
Surface `registerLibrary:withVersion:`

### DIFF
--- a/Firebase/Core/Private/FIRAppInternal.h
+++ b/Firebase/Core/Private/FIRAppInternal.h
@@ -135,15 +135,6 @@ extern NSString *const FIRAuthStateDidChangeInternalNotificationUIDKey;
 + (BOOL)isDefaultAppConfigured;
 
 /**
- * Registers a given third-party library with the given version number to be reported for
- * analytics.
- *
- * @param name Name of the library.
- * @param version Version of the library.
- */
-+ (void)registerLibrary:(nonnull NSString *)name withVersion:(nonnull NSString *)version;
-
-/**
  * Registers a given internal library with the given version number to be reported for
  * analytics.
  *

--- a/Firebase/Core/Public/FIRApp.h
+++ b/Firebase/Core/Public/FIRApp.h
@@ -81,8 +81,8 @@ NS_SWIFT_NAME(FirebaseApp)
  * @param name Name of the library.
  * @param version Version of the library.
  */
-+ (void)registerLibrary:(NSString *)name withVersion:(NSString *)version
-NS_SWIFT_NAME(registerLibrary(_:version:));
++ (void)registerLibrary:(NSString *)name
+            withVersion:(NSString *)version NS_SWIFT_NAME(registerLibrary(_:version:));
 
 /**
  * Returns the default app, or nil if the default app does not exist.

--- a/Firebase/Core/Public/FIRApp.h
+++ b/Firebase/Core/Public/FIRApp.h
@@ -75,6 +75,16 @@ NS_SWIFT_NAME(FirebaseApp)
 // clang-format on
 
 /**
+ * Registers a given third-party library with the given version number to be reported for
+ * analytics.
+ *
+ * @param name Name of the library.
+ * @param version Version of the library.
+ */
++ (void)registerLibrary:(NSString *)name withVersion:(NSString *)version
+NS_SWIFT_NAME(registerLibrary(_:version:));
+
+/**
  * Returns the default app, or nil if the default app does not exist.
  */
 + (nullable FIRApp *)defaultApp NS_SWIFT_NAME(app());


### PR DESCRIPTION
This moves the method from the FIRAppInternal header to the public header.