### PR TITLE
Disable incremental installation

### DIFF
--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -11,7 +11,6 @@ use_frameworks!
 
 install! 'cocoapods',
     :generate_multiple_pod_projects => true,
-    :incremental_installation => true,
     # Disable input/output path checking for generated frameworks to make
     # incremental builds work properly. Without this, changes to the framework
     # may not be picked up in between test runs.


### PR DESCRIPTION
This doesn't handle adding/removing files reliably when the version of
the pod doesn't change. That means incremental installation is
essentially not useful in combination with development pods.