### PR TITLE
Make api::DocumentReference accept ParsedSetData / ParsedUserData.

### DIFF
--- a/Firestore/Source/API/FIRDocumentReference.mm
+++ b/Firestore/Source/API/FIRDocumentReference.mm
@@ -38,7 +38,6 @@
 #include "Firestore/core/src/firebase/firestore/core/event_listener.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/document_set.h"
-#include "Firestore/core/src/firebase/firestore/model/precondition.h"
 #include "Firestore/core/src/firebase/firestore/model/resource_path.h"
 #include "Firestore/core/src/firebase/firestore/util/error_apple.h"
 #include "Firestore/core/src/firebase/firestore/util/status.h"
@@ -59,7 +58,6 @@ using firebase::firestore::core::ListenOptions;
 using firebase::firestore::core::ParsedSetData;
 using firebase::firestore::core::ParsedUpdateData;
 using firebase::firestore::model::DocumentKey;
-using firebase::firestore::model::Precondition;
 using firebase::firestore::model::ResourcePath;
 using firebase::firestore::util::Status;
 using firebase::firestore::util::StatusOr;
@@ -162,9 +160,7 @@ NS_ASSUME_NONNULL_BEGIN
   auto dataConverter = self.firestore.dataConverter;
   ParsedSetData parsed = merge ? [dataConverter parsedMergeData:documentData fieldMask:nil]
                                : [dataConverter parsedSetData:documentData];
-  _documentReference.SetData(
-      std::move(parsed).ToMutations(_documentReference.key(), Precondition::None()),
-      util::MakeCallback(completion));
+  _documentReference.SetData(std::move(parsed), util::MakeCallback(completion));
 }
 
 - (void)setData:(NSDictionary<NSString *, id> *)documentData
@@ -172,9 +168,7 @@ NS_ASSUME_NONNULL_BEGIN
      completion:(nullable void (^)(NSError *_Nullable error))completion {
   ParsedSetData parsed = [self.firestore.dataConverter parsedMergeData:documentData
                                                              fieldMask:mergeFields];
-  _documentReference.SetData(
-      std::move(parsed).ToMutations(_documentReference.key(), Precondition::None()),
-      util::MakeCallback(completion));
+  _documentReference.SetData(std::move(parsed), util::MakeCallback(completion));
 }
 
 - (void)updateData:(NSDictionary<id, id> *)fields {
@@ -184,9 +178,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)updateData:(NSDictionary<id, id> *)fields
         completion:(nullable void (^)(NSError *_Nullable error))completion {
   ParsedUpdateData parsed = [self.firestore.dataConverter parsedUpdateData:fields];
-  _documentReference.UpdateData(
-      std::move(parsed).ToMutations(_documentReference.key(), Precondition::Exists(true)),
-      util::MakeCallback(completion));
+  _documentReference.UpdateData(std::move(parsed), util::MakeCallback(completion));
 }
 
 - (void)deleteDocument {

--- a/Firestore/core/src/firebase/firestore/api/document_reference.h
+++ b/Firestore/core/src/firebase/firestore/api/document_reference.h
@@ -26,19 +26,17 @@
 #include <memory>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "Firestore/core/src/firebase/firestore/api/document_snapshot.h"
 #include "Firestore/core/src/firebase/firestore/api/listener_registration.h"
 #include "Firestore/core/src/firebase/firestore/core/listen_options.h"
+#include "Firestore/core/src/firebase/firestore/core/user_data.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/resource_path.h"
 #include "Firestore/core/src/firebase/firestore/util/status.h"
 #include "Firestore/core/src/firebase/firestore/util/statusor_callback.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
-@class FSTMutation;
 
 namespace firebase {
 namespace firestore {
@@ -77,10 +75,9 @@ class DocumentReference {
   // CollectionReference GetCollectionReference(
   //     const std::string& collection_path) const;
 
-  void SetData(std::vector<FSTMutation*>&& mutations,
-               util::StatusCallback callback);
+  void SetData(core::ParsedSetData&& setData, util::StatusCallback callback);
 
-  void UpdateData(std::vector<FSTMutation*>&& mutations,
+  void UpdateData(core::ParsedUpdateData&& updateData,
                   util::StatusCallback callback);
 
   void DeleteDocument(util::StatusCallback callback);

--- a/Firestore/core/src/firebase/firestore/api/document_reference.mm
+++ b/Firestore/core/src/firebase/firestore/api/document_reference.mm
@@ -25,7 +25,6 @@
 #import "Firestore/Source/Core/FSTEventManager.h"
 #import "Firestore/Source/Core/FSTFirestoreClient.h"
 #import "Firestore/Source/Core/FSTQuery.h"
-#import "Firestore/Source/Model/FSTMutation.h"
 
 #include "Firestore/core/src/firebase/firestore/api/source.h"
 #include "Firestore/core/src/firebase/firestore/core/view_snapshot.h"
@@ -96,16 +95,19 @@ std::string DocumentReference::Path() const {
 //   return CollectionReference{firestore_, path};
 // }
 
-void DocumentReference::SetData(std::vector<FSTMutation*>&& mutations,
+void DocumentReference::SetData(core::ParsedSetData&& setData,
                                 util::StatusCallback callback) {
-  [firestore_->client() writeMutations:std::move(mutations)
-                              callback:std::move(callback)];
+  [firestore_->client()
+      writeMutations:std::move(setData).ToMutations(key(), Precondition::None())
+            callback:std::move(callback)];
 }
 
-void DocumentReference::UpdateData(std::vector<FSTMutation*>&& mutations,
+void DocumentReference::UpdateData(core::ParsedUpdateData&& updateData,
                                    util::StatusCallback callback) {
-  return [firestore_->client() writeMutations:std::move(mutations)
-                                     callback:std::move(callback)];
+  return [firestore_->client()
+      writeMutations:std::move(updateData)
+                         .ToMutations(key(), Precondition::Exists(true))
+            callback:std::move(callback)];
 }
 
 void DocumentReference::DeleteDocument(util::StatusCallback callback) {


### PR DESCRIPTION
I *think* the intention was that the user_data.h types should be used as the representation of parsed user data that can be passed down from the public API to the api:: layer, so this PR "fixes" api::DocumentReference to accept ParsedSetData and ParsedUserData in SetData() / UpdateData() instead of taking the list of mutations. This is consistent with the approach I took in the api::WriteBatch port.

Sidenote: Prior to this change, SetData() / UpdateData() were actually identical methods just with different names.
