### PR TITLE
Add a run-all-checks script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,7 @@ jobs:
         - brew install clang-format
         - brew install swiftformat
       script:
-        - ./scripts/check_whitespace.sh
-        - ./scripts/check_copyright.sh
-        - ./scripts/check_no_module_imports.sh
-        - ./scripts/check_test_inclusion.py
-        - ./scripts/style.sh test-only $TRAVIS_COMMIT_RANGE
-        # Google C++ style compliance
-        - ./scripts/lint.sh $TRAVIS_COMMIT_RANGE
+        - ./scripts/check.sh --test-only $TRAVIS_COMMIT_RANGE
 
     # The order of builds matters (even though they are run in parallel):
     # Travis will schedule them in the same order they are listed here.

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -181,10 +181,10 @@ if ! git diff --quiet -- Firestore/Example/Firestore.xcodeproj; then
 fi
 
 # Check lint errors.
-#
-# Keep in sync with the checks stage in .travis.yml
-scripts/check_whitespace.sh
-scripts/check_copyright.sh
-scripts/check_no_module_imports.sh
-scripts/check_test_inclusion.py
-scripts/lint.sh "${START_SHA}"
+"${top_dir}/scripts/check_whitespace.sh"
+"${top_dir}/scripts/check_copyright.sh"
+"${top_dir}/scripts/check_no_module_imports.sh"
+"${top_dir}/scripts/check_test_inclusion.py"
+
+# Google C++ style
+"${top_dir}/scripts/lint.sh" "${START_SHA}"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Copyright 2019 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Checks that the current state of the tree is sane and optionally auto-fixes
+# errors automatically. Meant for interactive use.
+
+set -euo pipefail
+unset CDPATH
+
+# Change to the top-directory of the working tree
+top_dir=$(git rev-parse --show-toplevel)
+cd "$top_dir"
+
+commit=false
+start="HEAD^"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --)
+      # Do nothing: explicitly allow this, but ignore it
+      ;;
+
+    --commit)
+      commit=true
+      ;;
+
+    *)
+      if git rev-parse "$1" >& /dev/null; then
+        start="$1"
+        break
+      fi
+      ;;
+  esac
+  shift
+done
+
+# Record actual start
+start_sha=$(git rev-parse "$start")
+
+# Restyle and commit any changes
+scripts/style.sh "$start_sha" || :
+if ! git diff --quiet; then
+  if [[ $commit == true ]]; then
+    echo "Style generated changes"
+    git commit -a --fixup=HEAD
+  fi
+fi
+
+scripts/sync_project.rb
+if ! git diff --quiet; then
+  if [[ $commit == true ]]; then
+    echo "Sync Xcode project"
+    git commit -a --fixup=HEAD
+  fi
+fi
+
+# Check lint errors
+(
+  scripts/lint.sh "$start_sha"
+  scripts/check_copyright.sh
+  scripts/check_no_module_imports.sh
+  scripts/check_test_inclusion.py
+  scripts/check_whitespace.sh
+) 2>&1 | sed "s,^Firestore,$top_dir/Firestore,"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -25,7 +25,7 @@ top_dir=$(git rev-parse --show-toplevel)
 cd "$top_dir"
 
 commit=false
-start="HEAD^"
+start="master"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -149,8 +149,16 @@ if ! git diff-index --quiet HEAD --; then
   fi
 fi
 
