### PR TITLE
Use CocoaPods CDN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseDatabase.podspec --use-modular-headers --skip-tests
 
       env:
-        - PROJECT=DynamicLinks PLATFORM=all METHOD=xcodebuild
+        - PROJECT=DynamicLinks PLATFORM=all METHOD=pod_lib_lint
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseDatabase.podspec --use-modular-headers --skip-tests
 
       env:
-        - PROJECT=DynamicLinks PLATFORM=all METHOD=pod_lib_lint
+        - PROJECT=DynamicLinks PLATFORM=all METHOD=pod-lib-lint
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -2,10 +2,6 @@
 #source 'sso://cpdc-internal/firebase'
 #source 'https://github.com/CocoaPods/Specs.git'
 
-# Uncomment the next two lines for pre-release testing on public repo
-#source 'https://github.com/Firebase/SpecsStaging.git'
-#source 'https://github.com/CocoaPods/Specs.git'
-
 # Comment the following line to use the CocoaPods master repo instead.
 source 'https://cdn.jsdelivr.net/cocoa/'
 

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,7 +6,7 @@
 #source 'https://github.com/Firebase/SpecsStaging.git'
 #source 'https://github.com/CocoaPods/Specs.git'
 
-# Comment the follwoing line to use the CocoaPods master repo instead.
+# Comment the following line to use the CocoaPods master repo instead.
 source 'https://cdn.jsdelivr.net/cocoa/'
 
 use_frameworks!

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,8 +3,11 @@
 #source 'https://github.com/CocoaPods/Specs.git'
 
 # Uncomment the next two lines for pre-release testing on public repo
-source 'https://github.com/Firebase/SpecsStaging.git'
-source 'https://github.com/CocoaPods/Specs.git'
+#source 'https://github.com/Firebase/SpecsStaging.git'
+#source 'https://github.com/CocoaPods/Specs.git'
+
+# Comment the follwoing line to use the CocoaPods master repo instead.
+source 'https://cdn.jsdelivr.net/cocoa/'
 
 use_frameworks!
 

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -2,10 +2,6 @@
 #source 'sso://cpdc-internal/firebase'
 #source 'https://github.com/CocoaPods/Specs.git'
 
-# Uncomment the next two lines for pre-release testing on public repo
-#source 'https://github.com/Firebase/SpecsStaging.git'
-#source 'https://github.com/CocoaPods/Specs.git'
-
 # Comment the following line to use the CocoaPods master repo instead.
 source 'https://cdn.jsdelivr.net/cocoa/'
 

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -6,7 +6,7 @@
 #source 'https://github.com/Firebase/SpecsStaging.git'
 #source 'https://github.com/CocoaPods/Specs.git'
 
-# Comment the follwoing line to use the CocoaPods master repo instead.
+# Comment the following line to use the CocoaPods master repo instead.
 source 'https://cdn.jsdelivr.net/cocoa/'
 
 use_frameworks!

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -6,6 +6,9 @@
 #source 'https://github.com/Firebase/SpecsStaging.git'
 #source 'https://github.com/CocoaPods/Specs.git'
 
+# Comment the follwoing line to use the CocoaPods master repo instead.
+source 'https://cdn.jsdelivr.net/cocoa/'
+
 use_frameworks!
 
 

--- a/InAppMessaging/Example/Podfile
+++ b/InAppMessaging/Example/Podfile
@@ -1,8 +1,7 @@
 use_frameworks!
 
-# Uncomment the next two lines for pre-release testing on public repo
-source 'https://github.com/Firebase/SpecsStaging.git'
-source 'https://github.com/CocoaPods/Specs.git'
+# Comment the following line to use the CocoaPods master repo instead.
+source 'https://cdn.jsdelivr.net/cocoa/'
 
 pod 'FirebaseAnalytics'
 pod 'FirebaseCore', :path => '../..'

--- a/InAppMessagingDisplay/Example/Podfile
+++ b/InAppMessagingDisplay/Example/Podfile
@@ -1,6 +1,5 @@
-# Uncomment the next two lines for pre-release testing on public repo
-source 'https://github.com/Firebase/SpecsStaging.git'
-source 'https://github.com/CocoaPods/Specs.git'
+# Comment the following line to use the CocoaPods master repo instead.
+source 'https://cdn.jsdelivr.net/cocoa/'
 
 use_frameworks!
 

