### PR TITLE
CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@
 
 cmake_minimum_required(VERSION 2.8.11)
 
+# Disallow mixing keyword and non-keyword forms of target_link_libraries
+if(POLICY CMP0023)
+  cmake_policy(SET CMP0023 NEW)
+endif()
+
 # Report AppleClang separately from Clang. Their version numbers are different.
 # https://cmake.org/cmake/help/v3.0/policy/CMP0025.html
 if(POLICY CMP0025)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,14 @@ if(POLICY CMP0042)
   cmake_policy(SET CMP0042 NEW)
 endif()
 
+# Generate Ninja phony rules for unknown dependencies in the build tree and
+# don't complain about doing so. Our dependencies aren't good about declaring
+# BYPRODUCTS and we mix them all into a single uber build so we can't enable
+# this policy until all dependencies are capable of doing so.
+if(POLICY CMP0058)
+  cmake_policy(SET CMP0058 OLD)
+endif()
+
 # Defer enabling any languages.
 project(firebase NONE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,11 @@ if(POLICY CMP0025)
   cmake_policy(SET CMP0025 NEW)
 endif()
 
+# Enable rpath by default
+if(POLICY CMP0042)
+  cmake_policy(SET CMP0042 NEW)
+endif()
+
 # Defer enabling any languages.
 project(firebase NONE)
 

--- a/Firestore/core/test/firebase/firestore/objc/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/objc/CMakeLists.txt
@@ -23,7 +23,7 @@ cc_test(
 
 if(APPLE)
   target_sources(
-    firebase_firestore_objc_test PUBLIC
+    firebase_firestore_objc_test PRIVATE
     objc_class_test.cc
     objc_class_test_helper.h
     objc_class_test_helper.mm

--- a/cmake/cc_rules.cmake
+++ b/cmake/cc_rules.cmake
@@ -130,7 +130,7 @@ function(cc_binary name)
   add_objc_flags(${name} ${ccb_SOURCES})
 
   target_include_directories(${name} PUBLIC ${FIREBASE_SOURCE_DIR})
-  target_link_libraries(${name} ${ccb_DEPENDS})
+  target_link_libraries(${name} PRIVATE ${ccb_DEPENDS})
 
   if(ccb_EXCLUDE_FROM_ALL)
     set_property(
@@ -160,7 +160,7 @@ function(cc_test name)
   add_test(${name} ${name})
 
   target_include_directories(${name} PUBLIC ${FIREBASE_SOURCE_DIR})
-  target_link_libraries(${name} ${cct_DEPENDS})
+  target_link_libraries(${name} PRIVATE ${cct_DEPENDS})
 endfunction()
 
 # cc_fuzz_test(

--- a/cmake/cc_rules.cmake
+++ b/cmake/cc_rules.cmake
@@ -129,7 +129,7 @@ function(cc_binary name)
   add_executable(${name} ${sources})
   add_objc_flags(${name} ${ccb_SOURCES})
 
-  target_include_directories(${name} PUBLIC ${FIREBASE_SOURCE_DIR})
+  target_include_directories(${name} PRIVATE ${FIREBASE_SOURCE_DIR})
   target_link_libraries(${name} PRIVATE ${ccb_DEPENDS})
 
   if(ccb_EXCLUDE_FROM_ALL)
@@ -159,7 +159,7 @@ function(cc_test name)
   add_objc_flags(${name} ${cct_SOURCES})
   add_test(${name} ${name})
 
-  target_include_directories(${name} PUBLIC ${FIREBASE_SOURCE_DIR})
+  target_include_directories(${name} PRIVATE ${FIREBASE_SOURCE_DIR})
   target_link_libraries(${name} PRIVATE ${cct_DEPENDS})
 endfunction()
 

--- a/cmake/cc_rules.cmake
+++ b/cmake/cc_rules.cmake
@@ -128,7 +128,6 @@ function(cc_binary name)
   maybe_remove_objc_sources(sources ${ccb_SOURCES})
   add_executable(${name} ${sources})
   add_objc_flags(${name} ${ccb_SOURCES})
-  add_test(${name} ${name})
 
   target_include_directories(${name} PUBLIC ${FIREBASE_SOURCE_DIR})
   target_link_libraries(${name} ${ccb_DEPENDS})


### PR DESCRIPTION
Fix a bunch of policy warnings (and make them errors where possible).

Also make `cc_binary` not add its binaries as tests. The benefit of this is that benchmarks won't run (though they will still build).