### PR TITLE
Add objc::Handle and OBJC_CLASS

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		4A3FF3B16A39A5DC6B7EBA51 /* target.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618BBE7D20B89AAC00B5BCE7 /* target.pb.cc */; };
 		4A62B708A6532DD45414DA3A /* sorted_set_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 549CCA4C20A36DBB00BCEB75 /* sorted_set_test.cc */; };
 		4A64A339BCA77B9F875D1D8B /* FSTDatastoreTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E07E202154EC00B64F25 /* FSTDatastoreTests.mm */; };
+		4A699B93C58FDB46A308E745 /* objc_class_test_helper.mm in Sources */ = {isa = PBXBuildFile; fileRef = B5748BD89DF96FB1B20272F3 /* objc_class_test_helper.mm */; };
 		4AA4ABE36065DB79CD76DD8D /* Pods_Firestore_Benchmarks_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F694C3CE4B77B3C0FA4BBA53 /* Pods_Firestore_Benchmarks_iOS.framework */; };
 		4AD9809C9CE9FA09AC40992F /* async_queue_libdispatch_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = B6FB4680208EA0BE00554BA2 /* async_queue_libdispatch_test.mm */; };
 		4B52774AABF4ED7C2FA5C1C5 /* FSTMemoryQueryCacheTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E08B2021552B00B64F25 /* FSTMemoryQueryCacheTests.mm */; };
@@ -308,6 +309,7 @@
 		54DA12AF1F315EE100DD57A1 /* write_spec_test.json in Resources */ = {isa = PBXBuildFile; fileRef = 54DA12A51F315EE100DD57A1 /* write_spec_test.json */; };
 		54EB764D202277B30088B8F3 /* array_sorted_map_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54EB764C202277B30088B8F3 /* array_sorted_map_test.cc */; };
 		550FB7562D0CF9C3E1984000 /* FSTQueryListenerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E05D202154B900B64F25 /* FSTQueryListenerTests.mm */; };
+		5542632E76A0C17B61399B54 /* objc_class_test_helper.mm in Sources */ = {isa = PBXBuildFile; fileRef = B5748BD89DF96FB1B20272F3 /* objc_class_test_helper.mm */; };
 		5556B648B9B1C2F79A706B4F /* common.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 544129D221C2DDC800EFB9CC /* common.pb.cc */; };
 		55BDA39A16C4229A1AECB796 /* FSTLevelDBLRUGarbageCollectorTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CC9650620A0E9C600A2D6A1 /* FSTLevelDBLRUGarbageCollectorTests.mm */; };
 		5686B35D611C1CFF6BFE7215 /* credentials_provider_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = AB38D9342023966E000A432D /* credentials_provider_test.cc */; };
@@ -430,6 +432,7 @@
 		8C39F6D4B3AA9074DF00CFB8 /* string_util_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = AB380CFC201A2EE200D97691 /* string_util_test.cc */; };
 		8C82D4D3F9AB63E79CC52DC8 /* Pods_Firestore_IntegrationTests_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ECEBABC7E7B693BE808A1052 /* Pods_Firestore_IntegrationTests_iOS.framework */; };
 		8DA258092DD856D829D973B5 /* transform_operations_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = 54A0352220A3AEC3003E0143 /* transform_operations_test.mm */; };
+		8F1417FC39F417F7D1E5E4BF /* objc_class_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = B3CC6B2ACFDC873F06AE9E3F /* objc_class_test.cc */; };
 		8F3AE423677A4C50F7E0E5C0 /* database_info_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = AB38D92E20235D22000A432D /* database_info_test.cc */; };
 		8F4F40E9BC7ED588F67734D5 /* app_testing.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5467FB07203E6A44009C9584 /* app_testing.mm */; };
 		900D0E9F18CE3DB954DD0D1E /* async_queue_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = B6FB467B208E9A8200554BA2 /* async_queue_test.cc */; };
@@ -552,6 +555,7 @@
 		CA989C0E6020C372A62B7062 /* testutil.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54A0352820A3B3BD003E0143 /* testutil.cc */; };
 		CD0AA9E5D83C00CAAE7C2F67 /* FIRTimestampTest.m in Sources */ = {isa = PBXBuildFile; fileRef = B65D34A7203C99090076A5E1 /* FIRTimestampTest.m */; };
 		CD78EEAA1CD36BE691CA3427 /* hashing_test_apple.mm in Sources */ = {isa = PBXBuildFile; fileRef = B69CF3F02227386500B281C8 /* hashing_test_apple.mm */; };
+		CE222EAE5BD7D4CDEA8528BF /* objc_class_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = B3CC6B2ACFDC873F06AE9E3F /* objc_class_test.cc */; };
 		CEDDC6DB782989587D0139B2 /* datastore_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = 546854A820A36867004BDBD5 /* datastore_test.mm */; };
 		D063F56AC89E074F9AB05DD3 /* FSTRemoteDocumentCacheTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E09C2021552D00B64F25 /* FSTRemoteDocumentCacheTests.mm */; };
 		D22B96C19A0F3DE998D4320C /* delayed_constructor_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = D0A6E9136804A41CEC9D55D4 /* delayed_constructor_test.cc */; };
@@ -562,6 +566,7 @@
 		D5B252EE3F4037405DB1ECE3 /* FIRNumericTransformTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = D5B25E7E7D6873CBA4571841 /* FIRNumericTransformTests.mm */; };
 		D5B25CBF07F65E885C9D68AB /* perf_spec_test.json in Resources */ = {isa = PBXBuildFile; fileRef = D5B2593BCB52957D62F1C9D3 /* perf_spec_test.json */; };
 		D5E9954FC1C5ABBC7A180B33 /* FSTSpecTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E03020213FFC00B64F25 /* FSTSpecTests.mm */; };
