### PR TITLE
Allow decoding Timestamp as a Date

### DIFF
--- a/Firestore/Swift/Source/Codable/third_party/FirestoreDecoder.swift
+++ b/Firestore/Swift/Source/Codable/third_party/FirestoreDecoder.swift
@@ -978,6 +978,7 @@ extension _FirestoreDecoder {
 
   func unbox(_ value: Any, as type: Date.Type) throws -> Date? {
     guard !(value is NSNull) else { return nil }
+    // Firestore returns all dates as Timestamp, converting it to Date so it can be used in custom objects.
     if let timestamp = value as? Timestamp {
       return timestamp.dateValue()
     }

--- a/Firestore/Swift/Source/Codable/third_party/FirestoreDecoder.swift
+++ b/Firestore/Swift/Source/Codable/third_party/FirestoreDecoder.swift
@@ -978,6 +978,9 @@ extension _FirestoreDecoder {
 
   func unbox(_ value: Any, as type: Date.Type) throws -> Date? {
     guard !(value is NSNull) else { return nil }
+    if let timestamp = value as? Timestamp {
+      return timestamp.dateValue()
+    }
     guard let date = value as? Date else {
       throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)
     }

--- a/Firestore/Swift/Tests/Codable/FirestoreEncoderTests.swift
+++ b/Firestore/Swift/Tests/Codable/FirestoreEncoderTests.swift
@@ -182,6 +182,21 @@ class FirestoreEncoderTests: XCTestCase {
     assertRoundTrip(model: model, encoded: ["date": date])
   }
 
+  func testTimestampCanDecodeAsDate() {
+    struct EncodingModel: Codable, Equatable {
+      let date: Timestamp
+    }
+    struct DecodingModel: Codable, Equatable {
+      let date: Date
+    }
+    let date = Date(timeIntervalSinceReferenceDate: 0)
+    let timestamp = Timestamp(date: date)
+    let model = EncodingModel(date: timestamp)
+    let decoded = DecodingModel(date: date)
+    let encoded = assertEncodes(model, encoded: ["date": timestamp])
+    assertDecodes(encoded, encoded: decoded)
+  }
+
   func testDocumentReference() {
     struct Model: Codable, Equatable {
       let doc: DocumentReference


### PR DESCRIPTION
Very small addition to swift Firestore.Decoder() that allows a `Timestamp` to be decoded as a `Date`. This is import because Firestore now returns all dates as timestamps, and this allows clients to continue to use `Date` objects in their models. Please see #627 