### PR TITLE
FIRInstanceIDCheckinService: make sure tasks are not submitted to an invalidated NSURLSession

### DIFF
--- a/Example/InstanceID/Tests/FIRInstanceIDCheckinServiceTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDCheckinServiceTest.m
@@ -138,16 +138,16 @@ static NSString *const kVersionInfo = @"1.0";
   [self.checkinService stopFetching];
 
   XCTestExpectation *checkinCompletionExpectation =
-  [self expectationWithDescription:@"Checkin Completion"];
+      [self expectationWithDescription:@"Checkin Completion"];
 
   [self.checkinService
-           checkinWithExistingCheckin:nil
-           completion:^(FIRInstanceIDCheckinPreferences *preferences, NSError *error) {
-             [checkinCompletionExpectation fulfill];
-             XCTAssertNil(preferences);
-             XCTAssertNotNil(error);
-             XCTAssertEqual(error.code, kFIRInstanceIDErrorCodeRegistrarFailedToCheckIn);
-           }];
+      checkinWithExistingCheckin:nil
+                      completion:^(FIRInstanceIDCheckinPreferences *preferences, NSError *error) {
+                        [checkinCompletionExpectation fulfill];
+                        XCTAssertNil(preferences);
+                        XCTAssertNotNil(error);
+                        XCTAssertEqual(error.code, kFIRInstanceIDErrorCodeRegistrarFailedToCheckIn);
+                      }];
 
   [self waitForExpectationsWithTimeout:5
                                handler:^(NSError *error) {

--- a/Example/InstanceID/Tests/FIRInstanceIDCheckinServiceTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDCheckinServiceTest.m
@@ -134,6 +134,29 @@ static NSString *const kVersionInfo = @"1.0";
                                }];
 }
 
+- (void)testCheckinServiceFailsWithErrorAfterStopFetching {
+  [self.checkinService stopFetching];
+
+  XCTestExpectation *checkinCompletionExpectation =
+  [self expectationWithDescription:@"Checkin Completion"];
+
+  [self.checkinService
+           checkinWithExistingCheckin:nil
+           completion:^(FIRInstanceIDCheckinPreferences *preferences, NSError *error) {
+             [checkinCompletionExpectation fulfill];
+             XCTAssertNil(preferences);
+             XCTAssertNotNil(error);
+             XCTAssertEqual(error.code, kFIRInstanceIDErrorCodeRegistrarFailedToCheckIn);
+           }];
+
+  [self waitForExpectationsWithTimeout:5
+                               handler:^(NSError *error) {
+                                 if (error) {
+                                   XCTFail(@"Checkin Timeout Error: %@", error);
+                                 }
+                               }];
+}
+
 #pragma mark - Stub
 
 - (FIRInstanceIDCheckinPreferences *)stubCheckinCacheWithValidData {

--- a/Firebase/InstanceID/FIRIMessageCode.h
+++ b/Firebase/InstanceID/FIRIMessageCode.h
@@ -65,6 +65,7 @@ typedef NS_ENUM(NSInteger, FIRInstanceIDMessageCode) {
   kFIRInstanceIDMessageCodeService004 = 7004,
   kFIRInstanceIDMessageCodeService005 = 7005,
   kFIRInstanceIDMessageCodeService006 = 7006,
+  kFIRInstanceIDMessageCodeService007 = 7007,
   // FIRInstanceIDCheckinStore.m
   // DO NOT USE 8002, 8004 - 8008
   kFIRInstanceIDMessageCodeCheckinStore000 = 8000,

--- a/Firebase/InstanceID/FIRIMessageCode.h
+++ b/Firebase/InstanceID/FIRIMessageCode.h
@@ -65,7 +65,7 @@ typedef NS_ENUM(NSInteger, FIRInstanceIDMessageCode) {
   kFIRInstanceIDMessageCodeService004 = 7004,
   kFIRInstanceIDMessageCodeService005 = 7005,
   kFIRInstanceIDMessageCodeService006 = 7006,
-  kFIRInstanceIDMessageCodeService007 = 7007,
+  kFIRIntsanceIDInvalidNetworkSession = 7007,
   // FIRInstanceIDCheckinStore.m
   // DO NOT USE 8002, 8004 - 8008
   kFIRInstanceIDMessageCodeCheckinStore000 = 8000,

--- a/Firebase/InstanceID/FIRInstanceIDCheckinService.m
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinService.m
@@ -74,6 +74,15 @@ static FIRInstanceIDURLRequestTestBlock testBlock;
                         completion:(FIRInstanceIDDeviceCheckinCompletion)completion {
   _FIRInstanceIDDevAssert(completion != nil, @"completion required");
 
+  if (self.session == nil) {
+    FIRInstanceIDLoggerError(kFIRInstanceIDMessageCodeService007,
+                             @"Inconsistent state: NSURLSession has been invalidated");
+    NSError *error =
+        [NSError errorWithFIRInstanceIDErrorCode:kFIRInstanceIDErrorCodeRegistrarFailedToCheckIn];
+    completion(nil, error);
+    return;
+  }
+
   NSURL *url = [NSURL URLWithString:kDeviceCheckinURL];
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
 
@@ -179,6 +188,8 @@ static FIRInstanceIDURLRequestTestBlock testBlock;
 
 - (void)stopFetching {
   [self.session invalidateAndCancel];
+  // The session cannot be reused after invalidation. Dispose it to prevent accident reusing.
+  self.session = nil;
 }
 
 #pragma mark - Private

--- a/Firebase/InstanceID/FIRInstanceIDCheckinService.m
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinService.m
@@ -75,7 +75,7 @@ static FIRInstanceIDURLRequestTestBlock testBlock;
   _FIRInstanceIDDevAssert(completion != nil, @"completion required");
 
   if (self.session == nil) {
-    FIRInstanceIDLoggerError(kFIRInstanceIDMessageCodeService007,
+    FIRInstanceIDLoggerError(kFIRIntsanceIDInvalidNetworkSession,
                              @"Inconsistent state: NSURLSession has been invalidated");
     NSError *error =
         [NSError errorWithFIRInstanceIDErrorCode:kFIRInstanceIDErrorCodeRegistrarFailedToCheckIn];


### PR DESCRIPTION
A quick fix for the issue #2534.
- make sure tasks are not submitted to an invalidated NSURLSession
- log an error in case when this may have happened

Looks like there is a race condition involving `FIRInstanceID`/`FIRInstanceIDTokenManager`/`FIRInstanceIDAuthService`/`FIRInstanceIDCheckinService`. I was not able to find a core reason why the issue may happen so far.

The PR just fixes the particular consequence of the race condition to mitigate the impact on users while we are looking for a better solution. 