### PR TITLE
IID unit test update for Catalyst

### DIFF
--- a/Example/InstanceID/Tests/FIRInstanceIDKeyPairMigrationTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDKeyPairMigrationTest.m
@@ -156,7 +156,7 @@ NSString *FIRInstanceIDPrivateTagWithSubtype(NSString *subtype);
 }
 
 - (void)testUpdateKeyRefWithTagRetainsAndReleasesKeyRef {
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if (TARGET_OS_IOS || TARGET_OS_TV) && !defined(TARGET_OS_MACCATALYST)
   __weak id weakKeyRef;
 
   // Use a local autorelease pool to make sure any autorelease objects allocated will be released.

--- a/Example/InstanceID/Tests/FIRInstanceIDKeyPairMigrationTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDKeyPairMigrationTest.m
@@ -155,8 +155,8 @@ NSString *FIRInstanceIDPrivateTagWithSubtype(NSString *subtype);
 #endif
 }
 
-- (void)testUpdateKeyRefWithTagRetainsAndReleasesKeyRef {
 #if (TARGET_OS_IOS || TARGET_OS_TV) && !defined(TARGET_OS_MACCATALYST)
+- (void)testUpdateKeyRefWithTagRetainsAndReleasesKeyRef {
   __weak id weakKeyRef;
 
   // Use a local autorelease pool to make sure any autorelease objects allocated will be released.
@@ -183,7 +183,6 @@ NSString *FIRInstanceIDPrivateTagWithSubtype(NSString *subtype);
   // The check below is flaky for build under DEBUG (petentially due to ARC specifics).
   // Comment it so far as not-so-important one.
   //  XCTAssertNil(weakKeyRef);
-#endif
 }
 
 - (SecKeyRef)generateKeyRef {
@@ -201,5 +200,6 @@ NSString *FIRInstanceIDPrivateTagWithSubtype(NSString *subtype);
 
   return publicKey;
 }
+#endif  // (TARGET_OS_IOS || TARGET_OS_TV) && !defined(TARGET_OS_MACCATALYST)
 
 @end


### PR DESCRIPTION
With this change the IID unit tests run on Catalyst after adding Keychain Sharing Capability.