### PR TITLE
Skip tests on pod repo push

### DIFF
--- a/Releases/update-versions.py
+++ b/Releases/update-versions.py
@@ -205,8 +205,8 @@ def PushPodspecs(version_data):
     podspec = '{}.podspec'.format(pod)
     json = os.path.join(tmp_dir, '{}.json'.format(podspec))
     LogOrRun('pod ipc spec {} > {}'.format(podspec, json))
-    LogOrRun('pod repo push {} {}{}'.format(GetCpdcInternal(), json,
-                                            warnings_ok))
+    LogOrRun('pod repo push --skip-tests {} {}{}'.format(GetCpdcInternal(),
+                                                         json, warnings_ok))
   os.system('rm -rf {}'.format(tmp_dir))
 
 


### PR DESCRIPTION
Tests should have already been run.  Avoid any unnecessary configuration or delay in release process.