### PR TITLE
[WIP] Firestore tvOS support

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -52,7 +52,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
 
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
   s.dependency 'FirebaseCore', '~> 5.2'
-  s.dependency 'gRPC-C++', '0.0.8-dev'
+  s.dependency 'gRPC-C++'
   s.dependency 'leveldb-library', '~> 1.20'
   s.dependency 'Protobuf', '~> 3.1'
   s.dependency 'nanopb', '~> 0.3.901'

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -18,6 +18,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
+  s.tvos.deployment_target = '11.0'
 
   s.cocoapods_version = '>= 1.4.0'
   s.static_framework = true
@@ -51,7 +52,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
 
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
   s.dependency 'FirebaseCore', '~> 5.2'
-  s.dependency 'gRPC-C++', '0.0.6'
+  s.dependency 'gRPC-C++', '0.0.8-dev'
   s.dependency 'leveldb-library', '~> 1.20'
   s.dependency 'Protobuf', '~> 3.1'
   s.dependency 'nanopb', '~> 0.3.901'

--- a/Firestore/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc
+++ b/Firestore/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc
@@ -150,9 +150,12 @@ static bool SetupAlternateStackOnce() {
   }
 #endif
 
+#if !TARGET_OS_TV
   if (sigaltstack(&sigstk, nullptr) != 0) {
     ABSL_RAW_LOG(FATAL, "sigaltstack() failed with errno=%d", errno);
   }
+#endif
+    
   return true;
 }
 

--- a/Firestore/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc
+++ b/Firestore/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc
@@ -150,12 +150,9 @@ static bool SetupAlternateStackOnce() {
   }
 #endif
 
-#if !TARGET_OS_TV
   if (sigaltstack(&sigstk, nullptr) != 0) {
     ABSL_RAW_LOG(FATAL, "sigaltstack() failed with errno=%d", errno);
   }
-#endif
-    
   return true;
 }
 


### PR DESCRIPTION
As discussed in #10 this enables Firestore to work on tvOS. It requires the latest dev versions of gRPC-C++ & gRPC-Core which is why I've marked it as WIP. 

I've been able to successfully use Firestore on tvOS by pointing both gRPC-C++ & gRPC-Core pods to the grpc repo. We can reintroduce the version within the podspec once those versions are released.

I haven't looked at what is required for the FirestoreSwift pod yet.