### PR TITLE
Eliminate Objective-C BOOL in Firestore/core

### DIFF
--- a/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
@@ -398,7 +398,7 @@ NS_ASSUME_NONNULL_BEGIN
   XCTAssertEqual(10, removed);
   // Make sure we removed the even targets with targetID <= 20.
   _persistence.run("verify remaining targets are > 20 or odd", [&]() {
-    _queryCache->EnumerateTargets(^(FSTQueryData *queryData, BOOL *stop) {
+    _queryCache->EnumerateTargets([&](FSTQueryData *queryData) {
       XCTAssertTrue(queryData.targetID > 20 || queryData.targetID % 2 == 1);
     });
   });

--- a/Firestore/Source/Core/FSTFirestoreClient.mm
+++ b/Firestore/Source/Core/FSTFirestoreClient.mm
@@ -336,10 +336,9 @@ static const std::chrono::milliseconds FSTLruGcRegularDelay = std::chrono::minut
 
     if ([maybeDoc isKindOfClass:[FSTDocument class]]) {
       FSTDocument *document = (FSTDocument *)maybeDoc;
-      maybe_snapshot =
-          DocumentSnapshot{doc.firestore(), doc.key(), document,
-                           /*from_cache=*/true,
-                           /*has_pending_writes=*/static_cast<bool>(document.hasLocalMutations)};
+      maybe_snapshot = DocumentSnapshot{doc.firestore(), doc.key(), document,
+                                        /*from_cache=*/true,
+                                        /*has_pending_writes=*/document.hasLocalMutations};
     } else if ([maybeDoc isKindOfClass:[FSTDeletedDocument class]]) {
       maybe_snapshot = DocumentSnapshot{doc.firestore(), doc.key(), nil,
                                         /*from_cache=*/true,

--- a/Firestore/Source/Local/FSTLRUGarbageCollector.h
+++ b/Firestore/Source/Local/FSTLRUGarbageCollector.h
@@ -21,6 +21,8 @@
 
 #import "FIRFirestoreSettings.h"
 #import "Firestore/Source/Local/FSTQueryData.h"
+
+#include "Firestore/core/src/firebase/firestore/local/query_cache.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/types.h"
 
@@ -84,10 +86,8 @@ struct LruResults {
 /**
  * Enumerates all of the outstanding mutations.
  */
-- (void)enumerateMutationsUsingBlock:
-    (void (^)(const firebase::firestore::model::DocumentKey &key,
-              firebase::firestore::model::ListenSequenceNumber sequenceNumber,
-              BOOL *stop))block;
+- (void)enumerateMutationsUsingCallback:
+    (const firebase::firestore::local::OrphanedDocumentCallback &)callback;
 
 /**
  * Removes all unreferenced documents from the cache that have a sequence number less than or equal

--- a/Firestore/Source/Local/FSTLRUGarbageCollector.h
+++ b/Firestore/Source/Local/FSTLRUGarbageCollector.h
@@ -81,7 +81,7 @@ struct LruResults {
  * Enumerates all the targets that the delegate is aware of. This is typically all of the targets in
  * an FSTQueryCache.
  */
-- (void)enumerateTargetsUsingBlock:(void (^)(FSTQueryData *queryData, BOOL *stop))block;
+- (void)enumerateTargetsUsingCallback:(const firebase::firestore::local::TargetCallback &)callback;
 
 /**
  * Enumerates all of the outstanding mutations.

--- a/Firestore/Source/Local/FSTLRUGarbageCollector.mm
+++ b/Firestore/Source/Local/FSTLRUGarbageCollector.mm
@@ -164,9 +164,9 @@ class RollingSequenceNumberBuffer {
   [_delegate enumerateTargetsUsingBlock:^(FSTQueryData *queryData, BOOL *stop) {
     ptr_to_buffer->AddElement(queryData.sequenceNumber);
   }];
-  [_delegate enumerateMutationsUsingBlock:^(const DocumentKey &docKey,
-                                            ListenSequenceNumber sequenceNumber, BOOL *stop) {
-    ptr_to_buffer->AddElement(sequenceNumber);
+  [_delegate enumerateMutationsUsingCallback:[&buffer](const DocumentKey &docKey,
+                                                       ListenSequenceNumber sequenceNumber) {
+    buffer.AddElement(sequenceNumber);
   }];
   return buffer.max_value();
 }

--- a/Firestore/Source/Local/FSTLRUGarbageCollector.mm
+++ b/Firestore/Source/Local/FSTLRUGarbageCollector.mm
@@ -159,10 +159,9 @@ class RollingSequenceNumberBuffer {
     return kFSTListenSequenceNumberInvalid;
   }
   RollingSequenceNumberBuffer buffer(queryCount);
-  // Pointer is necessary to access stack-allocated buffer from a block.
-  RollingSequenceNumberBuffer *ptr_to_buffer = &buffer;
-  [_delegate enumerateTargetsUsingBlock:^(FSTQueryData *queryData, BOOL *stop) {
-    ptr_to_buffer->AddElement(queryData.sequenceNumber);
+
+  [_delegate enumerateTargetsUsingCallback:[&buffer](FSTQueryData *queryData) {
+    buffer.AddElement(queryData.sequenceNumber);
   }];
   [_delegate enumerateMutationsUsingCallback:[&buffer](const DocumentKey &docKey,
                                                        ListenSequenceNumber sequenceNumber) {

--- a/Firestore/Source/Local/FSTLevelDB.mm
+++ b/Firestore/Source/Local/FSTLevelDB.mm
@@ -76,6 +76,7 @@ using firebase::firestore::local::LruParams;
 using firebase::firestore::local::OrphanedDocumentCallback;
 using firebase::firestore::local::ReferenceSet;
 using firebase::firestore::local::RemoteDocumentCache;
+using firebase::firestore::local::TargetCallback;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::ListenSequenceNumber;
@@ -211,8 +212,8 @@ static const char *kReservedPathComponent = "firestore";
   return NO;
 }
 
-- (void)enumerateTargetsUsingBlock:(void (^)(FSTQueryData *queryData, BOOL *stop))block {
-  _db.queryCache->EnumerateTargets(block);
+- (void)enumerateTargetsUsingCallback:(const TargetCallback &)callback {
+  _db.queryCache->EnumerateTargets(callback);
 }
 
 - (void)enumerateMutationsUsingCallback:(const OrphanedDocumentCallback &)callback {

--- a/Firestore/Source/Local/FSTMemoryPersistence.mm
+++ b/Firestore/Source/Local/FSTMemoryPersistence.mm
@@ -42,6 +42,7 @@ using firebase::firestore::local::MemoryMutationQueue;
 using firebase::firestore::local::MemoryQueryCache;
 using firebase::firestore::local::MemoryRemoteDocumentCache;
 using firebase::firestore::local::ReferenceSet;
+using firebase::firestore::local::TargetCallback;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeyHash;
 using firebase::firestore::model::ListenSequenceNumber;
@@ -234,8 +235,8 @@ NS_ASSUME_NONNULL_BEGIN
   _currentSequenceNumber = kFSTListenSequenceNumberInvalid;
 }
 
-- (void)enumerateTargetsUsingBlock:(void (^)(FSTQueryData *queryData, BOOL *stop))block {
-  return _persistence.queryCache->EnumerateTargets(block);
+- (void)enumerateTargetsUsingCallback:(const TargetCallback &)callback {
+  return _persistence.queryCache->EnumerateTargets(callback);
 }
 
 - (void)enumerateMutationsUsingCallback:

--- a/Firestore/Source/Model/FSTDocument.h
+++ b/Firestore/Source/Model/FSTDocument.h
@@ -48,7 +48,7 @@ typedef NS_ENUM(NSInteger, FSTDocumentState) {
 /**
  * Whether this document has a local mutation applied that has not yet been acknowledged by Watch.
  */
-- (BOOL)hasPendingWrites;
+- (bool)hasPendingWrites;
 
 @end
 
@@ -65,8 +65,8 @@ typedef NS_ENUM(NSInteger, FSTDocumentState) {
                            proto:(GCFSDocument *)proto;
 
 - (nullable FSTFieldValue *)fieldForPath:(const firebase::firestore::model::FieldPath &)path;
-- (BOOL)hasLocalMutations;
-- (BOOL)hasCommittedMutations;
+- (bool)hasLocalMutations;
+- (bool)hasCommittedMutations;
 
 @property(nonatomic, strong, readonly) FSTObjectValue *data;
 
@@ -81,9 +81,9 @@ typedef NS_ENUM(NSInteger, FSTDocumentState) {
 @interface FSTDeletedDocument : FSTMaybeDocument
 + (instancetype)documentWithKey:(firebase::firestore::model::DocumentKey)key
                         version:(firebase::firestore::model::SnapshotVersion)version
-          hasCommittedMutations:(BOOL)committedMutations;
+          hasCommittedMutations:(bool)committedMutations;
 
-- (BOOL)hasCommittedMutations;
+- (bool)hasCommittedMutations;
 
 @end
 

--- a/Firestore/Source/Model/FSTDocument.mm
+++ b/Firestore/Source/Model/FSTDocument.mm
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
-- (BOOL)hasPendingWrites {
+- (bool)hasPendingWrites {
   @throw FSTAbstractMethodException();  // NOLINT
 }
 
@@ -127,15 +127,15 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
-- (BOOL)hasLocalMutations {
+- (bool)hasLocalMutations {
   return _documentState == FSTDocumentStateLocalMutations;
 }
 
-- (BOOL)hasCommittedMutations {
+- (bool)hasCommittedMutations {
   return _documentState == FSTDocumentStateCommittedMutations;
 }
 
-- (BOOL)hasPendingWrites {
+- (bool)hasPendingWrites {
   return self.hasLocalMutations || self.hasCommittedMutations;
 }
 
@@ -174,12 +174,12 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation FSTDeletedDocument {
-  BOOL _hasCommittedMutations;
+  bool _hasCommittedMutations;
 }
 
 + (instancetype)documentWithKey:(DocumentKey)key
                         version:(SnapshotVersion)version
-          hasCommittedMutations:(BOOL)committedMutations {
+          hasCommittedMutations:(bool)committedMutations {
   FSTDeletedDocument *deletedDocument = [[FSTDeletedDocument alloc] initWithKey:std::move(key)
                                                                         version:std::move(version)];
 
@@ -190,11 +190,11 @@ NS_ASSUME_NONNULL_BEGIN
   return deletedDocument;
 }
 
-- (BOOL)hasCommittedMutations {
+- (bool)hasCommittedMutations {
   return _hasCommittedMutations;
 }
 
-- (BOOL)hasPendingWrites {
+- (bool)hasPendingWrites {
   return self.hasCommittedMutations;
 }
 
@@ -233,8 +233,8 @@ NS_ASSUME_NONNULL_BEGIN
   return [[FSTUnknownDocument alloc] initWithKey:std::move(key) version:std::move(version)];
 }
 
-- (BOOL)hasPendingWrites {
-  return YES;
+- (bool)hasPendingWrites {
+  return true;
 }
 
 - (BOOL)isEqual:(id)other {

--- a/Firestore/core/src/firebase/firestore/local/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/local/CMakeLists.txt
@@ -16,11 +16,18 @@ if(HAVE_LEVELDB)
   cc_library(
     firebase_firestore_local_persistence_leveldb
     SOURCES
+      leveldb_index_manager.h
+      #leveldb_index_manager.mm
       leveldb_key.cc
       leveldb_key.h
-      #leveldb_index_manager.mm
       leveldb_migrations.cc
       leveldb_migrations.h
+      leveldb_mutation_queue.h
+      #leveldb_mutation_queue.mm
+      leveldb_query_cache.h
+      #leveldb_query_cache.mm
+      leveldb_remote_document_cache.h
+      #leveldb_remote_document_cache.mm
       leveldb_transaction.cc
       leveldb_transaction.h
       leveldb_util.cc
@@ -49,13 +56,25 @@ cc_library(
   SOURCES
     document_reference.h
     document_reference.cc
+    index_manager.h
+    listen_sequence.h
     local_serializer.h
     local_serializer.cc
     memory_index_manager.cc
+    memory_index_manager.h
+    memory_mutation_queue.h
+    #memory_mutation_queue.mm
+    memory_query_cache.h
+    #memory_query_cache.mm
+    memory_remote_document_cache.h
+    #memory_remote_document_cache.mm
+    mutation_queue.h
+    query_cache.h
     query_data.cc
     query_data.h
     reference_set.cc
     reference_set.h
+    remote_document_cache.h
   DEPENDS
     # TODO(b/111328563) Force nanopb first to work around ODR violations
     protobuf-nanopb

--- a/Firestore/core/src/firebase/firestore/local/leveldb_query_cache.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_query_cache.h
@@ -47,11 +47,6 @@ namespace local {
 /** Cached Queries backed by LevelDB. */
 class LevelDbQueryCache : public QueryCache {
  public:
-  /** Enumerator callback type for orphaned documents */
-  typedef void (^OrphanedDocumentEnumerator)(const model::DocumentKey&,
-                                             model::ListenSequenceNumber,
-                                             BOOL*);
-
   /**
    * Retrieves the global singleton metadata row from the given database, if it
    * exists.
@@ -123,7 +118,7 @@ class LevelDbQueryCache : public QueryCache {
   // Non-interface methods
   void Start();
 
-  void EnumerateOrphanedDocuments(OrphanedDocumentEnumerator block);
+  void EnumerateOrphanedDocuments(const OrphanedDocumentCallback& callback);
 
  private:
   void Save(FSTQueryData* query_data);

--- a/Firestore/core/src/firebase/firestore/local/leveldb_query_cache.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_query_cache.h
@@ -70,7 +70,7 @@ class LevelDbQueryCache : public QueryCache {
 
   FSTQueryData* _Nullable GetTarget(FSTQuery* query) override;
 
-  void EnumerateTargets(TargetEnumerator block) override;
+  void EnumerateTargets(const TargetCallback& callback) override;
 
   int RemoveTargets(model::ListenSequenceNumber upper_bound,
                     const std::unordered_map<model::TargetId, FSTQueryData*>&

--- a/Firestore/core/src/firebase/firestore/local/leveldb_query_cache.mm
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_query_cache.mm
@@ -306,23 +306,22 @@ void LevelDbQueryCache::SetLastRemoteSnapshotVersion(SnapshotVersion version) {
 }
 
 void LevelDbQueryCache::EnumerateOrphanedDocuments(
-    OrphanedDocumentEnumerator block) {
+    const OrphanedDocumentCallback& callback) {
   std::string document_target_prefix = LevelDbDocumentTargetKey::KeyPrefix();
   auto it = db_.currentTransaction->NewIterator();
   it->Seek(document_target_prefix);
   ListenSequenceNumber next_to_report = 0;
   DocumentKey key_to_report;
   LevelDbDocumentTargetKey key;
-  BOOL stop = NO;
-  for (; !stop && it->Valid() &&
-         absl::StartsWith(it->key(), document_target_prefix);
+
+  for (; it->Valid() && absl::StartsWith(it->key(), document_target_prefix);
        it->Next()) {
     HARD_ASSERT(key.Decode(it->key()), "Failed to decode DocumentTarget key");
     if (key.IsSentinel()) {
       // if next_to_report is non-zero, report it, this is a new key so the last
       // one must be not be a member of any targets.
       if (next_to_report != 0) {
-        block(key_to_report, next_to_report, &stop);
+        callback(key_to_report, next_to_report);
       }
       // set next_to_report to be this sequence number. It's the next one we
       // might report, if we don't find any targets for this document.
@@ -335,10 +334,10 @@ void LevelDbQueryCache::EnumerateOrphanedDocuments(
       next_to_report = 0;
     }
   }
-  // if not stop and next_to_report is non-zero, report it. We didn't find any
-  // targets for that document, and we weren't asked to stop.
-  if (!stop && next_to_report != 0) {
-    block(key_to_report, next_to_report, &stop);
+  // if next_to_report is non-zero, report it. We didn't find any targets for
+  // that document, and we weren't asked to stop.
+  if (next_to_report != 0) {
+    callback(key_to_report, next_to_report);
   }
 }
 

--- a/Firestore/core/src/firebase/firestore/local/leveldb_query_cache.mm
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_query_cache.mm
@@ -170,16 +170,15 @@ FSTQueryData* _Nullable LevelDbQueryCache::GetTarget(FSTQuery* query) {
   return nil;
 }
 
-void LevelDbQueryCache::EnumerateTargets(TargetEnumerator block) {
+void LevelDbQueryCache::EnumerateTargets(const TargetCallback& callback) {
   // Enumerate all targets, give their sequence numbers.
   std::string target_prefix = LevelDbTargetKey::KeyPrefix();
   auto it = db_.currentTransaction->NewIterator();
   it->Seek(target_prefix);
-  BOOL stop = NO;
-  for (; !stop && it->Valid() && absl::StartsWith(it->key(), target_prefix);
+  for (; it->Valid() && absl::StartsWith(it->key(), target_prefix);
        it->Next()) {
     FSTQueryData* target = DecodeTarget(it->value());
-    block(target, &stop);
+    callback(target);
   }
 }
 

--- a/Firestore/core/src/firebase/firestore/local/memory_query_cache.h
+++ b/Firestore/core/src/firebase/firestore/local/memory_query_cache.h
@@ -57,7 +57,7 @@ class MemoryQueryCache : public QueryCache {
 
   FSTQueryData* _Nullable GetTarget(FSTQuery* query) override;
 
-  void EnumerateTargets(TargetEnumerator block) override;
+  void EnumerateTargets(const TargetCallback& callback) override;
 
   int RemoveTargets(model::ListenSequenceNumber upper_bound,
                     const std::unordered_map<model::TargetId, FSTQueryData*>&
@@ -104,8 +104,10 @@ class MemoryQueryCache : public QueryCache {
 
   /** Maps a query to the data about that query. */
   NSMutableDictionary<FSTQuery*, FSTQueryData*>* queries_;
-  /** A ordered bidirectional mapping between documents and the remote target
-   * IDs. */
+  /**
+   * A ordered bidirectional mapping between documents and the remote target
+   * IDs.
+   */
   ReferenceSet references_;
 };
 

--- a/Firestore/core/src/firebase/firestore/local/memory_query_cache.h
+++ b/Firestore/core/src/firebase/firestore/local/memory_query_cache.h
@@ -32,6 +32,7 @@
 #include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
 #include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 #include "Firestore/core/src/firebase/firestore/model/types.h"
+#include "Firestore/core/src/firebase/firestore/util/objc_compatibility.h"
 
 @class FSTLocalSerializer;
 @class FSTMemoryPersistence;
@@ -78,7 +79,7 @@ class MemoryQueryCache : public QueryCache {
   size_t CalculateByteSize(FSTLocalSerializer* serializer);
 
   size_t size() const override {
-    return [queries_ count];
+    return queries_.size();
   }
 
   model::ListenSequenceNumber highest_listen_sequence_number() const override {
@@ -103,7 +104,12 @@ class MemoryQueryCache : public QueryCache {
   model::SnapshotVersion last_remote_snapshot_version_;
 
   /** Maps a query to the data about that query. */
-  NSMutableDictionary<FSTQuery*, FSTQueryData*>* queries_;
+  std::unordered_map<FSTQuery*,
+                     FSTQueryData*,
+                     util::objc::Hash<FSTQuery*>,
+                     util::objc::EqualTo<FSTQuery*>>
+      queries_;
+
   /**
    * A ordered bidirectional mapping between documents and the remote target
    * IDs.

--- a/Firestore/core/src/firebase/firestore/local/memory_query_cache.mm
+++ b/Firestore/core/src/firebase/firestore/local/memory_query_cache.mm
@@ -67,10 +67,10 @@ FSTQueryData* _Nullable MemoryQueryCache::GetTarget(FSTQuery* query) {
   return queries_[query];
 }
 
-void MemoryQueryCache::EnumerateTargets(TargetEnumerator block) {
+void MemoryQueryCache::EnumerateTargets(const TargetCallback& callback) {
   [queries_ enumerateKeysAndObjectsUsingBlock:^(
                 FSTQuery* query, FSTQueryData* query_data, BOOL* stop) {
-    block(query_data, stop);
+    callback(query_data);
   }];
 }
 

--- a/Firestore/core/src/firebase/firestore/local/memory_query_cache.mm
+++ b/Firestore/core/src/firebase/firestore/local/memory_query_cache.mm
@@ -15,12 +15,16 @@
  */
 
 #include "Firestore/core/src/firebase/firestore/local/memory_query_cache.h"
+
 #import <Protobuf/GPBMessage.h>
+
+#include <vector>
 
 #import "Firestore/Protos/objc/firestore/local/Target.pbobjc.h"
 #import "Firestore/Source/Core/FSTQuery.h"
 #import "Firestore/Source/Local/FSTMemoryPersistence.h"
 #import "Firestore/Source/Local/FSTQueryData.h"
+
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 
 using firebase::firestore::model::DocumentKey;
@@ -40,7 +44,7 @@ MemoryQueryCache::MemoryQueryCache(FSTMemoryPersistence* persistence)
       highest_listen_sequence_number_(ListenSequenceNumber(0)),
       highest_target_id_(TargetId(0)),
       last_remote_snapshot_version_(SnapshotVersion::None()),
-      queries_([NSMutableDictionary dictionary]) {
+      queries_() {
 }
 
 void MemoryQueryCache::AddTarget(FSTQueryData* query_data) {
@@ -59,36 +63,41 @@ void MemoryQueryCache::UpdateTarget(FSTQueryData* query_data) {
 }
 
 void MemoryQueryCache::RemoveTarget(FSTQueryData* query_data) {
-  [queries_ removeObjectForKey:query_data.query];
+  queries_.erase(query_data.query);
   references_.RemoveReferences(query_data.targetID);
 }
 
 FSTQueryData* _Nullable MemoryQueryCache::GetTarget(FSTQuery* query) {
-  return queries_[query];
+  auto iter = queries_.find(query);
+  return iter == queries_.end() ? nil : iter->second;
 }
 
 void MemoryQueryCache::EnumerateTargets(const TargetCallback& callback) {
-  [queries_ enumerateKeysAndObjectsUsingBlock:^(
-                FSTQuery* query, FSTQueryData* query_data, BOOL* stop) {
-    callback(query_data);
-  }];
+  for (const auto& kv : queries_) {
+    callback(kv.second);
+  }
 }
 
 int MemoryQueryCache::RemoveTargets(
     model::ListenSequenceNumber upper_bound,
     const std::unordered_map<TargetId, FSTQueryData*>& live_targets) {
-  NSMutableArray<FSTQuery*>* toRemove = [NSMutableArray array];
-  [queries_ enumerateKeysAndObjectsUsingBlock:^(
-                FSTQuery* query, FSTQueryData* queryData, BOOL* stop) {
-    if (queryData.sequenceNumber <= upper_bound) {
-      if (live_targets.find(queryData.targetID) == live_targets.end()) {
-        [toRemove addObject:query];
-        references_.RemoveReferences(queryData.targetID);
+  std::vector<FSTQuery*> to_remove;
+  for (const auto& kv : queries_) {
+    FSTQuery* query = kv.first;
+    FSTQueryData* query_data = kv.second;
+
+    if (query_data.sequenceNumber <= upper_bound) {
+      if (live_targets.find(query_data.targetID) == live_targets.end()) {
+        to_remove.push_back(query);
+        references_.RemoveReferences(query_data.targetID);
       }
     }
-  }];
-  [queries_ removeObjectsForKeys:toRemove];
-  return static_cast<int>([toRemove count]);
+  }
+
+  for (FSTQuery* element : to_remove) {
+    queries_.erase(element);
+  }
+  return static_cast<int>(to_remove.size());
 }
 
 void MemoryQueryCache::AddMatchingKeys(const DocumentKeySet& keys,
@@ -116,11 +125,11 @@ bool MemoryQueryCache::Contains(const DocumentKey& key) {
 }
 
 size_t MemoryQueryCache::CalculateByteSize(FSTLocalSerializer* serializer) {
-  __block size_t count = 0;
-  [queries_ enumerateKeysAndObjectsUsingBlock:^(
-                FSTQuery* query, FSTQueryData* query_data, BOOL* stop) {
+  size_t count = 0;
+  for (const auto& kv : queries_) {
+    FSTQueryData* query_data = kv.second;
     count += [[serializer encodedQueryData:query_data] serializedSize];
-  }];
+  }
   return count;
 }
 

--- a/Firestore/core/src/firebase/firestore/local/query_cache.h
+++ b/Firestore/core/src/firebase/firestore/local/query_cache.h
@@ -23,6 +23,7 @@
 
 #import <Foundation/Foundation.h>
 
+#include <functional>
 #include <unordered_map>
 
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
@@ -38,6 +39,9 @@ NS_ASSUME_NONNULL_BEGIN
 namespace firebase {
 namespace firestore {
 namespace local {
+
+using OrphanedDocumentCallback =
+    std::function<void(const model::DocumentKey&, model::ListenSequenceNumber)>;
 
 /**
  * Represents cached targets received from the remote backend. This contains

--- a/Firestore/core/src/firebase/firestore/local/query_cache.h
+++ b/Firestore/core/src/firebase/firestore/local/query_cache.h
@@ -43,6 +43,8 @@ namespace local {
 using OrphanedDocumentCallback =
     std::function<void(const model::DocumentKey&, model::ListenSequenceNumber)>;
 
+using TargetCallback = std::function<void(FSTQueryData*)>;
+
 /**
  * Represents cached targets received from the remote backend. This contains
  * both a mapping between targets and the documents that matched them according
@@ -53,8 +55,6 @@ using OrphanedDocumentCallback =
  */
 class QueryCache {
  public:
-  typedef void (^TargetEnumerator)(FSTQueryData*, BOOL*);
-
   virtual ~QueryCache() {
   }
 
@@ -93,7 +93,7 @@ class QueryCache {
    */
   virtual FSTQueryData* _Nullable GetTarget(FSTQuery* query) = 0;
 
-  virtual void EnumerateTargets(TargetEnumerator block) = 0;
+  virtual void EnumerateTargets(const TargetCallback& callback) = 0;
 
   virtual int RemoveTargets(
       model::ListenSequenceNumber upper_bound,

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -247,6 +247,7 @@ cc_library(
     config.h
     hashing.h
     iterator_adaptors.h
+    objc_compatibility.h
     ordered_code.cc
     ordered_code.h
     range.h

--- a/Firestore/core/src/firebase/firestore/util/objc_compatibility.h
+++ b/Firestore/core/src/firebase/firestore/util/objc_compatibility.h
@@ -74,6 +74,34 @@ bool Equals(const T& lhs, const T& rhs) {
 }
 
 /**
+ * A function object that implements equality for an Objective-C pointer by
+ * delegating to -isEqual:. This is useful for using Objective-C objects as
+ * keys in STL associative containers.
+ */
+template <typename T,
+          typename = absl::enable_if_t<is_objective_c_pointer<T>::value>>
+class EqualTo {
+ public:
+  bool operator()(T lhs, T rhs) const {
+    return [lhs isEqual:rhs];
+  }
+};
+
+/**
+ * A function object that implements STL-compatible hash code for an Objective-C
+ * pointer by delegating to -hash. This is useful for using Objective-C objects
+ * as keys in std::unordered_map.
+ */
+template <typename T,
+          typename = absl::enable_if_t<is_objective_c_pointer<T>::value>>
+class Hash {
+ public:
+  size_t operator()(T value) const {
+    return static_cast<size_t>([value hash]);
+  }
+};
+
+/**
  * Creates a debug description of the given `value` by calling `ToString` on it,
  * converting the result to an `NSString`. Exists mainly to simplify writing
  * `description:` methods for Objective-C classes.

--- a/cmake/cc_rules.cmake
+++ b/cmake/cc_rules.cmake
@@ -30,7 +30,7 @@ function(cc_library name)
 
   maybe_remove_objc_sources(sources ${ccl_SOURCES})
   add_library(${name} ${sources})
-  add_objc_flags(${name} ccl)
+  add_objc_flags(${name} ${ccl_SOURCES})
   target_include_directories(
     ${name}
     PUBLIC
@@ -107,7 +107,7 @@ function(cc_binary name)
 
   maybe_remove_objc_sources(sources ${ccb_SOURCES})
   add_executable(${name} ${sources})
-  add_objc_flags(${name} ccb)
+  add_objc_flags(${name} ${ccb_SOURCES})
   add_test(${name} ${name})
 
   target_include_directories(${name} PUBLIC ${FIREBASE_SOURCE_DIR})
@@ -137,7 +137,7 @@ function(cc_test name)
 
   maybe_remove_objc_sources(sources ${cct_SOURCES})
   add_executable(${name} ${sources})
-  add_objc_flags(${name} cct)
+  add_objc_flags(${name} ${cct_SOURCES})
   add_test(${name} ${name})
 
   target_include_directories(${name} PUBLIC ${FIREBASE_SOURCE_DIR})


### PR DESCRIPTION
This contains a smattering of fixes required to make this happen, initially prompted by the `static_cast<bool>` to convert from `BOOL` to `bool` in FSTFirestoreClient.

Most notably:
  * This includes `objc::EqualTo` and `objc::Hash` functors that make it possible to use `std::unordered_map` with Objective-C key types
  * Uses these in MemoryQueryCache
  * Changes enumeration interfaces to `std::function` instead of Objective-C block style.