### PR TITLE
Increase timeout on flaky test

### DIFF
--- a/InAppMessaging/Example/Tests/FIRIAMClearcutUploaderTests.m
+++ b/InAppMessaging/Example/Tests/FIRIAMClearcutUploaderTests.m
@@ -146,7 +146,7 @@
 
   // we expect expectation to be fulfilled right away since the upload can be carried out without
   // delay
-  [self waitForExpectationsWithTimeout:10.0 handler:nil];
+  [self waitForExpectationsWithTimeout:20.0 handler:nil];
   XCTAssertFalse(sendingAttempted);
 }
 


### PR DESCRIPTION
Fix #3046 

Increase the timeout to see if it makes a difference on the most common fiam travis flake.