### PR TITLE
Resolve issue with char * casting in format string invocation

### DIFF
--- a/GoogleUtilities/Example/Tests/Logger/GULASLLoggerTest.m
+++ b/GoogleUtilities/Example/Tests/Logger/GULASLLoggerTest.m
@@ -28,7 +28,7 @@ static NSString *const kCode = @"I-COR000001";
 
 // Redefine class property as readwrite for testing.
 @interface GULLogger (ForTesting)
-@property(nonatomic, class, readwrite) id<GULLoggerSystem> logger;
+@property(nonatomic, nullable, class, readwrite) id<GULLoggerSystem> logger;
 @end
 
 // Surface aslclient and dispatchQueues for tests.
@@ -40,7 +40,7 @@ static NSString *const kCode = @"I-COR000001";
 #pragma mark -
 
 @interface GULASLLoggerTest : XCTestCase
-@property(nonatomic) GULASLLogger *logger;
+@property(nonatomic, nullable) GULASLLogger *logger;
 @end
 
 @implementation GULASLLoggerTest

--- a/GoogleUtilities/Example/Tests/Logger/GULOSLoggerTest.m
+++ b/GoogleUtilities/Example/Tests/Logger/GULOSLoggerTest.m
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 static NSString *const kService = @"my service";
 static NSString *const kCode = @"I-COR000001";
-static NSTimeInterval const kTimeout = 1.0f;
+static NSTimeInterval const kTimeout = 1.0;
 
 // Expectation that contains the information needed to see if the correct parameters were used in an
 // os_log_with_type call.

--- a/GoogleUtilities/Logger/GULASLLogger.m
+++ b/GoogleUtilities/Logger/GULASLLogger.m
@@ -142,7 +142,7 @@ NS_ASSUME_NONNULL_BEGIN
   dispatch_async(self.dispatchQueue, ^{
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"  // asl is deprecated
-    asl_log(self.aslClient, NULL, level, "%s", logMsg);
+    asl_log(self.aslClient, NULL, (int)level, "%s", logMsg);
 #pragma clang diagnostic pop
   });
 }

--- a/GoogleUtilities/Logger/GULOSLogger.m
+++ b/GoogleUtilities/Logger/GULOSLogger.m
@@ -32,24 +32,24 @@ NS_ASSUME_NONNULL_BEGIN
 // Since the macro enforces built-in constant-ness of the format string, it is replaced by "s"
 // and the va_list should only contain one argument, a full message with format substitutions
 // already filled.
-static void GULLOSLogWithType(os_log_t log, os_log_type_t type, char *s, ...) {
+static void GULLOSLogWithType(os_log_t log, os_log_type_t type, char *format, ...) {
 #if __has_builtin(__builtin_available)
   if (@available(iOS 9.0, *)) {
 #else
   if ([[UIDevice currentDevice].systemVersion integerValue] >= 9) {
 #endif
     va_list args;
-    va_start(args, s);
-#if TARGET_OS_TV
-    os_log_with_type(log, type, "%s", (char *)args);
-#elif TARGET_OS_OSX
+    va_start(args, format);
+    NSString *formattedString =
+        [[NSString alloc] initWithFormat:[NSString stringWithUTF8String:format] arguments:args];
+#if TARGET_OS_OSX
     // Silence macOS 10.10 warning until we move minimum to 10.11.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability"
-    os_log_with_type(log, type, "%s", (char *)args);
+    os_log_with_type(log, type, "%s", [formattedString UTF8String]);
 #pragma clang diagnostic pop
 #else
-  os_log_with_type(log, type, "%s", args);
+    os_log_with_type(log, type, "%s", [formattedString UTF8String]);
 #endif
     va_end(args);
   } else {


### PR DESCRIPTION
* Use `-[NSString initWithFormat:arguments:]` instead of trying to trick the preprocessor macros of all the platforms.
* A couple drive-by warning fixes that `-Weverything` surfaced.

These changes match the ones done internally.