### PR TITLE
Use portable util/log.h instead of FIRLogger

### DIFF
--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -19,7 +19,6 @@
 #import <FirebaseCore/FIRApp.h>
 #import <FirebaseCore/FIRAppInternal.h>
 #import <FirebaseCore/FIRComponentContainer.h>
-#import <FirebaseCore/FIRLogger.h>
 #import <FirebaseCore/FIROptions.h>
 
 #include <memory>
@@ -294,7 +293,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (void)enableLogging:(BOOL)logging {
-  FIRSetLoggerLevel(logging ? FIRLoggerLevelDebug : FIRLoggerLevelNotice);
+  util::LogSetLevel(logging ? util::kLogLevelDebug : util::kLogLevelNotice);
 }
 
 - (void)enableNetworkWithCompletion:(nullable void (^)(NSError *_Nullable error))completion {
@@ -322,7 +321,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (BOOL)isLoggingEnabled {
-  return FIRIsLoggableLevel(FIRLoggerLevelDebug, NO);
+  return util::LogIsLoggable(util::kLogLevelDebug);
 }
 
 + (FIRFirestore *)recoverFromFirestore:(std::shared_ptr<Firestore>)firestore {

--- a/Firestore/core/src/firebase/firestore/util/log.h
+++ b/Firestore/core/src/firebase/firestore/util/log.h
@@ -29,6 +29,8 @@ namespace util {
 enum LogLevel {
   // Debug Log Level
   kLogLevelDebug,
+  // Notice Log Level
+  kLogLevelNotice,
   // Warning Log Level
   kLogLevelWarning,
   // Error Log Level

--- a/Firestore/core/src/firebase/firestore/util/log_apple.mm
+++ b/Firestore/core/src/firebase/firestore/util/log_apple.mm
@@ -39,6 +39,8 @@ FIRLoggerLevel ToFIRLoggerLevel(LogLevel level) {
   switch (level) {
     case kLogLevelDebug:
       return FIRLoggerLevelDebug;
+    case kLogLevelNotice:
+      return FIRLoggerLevelNotice;
     case kLogLevelWarning:
       return FIRLoggerLevelWarning;
     case kLogLevelError:


### PR DESCRIPTION
On iOS this still delegates to FIRLogger under the covers.