### PR TITLE
Add Sign in with apple with experimental

### DIFF
--- a/Firebase/Auth/Source/AuthProvider/Apple/FIRAppleAuthCredential.h
+++ b/Firebase/Auth/Source/AuthProvider/Apple/FIRAppleAuthCredential.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <AuthenticationServices/AuthenticationServices.h>
+#import "FIRAuthCredential_Internal.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** @class FIRAppleAuthCredential
+ @brief Internal implementation of FIRAuthCredential for Apple credentials.
+ */
+@interface FIRAppleAuthCredential : FIRAuthCredential <NSSecureCoding>
+
+@property(nonatomic, readonly) NSString* user;
+
+@property(nonatomic, readonly) NSString* password;
+
+/** @fn initWithAuthorizationCredential:
+ @brief Designated initializer.
+ @param appleIDCredential The Apple ID Credential.
+ */
+- (nullable instancetype)initWithAuthorizationCredential:(ASAuthorizationAppleIDCredential *)appleIDCredential NS_DESIGNATED_INITIALIZER API_AVAILABLE(ios(13.0));
+
+/** @fn initWithPasswordCredential:
+ @brief Designated initializer.
+ @param passwordCredential The Apple ID Credential.
+ */
+- (nullable instancetype)initWithPasswordCredential:(ASPasswordCredential *)passwordCredential NS_DESIGNATED_INITIALIZER API_AVAILABLE(ios(12.0));
+
+- (nullable instancetype)initWithUser:(NSString *)user password:(NSString *)password NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Firebase/Auth/Source/AuthProvider/Apple/FIRAppleAuthCredential.h
+++ b/Firebase/Auth/Source/AuthProvider/Apple/FIRAppleAuthCredential.h
@@ -27,6 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, readonly) NSString* user;
 
