### PR TITLE
Migrate FSTDocumentState to C++ DocumentState

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -1352,9 +1352,9 @@
 		5495EB012040E90200EBA509 /* Codable */ = {
 			isa = PBXGroup;
 			children = (
-				1235769422B86E65007DDFA9 /* FirestoreEncoderTests.swift */,
 				5495EB022040E90200EBA509 /* CodableGeoPointTests.swift */,
 				7B65C996438B84DBC7616640 /* CodableTimestampTests.swift */,
+				1235769422B86E65007DDFA9 /* FirestoreEncoderTests.swift */,
 			);
 			path = Codable;
 			sourceTree = "<group>";
@@ -1392,9 +1392,9 @@
 		54C9EDF22040E16300A969CD /* SwiftTests */ = {
 			isa = PBXGroup;
 			children = (
-				620C1427763BA5D3CCFB5A1F /* BridgingHeader.h */,
 				544A20ED20F6C046004E52CD /* API */,
 				5495EB012040E90200EBA509 /* Codable */,
+				620C1427763BA5D3CCFB5A1F /* BridgingHeader.h */,
 				54C9EDF52040E16300A969CD /* Info.plist */,
 			);
 			name = SwiftTests;

--- a/Firestore/Example/Tests/API/FIRQuerySnapshotTests.mm
+++ b/Firestore/Example/Tests/API/FIRQuerySnapshotTests.mm
@@ -45,6 +45,7 @@ using firebase::firestore::core::ViewSnapshot;
 using firebase::firestore::model::DocumentComparator;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::DocumentSet;
+using firebase::firestore::model::DocumentState;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -78,11 +79,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)testIncludeMetadataChanges {
-  FSTDocument *doc1Old = FSTTestDoc("foo/bar", 1, @{@"a" : @"b"}, FSTDocumentStateLocalMutations);
-  FSTDocument *doc1New = FSTTestDoc("foo/bar", 1, @{@"a" : @"b"}, FSTDocumentStateSynced);
+  FSTDocument *doc1Old = FSTTestDoc("foo/bar", 1, @{@"a" : @"b"}, DocumentState::kLocalMutations);
+  FSTDocument *doc1New = FSTTestDoc("foo/bar", 1, @{@"a" : @"b"}, DocumentState::kSynced);
 
-  FSTDocument *doc2Old = FSTTestDoc("foo/baz", 1, @{@"a" : @"b"}, FSTDocumentStateSynced);
-  FSTDocument *doc2New = FSTTestDoc("foo/baz", 1, @{@"a" : @"c"}, FSTDocumentStateSynced);
+  FSTDocument *doc2Old = FSTTestDoc("foo/baz", 1, @{@"a" : @"b"}, DocumentState::kSynced);
+  FSTDocument *doc2New = FSTTestDoc("foo/baz", 1, @{@"a" : @"c"}, DocumentState::kSynced);
 
   DocumentSet oldDocuments = FSTTestDocSet(DocumentComparator::ByKey(), @[ doc1Old, doc2Old ]);
   DocumentSet newDocuments = FSTTestDocSet(DocumentComparator::ByKey(), @[ doc2New, doc2New ]);

--- a/Firestore/Example/Tests/API/FSTAPIHelpers.mm
+++ b/Firestore/Example/Tests/API/FSTAPIHelpers.mm
@@ -34,6 +34,7 @@
 #import "Firestore/Source/Model/FSTDocument.h"
 
 #include "Firestore/core/src/firebase/firestore/core/view_snapshot.h"
+#include "Firestore/core/src/firebase/firestore/model/document.h"
 #include "Firestore/core/src/firebase/firestore/model/document_set.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 #include "Firestore/core/test/firebase/firestore/testutil/testutil.h"
@@ -47,6 +48,7 @@ using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentComparator;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::DocumentSet;
+using firebase::firestore::model::DocumentState;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -74,7 +76,7 @@ FIRDocumentSnapshot *FSTTestDocSnapshot(const absl::string_view path,
                                         BOOL fromCache) {
   FSTDocument *doc =
       data ? FSTTestDoc(path, version, data,
-                        hasMutations ? FSTDocumentStateLocalMutations : FSTDocumentStateSynced)
+                        hasMutations ? DocumentState::kLocalMutations : DocumentState::kSynced)
            : nil;
   return [[FIRDocumentSnapshot alloc] initWithFirestore:FSTTestFirestore().wrapped
                                             documentKey:testutil::Key(path)
@@ -106,7 +108,7 @@ FIRQuerySnapshot *FSTTestQuerySnapshot(
   for (NSString *key in oldDocs) {
     oldDocuments = oldDocuments.insert(
         FSTTestDoc(util::StringFormat("%s/%s", path, key), 1, oldDocs[key],
-                   hasPendingWrites ? FSTDocumentStateLocalMutations : FSTDocumentStateSynced));
+                   hasPendingWrites ? DocumentState::kLocalMutations : DocumentState::kSynced));
     if (hasPendingWrites) {
       const std::string documentKey = util::StringFormat("%s/%s", path, key);
       mutatedKeys = mutatedKeys.insert(testutil::Key(documentKey));
@@ -117,7 +119,7 @@ FIRQuerySnapshot *FSTTestQuerySnapshot(
   for (NSString *key in docsToAdd) {
     FSTDocument *docToAdd =
         FSTTestDoc(util::StringFormat("%s/%s", path, key), 1, docsToAdd[key],
-                   hasPendingWrites ? FSTDocumentStateLocalMutations : FSTDocumentStateSynced);
+                   hasPendingWrites ? DocumentState::kLocalMutations : DocumentState::kSynced);
     newDocuments = newDocuments.insert(docToAdd);
     documentChanges.emplace_back(docToAdd, DocumentViewChange::Type::kAdded);
     if (hasPendingWrites) {

--- a/Firestore/Example/Tests/Core/FSTQueryListenerTests.mm
+++ b/Firestore/Example/Tests/Core/FSTQueryListenerTests.mm
@@ -49,6 +49,7 @@ using firebase::firestore::core::QueryListener;
 using firebase::firestore::core::ViewSnapshot;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::DocumentSet;
+using firebase::firestore::model::DocumentState;
 using firebase::firestore::model::OnlineState;
 using firebase::firestore::remote::TargetChange;
 using firebase::firestore::util::DelayedConstructor;
@@ -103,10 +104,10 @@ ViewSnapshot::Listener Accumulating(std::vector<ViewSnapshot> *values) {
   std::vector<ViewSnapshot> otherAccum;
 
   FSTQuery *query = FSTTestQuery("rooms");
-  FSTDocument *doc1 = FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("rooms/Hades", 2, @{@"name" : @"Hades"}, FSTDocumentStateSynced);
+  FSTDocument *doc1 = FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("rooms/Hades", 2, @{@"name" : @"Hades"}, DocumentState::kSynced);
   FSTDocument *doc2prime = FSTTestDoc("rooms/Hades", 3, @{@"name" : @"Hades", @"owner" : @"Jonny"},
-                                      FSTDocumentStateSynced);
+                                      DocumentState::kSynced);
 
   auto listener = QueryListener::Create(query, _includeMetadataChanges, Accumulating(&accum));
   auto otherListener = QueryListener::Create(query, Accumulating(&otherAccum));
@@ -174,8 +175,8 @@ ViewSnapshot::Listener Accumulating(std::vector<ViewSnapshot> *values) {
   std::vector<ViewSnapshot> accum;
 
   FSTQuery *query = FSTTestQuery("rooms/Eros");
-  FSTDocument *doc1 = FSTTestDoc("rooms/Eros", 3, @{@"name" : @"Eros"}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("rooms/Eros", 4, @{@"name" : @"Eros2"}, FSTDocumentStateSynced);
+  FSTDocument *doc1 = FSTTestDoc("rooms/Eros", 3, @{@"name" : @"Eros"}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("rooms/Eros", 4, @{@"name" : @"Eros2"}, DocumentState::kSynced);
 
   std::shared_ptr<AsyncEventListener<ViewSnapshot>> listener =
       AsyncEventListener<ViewSnapshot>::Create(
@@ -212,8 +213,8 @@ ViewSnapshot::Listener Accumulating(std::vector<ViewSnapshot> *values) {
   std::vector<ViewSnapshot> fullAccum;
 
   FSTQuery *query = FSTTestQuery("rooms");
-  FSTDocument *doc1 = FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("rooms/Hades", 2, @{@"name" : @"Hades"}, FSTDocumentStateSynced);
+  FSTDocument *doc1 = FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("rooms/Hades", 2, @{@"name" : @"Hades"}, DocumentState::kSynced);
 
   auto filteredListener = QueryListener::Create(query, Accumulating(&filteredAccum));
   auto fullListener =
@@ -245,11 +246,11 @@ ViewSnapshot::Listener Accumulating(std::vector<ViewSnapshot> *values) {
 
   FSTQuery *query = FSTTestQuery("rooms");
   FSTDocument *doc1 =
-      FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, FSTDocumentStateLocalMutations);
-  FSTDocument *doc2 = FSTTestDoc("rooms/Hades", 2, @{@"name" : @"Hades"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, DocumentState::kLocalMutations);
+  FSTDocument *doc2 = FSTTestDoc("rooms/Hades", 2, @{@"name" : @"Hades"}, DocumentState::kSynced);
   FSTDocument *doc1Prime =
-      FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, FSTDocumentStateSynced);
-  FSTDocument *doc3 = FSTTestDoc("rooms/Other", 3, @{@"name" : @"Other"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, DocumentState::kSynced);
+  FSTDocument *doc3 = FSTTestDoc("rooms/Other", 3, @{@"name" : @"Other"}, DocumentState::kSynced);
 
   ListenOptions options(
       /*include_query_metadata_changes=*/false,
@@ -292,14 +293,14 @@ ViewSnapshot::Listener Accumulating(std::vector<ViewSnapshot> *values) {
 
   FSTQuery *query = FSTTestQuery("rooms");
   FSTDocument *doc1 =
-      FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, FSTDocumentStateLocalMutations);
+      FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, DocumentState::kLocalMutations);
   FSTDocument *doc2 =
-      FSTTestDoc("rooms/Hades", 2, @{@"name" : @"Hades"}, FSTDocumentStateLocalMutations);
+      FSTTestDoc("rooms/Hades", 2, @{@"name" : @"Hades"}, DocumentState::kLocalMutations);
   FSTDocument *doc1Prime =
-      FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, DocumentState::kSynced);
   FSTDocument *doc2Prime =
-      FSTTestDoc("rooms/Hades", 2, @{@"name" : @"Hades"}, FSTDocumentStateSynced);
-  FSTDocument *doc3 = FSTTestDoc("rooms/Other", 3, @{@"name" : @"Other"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/Hades", 2, @{@"name" : @"Hades"}, DocumentState::kSynced);
+  FSTDocument *doc3 = FSTTestDoc("rooms/Other", 3, @{@"name" : @"Other"}, DocumentState::kSynced);
 
   ListenOptions options(
       /*include_query_metadata_changes=*/true,
@@ -338,11 +339,11 @@ ViewSnapshot::Listener Accumulating(std::vector<ViewSnapshot> *values) {
 
   FSTQuery *query = FSTTestQuery("rooms");
   FSTDocument *doc1 =
-      FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, FSTDocumentStateLocalMutations);
-  FSTDocument *doc2 = FSTTestDoc("rooms/Hades", 2, @{@"name" : @"Hades"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, DocumentState::kLocalMutations);
+  FSTDocument *doc2 = FSTTestDoc("rooms/Hades", 2, @{@"name" : @"Hades"}, DocumentState::kSynced);
   FSTDocument *doc1Prime =
-      FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, FSTDocumentStateSynced);
-  FSTDocument *doc3 = FSTTestDoc("rooms/Other", 3, @{@"name" : @"Other"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, DocumentState::kSynced);
+  FSTDocument *doc3 = FSTTestDoc("rooms/Other", 3, @{@"name" : @"Other"}, DocumentState::kSynced);
 
   auto filteredListener = QueryListener::Create(query, Accumulating(&filteredAccum));
 
@@ -370,8 +371,8 @@ ViewSnapshot::Listener Accumulating(std::vector<ViewSnapshot> *values) {
   std::vector<ViewSnapshot> events;
 
   FSTQuery *query = FSTTestQuery("rooms");
-  FSTDocument *doc1 = FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("rooms/Hades", 2, @{@"name" : @"Hades"}, FSTDocumentStateSynced);
+  FSTDocument *doc1 = FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("rooms/Hades", 2, @{@"name" : @"Hades"}, DocumentState::kSynced);
 
   ListenOptions options(
       /*include_query_metadata_changes=*/false,
@@ -409,8 +410,8 @@ ViewSnapshot::Listener Accumulating(std::vector<ViewSnapshot> *values) {
   std::vector<ViewSnapshot> events;
 
   FSTQuery *query = FSTTestQuery("rooms");
-  FSTDocument *doc1 = FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("rooms/Hades", 2, @{@"name" : @"Hades"}, FSTDocumentStateSynced);
+  FSTDocument *doc1 = FSTTestDoc("rooms/Eros", 1, @{@"name" : @"Eros"}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("rooms/Hades", 2, @{@"name" : @"Hades"}, DocumentState::kSynced);
 
   ListenOptions options(
       /*include_query_metadata_changes=*/false,

--- a/Firestore/Example/Tests/Core/FSTQueryTests.mm
+++ b/Firestore/Example/Tests/Core/FSTQueryTests.mm
@@ -34,6 +34,7 @@ namespace testutil = firebase::firestore::testutil;
 namespace util = firebase::firestore::util;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentComparator;
+using firebase::firestore::model::DocumentState;
 using firebase::firestore::model::FieldPath;
 using firebase::firestore::model::ResourcePath;
 using firebase::firestore::util::ComparisonResult;
@@ -90,11 +91,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testMatchesBasedOnDocumentKey {
   FSTDocument *doc1 =
-      FSTTestDoc("rooms/eros/messages/1", 0, @{@"text" : @"msg1"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/1", 0, @{@"text" : @"msg1"}, DocumentState::kSynced);
   FSTDocument *doc2 =
-      FSTTestDoc("rooms/eros/messages/2", 0, @{@"text" : @"msg2"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/2", 0, @{@"text" : @"msg2"}, DocumentState::kSynced);
   FSTDocument *doc3 =
-      FSTTestDoc("rooms/other/messages/1", 0, @{@"text" : @"msg3"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/other/messages/1", 0, @{@"text" : @"msg3"}, DocumentState::kSynced);
 
   // document query
   FSTQuery *query = FSTTestQuery("rooms/eros/messages/1");
@@ -105,13 +106,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testMatchesCorrectlyForShallowAncestorQuery {
   FSTDocument *doc1 =
-      FSTTestDoc("rooms/eros/messages/1", 0, @{@"text" : @"msg1"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/1", 0, @{@"text" : @"msg1"}, DocumentState::kSynced);
   FSTDocument *doc1Meta =
-      FSTTestDoc("rooms/eros/messages/1/meta/1", 0, @{@"meta" : @"mv"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/1/meta/1", 0, @{@"meta" : @"mv"}, DocumentState::kSynced);
   FSTDocument *doc2 =
-      FSTTestDoc("rooms/eros/messages/2", 0, @{@"text" : @"msg2"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/2", 0, @{@"text" : @"msg2"}, DocumentState::kSynced);
   FSTDocument *doc3 =
-      FSTTestDoc("rooms/other/messages/1", 0, @{@"text" : @"msg3"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/other/messages/1", 0, @{@"text" : @"msg3"}, DocumentState::kSynced);
 
   // shallow ancestor query
   FSTQuery *query = FSTTestQuery("rooms/eros/messages");
@@ -123,8 +124,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)testEmptyFieldsAreAllowedForQueries {
   FSTDocument *doc1 =
-      FSTTestDoc("rooms/eros/messages/1", 0, @{@"text" : @"msg1"}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/2", 0, @{}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/1", 0, @{@"text" : @"msg1"}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/2", 0, @{}, DocumentState::kSynced);
 
   FSTQuery *query = [FSTTestQuery("rooms/eros/messages")
       queryByAddingFilter:FSTTestFilter("text", @"==", @"msg1")];
@@ -138,12 +139,12 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQuery *query2 =
       [FSTTestQuery("collection") queryByAddingFilter:FSTTestFilter("sort", @"<=", @(2))];
 
-  FSTDocument *doc1 = FSTTestDoc("collection/1", 0, @{@"sort" : @1}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{@"sort" : @2}, FSTDocumentStateSynced);
-  FSTDocument *doc3 = FSTTestDoc("collection/3", 0, @{@"sort" : @3}, FSTDocumentStateSynced);
-  FSTDocument *doc4 = FSTTestDoc("collection/4", 0, @{@"sort" : @NO}, FSTDocumentStateSynced);
-  FSTDocument *doc5 = FSTTestDoc("collection/5", 0, @{@"sort" : @"string"}, FSTDocumentStateSynced);
-  FSTDocument *doc6 = FSTTestDoc("collection/6", 0, @{}, FSTDocumentStateSynced);
+  FSTDocument *doc1 = FSTTestDoc("collection/1", 0, @{@"sort" : @1}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{@"sort" : @2}, DocumentState::kSynced);
+  FSTDocument *doc3 = FSTTestDoc("collection/3", 0, @{@"sort" : @3}, DocumentState::kSynced);
+  FSTDocument *doc4 = FSTTestDoc("collection/4", 0, @{@"sort" : @NO}, DocumentState::kSynced);
+  FSTDocument *doc5 = FSTTestDoc("collection/5", 0, @{@"sort" : @"string"}, DocumentState::kSynced);
+  FSTDocument *doc6 = FSTTestDoc("collection/6", 0, @{}, DocumentState::kSynced);
 
   XCTAssertFalse([query1 matchesDocument:doc1]);
   XCTAssertTrue([query1 matchesDocument:doc2]);
@@ -165,23 +166,23 @@ NS_ASSUME_NONNULL_BEGIN
       queryByAddingFilter:FSTTestFilter("array", @"array_contains", @42)];
 
   // not an array.
-  FSTDocument *doc = FSTTestDoc("collection/1", 0, @{@"array" : @1}, FSTDocumentStateSynced);
+  FSTDocument *doc = FSTTestDoc("collection/1", 0, @{@"array" : @1}, DocumentState::kSynced);
   XCTAssertFalse([query matchesDocument:doc]);
 
   // empty array.
-  doc = FSTTestDoc("collection/1", 0, @{@"array" : @[]}, FSTDocumentStateSynced);
+  doc = FSTTestDoc("collection/1", 0, @{@"array" : @[]}, DocumentState::kSynced);
   XCTAssertFalse([query matchesDocument:doc]);
 
   // array without element (and make sure it doesn't match in a nested field or a different field).
   doc = FSTTestDoc(
       "collection/1", 0,
       @{@"array" : @[ @41, @"42", @{@"a" : @42, @"b" : @[ @42 ]} ], @"different" : @[ @42 ]},
-      FSTDocumentStateSynced);
+      DocumentState::kSynced);
   XCTAssertFalse([query matchesDocument:doc]);
 
   // array with element.
   doc = FSTTestDoc("collection/1", 0, @{@"array" : @[ @1, @"2", @42, @{@"a" : @1} ]},
-                   FSTDocumentStateSynced);
+                   DocumentState::kSynced);
   XCTAssertTrue([query matchesDocument:doc]);
 }
 
@@ -196,12 +197,12 @@ NS_ASSUME_NONNULL_BEGIN
       @{@"a" : @42}, @{@"a" : @[ @42, @43 ]}, @{@"b" : @[ @42 ]}, @{@"a" : @[ @42 ], @"b" : @42}
     ]
   },
-                                FSTDocumentStateSynced);
+                                DocumentState::kSynced);
   XCTAssertFalse([query matchesDocument:doc]);
 
   // array with element.
   doc = FSTTestDoc("collection/1", 0, @{@"array" : @[ @1, @"2", @42, @{@"a" : @[ @42 ]} ]},
-                   FSTDocumentStateSynced);
+                   DocumentState::kSynced);
   XCTAssertTrue([query matchesDocument:doc]);
 }
 
@@ -209,11 +210,11 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQuery *query =
       [FSTTestQuery("collection") queryByAddingFilter:FSTTestFilter("sort", @"==", [NSNull null])];
   FSTDocument *doc1 =
-      FSTTestDoc("collection/1", 0, @{@"sort" : [NSNull null]}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{@"sort" : @2}, FSTDocumentStateSynced);
-  FSTDocument *doc3 = FSTTestDoc("collection/2", 0, @{@"sort" : @3.1}, FSTDocumentStateSynced);
-  FSTDocument *doc4 = FSTTestDoc("collection/4", 0, @{@"sort" : @NO}, FSTDocumentStateSynced);
-  FSTDocument *doc5 = FSTTestDoc("collection/5", 0, @{@"sort" : @"string"}, FSTDocumentStateSynced);
+      FSTTestDoc("collection/1", 0, @{@"sort" : [NSNull null]}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{@"sort" : @2}, DocumentState::kSynced);
+  FSTDocument *doc3 = FSTTestDoc("collection/2", 0, @{@"sort" : @3.1}, DocumentState::kSynced);
+  FSTDocument *doc4 = FSTTestDoc("collection/4", 0, @{@"sort" : @NO}, DocumentState::kSynced);
+  FSTDocument *doc5 = FSTTestDoc("collection/5", 0, @{@"sort" : @"string"}, DocumentState::kSynced);
 
   XCTAssertTrue([query matchesDocument:doc1]);
   XCTAssertFalse([query matchesDocument:doc2]);
@@ -225,11 +226,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testNanFilter {
   FSTQuery *query =
       [FSTTestQuery("collection") queryByAddingFilter:FSTTestFilter("sort", @"==", @(NAN))];
-  FSTDocument *doc1 = FSTTestDoc("collection/1", 0, @{@"sort" : @(NAN)}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{@"sort" : @2}, FSTDocumentStateSynced);
-  FSTDocument *doc3 = FSTTestDoc("collection/2", 0, @{@"sort" : @3.1}, FSTDocumentStateSynced);
-  FSTDocument *doc4 = FSTTestDoc("collection/4", 0, @{@"sort" : @NO}, FSTDocumentStateSynced);
-  FSTDocument *doc5 = FSTTestDoc("collection/5", 0, @{@"sort" : @"string"}, FSTDocumentStateSynced);
+  FSTDocument *doc1 = FSTTestDoc("collection/1", 0, @{@"sort" : @(NAN)}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{@"sort" : @2}, DocumentState::kSynced);
+  FSTDocument *doc3 = FSTTestDoc("collection/2", 0, @{@"sort" : @3.1}, DocumentState::kSynced);
+  FSTDocument *doc4 = FSTTestDoc("collection/4", 0, @{@"sort" : @NO}, DocumentState::kSynced);
+  FSTDocument *doc5 = FSTTestDoc("collection/5", 0, @{@"sort" : @"string"}, DocumentState::kSynced);
 
   XCTAssertTrue([query matchesDocument:doc1]);
   XCTAssertFalse([query matchesDocument:doc2]);
@@ -244,17 +245,17 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQuery *query2 =
       [FSTTestQuery("collection") queryByAddingFilter:FSTTestFilter("sort", @">=", @(2))];
 
-  FSTDocument *doc1 = FSTTestDoc("collection/1", 0, @{@"sort" : @2}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{@"sort" : @[]}, FSTDocumentStateSynced);
-  FSTDocument *doc3 = FSTTestDoc("collection/3", 0, @{@"sort" : @[ @1 ]}, FSTDocumentStateSynced);
+  FSTDocument *doc1 = FSTTestDoc("collection/1", 0, @{@"sort" : @2}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{@"sort" : @[]}, DocumentState::kSynced);
+  FSTDocument *doc3 = FSTTestDoc("collection/3", 0, @{@"sort" : @[ @1 ]}, DocumentState::kSynced);
   FSTDocument *doc4 =
-      FSTTestDoc("collection/4", 0, @{@"sort" : @{@"foo" : @2}}, FSTDocumentStateSynced);
+      FSTTestDoc("collection/4", 0, @{@"sort" : @{@"foo" : @2}}, DocumentState::kSynced);
   FSTDocument *doc5 =
-      FSTTestDoc("collection/5", 0, @{@"sort" : @{@"foo" : @"bar"}}, FSTDocumentStateSynced);
+      FSTTestDoc("collection/5", 0, @{@"sort" : @{@"foo" : @"bar"}}, DocumentState::kSynced);
   FSTDocument *doc6 =
-      FSTTestDoc("collection/6", 0, @{@"sort" : @{}}, FSTDocumentStateSynced);  // no sort field
+      FSTTestDoc("collection/6", 0, @{@"sort" : @{}}, DocumentState::kSynced);  // no sort field
   FSTDocument *doc7 =
-      FSTTestDoc("collection/7", 0, @{@"sort" : @[ @3, @1 ]}, FSTDocumentStateSynced);
+      FSTTestDoc("collection/7", 0, @{@"sort" : @[ @3, @1 ]}, DocumentState::kSynced);
 
   XCTAssertTrue([query1 matchesDocument:doc1]);
   XCTAssertFalse([query1 matchesDocument:doc2]);
@@ -278,14 +279,14 @@ NS_ASSUME_NONNULL_BEGIN
       queryByAddingSortOrder:[FSTSortOrder sortOrderWithFieldPath:testutil::Field("sort")
                                                         ascending:YES]];
 
-  FSTDocument *doc1 = FSTTestDoc("collection/1", 0, @{@"sort" : @2}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{@"sort" : @[]}, FSTDocumentStateSynced);
-  FSTDocument *doc3 = FSTTestDoc("collection/3", 0, @{@"sort" : @[ @1 ]}, FSTDocumentStateSynced);
+  FSTDocument *doc1 = FSTTestDoc("collection/1", 0, @{@"sort" : @2}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("collection/2", 0, @{@"sort" : @[]}, DocumentState::kSynced);
+  FSTDocument *doc3 = FSTTestDoc("collection/3", 0, @{@"sort" : @[ @1 ]}, DocumentState::kSynced);
   FSTDocument *doc4 =
-      FSTTestDoc("collection/4", 0, @{@"sort" : @{@"foo" : @2}}, FSTDocumentStateSynced);
+      FSTTestDoc("collection/4", 0, @{@"sort" : @{@"foo" : @2}}, DocumentState::kSynced);
   FSTDocument *doc5 =
-      FSTTestDoc("collection/5", 0, @{@"sort" : @{@"foo" : @"bar"}}, FSTDocumentStateSynced);
-  FSTDocument *doc6 = FSTTestDoc("collection/6", 0, @{}, FSTDocumentStateSynced);
+      FSTTestDoc("collection/5", 0, @{@"sort" : @{@"foo" : @"bar"}}, DocumentState::kSynced);
+  FSTDocument *doc6 = FSTTestDoc("collection/6", 0, @{}, DocumentState::kSynced);
 
   XCTAssertTrue([query1 matchesDocument:doc1]);
   XCTAssertTrue([query1 matchesDocument:doc2]);
@@ -298,7 +299,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testFiltersBasedOnArrayValue {
   FSTQuery *baseQuery = FSTTestQuery("collection");
   FSTDocument *doc1 =
-      FSTTestDoc("collection/doc", 0, @{@"tags" : @[ @"foo", @1, @YES ]}, FSTDocumentStateSynced);
+      FSTTestDoc("collection/doc", 0, @{@"tags" : @[ @"foo", @1, @YES ]}, DocumentState::kSynced);
 
   NSArray<FSTFilter *> *matchingFilters = @[ FSTTestFilter("tags", @"==", @[ @"foo", @1, @YES ]) ];
 
@@ -321,7 +322,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQuery *baseQuery = FSTTestQuery("collection");
   FSTDocument *doc1 = FSTTestDoc(
       "collection/doc", 0, @{@"tags" : @{@"foo" : @"foo", @"a" : @0, @"b" : @YES, @"c" : @(NAN)}},
-      FSTDocumentStateSynced);
+      DocumentState::kSynced);
 
   NSArray<FSTFilter *> *matchingFilters = @[
     FSTTestFilter("tags", @"==", @{@"foo" : @"foo", @"a" : @0, @"b" : @YES, @"c" : @(NAN)}),
@@ -369,21 +370,21 @@ NS_ASSUME_NONNULL_BEGIN
 
   // clang-format off
   NSArray<FSTDocument *> *docs = @[
-      FSTTestDoc("collection/1", 0, @{@"sort": [NSNull null]}, FSTDocumentStateSynced),
-      FSTTestDoc("collection/1", 0, @{@"sort": @NO}, FSTDocumentStateSynced),
-      FSTTestDoc("collection/1", 0, @{@"sort": @YES}, FSTDocumentStateSynced),
-      FSTTestDoc("collection/1", 0, @{@"sort": @1}, FSTDocumentStateSynced),
-      FSTTestDoc("collection/2", 0, @{@"sort": @1}, FSTDocumentStateSynced),  // by key
-      FSTTestDoc("collection/3", 0, @{@"sort": @1}, FSTDocumentStateSynced),  // by key
-      FSTTestDoc("collection/1", 0, @{@"sort": @1.9}, FSTDocumentStateSynced),
-      FSTTestDoc("collection/1", 0, @{@"sort": @2}, FSTDocumentStateSynced),
-      FSTTestDoc("collection/1", 0, @{@"sort": @2.1}, FSTDocumentStateSynced),
-      FSTTestDoc("collection/1", 0, @{@"sort": @""}, FSTDocumentStateSynced),
-      FSTTestDoc("collection/1", 0, @{@"sort": @"a"}, FSTDocumentStateSynced),
-      FSTTestDoc("collection/1", 0, @{@"sort": @"ab"}, FSTDocumentStateSynced),
-      FSTTestDoc("collection/1", 0, @{@"sort": @"b"}, FSTDocumentStateSynced),
+      FSTTestDoc("collection/1", 0, @{@"sort": [NSNull null]}, DocumentState::kSynced),
+      FSTTestDoc("collection/1", 0, @{@"sort": @NO}, DocumentState::kSynced),
+      FSTTestDoc("collection/1", 0, @{@"sort": @YES}, DocumentState::kSynced),
+      FSTTestDoc("collection/1", 0, @{@"sort": @1}, DocumentState::kSynced),
+      FSTTestDoc("collection/2", 0, @{@"sort": @1}, DocumentState::kSynced),  // by key
+      FSTTestDoc("collection/3", 0, @{@"sort": @1}, DocumentState::kSynced),  // by key
+      FSTTestDoc("collection/1", 0, @{@"sort": @1.9}, DocumentState::kSynced),
+      FSTTestDoc("collection/1", 0, @{@"sort": @2}, DocumentState::kSynced),
+      FSTTestDoc("collection/1", 0, @{@"sort": @2.1}, DocumentState::kSynced),
+      FSTTestDoc("collection/1", 0, @{@"sort": @""}, DocumentState::kSynced),
+      FSTTestDoc("collection/1", 0, @{@"sort": @"a"}, DocumentState::kSynced),
+      FSTTestDoc("collection/1", 0, @{@"sort": @"ab"}, DocumentState::kSynced),
+      FSTTestDoc("collection/1", 0, @{@"sort": @"b"}, DocumentState::kSynced),
       FSTTestDoc("collection/1", 0, @{@"sort":
-          FSTTestRef("project", DatabaseId::kDefault, @"collection/id1")}, FSTDocumentStateSynced),
+          FSTTestRef("project", DatabaseId::kDefault, @"collection/id1")}, DocumentState::kSynced),
   ];
   // clang-format on
 
@@ -401,16 +402,16 @@ NS_ASSUME_NONNULL_BEGIN
 
   // clang-format off
   NSArray<FSTDocument *> *docs =
-      @[FSTTestDoc("collection/1", 0, @{@"sort1": @1, @"sort2": @1}, FSTDocumentStateSynced),
-        FSTTestDoc("collection/1", 0, @{@"sort1": @1, @"sort2": @2}, FSTDocumentStateSynced),
-        FSTTestDoc("collection/2", 0, @{@"sort1": @1, @"sort2": @2}, FSTDocumentStateSynced),  // by key
-        FSTTestDoc("collection/3", 0, @{@"sort1": @1, @"sort2": @2}, FSTDocumentStateSynced),  // by key
-        FSTTestDoc("collection/1", 0, @{@"sort1": @1, @"sort2": @3}, FSTDocumentStateSynced),
-        FSTTestDoc("collection/1", 0, @{@"sort1": @2, @"sort2": @1}, FSTDocumentStateSynced),
-        FSTTestDoc("collection/1", 0, @{@"sort1": @2, @"sort2": @2}, FSTDocumentStateSynced),
-        FSTTestDoc("collection/2", 0, @{@"sort1": @2, @"sort2": @2}, FSTDocumentStateSynced),  // by key
-        FSTTestDoc("collection/3", 0, @{@"sort1": @2, @"sort2": @2}, FSTDocumentStateSynced),  // by key
-        FSTTestDoc("collection/1", 0, @{@"sort1": @2, @"sort2": @3}, FSTDocumentStateSynced),
+      @[FSTTestDoc("collection/1", 0, @{@"sort1": @1, @"sort2": @1}, DocumentState::kSynced),
+        FSTTestDoc("collection/1", 0, @{@"sort1": @1, @"sort2": @2}, DocumentState::kSynced),
+        FSTTestDoc("collection/2", 0, @{@"sort1": @1, @"sort2": @2}, DocumentState::kSynced),  // by key
+        FSTTestDoc("collection/3", 0, @{@"sort1": @1, @"sort2": @2}, DocumentState::kSynced),  // by key
+        FSTTestDoc("collection/1", 0, @{@"sort1": @1, @"sort2": @3}, DocumentState::kSynced),
+        FSTTestDoc("collection/1", 0, @{@"sort1": @2, @"sort2": @1}, DocumentState::kSynced),
+        FSTTestDoc("collection/1", 0, @{@"sort1": @2, @"sort2": @2}, DocumentState::kSynced),
+        FSTTestDoc("collection/2", 0, @{@"sort1": @2, @"sort2": @2}, DocumentState::kSynced),  // by key
+        FSTTestDoc("collection/3", 0, @{@"sort1": @2, @"sort2": @2}, DocumentState::kSynced),  // by key
+        FSTTestDoc("collection/1", 0, @{@"sort1": @2, @"sort2": @3}, DocumentState::kSynced),
         ];
   // clang-format on
 
@@ -428,16 +429,16 @@ NS_ASSUME_NONNULL_BEGIN
 
   // clang-format off
   NSArray<FSTDocument *> *docs =
-      @[FSTTestDoc("collection/1", 0, @{@"sort1": @2, @"sort2": @3}, FSTDocumentStateSynced),
-        FSTTestDoc("collection/3", 0, @{@"sort1": @2, @"sort2": @2}, FSTDocumentStateSynced),
-        FSTTestDoc("collection/2", 0, @{@"sort1": @2, @"sort2": @2}, FSTDocumentStateSynced),  // by key
-        FSTTestDoc("collection/1", 0, @{@"sort1": @2, @"sort2": @2}, FSTDocumentStateSynced),  // by key
-        FSTTestDoc("collection/1", 0, @{@"sort1": @2, @"sort2": @1}, FSTDocumentStateSynced),
-        FSTTestDoc("collection/1", 0, @{@"sort1": @1, @"sort2": @3}, FSTDocumentStateSynced),
-        FSTTestDoc("collection/3", 0, @{@"sort1": @1, @"sort2": @2}, FSTDocumentStateSynced),
-        FSTTestDoc("collection/2", 0, @{@"sort1": @1, @"sort2": @2}, FSTDocumentStateSynced),  // by key
-        FSTTestDoc("collection/1", 0, @{@"sort1": @1, @"sort2": @2}, FSTDocumentStateSynced),  // by key
-        FSTTestDoc("collection/1", 0, @{@"sort1": @1, @"sort2": @1}, FSTDocumentStateSynced),
+      @[FSTTestDoc("collection/1", 0, @{@"sort1": @2, @"sort2": @3}, DocumentState::kSynced),
+        FSTTestDoc("collection/3", 0, @{@"sort1": @2, @"sort2": @2}, DocumentState::kSynced),
+        FSTTestDoc("collection/2", 0, @{@"sort1": @2, @"sort2": @2}, DocumentState::kSynced),  // by key
+        FSTTestDoc("collection/1", 0, @{@"sort1": @2, @"sort2": @2}, DocumentState::kSynced),  // by key
+        FSTTestDoc("collection/1", 0, @{@"sort1": @2, @"sort2": @1}, DocumentState::kSynced),
+        FSTTestDoc("collection/1", 0, @{@"sort1": @1, @"sort2": @3}, DocumentState::kSynced),
+        FSTTestDoc("collection/3", 0, @{@"sort1": @1, @"sort2": @2}, DocumentState::kSynced),
+        FSTTestDoc("collection/2", 0, @{@"sort1": @1, @"sort2": @2}, DocumentState::kSynced),  // by key
+        FSTTestDoc("collection/1", 0, @{@"sort1": @1, @"sort2": @2}, DocumentState::kSynced),  // by key
+        FSTTestDoc("collection/1", 0, @{@"sort1": @1, @"sort2": @1}, DocumentState::kSynced),
         ];
   // clang-format on
 

--- a/Firestore/Example/Tests/Core/FSTViewSnapshotTest.mm
+++ b/Firestore/Example/Tests/Core/FSTViewSnapshotTest.mm
@@ -32,6 +32,7 @@ using firebase::firestore::core::ViewSnapshot;
 using firebase::firestore::model::DocumentComparator;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::DocumentSet;
+using firebase::firestore::model::DocumentState;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -41,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation FSTViewSnapshotTests
 
 - (void)testDocumentChangeConstructor {
-  FSTDocument *doc = FSTTestDoc("a/b", 0, @{}, FSTDocumentStateSynced);
+  FSTDocument *doc = FSTTestDoc("a/b", 0, @{}, DocumentState::kSynced);
   DocumentViewChange::Type type = DocumentViewChange::Type::kModified;
   DocumentViewChange change{doc, type};
   XCTAssertEqual(change.document(), doc);
@@ -51,15 +52,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testTrack {
   DocumentViewChangeSet set;
 
-  FSTDocument *docAdded = FSTTestDoc("a/1", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument *docRemoved = FSTTestDoc("a/2", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument *docModified = FSTTestDoc("a/3", 0, @{}, FSTDocumentStateSynced);
+  FSTDocument *docAdded = FSTTestDoc("a/1", 0, @{}, DocumentState::kSynced);
+  FSTDocument *docRemoved = FSTTestDoc("a/2", 0, @{}, DocumentState::kSynced);
+  FSTDocument *docModified = FSTTestDoc("a/3", 0, @{}, DocumentState::kSynced);
 
-  FSTDocument *docAddedThenModified = FSTTestDoc("b/1", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument *docAddedThenRemoved = FSTTestDoc("b/2", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument *docRemovedThenAdded = FSTTestDoc("b/3", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument *docModifiedThenRemoved = FSTTestDoc("b/4", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument *docModifiedThenModified = FSTTestDoc("b/5", 0, @{}, FSTDocumentStateSynced);
+  FSTDocument *docAddedThenModified = FSTTestDoc("b/1", 0, @{}, DocumentState::kSynced);
+  FSTDocument *docAddedThenRemoved = FSTTestDoc("b/2", 0, @{}, DocumentState::kSynced);
+  FSTDocument *docRemovedThenAdded = FSTTestDoc("b/3", 0, @{}, DocumentState::kSynced);
+  FSTDocument *docModifiedThenRemoved = FSTTestDoc("b/4", 0, @{}, DocumentState::kSynced);
+  FSTDocument *docModifiedThenModified = FSTTestDoc("b/5", 0, @{}, DocumentState::kSynced);
 
   set.AddChange(DocumentViewChange{docAdded, DocumentViewChange::Type::kAdded});
   set.AddChange(DocumentViewChange{docRemoved, DocumentViewChange::Type::kRemoved});
@@ -104,9 +105,9 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQuery *query = FSTTestQuery("a");
   DocumentSet documents = DocumentSet{DocumentComparator::ByKey()};
   DocumentSet oldDocuments = documents;
-  documents = documents.insert(FSTTestDoc("c/a", 1, @{}, FSTDocumentStateSynced));
+  documents = documents.insert(FSTTestDoc("c/a", 1, @{}, DocumentState::kSynced));
   std::vector<DocumentViewChange> documentChanges{DocumentViewChange{
-      FSTTestDoc("c/a", 1, @{}, FSTDocumentStateSynced), DocumentViewChange::Type::kAdded}};
+      FSTTestDoc("c/a", 1, @{}, DocumentState::kSynced), DocumentViewChange::Type::kAdded}};
 
   bool fromCache = true;
   DocumentKeySet mutatedKeys;

--- a/Firestore/Example/Tests/Core/FSTViewTests.mm
+++ b/Firestore/Example/Tests/Core/FSTViewTests.mm
@@ -43,6 +43,7 @@ using firebase::firestore::core::ViewSnapshot;
 using firebase::firestore::model::ResourcePath;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::DocumentSet;
+using firebase::firestore::model::DocumentState;
 using firebase::firestore::model::FieldValue;
 using testing::ElementsAre;
 
@@ -85,11 +86,11 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   FSTDocument *doc1 =
-      FSTTestDoc("rooms/eros/messages/1", 0, @{@"text" : @"msg1"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/1", 0, @{@"text" : @"msg1"}, DocumentState::kSynced);
   FSTDocument *doc2 =
-      FSTTestDoc("rooms/eros/messages/2", 0, @{@"text" : @"msg2"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/2", 0, @{@"text" : @"msg2"}, DocumentState::kSynced);
   FSTDocument *doc3 =
-      FSTTestDoc("rooms/other/messages/1", 0, @{@"text" : @"msg3"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/other/messages/1", 0, @{@"text" : @"msg3"}, DocumentState::kSynced);
 
   absl::optional<ViewSnapshot> maybe_snapshot = FSTTestApplyChanges(
       view, @[ doc1, doc2, doc3 ], FSTTestTargetChangeAckDocuments({doc1.key, doc2.key, doc3.key}));
@@ -115,11 +116,11 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   FSTDocument *doc1 =
-      FSTTestDoc("rooms/eros/messages/1", 0, @{@"text" : @"msg1"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/1", 0, @{@"text" : @"msg1"}, DocumentState::kSynced);
   FSTDocument *doc2 =
-      FSTTestDoc("rooms/eros/messages/2", 0, @{@"text" : @"msg2"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/2", 0, @{@"text" : @"msg2"}, DocumentState::kSynced);
   FSTDocument *doc3 =
-      FSTTestDoc("rooms/eros/messages/3", 0, @{@"text" : @"msg3"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/3", 0, @{@"text" : @"msg3"}, DocumentState::kSynced);
 
   // initial state
   FSTTestApplyChanges(view, @[ doc1, doc2 ], absl::nullopt);
@@ -149,9 +150,9 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   FSTDocument *doc1 =
-      FSTTestDoc("rooms/eros/messages/1", 0, @{@"text" : @"msg1"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/1", 0, @{@"text" : @"msg1"}, DocumentState::kSynced);
   FSTDocument *doc2 =
-      FSTTestDoc("rooms/eros/messages/2", 0, @{@"text" : @"msg2"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/2", 0, @{@"text" : @"msg2"}, DocumentState::kSynced);
 
   // initial state
   FSTTestApplyChanges(view, @[ doc1, doc2 ], absl::nullopt);
@@ -178,15 +179,15 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
 
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
   FSTDocument *doc1 =
-      FSTTestDoc("rooms/eros/messages/1", 0, @{@"sort" : @1}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/1", 0, @{@"sort" : @1}, DocumentState::kSynced);
   FSTDocument *doc2 =
-      FSTTestDoc("rooms/eros/messages/2", 0, @{@"sort" : @2}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/2", 0, @{@"sort" : @2}, DocumentState::kSynced);
   FSTDocument *doc3 =
-      FSTTestDoc("rooms/eros/messages/3", 0, @{@"sort" : @3}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/3", 0, @{@"sort" : @3}, DocumentState::kSynced);
   FSTDocument *doc4 =
-      FSTTestDoc("rooms/eros/messages/4", 0, @{}, FSTDocumentStateSynced);  // no sort, no match
+      FSTTestDoc("rooms/eros/messages/4", 0, @{}, DocumentState::kSynced);  // no sort, no match
   FSTDocument *doc5 =
-      FSTTestDoc("rooms/eros/messages/5", 0, @{@"sort" : @1}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/5", 0, @{@"sort" : @1}, DocumentState::kSynced);
 
   absl::optional<ViewSnapshot> maybe_snapshot =
       FSTTestApplyChanges(view, @[ doc1, doc2, doc3, doc4, doc5 ], absl::nullopt);
@@ -216,12 +217,12 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
 
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
   FSTDocument *doc1 =
-      FSTTestDoc("rooms/eros/messages/1", 0, @{@"sort" : @1}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/1", 0, @{@"sort" : @1}, DocumentState::kSynced);
   FSTDocument *doc2 =
-      FSTTestDoc("rooms/eros/messages/2", 0, @{@"sort" : @3}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/2", 0, @{@"sort" : @3}, DocumentState::kSynced);
   FSTDocument *doc3 =
-      FSTTestDoc("rooms/eros/messages/3", 0, @{@"sort" : @2}, FSTDocumentStateSynced);
-  FSTDocument *doc4 = FSTTestDoc("rooms/eros/messages/4", 0, @{}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/3", 0, @{@"sort" : @2}, DocumentState::kSynced);
+  FSTDocument *doc4 = FSTTestDoc("rooms/eros/messages/4", 0, @{}, DocumentState::kSynced);
 
   ViewSnapshot snapshot =
       FSTTestApplyChanges(view, @[ doc1, doc2, doc3, doc4 ], absl::nullopt).value();
@@ -231,11 +232,11 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
   XC_ASSERT_THAT(snapshot.documents(), ElementsAre(doc1, doc3));
 
   FSTDocument *newDoc2 =
-      FSTTestDoc("rooms/eros/messages/2", 1, @{@"sort" : @2}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/2", 1, @{@"sort" : @2}, DocumentState::kSynced);
   FSTDocument *newDoc3 =
-      FSTTestDoc("rooms/eros/messages/3", 1, @{@"sort" : @3}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/3", 1, @{@"sort" : @3}, DocumentState::kSynced);
   FSTDocument *newDoc4 =
-      FSTTestDoc("rooms/eros/messages/4", 1, @{@"sort" : @0}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/4", 1, @{@"sort" : @0}, DocumentState::kSynced);
 
   snapshot = FSTTestApplyChanges(view, @[ newDoc2, newDoc3, newDoc4 ], absl::nullopt).value();
 
@@ -258,11 +259,11 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   FSTDocument *doc1 =
-      FSTTestDoc("rooms/eros/messages/1", 0, @{@"text" : @"msg1"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/1", 0, @{@"text" : @"msg1"}, DocumentState::kSynced);
   FSTDocument *doc2 =
-      FSTTestDoc("rooms/eros/messages/2", 0, @{@"text" : @"msg2"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/2", 0, @{@"text" : @"msg2"}, DocumentState::kSynced);
   FSTDocument *doc3 =
-      FSTTestDoc("rooms/eros/messages/3", 0, @{@"text" : @"msg3"}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/3", 0, @{@"text" : @"msg3"}, DocumentState::kSynced);
 
   // initial state
   FSTTestApplyChanges(view, @[ doc1, doc3 ], absl::nullopt);
@@ -294,13 +295,13 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   FSTDocument *doc1 =
-      FSTTestDoc("rooms/eros/messages/1", 0, @{@"num" : @1}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/1", 0, @{@"num" : @1}, DocumentState::kSynced);
   FSTDocument *doc2 =
-      FSTTestDoc("rooms/eros/messages/2", 0, @{@"num" : @2}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/2", 0, @{@"num" : @2}, DocumentState::kSynced);
   FSTDocument *doc3 =
-      FSTTestDoc("rooms/eros/messages/3", 0, @{@"num" : @3}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/3", 0, @{@"num" : @3}, DocumentState::kSynced);
   FSTDocument *doc4 =
-      FSTTestDoc("rooms/eros/messages/4", 0, @{@"num" : @4}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/4", 0, @{@"num" : @4}, DocumentState::kSynced);
 
   // initial state
   FSTTestApplyChanges(view, @[ doc1, doc2 ], absl::nullopt);
@@ -309,7 +310,7 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
   // doc2 will be modified + removed = removed
   // doc3 will be added
   // doc4 will be added + removed = nothing
-  doc2 = FSTTestDoc("rooms/eros/messages/2", 1, @{@"num" : @5}, FSTDocumentStateSynced);
+  doc2 = FSTTestDoc("rooms/eros/messages/2", 1, @{@"num" : @5}, DocumentState::kSynced);
   FSTViewDocumentChanges *viewDocChanges =
       [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc2, doc3, doc4 ])];
   XCTAssertTrue(viewDocChanges.needsRefill);
@@ -340,9 +341,9 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
   FSTQuery *query = [self queryForMessages];
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
-  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/2", 0, @{}, FSTDocumentStateSynced);
+  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, DocumentState::kSynced);
+  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/2", 0, @{}, DocumentState::kSynced);
 
   FSTViewChange *change = [view
       applyChangesToDocuments:[view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc1 ])]];
@@ -382,8 +383,8 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
 - (void)testResumingQueryCreatesNoLimbos {
   FSTQuery *query = [self queryForMessages];
 
-  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, FSTDocumentStateSynced);
+  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, DocumentState::kSynced);
 
   // Unlike other cases, here the view is initialized with a set of previously synced documents
   // which happens when listening to a previously listened-to query.
@@ -398,8 +399,8 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
 
 - (void)testReturnsNeedsRefillOnDeleteInLimitQuery {
   FSTQuery *query = [[self queryForMessages] queryBySettingLimit:2];
-  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, FSTDocumentStateSynced);
+  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, DocumentState::kSynced);
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   // Start with a full view.
@@ -431,11 +432,11 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
                                                                ascending:YES]];
   query = [query queryBySettingLimit:2];
   FSTDocument *doc1 =
-      FSTTestDoc("rooms/eros/messages/0", 0, @{@"order" : @1}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/0", 0, @{@"order" : @1}, DocumentState::kSynced);
   FSTDocument *doc2 =
-      FSTTestDoc("rooms/eros/messages/1", 0, @{@"order" : @2}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/1", 0, @{@"order" : @2}, DocumentState::kSynced);
   FSTDocument *doc3 =
-      FSTTestDoc("rooms/eros/messages/2", 0, @{@"order" : @3}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/2", 0, @{@"order" : @3}, DocumentState::kSynced);
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   // Start with a full view.
@@ -447,7 +448,7 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
   [view applyChangesToDocuments:changes];
 
   // Move one of the docs.
-  doc2 = FSTTestDoc("rooms/eros/messages/1", 1, @{@"order" : @2000}, FSTDocumentStateSynced);
+  doc2 = FSTTestDoc("rooms/eros/messages/1", 1, @{@"order" : @2000}, DocumentState::kSynced);
   changes = [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc2 ])];
   XC_ASSERT_THAT(changes.documentSet, ContainsDocs({doc1, doc2}));
   XCTAssertTrue(changes.needsRefill);
@@ -468,15 +469,15 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
                                                                ascending:YES]];
   query = [query queryBySettingLimit:3];
   FSTDocument *doc1 =
-      FSTTestDoc("rooms/eros/messages/0", 0, @{@"order" : @1}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/0", 0, @{@"order" : @1}, DocumentState::kSynced);
   FSTDocument *doc2 =
-      FSTTestDoc("rooms/eros/messages/1", 0, @{@"order" : @2}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/1", 0, @{@"order" : @2}, DocumentState::kSynced);
   FSTDocument *doc3 =
-      FSTTestDoc("rooms/eros/messages/2", 0, @{@"order" : @3}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/2", 0, @{@"order" : @3}, DocumentState::kSynced);
   FSTDocument *doc4 =
-      FSTTestDoc("rooms/eros/messages/3", 0, @{@"order" : @4}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/3", 0, @{@"order" : @4}, DocumentState::kSynced);
   FSTDocument *doc5 =
-      FSTTestDoc("rooms/eros/messages/4", 0, @{@"order" : @5}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/4", 0, @{@"order" : @5}, DocumentState::kSynced);
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   // Start with a full view.
@@ -488,7 +489,7 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
   [view applyChangesToDocuments:changes];
 
   // Move one of the docs.
-  doc1 = FSTTestDoc("rooms/eros/messages/0", 1, @{@"order" : @3}, FSTDocumentStateSynced);
+  doc1 = FSTTestDoc("rooms/eros/messages/0", 1, @{@"order" : @3}, DocumentState::kSynced);
   changes = [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc1 ])];
   XC_ASSERT_THAT(changes.documentSet, ContainsDocs({doc2, doc3, doc1}));
   XCTAssertFalse(changes.needsRefill);
@@ -503,15 +504,15 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
                                                                ascending:YES]];
   query = [query queryBySettingLimit:3];
   FSTDocument *doc1 =
-      FSTTestDoc("rooms/eros/messages/0", 0, @{@"order" : @1}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/0", 0, @{@"order" : @1}, DocumentState::kSynced);
   FSTDocument *doc2 =
-      FSTTestDoc("rooms/eros/messages/1", 0, @{@"order" : @2}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/1", 0, @{@"order" : @2}, DocumentState::kSynced);
   FSTDocument *doc3 =
-      FSTTestDoc("rooms/eros/messages/2", 0, @{@"order" : @3}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/2", 0, @{@"order" : @3}, DocumentState::kSynced);
   FSTDocument *doc4 =
-      FSTTestDoc("rooms/eros/messages/3", 0, @{@"order" : @4}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/3", 0, @{@"order" : @4}, DocumentState::kSynced);
   FSTDocument *doc5 =
-      FSTTestDoc("rooms/eros/messages/4", 0, @{@"order" : @5}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/4", 0, @{@"order" : @5}, DocumentState::kSynced);
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   // Start with a full view.
@@ -523,7 +524,7 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
   [view applyChangesToDocuments:changes];
 
   // Move one of the docs.
-  doc4 = FSTTestDoc("rooms/eros/messages/3", 1, @{@"order" : @6}, FSTDocumentStateSynced);
+  doc4 = FSTTestDoc("rooms/eros/messages/3", 1, @{@"order" : @6}, DocumentState::kSynced);
   changes = [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc4 ])];
   XC_ASSERT_THAT(changes.documentSet, ContainsDocs({doc1, doc2, doc3}));
   XCTAssertFalse(changes.needsRefill);
@@ -533,8 +534,8 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
 
 - (void)testDoesntNeedRefillForAdditionAfterTheLimit {
   FSTQuery *query = [[self queryForMessages] queryBySettingLimit:2];
-  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, FSTDocumentStateSynced);
+  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, DocumentState::kSynced);
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   // Start with a full view.
@@ -546,7 +547,7 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
   [view applyChangesToDocuments:changes];
 
   // Add a doc that is past the limit.
-  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/2", 1, @{}, FSTDocumentStateSynced);
+  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/2", 1, @{}, DocumentState::kSynced);
   changes = [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc3 ])];
   XC_ASSERT_THAT(changes.documentSet, ContainsDocs({doc1, doc2}));
   XCTAssertFalse(changes.needsRefill);
@@ -556,8 +557,8 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
 
 - (void)testDoesntNeedRefillForDeletionsWhenNotNearTheLimit {
   FSTQuery *query = [[self queryForMessages] queryBySettingLimit:20];
-  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, FSTDocumentStateSynced);
+  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, DocumentState::kSynced);
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   FSTViewDocumentChanges *changes =
@@ -578,8 +579,8 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
 
 - (void)testHandlesApplyingIrrelevantDocs {
   FSTQuery *query = [[self queryForMessages] queryBySettingLimit:2];
-  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, FSTDocumentStateSynced);
+  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, DocumentState::kSynced);
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   // Start with a full view.
@@ -601,8 +602,8 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
 
 - (void)testComputesMutatedKeys {
   FSTQuery *query = [self queryForMessages];
-  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, FSTDocumentStateSynced);
+  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, DocumentState::kSynced);
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   // Start with a full view.
@@ -611,15 +612,15 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
   [view applyChangesToDocuments:changes];
   XCTAssertEqual(changes.mutatedKeys, DocumentKeySet{});
 
-  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/2", 0, @{}, FSTDocumentStateLocalMutations);
+  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/2", 0, @{}, DocumentState::kLocalMutations);
   changes = [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc3 ])];
   XCTAssertEqual(changes.mutatedKeys, DocumentKeySet{doc3.key});
 }
 
 - (void)testRemovesKeysFromMutatedKeysWhenNewDocHasNoLocalChanges {
   FSTQuery *query = [self queryForMessages];
-  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, FSTDocumentStateLocalMutations);
+  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, DocumentState::kLocalMutations);
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   // Start with a full view.
@@ -628,7 +629,7 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
   [view applyChangesToDocuments:changes];
   XCTAssertEqual(changes.mutatedKeys, (DocumentKeySet{doc2.key}));
 
-  FSTDocument *doc2Prime = FSTTestDoc("rooms/eros/messages/1", 0, @{}, FSTDocumentStateSynced);
+  FSTDocument *doc2Prime = FSTTestDoc("rooms/eros/messages/1", 0, @{}, DocumentState::kSynced);
   changes = [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc2Prime ])];
   [view applyChangesToDocuments:changes];
   XCTAssertEqual(changes.mutatedKeys, DocumentKeySet{});
@@ -636,8 +637,8 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
 
 - (void)testRemembersLocalMutationsFromPreviousSnapshot {
   FSTQuery *query = [self queryForMessages];
-  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, FSTDocumentStateLocalMutations);
+  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, DocumentState::kLocalMutations);
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   // Start with a full view.
@@ -646,7 +647,7 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
   [view applyChangesToDocuments:changes];
   XCTAssertEqual(changes.mutatedKeys, (DocumentKeySet{doc2.key}));
 
-  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/2", 0, @{}, FSTDocumentStateSynced);
+  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/2", 0, @{}, DocumentState::kSynced);
   changes = [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc3 ])];
   [view applyChangesToDocuments:changes];
   XCTAssertEqual(changes.mutatedKeys, (DocumentKeySet{doc2.key}));
@@ -654,8 +655,8 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
 
 - (void)testRemembersLocalMutationsFromPreviousCallToComputeChangesWithDocuments {
   FSTQuery *query = [self queryForMessages];
-  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, FSTDocumentStateLocalMutations);
+  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/0", 0, @{}, DocumentState::kSynced);
+  FSTDocument *doc2 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, DocumentState::kLocalMutations);
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
 
   // Start with a full view.
@@ -663,14 +664,14 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
       [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc1, doc2 ])];
   XCTAssertEqual(changes.mutatedKeys, (DocumentKeySet{doc2.key}));
 
-  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/2", 0, @{}, FSTDocumentStateSynced);
+  FSTDocument *doc3 = FSTTestDoc("rooms/eros/messages/2", 0, @{}, DocumentState::kSynced);
   changes = [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc3 ]) previousChanges:changes];
   XCTAssertEqual(changes.mutatedKeys, (DocumentKeySet{doc2.key}));
 }
 
 - (void)testRaisesHasPendingWritesForPendingMutationsInInitialSnapshot {
   FSTQuery *query = [self queryForMessages];
-  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, FSTDocumentStateLocalMutations);
+  FSTDocument *doc1 = FSTTestDoc("rooms/eros/messages/1", 0, @{}, DocumentState::kLocalMutations);
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
   FSTViewDocumentChanges *changes = [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc1 ])];
   FSTViewChange *viewChange = [view applyChangesToDocuments:changes];
@@ -680,7 +681,7 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
 - (void)testDoesntRaiseHasPendingWritesForCommittedMutationsInInitialSnapshot {
   FSTQuery *query = [self queryForMessages];
   FSTDocument *doc1 =
-      FSTTestDoc("rooms/eros/messages/1", 0, @{}, FSTDocumentStateCommittedMutations);
+      FSTTestDoc("rooms/eros/messages/1", 0, @{}, DocumentState::kCommittedMutations);
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
   FSTViewDocumentChanges *changes = [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc1 ])];
   FSTViewChange *viewChange = [view applyChangesToDocuments:changes];
@@ -694,17 +695,17 @@ inline ContainsDocsMatcherP<std::vector<FSTDocument *>> ContainsDocs(
 
   FSTQuery *query = [self queryForMessages];
   FSTDocument *doc1 =
-      FSTTestDoc("rooms/eros/messages/1", 1, @{@"time" : @1}, FSTDocumentStateLocalMutations);
+      FSTTestDoc("rooms/eros/messages/1", 1, @{@"time" : @1}, DocumentState::kLocalMutations);
   FSTDocument *doc1Committed =
-      FSTTestDoc("rooms/eros/messages/1", 2, @{@"time" : @2}, FSTDocumentStateCommittedMutations);
+      FSTTestDoc("rooms/eros/messages/1", 2, @{@"time" : @2}, DocumentState::kCommittedMutations);
   FSTDocument *doc1Acknowledged =
-      FSTTestDoc("rooms/eros/messages/1", 2, @{@"time" : @2}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/1", 2, @{@"time" : @2}, DocumentState::kSynced);
   FSTDocument *doc2 =
-      FSTTestDoc("rooms/eros/messages/2", 1, @{@"time" : @1}, FSTDocumentStateLocalMutations);
+      FSTTestDoc("rooms/eros/messages/2", 1, @{@"time" : @1}, DocumentState::kLocalMutations);
   FSTDocument *doc2Modified =
-      FSTTestDoc("rooms/eros/messages/2", 2, @{@"time" : @3}, FSTDocumentStateLocalMutations);
+      FSTTestDoc("rooms/eros/messages/2", 2, @{@"time" : @3}, DocumentState::kLocalMutations);
   FSTDocument *doc2Acknowledged =
-      FSTTestDoc("rooms/eros/messages/2", 2, @{@"time" : @3}, FSTDocumentStateSynced);
+      FSTTestDoc("rooms/eros/messages/2", 2, @{@"time" : @3}, DocumentState::kSynced);
   FSTView *view = [[FSTView alloc] initWithQuery:query remoteDocuments:DocumentKeySet{}];
   FSTViewDocumentChanges *changes =
       [view computeChangesWithDocuments:FSTTestDocUpdates(@[ doc1, doc2 ])];

--- a/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
@@ -54,6 +54,7 @@ using firebase::firestore::local::RemoteDocumentCache;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeyHash;
 using firebase::firestore::model::DocumentKeySet;
+using firebase::firestore::model::DocumentState;
 using firebase::firestore::model::ListenSequenceNumber;
 using firebase::firestore::model::ObjectValue;
 using firebase::firestore::model::Precondition;
@@ -242,7 +243,7 @@ NS_ASSUME_NONNULL_BEGIN
   return [FSTDocument documentWithData:value
                                    key:key
                                version:testutil::Version(version)
-                                 state:FSTDocumentStateSynced];
+                                 state:DocumentState::kSynced];
 }
 
 - (FSTDocument *)nextTestDocument {
@@ -629,7 +630,7 @@ NS_ASSUME_NONNULL_BEGIN
     FSTDocument *doc = [FSTDocument documentWithData:_testValue
                                                  key:middleDocToUpdate
                                              version:testutil::Version(version)
-                                               state:FSTDocumentStateSynced];
+                                               state:DocumentState::kSynced];
     _documentCache->Add(doc);
     [self updateTargetInTransaction:middleTarget];
   });

--- a/Firestore/Example/Tests/Local/FSTLocalSerializerTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLocalSerializerTests.mm
@@ -50,6 +50,7 @@
 namespace testutil = firebase::firestore::testutil;
 using firebase::Timestamp;
 using firebase::firestore::model::DatabaseId;
+using firebase::firestore::model::DocumentState;
 using firebase::firestore::model::FieldMask;
 using firebase::firestore::model::Precondition;
 using firebase::firestore::model::SnapshotVersion;
@@ -138,7 +139,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)testEncodesDocumentAsMaybeDocument {
-  FSTDocument *doc = FSTTestDoc("some/path", 42, @{@"foo" : @"bar"}, FSTDocumentStateSynced);
+  FSTDocument *doc = FSTTestDoc("some/path", 42, @{@"foo" : @"bar"}, DocumentState::kSynced);
 
   FSTPBMaybeDocument *maybeDocProto = [FSTPBMaybeDocument message];
   maybeDocProto.document = [GCFSDocument message];

--- a/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
@@ -51,6 +51,7 @@ using firebase::Timestamp;
 using firebase::firestore::auth::User;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeySet;
+using firebase::firestore::model::DocumentState;
 using firebase::firestore::model::FieldValue;
 using firebase::firestore::model::ListenSequenceNumber;
 using firebase::firestore::model::DocumentMap;
@@ -257,18 +258,18 @@ NS_ASSUME_NONNULL_BEGIN
 
   [self writeMutation:FSTTestSetMutation(@"foo/bar", @{@"foo" : @"bar"})];
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations));
+      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations));
 
   [self acknowledgeMutationWithVersion:0];
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateCommittedMutations) ]);
+      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kCommittedMutations) ]);
   if ([self gcIsEager]) {
     // Nothing is pinning this anymore, as it has been acknowledged and there are no targets active.
     FSTAssertNotContains(@"foo/bar");
   } else {
     FSTAssertContains(
-        FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateCommittedMutations));
+        FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kCommittedMutations));
   }
 }
 
@@ -277,18 +278,18 @@ NS_ASSUME_NONNULL_BEGIN
 
   [self writeMutation:FSTTestSetMutation(@"foo/bar", @{@"foo" : @"bar"})];
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations));
+      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations));
 
   FSTQuery *query = FSTTestQuery("foo");
   TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(FSTTestDoc("foo/bar", 2, @{@"it" : @"changed"},
-                                                             FSTDocumentStateSynced),
+                                                             DocumentState::kSynced),
                                                   {targetID}, {})];
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations));
+      @[ FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, DocumentState::kLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, DocumentState::kLocalMutations));
 }
 
 - (void)testHandlesAckThenRejectThenRemoteEvent {
@@ -300,13 +301,13 @@ NS_ASSUME_NONNULL_BEGIN
 
   [self writeMutation:FSTTestSetMutation(@"foo/bar", @{@"foo" : @"bar"})];
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations));
+      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations));
 
   // The last seen version is zero, so this ack must be held.
   [self acknowledgeMutationWithVersion:1];
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, FSTDocumentStateCommittedMutations) ]);
+      @[ FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, DocumentState::kCommittedMutations) ]);
 
   // Under eager GC, there is no longer a reference for the document, and it should be
   // deleted.
@@ -314,23 +315,23 @@ NS_ASSUME_NONNULL_BEGIN
     FSTAssertNotContains(@"foo/bar");
   } else {
     FSTAssertContains(
-        FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, FSTDocumentStateCommittedMutations));
+        FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, DocumentState::kCommittedMutations));
   }
 
   [self writeMutation:FSTTestSetMutation(@"bar/baz", @{@"bar" : @"baz"})];
   FSTAssertChanged(
-      @[ FSTTestDoc("bar/baz", 0, @{@"bar" : @"baz"}, FSTDocumentStateLocalMutations) ]);
-  FSTAssertContains(FSTTestDoc("bar/baz", 0, @{@"bar" : @"baz"}, FSTDocumentStateLocalMutations));
+      @[ FSTTestDoc("bar/baz", 0, @{@"bar" : @"baz"}, DocumentState::kLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("bar/baz", 0, @{@"bar" : @"baz"}, DocumentState::kLocalMutations));
 
   [self rejectMutation];
   FSTAssertRemoved(@[ @"bar/baz" ]);
   FSTAssertNotContains(@"bar/baz");
 
   [self applyRemoteEvent:FSTTestAddedRemoteEvent(FSTTestDoc("foo/bar", 2, @{@"it" : @"changed"},
-                                                            FSTDocumentStateSynced),
+                                                            DocumentState::kSynced),
                                                  {targetID})];
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 2, @{@"it" : @"changed"}, FSTDocumentStateSynced) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"it" : @"changed"}, FSTDocumentStateSynced));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 2, @{@"it" : @"changed"}, DocumentState::kSynced) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"it" : @"changed"}, DocumentState::kSynced));
   FSTAssertNotContains(@"bar/baz");
 }
 
