### PR TITLE
Restore style checking on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,8 @@ jobs:
       before_install:
         - brew install clang-format
         - brew install swiftformat
-      env:
-        - if [[ -z $TRAVIS_COMMIT_RANGE ]] ; then echo PARAM=$TRAVIS_COMMIT; else PARAM=$TRAVIS_COMMIT_RANGE; fi
       script:
-        - ./scripts/check.sh --test-only $PARAM
+        - ./scripts/travis_check.sh --test-only
 
     # The order of builds matters (even though they are run in parallel):
     # Travis will schedule them in the same order they are listed here.
@@ -376,5 +374,5 @@ jobs:
 branches:
   only:
     - master
-    - pb-tmp6
+    - pb-tmp7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -374,5 +374,3 @@ jobs:
 branches:
   only:
     - master
-    - pb-tmp9
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -374,3 +374,5 @@ jobs:
 branches:
   only:
     - master
+    - pb-tmp12
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -374,5 +374,3 @@ jobs:
 branches:
   only:
     - master
-    - pb-tmp5
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -374,5 +374,5 @@ jobs:
 branches:
   only:
     - master
-    - pb-tmp
+    - pb-tmp2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -374,5 +374,3 @@ jobs:
 branches:
   only:
     - master
-    - pb-tmp12
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -374,5 +374,5 @@ jobs:
 branches:
   only:
     - master
-    - pb-tmp4
+    - pb-tmp5
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ jobs:
       before_install:
         - brew install clang-format
         - brew install swiftformat
+      env:
+        - if [[ -z $TRAVIS_COMMIT_RANGE ]] ; then echo PARAM=$TRAVIS_COMMIT; else PARAM=$TRAVIS_COMMIT_RANGE; fi
       script:
-        - ./scripts/check.sh --test-only $TRAVIS_COMMIT_RANGE
+        - ./scripts/check.sh --test-only $PARAM
 
     # The order of builds matters (even though they are run in parallel):
     # Travis will schedule them in the same order they are listed here.
@@ -374,3 +376,5 @@ jobs:
 branches:
   only:
     - master
+    - pb-tmp6
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -374,5 +374,5 @@ jobs:
 branches:
   only:
     - master
-    - pb-tmp3
+    - pb-tmp4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -374,5 +374,5 @@ jobs:
 branches:
   only:
     - master
-    - pb-tmp8
+    - pb-tmp9
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -374,5 +374,5 @@ jobs:
 branches:
   only:
     - master
-    - pb-tmp2
+    - pb-tmp3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -374,3 +374,5 @@ jobs:
 branches:
   only:
     - master
+    - pb-tmp
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
         - brew install clang-format
         - brew install swiftformat
       script:
-        - ./scripts/travis_check.sh --test-only
+        - ./scripts/check.sh --test-only
 
     # The order of builds matters (even though they are run in parallel):
     # Travis will schedule them in the same order they are listed here.
@@ -374,5 +374,5 @@ jobs:
 branches:
   only:
     - master
-    - pb-tmp7
+    - pb-tmp8
 

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -83,7 +83,7 @@ static NSString *const kPlistURL = @"https://console.firebase.google.com/";
  */
 static NSMutableArray<Class<FIRLibrary>> *sRegisteredAsConfigurable;
 
-@interface  FIRApp ()
+@interface FIRApp ()
 
 #ifdef DEBUG
 @property(nonatomic) BOOL alreadyOutputDataCollectionFlag;

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -83,7 +83,7 @@ static NSString *const kPlistURL = @"https://console.firebase.google.com/";
  */
 static NSMutableArray<Class<FIRLibrary>> *sRegisteredAsConfigurable;
 
-@interface FIRApp ()
+@interface  FIRApp ()
 
 #ifdef DEBUG
 @property(nonatomic) BOOL alreadyOutputDataCollectionFlag;

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -91,7 +91,7 @@ static NSMutableArray<Class<FIRLibrary>> *sRegisteredAsConfigurable;
 
 @end
 
-@implementation FIRApp
+@implementation   FIRApp
 
 // This is necessary since our custom getter prevents `_options` from being created.
 @synthesize options = _options;

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -91,7 +91,7 @@ static NSMutableArray<Class<FIRLibrary>> *sRegisteredAsConfigurable;
 
 @end
 
