### PR TITLE
 Deprecated old Core configuration method

### DIFF
--- a/Firebase/Auth/Source/Auth/FIRAuth.m
+++ b/Firebase/Auth/Source/Auth/FIRAuth.m
@@ -1885,7 +1885,7 @@ didReceiveRemoteNotification:(NSDictionary *)userInfo {
     return [[FIRAuth alloc] initWithApp:container.app];
   };
 
-  // Always eager
+  // Always eager since Auth may need to swizzle delegate methods if appropriate.
   FIRComponent *authInterop = [FIRComponent componentWithProtocol:@protocol(FIRAuthInterop)
                                               instantiationTiming:FIRInstantiationTimingAlwaysEager
                                                      dependencies:@[]

--- a/Firebase/Auth/Source/Auth/FIRAuth.m
+++ b/Firebase/Auth/Source/Auth/FIRAuth.m
@@ -1884,18 +1884,13 @@ didReceiveRemoteNotification:(NSDictionary *)userInfo {
     *isCacheable = YES;
     return [[FIRAuth alloc] initWithApp:container.app];
   };
+
+  // Always eager
   FIRComponent *authInterop = [FIRComponent componentWithProtocol:@protocol(FIRAuthInterop)
+                                              instantiationTiming:FIRInstantiationTimingAlwaysEager
+                                                     dependencies:@[]
                                                     creationBlock:authCreationBlock];
   return @[authInterop];
-}
-
-#pragma mark - FIRCoreConfigurable
-
-+ (void)configureWithApp:(nonnull FIRApp *)app {
-  // TODO: Evaluate what actually needs to be configured here instead of initializing a full
-  // instance.
-  // Ensures the @c FIRAuth instance for a given app gets loaded as soon as the app is ready.
-  [FIRAuth authWithApp:app];
 }
 
 #pragma mark - FIRComponentLifecycleMaintainer

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -418,7 +418,7 @@ static NSMutableDictionary *sLibraryVersions;
                                                     userInfo:appInfoDict];
 
   // This is the new way of sending information to SDKs.
-  // TODO: Do we want this on a background thread, maybe?
+  // TODO: Remove this next breaking change.
   @synchronized(self) {
     for (Class<FIRLibrary> library in sRegisteredAsConfigurable) {
       [library configureWithApp:app];

--- a/Firebase/Core/FIRComponentContainer.m
+++ b/Firebase/Core/FIRComponentContainer.m
@@ -95,7 +95,7 @@ static NSMutableSet<Class> *sFIRComponentRegistrants;
       // Store the creation block for later usage.
       self.components[protocolName] = component.creationBlock;
 
-      // Queue any protocols that should be eagarly instantiated. Don't instantiate them yet because
+      // Queue any protocols that should be eagerly instantiated. Don't instantiate them yet because
       // they could depend on other components that haven't been added to the components array yet.
       BOOL shouldInstantiateEager =
           (component.instantiationTiming == FIRInstantiationTimingAlwaysEager);

--- a/Firebase/Core/FIRComponentContainer.m
+++ b/Firebase/Core/FIRComponentContainer.m
@@ -115,7 +115,6 @@ static NSMutableSet<Class> *sFIRComponentRegistrants;
     // cached yet. Ignore the instance coming back since we don't need it.
     __unused id unusedInstance = [self instanceForProtocol:protocol];
   }
-  
 }
 
 #pragma mark - Instance Creation

--- a/Firebase/Core/Private/FIRLibrary.h
+++ b/Firebase/Core/Private/FIRLibrary.h
@@ -35,7 +35,9 @@ NS_SWIFT_NAME(Library)
 @optional
 /// Implement this method if the library needs notifications for lifecycle events. This method is
 /// called when the developer calls `FirebaseApp.configure()`.
-+ (void)configureWithApp:(FIRApp *)app;
++ (void)configureWithApp:(FIRApp *)app
+    DEPRECATED_MSG_ATTRIBUTE("If your library needs to be instantiated immediately, register with "
+                             "`FIRInstantiationAlwaysEager` or `FIRInstantationEagerInDefaultApp`");
 
 @end
 

