### PR TITLE
Store the coerced base value in the BaseMutation

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+- [fixed] Fixed an internal assertion that was triggered when an update
+   with a `FieldValue.serverTimestamp()` and an update with a
+  `FieldValue.increment()` were pending for the same document.
 
 # 1.4.1
 - [fixed] Fixed certificate loading for non-CocoaPods builds that may not

--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -62,7 +62,6 @@
 		12158DFCEE09D24B7988A340 /* maybe_document.pb.cc in Sources */ = {isa = PBXBuildFile; fileRef = 618BBE7E20B89AAC00B5BCE7 /* maybe_document.pb.cc */; };
 		1235769322B7E99F007DDFA9 /* EncodableFieldValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1235769122B7E915007DDFA9 /* EncodableFieldValueTests.swift */; };
 		1235769522B86E65007DDFA9 /* FirestoreEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1235769422B86E65007DDFA9 /* FirestoreEncoderTests.swift */; };
-		124C933122C16ACB00CA8C2D /* CodableIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 124C932B22C1642C00CA8C2D /* CodableIntegrationTests.swift */; };
 		127CC0D222B3ADDC00A3E42A /* CodableTimestampTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B65C996438B84DBC7616640 /* CodableTimestampTests.swift */; };
 		1291D9F5300AFACD1FBD262D /* array_sorted_map_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54EB764C202277B30088B8F3 /* array_sorted_map_test.cc */; };
 		12BB9ED1CA98AA52B92F497B /* log_test.cc in Sources */ = {isa = PBXBuildFile; fileRef = 54C2294E1FECABAE007D065B /* log_test.cc */; };
