### PR TITLE
Add test_spec for FCM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --skip-tests
         # The Protobuf dependency of FirebaseMessaging has warnings with --use-libraries
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-libraries --skip-tests --allow-warnings
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessagingpodspec --use-modular-headers --skip-tests
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-modular-headers --skip-tests
 
     - stage: test
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,11 +70,9 @@ jobs:
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
+        # Run both build.sh and pod lib lint tests to get multi iOS version test coverage
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec
-        # The Protobuf dependency of FirebaseMessaging has warnings with --use-libraries
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-libraries --allow-warnings
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-modular-headers
 
     - stage: test
       env:
@@ -158,6 +156,9 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-libraries --platforms=tvos
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-modular-headers --platforms=ios
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-modular-headers --platforms=tvos
+        # The Protobuf dependency of FirebaseMessaging has warnings with --use-libraries.
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-libraries --allow-warnings
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-modular-headers
 
     - stage: test
       if: type = cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,18 +54,6 @@ jobs:
 
     - stage: test
       env:
-        - PROJECT=Storage PLATFORM=all METHOD=xcodebuild
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
-      script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
-        # The pod lib lint tests are fast enough that it's not worth a separate stage.
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseStorage.podspec --skip-tests
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseStorage.podspec --use-libraries --skip-tests
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseStorage.podspec --use-modular-headers --skip-tests
-
-    - stage: test
-      env:
         - PROJECT=Database PLATFORM=all METHOD=xcodebuild
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
@@ -75,6 +63,31 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseDatabase.podspec --skip-tests
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseDatabase.podspec --use-libraries --skip-tests
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseDatabase.podspec --use-modular-headers --skip-tests
+
+    - stage: test
+      env:
+        - PROJECT=Messaging PLATFORM=all METHOD=xcodebuild
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
+        # pod lib lint cannot run tests, since they crash in swizzling tests on iOS 8
+        # The Protobuf dependency of FirebaseMessaging has warnings with --use-libraries
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --skip-tests --allow-warnings
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-libraries --skip-tests --allow-warnings
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessagingpodspec --use-modular-headers --skip-tests --allow-warnings
+
+    - stage: test
+      env:
+        - PROJECT=Storage PLATFORM=all METHOD=xcodebuild
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
+        # The pod lib lint tests are fast enough that it's not worth a separate stage.
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseStorage.podspec --skip-tests
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseStorage.podspec --use-libraries --skip-tests
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseStorage.podspec --use-modular-headers --skip-tests
 
     - stage: test
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,10 +72,10 @@ jobs:
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
         # pod lib lint cannot run tests, since they crash in swizzling tests on iOS 8
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --skip-tests
         # The Protobuf dependency of FirebaseMessaging has warnings with --use-libraries
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --skip-tests --allow-warnings
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-libraries --skip-tests --allow-warnings
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessagingpodspec --use-modular-headers --skip-tests --allow-warnings
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessagingpodspec --use-modular-headers --skip-tests
 
     - stage: test
       env:
@@ -127,7 +127,6 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuth.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuthInterop.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseDynamicLinks.podspec
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInAppMessagingDisplay.podspec
 
@@ -154,8 +153,6 @@ jobs:
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseAuth.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseAuthInterop.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseDynamicLinks.podspec --use-libraries
-        # The Protobuf dependency of FirebaseMessaging has warnings with --use-libraries
-        - travis_retry ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-libraries --allow-warnings
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessagingDisplay.podspec --use-libraries
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-libraries --platforms=ios

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,11 +71,10 @@ jobs:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
-        # pod lib lint cannot run tests, since they crash in swizzling tests on iOS 8
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --skip-tests
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec
         # The Protobuf dependency of FirebaseMessaging has warnings with --use-libraries
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-libraries --skip-tests --allow-warnings
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-modular-headers --skip-tests
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-libraries --allow-warnings
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-modular-headers
 
     - stage: test
       env:

--- a/Example/Messaging/Tests/FIRMessagingAnalyticsTest.m
+++ b/Example/Messaging/Tests/FIRMessagingAnalyticsTest.m
@@ -147,6 +147,8 @@ withNotification:(NSDictionary *)notification
 }
 
 - (void)tearDown {
+  _eventHandler = nil;
+  _userPropertyHandler = nil;
   [self.logClassMock stopMocking];
   [super tearDown];
 }