-@implementation   FIRApp
+@implementation FIRApp
 
 // This is necessary since our custom getter prevents `_options` from being created.
 @synthesize options = _options;

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -76,7 +76,6 @@ EOF
 }
 
 set -euo pipefail
-set -x
 unset CDPATH
 
 # Change to the top-directory of the working tree

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -76,6 +76,7 @@ EOF
 }
 
 set -euo pipefail
+set -x
 unset CDPATH
 
 # Change to the top-directory of the working tree
@@ -86,7 +87,7 @@ ALLOW_DIRTY=false
 COMMIT_METHOD="none"
 START_REVISION="origin/master"
 TEST_ONLY=false
-VERBOSE=false
+VERBOSE=true
 
 # Default to verbose operation if this isn't an interactive build.
 if [[ ! -t 1 ]]; then
@@ -163,28 +164,8 @@ if [[ "${VERBOSE}" == true ]]; then
   env | egrep '^TRAVIS_(BRANCH|COMMIT|PULL|REPO)' | sort || true
 fi
 
-# When travis clones a repo for building, it uses a shallow clone. After the
-# first commit on a non-master branch, TRAVIS_COMMIT_RANGE is not set and
-# START_REVISION is "origin/master" because a range wasn't passed in.
 if [[ "${START_REVISION}" == *..* ]]; then
-  RANGE_START="${START_REVISION/..*/}"
-  RANGE_END="${START_REVISION/*../}"
-
-  # Figure out if we have access to origin/master. If not add it to the repo.
-  if ! git rev-parse origin/master >& /dev/null; then
-    git remote set-branches --add origin master
-    git fetch origin
-  fi
-
-  NEW_RANGE_START=$(git merge-base origin/master "${RANGE_END}")
-  START_REVISION="${START_REVISION/$RANGE_START/$NEW_RANGE_START}"
-
   START_SHA="${START_REVISION}"
-
-elif ! git rev-parse origin/master >& /dev/null; then
-  git remote set-branches --add origin master
-  git fetch origin
-  START_SHA=$(git merge-base origin/master "${TRAVIS_COMMIT}")
 
 else
   START_SHA=$(git rev-parse "${START_REVISION}")

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -130,6 +130,11 @@ while [[ $# -gt 0 ]]; do
       # require a clean source tree.
       ALLOW_DIRTY=true
       TEST_ONLY=true
+      if ! [[ -z $TRAVIS_COMMIT_RANGE ]] ; then
+        START_REVISION="$TRAVIS_COMMIT_RANGE"
+      elif ! [[ -z $TRAVIS_COMMIT ]] ; then
+        START_REVISION="$TRAVIS_COMMIT"
+      fi
       ;;
 
     *)

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -161,14 +161,12 @@ fi
 
 # Show Travis-related environment variables, to help with debuging failures.
 if [[ "${VERBOSE}" == true ]]; then
-  env | egrep '^TRAVIS_(BRANCH|COMMIT|PULL)' | sort || true
+  env | egrep '^TRAVIS_(BRANCH|COMMIT|PULL|REPO)' | sort || true
 fi
 
-# When travis clones a repo for building, it uses a shallow clone. When
-# building a branch it can sometimes give a revision range that refers to
-# commits that don't exist in the shallow clone. This has been observed in a
-# branch build where the branch only has a single commit. The cause of this
-# behavior is unclear but as a workaround ...
+# When travis clones a repo for building, it uses a shallow clone. After the
+# first commit on a non-master branch, TRAVIS_COMMIT_RANGE is not set and
+# START_REVISION is "origin/master" because a range wasn't passed in.
 if [[ "${START_REVISION}" == *..* ]]; then
   RANGE_START="${START_REVISION/..*/}"
   RANGE_END="${START_REVISION/*../}"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -76,7 +76,6 @@ EOF
 }
 
 set -euo pipefail
-set -x
 unset CDPATH
 
 # Change to the top-directory of the working tree
@@ -87,7 +86,7 @@ ALLOW_DIRTY=false
 COMMIT_METHOD="none"
 START_REVISION="origin/master"
 TEST_ONLY=false
