### PR TITLE
Add test_specs and fix test build warnings for Database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,18 @@ jobs:
 
     - stage: test
       env:
+        - PROJECT=Database PLATFORM=all METHOD=xcodebuild
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
+        # The pod lib lint tests are fast enough that it's not worth a separate stage.
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseDatabase.podspec --skip-tests
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseDatabase.podspec --use-libraries --skip-tests
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseDatabase.podspec --use-modular-headers --skip-tests
+
+    - stage: test
+      env:
         - PROJECT=Functions PLATFORM=iOS METHOD=pod-lib-lint
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
@@ -104,7 +116,6 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseAnalyticsInterop.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseAuth.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseAuthInterop.podspec
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseDatabase.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseDynamicLinks.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseInstanceID.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseMessaging.podspec
@@ -133,7 +144,6 @@ jobs:
         - travis_retry ./scripts/pod_lib_lint.sh FirebaseAnalyticsInterop.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.sh FirebaseAuth.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.sh FirebaseAuthInterop.podspec --use-libraries
-        - travis_retry ./scripts/pod_lib_lint.sh FirebaseDatabase.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.sh FirebaseDynamicLinks.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.sh FirebaseInstanceID.podspec --use-libraries
         # The Protobuf dependency of FirebaseMessaging has warnings with --use-libraries
@@ -363,3 +373,5 @@ jobs:
 branches:
   only:
     - master
+    # Delete next line before merge
+    - pb-db-testspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,24 +44,28 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseCore.podspec --use-modular-headers
 
     - stage: test
-      if: fork = false
       env:
-        - PROJECT=Storage PLATFORM=iOS METHOD=pod-lib-lint
+        - PROJECT=Storage PLATFORM=iOS METHOD=xcodebuild
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-libraries
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-modular-headers
+        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
-      if: fork = true
+      if: fork = false
+      env:
+        - PROJECT=Storage PLATFORM=iOS METHOD=integration
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
+
+    - stage: test
       env:
         - PROJECT=Storage PLATFORM=iOS METHOD=pod-lib-lint
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
-        # TODO Add tests for forks.
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --skip-tests
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-libraries --skip-tests
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-modular-headers --skip-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,18 +57,6 @@ jobs:
 
     - stage: test
       env:
-        - PROJECT=Storage PLATFORM=all METHOD=xcodebuild
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
-      script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
-        # The pod lib lint tests are fast enough that it's not worth a separate stage.
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --skip-tests
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-libraries --skip-tests
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-modular-headers --skip-tests
-
-    - stage: test
-      env:
         - PROJECT=Database PLATFORM=all METHOD=xcodebuild
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
@@ -373,5 +361,3 @@ jobs:
 branches:
   only:
     - master
-    # Delete next line before merge
-    - pb-db-testspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,29 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseCore.podspec --use-modular-headers
 
     - stage: test
+      if: fork = false
+      env:
+        - PROJECT=Storage PLATFORM=iOS METHOD=pod-lib-lint
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-libraries
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-modular-headers
+
+    - stage: test
+      if: fork = true
+      env:
+        - PROJECT=Storage PLATFORM=iOS METHOD=pod-lib-lint
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        # TODO Add tests for forks.
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --skip-tests
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-libraries --skip-tests
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-modular-headers --skip-tests
+
+    - stage: test
       env:
         - PROJECT=Storage PLATFORM=all METHOD=xcodebuild
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,12 @@ jobs:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
+        # The pod lib lint tests are fast enough that it's not worth a separate stage.
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --skip-tests
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-libraries --skip-tests
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-modular-headers --skip-tests
 
+    # The Storage integration tests cannot handle the parallelism of being run from pod lib lint.
     - stage: test
       if: fork = false
       env:
@@ -59,16 +64,6 @@ jobs:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
-
-    - stage: test
-      env:
-        - PROJECT=Storage PLATFORM=iOS METHOD=pod-lib-lint
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
-      script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --skip-tests
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-libraries --skip-tests
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-modular-headers --skip-tests
 
     - stage: test
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,16 +55,6 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-libraries --skip-tests
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseStorage.podspec --use-modular-headers --skip-tests
 
-    # The Storage integration tests cannot handle the parallelism of being run from pod lib lint.
-    - stage: test
-      if: fork = false
-      env:
-        - PROJECT=Storage PLATFORM=all METHOD=integration
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
-      script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
-
     - stage: test
       env:
         - PROJECT=Storage PLATFORM=all METHOD=xcodebuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
 
     - stage: test
       env:
-        - PROJECT=Storage PLATFORM=iOS METHOD=xcodebuild
+        - PROJECT=Storage PLATFORM=all METHOD=xcodebuild
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
@@ -54,7 +54,7 @@ jobs:
     - stage: test
       if: fork = false
       env:
-        - PROJECT=Storage PLATFORM=iOS METHOD=integration
+        - PROJECT=Storage PLATFORM=all METHOD=integration
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:

