### PR TITLE
Fix unaccessible init in FDL tests.

### DIFF
--- a/Example/DynamicLinks/Tests/FIRDynamicLinksTest.m
+++ b/Example/DynamicLinks/Tests/FIRDynamicLinksTest.m
@@ -83,6 +83,7 @@ typedef NSURL * (^FakeShortLinkResolverHandler)(NSURL *shortLink);
 
 @interface FakeShortLinkResolver : FIRDynamicLinkNetworking
 + (instancetype)resolverWithBlock:(FakeShortLinkResolverHandler)resolverHandler;
+- (instancetype)init;  // Re-declared since superclass's `init` is unavailable.
 @end
 
 @implementation FakeShortLinkResolver {


### PR DESCRIPTION
This causes a breakage with internal tests.