### PR TITLE
 Add InstanceID test_spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,16 @@ jobs:
 
     - stage: test
       env:
+        - PROJECT=InstanceID PLATFORM=iOS METHOD=pod-lib-lint
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseInstanceID.podspec
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseInstanceID.podspec --use-libraries
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseInstanceID.podspec --use-modular-headers
+
+    - stage: test
+      env:
         - PROJECT=Storage PLATFORM=all METHOD=xcodebuild
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
@@ -105,7 +115,6 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseAuth.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseAuthInterop.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseDynamicLinks.podspec
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseInstanceID.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseMessaging.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseInAppMessaging.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.sh FirebaseInAppMessagingDisplay.podspec
@@ -133,7 +142,6 @@ jobs:
         - travis_retry ./scripts/pod_lib_lint.sh FirebaseAuth.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.sh FirebaseAuthInterop.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.sh FirebaseDynamicLinks.podspec --use-libraries
-        - travis_retry ./scripts/pod_lib_lint.sh FirebaseInstanceID.podspec --use-libraries
         # The Protobuf dependency of FirebaseMessaging has warnings with --use-libraries
         - travis_retry ./scripts/pod_lib_lint.sh FirebaseMessaging.podspec --use-libraries --allow-warnings
         - travis_retry ./scripts/pod_lib_lint.sh FirebaseInAppMessaging.podspec --use-libraries

--- a/Example/InstanceID/Tests/FIRInstanceIDAPNSInfoTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDAPNSInfoTest.m
@@ -68,15 +68,6 @@
   XCTAssertNil(info);
 }
 
-- (void)testAPNSInfoCreationFromInvalidArchive {
-  NSData *badData = [@"badData" dataUsingEncoding:NSUTF8StringEncoding];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  FIRInstanceIDAPNSInfo *info = [NSKeyedUnarchiver unarchiveObjectWithData:badData];
-#pragma clang diagnostic pop
-  XCTAssertNil(info);
-}
-
 // Test that archiving a FIRInstanceIDAPNSInfo object and restoring it from the archive
 // yields the same values for all the fields.
 - (void)testAPNSInfoEncodingAndDecoding {

--- a/Example/InstanceID/Tests/FIRInstanceIDAuthKeyChainTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDAuthKeyChainTest.m
@@ -23,8 +23,6 @@
 
 static NSString *const kFIRInstanceIDTestKeychainId = @"com.google.iid-tests";
 
-static NSString *const kFakeCheckinPlistName = @"com.google.test.IIDStoreTestCheckin";
-
 static NSString *const kAuthorizedEntity = @"test-audience";
 static NSString *const kScope = @"test-scope";
 static NSString *const kAuthID = @"test-auth-id";

--- a/Example/InstanceID/Tests/FIRInstanceIDAuthServiceTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDAuthServiceTest.m
@@ -25,7 +25,6 @@
 
 static NSString *const kDeviceAuthId = @"device-id";
 static NSString *const kSecretToken = @"secret-token";
-static NSString *const kDigest = @"com.google.digest";
 static NSString *const kVersionInfo = @"1.0";
 
 @interface FIRInstanceIDCheckinService ()

--- a/Example/InstanceID/Tests/FIRInstanceIDCheckinServiceTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDCheckinServiceTest.m
@@ -64,7 +64,7 @@ static NSString *const kVersionInfo = @"1.0";
                         // For accuracy purposes it's better to compare seconds since the test
                         // should never run for more than 1 second.
                         NSInteger expectedTimestampInSeconds =
-                            FIRInstanceIDCurrentTimestampInSeconds();
+                            (NSInteger)FIRInstanceIDCurrentTimestampInSeconds();
                         NSInteger actualTimestampInSeconds =
                             checkinPreferences.lastCheckinTimestampMillis / 1000.0;
                         XCTAssertEqual(expectedTimestampInSeconds, actualTimestampInSeconds);

--- a/Example/InstanceID/Tests/FIRInstanceIDCheckinStoreTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDCheckinStoreTest.m
@@ -39,12 +39,9 @@ static const NSTimeInterval kExpectationTimeout = 12;
 static NSString *const kFakeCheckinPlistName = @"com.google.test.IIDStoreTestCheckin";
 static NSString *const kSubDirectoryName = @"FirebaseInstanceIDCheckinTest";
 
-static NSString *const kAuthorizedEntity = @"test-audience";
 static NSString *const kAuthID = @"test-auth-id";
 static NSString *const kDigest = @"test-digest";
-static NSString *const kScope = @"test-scope";
 static NSString *const kSecret = @"test-secret";
-static NSString *const kToken = @"test-token";
 static NSString *const kFakeErrorDomain = @"fakeDomain";
 static const NSUInteger kFakeErrorCode = -1;
 

--- a/Example/InstanceID/Tests/FIRInstanceIDKeyPairStoreTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDKeyPairStoreTest.m
@@ -92,7 +92,7 @@
   // Mock that the plist doesn't exist, and call the invalidation check. It should
   // trigger the identities to be deleted.
   id plistMock = OCMPartialMock(self.keyPairStore.plist);
-  [[[plistMock stub] andReturnValue:OCMOCK_VALUE(NO)] doesFileExist];
+  [[[plistMock stub] andReturnValue:[NSNumber numberWithBool:NO]] doesFileExist];
   // Mock the keypair store, to check if key pair deletes are requested
   id storeMock = OCMPartialMock(self.keyPairStore);
   // Now trigger a possible invalidation.
@@ -105,7 +105,7 @@
   // Mock that the plist doesn't exist, and call the invalidation check. It should
   // trigger the identities to be deleted.
   id plistMock = OCMPartialMock(self.keyPairStore.plist);
-  [[[plistMock stub] andReturnValue:OCMOCK_VALUE(YES)] doesFileExist];
+  [[[plistMock stub] andReturnValue:[NSNumber numberWithBool:YES]] doesFileExist];
   // Mock the keypair store, to check if key pair deletes are requested
   id storeMock = OCMPartialMock(self.keyPairStore);
   // Now trigger a possible invalidation.
@@ -141,7 +141,7 @@
                               XCTAssertNotEqualObjects(iid1, iid2);
                               [identityResetExpectation fulfill];
                             }];
