### PR TITLE
Ensure Storage initializer doesn't get called

### DIFF
--- a/Firebase/Storage/CHANGELOG.md
+++ b/Firebase/Storage/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Unreleased
+- [fixed] Ensure that users don't accidently invoke `Storage()` instead of `Storage.storage()`.
+  If your code calls the constructor of Storage directly, we will throw an assertion failure,
+  instead of crashing the process later as the instance is used (#3282).
+
+# 3.3.0
 - [added] Added `StorageReference.list()` and `StorageReference.listAll()`, which allows developers to list the files and folders under the given StorageReference.
 
 # 3.2.1

--- a/Firebase/Storage/FIRStorage.m
+++ b/Firebase/Storage/FIRStorage.m
@@ -158,6 +158,12 @@ static GTMSessionFetcherRetryBlock _retryWhenOffline;
   return self;
 }
 
+- (instancetype)init {
+  NSAssert(false, @"Storage cannot be directly instantiated, use "
+                   "Storage.storage() or Storage.storage(app:) instead");
+  return nil;
+}
+
 #pragma mark - NSObject overrides
 
 - (instancetype)copyWithZone:(NSZone *)zone {

--- a/Firebase/Storage/Public/FIRStorage.h
+++ b/Firebase/Storage/Public/FIRStorage.h
@@ -69,6 +69,8 @@ NS_SWIFT_NAME(Storage)
  */
 + (instancetype)storageForApp:(FIRApp *)app URL:(NSString *)url NS_SWIFT_NAME(storage(app:url:));
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
  * The Firebase App associated with this Firebase Storage instance.
  */


### PR DESCRIPTION
Obj-C/Swift lets you call the init-method on Storage, even though our users are supposed to use the factory methods. While `[[FIRStorage alloc] init]` results in a compile error (due to our usage of NS_UNAVAILABLE), `[FIRStorage new]` does not. This PR makes sure that we crash the process early on, and not further down the line as reported in https://github.com/firebase/firebase-ios-sdk/issues/3282

Fixes https://github.com/firebase/firebase-ios-sdk/issues/3282