### PR TITLE
Improved query performance in the face of subcollections.

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+- [changed] Improved performance when querying over documents that contain
+  subcollections.
 
 # v1.0.2
 - [changed] Internal improvements.

--- a/Firestore/Example/Tests/Local/FSTRemoteDocumentCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTRemoteDocumentCacheTests.mm
@@ -172,6 +172,7 @@ static const int kVersion = 42;
     // query path. We'll need more tests once we add index support.
     [self setTestDocumentAtPath:"a/1"];
     [self setTestDocumentAtPath:"b/1"];
+    [self setTestDocumentAtPath:"b/1/z/1"];
     [self setTestDocumentAtPath:"b/2"];
     [self setTestDocumentAtPath:"c/1"];
 

--- a/Firestore/core/src/firebase/firestore/local/leveldb_remote_document_cache.mm
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_remote_document_cache.mm
@@ -114,12 +114,12 @@ DocumentMap LevelDbRemoteDocumentCache::GetMatching(FSTQuery* query) {
       continue;
     }
 
-    FSTMaybeDocument* maybeDoc = DecodeMaybeDocument(it->value(), document_key);
-    if (!query_path.IsPrefixOf(maybeDoc.key.path())) {
+    FSTMaybeDocument* maybe_doc = DecodeMaybeDocument(it->value(), document_key);
+    if (!query_path.IsPrefixOf(maybe_doc.key.path())) {
       break;
-    } else if ([maybeDoc isKindOfClass:[FSTDocument class]]) {
+    } else if ([maybe_doc isKindOfClass:[FSTDocument class]]) {
       results =
-          results.insert(maybeDoc.key, static_cast<FSTDocument*>(maybeDoc));
+          results.insert(maybe_doc.key, static_cast<FSTDocument*>(maybe_doc));
     }
   }
 

--- a/Firestore/core/src/firebase/firestore/local/leveldb_remote_document_cache.mm
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_remote_document_cache.mm
@@ -92,17 +92,30 @@ MaybeDocumentMap LevelDbRemoteDocumentCache::GetAll(
 DocumentMap LevelDbRemoteDocumentCache::GetMatching(FSTQuery* query) {
   DocumentMap results;
 
+  // Use the query path as a prefix for testing if a document matches the query.
+  const model::ResourcePath& query_path = query.path;
+  unsigned long immediate_children_path_length = query_path.size() + 1;
+
   // Documents are ordered by key, so we can use a prefix scan to narrow down
   // the documents we need to match the query against.
-  std::string startKey = LevelDbRemoteDocumentKey::KeyPrefix(query.path);
+  std::string start_key = LevelDbRemoteDocumentKey::KeyPrefix(query_path);
   auto it = db_.currentTransaction->NewIterator();
-  it->Seek(startKey);
+  it->Seek(start_key);
 
-  LevelDbRemoteDocumentKey currentKey;
-  for (; it->Valid() && currentKey.Decode(it->key()); it->Next()) {
-    FSTMaybeDocument* maybeDoc =
-        DecodeMaybeDocument(it->value(), currentKey.document_key());
-    if (!query.path.IsPrefixOf(maybeDoc.key.path())) {
+  LevelDbRemoteDocumentKey current_key;
+  for (; it->Valid() && current_key.Decode(it->key()); it->Next()) {
+    // The query is actually returning any path that starts with the query path
+    // prefix which may include documents in subcollections. For example, a
+    // query on 'rooms' will return rooms/abc/messages/xyx but we shouldn't
+    // match it. Fix this by discarding rows with document keys more than one
+    // segment longer than the query path.
+    const DocumentKey& document_key = current_key.document_key();
+    if (document_key.path().size() != immediate_children_path_length) {
+      continue;
+    }
+
+    FSTMaybeDocument* maybeDoc = DecodeMaybeDocument(it->value(), document_key);
+    if (!query_path.IsPrefixOf(maybeDoc.key.path())) {
       break;
     } else if ([maybeDoc isKindOfClass:[FSTDocument class]]) {
       results =

--- a/Firestore/core/src/firebase/firestore/local/leveldb_remote_document_cache.mm
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_remote_document_cache.mm
@@ -114,7 +114,8 @@ DocumentMap LevelDbRemoteDocumentCache::GetMatching(FSTQuery* query) {
       continue;
     }
 
-    FSTMaybeDocument* maybe_doc = DecodeMaybeDocument(it->value(), document_key);
+    FSTMaybeDocument* maybe_doc =
+        DecodeMaybeDocument(it->value(), document_key);
     if (!query_path.IsPrefixOf(maybe_doc.key.path())) {
       break;
     } else if ([maybe_doc isKindOfClass:[FSTDocument class]]) {

--- a/Firestore/core/src/firebase/firestore/local/leveldb_remote_document_cache.mm
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_remote_document_cache.mm
@@ -94,7 +94,7 @@ DocumentMap LevelDbRemoteDocumentCache::GetMatching(FSTQuery* query) {
 
   // Use the query path as a prefix for testing if a document matches the query.
   const model::ResourcePath& query_path = query.path;
-  unsigned long immediate_children_path_length = query_path.size() + 1;
+  size_t immediate_children_path_length = query_path.size() + 1;
 
   // Documents are ordered by key, so we can use a prefix scan to narrow down
   // the documents we need to match the query against.


### PR DESCRIPTION
Ports an optimization from Android where we skip parsing documents that are in
subcollections beneath the collection we're querying over.

This should help #2466 at least to a degree.