### PR TITLE
FIRMessagingRemoteNotificationsProxy - test only public API with no assumptions on implementation

### DIFF
--- a/Example/Messaging/Tests/FIRMessagingRemoteNotificationsProxyTest.m
+++ b/Example/Messaging/Tests/FIRMessagingRemoteNotificationsProxyTest.m
@@ -42,10 +42,12 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 completionHandler {
 }
 
+#if TARGET_OS_IOS
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
 didReceiveNotificationResponse:(UNNotificationResponse *)response
          withCompletionHandler:(void(^)(void))completionHandler {
 }
+#endif // TARGET_OS_IOS
 
 #endif // __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 @end

--- a/Example/Messaging/Tests/FIRMessagingRemoteNotificationsProxyTest.m
+++ b/Example/Messaging/Tests/FIRMessagingRemoteNotificationsProxyTest.m
@@ -24,7 +24,7 @@
 #import "FIRMessaging.h"
 #import "FIRMessagingRemoteNotificationsProxy.h"
 
-#pragma mark - Invalid App Delegate
+#pragma mark - Invalid App Delegate or UNNotificationCenter
 
 @interface RandomObject : NSObject
 @property(nonatomic, weak) id delegate;

--- a/Example/Messaging/Tests/FIRMessagingRemoteNotificationsProxyTest.m
+++ b/Example/Messaging/Tests/FIRMessagingRemoteNotificationsProxyTest.m
@@ -24,39 +24,30 @@
 #import "FIRMessaging.h"
 #import "FIRMessagingRemoteNotificationsProxy.h"
 
-#pragma mark - Expose Internal Methods for Testing
-// Expose some internal properties and methods here, in order to test
-@interface FIRMessagingRemoteNotificationsProxy ()
-
-@property(readonly, nonatomic) BOOL hasSwizzledUserNotificationDelegate;
-@property(readonly, nonatomic) BOOL isObservingUserNotificationDelegateChanges;
-
-@property(strong, readonly, nonatomic) id userNotificationCenter;
-@property(strong, readonly, nonatomic) id currentUserNotificationCenterDelegate;
-
-- (void)listenForDelegateChangesInUserNotificationCenter:(id)notificationCenter;
-- (void)swizzleUserNotificationCenterDelegate:(id)delegate;
-- (void)unswizzleUserNotificationCenterDelegate:(id)delegate;
-
-void FCM_swizzle_appDidReceiveRemoteNotificationWithHandler(
-    id self, SEL _cmd, UIApplication *app, NSDictionary *userInfo,
-    void (^handler)(UIBackgroundFetchResult));
-void FCM_swizzle_willPresentNotificationWithHandler(
-    id self, SEL _cmd, id center, id notification, void (^handler)(NSUInteger));
-void FCM_swizzle_didReceiveNotificationResponseWithHandler(
-    id self, SEL _cmd, id center, id response, void (^handler)());
-
-@end
-
 #pragma mark - Invalid App Delegate
 
-@interface InvalidAppDelegate : NSObject
+@interface RandomObject : NSObject
+@property(nonatomic, weak) id delegate;
 @end
-@implementation InvalidAppDelegate
+@implementation RandomObject
 - (void)application:(UIApplication *)application
 didReceiveRemoteNotification:(NSDictionary *)userInfo
 fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 }
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+       willPresentNotification:(UNNotification *)notification
+         withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))
+completionHandler {
+}
+
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+didReceiveNotificationResponse:(UNNotificationResponse *)response
+         withCompletionHandler:(void(^)(void))completionHandler {
+}
+
+#endif // __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 @end
 
 #pragma mark - Incomplete App Delegate
@@ -117,11 +108,10 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 @interface FIRMessagingRemoteNotificationsProxyTest : XCTestCase
 
 @property(nonatomic, strong) FIRMessagingRemoteNotificationsProxy *proxy;
-@property(nonatomic, strong) id mockProxy;
 @property(nonatomic, strong) id mockProxyClass;
-@property(nonatomic, strong) id mockMessagingClass;
 @property(nonatomic, strong) id mockSharedApplication;
 @property(nonatomic, strong) id mockMessaging;
+@property(nonatomic, strong) id mockUserNotificationCenter;
 
 @end
 
@@ -135,21 +125,19 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
   OCMStub([_mockMessaging messaging]).andReturn(_mockMessaging);
 
   _proxy = [[FIRMessagingRemoteNotificationsProxy alloc] init];
