### PR TITLE
Remove checks for boolean migration

### DIFF
--- a/Firestore/core/src/firebase/firestore/local/leveldb_mutation_queue.mm
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_mutation_queue.mm
@@ -82,8 +82,8 @@ BatchId LoadNextBatchIdFromDb(DB* db) {
 
     // At this point there are three possible cases to handle differently. Each
     // case must prepare the next iteration (by assigning to next_user_id or
-    // setting more_user_ids = NO) and seek the iterator to the last row in the
-    // current user's mutation sequence.
+    // setting more_user_ids = false) and seek the iterator to the last row in
+    // the current user's mutation sequence.
     if (!it->Valid()) {
       // The iterator is past the last row altogether (there are no additional
       // userIDs and now rows in any table after mutations). The last row will

--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -211,7 +211,6 @@ _ERROR_CATEGORIES = [
     'readability/namespace',
     'readability/nolint',
     'readability/nul',
-    'readability/objc',
     'readability/strings',
     'readability/todo',
     'readability/utf8',
@@ -4625,30 +4624,6 @@ def CheckIncludeLine(filename, clean_lines, linenum, include_state, error):
       include_state.SetLastHeader(canonical_include)
 
 
-_BANNED_OBJC_WORDS = (r'\bYES\b', r'\bNO\b', r'\bBOOL\b')
-_BANNED_OBJC_REPLACEMENTS = {
-    'YES': 'true',
-    'NO': 'false',
-    'BOOL': 'bool',
-}
-
-_BANNED_OBJC_WORDS_RE = re.compile('(' + '|'.join(_BANNED_OBJC_WORDS) + ')')
-
-
-def CheckObjcConversion(filename, lines, error):
-  if 'Firestore/core/' not in filename:
-    return
-
-  for linenum, line in enumerate(lines):
-    match = _BANNED_OBJC_WORDS_RE.search(line)
-    if match:
-      word = match.group(1)
-      replacement = _BANNED_OBJC_REPLACEMENTS[word]
-      error(filename, linenum, 'readability/objc', 4,
-            'Migrate %s to %s' %
-            (word, replacement))
-
-
 
 def _GetTextInside(text, start_pattern):
   r"""Retrieves all the text between matching open and close parentheses.
@@ -6029,8 +6004,6 @@ def ProcessFileData(filename, file_extension, lines, error,
   nesting_state = NestingState()
 
   ResetNolintSuppressions()
-
-  CheckObjcConversion(filename, lines, error)
 
   CheckForCopyright(filename, lines, error)
   ProcessGlobalSuppresions(lines)


### PR DESCRIPTION
There are too many false positives to mark with NOLINT:

  * BOOL is type in Win32
  * BOOL is used as an identifier in the nanopb API
  * YES and NO should be used when calling Objective-C APIs
  * YES and NO are in the instructions for using NSDefaults

Leaving this check in place makes it impossible to change files that currently include these violations.