### PR TITLE
Fix bug where app launch messages weren't appearing on iOS

### DIFF
--- a/Firebase/InAppMessaging/Data/FIRIAMFetchResponseParser.m
+++ b/Firebase/InAppMessaging/Data/FIRIAMFetchResponseParser.m
@@ -101,9 +101,12 @@
   NSMutableArray<FIRIAMDisplayTriggerDefinition *> *triggers = [[NSMutableArray alloc] init];
 
   for (NSDictionary *nextTriggerCondition in triggerConditions) {
+    // Handle app_launch and on_foreground cases.
     if (nextTriggerCondition[@"fiamTrigger"]) {
       if ([nextTriggerCondition[@"fiamTrigger"] isEqualToString:@"ON_FOREGROUND"]) {
         [triggers addObject:[[FIRIAMDisplayTriggerDefinition alloc] initForAppForegroundTrigger]];
+      } else if ([nextTriggerCondition[@"fiamTrigger"] isEqualToString:@"APP_LAUNCH"]) {
+        [triggers addObject:[[FIRIAMDisplayTriggerDefinition alloc] initForAppLaunchTrigger]];
       }
     } else if ([nextTriggerCondition[@"event"] isKindOfClass:[NSDictionary class]]) {
       NSDictionary *triggeringEvent = (NSDictionary *)nextTriggerCondition[@"event"];

--- a/Firebase/InAppMessaging/Data/FIRIAMMessageDefinition.h
+++ b/Firebase/InAppMessaging/Data/FIRIAMMessageDefinition.h
@@ -52,6 +52,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)messageHasExpired;
 - (BOOL)messageHasStarted;
 
+// should this message be rendered on initial app launch?
+- (BOOL)messageRenderedOnAppLaunchEvent;
 // should this message be rendered when the app gets foregrounded?
 - (BOOL)messageRenderedOnAppForegroundEvent;
 // should this message be rendered when a given analytics event is fired?

--- a/Firebase/InAppMessaging/Data/FIRIAMMessageDefinition.h
+++ b/Firebase/InAppMessaging/Data/FIRIAMMessageDefinition.h
@@ -15,6 +15,7 @@
  */
 #import <Foundation/Foundation.h>
 
+#import "FIRIAMDisplayTriggerDefinition.h"
 #import "FIRIAMMessageRenderData.h"
 
 @class FIRIAMDisplayTriggerDefinition;
@@ -52,10 +53,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)messageHasExpired;
 - (BOOL)messageHasStarted;
 
-// should this message be rendered on initial app launch?
-- (BOOL)messageRenderedOnAppLaunchEvent;
-// should this message be rendered when the app gets foregrounded?
-- (BOOL)messageRenderedOnAppForegroundEvent;
+// should this message be rendered given the FIAM trigger type? only use this method for app launch
+// and foreground trigger, use messageRenderedOnAnalyticsEvent: for analytics triggers
+- (BOOL)messageRenderedOnTrigger:(FIRIAMRenderTrigger)trigger;
 // should this message be rendered when a given analytics event is fired?
 - (BOOL)messageRenderedOnAnalyticsEvent:(NSString *)eventName;
 @end

--- a/Firebase/InAppMessaging/Data/FIRIAMMessageDefinition.m
+++ b/Firebase/InAppMessaging/Data/FIRIAMMessageDefinition.m
@@ -15,7 +15,6 @@
  */
 
 #import "FIRIAMMessageDefinition.h"
-#import "FIRIAMDisplayTriggerDefinition.h"
 
 @implementation FIRIAMMessageRenderData
 
@@ -60,18 +59,9 @@
   return self.endTime < [[NSDate date] timeIntervalSince1970];
 }
 
