### PR TITLE
kill assertion code

### DIFF
--- a/Example/Firebase.xcodeproj/project.pbxproj
+++ b/Example/Firebase.xcodeproj/project.pbxproj
@@ -6830,7 +6830,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 4ANB9W7R3P;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				INFOPLIST_FILE = $SRCROOT/DynamicLinks/FDLBuilderTestAppObjC/Info.plist;
+				INFOPLIST_FILE = "$SRCROOT/DynamicLinks/FDLBuilderTestAppObjC/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -6864,7 +6864,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = 4ANB9W7R3P;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				INFOPLIST_FILE = $SRCROOT/DynamicLinks/FDLBuilderTestAppObjC/Info.plist;
+				INFOPLIST_FILE = "$SRCROOT/DynamicLinks/FDLBuilderTestAppObjC/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/Firebase/InstanceID/FIRIMessageCode.h
+++ b/Firebase/InstanceID/FIRIMessageCode.h
@@ -66,6 +66,7 @@ typedef NS_ENUM(NSInteger, FIRInstanceIDMessageCode) {
   kFIRInstanceIDMessageCodeService005 = 7005,
   kFIRInstanceIDMessageCodeService006 = 7006,
   kFIRIntsanceIDInvalidNetworkSession = 7007,
+  kFIRIntsanceIDInvalidSettingResponse = 7008,
   // FIRInstanceIDCheckinStore.m
   // DO NOT USE 8002, 8004 - 8008
   kFIRInstanceIDMessageCodeCheckinStore000 = 8000,
@@ -156,5 +157,9 @@ typedef NS_ENUM(NSInteger, FIRInstanceIDMessageCode) {
   kFIRInstanceIDKeychainDeleteItemError = 23002,
   kFIRInstanceIDKeychainCreateKeyPairError = 23003,
   kFIRInstanceIDKeychainUpdateItemError = 23004,
+
+  // FIRInstanceIDStringEncoding.m
+  kFIRInstanceIDStringEncodingBufferUnderflow = 24000,
+  kFIRInstanceIDStringEncodingBufferOverflow = 24001,
 
 };

--- a/Firebase/InstanceID/FIRIMessageCode.h
+++ b/Firebase/InstanceID/FIRIMessageCode.h
@@ -65,8 +65,8 @@ typedef NS_ENUM(NSInteger, FIRInstanceIDMessageCode) {
   kFIRInstanceIDMessageCodeService004 = 7004,
   kFIRInstanceIDMessageCodeService005 = 7005,
   kFIRInstanceIDMessageCodeService006 = 7006,
-  kFIRIntsanceIDInvalidNetworkSession = 7007,
-  kFIRIntsanceIDInvalidSettingResponse = 7008,
+  kFIRInstanceIDInvalidNetworkSession = 7007,
+  kFIRInstanceIDInvalidSettingResponse = 7008,
   // FIRInstanceIDCheckinStore.m
   // DO NOT USE 8002, 8004 - 8008
   kFIRInstanceIDMessageCodeCheckinStore000 = 8000,

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -258,8 +258,6 @@ static FIRInstanceID *gInstanceID;
                             scope:(NSString *)scope
                           options:(NSDictionary *)options
                           handler:(FIRInstanceIDTokenHandler)handler {
-  _FIRInstanceIDDevAssert(handler != nil && [authorizedEntity length] && [scope length],
-                          @"Invalid authorizedEntity or scope to new token");
   if (!handler) {
     FIRInstanceIDLoggerError(kFIRInstanceIDMessageCodeInstanceID000,
                              kFIRInstanceIDInvalidNilHandlerError);
@@ -367,9 +365,6 @@ static FIRInstanceID *gInstanceID;
 - (void)deleteTokenWithAuthorizedEntity:(NSString *)authorizedEntity
                                   scope:(NSString *)scope
                                 handler:(FIRInstanceIDDeleteTokenHandler)handler {
-  _FIRInstanceIDDevAssert(handler != nil && [authorizedEntity length] && [scope length],
-                          @"Invalid authorizedEntity or scope to delete token");
-
   if (!handler) {
     FIRInstanceIDLoggerError(kFIRInstanceIDMessageCodeInstanceID001,
                              kFIRInstanceIDInvalidNilHandlerError);
@@ -462,8 +457,6 @@ static FIRInstanceID *gInstanceID;
 #pragma mark - Identity
 
 - (void)getIDWithHandler:(FIRInstanceIDHandler)handler {
-  _FIRInstanceIDDevAssert(handler, @"Invalid nil handler to getIdentity");
-
   if (!handler) {
     FIRInstanceIDLoggerError(kFIRInstanceIDMessageCodeInstanceID003,
                              kFIRInstanceIDInvalidNilHandlerError);
@@ -497,8 +490,6 @@ static FIRInstanceID *gInstanceID;
 }
 
 - (void)deleteIDWithHandler:(FIRInstanceIDDeleteHandler)handler {
-  _FIRInstanceIDDevAssert(handler, @"Invalid nil handler to delete Identity");
-
   if (!handler) {
     FIRInstanceIDLoggerError(kFIRInstanceIDMessageCodeInstanceID004,
                              kFIRInstanceIDInvalidNilHandlerError);

--- a/Firebase/InstanceID/FIRInstanceIDBackupExcludedPlist.m
+++ b/Firebase/InstanceID/FIRInstanceIDBackupExcludedPlist.m
@@ -16,7 +16,6 @@
 
 #import "FIRInstanceIDBackupExcludedPlist.h"
 
-#import "FIRInstanceIDDefines.h"
 #import "FIRInstanceIDLogger.h"
 
 typedef enum : NSUInteger {
@@ -63,9 +62,6 @@ typedef enum : NSUInteger {
 
   // Successfully wrote contents -- change the in-memory contents
   self.cachedPlistContents = [dict copy];
-
-  _FIRInstanceIDDevAssert([[NSFileManager defaultManager] fileExistsAtPath:path],
-                          @"Error writing data to non-backed up plist %@.plist", self.fileName);
 
   NSURL *URL = [NSURL fileURLWithPath:path];
   if (error) {

--- a/Firebase/InstanceID/FIRInstanceIDCheckinPreferences.m
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinPreferences.m
@@ -18,7 +18,6 @@
 
 #import <GoogleUtilities/GULUserDefaults.h>
 #import "FIRInstanceIDCheckinService.h"
-#import "FIRInstanceIDDefines.h"
 #import "FIRInstanceIDUtilities.h"
 
 const NSTimeInterval kFIRInstanceIDDefaultCheckinInterval = 7 * 24 * 60 * 60;  // 7 days.
@@ -62,8 +61,7 @@ const NSTimeInterval kFIRInstanceIDDefaultCheckinInterval = 7 * 24 * 60 * 60;  /
 - (BOOL)hasValidCheckinInfo {
   int64_t currentTimestampInMillis = FIRInstanceIDCurrentTimestampInMilliseconds();
   int64_t timeSinceLastCheckinInMillis = currentTimestampInMillis - self.lastCheckinTimestampMillis;
-  _FIRInstanceIDDevAssert(timeSinceLastCheckinInMillis >= 0,
-                          @"FCM error: cannot have last checkin timestamp in future");
+
   BOOL hasCheckinInfo = [self hasCheckinInfo];
   NSString *lastLocale =
       [[GULUserDefaults standardUserDefaults] stringForKey:kFIRInstanceIDUserDefaultsKeyLocale];

--- a/Firebase/InstanceID/FIRInstanceIDCheckinService.m
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinService.m
@@ -71,7 +71,7 @@ static FIRInstanceIDURLRequestTestBlock testBlock;
 - (void)checkinWithExistingCheckin:(FIRInstanceIDCheckinPreferences *)existingCheckin
                         completion:(FIRInstanceIDDeviceCheckinCompletion)completion {
   if (self.session == nil) {
-    FIRInstanceIDLoggerError(kFIRIntsanceIDInvalidNetworkSession,
+    FIRInstanceIDLoggerError(kFIRInstanceIDInvalidNetworkSession,
                              @"Inconsistent state: NSURLSession has been invalidated");
     NSError *error =
         [NSError errorWithFIRInstanceIDErrorCode:kFIRInstanceIDErrorCodeRegistrarFailedToCheckIn];
@@ -157,7 +157,7 @@ static FIRInstanceIDURLRequestTestBlock testBlock;
           if (dict[@"name"] && dict[@"value"]) {
             gservicesData[dict[@"name"]] = dict[@"value"];
           } else {
-            FIRInstanceIDLoggerDebug(kFIRIntsanceIDInvalidSettingResponse,
+            FIRInstanceIDLoggerDebug(kFIRInstanceIDInvalidSettingResponse,
                                      @"Invalid setting in checkin response: (%@: %@)",
                                      dict[@"name"], dict[@"value"]);
           }

--- a/Firebase/InstanceID/FIRInstanceIDCheckinService.m
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinService.m
@@ -70,14 +70,14 @@ static FIRInstanceIDURLRequestTestBlock testBlock;
 
 - (void)checkinWithExistingCheckin:(FIRInstanceIDCheckinPreferences *)existingCheckin
                         completion:(FIRInstanceIDDeviceCheckinCompletion)completion {
-  _FIRInstanceIDDevAssert(completion != nil, @"completion required");
-
   if (self.session == nil) {
     FIRInstanceIDLoggerError(kFIRIntsanceIDInvalidNetworkSession,
                              @"Inconsistent state: NSURLSession has been invalidated");
     NSError *error =
         [NSError errorWithFIRInstanceIDErrorCode:kFIRInstanceIDErrorCodeRegistrarFailedToCheckIn];
-    completion(nil, error);
+    if (completion) {
+      completion(nil, error);
+    }
     return;
   }
 
@@ -97,7 +97,9 @@ static FIRInstanceIDURLRequestTestBlock testBlock;
           FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeService000,
                                    @"Device checkin HTTP fetch error. Error Code: %ld",
                                    (long)error.code);
-          completion(nil, error);
+          if (completion) {
+            completion(nil, error);
+          }
           return;
         }
 
@@ -109,7 +111,9 @@ static FIRInstanceIDURLRequestTestBlock testBlock;
           FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeService001,
                                    @"Error serializing json object. Error Code: %ld",
                                    _FIRInstanceID_L(serializationError.code));
-          completion(nil, serializationError);
+          if (completion) {
+            completion(nil, serializationError);
+          }
           return;
         }
 
@@ -118,7 +122,9 @@ static FIRInstanceIDURLRequestTestBlock testBlock;
         if ([deviceAuthID length] == 0) {
           NSError *error =
               [NSError errorWithFIRInstanceIDErrorCode:kFIRInstanceIDErrorCodeInvalidRequest];
-          completion(nil, error);
+          if (completion) {
+            completion(nil, error);
+          }
           return;
         }
 
@@ -151,8 +157,9 @@ static FIRInstanceIDURLRequestTestBlock testBlock;
           if (dict[@"name"] && dict[@"value"]) {
             gservicesData[dict[@"name"]] = dict[@"value"];
           } else {
-            _FIRInstanceIDDevAssert(NO, @"Invalid setting in checkin response: (%@: %@)",
-                                    dict[@"name"], dict[@"value"]);
+            FIRInstanceIDLoggerDebug(kFIRIntsanceIDInvalidSettingResponse,
+                                     @"Invalid setting in checkin response: (%@: %@)",
+                                     dict[@"name"], dict[@"value"]);
           }
         }
 
@@ -167,7 +174,9 @@ static FIRInstanceIDURLRequestTestBlock testBlock;
           kFIRInstanceIDDeviceDataVersionKey : deviceDataVersionInfo,
         };
         [checkinPreferences updateWithCheckinPlistContents:preferences];
-        completion(checkinPreferences, nil);
+        if (completion) {
+          completion(checkinPreferences, nil);
+        }
       };
   // Test block
   if (testBlock) {

--- a/Firebase/InstanceID/FIRInstanceIDDefines.h
+++ b/Firebase/InstanceID/FIRInstanceIDDefines.h
@@ -45,26 +45,3 @@
 #endif
 
 #endif
-
-// Debug Assert
-#ifndef _FIRInstanceIDDevAssert
-// we directly invoke the NSAssert handler so we can pass on the varargs
-// (NSAssert doesn't have a macro we can use that takes varargs)
-#if !defined(NS_BLOCK_ASSERTIONS)
-#define _FIRInstanceIDDevAssert(condition, ...)                                                   \
-  do {                                                                                            \
-    if (!(condition)) {                                                                           \
-      [[NSAssertionHandler currentHandler]                                                        \
-          handleFailureInFunction:(NSString *)[NSString stringWithUTF8String:__PRETTY_FUNCTION__] \
-                             file:(NSString *)[NSString stringWithUTF8String:__FILE__]            \
-                       lineNumber:__LINE__                                                        \
-                      description:__VA_ARGS__];                                                   \
-    }                                                                                             \
-  } while (0)
-#else  // !defined(NS_BLOCK_ASSERTIONS)
-#define _FIRInstanceIDDevAssert(condition, ...) \
-  do {                                          \
-  } while (0)
-#endif  // !defined(NS_BLOCK_ASSERTIONS)
-
-#endif  // _FIRInstanceIDDevAssert

--- a/Firebase/InstanceID/FIRInstanceIDKeyPairStore.m
+++ b/Firebase/InstanceID/FIRInstanceIDKeyPairStore.m
@@ -18,7 +18,6 @@
 
 #import "FIRInstanceIDBackupExcludedPlist.h"
 #import "FIRInstanceIDConstants.h"
-#import "FIRInstanceIDDefines.h"
 #import "FIRInstanceIDKeyPair.h"
 #import "FIRInstanceIDKeyPairUtilities.h"
 #import "FIRInstanceIDKeychain.h"
@@ -45,7 +44,6 @@ NSString *const kFIRInstanceIDKeyPairSubType = @"";
 
 // Query the key with NSData format
 NSData *FIRInstanceIDKeyDataWithTag(NSString *tag) {
-  _FIRInstanceIDDevAssert([tag length], @"Invalid tag for keychain specified");
   if (![tag length]) {
     return NULL;
   }
@@ -59,7 +57,6 @@ NSData *FIRInstanceIDKeyDataWithTag(NSString *tag) {
 
 // Query the key given a tag
 SecKeyRef FIRInstanceIDCachedKeyRefWithTag(NSString *tag) {
-  _FIRInstanceIDDevAssert([tag length], @"Invalid tag for keychain specified");
   if (!tag.length) {
     return NULL;
   }
@@ -299,8 +296,6 @@ NSString *FIRInstanceIDCreationTimeKeyWithSubtype(NSString *subtype) {
 + (FIRInstanceIDKeyPair *)keyPairForPrivateKeyTag:(NSString *)privateKeyTag
                                      publicKeyTag:(NSString *)publicKeyTag
                                             error:(NSError *__autoreleasing *)error {
-  _FIRInstanceIDDevAssert([privateKeyTag length] && [publicKeyTag length],
-                          @"Invalid tags for keypair");
   if (![privateKeyTag length] || ![publicKeyTag length]) {
     if (error) {
       *error = [NSError errorWithFIRInstanceIDErrorCode:kFIRInstanceIDErrorCodeInvalidKeyPairTags];

--- a/Firebase/InstanceID/FIRInstanceIDKeyPairUtilities.m
+++ b/Firebase/InstanceID/FIRInstanceIDKeyPairUtilities.m
@@ -18,7 +18,6 @@
 
 #import <CommonCrypto/CommonDigest.h>
 
-#import "FIRInstanceIDDefines.h"
 #import "FIRInstanceIDKeyPair.h"
 #import "FIRInstanceIDLogger.h"
 #import "FIRInstanceIDStringEncoding.h"

--- a/Firebase/InstanceID/FIRInstanceIDStringEncoding.m
+++ b/Firebase/InstanceID/FIRInstanceIDStringEncoding.m
@@ -1,5 +1,3 @@
-#import "FIRInstanceIDDefines.h"
-
 //
 //  FIRInstanceIDStringEncoding.m
 //
@@ -22,6 +20,8 @@
 // a CocoaPods GTM dependency. Hence we use our own version of StringEncoding.
 
 #import "FIRInstanceIDStringEncoding.h"
+
+#import "FIRInstanceIDLogger.h"
 
 enum { kUnknownChar = -1, kPaddingChar = -2, kIgnoreChar = -3 };
 
@@ -138,7 +138,11 @@ static inline int lcm(int a, int b) {
     while (outPos < outLen) outBuf[outPos++] = paddingChar_;
   }
 
-  _FIRInstanceIDDevAssert(outPos == outLen, @"Underflowed output buffer");
+  if (outPos != outLen) {
+    FIRInstanceIDLoggerError(kFIRInstanceIDStringEncodingBufferUnderflow,
+                             @"Underflowed output buffer");
+    return nil;
+  }
   [outData setLength:outPos];
 
   return [[NSString alloc] initWithData:outData encoding:NSASCIIStringEncoding];
@@ -193,7 +197,9 @@ static inline int lcm(int a, int b) {
   }
 
   // Shorten buffer if needed due to padding chars
-  _FIRInstanceIDDevAssert(outPos <= outLen, @"Overflowed buffer");
+  if (outPos > outLen) {
+    FIRInstanceIDLoggerError(kFIRInstanceIDStringEncodingBufferOverflow, @"Overflowed buffer");
+  }
   [outData setLength:outPos];
 
   return outData;

--- a/Firebase/InstanceID/FIRInstanceIDTokenFetchOperation.m
+++ b/Firebase/InstanceID/FIRInstanceIDTokenFetchOperation.m
@@ -137,7 +137,6 @@ NSString *const kFIRInstanceIDFirebaseUserAgentKey = @"X-firebase-client";
     return;
   }
   NSDictionary *parsedResponse = [self parseFetchTokenResponse:dataResponse];
-  _FIRInstanceIDDevAssert(parsedResponse.count, @"Invalid registration response");
 
   if ([parsedResponse[@"token"] length]) {
     [self finishWithResult:FIRInstanceIDTokenOperationSucceeded

--- a/Firebase/InstanceID/FIRInstanceIDTokenOperation.m
+++ b/Firebase/InstanceID/FIRInstanceIDTokenOperation.m
@@ -17,7 +17,6 @@
 #import "FIRInstanceIDTokenOperation.h"
 
 #import "FIRInstanceIDCheckinPreferences.h"
-#import "FIRInstanceIDDefines.h"
 #import "FIRInstanceIDKeyPair.h"
 #import "FIRInstanceIDKeyPairUtilities.h"
 #import "FIRInstanceIDLogger.h"
@@ -133,7 +132,6 @@ static NSString *const kFIRInstanceIDParamFCMLibVersion = @"X-cliv";
 
   // Quickly validate whether or not the operation has all it needs to begin
   BOOL checkinfoAvailable = [self.checkinPreferences hasCheckinInfo];
-  _FIRInstanceIDDevAssert(checkinfoAvailable, @"Cannot fetch token invalid checkin state");
   if (!checkinfoAvailable) {
     FIRInstanceIDErrorCode errorCode = kFIRInstanceIDErrorCodeRegistrarFailedToCheckIn;
     [self finishWithResult:FIRInstanceIDTokenOperationError

--- a/Firebase/InstanceID/FIRInstanceIDUtilities.m
+++ b/Firebase/InstanceID/FIRInstanceIDUtilities.m
@@ -23,7 +23,6 @@
 #import <GoogleUtilities/GULUserDefaults.h>
 #import "FIRInstanceID.h"
 #import "FIRInstanceIDConstants.h"
-#import "FIRInstanceIDDefines.h"
 #import "FIRInstanceIDLogger.h"
 
 // Convert the macro to a string

--- a/Firebase/InstanceID/FIRInstanceIDVersionUtilities.m
+++ b/Firebase/InstanceID/FIRInstanceIDVersionUtilities.m
@@ -16,8 +16,6 @@
 
 #import "FIRInstanceIDVersionUtilities.h"
 
-#import "FIRInstanceIDDefines.h"
-
 // Convert the macro to a string
 #define STR(x) STR_EXPAND(x)
 #define STR_EXPAND(x) #x
@@ -41,7 +39,6 @@ void FIRInstanceIDParseCurrentLibraryVersion() {
     // Parse versions
     // major, minor, patch[-beta#]
     allVersions = [daylightVersion componentsSeparatedByString:kSemanticVersioningSeparator];
-    _FIRInstanceIDDevAssert(allVersions.count == 3, @"Invalid versioning of FIRInstanceID library");
     if (allVersions.count == 3) {
       majorVersion = [allVersions[0] intValue];
       minorVersion = [allVersions[1] intValue];
@@ -49,9 +46,6 @@ void FIRInstanceIDParseCurrentLibraryVersion() {
       // Parse patch and beta versions
       NSArray *patchAndBetaVersion =
           [allVersions[2] componentsSeparatedByString:kBetaVersionPrefix];
-      _FIRInstanceIDDevAssert(patchAndBetaVersion.count <= 2,
-                              @"Invalid versioning of FIRInstanceID library");
-
       if (patchAndBetaVersion.count == 2) {
         patchVersion = [patchAndBetaVersion[0] intValue];
         betaVersion = [patchAndBetaVersion[1] intValue];


### PR DESCRIPTION
Remove the _FIRInstanceIDDevAssert which is supposed to be running only for debug mode. And it crashes the app when there's an error occurred. However, we already have error checking at the same time so there's no need to assert anything. Remove all the assertion logic to simplify the code base.

For assertion on condition that is already checked in code, remove the assertion.
For assertion on conditions that is not checked, remove the assertion and add a check and log with error or debug log.

This partially resolves the crash in #3018 but we are still investigating reason causing the error to occur. 