### PR TITLE
Work around duplicate nanopb symbols in gRPC build

### DIFF
--- a/cmake/external/grpc.cmake
+++ b/cmake/external/grpc.cmake
@@ -33,6 +33,11 @@ ExternalProject_Add(
   BUILD_COMMAND ""
   TEST_COMMAND ""
   INSTALL_COMMAND ""
+
+  # TODO(b/136119129): Get a common version of nanopb with gRPC.
+  # We need to resolve how to arrange for gRPC and Firestore to get a common
+  # version of nanopb.
+  PATCH_COMMAND sed -i.bak "/third_party\\/nanopb/ d" ${PROJECT_BINARY_DIR}/src/grpc/CMakeLists.txt
 )
 
 # gRPC depends upon these projects, so from an IWYU point of view should


### PR DESCRIPTION
gRPC packages 0.3.7-dev from 2016 in its own third_party directory and
builds it into libraries produced by CMake. Firestore depends on 0.3.9.2
via external dependency.

Firestore checks in its nanopb-generated sources for compatibility with
CocoaPods, where running the generator at build time on remote users'
machines is perilous. This means that Firestore's generated code must
match the version of nanopb available in CocoaPods.

Unfortunately, generated code from 0.3.7-dev and 0.3.9.2 are not
compatible with each other so we can't just downgrade the Firestore
CMake build to match gRPC and use its copy.

This change excludes gRPC's copy of nanopb until we get this fixed
upstream.