### PR TITLE
GULMutableDictionary: use `dispatch_sync` instead of `async`.

### DIFF
--- a/GoogleUtilities/Network/GULMutableDictionary.m
+++ b/GoogleUtilities/Network/GULMutableDictionary.m
@@ -51,19 +51,19 @@
 }
 
 - (void)setObject:(id)object forKey:(id<NSCopying>)key {
-  dispatch_async(_queue, ^{
+  dispatch_sync(_queue, ^{
     self->_objects[key] = object;
   });
 }
 
 - (void)removeObjectForKey:(id)key {
-  dispatch_async(_queue, ^{
+  dispatch_sync(_queue, ^{
     [self->_objects removeObjectForKey:key];
   });
 }
 
 - (void)removeAllObjects {
-  dispatch_async(_queue, ^{
+  dispatch_sync(_queue, ^{
     [self->_objects removeAllObjects];
   });
 }


### PR DESCRIPTION
Fixes one of the issues revealed by the crash #3183.

Motivation:
When a mutable dictionary adds or removes an object it accesses the object to call methods like `hash` and `isEqual:`, also, removing the object from the dict may trigger the object deallocation. `GULMutableDictionary` performs these operations on a background thread, which put an **implicit** requirement on the object methods implementations to be thread-safe (see [the crash](https://github.com/firebase/firebase-ios-sdk/issues/3183#issuecomment-507860199) description caused by a not thread-safe `GULObjectSwizzler` stored in `GULMutableDictionary`) . This thread-safety requirement limits the usage of `GULMutableDictionary`,  and does not look like an intended thing. 

This PR fixes it by replacing  `dispatch_async` by `dispatch_sync` to synchronize the caller and the `GULMutableDictionary` internal threads.