--- a/SymbolCollisionTest/Podfile
+++ b/SymbolCollisionTest/Podfile
@@ -1,6 +1,9 @@
 # Uncomment the next line to define a global platform for your project
 # platform :ios, '9.0'
 
+# Comment the following line to use the CocoaPods master repo instead.
+source 'https://cdn.jsdelivr.net/cocoa/'
+
 target 'SymbolCollisionTest' do
   # Uncomment the next line if you're using Swift or would like to use dynamic frameworks
   # use_frameworks!

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -332,14 +332,14 @@ case "$product-$method-$platform" in
 
   GoogleDataTransport-xcodebuild-*)
     RunXcodebuild \
-        -workspace 'GoogleDataTransport/gen/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
+        -workspace 'gen/GoogleDataTransport/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
         -scheme "GoogleDataTransport-$platform-Unit-Tests-Unit" \
         "${xcb_flags[@]}" \
         build \
         test
 
     RunXcodebuild \
-        -workspace 'GoogleDataTransport/gen/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
+        -workspace 'gen/GoogleDataTransport/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
         -scheme "GoogleDataTransport-$platform-Unit-Tests-Lifecycle" \
         "${xcb_flags[@]}" \
         build \
@@ -348,7 +348,7 @@ case "$product-$method-$platform" in
 
   GoogleDataTransportIntegrationTest-xcodebuild-*)
     RunXcodebuild \
-        -workspace 'GoogleDataTransport/gen/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
+        -workspace 'gen/GoogleDataTransport/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
         -scheme "GoogleDataTransport-$platform-Unit-Tests-Integration" \
         "${xcb_flags[@]}" \
         build \
@@ -357,14 +357,14 @@ case "$product-$method-$platform" in
 
   GoogleDataTransportCCTSupport-xcodebuild-*)
     RunXcodebuild \
-        -workspace 'GoogleDataTransportCCTSupport/gen/GoogleDataTransportCCTSupport/GoogleDataTransportCCTSupport.xcworkspace' \
+        -workspace 'gen/GoogleDataTransportCCTSupport/GoogleDataTransportCCTSupport/GoogleDataTransportCCTSupport.xcworkspace' \
         -scheme "GoogleDataTransportCCTSupport-$platform-Unit-Tests-Unit" \
         "${xcb_flags[@]}" \
         build \
         test
 
     RunXcodebuild \
-        -workspace 'GoogleDataTransportCCTSupport/gen/GoogleDataTransportCCTSupport/GoogleDataTransportCCTSupport.xcworkspace' \
+        -workspace 'gen/GoogleDataTransportCCTSupport/GoogleDataTransportCCTSupport/GoogleDataTransportCCTSupport.xcworkspace' \
         -scheme "GoogleDataTransportCCTSupport-$platform-Unit-Tests-Integration" \
         "${xcb_flags[@]}" \
         build \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -332,14 +332,14 @@ case "$product-$method-$platform" in
 
   GoogleDataTransport-xcodebuild-*)
     RunXcodebuild \
-        -workspace 'gen/GoogleDataTransport/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
+        -workspace 'gen/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
         -scheme "GoogleDataTransport-$platform-Unit-Tests-Unit" \
         "${xcb_flags[@]}" \
         build \
         test
 
     RunXcodebuild \
-        -workspace 'gen/GoogleDataTransport/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
+        -workspace 'gen/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
         -scheme "GoogleDataTransport-$platform-Unit-Tests-Lifecycle" \
         "${xcb_flags[@]}" \
         build \
@@ -348,7 +348,7 @@ case "$product-$method-$platform" in
 
   GoogleDataTransportIntegrationTest-xcodebuild-*)
     RunXcodebuild \
-        -workspace 'gen/GoogleDataTransport/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
+        -workspace 'gen/GoogleDataTransport/GoogleDataTransport.xcworkspace' \
         -scheme "GoogleDataTransport-$platform-Unit-Tests-Integration" \
         "${xcb_flags[@]}" \
         build \
@@ -357,14 +357,14 @@ case "$product-$method-$platform" in
 
   GoogleDataTransportCCTSupport-xcodebuild-*)
     RunXcodebuild \
-        -workspace 'gen/GoogleDataTransportCCTSupport/GoogleDataTransportCCTSupport/GoogleDataTransportCCTSupport.xcworkspace' \
+        -workspace 'gen/GoogleDataTransportCCTSupport/GoogleDataTransportCCTSupport.xcworkspace' \
         -scheme "GoogleDataTransportCCTSupport-$platform-Unit-Tests-Unit" \
         "${xcb_flags[@]}" \
         build \
         test
 
     RunXcodebuild \
