### PR TITLE
Add xcgmock

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -328,7 +328,7 @@
 		3C81DE3772628FE297055662 /* Pods-Firestore_Example_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_iOS/Pods-Firestore_Example_iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		3F0992A4B83C60841C52E960 /* Pods-Firestore_Example_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_iOS/Pods-Firestore_Example_iOS.release.xcconfig"; sourceTree = "<group>"; };
 		403DBF6EFB541DFD01582AA3 /* path_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = path_test.cc; sourceTree = "<group>"; };
-		4425A513895DEC60325A139E /* xcgmock_test.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = xcgmock_test.mm; sourceTree = "<group>"; };
+		4425A513895DEC60325A139E /* xcgmock_test.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; path = xcgmock_test.mm; sourceTree = "<group>"; };
 		444B7AB3F5A2929070CB1363 /* hard_assert_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = hard_assert_test.cc; sourceTree = "<group>"; };
 		54131E9620ADE678001DF3FF /* string_format_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_format_test.cc; sourceTree = "<group>"; };
 		544129D021C2DDC800EFB9CC /* query.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = query.pb.h; sourceTree = "<group>"; };
@@ -2678,12 +2678,12 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"${PODS_ROOT}/../../..\"",
+					"\"${PODS_ROOT}/../../../Firestore/Protos/cpp\"",
+					"\"${PODS_ROOT}/../../../Firestore/Protos/nanopb\"",
 					"\"${PODS_ROOT}/../../../Firestore/third_party/abseil-cpp\"",
 					"\"${PODS_ROOT}/GoogleTest/googlemock/include\"",
 					"\"${PODS_ROOT}/GoogleTest/googletest/include\"",
 					"\"${PODS_ROOT}/leveldb-library/include\"",
-					"\"${PODS_ROOT}/../../../Firestore/Protos/nanopb\"",
-					"\"${PODS_ROOT}/../../../Firestore/Protos/cpp\"",
 					"\"${PODS_ROOT}/ProtobufCpp/src\"",
 				);
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
@@ -2756,12 +2756,12 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"${PODS_ROOT}/../../..\"",
+					"\"${PODS_ROOT}/../../../Firestore/Protos/cpp\"",
+					"\"${PODS_ROOT}/../../../Firestore/Protos/nanopb\"",
 					"\"${PODS_ROOT}/../../../Firestore/third_party/abseil-cpp\"",
 					"\"${PODS_ROOT}/GoogleTest/googlemock/include\"",
 					"\"${PODS_ROOT}/GoogleTest/googletest/include\"",
 					"\"${PODS_ROOT}/leveldb-library/include\"",
-					"\"${PODS_ROOT}/../../../Firestore/Protos/nanopb\"",
-					"\"${PODS_ROOT}/../../../Firestore/Protos/cpp\"",
 					"\"${PODS_ROOT}/ProtobufCpp/src\"",
 				);
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
@@ -3052,8 +3052,9 @@
 					"$(inherited)",
 					"\"${PODS_ROOT}/../../..\"",
 					"\"${PODS_ROOT}/../../../Firestore/third_party/abseil-cpp\"",
-					"\"${PODS_ROOT}/leveldb-library/include\"",
+					"\"${PODS_ROOT}/GoogleTest/googlemock/include\"",
 					"\"${PODS_ROOT}/GoogleTest/googletest/include\"",
+					"\"${PODS_ROOT}/leveldb-library/include\"",
 				);
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
 				OTHER_LDFLAGS = (
@@ -3089,8 +3090,9 @@
 					"$(inherited)",
 					"\"${PODS_ROOT}/../../..\"",
 					"\"${PODS_ROOT}/../../../Firestore/third_party/abseil-cpp\"",
-					"\"${PODS_ROOT}/leveldb-library/include\"",
+					"\"${PODS_ROOT}/GoogleTest/googlemock/include\"",
 					"\"${PODS_ROOT}/GoogleTest/googletest/include\"",
+					"\"${PODS_ROOT}/leveldb-library/include\"",
 				);
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
 				OTHER_LDFLAGS = (

--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		36FD4CE79613D18BC783C55B /* string_apple_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0EE5300F8233D14025EF0456 /* string_apple_test.mm */; };
 		3B843E4C1F3A182900548890 /* remote_store_spec_test.json in Resources */ = {isa = PBXBuildFile; fileRef = 3B843E4A1F3930A400548890 /* remote_store_spec_test.json */; };
 		4AA4ABE36065DB79CD76DD8D /* Pods_Firestore_Benchmarks_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F694C3CE4B77B3C0FA4BBA53 /* Pods_Firestore_Benchmarks_iOS.framework */; };
+		4D1F46B2DD91198C8867C04C /* xcgmock_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4425A513895DEC60325A139E /* xcgmock_test.mm */; };
 		54131E9720ADE679001DF3FF /* string_format_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54131E9620ADE678001DF3FF /* string_format_test.cc */; };
 		544129DA21C2DDC800EFB9CC /* common.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 544129D221C2DDC800EFB9CC /* common.pb.cc */; };
 		544129DB21C2DDC800EFB9CC /* firestore.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 544129D421C2DDC800EFB9CC /* firestore.pb.cc */; };
@@ -181,6 +182,7 @@
 		84DBE646DCB49305879D3500 /* nanopb_string_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 353EEE078EF3F39A9B7279F6 /* nanopb_string_test.cc */; };
 		873B8AEB1B1F5CCA007FD442 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 873B8AEA1B1F5CCA007FD442 /* Main.storyboard */; };
 		8C82D4D3F9AB63E79CC52DC8 /* Pods_Firestore_IntegrationTests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ECEBABC7E7B693BE808A1052 /* Pods_Firestore_IntegrationTests_iOS.framework */; };
