### PR TITLE
Expand the upload package capabilities

### DIFF
--- a/GoogleDataTransport/GDTLibrary/GDTEvent.m
+++ b/GoogleDataTransport/GDTLibrary/GDTEvent.m
@@ -53,6 +53,10 @@
   return mappingIDHash ^ _target ^ dataObjectTransportBytesHash ^ _qosTier ^ timeHash;
 }
 
+- (BOOL)isEqual:(id)object {
+  return [self hash] == [object hash];
+}
+
 - (void)setDataObject:(id<GDTEventDataObject>)dataObject {
   // If you're looking here because of a performance issue in -transportBytes slowing the assignment
   // of -dataObject, one way to address this is to add a queue to this class,

--- a/GoogleDataTransport/GDTLibrary/GDTUploadPackage.m
+++ b/GoogleDataTransport/GDTLibrary/GDTUploadPackage.m
@@ -69,18 +69,18 @@
 }
 
 - (void)completeDelivery {
-  if (!_isHandled && _handler && [_handler respondsToSelector:@selector(packageDelivered:)]) {
+  if (!_isHandled && _handler && [_handler respondsToSelector:@selector(packageDelivered:successful:)]) {
     [_expirationTimer invalidate];
     _isHandled = YES;
-    [_handler packageDelivered:self];
+    [_handler packageDelivered:self successful:YES];
   }
 }
 
 - (void)retryDeliveryInTheFuture {
-  if (!_isHandled && _handler && [_handler respondsToSelector:@selector(packageDeliveryFailed:)]) {
+  if (!_isHandled && _handler && [_handler respondsToSelector:@selector(packageDelivered:successful:)]) {
     [_expirationTimer invalidate];
     _isHandled = YES;
-    [_handler packageDeliveryFailed:self];
+    [_handler packageDelivered:self successful:NO];
   }
 }
 

--- a/GoogleDataTransport/GDTLibrary/GDTUploadPackage.m
+++ b/GoogleDataTransport/GDTLibrary/GDTUploadPackage.m
@@ -35,7 +35,11 @@
     _target = target;
     _storage = [GDTStorage sharedInstance];
     _deliverByTime = [GDTClock clockSnapshotInTheFuture:180000];
-    _expirationTimer = [NSTimer scheduledTimerWithTimeInterval:5.0 target:self selector:@selector(checkIfPackageIsExpired:) userInfo:nil repeats:YES];
+    _expirationTimer = [NSTimer scheduledTimerWithTimeInterval:5.0
+                                                        target:self
+                                                      selector:@selector(checkIfPackageIsExpired:)
+                                                      userInfo:nil
+                                                       repeats:YES];
   }
   return self;
 }

--- a/GoogleDataTransport/GDTLibrary/GDTUploadPackage.m
+++ b/GoogleDataTransport/GDTLibrary/GDTUploadPackage.m
@@ -16,21 +16,32 @@
 
 #import <GoogleDataTransport/GDTUploadPackage.h>
 
+#import <GoogleDataTransport/GDTClock.h>
+
 #import "GDTLibrary/Private/GDTStorage_Private.h"
 #import "GDTLibrary/Private/GDTUploadPackage_Private.h"
 
-@implementation GDTUploadPackage
+@implementation GDTUploadPackage {
+  /** If YES, is being handled by the handler. */
+  BOOL _isHandled;
 
-- (instancetype)init {
+  /** A timer that will regularly check to see whether this package has expired or not. */
+  NSTimer *_expirationTimer;
+}
+
+- (instancetype)initWithTarget:(GDTTarget)target {
   self = [super init];
   if (self) {
+    _target = target;
     _storage = [GDTStorage sharedInstance];
+    _deliverByTime = [GDTClock clockSnapshotInTheFuture:180000];
+    _expirationTimer = [NSTimer scheduledTimerWithTimeInterval:5.0 target:self selector:@selector(checkIfPackageIsExpired:) userInfo:nil repeats:YES];
   }
   return self;
 }
 
 - (instancetype)copy {
-  GDTUploadPackage *newPackage = [[GDTUploadPackage alloc] init];
+  GDTUploadPackage *newPackage = [[GDTUploadPackage alloc] initWithTarget:_target];
   newPackage->_events = [_events copy];
   return newPackage;
 }
@@ -43,10 +54,82 @@
   return [self hash] == [object hash];
 }
 
