### PR TITLE
FirebaseApp: send Core Diagnostics data on appDidBecomeActive

### DIFF
--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -66,7 +66,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   _observerMock = OCMObserverMock();
   _mockCoreDiagnosticsConnector = OCMClassMock([FIRCoreDiagnosticsConnector class]);
 
-  OCMStub(ClassMethod([self.mockCoreDiagnosticsConnector logCoreDataWithOptions:[OCMArg any]]))
+  OCMStub(ClassMethod([self.mockCoreDiagnosticsConnector logCoreTelemetryWithOptions:[OCMArg any]]))
       .andDo(^(NSInvocation *invocation){
       });
 
@@ -778,7 +778,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   self.mockCoreDiagnosticsConnector = OCMClassMock([FIRCoreDiagnosticsConnector class]);
 
   OCMExpect(ClassMethod([self.mockCoreDiagnosticsConnector
-      logCoreDataWithOptions:[OCMArg checkWithBlock:^BOOL(FIROptions *options) {
+      logCoreTelemetryWithOptions:[OCMArg checkWithBlock:^BOOL(FIROptions *options) {
         if (!expectedOptions) {
           return YES;
         }

--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -770,7 +770,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 
 - (void)expectCoreDiagnosticsDataLogWithOptions:(nullable FIROptions *)expectedOptions {
   OCMExpect(ClassMethod([self.mockCoreDiagnosticsConnector
-      logConfigureCoreWithOptions:[OCMArg checkWithBlock:^BOOL(FIROptions *options) {
+      logCoreDataWithOptions:[OCMArg checkWithBlock:^BOOL(FIROptions *options) {
         if (!expectedOptions) {
           return YES;
         }

--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -67,7 +67,8 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   _mockCoreDiagnosticsConnector = OCMClassMock([FIRCoreDiagnosticsConnector class]);
 
   OCMStub(ClassMethod([self.mockCoreDiagnosticsConnector logCoreDataWithOptions:[OCMArg any]]))
-  .andDo(^(NSInvocation *invocation){});
+      .andDo(^(NSInvocation *invocation){
+      });
 
   // TODO: Remove all usages of defaultCenter in Core, then we can instantiate an instance here to
   //       inject instead of using defaultCenter.

--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -17,8 +17,8 @@
 
 #import <FirebaseCore/FIRAnalyticsConfiguration.h>
 #import <FirebaseCore/FIRAppInternal.h>
-#import <FirebaseCore/FIROptionsInternal.h>
 #import <FirebaseCore/FIRCoreDiagnosticsConnector.h>
+#import <FirebaseCore/FIROptionsInternal.h>
 
 NSString *const kFIRTestAppName1 = @"test_app_name_1";
 NSString *const kFIRTestAppName2 = @"test-app-name-2";
@@ -743,7 +743,8 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   FIRApp *app = [self createConfiguredAppWithName:NSStringFromSelector(_cmd)];
   [self expectCoreDiagnosticsDataLogWithOptions:app.options];
 
-  [self.notificationCenter postNotificationName:[self appDidBecomeActiveNotificationName] object:nil];
+  [self.notificationCenter postNotificationName:[self appDidBecomeActiveNotificationName]
+                                         object:nil];
 
   OCMVerifyAll(self.mockCoreDiagnosticsConnector);
 }
@@ -768,23 +769,24 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 }
 
 - (void)expectCoreDiagnosticsDataLogWithOptions:(nullable FIROptions *)expectedOptions {
-  OCMExpect(ClassMethod([self.mockCoreDiagnosticsConnector logConfigureCoreWithOptions:[OCMArg checkWithBlock:^BOOL(FIROptions *options) {
-    if (!expectedOptions) {
-      return YES;
-    }
-    return [options.googleAppID isEqualToString:expectedOptions.googleAppID] &&
-    [options.GCMSenderID isEqualToString:expectedOptions.GCMSenderID];
-  }]]));
+  OCMExpect(ClassMethod([self.mockCoreDiagnosticsConnector
+      logConfigureCoreWithOptions:[OCMArg checkWithBlock:^BOOL(FIROptions *options) {
+        if (!expectedOptions) {
+          return YES;
+        }
+        return [options.googleAppID isEqualToString:expectedOptions.googleAppID] &&
+               [options.GCMSenderID isEqualToString:expectedOptions.GCMSenderID];
+      }]]));
 }
 
 - (NSNotificationName)appDidBecomeActiveNotificationName {
-  #if TARGET_OS_IOS || TARGET_OS_TV
-    return UIApplicationDidBecomeActiveNotification;
-  #endif
+#if TARGET_OS_IOS || TARGET_OS_TV
+  return UIApplicationDidBecomeActiveNotification;
+#endif
 
-  #if TARGET_OS_OSX
-    return NSApplicationDidBecomeActiveNotification;
-  #endif
+#if TARGET_OS_OSX
+  return NSApplicationDidBecomeActiveNotification;
+#endif
 }
 
 - (FIRApp *)createConfiguredAppWithName:(NSString *)name {
@@ -794,8 +796,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 }
 
 - (FIROptions *)appOptions {
-  return [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
-                                                      GCMSenderID:kGCMSenderID];
+  return [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
 }
 
 @end

--- a/Example/Core/Tests/FIRAppTest.m
+++ b/Example/Core/Tests/FIRAppTest.m
@@ -66,6 +66,9 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   _observerMock = OCMObserverMock();
   _mockCoreDiagnosticsConnector = OCMClassMock([FIRCoreDiagnosticsConnector class]);
 
+  OCMStub(ClassMethod([self.mockCoreDiagnosticsConnector logCoreDataWithOptions:[OCMArg any]]))
+  .andDo(^(NSInvocation *invocation){});
+
   // TODO: Remove all usages of defaultCenter in Core, then we can instantiate an instance here to
   //       inject instead of using defaultCenter.
   _notificationCenter = [NSNotificationCenter defaultCenter];
@@ -769,6 +772,10 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 }
 
 - (void)expectCoreDiagnosticsDataLogWithOptions:(nullable FIROptions *)expectedOptions {
+  [self.mockCoreDiagnosticsConnector stopMocking];
+  self.mockCoreDiagnosticsConnector = nil;
+  self.mockCoreDiagnosticsConnector = OCMClassMock([FIRCoreDiagnosticsConnector class]);
+
   OCMExpect(ClassMethod([self.mockCoreDiagnosticsConnector
       logCoreDataWithOptions:[OCMArg checkWithBlock:^BOOL(FIROptions *options) {
         if (!expectedOptions) {

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -817,7 +817,10 @@ static NSMutableDictionary *sLibraryVersions;
   NSNotificationName notificationName = NSApplicationDidBecomeActiveNotification;
 #endif
 
-  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appDidBecomeActive:) name:notificationName object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(appDidBecomeActive:)
+                                               name:notificationName
+                                             object:nil];
 }
 
 - (void)appDidBecomeActive:(NSNotification *)notification {

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -14,9 +14,15 @@
 
 #include <sys/utsname.h>
 
-#import "FIRApp.h"
+#if __has_include(<UIKit/UIKit.h>)
+#import <UIKit/UIKit.h>
+#endif
 
-#import <FirebaseCoreDiagnosticsInterop/FIRCoreDiagnosticsData.h>
+#if __has_include(<AppKit/AppKit.h>)
+#import <AppKit/AppKit.h>
+#endif
+
+#import "FIRApp.h"
 
 #import "Private/FIRAnalyticsConfiguration.h"
 #import "Private/FIRAppInternal.h"
@@ -283,15 +289,17 @@ static NSMutableDictionary *sLibraryVersions;
   return self;
 }
 
+- (void)dealloc {
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
 - (BOOL)configureCore {
   [self checkExpectedBundleID];
   if (![self isAppIDValid]) {
     return NO;
   }
 
-  if ([self isDataCollectionDefaultEnabled]) {
-    [FIRCoreDiagnosticsConnector logConfigureCoreWithOptions:_options];
-  }
+  [self logDiagnostics];
 
 #if TARGET_OS_IOS
   // Initialize the Analytics once there is a valid options under default app. Analytics should
@@ -315,6 +323,8 @@ static NSMutableDictionary *sLibraryVersions;
     }
   }
 #endif
+
+  [self subscribeForAppDidBecomeActiveNotifications];
 
   return YES;
 }
@@ -795,5 +805,29 @@ static NSMutableDictionary *sLibraryVersions;
   // Do nothing. Please remove calls to this method.
 }
 #pragma clang diagnostic pop
+
+#pragma mark - App Life Cycle
+
+- (void)subscribeForAppDidBecomeActiveNotifications {
+#if TARGET_OS_IOS || TARGET_OS_TV
+  NSNotificationName notificationName = UIApplicationDidBecomeActiveNotification;
+#endif
+
+#if TARGET_OS_OSX
+  NSNotificationName notificationName = NSApplicationDidBecomeActiveNotification;
+#endif
+
+  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appDidBecomeActive:) name:notificationName object:nil];
+}
+
+- (void)appDidBecomeActive:(NSNotification *)notification {
+  [self logDiagnostics];
+}
+
+- (void)logDiagnostics {
+  if ([self isDataCollectionDefaultEnabled]) {
+    [FIRCoreDiagnosticsConnector logConfigureCoreWithOptions:_options];
+  }
+}
 
 @end

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -299,7 +299,7 @@ static NSMutableDictionary *sLibraryVersions;
     return NO;
   }
 
-  [self logDiagnostics];
+  [self logDiagnosticsIfEnabled];
 
 #if TARGET_OS_IOS
   // Initialize the Analytics once there is a valid options under default app. Analytics should
@@ -824,12 +824,12 @@ static NSMutableDictionary *sLibraryVersions;
 }
 
 - (void)appDidBecomeActive:(NSNotification *)notification {
-  [self logDiagnostics];
+  [self logDiagnosticsIfEnabled];
 }
 
-- (void)logDiagnostics {
+- (void)logDiagnosticsIfEnabled {
   if ([self isDataCollectionDefaultEnabled]) {
-    [FIRCoreDiagnosticsConnector logConfigureCoreWithOptions:_options];
+    [FIRCoreDiagnosticsConnector logCoreDataWithOptions:_options];
   }
 }
 

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -299,7 +299,7 @@ static NSMutableDictionary *sLibraryVersions;
     return NO;
   }
 
-  [self logDiagnosticsIfEnabled];
+  [self logCoreTelemetryIfEnabled];
 
 #if TARGET_OS_IOS
   // Initialize the Analytics once there is a valid options under default app. Analytics should
@@ -824,12 +824,12 @@ static NSMutableDictionary *sLibraryVersions;
 }
 
 - (void)appDidBecomeActive:(NSNotification *)notification {
-  [self logDiagnosticsIfEnabled];
+  [self logCoreTelemetryIfEnabled];
 }
 
-- (void)logDiagnosticsIfEnabled {
+- (void)logCoreTelemetryIfEnabled {
   if ([self isDataCollectionDefaultEnabled]) {
-    [FIRCoreDiagnosticsConnector logCoreDataWithOptions:_options];
+    [FIRCoreDiagnosticsConnector logCoreTelemetryWithOptions:_options];
   }
 }
 

--- a/Firebase/Core/FIRCoreDiagnosticsConnector.m
+++ b/Firebase/Core/FIRCoreDiagnosticsConnector.m
@@ -43,7 +43,7 @@ Class<FIRCoreDiagnosticsInterop> FIRCoreDiagnosticsImplementation;
   }
 }
 
-+ (void)logConfigureCoreWithOptions:(FIROptions *)options {
++ (void)logCoreDataWithOptions:(FIROptions *)options {
   if (FIRCoreDiagnosticsImplementation) {
     FIRDiagnosticsData *diagnosticsData = [[FIRDiagnosticsData alloc] init];
     [diagnosticsData insertValue:@(YES) forKey:kFIRCDIsDataCollectionDefaultEnabledKey];

--- a/Firebase/Core/FIRCoreDiagnosticsConnector.m
+++ b/Firebase/Core/FIRCoreDiagnosticsConnector.m
@@ -43,7 +43,7 @@ Class<FIRCoreDiagnosticsInterop> FIRCoreDiagnosticsImplementation;
   }
 }
 
-+ (void)logCoreDataWithOptions:(FIROptions *)options {
++ (void)logCoreTelemetryWithOptions:(FIROptions *)options {
   if (FIRCoreDiagnosticsImplementation) {
     FIRDiagnosticsData *diagnosticsData = [[FIRDiagnosticsData alloc] init];
     [diagnosticsData insertValue:@(YES) forKey:kFIRCDIsDataCollectionDefaultEnabledKey];

--- a/Firebase/Core/Private/FIRCoreDiagnosticsConnector.h
+++ b/Firebase/Core/Private/FIRCoreDiagnosticsConnector.h
@@ -24,11 +24,11 @@ NS_ASSUME_NONNULL_BEGIN
 /** Connects FIRCore with the CoreDiagnostics library. */
 @interface FIRCoreDiagnosticsConnector : NSObject
 
-/** Logs data related to a -configureCore call.
+/** Logs FirebaseCore  related data.
  *
  * @param options The options object containing data to log.
  */
-+ (void)logConfigureCoreWithOptions:(FIROptions *)options;
++ (void)logCoreDataWithOptions:(FIROptions *)options;
 
 @end
 

--- a/Firebase/Core/Private/FIRCoreDiagnosticsConnector.h
+++ b/Firebase/Core/Private/FIRCoreDiagnosticsConnector.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param options The options object containing data to log.
  */
-+ (void)logCoreDataWithOptions:(FIROptions *)options;
++ (void)logCoreTelemetryWithOptions:(FIROptions *)options;
 
 @end
 


### PR DESCRIPTION
It is needed to send reliable heartbeats even if an application is not relaunched for a long time.