### PR TITLE
Fix IID singleton usage.

### DIFF
--- a/Example/Messaging/Tests/FIRInstanceIDWithFCMTest.m
+++ b/Example/Messaging/Tests/FIRInstanceIDWithFCMTest.m
@@ -25,7 +25,8 @@
 
 @interface FIRInstanceID (ExposedForTest)
 - (BOOL)isFCMAutoInitEnabled;
-+ (FIRInstanceID *)instanceIDForTests;
+- (instancetype)initPrivately;
+- (void)start;
 @end
 
 @interface FIRMessaging ()
@@ -43,7 +44,8 @@
 
 - (void)setUp {
   [super setUp];
-  _instanceID = [FIRInstanceID instanceIDForTests];
+  _instanceID = [[FIRInstanceID alloc] initPrivately];
+  [_instanceID start];
   _mockFirebaseApp = OCMClassMock([FIRApp class]);
   OCMStub([_mockFirebaseApp defaultApp]).andReturn(_mockFirebaseApp);
 }


### PR DESCRIPTION
The singleton is cached and vended from the Core component system, we
shouldn't wrap it in a dispatch_async or cache it with a global variable.

This matches a change internally that has been made and shipped.