### PR TITLE
FIRInstallationsIDController - guarantee a single ongoing FID or AuthToken request

### DIFF
--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -82,19 +82,19 @@ NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 
     __weak FIRInstallationsIDController *weakSelf = self;
 
     _getInstallationPromiseCache = [[FIRInstallationsSingleOperationPromiseCache alloc]
-        initWithPromiseFactory:^FBLPromise *_Nonnull {
+        initWithNewOperationHandler:^FBLPromise *_Nonnull {
           FIRInstallationsIDController *strongSelf = weakSelf;
           return [strongSelf createGetInstallationItemPromise];
         }];
 
     _authTokenPromiseCache = [[FIRInstallationsSingleOperationPromiseCache alloc]
-        initWithPromiseFactory:^FBLPromise *_Nonnull {
+        initWithNewOperationHandler:^FBLPromise *_Nonnull {
           FIRInstallationsIDController *strongSelf = weakSelf;
           return [strongSelf createAuthTokenPromiseForcingRefresh:NO];
         }];
 
     _authTokenForcingRefreshPromiseCache = [[FIRInstallationsSingleOperationPromiseCache alloc]
-        initWithPromiseFactory:^FBLPromise *_Nonnull {
+        initWithNewOperationHandler:^FBLPromise *_Nonnull {
           FIRInstallationsIDController *strongSelf = weakSelf;
           return [strongSelf createAuthTokenPromiseForcingRefresh:YES];
         }];

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsSingleOperationPromiseCache.h
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsSingleOperationPromiseCache.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class FBLPromise<ValueType>;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * The class makes sure the a single operation (represented by a promise) is performed at a time. If
+ * there is an ongoing operation, then its existing corresponding promise will be returned instead
+ * of starting a new operation.
+ */
+@interface FIRInstallationsSingleOperationPromiseCache<__covariant ResultType> : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ * The designated initializer.
+ * @param factory The block that must return a new promise representing the single-at-a-time
+ * operation. The promise should be fulfilled when the operation is completed. The factory block
+ * will be used to create a new promise when needed.
+ */
+- (instancetype)initWithPromiseFactory:(FBLPromise<ResultType> *_Nonnull (^)(void))factory
+    NS_DESIGNATED_INITIALIZER;
+
+/**
+ * Creates a new promise or returns an existing pending one.
+ * @return Returns and existing pending promise if exists. If the pending promise does not exist
+ * then a new one will be created using the `factory` block passed in the initializer. Once the
+ * pending promise gets resolved, it is removed, so calling the method again will lead to creating
+ * and caching another promise.
+ */
+- (FBLPromise<ResultType> *)getExistingPendingOrCreateNewPromise;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsSingleOperationPromiseCache.h
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsSingleOperationPromiseCache.h
@@ -31,12 +31,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * The designated initializer.
- * @param factory The block that must return a new promise representing the single-at-a-time
- * operation. The promise should be fulfilled when the operation is completed. The factory block
- * will be used to create a new promise when needed.
+ * @param newOperationHandler The block that must return a new promise representing the
+ * single-at-a-time operation. The promise should be fulfilled when the operation is completed. The
+ * factory block will be used to create a new promise when needed.
  */
-- (instancetype)initWithPromiseFactory:(FBLPromise<ResultType> *_Nonnull (^)(void))factory
-    NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithNewOperationHandler:
+    (FBLPromise<ResultType> *_Nonnull (^)(void))newOperationHandler NS_DESIGNATED_INITIALIZER;
 
 /**
  * Creates a new promise or returns an existing pending one.

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsSingleOperationPromiseCache.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsSingleOperationPromiseCache.m
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRInstallationsSingleOperationPromiseCache.h"
+
+#if __has_include(<FBLPromises/FBLPromises.h>)
+#import <FBLPromises/FBLPromises.h>
+#else
+#import "FBLPromises.h"
+#endif
+
+@interface FIRInstallationsSingleOperationPromiseCache <ResultType>()
+@property(nonatomic, readonly) FBLPromise *_Nonnull (^promiseFactory)(void);
+@property(atomic, nullable) FBLPromise *pendingPromise;
+@end
+
+@implementation FIRInstallationsSingleOperationPromiseCache
+
+- (instancetype)initWithPromiseFactory:(FBLPromise<id> *_Nonnull (^)(void))factory {
+  if (factory == nil) {
+    [NSException raise:NSInvalidArgumentException format:@"`factory` must not be `nil`."];
+  }
+
+  self = [super init];
+  if (self) {
+    _promiseFactory = [factory copy];
+  }
+  return self;
+}
+
+- (FBLPromise *)getExistingPendingOrCreateNewPromise {
+  if (!self.pendingPromise) {
+    self.pendingPromise = self.promiseFactory();
+
+    self.pendingPromise
+        .then(^id(id result) {
+          self.pendingPromise = nil;
+          return nil;
+        })
+        .catch(^void(NSError *error) {
+          self.pendingPromise = nil;
+        });
+  }
+
+  return self.pendingPromise;
+}
+
+@end

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsSingleOperationPromiseCache.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsSingleOperationPromiseCache.m
@@ -23,27 +23,29 @@
 #endif
 
 @interface FIRInstallationsSingleOperationPromiseCache <ResultType>()
-@property(nonatomic, readonly) FBLPromise *_Nonnull (^promiseFactory)(void);
+@property(nonatomic, readonly) FBLPromise *_Nonnull (^newOperationHandler)(void);
 @property(atomic, nullable) FBLPromise *pendingPromise;
 @end
 
 @implementation FIRInstallationsSingleOperationPromiseCache
 
-- (instancetype)initWithPromiseFactory:(FBLPromise<id> *_Nonnull (^)(void))factory {
-  if (factory == nil) {
-    [NSException raise:NSInvalidArgumentException format:@"`factory` must not be `nil`."];
+- (instancetype)initWithNewOperationHandler:
+    (FBLPromise<id> *_Nonnull (^)(void))newOperationHandler {
+  if (newOperationHandler == nil) {
+    [NSException raise:NSInvalidArgumentException
+                format:@"`newOperationHandler` must not be `nil`."];
   }
 
   self = [super init];
   if (self) {
-    _promiseFactory = [factory copy];
+    _newOperationHandler = [newOperationHandler copy];
   }
   return self;
 }
 
 - (FBLPromise *)getExistingPendingOrCreateNewPromise {
   if (!self.pendingPromise) {
-    self.pendingPromise = self.promiseFactory();
+    self.pendingPromise = self.newOperationHandler();
 
     self.pendingPromise
         .then(^id(id result) {


### PR DESCRIPTION
The changes required to make sure that no parallel requests to register a FID or generate an auth token for the same app are performed.