### PR TITLE
Fix FIAM test flakes and exposed library bugs

### DIFF
--- a/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.h
+++ b/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.h
@@ -35,6 +35,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FIRIAMClearcutLogStorage : NSObject
 - (instancetype)initWithExpireAfterInSeconds:(NSInteger)expireInSeconds
+                             withTimeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher
+                               withCacheFile:(NSString *)cacheFile;
+
+- (instancetype)initWithExpireAfterInSeconds:(NSInteger)expireInSeconds
                              withTimeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher;
 
 // add new records into the storage

--- a/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.h
+++ b/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FIRIAMClearcutLogStorage : NSObject
 - (instancetype)initWithExpireAfterInSeconds:(NSInteger)expireInSeconds
                              withTimeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher
-                                   cachePath:(NSString *)cachePath;
+                                   cachePath:(nullable NSString *)cachePath;
 
 - (instancetype)initWithExpireAfterInSeconds:(NSInteger)expireInSeconds
                              withTimeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher;

--- a/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.h
+++ b/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FIRIAMClearcutLogStorage : NSObject
 - (instancetype)initWithExpireAfterInSeconds:(NSInteger)expireInSeconds
                              withTimeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher
-                               withCacheFile:(NSString *)cacheFile;
+                                   cachePath:(NSString *)cachePath;
 
 - (instancetype)initWithExpireAfterInSeconds:(NSInteger)expireInSeconds
                              withTimeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher;

--- a/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.m
+++ b/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.m
@@ -83,7 +83,7 @@ static NSString *const kEventExtensionJson = @"extension_js";
 
 - (instancetype)initWithExpireAfterInSeconds:(NSInteger)expireInSeconds
                              withTimeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher
