### PR TITLE
Restore GULLogger APIs, unit tests, and contents

### DIFF
--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -20,23 +20,23 @@
 
 #import "Private/FIRVersion.h"
 
-FIRLoggerService kFIRLoggerABTesting = @"[Firebase/ABTesting]";
-FIRLoggerService kFIRLoggerAdMob = @"[Firebase/AdMob]";
-FIRLoggerService kFIRLoggerAnalytics = @"[Firebase/Analytics]";
-FIRLoggerService kFIRLoggerAuth = @"[Firebase/Auth]";
-FIRLoggerService kFIRLoggerCore = @"[Firebase/Core]";
-FIRLoggerService kFIRLoggerCrash = @"[Firebase/Crash]";
-FIRLoggerService kFIRLoggerDatabase = @"[Firebase/Database]";
-FIRLoggerService kFIRLoggerDynamicLinks = @"[Firebase/DynamicLinks]";
-FIRLoggerService kFIRLoggerFirestore = @"[Firebase/Firestore]";
-FIRLoggerService kFIRLoggerInstanceID = @"[Firebase/InstanceID]";
-FIRLoggerService kFIRLoggerInvites = @"[Firebase/Invites]";
-FIRLoggerService kFIRLoggerMLKit = @"[Firebase/MLKit]";
-FIRLoggerService kFIRLoggerMessaging = @"[Firebase/Messaging]";
-FIRLoggerService kFIRLoggerPerf = @"[Firebase/Performance]";
-FIRLoggerService kFIRLoggerRemoteConfig = @"[Firebase/RemoteConfig]";
-FIRLoggerService kFIRLoggerStorage = @"[Firebase/Storage]";
-FIRLoggerService kFIRLoggerSwizzler = @"[FirebaseSwizzlingUtilities]";
+FIRLoggerService kFIRLoggerABTesting = @"Firebase/ABTesting";
+FIRLoggerService kFIRLoggerAdMob = @"Firebase/AdMob";
+FIRLoggerService kFIRLoggerAnalytics = @"Firebase/Analytics";
+FIRLoggerService kFIRLoggerAuth = @"Firebase/Auth";
+FIRLoggerService kFIRLoggerCore = @"Firebase/Core";
+FIRLoggerService kFIRLoggerCrash = @"Firebase/Crash";
+FIRLoggerService kFIRLoggerDatabase = @"Firebase/Database";
+FIRLoggerService kFIRLoggerDynamicLinks = @"Firebase/DynamicLinks";
+FIRLoggerService kFIRLoggerFirestore = @"Firebase/Firestore";
+FIRLoggerService kFIRLoggerInstanceID = @"Firebase/InstanceID";
+FIRLoggerService kFIRLoggerInvites = @"Firebase/Invites";
+FIRLoggerService kFIRLoggerMLKit = @"Firebase/MLKit";
+FIRLoggerService kFIRLoggerMessaging = @"Firebase/Messaging";
+FIRLoggerService kFIRLoggerPerf = @"Firebase/Performance";
+FIRLoggerService kFIRLoggerRemoteConfig = @"Firebase/RemoteConfig";
+FIRLoggerService kFIRLoggerStorage = @"Firebase/Storage";
+FIRLoggerService kFIRLoggerSwizzler = @"FirebaseSwizzlingUtilities";
 
 /// Arguments passed on launch.
 NSString *const kFIRDisableDebugModeApplicationArgument = @"-FIRDebugDisabled";

--- a/GoogleUtilities/Example/Tests/Logger/GULOSLoggerTest.m
+++ b/GoogleUtilities/Example/Tests/Logger/GULOSLoggerTest.m
@@ -261,7 +261,7 @@ void GULTestOSLogWithType(os_log_t log, os_log_type_t type, char *s, ...) {
                   withService:kService
                      isForced:NO
                      withCode:kCode
-                  withMessage:@"%@", message];
+                  withMessage:message];
   [self waitForExpectations:sExpectations timeout:kTimeout];
 }
 

