### PR TITLE
Pass the correct compiler flag for CoreDiagnostics.

### DIFF
--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -141,7 +141,7 @@ public enum CocoaPodUtils {
     }
 
     // Run pod install on the directory that contains the Podfile and blank Xcode project.
-    let result = Shell.executeCommandFromScript("pod _1.5.3_ install", workingDir: directory)
+    let result = Shell.executeCommandFromScript("pod install", workingDir: directory)
     switch result {
     case let .error(code, output):
       fatalError("""

--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -55,14 +55,18 @@ struct FrameworkBuilder {
   /// The directory containing the Xcode project and Pods folder.
   private let projectDir: URL
 
+  /// A flag to indicate this build is for carthage. This is primarily used for CoreDiagnostics.
+  private let carthageBuild: Bool
+
   /// The Pods directory for building the framework.
   private var podsDir: URL {
     return projectDir.appendingPathComponent("Pods", isDirectory: true)
   }
 
   /// Default initializer.
-  init(projectDir: URL) {
+  init(projectDir: URL, carthageBuild: Bool = false) {
     self.projectDir = projectDir
+    self.carthageBuild = carthageBuild
   }
 
   // MARK: - Public Functions
@@ -223,7 +227,8 @@ struct FrameworkBuilder {
                            "ARCHS=\(arch.rawValue)",
                            "BUILD_DIR=\(buildDir.path)",
                            "-sdk", platform.rawValue]
-    let args = standardOptions + platform.extraArguments()
+    let distributionFlag = carthageBuild ? "-DFIREBASE_BUILD_CARTHAGE" : "-DFIREBASE_BUILD_ZIP_FILE"
+    let args = standardOptions + platform.extraArguments() + [distributionFlag]
     print("""
     Compiling \(framework) for \(arch.rawValue) with command:
     /usr/bin/xcodebuild \(args.joined(separator: " "))

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -661,7 +661,8 @@ struct ZipBuilder {
   /// .framework file already).
   private func generateFrameworks(fromPods pods: [CocoaPodUtils.PodInfo],
                                   inProjectDir projectDir: URL,
-                                  useCache: Bool = false) -> [String: [URL]] {
+                                  useCache: Bool = false,
+                                  carthageBuild: Bool = false) -> [String: [URL]] {
     // Verify the Pods folder exists and we can get the contents of it.
     let fileManager = FileManager.default
 


### PR DESCRIPTION
When CoreDiagnostics is open sourced, we'll need to ensure that the
right compiler flag is passed. This doesn't add support for Carthage yet
but allows the `FrameworkBuilder` to pass the flag for Carthage as well.
An update to the ZipBuilder to allow for Carthage will follow shortly.