### PR TITLE
pod repo update is incompatible with travis_wait

### DIFF
--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -48,7 +48,6 @@ def main(args)
 
   command.push(*args)
   puts command.join(' ')
-  exec('bundle exec pod repo update')
   exec(*command)
 end
 


### PR DESCRIPTION
After #3166, The Firestore pod lib lint tests started failing with

`/Users/travis/.travis/functions: line 524:  2896 Terminated: 15          travis_jigger "${!}" "${timeout}" "${cmd[@]}"`

despite still returning a green build status.

Googling `travis_jigger` shows some inconclusive issues with travis_wait.

I don't think `pod_lib_lint.rb` needs to do `pod repo update` but if so it should be done before the script runs so that travis jobs with multiple `pod lib lint` invocations only do it once.