### PR TITLE
Add a getter for Firestore pointer to api::WriteBatch

### DIFF
--- a/Firestore/core/src/firebase/firestore/api/write_batch.h
+++ b/Firestore/core/src/firebase/firestore/api/write_batch.h
@@ -56,6 +56,10 @@ class WriteBatch {
 
   void Commit(util::StatusCallback callback);
 
+  const std::shared_ptr<Firestore>& firestore() const {
+    return firestore_;
+  }
+
  private:
   std::shared_ptr<Firestore> firestore_;
   std::vector<FSTMutation*> mutations_;


### PR DESCRIPTION
Other `api` classes have that.