### PR TITLE
Fix headers for copybara import for GDT

### DIFF
--- a/GoogleDataTransport/Library/Private/GDTConsoleLogger.h
+++ b/GoogleDataTransport/Library/Private/GDTConsoleLogger.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <GoogleDataTransport/GDTAssert.h>
+#import "Library/Private/GDTAssert.h"
 
 /** A list of message codes to print in the logger that help to correspond printed messages with
  * code locations.
@@ -46,7 +46,7 @@ typedef NS_ENUM(NSInteger, GDTMessageCode) {
 
 /** */
 FOUNDATION_EXPORT
-void GDTLog(GDTMessageCode code, NSString *format, ...);
+void GDTLog(GDTMessageCode code, NSString * _Nonnull format, ...);
 
 /** Returns the string that represents some message code.
  *

--- a/GoogleDataTransport/Library/Private/GDTConsoleLogger.h
+++ b/GoogleDataTransport/Library/Private/GDTConsoleLogger.h
@@ -46,7 +46,7 @@ typedef NS_ENUM(NSInteger, GDTMessageCode) {
 
 /** */
 FOUNDATION_EXPORT
-void GDTLog(GDTMessageCode code, NSString * _Nonnull format, ...);
+void GDTLog(GDTMessageCode code, NSString *_Nonnull format, ...);
 
 /** Returns the string that represents some message code.
  *

--- a/GoogleDataTransport/Library/Private/GDTReachability_Private.h
+++ b/GoogleDataTransport/Library/Private/GDTReachability_Private.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <GoogleDataTransport/GDTReachability.h>
+#import "Library/Private/GDTReachability.h"
 
 @interface GDTReachability ()
 

--- a/GoogleDataTransport/Library/Private/GDTStorage_Private.h
+++ b/GoogleDataTransport/Library/Private/GDTStorage_Private.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <GoogleDataTransport/GDTStorage.h>
+#import "Library/Private/GDTStorage.h"
 
 @class GDTUploadCoordinator;
 

--- a/GoogleDataTransport/Library/Private/GDTTransformer_Private.h
+++ b/GoogleDataTransport/Library/Private/GDTTransformer_Private.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <GoogleDataTransport/GDTTransformer.h>
+#import "Library/Private/GDTTransformer.h"
 
 @class GDTStorage;
 

--- a/GoogleDataTransport/Library/Public/GDTUploader.h
+++ b/GoogleDataTransport/Library/Public/GDTUploader.h
@@ -20,6 +20,8 @@
 #import <GoogleDataTransport/GDTLifecycle.h>
 #import <GoogleDataTransport/GDTTargets.h>
 
+@class GDTUploadPackage;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /** A convenient typedef to define the block to be called upon completion of an upload to the

--- a/GoogleDataTransport/Tests/Integration/GDTIntegrationTest.m
+++ b/GoogleDataTransport/Tests/Integration/GDTIntegrationTest.m
@@ -16,7 +16,10 @@
 
 #import <XCTest/XCTest.h>
 
-#import <GoogleDataTransport/GoogleDataTransport.h>
+#import <GoogleDataTransport/GDTEventDataObject.h>
+#import <GoogleDataTransport/GDTEventTransformer.h>
+#import <GoogleDataTransport/GDTEvent.h>
+#import <GoogleDataTransport/GDTTransport.h>
 
 #import "Tests/Common/Categories/GDTUploadCoordinator+Testing.h"
 

--- a/GoogleDataTransport/Tests/Integration/GDTIntegrationTest.m
+++ b/GoogleDataTransport/Tests/Integration/GDTIntegrationTest.m
@@ -16,9 +16,9 @@
 
 #import <XCTest/XCTest.h>
 
+#import <GoogleDataTransport/GDTEvent.h>
 #import <GoogleDataTransport/GDTEventDataObject.h>
 #import <GoogleDataTransport/GDTEventTransformer.h>
-#import <GoogleDataTransport/GDTEvent.h>
 #import <GoogleDataTransport/GDTTransport.h>
 
 #import "Tests/Common/Categories/GDTUploadCoordinator+Testing.h"

--- a/GoogleDataTransport/Tests/Integration/Helpers/GDTIntegrationTestPrioritizer.h
+++ b/GoogleDataTransport/Tests/Integration/Helpers/GDTIntegrationTestPrioritizer.h
@@ -16,8 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import <GoogleDataTransport/GDTTargets.h>
 #import <GoogleDataTransport/GDTPrioritizer.h>
+#import <GoogleDataTransport/GDTTargets.h>
 
 /** The integration test target. Normally, you should use a value in GDTTargets.h. */
 static GDTTarget kGDTIntegrationTestTarget = 100;

