### PR TITLE
Extract secrets on PRs coming from the same repo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -313,3 +313,4 @@ jobs:
 branches:
   only:
     - master
+    - secretPresubmit

--- a/.travis.yml
+++ b/.travis.yml
@@ -313,4 +313,3 @@ jobs:
 branches:
   only:
     - master
-    - secretPresubmit

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -31,7 +31,7 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     # Set up secrets for integration tests and metrics collection. This does not work for pull
     # requests from forks. See
     # https://docs.travis-ci.com/user/pull-requests#pull-requests-and-security-restrictions
-    if [ -v $encrypted_d6a88994a5ab_key ]; then
+    if [[ -z $encrypted_d6a88994a5ab_key ]]; then
       openssl aes-256-cbc -K $encrypted_d6a88994a5ab_key -iv $encrypted_d6a88994a5ab_iv \
       -in scripts/travis-encrypted/Secrets.tar.enc \
       -out scripts/travis-encrypted/Secrets.tar -d

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -28,9 +28,10 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     bundle exec pod install --project-directory=Functions/Example
     bundle exec pod install --project-directory=GoogleUtilities/Example
 
-    # Set up GoogleService-Info.plist for Storage and Database integration tests. The decrypting
-    # is not supported for pull requests. See https://docs.travis-ci.com/user/encrypting-files/
-    if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    # Set up secrets for integration tests and metrics collection. This does not work for pull
+    # requests from forks. See
+    # https://docs.travis-ci.com/user/pull-requests#pull-requests-and-security-restrictions
+    if [ -v $encrypted_d6a88994a5ab_key ]; then
       openssl aes-256-cbc -K $encrypted_d6a88994a5ab_key -iv $encrypted_d6a88994a5ab_iv \
       -in scripts/travis-encrypted/Secrets.tar.enc \
       -out scripts/travis-encrypted/Secrets.tar -d

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -31,7 +31,7 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     # Set up secrets for integration tests and metrics collection. This does not work for pull
     # requests from forks. See
     # https://docs.travis-ci.com/user/pull-requests#pull-requests-and-security-restrictions
-    if [[ -z $encrypted_d6a88994a5ab_key ]]; then
+    if [[ ! -z $encrypted_d6a88994a5ab_key ]]; then
       openssl aes-256-cbc -K $encrypted_d6a88994a5ab_key -iv $encrypted_d6a88994a5ab_iv \
       -in scripts/travis-encrypted/Secrets.tar.enc \
       -out scripts/travis-encrypted/Secrets.tar -d


### PR DESCRIPTION
This will help prevent issues like #2920 and allows us to collect
metrics on PRs.

Travis already protects secrets from being exposed to PRs originating from forks: https://docs.travis-ci.com/user/pull-requests#pull-requests-and-security-restrictions