--- a/Example/Database/Tests/Helpers/FDevice.m
+++ b/Example/Database/Tests/Helpers/FDevice.m
@@ -58,7 +58,8 @@ static NSUInteger deviceId = 0;
 - (id)initWithUrl:(NSString *)firebaseUrl andOnline:(BOOL)online {
     self = [super init];
     if (self) {
-        config = [FTestHelpers configForName:[NSString stringWithFormat:@"device-%lu", deviceId++]];
+        config = [FTestHelpers configForName:
+                  [NSString stringWithFormat:@"device-%lu", (unsigned long)deviceId++]];
         config.persistenceEnabled = YES;
         url = firebaseUrl;
         isOnline = online;

--- a/Example/Database/Tests/Helpers/FEventTester.m
+++ b/Example/Database/Tests/Helpers/FEventTester.m
@@ -132,7 +132,7 @@
         NSRange theRange;
         theRange.location = 0;
         theRange.length = self.initializationEvents;
-        [self->actualPathsAndEvents removeObjectsInRange:theRange];
+        [self.actualPathsAndEvents removeObjectsInRange:theRange];
 
         return YES;
     } timeout:kFirebaseTestTimeout];
@@ -150,7 +150,7 @@
         }
 
         FTupleEventTypeString* evt = [[FTupleEventTypeString alloc] initWithFirebase:ref withEvent:type withString:name];
-        [self->actualPathsAndEvents addObject:evt];
+        [self.actualPathsAndEvents addObject:evt];
 
         NSLog(@"Adding event: %@ (%@)", evt, [snap value]);
 

--- a/Example/Database/Tests/Helpers/FEventTester.m
+++ b/Example/Database/Tests/Helpers/FEventTester.m
@@ -132,7 +132,7 @@
         NSRange theRange;
         theRange.location = 0;
         theRange.length = self.initializationEvents;
-        [actualPathsAndEvents removeObjectsInRange:theRange];
+        [self->actualPathsAndEvents removeObjectsInRange:theRange];
 
         return YES;
     } timeout:kFirebaseTestTimeout];
@@ -150,7 +150,7 @@
         }
 
         FTupleEventTypeString* evt = [[FTupleEventTypeString alloc] initWithFirebase:ref withEvent:type withString:name];
-        [actualPathsAndEvents addObject:evt];
+        [self->actualPathsAndEvents addObject:evt];
 
         NSLog(@"Adding event: %@ (%@)", evt, [snap value]);
 

--- a/Example/Database/Tests/Helpers/FTestHelpers.m
+++ b/Example/Database/Tests/Helpers/FTestHelpers.m
@@ -29,7 +29,7 @@
 
 @implementation FTestHelpers
 
