### PR TITLE
In case user is nil, we don't generate FIRAuthResult.

### DIFF
--- a/Firebase/Auth/Source/Auth/FIRAuth.m
+++ b/Firebase/Auth/Source/Auth/FIRAuth.m
@@ -769,19 +769,17 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                           callback:callback];
     } else {
       // Email password sign in
-      FIRAuthResultCallback completeEmailSignIn = ^(FIRUser *user, NSError *error) {
+      FIRAuthResultCallback completeEmailSignIn = ^(FIRUser *_Nullable user,
+                                                    NSError *_Nullable error) {
         if (callback) {
-          if (error) {
-            callback(nil, error);
-            return;
-          }
           FIRAdditionalUserInfo *additionalUserInfo =
               [[FIRAdditionalUserInfo alloc] initWithProviderID:FIREmailAuthProviderID
                                                         profile:nil
                                                        username:nil
                                                       isNewUser:NO];
-          FIRAuthDataResult *result = [[FIRAuthDataResult alloc] initWithUser:user
-                                                           additionalUserInfo:additionalUserInfo];
+          FIRAuthDataResult *result = user ?
+              [[FIRAuthDataResult alloc] initWithUser:user
+                                   additionalUserInfo:additionalUserInfo] : nil;
           callback(result, error);
         }
       };
@@ -913,10 +911,10 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                                     profile:nil
                                                    username:nil
                                                   isNewUser:YES];
-        FIRAuthDataResult *authDataResult =
+        FIRAuthDataResult *authDataResult = user ?
             [[FIRAuthDataResult alloc] initWithUser:user
-                                 additionalUserInfo:additionalUserInfo];
-        decoratedCallback(authDataResult, nil);
+                                 additionalUserInfo:additionalUserInfo] : nil;
+        decoratedCallback(authDataResult, error);
       }];
     }];
   });
@@ -959,10 +957,10 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                                     profile:nil
                                                    username:nil
                                                   isNewUser:YES];
-        FIRAuthDataResult *authDataResult =
+        FIRAuthDataResult *authDataResult = user ?
             [[FIRAuthDataResult alloc] initWithUser:user
-                                 additionalUserInfo:additionalUserInfo];
-        decoratedCallback(authDataResult, nil);
+                                 additionalUserInfo:additionalUserInfo] : nil;
+        decoratedCallback(authDataResult, error);
       }];
     }];
   });
@@ -1462,21 +1460,15 @@ didReceiveRemoteNotification:(NSDictionary *)userInfo {
                               anonymous:NO
                                callback:^(FIRUser *_Nullable user,
                                           NSError *_Nullable error) {
-      if (error) {
-        if (completion) {
-          completion(nil, error);
-        }
-        return;
-      }
       FIRAdditionalUserInfo *additonalUserInfo =
           [[FIRAdditionalUserInfo alloc] initWithProviderID:nil
                                                    profile:nil
                                                   username:nil
                                                  isNewUser:response.isNewUser];
-      FIRAuthDataResult *result =
-          [[FIRAuthDataResult alloc] initWithUser:user additionalUserInfo:additonalUserInfo];
+      FIRAuthDataResult *result = user ?
+          [[FIRAuthDataResult alloc] initWithUser:user additionalUserInfo:additonalUserInfo] : nil;
       if (completion) {
-        completion(result, nil);
+        completion(result, error);
       }
     }];
   }];

