### PR TITLE
Add missing #include <ostream>

### DIFF
--- a/Firestore/core/src/firebase/firestore/timestamp.cc
+++ b/Firestore/core/src/firebase/firestore/timestamp.cc
@@ -16,6 +16,8 @@
 
 #include "Firestore/core/include/firebase/firestore/timestamp.h"
 
+#include <ostream>
+
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 #include "absl/strings/str_cat.h"
 

--- a/Firestore/core/src/firebase/firestore/util/status.cc
+++ b/Firestore/core/src/firebase/firestore/util/status.cc
@@ -16,6 +16,8 @@
 
 #include "Firestore/core/src/firebase/firestore/util/status.h"
 
+#include <ostream>
+
 #include "Firestore/core/src/firebase/firestore/util/string_format.h"
 #include "absl/memory/memory.h"
 


### PR DESCRIPTION
I discovered that when archiving a build you end up with undefined symbols if you only `#include <iosfwd>`.

This adds a IWYU check and fixes the cases I already broke.