### PR TITLE
Fix use-after-free in DocumentReference::AddSnapshotListener

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 - [feature] Added community support for tvOS.
+- [fixed] Fixed a use-after-free bug that could be observed when using snapshot
+  listeners on temporary document references (#2682).
 
 # 1.2.0
 - [feature] Added community support for macOS (#434).

--- a/Firestore/core/src/firebase/firestore/api/document_reference.mm
+++ b/Firestore/core/src/firebase/firestore/api/document_reference.mm
@@ -201,7 +201,9 @@ ListenerRegistration DocumentReference::AddSnapshotListener(
    public:
     Converter(DocumentReference* parent,
               DocumentSnapshot::Listener&& user_listener)
-        : parent_(parent), user_listener_(std::move(user_listener)) {
+        : firestore_(parent->firestore_),
+          key_(parent->key_),
+          user_listener_(std::move(user_listener)) {
     }
 
     void OnEvent(StatusOr<ViewSnapshot> maybe_snapshot) override {
@@ -209,26 +211,25 @@ ListenerRegistration DocumentReference::AddSnapshotListener(
         user_listener_->OnEvent(maybe_snapshot.status());
         return;
       }
-      Firestore* firestore = parent_->firestore_;
-      DocumentKey key = parent_->key_;
 
       ViewSnapshot snapshot = std::move(maybe_snapshot).ValueOrDie();
       HARD_ASSERT(snapshot.documents().size() <= 1,
                   "Too many documents returned on a document query");
-      FSTDocument* document = snapshot.documents().GetDocument(key);
+      FSTDocument* document = snapshot.documents().GetDocument(key_);
 
       bool has_pending_writes =
-          document ? snapshot.mutated_keys().contains(key)
+          document ? snapshot.mutated_keys().contains(key_)
                    // We don't raise `has_pending_writes` for deleted documents.
                    : false;
 
-      DocumentSnapshot result{firestore, std::move(key), document,
-                              snapshot.from_cache(), has_pending_writes};
+      DocumentSnapshot result{firestore_, key_, document, snapshot.from_cache(),
+                              has_pending_writes};
       user_listener_->OnEvent(std::move(result));
     }
 
    private:
-    DocumentReference* parent_;
+    Firestore* firestore_;
+    DocumentKey key_;
     DocumentSnapshot::Listener user_listener_;
   };
   auto view_listener =


### PR DESCRIPTION
Fixes #2682.

The issue here is that if you run code like this:

```swift
db.document('foo/bar').addSnapshotListener(...);
```

Callbacks to the implementation of addSnapshotHandler can happen after the DocumentReference has been released. The problem is that internally we were pointing at the underlying C++ DocumentReference via raw pointer which could cause use-after-free.

The fix is to copy the interesting state into the Converter such that it no longer depends on the lifetime of the DocumentReference.