### PR TITLE
pod_lib_lint.rb improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -403,13 +403,13 @@ jobs:
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --platforms=ios,tvos --ignore-local-specs=FirebaseInstanceID.podspec
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --platforms=ios,tvos --ignore-local-podspecs=FirebaseInstanceID.podspec
         # TODO: Fix FBLPromises warnings for macOS.
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --platforms=macos --allow-warnings --ignore-local-specs=FirebaseInstanceID.podspec
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --use-libraries --ignore-local-specs=FirebaseInstanceID.podspec
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --use-modular-headers --platforms=ios,tvos --ignore-local-specs=FirebaseInstanceID.podspec
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --platforms=macos --allow-warnings --ignore-local-podspecs=FirebaseInstanceID.podspec
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --use-libraries --ignore-local-podspecs=FirebaseInstanceID.podspec
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --use-modular-headers --platforms=ios,tvos --ignore-local-podspecs=FirebaseInstanceID.podspec
         # TODO: Fix FBLPromises warnings for macOS.
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --use-modular-headers --platforms=macos --allow-warnings --ignore-local-specs=FirebaseInstanceID.podspec
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --use-modular-headers --platforms=macos --allow-warnings --ignore-local-podspecs=FirebaseInstanceID.podspec
 
   allow_failures:
     # Run fuzz tests only on cron jobs.

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -70,8 +70,9 @@ def main(args)
   puts command.join(' ')
 
   # Run the lib lint command in a thread.
+  pod_lint_result = false
   t = Thread.new do
-    system(*command)
+    pod_lint_result = system(*command)
   end
 
   # Print every minute since linting can run for >10m without output.
@@ -83,6 +84,11 @@ def main(args)
       puts "Still working, running for #{number_of_times_checked / 60}min."
     end
   end
+
+  unless pod_lint_result == true
+    exit(1)
+  end
+
 end
 
 # Loads all the specs (inclusing subspecs) from the given podspec file.

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -74,9 +74,10 @@ def main(args)
   puts command.join(' ')
 
   # Run the lib lint command in a thread.
-  pod_lint_result = false
+  pod_lint_status = 1
   t = Thread.new do
-    pod_lint_result = system(*command)
+    system(*command)
+    pod_lint_status = $?
   end
 
   # Print every minute since linting can run for >10m without output.
@@ -89,10 +90,7 @@ def main(args)
     end
   end
 
-  unless pod_lint_result == true
-    exit(1)
-  end
-
+  exit(pod_lint_status.exitstatus)
 end
 
 # Loads all the specs (inclusing subspecs) from the given podspec file.

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -60,8 +60,12 @@ def main(args)
     end
   end
 
-  # Figure out which dependencies are local
   podspec_file = pod_args[0]
+  # Validating of the social URL can be very flaky (see #3416).
+  # Remove it from spec to let the acutual tests pass.
+  remove_social_url_from_podspec(podspec_file)
+
+  # Figure out which dependencies are local
   deps = find_local_deps(podspec_file, ignore_local_podspecs.to_set)
   arg = make_include_podspecs(deps)
   command.push(arg) if arg
@@ -166,6 +170,12 @@ def trace(*args)
   return if not $DEBUG
 
   STDERR.puts(args.join(' '))
+end
+
+def remove_social_url_from_podspec(spec)
+  podspec_content = File.read(spec)
+  updated_podspec_content = podspec_content.gsub("s.social_media_url = ", "# s.social_media_url = ")
+  File.open(spec, "w") { |file| file.puts updated_podspec_content }
 end
 
 main(ARGV)

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -62,7 +62,7 @@ def main(args)
 
   podspec_file = pod_args[0]
   # Validating of the social URL can be very flaky (see #3416).
-  # Remove it from spec to let the acutual tests pass.
+  # Remove it from spec to let the actual tests pass.
   remove_social_url_from_podspec(podspec_file)
 
   # Figure out which dependencies are local

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -74,7 +74,7 @@ def main(args)
   t = Thread.new do
     with_removed_social_media_url(podspec_file) do
       system(*command)
-      pod_lint_status = $?
+      pod_lint_status = $?.exitstatus
     end
   end
 
@@ -88,7 +88,7 @@ def main(args)
     end
   end
 
-  exit(pod_lint_status.exitstatus)
+  exit(pod_lint_status)
 end
 
 # Loads all the specs (inclusing subspecs) from the given podspec file.
@@ -174,7 +174,7 @@ end
 # pass.
 def with_removed_social_media_url(spec)
   podspec_content = File.read(spec)
-  updated_podspec_content = 
+  updated_podspec_content =
       podspec_content.gsub("s.social_media_url = ", "# s.social_media_url = ")
   write_file(spec, updated_podspec_content)
   yield

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -172,8 +172,11 @@ end
 
 def remove_social_url_from_podspec(spec)
   podspec_content = File.read(spec)
-  updated_podspec_content = podspec_content.gsub("s.social_media_url = ", "# s.social_media_url = ")
-  File.open(spec, "w") { |file| file.puts updated_podspec_content }
+  updated_podspec_content = 
+      podspec_content.gsub("s.social_media_url = ", "# s.social_media_url = ")
+  File.open(spec, "w") do |file|
+     file.write(updated_podspec_content)
+  end
 end
 
 main(ARGV)


### PR DESCRIPTION
Fixes #3416.

- comment out `social_media_url` in the linted podspec to fix #3416
- make sure the script fails if `pod lib lint` fails (converts silent failures like [this](https://travis-ci.org/firebase/firebase-ios-sdk/jobs/562678041) to visible failures like [this](https://travis-ci.org/firebase/firebase-ios-sdk/jobs/562705029))