### PR TITLE
Fix data collection switch unit tests

### DIFF
--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -672,6 +672,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   OCMStub([configurationMock sharedInstance]).andReturn(configurationMock);
 
   // Reject any changes to Analytics when the data collection changes.
+  OCMReject([configurationMock setAnalyticsCollectionEnabled:YES persistSetting:YES]);
   OCMReject([configurationMock setAnalyticsCollectionEnabled:YES persistSetting:NO]);
   [app setDataCollectionDefaultEnabled:YES];
 

--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -676,6 +676,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   OCMReject([configurationMock setAnalyticsCollectionEnabled:YES persistSetting:NO]);
   [app setDataCollectionDefaultEnabled:YES];
 
+  OCMReject([configurationMock setAnalyticsCollectionEnabled:YES persistSetting:YES]);
   OCMReject([configurationMock setAnalyticsCollectionEnabled:NO persistSetting:NO]);
   [app setDataCollectionDefaultEnabled:NO];
 }

--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -653,7 +653,6 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 
   id configurationMock = OCMClassMock([FIRAnalyticsConfiguration class]);
   OCMStub([configurationMock sharedInstance]).andReturn(configurationMock);
-  OCMStub([configurationMock setAnalyticsCollectionEnabled:OCMOCK_ANY persistSetting:OCMOCK_ANY]);
 
   // Ensure Analytics is set after the global flag is set. It needs to
   [defaultApp setDataCollectionDefaultEnabled:YES];
@@ -671,14 +670,13 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 
   id configurationMock = OCMClassMock([FIRAnalyticsConfiguration class]);
   OCMStub([configurationMock sharedInstance]).andReturn(configurationMock);
-  OCMStub([configurationMock setAnalyticsCollectionEnabled:OCMOCK_ANY persistSetting:OCMOCK_ANY]);
 
   // Reject any changes to Analytics when the data collection changes.
+  OCMReject([configurationMock setAnalyticsCollectionEnabled:YES persistSetting:NO]);
   [app setDataCollectionDefaultEnabled:YES];
-  OCMReject([configurationMock setAnalyticsCollectionEnabled:OCMOCK_ANY persistSetting:OCMOCK_ANY]);
 
+  OCMReject([configurationMock setAnalyticsCollectionEnabled:NO persistSetting:NO]);
   [app setDataCollectionDefaultEnabled:NO];
-  OCMReject([configurationMock setAnalyticsCollectionEnabled:OCMOCK_ANY persistSetting:OCMOCK_ANY]);
 }
 
 #pragma mark - Internal Methods

--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -676,7 +676,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   OCMReject([configurationMock setAnalyticsCollectionEnabled:YES persistSetting:NO]);
   [app setDataCollectionDefaultEnabled:YES];
 
-  OCMReject([configurationMock setAnalyticsCollectionEnabled:YES persistSetting:YES]);
+  OCMReject([configurationMock setAnalyticsCollectionEnabled:NO persistSetting:YES]);
   OCMReject([configurationMock setAnalyticsCollectionEnabled:NO persistSetting:NO]);
   [app setDataCollectionDefaultEnabled:NO];
 }


### PR DESCRIPTION
OCMOCK_ANY is only for object arguments.

I verified that the tests now pass and fail along with the corresponding changes in FIRApp

This was exposed as a build warning in the macOS test build. I'm not sure why the other platforms were warning-free.