### PR TITLE
Fix FIAM pod lib lint issue

### DIFF
--- a/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.m
@@ -56,7 +56,10 @@
     [appSideDelegate messageClicked:inAppMessage withAction:action];
   } else if ([appSideDelegate respondsToSelector:@selector(messageClicked:)]) {
     // Deprecated method is called only as a fall-back.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [appSideDelegate messageClicked:inAppMessage];
+#pragma clang diagnostic pop
   }
 
   self.isMsgBeingDisplayed = NO;


### PR DESCRIPTION
Running locally - `pod lib lint FirebaseInAppMessaging.podspec`

```
 -> FirebaseInAppMessaging (0.15.0)
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | [iOS] xcodebuild:  note: Planning build
    - NOTE  | [iOS] xcodebuild:  note: Constructing build description
    - NOTE  | [iOS] xcodebuild:  warning: Skipping code signing because the target does not have an Info.plist file. (in target 'App')
    - WARN  | xcodebuild:  /Users/paulbeusterien/gh4/firebase-ios-sdk/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.m:59:22: warning: 'messageClicked:' is deprecated [-Wdeprecated-declarations]
    - NOTE  | xcodebuild:  /Users/paulbeusterien/gh4/firebase-ios-sdk/Firebase/InAppMessaging/Public/FIRInAppMessagingRendering.h:338:72: note: 'messageClicked:' has been explicitly marked deprecated here
```