-                                   cachePath:(NSString *)cachePath {
+                                   cachePath:(nullable NSString *)cachePath {
   if (self = [super init]) {
     _records = [[NSMutableArray alloc] init];
     _timeFetcher = timeFetcher;

--- a/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.m
+++ b/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.m
@@ -82,8 +82,8 @@ static NSString *const kEventExtensionJson = @"extension_js";
 }
 
 - (instancetype)initWithExpireAfterInSeconds:(NSInteger)expireInSeconds
-                              withTimeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher
-                                 withCacheFile:(NSString *)cacheFile {
+                             withTimeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher
+                               withCacheFile:(NSString *)cacheFile {
   if (self = [super init]) {
     _records = [[NSMutableArray alloc] init];
     _timeFetcher = timeFetcher;
@@ -109,7 +109,6 @@ static NSString *const kEventExtensionJson = @"extension_js";
                             withTimeFetcher:timeFetcher
                               withCacheFile:nil];
 }
-
 
 - (void)appWillBecomeInactive {
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul), ^{

--- a/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.m
+++ b/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.m
@@ -82,7 +82,8 @@ static NSString *const kEventExtensionJson = @"extension_js";
 }
 
 - (instancetype)initWithExpireAfterInSeconds:(NSInteger)expireInSeconds
-                             withTimeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher {
+                              withTimeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher
+                                 withCacheFile:(NSString *)cacheFile {
   if (self = [super init]) {
     _records = [[NSMutableArray alloc] init];
     _timeFetcher = timeFetcher;
@@ -92,7 +93,7 @@ static NSString *const kEventExtensionJson = @"extension_js";
                                                  name:UIApplicationWillResignActiveNotification
                                                object:nil];
     @try {
-      [self loadFromCachePath:nil];
+      [self loadFromCachePath:cacheFile];
     } @catch (NSException *exception) {
       FIRLogWarning(kFIRLoggerInAppMessaging, @"I-IAM230004",
                     @"Non-fatal exception in loading persisted clearcut log records: %@.",
@@ -101,6 +102,14 @@ static NSString *const kEventExtensionJson = @"extension_js";
   }
   return self;
 }
+
+- (instancetype)initWithExpireAfterInSeconds:(NSInteger)expireInSeconds
+                             withTimeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher {
+  return [self initWithExpireAfterInSeconds:expireInSeconds
+                            withTimeFetcher:timeFetcher
+                              withCacheFile:nil];
+}
+
 
 - (void)appWillBecomeInactive {
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul), ^{

--- a/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.m
+++ b/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.m
@@ -83,7 +83,7 @@ static NSString *const kEventExtensionJson = @"extension_js";
 
 - (instancetype)initWithExpireAfterInSeconds:(NSInteger)expireInSeconds
                              withTimeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher
-                               withCacheFile:(NSString *)cacheFile {
+                                   cachePath:(NSString *)cachePath {
   if (self = [super init]) {
     _records = [[NSMutableArray alloc] init];
     _timeFetcher = timeFetcher;
@@ -93,7 +93,7 @@ static NSString *const kEventExtensionJson = @"extension_js";
                                                  name:UIApplicationWillResignActiveNotification
                                                object:nil];
     @try {
-      [self loadFromCachePath:cacheFile];
+      [self loadFromCachePath:cachePath];
     } @catch (NSException *exception) {
       FIRLogWarning(kFIRLoggerInAppMessaging, @"I-IAM230004",
                     @"Non-fatal exception in loading persisted clearcut log records: %@.",
@@ -107,7 +107,7 @@ static NSString *const kEventExtensionJson = @"extension_js";
                              withTimeFetcher:(id<FIRIAMTimeFetcher>)timeFetcher {
   return [self initWithExpireAfterInSeconds:expireInSeconds
                             withTimeFetcher:timeFetcher
-                              withCacheFile:nil];
+                                  cachePath:nil];
 }
 
 - (void)appWillBecomeInactive {

--- a/Firebase/InAppMessaging/Analytics/FIRIAMClearcutUploader.m
+++ b/Firebase/InAppMessaging/Analytics/FIRIAMClearcutUploader.m
@@ -104,7 +104,7 @@ static NSString *FIRIAM_UserDefaultsKeyForNextValidClearcutUploadTimeInMills =
     // you can send now
     _nextValidSendTimeInMills = (int64_t)
         [_userDefaults doubleForKey:FIRIAM_UserDefaultsKeyForNextValidClearcutUploadTimeInMills];
-    
+
     NSArray<FIRIAMClearcutLogRecord *> *availableLogs =
         [logStorage popStillValidRecordsForUpTo:strategy.batchSendSize];
     if (availableLogs.count) {
@@ -213,7 +213,7 @@ static NSString *FIRIAM_UserDefaultsKeyForNextValidClearcutUploadTimeInMills =
       return;
     }
   }
-  
+
   int64_t delayTimeInMills =
       self.nextValidSendTimeInMills - (int64_t)[self.timeFetcher currentTimestampInSeconds] * 1000;
 

--- a/InAppMessaging/Example/Tests/FIRIAMClearcutUploaderTests.m
+++ b/InAppMessaging/Example/Tests/FIRIAMClearcutUploaderTests.m
@@ -26,18 +26,33 @@
 @property(nonatomic) id<FIRIAMTimeFetcher> mockTimeFetcher;
 @property(nonatomic) FIRIAMClearcutHttpRequestSender *mockRequestSender;
 @property(nonatomic) FIRIAMClearcutLogStorage *mockLogStorage;
-
 @property(nonatomic) FIRIAMClearcutStrategy *defaultStrategy;
-
 @property(nonatomic) NSUserDefaults *mockUserDefaults;
+@property(nonatomic) NSString *cachePath;
 @end
 
-// expose certain internal things to help with unit testing
+// Expose certain internal things to help with unit testing.
 @interface FIRIAMClearcutUploader (UnitTest)
 @property(nonatomic, assign) int64_t nextValidSendTimeInMills;
 @end
 
 @implementation FIRIAMClearcutUploaderTests
+
+// Helper function to avoid conflicts between tests with the singleton cache path.
+- (NSString *)generatedCachePath {
+  // Filter out any invalid filesystem characters.
+  NSCharacterSet *invalidCharacters = [[NSCharacterSet alphanumericCharacterSet] invertedSet];
+
+  // This will result in a string with the class name, a space, and the test name. We only care
+  // about the test name so split it into components and return the last item.
+  NSString *friendlyTestName = [self.name stringByTrimmingCharactersInSet:invalidCharacters];
+  NSArray<NSString *> *components = [friendlyTestName componentsSeparatedByString:@" "];
+  NSString *testName = [components lastObject];
+
+  NSString *cacheDirPath =
+      NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES)[0];
+  return [NSString stringWithFormat:@"%@/%@", cacheDirPath, testName];
+}
 
 - (void)setUp {
   [super setUp];
@@ -51,12 +66,12 @@
                                                                       batchSendSize:10];
 
   self.mockUserDefaults = OCMClassMock(NSUserDefaults.class);
+  self.cachePath = [self generatedCachePath];
   OCMStub([self.mockUserDefaults integerForKey:[OCMArg any]]).andReturn(0);
 }
 
 - (void)tearDown {
-  // Put teardown code here. This method is called after the invocation of each test method in the
-  // class.
+  [[NSFileManager defaultManager] removeItemAtPath:self.cachePath error:NULL];
   [super tearDown];
 }
 
@@ -64,7 +79,11 @@
   // using a real storage in this case
   FIRIAMClearcutLogStorage *logStorage =
       [[FIRIAMClearcutLogStorage alloc] initWithExpireAfterInSeconds:1000
-                                                     withTimeFetcher:self.mockTimeFetcher];
+                                                     withTimeFetcher:self.mockTimeFetcher
+                                                       withCacheFile:self.cachePath];
+
+  NSTimeInterval currentMoment = 10000;
+  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
 
   FIRIAMClearcutUploader *uploader =
       [[FIRIAMClearcutUploader alloc] initWithRequestSender:self.mockRequestSender
@@ -73,10 +92,7 @@
                                               usingStrategy:self.defaultStrategy
                                           usingUserDefaults:self.mockUserDefaults];
 
-  // so the following setup is to say that it's now ok to do upload right away
-  // nextValidSendTimeInMills < currnt time
-  NSTimeInterval currentMoment = 10000;
-  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
+  // Upload right away: nextValidSendTimeInMills < current time
   uploader.nextValidSendTimeInMills = (int64_t)(currentMoment - 1) * 1000;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"Triggers send on sender"];
@@ -93,16 +109,20 @@
 
   [uploader addNewLogRecord:newRecord];
 
-  // we expect expectation to be fulfilled right away since the upload can be carried out without
-  // delay
+  // We expect expectation to be fulfilled right away since the upload can be carried out without
+  // delay.
   [self waitForExpectationsWithTimeout:1.0 handler:nil];
 }
 
 - (void)testUploadNotTriggeredWhenWaitTimeConditionNotSatisfied {
   // using a real storage in this case
+  NSTimeInterval currentMoment = 10000;
+  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
+
   FIRIAMClearcutLogStorage *logStorage =
       [[FIRIAMClearcutLogStorage alloc] initWithExpireAfterInSeconds:1000
-                                                     withTimeFetcher:self.mockTimeFetcher];
+                                                     withTimeFetcher:self.mockTimeFetcher
+                                                       withCacheFile:self.cachePath];
 
   FIRIAMClearcutUploader *uploader =
       [[FIRIAMClearcutUploader alloc] initWithRequestSender:self.mockRequestSender
@@ -111,10 +131,7 @@
                                               usingStrategy:self.defaultStrategy
                                           usingUserDefaults:self.mockUserDefaults];
 
-  // so the following setup is to say that we need at least 5 seconds from now to attempt the
-  // the uploading
-  NSTimeInterval currentMoment = 10000;
-  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
+  // Forces uploading to be at least 5 seconds later.
   uploader.nextValidSendTimeInMills = (int64_t)(currentMoment + 5) * 1000;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"Triggers send on sender"];
@@ -124,9 +141,9 @@
                                            eventTimestampInSeconds:currentMoment];
 
   __block BOOL sendingAttempted = NO;
-  // we don't expect sendClearcutHttpRequestForLogs:withCompletion: to be triggered
+  // We don't expect sendClearcutHttpRequestForLogs:withCompletion: to be triggered
   // after wait for 2.0 seconds below. We have a BOOL flag to be used for that kind verification
-  // checking
+  // checking.
   OCMStub([self.mockRequestSender sendClearcutHttpRequestForLogs:[OCMArg any]
                                                   withCompletion:[OCMArg any]])
       .andDo(^(NSInvocation *invocation) {
@@ -134,9 +151,9 @@
       });
   [uploader addNewLogRecord:newRecord];
 
-  // we wait for 2 seconds and we expect nothing should happen to self.mockRequestSender right after
+  // We wait for 2 seconds and we expect nothing should happen to self.mockRequestSender right after
   // 2 seconds: the upload will eventually be attempted in after 10 seconds based on the setup
-  // in this unit test
+  // in this unit test.
   double delayInSeconds = 2.0;
   dispatch_time_t popTime =
       dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
@@ -144,8 +161,8 @@
     [expectation fulfill];
   });
 
