### PR TITLE
Only assign message validation regex once

### DIFF
--- a/GoogleUtilities/Logger/GULASLLogger.m
+++ b/GoogleUtilities/Logger/GULASLLogger.m
@@ -119,9 +119,9 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)logWithLevel:(GULLoggerLevel)level
-         withService:(GULLoggerService)service
+         withService:(GULLoggerService)__unused service
             isForced:(BOOL)forced
-            withCode:(NSString *)messageCode
+            withCode:(NSString *)__unused messageCode
          withMessage:(NSString *)message {
   // Skip logging this if the level isn't to be logged unless it's forced.
   if (![self isLoggableLevel:level] && !forced) {

--- a/GoogleUtilities/Logger/GULOSLogger.m
+++ b/GoogleUtilities/Logger/GULOSLogger.m
@@ -152,7 +152,7 @@ static void GULLOSLogWithType(os_log_t log, os_log_type_t type, char *format, ..
 - (void)logWithLevel:(GULLoggerLevel)level
          withService:(GULLoggerService)service
             isForced:(BOOL)forced
-            withCode:(NSString *)messageCode
+            withCode:(NSString *)__unused messageCode
          withMessage:(NSString *)message {
   // Skip logging this if the level isn't to be logged unless it's forced.
   if (![self isLoggableLevel:level] && !forced) {


### PR DESCRIPTION
This fixes an internal error (b/128359839) that causes tests to crash.