### PR TITLE
Stop Xcode 9 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,44 +125,7 @@ jobs:
 
     # Alternative platforms
 
-    # Xcode 9
-    - stage: test
-      osx_image: xcode9.4
-      env:
-        - PROJECT=Firebase PLATFORM=iOS METHOD=xcodebuild
-      before_install:
-        - npm install ios-sim -g
-        - ios-sim start --devicetypeid "com.apple.CoreSimulator.SimDeviceType.iPhone-8-Plus, 11.3"
-        - ./scripts/if_cron.sh ./scripts/install_prereqs.sh
-      script:
-        - travis_retry ./scripts/if_cron.sh ./scripts/build.sh $PROJECT $PLATFORM
-
-    - stage: test
-      osx_image: xcode9.4
-      env:
-        - PROJECT=InAppMessaging PLATFORM=iOS METHOD=xcodebuild
-      before_install:
-        - ./scripts/if_cron.sh ./scripts/install_prereqs.sh
-      script:
-        - travis_retry ./scripts/if_cron.sh ./scripts/build.sh $PROJECT $PLATFORM
-
-    - stage: test
-      osx_image: xcode9.4
-      env:
-        - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild
-      before_install:
-        - ./scripts/if_cron.sh ./scripts/install_prereqs.sh
-      script:
-        - travis_retry ./scripts/if_cron.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
-
-    - stage: test
-      env:
-        - PROJECT=Firestore PLATFORM=macOS METHOD=cmake
-      before_install:
-        - ./scripts/if_cron.sh ./scripts/install_prereqs.sh
-      script:
-        - travis_retry ./scripts/if_cron.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
-
+    # Test Firestore on Xcode 8 to use old llvm to ensure C++ portability.
     - stage: test
       osx_image: xcode8.3
       env:
@@ -171,39 +134,6 @@ jobs:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
-
-    # Xcode 9 may find lint errors that don't show up in Xcode 10 (#2081)
-    - stage: test
-      osx_image: xcode9.4
-      env:
-        - PROJECT=Firebase PLATFORM=iOS METHOD=pod-lib-lint
-      before_install:
-        - ./scripts/if_cron.sh ./scripts/install_prereqs.sh
-      script:
-        - travis_retry ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh GoogleUtilities.podspec
-        - travis_retry ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh FirebaseCore.podspec
-        - travis_retry ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh FirebaseAnalyticsInterop.podspec
-        - travis_retry ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh FirebaseAuth.podspec
-        - travis_retry ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh FirebaseAuthInterop.podspec
-        - travis_retry ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh FirebaseDatabase.podspec
-        - travis_retry ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh FirebaseDynamicLinks.podspec
-        - travis_retry ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh FirebaseInstanceID.podspec
-        - travis_retry ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh FirebaseMessaging.podspec
-        - travis_retry ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec
-        - travis_retry ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh FirebaseFunctions.podspec
-        - travis_retry ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh FirebaseInAppMessaging.podspec
-        - travis_retry ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh FirebaseInAppMessagingDisplay.podspec
-
-    - stage: test
-      osx_image: xcode9.4
-      env:
-        - PROJECT=Firestore PLATFORM=iOS METHOD=pod-lib-lint
-      before_install:
-        - ./scripts/if_cron.sh ./scripts/install_prereqs.sh
-      script:
-        # Eliminate the one warning from BoringSSL when CocoaPods 1.6.0 is available.
-        # The travis_wait is necessary because the command takes more than 10 minutes.
-        - travis_wait 45 ./scripts/if_cron.sh ./scripts/pod_lib_lint.sh FirebaseFirestore.podspec --allow-warnings --no-subspecs
 
     # Community-supported platforms
 


### PR DESCRIPTION
As of this month, Apple requires Xcode 10.1 for submissions to the app store