### PR TITLE
 Eliminate 'instanceof' checks for FSTFieldValue 

### DIFF
--- a/Firestore/Example/Tests/Model/FSTFieldValueTests.mm
+++ b/Firestore/Example/Tests/Model/FSTFieldValueTests.mm
@@ -91,6 +91,7 @@ NSArray *FSTWrapGroups(NSArray *groups) {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);
     XCTAssertEqualObjects([wrapped class], [FSTIntegerValue class]);
     XCTAssertEqualObjects([wrapped value], @([value longLongValue]));
+    XCTAssertEqual([wrapped type], FSTFieldValueTypeInteger);
   }
 }
 
@@ -105,6 +106,7 @@ NSArray *FSTWrapGroups(NSArray *groups) {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);
     XCTAssertEqualObjects([wrapped class], [FSTDoubleValue class]);
     XCTAssertEqualObjects([wrapped value], value);
+    XCTAssertEqual([wrapped type], FSTFieldValueTypeDouble);
   }
 }
 
@@ -113,6 +115,7 @@ NSArray *FSTWrapGroups(NSArray *groups) {
   XCTAssertEqual(FSTTestFieldValue(nil), nullValue);
   XCTAssertEqual(FSTTestFieldValue([NSNull null]), nullValue);
   XCTAssertEqual([nullValue value], [NSNull null]);
+  XCTAssertEqual([nullValue type], FSTFieldValueTypeNull);
 }
 
 - (void)testWrapsBooleans {
@@ -121,6 +124,7 @@ NSArray *FSTWrapGroups(NSArray *groups) {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);
     XCTAssertEqualObjects([wrapped class], [FSTBooleanValue class]);
     XCTAssertEqualObjects([wrapped value], value);
+    XCTAssertEqual([wrapped type], FSTFieldValueTypeBoolean);
   }
 
   // Unsigned chars could conceivably be handled consistently with signed chars but on arm64 these
@@ -219,6 +223,7 @@ union DoubleBits {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);
     XCTAssertEqualObjects([wrapped class], [FSTStringValue class]);
     XCTAssertEqualObjects([wrapped value], value);
+    XCTAssertEqual([wrapped type], FSTFieldValueTypeString);
   }
 }
 
@@ -229,6 +234,7 @@ union DoubleBits {
     XCTAssertEqualObjects([wrapped class], [FSTTimestampValue class]);
     XCTAssertEqualObjects([[wrapped value] class], [FIRTimestamp class]);
     XCTAssertEqualObjects([wrapped value], [FIRTimestamp timestampWithDate:value]);
+    XCTAssertEqual([wrapped type], FSTFieldValueTypeTimestamp);
   }
 }
 
@@ -239,6 +245,7 @@ union DoubleBits {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);
     XCTAssertEqualObjects([wrapped class], [FSTGeoPointValue class]);
     XCTAssertEqualObjects([wrapped value], value);
+    XCTAssertEqual([wrapped type], FSTFieldValueTypeGeoPoint);
   }
 }
 
@@ -248,6 +255,7 @@ union DoubleBits {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);
     XCTAssertEqualObjects([wrapped class], [FSTBlobValue class]);
     XCTAssertEqualObjects([wrapped value], value);
+    XCTAssertEqual([wrapped type], FSTFieldValueTypeBlob);
   }
 }
 
@@ -262,11 +270,13 @@ union DoubleBits {
     XCTAssertEqualObjects([wrapped value], [FSTDocumentKey keyWithDocumentKey:value.key]);
     XCTAssertTrue(*((FSTReferenceValue *)wrapped).databaseID ==
                   *(const DatabaseId *)(value.databaseID));
+    XCTAssertEqual([wrapped type], FSTFieldValueTypeReference);
   }
 }
 
 - (void)testWrapsEmptyObjects {
   XCTAssertEqualObjects(FSTTestFieldValue(@{}), [FSTObjectValue objectValue]);
+  XCTAssertEqual([FSTTestFieldValue(@{}) type], FSTFieldValueTypeObject);
 }
 
 - (void)testWrapsSimpleObjects {
@@ -279,6 +289,7 @@ union DoubleBits {
     @"d" : [FSTNullValue nullValue]
   }];
   XCTAssertEqualObjects(actual, expected);
+  XCTAssertEqual([actual type], FSTFieldValueTypeObject);
 }
 
 - (void)testWrapsNestedObjects {
@@ -291,6 +302,7 @@ union DoubleBits {
     }]
   }];
   XCTAssertEqualObjects(actual, expected);
+  XCTAssertEqual([actual type], FSTFieldValueTypeObject);
 }
 
 - (void)testExtractsFields {
@@ -414,6 +426,7 @@ union DoubleBits {
 
   FSTArrayValue *actual = (FSTArrayValue *)FSTTestFieldValue(@[ @"value", @YES ]);
   XCTAssertEqualObjects(actual, expected);
+  XCTAssertEqual([actual type], FSTFieldValueTypeArray);
 }
 
 - (void)testValueEquality {

--- a/Firestore/Example/Tests/Model/FSTFieldValueTests.mm
+++ b/Firestore/Example/Tests/Model/FSTFieldValueTests.mm
@@ -93,7 +93,7 @@ NSArray *FSTWrapGroups(NSArray *groups) {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);
     XCTAssertEqualObjects([wrapped class], [FSTIntegerValue class]);
     XCTAssertEqualObjects([wrapped value], @([value longLongValue]));
-    XCTAssertEqual([wrapped type], FieldValue::Type::Integer);
+    XCTAssertEqual(wrapped.type, FieldValue::Type::Integer);
   }
 }
 
@@ -108,7 +108,7 @@ NSArray *FSTWrapGroups(NSArray *groups) {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);
     XCTAssertEqualObjects([wrapped class], [FSTDoubleValue class]);
     XCTAssertEqualObjects([wrapped value], value);
-    XCTAssertEqual([wrapped type], FieldValue::Type::Double);
+    XCTAssertEqual(wrapped.type, FieldValue::Type::Double);
   }
 }
 
@@ -117,7 +117,7 @@ NSArray *FSTWrapGroups(NSArray *groups) {
   XCTAssertEqual(FSTTestFieldValue(nil), nullValue);
   XCTAssertEqual(FSTTestFieldValue([NSNull null]), nullValue);
   XCTAssertEqual([nullValue value], [NSNull null]);
-  XCTAssertEqual([nullValue type], FieldValue::Type::Null);
+  XCTAssertEqual(nullValue.type, FieldValue::Type::Null);
 }
 
 - (void)testWrapsBooleans {
@@ -126,7 +126,7 @@ NSArray *FSTWrapGroups(NSArray *groups) {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);
     XCTAssertEqualObjects([wrapped class], [FSTBooleanValue class]);
     XCTAssertEqualObjects([wrapped value], value);
-    XCTAssertEqual([wrapped type], FieldValue::Type::Boolean);
+    XCTAssertEqual(wrapped.type, FieldValue::Type::Boolean);
   }
 
   // Unsigned chars could conceivably be handled consistently with signed chars but on arm64 these
@@ -225,7 +225,7 @@ union DoubleBits {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);
     XCTAssertEqualObjects([wrapped class], [FSTStringValue class]);
     XCTAssertEqualObjects([wrapped value], value);
-    XCTAssertEqual([wrapped type], FieldValue::Type::String);
+    XCTAssertEqual(wrapped.type, FieldValue::Type::String);
   }
 }
 
@@ -236,7 +236,7 @@ union DoubleBits {
     XCTAssertEqualObjects([wrapped class], [FSTTimestampValue class]);
     XCTAssertEqualObjects([[wrapped value] class], [FIRTimestamp class]);
     XCTAssertEqualObjects([wrapped value], [FIRTimestamp timestampWithDate:value]);
-    XCTAssertEqual([wrapped type], FieldValue::Type::Timestamp);
+    XCTAssertEqual(wrapped.type, FieldValue::Type::Timestamp);
   }
 }
 
@@ -247,7 +247,7 @@ union DoubleBits {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);
     XCTAssertEqualObjects([wrapped class], [FSTGeoPointValue class]);
     XCTAssertEqualObjects([wrapped value], value);
-    XCTAssertEqual([wrapped type], FieldValue::Type::GeoPoint);
+    XCTAssertEqual(wrapped.type, FieldValue::Type::GeoPoint);
   }
 }
 
@@ -257,7 +257,7 @@ union DoubleBits {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);
     XCTAssertEqualObjects([wrapped class], [FSTBlobValue class]);
     XCTAssertEqualObjects([wrapped value], value);
-    XCTAssertEqual([wrapped type], FieldValue::Type::Blob);
+    XCTAssertEqual(wrapped.type, FieldValue::Type::Blob);
   }
 }
 
@@ -272,13 +272,13 @@ union DoubleBits {
     XCTAssertEqualObjects([wrapped value], [FSTDocumentKey keyWithDocumentKey:value.key]);
     XCTAssertTrue(*((FSTReferenceValue *)wrapped).databaseID ==
                   *(const DatabaseId *)(value.databaseID));
-    XCTAssertEqual([wrapped type], FieldValue::Type::Reference);
+    XCTAssertEqual(wrapped.type, FieldValue::Type::Reference);
   }
 }
 
 - (void)testWrapsEmptyObjects {
   XCTAssertEqualObjects(FSTTestFieldValue(@{}), [FSTObjectValue objectValue]);
-  XCTAssertEqual([FSTTestFieldValue(@{}) type], FieldValue::Type::Object);
+  XCTAssertEqual(FSTTestFieldValue(@{}).type, FieldValue::Type::Object);
 }
 
 - (void)testWrapsSimpleObjects {
@@ -291,7 +291,7 @@ union DoubleBits {
     @"d" : [FSTNullValue nullValue]
   }];
   XCTAssertEqualObjects(actual, expected);
