### PR TITLE
Deprecate initializers for FIAM view model objects

### DIFF
--- a/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.m
@@ -390,18 +390,24 @@
 
   FIRInAppMessagingActionButton *primaryActionButton = nil;
   if (definition.renderData.contentData.actionButtonText) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     primaryActionButton = [[FIRInAppMessagingActionButton alloc]
         initWithButtonText:renderData.contentData.actionButtonText
            buttonTextColor:renderData.renderingEffectSettings.btnTextColor
            backgroundColor:renderData.renderingEffectSettings.btnBGColor];
+#pragma clang diagnostic pop
   }
 
   FIRInAppMessagingActionButton *secondaryActionButton = nil;
   if (definition.renderData.contentData.secondaryActionButtonText) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     secondaryActionButton = [[FIRInAppMessagingActionButton alloc]
         initWithButtonText:renderData.contentData.secondaryActionButtonText
            buttonTextColor:renderData.renderingEffectSettings.secondaryActionBtnTextColor
            backgroundColor:renderData.renderingEffectSettings.btnBGColor];
+#pragma clang diagnostic pop
   }
 
   FIRInAppMessagingCardDisplay *cardMessage = [[FIRInAppMessagingCardDisplay alloc]
@@ -431,6 +437,8 @@
   NSString *title = definition.renderData.contentData.titleText;
   NSString *body = definition.renderData.contentData.bodyText;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   FIRInAppMessagingBannerDisplay *bannerMessage = [[FIRInAppMessagingBannerDisplay alloc]
         initWithMessageID:definition.renderData.messageID
              campaignName:definition.renderData.name
@@ -442,6 +450,7 @@
           backgroundColor:definition.renderData.renderingEffectSettings.displayBGColor
                 imageData:imageData
                 actionURL:definition.renderData.contentData.actionURL];
+#pragma clang diagnostic pop
 
   return bannerMessage;
 }
@@ -450,6 +459,8 @@
     imageOnlyDisplayMessageWithMessageDefinition:(FIRIAMMessageDefinition *)definition
                                        imageData:(FIRInAppMessagingImageData *)imageData
                                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   FIRInAppMessagingImageOnlyDisplay *imageOnlyMessage = [[FIRInAppMessagingImageOnlyDisplay alloc]
         initWithMessageID:definition.renderData.messageID
              campaignName:definition.renderData.name
@@ -457,6 +468,7 @@
               triggerType:triggerType
                 imageData:imageData
                 actionURL:definition.renderData.contentData.actionURL];
+#pragma clang diagnostic pop
 
   return imageOnlyMessage;
 }
@@ -474,12 +486,17 @@
   FIRInAppMessagingActionButton *actionButton = nil;
 
   if (definition.renderData.contentData.actionButtonText) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     actionButton = [[FIRInAppMessagingActionButton alloc]
         initWithButtonText:renderData.contentData.actionButtonText
            buttonTextColor:renderData.renderingEffectSettings.btnTextColor
            backgroundColor:renderData.renderingEffectSettings.btnBGColor];
+#pragma clang diagnostic pop
   }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   FIRInAppMessagingModalDisplay *modalViewMessage = [[FIRInAppMessagingModalDisplay alloc]
         initWithMessageID:definition.renderData.messageID
              campaignName:definition.renderData.name
@@ -492,6 +509,7 @@
                 imageData:imageData
              actionButton:actionButton
                 actionURL:definition.renderData.contentData.actionURL];
+#pragma clang diagnostic pop
 
   return modalViewMessage;
 }
@@ -547,14 +565,20 @@
           return;
         } else {
           if (standardImageRawData) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             imageData = [[FIRInAppMessagingImageData alloc]
                 initWithImageURL:message.renderData.contentData.imageURL.absoluteString
                        imageData:standardImageRawData];
+#pragma clang diagnostic pop
           }
           if (landscapeImageRawData) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             landscapeImageData = [[FIRInAppMessagingImageData alloc]
                 initWithImageURL:message.renderData.contentData.landscapeImageURL.absoluteString
                        imageData:landscapeImageRawData];
