### PR TITLE
fix race condition that checkin can be deleted right after fetched (#2438)

### DIFF
--- a/Firebase/InstanceID/FIRIMessageCode.h
+++ b/Firebase/InstanceID/FIRIMessageCode.h
@@ -77,6 +77,8 @@ typedef NS_ENUM(NSInteger, FIRInstanceIDMessageCode) {
   kFIRInstanceIDMessageCodeKeyPair002 = 9002,
   kFIRInstanceIDMessageCodeKeyPairMigrationError = 9004,
   kFIRInstanceIDMessageCodeKeyPairMigrationSuccess = 9005,
+  kFIRInstanceIDMessageCodeKeyPairNoLegacyKeyPair = 9006,
+
   // FIRInstanceIDKeyPairStore.m
   kFIRInstanceIDMessageCodeKeyPairStore000 = 10000,
   kFIRInstanceIDMessageCodeKeyPairStore001 = 10001,

--- a/Firebase/InstanceID/FIRInstanceIDCheckinService.m
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinService.m
@@ -133,8 +133,9 @@ static FIRInstanceIDURLRequestTestBlock testBlock;
         // Somehow the server clock gets out of sync with the device clock.
         // Reset the last checkin timestamp in case this happens.
         if (lastCheckinTimestampMillis > currentTimestampMillis) {
-          FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeService002,
-                                   @"Invalid last checkin timestamp in future.");
+          FIRInstanceIDLoggerDebug(
+              kFIRInstanceIDMessageCodeService002, @"Invalid last checkin timestamp %@ in future.",
+              [NSDate dateWithTimeIntervalSince1970:lastCheckinTimestampMillis / 1000.0]);
           lastCheckinTimestampMillis = currentTimestampMillis;
         }
 

--- a/Firebase/InstanceID/FIRInstanceIDCheckinStore.m
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinStore.m
@@ -108,28 +108,6 @@ static const NSInteger kOldCheckinPlistCount = 6;
     return;
   }
 
-  // Save the deviceID and secret in the Keychain
-  __block BOOL shouldContinue = YES;
-  if (!preferences.hasPreCachedAuthCredentials) {
-    NSData *data = [checkinKeychainContent dataUsingEncoding:NSUTF8StringEncoding];
-    [self.keychain setData:data
-                forService:kFIRInstanceIDCheckinKeychainService
-             accessibility:nil
-                   account:self.bundleIdentifierForKeychainAccount
-                   handler:^(NSError *error) {
-                     if (error) {
-                       if (handler) {
-                         handler(error);
-                       }
-                       shouldContinue = NO;
-                       return;
-                     }
-                   }];
-  }
-  if (!shouldContinue) {
-    return;
-  }
-
   // Save all other checkin preferences in a plist
   NSError *error;
   if (![self.plist writeDictionary:checkinPlistContents error:&error]) {
@@ -144,7 +122,26 @@ static const NSInteger kOldCheckinPlistCount = 6;
     }
     return;
   }
-  handler(nil);
+  // Save the deviceID and secret in the Keychain
+  if (!preferences.hasPreCachedAuthCredentials) {
+    NSData *data = [checkinKeychainContent dataUsingEncoding:NSUTF8StringEncoding];
+    [self.keychain setData:data
+                forService:kFIRInstanceIDCheckinKeychainService
+             accessibility:nil
+                   account:self.bundleIdentifierForKeychainAccount
+                   handler:^(NSError *error) {
+                     if (error) {
+                       if (handler) {
+                         handler(error);
+                       }
+                       return;
+                     } else {
+                       if (handler) {
+                         handler(nil);
+                       }
+                     }
+                   }];
+  }
 }
 
 - (void)removeCheckinPreferencesWithHandler:(void (^)(NSError *error))handler {

--- a/Firebase/InstanceID/FIRInstanceIDCheckinStore.m
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinStore.m
@@ -140,6 +140,8 @@ static const NSInteger kOldCheckinPlistCount = 6;
                        handler(nil);
                      }
                    }];
+  } else {
+    handler(nil);
   }
 }
 

--- a/Firebase/InstanceID/FIRInstanceIDCheckinStore.m
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinStore.m
@@ -135,10 +135,9 @@ static const NSInteger kOldCheckinPlistCount = 6;
                          handler(error);
                        }
                        return;