-  // we expect expectation to be fulfilled right away since the upload can be carried out without
-  // delay
+  // We expect expectation to be fulfilled right away since the upload can be carried out without
+  // delay.
   [self waitForExpectationsWithTimeout:10.0 handler:nil];
   XCTAssertFalse(sendingAttempted);
 }
@@ -160,6 +177,10 @@
                                        failureBackoffTimeInMills:1000
                                                    batchSendSize:batchSendSize];
 
+  // Next upload is now.
+  NSTimeInterval currentMoment = 10000;
+  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
+
   FIRIAMClearcutUploader *uploader =
       [[FIRIAMClearcutUploader alloc] initWithRequestSender:self.mockRequestSender
                                                 timeFetcher:self.mockTimeFetcher
@@ -167,9 +188,6 @@
                                               usingStrategy:strategy
                                           usingUserDefaults:self.mockUserDefaults];
 
-  // so the following setup is to say that next upload is going to be now
-  NSTimeInterval currentMoment = 10000;
-  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
   uploader.nextValidSendTimeInMills = (int64_t)currentMoment * 1000;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"Triggers send on sender"];
@@ -199,7 +217,12 @@
   // using a real storage in this case
   FIRIAMClearcutLogStorage *logStorage =
       [[FIRIAMClearcutLogStorage alloc] initWithExpireAfterInSeconds:1000
-                                                     withTimeFetcher:self.mockTimeFetcher];
+                                                     withTimeFetcher:self.mockTimeFetcher
+                                                       withCacheFile:self.cachePath];
+
+  // The next upload is now.
+  NSTimeInterval currentMoment = 10000;
+  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
 
   FIRIAMClearcutUploader *uploader =
       [[FIRIAMClearcutUploader alloc] initWithRequestSender:self.mockRequestSender
@@ -208,9 +231,6 @@
                                               usingStrategy:self.defaultStrategy
                                           usingUserDefaults:self.mockUserDefaults];
 
