### PR TITLE
Upgrade to Firestore Emulator 1.5.0

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
@@ -147,8 +147,6 @@ using firebase::firestore::util::TimerId;
 }
 
 - (void)testCanMergeDataWithAnExistingDocumentUsingSet {
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;  // b/112104025
-
   FIRDocumentReference *doc = [[self.db collectionWithPath:@"rooms"] documentWithAutoID];
 
   NSDictionary<NSString *, id> *initialData =
@@ -1039,8 +1037,6 @@ using firebase::firestore::util::TimerId;
 }
 
 - (void)testUpdateFieldsWithDots {
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;  // b/112104025
-
   FIRDocumentReference *doc = [self documentRef];
 
   [self writeDocumentRef:doc data:@{@"a.b" : @"old", @"c.d" : @"old"}];

--- a/Firestore/Example/Tests/Integration/API/FIRFieldsTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRFieldsTests.mm
@@ -157,8 +157,6 @@ NSDictionary<NSString *, id> *testDataWithTimestamps(FIRTimestamp *timestamp) {
 }
 
 - (void)testFieldsWithSpecialCharsCanBeUpdated {
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;  // b/112104025
-
   NSDictionary<NSString *, id> *testData = [self testDottedDataNumbered:1];
 
   FIRDocumentReference *doc = [self documentRef];
@@ -174,8 +172,6 @@ NSDictionary<NSString *, id> *testDataWithTimestamps(FIRTimestamp *timestamp) {
 }
 
 - (void)testFieldsWithSpecialCharsCanBeUsedInQueryFilters {
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;  // b/112104025
-
   NSDictionary<NSString *, NSDictionary<NSString *, id> *> *testDocs = @{
     @"1" : [self testDottedDataNumbered:300],
     @"2" : [self testDottedDataNumbered:100],
@@ -200,8 +196,6 @@ NSDictionary<NSString *, id> *testDataWithTimestamps(FIRTimestamp *timestamp) {
 }
 
 - (void)testFieldsWithSpecialCharsCanBeUsedInOrderBy {
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;  // b/112104025
-
   NSDictionary<NSString *, NSDictionary<NSString *, id> *> *testDocs = @{
     @"1" : [self testDottedDataNumbered:300],
     @"2" : [self testDottedDataNumbered:100],

--- a/Firestore/Example/Tests/Integration/API/FIRValidationTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRValidationTests.mm
@@ -169,8 +169,6 @@
 }
 
 - (void)testWritesWithIndirectlyNestedArraysSucceed {
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;
-
   NSDictionary<NSString *, id> *data = @{@"nested-array" : @[ @1, @{@"foo" : @[ @2 ]} ]};
 
   FIRDocumentReference *ref = [self documentRef];

--- a/Firestore/Example/Tests/Integration/API/FIRWriteBatchTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRWriteBatchTests.mm
@@ -134,8 +134,6 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)testUpdateFieldsWithDots {
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;  // b/112104025
-
   FIRDocumentReference *doc = [self documentRef];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"testUpdateFieldsWithDots"];
@@ -327,8 +325,6 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)testCanWriteVeryLargeBatches {
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;
-
   // On Android, SQLite Cursors are limited reading no more than 2 MB per row (despite being able
   // to write very large values). This test verifies that the local MutationQueue is not subject
   // to this limitation.

--- a/Firestore/Example/Tests/Integration/FSTTransactionTests.mm
+++ b/Firestore/Example/Tests/Integration/FSTTransactionTests.mm
@@ -480,8 +480,6 @@
 }
 
 - (void)testUpdateFieldsWithDotsTransactionally {
-  if ([FSTIntegrationTestCase isRunningAgainstEmulator]) return;  // b/112104025
-
   FIRDocumentReference *doc = [self documentRef];
 
   XCTestExpectation *expectation =

--- a/scripts/run_firestore_emulator.sh
+++ b/scripts/run_firestore_emulator.sh
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-VERSION='1.4.6'
+VERSION='1.5.0'
 FILENAME="cloud-firestore-emulator-v${VERSION}.jar"
 URL="https://storage.googleapis.com/firebase-preview-drop/emulator/${FILENAME}"
 


### PR DESCRIPTION
This includes fixes for:

  * All the field escaping tests
  * `testCanWriteVeryLargeBatches`
  * `testWritesWithIndirectlyNestedArraysSucceed`

All tests now pass. I've left isRunningAgainstEmulator in the source
even though there are now no callers.

@ryanpbrewster FYI