-- (BOOL)messageRenderedOnAppLaunchEvent {
+- (BOOL)messageRenderedOnTrigger:(FIRIAMRenderTrigger)trigger {
   for (FIRIAMDisplayTriggerDefinition *nextTrigger in self.renderTriggers) {
-    if (nextTrigger.triggerType == FIRIAMRenderTriggerOnAppLaunch) {
-      return YES;
-    }
-  }
-  return NO;
-}
-
-- (BOOL)messageRenderedOnAppForegroundEvent {
-  for (FIRIAMDisplayTriggerDefinition *nextTrigger in self.renderTriggers) {
-    if (nextTrigger.triggerType == FIRIAMRenderTriggerOnAppForeground) {
+    if (nextTrigger.triggerType == trigger) {
       return YES;
     }
   }

--- a/Firebase/InAppMessaging/Data/FIRIAMMessageDefinition.m
+++ b/Firebase/InAppMessaging/Data/FIRIAMMessageDefinition.m
@@ -60,6 +60,15 @@
   return self.endTime < [[NSDate date] timeIntervalSince1970];
 }
 
+- (BOOL)messageRenderedOnAppLaunchEvent {
+  for (FIRIAMDisplayTriggerDefinition *nextTrigger in self.renderTriggers) {
+    if (nextTrigger.triggerType == FIRIAMRenderTriggerOnAppLaunch) {
+      return YES;
+    }
+  }
+  return NO;
+}
+
 - (BOOL)messageRenderedOnAppForegroundEvent {
   for (FIRIAMDisplayTriggerDefinition *nextTrigger in self.renderTriggers) {
     if (nextTrigger.triggerType == FIRIAMRenderTriggerOnAppForeground) {

--- a/Firebase/InAppMessaging/DisplayTrigger/FIRIAMDisplayTriggerDefinition.h
+++ b/Firebase/InAppMessaging/DisplayTrigger/FIRIAMDisplayTriggerDefinition.h
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSInteger, FIRIAMRenderTrigger) {
+  FIRIAMRenderTriggerOnAppLaunch,
   FIRIAMRenderTriggerOnAppForeground,
   FIRIAMRenderTriggerOnFirebaseAnalyticsEvent
 };
@@ -28,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 // applicable only when triggerType == FIRIAMRenderTriggerOnFirebaseAnalyticsEvent
 @property(nonatomic, copy, nullable, readonly) NSString *firebaseEventName;
 
+- (instancetype)initForAppLaunchTrigger;
 - (instancetype)initForAppForegroundTrigger;
 - (instancetype)initWithFirebaseAnalyticEvent:(NSString *)title;
 @end

--- a/Firebase/InAppMessaging/DisplayTrigger/FIRIAMDisplayTriggerDefinition.m
+++ b/Firebase/InAppMessaging/DisplayTrigger/FIRIAMDisplayTriggerDefinition.m
@@ -17,6 +17,14 @@
 #import "FIRIAMDisplayTriggerDefinition.h"
 
 @implementation FIRIAMDisplayTriggerDefinition
+
+- (instancetype)initForAppLaunchTrigger {
+  if (self = [super init]) {
+    _triggerType = FIRIAMRenderTriggerOnAppLaunch;
+  }
+  return self;
+}
+
 - (instancetype)initForAppForegroundTrigger {
   if (self = [super init]) {
     _triggerType = FIRIAMRenderTriggerOnAppForeground;

--- a/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.h
+++ b/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.h
@@ -49,6 +49,8 @@ NS_ASSUME_NONNULL_BEGIN
                         activityLogger:(FIRIAMActivityLogger *)activityLogger
                   analyticsEventLogger:(id<FIRIAMAnalyticsEventLogger>)analyticsEventLogger;
 
+// Check and display next in-app message eligible for app launch trigger
+- (void)checkAndDisplayNextAppLaunchMessage;
 // Check and display next in-app message eligible for app open trigger
 - (void)checkAndDisplayNextAppForegroundMessage;
 // Check and display next in-app message eligible for analytics event trigger with given event name.

--- a/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.m
@@ -604,6 +604,51 @@
   return intervalFromLastDisplayInSeconds >= self.setting.displayMinIntervalInMinutes * 60.0;
 }
 
+- (void)checkAndDisplayNextAppLaunchMessage {
+  // synchronizing on self so that we won't potentially enter the render flow from two
+  // threads: example like showing analytics triggered message and a regular app open
+  // triggered message concurrently
+  @synchronized(self) {
+    if (!self.messageDisplayComponent) {
+      FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400027",
+                  @"Message display component is not present yet. No display should happen.");
+      return;
+    }
+
+    if (self.suppressMessageDisplay) {
+      FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400016",
+                  @"Message display is being suppressed. No regular message rendering.");
+      return;
+    }
+
+    if (self.isMsgBeingDisplayed) {
+      FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400002",
+                  @"An in-app message display is in progress, do not over-display on top of it.");
+      return;
+    }
+
+    if ([self.messageCache hasTestMessage] || [self enoughIntervalFromLastDisplay]) {
+      // We can display test messages anytime or display regular messages when
+      // the display time interval has been reached
+      FIRIAMMessageDefinition *nextForegroundMessage =
+          [self.messageCache nextOnAppLaunchDisplayMsg];
+
+      if (nextForegroundMessage) {
+        [self displayForMessage:nextForegroundMessage
+                    triggerType:FIRInAppMessagingDisplayTriggerTypeOnAnalyticsEvent];
+        self.lastDisplayTime = [self.timeFetcher currentTimestampInSeconds];
+      } else {
+        FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400001",
+                    @"No appropriate in-app message detected for display.");
+      }
+    } else {
+      FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400003",
+                  @"Minimal display interval of %lf seconds has not been reached yet.",
+                  self.setting.displayMinIntervalInMinutes * 60.0);
+    }
+  }
+}
+
 - (void)checkAndDisplayNextAppForegroundMessage {
   // synchronizing on self so that we won't potentially enter the render flow from two
   // threads: example like showing analytics triggered message and a regular app open

--- a/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.m
@@ -606,23 +606,22 @@
 
 - (void)checkAndDisplayNextAppLaunchMessage {
   // synchronizing on self so that we won't potentially enter the render flow from two
-  // threads: example like showing analytics triggered message and a regular app open
-  // triggered message concurrently
+  // threads.
   @synchronized(self) {
     if (!self.messageDisplayComponent) {
-      FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400027",
+      FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400028",
                   @"Message display component is not present yet. No display should happen.");
       return;
     }
 
     if (self.suppressMessageDisplay) {
-      FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400016",
+      FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400029",
                   @"Message display is being suppressed. No regular message rendering.");
       return;
     }
 
     if (self.isMsgBeingDisplayed) {
-      FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400002",
+      FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400030",
                   @"An in-app message display is in progress, do not over-display on top of it.");
       return;
     }
