### PR TITLE
Add test_spec for FirebaseStorage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,16 +55,6 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-libraries --skip-tests
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-modular-headers --skip-tests
 
-    # The Storage integration tests cannot handle the parallelism of being run from pod lib lint.
-    - stage: test
-      if: fork = false
-      env:
-        - PROJECT=Storage PLATFORM=all METHOD=integration
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
-      script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
-
     - stage: test
       env:
         - PROJECT=Functions PLATFORM=iOS METHOD=pod-lib-lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,24 +44,28 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseCore.podspec --use-modular-headers
 
     - stage: test
-      if: fork = false
       env:
-        - PROJECT=Storage PLATFORM=iOS METHOD=pod-lib-lint
+        - PROJECT=Storage PLATFORM=iOS METHOD=xcodebuild
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-libraries
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-modular-headers
+        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
-      if: fork = true
+      if: fork = false
+      env:
+        - PROJECT=Storage PLATFORM=iOS METHOD=integration
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
+
+    - stage: test
       env:
         - PROJECT=Storage PLATFORM=iOS METHOD=pod-lib-lint
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
-        # TODO Add tests for forks.
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --skip-tests
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-libraries --skip-tests
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-modular-headers --skip-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,6 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseDynamicLinks.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseInstanceID.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseMessaging.podspec
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseInAppMessaging.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseInAppMessagingDisplay.podspec
 
@@ -138,7 +137,6 @@ jobs:
         - travis_retry ./scripts/pod_lib_lint.sh FirebaseInstanceID.podspec --use-libraries
         # The Protobuf dependency of FirebaseMessaging has warnings with --use-libraries
         - travis_retry ./scripts/pod_lib_lint.sh FirebaseMessaging.podspec --use-libraries --allow-warnings
-        - travis_retry ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.sh FirebaseInAppMessaging.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.sh FirebaseInAppMessagingDisplay.podspec --use-libraries
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,29 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseCore.podspec --use-modular-headers
 
     - stage: test
+      if: fork = false
+      env:
+        - PROJECT=Storage PLATFORM=iOS METHOD=pod-lib-lint
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-libraries
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-modular-headers
+
+    - stage: test
+      if: fork = true
+      env:
+        - PROJECT=Storage PLATFORM=iOS METHOD=pod-lib-lint
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        # TODO Add tests for forks.
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --skip-tests
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-libraries --skip-tests
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-modular-headers --skip-tests
+
+    - stage: test
       env:
         - PROJECT=Functions PLATFORM=iOS METHOD=pod-lib-lint
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,12 @@ jobs:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
+        # The pod lib lint tests are fast enough that it's not worth a separate stage.
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --skip-tests
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-libraries --skip-tests
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-modular-headers --skip-tests
 
+    # The Storage integration tests cannot handle the parallelism of being run from pod lib lint.
     - stage: test
       if: fork = false
       env:
@@ -59,16 +64,6 @@ jobs:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
-
-    - stage: test
-      env:
-        - PROJECT=Storage PLATFORM=iOS METHOD=pod-lib-lint
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
-      script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --skip-tests
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-libraries --skip-tests
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-modular-headers --skip-tests
 
     - stage: test
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
 
     - stage: test
       env:
-        - PROJECT=Storage PLATFORM=iOS METHOD=xcodebuild
+        - PROJECT=Storage PLATFORM=all METHOD=xcodebuild
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
@@ -54,7 +54,7 @@ jobs:
     - stage: test
       if: fork = false
       env:
-        - PROJECT=Storage PLATFORM=iOS METHOD=integration
+        - PROJECT=Storage PLATFORM=all METHOD=integration
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:

--- a/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
@@ -18,7 +18,7 @@
 #import <FirebaseCore/FIRApp.h>
 #import <FirebaseCore/FIROptions.h>
 
