### PR TITLE
Only retry transactions on non-permanent errors

### DIFF
--- a/Firestore/Source/Core/FSTSyncEngine.mm
+++ b/Firestore/Source/Core/FSTSyncEngine.mm
@@ -310,14 +310,14 @@ class LimboResolution {
           if (!maybe_result.ok()) {
             if (retries > 0 && [self isRetryableTransactionError:maybe_result.status()] &&
                 !transaction->IsPermanentlyFailed()) {
-              workerQueue->VerifyIsCurrentQueue();
               return [self transactionWithRetries:(retries - 1)
                                       workerQueue:workerQueue
                                    updateCallback:updateCallback
                                    resultCallback:resultCallback];
+            } else {
+              resultCallback(std::move(maybe_result));
+              return;
             }
-            resultCallback(std::move(maybe_result));
-            return;
           }
 
           transaction->Commit([self, retries, workerQueue, updateCallback, resultCallback,

--- a/Firestore/core/src/firebase/firestore/core/transaction.h
+++ b/Firestore/core/src/firebase/firestore/core/transaction.h
@@ -102,7 +102,7 @@ class Transaction {
   /**
    * Checks if the transaction is permanently failed.
    */
-  bool IsPermanentlyFailed();
+  bool IsPermanentlyFailed() const;
 
  private:
   /**

--- a/Firestore/core/src/firebase/firestore/core/transaction.h
+++ b/Firestore/core/src/firebase/firestore/core/transaction.h
@@ -93,6 +93,17 @@ class Transaction {
    */
   void Commit(util::StatusCallback&& callback);
 
+  /**
+   * Marks the transaction as permanently failed, so the transaction will not
+   * retry.
+   */
+  void MarkPermanentlyFailed();
+
+  /**
+   * Checks if the transaction is permanently failed.
+   */
+  bool IsPermanentlyFailed();
+
  private:
   /**
    * Every time a document is read, this should be called to record its version.
@@ -127,6 +138,7 @@ class Transaction {
 
   std::vector<FSTMutation*> mutations_;
   bool committed_ = false;
+  bool permanentError_ = false;
 
   /**
    * A deferred usage error that occurred previously in this transaction that

--- a/Firestore/core/src/firebase/firestore/core/transaction.mm
+++ b/Firestore/core/src/firebase/firestore/core/transaction.mm
@@ -209,6 +209,14 @@ void Transaction::Commit(util::StatusCallback&& callback) {
   }
 }
 
+void Transaction::MarkPermanentlyFailed() {
+  permanentError_ = true;
+}
+
+bool Transaction::IsPermanentlyFailed() {
+  return permanentError_;
+}
+
 void Transaction::EnsureCommitNotCalled() {
   HARD_ASSERT(!committed_, "A transaction object cannot be used after its "
                            "update callback has been invoked.");

--- a/Firestore/core/src/firebase/firestore/core/transaction.mm
+++ b/Firestore/core/src/firebase/firestore/core/transaction.mm
@@ -213,7 +213,7 @@ void Transaction::MarkPermanentlyFailed() {
   permanentError_ = true;
 }
 
-bool Transaction::IsPermanentlyFailed() {
+bool Transaction::IsPermanentlyFailed() const {
   return permanentError_;
 }
 


### PR DESCRIPTION
Based on Android [port](https://github.com/firebase/firebase-android-sdk/pull/628).

Added checks in Transaction for checking user errors.