### PR TITLE
Don't create credential when VerifyAssertionResponse is empty

### DIFF
--- a/Firebase/Auth/Source/RPCs/FIRAuthBackend.m
+++ b/Firebase/Auth/Source/RPCs/FIRAuthBackend.m
@@ -1058,11 +1058,13 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
     NSString *email;
     if ([response isKindOfClass:[FIRVerifyAssertionResponse class]]) {
       FIRVerifyAssertionResponse *verifyAssertion = (FIRVerifyAssertionResponse *)response;
-      credential =
-          [[FIROAuthCredential alloc] initWithProviderID:verifyAssertion.providerID
-                                                 IDToken:verifyAssertion.oauthIDToken
-                                             accessToken:verifyAssertion.oauthAccessToken
-                                            pendingToken:verifyAssertion.pendingToken];
+      if (verifyAssertion.oauthIDToken.length || verifyAssertion.oauthAccessToken.length) {
+        credential =
+            [[FIROAuthCredential alloc] initWithProviderID:verifyAssertion.providerID
+                                                   IDToken:verifyAssertion.oauthIDToken
+                                               accessToken:verifyAssertion.oauthAccessToken
+                                              pendingToken:verifyAssertion.pendingToken];
+      }
       email = verifyAssertion.email;
     }
     return [FIRAuthErrorUtils credentialAlreadyInUseErrorWithMessage:serverDetailErrorMessage


### PR DESCRIPTION
Fix #2522