-                     } else {
-                       if (handler) {
-                         handler(nil);
-                       }
+                     }
+                     if (handler) {
+                       handler(nil);
                      }
                    }];
   }

--- a/Firebase/InstanceID/FIRInstanceIDKeyPairStore.m
+++ b/Firebase/InstanceID/FIRInstanceIDKeyPairStore.m
@@ -159,7 +159,7 @@ NSString *FIRInstanceIDCreationTimeKeyWithSubtype(NSString *subtype) {
   if ([self cachedKeyPairWithSubtype:kFIRInstanceIDKeyPairSubType error:&error] == nil) {
     if (error) {
       FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeKeyPairStore000,
-                               @"Failed to get cached keyPair %@", error);
+                               @"Failed to get the cached keyPair %@", error);
     }
     error = nil;
     [self removeKeyPairCreationTimePlistWithError:&error];
@@ -316,7 +316,7 @@ NSString *FIRInstanceIDCreationTimeKeyWithSubtype(NSString *subtype) {
       *error = [NSError errorWithFIRInstanceIDErrorCode:kFIRInstanceIDErrorCodeMissingKeyPair];
     }
     FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeKeyPair000,
-                             @"No keypair info is retrieved with tag %@", privateKeyTag);
+                             @"No keypair info is found with tag %@", privateKeyTag);
     return nil;
   }
 
@@ -344,6 +344,8 @@ NSString *FIRInstanceIDCreationTimeKeyWithSubtype(NSString *subtype) {
                                             publicKeyTag:legacyPublicKeyTag
                                                    error:&error];
   if (![keyPair isValid]) {
+    FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeKeyPairNoLegacyKeyPair,
+                             @"There's no legacy keypair so no need to do migration.");
     if (handler) {
       handler(nil);
     }

--- a/Firebase/InstanceID/FIRInstanceIDKeychain.m
+++ b/Firebase/InstanceID/FIRInstanceIDKeychain.m
@@ -60,10 +60,9 @@ static const NSUInteger kRSA2048KeyPairSize = 2048;
       if (keyRef) {
         CFRelease(keyRef);
       }
-      FIRInstanceIDLoggerDebug(
-          kFIRInstanceIDKeychainReadItemError,
-          @"No info is retrieved from Keychain OSStatus: %d with the keychain query %@",
-          (int)status, keychainQuery);
+      FIRInstanceIDLoggerDebug(kFIRInstanceIDKeychainReadItemError,
+                               @"Info is not found in Keychain. OSStatus: %d. Keychain query: %@",
+                               (int)status, keychainQuery);
     }
   });
   return keyRef;

--- a/Firebase/InstanceID/FIRInstanceIDStore.m
+++ b/Firebase/InstanceID/FIRInstanceIDStore.m
@@ -153,11 +153,13 @@ static NSString *const kFIRInstanceIDLibraryVersion = @"GMSInstanceID-version";
   if (oldCheckinPreferences) {
     [self.checkinStore removeCheckinPreferencesWithHandler:^(NSError *error) {
       if (!error) {
-        FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeStore002,
-                                 @"Removed cached checkin preferences from Keychain.");
+        FIRInstanceIDLoggerDebug(
+            kFIRInstanceIDMessageCodeStore002,
+            @"Removed cached checkin preferences from Keychain because this is a fresh install.");
       } else {
-        FIRInstanceIDLoggerError(kFIRInstanceIDMessageCodeStore003,
-                                 @"Couldn't remove cached checkin preferences. Error: %@", error);
+        FIRInstanceIDLoggerError(
+            kFIRInstanceIDMessageCodeStore003,
+            @"Couldn't remove cached checkin preferences for a fresh install. Error: %@", error);
       }
       if (oldCheckinPreferences.deviceID.length && oldCheckinPreferences.secretToken.length) {
         FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeStore006,

--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -101,7 +101,7 @@ struct FrameworkBuilder {
 //    }
 //
 //    // TODO: Figure out if we need the MD5 at all.
-      let md5 = podName
+    let md5 = podName
 //    let md5 = Shell.calculateMD5(for: podInfo.installedLocation)
 
     // Get (or create) the cache directory for storing built frameworks.


### PR DESCRIPTION
For some users using Firebase 5.17.0, they fall into a condition where checkin is deleted right after the new one is fetched, causing checkin and token are kept being refreshed during app start. (#2438)

Also adjust a few debug logs to make it more easy to understand.