### PR TITLE
A temporary PR to investigate InAppMessaging build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -451,3 +451,4 @@ jobs:
 branches:
   only:
     - master
+    - mph-master

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -102,6 +102,8 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     gem install xcpretty
     bundle exec pod install --project-directory=InAppMessagingDisplay/Example --repo-update
     bundle exec pod install --project-directory=InAppMessaging/Example --repo-update
+    echo "InAppMessaging Podfile.lock"
+    cat InAppMessaging/Example/Podfile.lock
     ;;
 
   Firestore-*-xcodebuild | Firestore-*-fuzz)


### PR DESCRIPTION
Related to #3129. 
- print `InAppMessaging/Example/Podfile.lock` to understand why `InAppMessaging` uses both old and new `CoreDiagnostics` on Travis