### PR TITLE
Raise exception when log into Facebook using OAuth. 

### DIFF
--- a/Firebase/Auth/Source/AuthProvider/OAuth/FIROAuthCredential.m
+++ b/Firebase/Auth/Source/AuthProvider/OAuth/FIROAuthCredential.m
@@ -18,6 +18,7 @@
 
 #import "FIRAuthCredential_Internal.h"
 #import "FIRAuthExceptionUtils.h"
+#import "FIRFacebookAuthProvider.h"
 #import "FIROAuthCredential_Internal.h"
 #import "FIRVerifyAssertionRequest.h"
 #import "FIRVerifyAssertionResponse.h"
@@ -43,6 +44,12 @@ NS_ASSUME_NONNULL_BEGIN
                        accessToken:(nullable NSString *)accessToken
                             secret:(nullable NSString *)secret
                       pendingToken:(nullable NSString *)pendingToken {
+  if ([providerID isEqual:FIRFacebookAuthProviderID]) {
+    [FIRAuthExceptionUtils raiseInvalidParameterExceptionWithReason:
+        @"Sign in with Facebook is not supported via this method; the Facebook TOS "
+         "dictate that you must use the Facebook Android SDK for Facebook login."];
+    return nil;
+  }
   self = [super initWithProvider:providerID];
   if (self) {
     _IDToken = IDToken;

--- a/Firebase/Auth/Source/AuthProvider/OAuth/FIROAuthCredential.m
+++ b/Firebase/Auth/Source/AuthProvider/OAuth/FIROAuthCredential.m
@@ -18,7 +18,6 @@
 
 #import "FIRAuthCredential_Internal.h"
 #import "FIRAuthExceptionUtils.h"
-#import "FIRFacebookAuthProvider.h"
 #import "FIROAuthCredential_Internal.h"
 #import "FIRVerifyAssertionRequest.h"
 #import "FIRVerifyAssertionResponse.h"
@@ -44,12 +43,6 @@ NS_ASSUME_NONNULL_BEGIN
                        accessToken:(nullable NSString *)accessToken
                             secret:(nullable NSString *)secret
                       pendingToken:(nullable NSString *)pendingToken {
-  if ([providerID isEqual:FIRFacebookAuthProviderID]) {
-    [FIRAuthExceptionUtils raiseInvalidParameterExceptionWithReason:
-        @"Sign in with Facebook is not supported via this method; the Facebook TOS "
-         "dictate that you must use the Facebook Android SDK for Facebook login."];
-    return nil;
-  }
   self = [super initWithProvider:providerID];
   if (self) {
     _IDToken = IDToken;

--- a/Firebase/Auth/Source/AuthProvider/OAuth/FIROAuthProvider.m
+++ b/Firebase/Auth/Source/AuthProvider/OAuth/FIROAuthProvider.m
@@ -23,9 +23,11 @@
 #import "FIRAuthBackend.h"
 #import "FIRAuth_Internal.h"
 #import "FIRAuthErrorUtils.h"
+#import "FIRAuthExceptionUtils.h"
 #import "FIRAuthGlobalWorkQueue.h"
 #import "FIRAuthRequestConfiguration.h"
 #import "FIRAuthWebUtils.h"
+#import "FIRFacebookAuthProvider.h"
 #import "FIROAuthCredential_Internal.h"
 #import "FIROAuthCredential.h"
 
@@ -165,6 +167,12 @@ static NSString *const kAuthTypeSignInWithRedirect = @"signInWithRedirect";
     @return An Instance of @c FIROAuthProvider.
   */
 - (nullable instancetype)initWithProviderID:(NSString *)providerID auth:(FIRAuth *)auth {
+  if ([providerID isEqual:FIRFacebookAuthProviderID]) {
+    [FIRAuthExceptionUtils raiseInvalidParameterExceptionWithReason:
+        @"Sign in with Facebook is not supported via this method; the Facebook TOS "
+         "dictate that you must use the Facebook iOS SDK for Facebook login."];
+    return nil;
+  }
   self = [super init];
   if (self) {
     _auth = auth;


### PR DESCRIPTION
Facebook requires use of its official SDK for mobile and doesn't allow web based flows.
This is on par with Android implementation. 