+@property(nonatomic, readonly) NSString* identityToken;
+
 @property(nonatomic, readonly) NSString* password;
 
 /** @fn initWithAuthorizationCredential:
@@ -41,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable instancetype)initWithPasswordCredential:(ASPasswordCredential *)passwordCredential NS_DESIGNATED_INITIALIZER API_AVAILABLE(ios(12.0));
 
-- (nullable instancetype)initWithUser:(NSString *)user password:(NSString *)password NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithUser:(NSString *)user identityToken:(NSData *)identityToken NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/Firebase/Auth/Source/AuthProvider/Apple/FIRAppleAuthCredential.m
+++ b/Firebase/Auth/Source/AuthProvider/Apple/FIRAppleAuthCredential.m
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRAppleAuthCredential.h"
+
+#import "FIRAppleAuthProvider.h"
+#import "FIRAuthExceptionUtils.h"
+#import "FIRVerifyAssertionRequest.h"
+#import <AuthenticationServices/AuthenticationServices.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FIRAppleAuthCredential ()
+
+- (nullable instancetype)initWithProvider:(NSString *)provider NS_UNAVAILABLE;
+
+@end
+
+@implementation FIRAppleAuthCredential
+
+- (nullable instancetype)initWithProvider:(NSString *)provider {
+  [FIRAuthExceptionUtils raiseMethodNotImplementedExceptionWithReason:
+   @"Please call the designated initializer."];
+  return nil;
+}
+
+- (nullable instancetype)initWithAuthorizationCredential:(ASAuthorizationAppleIDCredential *)appleIDCredential {
+  self = [super initWithProvider:FIRAppleAuthProviderID];
+  if (self) {
+    _user = [[appleIDCredential user]copy];
+  }
+  return self;
+}
+
+- (nullable instancetype)initWithPasswordCredential: (ASPasswordCredential *)passwordCredential {
+  self = [super initWithProvider: FIRAppleAuthProviderID];
+  if (self) {
+    _password = [[passwordCredential password] copy];
+  }
+  return self;
+}
+
+- (nullable instancetype)initWithUser:(NSString *)user password:(NSString *)password {
+  self = [super initWithProvider: FIRAppleAuthProviderID];
+  if (self) {
+    _user = [user copy];
+    _password = [password copy];
+  }
+  return self;
+}
+
+- (void)prepareVerifyAssertionRequest:(FIRVerifyAssertionRequest *)request {
+  request.providerAccessToken = _user;
+}
+
+#pragma mark - NSSecureCoding
+
++ (BOOL)supportsSecureCoding {
+  return YES;
+}
+
+- (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
+  NSString *user = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"user"];
+  NSString *password = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"password"];
+  self = [self initWithUser:user password:password];
+  return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+  [aCoder encodeObject:self.user forKey:@"user"];
+  [aCoder encodeObject:self.password forKey: @"password"];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Firebase/Auth/Source/AuthProvider/Apple/FIRAppleAuthCredential.m
+++ b/Firebase/Auth/Source/AuthProvider/Apple/FIRAppleAuthCredential.m
@@ -41,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
   self = [super initWithProvider:FIRAppleAuthProviderID];
   if (self) {
     _user = [[appleIDCredential user]copy];
+    _identityToken = [[appleIDCredential identityToken] base64EncodedStringWithOptions: nil]
   }
   return self;
 }
@@ -48,22 +49,23 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable instancetype)initWithPasswordCredential: (ASPasswordCredential *)passwordCredential {
   self = [super initWithProvider: FIRAppleAuthProviderID];
   if (self) {
+    _user = [[passwordCredential user] copy];
     _password = [[passwordCredential password] copy];
   }
   return self;
 }
 
-- (nullable instancetype)initWithUser:(NSString *)user password:(NSString *)password {
+- (nullable instancetype)initWithUser:(NSString *)user identityToken:(NSString *)identityToken {
   self = [super initWithProvider: FIRAppleAuthProviderID];
   if (self) {
     _user = [user copy];
-    _password = [password copy];
+    _identityToken = [identityToken copy];
   }
   return self;
 }
 
 - (void)prepareVerifyAssertionRequest:(FIRVerifyAssertionRequest *)request {
-  request.providerAccessToken = _user;
+  request.providerAccessToken = _identityToken;
 }
 
 #pragma mark - NSSecureCoding
@@ -74,14 +76,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {
   NSString *user = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"user"];
-  NSString *password = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"password"];
-  self = [self initWithUser:user password:password];
+  NSString *identityToken = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"identityToken"];
+  self = [self initWithUser:user identityToken:identityToken];
   return self;
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
   [aCoder encodeObject:self.user forKey:@"user"];
-  [aCoder encodeObject:self.password forKey: @"password"];
+  [aCoder encodeObject:self.identityToken forKey: @"identityToken"];
 }
 
 @end

--- a/Firebase/Auth/Source/AuthProvider/Apple/FIRAppleAuthProvider.h
+++ b/Firebase/Auth/Source/AuthProvider/Apple/FIRAppleAuthProvider.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <AuthenticationServices/AuthenticationServices.h>
+
+@class FIRAuthCredential;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ @brief A string constant identifying the Apple identity provider.
+ */
+extern NSString *const FIRAppleAuthProviderID NS_SWIFT_NAME(AppleAuthProviderID);
+
+/**
+ @brief A string constant identifying the Apple sign-in method.
+ */
+extern NSString *const _Nonnull FIRAppleAuthSignInMethod NS_SWIFT_NAME(AppleAuthSignInMethod);
+
+
+/** @class FIRAppleAuthProvider
+ @brief Utility class for constructing Apple credentials.
+ */
+NS_SWIFT_NAME(AppleAuthProvider)
+@interface FIRAppleAuthProvider : NSObject
+
+/** @fn credentialWithAppleIDCredential:
+ @brief Creates an `FIRAuthCredential` for a Apple sign in.
+ 
+ @param credential The Apple OAuth access token.
+ @return A FIRAuthCredential containing the Apple credential.
+ */
++ (FIRAuthCredential *)credentialWithAppleIDCredential:(ASAuthorizationAppleIDCredential *)credential API_AVAILABLE(ios(13.0));
+
+/** @fn credentialWithPasswordCredential:
+ @brief Creates an `FIRAuthCredential` for a Apple sign in with password.
+ 
+ @param credential The Apple OAuth access token.
+ @return A FIRAuthCredential containing the Apple credential.
+ */
++ (FIRAuthCredential *)credentialWithPasswordCredential: (ASPasswordCredential *)credential API_AVAILABLE(ios(12.0));
+
+/** @fn init
+ @brief This class is not meant to be initialized.
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Firebase/Auth/Source/AuthProvider/Apple/FIRAppleAuthProvider.h
+++ b/Firebase/Auth/Source/AuthProvider/Apple/FIRAppleAuthProvider.h
@@ -40,7 +40,6 @@ NS_SWIFT_NAME(AppleAuthProvider)
 
 /** @fn credentialWithAppleIDCredential:
  @brief Creates an `FIRAuthCredential` for a Apple sign in.
- 
  @param credential The Apple OAuth access token.
  @return A FIRAuthCredential containing the Apple credential.
  */