@@ -630,19 +629,18 @@
     if ([self.messageCache hasTestMessage] || [self enoughIntervalFromLastDisplay]) {
       // We can display test messages anytime or display regular messages when
       // the display time interval has been reached
-      FIRIAMMessageDefinition *nextForegroundMessage =
-          [self.messageCache nextOnAppLaunchDisplayMsg];
+      FIRIAMMessageDefinition *nextAppLaunchMessage = [self.messageCache nextOnAppLaunchDisplayMsg];
 
-      if (nextForegroundMessage) {
-        [self displayForMessage:nextForegroundMessage
+      if (nextAppLaunchMessage) {
+        [self displayForMessage:nextAppLaunchMessage
                     triggerType:FIRInAppMessagingDisplayTriggerTypeOnAnalyticsEvent];
         self.lastDisplayTime = [self.timeFetcher currentTimestampInSeconds];
       } else {
-        FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400001",
+        FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400040",
                     @"No appropriate in-app message detected for display.");
       }
     } else {
-      FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400003",
+      FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400041",
                   @"Minimal display interval of %lf seconds has not been reached yet.",
                   self.setting.displayMinIntervalInMinutes * 60.0);
     }

--- a/Firebase/InAppMessaging/Flows/FIRIAMFetchFlow.h
+++ b/Firebase/InAppMessaging/Flows/FIRIAMFetchFlow.h
@@ -54,6 +54,7 @@ typedef void (^FIRIAMFetchMessageCompletionHandler)(
 
 // Triggers a potential fetch of in-app messaging from the source. It would check and respect the
 // the fetchMinIntervalInMinutes defined in setting
-- (void)checkAndFetch;
+- (void)checkAndFetchForInitialAppLaunch:(BOOL)forInitialAppLaunch;
+
 @end
 NS_ASSUME_NONNULL_END

--- a/Firebase/InAppMessaging/Flows/FIRIAMFetchFlow.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMFetchFlow.m
@@ -19,6 +19,7 @@
 #import "FIRCore+InAppMessaging.h"
 #import "FIRIAMClearcutLogger.h"
 #import "FIRIAMFetchFlow.h"
+#import "FIRIAMRuntimeManager.h"
 
 @implementation FIRIAMFetchSetting
 @end
@@ -124,7 +125,7 @@ NSString *const kFIRIAMFetchIsDoneNotification = @"FIRIAMFetchIsDoneNotification
                                    nextFetchWaitTime:fetchWaitTime];
 }
 
