### PR TITLE
Rename ApplicationSupportDirectory in IID tests

### DIFF
--- a/Example/InstanceID/Tests/FIRInstanceIDAuthKeyChainTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDAuthKeyChainTest.m
@@ -24,7 +24,6 @@
 static NSString *const kFIRInstanceIDTestKeychainId = @"com.google.iid-tests";
 
 static NSString *const kFakeCheckinPlistName = @"com.google.test.IIDStoreTestCheckin";
-static NSString *const kApplicationSupportSubDirectoryName = @"FirebaseInstanceIDCheckinTest";
 
 static NSString *const kAuthorizedEntity = @"test-audience";
 static NSString *const kScope = @"test-scope";

--- a/Example/InstanceID/Tests/FIRInstanceIDBackupExcludedPlistTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDBackupExcludedPlistTest.m
@@ -21,7 +21,7 @@
 #import "Firebase/InstanceID/FIRInstanceIDBackupExcludedPlist.h"
 #import "Firebase/InstanceID/FIRInstanceIDStore.h"
 
-static NSString *const kApplicationSupportSubDirectoryName = @"FirebaseInstanceIDBackupPlistTest";
+static NSString *const kSubDirectoryName = @"FirebaseInstanceIDBackupPlistTest";
 static NSString *const kTestPlistFileName = @"com.google.test.IIDBackupExcludedPlist";
 
 @interface FIRInstanceIDBackupExcludedPlist ()
@@ -38,15 +38,14 @@ static NSString *const kTestPlistFileName = @"com.google.test.IIDBackupExcludedP
 
 - (void)setUp {
   [super setUp];
-  [FIRInstanceIDStore createSubDirectory:kApplicationSupportSubDirectoryName];
-  self.plist = [[FIRInstanceIDBackupExcludedPlist alloc]
-      initWithFileName:kTestPlistFileName
-          subDirectory:kApplicationSupportSubDirectoryName];
+  [FIRInstanceIDStore createSubDirectory:kSubDirectoryName];
+  self.plist = [[FIRInstanceIDBackupExcludedPlist alloc] initWithFileName:kTestPlistFileName
+                                                             subDirectory:kSubDirectoryName];
 }
 
 - (void)tearDown {
   [self.plist deleteFile:nil];
-  [FIRInstanceIDStore removeSubDirectory:kApplicationSupportSubDirectoryName error:nil];
+  [FIRInstanceIDStore removeSubDirectory:kSubDirectoryName error:nil];
   [super tearDown];
 }
 
@@ -77,14 +76,14 @@ static NSString *const kTestPlistFileName = @"com.google.test.IIDBackupExcludedP
   XCTAssertTrue([self.plist doesFileExist]);
   XCTAssertEqualObjects(plistContents, [self.plist contentAsDictionary]);
 
-  XCTAssertTrue([self isPlistInApplicationSupportDirectory]);
+  XCTAssertTrue([self doesPlistFileExist]);
 }
 
 - (void)testMovePlistToApplicationSupportDirectorySuccess {
   NSDictionary *plistContents = @{@"hello" : @"world", @"id" : @123};
   [self.plist writeDictionary:plistContents error:nil];
-  [self.plist moveToApplicationSupportSubDirectory:kApplicationSupportSubDirectoryName];
-  XCTAssertTrue([self isPlistInApplicationSupportDirectory]);
+  [self.plist moveToApplicationSupportSubDirectory:kSubDirectoryName];
+  XCTAssertTrue([self doesPlistFileExist]);
   XCTAssertFalse([self isPlistInDocumentsDirectory]);
 
   NSDictionary *newPlistContents = @{@"world" : @"hello"};
@@ -97,19 +96,18 @@ static NSString *const kTestPlistFileName = @"com.google.test.IIDBackupExcludedP
   // which should only apply to iOS.
 #if TARGET_OS_IOS
   // Delete the subdirectory
-  [FIRInstanceIDStore removeSubDirectory:kApplicationSupportSubDirectoryName error:nil];
+  [FIRInstanceIDStore removeSubDirectory:kSubDirectoryName error:nil];
 
   // Create a new plistl This would try to move or write to the ApplicationSupport directory
   // but since the subdirectory is not there anymore it will fail and rather write to the
   // Documents folder.
-  self.plist = [[FIRInstanceIDBackupExcludedPlist alloc]
-      initWithFileName:kTestPlistFileName
-          subDirectory:kApplicationSupportSubDirectoryName];
+  self.plist = [[FIRInstanceIDBackupExcludedPlist alloc] initWithFileName:kTestPlistFileName
+                                                             subDirectory:kSubDirectoryName];
 
   NSDictionary *plistContents = @{@"hello" : @"world", @"id" : @123};
   [self.plist writeDictionary:plistContents error:nil];
 
-  XCTAssertFalse([self isPlistInApplicationSupportDirectory]);
+  XCTAssertFalse([self doesPlistFileExist]);
   XCTAssertTrue([self isPlistInDocumentsDirectory]);
 
   NSDictionary *newPlistContents = @{@"world" : @"hello"};
@@ -118,14 +116,14 @@ static NSString *const kTestPlistFileName = @"com.google.test.IIDBackupExcludedP
   XCTAssertEqualObjects(newPlistContents, [self.plist contentAsDictionary]);
 
   // The new file should still be written to the Documents folder.
-  XCTAssertFalse([self isPlistInApplicationSupportDirectory]);
+  XCTAssertFalse([self doesPlistFileExist]);
   XCTAssertTrue([self isPlistInDocumentsDirectory]);
 #endif
 }
 
 #pragma mark - Private Helpers
 
