### PR TITLE
Fix compilation error in non-Apple builds.

### DIFF
--- a/Firestore/core/src/firebase/firestore/remote/connectivity_monitor_noop.cc
+++ b/Firestore/core/src/firebase/firestore/remote/connectivity_monitor_noop.cc
@@ -29,7 +29,7 @@ using util::AsyncQueue;
 // build doesn't break on platforms which don't yet implement
 // `ConnectivityMonitor`.
 std::unique_ptr<ConnectivityMonitor> ConnectivityMonitor::Create(
-      const std::shared_ptr<util::AsyncQueue>& worker_queue) {
+      const std::shared_ptr<AsyncQueue>& worker_queue) {
   return absl::make_unique<ConnectivityMonitor>(worker_queue);
 }
 

--- a/Firestore/core/src/firebase/firestore/remote/connectivity_monitor_noop.cc
+++ b/Firestore/core/src/firebase/firestore/remote/connectivity_monitor_noop.cc
@@ -29,7 +29,7 @@ using util::AsyncQueue;
 // build doesn't break on platforms which don't yet implement
 // `ConnectivityMonitor`.
 std::unique_ptr<ConnectivityMonitor> ConnectivityMonitor::Create(
-    AsyncQueue* worker_queue) {
+      const std::shared_ptr<util::AsyncQueue>& worker_queue) {
   return absl::make_unique<ConnectivityMonitor>(worker_queue);
 }
 


### PR DESCRIPTION
Make the no-op connectivity monitor accept worker queue by a shared
pointer (a followup to #3004).