### PR TITLE
GoogleUtilities to testspec and pod gen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,6 @@ jobs:
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleUtilities.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAnalyticsInterop.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuth.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuthInterop.podspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,16 @@ jobs:
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
 
+    - stage: test
+      env:
+        - PROJECT=GoogleUtilities PLATFORM=iOS METHOD=pod-lib-lint
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleUtilities.podspec
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleUtilities.podspec --use-libraries
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleUtilities.podspec --use-modular-headers
+
     # pod lib lint to check build and warnings for dynamic framework build (use_frameworks!)
     - stage: test
       env:
@@ -136,7 +146,6 @@ jobs:
       before_install:
         - ./scripts/install_prereqs.sh
       script:
-        - travis_retry ./scripts/pod_lib_lint.rb GoogleUtilities.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseAnalyticsInterop.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseAuth.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseAuthInterop.podspec --use-libraries

--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -104,6 +104,7 @@ other Google CocoaPods. They're not intended for direct public usage.
     # All tests require arc except Tests/Network/third_party/GTMHTTPServer.m
     unit_tests.source_files = 'GoogleUtilities/Example/Tests/**/*.[mh]'
     unit_tests.requires_arc = 'GoogleUtilities/Example/Tests/*/*.[mh]'
+    unit_tests.requires_app_host = true
     unit_tests.dependency 'OCMock'
   end
 end

--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -99,4 +99,11 @@ other Google CocoaPods. They're not intended for direct public usage.
     ud.private_header_files = 'GoogleUtilities/UserDefaults/Private/*.h'
     ud.dependency 'GoogleUtilities/Logger'
   end
+
+  s.test_spec 'unit' do |unit_tests|
+    # All tests require arc except Tests/Network/third_party/GTMHTTPServer.m
+    unit_tests.source_files = 'GoogleUtilities/Example/Tests/**/*.[mh]'
+    unit_tests.requires_arc = 'GoogleUtilities/Example/Tests/*/*.[mh]'
+    unit_tests.dependency 'OCMock'
+  end
 end

--- a/GoogleUtilities/Example/Tests/Network/GULNetworkTest.m
+++ b/GoogleUtilities/Example/Tests/Network/GULNetworkTest.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "third_party/GTMHTTPServer.h"
+#import "GTMHTTPServer.h"
 
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>

--- a/GoogleUtilities/Example/Tests/Network/GULNetworkTest.m
+++ b/GoogleUtilities/Example/Tests/Network/GULNetworkTest.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "GTMHTTPServer.h"
+#import "third_party/GTMHTTPServer.h"
 
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>

--- a/GoogleUtilities/Example/Tests/Network/third_party/GTMHTTPServer.m
+++ b/GoogleUtilities/Example/Tests/Network/third_party/GTMHTTPServer.m
@@ -127,13 +127,6 @@ static NSString *kResponse = @"Response";
   [super dealloc];
 }
 
-#if !TARGET_OS_IPHONE
-- (void)finalize {
-  [self stop];
-  [super finalize];
-}
-#endif
-
 - (id)delegate {
   return delegate_;
 }

--- a/GoogleUtilities/Example/Tests/Swizzler/GULAppDelegateSwizzlerTest.m
+++ b/GoogleUtilities/Example/Tests/Swizzler/GULAppDelegateSwizzlerTest.m
@@ -91,7 +91,9 @@ static NSString *const kGULGoogleAppDelegateProxyEnabledPlistKey =
 /** YES if GULTestAppDelegate responds to application:openURL:sourceApplication:annotation:, NO
  *  otherwise.
  */
+#if TARGET_OS_IOS || TARGET_OS_TV
 static BOOL gRespondsToOpenURLHandler_iOS8;
+#endif
 
 /** YES if GULTestAppDelegate responds to application:openURL:options:, NO otherwise. */
 static BOOL gRespondsToOpenURLHandler_iOS9;
