### PR TITLE
fix for signInProvider property of FIRAuthTokenResult returning nil

### DIFF
--- a/Example/Auth/Tests/FIRUserTests.m
+++ b/Example/Auth/Tests/FIRUserTests.m
@@ -1072,7 +1072,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
       XCTAssertTrue(tokenResult.authDate && [tokenResult.authDate isKindOfClass:[NSDate class]]);
       XCTAssertTrue(tokenResult.expirationDate &&
           [tokenResult.expirationDate isKindOfClass:[NSDate class]]);
-      XCTAssertEqualObjects(tokenResult.signInProvider, @"password");
+      XCTAssertEqualObjects(tokenResult.signInProvider, FIREmailAuthProviderID);
       XCTAssertTrue(tokenResult.claims && [tokenResult.claims isKindOfClass:[NSDictionary class]]);
       [expectation fulfill];
     }];

--- a/Example/Auth/Tests/FIRUserTests.m
+++ b/Example/Auth/Tests/FIRUserTests.m
@@ -1072,6 +1072,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
       XCTAssertTrue(tokenResult.authDate && [tokenResult.authDate isKindOfClass:[NSDate class]]);
       XCTAssertTrue(tokenResult.expirationDate &&
           [tokenResult.expirationDate isKindOfClass:[NSDate class]]);
+      XCTAssertEqualObjects(tokenResult.signInProvider, @"password");
       XCTAssertTrue(tokenResult.claims && [tokenResult.claims isKindOfClass:[NSDictionary class]]);
       [expectation fulfill];
     }];

--- a/Firebase/Auth/Source/User/FIRUser.m
+++ b/Firebase/Auth/Source/User/FIRUser.m
@@ -938,7 +938,7 @@ static void callInMainThreadWithAuthDataResultAndError(
                                 expirationDate:expDate
                                       authDate:authDate
                                   issuedAtDate:issuedDate
-                                signInProvider:tokenPayloadDictionary[@"sign_in_provider"]
+                                signInProvider:tokenPayloadDictionary[@"firebase"][@"sign_in_provider"]
                                         claims:tokenPayloadDictionary];
   return result;
 }


### PR DESCRIPTION
Fixes #3445 ("signInProvider property of FIRAuthTokenResult returns nil")

### Testing
 
I added a test to `Example/Auth/Tests/FIRUserTests.m`. This only tests email and password sign-in.