-- (BOOL)isPlistInApplicationSupportDirectory {
+- (BOOL)doesPlistFileExist {
 #if TARGET_OS_TV
   NSArray *directoryPaths =
       NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
@@ -133,11 +131,9 @@ static NSString *const kTestPlistFileName = @"com.google.test.IIDBackupExcludedP
   NSArray *directoryPaths =
       NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
 #endif
-  NSString *applicationSupportDirPath = directoryPaths.lastObject;
-  NSArray *components = @[
-    applicationSupportDirPath, kApplicationSupportSubDirectoryName,
-    [NSString stringWithFormat:@"%@.plist", kTestPlistFileName]
-  ];
+  NSString *dirPath = directoryPaths.lastObject;
+  NSArray *components =
+      @[ dirPath, kSubDirectoryName, [NSString stringWithFormat:@"%@.plist", kTestPlistFileName] ];
   NSString *plistPath = [NSString pathWithComponents:components];
   return [[NSFileManager defaultManager] fileExistsAtPath:plistPath];
 }
@@ -145,9 +141,9 @@ static NSString *const kTestPlistFileName = @"com.google.test.IIDBackupExcludedP
 - (BOOL)isPlistInDocumentsDirectory {
   NSArray *directoryPaths =
       NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-  NSString *applicationSupportDirPath = directoryPaths.lastObject;
+  NSString *documentsSupportDirPath = directoryPaths.lastObject;
   NSArray *components =
-      @[ applicationSupportDirPath, [NSString stringWithFormat:@"%@.plist", kTestPlistFileName] ];
+      @[ documentsSupportDirPath, [NSString stringWithFormat:@"%@.plist", kTestPlistFileName] ];
   NSString *plistPath = [NSString pathWithComponents:components];
   return [[NSFileManager defaultManager] fileExistsAtPath:plistPath];
 }

--- a/Example/InstanceID/Tests/FIRInstanceIDCheckinStoreTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDCheckinStoreTest.m
@@ -37,7 +37,7 @@ static const NSTimeInterval kExpectationTimeout = 12;
 
 // Testing constants
 static NSString *const kFakeCheckinPlistName = @"com.google.test.IIDStoreTestCheckin";
-static NSString *const kApplicationSupportSubDirectoryName = @"FirebaseInstanceIDCheckinTest";
+static NSString *const kSubDirectoryName = @"FirebaseInstanceIDCheckinTest";
 
 static NSString *const kAuthorizedEntity = @"test-audience";
 static NSString *const kAuthID = @"test-auth-id";
@@ -56,7 +56,7 @@ static int64_t const kLastCheckinTimestamp = 123456;
 
 - (void)setUp {
   [super setUp];
-  [FIRInstanceIDStore createSubDirectory:kApplicationSupportSubDirectoryName];
+  [FIRInstanceIDStore createSubDirectory:kSubDirectoryName];
 }
 
 - (void)tearDown {
@@ -65,7 +65,7 @@ static int64_t const kLastCheckinTimestamp = 123456;
     NSError *error;
     [[NSFileManager defaultManager] removeItemAtPath:path error:&error];
   }
-  [FIRInstanceIDStore removeSubDirectory:kApplicationSupportSubDirectoryName error:nil];
+  [FIRInstanceIDStore removeSubDirectory:kSubDirectoryName error:nil];
   [super tearDown];
 }
 
