### PR TITLE
Firebase Installations - fix flaky tests

### DIFF
--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
@@ -71,6 +71,9 @@
   [self assertInstallationsWithAppNamed:@"testInstallationsWithApp1"];
   [self assertInstallationsWithAppNamed:@"testInstallationsWithApp2"];
 
+  // Wait for finishing all background operations.
+  FBLWaitForPromisesWithTimeout(10);
+
   [FIRApp resetApps];
 }
 
@@ -81,6 +84,9 @@
   XCTAssertNotNil(installations);
   XCTAssertEqualObjects(installations.appOptions.googleAppID, defaultApp.options.googleAppID);
   XCTAssertEqualObjects(installations.appName, defaultApp.name);
+
+  // Wait for finishing all background operations.
+  FBLWaitForPromisesWithTimeout(10);
 
   [FIRApp resetApps];
 }

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
@@ -67,6 +67,8 @@
   [super tearDown];
 }
 
+// TODO: Consider moving to the integration tests because [FIRInstallations installations] has a
+// side effect now (triggers a background task).
 - (void)testInstallationsWithApp {
   [self assertInstallationsWithAppNamed:@"testInstallationsWithApp1"];
   [self assertInstallationsWithAppNamed:@"testInstallationsWithApp2"];
@@ -77,6 +79,8 @@
   [FIRApp resetApps];
 }
 
+// TODO: Consider moving to the integration tests because [FIRInstallations installations] has a
+// side effect now (triggers a background task).
 - (void)testDefaultAppInstallation {
   FIRApp *defaultApp = [self createAndConfigureAppWithName:kFIRDefaultAppName];
   FIRInstallations *installations = [FIRInstallations installations];


### PR DESCRIPTION
Fix for flaky tests. Flakiness was introduced by #3308 by starting a background operation on FIRInstallations initialization. 