### PR TITLE
Rework gRPC certificate loading one last time

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [fixed] Fixed the way gRPC certificates are loaded on macOS (#2604).
 
 # 1.1.0
 - [feature] Added `FieldValue.increment()`, which can be used in

--- a/Firestore/Example/App/iOS/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Firestore/Example/App/iOS/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -84,6 +84,11 @@
       "idiom" : "ipad",
       "size" : "83.5x83.5",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/Firestore/Example/App/macOS_example/AppDelegate.m
+++ b/Firestore/Example/App/macOS_example/AppDelegate.m
@@ -35,7 +35,6 @@
 
   // do the timestamp fix
   FIRFirestoreSettings *settings = db.settings;
-  settings.timestampsInSnapshotsEnabled = true;
   db.settings = settings;
 
   // create a doc

--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -561,7 +561,7 @@
 		B9C261C26C5D311E1E3C0CB9 /* query_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = query_test.cc; sourceTree = "<group>"; };
 		BB92EB03E3F92485023F64ED /* Pods_Firestore_Example_iOS_Firestore_SwiftTests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Firestore_Example_iOS_Firestore_SwiftTests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C8522DE226C467C54E6788D8 /* mutation_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = mutation_test.cc; sourceTree = "<group>"; };
-		D0A6E9136804A41CEC9D55D4 /* delayed_constructor_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = delayed_constructor_test.cc; sourceTree = "<group>"; };
+		D0A6E9136804A41CEC9D55D4 /* delayed_constructor_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = delayed_constructor_test.cc; sourceTree = "<group>"; };
 		D3CC3DC5338DCAF43A211155 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		D5B2593BCB52957D62F1C9D3 /* perf_spec_test.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = perf_spec_test.json; sourceTree = "<group>"; };
 		D5B25E7E7D6873CBA4571841 /* FIRNumericTransformTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FIRNumericTransformTests.mm; sourceTree = "<group>"; };
@@ -2936,8 +2936,6 @@
 					"\"leveldb\"",
 					"-framework",
 					"\"nanopb\"",
-					"-framework",
-					"\"openssl\"",
 					"-ObjC",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.google.Firestore-macOS";
@@ -3012,8 +3010,6 @@
 					"\"leveldb\"",
 					"-framework",
 					"\"nanopb\"",
-					"-framework",
-					"\"openssl\"",
 					"-ObjC",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.google.Firestore-macOS";

--- a/Firestore/core/src/firebase/firestore/remote/grpc_root_certificate_finder_apple.mm
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_root_certificate_finder_apple.mm
@@ -20,8 +20,6 @@
 
 #include <string>
 
-#import "Firestore/Source/Core/FSTFirestoreClient.h"
-
 #include "Firestore/core/src/firebase/firestore/util/filesystem.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 #include "Firestore/core/src/firebase/firestore/util/log.h"
@@ -96,7 +94,6 @@ NSBundle* _Nullable FindFirestoreFrameworkBundle() {
 
 /**
  * Finds the path to the roots.pem certificates file, wherever it may be.
- *
  *
  * Carthage users will find roots.pem inside gRPCCertificates.bundle in
  * the main bundle.

--- a/Firestore/core/src/firebase/firestore/remote/grpc_root_certificate_finder_apple.mm
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_root_certificate_finder_apple.mm
@@ -16,14 +16,17 @@
 
 #include "Firestore/core/src/firebase/firestore/remote/grpc_root_certificate_finder.h"
 
+#import <objc/runtime.h>
+
 #include <string>
+
+#import "Firestore/Source/Core/FSTFirestoreClient.h"
 
 #include "Firestore/core/src/firebase/firestore/util/filesystem.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 #include "Firestore/core/src/firebase/firestore/util/log.h"
 #include "Firestore/core/src/firebase/firestore/util/statusor.h"
-
-#import "Firestore/Source/Core/FSTFirestoreClient.h"
+#include "absl/strings/str_cat.h"
 
 namespace firebase {
 namespace firestore {
@@ -34,44 +37,106 @@ using util::ReadFile;
 using util::StatusOr;
 using util::StringFormat;
 
+namespace {
+
+/**
+ * Finds the roots.pem certificate file in the given resource bundle and logs
+ * the outcome.
+ *
+ * @param bundle The bundle to check. Can be a nested bundle in Resources or
+ *     an app or framework bundle to look in directly.
+ * @param parent The parent bundle of the bundle to search. Used for logging.
+ */
+NSString* _Nullable FindCertFileInResourceBundle(NSBundle* _Nullable bundle,
+                                                 NSBundle* _Nullable parent) {
+  if (!bundle) return nil;
+
+  NSString* path = [bundle pathForResource:@"roots" ofType:@"pem"];
+  if (util::LogIsDebugEnabled()) {
+    std::string message =
+        absl::StrCat("roots.pem ", path ? "found " : "not found ", "in bundle ",
+                     util::MakeString([bundle bundleIdentifier]));
+    if (parent) {
+      absl::StrAppend(&message, " (in parent ",
+                      util::MakeString([parent bundleIdentifier]), ")");
+    }
+    LOG_DEBUG("%s", message);
+  }
+
+  return path;
+}
+
+/**
+ * Finds gRPCCertificates.bundle inside the given parent, if it exists.
+ *
+ * This function exists mostly to handle differences in platforms.
+ * On iOS, resources are nested directly within the top-level of the parent
+ * bundle, but on macOS this will actually be in Contents/Resources.
+ *
+ * @param parent A framework or app bundle to check.
+ * @return The nested gRPCCertificates.bundle if found, otherwise nil.
+ */
+NSBundle* _Nullable FindCertBundleInParent(NSBundle* _Nullable parent) {
+  if (!parent) return nil;
+
+  NSString* path = [parent pathForResource:@"gRPCCertificates"
+                                    ofType:@"bundle"];
+  if (!path) return nil;
+
+  return [[NSBundle alloc] initWithPath:path];
+}
+
+NSBundle* _Nullable FindFirestoreFrameworkBundle() {
+  // Load FIRFirestore reflectively to avoid a circular reference at build time.
+  Class firestore_class = objc_getClass("FIRFirestore");
+  if (!firestore_class) return nil;
+
+  return [NSBundle bundleForClass:firestore_class];
+}
+
+/**
+ * Finds the path to the roots.pem certificates file, wherever it may be.
+ *
+ *
+ * Carthage users will find roots.pem inside gRPCCertificates.bundle in
+ * the main bundle.
+ *
+ * There have been enough variations and workarounds posted on this that
+ * this also accepts the roots.pem file outside gRPCCertificates.bundle.
+ */
 NSString* FindPathToCertificatesFile() {
-  // Certificates file might be present in either the gRPC-C++ bundle or (for
+  // Certificates file might be present in either the gRPC-C++ framework or (for
   // some projects) in the main bundle.
   NSBundle* bundles[] = {
-      // Try to load certificates bundled by gRPC-C++.
+      // CocoaPods: try to load from the gRPC-C++ Framework.
       [NSBundle bundleWithIdentifier:@"org.cocoapods.grpcpp"],
-      // Users manually adding resources to the project may add the
-      // certificate to the main application bundle. Note that `mainBundle` is
-      // nil for unit tests of library projects, so it cannot fully substitute
-      // for checking the framework bundle.
+
+      // Carthage: try to load from the FirebaseFirestore.framework
+      FindFirestoreFrameworkBundle(),
+
+      // Carthage and manual projects: users manually adding resources to the
+      // project may add the certificate to the main application bundle. Note
+      // that `mainBundle` is nil for unit tests of library projects.
       [NSBundle mainBundle],
   };
 
-  // search for the roots.pem file in each of these resource locations
-  NSString* possibleResources[] = {
-      @"gRPCCertificates.bundle/roots",
-      @"roots",
-  };
+  NSString* path = nil;
 
-  for (NSBundle* bundle : bundles) {
-    if (!bundle) {
-      continue;
-    }
+  for (NSBundle* parent : bundles) {
+    if (!parent) continue;
 
-    for (NSString* resource : possibleResources) {
-      NSString* path = [bundle pathForResource:resource ofType:@"pem"];
-      if (path) {
-        LOG_DEBUG("%s.pem found in bundle %s", resource,
-                  [bundle bundleIdentifier]);
-        return path;
-      } else {
-        LOG_DEBUG("%s.pem not found in bundle %s", resource,
-                  [bundle bundleIdentifier]);
-      }
-    }
+    NSBundle* certs_bundle = FindCertBundleInParent(parent);
+    path = FindCertFileInResourceBundle(certs_bundle, parent);
+    if (path) break;
+
+    path = FindCertFileInResourceBundle(parent, nil);
+    if (path) break;
   }
-  return nil;
+
+  return path;
 }
+
+}  // namespace
 
 std::string LoadGrpcRootCertificate() {
   NSString* path = FindPathToCertificatesFile();


### PR DESCRIPTION
The prior implementation happened to work but only because it made implicit assumptions about the structure of the bundles we load.

In particular, by looking for `@"gRPCCertificates.bundle/roots"` the code was assuming the iOS bundle layout for the app was in effect, but this doesn't work on macOS, in which app/framework bundles have an additional `Contents/Resources` in the path.

This change gets rid of the implicit mapping of the bundle structure onto the directory structure and instead opens the nested `gRPCCertificates.bundle` itself as a resource, making this code portable without having to understand the bundle layout under the covers.

Fixes #2604. Should also remove the need for the workaround in #2177.