### PR TITLE
Implement a type of future for GDT stored NSData

### DIFF
--- a/GoogleDataTransport/GDTLibrary/GDTDataFuture.m
+++ b/GoogleDataTransport/GDTLibrary/GDTDataFuture.m
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <GoogleDataTransport/GDTDataFuture.h>
+
+@implementation GDTDataFuture
+
+- (instancetype)init {
+  self = [self initWithData:[NSData data]];
+  return self;
+}
+
+- (instancetype)initWithFileURL:(NSURL *)fileURL {
+  self = [super init];
+  if (self) {
+    _fileURL = fileURL;
+  }
+  return self;
+}
+
+- (instancetype)initWithData:(NSData *)data {
+  self = [super init];
+  if (self) {
+    _originalData = data;
+  }
+  return self;
+}
+
+- (nullable NSData *)data {
+  if (_fileURL) {
+    NSAssert([[NSFileManager defaultManager] fileExistsAtPath:_fileURL.path isDirectory:NULL],
+             @"A file should exist for this future at the given URL: %@", _fileURL);
+    return [NSData dataWithContentsOfURL:_fileURL];
+  } else if (_originalData) {
+    return _originalData;
+  }
+  return nil;
+}
+
+- (BOOL)isEqual:(id)object {
+  return [self hash] == [object hash];
+}
+
+- (NSUInteger)hash {
+  // In reality, only one of these should be populated.
+  return [_fileURL hash] ^ [_originalData hash];
+}
+
+#pragma mark - NSSecureCoding
+
+/** Coding key for _fileURL ivar. */
+static NSString *kGDTDataFutureFileURLKey = @"GDTDataFutureFileURLKey";
+
+/** Coding key for _data ivar. */
+static NSString *kGDTDataFutureDataKey = @"GDTDataFutureDataKey";
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (void)encodeWithCoder:(nonnull NSCoder *)aCoder {
+  [aCoder encodeObject:_fileURL forKey:kGDTDataFutureFileURLKey];
+  [aCoder encodeObject:_originalData forKey:kGDTDataFutureDataKey];
+}
+
+- (nullable instancetype)initWithCoder:(nonnull NSCoder *)aDecoder {
+  self = [self init];
+  if (self) {
+    _fileURL = [aDecoder decodeObjectOfClass:[NSURL class] forKey:kGDTDataFutureFileURLKey];
+    _originalData = [aDecoder decodeObjectOfClass:[NSData class] forKey:kGDTDataFutureDataKey];
+  }
+  return self;
+}
+
+@end

--- a/GoogleDataTransport/GDTLibrary/GDTEvent.m
+++ b/GoogleDataTransport/GDTLibrary/GDTEvent.m
@@ -63,8 +63,8 @@
   }
 }
 
