### PR TITLE
Avoid using  NSRegularExpression in FIRApp (b/65122393)

### DIFF
--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -389,11 +389,11 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   // Some direct tests of the validateAppIDFormat:withVersion: method.
   // Sanity checks first.
   NSString *const kGoodAppIDV1 = @"1:1337:ios:deadbeef";
-  NSString *const kGoodVersionV1 = @"1:";
+  NSString *const kGoodVersionV1 = @"1";
   XCTAssertTrue([FIRApp validateAppIDFormat:kGoodAppIDV1 withVersion:kGoodVersionV1]);
 
   NSString *const kGoodAppIDV2 = @"2:1337:ios:5e18052ab54fbfec";
-  NSString *const kGoodVersionV2 = @"2:";
+  NSString *const kGoodVersionV2 = @"2";
   XCTAssertTrue([FIRApp validateAppIDFormat:kGoodAppIDV2 withVersion:kGoodVersionV2]);
 
   // Version mismatch.
@@ -440,17 +440,12 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   // Some direct tests of the validateAppIDFingerprint:withVersion: method.
   // Sanity checks first.
   NSString *const kGoodAppIDV1 = @"1:1337:ios:deadbeef";
-  NSString *const kGoodVersionV1 = @"1:";
+  NSString *const kGoodVersionV1 = @"1";
   XCTAssertTrue([FIRApp validateAppIDFingerprint:kGoodAppIDV1 withVersion:kGoodVersionV1]);
 
   NSString *const kGoodAppIDV2 = @"2:1337:ios:5e18052ab54fbfec";
-  NSString *const kGoodVersionV2 = @"2:";
+  NSString *const kGoodVersionV2 = @"2";
   XCTAssertTrue([FIRApp validateAppIDFormat:kGoodAppIDV2 withVersion:kGoodVersionV2]);
-
-  // Version mismatch.
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:kGoodAppIDV2 withVersion:kGoodVersionV1]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:kGoodAppIDV1 withVersion:kGoodVersionV2]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:kGoodAppIDV1 withVersion:@"999:"]);
 
   // Nil or empty strings.
   XCTAssertFalse([FIRApp validateAppIDFingerprint:kGoodAppIDV1 withVersion:nil]);
@@ -464,34 +459,18 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   XCTAssertFalse([FIRApp validateAppIDFingerprint:kGoodVersionV1 withVersion:kGoodVersionV1]);
   // The version is the entire app ID.
   XCTAssertFalse([FIRApp validateAppIDFingerprint:kGoodAppIDV1 withVersion:kGoodAppIDV1]);
-
-  // Versions digits that may make a partial match.
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"01:1337:ios:deadbeef"
-                                      withVersion:kGoodVersionV1]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"10:1337:ios:deadbeef"
-                                      withVersion:kGoodVersionV1]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"11:1337:ios:deadbeef"
-                                      withVersion:kGoodVersionV1]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"21:1337:ios:5e18052ab54fbfec"
-                                      withVersion:kGoodVersionV2]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"22:1337:ios:5e18052ab54fbfec"
-                                      withVersion:kGoodVersionV2]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"02:1337:ios:5e18052ab54fbfec"
-                                      withVersion:kGoodVersionV2]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"20:1337:ios:5e18052ab54fbfec"
-                                      withVersion:kGoodVersionV2]);
-  // Extra fields.
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"ab:1:1337:ios:deadbeef"
-                                      withVersion:kGoodVersionV1]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"1:ab:1337:ios:deadbeef"
-                                      withVersion:kGoodVersionV1]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"1:1337:ab:ios:deadbeef"
-                                      withVersion:kGoodVersionV1]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"1:1337:ios:ab:deadbeef"
-                                      withVersion:kGoodVersionV1]);
-  XCTAssertFalse([FIRApp validateAppIDFingerprint:@"1:1337:ios:deadbeef:ab"
-                                      withVersion:kGoodVersionV1]);
 }
+
+// Uncomment if you need to mesure performance of [FIRApp validateAppID:].
+// It is commented because measures are hevely dependent on a build agent configuration,
+// so it cannot produce reliable resault on CI
+//- (void)testAppIDFingerprintPerfomance {
+//  [self measureBlock:^{
+//    for (NSInteger i = 0; i < 100; ++i) {
+//      [self testAppIDPrefix];
+//    }
+//  }];
+//}
 
 #pragma mark - Automatic Data Collection Tests
 

--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -461,8 +461,8 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   XCTAssertFalse([FIRApp validateAppIDFingerprint:kGoodAppIDV1 withVersion:kGoodAppIDV1]);
 }
 
-// Uncomment if you need to mesure performance of [FIRApp validateAppID:].
-// It is commented because measures are hevely dependent on a build agent configuration,
+// Uncomment if you need to measure performance of [FIRApp validateAppID:].
+// It is commented because measures are heavily dependent on a build agent configuration,
 // so it cannot produce reliable resault on CI
 //- (void)testAppIDFingerprintPerfomance {
 //  [self measureBlock:^{

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -636,14 +636,14 @@ static NSMutableDictionary *sLibraryVersions;
     return NO;
   }
 
