### PR TITLE
Firebase Installations - error reporting and API errors handling

### DIFF
--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -31,11 +31,11 @@
 
 #import "FIRInstallationsAuthTokenResultInternal.h"
 
+#import "FIRInstallationsErrorUtil.h"
 #import "FIRInstallationsIDController.h"
 #import "FIRInstallationsItem.h"
 #import "FIRInstallationsStoredAuthToken.h"
 #import "FIRInstallationsVersion.h"
-#import "FIRInstallationsErrorUtil.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -35,6 +35,7 @@
 #import "FIRInstallationsItem.h"
 #import "FIRInstallationsStoredAuthToken.h"
 #import "FIRInstallationsVersion.h"
+#import "FIRInstallationsErrorUtil.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -145,8 +146,7 @@ NS_ASSUME_NONNULL_BEGIN
         return nil;
       })
       .catch(^(NSError *error) {
-        // TODO: Make sure the error is in the public domain and wrap if needed.
-        completion(nil, error);
+        completion(nil, [FIRInstallationsErrorUtil publicDomainErrorWithError:error]);
       });
 }
 
@@ -168,8 +168,7 @@ NS_ASSUME_NONNULL_BEGIN
         return nil;
       })
       .catch(^void(NSError *error) {
-        // TODO: Make sure the error is in the public domain and wrap if needed.
-        completion(nil, error);
+        completion(nil, [FIRInstallationsErrorUtil publicDomainErrorWithError:error]);
       });
 }
 
@@ -180,8 +179,7 @@ NS_ASSUME_NONNULL_BEGIN
         return nil;
       })
       .catch(^void(NSError *error) {
-        // TODO: Make sure the error is in the public domain and wrap if needed.
-        completion(error);
+        completion([FIRInstallationsErrorUtil publicDomainErrorWithError:error]);
       });
 }
 

--- a/FirebaseInstallations/Source/Library/FIRInstallationsErrorUtil.h
+++ b/FirebaseInstallations/Source/Library/FIRInstallationsErrorUtil.h
@@ -26,6 +26,7 @@ void FIRInstallationsItemSetErrorToPointer(NSError *error, NSError **pointer);
 
 + (NSError *)keyedArchiverErrorWithException:(NSException *)exception;
 + (NSError *)keyedArchiverErrorWithError:(NSError *)error;
+
 + (NSError *)keychainErrorWithFunction:(NSString *)keychainFunction status:(OSStatus)status;
 
 + (NSError *)installationItemNotFoundForAppID:(NSString *)appID appName:(NSString *)appName;
@@ -37,6 +38,12 @@ void FIRInstallationsItemSetErrorToPointer(NSError *error, NSError **pointer);
 + (NSError *)networkErrorWithError:(NSError *)error;
 
 + (NSError *)FIDRegestrationErrorWithResponseMissingField:(NSString *)missingFieldName;
+
+/**
+ * Returns the passed error if it is already in the public domain or a new error with the passed
+ * error at `NSUnderlyingErrorKey`.
+ */
++ (NSError *)publicDomainErrorWithError:(NSError *)error;
 
 @end
 

--- a/FirebaseInstallations/Source/Library/FIRInstallationsErrorUtil.h
+++ b/FirebaseInstallations/Source/Library/FIRInstallationsErrorUtil.h
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import <FirebaseInstallations/FIRInstallationsErrors.h>
+
 NS_ASSUME_NONNULL_BEGIN
 
 void FIRInstallationsItemSetErrorToPointer(NSError *error, NSError **pointer);
@@ -23,6 +25,7 @@ void FIRInstallationsItemSetErrorToPointer(NSError *error, NSError **pointer);
 @interface FIRInstallationsErrorUtil : NSObject
 
 + (NSError *)keyedArchiverErrorWithException:(NSException *)exception;
++ (NSError *)keyedArchiverErrorWithError:(NSError *)error;
 + (NSError *)keychainErrorWithFunction:(NSString *)keychainFunction status:(OSStatus)status;
 
 + (NSError *)installationItemNotFoundForAppID:(NSString *)appID appName:(NSString *)appName;
@@ -30,6 +33,8 @@ void FIRInstallationsItemSetErrorToPointer(NSError *error, NSError **pointer);
 + (NSError *)APIErrorWithHTTPCode:(NSUInteger)HTTPCode;
 
 + (NSError *)JSONSerializationError:(NSError *)error;
+
++ (NSError *)networkErrorWithError:(NSError *)error;
 
 + (NSError *)FIDRegestrationErrorWithResponseMissingField:(NSString *)missingFieldName;
 