@@ -353,16 +354,16 @@ NS_ASSUME_NONNULL_BEGIN
 
   [self writeMutation:FSTTestSetMutation(@"foo/bar", @{@"foo" : @"bar"})];
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations));
+      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations));
   // Can now remove the target, since we have a mutation pinning the document
   [self.localStore releaseQuery:query];
   // Verify we didn't lose anything
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations));
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations));
 
   [self acknowledgeMutationWithVersion:3];
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 3, @{@"foo" : @"bar"}, FSTDocumentStateCommittedMutations) ]);
+      @[ FSTTestDoc("foo/bar", 3, @{@"foo" : @"bar"}, DocumentState::kCommittedMutations) ]);
   // It has been acknowledged, and should no longer be retained as there is no target and mutation
   if ([self gcIsEager]) {
     FSTAssertNotContains(@"foo/bar");
@@ -377,13 +378,13 @@ NS_ASSUME_NONNULL_BEGIN
 
   [self writeMutation:FSTTestSetMutation(@"foo/bar", @{@"foo" : @"bar"})];
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations) ]);
+      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations) ]);
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(FSTTestDeletedDoc("foo/bar", 2, NO), {targetID},
                                                   {})];
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations));
+      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations));
 }
 
 - (void)testHandlesDocumentThenSetMutationThenAckThenDocument {
@@ -394,28 +395,28 @@ NS_ASSUME_NONNULL_BEGIN
   TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestAddedRemoteEvent(
-                             FSTTestDoc("foo/bar", 2, @{@"it" : @"base"}, FSTDocumentStateSynced),
+                             FSTTestDoc("foo/bar", 2, @{@"it" : @"base"}, DocumentState::kSynced),
                              {targetID})];
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 2, @{@"it" : @"base"}, FSTDocumentStateSynced) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"it" : @"base"}, FSTDocumentStateSynced));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 2, @{@"it" : @"base"}, DocumentState::kSynced) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"it" : @"base"}, DocumentState::kSynced));
 
   [self writeMutation:FSTTestSetMutation(@"foo/bar", @{@"foo" : @"bar"})];
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations));
+      @[ FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, DocumentState::kLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, DocumentState::kLocalMutations));
 
   [self acknowledgeMutationWithVersion:3];
   // we haven't seen the remote event yet, so the write is still held.
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 3, @{@"foo" : @"bar"}, FSTDocumentStateCommittedMutations) ]);
+      @[ FSTTestDoc("foo/bar", 3, @{@"foo" : @"bar"}, DocumentState::kCommittedMutations) ]);
   FSTAssertContains(
-      FSTTestDoc("foo/bar", 3, @{@"foo" : @"bar"}, FSTDocumentStateCommittedMutations));
+      FSTTestDoc("foo/bar", 3, @{@"foo" : @"bar"}, DocumentState::kCommittedMutations));
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(FSTTestDoc("foo/bar", 3, @{@"it" : @"changed"},
-                                                             FSTDocumentStateSynced),
+                                                             DocumentState::kSynced),
                                                   {targetID}, {})];
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 3, @{@"it" : @"changed"}, FSTDocumentStateSynced) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 3, @{@"it" : @"changed"}, FSTDocumentStateSynced));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 3, @{@"it" : @"changed"}, DocumentState::kSynced) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 3, @{@"it" : @"changed"}, DocumentState::kSynced));
 }
 
 - (void)testHandlesPatchWithoutPriorDocument {
@@ -445,30 +446,30 @@ NS_ASSUME_NONNULL_BEGIN
   TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestAddedRemoteEvent(
-                             FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, FSTDocumentStateSynced),
+                             FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, DocumentState::kSynced),
                              {targetID})];
   FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar", @"it" : @"base"},
