### PR TITLE
Make DatabaseId a cheap value type

### DIFF
--- a/Firestore/core/src/firebase/firestore/model/database_id.cc
+++ b/Firestore/core/src/firebase/firestore/model/database_id.cc
@@ -27,22 +27,25 @@ namespace model {
 
 constexpr const char* DatabaseId::kDefault;
 
-DatabaseId::DatabaseId(std::string project_id, std::string database_id)
-    : project_id_{std::move(project_id)}, database_id_{std::move(database_id)} {
-  HARD_ASSERT(!project_id_.empty());
-  HARD_ASSERT(!database_id_.empty());
+DatabaseId::DatabaseId(std::string project_id, std::string database_id) {
+  HARD_ASSERT(!project_id.empty());
+  HARD_ASSERT(!database_id.empty());
+
+  rep_ = std::make_shared<Rep>();
+  rep_->project_id = std::move(project_id);
+  rep_->database_id = std::move(database_id);
 }
 
 util::ComparisonResult DatabaseId::CompareTo(
     const firebase::firestore::model::DatabaseId& rhs) const {
-  util::ComparisonResult cmp = util::Compare(project_id_, rhs.project_id_);
+  util::ComparisonResult cmp = util::Compare(project_id(), rhs.project_id());
   if (!util::Same(cmp)) return cmp;
 
-  return util::Compare(database_id_, rhs.database_id_);
+  return util::Compare(database_id(), rhs.database_id());
 }
 
 size_t DatabaseId::Hash() const {
-  return util::Hash(project_id_, database_id_);
+  return util::Hash(project_id(), database_id());
 }
 
 }  // namespace model

--- a/Firestore/core/src/firebase/firestore/model/database_id.h
+++ b/Firestore/core/src/firebase/firestore/model/database_id.h
@@ -64,6 +64,8 @@ class DatabaseId : public util::Comparable<DatabaseId> {
   size_t Hash() const;
 
  private:
+  // DocumentIds are copied into every ReferenceValue we create so hide the
+  // actual values behind a shared_ptr to make copying cheaper.
   struct Rep {
     std::string project_id;
     std::string database_id;

--- a/Firestore/core/src/firebase/firestore/model/database_id.h
+++ b/Firestore/core/src/firebase/firestore/model/database_id.h
@@ -17,11 +17,10 @@
 #ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_MODEL_DATABASE_ID_H_
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_MODEL_DATABASE_ID_H_
 
-#include <cstdint>
+#include <memory>
 #include <string>
 
 #include "Firestore/core/src/firebase/firestore/util/comparison.h"
-#include "absl/strings/string_view.h"
 
 namespace firebase {
 namespace firestore {
@@ -48,16 +47,16 @@ class DatabaseId : public util::Comparable<DatabaseId> {
   DatabaseId(std::string project_id, std::string database_id);
 
   const std::string& project_id() const {
-    return project_id_;
+    return rep_->project_id;
   }
 
   const std::string& database_id() const {
-    return database_id_;
+    return rep_->database_id;
   }
 
   /** Whether this is the default database of the project. */
   bool IsDefaultDatabase() const {
-    return database_id_ == kDefault;
+    return rep_->database_id == kDefault;
   }
 
   util::ComparisonResult CompareTo(const DatabaseId& rhs) const;
@@ -65,8 +64,12 @@ class DatabaseId : public util::Comparable<DatabaseId> {
   size_t Hash() const;
 
  private:
-  std::string project_id_;
-  std::string database_id_;
+  struct Rep {
+    std::string project_id;
+    std::string database_id;
+  };
+
+  std::shared_ptr<Rep> rep_;
 };
 
 }  // namespace model

--- a/Firestore/core/test/firebase/firestore/model/database_id_test.cc
+++ b/Firestore/core/test/firebase/firestore/model/database_id_test.cc
@@ -22,21 +22,21 @@ namespace firebase {
 namespace firestore {
 namespace model {
 
-TEST(DatabaseId, Constructor) {
+TEST(DatabaseIdTest, Constructor) {
   DatabaseId id("p", "d");
   EXPECT_EQ("p", id.project_id());
   EXPECT_EQ("d", id.database_id());
   EXPECT_FALSE(id.IsDefaultDatabase());
 }
 
-TEST(DatabaseId, DefaultDb) {
+TEST(DatabaseIdTest, DefaultDb) {
   DatabaseId id("p", DatabaseId::kDefault);
   EXPECT_EQ("p", id.project_id());
   EXPECT_EQ("(default)", id.database_id());
   EXPECT_TRUE(id.IsDefaultDatabase());
 }
 
-TEST(DatabaseId, Comparison) {
+TEST(DatabaseIdTest, Comparison) {
   EXPECT_LT(DatabaseId("a", "b"), DatabaseId("b", "a"));
   EXPECT_LT(DatabaseId("a", "b"), DatabaseId("a", "c"));
   EXPECT_EQ(DatabaseId("a", "b"), DatabaseId("a", "b"));


### PR DESCRIPTION
This makes it possible to use `DatabaseId` freely and naturally throughout instead of passing it with raw pointers as we currently do. Updates to usage and tests are coming in another PR.