### PR TITLE
Split a cron sub-job to mitigate timeout failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -168,9 +168,9 @@ jobs:
 
     # pod lib lint to check build and warnings for static library build - only on cron jobs
     - stage: test
-      if: type = cron
+#      if: type = cron
       env:
-        - PROJECT=Firebase PLATFORM=iOS METHOD=pod-lib-lint
+        - PROJECT=FirebasePllCron1 PLATFORM=iOS METHOD=pod-lib-lint
       before_install:
         - ./scripts/install_prereqs.sh
       script:
@@ -191,9 +191,9 @@ jobs:
 
     # Part 2: Split from previous stage to avoid overflowing 45 minute sub-job limit.
     - stage: test
-      if: type = cron
+#      if: type = cron
       env:
-        - PROJECT=Firebase PLATFORM=iOS METHOD=pod-lib-lint
+        - PROJECT=FirebasePllCron2 PLATFORM=iOS METHOD=pod-lib-lint
       before_install:
         - ./scripts/install_prereqs.sh
       script:
@@ -206,9 +206,9 @@ jobs:
 
     # Part 3: Split from previous stage to avoid overflowing 45 minute sub-job limit.
     - stage: test
-      if: type = cron
+#      if: type = cron
       env:
-        - PROJECT=Firebase PLATFORM=iOS METHOD=pod-lib-lint
+        - PROJECT=FirebasePllCron3 PLATFORM=iOS METHOD=pod-lib-lint
       before_install:
         - ./scripts/install_prereqs.sh
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,6 @@ jobs:
     - stage: test
       env:
         - PROJECT=InstanceID PLATFORM=iOS METHOD=pod-lib-lint
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --platforms=ios
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --platforms=tvos
@@ -81,8 +79,6 @@ jobs:
     - stage: test
       env:
         - PROJECT=DynamicLinks PLATFORM=all METHOD=pod-lib-lint
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseDynamicLinks.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseDynamicLinks.podspec --use-libraries
@@ -113,8 +109,6 @@ jobs:
     - stage: test
       env:
         - PROJECT=Functions PLATFORM=iOS METHOD=pod-lib-lint
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --use-libraries
@@ -139,8 +133,6 @@ jobs:
     - stage: test
       env:
         - PROJECT=GoogleUtilities PLATFORM=iOS METHOD=pod-lib-lint
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleUtilities.podspec
 
@@ -148,8 +140,6 @@ jobs:
     - stage: test
       env:
         - PROJECT=Firebase PLATFORM=iOS METHOD=pod-lib-lint
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAnalyticsInterop.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuthInterop.podspec
@@ -159,8 +149,6 @@ jobs:
     - stage: test
       env:
         - PROJECT=Firestore PLATFORM=iOS METHOD=pod-lib-lint
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
         # Eliminate the one warning from BoringSSL when CocoaPods 1.6.0 is available.
         # The travis_wait is necessary because the command takes more than 10 minutes.
@@ -171,8 +159,6 @@ jobs:
 #      if: type = cron
       env:
         - PROJECT=FirebasePllCron1 PLATFORM=iOS METHOD=pod-lib-lint
-      before_install:
-        - ./scripts/install_prereqs.sh
       script:
         # TODO investigate why macos tests hang for FirebaseAuth - keychain related?
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuth.podspec --use-libraries --platforms=ios,tvos
@@ -194,8 +180,6 @@ jobs:
 #      if: type = cron
       env:
         - PROJECT=FirebasePllCron2 PLATFORM=iOS METHOD=pod-lib-lint
-      before_install:
-        - ./scripts/install_prereqs.sh
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-libraries --platforms=ios
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-libraries --platforms=tvos
@@ -209,8 +193,6 @@ jobs:
 #      if: type = cron
       env:
         - PROJECT=FirebasePllCron3 PLATFORM=iOS METHOD=pod-lib-lint
-      before_install:
-        - ./scripts/install_prereqs.sh
       script:
         # The Protobuf dependency of FirebaseMessaging has warnings with --use-libraries.
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-libraries --allow-warnings
@@ -222,8 +204,6 @@ jobs:
       if: type = cron
       env:
         - PROJECT=Firestore PLATFORM=iOS METHOD=pod-lib-lint
-      before_install:
-        - ./scripts/install_prereqs.sh
       script:
         # TBD - non-portable path warnings
         # The travis_wait is necessary because the command takes more than 10 minutes.
@@ -409,8 +389,6 @@ jobs:
     - stage: test
       env:
         - PROJECT=Installations PLATFORM=iOS METHOD=pod-lib-lint
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstallations.podspec --platforms=ios,tvos --ignore-local-podspecs=FirebaseInstanceID.podspec
         # TODO: Fix FBLPromises warnings for macOS.