+		9794E074439ABE5457E60F35 /* xcgmock_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4425A513895DEC60325A139E /* xcgmock_test.mm */; };
 		AB356EF7200EA5EB0089B766 /* field_value_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = AB356EF6200EA5EB0089B766 /* field_value_test.cc */; };
 		AB380CFB2019388600D97691 /* target_id_generator_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = AB380CF82019382300D97691 /* target_id_generator_test.cc */; };
 		AB380CFE201A2F4500D97691 /* string_util_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = AB380CFC201A2EE200D97691 /* string_util_test.cc */; };
@@ -325,6 +327,7 @@
 		3C81DE3772628FE297055662 /* Pods-Firestore_Example_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_iOS/Pods-Firestore_Example_iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		3F0992A4B83C60841C52E960 /* Pods-Firestore_Example_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_iOS/Pods-Firestore_Example_iOS.release.xcconfig"; sourceTree = "<group>"; };
 		403DBF6EFB541DFD01582AA3 /* path_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = path_test.cc; sourceTree = "<group>"; };
+		4425A513895DEC60325A139E /* xcgmock_test.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = xcgmock_test.mm; sourceTree = "<group>"; };
 		444B7AB3F5A2929070CB1363 /* hard_assert_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = hard_assert_test.cc; sourceTree = "<group>"; };
 		54131E9620ADE678001DF3FF /* string_format_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_format_test.cc; sourceTree = "<group>"; };
 		544129D021C2DDC800EFB9CC /* query.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = query.pb.h; sourceTree = "<group>"; };
@@ -558,6 +561,7 @@
 		B6FB468A208F9B9100554BA2 /* executor_test.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = executor_test.h; sourceTree = "<group>"; };
 		B79CA87A1A01FC5329031C9B /* Pods_Firestore_FuzzTests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Firestore_FuzzTests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B9C261C26C5D311E1E3C0CB9 /* query_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = query_test.cc; sourceTree = "<group>"; };
+		BA6E5B9D53CCF301F58A62D7 /* xcgmock.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = xcgmock.h; sourceTree = "<group>"; };
 		BB92EB03E3F92485023F64ED /* Pods_Firestore_Example_iOS_Firestore_SwiftTests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Firestore_Example_iOS_Firestore_SwiftTests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C8522DE226C467C54E6788D8 /* mutation_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = mutation_test.cc; sourceTree = "<group>"; };
 		D3CC3DC5338DCAF43A211155 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
@@ -713,6 +717,8 @@
 				5467FB07203E6A44009C9584 /* app_testing.mm */,
 				54A0352820A3B3BD003E0143 /* testutil.cc */,
 				54A0352920A3B3BD003E0143 /* testutil.h */,
+				BA6E5B9D53CCF301F58A62D7 /* xcgmock.h */,
+				4425A513895DEC60325A139E /* xcgmock_test.mm */,
 			);
 			path = testutil;
 			sourceTree = "<group>";
@@ -2134,6 +2140,7 @@
 				ABC1D7DE2023A05300BA84F0 /* user_test.cc in Sources */,
 				B68FC0E521F6848700A7055C /* watch_change_test.mm in Sources */,
 				544129DE21C2DDC800EFB9CC /* write.pb.cc in Sources */,
+				9794E074439ABE5457E60F35 /* xcgmock_test.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2181,6 +2188,7 @@
 				5492E0442021457E00B64F25 /* XCTestCase+Await.mm in Sources */,
 				EBFC611B1BF195D0EC710AF4 /* app_testing.mm in Sources */,
 				CA989C0E6020C372A62B7062 /* testutil.cc in Sources */,
+				4D1F46B2DD91198C8867C04C /* xcgmock_test.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Firestore/Example/Tests/Core/FSTQueryListenerTests.mm
+++ b/Firestore/Example/Tests/Core/FSTQueryListenerTests.mm
@@ -36,6 +36,7 @@
 #include "Firestore/core/src/firebase/firestore/util/executor_libdispatch.h"
 #include "Firestore/core/src/firebase/firestore/util/status.h"
 #include "Firestore/core/src/firebase/firestore/util/statusor.h"
+#include "Firestore/core/test/firebase/firestore/testutil/xcgmock.h"
 #include "absl/memory/memory.h"
 
 using firebase::firestore::FirestoreErrorCode;
@@ -48,8 +49,30 @@ using firebase::firestore::remote::TargetChange;
 using firebase::firestore::util::ExecutorLibdispatch;
 using firebase::firestore::util::Status;
 using firebase::firestore::util::StatusOr;
+using testing::ElementsAre;
+using testing::IsEmpty;
 
 NS_ASSUME_NONNULL_BEGIN
+
+namespace {
+
+/**
+ * Returns a copy of the given snapshot, with excludesMetadataChanges set to true.
+ */
+ViewSnapshot ExcludingMetadataChanges(const ViewSnapshot &snapshot) {
+  return ViewSnapshot{
+      snapshot.query(),
+      snapshot.documents(),
+      snapshot.old_documents(),
+      snapshot.document_changes(),
+      snapshot.mutated_keys(),
+      snapshot.from_cache(),
+      snapshot.sync_state_changed(),
+      true,
+  };
+}
+
+}  // namespace
 
 @interface FSTQueryListenerTests : XCTestCase
 @end
@@ -67,20 +90,6 @@ NS_ASSUME_NONNULL_BEGIN
   _includeMetadataChanges = [[FSTListenOptions alloc] initWithIncludeQueryMetadataChanges:YES
                                                            includeDocumentMetadataChanges:YES
                                                                     waitForSyncWhenOnline:NO];
