### PR TITLE
remove deprecated token API

### DIFF
--- a/Example/InstanceID/Tests/FIRInstanceIDTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTest.m
@@ -535,7 +535,6 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
   [[[self.mockTokenManager stub] andReturn:sTokenInfo]
       cachedTokenInfoWithAuthorizedEntity:kAuthorizedEntity
                                     scope:@"*"];
-
   [[self.mockInstanceID reject] defaultTokenWithHandler:nil];
   NSString *token = [self.mockInstanceID token];
   XCTAssertEqualObjects(token, kToken);
@@ -590,10 +589,7 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
                 cachedTokenInfo = sTokenInfo;
 
                 notificationPostCount++;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 notificationToken = [[self.instanceID token] copy];
-#pragma clang diagnostic pop
                 [defaultTokenExpectation fulfill];
               }];
 
@@ -670,10 +666,7 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
                 cachedTokenInfo = sTokenInfo;
 
                 notificationPostCount++;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 notificationToken = [[self.instanceID token] copy];
-#pragma clang diagnostic pop
                 [defaultTokenExpectation fulfill];
               }];
 
@@ -741,10 +734,7 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
                 cachedTokenInfo = sTokenInfo;
 
                 notificationPostCount++;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 notificationToken = [[self.instanceID token] copy];
-#pragma clang diagnostic pop
                 [defaultTokenExpectation fulfill];
               }];
 

--- a/Example/InstanceID/Tests/FIRInstanceIDTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTest.m
@@ -18,6 +18,7 @@
 
 #import <FirebaseCore/FIRAppInternal.h>
 #import <FirebaseCore/FIROptionsInternal.h>
+#import <FirebaseInstanceID/FIRInstanceID_Private.h>
 #import <OCMock/OCMock.h>
 
 #import "Firebase/InstanceID/FIRInstanceID+Testing.h"

--- a/Firebase/InstanceID/FIRInstanceID+Private.h
+++ b/Firebase/InstanceID/FIRInstanceID+Private.h
@@ -52,4 +52,12 @@
  */
 - (nullable NSString *)appInstanceID:(NSError *_Nullable *_Nullable)error;
 
+/**
+ *  Returns a Firebase Messaging scoped token for the firebase app.
+ *
+ *  @return Returns the stored token if the device has registered with Firebase Messaging, otherwise
+ *          returns nil.
+ */
+- (nullable NSString *)token;
+
 @end

--- a/Firebase/InstanceID/FIRInstanceID+Private.h
+++ b/Firebase/InstanceID/FIRInstanceID+Private.h
@@ -19,8 +19,9 @@
 #import "FIRInstanceIDCheckinService.h"
 
 /**
- * Internal API used by other Firebase SDK teams, including Messaging, Analytics and Remote config.
+ * Internal API used by Firebase SDK teams by calling in reflection or internal teams.
  */
+// TODO(chliangGoogle) Rename this to Internal.
 @interface FIRInstanceID (Private)
 
 /**
@@ -51,13 +52,5 @@
  *  @return The InstanceID for the app.
  */
 - (nullable NSString *)appInstanceID:(NSError *_Nullable *_Nullable)error;
-
-/**
- *  Returns a Firebase Messaging scoped token for the firebase app.
- *
- *  @return Returns the stored token if the device has registered with Firebase Messaging, otherwise
- *          returns nil.
- */
-- (nullable NSString *)token;
 
 @end

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -490,10 +490,7 @@ static FIRInstanceID *gInstanceID;
     // When getID is explicitly called, trigger getToken to make sure token always exists.
     // This is to avoid ID conflict (ID is not checked for conflict until we generate a token)
     if (appIdentity) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
       [self token];
-#pragma clang diagnostic pop
     }
     callHandlerOnMainThread(appIdentity, error);
   });
@@ -707,20 +704,14 @@ static FIRInstanceID *gInstanceID;
       [self defaultTokenWithHandler:nil];
     }
     // Notify FCM with the default token.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     self.defaultFCMToken = [self token];
