### PR TITLE
Add Firebase info to checkin requests (directly from FIRInstanceIDCheckinService) - b/124533860

### DIFF
--- a/Example/InstanceID/Tests/FIRInstanceIDCheckinServiceTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDCheckinServiceTest.m
@@ -16,6 +16,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import <FirebaseCore/FIRAppInternal.h>
 #import <OCMock/OCMock.h>
 #import "Firebase/InstanceID/FIRInstanceIDCheckinPreferences+Internal.h"
 #import "Firebase/InstanceID/FIRInstanceIDCheckinPreferences.h"
@@ -38,15 +39,15 @@ static NSString *const kVersionInfo = @"1.0";
 
 - (void)setUp {
   [super setUp];
+  self.checkinService = [[FIRInstanceIDCheckinService alloc] init];
 }
 
 - (void)tearDown {
+  self.checkinService = nil;
   [super tearDown];
 }
 
 - (void)testCheckinWithSuccessfulCompletion {
-  self.checkinService = [[FIRInstanceIDCheckinService alloc] init];
-
   FIRInstanceIDCheckinPreferences *existingCheckin = [self stubCheckinCacheWithValidData];
 
   [FIRInstanceIDCheckinService setCheckinTestBlock:[self successfulCheckinCompletionHandler]];
@@ -79,8 +80,6 @@ static NSString *const kVersionInfo = @"1.0";
 }
 
 - (void)testFailedCheckinService {
-  self.checkinService = [[FIRInstanceIDCheckinService alloc] init];
-
   [FIRInstanceIDCheckinService setCheckinTestBlock:[self failCheckinCompletionHandler]];
 
   XCTestExpectation *checkinCompletionExpectation =
@@ -93,6 +92,37 @@ static NSString *const kVersionInfo = @"1.0";
                         XCTAssertNil(preferences.deviceID);
                         XCTAssertNil(preferences.secretToken);
                         XCTAssertFalse([preferences hasValidCheckinInfo]);
+                        [checkinCompletionExpectation fulfill];
+                      }];
+
+  [self waitForExpectationsWithTimeout:5
+                               handler:^(NSError *error) {
+                                 if (error) {
+                                   XCTFail(@"Checkin Timeout Error: %@", error);
+                                 }
+                               }];
+}
+
+- (void)testCheckinServiceAddsFirebaseUserAgentToHTTPHeader {
+  NSString *expectedFirebaseUserAgent = [FIRApp firebaseUserAgent];
+
+  FIRInstanceIDURLRequestTestBlock successHandler = [self successfulCheckinCompletionHandler];
+
+  [FIRInstanceIDCheckinService
+      setCheckinTestBlock:^(NSURLRequest *request,
+                            FIRInstanceIDURLRequestTestResponseBlock response) {
+        NSString *requestFirebaseUserAgentValue =
+            request.allHTTPHeaderFields[kFIRInstanceIDFirebaseUserAgentKey];
+        XCTAssertEqualObjects(requestFirebaseUserAgentValue, expectedFirebaseUserAgent);
+        successHandler(request, response);
+      }];
+
+  XCTestExpectation *checkinCompletionExpectation =
+      [self expectationWithDescription:@"Checkin Completion"];
+
+  [self.checkinService
+      checkinWithExistingCheckin:nil
+                      completion:^(FIRInstanceIDCheckinPreferences *preferences, NSError *error) {
                         [checkinCompletionExpectation fulfill];
                       }];
 

--- a/Firebase/InstanceID/FIRInstanceIDCheckinService.h
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinService.h
@@ -28,6 +28,7 @@ FOUNDATION_EXPORT NSString *const kFIRInstanceIDLastCheckinTimeKey;
 FOUNDATION_EXPORT NSString *const kFIRInstanceIDVersionInfoStringKey;
 FOUNDATION_EXPORT NSString *const kFIRInstanceIDGServicesDictionaryKey;
 FOUNDATION_EXPORT NSString *const kFIRInstanceIDDeviceDataVersionKey;
+FOUNDATION_EXPORT NSString *const kFIRInstanceIDFirebaseUserAgentKey;
 
 @class FIRInstanceIDCheckinPreferences;
 

--- a/Firebase/InstanceID/FIRInstanceIDCheckinService.m
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinService.m
@@ -16,6 +16,7 @@
 
 #import "FIRInstanceIDCheckinService.h"
 
+#import <FirebaseCore/FIRAppInternal.h>
 #import "FIRInstanceIDCheckinPreferences+Internal.h"
 #import "FIRInstanceIDCheckinPreferences_Private.h"
 #import "FIRInstanceIDDefines.h"
@@ -34,6 +35,7 @@ NSString *const kFIRInstanceIDLastCheckinTimeKey = @"GMSInstanceIDLastCheckinTim
 NSString *const kFIRInstanceIDVersionInfoStringKey = @"GMSInstanceIDVersionInfo";
 NSString *const kFIRInstanceIDGServicesDictionaryKey = @"GMSInstanceIDGServicesData";
 NSString *const kFIRInstanceIDDeviceDataVersionKey = @"GMSInstanceIDDeviceDataVersion";
+NSString *const kFIRInstanceIDFirebaseUserAgentKey = @"X-firebase-client";
 
 static NSUInteger const kCheckinType = 2;  // DeviceType IOS in l/w/a/_checkin.proto
 static NSUInteger const kCheckinVersion = 2;
@@ -74,7 +76,11 @@ static FIRInstanceIDURLRequestTestBlock testBlock;
 
   NSURL *url = [NSURL URLWithString:kDeviceCheckinURL];
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+
   [request setValue:@"application/json" forHTTPHeaderField:@"content-type"];
+  [request setValue:[FIRApp firebaseUserAgent]
+      forHTTPHeaderField:kFIRInstanceIDFirebaseUserAgentKey];
+
   NSDictionary *checkinParameters = [self checkinParametersWithExistingCheckin:existingCheckin];
   NSData *checkinData = [NSJSONSerialization dataWithJSONObject:checkinParameters
                                                         options:0


### PR DESCRIPTION
- Send Firebase info in the request header (directly from FIRInstanceIDCheckinService)

This is a replacement for #2500 to address the [comment](https://github.com/firebase/firebase-ios-sdk/pull/2500#discussion_r263894556)