### PR TITLE
Fix cron tests by disallowing CocoaPods 1.7.0.rc.1

### DIFF
--- a/CocoapodsIntegrationTest/Gemfile
+++ b/CocoapodsIntegrationTest/Gemfile
@@ -2,4 +2,4 @@
 
 source "https://rubygems.org"
 
-gem 'cocoapods', "~>1.7.0.beta"
+gem 'cocoapods', "!=1.7.0.rc.1"


### PR DESCRIPTION
CocoaPods 1.7.0.rc.1 has a regression (https://github.com/CocoaPods/CocoaPods/issues/8765) that breaks the Database and Firestore static library builds (via leveldb-library and gRPC)