### PR TITLE
Undeprecate +[FIRFirestore enableLogging:]

### DIFF
--- a/Firestore/Source/Public/FIRFirestore.h
+++ b/Firestore/Source/Public/FIRFirestore.h
@@ -137,9 +137,7 @@ NS_SWIFT_NAME(Firestore)
 #pragma mark - Logging
 
 /** Enables or disables logging from the Firestore client. */
-+ (void)enableLogging:(BOOL)logging
-    DEPRECATED_MSG_ATTRIBUTE("Use FirebaseConfiguration.shared.setLoggerLevel(.debug) to enable "
-                             "logging.");
++ (void)enableLogging:(BOOL)logging;
 
 #pragma mark - Network
 


### PR DESCRIPTION
Too many places refer to calling `enableLogging` and actually removing this method would be net harmful.

Resolves issues raised in discussing #2762.