### PR TITLE
Rewrite FieldValue tests to match the Android port

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -200,6 +200,9 @@
 		54740A571FC914BA00713A1A /* secure_random_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54740A531FC913E500713A1A /* secure_random_test.cc */; };
 		54740A581FC914F000713A1A /* autoid_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54740A521FC913E500713A1A /* autoid_test.cc */; };
 		54764FAF1FAA21B90085E60A /* FSTGoogleTestTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 54764FAE1FAA21B90085E60A /* FSTGoogleTestTests.mm */; };
+		548180A5228DEF1A004F70CD /* FSTUserDataConverterTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 548180A4228DEF1A004F70CD /* FSTUserDataConverterTests.mm */; };
+		548180A6228DEF1A004F70CD /* FSTUserDataConverterTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 548180A4228DEF1A004F70CD /* FSTUserDataConverterTests.mm */; };
+		548180A7228DEF1A004F70CD /* FSTUserDataConverterTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 548180A4228DEF1A004F70CD /* FSTUserDataConverterTests.mm */; };
 		548DB929200D59F600E00ABC /* comparison_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 548DB928200D59F600E00ABC /* comparison_test.cc */; };
 		5491BC721FB44593008B3588 /* FSTIntegrationTestCase.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5491BC711FB44593008B3588 /* FSTIntegrationTestCase.mm */; };
 		5491BC731FB44593008B3588 /* FSTIntegrationTestCase.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5491BC711FB44593008B3588 /* FSTIntegrationTestCase.mm */; };
@@ -746,7 +749,7 @@
 		132E32997D781B896672D30A /* reference_set_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = reference_set_test.cc; sourceTree = "<group>"; };
 		132E36BB104830BD806351AC /* FSTLevelDBTransactionTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FSTLevelDBTransactionTests.mm; sourceTree = "<group>"; };
 		132E3BB3D5C42282B4ACFB20 /* FSTLevelDBBenchmarkTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FSTLevelDBBenchmarkTests.mm; sourceTree = "<group>"; };
-		1B342370EAE3AA02393E33EB /* cc_compilation_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; name = cc_compilation_test.cc; path = api/cc_compilation_test.cc; sourceTree = "<group>"; };
+		1B342370EAE3AA02393E33EB /* cc_compilation_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = cc_compilation_test.cc; path = api/cc_compilation_test.cc; sourceTree = "<group>"; };
 		2220F583583EFC28DE792ABE /* Pods_Firestore_IntegrationTests_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Firestore_IntegrationTests_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2A0CF41BA5AED6049B0BEB2C /* objc_type_traits_apple_test.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; path = objc_type_traits_apple_test.mm; sourceTree = "<group>"; };
 		2B50B3A0DF77100EEE887891 /* Pods_Firestore_Tests_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Firestore_Tests_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -764,8 +767,8 @@
 		403DBF6EFB541DFD01582AA3 /* path_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = path_test.cc; sourceTree = "<group>"; };
 		4425A513895DEC60325A139E /* xcgmock_test.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; path = xcgmock_test.mm; sourceTree = "<group>"; };
 		444B7AB3F5A2929070CB1363 /* hard_assert_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = hard_assert_test.cc; sourceTree = "<group>"; };
-		4C73C0CC6F62A90D8573F383 /* string_apple_benchmark.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = string_apple_benchmark.mm; sourceTree = "<group>"; };
-		535B1420A19BEAA7FA4D77C8 /* ordered_code_benchmark.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = ordered_code_benchmark.mm; sourceTree = "<group>"; };
+		4C73C0CC6F62A90D8573F383 /* string_apple_benchmark.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; path = string_apple_benchmark.mm; sourceTree = "<group>"; };
+		535B1420A19BEAA7FA4D77C8 /* ordered_code_benchmark.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; path = ordered_code_benchmark.mm; sourceTree = "<group>"; };
 		54131E9620ADE678001DF3FF /* string_format_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_format_test.cc; sourceTree = "<group>"; };
 		544129D021C2DDC800EFB9CC /* query.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = query.pb.h; sourceTree = "<group>"; };
 		544129D121C2DDC800EFB9CC /* common.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.pb.h; sourceTree = "<group>"; };
@@ -786,6 +789,7 @@
 		54740A521FC913E500713A1A /* autoid_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = autoid_test.cc; sourceTree = "<group>"; };
 		54740A531FC913E500713A1A /* secure_random_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = secure_random_test.cc; sourceTree = "<group>"; };
 		54764FAE1FAA21B90085E60A /* FSTGoogleTestTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FSTGoogleTestTests.mm; sourceTree = "<group>"; };
+		548180A4228DEF1A004F70CD /* FSTUserDataConverterTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FSTUserDataConverterTests.mm; sourceTree = "<group>"; };
 		548DB928200D59F600E00ABC /* comparison_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = comparison_test.cc; sourceTree = "<group>"; };
 		5491BC711FB44593008B3588 /* FSTIntegrationTestCase.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FSTIntegrationTestCase.mm; sourceTree = "<group>"; };
 		5492E02C20213FFB00B64F25 /* FSTLevelDBSpecTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FSTLevelDBSpecTests.mm; sourceTree = "<group>"; };
@@ -986,9 +990,9 @@
 		ABC1D7E22023CDC500BA84F0 /* firebase_credentials_provider_test.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = firebase_credentials_provider_test.mm; sourceTree = "<group>"; };
 		ABF6506B201131F8005F2C74 /* timestamp_test.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = timestamp_test.cc; sourceTree = "<group>"; };
 		B1A7E1959AF8141FA7E6B888 /* grpc_stream_tester.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = grpc_stream_tester.cc; sourceTree = "<group>"; };
-		B3CC6B2ACFDC873F06AE9E3F /* objc_class_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = objc_class_test.cc; sourceTree = "<group>"; };
+		B3CC6B2ACFDC873F06AE9E3F /* objc_class_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = objc_class_test.cc; sourceTree = "<group>"; };
 		B3F5B3AAE791A5911B9EAA82 /* Pods-Firestore_Tests_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Tests_iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Tests_iOS/Pods-Firestore_Tests_iOS.release.xcconfig"; sourceTree = "<group>"; };
-		B5748BD89DF96FB1B20272F3 /* objc_class_test_helper.mm */ = {isa = PBXFileReference; includeInIndex = 1; path = objc_class_test_helper.mm; sourceTree = "<group>"; };
+		B5748BD89DF96FB1B20272F3 /* objc_class_test_helper.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; path = objc_class_test_helper.mm; sourceTree = "<group>"; };
 		B60894F52170207100EBC644 /* fake_credentials_provider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fake_credentials_provider.h; sourceTree = "<group>"; };
 		B60894F62170207100EBC644 /* fake_credentials_provider.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = fake_credentials_provider.cc; sourceTree = "<group>"; };
 		B6152AD5202A5385000E5744 /* document_key_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = document_key_test.cc; sourceTree = "<group>"; };
@@ -1796,6 +1800,7 @@
 				B65D34A7203C99090076A5E1 /* FIRTimestampTest.m */,
 				5492E047202154AA00B64F25 /* FSTAPIHelpers.h */,
 				5492E04E202154AA00B64F25 /* FSTAPIHelpers.mm */,
