### PR TITLE
Handle coverage flakiness more locally

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -183,7 +183,7 @@ case "$product-$method-$platform" in
   Firebase-xcodebuild-*)
     # Coverage collection often cause retries to fail because of partial
     # pre-existing data.
-    # TODO: Find a less blunt solution to this.
+    # TODO(paulb777): Find a less blunt solution to this.
     rm -rf ~/Library/Developer/Xcode/DerivedData
 
     RunXcodebuild \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -179,11 +179,13 @@ if [[ -n "${SANITIZERS:-}" ]]; then
   done
 fi
 
-# Clean the Derived Data between builds to help reduce flakiness.
-rm -rf ~/Library/Developer/Xcode/DerivedData
-
 case "$product-$method-$platform" in
   Firebase-xcodebuild-*)
+    # Coverage collection often cause retries to fail because of partial
+    # pre-existing data.
+    # TODO: Find a less blunt solution to this.
+    rm -rf ~/Library/Developer/Xcode/DerivedData
+
     RunXcodebuild \
         -workspace 'Example/Firebase.xcworkspace' \
         -scheme "AllUnitTests_$platform" \


### PR DESCRIPTION
Removing DerivedData can be costly, especially on Firestore build retries.

Since this is only known to help flakes related to coverage data collection, this PR moves the `rm` to the only place we're currently collection coverage.