### PR TITLE
Remove asserts and replace with GDTLogs (#3535)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -437,3 +437,4 @@ jobs:
 branches:
   only:
     - master
+    - release-6.6.0

--- a/Firebase/CoreDiagnostics/FIRCDLibrary/FIRCoreDiagnostics.m
+++ b/Firebase/CoreDiagnostics/FIRCDLibrary/FIRCoreDiagnostics.m
@@ -17,6 +17,7 @@
 #import <objc/runtime.h>
 #include <sys/utsname.h>
 
+#import <GoogleDataTransport/GDTConsoleLogger.h>
 #import <GoogleDataTransport/GDTEvent.h>
 #import <GoogleDataTransport/GDTTargets.h>
 #import <GoogleDataTransport/GDTTransport.h>
@@ -116,7 +117,8 @@ NSString *const kFIRCoreDiagnosticsHeartbeatDateFileName = @"FIREBASE_DIAGNOSTIC
 
   // Encode 1 time to determine the size.
   if (!pb_encode(&sizestream, logs_proto_mobilesdk_ios_ICoreConfiguration_fields, &_config)) {
-    NSCAssert(NO, @"Error in nanopb encoding for size: %s", PB_GET_ERROR(&sizestream));
+    GDTLogError(GDTMCETransportBytesError, @"Error in nanopb encoding for size: %s",
+                PB_GET_ERROR(&sizestream));
   }
 
   // Encode a 2nd time to actually get the bytes from it.
@@ -124,7 +126,8 @@ NSString *const kFIRCoreDiagnosticsHeartbeatDateFileName = @"FIREBASE_DIAGNOSTIC
   CFMutableDataRef dataRef = CFDataCreateMutable(CFAllocatorGetDefault(), bufferSize);
   pb_ostream_t ostream = pb_ostream_from_buffer((void *)CFDataGetBytePtr(dataRef), bufferSize);
   if (!pb_encode(&ostream, logs_proto_mobilesdk_ios_ICoreConfiguration_fields, &_config)) {
-    NSCAssert(NO, @"Error in nanopb encoding for bytes: %s", PB_GET_ERROR(&ostream));
+    GDTLogError(GDTMCETransportBytesError, @"Error in nanopb encoding for bytes: %s",
+                PB_GET_ERROR(&ostream));
   }
   CFDataSetLength(dataRef, ostream.bytes_written);
 
@@ -370,8 +373,9 @@ void FIRPopulateProtoWithCommonInfoFromApp(logs_proto_mobilesdk_ios_ICoreConfigu
   config->pod_name = logs_proto_mobilesdk_ios_ICoreConfiguration_PodName_FIREBASE;
   config->has_pod_name = 1;
 
-  NSCAssert(diagnosticObjects[kFIRCDllAppsCountKey],
-            @"App count is a required value in the data dict.");
+  if (!diagnosticObjects[kFIRCDllAppsCountKey]) {
+    GDTLogError(GDTMCEGeneralError, @"%@", @"App count is a required value in the data dict.");
+  }
   config->app_count = (int32_t)[diagnosticObjects[kFIRCDllAppsCountKey] integerValue];
   config->has_app_count = 1;
 

--- a/FirebaseCoreDiagnostics.podspec
+++ b/FirebaseCoreDiagnostics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCoreDiagnostics'
-  s.version          = '1.0.0'
+  s.version          = '1.0.1'
   s.summary          = 'Firebase Core Diagnostics'
 
   s.description      = <<-DESC

--- a/GoogleDataTransport.podspec
+++ b/GoogleDataTransport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleDataTransport'
-  s.version          = '1.0.0'
+  s.version          = '1.1.0'
   s.summary          = 'Google iOS SDK data transport.'
 
   s.description      = <<-DESC

--- a/GoogleDataTransport/GDTLibrary/GDTConsoleLogger.m
+++ b/GoogleDataTransport/GDTLibrary/GDTConsoleLogger.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "GDTLibrary/Private/GDTConsoleLogger.h"
+#import "GDTLibrary/Public/GDTConsoleLogger.h"
 
 /** The console logger prefix. */
 static NSString *kGDTConsoleLogger = @"[GoogleDataTransport]";

--- a/GoogleDataTransport/GDTLibrary/GDTPlatform.m
+++ b/GoogleDataTransport/GDTLibrary/GDTPlatform.m
@@ -39,6 +39,7 @@ BOOL GDTReachabilityFlagsContainWWAN(SCNetworkReachabilityFlags flags) {
 
 + (void)load {
 #if TARGET_OS_IOS || TARGET_OS_TV
+  // If this asserts, please file a bug at https://github.com/firebase/firebase-ios-sdk/issues.
   NSAssert(GDTBackgroundIdentifierInvalid == UIBackgroundTaskInvalid,
            @"GDTBackgroundIdentifierInvalid and UIBackgroundTaskInvalid should be the same.");
 #endif

--- a/GoogleDataTransport/GDTLibrary/GDTReachability.m
+++ b/GoogleDataTransport/GDTLibrary/GDTReachability.m
@@ -17,6 +17,8 @@
 #import "GDTLibrary/Private/GDTReachability.h"
 #import "GDTLibrary/Private/GDTReachability_Private.h"
 
+#import <GoogleDataTransport/GDTConsoleLogger.h>
+
 #import <netinet/in.h>
 
 /** Sets the _callbackFlag ivar whenever the network changes.
@@ -74,9 +76,13 @@ static void GDTReachabilityCallback(SCNetworkReachabilityRef reachability,
     _reachabilityRef = SCNetworkReachabilityCreateWithAddress(
         kCFAllocatorDefault, (const struct sockaddr *)&zeroAddress);
     Boolean success = SCNetworkReachabilitySetDispatchQueue(_reachabilityRef, _reachabilityQueue);
-    NSAssert(success, @"The reachability queue wasn't set.");
+    if (!success) {
+      GDTLogWarning(GDTMCWReachabilityFailed, @"%@", @"The reachability queue wasn't set.");
+    }
     success = SCNetworkReachabilitySetCallback(_reachabilityRef, GDTReachabilityCallback, NULL);
-    NSAssert(success, @"The reachability callback wasn't set.");
+    if (!success) {
+      GDTLogWarning(GDTMCWReachabilityFailed, @"%@", @"The reachability callback wasn't set.");
+    }
 
     // Get the initial set of flags.
     dispatch_async(_reachabilityQueue, ^{

--- a/GoogleDataTransport/GDTLibrary/GDTStorage.m
+++ b/GoogleDataTransport/GDTLibrary/GDTStorage.m
@@ -17,12 +17,12 @@
 #import "GDTLibrary/Private/GDTStorage.h"
 #import "GDTLibrary/Private/GDTStorage_Private.h"
 
+#import <GoogleDataTransport/GDTConsoleLogger.h>
 #import <GoogleDataTransport/GDTLifecycle.h>
 #import <GoogleDataTransport/GDTPrioritizer.h>
 #import <GoogleDataTransport/GDTStoredEvent.h>
 
 #import "GDTLibrary/Private/GDTAssert.h"
-#import "GDTLibrary/Private/GDTConsoleLogger.h"
 #import "GDTLibrary/Private/GDTEvent_Private.h"
 #import "GDTLibrary/Private/GDTRegistrar_Private.h"
 #import "GDTLibrary/Private/GDTUploadCoordinator.h"

--- a/GoogleDataTransport/GDTLibrary/GDTTransformer.m
+++ b/GoogleDataTransport/GDTLibrary/GDTTransformer.m
@@ -17,11 +17,11 @@
 #import "GDTLibrary/Private/GDTTransformer.h"
 #import "GDTLibrary/Private/GDTTransformer_Private.h"
 
+#import <GoogleDataTransport/GDTConsoleLogger.h>
 #import <GoogleDataTransport/GDTEventTransformer.h>
 #import <GoogleDataTransport/GDTLifecycle.h>
 
 #import "GDTLibrary/Private/GDTAssert.h"
-#import "GDTLibrary/Private/GDTConsoleLogger.h"
 #import "GDTLibrary/Private/GDTStorage.h"
 
 @implementation GDTTransformer

--- a/GoogleDataTransport/GDTLibrary/GDTUploadCoordinator.m
+++ b/GoogleDataTransport/GDTLibrary/GDTUploadCoordinator.m
@@ -17,9 +17,9 @@
 #import "GDTLibrary/Private/GDTUploadCoordinator.h"
 
 #import <GoogleDataTransport/GDTClock.h>
+#import <GoogleDataTransport/GDTConsoleLogger.h>
 
 #import "GDTLibrary/Private/GDTAssert.h"
-#import "GDTLibrary/Private/GDTConsoleLogger.h"
 #import "GDTLibrary/Private/GDTReachability.h"
 #import "GDTLibrary/Private/GDTRegistrar_Private.h"
 #import "GDTLibrary/Private/GDTStorage.h"
@@ -212,7 +212,10 @@ static NSString *const ktargetToInFlightPackagesKey =
     NSNumber *targetNumber = @(package.target);
     [self->_targetToInFlightPackages removeObjectForKey:targetNumber];
     id<GDTPrioritizer> prioritizer = self->_registrar.targetToPrioritizer[targetNumber];
-    NSAssert(prioritizer, @"A prioritizer should be registered for this target: %@", targetNumber);
+    if (!prioritizer) {
+      GDTLogError(GDTMCEPrioritizerError, @"A prioritizer should be registered for this target: %@",
+                  targetNumber);
+    }
     if ([prioritizer respondsToSelector:@selector(packageDelivered:successful:)]) {
       [prioritizer packageDelivered:package successful:successful];
     }

--- a/GoogleDataTransport/GDTLibrary/GDTUploadPackage.m
+++ b/GoogleDataTransport/GDTLibrary/GDTUploadPackage.m
@@ -17,6 +17,7 @@
 #import <GoogleDataTransport/GDTUploadPackage.h>
 
 #import <GoogleDataTransport/GDTClock.h>
+#import <GoogleDataTransport/GDTConsoleLogger.h>
 
 #import "GDTLibrary/Private/GDTStorage_Private.h"
 #import "GDTLibrary/Private/GDTUploadCoordinator.h"
@@ -74,7 +75,10 @@
 }
 
 - (void)completeDelivery {
-  NSAssert(_isDelivered == NO, @"It's an API violation to call -completeDelivery twice.");
+  if (_isDelivered) {
+    GDTLogError(GDTMCEDeliverTwice, @"%@",
+                @"It's an API violation to call -completeDelivery twice.");
+  }
   _isDelivered = YES;
   if (!_isHandled && _handler &&
       [_handler respondsToSelector:@selector(packageDelivered:successful:)]) {

--- a/GoogleDataTransport/GDTLibrary/Public/GDTConsoleLogger.h
+++ b/GoogleDataTransport/GDTLibrary/Public/GDTConsoleLogger.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "GDTLibrary/Private/GDTAssert.h"
+#import <Foundation/Foundation.h>
 
 /** A list of message codes to print in the logger that help to correspond printed messages with
  * code locations.
@@ -34,6 +34,9 @@ typedef NS_ENUM(NSInteger, GDTMessageCode) {
   /** For warning messages concerning a forced event upload. */
   GDTMCWForcedUpload = 3,
 
+  /** For warning messages concerning a failed reachability call. */
+  GDTMCWReachabilityFailed = 4,
+
   /** For error messages concerning transform: not being implemented by an event transformer. */
   GDTMCETransformerDoesntImplementTransform = 1000,
 
@@ -41,7 +44,19 @@ typedef NS_ENUM(NSInteger, GDTMessageCode) {
   GDTMCEDirectoryCreationError = 1001,
 
   /** For error messages concerning the writing of a event file. */
-  GDTMCEFileWriteError = 1002
+  GDTMCEFileWriteError = 1002,
+
+  /** For error messages concerning the lack of a prioritizer for a given backend. */
+  GDTMCEPrioritizerError = 1003,
+
+  /** For error messages concerning a package delivery API violation. */
+  GDTMCEDeliverTwice = 1004,
+
+  /** For error messages concerning an error in an implementation of -transportBytes. */
+  GDTMCETransportBytesError = 1005,
+
+  /** For general purpose error messages in a dependency. */
+  GDTMCEGeneralError = 1006
 };
 
 /** */
@@ -61,5 +76,4 @@ FOUNDATION_EXPORT NSString *_Nonnull GDTMessageCodeEnumToString(GDTMessageCode c
 
 // A define to wrap GULLogError with slightly more convenient usage and a failing assert.
 #define GDTLogError(MESSAGE_CODE, MESSAGE_FORMAT, ...) \
-  GDTLog(MESSAGE_CODE, MESSAGE_FORMAT, __VA_ARGS__);   \
-  GDTAssert(NO, MESSAGE_FORMAT, __VA_ARGS__);
+  GDTLog(MESSAGE_CODE, MESSAGE_FORMAT, __VA_ARGS__);

--- a/GoogleDataTransport/GDTLibrary/Public/GoogleDataTransport.h
+++ b/GoogleDataTransport/GDTLibrary/Public/GoogleDataTransport.h
@@ -15,6 +15,7 @@
  */
 
 #import "GDTClock.h"
+#import "GDTConsoleLogger.h"
 #import "GDTDataFuture.h"
 #import "GDTEvent.h"
 #import "GDTEventDataObject.h"

--- a/GoogleDataTransport/GDTTests/Unit/GDTTransformerTest.m
+++ b/GoogleDataTransport/GDTTests/Unit/GDTTransformerTest.m
@@ -110,19 +110,4 @@
   XCTAssertNoThrow([transformer transformEvent:event withTransformers:transformers]);
 }
 
-/** Tests that using a transformer without transform: implemented throws. */
-- (void)testWriteEventWithBadTransformer {
-  GDTTransformer *transformer = [GDTTransformer sharedInstance];
-  GDTEvent *event = [[GDTEvent alloc] initWithMappingID:@"2" target:1];
-  event.dataObject = [[GDTDataObjectTesterSimple alloc] init];
-  NSArray *transformers = @[ [[NSObject alloc] init] ];
-
-  XCTestExpectation *errorExpectation = [self expectationWithDescription:@"transform: is missing"];
-  [GDTAssertHelper setAssertionBlock:^{
-    [errorExpectation fulfill];
-  }];
-  [transformer transformEvent:event withTransformers:transformers];
-  [self waitForExpectations:@[ errorExpectation ] timeout:5.0];
-}
-
 @end

--- a/GoogleDataTransport/GDTTests/Unit/GDTUploadPackageTest.m
+++ b/GoogleDataTransport/GDTTests/Unit/GDTUploadPackageTest.m
@@ -77,19 +77,6 @@
   XCTAssertNotNil([[GDTUploadPackage alloc] initWithTarget:kGDTTargetTest]);
 }
 
-/** Tests that calling -completeDelivery twice on the same package asserts. */
-- (void)testCompleteDeliveryTwiceAsserts {
-  GDTTestPrioritizer *prioritizer = [[GDTTestPrioritizer alloc] init];
-  GDTTestUploader *uploader = [[GDTTestUploader alloc] init];
-
-  [[GDTRegistrar sharedInstance] registerPrioritizer:prioritizer target:kGDTTargetTest];
-  [[GDTRegistrar sharedInstance] registerUploader:uploader target:kGDTTargetTest];
-
-  GDTUploadPackage *uploadPackage = [[GDTUploadPackage alloc] initWithTarget:kGDTTargetTest];
-  [uploadPackage completeDelivery];
-  XCTAssertThrows([uploadPackage completeDelivery]);
-}
-
 /** Tests copying indicates that the underlying sets of events can't be changed from underneath. */
 - (void)testRegisterUpload {
   GDTUploadPackage *uploadPackage = [[GDTUploadPackage alloc] initWithTarget:kGDTTargetTest];

--- a/GoogleDataTransportCCTSupport.podspec
+++ b/GoogleDataTransportCCTSupport.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'GoogleDataTransportCCTSupport'
-  s.version          = '1.0.0'
+  s.version          = '1.0.1'
   s.summary          = 'Support library for the GoogleDataTransport CCT backend target.'
 
 
@@ -30,7 +30,7 @@ Support library to provide event prioritization and uploading for the GoogleData
   s.source_files = 'GoogleDataTransportCCTSupport/GDTCCTLibrary/**/*'
   s.private_header_files = 'GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/*.h'
 
-  s.dependency 'GoogleDataTransport', '~> 1.0'
+  s.dependency 'GoogleDataTransport', '~> 1.1'
   s.dependency 'nanopb'
 
   header_search_paths = {

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
@@ -22,6 +22,8 @@
 #import <AppKit/AppKit.h>
 #endif  // TARGET_OS_IOS || TARGET_OS_TV
 
+#import <GoogleDataTransport/GDTConsoleLogger.h>
+
 #import <nanopb/pb.h>
 #import <nanopb/pb_decode.h>
 #import <nanopb/pb_encode.h>
@@ -48,7 +50,8 @@ NSData *_Nullable GDTCCTEncodeBatchedLogRequest(gdt_cct_BatchedLogRequest *batch
   pb_ostream_t sizestream = PB_OSTREAM_SIZING;
   // Encode 1 time to determine the size.
   if (!pb_encode(&sizestream, gdt_cct_BatchedLogRequest_fields, batchedLogRequest)) {
-    NSCAssert(NO, @"Error in nanopb encoding for size: %s", PB_GET_ERROR(&sizestream));
+    GDTLogError(GDTMCEGeneralError, @"Error in nanopb encoding for size: %s",
+                PB_GET_ERROR(&sizestream));
   }
 
   // Encode a 2nd time to actually get the bytes from it.
@@ -56,7 +59,8 @@ NSData *_Nullable GDTCCTEncodeBatchedLogRequest(gdt_cct_BatchedLogRequest *batch
   CFMutableDataRef dataRef = CFDataCreateMutable(CFAllocatorGetDefault(), bufferSize);
   pb_ostream_t ostream = pb_ostream_from_buffer((void *)CFDataGetBytePtr(dataRef), bufferSize);
   if (!pb_encode(&ostream, gdt_cct_BatchedLogRequest_fields, batchedLogRequest)) {
-    NSCAssert(NO, @"Error in nanopb encoding for bytes: %s", PB_GET_ERROR(&ostream));
+    GDTLogError(GDTMCEGeneralError, @"Error in nanopb encoding for bytes: %s",
+                PB_GET_ERROR(&ostream));
   }
   CFDataSetLength(dataRef, ostream.bytes_written);
 
@@ -86,7 +90,11 @@ gdt_cct_BatchedLogRequest GDTCCTConstructBatchedLogRequest(
 
 gdt_cct_LogRequest GDTCCTConstructLogRequest(int32_t logSource,
                                              NSSet<GDTStoredEvent *> *_Nonnull logSet) {
-  NSCAssert(logSet.count, @"An empty event set can't be serialized to proto.");
+  if (logSet.count == 0) {
+    GDTLogError(GDTMCEGeneralError, @"%@", @"An empty event set can't be serialized to proto.");
+    gdt_cct_LogRequest logRequest = gdt_cct_LogRequest_init_default;
+    return logRequest;
+  }
   gdt_cct_LogRequest logRequest = gdt_cct_LogRequest_init_default;
   logRequest.log_source = logSource;
   logRequest.has_log_source = 1;
@@ -118,7 +126,11 @@ gdt_cct_LogEvent GDTCCTConstructLogEvent(GDTStoredEvent *event) {
   NSData *extensionBytes = [NSData dataWithContentsOfURL:event.dataFuture.fileURL
                                                  options:0
                                                    error:&error];
-  NSCAssert(error == nil, @"There was an error reading extension bytes from disk: %@", error);
+  if (error) {
+    GDTLogError(GDTMCEGeneralError, @"There was an error reading extension bytes from disk: %@",
+                error);
+    return logEvent;
+  }
   logEvent.source_extension = GDTCCTEncodeData(extensionBytes);  // read bytes from the file.
   return logEvent;
 }


### PR DESCRIPTION
* Remove asserts and replace with GDTLogs

Should infrequently log to the console in !NDEBUG builds instead of asserting.

* Remove tests that check for assertions.