### PR TITLE
Put the need to include Firestore/Source/Public in the podspec

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -75,6 +75,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
       'PB_FIELD_32BIT=1 PB_NO_PACKED_STRUCTS=1 PB_ENABLE_MALLOC=1',
     'HEADER_SEARCH_PATHS' =>
       '"${PODS_TARGET_SRCROOT}" ' +
+      '"${PODS_TARGET_SRCROOT}/Firestore/Source/Public" ' +
       '"${PODS_TARGET_SRCROOT}/Firestore/third_party/abseil-cpp" ' +
       '"${PODS_ROOT}/nanopb" ' +
       '"${PODS_TARGET_SRCROOT}/Firestore/Protos/nanopb"',

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -6,35 +6,6 @@ source 'https://cdn.cocoapods.org/'
 
 use_frameworks!
 
-
-# Appends the given +paths+ to the HEADER_SEARCH_PATHS setting for the given
-# target in all build configurations.
-def append_header_search_path(target, *paths)
-  setting = 'HEADER_SEARCH_PATHS'
-  target.build_configurations.each do |config|
-    config.build_settings[setting] ||= '$(inherited)'
-    paths.each do |path|
-      config.build_settings[setting] << ' '
-      config.build_settings[setting] << path
-    end
-  end
-end
-
-
-post_install do |installer|
-  installer.pods_project.targets.each do |target|
-    # Building the FirebaseFirestore framework proper seems fragile in Xcode:
-    # changes to public headers seem to cause weird cascading failures in the
-    # IDE's pre-build error detection. The issue seems to be that the Pod's
-    # public headers are found by clang at build time through a copy headers
-    # phase, but the interactive editor won't have those in place, especially
-    # when the build is broken by current edits.
-    if target.name =~ /^FirebaseFirestore/
-      append_header_search_path(target, '$(PODS_ROOT)/../../../Firestore/Source/Public')
-    end
-  end
-end
-
 target 'Firestore_Example_iOS' do
   platform :ios, '8.0'
 


### PR DESCRIPTION
This removes the need to munge the pods project after the fact and makes
it so that customers can click through to our headers too.