### PR TITLE
Upgrade the emulator we use for integration testing to 1.4.6

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRArrayTransformTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRArrayTransformTests.mm
@@ -42,12 +42,6 @@
   id<FIRListenerRegistration> _listenerRegistration;
 }
 
-- (void)invokeTest {
-  // None of these tests work in the emulator as of 1.4.5.
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;
-  [super invokeTest];
-}
-
 - (void)setUp {
   [super setUp];
 
@@ -172,12 +166,6 @@
 @implementation FIRArrayTransformServerApplicationTests {
   // A document reference to read and write to.
   FIRDocumentReference *_docRef;
-}
-
-- (void)invokeTest {
-  // None of these tests work in the emulator as of 1.4.5.
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;
-  [super invokeTest];
 }
 
 - (void)setUp {

--- a/Firestore/Example/Tests/Integration/API/FIRNumericTransformTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRNumericTransformTests.mm
@@ -39,12 +39,6 @@ double DOUBLE_EPSILON = 0.000001;
   id<FIRListenerRegistration> _listenerRegistration;
 }
 
-- (void)invokeTest {
-  // None of these tests work in the emulator as of 1.4.5.
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;
-  [super invokeTest];
-}
-
 - (void)setUp {
   [super setUp];
 

--- a/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
@@ -295,8 +295,6 @@
 }
 
 - (void)testCollectionGroupQueries {
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;  // b/131774876
-
   // Use .document() to get a random collection group name to use but ensure it starts with 'b'
   // for predictable ordering.
   NSString *collectionGroup = [NSString
@@ -331,8 +329,6 @@
 }
 
 - (void)testCollectionGroupQueriesWithStartAtEndAtWithArbitraryDocumentIDs {
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;  // b/131774876
-
   // Use .document() to get a random collection group name to use but ensure it starts with 'b'
   // for predictable ordering.
   NSString *collectionGroup = [NSString
@@ -370,8 +366,6 @@
 }
 
 - (void)testCollectionGroupQueriesWithWhereFiltersOnArbitraryDocumentIDs {
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;  // b/131774876
-
   // Use .document() to get a random collection group name to use but ensure it starts with 'b'
   // for predictable ordering.
   NSString *collectionGroup = [NSString

--- a/Firestore/Example/Tests/Integration/FSTTransactionTests.mm
+++ b/Firestore/Example/Tests/Integration/FSTTransactionTests.mm
@@ -246,8 +246,6 @@
 }
 
 - (void)testIncrementTransactionally {
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;
-
   // A barrier to make sure every transaction reaches the same spot.
   dispatch_semaphore_t writeBarrier = dispatch_semaphore_create(0);
   __block volatile int32_t started = 0;
@@ -290,8 +288,6 @@
 }
 
 - (void)testUpdateTransactionally {
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;
-
   // A barrier to make sure every transaction reaches the same spot.
   dispatch_semaphore_t writeBarrier = dispatch_semaphore_create(0);
   __block volatile int32_t started = 0;
@@ -458,8 +454,6 @@
 }
 
 - (void)testCancellationOnError {
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;
-
   FIRFirestore *firestore = [self firestore];
   FIRDocumentReference *doc = [[firestore collectionWithPath:@"towns"] documentWithAutoID];
   __block volatile int32_t count = 0;
@@ -486,7 +480,7 @@
 }
 
 - (void)testUpdateFieldsWithDotsTransactionally {
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;
+  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;  // b/112104025
 
   FIRDocumentReference *doc = [self documentRef];
 

--- a/scripts/run_firestore_emulator.sh
+++ b/scripts/run_firestore_emulator.sh
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-VERSION='1.4.5'
+VERSION='1.4.6'
 FILENAME="cloud-firestore-emulator-v${VERSION}.jar"
 URL="https://storage.googleapis.com/firebase-preview-drop/emulator/${FILENAME}"
 


### PR DESCRIPTION
... and re-enable tests that now work against it.

b/112104025 remains the major source of outstanding disabled tests.

@ryanpbrewster FYI