### PR TITLE
Port FIRFirestoreSource to C++ Source

### DIFF
--- a/Firestore/Source/API/FIRDocumentReference.mm
+++ b/Firestore/Source/API/FIRDocumentReference.mm
@@ -20,11 +20,11 @@
 #include <utility>
 
 #import "FIRFirestoreErrors.h"
-#import "FIRFirestoreSource.h"
 #import "Firestore/Source/API/FIRCollectionReference+Internal.h"
 #import "Firestore/Source/API/FIRDocumentReference+Internal.h"
 #import "Firestore/Source/API/FIRDocumentSnapshot+Internal.h"
 #import "Firestore/Source/API/FIRFirestore+Internal.h"
+#import "Firestore/Source/API/FIRFirestoreSource+Internal.h"
 #import "Firestore/Source/API/FIRListenerRegistration+Internal.h"
 #import "Firestore/Source/API/FSTUserDataConverter.h"
 #import "Firestore/Source/Core/FSTEventManager.h"
@@ -34,6 +34,7 @@
 #include "Firestore/core/src/firebase/firestore/api/document_reference.h"
 #include "Firestore/core/src/firebase/firestore/api/document_snapshot.h"
 #include "Firestore/core/src/firebase/firestore/api/input_validation.h"
+#include "Firestore/core/src/firebase/firestore/api/source.h"
 #include "Firestore/core/src/firebase/firestore/core/event_listener.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/document_set.h"
@@ -49,6 +50,8 @@ namespace util = firebase::firestore::util;
 using firebase::firestore::api::DocumentReference;
 using firebase::firestore::api::DocumentSnapshot;
 using firebase::firestore::api::Firestore;
+using firebase::firestore::api::Source;
+using firebase::firestore::api::MakeSource;
 using firebase::firestore::api::ThrowInvalidArgument;
 using firebase::firestore::core::EventListener;
 using firebase::firestore::core::ListenOptions;
@@ -192,13 +195,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)getDocumentWithCompletion:(FIRDocumentSnapshotBlock)completion {
-  _documentReference.GetDocument(FIRFirestoreSourceDefault,
-                                 [self wrapDocumentSnapshotBlock:completion]);
+  _documentReference.GetDocument(Source::Default, [self wrapDocumentSnapshotBlock:completion]);
 }
 
 - (void)getDocumentWithSource:(FIRFirestoreSource)source
                    completion:(FIRDocumentSnapshotBlock)completion {
-  _documentReference.GetDocument(source, [self wrapDocumentSnapshotBlock:completion]);
+  _documentReference.GetDocument(MakeSource(source), [self wrapDocumentSnapshotBlock:completion]);
 }
 
 - (id<FIRListenerRegistration>)addSnapshotListener:(FIRDocumentSnapshotBlock)listener {

--- a/Firestore/Source/API/FIRFirestoreSource+Internal.h
+++ b/Firestore/Source/API/FIRFirestoreSource+Internal.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRFirestoreSource.h"
+
+#include "Firestore/core/src/firebase/firestore/api/source.h"
+
+namespace firebase {
+namespace firestore {
+namespace api {
+
+Source MakeSource(FIRFirestoreSource source);
+
+}  // namespace api
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/Source/API/FIRFirestoreSource.mm
+++ b/Firestore/Source/API/FIRFirestoreSource.mm
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "FIRFirestoreSource.h"
+#import "Firestore/Source/API/FIRFirestoreSource+Internal.h"
 
 #include "Firestore/core/src/firebase/firestore/api/source.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"

--- a/Firestore/Source/API/FIRFirestoreSource.mm
+++ b/Firestore/Source/API/FIRFirestoreSource.mm
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRFirestoreSource.h"
+
+#include "Firestore/core/src/firebase/firestore/api/source.h"
+#include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
+
+namespace firebase {
+namespace firestore {
+namespace api {
+
+Source MakeSource(FIRFirestoreSource source) {
+  switch (source) {
+    case FIRFirestoreSourceDefault:
+      return Source::Default;
+    case FIRFirestoreSourceServer:
+      return Source::Server;
+    case FIRFirestoreSourceCache:
+      return Source::Cache;
+  }
+
+  UNREACHABLE();
+}
+
+}  // namespace api
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/Source/Core/FSTFirestoreClient.mm
+++ b/Firestore/Source/Core/FSTFirestoreClient.mm
@@ -345,7 +345,7 @@ static const std::chrono::milliseconds FSTLruGcRegularDelay = std::chrono::minut
       maybe_snapshot = Status{FirestoreErrorCode::Unavailable,
                               "Failed to get document from cache. (However, this document "
                               "may exist on the server. Run again without setting source to "
-                              "FIRFirestoreSourceCache to attempt to retrieve the document "};
+                              "FirestoreSourceCache to attempt to retrieve the document "};
     }
 
     if (shared_completion) {

--- a/Firestore/core/src/firebase/firestore/api/document_reference.h
+++ b/Firestore/core/src/firebase/firestore/api/document_reference.h
@@ -27,8 +27,6 @@
 #include <utility>
 #include <vector>
 
-#import "FIRFirestoreSource.h"
-
 #include "Firestore/core/src/firebase/firestore/api/document_snapshot.h"
 #include "Firestore/core/src/firebase/firestore/api/listener_registration.h"
 #include "Firestore/core/src/firebase/firestore/core/listen_options.h"
@@ -45,6 +43,7 @@ namespace firestore {
 namespace api {
 
 class Firestore;
+enum class Source;
 
 class DocumentReference {
  public:
@@ -82,8 +81,7 @@ class DocumentReference {
 
   void DeleteDocument(Completion completion);
 
-  void GetDocument(FIRFirestoreSource source,
-                   DocumentSnapshot::Listener&& completion);
+  void GetDocument(Source source, DocumentSnapshot::Listener&& completion);
 
   ListenerRegistration AddSnapshotListener(
       core::ListenOptions options, DocumentSnapshot::Listener&& listener);

--- a/Firestore/core/src/firebase/firestore/api/source.h
+++ b/Firestore/core/src/firebase/firestore/api/source.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_API_SOURCE_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_API_SOURCE_H_
+
+namespace firebase {
+namespace firestore {
+namespace api {
+
+/**
+ * An enum that configures the behavior of `DocumentReference.GetDocument()` and
+ * `Query.GetDocuments()`. By providing a source enum the `GetDocument[s]`
+ * methods can be configured to fetch results only from the server, only from
+ * the local cache, or attempt to fetch results from the server and fall back to
+ * the cache (which is the default).
+ *
+ * See `FIRFirestoreSource` for more details.
+ */
+enum class Source { Default, Server, Cache };
+
+}  // namespace api
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_API_SOURCE_H_


### PR DESCRIPTION
Note that the public type must continue to exist, but it should only exist for the public Objective-C API.