### PR TITLE
Correctly marshal var args through whole call stack

### DIFF
--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -121,10 +121,8 @@ __attribute__((no_sanitize("thread"))) BOOL FIRIsLoggableLevel(FIRLoggerLevel lo
   return GULIsLoggableLevel((GULLoggerLevel)loggerLevel);
 }
 
-void FIRLogBasic(FIRLoggerLevel level,
-                 FIRLoggerService service,
-                 NSString *messageCode,
-                 NSString *message, ...) {
+void FIRLogBasic(
+    FIRLoggerLevel level, FIRLoggerService service, NSString *messageCode, NSString *message, ...) {
   FIRLoggerInitializeASL();
   va_list args_ptr;
   va_start(args_ptr, message);

--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -121,20 +121,16 @@ __attribute__((no_sanitize("thread"))) BOOL FIRIsLoggableLevel(FIRLoggerLevel lo
   return GULIsLoggableLevel((GULLoggerLevel)loggerLevel);
 }
 
-void FIRLogBasic(FIRLoggerLevel level,
-                 FIRLoggerService service,
-                 NSString *messageCode,
-                 NSString *message,
-#if __LP64__ && TARGET_OS_SIMULATOR || TARGET_OS_OSX
-                 va_list args_ptr
-#else
-                 va_list _Nullable args_ptr
-#endif
-) {
+void FIRLogBasic(
+    FIRLoggerLevel level, FIRLoggerService service, NSString *messageCode, NSString *message, ...) {
   FIRLoggerInitializeASL();
+  va_list args_ptr;
+  va_start(args_ptr, message);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args_ptr];
+  va_end(args_ptr);
   GULLogBasic((GULLoggerLevel)level, service,
               sFIRAnalyticsDebugMode && [kFIRLoggerAnalytics isEqualToString:service], messageCode,
-              message, args_ptr);
+              @"%@", formattedMessage);
 }
 
 /**
@@ -149,8 +145,9 @@ void FIRLogBasic(FIRLoggerLevel level,
   void FIRLog##level(FIRLoggerService service, NSString *messageCode, NSString *message, ...) { \
     va_list args_ptr;                                                                           \
     va_start(args_ptr, message);                                                                \
-    FIRLogBasic(FIRLoggerLevel##level, service, messageCode, message, args_ptr);                \
+    NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args_ptr];  \
     va_end(args_ptr);                                                                           \
+    FIRLogBasic(FIRLoggerLevel##level, service, messageCode, @"%@", formattedMessage);          \
   }
 
 FIR_LOGGING_FUNCTION(Error)
@@ -160,17 +157,3 @@ FIR_LOGGING_FUNCTION(Info)
 FIR_LOGGING_FUNCTION(Debug)
 
 #undef FIR_MAKE_LOGGER
-
-#pragma mark - FIRLoggerWrapper
-
-@implementation FIRLoggerWrapper
-
-+ (void)logWithLevel:(FIRLoggerLevel)level
-         withService:(FIRLoggerService)service
-            withCode:(NSString *)messageCode
-         withMessage:(NSString *)message
-            withArgs:(va_list)args {
-  FIRLogBasic(level, service, messageCode, message, args);
-}
-
-@end

--- a/Firebase/Core/Private/FIRLogger.h
+++ b/Firebase/Core/Private/FIRLogger.h
@@ -137,7 +137,7 @@ NS_ASSUME_NONNULL_END
 
 @interface FIRLoggerWrapper : NSObject
 
- /**
+/**
  * Objective-C wrapper for FIRLogBasic to allow weak linking to FIRLogger
  * (required) log level (one of the FIRLoggerLevel enum values).
  * (required) service name of type FIRLoggerService.
@@ -150,10 +150,10 @@ NS_ASSUME_NONNULL_END
  *            string.
  */
 
- + (void)logWithLevel:(FIRLoggerLevel)level
++ (void)logWithLevel:(FIRLoggerLevel)level
          withService:(FIRLoggerService)service
             withCode:(NSString *)messageCode
          withMessage:(NSString *)message
             withArgs:(va_list)args;
 
- @end
+@end

--- a/Firebase/Core/Private/FIRLogger.h
+++ b/Firebase/Core/Private/FIRLogger.h
@@ -95,15 +95,7 @@ BOOL FIRIsLoggableLevel(FIRLoggerLevel loggerLevel, BOOL analyticsComponent);
 extern void FIRLogBasic(FIRLoggerLevel level,
                         FIRLoggerService service,
                         NSString *messageCode,
-                        NSString *message,
-// On 64-bit simulators, va_list is not a pointer, so cannot be marked nullable
-// See: http://stackoverflow.com/q/29095469
-#if __LP64__ && TARGET_OS_SIMULATOR || TARGET_OS_OSX
-                        va_list args_ptr
-#else
-                        va_list _Nullable args_ptr
-#endif
-);
+                        NSString *message, ...) NS_FORMAT_FUNCTION(4, 5);
 
 /**
  * The following functions accept the following parameters in order:
@@ -132,28 +124,5 @@ extern void FIRLogDebug(FIRLoggerService service, NSString *messageCode, NSStrin
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus
-
-@interface FIRLoggerWrapper : NSObject
-
-/**
- * Objective-C wrapper for FIRLogBasic to allow weak linking to FIRLogger
- * (required) log level (one of the FIRLoggerLevel enum values).
- * (required) service name of type FIRLoggerService.
- * (required) message code starting with "I-" which means iOS, followed by a capitalized
- *            three-character service identifier and a six digit integer message ID that is unique
- *            within the service.
- *            An example of the message code is @"I-COR000001".
- * (required) message string which can be a format string.
- * (optional) variable arguments list obtained from calling va_start, used when message is a format
- *            string.
- */
-
-+ (void)logWithLevel:(FIRLoggerLevel)level
-         withService:(FIRLoggerService)service
-            withCode:(NSString *)messageCode
-         withMessage:(NSString *)message
-            withArgs:(va_list)args;
-
-@end
 
 NS_ASSUME_NONNULL_END