-}
-
-- (ViewSnapshot)setExcludesMetadataChanges:(bool)excludesMetadataChanges
-                                  snapshot:(const ViewSnapshot &)snapshot {
-  return ViewSnapshot{
-      snapshot.query(),
-      snapshot.documents(),
-      snapshot.old_documents(),
-      snapshot.document_changes(),
-      snapshot.mutated_keys(),
-      snapshot.from_cache(),
-      snapshot.sync_state_changed(),
-      excludesMetadataChanges,
-  };
 }
 
 - (void)testRaisesCollectionEvents {
@@ -111,9 +120,9 @@ NS_ASSUME_NONNULL_BEGIN
   [listener queryDidChangeViewSnapshot:snap2];
   [otherListener queryDidChangeViewSnapshot:snap2];
 
-  XCTAssertTrue((accum == std::vector<ViewSnapshot>{snap1, snap2}));
-  XCTAssertTrue((accum[0].document_changes() == std::vector<DocumentViewChange>{change1, change2}));
-  XCTAssertTrue(accum[1].document_changes() == std::vector<DocumentViewChange>{change3});
+  XC_ASSERT_THAT(accum, ElementsAre(snap1, snap2));
+  XC_ASSERT_THAT(accum[0].document_changes(), ElementsAre(change1, change2));
+  XC_ASSERT_THAT(accum[1].document_changes(), ElementsAre(change3));
 
   ViewSnapshot expectedSnap2{
       snap2.query(),
@@ -124,7 +133,7 @@ NS_ASSUME_NONNULL_BEGIN
       snap2.from_cache(),
       /*sync_state_changed=*/true,
       /*excludes_metadata_changes=*/true};
-  XCTAssertTrue((otherAccum == std::vector<ViewSnapshot>{expectedSnap2}));
+  XC_ASSERT_THAT(otherAccum, ElementsAre(expectedSnap2));
 }
 
 - (void)testRaisesErrorEvent {
@@ -139,7 +148,7 @@ NS_ASSUME_NONNULL_BEGIN
   Status testError{FirestoreErrorCode::Unauthenticated, "Some info"};
   [listener queryDidError:testError];
 
-  XCTAssertTrue((accum == std::vector<Status>{testError}));
+  XC_ASSERT_THAT(accum, ElementsAre(testError));
 }
 
 - (void)testRaisesEventForEmptyCollectionAfterSync {
@@ -155,10 +164,10 @@ NS_ASSUME_NONNULL_BEGIN
   ViewSnapshot snap2 = FSTTestApplyChanges(view, @[], FSTTestTargetChangeMarkCurrent()).value();
 
   [listener queryDidChangeViewSnapshot:snap1];
-  XCTAssertTrue(accum.empty());
+  XC_ASSERT_THAT(accum, IsEmpty());
 
   [listener queryDidChangeViewSnapshot:snap2];
-  XCTAssertTrue((accum == std::vector<ViewSnapshot>{snap2}));
+  XC_ASSERT_THAT(accum, ElementsAre(snap2));
 }
 
 - (void)testMutingAsyncListenerPreventsAllSubsequentEvents {
@@ -195,7 +204,7 @@ NS_ASSUME_NONNULL_BEGIN
                                }];
 
   // We should get the first snapshot but not the second.
-  XCTAssertTrue((accum == std::vector<ViewSnapshot>{viewSnapshot1}));
+  XC_ASSERT_THAT(accum, ElementsAre(viewSnapshot1));
 }
 
 - (void)testDoesNotRaiseEventsForMetadataChangesUnlessSpecified {
@@ -227,10 +236,9 @@ NS_ASSUME_NONNULL_BEGIN
   [fullListener queryDidChangeViewSnapshot:snap2];  // state change event
   [fullListener queryDidChangeViewSnapshot:snap3];  // doc2 update
 
-  XCTAssertTrue((filteredAccum ==
-                 std::vector<ViewSnapshot>{[self setExcludesMetadataChanges:true snapshot:snap1],
-                                           [self setExcludesMetadataChanges:true snapshot:snap3]}));
-  XCTAssertTrue((fullAccum == std::vector<ViewSnapshot>{snap1, snap2, snap3}));
+  XC_ASSERT_THAT(filteredAccum,
+                 ElementsAre(ExcludingMetadataChanges(snap1), ExcludingMetadataChanges(snap3)));
+  XC_ASSERT_THAT(fullAccum, ElementsAre(snap1, snap2, snap3));
 }
 
 - (void)testRaisesDocumentMetadataEventsOnlyWhenSpecified {
@@ -272,18 +280,15 @@ NS_ASSUME_NONNULL_BEGIN
   [fullListener queryDidChangeViewSnapshot:snap2];
   [fullListener queryDidChangeViewSnapshot:snap3];
 
-  XCTAssertTrue((filteredAccum ==
-                 std::vector<ViewSnapshot>{[self setExcludesMetadataChanges:true snapshot:snap1],
-                                           [self setExcludesMetadataChanges:true snapshot:snap3]}));
-  XCTAssertTrue(
-      (filteredAccum[0].document_changes() == std::vector<DocumentViewChange>{change1, change2}));
-  XCTAssertTrue((filteredAccum[1].document_changes() == std::vector<DocumentViewChange>{change4}));
+  XC_ASSERT_THAT(filteredAccum,
+                 ElementsAre(ExcludingMetadataChanges(snap1), ExcludingMetadataChanges(snap3)));
+  XC_ASSERT_THAT(filteredAccum[0].document_changes(), ElementsAre(change1, change2));
+  XC_ASSERT_THAT(filteredAccum[1].document_changes(), ElementsAre(change4));
 
-  XCTAssertTrue((fullAccum == std::vector<ViewSnapshot>{snap1, snap2, snap3}));
-  XCTAssertTrue(
-      (fullAccum[0].document_changes() == std::vector<DocumentViewChange>{change1, change2}));
-  XCTAssertTrue((fullAccum[1].document_changes() == std::vector<DocumentViewChange>{change3}));
-  XCTAssertTrue((fullAccum[2].document_changes() == std::vector<DocumentViewChange>{change4}));
+  XC_ASSERT_THAT(fullAccum, ElementsAre(snap1, snap2, snap3));
+  XC_ASSERT_THAT(fullAccum[0].document_changes(), ElementsAre(change1, change2));
+  XC_ASSERT_THAT(fullAccum[1].document_changes(), ElementsAre(change3));
+  XC_ASSERT_THAT(fullAccum[2].document_changes(), ElementsAre(change4));
 }
 
 - (void)testRaisesQueryMetadataEventsOnlyWhenHasPendingWritesOnTheQueryChanges {
@@ -328,10 +333,9 @@ NS_ASSUME_NONNULL_BEGIN
       snap4.sync_state_changed(),
       /*excludes_metadata_changes=*/true  // This test excludes document metadata changes
   };