-        -workspace 'gen/GoogleDataTransportCCTSupport/GoogleDataTransportCCTSupport/GoogleDataTransportCCTSupport.xcworkspace' \
+        -workspace 'gen/GoogleDataTransportCCTSupport/GoogleDataTransportCCTSupport.xcworkspace' \
         -scheme "GoogleDataTransportCCTSupport-$platform-Unit-Tests-Integration" \
         "${xcb_flags[@]}" \
         build \

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -48,7 +48,7 @@ function install_secrets() {
 
 function pod_gen() {
   # Call pod gen with a podspec and additonal optional arguments.
-  bundle exec pod gen "$1" "${2-}" --local-sources=./ --sources=https://cdn.jsdelivr.net/cocoa/
+  bundle exec pod gen --local-sources=./ --sources=https://cdn.jsdelivr.net/cocoa/ "$@"
 }
 
 case "$PROJECT-$PLATFORM-$METHOD" in

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -46,6 +46,11 @@ function install_secrets() {
   fi
 }
 
+function pod_gen() {
+  # Call pod gen with a podspec and additonal optional arguments.
+  bundle exec pod gen "$1" "${2-}" --local-sources=./ --sources=https://cdn.jsdelivr.net/cocoa/
+}
+
 case "$PROJECT-$PLATFORM-$METHOD" in
   Firebase-iOS-xcodebuild)
     gem install xcpretty
@@ -64,29 +69,25 @@ case "$PROJECT-$PLATFORM-$METHOD" in
   Database-*)
     # Install the workspace to have better control over test runs than
     # pod lib lint, since the integration tests can be flaky.
-    #bundle exec pod repo update
-    bundle exec pod gen FirebaseDatabase.podspec --local-sources=./ --sources=https://cdn.jsdelivr.net/cocoa/
+    pod_gen FirebaseDatabase.podspec
     install_secrets
     ;;
 
   Functions-*)
     # Start server for Functions integration tests.
-    #bundle exec pod repo update
     ./Functions/Backend/start.sh synchronous
     ;;
 
   Messaging-*)
     # Install the workspace to have better control over test runs than
     # pod lib lint, since the integration tests can be flaky.
-    #bundle exec pod repo update
-    bundle exec pod gen FirebaseMessaging.podspec --local-sources=./ --sources=https://cdn.jsdelivr.net/cocoa/
+    pod_gen FirebaseMessaging.podspec
     ;;
 
   Storage-*)
     # Install the workspace to have better control over test runs than
     # pod lib lint, since the integration tests can be flaky.
-    #bundle exec pod repo update
-    bundle exec pod gen FirebaseStorage.podspec --local-sources=./ --sources=https://cdn.jsdelivr.net/cocoa/
+    pod_gen FirebaseStorage.podspec
     install_secrets
     ;;
 
@@ -102,7 +103,6 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     ;;
 
   *-pod-lib-lint)
-    #bundle exec pod repo update
     ;;
 
   Firestore-*-cmake)
@@ -120,12 +120,12 @@ case "$PROJECT-$PLATFORM-$METHOD" in
 
   GoogleDataTransport-*-xcodebuild)
     gem install xcpretty
-    bundle exec pod gen GoogleDataTransport.podspec --gen-directory=GoogleDataTransport/gen
+    pod_gen GoogleDataTransport.podspec --gen-directory=GoogleDataTransport/gen
     ;;
 
   GoogleDataTransportIntegrationTest-*-xcodebuild)
     gem install xcpretty
-    bundle exec pod gen GoogleDataTransport.podspec --gen-directory=GoogleDataTransport/gen
+    pod_gen GoogleDataTransport.podspec --gen-directory=GoogleDataTransport/gen
     ;;
 
   GoogleDataTransportCCTSupport-*-xcodebuild)

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -19,9 +19,6 @@
 #   - PROJECT - Firebase or Firestore
 #   - METHOD - xcodebuild or cmake; default is xcodebuild
 
