### PR TITLE
Update CHANGELOG for Firestore v1.4.4

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v1.4.4
+- [changed] Internal improvements.
+
 # v1.4.3
 - [changed] Transactions are now more flexible. Some sequences of operations
   that were previously incorrectly disallowed are now allowed. For example,


### PR DESCRIPTION
Just double-checking: we've made a bunch of changes on master but none of those changes result in user-visible behavioral changes. We're still obligated to release, right?