### PR TITLE
Change Functions test app to allow testing against prod, using a GoogleService-Info.plist

### DIFF
--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -42,6 +42,7 @@ iOS SDK for Cloud Functions for Firebase.
   s.test_spec 'integration' do |int_tests|
     int_tests.source_files = 'Functions/Example/IntegrationTests/*.[mh]',
                              'Functions/Example/TestUtils/*.[mh]',
-                             'Example/Shared/FIRAuthInteropFake*'
+                             'Example/Shared/FIRAuthInteropFake*',
+                             'Functions/Example/GoogleService-Info.plist'
   end
 end

--- a/Functions/Example/GoogleService-Info.plist
+++ b/Functions/Example/GoogleService-Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>correct_api_key</string>
+	<key>TRACKING_ID</key>
+	<string>correct_tracking_id</string>
+	<key>CLIENT_ID</key>
+	<string>correct_client_id</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>correct_reversed_client_id</string>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:123:ios:123abc</string>
+	<key>GCM_SENDER_ID</key>
+	<string>correct_gcm_sender_id</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.google.FirebaseSDKTests</string>
+	<key>PROJECT_ID</key>
+	<string>abc-xyz-123</string>
+	<key>DATABASE_URL</key>
+	<string>https://abc-xyz-123.firebaseio.com</string>
+	<key>STORAGE_BUCKET</key>
+	<string>project-id-123.storage.firebase.com</string>
+</dict>
+</plist>

--- a/Functions/Example/IntegrationTests/FIRIntegrationTests.m
+++ b/Functions/Example/IntegrationTests/FIRIntegrationTests.m
@@ -38,23 +38,23 @@ static NSString *const kDefaultProjectID = @"functions-integration-test";
 - (void)setUp {
   [super setUp];
 
-    _projectID = kDefaultProjectID;
-    _useLocalhost = YES;
-    
-    // Check for configuration of a prod project via GoogleServices-Info.plist.
-    FIROptions *options = [FIROptions defaultOptions];
-    if (options && ![options.projectID isEqualToString:@"abc-xyz-123"]) {
-        _projectID = options.projectID;
-        _useLocalhost = NO;
-    }
-    
+  _projectID = kDefaultProjectID;
+  _useLocalhost = YES;
+
+  // Check for configuration of a prod project via GoogleServices-Info.plist.
+  FIROptions *options = [FIROptions defaultOptions];
+  if (options && ![options.projectID isEqualToString:@"abc-xyz-123"]) {
+    _projectID = options.projectID;
+    _useLocalhost = NO;
+  }
+
   _functions = [[FIRFunctions alloc]
       initWithProjectID:_projectID
                  region:@"us-central1"
                    auth:[[FIRAuthInteropFake alloc] initWithToken:nil userID:nil error:nil]];
-    if (_useLocalhost) {
-        [_functions useLocalhost];
-    }
+  if (_useLocalhost) {
+    [_functions useLocalhost];
+  }
 }
 
 - (void)tearDown {
@@ -102,9 +102,9 @@ static NSString *const kDefaultProjectID = @"functions-integration-test";
       initWithProjectID:_projectID
                  region:@"us-central1"
                    auth:[[FIRAuthInteropFake alloc] initWithToken:@"token" userID:nil error:nil]];
-    if (_useLocalhost) {
-        [functions useLocalhost];
-    }
+  if (_useLocalhost) {
+    [functions useLocalhost];
+  }
 
   XCTestExpectation *expectation = [[XCTestExpectation alloc] init];
   FIRHTTPSCallable *function = [functions HTTPSCallableWithName:@"tokenTest"];

--- a/Functions/Example/IntegrationTests/FIRIntegrationTests.m
+++ b/Functions/Example/IntegrationTests/FIRIntegrationTests.m
@@ -14,6 +14,8 @@
 
 #import <XCTest/XCTest.h>
 
+#import <FirebaseCore/FIROptions.h>
+
 #import "FIRAuthInteropFake.h"
 #import "FIRError.h"
 #import "FIRFunctions+Internal.h"
@@ -33,11 +35,24 @@ static NSString *const kProjectID = @"functions-integration-test";
 
 - (void)setUp {
   [super setUp];
+
+    NSString *projectID = kProjectID;
+    BOOL useLocalhost = YES;
+    
+    // Check for configuration of a prod project via GoogleServices-Info.plist.
+    FIROptions *options = [FIROptions defaultOptions];
+    if (options && ![options.projectID isEqualToString:@"abc-xyz-123"]) {
+        projectID = options.projectID;
+        useLocalhost = NO;
+    }
+    
   _functions = [[FIRFunctions alloc]
       initWithProjectID:kProjectID
                  region:@"us-central1"
                    auth:[[FIRAuthInteropFake alloc] initWithToken:nil userID:nil error:nil]];
-  [_functions useLocalhost];
+    if (useLocalhost) {
+        [_functions useLocalhost];
+    }
 }
 
 - (void)tearDown {

--- a/Functions/Example/IntegrationTests/FIRIntegrationTests.m
+++ b/Functions/Example/IntegrationTests/FIRIntegrationTests.m
@@ -24,10 +24,12 @@
 #import "FUNFakeInstanceID.h"
 
 // Project ID used by these tests.
-static NSString *const kProjectID = @"functions-integration-test";
+static NSString *const kDefaultProjectID = @"functions-integration-test";
 
 @interface FIRIntegrationTests : XCTestCase {
   FIRFunctions *_functions;
+  NSString *_projectID;
+  BOOL _useLocalhost;
 }
 @end
 
@@ -36,21 +38,21 @@ static NSString *const kProjectID = @"functions-integration-test";
 - (void)setUp {
   [super setUp];
 
-    NSString *projectID = kProjectID;
-    BOOL useLocalhost = YES;
+    _projectID = kDefaultProjectID;
+    _useLocalhost = YES;
     
     // Check for configuration of a prod project via GoogleServices-Info.plist.
     FIROptions *options = [FIROptions defaultOptions];
     if (options && ![options.projectID isEqualToString:@"abc-xyz-123"]) {
-        projectID = options.projectID;
-        useLocalhost = NO;
+        _projectID = options.projectID;
+        _useLocalhost = NO;
     }
     
   _functions = [[FIRFunctions alloc]
-      initWithProjectID:kProjectID
+      initWithProjectID:_projectID
                  region:@"us-central1"
                    auth:[[FIRAuthInteropFake alloc] initWithToken:nil userID:nil error:nil]];
-    if (useLocalhost) {
+    if (_useLocalhost) {
         [_functions useLocalhost];
     }
 }
@@ -97,10 +99,12 @@ static NSString *const kProjectID = @"functions-integration-test";
 - (void)testToken {
   // Recreate _functions with a token.
   FIRFunctions *functions = [[FIRFunctions alloc]
-      initWithProjectID:kProjectID
+      initWithProjectID:_projectID
                  region:@"us-central1"
                    auth:[[FIRAuthInteropFake alloc] initWithToken:@"token" userID:nil error:nil]];
-  [functions useLocalhost];
+    if (_useLocalhost) {
+        [functions useLocalhost];
+    }
 
   XCTestExpectation *expectation = [[XCTestExpectation alloc] init];
   FIRHTTPSCallable *function = [functions HTTPSCallableWithName:@"tokenTest"];


### PR DESCRIPTION
I based this on the similar functionality in Firestore. The tests still use the emulator if you don't replace the plist. I tested with a plist manually. I didn't change the automated tests to use this, but may do that in a subsequent PR.
