### PR TITLE
Run Auth integration tests only in Auth travis phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=ios
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=tvos
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=macos
-        # TODO (renkelvin) Uncomment next line when Auth backend is fixed to support the integration tests.
-        # - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
+        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,8 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=ios
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=tvos
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=macos
-        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
+        # TODO (renkelvin) Uncomment next line when Auth backend is fixed for the integration tests.
+        # - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
       env:

--- a/Example/Auth/AuthSample/AuthSample.xcodeproj/project.pbxproj
+++ b/Example/Auth/AuthSample/AuthSample.xcodeproj/project.pbxproj
@@ -42,7 +42,6 @@
 		DE800B8822A592B100AC9A23 /* AccountInfoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DE800B7D22A592B100AC9A23 /* AccountInfoTests.m */; };
 		DE800B8922A592B100AC9A23 /* FacebookAuthTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DE800B7F22A592B100AC9A23 /* FacebookAuthTests.m */; };
 		DE800B8A22A592B100AC9A23 /* CustomAuthTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DE800B8022A592B100AC9A23 /* CustomAuthTests.m */; };
-		DE800B8B22A592B100AC9A23 /* GoogleAuthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE800B8222A592B100AC9A23 /* GoogleAuthTests.swift */; };
 		DE800B8C22A592B100AC9A23 /* AnonymousAuthTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DE800B8322A592B100AC9A23 /* AnonymousAuthTests.m */; };
 		DE800B8E22A592B100AC9A23 /* FIRAuthApiTestsBase.m in Sources */ = {isa = PBXBuildFile; fileRef = DE800B8522A592B100AC9A23 /* FIRAuthApiTestsBase.m */; };
 		DE800B8F22A592B100AC9A23 /* GoogleAuthTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DE800B8622A592B100AC9A23 /* GoogleAuthTests.m */; };
@@ -141,7 +140,6 @@
 		DE800B7F22A592B100AC9A23 /* FacebookAuthTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FacebookAuthTests.m; path = ../../ApiTests/FacebookAuthTests.m; sourceTree = "<group>"; };
 		DE800B8022A592B100AC9A23 /* CustomAuthTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CustomAuthTests.m; path = ../../ApiTests/CustomAuthTests.m; sourceTree = "<group>"; };
 		DE800B8122A592B100AC9A23 /* FIRAuthApiTestsBase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FIRAuthApiTestsBase.h; path = ../../ApiTests/FIRAuthApiTestsBase.h; sourceTree = "<group>"; };
-		DE800B8222A592B100AC9A23 /* GoogleAuthTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = GoogleAuthTests.swift; path = ../../ApiTests/GoogleAuthTests.swift; sourceTree = "<group>"; };
 		DE800B8322A592B100AC9A23 /* AnonymousAuthTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AnonymousAuthTests.m; path = ../../ApiTests/AnonymousAuthTests.m; sourceTree = "<group>"; };
 		DE800B8422A592B100AC9A23 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../../ApiTests/Info.plist; sourceTree = "<group>"; };
 		DE800B8522A592B100AC9A23 /* FIRAuthApiTestsBase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FIRAuthApiTestsBase.m; path = ../../ApiTests/FIRAuthApiTestsBase.m; sourceTree = "<group>"; };
@@ -293,7 +291,6 @@
 				DE800B8122A592B100AC9A23 /* FIRAuthApiTestsBase.h */,
 				DE800B8522A592B100AC9A23 /* FIRAuthApiTestsBase.m */,
 				DE800B8622A592B100AC9A23 /* GoogleAuthTests.m */,
-				DE800B8222A592B100AC9A23 /* GoogleAuthTests.swift */,
 				DE800B8422A592B100AC9A23 /* Info.plist */,
 			);
 			path = Auth_ApiTests;
@@ -483,7 +480,6 @@
 				DE800B8722A592B100AC9A23 /* EmailPasswordAuthTests.m in Sources */,
 				DE800B8E22A592B100AC9A23 /* FIRAuthApiTestsBase.m in Sources */,
 				DE800B8922A592B100AC9A23 /* FacebookAuthTests.m in Sources */,
-				DE800B8B22A592B100AC9A23 /* GoogleAuthTests.swift in Sources */,
 				DE800B8F22A592B100AC9A23 /* GoogleAuthTests.m in Sources */,
 				DE800B8822A592B100AC9A23 /* AccountInfoTests.m in Sources */,
 			);

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -204,17 +204,6 @@ case "$product-$method-$platform" in
       # Code Coverage collection is only working on iOS currently.
       ./scripts/collect_metrics.sh 'Example/Firebase.xcworkspace' "AllUnitTests_$platform"
 
-      # Run integration tests (not allowed on forks)
-      if [[ "$TRAVIS_PULL_REQUEST" == "false" ||
-            "$TRAVIS_PULL_REQUEST_SLUG" == "$TRAVIS_REPO_SLUG" ]]; then
-        RunXcodebuild \
-          -workspace 'Example/Firebase.xcworkspace' \
-          -scheme "Auth_ApiTests" \
-          "${xcb_flags[@]}" \
-          build \
-          test
-      fi
-
       # Test iOS Objective-C static library build
       cd Example
       sed -i -e 's/use_frameworks/\#use_frameworks/' Podfile


### PR DESCRIPTION
The first Travis phase started failing yesterday because of an Auth backend issue.

- Restore travis success
- Move Auth integration tests to the Auth specific phase
- Fix AuthSample xcproject issue for deleting file
- Recomment integration test runs while backend is broken.