-  XCTAssertTrue(
-      (fullAccum == std::vector<ViewSnapshot>{[self setExcludesMetadataChanges:true snapshot:snap1],
-                                              [self setExcludesMetadataChanges:true snapshot:snap3],
-                                              expectedSnap4}));
+
+  XC_ASSERT_THAT(fullAccum, ElementsAre(ExcludingMetadataChanges(snap1),
+                                        ExcludingMetadataChanges(snap3), expectedSnap4));
 }
 
 - (void)testMetadataOnlyDocumentChangesAreFilteredOutWhenIncludeDocumentMetadataChangesIsFalse {
@@ -365,9 +369,7 @@ NS_ASSUME_NONNULL_BEGIN
                              snap2.from_cache(),
                              snap2.sync_state_changed(),
                              /*excludes_metadata_changes=*/true};
-  XCTAssertTrue((filteredAccum == std::vector<ViewSnapshot>{[self setExcludesMetadataChanges:true
-                                                                                    snapshot:snap1],
-                                                            expectedSnap2}));
+  XC_ASSERT_THAT(filteredAccum, ElementsAre(ExcludingMetadataChanges(snap1), expectedSnap2));
 }
 
 - (void)testWillWaitForSyncIfOnline {
@@ -407,7 +409,7 @@ NS_ASSUME_NONNULL_BEGIN
       /*from_cache=*/false,
       /*sync_state_changed=*/true,
       /*excludes_metadata_changes=*/true};
-  XCTAssertTrue((events == std::vector<ViewSnapshot>{expectedSnap}));
+  XC_ASSERT_THAT(events, ElementsAre(expectedSnap));
 }
 
 - (void)testWillRaiseInitialEventWhenGoingOffline {
@@ -454,7 +456,7 @@ NS_ASSUME_NONNULL_BEGIN
                              /*from_cache=*/true,
                              /*sync_state_changed=*/false,
                              /*excludes_metadata_changes=*/true};
-  XCTAssertTrue((events == std::vector<ViewSnapshot>{expectedSnap1, expectedSnap2}));
+  XC_ASSERT_THAT(events, ElementsAre(expectedSnap1, expectedSnap2));
 }
 
 - (void)testWillRaiseInitialEventWhenGoingOfflineAndThereAreNoDocs {
@@ -481,7 +483,7 @@ NS_ASSUME_NONNULL_BEGIN
       /*from_cache=*/true,
       /*sync_state_changed=*/true,
       /*excludes_metadata_changes=*/true};
-  XCTAssertTrue((events == std::vector<ViewSnapshot>{expectedSnap}));
+  XC_ASSERT_THAT(events, ElementsAre(expectedSnap));
 }
 
 - (void)testWillRaiseInitialEventWhenStartingOfflineAndThereAreNoDocs {
@@ -507,7 +509,7 @@ NS_ASSUME_NONNULL_BEGIN
       /*from_cache=*/true,
       /*sync_state_changed=*/true,
       /*excludes_metadata_changes=*/true};
