### PR TITLE
Firebase Installations- missing API and API docs

### DIFF
--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -112,7 +112,7 @@
   if (!defaultApp) {
     return nil;
   }
-  
+
   return [self installationsWithApp:defaultApp];
 }
 

--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -113,10 +113,10 @@ NS_ASSUME_NONNULL_BEGIN
   FIRApp *defaultApp = [FIRApp defaultApp];
   if (!defaultApp) {
     [NSException raise:NSInternalInconsistencyException
-                format:@"The default FIRApp instance must be configured before the default FIRAuth"
-                       @"instance can be initialized. One way to ensure that is to call "
-                       @"`[FIRApp configure];` (`FirebaseApp.configure()` in Swift) in the App "
-                       @"Delegate's `application:didFinishLaunchingWithOptions:` "
+                format:@"The default FirebaseApp instance must be configured before the default"
+                       @"FirebaseApp instance can be initialized. One way to ensure that is to "
+                       @"call `[FIRApp configure];` (`FirebaseApp.configure()` in Swift) in the App"
+                       @" Delegate's `application:didFinishLaunchingWithOptions:` "
                        @"(`application(_:didFinishLaunchingWithOptions:)` in Swift)."];
   }
 

--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -36,6 +36,8 @@
 #import "FIRInstallationsStoredAuthToken.h"
 #import "FIRInstallationsVersion.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol FIRInstallationsInstanceProvider <FIRLibrary>
 @end
 
@@ -111,6 +113,12 @@
   FIRApp *defaultApp = [FIRApp defaultApp];
   if (!defaultApp) {
     return nil;
+    [NSException raise:NSInternalInconsistencyException
+                format:@"The default FIRApp instance must be configured before the default FIRAuth"
+                       @"instance can be initialized. One way to ensure that is to call "
+                       @"`[FIRApp configure];` (`FirebaseApp.configure()` in Swift) in the App "
+                       @"Delegate's `application:didFinishLaunchingWithOptions:` "
+                       @"(`application(_:didFinishLaunchingWithOptions:)` in Swift)."];
   }
 
   return [self installationsWithApp:defaultApp];
@@ -170,3 +178,5 @@
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -36,10 +36,10 @@
 #import "FIRInstallationsStoredAuthToken.h"
 #import "FIRInstallationsVersion.h"
 
-@protocol FIRInstallationsInstanceProvider
+@protocol FIRInstallationsInstanceProvider <FIRLibrary>
 @end
 
-@interface FIRInstallations () <FIRLibrary>
+@interface FIRInstallations () <FIRInstallationsInstanceProvider>
 @property(nonatomic, readonly) FIROptions *appOptions;
 @property(nonatomic, readonly) NSString *appName;
 
@@ -106,6 +106,15 @@
 }
 
 #pragma mark - Public
+
++ (FIRInstallations *)installations {
+  FIRApp *defaultApp = [FIRApp defaultApp];
+  if (!defaultApp) {
+    return nil;
+  }
+  
+  return [self installationsWithApp:defaultApp];
+}
 
 + (FIRInstallations *)installationsWithApp:(FIRApp *)app {
   id<FIRInstallationsInstanceProvider> installations =

--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -157,7 +157,7 @@
       });
 }
 
