### PR TITLE
Fix check script for 1st travis run on non-master branch

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -167,17 +167,15 @@ fi
 # first commit on a non-master branch, TRAVIS_COMMIT_RANGE is not set and
 # START_REVISION is "master" instead of a range.
 
-if [[ -z "${TRAVIS_COMMIT_RANGE}" ]]; then
-  # Figure out if we have access to master. If not add it to the repo.
+# If needed, check if we have access to master and add it to the repo.
+if [[ "${START_REVISION}" == "origin/master" ]]; then
   if ! git rev-parse origin/master >& /dev/null; then
     git remote set-branches --add origin master
     git fetch origin
   fi
-  START_SHA=$(git rev-parse origin/master)
-
-else
-  START_SHA=$(git rev-parse "${START_REVISION}")
 fi
+
+START_SHA=$(git rev-parse "${START_REVISION}")
 
 if [[ "${VERBOSE}" == true ]]; then
   echo "START_REVISION=$START_REVISION"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -22,7 +22,7 @@ function usage() {
 USAGE: scripts/check.sh [--allow-dirty] [--commit] [<revision>]
 
 Runs auto-formatting scripts, source-tree checks, and linters on any files that
-have changed since master.
+have changed since origin/master.
 
 By default, any changes are left as uncommited changes in the working tree. You
 can review them with git diff. Pass --commit to automatically commit any changes.
@@ -50,18 +50,18 @@ OPTIONS:
     Run all checks without making any changes to local files.
 
   <revision>
-    Specifies a starting revision other than the default of master.
+    Specifies a starting revision other than the default of origin/master.
 
 
 EXAMPLES:
 
   check.sh
-    Runs automated checks and formatters on all changed files since master.
-    Check for changes with git diff.
+    Runs automated checks and formatters on all changed files since
+    origin/master. Check for changes with git diff.
 
   check.sh --commit
-    Runs automated checks and formatters on all changed files since master and
-    commits the results.
+    Runs automated checks and formatters on all changed files since
+    origin/master and commits the results.
 
   check.sh --amend HEAD
     Runs automated checks and formatters on all changed files since the last
@@ -84,7 +84,7 @@ cd "${top_dir}"
 
 ALLOW_DIRTY=false
 COMMIT_METHOD="none"
-START_REVISION="master"
+START_REVISION="origin/master"
 TEST_ONLY=false
 VERBOSE=false
 


### PR DESCRIPTION
I noticed that non-master branch testing was still failing in https://travis-ci.org/firebase/firebase-ios-sdk/builds/533073316.

I debugged in a series of new branches prefixed with pb-travis-test. See recent runs at https://travis-ci.org/firebase/firebase-ios-sdk/builds

The pb-travis-test6 run demonstrates a successful first run with logging enabled.