### PR TITLE
kill debug assert and unnecessary macros

### DIFF
--- a/Example/Messaging/Tests/FIRMessagingServiceTest.m
+++ b/Example/Messaging/Tests/FIRMessagingServiceTest.m
@@ -177,57 +177,6 @@ static NSString *const kFIRMessagingTestsServiceSuiteName = @"com.messaging.test
                  }];
 }
 
-// TODO(chliangGoogle) Investigate why invalid token can't throw assertion but the rest can under
-// release build.
-- (void)testSubscribeWithInvalidTopic {
-
-  XCTestExpectation *exceptionExpectation =
-  [self expectationWithDescription:@"Should throw exception for invalid token"];
-  @try {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    [_mockPubSub subscribeWithToken:kFakeToken
-                              topic:nil
-                            options:nil
-                            handler:^(NSError *error) {
-                              XCTFail(@"Should not invoke the handler");
-                            }];
-#pragma clang diagnostic pop
-  }
-  @catch (NSException *exception) {
-    [exceptionExpectation fulfill];
-  }
-  @finally {
-    [self waitForExpectationsWithTimeout:0.1 handler:^(NSError *error) {
-      XCTAssertNil(error);
-    }];
-  }
-}
-
-- (void)testUnsubscribeWithInvalidTopic {
-  XCTestExpectation *exceptionExpectation =
-      [self expectationWithDescription:@"Should throw exception for invalid token"];
-  @try {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnonnull"
-    [_mockPubSub unsubscribeWithToken:kFakeToken
-                                topic:nil
-                              options:nil
-                              handler:^(NSError *error) {
-                                XCTFail(@"Should not invoke the handler");
-                              }];
-#pragma clang diagnostic pop
-  }
-  @catch (NSException *exception) {
-    [exceptionExpectation fulfill];
-  }
-  @finally {
-    [self waitForExpectationsWithTimeout:0.1 handler:^(NSError *error) {
-      XCTAssertNil(error);
-    }];
-  }
-}
-
 - (void)testSubscribeWithNoTopicPrefix {
   OCMStub([_mockInstanceID
       instanceIDWithHandler:([OCMArg invokeBlockWithArgs:_result, [NSNull null], nil])]);

--- a/Firebase/Messaging/FIRMMessageCode.h
+++ b/Firebase/Messaging/FIRMMessageCode.h
@@ -106,6 +106,8 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingMessageCodeDataMessageManager010 = 7010,  // I-FCM007010
   kFIRMessagingMessageCodeDataMessageManager011 = 7011,  // I-FCM007011
   kFIRMessagingMessageCodeDataMessageManager012 = 7012,  // I-FCM007012
+  kFIRMessagingMessageCodeDataMessageManager013 = 7013,
+
   // FIRMessagingPendingTopicsList.m
   kFIRMessagingMessageCodePendingTopicsList000 = 8000,  // I-FCM008000
   // FIRMessagingPubSub.m

--- a/Firebase/Messaging/FIRMMessageCode.h
+++ b/Firebase/Messaging/FIRMMessageCode.h
@@ -47,6 +47,7 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingMessageCodeTokenDelegateMethodsNotImplemented = 2023, // I-FCM002023
   kFIRMessagingMessageCodeTopicFormatIsDeprecated = 2024,
   kFIRMessagingMessageCodeDirectChannelConnectionFailed = 2025,
+  kFIRMessagingMessageCodeInvalidClient = 2026,
   // FIRMessagingClient.m
   kFIRMessagingMessageCodeClient000 = 4000,  // I-FCM004000
   kFIRMessagingMessageCodeClient001 = 4001,  // I-FCM004001
@@ -60,6 +61,9 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingMessageCodeClient009 = 4009,  // I-FCM004009
   kFIRMessagingMessageCodeClient010 = 4010,  // I-FCM004010
   kFIRMessagingMessageCodeClient011 = 4011,  // I-FCM004011
+  kFIRMessagingMessageCodeClientInvalidState = 4012,
+  kFIRMessagingMessageCodeClientInvalidStateTimeout = 4013,
+
   // FIRMessagingConnection.m
   kFIRMessagingMessageCodeConnection000 = 5000,  // I-FCM005000
   kFIRMessagingMessageCodeConnection001 = 5001,  // I-FCM005001
@@ -197,5 +201,8 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingServiceExtensionImageNotDownloaded = 20001,
   kFIRMessagingServiceExtensionLocalFileNotCreated = 20002,
   kFIRMessagingServiceExtensionImageNotAttached = 20003,
+
+  // FIRMessagingCodedInputStream.m
+  kFIRMessagingCodeInputStreamInvalidParameters = 21000,
 
 };

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -825,8 +825,8 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
                                                                        withID:messageID
                                                                    timeToLive:ttl
                                                                         delay:0];
