### PR TITLE
Travis: when linting Firestore, only lint iOS 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ jobs:
       script:
         # Eliminate the one warning from BoringSSL when CocoaPods 1.6.0 is available.
         # The travis_wait is necessary because the command takes more than 10 minutes.
-        - travis_wait 45 ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseFirestore.podspec --allow-warnings --no-subspecs
+        - travis_wait 25 ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseFirestore.podspec --platforms=ios --allow-warnings --no-subspecs
 
     # pod lib lint to check build and warnings for static library build - only on cron jobs
     - stage: test

--- a/scripts/pod_lib_lint.sh
+++ b/scripts/pod_lib_lint.sh
@@ -18,6 +18,8 @@
 #
 # Runs pod lib lint for the given podspec
 
+set -euo pipefail
+
 if [[ $# -lt 1 ]]; then
   cat 1>&2 <<EOF
 USAGE: $0 podspec [options]
@@ -27,8 +29,8 @@ podspec is the podspec to lint
 options can be any options for pod spec lint
 
 Optionally, ALT_SOURCES can be set in the script to add extra repos to the
-search path. This is useful when API's to core dependencies like FirebaseCore
-or GoogleUtilities and the public podspecs are not yet updated.
+search path. This is useful when APIs to core dependencies like FirebaseCore or
+GoogleUtilities and the public podspecs are not yet updated.
 EOF
   exit 1
 fi
@@ -39,20 +41,17 @@ fi
 # https://guides.cocoapods.org/making/private-cocoapods.
 ALT_SOURCES="--sources=https://github.com/Firebase/SpecsStaging.git,https://github.com/CocoaPods/Specs.git"
 
-podspec="$1"
-if [[ $# -gt 1 ]]; then
-  options="${@:2}"
-else
-  options=
+command=(bundle exec pod lib lint "$@")
+
+if [[ -n "${ALT_SOURCES:-}" ]]; then
+  command+=("${ALT_SOURCES}")
 fi
 
-command="bundle exec pod lib lint $podspec $options $ALT_SOURCES"
-echo $command
-
-$command ; result=$?
+echo "${command[*]}"
+"${command[@]}"; result=$?
 
 if [[ $result != 0 ]]; then
   # retry because of occasional network flakiness
-  $command ; result=$?
+  "${command[@]}"; result=$?
 fi
 exit $result


### PR DESCRIPTION
CocoaPods/CocoaPods#7783 added support for restricting pod lib lint to a limited set of platforms. This shipped with 1.6.0 and we're now up to 1.6.1.

Use this to cut the build time for `pod lib lint FirebaseFirestore.podspec` in individual PRs in half.