### PR TITLE
Make high priority events force an upload via upload conditions

### DIFF
--- a/GoogleDataTransport/GoogleDataTransport/Classes/GDTClock.m
+++ b/GoogleDataTransport/GoogleDataTransport/Classes/GDTClock.m
@@ -81,7 +81,8 @@ static int64_t UptimeInNanoseconds() {
   if (self) {
     _kernelBootTime = KernelBootTimeInNanoseconds();
     _uptime = UptimeInNanoseconds();
-    _timeMillis = (int64_t)((CFAbsoluteTimeGetCurrent() + kCFAbsoluteTimeIntervalSince1970) * NSEC_PER_USEC);
+    _timeMillis =
+        (int64_t)((CFAbsoluteTimeGetCurrent() + kCFAbsoluteTimeIntervalSince1970) * NSEC_PER_USEC);
     CFTimeZoneRef timeZoneRef = CFTimeZoneCopySystem();
     _timezoneOffsetSeconds = CFTimeZoneGetSecondsFromGMT(timeZoneRef, 0);
     CFRelease(timeZoneRef);

--- a/GoogleDataTransport/GoogleDataTransport/Classes/GDTClock.m
+++ b/GoogleDataTransport/GoogleDataTransport/Classes/GDTClock.m
@@ -81,7 +81,7 @@ static int64_t UptimeInNanoseconds() {
   if (self) {
     _kernelBootTime = KernelBootTimeInNanoseconds();
     _uptime = UptimeInNanoseconds();
-    _timeMillis = CFAbsoluteTimeGetCurrent() * NSEC_PER_USEC;
+    _timeMillis = (int64_t)((CFAbsoluteTimeGetCurrent() + kCFAbsoluteTimeIntervalSince1970) * NSEC_PER_USEC);
     CFTimeZoneRef timeZoneRef = CFTimeZoneCopySystem();
     _timezoneOffsetSeconds = CFTimeZoneGetSecondsFromGMT(timeZoneRef, 0);
     CFRelease(timeZoneRef);

--- a/GoogleDataTransport/GoogleDataTransport/Classes/GDTUploadCoordinator.h
+++ b/GoogleDataTransport/GoogleDataTransport/Classes/GDTUploadCoordinator.h
@@ -34,10 +34,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** Forces the backend specified by the target to upload the provided set of events. This should
  * only ever happen when the QoS tier of an event requires it.
  *
- * @param events The set of event hashes to force upload.
  * @param target The target that should force an upload.
  */
-- (void)forceUploadEvents:(NSSet<GDTStoredEvent *> *)events target:(GDTTarget)target;
+- (void)forceUploadForTarget:(GDTTarget)target;
 
 @end
 

--- a/GoogleDataTransport/GoogleDataTransport/Classes/Public/GDTPrioritizer.h
+++ b/GoogleDataTransport/GoogleDataTransport/Classes/Public/GDTPrioritizer.h
@@ -32,6 +32,9 @@ typedef NS_OPTIONS(NSInteger, GDTUploadConditions) {
 
   /** An upload would likely use wifi data. */
   GDTUploadConditionWifiData,
+
+  /** A high priority event has occurred. */
+  GDTUploadConditionHighPriority,
 };
 
 /** This protocol defines the common interface of event prioritization. Prioritizers are

--- a/GoogleDataTransport/Tests/Common/Fakes/GDTUploadCoordinatorFake.m
+++ b/GoogleDataTransport/Tests/Common/Fakes/GDTUploadCoordinatorFake.m
@@ -18,7 +18,7 @@
 
 @implementation GDTUploadCoordinatorFake
 
-- (void)forceUploadEvents:(NSSet<GDTStoredEvent *> *)events target:(GDTTarget)target {
+- (void)forceUploadForTarget:(GDTTarget)target {
   self.forceUploadCalled = YES;
 }
 

--- a/GoogleDataTransport/Tests/Integration/GDTIntegrationTest.m
+++ b/GoogleDataTransport/Tests/Integration/GDTIntegrationTest.m
@@ -152,7 +152,7 @@
   [testServer stop];
 }
 
-/** Generates and events a bunch of random events. */
+/** Generates a bunch of random events. */
 - (void)generateEvents {
   for (int i = 0; i < 50; i++) {
     // Choose a random transport, and randomly choose if it's a telemetry event.


### PR DESCRIPTION
Forced uploads should be defined as an additional upload condition, as opposed to constructing an ad-hoc upload package. This allows the prioritizer and uploader to do housekeeping more easily.

Address a race condition during high-priority event sending in which a package can be asked for whilst the storage is still asking the prioritizer to deprioritize events that have already been removed from disk.