### PR TITLE
Make FIAM tests required for Travis CI build to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -331,8 +331,6 @@ jobs:
     - env:
       - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild SANITIZERS=tsan
     - env:
-      - PROJECT=InAppMessaging PLATFORM=iOS METHOD=xcodebuild
-    - env:
       - PROJECT=GoogleDataTransportIntegrationTest PLATFORM=iOS METHOD=xcodebuild
 
   # TODO(varconst): enable if it's possible to make this flag work on build

--- a/InAppMessaging/Example/Tests/FIRIAMClearcutUploaderTests.m
+++ b/InAppMessaging/Example/Tests/FIRIAMClearcutUploaderTests.m
@@ -98,7 +98,7 @@
   [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
-- (void)disable_testUploadNotTriggeredWhenWaitTimeConditionNotSatisfied {
+- (void)testUploadNotTriggeredWhenWaitTimeConditionNotSatisfied {
   // using a real storage in this case
   FIRIAMClearcutLogStorage *logStorage =
       [[FIRIAMClearcutLogStorage alloc] initWithExpireAfterInSeconds:1000


### PR DESCRIPTION
We [made FIAM tests non-required](https://github.com/firebase/firebase-ios-sdk/commit/dd0ae1de4ccc17c9c7cd441f14816c851d1b4257#diff-354f30a63fb0907d4ad57269548329e3) due to some flake in `FIRIAMClearcutUploaderTests`. After some testing on a debugging PR, I'm not seeing the flake anymore. I'm not certain what changed, but I did see that our Travis CI Xcode config was recently updated. This PR adds FIAM tests back to the required set.

- Also re-enabled a unit test that had been disabled.