-                                 FSTDocumentStateLocalMutations) ]);
+                                 DocumentState::kLocalMutations) ]);
   FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar", @"it" : @"base"},
-                               FSTDocumentStateLocalMutations));
+                               DocumentState::kLocalMutations));
 
   [self acknowledgeMutationWithVersion:2];
   // We still haven't seen the remote events for the patch, so the local changes remain, and there
   // are no changes
   FSTAssertChanged(@[ FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar", @"it" : @"base"},
-                                 FSTDocumentStateCommittedMutations) ]);
+                                 DocumentState::kCommittedMutations) ]);
   FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar", @"it" : @"base"},
-                               FSTDocumentStateCommittedMutations));
+                               DocumentState::kCommittedMutations));
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(
                              FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar", @"it" : @"base"},
-                                        FSTDocumentStateSynced),
+                                        DocumentState::kSynced),
                              {targetID}, {})];
 
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar", @"it" : @"base"}, FSTDocumentStateSynced) ]);
+      @[ FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar", @"it" : @"base"}, DocumentState::kSynced) ]);
   FSTAssertContains(
-      FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar", @"it" : @"base"}, FSTDocumentStateSynced));
+      FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar", @"it" : @"base"}, DocumentState::kSynced));
 }
 
 - (void)testHandlesPatchMutationThenAckThenDocument {
@@ -492,10 +493,10 @@ NS_ASSUME_NONNULL_BEGIN
   TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(
-                             FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, FSTDocumentStateSynced),
+                             FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, DocumentState::kSynced),
                              {targetID}, {})];
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, FSTDocumentStateSynced) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, FSTDocumentStateSynced));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, DocumentState::kSynced) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, DocumentState::kSynced));
 }
 
 - (void)testHandlesDeleteMutationThenAck {
@@ -520,10 +521,10 @@ NS_ASSUME_NONNULL_BEGIN
   TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(
-                             FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, FSTDocumentStateSynced),
+                             FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, DocumentState::kSynced),
                              {targetID}, {})];
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, FSTDocumentStateSynced) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, FSTDocumentStateSynced));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, DocumentState::kSynced) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, DocumentState::kSynced));
 
   [self writeMutation:FSTTestDeleteMutation(@"foo/bar")];
   FSTAssertRemoved(@[ @"foo/bar" ]);
