### PR TITLE
Firebase In-app messaging callbacks

### DIFF
--- a/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.h
+++ b/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.h
@@ -22,6 +22,7 @@
 #import "FIRIAMClearcutLogger.h"
 #import "FIRIAMMessageClientCache.h"
 #import "FIRIAMTimeFetcher.h"
+#import "FIRInAppMessaging.h"
 #import "FIRInAppMessagingRendering.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -39,13 +40,14 @@ NS_ASSUME_NONNULL_BEGIN
 //   2 For non-contextual messages, the display interval in display setting is met.
 @interface FIRIAMDisplayExecutor : NSObject
 
-- (instancetype)initWithSetting:(FIRIAMDisplaySetting *)setting
-                   messageCache:(FIRIAMMessageClientCache *)cache
-                    timeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher
-                     bookKeeper:(id<FIRIAMBookKeeper>)displayBookKeeper
-              actionURLFollower:(FIRIAMActionURLFollower *)actionURLFollower
-                 activityLogger:(FIRIAMActivityLogger *)activityLogger
-           analyticsEventLogger:(id<FIRIAMAnalyticsEventLogger>)analyticsEventLogger;
+- (instancetype)initWithInAppMessaging:(FIRInAppMessaging *)inAppMessaging
+                               setting:(FIRIAMDisplaySetting *)setting
+                          messageCache:(FIRIAMMessageClientCache *)cache
+                           timeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher
+                            bookKeeper:(id<FIRIAMBookKeeper>)displayBookKeeper
+                     actionURLFollower:(FIRIAMActionURLFollower *)actionURLFollower
+                        activityLogger:(FIRIAMActivityLogger *)activityLogger
+                  analyticsEventLogger:(id<FIRIAMAnalyticsEventLogger>)analyticsEventLogger;
 
 // Check and display next in-app message eligible for app open trigger
 - (void)checkAndDisplayNextAppForegroundMessage;

