### PR TITLE
Add DelayedConstructor<T>

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 		6E59498D20F55BA800ECD9A5 /* FuzzingResources in Resources */ = {isa = PBXBuildFile; fileRef = 6ED6DEA120F5502700FC6076 /* FuzzingResources */; };
 		6E8302E021022309003E1EA3 /* FSTFuzzTestFieldPath.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6E8302DF21022309003E1EA3 /* FSTFuzzTestFieldPath.mm */; };
 		6EA39FDE20FE820E008D461F /* FSTFuzzTestSerializer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6EA39FDD20FE820E008D461F /* FSTFuzzTestSerializer.mm */; };
+		6EC28BB8C38E3FD126F68211 /* delayed_constructor_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = D0A6E9136804A41CEC9D55D4 /* delayed_constructor_test.cc */; };
 		6EDD3B4620BF247500C33877 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6EDD3B4820BF247500C33877 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
 		6EDD3B4920BF247500C33877 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F5AF195388D20070C39A /* XCTest.framework */; };
@@ -560,6 +561,7 @@
 		B9C261C26C5D311E1E3C0CB9 /* query_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = query_test.cc; sourceTree = "<group>"; };
 		BB92EB03E3F92485023F64ED /* Pods_Firestore_Example_iOS_Firestore_SwiftTests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Firestore_Example_iOS_Firestore_SwiftTests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C8522DE226C467C54E6788D8 /* mutation_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = mutation_test.cc; sourceTree = "<group>"; };
+		D0A6E9136804A41CEC9D55D4 /* delayed_constructor_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = delayed_constructor_test.cc; sourceTree = "<group>"; };
 		D3CC3DC5338DCAF43A211155 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		D5B2593BCB52957D62F1C9D3 /* perf_spec_test.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = perf_spec_test.json; sourceTree = "<group>"; };
 		D5B25E7E7D6873CBA4571841 /* FIRNumericTransformTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FIRNumericTransformTests.mm; sourceTree = "<group>"; };
@@ -746,6 +748,7 @@
 				548DB928200D59F600E00ABC /* comparison_test.cc */,
 				B67BF448216EB43000CA9097 /* create_noop_connectivity_monitor.cc */,
 				B67BF447216EB42F00CA9097 /* create_noop_connectivity_monitor.h */,
+				D0A6E9136804A41CEC9D55D4 /* delayed_constructor_test.cc */,
 				B6FB4689208F9B9100554BA2 /* executor_libdispatch_test.mm */,
 				B6FB4687208F9B9100554BA2 /* executor_std_test.cc */,
 				B6FB4688208F9B9100554BA2 /* executor_test.cc */,
@@ -2058,6 +2061,7 @@
 				ABE6637A201FA81900ED349A /* database_id_test.cc in Sources */,
 				AB38D93020236E21000A432D /* database_info_test.cc in Sources */,
 				546854AA20A36867004BDBD5 /* datastore_test.mm in Sources */,
+				6EC28BB8C38E3FD126F68211 /* delayed_constructor_test.cc in Sources */,
 				544129DD21C2DDC800EFB9CC /* document.pb.cc in Sources */,
 				B6152AD7202A53CB000E5744 /* document_key_test.cc in Sources */,
 				AB6B908420322E4D00CC290A /* document_test.cc in Sources */,

--- a/Firestore/Example/Tests/Core/FSTQueryListenerTests.mm
+++ b/Firestore/Example/Tests/Core/FSTQueryListenerTests.mm
@@ -33,10 +33,10 @@
 #include "Firestore/core/src/firebase/firestore/core/view_snapshot.h"
 #include "Firestore/core/src/firebase/firestore/model/types.h"
 #include "Firestore/core/src/firebase/firestore/remote/remote_event.h"