@@ -552,7 +553,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   // Add the document to a target so it will remain in persistence even when ack'd
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(
-                             FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, FSTDocumentStateSynced),
+                             FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, DocumentState::kSynced),
                              {targetID}, {})];
   FSTAssertRemoved(@[ @"foo/bar" ]);
   FSTAssertContains(FSTTestDeletedDoc("foo/bar", 0, NO));
@@ -576,10 +577,10 @@ NS_ASSUME_NONNULL_BEGIN
   TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(
-                             FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, FSTDocumentStateSynced),
+                             FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, DocumentState::kSynced),
                              {targetID}, {})];
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, FSTDocumentStateSynced) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, FSTDocumentStateSynced));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, DocumentState::kSynced) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, DocumentState::kSynced));
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(FSTTestDeletedDoc("foo/bar", 2, NO), {targetID},
                                                   {})];
@@ -589,10 +590,10 @@ NS_ASSUME_NONNULL_BEGIN
   }
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(FSTTestDoc("foo/bar", 3, @{@"it" : @"changed"},
-                                                             FSTDocumentStateSynced),
+                                                             DocumentState::kSynced),
                                                   {targetID}, {})];
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 3, @{@"it" : @"changed"}, FSTDocumentStateSynced) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 3, @{@"it" : @"changed"}, FSTDocumentStateSynced));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 3, @{@"it" : @"changed"}, DocumentState::kSynced) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 3, @{@"it" : @"changed"}, DocumentState::kSynced));
 }
 
 - (void)testHandlesSetMutationThenPatchMutationThenDocumentThenAckThenAck {
@@ -600,39 +601,39 @@ NS_ASSUME_NONNULL_BEGIN
 
   [self writeMutation:FSTTestSetMutation(@"foo/bar", @{@"foo" : @"old"})];
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"old"}, FSTDocumentStateLocalMutations) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"old"}, FSTDocumentStateLocalMutations));
+      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"old"}, DocumentState::kLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"old"}, DocumentState::kLocalMutations));
 
   [self writeMutation:FSTTestPatchMutation("foo/bar", @{@"foo" : @"bar"}, {})];
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations));
+      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations));
 
   FSTQuery *query = FSTTestQuery("foo");
   TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(
-                             FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, FSTDocumentStateSynced),
+                             FSTTestDoc("foo/bar", 1, @{@"it" : @"base"}, DocumentState::kSynced),
                              {targetID}, {})];
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations));
+      @[ FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, DocumentState::kLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, DocumentState::kLocalMutations));
 
   [self.localStore releaseQuery:query];
   [self acknowledgeMutationWithVersion:2];  // delete mutation
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations));
+      @[ FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, DocumentState::kLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, DocumentState::kLocalMutations));
 
   [self acknowledgeMutationWithVersion:3];  // patch mutation
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 3, @{@"foo" : @"bar"}, FSTDocumentStateCommittedMutations) ]);
+      @[ FSTTestDoc("foo/bar", 3, @{@"foo" : @"bar"}, DocumentState::kCommittedMutations) ]);
   if ([self gcIsEager]) {
     // we've ack'd all of the mutations, nothing is keeping this pinned anymore
     FSTAssertNotContains(@"foo/bar");
   } else {
     FSTAssertContains(
-        FSTTestDoc("foo/bar", 3, @{@"foo" : @"bar"}, FSTDocumentStateCommittedMutations));
+        FSTTestDoc("foo/bar", 3, @{@"foo" : @"bar"}, DocumentState::kCommittedMutations));
   }
 }
 