-  _mockProxy = OCMPartialMock(_proxy);
   _mockProxyClass = OCMClassMock([FIRMessagingRemoteNotificationsProxy class]);
   // Update +sharedProxy to always return our test instance
   OCMStub([_mockProxyClass sharedProxy]).andReturn(self.proxy);
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
+  _mockUserNotificationCenter = OCMClassMock([UNUserNotificationCenter class]);
+  OCMStub([_mockUserNotificationCenter currentNotificationCenter]).andReturn(_mockUserNotificationCenter);
+#endif
 }
 
 - (void)tearDown {
-  [_mockMessagingClass stopMocking];
-  _mockMessagingClass = nil;
-
   [_mockProxyClass stopMocking];
   _mockProxyClass = nil;
-
-  [_mockProxy stopMocking];
-  _mockProxy = nil;
 
   [_mockMessaging stopMocking];
   _mockMessaging = nil;
@@ -164,7 +152,7 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 #pragma mark - Method Swizzling Tests
 
 - (void)testSwizzlingNonAppDelegate {
-  InvalidAppDelegate *invalidAppDelegate = [[InvalidAppDelegate alloc] init];
+  RandomObject *invalidAppDelegate = [[RandomObject alloc] init];
   [OCMStub([self.mockSharedApplication delegate]) andReturn:invalidAppDelegate];
   [self.proxy swizzleMethodsIfPossible];
 
@@ -185,6 +173,8 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 
   [incompleteAppDelegate application:self.mockSharedApplication
         didReceiveRemoteNotification:notification];
+
+  [self.mockMessaging verify];
 }
 
 - (void)testIncompleteAppDelegateRemoteNotificationWithFetchHandlerMethod {
@@ -207,7 +197,7 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 
   NSDictionary *notification = @{@"test" : @""};
 
-  // application:didReceiveRemoteNotification:
+  //Test application:didReceiveRemoteNotification:
 
   // Verify our swizzled method was called
   OCMExpect([self.mockMessaging appDidReceiveMessage:notification]);
@@ -220,7 +210,7 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
   XCTAssertTrue(appDelegate.remoteNotificationMethodWasCalled);
   [self.mockMessaging verify];
 
-  // application:didReceiveRemoteNotification:fetchCompletionHandler:
+  //Test application:didReceiveRemoteNotification:fetchCompletionHandler:
 
   // Verify our swizzled method was called
   OCMExpect([self.mockMessaging appDidReceiveMessage:notification]);
@@ -231,6 +221,7 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 
   // Verify our original method was called
   XCTAssertTrue(appDelegate.remoteNotificationWithFetchHandlerWasCalled);
+
   [self.mockMessaging verify];
 #endif
 }
@@ -238,21 +229,50 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 
 - (void)testListeningForDelegateChangesOnInvalidUserNotificationCenter {
-  id randomObject = @"Random Object that is not a User Notification Center";
-  [self.proxy listenForDelegateChangesInUserNotificationCenter:randomObject];
-  XCTAssertFalse(self.proxy.isObservingUserNotificationDelegateChanges);
+  RandomObject *invalidNotificationCenter = [[RandomObject alloc] init];
+  OCMStub([self.mockUserNotificationCenter currentNotificationCenter]).andReturn(invalidNotificationCenter);
+  [self.proxy swizzleMethodsIfPossible];
+
+  OCMReject([self.mockMessaging appDidReceiveMessage:[OCMArg any]]);
+
+  [(id<UNUserNotificationCenterDelegate>)invalidNotificationCenter.delegate
+   userNotificationCenter:self.mockUserNotificationCenter
+   willPresentNotification:OCMClassMock([UNNotification class])
+   withCompletionHandler:^(UNNotificationPresentationOptions options) {
+   }];
 }
 
 - (void)testSwizzlingInvalidUserNotificationCenterDelegate {
-  id randomObject = @"Random Object that is not a User Notification Center Delegate";
-  [self.proxy swizzleUserNotificationCenterDelegate:randomObject];
-  XCTAssertFalse(self.proxy.hasSwizzledUserNotificationDelegate);
+  RandomObject *invalidDelegate = [[RandomObject alloc] init];
+  OCMStub([self.mockUserNotificationCenter delegate]).andReturn(invalidDelegate);
+  [self.proxy swizzleMethodsIfPossible];
+
+  OCMReject([self.mockMessaging appDidReceiveMessage:[OCMArg any]]);
+
+  [invalidDelegate
+   userNotificationCenter:self.mockUserNotificationCenter
+   willPresentNotification:OCMClassMock([UNNotification class])
+   withCompletionHandler:^(UNNotificationPresentationOptions options) {
+   }];
 }
 
 - (void)testSwizzlingUserNotificationsCenterDelegate {
   FakeUserNotificationCenterDelegate *delegate = [[FakeUserNotificationCenterDelegate alloc] init];
-  [self.proxy swizzleUserNotificationCenterDelegate:delegate];
-  XCTAssertTrue(self.proxy.hasSwizzledUserNotificationDelegate);
+  OCMStub([self.mockUserNotificationCenter delegate]).andReturn(delegate);
+  [self.proxy swizzleMethodsIfPossible];
+
+  NSDictionary *message = @{@"message": @""};
+  id notification = [self userNotificationWithMessage:message];
+
+  OCMExpect([self.mockMessaging appDidReceiveMessage:message]);
+
+  [delegate
+   userNotificationCenter:self.mockUserNotificationCenter
+   willPresentNotification:notification
+   withCompletionHandler:^(UNNotificationPresentationOptions options) {
+   }];
+
+  [self.mockMessaging verify];
 }
 
 // Use a fake delegate that doesn't actually implement the needed delegate method.
@@ -265,7 +285,8 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
   }
   IncompleteUserNotificationCenterDelegate *delegate =
       [[IncompleteUserNotificationCenterDelegate alloc] init];