-  // Validate vesrion part (see part between '*' symbols below)
+  // Validate version part (see part between '*' symbols below)
   // '<version #>*:*<project number>:ios:<fingerprint of bundle id>'
   if (![stringScanner scanString:@":" intoString:NULL]) {
     // appIDVersion must be separated by ":"
     return NO;
   }
 
-  // Validate vesrion part (see part between '*' symbols below)
+  // Validate version part (see part between '*' symbols below)
   // '<version #>:*<project number>*:ios:<fingerprint of bundle id>'.
   NSInteger projectNumber = NSNotFound;
   if (![stringScanner scanInteger:&projectNumber]) {
@@ -651,33 +651,33 @@ static NSMutableDictionary *sLibraryVersions;
     return NO;
   }
 
-  // Validate vesrion part (see part between '*' symbols below)
+  // Validate version part (see part between '*' symbols below)
   // '<version #>:<project number>*:*ios:<fingerprint of bundle id>'.
   if (![stringScanner scanString:@":" intoString:NULL]) {
     // The project number must be separated by ":"
     return NO;
   }
 
-  // Validate vesrion part (see part between '*' symbols below)
+  // Validate version part (see part between '*' symbols below)
   // '<version #>:<project number>:*ios*:<fingerprint of bundle id>'.
-  NSString *palform;
-  if (![stringScanner scanUpToString:@":" intoString:&palform]) {
+  NSString *platform;
+  if (![stringScanner scanUpToString:@":" intoString:&platform]) {
     return NO;
   }
 
-  if (![palform isEqualToString:@"ios"]) {
+  if (![platform isEqualToString:@"ios"]) {
     // The platform must be @"ios"
     return NO;
   }
 
-  // Validate vesrion part (see part between '*' symbols below)
+  // Validate version part (see part between '*' symbols below)
   // '<version #>:<project number>:ios*:*<fingerprint of bundle id>'.
   if (![stringScanner scanString:@":" intoString:NULL]) {
     // The platform must be separated by ":"
     return NO;
   }
 
-  // Validate vesrion part (see part between '*' symbols below)
+  // Validate version part (see part between '*' symbols below)
   // '<version #>:<project number>:ios:*<fingerprint of bundle id>*'.
   unsigned long long fingerprint = NSNotFound;
   if (![stringScanner scanHexLongLong:&fingerprint]) {

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -571,33 +571,32 @@ static NSMutableDictionary *sLibraryVersions;
     return NO;
   }
 
-  // All app IDs must start with at least "<version number>:".
-  NSString *const versionPattern = @"^\\d+:";
-  NSRegularExpression *versionRegex =
-      [NSRegularExpression regularExpressionWithPattern:versionPattern options:0 error:NULL];
-  if (!versionRegex) {
+  NSScanner *stringScanner = [NSScanner scannerWithString:appID];
+  stringScanner.charactersToBeSkipped = nil;
+
+  NSString *appIDVersion;
+  if (![stringScanner scanCharactersFromSet:[NSCharacterSet decimalDigitCharacterSet] intoString:&appIDVersion]) {
     return NO;
   }
 
-  NSRange appIDRange = NSMakeRange(0, appID.length);
-  NSArray *versionMatches = [versionRegex matchesInString:appID options:0 range:appIDRange];
-  if (versionMatches.count != 1) {
+  if (![stringScanner scanString:@":" intoString:NULL]) {
+    // appIDVersion must be separated by ":"
     return NO;
   }
 
-  NSRange versionRange = [(NSTextCheckingResult *)versionMatches.firstObject range];
-  NSString *appIDVersion = [appID substringWithRange:versionRange];
-  NSArray *knownVersions = @[ @"1:" ];
+  NSArray *knownVersions = @[ @"1" ];
   if (![knownVersions containsObject:appIDVersion]) {
     // Permit unknown yet properly formatted app ID versions.
+    FIRLogInfo(kFIRLoggerCore, @"I-COR000010",
+               @"Unknown GOOGLE_APP_ID version: %@", appIDVersion);
     return YES;
   }
 
-  if (![FIRApp validateAppIDFormat:appID withVersion:appIDVersion]) {
+  if (![self validateAppIDFormat:appID withVersion:appIDVersion]) {
     return NO;
   }
 
-  if (![FIRApp validateAppIDFingerprint:appID withVersion:appIDVersion]) {
+  if (![self validateAppIDFingerprint:appID withVersion:appIDVersion]) {
     return NO;
   }
 
@@ -627,33 +626,76 @@ static NSMutableDictionary *sLibraryVersions;
     return NO;
   }
 
-  if (![version hasSuffix:@":"]) {
+  NSScanner *stringScanner = [NSScanner scannerWithString:appID];
+  stringScanner.charactersToBeSkipped = nil;
+
+  // Skip version part
+  // '*<version #>*:<project number>:ios:<fingerprint of bundle id>'
+  if (![stringScanner scanString:version intoString:NULL]) {
+    // The version part is missing or mismatched
     return NO;
   }
 
-  if (![appID hasPrefix:version]) {
+  // Validate vesrion part (see part between '*' symbols below)
+  // '<version #>*:*<project number>:ios:<fingerprint of bundle id>'
+  if (![stringScanner scanString:@":" intoString:NULL]) {
+    // appIDVersion must be separated by ":"
     return NO;
   }
 
-  NSString *const pattern = @"^\\d+:ios:[a-f0-9]+$";
-  NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern
-                                                                         options:0
-                                                                           error:NULL];
-  if (!regex) {
+  // Validate vesrion part (see part between '*' symbols below)
+  // '<version #>:*<project number>*:ios:<fingerprint of bundle id>'.
+  NSInteger projectNumber = NSNotFound;
+  if (![stringScanner scanInteger:&projectNumber]) {
+    // NO project number found.
     return NO;
   }
 
-  NSRange localRange = NSMakeRange(version.length, appID.length - version.length);
-  NSUInteger numberOfMatches = [regex numberOfMatchesInString:appID options:0 range:localRange];
-  if (numberOfMatches != 1) {
+  // Validate vesrion part (see part between '*' symbols below)
+  // '<version #>:<project number>*:*ios:<fingerprint of bundle id>'.
+  if (![stringScanner scanString:@":" intoString:NULL]) {
+    // The project number must be separated by ":"
     return NO;
   }
+
+  // Validate vesrion part (see part between '*' symbols below)
+  // '<version #>:<project number>:*ios*:<fingerprint of bundle id>'.
+  NSString *palform;
+  if (![stringScanner scanUpToString:@":" intoString:&palform]) {
+    return NO;
+  }
+
+  if (![palform isEqualToString:@"ios"]) {
+    // The platform must be @"ios"
+    return NO;
+  }
+
+  // Validate vesrion part (see part between '*' symbols below)
+  // '<version #>:<project number>:ios*:*<fingerprint of bundle id>'.
+  if (![stringScanner scanString:@":" intoString:NULL]) {
+    // The platform must be separated by ":"
+    return NO;
+  }
+
+  // Validate vesrion part (see part between '*' symbols below)
+  // '<version #>:<project number>:ios:*<fingerprint of bundle id>*'.
+  unsigned long long fingerprint = NSNotFound;
+  if (![stringScanner scanHexLongLong:&fingerprint]) {
+    // Fingerprint part is missing
+    return NO;
+  }
+
+  if (!stringScanner.isAtEnd) {
+    // There are not allowed characters in the fingerprint part
+    return NO;
+  }
+
   return YES;
 }
 
 /**
  * Validates that the fingerprint of the app ID string is what is expected based on the supplied
- * version. The version must end in ":".
+ * version.
  *
  * Note that the v1 hash algorithm is not permitted on the client and cannot be fully validated.
  *
@@ -663,18 +705,6 @@ static NSMutableDictionary *sLibraryVersions;
  *         otherwise.
  */
 + (BOOL)validateAppIDFingerprint:(NSString *)appID withVersion:(NSString *)version {
-  if (!appID.length || !version.length) {
-    return NO;
-  }
-
-  if (![version hasSuffix:@":"]) {
-    return NO;
-  }
-
-  if (![appID hasPrefix:version]) {
-    return NO;
-  }
-
   // Extract the supplied fingerprint from the supplied app ID.
   // This assumes the app ID format is the same for all known versions below. If the app ID format
   // changes in future versions, the tokenizing of the app ID format will need to take into account
@@ -695,7 +725,7 @@ static NSMutableDictionary *sLibraryVersions;
     return NO;
   }
 
-  if ([version isEqual:@"1:"]) {
+  if ([version isEqual:@"1"]) {
     // The v1 hash algorithm is not permitted on the client so the actual hash cannot be validated.
     return YES;
   }

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -575,7 +575,8 @@ static NSMutableDictionary *sLibraryVersions;
   stringScanner.charactersToBeSkipped = nil;
 
   NSString *appIDVersion;
-  if (![stringScanner scanCharactersFromSet:[NSCharacterSet decimalDigitCharacterSet] intoString:&appIDVersion]) {
+  if (![stringScanner scanCharactersFromSet:[NSCharacterSet decimalDigitCharacterSet]
+                                 intoString:&appIDVersion]) {
     return NO;
   }
 
@@ -587,8 +588,7 @@ static NSMutableDictionary *sLibraryVersions;
   NSArray *knownVersions = @[ @"1" ];
   if (![knownVersions containsObject:appIDVersion]) {
     // Permit unknown yet properly formatted app ID versions.
-    FIRLogInfo(kFIRLoggerCore, @"I-COR000010",
-               @"Unknown GOOGLE_APP_ID version: %@", appIDVersion);
+    FIRLogInfo(kFIRLoggerCore, @"I-COR000010", @"Unknown GOOGLE_APP_ID version: %@", appIDVersion);
     return YES;
   }
 


### PR DESCRIPTION
- Use NSScanner instead of NSRegularExpression to validate App ID