--- a/Example/Messaging/Tests/FIRMessagingClientTest.m
+++ b/Example/Messaging/Tests/FIRMessagingClientTest.m
@@ -32,16 +32,8 @@
 
 #import <GoogleUtilities/GULReachabilityChecker.h>
 
-static NSString *const kFIRMessagingUserDefaultsSuite = @"FIRMessagingClientTestUserDefaultsSuite";
-
 static NSString *const kDeviceAuthId = @"123456";
 static NSString *const kSecretToken = @"56789";
-static NSString *const kDigest = @"com.google.digest";
-static NSString *const kVersionInfo = @"1.0";
-static NSString *const kSubscriptionID = @"abcdef-subscription-id";
-static NSString *const kDeletedSubscriptionID = @"deleted-abcdef-subscription-id";
-static NSString *const kFIRMessagingAppIDToken = @"1234xyzdef56789";
-static NSString *const kTopicToSubscribeTo = @"/topics/abcdef/hello-world";
 
 @interface FIRInstanceID (exposedForTests)
 

--- a/Example/Messaging/Tests/FIRMessagingDataMessageManagerTest.m
+++ b/Example/Messaging/Tests/FIRMessagingDataMessageManagerTest.m
@@ -33,10 +33,6 @@
 #import "FIRMessagingDefines.h"
 #import "NSError+FIRMessaging.h"
 
-static NSString *const kFIRMessagingUserDefaultsSuite = @"FIRMessagingClientTestUserDefaultsSuite";
-
-static NSString *const kFIRMessagingAppIDToken = @"1234abcdef789";
-
 static NSString *const kMessagePersistentID = @"abcdef123";
 static NSString *const kMessageFrom = @"com.example.gcm";
 static NSString *const kMessageTo = @"123456789";
@@ -268,7 +264,7 @@ static NSString *const kRmqDatabaseName = @"gcm-dmm-test";
   // should save the message to be sent when we reconnect the next time
   OCMExpect([self.mockClient sendOnConnectOrDrop:[OCMArg checkWithBlock:isValidStanza]]);
   // should also try to reconnect immediately
-  OCMExpect([self.mockClient retryConnectionImmediately:[OCMArg isEqual:@YES]]);
+  OCMExpect([self.mockClient retryConnectionImmediately:YES]);
 
   [self.dataMessageManager setDeviceAuthID:@"auth-id" secretToken:@"secret-token"];
   [self.dataMessageManager sendDataMessageStanza:message];
@@ -380,7 +376,8 @@ static NSString *const kRmqDatabaseName = @"gcm-dmm-test";
 - (void)testSendDelayedMessage_shouldNotSend {
   // should not send a delayed message even with an active connection
   // simulate active connection
-  [[[self.mockClient stub] andReturnValue:OCMOCK_VALUE(YES)] isConnectionActive];
+  [[[self.mockClient stub] andReturnValue:[NSNumber numberWithBool:YES]]
+    isConnectionActive];
   [[self.mockClient reject] sendMessage:[OCMArg any]];
 
   [[self.mockReceiver reject] didSendDataMessageWithID:[OCMArg any]];

--- a/Example/Messaging/Tests/FIRMessagingExtensionHelperTest.m
+++ b/Example/Messaging/Tests/FIRMessagingExtensionHelperTest.m
@@ -59,6 +59,7 @@ static NSString *const kValidImageURL =
   [_mockExtensionHelper stopMocking];
 }
 
+#if TARGET_OS_IOS
 #ifdef COCOAPODS
 // This test requires internet access.
 - (void)testModifyNotificationWithValidPayloadData {
@@ -112,5 +113,6 @@ static NSString *const kValidImageURL =
     [self waitForExpectationsWithTimeout:1.0 handler:nil];
   }
 }
+#endif // TARGET_OS_IOS
 
 @end

--- a/Example/Messaging/Tests/FIRMessagingExtensionHelperTest.m
+++ b/Example/Messaging/Tests/FIRMessagingExtensionHelperTest.m
@@ -22,6 +22,7 @@
 #import "FIRMessaging.h"
 #import "FIRMessagingExtensionHelper.h"
 
+API_AVAILABLE(ios(10.0))
 typedef void (^FIRMessagingContentHandler)(UNNotificationContent *content);
 
 static NSString *const kFCMPayloadOptionsName = @"fcm_options";
