### PR TITLE
FIRInstallations: use lazy initialization 

### DIFF
--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   FIRComponent *installationsProvider =
       [FIRComponent componentWithProtocol:@protocol(FIRInstallationsInstanceProvider)
-                      instantiationTiming:FIRInstantiationTimingAlwaysEager
+                      instantiationTiming:FIRInstantiationTimingLazy
                              dependencies:@[]
                             creationBlock:creationBlock];
   return @[ installationsProvider ];


### PR DESCRIPTION
- installations requests auth token on init. We would not like to request it before FirebaseApp has been configured. Let's use `FIRInstantiationTimingLazy`. We need to consider updating our components system to provide an App Configured call back.