--- a/Firebase/Auth/Source/Auth/FIRAuth.m
+++ b/Firebase/Auth/Source/Auth/FIRAuth.m
@@ -648,6 +648,10 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                            refreshToken:response.refreshToken
                               anonymous:NO
                                callback:^(FIRUser *_Nullable user, NSError *_Nullable error) {
+      if (error && callback) {
+        callback(nil, error);
+        return;
+      }
       FIRAdditionalUserInfo *additionalUserInfo =
       [[FIRAdditionalUserInfo alloc] initWithProviderID:FIRGameCenterAuthProviderID
                                                 profile:nil
@@ -704,10 +708,8 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                            refreshToken:response.refreshToken
                               anonymous:NO
                                callback:^(FIRUser *_Nullable user, NSError *_Nullable error) {
-      if (error) {
-        if (callback) {
-          callback(nil, error);
-        }
+      if (error && callback) {
+        callback(nil, error);
         return;
       }
       FIRAdditionalUserInfo *additionalUserInfo =
@@ -772,6 +774,10 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
       FIRAuthResultCallback completeEmailSignIn = ^(FIRUser *_Nullable user,
                                                     NSError *_Nullable error) {
         if (callback) {
+          if (error) {
+            callback(nil, error);
+            return;
+          }
           FIRAdditionalUserInfo *additionalUserInfo =
               [[FIRAdditionalUserInfo alloc] initWithProviderID:FIREmailAuthProviderID
                                                         profile:nil
@@ -819,6 +825,10 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                                refreshToken:response.refreshToken
                                   anonymous:NO
                                    callback:^(FIRUser *_Nullable user, NSError *_Nullable error) {
+          if (error && callback) {
+            callback(nil, error);
+            return;
+          }
           FIRAdditionalUserInfo *additionalUserInfo =
               [[FIRAdditionalUserInfo alloc] initWithProviderID:FIRPhoneAuthProviderID
                                                         profile:nil
@@ -871,6 +881,10 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                               anonymous:NO
                                callback:^(FIRUser *_Nullable user, NSError *_Nullable error) {
       if (callback) {
+        if (error) {
+          callback(nil, error);
+          return;
+        }
         FIRAdditionalUserInfo *additionalUserInfo =
             [FIRAdditionalUserInfo userInfoWithVerifyAssertionResponse:response];
         FIROAuthCredential *updatedOAuthCredential =
@@ -906,6 +920,10 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                              refreshToken:response.refreshToken
                                 anonymous:YES
                                  callback:^(FIRUser * _Nullable user, NSError * _Nullable error) {
+        if (error) {
+          decoratedCallback(nil, error);
+          return;
+        }
         FIRAdditionalUserInfo *additionalUserInfo =
           [[FIRAdditionalUserInfo alloc] initWithProviderID:FIREmailAuthProviderID
                                                     profile:nil
@@ -952,6 +970,10 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
                              refreshToken:response.refreshToken
                                 anonymous:NO
                                  callback:^(FIRUser *_Nullable user, NSError *_Nullable error) {
+        if (error) {
+          decoratedCallback(nil, error);
+          return;
+        }
         FIRAdditionalUserInfo *additionalUserInfo =
           [[FIRAdditionalUserInfo alloc] initWithProviderID:FIREmailAuthProviderID
                                                     profile:nil
@@ -1460,6 +1482,10 @@ didReceiveRemoteNotification:(NSDictionary *)userInfo {
                               anonymous:NO
                                callback:^(FIRUser *_Nullable user,
                                           NSError *_Nullable error) {
+      if (error && completion) {
+        completion(nil, error);
+        return;
+      }
       FIRAdditionalUserInfo *additonalUserInfo =
           [[FIRAdditionalUserInfo alloc] initWithProviderID:nil
                                                    profile:nil

--- a/Firebase/Auth/Source/Auth/FIRAuthDataResult.m
+++ b/Firebase/Auth/Source/Auth/FIRAuthDataResult.m
@@ -39,12 +39,12 @@ static NSString *const kUserCodingKey = @"user";
  */
 static NSString *const kCredentialCodingKey = @"credential";
 
-- (nullable instancetype)initWithUser:(nullable FIRUser *)user
+- (nullable instancetype)initWithUser:(FIRUser *)user
                    additionalUserInfo:(nullable FIRAdditionalUserInfo *)additionalUserInfo {
   return [self initWithUser:user additionalUserInfo:additionalUserInfo credential:nil];
 }
 
-- (nullable instancetype)initWithUser:(nullable FIRUser *)user
+- (nullable instancetype)initWithUser:(FIRUser *)user
                    additionalUserInfo:(nullable FIRAdditionalUserInfo *)additionalUserInfo
                            credential:(nullable FIROAuthCredential *)credential {
   self = [super init];

--- a/Firebase/Auth/Source/Auth/FIRAuthDataResult_Internal.h
+++ b/Firebase/Auth/Source/Auth/FIRAuthDataResult_Internal.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
     @param user The signed in user reference.
     @param additionalUserInfo The additional user info if available.
  */
-- (nullable instancetype)initWithUser:(nullable FIRUser *)user
+- (nullable instancetype)initWithUser:(FIRUser *)user
                    additionalUserInfo:(nullable FIRAdditionalUserInfo *)additionalUserInfo;
 
 /** @fn initWithUser:additionalUserInfo:
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
     @param additionalUserInfo The additional user info if available.
     @param credential The updated OAuth credential if available.
  */
-- (nullable instancetype)initWithUser:(nullable FIRUser *)user
+- (nullable instancetype)initWithUser:(FIRUser *)user
                    additionalUserInfo:(nullable FIRAdditionalUserInfo *)additionalUserInfo
                            credential:(nullable FIROAuthCredential *)credential
     NS_DESIGNATED_INITIALIZER;


### PR DESCRIPTION
I investigated all FIRAuthDataResult usages in the Frebase Auth. There are two distinct ways to generate it.

Method 1:
FIRAuthResultCallback completion = ^(FIRUser * _Nullable user,
                                     NSError * _Nullable error) {
  FIRAuthDataResult *result =
    [[FIRAuthDataResult alloc] initWithUser:user
			 additionalUserInfo:info];
  callback(result, error); // Some calls callback(result, nil);
}

Method 2:
FIRAuthResultCallback completion = ^(FIRUser * _Nullable user,
                                     NSError * _Nullable error) {
  FIRAuthDataResult *result = user ?
    [[FIRAuthDataResult alloc] initWithUser:user
			 additionalUserInfo:info] : nil;
  callback(result, error);
}

I believe the second way is better for two reasons:

1. We don't need to change the public API to make user a nullable object.

2. When user is null, this means an error is occurred. So in this case, calling callback(nil, error) is more correct than calling  callback(result, nil/error) where result has an empty user.

So in this commit, we change a couple of places which uses Method 2 to follow Moethod 1, which most of the other places are using.

Hey there! So you want to contribute to a Firebase SDK?
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here.
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help
    us make Firebase APIs better, please propose your change in a feature request so that we
    can discuss it together.
