### PR TITLE
Revert "Revert "Disable Facebook API tests (#2547)" (#2566)"

### DIFF
--- a/Example/Auth/ApiTests/FacebookAuthTests.m
+++ b/Example/Auth/ApiTests/FacebookAuthTests.m
@@ -36,7 +36,7 @@ static NSString *const kFacebookTestAccountName = KFACEBOOK_USER_NAME;
 
 @implementation FacebookAuthTests
 
-- (void)testSignInWithFaceboook {
+- (void)DISABLE_testSignInWithFaceboook {
   FIRAuth *auth = [FIRAuth auth];
   if (!auth) {
     XCTFail(@"Could not obtain auth object.");
@@ -76,7 +76,7 @@ static NSString *const kFacebookTestAccountName = KFACEBOOK_USER_NAME;
   [self deleteFacebookTestingAccountbyId:facebookAccountId];
 }
 
-- (void)testLinkAnonymousAccountToFacebookAccount {
+- (void)DISABLE_testLinkAnonymousAccountToFacebookAccount {
   FIRAuth *auth = [FIRAuth auth];
   if (!auth) {
     XCTFail(@"Could not obtain auth object.");


### PR DESCRIPTION
The Facebook tests are still failing. 

see https://travis-ci.org/firebase/firebase-ios-sdk/jobs/507027358

This reverts commit 2ae939b6ebf6329984695c71514d28d475f62014.