+#pragma clang diagnostic pop
           }
         }
 

--- a/Firebase/InAppMessaging/Public/FIRInAppMessagingRendering.h
+++ b/Firebase/InAppMessaging/Public/FIRInAppMessagingRendering.h
@@ -68,8 +68,7 @@ NS_SWIFT_NAME(InAppMessagingImageData)
 @property(nonatomic, readonly, nullable) NSData *imageRawData;
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithImageURL:(NSString *)imageURL
-                       imageData:(NSData *)imageData __deprecated;
+- (instancetype)initWithImageURL:(NSString *)imageURL imageData:(NSData *)imageData __deprecated;
 @end
 
 /** Defines the metadata for the campaign to which a FIAM message belongs.

--- a/Firebase/InAppMessaging/Public/FIRInAppMessagingRendering.h
+++ b/Firebase/InAppMessaging/Public/FIRInAppMessagingRendering.h
@@ -53,7 +53,7 @@ NS_SWIFT_NAME(InAppMessagingActionButton)
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithButtonText:(NSString *)btnText
                    buttonTextColor:(UIColor *)textColor
-                   backgroundColor:(UIColor *)bkgColor NS_DESIGNATED_INITIALIZER;
+                   backgroundColor:(UIColor *)bkgColor __deprecated;
 @end
 
 /** Contain display data for an image for a fiam message.
@@ -69,7 +69,7 @@ NS_SWIFT_NAME(InAppMessagingImageData)
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithImageURL:(NSString *)imageURL
-                       imageData:(NSData *)imageData NS_DESIGNATED_INITIALIZER;
+                       imageData:(NSData *)imageData __deprecated;
 @end
 
 /** Defines the metadata for the campaign to which a FIAM message belongs.
@@ -83,7 +83,7 @@ NS_SWIFT_NAME(InAppMessagingImageData)
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithMessageID:(NSString *)messageID
                      campaignName:(NSString *)campaignName
-              renderAsTestMessage:(BOOL)renderAsTestMessage;
+              renderAsTestMessage:(BOOL)renderAsTestMessage __deprecated;
 
 @end
 
@@ -102,7 +102,8 @@ NS_SWIFT_NAME(InAppMessagingAction)
 @property(nonatomic, nonnull, copy, readonly) NSURL *actionURL;
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithActionText:(nullable NSString *)actionText actionURL:(NSURL *)actionURL;
+- (instancetype)initWithActionText:(nullable NSString *)actionText
+                         actionURL:(NSURL *)actionURL __deprecated;
 
 @end
 
@@ -121,7 +122,7 @@ NS_SWIFT_NAME(InAppMessagingDisplayMessage)
                      campaignName:(NSString *)campaignName
               renderAsTestMessage:(BOOL)renderAsTestMessage
                       messageType:(FIRInAppMessagingDisplayMessageType)messageType
-                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType;
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType __deprecated;
 @end
 
 NS_SWIFT_NAME(InAppMessagingCardDisplay)
@@ -232,7 +233,7 @@ NS_SWIFT_NAME(InAppMessagingModalDisplay)
                   backgroundColor:(UIColor *)backgroundColor
                         imageData:(nullable FIRInAppMessagingImageData *)imageData
                      actionButton:(nullable FIRInAppMessagingActionButton *)actionButton
-                        actionURL:(nullable NSURL *)actionURL NS_DESIGNATED_INITIALIZER;
+                        actionURL:(nullable NSURL *)actionURL __deprecated;
 @end
 
 /** Class for defining a banner message for display.
@@ -271,7 +272,7 @@ NS_SWIFT_NAME(InAppMessagingBannerDisplay)
                         textColor:(UIColor *)textColor
                   backgroundColor:(UIColor *)backgroundColor
                         imageData:(nullable FIRInAppMessagingImageData *)imageData
-                        actionURL:(nullable NSURL *)actionURL NS_DESIGNATED_INITIALIZER;
+                        actionURL:(nullable NSURL *)actionURL __deprecated;
 @end
 
 /** Class for defining a image-only message for display.
@@ -295,7 +296,7 @@ NS_SWIFT_NAME(InAppMessagingImageOnlyDisplay)
               renderAsTestMessage:(BOOL)renderAsTestMessage
                       triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
                         imageData:(nullable FIRInAppMessagingImageData *)imageData
-                        actionURL:(nullable NSURL *)actionURL NS_DESIGNATED_INITIALIZER;
+                        actionURL:(nullable NSURL *)actionURL __deprecated;
 @end
 
 typedef NS_ENUM(NSInteger, FIRInAppMessagingDismissType) {

--- a/Firebase/InAppMessaging/RenderingObjects/FIRInAppMessagingRenderingDataClasses.m
+++ b/Firebase/InAppMessaging/RenderingObjects/FIRInAppMessagingRenderingDataClasses.m
@@ -64,11 +64,14 @@
                   backgroundColor:(UIColor *)backgroundColor
               primaryActionButton:(FIRInAppMessagingActionButton *)primaryActionButton
                  primaryActionURL:(NSURL *)primaryActionURL {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   if (self = [super initWithMessageID:messageID
                          campaignName:campaignName
                   renderAsTestMessage:renderAsTestMessage
                           messageType:FIRInAppMessagingDisplayMessageTypeCard
                           triggerType:triggerType]) {
+#pragma clang diagnostic pop
     _title = title;
     _textColor = textColor;
     _portraitImageData = portraitImageData;

--- a/Firebase/InAppMessaging/RenderingObjects/FIRInAppMessagingRenderingPrivate.h
+++ b/Firebase/InAppMessaging/RenderingObjects/FIRInAppMessagingRenderingPrivate.h
@@ -36,4 +36,86 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface FIRInAppMessagingActionButton (Private)
+
+- (instancetype)initWithButtonText:(NSString *)btnText
+                   buttonTextColor:(UIColor *)textColor
+                   backgroundColor:(UIColor *)bkgColor;
+
+@end
+
+@interface FIRInAppMessagingImageData (Private)
+
+- (instancetype)initWithImageURL:(NSString *)imageURL
+                       imageData:(NSData *)imageData;
+
+@end
+
+@interface FIRInAppMessagingCampaignInfo (Private)
+
+- (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage;
+
+@end
+
+@interface FIRInAppMessagingAction (Private)
+
+- (instancetype)initWithActionText:(nullable NSString *)actionText
+                         actionURL:(NSURL *)actionURL;
+
+@end
+
+@interface FIRInAppMessagingDisplayMessage (Private)
+
+- (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage
+                      messageType:(FIRInAppMessagingDisplayMessageType)messageType
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType;
+
+@end
+
+@interface FIRInAppMessagingModalDisplay (Private)
+
+- (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
+                        titleText:(NSString *)title
+                         bodyText:(NSString *)bodyText
+                        textColor:(UIColor *)textColor
+                  backgroundColor:(UIColor *)backgroundColor
+                        imageData:(nullable FIRInAppMessagingImageData *)imageData
+                     actionButton:(nullable FIRInAppMessagingActionButton *)actionButton
+                        actionURL:(nullable NSURL *)actionURL;
+
+@end
+
+@interface FIRInAppMessagingBannerDisplay (Private)
+
+- (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
+                        titleText:(NSString *)title
+                         bodyText:(NSString *)bodyText
+                        textColor:(UIColor *)textColor
+                  backgroundColor:(UIColor *)backgroundColor
+                        imageData:(nullable FIRInAppMessagingImageData *)imageData
+                        actionURL:(nullable NSURL *)actionURL;
+
+@end
+
+@interface FIRInAppMessagingImageOnlyDisplay (Private)
+
+- (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
+                        imageData:(nullable FIRInAppMessagingImageData *)imageData
+                        actionURL:(nullable NSURL *)actionURL;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/Firebase/InAppMessaging/RenderingObjects/FIRInAppMessagingRenderingPrivate.h
+++ b/Firebase/InAppMessaging/RenderingObjects/FIRInAppMessagingRenderingPrivate.h
@@ -46,8 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FIRInAppMessagingImageData (Private)
 
-- (instancetype)initWithImageURL:(NSString *)imageURL
-                       imageData:(NSData *)imageData;
+- (instancetype)initWithImageURL:(NSString *)imageURL imageData:(NSData *)imageData;
 
 @end
 
@@ -61,8 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FIRInAppMessagingAction (Private)
 
-- (instancetype)initWithActionText:(nullable NSString *)actionText
-                         actionURL:(NSURL *)actionURL;
+- (instancetype)initWithActionText:(nullable NSString *)actionText actionURL:(NSURL *)actionURL;
 
 @end
 

--- a/Firebase/InAppMessagingDisplay/Banner/FIDBannerViewController.m
+++ b/Firebase/InAppMessagingDisplay/Banner/FIDBannerViewController.m
@@ -194,9 +194,12 @@ static const CGFloat kSwipeUpThreshold = -10.0f;
 - (void)messageTapped:(UITapGestureRecognizer *)recognizer {
   [self.autoDismissTimer invalidate];
   [self dismissViewWithAnimation:^(void) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     FIRInAppMessagingAction *action =
         [[FIRInAppMessagingAction alloc] initWithActionText:nil
                                                   actionURL:self.bannerDisplayMessage.actionURL];
+#pragma clang diagnostic pop
     [self followAction:action];
   }];
 }

--- a/Firebase/InAppMessagingDisplay/Card/FIDCardViewController.m
+++ b/Firebase/InAppMessagingDisplay/Card/FIDCardViewController.m
@@ -60,9 +60,12 @@
 
 - (IBAction)primaryActionButtonTapped:(id)sender {
   if (self.cardDisplayMessage.primaryActionURL) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     FIRInAppMessagingAction *primaryAction = [[FIRInAppMessagingAction alloc]
         initWithActionText:self.cardDisplayMessage.primaryActionButton.buttonText
                  actionURL:self.cardDisplayMessage.primaryActionURL];
+#pragma clang diagnostic pop
     [self followAction:primaryAction];
   } else {
     [self dismissView:FIRInAppMessagingDismissTypeUserTapClose];
@@ -71,9 +74,12 @@
 
 - (IBAction)secondaryActionButtonTapped:(id)sender {
   if (self.cardDisplayMessage.secondaryActionURL) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     FIRInAppMessagingAction *secondaryAction = [[FIRInAppMessagingAction alloc]
         initWithActionText:self.cardDisplayMessage.secondaryActionButton.buttonText
                  actionURL:self.cardDisplayMessage.secondaryActionURL];
+#pragma clang diagnostic pop
     [self followAction:secondaryAction];
   } else {
     [self dismissView:FIRInAppMessagingDismissTypeUserTapClose];

--- a/Firebase/InAppMessagingDisplay/ImageOnly/FIDImageOnlyViewController.m
+++ b/Firebase/InAppMessagingDisplay/ImageOnly/FIDImageOnlyViewController.m
@@ -73,9 +73,12 @@
 }
 
 - (void)messageTapped:(UITapGestureRecognizer *)recognizer {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   FIRInAppMessagingAction *action =
       [[FIRInAppMessagingAction alloc] initWithActionText:nil
                                                 actionURL:self.imageOnlyMessage.actionURL];
+#pragma clang diagnostic pop
   [self followAction:action];
 }
 

--- a/Firebase/InAppMessagingDisplay/Modal/FIDModalViewController.m
+++ b/Firebase/InAppMessagingDisplay/Modal/FIDModalViewController.m
@@ -102,9 +102,12 @@ static CGFloat LandScapePaddingBetweenImageAndTextColumn = 24;
 }
 
 - (IBAction)actionButtonTapped:(id)sender {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   FIRInAppMessagingAction *action = [[FIRInAppMessagingAction alloc]
       initWithActionText:self.modalDisplayMessage.actionButton.buttonText
                actionURL:self.modalDisplayMessage.actionURL];
+#pragma clang diagnostic pop
   [self followAction:action];
 }
 


### PR DESCRIPTION
They never needed to be public, plan is to eventually remove and hide them in a private header.