### PR TITLE
FIAM fix Travis CI issues

### DIFF
--- a/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.h
+++ b/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.h
@@ -16,8 +16,8 @@
 
 #import <UIKit/UIKit.h>
 
-#import <FirebaseInAppMessaging/FIRInAppMessagingRendering.h>
 #import "FIDTimeFetcher.h"
+#import "FIRInAppMessagingRendering.h"
 
 @protocol FIRInAppMessagingDisplayDelegate;
 

--- a/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.h
+++ b/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)followActionURL;
 
 // Returns the in-app message being displayed. Overridden by message type subclasses.
-- (nullable FIRInAppMessagingDisplayMessage *)inAppMessage;
+- (FIRInAppMessagingDisplayMessage *)inAppMessage;
 
 @end
 NS_ASSUME_NONNULL_END

--- a/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.m
+++ b/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.m
@@ -33,7 +33,7 @@ static const NSTimeInterval kMinValidImpressionTime = 3.0;
 
 @implementation FIDBaseRenderingViewController
 
-- (nullable FIRInAppMessagingDisplayMessage *)inAppMessage {
+- (FIRInAppMessagingDisplayMessage *)inAppMessage {
   return nil;
 }
 

--- a/Firebase/InAppMessagingDisplay/FIRIAMDefaultDisplayImpl.m
+++ b/Firebase/InAppMessagingDisplay/FIRIAMDefaultDisplayImpl.m
@@ -26,7 +26,6 @@
 #import "FIRCore+InAppMessagingDisplay.h"
 #import "FIRIAMDefaultDisplayImpl.h"
 #import "FIRInAppMessaging.h"
-#import "FIRInAppMessagingRendering.h"
 
 @implementation FIRIAMDefaultDisplayImpl
 

--- a/Firebase/InAppMessagingDisplay/Public/FIRIAMDefaultDisplayImpl.h
+++ b/Firebase/InAppMessagingDisplay/Public/FIRIAMDefaultDisplayImpl.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <FirebaseInAppMessaging/FIRInAppMessagingRendering.h>
+#import "FIRInAppMessagingRendering.h"
 
 NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(InAppMessagingDefaultDisplayImpl)

--- a/Firebase/InAppMessagingDisplay/Public/FIRIAMDefaultDisplayImpl.h
+++ b/Firebase/InAppMessagingDisplay/Public/FIRIAMDefaultDisplayImpl.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "FIRInAppMessagingRendering.h"
+#import <FirebaseInAppMessaging/FIRInAppMessagingRendering.h>
 
 NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(InAppMessagingDefaultDisplayImpl)

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInAppMessaging'
-  s.version          = '0.12.0'
+  s.version          = '0.13.0'
   s.summary          = 'Firebase In-App Messaging for iOS'
 
   s.description      = <<-DESC

--- a/FirebaseInAppMessagingDisplay.podspec
+++ b/FirebaseInAppMessagingDisplay.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInAppMessagingDisplay'
-  s.version          = '0.12.2'
+  s.version          = '0.13.0'
   s.summary          = 'Firebase In-App Messaging UI for iOS'
 
   s.description      = <<-DESC
@@ -41,5 +41,5 @@ Firebase In-App Messaging SDK.
   }
 
   s.dependency 'FirebaseCore'
-  s.dependency 'FirebaseInAppMessaging', '>=0.12.0'
+  s.dependency 'FirebaseInAppMessaging', '>= 0.13.0'
 end


### PR DESCRIPTION
- Remove duplicate import of `FIRInAppMessagingRendering.h` in `FIRIAMDefaultDisplayImpl`
- Use global import