-  FIRMessagingLoggerInfo(kFIRMessagingMessageCodeMessaging013, @"Sending message: %@ with id: %@",
-                         message, messageID);
+  FIRMessagingLoggerInfo(kFIRMessagingMessageCodeMessaging013, @"Sending message: %@ with id: %@ to %@.",
+                         message, messageID, to);
   [self.dataMessageManager sendDataMessageStanza:fcmMessage];
 }
 

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -345,6 +345,9 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
 }
 
 - (void)setupTopics {
+  if (!self.client) {
+     FIRMessagingLoggerWarn(kFIRMessagingMessageCodeInvalidClient, @"Invalid nil client before init pubsub.");
+  }
   self.pubsub = [[FIRMessagingPubSub alloc] initWithClient:self.client];
 }
 

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -345,7 +345,6 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
 }
 
 - (void)setupTopics {
-  _FIRMessagingDevAssert(self.client, @"Invalid nil client before init pubsub.");
   self.pubsub = [[FIRMessagingPubSub alloc] initWithClient:self.client];
 }
 
@@ -364,8 +363,6 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
 }
 
 - (void)teardown {
-  _FIRMessagingDevAssert([NSThread isMainThread],
-                         @"FIRMessaging should be called from main thread only.");
   [self.client teardown];
   self.pubsub = nil;
   self.syncMessageManager = nil;
@@ -823,8 +820,6 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
                  to:(NSString *)to
       withMessageID:(NSString *)messageID
          timeToLive:(int64_t)ttl {
-  _FIRMessagingDevAssert([to length] != 0, @"Invalid receiver id for FIRMessaging-message");
-
   NSMutableDictionary *fcmMessage = [[self class] createFIRMessagingMessageWithMessage:message
                                                                            to:to
                                                                        withID:messageID

--- a/Firebase/Messaging/FIRMessagingClient.m
+++ b/Firebase/Messaging/FIRMessagingClient.m
@@ -131,7 +131,9 @@ static NSUInteger FIRMessagingServerPort() {
 }
 
 - (void)teardown {
-  FIRMessagingLoggerDebug(kFIRMessagingMessageCodeClient000, @"");
+  if (![NSThread isMainThread]) {
+    FIRMessagingLoggerDebug(kFIRMessagingMessageCodeClient000, @"FIRMessagingClient should be called from main thread only.");
+  }
   self.stayConnected = NO;
 
   // Clear all the handlers
@@ -178,7 +180,9 @@ static NSUInteger FIRMessagingServerPort() {
                                @"Successfully subscribed to topic %@", topic);
       }
     }
-    handler(error);
+    if (handler) {
+      handler(error);
+    }
   };
 
   if ([[FIRInstanceID instanceID] tryToLoadValidCheckinInfo]) {

--- a/Firebase/Messaging/FIRMessagingClient.m
+++ b/Firebase/Messaging/FIRMessagingClient.m
@@ -140,9 +140,8 @@ static NSUInteger FIRMessagingServerPort() {
   [self.connection teardown];
 
   // Stop all subscription requests
-    [self.registrar stopAllSubscriptionRequests];
+  [self.registrar stopAllSubscriptionRequests];
 
-  _FIRMessagingDevAssert(self.connection.state == kFIRMessagingConnectionNotConnected, @"Did not disconnect");
   [NSObject cancelPreviousPerformRequestsWithTarget:self];
 
   [[NSNotificationCenter defaultCenter] removeObserver:self];
@@ -166,10 +165,7 @@ static NSUInteger FIRMessagingServerPort() {
                             options:(NSDictionary *)options
                        shouldDelete:(BOOL)shouldDelete
                             handler:(FIRMessagingTopicOperationCompletion)handler {
-
-  _FIRMessagingDevAssert(handler != nil, @"Invalid handler to FIRMessaging subscribe");
-
-  FIRMessagingTopicOperationCompletion completion = ^void(NSError *error) {
+    FIRMessagingTopicOperationCompletion completion = ^void(NSError *error) {
     if (error) {
       FIRMessagingLoggerError(kFIRMessagingMessageCodeClient001, @"Failed to subscribe to topic %@",
                               error);
@@ -316,8 +312,6 @@ static NSUInteger FIRMessagingServerPort() {
 
   self.stayConnected = tryToConnectLater;
   [self.connection signOut];
-  _FIRMessagingDevAssert(self.connection.state == kFIRMessagingConnectionNotConnected,
-                @"FIRMessaging connection did not disconnect");
 
   // since we can disconnect while still trying to establish the connection it's required to
   // cancel all performSelectors else the object might be retained
@@ -421,8 +415,6 @@ static NSUInteger FIRMessagingServerPort() {
 - (void)setupConnection {
   NSString *host = FIRMessagingServerHost();
   NSUInteger port = FIRMessagingServerPort();
-  _FIRMessagingDevAssert([host length] > 0 && port != 0, @"Invalid port or host");
-
   if (self.connection != nil) {
     // if there is an old connection, explicitly sign it off.
     [self.connection signOut];
@@ -453,11 +445,6 @@ static NSUInteger FIRMessagingServerPort() {
     return;
   }
 
-  _FIRMessagingDevAssert([FIRInstanceID instanceID].deviceAuthID.length > 0 &&
-                 [FIRInstanceID instanceID].secretToken.length > 0 &&
-                 self.connection != nil,
-                 @"Invalid state cannot connect");
-
   self.connectRetryCount = MIN(kMaxRetryExponent, self.connectRetryCount + 1);
   [self performSelector:@selector(didConnectTimeout)
              withObject:nil
@@ -466,8 +453,6 @@ static NSUInteger FIRMessagingServerPort() {
 }
 
 - (void)didConnectTimeout {
-  _FIRMessagingDevAssert(self.connection.state != kFIRMessagingConnectionSignedIn,
-                @"Invalid state for MCS connection");
 
   if (self.stayConnected) {
     [self.connection signOut];

--- a/Firebase/Messaging/FIRMessagingClient.m
+++ b/Firebase/Messaging/FIRMessagingClient.m
@@ -443,12 +443,14 @@ static NSUInteger FIRMessagingServerPort() {
   [NSObject cancelPreviousPerformRequestsWithTarget:self
                                            selector:@selector(tryToConnect)
                                              object:nil];
-    NSString *deviceAuthID = [FIRInstanceID instanceID].deviceAuthID;
-    NSString *secretToken = [FIRInstanceID instanceID].secretToken;
+  NSString *deviceAuthID = [FIRInstanceID instanceID].deviceAuthID;
+  NSString *secretToken = [FIRInstanceID instanceID].secretToken;
   if (deviceAuthID.length == 0 || secretToken.length == 0 ||
-      !self.connection) {
-      FIRMessagingLoggerWarn(kFIRMessagingMessageCodeClientInvalidState, @"Invalid state to connect, deviceAuthID: %@, secretToken: %@, connection state: %ld", deviceAuthID, secretToken, (long)self.connection.state);
-      return;
+     !self.connection) {
+    FIRMessagingLoggerWarn(kFIRMessagingMessageCodeClientInvalidState,
+              @"Invalid state to connect, deviceAuthID: %@, secretToken: %@, connection state: %ld",
+              deviceAuthID, secretToken, (long)self.connection.state);
+    return;
   }
   // Do not re-sign in if there is already a connection in progress.
   if (self.connection.state != kFIRMessagingConnectionNotConnected) {

--- a/Firebase/Messaging/FIRMessagingCodedInputStream.m
+++ b/Firebase/Messaging/FIRMessagingCodedInputStream.m
@@ -34,7 +34,7 @@ static BOOL CheckSize(BufferState *state, size_t size) {
 }
 
 static BOOL ReadRawByte(BufferState *state, int8_t *output) {
-  if (!state || !output) {
+  if (state == NULL || output == NULL) {
     FIRMessagingLoggerDebug(kFIRMessagingCodeInputStreamInvalidParameters, @"Invalid parameters.");
   }
   if (CheckSize(state, sizeof(int8_t))) {
@@ -45,7 +45,7 @@ static BOOL ReadRawByte(BufferState *state, int8_t *output) {
 }
 
 static BOOL ReadRawVarInt32(BufferState *state, int32_t *output) {
-  if (!state || !output) {
+  if (state == NULL || output == NULL) {
     FIRMessagingLoggerDebug(kFIRMessagingCodeInputStreamInvalidParameters, @"Invalid parameters.");
   }
   int8_t tmp = 0;

--- a/Firebase/Messaging/FIRMessagingCodedInputStream.m
+++ b/Firebase/Messaging/FIRMessagingCodedInputStream.m
@@ -32,7 +32,6 @@ static BOOL CheckSize(BufferState *state, size_t size) {
 }
 
 static BOOL ReadRawByte(BufferState *state, int8_t *output) {
-  _FIRMessagingDevAssert(output != NULL && state != NULL, @"Invalid parameters");
 
   if (CheckSize(state, sizeof(int8_t))) {
     *output = ((int8_t *)state->bytes)[state->bufferPos++];
@@ -42,7 +41,6 @@ static BOOL ReadRawByte(BufferState *state, int8_t *output) {
 }
 
 static BOOL ReadRawVarInt32(BufferState *state, int32_t *output) {
-  _FIRMessagingDevAssert(output != NULL && state != NULL, @"Invalid parameters");
 
   int8_t tmp = 0;
   if (!ReadRawByte(state, &tmp)) {

--- a/Firebase/Messaging/FIRMessagingCodedInputStream.m
+++ b/Firebase/Messaging/FIRMessagingCodedInputStream.m
@@ -15,7 +15,9 @@
  */
 
 #import "Firebase/Messaging/FIRMessagingCodedInputStream.h"
-#import "Firebase/Messaging/FIRMessagingDefines.h"
+
+#import "Firebase/Messaging/FIRMMessageCode.h"
+#import "Firebase/Messaging/FIRMessagingLogger.h"
 
 typedef struct {
   const void *bytes;
@@ -32,7 +34,9 @@ static BOOL CheckSize(BufferState *state, size_t size) {
 }
 
 static BOOL ReadRawByte(BufferState *state, int8_t *output) {
-
+  if (!state || !output) {
+    FIRMessagingLoggerDebug(kFIRMessagingCodeInputStreamInvalidParameters, @"Invalid parameters.");
+  }
   if (CheckSize(state, sizeof(int8_t))) {
     *output = ((int8_t *)state->bytes)[state->bufferPos++];
     return YES;
@@ -41,7 +45,9 @@ static BOOL ReadRawByte(BufferState *state, int8_t *output) {
 }
 
 static BOOL ReadRawVarInt32(BufferState *state, int32_t *output) {
-
+  if (!state || !output) {
+    FIRMessagingLoggerDebug(kFIRMessagingCodeInputStreamInvalidParameters, @"Invalid parameters.");
+  }
   int8_t tmp = 0;
   if (!ReadRawByte(state, &tmp)) {
     return NO;

--- a/Firebase/Messaging/FIRMessagingConnection.m
+++ b/Firebase/Messaging/FIRMessagingConnection.m
@@ -145,7 +145,6 @@ static NSString *const kRemoteFromAddress = @"from";
 }
 
 - (void)signIn {
-  _FIRMessagingDevAssert(self.state == kFIRMessagingConnectionNotConnected, @"Invalid connection state.");
   if (self.state != kFIRMessagingConnectionNotConnected) {
     return;
   }
@@ -201,11 +200,8 @@ static NSString *const kRemoteFromAddress = @"from";
 }
 
 - (void)didDisconnectWithSecureSocket:(FIRMessagingSecureSocket *)socket {
-  _FIRMessagingDevAssert(self.socket == socket, @"Invalid socket");
-  _FIRMessagingDevAssert(self.socket.state == kFIRMessagingSecureSocketClosed, @"Socket already closed");
-
   FIRMessagingLoggerDebug(kFIRMessagingMessageCodeConnection002,
-                          @"Secure socket disconnected from FIRMessaging service.");
+                          @"Secure socket disconnected from FIRMessaging service. %ld", (long)self.socket.state);
   [self disconnect];
   [self.delegate connection:self didCloseForReason:kFIRMessagingConnectionCloseReasonSocketDisconnected];
 }
@@ -295,7 +291,6 @@ static NSString *const kRemoteFromAddress = @"from";
     return;
   }
 
-  _FIRMessagingDevAssert(self.socket != nil, @"Socket shouldn't be nil");
   if (self.socket == nil) {
     return;
   }
@@ -439,10 +434,6 @@ static NSString *const kRemoteFromAddress = @"from";
     return;
   }
   FIRMessagingLoggerDebug(kFIRMessagingMessageCodeConnection012, @"Logged onto MCS service.");
-  // We sent the persisted list of unack'd messages with login so we can assume they have been ack'd
-  // by the server.
-  _FIRMessagingDevAssert(self.unackedS2dIds.count == 0, @"No ids present");
-  _FIRMessagingDevAssert(self.outStreamId == 1, @"Login should be the first stream id");
 
   self.state = kFIRMessagingConnectionSignedIn;
   self.lastLoginServerTimestamp = loginResponse.serverTimestamp;
@@ -660,7 +651,6 @@ static NSString *const kRemoteFromAddress = @"from";
 }
 
 - (void)disconnect {
-  _FIRMessagingDevAssert(self.state != kFIRMessagingConnectionNotConnected, @"Connection already not connected");
   // cancel pending timeout tasks.
   [self cancelConnectionTimeoutTask];
   // cancel pending heartbeat.

--- a/Firebase/Messaging/FIRMessagingContextManagerService.m
+++ b/Firebase/Messaging/FIRMessagingContextManagerService.m
@@ -77,19 +77,16 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
 
 + (BOOL)handleContextManagerLocalTimeMessage:(NSDictionary *)message {
   NSString *startTimeString = message[kFIRMessagingContextManagerLocalTimeStart];
+  if (!startTimeString) {
+    FIRMessagingLoggerError(kFIRMessagingMessageCodeContextManagerService002,
+                              @"Invalid local start date format %@. Message dropped",
+                              startTimeString);
+    return NO;
+  }
   NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
   dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
   [dateFormatter setDateFormat:kLocalTimeFormatString];
   NSDate *startDate = [dateFormatter dateFromString:startTimeString];
-
-  _FIRMessagingDevAssert(startDate, @"Invalid local start date format %@", startTimeString);
-  if (!startTimeString) {
-    FIRMessagingLoggerError(kFIRMessagingMessageCodeContextManagerService002,
-                            @"Invalid local start date format %@. Message dropped",
-                            startTimeString);
-    return NO;
-  }
-
   NSDate *currentDate = [NSDate date];
 
   if ([currentDate compare:startDate] == NSOrderedAscending) {
@@ -106,8 +103,6 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
     }
 
     NSDate *endDate = [dateFormatter dateFromString:endTimeString];
-
-    _FIRMessagingDevAssert(endDate, @"Invalid local end date format %@", endTimeString);
     if (!endTimeString) {
       FIRMessagingLoggerError(kFIRMessagingMessageCodeContextManagerService004,
                               @"Invalid local end date format %@. Message dropped", endTimeString);

--- a/Firebase/Messaging/FIRMessagingDataMessageManager.m
+++ b/Firebase/Messaging/FIRMessagingDataMessageManager.m
@@ -96,8 +96,6 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
 }
 
 - (void)setDeviceAuthID:(NSString *)deviceAuthID secretToken:(NSString *)secretToken {
-  _FIRMessagingDevAssert([deviceAuthID length] && [secretToken length],
-                @"Invalid credentials for FIRMessaging");
   self.deviceAuthID = deviceAuthID;
   self.secretToken = secretToken;
 }
@@ -152,14 +150,12 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
 
   // Add the persistent_id. This would be removed later before sending the message to the device.
   NSString *persistentID = [dataMessage persistentId];
-  _FIRMessagingDevAssert([persistentID length], @"Invalid MCS message without persistentID");
   if ([persistentID length]) {
     message[kFIRMessagingMessageIDKey] = persistentID;
   }
 
   // third-party data
   for (GtalkAppData *item in dataMessage.appDataArray) {
-    _FIRMessagingDevAssert(item.hasKey && item.hasValue, @"Invalid AppData");
 
     // do not process the "from" key -- is not useful
     if ([kFIRMessagingFromKey isEqualToString:item.key]) {
@@ -175,7 +171,6 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
         }
         message[kDataMessageNotificationKey][key] = item.value;
       } else {
-        _FIRMessagingDevAssert([key length], @"Invalid key in MCS message: %@", key);
         FIRMessagingLoggerError(kFIRMessagingMessageCodeDataMessageManager001,
                                 @"Invalid key in MCS message: %@", key);
       }

--- a/Firebase/Messaging/FIRMessagingDataMessageManager.m
+++ b/Firebase/Messaging/FIRMessagingDataMessageManager.m
@@ -96,6 +96,9 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
 }
 
 - (void)setDeviceAuthID:(NSString *)deviceAuthID secretToken:(NSString *)secretToken {
+  if (deviceAuthID.length == 0 || secretToken.length == 0) {
+      FIRMessagingLoggerDebug(kFIRMessagingMessageCodeDataMessageManager013, @"Invalid credentials: deviceAuthID: %@, secrectToken: %@", deviceAuthID, secretToken);
+  }
   self.deviceAuthID = deviceAuthID;
   self.secretToken = secretToken;
 }
@@ -133,24 +136,24 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
 - (NSDictionary *)parseDataMessage:(GtalkDataMessageStanza *)dataMessage {
   NSMutableDictionary *message = [NSMutableDictionary dictionary];
   NSString *from = [dataMessage from];
-  if ([from length]) {
+  if (from.length) {
     message[kFIRMessagingFromKey] = from;
   }
 
   // raw data
   NSData *rawData = [dataMessage rawData];
-  if ([rawData length]) {
+  if (rawData.length) {
     message[kFIRMessagingRawDataKey] = rawData;
   }
 
   NSString *token = [dataMessage token];
-  if ([token length]) {
+  if (token.length) {
     message[kFIRMessagingCollapseKey] = token;
   }
 
   // Add the persistent_id. This would be removed later before sending the message to the device.
   NSString *persistentID = [dataMessage persistentId];
-  if ([persistentID length]) {
+  if (persistentID.length) {
     message[kFIRMessagingMessageIDKey] = persistentID;
   }
 

--- a/Firebase/Messaging/FIRMessagingDataMessageManager.m
+++ b/Firebase/Messaging/FIRMessagingDataMessageManager.m
@@ -97,7 +97,7 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
 
 - (void)setDeviceAuthID:(NSString *)deviceAuthID secretToken:(NSString *)secretToken {
   if (deviceAuthID.length == 0 || secretToken.length == 0) {
-      FIRMessagingLoggerDebug(kFIRMessagingMessageCodeDataMessageManager013, @"Invalid credentials: deviceAuthID: %@, secrectToken: %@", deviceAuthID, secretToken);
+      FIRMessagingLoggerWarn(kFIRMessagingMessageCodeDataMessageManager013, @"Invalid credentials: deviceAuthID: %@, secrectToken: %@", deviceAuthID, secretToken);
   }
   self.deviceAuthID = deviceAuthID;
   self.secretToken = secretToken;

--- a/Firebase/Messaging/FIRMessagingDefines.h
+++ b/Firebase/Messaging/FIRMessagingDefines.h
@@ -17,16 +17,6 @@
 #ifndef FIRMessaging_xcodeproj_FIRMessagingDefines_h
 #define FIRMessaging_xcodeproj_FIRMessagingDefines_h
 
-#define _FIRMessaging_VERBOSE_LOGGING 1
-
-// Verbose Logging
-#if (_FIRMessaging_VERBOSE_LOGGING)
-#define FIRMessaging_DEV_VERBOSE_LOG(...) NSLog(__VA_ARGS__)
-#else
-#define FIRMessaging_DEV_VERBOSE_LOG(...) do { } while (0)
-#endif // FIRMessaging_VERBOSE_LOGGING
-
-
 // WEAKIFY & STRONGIFY
 // Helper macro.
 #define _FIRMessaging_WEAKNAME(VAR) VAR ## _weak_
@@ -40,45 +30,18 @@ __strong __typeof__(VAR) VAR = _FIRMessaging_WEAKNAME(VAR); \
 _Pragma("clang diagnostic pop")
 
 
-// Type Conversions (used for NSInteger etc)
-#ifndef _FIRMessaging_L
-#define _FIRMessaging_L(v) (long)(v)
-#endif
-
 #ifndef _FIRMessaging_UL
 #define _FIRMessaging_UL(v) (unsigned long)(v)
 #endif
 
 #endif
 
-// Debug Assert
-#ifndef _FIRMessagingDevAssert
-// we directly invoke the NSAssert handler so we can pass on the varargs
-// (NSAssert doesn't have a macro we can use that takes varargs)
-#ifdef DEBUG
-#define _FIRMessagingDevAssert(condition, ...)                                       \
-  do {                                                                      \
-    if (!(condition)) {                                                     \
-      [[NSAssertionHandler currentHandler]                                  \
-          handleFailureInFunction:(NSString *)                              \
-                                      [NSString stringWithUTF8String:__PRETTY_FUNCTION__] \
-                             file:(NSString *)[NSString stringWithUTF8String:__FILE__]  \
-                       lineNumber:__LINE__                                  \
-                      description:__VA_ARGS__];                             \
-    }                                                                       \
-  } while(0)
-#else // !defined(DEBUG)
-#define _FIRMessagingDevAssert(condition, ...) do { } while (0)
-#endif // !defined(DEBUG)
-
-#endif // _FIRMessagingDevAssert
-
 // Invalidates the initializer from which it's called.
 #ifndef FIRMessagingInvalidateInitializer
 #define FIRMessagingInvalidateInitializer() \
   do { \
     [self class]; /* Avoid warning of dead store to |self|. */ \
-    _FIRMessagingDevAssert(NO, @"Invalid initializer."); \
+    NSAssert(NO, @"Invalid initializer."); \
     return nil; \
   } while (0)
 #endif

--- a/Firebase/Messaging/FIRMessagingDelayedMessageQueue.m
+++ b/Firebase/Messaging/FIRMessagingDelayedMessageQueue.m
@@ -49,7 +49,6 @@ static const int kMaxQueuedMessageCount = 10;
 
 - (instancetype)initWithRmqScanner:(id<FIRMessagingRmqScanner>)rmqScanner
         sendDelayedMessagesHandler:(FIRMessagingSendDelayedMessagesHandler)sendDelayedMessagesHandler {
-  _FIRMessagingDevAssert(sendDelayedMessagesHandler, @"Invalid nil callback for delayed messages");
   self = [super init];
   if (self) {
     _rmqScanner = rmqScanner;

--- a/Firebase/Messaging/FIRMessagingPubSub.m
+++ b/Firebase/Messaging/FIRMessagingPubSub.m
@@ -104,7 +104,6 @@ static NSString *const kPendingSubscriptionsListKey =
     handler([NSError errorWithFCMErrorCode:kFIRMessagingErrorCodePubSubFIRMessagingNotSetup]);
     return;
   }
-
   token = [token copy];
   topic = [topic copy];
   if (![options count]) {

--- a/Firebase/Messaging/FIRMessagingPubSub.m
+++ b/Firebase/Messaging/FIRMessagingPubSub.m
@@ -59,8 +59,6 @@ static NSString *const kPendingSubscriptionsListKey =
                      topic:(NSString *)topic
                    options:(NSDictionary *)options
                    handler:(FIRMessagingTopicOperationCompletion)handler {
-  _FIRMessagingDevAssert([token length], @"FIRMessaging error no token specified");
-  _FIRMessagingDevAssert([topic length], @"FIRMessaging error Invalid empty topic specified");
   if (!self.client) {
     handler([NSError errorWithFCMErrorCode:kFIRMessagingErrorCodePubSubFIRMessagingNotSetup]);
     return;
@@ -102,9 +100,6 @@ static NSString *const kPendingSubscriptionsListKey =
                        topic:(NSString *)topic
                      options:(NSDictionary *)options
                      handler:(FIRMessagingTopicOperationCompletion)handler {
-  _FIRMessagingDevAssert([token length], @"FIRMessaging error no token specified");
-  _FIRMessagingDevAssert([topic length], @"FIRMessaging error Invalid empty topic specified");
-
   if (!self.client) {
     handler([NSError errorWithFCMErrorCode:kFIRMessagingErrorCodePubSubFIRMessagingNotSetup]);
     return;

--- a/Firebase/Messaging/FIRMessagingRmqManager.m
+++ b/Firebase/Messaging/FIRMessagingRmqManager.m
@@ -51,7 +51,6 @@ static NSString *const kFCMRmqTag = @"FIRMessagingRmq:";
 - (instancetype)initWithDatabaseName:(NSString *)databaseName {
   self = [super init];
   if (self) {
-    _FIRMessagingDevAssert([databaseName length] > 0, @"RMQ: Invalid rmq db name");
     _rmq2Store = [[FIRMessagingRmq2PersistentStore alloc] initWithDatabaseName:databaseName];
     _outstandingMessages = [NSMutableDictionary dictionaryWithCapacity:2];
     _rmqId = -1;

--- a/Firebase/Messaging/FIRMessagingSecureSocket.m
+++ b/Firebase/Messaging/FIRMessagingSecureSocket.m
@@ -97,10 +97,6 @@ static NSUInteger SerializedSize(int32_t value) {
 - (void)connectToHost:(NSString *)host
                  port:(NSUInteger)port
             onRunLoop:(NSRunLoop *)runLoop {
-  _FIRMessagingDevAssert(host != nil, @"Invalid host");
-  _FIRMessagingDevAssert(runLoop != nil, @"Invalid runloop");
-  _FIRMessagingDevAssert(self.state == kFIRMessagingSecureSocketNotOpen, @"Socket is already connected");
-
   if (!host || self.state != kFIRMessagingSecureSocketNotOpen) {
     return;
   }
@@ -140,8 +136,6 @@ static NSUInteger SerializedSize(int32_t value) {
   if (!self.inStream && !self.outStream) {
     FIRMessagingLoggerDebug(kFIRMessagingMessageCodeSecureSocket002,
                             @"The socket is not open or already closed.");
-    _FIRMessagingDevAssert(self.state == kFIRMessagingSecureSocketClosed || self.state == kFIRMessagingSecureSocketNotOpen,
-                  @"Socket is already disconnected.");
     return;
   }
 
@@ -175,7 +169,6 @@ static NSUInteger SerializedSize(int32_t value) {
                                 @"Try to read from socket that is not opened");
         return;
       }
-      _FIRMessagingDevAssert(stream == self.inStream, @"Incorrect stream");
       if (![self performRead]) {
         FIRMessagingLoggerDebug(kFIRMessagingMessageCodeSecureSocket004,
                                 @"Error occurred when reading incoming stream");
@@ -218,7 +211,6 @@ static NSUInteger SerializedSize(int32_t value) {
                                 @"Try to write to socket that is not opened");
         return;
       }
-      _FIRMessagingDevAssert(stream == self.outStream, @"Incorrect stream");
       [self performWrite];
       break;
     default:
@@ -229,11 +221,7 @@ static NSUInteger SerializedSize(int32_t value) {
 #pragma mark - Private
 
 - (void)openStream:(NSStream *)stream isVOIPStream:(BOOL)isVOIPStream {
-  _FIRMessagingDevAssert(stream != nil, @"Invalid stream");
-  _FIRMessagingDevAssert(self.runLoop != nil, @"Invalid runloop");
-
   if (stream) {
-    _FIRMessagingDevAssert([stream streamStatus] == NSStreamStatusNotOpen, @"Stream already open");
     if ([stream streamStatus] != NSStreamStatusNotOpen) {
       FIRMessagingLoggerDebug(kFIRMessagingMessageCodeSecureSocket009,
                               @"stream should not be open.");
@@ -252,9 +240,6 @@ static NSUInteger SerializedSize(int32_t value) {
 }
 
 - (void)closeStream:(NSStream *)stream {
-  _FIRMessagingDevAssert(stream != nil, @"Invalid stream");
-  _FIRMessagingDevAssert(self.runLoop != nil, @"Invalid runloop");
-
   if (stream) {
     [stream close];
     [stream removeFromRunLoop:self.runLoop forMode:NSDefaultRunLoopMode];
@@ -263,8 +248,6 @@ static NSUInteger SerializedSize(int32_t value) {
 }
 
 - (BOOL)performRead {
-  _FIRMessagingDevAssert(self.state == kFIRMessagingSecureSocketOpen, @"Socket should be open");
-
   if (!self.isVersionReceived) {
     self.isVersionReceived = YES;
     uint8_t versionByte = 0;
@@ -279,11 +262,6 @@ static NSUInteger SerializedSize(int32_t value) {
 
   while (YES) {
     BOOL isInputBufferValid = [self.inputBuffer length] > 0;
-    _FIRMessagingDevAssert(isInputBufferValid,
-                  @"Invalid input buffer size %lu. Used bytes length %lu, buffer content: %@",
-                  _FIRMessaging_UL([self.inputBuffer length]),
-                  _FIRMessaging_UL(self.inputBufferLength),
-                  self.inputBuffer);
     if (!isInputBufferValid) {
       FIRMessagingLoggerDebug(kFIRMessagingMessageCodeSecureSocket011,
                               @"Input buffer is not valid.");
@@ -323,12 +301,9 @@ static NSUInteger SerializedSize(int32_t value) {
                               _FIRMessaging_UL(self.inputBufferLength),
                               _FIRMessaging_UL([self.inputBuffer length]));
       [self.inputBuffer increaseLengthBy:kBufferLengthIncrement];
-      _FIRMessagingDevAssert([self.inputBuffer length] > self.inputBufferLength, @"Invalid buffer size");
     }
 
     while (self.inputBufferLength > 0 && [self.inputBuffer length] > 0) {
-      _FIRMessagingDevAssert([self.inputBuffer length] >= self.inputBufferLength,
-                             @"Buffer longer than length");
       NSRange inputRange = NSMakeRange(0, self.inputBufferLength);
       size_t protoBytes = 0;
       // read the actual proto data coming in
@@ -342,7 +317,6 @@ static NSUInteger SerializedSize(int32_t value) {
       } else if (readResult == kFIRMessagingSecureSocketReadResultIncomplete) {
         break;
       }
-      _FIRMessagingDevAssert(self.inputBufferLength >= protoBytes, @"More bytes than buffer can handle");
       // we have read (0, protoBytes) of data in the inputBuffer
       if (protoBytes == self.inputBufferLength) {
         // did completely read the buffer data can be reset for further processing
@@ -354,12 +328,6 @@ static NSUInteger SerializedSize(int32_t value) {
         [self.inputBuffer replaceBytesInRange:NSMakeRange(0, protoBytes) withBytes:NULL length:0];
         // reallocate more data
         [self.inputBuffer increaseLengthBy:protoBytes];
-        _FIRMessagingDevAssert([self.inputBuffer length] == prevLength,
-                               @"Invalid input buffer size %lu. Used bytes length %lu, "
-                               @"buffer content: %@",
-                               _FIRMessaging_UL([self.inputBuffer length]),
-                               _FIRMessaging_UL(self.inputBufferLength),
-                               self.inputBuffer);
         self.inputBufferLength -= protoBytes;
       }
     }
@@ -381,7 +349,6 @@ static NSUInteger SerializedSize(int32_t value) {
     return kFIRMessagingSecureSocketReadResultIncomplete;
   }
   // NOTE tag can be zero for |HeartbeatPing|, and length can be zero for |Close| proto
-  _FIRMessagingDevAssert(rawTag >= 0 && length >= 0, @"Invalid tag or length");
   if (rawTag < 0 || length < 0) {
     FIRMessagingLoggerDebug(kFIRMessagingMessageCodeSecureSocket015, @"Buffer data corrupted.");
     return kFIRMessagingSecureSocketReadResultCorrupt;
@@ -399,8 +366,6 @@ static NSUInteger SerializedSize(int32_t value) {
 }
 
 - (void)performWrite {
-  _FIRMessagingDevAssert(self.state == kFIRMessagingSecureSocketOpen, @"Invalid socket state");
-
   if (!self.isVersionSent) {
     self.isVersionSent = YES;
     uint8_t versionByte = kVersion;

--- a/Firebase/Messaging/FIRMessagingSyncMessageManager.m
+++ b/Firebase/Messaging/FIRMessagingSyncMessageManager.m
@@ -40,7 +40,6 @@ static const uint64_t kMinFreeDiskSpaceInMB = 1;
 }
 
 - (instancetype)initWithRmqManager:(FIRMessagingRmqManager *)rmqManager {
-  _FIRMessagingDevAssert(rmqManager, @"Invalid nil rmq manager while initalizing sync message manager");
   self = [super init];
   if (self) {
     _rmqManager = rmqManager;
@@ -72,7 +71,6 @@ static const uint64_t kMinFreeDiskSpaceInMB = 1;
                       viaAPNS:(BOOL)viaAPNS
                        viaMCS:(BOOL)viaMCS {
   NSString *rmqID = message[kFIRMessagingMessageIDKey];
-  _FIRMessagingDevAssert([rmqID length], @"Invalid nil rmqID for message");
   if (![rmqID length]) {
     FIRMessagingLoggerError(kFIRMessagingMessageCodeSyncMessageManager002,
                             @"Invalid nil rmqID for sync message.");

--- a/Firebase/Messaging/FIRMessagingTopicOperation.m
+++ b/Firebase/Messaging/FIRMessagingTopicOperation.m
@@ -217,7 +217,7 @@ NSString *FIRMessagingSubscriptionsServer() {
       }
       FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTopicOption001,
                               @"Device registration HTTP fetch error. Error Code: %ld",
-                              _FIRMessaging_L(error.code));
+                              (long)error.code);
       [self finishWithError:error];
       return;
     }
@@ -229,7 +229,6 @@ NSString *FIRMessagingSubscriptionsServer() {
       return;
     }
     NSArray *parts = [response componentsSeparatedByString:@"="];
-    _FIRMessagingDevAssert(parts.count, @"Invalid registration response");
     if (![parts[0] isEqualToString:@"token"] || parts.count <= 1) {
       FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTopicOption002,
                               @"Invalid registration response %@", response);

--- a/Firebase/Messaging/FIRMessagingVersionUtilities.m
+++ b/Firebase/Messaging/FIRMessagingVersionUtilities.m
@@ -39,7 +39,6 @@ void FIRMessagingParseCurrentLibraryVersion(void) {
     // Parse versions
     // major, minor, patch[-beta#]
     allVersions = [daylightVersion componentsSeparatedByString:kSemanticVersioningSeparator];
-    _FIRMessagingDevAssert(allVersions.count == 3, @"Invalid versioning of FIRMessaging library");
     if (allVersions.count == 3) {
       majorVersion = [allVersions[0] intValue];
       minorVersion = [allVersions[1] intValue];
@@ -47,7 +46,6 @@ void FIRMessagingParseCurrentLibraryVersion(void) {
       // Parse patch and beta versions
       NSArray *patchAndBetaVersion =
           [allVersions[2] componentsSeparatedByString:kBetaVersionPrefix];
-      _FIRMessagingDevAssert(patchAndBetaVersion.count <= 2, @"Invalid versioning of FIRMessaging library");
       if (patchAndBetaVersion.count == 2) {
         patchVersion = [patchAndBetaVersion[0] intValue];
         betaVersion = [patchAndBetaVersion[1] intValue];


### PR DESCRIPTION
Remove _FIRMessagingDevAssert that are only called if a DEBUG flag, which is never set in both debug/production build. Most of the assert logics are already been checked in the code, for the ones that are not, we replace it with a debugLog.
Also remove a few macros that are either not used at all or barely used.