--- a/Firebase/Core/Private/FIRLogger.h
+++ b/Firebase/Core/Private/FIRLogger.h
@@ -96,14 +96,7 @@ extern void FIRLogBasic(FIRLoggerLevel level,
                         FIRLoggerService service,
                         NSString *messageCode,
                         NSString *message,
-// On 64-bit simulators, va_list is not a pointer, so cannot be marked nullable
-// See: http://stackoverflow.com/q/29095469
-#if __LP64__ && TARGET_OS_SIMULATOR || TARGET_OS_OSX
-                        va_list args_ptr
-#else
-                        va_list _Nullable args_ptr
-#endif
-);
+                        ...) NS_FORMAT_FUNCTION(4, 5);
 
 /**
  * The following functions accept the following parameters in order:
@@ -134,26 +127,3 @@ extern void FIRLogDebug(FIRLoggerService service, NSString *messageCode, NSStrin
 #endif  // __cplusplus
 
 NS_ASSUME_NONNULL_END
-
-@interface FIRLoggerWrapper : NSObject
-
-/**
- * Objective-C wrapper for FIRLogBasic to allow weak linking to FIRLogger
- * (required) log level (one of the FIRLoggerLevel enum values).
- * (required) service name of type FIRLoggerService.
- * (required) message code starting with "I-" which means iOS, followed by a capitalized
- *            three-character service identifier and a six digit integer message ID that is unique
- *            within the service.
- *            An example of the message code is @"I-COR000001".
- * (required) message string which can be a format string.
- * (optional) variable arguments list obtained from calling va_start, used when message is a format
- *            string.
- */
-
-+ (void)logWithLevel:(FIRLoggerLevel)level
-         withService:(FIRLoggerService)service
-            withCode:(NSString *)messageCode
-         withMessage:(NSString *)message
-            withArgs:(va_list)args;
-
-@end

--- a/Firebase/Core/Private/FIRLogger.h
+++ b/Firebase/Core/Private/FIRLogger.h
@@ -95,7 +95,8 @@ BOOL FIRIsLoggableLevel(FIRLoggerLevel loggerLevel, BOOL analyticsComponent);
 extern void FIRLogBasic(FIRLoggerLevel level,
                         FIRLoggerService service,
                         NSString *messageCode,
-                        NSString *message, ...) NS_FORMAT_FUNCTION(4, 5);
+                        NSString *message,
+                        ...) NS_FORMAT_FUNCTION(4, 5);
 
 /**
  * The following functions accept the following parameters in order:

--- a/Firebase/Core/Private/FIRLogger.h
+++ b/Firebase/Core/Private/FIRLogger.h
@@ -96,7 +96,14 @@ extern void FIRLogBasic(FIRLoggerLevel level,
                         FIRLoggerService service,
                         NSString *messageCode,
                         NSString *message,
-                        ...) NS_FORMAT_FUNCTION(4, 5);
+// On 64-bit simulators, va_list is not a pointer, so cannot be marked nullable
+// See: http://stackoverflow.com/q/29095469
+#if __LP64__ && TARGET_OS_SIMULATOR || TARGET_OS_OSX
+                        va_list args_ptr
+#else
+                        va_list _Nullable args_ptr
+#endif
+);
 
 /**
  * The following functions accept the following parameters in order:
@@ -127,3 +134,26 @@ extern void FIRLogDebug(FIRLoggerService service, NSString *messageCode, NSStrin
 #endif  // __cplusplus
 
 NS_ASSUME_NONNULL_END
+
+@interface FIRLoggerWrapper : NSObject
+
+ /**
+ * Objective-C wrapper for FIRLogBasic to allow weak linking to FIRLogger
+ * (required) log level (one of the FIRLoggerLevel enum values).
+ * (required) service name of type FIRLoggerService.
+ * (required) message code starting with "I-" which means iOS, followed by a capitalized
+ *            three-character service identifier and a six digit integer message ID that is unique
+ *            within the service.
+ *            An example of the message code is @"I-COR000001".
+ * (required) message string which can be a format string.
+ * (optional) variable arguments list obtained from calling va_start, used when message is a format
+ *            string.
+ */
+
+ + (void)logWithLevel:(FIRLoggerLevel)level
+         withService:(FIRLoggerService)service
+            withCode:(NSString *)messageCode
+         withMessage:(NSString *)message
+            withArgs:(va_list)args;
+
+ @end

