### PR TITLE
Migrate FSTServerTimestampValue to FSTDelegateValue

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -25,7 +25,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.prefix_header_file = false
 
   s.source_files = [
-    'Firestore/Source/**/*',
+    'Firestore/Source/**/*.{h,m,mm}',
     'Firestore/Protos/nanopb/**/*.{h,cc}',
     'Firestore/Protos/objc/**/*.[hm]',
     'Firestore/core/include/**/*.{h,cc,mm}',

--- a/Firestore/CMakeLists.txt
+++ b/Firestore/CMakeLists.txt
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 add_subdirectory(Example/Benchmarks)
+add_subdirectory(Source)
+add_subdirectory(third_party/Immutable)
+
 add_subdirectory(Protos)
 add_subdirectory(core)
 add_subdirectory(fuzzing)

--- a/Firestore/Example/Tests/Model/FSTFieldValueTests.mm
+++ b/Firestore/Example/Tests/Model/FSTFieldValueTests.mm
@@ -51,13 +51,12 @@ NSArray *FSTWrapGroups(NSArray *groups) {
       // Server Timestamp values can't be parsed directly, so we have a couple predefined sentinel
       // strings that can be used instead.
       if ([value isEqual:@"server-timestamp-1"]) {
-        wrappedValue = [FSTServerTimestampValue
-            serverTimestampValueWithLocalWriteTime:testutil::MakeTimestamp(2016, 5, 20, 10, 20, 0)
-                                     previousValue:nil];
+        wrappedValue =
+            FieldValue::FromServerTimestamp(testutil::MakeTimestamp(2016, 5, 20, 10, 20, 0)).Wrap();
       } else if ([value isEqual:@"server-timestamp-2"]) {
-        wrappedValue = [FSTServerTimestampValue
-            serverTimestampValueWithLocalWriteTime:testutil::MakeTimestamp(2016, 10, 21, 15, 32, 0)
-                                     previousValue:nil];
+        wrappedValue =
+            FieldValue::FromServerTimestamp(testutil::MakeTimestamp(2016, 10, 21, 15, 32, 0))
+                .Wrap();
       } else if ([value isKindOfClass:[FSTDocumentKeyReference class]]) {
         // We directly convert these here so that the databaseIDs can be different.
         FSTDocumentKeyReference *reference = (FSTDocumentKeyReference *)value;
@@ -311,13 +310,10 @@ union DoubleBits {
     @[ FSTTestFieldValue(date2) ],
     @[
       // NOTE: ServerTimestampValues can't be parsed via FSTTestFieldValue().
-      [FSTServerTimestampValue serverTimestampValueWithLocalWriteTime:MakeTimestamp(date1)
-                                                        previousValue:nil],
-      [FSTServerTimestampValue serverTimestampValueWithLocalWriteTime:MakeTimestamp(date1)
-                                                        previousValue:nil]
+      FieldValue::FromServerTimestamp(MakeTimestamp(date1)).Wrap(),
+      FieldValue::FromServerTimestamp(MakeTimestamp(date1)).Wrap()
     ],
-    @[ [FSTServerTimestampValue serverTimestampValueWithLocalWriteTime:MakeTimestamp(date2)
-                                                         previousValue:nil] ],
+    @[ FieldValue::FromServerTimestamp(MakeTimestamp(date2)).Wrap() ],
     @[ FSTTestFieldValue(FSTTestGeoPoint(0, 1)), FieldValue::FromGeoPoint(GeoPoint(0, 1)).Wrap() ],
     @[ FSTTestFieldValue(FSTTestGeoPoint(1, 0)) ],
     @[

--- a/Firestore/Example/Tests/Model/FSTMutationTests.mm
+++ b/Firestore/Example/Tests/Model/FSTMutationTests.mm
@@ -144,9 +144,7 @@ using firebase::firestore::model::TransformOperation;
   FSTObjectValue *expectedData =
       FSTTestObjectValue(@{@"foo" : @{@"bar" : @"<server-timestamp>"}, @"baz" : @"baz-value"});
   expectedData =
-      [expectedData objectBySettingValue:[FSTServerTimestampValue
-                                             serverTimestampValueWithLocalWriteTime:_timestamp
-                                                                      previousValue:nil]
+      [expectedData objectBySettingValue:FieldValue::FromServerTimestamp(_timestamp).Wrap()
                                  forPath:testutil::Field("foo.bar")];
 
   FSTDocument *expectedDoc = [FSTDocument documentWithData:expectedData

--- a/Firestore/Source/API/CMakeLists.txt
+++ b/Firestore/Source/API/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018 Google
+# Copyright 2019 Google
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,26 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Public types to be used both internally and externally.
 cc_library(
-  firebase_firestore_core
+  firebase_firestore_objc_api
   SOURCES
-    database_info.cc
-    database_info.h
-    direction.cc
-    direction.h
-    filter.cc
-    filter.h
-    listen_options.h
-    target_id_generator.cc
-    target_id_generator.h
-    query.cc
-    query.h
-    relation_filter.cc
-    relation_filter.h
-    user_data.h
-    user_data.mm
+    FIRGeoPoint+Internal.h
+    FIRGeoPoint.mm
+    FIRTimestamp.m
+    FIRTimestamp+Internal.h
+    converters.h
+    converters.mm
   DEPENDS
-    absl_strings
-    firebase_firestore_model
-    firebase_firestore_objc
+    firebase_firestore_api
+    firebase_firestore_util
+)
+
+target_include_directories(
+  firebase_firestore_objc_api
+  PUBLIC ${PROJECT_SOURCE_DIR}/Firestore/Source/Public
+)
+
+target_compile_options(
+  firebase_firestore_objc_api PRIVATE
+  -Wno-unused-parameter
 )

--- a/Firestore/Source/API/CMakeLists.txt
+++ b/Firestore/Source/API/CMakeLists.txt
@@ -13,26 +13,28 @@
 # limitations under the License.
 
 # Public types to be used both internally and externally.
-cc_library(
-  firebase_firestore_objc_api
-  SOURCES
-    FIRGeoPoint+Internal.h
-    FIRGeoPoint.mm
-    FIRTimestamp.m
-    FIRTimestamp+Internal.h
-    converters.h
-    converters.mm
-  DEPENDS
-    firebase_firestore_api
-    firebase_firestore_util
-)
+if(APPLE)
+  cc_library(
+    firebase_firestore_objc_api
+    SOURCES
+      FIRGeoPoint+Internal.h
+      FIRGeoPoint.mm
+      FIRTimestamp.m
+      FIRTimestamp+Internal.h
+      converters.h
+      converters.mm
+    DEPENDS
+      firebase_firestore_api
+      firebase_firestore_util
+  )
 
-target_include_directories(
-  firebase_firestore_objc_api
-  PUBLIC ${PROJECT_SOURCE_DIR}/Firestore/Source/Public
-)
+  target_include_directories(
+    firebase_firestore_objc_api
+    PUBLIC ${PROJECT_SOURCE_DIR}/Firestore/Source/Public
+  )
 
-target_compile_options(
-  firebase_firestore_objc_api PRIVATE
-  -Wno-unused-parameter
-)
+  target_compile_options(
+    firebase_firestore_objc_api PRIVATE
+    -Wno-unused-parameter
+  )
+endif()

--- a/Firestore/Source/API/FIRFieldPath.mm
+++ b/Firestore/Source/API/FIRFieldPath.mm
@@ -48,13 +48,13 @@ NS_ASSUME_NONNULL_BEGIN
     ThrowInvalidArgument("Invalid field path. Provided names must not be empty.");
   }
 
-  std::vector<std::string> field_names;
-  field_names.reserve(fieldNames.count);
-  for (int i = 0; i < fieldNames.count; ++i) {
-    field_names.emplace_back(util::MakeString(fieldNames[i]));
+  std::vector<std::string> converted;
+  converted.reserve(fieldNames.count);
+  for (NSString *fieldName in fieldNames) {
+    converted.emplace_back(util::MakeString(fieldName));
   }
 
-  return [self initPrivate:FieldPath::FromSegments(std::move(field_names))];
+  return [self initPrivate:FieldPath::FromSegments(std::move(converted))];
 }
 
 + (instancetype)documentID {

--- a/Firestore/Source/API/FIRFieldValue.mm
+++ b/Firestore/Source/API/FIRFieldValue.mm
@@ -130,8 +130,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation FSTNumericIncrementFieldValue
-- (instancetype)initWithOperand:(NSNumber *)operand;
-{
+- (instancetype)initWithOperand:(NSNumber *)operand {
   if (self = [super initPrivate]) {
     _operand = operand;
   }

--- a/Firestore/Source/CMakeLists.txt
+++ b/Firestore/Source/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018 Google
+# Copyright 2019 Google
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,26 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cc_library(
-  firebase_firestore_core
-  SOURCES
-    database_info.cc
-    database_info.h
-    direction.cc
-    direction.h
-    filter.cc
-    filter.h
-    listen_options.h
-    target_id_generator.cc
-    target_id_generator.h
-    query.cc
-    query.h
-    relation_filter.cc
-    relation_filter.h
-    user_data.h
-    user_data.mm
-  DEPENDS
-    absl_strings
-    firebase_firestore_model
-    firebase_firestore_objc
-)
+add_subdirectory(API)
+add_subdirectory(Model)

--- a/Firestore/Source/Model/CMakeLists.txt
+++ b/Firestore/Source/Model/CMakeLists.txt
@@ -13,27 +13,29 @@
 # limitations under the License.
 
 # Public types to be used both internally and externally.
-cc_library(
-  firebase_firestore_objc_model
-  SOURCES
-    FSTDocument.h
-    FSTDocument.mm
-    FSTDocumentKey.h
-    FSTDocumentKey.mm
-    FSTFieldValue.h
-    FSTFieldValue.mm
-    FSTMutation.h
-    FSTMutation.mm
-    FSTMutationBatch.h
-    FSTMutationBatch.mm
-  DEPENDS
-    firebase_firestore_model
-    firebase_firestore_objc_api
-    firebase_firestore_objc_immutable
-    firebase_firestore_util
-)
+if(APPLE)
+  cc_library(
+    firebase_firestore_objc_model
+    SOURCES
+      FSTDocument.h
+      FSTDocument.mm
+      FSTDocumentKey.h
+      FSTDocumentKey.mm
+      FSTFieldValue.h
+      FSTFieldValue.mm
+      FSTMutation.h
+      FSTMutation.mm
+      FSTMutationBatch.h
+      FSTMutationBatch.mm
+    DEPENDS
+      firebase_firestore_model
+      firebase_firestore_objc_api
+      firebase_firestore_objc_immutable
+      firebase_firestore_util
+  )
 
-target_compile_options(
-  firebase_firestore_objc_model PRIVATE
-  -Wno-unused-parameter
-)
+  target_compile_options(
+    firebase_firestore_objc_model PRIVATE
+    -Wno-unused-parameter
+  )
+endif()

--- a/Firestore/Source/Model/CMakeLists.txt
+++ b/Firestore/Source/Model/CMakeLists.txt
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Public types to be used both internally and externally.
 if(APPLE)
   cc_library(
     firebase_firestore_objc_model

--- a/Firestore/Source/Model/CMakeLists.txt
+++ b/Firestore/Source/Model/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2018 Google
+# Copyright 2019 Google
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,26 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Public types to be used both internally and externally.
 cc_library(
-  firebase_firestore_core
+  firebase_firestore_objc_model
   SOURCES
-    database_info.cc
-    database_info.h
-    direction.cc
-    direction.h
-    filter.cc
-    filter.h
-    listen_options.h
-    target_id_generator.cc
-    target_id_generator.h
-    query.cc
-    query.h
-    relation_filter.cc
-    relation_filter.h
-    user_data.h
-    user_data.mm
+    FSTDocument.h
+    FSTDocument.mm
+    FSTDocumentKey.h
+    FSTDocumentKey.mm
+    FSTFieldValue.h
+    FSTFieldValue.mm
+    FSTMutation.h
+    FSTMutation.mm
+    FSTMutationBatch.h
+    FSTMutationBatch.mm
   DEPENDS
-    absl_strings
     firebase_firestore_model
-    firebase_firestore_objc
+    firebase_firestore_objc_api
+    firebase_firestore_objc_immutable
+    firebase_firestore_util
+)
+
+target_compile_options(
+  firebase_firestore_objc_model PRIVATE
+  -Wno-unused-parameter
 )

--- a/Firestore/Source/Model/FSTDocumentKey.mm
+++ b/Firestore/Source/Model/FSTDocumentKey.mm
@@ -19,8 +19,6 @@
 #include <string>
 #include <utility>
 
-#import "Firestore/Source/Core/FSTFirestoreClient.h"
-
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 #include "Firestore/core/src/firebase/firestore/util/hashing.h"

--- a/Firestore/Source/Model/FSTFieldValue.h
+++ b/Firestore/Source/Model/FSTFieldValue.h
@@ -104,27 +104,6 @@ typedef NS_ENUM(NSInteger, FSTTypeOrder) {
 @end
 
 /**
- * Represents a locally-applied Server Timestamp.
- *
- * Notes:
- * - FSTServerTimestampValue instances are created as the result of applying an FSTTransformMutation
- *   (see [FSTTransformMutation applyTo]). They can only exist in the local view of a document.
- *   Therefore they do not need to be parsed or serialized.
- * - When evaluated locally (e.g. via FSTDocumentSnapshot data), they by default evaluate to NSNull.
- *   This behavior can be configured by passing custom FieldValueOptions to `valueWithOptions:`.
- * - They sort after all Timestamp values. With respect to other FSTServerTimestampValues, they
- *   sort by their localWriteTime.
- */
-@interface FSTServerTimestampValue : FSTFieldValue <id>
-+ (instancetype)serverTimestampValueWithLocalWriteTime:(const firebase::Timestamp &)localWriteTime
-                                         previousValue:(nullable FSTFieldValue *)previousValue;
-
-@property(nonatomic, assign, readonly) const firebase::Timestamp &localWriteTime;
-@property(nonatomic, strong, readonly, nullable) FSTFieldValue *previousValue;
-
-@end
-
-/**
  * A reference value stored in Firestore.
  */
 @interface FSTReferenceValue : FSTFieldValue <FSTDocumentKey *>

--- a/Firestore/Source/Model/FSTFieldValue.mm
+++ b/Firestore/Source/Model/FSTFieldValue.mm
@@ -589,7 +589,7 @@ static const NSComparator StringComparator = ^NSComparisonResult(NSString *left,
           return
               [FieldValue::FromTimestamp(sts.local_write_time()).Wrap() valueWithOptions:options];
         case ServerTimestampBehavior::kPrevious:
-          return sts.previous_value() ? [sts.previous_value()->Wrap() valueWithOptions:options]
+          return sts.previous_value() ? [sts.previous_value() valueWithOptions:options]
                                       : [NSNull null];
         default:
           HARD_FAIL("Unexpected server timestamp option: %s", options.server_timestamp_behavior());

--- a/Firestore/Source/Model/FSTFieldValue.mm
+++ b/Firestore/Source/Model/FSTFieldValue.mm
@@ -542,6 +542,8 @@ static const NSComparator StringComparator = ^NSComparisonResult(NSString *left,
 - (id)value {
   switch (self.internalValue.type()) {
     case FieldValue::Type::Null:
+      // NSDictionary disallows storing `nil` values. Use NSNull as an
+      // explicitly existing null value.
       return [NSNull null];
     case FieldValue::Type::Boolean:
       return self.internalValue.boolean_value() ? @YES : @NO;

--- a/Firestore/Source/Model/FSTFieldValue.mm
+++ b/Firestore/Source/Model/FSTFieldValue.mm
@@ -549,11 +549,8 @@ static const NSComparator StringComparator = ^NSComparisonResult(NSString *left,
       return @(self.internalValue.integer_value());
     case FieldValue::Type::Double:
       return @(self.internalValue.double_value());
-    case FieldValue::Type::Timestamp: {
-      auto timestamp = self.internalValue.timestamp_value();
-      return [[FIRTimestamp alloc] initWithSeconds:timestamp.seconds()
-                                       nanoseconds:timestamp.nanoseconds()];
-    }
+    case FieldValue::Type::Timestamp:
+      return MakeFIRTimestamp(self.internalValue.timestamp_value());
     case FieldValue::Type::ServerTimestamp:
       return [NSNull null];
     case FieldValue::Type::String:

--- a/Firestore/Source/Model/FSTMutation.mm
+++ b/Firestore/Source/Model/FSTMutation.mm
@@ -481,7 +481,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param baseDocument The document prior to applying this mutation batch.
  * @param localWriteTime The local time of the transform mutation (used to generate
- * FSTServerTimestampValues).
+ *     ServerTimestampValues).
  * @return The transform results array.
  */
 - (NSArray<FSTFieldValue *> *)

--- a/Firestore/core/src/firebase/firestore/api/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/api/CMakeLists.txt
@@ -51,5 +51,6 @@ cc_library(
     absl_meta
     firebase_firestore_api_input_validation
     firebase_firestore_core
+    firebase_firestore_model
     firebase_firestore_util
 )

--- a/Firestore/core/src/firebase/firestore/model/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/model/CMakeLists.txt
@@ -29,6 +29,7 @@ cc_library(
     field_transform.h
     field_value.cc
     field_value.h
+    field_value.mm
     field_value_options.h
     maybe_document.cc
     maybe_document.h
@@ -56,6 +57,15 @@ cc_library(
     absl_strings
     firebase_firestore_api_input_validation
     firebase_firestore_immutable
+    firebase_firestore_objc
     firebase_firestore_util
     firebase_firestore_types
 )
+
+if(APPLE)
+  target_link_libraries(
+    firebase_firestore_model
+    PRIVATE
+    firebase_firestore_objc_model
+  )
+endif()

--- a/Firestore/core/src/firebase/firestore/model/field_value.cc
+++ b/Firestore/core/src/firebase/firestore/model/field_value.cc
@@ -308,7 +308,7 @@ class ServerTimestampValue : public FieldValue::BaseValue {
     size_t result =
         TimestampInternal::Hash(server_timestamp_.local_write_time());
     if (server_timestamp_.previous_value()) {
-      result = util::Hash(result, *server_timestamp_.previous_value());
+      result = util::Hash(result, server_timestamp_.previous_value());
     }
     return result;
   }
@@ -686,7 +686,7 @@ FieldValue FieldValue::FromTimestamp(const Timestamp& value) {
 }
 
 FieldValue FieldValue::FromServerTimestamp(const Timestamp& local_write_time,
-                                           const FieldValue& previous_value) {
+                                           FSTFieldValue* previous_value) {
   return FieldValue(std::make_shared<ServerTimestampValue>(
       ServerTimestamp(local_write_time, previous_value)));
 }

--- a/Firestore/core/src/firebase/firestore/model/field_value.cc
+++ b/Firestore/core/src/firebase/firestore/model/field_value.cc
@@ -280,7 +280,7 @@ class ServerTimestampValue : public FieldValue::BaseValue {
   }
 
   std::string ToString() const override {
-    std::string time = server_timestamp_.local_write_time().ToString();
+    std::string time = value().local_write_time().ToString();
     return absl::StrCat("ServerTimestamp(local_write_time=", time, ")");
   }
 
@@ -305,10 +305,9 @@ class ServerTimestampValue : public FieldValue::BaseValue {
   }
 
   size_t Hash() const override {
-    size_t result =
-        TimestampInternal::Hash(server_timestamp_.local_write_time());
-    if (server_timestamp_.previous_value()) {
-      result = util::Hash(result, server_timestamp_.previous_value());
+    size_t result = TimestampInternal::Hash(value().local_write_time());
+    if (value().previous_value()) {
+      result = util::Hash(result, value().previous_value());
     }
     return result;
   }

--- a/Firestore/core/src/firebase/firestore/model/field_value.cc
+++ b/Firestore/core/src/firebase/firestore/model/field_value.cc
@@ -42,6 +42,7 @@ namespace model {
 namespace {
 
 using BaseValue = FieldValue::BaseValue;
+using ServerTimestamp = FieldValue::ServerTimestamp;
 using Type = FieldValue::Type;
 
 using nanopb::ByteString;
@@ -253,16 +254,25 @@ class TimestampValue : public BaseValue {
   Timestamp value_;
 };
 
+/**
+ * Represents a locally-applied Server Timestamp.
+ *
+ * Notes:
+ *   - ServerTimestampValue instances are created as the result of applying an
+ *     FSTTransformMutation (see [FSTTransformMutation applyTo]). They can only
+ *     exist in the local view of a document. Therefore they do not need to be
+ *     parsed or serialized.
+ *   - When evaluated locally (e.g. via DocumentSnapshot data), they by default
+ *     evaluate to null.
+ *   - This behavior can be configured by passing custom FieldValueOptions to
+ *     `valueWithOptions:`.
+ *   - They sort after all Timestamp values. With respect to other
+ *     ServerTimestampValues, they sort by their local_write_time.
+ */
 class ServerTimestampValue : public FieldValue::BaseValue {
  public:
-  ServerTimestampValue(Timestamp local_write_time,
-                       absl::optional<FieldValue> previous_value)
-      : local_write_time_(local_write_time),
-        previous_value_(std::move(previous_value)) {
-  }
-
-  explicit ServerTimestampValue(Timestamp local_write_time)
-      : ServerTimestampValue(local_write_time, absl::nullopt) {
+  explicit ServerTimestampValue(ServerTimestamp server_timestamp)
+      : server_timestamp_(server_timestamp) {
   }
 
   Type type() const override {
@@ -270,7 +280,7 @@ class ServerTimestampValue : public FieldValue::BaseValue {
   }
 
   std::string ToString() const override {
-    std::string time = local_write_time_.ToString();
+    std::string time = server_timestamp_.local_write_time().ToString();
     return absl::StrCat("ServerTimestamp(local_write_time=", time, ")");
   }
 
@@ -278,7 +288,7 @@ class ServerTimestampValue : public FieldValue::BaseValue {
     if (type() != other.type()) return false;
 
     auto& other_value = Cast<ServerTimestampValue>(other);
-    return local_write_time_ == other_value.local_write_time_;
+    return value().local_write_time() == other_value.value().local_write_time();
   }
 
   ComparisonResult CompareTo(const BaseValue& other) const override {
@@ -286,24 +296,29 @@ class ServerTimestampValue : public FieldValue::BaseValue {
     if (!util::Same(cmp)) return cmp;
 
     if (other.type() == Type::ServerTimestamp) {
-      return Compare(local_write_time_,
-                     Cast<ServerTimestampValue>(other).local_write_time_);
+      return Compare(
+          value().local_write_time(),
+          Cast<ServerTimestampValue>(other).value().local_write_time());
     } else {
       return ComparisonResult::Descending;
     }
   }
 
   size_t Hash() const override {
-    size_t result = TimestampInternal::Hash(local_write_time_);
-    if (previous_value_) {
-      result = util::Hash(result, *previous_value_);
+    size_t result =
+        TimestampInternal::Hash(server_timestamp_.local_write_time());
+    if (server_timestamp_.previous_value()) {
+      result = util::Hash(result, *server_timestamp_.previous_value());
     }
     return result;
   }
 
+  const ServerTimestamp& value() const {
+    return server_timestamp_;
+  }
+
  private:
-  Timestamp local_write_time_;
-  absl::optional<FieldValue> previous_value_;
+  ServerTimestamp server_timestamp_;
 };
 
 class StringValue : public SimpleFieldValue<Type::String, std::string> {
@@ -519,6 +534,11 @@ Timestamp FieldValue::timestamp_value() const {
   return Cast<TimestampValue>(*rep_).value();
 }
 
+const ServerTimestamp& FieldValue::server_timestamp_value() const {
+  HARD_ASSERT(type() == Type::ServerTimestamp);
+  return Cast<ServerTimestampValue>(*rep_).value();
+}
+
 const std::string& FieldValue::string_value() const {
   HARD_ASSERT(type() == Type::String);
   return Cast<StringValue>(*rep_).value();
@@ -667,12 +687,13 @@ FieldValue FieldValue::FromTimestamp(const Timestamp& value) {
 
 FieldValue FieldValue::FromServerTimestamp(const Timestamp& local_write_time,
                                            const FieldValue& previous_value) {
-  return FieldValue(
-      std::make_shared<ServerTimestampValue>(local_write_time, previous_value));
+  return FieldValue(std::make_shared<ServerTimestampValue>(
+      ServerTimestamp(local_write_time, previous_value)));
 }
 
 FieldValue FieldValue::FromServerTimestamp(const Timestamp& local_write_time) {
-  return FieldValue(std::make_shared<ServerTimestampValue>(local_write_time));
+  return FieldValue(std::make_shared<ServerTimestampValue>(
+      ServerTimestamp(local_write_time)));
 }
 
 FieldValue FieldValue::FromString(const char* value) {

--- a/Firestore/core/src/firebase/firestore/model/field_value.h
+++ b/Firestore/core/src/firebase/firestore/model/field_value.h
@@ -53,6 +53,7 @@ class ObjectValue;
  */
 class FieldValue {
  public:
+  class ServerTimestamp;
   using Array = std::vector<FieldValue>;
   using Map = immutable::SortedMap<std::string, FieldValue>;
 
@@ -85,6 +86,7 @@ class FieldValue {
   FieldValue(ObjectValue object);  // NOLINT(runtime/explicit)
 
 #if __OBJC__
+  FSTFieldValue* Wrap() const&;
   FSTFieldValue* Wrap() &&;
 #endif  // __OBJC__
 
@@ -117,6 +119,8 @@ class FieldValue {
   double double_value() const;
 
   Timestamp timestamp_value() const;
+
+  const ServerTimestamp& server_timestamp_value() const;
 
   const std::string& string_value() const;
 
@@ -287,6 +291,31 @@ class ObjectValue : public util::Comparable<ObjectValue> {
                        const FieldValue& value) const;
 
   FieldValue fv_;
+};
+
+class FieldValue::ServerTimestamp {
+ public:
+  ServerTimestamp(Timestamp local_write_time,
+                  absl::optional<FieldValue> previous_value)
+      : local_write_time_(local_write_time),
+        previous_value_(std::move(previous_value)) {
+  }
+
+  explicit ServerTimestamp(Timestamp local_write_time)
+      : ServerTimestamp(local_write_time, absl::nullopt) {
+  }
+
+  const Timestamp& local_write_time() const {
+    return local_write_time_;
+  }
+
+  const absl::optional<FieldValue>& previous_value() const {
+    return previous_value_;
+  }
+
+ private:
+  Timestamp local_write_time_;
+  absl::optional<FieldValue> previous_value_;
 };
 
 // Pretend you can automatically upcast from ObjectValue to FieldValue.

--- a/Firestore/core/src/firebase/firestore/model/field_value.h
+++ b/Firestore/core/src/firebase/firestore/model/field_value.h
@@ -32,13 +32,12 @@
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/field_path.h"
 #include "Firestore/core/src/firebase/firestore/nanopb/byte_string.h"
+#include "Firestore/core/src/firebase/firestore/objc/objc_class.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 #include "absl/base/attributes.h"
 #include "absl/types/optional.h"
 
-#if __OBJC__
-@class FSTFieldValue;
-#endif  // __OBJC__
+OBJC_CLASS(FSTFieldValue);
 
 namespace firebase {
 namespace firestore {
@@ -85,10 +84,8 @@ class FieldValue {
 
   FieldValue(ObjectValue object);  // NOLINT(runtime/explicit)
 
-#if __OBJC__
   FSTFieldValue* Wrap() const&;
   FSTFieldValue* Wrap() &&;
-#endif  // __OBJC__
 
   /** Returns the true type for this value. */
   Type type() const {
@@ -148,7 +145,7 @@ class FieldValue {
   static FieldValue FromDouble(double value);
   static FieldValue FromTimestamp(const Timestamp& value);
   static FieldValue FromServerTimestamp(const Timestamp& local_write_time,
-                                        const FieldValue& previous_value);
+                                        FSTFieldValue* previous_value);
   static FieldValue FromServerTimestamp(const Timestamp& local_write_time);
   static FieldValue FromString(const char* value);
   static FieldValue FromString(const std::string& value);
@@ -295,27 +292,19 @@ class ObjectValue : public util::Comparable<ObjectValue> {
 
 class FieldValue::ServerTimestamp {
  public:
-  ServerTimestamp(Timestamp local_write_time,
-                  absl::optional<FieldValue> previous_value)
-      : local_write_time_(local_write_time),
-        previous_value_(std::move(previous_value)) {
-  }
+  ServerTimestamp(Timestamp local_write_time, FSTFieldValue* previous_value);
 
-  explicit ServerTimestamp(Timestamp local_write_time)
-      : ServerTimestamp(local_write_time, absl::nullopt) {
-  }
+  explicit ServerTimestamp(Timestamp local_write_time);
 
   const Timestamp& local_write_time() const {
     return local_write_time_;
   }
 
-  const absl::optional<FieldValue>& previous_value() const {
-    return previous_value_;
-  }
+  FSTFieldValue* previous_value() const;
 
  private:
   Timestamp local_write_time_;
-  absl::optional<FieldValue> previous_value_;
+  objc::Handle<FSTFieldValue> previous_value_;
 };
 
 // Pretend you can automatically upcast from ObjectValue to FieldValue.

--- a/Firestore/core/src/firebase/firestore/model/field_value.h
+++ b/Firestore/core/src/firebase/firestore/model/field_value.h
@@ -292,9 +292,8 @@ class ObjectValue : public util::Comparable<ObjectValue> {
 
 class FieldValue::ServerTimestamp {
  public:
-  ServerTimestamp(Timestamp local_write_time, FSTFieldValue* previous_value);
-
-  explicit ServerTimestamp(Timestamp local_write_time);
+  explicit ServerTimestamp(Timestamp local_write_time,
+                           FSTFieldValue* previous_value = nil);
 
   const Timestamp& local_write_time() const {
     return local_write_time_;

--- a/Firestore/core/src/firebase/firestore/model/field_value.mm
+++ b/Firestore/core/src/firebase/firestore/model/field_value.mm
@@ -30,6 +30,19 @@ FSTFieldValue* FieldValue::Wrap() && {
   return [FSTDelegateValue delegateWithValue:std::move(*this)];
 }
 
+FieldValue::ServerTimestamp::ServerTimestamp(Timestamp local_write_time,
+                                             FSTFieldValue* previous_value)
+    : local_write_time_(local_write_time), previous_value_(previous_value) {
+}
+
+FieldValue::ServerTimestamp::ServerTimestamp(Timestamp local_write_time)
+    : ServerTimestamp(local_write_time, nil) {
+}
+
+FSTFieldValue* FieldValue::ServerTimestamp::previous_value() const {
+  return previous_value_;
+}
+
 }  // namespace model
 }  // namespace firestore
 }  // namespace firebase

--- a/Firestore/core/src/firebase/firestore/model/field_value.mm
+++ b/Firestore/core/src/firebase/firestore/model/field_value.mm
@@ -35,10 +35,6 @@ FieldValue::ServerTimestamp::ServerTimestamp(Timestamp local_write_time,
     : local_write_time_(local_write_time), previous_value_(previous_value) {
 }
 
-FieldValue::ServerTimestamp::ServerTimestamp(Timestamp local_write_time)
-    : ServerTimestamp(local_write_time, nil) {
-}
-
 FSTFieldValue* FieldValue::ServerTimestamp::previous_value() const {
   return previous_value_;
 }

--- a/Firestore/core/src/firebase/firestore/model/field_value.mm
+++ b/Firestore/core/src/firebase/firestore/model/field_value.mm
@@ -22,6 +22,10 @@ namespace firebase {
 namespace firestore {
 namespace model {
 
+FSTFieldValue* FieldValue::Wrap() const& {
+  return [FSTDelegateValue delegateWithValue:FieldValue(*this)];
+}
+
 FSTFieldValue* FieldValue::Wrap() && {
   return [FSTDelegateValue delegateWithValue:std::move(*this)];
 }

--- a/Firestore/core/src/firebase/firestore/model/transform_operations.h
+++ b/Firestore/core/src/firebase/firestore/model/transform_operations.h
@@ -97,8 +97,7 @@ class ServerTimestampTransform : public TransformOperation {
   FSTFieldValue* ApplyToLocalView(
       FSTFieldValue* previousValue,
       const Timestamp& local_write_time) const override {
-    // TODO(wilhuff): DO NOT SUBMIT: handle previousValue
-    return FieldValue::FromServerTimestamp(local_write_time, FieldValue::Null())
+    return FieldValue::FromServerTimestamp(local_write_time, previousValue)
         .Wrap();
   }
 

--- a/Firestore/core/src/firebase/firestore/model/transform_operations.h
+++ b/Firestore/core/src/firebase/firestore/model/transform_operations.h
@@ -97,9 +97,9 @@ class ServerTimestampTransform : public TransformOperation {
   FSTFieldValue* ApplyToLocalView(
       FSTFieldValue* previousValue,
       const Timestamp& local_write_time) const override {
-    return [FSTServerTimestampValue
-        serverTimestampValueWithLocalWriteTime:local_write_time
-                                 previousValue:previousValue];
+    // TODO(wilhuff): DO NOT SUBMIT: handle previousValue
+    return FieldValue::FromServerTimestamp(local_write_time, FieldValue::Null())
+        .Wrap();
   }
 
   FSTFieldValue* ApplyToRemoteDocument(

--- a/Firestore/core/test/firebase/firestore/model/field_value_test.cc
+++ b/Firestore/core/test/firebase/firestore/model/field_value_test.cc
@@ -422,7 +422,7 @@ TEST(FieldValue, TimestampType) {
   EXPECT_FALSE(a < a);
   const FieldValue c = FieldValue::FromServerTimestamp({100, 0});
   const FieldValue d = FieldValue::FromServerTimestamp(
-      {200, 0}, FieldValue::FromTimestamp({300, 0}));
+      {200, 0}, FieldValue::FromTimestamp({300, 0}).Wrap());
   EXPECT_EQ(Type::ServerTimestamp, c.type());
   EXPECT_EQ(Type::ServerTimestamp, d.type());
   EXPECT_TRUE(c < d);
@@ -575,17 +575,17 @@ TEST(FieldValue, Copy) {
   EXPECT_EQ(FieldValue::Null(), clone);
 
   const FieldValue server_timestamp_value = FieldValue::FromServerTimestamp(
-      {1, 2}, FieldValue::FromTimestamp({3, 4}));
+      {1, 2}, FieldValue::FromTimestamp({3, 4}).Wrap());
   clone = server_timestamp_value;
-  EXPECT_EQ(FieldValue::FromServerTimestamp({1, 2},
-                                            FieldValue::FromTimestamp({3, 4})),
+  EXPECT_EQ(FieldValue::FromServerTimestamp(
+                {1, 2}, FieldValue::FromTimestamp({3, 4}).Wrap()),
             clone);
-  EXPECT_EQ(FieldValue::FromServerTimestamp({1, 2},
-                                            FieldValue::FromTimestamp({3, 4})),
+  EXPECT_EQ(FieldValue::FromServerTimestamp(
+                {1, 2}, FieldValue::FromTimestamp({3, 4}).Wrap()),
             server_timestamp_value);
   clone = *&clone;
-  EXPECT_EQ(FieldValue::FromServerTimestamp({1, 2},
-                                            FieldValue::FromTimestamp({3, 4})),
+  EXPECT_EQ(FieldValue::FromServerTimestamp(
+                {1, 2}, FieldValue::FromTimestamp({3, 4}).Wrap()),
             clone);
   clone = null_value;
   EXPECT_EQ(FieldValue::Null(), clone);

--- a/Firestore/core/test/firebase/firestore/testutil/xcgmock.h
+++ b/Firestore/core/test/firebase/firestore/testutil/xcgmock.h
@@ -187,7 +187,6 @@ OBJC_PRINT_TO(FSTReferenceValue);
 OBJC_PRINT_TO(FSTRelationFilter);
 OBJC_PRINT_TO(FSTSerializerBeta);
 OBJC_PRINT_TO(FSTServerTimestampFieldValue);
-OBJC_PRINT_TO(FSTServerTimestampValue);
 OBJC_PRINT_TO(FSTSetMutation);
 OBJC_PRINT_TO(FSTSortOrder);
 OBJC_PRINT_TO(FSTStringValue);

--- a/Firestore/third_party/Immutable/CMakeLists.txt
+++ b/Firestore/third_party/Immutable/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright 2019 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Public types to be used both internally and externally.
+cc_library(
+  firebase_firestore_objc_immutable
+  SOURCES
+    FSTArraySortedDictionary.h
+    FSTArraySortedDictionary.m
+    FSTArraySortedDictionaryEnumerator.h
+    FSTArraySortedDictionaryEnumerator.m
+    FSTImmutableSortedDictionary.h
+    FSTImmutableSortedDictionary.m
+    FSTImmutableSortedSet.h
+    FSTImmutableSortedSet.m
+    FSTLLRBEmptyNode.h
+    FSTLLRBEmptyNode.m
+    FSTLLRBNode.h
+    FSTLLRBValueNode.h
+    FSTLLRBValueNode.m
+    FSTTreeSortedDictionary.h
+    FSTTreeSortedDictionary.m
+    FSTTreeSortedDictionaryEnumerator.h
+    FSTTreeSortedDictionaryEnumerator.m
+)
+
+target_compile_options(
+  firebase_firestore_objc_immutable PRIVATE
+  -Wno-unused-parameter
+)

--- a/Firestore/third_party/Immutable/CMakeLists.txt
+++ b/Firestore/third_party/Immutable/CMakeLists.txt
@@ -13,29 +13,31 @@
 # limitations under the License.
 
 # Public types to be used both internally and externally.
-cc_library(
-  firebase_firestore_objc_immutable
-  SOURCES
-    FSTArraySortedDictionary.h
-    FSTArraySortedDictionary.m
-    FSTArraySortedDictionaryEnumerator.h
-    FSTArraySortedDictionaryEnumerator.m
-    FSTImmutableSortedDictionary.h
-    FSTImmutableSortedDictionary.m
-    FSTImmutableSortedSet.h
-    FSTImmutableSortedSet.m
-    FSTLLRBEmptyNode.h
-    FSTLLRBEmptyNode.m
-    FSTLLRBNode.h
-    FSTLLRBValueNode.h
-    FSTLLRBValueNode.m
-    FSTTreeSortedDictionary.h
-    FSTTreeSortedDictionary.m
-    FSTTreeSortedDictionaryEnumerator.h
-    FSTTreeSortedDictionaryEnumerator.m
-)
+if(APPLE)
+  cc_library(
+    firebase_firestore_objc_immutable
+    SOURCES
+      FSTArraySortedDictionary.h
+      FSTArraySortedDictionary.m
+      FSTArraySortedDictionaryEnumerator.h
+      FSTArraySortedDictionaryEnumerator.m
+      FSTImmutableSortedDictionary.h
+      FSTImmutableSortedDictionary.m
+      FSTImmutableSortedSet.h
+      FSTImmutableSortedSet.m
+      FSTLLRBEmptyNode.h
+      FSTLLRBEmptyNode.m
+      FSTLLRBNode.h
+      FSTLLRBValueNode.h
+      FSTLLRBValueNode.m
+      FSTTreeSortedDictionary.h
+      FSTTreeSortedDictionary.m
+      FSTTreeSortedDictionaryEnumerator.h
+      FSTTreeSortedDictionaryEnumerator.m
+  )
 
-target_compile_options(
-  firebase_firestore_objc_immutable PRIVATE
-  -Wno-unused-parameter
-)
+  target_compile_options(
+    firebase_firestore_objc_immutable PRIVATE
+    -Wno-unused-parameter
+  )
+endif()

--- a/Firestore/third_party/Immutable/FSTArraySortedDictionary.m
+++ b/Firestore/third_party/Immutable/FSTArraySortedDictionary.m
@@ -194,14 +194,14 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSEnumerator *)keyEnumeratorFrom:(id)startKey to:(nullable id)endKey {
-  int start = [self findInsertPositionForKey:startKey];
-  int end = (int)self.count;
+  NSUInteger start = [self findInsertPositionForKey:startKey];
+  NSUInteger end = self.count;
   if (endKey) {
     end = [self findInsertPositionForKey:endKey];
   }
   return [[FSTArraySortedDictionaryEnumerator alloc] initWithKeys:self.keys
-                                                         startPos:start
-                                                           endPos:end
+                                                         startPos:(int)start
+                                                           endPos:(int)end
                                                         isReverse:NO];
 }
 
@@ -218,7 +218,7 @@ NS_ASSUME_NONNULL_BEGIN
     startPos -= 1;
   }
   return [[FSTArraySortedDictionaryEnumerator alloc] initWithKeys:self.keys
-                                                         startPos:startPos
+                                                         startPos:(int)startPos
                                                            endPos:-1
                                                         isReverse:YES];
 }

--- a/Firestore/third_party/Immutable/FSTArraySortedDictionary.m
+++ b/Firestore/third_party/Immutable/FSTArraySortedDictionary.m
@@ -58,8 +58,8 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 /** Returns the index of the first position where array[position] >= key.  */
-- (int)findInsertPositionForKey:(id)key {
-  int newPos = 0;
+- (NSUInteger)findInsertPositionForKey:(id)key {
+  NSUInteger newPos = 0;
   while (newPos < self.keys.count && self.comparator(self.keys[newPos], key) < NSOrderedSame) {
     newPos++;
   }
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (key == nil) {
     return NSNotFound;
   }
-  for (NSInteger pos = 0; pos < self.keys.count; pos++) {
+  for (NSUInteger pos = 0; pos < self.keys.count; pos++) {
     NSComparisonResult result = self.comparator(key, self.keys[pos]);
     if (result == NSOrderedSame) {
       return pos;
@@ -91,7 +91,7 @@ NS_ASSUME_NONNULL_BEGIN
      */
     if (self.count >= kSortedDictionaryArrayToRBTreeSizeThreshold) {
       NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithCapacity:self.count];
-      for (NSInteger i = 0; i < self.keys.count; i++) {
+      for (NSUInteger i = 0; i < self.keys.count; i++) {
         dict[self.keys[i]] = self.values[i];
       }
       dict[key] = value;
@@ -174,7 +174,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
   } else {
     BOOL stop = NO;
-    for (NSInteger i = 0; i < self.keys.count; i++) {
+    for (NSUInteger i = 0; i < self.keys.count; i++) {
       block(self.keys[i], self.values[i], &stop);
       if (stop) return;
     }
@@ -210,7 +210,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSEnumerator *)reverseKeyEnumeratorFrom:(id)startKey {
-  int startPos = [self findInsertPositionForKey:startKey];
+  NSUInteger startPos = [self findInsertPositionForKey:startKey];
   // if there's no exact match, findKeyOrInsertPosition will return the index *after* the closest
   // match, but since this is a reverse iterator, we want to start just *before* the closest match.
   if (startPos >= self.keys.count ||

--- a/Firestore/third_party/Immutable/FSTArraySortedDictionaryEnumerator.m
+++ b/Firestore/third_party/Immutable/FSTArraySortedDictionaryEnumerator.m
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable id)nextObject {
-  if (self.pos < 0 || self.pos >= self.keys.count) {
+  if (self.pos < 0 || self.pos >= (int)self.keys.count) {
     return nil;
   }
   if (self.reverse) {

--- a/Firestore/third_party/Immutable/FSTImmutableSortedDictionary.h
+++ b/Firestore/third_party/Immutable/FSTImmutableSortedDictionary.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
  * inserting and lookups. Feel free to empirically determine this constant, but don't expect much
  * gain in real world performance.
  */
-extern const int kSortedDictionaryArrayToRBTreeSizeThreshold;
+extern const NSUInteger kSortedDictionaryArrayToRBTreeSizeThreshold;
 
 /**
  * FSTImmutableSortedDictionary is a dictionary. It is immutable, but has methods to create new

--- a/Firestore/third_party/Immutable/FSTImmutableSortedDictionary.m
+++ b/Firestore/third_party/Immutable/FSTImmutableSortedDictionary.m
@@ -6,7 +6,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-const int kSortedDictionaryArrayToRBTreeSizeThreshold = 25;
+const NSUInteger kSortedDictionaryArrayToRBTreeSizeThreshold = 25;
 
 @implementation FSTImmutableSortedDictionary
 

--- a/Firestore/third_party/Immutable/FSTTreeSortedDictionary.m
+++ b/Firestore/third_party/Immutable/FSTTreeSortedDictionary.m
@@ -205,7 +205,7 @@ BOOL Base12ListNext(Base12List *list) {
 }
 
 static inline unsigned BitMask(int x) {
-  return (x >= sizeof(unsigned) * CHAR_BIT) ? (unsigned)-1 : (1U << x) - 1;
+  return ((size_t)x >= sizeof(unsigned) * CHAR_BIT) ? (unsigned)-1 : (1U << x) - 1;
 }
 
 /**


### PR DESCRIPTION
This includes a temporary change that makes the C++ `ServerTimestamp` include an Objective-C `FSTFieldValue*` as its previous value (0f6b330). This change will be reverted in the big switchover.