-NSTimeInterval kFIRStorageIntegrationTestTimeout = 30;
+NSTimeInterval kFIRStorageIntegrationTestTimeout = 60;
 
 /**
  * Firebase Storage Integration tests
@@ -69,8 +69,15 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 30;
     XCTestExpectation *expectation = [self expectationWithDescription:@"setup"];
 
     FIRStorageReference *ref = [[FIRStorage storage].reference child:@"ios/public/1mb"];
-    NSData *data = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"1mb"
-                                                                                  ofType:@"dat"]];
+
+    NSString *filePath = [[NSBundle mainBundle] pathForResource:@"1mb" ofType:@"dat"];
+    if (filePath == nil) {
+      // Use bundleForClass to allow 1mb.dat to be in the test target's bundle.
+      NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+      filePath = [bundle pathForResource:@"1mb" ofType:@"dat"];
+    }
+    NSData *data =  [NSData dataWithContentsOfFile:filePath];
+
     XCTAssertNotNil(data, "Could not load bundled file");
     [ref putData:data
           metadata:nil
@@ -309,7 +316,7 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 30;
                               [[snapshot description] containsString:@"State: Resume"]);
                 NSProgress *progress = snapshot.progress;
                 XCTAssertGreaterThanOrEqual(progress.completedUnitCount, uploadedBytes);
-                uploadedBytes = progress.completedUnitCount;
+                uploadedBytes = (long)progress.completedUnitCount;
               }];
 
   [self waitForExpectations];
@@ -645,7 +652,7 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 30;
                               [[snapshot description] containsString:@"State: Resume"]);
                 NSProgress *progress = snapshot.progress;
                 XCTAssertGreaterThanOrEqual(progress.completedUnitCount, downloadedBytes);
-                downloadedBytes = progress.completedUnitCount;
+                downloadedBytes = (long)progress.completedUnitCount;
                 if (progress.completedUnitCount > resumeAtBytes) {
                   // Making sure the main run loop is busy.
                   for (int i = 0; i < 500; ++i) {
@@ -698,7 +705,7 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 30;
                               [[snapshot description] containsString:@"State: Resume"]);
                 NSProgress *progress = snapshot.progress;
                 XCTAssertGreaterThanOrEqual(progress.completedUnitCount, downloadedBytes);
-                downloadedBytes = progress.completedUnitCount;
+                downloadedBytes = (long)progress.completedUnitCount;
                 if (progress.completedUnitCount > resumeAtBytes) {
                   NSLog(@"Pausing");
                   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -37,4 +37,18 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
     'GCC_PREPROCESSOR_DEFINITIONS' =>
       'FIRStorage_VERSION=' + s.version.to_s
   }
+
+  s.test_spec 'unit' do |unit_tests|
+    unit_tests.source_files = 'Example/Storage/Tests/Unit/*.[mh]',
+                              'Example/Shared/FIRComponentTestUtilities.*',
+                              'Example/Shared/FIRAuthInteropFake.*'
+    unit_tests.dependency 'OCMock'
+  end
+
+  s.test_spec 'integration' do |int_tests|
+    int_tests.source_files = 'Example/Storage/Tests/Integration/*.[mh]'
+    int_tests.requires_app_host = true
+    int_tests.resources = 'Example/Storage/App/1mb.dat',
+                          'Example/Storage/App/GoogleService-Info.plist'
+  end
 end

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -102,19 +102,19 @@ tvos_flags=(
 # Compute standard flags for all platforms
 case "$platform" in
   iOS)
-    xcb_flags= "${ios_flags[@]}"
+    xcb_flags="${ios_flags[@]}"
     ;;
 
   macOS)
-    xcb_flags= "${macos_flags[@]}"
+    xcb_flags="${macos_flags[@]}"
     ;;
 
   tvOS)
-    xcb_flags= "${tvos_flags[@]}"
+    xcb_flags="${tvos_flags[@]}"
     ;;
 
   all)
-    xcb_flag=()
+    xcb_flags=()
     ;;
 
   *)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -376,7 +376,7 @@ case "$product-$method-$platform" in
         test
     ;;
 
-  Storage-*-xcodebuild)
+  Storage-xcodebuild-*)
     RunXcodebuild \
       -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
       -scheme "FirebaseStorage-iOS-Unit-unit" \
@@ -397,7 +397,7 @@ case "$product-$method-$platform" in
       test
     ;;
 
-  Storage-*-integration)
+  Storage-integration-*)
     RunXcodebuild \
       -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
       -scheme "FirebaseStorage-iOS-Unit-integration" \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -86,27 +86,35 @@ function RunXcodebuild() {
   fi
 }
 
+ios_flags=(
+  -sdk 'iphonesimulator'
+  -destination 'platform=iOS Simulator,name=iPhone 7'
+)
+macos_flags=(
+  -sdk 'macosx'
+  -destination 'platform=OS X,arch=x86_64'
+)
+tvos_flags=(
+  -sdk "appletvsimulator"
+  -destination 'platform=tvOS Simulator,name=Apple TV'
+)
+
 # Compute standard flags for all platforms
 case "$platform" in
   iOS)
-    xcb_flags=(
-      -sdk 'iphonesimulator'
-      -destination 'platform=iOS Simulator,name=iPhone 7'
-    )
+    xcb_flags=ios_flags
     ;;
 
   macOS)
-    xcb_flags=(
-      -sdk 'macosx'
-      -destination 'platform=OS X,arch=x86_64'
-    )
+    xcb_flags=macos_flags
     ;;
 
   tvOS)
-    xcb_flags=(
-      -sdk "appletvsimulator"
-      -destination 'platform=tvOS Simulator,name=Apple TV'
-    )
+    xcb_flags=tvos_flags
+    ;;
+
+  all)
+    xcb_flag=()
     ;;
 
   *)
@@ -380,18 +388,21 @@ case "$product-$method-$platform" in
     RunXcodebuild \
       -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
       -scheme "FirebaseStorage-iOS-Unit-unit" \
+      "${ios_flags[@]}" \
       "${xcb_flags[@]}" \
       build \
       test
     RunXcodebuild \
       -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
       -scheme "FirebaseStorage-macOS-Unit-unit" \
+      "${macos_flags[@]}" \
       "${xcb_flags[@]}" \
       build \
       test
     RunXcodebuild \
       -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
       -scheme "FirebaseStorage-tvOS-Unit-unit" \
+      "${tvos_flags[@]}" \
       "${xcb_flags[@]}" \
       build \
       test
@@ -401,18 +412,21 @@ case "$product-$method-$platform" in
     RunXcodebuild \
       -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
       -scheme "FirebaseStorage-iOS-Unit-integration" \
+      "${ios_flags[@]}" \
       "${xcb_flags[@]}" \
       build \
       test
     RunXcodebuild \
       -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
       -scheme "FirebaseStorage-macOS-Unit-integration" \
+      "${macos_flags[@]}" \
       "${xcb_flags[@]}" \
       build \
       test
     RunXcodebuild \
       -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
       -scheme "FirebaseStorage-tvOS-Unit-integration" \
+      "${tvos_flags[@]}" \
       "${xcb_flags[@]}" \
       build \
       test

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -368,7 +368,7 @@ case "$product-$method-$platform" in
         build \
         test
 
-        RunXcodebuild \
+    RunXcodebuild \
         -workspace 'GoogleDataTransportCCTSupport/gen/GoogleDataTransportCCTSupport/GoogleDataTransportCCTSupport.xcworkspace' \
         -scheme "GoogleDataTransportCCTSupport-Unit-Tests-Integration" \
         "${xcb_flags[@]}" \
@@ -376,6 +376,46 @@ case "$product-$method-$platform" in
         test
     ;;
 
+  Storage-*-xcodebuild)
+    RunXcodebuild \
+      -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
+      -scheme "FirebaseStorage-iOS-Unit-unit" \
+      "${xcb_flags[@]}" \
+      build \
+      test
+    RunXcodebuild \
+      -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
+      -scheme "FirebaseStorage-macOS-Unit-unit" \
+      "${xcb_flags[@]}" \
+      build \
+      test
+    RunXcodebuild \
+      -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
+      -scheme "FirebaseStorage-tvOS-Unit-unit" \
+      "${xcb_flags[@]}" \
+      build \
+      test
+    ;;
+
+  Storage-*-integration)
+    RunXcodebuild \
+      -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
+      -scheme "FirebaseStorage-iOS-Unit-integration" \
+      "${xcb_flags[@]}" \
+      build \
+      test
+    RunXcodebuild \
+      -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
+      -scheme "FirebaseStorage-macOS-Unit-integration" \
+      "${xcb_flags[@]}" \
+      build \
+      test
+    RunXcodebuild \
+      -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
+      -scheme "FirebaseStorage-tvOS-Unit-integration" \
+      "${xcb_flags[@]}" \
+      build \
+      test
   *)
     echo "Don't know how to build this product-platform-method combination" 1>&2
     echo "  product=$product" 1>&2

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -416,6 +416,7 @@ case "$product-$method-$platform" in
       "${xcb_flags[@]}" \
       build \
       test
+    ;;
   *)
     echo "Don't know how to build this product-platform-method combination" 1>&2
     echo "  product=$product" 1>&2

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -406,30 +406,31 @@ case "$product-$method-$platform" in
       "${xcb_flags[@]}" \
       build \
       test
-    ;;
 
-  Storage-integration-*)
-    RunXcodebuild \
-      -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
-      -scheme "FirebaseStorage-iOS-Unit-integration" \
-      "${ios_flags[@]}" \
-      "${xcb_flags[@]}" \
-      build \
-      test
-    RunXcodebuild \
-      -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
-      -scheme "FirebaseStorage-macOS-Unit-integration" \
-      "${macos_flags[@]}" \
-      "${xcb_flags[@]}" \
-      build \
-      test
-    RunXcodebuild \
-      -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
-      -scheme "FirebaseStorage-tvOS-Unit-integration" \
-      "${tvos_flags[@]}" \
-      "${xcb_flags[@]}" \
-      build \
-      test
+    if [[ "$TRAVIS_PULL_REQUEST" == "false" ||
+          "TRAVIS_PULL_REQUEST_SLUG" == "$TRAVIS_REPO_SLUG" ]]; then
+      RunXcodebuild \
+        -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
+        -scheme "FirebaseStorage-iOS-Unit-integration" \
+        "${ios_flags[@]}" \
+        "${xcb_flags[@]}" \
+        build \
+        test
+      RunXcodebuild \
+        -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
+        -scheme "FirebaseStorage-macOS-Unit-integration" \
+        "${macos_flags[@]}" \
+        "${xcb_flags[@]}" \
+        build \
+        test
+      RunXcodebuild \
+        -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
+        -scheme "FirebaseStorage-tvOS-Unit-integration" \
+        "${tvos_flags[@]}" \
+        "${xcb_flags[@]}" \
+        build \
+        test
+      fi
     ;;
   *)
     echo "Don't know how to build this product-platform-method combination" 1>&2

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -102,15 +102,15 @@ tvos_flags=(
 # Compute standard flags for all platforms
 case "$platform" in
   iOS)
-    xcb_flags=ios_flags
+    xcb_flags= "${ios_flags[@]}"
     ;;
 
   macOS)
-    xcb_flags=macos_flags
+    xcb_flags= "${macos_flags[@]}"
     ;;
 
   tvOS)
-    xcb_flags=tvos_flags
+    xcb_flags= "${tvos_flags[@]}"
     ;;
 
   all)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -402,24 +402,11 @@ case "$product-$method-$platform" in
 
     if [[ "$TRAVIS_PULL_REQUEST" == "false" ||
           "$TRAVIS_PULL_REQUEST_SLUG" == "$TRAVIS_REPO_SLUG" ]]; then
+      # Integration tests are only run on iOS to minimize flake failures.
       RunXcodebuild \
         -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
         -scheme "FirebaseStorage-iOS-Unit-integration" \
         "${ios_flags[@]}" \
-        "${xcb_flags[@]}" \
-        build \
-        test
-      RunXcodebuild \
-        -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
-        -scheme "FirebaseStorage-macOS-Unit-integration" \
-        "${macos_flags[@]}" \
-        "${xcb_flags[@]}" \
-        build \
-        test
-      RunXcodebuild \
-        -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
-        -scheme "FirebaseStorage-tvOS-Unit-integration" \
-        "${tvos_flags[@]}" \
         "${xcb_flags[@]}" \
         build \
         test

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -408,7 +408,7 @@ case "$product-$method-$platform" in
       test
 
     if [[ "$TRAVIS_PULL_REQUEST" == "false" ||
-          "TRAVIS_PULL_REQUEST_SLUG" == "$TRAVIS_REPO_SLUG" ]]; then
+          "$TRAVIS_PULL_REQUEST_SLUG" == "$TRAVIS_REPO_SLUG" ]]; then
       RunXcodebuild \
         -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
         -scheme "FirebaseStorage-iOS-Unit-integration" \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -210,13 +210,6 @@ case "$product-$method-$platform" in
 
         RunXcodebuild \
           -workspace 'Example/Firebase.xcworkspace' \
-          -scheme "Storage_IntegrationTests_iOS" \
-          "${xcb_flags[@]}" \
-          build \
-          test
-
-        RunXcodebuild \
-          -workspace 'Example/Firebase.xcworkspace' \
           -scheme "Database_IntegrationTests_iOS" \
           "${xcb_flags[@]}" \
           build \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -102,15 +102,15 @@ tvos_flags=(
 # Compute standard flags for all platforms
 case "$platform" in
   iOS)
-    xcb_flags="${ios_flags[@]}"
+    xcb_flags=("${ios_flags[@]}")
     ;;
 
   macOS)
-    xcb_flags="${macos_flags[@]}"
+    xcb_flags=("${macos_flags[@]}")
     ;;
 
   tvOS)
-    xcb_flags="${tvos_flags[@]}"
+    xcb_flags=("${tvos_flags[@]}")
     ;;
 
   all)

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -160,7 +160,7 @@ fi
 
 # Show Travis-related environment variables, to help with debuging failures.
 if [[ "${VERBOSE}" == true ]]; then
-  env | egrep '^TRAVIS_(BRANCH|COMMIT|PULL)' | sort || true
+  env | egrep '^TRAVIS_(BRANCH|COMMIT|PULL|REPO)' | sort || true
 fi
 
 # When travis clones a repo for building, it uses a shallow clone. When

--- a/scripts/if_changed.sh
+++ b/scripts/if_changed.sh
@@ -67,7 +67,7 @@ else
       ;;
 
     Core-*)
-      check_changes '^(Firebase/Core|GoogleUtilities|FirebaseCore.podspec)'
+      check_changes '^(Firebase/Core|Example/Core/Tests|GoogleUtilities|FirebaseCore.podspec)'
       ;;
 
     Functions-*)
@@ -94,6 +94,10 @@ else
 
     GoogleDataTransportCCTSupport-*)
       check_changes '^(GoogleDataTransportCCTSupport|GoogleDataTransportCCTSupport.podspec|GoogleDataTransport|GoogleDataTransport.podspec)'
+      ;;
+
+    Storage-*)
+      check_changes '^(Firebase/Core|Firebase/Storage|Example/Storage|GoogleUtilities|FirebaseStorage.podspec)'
       ;;
 
     *)

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -21,35 +21,38 @@
 
 bundle install
 
+function install_secrets() {
+  # Set up secrets for integration tests and metrics collection. This does not work for pull
+  # requests from forks. See
+  # https://docs.travis-ci.com/user/pull-requests#pull-requests-and-security-restrictions
+  if [[ ! -z $encrypted_d6a88994a5ab_key ]]; then
+    openssl aes-256-cbc -K $encrypted_d6a88994a5ab_key -iv $encrypted_d6a88994a5ab_iv \
+    -in scripts/travis-encrypted/Secrets.tar.enc \
+    -out scripts/travis-encrypted/Secrets.tar -d
+
+    tar xvf scripts/travis-encrypted/Secrets.tar
+
+    cp Secrets/Auth/Sample/Application.plist Example/Auth/Sample/Application.plist
+    cp Secrets/Auth/Sample/AuthCredentials.h Example/Auth/Sample/AuthCredentials.h
+    cp Secrets/Auth/Sample/GoogleService-Info_multi.plist Example/Auth/Sample/GoogleService-Info_multi.plist
+    cp Secrets/Auth/Sample/GoogleService-Info.plist Example/Auth/Sample/GoogleService-Info.plist
+    cp Secrets/Auth/Sample/Sample.entitlements Example/Auth/Sample/Sample.entitlements
+    cp Secrets/Auth/ApiTests/AuthCredentials.h Example/Auth/ApiTests/AuthCredentials.h
+
+    cp Secrets/Storage/App/GoogleService-Info.plist Example/Storage/App/GoogleService-Info.plist
+    cp Secrets/Storage/App/GoogleService-Info.plist Example/Database/App/GoogleService-Info.plist
+
+    cp Secrets/Metrics/database.config Metrics/database.config
+  fi
+}
+
 case "$PROJECT-$PLATFORM-$METHOD" in
   Firebase-iOS-xcodebuild)
     gem install xcpretty
     bundle exec pod install --project-directory=Example --repo-update
     bundle exec pod install --project-directory=Functions/Example
     bundle exec pod install --project-directory=GoogleUtilities/Example
-
-    # Set up secrets for integration tests and metrics collection. This does not work for pull
-    # requests from forks. See
-    # https://docs.travis-ci.com/user/pull-requests#pull-requests-and-security-restrictions
-    if [[ ! -z $encrypted_d6a88994a5ab_key ]]; then
-      openssl aes-256-cbc -K $encrypted_d6a88994a5ab_key -iv $encrypted_d6a88994a5ab_iv \
-      -in scripts/travis-encrypted/Secrets.tar.enc \
-      -out scripts/travis-encrypted/Secrets.tar -d
-
-      tar xvf scripts/travis-encrypted/Secrets.tar
-
-      cp Secrets/Auth/Sample/Application.plist Example/Auth/Sample/Application.plist
-      cp Secrets/Auth/Sample/AuthCredentials.h Example/Auth/Sample/AuthCredentials.h
-      cp Secrets/Auth/Sample/GoogleService-Info_multi.plist Example/Auth/Sample/GoogleService-Info_multi.plist
-      cp Secrets/Auth/Sample/GoogleService-Info.plist Example/Auth/Sample/GoogleService-Info.plist
-      cp Secrets/Auth/Sample/Sample.entitlements Example/Auth/Sample/Sample.entitlements
-      cp Secrets/Auth/ApiTests/AuthCredentials.h Example/Auth/ApiTests/AuthCredentials.h
-
-      cp Secrets/Storage/App/GoogleService-Info.plist Example/Storage/App/GoogleService-Info.plist
-      cp Secrets/Storage/App/GoogleService-Info.plist Example/Database/App/GoogleService-Info.plist
-
-      cp Secrets/Metrics/database.config Metrics/database.config
-    fi
+    install_secrets
     ;;
 
   Firebase-*-xcodebuild)
@@ -62,6 +65,11 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     bundle exec pod repo update
     # Start server for Functions integration tests.
     ./Functions/Backend/start.sh synchronous
+    ;;
+
+  Storage-*)
+    bundle exec pod repo update
+    install_secrets
     ;;
 
   InAppMessaging-iOS-xcodebuild)

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -62,13 +62,14 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     ;;
 
   Functions-*)
-    bundle exec pod repo update
     # Start server for Functions integration tests.
     ./Functions/Backend/start.sh synchronous
     ;;
 
   Storage-*)
-    bundle exec pod repo update
+    # Install the workspace to have better control over test runs than
+    # pod lib lint, since the integration tests can be flaky.
+    bundle exec pod gen FirebaseStorage.podspec --local-sources=./
     install_secrets
     ;;
 

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -70,9 +70,7 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     # Install the workspace to have better control over test runs than
     # pod lib lint, since the integration tests can be flaky.
     bundle exec pod gen FirebaseStorage.podspec --local-sources=./
-    if [[ $METHOD = "integration" ]]; then
-      install_secrets
-    fi
+    install_secrets
     ;;
 
   InAppMessaging-iOS-xcodebuild)

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -70,7 +70,9 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     # Install the workspace to have better control over test runs than
     # pod lib lint, since the integration tests can be flaky.
     bundle exec pod gen FirebaseStorage.podspec --local-sources=./
-    install_secrets
+    if [[ $METHOD = "integration" ]]; then
+      install_secrets
+    fi
     ;;
 
   InAppMessaging-iOS-xcodebuild)


### PR DESCRIPTION
- Add unit and integration test specs for FirebaseStorage.
- Add a complete Storage build and test rule.
- Extend an integration test timeout to fix a flake running `pod lib lint` locally.
- Fix build warnings in integration test source.
- Update integration tests to handle `1mb.dat` in either the main bundle or the the test target bundle.
- Run integration tests on all builds in the repo including PRs - only external PRs will not run them now.
- The old build environment is still supported.
- It will be removed when all pods have transitioned to test_specs and `pod gen`.
- For now, see the instructions at https://github.com/firebase/firebase-ios-sdk/blob/master/Functions/README.md.