### PR TITLE
Change limit to an int32 to match the backend

### DIFF
--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -177,8 +177,9 @@ std::vector<TargetId> ConvertTargetsArray(NSArray<NSNumber *> *from) {
     __block FSTQuery *query = [FSTQuery queryWithPath:resource_path
                                       collectionGroup:collectionGroup];
     if (queryDict[@"limit"]) {
-      NSNumber *limit = queryDict[@"limit"];
-      query = [query queryBySettingLimit:limit.integerValue];
+      NSNumber *limitNumber = queryDict[@"limit"];
+      auto limit = static_cast<int32_t>(limitNumber.integerValue);
+      query = [query queryBySettingLimit:limit];
     }
     if (queryDict[@"filters"]) {
       NSArray *filters = queryDict[@"filters"];

--- a/Firestore/Source/API/FIRQuery.mm
+++ b/Firestore/Source/API/FIRQuery.mm
@@ -42,6 +42,7 @@
 #include "Firestore/core/src/firebase/firestore/api/query_core.h"
 #include "Firestore/core/src/firebase/firestore/core/direction.h"
 #include "Firestore/core/src/firebase/firestore/core/filter.h"
+#include "Firestore/core/src/firebase/firestore/core/query.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/field_path.h"
 #include "Firestore/core/src/firebase/firestore/model/field_value.h"
@@ -348,7 +349,13 @@ FIRQuery *Wrap(Query &&query) {
 }
 
 - (FIRQuery *)queryLimitedTo:(NSInteger)limit {
-  return Wrap(_query.Limit(static_cast<int64_t>(limit)));
+  int32_t internalLimit;
+  if (limit == NSNotFound || limit > std::numeric_limits<int32_t>::max()) {
+    internalLimit = core::Query::kNoLimit;
+  } else {
+    internalLimit = static_cast<int32_t>(limit);
+  }
+  return Wrap(_query.Limit(internalLimit));
 }
 
 - (FIRQuery *)queryStartingAtDocument:(FIRDocumentSnapshot *)snapshot {

--- a/Firestore/Source/API/FIRQuery.mm
+++ b/Firestore/Source/API/FIRQuery.mm
@@ -350,7 +350,7 @@ FIRQuery *Wrap(Query &&query) {
 
 - (FIRQuery *)queryLimitedTo:(NSInteger)limit {
   int32_t internalLimit;
-  if (limit == NSNotFound || limit > std::numeric_limits<int32_t>::max()) {
+  if (limit == NSNotFound || limit >= core::Query::kNoLimit) {
     internalLimit = core::Query::kNoLimit;
   } else {
     internalLimit = static_cast<int32_t>(limit);

--- a/Firestore/Source/Core/FSTQuery.h
+++ b/Firestore/Source/Core/FSTQuery.h
@@ -168,7 +168,7 @@ NS_ASSUME_NONNULL_BEGIN
              collectionGroup:(nullable NSString *)collectionGroup
                     filterBy:(NSArray<FSTFilter *> *)filters
                      orderBy:(NSArray<FSTSortOrder *> *)sortOrders
-                       limit:(NSInteger)limit
+                       limit:(int32_t)limit
                      startAt:(nullable FSTBound *)startAtBound
                        endAt:(nullable FSTBound *)endAtBound NS_DESIGNATED_INITIALIZER;
 
@@ -230,7 +230,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param limit The maximum number of results to return. If @a limit <= 0, behavior is unspecified.
  *     If @a limit == NSNotFound, then no limit is applied.
  */
-- (instancetype)queryBySettingLimit:(NSInteger)limit;
+- (instancetype)queryBySettingLimit:(int32_t)limit;
 
 /**
  * Creates a new FSTQuery starting at the provided bound.
@@ -287,7 +287,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong, readonly) NSArray<FSTFilter *> *filters;
 
 /** The maximum number of results to return, or NSNotFound if no limit. */
-@property(nonatomic, assign, readonly) NSInteger limit;
+@property(nonatomic, assign, readonly) int32_t limit;
 
 /**
  * A canonical string identifying the query. Two different instances of equivalent queries will

--- a/Firestore/Source/Core/FSTQuery.mm
+++ b/Firestore/Source/Core/FSTQuery.mm
@@ -16,6 +16,7 @@
 
 #import "Firestore/Source/Core/FSTQuery.h"
 
+#include <limits>
 #include <memory>
 #include <string>
 #include <utility>
@@ -27,6 +28,7 @@
 
 #include "Firestore/core/src/firebase/firestore/api/input_validation.h"
 #include "Firestore/core/src/firebase/firestore/core/filter.h"
+#include "Firestore/core/src/firebase/firestore/core/query.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/field_path.h"
 #include "Firestore/core/src/firebase/firestore/model/field_value.h"
@@ -41,6 +43,7 @@ namespace objc = firebase::firestore::objc;
 namespace util = firebase::firestore::util;
 using firebase::firestore::api::ThrowInvalidArgument;
 using firebase::firestore::core::Filter;
+using firebase::firestore::core::Query;
 using firebase::firestore::model::DocumentComparator;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::FieldPath;
@@ -557,7 +560,7 @@ NSString *FSTStringFromQueryRelationOperator(Filter::Operator filterOperator) {
                         collectionGroup:collectionGroup
                                filterBy:@[]
                                 orderBy:@[]
-                                  limit:NSNotFound
+                                  limit:Query::kNoLimit
                                 startAt:nil
                                   endAt:nil];
 }
@@ -566,7 +569,7 @@ NSString *FSTStringFromQueryRelationOperator(Filter::Operator filterOperator) {
              collectionGroup:(nullable NSString *)collectionGroup
                     filterBy:(NSArray<FSTFilter *> *)filters
                      orderBy:(NSArray<FSTSortOrder *> *)sortOrders
-                       limit:(NSInteger)limit
+                       limit:(int32_t)limit
                      startAt:(nullable FSTBound *)startAtBound
                        endAt:(nullable FSTBound *)endAtBound {
   if (self = [super init]) {
@@ -689,7 +692,7 @@ NSString *FSTStringFromQueryRelationOperator(Filter::Operator filterOperator) {
                                   endAt:self.endAt];
 }
 
-- (instancetype)queryBySettingLimit:(NSInteger)limit {
+- (instancetype)queryBySettingLimit:(int32_t)limit {
   return [[FSTQuery alloc] initWithPath:self.path
                         collectionGroup:self.collectionGroup
                                filterBy:self.filters
@@ -818,7 +821,7 @@ NSString *FSTStringFromQueryRelationOperator(Filter::Operator filterOperator) {
   }
 
   // Add limit.
-  if (self.limit != NSNotFound) {
+  if (self.limit != Query::kNoLimit) {
     [canonicalID appendFormat:@"|l:%ld", (long)self.limit];
   }
 

--- a/Firestore/Source/Core/FSTView.mm
+++ b/Firestore/Source/Core/FSTView.mm
@@ -24,6 +24,7 @@
 #import "Firestore/Source/Model/FSTDocument.h"
 #import "Firestore/Source/Model/FSTFieldValue.h"
 
+#include "Firestore/core/src/firebase/firestore/core/query.h"
 #include "Firestore/core/src/firebase/firestore/core/view_snapshot.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
@@ -35,6 +36,7 @@
 namespace util = firebase::firestore::util;
 using firebase::firestore::core::DocumentViewChange;
 using firebase::firestore::core::DocumentViewChangeSet;
+using firebase::firestore::core::Query;
 using firebase::firestore::core::SyncState;
 using firebase::firestore::core::ViewSnapshot;
 using firebase::firestore::model::DocumentKey;
@@ -279,7 +281,7 @@ int GetDocumentViewChangeTypePosition(DocumentViewChange::Type changeType) {
   // Note that this should never get used in a refill (when previousChanges is set), because there
   // will only be adds -- no deletes or updates.
   FSTDocument *_Nullable lastDocInLimit =
-      (self.query.limit != NSNotFound && oldDocumentSet.size() == self.query.limit)
+      (self.query.limit != Query::kNoLimit && oldDocumentSet.size() == self.query.limit)
           ? oldDocumentSet.GetLastDocument()
           : nil;
 
@@ -357,7 +359,7 @@ int GetDocumentViewChangeTypePosition(DocumentViewChange::Type changeType) {
     }
   }
 
-  if (self.query.limit != NSNotFound && newDocumentSet.size() > self.query.limit) {
+  if (self.query.limit != Query::kNoLimit && newDocumentSet.size() > self.query.limit) {
     for (size_t i = newDocumentSet.size() - self.query.limit; i > 0; --i) {
       FSTDocument *oldDoc = newDocumentSet.GetLastDocument();
       newDocumentSet = newDocumentSet.erase(oldDoc.key);

--- a/Firestore/Source/Remote/FSTSerializerBeta.mm
+++ b/Firestore/Source/Remote/FSTSerializerBeta.mm
@@ -43,6 +43,7 @@
 #include "Firestore/core/include/firebase/firestore/firestore_errors.h"
 #include "Firestore/core/include/firebase/firestore/geo_point.h"
 #include "Firestore/core/src/firebase/firestore/core/filter.h"
+#include "Firestore/core/src/firebase/firestore/core/query.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/field_mask.h"
@@ -64,6 +65,7 @@ using firebase::Timestamp;
 using firebase::firestore::FirestoreErrorCode;
 using firebase::firestore::GeoPoint;
 using firebase::firestore::core::Filter;
+using firebase::firestore::core::Query;
 using firebase::firestore::model::ArrayTransform;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentKey;
@@ -801,7 +803,7 @@ NS_ASSUME_NONNULL_BEGIN
     [queryTarget.structuredQuery.orderByArray addObjectsFromArray:orders];
   }
 
-  if (query.limit != NSNotFound) {
+  if (query.limit != Query::kNoLimit) {
     queryTarget.structuredQuery.limit.value = (int32_t)query.limit;
   }
 
@@ -848,7 +850,7 @@ NS_ASSUME_NONNULL_BEGIN
     orderBy = @[];
   }
 
-  NSInteger limit = NSNotFound;
+  int32_t limit = Query::kNoLimit;
   if (query.hasLimit) {
     limit = query.limit.value;
   }

--- a/Firestore/core/src/firebase/firestore/api/query_core.h
+++ b/Firestore/core/src/firebase/firestore/api/query_core.h
@@ -134,7 +134,7 @@ class Query {
    *
    * @return The created `Query`.
    */
-  Query Limit(int64_t limit) const;
+  Query Limit(int32_t limit) const;
 
   /**
    * Creates and returns a new `Query` that starts at the given bound.  The

--- a/Firestore/core/src/firebase/firestore/api/query_core.mm
+++ b/Firestore/core/src/firebase/firestore/api/query_core.mm
@@ -253,7 +253,7 @@ Query Query::OrderBy(FieldPath fieldPath, Direction direction) const {
   return Wrap([query() queryByAddingSortOrder:sortOrder]);
 }
 
-Query Query::Limit(int64_t limit) const {
+Query Query::Limit(int32_t limit) const {
   if (limit <= 0) {
     ThrowInvalidArgument(
         "Invalid Query. Query limit (%s) is invalid. Limit must be positive.",

--- a/Firestore/core/src/firebase/firestore/core/query.h
+++ b/Firestore/core/src/firebase/firestore/core/query.h
@@ -35,6 +35,8 @@ namespace core {
  */
 class Query {
  public:
+  static constexpr int32_t kNoLimit = -1;
+
   /**
    * Creates and returns a new Query.
    *

--- a/Firestore/core/src/firebase/firestore/core/query.h
+++ b/Firestore/core/src/firebase/firestore/core/query.h
@@ -17,6 +17,7 @@
 #ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_QUERY_H_
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_QUERY_H_
 
+#include <limits>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -35,7 +36,7 @@ namespace core {
  */
 class Query {
  public:
-  static constexpr int32_t kNoLimit = -1;
+  static constexpr int32_t kNoLimit = std::numeric_limits<int32_t>::max();
 
   /**
    * Creates and returns a new Query.


### PR DESCRIPTION
This cleans up a warning you get about a bad cast when building in 32-bit mode. It also makes the limit have a portable type, where previously it was `NSInteger` which doesn't exist outside Apple platforms.