--- a/FirebaseInstallations/Source/Library/FIRInstallationsErrorUtil.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallationsErrorUtil.m
@@ -32,53 +32,72 @@ void FIRInstallationsItemSetErrorToPointer(NSError *error, NSError **pointer) {
   NSString *failureReason = [NSString
       stringWithFormat:@"NSKeyedArchiver exception with name: %@, reason: %@, userInfo: %@",
                        exception.name, exception.reason, exception.userInfo];
-  return [self publicErrorWithCode:FIRInstallationsErrorCodeUnknown
+  return [self installationsErrorWithCode:FIRInstallationsErrorCodeUnknown
                      failureReason:failureReason
                    underlyingError:nil];
 }
 
 + (NSError *)keyedArchiverErrorWithError:(NSError *)error {
   NSString *failureReason = [NSString stringWithFormat:@"NSKeyedArchiver error"];
-  return [self publicErrorWithCode:FIRInstallationsErrorCodeUnknown
+  return [self installationsErrorWithCode:FIRInstallationsErrorCodeUnknown
                      failureReason:failureReason
                    underlyingError:error];
 }
 
 + (NSError *)keychainErrorWithFunction:(NSString *)keychainFunction status:(OSStatus)status {
-  // TODO: Form a proper error
   NSString *failureReason = [NSString stringWithFormat:@"%@ (%li)", keychainFunction, (long)status];
-  return [self publicErrorWithCode:FIRInstallationsErrorCodeKeychain failureReason:failureReason underlyingError:nil];
+  return [self installationsErrorWithCode:FIRInstallationsErrorCodeKeychain
+                     failureReason:failureReason
+                   underlyingError:nil];
 }
 
 + (NSError *)installationItemNotFoundForAppID:(NSString *)appID appName:(NSString *)appName {
   NSString *failureReason =
       [NSString stringWithFormat:@"Installation for appID %@ appName %@ not found", appID, appName];
-  return [self publicErrorWithCode:FIRInstallationsErrorCodeUnknown failureReason:failureReason underlyingError:nil];
+  return [self installationsErrorWithCode:FIRInstallationsErrorCodeUnknown
+                     failureReason:failureReason
+                   underlyingError:nil];
 }
 
 + (NSError *)APIErrorWithHTTPCode:(NSUInteger)HTTPCode {
   NSString *failureReason = [NSString
       stringWithFormat:@"Unexpected server response HTTP code: %lu", (unsigned long)HTTPCode];
-  return [self publicErrorWithCode:FIRInstallationsErrorCodeUnknown failureReason:failureReason underlyingError:nil];
+  return [self installationsErrorWithCode:FIRInstallationsErrorCodeUnknown
+                     failureReason:failureReason
+                   underlyingError:nil];
 }
 
 + (NSError *)JSONSerializationError:(NSError *)error {
   NSString *failureReason = [NSString stringWithFormat:@"Failed to serialize JSON data."];
-  return [self publicErrorWithCode:FIRInstallationsErrorCodeUnknown failureReason:failureReason underlyingError:nil];
+  return [self installationsErrorWithCode:FIRInstallationsErrorCodeUnknown
+                     failureReason:failureReason
+                   underlyingError:nil];
 }
 
 + (NSError *)FIDRegestrationErrorWithResponseMissingField:(NSString *)missingFieldName {
   NSString *failureReason = [NSString
       stringWithFormat:@"A required response field with name %@ is missing", missingFieldName];
-  return [self publicErrorWithCode:FIRInstallationsErrorCodeUnknown failureReason:failureReason underlyingError:nil];
+  return [self installationsErrorWithCode:FIRInstallationsErrorCodeUnknown
+                     failureReason:failureReason
+                   underlyingError:nil];
 }
 
 + (NSError *)networkErrorWithError:(NSError *)error {
-  return [self publicErrorWithCode:FIRInstallationsErrorCodeServerUnreachable failureReason:@"Networt connection error" underlyingError:error];
+  return [self installationsErrorWithCode:FIRInstallationsErrorCodeServerUnreachable
+                     failureReason:@"Networt connection error"
+                   underlyingError:error];
 }
 
-+ (NSError *)publicErrorWithCode:(FIRInstallationsErrorCode)code
-                   failureReason:(NSString *)failureReason
++ (NSError *)publicDomainErrorWithError:(NSError *)error {
+  if ([error.domain isEqualToString:kFirebaseInstallationsErrorDomain]) {
+    return error;
+  }
+
+  return [self installationsErrorWithCode:FIRInstallationsErrorCodeUnknown failureReason:nil underlyingError:error];
+}
+
++ (NSError *)installationsErrorWithCode:(FIRInstallationsErrorCode)code
+                   failureReason:(nullable NSString *)failureReason
                  underlyingError:(nullable NSError *)underlyingError {
   NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
   userInfo[NSUnderlyingErrorKey] = underlyingError;

--- a/FirebaseInstallations/Source/Library/FIRInstallationsErrorUtil.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallationsErrorUtil.m
@@ -33,59 +33,59 @@ void FIRInstallationsItemSetErrorToPointer(NSError *error, NSError **pointer) {
       stringWithFormat:@"NSKeyedArchiver exception with name: %@, reason: %@, userInfo: %@",
                        exception.name, exception.reason, exception.userInfo];
   return [self installationsErrorWithCode:FIRInstallationsErrorCodeUnknown
-                     failureReason:failureReason
-                   underlyingError:nil];
+                            failureReason:failureReason
+                          underlyingError:nil];
 }
 
 + (NSError *)keyedArchiverErrorWithError:(NSError *)error {
   NSString *failureReason = [NSString stringWithFormat:@"NSKeyedArchiver error"];
   return [self installationsErrorWithCode:FIRInstallationsErrorCodeUnknown
-                     failureReason:failureReason
-                   underlyingError:error];
+                            failureReason:failureReason
+                          underlyingError:error];
 }
 
 + (NSError *)keychainErrorWithFunction:(NSString *)keychainFunction status:(OSStatus)status {
   NSString *failureReason = [NSString stringWithFormat:@"%@ (%li)", keychainFunction, (long)status];
   return [self installationsErrorWithCode:FIRInstallationsErrorCodeKeychain
-                     failureReason:failureReason
-                   underlyingError:nil];
+                            failureReason:failureReason
+                          underlyingError:nil];
 }
 
 + (NSError *)installationItemNotFoundForAppID:(NSString *)appID appName:(NSString *)appName {
   NSString *failureReason =
       [NSString stringWithFormat:@"Installation for appID %@ appName %@ not found", appID, appName];
   return [self installationsErrorWithCode:FIRInstallationsErrorCodeUnknown
-                     failureReason:failureReason
-                   underlyingError:nil];
+                            failureReason:failureReason
+                          underlyingError:nil];
 }
 
 + (NSError *)APIErrorWithHTTPCode:(NSUInteger)HTTPCode {
   NSString *failureReason = [NSString
       stringWithFormat:@"Unexpected server response HTTP code: %lu", (unsigned long)HTTPCode];
   return [self installationsErrorWithCode:FIRInstallationsErrorCodeUnknown
-                     failureReason:failureReason
-                   underlyingError:nil];
+                            failureReason:failureReason
+                          underlyingError:nil];
 }
 
 + (NSError *)JSONSerializationError:(NSError *)error {
   NSString *failureReason = [NSString stringWithFormat:@"Failed to serialize JSON data."];
   return [self installationsErrorWithCode:FIRInstallationsErrorCodeUnknown
-                     failureReason:failureReason
-                   underlyingError:nil];
+                            failureReason:failureReason
+                          underlyingError:nil];
 }
 
 + (NSError *)FIDRegestrationErrorWithResponseMissingField:(NSString *)missingFieldName {
   NSString *failureReason = [NSString
       stringWithFormat:@"A required response field with name %@ is missing", missingFieldName];
   return [self installationsErrorWithCode:FIRInstallationsErrorCodeUnknown
-                     failureReason:failureReason
-                   underlyingError:nil];
+                            failureReason:failureReason
+                          underlyingError:nil];
 }
 
 + (NSError *)networkErrorWithError:(NSError *)error {
   return [self installationsErrorWithCode:FIRInstallationsErrorCodeServerUnreachable
-                     failureReason:@"Networt connection error"
-                   underlyingError:error];
+                            failureReason:@"Networt connection error"
+                          underlyingError:error];
 }
 
 + (NSError *)publicDomainErrorWithError:(NSError *)error {
@@ -93,12 +93,14 @@ void FIRInstallationsItemSetErrorToPointer(NSError *error, NSError **pointer) {
     return error;
   }
 
-  return [self installationsErrorWithCode:FIRInstallationsErrorCodeUnknown failureReason:nil underlyingError:error];
+  return [self installationsErrorWithCode:FIRInstallationsErrorCodeUnknown
+                            failureReason:nil
+                          underlyingError:error];
 }
 
 + (NSError *)installationsErrorWithCode:(FIRInstallationsErrorCode)code