-  XCTAssertTrue((events == std::vector<ViewSnapshot>{expectedSnap}));
+  XC_ASSERT_THAT(events, ElementsAre(expectedSnap));
 }
 
 - (FSTQueryListener *)listenToQuery:(FSTQuery *)query handler:(ViewSnapshotHandler &&)handler {

--- a/Firestore/Example/Tests/Core/FSTQueryListenerTests.mm
+++ b/Firestore/Example/Tests/Core/FSTQueryListenerTests.mm
@@ -56,9 +56,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 namespace {
 
-/**
- * Returns a copy of the given snapshot, with excludesMetadataChanges set to true.
- */
 ViewSnapshot ExcludingMetadataChanges(const ViewSnapshot &snapshot) {
   return ViewSnapshot{
       snapshot.query(),
@@ -68,7 +65,7 @@ ViewSnapshot ExcludingMetadataChanges(const ViewSnapshot &snapshot) {
       snapshot.mutated_keys(),
       snapshot.from_cache(),
       snapshot.sync_state_changed(),
-      true,
+      /*excludes_metadata_changes=*/true,
   };
 }
 

--- a/Firestore/Example/Tests/Core/FSTViewTests.mm
+++ b/Firestore/Example/Tests/Core/FSTViewTests.mm
@@ -32,6 +32,7 @@
 #include "Firestore/core/src/firebase/firestore/core/view_snapshot.h"
 #include "Firestore/core/src/firebase/firestore/model/resource_path.h"
 #include "Firestore/core/test/firebase/firestore/testutil/testutil.h"
+#include "Firestore/core/test/firebase/firestore/testutil/xcgmock.h"
 #include "absl/types/optional.h"
 
 namespace testutil = firebase::firestore::testutil;
@@ -39,6 +40,7 @@ using firebase::firestore::core::DocumentViewChange;
 using firebase::firestore::core::ViewSnapshot;
 using firebase::firestore::model::ResourcePath;
 using firebase::firestore::model::DocumentKeySet;
+using testing::ElementsAre;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -217,11 +219,10 @@ NS_ASSUME_NONNULL_BEGIN
 
   XCTAssertEqualObjects(snapshot.documents().arrayValue, (@[ newDoc4, doc1, newDoc2 ]));
 
-  XCTAssertTrue((snapshot.document_changes() ==
-                 std::vector<DocumentViewChange>{
-                     DocumentViewChange{doc3, DocumentViewChange::Type::kRemoved},
-                     DocumentViewChange{newDoc4, DocumentViewChange::Type::kAdded},
-                     DocumentViewChange{newDoc2, DocumentViewChange::Type::kAdded}}));
+  XC_ASSERT_THAT(snapshot.document_changes(),
+                 ElementsAre(DocumentViewChange{doc3, DocumentViewChange::Type::kRemoved},
+                             DocumentViewChange{newDoc4, DocumentViewChange::Type::kAdded},
+                             DocumentViewChange{newDoc2, DocumentViewChange::Type::kAdded}));
 
   XCTAssertTrue(snapshot.from_cache());
   XCTAssertFalse(snapshot.sync_state_changed());
@@ -303,11 +304,9 @@ NS_ASSUME_NONNULL_BEGIN
 
   XCTAssertEqualObjects(snapshot.documents().arrayValue, (@[ doc1, doc3 ]));
 
-  XCTAssertTrue((snapshot.document_changes() ==
-                 std::vector<DocumentViewChange>{
-                     DocumentViewChange{doc2, DocumentViewChange::Type::kRemoved},
-                     DocumentViewChange{doc3, DocumentViewChange::Type::kAdded},
-                 }));
+  XC_ASSERT_THAT(snapshot.document_changes(),
+                 ElementsAre(DocumentViewChange{doc2, DocumentViewChange::Type::kRemoved},
+                             DocumentViewChange{doc3, DocumentViewChange::Type::kAdded}));
 
   XCTAssertFalse(snapshot.from_cache());
   XCTAssertTrue(snapshot.sync_state_changed());
@@ -694,28 +693,24 @@ NS_ASSUME_NONNULL_BEGIN
       [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc1, doc2 ])];
   FSTViewChange *viewChange = [view applyChangesToDocuments:changes];
 
-  XCTAssertTrue((viewChange.snapshot.value().document_changes() ==
-                 std::vector<DocumentViewChange>{
-                     DocumentViewChange{doc1, DocumentViewChange::Type::kAdded},
-                     DocumentViewChange{doc2, DocumentViewChange::Type::kAdded},
-                 }));
+  XC_ASSERT_THAT(viewChange.snapshot.value().document_changes(),
+                 ElementsAre(DocumentViewChange{doc1, DocumentViewChange::Type::kAdded},
+                             DocumentViewChange{doc2, DocumentViewChange::Type::kAdded}));
 
   changes = [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc1Committed, doc2Modified ])];
   viewChange = [view applyChangesToDocuments:changes];
   // The 'doc1Committed' update is suppressed
-  XCTAssertTrue((viewChange.snapshot.value().document_changes() ==
-                 std::vector<DocumentViewChange>{
-                     DocumentViewChange{doc2Modified, DocumentViewChange::Type::kModified},
-                 }));
+  XC_ASSERT_THAT(
+      viewChange.snapshot.value().document_changes(),
+      ElementsAre(DocumentViewChange{doc2Modified, DocumentViewChange::Type::kModified}));
 
   changes =
       [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc1Acknowledged, doc2Acknowledged ])];
   viewChange = [view applyChangesToDocuments:changes];
-  XCTAssertTrue((viewChange.snapshot.value().document_changes() ==
-                 std::vector<DocumentViewChange>{
-                     DocumentViewChange{doc1Acknowledged, DocumentViewChange::Type::kModified},
-                     DocumentViewChange{doc2Acknowledged, DocumentViewChange::Type::kMetadata},
-                 }));
+  XC_ASSERT_THAT(
+      viewChange.snapshot.value().document_changes(),
+      ElementsAre(DocumentViewChange{doc1Acknowledged, DocumentViewChange::Type::kModified},
+                  DocumentViewChange{doc2Acknowledged, DocumentViewChange::Type::kMetadata}));
 }
 
 @end

--- a/Firestore/core/include/firebase/firestore/timestamp.h
+++ b/Firestore/core/include/firebase/firestore/timestamp.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <ctime>
+#include <iosfwd>
 #include <string>
 
 #if !defined(_STLPORT_VERSION)