@@ -48,7 +47,6 @@ NS_SWIFT_NAME(AppleAuthProvider)
 
 /** @fn credentialWithPasswordCredential:
  @brief Creates an `FIRAuthCredential` for a Apple sign in with password.
- 
  @param credential The Apple OAuth access token.
  @return A FIRAuthCredential containing the Apple credential.
  */

--- a/Firebase/Auth/Source/AuthProvider/Apple/FIRAppleAuthProvider.m
+++ b/Firebase/Auth/Source/AuthProvider/Apple/FIRAppleAuthProvider.m
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRAppleAuthProvider.h"
+
+#import "FIRAppleAuthCredential.h"
+#import "FIRAuthExceptionUtils.h"
+
+// FIRAppleAuthProviderID is defined in FIRAuthProvider.m.
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation FIRAppleAuthProvider
+
+- (instancetype)init {
+  [FIRAuthExceptionUtils raiseMethodNotImplementedExceptionWithReason:
+   @"This class is not meant to be initialized."];
+  return nil;
+}
+
++ (FIRAuthCredential *)credentialWithAppleIDCredential:(ASAuthorizationAppleIDCredential *)credential API_AVAILABLE(ios(13.0)){
+  return [[FIRAppleAuthCredential alloc] initWithAuthorizationCredential:credential];
+}
+
++ (FIRAuthCredential *)credentialWithPasswordCredential: (ASPasswordCredential *)credential  API_AVAILABLE(ios(12.0)) {
+  return [[FIRAppleAuthCredential alloc] initWithPasswordCredential: credential];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Firebase/Auth/Source/AuthProvider/FIRAuthProvider.m
+++ b/Firebase/Auth/Source/AuthProvider/FIRAuthProvider.m
@@ -45,6 +45,9 @@ NSString *const FIRYahooAuthProviderID = @"yahoo.com";
 // Declared 'extern' in FIROAuthProvider.h
 NSString *const FIRMicrosoftAuthProviderID = @"hotmail.com";
 
+// Declared 'extern' in FIROAuthProvider.h
+NSString *const FIRAppleAuthProviderID = @"apple.com";
+
 #pragma mark - sign-in methods constants
 
 // Declared 'extern' in FIRGoogleAuthProvider.h


### PR DESCRIPTION

### Discussion

  As announcement from WWDC, we need to implement signing in with Apple.

  https://github.com/firebase/firebase-ios-sdk/issues/3145

  This is experimental since still beta-1 releasing.

### API Changes

  No effect for existing APIs.

### Note

  Since Swift runtime API has introduced from iOS 13, I think you need to rewrite with Swift to adopt Swift packages. Do you have any plan to do that?