### PR TITLE
Rename WrapNSString to MakeNSString

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRWriteBatchTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRWriteBatchTests.mm
@@ -28,8 +28,8 @@
 #include "Firestore/core/src/firebase/firestore/util/sanitizers.h"
 #include "Firestore/core/src/firebase/firestore/util/string_apple.h"
 
+namespace util = firebase::firestore::util;
 using firebase::firestore::util::CreateAutoId;
-using firebase::firestore::util::WrapNSString;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -334,7 +334,7 @@ NS_ASSUME_NONNULL_BEGIN
   NSString *kb = [@"" stringByPaddingToLength:1000 withString:@"a" startingAtIndex:0];
   NSMutableDictionary<NSString *, id> *values = [NSMutableDictionary dictionary];
   for (int i = 0; i < 1000; i++) {
-    values[WrapNSString(CreateAutoId())] = kb;
+    values[util::MakeNSString(CreateAutoId())] = kb;
   }
 
   FIRDocumentReference *doc = [self documentRef];

--- a/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.mm
+++ b/Firestore/Example/Tests/SpecTests/FSTSyncEngineTestDriver.mm
@@ -81,7 +81,6 @@ using firebase::firestore::util::Status;
 using firebase::firestore::util::StatusOr;
 using firebase::firestore::util::StringFormat;
 using firebase::firestore::util::ToString;
-using firebase::firestore::util::WrapNSString;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -101,7 +100,7 @@ NS_ASSUME_NONNULL_BEGIN
   // The Query is also included in the view, so we skip it.
   std::string str = StringFormat("<FSTQueryEvent: viewSnapshot=%s, error=%s>",
                                  ToString(_maybeViewSnapshot), self.error);
-  return WrapNSString(str);
+  return util::MakeNSString(str);
 }
 
 @end

--- a/Firestore/Source/API/FIRCollectionReference.mm
+++ b/Firestore/Source/API/FIRCollectionReference.mm
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSString *)collectionID {
-  return util::WrapNSString(self.reference.collection_id());
+  return util::MakeNSString(self.reference.collection_id());
 }
 
 - (FIRDocumentReference *_Nullable)parent {
@@ -96,7 +96,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSString *)path {
-  return util::WrapNSString(self.reference.path());
+  return util::MakeNSString(self.reference.path());
 }
 
 - (FIRDocumentReference *)documentWithPath:(NSString *)documentPath {

--- a/Firestore/Source/API/FIRDocumentReference.mm
+++ b/Firestore/Source/API/FIRDocumentReference.mm
@@ -114,7 +114,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSString *)documentID {
-  return util::WrapNSString(_documentReference.document_id());
+  return util::MakeNSString(_documentReference.document_id());
 }
 
 - (FIRCollectionReference *)parent {
@@ -122,7 +122,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSString *)path {
-  return util::WrapNSString(_documentReference.Path());
+  return util::MakeNSString(_documentReference.Path());
 }
 
 - (FIRCollectionReference *)collectionWithPath:(NSString *)collectionPath {

--- a/Firestore/Source/API/FIRDocumentSnapshot.mm
+++ b/Firestore/Source/API/FIRDocumentSnapshot.mm
@@ -59,7 +59,6 @@ using firebase::firestore::model::FieldValueOptions;
 using firebase::firestore::model::ObjectValue;
 using firebase::firestore::model::ServerTimestampBehavior;
 using firebase::firestore::nanopb::MakeNSData;
-using firebase::firestore::util::WrapNSString;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -143,7 +142,7 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
 }
 
 - (NSString *)documentID {
-  return WrapNSString(_snapshot.document_id());
+  return util::MakeNSString(_snapshot.document_id());
 }
 
 @dynamic metadata;
@@ -215,7 +214,7 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
     case FieldValue::Type::ServerTimestamp:
       return [self convertedServerTimestamp:value options:options];
     case FieldValue::Type::String:
-      return util::WrapNSString(value.string_value());
+      return util::MakeNSString(value.string_value());
     case FieldValue::Type::Blob:
       return MakeNSData(value.blob_value());
     case FieldValue::Type::Reference:
@@ -289,7 +288,7 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
     const std::string &key = kv.first;
     const FieldValue &value = kv.second;
 
