### PR TITLE
Enable code coverage for AllUnitTests_iOS target

### DIFF
--- a/Example/Auth/Tests/FIRAuthAppDelegateProxyTests.m
+++ b/Example/Auth/Tests/FIRAuthAppDelegateProxyTests.m
@@ -376,9 +376,9 @@ NS_ASSUME_NONNULL_BEGIN
     XCTFail(@"Should not call completion handler.");
   }];
   if (_isIOS9orLater) {
-    XCTAssertFalse([delegate application:_mockApplication openURL:_url options:@{}]);
+    XCTAssertNoThrow([delegate application:_mockApplication openURL:_url options:@{}]);
   } else {
-    XCTAssertFalse([delegate application:_mockApplication
+    XCTAssertNoThrow([delegate application:_mockApplication
                                  openURL:_url
                        sourceApplication:@"sourceApplication"
                               annotation:@"annotaton"]);

--- a/Example/Auth/Tests/FIRAuthAppDelegateProxyTests.m
+++ b/Example/Auth/Tests/FIRAuthAppDelegateProxyTests.m
@@ -379,9 +379,9 @@ NS_ASSUME_NONNULL_BEGIN
     XCTAssertNoThrow([delegate application:_mockApplication openURL:_url options:@{}]);
   } else {
     XCTAssertNoThrow([delegate application:_mockApplication
-                                 openURL:_url
-                       sourceApplication:@"sourceApplication"
-                              annotation:@"annotaton"]);
+                                   openURL:_url
+                         sourceApplication:@"sourceApplication"
+                                annotation:@"annotaton"]);
   }
 }
 

--- a/Example/Firebase.xcodeproj/xcshareddata/xcschemes/AllUnitTests_iOS.xcscheme
+++ b/Example/Firebase.xcodeproj/xcshareddata/xcschemes/AllUnitTests_iOS.xcscheme
@@ -139,6 +139,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       disableMainThreadChecker = "YES"
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference


### PR DESCRIPTION
A step toward #793:

- collecting of code coverage enabled for target AllUnitTests_iOS target. The collected data will be used to generate a human readable report
- issue with `FIRAuthAppDelegateProxyTests` fixed

A related PR: #2400