@@ -148,6 +149,8 @@ class Timestamp {
    * don't rely on the format of the string.
    */
   std::string ToString() const;
+  friend std::ostream& operator<<(std::ostream& out,
+                                  const Timestamp& timestamp);
 
  private:
   // Checks that the number of seconds is within the supported date range, and

--- a/Firestore/core/src/firebase/firestore/core/view_snapshot.h
+++ b/Firestore/core/src/firebase/firestore/core/view_snapshot.h
@@ -22,6 +22,7 @@
 #endif  // !defined(__OBJC__)
 
 #include <functional>
+#include <iosfwd>
 #include <string>
 #include <utility>
 #include <vector>
@@ -177,6 +178,7 @@ class ViewSnapshot {
   }
 
   std::string ToString() const;
+  friend std::ostream& operator<<(std::ostream& out, const ViewSnapshot& value);
   size_t Hash() const;
 
  private:

--- a/Firestore/core/src/firebase/firestore/core/view_snapshot.mm
+++ b/Firestore/core/src/firebase/firestore/core/view_snapshot.mm
@@ -16,6 +16,8 @@
 
 #include "Firestore/core/src/firebase/firestore/core/view_snapshot.h"
 
+#include <ostream>
+
 #import "Firestore/Source/Core/FSTQuery.h"
 #import "Firestore/Source/Model/FSTDocument.h"
 #import "Firestore/Source/Model/FSTDocumentSet.h"
@@ -176,6 +178,10 @@ std::string ViewSnapshot::ToString() const {
       query(), documents(), old_documents(),
       objc::Description(document_changes()), from_cache(),
       mutated_keys().size(), sync_state_changed(), excludes_metadata_changes());
+}
+
+std::ostream& operator<<(std::ostream& out, const ViewSnapshot& value) {
+  return out << value.ToString();
 }
 
 size_t ViewSnapshot::Hash() const {

--- a/Firestore/core/src/firebase/firestore/timestamp.cc
+++ b/Firestore/core/src/firebase/firestore/timestamp.cc
@@ -90,8 +90,7 @@ std::string Timestamp::ToString() const {
 }
 
 std::ostream& operator<<(std::ostream& out, const Timestamp& timestamp) {
-  out << timestamp.ToString();
-  return out;
+  return out << timestamp.ToString();
 }
 
 void Timestamp::ValidateBounds() const {

--- a/Firestore/core/src/firebase/firestore/timestamp.cc
+++ b/Firestore/core/src/firebase/firestore/timestamp.cc
@@ -17,6 +17,7 @@
 #include "Firestore/core/include/firebase/firestore/timestamp.h"
 
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
+#include "absl/strings/str_cat.h"
 
 namespace firebase {
 
@@ -84,8 +85,13 @@ Timestamp Timestamp::FromTimePoint(
 #endif  // !defined(_STLPORT_VERSION)
 
 std::string Timestamp::ToString() const {
-  return std::string("Timestamp(seconds=") + std::to_string(seconds_) +
-         ", nanoseconds=" + std::to_string(nanoseconds_) + ")";
+  return absl::StrCat("Timestamp(seconds=", seconds_,
+                      ", nanoseconds=", nanoseconds_, ")");
+}
+
+std::ostream& operator<<(std::ostream& out, const Timestamp& timestamp) {
+  out << timestamp.ToString();
+  return out;
 }
 
 void Timestamp::ValidateBounds() const {

--- a/Firestore/core/src/firebase/firestore/util/status.cc
+++ b/Firestore/core/src/firebase/firestore/util/status.cc
@@ -127,6 +127,11 @@ std::string Status::ToString() const {
   }
 }
 
+std::ostream& operator<<(std::ostream& out, const Status& status) {
+  out << status.ToString();
+  return out;
+}
+
 void Status::IgnoreError() const {
   // no-op
 }

--- a/Firestore/core/src/firebase/firestore/util/status.h
+++ b/Firestore/core/src/firebase/firestore/util/status.h
@@ -100,6 +100,7 @@ class ABSL_MUST_USE_RESULT Status {
   /// \brief Return a string representation of this status suitable for
   /// printing. Returns the string `"OK"` for success.
   std::string ToString() const;
+  friend std::ostream& operator<<(std::ostream& out, const Status& status);
 
   // Ignores any errors. This method does nothing except potentially suppress
   // complaints from any tools that are checking that errors are not dropped on

--- a/Firestore/core/test/firebase/firestore/testutil/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/testutil/CMakeLists.txt
@@ -17,6 +17,7 @@ cc_library(
   SOURCES
     app_testing.h
     app_testing.mm
+    xcgmock.h
   DEPENDS
     FirebaseCore
     GoogleUtilities

--- a/Firestore/core/test/firebase/firestore/testutil/xcgmock.h
+++ b/Firestore/core/test/firebase/firestore/testutil/xcgmock.h
@@ -77,8 +77,6 @@ XcTestRecorder<M> MakeXcTestRecorder(M matcher,
 
 #define XC_ASSERT_THAT(actual, matcher)                                \
   do {                                                                 \
-    using actual_type =                                                \
-        typename std::remove_reference<decltype(actual)>::type;        \
     auto recorder = firebase::firestore::testutil::MakeXcTestRecorder( \
         matcher, self, __FILE__, __LINE__);                            \
     recorder.Match(#actual, actual);                                   \
@@ -109,6 +107,7 @@ inline void ObjcPrintTo(id value, std::ostream* os) {
 // of `operator<<` would be sufficient.
 
 // Select Foundation types
+OBJC_PRINT_TO(NSObject);
 OBJC_PRINT_TO(NSArray);
 OBJC_PRINT_TO(NSDictionary);
 OBJC_PRINT_TO(NSNumber);

--- a/Firestore/core/test/firebase/firestore/testutil/xcgmock.h
+++ b/Firestore/core/test/firebase/firestore/testutil/xcgmock.h
@@ -17,6 +17,10 @@
 #ifndef FIRESTORE_CORE_TEST_FIREBASE_FIRESTORE_TESTUTIL_XCGMOCK_H_
 #define FIRESTORE_CORE_TEST_FIREBASE_FIRESTORE_TESTUTIL_XCGMOCK_H_
 
+#if !defined(__OBJC__)
+#error "This header only supports Objective-C++"
+#endif  // !defined(__OBJC__)
+
 #import <XCTest/XCTest.h>
 
 #include <iostream>

--- a/Firestore/core/test/firebase/firestore/testutil/xcgmock.h
+++ b/Firestore/core/test/firebase/firestore/testutil/xcgmock.h
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_TEST_FIREBASE_FIRESTORE_TESTUTIL_XCGMOCK_H_
+#define FIRESTORE_CORE_TEST_FIREBASE_FIRESTORE_TESTUTIL_XCGMOCK_H_
+
+#import <XCTest/XCTest.h>
+
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <utility>
+
+#import "Firestore/Source/Model/FSTDocument.h"
+
+#include "Firestore/core/src/firebase/firestore/util/string_apple.h"
+#include "gmock/gmock.h"
+
+namespace firebase {
+namespace firestore {
+namespace testutil {
+
+template <typename M>
+class XcTestRecorder {
+ public:
+  XcTestRecorder(M matcher, XCTestCase* test_case, const char* file, int line)
+      : formatter_(std::move(matcher)),
+        test_case_(test_case),
+        file_(file),
+        line_(line) {
+  }
+
+  template <typename T>
+  void Match(const char* text, const T& value) const {
+    testing::AssertionResult result = formatter_(text, value);
+    if (!result) {
+      RecordFailure(result.message());
+    }
+  }
+
+  void RecordFailure(const char* message) const {
+    [test_case_
+        recordFailureWithDescription:[NSString stringWithUTF8String:message]
+                              inFile:[NSString stringWithUTF8String:file_]
+                              atLine:line_
+                            expected:YES];
+  }
+
+ private:
+  testing::internal::PredicateFormatterFromMatcher<M> formatter_;
+
+  XCTestCase* test_case_;
+  const char* file_;
+  int line_;
+};
+
+template <typename M>
+XcTestRecorder<M> MakeXcTestRecorder(M matcher,
+                                     XCTestCase* test_case,
+                                     const char* file,
+                                     int line) {
+  return XcTestRecorder<M>(std::move(matcher), test_case, file, line);
+}
+
+#define XC_ASSERT_THAT(actual, matcher)                                \
+  do {                                                                 \
+    using actual_type =                                                \
+        typename std::remove_reference<decltype(actual)>::type;        \
+    auto recorder = firebase::firestore::testutil::MakeXcTestRecorder( \
+        matcher, self, __FILE__, __LINE__);                            \
+    recorder.Match(#actual, actual);                                   \
+  } while (0)
+
+/**
+ * Prints the -description of an Objective-C object to the given ostream.
+ */
+inline void ObjcPrintTo(id value, std::ostream* os) {
+  // Force the result type to NSString* or we can't resolve MakeString.
+  NSString* description = [value description];
+  *os << util::MakeString(description);
+}
+
+}  // namespace testutil
+}  // namespace firestore
+}  // namespace firebase
+
+#define OBJC_PRINT_TO(objc_class)                            \
+  @class objc_class;                                         \
+  inline void PrintTo(objc_class* value, std::ostream* os) { \
+    firebase::firestore::testutil::ObjcPrintTo(value, os);   \
+  }
+
+// Define overloads for Objective-C types. Note that each type must be
+// explicitly overloaded here because `id` cannot be implicitly converted to
+// void* under ARC. If `id` could be converted to void*, then a single overload
+// of `operator<<` would be sufficient.
+
+// Select Foundation types
+OBJC_PRINT_TO(NSArray);
+OBJC_PRINT_TO(NSDictionary);
+OBJC_PRINT_TO(NSNumber);
+OBJC_PRINT_TO(NSString);
+
+// Declare all Firestore Objective-C classes printable.
+//
+// Regenerate with:
+// find Firestore/Source -name \*.h \
+//   | xargs sed -n '/@interface/{ s/<.*//; p; }' \
+//   | awk '{ print "OBJC_PRINT_TO(" $2 ");" }' \
+//   | sort -u
+
+OBJC_PRINT_TO(FIRCollectionReference);
+OBJC_PRINT_TO(FIRDocumentChange);
+OBJC_PRINT_TO(FIRDocumentReference);
+OBJC_PRINT_TO(FIRDocumentSnapshot);
+OBJC_PRINT_TO(FIRFieldPath);
+OBJC_PRINT_TO(FIRFieldValue);
+OBJC_PRINT_TO(FIRFirestore);
+OBJC_PRINT_TO(FIRFirestoreSettings);
+OBJC_PRINT_TO(FIRGeoPoint);
+OBJC_PRINT_TO(FIRQuery);
+OBJC_PRINT_TO(FIRQueryDocumentSnapshot);
+OBJC_PRINT_TO(FIRQuerySnapshot);
+OBJC_PRINT_TO(FIRSnapshotMetadata);
+OBJC_PRINT_TO(FIRTimestamp);
+OBJC_PRINT_TO(FIRTransaction);
+OBJC_PRINT_TO(FIRWriteBatch);
+OBJC_PRINT_TO(FSTArrayRemoveFieldValue);
+OBJC_PRINT_TO(FSTArrayUnionFieldValue);
+OBJC_PRINT_TO(FSTArrayValue);
+OBJC_PRINT_TO(FSTAsyncQueryListener);
+OBJC_PRINT_TO(FSTBlobValue);
+OBJC_PRINT_TO(FSTBooleanValue);
+OBJC_PRINT_TO(FSTBound);
+OBJC_PRINT_TO(FSTDeleteFieldValue);
+OBJC_PRINT_TO(FSTDeleteMutation);
+OBJC_PRINT_TO(FSTDeletedDocument);
+OBJC_PRINT_TO(FSTDocument);
+OBJC_PRINT_TO(FSTDocumentKey);
+OBJC_PRINT_TO(FSTDocumentKeyReference);
+OBJC_PRINT_TO(FSTDocumentSet);
+OBJC_PRINT_TO(FSTDoubleValue);
+OBJC_PRINT_TO(FSTEventManager);
+OBJC_PRINT_TO(FSTFieldValue);
+OBJC_PRINT_TO(FSTFieldValueOptions);
+OBJC_PRINT_TO(FSTFilter);
+OBJC_PRINT_TO(FSTFirestoreClient);
+OBJC_PRINT_TO(FSTFirestoreComponent);
+OBJC_PRINT_TO(FSTGeoPointValue);
+OBJC_PRINT_TO(FSTIntegerValue);
+OBJC_PRINT_TO(FSTLRUGarbageCollector);
+OBJC_PRINT_TO(FSTLevelDB);
+OBJC_PRINT_TO(FSTLevelDBLRUDelegate);
+OBJC_PRINT_TO(FSTLimboDocumentChange);
+OBJC_PRINT_TO(FSTListenOptions);
+OBJC_PRINT_TO(FSTListenerRegistration);
+OBJC_PRINT_TO(FSTLocalDocumentsView);
+OBJC_PRINT_TO(FSTLocalSerializer);
+OBJC_PRINT_TO(FSTLocalStore);
+OBJC_PRINT_TO(FSTLocalViewChanges);
+OBJC_PRINT_TO(FSTLocalWriteResult);
+OBJC_PRINT_TO(FSTMaybeDocument);
+OBJC_PRINT_TO(FSTMemoryEagerReferenceDelegate);
+OBJC_PRINT_TO(FSTMemoryLRUReferenceDelegate);
+OBJC_PRINT_TO(FSTMemoryPersistence);
+OBJC_PRINT_TO(FSTMutation);
+OBJC_PRINT_TO(FSTMutationBatch);
+OBJC_PRINT_TO(FSTMutationBatchResult);
+OBJC_PRINT_TO(FSTMutationResult);
+OBJC_PRINT_TO(FSTNanFilter);
+OBJC_PRINT_TO(FSTNullFilter);
+OBJC_PRINT_TO(FSTNullValue);
+OBJC_PRINT_TO(FSTNumberValue);
+OBJC_PRINT_TO(FSTNumericIncrementFieldValue);
+OBJC_PRINT_TO(FSTObjectValue);
+OBJC_PRINT_TO(FSTPatchMutation);
+OBJC_PRINT_TO(FSTQuery);
+OBJC_PRINT_TO(FSTQueryData);
+OBJC_PRINT_TO(FSTQueryListener);
+OBJC_PRINT_TO(FSTReferenceValue);
+OBJC_PRINT_TO(FSTRelationFilter);
+OBJC_PRINT_TO(FSTSerializerBeta);
+OBJC_PRINT_TO(FSTServerTimestampFieldValue);
+OBJC_PRINT_TO(FSTServerTimestampValue);
+OBJC_PRINT_TO(FSTSetMutation);
+OBJC_PRINT_TO(FSTSortOrder);
+OBJC_PRINT_TO(FSTStringValue);
+OBJC_PRINT_TO(FSTSyncEngine);
+OBJC_PRINT_TO(FSTTimestampValue);
+OBJC_PRINT_TO(FSTTransformMutation);
+OBJC_PRINT_TO(FSTUnknownDocument);
+OBJC_PRINT_TO(FSTUserDataConverter);
+OBJC_PRINT_TO(FSTView);
+OBJC_PRINT_TO(FSTViewChange);
+OBJC_PRINT_TO(FSTViewDocumentChanges);
+
+#endif  // FIRESTORE_CORE_TEST_FIREBASE_FIRESTORE_TESTUTIL_XCGMOCK_H_

--- a/Firestore/core/test/firebase/firestore/testutil/xcgmock_test.mm
+++ b/Firestore/core/test/firebase/firestore/testutil/xcgmock_test.mm
@@ -19,17 +19,27 @@
 #import "Firestore/Source/Core/FSTQuery.h"
 
 #include "Firestore/core/src/firebase/firestore/util/status.h"
+#include "Firestore/core/src/firebase/firestore/util/to_string.h"
 #include "gtest/gtest.h"
 
 namespace firebase {
 namespace firestore {
 namespace testutil {
 
-TEST(XcGmockTest, FoundationPrints) {
-  EXPECT_EQ("value", testing::PrintToString(@"value"));
+TEST(XcGmockTest, NSArrayPrints) {
+  std::string expected = util::ToString(@[ @"value" ]);
 
-  std::string expected = util::MakeString([@[ @"value" ] description]);
   EXPECT_EQ(expected, testing::PrintToString(@[ @"value" ]));
+}
+
+TEST(XcGmockTest, NSNumberPrints) {
+  EXPECT_EQ("1", testing::PrintToString(@1));
+}
+
+// TODO(wilhuff): make this actually work!
+// For whatever reason, this prints like a pointer.
+TEST(XcGmockTest, DISABLED_NSStringPrints) {
+  EXPECT_EQ("value", testing::PrintToString(@"value"));
 }
 
 TEST(XcGmockTest, FSTNullFilterPrints) {

--- a/Firestore/core/test/firebase/firestore/testutil/xcgmock_test.mm
+++ b/Firestore/core/test/firebase/firestore/testutil/xcgmock_test.mm
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/test/firebase/firestore/testutil/xcgmock.h"
+
+#import "Firestore/Source/Core/FSTQuery.h"
+
+#include "Firestore/core/src/firebase/firestore/util/status.h"
+#include "gtest/gtest.h"
+
+namespace firebase {
+namespace firestore {
+namespace testutil {
+
+TEST(XcGmockTest, FoundationPrints) {
+  EXPECT_EQ("value", testing::PrintToString(@"value"));
+
+  std::string expected = util::MakeString([@[ @"value" ] description]);
+  EXPECT_EQ(expected, testing::PrintToString(@[ @"value" ]));
+}
+
+TEST(XcGmockTest, FSTNullFilterPrints) {
+  FSTNullFilter* filter =
+      [[FSTNullFilter alloc] initWithField:model::FieldPath({"field"})];
+  EXPECT_EQ("field IS NULL", testing::PrintToString(filter));
+}
+
+TEST(XcGmockTest, StatusPrints) {
+  util::Status status(FirestoreErrorCode::NotFound, "missing foo");
+  EXPECT_EQ("Not found: missing foo", testing::PrintToString(status));
+}
+
+TEST(XcGmockTest, TimestampPrints) {
+  Timestamp timestamp(32, 42);
+  EXPECT_EQ("Timestamp(seconds=32, nanoseconds=42)",
+            testing::PrintToString(timestamp));
+}
+
+}  // namespace testutil
+}  // namespace firestore
+}  // namespace firebase


### PR DESCRIPTION
This defines a means of using gmock matchers in XCTest tests.

This makes it easy to fix tests currently depending on e.g. `NSArray` values and `XCTAssertEqualObjects` to instead use something else. It's better to fix the test to

```c++
XC_ASSERT_THAT(accum, ElementsAre(viewSnapshot1));
```

Instead of:
```
XCTAssertEqual(accum, (std::vector<ViewSnapshot>(viewSnapshot1)));
```

... or the even worse:
```
XCTAssertTrue(accum == std::vector<ViewSnapshot>(viewSnapshot1));
```