-+ (NSTimeInterval)waitUntil:(BOOL (^)())predicate timeout:(NSTimeInterval)seconds {
++ (NSTimeInterval)waitUntil:(BOOL (^)(void))predicate timeout:(NSTimeInterval)seconds {
   NSTimeInterval start = [NSDate timeIntervalSinceReferenceDate];
   NSDate *timeoutDate = [NSDate dateWithTimeIntervalSinceNow:seconds];
   NSTimeInterval timeoutTime = [timeoutDate timeIntervalSinceReferenceDate];
@@ -77,9 +77,8 @@
   id<FAuthTokenProvider> authTokenProvider = [FAuthTokenProvider authTokenProviderWithAuth:auth];
 
   while (num > refs.count) {
-    NSString *sessionIdentifier =
-        [NSString stringWithFormat:@"test-config-%@persistence-%lu", (persistence) ? @"" : @"no-",
-                                   refs.count];
+    NSString *sessionIdentifier = [NSString stringWithFormat:@"test-config-%@persistence-%lu",
+       (persistence) ? @"" : @"no-", (unsigned long)refs.count];
     FIRDatabaseConfig *config =
         [[FIRDatabaseConfig alloc] initWithSessionIdentifier:sessionIdentifier
                                            authTokenProvider:authTokenProvider];

--- a/Example/Database/Tests/Helpers/SenTest+FWaiter.h
+++ b/Example/Database/Tests/Helpers/SenTest+FWaiter.h
@@ -18,9 +18,9 @@
 
 @interface XCTest (FWaiter)
 
-- (NSTimeInterval) waitUntil:(BOOL (^)())predicate;
-- (NSTimeInterval) waitUntil:(BOOL (^)())predicate description:(NSString*)desc;
-- (NSTimeInterval) waitUntil:(BOOL (^)())predicate timeout:(NSTimeInterval)seconds;
-- (NSTimeInterval) waitUntil:(BOOL (^)())predicate timeout:(NSTimeInterval)seconds description:(NSString*)desc;
+- (NSTimeInterval) waitUntil:(BOOL (^)(void))predicate;
+- (NSTimeInterval) waitUntil:(BOOL (^)(void))predicate description:(NSString*)desc;
+- (NSTimeInterval) waitUntil:(BOOL (^)(void))predicate timeout:(NSTimeInterval)seconds;
+- (NSTimeInterval) waitUntil:(BOOL (^)(void))predicate timeout:(NSTimeInterval)seconds description:(NSString*)desc;
 
 @end

--- a/Example/Database/Tests/Helpers/SenTest+FWaiter.m
+++ b/Example/Database/Tests/Helpers/SenTest+FWaiter.m
@@ -19,19 +19,19 @@
 
 @implementation XCTestCase (FWaiter)
 
-- (NSTimeInterval) waitUntil:(BOOL (^)())predicate {
+- (NSTimeInterval) waitUntil:(BOOL (^)(void))predicate {
     return [self waitUntil:predicate timeout:kFirebaseTestWaitUntilTimeout description:nil];
 }
 
-- (NSTimeInterval) waitUntil:(BOOL (^)())predicate description:(NSString*)desc {
+- (NSTimeInterval) waitUntil:(BOOL (^)(void))predicate description:(NSString*)desc {
     return [self waitUntil:predicate timeout:kFirebaseTestWaitUntilTimeout description:desc];
 }
 
-- (NSTimeInterval) waitUntil:(BOOL (^)())predicate timeout:(NSTimeInterval)seconds {
+- (NSTimeInterval) waitUntil:(BOOL (^)(void))predicate timeout:(NSTimeInterval)seconds {
     return [self waitUntil:predicate timeout:seconds description:nil];
 }
 
-- (NSTimeInterval) waitUntil:(BOOL (^)())predicate timeout:(NSTimeInterval)seconds description:(NSString*)desc {
+- (NSTimeInterval) waitUntil:(BOOL (^)(void))predicate timeout:(NSTimeInterval)seconds description:(NSString*)desc {
     NSTimeInterval start = [NSDate timeIntervalSinceReferenceDate];
     NSDate *timeoutDate = [NSDate dateWithTimeIntervalSinceNow:seconds];
     NSTimeInterval timeoutTime = [timeoutDate timeIntervalSinceReferenceDate];

--- a/Example/Database/Tests/Integration/FData.m
+++ b/Example/Database/Tests/Integration/FData.m
@@ -2150,7 +2150,7 @@
     FIRDatabaseReference * ref = [FTestHelpers getRandomNode];
 
     long long jsMaxInt = 9007199254740992;
-    long jsMaxIntPlusOne = jsMaxInt + 1;
+    long jsMaxIntPlusOne = (long)jsMaxInt + 1;
     NSNumber* toSet = [NSNumber numberWithLong:jsMaxIntPlusOne];
     [ref setValue:toSet];
 

--- a/Example/Database/Tests/Integration/FIRDatabaseQueryTests.m
+++ b/Example/Database/Tests/Integration/FIRDatabaseQueryTests.m
@@ -133,11 +133,13 @@
     XCTAssertThrows([ref queryLimitedToLast:0], @"Can't pass zero as limit");
     XCTAssertThrows([ref queryLimitedToFirst:0], @"Can't pass zero as limit");
     XCTAssertThrows([ref queryLimitedToLast:0], @"Can't pass zero as limit");
-    uint64_t MAX_ALLOWED_VALUE = (1l << 31) - 1;
-    [ref queryLimitedToFirst:MAX_ALLOWED_VALUE];
-    [ref queryLimitedToLast:MAX_ALLOWED_VALUE];
-    XCTAssertThrows([ref queryLimitedToFirst:(MAX_ALLOWED_VALUE+1)], @"Can't pass limits that don't fit into 32 bit signed integer range");
-    XCTAssertThrows([ref queryLimitedToLast:(MAX_ALLOWED_VALUE+1)], @"Can't pass limits that don't fit into 32 bit signed integer range");
+    uint64_t MAX_ALLOWED_VALUE = (uint64_t)(1l << 31) - 1;
+    [ref queryLimitedToFirst:(NSUInteger)MAX_ALLOWED_VALUE];
+    [ref queryLimitedToLast:(NSUInteger)MAX_ALLOWED_VALUE];
+    XCTAssertThrows([ref queryLimitedToFirst:(NSUInteger)(MAX_ALLOWED_VALUE+1)],
+                    @"Can't pass limits that don't fit into 32 bit signed integer range");
+    XCTAssertThrows([ref queryLimitedToLast:(NSUInteger)(MAX_ALLOWED_VALUE+1)],
+                    @"Can't pass limits that don't fit into 32 bit signed integer range");
 }
 
 - (void) testInvalidKeys {

--- a/Example/Database/Tests/Integration/FIRDatabaseTests.m
+++ b/Example/Database/Tests/Integration/FIRDatabaseTests.m
@@ -430,7 +430,11 @@ static NSString *kFirebaseTestAltNamespace = @"https://foobar.firebaseio.com";
     __block BOOL done = NO;
     [database.reference.childByAutoId observeSingleEventOfType:FIRDataEventTypeValue
                                                      withBlock:^(FIRDataSnapshot *snapshot) {
-        dispatch_assert_queue(callbackQueue);
+                                                       if (@available(iOS 10.0, macOS 10.12, *)) {
+                                                         dispatch_assert_queue(callbackQueue);
+                                                       } else {
+                                                         NSAssert(YES, @"Test requires iOS 10");
+                                                       }
         done = YES;
     }];
     WAIT_FOR(done);

--- a/Example/Database/Tests/Integration/FTransactionTest.m
+++ b/Example/Database/Tests/Integration/FTransactionTest.m
@@ -40,8 +40,8 @@
 - (void) fetchTokenForcingRefresh:(BOOL)forceRefresh withCallback:(fbt_void_nsstring_nserror)callback {
     // Simulate delay
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10 * NSEC_PER_MSEC)), [FIRDatabaseQuery sharedQueue], ^{
-        if (firstFetch) {
-            firstFetch = NO;
+        if (self->firstFetch) {
+            self->firstFetch = NO;
             callback(@"bad-token", nil);
         } else {
             callback(nil, nil);

--- a/Example/Database/Tests/Unit/FTrackedQueryManagerTest.m
+++ b/Example/Database/Tests/Unit/FTrackedQueryManagerTest.m
@@ -195,8 +195,10 @@
     FTrackedQueryManager *manager = [self newManagerWithClock:clock];
 
     for (NSUInteger i = 0; i < 10; i++) {
-      [manager setQueryActive:[FQuerySpec defaultQueryAtPath:PATH(([NSString stringWithFormat:@"%lu", (unsigned long)i]))]];
-      [manager setQueryInactive:[FQuerySpec defaultQueryAtPath:PATH(([NSString stringWithFormat:@"%lu", (unsigned long)i]))]];
+        [manager setQueryActive:[FQuerySpec defaultQueryAtPath:
+                               PATH(([NSString stringWithFormat:@"%lu", (unsigned long)i]))]];
+        [manager setQueryInactive:[FQuerySpec defaultQueryAtPath:
+                                 PATH(([NSString stringWithFormat:@"%lu", (unsigned long)i]))]];
         [clock tick];
     }
 

--- a/Example/Database/Tests/Unit/FTrackedQueryManagerTest.m
+++ b/Example/Database/Tests/Unit/FTrackedQueryManagerTest.m
@@ -195,8 +195,8 @@
     FTrackedQueryManager *manager = [self newManagerWithClock:clock];
 
     for (NSUInteger i = 0; i < 10; i++) {
-        [manager setQueryActive:[FQuerySpec defaultQueryAtPath:PATH(([NSString stringWithFormat:@"%lu", i]))]];
-        [manager setQueryInactive:[FQuerySpec defaultQueryAtPath:PATH(([NSString stringWithFormat:@"%lu", i]))]];
+      [manager setQueryActive:[FQuerySpec defaultQueryAtPath:PATH(([NSString stringWithFormat:@"%lu", (unsigned long)i]))]];
+      [manager setQueryInactive:[FQuerySpec defaultQueryAtPath:PATH(([NSString stringWithFormat:@"%lu", (unsigned long)i]))]];
         [clock tick];
     }
 
@@ -240,8 +240,10 @@
     FTrackedQueryManager *manager = [self newManagerWithClock:clock];
 
     for (NSUInteger i = 0; i < 10; i++) {
-        [manager setQueryActive:[FQuerySpec defaultQueryAtPath:PATH(([NSString stringWithFormat:@"%lu", i]))]];
-        [manager setQueryInactive:[FQuerySpec defaultQueryAtPath:PATH(([NSString stringWithFormat:@"%lu", i]))]];
+        [manager setQueryActive:[FQuerySpec defaultQueryAtPath:
+                                 PATH(([NSString stringWithFormat:@"%lu", (unsigned long)i]))]];
+        [manager setQueryInactive:[FQuerySpec defaultQueryAtPath:
+                                   PATH(([NSString stringWithFormat:@"%lu", (unsigned long)i]))]];
         [clock tick];
     }
 

--- a/Example/Database/Tests/third_party/Base64.m
+++ b/Example/Database/Tests/third_party/Base64.m
@@ -60,7 +60,7 @@
     const unsigned char *inputBytes = [inputData bytes];
 
     long long maxOutputLength = (inputLength / 4 + 1) * 3;
-    NSMutableData *outputData = [NSMutableData dataWithLength:maxOutputLength];
+    NSMutableData *outputData = [NSMutableData dataWithLength:(NSUInteger)maxOutputLength];
     unsigned char *outputBytes = (unsigned char *)[outputData mutableBytes];
 
     int accumulator = 0;
@@ -88,7 +88,7 @@
     if (accumulator > 2) outputLength++;
 
     //truncate data to match actual output length
-    outputData.length = outputLength;
+    outputData.length = (NSUInteger)outputLength;
     return outputLength? outputData: nil;
 }
 
@@ -104,7 +104,7 @@
 
     long long maxOutputLength = (inputLength / 3 + 1) * 4;
     maxOutputLength += wrapWidth? (maxOutputLength / wrapWidth) * 2: 0;
-    unsigned char *outputBytes = (unsigned char *)malloc(maxOutputLength);
+    unsigned char *outputBytes = (unsigned char *)malloc((NSUInteger)maxOutputLength);
 
     long long i;
     long long outputLength = 0;
@@ -144,9 +144,9 @@
     if (outputLength >= 4)
     {
         //truncate data to match actual output length
-        outputBytes = realloc(outputBytes, outputLength);
+        outputBytes = realloc(outputBytes, (NSUInteger)outputLength);
         return [[NSString alloc] initWithBytesNoCopy:outputBytes
-                                              length:outputLength
+                                              length:(NSUInteger)outputLength
                                             encoding:NSASCIIStringEncoding
                                         freeWhenDone:YES];
     }

--- a/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/Example/Storage/Tests/Integration/FIRStorageIntegrationTests.m
@@ -76,7 +76,7 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 60;
       NSBundle *bundle = [NSBundle bundleForClass:[self class]];
       filePath = [bundle pathForResource:@"1mb" ofType:@"dat"];
     }
-    NSData *data =  [NSData dataWithContentsOfFile:filePath];
+    NSData *data = [NSData dataWithContentsOfFile:filePath];
 
     XCTAssertNotNil(data, "Could not load bundled file");
     [ref putData:data

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -51,10 +51,10 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
                            'Example/Database/App/GoogleService-Info.plist'
   end
 
-  # s.test_spec 'integration' do |int_tests|
-  #   int_tests.source_files = 'Example/Storage/Tests/Integration/*.[mh]'
-  #   int_tests.requires_app_host = true
-  #   int_tests.resources = 'Example/Storage/App/1mb.dat',
-  #                         'Example/Storage/App/GoogleService-Info.plist'
-  #end
+  s.test_spec 'integration' do |int_tests|
+    int_tests.source_files = 'Example/Database/Tests/Integration/*.[mh]',
+                             'Example/Database/Tests/Helpers/*.[mh]',
+                             'Example/Shared/FIRAuthInteropFake.[mh]'
+    int_tests.resources = 'Example/Database/App/GoogleService-Info.plist'
+  end
 end

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -39,4 +39,22 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
     'GCC_PREPROCESSOR_DEFINITIONS' =>
       'FIRDatabase_VERSION=' + s.version.to_s
   }
+
+  s.test_spec 'unit' do |unit_tests|
+    unit_tests.source_files = 'Example/Database/Tests/Unit/*.[mh]',
+                              'Example/Database/Tests/Helpers/*.[mh]',
+                              'Example/Database/Tests/third_party/*.[mh]',
+                              'Example/Shared/FIRAuthInteropFake.[mh]',
+                              'Example/Shared/FIRComponentTestUtilities.h'
+    unit_tests.resources = 'Example/Database/Tests/infoPlist.strings',
+                           'Example/Database/Tests/syncPointSpec.json',
+                           'Example/Database/App/GoogleService-Info.plist'
+  end
+
+  # s.test_spec 'integration' do |int_tests|
+  #   int_tests.source_files = 'Example/Storage/Tests/Integration/*.[mh]'
+  #   int_tests.requires_app_host = true
+  #   int_tests.resources = 'Example/Storage/App/1mb.dat',
+  #                         'Example/Storage/App/GoogleService-Info.plist'
+  #end
 end

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -332,7 +332,7 @@ case "$product-$method-$platform" in
   GoogleDataTransport-xcodebuild-*)
     RunXcodebuild \
         -workspace 'GoogleDataTransport/gen/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
-        -scheme "GoogleDataTransport-$platform-Unit-Tests-Unit"
+        -scheme "GoogleDataTransport-$platform-Unit-Tests-Unit" \
         "${xcb_flags[@]}" \
         build \
         test

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -401,7 +401,7 @@ case "$product-$method-$platform" in
       test
 
     if [[ "$TRAVIS_PULL_REQUEST" == "false" ||
-          "TRAVIS_PULL_REQUEST_SLUG" == "$TRAVIS_REPO_SLUG" ]]; then
+          "$TRAVIS_PULL_REQUEST_SLUG" == "$TRAVIS_REPO_SLUG" ]]; then
       RunXcodebuild \
         -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
         -scheme "FirebaseStorage-iOS-Unit-integration" \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -381,18 +381,21 @@ case "$product-$method-$platform" in
     RunXcodebuild \
       -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
       -scheme "FirebaseStorage-iOS-Unit-unit" \
+      "${ios_flags[@]}" \
       "${xcb_flags[@]}" \
       build \
       test
     RunXcodebuild \
       -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
       -scheme "FirebaseStorage-macOS-Unit-unit" \
+      "${macos_flags[@]}" \
       "${xcb_flags[@]}" \
       build \
       test
     RunXcodebuild \
       -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
       -scheme "FirebaseStorage-tvOS-Unit-unit" \
+      "${tvos_flags[@]}" \
       "${xcb_flags[@]}" \
       build \
       test

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -377,7 +377,7 @@ case "$product-$method-$platform" in
         test
     ;;
 
-  Storage-*-xcodebuild)
+  Storage-xcodebuild-*)
     RunXcodebuild \
       -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
       -scheme "FirebaseStorage-iOS-Unit-unit" \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -102,15 +102,15 @@ tvos_flags=(
 # Compute standard flags for all platforms
 case "$platform" in
   iOS)
-    xcb_flags=("${ios_flags[@]}")
+    xcb_flags="${ios_flags[@]}"
     ;;
 
   macOS)
-    xcb_flags=("${macos_flags[@]}")
+    xcb_flags="${macos_flags[@]}"
     ;;
 
   tvOS)
-    xcb_flags=("${tvos_flags[@]}")
+    xcb_flags="${tvos_flags[@]}"
     ;;
 
   all)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -399,40 +399,27 @@ case "$product-$method-$platform" in
       "${xcb_flags[@]}" \
       build \
       test