-    result[util::WrapNSString(key)] = [self convertedValue:value options:options];
+    result[util::MakeNSString(key)] = [self convertedValue:value options:options];
   }
   return result;
 }

--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -80,11 +80,11 @@ NS_ASSUME_NONNULL_BEGIN
     ThrowIllegalState("Failed to get FirebaseApp instance. Please call FirebaseApp.configure() "
                       "before using Firestore");
   }
-  return [self firestoreForApp:app database:util::WrapNSString(DatabaseId::kDefault)];
+  return [self firestoreForApp:app database:util::MakeNSString(DatabaseId::kDefault)];
 }
 
 + (instancetype)firestoreForApp:(FIRApp *)app {
-  return [self firestoreForApp:app database:util::WrapNSString(DatabaseId::kDefault)];
+  return [self firestoreForApp:app database:util::MakeNSString(DatabaseId::kDefault)];
 }
 
 // TODO(b/62410906): make this public

--- a/Firestore/Source/Remote/FSTSerializerBeta.mm
+++ b/Firestore/Source/Remote/FSTSerializerBeta.mm
@@ -159,7 +159,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)encodedResourcePathForDatabaseID:(const DatabaseId &)databaseID
                                           path:(const ResourcePath &)path {
-  return util::WrapNSString([self encodedResourcePathForDatabaseID:databaseID]
+  return util::MakeNSString([self encodedResourcePathForDatabaseID:databaseID]
                                 .Append("documents")
                                 .Append(path)
                                 .CanonicalString());
@@ -203,7 +203,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSString *)encodedDatabaseID {
-  return util::WrapNSString([self encodedResourcePathForDatabaseID:_databaseID].CanonicalString());
+  return util::MakeNSString([self encodedResourcePathForDatabaseID:_databaseID].CanonicalString());
 }
 
 #pragma mark - FieldValue <=> Value proto
@@ -315,7 +315,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (GCFSValue *)encodedString:(absl::string_view)value {
   GCFSValue *result = [GCFSValue message];
-  result.stringValue = util::WrapNSString(value);
+  result.stringValue = util::MakeNSString(value);
   return result;
 }
 
@@ -404,7 +404,7 @@ NS_ASSUME_NONNULL_BEGIN
   NSMutableDictionary<NSString *, GCFSValue *> *result = [NSMutableDictionary dictionary];
 
   for (const auto &kv : value) {
-    NSString *key = util::WrapNSString(kv.first);
+    NSString *key = util::MakeNSString(kv.first);
     GCFSValue *converted = [self encodedFieldValue:kv.second];
     result[key] = converted;
   }
@@ -579,7 +579,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (GCFSDocumentMask *)encodedFieldMask:(const FieldMask &)fieldMask {
   GCFSDocumentMask *mask = [GCFSDocumentMask message];
   for (const FieldPath &field : fieldMask) {
-    [mask.fieldPathsArray addObject:util::WrapNSString(field.CanonicalString())];
+    [mask.fieldPathsArray addObject:util::MakeNSString(field.CanonicalString())];
   }
   return mask;
 }
@@ -605,7 +605,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (GCFSDocumentTransform_FieldTransform *)encodedFieldTransform:
     (const FieldTransform &)fieldTransform {
   GCFSDocumentTransform_FieldTransform *proto = [GCFSDocumentTransform_FieldTransform message];
-  proto.fieldPath = util::WrapNSString(fieldTransform.path().CanonicalString());
+  proto.fieldPath = util::MakeNSString(fieldTransform.path().CanonicalString());
   if (fieldTransform.transformation().type() == TransformOperation::Type::ServerTimestamp) {
     proto.setToServerValue = GCFSDocumentTransform_FieldTransform_ServerValue_RequestTime;
 
@@ -793,7 +793,7 @@ NS_ASSUME_NONNULL_BEGIN
     HARD_ASSERT(path.size() % 2 != 0, "Document queries with filters are not supported.");
     queryTarget.parent = [self encodedQueryPath:path.PopLast()];
     GCFSStructuredQuery_CollectionSelector *from = [GCFSStructuredQuery_CollectionSelector message];
-    from.collectionId = util::WrapNSString(path.last_segment());
+    from.collectionId = util::MakeNSString(path.last_segment());
     [queryTarget.structuredQuery.fromArray addObject:from];
   }
 
@@ -982,7 +982,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (GCFSStructuredQuery_FieldReference *)encodedFieldPath:(const FieldPath &)fieldPath {
   GCFSStructuredQuery_FieldReference *ref = [GCFSStructuredQuery_FieldReference message];
-  ref.fieldPath = util::WrapNSString(fieldPath.CanonicalString());
+  ref.fieldPath = util::MakeNSString(fieldPath.CanonicalString());
   return ref;
 }
 

--- a/Firestore/core/src/firebase/firestore/api/input_validation_apple.mm
+++ b/Firestore/core/src/firebase/firestore/api/input_validation_apple.mm
@@ -29,7 +29,7 @@ namespace impl {
 
 static NSException* MakeException(NSString* name, const std::string& message) {
   return [[NSException alloc] initWithName:name
-                                    reason:util::WrapNSString(message)
+                                    reason:util::MakeNSString(message)
                                   userInfo:nil];
 }
 

--- a/Firestore/core/src/firebase/firestore/objc/objc_compatibility.h
+++ b/Firestore/core/src/firebase/firestore/objc/objc_compatibility.h
@@ -114,7 +114,7 @@ using unordered_map = std::unordered_map<K, V, Hash<K>, EqualTo<K>>;
  */
 template <typename T>
 NSString* Description(const T& value) {
-  return util::WrapNSString(util::ToString(value));
+  return util::MakeNSString(util::ToString(value));
 }
 
 }  // namespace objc

--- a/Firestore/core/src/firebase/firestore/util/error_apple.mm
+++ b/Firestore/core/src/firebase/firestore/util/error_apple.mm
@@ -39,7 +39,7 @@ NSError* MakeNSError(const int64_t error_code,
 
   NSMutableDictionary<NSString*, id>* user_info =
       [NSMutableDictionary dictionary];
-  user_info[NSLocalizedDescriptionKey] = WrapNSString(error_msg);
+  user_info[NSLocalizedDescriptionKey] = MakeNSString(error_msg);
   if (cause) {
     user_info[NSUnderlyingErrorKey] = cause;
   }

--- a/Firestore/core/src/firebase/firestore/util/hard_assert_apple.mm
+++ b/Firestore/core/src/firebase/firestore/util/hard_assert_apple.mm
@@ -32,8 +32,8 @@ void Fail(const char* file,
           const int line,
           const std::string& message) {
   [[NSAssertionHandler currentHandler]
-      handleFailureInFunction:WrapNSString(func)
-                         file:WrapNSString(file)
+      handleFailureInFunction:MakeNSString(func)
+                         file:MakeNSString(file)
                    lineNumber:line
                   description:@"FIRESTORE INTERNAL ASSERTION FAILED: %s",
                               message.c_str()];

--- a/Firestore/core/src/firebase/firestore/util/path.h
+++ b/Firestore/core/src/firebase/firestore/util/path.h
@@ -95,7 +95,7 @@ class Path {
 
 #if defined(__OBJC__)
   NSString* ToNSString() const {
-    return WrapNSString(native_value());
+    return MakeNSString(native_value());
   }
 #endif
 

--- a/Firestore/core/src/firebase/firestore/util/string_apple.h
+++ b/Firestore/core/src/firebase/firestore/util/string_apple.h
@@ -46,7 +46,7 @@ inline CFStringRef MakeCFString(absl::string_view contents) {
 #if defined(__OBJC__)
 
 // Translates a C string to the equivalent NSString without making a copy.
-inline NSString* WrapNSStringNoCopy(const char* c_str, size_t size) {
+inline NSString* MakeNSStringNoCopy(const char* c_str, size_t size) {
   return [[NSString alloc]
       initWithBytesNoCopy:const_cast<void*>(static_cast<const void*>(c_str))
                    length:size
@@ -55,12 +55,12 @@ inline NSString* WrapNSStringNoCopy(const char* c_str, size_t size) {
 }
 
 // Translates a string_view to the equivalent NSString without making a copy.
-inline NSString* WrapNSStringNoCopy(const absl::string_view str) {
-  return WrapNSStringNoCopy(str.data(), str.size());
+inline NSString* MakeNSStringNoCopy(const absl::string_view str) {
+  return MakeNSStringNoCopy(str.data(), str.size());
 }
 
 // Translates a string_view string to the equivalent NSString by making a copy.
-inline NSString* WrapNSString(const absl::string_view str) {
+inline NSString* MakeNSString(const absl::string_view str) {
   return [[NSString alloc]
       initWithBytes:const_cast<void*>(static_cast<const void*>(str.data()))
              length:str.length()

--- a/Firestore/core/test/firebase/firestore/remote/datastore_test.mm
+++ b/Firestore/core/test/firebase/firestore/remote/datastore_test.mm
@@ -26,6 +26,7 @@
 #include "Firestore/core/test/firebase/firestore/util/fake_credentials_provider.h"
 #include "Firestore/core/test/firebase/firestore/util/grpc_stream_tester.h"
 #include "absl/memory/memory.h"
+#include "absl/strings/str_cat.h"
 #include "gtest/gtest.h"
 
 #import "Firestore/Protos/objc/google/firestore/v1/Document.pbobjc.h"
@@ -44,7 +45,6 @@ using util::CompletionEndState;
 using util::GrpcStreamTester;
 using util::FakeCredentialsProvider;
 using util::FakeGrpcQueue;
-using util::WrapNSString;
 using util::ExecutorLibdispatch;
 using util::CompletionResult::Error;
 using util::CompletionResult::Ok;
@@ -61,8 +61,8 @@ grpc::ByteBuffer MakeByteBuffer(NSData* data) {
 
 grpc::ByteBuffer MakeFakeDocument(const std::string& doc_name) {
   GCFSDocument* doc = [GCFSDocument message];
-  doc.name =
-      WrapNSString(std::string{"projects/p/databases/d/documents/"} + doc_name);
+  doc.name = util::MakeNSString(
+      absl::StrCat("projects/p/databases/d/documents/", doc_name));
   GCFSValue* value = [GCFSValue message];
   value.stringValue = @"bar";
   [doc.fields addEntriesFromDictionary:@{

--- a/Firestore/core/test/firebase/firestore/testutil/app_testing.mm
+++ b/Firestore/core/test/firebase/firestore/testutil/app_testing.mm
@@ -28,7 +28,7 @@ FIROptions* OptionsForUnitTesting(const absl::string_view project_id) {
   FIROptions* options =
       [[FIROptions alloc] initWithGoogleAppID:@"1:123:ios:123ab"
                                   GCMSenderID:@"gcm_sender_id"];
-  options.projectID = util::WrapNSString(project_id);
+  options.projectID = util::MakeNSString(project_id);
   return options;
 }
 

--- a/Firestore/core/test/firebase/firestore/util/string_apple_test.mm
+++ b/Firestore/core/test/firebase/firestore/util/string_apple_test.mm
@@ -58,7 +58,7 @@ TEST_F(StringAppleTest, MakeStringFromCFStringRef) {
 
 TEST_F(StringAppleTest, MakeStringFromNSString) {
   for (const std::string& string_value : StringTestCases()) {
-    NSString* ns_string = WrapNSString(string_value);
+    NSString* ns_string = MakeNSString(string_value);
     std::string actual = MakeString(ns_string);
     EXPECT_EQ(string_value, actual);
   }
@@ -66,7 +66,7 @@ TEST_F(StringAppleTest, MakeStringFromNSString) {
 
 TEST_F(StringAppleTest, MakeStringFromNSStringNoCopy) {
   for (const std::string& string_value : StringTestCases()) {
-    NSString* ns_string = WrapNSStringNoCopy(string_value);
+    NSString* ns_string = MakeNSStringNoCopy(string_value);
     std::string actual = MakeString(ns_string);
     EXPECT_EQ(string_value, actual);
   }


### PR DESCRIPTION
This makes it match the convention we've established for other
converters of this type. `WrapNSString` was perhaps the earliest of these
that we wrote and the convention hadn't yet been established.

Other examples:
https://github.com/firebase/firebase-ios-sdk/blob/master/Firestore/Source/API/converters.h

https://github.com/firebase/firebase-ios-sdk/blob/master/Firestore/core/src/firebase/firestore/local/leveldb_util.h