-- (GDTStoredEvent *)storedEventWithFileURL:(NSURL *)fileURL {
-  return [[GDTStoredEvent alloc] initWithFileURL:fileURL event:self];
+- (GDTStoredEvent *)storedEventWithDataFuture:(GDTDataFuture *)dataFuture {
+  return [[GDTStoredEvent alloc] initWithEvent:self dataFuture:dataFuture];
 }
 
 #pragma mark - NSSecureCoding and NSCoding Protocols

--- a/GoogleDataTransport/GDTLibrary/GDTStoredEvent.m
+++ b/GoogleDataTransport/GDTLibrary/GDTStoredEvent.m
@@ -18,12 +18,14 @@
 
 #import <GoogleDataTransport/GDTClock.h>
 
+#import "GDTStorage_Private.h"
+
 @implementation GDTStoredEvent
 
-- (instancetype)initWithFileURL:(NSURL *)URL event:(GDTEvent *)event {
+- (instancetype)initWithEvent:(GDTEvent *)event dataFuture:(nonnull GDTDataFuture *)dataFuture {
   self = [super init];
   if (self) {
-    _eventFileURL = URL;
+    _dataFuture = dataFuture;
     _mappingID = event.mappingID;
     _target = @(event.target);
     _qosTier = event.qosTier;
@@ -35,8 +37,8 @@
 
 #pragma mark - NSSecureCoding
 
-/** Coding key for eventFileURL ivar. */
-static NSString *kEventFileURLKey = @"GDTStoredEventEventFileURLKey";
+/** Coding key for the dataFuture ivar. */
+static NSString *kDataFutureKey = @"GDTStoredEventDataFutureKey";
 
 /** Coding key for mappingID ivar. */
 static NSString *kMappingIDKey = @"GDTStoredEventMappingIDKey";
@@ -58,7 +60,7 @@ static NSString *kCustomPrioritizationParamsKey = @"GDTStoredEventcustomPrioriti
 }
 
 - (void)encodeWithCoder:(nonnull NSCoder *)aCoder {
-  [aCoder encodeObject:_eventFileURL forKey:kEventFileURLKey];
+  [aCoder encodeObject:_dataFuture forKey:kDataFutureKey];
   [aCoder encodeObject:_mappingID forKey:kMappingIDKey];
   [aCoder encodeObject:_target forKey:kTargetKey];
   [aCoder encodeObject:@(_qosTier) forKey:kQosTierKey];
@@ -69,7 +71,7 @@ static NSString *kCustomPrioritizationParamsKey = @"GDTStoredEventcustomPrioriti
 - (nullable instancetype)initWithCoder:(nonnull NSCoder *)aDecoder {
   self = [self init];
   if (self) {
-    _eventFileURL = [aDecoder decodeObjectOfClass:[NSURL class] forKey:kEventFileURLKey];
+    _dataFuture = [aDecoder decodeObjectOfClass:[GDTDataFuture class] forKey:kDataFutureKey];
     _mappingID = [aDecoder decodeObjectOfClass:[NSString class] forKey:kMappingIDKey];
     _target = [aDecoder decodeObjectOfClass:[NSNumber class] forKey:kTargetKey];
     NSNumber *qosTier = [aDecoder decodeObjectOfClass:[NSNumber class] forKey:kQosTierKey];
@@ -86,8 +88,7 @@ static NSString *kCustomPrioritizationParamsKey = @"GDTStoredEventcustomPrioriti
 }
 
 - (NSUInteger)hash {
-  return
-      [_eventFileURL hash] ^ [_mappingID hash] ^ [_target hash] ^ [_clockSnapshot hash] ^ _qosTier;
+  return [_dataFuture hash] ^ [_mappingID hash] ^ [_target hash] ^ [_clockSnapshot hash] ^ _qosTier;
 }
 
 @end

--- a/GoogleDataTransport/GDTLibrary/Public/GDTDataFuture.h
+++ b/GoogleDataTransport/GDTLibrary/Public/GDTDataFuture.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** This class represents a future data object, determined at instantiation time. */
+@interface GDTDataFuture : NSObject <NSSecureCoding>
+
+/** The data, computed on-demand, depending on the initializer. */
+@property(nullable, readonly, nonatomic) NSData *data;
+
+/** If not nil, this data future was instantiated with this file URL. */
+@property(nullable, readonly, nonatomic) NSURL *fileURL;
+
+/** If not nil, this data future was instantiated with this NSData instance. */
+@property(nullable, readonly, nonatomic) NSData *originalData;
+
+/** Initializes an instance with the given the fileURL.
+ *
+ * @param fileURL The fileURL containing the data to return in -data.
+ * @return An instance of this class.
+ */
+- (instancetype)initWithFileURL:(NSURL *)fileURL NS_DESIGNATED_INITIALIZER;
+
+/** Initializes an instance with the given data.
+ *
+ * @param data The data to return from -data.
+ * @return An instance of this class.
+ */
+- (instancetype)initWithData:(NSData *)data NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleDataTransport/GDTLibrary/Public/GDTEvent.h
+++ b/GoogleDataTransport/GDTLibrary/Public/GDTEvent.h
@@ -19,6 +19,7 @@
 #import <GoogleDataTransport/GDTEventDataObject.h>
 
 @class GDTClock;
+@class GDTDataFuture;
 @class GDTStoredEvent;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -83,10 +84,10 @@ typedef NS_ENUM(NSInteger, GDTEventQoS) {
 
 /** Returns the GDTStoredEvent equivalent of self.
  *
- * @param fileURL The file URL of the result of the dataObject's -transportBytes.
+ * @param dataFuture The data future representing the transport bytes of the original event.
  * @return An equivalent GDTStoredEvent.
  */
-- (GDTStoredEvent *)storedEventWithFileURL:(NSURL *)fileURL;
+- (GDTStoredEvent *)storedEventWithDataFuture:(GDTDataFuture *)dataFuture;
 
 @end
 

--- a/GoogleDataTransport/GDTLibrary/Public/GDTStoredEvent.h
+++ b/GoogleDataTransport/GDTLibrary/Public/GDTStoredEvent.h
@@ -15,6 +15,7 @@
  */
 #import <Foundation/Foundation.h>
 
+#import <GoogleDataTransport/GDTDataFuture.h>
 #import <GoogleDataTransport/GDTEvent.h>
 
 @class GDTEvent;
@@ -23,8 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface GDTStoredEvent : NSObject <NSSecureCoding>
 
-/** The file URL containing the transport bytes of this event. */
-@property(readonly, nonatomic) NSURL *eventFileURL;
+/** The data future representing the original event's transport bytes. */
+@property(readonly, nonatomic) GDTDataFuture *dataFuture;
 
 /** The mapping identifier, to allow backends to map the transport bytes to a proto. */
 @property(readonly, nonatomic) NSString *mappingID;
@@ -46,11 +47,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Initializes a stored event with the given URL and event.
  *
- * @param URL The file URL of the transport bytes associated with the event.
  * @param event The event this stored event represents.
+ * @param dataFuture The dataFuture this event represents.
  * @return An instance of this class.
  */
-- (instancetype)initWithFileURL:(NSURL *)URL event:(GDTEvent *)event;
+- (instancetype)initWithEvent:(GDTEvent *)event dataFuture:(GDTDataFuture *)dataFuture;
 
 @end
 

--- a/GoogleDataTransport/GDTLibrary/Public/GoogleDataTransport.h
+++ b/GoogleDataTransport/GDTLibrary/Public/GoogleDataTransport.h
@@ -15,6 +15,7 @@
  */
 
 #import "GDTClock.h"
+#import "GDTDataFuture.h"
 #import "GDTEvent.h"
 #import "GDTEventDataObject.h"
 #import "GDTEventTransformer.h"
@@ -22,5 +23,7 @@
 #import "GDTPrioritizer.h"
 #import "GDTRegistrar.h"
 #import "GDTStoredEvent.h"
+#import "GDTTargets.h"
 #import "GDTTransport.h"
+#import "GDTUploadPackage.h"
 #import "GDTUploader.h"

--- a/GoogleDataTransport/GDTTests/Integration/Helpers/GDTIntegrationTestUploader.m
+++ b/GoogleDataTransport/GDTTests/Integration/Helpers/GDTIntegrationTestUploader.m
@@ -54,7 +54,7 @@
 
   // In real usage, you'd create an instance of whatever request proto your server needs.
   for (GDTStoredEvent *event in package.events) {
-    NSData *fileData = [NSData dataWithContentsOfURL:event.eventFileURL];
+    NSData *fileData = [NSData dataWithContentsOfURL:event.dataFuture.fileURL];
     NSAssert(fileData, @"An event file shouldn't be empty");
     [uploadData appendData:fileData];
   }

--- a/GoogleDataTransport/GDTTests/Unit/GDTStorageTest.m
+++ b/GoogleDataTransport/GDTTests/Unit/GDTStorageTest.m
@@ -88,7 +88,7 @@ static NSInteger target = 1337;
   dispatch_sync([GDTStorage sharedInstance].storageQueue, ^{
     XCTAssertEqual([GDTStorage sharedInstance].storedEvents.count, 1);
     XCTAssertEqual([GDTStorage sharedInstance].targetToEventSet[@(target)].count, 1);
-    NSURL *eventFile = [[GDTStorage sharedInstance].storedEvents lastObject].eventFileURL;
+    NSURL *eventFile = [[GDTStorage sharedInstance].storedEvents lastObject].dataFuture.fileURL;
     XCTAssertNotNil(eventFile);
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:eventFile.path]);
     NSError *error;
@@ -107,7 +107,7 @@ static NSInteger target = 1337;
   }
   __block NSURL *eventFile;
   dispatch_sync([GDTStorage sharedInstance].storageQueue, ^{
-    eventFile = [[GDTStorage sharedInstance].storedEvents lastObject].eventFileURL;
+    eventFile = [[GDTStorage sharedInstance].storedEvents lastObject].dataFuture.fileURL;
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:eventFile.path]);
   });
   [[GDTStorage sharedInstance] removeEvents:[GDTStorage sharedInstance].storedEvents.set];
@@ -155,7 +155,8 @@ static NSInteger target = 1337;
     XCTAssertFalse([storage.storedEvents containsObject:storedEvent3]);
     XCTAssertEqual(storage.targetToEventSet[@(target)].count, 0);
     for (GDTStoredEvent *event in eventSet) {
-      XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:event.eventFileURL.path]);
+      XCTAssertFalse(
+          [[NSFileManager defaultManager] fileExistsAtPath:event.dataFuture.fileURL.path]);
     }
   });
 }
