### PR TITLE
fix the typo error that cause bundle identifier checking failed for app extension

### DIFF
--- a/Example/Core/Tests/FIRBundleUtilTest.m
+++ b/Example/Core/Tests/FIRBundleUtilTest.m
@@ -87,8 +87,9 @@ static NSString *const kFileType = @"fileType";
   id environmentUtilsMock = [OCMockObject mockForClass:[GULAppEnvironmentUtil class]];
   [[[environmentUtilsMock stub] andReturnValue:@(YES)] isAppExtension];
 
-  [OCMStub([self.mockBundle bundleIdentifier]) andReturn:@"com.google.test"];
-  XCTAssertTrue([FIRBundleUtil hasBundleIdentifierPrefix:@"com.google.test.someextension"
+  // Mock bundle should have what app extension has, the extension bundle ID.
+  [OCMStub([self.mockBundle bundleIdentifier]) andReturn:@"com.google.test.someextension"];
+  XCTAssertTrue([FIRBundleUtil hasBundleIdentifierPrefix:@"com.google.test"
                                                inBundles:@[ self.mockBundle ]]);
 
   [environmentUtilsMock stopMocking];
@@ -98,17 +99,20 @@ static NSString *const kFileType = @"fileType";
   id environmentUtilsMock = [OCMockObject mockForClass:[GULAppEnvironmentUtil class]];
   [[[environmentUtilsMock stub] andReturnValue:@(YES)] isAppExtension];
 
-  [OCMStub([self.mockBundle bundleIdentifier]) andReturn:@"com.google.test"];
-  XCTAssertFalse([FIRBundleUtil hasBundleIdentifierPrefix:@"com.google.test.someextension.some"
+  [OCMStub([self.mockBundle bundleIdentifier]) andReturn:@"com.google.test.someextension.some"];
+  XCTAssertFalse([FIRBundleUtil hasBundleIdentifierPrefix:@"com.google.test"
                                                 inBundles:@[ self.mockBundle ]]);
 
-  XCTAssertFalse([FIRBundleUtil hasBundleIdentifierPrefix:@"com.google.testsomeextension"
+  [OCMStub([self.mockBundle bundleIdentifier]) andReturn:@"com.google.testsomeextension"];
+  XCTAssertFalse([FIRBundleUtil hasBundleIdentifierPrefix:@"com.google.test"
                                                 inBundles:@[ self.mockBundle ]]);
 
-  XCTAssertFalse([FIRBundleUtil hasBundleIdentifierPrefix:@"com.google.testsomeextension.some"
+  [OCMStub([self.mockBundle bundleIdentifier]) andReturn:@"com.google.testsomeextension.some"];
+  XCTAssertFalse([FIRBundleUtil hasBundleIdentifierPrefix:@"com.google.test"
                                                 inBundles:@[ self.mockBundle ]]);
 
-  XCTAssertFalse([FIRBundleUtil hasBundleIdentifierPrefix:@"not-exist"
+  [OCMStub([self.mockBundle bundleIdentifier]) andReturn:@"not-exist"];
+  XCTAssertFalse([FIRBundleUtil hasBundleIdentifierPrefix:@"com.google.test"
                                                 inBundles:@[ self.mockBundle ]]);
 
   // Should be NO, since if @"com.google.tests" is an app extension identifier, then the app bundle

--- a/Firebase/Core/FIRBundleUtil.m
+++ b/Firebase/Core/FIRBundleUtil.m
@@ -53,7 +53,7 @@
     NSString *applicationBundleIdentifier =
         [GULAppEnvironmentUtil isAppExtension]
             ? [self bundleIdentifierByRemovingLastPartFrom:bundle.bundleIdentifier]
-            : bundleIdentifier;
+            : bundle.bundleIdentifier;
 
     if ([applicationBundleIdentifier isEqualToString:bundleIdentifier]) {
       return YES;

--- a/Firebase/Core/FIRBundleUtil.m
+++ b/Firebase/Core/FIRBundleUtil.m
@@ -52,10 +52,10 @@
     // This allows app extensions that have the app's bundle as their prefix to pass this test.
     NSString *applicationBundleIdentifier =
         [GULAppEnvironmentUtil isAppExtension]
-            ? [self bundleIdentifierByRemovingLastPartFrom:bundleIdentifier]
+            ? [self bundleIdentifierByRemovingLastPartFrom:bundle.bundleIdentifier]
             : bundleIdentifier;
 
-    if ([applicationBundleIdentifier isEqualToString:bundle.bundleIdentifier]) {
+    if ([applicationBundleIdentifier isEqualToString:bundleIdentifier]) {
       return YES;
     }
   }


### PR DESCRIPTION
Expected: Import the same GoogleService-Info.plist to app extension target and call FIRApp configure and succeed.

Currently: [FIRApp configure] return error:
[Firebase/Core][I-COR000008] The project's Bundle ID is inconsistent with either the Bundle ID in 'GoogleService-Info.plist', or the Bundle ID in the options if you are using a customized options. To ensure that everything can be configured correctly, you may need to make the Bundle IDs consistent. To continue with this plist file, you may change your app's bundle identifier to 'com.google.firebase.extensions.dev'. Or you can download a new configuration file that matches your bundle identifier from https://console.firebase.google.com/ and replace the current one.