### PR TITLE
Delete test with new

### DIFF
--- a/GoogleUtilities/Example/Tests/Swizzler/GULRuntimeClassSnapshotTests.m
+++ b/GoogleUtilities/Example/Tests/Swizzler/GULRuntimeClassSnapshotTests.m
@@ -47,11 +47,6 @@ static NSString *dynamicClassBacking;
 
 @implementation GULRuntimeClassSnapshotTests
 
-/** Tests the assurance that init throws. */
-- (void)testInitThrows {
-  XCTAssertThrows([GULRuntimeClassSnapshot new]);
-}
-
 /** Tests initialization. */
 - (void)testInitWithClass {
   Class NSObjectClass = [NSObject class];


### PR DESCRIPTION
Delete test with `new`.

This causes build issues in internal system.
Checking for init happens at build time, not runtime.