### PR TITLE
correct timezone proto key

### DIFF
--- a/Firebase/InstanceID/FIRInstanceIDCheckinService.m
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinService.m
@@ -226,7 +226,7 @@ static FIRInstanceIDURLRequestTestBlock testBlock;
     @"locale" : locale,
     @"version" : @(kCheckinVersion),
     @"digest" : checkinPreferences.digest ?: @"",
-    @"timezone" : timeZone,
+    @"time_zone" : timeZone,
     @"user_serial_number" : @(userSerialNumber),
     @"id" : @([checkinPreferences.deviceID longLongValue]),
     @"security_token" : @([checkinPreferences.secretToken longLongValue]),


### PR DESCRIPTION
The timezone proto key passed in is in wrong format.