+- (void)dealloc {
+  [_expirationTimer invalidate];
+}
+
 - (void)setStorage:(GDTStorage *)storage {
   if (storage != _storage) {
     _storage = storage;
   }
+}
+
+- (void)completeDelivery {
+  if (!_isHandled && _handler && [_handler respondsToSelector:@selector(packageDelivered:)]) {
+    [_expirationTimer invalidate];
+    _isHandled = YES;
+    [_handler packageDelivered:self];
+  }
+}
+
+- (void)retryDeliveryInTheFuture {
+  if (!_isHandled && _handler && [_handler respondsToSelector:@selector(packageDeliveryFailed:)]) {
+    [_expirationTimer invalidate];
+    _isHandled = YES;
+    [_handler packageDeliveryFailed:self];
+  }
+}
+
+- (void)checkIfPackageIsExpired:(NSTimer *)timer {
+  if ([[GDTClock snapshot] isAfter:_deliverByTime]) {
+    if (_handler && [_handler respondsToSelector:@selector(packageExpired:)]) {
+      _isHandled = YES;
+      [_expirationTimer invalidate];
+      [_handler packageExpired:self];
+    }
+  }
+}
+
+#pragma mark - NSSecureCoding
+
+/** The keyed archiver key for the events property. */
+static NSString *const kEventsKey = @"GDTUploadPackageEventsKey";
+
+/** The keyed archiver key for the _isHandled property. */
+static NSString *const kDeliverByTimeKey = @"GDTUploadPackageDeliveryByTimeKey";
+
+/** The keyed archiver key for the _isHandled ivar. */
+static NSString *const kIsHandledKey = @"GDTUploadPackageIsHandledKey";
+
+/** The keyed archiver key for the handler property. */
+static NSString *const kHandlerKey = @"GDTUploadPackageHandlerKey";
+
+/** The keyed archiver key for the target property. */
+static NSString *const kTargetKey = @"GDTUploadPackageTargetKey";
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (void)encodeWithCoder:(nonnull NSCoder *)aCoder {
+  [aCoder encodeObject:_events forKey:kEventsKey];
+  [aCoder encodeObject:_deliverByTime forKey:kDeliverByTimeKey];
+  [aCoder encodeBool:_isHandled forKey:kIsHandledKey];
+  [aCoder encodeObject:_handler forKey:kHandlerKey];
+  [aCoder encodeInteger:_target forKey:kTargetKey];
+}
+
+- (nullable instancetype)initWithCoder:(nonnull NSCoder *)aDecoder {
+  GDTTarget target = [aDecoder decodeIntegerForKey:kTargetKey];
+  self = [self initWithTarget:target];
+  if (self) {
+    _events = [aDecoder decodeObjectOfClass:[NSSet class] forKey:kEventsKey];
+    _deliverByTime = [aDecoder decodeObjectOfClass:[GDTClock class] forKey:kDeliverByTimeKey];
+    _isHandled = [aDecoder decodeBoolForKey:kIsHandledKey];
+    // Isn't technically NSSecureCoding, because we don't know the class of this object.
+    _handler = [aDecoder decodeObjectForKey:kHandlerKey];
+  }
+  return self;
 }
 
 @end

