### PR TITLE
Pin to older version of functions emulator.

### DIFF
--- a/Functions/Backend/package.json
+++ b/Functions/Backend/package.json
@@ -7,6 +7,6 @@
   },
   "private": true,
   "devDependencies": {
-    "@google-cloud/functions-emulator": "^1.0.0-beta.5"
+    "@google-cloud/functions-emulator": "1.0.0-beta.5"
   }
 }


### PR DESCRIPTION
Fixes Issue #2851 by pinning the tests to an older version of the emulator.
The team working on the emulator is aware of the breakage in the newer version, and is working on a fix.