+		D6826E6A53030C44EA0741DE /* objc_class_test_helper.mm in Sources */ = {isa = PBXBuildFile; fileRef = B5748BD89DF96FB1B20272F3 /* objc_class_test_helper.mm */; };
 		D69B97FF4C065EACEDD91886 /* FSTSyncEngineTestDriver.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E02E20213FFC00B64F25 /* FSTSyncEngineTestDriver.mm */; };
 		D6DE74259F5C0CCA010D6A0D /* grpc_stream_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = B6BBE42F21262CF400C6A53E /* grpc_stream_test.cc */; };
 		D6E0E54CD1640E726900828A /* document_key_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = B6152AD5202A5385000E5744 /* document_key_test.cc */; };
@@ -595,6 +600,7 @@
 		E0E640226A1439C59BBBA9C1 /* hard_assert_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 444B7AB3F5A2929070CB1363 /* hard_assert_test.cc */; };
 		E11DDA3DD75705F26245E295 /* FIRCollectionReferenceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E045202154AA00B64F25 /* FIRCollectionReferenceTests.mm */; };
 		E2B15548A3B6796CE5A01975 /* FIRListenerRegistrationTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E06B202154D500B64F25 /* FIRListenerRegistrationTests.mm */; };
+		E2FBB88C3EC515A879C5A26E /* objc_class_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = B3CC6B2ACFDC873F06AE9E3F /* objc_class_test.cc */; };
 		E375FBA0632EFB4D14C4E5A9 /* FSTGoogleTestTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 54764FAE1FAA21B90085E60A /* FSTGoogleTestTests.mm */; };
 		E3C0E5F834A82EEE9F8C4519 /* watch_change_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = B68FC0E421F6848700A7055C /* watch_change_test.mm */; };
 		E4C0CC7FB88D8F6CB1B972C6 /* leveldb_index_manager_test.mm in Sources */ = {isa = PBXBuildFile; fileRef = 73F1F7402211FEF300E1F692 /* leveldb_index_manager_test.mm */; };