-VERBOSE=true
+VERBOSE=false
 
 # Default to verbose operation if this isn't an interactive build.
 if [[ ! -t 1 ]]; then

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -22,7 +22,7 @@ function usage() {
 USAGE: scripts/check.sh [--allow-dirty] [--commit] [<revision>]
 
 Runs auto-formatting scripts, source-tree checks, and linters on any files that
-have changed since master.
+have changed since origin/master.
 
 By default, any changes are left as uncommited changes in the working tree. You
 can review them with git diff. Pass --commit to automatically commit any changes.
@@ -50,18 +50,18 @@ OPTIONS:
     Run all checks without making any changes to local files.
 
   <revision>
-    Specifies a starting revision other than the default of master.
+    Specifies a starting revision other than the default of origin/master.
 
 
 EXAMPLES:
 
   check.sh
-    Runs automated checks and formatters on all changed files since master.
-    Check for changes with git diff.
+    Runs automated checks and formatters on all changed files since
+    origin/master. Check for changes with git diff.
 
   check.sh --commit
-    Runs automated checks and formatters on all changed files since master and
-    commits the results.
+    Runs automated checks and formatters on all changed files since
+    origin/master and commits the results.
 
   check.sh --amend HEAD
     Runs automated checks and formatters on all changed files since the last
@@ -85,7 +85,7 @@ cd "${top_dir}"
 
 ALLOW_DIRTY=false
 COMMIT_METHOD="none"
-START_REVISION="master"
+START_REVISION="origin/master"
 TEST_ONLY=false
 VERBOSE=false
 
@@ -173,7 +173,7 @@ if [[ "${START_REVISION}" == *..* ]]; then
   RANGE_START="${START_REVISION/..*/}"
   RANGE_END="${START_REVISION/*../}"
 
-  # Figure out if we have access to master. If not add it to the repo.
+  # Figure out if we have access to origin/master. If not add it to the repo.
   if ! git rev-parse origin/master >& /dev/null; then
     git remote set-branches --add origin master
     git fetch origin
@@ -184,7 +184,7 @@ if [[ "${START_REVISION}" == *..* ]]; then
 
   START_SHA="${START_REVISION}"
 
-elif [[ -z "${START_REVISION}" ]]; then
+elif ! git rev-parse origin/master >& /dev/null; then
   git remote set-branches --add origin master
   git fetch origin
   START_SHA=$(git merge-base origin/master "${TRAVIS_COMMIT}")

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -76,6 +76,7 @@ EOF
 }
 
 set -euo pipefail
+set -x
 unset CDPATH
 
 # Change to the top-directory of the working tree
@@ -86,7 +87,7 @@ ALLOW_DIRTY=false
 COMMIT_METHOD="none"
 START_REVISION="origin/master"
 TEST_ONLY=false
-VERBOSE=false
+VERBOSE=true
 
 # Default to verbose operation if this isn't an interactive build.
 if [[ ! -t 1 ]]; then
@@ -175,7 +176,17 @@ if [[ "${START_REVISION}" == "origin/master" ]]; then
   fi
 fi
 
-START_SHA=$(git rev-parse "${START_REVISION}")
+if [[ "${START_REVISION}" == *..* ]]; then
+  RANGE_START="${START_REVISION/..*/}"
+  RANGE_END="${START_REVISION/*../}"
+
+  NEW_RANGE_START=$(git merge-base origin/master "${RANGE_END}")
+  START_REVISION="${START_REVISION/$RANGE_START/$NEW_RANGE_START}"
+
+  START_SHA="${START_REVISION}"
+else
+  START_SHA=$(git rev-parse "${START_REVISION}")
+fi
 
 if [[ "${VERBOSE}" == true ]]; then
   echo "START_REVISION=$START_REVISION"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -168,17 +168,17 @@ fi
 # first commit on a non-master branch, TRAVIS_COMMIT_RANGE is not set and
 # START_REVISION is "master" instead of a range.
 
