### PR TITLE
GULLogger: logged issue counting concurrency issue fix

### DIFF
--- a/GoogleUtilities/Example/Tests/Logger/GULLoggerTest.m
+++ b/GoogleUtilities/Example/Tests/Logger/GULLoggerTest.m
@@ -32,7 +32,7 @@ extern dispatch_queue_t getGULClientQueue(void);
 
 extern BOOL getGULLoggerDebugMode(void);
 
-extern CFStringRef getGULLoggerUsetDefaultsSuiteName(void);
+extern CFStringRef getGULLoggerUserDefaultsSuiteName(void);
 extern dispatch_queue_t getGULLoggerCounterQueue(void);
 
 static NSString *const kMessageCode = @"I-COR000001";
@@ -51,7 +51,7 @@ static NSString *const kMessageCode = @"I-COR000001";
   GULResetLogger();
 
   self.loggerDefaults = [[NSUserDefaults alloc]
-      initWithSuiteName:CFBridgingRelease(getGULLoggerUsetDefaultsSuiteName())];
+      initWithSuiteName:CFBridgingRelease(getGULLoggerUserDefaultsSuiteName())];
 }
 
 - (void)tearDown {

--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -238,8 +238,6 @@ dispatch_queue_t getGULLoggerCounterQueue(void) {
   dispatch_once(&onceToken, ^{
     queue =
         dispatch_queue_create("GoogleUtilities.GULLogger.counterQueue", DISPATCH_QUEUE_CONCURRENT);
-    dispatch_set_target_queue(queue,
-                              dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0));
   });
 
   return queue;

--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -207,15 +207,15 @@ GUL_LOGGING_FUNCTION(Debug)
 
 // NSUserDefaults cannot be used due to a bug described in GULUserDefaults
 // GULUserDefaults cannot be used because GULLogger is a dependency for GULUserDefaults
-// We have to use C API deireclty here
+// We have to use C API direclty here
 
-CFStringRef getGULLoggerUsetDefaultsSuiteName(void) {
+CFStringRef getGULLoggerUserDefaultsSuiteName(void) {
   return (__bridge CFStringRef) @"GoogleUtilities.Logger.GULLogger";
 }
 
 NSInteger GULGetUserDefaultsIntegerForKey(NSString *key) {
   id value = (__bridge_transfer id)CFPreferencesCopyAppValue((__bridge CFStringRef)key,
-                                                             getGULLoggerUsetDefaultsSuiteName());
+                                                             getGULLoggerUserDefaultsSuiteName());
   if (![value isKindOfClass:[NSNumber class]]) {
     return 0;
   }
@@ -226,8 +226,8 @@ NSInteger GULGetUserDefaultsIntegerForKey(NSString *key) {
 void GULLoggerUserDefaultsSetIntegerForKey(NSInteger count, NSString *key) {
   NSNumber *countNumber = @(count);
   CFPreferencesSetAppValue((__bridge CFStringRef)key, (__bridge CFNumberRef)countNumber,
-                           getGULLoggerUsetDefaultsSuiteName());
-  CFPreferencesAppSynchronize(getGULLoggerUsetDefaultsSuiteName());
+                           getGULLoggerUserDefaultsSuiteName());
+  CFPreferencesAppSynchronize(getGULLoggerUserDefaultsSuiteName());
 }
 
 #pragma mark - Number of errors and warnings


### PR DESCRIPTION
- don't set global queue as a target for GULLoggerCounterQueue. `dispatch_barier_async` on a global queue behaves as just `dispatch_async`, so the counter could be updated concurrently.