### PR TITLE
Stop calling deprecated sendLogsWithServiceName

### DIFF
--- a/Firebase/DynamicLinks/FIRDynamicLinks.m
+++ b/Firebase/DynamicLinks/FIRDynamicLinks.m
@@ -194,7 +194,6 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
                                                        reason:errorDescription];
   }
   if (error) {
-    [app sendLogsWithServiceName:kFIRServiceDynamicLinks version:kFIRDLVersion error:error];
     NSString *message = nil;
     if (options.usingOptionsFromDefaultPlist) {
       // Configured using plist file

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -697,13 +697,7 @@ static FIRInstanceID *gInstanceID;
                          userInfo:userInfo];
 }
 
-// If the firebaseApp is available we should send logs for the error through it before
-// raising an exception.
 + (void)exitWithReason:(nonnull NSString *)reason forFirebaseApp:(FIRApp *)firebaseApp {
-  [firebaseApp sendLogsWithServiceName:kFIRIIDServiceInstanceID
-                               version:FIRInstanceIDCurrentLibraryVersion()
-                                 error:[self configureErrorWithReason:reason]];
-
   [NSException raise:kFIRIIDErrorDomain
               format:@"Could not configure Firebase InstanceID. %@", reason];
 }


### PR DESCRIPTION
This is the open source part of b/137222285.

The implementation in FirebaseCore can be removed after the closed source part is done.