### PR TITLE
Disable warnings in the Abseil build

### DIFF
--- a/Firestore/third_party/abseil-cpp/absl/copts/GENERATED_AbseilCopts.cmake
+++ b/Firestore/third_party/abseil-cpp/absl/copts/GENERATED_AbseilCopts.cmake
@@ -52,6 +52,10 @@ list(APPEND ABSL_CLANG_CL_FLAGS
     "-Wobjc-literal-conversion"
     "-Wno-sign-conversion"
     "-Wstring-conversion"
+    "-Wno-shadow"
+    "-Wno-unused-member-function"
+    "-Wno-tautological-type-limit-compare"
+    "-Wno-unused-template"
     "/DNOMINMAX"
     "/DWIN32_LEAN_AND_MEAN"
     "/D_CRT_SECURE_NO_WARNINGS"
@@ -160,6 +164,10 @@ list(APPEND ABSL_LLVM_FLAGS
     "-Wobjc-literal-conversion"
     "-Wno-sign-conversion"
     "-Wstring-conversion"
+    "-Wno-shadow"
+    "-Wno-unused-member-function"
+    "-Wno-tautological-type-limit-compare"
+    "-Wno-unused-template"
 )
 
 list(APPEND ABSL_LLVM_TEST_FLAGS

--- a/Firestore/third_party/abseil-cpp/absl/copts/GENERATED_copts.bzl
+++ b/Firestore/third_party/abseil-cpp/absl/copts/GENERATED_copts.bzl
@@ -53,6 +53,10 @@ ABSL_CLANG_CL_FLAGS = [
     "-Wobjc-literal-conversion",
     "-Wno-sign-conversion",
     "-Wstring-conversion",
+    "-Wno-shadow",
+    "-Wno-unused-member-function",
+    "-Wno-tautological-type-limit-compare",
+    "-Wno-unused-template",
     "/DNOMINMAX",
     "/DWIN32_LEAN_AND_MEAN",
     "/D_CRT_SECURE_NO_WARNINGS",
@@ -161,6 +165,10 @@ ABSL_LLVM_FLAGS = [
     "-Wobjc-literal-conversion",
     "-Wno-sign-conversion",
     "-Wstring-conversion",
+    "-Wno-shadow",
+    "-Wno-unused-member-function",
+    "-Wno-tautological-type-limit-compare",
+    "-Wno-unused-template",
 ]
 
 ABSL_LLVM_TEST_FLAGS = [

--- a/Firestore/third_party/abseil-cpp/absl/copts/copts.py
+++ b/Firestore/third_party/abseil-cpp/absl/copts/copts.py
@@ -84,6 +84,12 @@ LLVM_DISABLE_WARNINGS_FLAGS = [
     "-Wobjc-literal-conversion",
     "-Wno-sign-conversion",
     "-Wstring-conversion",
+
+    # Additional flags added to make Firestore builds warning-clean
+    "-Wno-shadow",
+    "-Wno-unused-member-function",
+    "-Wno-tautological-type-limit-compare",
+    "-Wno-unused-template",
 ]
 
 LLVM_TEST_DISABLE_WARNINGS_FLAGS = [


### PR DESCRIPTION
These warnings are issued when building the `absl_time` library.

Note that `copts.py` is the master file, the rest are generated.

Note that the equivalent warnings don't apply in the Xcode build: we were already building absl_time there and the warnings are looser in our podspec anyway.