-    ;;
-
-  Storage-xcodebuild-*)
-    RunXcodebuild \
-      -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
-      -scheme "FirebaseStorage-iOS-Unit-unit" \
-      "${ios_flags[@]}" \
-      "${xcb_flags[@]}" \
-      build \
-      test
-
-    RunXcodebuild \
-      -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
-      -scheme "FirebaseStorage-macOS-Unit-unit" \
-      "${macos_flags[@]}" \
-      "${xcb_flags[@]}" \
-      build \
-      test
-
-    RunXcodebuild \
-      -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
-      -scheme "FirebaseStorage-tvOS-Unit-unit" \
-      "${tvos_flags[@]}" \
-      "${xcb_flags[@]}" \
-      build \
-      test
 
     if [[ "$TRAVIS_PULL_REQUEST" == "false" ||
-      "$TRAVIS_PULL_REQUEST_SLUG" == "$TRAVIS_REPO_SLUG" ]]; then
-      # Integration tests are only run on iOS to minimize flake failures.
+          "TRAVIS_PULL_REQUEST_SLUG" == "$TRAVIS_REPO_SLUG" ]]; then
       RunXcodebuild \
         -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
         -scheme "FirebaseStorage-iOS-Unit-integration" \
         "${ios_flags[@]}" \
+        "${xcb_flags[@]}" \
+        build \
+        test
+      RunXcodebuild \
+        -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
+        -scheme "FirebaseStorage-macOS-Unit-integration" \
+        "${macos_flags[@]}" \
+        "${xcb_flags[@]}" \
+        build \
+        test
+      RunXcodebuild \
+        -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
+        -scheme "FirebaseStorage-tvOS-Unit-integration" \
+        "${tvos_flags[@]}" \
         "${xcb_flags[@]}" \
         build \
         test

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -402,24 +402,11 @@ case "$product-$method-$platform" in
 
     if [[ "$TRAVIS_PULL_REQUEST" == "false" ||
           "$TRAVIS_PULL_REQUEST_SLUG" == "$TRAVIS_REPO_SLUG" ]]; then
