### PR TITLE
Import GULLoggerLevel.h via public framework header

### DIFF
--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -17,7 +17,7 @@
 #include <asl.h>
 
 #import <GoogleUtilities/GULAppEnvironmentUtil.h>
-#import "Public/GULLoggerLevel.h"
+#import <GoogleUtilities/GULLoggerLevel.h>
 
 /// ASL client facility name used by GULLogger.
 const char *kGULLoggerASLClientFacilityName = "com.google.utilities.logger";

--- a/GoogleUtilities/Logger/Public/GULLoggerLevel.h
+++ b/GoogleUtilities/Logger/Public/GULLoggerLevel.h
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-#ifndef GUL_LOGGER_LEVEL_H
-#define GUL_LOGGER_LEVEL_H
-
 /**
  * The log levels used by internal logging.
  */
@@ -36,5 +33,3 @@ typedef NS_ENUM(NSInteger, GULLoggerLevel) {
   /** Maximum log level. */
   GULLoggerLevelMax = GULLoggerLevelDebug
 } NS_SWIFT_NAME(GoogleLoggerLevel);
-
-#endif /* GUL_LOGGER_LEVEL_H */

--- a/GoogleUtilities/Logger/Public/GULLoggerLevel.h
+++ b/GoogleUtilities/Logger/Public/GULLoggerLevel.h
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#ifndef GUL_LOGGER_LEVEL_H
+#define GUL_LOGGER_LEVEL_H
+
 /**
  * The log levels used by internal logging.
  */
@@ -33,3 +36,5 @@ typedef NS_ENUM(NSInteger, GULLoggerLevel) {
   /** Maximum log level. */
   GULLoggerLevelMax = GULLoggerLevelDebug
 } NS_SWIFT_NAME(GoogleLoggerLevel);
+
+#endif /* GUL_LOGGER_LEVEL_H */


### PR DESCRIPTION
ifndef guard the GULLoggerLevel enum.

Quite often, usually on every first compile step, I run into these kind of errors:
```
In file included from /Users/ened/git/com.company.app/ios/Pods/GoogleUtilities/GoogleUtilities/Logger/GULLogger.m:20:
/Users/ened/git/com.company.app/ios/Pods/GoogleUtilities/GoogleUtilities/Logger/Public/GULLoggerLevel.h:20:28: error: redefinition of 'GULLoggerLevel'
typedef NS_ENUM(NSInteger, GULLoggerLevel) {
                           ^
In file included from /Users/ened/git/com.company.app/ios/Pods/GoogleUtilities/GoogleUtilities/Logger/GULLogger.m:15:
In file included from /Users/ened/git/com.company.app/ios/Pods/GoogleUtilities/GoogleUtilities/Logger/Private/GULLogger.h:19:
/Users/ened/git/com.company.app/build/ios/Profile-iphoneos/GoogleUtilities/GoogleUtilities.framework/Headers/GULLoggerLevel.h:20:28: note: previous definition is here
typedef NS_ENUM(NSInteger, GULLoggerLevel) {
                           ^
In file included from /Users/ened/git/com.company.app/ios/Pods/GoogleUtilities/GoogleUtilities/Logger/GULLogger.m:20:
/Users/ened/git/com.company.app/ios/Pods/GoogleUtilities/GoogleUtilities/Logger/Public/GULLoggerLevel.h:22:3: error: redefinition of enumerator 'GULLoggerLevelError'
  GULLoggerLevelError = 3,
  ^
In file included from /Users/ened/git/com.company.app/ios/Pods/GoogleUtilities/GoogleUtilities/Logger/GULLogger.m:15:
In file included from /Users/ened/git/com.company.app/ios/Pods/GoogleUtilities/GoogleUtilities/Logger/Private/GULLogger.h:19:
/Users/ened/git/com.company.app/build/ios/Profile-iphoneos/GoogleUtilities/GoogleUtilities.framework/Headers/GULLoggerLevel.h:22:3: note: previous definition is here
  GULLoggerLevelError = 3,
```

Therefore, I believe a `#ifndef` check, just like it's done on other public SDK headers, may help.
