### PR TITLE
Stop pushing json podspecs to cpdc

### DIFF
--- a/Releases/update-versions.py
+++ b/Releases/update-versions.py
@@ -204,10 +204,8 @@ def PushPodspecs(version_data):
       warnings_ok = ''
 
     podspec = '{}.podspec'.format(pod)
-    json = os.path.join(tmp_dir, '{}.json'.format(podspec))
-    LogOrRun('pod ipc spec {} > {}'.format(podspec, json))
     LogOrRun('pod repo push --skip-tests {} {}{}'.format(GetCpdcInternal(),
-                                                         json, warnings_ok))
+                                                         podspec, warnings_ok))
   os.system('rm -rf {}'.format(tmp_dir))
 
 


### PR DESCRIPTION
We don't remember why json podspecs were needed in cpdc and they expose a bug with CocoaPods 1.6.1 running pod spec lint on test specs.