### PR TITLE
Remove pendingToken from public API. 

### DIFF
--- a/Firebase/Auth/Source/AuthProviders/OAuth/FIROAuthCredential_Internal.h
+++ b/Firebase/Auth/Source/AuthProviders/OAuth/FIROAuthCredential_Internal.h
@@ -35,6 +35,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, readonly, nullable) NSString *sessionID;
 
+/** @property pendingToken
+    @brief The pending token used when completing the headful-lite flow.
+ */
+@property(nonatomic, readonly, nullable) NSString *pendingToken;
+
 /** @fn initWithProviderId:IDToken:accessToken:pendingToken
     @brief Designated initializer.
     @param providerID The provider ID associated with the credential being created.

--- a/Firebase/Auth/Source/AuthProviders/OAuth/FIROAuthProvider.m
+++ b/Firebase/Auth/Source/AuthProviders/OAuth/FIROAuthProvider.m
@@ -66,16 +66,6 @@ static NSString *const kAuthTypeSignInWithRedirect = @"signInWithRedirect";
 
 + (FIROAuthCredential *)credentialWithProviderID:(NSString *)providerID
                                         IDToken:(NSString *)IDToken
-                                    accessToken:(nullable NSString *)accessToken
-                                   pendingToken:(nullable NSString *)pendingToken {
-  return [[FIROAuthCredential alloc] initWithProviderID:providerID
-                                                IDToken:IDToken
-                                            accessToken:accessToken
-                                           pendingToken:pendingToken];
-}
-
-+ (FIROAuthCredential *)credentialWithProviderID:(NSString *)providerID
-                                        IDToken:(NSString *)IDToken
                                     accessToken:(nullable NSString *)accessToken {
   return [[FIROAuthCredential alloc] initWithProviderID:providerID
                                                 IDToken:IDToken

--- a/Firebase/Auth/Source/Public/FIROAuthCredential.h
+++ b/Firebase/Auth/Source/Public/FIROAuthCredential.h
@@ -36,11 +36,6 @@ NS_SWIFT_NAME(OAuthCredential)
  */
 @property(nonatomic, readonly, nullable) NSString *accessToken;
 
-/** @property pendingToken
-    @brief The pending token used when completing the headful-lite flow.
- */
-@property(nonatomic, readonly, nullable) NSString *pendingToken;
-
 /** @fn init
     @brief This class is not supposed to be instantiated directly.
  */

--- a/Firebase/Auth/Source/Public/FIROAuthProvider.h
+++ b/Firebase/Auth/Source/Public/FIROAuthProvider.h
@@ -80,22 +80,6 @@ NS_SWIFT_NAME(OAuthProvider)
     @param IDToken The IDToken associated with the Auth credential being created.
     @param accessToken The accessstoken associated with the Auth credential be created, if
         available.
-    @param pendingToken The pending token used when completing the headful-lite flow.
-    @return A FIRAuthCredential for the specified provider ID, ID token and access token.
- */
-+ (FIROAuthCredential *)credentialWithProviderID:(NSString *)providerID
-                                         IDToken:(NSString *)IDToken
-                                     accessToken:(nullable NSString *)accessToken
-                                    pendingToken:(nullable NSString *)pendingToken;
-
-/** @fn credentialWithProviderID:IDToken:accessToken:
-    @brief Creates an `FIRAuthCredential` for that OAuth 2 provider identified by providerID, ID
-        token and access token.
-
-    @param providerID The provider ID associated with the Auth credential being created.
-    @param IDToken The IDToken associated with the Auth credential being created.
-    @param accessToken The accessstoken associated with the Auth credential be created, if
-        available.
     @return A FIRAuthCredential for the specified provider ID, ID token and access token.
  */
 + (FIROAuthCredential *)credentialWithProviderID:(NSString *)providerID


### PR DESCRIPTION
It's added to public header by mistake.

Developers are not supposed to use it, and they currently have no way to use it.
