### PR TITLE
extract errorMessage directly from response when server returns 200

### DIFF
--- a/Firebase/Auth/CHANGELOG.md
+++ b/Firebase/Auth/CHANGELOG.md
@@ -1,7 +1,8 @@
 # v5.4.1
 - Deprecate Microsoft and Yahoo OAuth Provider ID (#2517)
 - Fix an issue where an exception was thrown when linking OAuth credentials. (#2521)
-- Fix an issue where a wrong error was thrown when upgrading anonymous user. (#2530)
+- Fix an issue where a wrong error was thrown when handling error with
+  FEDERATED_USER_ID_ALREADY_LINKED. (#2530, #2542)
 
 # v5.4.0
 - Add support of Generic IDP (#2405).

--- a/Firebase/Auth/Source/RPCs/FIRAuthBackend.m
+++ b/Firebase/Auth/Source/RPCs/FIRAuthBackend.m
@@ -128,6 +128,12 @@ static NSString *const kAppNotAuthorizedReasonValue = @"ipRefererBlocked";
  */
 static NSString *const kErrorMessageKey = @"message";
 
+/** @var kReturnIDPCredentialErrorMessageKey
+    @brief The key for "errorMessage" value in JSON responses from the server, In case
+        returnIDPCredential of a verifyAssertion request is set to @YES.
+ */
+static NSString *const kReturnIDPCredentialErrorMessageKey = @"errorMessage";
+
 /** @var kUserNotFoundErrorMessage
     @brief This is the error message returned when the user is not found, which means the user
         account has been deleted given the token was once valid.
@@ -925,18 +931,15 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
     if ([request isKindOfClass:[FIRVerifyAssertionRequest class]]) {
       FIRVerifyAssertionRequest *verifyAssertionRequest = (FIRVerifyAssertionRequest *)request;
       if (verifyAssertionRequest.returnIDPCredential) {
-        NSDictionary *errorDictionary = dictionary[kErrorKey];
-        if ([errorDictionary isKindOfClass:[NSDictionary class]]) {
-          id<NSObject> errorMessage = errorDictionary[kErrorMessageKey];
-          if ([errorMessage isKindOfClass:[NSString class]]) {
-            NSString *errorString = (NSString *)errorMessage;
-            NSError *clientError = [[self class] clientErrorWithServerErrorMessage:errorString
-                                                                   errorDictionary:errorDictionary
-                                                                          response:response];
-            if (clientError) {
-              callback(clientError);
-              return;
-            }
+        NSString *errorMessage = dictionary[kReturnIDPCredentialErrorMessageKey];
+        if ([errorMessage isKindOfClass:[NSString class]]) {
+          NSString *errorString = (NSString *)errorMessage;
+          NSError *clientError = [[self class] clientErrorWithServerErrorMessage:errorString
+                                                                 errorDictionary:@{}
+                                                                        response:response];
+          if (clientError) {
+            callback(clientError);
+            return;
           }
         }
       }


### PR DESCRIPTION

Fix #2522.

in case of returnIDPCredential=YES, instead of an error like the following:

```
[response data:] {
  "error": {
    "code": 400,
    "message": "FEDERATED_USER_ID_ALREADY_LINKED",
    "errors": [
      {
        "message": "FEDERATED_USER_ID_ALREADY_LINKED",
        "domain": "global",
        "reason": "invalid"
      }
    ]
  }
}
```
the error message is directly enclosed in the response without a structure:

```
 [response data:] {
  key: value
 ...
  "errorMessage": "FEDERATED_USER_ID_ALREADY_LINKED",
  "kind": "identitytoolkit#VerifyAssertionResponse"
}
```