-  XCTAssertEqual([actual type], FieldValue::Type::Object);
+  XCTAssertEqual(actual.type, FieldValue::Type::Object);
 }
 
 - (void)testWrapsNestedObjects {
@@ -304,7 +304,7 @@ union DoubleBits {
     }]
   }];
   XCTAssertEqualObjects(actual, expected);
-  XCTAssertEqual([actual type], FieldValue::Type::Object);
+  XCTAssertEqual(actual.type, FieldValue::Type::Object);
 }
 
 - (void)testExtractsFields {
@@ -428,7 +428,7 @@ union DoubleBits {
 
   FSTArrayValue *actual = (FSTArrayValue *)FSTTestFieldValue(@[ @"value", @YES ]);
   XCTAssertEqualObjects(actual, expected);
-  XCTAssertEqual([actual type], FieldValue::Type::Array);
+  XCTAssertEqual(actual.type, FieldValue::Type::Array);
 }
 
 - (void)testValueEquality {

--- a/Firestore/Example/Tests/Model/FSTFieldValueTests.mm
+++ b/Firestore/Example/Tests/Model/FSTFieldValueTests.mm
@@ -27,12 +27,14 @@
 #import "Firestore/Example/Tests/Util/FSTHelpers.h"
 
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
+#include "Firestore/core/src/firebase/firestore/model/field_value.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 #include "Firestore/core/test/firebase/firestore/testutil/testutil.h"
 
 namespace testutil = firebase::firestore::testutil;
 namespace util = firebase::firestore::util;
 using firebase::firestore::model::DatabaseId;
+using firebase::firestore::model::FieldValue;
 
 /** Helper to wrap the values in a set of equality groups using FSTTestFieldValue(). */
 NSArray *FSTWrapGroups(NSArray *groups) {
@@ -91,7 +93,7 @@ NSArray *FSTWrapGroups(NSArray *groups) {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);
     XCTAssertEqualObjects([wrapped class], [FSTIntegerValue class]);
     XCTAssertEqualObjects([wrapped value], @([value longLongValue]));
-    XCTAssertEqual([wrapped type], FSTFieldValueTypeInteger);
+    XCTAssertEqual([wrapped type], FieldValue::Type::Integer);
   }
 }
 
@@ -106,7 +108,7 @@ NSArray *FSTWrapGroups(NSArray *groups) {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);
     XCTAssertEqualObjects([wrapped class], [FSTDoubleValue class]);
     XCTAssertEqualObjects([wrapped value], value);
-    XCTAssertEqual([wrapped type], FSTFieldValueTypeDouble);
+    XCTAssertEqual([wrapped type], FieldValue::Type::Double);
   }
 }
 
@@ -115,7 +117,7 @@ NSArray *FSTWrapGroups(NSArray *groups) {
   XCTAssertEqual(FSTTestFieldValue(nil), nullValue);
   XCTAssertEqual(FSTTestFieldValue([NSNull null]), nullValue);
   XCTAssertEqual([nullValue value], [NSNull null]);
-  XCTAssertEqual([nullValue type], FSTFieldValueTypeNull);
+  XCTAssertEqual([nullValue type], FieldValue::Type::Null);
 }
 
 - (void)testWrapsBooleans {
@@ -124,7 +126,7 @@ NSArray *FSTWrapGroups(NSArray *groups) {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);
     XCTAssertEqualObjects([wrapped class], [FSTBooleanValue class]);
     XCTAssertEqualObjects([wrapped value], value);
-    XCTAssertEqual([wrapped type], FSTFieldValueTypeBoolean);
+    XCTAssertEqual([wrapped type], FieldValue::Type::Boolean);
   }
 
   // Unsigned chars could conceivably be handled consistently with signed chars but on arm64 these
@@ -223,7 +225,7 @@ union DoubleBits {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);
     XCTAssertEqualObjects([wrapped class], [FSTStringValue class]);
     XCTAssertEqualObjects([wrapped value], value);
-    XCTAssertEqual([wrapped type], FSTFieldValueTypeString);
+    XCTAssertEqual([wrapped type], FieldValue::Type::String);
   }
 }
 
@@ -234,7 +236,7 @@ union DoubleBits {
     XCTAssertEqualObjects([wrapped class], [FSTTimestampValue class]);
     XCTAssertEqualObjects([[wrapped value] class], [FIRTimestamp class]);
     XCTAssertEqualObjects([wrapped value], [FIRTimestamp timestampWithDate:value]);
-    XCTAssertEqual([wrapped type], FSTFieldValueTypeTimestamp);
+    XCTAssertEqual([wrapped type], FieldValue::Type::Timestamp);
   }
 }
 
@@ -245,7 +247,7 @@ union DoubleBits {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);
     XCTAssertEqualObjects([wrapped class], [FSTGeoPointValue class]);
     XCTAssertEqualObjects([wrapped value], value);
-    XCTAssertEqual([wrapped type], FSTFieldValueTypeGeoPoint);
+    XCTAssertEqual([wrapped type], FieldValue::Type::GeoPoint);
   }
 }
 
@@ -255,7 +257,7 @@ union DoubleBits {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);
     XCTAssertEqualObjects([wrapped class], [FSTBlobValue class]);
     XCTAssertEqualObjects([wrapped value], value);
-    XCTAssertEqual([wrapped type], FSTFieldValueTypeBlob);
+    XCTAssertEqual([wrapped type], FieldValue::Type::Blob);
   }
 }
 
@@ -270,13 +272,13 @@ union DoubleBits {
     XCTAssertEqualObjects([wrapped value], [FSTDocumentKey keyWithDocumentKey:value.key]);
     XCTAssertTrue(*((FSTReferenceValue *)wrapped).databaseID ==
                   *(const DatabaseId *)(value.databaseID));
-    XCTAssertEqual([wrapped type], FSTFieldValueTypeReference);
+    XCTAssertEqual([wrapped type], FieldValue::Type::Reference);
   }
 }
 
 - (void)testWrapsEmptyObjects {
   XCTAssertEqualObjects(FSTTestFieldValue(@{}), [FSTObjectValue objectValue]);
-  XCTAssertEqual([FSTTestFieldValue(@{}) type], FSTFieldValueTypeObject);
+  XCTAssertEqual([FSTTestFieldValue(@{}) type], FieldValue::Type::Object);
 }
 
 - (void)testWrapsSimpleObjects {
@@ -289,7 +291,7 @@ union DoubleBits {
     @"d" : [FSTNullValue nullValue]
   }];
   XCTAssertEqualObjects(actual, expected);
-  XCTAssertEqual([actual type], FSTFieldValueTypeObject);
+  XCTAssertEqual([actual type], FieldValue::Type::Object);
 }
 
 - (void)testWrapsNestedObjects {
@@ -302,7 +304,7 @@ union DoubleBits {
     }]
   }];
   XCTAssertEqualObjects(actual, expected);