@@ -109,10 +111,13 @@ static BOOL gRespondsToHandleBackgroundSession;
 + (void)load {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
   // Before being proxied, it should be only be able to respond to
   // application:openURL:sourceApplication:annotation:.
+#if TARGET_OS_IOS || TARGET_OS_TV
   gRespondsToOpenURLHandler_iOS8 = [self
       instancesRespondToSelector:@selector(application:openURL:sourceApplication:annotation:)];
+#endif
   gRespondsToOpenURLHandler_iOS9 =
       [self instancesRespondToSelector:@selector(application:openURL:options:)];
   gRespondsToHandleBackgroundSession =

--- a/GoogleUtilities/README.md
+++ b/GoogleUtilities/README.md
@@ -20,7 +20,7 @@ integration test FirebaseFunctions:
 
 ### Prereqs
 
-- At least CocoaPods 1.6.0
+- At least CocoaPods 1.7.0
 
 ### To Develop
 

--- a/GoogleUtilities/README.md
+++ b/GoogleUtilities/README.md
@@ -24,12 +24,12 @@ integration test FirebaseFunctions:
 
 ### To Develop
 
-- Run `bundle exec pod gen GoogleUtilities.podspec`
+- Run `pod gen GoogleUtilities.podspec`
 - `open gen/GoogleUtilities/GoogleUtilities.xcworkspace`
 
 OR these two commands can be combined with
 
-- `bundle exec pod gen GoogleUtilities.podspec --auto-open --gen-directory="gen" --clean`
+- `pod gen GoogleUtilities.podspec --auto-open --gen-directory="gen" --clean`
 
 You're now in an Xcode workspace generate for building, debugging and
 testing the GoogleUtilities CocoaPod.

--- a/GoogleUtilities/README.md
+++ b/GoogleUtilities/README.md
@@ -21,14 +21,15 @@ integration test FirebaseFunctions:
 ### Prereqs
 
 - At least CocoaPods 1.6.0
-- Install [cocoapods-generate](https://github.com/square/cocoapods-generate)
 
-- Run `pod gen GoogleUtilities.podspec`
+### To Develop
+
+- Run `bundle exec pod gen GoogleUtilities.podspec`
 - `open gen/GoogleUtilities/GoogleUtilities.xcworkspace`
 
 OR these two commands can be combined with
 
-- `pod gen GoogleUtilities.podspec --auto-open --gen-directory="gen" --clean`
+- `bundle exec pod gen GoogleUtilities.podspec --auto-open --gen-directory="gen" --clean`
 
 You're now in an Xcode workspace generate for building, debugging and
 testing the GoogleUtilities CocoaPod.

--- a/GoogleUtilities/README.md
+++ b/GoogleUtilities/README.md
@@ -15,15 +15,23 @@ Instructions on how to adopt the app delegate swizzler for use by your SDK are a
 
 ## Development
 
-Follow the subsequent instructions to develop, debug, and unit test
-GoogleUtilities:
+Follow the subsequent instructions to develop, debug, unit test, and
+integration test FirebaseFunctions:
 
-```
-$ git clone git@github.com:firebase/firebase-ios-sdk.git
-$ cd firebase-ios-sdk/GoogleUtilities/Example
-$ pod update
-$ open GoogleUtilities.xcworkspace
-```
+### Prereqs
+
+- At least CocoaPods 1.6.0
+- Install [cocoapods-generate](https://github.com/square/cocoapods-generate)
+
+- Run `pod gen GoogleUtilities.podspec`
+- `open gen/GoogleUtilities/GoogleUtilities.xcworkspace`
+
+OR these two commands can be combined with
+
+- `pod gen GoogleUtilities.podspec --auto-open --gen-directory="gen" --clean`
+
+You're now in an Xcode workspace generate for building, debugging and
+testing the GoogleUtilities CocoaPod.
 
 ### Running Unit Tests
 

--- a/scripts/if_changed.sh
+++ b/scripts/if_changed.sh
@@ -78,6 +78,10 @@ else
       check_changes '^(Firebase/Core|Functions|GoogleUtilities|FirebaseFunctions.podspec)'
       ;;
 
+    GoogleUtilities-*)
+      check_changes '^(GoogleUtilities|GoogleUtilities.podspec)'
+      ;;
+
     InAppMessaging-*)
       check_changes '^(Firebase/InAppMessagingDisplay|InAppMessagingDisplay|InAppMessaging|'\
 'Firebase/InAppMessaging)'


### PR DESCRIPTION
Update GoogleUtilities development process to use CocoaPods testspec's and `pod gen`.