### PR TITLE
Make disabling GC prevent even scheduling it

### DIFF
--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -138,8 +138,9 @@ static FIRFirestoreSettings *defaultSettings;
     return;
   }
 
-  // Otherwise fall back on assuming the emulator or Hexa on localhost.
+  // Otherwise fall back on assuming Hexa on localhost.
   defaultProjectId = @"test-db";
+  defaultSettings.host = @"localhost:8081";
 
   // Hexa uses a self-signed cert: the first bundle location is used by bazel builds. The second is
   // used for github clones.
@@ -152,23 +153,14 @@ static FIRFirestoreSettings *defaultSettings;
   unsigned long long fileSize =
       [[[NSFileManager defaultManager] attributesOfItemAtPath:certsPath error:nil] fileSize];
 
-  if (fileSize != 0) {
-    defaultSettings.host = @"localhost:8081";
-
-    GrpcConnection::UseTestCertificate(util::MakeString(defaultSettings.host),
-                                       Path::FromNSString(certsPath), "test_cert_2");
-  } else {
-    // If no cert is set up, configure for the Firestore emulator.
-    defaultSettings.host = @"localhost:8080";
-    defaultSettings.sslEnabled = false;
-
-    // Also issue a warning because the Firestore emulator doesn't completely work yet.
+  if (fileSize == 0) {
     NSLog(@"Please set up a GoogleServices-Info.plist for Firestore in Firestore/Example/App using "
-       "instructions at <https://github.com/firebase/firebase-ios-sdk#running-sample-apps>. "
-       "Alternatively, if you're a Googler with a Hexa preproduction environment, run "
-       "setup_integration_tests.py to properly configure testing SSL certificates.");
-
+           "instructions at <https://github.com/firebase/firebase-ios-sdk#running-sample-apps>. "
+           "Alternatively, if you're a Googler with a Hexa preproduction environment, run "
+           "setup_integration_tests.py to properly configure testing SSL certificates.");
   }
+  GrpcConnection::UseTestCertificate(util::MakeString(defaultSettings.host),
+                                     Path::FromNSString(certsPath), "test_cert_2");
 }
 
 + (NSString *)projectID {

--- a/Firestore/Source/API/FIRFirestoreSettings.mm
+++ b/Firestore/Source/API/FIRFirestoreSettings.mm
@@ -20,34 +20,29 @@
 #include "Firestore/core/src/firebase/firestore/api/settings.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 #include "Firestore/core/src/firebase/firestore/util/warnings.h"
+#include "absl/base/attributes.h"
 #include "absl/memory/memory.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 namespace api = firebase::firestore::api;
 namespace util = firebase::firestore::util;
+using api::Settings;
 using api::ThrowInvalidArgument;
 
-static NSString *const kDefaultHost = @"firestore.googleapis.com";
-static const BOOL kDefaultSSLEnabled = YES;
-static const BOOL kDefaultPersistenceEnabled = YES;
-static const int64_t kDefaultCacheSizeBytes = 100 * 1024 * 1024;
-static const int64_t kMinimumCacheSizeBytes = 1 * 1024 * 1024;
-static const BOOL kDefaultTimestampsInSnapshotsEnabled = YES;
-
 // Public constant
-extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited = api::Settings::CacheSizeUnlimited;
+ABSL_CONST_INIT extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited = api::Settings::CacheSizeUnlimited;
 
 @implementation FIRFirestoreSettings
 
 - (instancetype)init {
   if (self = [super init]) {
-    _host = kDefaultHost;
-    _sslEnabled = kDefaultSSLEnabled;
+    _host = [NSString stringWithUTF8String:Settings::DefaultHost];
+    _sslEnabled = Settings::DefaultSslEnabled;
     _dispatchQueue = dispatch_get_main_queue();
-    _persistenceEnabled = kDefaultPersistenceEnabled;
-    _timestampsInSnapshotsEnabled = kDefaultTimestampsInSnapshotsEnabled;
-    _cacheSizeBytes = kDefaultCacheSizeBytes;
+    _persistenceEnabled = Settings::DefaultPersistenceEnabled;
+    _timestampsInSnapshotsEnabled = Settings::DefaultTimestampsInSnapshotsEnabled;
+    _cacheSizeBytes = Settings::DefaultCacheSizeBytes;
   }
   return self;
 }
@@ -99,7 +94,7 @@ extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited = api::Settings::CacheS
   if (!host) {
     ThrowInvalidArgument("Host setting may not be nil. You should generally just use the default "
                          "value (which is %s)",
-                         kDefaultHost);
+                         Settings::DefaultHost);
   }
   _host = [host mutableCopy];
 }