-  // so the following setup is to say that next upload is going to be now
-  NSTimeInterval currentMoment = 10000;
-  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
   uploader.nextValidSendTimeInMills = (int64_t)currentMoment * 1000;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"Triggers send on sender"];
@@ -242,7 +262,12 @@
   // using a real storage in this case
   FIRIAMClearcutLogStorage *logStorage =
       [[FIRIAMClearcutLogStorage alloc] initWithExpireAfterInSeconds:1000
-                                                     withTimeFetcher:self.mockTimeFetcher];
+                                                     withTimeFetcher:self.mockTimeFetcher
+                                                       withCacheFile:self.cachePath];
+
+  // The next upload is now.
+  NSTimeInterval currentMoment = 10000;
+  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
 
   FIRIAMClearcutUploader *uploader =
       [[FIRIAMClearcutUploader alloc] initWithRequestSender:self.mockRequestSender
@@ -251,9 +276,6 @@
                                               usingStrategy:self.defaultStrategy
                                           usingUserDefaults:self.mockUserDefaults];
 
-  // so the following setup is to say that next upload is going to be now
-  NSTimeInterval currentMoment = 10000;
-  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
   uploader.nextValidSendTimeInMills = (int64_t)currentMoment * 1000;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"Triggers send on sender"];
@@ -286,7 +308,12 @@
   // using a real storage in this case
   FIRIAMClearcutLogStorage *logStorage =
       [[FIRIAMClearcutLogStorage alloc] initWithExpireAfterInSeconds:1000
-                                                     withTimeFetcher:self.mockTimeFetcher];
+                                                     withTimeFetcher:self.mockTimeFetcher
+                                                       withCacheFile:self.cachePath];
+
+  // The next upload is now.
+  NSTimeInterval currentMoment = 10000;
+  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
 
   FIRIAMClearcutUploader *uploader =
       [[FIRIAMClearcutUploader alloc] initWithRequestSender:self.mockRequestSender
@@ -295,9 +322,6 @@
                                               usingStrategy:self.defaultStrategy
                                           usingUserDefaults:self.mockUserDefaults];
 