+				548180A4228DEF1A004F70CD /* FSTUserDataConverterTests.mm */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -2189,15 +2194,18 @@
 					};
 					5CAE131820FFFED600BE9A4A = {
 						CreatedOnToolsVersion = 9.3.1;
+						DevelopmentTeam = EQHXZ8M8AV;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 6003F589195388D20070C39A;
 					};
 					6003F5AD195388D20070C39A = {
 						CreatedOnToolsVersion = 9.0;
+						DevelopmentTeam = EQHXZ8M8AV;
 						TestTargetID = 6003F589195388D20070C39A;
 					};
 					6EDD3AD120BF247500C33877 = {
 						CreatedOnToolsVersion = 9.0;
+						DevelopmentTeam = EQHXZ8M8AV;
 					};
 					DAFF0CF421E64AC30062958F = {
 						CreatedOnToolsVersion = 10.0;
@@ -2210,9 +2218,11 @@
 					};
 					DE03B2941F2149D600A30B9C = {
 						CreatedOnToolsVersion = 9.0;
+						DevelopmentTeam = EQHXZ8M8AV;
 					};
 					DE29E7F51F2174B000909613 = {
 						CreatedOnToolsVersion = 9.0;
+						DevelopmentTeam = EQHXZ8M8AV;
 					};
 				};
 			};
@@ -3032,6 +3042,7 @@
 				A907244EE37BC32C8D82948E /* FSTSpecTests.mm in Sources */,
 				072D805A94E767DE4D371881 /* FSTSyncEngineTestDriver.mm in Sources */,
 				156B042479C42DB2C3190C63 /* FSTTreeSortedDictionaryTests.m in Sources */,
+				548180A6228DEF1A004F70CD /* FSTUserDataConverterTests.mm in Sources */,
 				3021937CBABFD9270A051900 /* FSTViewSnapshotTest.mm in Sources */,
 				B67BB1DA1E247A87B4755C26 /* FSTViewTests.mm in Sources */,
 				6DCA8E54E652B78EFF3EEDAC /* XCTestCase+Await.mm in Sources */,
@@ -3205,6 +3216,7 @@
 				D5E9954FC1C5ABBC7A180B33 /* FSTSpecTests.mm in Sources */,
 				D69B97FF4C065EACEDD91886 /* FSTSyncEngineTestDriver.mm in Sources */,
 				406939B62E5A6A22ADAB6FE6 /* FSTTreeSortedDictionaryTests.m in Sources */,
+				548180A7228DEF1A004F70CD /* FSTUserDataConverterTests.mm in Sources */,
 				4BB325E8B87A2FA4483AA070 /* FSTViewSnapshotTest.mm in Sources */,
 				0265CCC8BBB76AE013F52411 /* FSTViewTests.mm in Sources */,
 				AAC15E7CCAE79619B2ABB972 /* XCTestCase+Await.mm in Sources */,
@@ -3453,6 +3465,7 @@
 				5492E03520213FFC00B64F25 /* FSTSpecTests.mm in Sources */,
 				5492E03320213FFC00B64F25 /* FSTSyncEngineTestDriver.mm in Sources */,
 				DE2EF0881F3D0B6E003D0CDC /* FSTTreeSortedDictionaryTests.m in Sources */,
+				548180A5228DEF1A004F70CD /* FSTUserDataConverterTests.mm in Sources */,
 				5492E063202154B900B64F25 /* FSTViewSnapshotTest.mm in Sources */,
 				5492E065202154B900B64F25 /* FSTViewTests.mm in Sources */,
 				5492E03C2021401F00B64F25 /* XCTestCase+Await.mm in Sources */,