-- (void)checkAndFetch {
+- (void)checkAndFetchForInitialAppLaunch:(BOOL)forInitialAppLaunch {
   NSTimeInterval intervalFromLastFetchInSeconds =
       [self.timeFetcher currentTimestampInSeconds] - self.fetchBookKeeper.lastFetchTime;
 
@@ -229,6 +230,11 @@ NSString *const kFIRIAMFetchIsDoneNotification = @"FIRIAMFetchIsDoneNotification
                              [self handleSuccessullyFetchedMessages:messages
                                                   withFetchWaitTime:nextFetchWaitTime
                                                  requestImpressions:impressions];
+
+                             if (forInitialAppLaunch) {
+                               [[FIRIAMRuntimeManager getSDKRuntimeInstance]
+                                       .displayExecutor checkAndDisplayNextAppLaunchMessage];
+                             }
                            }
                            // Send this regardless whether fetch is successful or not.
                            [self sendFetchIsDoneNotification];

--- a/Firebase/InAppMessaging/Flows/FIRIAMFetchFlow.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMFetchFlow.m
@@ -232,8 +232,7 @@ NSString *const kFIRIAMFetchIsDoneNotification = @"FIRIAMFetchIsDoneNotification
                                                  requestImpressions:impressions];
 
                              if (forInitialAppLaunch) {
-                               [[FIRIAMRuntimeManager getSDKRuntimeInstance]
-                                       .displayExecutor checkAndDisplayNextAppLaunchMessage];
+                               [self checkForAppLaunchMessage];
                              }
                            }
                            // Send this regardless whether fetch is successful or not.
@@ -255,5 +254,10 @@ NSString *const kFIRIAMFetchIsDoneNotification = @"FIRIAMFetchIsDoneNotification
                                                  timestamp:nil];
     [self.activityLogger addLogRecord:record];
   }
+}
+
+- (void)checkForAppLaunchMessage {
+  [[FIRIAMRuntimeManager getSDKRuntimeInstance]
+          .displayExecutor checkAndDisplayNextAppLaunchMessage];
 }
 @end

--- a/Firebase/InAppMessaging/Flows/FIRIAMFetchOnAppForegroundFlow.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMFetchOnAppForegroundFlow.m
@@ -35,7 +35,7 @@
   // to a concurrent global queue instead of serial queue since app open event won't happen at
   // fast speed to cause race conditions
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul), ^{
-    [self checkAndFetch];
+    [self checkAndFetchForInitialAppLaunch:NO];
   });
 }
 

--- a/Firebase/InAppMessaging/Flows/FIRIAMMessageClientCache.h
+++ b/Firebase/InAppMessaging/Flows/FIRIAMMessageClientCache.h
@@ -74,6 +74,8 @@ NS_ASSUME_NONNULL_BEGIN
 // nextOnFirebaseAnalyticEventDisplayMsg to fetch the next eligible message and use
 // removeMessageWithId to remove it from cache once the message has been correctly rendered
 
