### PR TITLE
Fix Auth post-submit CI build break

### DIFF
--- a/Example/Auth/Sample/FacebookAuthProvider.m
+++ b/Example/Auth/Sample/FacebookAuthProvider.m
@@ -49,9 +49,9 @@ static NSString *const kFacebookAppID = KFACEBOOK_APP_ID;
 
   [ApplicationDelegate setOpenURLDelegate:self];
   [FBSDKSettings setAppID:kFacebookAppID];
-  [_loginManager logInWithReadPermissions:@[ @"email" ]
-                       fromViewController:viewController
-                                  handler:^(FBSDKLoginManagerLoginResult *result, NSError *error) {
+  [_loginManager logInWithPermissions:@[ @"email" ]
+                   fromViewController:viewController
+                              handler:^(FBSDKLoginManagerLoginResult *result, NSError *error) {
     [ApplicationDelegate setOpenURLDelegate:nil];
     if (!error && result.isCancelled) {
       error = [NSError errorWithDomain:@"com.google.FirebaseAuthSample" code:-1 userInfo:nil];

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -199,8 +199,9 @@ case "$product-$method-$platform" in
       # Code Coverage collection is only working on iOS currently.
       ./scripts/collect_metrics.sh 'Example/Firebase.xcworkspace' "AllUnitTests_$platform"
 
-      # Run integration tests (not allowed on PRs)
-      if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+      # Run integration tests (not allowed on forks)
+      if [[ "$TRAVIS_PULL_REQUEST" == "false" ||
+            "$TRAVIS_PULL_REQUEST_SLUG" == "$TRAVIS_REPO_SLUG" ]]; then
         RunXcodebuild \
           -workspace 'Example/Firebase.xcworkspace' \
           -scheme "Auth_ApiTests" \


### PR DESCRIPTION
The Auth_ApiTests started failing in CI after the migration to CocoaPods 1.7.0.

- Migrate from deprecated Facebook API
- Start running the Auth_ApiTests on internal PRs - only exclude them for forks.