### PR TITLE
Temporarily restore setAnalyticsCollectionEnabled

### DIFF
--- a/Firebase/Core/FIRAnalyticsConfiguration.m
+++ b/Firebase/Core/FIRAnalyticsConfiguration.m
@@ -39,6 +39,10 @@
                                                     userInfo:@{name : value}];
 }
 
+- (void)setAnalyticsCollectionEnabled:(BOOL)analyticsCollectionEnabled {
+  [self setAnalyticsCollectionEnabled:analyticsCollectionEnabled persistSetting:YES];
+}
+
 - (void)setAnalyticsCollectionEnabled:(BOOL)analyticsCollectionEnabled
                        persistSetting:(BOOL)shouldPersist {
   // Persist the measurementEnabledState. Use FIRAnalyticsEnabledState values instead of YES/NO.

--- a/Firebase/Core/Private/FIRAnalyticsConfiguration.h
+++ b/Firebase/Core/Private/FIRAnalyticsConfiguration.h
@@ -43,6 +43,10 @@ static NSString *const kFIRAnalyticsConfigurationSetSessionTimeoutIntervalNotifi
 /// Returns the shared instance of FIRAnalyticsConfiguration.
 + (FIRAnalyticsConfiguration *)sharedInstance;
 
+// Sets whether analytics collection is enabled for this app on this device. This setting is
+// persisted across app sessions. By default it is enabled.
+- (void)setAnalyticsCollectionEnabled:(BOOL)analyticsCollectionEnabled;
+
 /// Sets whether analytics collection is enabled for this app on this device, and a flag to persist
 /// the value or not. The setting should not be persisted if being set by the global data collection
 /// flag.


### PR DESCRIPTION
Restore single argument version of setAnalyticsCollectionEnabled until clients can migrate to the Analytics version.