-# If needed, check if we have access to master and add it to the repo.
-if [[ "${START_REVISION}" == "origin/master" ]]; then
-  if ! git rev-parse origin/master >& /dev/null; then
-    git remote set-branches --add origin master
-    git fetch origin
-  fi
-fi
-
 if [[ "${START_REVISION}" == *..* ]]; then
   RANGE_START="${START_REVISION/..*/}"
   RANGE_END="${START_REVISION/*../}"
+
+  # If needed, check if we have access to master and add it to the repo.
+  if [[ "${START_REVISION}" == "origin/master" ]]; then
+    if ! git rev-parse origin/master >& /dev/null; then
+      git remote set-branches --add origin master
+      git fetch origin
+    fi
+  fi
 
   NEW_RANGE_START=$(git merge-base origin/master "${RANGE_END}")
   START_REVISION="${START_REVISION/$RANGE_START/$NEW_RANGE_START}"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -97,9 +97,9 @@ fi
 # first commit on a non-master branch, TRAVIS_COMMIT_RANGE is not set, master
 # is not available and we need to compute the START_REVISION from the common
 # ancestor of $TRAVIS_COMMIT and origin/master.
-if [[ -n ${TRAVIS_COMMIT_RANGE:-} ]] ; then
+if [[ -n "${TRAVIS_COMMIT_RANGE:-}" ]] ; then
   START_REVISION="$TRAVIS_COMMIT_RANGE"
-elif [[ -n ${TRAVIS_COMMIT:-} ]] ; then
+elif [[ -n "${TRAVIS_COMMIT:-}" ]] ; then
   if ! git rev-parse origin/master >& /dev/null; then
     git remote set-branches --add origin master
     git fetch origin

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -173,11 +173,9 @@ if [[ "${START_REVISION}" == *..* ]]; then
   RANGE_END="${START_REVISION/*../}"
 
   # If needed, check if we have access to master and add it to the repo.
-  if [[ "${START_REVISION}" == "origin/master" ]]; then
-    if ! git rev-parse origin/master >& /dev/null; then
-      git remote set-branches --add origin master
-      git fetch origin
-    fi
+  if ! git rev-parse origin/master >& /dev/null; then
+    git remote set-branches --add origin master
+    git fetch origin
   fi
 
   NEW_RANGE_START=$(git merge-base origin/master "${RANGE_END}")

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -130,11 +130,6 @@ while [[ $# -gt 0 ]]; do
       # require a clean source tree.
       ALLOW_DIRTY=true
       TEST_ONLY=true
-      if ! [[ -z $TRAVIS_COMMIT_RANGE ]] ; then
-        START_REVISION="$TRAVIS_COMMIT_RANGE"
-      elif ! [[ -z $TRAVIS_COMMIT ]] ; then
-        START_REVISION="$TRAVIS_COMMIT"
-      fi
       ;;
 
     *)
@@ -154,6 +149,22 @@ fi
 if [[ "${ALLOW_DIRTY}" == true && "${COMMIT_METHOD}" == "message" ]]; then
   echo "--allow-dirty and --commit are mutually exclusive"
   exit 1
+fi
+
+# When travis clones a repo for building, it uses a shallow clone. After the
+# first commit on a non-master branch, TRAVIS_COMMIT_RANGE is not set, master
+# is not available and we need to compute the START_REVISION from the common
+# ancestor of $TRAVIS_COMMIT and origin/master.
+if [[ "${TEST_ONLY}" == true ]]; then
+  if ! [[ -z $TRAVIS_COMMIT_RANGE ]] ; then
+    START_REVISION="$TRAVIS_COMMIT_RANGE"
+  elif ! [[ -z $TRAVIS_COMMIT ]] ; then
+    if ! git rev-parse origin/master >& /dev/null; then
+      git remote set-branches --add origin master
+      git fetch origin
+    fi
+    START_REVISION=$(git merge-base origin/master "${TRAVIS_COMMIT}")
+  fi
 fi
 
 if ! git diff-index --quiet HEAD --; then


### PR DESCRIPTION
Travis style checking was broken in #3020. This PR does a proper fix. See tests in pb-tmp* in recent runs at https://travis-ci.org/firebase/firebase-ios-sdk/builds. 

It may be helpful to see the delta from before #3020 ` git diff bad992edb3cbb4295d216941cb2571961b2a1da0 -- scripts/check.sh`

