### PR TITLE
Add a vector of pointers type

### DIFF
--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -182,6 +182,9 @@
 		535F51F2FF2AB52A6E629091 /* FSTLevelDBMutationQueueTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E0872021552A00B64F25 /* FSTLevelDBMutationQueueTests.mm */; };
 		53AB47E44D897C81A94031F6 /* write.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 544129D921C2DDC800EFB9CC /* write.pb.cc */; };
 		54080260D85A6F583E61DA1D /* FSTLocalSerializerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5492E08A2021552A00B64F25 /* FSTLocalSerializerTests.mm */; };
+		540C379D22C1741000E70F15 /* vector_of_ptr_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 540C379C22C1741000E70F15 /* vector_of_ptr_test.cc */; };
+		540C379E22C1741000E70F15 /* vector_of_ptr_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 540C379C22C1741000E70F15 /* vector_of_ptr_test.cc */; };
+		540C379F22C1741000E70F15 /* vector_of_ptr_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 540C379C22C1741000E70F15 /* vector_of_ptr_test.cc */; };
 		54131E9720ADE679001DF3FF /* string_format_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54131E9620ADE678001DF3FF /* string_format_test.cc */; };
 		544129DA21C2DDC800EFB9CC /* common.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 544129D221C2DDC800EFB9CC /* common.pb.cc */; };
 		544129DB21C2DDC800EFB9CC /* firestore.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 544129D421C2DDC800EFB9CC /* firestore.pb.cc */; };
@@ -783,6 +786,7 @@
 		444B7AB3F5A2929070CB1363 /* hard_assert_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = hard_assert_test.cc; sourceTree = "<group>"; };
 		4C73C0CC6F62A90D8573F383 /* string_apple_benchmark.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; path = string_apple_benchmark.mm; sourceTree = "<group>"; };
 		5342CDDB137B4E93E2E85CCA /* byte_string_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; name = byte_string_test.cc; path = nanopb/byte_string_test.cc; sourceTree = "<group>"; };
+		540C379C22C1741000E70F15 /* vector_of_ptr_test.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = vector_of_ptr_test.cc; sourceTree = "<group>"; };
 		54131E9620ADE678001DF3FF /* string_format_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = string_format_test.cc; sourceTree = "<group>"; };
 		544129D021C2DDC800EFB9CC /* query.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = query.pb.h; sourceTree = "<group>"; };
 		544129D121C2DDC800EFB9CC /* common.pb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = common.pb.h; sourceTree = "<group>"; };
@@ -1316,6 +1320,7 @@
 				79507DF8378D3C42F5B36268 /* string_win_test.cc */,
 				B68B1E002213A764008977EF /* to_string_apple_test.mm */,
 				B696858D2214B53900271095 /* to_string_test.cc */,
+				540C379C22C1741000E70F15 /* vector_of_ptr_test.cc */,
 			);
 			path = util;
 			sourceTree = "<group>";
@@ -3150,6 +3155,7 @@
 				8DA258092DD856D829D973B5 /* transform_operations_test.mm in Sources */,
 				5F19F66D8B01BA2B97579017 /* tree_sorted_map_test.cc in Sources */,
 				16F52ECC6FA8A0587CD779EB /* user_test.cc in Sources */,
+				540C379E22C1741000E70F15 /* vector_of_ptr_test.cc in Sources */,
 				E3C0E5F834A82EEE9F8C4519 /* watch_change_test.mm in Sources */,
 				53AB47E44D897C81A94031F6 /* write.pb.cc in Sources */,
 				59E6941008253D4B0F77C2BA /* writer_test.cc in Sources */,
@@ -3325,6 +3331,7 @@
 				5C7FAF228D0F52CFFE9E41B5 /* transform_operations_test.mm in Sources */,
 				627253FDEC6BB5549FE77F4E /* tree_sorted_map_test.cc in Sources */,
 				596C782EFB68131380F8EEF8 /* user_test.cc in Sources */,
+				540C379F22C1741000E70F15 /* vector_of_ptr_test.cc in Sources */,
 				178FE1E277C63B3E7120BE56 /* watch_change_test.mm in Sources */,
 				A5AB1815C45FFC762981E481 /* write.pb.cc in Sources */,
 				A21819C437C3C80450D7EEEE /* writer_test.cc in Sources */,