@@ -645,8 +646,8 @@ NS_ASSUME_NONNULL_BEGIN
   }];
 
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations) ]);
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations));
+      @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations));
 }
 
 - (void)testHandlesSetMutationThenPatchMutationThenReject {
@@ -654,7 +655,7 @@ NS_ASSUME_NONNULL_BEGIN
   if (![self gcIsEager]) return;
 
   [self writeMutation:FSTTestSetMutation(@"foo/bar", @{@"foo" : @"old"})];
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"old"}, FSTDocumentStateLocalMutations));
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"old"}, DocumentState::kLocalMutations));
   [self acknowledgeMutationWithVersion:1];
   FSTAssertNotContains(@"foo/bar");
 
@@ -676,11 +677,11 @@ NS_ASSUME_NONNULL_BEGIN
   }];
 
   FSTAssertChanged((@[
-    FSTTestDoc("bar/baz", 0, @{@"bar" : @"baz"}, FSTDocumentStateLocalMutations),
-    FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations)
+    FSTTestDoc("bar/baz", 0, @{@"bar" : @"baz"}, DocumentState::kLocalMutations),
+    FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations)
   ]));
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations));
-  FSTAssertContains(FSTTestDoc("bar/baz", 0, @{@"bar" : @"baz"}, FSTDocumentStateLocalMutations));
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations));
+  FSTAssertContains(FSTTestDoc("bar/baz", 0, @{@"bar" : @"baz"}, DocumentState::kLocalMutations));
 }
 
 - (void)testHandlesDeleteMutationThenPatchMutationThenAckThenAck {
@@ -717,7 +718,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTAssertNotContains(@"foo/bar");
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEventWithLimboTargets(
-                             FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, FSTDocumentStateSynced),
+                             FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, DocumentState::kSynced),
                              {}, {}, {1})];
   FSTAssertNotContains(@"foo/bar");
 }
@@ -730,12 +731,12 @@ NS_ASSUME_NONNULL_BEGIN
   TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestAddedRemoteEvent(
-                             FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, FSTDocumentStateSynced),
+                             FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, DocumentState::kSynced),
                              {targetID})];
-  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, FSTDocumentStateSynced));
+  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"foo" : @"bar"}, DocumentState::kSynced));
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(
-                             FSTTestDoc("foo/bar", 2, @{@"foo" : @"baz"}, FSTDocumentStateSynced),
+                             FSTTestDoc("foo/bar", 2, @{@"foo" : @"baz"}, DocumentState::kSynced),
                              {}, {targetID})];
 
   FSTAssertNotContains(@"foo/bar");
@@ -749,7 +750,7 @@ NS_ASSUME_NONNULL_BEGIN
   TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(
-                             FSTTestDoc("foo/bar", 0, @{@"foo" : @"old"}, FSTDocumentStateSynced),
+                             FSTTestDoc("foo/bar", 0, @{@"foo" : @"old"}, DocumentState::kSynced),
                              {targetID}, {})];
   [self writeMutation:FSTTestPatchMutation("foo/bar", @{@"foo" : @"bar"}, {})];
   // Release the query so that our target count goes back to 0 and we are considered up-to-date.
