### PR TITLE
Revert "Disable incremental installation"

### DIFF
--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -11,6 +11,7 @@ use_frameworks!
 
 install! 'cocoapods',
     :generate_multiple_pod_projects => true,
+    :incremental_installation => true,
     # Disable input/output path checking for generated frameworks to make
     # incremental builds work properly. Without this, changes to the framework
     # may not be picked up in between test runs.


### PR DESCRIPTION
This reverts commit d3ba21f87adfcab576a719344413e75ea9210593.

#3356 disabled incremental installation because I observed that when changing branches, files that were added and removed weren't necessarily reflected in the Xcode build and this caused the build to fail with missing source files or missing symbols.

Since then I conducted a series of experiments using the `xcodebuild` command-line and confirmed that CocoaPods is actually doing the right thing. What I was observing was that the Xcode UI still doesn't always pick up changes to the underlying generated project. Restarting Xcode after a branch change forces it to pick these changes up and then interactive builds work too.