-# Record actual start
-START_SHA=$(git rev-parse "${START_REVISION}")
+# Record actual start, but only if the revision is specified as a single
+# commit. Ranges specified with .. or ... are left alone.
+if [[ "${START_REVISION}" == *..* ]]; then
+  START_SHA="${START_REVISION}"
+else
+  START_SHA=$(git rev-parse "${START_REVISION}")
+fi
+
+# If committing --fixup, avoid messages with fixup! fixup! that might come from
+# multiple fixup commits.
 HEAD_SHA=$(git rev-parse HEAD)
 
 function maybe_commit() {

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -129,11 +129,17 @@ if ! git diff --quiet; then
   fi
 fi
 
-scripts/sync_project.rb
-if ! git diff --quiet; then
-  if [[ $commit == true ]]; then
-    echo "Sync Xcode project"
-    git commit -a --fixup=HEAD
+# If there are changes to the Firestore project, ensure they're ordered
+# correctly to minimize conflicts.
+if ! git diff --quiet --name-only --diff-filter=ACMR -- \
+    Firestore/Example/Firestore.xcodeproj; then
+
+  scripts/sync_project.rb
+  if ! git diff --quiet; then
+    if [[ $commit == true ]]; then
+      echo "Sync Xcode project"
+      git commit -a --fixup=HEAD
+    fi
   fi
 fi
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -180,11 +180,11 @@ if ! git diff --quiet -- Firestore/Example/Firestore.xcodeproj; then
   fi
 fi
 
-# Check lint errors
-(
-  scripts/lint.sh "${START_SHA}"
-  scripts/check_copyright.sh
-  scripts/check_no_module_imports.sh
-  scripts/check_test_inclusion.py
-  scripts/check_whitespace.sh
-) 2>&1 | sed "s,^\\([^:]*:[0-9]*: \\),${top_dir}/\\1,"
+# Check lint errors.
+#
+# Keep in sync with the checks stage in .travis.yml
+scripts/check_whitespace.sh
+scripts/check_copyright.sh
+scripts/check_no_module_imports.sh
+scripts/check_test_inclusion.py
+scripts/lint.sh "${START_SHA}"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -144,4 +144,4 @@ fi
   scripts/check_no_module_imports.sh
   scripts/check_test_inclusion.py
   scripts/check_whitespace.sh
-) 2>&1 | sed "s,^Firestore,$top_dir/Firestore,"
+) 2>&1 | sed "s,^\\([A-Za-z]*/\\),$top_dir/\\1,"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -78,12 +78,6 @@ EOF
 set -euo pipefail
 unset CDPATH
 
-for arg in "$@"; do
-  echo "check.sh arg: '${arg}'"
-done
-
-set -x
-
 # Change to the top-directory of the working tree
 top_dir=$(git rev-parse --show-toplevel)
 cd "${top_dir}"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -17,6 +17,35 @@
 # Checks that the current state of the tree is sane and optionally auto-fixes
 # errors automatically. Meant for interactive use.
 
+function usage() {
+  cat <<EOF
+USAGE: scripts/check.sh [--commit] [<revision>]
+
+Runs auto-formatting scripts, source-tree checks, and linters on any files that
+have changed since master.
+
+By default, any changes are left as uncommited changes in the working tree. You
+can review them with git diff. Pass --commit to automatically commit any changes.
+
+Pass an alternate revision to use as the basis for checking changes.
+
+EXAMPLES:
+
+  check.sh
+    Runs automated checks and formatters on all changed files since master.
+    Check for changes with git diff.
+
+  check.sh --commit
+    Runs automated checks and formatters on all changed files since master and
+    commits the results.
+
+  check.sh --commit HEAD
+    Runs automated checks and formatters on all changed files since the last
+    commit.
+
+EOF
+}
+
 set -euo pipefail
 unset CDPATH
 
@@ -31,6 +60,11 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --)
       # Do nothing: explicitly allow this, but ignore it
+      ;;
+
+    -h | --help)
+      usage
+      exit 1
       ;;
 
     --commit)

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -78,6 +78,12 @@ EOF
 set -euo pipefail
 unset CDPATH
 
+for arg in "$@"; do
+  echo "check.sh arg: '${arg}'"
+done
+
+set -x
+
 # Change to the top-directory of the working tree
 top_dir=$(git rev-parse --show-toplevel)
 cd "${top_dir}"


### PR DESCRIPTION
It's hard to run all checks locally despite the fact that they can typically run very quickly.

Add a script that does everything travis does interactively, and optionally fixes things that can be fixed automatically.