### PR TITLE
Add an OBJC_CLASS macro

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		358DBA8B2560C65D9EB23C35 /* Pods_Firestore_IntegrationTests_macOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39B832380209CC5BAF93BC52 /* Pods_Firestore_IntegrationTests_macOS.framework */; };
 		36E174A66C323891AEA16A2A /* FIRTimestampTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B65D34A7203C99090076A5E1 /* FIRTimestampTest.m */; };
 		36FD4CE79613D18BC783C55B /* string_apple_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0EE5300F8233D14025EF0456 /* string_apple_test.mm */; };
+		374C40F6DA14EDD2F0D0A0D3 /* cc_compilation_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = DBEC175659988451E52F5F0E /* cc_compilation_test.cc */; };
 		37EC6C6EA9169BB99078CA96 /* reference_set_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 132E32997D781B896672D30A /* reference_set_test.cc */; };
 		38208AC761FF994BA69822BE /* async_queue_std_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = B6FB4681208EA0BE00554BA2 /* async_queue_std_test.cc */; };
 		38430E0E07C54FCD399AE919 /* FIRQueryTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E046202154AA00B64F25 /* FIRQueryTests.mm */; };
@@ -593,6 +594,7 @@
 		E11DDA3DD75705F26245E295 /* FIRCollectionReferenceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E045202154AA00B64F25 /* FIRCollectionReferenceTests.mm */; };
 		E2B15548A3B6796CE5A01975 /* FIRListenerRegistrationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E06B202154D500B64F25 /* FIRListenerRegistrationTests.mm */; };
 		E375FBA0632EFB4D14C4E5A9 /* FSTGoogleTestTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 54764FAE1FAA21B90085E60A /* FSTGoogleTestTests.mm */; };
+		E3A4A5C7F884FC061D6DABA2 /* cc_compilation_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = DBEC175659988451E52F5F0E /* cc_compilation_test.cc */; };
 		E3C0E5F834A82EEE9F8C4519 /* watch_change_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = B68FC0E421F6848700A7055C /* watch_change_test.mm */; };
 		E4C0CC7FB88D8F6CB1B972C6 /* leveldb_index_manager_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = 73F1F7402211FEF300E1F692 /* leveldb_index_manager_test.mm */; };
 		E4EEF6AAFCD33303CE9E5408 /* field_value_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = AB356EF6200EA5EB0089B766 /* field_value_test.cc */; };
@@ -627,6 +629,7 @@
 		F9DC01FCBE76CD4F0453A67C /* strerror_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 358C3B5FE573B1D60A4F7592 /* strerror_test.cc */; };
 		FA63B7521A07F1EB2F999859 /* FSTLevelDBMigrationsTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E0862021552A00B64F25 /* FSTLevelDBMigrationsTests.mm */; };
 		FA7837C5CDFB273DE447E447 /* FIRServerTimestampTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E06E202154D600B64F25 /* FIRServerTimestampTests.mm */; };
+		FCA79F1C467581B6C23362A3 /* cc_compilation_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = DBEC175659988451E52F5F0E /* cc_compilation_test.cc */; };
 		FD8EA96A604E837092ACA51D /* ordered_code_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = AB380D03201BC6E400D97691 /* ordered_code_test.cc */; };
 		FEF55ECFB0CA317B351179AB /* no_document_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = AB6B908720322E8800CC290A /* no_document_test.cc */; };
 		FF3405218188DFCE586FB26B /* app_testing.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5467FB07203E6A44009C9584 /* app_testing.mm */; };
