### PR TITLE
Fix FIAM flake

### DIFF
--- a/InAppMessaging/Example/Tests/FIRIAMClearcutUploaderTests.m
+++ b/InAppMessaging/Example/Tests/FIRIAMClearcutUploaderTests.m
@@ -115,7 +115,7 @@
   // the uploading
   NSTimeInterval currentMoment = 10000;
   OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
-  uploader.nextValidSendTimeInMills = (int64_t)(currentMoment + 5) * 1000;
+  uploader.nextValidSendTimeInMills = (int64_t)(currentMoment + 25) * 1000;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"Triggers send on sender"];
 


### PR DESCRIPTION
The 5 second nextValidSendTimeInMills can be too close to the two second delay below for a slow system like travis.  The important thing for the test seems to be that the next sendClearcutHttpRequestForLogs doesn't get called before the `dispatch_after`.