### PR TITLE
Fix unaccessible init in FDL tests.

### DIFF
--- a/Example/DynamicLinks/Tests/FIRDynamicLinksTest.m
+++ b/Example/DynamicLinks/Tests/FIRDynamicLinksTest.m
@@ -90,7 +90,8 @@ typedef NSURL * (^FakeShortLinkResolverHandler)(NSURL *shortLink);
 }
 
 + (instancetype)resolverWithBlock:(FakeShortLinkResolverHandler)resolverHandler {
-  FakeShortLinkResolver *resolver = [[self alloc] init];
+  // The parameters don't matter since they aren't validated or used here.
+  FakeShortLinkResolver *resolver = [[self alloc] initWithAPIKey:@"" clientID:@"" URLScheme:@""];
   resolver->_resolverHandler = [resolverHandler copy];
   return resolver;
 }


### PR DESCRIPTION
This causes a breakage with internal tests.