-  [self.mockProxy swizzleUserNotificationCenterDelegate:delegate];
+  OCMStub([self.mockUserNotificationCenter delegate]).andReturn(delegate);
+  [self.proxy swizzleMethodsIfPossible];
   // Because the incomplete delete does not implement either of the optional delegate methods, we
   // should swizzle nothing. If we had swizzled them, then respondsToSelector: would return YES
   // even though the delegate does not implement the methods.
@@ -278,55 +299,67 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 
 // Use an object that does actually implement the optional methods. Both should be called.
 - (void)testSwizzledUserNotificationsCenterDelegate {
-  // Early exit if running on pre iOS 10
-  if (![UNNotification class]) {
-    return;
-  }
   FakeUserNotificationCenterDelegate *delegate = [[FakeUserNotificationCenterDelegate alloc] init];
-  [self.mockProxy swizzleUserNotificationCenterDelegate:delegate];
+  OCMStub([self.mockUserNotificationCenter delegate]).andReturn(delegate);
+  [self.proxy swizzleMethodsIfPossible];
+
+  NSDictionary *message = @{@"message": @""};
+
+  // Verify userNotificationCenter:willPresentNotification:withCompletionHandler:
+  OCMExpect([self.mockMessaging appDidReceiveMessage:message]);
+
   // Invoking delegate method should also invoke our swizzled method
   // The swizzled method uses the +sharedProxy, which should be
-  // returning our mocked proxy.
+  // returning our proxy.
   // Use non-nil, proper classes, otherwise our SDK bails out.
-  [delegate userNotificationCenter:OCMClassMock([UNUserNotificationCenter class])
-           willPresentNotification:[self generateMockNotification]
+  [delegate userNotificationCenter:self.mockUserNotificationCenter
+           willPresentNotification:[self userNotificationWithMessage:message]
              withCompletionHandler:^(NSUInteger options) {}];
-  // Verify our swizzled method was called
-  OCMVerify(FCM_swizzle_willPresentNotificationWithHandler);
+
   // Verify our original method was called
   XCTAssertTrue(delegate.willPresentWasCalled);
-#if TARGET_OS_IOS
-  [delegate userNotificationCenter:OCMClassMock([UNUserNotificationCenter class])
-    didReceiveNotificationResponse:[self generateMockNotificationResponse]
-             withCompletionHandler:^{}];
+
   // Verify our swizzled method was called
-  OCMVerify(FCM_swizzle_appDidReceiveRemoteNotificationWithHandler);
+  [self.mockMessaging verify];
+
+#if TARGET_OS_IOS
+  // Verify userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:
+
+  OCMExpect([self.mockMessaging appDidReceiveMessage:message]);
+
+  [delegate userNotificationCenter:self.mockUserNotificationCenter
+    didReceiveNotificationResponse:[self userNotificationResponseWithMessage:message]
+             withCompletionHandler:^{}];
+
   // Verify our original method was called
   XCTAssertTrue(delegate.didReceiveResponseWasCalled);
-#endif
+
+  // Verify our swizzled method was called
+  [self.mockMessaging verify];
+#endif // TARGET_OS_IOS
 }
 
-- (id)generateMockNotification {
-  // Stub out: notification.request.content.userInfo
-  id mockNotification = OCMClassMock([UNNotification class]);
-  id mockRequest = OCMClassMock([UNNotificationRequest class]);
-  id mockContent = OCMClassMock([UNNotificationContent class]);
-  OCMStub([mockContent userInfo]).andReturn(@{});
-  OCMStub([mockRequest content]).andReturn(mockContent);
-  OCMStub([mockNotification request]).andReturn(mockRequest);
-  return mockNotification;
-}
-
-- (id)generateMockNotificationResponse {
+- (id)userNotificationResponseWithMessage:(NSDictionary *)message {
   // Stub out: response.[mock notification above]
 #if TARGET_OS_IOS
   id mockNotificationResponse = OCMClassMock([UNNotificationResponse class]);
-  id mockNotification = [self generateMockNotification];
+  id mockNotification = [self userNotificationWithMessage:message];
   OCMStub([mockNotificationResponse notification]).andReturn(mockNotification);
   return mockNotificationResponse;
 #else
   return nil;
 #endif
+}
+
+- (UNNotification *)userNotificationWithMessage:(NSDictionary *)message {
+  UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+  content.userInfo = message;
+  id notificationRequest = OCMClassMock([UNNotificationRequest class]);
+  OCMStub([notificationRequest content]).andReturn(content);
+  id notification = OCMClassMock([UNNotification class]);
+  OCMStub([notification request]).andReturn(notificationRequest);
+
+  return notification;
 }
 
 #endif // __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0

--- a/Example/Messaging/Tests/FIRMessagingRemoteNotificationsProxyTest.m
+++ b/Example/Messaging/Tests/FIRMessagingRemoteNotificationsProxyTest.m
@@ -96,7 +96,9 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
   self.willPresentWasCalled = YES;
 }
 #if TARGET_OS_IOS
-- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler {
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+didReceiveNotificationResponse:(UNNotificationResponse *)response
+         withCompletionHandler:(void (^)(void))completionHandler {
   self.didReceiveResponseWasCalled = YES;
 }
 #endif // TARGET_OS_IOS
@@ -346,9 +348,9 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
   id mockNotification = [self userNotificationWithMessage:message];
   OCMStub([mockNotificationResponse notification]).andReturn(mockNotification);
   return mockNotificationResponse;
-#else
+#else // TARGET_OS_IOS
   return nil;
-#endif
+#endif // TARGET_OS_IOS
 }
 
 - (UNNotification *)userNotificationWithMessage:(NSDictionary *)message {

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -259,7 +259,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
                              @"proper integration.",
                              kFIRMessagingRemoteNotificationsProxyEnabledInfoPlistKey,
                              docsURLString);
-    [FIRMessagingRemoteNotificationsProxy swizzleMethods];
+    [[FIRMessagingRemoteNotificationsProxy sharedProxy] swizzleMethodsIfPossible];
   }
 }
 

