### PR TITLE
Bump FirebaseCore to 6.0.0

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -19,7 +19,7 @@ target 'Core_Example_iOS' do
   # The next line is the forcing function for the Firebase pod. The Firebase
   # version's subspecs should depend on the component versions in their
   # corresponding podspec's.
-  pod 'Firebase/CoreOnly', '5.20.991'
+  pod 'Firebase/CoreOnly', '6.0.0-pre'
 
   target 'Core_Tests_iOS' do
     inherit! :search_paths

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -62,7 +62,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
   s.framework = 'Security'
   s.ios.framework = 'SafariServices'
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
-  s.dependency 'FirebaseCore', '~> 5.2'
+  s.dependency 'FirebaseCore', '~> 6.0'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 5.6'
   s.dependency 'GoogleUtilities/Environment', '~> 5.6'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCore'
-  s.version          = '5.4.91'
+  s.version          = '6.0.0'
   s.summary          = 'Firebase Core for iOS (plus community support for macOS and tvOS)'
 
   s.description      = <<-DESC

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -33,7 +33,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.frameworks = 'CFNetwork', 'Security', 'SystemConfiguration'
   s.dependency 'leveldb-library', '~> 1.18'
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
-  s.dependency 'FirebaseCore', '~> 5.2'
+  s.dependency 'FirebaseCore', '~> 6.0'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'GCC_PREPROCESSOR_DEFINITIONS' =>

--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -26,7 +26,7 @@ Firebase Dynamic Links are deep links that enhance user experience and increase 
   s.public_header_files = 'Firebase/DynamicLinks/Public/*.h'
   s.frameworks = 'AssetsLibrary', 'MessageUI', 'QuartzCore'
   s.weak_framework = 'WebKit'
-  s.dependency 'FirebaseCore', '~> 5.2'
+  s.dependency 'FirebaseCore', '~> 6.0'
   s.dependency 'FirebaseAnalyticsInterop', '~> 1.0'
 
   s.pod_target_xcconfig = {

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -52,7 +52,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.public_header_files = 'Firestore/Source/Public/*.h'
 
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
-  s.dependency 'FirebaseCore', '~> 5.2'
+  s.dependency 'FirebaseCore', '~> 6.0'
   s.dependency 'gRPC-C++', '0.0.8'
   s.dependency 'leveldb-library', '~> 1.20'
   s.dependency 'Protobuf', '~> 3.1'

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -27,7 +27,7 @@ iOS SDK for Cloud Functions for Firebase.
   s.public_header_files = 'Functions/FirebaseFunctions/Public/*.h'
 
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
-  s.dependency 'FirebaseCore', '~> 5.2'
+  s.dependency 'FirebaseCore', '~> 6.0'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
 
   s.pod_target_xcconfig = {

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -33,6 +33,6 @@ See more product details at https://firebase.google.com/products/in-app-messagin
   }
 
   s.dependency 'FirebaseCore', '~> 6.0'
-  s.ios.dependency 'FirebaseAnalyticsInterop'
-  s.dependency 'FirebaseInstanceID', '~> 3.6'
+  s.ios.dependency 'FirebaseAnalyticsInterop', '~> 1.2'
+  s.dependency 'FirebaseInstanceID', '~> 4.0'
 end

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -32,7 +32,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
       'FIRInAppMessaging_LIB_VERSION=' + String(s.version)
   }
 
-  s.dependency 'FirebaseCore'
+  s.dependency 'FirebaseCore', '~> 6.0'
   s.ios.dependency 'FirebaseAnalyticsInterop'
-  s.dependency 'FirebaseInstanceID'
+  s.dependency 'FirebaseInstanceID', '~> 3.6'
 end

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInAppMessaging'
-  s.version          = '0.13.0'
+  s.version          = '0.14.0'
   s.summary          = 'Firebase In-App Messaging for iOS'
 
   s.description      = <<-DESC

--- a/FirebaseInAppMessagingDisplay.podspec
+++ b/FirebaseInAppMessagingDisplay.podspec
@@ -40,6 +40,6 @@ Firebase In-App Messaging SDK.
       'FIRInAppMessagingDisplay_LIB_VERSION=' + String(s.version)
   }
 
-  s.dependency 'FirebaseCore'
+  s.dependency 'FirebaseCore', '~> 6.0'
   s.dependency 'FirebaseInAppMessaging', '>=0.12.0'
 end

--- a/FirebaseInAppMessagingDisplay.podspec
+++ b/FirebaseInAppMessagingDisplay.podspec
@@ -41,5 +41,5 @@ Firebase In-App Messaging SDK.
   }
 
   s.dependency 'FirebaseCore', '~> 6.0'
-  s.dependency 'FirebaseInAppMessaging', '>=0.12.0'
+  s.dependency 'FirebaseInAppMessaging', '>=0.14.0'
 end

--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInstanceID'
-  s.version          = '3.8.1'
+  s.version          = '4.0.0'
   s.summary          = 'Firebase InstanceID for iOS'
 
   s.description      = <<-DESC

--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -35,7 +35,7 @@ services.
       'FIRInstanceID_LIB_VERSION=' + String(s.version)
   }
   s.framework = 'Security'
-  s.dependency 'FirebaseCore', '~> 5.2'
+  s.dependency 'FirebaseCore', '~> 6.0'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 5.2'
   s.dependency 'GoogleUtilities/Environment', '~> 5.2'
 end

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -39,7 +39,7 @@ device, and it is completely free.
   }
   s.framework = 'SystemConfiguration'
   s.dependency 'FirebaseAnalyticsInterop', '~> 1.1'
-  s.dependency 'FirebaseCore', '~> 5.2'
+  s.dependency 'FirebaseCore', '~> 6.0'
   s.dependency 'FirebaseInstanceID', '~> 3.6'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 5.6'
   s.dependency 'GoogleUtilities/Reachability', '~> 5.6'

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -40,7 +40,7 @@ device, and it is completely free.
   s.framework = 'SystemConfiguration'
   s.dependency 'FirebaseAnalyticsInterop', '~> 1.1'
   s.dependency 'FirebaseCore', '~> 6.0'
-  s.dependency 'FirebaseInstanceID', '~> 3.6'
+  s.dependency 'FirebaseInstanceID', '~> 4.0'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 5.6'
   s.dependency 'GoogleUtilities/Reachability', '~> 5.6'
   s.dependency 'GoogleUtilities/Environment', '~> 5.6'

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -30,7 +30,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   s.osx.framework = 'CoreServices'
 
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
-  s.dependency 'FirebaseCore', '~> 5.2'
+  s.dependency 'FirebaseCore', '~> 6.0'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -43,7 +43,7 @@ target 'Firestore_Example_iOS' do
   # The next line is the forcing function for the Firebase pod. The Firebase
   # version's subspecs should depend on the component versions in their
   # corresponding podspec's.
-  pod 'Firebase/CoreOnly', '5.20.991'
+  pod 'Firebase/CoreOnly', '6.0.0-pre'
 
   pod 'FirebaseAuth', :path => '../../'
   pod 'FirebaseAuthInterop', :path => '../../'


### PR DESCRIPTION
And update all dependents to require at least 6.0.0.

To pass `pod lib lint` tests it was also necessary to bump FirebaseInstanceID to 4.0.0 and FirebaseInAppMessaging to 0.14.0 on https://github.com/firebase/SpecsStaging

Leaf pods will get their versions updated when we cut the release branch.