### PR TITLE
Fix logger warning on iOS 7.

### DIFF
--- a/GoogleUtilities/Logger/GULASLLogger.m
+++ b/GoogleUtilities/Logger/GULASLLogger.m
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)dealloc {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"  // asl is deprecated
-  asl_release(self.aslClient);
+  asl_free(self.aslClient);
 #pragma clang diagnostic pop
 }
 


### PR DESCRIPTION
This should fix the current travis failure and remove the warning.

Although Apple's docs suggest using `asl_release`, it's only available on iOS 8 and above. `asl_free` does the same thing as `asl_release` and since this will be going away eventually, this is fine to deviate from Apple's recommendations this time.