### PR TITLE
Allow Bundle IDs that have a valid prefix

### DIFF
--- a/Example/Core/Tests/FIRBundleUtilTest.m
+++ b/Example/Core/Tests/FIRBundleUtilTest.m
@@ -69,16 +69,22 @@ static NSString *const kFileType = @"fileType";
 - (void)testBundleIdentifierExistsInBundles {
   NSString *bundleID = @"com.google.test";
   [OCMStub([self.mockBundle bundleIdentifier]) andReturn:bundleID];
-  XCTAssertTrue([FIRBundleUtil hasBundleIdentifier:bundleID inBundles:@[ self.mockBundle ]]);
+  XCTAssertTrue([FIRBundleUtil hasBundleIdentifierPrefix:bundleID inBundles:@[ self.mockBundle ]]);
 }
 
 - (void)testBundleIdentifierExistsInBundles_notExist {
   [OCMStub([self.mockBundle bundleIdentifier]) andReturn:@"com.google.test"];
-  XCTAssertFalse([FIRBundleUtil hasBundleIdentifier:@"not-exist" inBundles:@[ self.mockBundle ]]);
+  XCTAssertFalse([FIRBundleUtil hasBundleIdentifierPrefix:@"not-exist" inBundles:@[ self.mockBundle ]]);
 }
 
 - (void)testBundleIdentifierExistsInBundles_emptyBundlesArray {
-  XCTAssertFalse([FIRBundleUtil hasBundleIdentifier:@"com.google.test" inBundles:@[]]);
+  XCTAssertFalse([FIRBundleUtil hasBundleIdentifierPrefix:@"com.google.test" inBundles:@[]]);
+}
+
+- (void)testBundleIdentifierHasPrefixInBundles {
+  [OCMStub([self.mockBundle bundleIdentifier]) andReturn:@"com.google.test"];
+  XCTAssertTrue([FIRBundleUtil hasBundleIdentifierPrefix:@"com.google.test.someextension"
+                                               inBundles:@[ self.mockBundle ]]);
 }
 
 @end

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -525,7 +525,7 @@ static NSMutableDictionary *sLibraryVersions;
   NSString *expectedBundleID = [self expectedBundleID];
   // The checking is only done when the bundle ID is provided in the serviceInfo dictionary for
   // backward compatibility.
-  if (expectedBundleID != nil && ![FIRBundleUtil hasBundleIdentifier:expectedBundleID
+  if (expectedBundleID != nil && ![FIRBundleUtil hasBundleIdentifierPrefix:expectedBundleID
                                                            inBundles:bundles]) {
     FIRLogError(kFIRLoggerCore, @"I-COR000008",
                 @"The project's Bundle ID is inconsistent with "

--- a/Firebase/Core/FIRBundleUtil.m
+++ b/Firebase/Core/FIRBundleUtil.m
@@ -45,9 +45,10 @@
   return result;
 }
 
-+ (BOOL)hasBundleIdentifier:(NSString *)bundleIdentifier inBundles:(NSArray *)bundles {
++ (BOOL)hasBundleIdentifierPrefix:(NSString *)bundleIdentifier inBundles:(NSArray *)bundles {
   for (NSBundle *bundle in bundles) {
-    if ([bundle.bundleIdentifier isEqualToString:bundleIdentifier]) {
+    // This allows app extensions that have the app's bundle as their prefix to pass this test.
+    if ([bundleIdentifier hasPrefix:bundle.bundleIdentifier]) {
       return YES;
     }
   }

--- a/Firebase/Core/Private/FIRBundleUtil.h
+++ b/Firebase/Core/Private/FIRBundleUtil.h
@@ -45,8 +45,8 @@
 + (NSArray *)relevantURLSchemes;
 
 /**
- * Checks if the bundle identifier exists in the given bundles.
+ * Checks the given bundles to see of them is a prefix of the given identifier.
  */
-+ (BOOL)hasBundleIdentifier:(NSString *)bundleIdentifier inBundles:(NSArray *)bundles;
++ (BOOL)hasBundleIdentifierPrefix:(NSString *)bundleIdentifier inBundles:(NSArray *)bundles;
 
 @end


### PR DESCRIPTION
This allows iOS Extensions that have a Bundle ID of the format `com.google.appName.extension`
