### PR TITLE
Disable CocoaPods CDN in pod installs (#3165)

### DIFF
--- a/Example/Auth/AuthSample/Podfile
+++ b/Example/Auth/AuthSample/Podfile
@@ -3,7 +3,8 @@
 #source 'https://github.com/CocoaPods/Specs.git'
 
 # Comment the following line to use the CocoaPods master repo instead.
-source 'https://cdn.jsdelivr.net/cocoa/'
+# Disabled. See https://github.com/firebase/firebase-ios-sdk/issues/3165
+# source 'https://cdn.jsdelivr.net/cocoa/'
 
 use_frameworks!
 

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,7 +3,8 @@
 #source 'https://github.com/CocoaPods/Specs.git'
 
 # Comment the following line to use the CocoaPods master repo instead.
-source 'https://cdn.jsdelivr.net/cocoa/'
+# Disabled. See https://github.com/firebase/firebase-ios-sdk/issues/3165
+# source 'https://cdn.jsdelivr.net/cocoa/'
 
 use_frameworks!
 

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -3,7 +3,8 @@
 #source 'https://github.com/CocoaPods/Specs.git'
 
 # Comment the following line to use the CocoaPods master repo instead.
-source 'https://cdn.jsdelivr.net/cocoa/'
+# Disabled. See https://github.com/firebase/firebase-ios-sdk/issues/3165
+# source 'https://cdn.jsdelivr.net/cocoa/'
 
 use_frameworks!
 

--- a/InAppMessaging/Example/Podfile
+++ b/InAppMessaging/Example/Podfile
@@ -1,7 +1,8 @@
 use_frameworks!
 
 # Comment the following line to use the CocoaPods master repo instead.
-source 'https://cdn.jsdelivr.net/cocoa/'
+# Disabled. See https://github.com/firebase/firebase-ios-sdk/issues/3165
+# source 'https://cdn.jsdelivr.net/cocoa/'
 
 pod 'FirebaseAnalytics'
 pod 'FirebaseCore', :path => '../..'

--- a/InAppMessagingDisplay/Example/Podfile
+++ b/InAppMessagingDisplay/Example/Podfile
@@ -1,5 +1,6 @@
 # Comment the following line to use the CocoaPods master repo instead.
-source 'https://cdn.jsdelivr.net/cocoa/'
+# Disabled. See https://github.com/firebase/firebase-ios-sdk/issues/3165
+# source 'https://cdn.jsdelivr.net/cocoa/'
 
 use_frameworks!
 

--- a/SymbolCollisionTest/Podfile
+++ b/SymbolCollisionTest/Podfile
@@ -2,7 +2,8 @@
 # platform :ios, '9.0'
 
 # Comment the following line to use the CocoaPods master repo instead.
-source 'https://cdn.jsdelivr.net/cocoa/'
+# Disabled. See https://github.com/firebase/firebase-ios-sdk/issues/3165
+# source 'https://cdn.jsdelivr.net/cocoa/'
 
 target 'SymbolCollisionTest' do
   # Uncomment the next line if you're using Swift or would like to use dynamic frameworks

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -48,7 +48,9 @@ function install_secrets() {
 
 function pod_gen() {
   # Call pod gen with a podspec and additonal optional arguments.
-  bundle exec pod gen --local-sources=./ --sources=https://cdn.jsdelivr.net/cocoa/ "$@"
+  # Disabled CDN. See https://github.com/firebase/firebase-ios-sdk/issues/3165
+  # bundle exec pod gen --local-sources=./ --sources=https://cdn.jsdelivr.net/cocoa/ "$@"
+  bundle exec pod gen --local-sources=./ "$@"
 }
 
 case "$PROJECT-$PLATFORM-$METHOD" in

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -38,7 +38,9 @@ def main(args)
     exit(1)
   end
 
-  command = %w(bundle exec pod lib lint --sources=https://cdn.jsdelivr.net/cocoa/)
+  # Disabled CDN. See https://github.com/firebase/firebase-ios-sdk/issues/3165
+  # command = %w(bundle exec pod lib lint --sources=https://cdn.jsdelivr.net/cocoa/)
+  command = %w(bundle exec pod lib lint)
 
   # Figure out which dependencies are local
   podspec_file = args[0]
@@ -48,6 +50,7 @@ def main(args)
 
   command.push(*args)
   puts command.join(' ')
+  exec('bundle exec pod repo update')
   exec(*command)
 end
 


### PR DESCRIPTION
Disables CocoaPods CDN. Context:

https://github.com/firebase/firebase-ios-sdk/issues/3165
https://github.com/firebase/firebase-ios-sdk/commit/52e42c0fe77fab956603a3159a626bee5506af9b