### PR TITLE
Build Core with SPM

### DIFF
--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -14,11 +14,7 @@
 
 #include <sys/utsname.h>
 
-#if SWIFT_PACKAGE
-#import "Public/FIRApp.h"
-#else
-#import <Firebase/FIRApp.h>
-#endif
+#import "Core/Public/FIRApp.h"
 #import "Private/FIRAnalyticsConfiguration.h"
 #import "Private/FIRAppInternal.h"
 #import "Private/FIRBundleUtil.h"

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -14,7 +14,11 @@
 
 #include <sys/utsname.h>
 
-#import "FIRApp.h"
+#if SWIFT_PACKAGE
+#import "Public/FIRApp.h"
+#else
+#import <Firebase/FIRApp.h>
+#endif
 #import "Private/FIRAnalyticsConfiguration.h"
 #import "Private/FIRAppInternal.h"
 #import "Private/FIRBundleUtil.h"

--- a/Firebase/Core/FIRBundleUtil.m
+++ b/Firebase/Core/FIRBundleUtil.m
@@ -14,7 +14,11 @@
 
 #import "Private/FIRBundleUtil.h"
 
+#if SWIFT_PACKAGE
+#import "GULAppEnvironmentUtil.h"
+#else
 #import <GoogleUtilities/GULAppEnvironmentUtil.h>
+#endif
 
 @implementation FIRBundleUtil
 

--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -14,9 +14,15 @@
 
 #import "Private/FIRLogger.h"
 
+#if SWIFT_PACKAGE
+#import "FIRLoggerLevel.h"
+#import "GULAppEnvironmentUtil.h"
+#import "GULLogger.h"
+#else
 #import <FirebaseCore/FIRLoggerLevel.h>
 #import <GoogleUtilities/GULAppEnvironmentUtil.h>
 #import <GoogleUtilities/GULLogger.h>
+#endif
 
 #import "Private/FIRVersion.h"
 

--- a/Firebase/Core/FIRLogger.m
+++ b/Firebase/Core/FIRLogger.m
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "Private/FIRLogger.h"
+#import "Core/Private/FIRLogger.h"
+#import "Core/Public/FIRLoggerLevel.h"
 
 #if SWIFT_PACKAGE
-#import "FIRLoggerLevel.h"
 #import "GULAppEnvironmentUtil.h"
 #import "GULLogger.h"
 #else
-#import <FirebaseCore/FIRLoggerLevel.h>
 #import <GoogleUtilities/GULAppEnvironmentUtil.h>
 #import <GoogleUtilities/GULLogger.h>
 #endif

--- a/Firebase/Core/Private/FIRAppInternal.h
+++ b/Firebase/Core/Private/FIRAppInternal.h
@@ -14,14 +14,8 @@
  * limitations under the License.
  */
 
-
-#if SWIFT_PACKAGE
-#import "../Public/FIRApp.h"
-#import "FIRErrors.h"
-#else
-#import <FirebaseCore/FIRApp.h>
-#import <FirebaseCore/FIRErrors.h>
-#endif
+#import "Core/Private/FIRErrors.h"
+#import "Core/Public/FIRApp.h"
 
 @class FIRComponentContainer;
 @protocol FIRLibrary;

--- a/Firebase/Core/Private/FIRAppInternal.h
+++ b/Firebase/Core/Private/FIRAppInternal.h
@@ -14,8 +14,14 @@
  * limitations under the License.
  */
 
+
+#if SWIFT_PACKAGE
+#import "../Public/FIRApp.h"
+#import "FIRErrors.h"
+#else
 #import <FirebaseCore/FIRApp.h>
 #import <FirebaseCore/FIRErrors.h>
+#endif
 
 @class FIRComponentContainer;
 @protocol FIRLibrary;

--- a/Firebase/Core/Private/FIRLogger.h
+++ b/Firebase/Core/Private/FIRLogger.h
@@ -16,7 +16,11 @@
 
 #import <Foundation/Foundation.h>
 
+#if SWIFT_PACKAGE
+#import "FIRLoggerLevel.h"
+#else
 #import <FirebaseCore/FIRLoggerLevel.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firebase/Core/Private/FIRLogger.h
+++ b/Firebase/Core/Private/FIRLogger.h
@@ -16,11 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if SWIFT_PACKAGE
-#import "FIRLoggerLevel.h"
-#else
-#import <FirebaseCore/FIRLoggerLevel.h>
-#endif
+#import "Core/Public/FIRLoggerLevel.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firebase/Core/Private/FIROptionsInternal.h
+++ b/Firebase/Core/Private/FIROptionsInternal.h
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
+#if SWIFT_PACKAGE
+#import "../Public/FIROptions.h"
+#else
 #import <FirebaseCore/FIROptions.h>