@@ -46,67 +47,70 @@ static NSString *const kValidImageURL =
 
 - (void)setUp {
   [super setUp];
-  FIRMessagingExtensionHelper *extensionHelper = [FIRMessaging extensionHelper];
-  _mockExtensionHelper = OCMPartialMock(extensionHelper);
+  if (@available(iOS 10.0, *)) {
+    FIRMessagingExtensionHelper *extensionHelper = [FIRMessaging extensionHelper];
+    _mockExtensionHelper = OCMPartialMock(extensionHelper);
+  } else {
+    // Fallback on earlier versions
+  }
 }
 
 - (void)tearDown {
   [_mockExtensionHelper stopMocking];
 }
 
-#if TARGET_OS_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 #ifdef COCOAPODS
 // This test requires internet access.
 - (void)testModifyNotificationWithValidPayloadData {
-  XCTestExpectation *validPayloadExpectation =
-      [self expectationWithDescription:@"Test payload is valid."];
-
-  UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
-  content.userInfo = @{kFCMPayloadOptionsName : @{kFCMPayloadOptionsImageURLName : kValidImageURL}};
-  FIRMessagingContentHandler handler = ^(UNNotificationContent *content) {
-    [validPayloadExpectation fulfill];
-  };
-  [_mockExtensionHelper populateNotificationContent:content withContentHandler:handler];
-
-  OCMVerify([_mockExtensionHelper loadAttachmentForURL:[OCMArg any]
-                                     completionHandler:[OCMArg any]]);
-  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  if (@available(iOS 10.0, *)) {
+    XCTestExpectation *validPayloadExpectation =
+    [self expectationWithDescription:@"Test payload is valid."];
+    UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+    content.userInfo = @{kFCMPayloadOptionsName : @{kFCMPayloadOptionsImageURLName : kValidImageURL}};
+    FIRMessagingContentHandler handler = ^(UNNotificationContent *content) {
+      [validPayloadExpectation fulfill];
+    };
+    [_mockExtensionHelper populateNotificationContent:content withContentHandler:handler];
+    OCMVerify([_mockExtensionHelper loadAttachmentForURL:[OCMArg any]
+                                       completionHandler:[OCMArg any]]);
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  }
 }
 #endif
 
 - (void)testModifyNotificationWithInvalidPayloadData {
-  XCTestExpectation *validPayloadExpectation =
-      [self expectationWithDescription:@"Test payload is valid."];
+  if (@available(iOS 10.0, *)) {
+    XCTestExpectation *validPayloadExpectation =
+    [self expectationWithDescription:@"Test payload is valid."];
+    UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+    content.userInfo =
+        @{kFCMPayloadOptionsName : @{kFCMPayloadOptionsImageURLName : @"a invalid URL"}};
+    FIRMessagingContentHandler handler = ^(UNNotificationContent *content) {
+      [validPayloadExpectation fulfill];
+    };
+    [_mockExtensionHelper populateNotificationContent:content withContentHandler:handler];
 
-  UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
-  content.userInfo =
-      @{kFCMPayloadOptionsName : @{kFCMPayloadOptionsImageURLName : @"a invalid URL"}};
-  FIRMessagingContentHandler handler = ^(UNNotificationContent *content) {
-    [validPayloadExpectation fulfill];
-  };
-  [_mockExtensionHelper populateNotificationContent:content withContentHandler:handler];
-
-  OCMReject([_mockExtensionHelper loadAttachmentForURL:[OCMArg any]
-                                     completionHandler:[OCMArg any]]);
-  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+    OCMReject([_mockExtensionHelper loadAttachmentForURL:[OCMArg any]
+                                       completionHandler:[OCMArg any]]);
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  }
 }
 
 - (void)testModifyNotificationWithEmptyPayloadData {
-  XCTestExpectation *validPayloadExpectation =
-      [self expectationWithDescription:@"Test payload is valid."];
-
-  UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
-  content.userInfo =
-      @{kFCMPayloadOptionsName : @{kFCMPayloadOptionsImageURLName : @"a invalid URL"}};
-  FIRMessagingContentHandler handler = ^(UNNotificationContent *content) {
-    [validPayloadExpectation fulfill];
-  };
-  [_mockExtensionHelper populateNotificationContent:content withContentHandler:handler];
-
-  OCMReject([_mockExtensionHelper loadAttachmentForURL:[OCMArg any]
-                                     completionHandler:[OCMArg any]]);
-  [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  if (@available(iOS 10.0, *)) {
+    XCTestExpectation *validPayloadExpectation =
+    [self expectationWithDescription:@"Test payload is valid."];
+    UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+    content.userInfo =
+    @{kFCMPayloadOptionsName : @{kFCMPayloadOptionsImageURLName : @"a invalid URL"}};
+    FIRMessagingContentHandler handler = ^(UNNotificationContent *content) {
+      [validPayloadExpectation fulfill];
+    };
+    [_mockExtensionHelper populateNotificationContent:content withContentHandler:handler];
+    OCMReject([_mockExtensionHelper loadAttachmentForURL:[OCMArg any]
+                                       completionHandler:[OCMArg any]]);
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+  }
 }
-#endif
 
 @end

--- a/Example/Messaging/Tests/FIRMessagingExtensionHelperTest.m
+++ b/Example/Messaging/Tests/FIRMessagingExtensionHelperTest.m
@@ -25,11 +25,13 @@
 API_AVAILABLE(ios(10.0))
 typedef void (^FIRMessagingContentHandler)(UNNotificationContent *content);
 
+#if TARGET_OS_IOS
 static NSString *const kFCMPayloadOptionsName = @"fcm_options";
 static NSString *const kFCMPayloadOptionsImageURLName = @"image";
 static NSString *const kValidImageURL =
     @"https://firebasestorage.googleapis.com/v0/b/fcm-ios-f7f9c.appspot.com/o/"
     @"chubbyBunny.jpg?alt=media&token=d6c56a57-c007-4b27-b20f-f267cc83e9e5";
+#endif
 
 @interface FIRMessagingExtensionHelper (ExposedForTest)
 #if TARGET_OS_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0

--- a/Example/Messaging/Tests/FIRMessagingPendingTopicsListTest.m
+++ b/Example/Messaging/Tests/FIRMessagingPendingTopicsListTest.m
@@ -35,7 +35,7 @@ typedef void (^MockDelegateSubscriptionHandler)(NSString *topic,
 
 @property(nonatomic, assign) BOOL isReady;
 @property(nonatomic, copy) MockDelegateSubscriptionHandler subscriptionHandler;
-@property(nonatomic, copy) void(^updateHandler)();
+@property(nonatomic, copy) void(^updateHandler)(void);
 
 @end
 
@@ -121,7 +121,7 @@ typedef void (^MockDelegateSubscriptionHandler)(NSString *topic,
   pendingTopics.delegate = self.notReadyDelegate;
 
   for (NSInteger i = 0; i < 10; i++) {
-    NSString *topic = [NSString stringWithFormat:@"/topics/%ld", i];
+    NSString *topic = [NSString stringWithFormat:@"/topics/%ld", (long)i];
     [pendingTopics addOperationForTopic:topic
                              withAction:FIRMessagingTopicActionSubscribe
                              completion:nil];

--- a/Example/Messaging/Tests/FIRMessagingRemoteNotificationsProxyTest.m
+++ b/Example/Messaging/Tests/FIRMessagingRemoteNotificationsProxyTest.m
@@ -405,10 +405,9 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
     id mockNotification = [self userNotificationWithMessage:message];
     OCMStub([mockNotificationResponse notification]).andReturn(mockNotification);
     return mockNotificationResponse;
-#else // TARGET_OS_IOS
-    return nil;
 #endif // TARGET_OS_IOS
   }
+  return nil;
 }
 
 - (UNNotification *)userNotificationWithMessage:(NSDictionary *)message  API_AVAILABLE(ios(10.0)){

--- a/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
+++ b/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
@@ -110,7 +110,7 @@ static NSString *const kRmqDataMessageCategory = @"com.google.gcm-rmq-test";
   GtalkDataMessageStanza *message1 = [self dataMessageWithMessageID:@"message1"
                                                                from:from
                                                                data:nil];
-  NSError *error;
+  NSError *error = nil;
 
   // should successfully save the message to RMQ
   XCTAssertTrue([self.rmqManager saveRmqMessage:message1 error:&error]);
@@ -159,7 +159,7 @@ static NSString *const kRmqDataMessageCategory = @"com.google.gcm-rmq-test";
   [message setTo:to];
   [message setTtl:ttl];
   [message setRegId:registrationToken];
-  NSError *error;
+  NSError *error = nil;
 
   // should successfully save the message to RMQ
   XCTAssertTrue([self.rmqManager saveRmqMessage:message error:&error]);
@@ -191,7 +191,7 @@ static NSString *const kRmqDataMessageCategory = @"com.google.gcm-rmq-test";
   GtalkDataMessageStanza *stanza2 = [self dataMessageWithMessageID:ackedMessage
                                                               from:from
                                                               data:nil];
-  NSError *error;
+  NSError *error = nil;
   XCTAssertTrue([self.rmqManager saveRmqMessage:stanza1 error:&error]);
   XCTAssertNil(error);
   XCTAssertTrue([self.rmqManager saveRmqMessage:stanza2 error:&error]);

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -47,4 +47,14 @@ device, and it is completely free.
   s.dependency 'GoogleUtilities/Environment', '~> 6.0'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 6.0'
   s.dependency 'Protobuf', '~> 3.1'
+
+  s.test_spec 'unit' do |unit_tests|
+    unit_tests.source_files = 'Example/Messaging/Tests/*.[mh]'
+    unit_tests.requires_app_host = true
+    unit_tests.pod_target_xcconfig = {
+      # Unit tests do library imports using Firebase/Messaging relative paths.
+      'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"/Firebase/Messaging'
+    }
+    unit_tests.dependency 'OCMock'
+  end
 end

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -407,6 +407,23 @@ case "$product-$method-$platform" in
       fi
     ;;
 
+  Messaging-xcodebuild-*)
+    RunXcodebuild \
+      -workspace 'gen/FirebaseMessaging/FirebaseMessaging.xcworkspace' \
+      -scheme "FirebaseMessaging-iOS-Unit-unit" \
+      "${ios_flags[@]}" \
+      "${xcb_flags[@]}" \
+      build \
+      test
+    RunXcodebuild \
+      -workspace 'gen/FirebaseMessaging/FirebaseMessaging.xcworkspace' \
+      -scheme "FirebaseMessaging-tvOS-Unit-unit" \
+      "${tvos_flags[@]}" \
+      "${xcb_flags[@]}" \
+      build \
+      test
+    ;;
+
   Storage-xcodebuild-*)
     RunXcodebuild \
       -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \

--- a/scripts/if_changed.sh
+++ b/scripts/if_changed.sh
@@ -109,6 +109,10 @@ else
       check_changes '^(GoogleDataTransportCCTSupport|GoogleDataTransportCCTSupport.podspec|GoogleDataTransport|GoogleDataTransport.podspec)'
       ;;
 
+    Messaging-*)
+      check_changes '^(Firebase/Core|Firebase/Messaging|Example/Messaging|GoogleUtilities|FirebaseMessaging.podspec|Firebase/InstanceID)'
+      ;;
+
     Storage-*)
       check_changes '^(Firebase/Core|Firebase/Storage|Example/Storage|GoogleUtilities|FirebaseStorage.podspec)'
       ;;

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -61,18 +61,25 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     bundle exec pod install --project-directory=GoogleUtilities/Example
     ;;
 
