### PR TITLE
Early return from sending analytics events if instance ID is nil

### DIFF
--- a/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogger.m
+++ b/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogger.m
@@ -149,6 +149,13 @@
     eventTimeInMs = @((long)nowInMs);
   }
 
+  if (!iid) {
+    FIRLogWarning(kFIRLoggerInAppMessaging, @"I-IAM210009",
+                  @"Instance ID is nil, event %ld for campaign ID %@ will not be sent",
+                  (long)eventType, campaignID);
+    return;
+  }
+
   NSString *sourceExtensionJsonString =
       [self constructSourceExtensionJsonForClearcutWithEventType:eventType
                                                    forCampaignID:campaignID


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-ios-sdk/issues/2988, where nil instance ID was being inserted into an NSDictionary.