--- a/GoogleUtilities/Logger/GULASLLogger.m
+++ b/GoogleUtilities/Logger/GULASLLogger.m
@@ -122,27 +122,16 @@ NS_ASSUME_NONNULL_BEGIN
          withService:(GULLoggerService)service
             isForced:(BOOL)forced
             withCode:(NSString *)messageCode
-         withMessage:(NSString *)message, ... {
+         withMessage:(NSString *)message {
   // Skip logging this if the level isn't to be logged unless it's forced.
   if (![self isLoggableLevel:level] && !forced) {
     return;
   }
   [self initializeLogger];
-
-  // Process the va_list here, while the parameters are on the stack.
-  va_list args;
-  va_start(args, message);
-  message = [[NSString alloc] initWithFormat:message arguments:args];
-  va_end(args);
-  const char *logMsg = [GULLogger messageFromLogger:self
-                                        withService:service
-                                               code:messageCode
-                                            message:message]
-                           .UTF8String;
   dispatch_async(self.dispatchQueue, ^{
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"  // asl is deprecated
-    asl_log(self.aslClient, NULL, (int)level, "%s", logMsg);
+    asl_log(self.aslClient, NULL, (int)level, "%s", message.UTF8String);
 #pragma clang diagnostic pop
   });
 }

--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -49,10 +49,9 @@ static NSRegularExpression *sMessageCodeRegex;
   NSCAssert(code.length == 11, @"Incorrect message code length.");
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    sMessageCodeRegex =
-        [NSRegularExpression regularExpressionWithPattern:kMessageCodePattern
-                                                  options:0
-                                                    error:NULL];
+    sMessageCodeRegex = [NSRegularExpression regularExpressionWithPattern:kMessageCodePattern
+                                                                  options:0
+                                                                    error:NULL];
   });
   NSRange messageCodeRange = NSMakeRange(0, code.length);
   NSUInteger numberOfMatches = [sMessageCodeRegex numberOfMatchesInString:code

--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -25,8 +25,9 @@
 #endif
 
 #ifdef DEBUG
+/// The regex pattern for the message code.
+static NSString *const kMessageCodePattern = @"^I-[A-Z]{3}[0-9]{6}$";
 static NSRegularExpression *sMessageCodeRegex;
-static NSString *const kGULLoggerMessageCodePattern = @"^I-[A-Z]{3}[0-9]{6}$";
 #endif
 
 @implementation GULLogger (Internal)
@@ -49,7 +50,7 @@ static NSString *const kGULLoggerMessageCodePattern = @"^I-[A-Z]{3}[0-9]{6}$";
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     sMessageCodeRegex =
-        [NSRegularExpression regularExpressionWithPattern:kGULLoggerMessageCodePattern
+        [NSRegularExpression regularExpressionWithPattern:kMessageCodePattern
                                                   options:0
                                                     error:NULL];
   });
