### PR TITLE
Ensure that only one package per target should ever be in flight

### DIFF
--- a/GoogleDataTransport/GDTLibrary/GDTUploadCoordinator.m
+++ b/GoogleDataTransport/GDTLibrary/GDTUploadCoordinator.m
@@ -164,7 +164,8 @@
 #pragma mark - NSSecureCoding support
 
 /** The NSKeyedCoder key for the targetToInFlightPackages property. */
-static NSString *const ktargetToInFlightPackagesKey = @"GDTUploadCoordinatortargetToInFlightPackages";
+static NSString *const ktargetToInFlightPackagesKey =
+    @"GDTUploadCoordinatortargetToInFlightPackages";
 
 + (BOOL)supportsSecureCoding {
   return YES;
@@ -173,7 +174,8 @@ static NSString *const ktargetToInFlightPackagesKey = @"GDTUploadCoordinatortarg
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
   GDTUploadCoordinator *sharedCoordinator = [GDTUploadCoordinator sharedInstance];
   sharedCoordinator->_targetToInFlightPackages =
-      [aDecoder decodeObjectOfClass:[NSMutableDictionary class] forKey:ktargetToInFlightPackagesKey];
+      [aDecoder decodeObjectOfClass:[NSMutableDictionary class]
+                             forKey:ktargetToInFlightPackagesKey];
   return sharedCoordinator;
 }
 

--- a/GoogleDataTransport/GDTLibrary/GDTUploadCoordinator.m
+++ b/GoogleDataTransport/GDTLibrary/GDTUploadCoordinator.m
@@ -44,7 +44,7 @@
     _registrar = [GDTRegistrar sharedInstance];
     _timerInterval = 30 * NSEC_PER_SEC;
     _timerLeeway = 5 * NSEC_PER_SEC;
-    _inFlightUploadPackages = [[NSMutableSet alloc] init];
+    _targetToInFlightPackages = [[NSMutableDictionary alloc] init];
   }
   return self;
 }