--- a/.travis.yml
+++ b/.travis.yml
@@ -189,7 +189,7 @@ jobs:
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessagingDisplay.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessagingDisplay.podspec --use-modular-headers
 
-    # Split from previous stage to avoid overflowing 45 minute sub-job limit.
+    # Part 2: Split from previous stage to avoid overflowing 45 minute sub-job limit.
     - stage: test
       if: type = cron
       env:
@@ -203,6 +203,15 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-modular-headers --platforms=ios
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-modular-headers --platforms=tvos
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-modular-headers --platforms=macos
+
+    # Part 3: Split from previous stage to avoid overflowing 45 minute sub-job limit.
+    - stage: test
+      if: type = cron
+      env:
+        - PROJECT=Firebase PLATFORM=iOS METHOD=pod-lib-lint
+      before_install:
+        - ./scripts/install_prereqs.sh
+      script:
         # The Protobuf dependency of FirebaseMessaging has warnings with --use-libraries.
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-libraries --allow-warnings
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-modular-headers

--- a/.travis.yml
+++ b/.travis.yml
@@ -161,10 +161,10 @@ jobs:
         - PROJECT=FirebasePllCron1 PLATFORM=iOS METHOD=pod-lib-lint
       script:
         # TODO investigate why macos tests hang for FirebaseAuth - keychain related?
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuth.podspec --use-libraries --platforms=ios,tvos
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuth.podspec --use-modular-headers --platforms=ios,tvos
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuth.podspec --use-libraries --platforms=macos --skip-tests
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuth.podspec --use-modular-headers --platforms=macos --skip-tests
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseAuth.podspec --use-libraries --platforms=ios,tvos
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseAuth.podspec --use-modular-headers --platforms=ios,tvos
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseAuth.podspec --use-libraries --platforms=macos --skip-tests
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseAuth.podspec --use-modular-headers --platforms=macos --skip-tests
 
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseAnalyticsInterop.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseAnalyticsInterop.podspec --use-modular-headers
@@ -181,12 +181,12 @@ jobs:
       env:
         - PROJECT=FirebasePllCron2 PLATFORM=iOS METHOD=pod-lib-lint
       script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-libraries --platforms=ios
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-libraries --platforms=tvos
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-libraries --platforms=macos
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-modular-headers --platforms=ios
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-modular-headers --platforms=tvos
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-modular-headers --platforms=macos
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-libraries --platforms=ios
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-libraries --platforms=tvos
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-libraries --platforms=macos
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-modular-headers --platforms=ios
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-modular-headers --platforms=tvos
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --use-modular-headers --platforms=macos
 
     # Part 3: Split from previous stage to avoid overflowing 45 minute sub-job limit.
     - stage: test
@@ -195,10 +195,10 @@ jobs:
         - PROJECT=FirebasePllCron3 PLATFORM=iOS METHOD=pod-lib-lint
       script:
         # The Protobuf dependency of FirebaseMessaging has warnings with --use-libraries.
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-libraries --allow-warnings
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-modular-headers
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleUtilities.podspec --use-libraries
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleUtilities.podspec --use-modular-headers
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-libraries --allow-warnings
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-modular-headers
+        - travis_retry ./scripts/pod_lib_lint.rb GoogleUtilities.podspec --use-libraries
+        - travis_retry ./scripts/pod_lib_lint.rb GoogleUtilities.podspec --use-modular-headers
 
     - stage: test
       if: type = cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -156,7 +156,7 @@ jobs:
 
     # pod lib lint to check build and warnings for static library build - only on cron jobs
     - stage: test
-#      if: type = cron
+      if: type = cron
       env:
         - PROJECT=FirebasePllCron1 PLATFORM=iOS METHOD=pod-lib-lint
       script:
@@ -177,7 +177,7 @@ jobs:
 
     # Part 2: Split from previous stage to avoid overflowing 45 minute sub-job limit.
     - stage: test
-#      if: type = cron
+      if: type = cron
       env:
         - PROJECT=FirebasePllCron2 PLATFORM=iOS METHOD=pod-lib-lint
       script:
@@ -190,7 +190,7 @@ jobs:
 
     # Part 3: Split from previous stage to avoid overflowing 45 minute sub-job limit.
     - stage: test
-#      if: type = cron
+      if: type = cron
       env:
         - PROJECT=FirebasePllCron3 PLATFORM=iOS METHOD=pod-lib-lint
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,8 @@ jobs:
     - stage: test
       env:
         - PROJECT=Functions PLATFORM=iOS METHOD=pod-lib-lint
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh # Start integration test server
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --use-libraries


### PR DESCRIPTION
Split and rename cron sub-job to mitigate timeout failures
Remove if_changed checks from cron jobs
Remove unnecessary install_prereqs invocations.