+#include "Firestore/core/src/firebase/firestore/util/delayed_constructor.h"
 #include "Firestore/core/src/firebase/firestore/util/executor_libdispatch.h"
 #include "Firestore/core/src/firebase/firestore/util/status.h"
 #include "Firestore/core/src/firebase/firestore/util/statusor.h"
-#include "absl/memory/memory.h"
 
 using firebase::firestore::FirestoreErrorCode;
 using firebase::firestore::core::DocumentViewChange;
@@ -45,6 +45,7 @@ using firebase::firestore::core::ViewSnapshotHandler;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::OnlineState;
 using firebase::firestore::remote::TargetChange;
+using firebase::firestore::util::DelayedConstructor;
 using firebase::firestore::util::ExecutorLibdispatch;
 using firebase::firestore::util::Status;
 using firebase::firestore::util::StatusOr;
@@ -55,15 +56,12 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation FSTQueryListenerTests {
-  std::unique_ptr<ExecutorLibdispatch> _executor;
+  DelayedConstructor<ExecutorLibdispatch> _executor;
   FSTListenOptions *_includeMetadataChanges;
 }
 
 - (void)setUp {
-  // TODO(varconst): moving this test to C++, it should be possible to store Executor as a value,
-  // not a pointer, and initialize it in the constructor.
-  _executor = absl::make_unique<ExecutorLibdispatch>(
-      dispatch_queue_create("FSTQueryListenerTests Queue", DISPATCH_QUEUE_SERIAL));
+  _executor.Init(dispatch_queue_create("FSTQueryListenerTests Queue", DISPATCH_QUEUE_SERIAL));
   _includeMetadataChanges = [[FSTListenOptions alloc] initWithIncludeQueryMetadataChanges:YES
                                                            includeDocumentMetadataChanges:YES
                                                                     waitForSyncWhenOnline:NO];

--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -39,6 +39,7 @@
 #include "Firestore/core/src/firebase/firestore/core/database_info.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
 #include "Firestore/core/src/firebase/firestore/util/async_queue.h"
+#include "Firestore/core/src/firebase/firestore/util/delayed_constructor.h"
 #include "Firestore/core/src/firebase/firestore/util/log.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 
@@ -48,6 +49,7 @@ using firebase::firestore::api::Firestore;
 using firebase::firestore::auth::CredentialsProvider;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::util::AsyncQueue;
+using firebase::firestore::util::DelayedConstructor;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -62,9 +64,7 @@ extern "C" NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
 @end
 
 @implementation FIRFirestore {
-  // `std::mutex` member variable makes `core::Firestore` unmovable.
-
-  std::unique_ptr<Firestore> _firestore;
+  DelayedConstructor<Firestore> _firestore;
 }
 
 + (NSMutableDictionary<NSString *, FIRFirestore *> *)instances {
@@ -144,9 +144,8 @@ extern "C" NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
                       workerQueue:(std::unique_ptr<AsyncQueue>)workerQueue
                       firebaseApp:(FIRApp *)app {
   if (self = [super init]) {
-    _firestore = absl::make_unique<Firestore>(
-        std::move(projectID), std::move(database), std::move(persistenceKey),
-        std::move(credentialsProvider), std::move(workerQueue), (__bridge void *)self);
+    _firestore.Init(std::move(projectID), std::move(database), std::move(persistenceKey),
+                    std::move(credentialsProvider), std::move(workerQueue), (__bridge void *)self);
 
     _app = app;
 

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -245,6 +245,7 @@ cc_library(
     comparison.cc
     comparison.h
     config.h
+    delayed_constructor.h
     hashing.h
     iterator_adaptors.h
     ordered_code.cc

--- a/Firestore/core/src/firebase/firestore/util/delayed_constructor.h
+++ b/Firestore/core/src/firebase/firestore/util/delayed_constructor.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_DELAYED_CONSTRUCTOR_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_DELAYED_CONSTRUCTOR_H_
+
+#include <type_traits>
+#include <utility>
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+// DelayedConstructor<T> is a wrapper around an object of type T that
+//
+//   * stores the object of type T inline inside DelayedConstructor<T>;
+//   * initially does not call T's constructor, leaving storage uninitialized;
+//   * calls the constructor when you call Init();
+//   * provides access to the object of type T like a pointer via ->, *, and
+//     get(); and
+//   * calls T's destructor as usual.
+//
+// This is useful for embedding objects of type T inside Objective-C objects
+// when T has no default constructor.
+//
+// Objective-C separates allocation from initialization which is different from
+// the way C++ does it. A C++ object embedded in an Objective-C object is
+// normally default constructed then assigned a value later. This doesn't work
+// for classes that have no default constructor.
+//
+// DelayedConstructor does not count or otherwise check that Init is only
+// called once. For best results call Init() from the Objective-C class's
+// designated initializer.
+//
+// Note that DelayedConstructor makes no guarantees about the state of the
+// storage backing it before Init() is called. However, Objective-C objects are
+// zero filled during allocation, so as a member of an Objective-C object, the
+// default state will be zero-filled.
+//
+// Normally this doesn't matter, but DelayedConstructor unconditionally invokes
+// T's destructor, even if you don't call Init(). This may cause problems in
+// Objective-C classes where the initializer is designed to return an instance
+// other than self. It's best to avoid such instance switching techniques in
+// combination with DelayedConstructor, but it is possible: either ensure that
+// T's destructor handles the zero-filled case correctly, or call Init() before
+// switching instances.
+template <typename T>
+class DelayedConstructor {
+ public:
+  typedef T element_type;
+
+  /**
+   * Default constructor does nothing.
+   */
+  DelayedConstructor() {
+  }
+
+  /**
+   * Forwards arguments to the T's constructor: calls T(args...).
+   *
+   * This overload is disabled when it might collide with copy/move.
+   */
+  template <typename... Ts,
+            typename std::enable_if<
+                !std::is_same<void(typename std::decay<Ts>::type...),
+                              void(DelayedConstructor)>::value,
+                int>::type = 0>
+  void Init(Ts&&... args) {
+    new (&space_) T(std::forward<Ts>(args)...);
+  }
+
+  /**
+   * Forwards copy and move construction for T.
+   */
+  void Init(const T& x) {
+    new (&space_) T(x);
+  }
+  void Init(T&& x) {
+    new (&space_) T(std::move(x));
+  }
+
+  // No copying.
+  DelayedConstructor(const DelayedConstructor&) = delete;
+  DelayedConstructor& operator=(const DelayedConstructor&) = delete;
+
+  ~DelayedConstructor() {
+    get()->~T();
+  }
+
+  // Pretend to be a smart pointer to T.
+  T& operator*() {
+    return *get();
+  }
+  T* operator->() {
+    return get();
+  }
+  T* get() {
+    return reinterpret_cast<T*>(&space_);
+  }
+  const T& operator*() const {
+    return *get();
+  }
+  const T* operator->() const {
+    return get();
+  }
+  const T* get() const {
+    return reinterpret_cast<const T*>(&space_);
+  }
+
+ private:
+  typename std::aligned_storage<sizeof(T), alignof(T)>::type space_;
+};
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_DELAYED_CONSTRUCTOR_H_

--- a/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
@@ -150,6 +150,7 @@ cc_test(
     autoid_test.cc
     bits_test.cc
     comparison_test.cc
+    delayed_constructor_test.cc
     hashing_test.cc
     iterator_adaptors_test.cc
     ordered_code_test.cc

--- a/Firestore/core/test/firebase/firestore/util/delayed_constructor_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/delayed_constructor_test.cc
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/util/delayed_constructor.h"
+
+#include <string>
+
+#include "gtest/gtest.h"
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+TEST(DelayedConstructorTest, NoDefaultConstructor) {
+  static int constructed = 0;
+
+  struct NoDefault {
+    NoDefault() = delete;
+    NoDefault(const NoDefault&) = delete;
+
+    explicit NoDefault(int) {
+      constructed += 1;
+    }
+  };
+
+  DelayedConstructor<NoDefault> value;
+  EXPECT_EQ(0, constructed);
+
+  value.Init(0);
+  EXPECT_EQ(1, constructed);
+}
+
+TEST(DelayedConstructorTest, NonCopyableType) {
+  static int constructed = 0;
+
+  struct NonCopyable {
+    NonCopyable() {
+      constructed += 1;
+    }
+    NonCopyable(const NonCopyable&) = delete;
+  };
+
+  DelayedConstructor<NonCopyable> value;
+  EXPECT_EQ(0, constructed);
+
+  value.Init();
+  EXPECT_EQ(1, constructed);
+}
+
+TEST(DelayedConstructorTest, CopyableType) {
+  static int constructed = 0;
+
+  struct Copyable {
+    Copyable() = delete;
+    Copyable(const Copyable&) {
+      constructed += 1;
+    }
+
+    // Backdoor to construct a value without exposing a default constructor
+    explicit Copyable(int) {
+    }
+  };
+
+  DelayedConstructor<Copyable> value;
+  EXPECT_EQ(0, constructed);
+
+  value.Init(Copyable(0));
+  EXPECT_EQ(1, constructed);
+}
+
+TEST(DelayedConstructorTest, MoveOnlyType) {
+  static int constructed = 0;
+
+  struct MoveOnly {
+    MoveOnly() = delete;
+    MoveOnly(MoveOnly&&) {
+      constructed += 1;
+    }
+
+    // Backdoor to construct a value without exposing a default constructor
+    explicit MoveOnly(int) {
+    }
+  };
+
+  DelayedConstructor<MoveOnly> value;
+  EXPECT_EQ(0, constructed);
+
+  value.Init(MoveOnly(0));
+  EXPECT_EQ(1, constructed);
+}
+
+TEST(DelayedConstructorTest, CallsDestructor) {
+  static int constructed = 0;
+  static int destructed = 0;
+
+  struct Counter {
+    Counter() {
+      constructed += 1;
+    }
+
+    ~Counter() {
+      destructed += 1;
+    }
+  };
+
+  {
+    DelayedConstructor<Counter> value;
+    EXPECT_EQ(0, constructed);
+    EXPECT_EQ(0, destructed);
+
+    value.Init();
+    EXPECT_EQ(1, constructed);
+    EXPECT_EQ(0, destructed);
+  }
+
+  EXPECT_EQ(1, constructed);
+  EXPECT_EQ(1, destructed);
+}
+
+TEST(DelayedConstructorTest, SingleConstructorArg) {
+  DelayedConstructor<std::string> str;
+  str.Init("foo");
+
+  EXPECT_EQ(*str, std::string("foo"));
+}
+
+TEST(DelayedConstructorTest, MultipleConstructorArgs) {
+  DelayedConstructor<std::string> str;
+  str.Init(3, 'a');
+
+  EXPECT_EQ(*str, std::string("aaa"));
+}
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -203,7 +203,7 @@ fi
 
 # If there are changes to the Firestore project, ensure they're ordered
 # correctly to minimize conflicts.
-if ! git diff --quiet -- Firestore/Example/Firestore.xcodeproj; then
+if ! git diff --quiet "${START_SHA}" -- Firestore; then
   "${top_dir}/scripts/sync_project.rb"
   if ! git diff --quiet; then
     maybe_commit "sync_project.rb generated changes"


### PR DESCRIPTION
This is useful for embedding C++ objects of type `T` inside Objective-C objects when `T` has no default constructor or is not a movable type. It works by allocating space for T with `std::aligned_storage` and then adding an `Init()` method that uses placement new to later construct the object in the allocated space.

See class comments for more detail and restrictions.