### PR TITLE
Make `api::DocumentSnapshot::document_id()` return a const reference.

### DIFF
--- a/Firestore/core/src/firebase/firestore/api/document_snapshot.h
+++ b/Firestore/core/src/firebase/firestore/api/document_snapshot.h
@@ -60,7 +60,7 @@ class DocumentSnapshot {
 
   bool exists() const;
   FSTDocument* internal_document() const;
-  std::string document_id() const;
+  const std::string& document_id() const;
 
   const SnapshotMetadata& metadata() const {
     return metadata_;

--- a/Firestore/core/src/firebase/firestore/api/document_snapshot.mm
+++ b/Firestore/core/src/firebase/firestore/api/document_snapshot.mm
@@ -70,7 +70,7 @@ DocumentReference DocumentSnapshot::CreateReference() const {
   return DocumentReference{internal_key_, firestore_};
 }
 
-std::string DocumentSnapshot::document_id() const {
+const std::string& DocumentSnapshot::document_id() const {
   return internal_key_.path().last_segment();
 }
 


### PR DESCRIPTION
The function its delegating to is returning a const reference already.
