### PR TITLE
Add FirebaseCore test_spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,16 @@ jobs:
 
     - stage: test
       env:
+        - PROJECT=Core PLATFORM=iOS METHOD=pod-lib-lint
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseCore.podspec
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseCore.podspec --use-libraries
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseCore.podspec --use-modular-headers
+
+    - stage: test
+      env:
         - PROJECT=Functions PLATFORM=iOS METHOD=pod-lib-lint
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
@@ -67,7 +77,6 @@ jobs:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh GoogleUtilities.podspec
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseCore.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseAnalyticsInterop.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseAuth.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseAuthInterop.podspec
@@ -98,7 +107,6 @@ jobs:
         - ./scripts/install_prereqs.sh
       script:
         - travis_retry ./scripts/pod_lib_lint.sh GoogleUtilities.podspec --use-libraries
-        - travis_retry ./scripts/pod_lib_lint.sh FirebaseCore.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.sh FirebaseAnalyticsInterop.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.sh FirebaseAuth.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.sh FirebaseAuthInterop.podspec --use-libraries

--- a/Example/Core/Tests/FIROptionsTest.m
+++ b/Example/Core/Tests/FIROptionsTest.m
@@ -98,10 +98,13 @@ extern NSString *const kFIRLibraryVersionID;
 }
 
 - (void)testInitWithContentsOfFile {
-  // Use bundleForClass to support GoogleService-Info.plist being in either the main bundle
-  // or the test target's bundle.
-  NSBundle *bundle = [NSBundle bundleForClass:[self class]];
-  NSString *filePath = [bundle pathForResource:@"GoogleService-Info" ofType:@"plist"];
+  NSString *filePath = [[NSBundle mainBundle] pathForResource:@"GoogleService-Info"
+                           -                                                       ofType:@"plist"];
+  if (filePath == nil) {
+    // Use bundleForClass to allow GoogleService-Info.plist to be in the test target's bundle.
+    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    filePath = [bundle pathForResource:@"GoogleService-Info" ofType:@"plist"];
+  }
   FIROptions *options = [[FIROptions alloc] initWithContentsOfFile:filePath];
   [self assertOptionsMatchDefaults:options andProjectID:YES];
   XCTAssertNil(options.deepLinkURLScheme);

--- a/Example/Core/Tests/FIROptionsTest.m
+++ b/Example/Core/Tests/FIROptionsTest.m
@@ -98,8 +98,10 @@ extern NSString *const kFIRLibraryVersionID;
 }
 
 - (void)testInitWithContentsOfFile {
-  NSString *filePath = [[NSBundle mainBundle] pathForResource:@"GoogleService-Info"
-                                                       ofType:@"plist"];
+  // Use bundleForClass to support GoogleService-Info.plist being in either the main bundle
+  // or the test target's bundle.
+  NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+  NSString *filePath = [bundle pathForResource:@"GoogleService-Info" ofType:@"plist"];
   FIROptions *options = [[FIROptions alloc] initWithContentsOfFile:filePath];
   [self assertOptionsMatchDefaults:options andProjectID:YES];
   XCTAssertNil(options.deepLinkURLScheme);

--- a/Example/Core/Tests/FIROptionsTest.m
+++ b/Example/Core/Tests/FIROptionsTest.m
@@ -99,7 +99,7 @@ extern NSString *const kFIRLibraryVersionID;
 
 - (void)testInitWithContentsOfFile {
   NSString *filePath = [[NSBundle mainBundle] pathForResource:@"GoogleService-Info"
-                           -                                                       ofType:@"plist"];
+                                                       ofType:@"plist"];
   if (filePath == nil) {
     // Use bundleForClass to allow GoogleService-Info.plist to be in the test target's bundle.
     NSBundle *bundle = [NSBundle bundleForClass:[self class]];

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -36,4 +36,10 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
       'FIRCore_VERSION=' + s.version.to_s + ' Firebase_VERSION=5.20.0',
     'OTHER_CFLAGS' => '-fno-autolink'
   }
+  s.test_spec 'unit' do |unit_tests|
+    unit_tests.source_files = 'Example/Core/Tests/**/*.[mh]'
+    unit_tests.requires_app_host = true
+    unit_tests.dependency 'OCMock'
+    unit_tests.resources = 'Example/Core/App/GoogleService-Info.plist'
+  end
 end

--- a/scripts/if_changed.sh
+++ b/scripts/if_changed.sh
@@ -46,10 +46,10 @@ elif [[ -z "$TRAVIS_COMMIT_RANGE" ]]; then
 else
   case "$PROJECT-$METHOD" in
     Firebase-pod-lib-lint) # Combines Firebase-* and InAppMessaging*
-      check_changes '^(Firebase/Auth|Firebase/Core|Firebase/Database|Firebase/DynamicLinks|'\
+      check_changes '^(Firebase/Auth|Firebase/Database|Firebase/DynamicLinks|'\
 'Firebase/Messaging|Firebase/Storage|GoogleUtilities|Interop|Example|'\
 'FirebaseAnalyticsIntop.podspec|FirebaseAuth.podspec|FirebaseAuthInterop.podspec|'\
-'FirebaseCore.podspec|FirebaseDatabase.podspec|FirebaseDynamicLinks.podspec|'\
+'FirebaseDatabase.podspec|FirebaseDynamicLinks.podspec|'\
 'FirebaseMessaging.podspec|FirebaseStorage.podspec|'\
 'FirebaseStorage.podspec|Firebase/InAppMessagingDisplay|InAppMessagingDisplay|'\
 'InAppMessaging|Firebase/InAppMessaging|'\
@@ -64,6 +64,10 @@ else
 'FirebaseCore.podspec|FirebaseDatabase.podspec|FirebaseDynamicLinks.podspec|'\
 'FirebaseMessaging.podspec|FirebaseStorage.podspec|'\
 'FirebaseStorage.podspec|Firebase/InstanceID|FirebaseInstanceID.podspec)'
+      ;;
+
+    Core-*)
+      check_changes '^(Firebase/Core|GoogleUtilities|FirebaseCore.podspec)'
       ;;
 
     Functions-*)


### PR DESCRIPTION
FirebaseCore now has a test_spec and supports working with `pod gen`.  Default instructions will be updated once other pods are updated and https://github.com/square/cocoapods-generate/pull/19 lands.

`pod lib lint` runs into https://github.com/CocoaPods/CocoaPods/issues/8173, but it doesn't prevent its success.