--- a/Firebase/DynamicLinks/FIRDynamicLinks.m
+++ b/Firebase/DynamicLinks/FIRDynamicLinks.m
@@ -129,34 +129,31 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
                                                            isRequired:NO];
   FIRComponentCreationBlock creationBlock =
       ^id _Nullable(FIRComponentContainer *container, BOOL *isCacheable) {
+    // Don't return an instance when it's not the default app.
+    if (!container.app.isDefaultApp) {
+      return nil;
+    }
+
     // Ensure it's cached so it returns the same instance every time dynamicLinks is called.
     *isCacheable = YES;
     id<FIRAnalyticsInterop> analytics = FIR_COMPONENT(FIRAnalyticsInterop, container);
-    return [[FIRDynamicLinks alloc] initWithAnalytics:analytics];
+    FIRDynamicLinks *dynamicLinks = [[FIRDynamicLinks alloc] initWithAnalytics:analytics];
+    [dynamicLinks configureDynamicLinks:container.app];
+    // Check for pending Dynamic Link automatically if enabled, otherwise we expect the developer to
+    // call strong match FDL API to retrieve a pending link.
+    if ([FIRDynamicLinks isAutomaticRetrievalEnabled]) {
+      [dynamicLinks checkForPendingDynamicLink];
+    }
+
+    return dynamicLinks;
   };
   FIRComponent *dynamicLinksProvider =
       [FIRComponent componentWithProtocol:@protocol(FIRDynamicLinksInstanceProvider)
-                      instantiationTiming:FIRInstantiationTimingLazy
+                      instantiationTiming:FIRInstantiationTimingEagerInDefaultApp
                              dependencies:@[ analyticsDep ]
                             creationBlock:creationBlock];
 
   return @[ dynamicLinksProvider ];
