### PR TITLE
Fix use-after-free in DocumentReference::AddSnapshotListener (#2686)

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+- [fixed] Fixed a use-after-free bug that could be observed when using snapshot
+  listeners on temporary document references (#2682).
+
+# 1.2.0
 - [fixed] Fixed the way gRPC certificates are loaded on macOS (#2604).
 
 # 1.1.0


### PR DESCRIPTION
Cherry-pick of https://github.com/firebase/firebase-ios-sdk/commit/8ef6cf80bee255f9ce81460422986eb29cb7eb52