@@ -946,6 +952,7 @@
 		8E002F4AD5D9B6197C940847 /* Firestore.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Firestore.podspec; path = ../Firestore.podspec; sourceTree = "<group>"; };
 		97C492D2524E92927C11F425 /* Pods-Firestore_FuzzTests_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_FuzzTests_iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_FuzzTests_iOS/Pods-Firestore_FuzzTests_iOS.release.xcconfig"; sourceTree = "<group>"; };
 		98366480BD1FD44A1FEDD982 /* Pods-Firestore_Example_macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_macOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_macOS/Pods-Firestore_Example_macOS.debug.xcconfig"; sourceTree = "<group>"; };
+		9B7F2784838799FBBD3C80F5 /* objc_class_test_helper.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = objc_class_test_helper.h; sourceTree = "<group>"; };
 		9CFD366B783AE27B9E79EE7A /* string_format_apple_test.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; path = string_format_apple_test.mm; sourceTree = "<group>"; };
 		A5FA86650A18F3B7A8162287 /* Pods-Firestore_Benchmarks_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Benchmarks_iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Benchmarks_iOS/Pods-Firestore_Benchmarks_iOS.release.xcconfig"; sourceTree = "<group>"; };
 		A70E82DD627B162BEF92B8ED /* Pods-Firestore_Example_tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_tvOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_tvOS/Pods-Firestore_Example_tvOS.debug.xcconfig"; sourceTree = "<group>"; };
@@ -967,7 +974,9 @@
 		ABC1D7E22023CDC500BA84F0 /* firebase_credentials_provider_test.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = firebase_credentials_provider_test.mm; sourceTree = "<group>"; };
 		ABF6506B201131F8005F2C74 /* timestamp_test.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = timestamp_test.cc; sourceTree = "<group>"; };
 		B1A7E1959AF8141FA7E6B888 /* grpc_stream_tester.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = grpc_stream_tester.cc; sourceTree = "<group>"; };
+		B3CC6B2ACFDC873F06AE9E3F /* objc_class_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = objc_class_test.cc; sourceTree = "<group>"; };
 		B3F5B3AAE791A5911B9EAA82 /* Pods-Firestore_Tests_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Tests_iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Tests_iOS/Pods-Firestore_Tests_iOS.release.xcconfig"; sourceTree = "<group>"; };
+		B5748BD89DF96FB1B20272F3 /* objc_class_test_helper.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = objc_class_test_helper.mm; sourceTree = "<group>"; };
 		B60894F52170207100EBC644 /* fake_credentials_provider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_credentials_provider.h; sourceTree = "<group>"; };
 		B60894F62170207100EBC644 /* fake_credentials_provider.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fake_credentials_provider.cc; sourceTree = "<group>"; };
 		B6152AD5202A5385000E5744 /* document_key_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = document_key_test.cc; sourceTree = "<group>"; };
@@ -1295,6 +1304,9 @@
 		5493A41E225EB4D6006DE7BA /* objc */ = {
 			isa = PBXGroup;
 			children = (
+				B3CC6B2ACFDC873F06AE9E3F /* objc_class_test.cc */,
+				9B7F2784838799FBBD3C80F5 /* objc_class_test_helper.h */,
+				B5748BD89DF96FB1B20272F3 /* objc_class_test_helper.mm */,
 				2A0CF41BA5AED6049B0BEB2C /* objc_type_traits_apple_test.mm */,
 			);
 			path = objc;
@@ -3050,6 +3062,8 @@
 				1CC9BABDD52B2A1E37E2698D /* mutation_test.cc in Sources */,
 				9720B8BD354CCB64C0C627E6 /* nanopb_string_test.cc in Sources */,
 				051D3E20184AF195266EF678 /* no_document_test.cc in Sources */,
+				E2FBB88C3EC515A879C5A26E /* objc_class_test.cc in Sources */,
+				4A699B93C58FDB46A308E745 /* objc_class_test_helper.mm in Sources */,
 				D572B4D4DBDD6B9235781646 /* objc_compatibility_apple_test.mm in Sources */,
 				16FE432587C1B40AF08613D2 /* objc_type_traits_apple_test.mm in Sources */,
 				72AD91671629697074F2545B /* ordered_code_test.cc in Sources */,
@@ -3218,6 +3232,8 @@
 				5E6F9184B271F6D5312412FF /* mutation_test.cc in Sources */,
 				78E38BEDF502B85E27D50C3B /* nanopb_string_test.cc in Sources */,
 				FEF55ECFB0CA317B351179AB /* no_document_test.cc in Sources */,
+				8F1417FC39F417F7D1E5E4BF /* objc_class_test.cc in Sources */,
+				D6826E6A53030C44EA0741DE /* objc_class_test_helper.mm in Sources */,
 				7400AC9377419A28B782B5EC /* objc_compatibility_apple_test.mm in Sources */,
 				9AC28D928902C6767A11F5FC /* objc_type_traits_apple_test.mm in Sources */,
 				FD8EA96A604E837092ACA51D /* ordered_code_test.cc in Sources */,
@@ -3461,6 +3477,8 @@
 				32F022CB75AEE48CDDAF2982 /* mutation_test.cc in Sources */,
 				84DBE646DCB49305879D3500 /* nanopb_string_test.cc in Sources */,
 				AB6B908820322E8800CC290A /* no_document_test.cc in Sources */,
+				CE222EAE5BD7D4CDEA8528BF /* objc_class_test.cc in Sources */,
+				5542632E76A0C17B61399B54 /* objc_class_test_helper.mm in Sources */,
 				B6968590221770F100271095 /* objc_compatibility_apple_test.mm in Sources */,
 				C80B10E79CDD7EF7843C321E /* objc_type_traits_apple_test.mm in Sources */,
 				AB380D04201BC6E400D97691 /* ordered_code_test.cc in Sources */,

--- a/Firestore/core/src/firebase/firestore/objc/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/objc/CMakeLists.txt
@@ -18,9 +18,10 @@
 
 cc_library(
   firebase_firestore_objc
-  HEADER_ONLY
+  HEADER_ONLY  # Still true on non-Apple platforms
   SOURCES
     objc_class.h
+    objc_class.mm
     objc_compatibility.h
     objc_type_traits.h
   DEPENDS

--- a/Firestore/core/src/firebase/firestore/objc/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/objc/CMakeLists.txt
@@ -20,6 +20,7 @@ cc_library(
   firebase_firestore_objc
   HEADER_ONLY
   SOURCES
+    objc_class.h
     objc_compatibility.h
     objc_type_traits.h
   DEPENDS

--- a/Firestore/core/src/firebase/firestore/objc/objc_class.h
+++ b/Firestore/core/src/firebase/firestore/objc/objc_class.h
@@ -19,8 +19,6 @@
 
 #include <objc/objc.h>
 
-#include <functional>
-
 #include "Firestore/core/src/firebase/firestore/objc/objc_compatibility.h"
 
 namespace firebase {

--- a/Firestore/core/src/firebase/firestore/objc/objc_class.h
+++ b/Firestore/core/src/firebase/firestore/objc/objc_class.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_OBJC_OBJC_CLASS_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_OBJC_OBJC_CLASS_H_
+
+// The OBJC_CLASS macro defines a forward declaration for an Objective-C class
+// that's compatible both with Objective-C++ and regular C++. It's useful in
+// headers that reference Objective-C types as members of C++ classes that must
+// be usable from straight C++.
+//
+// Care must be taken to not use the forward declaration (even implicitly) in
+// any inline definitions in the header. Even though Objective-C object
+// pointers look like raw pointers, under ARC they're more like
+// std::shared_ptr, where assignments and copies all potentially change the
+// refcount of the pointee. When methods that affect the reference count are
+// compiled inline in regular C++ this additional behavior won't get compiled
+// in and the Objective-C reference counts will be off.
+//
+// Note that this may even appear to work, though it does so through undefined
+// behavior: inline definitions are deduplicated at link time, and if the
+// linker happens to choose a definition that was generated in an ARC-enabled
+// translation unit then that specific build will work.
+//
+// Concretely this means that any method manipulating an Objective-C object
+// pointer (constructors, destructors, getters, and setters) all must be
+// defined out of line to avoid problems where ARC does not see changes to the
+// reference.
+#if __OBJC__
+#define OBJC_CLASS(name) @class name
+
+#else
+// Forward declaration for struct objc_object from objc/objc.h
+#define OBJC_CLASS(name) using name = struct objc_object
+
+#endif  // __OBJC__
+
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_OBJC_OBJC_CLASS_H_

--- a/Firestore/core/src/firebase/firestore/objc/objc_class.h
+++ b/Firestore/core/src/firebase/firestore/objc/objc_class.h
@@ -21,6 +21,8 @@
 
 #include <functional>
 
+#include "Firestore/core/src/firebase/firestore/objc/objc_compatibility.h"
+
 namespace firebase {
 namespace firestore {
 namespace objc {
@@ -61,7 +63,7 @@ namespace objc {
 // An alternative implementation would be to make this an alias for objc_object.
 // While that's appealing because it makes interaction with functions taking id
 // easier, any parameters of that type will be mangled differently in C++ vs
-// Objective-C++ leading undefined symbol errors at link time.
+// Objective-C++ leading to undefined symbol errors at link time.
 #define OBJC_CLASS(name) struct name
 #endif  // __OBJC__
 
@@ -73,10 +75,15 @@ namespace objc {
 class HandleBase {
  public:
   HandleBase();
+  HandleBase(const HandleBase& other);
+  HandleBase(HandleBase&& other) noexcept;
 
   explicit HandleBase(id object);
 
   ~HandleBase();
+
+  HandleBase& operator=(const HandleBase& other);
+  HandleBase& operator=(HandleBase&& other) noexcept;
 
   void Assign(id object);
 
@@ -95,18 +102,25 @@ template <typename ObjcType>
 class Handle : public HandleBase {
  public:
   Handle() = default;
-
+#if __OBJC__
   explicit Handle(ObjcType* object) : HandleBase(object) {
   }
 
-#if __OBJC__
+  // In most cases, just using the handle as an Objective-C pointer works.
   operator ObjcType*() const {
+    return get();
+  }
+
+  // Explicit conversion to the Objective-C pointer type is required when
+  // accessing Objective-C properties. C++ doesn't have an operator overload
+  // that makes that work, and the compiler doesn't attempt to coerce to the
+  // Objective-C type to find it.
+  ObjcType* get() const {
     return static_cast<ObjcType*>(object_);
   }
 
   friend bool operator==(const Handle& lhs, const Handle& rhs) {
-    return (lhs.object_ == nil && rhs.object_ == nil) ||
-           [lhs.object_ isEqual:rhs.object_];
+    return Equals(lhs.object_, rhs.object_);
   }
 
   friend bool operator!=(const Handle& lhs, const Handle& rhs) {
@@ -114,7 +128,7 @@ class Handle : public HandleBase {
   }
 
   friend bool operator==(const Handle& lhs, ObjcType* rhs) {
-    return (lhs.object_ == nil && rhs == nil) || [lhs.object_ isEqual:rhs];
+    return Equals(lhs.object_, rhs);
   }
 
   friend bool operator!=(const Handle& lhs, ObjcType* rhs) {

--- a/Firestore/core/src/firebase/firestore/objc/objc_class.mm
+++ b/Firestore/core/src/firebase/firestore/objc/objc_class.mm
@@ -16,6 +16,8 @@
 
 #include "Firestore/core/src/firebase/firestore/objc/objc_class.h"
 
+#include <utility>
+
 namespace firebase {
 namespace firestore {
 namespace objc {
@@ -26,16 +28,13 @@ HandleBase::HandleBase() : object_(nil) {
 HandleBase::HandleBase(id object) : object_(object) {
 }
 
-HandleBase::HandleBase(const HandleBase& other)
-    : object_(other.object_) {
+HandleBase::HandleBase(const HandleBase& other) : object_(other.object_) {
 }
 
-HandleBase::HandleBase(HandleBase&& other) noexcept
-    : object_(nil) {
+HandleBase::HandleBase(HandleBase&& other) noexcept : object_(nil) {
   using std::swap;
   swap(object_, other.object_);
 }
-
 
 HandleBase::~HandleBase() {
   Release();
@@ -51,7 +50,6 @@ HandleBase& HandleBase::operator=(HandleBase&& other) noexcept {
   swap(object_, other.object_);
   return *this;
 }
-
 
 void HandleBase::Assign(id object) {
   object_ = object;

--- a/Firestore/core/src/firebase/firestore/objc/objc_class.mm
+++ b/Firestore/core/src/firebase/firestore/objc/objc_class.mm
@@ -26,16 +26,39 @@ HandleBase::HandleBase() : object_(nil) {
 HandleBase::HandleBase(id object) : object_(object) {
 }
 
+HandleBase::HandleBase(const HandleBase& other)
+    : object_(other.object_) {
+}
+
+HandleBase::HandleBase(HandleBase&& other) noexcept
+    : object_(nil) {
+  using std::swap;
+  swap(object_, other.object_);
+}
+
+
 HandleBase::~HandleBase() {
   Release();
 }
+
+HandleBase& HandleBase::operator=(const HandleBase& other) {
+  object_ = other.object_;
+  return *this;
+}
+
+HandleBase& HandleBase::operator=(HandleBase&& other) noexcept {
+  using std::swap;
+  swap(object_, other.object_);
+  return *this;
+}
+
 
 void HandleBase::Assign(id object) {
   object_ = object;
 }
 
 void HandleBase::Release() {
-  Assign(nil);
+  object_ = nil;
 }
 
 }  // namespace objc

--- a/Firestore/core/src/firebase/firestore/objc/objc_class.mm
+++ b/Firestore/core/src/firebase/firestore/objc/objc_class.mm
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/objc/objc_class.h"
+
+namespace firebase {
+namespace firestore {
+namespace objc {
+
+HandleBase::HandleBase() : object_(nil) {
+}
+
+HandleBase::HandleBase(id object) : object_(object) {
+}
+
+HandleBase::~HandleBase() {
+  Release();
+}
+
+void HandleBase::Assign(id object) {
+  object_ = object;
+}
+
+void HandleBase::Release() {
+  Assign(nil);
+}
+
+}  // namespace objc
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/core/src/firebase/firestore/objc/objc_class.mm
+++ b/Firestore/core/src/firebase/firestore/objc/objc_class.mm
@@ -31,9 +31,8 @@ HandleBase::HandleBase(id object) : object_(object) {
 HandleBase::HandleBase(const HandleBase& other) : object_(other.object_) {
 }
 
-HandleBase::HandleBase(HandleBase&& other) noexcept : object_(nil) {
-  using std::swap;
-  swap(object_, other.object_);
+HandleBase::HandleBase(HandleBase&& other) noexcept : object_(other.object_) {
+  other.Release();
 }
 
 HandleBase::~HandleBase() {
@@ -46,8 +45,8 @@ HandleBase& HandleBase::operator=(const HandleBase& other) {
 }
 
 HandleBase& HandleBase::operator=(HandleBase&& other) noexcept {
-  using std::swap;
-  swap(object_, other.object_);
+  object_ = other.object_;
+  other.Release();
   return *this;
 }
 

--- a/Firestore/core/src/firebase/firestore/objc/objc_compatibility.h
+++ b/Firestore/core/src/firebase/firestore/objc/objc_compatibility.h
@@ -17,9 +17,7 @@
 #ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_OBJC_OBJC_COMPATIBILITY_H_
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_OBJC_OBJC_COMPATIBILITY_H_
 
-#if !defined(__OBJC__)
-#error "This header only supports Objective-C++"
-#endif  // !defined(__OBJC__)
+#if __OBJC__
 
 #import <Foundation/Foundation.h>
 
@@ -122,5 +120,7 @@ NSString* Description(const T& value) {
 }  // namespace objc
 }  // namespace firestore
 }  // namespace firebase
+
+#endif  // __OBJC__
 
 #endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_OBJC_OBJC_COMPATIBILITY_H_

--- a/Firestore/core/test/firebase/firestore/objc/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/objc/CMakeLists.txt
@@ -18,4 +18,14 @@ cc_test(
     objc_type_traits_apple_test.mm
   DEPENDS
     firebase_firestore_objc
+    firebase_firestore_util
 )
+
+if(APPLE)
+  target_sources(
+    firebase_firestore_objc_test PUBLIC
+    objc_class_test.cc
+    objc_class_test_helper.h
+    objc_class_test_helper.mm
+  )
+endif()

--- a/Firestore/core/test/firebase/firestore/objc/objc_class_test.cc
+++ b/Firestore/core/test/firebase/firestore/objc/objc_class_test.cc
@@ -30,11 +30,14 @@ TEST(ObjcClassTest, CanSendMessages) {
 
 TEST(ObjcClassTest, Deallocates) {
   AllocationTracker tracker;
-  ObjcClassWrapper wrapper(&tracker);
-  ASSERT_EQ(1, tracker.init_calls);
-  ASSERT_EQ(0, tracker.dealloc_calls);
 
-  wrapper.handle.Release();
+  tracker.ScopedRun([&]() {
+    ObjcClassWrapper wrapper(&tracker);
+    ASSERT_EQ(1, tracker.init_calls);
+    ASSERT_EQ(0, tracker.dealloc_calls);
+
+    // Exiting the scope destroys the wrapper and its handle.
+  });
   ASSERT_EQ(1, tracker.init_calls);
   ASSERT_EQ(1, tracker.dealloc_calls);
 }
@@ -43,20 +46,27 @@ TEST(ObjcClassTest, MultipleReleasesAreAllowed) {
   AllocationTracker tracker;
   ObjcClassWrapper wrapper(&tracker);
 
-  wrapper.handle.Release();
-  ASSERT_EQ(1, tracker.dealloc_calls);
+  tracker.ScopedRun([&]() {
+    ObjcClassWrapper wrapper(&tracker);
+    ASSERT_EQ(0, tracker.dealloc_calls);
 
-  wrapper.handle.Release();
+    // Explicitly calling Release() here means that the second call in the
+    // destructor is a duplicate. This shows that multiple calls are allowed.
+    //
+    // Note that checking whether or not the object is deallocated after the
+    // explicit release is fragile. See comments on ScopedRun for rationale.
+    wrapper.handle.Release();
+  });
   ASSERT_EQ(1, tracker.dealloc_calls);
 }
 
 TEST(ObjcClassTest, SupportsCopying) {
   AllocationTracker tracker;
 
-  tracker.Run([&]() {
+  tracker.ScopedRun([&]() {
     ObjcClassWrapper second;
 
-    tracker.Run([&]() {
+    tracker.ScopedRun([&]() {
       ObjcClassWrapper first(&tracker);
       second = first;
       ASSERT_EQ(1, tracker.init_calls);
@@ -74,9 +84,9 @@ TEST(ObjcClassTest, SupportsCopying) {
 TEST(ObjcClassTest, SupportsMoving) {
   AllocationTracker tracker;
 
-  tracker.Run([&]() {
+  tracker.ScopedRun([&]() {
     ObjcClassWrapper second;
-    tracker.Run([&]() {
+    tracker.ScopedRun([&]() {
       // Moving does not bump reference count.
       ObjcClassWrapper first(&tracker);
       second = std::move(first);
@@ -94,12 +104,12 @@ TEST(ObjcClassTest, SupportsMoving) {
 TEST(ObjcClassTest, Reassigns) {
   AllocationTracker tracker;
 
-  tracker.Run([&]() {
+  tracker.ScopedRun([&]() {
     ObjcClassWrapper wrapper(&tracker);
     ASSERT_EQ(1, tracker.init_calls);
     ASSERT_EQ(0, tracker.dealloc_calls);
 
-    tracker.Run([&]() {
+    tracker.ScopedRun([&]() {
       // Reassigning should deallocate the initial object allocated in the
       // constructor.
       ObjcClassWrapper wrapper2(&tracker);

--- a/Firestore/core/test/firebase/firestore/objc/objc_class_test.cc
+++ b/Firestore/core/test/firebase/firestore/objc/objc_class_test.cc
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/objc/objc_class.h"
+
+#include <objc/objc.h>
+
+#include "Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.h"
+#include "gtest/gtest.h"
+
+// Runtime function that's not declared anywhere I can find, but specified here
+// https://clang.llvm.org/docs/AutomaticReferenceCounting.html#void-objc-release-id-value
+//
+// This should be declared as taking `id`, but this declaration makes it easier
+// to invoke without casting in the tests below.
+extern "C" void objc_release(void* value);
+
+namespace firebase {
+namespace firestore {
+namespace objc {
+
+TEST(ObjcClassTest, CanSendMessages) {
+  ObjcClassTester tester;
+  ASSERT_EQ("hello world", tester.ToString());
+}
+
+TEST(ObjcClassTest, Deallocates) {
+  ObjcClassTester tester;
+  ASSERT_EQ(1, tester.init_calls);
+  ASSERT_EQ(0, tester.dealloc_calls);
+
+  tester.handle.Release();
+  ASSERT_EQ(1, tester.init_calls);
+  ASSERT_EQ(1, tester.dealloc_calls);
+}
+
+TEST(ObjcClassTest, RetainsBehaveAsExpected) {
+  ObjcClassTester tester(nullptr);
+  ASSERT_EQ(0, tester.init_calls);
+  ASSERT_EQ(0, tester.dealloc_calls);
+
+  // This is plain C++, so ARC isn't managing this pointer. Initial retain count
+  // is 1 though.
+  FSTObjcClassTestHelper* helper = ObjcClassTester::CreateHelper();
+
+  // Assign to the handle, bumping retain count
+  tester.set_helper(helper);
+  ASSERT_EQ(0, tester.init_calls);
+  ASSERT_EQ(0, tester.dealloc_calls);
+
+  // Transfer ownership to the helper
+  objc_release(helper);
+  ASSERT_EQ(0, tester.dealloc_calls);
+
+  // And release
+  tester.handle.Release();
+  ASSERT_EQ(1, tester.dealloc_calls);
+}
+
+TEST(ObjcClassTest, Reassigns) {
+  ObjcClassTester tester;
+  ASSERT_EQ(1, tester.init_calls);
+  ASSERT_EQ(0, tester.dealloc_calls);
+
+  // Reassigning should deallocate the initial object allocated in the
+  // constructor.
+  FSTObjcClassTestHelper* helper = ObjcClassTester::CreateHelper();
+  tester.set_helper(helper);
+  ASSERT_EQ(1, tester.init_calls);
+  ASSERT_EQ(1, tester.dealloc_calls);
+
+  // Transfer ownership to the helper
+  objc_release(helper);
+  ASSERT_EQ(1, tester.dealloc_calls);
+
+  tester.handle.Release();
+  ASSERT_EQ(2, tester.dealloc_calls);
+}
+
+}  // namespace objc
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/core/test/firebase/firestore/objc/objc_class_test.cc
+++ b/Firestore/core/test/firebase/firestore/objc/objc_class_test.cc
@@ -16,78 +16,98 @@
 
 #include "Firestore/core/src/firebase/firestore/objc/objc_class.h"
 
-#include <objc/objc.h>
-
 #include "Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.h"
 #include "gtest/gtest.h"
-
-// Runtime function that's not declared anywhere I can find, but specified here
-// https://clang.llvm.org/docs/AutomaticReferenceCounting.html#void-objc-release-id-value
-//
-// This should be declared as taking `id`, but this declaration makes it easier
-// to invoke without casting in the tests below.
-extern "C" void objc_release(void* value);
 
 namespace firebase {
 namespace firestore {
 namespace objc {
 
 TEST(ObjcClassTest, CanSendMessages) {
-  ObjcClassTester tester;
-  ASSERT_EQ("hello world", tester.ToString());
+  ObjcClassWrapper tester(nullptr);
+  ASSERT_EQ("FSTObjcClassTestValue", tester.ToString());
 }
 
 TEST(ObjcClassTest, Deallocates) {
-  ObjcClassTester tester;
-  ASSERT_EQ(1, tester.init_calls);
-  ASSERT_EQ(0, tester.dealloc_calls);
+  AllocationTracker tracker;
+  ObjcClassWrapper wrapper(&tracker);
+  ASSERT_EQ(1, tracker.init_calls);
+  ASSERT_EQ(0, tracker.dealloc_calls);
 
-  tester.handle.Release();
-  ASSERT_EQ(1, tester.init_calls);
-  ASSERT_EQ(1, tester.dealloc_calls);
+  wrapper.handle.Release();
+  ASSERT_EQ(1, tracker.init_calls);
+  ASSERT_EQ(1, tracker.dealloc_calls);
 }
 
-TEST(ObjcClassTest, RetainsBehaveAsExpected) {
-  ObjcClassTester tester(nullptr);
-  ASSERT_EQ(0, tester.init_calls);
-  ASSERT_EQ(0, tester.dealloc_calls);
+TEST(ObjcClassTest, MultipleReleasesAreAllowed) {
+  AllocationTracker tracker;
+  ObjcClassWrapper wrapper(&tracker);
 
-  // This is plain C++, so ARC isn't managing this pointer. Initial retain count
-  // is 1 though.
-  FSTObjcClassTestHelper* helper = ObjcClassTester::CreateHelper();
+  wrapper.handle.Release();
+  ASSERT_EQ(1, tracker.dealloc_calls);
 
-  // Assign to the handle, bumping retain count
-  tester.set_helper(helper);
-  ASSERT_EQ(0, tester.init_calls);
-  ASSERT_EQ(0, tester.dealloc_calls);
+  wrapper.handle.Release();
+  ASSERT_EQ(1, tracker.dealloc_calls);
+}
 
-  // Transfer ownership to the helper
-  objc_release(helper);
-  ASSERT_EQ(0, tester.dealloc_calls);
+TEST(ObjcClassTest, SupportsCopying) {
+  AllocationTracker tracker;
 
-  // And release
-  tester.handle.Release();
-  ASSERT_EQ(1, tester.dealloc_calls);
+  tracker.Run([&]() {
+    ObjcClassWrapper second;
+
+    tracker.Run([&]() {
+      ObjcClassWrapper first(&tracker);
+      second = first;
+      ASSERT_EQ(1, tracker.init_calls);
+      ASSERT_EQ(0, tracker.dealloc_calls);
+    });
+
+    // first deallocated, but the value should survive
+    ASSERT_EQ(0, tracker.dealloc_calls);
+  });
+
+  // second deallocated
+  ASSERT_EQ(1, tracker.dealloc_calls);
+}
+
+TEST(ObjcClassTest, SupportsMoving) {
+  AllocationTracker tracker;
+
+  // Moving does not bump reference count. Moving changes where the allocations
+  // are tracked.
+  ObjcClassWrapper first(&tracker);
+  ObjcClassWrapper second = std::move(first);
+  ASSERT_EQ(1, tracker.init_calls);
+  ASSERT_EQ(0, tracker.dealloc_calls);
+
+  second.handle.Release();
+  ASSERT_EQ(1, tracker.dealloc_calls);
 }
 
 TEST(ObjcClassTest, Reassigns) {
-  ObjcClassTester tester;
-  ASSERT_EQ(1, tester.init_calls);
-  ASSERT_EQ(0, tester.dealloc_calls);
+  AllocationTracker tracker;
 
-  // Reassigning should deallocate the initial object allocated in the
-  // constructor.
-  FSTObjcClassTestHelper* helper = ObjcClassTester::CreateHelper();
-  tester.set_helper(helper);
-  ASSERT_EQ(1, tester.init_calls);
-  ASSERT_EQ(1, tester.dealloc_calls);
+  tracker.Run([&]() {
+    ObjcClassWrapper wrapper(&tracker);
+    ASSERT_EQ(1, tracker.init_calls);
+    ASSERT_EQ(0, tracker.dealloc_calls);
 
-  // Transfer ownership to the helper
-  objc_release(helper);
-  ASSERT_EQ(1, tester.dealloc_calls);
+    tracker.Run([&]() {
+      // Reassigning should deallocate the initial object allocated in the
+      // constructor.
+      ObjcClassWrapper wrapper2(&tracker);
+      wrapper.set_value(wrapper2.handle);
+      ASSERT_EQ(2, tracker.init_calls);
+      ASSERT_EQ(1, tracker.dealloc_calls);
 
-  tester.handle.Release();
-  ASSERT_EQ(2, tester.dealloc_calls);
+      // Transfer ownership to the helper
+    });
+
+    ASSERT_EQ(1, tracker.dealloc_calls);
+  });
+
+  ASSERT_EQ(2, tracker.dealloc_calls);
 }
 
 }  // namespace objc

--- a/Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.h
+++ b/Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.h
@@ -18,34 +18,41 @@
 #define FIRESTORE_CORE_TEST_FIREBASE_FIRESTORE_OBJC_OBJC_CLASS_TEST_HELPER_H_
 
 #include <cstddef>
+#include <functional>
 #include <string>
 
 #include "Firestore/core/src/firebase/firestore/objc/objc_class.h"
 
-OBJC_CLASS(FSTObjcClassTestHelper);
+OBJC_CLASS(FSTObjcClassTestValue);
 
 namespace firebase {
 namespace firestore {
 namespace objc {
 
-class ObjcClassTester {
+struct AllocationTracker {
+  int init_calls = 0;
+  int dealloc_calls = 0;
+
+  void Run(const std::function<void()>& callback);
+};
+
+class ObjcClassWrapper {
  public:
-  /** Creates the tester with a backing test helper. */
-  ObjcClassTester();
+  /** Creates a new, unmanaged test value. */
+  static FSTObjcClassTestValue* CreateTestValue();
 
-  /** Creates the tester with no backing test helper. */
-  explicit ObjcClassTester(std::nullptr_t);
+  /** Creates the tester with no backing test value. */
+  ObjcClassWrapper();
 
-  /** Creates a new, unmanaged test helper. */
-  static FSTObjcClassTestHelper* CreateHelper();
+  /** Creates the tester with a backing test value. */
+  explicit ObjcClassWrapper(AllocationTracker* tracker);
 
-  void set_helper(FSTObjcClassTestHelper* helper);
+  void set_value(Handle<FSTObjcClassTestValue> helper);
 
   std::string ToString() const;
 
-  int init_calls = 0;
-  int dealloc_calls = 0;
-  Handle<FSTObjcClassTestHelper> handle;
+  AllocationTracker* tracker;
+  Handle<FSTObjcClassTestValue> handle;
 };
 
 }  // namespace objc

--- a/Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.h
+++ b/Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_TEST_FIREBASE_FIRESTORE_OBJC_OBJC_CLASS_TEST_HELPER_H_
+#define FIRESTORE_CORE_TEST_FIREBASE_FIRESTORE_OBJC_OBJC_CLASS_TEST_HELPER_H_
+
+#include <cstddef>
+#include <string>
+
+#include "Firestore/core/src/firebase/firestore/objc/objc_class.h"
+
+OBJC_CLASS(FSTObjcClassTestHelper);
+
+namespace firebase {
+namespace firestore {
+namespace objc {
+
+class ObjcClassTester {
+ public:
+  /** Creates the tester with a backing test helper. */
+  ObjcClassTester();
+
+  /** Creates the tester with no backing test helper. */
+  explicit ObjcClassTester(std::nullptr_t);
+
+  /** Creates a new, unmanaged test helper. */
+  static FSTObjcClassTestHelper* CreateHelper();
+
+  void set_helper(FSTObjcClassTestHelper* helper);
+
+  std::string ToString() const;
+
+  int init_calls = 0;
+  int dealloc_calls = 0;
+  Handle<FSTObjcClassTestHelper> handle;
+};
+
+}  // namespace objc
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_TEST_FIREBASE_FIRESTORE_OBJC_OBJC_CLASS_TEST_HELPER_H_

--- a/Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.h
+++ b/Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.h
@@ -38,9 +38,6 @@ struct AllocationTracker {
 
 class ObjcClassWrapper {
  public:
-  /** Creates a new, unmanaged test value. */
-  static FSTObjcClassTestValue* CreateTestValue();
-
   /** Creates the tester with no backing test value. */
   ObjcClassWrapper();
 
@@ -51,7 +48,6 @@ class ObjcClassWrapper {
 
   std::string ToString() const;
 
-  AllocationTracker* tracker;
   Handle<FSTObjcClassTestValue> handle;
 };
 

--- a/Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.h
+++ b/Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.h
@@ -17,7 +17,6 @@
 #ifndef FIRESTORE_CORE_TEST_FIREBASE_FIRESTORE_OBJC_OBJC_CLASS_TEST_HELPER_H_
 #define FIRESTORE_CORE_TEST_FIREBASE_FIRESTORE_OBJC_OBJC_CLASS_TEST_HELPER_H_
 
-#include <cstddef>
 #include <functional>
 #include <string>
 
@@ -33,7 +32,24 @@ struct AllocationTracker {
   int init_calls = 0;
   int dealloc_calls = 0;
 
-  void Run(const std::function<void()>& callback);
+  /**
+   * Runs the given code block in an autorelease pool to prevent Clang's
+   * generation of implicit `autorelease` calls from interfering with the test.
+   *
+   * Checking whether or not an object is deallocated after the a release is
+   * fragile. The problem is that Clang will sometimes infer that an object
+   * should be added to the autorelease pool which typically extends the
+   * lifetime of the object beyond the duration of the test. While this process
+   * is predictable, it's also highly opaque and we're better off avoiding any
+   * dependency on that behavior at all.
+   *
+   * Instead, at any point where you want to check that a deallocation happens,
+   * do so after the close of a ScopedRun block. ScopedRun runs the given
+   * callback in an explicit AutoRelease pool, and this guarantees that even if
+   * Clang does autorelease the deallocation will actually happen by the time
+   * ScopedRun returns.
+   */
+  void ScopedRun(const std::function<void()>& callback);
 };
 
 class ObjcClassWrapper {

--- a/Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.h
+++ b/Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.h
@@ -55,12 +55,11 @@ struct AllocationTracker {
 class ObjcClassWrapper {
  public:
   /** Creates the tester with no backing test value. */
-  ObjcClassWrapper();
+  explicit ObjcClassWrapper(AllocationTracker* tracker = nullptr);
 
-  /** Creates the tester with a backing test value. */
-  explicit ObjcClassWrapper(AllocationTracker* tracker);
+  void CreateValue(AllocationTracker* tracker = nullptr);
 
-  void set_value(Handle<FSTObjcClassTestValue> helper);
+  void SetValue(Handle<FSTObjcClassTestValue> helper);
 
   std::string ToString() const;
 

--- a/Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.mm
+++ b/Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.mm
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "Firestore/core/src/firebase/firestore/util/string_apple.h"
+#include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 
 namespace objc = firebase::firestore::objc;
 
@@ -60,7 +60,7 @@ namespace firebase {
 namespace firestore {
 namespace objc {
 
-void AllocationTracker::Run(const std::function<void()>& callback) {
+void AllocationTracker::ScopedRun(const std::function<void()>& callback) {
   @autoreleasepool {
     callback();
   }

--- a/Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.mm
+++ b/Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.mm
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.h"
+
+#import <Foundation/Foundation.h>
+
+#import "Firestore/core/src/firebase/firestore/util/string_apple.h"
+
+namespace objc = firebase::firestore::objc;
+
+@interface FSTObjcClassTestHelper : NSObject
+
+- (instancetype)initWithTester:(objc::ObjcClassTester*)tester
+    NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
+@property(nonatomic, assign, readwrite) objc::ObjcClassTester* tester;
+
+@end
+
+@implementation FSTObjcClassTestHelper
+
+- (instancetype)initWithTester:(objc::ObjcClassTester*)tester {
+  if (self = [super init]) {
+    _tester = tester;
+    if (_tester) {
+      _tester->init_calls += 1;
+    }
+  }
+  return self;
+}
+
+- (void)dealloc {
+  if (_tester) {
+    _tester->dealloc_calls += 1;
+  }
+}
+
+- (NSString*)description {
+  return @"hello world";
+}
+
+@end
+
+namespace firebase {
+namespace firestore {
+namespace objc {
+
+ObjcClassTester::ObjcClassTester()
+    : handle([[FSTObjcClassTestHelper alloc] initWithTester:this]) {
+}
+
+ObjcClassTester::ObjcClassTester(std::nullptr_t) : handle(nil) {
+}
+
+FSTObjcClassTestHelper* ObjcClassTester::CreateHelper() {
+  return [[FSTObjcClassTestHelper alloc] initWithTester:nullptr];
+}
+
+void ObjcClassTester::set_helper(FSTObjcClassTestHelper* helper) {
+  helper.tester = this;
+  handle.Assign(helper);
+}
+
+std::string ObjcClassTester::ToString() const {
+  return util::MakeString([handle description]);
+}
+
+}  // namespace objc
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.mm
+++ b/Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.mm
@@ -66,11 +66,6 @@ void AllocationTracker::Run(const std::function<void()>& callback) {
   }
 }
 
-FSTObjcClassTestValue* ObjcClassWrapper::CreateTestValue() CF_RETURNS_RETAINED {
-  FSTObjcClassTestValue* value = [[FSTObjcClassTestValue alloc] initWithTracker:nullptr];
-  return value;
-}
-
 ObjcClassWrapper::ObjcClassWrapper() : handle(nil) {
 }
 

--- a/Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.mm
+++ b/Firestore/core/test/firebase/firestore/objc/objc_class_test_helper.mm
@@ -66,14 +66,17 @@ void AllocationTracker::ScopedRun(const std::function<void()>& callback) {
   }
 }
 
-ObjcClassWrapper::ObjcClassWrapper() : handle(nil) {
+ObjcClassWrapper::ObjcClassWrapper(AllocationTracker* tracker) {
+  if (tracker) {
+    CreateValue(tracker);
+  }
 }
 
-ObjcClassWrapper::ObjcClassWrapper(AllocationTracker* tracker)
-    : handle([[FSTObjcClassTestValue alloc] initWithTracker:tracker]) {
+void ObjcClassWrapper::CreateValue(AllocationTracker* tracker) {
+  handle.Assign([[FSTObjcClassTestValue alloc] initWithTracker:tracker]);
 }
 
-void ObjcClassWrapper::set_value(Handle<FSTObjcClassTestValue> helper) {
+void ObjcClassWrapper::SetValue(Handle<FSTObjcClassTestValue> helper) {
   handle.Assign(helper);
 }
 


### PR DESCRIPTION
This makes it possible to safely embed pointers to Objective-C objects in plain C++, without needing any additional PIMPL indirection.