### PR TITLE
GULLogger - count errors and warnigns

### DIFF
--- a/GoogleUtilities/Example/Tests/Logger/GULLoggerTest.m
+++ b/GoogleUtilities/Example/Tests/Logger/GULLoggerTest.m
@@ -32,6 +32,8 @@ extern dispatch_queue_t getGULClientQueue(void);
 
 extern BOOL getGULLoggerDebugMode(void);
 
+extern NSUserDefaults *getGULLoggerUsetDefaults(void);
+
 static NSString *const kMessageCode = @"I-COR000001";
 
 @interface GULLoggerTest : XCTestCase
@@ -151,6 +153,62 @@ static NSString *const kMessageCode = @"I-COR000001";
   XCTAssertEqual(GULLoggerLevelNotice, ASL_LEVEL_NOTICE);
   XCTAssertEqual(GULLoggerLevelInfo, ASL_LEVEL_INFO);
   XCTAssertEqual(GULLoggerLevelDebug, ASL_LEVEL_DEBUG);
+}
+
+- (void)testErrorNumberIncrement {
+  [getGULLoggerUsetDefaults() setInteger:10 forKey:kGULLoggerErrorCountKey];
+
+  GULLogError(@"my service", NO, kMessageCode, @"Message.");
+
+  XCTestExpectation *getErrorCountExpectation =
+      [self expectationWithDescription:@"getErrorCountExpectation"];
+
+  GULNumberOfErrorsLogged(^(NSInteger count){
+    [getErrorCountExpectation fulfill];
+    XCTAssertEqual(count, 11);
+  });
+
+  [self waitForExpectationsWithTimeout:0.5 handler:NULL];
+}
+
+- (void)testWarningNumberIncrement {
+  [getGULLoggerUsetDefaults() setInteger:5 forKey:kGULLoggerWarningCountKey];
+
+  GULLogWarning(@"my service", NO, kMessageCode, @"Message.");
+
+  XCTestExpectation *getWarningsCountExpectation =
+    [self expectationWithDescription:@"getWarningsCountExpectation"];
+
+  GULNumberOfWarningsLogged(^(NSInteger count){
+    [getWarningsCountExpectation fulfill];
+    XCTAssertEqual(count, 6);
+  });
+
+  [self waitForExpectationsWithTimeout:0.5 handler:NULL];
+}
+
+- (void)testResetIssuesCount {
+  [getGULLoggerUsetDefaults() setInteger:3 forKey:kGULLoggerErrorCountKey];
+  [getGULLoggerUsetDefaults() setInteger:4 forKey:kGULLoggerWarningCountKey];
+
+  GULResetNumberOfIssuesLogged();
+
+  XCTestExpectation *getErrorCountExpectation =
+    [self expectationWithDescription:@"getErrorCountExpectation"];
+  XCTestExpectation *getWarningsCountExpectation =
+    [self expectationWithDescription:@"getWarningsCountExpectation"];
+
+  GULNumberOfWarningsLogged(^(NSInteger count){
+    [getWarningsCountExpectation fulfill];
+    XCTAssertEqual(count, 0);
+  });
+
+  GULNumberOfErrorsLogged(^(NSInteger count){
+    [getErrorCountExpectation fulfill];
+    XCTAssertEqual(count, 0);
+  });
+
+  [self waitForExpectationsWithTimeout:0.5 handler:NULL];
 }
 
 // Helper functions.

--- a/GoogleUtilities/Example/Tests/Logger/GULLoggerTest.m
+++ b/GoogleUtilities/Example/Tests/Logger/GULLoggerTest.m
@@ -155,6 +155,27 @@ static NSString *const kMessageCode = @"I-COR000001";
   XCTAssertEqual(GULLoggerLevelDebug, ASL_LEVEL_DEBUG);
 }
 