-- (void)deleteWithCompletion:(void (^)(NSError *__nullable))completion {
+- (void)deleteWithCompletion:(void (^)(NSError *__nullable error))completion {
   [self.installationsIDController deleteInstallation]
       .then(^id(id result) {
         completion(nil);

--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -112,7 +112,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (FIRInstallations *)installations {
   FIRApp *defaultApp = [FIRApp defaultApp];
   if (!defaultApp) {
-    return nil;
     [NSException raise:NSInternalInconsistencyException
                 format:@"The default FIRApp instance must be configured before the default FIRAuth"
                        @"instance can be initialized. One way to ensure that is to call "

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -31,7 +31,8 @@
 #import "FIRInstallationsStoredAuthToken.h"
 #import "FIRSecureStorage.h"
 
-NSString *const FIRInstallationIDDidChangeNotification = @"FIRInstallationIDDidChangeNotification";
+const NSNotificationName FIRInstallationIDDidChangeNotification =
+    @"FIRInstallationIDDidChangeNotification";
 NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 hour.
 
 @interface FIRInstallationsIDController ()

--- a/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
+++ b/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
@@ -22,23 +22,52 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/** A notification with this name is sent each time an installation is created or deleted. */
 FOUNDATION_EXPORT const NSNotificationName FIRInstallationIDDidChangeNotification;
 
+/**
+ * An installation ID handler block.
+ * @param identifier The instalation ID string if exists or @c nil otherwise.
+ * @param error The error when @c identifier==nil or @c nil otherwise.
+ */
 typedef void (^FIRInstallationsIDHandler)(NSString *__nullable identifier,
                                           NSError *__nullable error)
     NS_SWIFT_NAME(InstallationsIDHandler);
 
+/**
+ * An authentification token handler block.
+ * @param tokenResult An instance of @c FIRInstallationsAuthTokenResult in case of success or @c nil otherwise.
+ * @param error The error when @c tokenResult==nil or @c nil otherwise.
+ */
 typedef void (^FIRInstallationsTokenHandler)(
     FIRInstallationsAuthTokenResult *__nullable tokenResult, NSError *__nullable error)
     NS_SWIFT_NAME(InstallationsTokenHandler);
 
+/**
+ * The class provides API for Firebase Installations.
+ * Each configured @c FIRApp has a corresponding single instance of @c FIRInstallations.
+ * An instance of the class provides access to the installation info for the @c FIRApp as well as allows to delete it.
+ * A Firebase Installation is unique by @c FIRApp.name and @c FIRApp.options.googleAppID .
+ */
 NS_SWIFT_NAME(Installations)
 @interface FIRInstallations : NSObject
 
+/**
+ * Returns a default instance of @c FIRInstallations.
+ * @return Returns an instance of @c FIRInstallations for @c[FIRApp defaultApp]. Returns @c nil if the default app is not configured yet.
+ */
 + (nullable FIRInstallations *)installations;
 
+/**
+ * Returns an instance of @c FIRInstallations for an application.
+ * @param application A configured @c FIRApp instance.
+ * @return Returns an instance of @c FIRInstallations corresponding to the passed application.
+ */
 + (FIRInstallations *)installationsWithApp:(FIRApp *)application NS_SWIFT_NAME(installations(app:));
 
+/**
+ * 
+ */
 - (void)installationIDWithCompletion:(FIRInstallationsIDHandler)completion;
 
 - (void)authTokenWithCompletion:(FIRInstallationsTokenHandler)completion;

--- a/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
+++ b/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-// TODO: Add short docs to the API
 #import <FirebaseInstallations/FIRInstallationsAuthTokenResult.h>
 #import <Foundation/Foundation.h>
 
@@ -35,8 +34,9 @@ typedef void (^FIRInstallationsIDHandler)(NSString *__nullable identifier,
     NS_SWIFT_NAME(InstallationsIDHandler);
 
 /**
- * An authentification token handler block.
- * @param tokenResult An instance of @c FIRInstallationsAuthTokenResult in case of success or @c nil otherwise.
+ * An authorization token handler block.
+ * @param tokenResult An instance of @c FIRInstallationsAuthTokenResult in case of success or @c nil
+ * otherwise.
  * @param error The error when @c tokenResult==nil or @c nil otherwise.
  */
 typedef void (^FIRInstallationsTokenHandler)(
@@ -46,15 +46,17 @@ typedef void (^FIRInstallationsTokenHandler)(
 /**
  * The class provides API for Firebase Installations.
  * Each configured @c FIRApp has a corresponding single instance of @c FIRInstallations.
- * An instance of the class provides access to the installation info for the @c FIRApp as well as allows to delete it.
- * A Firebase Installation is unique by @c FIRApp.name and @c FIRApp.options.googleAppID .
+ * An instance of the class provides access to the installation info for the @c FIRApp as well as
+ * allows to delete it. A Firebase Installation is unique by @c FIRApp.name and @c
+ * FIRApp.options.googleAppID .
  */
 NS_SWIFT_NAME(Installations)
 @interface FIRInstallations : NSObject
 
 /**
  * Returns a default instance of @c FIRInstallations.
- * @return Returns an instance of @c FIRInstallations for @c[FIRApp defaultApp]. Returns @c nil if the default app is not configured yet.
+ * @return Returns an instance of @c FIRInstallations for @c[FIRApp defaultApp]. Returns @c nil if
+ * the default app is not configured yet.
  */
 + (nullable FIRInstallations *)installations;
 
@@ -66,16 +68,46 @@ NS_SWIFT_NAME(Installations)
 + (FIRInstallations *)installationsWithApp:(FIRApp *)application NS_SWIFT_NAME(installations(app:));
 
 /**
- * 
+ * The method creates or retrieves an installation ID. The installation ID is a stable identifier
+ * that uniquely identifies the app instance. NOTE: If the application already has an existing
+ * FirebaseInstanceID then the InstanceID ideintifier will be used.
+ * @param completion A completion handler which is invoked when the operation completes. See @c
+ * FIRInstallationsIDHandler for additional details.
  */
 - (void)installationIDWithCompletion:(FIRInstallationsIDHandler)completion;
 
+/**
+ * Retrives (locally if exists or from the server) a valid authorization token. An existing token
+ * may be invalidated or expire, so it is recommended the auth token before each server request. The
+ * method does the same as @c-[FIRInstallations authTokenForcingRefresh:completion:] with forcing
+ * refresh @c NO.
+ * @param completion A completion handler which is invoked when the operation completes. See @c
+ * FIRInstallationsTokenHandler for additional details.
+ */
 - (void)authTokenWithCompletion:(FIRInstallationsTokenHandler)completion;
 
+/**
+ * Retrives (locally or from the server depending on @c forceRefresh value) a valid authorization
+ * token. An existing token may be invalidated or expire, so it is recommended the auth token before
+ * each server request. This method should be used with @c forceRefresh == YES when e.g. a request
+ * with the previously fetched auth token failed with "Not Authorized" error.
+ * @param forceRefresh If @c YES then the locally chached auth token will be ignored and a new one
+ * will be requested from the server. If @c NO, then the locally cached auth token will be returned
+ * if exists and has not expired yet.
+ * @param completion  A completion handler which is invoked when the operation completes. See @c
+ * FIRInstallationsTokenHandler for additional details.
+ */
 - (void)authTokenForcingRefresh:(BOOL)forceRefresh
                      completion:(FIRInstallationsTokenHandler)completion;
 
-- (void)deleteWithCompletion:(void (^)(NSError *__nullable))completion;
+/**
+ * Deletes all the installation data including the unique indentifier, auth tokens and
+ * all related data on the server side. The network connection is required for the method to
+ * succeed. If fails, the existing instalation data remains untouched.
+ * @param completion A completion handler which is invoked when the operation completes. @c error ==
+ * nil indicates success.
+ */
+- (void)deleteWithCompletion:(void (^)(NSError *__nullable error))completion;
 
 @end
 

--- a/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
+++ b/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
@@ -15,14 +15,14 @@
  */
 
 // TODO: Add short docs to the API
-#import <Foundation/Foundation.h>
 #import <FirebaseInstallations/FIRInstallationsAuthTokenResult.h>
+#import <Foundation/Foundation.h>
 
 @class FIRApp;
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString *const FIRInstallationIDDidChangeNotification;
+FOUNDATION_EXPORT const NSNotificationName FIRInstallationIDDidChangeNotification;
 
 typedef void (^FIRInstallationsIDHandler)(NSString *__nullable identifier,
                                           NSError *__nullable error)

--- a/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
+++ b/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
@@ -27,8 +27,8 @@ FOUNDATION_EXPORT const NSNotificationName FIRInstallationIDDidChangeNotificatio
 
 /**
  * An installation ID handler block.
- * @param identifier The instalation ID string if exists or @c nil otherwise.
- * @param error The error when @c identifier==nil or @c nil otherwise.
+ * @param identifier The installation ID string if exists or `nil` otherwise.
+ * @param error The error when `identifier == nil` or `nil` otherwise.
  */
 typedef void (^FIRInstallationsIDHandler)(NSString *__nullable identifier,
                                           NSError *__nullable error)
@@ -36,9 +36,9 @@ typedef void (^FIRInstallationsIDHandler)(NSString *__nullable identifier,
 
 /**
  * An authorization token handler block.
- * @param tokenResult An instance of @c FIRInstallationsAuthTokenResult in case of success or @c nil
+ * @param tokenResult An instance of `InstallationsAuthTokenResult` in case of success or `nil`
  * otherwise.
- * @param error The error when @c tokenResult==nil or @c nil otherwise.
+ * @param error The error when `tokenResult == nil` or `nil` otherwise.
  */
 typedef void (^FIRInstallationsTokenHandler)(
     FIRInstallationsAuthTokenResult *__nullable tokenResult, NSError *__nullable error)
@@ -46,25 +46,25 @@ typedef void (^FIRInstallationsTokenHandler)(
 
 /**
  * The class provides API for Firebase Installations.
- * Each configured @c FIRApp has a corresponding single instance of @c FIRInstallations.
- * An instance of the class provides access to the installation info for the @c FIRApp as well as
- * allows to delete it. A Firebase Installation is unique by @c FIRApp.name and @c
- * FIRApp.options.googleAppID .
+ * Each configured `FirebaseApp` has a corresponding single instance of `Installations`.
+ * An instance of the class provides access to the installation info for the `FirebaseApp` as well
+ * as allows to delete it. A Firebase Installation is unique by `FirebaseApp.name` and
+ * `FirebaseApp.options.googleAppID` .
  */
 NS_SWIFT_NAME(Installations)
 @interface FIRInstallations : NSObject
 
 /**
- * Returns a default instance of @c FIRInstallations.
- * @return Returns an instance of @c FIRInstallations for @c[FIRApp defaultApp]. Returns @c nil if
- * the default app is not configured yet.
+ * Returns a default instance of `Installations`.
+ * @return Returns an instance of `Installations` for `FirebaseApp.defaultApp(). Throws an exception
+ * if the default app is not configured yet.
  */
-+ (nullable FIRInstallations *)installations;
++ (FIRInstallations *)installations;
 
 /**
- * Returns an instance of @c FIRInstallations for an application.
- * @param application A configured @c FIRApp instance.
- * @return Returns an instance of @c FIRInstallations corresponding to the passed application.
+ * Returns an instance of `Installations` for an application.
+ * @param application A configured `FirebaseApp` instance.
+ * @return Returns an instance of `Installations` corresponding to the passed application.
  */
 + (FIRInstallations *)installationsWithApp:(FIRApp *)application NS_SWIFT_NAME(installations(app:));
 
@@ -72,41 +72,41 @@ NS_SWIFT_NAME(Installations)
  * The method creates or retrieves an installation ID. The installation ID is a stable identifier
  * that uniquely identifies the app instance. NOTE: If the application already has an existing
  * FirebaseInstanceID then the InstanceID ideintifier will be used.
- * @param completion A completion handler which is invoked when the operation completes. See @c
- * FIRInstallationsIDHandler for additional details.
+ * @param completion A completion handler which is invoked when the operation completes. See
+ * `InstallationsIDHandler` for additional details.
  */
 - (void)installationIDWithCompletion:(FIRInstallationsIDHandler)completion;
 
 /**
- * Retrives (locally if exists or from the server) a valid authorization token. An existing token
- * may be invalidated or expire, so it is recommended the auth token before each server request. The
- * method does the same as @c-[FIRInstallations authTokenForcingRefresh:completion:] with forcing
- * refresh @c NO.
- * @param completion A completion handler which is invoked when the operation completes. See @c
- * FIRInstallationsTokenHandler for additional details.
+ * Retrieves (locally if it exists or from the server) a valid authorization token. An existing
+ * token may be invalidated or expired, so it is recommended to fetch the auth token before each
+ * server request. The method does the same as `Installations.authTokenForcingRefresh(:,
+ * completion:)` with forcing refresh `NO`.
+ * @param completion A completion handler which is invoked when the operation completes. See
+ * `InstallationsTokenHandler` for additional details.
  */
 - (void)authTokenWithCompletion:(FIRInstallationsTokenHandler)completion;
 
 /**
- * Retrives (locally or from the server depending on @c forceRefresh value) a valid authorization
- * token. An existing token may be invalidated or expire, so it is recommended the auth token before
- * each server request. This method should be used with @c forceRefresh == YES when e.g. a request
- * with the previously fetched auth token failed with "Not Authorized" error.
- * @param forceRefresh If @c YES then the locally chached auth token will be ignored and a new one
- * will be requested from the server. If @c NO, then the locally cached auth token will be returned
+ * Retrieves (locally or from the server depending on `forceRefresh` value) a valid authorization
+ * token. An existing token may be invalidated or expire, so it is recommended to fetch the auth
+ * token before each server request. This method should be used with `forceRefresh == YES` when e.g.
+ * a request with the previously fetched auth token failed with "Not Authorized" error.
+ * @param forceRefresh If `YES` then the locally cached auth token will be ignored and a new one
+ * will be requested from the server. If `NO`, then the locally cached auth token will be returned
  * if exists and has not expired yet.
- * @param completion  A completion handler which is invoked when the operation completes. See @c
- * FIRInstallationsTokenHandler for additional details.
+ * @param completion  A completion handler which is invoked when the operation completes. See
+ * `InstallationsTokenHandler` for additional details.
  */
 - (void)authTokenForcingRefresh:(BOOL)forceRefresh
                      completion:(FIRInstallationsTokenHandler)completion;
 
 /**
  * Deletes all the installation data including the unique indentifier, auth tokens and
- * all related data on the server side. The network connection is required for the method to
- * succeed. If fails, the existing instalation data remains untouched.
- * @param completion A completion handler which is invoked when the operation completes. @c error ==
- * nil indicates success.
+ * all related data on the server side. A network connection is required for the method to
+ * succeed. If fails, the existing installation data remains untouched.
+ * @param completion A completion handler which is invoked when the operation completes. `error ==
+ * nil` indicates success.
  */
 - (void)deleteWithCompletion:(void (^)(NSError *__nullable error))completion;
 

--- a/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
+++ b/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
@@ -48,7 +48,7 @@ typedef void (^FIRInstallationsTokenHandler)(
  * The class provides API for Firebase Installations.
  * Each configured `FirebaseApp` has a corresponding single instance of `Installations`.
  * An instance of the class provides access to the installation info for the `FirebaseApp` as well
- * as allows to delete it. A Firebase Installation is unique by `FirebaseApp.name` and
+ * as the ability to delete it. A Firebase Installation is unique by `FirebaseApp.name` and
  * `FirebaseApp.options.googleAppID` .
  */
 NS_SWIFT_NAME(Installations)

--- a/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
+++ b/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
@@ -16,8 +16,8 @@
 
 // TODO: Add short docs to the API
 #import <Foundation/Foundation.h>
+#import <FirebaseInstallations/FIRInstallationsAuthTokenResult.h>
 
-@class FIRInstallationsAuthTokenResult;
 @class FIRApp;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -35,7 +35,7 @@ typedef void (^FIRInstallationsTokenHandler)(
 NS_SWIFT_NAME(Installations)
 @interface FIRInstallations : NSObject
 
-// TODO: Add `+ (FIRInstallations *)installations;`
++ (nullable FIRInstallations *)installations;
 
 + (FIRInstallations *)installationsWithApp:(FIRApp *)application NS_SWIFT_NAME(installations(app:));
 

--- a/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
+++ b/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-#import <FirebaseInstallations/FIRInstallationsAuthTokenResult.h>
 #import <Foundation/Foundation.h>
+
+#import <FirebaseInstallations/FIRInstallationsAuthTokenResult.h>
 
 @class FIRApp;
 

--- a/FirebaseInstallations/Source/Library/Public/FIRInstallationsAuthTokenResult.h
+++ b/FirebaseInstallations/Source/Library/Public/FIRInstallationsAuthTokenResult.h
@@ -18,9 +18,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/** The class represents a result of the auth token request. */
 @interface FIRInstallationsAuthTokenResult : NSObject
 
+/** The authorization token string. */
 @property(nonatomic, readonly) NSString *authToken;
+
+/** The auth token experation date. */
 @property(nonatomic, readonly) NSDate *expirationDate;
 
 @end

--- a/FirebaseInstallations/Source/Library/Public/FIRInstallationsAuthTokenResult.h
+++ b/FirebaseInstallations/Source/Library/Public/FIRInstallationsAuthTokenResult.h
@@ -19,6 +19,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** The class represents a result of the auth token request. */
+NS_SWIFT_NAME(InstallationsAuthTokenResult)
 @interface FIRInstallationsAuthTokenResult : NSObject
 
 /** The authorization token string. */

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
@@ -72,6 +72,21 @@
   [FIRApp resetApps];
 }
 
+- (void)testDefaultAppInstallation {
+  FIRApp *defaultApp = [self createAndConfigureAppWithName:kFIRDefaultAppName];
+  FIRInstallations *installations = [FIRInstallations installations];
+
+  XCTAssertNotNil(installations);
+  XCTAssertEqualObjects(installations.appOptions.googleAppID, defaultApp.options.googleAppID);
+  XCTAssertEqualObjects(installations.appName, defaultApp.name);
+
+  [FIRApp resetApps];
+}
+
+- (void)testDefaultInstallationWhenNoDefaultAppThenIsNil {
+  XCTAssertNil([FIRInstallations installations]);
+}
+
 - (void)testInstallationIDSuccess {
   // Stub get installation.
   FIRInstallationsItem *installation = [FIRInstallationsItem createValidInstallationItem];
@@ -259,6 +274,7 @@
 - (FIRApp *)createAndConfigureAppWithName:(NSString *)name {
   FIROptions *options = [[FIROptions alloc] initInternalWithOptionsDictionary:@{
     @"GOOGLE_APP_ID" : @"1:100000000000:ios:aaaaaaaaaaaaaaaaaaaaaaaa",
+    @"GCM_SENDER_ID" : @"valid_sender_id"
   }];
   [FIRApp configureWithName:name options:options];
 

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
@@ -84,7 +84,7 @@
 }
 
 - (void)testDefaultInstallationWhenNoDefaultAppThenIsNil {
-  XCTAssertNil([FIRInstallations installations]);
+  XCTAssertThrows([FIRInstallations installations]);
 }
 
 - (void)testInstallationIDSuccess {


### PR DESCRIPTION
Firebase Installations changes:
- `[FIRInstallations installations]` added
- API docs for public methods and classes added
- some cleanup and fixes