### PR TITLE
Fix 1P build issue

### DIFF
--- a/Firebase/DynamicLinks/FDLURLComponents/FDLURLComponents+Private.h
+++ b/Firebase/DynamicLinks/FDLURLComponents/FDLURLComponents+Private.h
@@ -16,6 +16,11 @@
 
 #import "DynamicLinks/Public/FDLURLComponents.h"
 
+/**
+ * Label exceptions from FDL.
+ */
+FOUNDATION_EXPORT NSString *_Nonnull const kFirebaseDurableDeepLinkErrorDomain;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /// Each of the parameter classes used in FIRDynamicLinkURLComponents needs to be able to

--- a/Firebase/DynamicLinks/FDLURLComponents/FDLURLComponents.m
+++ b/Firebase/DynamicLinks/FDLURLComponents/FDLURLComponents.m
@@ -18,7 +18,6 @@
 
 #import "DynamicLinks/FDLURLComponents/FDLURLComponents+Private.h"
 #import "DynamicLinks/FDLURLComponents/FIRDynamicLinkComponentsKeyProvider.h"
-#import "DynamicLinks/FIRDynamicLinks+Private.h"
 #import "DynamicLinks/Public/FDLURLComponents.h"
 
 #import "DynamicLinks/Logging/FDLLogging.h"

--- a/Firebase/DynamicLinks/FIRDynamicLinks+Private.h
+++ b/Firebase/DynamicLinks/FIRDynamicLinks+Private.h
@@ -30,11 +30,6 @@ FOUNDATION_EXPORT NSString *const kFIRDLVersion;
  */
 FOUNDATION_EXPORT NSString *const kFIRDLReadDeepLinkAfterInstallKey;
 
-/**
- * Label exceptions from FDL.
- */
-FOUNDATION_EXPORT NSString *const kFirebaseDurableDeepLinkErrorDomain;
-
 @interface FIRDynamicLinks (Private)
 
 /**


### PR DESCRIPTION
In the internal Dynamic Links build, the FDLComponents directory does not have access to the higher level headers.