### PR TITLE
Remove support for cached zip builds.

### DIFF
--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -31,13 +31,6 @@ public enum CocoaPodUtils {
 
     /// The location of the pod on disk.
     var installedLocation: URL
-
-    /// Default initializer. Explicitly declared to take advantage of default arguments.
-    init(name: String, version: String, installedLocation: URL) {
-      self.name = name
-      self.version = version
-      self.installedLocation = installedLocation
-    }
   }
 
   /// Executes the `pod cache clean --all` command to remove any cached CocoaPods.

--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -76,78 +76,43 @@ struct FrameworkBuilder {
   /// - Parameters:
   ///   - framework: The name of the Framework being built.
   ///   - version: String representation of the version.
-  ///   - cacheKey: The key used for caching this framework build. If nil, the framework name will
-  ///               be used.
-  ///   - cacheEnabled: Flag for enabling the cache. Defaults to false.
   /// - Parameter logsOutputDir: The path to the directory to place build logs.
   /// - Returns: A URL to the framework that was built (or pulled from the cache).
   public func buildFramework(withName podName: String,
                              version: String,
-                             cacheKey: String?,
-                             cacheEnabled: Bool = false,
                              logsOutputDir: URL? = nil) -> URL {
     print("Building \(podName)")
-
-//  Cache is temporarily disabled due to pod cache list issues.
-    // Get the CocoaPods cache to see if we can pull from any frameworks already built.
-//    let podsCache = CocoaPodUtils.listPodCache(inDir: projectDir)
-//
-//    guard let cachedVersions = podsCache[podName] else {
-//      fatalError("Cannot find a pod cache for framework \(podName).")
-//    }
-//
-//    guard let podInfo = cachedVersions[version] else {
-//      fatalError("""
-//      Cannot find a pod cache for framework \(podName) at version \(version).
-//      Something could be wrong with your CocoaPods cache - try running the following:
-//
-//      pod cache clean '\(podName)' --all
-//      """)
-//    }
-//
-//    // TODO: Figure out if we need the MD5 at all.
-    let md5 = podName
-//    let md5 = Shell.calculateMD5(for: podInfo.installedLocation)
 
     // Get (or create) the cache directory for storing built frameworks.
     let fileManager = FileManager.default
     var cachedFrameworkRoot: URL
     do {
       let cacheDir = try fileManager.firebaseCacheDirectory()
-      cachedFrameworkRoot = cacheDir.appendingPathComponents([podName, version, md5])
-      if let cacheKey = cacheKey {
-        cachedFrameworkRoot.appendPathComponent(cacheKey)
-      }
+      cachedFrameworkRoot = cacheDir.appendingPathComponents([podName, version])
     } catch {
       fatalError("Could not create caches directory for building frameworks: \(error)")
     }
 
     // Build the full cached framework path.
     let cachedFrameworkDir = cachedFrameworkRoot.appendingPathComponent("\(podName).framework")
-    let cachedFrameworkExists = fileManager.directoryExists(at: cachedFrameworkDir)
-    if cachedFrameworkExists, cacheEnabled {
-      print("Framework \(podName) version \(version) has already been built and cached at " +
-        "\(cachedFrameworkDir)")
-      return cachedFrameworkDir
-    } else {
-      let frameworkDir = compileFrameworkAndResources(withName: podName)
-      do {
-        // Remove the previously cached framework, if it exists, otherwise the `moveItem` call will
-        // fail.
-        if cachedFrameworkExists {
-          try fileManager.removeItem(at: cachedFrameworkDir)
-        } else if !fileManager.directoryExists(at: cachedFrameworkRoot) {
-          // If the root directory doesn't exist, create it so the `moveItem` will succeed.
-          try fileManager.createDirectory(at: cachedFrameworkRoot,
-                                          withIntermediateDirectories: true)
-        }
+    let frameworkDir = compileFrameworkAndResources(withName: podName)
+    do {
+      // Remove the previously cached framework if it exists, otherwise the `moveItem` call will
+      // fail.
+      fileManager.removeDirectoryIfExists(at: cachedFrameworkDir)
 
-        // Move the newly built framework to the cache directory.
-        try fileManager.moveItem(at: frameworkDir, to: cachedFrameworkDir)
-        return cachedFrameworkDir
-      } catch {
-        fatalError("Could not move built frameworks into the cached frameworks directory: \(error)")
+      // Create the root cache directory if it doesn't exist.
+      if !fileManager.directoryExists(at: cachedFrameworkRoot) {
+        // If the root directory doesn't exist, create it so the `moveItem` will succeed.
+        try fileManager.createDirectory(at: cachedFrameworkRoot,
+                                        withIntermediateDirectories: true)
       }
+
+      // Move the newly built framework to the cache directory.
+      try fileManager.moveItem(at: frameworkDir, to: cachedFrameworkDir)
+      return cachedFrameworkDir
+    } catch {
+      fatalError("Could not move built frameworks into the cached frameworks directory: \(error)")
     }
   }
 

--- a/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
+++ b/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
@@ -39,10 +39,8 @@ extension FileManager: FileChecker {}
 struct LaunchArgs {
   /// Keys associated with the launch args. See `Usage` for descriptions of each flag.
   private enum Key: String, CaseIterable {
-    case cacheEnabled
     case carthageDir
     case customSpecRepos
-    case deleteCache
     case existingVersions
     case outputDir
     case releasingSDKs
@@ -53,16 +51,11 @@ struct LaunchArgs {
     /// Usage description for the key.
     var usage: String {
       switch self {
-      case .cacheEnabled:
-        return "A flag to control using the cache for frameworks."
       case .carthageDir:
         return "The directory pointing to all Carthage JSON manifests. Passing this flag enables" +
           "the Carthage build."
       case .customSpecRepos:
         return "A comma separated list of custom CocoaPod Spec repos."
-      case .deleteCache:
-        return "A flag to empty the cache. Note: if this flag and the `cacheEnabled` flag is " +
-          "set, it will fail since that's probably unintended."
       case .existingVersions:
         return "The file path to a textproto file containing the existing released SDK versions, " +
           "of type `ZipBuilder_FirebaseSDKs`."
@@ -105,12 +98,6 @@ struct LaunchArgs {
   /// The path to the directory containing the blank xcodeproj and Info.plist for building source
   /// based frameworks.
   let templateDir: URL
-
-  /// A flag to control using the cache for frameworks.
-  let cacheEnabled: Bool
-
-  /// A flag to delete the cache from the cache directory.
-  let deleteCache: Bool
 
   /// The release candidate number, zero indexed.
   let rcNumber: Int?
@@ -233,16 +220,6 @@ struct LaunchArgs {
     }
 
     updatePodRepo = defaults.bool(forKey: Key.updatePodRepo.rawValue)
-
-    // Parse the cache keys. If no value is provided for each, it defaults to `false`.
-    cacheEnabled = defaults.bool(forKey: Key.cacheEnabled.rawValue)
-    deleteCache = defaults.bool(forKey: Key.deleteCache.rawValue)
-
-    if deleteCache, cacheEnabled {
-      LaunchArgs.exitWithUsageAndLog("Invalid pair - attempted to delete the cache and enable " +
-        "it at the same time. Please remove on of the keys and try " +
-        "again.")
-    }
   }
 
   /// Prints an error that occurred, the proper usage String, and quits the application.

--- a/ZipBuilder/Sources/ZipBuilder/main.swift
+++ b/ZipBuilder/Sources/ZipBuilder/main.swift
@@ -16,18 +16,16 @@
 
 import Foundation
 
+// Delete the cache directory, if it exists.
+do {
+  let cacheDir = try FileManager.default.firebaseCacheDirectory()
+  FileManager.default.removeDirectoryIfExists(at: cacheDir)
+} catch {
+  fatalError("Could not remove the cache before packaging the release: \(error)")
+}
+
 // Get the launch arguments, parsed by user defaults.
 let args = LaunchArgs()
-
-// Clear the cache if requested.
-if args.deleteCache {
-  do {
-    let cacheDir = try FileManager.default.firebaseCacheDirectory()
-    try FileManager.default.removeItem(at: cacheDir)
-  } catch {
-    fatalError("Could not empty the cache before building the zip file: \(error)")
-  }
-}
 
 // Keep timing for how long it takes to build the zip file for information purposes.
 let buildStart = Date()
@@ -43,9 +41,7 @@ var paths = ZipBuilder.FilesystemPaths(templateDir: args.templateDir)
 paths.allSDKsPath = args.allSDKsPath
 paths.currentReleasePath = args.currentReleasePath
 paths.logsOutputDir = args.outputDir?.appendingPathComponent("build_logs")
-let builder = ZipBuilder(paths: paths,
-                         customSpecRepos: args.customSpecRepos,
-                         useCache: args.cacheEnabled)
+let builder = ZipBuilder(paths: paths, customSpecRepos: args.customSpecRepos)
 
 do {
   // Build the zip file and get the path.


### PR DESCRIPTION
This never really worked that well, and isn't used since we're now
building the zip file on Kokoro. Quick iterations can be handled with
changing the `podsToInstall` variable leaving this code outdated and
unnecessary.