+      # Integration tests are only run on iOS to minimize flake failures.
       RunXcodebuild \
         -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
         -scheme "FirebaseStorage-iOS-Unit-integration" \
         "${ios_flags[@]}" \
-        "${xcb_flags[@]}" \
-        build \
-        test
-      RunXcodebuild \
-        -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
-        -scheme "FirebaseStorage-macOS-Unit-integration" \
-        "${macos_flags[@]}" \
-        "${xcb_flags[@]}" \
-        build \
-        test
-      RunXcodebuild \
-        -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
-        -scheme "FirebaseStorage-tvOS-Unit-integration" \
-        "${tvos_flags[@]}" \
         "${xcb_flags[@]}" \
         build \
         test

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -207,13 +207,6 @@ case "$product-$method-$platform" in
           "${xcb_flags[@]}" \
           build \
           test
-
-        RunXcodebuild \
-          -workspace 'Example/Firebase.xcworkspace' \
-          -scheme "Database_IntegrationTests_iOS" \
-          "${xcb_flags[@]}" \
-          build \
-          test
       fi
 
       # Test iOS Objective-C static library build
@@ -375,6 +368,42 @@ case "$product-$method-$platform" in
         "${xcb_flags[@]}" \
         build \
         test
+    ;;
+
+  Database-xcodebuild-*)
+    RunXcodebuild \
+      -workspace 'gen/FirebaseDatabase/FirebaseDatabase.xcworkspace' \
+      -scheme "FirebaseDatabase-iOS-Unit-unit" \
+      "${ios_flags[@]}" \
+      "${xcb_flags[@]}" \
+      build \
+      test
+    RunXcodebuild \
+      -workspace 'gen/FirebaseDatabase/FirebaseDatabase.xcworkspace' \
+      -scheme "FirebaseDatabase-macOS-Unit-unit" \
+      "${macos_flags[@]}" \
+      "${xcb_flags[@]}" \
+      build \
+      test
+    RunXcodebuild \
+      -workspace 'gen/FirebaseDatabase/FirebaseDatabase.xcworkspace' \
+      -scheme "FirebaseDatabase-tvOS-Unit-unit" \
+      "${tvos_flags[@]}" \
+      "${xcb_flags[@]}" \
+      build \
+      test
+
+    if [[ "$TRAVIS_PULL_REQUEST" == "false" ||
+          "$TRAVIS_PULL_REQUEST_SLUG" == "$TRAVIS_REPO_SLUG" ]]; then
+      # Integration tests are only run on iOS to minimize flake failures.
+      RunXcodebuild \
+        -workspace 'gen/FirebaseDatabase/FirebaseDatabase.xcworkspace' \
+        -scheme "FirebaseDatabase-iOS-Unit-integration" \
+        "${ios_flags[@]}" \
+        "${xcb_flags[@]}" \
+        build \
+        test
+      fi
     ;;
 
   Storage-xcodebuild-*)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -329,42 +329,42 @@ case "$product-$method-$platform" in
         build
     ;;
 
