### PR TITLE
pod_lib_lint.rb - argument to ignore specified local podspecs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -403,11 +403,13 @@ jobs:
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --platforms=ios,tvos
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --platforms=macos --allow-warnings # TODO: Fix FBLPromises warnings for macOS.
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --use-libraries
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --use-modular-headers --platforms=ios,tvos
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --use-modular-headers --platforms=macos --allow-warnings # TODO: Fix FBLPromises warnings for macOS.
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --platforms=ios,tvos --ignore-local-specs=FirebaseInstanceID.podspec
+        # TODO: Fix FBLPromises warnings for macOS.
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --platforms=macos --allow-warnings --ignore-local-specs=FirebaseInstanceID.podspec
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --use-libraries --ignore-local-specs=FirebaseInstanceID.podspec
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --use-modular-headers --platforms=ios,tvos --ignore-local-specs=FirebaseInstanceID.podspec
+        # TODO: Fix FBLPromises warnings for macOS.
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --use-modular-headers --platforms=macos --allow-warnings --ignore-local-specs=FirebaseInstanceID.podspec
 
   allow_failures:
     # Run fuzz tests only on cron jobs.

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -33,7 +33,7 @@ def usage()
   script options:
     --ignore-local-podspecs: list of podspecs that should not be added to
       "--include-podspecs" list. If not specified, then all podspec
-      dependencies will be passed to "--include-podspecs."
+      dependencies will be passed to "--include-podspecs".
       Example: --ignore-local-podspecs=FirebaseInstanceID.podspec,GoogleDataTransport.podspec
   EOF
 end

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -52,10 +52,11 @@ def main(args)
   # to the pod command.
   script_args = {}
   pod_args = []
+  local_specs_to_ignore_arg = ""
   args.each do |arg|
     case arg
     when /--ignore-local-specs=*/
-      then script_args[:ignored_local_specs] = arg.split("=")[1]
+      then local_specs_to_ignore_arg = arg.split("=")[1]
     else
       pod_args.append arg
     end
@@ -63,7 +64,7 @@ def main(args)
 
   # Figure out which dependencies are local
   podspec_file = args[0]
-  local_specs_to_ignore = script_args[:ignored_local_specs].split(",")
+  local_specs_to_ignore = local_specs_to_ignore_arg.split(",")
   deps = find_local_deps(podspec_file, local_specs_to_ignore.to_set)
   arg = make_include_podspecs(deps)
   command.push(arg) if arg

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -61,7 +61,7 @@ def main(args)
   end
 
   # Figure out which dependencies are local
-  podspec_file = args[0]
+  podspec_file = pod_args[0]
   deps = find_local_deps(podspec_file, ignore_local_podspecs.to_set)
   arg = make_include_podspecs(deps)
   command.push(arg) if arg

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -31,10 +31,10 @@ def usage()
   options can be any options for pod spec lint
 
   script options:
-    --ignore-local-specs: list of podspecs that should not be added to
+    --ignore-local-podspecs: list of podspecs that should not be added to
       "--include-podspecs" list. If not specified, then all podspec
       dependencies will be passed to "--include-podspecs."
-      Example: --ignore-local-specs=FirebaseInstanceID.podspec,GoogleDataTransport.podspec
+      Example: --ignore-local-podspecs=FirebaseInstanceID.podspec,GoogleDataTransport.podspec
   EOF
 end
 
@@ -50,22 +50,19 @@ def main(args)
 
   # Split arguments that need to be processed by the script itself and passed
   # to the pod command.
-  script_args = {}
   pod_args = []
-  local_specs_to_ignore_arg = ""
+  ignore_local_podspecs = []
   args.each do |arg|
-    case arg
-    when /--ignore-local-specs=*/
-      then local_specs_to_ignore_arg = arg.split("=")[1]
+    if arg =~ /--ignore-local-podspecs=(.*)/
+      ignore_local_podspecs = $1.split(',')
     else
-      pod_args.append arg
+      pod_args.push(arg)
     end
   end
 
   # Figure out which dependencies are local
   podspec_file = args[0]
-  local_specs_to_ignore = local_specs_to_ignore_arg.split(",")
-  deps = find_local_deps(podspec_file, local_specs_to_ignore.to_set)
+  deps = find_local_deps(podspec_file, ignore_local_podspecs.to_set)
   arg = make_include_podspecs(deps)
   command.push(arg) if arg
 

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -32,7 +32,7 @@ def usage()
 
   script options:
     --ignore-local-specs: list of podspecs that should not be added to
-      "--include-podspecs" list. If not sepcified, then all podspec
+      "--include-podspecs" list. If not specified, then all podspec
       dependencies will be passed to "--include-podspecs."
       Example: --ignore-local-specs=FirebaseInstanceID.podspec,GoogleDataTransport.podspec
   EOF


### PR DESCRIPTION
The modification is required to support `FirebaseInstallations` tests which require a particular version of `FirebaseInstanceID` to test migration.
- `./scripts/pod_lib_lint.rb.`: a parameter `--ignore-local-specs` introduced to specify the local podspecs to be ignored (publicly available versions will be used instead).