### PR TITLE
Fix check script for non-master branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -332,3 +332,5 @@ jobs:
 branches:
   only:
     - master
+    - pb-fix-check-script
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -332,3 +332,4 @@ jobs:
 branches:
   only:
     - master
+    - pb-fix-check-script

--- a/.travis.yml
+++ b/.travis.yml
@@ -333,4 +333,3 @@ branches:
   only:
     - master
     - pb-fix-check-script
-  

--- a/.travis.yml
+++ b/.travis.yml
@@ -332,4 +332,3 @@ jobs:
 branches:
   only:
     - master
-    - pb-fix-check-script

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -76,6 +76,7 @@ EOF
 }
 
 set -euo pipefail
+set -x
 unset CDPATH
 
 # Change to the top-directory of the working tree

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -75,7 +75,7 @@ EXAMPLES:
 EOF
 }
 
-set -euo pipefail
+set -x
 unset CDPATH
 
 # Change to the top-directory of the working tree
@@ -84,7 +84,7 @@ cd "${top_dir}"
 
 ALLOW_DIRTY=false
 COMMIT_METHOD="none"
-START_REVISION="origin/master"
+START_REVISION="master"
 TEST_ONLY=false
 
 while [[ $# -gt 0 ]]; do

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -141,6 +141,10 @@ if [[ "${ALLOW_DIRTY}" == true && "${COMMIT_METHOD}" == "message" ]]; then
   exit 1
 fi
 
+# Prevent travis failures like
+# fatal: ambiguous argument 'master': unknown revision or path not in the working tree.
+git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
+
 if ! git diff-index --quiet HEAD --; then
   if [[ "${ALLOW_DIRTY}" != true ]]; then
     echo "You have local changes that could be overwritten by this script."

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -84,7 +84,7 @@ cd "${top_dir}"
 
 ALLOW_DIRTY=false
 COMMIT_METHOD="none"
-START_REVISION="master"
+START_REVISION="origin/master"
 TEST_ONLY=false
 
 while [[ $# -gt 0 ]]; do

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -75,7 +75,7 @@ EXAMPLES:
 EOF
 }
 
-set -x
+set -euo pipefail
 unset CDPATH
 
 # Change to the top-directory of the working tree


### PR DESCRIPTION
Fix the the check.sh script failing on non-master branches with

```
$ ./scripts/check.sh --test-only $TRAVIS_COMMIT_RANGE
fatal: ambiguous argument 'master': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
The command "./scripts/check.sh --test-only $TRAVIS_COMMIT_RANGE" exited with 128.
```

From https://travis-ci.org/firebase/firebase-ios-sdk/jobs/530114948

Verified fix in https://travis-ci.org/firebase/firebase-ios-sdk/jobs/530319920

Thanks to https://stackoverflow.com/a/53771249/556617