-}
-
-+ (void)configureWithApp:(FIRApp *)app {
-  if (!app.isDefaultApp) {
-    // Only configure for the default FIRApp.
-    FDLLog(FDLLogLevelInfo, FDLLogIdentifierSetupNonDefaultApp,
-           @"Firebase Dynamic Links only "
-            "works with the default app.");
-    return;
-  }
-  [[FIRDynamicLinks dynamicLinks] configureDynamicLinks:app];
-  // check for pending Dynamic Link automatically if enabled
-  // otherwise we expect developer to call strong match FDL API to retrieve link
-  if ([FIRDynamicLinks isAutomaticRetrievalEnabled]) {
-    [[FIRDynamicLinks dynamicLinks] checkForPendingDynamicLink];
-  }
 }
 
 - (void)configureDynamicLinks:(FIRApp *)app {
@@ -181,11 +178,11 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
   if (!errorDescription) {
     // setup FDL if no error detected
     urlScheme = options.deepLinkURLScheme ?: [NSBundle mainBundle].bundleIdentifier;
-    [[FIRDynamicLinks dynamicLinks] setUpWithLaunchOptions:nil
-                                                    apiKey:options.APIKey
-                                                  clientID:options.clientID
-                                                 urlScheme:urlScheme
-                                              userDefaults:nil];
+    [self setUpWithLaunchOptions:nil
+                          apiKey:options.APIKey
+                        clientID:options.clientID
+                       urlScheme:urlScheme
+                    userDefaults:nil];
   } else {
     error =
         [FIRApp errorForSubspecConfigurationFailureWithDomain:kFirebaseDurableDeepLinkErrorDomain

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -639,41 +639,42 @@ static FIRInstanceID *gInstanceID;
 + (nonnull NSArray<FIRComponent *> *)componentsToRegister {
   FIRComponentCreationBlock creationBlock =
       ^id _Nullable(FIRComponentContainer *container, BOOL *isCacheable) {
+    // InstanceID only works with the default app.
+    if (!container.app.isDefaultApp) {
+      // Only configure for the default FIRApp.
+      FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeFIRApp002,
+                               @"Firebase Instance ID only works with the default app.");
+      return nil;
+    }
+
     // Ensure it's cached so it returns the same instance every time instanceID is called.
     *isCacheable = YES;
     FIRInstanceID *instanceID = [[FIRInstanceID alloc] initPrivately];
     [instanceID start];
+    [instanceID configureInstanceIDWithOptions:container.app.options];
     return instanceID;
   };
   FIRComponent *instanceIDProvider =
       [FIRComponent componentWithProtocol:@protocol(FIRInstanceIDInstanceProvider)
-                      instantiationTiming:FIRInstantiationTimingLazy
+                      instantiationTiming:FIRInstantiationTimingEagerInDefaultApp
                              dependencies:@[]
                             creationBlock:creationBlock];
   return @[ instanceIDProvider ];
 }
 
-+ (void)configureWithApp:(FIRApp *)app {
-  if (!app.isDefaultApp) {
-    // Only configure for the default FIRApp.
-    FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeFIRApp002,
-                             @"Firebase Instance ID only works with the default app.");
-    return;
-  }
-  [[FIRInstanceID instanceID] configureInstanceIDWithOptions:app.options app:app];
-}
-
-- (void)configureInstanceIDWithOptions:(FIROptions *)options app:(FIRApp *)firApp {
+- (void)configureInstanceIDWithOptions:(FIROptions *)options {
   NSString *GCMSenderID = options.GCMSenderID;
   if (!GCMSenderID.length) {
     FIRInstanceIDLoggerError(kFIRInstanceIDMessageCodeFIRApp000,
                              @"Firebase not set up correctly, nil or empty senderID.");
-    [FIRInstanceID exitWithReason:@"GCM_SENDER_ID must not be nil or empty." forFirebaseApp:firApp];
-    return;
+    NSString *exceptionMessage =
+        @"Could not configure Firebase InstanceID. GCMSenderID must not be nil or empty.";
+    [NSException raise:kFIRIIDErrorDomain
+                format:exceptionMessage];
   }
 
   self.fcmSenderID = GCMSenderID;
-  self.firebaseAppID = firApp.options.googleAppID;
+  self.firebaseAppID = options.googleAppID;
 
   // FCM generates a FCM token during app start for sending push notification to device.
   // This is not needed for app extension.
@@ -695,11 +696,6 @@ static FIRInstanceID *gInstanceID;
   return [NSError errorWithDomain:kFIRIIDErrorDomain
                              code:kFIRIIDErrorCodeInstanceIDFailed
                          userInfo:userInfo];
-}
-
-+ (void)exitWithReason:(nonnull NSString *)reason forFirebaseApp:(FIRApp *)firebaseApp {
-  [NSException raise:kFIRIIDErrorDomain
-              format:@"Could not configure Firebase InstanceID. %@", reason];
 }
 
 // This is used to start any operations when we receive FirebaseSDK setup notification

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -667,10 +667,9 @@ static FIRInstanceID *gInstanceID;
   if (!GCMSenderID.length) {
     FIRInstanceIDLoggerError(kFIRInstanceIDMessageCodeFIRApp000,
                              @"Firebase not set up correctly, nil or empty senderID.");
-    NSString *exceptionMessage =
-        @"Could not configure Firebase InstanceID. GCMSenderID must not be nil or empty.";
     [NSException raise:kFIRIIDErrorDomain
-                format:exceptionMessage];
+                format:@"Could not configure Firebase InstanceID. GCMSenderID must not be nil or "
+                       @"empty."];
   }
 
   self.fcmSenderID = GCMSenderID;


### PR DESCRIPTION
This shouldn't have been added - the component registration system can
provide proper configuration instead of relying on a static
`configureWithApp:` call. Many of the SDKs relied on singletons being
available there, which wasn't necessary. Instead, this should happen
in the component creation block and use the `instantiationTiming`
parameter on `registerInternalLibrary`