### PR TITLE
b/62961699: Use :nodoc: to prevent methods from showing up in reference docs.

### DIFF
--- a/Firestore/Source/Public/FIRCollectionReference.h
+++ b/Firestore/Source/Public/FIRCollectionReference.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CollectionReference)
 @interface FIRCollectionReference : FIRQuery
 
-/**   */
+/** :nodoc: */
 - (id)init __attribute__((unavailable("FIRCollectionReference cannot be created directly.")));
 
 /** ID of the referenced collection. */

--- a/Firestore/Source/Public/FIRDocumentChange.h
+++ b/Firestore/Source/Public/FIRDocumentChange.h
@@ -40,7 +40,7 @@ typedef NS_ENUM(NSInteger, FIRDocumentChangeType) {
 NS_SWIFT_NAME(DocumentChange)
 @interface FIRDocumentChange : NSObject
 
-/**   */
+/** :nodoc: */
 - (id)init __attribute__((unavailable("FIRDocumentChange cannot be created directly.")));
 
 /** The type of change that occurred (added, modified, or removed). */

--- a/Firestore/Source/Public/FIRDocumentReference.h
+++ b/Firestore/Source/Public/FIRDocumentReference.h
@@ -37,7 +37,7 @@ typedef void (^FIRDocumentSnapshotBlock)(FIRDocumentSnapshot *_Nullable snapshot
 NS_SWIFT_NAME(DocumentReference)
 @interface FIRDocumentReference : NSObject
 
-/**   */
+/** :nodoc: */
 - (instancetype)init
     __attribute__((unavailable("FIRDocumentReference cannot be created directly.")));
 

--- a/Firestore/Source/Public/FIRDocumentSnapshot.h
+++ b/Firestore/Source/Public/FIRDocumentSnapshot.h
@@ -58,7 +58,7 @@ typedef NS_ENUM(NSInteger, FIRServerTimestampBehavior) {
 NS_SWIFT_NAME(DocumentSnapshot)
 @interface FIRDocumentSnapshot : NSObject
 
-/**   */
+/** :nodoc: */
 - (instancetype)init
     __attribute__((unavailable("FIRDocumentSnapshot cannot be created directly.")));
 
@@ -151,7 +151,7 @@ NS_SWIFT_NAME(DocumentSnapshot)
 NS_SWIFT_NAME(QueryDocumentSnapshot)
 @interface FIRQueryDocumentSnapshot : FIRDocumentSnapshot
 
-/**   */
+/** :nodoc: */
 - (instancetype)init
     __attribute__((unavailable("FIRQueryDocumentSnapshot cannot be created directly.")));
 

--- a/Firestore/Source/Public/FIRFieldValue.h
+++ b/Firestore/Source/Public/FIRFieldValue.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(FieldValue)
 @interface FIRFieldValue : NSObject
 
-/**   */
+/** :nodoc: */
 - (instancetype)init NS_UNAVAILABLE;
 
 /** Used with updateData() to mark a field for deletion. */

--- a/Firestore/Source/Public/FIRFirestore.h
+++ b/Firestore/Source/Public/FIRFirestore.h
@@ -34,7 +34,7 @@ NS_SWIFT_NAME(Firestore)
 @interface FIRFirestore : NSObject
 
 #pragma mark - Initializing
-/**   */
+/** :nodoc: */
 - (instancetype)init __attribute__((unavailable("Use a static constructor method.")));
 
 /**

--- a/Firestore/Source/Public/FIRGeoPoint.h
+++ b/Firestore/Source/Public/FIRGeoPoint.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(GeoPoint)
 @interface FIRGeoPoint : NSObject <NSCopying>
 
-/**   */
+/** :nodoc: */
 - (instancetype)init NS_UNAVAILABLE;
 
 /**

--- a/Firestore/Source/Public/FIRQuery.h
+++ b/Firestore/Source/Public/FIRQuery.h
@@ -35,7 +35,7 @@ typedef void (^FIRQuerySnapshotBlock)(FIRQuerySnapshot *_Nullable snapshot,
  */
 NS_SWIFT_NAME(Query)
 @interface FIRQuery : NSObject
-/**   */
+/** :nodoc: */
 - (id)init __attribute__((unavailable("FIRQuery cannot be created directly.")));
 
 /** The `FIRFirestore` for the Firestore database (useful for performing transactions, etc.). */

--- a/Firestore/Source/Public/FIRQuerySnapshot.h
+++ b/Firestore/Source/Public/FIRQuerySnapshot.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(QuerySnapshot)
 @interface FIRQuerySnapshot : NSObject
 
-/**   */
+/** :nodoc: */
 - (id)init __attribute__((unavailable("FIRQuerySnapshot cannot be created directly.")));
 
 /**

--- a/Firestore/Source/Public/FIRSnapshotMetadata.h
+++ b/Firestore/Source/Public/FIRSnapshotMetadata.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(SnapshotMetadata)
 @interface FIRSnapshotMetadata : NSObject
 
-/**   */
+/** :nodoc: */
 - (instancetype)init NS_UNAVAILABLE;
 
 /**

--- a/Firestore/Source/Public/FIRTimestamp.h
+++ b/Firestore/Source/Public/FIRTimestamp.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(Timestamp)
 @interface FIRTimestamp : NSObject <NSCopying>
 
-/** */
+/** :nodoc: */
 - (instancetype)init NS_UNAVAILABLE;
 
 /**

--- a/Firestore/Source/Public/FIRTransaction.h
+++ b/Firestore/Source/Public/FIRTransaction.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(Transaction)
 @interface FIRTransaction : NSObject
 
-/**   */
+/** :nodoc: */
 - (id)init __attribute__((unavailable("FIRTransaction cannot be created directly.")));
 
 /**


### PR DESCRIPTION
Better late than never!