### PR TITLE
Add explicit Foundation import.

### DIFF
--- a/GoogleUtilities/AppDelegateSwizzler/Internal/GULAppDelegateSwizzler_Private.h
+++ b/GoogleUtilities/AppDelegateSwizzler/Internal/GULAppDelegateSwizzler_Private.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
 #import <GoogleUtilities/GULAppDelegateSwizzler.h>
 #import <GoogleUtilities/GULMutableDictionary.h>
 

--- a/GoogleUtilities/CHANGELOG.md
+++ b/GoogleUtilities/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Add explicit Foundation import for headers.
+
 # 6.2.1
 - Fix Xcode 11 build warning. (#3133)
 

--- a/GoogleUtilities/Common/GULLoggerCodes.h
+++ b/GoogleUtilities/Common/GULLoggerCodes.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 typedef NS_ENUM(NSInteger, GULSwizzlerMessageCode) {
   // App Delegate Swizzling.
   kGULSwizzlerMessageCodeAppDelegateSwizzling000 = 1000,                 // I-SWZ001000

--- a/GoogleUtilities/Logger/Public/GULLoggerLevel.h
+++ b/GoogleUtilities/Logger/Public/GULLoggerLevel.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 /**
  * The log levels used by internal logging.
  */

--- a/GoogleUtilities/Network/Private/GULNetworkMessageCode.h
+++ b/GoogleUtilities/Network/Private/GULNetworkMessageCode.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 // Make sure these codes do not overlap with any contained in the FIRAMessageCode enum.
 typedef NS_ENUM(NSInteger, GULNetworkMessageCode) {
   // GULNetwork.m

--- a/GoogleUtilities/Reachability/Private/GULReachabilityMessageCode.h
+++ b/GoogleUtilities/Reachability/Private/GULReachabilityMessageCode.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#import <Foundation/Foundation.h>
+
 // Make sure these codes do not overlap with any contained in the FIRAMessageCode enum.
 typedef NS_ENUM(NSInteger, GULReachabilityMessageCode) {
   // GULReachabilityChecker.m


### PR DESCRIPTION
This is causing issues when building an XCFramework. This work relates to #3144 