### PR TITLE
Restore cmake build inadvertently deleted in #2482

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -165,9 +165,9 @@ jobs:
       env:
         - PROJECT=Firestore PLATFORM=macOS METHOD=cmake
       before_install:
-        - ./scripts/if_cron.sh ./scripts/install_prereqs.sh
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
-        - travis_retry ./scripts/if_cron.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
+        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
 
     # Test Firestore on Xcode 8 to use old llvm to ensure C++ portability.
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -161,6 +161,13 @@ jobs:
         - travis_retry ./scripts/build.sh $PROJECT $PLATFORM $METHOD
 
     # Alternative platforms
+    - stage: test
+      env:
+        - PROJECT=Firestore PLATFORM=macOS METHOD=cmake
+      before_install:
+        - ./scripts/if_cron.sh ./scripts/install_prereqs.sh
+      script:
+        - travis_retry ./scripts/if_cron.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
 
     # Test Firestore on Xcode 8 to use old llvm to ensure C++ portability.
     - stage: test


### PR DESCRIPTION
The plain travis cmake build has been deleted since #2482 and we missed that adding test_specs to FirebaseCore in #2943 broke them.

@wilhuff Feel free to merge, copy, discard or whatever works best with the cmake fixes you're doing.