@@ -116,8 +111,8 @@ extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited = api::Settings::CacheS
 
 - (void)setCacheSizeBytes:(int64_t)cacheSizeBytes {
   if (cacheSizeBytes != kFIRFirestoreCacheSizeUnlimited &&
-      cacheSizeBytes < kMinimumCacheSizeBytes) {
-    ThrowInvalidArgument("Cache size must be set to at least %s bytes", kMinimumCacheSizeBytes);
+      cacheSizeBytes < Settings::MinimumCacheSizeBytes) {
+    ThrowInvalidArgument("Cache size must be set to at least %s bytes", Settings::MinimumCacheSizeBytes);
   }
   _cacheSizeBytes = cacheSizeBytes;
 }

--- a/Firestore/Source/API/FIRFirestoreSettings.mm
+++ b/Firestore/Source/API/FIRFirestoreSettings.mm
@@ -31,7 +31,8 @@ using api::Settings;
 using api::ThrowInvalidArgument;
 
 // Public constant
-ABSL_CONST_INIT extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited = api::Settings::CacheSizeUnlimited;
+ABSL_CONST_INIT extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited =
+    api::Settings::CacheSizeUnlimited;
 
 @implementation FIRFirestoreSettings
 
@@ -112,7 +113,8 @@ ABSL_CONST_INIT extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited = api::
 - (void)setCacheSizeBytes:(int64_t)cacheSizeBytes {
   if (cacheSizeBytes != kFIRFirestoreCacheSizeUnlimited &&
       cacheSizeBytes < Settings::MinimumCacheSizeBytes) {
-    ThrowInvalidArgument("Cache size must be set to at least %s bytes", Settings::MinimumCacheSizeBytes);
+    ThrowInvalidArgument("Cache size must be set to at least %s bytes",
+                         Settings::MinimumCacheSizeBytes);
   }
   _cacheSizeBytes = cacheSizeBytes;
 }

--- a/Firestore/Source/API/FIRFirestoreSettings.mm
+++ b/Firestore/Source/API/FIRFirestoreSettings.mm
@@ -24,9 +24,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-using firebase::firestore::api::Settings;
-using firebase::firestore::api::ThrowInvalidArgument;
-using firebase::firestore::util::MakeString;
+namespace api = firebase::firestore::api;
+namespace util = firebase::firestore::util;
+using api::ThrowInvalidArgument;
 
 static NSString *const kDefaultHost = @"firestore.googleapis.com";
 static const BOOL kDefaultSSLEnabled = YES;
@@ -34,6 +34,9 @@ static const BOOL kDefaultPersistenceEnabled = YES;
 static const int64_t kDefaultCacheSizeBytes = 100 * 1024 * 1024;
 static const int64_t kMinimumCacheSizeBytes = 1 * 1024 * 1024;
 static const BOOL kDefaultTimestampsInSnapshotsEnabled = YES;
+
+// Public constant
+extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited = api::Settings::CacheSizeUnlimited;
 
 @implementation FIRFirestoreSettings
 
@@ -119,9 +122,9 @@ static const BOOL kDefaultTimestampsInSnapshotsEnabled = YES;
   _cacheSizeBytes = cacheSizeBytes;
 }
 
-- (Settings)internalSettings {
-  Settings settings;
-  settings.set_host(MakeString(_host));
+- (api::Settings)internalSettings {
+  api::Settings settings;
+  settings.set_host(util::MakeString(_host));
   settings.set_ssl_enabled(_sslEnabled);
   settings.set_persistence_enabled(_persistenceEnabled);
   settings.set_timestamps_in_snapshots_enabled(_timestampsInSnapshotsEnabled);

--- a/Firestore/Source/Core/FSTFirestoreClient.mm
+++ b/Firestore/Source/Core/FSTFirestoreClient.mm
@@ -231,7 +231,9 @@ static const std::chrono::milliseconds FSTLruGcRegularDelay = std::chrono::minut
     }
     _lruDelegate = ldb.referenceDelegate;
     _persistence = ldb;
-    [self scheduleLruGarbageCollection];
+    if (settings.gc_enabled()) {
+      [self scheduleLruGarbageCollection];
+    }
   } else {
     _persistence = [FSTMemoryPersistence persistenceWithEagerGC];
   }

--- a/Firestore/Source/Local/FSTLRUGarbageCollector.h
+++ b/Firestore/Source/Local/FSTLRUGarbageCollector.h
@@ -19,9 +19,9 @@
 #include <string>
 #include <unordered_map>
 
-#import "FIRFirestoreSettings.h"
 #import "Firestore/Source/Local/FSTQueryData.h"
 
+#include "Firestore/core/src/firebase/firestore/api/settings.h"
 #include "Firestore/core/src/firebase/firestore/local/query_cache.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/types.h"
