### PR TITLE
Update to CocoaPods 1.6.2 and CocoaPods generate to 1.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@
 # commit Gemfile and Gemfile.lock.
 source 'https://rubygems.org'
 
-gem 'cocoapods', "1.6.1"
-gem 'cocoapods-generate', "1.4.1"
+gem 'cocoapods', "1.6.2"
+gem 'cocoapods-generate', "1.5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GEM
       tzinfo (~> 1.1)
     atomos (0.1.3)
     claide (1.0.2)
-    cocoapods (1.6.1)
+    cocoapods (1.6.2)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.6.1)
+      cocoapods-core (= 1.6.2)
       cocoapods-deintegrate (>= 1.0.2, < 2.0)
       cocoapods-downloader (>= 1.2.2, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -28,13 +28,15 @@ GEM
       nap (~> 1.0)
       ruby-macho (~> 1.4)
       xcodeproj (>= 1.8.1, < 2.0)
-    cocoapods-core (1.6.1)
+    cocoapods-core (1.6.2)
       activesupport (>= 4.0.2, < 6)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
     cocoapods-deintegrate (1.0.4)
+    cocoapods-disable-podfile-validations (0.1.1)
     cocoapods-downloader (1.2.2)
-    cocoapods-generate (1.4.1)
+    cocoapods-generate (1.5.0)
+      cocoapods-disable-podfile-validations (~> 0.1.1)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
@@ -60,7 +62,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    xcodeproj (1.8.2)
+    xcodeproj (1.9.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -71,8 +73,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (= 1.6.1)
-  cocoapods-generate (= 1.4.1)
+  cocoapods (= 1.6.2)
+  cocoapods-generate (= 1.5.0)
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
CocoaPods 1.6.2 fixes a pod lib lint bug with json podspecs and testspec's.
cocoapods-generate 1.5.0 enables pod gen to include local podspecs as dependencies in the generated Xcode project