-  [self waitForExpectationsWithTimeout:1 handler:nil];
+  [self waitForExpectationsWithTimeout:3 handler:nil];
 }
 
 /**

--- a/Example/InstanceID/Tests/FIRInstanceIDKeyPairStoreTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDKeyPairStoreTest.m
@@ -141,7 +141,7 @@
                               XCTAssertNotEqualObjects(iid1, iid2);
                               [identityResetExpectation fulfill];
                             }];
-  [self waitForExpectationsWithTimeout:3 handler:nil];
+  [self waitForExpectationsWithTimeout:5 handler:nil];
 }
 
 /**

--- a/Example/InstanceID/Tests/FIRInstanceIDStoreTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDStoreTest.m
@@ -33,15 +33,8 @@ static NSString *const kSubDirectoryName = @"FirebaseInstanceIDStoreTest";
 static NSString *const kAuthorizedEntity = @"test-audience";
 static NSString *const kScope = @"test-scope";
 static NSString *const kToken = @"test-token";
-static NSString *const kKey = @"test-key";
-static NSString *const kTimeSuffix = @"-time";
 static NSString *const kAuthID = @"test-auth-id";
 static NSString *const kSecret = @"test-secret";
-
-// This should stay in sync with the same constant name in FIRInstanceIDStore.
-// We don't want to make a new method in FIRInstanceIDStore to avoid adding
-// binary bloat.
-static NSString *const kFIRInstanceIDAPNSTokenKey = @"APNSTuple";
 
 @interface FIRInstanceIDStore ()
 
@@ -60,13 +53,13 @@ static NSString *const kFIRInstanceIDAPNSTokenKey = @"APNSTuple";
 
 @interface FIRInstanceIDStoreTest : XCTestCase
 
-@property(nonatomic) FIRInstanceIDStore *instanceIDStore;
-@property(nonatomic) FIRInstanceIDBackupExcludedPlist *checkinPlist;
-@property(nonatomic) FIRInstanceIDCheckinStore *checkinStore;
-@property(nonatomic) FIRInstanceIDTokenStore *tokenStore;
-@property(nonatomic) id mockCheckinStore;
-@property(nonatomic) id mockTokenStore;
-@property(nonatomic) id mockInstanceIDStore;
+@property(assign, nonatomic) FIRInstanceIDStore *instanceIDStore;
+@property(assign, nonatomic) FIRInstanceIDBackupExcludedPlist *checkinPlist;
+@property(assign, nonatomic) FIRInstanceIDCheckinStore *checkinStore;
+@property(assign, nonatomic) FIRInstanceIDTokenStore *tokenStore;
+@property(assign, nonatomic) id mockCheckinStore;
+@property(assign, nonatomic) id mockTokenStore;
+@property(assign, nonatomic) id mockInstanceIDStore;
 
 @end
 
@@ -103,7 +96,8 @@ static NSString *const kFIRInstanceIDAPNSTokenKey = @"APNSTuple";
   [self.instanceIDStore removeAllCachedTokensWithHandler:nil];
   [self.instanceIDStore removeCheckinPreferencesWithHandler:nil];
   [FIRInstanceIDStore removeSubDirectory:kSubDirectoryName error:nil];
-  [_mockCheckinStore stopMocking];
+  // EXC_BAD_ACCESS and doesn't seem necessary. Perhaps https://github.com/erikdoe/ocmock/issues/317
+  // [_mockCheckinStore stopMocking];
   [_mockTokenStore stopMocking];
   [_mockInstanceIDStore stopMocking];
   [super tearDown];

--- a/Example/InstanceID/Tests/FIRInstanceIDStoreTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDStoreTest.m
@@ -53,13 +53,13 @@ static NSString *const kSecret = @"test-secret";
 
 @interface FIRInstanceIDStoreTest : XCTestCase
 
-@property(assign, nonatomic) FIRInstanceIDStore *instanceIDStore;
-@property(assign, nonatomic) FIRInstanceIDBackupExcludedPlist *checkinPlist;
-@property(assign, nonatomic) FIRInstanceIDCheckinStore *checkinStore;
-@property(assign, nonatomic) FIRInstanceIDTokenStore *tokenStore;
-@property(assign, nonatomic) id mockCheckinStore;
-@property(assign, nonatomic) id mockTokenStore;
-@property(assign, nonatomic) id mockInstanceIDStore;
+@property(strong, nonatomic) FIRInstanceIDStore *instanceIDStore;
+@property(strong, nonatomic) FIRInstanceIDBackupExcludedPlist *checkinPlist;
+@property(strong, nonatomic) FIRInstanceIDCheckinStore *checkinStore;
+@property(strong, nonatomic) FIRInstanceIDTokenStore *tokenStore;
+@property(strong, nonatomic) id mockCheckinStore;
+@property(strong, nonatomic) id mockTokenStore;
+@property(strong, nonatomic) id mockInstanceIDStore;
 
 @end
 
@@ -96,8 +96,7 @@ static NSString *const kSecret = @"test-secret";
   [self.instanceIDStore removeAllCachedTokensWithHandler:nil];
   [self.instanceIDStore removeCheckinPreferencesWithHandler:nil];
   [FIRInstanceIDStore removeSubDirectory:kSubDirectoryName error:nil];
-  // EXC_BAD_ACCESS and doesn't seem necessary. Perhaps https://github.com/erikdoe/ocmock/issues/317
-  // [_mockCheckinStore stopMocking];
+  [_mockCheckinStore stopMocking];
   [_mockTokenStore stopMocking];
   [_mockInstanceIDStore stopMocking];
   [super tearDown];
@@ -245,13 +244,13 @@ static NSString *const kSecret = @"test-secret";
 }
 
 - (void)testResetCredentialsWithNoCachedCheckin {
-  _mockCheckinStore = [OCMockObject niceMockForClass:[FIRInstanceIDCheckinStore class]];
-  [[_mockCheckinStore reject]
+  id niceMockCheckinStore = [OCMockObject niceMockForClass:[FIRInstanceIDCheckinStore class]];
+  [[niceMockCheckinStore reject]
       removeCheckinPreferencesWithHandler:[OCMArg invokeBlockWithArgs:[NSNull null], nil]];
   // Always setting up stub after expect.
   OCMStub([_checkinStore cachedCheckinPreferences]).andReturn(nil);
 
   [_instanceIDStore resetCredentialsIfNeeded];
-  OCMVerifyAll(_mockCheckinStore);
+  OCMVerifyAll(niceMockCheckinStore);
 }
 @end

--- a/Example/InstanceID/Tests/FIRInstanceIDTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTest.m
@@ -40,7 +40,6 @@ static FIRInstanceIDTokenInfo *sTokenInfo;
 // Faking checkin calls
 static NSString *const kDeviceAuthId = @"device-id";
 static NSString *const kSecretToken = @"secret-token";
-static NSString *const kDigest = @"com.google.digest";
 static NSString *const kVersionInfo = @"1.0";
 // FIRApp configuration.
 static NSString *const kGCMSenderID = @"correct_gcm_sender_id";
@@ -204,7 +203,7 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
 - (void)testTokenIsFetchedDuringIIDGeneration {
   XCTestExpectation *tokenExpectation = [self
       expectationWithDescription:@"Token is refreshed when getID is called to avoid IID conflict."];
-  NSError *error;
+  NSError *error = nil;
   [[[self.mockKeyPairStore stub] andReturn:kFakeIID] appIdentityWithError:[OCMArg setTo:error]];
 
   [self.mockInstanceID getIDWithHandler:^(NSString *identity, NSError *error) {

--- a/Example/InstanceID/Tests/FIRInstanceIDTokenInfoTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTokenInfoTest.m
@@ -69,10 +69,15 @@ static BOOL const kAPNSSandbox = NO;
 
 - (void)testTokenInfoCreationWithInvalidArchive {
   NSData *badData = [@"badData" dataUsingEncoding:NSUTF8StringEncoding];
+  FIRInstanceIDTokenInfo *info = nil;
+  @try {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  FIRInstanceIDTokenInfo *info = [NSKeyedUnarchiver unarchiveObjectWithData:badData];
+    info = [NSKeyedUnarchiver unarchiveObjectWithData:badData];
 #pragma clang diagnostic pop
+  } @catch (NSException *e) {
+    XCTAssertEqualObjects([e name], @"NSInvalidArgumentException");
+  }
   XCTAssertNil(info);
 }
 

--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -39,4 +39,17 @@ services.
   s.dependency 'FirebaseCore', '~> 6.0'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 6.0'
   s.dependency 'GoogleUtilities/Environment', '~> 6.0'
+
+  s.test_spec 'unit' do |unit_tests|
+    unit_tests.source_files = 'Example/InstanceID/Tests/*.[mh]'
+    unit_tests.requires_app_host = true
+    unit_tests.dependency 'OCMock'
+    unit_tests.pod_target_xcconfig = {
+      # Unit tests do library imports using repo-root relative paths.
+      'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
+      # Prevent linker warning for test category override of
+      # store:didDeleteFCMScopedTokensForCheckin:
+      'OTHER_LDFLAGS' => '-Xlinker -no_objc_category_merging'
+   }
+  end
 end

--- a/scripts/if_changed.sh
+++ b/scripts/if_changed.sh
@@ -83,6 +83,11 @@ else
 'Firebase/InAppMessaging)'
       ;;
 
+    InstanceID-*)
+      check_changes '^(Firebase/InstanceID|Example/InstanceID|Firebase/Core|GoogleUtilities|'\
+'FirebaseInstanceID.podspec)'
+      ;;
+
     Firestore-xcodebuild|Firestore-pod-lib-lint)
       check_changes '^(Firestore|FirebaseFirestore.podspec|FirebaseFirestoreSwift.podspec|'\
 'GoogleUtilities)'


### PR DESCRIPTION
- Add unit test spec for InstanceID.
- Add a complete InstanceID build and test rule.
- Fix build warnings in test source.
- Fix tests for running on 32 bit simulators
- Remove redundant test
- The old build environment is still supported.
- It will be removed when all pods have transitioned to test_specs and pod gen.
- For now, see the instructions at https://github.com/firebase/firebase-ios-sdk/blob/master/Functions/README.md.