### PR TITLE
Clean up GeoPoint port to C++

### DIFF
--- a/Firestore/Source/API/FIRGeoPoint.mm
+++ b/Firestore/Source/API/FIRGeoPoint.mm
@@ -88,10 +88,6 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-- (firestore::GeoPoint)toGeoPoint {
-  return firestore::GeoPoint(self.latitude, self.longitude);
-}
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Firestore/Source/API/FSTUserDataConverter.mm
+++ b/Firestore/Source/API/FSTUserDataConverter.mm
@@ -30,6 +30,7 @@
 #import "Firestore/Source/API/FIRFieldValue+Internal.h"
 #import "Firestore/Source/API/FIRFirestore+Internal.h"
 #import "Firestore/Source/API/FIRGeoPoint+Internal.h"
+#import "Firestore/Source/API/converters.h"
 #import "Firestore/Source/Model/FSTFieldValue.h"
 #import "Firestore/Source/Model/FSTMutation.h"
 
@@ -48,6 +49,7 @@
 #include "absl/strings/match.h"
 
 namespace util = firebase::firestore::util;
+using firebase::firestore::GeoPoint;
 using firebase::firestore::api::ThrowInvalidArgument;
 using firebase::firestore::core::ParsedSetData;
 using firebase::firestore::core::ParsedUpdateData;
@@ -453,8 +455,7 @@ NS_ASSUME_NONNULL_BEGIN
     return [FSTTimestampValue timestampValue:truncatedTimestamp];
 
   } else if ([input isKindOfClass:[FIRGeoPoint class]]) {
-    FIRGeoPoint *geoPoint = input;
-    return FieldValue::FromGeoPoint([geoPoint toGeoPoint]).Wrap();
+    return FieldValue::FromGeoPoint(api::MakeGeoPoint(input)).Wrap();
 
   } else if ([input isKindOfClass:[NSData class]]) {
     return [FSTBlobValue blobValue:input];

--- a/Firestore/Source/API/converters.h
+++ b/Firestore/Source/API/converters.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_API_OBJC_CONVERTERS_H_
-#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_API_OBJC_CONVERTERS_H_
+#ifndef FIRESTORE_SOURCE_API_CONVERTERS_H_
+#define FIRESTORE_SOURCE_API_CONVERTERS_H_
 
 #if !defined(__OBJC__)
 #error "This header only supports Objective-C++"
@@ -46,4 +46,4 @@ FIRGeoPoint* MakeFIRGeoPoint(const GeoPoint& geo_point);
 
 NS_ASSUME_NONNULL_END
 
-#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_API_OBJC_CONVERTERS_H_
+#endif  // FIRESTORE_SOURCE_API_CONVERTERS_H_

--- a/Firestore/Source/API/converters.h
+++ b/Firestore/Source/API/converters.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_API_OBJC_CONVERTERS_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_API_OBJC_CONVERTERS_H_
+
+#if !defined(__OBJC__)
+#error "This header only supports Objective-C++"
+#endif  // !defined(__OBJC__)
+
+#import <Foundation/Foundation.h>
+
+@class FIRGeoPoint;
+
+NS_ASSUME_NONNULL_BEGIN
+
+namespace firebase {
+namespace firestore {
+
+class GeoPoint;
+
+namespace api {
+
+/** Converts a user-supplied FIRGeoPoint to the equivalent C++ GeoPoint. */
+GeoPoint MakeGeoPoint(FIRGeoPoint* geo_point);
+
+/** Converts a C++ GeoPoint to the equivalent Objective-C FIRGeoPoint. */
+FIRGeoPoint* MakeFIRGeoPoint(const GeoPoint& geo_point);
+
+}  // namespace api
+}  // namespace firestore
+}  // namespace firebase
+
+NS_ASSUME_NONNULL_END
+
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_API_OBJC_CONVERTERS_H_

--- a/Firestore/Source/API/converters.mm
+++ b/Firestore/Source/API/converters.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google
+ * Copyright 2019 Google
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,29 @@
  * limitations under the License.
  */
 
+#include "Firestore/Source/API/converters.h"
+
 #import "FIRGeoPoint.h"
+
+#include "Firestore/core/include/firebase/firestore/geo_point.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-/** Internal FIRGeoPoint API we don't want exposed in our public header files. */
-@interface FIRGeoPoint (Internal)
+namespace firebase {
+namespace firestore {
+namespace api {
 
-- (NSComparisonResult)compare:(FIRGeoPoint *)other;
+GeoPoint MakeGeoPoint(FIRGeoPoint* geo_point) {
+  return GeoPoint(geo_point.latitude, geo_point.longitude);
+}
 
-@end
+FIRGeoPoint* MakeFIRGeoPoint(const GeoPoint& geo_point) {
+  return [[FIRGeoPoint alloc] initWithLatitude:geo_point.latitude()
+                                     longitude:geo_point.longitude()];
+}
+
+}  // namespace api
+}  // namespace firestore
+}  // namespace firebase
 
 NS_ASSUME_NONNULL_END

--- a/Firestore/Source/Model/FSTFieldValue.h
+++ b/Firestore/Source/Model/FSTFieldValue.h
@@ -26,7 +26,6 @@
 #include "Firestore/core/src/firebase/firestore/model/field_value_options.h"
 
 @class FIRTimestamp;
-@class FIRGeoPoint;
 
 namespace model = firebase::firestore::model;
 

--- a/Firestore/Source/Model/FSTFieldValue.mm
+++ b/Firestore/Source/Model/FSTFieldValue.mm
@@ -23,6 +23,7 @@
 #import "FIRTimestamp.h"
 
 #import "Firestore/Source/API/FIRGeoPoint+Internal.h"
+#import "Firestore/Source/API/converters.h"
 #import "Firestore/Source/Model/FSTDocumentKey.h"
 #import "Firestore/Source/Util/FSTClasses.h"
 
@@ -34,7 +35,7 @@
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 
 namespace util = firebase::firestore::util;
-using firebase::firestore::GeoPoint;
+using firebase::firestore::api::MakeFIRGeoPoint;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::FieldMask;
 using firebase::firestore::model::FieldPath;
@@ -751,10 +752,8 @@ static const NSComparator StringComparator = ^NSComparisonResult(NSString *left,
     case FieldValue::Type::Blob:
     case FieldValue::Type::Reference:
       HARD_FAIL("TODO(rsgowman): implement");
-    case FieldValue::Type::GeoPoint: {
-      GeoPoint value = self.internalValue.geo_point_value();
-      return [[FIRGeoPoint alloc] initWithLatitude:value.latitude() longitude:value.longitude()];
-    }
+    case FieldValue::Type::GeoPoint:
+      return MakeFIRGeoPoint(self.internalValue.geo_point_value());
     case FieldValue::Type::Array:
     case FieldValue::Type::Object:
       HARD_FAIL("TODO(rsgowman): implement");


### PR DESCRIPTION
... based on things learned porting Timestamps.

There's no good way to include conversions equivalent to toGeoPoint in
FIRTimestamp, so pull out separate conversion functions that match other
similar things.

Also clean up leftover references to `FIRGeoPoint` internally.