-                   failureReason:(nullable NSString *)failureReason
-                 underlyingError:(nullable NSError *)underlyingError {
+                          failureReason:(nullable NSString *)failureReason
+                        underlyingError:(nullable NSError *)underlyingError {
   NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
   userInfo[NSUnderlyingErrorKey] = underlyingError;
   userInfo[NSLocalizedFailureReasonErrorKey] = failureReason;

--- a/FirebaseInstallations/Source/Library/FIRInstallationsErrorUtil.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallationsErrorUtil.m
@@ -38,7 +38,7 @@ void FIRInstallationsItemSetErrorToPointer(NSError *error, NSError **pointer) {
 }
 
 + (NSError *)keyedArchiverErrorWithError:(NSError *)error {
-  NSString *failureReason = [NSString stringWithFormat:@"NSKeyedArchiver error"];
+  NSString *failureReason = [NSString stringWithFormat:@"NSKeyedArchiver error."];
   return [self installationsErrorWithCode:FIRInstallationsErrorCodeUnknown
                             failureReason:failureReason
                           underlyingError:error];
@@ -84,7 +84,7 @@ void FIRInstallationsItemSetErrorToPointer(NSError *error, NSError **pointer) {
 
 + (NSError *)networkErrorWithError:(NSError *)error {
   return [self installationsErrorWithCode:FIRInstallationsErrorCodeServerUnreachable
-                            failureReason:@"Networt connection error"
+                            failureReason:@"Network connection error."
                           underlyingError:error];
 }
 

--- a/FirebaseInstallations/Source/Library/FIRSecureStorage.h
+++ b/FirebaseInstallations/Source/Library/FIRSecureStorage.h
@@ -60,10 +60,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (FBLPromise<NSNull *> *)removeObjectForKey:(NSString *)key
                                  accessGroup:(nullable NSString *)accessGroup;
 
-// TODO: May be needed to read write legacy IID keychain items.
-//- (FBLPromise<NSString *> *)getStringForKey:(NSString *)key;
-//- (FBLPromise<id> *)setString:(NSString *)string forKey:(NSString *)key;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseInstallations/Source/Library/FIRSecureStorage.m
+++ b/FirebaseInstallations/Source/Library/FIRSecureStorage.m
@@ -184,9 +184,13 @@
 - (nullable NSData *)archiveDataForObject:(id<NSSecureCoding>)object error:(NSError **)outError {
   NSData *archiveData;
   if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
+    NSError *error;
     archiveData = [NSKeyedArchiver archivedDataWithRootObject:object
                                         requiringSecureCoding:YES
-                                                        error:outError];
+                                                        error:&error];
+    if (error && outError) {
+      *outError = [FIRInstallationsErrorUtil keyedArchiverErrorWithError:error];
+    }
   } else {
     @try {
       NSMutableData *data = [NSMutableData data];
@@ -212,7 +216,11 @@
                                  error:(NSError **)outError {
   id object;
   if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-    object = [NSKeyedUnarchiver unarchivedObjectOfClass:class fromData:data error:outError];
+    NSError *error;
+    object = [NSKeyedUnarchiver unarchivedObjectOfClass:class fromData:data error:&error];
+    if (error && outError) {
+      *outError = [FIRInstallationsErrorUtil keyedArchiverErrorWithError:error];
+    }
   } else {
     @try {
       NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:data];

--- a/FirebaseInstallations/Source/Library/InstallationsAPI/FIRInstallationsAPIService.m
+++ b/FirebaseInstallations/Source/Library/InstallationsAPI/FIRInstallationsAPIService.m
@@ -248,7 +248,6 @@ NS_ASSUME_NONNULL_END
   }];
 }
 
-// TODO: Set proper sdkVersion.
 - (NSString *)SDKVersion {
   return [NSString stringWithUTF8String:FIRInstallationsVersionStr];
 }

--- a/FirebaseInstallations/Source/Library/InstallationsAPI/FIRInstallationsAPIService.m
+++ b/FirebaseInstallations/Source/Library/InstallationsAPI/FIRInstallationsAPIService.m
@@ -16,6 +16,8 @@
 
 #import "FIRInstallationsAPIService.h"
 
+#import <FirebaseInstallations/FIRInstallationsVersion.h>
+
 #if __has_include(<FBLPromises/FBLPromises.h>)
 #import <FBLPromises/FBLPromises.h>
 #else
@@ -248,7 +250,7 @@ NS_ASSUME_NONNULL_END
 
 // TODO: Set proper sdkVersion.
 - (NSString *)SDKVersion {
-  return @"a1.0";
+  return [NSString stringWithUTF8String:FIRInstallationsVersionStr];
 }
 
 #pragma mark - JSON

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -238,7 +238,7 @@ NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 
             [registeredInstallstion.authToken.expirationDate timeIntervalSinceDate:[NSDate date]] <
             kFIRInstallationsTokenExpirationThreshold;
         if (forceRefresh || isTokenExpiredOrExpiresSoon) {
-          return [self.APIService refreshAuthTokenForInstallation:registeredInstallstion];
+          return [self refreshAuthTokenForInstallation:registeredInstallstion];
         } else {
           return registeredInstallstion;
         }
@@ -246,6 +246,18 @@ NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 
       .catch(^void(NSError *error){
           // TODO: Handle the errors.
       });
+}
+
+- (FBLPromise<FIRInstallationsItem *> *)refreshAuthTokenForInstallation:
+    (FIRInstallationsItem *)installation {
+  return [FBLPromise attempts:1
+      delay:1
+      condition:^BOOL(NSInteger remainingAttempts, NSError *_Nonnull error) {
+        return [error isEqual:[FIRInstallationsErrorUtil APIErrorWithHTTPCode:500]];
+      }
+      retry:^id _Nullable {
+        return [self.APIService refreshAuthTokenForInstallation:installation];
+      }];
 }
 
 #pragma mark - Delete FID

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -233,14 +233,14 @@ NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 
       .then(^FBLPromise<FIRInstallationsItem *> *(FIRInstallationsItem *installstion) {
         return [self registerInstallationIfNeeded:installstion];
       })
-      .then(^id(FIRInstallationsItem *registeredInstallstion) {
+      .then(^id(FIRInstallationsItem *registeredInstallation) {
         BOOL isTokenExpiredOrExpiresSoon =
-            [registeredInstallstion.authToken.expirationDate timeIntervalSinceDate:[NSDate date]] <
+            [registeredInstallation.authToken.expirationDate timeIntervalSinceDate:[NSDate date]] <
             kFIRInstallationsTokenExpirationThreshold;
         if (forceRefresh || isTokenExpiredOrExpiresSoon) {
-          return [self refreshAuthTokenForInstallation:registeredInstallstion];
+          return [self refreshAuthTokenForInstallation:registeredInstallation];
         } else {
-          return registeredInstallstion;
+          return registeredInstallation;
         }
       })
       .catch(^void(NSError *error){

--- a/FirebaseInstallations/Source/Library/Public/FIRInstallationsErrors.h
+++ b/FirebaseInstallations/Source/Library/Public/FIRInstallationsErrors.h
@@ -19,17 +19,16 @@
 extern NSString *const kFirebaseInstallationsErrorDomain;
 
 typedef NS_ENUM(NSUInteger, FIRInstallationsErrorCode) {
-  /// Unknown error.
+  /** Unknown error. See `userInfo` for details. */
   FIRInstallationsErrorCodeUnknown = 0,
 
-  /// Keychain error. See userInfo value by key NSUnderlyingErrorKey for details.
+  /** Keychain error. See `userInfo` for details. */
   FIRInstallationsErrorCodeKeychain = 1,
 
-  /// Server unreachable. A network error or server is unavailable.
+  /** Server unreachable. A network error or server is unavailable. See `userInfo` for details. */
   FIRInstallationsErrorCodeServerUnreachable = 2,
 
-  /// FIRApp configuration issues e.g. invalid GMP-App-ID, etc. See userInfo value by key
-  /// NSUnderlyingErrorKey for details.
+  /** FIRApp configuration issues e.g. invalid GMP-App-ID, etc. See `userInfo` for details. */
   FIRInstallationsErrorCodeInvalidConfiguration = 3,
 
 } NS_SWIFT_NAME(InstallationsErrorCode);

--- a/FirebaseInstallations/Source/Library/Public/FIRInstallationsErrors.h
+++ b/FirebaseInstallations/Source/Library/Public/FIRInstallationsErrors.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+extern NSString *const kFirebaseInstallationsErrorDomain;
+
+typedef NS_ENUM(NSUInteger, FIRInstallationsErrorCode) {
+  /// Unknown error.
+  FIRInstallationsErrorCodeUnknown = 0,
+
+  /// Keychain error. See userInfo value by key NSUnderlyingErrorKey for details.
+  FIRInstallationsErrorCodeKeychain = 1,
+
+  /// Server unreachable. A network error or server is unavailable.
+  FIRInstallationsErrorCodeServerUnreachable = 2,
+
+  /// FIRApp configuration issues e.g. invalid GMP-App-ID, etc. See userInfo value by key
+  /// NSUnderlyingErrorKey for details.
+  FIRInstallationsErrorCodeInvalidConfiguration = 3,
+
+} NS_SWIFT_NAME(InstallationsErrorCode);

--- a/FirebaseInstallations/Source/Library/Public/FIRInstallationsErrors.h
+++ b/FirebaseInstallations/Source/Library/Public/FIRInstallationsErrors.h
@@ -28,7 +28,7 @@ typedef NS_ENUM(NSUInteger, FIRInstallationsErrorCode) {
   /** Server unreachable. A network error or server is unavailable. See `userInfo` for details. */
   FIRInstallationsErrorCodeServerUnreachable = 2,
 
-  /** FIRApp configuration issues e.g. invalid GMP-App-ID, etc. See `userInfo` for details. */
+  /** FirebaseApp configuration issues e.g. invalid GMP-App-ID, etc. See `userInfo` for details. */
   FIRInstallationsErrorCodeInvalidConfiguration = 3,
 
 } NS_SWIFT_NAME(InstallationsErrorCode);

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
@@ -83,8 +83,7 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
     XCTAssertEqualObjects(body[@"authVersion"], @"FIS_v2");
     XCTAssertEqualObjects(body[@"appId"], installation.appID);
 
-    // TODO: Find out what the version should we pass and test.
-    //    XCTAssertEqualObjects(body[@"sdkVersion"], @"a1.0");
+    XCTAssertEqualObjects(body[@"sdkVersion"], @"0.1.0");
 
     return YES;
   }];
@@ -435,7 +434,7 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
     XCTAssertNotNil(body, @"Error: %@, test: %@", error, self.name);
 
     // TODO: Find out what the version should we pass and test.
-    XCTAssertEqualObjects(body, @{@"installation" : @{@"sdkVersion" : @"a1.0"}}, @"%@", self.name);
+    XCTAssertEqualObjects(body, @{@"installation" : @{@"sdkVersion" : @"0.1.0"}}, @"%@", self.name);
 
     return YES;
   }];

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
@@ -23,6 +23,7 @@
 #import "FIRInstallationsAPIService.h"
 #import "FIRInstallationsErrorUtil.h"
 #import "FIRInstallationsStoredAuthToken.h"
+#import "FIRInstallationsVersion.h"
 
 typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
 
@@ -83,7 +84,7 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
     XCTAssertEqualObjects(body[@"authVersion"], @"FIS_v2");
     XCTAssertEqualObjects(body[@"appId"], installation.appID);
 
-    XCTAssertEqualObjects(body[@"sdkVersion"], @"0.1.0");
+    XCTAssertEqualObjects(body[@"sdkVersion"], [self SDKVersion]);
 
     return YES;
   }];