-  XCTAssertEqual([actual type], FSTFieldValueTypeObject);
+  XCTAssertEqual([actual type], FieldValue::Type::Object);
 }
 
 - (void)testExtractsFields {
@@ -426,7 +428,7 @@ union DoubleBits {
 
   FSTArrayValue *actual = (FSTArrayValue *)FSTTestFieldValue(@[ @"value", @YES ]);
   XCTAssertEqualObjects(actual, expected);
-  XCTAssertEqual([actual type], FSTFieldValueTypeArray);
+  XCTAssertEqual([actual type], FieldValue::Type::Array);
 }
 
 - (void)testValueEquality {

--- a/Firestore/Example/Tests/Util/FSTHelpers.mm
+++ b/Firestore/Example/Tests/Util/FSTHelpers.mm
@@ -147,7 +147,7 @@ FSTFieldValue *FSTTestFieldValue(id _Nullable value) {
 
 FSTObjectValue *FSTTestObjectValue(NSDictionary<NSString *, id> *data) {
   FSTFieldValue *wrapped = FSTTestFieldValue(data);
-  HARD_ASSERT([wrapped isKindOfClass:[FSTObjectValue class]], "Unsupported value: %s", data);
+  HARD_ASSERT([wrapped type] == FSTFieldValueTypeObject, "Unsupported value: %s", data);
   return (FSTObjectValue *)wrapped;
 }
 

--- a/Firestore/Example/Tests/Util/FSTHelpers.mm
+++ b/Firestore/Example/Tests/Util/FSTHelpers.mm
@@ -147,7 +147,7 @@ FSTFieldValue *FSTTestFieldValue(id _Nullable value) {
 
 FSTObjectValue *FSTTestObjectValue(NSDictionary<NSString *, id> *data) {
   FSTFieldValue *wrapped = FSTTestFieldValue(data);
-  HARD_ASSERT([wrapped type] == FSTFieldValueTypeObject, "Unsupported value: %s", data);
+  HARD_ASSERT([wrapped type] == FieldValue::Type::Object, "Unsupported value: %s", data);
   return (FSTObjectValue *)wrapped;
 }
 

--- a/Firestore/Example/Tests/Util/FSTHelpers.mm
+++ b/Firestore/Example/Tests/Util/FSTHelpers.mm
@@ -147,7 +147,7 @@ FSTFieldValue *FSTTestFieldValue(id _Nullable value) {
 
 FSTObjectValue *FSTTestObjectValue(NSDictionary<NSString *, id> *data) {
   FSTFieldValue *wrapped = FSTTestFieldValue(data);
-  HARD_ASSERT([wrapped type] == FieldValue::Type::Object, "Unsupported value: %s", data);
+  HARD_ASSERT(wrapped.type == FieldValue::Type::Object, "Unsupported value: %s", data);
   return (FSTObjectValue *)wrapped;
 }
 

--- a/Firestore/Source/API/FIRDocumentSnapshot.mm
+++ b/Firestore/Source/API/FIRDocumentSnapshot.mm
@@ -185,11 +185,11 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
 }
 
 - (id)convertedValue:(FSTFieldValue *)value options:(FSTFieldValueOptions *)options {
-  if ([value isKindOfClass:[FSTObjectValue class]]) {
+  if ([value type] == FSTFieldValueTypeObject) {
     return [self convertedObject:(FSTObjectValue *)value options:options];
-  } else if ([value isKindOfClass:[FSTArrayValue class]]) {
+  } else if ([value type] == FSTFieldValueTypeArray) {
     return [self convertedArray:(FSTArrayValue *)value options:options];
-  } else if ([value isKindOfClass:[FSTReferenceValue class]]) {
+  } else if ([value type] == FSTFieldValueTypeReference) {
     FSTReferenceValue *ref = (FSTReferenceValue *)value;
     const DatabaseId *refDatabase = ref.databaseID;
     const DatabaseId *database = &_snapshot.firestore()->database_id();

--- a/Firestore/Source/API/FIRDocumentSnapshot.mm
+++ b/Firestore/Source/API/FIRDocumentSnapshot.mm
@@ -187,11 +187,11 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
 }
 
 - (id)convertedValue:(FSTFieldValue *)value options:(FSTFieldValueOptions *)options {
-  if ([value type] == FieldValue::Type::Object) {
+  if (value.type == FieldValue::Type::Object) {
     return [self convertedObject:(FSTObjectValue *)value options:options];
-  } else if ([value type] == FieldValue::Type::Array) {
+  } else if (value.type == FieldValue::Type::Array) {
     return [self convertedArray:(FSTArrayValue *)value options:options];
-  } else if ([value type] == FieldValue::Type::Reference) {
+  } else if (value.type == FieldValue::Type::Reference) {
     FSTReferenceValue *ref = (FSTReferenceValue *)value;
     const DatabaseId *refDatabase = ref.databaseID;
     const DatabaseId *database = &_snapshot.firestore()->database_id();

--- a/Firestore/Source/API/FIRDocumentSnapshot.mm
+++ b/Firestore/Source/API/FIRDocumentSnapshot.mm
@@ -34,6 +34,7 @@
 #include "Firestore/core/src/firebase/firestore/api/firestore.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/field_value.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 
@@ -42,6 +43,7 @@ using firebase::firestore::api::DocumentSnapshot;
 using firebase::firestore::api::Firestore;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::FieldValue;
 using firebase::firestore::util::WrapNSString;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -185,11 +187,11 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
 }
 
 - (id)convertedValue:(FSTFieldValue *)value options:(FSTFieldValueOptions *)options {
-  if ([value type] == FSTFieldValueTypeObject) {
+  if ([value type] == FieldValue::Type::Object) {
     return [self convertedObject:(FSTObjectValue *)value options:options];
-  } else if ([value type] == FSTFieldValueTypeArray) {
+  } else if ([value type] == FieldValue::Type::Array) {
     return [self convertedArray:(FSTArrayValue *)value options:options];
-  } else if ([value type] == FSTFieldValueTypeReference) {
+  } else if ([value type] == FieldValue::Type::Reference) {
     FSTReferenceValue *ref = (FSTReferenceValue *)value;
     const DatabaseId *refDatabase = ref.databaseID;
     const DatabaseId *database = &_snapshot.firestore()->database_id();

--- a/Firestore/Source/API/FIRQuery.mm
+++ b/Firestore/Source/API/FIRQuery.mm
@@ -43,6 +43,7 @@
 
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/field_path.h"
+#include "Firestore/core/src/firebase/firestore/model/field_value.h"
 #include "Firestore/core/src/firebase/firestore/model/resource_path.h"
 #include "Firestore/core/src/firebase/firestore/util/error_apple.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
@@ -54,6 +55,7 @@ using firebase::firestore::core::ViewSnapshot;
 using firebase::firestore::core::ViewSnapshotHandler;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::FieldPath;
+using firebase::firestore::model::FieldValue;
 using firebase::firestore::model::ResourcePath;
 using firebase::firestore::util::MakeNSError;
 using firebase::firestore::util::StatusOr;
@@ -598,7 +600,7 @@ NS_ASSUME_NONNULL_BEGIN
     } else {
       FSTFieldValue *value = [document fieldForPath:sortOrder.field];
 
-      if ([value type] == FSTFieldValueTypeServerTimestamp) {
+      if ([value type] == FieldValue::Type::ServerTimestamp) {
         FSTThrowInvalidUsage(@"InvalidQueryException",
                              @"Invalid query. You are trying to start or end a query using a "
                               "document for which the field '%s' is an uncommitted server "

--- a/Firestore/Source/API/FIRQuery.mm
+++ b/Firestore/Source/API/FIRQuery.mm
@@ -598,7 +598,7 @@ NS_ASSUME_NONNULL_BEGIN
     } else {
       FSTFieldValue *value = [document fieldForPath:sortOrder.field];
 
-      if ([value isKindOfClass:[FSTServerTimestampValue class]]) {
+      if ([value type] == FSTFieldValueTypeServerTimestamp) {
         FSTThrowInvalidUsage(@"InvalidQueryException",
                              @"Invalid query. You are trying to start or end a query using a "
                               "document for which the field '%s' is an uncommitted server "

--- a/Firestore/Source/API/FIRQuery.mm
+++ b/Firestore/Source/API/FIRQuery.mm
@@ -600,7 +600,7 @@ NS_ASSUME_NONNULL_BEGIN
     } else {
       FSTFieldValue *value = [document fieldForPath:sortOrder.field];
 
-      if ([value type] == FieldValue::Type::ServerTimestamp) {
+      if (value.type == FieldValue::Type::ServerTimestamp) {
         FSTThrowInvalidUsage(@"InvalidQueryException",
                              @"Invalid query. You are trying to start or end a query using a "
                               "document for which the field '%s' is an uncommitted server "

--- a/Firestore/Source/Core/FSTQuery.mm
+++ b/Firestore/Source/Core/FSTQuery.mm
@@ -183,7 +183,7 @@ NSString *FSTStringFromQueryRelationOperator(FSTRelationFilterOperator filterOpe
 
 - (BOOL)matchesDocument:(FSTDocument *)document {
   if (_field.IsKeyFieldPath()) {
-    HARD_ASSERT([self.value isKindOfClass:[FSTReferenceValue class]],
+    HARD_ASSERT([self.value type] == FSTFieldValueTypeReference,
                 "Comparing on key, but filter value not a FSTReferenceValue.");
     HARD_ASSERT(self.filterOperator != FSTRelationFilterOperatorArrayContains,
                 "arrayContains queries don't make sense on document keys.");
@@ -472,7 +472,7 @@ NSString *FSTStringFromQueryRelationOperator(FSTRelationFilterOperator filterOpe
     FSTSortOrder *sortOrderComponent = sortOrder[idx];
     NSComparisonResult comparison;
     if (sortOrderComponent.field == FieldPath::KeyFieldPath()) {
-      HARD_ASSERT([fieldValue isKindOfClass:[FSTReferenceValue class]],
+      HARD_ASSERT([fieldValue type] == FSTFieldValueTypeReference,
                   "FSTBound has a non-key value where the key path is being used %s", fieldValue);
       FSTReferenceValue *refValue = (FSTReferenceValue *)fieldValue;
       comparison = CompareKeys(refValue.value.key, document.key);

--- a/Firestore/Source/Core/FSTQuery.mm
+++ b/Firestore/Source/Core/FSTQuery.mm
@@ -28,6 +28,7 @@
 
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/field_path.h"
+#include "Firestore/core/src/firebase/firestore/model/field_value.h"
 #include "Firestore/core/src/firebase/firestore/model/resource_path.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 #include "Firestore/core/src/firebase/firestore/util/hashing.h"
@@ -36,6 +37,7 @@
 namespace util = firebase::firestore::util;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::FieldPath;
+using firebase::firestore::model::FieldValue;
 using firebase::firestore::model::ResourcePath;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -183,7 +185,7 @@ NSString *FSTStringFromQueryRelationOperator(FSTRelationFilterOperator filterOpe
 
 - (BOOL)matchesDocument:(FSTDocument *)document {
   if (_field.IsKeyFieldPath()) {
-    HARD_ASSERT([self.value type] == FSTFieldValueTypeReference,
+    HARD_ASSERT([self.value type] == FieldValue::Type::Reference,
                 "Comparing on key, but filter value not a FSTReferenceValue.");
     HARD_ASSERT(self.filterOperator != FSTRelationFilterOperatorArrayContains,
                 "arrayContains queries don't make sense on document keys.");
@@ -472,7 +474,7 @@ NSString *FSTStringFromQueryRelationOperator(FSTRelationFilterOperator filterOpe
     FSTSortOrder *sortOrderComponent = sortOrder[idx];
     NSComparisonResult comparison;
     if (sortOrderComponent.field == FieldPath::KeyFieldPath()) {
-      HARD_ASSERT([fieldValue type] == FSTFieldValueTypeReference,
+      HARD_ASSERT([fieldValue type] == FieldValue::Type::Reference,
                   "FSTBound has a non-key value where the key path is being used %s", fieldValue);
       FSTReferenceValue *refValue = (FSTReferenceValue *)fieldValue;
       comparison = CompareKeys(refValue.value.key, document.key);

--- a/Firestore/Source/Core/FSTQuery.mm
+++ b/Firestore/Source/Core/FSTQuery.mm
@@ -185,7 +185,7 @@ NSString *FSTStringFromQueryRelationOperator(FSTRelationFilterOperator filterOpe
 
 - (BOOL)matchesDocument:(FSTDocument *)document {
   if (_field.IsKeyFieldPath()) {
-    HARD_ASSERT([self.value type] == FieldValue::Type::Reference,
+    HARD_ASSERT(self.value.type == FieldValue::Type::Reference,
                 "Comparing on key, but filter value not a FSTReferenceValue.");
     HARD_ASSERT(self.filterOperator != FSTRelationFilterOperatorArrayContains,
                 "arrayContains queries don't make sense on document keys.");
@@ -474,7 +474,7 @@ NSString *FSTStringFromQueryRelationOperator(FSTRelationFilterOperator filterOpe
     FSTSortOrder *sortOrderComponent = sortOrder[idx];
     NSComparisonResult comparison;
     if (sortOrderComponent.field == FieldPath::KeyFieldPath()) {
-      HARD_ASSERT([fieldValue type] == FieldValue::Type::Reference,
+      HARD_ASSERT(fieldValue.type == FieldValue::Type::Reference,
                   "FSTBound has a non-key value where the key path is being used %s", fieldValue);
       FSTReferenceValue *refValue = (FSTReferenceValue *)fieldValue;
       comparison = CompareKeys(refValue.value.key, document.key);

--- a/Firestore/Source/Model/FSTFieldValue.h
+++ b/Firestore/Source/Model/FSTFieldValue.h
@@ -21,6 +21,7 @@
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
 #include "Firestore/core/src/firebase/firestore/model/field_mask.h"
 #include "Firestore/core/src/firebase/firestore/model/field_path.h"
+#include "Firestore/core/src/firebase/firestore/model/field_value.h"
 
 @class FSTDocumentKey;
 @class FIRTimestamp;
@@ -28,25 +29,6 @@
 @class FIRGeoPoint;
 
 NS_ASSUME_NONNULL_BEGIN
-
-/**
- * The 'type' of this FSTFieldValue. Used for RTTI (rather than isKindOfClass)
- * to ease migration to C++.
- */
-typedef NS_ENUM(NSInteger, FSTFieldValueType) {
-  FSTFieldValueTypeNull,
-  FSTFieldValueTypeBoolean,
-  FSTFieldValueTypeInteger,
-  FSTFieldValueTypeDouble,
-  FSTFieldValueTypeTimestamp,
-  FSTFieldValueTypeServerTimestamp,
-  FSTFieldValueTypeString,
-  FSTFieldValueTypeBlob,
-  FSTFieldValueTypeReference,
-  FSTFieldValueTypeGeoPoint,
-  FSTFieldValueTypeArray,
-  FSTFieldValueTypeObject,
-};
 
 /** The order of types in Firestore; this order is defined by the backend. */
 typedef NS_ENUM(NSInteger, FSTTypeOrder) {
@@ -108,7 +90,7 @@ enum class ServerTimestampBehavior { None, Estimate, Previous };
  * Returns the 'type' of this FSTFieldValue. Used for RTTI (rather than isKindOfClass)
  * to ease migration to C++.
  */
-- (FSTFieldValueType)type;
+- (firebase::firestore::model::FieldValue::Type)type;
 
 /** Returns the FSTTypeOrder for this value. */
 - (FSTTypeOrder)typeOrder;

--- a/Firestore/Source/Model/FSTFieldValue.h
+++ b/Firestore/Source/Model/FSTFieldValue.h
@@ -23,6 +23,8 @@
 #include "Firestore/core/src/firebase/firestore/model/field_path.h"
 #include "Firestore/core/src/firebase/firestore/model/field_value.h"
 
+using firebase::firestore::model::FieldValue;
+
 @class FSTDocumentKey;
 @class FIRTimestamp;
 @class FSTFieldValueOptions;
@@ -90,10 +92,10 @@ enum class ServerTimestampBehavior { None, Estimate, Previous };
  * Returns the 'type' of this FSTFieldValue. Used for RTTI (rather than isKindOfClass)
  * to ease migration to C++.
  */
-- (firebase::firestore::model::FieldValue::Type)type;
+@property(nonatomic, assign, readonly) FieldValue::Type type;
 
 /** Returns the FSTTypeOrder for this value. */
-- (FSTTypeOrder)typeOrder;
+@property(nonatomic, assign, readonly) FSTTypeOrder typeOrder;
 
 /**
  * Converts an FSTFieldValue into the value that users will see in document snapshots.

--- a/Firestore/Source/Model/FSTFieldValue.h
+++ b/Firestore/Source/Model/FSTFieldValue.h
@@ -29,6 +29,25 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * The 'type' of this FSTFieldValue. Used for RTTI (rather than isKindOfClass)
+ * to ease migration to C++.
+ */
+typedef NS_ENUM(NSInteger, FSTFieldValueType) {
+  FSTFieldValueTypeNull,
+  FSTFieldValueTypeBoolean,
+  FSTFieldValueTypeInteger,
+  FSTFieldValueTypeDouble,
+  FSTFieldValueTypeTimestamp,
+  FSTFieldValueTypeServerTimestamp,
+  FSTFieldValueTypeString,
+  FSTFieldValueTypeBlob,
+  FSTFieldValueTypeReference,
+  FSTFieldValueTypeGeoPoint,
+  FSTFieldValueTypeArray,
+  FSTFieldValueTypeObject,
+};
+
 /** The order of types in Firestore; this order is defined by the backend. */
 typedef NS_ENUM(NSInteger, FSTTypeOrder) {
   FSTTypeOrderNull,
@@ -84,6 +103,12 @@ enum class ServerTimestampBehavior { None, Estimate, Previous };
  *  - Object
  */
 @interface FSTFieldValue<__covariant T> : NSObject
+
+/**
+ * Returns the 'type' of this FSTFieldValue. Used for RTTI (rather than isKindOfClass)
+ * to ease migration to C++.
+ */
+- (FSTFieldValueType)type;
 
 /** Returns the FSTTypeOrder for this value. */
 - (FSTTypeOrder)typeOrder;

--- a/Firestore/Source/Model/FSTFieldValue.mm
+++ b/Firestore/Source/Model/FSTFieldValue.mm
@@ -223,7 +223,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if ([other type] == FieldValue::Type::Boolean) {
+  if (other.type == FieldValue::Type::Boolean) {
     return WrapCompare<bool>(self.internalValue, ((FSTBooleanValue *)other).internalValue);
   } else {
     return [self defaultCompare:other];
@@ -241,24 +241,24 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if (!([other type] == FieldValue::Type::Integer || [other type] == FieldValue::Type::Double)) {
+  if (!FieldValue::IsNumber(other.type)) {
     return [self defaultCompare:other];
   } else {
-    if ([self type] == FieldValue::Type::Double) {
+    if (self.type == FieldValue::Type::Double) {
       double thisDouble = ((FSTDoubleValue *)self).internalValue;
-      if ([other type] == FieldValue::Type::Double) {
+      if (other.type == FieldValue::Type::Double) {
         return WrapCompare(thisDouble, ((FSTDoubleValue *)other).internalValue);
       } else {
-        HARD_ASSERT([other type] == FieldValue::Type::Integer, "Unknown number value: %s", other);
+        HARD_ASSERT(other.type == FieldValue::Type::Integer, "Unknown number value: %s", other);
         auto result = CompareMixedNumber(thisDouble, ((FSTIntegerValue *)other).internalValue);
         return static_cast<NSComparisonResult>(result);
       }
     } else {
       int64_t thisInt = ((FSTIntegerValue *)self).internalValue;
-      if ([other type] == FieldValue::Type::Integer) {
+      if (other.type == FieldValue::Type::Integer) {
         return WrapCompare(thisInt, ((FSTIntegerValue *)other).internalValue);
       } else {
-        HARD_ASSERT([other type] == FieldValue::Type::Double, "Unknown number value: %s", other);
+        HARD_ASSERT(other.type == FieldValue::Type::Double, "Unknown number value: %s", other);
         double otherDouble = ((FSTDoubleValue *)other).internalValue;
         auto result = ReverseOrder(CompareMixedNumber(otherDouble, thisInt));
         return static_cast<NSComparisonResult>(result);
@@ -301,7 +301,7 @@ NS_ASSUME_NONNULL_BEGIN
   // NOTE: DoubleValue and LongValue instances may compare: the same, but that doesn't make them
   // equal via isEqual:
   return [other isKindOfClass:[FSTFieldValue class]] &&
-         [(FSTFieldValue *)other type] == FieldValue::Type::Integer &&
+         ((FSTFieldValue *)other).type == FieldValue::Type::Integer &&
          self.internalValue == ((FSTIntegerValue *)other).internalValue;
 }
 
@@ -361,7 +361,7 @@ NS_ASSUME_NONNULL_BEGIN
   // NOTE: isEqual: should compare NaN equal to itself and -0.0 not equal to 0.0.
 
   return [other isKindOfClass:[FSTFieldValue class]] &&
-         [(FSTFieldValue *)other type] == FieldValue::Type::Double &&
+         ((FSTFieldValue *)other).type == FieldValue::Type::Double &&
          DoubleBitwiseEquals(self.internalValue, ((FSTDoubleValue *)other).internalValue);
 }
 
@@ -419,7 +419,7 @@ struct Comparator<NSString *> {
 
 - (BOOL)isEqual:(id)other {
   return [other isKindOfClass:[FSTFieldValue class]] &&
-         [(FSTFieldValue *)other type] == FieldValue::Type::String &&
+         ((FSTFieldValue *)other).type == FieldValue::Type::String &&
          [self.internalValue isEqualToString:((FSTStringValue *)other).internalValue];
 }
 
@@ -428,7 +428,7 @@ struct Comparator<NSString *> {
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if ([other type] == FieldValue::Type::String) {
+  if (other.type == FieldValue::Type::String) {
     return WrapCompare(self.internalValue, ((FSTStringValue *)other).internalValue);
   } else {
     return [self defaultCompare:other];
@@ -479,7 +479,7 @@ struct Comparator<NSString *> {
 
 - (BOOL)isEqual:(id)other {
   return [other isKindOfClass:[FSTFieldValue class]] &&
-         [(FSTFieldValue *)other type] == FieldValue::Type::Timestamp &&
+         ((FSTFieldValue *)other).type == FieldValue::Type::Timestamp &&
          [self.internalValue isEqual:((FSTTimestampValue *)other).internalValue];
 }
 
@@ -488,9 +488,9 @@ struct Comparator<NSString *> {
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if ([other type] == FieldValue::Type::Timestamp) {
+  if (other.type == FieldValue::Type::Timestamp) {
     return [self.internalValue compare:((FSTTimestampValue *)other).internalValue];
-  } else if ([other type] == FieldValue::Type::ServerTimestamp) {
+  } else if (other.type == FieldValue::Type::ServerTimestamp) {
     // Concrete timestamps come before server timestamps.
     return NSOrderedAscending;
   } else {
@@ -546,7 +546,7 @@ struct Comparator<NSString *> {
 
 - (BOOL)isEqual:(id)other {
   return [other isKindOfClass:[FSTFieldValue class]] &&
-         [(FSTFieldValue *)other type] == FieldValue::Type::ServerTimestamp &&
+         ((FSTFieldValue *)other).type == FieldValue::Type::ServerTimestamp &&
          [self.localWriteTime isEqual:((FSTServerTimestampValue *)other).localWriteTime];
 }
 
@@ -559,9 +559,9 @@ struct Comparator<NSString *> {
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if ([other type] == FieldValue::Type::ServerTimestamp) {
+  if (other.type == FieldValue::Type::ServerTimestamp) {
     return [self.localWriteTime compare:((FSTServerTimestampValue *)other).localWriteTime];
-  } else if ([other type] == FieldValue::Type::Timestamp) {
+  } else if (other.type == FieldValue::Type::Timestamp) {
     // Server timestamps come after all concrete timestamps.
     return NSOrderedDescending;
   } else {
@@ -605,7 +605,7 @@ struct Comparator<NSString *> {
 
 - (BOOL)isEqual:(id)other {
   return [other isKindOfClass:[FSTFieldValue class]] &&
-         [(FSTFieldValue *)other type] == FieldValue::Type::GeoPoint &&
+         ((FSTFieldValue *)other).type == FieldValue::Type::GeoPoint &&
          [self.internalValue isEqual:((FSTGeoPointValue *)other).internalValue];
 }
 
@@ -614,7 +614,7 @@ struct Comparator<NSString *> {
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if ([other type] == FieldValue::Type::GeoPoint) {
+  if (other.type == FieldValue::Type::GeoPoint) {
     return [self.internalValue compare:((FSTGeoPointValue *)other).internalValue];
   } else {
     return [self defaultCompare:other];
@@ -673,7 +673,7 @@ static NSComparisonResult CompareBytes(NSData *left, NSData *right) {
 
 - (BOOL)isEqual:(id)other {
   return [other isKindOfClass:[FSTFieldValue class]] &&
-         [(FSTFieldValue *)other type] == FieldValue::Type::Blob &&
+         ((FSTFieldValue *)other).type == FieldValue::Type::Blob &&
          [self.internalValue isEqual:((FSTBlobValue *)other).internalValue];
 }
 
@@ -682,7 +682,7 @@ static NSComparisonResult CompareBytes(NSData *left, NSData *right) {
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if ([other type] == FieldValue::Type::Blob) {
+  if (other.type == FieldValue::Type::Blob) {
     return CompareBytes(self.internalValue, ((FSTBlobValue *)other).internalValue);
   } else {
     return [self defaultCompare:other];
@@ -729,7 +729,7 @@ static NSComparisonResult CompareBytes(NSData *left, NSData *right) {
     return YES;
   }
   if (!([other isKindOfClass:[FSTFieldValue class]] &&
-        [(FSTFieldValue *)other type] == FieldValue::Type::Reference)) {
+        ((FSTFieldValue *)other).type == FieldValue::Type::Reference)) {
     return NO;
   }
 
@@ -744,7 +744,7 @@ static NSComparisonResult CompareBytes(NSData *left, NSData *right) {
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if ([other type] == FieldValue::Type::Reference) {
+  if (other.type == FieldValue::Type::Reference) {
     FSTReferenceValue *ref = (FSTReferenceValue *)other;
     NSComparisonResult cmp =
         WrapCompare(self.databaseID->project_id(), ref.databaseID->project_id());
@@ -831,7 +831,7 @@ static const NSComparator StringComparator = ^NSComparisonResult(NSString *left,
     return YES;
   }
   if (!([other isKindOfClass:[FSTFieldValue class]] &&
-        [(FSTFieldValue *)other type] == FieldValue::Type::Object)) {
+        ((FSTFieldValue *)other).type == FieldValue::Type::Object)) {
     return NO;
   }
 
@@ -844,7 +844,7 @@ static const NSComparator StringComparator = ^NSComparisonResult(NSString *left,
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if ([other type] == FieldValue::Type::Object) {
+  if (other.type == FieldValue::Type::Object) {
     FSTImmutableSortedDictionary *selfDict = self.internalValue;
     FSTImmutableSortedDictionary *otherDict = ((FSTObjectValue *)other).internalValue;
     NSEnumerator *enumerator1 = [selfDict keyEnumerator];
@@ -897,7 +897,7 @@ static const NSComparator StringComparator = ^NSComparisonResult(NSString *left,
     // around the result.
     FSTFieldValue *child = [_internalValue objectForKey:childName];
     FSTObjectValue *childObject;
-    if ([child type] == FieldValue::Type::Object) {
+    if (child.type == FieldValue::Type::Object) {
       childObject = (FSTObjectValue *)child;
     } else {
       // If the child is not found or is a primitive type, pretend as if an empty object lived
@@ -917,7 +917,7 @@ static const NSComparator StringComparator = ^NSComparisonResult(NSString *left,
         initWithImmutableDictionary:[_internalValue dictionaryByRemovingObjectForKey:childName]];
   } else {
     FSTFieldValue *child = _internalValue[childName];
-    if ([child type] == FieldValue::Type::Object) {
+    if (child.type == FieldValue::Type::Object) {
       FSTObjectValue *newChild =
           [((FSTObjectValue *)child) objectByDeletingPath:fieldPath.PopFirst()];
       return [self objectBySettingValue:newChild forField:childName];
@@ -1009,7 +1009,7 @@ static const NSComparator StringComparator = ^NSComparisonResult(NSString *left,
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if ([other type] == FieldValue::Type::Array) {
+  if (other.type == FieldValue::Type::Array) {
     NSArray<FSTFieldValue *> *selfArray = self.internalValue;
     NSArray<FSTFieldValue *> *otherArray = ((FSTArrayValue *)other).internalValue;
     NSUInteger minLength = MIN(selfArray.count, otherArray.count);

--- a/Firestore/Source/Model/FSTFieldValue.mm
+++ b/Firestore/Source/Model/FSTFieldValue.mm
@@ -69,6 +69,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FSTFieldValue
 
+- (FSTFieldValueType)type {
+  @throw FSTAbstractMethodException();  // NOLINT
+}
+
 - (FSTTypeOrder)typeOrder {
   @throw FSTAbstractMethodException();  // NOLINT
 }
@@ -121,6 +125,10 @@ NS_ASSUME_NONNULL_BEGIN
     sharedInstance = [[FSTNullValue alloc] init];
   });
   return sharedInstance;
+}
+
+- (FSTFieldValueType)type {
+  return FSTFieldValueTypeNull;
 }
 
 - (FSTTypeOrder)typeOrder {
@@ -187,6 +195,10 @@ NS_ASSUME_NONNULL_BEGIN
     _internalValue = value;
   }
   return self;
+}
+
+- (FSTFieldValueType)type {
+  return FSTFieldValueTypeBoolean;
 }
 
 - (FSTTypeOrder)typeOrder {
@@ -279,6 +291,10 @@ NS_ASSUME_NONNULL_BEGIN
   return @(self.internalValue);
 }
 
+- (FSTFieldValueType)type {
+  return FSTFieldValueTypeInteger;
+}
+
 - (BOOL)isEqual:(id)other {
   // NOTE: DoubleValue and LongValue instances may compare: the same, but that doesn't make them
   // equal via isEqual:
@@ -331,6 +347,10 @@ NS_ASSUME_NONNULL_BEGIN
   return @(self.internalValue);
 }
 
+- (FSTFieldValueType)type {
+  return FSTFieldValueTypeDouble;
+}
+
 - (BOOL)isEqual:(id)other {
   // NOTE: DoubleValue and LongValue instances may compare: the same, but that doesn't make them
   // equal via isEqual:
@@ -381,6 +401,10 @@ struct Comparator<NSString *> {
   return self;
 }
 
+- (FSTFieldValueType)type {
+  return FSTFieldValueTypeString;
+}
+
 - (FSTTypeOrder)typeOrder {
   return FSTTypeOrderString;
 }
@@ -426,6 +450,10 @@ struct Comparator<NSString *> {
     _internalValue = value;  // FIRTimestamp is immutable.
   }
   return self;
+}
+
+- (FSTFieldValueType)type {
+  return FSTFieldValueTypeTimestamp;
 }
 
 - (FSTTypeOrder)typeOrder {
@@ -483,6 +511,10 @@ struct Comparator<NSString *> {
     _previousValue = previousValue;
   }
   return self;
+}
+
+- (FSTFieldValueType)type {
+  return FSTFieldValueTypeServerTimestamp;
 }
 
 - (FSTTypeOrder)typeOrder {
@@ -552,6 +584,10 @@ struct Comparator<NSString *> {
   return self;
 }
 
+- (FSTFieldValueType)type {
+  return FSTFieldValueTypeGeoPoint;
+}
+
 - (FSTTypeOrder)typeOrder {
   return FSTTypeOrderGeoPoint;
 }
@@ -615,6 +651,10 @@ static NSComparisonResult CompareBytes(NSData *left, NSData *right) {
   return self;
 }
 
+- (FSTFieldValueType)type {
+  return FSTFieldValueTypeBlob;
+}
+
 - (FSTTypeOrder)typeOrder {
   return FSTTypeOrderBlob;
 }
@@ -665,6 +705,10 @@ static NSComparisonResult CompareBytes(NSData *left, NSData *right) {
 
 - (id)value {
   return self.key;
+}
+
+- (FSTFieldValueType)type {
+  return FSTFieldValueTypeReference;
 }
 
 - (FSTTypeOrder)typeOrder {
@@ -762,6 +806,10 @@ static const NSComparator StringComparator = ^NSComparisonResult(NSString *left,
         result[key] = [obj valueWithOptions:options];
       }];
   return result;
+}
+
+- (FSTFieldValueType)type {
+  return FSTFieldValueTypeObject;
 }
 
 - (FSTTypeOrder)typeOrder {
@@ -939,6 +987,10 @@ static const NSComparator StringComparator = ^NSComparisonResult(NSString *left,
     [result addObject:[obj valueWithOptions:options]];
   }];
   return result;
+}
+
+- (FSTFieldValueType)type {
+  return FSTFieldValueTypeArray;
 }
 
 - (FSTTypeOrder)typeOrder {

--- a/Firestore/Source/Model/FSTFieldValue.mm
+++ b/Firestore/Source/Model/FSTFieldValue.mm
@@ -70,6 +70,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FSTFieldValue
 
+@dynamic type;
+@dynamic typeOrder;
+
 - (FieldValue::Type)type {
   @throw FSTAbstractMethodException();  // NOLINT
 }

--- a/Firestore/Source/Model/FSTFieldValue.mm
+++ b/Firestore/Source/Model/FSTFieldValue.mm
@@ -34,6 +34,7 @@ namespace util = firebase::firestore::util;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::FieldMask;
 using firebase::firestore::model::FieldPath;
+using firebase::firestore::model::FieldValue;
 using firebase::firestore::util::Comparator;
 using firebase::firestore::util::CompareMixedNumber;
 using firebase::firestore::util::DoubleBitwiseEquals;
@@ -69,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FSTFieldValue
 
-- (FSTFieldValueType)type {
+- (FieldValue::Type)type {
   @throw FSTAbstractMethodException();  // NOLINT
 }
 
@@ -127,8 +128,8 @@ NS_ASSUME_NONNULL_BEGIN
   return sharedInstance;
 }
 
-- (FSTFieldValueType)type {
-  return FSTFieldValueTypeNull;
+- (FieldValue::Type)type {
+  return FieldValue::Type::Null;
 }
 
 - (FSTTypeOrder)typeOrder {
@@ -197,8 +198,8 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
-- (FSTFieldValueType)type {
-  return FSTFieldValueTypeBoolean;
+- (FieldValue::Type)type {
+  return FieldValue::Type::Boolean;
 }
 
 - (FSTTypeOrder)typeOrder {
@@ -219,7 +220,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if ([other type] == FSTFieldValueTypeBoolean) {
+  if ([other type] == FieldValue::Type::Boolean) {
     return WrapCompare<bool>(self.internalValue, ((FSTBooleanValue *)other).internalValue);
   } else {
     return [self defaultCompare:other];
@@ -237,24 +238,24 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if (!([other type] == FSTFieldValueTypeInteger || [other type] == FSTFieldValueTypeDouble)) {
+  if (!([other type] == FieldValue::Type::Integer || [other type] == FieldValue::Type::Double)) {
     return [self defaultCompare:other];
   } else {
-    if ([self type] == FSTFieldValueTypeDouble) {
+    if ([self type] == FieldValue::Type::Double) {
       double thisDouble = ((FSTDoubleValue *)self).internalValue;
-      if ([other type] == FSTFieldValueTypeDouble) {
+      if ([other type] == FieldValue::Type::Double) {
         return WrapCompare(thisDouble, ((FSTDoubleValue *)other).internalValue);
       } else {
-        HARD_ASSERT([other type] == FSTFieldValueTypeInteger, "Unknown number value: %s", other);
+        HARD_ASSERT([other type] == FieldValue::Type::Integer, "Unknown number value: %s", other);
         auto result = CompareMixedNumber(thisDouble, ((FSTIntegerValue *)other).internalValue);
         return static_cast<NSComparisonResult>(result);
       }
     } else {
       int64_t thisInt = ((FSTIntegerValue *)self).internalValue;
-      if ([other type] == FSTFieldValueTypeInteger) {
+      if ([other type] == FieldValue::Type::Integer) {
         return WrapCompare(thisInt, ((FSTIntegerValue *)other).internalValue);
       } else {
-        HARD_ASSERT([other type] == FSTFieldValueTypeDouble, "Unknown number value: %s", other);
+        HARD_ASSERT([other type] == FieldValue::Type::Double, "Unknown number value: %s", other);
         double otherDouble = ((FSTDoubleValue *)other).internalValue;
         auto result = ReverseOrder(CompareMixedNumber(otherDouble, thisInt));
         return static_cast<NSComparisonResult>(result);
@@ -289,15 +290,15 @@ NS_ASSUME_NONNULL_BEGIN
   return @(self.internalValue);
 }
 
-- (FSTFieldValueType)type {
-  return FSTFieldValueTypeInteger;
+- (FieldValue::Type)type {
+  return FieldValue::Type::Integer;
 }
 
 - (BOOL)isEqual:(id)other {
   // NOTE: DoubleValue and LongValue instances may compare: the same, but that doesn't make them
   // equal via isEqual:
   return [other isKindOfClass:[FSTFieldValue class]] &&
-         [(FSTFieldValue *)other type] == FSTFieldValueTypeInteger &&
+         [(FSTFieldValue *)other type] == FieldValue::Type::Integer &&
          self.internalValue == ((FSTIntegerValue *)other).internalValue;
 }
 
@@ -346,8 +347,8 @@ NS_ASSUME_NONNULL_BEGIN
   return @(self.internalValue);
 }
 
-- (FSTFieldValueType)type {
-  return FSTFieldValueTypeDouble;
+- (FieldValue::Type)type {
+  return FieldValue::Type::Double;
 }
 
 - (BOOL)isEqual:(id)other {
@@ -357,7 +358,7 @@ NS_ASSUME_NONNULL_BEGIN
   // NOTE: isEqual: should compare NaN equal to itself and -0.0 not equal to 0.0.
 
   return [other isKindOfClass:[FSTFieldValue class]] &&
-         [(FSTFieldValue *)other type] == FSTFieldValueTypeDouble &&
+         [(FSTFieldValue *)other type] == FieldValue::Type::Double &&
          DoubleBitwiseEquals(self.internalValue, ((FSTDoubleValue *)other).internalValue);
 }
 
@@ -401,8 +402,8 @@ struct Comparator<NSString *> {
   return self;
 }
 
-- (FSTFieldValueType)type {
-  return FSTFieldValueTypeString;
+- (FieldValue::Type)type {
+  return FieldValue::Type::String;
 }
 
 - (FSTTypeOrder)typeOrder {
@@ -415,7 +416,7 @@ struct Comparator<NSString *> {
 
 - (BOOL)isEqual:(id)other {
   return [other isKindOfClass:[FSTFieldValue class]] &&
-         [(FSTFieldValue *)other type] == FSTFieldValueTypeString &&
+         [(FSTFieldValue *)other type] == FieldValue::Type::String &&
          [self.internalValue isEqualToString:((FSTStringValue *)other).internalValue];
 }
 
@@ -424,7 +425,7 @@ struct Comparator<NSString *> {
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if ([other type] == FSTFieldValueTypeString) {
+  if ([other type] == FieldValue::Type::String) {
     return WrapCompare(self.internalValue, ((FSTStringValue *)other).internalValue);
   } else {
     return [self defaultCompare:other];
@@ -453,8 +454,8 @@ struct Comparator<NSString *> {
   return self;
 }
 
-- (FSTFieldValueType)type {
-  return FSTFieldValueTypeTimestamp;
+- (FieldValue::Type)type {
+  return FieldValue::Type::Timestamp;
 }
 
 - (FSTTypeOrder)typeOrder {
@@ -475,7 +476,7 @@ struct Comparator<NSString *> {
 
 - (BOOL)isEqual:(id)other {
   return [other isKindOfClass:[FSTFieldValue class]] &&
-         [(FSTFieldValue *)other type] == FSTFieldValueTypeTimestamp &&
+         [(FSTFieldValue *)other type] == FieldValue::Type::Timestamp &&
          [self.internalValue isEqual:((FSTTimestampValue *)other).internalValue];
 }
 
@@ -484,9 +485,9 @@ struct Comparator<NSString *> {
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if ([other type] == FSTFieldValueTypeTimestamp) {
+  if ([other type] == FieldValue::Type::Timestamp) {
     return [self.internalValue compare:((FSTTimestampValue *)other).internalValue];
-  } else if ([other type] == FSTFieldValueTypeServerTimestamp) {
+  } else if ([other type] == FieldValue::Type::ServerTimestamp) {
     // Concrete timestamps come before server timestamps.
     return NSOrderedAscending;
   } else {
@@ -515,8 +516,8 @@ struct Comparator<NSString *> {
   return self;
 }
 
-- (FSTFieldValueType)type {
-  return FSTFieldValueTypeServerTimestamp;
+- (FieldValue::Type)type {
+  return FieldValue::Type::ServerTimestamp;
 }
 
 - (FSTTypeOrder)typeOrder {
@@ -542,7 +543,7 @@ struct Comparator<NSString *> {
 
 - (BOOL)isEqual:(id)other {
   return [other isKindOfClass:[FSTFieldValue class]] &&
-         [(FSTFieldValue *)other type] == FSTFieldValueTypeServerTimestamp &&
+         [(FSTFieldValue *)other type] == FieldValue::Type::ServerTimestamp &&
          [self.localWriteTime isEqual:((FSTServerTimestampValue *)other).localWriteTime];
 }
 
@@ -555,9 +556,9 @@ struct Comparator<NSString *> {
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if ([other type] == FSTFieldValueTypeServerTimestamp) {
+  if ([other type] == FieldValue::Type::ServerTimestamp) {
     return [self.localWriteTime compare:((FSTServerTimestampValue *)other).localWriteTime];
-  } else if ([other type] == FSTFieldValueTypeTimestamp) {
+  } else if ([other type] == FieldValue::Type::Timestamp) {
     // Server timestamps come after all concrete timestamps.
     return NSOrderedDescending;
   } else {
@@ -587,8 +588,8 @@ struct Comparator<NSString *> {
   return self;
 }
 
-- (FSTFieldValueType)type {
-  return FSTFieldValueTypeGeoPoint;
+- (FieldValue::Type)type {
+  return FieldValue::Type::GeoPoint;
 }
 
 - (FSTTypeOrder)typeOrder {
@@ -601,7 +602,7 @@ struct Comparator<NSString *> {
 
 - (BOOL)isEqual:(id)other {
   return [other isKindOfClass:[FSTFieldValue class]] &&
-         [(FSTFieldValue *)other type] == FSTFieldValueTypeGeoPoint &&
+         [(FSTFieldValue *)other type] == FieldValue::Type::GeoPoint &&
          [self.internalValue isEqual:((FSTGeoPointValue *)other).internalValue];
 }
 
@@ -610,7 +611,7 @@ struct Comparator<NSString *> {
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if ([other type] == FSTFieldValueTypeGeoPoint) {
+  if ([other type] == FieldValue::Type::GeoPoint) {
     return [self.internalValue compare:((FSTGeoPointValue *)other).internalValue];
   } else {
     return [self defaultCompare:other];
@@ -655,8 +656,8 @@ static NSComparisonResult CompareBytes(NSData *left, NSData *right) {
   return self;
 }
 
-- (FSTFieldValueType)type {
-  return FSTFieldValueTypeBlob;
+- (FieldValue::Type)type {
+  return FieldValue::Type::Blob;
 }
 
 - (FSTTypeOrder)typeOrder {
@@ -669,7 +670,7 @@ static NSComparisonResult CompareBytes(NSData *left, NSData *right) {
 
 - (BOOL)isEqual:(id)other {
   return [other isKindOfClass:[FSTFieldValue class]] &&
-         [(FSTFieldValue *)other type] == FSTFieldValueTypeBlob &&
+         [(FSTFieldValue *)other type] == FieldValue::Type::Blob &&
          [self.internalValue isEqual:((FSTBlobValue *)other).internalValue];
 }
 
@@ -678,7 +679,7 @@ static NSComparisonResult CompareBytes(NSData *left, NSData *right) {
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if ([other type] == FSTFieldValueTypeBlob) {
+  if ([other type] == FieldValue::Type::Blob) {
     return CompareBytes(self.internalValue, ((FSTBlobValue *)other).internalValue);
   } else {
     return [self defaultCompare:other];
@@ -712,8 +713,8 @@ static NSComparisonResult CompareBytes(NSData *left, NSData *right) {
   return self.key;
 }
 
-- (FSTFieldValueType)type {
-  return FSTFieldValueTypeReference;
+- (FieldValue::Type)type {
+  return FieldValue::Type::Reference;
 }
 
 - (FSTTypeOrder)typeOrder {
@@ -725,7 +726,7 @@ static NSComparisonResult CompareBytes(NSData *left, NSData *right) {
     return YES;
   }
   if (!([other isKindOfClass:[FSTFieldValue class]] &&
-        [(FSTFieldValue *)other type] == FSTFieldValueTypeReference)) {
+        [(FSTFieldValue *)other type] == FieldValue::Type::Reference)) {
     return NO;
   }
 
@@ -740,7 +741,7 @@ static NSComparisonResult CompareBytes(NSData *left, NSData *right) {
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if ([other type] == FSTFieldValueTypeReference) {
+  if ([other type] == FieldValue::Type::Reference) {
     FSTReferenceValue *ref = (FSTReferenceValue *)other;
     NSComparisonResult cmp =
         WrapCompare(self.databaseID->project_id(), ref.databaseID->project_id());
@@ -814,8 +815,8 @@ static const NSComparator StringComparator = ^NSComparisonResult(NSString *left,
   return result;
 }
 
-- (FSTFieldValueType)type {
-  return FSTFieldValueTypeObject;
+- (FieldValue::Type)type {
+  return FieldValue::Type::Object;
 }
 
 - (FSTTypeOrder)typeOrder {
@@ -827,7 +828,7 @@ static const NSComparator StringComparator = ^NSComparisonResult(NSString *left,
     return YES;
   }
   if (!([other isKindOfClass:[FSTFieldValue class]] &&
-        [(FSTFieldValue *)other type] == FSTFieldValueTypeObject)) {
+        [(FSTFieldValue *)other type] == FieldValue::Type::Object)) {
     return NO;
   }
 
@@ -840,7 +841,7 @@ static const NSComparator StringComparator = ^NSComparisonResult(NSString *left,
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if ([other type] == FSTFieldValueTypeObject) {
+  if ([other type] == FieldValue::Type::Object) {
     FSTImmutableSortedDictionary *selfDict = self.internalValue;
     FSTImmutableSortedDictionary *otherDict = ((FSTObjectValue *)other).internalValue;
     NSEnumerator *enumerator1 = [selfDict keyEnumerator];
@@ -893,7 +894,7 @@ static const NSComparator StringComparator = ^NSComparisonResult(NSString *left,
     // around the result.
     FSTFieldValue *child = [_internalValue objectForKey:childName];
     FSTObjectValue *childObject;
-    if ([child type] == FSTFieldValueTypeObject) {
+    if ([child type] == FieldValue::Type::Object) {
       childObject = (FSTObjectValue *)child;
     } else {
       // If the child is not found or is a primitive type, pretend as if an empty object lived
@@ -913,7 +914,7 @@ static const NSComparator StringComparator = ^NSComparisonResult(NSString *left,
         initWithImmutableDictionary:[_internalValue dictionaryByRemovingObjectForKey:childName]];
   } else {
     FSTFieldValue *child = _internalValue[childName];
-    if ([child type] == FSTFieldValueTypeObject) {
+    if ([child type] == FieldValue::Type::Object) {
       FSTObjectValue *newChild =
           [((FSTObjectValue *)child) objectByDeletingPath:fieldPath.PopFirst()];
       return [self objectBySettingValue:newChild forField:childName];
@@ -996,8 +997,8 @@ static const NSComparator StringComparator = ^NSComparisonResult(NSString *left,
   return result;
 }
 
-- (FSTFieldValueType)type {
-  return FSTFieldValueTypeArray;
+- (FieldValue::Type)type {
+  return FieldValue::Type::Array;
 }
 
 - (FSTTypeOrder)typeOrder {
@@ -1005,7 +1006,7 @@ static const NSComparator StringComparator = ^NSComparisonResult(NSString *left,
 }
 
 - (NSComparisonResult)compare:(FSTFieldValue *)other {
-  if ([other type] == FSTFieldValueTypeArray) {
+  if ([other type] == FieldValue::Type::Array) {
     NSArray<FSTFieldValue *> *selfArray = self.internalValue;
     NSArray<FSTFieldValue *> *otherArray = ((FSTArrayValue *)other).internalValue;
     NSUInteger minLength = MIN(selfArray.count, otherArray.count);

--- a/Firestore/core/src/firebase/firestore/model/field_value.h
+++ b/Firestore/core/src/firebase/firestore/model/field_value.h
@@ -80,6 +80,14 @@ class FieldValue {
     // position instead, see the doc comment above.
   };
 
+  /**
+   * Checks if the given type is a numeric, such as Type::Integer or
+   * Type::Double.
+   */
+  static bool IsNumber(Type type) {
+    return type == Type::Integer || type == Type::Double;
+  }
+
   FieldValue() {
   }
 

--- a/Firestore/core/src/firebase/firestore/model/transform_operations.h
+++ b/Firestore/core/src/firebase/firestore/model/transform_operations.h
@@ -27,6 +27,7 @@
 #import "Firestore/Source/Model/FSTFieldValue.h"
 
 #include "Firestore/core/include/firebase/firestore/timestamp.h"
+#include "Firestore/core/src/firebase/firestore/model/field_value.h"
 
 namespace firebase {
 namespace firestore {
@@ -259,18 +260,18 @@ class NumericIncrementTransform : public TransformOperation {
       FIRTimestamp* /* localWriteTime */) const override {
     // Return an integer value only if the previous value and the operand is an
     // integer.
-    if ([previousValue type] == FSTFieldValueTypeInteger &&
-        [operand_ type] == FSTFieldValueTypeInteger) {
+    if ([previousValue type] == FieldValue::Type::Integer &&
+        [operand_ type] == FieldValue::Type::Integer) {
       int64_t sum = SafeIncrement(
           (static_cast<FSTIntegerValue*>(previousValue)).internalValue,
           (static_cast<FSTIntegerValue*>(operand_)).internalValue);
       return [FSTIntegerValue integerValue:sum];
-    } else if ([previousValue type] == FSTFieldValueTypeInteger) {
+    } else if ([previousValue type] == FieldValue::Type::Integer) {
       double sum =
           (static_cast<FSTIntegerValue*>(previousValue)).internalValue +
           OperandAsDouble();
       return [FSTDoubleValue doubleValue:sum];
-    } else if ([previousValue type] == FSTFieldValueTypeDouble) {
+    } else if ([previousValue type] == FieldValue::Type::Double) {
       double sum = (static_cast<FSTDoubleValue*>(previousValue)).internalValue +
                    OperandAsDouble();
       return [FSTDoubleValue doubleValue:sum];
@@ -329,9 +330,9 @@ class NumericIncrementTransform : public TransformOperation {
   }
 
   double OperandAsDouble() const {
-    if ([operand_ type] == FSTFieldValueTypeDouble) {
+    if ([operand_ type] == FieldValue::Type::Double) {
       return (static_cast<FSTDoubleValue*>(operand_)).internalValue;
-    } else if ([operand_ type] == FSTFieldValueTypeInteger) {
+    } else if ([operand_ type] == FieldValue::Type::Integer) {
       return (static_cast<FSTIntegerValue*>(operand_)).internalValue;
     } else {
       HARD_FAIL("Expected 'operand' to be of FSTNumerValue type, but was %s",

--- a/Firestore/core/src/firebase/firestore/model/transform_operations.h
+++ b/Firestore/core/src/firebase/firestore/model/transform_operations.h
@@ -260,18 +260,18 @@ class NumericIncrementTransform : public TransformOperation {
       FIRTimestamp* /* localWriteTime */) const override {
     // Return an integer value only if the previous value and the operand is an
     // integer.
-    if ([previousValue type] == FieldValue::Type::Integer &&
-        [operand_ type] == FieldValue::Type::Integer) {
+    if (previousValue.type == FieldValue::Type::Integer &&
+        operand_.type == FieldValue::Type::Integer) {
       int64_t sum = SafeIncrement(
           (static_cast<FSTIntegerValue*>(previousValue)).internalValue,
           (static_cast<FSTIntegerValue*>(operand_)).internalValue);
       return [FSTIntegerValue integerValue:sum];
-    } else if ([previousValue type] == FieldValue::Type::Integer) {
+    } else if (previousValue.type == FieldValue::Type::Integer) {
       double sum =
           (static_cast<FSTIntegerValue*>(previousValue)).internalValue +
           OperandAsDouble();
       return [FSTDoubleValue doubleValue:sum];
-    } else if ([previousValue type] == FieldValue::Type::Double) {
+    } else if (previousValue.type == FieldValue::Type::Double) {
       double sum = (static_cast<FSTDoubleValue*>(previousValue)).internalValue +
                    OperandAsDouble();
       return [FSTDoubleValue doubleValue:sum];
@@ -330,9 +330,9 @@ class NumericIncrementTransform : public TransformOperation {
   }
 
   double OperandAsDouble() const {
-    if ([operand_ type] == FieldValue::Type::Double) {
+    if (operand_.type == FieldValue::Type::Double) {
       return (static_cast<FSTDoubleValue*>(operand_)).internalValue;
-    } else if ([operand_ type] == FieldValue::Type::Integer) {
+    } else if (operand_.type == FieldValue::Type::Integer) {
       return (static_cast<FSTIntegerValue*>(operand_)).internalValue;
     } else {
       HARD_FAIL("Expected 'operand' to be of FSTNumerValue type, but was %s",

--- a/Firestore/core/src/firebase/firestore/model/transform_operations.h
+++ b/Firestore/core/src/firebase/firestore/model/transform_operations.h
@@ -259,18 +259,18 @@ class NumericIncrementTransform : public TransformOperation {
       FIRTimestamp* /* localWriteTime */) const override {
     // Return an integer value only if the previous value and the operand is an
     // integer.
-    if ([previousValue isKindOfClass:[FSTIntegerValue class]] &&
-        [operand_ isKindOfClass:[FSTIntegerValue class]]) {
+    if ([previousValue type] == FSTFieldValueTypeInteger &&
+        [operand_ type] == FSTFieldValueTypeInteger) {
       int64_t sum = SafeIncrement(
           (static_cast<FSTIntegerValue*>(previousValue)).internalValue,
           (static_cast<FSTIntegerValue*>(operand_)).internalValue);
       return [FSTIntegerValue integerValue:sum];
-    } else if ([previousValue isKindOfClass:[FSTIntegerValue class]]) {
+    } else if ([previousValue type] == FSTFieldValueTypeInteger) {
       double sum =
           (static_cast<FSTIntegerValue*>(previousValue)).internalValue +
           OperandAsDouble();
       return [FSTDoubleValue doubleValue:sum];
-    } else if ([previousValue isKindOfClass:[FSTDoubleValue class]]) {
+    } else if ([previousValue type] == FSTFieldValueTypeDouble) {
       double sum = (static_cast<FSTDoubleValue*>(previousValue)).internalValue +
                    OperandAsDouble();
       return [FSTDoubleValue doubleValue:sum];
@@ -329,9 +329,9 @@ class NumericIncrementTransform : public TransformOperation {
   }
 
   double OperandAsDouble() const {
-    if ([operand_ isKindOfClass:[FSTDoubleValue class]]) {
+    if ([operand_ type] == FSTFieldValueTypeDouble) {
       return (static_cast<FSTDoubleValue*>(operand_)).internalValue;
-    } else if ([operand_ isKindOfClass:[FSTIntegerValue class]]) {
+    } else if ([operand_ type] == FSTFieldValueTypeInteger) {
       return (static_cast<FSTIntegerValue*>(operand_)).internalValue;
     } else {
       HARD_FAIL("Expected 'operand' to be of FSTNumerValue type, but was %s",


### PR DESCRIPTION
Previously, we checked for FSTFieldValue subtypes via:
`[value isKindOfClass:[FSTStringValue class]]`

Now, we check via a new type parameter on FSTFieldValue, i.e.:
`[value type] == FSTFieldValueTypeString`

This should enable easier transition to C++.

(Slightly) more context: go/firestore-cpp-fieldvalue