### PR TITLE
Assert version is read successfully from LevelDB

### DIFF
--- a/Firestore/core/src/firebase/firestore/local/leveldb_migrations.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_migrations.cc
@@ -316,6 +316,7 @@ LevelDbMigrations::SchemaVersion LevelDbMigrations::ReadSchemaVersion(
   if (status.IsNotFound()) {
     return 0;
   } else {
+    HARD_ASSERT(status.ok(), "Failed to read version string from LevelDB, error: '%s'", status.ToString());
     return stoi(version_string);
   }
 }

--- a/Firestore/core/src/firebase/firestore/local/leveldb_migrations.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_migrations.cc
@@ -316,7 +316,9 @@ LevelDbMigrations::SchemaVersion LevelDbMigrations::ReadSchemaVersion(
   if (status.IsNotFound()) {
     return 0;
   } else {
-    HARD_ASSERT(status.ok(), "Failed to read version string from LevelDB, error: '%s'", status.ToString());
+    HARD_ASSERT(status.ok(),
+                "Failed to read version string from LevelDB, error: '%s'",
+                status.ToString());
     return stoi(version_string);
   }
 }


### PR DESCRIPTION
This is just to make the failure more obvious (otherwise, the call to `std::stoi` fails).