--- a/Firebase/InstanceID/FIRInstanceIDLogger.m
+++ b/Firebase/InstanceID/FIRInstanceIDLogger.m
@@ -34,9 +34,10 @@ NSString *const kFIRInstanceIDLoggerService = @"[Firebase/InstanceID]";
                  msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelDebug, kFIRInstanceIDLoggerService,
-              [FIRInstanceIDLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelDebug, kFIRInstanceIDLoggerService,
+              [FIRInstanceIDLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 - (void)logFuncInfo:(const char *)func
@@ -44,9 +45,10 @@ NSString *const kFIRInstanceIDLoggerService = @"[Firebase/InstanceID]";
                 msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelInfo, kFIRInstanceIDLoggerService,
-              [FIRInstanceIDLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelInfo, kFIRInstanceIDLoggerService,
+              [FIRInstanceIDLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 - (void)logFuncNotice:(const char *)func
@@ -54,9 +56,10 @@ NSString *const kFIRInstanceIDLoggerService = @"[Firebase/InstanceID]";
                   msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelNotice, kFIRInstanceIDLoggerService,
-              [FIRInstanceIDLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelNotice, kFIRInstanceIDLoggerService,
+              [FIRInstanceIDLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 - (void)logFuncWarning:(const char *)func
@@ -64,9 +67,10 @@ NSString *const kFIRInstanceIDLoggerService = @"[Firebase/InstanceID]";
                    msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelWarning, kFIRInstanceIDLoggerService,
-              [FIRInstanceIDLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelWarning, kFIRInstanceIDLoggerService,
+              [FIRInstanceIDLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 - (void)logFuncError:(const char *)func
@@ -74,9 +78,10 @@ NSString *const kFIRInstanceIDLoggerService = @"[Firebase/InstanceID]";
                  msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelError, kFIRInstanceIDLoggerService,
-              [FIRInstanceIDLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelError, kFIRInstanceIDLoggerService,
+              [FIRInstanceIDLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 @end

--- a/Firebase/InstanceID/FIRInstanceIDLogger.m
+++ b/Firebase/InstanceID/FIRInstanceIDLogger.m
@@ -34,10 +34,9 @@ NSString *const kFIRInstanceIDLoggerService = @"[Firebase/InstanceID]";
                  msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
-  va_end(args);
   FIRLogBasic(FIRLoggerLevelDebug, kFIRInstanceIDLoggerService,
-              [FIRInstanceIDLogger formatMessageCode:messageCode], @"%@", formattedMessage);
+              [FIRInstanceIDLogger formatMessageCode:messageCode], fmt, args);
+  va_end(args);
 }
 
 - (void)logFuncInfo:(const char *)func
@@ -45,10 +44,9 @@ NSString *const kFIRInstanceIDLoggerService = @"[Firebase/InstanceID]";
                 msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
-  va_end(args);
   FIRLogBasic(FIRLoggerLevelInfo, kFIRInstanceIDLoggerService,
-              [FIRInstanceIDLogger formatMessageCode:messageCode], @"%@", formattedMessage);
+              [FIRInstanceIDLogger formatMessageCode:messageCode], fmt, args);
+  va_end(args);
 }
 
 - (void)logFuncNotice:(const char *)func
@@ -56,10 +54,9 @@ NSString *const kFIRInstanceIDLoggerService = @"[Firebase/InstanceID]";
                   msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
-  va_end(args);
   FIRLogBasic(FIRLoggerLevelNotice, kFIRInstanceIDLoggerService,
-              [FIRInstanceIDLogger formatMessageCode:messageCode], @"%@", formattedMessage);
+              [FIRInstanceIDLogger formatMessageCode:messageCode], fmt, args);
+  va_end(args);
 }
 
 - (void)logFuncWarning:(const char *)func
@@ -67,10 +64,9 @@ NSString *const kFIRInstanceIDLoggerService = @"[Firebase/InstanceID]";
                    msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
-  va_end(args);
   FIRLogBasic(FIRLoggerLevelWarning, kFIRInstanceIDLoggerService,
-              [FIRInstanceIDLogger formatMessageCode:messageCode], @"%@", formattedMessage);
+              [FIRInstanceIDLogger formatMessageCode:messageCode], fmt, args);
+  va_end(args);
 }
 
 - (void)logFuncError:(const char *)func
@@ -78,10 +74,9 @@ NSString *const kFIRInstanceIDLoggerService = @"[Firebase/InstanceID]";
                  msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
-  va_end(args);
   FIRLogBasic(FIRLoggerLevelError, kFIRInstanceIDLoggerService,
-              [FIRInstanceIDLogger formatMessageCode:messageCode], @"%@", formattedMessage);
+              [FIRInstanceIDLogger formatMessageCode:messageCode], fmt, args);
+  va_end(args);
 }
 
 @end