-set -euo pipefail
-set -x
-
 bundle install
 
 function install_secrets() {

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -19,6 +19,9 @@
 #   - PROJECT - Firebase or Firestore
 #   - METHOD - xcodebuild or cmake; default is xcodebuild
 
+set -euo pipefail
+set -x
+
 bundle install
 
 function install_secrets() {

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -120,17 +120,17 @@ case "$PROJECT-$PLATFORM-$METHOD" in
 
   GoogleDataTransport-*-xcodebuild)
     gem install xcpretty
-    pod_gen GoogleDataTransport.podspec --gen-directory=GoogleDataTransport/gen
+    pod_gen GoogleDataTransport.podspec
     ;;
 
   GoogleDataTransportIntegrationTest-*-xcodebuild)
     gem install xcpretty
-    pod_gen GoogleDataTransport.podspec --gen-directory=GoogleDataTransport/gen
+    pod_gen GoogleDataTransport.podspec
     ;;
 
   GoogleDataTransportCCTSupport-*-xcodebuild)
     gem install xcpretty
-    pod_gen GoogleDataTransportCCTSupport.podspec --gen-directory=GoogleDataTransportCCTSupport/gen
+    pod_gen GoogleDataTransportCCTSupport.podspec
     ;;
   *)
     echo "Unknown project-platform-method combo" 1>&2

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -64,33 +64,29 @@ case "$PROJECT-$PLATFORM-$METHOD" in
   Database-*)
     # Install the workspace to have better control over test runs than
     # pod lib lint, since the integration tests can be flaky.
-    bundle exec pod repo update
-    bundle exec pod gen FirebaseDatabase.podspec --local-sources=./
+    #bundle exec pod repo update
+    bundle exec pod gen FirebaseDatabase.podspec --local-sources=./ --sources=https://cdn.jsdelivr.net/cocoa/
     install_secrets
-    ;;
-
-  DynamicLinks-*)
-    bundle exec pod repo update
     ;;
 
   Functions-*)
     # Start server for Functions integration tests.
-    bundle exec pod repo update
+    #bundle exec pod repo update
     ./Functions/Backend/start.sh synchronous
     ;;
 
   Messaging-*)
     # Install the workspace to have better control over test runs than
     # pod lib lint, since the integration tests can be flaky.
-    bundle exec pod repo update
-    bundle exec pod gen FirebaseMessaging.podspec --local-sources=./
+    #bundle exec pod repo update
+    bundle exec pod gen FirebaseMessaging.podspec --local-sources=./ --sources=https://cdn.jsdelivr.net/cocoa/
     ;;
 
   Storage-*)
     # Install the workspace to have better control over test runs than
     # pod lib lint, since the integration tests can be flaky.
-    bundle exec pod repo update
-    bundle exec pod gen FirebaseStorage.podspec --local-sources=./
+    #bundle exec pod repo update
+    bundle exec pod gen FirebaseStorage.podspec --local-sources=./ --sources=https://cdn.jsdelivr.net/cocoa/
     install_secrets
     ;;
 
@@ -106,7 +102,7 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     ;;
 
   *-pod-lib-lint)
-    bundle exec pod repo update
+    #bundle exec pod repo update
     ;;
 
   Firestore-*-cmake)

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -130,10 +130,7 @@ case "$PROJECT-$PLATFORM-$METHOD" in
 
   GoogleDataTransportCCTSupport-*-xcodebuild)
     gem install xcpretty
-    # TODO(mikehaney24): Remove the SpecsStaging repo once GDT is published.
-    bundle exec pod gen GoogleDataTransportCCTSupport.podspec \
---gen-directory=GoogleDataTransportCCTSupport/gen  \
---sources=https://github.com/Firebase/SpecsStaging.git,https://github.com/CocoaPods/Specs.git
+    pod_gen GoogleDataTransportCCTSupport.podspec --gen-directory=GoogleDataTransportCCTSupport/gen
     ;;
   *)
     echo "Unknown project-platform-method combo" 1>&2

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -38,7 +38,7 @@ def main(args)
     exit(1)
   end
 
-  command = %w(bundle exec pod lib lint)
+  command = %w(bundle exec pod lib lint --sources=https://cdn.jsdelivr.net/cocoa/)
 
   # Figure out which dependencies are local
   podspec_file = args[0]


### PR DESCRIPTION
Using the CDN makes the travis sub-jobs 1-4 minutes faster

Also:
- Create a pod_gen shell function to consolidate all usages of `pod gen`
- Clean up references to no longer needed SpecsStaging
- For GoogleDataTransport, use default `pod gen` workspace to be consistent and because the `pod gen` options `--gen-directory` and `--local-sources` do not work when combined.