### PR TITLE
providerID should be nil in additionalUserInfo for signInAnonymouslyWithCompletion:

### DIFF
--- a/Example/Auth/Tests/FIRAuthTests.m
+++ b/Example/Auth/Tests/FIRAuthTests.m
@@ -1468,12 +1468,12 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
     XCTAssertTrue([NSThread isMainThread]);
     [self assertUserAnonymous:result.user];
     XCTAssertNil(error);
-    FIRAdditionalUserInfo additionalUserInfo = result.additionalUserInfo;
-    XCTAssertNotNil(additionalUserInfo);
-    XCTAssertTrue(additionalUserInfo.isNewUser);
-    XCTAssertNil(additionalUserInfo.username);
-    XCTAssertNil(additionalUserInfo.profile);
-    XCTAssertNil(additionalUserInfo.providerID);
+    FIRAdditionalUserInfo *userInfo = result.additionalUserInfo;
+    XCTAssertNotNil(userInfo);
+    XCTAssertTrue(userInfo.isNewUser);
+    XCTAssertNil(userInfo.username);
+    XCTAssertNil(userInfo.profile);
+    XCTAssertNil(userInfo.providerID);
     [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];

--- a/Example/Auth/Tests/FIRAuthTests.m
+++ b/Example/Auth/Tests/FIRAuthTests.m
@@ -1468,6 +1468,12 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
     XCTAssertTrue([NSThread isMainThread]);
     [self assertUserAnonymous:result.user];
     XCTAssertNil(error);
+    FIRAdditionalUserInfo additionalUserInfo = result.additionalUserInfo;
+    XCTAssertNotNil(additionalUserInfo);
+    XCTAssertTrue(additionalUserInfo.isNewUser);
+    XCTAssertNil(additionalUserInfo.username);
+    XCTAssertNil(additionalUserInfo.profile);
+    XCTAssertNil(additionalUserInfo.providerID);
     [expectation fulfill];
   }];
   [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];

--- a/Firebase/Auth/Source/Auth/FIRAuth.m
+++ b/Firebase/Auth/Source/Auth/FIRAuth.m
@@ -928,7 +928,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
           return;
         }
         FIRAdditionalUserInfo *additionalUserInfo =
-          [[FIRAdditionalUserInfo alloc] initWithProviderID:FIREmailAuthProviderID
+          [[FIRAdditionalUserInfo alloc] initWithProviderID:nil
                                                     profile:nil
                                                    username:nil
                                                   isNewUser:YES];


### PR DESCRIPTION
This makes the behavior consistent between iOS and Android for `additionalUserInfo` of an anonymous sign-in. Right now the iOS SDK is returning `"password"` (email sign-in) as the `providerID` but I think `nil` would be more appropriate and matches Android.

Also added a test.

Fixes firebase/firebase-ios-sdk#3450