+// Fetch next eligible messages that are appropriate for display at app launch time
+- (nullable FIRIAMMessageDefinition *)nextOnAppLaunchDisplayMsg;
 // Fetch next eligible messages that are appropriate for display at app open time
 - (nullable FIRIAMMessageDefinition *)nextOnAppOpenDisplayMsg;
 // Fetch next eligible message that matches the event triggering condition

--- a/Firebase/InAppMessaging/Flows/FIRIAMMessageClientCache.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMMessageClientCache.m
@@ -142,7 +142,7 @@
       return testMessage;
     }
   }
-  
+
   // otherwise check for a message from a published campaign
   return [self nextMessageForTrigger:FIRIAMRenderTriggerOnAppForeground];
 }
@@ -152,8 +152,8 @@
   // first match (some messages in the cache may not be eligible for the current display
   // message fetch
   NSSet<NSString *> *impressionSet =
-  [NSSet setWithArray:[self.bookKeeper getMessageIDsFromImpressions]];
-  
+      [NSSet setWithArray:[self.bookKeeper getMessageIDsFromImpressions]];
+
   @synchronized(self) {
     for (FIRIAMMessageDefinition *next in self.regularMessages) {
       // message being active and message not impressed yet

--- a/Firebase/InAppMessaging/Flows/FIRIAMMessageClientCache.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMMessageClientCache.m
@@ -126,6 +126,26 @@
   return self.testMessages.count > 0;
 }
 
+- (nullable FIRIAMMessageDefinition *)nextOnAppLaunchDisplayMsg {
+  // search from the start to end in the list (which implies the display priority) for the
+  // first match (some messages in the cache may not be eligible for the current display
+  // message fetch
+  NSSet<NSString *> *impressionSet =
+      [NSSet setWithArray:[self.bookKeeper getMessageIDsFromImpressions]];
+
+  @synchronized(self) {
+    for (FIRIAMMessageDefinition *next in self.regularMessages) {
+      // message being active and message not impressed yet
+      if ([next messageHasStarted] && ![next messageHasExpired] &&
+          ![impressionSet containsObject:next.renderData.messageID] &&
+          [next messageRenderedOnAppLaunchEvent]) {
+        return next;
+      }
+    }
+  }
+  return nil;
+}
+
 - (nullable FIRIAMMessageDefinition *)nextOnAppOpenDisplayMsg {
   // search from the start to end in the list (which implies the display priority) for the
   // first match (some messages in the cache may not be eligible for the current display

--- a/Firebase/InAppMessaging/Runtime/FIRIAMRuntimeManager.m
+++ b/Firebase/InAppMessaging/Runtime/FIRIAMRuntimeManager.m
@@ -417,7 +417,8 @@ static NSString *const kFirebaseInAppMessagingAutoDataCollectionKey =
 
                                  // One-time triggering of checks for both fetch flow
                                  // upon SDK/app startup.
-                                 [self.fetchOnAppForegroundFlow checkAndFetch];
+                                 [self.fetchOnAppForegroundFlow
+                                     checkAndFetchForInitialAppLaunch:YES];
                                } else {
                                  FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM180009",
                                              @"No FIAM SDK startup due to settings.");

--- a/InAppMessaging/Example/Tests/FIRIAMFetchFlowTests.m
+++ b/InAppMessaging/Example/Tests/FIRIAMFetchFlowTests.m
@@ -274,7 +274,7 @@ CGFloat FETCH_MIN_INTERVALS = 1;
 
   // we expect to register a fetch with sdk manager
   OCMVerify([self.mockSDKModeManager registerOneMoreFetch]);
-  
+
   // we expect that the message cache is checked for app launch messages
   OCMVerify([self.flow checkForAppLaunchMessage]);
 }

--- a/InAppMessaging/Example/Tests/FIRIAMFetchFlowTests.m
+++ b/InAppMessaging/Example/Tests/FIRIAMFetchFlowTests.m
@@ -24,6 +24,11 @@
 #import "FIRIAMMessageContentDataWithImageURL.h"
 #import "FIRIAMSDKModeManager.h"
 