@@ -104,11 +104,16 @@
 - (void)uploadTargets:(NSArray<NSNumber *> *)targets conditions:(GDTUploadConditions)conditions {
   dispatch_async(_coordinationQueue, ^{
     for (NSNumber *target in targets) {
+      // Don't trigger uploads for targets that have an in-flight package already.
+      if (self->_targetToInFlightPackages[target]) {
+        continue;
+      }
+      // Ask the uploader if they can upload and do so, if it can.
       id<GDTUploader> uploader = self.registrar.targetToUploader[target];
       if ([uploader readyToUploadWithConditions:conditions]) {
         id<GDTPrioritizer> prioritizer = self.registrar.targetToPrioritizer[target];
         GDTUploadPackage *package = [prioritizer uploadPackageWithConditions:conditions];
-        [self->_inFlightUploadPackages addObject:package];
+        self->_targetToInFlightPackages[target] = package;
         [uploader uploadPackage:package];
       }
     }
@@ -158,8 +163,8 @@
 
 #pragma mark - NSSecureCoding support
 
-/** The NSKeyedCoder key for the inFlightUploadPackages property. */
-static NSString *const kInFlightUploadPackagesKey = @"GDTUploadCoordinatorInFlightUploadPackages";
+/** The NSKeyedCoder key for the targetToInFlightPackages property. */
+static NSString *const ktargetToInFlightPackagesKey = @"GDTUploadCoordinatortargetToInFlightPackages";
 
 + (BOOL)supportsSecureCoding {
   return YES;
@@ -167,15 +172,15 @@ static NSString *const kInFlightUploadPackagesKey = @"GDTUploadCoordinatorInFlig
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
   GDTUploadCoordinator *sharedCoordinator = [GDTUploadCoordinator sharedInstance];
-  sharedCoordinator->_inFlightUploadPackages =
-      [aDecoder decodeObjectOfClass:[NSMutableSet class] forKey:kInFlightUploadPackagesKey];
+  sharedCoordinator->_targetToInFlightPackages =
+      [aDecoder decodeObjectOfClass:[NSMutableDictionary class] forKey:ktargetToInFlightPackagesKey];
   return sharedCoordinator;
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
   // All packages that have been given to uploaders need to be tracked so that their expiration
   // timers can be called.
-  [aCoder encodeObject:_inFlightUploadPackages forKey:kInFlightUploadPackagesKey];
+  [aCoder encodeObject:_targetToInFlightPackages forKey:ktargetToInFlightPackagesKey];
 }
 
 #pragma mark - GDTLifecycleProtocol
@@ -212,8 +217,8 @@ static NSString *const kInFlightUploadPackagesKey = @"GDTUploadCoordinatorInFlig
 
 - (void)packageDelivered:(GDTUploadPackage *)package successful:(BOOL)successful {
   dispatch_async(_coordinationQueue, ^{
-    [self->_inFlightUploadPackages removeObject:package];
     NSNumber *targetNumber = @(package.target);
+    [self->_targetToInFlightPackages removeObjectForKey:targetNumber];
     id<GDTPrioritizer> prioritizer = self->_registrar.targetToPrioritizer[targetNumber];
     NSAssert(prioritizer, @"A prioritizer should be registered for this target: %@", targetNumber);
     if ([prioritizer respondsToSelector:@selector(packageDelivered:successful:)]) {
@@ -225,8 +230,8 @@ static NSString *const kInFlightUploadPackagesKey = @"GDTUploadCoordinatorInFlig
 
 - (void)packageExpired:(GDTUploadPackage *)package {
   dispatch_async(_coordinationQueue, ^{
-    [self->_inFlightUploadPackages removeObject:package];
     NSNumber *targetNumber = @(package.target);
+    [self->_targetToInFlightPackages removeObjectForKey:targetNumber];
     id<GDTPrioritizer> prioritizer = self->_registrar.targetToPrioritizer[targetNumber];
     id<GDTUploader> uploader = self->_registrar.targetToUploader[targetNumber];
     if ([prioritizer respondsToSelector:@selector(packageExpired:)]) {

--- a/GoogleDataTransport/GDTLibrary/GDTUploadPackage.m
+++ b/GoogleDataTransport/GDTLibrary/GDTUploadPackage.m
@@ -23,6 +23,10 @@
 #import "GDTLibrary/Private/GDTUploadPackage_Private.h"
 
 @implementation GDTUploadPackage {
+
+  /** If YES, the package's -completeDelivery method has been called. */
+  BOOL _isDelivered;
+
   /** If YES, is being handled by the handler. */
   BOOL _isHandled;
 
@@ -71,6 +75,8 @@
 }
 
 - (void)completeDelivery {
+  NSAssert(_isDelivered == NO,  @"It's an API violation to call -completeDelivery twice.");
+  _isDelivered = YES;
   if (!_isHandled && _handler &&
       [_handler respondsToSelector:@selector(packageDelivered:successful:)]) {
     [_expirationTimer invalidate];

--- a/GoogleDataTransport/GDTLibrary/GDTUploadPackage.m
+++ b/GoogleDataTransport/GDTLibrary/GDTUploadPackage.m
@@ -23,7 +23,6 @@
 #import "GDTLibrary/Private/GDTUploadPackage_Private.h"
 
 @implementation GDTUploadPackage {
-
   /** If YES, the package's -completeDelivery method has been called. */
   BOOL _isDelivered;
 
@@ -75,7 +74,7 @@
 }
 
 - (void)completeDelivery {
-  NSAssert(_isDelivered == NO,  @"It's an API violation to call -completeDelivery twice.");
+  NSAssert(_isDelivered == NO, @"It's an API violation to call -completeDelivery twice.");
   _isDelivered = YES;
   if (!_isHandled && _handler &&
       [_handler respondsToSelector:@selector(packageDelivered:successful:)]) {

--- a/GoogleDataTransport/GDTLibrary/Private/GDTUploadCoordinator.h
+++ b/GoogleDataTransport/GDTLibrary/Private/GDTUploadCoordinator.h
@@ -49,8 +49,8 @@ NS_ASSUME_NONNULL_BEGIN
 /** Some leeway given to libdispatch for the timer interval event. */
 @property(nonatomic, readonly) uint64_t timerLeeway;
 
-/** The current in-flight packages. */
-@property(nonatomic, readonly) NSMutableSet<GDTUploadPackage *> *inFlightUploadPackages;
+/** The map of targets to in-flight packages. */
+@property(nonatomic, readonly) NSMutableDictionary<NSNumber *, GDTUploadPackage *> *targetToInFlightPackages;
 
 /** The storage object the coordinator will use. Generally used for testing. */
 @property(nonatomic) GDTStorage *storage;

--- a/GoogleDataTransport/GDTLibrary/Private/GDTUploadCoordinator.h
+++ b/GoogleDataTransport/GDTLibrary/Private/GDTUploadCoordinator.h
@@ -50,7 +50,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) uint64_t timerLeeway;
 
 /** The map of targets to in-flight packages. */
-@property(nonatomic, readonly) NSMutableDictionary<NSNumber *, GDTUploadPackage *> *targetToInFlightPackages;
+@property(nonatomic, readonly)
+    NSMutableDictionary<NSNumber *, GDTUploadPackage *> *targetToInFlightPackages;
 
 /** The storage object the coordinator will use. Generally used for testing. */
 @property(nonatomic) GDTStorage *storage;

--- a/GoogleDataTransport/GDTTests/Common/Categories/GDTUploadCoordinator+Testing.m
+++ b/GoogleDataTransport/GDTTests/Common/Categories/GDTUploadCoordinator+Testing.m
@@ -24,8 +24,11 @@
 @implementation GDTUploadCoordinator (Testing)
 
 - (void)reset {
-  self.storage = [GDTStorage sharedInstance];
-  self.registrar = [GDTRegistrar sharedInstance];
+  dispatch_sync(self.coordinationQueue, ^{
+    self.storage = [GDTStorage sharedInstance];
+    self.registrar = [GDTRegistrar sharedInstance];
+    [self.targetToInFlightPackages removeAllObjects];
+  });
 }
 
 - (void)setTimerInterval:(uint64_t)timerInterval {

--- a/GoogleDataTransport/GDTTests/Unit/GDTTestCase.m
+++ b/GoogleDataTransport/GDTTests/Unit/GDTTestCase.m
@@ -25,6 +25,7 @@
 - (void)setUp {
   [GDTReachability sharedInstance].flags = kSCNetworkReachabilityFlagsReachable;
   [[GDTUploadCoordinator sharedInstance] stopTimer];
+  [[GDTUploadCoordinator sharedInstance] reset];
 }
 
 - (void)tearDown {

--- a/GoogleDataTransport/GDTTests/Unit/GDTUploadCoordinatorTest.m
+++ b/GoogleDataTransport/GDTTests/Unit/GDTUploadCoordinatorTest.m
@@ -86,7 +86,7 @@
 /** Tests the timer is running at the desired frequency. */
 - (void)testTimerIsRunningAtDesiredFrequency {
   __block int numberOfTimesCalled = 0;
-  self.uploader.uploadPackageBlock = ^(GDTUploadPackage * _Nonnull package) {
+  self.uploader.uploadPackageBlock = ^(GDTUploadPackage *_Nonnull package) {
     numberOfTimesCalled++;
     [package completeDelivery];
   };
@@ -110,7 +110,7 @@
 /** Tests uploading events via the coordinator timer. */
 - (void)testUploadingEventsViaTimer {
   __block int uploadAttempts = 0;
- self.prioritizer.events = [GDTEventGenerator generate3StoredEvents];
+  self.prioritizer.events = [GDTEventGenerator generate3StoredEvents];
   self.uploader.uploadPackageBlock = ^(GDTUploadPackage *_Nonnull package) {
     [package completeDelivery];
     uploadAttempts++;

--- a/GoogleDataTransport/GDTTests/Unit/GDTUploadPackageTest.m
+++ b/GoogleDataTransport/GDTTests/Unit/GDTUploadPackageTest.m
@@ -17,8 +17,8 @@
 #import "GDTTests/Unit/GDTTestCase.h"
 
 #import <GoogleDataTransport/GDTClock.h>
-#import <GoogleDataTransport/GDTUploadPackage.h>
 #import <GoogleDataTransport/GDTRegistrar.h>
+#import <GoogleDataTransport/GDTUploadPackage.h>
 
 #import "GDTLibrary/Private/GDTUploadPackage_Private.h"
 

--- a/GoogleDataTransport/GDTTests/Unit/GDTUploadPackageTest.m
+++ b/GoogleDataTransport/GDTTests/Unit/GDTUploadPackageTest.m
@@ -18,9 +18,14 @@
 
 #import <GoogleDataTransport/GDTClock.h>
 #import <GoogleDataTransport/GDTUploadPackage.h>
+#import <GoogleDataTransport/GDTRegistrar.h>
 
 #import "GDTLibrary/Private/GDTUploadPackage_Private.h"
+
 #import "GDTTests/Unit/Helpers/GDTEventGenerator.h"
+#import "GDTTests/Unit/Helpers/GDTTestPrioritizer.h"
+#import "GDTTests/Unit/Helpers/GDTTestUploadPackage.h"
+#import "GDTTests/Unit/Helpers/GDTTestUploader.h"
 
 @interface GDTUploadPackageTest : GDTTestCase <NSSecureCoding, GDTUploadPackageProtocol>
 
@@ -70,6 +75,19 @@
 /** Tests the default initializer. */
 - (void)testInit {
   XCTAssertNotNil([[GDTUploadPackage alloc] initWithTarget:kGDTTargetTest]);
+}
+
+/** Tests that calling -completeDelivery twice on the same package asserts. */
+- (void)testCompleteDeliveryTwiceAsserts {
+  GDTTestPrioritizer *prioritizer = [[GDTTestPrioritizer alloc] init];
+  GDTTestUploader *uploader = [[GDTTestUploader alloc] init];
+
+  [[GDTRegistrar sharedInstance] registerPrioritizer:prioritizer target:kGDTTargetTest];
+  [[GDTRegistrar sharedInstance] registerUploader:uploader target:kGDTTargetTest];
+
+  GDTUploadPackage *uploadPackage = [[GDTUploadPackage alloc] initWithTarget:kGDTTargetTest];
+  [uploadPackage completeDelivery];
+  XCTAssertThrows([uploadPackage completeDelivery]);
 }
 
 /** Tests copying indicates that the underlying sets of events can't be changed from underneath. */

--- a/GoogleDataTransport/GDTTests/Unit/Helpers/GDTTestPrioritizer.h
+++ b/GoogleDataTransport/GDTTests/Unit/Helpers/GDTTestPrioritizer.h
@@ -25,8 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface GDTTestPrioritizer : NSObject <GDTPrioritizer>
 
-/** The return value of -uploadPackageWithConditions. */
-@property(nullable, nonatomic) GDTUploadPackage *uploadPackage;
+/** The events in the package given by -uploadPackageWithConditions. */
+@property(nullable, nonatomic) NSSet<GDTStoredEvent *> *events;
 
 /** Allows the running of a block of code during -prioritizeEvent. */
 @property(nullable, nonatomic) void (^prioritizeEventBlock)(GDTStoredEvent *event);

--- a/GoogleDataTransport/GDTTests/Unit/Helpers/GDTTestPrioritizer.m
+++ b/GoogleDataTransport/GDTTests/Unit/Helpers/GDTTestPrioritizer.m
@@ -20,19 +20,13 @@
 
 @implementation GDTTestPrioritizer
 
-- (instancetype)init {
-  self = [super init];
-  if (self) {
-    _uploadPackage = [[GDTTestUploadPackage alloc] initWithTarget:kGDTTargetTest];
-  }
-  return self;
-}
-
 - (GDTUploadPackage *)uploadPackageWithConditions:(GDTUploadConditions)conditions {
   if (_uploadPackageWithConditionsBlock) {
     _uploadPackageWithConditionsBlock();
   }
-  return _uploadPackage;
+  GDTUploadPackage *uploadPackage = [[GDTUploadPackage alloc] initWithTarget:kGDTTargetTest];
+  uploadPackage.events = _events;
+  return uploadPackage;
 }
 
 - (void)prioritizeEvent:(GDTStoredEvent *)event {


### PR DESCRIPTION
This avoids a lot of housekeeping and situations in which two packages could be created by a prioritizer that have overlapping events in them.

