### PR TITLE
Put secret and oauth credentials into the private headers for now.

### DIFF
--- a/Firebase/Auth/Source/Auth/FIRAuthDataResult_Internal.h
+++ b/Firebase/Auth/Source/Auth/FIRAuthDataResult_Internal.h
@@ -16,9 +16,17 @@
 
 #import "FIRAuthDataResult.h"
 
+@class FIROAuthCredential;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface FIRAuthDataResult () <NSSecureCoding>
+
+/** @property credential
+    @brief The updated OAuth credential after the the sign-in, link and reauthenticate action.
+    @detial This property is for OAuth sign in only.
+ */
+@property(nonatomic, readonly, nullable) FIROAuthCredential *credential;
 
 /** @fn initWithUser:additionalUserInfo:
     @brief Designated initializer.

--- a/Firebase/Auth/Source/Auth/FIRAuthDataResult_Internal.h
+++ b/Firebase/Auth/Source/Auth/FIRAuthDataResult_Internal.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** @property credential
     @brief The updated OAuth credential after the the sign-in, link and reauthenticate action.
-    @detial This property is for OAuth sign in only.
+    @detail This property is for OAuth sign in only.
  */
 @property(nonatomic, readonly, nullable) FIROAuthCredential *credential;
 

--- a/Firebase/Auth/Source/AuthProvider/OAuth/FIROAuthCredential_Internal.h
+++ b/Firebase/Auth/Source/AuthProvider/OAuth/FIROAuthCredential_Internal.h
@@ -42,6 +42,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, readonly, nullable) NSString *pendingToken;
 
+/** @property secret
+    @brief The secret associated with this credential. This will be nil for OAuth 2.0 providers.
+    @detail OAuthCredential already exposes a providerId getter. This will help the developer
+        determine whether an access token/secret pair is needed.
+ */
+@property(nonatomic, readonly, nullable) NSString *secret;
+
 /** @fn initWithProviderId:IDToken:accessToken:secret:pendingToken
     @brief Designated initializer.
     @param providerID The provider ID associated with the credential being created.

--- a/Firebase/Auth/Source/Public/FIRAuthDataResult.h
+++ b/Firebase/Auth/Source/Public/FIRAuthDataResult.h
@@ -37,7 +37,7 @@ NS_SWIFT_NAME(AuthDataResult)
 /** @property user
     @brief The signed in user.
  */
-@property(nonatomic, readonly, nullable) FIRUser *user;
+@property(nonatomic, readonly) FIRUser *user;
 
 /** @property additionalUserInfo
     @brief If available contains the additional IdP specific information about signed in user.

--- a/Firebase/Auth/Source/Public/FIRAuthDataResult.h
+++ b/Firebase/Auth/Source/Public/FIRAuthDataResult.h
@@ -17,7 +17,6 @@
 #import <Foundation/Foundation.h>
 
 @class FIRAdditionalUserInfo;
-@class FIROAuthCredential;
 @class FIRUser;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -39,13 +38,6 @@ NS_SWIFT_NAME(AuthDataResult)
     @brief The signed in user.
  */
 @property(nonatomic, readonly, nullable) FIRUser *user;
-
-/** @property credential
-    @brief The updated OAuth credential after the the sign-in, link and reauthenticate action.
-    @detial This property is for OAuth sign in only.
- */
-@property(nonatomic, readonly, nullable) FIROAuthCredential *credential;
-
 
 /** @property additionalUserInfo
     @brief If available contains the additional IdP specific information about signed in user.

--- a/Firebase/Auth/Source/Public/FIROAuthCredential.h
+++ b/Firebase/Auth/Source/Public/FIROAuthCredential.h
@@ -36,13 +36,6 @@ NS_SWIFT_NAME(OAuthCredential)
  */
 @property(nonatomic, readonly, nullable) NSString *accessToken;
 
-/** @property secret
-    @brief The secret associated with this credential. This will be nil for OAuth 2.0 providers.
-    @detail OAuthCredential already exposes a providerId getter. This will help the developer
-        determine whether an access token/secret pair is needed.
- */
-@property(nonatomic, readonly, nullable) NSString *secret;
-
 /** @fn init
     @brief This class is not supposed to be instantiated directly.
  */


### PR DESCRIPTION
Removing this from the public API for the Firebase 6 release.