### PR TITLE
Remove `=default`ed constructors resulting in deleted constructors.

### DIFF
--- a/Firestore/core/src/firebase/firestore/core/array_contains_filter.h
+++ b/Firestore/core/src/firebase/firestore/core/array_contains_filter.h
@@ -31,8 +31,6 @@ namespace core {
  */
 class ArrayContainsFilter : public FieldFilter {
  public:
-  ArrayContainsFilter() = default;
-
   ArrayContainsFilter(model::FieldPath field, model::FieldValue value);
 
   Type type() const override {

--- a/Firestore/core/src/firebase/firestore/core/key_field_filter.h
+++ b/Firestore/core/src/firebase/firestore/core/key_field_filter.h
@@ -30,8 +30,6 @@ namespace core {
  */
 class KeyFieldFilter : public FieldFilter {
  public:
-  KeyFieldFilter() = default;
-
   KeyFieldFilter(model::FieldPath field,
                  core::Filter::Operator op,
                  model::FieldValue value);


### PR DESCRIPTION
Some classes derived from `FieldFilter` declare a `=default` default
constructor. This actually makes the constructor deleted, because the
base class has no default constructor, resulting in a compilation
warning.