### PR TITLE
Firebase Installations - eagerly request auth token

### DIFF
--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -89,18 +89,27 @@
                                                       projectID:appOptions.projectID];
   return [self initWithAppOptions:appOptions
                           appName:appName
-        installationsIDController:IDController];
+        installationsIDController:IDController
+                prefetchAuthToken:YES];
 }
 
 /// The initializer is supposed to be used by tests to inject `installationsStore`.
 - (instancetype)initWithAppOptions:(FIROptions *)appOptions
                            appName:(NSString *)appName
-         installationsIDController:(FIRInstallationsIDController *)installationsIDController {
+         installationsIDController:(FIRInstallationsIDController *)installationsIDController
+                 prefetchAuthToken:(BOOL)prefetchAuthToken {
   self = [super init];
   if (self) {
     _appOptions = [appOptions copy];
     _appName = [appName copy];
     _installationsIDController = installationsIDController;
+
+    // Pre-fetch auth token.
+    if (prefetchAuthToken) {
+      [self authTokenWithCompletion:^(FIRInstallationsAuthTokenResult *_Nullable tokenResult,
+                                      NSError *_Nullable error){
+      }];
+    }
   }
   return self;
 }

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
@@ -36,7 +36,8 @@
 
 - (instancetype)initWithAppOptions:(FIROptions *)appOptions
                            appName:(NSString *)appName
-         installationsIDController:(FIRInstallationsIDController *)installationsIDController;
+         installationsIDController:(FIRInstallationsIDController *)installationsIDController
+                 prefetchAuthToken:(BOOL)prefetchAuthToken;
 
 @end
 
@@ -56,7 +57,8 @@
   self.mockIDController = OCMClassMock([FIRInstallationsIDController class]);
   self.installations = [[FIRInstallations alloc] initWithAppOptions:self.appOptions
                                                             appName:@"appName"
-                                          installationsIDController:self.mockIDController];
+                                          installationsIDController:self.mockIDController
+                                                  prefetchAuthToken:NO];
 }
 
 - (void)tearDown {


### PR DESCRIPTION
Firebase Installations: 
- request auth token on each initialization to prevent unwanted FID garbage collection (if the server does not get any request with a FID during 18 months, then FID and all related data will be deleted).