-  GoogleDataTransport-xcodebuild-iOS)
+  GoogleDataTransport-xcodebuild-*)
     RunXcodebuild \
         -workspace 'GoogleDataTransport/gen/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
-        -scheme "GoogleDataTransport-Unit-Tests-Unit" \
+        -scheme "GoogleDataTransport-$platform-Unit-Tests-Unit"
         "${xcb_flags[@]}" \
         build \
         test
 
     RunXcodebuild \
         -workspace 'GoogleDataTransport/gen/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
-        -scheme "GoogleDataTransport-Unit-Tests-Lifecycle" \
+        -scheme "GoogleDataTransport-$platform-Unit-Tests-Lifecycle" \
         "${xcb_flags[@]}" \
         build \
         test
     ;;
 
-  GoogleDataTransportIntegrationTest-xcodebuild-iOS)
+  GoogleDataTransportIntegrationTest-xcodebuild-*)
     RunXcodebuild \
         -workspace 'GoogleDataTransport/gen/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
-        -scheme "GoogleDataTransport-Unit-Tests-Integration" \
+        -scheme "GoogleDataTransport-$platform-Unit-Tests-Integration" \
         "${xcb_flags[@]}" \
         build \
         test
     ;;
 
-  GoogleDataTransportCCTSupport-xcodebuild-iOS)
+  GoogleDataTransportCCTSupport-xcodebuild-*)
     RunXcodebuild \
         -workspace 'GoogleDataTransportCCTSupport/gen/GoogleDataTransportCCTSupport/GoogleDataTransportCCTSupport.xcworkspace' \
