### PR TITLE
Add missing nil check

### DIFF
--- a/Firebase/Database/CHANGELOG.md
+++ b/Firebase/Database/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v5.1.1
+- [fixed] Fixed crash in FSRWebSocket. (#2485)
+
 # v5.0.2
 - [fixed] Fixed undefined behavior sanitizer issues. (#1443, #1444)
 

--- a/Firebase/Database/third_party/SocketRocket/FSRWebSocket.m
+++ b/Firebase/Database/third_party/SocketRocket/FSRWebSocket.m
@@ -1354,11 +1354,11 @@ static const size_t SRFrameHeaderOverhead = 32;
 {
     [self assertOnWorkQueue];
 
-    NSAssert(data == nil || [data isKindOfClass:[NSData class]] || [data isKindOfClass:[NSString class]], @"Function expects nil, NSString or NSData");
-
     if (data == nil) {
         return;
     }
+
+    NSAssert([data isKindOfClass:[NSData class]] || [data isKindOfClass:[NSString class]], @"Function expects nil, NSString or NSData");
 
     size_t payloadLength = [data isKindOfClass:[NSString class]] ? [(NSString *)data lengthOfBytesUsingEncoding:NSUTF8StringEncoding] : [data length];
 

--- a/Firebase/Database/third_party/SocketRocket/FSRWebSocket.m
+++ b/Firebase/Database/third_party/SocketRocket/FSRWebSocket.m
@@ -1356,6 +1356,10 @@ static const size_t SRFrameHeaderOverhead = 32;
 
     NSAssert(data == nil || [data isKindOfClass:[NSData class]] || [data isKindOfClass:[NSString class]], @"Function expects nil, NSString or NSData");
 
+    if (data == nil) {
+        return;
+    }
+
     size_t payloadLength = [data isKindOfClass:[NSString class]] ? [(NSString *)data lengthOfBytesUsingEncoding:NSUTF8StringEncoding] : [data length];
 
     NSMutableData *frame = [[NSMutableData alloc] initWithLength:payloadLength + SRFrameHeaderOverhead];


### PR DESCRIPTION
Fix #2485

The _sendFrameWithOpcode function in FSRWebSocket assert for nil at the top but then fails to test it earlier. The [upstream SocketRocket code includes a nil check](https://github.com/facebook/SocketRocket/blame/master/SocketRocket/SRWebSocket.m#L1338).

This PR adds it.