### PR TITLE
Pass UTM parameters to dynamic_link_fist_open after fresh install

### DIFF
--- a/Firebase/DynamicLinks/FIRDLDefaultRetrievalProcessV2.m
+++ b/Firebase/DynamicLinks/FIRDLDefaultRetrievalProcessV2.m
@@ -143,6 +143,9 @@ NS_ASSUME_NONNULL_BEGIN
         }
         FIRDLRetrievalProcessResult *result =
             [[FIRDLRetrievalProcessResult alloc] initWithDynamicLink:dynamicLink
+                                                              source:dynamicLinkParameters[kFIRDLParameterSource]
+                                                              medium:dynamicLinkParameters[kFIRDLParameterMedium]
+                                                            campaign:dynamicLinkParameters[kFIRDLParameterCampaign]
                                                                error:error
                                                              message:matchMessage
                                                          matchSource:nil];
@@ -253,6 +256,9 @@ NS_ASSUME_NONNULL_BEGIN
         NSString *message = NSLocalizedString(@"Pending dynamic link not found",
                                               @"Message when dynamic link was not found");
         result = [[FIRDLRetrievalProcessResult alloc] initWithDynamicLink:nil
+                                                                   source:nil
+                                                                   medium:nil
+                                                                 campaign:nil
                                                                     error:nil
                                                                   message:message
                                                               matchSource:nil];

--- a/Firebase/DynamicLinks/FIRDLRetrievalProcessResult+Private.h
+++ b/Firebase/DynamicLinks/FIRDLRetrievalProcessResult+Private.h
@@ -21,6 +21,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FIRDLRetrievalProcessResult ()
 
 - (instancetype)initWithDynamicLink:(nullable FIRDynamicLink *)dynamicLink
+                             source:(nullable NSString *)source
+                             medium:(nullable NSString *)medium
+                           campaign:(nullable NSString *)campaign
                               error:(nullable NSError *)error
                             message:(nullable NSString *)message
                         matchSource:(nullable NSString *)matchSource NS_DESIGNATED_INITIALIZER;

--- a/Firebase/DynamicLinks/FIRDLRetrievalProcessResult.h
+++ b/Firebase/DynamicLinks/FIRDLRetrievalProcessResult.h
@@ -29,6 +29,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSURL *)URLWithCustomURLScheme:(NSString *)customURLScheme;
 
 @property(nonatomic, nullable, readonly) FIRDynamicLink *dynamicLink;
+@property(nonatomic, nullable, copy, readonly) NSString *source;
+@property(nonatomic, nullable, copy, readonly) NSString *medium;
+@property(nonatomic, nullable, copy, readonly) NSString *campaign;
 @property(nonatomic, nullable, readonly) NSError *error;
 @property(nonatomic, nullable, copy, readonly) NSString *message;
 @property(nonatomic, nullable, copy, readonly) NSString *matchSource;

--- a/Firebase/DynamicLinks/FIRDLRetrievalProcessResult.m
+++ b/Firebase/DynamicLinks/FIRDLRetrievalProcessResult.m
@@ -24,11 +24,17 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation FIRDLRetrievalProcessResult
 
 - (instancetype)initWithDynamicLink:(nullable FIRDynamicLink *)dynamicLink
+                             source:(nullable NSString *)source
+                             medium:(nullable NSString *)medium
+                           campaign:(nullable NSString *)campaign
                               error:(nullable NSError *)error
                             message:(nullable NSString *)message
                         matchSource:(nullable NSString *)matchSource {
   if (self = [super init]) {
     _dynamicLink = dynamicLink;
+    _source = [source copy];
+    _medium = [medium copy];
+    _campaign = [campaign copy];
     _error = error;
     _message = [message copy];
     _matchSource = [matchSource copy];
@@ -40,10 +46,13 @@ NS_ASSUME_NONNULL_BEGIN
   NSURL *URL;
   if (_dynamicLink) {
     NSString *queryString = FIRDLURLQueryStringFromDictionary(_dynamicLink.parametersDictionary);
+    NSString *utmFormatString = @"&utm_medium=%@&utm_campaign=%@&utm_source=%@";
+    NSString *queryStringUtm = [NSString stringWithFormat:utmFormatString, _medium, _campaign, _source];
     NSMutableString *URLString = [[NSMutableString alloc] init];
     [URLString appendString:customURLScheme];
     [URLString appendString:@"://google/link/"];
     [URLString appendString:queryString];
+    [URLString appendString:queryStringUtm];
     URL = [NSURL URLWithString:URLString];
   } else {
     NSMutableString *URLString = [[NSMutableString alloc] init];


### PR DESCRIPTION
This is a change that intends to demonstrate better (via code) the issue I'm facing with attribution of `dynamic_link_first_open` event - https://github.com/firebase/firebase-ios-sdk/issues/2462.

I don't really intend to merge this at this stage. Please be forgiving, this is my first Objective C code, and I didn't manage to completely understand the code around, mostly I tried to understand where my problem is and patch it.