### PR TITLE
Make sure all move operations are marked noexcept

### DIFF
--- a/Firestore/core/src/firebase/firestore/immutable/sorted_map_iterator.h
+++ b/Firestore/core/src/firebase/firestore/immutable/sorted_map_iterator.h
@@ -60,7 +60,7 @@ class SortedMapIterator {
     }
   }
 
-  SortedMapIterator(SortedMapIterator&& other) : tag_(other.tag_) {
+  SortedMapIterator(SortedMapIterator&& other) noexcept : tag_(other.tag_) {
     switch (tag_) {
       case Tag::Array:
         new (&array_iter_) ArrayIter{std::move(other.array_iter_)};
@@ -99,7 +99,7 @@ class SortedMapIterator {
     return *this;
   }
 
-  SortedMapIterator& operator=(SortedMapIterator&& other) {
+  SortedMapIterator& operator=(SortedMapIterator&& other) noexcept {
     if (tag_ == other.tag_) {
       switch (tag_) {
         case Tag::Array:

--- a/Firestore/core/src/firebase/firestore/util/statusor_internals.h
+++ b/Firestore/core/src/firebase/firestore/util/statusor_internals.h
@@ -118,7 +118,7 @@ class StatusOrData {
     return *this;
   }
 
-  StatusOrData& operator=(StatusOrData&& other) {
+  StatusOrData& operator=(StatusOrData&& other) noexcept {
     if (this == &other) return *this;
     if (other.ok())
       Assign(std::move(other.data_));


### PR DESCRIPTION
Added a couple of missing `noexcept` specifiers. While it probably won't affect performance much, it certainly won't hurt.