--- a/Firestore/Example/Tests/API/FSTUserDataConverterTests.mm
+++ b/Firestore/Example/Tests/API/FSTUserDataConverterTests.mm
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "Firestore/Source/API/FSTUserDataConverter.h"
+
+#import <FirebaseFirestore/FIRGeoPoint.h>
+#import <FirebaseFirestore/FIRTimestamp.h>
+#import <XCTest/XCTest.h>
+
+#import "Firestore/Example/Tests/Util/FSTHelpers.h"
+
+#include "Firestore/core/src/firebase/firestore/model/database_id.h"
+#include "Firestore/core/src/firebase/firestore/model/field_value.h"
+
+namespace util = firebase::firestore::util;
+using firebase::firestore::model::DatabaseId;
+using firebase::firestore::model::FieldValue;
+
+@interface FSTUserDataConverterTests : XCTestCase
+@end
+
+@implementation FSTUserDataConverterTests
+
+- (void)testConvertsIntegers {
+  NSArray *values = @[
+    @(INT_MIN), @(-1), @0, @1, @2, @(UCHAR_MAX), @(INT_MAX),  // Standard integers
+    @(LONG_MIN), @(LONG_MAX), @(LLONG_MIN), @(LLONG_MAX)      // Larger values
+  ];
+  for (id value in values) {
+    FSTFieldValue *wrapped = FSTTestFieldValue(value);
+    XCTAssertEqualObjects([wrapped class], [FSTIntegerValue class]);
+    XCTAssertEqualObjects([wrapped value], @([value longLongValue]));
+    XCTAssertEqual(wrapped.type, FieldValue::Type::Integer);
+  }
+}
+
+- (void)testConvertsDoubles {
+  // Note that 0x1.0p-1074 is a hex floating point literal representing the minimum subnormal
+  // number: <https://en.wikipedia.org/wiki/Denormal_number>.
+  NSArray *values = @[
+    @(-INFINITY), @(-DBL_MAX), @(LLONG_MIN * -1.0), @(-1.1), @(-0x1.0p-1074), @(-0.0), @(0.0),
+    @(0x1.0p-1074), @(DBL_MIN), @(1.1), @(LLONG_MAX * 1.0), @(DBL_MAX), @(INFINITY)
+  ];
+  for (id value in values) {
+    FSTFieldValue *wrapped = FSTTestFieldValue(value);
+    XCTAssertEqualObjects([wrapped class], [FSTDoubleValue class]);
+    XCTAssertEqualObjects([wrapped value], value);
+    XCTAssertEqual(wrapped.type, FieldValue::Type::Double);
+  }
+}
+
+- (void)testConvertsNilAndNSNull {
+  FSTNullValue *nullValue = [FSTNullValue nullValue];
+  XCTAssertEqual(FSTTestFieldValue(nil), nullValue);
+  XCTAssertEqual(FSTTestFieldValue([NSNull null]), nullValue);
+  XCTAssertEqual([nullValue value], [NSNull null]);
+  XCTAssertEqual(nullValue.type, FieldValue::Type::Null);
+}
+
+- (void)testConvertsBooleans {
+  NSArray *values = @[ @YES, @NO ];
+  for (id value in values) {
+    FSTFieldValue *wrapped = FSTTestFieldValue(value);
+    XCTAssertEqualObjects([wrapped class], [FSTDelegateValue class]);
+    XCTAssertEqualObjects([wrapped value], value);
+    XCTAssertEqual(wrapped.type, FieldValue::Type::Boolean);
+  }
+
+  // Unsigned chars could conceivably be handled consistently with signed chars but on arm64 these
+  // end up being stored as signed shorts.
+  FSTFieldValue *wrapped = FSTTestFieldValue([NSNumber numberWithUnsignedChar:1]);
+  XCTAssertEqualObjects(wrapped, [FSTIntegerValue integerValue:1]);
+}
+
+union DoubleBits {
+  double d;
+  uint64_t bits;
+};
+
+- (void)testConvertstrings {
+  NSArray *values = @[ @"", @"abc" ];
+  for (id value in values) {
+    FSTFieldValue *wrapped = FSTTestFieldValue(value);
+    XCTAssertEqualObjects([wrapped class], [FSTDelegateValue class]);
+    XCTAssertEqualObjects([wrapped value], value);
+    XCTAssertEqual(wrapped.type, FieldValue::Type::String);
+  }
+}
+
+- (void)testConvertsDates {
+  NSArray *values = @[ FSTTestDate(1900, 12, 1, 1, 20, 30), FSTTestDate(2017, 4, 24, 13, 20, 30) ];
+  for (id value in values) {
+    FSTFieldValue *wrapped = FSTTestFieldValue(value);
+    XCTAssertEqualObjects([wrapped class], [FSTTimestampValue class]);
+    XCTAssertEqualObjects([[wrapped value] class], [FIRTimestamp class]);
+    XCTAssertEqualObjects([wrapped value], [FIRTimestamp timestampWithDate:value]);
+    XCTAssertEqual(wrapped.type, FieldValue::Type::Timestamp);
+  }
+}
+
+- (void)testConvertsGeoPoints {
+  NSArray *values = @[ FSTTestGeoPoint(1.24, 4.56), FSTTestGeoPoint(-20, 100) ];
+
+  for (id value in values) {
+    FSTFieldValue *wrapped = FSTTestFieldValue(value);
+    XCTAssertEqualObjects([wrapped class], [FSTGeoPointValue class]);
+    XCTAssertEqualObjects([wrapped value], value);
+    XCTAssertEqual(wrapped.type, FieldValue::Type::GeoPoint);
+  }
+}
+
+- (void)testConvertsBlobs {
+  NSArray *values = @[ FSTTestData(1, 2, 3), FSTTestData(1, 2) ];
+  for (id value in values) {
+    FSTFieldValue *wrapped = FSTTestFieldValue(value);
+    XCTAssertEqualObjects([wrapped class], [FSTBlobValue class]);
+    XCTAssertEqualObjects([wrapped value], value);
+    XCTAssertEqual(wrapped.type, FieldValue::Type::Blob);
+  }
+}
+
+- (void)testConvertsResourceNames {
+  NSArray *values = @[
+    FSTTestRef("project", DatabaseId::kDefault, @"foo/bar"),
+    FSTTestRef("project", DatabaseId::kDefault, @"foo/baz")
+  ];
+  for (FSTDocumentKeyReference *value in values) {
+    FSTFieldValue *wrapped = FSTTestFieldValue(value);
+    XCTAssertEqualObjects([wrapped class], [FSTReferenceValue class]);
+    XCTAssertEqualObjects([wrapped value], [FSTDocumentKey keyWithDocumentKey:value.key]);
+    XCTAssertTrue(*((FSTReferenceValue *)wrapped).databaseID ==
+                  *(const DatabaseId *)(value.databaseID));
+    XCTAssertEqual(wrapped.type, FieldValue::Type::Reference);
+  }
+}
+
+- (void)testConvertsEmptyObjects {
+  XCTAssertEqualObjects(FSTTestFieldValue(@{}), [FSTObjectValue objectValue]);
+  XCTAssertEqual(FSTTestFieldValue(@{}).type, FieldValue::Type::Object);
+}
+
+- (void)testConvertsSimpleObjects {
+  FSTObjectValue *actual =
+      FSTTestObjectValue(@{@"a" : @"foo", @"b" : @(1L), @"c" : @YES, @"d" : [NSNull null]});
+  FSTObjectValue *expected = [[FSTObjectValue alloc] initWithDictionary:@{
+    @"a" : FieldValue::FromString("foo").Wrap(),
+    @"b" : [FSTIntegerValue integerValue:1LL],
+    @"c" : FieldValue::True().Wrap(),
+    @"d" : [FSTNullValue nullValue]
+  }];
+  XCTAssertEqualObjects(actual, expected);
+  XCTAssertEqual(actual.type, FieldValue::Type::Object);
+}
+
+- (void)testConvertsNestedObjects {
+  FSTObjectValue *actual = FSTTestObjectValue(@{@"a" : @{@"b" : @{@"c" : @"foo"}, @"d" : @YES}});
+  FSTObjectValue *expected = [[FSTObjectValue alloc] initWithDictionary:@{
+    @"a" : [[FSTObjectValue alloc] initWithDictionary:@{
+      @"b" : [[FSTObjectValue alloc]
+          initWithDictionary:@{@"c" : FieldValue::FromString("foo").Wrap()}],
+      @"d" : FieldValue::True().Wrap()
+    }]
+  }];
+  XCTAssertEqualObjects(actual, expected);
+  XCTAssertEqual(actual.type, FieldValue::Type::Object);
+}
+
+- (void)testConvertsArrays {
+  FSTArrayValue *expected = [[FSTArrayValue alloc]
+      initWithValueNoCopy:@[ FieldValue::FromString("value").Wrap(), FieldValue::True().Wrap() ]];
+
+  FSTArrayValue *actual = (FSTArrayValue *)FSTTestFieldValue(@[ @"value", @YES ]);
+  XCTAssertEqualObjects(actual, expected);
+  XCTAssertEqual(actual.type, FieldValue::Type::Array);
+}
+
+- (void)testNSDatesAreConvertedToTimestamps {
+  NSDate *date = [NSDate date];
+  id input = @{@"array" : @[ @1, date ], @"obj" : @{@"date" : date, @"string" : @"hi"}};
+  FSTObjectValue *value = FSTTestObjectValue(input);
+  id output = [value value];
+  {
+    XCTAssertTrue([output[@"array"][1] isKindOfClass:[FIRTimestamp class]]);
+    FIRTimestamp *actual = output[@"array"][1];
+    XCTAssertEqualObjects([FIRTimestamp timestampWithDate:date], actual);
+  }
+  {
+    XCTAssertTrue([output[@"obj"][@"date"] isKindOfClass:[FIRTimestamp class]]);
+    FIRTimestamp *actual = output[@"array"][1];
+    XCTAssertEqualObjects([FIRTimestamp timestampWithDate:date], actual);
+  }
+}
+
+@end

--- a/Firestore/Example/Tests/API/FSTUserDataConverterTests.mm
+++ b/Firestore/Example/Tests/API/FSTUserDataConverterTests.mm
@@ -78,9 +78,14 @@ using firebase::firestore::model::FieldValue;
     XCTAssertEqualObjects([wrapped value], value);
     XCTAssertEqual(wrapped.type, FieldValue::Type::Boolean);
   }
+}
 
-  // Unsigned chars could conceivably be handled consistently with signed chars but on arm64 these
-  // end up being stored as signed shorts.
+- (void)testConvertsUnsignedCharToInteger {
+  // See comments in FSTUserDataConverter regarding handling of signed char. Essentially, signed
+  // char has to be treated as boolean. Unsigned chars could conceivably be handled consistently
+  // with signed chars but on arm64 these end up being stored as signed shorts. This forces us to
+  // choose, and it's more useful to support shorts as Integers than it is to treat unsigned char as
+  // Boolean.
   FSTFieldValue *wrapped = FSTTestFieldValue([NSNumber numberWithUnsignedChar:1]);
   XCTAssertEqualObjects(wrapped, [FSTIntegerValue integerValue:1]);
 }