-  Functions-*)
-    # Start server for Functions integration tests.
-    bundle exec pod repo update
-    ./Functions/Backend/start.sh synchronous
-    ;;
-
   Database-*)
     # Install the workspace to have better control over test runs than
     # pod lib lint, since the integration tests can be flaky.
     bundle exec pod repo update
     bundle exec pod gen FirebaseDatabase.podspec --local-sources=./
     install_secrets
+    ;;
+
+  Functions-*)
+    # Start server for Functions integration tests.
+    bundle exec pod repo update
+    ./Functions/Backend/start.sh synchronous
+    ;;
+
+  Messaging-*)
+    # Install the workspace to have better control over test runs than
+    # pod lib lint, since the integration tests can be flaky.
+    bundle exec pod repo update
+    bundle exec pod gen FirebaseMessaging.podspec --local-sources=./
     ;;
 
   Storage-*)


### PR DESCRIPTION
- Add unit test spec for Messaging.
- Add a complete Messaging build and test rule.
- Testing is done via the `pod gen` generated workspace.
- Merge iOS 8 test fixes from @maksymmalyhin's #3094
- Fix build warnings in test source.
- The old build environment is still supported.
- It will be removed when all pods have transitioned to test_specs and pod gen.
- For now, see the instructions at https://github.com/firebase/firebase-ios-sdk/blob/master/Functions/README.md.
- Use `--local-sources=./` with `pod gen` to include local InstanceID in workspace: 
- ` pod gen FirebaseMessaging.podspec --local-sources=./ --auto-open`