@@ -3582,6 +3589,7 @@
 				54A0352720A3AED0003E0143 /* transform_operations_test.mm in Sources */,
 				549CCA5120A36DBC00BCEB75 /* tree_sorted_map_test.cc in Sources */,
 				ABC1D7DE2023A05300BA84F0 /* user_test.cc in Sources */,
+				540C379D22C1741000E70F15 /* vector_of_ptr_test.cc in Sources */,
 				B68FC0E521F6848700A7055C /* watch_change_test.mm in Sources */,
 				544129DE21C2DDC800EFB9CC /* write.pb.cc in Sources */,
 				3BA4EEA6153B3833F86B8104 /* writer_test.cc in Sources */,

--- a/Firestore/core/src/firebase/firestore/model/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/model/CMakeLists.txt
@@ -22,7 +22,11 @@ cc_library(
     document.h
     document_key.cc
     document_key.h
+    document_key_set.h
     document_map.h
+    document_map.mm
+    document_set.h
+    document_set.mm
     field_mask.h
     field_mask.cc
     field_path.cc

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -259,6 +259,7 @@ cc_library(
     string_util.h
     to_string.h
     type_traits.h
+    vector_of_ptr.h
     warnings.h
   DEPENDS
     absl_base

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -210,6 +210,7 @@ cc_library(
     status_win.cc
     statusor.cc
     statusor.h
+    statusor_callback.h
     statusor_internals.h
     strerror.cc
     strerror.h
@@ -253,6 +254,7 @@ cc_library(
     ordered_code.cc
     ordered_code.h
     range.h
+    sanitizers.h
     string_util.cc
     string_util.h
     to_string.h

--- a/Firestore/core/src/firebase/firestore/util/vector_of_ptr.h
+++ b/Firestore/core/src/firebase/firestore/util/vector_of_ptr.h
@@ -41,11 +41,11 @@ namespace util {
  * for some reason, usually this is to enable polymorphism or because copying
  * values of T is expensive.
  */
-template <typename T, typename P = std::shared_ptr<T>>
+template <typename P>
 class vector_of_ptr {
  public:
-  using value_type = T;
   using pointer_type = P;
+  using value_type = decltype(*std::declval<P>());
   using vector_type = std::vector<P>;
 
   vector_of_ptr() = default;

--- a/Firestore/core/src/firebase/firestore/util/vector_of_ptr.h
+++ b/Firestore/core/src/firebase/firestore/util/vector_of_ptr.h
@@ -45,11 +45,14 @@ template <typename P>
 class vector_of_ptr {
  public:
   using pointer_type = P;
-  using value_type = decltype(*std::declval<P>());
+  using value_type = decltype(*P());
   using vector_type = std::vector<P>;
 
+  using iterator = typename vector_type::iterator;
+  using const_iterator = typename vector_type::const_iterator;
+
   vector_of_ptr() = default;
-  vector_of_ptr(std::initializer_list<P> values) : values_(std::move(values)) {
+  vector_of_ptr(std::initializer_list<P> values) : values_(values) {
   }
 
   size_t size() const {
@@ -60,17 +63,17 @@ class vector_of_ptr {
     values_.push_back(std::move(value));
   }
 
-  typename vector_type::iterator begin() {
+  iterator begin() {
     return values_.begin();
   }
-  typename vector_type::const_iterator begin() const {
+  const_iterator begin() const {
     return values_.begin();
   }
 
-  typename vector_type::iterator end() {
+  iterator end() {
     return values_.end();
   }
-  typename vector_type::const_iterator end() const {
+  const_iterator end() const {
     return values_.end();
   }
 

--- a/Firestore/core/src/firebase/firestore/util/vector_of_ptr.h
+++ b/Firestore/core/src/firebase/firestore/util/vector_of_ptr.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_VECTOR_OF_PTR_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_VECTOR_OF_PTR_H_
+
+#include <initializer_list>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "absl/algorithm/container.h"
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+/**
+ * A std::vector of some pointer type where equality and many other operations
+ * are defined as operating on the value pointed to rather than on the pointers
+ * themselves.
+ *
+ * Contrast with `std::vector<std::shared_ptr<T>>`, where `operator==` just
+ * checks if the pointers in the collection are equal rather than checking if
+ * the things the pointers point to are equal.
+ *
+ * This is useful in cases where values of type T need to be held by pointer
+ * for some reason, usually this is to enable polymorphism or because copying
+ * values of T is expensive.
+ */
+template <typename T, typename P = std::shared_ptr<T>>
+class vector_of_ptr {
+ public:
+  using value_type = T;
+  using pointer_type = P;
+  using vector_type = std::vector<P>;
+
+  vector_of_ptr() = default;
+  vector_of_ptr(std::initializer_list<P> values) : values_(std::move(values)) {
+  }
+
+  size_t size() const {
+    return values_.size();
+  }
+
+  void push_back(P value) {
+    values_.push_back(std::move(value));
+  }
+
+  typename vector_type::iterator begin() {
+    return values_.begin();
+  }
+  typename vector_type::const_iterator begin() const {
+    return values_.begin();
+  }
+
+  typename vector_type::iterator end() {
+    return values_.end();
+  }
+  typename vector_type::const_iterator end() const {
+    return values_.end();
+  }
+
+  friend bool operator==(const vector_of_ptr& lhs, const vector_of_ptr& rhs) {
+    return absl::c_equal(
+        lhs.values_, rhs.values_, [](const P& left, const P& right) {
+          return left == nullptr ? right == nullptr
+                                 : right != nullptr && *left == *right;
+        });
+  }
+
+  friend bool operator!=(const vector_of_ptr& lhs, const vector_of_ptr& rhs) {
+    return !(lhs == rhs);
+  }
+
+ private:
+  vector_type values_;
+};
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_VECTOR_OF_PTR_H_

--- a/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/util/CMakeLists.txt
@@ -163,6 +163,7 @@ cc_test(
     string_format_test.cc
     string_util_test.cc
     string_win_test.cc
+    vector_of_ptr_test.cc
   DEPENDS
     absl_base
     absl_strings

--- a/Firestore/core/test/firebase/firestore/util/vector_of_ptr_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/vector_of_ptr_test.cc
@@ -63,11 +63,16 @@ TEST(VectorOfPtrTest, EqualityIsValueEquality) {
   int_ptr_vector contains_nulls = {nullptr, nullptr};
   int_ptr_vector empty;
 
+  EXPECT_EQ(empty, int_ptr_vector());
+
   EXPECT_EQ(lhs, lhs);
   EXPECT_EQ(lhs, rhs);
   EXPECT_NE(lhs, other);
   EXPECT_NE(lhs, contains_nulls);
   EXPECT_NE(lhs, empty);
+
+  EXPECT_EQ(contains_nulls, contains_nulls);
+  EXPECT_NE(contains_nulls, lhs);
 }
 
 TEST(VectorOfPtrTest, IterationIsOnPointers) {

--- a/Firestore/core/test/firebase/firestore/util/vector_of_ptr_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/vector_of_ptr_test.cc
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/util/vector_of_ptr.h"
+
+#include "gtest/gtest.h"
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+TEST(VectorOfPtrTest, DefaultConstructor) {
+  vector_of_ptr<int> values;
+  EXPECT_EQ(0, values.size());
+}
+
+TEST(VectorOfPtrTest, PushBack) {
+  vector_of_ptr<int> values;
+  values.push_back(std::make_shared<int>(0));
+  values.push_back(std::make_shared<int>(42));
+  EXPECT_EQ(2, values.size());
+}
+
+TEST(VectorOfPtrTest, BracedInitialization) {
+  vector_of_ptr<int> brace_initialized_ints{std::make_shared<int>(0),
+                                            std::make_shared<int>(1)};
+
+  EXPECT_EQ(2, brace_initialized_ints.size());
+
+  brace_initialized_ints = {};
+  EXPECT_EQ(0, brace_initialized_ints.size());
+}
+
+TEST(VectorOfPtrTest, EqualityIsValueEquality) {
+  vector_of_ptr<int> lhs = {std::make_shared<int>(0), std::make_shared<int>(1)};
+  vector_of_ptr<int> rhs = {std::make_shared<int>(0), std::make_shared<int>(1)};
+  vector_of_ptr<int> other = {std::make_shared<int>(1),
+                              std::make_shared<int>(0)};
+  vector_of_ptr<int> contains_nulls = {nullptr, nullptr};
+  vector_of_ptr<int> empty;
+
+  EXPECT_EQ(lhs, lhs);
+  EXPECT_EQ(lhs, rhs);
+  EXPECT_NE(lhs, other);
+  EXPECT_NE(lhs, contains_nulls);
+  EXPECT_NE(lhs, empty);
+}
+
+TEST(VectorOfPtrTest, IterationIsOnPointers) {
+  std::shared_ptr<int> pointers[] = {std::make_shared<int>(-1),
+                                     std::make_shared<int>(42)};
+  vector_of_ptr<int> vector = {pointers[0], pointers[1]};
+
+  size_t pos = 0;
+  for (const std::shared_ptr<int>& element : vector) {
+    ASSERT_EQ(*pointers[pos], *element);
+    ++pos;
+  }
+  ASSERT_EQ(pos, sizeof(pointers) / sizeof(pointers[0]));
+}
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/core/test/firebase/firestore/util/vector_of_ptr_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/vector_of_ptr_test.cc
@@ -16,6 +16,7 @@
 
 #include "Firestore/core/src/firebase/firestore/util/vector_of_ptr.h"
 
+#include "absl/memory/memory.h"
 #include "gtest/gtest.h"
 
 namespace firebase {
@@ -23,20 +24,20 @@ namespace firestore {
 namespace util {
 
 TEST(VectorOfPtrTest, DefaultConstructor) {
-  vector_of_ptr<int> values;
+  vector_of_ptr<std::shared_ptr<int>> values;
   EXPECT_EQ(0, values.size());
 }
 
 TEST(VectorOfPtrTest, PushBack) {
-  vector_of_ptr<int> values;
+  vector_of_ptr<std::shared_ptr<int>> values;
   values.push_back(std::make_shared<int>(0));
   values.push_back(std::make_shared<int>(42));
   EXPECT_EQ(2, values.size());
 }
 
 TEST(VectorOfPtrTest, BracedInitialization) {
-  vector_of_ptr<int> brace_initialized_ints{std::make_shared<int>(0),
-                                            std::make_shared<int>(1)};
+  vector_of_ptr<std::shared_ptr<int>> brace_initialized_ints{
+      std::make_shared<int>(0), std::make_shared<int>(1)};
 
   EXPECT_EQ(2, brace_initialized_ints.size());
 
@@ -44,13 +45,23 @@ TEST(VectorOfPtrTest, BracedInitialization) {
   EXPECT_EQ(0, brace_initialized_ints.size());
 }
 
+TEST(VectorOfPtrTest, WorksWithUniquePtr) {
+  vector_of_ptr<std::unique_ptr<int>> values;
+  values.push_back(absl::make_unique<int>(42));
+
+  auto pointer = absl::make_unique<int>(0);
+  values.push_back(std::move(pointer));
+
+  ASSERT_EQ(2, values.size());
+}
+
 TEST(VectorOfPtrTest, EqualityIsValueEquality) {
-  vector_of_ptr<int> lhs = {std::make_shared<int>(0), std::make_shared<int>(1)};
-  vector_of_ptr<int> rhs = {std::make_shared<int>(0), std::make_shared<int>(1)};
-  vector_of_ptr<int> other = {std::make_shared<int>(1),
-                              std::make_shared<int>(0)};
-  vector_of_ptr<int> contains_nulls = {nullptr, nullptr};
-  vector_of_ptr<int> empty;
+  using int_ptr_vector = vector_of_ptr<std::shared_ptr<int>>;
+  int_ptr_vector lhs = {std::make_shared<int>(0), std::make_shared<int>(1)};
+  int_ptr_vector rhs = {std::make_shared<int>(0), std::make_shared<int>(1)};
+  int_ptr_vector other = {std::make_shared<int>(1), std::make_shared<int>(0)};
+  int_ptr_vector contains_nulls = {nullptr, nullptr};
+  int_ptr_vector empty;
 
   EXPECT_EQ(lhs, lhs);
   EXPECT_EQ(lhs, rhs);
@@ -62,7 +73,7 @@ TEST(VectorOfPtrTest, EqualityIsValueEquality) {
 TEST(VectorOfPtrTest, IterationIsOnPointers) {
   std::shared_ptr<int> pointers[] = {std::make_shared<int>(-1),
                                      std::make_shared<int>(42)};
-  vector_of_ptr<int> vector = {pointers[0], pointers[1]};
+  vector_of_ptr<std::shared_ptr<int>> vector = {pointers[0], pointers[1]};
 
   size_t pos = 0;
   for (const std::shared_ptr<int>& element : vector) {


### PR DESCRIPTION
The idea is to make equality by pointed-to-value fully encapsulated in things like `Query::filters_`.

This is a separate change from implementing filters to make it straightforward to review. We can add additional operations as required as we need them.