--- a/GoogleDataTransport/Tests/Integration/Helpers/GDTIntegrationTestPrioritizer.h
+++ b/GoogleDataTransport/Tests/Integration/Helpers/GDTIntegrationTestPrioritizer.h
@@ -16,7 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import <GoogleDataTransport/GoogleDataTransport.h>
+#import <GoogleDataTransport/GDTTargets.h>
+#import <GoogleDataTransport/GDTPrioritizer.h>
 
 /** The integration test target. Normally, you should use a value in GDTTargets.h. */
 static GDTTarget kGDTIntegrationTestTarget = 100;

--- a/GoogleDataTransport/Tests/Integration/Helpers/GDTIntegrationTestPrioritizer.m
+++ b/GoogleDataTransport/Tests/Integration/Helpers/GDTIntegrationTestPrioritizer.m
@@ -16,6 +16,9 @@
 
 #import "Tests/Integration/Helpers/GDTIntegrationTestPrioritizer.h"
 
+#import <GoogleDataTransport/GDTRegistrar.h>
+#import <GoogleDataTransport/GDTStoredEvent.h>
+
 #import "Tests/Integration/Helpers/GDTIntegrationTestUploadPackage.h"
 
 @interface GDTIntegrationTestPrioritizer ()

--- a/GoogleDataTransport/Tests/Integration/Helpers/GDTIntegrationTestUploader.h
+++ b/GoogleDataTransport/Tests/Integration/Helpers/GDTIntegrationTestUploader.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <GoogleDataTransport/GoogleDataTransport.h>
+#import <GoogleDataTransport/GDTUploader.h>
 
 #import "Tests/Integration/Helpers/GDTIntegrationTestPrioritizer.h"
 

--- a/GoogleDataTransport/Tests/Integration/Helpers/GDTIntegrationTestUploader.m
+++ b/GoogleDataTransport/Tests/Integration/Helpers/GDTIntegrationTestUploader.m
@@ -16,6 +16,9 @@
 
 #import "Tests/Integration/Helpers/GDTIntegrationTestUploader.h"
 
+#import <GoogleDataTransport/GDTRegistrar.h>
+#import <GoogleDataTransport/GDTStoredEvent.h>
+
 #import "Tests/Integration/Helpers/GDTIntegrationTestPrioritizer.h"
 
 #import "Tests/Integration/TestServer/GDTTestServer.h"

--- a/GoogleDataTransport/Tests/Lifecycle/GDTLifecycleTest.m
+++ b/GoogleDataTransport/Tests/Lifecycle/GDTLifecycleTest.m
@@ -16,9 +16,9 @@
 
 #import <XCTest/XCTest.h>
 
+#import <GoogleDataTransport/GDTEvent.h>
 #import <GoogleDataTransport/GDTEventDataObject.h>
 #import <GoogleDataTransport/GDTTransport.h>
-#import <GoogleDataTransport/GDTEvent.h>
 
 #import "Library/Private/GDTStorage_Private.h"
 #import "Library/Private/GDTTransformer_Private.h"

--- a/GoogleDataTransport/Tests/Lifecycle/GDTLifecycleTest.m
+++ b/GoogleDataTransport/Tests/Lifecycle/GDTLifecycleTest.m
@@ -16,7 +16,9 @@
 
 #import <XCTest/XCTest.h>
 