@@ -757,13 +758,13 @@ NS_ASSUME_NONNULL_BEGIN
 
   [self writeMutation:FSTTestSetMutation(@"foo/bah", @{@"foo" : @"bah"})];
   [self writeMutation:FSTTestDeleteMutation(@"foo/baz")];
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations));
-  FSTAssertContains(FSTTestDoc("foo/bah", 0, @{@"foo" : @"bah"}, FSTDocumentStateLocalMutations));
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations));
+  FSTAssertContains(FSTTestDoc("foo/bah", 0, @{@"foo" : @"bah"}, DocumentState::kLocalMutations));
   FSTAssertContains(FSTTestDeletedDoc("foo/baz", 0, NO));
 
   [self acknowledgeMutationWithVersion:3];
   FSTAssertNotContains(@"foo/bar");
-  FSTAssertContains(FSTTestDoc("foo/bah", 0, @{@"foo" : @"bah"}, FSTDocumentStateLocalMutations));
+  FSTAssertContains(FSTTestDoc("foo/bah", 0, @{@"foo" : @"bah"}, DocumentState::kLocalMutations));
   FSTAssertContains(FSTTestDeletedDoc("foo/baz", 0, NO));
 
   [self acknowledgeMutationWithVersion:4];
@@ -785,7 +786,7 @@ NS_ASSUME_NONNULL_BEGIN
   TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(
-                             FSTTestDoc("foo/bar", 0, @{@"foo" : @"old"}, FSTDocumentStateSynced),
+                             FSTTestDoc("foo/bar", 0, @{@"foo" : @"old"}, DocumentState::kSynced),
                              {targetID}, {})];
   [self writeMutation:FSTTestPatchMutation("foo/bar", @{@"foo" : @"bar"}, {})];
   // Release the query so that our target count goes back to 0 and we are considered up-to-date.
@@ -793,13 +794,13 @@ NS_ASSUME_NONNULL_BEGIN
 
   [self writeMutation:FSTTestSetMutation(@"foo/bah", @{@"foo" : @"bah"})];
   [self writeMutation:FSTTestDeleteMutation(@"foo/baz")];
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations));
-  FSTAssertContains(FSTTestDoc("foo/bah", 0, @{@"foo" : @"bah"}, FSTDocumentStateLocalMutations));
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations));
+  FSTAssertContains(FSTTestDoc("foo/bah", 0, @{@"foo" : @"bah"}, DocumentState::kLocalMutations));
   FSTAssertContains(FSTTestDeletedDoc("foo/baz", 0, NO));
 
   [self rejectMutation];  // patch mutation
   FSTAssertNotContains(@"foo/bar");
-  FSTAssertContains(FSTTestDoc("foo/bah", 0, @{@"foo" : @"bah"}, FSTDocumentStateLocalMutations));
+  FSTAssertContains(FSTTestDoc("foo/bah", 0, @{@"foo" : @"bah"}, DocumentState::kLocalMutations));
   FSTAssertContains(FSTTestDeletedDoc("foo/baz", 0, NO));
 
   [self rejectMutation];  // set mutation
@@ -821,25 +822,25 @@ NS_ASSUME_NONNULL_BEGIN
   TargetId targetID = [self allocateQuery:query];
 
   [self applyRemoteEvent:FSTTestAddedRemoteEvent(
-                             FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, FSTDocumentStateSynced),
+                             FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, DocumentState::kSynced),
                              {targetID})];
   [self writeMutation:FSTTestSetMutation(@"foo/baz", @{@"foo" : @"baz"})];
-  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, FSTDocumentStateSynced));
-  FSTAssertContains(FSTTestDoc("foo/baz", 0, @{@"foo" : @"baz"}, FSTDocumentStateLocalMutations));
+  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, DocumentState::kSynced));
+  FSTAssertContains(FSTTestDoc("foo/baz", 0, @{@"foo" : @"baz"}, DocumentState::kLocalMutations));
 
   [self notifyLocalViewChanges:FSTTestViewChanges(targetID, @[ @"foo/bar", @"foo/baz" ], @[])];
-  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, FSTDocumentStateSynced));
+  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, DocumentState::kSynced));
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(
-                             FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, FSTDocumentStateSynced),
+                             FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, DocumentState::kSynced),
                              {}, {targetID})];
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(
-                             FSTTestDoc("foo/baz", 2, @{@"foo" : @"baz"}, FSTDocumentStateSynced),
+                             FSTTestDoc("foo/baz", 2, @{@"foo" : @"baz"}, DocumentState::kSynced),
                              {targetID}, {})];
-  FSTAssertContains(FSTTestDoc("foo/baz", 2, @{@"foo" : @"baz"}, FSTDocumentStateLocalMutations));
+  FSTAssertContains(FSTTestDoc("foo/baz", 2, @{@"foo" : @"baz"}, DocumentState::kLocalMutations));
   [self acknowledgeMutationWithVersion:2];
-  FSTAssertContains(FSTTestDoc("foo/baz", 2, @{@"foo" : @"baz"}, FSTDocumentStateSynced));
-  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, FSTDocumentStateSynced));
-  FSTAssertContains(FSTTestDoc("foo/baz", 2, @{@"foo" : @"baz"}, FSTDocumentStateSynced));
+  FSTAssertContains(FSTTestDoc("foo/baz", 2, @{@"foo" : @"baz"}, DocumentState::kSynced));
+  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"foo" : @"bar"}, DocumentState::kSynced));
+  FSTAssertContains(FSTTestDoc("foo/baz", 2, @{@"foo" : @"baz"}, DocumentState::kSynced));
 
   [self notifyLocalViewChanges:FSTTestViewChanges(targetID, @[], @[ @"foo/bar", @"foo/baz" ])];
   [self.localStore releaseQuery:query];
@@ -854,7 +855,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   TargetId targetID = 321;
   [self applyRemoteEvent:FSTTestUpdateRemoteEventWithLimboTargets(
-                             FSTTestDoc("foo/bar", 1, @{}, FSTDocumentStateSynced), {}, {},
+                             FSTTestDoc("foo/bar", 1, @{}, DocumentState::kSynced), {}, {},
                              {targetID})];
 
   FSTAssertNotContains(@"foo/bar");
@@ -871,7 +872,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTQuery *query = FSTTestQuery("foo/bar");
   DocumentMap docs = [self.localStore executeQuery:query];
   XCTAssertEqualObjects(docMapToArray(docs), @[ FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"},
-                                                           FSTDocumentStateLocalMutations) ]);
+                                                           DocumentState::kLocalMutations) ]);
 }
 
 - (void)testCanExecuteCollectionQueries {
@@ -888,8 +889,8 @@ NS_ASSUME_NONNULL_BEGIN
   DocumentMap docs = [self.localStore executeQuery:query];
   XCTAssertEqualObjects(
       docMapToArray(docs), (@[
-        FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, FSTDocumentStateLocalMutations),
-        FSTTestDoc("foo/baz", 0, @{@"foo" : @"baz"}, FSTDocumentStateLocalMutations)
+        FSTTestDoc("foo/bar", 0, @{@"foo" : @"bar"}, DocumentState::kLocalMutations),
+        FSTTestDoc("foo/baz", 0, @{@"foo" : @"baz"}, DocumentState::kLocalMutations)
       ]));
 }
 
@@ -901,19 +902,19 @@ NS_ASSUME_NONNULL_BEGIN
   FSTAssertTargetID(2);
 
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(
-                             FSTTestDoc("foo/baz", 10, @{@"a" : @"b"}, FSTDocumentStateSynced), {2},
+                             FSTTestDoc("foo/baz", 10, @{@"a" : @"b"}, DocumentState::kSynced), {2},
                              {})];
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(
-                             FSTTestDoc("foo/bar", 20, @{@"a" : @"b"}, FSTDocumentStateSynced), {2},
+                             FSTTestDoc("foo/bar", 20, @{@"a" : @"b"}, DocumentState::kSynced), {2},
                              {})];
 
   [self.localStore locallyWriteMutations:{ FSTTestSetMutation(@"foo/bonk", @{@"a" : @"b"}) }];
 
   DocumentMap docs = [self.localStore executeQuery:query];
   XCTAssertEqualObjects(docMapToArray(docs), (@[
-                          FSTTestDoc("foo/bar", 20, @{@"a" : @"b"}, FSTDocumentStateSynced),
-                          FSTTestDoc("foo/baz", 10, @{@"a" : @"b"}, FSTDocumentStateSynced),
-                          FSTTestDoc("foo/bonk", 0, @{@"a" : @"b"}, FSTDocumentStateLocalMutations)
+                          FSTTestDoc("foo/bar", 20, @{@"a" : @"b"}, DocumentState::kSynced),
+                          FSTTestDoc("foo/baz", 10, @{@"a" : @"b"}, DocumentState::kSynced),
+                          FSTTestDoc("foo/bonk", 0, @{@"a" : @"b"}, DocumentState::kLocalMutations)
                         ]));
 }
 
@@ -957,10 +958,10 @@ NS_ASSUME_NONNULL_BEGIN
 
   [self
       applyRemoteEvent:FSTTestAddedRemoteEvent(
-                           FSTTestDoc("foo/baz", 10, @{@"a" : @"b"}, FSTDocumentStateSynced), {2})];
+                           FSTTestDoc("foo/baz", 10, @{@"a" : @"b"}, DocumentState::kSynced), {2})];
   [self
       applyRemoteEvent:FSTTestAddedRemoteEvent(
-                           FSTTestDoc("foo/bar", 20, @{@"a" : @"b"}, FSTDocumentStateSynced), {2})];
+                           FSTTestDoc("foo/bar", 20, @{@"a" : @"b"}, DocumentState::kSynced), {2})];
 
   [self.localStore locallyWriteMutations:{ FSTTestSetMutation(@"foo/bonk", @{@"a" : @"b"}) }];
 
@@ -979,18 +980,18 @@ NS_ASSUME_NONNULL_BEGIN
   if ([self isTestBaseClass]) return;
 
   [self writeMutation:FSTTestSetMutation(@"foo/bar", @{@"sum" : @0})];
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"sum" : @0}, FSTDocumentStateLocalMutations));
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 0, @{@"sum" : @0}, FSTDocumentStateLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"sum" : @0}, DocumentState::kLocalMutations));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 0, @{@"sum" : @0}, DocumentState::kLocalMutations) ]);
 
   [self writeMutation:FSTTestTransformMutation(
                           @"foo/bar", @{@"sum" : [FIRFieldValue fieldValueForIntegerIncrement:1]})];
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"sum" : @1}, FSTDocumentStateLocalMutations));
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 0, @{@"sum" : @1}, FSTDocumentStateLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"sum" : @1}, DocumentState::kLocalMutations));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 0, @{@"sum" : @1}, DocumentState::kLocalMutations) ]);
 
   [self writeMutation:FSTTestTransformMutation(
                           @"foo/bar", @{@"sum" : [FIRFieldValue fieldValueForIntegerIncrement:2]})];
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"sum" : @3}, FSTDocumentStateLocalMutations));
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 0, @{@"sum" : @3}, FSTDocumentStateLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"sum" : @3}, DocumentState::kLocalMutations));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 0, @{@"sum" : @3}, DocumentState::kLocalMutations) ]);
 }
 
 - (void)testHandlesSetMutationThenAckThenTransformMutationThenAckThenTransformMutation {
@@ -1002,28 +1003,28 @@ NS_ASSUME_NONNULL_BEGIN
   if ([self gcIsEager]) return;
 
   [self writeMutation:FSTTestSetMutation(@"foo/bar", @{@"sum" : @0})];
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"sum" : @0}, FSTDocumentStateLocalMutations));
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 0, @{@"sum" : @0}, FSTDocumentStateLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"sum" : @0}, DocumentState::kLocalMutations));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 0, @{@"sum" : @0}, DocumentState::kLocalMutations) ]);
 
   [self acknowledgeMutationWithVersion:1];
-  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"sum" : @0}, FSTDocumentStateCommittedMutations));
+  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"sum" : @0}, DocumentState::kCommittedMutations));
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 1, @{@"sum" : @0}, FSTDocumentStateCommittedMutations) ]);
+      @[ FSTTestDoc("foo/bar", 1, @{@"sum" : @0}, DocumentState::kCommittedMutations) ]);
 
   [self writeMutation:FSTTestTransformMutation(
                           @"foo/bar", @{@"sum" : [FIRFieldValue fieldValueForIntegerIncrement:1]})];
-  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"sum" : @1}, FSTDocumentStateLocalMutations));
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"sum" : @1}, FSTDocumentStateLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"sum" : @1}, DocumentState::kLocalMutations));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"sum" : @1}, DocumentState::kLocalMutations) ]);
 
   [self acknowledgeMutationWithVersion:2 transformResult:@1];
-  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"sum" : @1}, FSTDocumentStateCommittedMutations));
+  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"sum" : @1}, DocumentState::kCommittedMutations));
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 2, @{@"sum" : @1}, FSTDocumentStateCommittedMutations) ]);
+      @[ FSTTestDoc("foo/bar", 2, @{@"sum" : @1}, DocumentState::kCommittedMutations) ]);
 
   [self writeMutation:FSTTestTransformMutation(
                           @"foo/bar", @{@"sum" : [FIRFieldValue fieldValueForIntegerIncrement:2]})];
-  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"sum" : @3}, FSTDocumentStateLocalMutations));
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 2, @{@"sum" : @3}, FSTDocumentStateLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"sum" : @3}, DocumentState::kLocalMutations));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 2, @{@"sum" : @3}, DocumentState::kLocalMutations) ]);
 }
 
 - (void)testHandlesSetMutationThenTransformMutationThenRemoteEventThenTransformMutation {
@@ -1034,44 +1035,44 @@ NS_ASSUME_NONNULL_BEGIN
   FSTAssertTargetID(2);
 
   [self writeMutation:FSTTestSetMutation(@"foo/bar", @{@"sum" : @0})];
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"sum" : @0}, FSTDocumentStateLocalMutations));
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 0, @{@"sum" : @0}, FSTDocumentStateLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"sum" : @0}, DocumentState::kLocalMutations));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 0, @{@"sum" : @0}, DocumentState::kLocalMutations) ]);
 
   [self
       applyRemoteEvent:FSTTestAddedRemoteEvent(
-                           FSTTestDoc("foo/bar", 1, @{@"sum" : @0}, FSTDocumentStateSynced), {2})];
+                           FSTTestDoc("foo/bar", 1, @{@"sum" : @0}, DocumentState::kSynced), {2})];
 
   [self acknowledgeMutationWithVersion:1];
-  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"sum" : @0}, FSTDocumentStateSynced));
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"sum" : @0}, FSTDocumentStateSynced) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"sum" : @0}, DocumentState::kSynced));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"sum" : @0}, DocumentState::kSynced) ]);
 
   [self writeMutation:FSTTestTransformMutation(
                           @"foo/bar", @{@"sum" : [FIRFieldValue fieldValueForIntegerIncrement:1]})];
-  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"sum" : @1}, FSTDocumentStateLocalMutations));
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"sum" : @1}, FSTDocumentStateLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"sum" : @1}, DocumentState::kLocalMutations));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"sum" : @1}, DocumentState::kLocalMutations) ]);
 
   // The value in this remote event gets ignored since we still have a pending transform mutation.
   [self applyRemoteEvent:FSTTestUpdateRemoteEvent(
-                             FSTTestDoc("foo/bar", 2, @{@"sum" : @0}, FSTDocumentStateSynced), {2},
+                             FSTTestDoc("foo/bar", 2, @{@"sum" : @0}, DocumentState::kSynced), {2},
                              {})];
-  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"sum" : @1}, FSTDocumentStateLocalMutations));
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 2, @{@"sum" : @1}, FSTDocumentStateLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"sum" : @1}, DocumentState::kLocalMutations));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 2, @{@"sum" : @1}, DocumentState::kLocalMutations) ]);
 
   // Add another increment. Note that we still compute the increment based on the local value.
   [self writeMutation:FSTTestTransformMutation(
                           @"foo/bar", @{@"sum" : [FIRFieldValue fieldValueForIntegerIncrement:2]})];
-  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"sum" : @3}, FSTDocumentStateLocalMutations));
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 2, @{@"sum" : @3}, FSTDocumentStateLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 2, @{@"sum" : @3}, DocumentState::kLocalMutations));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 2, @{@"sum" : @3}, DocumentState::kLocalMutations) ]);
 
   [self acknowledgeMutationWithVersion:3 transformResult:@1];