-        -scheme "GoogleDataTransportCCTSupport-Unit-Tests-Unit" \
+        -scheme "GoogleDataTransportCCTSupport-$platform-Unit-Tests-Unit" \
         "${xcb_flags[@]}" \
         build \
         test
 
     RunXcodebuild \
         -workspace 'GoogleDataTransportCCTSupport/gen/GoogleDataTransportCCTSupport/GoogleDataTransportCCTSupport.xcworkspace' \
-        -scheme "GoogleDataTransportCCTSupport-Unit-Tests-Integration" \
+        -scheme "GoogleDataTransportCCTSupport-$platform-Unit-Tests-Integration" \
         "${xcb_flags[@]}" \
         build \
         test

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -336,45 +336,66 @@ case "$product-$method-$platform" in
         build
     ;;
 
-  GoogleDataTransport-xcodebuild-*)
+  GoogleDataTransport-xcodebuild-iOS)
     RunXcodebuild \
         -workspace 'GoogleDataTransport/gen/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
-        -scheme "GoogleDataTransport-$platform-Unit-Tests-Unit" \
+        -scheme "GoogleDataTransport-Unit-Tests-Unit" \
         "${xcb_flags[@]}" \
         build \
         test
 
     RunXcodebuild \
         -workspace 'GoogleDataTransport/gen/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
-        -scheme "GoogleDataTransport-$platform-Unit-Tests-Lifecycle" \
+        -scheme "GoogleDataTransport-Unit-Tests-Lifecycle" \
         "${xcb_flags[@]}" \
         build \
         test
     ;;
 
-  GoogleDataTransportIntegrationTest-xcodebuild-*)
+  GoogleDataTransportIntegrationTest-xcodebuild-iOS)
     RunXcodebuild \
         -workspace 'GoogleDataTransport/gen/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
-        -scheme "GoogleDataTransport-$platform-Unit-Tests-Integration" \
+        -scheme "GoogleDataTransport-Unit-Tests-Integration" \
         "${xcb_flags[@]}" \
         build \
         test
     ;;
 
-  GoogleDataTransportCCTSupport-xcodebuild-*)
+  GoogleDataTransportCCTSupport-xcodebuild-iOS)
     RunXcodebuild \
         -workspace 'GoogleDataTransportCCTSupport/gen/GoogleDataTransportCCTSupport/GoogleDataTransportCCTSupport.xcworkspace' \
-        -scheme "GoogleDataTransportCCTSupport-$platform-Unit-Tests-Unit" \
+        -scheme "GoogleDataTransportCCTSupport-Unit-Tests-Unit" \
         "${xcb_flags[@]}" \
         build \
         test
 
     RunXcodebuild \
         -workspace 'GoogleDataTransportCCTSupport/gen/GoogleDataTransportCCTSupport/GoogleDataTransportCCTSupport.xcworkspace' \
