### PR TITLE
Add postcondition tracking to transactions

### DIFF
--- a/Firestore/core/src/firebase/firestore/core/transaction.h
+++ b/Firestore/core/src/firebase/firestore/core/transaction.h
@@ -137,6 +137,11 @@ class Transaction {
                      model::SnapshotVersion,
                      model::DocumentKeyHash>
       read_versions_;
+
+  std::unordered_map<model::DocumentKey,
+                     model::Precondition,
+                     model::DocumentKeyHash>
+      write_postconditions_;
 };
 
 using TransactionResultCallback = util::StatusOrCallback<absl::any>;

--- a/Firestore/core/src/firebase/firestore/remote/datastore.mm
+++ b/Firestore/core/src/firebase/firestore/remote/datastore.mm
@@ -183,8 +183,11 @@ void Datastore::CommitMutationsWithCredentials(
     const Token& token,
     const std::vector<FSTMutation*>& mutations,
     CommitCallback&& callback) {
-  grpc::ByteBuffer message = serializer_bridge_.ToByteBuffer(
-      serializer_bridge_.CreateCommitRequest(mutations));
+  GCFSCommitRequest* request =
+      serializer_bridge_.CreateCommitRequest(mutations);
+  LOG_DEBUG("commit: %s", [request description]);
+
+  grpc::ByteBuffer message = serializer_bridge_.ToByteBuffer(request);
 
   std::unique_ptr<GrpcUnaryCall> call_owning = grpc_connection_.CreateUnaryCall(
       kRpcNameCommit, token, std::move(message));


### PR DESCRIPTION
This makes it so that certain sequences of operations now work. Namely:

  * Read non-existent document, then set, set
  * Read existing document, delete, set