### PR TITLE
Revert GoogleUtilities version bump.

### DIFF
--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleUtilities'
-  s.version          = '5.4.0'
+  s.version          = '5.3.7'
   s.summary          = 'Google Utilities for iOS (plus community support for macOS and tvOS)'
 
   s.description      = <<-DESC

--- a/Releases/Manifests/5.18.0.json
+++ b/Releases/Manifests/5.18.0.json
@@ -6,6 +6,5 @@
   "FirebaseFunctions":"2.3.0",
   "FirebaseInAppMessaging":"0.13.0",
   "FirebaseInAppMessagingDisplay":"0.13.0",
-  "FirebaseMessaging":"3.3.2",
-  "GoogleUtilities":"5.4.0"
+  "FirebaseMessaging":"3.3.2"
 }


### PR DESCRIPTION
This was originally staged for release in 5.18.0 but was pulled out. The podspec was never pushed, so it shouldn't be included in the merge to master.