### PR TITLE
Handle new cert bundle name in gRPC-C++

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -53,7 +53,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
 
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
   s.dependency 'FirebaseCore', '~> 6.0'
-  s.dependency 'gRPC-C++', '0.0.8'
+  s.dependency 'gRPC-C++', '0.0.9'
   s.dependency 'leveldb-library', '~> 1.20'
   s.dependency 'Protobuf', '~> 3.1'
   s.dependency 'nanopb', '~> 0.3.901'

--- a/Firestore/core/src/firebase/firestore/remote/grpc_root_certificate_finder_apple.mm
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_root_certificate_finder_apple.mm
@@ -78,7 +78,7 @@ NSBundle* _Nullable FindCertBundleInParent(NSBundle* _Nullable parent) {
   if (!parent) return nil;
 
   static NSString* const bundle_names[] = {
-      // gRPC-C++ 0.0.9 Changed the name of the resource bundle to allow it to
+      // gRPC-C++ 0.0.9 changed the name of the resource bundle to allow it to
       // coexist with Objective-C gRPC.
       @"gRPCCertificates-Cpp",
 

--- a/Firestore/core/src/firebase/firestore/remote/grpc_root_certificate_finder_apple.mm
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_root_certificate_finder_apple.mm
@@ -67,9 +67,9 @@ NSString* _Nullable FindCertFileInResourceBundle(NSBundle* _Nullable bundle,
 /**
  * Finds gRPCCertificates.bundle inside the given parent, if it exists.
  *
- * This function exists mostly to handle differences in platforms.
- * On iOS, resources are nested directly within the top-level of the parent
- * bundle, but on macOS this will actually be in Contents/Resources.
+ * This function exists mostly to handle differences in platforms.  On iOS,
+ * resources are nested directly within the top-level of the parent bundle, but
+ * on macOS this will actually be in Contents/Resources.
  *
  * @param parent A framework or app bundle to check.
  * @return The nested gRPCCertificates.bundle if found, otherwise nil.
@@ -77,11 +77,23 @@ NSString* _Nullable FindCertFileInResourceBundle(NSBundle* _Nullable bundle,
 NSBundle* _Nullable FindCertBundleInParent(NSBundle* _Nullable parent) {
   if (!parent) return nil;
 
-  NSString* path = [parent pathForResource:@"gRPCCertificates"
-                                    ofType:@"bundle"];
-  if (!path) return nil;
+  static NSString* const bundle_names[] = {
+      // gRPC-C++ 0.0.9 Changed the name of the resource bundle to allow it to
+      // coexist with Objective-C gRPC.
+      @"gRPCCertificates-Cpp",
 
-  return [[NSBundle alloc] initWithPath:path];
+      // Older gRPC-C++ or Objective-C gRPC use this name.
+      @"gRPCCertificates",
+  };
+
+  for (NSString* bundle_name : bundle_names) {
+    NSString* path = [parent pathForResource:bundle_name ofType:@"bundle"];
+    if (path) {
+      return [[NSBundle alloc] initWithPath:path];
+    }
+  }
+
+  return nil;
 }
 
 using BundleLoader = NSBundle* _Nullable (*)(void);


### PR DESCRIPTION
gRPC-C++ 0.0.9 is changing the certificate bundle name to gRPCCertificates-Cpp.bundle to allow gRPC-C++ to coexist with the Objective-C gRPC CocoaPod. Without this the bundles collide and cause build errors.

Note that we allow all the configuration variation in here to avoid this being a breaking change for our users who may be assembling projects by hand.

This change depends upon grpc/grpc#19082 and the release of gRPC-C++ 0.0.9, which hasn't happened yet.