-  FSTAssertContains(FSTTestDoc("foo/bar", 3, @{@"sum" : @3}, FSTDocumentStateLocalMutations));
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 3, @{@"sum" : @3}, FSTDocumentStateLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 3, @{@"sum" : @3}, DocumentState::kLocalMutations));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 3, @{@"sum" : @3}, DocumentState::kLocalMutations) ]);
 
   [self acknowledgeMutationWithVersion:4 transformResult:@1339];
   FSTAssertContains(
-      FSTTestDoc("foo/bar", 4, @{@"sum" : @1339}, FSTDocumentStateCommittedMutations));
+      FSTTestDoc("foo/bar", 4, @{@"sum" : @1339}, DocumentState::kCommittedMutations));
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 4, @{@"sum" : @1339}, FSTDocumentStateCommittedMutations) ]);
+      @[ FSTTestDoc("foo/bar", 4, @{@"sum" : @1339}, DocumentState::kCommittedMutations) ]);
 }
 
 - (void)testHoldsBackOnlyNonIdempotentTransforms {
@@ -1083,18 +1084,18 @@ NS_ASSUME_NONNULL_BEGIN
 
   [self writeMutation:FSTTestSetMutation(@"foo/bar", @{@"sum" : @0, @"array_union" : @[]})];
   FSTAssertChanged(@[ FSTTestDoc("foo/bar", 0, @{@"sum" : @0, @"array_union" : @[]},
-                                 FSTDocumentStateLocalMutations) ]);
+                                 DocumentState::kLocalMutations) ]);
 
   [self acknowledgeMutationWithVersion:1];
   FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"sum" : @0, @"array_union" : @[]},
-                                 FSTDocumentStateCommittedMutations) ]);
+                                 DocumentState::kCommittedMutations) ]);
 
   [self applyRemoteEvent:FSTTestAddedRemoteEvent(
                              FSTTestDoc("foo/bar", 1, @{@"sum" : @0, @"array_union" : @[]},
-                                        FSTDocumentStateSynced),
+                                        DocumentState::kSynced),
                              {2})];
   FSTAssertChanged(
-      @[ FSTTestDoc("foo/bar", 1, @{@"sum" : @0, @"array_union" : @[]}, FSTDocumentStateSynced) ]);
+      @[ FSTTestDoc("foo/bar", 1, @{@"sum" : @0, @"array_union" : @[]}, DocumentState::kSynced) ]);
 
   [self writeMutations:{
     FSTTestTransformMutation(@"foo/bar",
@@ -1105,17 +1106,17 @@ NS_ASSUME_NONNULL_BEGIN
   }];
 
   FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"sum" : @1, @"array_union" : @[ @"foo" ]},
-                                 FSTDocumentStateLocalMutations) ]);
+                                 DocumentState::kLocalMutations) ]);
 
   // The sum transform is not idempotent and the backend's updated value is ignored. The
   // ArrayUnion transform is recomputed and includes the backend value.
   [self
       applyRemoteEvent:FSTTestUpdateRemoteEvent(
                            FSTTestDoc("foo/bar", 1, @{@"sum" : @1337, @"array_union" : @[ @"bar" ]},
-                                      FSTDocumentStateSynced),
+                                      DocumentState::kSynced),
                            {2}, {})];
   FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"sum" : @1, @"array_union" : @[ @"bar", @"foo" ]},
-                                 FSTDocumentStateLocalMutations) ]);
+                                 DocumentState::kLocalMutations) ]);
 }
 
 - (void)testHandlesMergeMutationWithTransformThenRemoteEvent {
@@ -1131,15 +1132,15 @@ NS_ASSUME_NONNULL_BEGIN
                                  @{@"sum" : [FIRFieldValue fieldValueForIntegerIncrement:1]})
   }];
 
-  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"sum" : @1}, FSTDocumentStateLocalMutations));
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 0, @{@"sum" : @1}, FSTDocumentStateLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 0, @{@"sum" : @1}, DocumentState::kLocalMutations));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 0, @{@"sum" : @1}, DocumentState::kLocalMutations) ]);
 
   [self applyRemoteEvent:FSTTestAddedRemoteEvent(
-                             FSTTestDoc("foo/bar", 1, @{@"sum" : @1337}, FSTDocumentStateSynced),
+                             FSTTestDoc("foo/bar", 1, @{@"sum" : @1337}, DocumentState::kSynced),
                              {2})];
 
-  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"sum" : @1}, FSTDocumentStateLocalMutations));
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"sum" : @1}, FSTDocumentStateLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"sum" : @1}, DocumentState::kLocalMutations));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"sum" : @1}, DocumentState::kLocalMutations) ]);
 }
 
 - (void)testHandlesPatchMutationWithTransformThenRemoteEvent {
@@ -1161,11 +1162,11 @@ NS_ASSUME_NONNULL_BEGIN
   // Note: This test reflects the current behavior, but it may be preferable to replay the
   // mutation once we receive the first value from the remote event.
   [self applyRemoteEvent:FSTTestAddedRemoteEvent(
-                             FSTTestDoc("foo/bar", 1, @{@"sum" : @1337}, FSTDocumentStateSynced),
+                             FSTTestDoc("foo/bar", 1, @{@"sum" : @1337}, DocumentState::kSynced),
                              {2})];
 
-  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"sum" : @1}, FSTDocumentStateLocalMutations));
-  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"sum" : @1}, FSTDocumentStateLocalMutations) ]);
+  FSTAssertContains(FSTTestDoc("foo/bar", 1, @{@"sum" : @1}, DocumentState::kLocalMutations));
+  FSTAssertChanged(@[ FSTTestDoc("foo/bar", 1, @{@"sum" : @1}, DocumentState::kLocalMutations) ]);
 }
 
 @end

--- a/Firestore/Example/Tests/Local/FSTRemoteDocumentCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTRemoteDocumentCacheTests.mm
@@ -39,6 +39,7 @@ using firebase::firestore::local::RemoteDocumentCache;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::DocumentMap;
+using firebase::firestore::model::DocumentState;
 using firebase::firestore::model::MaybeDocumentMap;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -137,7 +138,7 @@ static const int kVersion = 42;
 
   self.persistence.run("testSetDocumentToNewValue", [&]() {
     [self setTestDocumentAtPath:kDocPath];
-    FSTDocument *newDoc = FSTTestDoc(kDocPath, kVersion, @{@"data" : @2}, FSTDocumentStateSynced);
+    FSTDocument *newDoc = FSTTestDoc(kDocPath, kVersion, @{@"data" : @2}, DocumentState::kSynced);
     self.remoteDocumentCache->Add(newDoc);
     XCTAssertEqualObjects(self.remoteDocumentCache->Get(testutil::Key(kDocPath)), newDoc);
   });
@@ -180,8 +181,8 @@ static const int kVersion = 42;
     DocumentMap results = self.remoteDocumentCache->GetMatching(query);
     [self expectMap:results.underlying_map()
         hasDocsInArray:@[
-          FSTTestDoc("b/1", kVersion, _kDocData, FSTDocumentStateSynced),
-          FSTTestDoc("b/2", kVersion, _kDocData, FSTDocumentStateSynced)
+          FSTTestDoc("b/1", kVersion, _kDocData, DocumentState::kSynced),
+          FSTTestDoc("b/2", kVersion, _kDocData, DocumentState::kSynced)
         ]
                exactly:YES];
   });
@@ -189,7 +190,7 @@ static const int kVersion = 42;
 
 #pragma mark - Helpers
 - (FSTDocument *)setTestDocumentAtPath:(const absl::string_view)path {
-  FSTDocument *doc = FSTTestDoc(path, kVersion, _kDocData, FSTDocumentStateSynced);
+  FSTDocument *doc = FSTTestDoc(path, kVersion, _kDocData, DocumentState::kSynced);
   self.remoteDocumentCache->Add(doc);
   return doc;
 }

--- a/Firestore/Example/Tests/Model/FSTDocumentSetTests.mm
+++ b/Firestore/Example/Tests/Model/FSTDocumentSetTests.mm
@@ -29,6 +29,7 @@
 namespace util = firebase::firestore::util;
 using firebase::firestore::model::DocumentComparator;
 using firebase::firestore::model::DocumentSet;
+using firebase::firestore::model::DocumentState;
 using testing::ElementsAre;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -47,9 +48,9 @@ NS_ASSUME_NONNULL_BEGIN
   [super setUp];
 
   _comp.Init(FSTTestDocComparator("sort"));
-  _doc1 = FSTTestDoc("docs/1", 0, @{@"sort" : @2}, FSTDocumentStateSynced);
-  _doc2 = FSTTestDoc("docs/2", 0, @{@"sort" : @3}, FSTDocumentStateSynced);
-  _doc3 = FSTTestDoc("docs/3", 0, @{@"sort" : @1}, FSTDocumentStateSynced);
+  _doc1 = FSTTestDoc("docs/1", 0, @{@"sort" : @2}, DocumentState::kSynced);
+  _doc2 = FSTTestDoc("docs/2", 0, @{@"sort" : @3}, DocumentState::kSynced);
+  _doc3 = FSTTestDoc("docs/3", 0, @{@"sort" : @1}, DocumentState::kSynced);
 }
 
 - (void)testCount {
@@ -106,7 +107,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testUpdates {
   DocumentSet set = FSTTestDocSet(*_comp, @[ _doc1, _doc2, _doc3 ]);
 
-  FSTDocument *doc2Prime = FSTTestDoc("docs/2", 0, @{@"sort" : @9}, FSTDocumentStateSynced);
+  FSTDocument *doc2Prime = FSTTestDoc("docs/2", 0, @{@"sort" : @9}, DocumentState::kSynced);
 
   set = set.insert(doc2Prime);
   XCTAssertEqual(set.size(), 3);
@@ -115,7 +116,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)testAddsDocsWithEqualComparisonValues {
-  FSTDocument *doc4 = FSTTestDoc("docs/4", 0, @{@"sort" : @2}, FSTDocumentStateSynced);
+  FSTDocument *doc4 = FSTTestDoc("docs/4", 0, @{@"sort" : @2}, DocumentState::kSynced);
 
   DocumentSet set = FSTTestDocSet(*_comp, @[ _doc1, doc4 ]);
   XC_ASSERT_THAT(set, ElementsAre(_doc1, doc4));

--- a/Firestore/Example/Tests/Model/FSTDocumentTests.mm
+++ b/Firestore/Example/Tests/Model/FSTDocumentTests.mm
@@ -25,6 +25,7 @@
 
 namespace testutil = firebase::firestore::testutil;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::DocumentState;
 using firebase::firestore::model::FieldValue;
 using firebase::firestore::model::ObjectValue;
 using firebase::firestore::model::SnapshotVersion;
@@ -44,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTDocument *doc = [FSTDocument documentWithData:data
                                                key:key
                                            version:version
-                                             state:FSTDocumentStateSynced];
+                                             state:DocumentState::kSynced];
 
   XCTAssertEqual(doc.key, FSTTestDocKey(@"messages/first"));
   XCTAssertEqual(doc.version, version);
@@ -62,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTDocument *doc = [FSTDocument documentWithData:data
                                                key:key
                                            version:version
-                                             state:FSTDocumentStateSynced];
+                                             state:DocumentState::kSynced];
 
   XCTAssertEqual(*[doc fieldForPath:Field("desc")],
                  FieldValue::FromString("Discuss all the project related stuff"));
@@ -70,21 +71,21 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (void)testIsEqual {
-  XCTAssertEqualObjects(FSTTestDoc("messages/first", 1, @{@"a" : @1}, FSTDocumentStateSynced),
-                        FSTTestDoc("messages/first", 1, @{@"a" : @1}, FSTDocumentStateSynced));
-  XCTAssertNotEqualObjects(FSTTestDoc("messages/first", 1, @{@"a" : @1}, FSTDocumentStateSynced),
-                           FSTTestDoc("messages/first", 1, @{@"b" : @1}, FSTDocumentStateSynced));
-  XCTAssertNotEqualObjects(FSTTestDoc("messages/first", 1, @{@"a" : @1}, FSTDocumentStateSynced),
-                           FSTTestDoc("messages/second", 1, @{@"b" : @1}, FSTDocumentStateSynced));
-  XCTAssertNotEqualObjects(FSTTestDoc("messages/first", 1, @{@"a" : @1}, FSTDocumentStateSynced),
-                           FSTTestDoc("messages/first", 2, @{@"a" : @1}, FSTDocumentStateSynced));
+  XCTAssertEqualObjects(FSTTestDoc("messages/first", 1, @{@"a" : @1}, DocumentState::kSynced),
+                        FSTTestDoc("messages/first", 1, @{@"a" : @1}, DocumentState::kSynced));
+  XCTAssertNotEqualObjects(FSTTestDoc("messages/first", 1, @{@"a" : @1}, DocumentState::kSynced),
+                           FSTTestDoc("messages/first", 1, @{@"b" : @1}, DocumentState::kSynced));
+  XCTAssertNotEqualObjects(FSTTestDoc("messages/first", 1, @{@"a" : @1}, DocumentState::kSynced),
+                           FSTTestDoc("messages/second", 1, @{@"b" : @1}, DocumentState::kSynced));
+  XCTAssertNotEqualObjects(FSTTestDoc("messages/first", 1, @{@"a" : @1}, DocumentState::kSynced),
+                           FSTTestDoc("messages/first", 2, @{@"a" : @1}, DocumentState::kSynced));
   XCTAssertNotEqualObjects(
-      FSTTestDoc("messages/first", 1, @{@"a" : @1}, FSTDocumentStateSynced),
-      FSTTestDoc("messages/first", 1, @{@"a" : @1}, FSTDocumentStateLocalMutations));
+      FSTTestDoc("messages/first", 1, @{@"a" : @1}, DocumentState::kSynced),
+      FSTTestDoc("messages/first", 1, @{@"a" : @1}, DocumentState::kLocalMutations));
 
   XCTAssertEqualObjects(
-      FSTTestDoc("messages/first", 1, @{@"a" : @1}, FSTDocumentStateLocalMutations),
-      FSTTestDoc("messages/first", 1, @{@"a" : @1}, FSTDocumentStateLocalMutations));
+      FSTTestDoc("messages/first", 1, @{@"a" : @1}, DocumentState::kLocalMutations),
+      FSTTestDoc("messages/first", 1, @{@"a" : @1}, DocumentState::kLocalMutations));
 }
 
 @end

--- a/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.mm
+++ b/Firestore/Example/Tests/Remote/FSTSerializerBetaTests.mm
@@ -64,6 +64,7 @@ using firebase::Timestamp;
 using firebase::firestore::FirestoreErrorCode;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::DocumentState;
 using firebase::firestore::model::FieldMask;
 using firebase::firestore::model::FieldPath;
 using firebase::firestore::model::FieldTransform;
