### PR TITLE
CMake fixes for GoogleDataTransport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,9 +206,12 @@ target_compile_definitions(
   PUBLIC -DPB_FIELD_32BIT -DPB_ENABLE_MALLOC
 )
 
+# Enable #include <nanopb/pb.h>
 target_include_directories(
   protobuf-nanopb-static
-  INTERFACE $<BUILD_INTERFACE:${FIREBASE_EXTERNAL_SOURCE_DIR}/nanopb>
+  INTERFACE
+  $<BUILD_INTERFACE:${FIREBASE_EXTERNAL_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${FIREBASE_EXTERNAL_SOURCE_DIR}/nanopb>
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,6 +217,11 @@ include(compiler_setup)
 
 
 # Firebase packages
+
+# Set variables that CocoaPods expects to be able to expand in values it
+# includes in the xcconfigs it generates.
+set(PODS_TARGET_SRCROOT ${FIREBASE_SOURCE_DIR})
+
 podspec_framework(
   ${FIREBASE_SOURCE_DIR}/GoogleUtilities.podspec
   SPECS Logger

--- a/cmake/podspec_cmake.rb
+++ b/cmake/podspec_cmake.rb
@@ -303,7 +303,7 @@ class CMakeGenerator
 
       hmap_dirs.add(File.dirname(source))
     end
-    @target.include_directories('PRIVATE', hmap_dirs.to_a.sort)
+    @target.include_directories('PRIVATE', *hmap_dirs.to_a.sort)
   end
 
   # Adds Pod::Spec +dependencies+ as target_link_libraries. Only root-specs are
@@ -345,9 +345,9 @@ class CMakeGenerator
 
     defs = split(xcconfig['GCC_PREPROCESSOR_DEFINITIONS'])
     defs = defs.map { |x| '-D' + x }
-    @target.compile_definitions(type, defs)
+    @target.compile_definitions(type, *defs)
 
-    @target.include_directories(type, split(xcconfig['HEADER_SEARCH_PATHS']))
+    @target.include_directories(type, *split(xcconfig['HEADER_SEARCH_PATHS']))
   end
 
   # Splits a textual value in xcconfig. Always returns an array, but that array

--- a/cmake/podspec_cmake.rb
+++ b/cmake/podspec_cmake.rb
@@ -306,6 +306,13 @@ class CMakeGenerator
     @target.include_directories('PRIVATE', *hmap_dirs.to_a.sort)
   end
 
+  # Account for differences in dependency names between CocoaPods and CMake.
+  # Keys should be CocoaPod dependency names and values should be the
+  # equivalent CMake library targets.
+  DEP_RENAMES = {
+    'nanopb' => 'protobuf-nanopb-static'
+  }
+
   # Adds Pod::Spec +dependencies+ as target_link_libraries. Only root-specs are
   # added as dependencies because in the CMake build there can be only one
   # target for the framework.
@@ -316,6 +323,8 @@ class CMakeGenerator
       next if dep.name.start_with?(prefix)
 
       name = dep.name.sub(/\/.*/, '')
+      name = DEP_RENAMES.fetch(name, name)
+
       @target.link_libraries('PUBLIC', name)
     end
   end

--- a/cmake/podspec_rules.cmake
+++ b/cmake/podspec_rules.cmake
@@ -24,8 +24,8 @@ macro(podspec_framework PODSPEC_FILE)
     set(multi SPECS)
     cmake_parse_arguments(psf "" "" "${multi}" ${ARGN})
 
-    get_filename_component(_properties_file ${PODSPEC_FILE} NAME_WE)
-    set(_properties_file ${_properties_file}.cmake)
+    get_filename_component(_pod_name ${PODSPEC_FILE} NAME_WE)
+    set(_properties_file ${_pod_name}.cmake)
 
     # Use bundler only if the current source tree has it set up. Otherwise fall
     # back on the system ruby setup, which may have CocoaPods installed.
@@ -55,5 +55,14 @@ macro(podspec_framework PODSPEC_FILE)
     )
 
     include(${CMAKE_CURRENT_BINARY_DIR}/${_properties_file})
+
+    # Non-Firestore Objective-C code in this repository is not as strict about
+    # warnings.
+    target_compile_options(
+      ${_pod_name}
+      PRIVATE
+      -Wno-unused-parameter
+      -Wno-deprecated-declarations
+    )
   endif()
 endmacro()


### PR DESCRIPTION
Essentially this makes it such that `PODS_TARGET_SRCROOT` is available for substitution in values derived from CocoaPods xcconfig settings

There's also a few misc fixes:
  * Handle differences between CocoaPod and CMake dependency names
  * Allow podspec-sourced libraries to compile with looser settings to match Xcode defaults