### PR TITLE
CoreDiagnostics: set missing flag `has_sdk_name` for heartbeats.

### DIFF
--- a/Example/CoreDiagnostics/Tests/FIRCoreDiagnosticsTest.m
+++ b/Example/CoreDiagnostics/Tests/FIRCoreDiagnosticsTest.m
@@ -328,6 +328,7 @@ extern void FIRPopulateProtoWithInfoPlistValues(
 
     BOOL isSentEventHeartbeat =
         dataObject.config.sdk_name == logs_proto_mobilesdk_ios_ICoreConfiguration_ServiceType_ICORE;
+    isSentEventHeartbeat &= dataObject.config.has_sdk_name;
     XCTAssertEqual(isSentEventHeartbeat, isHeartbeat);
 
     return YES;

--- a/Firebase/CoreDiagnostics/FIRCDLibrary/FIRCoreDiagnostics.m
+++ b/Firebase/CoreDiagnostics/FIRCDLibrary/FIRCoreDiagnostics.m
@@ -659,6 +659,7 @@ void FIRPopulateProtoWithInfoPlistValues(logs_proto_mobilesdk_ios_ICoreConfigura
 
   // Set the flag.
   config->sdk_name = logs_proto_mobilesdk_ios_ICoreConfiguration_ServiceType_ICORE;
+  config->has_sdk_name = true;
 }
 
 - (BOOL)isDate:(NSDate *)date1 inSameDayOrBeforeThan:(NSDate *)date2 {

--- a/Firebase/CoreDiagnostics/FIRCDLibrary/FIRCoreDiagnostics.m
+++ b/Firebase/CoreDiagnostics/FIRCDLibrary/FIRCoreDiagnostics.m
@@ -659,7 +659,7 @@ void FIRPopulateProtoWithInfoPlistValues(logs_proto_mobilesdk_ios_ICoreConfigura
 
   // Set the flag.
   config->sdk_name = logs_proto_mobilesdk_ios_ICoreConfiguration_ServiceType_ICORE;
-  config->has_sdk_name = true;
+  config->has_sdk_name = 1;
 }
 
 - (BOOL)isDate:(NSDate *)date1 inSameDayOrBeforeThan:(NSDate *)date2 {


### PR DESCRIPTION
Without `has_sdk_name == true` the field `sdk_name` is ignored.