### PR TITLE
FirebaseMessaging: `NSUserDefaults` replaced by `GULUserDefaults`

### DIFF
--- a/Example/Messaging/Tests/FIRMessagingTestUtilities.m
+++ b/Example/Messaging/Tests/FIRMessagingTestUtilities.m
@@ -18,6 +18,7 @@
 
 #import <FirebaseAnalyticsInterop/FIRAnalyticsInterop.h>
 #import <FirebaseInstanceID/FirebaseInstanceID.h>
+#import <GoogleUtilities/GULUserDefaults.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -37,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Surface internal initializer to avoid singleton usage during tests.
 - (instancetype)initWithAnalytics:(nullable id<FIRAnalyticsInterop>)analytics
                    withInstanceID:(FIRInstanceID *)instanceID
-                 withUserDefaults:(NSUserDefaults *)defaults;
+                 withUserDefaults:(GULUserDefaults *)defaults;
 
 /// Kicks off required calls for some messaging tests.
 - (void)start;
@@ -46,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FIRMessagingTestUtilities
 
-+ (FIRMessaging *)messagingForTestsWithUserDefaults:(NSUserDefaults *)userDefaults {
++ (FIRMessaging *)messagingForTestsWithUserDefaults:(GULUserDefaults *)userDefaults {
   // Create the messaging instance with all the necessary dependencies.
   FIRInstanceID *instanceID = [[FIRInstanceID alloc] initPrivately];
   [instanceID start];

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -47,6 +47,7 @@
 #import <FirebaseCore/FIRLibrary.h>
 #import <FirebaseInstanceID/FirebaseInstanceID.h>
 #import <GoogleUtilities/GULReachabilityChecker.h>
+#import <GoogleUtilities/GULUserDefaults.h>
 
 #import "NSError+FIRMessaging.h"
 
@@ -141,7 +142,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
 @property(nonatomic, readwrite, strong) FIRMessagingRmqManager *rmq2Manager;
 @property(nonatomic, readwrite, strong) FIRMessagingReceiver *receiver;
 @property(nonatomic, readwrite, strong) FIRMessagingSyncMessageManager *syncMessageManager;
-@property(nonatomic, readwrite, strong) NSUserDefaults *messagingUserDefaults;
+@property(nonatomic, readwrite, strong) GULUserDefaults *messagingUserDefaults;
 
 /// Message ID's logged for analytics. This prevents us from logging the same message twice
 /// which can happen if the user inadvertently calls `appDidReceiveMessage` along with us
@@ -179,7 +180,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
 
 - (instancetype)initWithAnalytics:(nullable id<FIRAnalyticsInterop>)analytics
                    withInstanceID:(FIRInstanceID *)instanceID
-                 withUserDefaults:(NSUserDefaults *)defaults {
+                 withUserDefaults:(GULUserDefaults *)defaults {
   self = [super init];
   if (self != nil) {
     _loggedMessageIDs = [NSMutableSet set];
@@ -214,7 +215,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
     id<FIRAnalyticsInterop> analytics = FIR_COMPONENT(FIRAnalyticsInterop, container);
         return [[FIRMessaging alloc] initWithAnalytics:analytics
                                         withInstanceID:[FIRInstanceID instanceID]
-                                      withUserDefaults:[NSUserDefaults standardUserDefaults]];
+                                      withUserDefaults:[GULUserDefaults standardUserDefaults]];
   };
   FIRComponent *messagingProvider =
       [FIRComponent componentWithProtocol:@protocol(FIRMessagingInstanceProvider)

--- a/Firebase/Messaging/FIRMessagingPubSub.m
+++ b/Firebase/Messaging/FIRMessagingPubSub.m
@@ -23,6 +23,7 @@
 #import "FIRMessagingPendingTopicsList.h"
 #import "FIRMessagingUtilities.h"
 #import "FIRMessaging_Private.h"
+#import <GoogleUtilities/GULUserDefaults.h>
 #import "NSDictionary+FIRMessaging.h"
 #import "NSError+FIRMessaging.h"
 
@@ -186,14 +187,14 @@ static NSString *const kPendingSubscriptionsListKey =
 #pragma mark - Storing Pending Topics
 
 - (void)archivePendingTopicsList:(FIRMessagingPendingTopicsList *)topicsList {
-  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  GULUserDefaults *defaults = [GULUserDefaults standardUserDefaults];
   NSData *pendingData = [NSKeyedArchiver archivedDataWithRootObject:topicsList];
   [defaults setObject:pendingData forKey:kPendingSubscriptionsListKey];
   [defaults synchronize];
 }
 
 - (void)restorePendingTopicsList {
-  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  GULUserDefaults *defaults = [GULUserDefaults standardUserDefaults];
   NSData *pendingData = [defaults objectForKey:kPendingSubscriptionsListKey];
   FIRMessagingPendingTopicsList *subscriptions;
   @try {

--- a/Firebase/Messaging/FIRMessagingPubSub.m
+++ b/Firebase/Messaging/FIRMessagingPubSub.m
@@ -16,6 +16,8 @@
 
 #import "FIRMessagingPubSub.h"
 
+#import <GoogleUtilities/GULUserDefaults.h>
+
 #import "FIRMessaging.h"
 #import "FIRMessagingClient.h"
 #import "FIRMessagingDefines.h"
@@ -23,7 +25,6 @@
 #import "FIRMessagingPendingTopicsList.h"
 #import "FIRMessagingUtilities.h"
 #import "FIRMessaging_Private.h"
-#import <GoogleUtilities/GULUserDefaults.h>
 #import "NSDictionary+FIRMessaging.h"
 #import "NSError+FIRMessaging.h"
 

--- a/Firebase/Messaging/FIRMessagingReceiver.h
+++ b/Firebase/Messaging/FIRMessagingReceiver.h
@@ -20,6 +20,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class FIRMessagingReceiver;
+@class GULUserDefaults;
 @protocol FIRMessagingReceiverDelegate <NSObject>
 
 - (void)receiver:(FIRMessagingReceiver *)receiver
@@ -30,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FIRMessagingReceiver : NSObject <FIRMessagingDataMessageManagerDelegate>
 
 /// Default initializer for creating the messaging receiver.
-- (instancetype)initWithUserDefaults:(NSUserDefaults *)defaults NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithUserDefaults:(GULUserDefaults *)defaults NS_DESIGNATED_INITIALIZER;
 
 /// Use `initWithUserDefaults:` instead.
 - (instancetype)init NS_UNAVAILABLE;

--- a/Firebase/Messaging/FIRMessagingReceiver.m
+++ b/Firebase/Messaging/FIRMessagingReceiver.m
@@ -19,6 +19,7 @@
 #import <UIKit/UIKit.h>
 
 #import <GoogleUtilities/GULAppEnvironmentUtil.h>
+#import <GoogleUtilities/GULUserDefaults.h>
 
 #import "FIRMessaging.h"
 #import "FIRMessagingLogger.h"
@@ -37,14 +38,14 @@ NSString *const kFIRMessagingPlistUseMessagingDelegate =
 static int downstreamMessageID = 0;
 
 @interface FIRMessagingReceiver ()
-@property(nonatomic, strong) NSUserDefaults *defaults;
+@property(nonatomic, strong) GULUserDefaults *defaults;
 @end
 
 @implementation FIRMessagingReceiver
 
 #pragma mark - Initializer
 
-- (instancetype)initWithUserDefaults:(NSUserDefaults *)defaults {
+- (instancetype)initWithUserDefaults:(GULUserDefaults *)defaults {
   self = [super init];
   if (self != nil) {
     _defaults = defaults;

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -40,7 +40,8 @@ device, and it is completely free.
   s.dependency 'FirebaseAnalyticsInterop', '~> 1.1'
   s.dependency 'FirebaseCore', '~> 5.2'
   s.dependency 'FirebaseInstanceID', '~> 3.6'
-  s.dependency 'GoogleUtilities/Reachability', '~> 5.2'
-  s.dependency 'GoogleUtilities/Environment', '~> 5.2'
+  s.dependency 'GoogleUtilities/Reachability', '~> 5.3'
+  s.dependency 'GoogleUtilities/Environment', '~> 5.3'
+  s.dependency 'GoogleUtilities/UserDefaults', '~> 5.3'
   s.dependency 'Protobuf', '~> 3.1'
 end


### PR DESCRIPTION
This is a fix for #1919:
* `NSUserDefaults` replaced by `GULUserDefaults` in `FirebaseMessaging`