### PR TITLE
Remove implicit Analytics dependency from FIAM

### DIFF
--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -33,7 +33,6 @@ See more product details at https://firebase.google.com/products/in-app-messagin
   }
 
   s.dependency 'FirebaseCore'
-  s.ios.dependency 'FirebaseAnalytics'
   s.ios.dependency 'FirebaseAnalyticsInterop'
   s.dependency 'FirebaseInstanceID'
 end

--- a/InAppMessaging/Example/Podfile
+++ b/InAppMessaging/Example/Podfile
@@ -12,7 +12,6 @@ target 'InAppMessaging_Example_iOS' do
   pod 'FirebaseInAppMessagingDisplay', :path => '../..'
   pod 'FirebaseInAppMessaging', :path => '../..'
   pod 'FirebaseAnalyticsInterop',  :path => '../..'
-  pod 'FirebaseAnalytics'
   pod 'FirebaseDynamicLinks',  :path => '../..'
 end
 


### PR DESCRIPTION
Developers will need to continue to include Firebase/Core or update to including Firebase/Analytics in their Podfile to continue to use FIAM features that depend on FirebaseAnalytics.