### PR TITLE
Revert "GULMutableDictionary: use `dispatch_sync` instead of `async`."

### DIFF
--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleUtilities'
-  s.version          = '6.2.2'
+  s.version          = '6.2.3'
   s.summary          = 'Google Utilities for iOS (plus community support for macOS and tvOS)'
 
   s.description      = <<-DESC

--- a/GoogleUtilities/CHANGELOG.md
+++ b/GoogleUtilities/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 6.2.3
+- Revert "Fix `GULMutableDictionary` thread-safety." (#3322)
+
 # 6.2.2
 - Add explicit Foundation import for headers.
 - Fix headers import. (#3277)

--- a/GoogleUtilities/Network/GULMutableDictionary.m
+++ b/GoogleUtilities/Network/GULMutableDictionary.m
@@ -51,19 +51,19 @@
 }
 
 - (void)setObject:(id)object forKey:(id<NSCopying>)key {
-  dispatch_sync(_queue, ^{
+  dispatch_async(_queue, ^{
     self->_objects[key] = object;
   });
 }
 
 - (void)removeObjectForKey:(id)key {
-  dispatch_sync(_queue, ^{
+  dispatch_async(_queue, ^{
     [self->_objects removeObjectForKey:key];
   });
 }
 
 - (void)removeAllObjects {
-  dispatch_sync(_queue, ^{
+  dispatch_async(_queue, ^{
     [self->_objects removeAllObjects];
   });
 }


### PR DESCRIPTION
Reverts firebase/firebase-ios-sdk#3322

Reverting it so far to better validate impact on Analytics first.