@@ -191,21 +192,21 @@ static NSInteger target = 1337;
     XCTAssertEqual([GDTStorage sharedInstance].storedEvents.count, 3);
     XCTAssertEqual([GDTStorage sharedInstance].targetToEventSet[@(target)].count, 3);
 
-    NSURL *event1File = storedEvent1.eventFileURL;
+    NSURL *event1File = storedEvent1.dataFuture.fileURL;
     XCTAssertNotNil(event1File);
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:event1File.path]);
     NSError *error;
     XCTAssertTrue([[NSFileManager defaultManager] removeItemAtURL:event1File error:&error]);
     XCTAssertNil(error, @"There was an error deleting the eventFile: %@", error);
 
-    NSURL *event2File = storedEvent2.eventFileURL;
+    NSURL *event2File = storedEvent2.dataFuture.fileURL;
     XCTAssertNotNil(event2File);
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:event2File.path]);
     error = nil;
     XCTAssertTrue([[NSFileManager defaultManager] removeItemAtURL:event2File error:&error]);
     XCTAssertNil(error, @"There was an error deleting the eventFile: %@", error);
 
-    NSURL *event3File = storedEvent3.eventFileURL;
+    NSURL *event3File = storedEvent3.dataFuture.fileURL;
     XCTAssertNotNil(event3File);
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:event3File.path]);
     error = nil;
