### PR TITLE
Be sure to validate return code when calling sysctlbyname function (C…

### DIFF
--- a/Firebase/DynamicLinks/Utilities/FDLUtilities.m
+++ b/Firebase/DynamicLinks/Utilities/FDLUtilities.m
@@ -169,7 +169,7 @@ NSString *FIRDLDeviceModelName() {
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     size_t size;
-      
+
     // compute string size
     if (sysctlbyname("hw.machine", NULL, &size, NULL, 0) == 0) {
 

--- a/Firebase/DynamicLinks/Utilities/FDLUtilities.m
+++ b/Firebase/DynamicLinks/Utilities/FDLUtilities.m
@@ -169,11 +169,17 @@ NSString *FIRDLDeviceModelName() {
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     size_t size;
-    sysctlbyname("hw.machine", NULL, &size, NULL, 0);
-    char *machine = calloc(1, size);
-    sysctlbyname("hw.machine", machine, &size, NULL, 0);
-    machineString = [NSString stringWithCString:machine encoding:NSUTF8StringEncoding];
-    free(machine);
+      
+    // compute string size
+    if (sysctlbyname("hw.machine", NULL, &size, NULL, 0) == 0) {
+
+      // get device name
+      char *machine = calloc(1, size);
+      if (sysctlbyname("hw.machine", machine, &size, NULL, 0) == 0) {
+        machineString = [NSString stringWithCString:machine encoding:NSUTF8StringEncoding];
+      }
+      free(machine);
+    }
   });
   return machineString;
 }

--- a/Firebase/DynamicLinks/Utilities/FDLUtilities.m
+++ b/Firebase/DynamicLinks/Utilities/FDLUtilities.m
@@ -172,7 +172,6 @@ NSString *FIRDLDeviceModelName() {
 
     // compute string size
     if (sysctlbyname("hw.machine", NULL, &size, NULL, 0) == 0) {
-
       // get device name
       char *machine = calloc(1, size);
       if (sysctlbyname("hw.machine", machine, &size, NULL, 0) == 0) {


### PR DESCRIPTION
Hi!

This is a simple PR to fix an issue related to not checking return code of a C function.
The issue was raised by a static code/binary analysis we use to validate our app. 

Firebase SDK (in DynamicLinks part) is using the C function sysctlbyname without being sure the call was successful. 
The issue is related to the following CWE: http://cwe.mitre.org/data/definitions/391.html.

Let me know if I should made any other adjustment to this PR.

Best regards.

