### PR TITLE
Fix build (unused parameter) under mac/cmake/clang

### DIFF
--- a/Firestore/core/src/firebase/firestore/model/transform_operations.h
+++ b/Firestore/core/src/firebase/firestore/model/transform_operations.h
@@ -282,7 +282,7 @@ class NumericIncrementTransform : public TransformOperation {
   }
 
   FSTFieldValue* ApplyToRemoteDocument(
-      FSTFieldValue* previousValue,
+      FSTFieldValue*,
       FSTFieldValue* transformResult) const override {
     return transformResult;
   }

--- a/Firestore/core/src/firebase/firestore/model/transform_operations.h
+++ b/Firestore/core/src/firebase/firestore/model/transform_operations.h
@@ -282,8 +282,7 @@ class NumericIncrementTransform : public TransformOperation {
   }
 
   FSTFieldValue* ApplyToRemoteDocument(
-      FSTFieldValue*,
-      FSTFieldValue* transformResult) const override {
+      FSTFieldValue*, FSTFieldValue* transformResult) const override {
     return transformResult;
   }
 


### PR DESCRIPTION
Only seems to impact the mac cmake build (not the xcode build). Linux
build is unaffected since there's an ifdef objc at the top of the file.