### PR TITLE
Add IAM headless to CI

### DIFF
--- a/Firebase/InAppMessaging/Data/FIRIAMFetchResponseParser.h
+++ b/Firebase/InAppMessaging/Data/FIRIAMFetchResponseParser.h
@@ -32,7 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
 // @param fetchWaitTime would be non nil if fetch wait time data is found in the api response.
 - (NSArray<FIRIAMMessageDefinition *> *)parseAPIResponseDictionary:(NSDictionary *)responseDict
                                                  discardedMsgCount:(NSInteger *)discardCount
-                                            fetchWaitTimeInSeconds:(NSNumber **)fetchWaitTime;
+                                            fetchWaitTimeInSeconds:
+                                                (NSNumber *_Nullable *_Nonnull)fetchWaitTime;
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithTimeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher;

--- a/InAppMessaging/Example/App/InAppMessaging-Example-iOS/AppDelegate.m
+++ b/InAppMessaging/Example/App/InAppMessaging-Example-iOS/AppDelegate.m
@@ -53,7 +53,6 @@
   sdkSetting.loggerSizeAfterReduce = 600;
   sdkSetting.appFGRenderMinIntervalInMinutes = 0.1;
   sdkSetting.loggerInVerboseMode = YES;
-  sdkSetting.conversionTrackingExpiresInSeconds = 180;
   sdkSetting.firebaseAutoDataCollectionEnabled = NO;
 
   sdkSetting.clearcutStrategy =
@@ -68,7 +67,7 @@
 
 - (BOOL)application:(UIApplication *)application
     continueUserActivity:(NSUserActivity *)userActivity
-      restorationHandler:(void (^)(NSArray *))restorationHandler {
+      restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> *))restorationHandler {
   NSLog(@"handle page url %@", userActivity.webpageURL);
   BOOL handled = [[FIRDynamicLinks dynamicLinks]
       handleUniversalLink:userActivity.webpageURL

--- a/InAppMessaging/Example/App/InAppMessaging-Example-iOS/AppDelegate.m
+++ b/InAppMessaging/Example/App/InAppMessaging-Example-iOS/AppDelegate.m
@@ -67,7 +67,7 @@
 
 - (BOOL)application:(UIApplication *)application
     continueUserActivity:(NSUserActivity *)userActivity
-      restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> *))restorationHandler {
+      restorationHandler:(void (^)(NSArray *))restorationHandler {
   NSLog(@"handle page url %@", userActivity.webpageURL);
   BOOL handled = [[FIRDynamicLinks dynamicLinks]
       handleUniversalLink:userActivity.webpageURL

--- a/InAppMessaging/Example/Podfile
+++ b/InAppMessaging/Example/Podfile
@@ -1,9 +1,8 @@
-
 use_frameworks!
 
 # Uncomment the next two lines for pre-release testing on public repo
-source 'https://github.com/Firebase/SpecsStaging.git'
-source 'https://github.com/CocoaPods/Specs.git'
+# source 'https://github.com/Firebase/SpecsStaging.git'
+# source 'https://github.com/CocoaPods/Specs.git'
 
 pod 'FirebaseCore', :path => '../..'
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -233,6 +233,13 @@ case "$product-$method-$platform" in
     ;;
 
   InAppMessagingDisplay-xcodebuild-iOS)
+    RunXcodebuild \
+        -workspace 'InAppMessaging/Example/InAppMessaging-Example-iOS.xcworkspace'  \
+        -scheme 'InAppMessaging-Example-iOS' \
+        "${xcb_flags[@]}" \
+        build \
+        test
+
     # Run UI tests on both iPad and iPhone simulators
     # TODO: Running two destinations from one xcodebuild command stopped working with Xcode 10.
     # Consider separating static library tests to a separate job.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -235,7 +235,7 @@ case "$product-$method-$platform" in
   InAppMessagingDisplay-xcodebuild-iOS)
     RunXcodebuild \
         -workspace 'InAppMessaging/Example/InAppMessaging-Example-iOS.xcworkspace'  \
-        -scheme 'InAppMessaging-Example-iOS' \
+        -scheme 'InAppMessaging_Example_iOS' \
         "${xcb_flags[@]}" \
         build \
         test

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -48,6 +48,7 @@ case "$PROJECT-$PLATFORM-$METHOD" in
   InAppMessagingDisplay-iOS-xcodebuild)
     gem install xcpretty
     bundle exec pod install --project-directory=InAppMessagingDisplay/Example --repo-update
+    bundle exec pod install --project-directory=InAppMessaging/Example --repo-update
     ;;
 
   Firestore-*-xcodebuild | Firestore-*-fuzz)


### PR DESCRIPTION
Adds headless In App Messaging build and unit testing to Travis CI.

A follow up PR will add `pod lib lint` testing once the SpecsStaging repo gets set up with its new dependencies.