+- (void)testGetErrorWarningNumberBeforeLogDontCrash {
+  GULResetLogger();
+
+  XCTestExpectation *getErrorCountExpectation =
+      [self expectationWithDescription:@"getErrorCountExpectation"];
+  XCTestExpectation *getWarningsCountExpectation =
+      [self expectationWithDescription:@"getWarningsCountExpectation"];
+
+  GULNumberOfErrorsLogged(^(NSInteger count){
+    [getErrorCountExpectation fulfill];
+  });
+
+  GULNumberOfWarningsLogged(^(NSInteger count){
+    [getWarningsCountExpectation fulfill];
+  });
+
+  [self waitForExpectations:@[getErrorCountExpectation, getWarningsCountExpectation]
+                    timeout:0.5
+               enforceOrder:YES];
+}
+
 - (void)testErrorNumberIncrement {
   [getGULLoggerUsetDefaults() setInteger:10 forKey:kGULLoggerErrorCountKey];
 
@@ -198,17 +219,19 @@ static NSString *const kMessageCode = @"I-COR000001";
   XCTestExpectation *getWarningsCountExpectation =
     [self expectationWithDescription:@"getWarningsCountExpectation"];
 
-  GULNumberOfWarningsLogged(^(NSInteger count){
-    [getWarningsCountExpectation fulfill];
-    XCTAssertEqual(count, 0);
-  });
-
   GULNumberOfErrorsLogged(^(NSInteger count){
     [getErrorCountExpectation fulfill];
     XCTAssertEqual(count, 0);
   });
 
-  [self waitForExpectationsWithTimeout:0.5 handler:NULL];
+  GULNumberOfWarningsLogged(^(NSInteger count){
+    [getWarningsCountExpectation fulfill];
+    XCTAssertEqual(count, 0);
+  });
+
+  [self waitForExpectations:@[getErrorCountExpectation, getWarningsCountExpectation]
+                    timeout:0.5
+               enforceOrder:YES];
 }
 
 // Helper functions.

--- a/GoogleUtilities/Example/Tests/Logger/GULLoggerTest.m
+++ b/GoogleUtilities/Example/Tests/Logger/GULLoggerTest.m
@@ -163,15 +163,15 @@ static NSString *const kMessageCode = @"I-COR000001";
   XCTestExpectation *getWarningsCountExpectation =
       [self expectationWithDescription:@"getWarningsCountExpectation"];
 
