### PR TITLE
FIROptions.appGroupID introduced

### DIFF
--- a/Example/Core/Tests/FIROptionsTest.m
+++ b/Example/Core/Tests/FIROptionsTest.m
@@ -197,6 +197,11 @@ extern NSString *const kFIRLibraryVersionID;
   options.storageBucket = mutableString;
   [mutableString appendString:@"2"];
   XCTAssertEqualObjects(options.storageBucket, @"1");
+
+  mutableString = [[NSMutableString alloc] initWithString:@"1"];
+  options.appGroupID = mutableString;
+  [mutableString appendString:@"2"];
+  XCTAssertEqualObjects(options.appGroupID, @"1");
 }
 
 - (void)testCopyWithZone {

--- a/Firebase/Core/FIROptions.m
+++ b/Firebase/Core/FIROptions.m
@@ -179,6 +179,7 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
   if (newOptions) {
     newOptions.optionsDictionary = self.optionsDictionary;
     newOptions.deepLinkURLScheme = self.deepLinkURLScheme;
+    newOptions.appGroupID = self.appGroupID;
     newOptions.editingLocked = self.isEditingLocked;
     newOptions.usingOptionsFromDefaultPlist = self.usingOptionsFromDefaultPlist;
   }
@@ -338,6 +339,11 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
 - (void)setBundleID:(NSString *)bundleID {
   [self checkEditingLocked];
   _optionsDictionary[kFIRBundleID] = [bundleID copy];
+}
+
+- (void)setAppGroupID:(NSString *)appGroupID {
+  [self checkEditingLocked];
+  _appGroupID = [appGroupID copy];
 }
 
 #pragma mark - Internal instance methods

--- a/Firebase/Core/Public/FIROptions.h
+++ b/Firebase/Core/Public/FIROptions.h
@@ -91,6 +91,13 @@ NS_SWIFT_NAME(FirebaseOptions)
 @property(nonatomic, copy, nullable) NSString *storageBucket;
 
 /**
+ * The App Group identifier to share data between the application and the application extensions.
+ * The App Group must be configured in the application and on the Apple Developer Portal. Default
+ * value `nil`.
+ */
+@property(nonatomic, copy, nullable) NSString *appGroupID;
+
+/**
  * Initializes a customized instance of FIROptions from the file at the given plist file path. This
  * will read the file synchronously from disk.
  * For example,


### PR DESCRIPTION
This is a PR required for the application extensions support:
- a property `FIROptions.appGroupID` added which can be used by Firebase SDKs to share data between the application and the app extensions.