### PR TITLE
Feedback for #2492 in the form of a PR

### DIFF
--- a/Firestore/Example/Tests/API/FIRQuerySnapshotTests.mm
+++ b/Firestore/Example/Tests/API/FIRQuerySnapshotTests.mm
@@ -25,6 +25,7 @@
 #import "Firestore/Example/Tests/Util/FSTHelpers.h"
 #import "Firestore/Source/API/FIRDocumentChange+Internal.h"
 #import "Firestore/Source/API/FIRDocumentSnapshot+Internal.h"
+#import "Firestore/Source/API/FIRFirestore+Internal.h"
 #import "Firestore/Source/API/FIRQuerySnapshot+Internal.h"
 #import "Firestore/Source/API/FIRSnapshotMetadata+Internal.h"
 #import "Firestore/Source/Model/FSTDocument.h"
@@ -109,16 +110,18 @@ NS_ASSUME_NONNULL_BEGIN
                                                               snapshot:std::move(viewSnapshot)
                                                               metadata:metadata];
 
-  FIRQueryDocumentSnapshot *doc1Snap = [FIRQueryDocumentSnapshot snapshotWithFirestore:firestore
-                                                                           documentKey:doc1New.key
-                                                                              document:doc1New
-                                                                             fromCache:NO
-                                                                      hasPendingWrites:NO];
-  FIRQueryDocumentSnapshot *doc2Snap = [FIRQueryDocumentSnapshot snapshotWithFirestore:firestore
-                                                                           documentKey:doc2New.key
-                                                                              document:doc2New
-                                                                             fromCache:NO
-                                                                      hasPendingWrites:NO];
+  FIRQueryDocumentSnapshot *doc1Snap =
+      [[FIRQueryDocumentSnapshot alloc] initWithFirestore:firestore.wrapped
+                                              documentKey:doc1New.key
+                                                 document:doc1New
+                                                fromCache:false
+                                         hasPendingWrites:false];
+  FIRQueryDocumentSnapshot *doc2Snap =
+      [[FIRQueryDocumentSnapshot alloc] initWithFirestore:firestore.wrapped
+                                              documentKey:doc2New.key
+                                                 document:doc2New
+                                                fromCache:false
+                                         hasPendingWrites:false];
 
   NSArray<FIRDocumentChange *> *changesWithoutMetadata = @[
     [[FIRDocumentChange alloc] initWithType:FIRDocumentChangeTypeModified

--- a/Firestore/Example/Tests/API/FSTAPIHelpers.mm
+++ b/Firestore/Example/Tests/API/FSTAPIHelpers.mm
@@ -73,11 +73,11 @@ FIRDocumentSnapshot *FSTTestDocSnapshot(const absl::string_view path,
       data ? FSTTestDoc(path, version, data,
                         hasMutations ? FSTDocumentStateLocalMutations : FSTDocumentStateSynced)
            : nil;
-  return [FIRDocumentSnapshot snapshotWithFirestore:FSTTestFirestore()
-                                        documentKey:testutil::Key(path)
-                                           document:doc
-                                          fromCache:fromCache
-                                   hasPendingWrites:hasMutations];
+  return [[FIRDocumentSnapshot alloc] initWithFirestore:FSTTestFirestore().wrapped
+                                            documentKey:testutil::Key(path)
+                                               document:doc
+                                              fromCache:fromCache
+                                       hasPendingWrites:hasMutations];
 }
 
 FIRCollectionReference *FSTTestCollectionRef(const absl::string_view path) {

--- a/Firestore/Example/Tests/API/FSTAPIHelpers.mm
+++ b/Firestore/Example/Tests/API/FSTAPIHelpers.mm
@@ -86,8 +86,8 @@ FIRCollectionReference *FSTTestCollectionRef(const absl::string_view path) {
 }
 
 FIRDocumentReference *FSTTestDocRef(const absl::string_view path) {
-  return [FIRDocumentReference referenceWithPath:testutil::Resource(path)
-                                       firestore:FSTTestFirestore()];
+  return [[FIRDocumentReference alloc] initWithPath:testutil::Resource(path)
+                                          firestore:FSTTestFirestore().wrapped];
 }
 
 /** A convenience method for creating a query snapshots for tests. */

--- a/Firestore/Example/Tests/API/FSTAPIHelpers.mm
+++ b/Firestore/Example/Tests/API/FSTAPIHelpers.mm
@@ -34,15 +34,12 @@
 #import "Firestore/Source/Model/FSTDocument.h"
 #import "Firestore/Source/Model/FSTDocumentSet.h"
 
-#include "Firestore/core/src/firebase/firestore/api/firestore.h"
 #include "Firestore/core/src/firebase/firestore/core/view_snapshot.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 #include "Firestore/core/test/firebase/firestore/testutil/testutil.h"
-#include "absl/memory/memory.h"
 
 namespace testutil = firebase::firestore::testutil;
 namespace util = firebase::firestore::util;
-using firebase::firestore::api::Firestore;
 using firebase::firestore::core::DocumentViewChange;
 using firebase::firestore::core::ViewSnapshot;
 using firebase::firestore::model::DocumentKeySet;
@@ -56,9 +53,11 @@ FIRFirestore *FSTTestFirestore() {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
   dispatch_once(&onceToken, ^{
-    auto underlyingFirestore =
-        absl::make_unique<Firestore>("abc", "abc", "db123", nullptr, nullptr);
-    sharedInstance = [[FIRFirestore alloc] initWithFirestore:std::move(underlyingFirestore)
+    sharedInstance = [[FIRFirestore alloc] initWithProjectID:"abc"
+                                                    database:"abc"
+                                              persistenceKey:"db123"
+                                         credentialsProvider:nullptr
+                                                 workerQueue:nullptr
                                                  firebaseApp:nil];
   });
 #pragma clang diagnostic pop

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -32,7 +32,6 @@
 #include <string>
 #include <utility>
 
-#include "Firestore/core/src/firebase/firestore/api/firestore.h"
 #include "Firestore/core/src/firebase/firestore/auth/empty_credentials_provider.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
 #include "Firestore/core/src/firebase/firestore/remote/grpc_connection.h"
@@ -56,7 +55,6 @@
 #include "Firestore/core/src/firebase/firestore/util/executor_libdispatch.h"
 
 namespace util = firebase::firestore::util;
-using firebase::firestore::api::Firestore;
 using firebase::firestore::auth::CredentialsProvider;
 using firebase::firestore::auth::EmptyCredentialsProvider;
 using firebase::firestore::model::DatabaseId;
@@ -193,10 +191,11 @@ static FIRFirestoreSettings *defaultSettings;
   std::unique_ptr<CredentialsProvider> credentials_provider =
       absl::make_unique<firebase::firestore::auth::EmptyCredentialsProvider>();
 
-  auto underlyingFirestore = absl::make_unique<Firestore>(
-      util::MakeString(projectID), DatabaseId::kDefault, util::MakeString(persistenceKey),
-      std::move(credentials_provider), std::move(workerQueue));
-  FIRFirestore *firestore = [[FIRFirestore alloc] initWithFirestore:std::move(underlyingFirestore)
+  FIRFirestore *firestore = [[FIRFirestore alloc] initWithProjectID:util::MakeString(projectID)
+                                                           database:DatabaseId::kDefault
+                                                     persistenceKey:util::MakeString(persistenceKey)
+                                                credentialsProvider:std::move(credentials_provider)
+                                                        workerQueue:std::move(workerQueue)
                                                         firebaseApp:app];
 
   firestore.settings = [FSTIntegrationTestCase settings];

--- a/Firestore/Source/API/FIRCollectionReference.mm
+++ b/Firestore/Source/API/FIRCollectionReference.mm
@@ -15,11 +15,13 @@
  */
 
 #import "FIRCollectionReference.h"
-#import "FIRFirestore.h"
+
+#include <utility>
 
 #include "Firestore/core/src/firebase/firestore/util/autoid.h"
 
 #import "Firestore/Source/API/FIRDocumentReference+Internal.h"
+#import "Firestore/Source/API/FIRFirestore+Internal.h"
 #import "Firestore/Source/API/FIRQuery+Internal.h"
 #import "Firestore/Source/API/FIRQuery_Init.h"
 #import "Firestore/Source/Core/FSTQuery.h"
@@ -99,7 +101,8 @@ NS_ASSUME_NONNULL_BEGIN
     return nil;
   } else {
     DocumentKey key{parentPath};
-    return [FIRDocumentReference referenceWithKey:key firestore:self.firestore];
+    return [[FIRDocumentReference alloc] initWithKey:std::move(key)
+                                           firestore:self.firestore.wrapped];
   }
 }
 
@@ -112,8 +115,9 @@ NS_ASSUME_NONNULL_BEGIN
     FSTThrowInvalidArgument(@"Document path cannot be nil.");
   }
   const ResourcePath subPath = ResourcePath::FromString(util::MakeString(documentPath));
-  const ResourcePath path = self.query.path.Append(subPath);
-  return [FIRDocumentReference referenceWithPath:path firestore:self.firestore];
+  ResourcePath path = self.query.path.Append(subPath);
+  return [[FIRDocumentReference alloc] initWithPath:std::move(path)
+                                          firestore:self.firestore.wrapped];
 }
 
 - (FIRDocumentReference *)addDocumentWithData:(NSDictionary<NSString *, id> *)data {
@@ -129,8 +133,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (FIRDocumentReference *)documentWithAutoID {
-  const DocumentKey key{self.query.path.Append(CreateAutoId())};
-  return [FIRDocumentReference referenceWithKey:key firestore:self.firestore];
+  DocumentKey key{self.query.path.Append(CreateAutoId())};
+  return [[FIRDocumentReference alloc] initWithKey:std::move(key) firestore:self.firestore.wrapped];
 }
 
 @end

--- a/Firestore/Source/API/FIRDocumentChange+Internal.h
+++ b/Firestore/Source/API/FIRDocumentChange+Internal.h
@@ -16,6 +16,7 @@
 
 #import "FIRDocumentChange.h"
 
+#include "Firestore/core/src/firebase/firestore/api/firestore.h"
 #include "Firestore/core/src/firebase/firestore/core/view_snapshot.h"
 
 @class FIRFirestore;
@@ -26,10 +27,10 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FIRDocumentChange (Internal)
 
 /** Calculates the array of FIRDocumentChange's based on the given FSTViewSnapshot. */
-+ (NSArray<FIRDocumentChange *> *)documentChangesForSnapshot:
-                                      (const firebase::firestore::core::ViewSnapshot &)snapshot
-                                      includeMetadataChanges:(BOOL)includeMetadataChanges
-                                                   firestore:(FIRFirestore *)firestore;
++ (NSArray<FIRDocumentChange *> *)
+    documentChangesForSnapshot:(const firebase::firestore::core::ViewSnapshot &)snapshot
+        includeMetadataChanges:(bool)includeMetadataChanges
+                     firestore:(firebase::firestore::api::Firestore *)firestore;
 
 @end
 

--- a/Firestore/Source/API/FIRDocumentChange.mm
+++ b/Firestore/Source/API/FIRDocumentChange.mm
@@ -17,6 +17,7 @@
 #import "FIRDocumentChange.h"
 
 #import "Firestore/Source/API/FIRDocumentSnapshot+Internal.h"
+#import "Firestore/Source/API/FIRFirestore+Internal.h"
 #import "Firestore/Source/Core/FSTQuery.h"
 #import "Firestore/Source/Model/FSTDocument.h"
 #import "Firestore/Source/Model/FSTDocumentSet.h"
@@ -24,6 +25,7 @@
 #include "Firestore/core/src/firebase/firestore/core/view_snapshot.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 
+using firebase::firestore::api::Firestore;
 using firebase::firestore::core::DocumentViewChange;
 using firebase::firestore::core::ViewSnapshot;
 
@@ -55,8 +57,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (NSArray<FIRDocumentChange *> *)documentChangesForSnapshot:(const ViewSnapshot &)snapshot
-                                      includeMetadataChanges:(BOOL)includeMetadataChanges
-                                                   firestore:(FIRFirestore *)firestore {
+                                      includeMetadataChanges:(bool)includeMetadataChanges
+                                                   firestore:(Firestore *)firestore {
   if (snapshot.old_documents().isEmpty) {
     // Special case the first snapshot because index calculation is easy and fast. Also all changes
     // on the first snapshot are adds so there are also no metadata-only changes to filter out.
@@ -64,12 +66,12 @@ NS_ASSUME_NONNULL_BEGIN
     NSUInteger index = 0;
     NSMutableArray<FIRDocumentChange *> *changes = [NSMutableArray array];
     for (const DocumentViewChange &change : snapshot.document_changes()) {
-      FIRQueryDocumentSnapshot *document = [FIRQueryDocumentSnapshot
-          snapshotWithFirestore:firestore
-                    documentKey:change.document().key
-                       document:change.document()
-                      fromCache:snapshot.from_cache()
-               hasPendingWrites:snapshot.mutated_keys().contains(change.document().key)];
+      FIRQueryDocumentSnapshot *document = [[FIRQueryDocumentSnapshot alloc]
+          initWithFirestore:firestore
+                documentKey:change.document().key
+                   document:change.document()
+                  fromCache:snapshot.from_cache()
+           hasPendingWrites:snapshot.mutated_keys().contains(change.document().key)];
       HARD_ASSERT(change.type() == DocumentViewChange::Type::kAdded,
                   "Invalid event type for first snapshot");
       HARD_ASSERT(!lastDocument || snapshot.query().comparator(lastDocument, change.document()) ==
@@ -91,12 +93,12 @@ NS_ASSUME_NONNULL_BEGIN
         continue;
       }
 
-      FIRQueryDocumentSnapshot *document = [FIRQueryDocumentSnapshot
-          snapshotWithFirestore:firestore
-                    documentKey:change.document().key
-                       document:change.document()
-                      fromCache:snapshot.from_cache()
-               hasPendingWrites:snapshot.mutated_keys().contains(change.document().key)];
+      FIRQueryDocumentSnapshot *document = [[FIRQueryDocumentSnapshot alloc]
+          initWithFirestore:firestore
+                documentKey:change.document().key
+                   document:change.document()
+                  fromCache:snapshot.from_cache()
+           hasPendingWrites:snapshot.mutated_keys().contains(change.document().key)];
 
       NSUInteger oldIndex = NSNotFound;
       NSUInteger newIndex = NSNotFound;

--- a/Firestore/Source/API/FIRDocumentReference+Internal.h
+++ b/Firestore/Source/API/FIRDocumentReference+Internal.h
@@ -22,15 +22,21 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface FIRDocumentReference (/* Init */)
+
+- (instancetype)initWithReference:(firebase::firestore::api::DocumentReference &&)reference
+    NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithPath:(firebase::firestore::model::ResourcePath)path
+                   firestore:(firebase::firestore::api::Firestore *)firestore;
+
+- (instancetype)initWithKey:(firebase::firestore::model::DocumentKey)key
+                  firestore:(firebase::firestore::api::Firestore *)firestore;
+
+@end
+
 /** Internal FIRDocumentReference API we don't want exposed in our public header files. */
 @interface FIRDocumentReference (Internal)
-
-+ (instancetype)referenceWithPath:(const firebase::firestore::model::ResourcePath &)path
-                        firestore:(FIRFirestore *)firestore;
-+ (instancetype)referenceWithKey:(firebase::firestore::model::DocumentKey)key
-                       firestore:(FIRFirestore *)firestore;
-+ (instancetype)referenceWithReference:(firebase::firestore::api::DocumentReference &&)reference
-                             firestore:(FIRFirestore *)firestore;
 
 - (const firebase::firestore::model::DocumentKey &)key;
 

--- a/Firestore/Source/API/FIRDocumentReference.mm
+++ b/Firestore/Source/API/FIRDocumentReference.mm
@@ -228,8 +228,7 @@ NS_ASSUME_NONNULL_BEGIN
   return [block, firestore](StatusOr<DocumentSnapshot> maybe_snapshot) {
     if (maybe_snapshot.ok()) {
       FIRDocumentSnapshot *result =
-          [FIRDocumentSnapshot snapshotWithSnapshot:std::move(maybe_snapshot).ValueOrDie()
-                                          firestore:firestore];
+          [[FIRDocumentSnapshot alloc] initWithSnapshot:std::move(maybe_snapshot).ValueOrDie()];
       block(result, nil);
     } else {
       block(nil, util::MakeNSError(maybe_snapshot.status()));

--- a/Firestore/Source/API/FIRDocumentReference.mm
+++ b/Firestore/Source/API/FIRDocumentReference.mm
@@ -47,6 +47,7 @@
 namespace util = firebase::firestore::util;
 using firebase::firestore::api::DocumentReference;
 using firebase::firestore::api::DocumentSnapshot;
+using firebase::firestore::api::Firestore;
 using firebase::firestore::api::HandleMaybe;
 using firebase::firestore::core::ParsedSetData;
 using firebase::firestore::core::ParsedUpdateData;
@@ -60,23 +61,29 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - FIRDocumentReference
 
-@interface FIRDocumentReference ()
-- (instancetype)initWithReference:(DocumentReference &&)reference
-                        firestore:(FIRFirestore *)firestore NS_DESIGNATED_INITIALIZER;
-
-@end
-
 @implementation FIRDocumentReference {
   DocumentReference _documentReference;
 }
 
-- (instancetype)initWithReference:(DocumentReference &&)reference
-                        firestore:(FIRFirestore *)firestore {
+- (instancetype)initWithReference:(DocumentReference &&)reference {
   if (self = [super init]) {
     _documentReference = std::move(reference);
-    _firestore = firestore;
   }
   return self;
+}
+
+- (instancetype)initWithPath:(ResourcePath)path firestore:(Firestore *)firestore {
+  if (path.size() % 2 != 0) {
+    FSTThrowInvalidArgument(@"Invalid document reference. Document references must have an even "
+                             "number of segments, but %s has %zu",
+                            path.CanonicalString().c_str(), path.size());
+  }
+  return [self initWithKey:DocumentKey{std::move(path)} firestore:firestore];
+}
+
+- (instancetype)initWithKey:(DocumentKey)key firestore:(Firestore *)firestore {
+  DocumentReference delegate{firestore, std::move(key)};
+  return [self initWithReference:std::move(delegate)];
 }
 
 #pragma mark - NSObject Methods
@@ -94,13 +101,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Public Methods
 
+@dynamic firestore;
+
+- (FIRFirestore *)firestore {
+  return [FIRFirestore recoverFromFirestore:_documentReference.firestore()];
+}
+
 - (NSString *)documentID {
   return util::WrapNSString(_documentReference.document_id());
 }
 
 - (FIRCollectionReference *)parent {
   return [FIRCollectionReference referenceWithPath:_documentReference.key().path().PopLast()
-                                         firestore:_firestore];
+                                         firestore:self.firestore];
 }
 
 - (NSString *)path {
@@ -112,9 +125,9 @@ NS_ASSUME_NONNULL_BEGIN
     FSTThrowInvalidArgument(@"Collection path cannot be nil.");
   }
 
-  ResourcePath sub_path = ResourcePath::FromString(util::MakeString(collectionPath));
-  ResourcePath path = _documentReference.key().path().Append(sub_path);
-  return [FIRCollectionReference referenceWithPath:path firestore:_firestore];
+  ResourcePath subPath = ResourcePath::FromString(util::MakeString(collectionPath));
+  ResourcePath path = _documentReference.key().path().Append(subPath);
+  return [FIRCollectionReference referenceWithPath:path firestore:self.firestore];
 }
 
 - (void)setData:(NSDictionary<NSString *, id> *)documentData {
@@ -138,9 +151,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setData:(NSDictionary<NSString *, id> *)documentData
           merge:(BOOL)merge
      completion:(nullable void (^)(NSError *_Nullable error))completion {
-  ParsedSetData parsed = merge
-                             ? [_firestore.dataConverter parsedMergeData:documentData fieldMask:nil]
-                             : [_firestore.dataConverter parsedSetData:documentData];
+  auto dataConverter = self.firestore.dataConverter;
+  ParsedSetData parsed = merge ? [dataConverter parsedMergeData:documentData fieldMask:nil]
+                               : [dataConverter parsedSetData:documentData];
   _documentReference.SetData(
       std::move(parsed).ToMutations(_documentReference.key(), Precondition::None()), completion);
 }
@@ -148,8 +161,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setData:(NSDictionary<NSString *, id> *)documentData
     mergeFields:(NSArray<id> *)mergeFields
      completion:(nullable void (^)(NSError *_Nullable error))completion {
-  ParsedSetData parsed = [_firestore.dataConverter parsedMergeData:documentData
-                                                         fieldMask:mergeFields];
+  ParsedSetData parsed = [self.firestore.dataConverter parsedMergeData:documentData
+                                                             fieldMask:mergeFields];
   _documentReference.SetData(
       std::move(parsed).ToMutations(_documentReference.key(), Precondition::None()), completion);
 }
@@ -160,7 +173,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)updateData:(NSDictionary<id, id> *)fields
         completion:(nullable void (^)(NSError *_Nullable error))completion {
-  ParsedUpdateData parsed = [_firestore.dataConverter parsedUpdateData:fields];
+  ParsedUpdateData parsed = [self.firestore.dataConverter parsedUpdateData:fields];
   _documentReference.UpdateData(
       std::move(parsed).ToMutations(_documentReference.key(), Precondition::Exists(true)),
       completion);
@@ -211,7 +224,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (HandleMaybe<DocumentSnapshot>)wrapDocumentSnapshotBlock:(FIRDocumentSnapshotBlock)block {
-  FIRFirestore *firestore = _firestore;
+  FIRFirestore *firestore = self.firestore;
   return [block, firestore](StatusOr<DocumentSnapshot> maybe_snapshot) {
     if (maybe_snapshot.ok()) {
       FIRDocumentSnapshot *result =
@@ -229,26 +242,6 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - FIRDocumentReference (Internal)
 
 @implementation FIRDocumentReference (Internal)
-
-+ (instancetype)referenceWithPath:(const ResourcePath &)path firestore:(FIRFirestore *)firestore {
-  if (path.size() % 2 != 0) {
-    FSTThrowInvalidArgument(@"Invalid document reference. Document references must have an even "
-                             "number of segments, but %s has %zu",
-                            path.CanonicalString().c_str(), path.size());
-  }
-  return [FIRDocumentReference referenceWithKey:DocumentKey{path} firestore:firestore];
-}
-
-+ (instancetype)referenceWithKey:(DocumentKey)key firestore:(FIRFirestore *)firestore {
-  DocumentReference underlyingReference{firestore.underlyingFirestore, std::move(key)};
-  return [FIRDocumentReference referenceWithReference:std::move(underlyingReference)
-                                            firestore:firestore];
-}
-
-+ (instancetype)referenceWithReference:(DocumentReference &&)reference
-                             firestore:(FIRFirestore *)firestore {
-  return [[FIRDocumentReference alloc] initWithReference:std::move(reference) firestore:firestore];
-}
 
 - (const DocumentKey &)key {
   return _documentReference.key();

--- a/Firestore/Source/API/FIRDocumentSnapshot+Internal.h
+++ b/Firestore/Source/API/FIRDocumentSnapshot+Internal.h
@@ -16,34 +16,29 @@
 
 #import "FIRDocumentSnapshot.h"
 
+#include "Firestore/core/src/firebase/firestore/api/document_snapshot.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
-
-namespace firebase {
-namespace firestore {
-namespace api {
-
-class DocumentSnapshot;
-
-}  // namespace api
-}  // namespace firestore
-}  // namespace firebase
 
 @class FIRFirestore;
 @class FSTDocument;
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface FIRDocumentSnapshot (/* Init */)
+
+- (instancetype)initWithSnapshot:(firebase::firestore::api::DocumentSnapshot &&)snapshot
+    NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithFirestore:(firebase::firestore::api::Firestore *)firestore
+                      documentKey:(firebase::firestore::model::DocumentKey)documentKey
+                         document:(nullable FSTDocument *)document
+                        fromCache:(bool)fromCache
+                 hasPendingWrites:(bool)pendingWrites;
+
+@end
+
 /** Internal FIRDocumentSnapshot API we don't want exposed in our public header files. */
 @interface FIRDocumentSnapshot (Internal)
-
-+ (instancetype)snapshotWithFirestore:(FIRFirestore *)firestore
-                          documentKey:(firebase::firestore::model::DocumentKey)documentKey
-                             document:(nullable FSTDocument *)document
-                            fromCache:(BOOL)fromCache
-                     hasPendingWrites:(BOOL)pendingWrites;
-
-+ (instancetype)snapshotWithSnapshot:(firebase::firestore::api::DocumentSnapshot &&)snapshot
-                           firestore:(FIRFirestore *)firestore;
 
 @property(nonatomic, strong, readonly, nullable) FSTDocument *internalDocument;
 

--- a/Firestore/Source/API/FIRDocumentSnapshot.mm
+++ b/Firestore/Source/API/FIRDocumentSnapshot.mm
@@ -31,6 +31,7 @@
 #import "Firestore/Source/Util/FSTUsageValidation.h"
 
 #include "Firestore/core/src/firebase/firestore/api/document_snapshot.h"
+#include "Firestore/core/src/firebase/firestore/api/firestore.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
@@ -38,6 +39,7 @@
 
 namespace util = firebase::firestore::util;
 using firebase::firestore::api::DocumentSnapshot;
+using firebase::firestore::api::Firestore;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::util::WrapNSString;
@@ -64,44 +66,24 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
 
 }  // namespace
 
-@interface FIRDocumentSnapshot ()
-
-- (instancetype)initWithSnapshot:(DocumentSnapshot &&)snapshot firestore:(FIRFirestore *)firestore;
-
-@property(nonatomic, readonly, readonly) FIRFirestore *firestore;
-
-@end
-
-@implementation FIRDocumentSnapshot (Internal)
-
-+ (instancetype)snapshotWithFirestore:(FIRFirestore *)firestore
-                          documentKey:(DocumentKey)documentKey
-                             document:(nullable FSTDocument *)document
-                            fromCache:(BOOL)fromCache
-                     hasPendingWrites:(BOOL)pendingWrites {
-  DocumentSnapshot underlyingSnapshot{firestore.wrapped, documentKey, document,
-                                      static_cast<bool>(fromCache),
-                                      static_cast<bool>(pendingWrites)};
-  return [[[self class] alloc] initWithSnapshot:std::move(underlyingSnapshot) firestore:firestore];
-}
-
-+ (instancetype)snapshotWithSnapshot:(DocumentSnapshot &&)snapshot
-                           firestore:(FIRFirestore *)firestore {
-  return [[[self class] alloc] initWithSnapshot:std::move(snapshot) firestore:firestore];
-}
-
-@end
-
 @implementation FIRDocumentSnapshot {
   DocumentSnapshot _snapshot;
 }
 
-- (instancetype)initWithSnapshot:(DocumentSnapshot &&)snapshot firestore:(FIRFirestore *)firestore {
+- (instancetype)initWithSnapshot:(DocumentSnapshot &&)snapshot {
   if (self = [super init]) {
     _snapshot = std::move(snapshot);
-    _firestore = firestore;
   }
   return self;
+}
+
+- (instancetype)initWithFirestore:(Firestore *)firestore
+                      documentKey:(DocumentKey)documentKey
+                         document:(nullable FSTDocument *)document
+                        fromCache:(bool)fromCache
+                 hasPendingWrites:(bool)pendingWrites {
+  DocumentSnapshot wrapped{firestore, std::move(documentKey), document, fromCache, pendingWrites};
+  return [self initWithSnapshot:std::move(wrapped)];
 }
 
 // NSObject Methods
@@ -206,7 +188,7 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
             database->database_id().c_str());
     }
     DocumentKey key = [[ref valueWithOptions:options] key];
-    return [[FIRDocumentReference alloc] initWithKey:key firestore:_firestore.wrapped];
+    return [[FIRDocumentReference alloc] initWithKey:key firestore:_snapshot.firestore()];
   } else {
     return [value valueWithOptions:options];
   }
@@ -234,18 +216,7 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
 
 @end
 
-@interface FIRQueryDocumentSnapshot ()
-
-- (instancetype)initWithSnapshot:(DocumentSnapshot &&)snapshot
-                       firestore:(FIRFirestore *)firestore NS_DESIGNATED_INITIALIZER;
-
-@end
-
 @implementation FIRQueryDocumentSnapshot
-
-- (instancetype)initWithSnapshot:(DocumentSnapshot &&)snapshot firestore:(FIRFirestore *)firestore {
-  return [super initWithSnapshot:std::move(snapshot) firestore:firestore];
-}
 
 - (NSDictionary<NSString *, id> *)data {
   NSDictionary<NSString *, id> *data = [super data];

--- a/Firestore/Source/API/FIRDocumentSnapshot.mm
+++ b/Firestore/Source/API/FIRDocumentSnapshot.mm
@@ -79,7 +79,7 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
                              document:(nullable FSTDocument *)document
                             fromCache:(BOOL)fromCache
                      hasPendingWrites:(BOOL)pendingWrites {
-  DocumentSnapshot underlyingSnapshot{firestore.underlyingFirestore, documentKey, document,
+  DocumentSnapshot underlyingSnapshot{firestore.wrapped, documentKey, document,
                                       static_cast<bool>(fromCache),
                                       static_cast<bool>(pendingWrites)};
   return [[[self class] alloc] initWithSnapshot:std::move(underlyingSnapshot) firestore:firestore];
@@ -128,8 +128,7 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
 }
 
 - (FIRDocumentReference *)reference {
-  return [FIRDocumentReference referenceWithReference:_snapshot.CreateReference()
-                                            firestore:_firestore];
+  return [[FIRDocumentReference alloc] initWithReference:_snapshot.CreateReference()];
 }
 
 - (NSString *)documentID {
@@ -207,7 +206,7 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
             database->database_id().c_str());
     }
     DocumentKey key = [[ref valueWithOptions:options] key];
-    return [FIRDocumentReference referenceWithKey:key firestore:_firestore];
+    return [[FIRDocumentReference alloc] initWithKey:key firestore:_firestore.wrapped];
   } else {
     return [value valueWithOptions:options];
   }

--- a/Firestore/Source/API/FIRFirestore+Internal.h
+++ b/Firestore/Source/API/FIRFirestore+Internal.h
@@ -51,6 +51,8 @@ NS_ASSUME_NONNULL_BEGIN
 /** Checks to see if logging is is globally enabled for the Firestore client. */
 + (BOOL)isLoggingEnabled;
 
++ (FIRFirestore *)recoverFromFirestore:(firebase::firestore::api::Firestore *)firestore;
+
 /**
  * Shutdown this `FIRFirestore`, releasing all resources (abandoning any outstanding writes,
  * removing all listens, closing all network connections, etc.).
@@ -60,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)shutdownWithCompletion:(nullable void (^)(NSError *_Nullable error))completion
     NS_SWIFT_NAME(shutdown(completion:));
 
-@property(nonatomic, assign, readonly) firebase::firestore::api::Firestore *delegate;
+@property(nonatomic, assign, readonly) firebase::firestore::api::Firestore *wrapped;
 
 @property(nonatomic, assign, readonly) firebase::firestore::util::AsyncQueue *workerQueue;
 

--- a/Firestore/Source/API/FIRFirestore+Internal.h
+++ b/Firestore/Source/API/FIRFirestore+Internal.h
@@ -60,9 +60,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)shutdownWithCompletion:(nullable void (^)(NSError *_Nullable error))completion
     NS_SWIFT_NAME(shutdown(completion:));
 
-- (firebase::firestore::util::AsyncQueue *)workerQueue;
+@property(nonatomic, assign, readonly) firebase::firestore::api::Firestore *delegate;
 
-- (firebase::firestore::api::Firestore *)underlyingFirestore;
+@property(nonatomic, assign, readonly) firebase::firestore::util::AsyncQueue *workerQueue;
 
 // FIRFirestore ownes the DatabaseId instance.
 @property(nonatomic, assign, readonly) const firebase::firestore::model::DatabaseId *databaseID;

--- a/Firestore/Source/API/FIRFirestore+Internal.h
+++ b/Firestore/Source/API/FIRFirestore+Internal.h
@@ -17,20 +17,13 @@
 #import "FIRFirestore.h"
 
 #include <memory>
+#include <string>
 
 #include "Firestore/core/src/firebase/firestore/api/firestore.h"
+#include "Firestore/core/src/firebase/firestore/auth/credentials_provider.h"
+#include "Firestore/core/src/firebase/firestore/util/async_queue.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
-namespace firebase {
-namespace firestore {
-namespace api {
-
-class Firestore;
-
-}  // namespace api
-}  // namespace firestore
-}  // namespace firebase
 
 @class FIRApp;
 @class FSTFirestoreClient;
@@ -42,9 +35,14 @@ class Firestore;
  * Initializes a Firestore object with all the required parameters directly. This exists so that
  * tests can create FIRFirestore objects without needing FIRApp.
  */
-- (instancetype)initWithFirestore:(std::unique_ptr<firebase::firestore::api::Firestore>)firestore
-                      firebaseApp:(FIRApp *)app;
-
+- (instancetype)
+      initWithProjectID:(std::string)projectID
+               database:(std::string)database
+         persistenceKey:(std::string)persistenceKey
+    credentialsProvider:
+        (std::unique_ptr<firebase::firestore::auth::CredentialsProvider>)credentialsProvider
+            workerQueue:(std::unique_ptr<firebase::firestore::util::AsyncQueue>)workerQueue
+            firebaseApp:(FIRApp *)app;
 @end
 
 /** Internal FIRFirestore API we don't want exposed in our public header files. */

--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -200,7 +200,7 @@ extern "C" NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
   }
 
   DocumentReference documentReference = _firestore->GetDocument(util::MakeString(documentPath));
-  return [FIRDocumentReference referenceWithReference:std::move(documentReference) firestore:self];
+  return [[FIRDocumentReference alloc] initWithReference:std::move(documentReference)];
 }
 
 - (FIRWriteBatch *)batch {
@@ -252,7 +252,7 @@ extern "C" NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
 
 @implementation FIRFirestore (Internal)
 
-- (Firestore *)delegate {
+- (Firestore *)wrapped {
   return _firestore.get();
 }
 
@@ -266,6 +266,10 @@ extern "C" NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
 
 + (BOOL)isLoggingEnabled {
   return FIRIsLoggableLevel(FIRLoggerLevelDebug, NO);
+}
+
++ (FIRFirestore *)recoverFromFirestore:(Firestore *)firestore {
+  return (__bridge FIRFirestore *)firestore->extension();
 }
 
 - (void)shutdownWithCompletion:(nullable void (^)(NSError *_Nullable error))completion {

--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -143,9 +143,17 @@ extern "C" NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
   return [provider firestoreForDatabase:database];
 }
 
-- (instancetype)initWithFirestore:(std::unique_ptr<Firestore>)firestore firebaseApp:(FIRApp *)app {
+- (instancetype)initWithProjectID:(std::string)projectID
+                         database:(std::string)database
+                   persistenceKey:(std::string)persistenceKey
+              credentialsProvider:(std::unique_ptr<CredentialsProvider>)credentialsProvider
+                      workerQueue:(std::unique_ptr<AsyncQueue>)workerQueue
+                      firebaseApp:(FIRApp *)app {
   if (self = [super init]) {
-    _firestore = std::move(firestore);
+    _firestore = absl::make_unique<Firestore>(
+        std::move(projectID), std::move(database), std::move(persistenceKey),
+        std::move(credentialsProvider), std::move(workerQueue), (__bridge void *)self);
+
     _app = app;
 
     FSTPreConverterBlock block = ^id _Nullable(id _Nullable input) {

--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -65,14 +65,6 @@ extern "C" NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
   std::unique_ptr<Firestore> _firestore;
 }
 
-- (AsyncQueue *)workerQueue {
-  return _firestore->worker_queue();
-}
-
-- (Firestore *)underlyingFirestore {
-  return _firestore.get();
-}
-
 + (NSMutableDictionary<NSString *, FIRFirestore *> *)instances {
   static dispatch_once_t token = 0;
   static NSMutableDictionary<NSString *, FIRFirestore *> *instances;
@@ -244,14 +236,6 @@ extern "C" NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
                      completion:completion];
 }
 
-- (void)shutdownWithCompletion:(nullable void (^)(NSError *_Nullable error))completion {
-  _firestore->Shutdown(completion);
-}
-
-+ (BOOL)isLoggingEnabled {
-  return FIRIsLoggableLevel(FIRLoggerLevelDebug, NO);
-}
-
 + (void)enableLogging:(BOOL)logging {
   FIRSetLoggerLevel(logging ? FIRLoggerLevelDebug : FIRLoggerLevelNotice);
 }
@@ -264,8 +248,28 @@ extern "C" NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
   _firestore->DisableNetwork(completion);
 }
 
+@end
+
+@implementation FIRFirestore (Internal)
+
+- (Firestore *)delegate {
+  return _firestore.get();
+}
+
+- (AsyncQueue *)workerQueue {
+  return _firestore->worker_queue();
+}
+
 - (const DatabaseId *)databaseID {
   return &_firestore->database_id();
+}
+
++ (BOOL)isLoggingEnabled {
+  return FIRIsLoggableLevel(FIRLoggerLevelDebug, NO);
+}
+
+- (void)shutdownWithCompletion:(nullable void (^)(NSError *_Nullable error))completion {
+  _firestore->Shutdown(completion);
 }
 
 @end

--- a/Firestore/Source/API/FIRQuerySnapshot.mm
+++ b/Firestore/Source/API/FIRQuerySnapshot.mm
@@ -18,10 +18,10 @@
 
 #import "Firestore/Source/API/FIRQuerySnapshot+Internal.h"
 
-#import "FIRFirestore.h"
 #import "FIRSnapshotMetadata.h"
 #import "Firestore/Source/API/FIRDocumentChange+Internal.h"
 #import "Firestore/Source/API/FIRDocumentSnapshot+Internal.h"
+#import "Firestore/Source/API/FIRFirestore+Internal.h"
 #import "Firestore/Source/API/FIRQuery+Internal.h"
 #import "Firestore/Source/Core/FSTQuery.h"
 #import "Firestore/Source/Model/FSTDocument.h"
@@ -30,6 +30,7 @@
 
 #include "Firestore/core/src/firebase/firestore/core/view_snapshot.h"
 
+using firebase::firestore::api::Firestore;
 using firebase::firestore::core::ViewSnapshot;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -135,17 +136,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<FIRQueryDocumentSnapshot *> *)documents {
   if (!_documents) {
     FSTDocumentSet *documentSet = _snapshot.documents();
-    FIRFirestore *firestore = self.firestore;
+    Firestore *firestore = self.firestore.wrapped;
     BOOL fromCache = self.metadata.fromCache;
 
     NSMutableArray<FIRQueryDocumentSnapshot *> *result = [NSMutableArray array];
     for (FSTDocument *document in documentSet.documentEnumerator) {
-      [result addObject:[FIRQueryDocumentSnapshot
-                            snapshotWithFirestore:firestore
-                                      documentKey:document.key
-                                         document:document
-                                        fromCache:fromCache
-                                 hasPendingWrites:_snapshot.mutated_keys().contains(document.key)]];
+      [result addObject:[[FIRQueryDocumentSnapshot alloc]
+                            initWithFirestore:firestore
+                                  documentKey:document.key
+                                     document:document
+                                    fromCache:fromCache
+                             hasPendingWrites:_snapshot.mutated_keys().contains(document.key)]];
     }
 
     _documents = result;
@@ -168,7 +169,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (!_documentChanges || _documentChangesIncludeMetadataChanges != includeMetadataChanges) {
     _documentChanges = [FIRDocumentChange documentChangesForSnapshot:_snapshot
                                               includeMetadataChanges:includeMetadataChanges
-                                                           firestore:self.firestore];
+                                                           firestore:self.firestore.wrapped];
     _documentChangesIncludeMetadataChanges = includeMetadataChanges;
   }
   return _documentChanges;

--- a/Firestore/Source/API/FIRTransaction.mm
+++ b/Firestore/Source/API/FIRTransaction.mm
@@ -127,19 +127,20 @@ NS_ASSUME_NONNULL_BEGIN
         HARD_ASSERT(documents.size() == 1, "Mismatch in docs returned from document lookup.");
         FSTMaybeDocument *internalDoc = documents.front();
         if ([internalDoc isKindOfClass:[FSTDeletedDocument class]]) {
-          FIRDocumentSnapshot *doc = [FIRDocumentSnapshot snapshotWithFirestore:self.firestore
-                                                                    documentKey:document.key
-                                                                       document:nil
-                                                                      fromCache:NO
-                                                               hasPendingWrites:NO];
+          FIRDocumentSnapshot *doc =
+              [[FIRDocumentSnapshot alloc] initWithFirestore:self.firestore.wrapped
+                                                 documentKey:document.key
+                                                    document:nil
+                                                   fromCache:false
+                                            hasPendingWrites:false];
           completion(doc, nil);
         } else if ([internalDoc isKindOfClass:[FSTDocument class]]) {
           FIRDocumentSnapshot *doc =
-              [FIRDocumentSnapshot snapshotWithFirestore:self.firestore
-                                             documentKey:internalDoc.key
-                                                document:(FSTDocument *)internalDoc
-                                               fromCache:NO
-                                        hasPendingWrites:NO];
+              [[FIRDocumentSnapshot alloc] initWithFirestore:self.firestore.wrapped
+                                                 documentKey:internalDoc.key
+                                                    document:(FSTDocument *)internalDoc
+                                                   fromCache:false
+                                            hasPendingWrites:false];
           completion(doc, nil);
         } else {
           HARD_FAIL("BatchGetDocumentsRequest returned unexpected document type: %s",

--- a/Firestore/Source/API/FSTFirestoreComponent.mm
+++ b/Firestore/Source/API/FSTFirestoreComponent.mm
@@ -92,15 +92,15 @@ NS_ASSUME_NONNULL_BEGIN
       auto workerQueue = absl::make_unique<AsyncQueue>(std::move(executor));
 
       id<FIRAuthInterop> auth = FIR_COMPONENT(FIRAuthInterop, self.app.container);
-      std::unique_ptr<CredentialsProvider> credentials_provider =
-          absl::make_unique<FirebaseCredentialsProvider>(self.app, auth);
+      auto credentialsProvider = absl::make_unique<FirebaseCredentialsProvider>(self.app, auth);
 
-      NSString *persistenceKey = self.app.name;
-      NSString *projectID = self.app.options.projectID;
-      auto underlyingFirestore = absl::make_unique<Firestore>(
-          util::MakeString(projectID), util::MakeString(database), util::MakeString(persistenceKey),
-          std::move(credentials_provider), std::move(workerQueue));
-      firestore = [[FIRFirestore alloc] initWithFirestore:std::move(underlyingFirestore)
+      std::string projectID = util::MakeString(self.app.options.projectID);
+      std::string persistenceKey = util::MakeString(self.app.name);
+      firestore = [[FIRFirestore alloc] initWithProjectID:std::move(projectID)
+                                                 database:util::MakeString(database)
+                                           persistenceKey:std::move(persistenceKey)
+                                      credentialsProvider:std::move(credentialsProvider)
+                                              workerQueue:std::move(workerQueue)
                                               firebaseApp:self.app];
       _instances[key] = firestore;
     }

--- a/Firestore/core/src/firebase/firestore/api/firestore.h
+++ b/Firestore/core/src/firebase/firestore/api/firestore.h
@@ -62,7 +62,8 @@ class Firestore {
             std::string database,
             std::string persistence_key,
             std::unique_ptr<auth::CredentialsProvider> credentials_provider,
-            std::unique_ptr<util::AsyncQueue> worker_queue);
+            std::unique_ptr<util::AsyncQueue> worker_queue,
+            void* extension);
 
   const model::DatabaseId& database_id() const {
     return database_id_;
@@ -78,12 +79,12 @@ class Firestore {
 
   util::AsyncQueue* worker_queue();
 
+  void* extension() {
+    return extension_;
+  }
+
   FIRFirestoreSettings* settings() const;
   void set_settings(FIRFirestoreSettings* settings);
-
-  FIRApp* app() const {
-    return app_;
-  }
 
   FIRCollectionReference* GetCollection(absl::string_view collection_path,
                                         FIRFirestore* firestore);
@@ -112,9 +113,9 @@ class Firestore {
   // client is created.
   std::unique_ptr<util::AsyncQueue> worker_queue_;
 
-  FIRFirestoreSettings* settings_ = nil;
+  void* extension_ = nullptr;
 
-  FIRApp* app_ = nil;
+  FIRFirestoreSettings* settings_ = nil;
 
   mutable std::mutex mutex_;
 };

--- a/Firestore/core/src/firebase/firestore/api/firestore.mm
+++ b/Firestore/core/src/firebase/firestore/api/firestore.mm
@@ -51,11 +51,13 @@ Firestore::Firestore(std::string project_id,
                      std::string database,
                      std::string persistence_key,
                      std::unique_ptr<CredentialsProvider> credentials_provider,
-                     std::unique_ptr<AsyncQueue> worker_queue)
+                     std::unique_ptr<AsyncQueue> worker_queue,
+                     void* extension)
     : database_id_{std::move(project_id), std::move(database)},
       credentials_provider_{std::move(credentials_provider)},
       persistence_key_{std::move(persistence_key)},
-      worker_queue_{std::move(worker_queue)} {
+      worker_queue_{std::move(worker_queue)},
+      extension_{extension} {
   settings_ = [[FIRFirestoreSettings alloc] init];
 }
 


### PR DESCRIPTION
This change includes a number of proposed fixes for #2492:

  * Get rid of factory methods duplicating initializers in affected types
  * Have `api::Firestore` store a `void*` extension to avoid needing to pass and store extra `FIRFirestore *` references everywhere
  * Add `+[FIRFirestore recoverFromFirestore:]` to help deal with the extension
  * Fixes a few errors in where category methods are defined

I'm filing this in the form of a PR to avoid prompting you to do this and it not being feasible. Feedback welcome, but by the time I proved this approach could work I was in a mostly done state.