### PR TITLE
Ensure token refresh notification is triggered any time a new token is refreshed. b/77662386

### DIFF
--- a/Example/InstanceID/Tests/FIRInstanceIDTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTest.m
@@ -52,6 +52,7 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
 - (NSString *)cachedTokenIfAvailable;
 - (void)deleteIdentityWithHandler:(FIRInstanceIDDeleteHandler)handler;
 + (FIRInstanceID *)instanceIDForTests;
+- (void)defaultTokenWithHandler:(FIRInstanceIDTokenHandler)handler;
 @end
 
 @interface FIRInstanceIDTest : XCTestCase
@@ -157,7 +158,7 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
                        handler:[OCMArg any]];
 
   [self.mockInstanceID didCompleteConfigure];
-  OCMVerify([self.mockInstanceID fetchDefaultToken]);
+  OCMVerify([self.mockInstanceID defaultTokenWithHandler:[OCMArg any]]);
   XCTAssertEqualObjects([self.mockInstanceID token], kToken);
 }
 
@@ -172,7 +173,7 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
 
   [self.mockInstanceID didCompleteConfigure];
 
-  OCMVerify([self.mockInstanceID fetchDefaultToken]);
+  OCMVerify([self.mockInstanceID defaultTokenWithHandler:[OCMArg any]]);
 }
 
 - (void)testTokenIsDeletedAlongWithIdentity {
@@ -519,11 +520,11 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
       cachedTokenInfoWithAuthorizedEntity:kAuthorizedEntity
                                     scope:@"*"];
 
-  OCMExpect([self.mockInstanceID fetchDefaultToken]);
+  OCMExpect([self.mockInstanceID defaultTokenWithHandler:[OCMArg any]]);
   NSString *token = [self.mockInstanceID token];
   XCTAssertNil(token);
   [self.mockInstanceID stopMocking];
-  OCMVerify([self.mockInstanceID fetchDefaultToken]);
+  OCMVerify([self.mockInstanceID defaultTokenWithHandler:[OCMArg any]]);
 }
 
 /**
@@ -535,7 +536,7 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
       cachedTokenInfoWithAuthorizedEntity:kAuthorizedEntity
                                     scope:@"*"];
 
-  [[self.mockInstanceID reject] fetchDefaultToken];
+  [[self.mockInstanceID reject] defaultTokenWithHandler:[OCMArg any]];
   NSString *token = [self.mockInstanceID token];
   XCTAssertEqualObjects(token, kToken);
 }

--- a/Example/InstanceID/Tests/FIRInstanceIDTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTest.m
@@ -158,7 +158,7 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
                        handler:[OCMArg any]];
 
   [self.mockInstanceID didCompleteConfigure];
-  OCMVerify([self.mockInstanceID defaultTokenWithHandler:[OCMArg any]]);
+  OCMVerify([self.mockInstanceID defaultTokenWithHandler:nil]);
   XCTAssertEqualObjects([self.mockInstanceID token], kToken);
 }
 

--- a/Example/InstanceID/Tests/FIRInstanceIDTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTest.m
@@ -173,7 +173,7 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
 
   [self.mockInstanceID didCompleteConfigure];
 
-  OCMVerify([self.mockInstanceID defaultTokenWithHandler:[OCMArg any]]);
+  OCMVerify([self.mockInstanceID defaultTokenWithHandler:nil]);
 }
 
 - (void)testTokenIsDeletedAlongWithIdentity {
@@ -520,11 +520,11 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
       cachedTokenInfoWithAuthorizedEntity:kAuthorizedEntity
                                     scope:@"*"];
 
-  OCMExpect([self.mockInstanceID defaultTokenWithHandler:[OCMArg any]]);
+  OCMExpect([self.mockInstanceID defaultTokenWithHandler:nil]);
   NSString *token = [self.mockInstanceID token];
   XCTAssertNil(token);
   [self.mockInstanceID stopMocking];
-  OCMVerify([self.mockInstanceID defaultTokenWithHandler:[OCMArg any]]);
+  OCMVerify([self.mockInstanceID defaultTokenWithHandler:nil]);
 }
 
 /**
@@ -536,7 +536,7 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
       cachedTokenInfoWithAuthorizedEntity:kAuthorizedEntity
                                     scope:@"*"];
 
-  [[self.mockInstanceID reject] defaultTokenWithHandler:[OCMArg any]];
+  [[self.mockInstanceID reject] defaultTokenWithHandler:nil];
   NSString *token = [self.mockInstanceID token];
   XCTAssertEqualObjects(token, kToken);
 }

--- a/Firebase/InstanceID/FIRInstanceID+Testing.h
+++ b/Firebase/InstanceID/FIRInstanceID+Testing.h
@@ -35,12 +35,6 @@
  */
 - (void)start;
 
-/**
- *  Without checking any caches etc, always attempts to fetch the default token (unless a fetch
- *  is already in progress.
- */
-- (void)fetchDefaultToken;
-
 + (int64_t)maxRetryCountForDefaultToken;
 + (int64_t)minIntervalForDefaultTokenRetry;
 + (int64_t)maxRetryIntervalForDefaultTokenInSeconds;

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -914,6 +914,8 @@ static FIRInstanceID *gInstanceID;
         FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeRefetchingTokenForAPNS,
                                  @"Received APNS token while fetching default token. "
                                  @"Refetching default token.");
+        // Do not notify and handle completion handler since this is a retry.
+        // Simply return.
         return;
       } else {
         FIRInstanceIDLoggerInfo(kFIRInstanceIDMessageCodeInstanceID010,

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -219,6 +219,10 @@ static FIRInstanceID *gInstanceID;
     }
     [self defaultTokenWithHandler:^(NSString *_Nullable token, NSError *_Nullable error) {
       if (handler) {
+        if (error) {
+          handler(nil, error);
+          return;
+        }
         result.token = token;
         handler(result, nil);
       }
@@ -918,7 +922,7 @@ static FIRInstanceID *gInstanceID;
                                 @"Successfully fetched default token.");
       }
       // Post the required notifications if somebody is waiting.
-      if (shouldNotifyHandler && handler) {
+      if (shouldNotifyHandler) {
         FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeInstanceID008, @"Got default token %@",
                                  token);
         NSString *previousFCMToken = self.defaultFCMToken;
@@ -933,6 +937,8 @@ static FIRInstanceID *gInstanceID;
           [[NSNotificationQueue defaultQueue] enqueueNotification:tokenRefreshNotification
                                                      postingStyle:NSPostASAP];
         }
+      }
+      if (handler) {
         handler(token, nil);
       }
     }


### PR DESCRIPTION
Before there's this strange handler created to finish some logic of defaultTokenWithHandler: and it is only defined and passing in defaultTokenWithHandler: at two places, where the rest of the defaultTokenWithHandler: calls are not. This could cause issue because it contains critical token refresh code. Move the logic inside defaultTokenWithHandler: so it's always triggered and more readable.

So merge repetitive code and move inside defaultTokenWithHandler: and after that I notice fetchDefaultToken call is simply just calling defaultTokenWithHandler:, so remove it too as there are too many layers of calling default token.