--- a/GoogleDataTransport/GDTLibrary/GDTUploadPackage.m
+++ b/GoogleDataTransport/GDTLibrary/GDTUploadPackage.m
@@ -69,7 +69,8 @@
 }
 
 - (void)completeDelivery {
-  if (!_isHandled && _handler && [_handler respondsToSelector:@selector(packageDelivered:successful:)]) {
+  if (!_isHandled && _handler &&
+      [_handler respondsToSelector:@selector(packageDelivered:successful:)]) {
     [_expirationTimer invalidate];
     _isHandled = YES;
     [_handler packageDelivered:self successful:YES];
@@ -77,7 +78,8 @@
 }
 
 - (void)retryDeliveryInTheFuture {
-  if (!_isHandled && _handler && [_handler respondsToSelector:@selector(packageDelivered:successful:)]) {
+  if (!_isHandled && _handler &&
+      [_handler respondsToSelector:@selector(packageDelivered:successful:)]) {
     [_expirationTimer invalidate];
     _isHandled = YES;
     [_handler packageDelivered:self successful:NO];

--- a/GoogleDataTransport/GDTLibrary/Private/GDTUploadPackage_Private.h
+++ b/GoogleDataTransport/GDTLibrary/Private/GDTUploadPackage_Private.h
@@ -23,4 +23,7 @@
 /** The storage object this upload package will use to resolve event hashes to files. */
 @property(nonatomic) GDTStorage *storage;
 
+/** A handler that will receive callbacks for certain events. */
+@property(nonatomic) id<NSSecureCoding, GDTUploadPackageProtocol> handler;
+
 @end

--- a/GoogleDataTransport/GDTLibrary/Public/GDTUploadPackage.h
+++ b/GoogleDataTransport/GDTLibrary/Public/GDTUploadPackage.h
@@ -16,12 +16,71 @@
 
 #import <Foundation/Foundation.h>
 
+#import <GoogleDataTransport/GDTTargets.h>
+
+@class GDTClock;
 @class GDTStoredEvent;
+@class GDTUploadPackage;
+
+/** A protocol that allows a handler to respond to package lifecycle events. */
+@protocol GDTUploadPackageProtocol <NSObject>
+
+@optional
+
+/** Indicates that the package has expired.
+ *
+ * @note Package expiration will only be checked every 5 seconds.
+ *
+ * @param package The package that has expired.
+ */
+- (void)packageExpired:(GDTUploadPackage *)package;
+
+/** Indicates that the package was successfully delivered.
+ *
+ * @param package The package that was delivered.
+ */
+- (void)packageDelivered:(GDTUploadPackage *)package;
+
+/** Indicates that delivery of the package failed.
+ *
+ * @param package The package that was not delivered.
+ */
+- (void)packageDeliveryFailed:(GDTUploadPackage *)package;
+
+@end
 
 /** This class is a container that's handed off to uploaders. */
-@interface GDTUploadPackage : NSObject
+@interface GDTUploadPackage : NSObject <NSSecureCoding>
 
 /** The set of stored events in this upload package. */
 @property(nonatomic) NSSet<GDTStoredEvent *> *events;
+
+/** The expiration time. If [[GDTClock snapshot] isAfter:deliverByTime] this package has expired.
+ *
+ * @note By default, the expiration time will be 3 minutes from creation.
+ */
+@property(nonatomic) GDTClock *deliverByTime;
+
+/** The target of this package. */
+@property(nonatomic, readonly) GDTTarget target;
+
+/** Initializes a package instance.
+ *
+ * @param target The target/destination of this package.
+ * @return An instance of this class.
+ */
+- (instancetype)initWithTarget:(GDTTarget)target NS_DESIGNATED_INITIALIZER;
+
+// Please use the designated initializer.
+- (instancetype)init NS_UNAVAILABLE;
+
+/** Completes delivery of the package.
+ *
+ * @note This *needs* to be called by an uploader for the package to not expire.
+ */
+- (void)completeDelivery;
+
+/** Sends the package back, indicating that delivery should be attempted again in the future. */
+- (void)retryDeliveryInTheFuture;
 
 @end

--- a/GoogleDataTransport/GDTLibrary/Public/GDTUploadPackage.h
+++ b/GoogleDataTransport/GDTLibrary/Public/GDTUploadPackage.h
@@ -39,13 +39,7 @@
  *
  * @param package The package that was delivered.
  */
-- (void)packageDelivered:(GDTUploadPackage *)package;
-
-/** Indicates that delivery of the package failed.
- *
- * @param package The package that was not delivered.
- */
-- (void)packageDeliveryFailed:(GDTUploadPackage *)package;
+- (void)packageDelivered:(GDTUploadPackage *)package successful:(BOOL)successful;
 
 @end
 

--- a/GoogleDataTransport/GDTLibrary/Public/GDTUploader.h
+++ b/GoogleDataTransport/GDTLibrary/Public/GDTUploader.h
@@ -19,8 +19,7 @@
 #import <GoogleDataTransport/GDTClock.h>
 #import <GoogleDataTransport/GDTLifecycle.h>
 #import <GoogleDataTransport/GDTTargets.h>
-
-@class GDTUploadPackage;
+#import <GoogleDataTransport/GDTUploadPackage.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/GoogleDataTransport/GDTTests/Integration/Helpers/GDTIntegrationTestPrioritizer.m
+++ b/GoogleDataTransport/GDTTests/Integration/Helpers/GDTIntegrationTestPrioritizer.m
@@ -69,7 +69,7 @@
 
 - (GDTUploadPackage *)uploadPackageWithConditions:(GDTUploadConditions)conditions {
   __block GDTIntegrationTestUploadPackage *uploadPackage =
-      [[GDTIntegrationTestUploadPackage alloc] init];
+      [[GDTIntegrationTestUploadPackage alloc] initWithTarget:kGDTIntegrationTestTarget];
   dispatch_sync(_queue, ^{
     if ((conditions & GDTUploadConditionWifiData) == GDTUploadConditionWifiData) {
       uploadPackage.events = [self.wifiOnlyEvents setByAddingObjectsFromSet:self.nonWifiEvents];

--- a/GoogleDataTransport/GDTTests/Lifecycle/Helpers/GDTLifecycleTestPrioritizer.m
+++ b/GoogleDataTransport/GDTTests/Lifecycle/Helpers/GDTLifecycleTestPrioritizer.m
@@ -55,7 +55,7 @@
 }
 
 - (GDTUploadPackage *)uploadPackageWithConditions:(GDTUploadConditions)conditions {
-  __block GDTUploadPackage *uploadPackage = [[GDTUploadPackage alloc] init];
+  __block GDTUploadPackage *uploadPackage = [[GDTUploadPackage alloc] initWithTarget:kGDTTargetTest];
   dispatch_sync(_queue, ^{
     uploadPackage.events = self.events;
   });

--- a/GoogleDataTransport/GDTTests/Lifecycle/Helpers/GDTLifecycleTestPrioritizer.m
+++ b/GoogleDataTransport/GDTTests/Lifecycle/Helpers/GDTLifecycleTestPrioritizer.m
@@ -55,7 +55,8 @@
 }
 
 - (GDTUploadPackage *)uploadPackageWithConditions:(GDTUploadConditions)conditions {
-  __block GDTUploadPackage *uploadPackage = [[GDTUploadPackage alloc] initWithTarget:kGDTTargetTest];
+  __block GDTUploadPackage *uploadPackage =
+      [[GDTUploadPackage alloc] initWithTarget:kGDTTargetTest];
   dispatch_sync(_queue, ^{
     uploadPackage.events = self.events;
   });

--- a/GoogleDataTransport/GDTTests/Unit/GDTUploadPackageTest.m
+++ b/GoogleDataTransport/GDTTests/Unit/GDTUploadPackageTest.m
@@ -24,11 +24,11 @@
 
 @interface GDTUploadPackageTest : GDTTestCase <NSSecureCoding, GDTUploadPackageProtocol>
 
-/** If YES, -packageDelivered: was called. */
-@property(nonatomic) BOOL packageDeliveredCalled;
+/** If YES, -packageDelivered:successful was called. */
+@property(nonatomic) BOOL packageDeliveredCalledSuccessful;
 
 /** If YES, -packageDeliveryFailed: was called. */
-@property(nonatomic) BOOL packageDeliveryFailedCalled;
+@property(nonatomic) BOOL packageDeliveredCalledFailed;
 
 /** If YES, -packageExpired: was called. */
 @property(nonatomic) BOOL packageExpiredCalled;
@@ -40,16 +40,16 @@
 - (void)setUp {
   [super setUp];
   _packageExpiredCalled = NO;
-  _packageDeliveryFailedCalled = NO;
-  _packageDeliveredCalled = NO;
+  _packageDeliveredCalledFailed = NO;
+  _packageDeliveredCalledSuccessful = NO;
 }
 
-- (void)packageDelivered:(GDTUploadPackage *)package {
-  self.packageDeliveredCalled = YES;
-}
-
-- (void)packageDeliveryFailed:(GDTUploadPackage *)package {
-  self.packageDeliveryFailedCalled = YES;
+- (void)packageDelivered:(GDTUploadPackage *)package successful:(BOOL)successful {
+  if (successful) {
+    self.packageDeliveredCalledSuccessful = YES;
+  } else {
+    self.packageDeliveredCalledFailed = YES;
+  }
 }
 
 - (void)packageExpired:(GDTUploadPackage *)package {

--- a/GoogleDataTransport/GDTTests/Unit/GDTUploadPackageTest.m
+++ b/GoogleDataTransport/GDTTests/Unit/GDTUploadPackageTest.m
@@ -16,8 +16,8 @@
 
 #import "GDTTests/Unit/GDTTestCase.h"
 
-#import <GoogleDataTransport/GDTUploadPackage.h>
 #import <GoogleDataTransport/GDTClock.h>
+#import <GoogleDataTransport/GDTUploadPackage.h>
 
 #import "GDTLibrary/Private/GDTUploadPackage_Private.h"
 #import "GDTTests/Unit/Helpers/GDTEventGenerator.h"
@@ -116,10 +116,11 @@
   GDTUploadPackage *uploadPackage = [[GDTUploadPackage alloc] initWithTarget:kGDTTargetTest];
   uploadPackage.deliverByTime = [GDTClock clockSnapshotInTheFuture:1000];
   uploadPackage.handler = self;
-  NSPredicate *pred = [NSPredicate predicateWithBlock:^BOOL(id _Nullable evaluatedObject,
-                                        NSDictionary<NSString *, id> *_Nullable bindings) {
-    return self.packageExpiredCalled;
-  }];
+  NSPredicate *pred =
+      [NSPredicate predicateWithBlock:^BOOL(id _Nullable evaluatedObject,
+                                            NSDictionary<NSString *, id> *_Nullable bindings) {
+        return self.packageExpiredCalled;
+      }];
   XCTestExpectation *expectation = [self expectationForPredicate:pred
                                              evaluatedWithObject:self
                                                          handler:nil];

--- a/GoogleDataTransport/GDTTests/Unit/Helpers/GDTTestPrioritizer.m
+++ b/GoogleDataTransport/GDTTests/Unit/Helpers/GDTTestPrioritizer.m
@@ -23,7 +23,7 @@
 - (instancetype)init {
   self = [super init];
   if (self) {
-    _uploadPackage = [[GDTTestUploadPackage alloc] init];
+    _uploadPackage = [[GDTTestUploadPackage alloc] initWithTarget:kGDTTargetTest];
   }
   return self;
 }

--- a/GoogleDataTransport/GDTTests/Unit/Helpers/GDTTestUploader.m
+++ b/GoogleDataTransport/GDTTests/Unit/Helpers/GDTTestUploader.m
@@ -25,6 +25,7 @@
   } else if (onComplete) {
     onComplete(kGDTTargetCCT, [GDTClock snapshot], nil);
   }
+  [package completeDelivery];
 }
 
 - (void)appWillBackground:(nonnull UIApplication *)app {


### PR DESCRIPTION
This will help the library deal with lifecycle events better, since blocks don't serialize well with NSSecureCoding. Using delegate callbacks to ensure that an upload is always completed seems to be the only way to address this lifecycle issue.