@@ -225,7 +226,9 @@ static NSInteger target = 1337;
 
     // Store the event and wait for the expectation.
     [[GDTStorage sharedInstance] storeEvent:event];
-    storedEvent = [event storedEventWithFileURL:[NSURL fileURLWithPath:@"/test"]];
+    GDTDataFuture *dataFuture =
+        [[GDTDataFuture alloc] initWithFileURL:[NSURL fileURLWithPath:@"/test"]];
+    storedEvent = [event storedEventWithDataFuture:dataFuture];
   }
   dispatch_sync([GDTStorage sharedInstance].storageQueue, ^{
     XCTAssertNil(weakEvent);
@@ -233,7 +236,7 @@ static NSInteger target = 1337;
   });
 
   NSURL *eventFile;
-  eventFile = [[GDTStorage sharedInstance].storedEvents lastObject].eventFileURL;
+  eventFile = [[GDTStorage sharedInstance].storedEvents lastObject].dataFuture.fileURL;
 
   // This isn't strictly necessary because of the -waitForExpectations above.
   dispatch_sync([GDTStorage sharedInstance].storageQueue, ^{
@@ -302,7 +305,7 @@ static NSInteger target = 1337;
     XCTAssertTrue(self.uploaderFake.forceUploadCalled);
     XCTAssertEqual([GDTStorage sharedInstance].storedEvents.count, 1);
     XCTAssertEqual([GDTStorage sharedInstance].targetToEventSet[@(target)].count, 1);
-    NSURL *eventFile = [[GDTStorage sharedInstance].storedEvents lastObject].eventFileURL;
+    NSURL *eventFile = [[GDTStorage sharedInstance].storedEvents lastObject].dataFuture.fileURL;
     XCTAssertNotNil(eventFile);
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:eventFile.path]);
     NSError *error;

--- a/GoogleDataTransport/GDTTests/Unit/GDTStoredEventTest.m
+++ b/GoogleDataTransport/GDTTests/Unit/GDTStoredEventTest.m
@@ -29,8 +29,8 @@
 - (void)testInit {
   GDTEvent *event = [[GDTEvent alloc] initWithMappingID:@"testing" target:1];
   event.clockSnapshot = [GDTClock snapshot];
-  GDTStoredEvent *storedEvent = [[GDTStoredEvent alloc] initWithFileURL:[NSURL URLWithString:@"1"]
-                                                                  event:event];
+  GDTDataFuture *dataFuture = [[GDTDataFuture alloc] initWithFileURL:[NSURL URLWithString:@"1"]];
+  GDTStoredEvent *storedEvent = [[GDTStoredEvent alloc] initWithEvent:event dataFuture:dataFuture];
   XCTAssertNotNil(storedEvent);
 }
 
