### PR TITLE
Ensure Messaging instance is usable after FIRApp's `delete`

### DIFF
--- a/Example/Messaging/Tests/FIRMessagingInstanceTest.swift
+++ b/Example/Messaging/Tests/FIRMessagingInstanceTest.swift
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import FirebaseCore
+import FirebaseMessaging
+import XCTest
+
+class FIRMessagingInstanceTest: XCTestCase {
+
+  func testSingleton_worksAfterDelete() {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+    let options = FirebaseOptions(googleAppID: "1:123:ios:123abc", gcmSenderID: "valid-sender-id")
+    FirebaseApp.configure(options: options)
+    let original = Messaging.messaging()
+
+    // Ensure the client is set up as expected.
+    guard let isOrigClientSetup = original.value(forKey: "isClientSetup") as? Bool else {
+      XCTFail("Could not get internal Messaging variable `isClientSetup`.")
+      return
+    }
+
+    XCTAssertTrue(isOrigClientSetup, "Property `isClientSetup` should be true after creation.")
+
+    // Get and delete the default app.
+    guard let defaultApp = FirebaseApp.app() else {
+      XCTFail("Default app was not configured properly.")
+      return
+    }
+
+    // The delete API is synchronous, so the default app will be deleted afterwards.
+    defaultApp.delete { (success) in
+      XCTAssertTrue(success, "FirebaseApp deletion should be successful")
+    }
+
+    XCTAssertNil(FirebaseApp.app(), "The default app should be `nil` at this point.")
+
+    // Re-configure the app to trigger Messaging to re-instantiate.
+    FirebaseApp.configure(options: options)
+
+    // Get another instance of Messaging, make sure it's not the same instance.
+    let postDelete = Messaging.messaging()
+    XCTAssertNotEqual(original, postDelete)
+
+    // Ensure the new client is set up as expected.
+    guard let isClientSetup = postDelete.value(forKey: "isClientSetup") as? Bool else {
+      XCTFail("Could not get internal Messaging variable `isClientSetup`.")
+      return
+    }
+
+    XCTAssertTrue(isClientSetup, "Property `isClientSetup` should be true after creation.")
+  }
+}

--- a/Example/Messaging/Tests/FIRMessagingTest.m
+++ b/Example/Messaging/Tests/FIRMessagingTest.m
@@ -61,7 +61,6 @@ NSString *const kFIRMessagingDefaultsTestDomain = @"com.messaging.tests";
   NSUserDefaults *defaults =
       [[NSUserDefaults alloc] initWithSuiteName:kFIRMessagingDefaultsTestDomain];
   _messaging = [FIRMessagingTestUtilities messagingForTestsWithUserDefaults:defaults];
-
   _mockFirebaseApp = OCMClassMock([FIRApp class]);
    OCMStub([_mockFirebaseApp defaultApp]).andReturn(_mockFirebaseApp);
   _mockInstanceID = OCMPartialMock(self.messaging.instanceID);

--- a/Firebase/Messaging/CHANGELOG.md
+++ b/Firebase/Messaging/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 2019-08-20 -- v4.1.3
 - [changed] Cleaned up the documents, unused macros, and folders. (#3490, #3537, #3556, #3498)
 - [changed] Updated the header path to pod repo relative. (#3527)
-- [fixed] Fix singleton functionality after a FirebaseApp is deleted and recreated. (#3579)
+- [fixed] Fix singleton functionality after a FirebaseApp is deleted and recreated. (#3411)
 
 # 2019-08-08 -- v4.1.2
 - [fixed] Fix hang when token is not available before topic subscription and unsubscription. (#3438)

--- a/Firebase/Messaging/CHANGELOG.md
+++ b/Firebase/Messaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fix singleton functionality after a FirebaseApp is deleted and recreated. (#3579)
+
 # 2019-08-08 -- v4.1.2
 - [fixed] Fix hang when token is not available before topic subscription and unsubscription. (#3438)
 

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -167,13 +167,7 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
       FIR_COMPONENT(FIRMessagingInstanceProvider, defaultApp.container);
 
   // We know the instance coming from the container is a FIRMessaging instance, cast it and move on.
-  FIRMessaging *messaging = (FIRMessaging *)instance;
-
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    [messaging start];
-  });
-  return messaging;
+  return (FIRMessaging *)instance;
 }
 
 + (FIRMessagingExtensionHelper *)extensionHelper {
@@ -220,9 +214,12 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
     // Ensure it's cached so it returns the same instance every time messaging is called.
     *isCacheable = YES;
     id<FIRAnalyticsInterop> analytics = FIR_COMPONENT(FIRAnalyticsInterop, container);
-        return [[FIRMessaging alloc] initWithAnalytics:analytics
-                                        withInstanceID:[FIRInstanceID instanceID]
-                                      withUserDefaults:[GULUserDefaults standardUserDefaults]];
+    FIRMessaging *messaging =
+        [[FIRMessaging alloc] initWithAnalytics:analytics
+                                 withInstanceID:[FIRInstanceID instanceID]
+                               withUserDefaults:[GULUserDefaults standardUserDefaults]];
+    [messaging start];
+    return messaging;
   };
   FIRComponent *messagingProvider =
       [FIRComponent componentWithProtocol:@protocol(FIRMessagingInstanceProvider)

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -52,7 +52,7 @@ device, and it is completely free.
   s.dependency 'Protobuf', '~> 3.1'
 
   s.test_spec 'unit' do |unit_tests|
-    unit_tests.source_files = 'Example/Messaging/Tests/*.[mh]'
+    unit_tests.source_files = 'Example/Messaging/Tests/*.{m,h,swift}'
     unit_tests.requires_app_host = true
     unit_tests.pod_target_xcconfig = {
      'CLANG_ENABLE_OBJC_WEAK' => 'YES'


### PR DESCRIPTION
This fixes #3411. Test fails before the code change, and succeeds
afterwards.