@@ -90,7 +95,7 @@ union DoubleBits {
   uint64_t bits;
 };
 
-- (void)testConvertstrings {
+- (void)testConvertsStrings {
   NSArray *values = @[ @"", @"abc" ];
   for (id value in values) {
     FSTFieldValue *wrapped = FSTTestFieldValue(value);

--- a/Firestore/Example/Tests/Model/FSTFieldValueTests.mm
+++ b/Firestore/Example/Tests/Model/FSTFieldValueTests.mm
@@ -84,57 +84,6 @@ NSArray *FSTWrapGroups(NSArray *groups) {
   date2 = FSTTestDate(2016, 10, 21, 15, 32, 0);
 }
 
-- (void)testWrapIntegers {
-  NSArray *values = @[
-    @(INT_MIN), @(-1), @0, @1, @2, @(UCHAR_MAX), @(INT_MAX),  // Standard integers
-    @(LONG_MIN), @(LONG_MAX), @(LLONG_MIN), @(LLONG_MAX)      // Larger values
-  ];
-  for (id value in values) {
-    FSTFieldValue *wrapped = FSTTestFieldValue(value);
-    XCTAssertEqualObjects([wrapped class], [FSTIntegerValue class]);
-    XCTAssertEqualObjects([wrapped value], @([value longLongValue]));
-    XCTAssertEqual(wrapped.type, FieldValue::Type::Integer);
-  }
-}
-
-- (void)testWrapsDoubles {
-  // Note that 0x1.0p-1074 is a hex floating point literal representing the minimum subnormal
-  // number: <https://en.wikipedia.org/wiki/Denormal_number>.
-  NSArray *values = @[
-    @(-INFINITY), @(-DBL_MAX), @(LLONG_MIN * -1.0), @(-1.1), @(-0x1.0p-1074), @(-0.0), @(0.0),
-    @(0x1.0p-1074), @(DBL_MIN), @(1.1), @(LLONG_MAX * 1.0), @(DBL_MAX), @(INFINITY)
-  ];
-  for (id value in values) {
-    FSTFieldValue *wrapped = FSTTestFieldValue(value);
-    XCTAssertEqualObjects([wrapped class], [FSTDoubleValue class]);
-    XCTAssertEqualObjects([wrapped value], value);
-    XCTAssertEqual(wrapped.type, FieldValue::Type::Double);
-  }
-}
-
-- (void)testWrapsNilAndNSNull {
-  FSTNullValue *nullValue = [FSTNullValue nullValue];
-  XCTAssertEqual(FSTTestFieldValue(nil), nullValue);
-  XCTAssertEqual(FSTTestFieldValue([NSNull null]), nullValue);
-  XCTAssertEqual([nullValue value], [NSNull null]);
-  XCTAssertEqual(nullValue.type, FieldValue::Type::Null);
-}
-
-- (void)testWrapsBooleans {
-  NSArray *values = @[ @YES, @NO ];
-  for (id value in values) {
-    FSTFieldValue *wrapped = FSTTestFieldValue(value);
-    XCTAssertEqualObjects([wrapped class], [FSTDelegateValue class]);
-    XCTAssertEqualObjects([wrapped value], value);
-    XCTAssertEqual(wrapped.type, FieldValue::Type::Boolean);
-  }
-
-  // Unsigned chars could conceivably be handled consistently with signed chars but on arm64 these
-  // end up being stored as signed shorts.
-  FSTFieldValue *wrapped = FSTTestFieldValue([NSNumber numberWithUnsignedChar:1]);
-  XCTAssertEqualObjects(wrapped, [FSTIntegerValue integerValue:1]);
-}
-
 union DoubleBits {
   double d;
   uint64_t bits;
@@ -217,94 +166,6 @@ union DoubleBits {
 
   // ... but compares positive/negative zero as unequal, compatibly with Firestore.
   XCTAssertNotEqualObjects([FSTDoubleValue doubleValue:0.0], [FSTDoubleValue doubleValue:-0.0]);
-}
-
-- (void)testWrapStrings {
-  NSArray *values = @[ @"", @"abc" ];
-  for (id value in values) {
-    FSTFieldValue *wrapped = FSTTestFieldValue(value);
-    XCTAssertEqualObjects([wrapped class], [FSTDelegateValue class]);
-    XCTAssertEqualObjects([wrapped value], value);
-    XCTAssertEqual(wrapped.type, FieldValue::Type::String);
-  }
-}
-
-- (void)testWrapDates {
-  NSArray *values = @[ FSTTestDate(1900, 12, 1, 1, 20, 30), FSTTestDate(2017, 4, 24, 13, 20, 30) ];
-  for (id value in values) {
-    FSTFieldValue *wrapped = FSTTestFieldValue(value);
-    XCTAssertEqualObjects([wrapped class], [FSTTimestampValue class]);
-    XCTAssertEqualObjects([[wrapped value] class], [FIRTimestamp class]);
-    XCTAssertEqualObjects([wrapped value], [FIRTimestamp timestampWithDate:value]);
-    XCTAssertEqual(wrapped.type, FieldValue::Type::Timestamp);
-  }
-}
-
-- (void)testWrapGeoPoints {
-  NSArray *values = @[ FSTTestGeoPoint(1.24, 4.56), FSTTestGeoPoint(-20, 100) ];
-
-  for (id value in values) {
-    FSTFieldValue *wrapped = FSTTestFieldValue(value);
-    XCTAssertEqualObjects([wrapped class], [FSTGeoPointValue class]);
-    XCTAssertEqualObjects([wrapped value], value);
-    XCTAssertEqual(wrapped.type, FieldValue::Type::GeoPoint);
-  }
-}
-
-- (void)testWrapBlobs {
-  NSArray *values = @[ FSTTestData(1, 2, 3), FSTTestData(1, 2) ];
-  for (id value in values) {
-    FSTFieldValue *wrapped = FSTTestFieldValue(value);
-    XCTAssertEqualObjects([wrapped class], [FSTBlobValue class]);
-    XCTAssertEqualObjects([wrapped value], value);
-    XCTAssertEqual(wrapped.type, FieldValue::Type::Blob);
-  }
-}
-
-- (void)testWrapResourceNames {
-  NSArray *values = @[
-    FSTTestRef("project", DatabaseId::kDefault, @"foo/bar"),
-    FSTTestRef("project", DatabaseId::kDefault, @"foo/baz")
-  ];
-  for (FSTDocumentKeyReference *value in values) {
-    FSTFieldValue *wrapped = FSTTestFieldValue(value);
-    XCTAssertEqualObjects([wrapped class], [FSTReferenceValue class]);
-    XCTAssertEqualObjects([wrapped value], [FSTDocumentKey keyWithDocumentKey:value.key]);
-    XCTAssertTrue(*((FSTReferenceValue *)wrapped).databaseID ==
-                  *(const DatabaseId *)(value.databaseID));
-    XCTAssertEqual(wrapped.type, FieldValue::Type::Reference);
-  }
-}
-
-- (void)testWrapsEmptyObjects {
-  XCTAssertEqualObjects(FSTTestFieldValue(@{}), [FSTObjectValue objectValue]);
-  XCTAssertEqual(FSTTestFieldValue(@{}).type, FieldValue::Type::Object);
-}
-
-- (void)testWrapsSimpleObjects {
-  FSTObjectValue *actual =
-      FSTTestObjectValue(@{@"a" : @"foo", @"b" : @(1L), @"c" : @YES, @"d" : [NSNull null]});
-  FSTObjectValue *expected = [[FSTObjectValue alloc] initWithDictionary:@{
-    @"a" : FieldValue::FromString("foo").Wrap(),
-    @"b" : [FSTIntegerValue integerValue:1LL],
-    @"c" : FieldValue::True().Wrap(),
-    @"d" : [FSTNullValue nullValue]
-  }];
-  XCTAssertEqualObjects(actual, expected);
-  XCTAssertEqual(actual.type, FieldValue::Type::Object);
-}
-
-- (void)testWrapsNestedObjects {
-  FSTObjectValue *actual = FSTTestObjectValue(@{@"a" : @{@"b" : @{@"c" : @"foo"}, @"d" : @YES}});
-  FSTObjectValue *expected = [[FSTObjectValue alloc] initWithDictionary:@{
-    @"a" : [[FSTObjectValue alloc] initWithDictionary:@{
-      @"b" : [[FSTObjectValue alloc]
-          initWithDictionary:@{@"c" : FieldValue::FromString("foo").Wrap()}],
-      @"d" : FieldValue::True().Wrap()
-    }]
-  }];
-  XCTAssertEqualObjects(actual, expected);
-  XCTAssertEqual(actual.type, FieldValue::Type::Object);
 }
 
 - (void)testExtractsFields {
@@ -420,15 +281,6 @@ union DoubleBits {
   mod = [old objectByDeletingPath:testutil::Field("a")];
   XCTAssertEqualObjects(old, FSTTestFieldValue(@{@"a" : @{@"b" : @1}}));
   XCTAssertEqualObjects(mod, FSTTestFieldValue(@{}));
-}
-
-- (void)testArrays {
-  FSTArrayValue *expected = [[FSTArrayValue alloc]
-      initWithValueNoCopy:@[ FieldValue::FromString("value").Wrap(), FieldValue::True().Wrap() ]];
-
-  FSTArrayValue *actual = (FSTArrayValue *)FSTTestFieldValue(@[ @"value", @YES ]);
-  XCTAssertEqualObjects(actual, expected);
-  XCTAssertEqual(actual.type, FieldValue::Type::Array);
 }
 
 - (void)testValueEquality {
@@ -551,23 +403,6 @@ union DoubleBits {
 
   NSArray *wrapped = FSTWrapGroups(groups);
   FSTAssertComparisons(wrapped);
-}
-
-- (void)testValue {
-  NSDate *date = [NSDate date];
-  id input = @{@"array" : @[ @1, date ], @"obj" : @{@"date" : date, @"string" : @"hi"}};
-  FSTObjectValue *value = FSTTestObjectValue(input);
-  id output = [value value];
-  {
-    XCTAssertTrue([output[@"array"][1] isKindOfClass:[FIRTimestamp class]]);
-    FIRTimestamp *actual = output[@"array"][1];
-    XCTAssertEqualObjects([FIRTimestamp timestampWithDate:date], actual);
-  }
-  {
-    XCTAssertTrue([output[@"obj"][@"date"] isKindOfClass:[FIRTimestamp class]]);
-    FIRTimestamp *actual = output[@"array"][1];
-    XCTAssertEqualObjects([FIRTimestamp timestampWithDate:date], actual);
-  }
 }
 
 @end

--- a/Firestore/core/src/firebase/firestore/model/field_value.h
+++ b/Firestore/core/src/firebase/firestore/model/field_value.h
@@ -146,11 +146,6 @@ class FieldValue : public util::Comparable<FieldValue> {
     return *blob_value_;
   }
 
-  const Map& object_value() const {
-    HARD_ASSERT(tag_ == Type::Object);
-    return *object_value_;
-  }
-
   /**
    * Returns a string_view of the blob_value(). This can be useful when using
    * abseil bytewise APIs that accept this type.
@@ -262,6 +257,9 @@ class ObjectValue : public util::Comparable<ObjectValue> {
    * @return A new FieldValue with the field set.
    */
   ObjectValue Set(const FieldPath& field_path, const FieldValue& value) const;
+  ObjectValue Set(const FieldPath& field_path, const ObjectValue& value) const {
+    return Set(field_path, value.fv_);
+  }
 
   /**
    * Returns a FieldValue with the field path deleted. If there is no field at
@@ -280,6 +278,10 @@ class ObjectValue : public util::Comparable<ObjectValue> {
 
   const FieldValue::Map& GetInternalValue() const {
     return *fv_.object_value_;
+  }
+
+  const FieldValue& AsFieldValue() const {
+    return fv_;
   }
 
   util::ComparisonResult CompareTo(const ObjectValue& rhs) const;

--- a/Firestore/core/src/firebase/firestore/model/field_value.h
+++ b/Firestore/core/src/firebase/firestore/model/field_value.h
@@ -146,6 +146,11 @@ class FieldValue : public util::Comparable<FieldValue> {
     return *blob_value_;
   }
 
+  const Map& object_value() const {
+    HARD_ASSERT(tag_ == Type::Object);
+    return *object_value_;
+  }
+
   /**
    * Returns a string_view of the blob_value(). This can be useful when using
    * abseil bytewise APIs that accept this type.

--- a/Firestore/core/test/firebase/firestore/model/field_value_test.cc
+++ b/Firestore/core/test/firebase/firestore/model/field_value_test.cc
@@ -28,7 +28,12 @@ namespace model {
 
 using Type = FieldValue::Type;
 
+using absl::nullopt;
+using testutil::Field;
 using testutil::Key;
+using testutil::Object;
+using testutil::Value;
+using testutil::WrapObject;
 
 namespace {
 
@@ -37,6 +42,125 @@ const uint8_t* Bytes(const char* value) {
 }
 
 }  // namespace
+
+TEST(FieldValueTest, ExtractsFields) {
+  ObjectValue value =
+      WrapObject("foo", Object("a", 1, "b", true, "c", "string"));
+
+  ASSERT_EQ(Type::Object, value.Get(Field("foo"))->type());
+
+  EXPECT_EQ(Value(1), value.Get(Field("foo.a")));
+  EXPECT_EQ(Value(true), value.Get(Field("foo.b")));
+  EXPECT_EQ(Value("string"), value.Get(Field("foo.c")));
+
+  EXPECT_EQ(nullopt, value.Get(Field("foo.a.b")));
+  EXPECT_EQ(nullopt, value.Get(Field("bar")));
+  EXPECT_EQ(nullopt, value.Get(Field("bar.a")));
+}
+
+TEST(FieldValueTest, OverwritesExistingFields) {
+  ObjectValue old = WrapObject("a", "old");
+  ObjectValue mod = old.Set(Field("a"), Value("mod"));
+  EXPECT_NE(old, mod);
+  EXPECT_EQ(WrapObject("a", "old"), old);
+  EXPECT_EQ(WrapObject("a", "mod"), mod);
+}
+
+TEST(FieldValueTest, AddsNewFields) {
+  ObjectValue empty = WrapObject();
+  ObjectValue mod = empty.Set(Field("a"), Value("mod"));
+  EXPECT_EQ(ObjectValue::Empty(), empty);
+  EXPECT_EQ(WrapObject("a", "mod"), mod);
+
+  ObjectValue old = mod;
+  mod = old.Set(Field("b"), Value(1));
+  EXPECT_EQ(WrapObject("a", "mod"), old);
+  EXPECT_EQ(WrapObject("a", "mod", "b", 1), mod);
+}
+
+TEST(FieldValueTest, ImplicitlyCreatesObjects) {
+  ObjectValue old = WrapObject("a", "old");
+  ObjectValue mod = old.Set(Field("b.c.d"), Value("mod"));
+
+  EXPECT_NE(old, mod);
+  EXPECT_EQ(WrapObject("a", "old"), old);
+  EXPECT_EQ(WrapObject("a", "old", "b", Object("c", Object("d", "mod"))), mod);
+}
+
+TEST(FieldValueTest, CanOverwritePrimitivesWithObjects) {
+  ObjectValue old = WrapObject("a", Object("b", "old"));
+  ObjectValue mod = old.Set(Field("a"), Object("b", "mod"));
+  EXPECT_NE(old, mod);
+  EXPECT_EQ(WrapObject("a", Object("b", "old")), old);
+  EXPECT_EQ(WrapObject("a", Object("b", "mod")), mod);
+}
+
+TEST(FieldValueTest, AddsToNestedObjects) {
+  ObjectValue old = WrapObject("a", Object("b", "old"));
+  ObjectValue mod = old.Set(Field("a.c"), Value("mod"));
+  EXPECT_NE(old, mod);
+  EXPECT_EQ(WrapObject("a", Object("b", "old")), old);
+  EXPECT_EQ(WrapObject("a", Object("b", "old", "c", "mod")), mod);
+}
+
+TEST(FieldValueTest, DeletesKey) {
+  ObjectValue old = WrapObject("a", 1, "b", 2);
+  ObjectValue mod = old.Delete(Field("a"));
+
+  EXPECT_NE(old, mod);
+  EXPECT_EQ(WrapObject("a", 1, "b", 2), old);
+  EXPECT_EQ(WrapObject("b", 2), mod);
+
+  ObjectValue empty = mod.Delete(Field("b"));
+  EXPECT_NE(mod, empty);
+  EXPECT_EQ(WrapObject("b", 2), mod);
+  EXPECT_EQ(ObjectValue::Empty(), empty);
+}
+
+TEST(FieldValueTest, DeletesHandleMissingKeys) {
+  ObjectValue old = WrapObject("a", Object("b", 1, "c", 2));
+  ObjectValue mod = old.Delete(Field("b"));
+  EXPECT_EQ(mod, old);
+  EXPECT_EQ(WrapObject("a", Object("b", 1, "c", 2)), mod);
+
+  mod = old.Delete(Field("a.d"));
+  EXPECT_EQ(mod, old);
+  EXPECT_EQ(WrapObject("a", Object("b", 1, "c", 2)), mod);
+
+  mod = old.Delete(Field("a.b.c"));
+  EXPECT_EQ(mod, old);
+  EXPECT_EQ(WrapObject("a", Object("b", 1, "c", 2)), mod);
+}
+
+TEST(FieldValueTest, DeletesNestedKeys) {
+  FieldValue::Map orig =
+      Object("a", Object("b", 1, "c", Object("d", 2, "e", 3))).object_value();
+  ObjectValue old = WrapObject(orig);
+  ObjectValue mod = old.Delete(Field("a.c.d"));
+
+  EXPECT_NE(mod, old);
+  EXPECT_EQ(WrapObject(orig), old);
+
+  FieldValue::Map second =
+      Object("a", Object("b", 1, "c", Object("e", 3))).object_value();
+  EXPECT_EQ(WrapObject(second), mod);
+
+  old = mod;
+  mod = old.Delete(Field("a.c"));
+
+  EXPECT_NE(old, mod);
+  EXPECT_EQ(WrapObject(second), old);
+
+  FieldValue::Map third = Object("a", Object("b", 1)).object_value();
+  EXPECT_EQ(WrapObject(third), mod);
+
+  old = mod;
+  mod = old.Delete(Field("a"));
+
+  EXPECT_NE(old, mod);
+  EXPECT_EQ(WrapObject(third), old);
+  EXPECT_EQ(ObjectValue::Empty(), mod);
+}
 
 TEST(FieldValue, ToString) {
   EXPECT_EQ("null", FieldValue::Null().ToString());
@@ -56,7 +180,8 @@ TEST(FieldValue, ToString) {
             FieldValue::FromTimestamp(Timestamp(12, 42)).ToString());
 
   EXPECT_EQ(
-      "ServerTimestamp(local_write_time=Timestamp(seconds=12, nanoseconds=42))",
+      "ServerTimestamp(local_write_time=Timestamp(seconds=12, "
+      "nanoseconds=42))",
       FieldValue::FromServerTimestamp(Timestamp(12, 42)).ToString());
 
   EXPECT_EQ("", FieldValue::FromString("").ToString());
@@ -539,93 +664,6 @@ TEST(FieldValue, CompareWithOperator) {
   EXPECT_FALSE(small == large);
 }
 
-TEST(FieldValue, Set) {
-  // Set a field in an object.
-  const ObjectValue value = ObjectValue::FromMap({
-      {"a", FieldValue::FromString("A")},
-      {"b", FieldValue::FromMap({
-                {"ba", FieldValue::FromString("BA")},
-            })},
-  });
-  const ObjectValue expected = ObjectValue::FromMap({
-      {"a", FieldValue::FromString("A")},
-      {"b", FieldValue::FromMap({
-                {"ba", FieldValue::FromString("BA")},
-                {"bb", FieldValue::FromString("BB")},
-            })},
-  });
-  EXPECT_EQ(expected,
-            value.Set(testutil::Field("b.bb"), FieldValue::FromString("BB")));
-}
-
-TEST(FieldValue, SetRecursive) {
-  // Set a field in a new object.
-  const ObjectValue value = ObjectValue::FromMap({
-      {"a", FieldValue::FromString("A")},
-  });
-  const ObjectValue expected = ObjectValue::FromMap({
-      {"a", FieldValue::FromString("A")},
-      {"b", FieldValue::FromMap({
-                {"bb", FieldValue::FromString("BB")},
-            })},
-  });
-  EXPECT_EQ(expected,
-            value.Set(testutil::Field("b.bb"), FieldValue::FromString("BB")));
-}
-
-TEST(FieldValue, Delete) {
-  const ObjectValue value = ObjectValue::FromMap({
-      {"a", FieldValue::FromString("A")},
-      {"b", FieldValue::FromMap({
-                {"ba", FieldValue::FromString("BA")},
-                {"bb", FieldValue::FromString("BB")},
-            })},
-  });
-  const ObjectValue expected = ObjectValue::FromMap({
-      {"a", FieldValue::FromString("A")},
-      {"b", FieldValue::FromMap({
-                {"ba", FieldValue::FromString("BA")},
-            })},
-  });
-  EXPECT_EQ(expected, value.Delete(testutil::Field("b.bb")));
-}
-
-TEST(FieldValue, DeleteNothing) {
-  const ObjectValue value = ObjectValue::FromMap({
-      {"a", FieldValue::FromString("A")},
-      {"b", FieldValue::FromMap({
-                {"ba", FieldValue::FromString("BA")},
-                {"bb", FieldValue::FromString("BB")},
-            })},
-  });
-  EXPECT_EQ(value, value.Delete(testutil::Field("aa")));
-}
-
-TEST(FieldValue, Get) {
-  const ObjectValue value = ObjectValue::FromMap({
-      {"a", FieldValue::FromString("A")},
-      {"b", FieldValue::FromMap({
-                {"ba", FieldValue::FromString("BA")},
-                {"bb", FieldValue::FromString("BB")},
-            })},
-  });
-  EXPECT_EQ(FieldValue::FromString("A"), value.Get(testutil::Field("a")));
-  EXPECT_EQ(FieldValue::FromString("BA"), value.Get(testutil::Field("b.ba")));
-  EXPECT_EQ(FieldValue::FromString("BB"), value.Get(testutil::Field("b.bb")));
-}
-
-TEST(FieldValue, GetNothing) {
-  const ObjectValue value = ObjectValue::FromMap({
-      {"a", FieldValue::FromString("A")},
-      {"b", FieldValue::FromMap({
-                {"ba", FieldValue::FromString("BA")},
-                {"bb", FieldValue::FromString("BB")},
-            })},
-  });
-  EXPECT_EQ(absl::nullopt, value.Get(testutil::Field("aa")));
-  EXPECT_EQ(absl::nullopt, value.Get(testutil::Field("a.a")));
-}
-
 TEST(FieldValue, IsSmallish) {
   // We expect the FV to use 4 bytes to track the type of the union, plus 8
   // bytes for the union contents themselves. The other 4 is for padding. We
@@ -633,6 +671,6 @@ TEST(FieldValue, IsSmallish) {
   EXPECT_LE(sizeof(FieldValue), 2 * sizeof(int64_t));
 }
 
-}  //  namespace model
-}  //  namespace firestore
-}  //  namespace firebase
+}  // namespace model
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/core/test/firebase/firestore/model/field_value_test.cc
+++ b/Firestore/core/test/firebase/firestore/model/field_value_test.cc
@@ -31,7 +31,7 @@ using Type = FieldValue::Type;
 using absl::nullopt;
 using testutil::Field;
 using testutil::Key;
-using testutil::Object;
+using testutil::Map;
 using testutil::Value;
 using testutil::WrapObject;
 
@@ -44,8 +44,7 @@ const uint8_t* Bytes(const char* value) {
 }  // namespace
 
 TEST(FieldValueTest, ExtractsFields) {
-  ObjectValue value =
-      WrapObject("foo", Object("a", 1, "b", true, "c", "string"));
+  ObjectValue value = WrapObject("foo", Map("a", 1, "b", true, "c", "string"));
 
   ASSERT_EQ(Type::Object, value.Get(Field("foo"))->type());
 
@@ -67,7 +66,7 @@ TEST(FieldValueTest, OverwritesExistingFields) {
 }
 
 TEST(FieldValueTest, AddsNewFields) {
-  ObjectValue empty = WrapObject();
+  ObjectValue empty = ObjectValue::Empty();
   ObjectValue mod = empty.Set(Field("a"), Value("mod"));
   EXPECT_EQ(ObjectValue::Empty(), empty);
   EXPECT_EQ(WrapObject("a", "mod"), mod);
@@ -84,23 +83,23 @@ TEST(FieldValueTest, ImplicitlyCreatesObjects) {
 
   EXPECT_NE(old, mod);
   EXPECT_EQ(WrapObject("a", "old"), old);
-  EXPECT_EQ(WrapObject("a", "old", "b", Object("c", Object("d", "mod"))), mod);
+  EXPECT_EQ(WrapObject("a", "old", "b", Map("c", Map("d", "mod"))), mod);
 }
 
 TEST(FieldValueTest, CanOverwritePrimitivesWithObjects) {
-  ObjectValue old = WrapObject("a", Object("b", "old"));
-  ObjectValue mod = old.Set(Field("a"), Object("b", "mod"));
+  ObjectValue old = WrapObject("a", Map("b", "old"));
+  ObjectValue mod = old.Set(Field("a"), WrapObject("b", "mod"));
   EXPECT_NE(old, mod);
-  EXPECT_EQ(WrapObject("a", Object("b", "old")), old);
-  EXPECT_EQ(WrapObject("a", Object("b", "mod")), mod);
+  EXPECT_EQ(WrapObject("a", Map("b", "old")), old);
+  EXPECT_EQ(WrapObject("a", Map("b", "mod")), mod);
 }
 
 TEST(FieldValueTest, AddsToNestedObjects) {
-  ObjectValue old = WrapObject("a", Object("b", "old"));
+  ObjectValue old = WrapObject("a", Map("b", "old"));
   ObjectValue mod = old.Set(Field("a.c"), Value("mod"));
   EXPECT_NE(old, mod);
-  EXPECT_EQ(WrapObject("a", Object("b", "old")), old);
-  EXPECT_EQ(WrapObject("a", Object("b", "old", "c", "mod")), mod);
+  EXPECT_EQ(WrapObject("a", Map("b", "old")), old);
+  EXPECT_EQ(WrapObject("a", Map("b", "old", "c", "mod")), mod);
 }
 
 TEST(FieldValueTest, DeletesKey) {
@@ -118,31 +117,28 @@ TEST(FieldValueTest, DeletesKey) {
 }
 
 TEST(FieldValueTest, DeletesHandleMissingKeys) {
-  ObjectValue old = WrapObject("a", Object("b", 1, "c", 2));
+  ObjectValue old = WrapObject("a", Map("b", 1, "c", 2));
   ObjectValue mod = old.Delete(Field("b"));
   EXPECT_EQ(mod, old);
-  EXPECT_EQ(WrapObject("a", Object("b", 1, "c", 2)), mod);
+  EXPECT_EQ(WrapObject("a", Map("b", 1, "c", 2)), mod);
 
   mod = old.Delete(Field("a.d"));
   EXPECT_EQ(mod, old);
-  EXPECT_EQ(WrapObject("a", Object("b", 1, "c", 2)), mod);
+  EXPECT_EQ(WrapObject("a", Map("b", 1, "c", 2)), mod);
 
   mod = old.Delete(Field("a.b.c"));
   EXPECT_EQ(mod, old);
-  EXPECT_EQ(WrapObject("a", Object("b", 1, "c", 2)), mod);
+  EXPECT_EQ(WrapObject("a", Map("b", 1, "c", 2)), mod);
 }
 
 TEST(FieldValueTest, DeletesNestedKeys) {
-  FieldValue::Map orig =
-      Object("a", Object("b", 1, "c", Object("d", 2, "e", 3))).object_value();
+  FieldValue::Map orig = Map("a", Map("b", 1, "c", Map("d", 2, "e", 3)));
   ObjectValue old = WrapObject(orig);
   ObjectValue mod = old.Delete(Field("a.c.d"));
 
   EXPECT_NE(mod, old);
-  EXPECT_EQ(WrapObject(orig), old);
 
-  FieldValue::Map second =
-      Object("a", Object("b", 1, "c", Object("e", 3))).object_value();
+  FieldValue::Map second = Map("a", Map("b", 1, "c", Map("e", 3)));
   EXPECT_EQ(WrapObject(second), mod);
 
   old = mod;
@@ -151,7 +147,7 @@ TEST(FieldValueTest, DeletesNestedKeys) {
   EXPECT_NE(old, mod);
   EXPECT_EQ(WrapObject(second), old);
 
-  FieldValue::Map third = Object("a", Object("b", 1)).object_value();
+  FieldValue::Map third = Map("a", Map("b", 1));
   EXPECT_EQ(WrapObject(third), mod);
 
   old = mod;

--- a/Firestore/core/test/firebase/firestore/testutil/testutil.h
+++ b/Firestore/core/test/firebase/firestore/testutil/testutil.h
@@ -105,6 +105,14 @@ inline model::FieldValue Value(const model::FieldValue& value) {
   return value;
 }
 
+inline model::FieldValue Value(const model::ObjectValue& value) {
+  return value.AsFieldValue();
+}
+
+inline model::FieldValue Value(const model::FieldValue::Map& value) {
+  return Value(model::ObjectValue::FromMap(value));
+}
+
 inline model::FieldValue ArrayValue(std::vector<model::FieldValue>&& value) {
   return model::FieldValue::FromArray(std::move(value));
 }
@@ -150,25 +158,20 @@ model::FieldValue::Map MakeMap(Args... key_value_pairs) {
 
 }  // namespace details
 
-/** Wraps an immutable sorted map in FieldValue with Type::Object. */
-inline model::FieldValue Object(const model::FieldValue::Map& value) {
-  return model::FieldValue::FromMap(value);
+/** Wraps an immutable sorted map into an ObjectValue. */
+inline model::ObjectValue WrapObject(const model::FieldValue::Map& value) {
+  return model::ObjectValue::FromMap(value);
 }
 
 /**
- * Creates a FieldValue from the given key/value pairs with Type::Object.
+ * Creates an ObjectValue from the given key/value pairs.
  *
  * @param key_value_pairs Alternating strings naming keys and values that can
  *     be passed to Value().
  */
 template <typename... Args>
-model::FieldValue Object(Args... key_value_pairs) {
-  return Object(details::MakeMap(key_value_pairs...));
-}
-
-/** Wraps an immutable sorted map into an ObjectValue with Type::Object. */
-inline model::ObjectValue WrapObject(const model::FieldValue::Map& value) {
-  return model::ObjectValue::FromMap(value);
+model::ObjectValue WrapObject(Args... key_value_pairs) {
+  return WrapObject(details::MakeMap(key_value_pairs...));
 }
 
 /**
@@ -178,8 +181,8 @@ inline model::ObjectValue WrapObject(const model::FieldValue::Map& value) {
  *     be passed to Value().
  */
 template <typename... Args>
-model::ObjectValue WrapObject(Args... key_value_pairs) {
-  return WrapObject(details::MakeMap(key_value_pairs...));
+model::FieldValue::Map Map(Args... key_value_pairs) {
+  return details::MakeMap(key_value_pairs...);
 }
 
 inline model::DocumentKey Key(absl::string_view path) {

--- a/Firestore/core/test/firebase/firestore/testutil/testutil.h
+++ b/Firestore/core/test/firebase/firestore/testutil/testutil.h
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <chrono>  // NOLINT(build/c++11)
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -51,7 +52,135 @@ namespace testutil {
  */
 constexpr const char* kDeleteSentinel = "<DELETE>";
 
-// Below are convenience methods for creating instances for tests.
+// Convenience methods for creating instances for tests.
+
+inline model::FieldValue Value(std::nullptr_t) {
+  return model::FieldValue::Null();
+}
+
+/**
+ * Creates a boolean FieldValue.
+ *
+ * @param bool_value A boolean value that disallows implicit conversions.
+ */
+template <typename T,
+          typename = typename std::enable_if<std::is_same<bool, T>{}>::type>
+inline model::FieldValue Value(T bool_value) {
+  return model::FieldValue::FromBoolean(bool_value);
+}
+
+// Overload that captures integer literals. Without this, int64_t and double
+// are equally applicable conversions.
+inline model::FieldValue Value(int value) {
+  return model::FieldValue::FromInteger(value);
+}
+
+inline model::FieldValue Value(int64_t value) {
+  return model::FieldValue::FromInteger(value);
+}
+
+inline model::FieldValue Value(double value) {
+  return model::FieldValue::FromDouble(value);
+}
+
+inline model::FieldValue Value(Timestamp value) {
+  return model::FieldValue::FromTimestamp(std::move(value));
+}
+
+inline model::FieldValue Value(const char* value) {
+  return model::FieldValue::FromString(value);
+}
+
+inline model::FieldValue Value(const std::string& value) {
+  return model::FieldValue::FromString(value);
+}
+
+inline model::FieldValue Value(const GeoPoint& value) {
+  return model::FieldValue::FromGeoPoint(value);
+}
+
+// This overload allows Object() to appear as a value (along with any explicitly
+// constructed FieldValues).
+inline model::FieldValue Value(const model::FieldValue& value) {
+  return value;
+}
+
+inline model::FieldValue ArrayValue(std::vector<model::FieldValue>&& value) {
+  return model::FieldValue::FromArray(std::move(value));
+}
+
+namespace details {
+
+/**
+ * Recursive base case for AddPairs, below. Returns the map.
+ */
+inline model::FieldValue::Map AddPairs(const model::FieldValue::Map& prior) {
+  return prior;
+}
+
+/**
+ * Inserts the given key-value pair into the map, and then recursively calls
+ * AddPairs to add any remaining arguments.
+ *
+ * @param prior A map into which the values should be inserted.
+ * @param key The key naming the field to insert.
+ * @param value A value to wrap with a call to Value(), above.
+ * @param rest Any remaining arguments
+ *
+ * @return The resulting map.
+ */
+template <typename ValueType, typename... Args>
+model::FieldValue::Map AddPairs(const model::FieldValue::Map& prior,
+                                const std::string& key,
+                                const ValueType& value,
+                                Args... rest) {
+  return AddPairs(prior.insert(key, Value(value)), rest...);
+}
+
+/**
+ * Creates an immutable sorted map from the given key/value pairs.
+ *
+ * @param key_value_pairs Alternating strings naming keys and values that can
+ *     be passed to Value().
+ */
+template <typename... Args>
+model::FieldValue::Map MakeMap(Args... key_value_pairs) {
+  return AddPairs(model::FieldValue::Map(), key_value_pairs...);
+}
+
+}  // namespace details
+
+/** Wraps an immutable sorted map in FieldValue with Type::Object. */
+inline model::FieldValue Object(const model::FieldValue::Map& value) {
+  return model::FieldValue::FromMap(value);
+}
+
+/**
+ * Creates a FieldValue from the given key/value pairs with Type::Object.
+ *
+ * @param key_value_pairs Alternating strings naming keys and values that can
+ *     be passed to Value().
+ */
+template <typename... Args>
+model::FieldValue Object(Args... key_value_pairs) {
+  return Object(details::MakeMap(key_value_pairs...));
+}
+
+/** Wraps an immutable sorted map into an ObjectValue with Type::Object. */
+inline model::ObjectValue WrapObject(const model::FieldValue::Map& value) {
+  return model::ObjectValue::FromMap(value);
+}
+
+/**
+ * Creates an ObjectValue from the given key/value pairs with Type::Object.
+ *
+ * @param key_value_pairs Alternating strings naming keys and values that can
+ *     be passed to Value().
+ */
+template <typename... Args>
+model::ObjectValue WrapObject(Args... key_value_pairs) {
+  return WrapObject(details::MakeMap(key_value_pairs...));
+}
 
 inline model::DocumentKey Key(absl::string_view path) {
   return model::DocumentKey::FromPathString(path);


### PR DESCRIPTION
Also, split userdata converter tests out of FSTFieldValue tests.

Equality and comparison tests are not yet ported.