@@ -40,15 +40,15 @@
   GDTEvent *event = [[GDTEvent alloc] initWithMappingID:@"testing" target:1];
   event.clockSnapshot = [GDTClock snapshot];
   event.qosTier = GDTEventQoSTelemetry;
-  GDTStoredEvent *storedEvent = [[GDTStoredEvent alloc] initWithFileURL:[NSURL URLWithString:@"1"]
-                                                                  event:event];
+  GDTDataFuture *dataFuture = [[GDTDataFuture alloc] initWithFileURL:[NSURL URLWithString:@"1"]];
+  GDTStoredEvent *storedEvent = [[GDTStoredEvent alloc] initWithEvent:event dataFuture:dataFuture];
   XCTAssertNotNil(storedEvent);
   XCTAssertNotNil(storedEvent.mappingID);
   XCTAssertNotNil(storedEvent.target);
   XCTAssertEqual(storedEvent.qosTier, GDTEventQoSTelemetry);
   XCTAssertNotNil(storedEvent.clockSnapshot);
   XCTAssertNil(storedEvent.customPrioritizationParams);
-  XCTAssertNotNil(storedEvent.eventFileURL);
+  XCTAssertNotNil(storedEvent.dataFuture.fileURL);
 }
 
 /** Tests equality between GDTStoredEvents. */
@@ -61,8 +61,10 @@
   [event1.clockSnapshot setValue:@(961141365197) forKeyPath:@"uptime"];
   event1.qosTier = GDTEventQosDefault;
   event1.customPrioritizationParams = @{@"customParam1" : @"aValue1"};
-  GDTStoredEvent *storedEvent1 =
-      [event1 storedEventWithFileURL:[NSURL fileURLWithPath:@"/tmp/fake.txt"]];
+  GDTDataFuture *dataFuture1 =
+      [[GDTDataFuture alloc] initWithFileURL:[NSURL fileURLWithPath:@"/tmp/fake.txt"]];
+  GDTStoredEvent *storedEvent1 = [[GDTStoredEvent alloc] initWithEvent:event1
+                                                            dataFuture:dataFuture1];
 
   GDTEvent *event2 = [[GDTEvent alloc] initWithMappingID:@"1018" target:1];
   event2.clockSnapshot = [GDTClock snapshot];
@@ -72,8 +74,10 @@
   [event2.clockSnapshot setValue:@(961141365197) forKeyPath:@"uptime"];
   event2.qosTier = GDTEventQosDefault;
   event2.customPrioritizationParams = @{@"customParam1" : @"aValue1"};
-  GDTStoredEvent *storedEvent2 =
-      [event2 storedEventWithFileURL:[NSURL fileURLWithPath:@"/tmp/fake.txt"]];
+  GDTDataFuture *dataFuture2 =
+      [[GDTDataFuture alloc] initWithFileURL:[NSURL fileURLWithPath:@"/tmp/fake.txt"]];
+  GDTStoredEvent *storedEvent2 = [[GDTStoredEvent alloc] initWithEvent:event2
+                                                            dataFuture:dataFuture2];
 
   XCTAssertEqual([storedEvent1 hash], [storedEvent2 hash]);
   XCTAssertEqualObjects(storedEvent1, storedEvent2);

--- a/GoogleDataTransport/GDTTests/Unit/Helpers/GDTEventGenerator.m
+++ b/GoogleDataTransport/GDTTests/Unit/Helpers/GDTEventGenerator.m
@@ -40,7 +40,9 @@
     [[NSFileManager defaultManager] createFileAtPath:filePath
                                             contents:[NSData data]
                                           attributes:nil];
-    [set addObject:[event storedEventWithFileURL:[NSURL fileURLWithPath:filePath]]];
+    GDTDataFuture *dataFuture =
+        [[GDTDataFuture alloc] initWithFileURL:[NSURL fileURLWithPath:filePath]];
+    [set addObject:[event storedEventWithDataFuture:dataFuture]];
     counter++;
   }
   return set;


### PR DESCRIPTION
This will make future refactoring of GDTStorage much easier. Having the framework utilize a data future instead of raw file URLs will be easier to manage because future storage systems might not have file URLs (e.g. sqlite)