-  GULNumberOfErrorsLogged(^(NSInteger count){
+  GULNumberOfErrorsLogged(^(NSInteger count) {
     [getErrorCountExpectation fulfill];
   });
 
-  GULNumberOfWarningsLogged(^(NSInteger count){
+  GULNumberOfWarningsLogged(^(NSInteger count) {
     [getWarningsCountExpectation fulfill];
   });
 
-  [self waitForExpectations:@[getErrorCountExpectation, getWarningsCountExpectation]
+  [self waitForExpectations:@[ getErrorCountExpectation, getWarningsCountExpectation ]
                     timeout:0.5
                enforceOrder:YES];
 }
@@ -184,7 +184,7 @@ static NSString *const kMessageCode = @"I-COR000001";
   XCTestExpectation *getErrorCountExpectation =
       [self expectationWithDescription:@"getErrorCountExpectation"];
 
-  GULNumberOfErrorsLogged(^(NSInteger count){
+  GULNumberOfErrorsLogged(^(NSInteger count) {
     [getErrorCountExpectation fulfill];
     XCTAssertEqual(count, 11);
   });
@@ -198,9 +198,9 @@ static NSString *const kMessageCode = @"I-COR000001";
   GULLogWarning(@"my service", NO, kMessageCode, @"Message.");
 
   XCTestExpectation *getWarningsCountExpectation =
-    [self expectationWithDescription:@"getWarningsCountExpectation"];
+      [self expectationWithDescription:@"getWarningsCountExpectation"];
 
-  GULNumberOfWarningsLogged(^(NSInteger count){
+  GULNumberOfWarningsLogged(^(NSInteger count) {
     [getWarningsCountExpectation fulfill];
     XCTAssertEqual(count, 6);
   });
@@ -215,21 +215,21 @@ static NSString *const kMessageCode = @"I-COR000001";
   GULResetNumberOfIssuesLogged();
 
   XCTestExpectation *getErrorCountExpectation =
-    [self expectationWithDescription:@"getErrorCountExpectation"];
+      [self expectationWithDescription:@"getErrorCountExpectation"];
   XCTestExpectation *getWarningsCountExpectation =
-    [self expectationWithDescription:@"getWarningsCountExpectation"];
+      [self expectationWithDescription:@"getWarningsCountExpectation"];
 
-  GULNumberOfErrorsLogged(^(NSInteger count){
+  GULNumberOfErrorsLogged(^(NSInteger count) {
     [getErrorCountExpectation fulfill];
     XCTAssertEqual(count, 0);
   });
 
-  GULNumberOfWarningsLogged(^(NSInteger count){
+  GULNumberOfWarningsLogged(^(NSInteger count) {
     [getWarningsCountExpectation fulfill];
     XCTAssertEqual(count, 0);
   });
 
-  [self waitForExpectations:@[getErrorCountExpectation, getWarningsCountExpectation]
+  [self waitForExpectations:@[ getErrorCountExpectation, getWarningsCountExpectation ]
                     timeout:0.5
                enforceOrder:YES];
 }

--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -227,7 +227,7 @@ dispatch_queue_t getGULLoggerCounterQueue(void) {
   return queue;
 }
 
-void GULAsyncGetUserDefaultsIntegerForKey(NSString *key, void(^completion)(NSInteger)) {
+void GULAsyncGetUserDefaultsIntegerForKey(NSString *key, void (^completion)(NSInteger)) {
   dispatch_async(getGULLoggerCounterQueue(), ^{
     NSInteger count = [getGULLoggerUsetDefaults() integerForKey:key];
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -236,11 +236,11 @@ void GULAsyncGetUserDefaultsIntegerForKey(NSString *key, void(^completion)(NSInt
   });
 }
 
-void GULNumberOfErrorsLogged(void(^completion)(NSInteger)) {
+void GULNumberOfErrorsLogged(void (^completion)(NSInteger)) {
   GULAsyncGetUserDefaultsIntegerForKey(kGULLoggerErrorCountKey, completion);
 }
 
-void GULNumberOfWarningsLogged(void(^completion)(NSInteger)) {
+void GULNumberOfWarningsLogged(void (^completion)(NSInteger)) {
   GULAsyncGetUserDefaultsIntegerForKey(kGULLoggerWarningCountKey, completion);
 }
 

--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -154,6 +154,10 @@ void GULLogBasic(GULLoggerLevel level,
                  NSString *message,
                  va_list args_ptr) {
   GULLoggerInitializeASL();
+
+  // Keep count of how many errors and warnings are triggered.
+  GULIncrementLogCountForLevel(level);
+
   if (!(level <= sGULLoggerMaximumLevel || sGULLoggerDebugMode || forceLog)) {
     return;
   }
@@ -170,10 +174,6 @@ void GULLogBasic(GULLoggerLevel level,
   logMsg = [NSString stringWithFormat:@"%s - %@[%@] %@", sVersion, service, messageCode, logMsg];
   dispatch_async(sGULClientQueue, ^{
     asl_log(sGULLoggerClient, NULL, level, "%s", logMsg.UTF8String);
-
-    // Keep count of how many errors and warnings are triggered.
-    // The message won't be added if it is of lower level then the logger level
-    GULIncrementLogCountForLevel(level);
   });
 }
 #pragma clang diagnostic pop
@@ -215,8 +215,20 @@ NSUserDefaults *getGULLoggerUsetDefaults(void) {
   return _userDefaults;
 }
 
+dispatch_queue_t getGULLoggerCounterQueue(void) {
+  static dispatch_queue_t queue;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    queue = dispatch_queue_create("GoogleUtilities.GULLogger.counterQueue", DISPATCH_QUEUE_SERIAL);
+    dispatch_set_target_queue(queue,
+                              dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0));
+  });
+
+  return queue;
+}
+
 void GULAsyncGetUserDefaultsIntegerForKey(NSString *key, void(^completion)(NSInteger)) {
-  dispatch_async(sGULClientQueue, ^{
+  dispatch_async(getGULLoggerCounterQueue(), ^{
     NSInteger count = [getGULLoggerUsetDefaults() integerForKey:key];
     dispatch_async(dispatch_get_main_queue(), ^{
       completion(count);
@@ -233,7 +245,7 @@ void GULNumberOfWarningsLogged(void(^completion)(NSInteger)) {
 }
 
 void GULResetNumberOfIssuesLogged(void) {
-  dispatch_async(sGULClientQueue, ^{
+  dispatch_async(getGULLoggerCounterQueue(), ^{
     [getGULLoggerUsetDefaults() setInteger:0 forKey:kGULLoggerErrorCountKey];
     [getGULLoggerUsetDefaults() setInteger:0 forKey:kGULLoggerWarningCountKey];
   });
@@ -246,11 +258,13 @@ void GULIncrementUserDefaultsIntegerForKey(NSString *key) {
 }
 
 void GULIncrementLogCountForLevel(GULLoggerLevel level) {
-  if (level == GULLoggerLevelError) {
-    GULIncrementUserDefaultsIntegerForKey(kGULLoggerErrorCountKey);
-  } else if (level == GULLoggerLevelWarning) {
-    GULIncrementUserDefaultsIntegerForKey(kGULLoggerWarningCountKey);
-  }
+  dispatch_async(getGULLoggerCounterQueue(), ^{
+    if (level == GULLoggerLevelError) {
+      GULIncrementUserDefaultsIntegerForKey(kGULLoggerErrorCountKey);
+    } else if (level == GULLoggerLevelWarning) {
+      GULIncrementUserDefaultsIntegerForKey(kGULLoggerWarningCountKey);
+    }
+  });
 }
 
 #pragma mark - GULLoggerWrapper

--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -19,6 +19,9 @@
 #import <GoogleUtilities/GULAppEnvironmentUtil.h>
 #import "Public/GULLoggerLevel.h"
 
+NSString *const kGULLoggerErrorCountKey = @"kGULLoggerErrorCountKey";
+NSString *const kGULLoggerWarningCountKey = @"kGULLoggerWarningCountKey";
+
 /// ASL client facility name used by GULLogger.
 const char *kGULLoggerASLClientFacilityName = "com.google.utilities.logger";
 
@@ -42,6 +45,8 @@ static GULLoggerService kGULLoggerLogger = @"[GULLogger]";
 static NSString *const kMessageCodePattern = @"^I-[A-Z]{3}[0-9]{6}$";
 static NSRegularExpression *sMessageCodeRegex;
 #endif
+
+void GULIncrementLogCountForLevel(GULLoggerLevel level);
 
 void GULLoggerInitializeASL(void) {
   dispatch_once(&sGULLoggerOnceToken, ^{
@@ -165,6 +170,10 @@ void GULLogBasic(GULLoggerLevel level,
   logMsg = [NSString stringWithFormat:@"%s - %@[%@] %@", sVersion, service, messageCode, logMsg];
   dispatch_async(sGULClientQueue, ^{
     asl_log(sGULLoggerClient, NULL, level, "%s", logMsg.UTF8String);
+
+    // Keep count of how many errors and warnings are triggered.
+    // The message won't be added if it is of lower level then the logger level
+    GULIncrementLogCountForLevel(level);
   });
 }
 #pragma clang diagnostic pop
@@ -193,6 +202,56 @@ GUL_LOGGING_FUNCTION(Info)
 GUL_LOGGING_FUNCTION(Debug)
 
 #undef GUL_MAKE_LOGGER
+
+#pragma mark - Number of errors and warnings
+
+NSUserDefaults *getGULLoggerUsetDefaults(void) {
+  static NSUserDefaults *_userDefaults = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    _userDefaults = [[NSUserDefaults alloc] initWithSuiteName:@"GoogleUtilities.Logger.GULLogger"];
+  });
+
+  return _userDefaults;
+}
+
+void GULAsyncGetUserDefaultsIntegerForKey(NSString *key, void(^completion)(NSInteger)) {
+  dispatch_async(sGULClientQueue, ^{
+    NSInteger count = [getGULLoggerUsetDefaults() integerForKey:key];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      completion(count);
+    });
+  });
+}
+
+void GULNumberOfErrorsLogged(void(^completion)(NSInteger)) {
+  GULAsyncGetUserDefaultsIntegerForKey(kGULLoggerErrorCountKey, completion);
+}
+
+void GULNumberOfWarningsLogged(void(^completion)(NSInteger)) {
+  GULAsyncGetUserDefaultsIntegerForKey(kGULLoggerWarningCountKey, completion);
+}
+
+void GULResetNumberOfIssuesLogged(void) {
+  dispatch_async(sGULClientQueue, ^{
+    [getGULLoggerUsetDefaults() setInteger:0 forKey:kGULLoggerErrorCountKey];
+    [getGULLoggerUsetDefaults() setInteger:0 forKey:kGULLoggerWarningCountKey];
+  });
+}
+
+void GULIncrementUserDefaultsIntegerForKey(NSString *key) {
+  NSUserDefaults *defaults = getGULLoggerUsetDefaults();
+  NSInteger errorCount = [defaults integerForKey:key];
+  [defaults setInteger:errorCount + 1 forKey:key];
+}
+
+void GULIncrementLogCountForLevel(GULLoggerLevel level) {
+  if (level == GULLoggerLevelError) {
+    GULIncrementUserDefaultsIntegerForKey(kGULLoggerErrorCountKey);
+  } else if (level == GULLoggerLevelWarning) {
+    GULIncrementUserDefaultsIntegerForKey(kGULLoggerWarningCountKey);
+  }
+}
 
 #pragma mark - GULLoggerWrapper
 

--- a/GoogleUtilities/Logger/Private/GULLogger.h
+++ b/GoogleUtilities/Logger/Private/GULLogger.h
@@ -25,6 +25,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 typedef NSString *const GULLoggerService;
 
+/**
+ * The key used to store the logger's error count.
+ */
+extern NSString *const kGULLoggerErrorCountKey;
+
+/**
+ * The key used to store the logger's warning count.
+ */
+extern NSString *const kGULLoggerWarningCountKey;
+
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
@@ -128,6 +138,21 @@ extern void GULLogDebug(GULLoggerService service,
                         NSString *messageCode,
                         NSString *message,
                         ...) NS_FORMAT_FUNCTION(4, 5);
+
+/**
+* Retrieve the number of errors that have been logged since the stat was last reset.
+*/
+extern void GULNumberOfErrorsLogged(void(^completion)(NSInteger));
+
+/**
+ * Retrieve the number of warnings that have been logged since the stat was last reset.
+ */
+extern void GULNumberOfWarningsLogged(void(^completion)(NSInteger));
+
+/**
+ * Reset number of errors and warnings that have been logged to 0.
+ */
+extern void GULResetNumberOfIssuesLogged(void);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/GoogleUtilities/Logger/Private/GULLogger.h
+++ b/GoogleUtilities/Logger/Private/GULLogger.h
@@ -140,14 +140,14 @@ extern void GULLogDebug(GULLoggerService service,
                         ...) NS_FORMAT_FUNCTION(4, 5);
 
 /**
-* Retrieve the number of errors that have been logged since the stat was last reset.
-*/
-extern void GULNumberOfErrorsLogged(void(^completion)(NSInteger));
+ * Retrieve the number of errors that have been logged since the stat was last reset.
+ */
+extern void GULNumberOfErrorsLogged(void (^completion)(NSInteger));
 
 /**
  * Retrieve the number of warnings that have been logged since the stat was last reset.
  */
-extern void GULNumberOfWarningsLogged(void(^completion)(NSInteger));
+extern void GULNumberOfWarningsLogged(void (^completion)(NSInteger));
 
 /**
  * Reset number of errors and warnings that have been logged to 0.


### PR DESCRIPTION
- logic to count error and warning messages added to GULLogger (https://github.com/firebase/firebase-ios-sdk/pull/1201 used as a base)