### PR TITLE
Use Travis to check that fuzz tests can build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -352,7 +352,7 @@ jobs:
 
     - stage: test
       env:
-        - PROJECT=FirestoreFuzzing PLATFORM=macOS METHOD=cmake
+        - PROJECT=Firestore PLATFORM=macOS METHOD=cmake2
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -350,6 +350,14 @@ jobs:
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
 
+    - stage: test
+      env:
+        - PROJECT=FirestoreFuzzing PLATFORM=macOS METHOD=cmake
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
+
     # Validate Cocoapods configurations
     # This may take long time, so we would like to run it only once all other tests pass
     # Validate Cocoapods 1.7.0 compatibility

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -27,6 +27,7 @@ USAGE: $0 product [platform] [method]
 product can be one of:
   Firebase
   Firestore
+  FirestoreFuzzing
   InAppMessaging
   SymbolCollision
 
@@ -340,6 +341,17 @@ case "$product-$method-$platform" in
     cpus=$(sysctl -n hw.ncpu)
     (cd build; env make -j $cpus all generate_protos)
     (cd build; env CTEST_OUTPUT_ON_FAILURE=1 make -j $cpus test)
+    ;;
+
+  FirestoreFuzzing-cmake-macOS)
+    test -d build || mkdir build
+    echo "Preparing cmake build ..."
+    (cd build; cmake -DWITH_ASAN=ON -DFUZZING=ON "${cmake_options[@]}" ..)
+
+    echo "Building cmake build ..."
+    cpus=$(sysctl -n hw.ncpu)
+    (cd build; env make -j $cpus all generate_protos)
+    # Don't run the tests, only make sure the target builds.
     ;;
 
   SymbolCollision-xcodebuild-*)


### PR DESCRIPTION
This should proactively prevent breaking Firestore in OSS-Fuzz.