### PR TITLE
Use outputDir for build logs.

### DIFF
--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -75,11 +75,13 @@ struct FrameworkBuilder {
   ///   - cacheKey: The key used for caching this framework build. If nil, the framework name will
   ///               be used.
   ///   - cacheEnabled: Flag for enabling the cache. Defaults to false.
+  /// - Parameter logsOutputDir: The path to the directory to place build logs.
   /// - Returns: A URL to the framework that was built (or pulled from the cache).
   public func buildFramework(withName podName: String,
                              version: String,
                              cacheKey: String?,
-                             cacheEnabled: Bool = false) -> URL {
+                             cacheEnabled: Bool = false,
+                             logsOutputDir: URL? = nil) -> URL {
     print("Building \(podName)")
 
 //  Cache is temporarily disabled due to pod cache list issues.
@@ -332,11 +334,13 @@ struct FrameworkBuilder {
   /// This will compile all architectures and use the lipo command to create a "fat" archive.
   ///
   /// - Parameter framework: The name of the framework to be built.
+  /// - Parameter logsOutputDir: The path to the directory to place build logs.
   /// - Returns: A path to the newly compiled framework (with any included Resources embedded).
-  private func compileFrameworkAndResources(withName framework: String) -> URL {
+  private func compileFrameworkAndResources(withName framework: String,
+                                            logsOutputDir: URL? = nil) -> URL {
     let fileManager = FileManager.default
-    let outputDir = fileManager.temporaryDirectory(withName: "frameworkBeingBuilt")
-    let logsDir = fileManager.temporaryDirectory(withName: "buildLogs")
+    let outputDir = fileManager.temporaryDirectory(withName: "frameworks_being_built")
+    let logsDir = logsOutputDir ?? fileManager.temporaryDirectory(withName: "build_logs")
     do {
       // Remove the compiled frameworks directory, this isn't the cache we're using.
       if fileManager.directoryExists(at: outputDir) {

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -84,7 +84,7 @@ struct ZipBuilder {
 
     /// The path to a directory to move all build logs to. If nil, a temporary directory will be
     /// used.
-    var logOutputDir: URL?
+    var logsOutputDir: URL?
 
     /// Default initializer with all required paths.
     init(templateDir: URL, coreDiagnosticsDir: URL) {
@@ -709,7 +709,7 @@ struct ZipBuilder {
                                                version: pod.version,
                                                cacheKey: pod.cacheKey,
                                                cacheEnabled: useCache,
-                                               logOutputDir: paths.logOutputDir)
+                                               logsOutputDir: paths.logsOutputDir)
 
         frameworks = [framework]
       } else {

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -82,6 +82,10 @@ struct ZipBuilder {
     /// expected version numbers.
     var currentReleasePath: URL?
 
+    /// The path to a directory to move all build logs to. If nil, a temporary directory will be
+    /// used.
+    var logOutputDir: URL?
+
     /// Default initializer with all required paths.
     init(templateDir: URL, coreDiagnosticsDir: URL) {
       self.templateDir = templateDir
@@ -704,7 +708,8 @@ struct ZipBuilder {
         let framework = builder.buildFramework(withName: pod.name,
                                                version: pod.version,
                                                cacheKey: pod.cacheKey,
-                                               cacheEnabled: useCache)
+                                               cacheEnabled: useCache,
+                                               logOutputDir: paths.logOutputDir)
 
         frameworks = [framework]
       } else {

--- a/ZipBuilder/Sources/ZipBuilder/main.swift
+++ b/ZipBuilder/Sources/ZipBuilder/main.swift
@@ -43,6 +43,7 @@ var paths = ZipBuilder.FilesystemPaths(templateDir: args.templateDir,
                                        coreDiagnosticsDir: args.coreDiagnosticsDir)
 paths.allSDKsPath = args.allSDKsPath
 paths.currentReleasePath = args.currentReleasePath
+paths.logOutputDir = args.outputDir?.appendingPathComponent("build_logs")
 let builder = ZipBuilder(paths: paths,
                          customSpecRepos: args.customSpecRepos,
                          useCache: args.cacheEnabled)

--- a/ZipBuilder/Sources/ZipBuilder/main.swift
+++ b/ZipBuilder/Sources/ZipBuilder/main.swift
@@ -43,7 +43,7 @@ var paths = ZipBuilder.FilesystemPaths(templateDir: args.templateDir,
                                        coreDiagnosticsDir: args.coreDiagnosticsDir)
 paths.allSDKsPath = args.allSDKsPath
 paths.currentReleasePath = args.currentReleasePath
-paths.logOutputDir = args.outputDir?.appendingPathComponent("build_logs")
+paths.logsOutputDir = args.outputDir?.appendingPathComponent("build_logs")
 let builder = ZipBuilder(paths: paths,
                          customSpecRepos: args.customSpecRepos,
                          useCache: args.cacheEnabled)


### PR DESCRIPTION
Use the already existing outputDir specified by the command line
parameters as the output directory for build logs (for frameworks that
are compiled).

This will help our CI system be able to fetch the build logs easier.