### PR TITLE
Disable index-while-compiling in Travis

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -116,6 +116,7 @@ xcb_flags+=(
   ONLY_ACTIVE_ARCH=YES
   CODE_SIGNING_REQUIRED=NO
   CODE_SIGNING_ALLOWED=YES
+  COMPILER_INDEX_STORE_ENABLE=NO
 )
 
 # TODO(varconst): --warn-unused-vars - right now, it makes the log overflow on


### PR DESCRIPTION
We don't need to use Xcode's index-while-compiling during builds. Folks have
seen ~8% speedup with builds here.

Seen at https://twitter.com/steipete/status/1100404024224804871