### PR TITLE
GoogleUtilities min ios version from 6 to 8

### DIFF
--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -63,7 +63,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
   s.ios.framework = 'SafariServices'
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
   s.dependency 'FirebaseCore', '~> 6.0'
-  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 5.8'
-  s.dependency 'GoogleUtilities/Environment', '~> 5.8'
+  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 6.0'
+  s.dependency 'GoogleUtilities/Environment', '~> 6.0'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
 end

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -28,8 +28,8 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   s.public_header_files = 'Firebase/Core/Public/*.h', 'Firebase/Core/Private/*.h'
   s.private_header_files = 'Firebase/Core/Private/*.h'
   s.framework = 'Foundation'
-  s.dependency 'GoogleUtilities/Environment', '~> 5.2'
-  s.dependency 'GoogleUtilities/Logger', '~> 5.2'
+  s.dependency 'GoogleUtilities/Environment', '~> 6.0'
+  s.dependency 'GoogleUtilities/Logger', '~> 6.0'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'GCC_PREPROCESSOR_DEFINITIONS' =>

--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -37,6 +37,6 @@ services.
   }
   s.framework = 'Security'
   s.dependency 'FirebaseCore', '~> 6.0'
-  s.dependency 'GoogleUtilities/UserDefaults', '~> 5.2'
-  s.dependency 'GoogleUtilities/Environment', '~> 5.2'
+  s.dependency 'GoogleUtilities/UserDefaults', '~> 6.0'
+  s.dependency 'GoogleUtilities/Environment', '~> 6.0'
 end

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -41,9 +41,9 @@ device, and it is completely free.
   s.dependency 'FirebaseAnalyticsInterop', '~> 1.1'
   s.dependency 'FirebaseCore', '~> 6.0'
   s.dependency 'FirebaseInstanceID', '~> 4.1'
-  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 5.8'
-  s.dependency 'GoogleUtilities/Reachability', '~> 5.8'
-  s.dependency 'GoogleUtilities/Environment', '~> 5.8'
-  s.dependency 'GoogleUtilities/UserDefaults', '~> 5.8'
+  s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 6.0'
+  s.dependency 'GoogleUtilities/Reachability', '~> 6.0'
+  s.dependency 'GoogleUtilities/Environment', '~> 6.0'
+  s.dependency 'GoogleUtilities/UserDefaults', '~> 6.0'
   s.dependency 'Protobuf', '~> 3.1'
 end

--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleUtilities'
-  s.version          = '5.8.0'
+  s.version          = '6.0.0'
   s.summary          = 'Google Utilities for iOS (plus community support for macOS and tvOS)'
 
   s.description      = <<-DESC
@@ -16,9 +16,8 @@ other Google CocoaPods. They're not intended for direct public usage.
     :git => 'https://github.com/firebase/firebase-ios-sdk.git',
     :tag => 'Utilities-' + s.version.to_s
   }
-  # Technically GoogleUtilites requires iOS 7, but it supports a dependency pod with a minimum
-  # iOS 6, that will do runtime checking to avoid calling into GoogleUtilities.
-  s.ios.deployment_target = '6.0'
+
+  s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.11'
   s.tvos.deployment_target = '10.0'
 

--- a/GoogleUtilities/CHANGELOG.md
+++ b/GoogleUtilities/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Unreleased
 
+# 6.0.0
+- GULAppDelegateSwizzler - proxy APNS methods separately. (#2835)
+- Cocoapods 1.7.0 multiproject support. (#2751)
+- Bump minimium iOS version to iOS 8. (#2876)
+
 # 5.7.0
--  Restore to 5.5.0 tag after increased App Store warnings. (#2807)
+- Restore to 5.5.0 tag after increased App Store warnings. (#2807)
 
 # 5.6.0
 - `GULAppDelegateSwizzler`: support of remote notification methods. (#2698)


### PR DESCRIPTION
Also bump major version, since this is technically a breaking change.

The special case ios 6 and ios 7 code can be cleaned up in subsequent PRs.

This is a candidate for cherry-pick to Firebase 6.