### PR TITLE
GoogleUtilities to 5.8.0

### DIFF
--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -63,7 +63,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
   s.ios.framework = 'SafariServices'
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
   s.dependency 'FirebaseCore', '~> 6.0'
-  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 5.6'
-  s.dependency 'GoogleUtilities/Environment', '~> 5.6'
+  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 5.8'
+  s.dependency 'GoogleUtilities/Environment', '~> 5.8'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
 end

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -41,9 +41,9 @@ device, and it is completely free.
   s.dependency 'FirebaseAnalyticsInterop', '~> 1.1'
   s.dependency 'FirebaseCore', '~> 6.0'
   s.dependency 'FirebaseInstanceID', '~> 4.0'
-  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 5.6'
-  s.dependency 'GoogleUtilities/Reachability', '~> 5.6'
-  s.dependency 'GoogleUtilities/Environment', '~> 5.6'
-  s.dependency 'GoogleUtilities/UserDefaults', '~> 5.6'
+  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 5.8'
+  s.dependency 'GoogleUtilities/Reachability', '~> 5.8'
+  s.dependency 'GoogleUtilities/Environment', '~> 5.8'
+  s.dependency 'GoogleUtilities/UserDefaults', '~> 5.8'
   s.dependency 'Protobuf', '~> 3.1'
 end

--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleUtilities'
-  s.version          = '5.6.0'
+  s.version          = '5.8.0'
   s.summary          = 'Google Utilities for iOS (plus community support for macOS and tvOS)'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Bump GoogleUtilities to 5.8.0 internally after doing public push of 5.7.0 to address #2807