@@ -1412,9 +1411,9 @@
 		54C9EDF22040E16300A969CD /* SwiftTests */ = {
 			isa = PBXGroup;
 			children = (
-				124C932A22C1635300CA8C2D /* Integration */,
 				544A20ED20F6C046004E52CD /* API */,
 				5495EB012040E90200EBA509 /* Codable */,
+				124C932A22C1635300CA8C2D /* Integration */,
 				620C1427763BA5D3CCFB5A1F /* BridgingHeader.h */,
 				54C9EDF52040E16300A969CD /* Info.plist */,
 			);
@@ -3652,7 +3651,6 @@
 				D5B252EE3F4037405DB1ECE3 /* FIRNumericTransformTests.mm in Sources */,
 				5492E072202154D600B64F25 /* FIRQueryTests.mm in Sources */,
 				5492E077202154D600B64F25 /* FIRServerTimestampTests.mm in Sources */,
-				124C933122C16ACB00CA8C2D /* CodableIntegrationTests.swift in Sources */,
 				5492E07A202154D600B64F25 /* FIRTypeTests.mm in Sources */,
 				5492E076202154D600B64F25 /* FIRValidationTests.mm in Sources */,
 				5492E078202154D600B64F25 /* FIRWriteBatchTests.mm in Sources */,

--- a/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_Tests_macOS.xcscheme
+++ b/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_Tests_macOS.xcscheme
@@ -5,6 +5,18 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForRunning = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DAFF0CF421E64AC30062958F"
+               BuildableName = "Firestore_Example_macOS.app"
+               BlueprintName = "Firestore_Example_macOS"
+               ReferencedContainer = "container:Firestore.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"

--- a/Firestore/Example/Tests/Integration/API/FIRServerTimestampTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRServerTimestampTests.mm
@@ -171,6 +171,12 @@
 }
 
 - (void)testServerTimestampsWithPreviousValue {
+  // The following update includes an update of the nested map "deep", which updates it to contain
+  // a single ServerTimestamp. As such, the update is split into two mutations: One that sets
+  // "deep" to an empty map and overwrites the previous ServerTimestamp value and a second
+  // transform that writes the new ServerTimestamp. This step in the test verifies that we can
+  // still access the old ServerTimestamp value (from `previousSnapshot`) even though it was
+  // removed in an intermediate step.
   [self writeDocumentRef:_docRef data:_setData];
   [self verifyTimestampsInSnapshot:[_accumulator awaitLocalEvent] fromPreviousSnapshot:nil];
   FIRDocumentSnapshot *remoteSnapshot = [_accumulator awaitRemoteEvent];

--- a/Firestore/Example/Tests/Integration/API/FIRServerTimestampTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRServerTimestampTests.mm
@@ -171,12 +171,12 @@
 }
 
 - (void)testServerTimestampsWithPreviousValue {
-  // The following update includes an update of the nested map "deep", which updates it to contain
-  // a single ServerTimestamp. As such, the update is split into two mutations: One that sets
-  // "deep" to an empty map and overwrites the previous ServerTimestamp value and a second
-  // transform that writes the new ServerTimestamp. This step in the test verifies that we can
-  // still access the old ServerTimestamp value (from `previousSnapshot`) even though it was
-  // removed in an intermediate step.
+  // The following test includes an update of the nested map "deep", which updates it to contain
+  // a single ServerTimestamp. This update is split into two mutations: One that sets "deep" to
+  // an empty map and overwrites the previous ServerTimestamp value and a second transform that
+  // writes the new ServerTimestamp. This step in the test verifies that we can still access the
+  // old ServerTimestamp value (from `previousSnapshot`) even though it was removed in an
+  // intermediate step.
   [self writeDocumentRef:_docRef data:_setData];
   [self verifyTimestampsInSnapshot:[_accumulator awaitLocalEvent] fromPreviousSnapshot:nil];
   FIRDocumentSnapshot *remoteSnapshot = [_accumulator awaitRemoteEvent];

--- a/Firestore/Example/Tests/Model/transform_operations_test.mm
+++ b/Firestore/Example/Tests/Model/transform_operations_test.mm
@@ -42,8 +42,9 @@ class DummyOperation : public TransformOperation {
     return FieldValue::Null();
   }
 
-  bool idempotent() const override {
-    return true;
+  absl::optional<model::FieldValue> ComputeBaseValue(
+      const absl::optional<model::FieldValue>& previous_value) const override {
+    return absl::nullopt;
   }
 
   bool operator==(const TransformOperation& other) const override {

--- a/Firestore/Source/Model/FSTMutation.h
+++ b/Firestore/Source/Model/FSTMutation.h
@@ -154,19 +154,25 @@ NS_ASSUME_NONNULL_BEGIN
                                        baseDocument:(nullable FSTMaybeDocument *)baseDoc
                                      localWriteTime:(const firebase::Timestamp &)localWriteTime;
 
+/**
+ * If this mutation is not idempotent, returns the base value to persist with this mutation.
+ * If a base value is returned, the mutation is always applied to this base value, even if
+ * document has already been updated.
+ *
+ * The base value is a sparse object that consists of only the document fields for which this
+ * mutation contains a non-idempotent transformation (e.g. a numeric increment). The provided
+ * value guarantees consistent behavior for non-idempotent transforms and allow us to return the
+ * same latency-compensated value even if the backend has already applied the mutation. The base
+ * value is empty for idempotent mutations, as they can be re-played even if the backend has
+ * already applied them.
+ *
+ * @return a base value to store along with the mutation, or empty for idempotent mutations.
+ */
+- (absl::optional<model::ObjectValue>)extractBaseValue:(nullable FSTMaybeDocument *)maybeDoc;
+
 - (const model::DocumentKey &)key;
 
 - (const model::Precondition &)precondition;
-
-/**
- * If applicable, returns the field mask for this mutation. Fields that are not included in this
- * field mask are not modified when this mutation is applied. Mutations that replace all document
- * values return 'nullptr'.
- */
-- (nullable const model::FieldMask *)fieldMask;
-
-/** Returns whether all operations in the mutation are idempotent. */
-@property(nonatomic, readonly) BOOL idempotent;
 
 @end
 

--- a/Firestore/core/src/firebase/firestore/model/field_mask.cc
+++ b/Firestore/core/src/firebase/firestore/model/field_mask.cc
@@ -33,21 +33,6 @@ bool FieldMask::covers(const FieldPath& fieldPath) const {
   return false;
 }
 
-ObjectValue FieldMask::ApplyTo(const ObjectValue& data) const {
-  ObjectValue filtered = ObjectValue::Empty();
-  for (const FieldPath& path : fields_) {
-    if (path.empty()) {
-      return data;
-    } else {
-      absl::optional<FieldValue> new_value = data.Get(path);
-      if (new_value) {
-        filtered = filtered.Set(path, *new_value);
-      }
-    }
-  }
-  return filtered;
-}
-
 std::string FieldMask::ToString() const {
   // Ideally, one should use a string builder. Since this is only non-critical
   // code for logging and debugging, the logic is kept simple here.

--- a/Firestore/core/src/firebase/firestore/model/field_mask.h
+++ b/Firestore/core/src/firebase/firestore/model/field_mask.h
@@ -74,13 +74,6 @@ class FieldMask {
    */
   bool covers(const FieldPath& fieldPath) const;
 
-  /**
-   * Applies this field mask to the provided object value and returns an object
-   * that only contains fields that are specified in both the input object and
-   * this field mask.
-   */
-  ObjectValue ApplyTo(const ObjectValue& data) const;
-
   std::string ToString() const;
 
 #if defined(__OBJC__)

--- a/Firestore/core/src/firebase/firestore/model/field_transform.h
+++ b/Firestore/core/src/firebase/firestore/model/field_transform.h
@@ -44,10 +44,6 @@ class FieldTransform {
     return *transformation_.get();
   }
 
-  bool idempotent() const {
-    return transformation_->idempotent();
-  }
-
   bool operator==(const FieldTransform& other) const {
     return path_ == other.path_ && *transformation_ == *other.transformation_;
   }

--- a/Firestore/core/src/firebase/firestore/model/field_value.cc
+++ b/Firestore/core/src/firebase/firestore/model/field_value.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "Firestore/core/src/firebase/firestore/immutable/sorted_map.h"
+#include "Firestore/core/src/firebase/firestore/model/field_mask.h"
 #include "Firestore/core/src/firebase/firestore/timestamp_internal.h"
 #include "Firestore/core/src/firebase/firestore/util/comparison.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
@@ -645,6 +646,34 @@ absl::optional<FieldValue> ObjectValue::Get(const FieldPath& field_path) const {
     }
   }
   return *current;
+}
+
+FieldMask ObjectValue::ToFieldMask() const {
+  std::set<FieldPath> fields;
+
+  for (FieldValue::Map::const_iterator iter = fv_.object_value().begin();
+       iter != fv_.object_value().end(); ++iter) {
+    FieldPath current_path{iter->first};
+    FieldValue value = iter->second;
+
+    if (value.type() == Type::Object) {
+      ObjectValue nested_map{value};
+      FieldMask nested_mask = nested_map.ToFieldMask();
+      if (nested_mask.size() == 0) {
+        // Preserve the empty map by adding it to the FieldMask.
+        fields.insert(current_path);
+      } else {
+        // For nested and non-empty ObjectValues, add the FieldPath of the leaf
+        // nodes.
+        for (const FieldPath& nested_path : nested_mask) {
+          fields.insert(current_path.Append(nested_path));
+        }
+      }
+    } else {
+      fields.insert(current_path);
+    }
+  }
+  return FieldMask(fields);
 }
 
 ObjectValue ObjectValue::SetChild(const std::string& child_name,

--- a/Firestore/core/src/firebase/firestore/model/field_value.cc
+++ b/Firestore/core/src/firebase/firestore/model/field_value.cc
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <memory>
 #include <new>
+#include <set>
 #include <utility>
 #include <vector>
 

--- a/Firestore/core/src/firebase/firestore/model/field_value.h
+++ b/Firestore/core/src/firebase/firestore/model/field_value.h
@@ -30,6 +30,7 @@
 #include "Firestore/core/src/firebase/firestore/immutable/sorted_map.h"
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
+#include "Firestore/core/src/firebase/firestore/model/field_mask.h"
 #include "Firestore/core/src/firebase/firestore/model/field_path.h"
 #include "Firestore/core/src/firebase/firestore/model/field_value.h"
 #include "Firestore/core/src/firebase/firestore/nanopb/byte_string.h"
@@ -265,6 +266,12 @@ class ObjectValue : public util::Comparable<ObjectValue> {
    * @return A new FieldValue with the field path removed.
    */
   ObjectValue Delete(const FieldPath& field_path) const;
+
+  /**
+   * Returns a FieldMask built from all FieldPaths starting from this
+   * ObjectValue, including paths from nested objects.
+   */
+  FieldMask ToFieldMask() const;
 
   // TODO(rsgowman): Add Value() method?
   //

--- a/Firestore/core/src/firebase/firestore/model/transform_operations.h
+++ b/Firestore/core/src/firebase/firestore/model/transform_operations.h
@@ -113,7 +113,8 @@ class ServerTimestampTransform : public TransformOperation {
       const model::FieldValue& transform_result) const override;
 
   absl::optional<model::FieldValue> ComputeBaseValue(
-      const absl::optional<model::FieldValue>& /* previous_value */) const override {
+      const absl::optional<model::FieldValue>& /* previous_value */)
+      const override {
     return absl::nullopt;  // Server timestamps are idempotent and don't require
                            // a base value.
   }
@@ -153,7 +154,8 @@ class ArrayTransform : public TransformOperation {
       const model::FieldValue& transform_result) const override;
 
   absl::optional<model::FieldValue> ComputeBaseValue(
-      const absl::optional<model::FieldValue>& /* previous_value */) const override {
+      const absl::optional<model::FieldValue>& /* previous_value */)
+      const override {
     return absl::nullopt;  // Array transforms are idempotent and don't require
                            // a base value.
   }

--- a/Firestore/core/src/firebase/firestore/model/transform_operations.h
+++ b/Firestore/core/src/firebase/firestore/model/transform_operations.h
@@ -66,8 +66,23 @@ class TransformOperation {
       const absl::optional<model::FieldValue>& previous_value,
       const model::FieldValue& transform_result) const = 0;
 
-  /** Returns whether this field transform is idempotent. */
-  virtual bool idempotent() const = 0;
+  /**
+   * If this transform operation is not idempotent, returns the base value to
+   * persist for this transform operation. If a base value is returned, the
+   * transform operation is always applied to this base value, even if document
+   * has already been updated.
+   *
+   * <p>Base values provide consistent behavior for non-idempotent transforms
+   * and allow us to return the same latency-compensated value even if the
+   * backend has already applied the transform operation. The base value is
+   * empty for idempotent transforms, as they can be re-played even if the
+   * backend has already applied them.
+   *
+   * @return a base value to store along with the mutation, or empty for
+   * idempotent transforms.
+   */
+  virtual absl::optional<model::FieldValue> ComputeBaseValue(
+      const absl::optional<model::FieldValue>& previous_value) const = 0;
 
   /** Returns whether the two are equal. */
   virtual bool operator==(const TransformOperation& other) const = 0;
@@ -89,10 +104,6 @@ class ServerTimestampTransform : public TransformOperation {
     return Type::ServerTimestamp;
   }
 
-  bool idempotent() const override {
-    return true;
-  }
-
   model::FieldValue ApplyToLocalView(
       const absl::optional<model::FieldValue>& previous_value,
       const Timestamp& local_write_time) const override;
@@ -100,6 +111,12 @@ class ServerTimestampTransform : public TransformOperation {
   model::FieldValue ApplyToRemoteDocument(
       const absl::optional<model::FieldValue>& previous_value,
       const model::FieldValue& transform_result) const override;
+
+  absl::optional<model::FieldValue> ComputeBaseValue(
+      const absl::optional<model::FieldValue>& previous_value) const override {
+    return absl::nullopt;  // Server timestamps are idempotent and don't require
+                           // a base value.
+  }
 
   bool operator==(const TransformOperation& other) const override;
 
@@ -135,12 +152,14 @@ class ArrayTransform : public TransformOperation {
       const absl::optional<model::FieldValue>& previous_value,
       const model::FieldValue& transform_result) const override;
 
-  const std::vector<model::FieldValue>& elements() const {
-    return elements_;
+  absl::optional<model::FieldValue> ComputeBaseValue(
+      const absl::optional<model::FieldValue>& previous_value) const override {
+    return absl::nullopt;  // Array transforms are idempotent and don't require
+                           // a base value.
   }
 
-  bool idempotent() const override {
-    return true;
+  const std::vector<model::FieldValue>& elements() const {
+    return elements_;
   }
 
   bool operator==(const TransformOperation& other) const override;
@@ -187,12 +206,11 @@ class NumericIncrementTransform : public TransformOperation {
       const absl::optional<model::FieldValue>& previous_value,
       const model::FieldValue& transform_result) const override;
 
+  absl::optional<model::FieldValue> ComputeBaseValue(
+      const absl::optional<model::FieldValue>& previous_value) const override;
+
   model::FieldValue operand() const {
     return operand_;
-  }
-
-  bool idempotent() const override {
-    return false;
   }
 
   bool operator==(const TransformOperation& other) const override;

--- a/Firestore/core/src/firebase/firestore/model/transform_operations.h
+++ b/Firestore/core/src/firebase/firestore/model/transform_operations.h
@@ -113,7 +113,7 @@ class ServerTimestampTransform : public TransformOperation {
       const model::FieldValue& transform_result) const override;
 
   absl::optional<model::FieldValue> ComputeBaseValue(
-      const absl::optional<model::FieldValue>& previous_value) const override {
+      const absl::optional<model::FieldValue>& /* previous_value */) const override {
     return absl::nullopt;  // Server timestamps are idempotent and don't require
                            // a base value.
   }
@@ -153,7 +153,7 @@ class ArrayTransform : public TransformOperation {
       const model::FieldValue& transform_result) const override;
 
   absl::optional<model::FieldValue> ComputeBaseValue(
-      const absl::optional<model::FieldValue>& previous_value) const override {
+      const absl::optional<model::FieldValue>& /* previous_value */) const override {
     return absl::nullopt;  // Array transforms are idempotent and don't require
                            // a base value.
   }

--- a/Firestore/core/test/firebase/firestore/model/field_value_test.cc
+++ b/Firestore/core/test/firebase/firestore/model/field_value_test.cc
@@ -87,6 +87,20 @@ TEST(FieldValueTest, ExtractsFields) {
   EXPECT_EQ(nullopt, value.Get(Field("bar.a")));
 }
 
+TEST(FieldValueTest, ExtractsFieldMask) {
+  ObjectValue value =
+      WrapObject("a", "b", "map",
+                 Map("a", 1, "b", true, "c", "string", "nested", Map("d", "e")),
+                 "emptymap", Map());
+
+  FieldMask expectedMask =
+      FieldMask({Field("a"), Field("map.a"), Field("map.b"), Field("map.c"),
+                 Field("map.nested.d"), Field("emptymap")});
+  FieldMask actualMask = value.ToFieldMask();
+
+  EXPECT_EQ(expectedMask, actualMask);
+}
+
 TEST(FieldValueTest, OverwritesExistingFields) {
   ObjectValue old = WrapObject("a", "old");
   ObjectValue mod = old.Set(Field("a"), Value("mod"));


### PR DESCRIPTION
Port of https://github.com/firebase/firebase-android-sdk#564 and https://github.com/firebase/firebase-js-sdk/pull/1928

The PR changes what we store in a BaseMutation. With the changes here, every transform operation computes what it needs to store in the BaseMutation. For Numeric increment, this is either an existing numeric value or the IntegerValue.of(0), replacing all invalid base values at time of creation.