### PR TITLE
Bump the patch version of FirebaseInstanceID.

### DIFF
--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInstanceID'
-  s.version          = '3.6.0'
+  s.version          = '3.6.1'
   s.summary          = 'Firebase InstanceID for iOS'
 
   s.description      = <<-DESC


### PR DESCRIPTION
The code was unintentionally released as closed source again, this
is only to push a new version to CocoaPods with the proper podspec.