--- a/Firebase/Messaging/FIRMessagingRemoteNotificationsProxy.h
+++ b/Firebase/Messaging/FIRMessagingRemoteNotificationsProxy.h
@@ -32,9 +32,14 @@
 + (BOOL)canSwizzleMethods;
 
 /**
+ * A shared instance of `FIRMessagingRemoteNotificationsProxy`
+ */
++ (instancetype)sharedProxy;
+
+/**
  *  Swizzles Application Delegate's remote-notification callbacks and User Notification Center
  *  delegate callback, and invokes the original selectors once done.
  */
-+ (void)swizzleMethods;
+- (void)swizzleMethodsIfPossible;
 
 @end

--- a/Firebase/Messaging/FIRMessagingRemoteNotificationsProxy.m
+++ b/Firebase/Messaging/FIRMessagingRemoteNotificationsProxy.m
@@ -63,10 +63,6 @@ static NSString *kReceiveDataMessageSelectorString = @"messaging:didReceiveMessa
   }
 }
 
-+ (void)swizzleMethods {
-  [[FIRMessagingRemoteNotificationsProxy sharedProxy] swizzleMethodsIfPossible];
-}
-
 + (instancetype)sharedProxy {
   static FIRMessagingRemoteNotificationsProxy *proxy;
   static dispatch_once_t onceToken;


### PR DESCRIPTION
The update is an intermediate step for #2591. To update `FIRMessagingRemoteNotificationsProxy` implementation with `GoogleUtilities` we need reliable set of tests.

- `FIRMessagingRemoteNotificationsProxyTests` updated to use only public API of `FIRMessagingRemoteNotificationsProxy`. This will allow to reuse the same tests for the updated implementation.