@@ -1014,6 +1017,7 @@
 		DAFF0D0021E64AC40062958F /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		DAFF0D0221E64AC40062958F /* macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = macOS.entitlements; sourceTree = "<group>"; };
 		DAFF0D0721E653460062958F /* roots.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = roots.pem; path = ../../../../etc/roots.pem; sourceTree = "<group>"; };
+		DBEC175659988451E52F5F0E /* cc_compilation_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = cc_compilation_test.cc; path = api/cc_compilation_test.cc; sourceTree = "<group>"; };
 		DE03B2E91F2149D600A30B9C /* Firestore_IntegrationTests_iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Firestore_IntegrationTests_iOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE03B3621F215E1600A30B9C /* CAcert.pem */ = {isa = PBXFileReference; lastKnownFileType = text; path = CAcert.pem; sourceTree = "<group>"; };
 		DE0761F61F2FE68D003233AF /* BasicCompileTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasicCompileTests.swift; sourceTree = "<group>"; };
@@ -1154,6 +1158,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3FF0D9A8259A31CABA4BE13C /* api */ = {
+			isa = PBXGroup;
+			children = (
+				DBEC175659988451E52F5F0E /* cc_compilation_test.cc */,
+			);
+			name = api;
+			sourceTree = "<group>";
+		};
 		543B4F0520A91E4B001F506D /* App */ = {
 			isa = PBXGroup;
 			children = (
@@ -1270,6 +1282,7 @@
 		54764FAC1FAA0C390085E60A /* CoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				3FF0D9A8259A31CABA4BE13C /* api */,
 				AB38D9312023962A000A432D /* auth */,
 				AB380CF7201937B800D97691 /* core */,
 				54EB764B202277970088B8F3 /* immutable */,
@@ -2989,6 +3002,7 @@
 				0B7B24194E2131F5C325FE0E /* async_queue_test.cc in Sources */,
 				1733601ECCEA33E730DEAF45 /* autoid_test.cc in Sources */,
 				0DAA255C2FEB387895ADEE12 /* bits_test.cc in Sources */,
+				FCA79F1C467581B6C23362A3 /* cc_compilation_test.cc in Sources */,
 				5556B648B9B1C2F79A706B4F /* common.pb.cc in Sources */,
 				08D853C9D3A4DC919C55671A /* comparison_test.cc in Sources */,
 				AAA50E56B9A7EF3EFDA62172 /* create_noop_connectivity_monitor.cc in Sources */,
@@ -3156,6 +3170,7 @@
 				900D0E9F18CE3DB954DD0D1E /* async_queue_test.cc in Sources */,
 				5D5E24E3FA1128145AA117D2 /* autoid_test.cc in Sources */,
 				B6FDE6F91D3F81D045E962A0 /* bits_test.cc in Sources */,
+				374C40F6DA14EDD2F0D0A0D3 /* cc_compilation_test.cc in Sources */,
 				18638EAED9E126FC5D895B14 /* common.pb.cc in Sources */,
 				1115DB1F1DCE93B63E03BA8C /* comparison_test.cc in Sources */,
 				169D01E6FF2CDF994B32B491 /* create_noop_connectivity_monitor.cc in Sources */,
@@ -3398,6 +3413,7 @@
 				B6FB467D208E9D3C00554BA2 /* async_queue_test.cc in Sources */,
 				54740A581FC914F000713A1A /* autoid_test.cc in Sources */,
 				AB380D02201BC69F00D97691 /* bits_test.cc in Sources */,
+				E3A4A5C7F884FC061D6DABA2 /* cc_compilation_test.cc in Sources */,
 				544129DA21C2DDC800EFB9CC /* common.pb.cc in Sources */,
 				548DB929200D59F600E00ABC /* comparison_test.cc in Sources */,
 				B67BF449216EB43000CA9097 /* create_noop_connectivity_monitor.cc in Sources */,

--- a/Firestore/core/src/firebase/firestore/api/document_snapshot.h
+++ b/Firestore/core/src/firebase/firestore/api/document_snapshot.h
@@ -17,26 +17,22 @@
 #ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_API_DOCUMENT_SNAPSHOT_H_
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_API_DOCUMENT_SNAPSHOT_H_
 
-#if !defined(__OBJC__)
-#error "This header only supports Objective-C++"
-#endif  // !defined(__OBJC__)
-
-#import <Foundation/Foundation.h>
+#include <objc/objc.h>  // for id
 
 #include <memory>
 #include <string>
 #include <utility>
 
-#import "Firestore/Source/Model/FSTFieldValue.h"
-
 #include "Firestore/core/src/firebase/firestore/api/snapshot_metadata.h"
 #include "Firestore/core/src/firebase/firestore/core/event_listener.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/field_path.h"
+#include "Firestore/core/src/firebase/firestore/util/objc_class.h"
 
-NS_ASSUME_NONNULL_BEGIN
+OBJC_CLASS(FSTDocument);
+OBJC_CLASS(FSTObjectValue);
 
-@class FSTDocument;
+#pragma clang assume_nonnull begin
 
 namespace firebase {
 namespace firestore {
@@ -49,37 +45,23 @@ class DocumentSnapshot {
  public:
   using Listener = std::unique_ptr<core::EventListener<DocumentSnapshot>>;
 
-  DocumentSnapshot() = default;
+  DocumentSnapshot();
 
   DocumentSnapshot(Firestore* firestore,
                    model::DocumentKey document_key,
                    FSTDocument* _Nullable document,
-                   SnapshotMetadata metadata)
-      : firestore_{firestore},
-        internal_key_{std::move(document_key)},
-        internal_document_{document},
-        metadata_{std::move(metadata)} {
-  }
+                   SnapshotMetadata metadata);
 
   DocumentSnapshot(Firestore* firestore,
                    model::DocumentKey document_key,
                    FSTDocument* _Nullable document,
                    bool from_cache,
-                   bool has_pending_writes)
-      : firestore_{firestore},
-        internal_key_{std::move(document_key)},
-        internal_document_{document},
-        metadata_{has_pending_writes, from_cache} {
-  }
+                   bool has_pending_writes);
 
   size_t Hash() const;
 
-  bool exists() const {
-    return internal_document_ != nil;
-  }
-  FSTDocument* internal_document() const {
-    return internal_document_;
-  }
+  bool exists() const;
+  FSTDocument* internal_document() const;
   std::string document_id() const;
 
   const SnapshotMetadata& metadata() const {
@@ -109,6 +91,7 @@ class DocumentSnapshot {
 }  // namespace firestore
 }  // namespace firebase
 
-NS_ASSUME_NONNULL_END
+#pragma clang assume_nonnull end
+
 
 #endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_API_DOCUMENT_SNAPSHOT_H_

--- a/Firestore/core/src/firebase/firestore/api/document_snapshot.mm
+++ b/Firestore/core/src/firebase/firestore/api/document_snapshot.mm
@@ -16,8 +16,11 @@
 
 #include "Firestore/core/src/firebase/firestore/api/document_snapshot.h"
 
+#import <Foundation/Foundation.h>
+
 #import "Firestore/Source/API/FIRDocumentReference+Internal.h"
 #import "Firestore/Source/Model/FSTDocument.h"
+#import "Firestore/Source/Model/FSTFieldValue.h"
 
 #include "Firestore/core/src/firebase/firestore/util/hashing.h"
 #include "Firestore/core/src/firebase/firestore/util/objc_compatibility.h"
@@ -32,16 +35,47 @@ namespace objc = util::objc;
 using model::DocumentKey;
 using model::FieldPath;
 
+DocumentSnapshot::DocumentSnapshot() = default;
+
+DocumentSnapshot::DocumentSnapshot(Firestore* firestore,
+                 model::DocumentKey document_key,
+                 FSTDocument* _Nullable document,
+                 SnapshotMetadata metadata)
+    : firestore_{firestore},
+      internal_key_{std::move(document_key)},
+      internal_document_{document},
+      metadata_{std::move(metadata)} {
+}
+
+DocumentSnapshot::DocumentSnapshot(Firestore* firestore,
+                 model::DocumentKey document_key,
+                 FSTDocument* _Nullable document,
+                 bool from_cache,
+                 bool has_pending_writes)
+    : firestore_{firestore},
+      internal_key_{std::move(document_key)},
+      internal_document_{document},
+      metadata_{has_pending_writes, from_cache} {
+}
+
 size_t DocumentSnapshot::Hash() const {
   return util::Hash(firestore_, internal_key_, internal_document_, metadata_);
 }
 
-DocumentReference DocumentSnapshot::CreateReference() const {
-  return DocumentReference{internal_key_, firestore_};
+bool DocumentSnapshot::exists() const {
+  return internal_document_ != nil;
+}
+FSTDocument* DocumentSnapshot::internal_document() const {
+  return internal_document_;
 }
 
 std::string DocumentSnapshot::document_id() const {
   return internal_key_.path().last_segment();
+}
+
+
+DocumentReference DocumentSnapshot::CreateReference() const {
+  return DocumentReference{internal_key_, firestore_};
 }
 
 FSTObjectValue* _Nullable DocumentSnapshot::GetData() const {

--- a/Firestore/core/src/firebase/firestore/api/query_snapshot.h
+++ b/Firestore/core/src/firebase/firestore/api/query_snapshot.h
@@ -17,12 +17,6 @@
 #ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_API_QUERY_SNAPSHOT_H_
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_API_QUERY_SNAPSHOT_H_
 
-#if !defined(__OBJC__)
-#error "This header only supports Objective-C++"
-#endif  // !defined(__OBJC__)
-
-#import <Foundation/Foundation.h>
-
 #include <functional>
 #include <utility>
 
@@ -31,10 +25,11 @@
 #include "Firestore/core/src/firebase/firestore/api/snapshot_metadata.h"
 #include "Firestore/core/src/firebase/firestore/core/view_snapshot.h"
 #include "Firestore/core/src/firebase/firestore/model/document_set.h"
+#include "Firestore/core/src/firebase/firestore/util/objc_class.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class FSTQuery;
+OBJC_CLASS(FSTQuery);
 
 namespace firebase {
 namespace firestore {
@@ -48,12 +43,7 @@ class QuerySnapshot {
   QuerySnapshot(Firestore* firestore,
                 FSTQuery* query,
                 core::ViewSnapshot&& snapshot,
-                SnapshotMetadata metadata)
-      : firestore_(firestore),
-        internal_query_(query),
-        snapshot_(std::move(snapshot)),
-        metadata_(std::move(metadata)) {
-  }
+                SnapshotMetadata metadata);
 
   size_t Hash() const;
 
@@ -73,9 +63,7 @@ class QuerySnapshot {
     return firestore_;
   }
 
-  FSTQuery* internal_query() const {
-    return internal_query_;
-  }
+  FSTQuery* internal_query() const;
 
   /**
    * Metadata about this snapshot, concerning its source and if it has local

--- a/Firestore/core/src/firebase/firestore/api/query_snapshot.mm
+++ b/Firestore/core/src/firebase/firestore/api/query_snapshot.mm
@@ -44,6 +44,20 @@ using core::DocumentViewChange;
 using core::ViewSnapshot;
 using model::DocumentSet;
 
+QuerySnapshot::QuerySnapshot(Firestore* firestore,
+                FSTQuery* query,
+                core::ViewSnapshot&& snapshot,
+                SnapshotMetadata metadata)
+      : firestore_(firestore),
+        internal_query_(query),
+        snapshot_(std::move(snapshot)),
+        metadata_(std::move(metadata)) {
+}
+
+FSTQuery* QuerySnapshot::internal_query() const {
+  return internal_query_;
+}
+
 bool operator==(const QuerySnapshot& lhs, const QuerySnapshot& rhs) {
   return lhs.firestore_ == rhs.firestore_ &&
          objc::Equals(lhs.internal_query_, rhs.internal_query_) &&

--- a/Firestore/core/src/firebase/firestore/core/view_snapshot.h
+++ b/Firestore/core/src/firebase/firestore/core/view_snapshot.h
@@ -17,10 +17,6 @@
 #ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_VIEW_SNAPSHOT_H_
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_VIEW_SNAPSHOT_H_
 
-#if !defined(__OBJC__)
-#error "This header only supports Objective-C++"
-#endif  // !defined(__OBJC__)
-
 #include <functional>
 #include <iosfwd>
 #include <memory>
@@ -33,12 +29,13 @@
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
 #include "Firestore/core/src/firebase/firestore/model/document_set.h"
+#include "Firestore/core/src/firebase/firestore/util/objc_class.h"
 #include "Firestore/core/src/firebase/firestore/util/statusor.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class FSTDocument;
-@class FSTQuery;
+OBJC_CLASS(FSTDocument);
+OBJC_CLASS(FSTQuery);
 
 namespace firebase {
 namespace firestore {
@@ -131,9 +128,7 @@ class ViewSnapshot {
                                            bool excludes_metadata_changes);
 
   /** The query this view is tracking the results for. */
-  FSTQuery* query() const {
-    return query_;
-  }
+  FSTQuery* query() const;
 
   /** The documents currently known to be results of the query. */
   const model::DocumentSet& documents() const {
@@ -198,6 +193,6 @@ bool operator==(const ViewSnapshot& lhs, const ViewSnapshot& rhs);
 }  // namespace firestore
 }  // namespace firebase
 
-NS_ASSUME_NONNULL_END
+#pragma clang assume_nonnull end
 
 #endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_VIEW_SNAPSHOT_H_

--- a/Firestore/core/src/firebase/firestore/core/view_snapshot.mm
+++ b/Firestore/core/src/firebase/firestore/core/view_snapshot.mm
@@ -170,6 +170,11 @@ ViewSnapshot ViewSnapshot::FromInitialDocuments(
                       /*sync_state_changed=*/true, excludes_metadata_changes};
 }
 
+FSTQuery* ViewSnapshot::query() const {
+  return query_;
+}
+
+
 std::string ViewSnapshot::ToString() const {
   return StringFormat(
       "<ViewSnapshot query: %s documents: %s old_documents: %s changes: %s "

--- a/Firestore/core/src/firebase/firestore/local/leveldb_remote_document_cache.mm
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_remote_document_cache.mm
@@ -24,6 +24,8 @@
 #import "Firestore/Source/Core/FSTQuery.h"
 #import "Firestore/Source/Local/FSTLevelDB.h"
 #import "Firestore/Source/Local/FSTLocalSerializer.h"
+#import "Firestore/Source/Model/FSTDocument.h"
+
 #include "Firestore/core/src/firebase/firestore/local/leveldb_key.h"
 #include "Firestore/core/src/firebase/firestore/util/status.h"
 #include "leveldb/db.h"

--- a/Firestore/core/src/firebase/firestore/local/memory_remote_document_cache.mm
+++ b/Firestore/core/src/firebase/firestore/local/memory_remote_document_cache.mm
@@ -19,6 +19,7 @@
 #import "Firestore/Protos/objc/firestore/local/MaybeDocument.pbobjc.h"
 #import "Firestore/Source/Core/FSTQuery.h"
 #import "Firestore/Source/Local/FSTMemoryPersistence.h"
+#import "Firestore/Source/Model/FSTDocument.h"
 
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 

--- a/Firestore/core/src/firebase/firestore/model/document_map.h
+++ b/Firestore/core/src/firebase/firestore/model/document_map.h
@@ -19,12 +19,13 @@
 
 #include <utility>
 
-#import "Firestore/Source/Model/FSTDocument.h"
-
 #include "Firestore/core/src/firebase/firestore/immutable/sorted_map.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
-
+#include "Firestore/core/src/firebase/firestore/util/objc_class.h"
 #include "absl/base/attributes.h"
+
+OBJC_CLASS(FSTDocument);
+OBJC_CLASS(FSTMaybeDocument);
 
 namespace firebase {
 namespace firestore {
@@ -55,16 +56,12 @@ using MaybeDocumentMap = immutable::SortedMap<DocumentKey, FSTMaybeDocument*>;
  */
 class DocumentMap {
  public:
-  DocumentMap() = default;
+  DocumentMap();
 
   ABSL_MUST_USE_RESULT DocumentMap insert(const DocumentKey& key,
-                                          FSTDocument* value) const {
-    return DocumentMap{map_.insert(key, value)};
-  }
+                                          FSTDocument* value) const;
 
-  ABSL_MUST_USE_RESULT DocumentMap erase(const DocumentKey& key) const {
-    return DocumentMap{map_.erase(key)};
-  }
+  ABSL_MUST_USE_RESULT DocumentMap erase(const DocumentKey& key) const;
 
   bool empty() const {
     return map_.empty();
@@ -85,16 +82,9 @@ class DocumentMap {
   MaybeDocumentMap map_;
 };
 
-inline FSTDocument* GetFSTDocumentOrNil(FSTMaybeDocument* maybeDoc) {
-  if ([maybeDoc isKindOfClass:[FSTDocument class]]) {
-    return static_cast<FSTDocument*>(maybeDoc);
-  }
-  return nil;
-}
+FSTDocument* GetFSTDocumentOrNil(FSTMaybeDocument* maybeDoc);
 
-inline FSTDocument* GetFSTDocumentOrNil(FSTDocument* doc) {
-  return doc;
-}
+FSTDocument* GetFSTDocumentOrNil(FSTDocument* doc);
 
 }  // namespace model
 }  // namespace firestore

--- a/Firestore/core/src/firebase/firestore/model/document_map.mm
+++ b/Firestore/core/src/firebase/firestore/model/document_map.mm
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/model/document_map.h"
+
+#import <Foundation/Foundation.h>
+
+#import "Firestore/Source/Model/FSTDocument.h"
+
+namespace firebase {
+namespace firestore {
+namespace model {
+
+  DocumentMap::DocumentMap() = default;
+
+  ABSL_MUST_USE_RESULT DocumentMap DocumentMap::insert(const DocumentKey& key,
+                                          FSTDocument* value) const {
+    return DocumentMap{map_.insert(key, value)};
+  }
+
+  ABSL_MUST_USE_RESULT DocumentMap DocumentMap::erase(const DocumentKey& key) const {
+    return DocumentMap{map_.erase(key)};
+  }
+
+FSTDocument* GetFSTDocumentOrNil(FSTMaybeDocument* maybeDoc) {
+  if ([maybeDoc isKindOfClass:[FSTDocument class]]) {
+    return static_cast<FSTDocument*>(maybeDoc);
+  }
+  return nil;
+}
+
+FSTDocument* GetFSTDocumentOrNil(FSTDocument* doc) {
+  return doc;
+}
+
+}  // namespace model
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/core/src/firebase/firestore/model/document_set.h
+++ b/Firestore/core/src/firebase/firestore/model/document_set.h
@@ -17,12 +17,6 @@
 #ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_MODEL_DOCUMENT_SET_H_
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_MODEL_DOCUMENT_SET_H_
 
-#if !defined(__OBJC__)
-#error "This header only supports Objective-C++"
-#endif  // !defined(__OBJC__)
-
-#import <Foundation/Foundation.h>
-
 #include <iosfwd>
 #include <string>
 #include <utility>
@@ -33,8 +27,9 @@
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/document_map.h"
 #include "Firestore/core/src/firebase/firestore/util/comparison.h"
+#include "Firestore/core/src/firebase/firestore/util/objc_class.h"
 
-@class FSTDocument;
+OBJC_CLASS(FSTDocument);
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -248,6 +248,7 @@ cc_library(
     delayed_constructor.h
     hashing.h
     iterator_adaptors.h
+    objc_class.h
     objc_compatibility.h
     ordered_code.cc
     ordered_code.h

--- a/Firestore/core/src/firebase/firestore/util/objc_class.h
+++ b/Firestore/core/src/firebase/firestore/util/objc_class.h
@@ -23,8 +23,22 @@
 // be usable from straight C++.
 //
 // Care must be taken to not use the forward declaration (even implicitly) in
-// the header. Constructors, getters and setters all must be defined out of
-// line to avoid problems where ARC does not see changes to the reference.
+// any inline definitions in the header. Even though Objective-C object
+// pointers look like raw pointers, under ARC they're more like
+// std::shared_ptr, where assignments and copies all potentially change the
+// refcount of the pointee. When methods that affect the reference count are
+// compiled inline in regular C++ this additional behavior won't get compiled
+// in and the Objective-C reference counts will be off.
+//
+// Note that this may even appear to work, though it does so through undefined
+// behavior: inline definitions are deduplicated at link time, and if the
+// linker happens to choose a definition that was generated in an ARC-enabled
+// translation unit then that specific build will work.
+//
+// Concretely this means that any method manipulating an Objective-C object
+// pointer (constructors, destructors, getters, and setters) all must be
+// defined out of line to avoid problems where ARC does not see changes to the
+// reference.
 #if __OBJC__
 #define OBJC_CLASS(name) @class name
 

--- a/Firestore/core/src/firebase/firestore/util/objc_class.h
+++ b/Firestore/core/src/firebase/firestore/util/objc_class.h
@@ -43,11 +43,21 @@
 #define OBJC_CLASS(name) @class name
 
 #else
-// Forward declaration from objc/objc.h
-struct objc_object;
-
 #define OBJC_CLASS(name) using name = struct objc_object
 
 #endif  // __OBJC__
+
+// Define NS_ASSUME_NONNULL_BEGIN for straight C++ so that everything gets the
+// correct nullability specifier.
+#if !defined(NS_ASSUME_NONNULL_BEGIN)
+#if __clang__
+#define NS_ASSUME_NONNULL_BEGIN _Pragma("clang assume_nonnull begin")
+#define NS_ASSUME_NONNULL_END   _Pragma("clang assume_nonnull end")
+
+#else
+#define NS_ASSUME_NONNULL_BEGIN
+#define NS_ASSUME_NONNULL_END
+#endif  // __clang__
+#endif  // !defined(NS_ASSUME_NONNULL_BEGIN)
 
 #endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_OBJC_CLASS_H_

--- a/Firestore/core/src/firebase/firestore/util/objc_class.h
+++ b/Firestore/core/src/firebase/firestore/util/objc_class.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_OBJC_CLASS_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_OBJC_CLASS_H_
+
+// The OBJC_CLASS macro defines a forward declaration for an Objective-C class
+// that's compatible both with Objective-C++ and regular C++. It's useful in
+// headers that reference Objective-C types as members of C++ classes that must
+// be usable from straight C++.
+//
+// Care must be taken to not use the forward declaration (even implicitly) in
+// the header. Constructors, getters and setters all must be defined out of
+// line to avoid problems where ARC does not see changes to the reference.
+#if __OBJC__
+#define OBJC_CLASS(name) @class name
+
+#else
+// Forward declaration from objc/objc.h
+struct objc_object;
+
+#define OBJC_CLASS(name) using name = struct objc_object
+
+#endif  // __OBJC__
+
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_OBJC_CLASS_H_

--- a/Firestore/core/test/firebase/firestore/api/cc_compilation_test.cc
+++ b/Firestore/core/test/firebase/firestore/api/cc_compilation_test.cc
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/api/query_snapshot.h"
+#include "gtest/gtest.h"
+
+namespace firebase {
+namespace firestore {
+namespace api {
+
+TEST(CompilationTest, Compiles) {
+  // TODO(wilhuff) make this test more useful
+  // It's hard to do right now because QuerySnapshot can't have a default constructor.
+  QuerySnapshot* snapshot = nullptr;
+  ASSERT_EQ(snapshot, nullptr);
+}
+
+}  // namespace api
+}  // namespace firestore
+}  // namespace firebase


### PR DESCRIPTION
This makes it possible to forward declare Objective-C types in plain C++
headers.
