### PR TITLE
Set DerivePointerAlignment=false for Firestore cpp files.

### DIFF
--- a/Firestore/core/.clang-format
+++ b/Firestore/core/.clang-format
@@ -4,5 +4,6 @@ ColumnLimit: 80
 BinPackParameters: false
 AllowAllParametersOfDeclarationOnNextLine: true
 SpacesInContainerLiterals: true
+DerivePointerAlignment: false
 PointerAlignment: Left
 AllowShortFunctionsOnASingleLine: None

--- a/Firestore/core/src/firebase/firestore/local/memory_remote_document_cache.h
+++ b/Firestore/core/src/firebase/firestore/local/memory_remote_document_cache.h
@@ -43,27 +43,27 @@ namespace local {
 
 class MemoryRemoteDocumentCache : public RemoteDocumentCache {
  public:
-  explicit MemoryRemoteDocumentCache(FSTMemoryPersistence *persistence);
+  explicit MemoryRemoteDocumentCache(FSTMemoryPersistence* persistence);
 
-  void Add(FSTMaybeDocument *document) override;
-  void Remove(const model::DocumentKey &key) override;
+  void Add(FSTMaybeDocument* document) override;
+  void Remove(const model::DocumentKey& key) override;
 
-  FSTMaybeDocument *_Nullable Get(const model::DocumentKey &key) override;
-  model::MaybeDocumentMap GetAll(const model::DocumentKeySet &keys) override;
-  model::DocumentMap GetMatching(FSTQuery *query) override;
+  FSTMaybeDocument* _Nullable Get(const model::DocumentKey& key) override;
+  model::MaybeDocumentMap GetAll(const model::DocumentKeySet& keys) override;
+  model::DocumentMap GetMatching(FSTQuery* query) override;
 
   std::vector<model::DocumentKey> RemoveOrphanedDocuments(
-      FSTMemoryLRUReferenceDelegate *reference_delegate,
+      FSTMemoryLRUReferenceDelegate* reference_delegate,
       model::ListenSequenceNumber upper_bound);
 
-  size_t CalculateByteSize(FSTLocalSerializer *serializer);
+  size_t CalculateByteSize(FSTLocalSerializer* serializer);
 
  private:
   /** Underlying cache of documents. */
   model::MaybeDocumentMap docs_;
 
   // This instance is owned by FSTMemoryPersistence; avoid a retain cycle.
-  __weak FSTMemoryPersistence *persistence_;
+  __weak FSTMemoryPersistence* persistence_;
 };
 
 }  // namespace local

--- a/Firestore/core/test/firebase/firestore/local/index_manager_test.h
+++ b/Firestore/core/test/firebase/firestore/local/index_manager_test.h
@@ -49,7 +49,7 @@ class IndexManagerTest : public ::testing::TestWithParam<FactoryFunc> {
   virtual ~IndexManagerTest();
 
  protected:
-  void AssertParents(const std::string &collection_id,
+  void AssertParents(const std::string& collection_id,
                      std::vector<std::string> expected);
 };
 

--- a/Firestore/core/test/firebase/firestore/local/index_manager_test.mm
+++ b/Firestore/core/test/firebase/firestore/local/index_manager_test.mm
@@ -31,13 +31,13 @@ namespace local {
 
 using model::ResourcePath;
 
-void IndexManagerTest::AssertParents(const std::string &collection_id,
+void IndexManagerTest::AssertParents(const std::string& collection_id,
                                      std::vector<std::string> expected) {
-  IndexManager *index_manager = persistence.indexManager;
+  IndexManager* index_manager = persistence.indexManager;
   std::vector<ResourcePath> actual_paths =
       index_manager->GetCollectionParents(collection_id);
   std::vector<std::string> actual;
-  for (const ResourcePath &actual_path : actual_paths) {
+  for (const ResourcePath& actual_path : actual_paths) {
     actual.push_back(actual_path.CanonicalString());
   }
   std::sort(expected.begin(), expected.end());
@@ -52,7 +52,7 @@ IndexManagerTest::~IndexManagerTest() {
 }
 
 TEST_P(IndexManagerTest, AddAndReadCollectionParentIndexEntries) {
-  IndexManager *index_manager = persistence.indexManager;
+  IndexManager* index_manager = persistence.indexManager;
   persistence.run("AddAndReadCollectionParentIndexEntries", [&]() {
     index_manager->AddToCollectionParentIndex(ResourcePath{"messages"});
     index_manager->AddToCollectionParentIndex(ResourcePath{"messages"});

--- a/Firestore/core/test/firebase/firestore/remote/watch_change_test.mm
+++ b/Firestore/core/test/firebase/firestore/remote/watch_change_test.mm
@@ -35,7 +35,7 @@ namespace firestore {
 namespace remote {
 
 TEST(WatchChangeTest, CanCreateDocumentWatchChange) {
-  FSTMaybeDocument *doc = FSTTestDoc("a/b", 1, @{}, FSTDocumentStateSynced);
+  FSTMaybeDocument* doc = FSTTestDoc("a/b", 1, @{}, FSTDocumentStateSynced);
   DocumentWatchChange change{{1, 2, 3}, {4, 5}, doc.key, doc};
 
   EXPECT_EQ(change.updated_target_ids().size(), 3);


### PR DESCRIPTION
Context: https://github.com/firebase/firebase-ios-sdk/pull/2844/files#r276370766

Fix pointer alignment once-and-for-all?