### PR TITLE
InstanceID - Add private initializer used by Swift 1p tests

### DIFF
--- a/Firebase/InstanceID/FIRInstanceID+Private.h
+++ b/Firebase/InstanceID/FIRInstanceID+Private.h
@@ -25,6 +25,11 @@
 @interface FIRInstanceID (Private)
 
 /**
+ *  Private initializer.
+ */
+- (nonnull instancetype)initPrivately;
+
+/**
  *  Return the cached checkin preferences on the disk. This is used internally only by Messaging.
  *
  *  @return The cached checkin preferences on the client.


### PR DESCRIPTION
Needed to fix 1p. The initializer was removed along with FIRInstanceID+Testing