### PR TITLE
Disable data protection when opening the Rmq2PersistentStore

### DIFF
--- a/Firebase/Messaging/FIRMessagingRmq2PersistentStore.m
+++ b/Firebase/Messaging/FIRMessagingRmq2PersistentStore.m
@@ -279,7 +279,10 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
   BOOL didOpenDatabase = YES;
   if (![fileManager fileExistsAtPath:path]) {
     // We've to separate between different versions here because of backwards compatbility issues.
-    int result = sqlite3_open([path UTF8String], &_database);
+    int result = sqlite3_open_v2([path UTF8String],
+                                 &_database,
+                                 SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE,
+                                 NULL);
     if (result != SQLITE_OK) {
       NSString *errorString = FIRMessagingStringFromSQLiteResult(result);
       NSString *errorMessage =
@@ -299,7 +302,10 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
     [self createTableWithName:kTableS2DRmqIds command:kCreateTableS2DRmqIds];
   } else {
     // Calling sqlite3_open should create the database, since the file doesn't exist.
-    int result = sqlite3_open([path UTF8String], &_database);
+    int result = sqlite3_open_v2([path UTF8String],
+                                 &_database,
+                                 SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE,
+                                 NULL);
     if (result != SQLITE_OK) {
       NSString *errorString = FIRMessagingStringFromSQLiteResult(result);
       NSString *errorMessage =


### PR DESCRIPTION
### Discussion

Other issue that have touched this is #401.

The error shown in  my logs is:

```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Could not create RMQ database at path /var/mobile/Containers/Data/Application/F0DD20A3-DA44-4033-8736-A371A2725EC1/Library/Application Support/Google/FirebaseMessaging/rmq2.sqlite, error: 23 - authorization denied'
*** First throw call stack:
(0x1e1a03758 0x1e0c0bd00 0x1e1919434 0x1e23f3754 0x102e05da8 0x102e04460 0x102e0968c 0x102ddd594 0x102ddce84 0x102ddc364 0x1e14158f4 0x1e1417788 0x102ddc2d0 0x102dba238 0x102dba0f0 0x102db9be8 0x102db99cc 0x102da0d94 0x102d9f3f4 0x102d9ef50 0x102d9ee7c 0x1032b66cc 0x1032b6510 0x102cb22d8 0x102cbb9cc 0x102cbdbc8 0x20e8db0c8 0x20e8dc890 0x20e8e22b0 0x20e175e20 0x20e17e7e8 0x20e175a88 0x20e1763a4 0x20e1745ec 0x20e1742b0 0x20e178fd0 0x20e179e1c 0x20e178e84 0x20e17de68 0x20e8e07ec 0x20e4c3648 0x1e43c13a8 0x1e43cb6e4 0x1e43cae34 0x1e14158f4 0x1e1418ecc 0x1e43fe218 0x1e43fde94 0x1e43fe490 0x1e1993954 0x1e19938d0 0x1e199318c 0x1e198de60 0x1e198d764 0x1e3bc9dd4 0x20e8e400c 0x102cbe<…>
```

The reproduction of this issue is interesting and requires quite a few steps. The gist is that the Rmq2 persistent store can not be opened when the phone has a passcode AND is locked AND the App is woken up AND it somehow touches the firebase messaging code.

In our case this was reproduced this way:
 - We have a Flutter App, which uses a plugin architecture. The `firebase_messaging` plugin will be instantiated when the App is started. By nature, all project plugins will be instantiated in ALL Isolates, therefore the FB messaging plugin will be started as well.
 - The App connects to a MFi certified device, which means: When the App is dead and the screen is locked, then the App will be woken up, but starts in *background*, when the MFi device is connected.
 - Once the App has been woken up, the plugin as above will be instantiated and tries to create access to the sqlite database, which fails with error code 23.

The folks over at FMDB have seen this before:
 - https://github.com/ccgus/fmdb/issues/262

And the Apple Mailing lists have this Gem:
 - https://lists.apple.com/archives/cocoa-dev/2012/Aug/msg00527.html

Once I patched my local firebase messaging plugin with this PR, the errors went away.

This PR changes the Rmq database protection to not-protected. As all App data is sandboxed anyway, I think this may not have negative security implications.