### PR TITLE
Upgrade to Firestore Emulator 1.6.2

### DIFF
--- a/scripts/run_firestore_emulator.sh
+++ b/scripts/run_firestore_emulator.sh
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-VERSION='1.6.1'
+VERSION='1.6.2'
 FILENAME="cloud-firestore-emulator-v${VERSION}.jar"
 URL="https://storage.googleapis.com/firebase-preview-drop/emulator/${FILENAME}"
 


### PR DESCRIPTION
This just brings us up-to-date without any functional changes as far as
the SDK is concerned.