### PR TITLE
Prepare for macOS test support

### DIFF
--- a/Firestore/Example/GoogleBenchmark.podspec
+++ b/Firestore/Example/GoogleBenchmark.podspec
@@ -34,6 +34,8 @@ Google's C++ benchmark framework.
   }
 
   s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.10'
+
   s.requires_arc = false
 
   s.public_header_files = [

--- a/Firestore/Example/GoogleTest.podspec
+++ b/Firestore/Example/GoogleTest.podspec
@@ -34,6 +34,8 @@ Google's C++ test framework.
   }
 
   s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.10'
+
   s.requires_arc = false
 
   # Exclude include/gtest/internal/custom files from public headers. These

--- a/Firestore/Example/LibFuzzer.podspec
+++ b/Firestore/Example/LibFuzzer.podspec
@@ -31,6 +31,7 @@ Pod::Spec.new do |s|
   # LibFuzzer uses thread_local which does not appear to be supported before
   # iOS 9.
   s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.10'
 
   # Check out only libFuzzer folder.
   s.source              = {

--- a/Firestore/Example/ProtobufCpp.podspec
+++ b/Firestore/Example/ProtobufCpp.podspec
@@ -29,6 +29,9 @@ Pod::Spec.new do |s|
     :tag => "v#{s.version}"
   }
 
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.10'
+
   s.source_files = 'src/**/*.{h,cc}'
   s.exclude_files = # skip test files. (Yes, the test files are intermixed with
                     # the source. No there doesn't seem to be a common/simple

--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -728,7 +728,7 @@ std::vector<TargetId> ConvertTargetsArray(NSArray<NSNumber *> *from) {
   NSBundle *bundle = [NSBundle bundleForClass:[self class]];
   NSFileManager *fs = [NSFileManager defaultManager];
   BOOL exclusiveMode = NO;
-  for (NSString *file in [fs enumeratorAtPath:[bundle bundlePath]]) {
+  for (NSString *file in [fs enumeratorAtPath:[bundle resourcePath]]) {
     if (![@"json" isEqual:[file pathExtension]]) {
       continue;
     }

--- a/Firestore/core/test/firebase/firestore/FSTGoogleTestTests.mm
+++ b/Firestore/core/test/firebase/firestore/FSTGoogleTestTests.mm
@@ -50,7 +50,7 @@ NSDictionary<NSString *, NSValue *> *testInfosByKey;
 
 // If the user focuses on GoogleTests itself, this means force all C++ tests to
 // run.
-BOOL forceAllTests = NO;
+bool forceAllTests = false;
 
 /**
  * Loads this XCTest runner's configuration file and figures out which tests to
@@ -216,7 +216,7 @@ void ReportTestResult(XCTestCase *self, SEL _cmd) {
                               atLine:(part.line_number() > 0
                                           ? part.line_number()
                                           : 0)
-                            expected:YES];
+                            expected:true];
   }
 }
 
@@ -305,15 +305,15 @@ void RunGoogleTestTests() {
 
   // Convert XCTest's testToRun set to the equivalent --gtest_filter flag.
   //
-  // Note that we only set forceAllTests to YES if the user specifically focused
-  // on GoogleTests. This prevents XCTest double-counting test cases (and
-  // failures) when a user asks for all tests.
+  // Note that we only set forceAllTests to true if the user specifically
+  // focused on GoogleTests. This prevents XCTest double-counting test cases
+  // (and failures) when a user asks for all tests.
   NSSet<NSString *> *allTests = [NSSet setWithObject:masterTestCaseName];
   NSSet<NSString *> *testsToRun = LoadXCTestConfigurationTestsToRun();
   if (testsToRun) {
     if ([allTests isEqual:testsToRun]) {
       NSLog(@"Forcing all tests to run");
-      forceAllTests = YES;
+      forceAllTests = true;
     } else {
       NSString *filters = CreateTestFiltersFromTestsToRun(testsToRun);
       NSLog(@"Using --gtest_filter=%@", filters);

--- a/Firestore/core/test/firebase/firestore/FSTGoogleTestTests.mm
+++ b/Firestore/core/test/firebase/firestore/FSTGoogleTestTests.mm
@@ -225,8 +225,9 @@ void ReportTestResult(XCTestCase *self, SEL _cmd) {
  * Each TestInfo (which represents an indivudal test method execution) is
  * translated into a method on the test case.
  *
- * @param The testing::TestCase of interest to translate.
- * @param A map of TestInfoKeys to testing::TestInfos, populated by this method.
+ * @param testCase The testing::TestCase of interest to translate.
+ * @param infoMap A map of TestInfoKeys to testing::TestInfos, populated by this
+ *     method.
  *
  * @return A new Class that's a subclass of XCTestCase, that's been registered
  * with the Objective-C runtime.


### PR DESCRIPTION
This is a grab bag of minor fixes that can be made independently of the major project file overhaul required to enable unit tests working under macOS.