### PR TITLE
Update gRPC certificate bundles locations for Firebase 5.16

### DIFF
--- a/Carthage.md
+++ b/Carthage.md
@@ -65,7 +65,7 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseStorageBinary.jso
     into the Xcode project and make sure they're added to the
     `Copy Bundle Resources` Build Phase :
     - For Firestore:
-        - ./Carthage/Build/iOS/gRPC-C++.framework/gRPCCertificates.bundle
+        - ./Carthage/Build/iOS/FirebaseFirestore.framework/gRPCCertificates.bundle
     - For Invites:
         - ./Carthage/Build/iOS/FirebaseInvites.framework/GoogleSignIn.bundle
         - ./Carthage/Build/iOS/FirebaseInvites.framework/GPPACLPickerResources.bundle

--- a/Carthage.md
+++ b/Carthage.md
@@ -65,7 +65,7 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseStorageBinary.jso
     into the Xcode project and make sure they're added to the
     `Copy Bundle Resources` Build Phase :
     - For Firestore:
-        - ./Carthage/Build/iOS/FirebaseFirestore.framework/gRPCCertificates-Firestore.bundle
+        - ./Carthage/Build/iOS/gRPC-C++.framework/gRPCCertificates.bundle
     - For Invites:
         - ./Carthage/Build/iOS/FirebaseInvites.framework/GoogleSignIn.bundle
         - ./Carthage/Build/iOS/FirebaseInvites.framework/GPPACLPickerResources.bundle


### PR DESCRIPTION
We referred to this updated text in the [release notes](https://firebase.google.com/support/release-notes/ios#5.16.0) but then failed to actually update them (AFAICS).