-#pragma clang diagnostic pop
   } else if ([self isFCMAutoInitEnabled]) {
     // When there is no cached token, must check auto init is enabled.
     // If it's disabled, don't initiate token generation/refresh.
     // If no cache token and auto init is enabled, fetch a token from server.
     [self defaultTokenWithHandler:nil];
     // Notify FCM with the default token.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     self.defaultFCMToken = [self token];
-#pragma clang diagnostic pop
   }
   // ONLY checkin when auto data collection is turned on.
   if ([self isFCMAutoInitEnabled]) {

--- a/Firebase/InstanceID/Private/FIRInstanceID_Private.h
+++ b/Firebase/InstanceID/Private/FIRInstanceID_Private.h
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-#ifdef COCOAPODS
-#import "FIRInstanceID.h"
-#else
-#import "third_party/firebase/ios/Releases/FirebaseInstanceID/Library/Public/FIRInstanceID.h"
-#endif
+#import <FirebaseInstanceID/FIRInstanceID.h>
 
 /**
  * Private API used by other Firebase SDKs.

--- a/Firebase/InstanceID/Private/FIRInstanceID_Private.h
+++ b/Firebase/InstanceID/Private/FIRInstanceID_Private.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef COCOAPODS
+#import "FIRInstanceID.h"
+#else
+#import "third_party/firebase/ios/Releases/FirebaseInstanceID/Library/Public/FIRInstanceID.h"
+#endif
+
+/**
+ * Private API used by other Firebase SDKs.
+ */
+@interface FIRInstanceID ()
+
+/**
+ *  Returns a Firebase Messaging scoped token for the firebase app.
+ *
+ *  @return Returns the stored token if the device has registered with Firebase Messaging, otherwise
+ *          returns nil.
+ */
+- (nullable NSString *)token;
+
+@end

--- a/Firebase/InstanceID/Public/FIRInstanceID.h
+++ b/Firebase/InstanceID/Public/FIRInstanceID.h
@@ -209,14 +209,6 @@ NS_SWIFT_NAME(InstanceID)
 - (void)instanceIDWithHandler:(FIRInstanceIDResultHandler)handler;
 
 /**
- *  Returns a Firebase Messaging scoped token for the firebase app.
- *
- *  @return Returns the stored token if the device has registered with Firebase Messaging, otherwise
- *          returns nil.
- */
-- (nullable NSString *)token __deprecated_msg("Use instanceIDWithHandler: instead.");
-
-/**
  *  Returns a token that authorizes an Entity (example: cloud service) to perform
  *  an action on behalf of the application identified by Instance ID.
  *

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -47,6 +47,7 @@
 #import <FirebaseCore/FIRDependency.h>
 #import <FirebaseCore/FIRLibrary.h>
 #import <FirebaseInstanceID/FirebaseInstanceID.h>
+#import <FirebaseInstanceID/FirebaseInstanceID+Private.h>
 #import <GoogleUtilities/GULReachabilityChecker.h>
 #import <GoogleUtilities/GULUserDefaults.h>
 
@@ -556,10 +557,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
                            forKey:kFIRMessagingUserDefaultsKeyAutoInitEnabled];
   [_messagingUserDefaults synchronize];
   if (!isFCMAutoInitEnabled && autoInitEnabled) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     self.defaultFcmToken = self.instanceID.token;
-#pragma clang diagnostic pop
   }
 }
 
@@ -567,10 +565,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
   NSString *token = self.defaultFcmToken;
   if (!token) {
     // We may not have received it from Instance ID yet (via NSNotification), so extract it directly
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     token = self.instanceID.token;
-#pragma clang diagnostic pop
   }
   return token;
 }
@@ -918,10 +913,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
 
 - (void)defaultInstanceIDTokenWasRefreshed:(NSNotification *)notification {
   // Retrieve the Instance ID default token, and if it is non-nil, post it
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   NSString *token = self.instanceID.token;
-#pragma clang diagnostic pop
   // Sometimes Instance ID doesn't yet have a token, so wait until the default
   // token is fetched, and then notify. This ensures that this token should not
   // be nil when the developer accesses it.

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -47,7 +47,7 @@
 #import <FirebaseCore/FIRDependency.h>
 #import <FirebaseCore/FIRLibrary.h>
 #import <FirebaseInstanceID/FirebaseInstanceID.h>
-#import <FirebaseInstanceID/FIRInstanceID+Private.h>
+#import <FirebaseInstanceID/FIRInstanceID_Private.h>
 #import <GoogleUtilities/GULReachabilityChecker.h>
 #import <GoogleUtilities/GULUserDefaults.h>
 

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -47,7 +47,7 @@
 #import <FirebaseCore/FIRDependency.h>
 #import <FirebaseCore/FIRLibrary.h>
 #import <FirebaseInstanceID/FirebaseInstanceID.h>
-#import <FirebaseInstanceID/FirebaseInstanceID+Private.h>
+#import <FirebaseInstanceID/FIRInstanceID+Private.h>
 #import <GoogleUtilities/GULReachabilityChecker.h>
 #import <GoogleUtilities/GULUserDefaults.h>
 

--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -29,6 +29,7 @@ services.
   s.source_files = base_dir + '**/*.[mh]'
   s.requires_arc = base_dir + '*.m'
   s.public_header_files = base_dir + 'Public/*.h'
+  s.private_header_files = base_dir + 'Private/*.h'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'GCC_PREPROCESSOR_DEFINITIONS' =>


### PR DESCRIPTION
Remove deprecated token API as requested in #2761. Use instanceIDWithHandler: instead.