--- a/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.m
@@ -49,7 +49,7 @@
 - (void)messageClicked:(FIRInAppMessagingDisplayMessage *)inAppMessage {
   // Call through to app-side delegate.
   __weak id<FIRInAppMessagingDisplayDelegate> appSideDelegate =
-  [FIRInAppMessaging inAppMessaging].delegate;
+      [FIRInAppMessaging inAppMessaging].delegate;
   if ([appSideDelegate respondsToSelector:@selector(messageClicked:)]) {
     [appSideDelegate messageClicked:inAppMessage];
   }
@@ -136,7 +136,7 @@
              dismissType:(FIRInAppMessagingDismissType)dismissType {
   // Call through to app-side delegate.
   __weak id<FIRInAppMessagingDisplayDelegate> appSideDelegate =
-  [FIRInAppMessaging inAppMessaging].delegate;
+      [FIRInAppMessaging inAppMessaging].delegate;
   if ([appSideDelegate respondsToSelector:@selector(messageDismissed:dismissType:)]) {
     [appSideDelegate messageDismissed:inAppMessage dismissType:dismissType];
   }
@@ -188,7 +188,7 @@
 
 - (void)impressionDetectedForMessage:(FIRInAppMessagingDisplayMessage *)inAppMessage {
   __weak id<FIRInAppMessagingDisplayDelegate> appSideDelegate =
-  [FIRInAppMessaging inAppMessaging].delegate;
+      [FIRInAppMessaging inAppMessaging].delegate;
   if ([appSideDelegate respondsToSelector:@selector(impressionDetectedForMessage:)]) {
     [appSideDelegate impressionDetectedForMessage:inAppMessage];
   }
@@ -214,7 +214,7 @@
 - (void)displayErrorForMessage:(FIRInAppMessagingDisplayMessage *)inAppMessage
                          error:(NSError *)error {
   __weak id<FIRInAppMessagingDisplayDelegate> appSideDelegate =
-  [FIRInAppMessaging inAppMessaging].delegate;
+      [FIRInAppMessaging inAppMessaging].delegate;
   if ([appSideDelegate respondsToSelector:@selector(displayErrorForMessage:error:)]) {
     [appSideDelegate displayErrorForMessage:inAppMessage error:error];
   }
@@ -395,13 +395,13 @@
     imageOnlyMessageWithMessageDefinition:(FIRIAMMessageDefinition *)definition
                                 imageData:(FIRInAppMessagingImageData *)imageData
                               triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType {
-  FIRInAppMessagingImageOnlyDisplay *imageOnlyMessage =
-      [[FIRInAppMessagingImageOnlyDisplay alloc] initWithMessageID:definition.renderData.messageID
-                                                      campaignName:definition.renderData.name
-                                               renderAsTestMessage:definition.isTestMessage
-                                                       triggerType:triggerType
-                                                         imageData:imageData
-                                                         actionURL:definition.renderData.contentData.actionURL];
+  FIRInAppMessagingImageOnlyDisplay *imageOnlyMessage = [[FIRInAppMessagingImageOnlyDisplay alloc]
+        initWithMessageID:definition.renderData.messageID
+             campaignName:definition.renderData.name
+      renderAsTestMessage:definition.isTestMessage
+              triggerType:triggerType
+                imageData:imageData
+                actionURL:definition.renderData.contentData.actionURL];
 
   return imageOnlyMessage;
 }

--- a/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.m
@@ -33,6 +33,7 @@
 // YES if a message is being rendered at this time
 @property(nonatomic) BOOL isMsgBeingDisplayed;
 @property(nonatomic) NSTimeInterval lastDisplayTime;
+@property(nonatomic, nonnull, readonly) FIRInAppMessaging *inAppMessaging;
 @property(nonatomic, nonnull, readonly) FIRIAMDisplaySetting *setting;
 @property(nonatomic, nonnull, readonly) FIRIAMMessageClientCache *messageCache;
 @property(nonatomic, nonnull, readonly) id<FIRIAMBookKeeper> displayBookKeeper;
@@ -48,8 +49,7 @@
 #pragma mark - FIRInAppMessagingDisplayDelegate methods
 - (void)messageClicked:(FIRInAppMessagingDisplayMessage *)inAppMessage {
   // Call through to app-side delegate.
-  __weak id<FIRInAppMessagingDisplayDelegate> appSideDelegate =
-      [FIRInAppMessaging inAppMessaging].delegate;
+  __weak id<FIRInAppMessagingDisplayDelegate> appSideDelegate = self.inAppMessaging.delegate;
   if ([appSideDelegate respondsToSelector:@selector(messageClicked:)]) {
     [appSideDelegate messageClicked:inAppMessage];
   }
@@ -135,8 +135,7 @@
 - (void)messageDismissed:(FIRInAppMessagingDisplayMessage *)inAppMessage
              dismissType:(FIRInAppMessagingDismissType)dismissType {
   // Call through to app-side delegate.
-  __weak id<FIRInAppMessagingDisplayDelegate> appSideDelegate =
-      [FIRInAppMessaging inAppMessaging].delegate;
+  __weak id<FIRInAppMessagingDisplayDelegate> appSideDelegate = self.inAppMessaging.delegate;
   if ([appSideDelegate respondsToSelector:@selector(messageDismissed:dismissType:)]) {
     [appSideDelegate messageDismissed:inAppMessage dismissType:dismissType];
   }
@@ -187,8 +186,7 @@
 }
 
 - (void)impressionDetectedForMessage:(FIRInAppMessagingDisplayMessage *)inAppMessage {
-  __weak id<FIRInAppMessagingDisplayDelegate> appSideDelegate =
-      [FIRInAppMessaging inAppMessaging].delegate;
+  __weak id<FIRInAppMessagingDisplayDelegate> appSideDelegate = self.inAppMessaging.delegate;
   if ([appSideDelegate respondsToSelector:@selector(impressionDetectedForMessage:)]) {
     [appSideDelegate impressionDetectedForMessage:inAppMessage];
   }
@@ -213,8 +211,7 @@
 
 - (void)displayErrorForMessage:(FIRInAppMessagingDisplayMessage *)inAppMessage
                          error:(NSError *)error {
-  __weak id<FIRInAppMessagingDisplayDelegate> appSideDelegate =
-      [FIRInAppMessaging inAppMessaging].delegate;
+  __weak id<FIRInAppMessagingDisplayDelegate> appSideDelegate = self.inAppMessaging.delegate;
   if ([appSideDelegate respondsToSelector:@selector(displayErrorForMessage:error:)]) {
     [appSideDelegate displayErrorForMessage:inAppMessage error:error];
   }
@@ -312,14 +309,16 @@
                                                                              completion:nil];
 }
 
-- (instancetype)initWithSetting:(FIRIAMDisplaySetting *)setting
-                   messageCache:(FIRIAMMessageClientCache *)cache
-                    timeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher
-                     bookKeeper:(id<FIRIAMBookKeeper>)displayBookKeeper
-              actionURLFollower:(FIRIAMActionURLFollower *)actionURLFollower
-                 activityLogger:(FIRIAMActivityLogger *)activityLogger
-           analyticsEventLogger:(id<FIRIAMAnalyticsEventLogger>)analyticsEventLogger {
+- (instancetype)initWithInAppMessaging:(FIRInAppMessaging *)inAppMessaging
+                               setting:(FIRIAMDisplaySetting *)setting
+                          messageCache:(FIRIAMMessageClientCache *)cache
+                           timeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher
+                            bookKeeper:(id<FIRIAMBookKeeper>)displayBookKeeper
+                     actionURLFollower:(FIRIAMActionURLFollower *)actionURLFollower
+                        activityLogger:(FIRIAMActivityLogger *)activityLogger
+                  analyticsEventLogger:(id<FIRIAMAnalyticsEventLogger>)analyticsEventLogger {
   if (self = [super init]) {
+    _inAppMessaging = inAppMessaging;
     _timeFetcher = timeFetcher;
     _lastDisplayTime = displayBookKeeper.lastDisplayTime;
     _setting = setting;

--- a/Firebase/InAppMessaging/Public/FIRInAppMessaging.h
+++ b/Firebase/InAppMessaging/Public/FIRInAppMessaging.h
@@ -76,5 +76,11 @@ NS_SWIFT_NAME(InAppMessaging)
  * property so that it can be used for rendering fiam message UIs.
  */
 @property(nonatomic) id<FIRInAppMessagingDisplay> messageDisplayComponent;
+
+/**
+ * This delegate should be set on the app side to receive message lifecycle events in app runtime.
+ */
+@property(nonatomic, weak) id<FIRInAppMessagingDisplayDelegate> delegate;
+
 @end
 NS_ASSUME_NONNULL_END

--- a/Firebase/InAppMessaging/Public/FIRInAppMessagingRendering.h
+++ b/Firebase/InAppMessaging/Public/FIRInAppMessagingRendering.h
@@ -24,7 +24,6 @@ typedef NS_ENUM(NSInteger, FIRInAppMessagingDisplayMessageType) {
   FIRInAppMessagingDisplayMessageTypeImageOnly
 };
 
-
 typedef NS_ENUM(NSInteger, FIRInAppMessagingDisplayTriggerType) {
   FIRInAppMessagingDisplayTriggerTypeOnAppForeground,
   FIRInAppMessagingDisplayTriggerTypeOnAnalyticsEvent
@@ -156,8 +155,7 @@ NS_SWIFT_NAME(InAppMessagingModalDisplay)
                   backgroundColor:(UIColor *)backgroundColor
                         imageData:(nullable FIRInAppMessagingImageData *)imageData
                      actionButton:(nullable FIRInAppMessagingActionButton *)actionButton
-                        actionURL:(nullable NSURL *)actionURL
-    NS_DESIGNATED_INITIALIZER;
+                        actionURL:(nullable NSURL *)actionURL NS_DESIGNATED_INITIALIZER;
 @end
 
 /** Class for defining a banner message for display.
@@ -196,8 +194,7 @@ NS_SWIFT_NAME(InAppMessagingBannerDisplay)
                         textColor:(UIColor *)textColor
                   backgroundColor:(UIColor *)backgroundColor
                         imageData:(nullable FIRInAppMessagingImageData *)imageData
-                        actionURL:(nullable NSURL *)actionURL
-    NS_DESIGNATED_INITIALIZER;
+                        actionURL:(nullable NSURL *)actionURL NS_DESIGNATED_INITIALIZER;
 @end
 
 /** Class for defining a image-only message for display.

--- a/Firebase/InAppMessaging/Public/FIRInAppMessagingRendering.h
+++ b/Firebase/InAppMessaging/Public/FIRInAppMessagingRendering.h
@@ -18,6 +18,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSInteger, FIRInAppMessagingDisplayMessageType) {
+  FIRInAppMessagingDisplayMessageTypeModal,
+  FIRInAppMessagingDisplayMessageTypeBanner,
+  FIRInAppMessagingDisplayMessageTypeImageOnly
+};
+
+
+typedef NS_ENUM(NSInteger, FIRInAppMessagingDisplayTriggerType) {
+  FIRInAppMessagingDisplayTriggerTypeOnAppForeground,
+  FIRInAppMessagingDisplayTriggerTypeOnAnalyticsEvent
+};
+
 /** Contains the display information for an action button.
  */
 NS_SWIFT_NAME(InAppMessagingActionButton)
@@ -60,24 +72,43 @@ NS_SWIFT_NAME(InAppMessagingImageData)
                        imageData:(NSData *)imageData NS_DESIGNATED_INITIALIZER;
 @end
 
-/**
- * Base class representing a FIAM message to be displayed. Don't create instance
- * of this class directly. Instantiate one of its subclasses instead.
+/** Defines the metadata for the campaign to which a FIAM message belongs.
  */
-NS_SWIFT_NAME(InAppMessagingDisplayMessageBase)
-@interface FIRInAppMessagingDisplayMessageBase : NSObject
-@property(nonatomic, copy, nonnull, readonly) NSString *messageID;
+@interface FIRInAppMessagingCampaignInfo : NSObject
+
+@property(nonatomic, nonnull, copy, readonly) NSString *messageID;
+@property(nonatomic, nonnull, copy, readonly) NSString *campaignName;
 @property(nonatomic, readonly) BOOL renderAsTestMessage;
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
               renderAsTestMessage:(BOOL)renderAsTestMessage;
+
+@end
+
+/**
+ * Base class representing a FIAM message to be displayed. Don't create instance
+ * of this class directly. Instantiate one of its subclasses instead.
+ */
+NS_SWIFT_NAME(InAppMessagingDisplayMessage)
+@interface FIRInAppMessagingDisplayMessage : NSObject
+@property(nonatomic, copy, nonnull, readonly) FIRInAppMessagingCampaignInfo *campaignInfo;
+@property(nonatomic, readonly) FIRInAppMessagingDisplayMessageType type;
+@property(nonatomic, readonly) FIRInAppMessagingDisplayTriggerType triggerType;
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage
+                      messageType:(FIRInAppMessagingDisplayMessageType)messageType
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType;
 @end
 
 /** Class for defining a modal message for display.
  */
 NS_SWIFT_NAME(InAppMessagingModalDisplay)
-@interface FIRInAppMessagingModalDisplay : FIRInAppMessagingDisplayMessageBase
+@interface FIRInAppMessagingModalDisplay : FIRInAppMessagingDisplayMessage
 
 /**
  * Gets the title for a modal fiam message.
@@ -100,6 +131,11 @@ NS_SWIFT_NAME(InAppMessagingModalDisplay)
 @property(nonatomic, nullable, readonly) FIRInAppMessagingActionButton *actionButton;
 
 /**
+ * Gets the action URL for a modal fiam message.
+ */
+@property(nonatomic, nullable, readonly) NSURL *actionURL;
+
+/**
  * Gets the background color for a modal fiam message.
  */
 @property(nonatomic, copy, nonnull) UIColor *displayBackgroundColor;
@@ -111,20 +147,23 @@ NS_SWIFT_NAME(InAppMessagingModalDisplay)
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
               renderAsTestMessage:(BOOL)renderAsTestMessage
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
                         titleText:(NSString *)title
                          bodyText:(NSString *)bodyText
                         textColor:(UIColor *)textColor
                   backgroundColor:(UIColor *)backgroundColor
                         imageData:(nullable FIRInAppMessagingImageData *)imageData
                      actionButton:(nullable FIRInAppMessagingActionButton *)actionButton
+                        actionURL:(nullable NSURL *)actionURL
     NS_DESIGNATED_INITIALIZER;
 @end
 
 /** Class for defining a banner message for display.
  */
 NS_SWIFT_NAME(InAppMessagingBannerDisplay)
-@interface FIRInAppMessagingBannerDisplay : FIRInAppMessagingDisplayMessageBase
+@interface FIRInAppMessagingBannerDisplay : FIRInAppMessagingDisplayMessage
 // Title is always required for modal messages.
 @property(nonatomic, nonnull, copy, readonly) NSString *title;
 
@@ -142,30 +181,47 @@ NS_SWIFT_NAME(InAppMessagingBannerDisplay)
  */
 @property(nonatomic, copy, nonnull) UIColor *textColor;
 
+/**
+ * Gets the action URL for a banner fiam message.
+ */
+@property(nonatomic, nullable, readonly) NSURL *actionURL;
+
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
               renderAsTestMessage:(BOOL)renderAsTestMessage
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
                         titleText:(NSString *)title
                          bodyText:(NSString *)bodyText
                         textColor:(UIColor *)textColor
                   backgroundColor:(UIColor *)backgroundColor
                         imageData:(nullable FIRInAppMessagingImageData *)imageData
+                        actionURL:(nullable NSURL *)actionURL
     NS_DESIGNATED_INITIALIZER;
 @end
 
 /** Class for defining a image-only message for display.
  */
 NS_SWIFT_NAME(InAppMessagingImageOnlyDisplay)
-@interface FIRInAppMessagingImageOnlyDisplay : FIRInAppMessagingDisplayMessageBase
+@interface FIRInAppMessagingImageOnlyDisplay : FIRInAppMessagingDisplayMessage
 
 /**
  * Gets the image for this message
  */
 @property(nonatomic, nonnull, copy, readonly) FIRInAppMessagingImageData *imageData;
+
+/**
+ * Gets the action URL for an image-only fiam message.
+ */
+@property(nonatomic, nullable, readonly) NSURL *actionURL;
+
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
               renderAsTestMessage:(BOOL)renderAsTestMessage
-                        imageData:(FIRInAppMessagingImageData *)imageData NS_DESIGNATED_INITIALIZER;
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
+                        imageData:(FIRInAppMessagingImageData *)imageData
+                        actionURL:(nullable NSURL *)actionURL NS_DESIGNATED_INITIALIZER;
 @end
 
 typedef NS_ENUM(NSInteger, FIRInAppMessagingDismissType) {
@@ -192,15 +248,17 @@ NS_SWIFT_NAME(InAppMessagingDisplayDelegate)
 @protocol FIRInAppMessagingDisplayDelegate <NSObject>
 /**
  * Called when the message is dismissed. Should be called from main thread.
+ * @param inAppMessage the message that was dismissed.
  * @param dismissType specifies how the message is closed.
  */
-- (void)messageDismissedWithType:(FIRInAppMessagingDismissType)dismissType
-    NS_SWIFT_NAME(messageDismissed(dismissType:));
+- (void)messageDismissed:(FIRInAppMessagingDisplayMessage *)inAppMessage
+             dismissType:(FIRInAppMessagingDismissType)dismissType;
 
 /**
  * Called when the message's action button is followed by the user.
+ * @param inAppMessage the message that was clicked.
  */
-- (void)messageClicked;
+- (void)messageClicked:(FIRInAppMessagingDisplayMessage *)inAppMessage;
 
 /**
  * Use this to mark a message as having gone through enough impression so that
@@ -217,8 +275,9 @@ NS_SWIFT_NAME(InAppMessagingDisplayDelegate)
  * in this case. But if the app regards this as a valid impression and does not
  * want the user to see the same message again, call impressionDetected to mark
  * a valid impression.
+ * @param inAppMessage the message for which an impression was detected.
  */
-- (void)impressionDetected;
+- (void)impressionDetectedForMessage:(FIRInAppMessagingDisplayMessage *)inAppMessage;
 
 /**
  * Called when the display component could not render the message due to various reason.
@@ -228,8 +287,10 @@ NS_SWIFT_NAME(InAppMessagingDisplayDelegate)
  * met. Missing this callback in failed rendering attempt would make headless
  * component think a fiam message is still being rendered and therefore suppress any
  * future message rendering.
+ * @param inAppMessage the message that encountered a display error.
  */
-- (void)displayErrorEncountered:(NSError *)error;
+- (void)displayErrorForMessage:(FIRInAppMessagingDisplayMessage *)inAppMessage
+                         error:(NSError *)error;
 @end
 
 /**
@@ -245,7 +306,7 @@ NS_SWIFT_NAME(InAppMessagingDisplay)
  * @param displayDelegate the callback object used to trigger notifications about certain
  *        conditions related to message rendering.
  */
-- (void)displayMessage:(FIRInAppMessagingDisplayMessageBase *)messageForDisplay
+- (void)displayMessage:(FIRInAppMessagingDisplayMessage *)messageForDisplay
        displayDelegate:(id<FIRInAppMessagingDisplayDelegate>)displayDelegate;
 @end
 NS_ASSUME_NONNULL_END

--- a/Firebase/InAppMessaging/RenderingObjects/FIRInAppMessagingRenderingDataClasses.m
+++ b/Firebase/InAppMessaging/RenderingObjects/FIRInAppMessagingRenderingDataClasses.m
@@ -18,13 +18,19 @@
 
 #import "FIRInAppMessagingRendering.h"
 
-@implementation FIRInAppMessagingDisplayMessageBase
+@implementation FIRInAppMessagingDisplayMessage
 
 - (instancetype)initWithMessageID:(NSString *)messageID
-              renderAsTestMessage:(BOOL)renderAsTestMessage {
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage
+                      messageType:(FIRInAppMessagingDisplayMessageType)messageType
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType {
   if (self = [super init]) {
-    _messageID = messageID;
-    _renderAsTestMessage = renderAsTestMessage;
+    _campaignInfo = [[FIRInAppMessagingCampaignInfo alloc] initWithMessageID:messageID
+                                                                campaignName:campaignName
+                                                         renderAsTestMessage:renderAsTestMessage];
+    _type = messageType;
+    _triggerType = triggerType;
   }
   return self;
 }
@@ -32,18 +38,26 @@
 
 @implementation FIRInAppMessagingBannerDisplay
 - (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
               renderAsTestMessage:(BOOL)renderAsTestMessage
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
                         titleText:(NSString *)title
                          bodyText:(NSString *)bodyText
                         textColor:(UIColor *)textColor
                   backgroundColor:(UIColor *)backgroundColor
-                        imageData:(nullable FIRInAppMessagingImageData *)imageData {
-  if (self = [super initWithMessageID:messageID renderAsTestMessage:renderAsTestMessage]) {
+                        imageData:(nullable FIRInAppMessagingImageData *)imageData
+                        actionURL:(nullable NSURL *)actionURL {
+  if (self = [super initWithMessageID:messageID
+                         campaignName:campaignName
+                  renderAsTestMessage:renderAsTestMessage
+                          messageType:FIRInAppMessagingDisplayMessageTypeBanner
+                          triggerType:triggerType]) {
     _title = title;
     _bodyText = bodyText;
     _textColor = textColor;
     _displayBackgroundColor = backgroundColor;
     _imageData = imageData;
+    _actionURL = actionURL;
   }
   return self;
 }
@@ -52,20 +66,28 @@
 @implementation FIRInAppMessagingModalDisplay
 
 - (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
               renderAsTestMessage:(BOOL)renderAsTestMessage
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
                         titleText:(NSString *)title
                          bodyText:(NSString *)bodyText
                         textColor:(UIColor *)textColor
                   backgroundColor:(UIColor *)backgroundColor
                         imageData:(nullable FIRInAppMessagingImageData *)imageData
-                     actionButton:(nullable FIRInAppMessagingActionButton *)actionButton {
-  if (self = [super initWithMessageID:messageID renderAsTestMessage:renderAsTestMessage]) {
+                     actionButton:(nullable FIRInAppMessagingActionButton *)actionButton
+                        actionURL:(nullable NSURL *)actionURL {
+  if (self = [super initWithMessageID:messageID
+                         campaignName:campaignName
+                  renderAsTestMessage:renderAsTestMessage
+                          messageType:FIRInAppMessagingDisplayMessageTypeModal
+                          triggerType:triggerType]) {
     _title = title;
     _bodyText = bodyText;
     _textColor = textColor;
     _displayBackgroundColor = backgroundColor;
     _imageData = imageData;
     _actionButton = actionButton;
+    _actionURL = actionURL;
   }
   return self;
 }
@@ -74,10 +96,18 @@
 @implementation FIRInAppMessagingImageOnlyDisplay
 
 - (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
               renderAsTestMessage:(BOOL)renderAsTestMessage
-                        imageData:(FIRInAppMessagingImageData *)imageData {
-  if (self = [super initWithMessageID:messageID renderAsTestMessage:renderAsTestMessage]) {
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
+                        imageData:(FIRInAppMessagingImageData *)imageData
+                        actionURL:(nullable NSURL *)actionURL {
+  if (self = [super initWithMessageID:messageID
+                         campaignName:campaignName
+                  renderAsTestMessage:renderAsTestMessage
+                          messageType:FIRInAppMessagingDisplayMessageTypeModal
+                          triggerType:triggerType]) {
     _imageData = imageData;
+    _actionURL = actionURL;
   }
   return self;
 }
@@ -102,6 +132,19 @@
   if (self = [super init]) {
     _imageURL = imageURL;
     _imageRawData = imageData;
+  }
+  return self;
+}
+@end
+
+@implementation FIRInAppMessagingCampaignInfo
+- (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage {
+  if (self = [super init]) {
+    _messageID = messageID;
+    _campaignName = campaignName;
+    _renderAsTestMessage = renderAsTestMessage;
   }
   return self;
 }

--- a/Firebase/InAppMessaging/Runtime/FIRIAMRuntimeManager.m
+++ b/Firebase/InAppMessaging/Runtime/FIRIAMRuntimeManager.m
@@ -337,13 +337,15 @@ static NSString *const kFirebaseInAppMessagingAutoDataCollectionKey =
 
   FIRIAMActionURLFollower *actionFollower = [FIRIAMActionURLFollower actionURLFollower];
 
-  self.displayExecutor = [[FIRIAMDisplayExecutor alloc] initWithSetting:appForegroundDisplaysetting
-                                                           messageCache:self.messageCache
-                                                            timeFetcher:timeFetcher
-                                                             bookKeeper:self.bookKeeper
-                                                      actionURLFollower:actionFollower
-                                                         activityLogger:self.activityLogger
-                                                   analyticsEventLogger:analyticsEventLogger];
+  self.displayExecutor =
+      [[FIRIAMDisplayExecutor alloc] initWithInAppMessaging:[FIRInAppMessaging inAppMessaging]
+                                                    setting:appForegroundDisplaysetting
+                                               messageCache:self.messageCache
+                                                timeFetcher:timeFetcher
+                                                 bookKeeper:self.bookKeeper
+                                          actionURLFollower:actionFollower
+                                             activityLogger:self.activityLogger
+                                       analyticsEventLogger:analyticsEventLogger];
 
   // Setting the display component. It's needed in case headless SDK is initialized after
   // the display component is already set on FIRInAppMessaging.

--- a/Firebase/InAppMessagingDisplay/Banner/FIDBannerViewController.m
+++ b/Firebase/InAppMessagingDisplay/Banner/FIDBannerViewController.m
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-#import <FirebaseInAppMessaging/FIRInAppMessagingRendering.h>
-
 #import "FIDBannerViewController.h"
 #import "FIRCore+InAppMessagingDisplay.h"
+#import "FIRInAppMessagingRendering.h"
 
 @interface FIDBannerViewController ()
 

--- a/Firebase/InAppMessagingDisplay/Banner/FIDBannerViewController.m
+++ b/Firebase/InAppMessagingDisplay/Banner/FIDBannerViewController.m
@@ -86,6 +86,10 @@ static const CGFloat kSwipeUpThreshold = -10.0f;
   return bannerVC;
 }
 
+- (FIRInAppMessagingDisplayMessage *)inAppMessage {
+  return self.bannerDisplayMessage;
+}
+
 - (void)setupRecognizers {
   UIPanGestureRecognizer *panSwipeRecognizer =
       [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePanSwipe:)];

--- a/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.h
+++ b/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.h
@@ -43,5 +43,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Call this when end user wants to follow the action url
 - (void)followActionURL;
+
+// Returns the in-app message being displayed. Overridden by message type subclasses.
+- (nullable FIRInAppMessagingDisplayMessage *)inAppMessage;
+
 @end
 NS_ASSUME_NONNULL_END

--- a/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.h
+++ b/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.h
@@ -16,8 +16,8 @@
 
 #import <UIKit/UIKit.h>
 
-#import <FirebaseInAppMessaging/FIRInAppMessagingRendering.h>
 #import "FIDTimeFetcher.h"
+#import "FIRInAppMessagingRendering.h"
 
 @protocol FIRInAppMessagingDisplayDelegate;
 

--- a/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.m
+++ b/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.m
@@ -35,6 +35,10 @@ static const NSTimeInterval kMinValidImpressionTime = 3.0;
 
 @implementation FIDBaseRenderingViewController
 
+- (nullable FIRInAppMessagingDisplayMessage *)inAppMessage {
+  return nil;
+}
+
 - (void)viewDidLoad {
   [super viewDidLoad];
 
@@ -102,8 +106,8 @@ static const NSTimeInterval kMinValidImpressionTime = 3.0;
   FIRLogDebug(kFIRLoggerInAppMessagingDisplay, @"I-FID200004",
               @"Min impression time has been reached.");
 
-  if ([self.displayDelegate respondsToSelector:@selector(impressionDetected)]) {
-    [self.displayDelegate impressionDetected];
+  if ([self.displayDelegate respondsToSelector:@selector(impressionDetectedForMessage:)]) {
+    [self.displayDelegate impressionDetectedForMessage:[self inAppMessage]];
   }
 
   [NSNotificationCenter.defaultCenter removeObserver:self];
@@ -133,7 +137,7 @@ static const NSTimeInterval kMinValidImpressionTime = 3.0;
   self.view.window.rootViewController = nil;
 
   if (self.displayDelegate) {
-    [self.displayDelegate messageDismissedWithType:dismissType];
+    [self.displayDelegate messageDismissed:[self inAppMessage] dismissType:dismissType];
   } else {
     FIRLogWarning(kFIRLoggerInAppMessagingDisplay, @"I-FID200007",
                   @"Display delegate is nil while message is being dismissed.");
@@ -147,7 +151,7 @@ static const NSTimeInterval kMinValidImpressionTime = 3.0;
   self.view.window.rootViewController = nil;
 
   if (self.displayDelegate) {
-    [self.displayDelegate messageClicked];
+    [self.displayDelegate messageClicked:[self inAppMessage]];
   } else {
     FIRLogWarning(kFIRLoggerInAppMessagingDisplay, @"I-FID200008",
                   @"Display delegate is nil while trying to follow action URL.");

--- a/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.m
+++ b/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.m
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-#import <FirebaseInAppMessaging/FIRInAppMessagingRendering.h>
-
 #import "FIDBaseRenderingViewController.h"
 #import "FIDTimeFetcher.h"
 #import "FIRCore+InAppMessagingDisplay.h"
+#import "FIRInAppMessagingRendering.h"
 
 @interface FIDBaseRenderingViewController ()
 // For fiam messages, it's required to be kMinValidImpressionTime to

--- a/Firebase/InAppMessagingDisplay/FIRIAMDefaultDisplayImpl.m
+++ b/Firebase/InAppMessagingDisplay/FIRIAMDefaultDisplayImpl.m
@@ -17,8 +17,6 @@
 #import <Foundation/Foundation.h>
 
 #import <FirebaseCore/FIRAppInternal.h>
-#import <FirebaseInAppMessaging/FIRInAppMessaging.h>
-#import <FirebaseInAppMessaging/FIRInAppMessagingRendering.h>
 
 #import "FIDBannerViewController.h"
 #import "FIDImageOnlyViewController.h"
@@ -27,6 +25,8 @@
 #import "FIDTimeFetcher.h"
 #import "FIRCore+InAppMessagingDisplay.h"
 #import "FIRIAMDefaultDisplayImpl.h"
+#import "FIRInAppMessaging.h"
+#import "FIRInAppMessagingRendering.h"
 
 @implementation FIRIAMDefaultDisplayImpl
 

--- a/Firebase/InAppMessagingDisplay/FIRIAMDefaultDisplayImpl.m
+++ b/Firebase/InAppMessagingDisplay/FIRIAMDefaultDisplayImpl.m
@@ -78,7 +78,7 @@
     NSError *error = [NSError errorWithDomain:kFirebaseInAppMessagingDisplayErrorDomain
                                          code:FIAMDisplayRenderErrorTypeUnspecifiedError
                                      userInfo:@{@"message" : @"resource bundle is missing"}];
-    [displayDelegate displayErrorEncountered:error];
+    [displayDelegate displayErrorForMessage:modalMessage error:error];
     return;
   }
 
@@ -96,7 +96,7 @@
       NSError *error = [NSError errorWithDomain:kFirebaseInAppMessagingDisplayErrorDomain
                                            code:FIAMDisplayRenderErrorTypeUnspecifiedError
                                        userInfo:@{}];
-      [displayDelegate displayErrorEncountered:error];
+      [displayDelegate displayErrorForMessage:modalMessage error:error];
       return;
     }
 
@@ -115,7 +115,7 @@
     NSError *error = [NSError errorWithDomain:kFirebaseInAppMessagingDisplayErrorDomain
                                          code:FIAMDisplayRenderErrorTypeUnspecifiedError
                                      userInfo:@{}];
-    [displayDelegate displayErrorEncountered:error];
+    [displayDelegate displayErrorForMessage:bannerMessage error:error];
     return;
   }
 
@@ -133,7 +133,7 @@
       NSError *error = [NSError errorWithDomain:kFirebaseInAppMessagingDisplayErrorDomain
                                            code:FIAMDisplayRenderErrorTypeUnspecifiedError
                                        userInfo:@{}];
-      [displayDelegate displayErrorEncountered:error];
+      [displayDelegate displayErrorForMessage:bannerMessage error:error];
       return;
     }
 
@@ -153,7 +153,7 @@
     NSError *error = [NSError errorWithDomain:kFirebaseInAppMessagingDisplayErrorDomain
                                          code:FIAMDisplayRenderErrorTypeUnspecifiedError
                                      userInfo:@{}];
-    [displayDelegate displayErrorEncountered:error];
+    [displayDelegate displayErrorForMessage:imageOnlyMessage error:error];
     return;
   }
 
@@ -171,7 +171,7 @@
       NSError *error = [NSError errorWithDomain:kFirebaseInAppMessagingDisplayErrorDomain
                                            code:FIAMDisplayRenderErrorTypeUnspecifiedError
                                        userInfo:@{}];
-      [displayDelegate displayErrorEncountered:error];
+      [displayDelegate displayErrorForMessage:imageOnlyMessage error:error];
       return;
     }
 
@@ -182,7 +182,7 @@
 }
 
 #pragma mark - protocol FIRInAppMessagingDisplay
-- (void)displayMessage:(FIRInAppMessagingDisplayMessageBase *)messageForDisplay
+- (void)displayMessage:(FIRInAppMessagingDisplayMessage *)messageForDisplay
        displayDelegate:(id<FIRInAppMessagingDisplayDelegate>)displayDelegate {
   if ([messageForDisplay isKindOfClass:[FIRInAppMessagingModalDisplay class]]) {
     FIRLogDebug(kFIRLoggerInAppMessagingDisplay, @"I-FID100000", @"Display a modal message");
@@ -208,7 +208,7 @@
     NSError *error = [NSError errorWithDomain:kFirebaseInAppMessagingDisplayErrorDomain
                                          code:FIAMDisplayRenderErrorTypeUnspecifiedError
                                      userInfo:@{}];
-    [displayDelegate displayErrorEncountered:error];
+    [displayDelegate displayErrorForMessage:messageForDisplay error:error];
   }
 }
 @end

--- a/Firebase/InAppMessagingDisplay/ImageOnly/FIDImageOnlyViewController.m
+++ b/Firebase/InAppMessagingDisplay/ImageOnly/FIDImageOnlyViewController.m
@@ -56,6 +56,10 @@
   return imageOnlyVC;
 }
 
+- (FIRInAppMessagingDisplayMessage *)inAppMessage {
+  return self.imageOnlyMessage;
+}
+
 - (IBAction)closeButtonClicked:(id)sender {
   [self dismissView:FIRInAppMessagingDismissTypeUserTapClose];
 }
@@ -151,7 +155,7 @@
                                              to:nil
                                            from:nil
                                        forEvent:nil];
-  if (self.imageOnlyMessage.renderAsTestMessage) {
+  if (self.imageOnlyMessage.campaignInfo.renderAsTestMessage) {
     FIRLogDebug(kFIRLoggerInAppMessagingDisplay, @"I-FID110004",
                 @"Flashing the close button since this is a test message.");
     [self flashCloseButton:self.closeButton];

--- a/Firebase/InAppMessagingDisplay/ImageOnly/FIDImageOnlyViewController.m
+++ b/Firebase/InAppMessagingDisplay/ImageOnly/FIDImageOnlyViewController.m
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-#import <FirebaseInAppMessaging/FIRInAppMessagingRendering.h>
-
 #import "FIDImageOnlyViewController.h"
 #import "FIRCore+InAppMessagingDisplay.h"
+#import "FIRInAppMessagingRendering.h"
 
 @interface FIDImageOnlyViewController ()
 

--- a/Firebase/InAppMessagingDisplay/Modal/FIDModalViewController.m
+++ b/Firebase/InAppMessagingDisplay/Modal/FIDModalViewController.m
@@ -95,6 +95,10 @@ static CGFloat LandScapePaddingBetweenImageAndTextColumn = 24;
   return modalVC;
 }
 
+- (FIRInAppMessagingDisplayMessage *)inAppMessage {
+  return self.modalDisplayMessage;
+}
+
 - (IBAction)closeButtonClicked:(id)sender {
   [self dismissView:FIRInAppMessagingDismissTypeUserTapClose];
 }
@@ -428,7 +432,7 @@ struct TitleBodyButtonHeightInfo {
                                            from:nil
                                        forEvent:nil];
 
-  if (self.modalDisplayMessage.renderAsTestMessage) {
+  if (self.modalDisplayMessage.campaignInfo.renderAsTestMessage) {
     FIRLogDebug(kFIRLoggerInAppMessagingDisplay, @"I-FID300011",
                 @"Flushing the close button since this is a test message.");
     [self flashCloseButton:self.closeButton];

--- a/Firebase/InAppMessagingDisplay/Modal/FIDModalViewController.m
+++ b/Firebase/InAppMessagingDisplay/Modal/FIDModalViewController.m
@@ -16,10 +16,9 @@
 
 #import <UIKit/UIKit.h>
 
-#import <FirebaseInAppMessaging/FIRInAppMessagingRendering.h>
-
 #import "FIDModalViewController.h"
 #import "FIRCore+InAppMessagingDisplay.h"
+#import "FIRInAppMessagingRendering.h"
 
 @interface FIDModalViewController ()
 

--- a/Firebase/InAppMessagingDisplay/Public/FIRIAMDefaultDisplayImpl.h
+++ b/Firebase/InAppMessagingDisplay/Public/FIRIAMDefaultDisplayImpl.h
@@ -25,7 +25,7 @@ NS_SWIFT_NAME(InAppMessagingDefaultDisplayImpl)
  * to help UI Testing app access the UI layer directly.
  */
 @interface FIRIAMDefaultDisplayImpl : NSObject <FIRInAppMessagingDisplay>
-- (void)displayMessage:(FIRInAppMessagingDisplayMessageBase *)messageForDisplay
+- (void)displayMessage:(FIRInAppMessagingDisplayMessage *)messageForDisplay
        displayDelegate:(id<FIRInAppMessagingDisplayDelegate>)displayDelegate;
 @end
 NS_ASSUME_NONNULL_END

--- a/Firebase/InAppMessagingDisplay/Public/FIRIAMDefaultDisplayImpl.h
+++ b/Firebase/InAppMessagingDisplay/Public/FIRIAMDefaultDisplayImpl.h
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-#import <FirebaseInAppMessaging/FIRInAppMessagingRendering.h>
 #import <Foundation/Foundation.h>
+
+#import "FIRInAppMessagingRendering.h"
 
 NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(InAppMessagingDefaultDisplayImpl)

--- a/Firestore/Swift/Source/Codable/CodableGeoPoint.swift
+++ b/Firestore/Swift/Source/Codable/CodableGeoPoint.swift
@@ -24,7 +24,7 @@ import FirebaseFirestore
  * marked required but that can't be done in an extension. Declaring the extension on the protocol
  * sidesteps this issue.
  */
-fileprivate protocol CodableGeoPoint: Codable {
+private protocol CodableGeoPoint: Codable {
   var latitude: Double { get }
   var longitude: Double { get }
 
@@ -32,7 +32,7 @@ fileprivate protocol CodableGeoPoint: Codable {
 }
 
 /** The keys in a GeoPoint. Must match the properties of CodableGeoPoint. */
-fileprivate enum GeoPointKeys: String, CodingKey {
+private enum GeoPointKeys: String, CodingKey {
   case latitude
   case longitude
 }

--- a/InAppMessaging/Example/Tests/FIRIAMDisplayExecutorTests.m
+++ b/InAppMessaging/Example/Tests/FIRIAMDisplayExecutorTests.m
@@ -125,33 +125,6 @@ typedef NS_ENUM(NSInteger, FIRInAppMessagingDelegateInteraction) {
 }
 @end
 
-@interface FIRInAppMessagingDisplayTestDelegate : NSObject <FIRInAppMessagingDisplayDelegate>
-
-@property(nonatomic) BOOL receivedMessageImpressionCallback;
-@property(nonatomic) BOOL receivedMessageClickedCallback;
-
-@end
-
-@implementation FIRInAppMessagingDisplayTestDelegate
-
-- (void)displayErrorForMessage:(nonnull FIRInAppMessagingDisplayMessage *)inAppMessage
-                         error:(nonnull NSError *)error {
-}
-
-- (void)impressionDetectedForMessage:(nonnull FIRInAppMessagingDisplayMessage *)inAppMessage {
-  self.receivedMessageImpressionCallback = YES;
-}
-
-- (void)messageClicked:(nonnull FIRInAppMessagingDisplayMessage *)inAppMessage {
-  self.receivedMessageClickedCallback = YES;
-}
-
-- (void)messageDismissed:(nonnull FIRInAppMessagingDisplayMessage *)inAppMessage
-             dismissType:(FIRInAppMessagingDismissType)dismissType {
-}
-
-@end
-
 @interface FIRIAMDisplayExecutorTests : XCTestCase
 
 @property(nonatomic) FIRIAMDisplaySetting *displaySetting;
@@ -313,11 +286,6 @@ NSTimeInterval DISPLAY_MIN_INTERVALS = 1;
 
   OCMStub([self.mockBookkeeper recordNewImpressionForMessage:[OCMArg any]
                                  withStartTimestampInSeconds:1000]);
-}
-
-- (void)tearDown {
-  [FIRInAppMessaging inAppMessaging].delegate = nil;
-  [super tearDown];
 }
 
 - (void)testRegularMessageAvailableCase {
@@ -786,29 +754,6 @@ NSTimeInterval DISPLAY_MIN_INTERVALS = 1;
   NSInteger remainingMsgCount2 = [self.clientMessageCache allRegularMessages].count;
   // one message was rendered and removed from the cache
   XCTAssertEqual(1, remainingMsgCount2);
-}
-
-- (void)testRegularMessageRegistersImpression {
-  FIRInAppMessagingDisplayTestDelegate *delegate =
-      [[FIRInAppMessagingDisplayTestDelegate alloc] init];
-  [FIRInAppMessaging inAppMessaging].delegate = delegate;
-
-  // This setup allows next message to be displayed from display interval perspective.
-  OCMStub([self.mockTimeFetcher currentTimestampInSeconds])
-      .andReturn(DISPLAY_MIN_INTERVALS * 60 + 100);
-
-  FIRIAMMessageDisplayForTesting *display = [[FIRIAMMessageDisplayForTesting alloc]
-      initWithDelegateInteraction:FIRInAppMessagingDelegateInteractionClick];
-  self.displayExecutor.messageDisplayComponent = display;
-  [self.clientMessageCache setMessageData:@[ self.m2, self.m4 ]];
-  [self.displayExecutor checkAndDisplayNextAppForegroundMessage];
-  NSInteger remainingMsgCount = [self.clientMessageCache allRegularMessages].count;
-  XCTAssertEqual(1, remainingMsgCount);
-
-  // Verify that the message content handed to display component is expected
-  XCTAssertEqualObjects(self.m2.renderData.messageID, display.message.campaignInfo.messageID);
-
-  XCTAssertTrue(delegate.receivedMessageClickedCallback);
 }
 
 @end

--- a/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/BannerMessageViewController.swift
+++ b/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/BannerMessageViewController.swift
@@ -16,8 +16,6 @@
 
 import UIKit
 
-import FirebaseInAppMessaging
-
 class BannerMessageViewController: CommonMessageTestVC {
   let displayImpl = InAppMessagingDefaultDisplayImpl()
 

--- a/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/BannerMessageViewController.swift
+++ b/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/BannerMessageViewController.swift
@@ -23,13 +23,14 @@ class BannerMessageViewController: CommonMessageTestVC {
 
   @IBOutlet var verifyLabel: UILabel!
 
-  override func messageClicked() {
-    super.messageClicked()
+  override func messageClicked(_ inAppMessage: InAppMessagingDisplayMessage) {
+    super.messageClicked(inAppMessage)
     verifyLabel.text = "message clicked!"
   }
 
-  override func messageDismissed(dismissType dimissType: FIRInAppMessagingDismissType) {
-    super.messageClicked()
+  override func messageDismissed(_ inAppMessage: InAppMessagingDisplayMessage,
+                                 dismissType: FIRInAppMessagingDismissType) {
+    super.messageClicked(inAppMessage)
     verifyLabel.text = "message dismissed!"
   }
 
@@ -38,26 +39,32 @@ class BannerMessageViewController: CommonMessageTestVC {
     let imageRawData = produceImageOfSize(size: CGSize(width: 200, height: 200))
     let fiamImageData = InAppMessagingImageData(imageURL: "url not important", imageData: imageRawData!)
 
-    let modalMessage = InAppMessagingBannerDisplay(messageID: "messageId",
-                                                   renderAsTestMessage: false,
-                                                   titleText: normalMessageTitle,
-                                                   bodyText: normalMessageBody,
-                                                   textColor: UIColor.black,
-                                                   backgroundColor: UIColor.blue,
-                                                   imageData: fiamImageData)
+    let bannerMessage = InAppMessagingBannerDisplay(messageID: "messageId",
+                                                    campaignName: "testCampaign",
+                                                    renderAsTestMessage: false,
+                                                    triggerType: .onAnalyticsEvent,
+                                                    titleText: normalMessageTitle,
+                                                    bodyText: normalMessageBody,
+                                                    textColor: UIColor.black,
+                                                    backgroundColor: UIColor.blue,
+                                                    imageData: fiamImageData,
+                                                    actionURL: URL(string: "http://firebase.com"))
 
-    displayImpl.displayMessage(modalMessage, displayDelegate: self)
+    displayImpl.displayMessage(bannerMessage, displayDelegate: self)
   }
 
   @IBAction func showBannerViewWithoutImageTapped(_ sender: Any) {
     verifyLabel.text = "Verification Label"
     let modalMessage = InAppMessagingBannerDisplay(messageID: "messageId",
+                                                   campaignName: "testCampaign",
                                                    renderAsTestMessage: false,
+                                                   triggerType: .onAnalyticsEvent,
                                                    titleText: normalMessageTitle,
                                                    bodyText: normalMessageBody,
                                                    textColor: UIColor.black,
                                                    backgroundColor: UIColor.blue,
-                                                   imageData: nil)
+                                                   imageData: nil,
+                                                   actionURL: URL(string: "http://firebase.com"))
 
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
@@ -68,12 +75,15 @@ class BannerMessageViewController: CommonMessageTestVC {
     let fiamImageData = InAppMessagingImageData(imageURL: "url not important", imageData: imageRawData!)
 
     let modalMessage = InAppMessagingBannerDisplay(messageID: "messageId",
+                                                   campaignName: "testCampaign",
                                                    renderAsTestMessage: false,
+                                                   triggerType: .onAnalyticsEvent,
                                                    titleText: normalMessageTitle,
                                                    bodyText: normalMessageBody,
                                                    textColor: UIColor.black,
                                                    backgroundColor: UIColor.blue,
-                                                   imageData: fiamImageData)
+                                                   imageData: fiamImageData,
+                                                   actionURL: URL(string: "http://firebase.com"))
 
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
@@ -84,12 +94,15 @@ class BannerMessageViewController: CommonMessageTestVC {
     let fiamImageData = InAppMessagingImageData(imageURL: "url not important", imageData: imageRawData!)
 
     let modalMessage = InAppMessagingBannerDisplay(messageID: "messageId",
+                                                   campaignName: "testCampaign",
                                                    renderAsTestMessage: false,
+                                                   triggerType: .onAnalyticsEvent,
                                                    titleText: normalMessageTitle,
                                                    bodyText: normalMessageBody,
                                                    textColor: UIColor.black,
                                                    backgroundColor: UIColor.blue,
-                                                   imageData: fiamImageData)
+                                                   imageData: fiamImageData,
+                                                   actionURL: URL(string: "http://firebase.com"))
 
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
@@ -100,12 +113,15 @@ class BannerMessageViewController: CommonMessageTestVC {
     let fiamImageData = InAppMessagingImageData(imageURL: "url not important", imageData: imageRawData!)
 
     let modalMessage = InAppMessagingBannerDisplay(messageID: "messageId",
+                                                   campaignName: "testCampaign",
                                                    renderAsTestMessage: false,
+                                                   triggerType: .onAnalyticsEvent,
                                                    titleText: normalMessageTitle,
                                                    bodyText: longBodyText,
                                                    textColor: UIColor.black,
                                                    backgroundColor: UIColor.blue,
-                                                   imageData: fiamImageData)
+                                                   imageData: fiamImageData,
+                                                   actionURL: URL(string: "http://firebase.com"))
 
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
@@ -116,12 +132,15 @@ class BannerMessageViewController: CommonMessageTestVC {
     let fiamImageData = InAppMessagingImageData(imageURL: "url not important", imageData: imageRawData!)
 
     let modalMessage = InAppMessagingBannerDisplay(messageID: "messageId",
+                                                   campaignName: "testCampaign",
                                                    renderAsTestMessage: false,
+                                                   triggerType: .onAnalyticsEvent,
                                                    titleText: longTitleText,
                                                    bodyText: normalMessageBody,
                                                    textColor: UIColor.black,
                                                    backgroundColor: UIColor.blue,
-                                                   imageData: fiamImageData)
+                                                   imageData: fiamImageData,
+                                                   actionURL: URL(string: "http://firebase.com"))
 
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }

--- a/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/CommonMessageTestVC.swift
+++ b/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/CommonMessageTestVC.swift
@@ -32,7 +32,7 @@ class CommonMessageTestVC: UIViewController, InAppMessagingDisplayDelegate {
   func impressionDetected(for inAppMessage: InAppMessagingDisplayMessage) {
     print("valid impression detected")
   }
-  
+
   func displayError(for inAppMessage: InAppMessagingDisplayMessage, error: Error) {
     print("error encountered \(error)")
   }

--- a/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/CommonMessageTestVC.swift
+++ b/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/CommonMessageTestVC.swift
@@ -24,14 +24,21 @@ class CommonMessageTestVC: UIViewController, InAppMessagingDisplayDelegate {
   var messageClosedDismiss = false
 
   // start of InAppMessagingDisplayDelegate functions
-  func messageClicked() {
+  func messageClicked(_ inAppMessage: InAppMessagingDisplayMessage) {
     print("message clicked to follow action url")
     messageClosedWithClick = true
   }
 
-  func impressionDetected() { print("valid impression detected") }
-  func displayErrorEncountered(_ error: Error) { print("error encountered \(error)") }
-  func messageDismissed(dismissType: FIRInAppMessagingDismissType) {
+  func impressionDetected(for inAppMessage: InAppMessagingDisplayMessage) {
+    print("valid impression detected")
+  }
+  
+  func displayError(for inAppMessage: InAppMessagingDisplayMessage, error: Error) {
+    print("error encountered \(error)")
+  }
+
+  func messageDismissed(_ inAppMessage: InAppMessagingDisplayMessage,
+                        dismissType: FIRInAppMessagingDismissType) {
     print("message dimissed with type \(dismissType)")
     messageClosedDismiss = true
   }

--- a/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/CommonMessageTestVC.swift
+++ b/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/CommonMessageTestVC.swift
@@ -16,8 +16,6 @@
 
 import Foundation
 
-import FirebaseInAppMessaging
-
 class CommonMessageTestVC: UIViewController, InAppMessagingDisplayDelegate {
   var messageClosedWithClick = false
 

--- a/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/ImageOnlyMessageViewController.swift
+++ b/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/ImageOnlyMessageViewController.swift
@@ -21,13 +21,14 @@ class ImageOnlyMessageViewController: CommonMessageTestVC {
 
   @IBOutlet var verifyLabel: UILabel!
 
-  override func messageClicked() {
-    super.messageClicked()
+  override func messageClicked(_ inAppMessage: InAppMessagingDisplayMessage) {
+    super.messageClicked(inAppMessage)
     verifyLabel.text = "message clicked!"
   }
 
-  override func messageDismissed(dismissType dimissType: FIRInAppMessagingDismissType) {
-    super.messageClicked()
+  override func messageDismissed(_ inAppMessage: InAppMessagingDisplayMessage,
+                                 dismissType: FIRInAppMessagingDismissType) {
+    super.messageClicked(inAppMessage)
     verifyLabel.text = "message dismissed!"
   }
 
@@ -37,9 +38,11 @@ class ImageOnlyMessageViewController: CommonMessageTestVC {
     let fiamImageData = InAppMessagingImageData(imageURL: "url not important", imageData: imageRawData!)
 
     let modalMessage = InAppMessagingImageOnlyDisplay(messageID: "messageId",
+                                                      campaignName: "testCampaign",
                                                       renderAsTestMessage: false,
-                                                      imageData: fiamImageData)
-
+                                                      triggerType: .onAnalyticsEvent,
+                                                      imageData: fiamImageData,
+                                                      actionURL: URL(string: "http://firebase.com"))
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
 
@@ -49,9 +52,11 @@ class ImageOnlyMessageViewController: CommonMessageTestVC {
     let fiamImageData = InAppMessagingImageData(imageURL: "url not important", imageData: imageRawData!)
 
     let modalMessage = InAppMessagingImageOnlyDisplay(messageID: "messageId",
+                                                      campaignName: "testCampaign",
                                                       renderAsTestMessage: false,
-                                                      imageData: fiamImageData)
-
+                                                      triggerType: .onAnalyticsEvent,
+                                                      imageData: fiamImageData,
+                                                      actionURL: URL(string: "http://firebase.com"))
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
 
@@ -61,9 +66,11 @@ class ImageOnlyMessageViewController: CommonMessageTestVC {
     let fiamImageData = InAppMessagingImageData(imageURL: "url not important", imageData: imageRawData!)
 
     let modalMessage = InAppMessagingImageOnlyDisplay(messageID: "messageId",
+                                                      campaignName: "testCampaign",
                                                       renderAsTestMessage: false,
-                                                      imageData: fiamImageData)
-
+                                                      triggerType: .onAnalyticsEvent,
+                                                      imageData: fiamImageData,
+                                                      actionURL: URL(string: "http://firebase.com"))
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
 
@@ -73,9 +80,11 @@ class ImageOnlyMessageViewController: CommonMessageTestVC {
     let fiamImageData = InAppMessagingImageData(imageURL: "url not important", imageData: imageRawData!)
 
     let modalMessage = InAppMessagingImageOnlyDisplay(messageID: "messageId",
+                                                      campaignName: "testCampaign",
                                                       renderAsTestMessage: false,
-                                                      imageData: fiamImageData)
-
+                                                      triggerType: .onAnalyticsEvent,
+                                                      imageData: fiamImageData,
+                                                      actionURL: URL(string: "http://firebase.com"))
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
 
@@ -84,9 +93,11 @@ class ImageOnlyMessageViewController: CommonMessageTestVC {
     let fiamImageData = InAppMessagingImageData(imageURL: "url not important", imageData: imageRawData!)
 
     let modalMessage = InAppMessagingImageOnlyDisplay(messageID: "messageId",
+                                                      campaignName: "testCampaign",
                                                       renderAsTestMessage: false,
-                                                      imageData: fiamImageData)
-
+                                                      triggerType: .onAnalyticsEvent,
+                                                      imageData: fiamImageData,
+                                                      actionURL: URL(string: "http://firebase.com"))
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
 }

--- a/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/ImageOnlyMessageViewController.swift
+++ b/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/ImageOnlyMessageViewController.swift
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import UIKit
-import FirebaseInAppMessaging
 
 class ImageOnlyMessageViewController: CommonMessageTestVC {
   let displayImpl = InAppMessagingDefaultDisplayImpl()

--- a/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/ModalMessageViewController.swift
+++ b/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/ModalMessageViewController.swift
@@ -22,13 +22,14 @@ class ModalMessageViewController: CommonMessageTestVC {
 
   @IBOutlet var verifyLabel: UILabel!
 
-  override func messageClicked() {
-    super.messageClicked()
+  override func messageClicked(_ inAppMessage: InAppMessagingDisplayMessage) {
+    super.messageClicked(inAppMessage)
     verifyLabel.text = "message clicked!"
   }
 
-  override func messageDismissed(dismissType dimissType: FIRInAppMessagingDismissType) {
-    super.messageClicked()
+  override func messageDismissed(_ inAppMessage: InAppMessagingDisplayMessage,
+                                 dismissType: FIRInAppMessagingDismissType) {
+    super.messageClicked(inAppMessage)
     verifyLabel.text = "message dismissed!"
   }
 
@@ -36,15 +37,18 @@ class ModalMessageViewController: CommonMessageTestVC {
     verifyLabel.text = "Verification Label"
     let imageRawData = produceImageOfSize(size: CGSize(width: 200, height: 200))
     let fiamImageData = InAppMessagingImageData(imageURL: "url not important", imageData: imageRawData!)
-
+    
     let modalMessage = InAppMessagingModalDisplay(messageID: "messageId",
+                                                  campaignName: "testCampaign",
                                                   renderAsTestMessage: false,
+                                                  triggerType: .onAnalyticsEvent,
                                                   titleText: normalMessageTitle,
                                                   bodyText: normalMessageBody,
                                                   textColor: UIColor.black,
                                                   backgroundColor: UIColor.blue,
                                                   imageData: fiamImageData,
-                                                  actionButton: defaultActionButton)
+                                                  actionButton: defaultActionButton,
+                                                  actionURL: URL(string: "http://firebase.com"))
 
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
@@ -52,13 +56,16 @@ class ModalMessageViewController: CommonMessageTestVC {
   @IBAction func showWithoutImage(_ sender: Any) {
     verifyLabel.text = "Verification Label"
     let modalMessage = InAppMessagingModalDisplay(messageID: "messageId",
+                                                  campaignName: "testCampaign",
                                                   renderAsTestMessage: false,
+                                                  triggerType: .onAnalyticsEvent,
                                                   titleText: normalMessageTitle,
                                                   bodyText: normalMessageBody,
                                                   textColor: UIColor.black,
                                                   backgroundColor: UIColor.blue,
                                                   imageData: nil,
-                                                  actionButton: defaultActionButton)
+                                                  actionButton: defaultActionButton,
+                                                  actionURL: URL(string: "http://firebase.com"))
 
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
@@ -69,13 +76,16 @@ class ModalMessageViewController: CommonMessageTestVC {
     let fiamImageData = InAppMessagingImageData(imageURL: "url not important", imageData: imageRawData!)
 
     let modalMessage = InAppMessagingModalDisplay(messageID: "messageId",
+                                                  campaignName: "testCampaign",
                                                   renderAsTestMessage: false,
+                                                  triggerType: .onAnalyticsEvent,
                                                   titleText: normalMessageTitle,
                                                   bodyText: normalMessageBody,
                                                   textColor: UIColor.black,
                                                   backgroundColor: UIColor.blue,
                                                   imageData: fiamImageData,
-                                                  actionButton: nil)
+                                                  actionButton: nil,
+                                                  actionURL: nil)
 
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
@@ -83,13 +93,16 @@ class ModalMessageViewController: CommonMessageTestVC {
   @IBAction func showWithoutImageAndButton(_ sender: Any) {
     verifyLabel.text = "Verification Label"
     let modalMessage = InAppMessagingModalDisplay(messageID: "messageId",
+                                                  campaignName: "testCampaign",
                                                   renderAsTestMessage: false,
+                                                  triggerType: .onAnalyticsEvent,
                                                   titleText: normalMessageTitle,
                                                   bodyText: normalMessageBody,
                                                   textColor: UIColor.black,
                                                   backgroundColor: UIColor.blue,
                                                   imageData: nil,
-                                                  actionButton: nil)
+                                                  actionButton: nil,
+                                                  actionURL: nil)
 
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
@@ -97,13 +110,16 @@ class ModalMessageViewController: CommonMessageTestVC {
   @IBAction func showWithLargeBody(_ sender: Any) {
     verifyLabel.text = "Verification Label"
     let modalMessage = InAppMessagingModalDisplay(messageID: "messageId",
+                                                  campaignName: "testCampaign",
                                                   renderAsTestMessage: false,
+                                                  triggerType: .onAnalyticsEvent,
                                                   titleText: normalMessageTitle,
                                                   bodyText: longBodyText,
                                                   textColor: UIColor.black,
                                                   backgroundColor: UIColor.blue,
                                                   imageData: nil,
-                                                  actionButton: defaultActionButton)
+                                                  actionButton: defaultActionButton,
+                                                  actionURL: URL(string: "http://firebase.com"))
 
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
@@ -114,13 +130,16 @@ class ModalMessageViewController: CommonMessageTestVC {
     let fiamImageData = InAppMessagingImageData(imageURL: "url not important", imageData: imageRawData!)
 
     let modalMessage = InAppMessagingModalDisplay(messageID: "messageId",
+                                                  campaignName: "testCampaign",
                                                   renderAsTestMessage: false,
-                                                  titleText: longBodyText,
+                                                  triggerType: .onAnalyticsEvent,
+                                                  titleText: longTitleText,
                                                   bodyText: longBodyText,
                                                   textColor: UIColor.black,
                                                   backgroundColor: UIColor.blue,
                                                   imageData: fiamImageData,
-                                                  actionButton: defaultActionButton)
+                                                  actionButton: defaultActionButton,
+                                                  actionURL: URL(string: "http://firebase.com"))
 
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
@@ -128,13 +147,16 @@ class ModalMessageViewController: CommonMessageTestVC {
   @IBAction func showWithLargeTitle(_ sender: Any) {
     verifyLabel.text = "Verification Label"
     let modalMessage = InAppMessagingModalDisplay(messageID: "messageId",
+                                                  campaignName: "testCampaign",
                                                   renderAsTestMessage: false,
+                                                  triggerType: .onAnalyticsEvent,
                                                   titleText: longBodyText,
                                                   bodyText: normalMessageBody,
                                                   textColor: UIColor.black,
                                                   backgroundColor: UIColor.blue,
                                                   imageData: nil,
-                                                  actionButton: defaultActionButton)
+                                                  actionButton: defaultActionButton,
+                                                  actionURL: URL(string: "http://firebase.com"))
 
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
@@ -142,13 +164,16 @@ class ModalMessageViewController: CommonMessageTestVC {
   @IBAction func showWithLargeTitleAndBodyWithoutImage(_ sender: Any) {
     verifyLabel.text = "Verification Label"
     let modalMessage = InAppMessagingModalDisplay(messageID: "messageId",
+                                                  campaignName: "testCampaign",
                                                   renderAsTestMessage: false,
-                                                  titleText: longBodyText,
+                                                  triggerType: .onAnalyticsEvent,
+                                                  titleText: longTitleText,
                                                   bodyText: longBodyText,
                                                   textColor: UIColor.black,
                                                   backgroundColor: UIColor.blue,
                                                   imageData: nil,
-                                                  actionButton: defaultActionButton)
+                                                  actionButton: defaultActionButton,
+                                                  actionURL: URL(string: "http://firebase.com"))
 
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
@@ -156,13 +181,16 @@ class ModalMessageViewController: CommonMessageTestVC {
   @IBAction func showWithLargeTitleWithoutBodyWithoutImageWithoutButton(_ sender: Any) {
     verifyLabel.text = "Verification Label"
     let modalMessage = InAppMessagingModalDisplay(messageID: "messageId",
+                                                  campaignName: "testCampaign",
                                                   renderAsTestMessage: false,
+                                                  triggerType: .onAnalyticsEvent,
                                                   titleText: longBodyText,
                                                   bodyText: "",
                                                   textColor: UIColor.black,
                                                   backgroundColor: UIColor.blue,
                                                   imageData: nil,
-                                                  actionButton: nil)
+                                                  actionButton: nil,
+                                                  actionURL: nil)
 
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
@@ -173,13 +201,16 @@ class ModalMessageViewController: CommonMessageTestVC {
     let fiamImageData = InAppMessagingImageData(imageURL: "url not important", imageData: imageRawData!)
 
     let modalMessage = InAppMessagingModalDisplay(messageID: "messageId",
+                                                  campaignName: "testCampaign",
                                                   renderAsTestMessage: false,
+                                                  triggerType: .onAnalyticsEvent,
                                                   titleText: normalMessageTitle,
                                                   bodyText: normalMessageBody,
                                                   textColor: UIColor.black,
                                                   backgroundColor: UIColor.blue,
                                                   imageData: fiamImageData,
-                                                  actionButton: defaultActionButton)
+                                                  actionButton: defaultActionButton,
+                                                  actionURL: URL(string: "http://firebase.com"))
 
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }
@@ -190,13 +221,16 @@ class ModalMessageViewController: CommonMessageTestVC {
     let fiamImageData = InAppMessagingImageData(imageURL: "url not important", imageData: imageRawData!)
 
     let modalMessage = InAppMessagingModalDisplay(messageID: "messageId",
+                                                  campaignName: "testCampaign",
                                                   renderAsTestMessage: false,
+                                                  triggerType: .onAnalyticsEvent,
                                                   titleText: normalMessageTitle,
                                                   bodyText: normalMessageBody,
                                                   textColor: UIColor.black,
                                                   backgroundColor: UIColor.blue,
                                                   imageData: fiamImageData,
-                                                  actionButton: defaultActionButton)
+                                                  actionButton: defaultActionButton,
+                                                  actionURL: URL(string: "http://firebase.com"))
 
     displayImpl.displayMessage(modalMessage, displayDelegate: self)
   }

--- a/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/ModalMessageViewController.swift
+++ b/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/ModalMessageViewController.swift
@@ -15,7 +15,6 @@
  */
 
 import UIKit
-import FirebaseInAppMessaging
 
 class ModalMessageViewController: CommonMessageTestVC {
   let displayImpl = InAppMessagingDefaultDisplayImpl()

--- a/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/ModalMessageViewController.swift
+++ b/InAppMessagingDisplay/Example/FiamDisplaySwiftExample/ModalMessageViewController.swift
@@ -37,7 +37,7 @@ class ModalMessageViewController: CommonMessageTestVC {
     verifyLabel.text = "Verification Label"
     let imageRawData = produceImageOfSize(size: CGSize(width: 200, height: 200))
     let fiamImageData = InAppMessagingImageData(imageURL: "url not important", imageData: imageRawData!)
-    
+
     let modalMessage = InAppMessagingModalDisplay(messageID: "messageId",
                                                   campaignName: "testCampaign",
                                                   renderAsTestMessage: false,

--- a/InAppMessagingDisplay/Example/Podfile
+++ b/InAppMessagingDisplay/Example/Podfile
@@ -4,5 +4,6 @@ use_frameworks!
 target 'FiamDisplaySwiftExample' do
   platform :ios, '8.0'
   pod 'FirebaseInAppMessagingDisplay', :path => '../..'
+  pod 'FirebaseInAppMessaging', :path => '../..'
 end
 

--- a/InAppMessagingDisplay/Example/Podfile
+++ b/InAppMessagingDisplay/Example/Podfile
@@ -5,5 +5,6 @@ target 'FiamDisplaySwiftExample' do
   platform :ios, '8.0'
   pod 'FirebaseInAppMessagingDisplay', :path => '../..'
   pod 'FirebaseInAppMessaging', :path => '../..'
+  pod 'FirebaseAnalyticsInterop', :path => '../..'
 end
 


### PR DESCRIPTION
Adds functionality for apps to receive message lifecycle callbacks by registering a delegate that implements a fleshed out `FIRInAppMessagingDisplayDelegate`:

```
// Swift
InAppMessaging.inAppMessaging().delegate = self
```

```
// Objective-C
[FIRInAppMessaging inAppMessaging].delegate = self;
```

Fleshed out `FIRInAppMessagingDisplayDelegate` is now:
`- (void)messageClicked:(FIRInAppMessagingDisplayMessage *)inAppMessage`
`- (void)messageDismissed:(FIRInAppMessagingDisplayMessage *)inAppMessage dismissType:(FIRInAppMessagingDismissType)dismissType`
`- (void)impressionDetectedForMessage:(FIRInAppMessagingDisplayMessage *)inAppMessage`
`- (void)displayErrorForMessage:(FIRInAppMessagingDisplayMessage *)inAppMessage error:(NSError *)error`

TODO: Add unit tests to ensure delegate callbacks are fired.