+#endif
 
 /**
  * Keys for the strings in the plist file.

--- a/Firebase/Core/Private/FIROptionsInternal.h
+++ b/Firebase/Core/Private/FIROptionsInternal.h
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-#if SWIFT_PACKAGE
-#import "../Public/FIROptions.h"
-#else
-#import <FirebaseCore/FIROptions.h>
-#endif
+#import "Core/Public/FIROptions.h"
 
 /**
  * Keys for the strings in the plist file.

--- a/Firebase/Core/Public/FIRConfiguration.h
+++ b/Firebase/Core/Public/FIRConfiguration.h
@@ -16,11 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if SWIFT_PACKAGE
 #import "FIRLoggerLevel.h"
-#else
-#import <FirebaseCore/FIRLoggerLevel.h>
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firebase/Core/Public/FIRConfiguration.h
+++ b/Firebase/Core/Public/FIRConfiguration.h
@@ -16,7 +16,11 @@
 
 #import <Foundation/Foundation.h>
 
+#if SWIFT_PACKAGE
+#import "FIRLoggerLevel.h"
+#else
 #import <FirebaseCore/FIRLoggerLevel.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -34,6 +34,7 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'GCC_PREPROCESSOR_DEFINITIONS' =>
       'FIRCore_VERSION=' + s.version.to_s + ' Firebase_VERSION=6.2.0',
+    'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"/Firebase',
     'OTHER_CFLAGS' => '-fno-autolink'
   }
   s.test_spec 'unit' do |unit_tests|

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
     // Targets can depend on other targets in this package, and on products in packages which this package depends on.
     .target(
       name: "firebase-test",
-      dependencies: ["GoogleUtilities_Environment", "GoogleUtilities_Logger"]
+      dependencies: ["FirebaseCore", "GoogleUtilities_Environment", "GoogleUtilities_Logger"]
     ),
     .target(
       name: "GoogleUtilities_Environment",
@@ -50,11 +50,12 @@ let package = Package(
       path: "Firebase/Core",
       publicHeadersPath: "Public",
       cSettings: [
-        .headerSearchPath("$(SRCROOT)/GoogleUtilities/Logger/Private"), // SPM doesn't support private headers
+        .headerSearchPath("$(SRCROOT)/Firebase $(SRCROOT)/GoogleUtilities/Logger/Private"), // SPM doesn't support private headers
         .define("FIRCore_VERSION", to: "0.0.1"),  // TODO Fix version
         .define("Firebase_VERSION", to: "0.0.1"),  // TODO Fix version
         .define("SWIFT_PACKAGE", to: "1"),  // SPM loses defaults if other cSettings
 //        .define("DEBUG", .when(configuration: .debug)), // TODO - destroys other settings in DEBUG config
+// TODO - Add support for cflags cSetting so that we can set the -fno-autolink option
       ])
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,9 @@ let package = Package(
     .library(
       name: "GoogleUtilities_Logger",
       targets: ["GoogleUtilities_Logger"]),
+    .library(
+      name: "FirebaseCore",
+      targets: ["FirebaseCore"]),
   ],
   dependencies: [
     // Dependencies declare other external packages that this package depends on.
@@ -40,6 +43,18 @@ let package = Package(
       name: "GoogleUtilities_Logger",
       dependencies: ["GoogleUtilities_Environment"],
       path: "GoogleUtilities/Logger",
-      publicHeadersPath: "Public")
+      publicHeadersPath: "Public"),
+    .target(
+      name: "FirebaseCore",
+      dependencies: ["GoogleUtilities_Environment", "GoogleUtilities_Logger"],
+      path: "Firebase/Core",
+      publicHeadersPath: "Public",
+      cSettings: [
+        .headerSearchPath("$(SRCROOT)/GoogleUtilities/Logger/Private"), // SPM doesn't support private headers
+        .define("FIRCore_VERSION", to: "0.0.1"),  // TODO Fix version
+        .define("Firebase_VERSION", to: "0.0.1"),  // TODO Fix version
+        .define("SWIFT_PACKAGE", to: "1"),  // SPM loses defaults if other cSettings
+//        .define("DEBUG", .when(configuration: .debug)), // TODO - destroys other settings in DEBUG config
+      ])
   ]
 )

--- a/Sources/firebase-test/main.swift
+++ b/Sources/firebase-test/main.swift
@@ -1,4 +1,5 @@
 import Foundation
+import FirebaseCore
 import GoogleUtilities_Environment
 import GoogleUtilities_Logger
 
@@ -10,3 +11,5 @@ print("Device model? Answer: \(GULAppEnvironmentUtil.deviceModel() ?? "NONE")")
 print("System version? Answer: \(GULAppEnvironmentUtil.systemVersion() ?? "NONE")")
 print("Is App extension? Answer: \(GULAppEnvironmentUtil.isAppExtension())")
 print("Is iOS 7 or higher? Answer: \(GULAppEnvironmentUtil.isIOS7OrHigher())")
+
+print("Is there a default app? Answer: \(FirebaseApp.app() != nil)")


### PR DESCRIPTION
Initial successful build of FirebaseCore with SPM.

SPM issues:

- Doesn't support private headers
- Doesn't support public header references from current pod
- Need to figure out versioning strategy and implementation with SPM
- SPM has bugs with `define` implementation for setting up build flags