+@interface FIRIAMFetchFlow (Testing)
+// Expose to verify that this gets called on initial app launch fetch.
+- (void)checkForAppLaunchMessage;
+@end
+
 @interface FIRIAMFetchFlowTests : XCTestCase
 @property(nonatomic) FIRIAMFetchSetting *fetchSetting;
 @property FIRIAMMessageClientCache *clientMessageCache;
@@ -202,7 +207,7 @@ CGFloat FETCH_MIN_INTERVALS = 1;
                                                                    fetchWaitTimeFromResponse,
                                                                    [NSNull null], [NSNull null],
                                                                    nil])]);
-  [self.flow checkAndFetch];
+  [self.flow checkAndFetchForInitialAppLaunch:NO];
 
   // We expect m1 and m2 to be dumped into clientMessageCache.
   NSArray<FIRIAMMessageDefinition *> *foundMessages = [self.clientMessageCache allRegularMessages];
@@ -238,7 +243,7 @@ CGFloat FETCH_MIN_INTERVALS = 1;
   // We don't expect fetchMessages: for self.mockMessageFetcher to be triggred
   OCMReject([self.mockMessageFetcher fetchMessagesWithImpressionList:[OCMArg any]
                                                       withCompletion:[OCMArg any]]);
-  [self.flow checkAndFetch];
+  [self.flow checkAndFetchForInitialAppLaunch:NO];
 
   NSArray<FIRIAMMessageDefinition *> *foundMessages = [self.clientMessageCache allRegularMessages];
   XCTAssertEqual(0, foundMessages.count);
@@ -259,7 +264,7 @@ CGFloat FETCH_MIN_INTERVALS = 1;
   OCMStub([self.mockBookkeeper nextFetchWaitTime]).andReturn(1000);
   OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(100);
 
-  [self.flow checkAndFetch];
+  [self.flow checkAndFetchForInitialAppLaunch:YES];
 
   // we expect m1 and m2 to be dumped into clientMessageCache
   NSArray<FIRIAMMessageDefinition *> *foundMessages = [self.clientMessageCache allRegularMessages];
@@ -269,6 +274,9 @@ CGFloat FETCH_MIN_INTERVALS = 1;
 
   // we expect to register a fetch with sdk manager
   OCMVerify([self.mockSDKModeManager registerOneMoreFetch]);
+  
+  // we expect that the message cache is checked for app launch messages
+  OCMVerify([self.flow checkForAppLaunchMessage]);
 }
 
 // Fetch always in testing app instance mode
@@ -285,7 +293,7 @@ CGFloat FETCH_MIN_INTERVALS = 1;
   OCMStub([self.mockBookkeeper nextFetchWaitTime]).andReturn(1000);
   OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(100);
 
-  [self.flow checkAndFetch];
+  [self.flow checkAndFetchForInitialAppLaunch:NO];
 
   // we expect m1 and m2 to be dumped into clientMessageCache
   NSArray<FIRIAMMessageDefinition *> *foundMessages = [self.clientMessageCache allRegularMessages];
@@ -313,7 +321,7 @@ CGFloat FETCH_MIN_INTERVALS = 1;
   // 100 seconds is larger than FETCH_MIN_INTERVALS minutes
   OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(100);
 
-  [self.flow checkAndFetch];
+  [self.flow checkAndFetchForInitialAppLaunch:NO];
 
   // Expecting turning sdk mode into a testing instance
   OCMVerify([self.mockSDKModeManager becomeTestingInstance]);
@@ -335,6 +343,6 @@ CGFloat FETCH_MIN_INTERVALS = 1;
   OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(1000);
   OCMReject([self.mockSDKModeManager becomeTestingInstance]);
 
-  [self.flow checkAndFetch];
+  [self.flow checkAndFetchForInitialAppLaunch:NO];
 }
 @end


### PR DESCRIPTION
There were two issues:
1. App launch FIAMs come through with a `fiamTrigger` param in the payload (as opposed to the `event` param for general analytics events) and we were only validating messages with a `fiamTrigger` of `ON_FOREGROUND`.
2. We needed to add a flow to check for app launch FIAMs at the appropriate time-- after the initial app launch fetch occurs and messages are retrieved and stored into the cache.