-#import <GoogleDataTransport/GoogleDataTransport.h>
+#import <GoogleDataTransport/GDTEventDataObject.h>
+#import <GoogleDataTransport/GDTTransport.h>
+#import <GoogleDataTransport/GDTEvent.h>
 
 #import "Library/Private/GDTStorage_Private.h"
 #import "Library/Private/GDTTransformer_Private.h"

--- a/GoogleDataTransport/Tests/Lifecycle/Helpers/GDTLifecycleTestPrioritizer.h
+++ b/GoogleDataTransport/Tests/Lifecycle/Helpers/GDTLifecycleTestPrioritizer.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <GoogleDataTransport/GoogleDataTransport.h>
+#import <GoogleDataTransport/GDTPrioritizer.h>
 
 /** An integration test prioritization class. */
 @interface GDTLifecycleTestPrioritizer : NSObject <GDTPrioritizer>

--- a/GoogleDataTransport/Tests/Lifecycle/Helpers/GDTLifecycleTestPrioritizer.m
+++ b/GoogleDataTransport/Tests/Lifecycle/Helpers/GDTLifecycleTestPrioritizer.m
@@ -16,6 +16,8 @@
 
 #import "Tests/Lifecycle/Helpers/GDTLifecycleTestPrioritizer.h"
 
+#import <GoogleDataTransport/GDTRegistrar.h>
+
 @interface GDTLifecycleTestPrioritizer ()
 
 /** Events that are only supposed to be uploaded whilst on wifi. */

--- a/GoogleDataTransport/Tests/Lifecycle/Helpers/GDTLifecycleTestUploader.h
+++ b/GoogleDataTransport/Tests/Lifecycle/Helpers/GDTLifecycleTestUploader.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <GoogleDataTransport/GoogleDataTransport.h>
+#import <GoogleDataTransport/GDTUploader.h>
 
 #import "Tests/Lifecycle/Helpers/GDTLifecycleTestUploader.h"
 

--- a/GoogleDataTransportCCTSupport/Library/Protogen/nanopb/cct.nanopb.h
+++ b/GoogleDataTransportCCTSupport/Library/Protogen/nanopb/cct.nanopb.h
@@ -81,9 +81,10 @@ typedef enum _gdt_cct_NetworkConnectionInfo_MobileSubtype {
 #define _gdt_cct_NetworkConnectionInfo_MobileSubtype_ARRAYSIZE ((gdt_cct_NetworkConnectionInfo_MobileSubtype)(gdt_cct_NetworkConnectionInfo_MobileSubtype_COMBINED+1))
 
 typedef enum _gdt_cct_ClientInfo_ClientType {
+    gdt_cct_ClientInfo_ClientType_CLIENT_UNKNOWN = 0,
     gdt_cct_ClientInfo_ClientType_IOS_FIREBASE = 15
 } gdt_cct_ClientInfo_ClientType;
-#define _gdt_cct_ClientInfo_ClientType_MIN gdt_cct_ClientInfo_ClientType_IOS_FIREBASE
+#define _gdt_cct_ClientInfo_ClientType_MIN gdt_cct_ClientInfo_ClientType_CLIENT_UNKNOWN
 #define _gdt_cct_ClientInfo_ClientType_MAX gdt_cct_ClientInfo_ClientType_IOS_FIREBASE
 #define _gdt_cct_ClientInfo_ClientType_ARRAYSIZE ((gdt_cct_ClientInfo_ClientType)(gdt_cct_ClientInfo_ClientType_IOS_FIREBASE+1))
 

--- a/GoogleDataTransportCCTSupport/ProtoSupport/Protos/cct.proto
+++ b/GoogleDataTransportCCTSupport/ProtoSupport/Protos/cct.proto
@@ -120,6 +120,8 @@ message IosClientInfo {
 message ClientInfo {
 
   enum ClientType {
+    CLIENT_UNKNOWN = 0;
+
     IOS_FIREBASE = 15;
   }
 


### PR DESCRIPTION
- Adds a _Nonnull nullability annotation
- Removes all umbrella header imports
- Adds a 0-value field for a proto enum, along with new generated code

Additional changes may be needed for GDT CCT support library.