### PR TITLE
CocoaPods 1.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@
 # commit Gemfile and Gemfile.lock.
 source 'https://rubygems.org'
 
-gem 'cocoapods', "1.7.0"
+gem 'cocoapods', "1.7.1"
 gem 'cocoapods-generate', "1.5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GEM
       tzinfo (~> 1.1)
     atomos (0.1.3)
     claide (1.0.2)
-    cocoapods (1.7.0)
+    cocoapods (1.7.1)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.7.0)
+      cocoapods-core (= 1.7.1)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 1.2.2, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -28,7 +28,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (~> 1.4)
       xcodeproj (>= 1.8.2, < 2.0)
-    cocoapods-core (1.7.0)
+    cocoapods-core (1.7.1)
       activesupport (>= 4.0.2, < 6)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
@@ -73,7 +73,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (= 1.7.0)
+  cocoapods (= 1.7.1)
   cocoapods-generate (= 1.5.0)
 
 BUNDLED WITH


### PR DESCRIPTION
CocoaPods 1.7.1 released today.

I don't expect any of its fixes to impact Firebase.