### PR TITLE
Attempt to support iOS 13's new lifecycle APIs

### DIFF
--- a/Firebase/Database/Core/FPersistentConnection.m
+++ b/Firebase/Database/Core/FPersistentConnection.m
@@ -553,6 +553,17 @@ static void reachabilityCallback(SCNetworkReachabilityRef ref,
                    name:*foregroundConstant
                  object:nil];
     }
+
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+    if (@available(iOS 13, *)) {
+        [[NSNotificationCenter defaultCenter]
+            addObserver:self
+               selector:@selector(enteringForeground:)
+                   name:UISceneWillEnterForegroundNotification
+                 object:nil];
+    }
+#endif
+
     // An empty address is interpreted a generic internet access
     struct sockaddr_in zeroAddress;
     bzero(&zeroAddress, sizeof(zeroAddress));

--- a/Firebase/Database/Core/FRepo.m
+++ b/Firebase/Database/Core/FRepo.m
@@ -723,6 +723,16 @@
         FFLog(@"I-RDB038016",
               @"Skipped registering for background notification.");
     }
+
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+    if (@available(iOS 13, *)) {
+        [[NSNotificationCenter defaultCenter]
+            addObserver:self
+               selector:@selector(didEnterBackground:)
+                   name:UISceneWillDeactivateNotification
+                 object:nil];
+    }
+#endif
 }
 
 - (void)didEnterBackground {


### PR DESCRIPTION
Request for comments - this is not tested, but I want to get some feedback before I figure out how to test it.

I verified that both callbacks can be called any number of times (by code inspection).

Fixes: https://github.com/firebase/firebase-ios-sdk/issues/3523