### PR TITLE
Take 2: Move input validation logic from FIRFieldPath to model::FieldPath. (#2727)

### DIFF
--- a/Firestore/Source/API/FIRFieldPath.mm
+++ b/Firestore/Source/API/FIRFieldPath.mm
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
     field_names.emplace_back(util::MakeString(fieldNames[i]));
   }
 
-  return [self initPrivate:FieldPath(std::move(field_names))];
+  return [self initPrivate:FieldPath::FromSegments(std::move(field_names))];
 }
 
 + (instancetype)documentID {

--- a/Firestore/Source/API/FIRFieldPath.mm
+++ b/Firestore/Source/API/FIRFieldPath.mm
@@ -51,9 +51,6 @@ NS_ASSUME_NONNULL_BEGIN
   std::vector<std::string> field_names;
   field_names.reserve(fieldNames.count);
   for (int i = 0; i < fieldNames.count; ++i) {
-    if (fieldNames[i].length == 0) {
-      ThrowInvalidArgument("Invalid field name at index %s. Field names must not be empty.", i);
-    }
     field_names.emplace_back(util::MakeString(fieldNames[i]));
   }
 
@@ -72,21 +69,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (instancetype)pathWithDotSeparatedString:(NSString *)path {
-  if ([[FIRFieldPath reservedCharactersRegex]
-          numberOfMatchesInString:path
-                          options:0
-                            range:NSMakeRange(0, path.length)] > 0) {
-    ThrowInvalidArgument(
-        "Invalid field path (%s). Paths must not contain '~', '*', '/', '[', or ']'", path);
-  }
-  @try {
-    return [[FIRFieldPath alloc] initWithFields:[path componentsSeparatedByString:@"."]];
-  } @catch (NSException *exception) {
-    ThrowInvalidArgument(
-        "Invalid field path (%s). Paths must not be empty, begin with '.', end with '.', or "
-        "contain '..'",
-        path);
-  }
+  return
+      [[FIRFieldPath alloc] initPrivate:FieldPath::FromDotSeparatedString(util::MakeString(path))];
 }
 
 /** Matches any characters in a field path string that are reserved. */

--- a/Firestore/core/src/firebase/firestore/model/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/model/CMakeLists.txt
@@ -50,6 +50,7 @@ cc_library(
   DEPENDS
     absl_optional
     absl_strings
+    firebase_firestore_api_input_validation
     firebase_firestore_immutable
     firebase_firestore_util
     firebase_firestore_types

--- a/Firestore/core/src/firebase/firestore/model/field_path.cc
+++ b/Firestore/core/src/firebase/firestore/model/field_path.cc
@@ -100,7 +100,7 @@ FieldPath FieldPath::FromDotSeparatedString(absl::string_view path) {
         return true;
       });
 
-  return FieldPath{std::move(segments)};
+  return FieldPath(std::move(segments));
 }
 
 FieldPath FieldPath::FromServerFormat(const absl::string_view path) {

--- a/Firestore/core/src/firebase/firestore/model/field_path.cc
+++ b/Firestore/core/src/firebase/firestore/model/field_path.cc
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <utility>
 
+#include "Firestore/core/src/firebase/firestore/api/input_validation.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_replace.h"
@@ -27,6 +28,8 @@
 namespace firebase {
 namespace firestore {
 namespace model {
+
+using api::ThrowInvalidArgument;
 
 namespace {
 
@@ -77,6 +80,28 @@ struct JoinEscaped {
   }
 };
 }  // namespace
+
+FieldPath FieldPath::FromDotSeparatedString(absl::string_view path) {
+  if (path.find_first_of("~*/[]") != absl::string_view::npos) {
+    ThrowInvalidArgument(
+        "Invalid field path (%s). Paths must not contain '~', '*', '/', '[', "
+        "or ']'",
+        path);
+  }
+
+  SegmentsT segments =
+      absl::StrSplit(path, '.', [path](absl::string_view segment) {
+        if (segment.empty()) {
+          ThrowInvalidArgument(
+              "Invalid field path (%s). Paths must not be empty, begin with "
+              "'.', end with '.', or contain '..'",
+              path);
+        }
+        return true;
+      });
+
+  return FieldPath{std::move(segments)};
+}
 
 FieldPath FieldPath::FromServerFormat(const absl::string_view path) {
   SegmentsT segments;


### PR DESCRIPTION
The first commit is a cherry-pick of my first attempt (384ccd81a).

The second commit reworks it to do the validation in a FromSegments() method that is only called from the public API.