### PR TITLE
Manage configuration for benchmarks and fuzz tests and fix them

### DIFF
--- a/Firestore/Example/Benchmarks/FSTLevelDBBenchmarkTests.mm
+++ b/Firestore/Example/Benchmarks/FSTLevelDBBenchmarkTests.mm
@@ -60,12 +60,11 @@ std::string UpdatedDocumentData(int64_t documentSize) {
 
 FSTLevelDB *LevelDBPersistence() {
   DatabaseId db_id("p", "d");
-  Path path = util::TempDir().AppendUtf8("FSTLevelDBBenchmarkTests");
+  auto remoteSerializer = [[FSTSerializerBeta alloc] initWithDatabaseID:db_id];
+  auto serializer = [[FSTLocalSerializer alloc] initWithRemoteSerializer:remoteSerializer];
 
-  FSTSerializerBeta *remoteSerializer = [[FSTSerializerBeta alloc] initWithDatabaseID:db_id];
-  FSTLocalSerializer *serializer =
-      [[FSTLocalSerializer alloc] initWithRemoteSerializer:remoteSerializer];
   FSTLevelDB *db;
+  Path path = util::TempDir().AppendUtf8("FSTLevelDBBenchmarkTests");
   util::Status status = [FSTLevelDB dbWithDirectory:std::move(path)
                                          serializer:serializer
                                           lruParams:local::LruParams::Disabled()

--- a/Firestore/Example/Benchmarks/FSTLevelDBBenchmarkTests.mm
+++ b/Firestore/Example/Benchmarks/FSTLevelDBBenchmarkTests.mm
@@ -27,11 +27,15 @@
 #include "Firestore/core/src/firebase/firestore/local/leveldb_transaction.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/types.h"
+#include "Firestore/core/src/firebase/firestore/util/filesystem.h"
+#include "Firestore/core/src/firebase/firestore/util/path.h"
 #include "Firestore/core/src/firebase/firestore/util/string_format.h"
 #include "benchmark/benchmark.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+namespace util = firebase::firestore::util;
+using firebase::firestore::local::LevelDbDocumentTargetKey;
 using firebase::firestore::local::LevelDbRemoteDocumentKey;
 using firebase::firestore::local::LevelDbTargetDocumentKey;
 using firebase::firestore::local::LevelDbTransaction;
@@ -39,6 +43,7 @@ using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::DocumentKey;
 using firebase::firestore::model::TargetId;
 using firebase::firestore::util::StringFormat;
+using firebase::firestore::util::Path;
 
 namespace {
 
@@ -53,33 +58,21 @@ std::string UpdatedDocumentData(int64_t documentSize) {
   return std::string(documentSize, 'b');
 }
 
-NSString *LevelDBDir() {
-  NSFileManager *files = [NSFileManager defaultManager];
-  NSString *dir =
-      [NSTemporaryDirectory() stringByAppendingPathComponent:@"FSTPersistenceTestHelpers"];
-  if ([files fileExistsAtPath:dir]) {
-    // Delete the directory first to ensure isolation between runs.
-    NSError *error;
-    BOOL success = [files removeItemAtPath:dir error:&error];
-    if (!success) {
-      [NSException raise:NSInternalInconsistencyException
-                  format:@"Failed to clean up leveldb path %@: %@", dir, error];
-    }
-  }
-  return dir;
-}
-
 FSTLevelDB *LevelDBPersistence() {
-  NSString *dir = LevelDBDir();
-  auto remoteSerializer = [[FSTSerializerBeta alloc] initWithDatabaseID:DatabaseId("p", "d")];
-  auto serializer = [[FSTLocalSerializer alloc] initWithRemoteSerializer:remoteSerializer];
-  auto db = [[FSTLevelDB alloc] initWithDirectory:dir serializer:serializer];
+  DatabaseId db_id("p", "d");
+  Path path = util::TempDir().AppendUtf8("FSTLevelDBBenchmarkTests");
 
-  NSError *error;
-  BOOL success = [db start:&error];
-  if (!success) {
+  FSTSerializerBeta *remoteSerializer = [[FSTSerializerBeta alloc] initWithDatabaseID:db_id];
+  FSTLocalSerializer *serializer =
+      [[FSTLocalSerializer alloc] initWithRemoteSerializer:remoteSerializer];
+  FSTLevelDB *db;
+  util::Status status = [FSTLevelDB dbWithDirectory:std::move(path)
+                                         serializer:serializer
+                                          lruParams:local::LruParams::Disabled()
+                                                ptr:&db];
+  if (!status.ok()) {
     [NSException raise:NSInternalInconsistencyException
-                format:@"Failed to create leveldb path %@: %@", dir, error];
+                format:@"Failed to open DB: %s", status.ToString().c_str()];
   }
 
   return db;
@@ -94,6 +87,7 @@ class LevelDBFixture : public benchmark::Fixture {
   }
 
   void TearDown(benchmark::State &state) override {
+    [db_ shutdown];
     db_ = nil;
   }
 
@@ -133,7 +127,7 @@ BENCHMARK_DEFINE_F(LevelDBFixture, RemoteEvent)(benchmark::State &state) {  // N
   int64_t documentSize = state.range(1);
   int64_t docsToUpdate = state.range(2);
   std::string documentUpdate = UpdatedDocumentData(documentSize);
-  for (const auto &_ : state) {
+  for (auto _ : state) {
     LevelDbTransaction txn(db_.ptr, "benchmark");
     for (int i = 0; i < docsToUpdate; i++) {
       auto docKey = DocumentKey::FromPathString(StringFormat("docs/doc_%i", i));

--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -4107,55 +4107,8 @@
 				DEVELOPMENT_TEAM = EQHXZ8M8AV;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"COCOAPODS=1",
-					"GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1",
-				);
-				INFOPLIST_FILE = Benchmarks/Info.plist;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/GoogleTest/GoogleTest.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/OCMock/OCMock.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/ProtobufCpp/ProtobufCpp.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/leveldb-library/leveldb.framework/Headers\"",
-					"$(inherited)",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/BoringSSL/openssl.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/FirebaseAuth/FirebaseAuth.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/FirebaseCore/FirebaseCore.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/FirebaseFirestore/FirebaseFirestore.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/GoogleToolboxForMac/GoogleToolboxForMac.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/Protobuf/Protobuf.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/leveldb-library/leveldb.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/nanopb/nanopb.framework/Headers\"",
-					"-isystem",
-					"\"${PODS_ROOT}/Headers/Public\"",
-					"-isystem",
-					"\"${PODS_ROOT}/Headers/Public/Firebase\"",
-					"-isystem",
-					"\"${PODS_ROOT}/Headers/Public/FirebaseAnalytics\"",
-					"-isystem",
-					"\"${PODS_ROOT}/Headers/Public/FirebaseInstanceID\"",
-					"-DPB_FIELD_32BIT",
-					"-DPB_NO_PACKED_STRUCTS=1",
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = "Firebase.Firestore-Benchmarks-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYSTEM_HEADER_SEARCH_PATHS = "\"${PODS_ROOT}/nanopb\"";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Firestore_Example_iOS.app/Firestore_Example_iOS";
 			};
 			name = Debug;
@@ -4168,55 +4121,8 @@
 				DEVELOPMENT_TEAM = EQHXZ8M8AV;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"COCOAPODS=1",
-					"GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1",
-				);
-				INFOPLIST_FILE = Benchmarks/Info.plist;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/GoogleTest/GoogleTest.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/OCMock/OCMock.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/ProtobufCpp/ProtobufCpp.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/leveldb-library/leveldb.framework/Headers\"",
-					"$(inherited)",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/BoringSSL/openssl.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/FirebaseAuth/FirebaseAuth.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/FirebaseCore/FirebaseCore.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/FirebaseFirestore/FirebaseFirestore.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/GoogleToolboxForMac/GoogleToolboxForMac.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/Protobuf/Protobuf.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/leveldb-library/leveldb.framework/Headers\"",
-					"-iquote",
-					"\"${PODS_CONFIGURATION_BUILD_DIR}/nanopb/nanopb.framework/Headers\"",
-					"-isystem",
-					"\"${PODS_ROOT}/Headers/Public\"",
-					"-isystem",
-					"\"${PODS_ROOT}/Headers/Public/Firebase\"",
-					"-isystem",
-					"\"${PODS_ROOT}/Headers/Public/FirebaseAnalytics\"",
-					"-isystem",
-					"\"${PODS_ROOT}/Headers/Public/FirebaseInstanceID\"",
-					"-DPB_FIELD_32BIT",
-					"-DPB_NO_PACKED_STRUCTS=1",
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = "Firebase.Firestore-Benchmarks-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SYSTEM_HEADER_SEARCH_PATHS = "\"${PODS_ROOT}/nanopb\"";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Firestore_Example_iOS.app/Firestore_Example_iOS";
 			};
 			name = Release;
@@ -4501,16 +4407,6 @@
 				DEVELOPMENT_TEAM = EQHXZ8M8AV;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"COCOAPODS=1",
-					"GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1",
-				);
-				INFOPLIST_FILE = "FuzzTests/Firestore_FuzzTests_iOS-Info.plist";
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-fsanitize-coverage=trace-pc-guard",
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Firestore_Example_iOS.app/Firestore_Example_iOS";
@@ -4526,16 +4422,6 @@
 				DEVELOPMENT_TEAM = EQHXZ8M8AV;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"COCOAPODS=1",
-					"GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1",
-				);
-				INFOPLIST_FILE = "FuzzTests/Firestore_FuzzTests_iOS-Info.plist";
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-fsanitize-coverage=trace-pc-guard",
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Firestore_Example_iOS.app/Firestore_Example_iOS";

--- a/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_Benchmarks_iOS.xcscheme
+++ b/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_Benchmarks_iOS.xcscheme
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6003F589195388D20070C39A"
+               BuildableName = "Firestore_Example_iOS.app"
+               BlueprintName = "Firestore_Example_iOS"
+               ReferencedContainer = "container:Firestore.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5CAE131820FFFED600BE9A4A"
+               BuildableName = "Firestore_Benchmarks_iOS.xctest"
+               BlueprintName = "Firestore_Benchmarks_iOS"
+               ReferencedContainer = "container:Firestore.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5CAE131820FFFED600BE9A4A"
+               BuildableName = "Firestore_Benchmarks_iOS.xctest"
+               BlueprintName = "Firestore_Benchmarks_iOS"
+               ReferencedContainer = "container:Firestore.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5CAE131820FFFED600BE9A4A"
+            BuildableName = "Firestore_Benchmarks_iOS.xctest"
+            BlueprintName = "Firestore_Benchmarks_iOS"
+            ReferencedContainer = "container:Firestore.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5CAE131820FFFED600BE9A4A"
+            BuildableName = "Firestore_Benchmarks_iOS.xctest"
+            BlueprintName = "Firestore_Benchmarks_iOS"
+            ReferencedContainer = "container:Firestore.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5CAE131820FFFED600BE9A4A"
+            BuildableName = "Firestore_Benchmarks_iOS.xctest"
+            BlueprintName = "Firestore_Benchmarks_iOS"
+            ReferencedContainer = "container:Firestore.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -65,7 +65,7 @@ target 'Firestore_Example_iOS' do
     inherit! :search_paths
     platform :ios, '9.0'
 
-    pod 'LibFuzzer', :podspec => 'LibFuzzer.podspec'
+    pod 'LibFuzzer', :podspec => 'LibFuzzer.podspec', :inhibit_warnings => true
     pod '!ProtoCompiler'
   end
 end

--- a/scripts/sync_project.rb
+++ b/scripts/sync_project.rb
@@ -199,7 +199,7 @@ def sync_firestore(test_only)
         'INFOPLIST_FILE' =>
             '${SRCROOT}/FuzzTests/Firestore_FuzzTests_iOS-Info.plist',
         'OTHER_CFLAGS' => [
-            '-fsanitize-coverage=trace-pc-guard',
+            '-fsanitize=fuzzer',
         ]
       }
 

--- a/scripts/sync_project.rb
+++ b/scripts/sync_project.rb
@@ -188,6 +188,23 @@ def sync_firestore(test_only)
       t.xcconfig = xcconfig_objc + xcconfig_swift
     end
 
+    s.target 'Firestore_Benchmarks_iOS' do |t|
+      t.xcconfig = xcconfig_objc + {
+        'INFOPLIST_FILE' => '${SRCROOT}/Benchmarks/Info.plist',
+      }
+    end
+
+    s.target 'Firestore_FuzzTests_iOS' do |t|
+      t.xcconfig = xcconfig_objc + {
+        'INFOPLIST_FILE' =>
+            '${SRCROOT}/FuzzTests/Firestore_FuzzTests_iOS-Info.plist',
+        'OTHER_CFLAGS' => [
+            '-fsanitize-coverage=trace-pc-guard',
+        ]
+      }
+
+    end
+
     s.target 'Firestore_SwiftTests_iOS' do |t|
       t.xcconfig = xcconfig_objc + xcconfig_swift
     end


### PR DESCRIPTION
This change:

  * Makes it possible to build the benchmarks in Xcode (by adding a scheme)
  * Manages configuration for benchmarks and fuzz tests via `sync_project.rb`
  * Fixes the fuzz tests by passing `-fsanitize=fuzzer`. The old method of passing `-fsanitize-coverage=trace-pc-guard` is no longer supported by LibFuzzer.