### PR TITLE
CoreDiagnostics tests code style.

### DIFF
--- a/Example/CoreDiagnostics/Tests/FIRCoreDiagnosticsTest.m
+++ b/Example/CoreDiagnostics/Tests/FIRCoreDiagnosticsTest.m
@@ -328,7 +328,7 @@ extern void FIRPopulateProtoWithInfoPlistValues(
 
     BOOL isSentEventHeartbeat =
         dataObject.config.sdk_name == logs_proto_mobilesdk_ios_ICoreConfiguration_ServiceType_ICORE;
-    isSentEventHeartbeat &= dataObject.config.has_sdk_name;
+    isSentEventHeartbeat = isSentEventHeartbeat && dataObject.config.has_sdk_name;
     XCTAssertEqual(isSentEventHeartbeat, isHeartbeat);
 
     return YES;


### PR DESCRIPTION
- use boolean operation to calculate `isSentEventHeartbeat` (instead of a bitwise) - fixes the [comment](https://github.com/firebase/firebase-ios-sdk/pull/3422#discussion_r306943125)