### PR TITLE
Use free() for memory allocated with malloc.

### DIFF
--- a/Firestore/core/src/firebase/firestore/nanopb/nanopb_string.cc
+++ b/Firestore/core/src/firebase/firestore/nanopb/nanopb_string.cc
@@ -23,6 +23,10 @@ namespace firebase {
 namespace firestore {
 namespace nanopb {
 
+String::~String() {
+  std::free(bytes_);
+}
+
 /* static */ pb_bytes_array_t* String::MakeBytesArray(absl::string_view value) {
   auto size = static_cast<pb_size_t>(value.size());
 

--- a/Firestore/core/src/firebase/firestore/nanopb/nanopb_string.h
+++ b/Firestore/core/src/firebase/firestore/nanopb/nanopb_string.h
@@ -19,6 +19,7 @@
 
 #include <pb.h>
 
+#include <cstdlib>
 #include <string>
 #include <utility>
 
@@ -73,7 +74,7 @@ class String : public util::Comparable<String> {
   }
 
   ~String() {
-    delete bytes_;
+    std::free(bytes_);
   }
 
   String& operator=(String other) {

--- a/Firestore/core/src/firebase/firestore/nanopb/nanopb_string.h
+++ b/Firestore/core/src/firebase/firestore/nanopb/nanopb_string.h
@@ -19,7 +19,6 @@
 
 #include <pb.h>
 
-#include <cstdlib>
 #include <string>
 #include <utility>
 
@@ -73,9 +72,7 @@ class String : public util::Comparable<String> {
     swap(*this, other);
   }
 
-  ~String() {
-    std::free(bytes_);
-  }
+  ~String();
 
   String& operator=(String other) {
     swap(*this, other);


### PR DESCRIPTION
Rather than delete, which technically results in undefined behaviour.