@@ -37,14 +37,12 @@ namespace firestore {
 namespace local {
 
 struct LruParams {
-  static const int64_t CacheSizeUnlimited = -1;
-
   static LruParams Default() {
     return LruParams{100 * 1024 * 1024, 10, 1000};
   }
 
   static LruParams Disabled() {
-    return LruParams{kFIRFirestoreCacheSizeUnlimited, 0, 0};
+    return LruParams{api::Settings::CacheSizeUnlimited, 0, 0};
   }
 
   static LruParams WithCacheSize(int64_t cacheSize) {

--- a/Firestore/Source/Public/FIRFirestoreSettings.h
+++ b/Firestore/Source/Public/FIRFirestoreSettings.h
@@ -19,7 +19,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** Used to set on-disk cache size to unlimited. Garbage collection will not run. */
-extern const int64_t kFIRFirestoreCacheSizeUnlimited NS_SWIFT_NAME(FirestoreCacheSizeUnlimited);
+FOUNDATION_EXTERN const int64_t kFIRFirestoreCacheSizeUnlimited
+    NS_SWIFT_NAME(FirestoreCacheSizeUnlimited);
 
 /** Settings used to configure a `FIRFirestore` instance. */
 NS_SWIFT_NAME(FirestoreSettings)

--- a/Firestore/core/src/firebase/firestore/api/settings.cc
+++ b/Firestore/core/src/firebase/firestore/api/settings.cc
@@ -22,6 +22,13 @@ namespace firebase {
 namespace firestore {
 namespace api {
 
+constexpr char Settings::DefaultHost[];
+constexpr bool Settings::DefaultSslEnabled;
+constexpr bool Settings::DefaultPersistenceEnabled;
+constexpr int64_t Settings::DefaultCacheSizeBytes;
+constexpr int64_t Settings::MinimumCacheSizeBytes;
+constexpr bool Settings::DefaultTimestampsInSnapshotsEnabled;
+
 size_t Settings::Hash() const {
   return util::Hash(host_, ssl_enabled_, persistence_enabled_,
                     timestamps_in_snapshots_enabled_, cache_size_bytes_);

--- a/Firestore/core/src/firebase/firestore/api/settings.h
+++ b/Firestore/core/src/firebase/firestore/api/settings.h
@@ -32,7 +32,13 @@ namespace api {
  */
 class Settings {
  public:
-  static const int64_t CacheSizeUnlimited = -1;
+  static constexpr char DefaultHost[] = "firestore.googleapis.com";
+  static constexpr bool DefaultSslEnabled = true;
+  static constexpr bool DefaultPersistenceEnabled = true;
+  static constexpr int64_t DefaultCacheSizeBytes = 100 * 1024 * 1024;
+  static constexpr int64_t MinimumCacheSizeBytes = 1 * 1024 * 1024;
+  static constexpr int64_t CacheSizeUnlimited = -1;
+  static constexpr bool DefaultTimestampsInSnapshotsEnabled = true;
 
   Settings() = default;
 
@@ -79,11 +85,11 @@ class Settings {
   size_t Hash() const;
 
  private:
-  std::string host_;
-  bool ssl_enabled_ = false;
-  bool persistence_enabled_ = false;
-  bool timestamps_in_snapshots_enabled_ = false;
-  int64_t cache_size_bytes_ = 0;
+  std::string host_ = DefaultHost;
+  bool ssl_enabled_ = DefaultSslEnabled;
+  bool persistence_enabled_ = DefaultPersistenceEnabled;
+  bool timestamps_in_snapshots_enabled_ = DefaultTimestampsInSnapshotsEnabled;
+  int64_t cache_size_bytes_ = DefaultCacheSizeBytes;
 };
 
 }  // namespace api

--- a/Firestore/core/src/firebase/firestore/api/settings.h
+++ b/Firestore/core/src/firebase/firestore/api/settings.h
@@ -32,6 +32,8 @@ namespace api {
  */
 class Settings {
  public:
+  static const int64_t CacheSizeUnlimited = -1;
+
   Settings() = default;
 
   void set_host(const std::string& value) {
@@ -67,6 +69,9 @@ class Settings {
   }
   int64_t cache_size_bytes() const {
     return cache_size_bytes_;
+  }
+  bool gc_enabled() const {
+    return cache_size_bytes_ != CacheSizeUnlimited;
   }
 
   friend bool operator==(const Settings& lhs, const Settings& rhs);


### PR DESCRIPTION
We learned in #2846 that the current implementation isn't an effective way to disable GC, because the empty commit itself was failing.

Also make the linkage of kFIRFirestoreCacheSizeUnlimited explicitly extern "C". This previously had no fixed linkage in the header and only accidentally worked because the implementation had C++ linkage.

Move internal `CacheSizeUnlimited` to `api::Settings` and the definition of `kFIRFirestoreCacheSizeUnlimited` into the Objective-C language binding.

Move the rest of the `FIRFirestoreSettings` defaults to `api::Settings` as well.