--- a/Firebase/InstanceID/FIRInstanceIDLogger.m
+++ b/Firebase/InstanceID/FIRInstanceIDLogger.m
@@ -56,9 +56,10 @@ NSString *const kFIRInstanceIDLoggerService = @"[Firebase/InstanceID]";
                   msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelNotice, kFIRInstanceIDLoggerService,
-              [FIRInstanceIDLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelNotice, kFIRInstanceIDLoggerService,
+              [FIRInstanceIDLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 - (void)logFuncWarning:(const char *)func
@@ -66,9 +67,10 @@ NSString *const kFIRInstanceIDLoggerService = @"[Firebase/InstanceID]";
                    msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelWarning, kFIRInstanceIDLoggerService,
-              [FIRInstanceIDLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelWarning, kFIRInstanceIDLoggerService,
+              [FIRInstanceIDLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 - (void)logFuncError:(const char *)func
@@ -76,9 +78,10 @@ NSString *const kFIRInstanceIDLoggerService = @"[Firebase/InstanceID]";
                  msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelError, kFIRInstanceIDLoggerService,
-              [FIRInstanceIDLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelError, kFIRInstanceIDLoggerService,
+              [FIRInstanceIDLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 @end

--- a/Firebase/InstanceID/FIRInstanceIDLogger.m
+++ b/Firebase/InstanceID/FIRInstanceIDLogger.m
@@ -34,9 +34,10 @@ NSString *const kFIRInstanceIDLoggerService = @"[Firebase/InstanceID]";
                  msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelDebug, kFIRInstanceIDLoggerService,
-              [FIRInstanceIDLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelDebug, kFIRInstanceIDLoggerService,
+              [FIRInstanceIDLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 - (void)logFuncInfo:(const char *)func
@@ -44,9 +45,10 @@ NSString *const kFIRInstanceIDLoggerService = @"[Firebase/InstanceID]";
                 msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelInfo, kFIRInstanceIDLoggerService,
-              [FIRInstanceIDLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelInfo, kFIRInstanceIDLoggerService,
+              [FIRInstanceIDLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 - (void)logFuncNotice:(const char *)func

--- a/Firebase/Messaging/FIRMessagingLogger.m
+++ b/Firebase/Messaging/FIRMessagingLogger.m
@@ -57,9 +57,10 @@
                   msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelNotice, kFIRLoggerMessaging,
-              [FIRMessagingLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelNotice, kFIRLoggerMessaging,
+              [FIRMessagingLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 - (void)logFuncWarning:(const char *)func
@@ -67,9 +68,10 @@
                    msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelWarning, kFIRLoggerMessaging,
-              [FIRMessagingLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelWarning, kFIRLoggerMessaging,
+              [FIRMessagingLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 - (void)logFuncError:(const char *)func
@@ -77,9 +79,10 @@
                  msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelError, kFIRLoggerMessaging,
-              [FIRMessagingLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelError, kFIRLoggerMessaging,
+              [FIRMessagingLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 @end

--- a/Firebase/Messaging/FIRMessagingLogger.m
+++ b/Firebase/Messaging/FIRMessagingLogger.m
@@ -35,9 +35,10 @@
                  msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelDebug, kFIRLoggerMessaging,
-              [FIRMessagingLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelDebug, kFIRLoggerMessaging,
+              [FIRMessagingLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 - (void)logFuncInfo:(const char *)func
@@ -45,9 +46,10 @@
                 msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelInfo, kFIRLoggerMessaging,
-              [FIRMessagingLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelInfo, kFIRLoggerMessaging,
+              [FIRMessagingLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 - (void)logFuncNotice:(const char *)func
@@ -55,9 +57,10 @@
                   msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelNotice, kFIRLoggerMessaging,
-              [FIRMessagingLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelNotice, kFIRLoggerMessaging,
+              [FIRMessagingLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 - (void)logFuncWarning:(const char *)func
@@ -65,9 +68,10 @@
                    msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelWarning, kFIRLoggerMessaging,
-              [FIRMessagingLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelWarning, kFIRLoggerMessaging,
+              [FIRMessagingLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 - (void)logFuncError:(const char *)func
@@ -75,9 +79,10 @@
                  msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelError, kFIRLoggerMessaging,
-              [FIRMessagingLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelError, kFIRLoggerMessaging,
+              [FIRMessagingLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 @end

--- a/Firebase/Messaging/FIRMessagingLogger.m
+++ b/Firebase/Messaging/FIRMessagingLogger.m
@@ -35,9 +35,10 @@
                  msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelDebug, kFIRLoggerMessaging,
-              [FIRMessagingLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelDebug, kFIRLoggerMessaging,
+              [FIRMessagingLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 - (void)logFuncInfo:(const char *)func
@@ -45,9 +46,10 @@
                 msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  FIRLogBasic(FIRLoggerLevelInfo, kFIRLoggerMessaging,
-              [FIRMessagingLogger formatMessageCode:messageCode], fmt, args);
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
   va_end(args);
+  FIRLogBasic(FIRLoggerLevelInfo, kFIRLoggerMessaging,
+              [FIRMessagingLogger formatMessageCode:messageCode], @"%@", formattedMessage);
 }
 
 - (void)logFuncNotice:(const char *)func

--- a/Firebase/Messaging/FIRMessagingLogger.m
+++ b/Firebase/Messaging/FIRMessagingLogger.m
@@ -35,10 +35,9 @@
                  msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
-  va_end(args);
   FIRLogBasic(FIRLoggerLevelDebug, kFIRLoggerMessaging,
-              [FIRMessagingLogger formatMessageCode:messageCode], @"%@", formattedMessage);
+              [FIRMessagingLogger formatMessageCode:messageCode], fmt, args);
+  va_end(args);
 }
 
 - (void)logFuncInfo:(const char *)func
@@ -46,10 +45,9 @@
                 msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
-  va_end(args);
   FIRLogBasic(FIRLoggerLevelInfo, kFIRLoggerMessaging,
-              [FIRMessagingLogger formatMessageCode:messageCode], @"%@", formattedMessage);
+              [FIRMessagingLogger formatMessageCode:messageCode], fmt, args);
+  va_end(args);
 }
 
 - (void)logFuncNotice:(const char *)func
@@ -57,10 +55,9 @@
                   msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
-  va_end(args);
   FIRLogBasic(FIRLoggerLevelNotice, kFIRLoggerMessaging,
-              [FIRMessagingLogger formatMessageCode:messageCode], @"%@", formattedMessage);
+              [FIRMessagingLogger formatMessageCode:messageCode], fmt, args);
+  va_end(args);
 }
 
 - (void)logFuncWarning:(const char *)func
@@ -68,10 +65,9 @@
                    msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
-  va_end(args);
   FIRLogBasic(FIRLoggerLevelWarning, kFIRLoggerMessaging,
-              [FIRMessagingLogger formatMessageCode:messageCode], @"%@", formattedMessage);
+              [FIRMessagingLogger formatMessageCode:messageCode], fmt, args);
+  va_end(args);
 }
 
 - (void)logFuncError:(const char *)func
@@ -79,10 +75,9 @@
                  msg:(NSString *)fmt, ... {
   va_list args;
   va_start(args, fmt);
-  NSString *formattedMessage = [[NSString alloc] initWithFormat:fmt arguments:args];
-  va_end(args);
   FIRLogBasic(FIRLoggerLevelError, kFIRLoggerMessaging,
-              [FIRMessagingLogger formatMessageCode:messageCode], @"%@", formattedMessage);
+              [FIRMessagingLogger formatMessageCode:messageCode], fmt, args);
+  va_end(args);
 }
 
 @end

--- a/Firestore/core/src/firebase/firestore/util/log_apple.mm
+++ b/Firestore/core/src/firebase/firestore/util/log_apple.mm
@@ -50,11 +50,11 @@ FIRLoggerLevel ToFIRLoggerLevel(LogLevel level) {
 void LogMessageV(LogLevel level, NSString* format, ...) {
   va_list list;
   va_start(list, format);
-  NSString* formattedMessage = [[NSString alloc] initWithFormat:format
-                                                      arguments:list];
-  va_end(list);
+
   FIRLogBasic(ToFIRLoggerLevel(level), kFIRLoggerFirestore, @"I-FST000001",
-              @"%@", formattedMessage);
+              format, list);
+
+  va_end(list);
 }
 
 }  // namespace

--- a/Firestore/core/src/firebase/firestore/util/log_apple.mm
+++ b/Firestore/core/src/firebase/firestore/util/log_apple.mm
@@ -52,6 +52,7 @@ void LogMessageV(LogLevel level, NSString* format, ...) {
   va_start(list, format);
   NSString* formattedMessage = [[NSString alloc] initWithFormat:format
                                                       arguments:list];
+  va_end(list);
   FIRLogBasic(ToFIRLoggerLevel(level), kFIRLoggerFirestore, @"I-FST000001",
               @"%@", formattedMessage);
 }

--- a/Firestore/core/src/firebase/firestore/util/log_apple.mm
+++ b/Firestore/core/src/firebase/firestore/util/log_apple.mm
@@ -50,11 +50,9 @@ FIRLoggerLevel ToFIRLoggerLevel(LogLevel level) {
 void LogMessageV(LogLevel level, NSString* format, ...) {
   va_list list;
   va_start(list, format);
-
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:list];
   FIRLogBasic(ToFIRLoggerLevel(level), kFIRLoggerFirestore, @"I-FST000001",
-              format, list);
-
-  va_end(list);
+              @"%@", formattedMessage);
 }
 
 }  // namespace

--- a/Firestore/core/src/firebase/firestore/util/log_apple.mm
+++ b/Firestore/core/src/firebase/firestore/util/log_apple.mm
@@ -50,11 +50,11 @@ FIRLoggerLevel ToFIRLoggerLevel(LogLevel level) {
 void LogMessageV(LogLevel level, NSString* format, ...) {
   va_list list;
   va_start(list, format);
-
-  FIRLogBasic(ToFIRLoggerLevel(level), kFIRLoggerFirestore, @"I-FST000001",
-              format, list);
-
+  NSString* formattedMessage = [[NSString alloc] initWithFormat:format
+                                                      arguments:list];
   va_end(list);
+  FIRLogBasic(ToFIRLoggerLevel(level), kFIRLoggerFirestore, @"I-FST000001",
+              @"%@", formattedMessage);
 }
 
 }  // namespace

--- a/Firestore/core/src/firebase/firestore/util/log_apple.mm
+++ b/Firestore/core/src/firebase/firestore/util/log_apple.mm
@@ -50,7 +50,8 @@ FIRLoggerLevel ToFIRLoggerLevel(LogLevel level) {
 void LogMessageV(LogLevel level, NSString* format, ...) {
   va_list list;
   va_start(list, format);
-  NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:list];
+  NSString* formattedMessage = [[NSString alloc] initWithFormat:format
+                                                      arguments:list];
   FIRLogBasic(ToFIRLoggerLevel(level), kFIRLoggerFirestore, @"I-FST000001",
               @"%@", formattedMessage);
 }

--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -106,7 +106,7 @@ void GULLogBasic(GULLoggerLevel level,
                      withService:service
                         isForced:forceLog
                         withCode:messageCode
-                     withMessage:messageCode, formatArgs];
+                     withMessage:message, formatArgs];
   va_end(formatArgs);
 }
 

--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -119,14 +119,14 @@ void GULLogBasic(GULLoggerLevel level,
  * Calling GULLogDebug(kGULLoggerCore, @"I-COR000001", @"Configure succeed.") shows:
  * yyyy-mm-dd hh:mm:ss.SSS sender[PID] <Debug> [{service}][I-COR000001] Configure succeed.
  */
-#define GUL_LOGGING_FUNCTION(level)                                                            \
-  void GULLog##level(GULLoggerService service, BOOL force, NSString *messageCode,              \
-                     NSString *message, ...) {                                                 \
-    va_list args;                                                                              \
-    va_start(args, message);                                                                   \
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args];     \
-    va_end(args);                                                                              \
-    GULLogBasic(GULLoggerLevel##level, service, force, messageCode, @"%@", formattedMessage);  \
+#define GUL_LOGGING_FUNCTION(level)                                                           \
+  void GULLog##level(GULLoggerService service, BOOL force, NSString *messageCode,             \
+                     NSString *message, ...) {                                                \
+    va_list args;                                                                             \
+    va_start(args, message);                                                                  \
+    NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args];    \
+    va_end(args);                                                                             \
+    GULLogBasic(GULLoggerLevel##level, service, force, messageCode, @"%@", formattedMessage); \
   }
 
 GUL_LOGGING_FUNCTION(Error)

--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -119,13 +119,14 @@ void GULLogBasic(GULLoggerLevel level,
  * Calling GULLogDebug(kGULLoggerCore, @"I-COR000001", @"Configure succeed.") shows:
  * yyyy-mm-dd hh:mm:ss.SSS sender[PID] <Debug> [{service}][I-COR000001] Configure succeed.
  */
-#define GUL_LOGGING_FUNCTION(level)                                                     \
-  void GULLog##level(GULLoggerService service, BOOL force, NSString *messageCode,       \
-                     NSString *message, ...) {                                          \
-    va_list args_ptr;                                                                   \
-    va_start(args_ptr, message);                                                        \
-    GULLogBasic(GULLoggerLevel##level, service, force, messageCode, message, args_ptr); \
-    va_end(args_ptr);                                                                   \
+#define GUL_LOGGING_FUNCTION(level)                                                            \
+  void GULLog##level(GULLoggerService service, BOOL force, NSString *messageCode,              \
+                     NSString *message, ...) {                                                 \
+    va_list args;                                                                              \
+    va_start(args, message);                                                                   \
+    NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args];     \
+    va_end(args);                                                                              \
+    GULLogBasic(GULLoggerLevel##level, service, force, messageCode, @"%@", formattedMessage);  \
   }
 
 GUL_LOGGING_FUNCTION(Error)

--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -99,11 +99,15 @@ void GULLogBasic(GULLoggerLevel level,
                  BOOL forceLog,
                  NSString *messageCode,
                  NSString *message,
-                 ...) {
-  va_list formatArgs;
-  va_start(formatArgs, message);
-  NSString *completeMessage = [[NSString alloc] initWithFormat:message arguments:formatArgs];
-  va_end(formatArgs);
+// On 64-bit simulators, va_list is not a pointer, so cannot be marked nullable
+// See: http://stackoverflow.com/q/29095469
+#if __LP64__ && TARGET_OS_SIMULATOR || TARGET_OS_OSX
+                 va_list args_ptr
+#else
+                 va_list _Nullable args_ptr
+#endif
+) {
+  NSString *completeMessage = [[NSString alloc] initWithFormat:message arguments:args_ptr];
   [GULLogger.logger logWithLevel:level
                      withService:service
                         isForced:forceLog
@@ -119,14 +123,13 @@ void GULLogBasic(GULLoggerLevel level,
  * Calling GULLogDebug(kGULLoggerCore, @"I-COR000001", @"Configure succeed.") shows:
  * yyyy-mm-dd hh:mm:ss.SSS sender[PID] <Debug> [{service}][I-COR000001] Configure succeed.
  */
-#define GUL_LOGGING_FUNCTION(level)                                                           \
-  void GULLog##level(GULLoggerService service, BOOL force, NSString *messageCode,             \
-                     NSString *message, ...) {                                                \
-    va_list args;                                                                             \
-    va_start(args, message);                                                                  \
-    NSString *formattedMessage = [[NSString alloc] initWithFormat:message arguments:args];    \
-    va_end(args);                                                                             \
-    GULLogBasic(GULLoggerLevel##level, service, force, messageCode, @"%@", formattedMessage); \
+#define GUL_LOGGING_FUNCTION(level)                                                 \
+  void GULLog##level(GULLoggerService service, BOOL force, NSString *messageCode,   \
+                     NSString *message, ...) {                                      \
+    va_list args;                                                                   \
+    va_start(args, message);                                                        \
+    GULLogBasic(GULLoggerLevel##level, service, force, messageCode, message, args); \
+    va_end(args);                                                                   \
   }
 
 GUL_LOGGING_FUNCTION(Error)

--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -102,12 +102,13 @@ void GULLogBasic(GULLoggerLevel level,
                  ...) {
   va_list formatArgs;
   va_start(formatArgs, message);
+  NSString *completeMessage = [[NSString alloc] initWithFormat:message arguments:formatArgs];
+  va_end(formatArgs);
   [GULLogger.logger logWithLevel:level
                      withService:service
                         isForced:forceLog
                         withCode:messageCode
-                     withMessage:message, formatArgs];
-  va_end(formatArgs);
+                     withMessage:@"%@", completeMessage];
 }
 
 /**

--- a/GoogleUtilities/Logger/GULOSLogger.m
+++ b/GoogleUtilities/Logger/GULOSLogger.m
@@ -163,7 +163,7 @@ static void GULLOSLogWithType(os_log_t log, os_log_type_t type, char *format, ..
   // Process the va_list here, while the parameters are on the stack.
   va_list args_ptr;
   va_start(args_ptr, message);
-  __block NSString *completeMessage = [[NSString alloc] initWithFormat:message arguments:args_ptr];
+  NSString *completeMessage = [[NSString alloc] initWithFormat:message arguments:args_ptr];
   va_end(args_ptr);
   completeMessage = [GULLogger messageFromLogger:self
                                      withService:service

--- a/GoogleUtilities/Logger/Private/GULLogger.h
+++ b/GoogleUtilities/Logger/Private/GULLogger.h
@@ -80,15 +80,22 @@ extern void GULLoggerRegisterVersion(const char *version);
  *            within the service.
  *            An example of the message code is @"I-COR000001".
  * @param message string which can be a format string.
- * @param ... variable arguments list obtained from calling va_start, used when message is a format
- *            string.
+ * @param args_ptr variable arguments list obtained from calling va_start, used when message is a
+ *            format string.
  */
 extern void GULLogBasic(GULLoggerLevel level,
-                        GULLoggerService service,
-                        BOOL forceLog,
-                        NSString *messageCode,
-                        NSString *message,
-                        ...) NS_FORMAT_FUNCTION(5, 6);
+                 GULLoggerService service,
+                 BOOL forceLog,
+                 NSString *messageCode,
+                 NSString *message,
+// On 64-bit simulators, va_list is not a pointer, so cannot be marked nullable
+// See: http://stackoverflow.com/q/29095469
+#if __LP64__ && TARGET_OS_SIMULATOR || TARGET_OS_OSX
+                 va_list args_ptr
+#else
+                 va_list _Nullable args_ptr
+#endif
+);
 
 /**
  * The following functions accept the following parameters in order:

--- a/GoogleUtilities/Logger/Private/GULLogger.h
+++ b/GoogleUtilities/Logger/Private/GULLogger.h
@@ -80,22 +80,15 @@ extern void GULLoggerRegisterVersion(const char *version);
  *            within the service.
  *            An example of the message code is @"I-COR000001".
  * @param message string which can be a format string.
- * @param args_ptr variable arguments list obtained from calling va_start, used when message is a
- *            format string.
+ * @param ... variable arguments list obtained from calling va_start, used when message is a format
+ *            string.
  */
 extern void GULLogBasic(GULLoggerLevel level,
                         GULLoggerService service,
                         BOOL forceLog,
                         NSString *messageCode,
                         NSString *message,
-// On 64-bit simulators, va_list is not a pointer, so cannot be marked nullable
-// See: http://stackoverflow.com/q/29095469
-#if __LP64__ && TARGET_OS_SIMULATOR || TARGET_OS_OSX
-                        va_list args_ptr
-#else
-                        va_list _Nullable args_ptr
-#endif
-);
+                        ...) NS_FORMAT_FUNCTION(5, 6);
 
 /**
  * The following functions accept the following parameters in order:

--- a/GoogleUtilities/Logger/Private/GULLogger.h
+++ b/GoogleUtilities/Logger/Private/GULLogger.h
@@ -84,16 +84,16 @@ extern void GULLoggerRegisterVersion(const char *version);
  *            format string.
  */
 extern void GULLogBasic(GULLoggerLevel level,
-                 GULLoggerService service,
-                 BOOL forceLog,
-                 NSString *messageCode,
-                 NSString *message,
+                        GULLoggerService service,
+                        BOOL forceLog,
+                        NSString *messageCode,
+                        NSString *message,
 // On 64-bit simulators, va_list is not a pointer, so cannot be marked nullable
 // See: http://stackoverflow.com/q/29095469
 #if __LP64__ && TARGET_OS_SIMULATOR || TARGET_OS_OSX
-                 va_list args_ptr
+                        va_list args_ptr
 #else
-                 va_list _Nullable args_ptr
+                        va_list _Nullable args_ptr
 #endif
 );
 

--- a/GoogleUtilities/Logger/Private/GULLogger.h
+++ b/GoogleUtilities/Logger/Private/GULLogger.h
@@ -88,7 +88,7 @@ extern void GULLogBasic(GULLoggerLevel level,
                         BOOL forceLog,
                         NSString *messageCode,
                         NSString *message,
-                        ...);
+                        ...) NS_FORMAT_FUNCTION(5, 6);
 
 /**
  * The following functions accept the following parameters in order:


### PR DESCRIPTION
The main issue here was that some of the functions/methods accepted `va_list` arguments, whereas others expected actual variable arguments. The ones that took in a `va_list`-typed argument did not `va_copy()` them as they should and would just pass them along. In addition to this, the way the format arguments were read created a potentially insecure buffer overflow condition that could lead to a crash.

The whole call stack now standardizes on using `+[NSString initWithFormat:arguments:]` to safely pass the message and arguments.

* Correctly format the message from `FIRLogger` to `GULLogger`
* Updated function and method signatures to correctly take in var args
* Updated implementations to correctly unpack var args
* Removed unused `FIRLoggerWrapper`