### PR TITLE
Fix a couple small issues I tripped over today.

### DIFF
--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -395,14 +395,13 @@ static FIRFirestoreSettings *defaultSettings;
 }
 
 - (void)disableNetwork {
-  [self.db.client
+  [self.db
       disableNetworkWithCompletion:[self completionForExpectationWithName:@"Disable Network."]];
   [self awaitExpectations];
 }
 
 - (void)enableNetwork {
-  [self.db.client
-      enableNetworkWithCompletion:[self completionForExpectationWithName:@"Enable Network."]];
+  [self.db enableNetworkWithCompletion:[self completionForExpectationWithName:@"Enable Network."]];
   [self awaitExpectations];
 }
 

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -85,6 +85,7 @@ static FIRFirestoreSettings *defaultSettings;
   [super setUp];
 
   [self clearPersistence];
+  [self primeBackend];
 
   _firestores = [NSMutableArray array];
   self.db = [self firestore];
@@ -202,14 +203,13 @@ static FIRFirestoreSettings *defaultSettings;
 
   [_firestores addObject:firestore];
 
-  [self primeBackend:firestore];
-
   return firestore;
 }
 
-- (void)primeBackend:(FIRFirestore *)db {
+- (void)primeBackend {
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
+    FIRFirestore *db = [self firestore];
     XCTestExpectation *watchInitialized =
         [self expectationWithDescription:@"Prime backend: Watch initialized"];
     __block XCTestExpectation *watchUpdateReceived;
@@ -247,6 +247,8 @@ static FIRFirestoreSettings *defaultSettings;
                                  }];
 
     [listenerRegistration remove];
+
+    [self shutdownFirestore:db];
   });
 }
 

--- a/Firestore/Source/API/FIRFirestore+Internal.h
+++ b/Firestore/Source/API/FIRFirestore+Internal.h
@@ -68,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // FIRFirestore ownes the DatabaseId instance.
 @property(nonatomic, assign, readonly) const firebase::firestore::model::DatabaseId *databaseID;
-@property(nonatomic, strong, readonly) FSTFirestoreClient *client;
+@property(nonatomic, nullable, strong, readonly) FSTFirestoreClient *client;
 @property(nonatomic, strong, readonly) FSTUserDataConverter *dataConverter;
 
 @end

--- a/Firestore/Source/API/FIRFirestore+Internal.h
+++ b/Firestore/Source/API/FIRFirestore+Internal.h
@@ -68,7 +68,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 // FIRFirestore ownes the DatabaseId instance.
 @property(nonatomic, assign, readonly) const firebase::firestore::model::DatabaseId *databaseID;
-@property(nonatomic, nullable, strong, readonly) FSTFirestoreClient *client;
 @property(nonatomic, strong, readonly) FSTUserDataConverter *dataConverter;
 
 @end

--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -174,13 +174,6 @@ extern "C" NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
   _firestore->set_settings(settings);
 }
 
-/**
- * Returns the FirestoreClient if it is configured.
- */
-- (nullable FSTFirestoreClient *)client {
-  return _firestore->client();
-}
-
 - (FIRCollectionReference *)collectionWithPath:(NSString *)collectionPath {
   if (!collectionPath) {
     ThrowInvalidArgument("Collection path cannot be nil.");

--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -175,9 +175,9 @@ extern "C" NSString *const FIRFirestoreErrorDomain = @"FIRFirestoreErrorDomain";
 }
 
 /**
- * Ensures that the FirestoreClient is configured and returns it.
+ * Returns the FirestoreClient if it is configured.
  */
-- (FSTFirestoreClient *)client {
+- (nullable FSTFirestoreClient *)client {
   return _firestore->client();
 }
 

--- a/Firestore/Source/API/FIRQuery.mm
+++ b/Firestore/Source/API/FIRQuery.mm
@@ -121,7 +121,7 @@ NS_ASSUME_NONNULL_BEGIN
                                          NSError *_Nullable error))completion {
   Source source = MakeSource(publicSource);
   if (source == Source::Cache) {
-    [self.firestore.client getDocumentsFromLocalCache:self completion:completion];
+    [self.firestore.wrapped->client() getDocumentsFromLocalCache:self completion:completion];
     return;
   }
 

--- a/Firestore/Source/API/FIRWriteBatch.mm
+++ b/Firestore/Source/API/FIRWriteBatch.mm
@@ -133,7 +133,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)commitWithCompletion:(nullable void (^)(NSError *_Nullable error))completion {
   [self verifyNotCommitted];
   self.committed = TRUE;
-  [self.firestore.client writeMutations:std::move(_mutations) completion:completion];
+  [self.firestore.wrapped->client() writeMutations:std::move(_mutations) completion:completion];
 }
 
 - (void)verifyNotCommitted {

--- a/Firestore/core/src/firebase/firestore/api/firestore.h
+++ b/Firestore/core/src/firebase/firestore/api/firestore.h
@@ -32,6 +32,7 @@
 #include "Firestore/core/src/firebase/firestore/auth/credentials_provider.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
 #include "Firestore/core/src/firebase/firestore/util/async_queue.h"
+#include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -75,6 +76,7 @@ class Firestore {
   }
 
   FSTFirestoreClient* client() {
+    HARD_ASSERT(client_, "Client is not yet configured.");
     return client_;
   }
 


### PR DESCRIPTION
1. Fix primeBackend so it uses an isolated FIRFirestore* instance. I ran into
   an issue where tests that try to change .settings would fail if they were the
   very first test run, since primeBackend had already configured the client and
   so settings could no longer be changed.
2. FIRFirestore.client was incorrectly typed / commented as non-null.