@@ -68,6 +69,11 @@ static id<GULLoggerSystem> sGULLogger;
 
 void GULLoggerInitialize(void) {
   [GULLogger.logger initializeLogger];
+#ifdef DEBUG
+  sMessageCodeRegex = [NSRegularExpression regularExpressionWithPattern:kMessageCodePattern
+                                                                options:0
+                                                                  error:NULL];
+#endif
 }
 
 void GULLoggerInitializeASL(void) {
@@ -99,15 +105,26 @@ void GULLogBasic(GULLoggerLevel level,
                  BOOL forceLog,
                  NSString *messageCode,
                  NSString *message,
-                 ...) {
-  va_list formatArgs;
-  va_start(formatArgs, message);
+                 va_list args_ptr) {
+#ifdef DEBUG
+  sMessageCodeRegex = [NSRegularExpression regularExpressionWithPattern:kMessageCodePattern
+                                                                options:0
+                                                                  error:NULL];
+  NSCAssert(messageCode.length == 11, @"Incorrect message code length.");
+  NSRange messageCodeRange = NSMakeRange(0, messageCode.length);
+  NSUInteger numberOfMatches = [sMessageCodeRegex numberOfMatchesInString:messageCode
+                                                                  options:0
+                                                                    range:messageCodeRange];
+  NSCAssert(numberOfMatches == 1, @"Incorrect message code format.");
+#endif
+  NSString *logMsg = [[NSString alloc] initWithFormat:message arguments:args_ptr];
+  NSString *formattedMsg =
+      [NSString stringWithFormat:@"%@ - [%@] %@", GULLogger.logger.version, messageCode, logMsg];
   [GULLogger.logger logWithLevel:level
                      withService:service
                         isForced:forceLog
                         withCode:messageCode
-                     withMessage:messageCode, formatArgs];
-  va_end(formatArgs);
+                     withMessage:formattedMsg];
 }
 
 /**

--- a/GoogleUtilities/Logger/GULOSLogger.m
+++ b/GoogleUtilities/Logger/GULOSLogger.m
@@ -153,22 +153,12 @@ static void GULLOSLogWithType(os_log_t log, os_log_type_t type, char *format, ..
          withService:(GULLoggerService)service
             isForced:(BOOL)forced
             withCode:(NSString *)messageCode
-         withMessage:(NSString *)message, ... {
+         withMessage:(NSString *)message {
   // Skip logging this if the level isn't to be logged unless it's forced.
   if (![self isLoggableLevel:level] && !forced) {
     return;
   }
   [self initializeLogger];
-
-  // Process the va_list here, while the parameters are on the stack.
-  va_list args;
-  va_start(args, message);
-  NSString *completeMessage = [[NSString alloc] initWithFormat:message arguments:args];
-  va_end(args);
-  completeMessage = [GULLogger messageFromLogger:self
-                                     withService:service
-                                            code:messageCode
-                                         message:[completeMessage copy]];
 
   // Avoid blocking during logging.
   dispatch_async(self.dispatchQueue, ^{
@@ -197,7 +187,7 @@ static void GULLOSLogWithType(os_log_t log, os_log_type_t type, char *format, ..
     }
     // Call the function pointer using the message constructed by GULLogger.
     (*self.logFunction)(osLog, [[self class] osLogTypeForGULLoggerLevel:level], "%s",
-                        completeMessage.UTF8String);
+                        message.UTF8String);
   });
 }
 

--- a/GoogleUtilities/Logger/Private/GULLogger.h
+++ b/GoogleUtilities/Logger/Private/GULLogger.h
@@ -80,15 +80,21 @@ extern void GULLoggerRegisterVersion(const char *version);
  *            within the service.
  *            An example of the message code is @"I-COR000001".
  * @param message string which can be a format string.
- * @param ... variable arguments list obtained from calling va_start, used when message is a format
- *            string.
+ * @param args_ptr the list of arguments to substitute into the format string.
  */
 extern void GULLogBasic(GULLoggerLevel level,
                         GULLoggerService service,
                         BOOL forceLog,
                         NSString *messageCode,
                         NSString *message,
-                        ...);
+// On 64-bit simulators, va_list is not a pointer, so cannot be marked nullable
+// See: http://stackoverflow.com/q/29095469
+#if __LP64__ && TARGET_OS_SIMULATOR || TARGET_OS_OSX
+                        va_list args_ptr
+#else
+                        va_list _Nullable args_ptr
+#endif
+);
 
 /**
  * The following functions accept the following parameters in order:

--- a/GoogleUtilities/Logger/Private/GULLoggerSystem.h
+++ b/GoogleUtilities/Logger/Private/GULLoggerSystem.h
@@ -45,7 +45,7 @@ typedef NSString *const GULLoggerService;
          withService:(GULLoggerService)service
             isForced:(BOOL)forced
             withCode:(NSString *)messageCode
-         withMessage:(NSString *)message, ... NS_FORMAT_FUNCTION(5, 6);
+         withMessage:(NSString *)message;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Restore GULLogger to the same API that it has used with Firebase 5.x
Fix the regression that messages were not being logged (only the rest of info in log line)
Remove brackets around service names since os_log adds them anyways.