@@ -839,7 +840,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testConvertsDocumentChangeWithTargetIds {
   DocumentWatchChange expected {
     {1, 2}, {}, FSTTestDocKey(@"coll/1"),
-        FSTTestDoc("coll/1", 5, @{@"foo" : @"bar"}, FSTDocumentStateSynced)
+        FSTTestDoc("coll/1", 5, @{@"foo" : @"bar"}, DocumentState::kSynced)
   };
   GCFSListenResponse *listenResponse = [GCFSListenResponse message];
   listenResponse.documentChange.document.name = @"projects/p/databases/d/documents/coll/1";
@@ -857,7 +858,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)testConvertsDocumentChangeWithRemovedTargetIds {
   DocumentWatchChange expected {
     {2}, {1}, FSTTestDocKey(@"coll/1"),
-        FSTTestDoc("coll/1", 5, @{@"foo" : @"bar"}, FSTDocumentStateSynced)
+        FSTTestDoc("coll/1", 5, @{@"foo" : @"bar"}, DocumentState::kSynced)
   };
 
   GCFSListenResponse *listenResponse = [GCFSListenResponse message];

--- a/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSpecTests.mm
@@ -61,6 +61,7 @@ using firebase::firestore::auth::User;
 using firebase::firestore::core::DocumentViewChange;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeySet;
+using firebase::firestore::model::DocumentState;
 using firebase::firestore::model::ObjectValue;
 using firebase::firestore::model::ResourcePath;
 using firebase::firestore::model::SnapshotVersion;
@@ -213,11 +214,11 @@ std::vector<TargetId> ConvertTargetsArray(NSArray<NSNumber *> *from) {
 - (DocumentViewChange)parseChange:(NSDictionary *)jsonDoc ofType:(DocumentViewChange::Type)type {
   NSNumber *version = jsonDoc[@"version"];
   NSDictionary *options = jsonDoc[@"options"];
-  FSTDocumentState documentState = [options[@"hasLocalMutations"] isEqualToNumber:@YES]
-                                       ? FSTDocumentStateLocalMutations
-                                       : ([options[@"hasCommittedMutations"] isEqualToNumber:@YES]
-                                              ? FSTDocumentStateCommittedMutations
-                                              : FSTDocumentStateSynced);
+  DocumentState documentState = [options[@"hasLocalMutations"] isEqualToNumber:@YES]
+                                    ? DocumentState::kLocalMutations
+                                    : ([options[@"hasCommittedMutations"] isEqualToNumber:@YES]
+                                           ? DocumentState::kCommittedMutations
+                                           : DocumentState::kSynced);
 
   XCTAssert([jsonDoc[@"key"] isKindOfClass:[NSString class]]);
   FSTDocument *doc = FSTTestDoc(util::MakeString((NSString *)jsonDoc[@"key"]),
@@ -308,7 +309,7 @@ std::vector<TargetId> ConvertTargetsArray(NSArray<NSNumber *> *from) {
     FSTMaybeDocument *doc = value ? [FSTDocument documentWithData:*value
                                                               key:key
                                                           version:std::move(version)
-                                                            state:FSTDocumentStateSynced]
+                                                            state:DocumentState::kSynced]
                                   : [FSTDeletedDocument documentWithKey:key
                                                                 version:std::move(version)
                                                   hasCommittedMutations:NO];

--- a/Firestore/Example/Tests/Util/FSTHelpers.h
+++ b/Firestore/Example/Tests/Util/FSTHelpers.h
@@ -243,7 +243,7 @@ typedef int64_t FSTTestSnapshotVersion;
 FSTDocument *FSTTestDoc(const absl::string_view path,
                         FSTTestSnapshotVersion version,
                         NSDictionary<NSString *, id> *data,
-                        FSTDocumentState documentState);
+                        model::DocumentState documentState);
 
 /** A convenience method for creating deleted docs for tests. */
 FSTDeletedDocument *FSTTestDeletedDoc(const absl::string_view path,

--- a/Firestore/Example/Tests/Util/FSTHelpers.mm
+++ b/Firestore/Example/Tests/Util/FSTHelpers.mm
@@ -37,6 +37,7 @@
 #include "Firestore/core/src/firebase/firestore/core/filter.h"
 #include "Firestore/core/src/firebase/firestore/core/view_snapshot.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
+#include "Firestore/core/src/firebase/firestore/model/document.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
 #include "Firestore/core/src/firebase/firestore/model/document_set.h"
@@ -62,6 +63,7 @@ using firebase::firestore::model::DocumentComparator;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::DocumentKeySet;
 using firebase::firestore::model::DocumentSet;
+using firebase::firestore::model::DocumentState;
 using firebase::firestore::model::FieldMask;
 using firebase::firestore::model::FieldPath;
 using firebase::firestore::model::FieldTransform;
@@ -159,7 +161,7 @@ DocumentKey FSTTestDocKey(NSString *path) {
 FSTDocument *FSTTestDoc(const absl::string_view path,
                         FSTTestSnapshotVersion version,
                         NSDictionary<NSString *, id> *data,
-                        FSTDocumentState documentState) {
+                        DocumentState documentState) {
   DocumentKey key = testutil::Key(path);
   return [FSTDocument documentWithData:FSTTestObjectValue(data)
                                    key:key

--- a/Firestore/Source/Local/FSTLocalSerializer.mm
+++ b/Firestore/Source/Local/FSTLocalSerializer.mm
@@ -32,12 +32,14 @@
 #import "Firestore/Source/Remote/FSTSerializerBeta.h"
 
 #include "Firestore/core/include/firebase/firestore/timestamp.h"
+#include "Firestore/core/src/firebase/firestore/model/document.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 
 using firebase::Timestamp;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::DocumentState;
 using firebase::firestore::model::ListenSequenceNumber;
 using firebase::firestore::model::ObjectValue;
 using firebase::firestore::model::SnapshotVersion;
@@ -130,8 +132,8 @@ using firebase::firestore::model::TargetId;
   return [FSTDocument documentWithData:std::move(data)
                                    key:std::move(key)
                                version:version
-                                 state:committedMutations ? FSTDocumentStateCommittedMutations
-                                                          : FSTDocumentStateSynced];
+                                 state:committedMutations ? DocumentState::kCommittedMutations
+                                                          : DocumentState::kSynced];
 }
 
 /** Encodes a NoDocument value to the equivalent proto. */

--- a/Firestore/Source/Model/FSTDocument.h
+++ b/Firestore/Source/Model/FSTDocument.h
@@ -16,6 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
+#include "Firestore/core/src/firebase/firestore/model/document.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/field_path.h"
 #include "Firestore/core/src/firebase/firestore/model/field_value.h"
@@ -28,16 +29,6 @@
 namespace model = firebase::firestore::model;
 
 NS_ASSUME_NONNULL_BEGIN
-
-/** Describes the `hasPendingWrites` state of a document. */
-typedef NS_ENUM(NSInteger, FSTDocumentState) {
-  /** Local mutations applied via the mutation queue. Document is potentially inconsistent. */
-  FSTDocumentStateLocalMutations,
-  /** Mutations applied based on a write acknowledgment. Document is potentially inconsistent. */
-  FSTDocumentStateCommittedMutations,
-  /** No mutations applied. Document was sent to us by Watch. */
-  FSTDocumentStateSynced
-};
 
 /**
  * The result of a lookup for a given path may be an existing document or a tombstone that marks
@@ -59,12 +50,12 @@ typedef NS_ENUM(NSInteger, FSTDocumentState) {
 + (instancetype)documentWithData:(model::ObjectValue)data
                              key:(model::DocumentKey)key
                          version:(model::SnapshotVersion)version
-                           state:(FSTDocumentState)state;
+                           state:(model::DocumentState)state;
 
 + (instancetype)documentWithData:(model::ObjectValue)data
                              key:(model::DocumentKey)key
                          version:(model::SnapshotVersion)version
-                           state:(FSTDocumentState)state
+                           state:(model::DocumentState)state
                            proto:(GCFSDocument *)proto;
 
 - (absl::optional<model::FieldValue>)fieldForPath:(const model::FieldPath &)path;

--- a/Firestore/Source/Model/FSTDocument.mm
+++ b/Firestore/Source/Model/FSTDocument.mm
@@ -32,6 +32,7 @@
 
 namespace util = firebase::firestore::util;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::DocumentState;
 using firebase::firestore::model::FieldPath;
 using firebase::firestore::model::FieldValue;
 using firebase::firestore::model::ObjectValue;
@@ -80,14 +81,14 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation FSTDocument {
-  FSTDocumentState _documentState;
+  DocumentState _documentState;
   util::DelayedConstructor<ObjectValue> _data;
 }
 
 + (instancetype)documentWithData:(ObjectValue)data
                              key:(DocumentKey)key
                          version:(SnapshotVersion)version
-                           state:(FSTDocumentState)state {
+                           state:(DocumentState)state {
   return [[FSTDocument alloc] initWithData:std::move(data)
                                        key:std::move(key)
                                    version:std::move(version)
@@ -97,7 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)documentWithData:(ObjectValue)data
                              key:(DocumentKey)key
                          version:(SnapshotVersion)version
-                           state:(FSTDocumentState)state
+                           state:(DocumentState)state
                            proto:(GCFSDocument *)proto {
   return [[FSTDocument alloc] initWithData:std::move(data)
                                        key:std::move(key)
@@ -109,7 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithData:(ObjectValue)data
                          key:(DocumentKey)key
                      version:(SnapshotVersion)version
-                       state:(FSTDocumentState)state {
+                       state:(DocumentState)state {
   self = [super initWithKey:std::move(key) version:std::move(version)];
   if (self) {
     _data.Init(std::move(data));
@@ -122,7 +123,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithData:(ObjectValue)data
                          key:(DocumentKey)key
                      version:(SnapshotVersion)version
-                       state:(FSTDocumentState)state
+                       state:(DocumentState)state
                        proto:(GCFSDocument *)proto {
   self = [super initWithKey:std::move(key) version:std::move(version)];
   if (self) {
@@ -134,11 +135,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (bool)hasLocalMutations {
-  return _documentState == FSTDocumentStateLocalMutations;
+  return _documentState == DocumentState::kLocalMutations;
 }
 
 - (bool)hasCommittedMutations {
-  return _documentState == FSTDocumentStateCommittedMutations;
+  return _documentState == DocumentState::kCommittedMutations;
 }
 
 - (bool)hasPendingWrites {

--- a/Firestore/Source/Model/FSTMutation.mm
+++ b/Firestore/Source/Model/FSTMutation.mm
@@ -40,6 +40,7 @@
 using firebase::Timestamp;
 using firebase::firestore::model::ArrayTransform;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::DocumentState;
 using firebase::firestore::model::FieldMask;
 using firebase::firestore::model::FieldPath;
 using firebase::firestore::model::FieldTransform;
@@ -183,7 +184,7 @@ NS_ASSUME_NONNULL_BEGIN
   return [FSTDocument documentWithData:self.value
                                    key:self.key
                                version:version
-                                 state:FSTDocumentStateLocalMutations];
+                                 state:DocumentState::kLocalMutations];
 }
 
 - (FSTMaybeDocument *)applyToRemoteDocument:(nullable FSTMaybeDocument *)maybeDoc
@@ -198,7 +199,7 @@ NS_ASSUME_NONNULL_BEGIN
   return [FSTDocument documentWithData:self.value
                                    key:self.key
                                version:mutationResult.version
-                                 state:FSTDocumentStateCommittedMutations];
+                                 state:DocumentState::kCommittedMutations];
 }
 
 - (nullable const FieldMask *)fieldMask {
@@ -285,7 +286,7 @@ NS_ASSUME_NONNULL_BEGIN
   return [FSTDocument documentWithData:newData
                                    key:self.key
                                version:version
-                                 state:FSTDocumentStateLocalMutations];
+                                 state:DocumentState::kLocalMutations];
 }
 
 - (FSTMaybeDocument *)applyToRemoteDocument:(nullable FSTMaybeDocument *)maybeDoc
@@ -306,7 +307,7 @@ NS_ASSUME_NONNULL_BEGIN
   return [FSTDocument documentWithData:newData
                                    key:self.key
                                version:mutationResult.version
-                                 state:FSTDocumentStateCommittedMutations];
+                                 state:DocumentState::kCommittedMutations];
 }
 
 - (ObjectValue)patchObjectValue:(ObjectValue)objectValue {
@@ -412,7 +413,7 @@ NS_ASSUME_NONNULL_BEGIN
   return [FSTDocument documentWithData:std::move(newData)
                                    key:doc.key
                                version:doc.version
-                                 state:FSTDocumentStateLocalMutations];
+                                 state:DocumentState::kLocalMutations];
 }
 
 - (FSTMaybeDocument *)applyToRemoteDocument:(nullable FSTMaybeDocument *)maybeDoc
@@ -446,7 +447,7 @@ NS_ASSUME_NONNULL_BEGIN
   return [FSTDocument documentWithData:newData
                                    key:self.key
                                version:mutationResult.version
-                                 state:FSTDocumentStateCommittedMutations];
+                                 state:DocumentState::kCommittedMutations];
 }
 
 /**

--- a/Firestore/Source/Remote/FSTSerializerBeta.mm
+++ b/Firestore/Source/Remote/FSTSerializerBeta.mm
@@ -71,6 +71,7 @@ using firebase::firestore::core::Query;
 using firebase::firestore::model::ArrayTransform;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::DocumentState;
 using firebase::firestore::model::FieldMask;
 using firebase::firestore::model::FieldPath;
 using firebase::firestore::model::FieldTransform;
@@ -455,7 +456,7 @@ NS_ASSUME_NONNULL_BEGIN
   return [FSTDocument documentWithData:value
                                    key:key
                                version:version
-                                 state:FSTDocumentStateSynced
+                                 state:DocumentState::kSynced
                                  proto:response.found];
 }
 
@@ -1186,7 +1187,7 @@ NS_ASSUME_NONNULL_BEGIN
   FSTMaybeDocument *document = [FSTDocument documentWithData:value
                                                          key:key
                                                      version:version
-                                                       state:FSTDocumentStateSynced
+                                                       state:DocumentState::kSynced
                                                        proto:change.document];
 
   std::vector<TargetId> updatedTargetIDs = [self decodedIntegerArray:change.targetIdsArray];

--- a/Firestore/core/src/firebase/firestore/model/document.h
+++ b/Firestore/core/src/firebase/firestore/model/document.h
@@ -26,6 +26,7 @@ namespace firebase {
 namespace firestore {
 namespace model {
 
+/** Describes the `hasPendingWrites` state of a document. */
 enum class DocumentState {
   /**
    * Local mutations applied via the mutation queue. Document is potentially

--- a/Firestore/core/test/firebase/firestore/remote/watch_change_test.mm
+++ b/Firestore/core/test/firebase/firestore/remote/watch_change_test.mm
@@ -22,6 +22,7 @@
 #include "Firestore/core/src/firebase/firestore/remote/watch_change.h"
 #include "gtest/gtest.h"
 
+using firebase::firestore::model::DocumentState;
 using firebase::firestore::remote::DocumentWatchChange;
 using firebase::firestore::remote::ExistenceFilter;
 using firebase::firestore::remote::ExistenceFilterWatchChange;
@@ -35,7 +36,7 @@ namespace firestore {
 namespace remote {
 
 TEST(WatchChangeTest, CanCreateDocumentWatchChange) {
-  FSTMaybeDocument* doc = FSTTestDoc("a/b", 1, @{}, FSTDocumentStateSynced);
+  FSTMaybeDocument* doc = FSTTestDoc("a/b", 1, @{}, DocumentState::kSynced);
   DocumentWatchChange change{{1, 2, 3}, {4, 5}, doc.key, doc};
 
   EXPECT_EQ(change.updated_target_ids().size(), 3);

--- a/Firestore/core/test/firebase/firestore/util/objc_compatibility_apple_test.mm
+++ b/Firestore/core/test/firebase/firestore/util/objc_compatibility_apple_test.mm
@@ -34,10 +34,12 @@ namespace firebase {
 namespace firestore {
 namespace objc {
 
+using model::DocumentState;
+
 TEST(ObjCCompatibilityTest, Equals) {
-  FSTDocument* doc1a = FSTTestDoc("a/b", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument* doc1b = FSTTestDoc("a/b", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument* doc2 = FSTTestDoc("b/c", 1, @{}, FSTDocumentStateSynced);
+  FSTDocument* doc1a = FSTTestDoc("a/b", 0, @{}, DocumentState::kSynced);
+  FSTDocument* doc1b = FSTTestDoc("a/b", 0, @{}, DocumentState::kSynced);
+  FSTDocument* doc2 = FSTTestDoc("b/c", 1, @{}, DocumentState::kSynced);
 
   EXPECT_TRUE(Equals(doc1a, doc1b));
   EXPECT_FALSE(Equals(doc1a, doc2));
@@ -45,10 +47,10 @@ TEST(ObjCCompatibilityTest, Equals) {
 }
 
 TEST(ObjCCompatibilityTest, ContainerEquals) {
-  FSTDocument* doc1a = FSTTestDoc("a/b", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument* doc2a = FSTTestDoc("b/c", 1, @{}, FSTDocumentStateSynced);
-  FSTDocument* doc1b = FSTTestDoc("a/b", 0, @{}, FSTDocumentStateSynced);
-  FSTDocument* doc2b = FSTTestDoc("b/c", 1, @{}, FSTDocumentStateSynced);
+  FSTDocument* doc1a = FSTTestDoc("a/b", 0, @{}, DocumentState::kSynced);
+  FSTDocument* doc2a = FSTTestDoc("b/c", 1, @{}, DocumentState::kSynced);
+  FSTDocument* doc1b = FSTTestDoc("a/b", 0, @{}, DocumentState::kSynced);
+  FSTDocument* doc2b = FSTTestDoc("b/c", 1, @{}, DocumentState::kSynced);
 
   std::vector<FSTDocument*> v1{doc1a, doc2a};
   std::vector<FSTDocument*> v2{doc1b, doc2b};


### PR DESCRIPTION
This is an almost entirely mechanical change that does the substitution.