### PR TITLE
Remove unused import

### DIFF
--- a/Firebase/Auth/Source/Auth/FIRAuth.m
+++ b/Firebase/Auth/Source/Auth/FIRAuth.m
@@ -22,7 +22,6 @@
 #import <UIKit/UIKit.h>
 #endif
 
-#import <FirebaseCore/FIRAppAssociationRegistration.h>
 #import <FirebaseCore/FIRAppInternal.h>
 #import <FirebaseCore/FIRComponent.h>
 #import <FirebaseCore/FIRComponentContainer.h>


### PR DESCRIPTION
FIRAppAssociationRegistration is soon to be deprecated and has already been replaced by FIRComponent.