@@ -433,8 +434,9 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
                                                            error:&error];
     XCTAssertNotNil(body, @"Error: %@, test: %@", error, self.name);
 
-    // TODO: Find out what the version should we pass and test.
-    XCTAssertEqualObjects(body, @{@"installation" : @{@"sdkVersion" : @"0.1.0"}}, @"%@", self.name);
+    XCTAssertEqualObjects(body,
+                          @{@"installation" : @{@"sdkVersion" : [self SDKVersion]}}, @"%@",
+                          self.name);
 
     return YES;
   }];
@@ -467,6 +469,12 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
 
     return YES;
   }];
+}
+
+#pragma mark - Helpers
+
+- (NSString *)SDKVersion {
+  return [NSString stringWithUTF8String:FIRInstallationsVersionStr];
 }
 
 @end

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
@@ -86,7 +86,7 @@
 }
 
 - (void)testDefaultInstallationWhenNoDefaultAppThenIsNil {
-  XCTAssertNil([FIRInstallations installations]);
+  XCTAssertThrows([FIRInstallations installations]);
 }
 
 - (void)testInstallationIDSuccess {


### PR DESCRIPTION
This is the first part of the error related changes. I am breaking the changes into parts to simplify the review:
- make sure all errors reported by SDK are in `FirebaseInstallationsErrorDomain` domain.
- retry Auth Token request on HTTP 500
- send proper `sdkVersion` to the server