-  // so the following setup is to say that next upload is going to be now
-  NSTimeInterval currentMoment = 10000;
-  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
   uploader.nextValidSendTimeInMills = (int64_t)currentMoment * 1000;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"Triggers send on sender"];
@@ -330,7 +354,12 @@
   // using a real storage in this case
   FIRIAMClearcutLogStorage *logStorage =
       [[FIRIAMClearcutLogStorage alloc] initWithExpireAfterInSeconds:1000
-                                                     withTimeFetcher:self.mockTimeFetcher];
+                                                     withTimeFetcher:self.mockTimeFetcher
+                                                       withCacheFile:self.cachePath];
+
+  // The next upload is now.
+  NSTimeInterval currentMoment = 10000;
+  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
 
   FIRIAMClearcutUploader *uploader =
       [[FIRIAMClearcutUploader alloc] initWithRequestSender:self.mockRequestSender
@@ -339,9 +368,6 @@
                                               usingStrategy:self.defaultStrategy
                                           usingUserDefaults:self.mockUserDefaults];
 
-  // so the following setup is to say that next upload is going to be now
-  NSTimeInterval currentMoment = 10000;
-  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
   uploader.nextValidSendTimeInMills = (int64_t)currentMoment * 1000;
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"Triggers send on sender"];

--- a/InAppMessaging/Example/Tests/FIRIAMClearcutUploaderTests.m
+++ b/InAppMessaging/Example/Tests/FIRIAMClearcutUploaderTests.m
@@ -76,14 +76,14 @@
 }
 
 - (void)testUploadTriggeredWhenWaitTimeConditionSatisfied {
+  NSTimeInterval currentMoment = 10000;
+  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
+
   // using a real storage in this case
   FIRIAMClearcutLogStorage *logStorage =
       [[FIRIAMClearcutLogStorage alloc] initWithExpireAfterInSeconds:1000
                                                      withTimeFetcher:self.mockTimeFetcher
-                                                       withCacheFile:self.cachePath];
-
-  NSTimeInterval currentMoment = 10000;
-  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
+                                                           cachePath:self.cachePath];
 
   FIRIAMClearcutUploader *uploader =
       [[FIRIAMClearcutUploader alloc] initWithRequestSender:self.mockRequestSender
@@ -122,7 +122,7 @@
   FIRIAMClearcutLogStorage *logStorage =
       [[FIRIAMClearcutLogStorage alloc] initWithExpireAfterInSeconds:1000
                                                      withTimeFetcher:self.mockTimeFetcher
-                                                       withCacheFile:self.cachePath];
+                                                           cachePath:self.cachePath];
 
   FIRIAMClearcutUploader *uploader =
       [[FIRIAMClearcutUploader alloc] initWithRequestSender:self.mockRequestSender
@@ -214,15 +214,15 @@
 }
 
 - (void)testRespectingWaitTimeFromRequestSender {
+  // The next upload is now.
+  NSTimeInterval currentMoment = 10000;
+  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
+
   // using a real storage in this case
   FIRIAMClearcutLogStorage *logStorage =
       [[FIRIAMClearcutLogStorage alloc] initWithExpireAfterInSeconds:1000
                                                      withTimeFetcher:self.mockTimeFetcher
-                                                       withCacheFile:self.cachePath];
-
-  // The next upload is now.
-  NSTimeInterval currentMoment = 10000;
-  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
+                                                           cachePath:self.cachePath];
 
   FIRIAMClearcutUploader *uploader =
       [[FIRIAMClearcutUploader alloc] initWithRequestSender:self.mockRequestSender
@@ -259,15 +259,15 @@
 }
 
 - (void)disable_testWaitTimeFromRequestSenderAdjustedByMinWaitTimeInStrategy {
+  // The next upload is now.
+  NSTimeInterval currentMoment = 10000;
+  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
+
   // using a real storage in this case
   FIRIAMClearcutLogStorage *logStorage =
       [[FIRIAMClearcutLogStorage alloc] initWithExpireAfterInSeconds:1000
                                                      withTimeFetcher:self.mockTimeFetcher
-                                                       withCacheFile:self.cachePath];
-
-  // The next upload is now.
-  NSTimeInterval currentMoment = 10000;
-  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
+                                                           cachePath:self.cachePath];
 
   FIRIAMClearcutUploader *uploader =
       [[FIRIAMClearcutUploader alloc] initWithRequestSender:self.mockRequestSender
@@ -305,15 +305,15 @@
 }
 
 - (void)testWaitTimeFromRequestSenderAdjustedByMaxWaitTimeInStrategy {
+  // The next upload is now.
+  NSTimeInterval currentMoment = 10000;
+  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
+
   // using a real storage in this case
   FIRIAMClearcutLogStorage *logStorage =
       [[FIRIAMClearcutLogStorage alloc] initWithExpireAfterInSeconds:1000
                                                      withTimeFetcher:self.mockTimeFetcher
-                                                       withCacheFile:self.cachePath];
-
-  // The next upload is now.
-  NSTimeInterval currentMoment = 10000;
-  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
+                                                           cachePath:self.cachePath];
 
   FIRIAMClearcutUploader *uploader =
       [[FIRIAMClearcutUploader alloc] initWithRequestSender:self.mockRequestSender
@@ -351,15 +351,15 @@
 }
 
 - (void)testRepushLogsIfRequestSenderSaysSo {
+  // The next upload is now.
+  NSTimeInterval currentMoment = 10000;
+  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
+
   // using a real storage in this case
   FIRIAMClearcutLogStorage *logStorage =
       [[FIRIAMClearcutLogStorage alloc] initWithExpireAfterInSeconds:1000
                                                      withTimeFetcher:self.mockTimeFetcher
-                                                       withCacheFile:self.cachePath];
-
-  // The next upload is now.
-  NSTimeInterval currentMoment = 10000;
-  OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(currentMoment);
+                                                           cachePath:self.cachePath];
 
   FIRIAMClearcutUploader *uploader =
       [[FIRIAMClearcutUploader alloc] initWithRequestSender:self.mockRequestSender


### PR DESCRIPTION
Fix #3046.

- Add a test specific cache file for logStorage so that tests don't fail because of stuff in the cache from other tests. Thanks to @ryanwilson for the suggestion and helper file implementation!
- Set up the `self.mockTimeFetcher currentTimestampInSeconds` stub before the mock is passed to other functions.
- Stop calling `scheduleNextSend` in the initializer since the first zero-delayed log can happen logs to happen to soon.
- Remove early exit from `scheduleNextSend` since it can cause logs to get dropped if the first zero-length log is scheduled, the next real log gets scheduled, but the log has already been dropped because of no packets available.
- Multiple spelling and wording fixes.
