### PR TITLE
FIRStorageUploadTask - fix crash in `isContentToUploadValid`

### DIFF
--- a/Example/Storage/Tests/Unit/FIRStorageReferenceTests.m
+++ b/Example/Storage/Tests/Unit/FIRStorageReferenceTests.m
@@ -187,4 +187,29 @@
   [self waitForExpectationsWithTimeout:0.5 handler:NULL];
 }
 
+- (void)testReferenceWithNilFileURLFailsWithCompletion {
+  NSString *tempFilePath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"temp.data"];
+  FIRStorageReference *ref = [self.storage referenceWithPath:tempFilePath];
+
+  NSURL *dummyFileURL = nil;
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completionExpectation"];
+
+  [ref putFile:dummyFileURL
+        metadata:nil
+      completion:^(FIRStorageMetadata *_Nullable metadata, NSError *_Nullable error) {
+        [expectation fulfill];
+        XCTAssertNotNil(error);
+        XCTAssertNil(metadata);
+
+        XCTAssertEqualObjects(error.domain, FIRStorageErrorDomain);
+        XCTAssertEqual(error.code, FIRStorageErrorCodeUnknown);
+        NSString *expectedDescription = [NSString
+            stringWithFormat:@"File at URL: %@ is not reachable.", dummyFileURL.absoluteString];
+        XCTAssertEqualObjects(error.localizedDescription, expectedDescription);
+      }];
+
+  [self waitForExpectationsWithTimeout:0.5 handler:NULL];
+}
+
 @end

--- a/Example/Storage/Tests/Unit/FIRStorageReferenceTests.m
+++ b/Example/Storage/Tests/Unit/FIRStorageReferenceTests.m
@@ -204,8 +204,7 @@
 
         XCTAssertEqualObjects(error.domain, FIRStorageErrorDomain);
         XCTAssertEqual(error.code, FIRStorageErrorCodeUnknown);
-        NSString *expectedDescription = [NSString
-            stringWithFormat:@"File at URL: %@ is not reachable.", dummyFileURL.absoluteString];
+        NSString *expectedDescription = @"File at URL: (null) is not reachable.";
         XCTAssertEqualObjects(error.localizedDescription, expectedDescription);
       }];
 

--- a/Firebase/Storage/CHANGELOG.md
+++ b/Firebase/Storage/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+- [fixed] Fixed carsh when URL passesed `StorageReference.putFile()` is `nil` (#2852)
+
+# 3.1.0
 - [fixed] `StorageReference.putFile()` now correctly propagates error if file to upload does not exist (#2458, #2350).
 
 # 3.0.3

--- a/Firebase/Storage/FIRStorageUploadTask.m
+++ b/Firebase/Storage/FIRStorageUploadTask.m
@@ -196,14 +196,17 @@
   NSError *fileReachabilityError;
   if (![_fileURL checkResourceIsReachableAndReturnError:&fileReachabilityError]) {
     if (outError != NULL) {
-      NSString *description =
+      NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithCapacity:2];
+      userInfo[NSLocalizedDescriptionKey] =
           [NSString stringWithFormat:@"File at URL: %@ is not reachable.", _fileURL.absoluteString];
+
+      if (fileReachabilityError) {
+        userInfo[NSUnderlyingErrorKey] = fileReachabilityError;
+      }
+
       *outError = [NSError errorWithDomain:FIRStorageErrorDomain
                                       code:FIRStorageErrorCodeUnknown
-                                  userInfo:@{
-                                    NSUnderlyingErrorKey : fileReachabilityError,
-                                    NSLocalizedDescriptionKey : description
-                                  }];
+                                  userInfo:userInfo];
     }
 
     return NO;


### PR DESCRIPTION
Fixes #2852