### PR TITLE
Unavailable init methods should not be nullable

### DIFF
--- a/Firebase/Auth/Source/Backend/FIRAuthRequestConfiguration.h
+++ b/Firebase/Auth/Source/Backend/FIRAuthRequestConfiguration.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property(nonatomic, copy, nullable) NSString *additionalFrameworkMarker;
 
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 /** @fn initWithRequestClass:APIKey:authLanguage:
     @brief Designated initializer.

--- a/Firebase/Storage/Public/FIRStorageListResult.h
+++ b/Firebase/Storage/Public/FIRStorageListResult.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(StorageListResult)
 @interface FIRStorageListResult : NSObject <NSCopying>
 
-- (nullable instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 /**
  * The prefixes (folders) returned by the `list()` operation.


### PR DESCRIPTION
It can cause build warnings in Swift code.

From  https://developer.apple.com/documentation/objectivec/nsobject/1418641-init

> In terms of nullability, callers can assume that the NSObject implementation of init() does not return nil.