### PR TITLE
Restore Database integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseDatabase.podspec --use-libraries --skip-tests
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseDatabase.podspec --use-modular-headers --skip-tests
 
+    - stage: test
       env:
         - PROJECT=DynamicLinks PLATFORM=all METHOD=pod-lib-lint
       before_install:


### PR DESCRIPTION
The database travis stage stopped running after a typo from #3115.  

The unit tests have continued to run from the deprecated xcodeproject test, but not the integration tests.

This PR restores the stage.