### PR TITLE
Add a release notes generator

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -5,13 +5,13 @@
   that previously had not matched but had been updated to now match the query
   (https://github.com/firebase/firebase-android-sdk/issues/155).
 - [fixed] Fixed an internal assertion that was triggered when an update
-   with a `FieldValue.serverTimestamp()` and an update with a
+  with a `FieldValue.serverTimestamp()` and an update with a
   `FieldValue.increment()` were pending for the same document.
 - [fixed] Fixed the `oldIndex` and `newIndex` values in `DocumentChange` to
   actually be `NSNotFound` when documents are added or removed, respectively
   (#3298).
 - [changed] Failed transactions now return the failure from the last attempt,
-  instead of `ABORTED.`
+  instead of `ABORTED`.
 
 # 1.4.1
 - [fixed] Fixed certificate loading for non-CocoaPods builds that may not

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 1.4.2
+# v1.4.2
 - [fixed] Fixed an issue where query results were temporarily missing documents
   that previously had not matched but had been updated to now match the query
   (https://github.com/firebase/firebase-android-sdk/issues/155).
@@ -13,16 +13,16 @@
 - [changed] Failed transactions now return the failure from the last attempt,
   instead of `ABORTED`.
 
-# 1.4.1
+# v1.4.1
 - [fixed] Fixed certificate loading for non-CocoaPods builds that may not
   include bundle identifiers in their frameworks or apps (#3184).
 
-# 1.4.0
+# v1.4.0
 - [feature] Added `clearPersistence()`, which clears the persistent storage
   including pending writes and cached documents. This is intended to help
   write reliable tests (https://github.com/firebase/firebase-js-sdk/issues/449).
 
-# 1.3.2
+# v1.3.2
 - [fixed] Firestore should now recover its connection to the server more
   quickly after being on a network suffering from total packet loss (#2987).
 - [fixed] Changed gRPC-C++ dependency to 0.0.9 which adds support for using it
@@ -30,7 +30,7 @@
   errors you might encounter when trying to use Firestore and other Google
   Cloud Objective-C APIs in the same project.
 
-# 1.3.1
+# v1.3.1
 - [fixed] Disabling garbage collection now avoids even scheduling the
   collection process. This can be used to prevent crashes in the background when
   using `NSFileProtectionComplete`. Note that Firestore does not support
@@ -38,20 +38,20 @@
   protection is enabled. This change just prevents a crash when Firestore is
   idle (#2846).
 
-# 1.3.0
+# v1.3.0
 - [feature] You can now query across all collections in your database with a
   given collection ID using the `Firestore.collectionGroup()` method.
 - [feature] Added community support for tvOS.
 
-# 1.2.1
+# v1.2.1
 - [fixed] Fixed a use-after-free bug that could be observed when using snapshot
   listeners on temporary document references (#2682).
 
-# 1.2.0
+# v1.2.0
 - [feature] Added community support for macOS (#434).
 - [fixed] Fixed the way gRPC certificates are loaded on macOS (#2604).
 
-# 1.1.0
+# v1.1.0
 - [feature] Added `FieldValue.increment()`, which can be used in
   `updateData(_:)` and `setData(_:merge:)` to increment or decrement numeric
   field values safely without transactions.

--- a/scripts/make_release_notes.py
+++ b/scripts/make_release_notes.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Converts github flavored markdown changelogs to release notes.
+"""
+
+import argparse
+import mistune
+import re
+import subprocess
+import textwrap
+
+from pprint import pprint as pp
+
+
+def main():
+  local_repo = find_local_repo()
+
+  parser = argparse.ArgumentParser(description='Create release notes.')
+  parser.add_argument('--repo', '-r', default=local_repo,
+                      help='Specify which GitHub repo is local.')
+  parser.add_argument('changelog',
+                      help='The CHANGELOG.md file to parse')
+  args = parser.parse_args()
+
+  renderer = Renderer(args.repo)
+
+  inline = ChangelogInlineLexer(renderer)
+  inline.enable_changelog()
+
+  md = mistune.Markdown(renderer=renderer, inline=inline)
+  process_changelog(md, args.changelog)
+
+
+def find_local_repo():
+  url = subprocess.check_output(['git', 'config', '--get', 'remote.origin.url'])
+
+  # ssh style URL
+  m = re.match(r'^git@github.com:(.*)\.git$', url)
+  if m:
+    return m.group(1)
+
+  # https style URL
+  m = re.match(r'^https://github.com/(.*).git$')
+  if m:
+    return m.group(1)
+
+  raise LookupError('Can\'t figure local repo from remote URL %s' % url)
+
+
+class ChangelogInlineLexer(mistune.InlineLexer):
+  """Recognizes certain additional patterns within the changelog.
+
+  This extends Mistune's lexer for inline elements (those within a block) to add
+  the following lexical elements:
+
+    - support for change-type tags "[fixed]", "[changed]", etc.
+    - support for expanding short issue references "(#2987)".
+
+  These are translated to the equivalent form for docsite.
+  """
+
+  def enable_changelog(self):
+    self.rules.change_type = re.compile(
+        r'\['           # opening square bracket
+        r'(\w+)'        # tag word (like "feature" or "changed"
+        r'\]'           # closing square bracket
+        r'(?!\()'       # not followed by opening paren (that would be a link)
+    )
+    self.default_rules.insert(0, 'change_type')
+
+    self.rules.issue_link = re.compile(
+        r'\('           # opening paren
+        r'(#\d+)'       # hash and issue number
+        r'\)'           # closing paren
+    )
+    self.default_rules.insert(0, 'issue_link')
+
+    # Adjust the text rule to stop at open parentheses so that the issue_link
+    # rule can trigger. Without this, issue_link would only match if it were the
+    # first thing on the line.
+    self.rules.text = re.compile(
+        r'^[\s\S]+?(?=[\(\\<!\[_*`~]|https?://| {2,}\n|$)'
+    )
+
+  def output_change_type(self, m):
+    """Translates change types like [fixed] into {{fixed}}."""
+    tag = m.group(1)
+    return self.renderer.change_type(tag)
+
+  def output_issue_link(self, m):
+    return (self.renderer.text('(') +
+            self.renderer.autolink(m.group(1), False) +
+            self.renderer.text(')'))
+
+
+class Renderer(mistune.Renderer):
+
+  def __init__(self, local_repo):
+    super(Renderer, self).__init__()
+    self.local_repo = local_repo
+
+  def header(self, text, level, raw=None):
+    return '%s %s\n' % ('#' * level, text)
+
+  def list(self, body, ordered=True):
+    if 'nested list' in body:
+      pp(body)
+    return '%s\n' % body
+
+  def list_item(self, text):
+    wrapper = textwrap.TextWrapper(
+        initial_indent='* ', subsequent_indent='  ', width=79,
+        break_long_words=False, break_on_hyphens=False)
+    text = wrapper.fill(text)
+
+    return '%s\n' % text
+
+  def paragraph(self, text):
+    return '%s\n\n' % text
+
+  def double_emphasis(self, text):
+    return '__%s__' % text
+
+  def emphasis(self, text):
+    return '_%s_' % text
+
+  def codespan(self, text):
+    return '`%s`' % text
+
+  def linebreak(self):
+    raise NotImplementedError('linebreak')
+
+  def text(self, text):
+    return text
+
+  def escape(self, text):
+    raise NotImplementedError('escape %s' % text)
+
+  def autolink(self, link, is_email=False):
+    return self.link(link, None, link)
+
+  def link(self, link, title, text):
+    link, text = self._adjust_link(link, text)
+    if title is not None:
+      link = '%s "%s"' % (link, title)
+    return '[%s](%s)' % (text, link)
+
+  def _adjust_link(self, link, text):
+    m = re.match(r'^(?:https:)?(//github.com/(.*)/issues/(\d+))$', link)
+    if m:
+      link = m.group(1)
+      repo = m.group(2)
+      issue = m.group(3)
+
+      if repo == self.local_repo:
+        text = '#' + issue
+      else:
+        text = repo + '#' + issue
+
+      return link, text
+
+    m = re.match(r'^#(\d+)$', link)
+    if m:
+      issue = m.group(1)
+      link = '//github.com/%s/issues/%s' % (self.local_repo, issue)
+      return link, text
+
+    return link, text
+
+  def newline(self):
+    return '\n'
+
+  def change_type(self, tag):
+    """Renders a change type in double curly braces.
+
+    Renders [fixed] as {{fixed}}.
+    """
+    return '{{%s}}' % tag
+
+
+def process_changelog(md, filename):
+  with open(filename, 'r') as fd:
+    text = fd.read()
+    result = md(text)
+    print(result)
+
+
+def read_lines(filename):
+  with open(filename, 'r') as fd:
+    return [line.rstrip() for line in fd.readlines()]
+
+
+if __name__ == '__main__':
+  main()

--- a/scripts/make_release_notes.py
+++ b/scripts/make_release_notes.py
@@ -22,9 +22,12 @@ import re
 import subprocess
 
 
+NO_HEADING = 'PRODUCT HAS NO HEADING'
+
+
 PRODUCTS = {
     'Firebase/Auth/CHANGELOG.md': '{{auth}}',
-    'Firebase/Core/CHANGELOG.md': '{{core}}',
+    'Firebase/Core/CHANGELOG.md': NO_HEADING,
     'Firebase/Database/CHANGELOG.md': '{{database}}',
     'Firebase/DynamicLinks/CHANGELOG.md': '{{ddls}}',
     'Firebase/InAppMessaging/CHANGELOG.md': '{{inapp_messaging}}',
@@ -34,12 +37,9 @@ PRODUCTS = {
     'Firestore/CHANGELOG.md': '{{firestore}}',
     'Functions/CHANGELOG.md': '{{cloud_functions}}',
 
-    # 'Firebase/CoreDiagnostics/CHANGELOG.md': '?',
     # 'Firebase/InAppMessagingDisplay/CHANGELOG.md': '?',
     # 'GoogleDataTransport/CHANGELOG.md': '?',
     # 'GoogleDataTransportCCTSupport/CHANGELOG.md': '?',
-    # 'GoogleUtilities/CHANGELOG.md': '?',
-    # 'Interop/CoreDiagnostics/CHANGELOG.md': '?',
 }
 
 
@@ -84,6 +84,11 @@ def find_local_repo():
   raise LookupError('Can\'t figure local repo from remote URL %s' % url)
 
 
+CHANGE_TYPE_MAPPING = {
+    'added': 'feature'
+}
+
+
 class Renderer(object):
 
   def __init__(self, local_repo, product):
@@ -92,7 +97,10 @@ class Renderer(object):
 
   def heading(self, heading):
     if self.product:
-      return '### %s\n' % self.product
+      if self.product == NO_HEADING:
+        return ''
+      else:
+        return '### %s\n' % self.product
 
     return heading
 
@@ -108,6 +116,7 @@ class Renderer(object):
 
     That is "[fixed]" is rendered as "{{fixed}}".
     """
+    tag = CHANGE_TYPE_MAPPING.get(tag, tag)
     return '{{%s}}' % tag
 
   def url(self, url):

--- a/scripts/make_release_notes.py
+++ b/scripts/make_release_notes.py
@@ -23,23 +23,23 @@ import subprocess
 
 
 PRODUCTS = {
-  'Firebase/Auth/CHANGELOG.md': '{{auth}}',
-  'Firebase/Core/CHANGELOG.md': '{{core}}',
-  'Firebase/Database/CHANGELOG.md': '{{database}}',
-  'Firebase/DynamicLinks/CHANGELOG.md': '{{ddls}}',
-  'Firebase/InAppMessaging/CHANGELOG.md': '{{inapp_messaging}}',
-  'Firebase/InstanceID/CHANGELOG.md': 'InstanceID',
-  'Firebase/Messaging/CHANGELOG.md': '{{messaging}}',
-  'Firebase/Storage/CHANGELOG.md': '{{storage}}',
-  'Firestore/CHANGELOG.md': '{{firestore}}',
-  'Functions/CHANGELOG.md': '{{cloud_functions}}',
+    'Firebase/Auth/CHANGELOG.md': '{{auth}}',
+    'Firebase/Core/CHANGELOG.md': '{{core}}',
+    'Firebase/Database/CHANGELOG.md': '{{database}}',
+    'Firebase/DynamicLinks/CHANGELOG.md': '{{ddls}}',
+    'Firebase/InAppMessaging/CHANGELOG.md': '{{inapp_messaging}}',
+    'Firebase/InstanceID/CHANGELOG.md': 'InstanceID',
+    'Firebase/Messaging/CHANGELOG.md': '{{messaging}}',
+    'Firebase/Storage/CHANGELOG.md': '{{storage}}',
+    'Firestore/CHANGELOG.md': '{{firestore}}',
+    'Functions/CHANGELOG.md': '{{cloud_functions}}',
 
-  # 'Firebase/CoreDiagnostics/CHANGELOG.md': '?',
-  # 'Firebase/InAppMessagingDisplay/CHANGELOG.md': '?',
-  # 'GoogleDataTransport/CHANGELOG.md': '?',
-  # 'GoogleDataTransportCCTSupport/CHANGELOG.md': '?',
-  # 'GoogleUtilities/CHANGELOG.md': '?',
-  # 'Interop/CoreDiagnostics/CHANGELOG.md': '?',
+    # 'Firebase/CoreDiagnostics/CHANGELOG.md': '?',
+    # 'Firebase/InAppMessagingDisplay/CHANGELOG.md': '?',
+    # 'GoogleDataTransport/CHANGELOG.md': '?',
+    # 'GoogleDataTransportCCTSupport/CHANGELOG.md': '?',
+    # 'GoogleUtilities/CHANGELOG.md': '?',
+    # 'Interop/CoreDiagnostics/CHANGELOG.md': '?',
 }
 
 
@@ -207,7 +207,9 @@ class Translator(object):
   def parse_text(self, m):
     return self.renderer.text(m.group(0))
 
-  rules = ['heading', 'bullet', 'change_type', 'url', 'local_issue_link', 'text']
+  rules = [
+      'heading', 'bullet', 'change_type', 'url', 'local_issue_link', 'text'
+  ]
 
 
 def read_file(filename):


### PR DESCRIPTION
Translates from CHANGELOG markdown to release notes markdown.

`scripts/make_release_notes.py Firestore/CHANGELOG.md` generates exactly what @morganchen12 manually put together in the latest release note snippet.