### PR TITLE
Fix small compilation and linter issues

### DIFF
--- a/Firestore/Example/Tests/API/FSTUserDataConverterTests.mm
+++ b/Firestore/Example/Tests/API/FSTUserDataConverterTests.mm
@@ -36,7 +36,6 @@ using firebase::firestore::model::FieldValue;
 using firebase::firestore::model::ObjectValue;
 using firebase::firestore::nanopb::MakeNSData;
 using firebase::firestore::testutil::Field;
-using firebase::firestore::testutil::WrapObject;
 
 @interface FSTUserDataConverterTests : XCTestCase
 @end

--- a/Firestore/Source/API/FIRDocumentSnapshot.mm
+++ b/Firestore/Source/API/FIRDocumentSnapshot.mm
@@ -239,7 +239,8 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
   }
 }
 
-- (id)convertedServerTimestamp:(const FieldValue &)value options:(const FieldValueOptions &)options {
+- (id)convertedServerTimestamp:(const FieldValue &)value
+                       options:(const FieldValueOptions &)options {
   const auto &sts = value.server_timestamp_value();
   switch (options.server_timestamp_behavior()) {
     case ServerTimestampBehavior::kNone:

--- a/Firestore/Source/API/FIRDocumentSnapshot.mm
+++ b/Firestore/Source/API/FIRDocumentSnapshot.mm
@@ -212,7 +212,7 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
     case FieldValue::Type::Timestamp:
       return [self convertedTimestamp:value options:options];
     case FieldValue::Type::ServerTimestamp:
-      return [self convertedServerTimetamp:value options:options];
+      return [self convertedServerTimestamp:value options:options];
     case FieldValue::Type::String:
       return util::WrapNSString(value.string_value());
     case FieldValue::Type::Blob:
@@ -239,7 +239,7 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
   }
 }
 
-- (id)convertedServerTimetamp:(const FieldValue &)value options:(const FieldValueOptions &)options {
+- (id)convertedServerTimestamp:(const FieldValue &)value options:(const FieldValueOptions &)options {
   const auto &sts = value.server_timestamp_value();
   switch (options.server_timestamp_behavior()) {
     case ServerTimestampBehavior::kNone:

--- a/Firestore/Source/Core/FSTQuery.mm
+++ b/Firestore/Source/Core/FSTQuery.mm
@@ -472,7 +472,7 @@ NSString *FSTStringFromQueryRelationOperator(Filter::Operator filterOperator) {
   return string;
 }
 
-- (BOOL)sortsBeforeDocument:(FSTDocument *)document
+- (bool)sortsBeforeDocument:(FSTDocument *)document
              usingSortOrder:(NSArray<FSTSortOrder *> *)sortOrder {
   HARD_ASSERT(_position.size() <= sortOrder.count,
               "FSTIndexPosition has more components than provided sort order.");

--- a/Firestore/core/src/firebase/firestore/timestamp.cc
+++ b/Firestore/core/src/firebase/firestore/timestamp.cc
@@ -31,10 +31,6 @@ namespace firebase {
 
 namespace {
 
-// We pass it by value without std::move.
-static_assert(std::is_trivially_copyable<Timestamp>::value,
-              "Timestamp must be trivially copyable");
-
 constexpr int32_t kNanosPerSecond = 1E9;
 
 /**


### PR DESCRIPTION
* remove C++11 library feature from `Timestamp` (which is supposed to be "portable");
* fix return type mismatch (`bool` vs `BOOL`);
* fix typo in function name.