### PR TITLE
Rename Query::Filter to Query::AddingFilter

### DIFF
--- a/Firestore/Source/Core/FSTQuery.mm
+++ b/Firestore/Source/Core/FSTQuery.mm
@@ -376,7 +376,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)queryByAddingFilter:(std::shared_ptr<Filter>)filter {
-  return [[FSTQuery alloc] initWithQuery:_query.Filter(std::move(filter))
+  return [[FSTQuery alloc] initWithQuery:_query.AddingFilter(std::move(filter))
                                  orderBy:self.explicitSortOrders
                                    limit:self.limit
                                  startAt:self.startAt

--- a/Firestore/core/src/firebase/firestore/core/query.cc
+++ b/Firestore/core/src/firebase/firestore/core/query.cc
@@ -84,7 +84,7 @@ bool Query::HasArrayContainsFilter() const {
 
 // MARK: - Builder methods
 
-Query Query::Filter(std::shared_ptr<core::Filter> filter) const {
+Query Query::AddingFilter(std::shared_ptr<Filter> filter) const {
   HARD_ASSERT(!IsDocumentQuery(), "No filter is allowed for document query");
 
   const FieldPath* new_inequality_field = nullptr;
@@ -124,7 +124,7 @@ bool Query::MatchesPath(const Document& doc) const {
 
 bool Query::MatchesFilters(const Document& doc) const {
   return std::all_of(filters_.begin(), filters_.end(),
-                     [&](const std::shared_ptr<core::Filter>& filter) {
+                     [&](const std::shared_ptr<Filter>& filter) {
                        return filter->Matches(doc);
                      });
 }

--- a/Firestore/core/src/firebase/firestore/core/query.h
+++ b/Firestore/core/src/firebase/firestore/core/query.h
@@ -38,7 +38,7 @@ namespace core {
  */
 class Query {
  public:
-  using FilterList = util::vector_of_ptr<std::shared_ptr<class Filter>>;
+  using FilterList = util::vector_of_ptr<std::shared_ptr<Filter>>;
 
   static constexpr int32_t kNoLimit = std::numeric_limits<int32_t>::max();
 
@@ -101,7 +101,7 @@ class Query {
   /**
    * Returns a copy of this Query object with the additional specified filter.
    */
-  Query Filter(std::shared_ptr<core::Filter> filter) const;
+  Query AddingFilter(std::shared_ptr<Filter> filter) const;
 
   // MARK: - Matching
 

--- a/Firestore/core/test/firebase/firestore/core/query_test.cc
+++ b/Firestore/core/test/firebase/firestore/core/query_test.cc
@@ -66,14 +66,16 @@ TEST(QueryTest, EmptyFieldsAreAllowedForQueries) {
   Document doc2 = *Doc("rooms/eros/messages/2");
 
   Query query = Query(Resource("rooms/eros/messages"))
-                    .Filter(Filter("text", "==", "msg1"));
+                    .AddingFilter(Filter("text", "==", "msg1"));
   EXPECT_TRUE(query.Matches(doc1));
   EXPECT_FALSE(query.Matches(doc2));
 }
 
 TEST(QueryTest, PrimitiveValueFilter) {
-  Query query1 = Query(Resource("collection")).Filter(Filter("sort", ">=", 2));
-  Query query2 = Query(Resource("collection")).Filter(Filter("sort", "<=", 2));
+  Query query1 =
+      Query(Resource("collection")).AddingFilter(Filter("sort", ">=", 2));
+  Query query2 =
+      Query(Resource("collection")).AddingFilter(Filter("sort", "<=", 2));
 
   Document doc1 =
       *Doc("collection/1", 0, {{"sort", FieldValue::FromInteger(1)}});
@@ -99,7 +101,8 @@ TEST(QueryTest, PrimitiveValueFilter) {
 }
 
 TEST(QueryTest, NanFilter) {
-  Query query = Query(Resource("collection")).Filter(Filter("sort", "==", NAN));
+  Query query =
+      Query(Resource("collection")).AddingFilter(Filter("sort", "==", NAN));
 
   Document doc1 = *Doc("collection/1", 0, {{"sort", FieldValue::Nan()}});
   Document doc2 =


### PR DESCRIPTION
This removes the ambiguity between the `Filter` class and the `Filter` method.

I'm not sure if there's a C++ convention for how to name methods that operate on an immutable object to produce a new, modified immutable object, but in Swift [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/#name-according-to-side-effects) produce this name and it reads pretty well. Of course there's a limit to how well Swift API guidelines can apply to C++ because C++ does not have argument labels, but this part seems to apply cleanly. Thoughts?