-        -scheme "GoogleDataTransportCCTSupport-$platform-Unit-Tests-Integration" \
+        -scheme "GoogleDataTransportCCTSupport-Unit-Tests-Integration" \
         "${xcb_flags[@]}" \
         build \
         test
+    ;;
+
+  Storage-*-xcodebuild)
+    RunXcodebuild \
+      -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
+      -scheme "FirebaseStorage-iOS-Unit-unit" \
+      "${xcb_flags[@]}" \
+      build \
+      test
+    RunXcodebuild \
+      -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
+      -scheme "FirebaseStorage-macOS-Unit-unit" \
+      "${xcb_flags[@]}" \
+      build \
+      test
+    RunXcodebuild \
+      -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
+      -scheme "FirebaseStorage-tvOS-Unit-unit" \
+      "${xcb_flags[@]}" \
+      build \
+      test
     ;;
 
   Storage-xcodebuild-*)
@@ -385,6 +406,7 @@ case "$product-$method-$platform" in
       "${xcb_flags[@]}" \
       build \
       test
+
     RunXcodebuild \
       -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
       -scheme "FirebaseStorage-macOS-Unit-unit" \
@@ -392,6 +414,7 @@ case "$product-$method-$platform" in
       "${xcb_flags[@]}" \
       build \
       test
+
     RunXcodebuild \
       -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
       -scheme "FirebaseStorage-tvOS-Unit-unit" \
@@ -401,7 +424,7 @@ case "$product-$method-$platform" in
       test
 
     if [[ "$TRAVIS_PULL_REQUEST" == "false" ||
-          "$TRAVIS_PULL_REQUEST_SLUG" == "$TRAVIS_REPO_SLUG" ]]; then
+      "$TRAVIS_PULL_REQUEST_SLUG" == "$TRAVIS_REPO_SLUG" ]]; then
       # Integration tests are only run on iOS to minimize flake failures.
       RunXcodebuild \
         -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -102,15 +102,15 @@ tvos_flags=(
 # Compute standard flags for all platforms
 case "$platform" in
   iOS)
-    xcb_flags="${ios_flags[@]}"
+    xcb_flags=("${ios_flags[@]}")
     ;;
 
   macOS)
-    xcb_flags="${macos_flags[@]}"
+    xcb_flags=("${macos_flags[@]}")
     ;;
 
   tvOS)
-    xcb_flags="${tvos_flags[@]}"
+    xcb_flags=("${tvos_flags[@]}")
     ;;
 
   all)

--- a/scripts/if_changed.sh
+++ b/scripts/if_changed.sh
@@ -70,6 +70,10 @@ else
       check_changes '^(Firebase/Core|Example/Core/Tests|GoogleUtilities|FirebaseCore.podspec)'
       ;;
 
+    Database-*)
+      check_changes '^(Firebase/Core|Firebase/Database|Example/Database|GoogleUtilities|FirebaseDatabase.podspec)'
+      ;;
+
     Functions-*)
       check_changes '^(Firebase/Core|Functions|GoogleUtilities|FirebaseFunctions.podspec)'
       ;;

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -66,6 +66,13 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     ./Functions/Backend/start.sh synchronous
     ;;
 
+  Database-*)
+    # Install the workspace to have better control over test runs than
+    # pod lib lint, since the integration tests can be flaky.
+    bundle exec pod gen FirebaseDatabase.podspec --local-sources=./
+    install_secrets
+    ;;
+
   Storage-*)
     # Install the workspace to have better control over test runs than
     # pod lib lint, since the integration tests can be flaky.

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -70,9 +70,7 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     # Install the workspace to have better control over test runs than
     # pod lib lint, since the integration tests can be flaky.
     bundle exec pod gen FirebaseStorage.podspec --local-sources=./
-    if [[ $METHOD = "integration" ]]; then
-      install_secrets
-    fi
+    install_secrets
     ;;
 
   InAppMessaging-iOS-xcodebuild)

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -70,7 +70,9 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     # Install the workspace to have better control over test runs than
     # pod lib lint, since the integration tests can be flaky.
     bundle exec pod gen FirebaseStorage.podspec --local-sources=./
-    install_secrets
+    if [[ $METHOD = "integration" ]]; then
+      install_secrets
+    fi
     ;;
 
   InAppMessaging-iOS-xcodebuild)


### PR DESCRIPTION
- Add unit and integration test specs for FirebaseDatabase.
- Add a complete Database build and test rule.
- Fix build warnings in test source.
- Update integration tests to handle 1mb.dat in either the main bundle or the the test target bundle.
- Run integration tests on all builds in the repo including PRs - only external PRs will not run them now.
- The old build environment is still supported.
- It will be removed when all pods have transitioned to test_specs and pod gen.
- For now, see the instructions at https://github.com/firebase/firebase-ios-sdk/blob/master/Functions/README.md.