### PR TITLE
Clean the pod cache before starting.

### DIFF
--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -50,7 +50,20 @@ public enum CocoaPodUtils {
     }
   }
 
-  /// Execute the `pod cache list` command to get the Pods currently cached on your machine.
+  /// Executes the `pod cache clean --all` command to remove any cached CocoaPods.
+  public static func cleanPodCache() {
+    let result = Shell.executeCommandFromScript("pod cache clean --all", outputToConsole: false)
+    switch result {
+    case let .error(code):
+      fatalError("Could not clean the pod cache, the command exited with \(code). Try running the" +
+        "command in Terminal to see what's wrong.")
+    case .success:
+      // No need to do anything else, continue on.
+      print("Successfully cleaned pod cache.")
+      return
+    }
+  }
+
   /// Executes the `pod cache list` command to get the Pods curerntly cached on your machine.
   ///
   /// - Parameter dir: The directory containing all installed pods.

--- a/ZipBuilder/Sources/ZipBuilder/ShellUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ShellUtils.swift
@@ -54,9 +54,10 @@ extension Shell {
       scriptPath = tempScriptsDir.appendingPathComponent("wrapper.sh")
 
       // Write the temporary script contents to the script's path. CocoaPods complains when LANG
-      // isn't set in the environment, so explicitly set it here.
+      // isn't set in the environment, so explicitly set it here. The `/usr/local/git/current/bin`
+      // is to allow the `sso` protocol if it's there.
       let contents = """
-      export PATH="/usr/local/bin:$PATH"
+      export PATH="/usr/local/bin:/usr/local/git/current/bin:$PATH"
       export LANG="en_US.UTF-8"
       source ~/.bash_profile
       \(command)

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -182,6 +182,10 @@ struct ZipBuilder {
     // builds to just install a subset: `[.core, .analytics, .storage, .firestore]` for example.
     let subspecsToInstall = Subspec.allCases
 
+    // Remove CocoaPods cache so the build gets updates after a version is rebuilt during the
+    // release process.
+    CocoaPodUtils.cleanPodCache()
+
     // We need to install all the subpsecs in order to get every single framework that we'll need
     // for the zip file. We can't install each one individually since some pods depend on different
     // subspecs from the same pod (ex: GoogleUtilities, GoogleToolboxForMac, etc). All of the code


### PR DESCRIPTION
This prevents errors from occurring, and will also ensure that the
most recent version will be included if it was rebuilt.

Also fixes an issue where `pod repo update` wouldn't work with `sso` repos.