### PR TITLE
fix race condition checkin is deleted before writing during app start

### DIFF
--- a/Firebase/InstanceID/FIRIMessageCode.h
+++ b/Firebase/InstanceID/FIRIMessageCode.h
@@ -71,6 +71,8 @@ typedef NS_ENUM(NSInteger, FIRInstanceIDMessageCode) {
   kFIRInstanceIDMessageCodeCheckinStore000 = 8000,
   kFIRInstanceIDMessageCodeCheckinStore001 = 8001,
   kFIRInstanceIDMessageCodeCheckinStore003 = 8003,
+  kFIRInstanceIDMessageCodeCheckinStoreCheckinPlistDeleted = 8009,
+  kFIRInstanceIDMessageCodeCheckinStoreCheckinPlistSaved = 8010,
   // FIRInstanceIDKeyPair.m
   // DO NOT USE 9001, 9003
   kFIRInstanceIDMessageCodeKeyPair000 = 9000,

--- a/Firebase/InstanceID/FIRInstanceIDCheckinStore.m
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinStore.m
@@ -122,6 +122,9 @@ static const NSInteger kOldCheckinPlistCount = 6;
     }
     return;
   }
+  FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeCheckinStoreCheckinPlistSaved,
+                           @"Checkin plist file is saved");
+
   // Save the deviceID and secret in the Keychain
   if (!preferences.hasPreCachedAuthCredentials) {
     NSData *data = [checkinKeychainContent dataUsingEncoding:NSUTF8StringEncoding];
@@ -146,21 +149,20 @@ static const NSInteger kOldCheckinPlistCount = 6;
 }
 
 - (void)removeCheckinPreferencesWithHandler:(void (^)(NSError *error))handler {
+  // Delete the checkin preferences plist first to avoid delay.
+  NSError *deletePlistError;
+  [self.plist deleteFile:&deletePlistError];
+  if (deletePlistError) {
+    handler(deletePlistError);
+    return;
+  }
+  FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeCheckinStoreCheckinPlistDeleted,
+                           @"Deleted checkin plist file.");
   // Remove deviceID and secret from Keychain
   [self.keychain
       removeItemsMatchingService:kFIRInstanceIDCheckinKeychainService
                          account:self.bundleIdentifierForKeychainAccount
                          handler:^(NSError *error) {
-                           if (error) {
-                             if (handler) {
-                               handler(error);
-                             }
-                             return;
-                           }
-                           // Delete the checkin preferences plist
-                           NSError *deletePlistError;
-                           [self.plist deleteFile:&deletePlistError];
-
                            // Try to remove from old location as well because migration
                            // is no longer needed. Consider this is either a fresh install
                            // or an identity wipe.
@@ -168,7 +170,7 @@ static const NSInteger kOldCheckinPlistCount = 6;
                                removeItemsMatchingService:kFIRInstanceIDLegacyCheckinKeychainService
                                                   account:kFIRInstanceIDLegacyCheckinKeychainAccount
                                                   handler:nil];
-                           handler(deletePlistError);
+                           handler(error);
                          }];
 }
 

--- a/Firebase/InstanceID/FIRInstanceIDCheckinStore.m
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinStore.m
@@ -151,8 +151,7 @@ static const NSInteger kOldCheckinPlistCount = 6;
 - (void)removeCheckinPreferencesWithHandler:(void (^)(NSError *error))handler {
   // Delete the checkin preferences plist first to avoid delay.
   NSError *deletePlistError;
-  [self.plist deleteFile:&deletePlistError];
-  if (deletePlistError) {
+  if (![self.plist deleteFile:&deletePlistError]) {
     handler(deletePlistError);
     return;
   }


### PR DESCRIPTION
This is a prevention fix for #2438 because we still couldn't reproduce. But users are facing race condition where checkin plist file is deleted after a new checkin is written to the file. So we move the plist deletion call to the first step of resetting checkin during app start. Because FIRInstanceID init call should be always before first checkin call got issued. 

Also add two more logs which helps provide the timeline when checkin plist file is written or read.