### PR TITLE
Fix -[FIRGeoPoint compare:] analysis warning

### DIFF
--- a/Firestore/Source/API/FIRGeoPoint.mm
+++ b/Firestore/Source/API/FIRGeoPoint.mm
@@ -48,15 +48,6 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
-- (NSComparisonResult)compare:(FIRGeoPoint *)other {
-  NSComparisonResult result = WrapCompare<double>(self.latitude, other.latitude);
-  if (result != NSOrderedSame) {
-    return result;
-  } else {
-    return WrapCompare<double>(self.longitude, other.longitude);
-  }
-}
-
 #pragma mark - NSObject methods
 
 - (NSString *)description {
@@ -87,6 +78,15 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation FIRGeoPoint (Internal)
+
+- (NSComparisonResult)compare:(FIRGeoPoint *)other {
+  NSComparisonResult result = WrapCompare<double>(self.latitude, other.latitude);
+  if (result != NSOrderedSame) {
+    return result;
+  } else {
+    return WrapCompare<double>(self.longitude, other.longitude);
+  }
+}
 
 - (firestore::GeoPoint)toGeoPoint {
   return firestore::GeoPoint(self.latitude, self.longitude);


### PR DESCRIPTION
This fixes a warning I introduced in #3044.

The issue is that the header declares `-compare:` to be a part of the `Internal` category but the current state defines that method in the main `@implementation`. This moves the definition into the category to match the declaration.