@@ -75,9 +75,9 @@ static int64_t const kLastCheckinTimestamp = 123456;
 - (void)testInvalidCheckinPreferencesOnKeychainFail {
   XCTestExpectation *checkinInvalidExpectation = [self
       expectationWithDescription:@"Checkin preference should be invalid after keychain failure"];
-  FIRInstanceIDBackupExcludedPlist *checkinPlist = [[FIRInstanceIDBackupExcludedPlist alloc]
-      initWithFileName:kFakeCheckinPlistName
-          subDirectory:kApplicationSupportSubDirectoryName];
+  FIRInstanceIDBackupExcludedPlist *checkinPlist =
+      [[FIRInstanceIDBackupExcludedPlist alloc] initWithFileName:kFakeCheckinPlistName
+                                                    subDirectory:kSubDirectoryName];
 
   FIRInstanceIDFakeKeychain *fakeKeychain = [[FIRInstanceIDFakeKeychain alloc] init];
 
@@ -108,9 +108,9 @@ static int64_t const kLastCheckinTimestamp = 123456;
 - (void)testCheckinSaveFailsOnKeychainWriteFailure {
   XCTestExpectation *checkinSaveFailsExpectation =
       [self expectationWithDescription:@"Checkin save should fail after keychain write failure"];
-  FIRInstanceIDBackupExcludedPlist *checkinPlist = [[FIRInstanceIDBackupExcludedPlist alloc]
-      initWithFileName:kFakeCheckinPlistName
-          subDirectory:kApplicationSupportSubDirectoryName];
+  FIRInstanceIDBackupExcludedPlist *checkinPlist =
+      [[FIRInstanceIDBackupExcludedPlist alloc] initWithFileName:kFakeCheckinPlistName
+                                                    subDirectory:kSubDirectoryName];
 
   FIRInstanceIDFakeKeychain *fakeKeychain = [[FIRInstanceIDFakeKeychain alloc] init];
   fakeKeychain.cannotWriteToKeychain = YES;
@@ -139,9 +139,9 @@ static int64_t const kLastCheckinTimestamp = 123456;
   XCTestExpectation *checkinMigrationExpectation =
       [self expectationWithDescription:@"checkin migration should move to the new location"];
   // Create checkin store class.
-  FIRInstanceIDBackupExcludedPlist *checkinPlist = [[FIRInstanceIDBackupExcludedPlist alloc]
-      initWithFileName:kFakeCheckinPlistName
-          subDirectory:kApplicationSupportSubDirectoryName];
+  FIRInstanceIDBackupExcludedPlist *checkinPlist =
+      [[FIRInstanceIDBackupExcludedPlist alloc] initWithFileName:kFakeCheckinPlistName
+                                                    subDirectory:kSubDirectoryName];
 
   FIRInstanceIDFakeKeychain *fakeKeychain = [[FIRInstanceIDFakeKeychain alloc] init];
   FIRInstanceIDFakeKeychain *weakKeychain = fakeKeychain;

--- a/Example/InstanceID/Tests/FIRInstanceIDStoreTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDStoreTest.m
@@ -28,7 +28,7 @@
 #import "Firebase/InstanceID/FIRInstanceIDTokenStore.h"
 #import "Firebase/InstanceID/FIRInstanceIDUtilities.h"
 
-static NSString *const kApplicationSupportSubDirectoryName = @"FirebaseInstanceIDStoreTest";
+static NSString *const kSubDirectoryName = @"FirebaseInstanceIDStoreTest";
 
 static NSString *const kAuthorizedEntity = @"test-audience";
 static NSString *const kScope = @"test-scope";
@@ -74,12 +74,11 @@ static NSString *const kFIRInstanceIDAPNSTokenKey = @"APNSTuple";
 
 - (void)setUp {
   [super setUp];
-  [FIRInstanceIDStore createSubDirectory:kApplicationSupportSubDirectoryName];
+  [FIRInstanceIDStore createSubDirectory:kSubDirectoryName];
 
   NSString *checkinPlistName = @"com.google.test.IIDStoreTestCheckin";
-  self.checkinPlist = [[FIRInstanceIDBackupExcludedPlist alloc]
-      initWithFileName:checkinPlistName
-          subDirectory:kApplicationSupportSubDirectoryName];
+  self.checkinPlist = [[FIRInstanceIDBackupExcludedPlist alloc] initWithFileName:checkinPlistName
+                                                                    subDirectory:kSubDirectoryName];
 
   // checkin store
   FIRInstanceIDFakeKeychain *fakeKeychain = [[FIRInstanceIDFakeKeychain alloc] init];
@@ -103,7 +102,7 @@ static NSString *const kFIRInstanceIDAPNSTokenKey = @"APNSTuple";
 - (void)tearDown {
   [self.instanceIDStore removeAllCachedTokensWithHandler:nil];
   [self.instanceIDStore removeCheckinPreferencesWithHandler:nil];
-  [FIRInstanceIDStore removeSubDirectory:kApplicationSupportSubDirectoryName error:nil];
+  [FIRInstanceIDStore removeSubDirectory:kSubDirectoryName error:nil];
   [_mockCheckinStore stopMocking];
   [_mockTokenStore stopMocking];
   [_mockInstanceIDStore stopMocking];

--- a/Example/InstanceID/Tests/FIRInstanceIDTokenManagerTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTokenManagerTest.m
@@ -30,7 +30,7 @@
 #import "Firebase/InstanceID/FIRInstanceIDTokenOperation.h"
 #import "Firebase/InstanceID/FIRInstanceIDTokenStore.h"
 
-static NSString *const kApplicationSupportSubDirectoryName = @"FirebaseInstanceIDTokenManagerTest";
+static NSString *const kSubDirectoryName = @"FirebaseInstanceIDTokenManagerTest";
 
 static NSString *const kAuthorizedEntity = @"test-authorized-entity";
 static NSString *const kScope = @"test-scope";
@@ -91,12 +91,12 @@ static NSString *const kNewAPNSTokenString = @"newAPNSData";
 
 - (void)setUp {
   [super setUp];
-  [FIRInstanceIDStore createSubDirectory:kApplicationSupportSubDirectoryName];
+  [FIRInstanceIDStore createSubDirectory:kSubDirectoryName];
 
   NSString *checkinPlistFilename = @"com.google.test.IIDCheckinTest";
-  self.checkinPlist = [[FIRInstanceIDBackupExcludedPlist alloc]
-      initWithFileName:checkinPlistFilename
-          subDirectory:kApplicationSupportSubDirectoryName];
+  self.checkinPlist =
+      [[FIRInstanceIDBackupExcludedPlist alloc] initWithFileName:checkinPlistFilename
+                                                    subDirectory:kSubDirectoryName];
 
   // checkin store
   FIRInstanceIDFakeKeychain *fakeCheckinKeychain = [[FIRInstanceIDFakeKeychain alloc] init];
@@ -123,7 +123,7 @@ static NSString *const kNewAPNSTokenString = @"newAPNSData";
   }
 
   self.tokenManager = nil;
-  [FIRInstanceIDStore removeSubDirectory:kApplicationSupportSubDirectoryName error:nil];
+  [FIRInstanceIDStore removeSubDirectory:kSubDirectoryName error:nil];
   [super tearDown];
 }
 

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -175,10 +175,6 @@ static FIRInstanceID *gInstanceID;
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (void)stopAllRequests {
-  [self.tokenManager stopAllTokenOperations];
-}
-
 #pragma mark - Tokens
 
 - (NSString *)token {

--- a/Firebase/InstanceID/FIRInstanceIDBackupExcludedPlist.m
+++ b/Firebase/InstanceID/FIRInstanceIDBackupExcludedPlist.m
@@ -111,6 +111,7 @@ typedef enum : NSUInteger {
 - (BOOL)moveToApplicationSupportSubDirectory:(NSString *)subDirectoryName {
   NSArray *directoryPaths =
       NSSearchPathForDirectoriesInDomains([self supportedDirectory], NSUserDomainMask, YES);
+  // This only going to happen inside iOS so it is an applicationSupportDirectory.
   NSString *applicationSupportDirPath = directoryPaths.lastObject;
   NSArray *components = @[ applicationSupportDirPath, subDirectoryName ];
   NSString *subDirectoryPath = [NSString pathWithComponents:components];

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -985,8 +985,8 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
 + (NSString *)pathForSubDirectory:(NSString *)subDirectoryName {
   NSArray *directoryPaths = NSSearchPathForDirectoriesInDomains(FIRMessagingSupportedDirectory(),
                                                                 NSUserDomainMask, YES);
-  NSString *applicationSupportDirPath = directoryPaths.lastObject;
-  NSArray *components = @[applicationSupportDirPath, subDirectoryName];
+  NSString *dirPath = directoryPaths.lastObject;
+  NSArray *components = @[dirPath, subDirectoryName];
   return [NSString pathWithComponents:components];
 }
 


### PR DESCRIPTION
This fix #2544. Also remove a method in FIRMessaging.m that is never called.