### PR TITLE
 Remove state management from the upload coordinator

### DIFF
--- a/GoogleDataTransport/GDTLibrary/GDTStorage.m
+++ b/GoogleDataTransport/GDTLibrary/GDTStorage.m
@@ -119,12 +119,6 @@ static NSString *GDTStoragePath() {
 
 - (void)removeEvents:(NSSet<GDTStoredEvent *> *)events {
   NSSet<GDTStoredEvent *> *eventsToRemove = [events copy];
-  GDTStoredEvent *anyEvent = [eventsToRemove anyObject];
-  id<GDTPrioritizer> prioritizer =
-      [GDTRegistrar sharedInstance].targetToPrioritizer[anyEvent.target];
-  GDTAssert(prioritizer, @"There must be a prioritizer.");
-  [prioritizer unprioritizeEvents:events];
-
   dispatch_async(_storageQueue, ^{
     for (GDTStoredEvent *event in eventsToRemove) {
       // Remove from disk, first and foremost.
@@ -133,8 +127,6 @@ static NSString *GDTStoragePath() {
         NSURL *fileURL = event.dataFuture.fileURL;
         [[NSFileManager defaultManager] removeItemAtURL:fileURL error:&error];
         GDTAssert(error == nil, @"There was an error removing an event file: %@", error);
-        GDTAssert([GDTRegistrar sharedInstance].targetToPrioritizer[event.target] == prioritizer,
-                  @"All logs within an upload set should have the same prioritizer.");
       }
 
       // Remove from the tracking collections.

--- a/GoogleDataTransport/GDTLibrary/GDTUploadPackage.m
+++ b/GoogleDataTransport/GDTLibrary/GDTUploadPackage.m
@@ -19,6 +19,7 @@
 #import <GoogleDataTransport/GDTClock.h>
 
 #import "GDTLibrary/Private/GDTStorage_Private.h"
+#import "GDTLibrary/Private/GDTUploadCoordinator_Private.h"
 #import "GDTLibrary/Private/GDTUploadPackage_Private.h"
 
 @implementation GDTUploadPackage {
@@ -35,6 +36,7 @@
     _target = target;
     _storage = [GDTStorage sharedInstance];
     _deliverByTime = [GDTClock clockSnapshotInTheFuture:180000];
+    _handler = [GDTUploadCoordinator sharedInstance];
     _expirationTimer = [NSTimer scheduledTimerWithTimeInterval:5.0
                                                         target:self
                                                       selector:@selector(checkIfPackageIsExpired:)

--- a/GoogleDataTransport/GDTLibrary/Private/GDTUploadCoordinator_Private.h
+++ b/GoogleDataTransport/GDTLibrary/Private/GDTUploadCoordinator_Private.h
@@ -16,6 +16,8 @@
 
 #import "GDTLibrary/Private/GDTUploadCoordinator.h"
 
+#import "GDTLibrary/Private/GDTUploadPackage_Private.h"
+
 @class GDTClock;
 @class GDTStorage;
 
@@ -24,24 +26,10 @@ typedef void (^GDTUploadCoordinatorForceUploadBlock)(void);
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface GDTUploadCoordinator ()
+@interface GDTUploadCoordinator () <GDTUploadPackageProtocol>
 
 /** The queue on which all upload coordination will occur. Also used by a dispatch timer. */
 @property(nonatomic, readonly) dispatch_queue_t coordinationQueue;
-
-/** The completion block to run after an uploader completes. */
-@property(nonatomic, readonly) GDTUploaderCompletionBlock onCompleteBlock;
-
-/** A map of targets to their desired next upload time, if they have one. */
-@property(nonatomic, readonly) NSMutableDictionary<NSNumber *, GDTClock *> *targetToNextUploadTimes;
-
-/** A map of targets to a set of event hashes that has been handed off to the uploader. */
-@property(nonatomic, readonly)
-    NSMutableDictionary<NSNumber *, NSSet<GDTStoredEvent *> *> *targetToInFlightEventSet;
-
-/** A queue of forced uploads. Only populated if the target already had in-flight events. */
-@property(nonatomic, readonly)
-    NSMutableArray<GDTUploadCoordinatorForceUploadBlock> *forcedUploadQueue;
 
 /** A timer that will causes regular checks for events to upload. */
 @property(nonatomic, readonly) dispatch_source_t timer;
@@ -60,13 +48,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** If YES, completion and other operations will result in serializing the singleton to disk. */
 @property(nonatomic, readonly) BOOL runningInBackground;
-
-/** Returns the path to the keyed archive of the singleton. This is where the singleton is saved
- * to disk during certain app lifecycle events.
- *
- * @return File path to serialized singleton.
- */
-+ (NSString *)archivePath;
 
 /** Starts the upload timer. */
 - (void)startTimer;

--- a/GoogleDataTransport/GDTLibrary/Public/GDTPrioritizer.h
+++ b/GoogleDataTransport/GDTLibrary/Public/GDTPrioritizer.h
@@ -48,7 +48,7 @@ typedef NS_OPTIONS(NSInteger, GDTUploadConditions) {
  * stateful objects that prioritize events upon insertion into storage and remain prepared to return
  * a set of filenames to the storage system.
  */
-@protocol GDTPrioritizer <NSObject, GDTLifecycleProtocol>
+@protocol GDTPrioritizer <NSObject, GDTLifecycleProtocol, GDTUploadPackageProtocol>
 
 @required
 
@@ -59,16 +59,6 @@ typedef NS_OPTIONS(NSInteger, GDTUploadConditions) {
  * @param event The event to prioritize.
  */
 - (void)prioritizeEvent:(GDTStoredEvent *)event;
-
-/** Unprioritizes a set of events. This method is called after all the events in the set have been
- * removed from storage and from disk. It's passed as a set so that instead of having N blocks
- * dispatched to a queue, it can be a single block--this prevents possible race conditions in which
- * the storage system has removed the events, but the prioritizers haven't unprioritized the events
- * because it was being done one at a time.
- *
- * @param events The set of events to unprioritize.
- */
-- (void)unprioritizeEvents:(NSSet<GDTStoredEvent *> *)events;
 
 /** Returns a set of events to upload given a set of conditions.
  *

--- a/GoogleDataTransport/GDTLibrary/Public/GDTUploader.h
+++ b/GoogleDataTransport/GDTLibrary/Public/GDTUploader.h
@@ -18,36 +18,29 @@
 
 #import <GoogleDataTransport/GDTClock.h>
 #import <GoogleDataTransport/GDTLifecycle.h>
+#import <GoogleDataTransport/GDTPrioritizer.h>
 #import <GoogleDataTransport/GDTTargets.h>
 #import <GoogleDataTransport/GDTUploadPackage.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-/** A convenient typedef to define the block to be called upon completion of an upload to the
- * backend.
- *
- * target: The target that was uploading.
- * nextUploadAttemptUTC: The desired next upload attempt time.
- * uploadError: Populated with any upload error. If non-nil, a retry will be attempted.
- */
-typedef void (^GDTUploaderCompletionBlock)(GDTTarget target,
-                                           GDTClock *nextUploadAttemptUTC,
-                                           NSError *_Nullable uploadError);
-
 /** This protocol defines the common interface for uploader implementations. */
-@protocol GDTUploader <NSObject, GDTLifecycleProtocol>
+@protocol GDTUploader <NSObject, GDTLifecycleProtocol, GDTUploadPackageProtocol>
 
 @required
 
+/** Returns YES if the uploader can make an upload attempt, NO otherwise.
+ *
+ * @param conditions The conditions that the upload attempt is likely to occur under.
+ * @return YES if the uploader can make an upload attempt, NO otherwise.
+ */
+- (BOOL)readyToUploadWithConditions:(GDTUploadConditions)conditions;
+
 /** Uploads events to the backend using this specific backend's chosen format.
  *
- * @param package The event package to upload.
- * @param onComplete A block to invoke upon completing the upload. Has three arguments:
- *   - target: The GDTTarget that just uploaded.
- *   - nextUploadAttemptUTC: A clock representing the next upload attempt.
- *   - uploadError: An error object describing the upload error, or nil if upload was successful.
+ * @param package The event package to upload. Make sure to call -completeDelivery.
  */
-- (void)uploadPackage:(GDTUploadPackage *)package onComplete:(GDTUploaderCompletionBlock)onComplete;
+- (void)uploadPackage:(GDTUploadPackage *)package;
 
 @end
 

--- a/GoogleDataTransport/GDTTests/Common/Categories/GDTUploadCoordinator+Testing.m
+++ b/GoogleDataTransport/GDTTests/Common/Categories/GDTUploadCoordinator+Testing.m
@@ -25,9 +25,6 @@
 @implementation GDTUploadCoordinator (Testing)
 
 - (void)reset {
-  [self.targetToNextUploadTimes removeAllObjects];
-  [self.targetToInFlightEventSet removeAllObjects];
-  [self.forcedUploadQueue removeAllObjects];
   self.storage = [GDTStorage sharedInstance];
   self.registrar = [GDTRegistrar sharedInstance];
 }

--- a/GoogleDataTransport/GDTTests/Integration/Helpers/GDTIntegrationTestPrioritizer.m
+++ b/GoogleDataTransport/GDTTests/Integration/Helpers/GDTIntegrationTestPrioritizer.m
@@ -58,15 +58,6 @@
   });
 }
 
-- (void)unprioritizeEvents:(NSSet<GDTStoredEvent *> *)events {
-  dispatch_async(_queue, ^{
-    for (GDTStoredEvent *event in events) {
-      [self.wifiOnlyEvents removeObject:event];
-      [self.nonWifiEvents removeObject:event];
-    }
-  });
-}
-
 - (GDTUploadPackage *)uploadPackageWithConditions:(GDTUploadConditions)conditions {
   __block GDTIntegrationTestUploadPackage *uploadPackage =
       [[GDTIntegrationTestUploadPackage alloc] initWithTarget:kGDTIntegrationTestTarget];
@@ -87,6 +78,15 @@
 }
 
 - (void)appWillTerminate:(UIApplication *)application {
+}
+
+- (void)packageDelivered:(GDTUploadPackage *)package successful:(BOOL)successful {
+  dispatch_async(_queue, ^{
+    for (GDTStoredEvent *event in package.events) {
+      [self.wifiOnlyEvents removeObject:event];
+      [self.nonWifiEvents removeObject:event];
+    }
+  });
 }
 
 @end

--- a/GoogleDataTransport/GDTTests/Integration/Helpers/GDTIntegrationTestUploader.m
+++ b/GoogleDataTransport/GDTTests/Integration/Helpers/GDTIntegrationTestUploader.m
@@ -40,8 +40,7 @@
   return self;
 }
 
-- (void)uploadPackage:(GDTUploadPackage *)package
-           onComplete:(GDTUploaderCompletionBlock)onComplete {
+- (void)uploadPackage:(GDTUploadPackage *)package {
   NSAssert(!_currentUploadTask, @"An upload shouldn't be initiated with another in progress.");
   NSURL *serverURL = arc4random_uniform(2) ? [_serverURL URLByAppendingPathComponent:@"log"]
                                            : [_serverURL URLByAppendingPathComponent:@"logBatch"];
@@ -58,7 +57,7 @@
     NSAssert(fileData, @"An event file shouldn't be empty");
     [uploadData appendData:fileData];
   }
-  NSURLSessionUploadTask *uploadTask =
+  _currentUploadTask =
       [session uploadTaskWithRequest:request
                             fromData:uploadData
                    completionHandler:^(NSData *_Nullable data, NSURLResponse *_Nullable response,
@@ -66,13 +65,18 @@
                      NSLog(@"Batch upload complete.");
                      // Remove from the prioritizer if there were no errors.
                      NSAssert(!error, @"There should be no errors uploading events: %@", error);
-                     if (onComplete) {
-                       // In real usage, the server would/should return a desired next upload time.
-                       GDTClock *nextUploadTime = [GDTClock clockSnapshotInTheFuture:1000];
-                       onComplete(kGDTIntegrationTestTarget, nextUploadTime, error);
+                     if (error) {
+                       [package retryDeliveryInTheFuture];
+                     } else {
+                       [package completeDelivery];
                      }
+                     self->_currentUploadTask = nil;
                    }];
-  [uploadTask resume];
+  [_currentUploadTask resume];
+}
+
+- (BOOL)readyToUploadWithConditions:(GDTUploadConditions)conditions {
+  return _currentUploadTask ? NO : YES;
 }
 
 - (void)appWillBackground:(UIApplication *)app {

--- a/GoogleDataTransport/GDTTests/Lifecycle/GDTLifecycleTest.m
+++ b/GoogleDataTransport/GDTTests/Lifecycle/GDTLifecycleTest.m
@@ -81,7 +81,6 @@
   // Don't check the error, because it'll be populated in cases where the file doesn't exist.
   NSError *error;
   [[NSFileManager defaultManager] removeItemAtPath:[GDTStorage archivePath] error:&error];
-  [[NSFileManager defaultManager] removeItemAtPath:[GDTUploadCoordinator archivePath] error:&error];
   self.uploader = [[GDTLifecycleTestUploader alloc] init];
   [[GDTRegistrar sharedInstance] registerUploader:self.uploader target:kGDTTargetTest];
 
@@ -113,8 +112,7 @@
   GDTWaitForBlock(
       ^BOOL {
         NSFileManager *fm = [NSFileManager defaultManager];
-        return [fm fileExistsAtPath:[GDTStorage archivePath] isDirectory:NULL] &&
-               [fm fileExistsAtPath:[GDTUploadCoordinator archivePath] isDirectory:NULL];
+        return [fm fileExistsAtPath:[GDTStorage archivePath] isDirectory:NULL];
       },
       5.0);
 }
@@ -140,8 +138,7 @@
   GDTWaitForBlock(
       ^BOOL {
         NSFileManager *fm = [NSFileManager defaultManager];
-        return [fm fileExistsAtPath:[GDTStorage archivePath] isDirectory:NULL] &&
-               [fm fileExistsAtPath:[GDTUploadCoordinator archivePath] isDirectory:NULL];
+        return [fm fileExistsAtPath:[GDTStorage archivePath] isDirectory:NULL];
       },
       5.0);
 
@@ -176,8 +173,7 @@
   GDTWaitForBlock(
       ^BOOL {
         NSFileManager *fm = [NSFileManager defaultManager];
-        return [fm fileExistsAtPath:[GDTStorage archivePath] isDirectory:NULL] &&
-               [fm fileExistsAtPath:[GDTUploadCoordinator archivePath] isDirectory:NULL];
+        return [fm fileExistsAtPath:[GDTStorage archivePath] isDirectory:NULL];
       },
       5.0);
 }

--- a/GoogleDataTransport/GDTTests/Lifecycle/Helpers/GDTLifecycleTestPrioritizer.m
+++ b/GoogleDataTransport/GDTTests/Lifecycle/Helpers/GDTLifecycleTestPrioritizer.m
@@ -46,14 +46,6 @@
   });
 }
 
-- (void)unprioritizeEvents:(NSSet<GDTStoredEvent *> *)events {
-  dispatch_async(_queue, ^{
-    for (GDTStoredEvent *event in events) {
-      [self.events removeObject:event];
-    }
-  });
-}
-
 - (GDTUploadPackage *)uploadPackageWithConditions:(GDTUploadConditions)conditions {
   __block GDTUploadPackage *uploadPackage =
       [[GDTUploadPackage alloc] initWithTarget:kGDTTargetTest];
@@ -61,6 +53,14 @@
     uploadPackage.events = self.events;
   });
   return uploadPackage;
+}
+
+- (void)packageDelivered:(GDTUploadPackage *)package successful:(BOOL)successful {
+  dispatch_async(_queue, ^{
+    for (GDTStoredEvent *event in package.events) {
+      [self.events removeObject:event];
+    }
+  });
 }
 
 - (void)appWillBackground:(UIApplication *)app {

--- a/GoogleDataTransport/GDTTests/Lifecycle/Helpers/GDTLifecycleTestUploader.m
+++ b/GoogleDataTransport/GDTTests/Lifecycle/Helpers/GDTLifecycleTestUploader.m
@@ -18,8 +18,11 @@
 
 @implementation GDTLifecycleTestUploader
 
-- (void)uploadPackage:(GDTUploadPackage *)package
-           onComplete:(GDTUploaderCompletionBlock)onComplete {
+- (void)uploadPackage:(GDTUploadPackage *)package {
+}
+
+- (BOOL)readyToUploadWithConditions:(GDTUploadConditions)conditions {
+  return YES;
 }
 
 - (void)appWillBackground:(UIApplication *)app {

--- a/GoogleDataTransport/GDTTests/Unit/Helpers/GDTTestPrioritizer.m
+++ b/GoogleDataTransport/GDTTests/Unit/Helpers/GDTTestPrioritizer.m
@@ -41,9 +41,6 @@
   }
 }
 
-- (void)unprioritizeEvents:(NSSet<GDTStoredEvent *> *)events {
-}
-
 - (void)appWillBackground:(UIApplication *)app {
 }
 

--- a/GoogleDataTransport/GDTTests/Unit/Helpers/GDTTestUploader.h
+++ b/GoogleDataTransport/GDTTests/Unit/Helpers/GDTTestUploader.h
@@ -27,9 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface GDTTestUploader : NSObject <GDTUploader>
 
-/** A block that can be ran in -uploadPackage:onComplete:. */
-@property(nullable, nonatomic) void (^uploadEventsBlock)
-    (GDTUploadPackage *package, GDTUploaderCompletionBlock completionBlock);
+/** A block that can be ran in -uploadPackage:. */
+@property(nullable, nonatomic) void (^uploadPackageBlock)(GDTUploadPackage *package);
 
 @end
 

--- a/GoogleDataTransport/GDTTests/Unit/Helpers/GDTTestUploader.m
+++ b/GoogleDataTransport/GDTTests/Unit/Helpers/GDTTestUploader.m
@@ -18,14 +18,16 @@
 
 @implementation GDTTestUploader
 
-- (void)uploadPackage:(GDTUploadPackage *)package
-           onComplete:(GDTUploaderCompletionBlock)onComplete {
-  if (_uploadEventsBlock) {
-    _uploadEventsBlock(package, onComplete);
-  } else if (onComplete) {
-    onComplete(kGDTTargetCCT, [GDTClock snapshot], nil);
+- (void)uploadPackage:(GDTUploadPackage *)package {
+  if (_uploadPackageBlock) {
+    _uploadPackageBlock(package);
+  } else {
+    [package completeDelivery];
   }
-  [package completeDelivery];
+}
+
+- (BOOL)readyToUploadWithConditions:(GDTUploadConditions)conditions {
+  return YES;
 }
 
 - (void)appWillBackground:(nonnull UIApplication *)app {


### PR DESCRIPTION
Refactors the GDTPrioritizer and GDTUploader interfaces, which caused some cascading changes.
- The removal of -unprioritizeEvents means that the logic was moved to an implementation of packageDelivered:successful:
- NSSecureCoding doesn't need a full implementation for GDTUploadCoordinator
- The upload coordinator doesn't track next upload times and doesn't run a completion block anymore. This prevents some lifecycle issues from occurring when restoring blocks.
- An implementor of GDTUploader now determines the appropriate time for an upload. A timer will run in GDTUploadCoordinator and regularly trigger -readyToUploadWithConditions in each uploader instance.
- Forcing an upload isn't as much a thing now. It simply triggers an upload attempt for that target with the 'High' priority condition present. It's up to the uploader to figure out how to deal with that.