### PR TITLE
Handle newly removed `userInfo` property on tvOS.

### DIFF
--- a/Firebase/Messaging/FIRMessagingExtensionHelper.m
+++ b/Firebase/Messaging/FIRMessagingExtensionHelper.m
@@ -35,12 +35,13 @@ static NSString *const kPayloadOptionsImageURLName = @"image";
   self.contentHandler = [contentHandler copy];
   self.bestAttemptContent = content;
 
-   NSString *currentImageURL = content.userInfo[kPayloadOptionsName][kPayloadOptionsImageURLName];
+  // The `userInfo` property isn't available on newer versions of tvOS.
+#if TARGET_OS_IOS || TARGET_OS_OSX
+  NSString *currentImageURL = content.userInfo[kPayloadOptionsName][kPayloadOptionsImageURLName];
   if (!currentImageURL) {
     [self deliverNotification];
     return;
   }
-#if TARGET_OS_IOS || TARGET_OS_OSX
   NSURL *attachmentURL = [NSURL URLWithString:currentImageURL];
   if (attachmentURL) {
     [self loadAttachmentForURL:attachmentURL


### PR DESCRIPTION
The build is currently broken in Xcode 11 because of this.