### PR TITLE
Private headers need to also be part of public

### DIFF
--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -28,7 +28,7 @@ services.
   base_dir = "Firebase/InstanceID/"
   s.source_files = base_dir + '**/*.[mh]'
   s.requires_arc = base_dir + '*.m'
-  s.public_header_files = base_dir + 'Public/*.h'
+  s.public_header_files = base_dir + 'Public/*.h', base_dir + 'Private/*.h'
   s.private_header_files = base_dir + 'Private/*.h'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',


### PR DESCRIPTION
While not true for Development Pods, published pods need to include private headers in the list of public headers for Xcode to make them Private instead of Project.

Pushing this to SpecsStaging fixes the regression in the FirebaseMessaging pod lib lint test.  Verified in https://travis-ci.org/firebase/firebase-ios-sdk/jobs/517555143