### PR TITLE
FIRIAMDefaultDisplayImpl: validate bundleURL to prevent crash.

### DIFF
--- a/Firebase/InAppMessagingDisplay/FIRIAMDefaultDisplayImpl.m
+++ b/Firebase/InAppMessagingDisplay/FIRIAMDefaultDisplayImpl.m
@@ -58,6 +58,13 @@
     // This is assuming the display resource bundle is contained in the main bundle
     NSURL *bundleURL = [containingBundle URLForResource:@"InAppMessagingDisplayResources"
                                           withExtension:@"bundle"];
+    if (bundleURL == nil) {
+      FIRLogWarning(kFIRLoggerInAppMessagingDisplay, @"I-FID100007",
+                    @"FIAM Display Resource bundle "
+                     "is missing: not contained within bundle %@",
+                    containingBundle);
+    }
+
     resourceBundle = [NSBundle bundleWithURL:bundleURL];
 
     if (resourceBundle == nil) {


### PR DESCRIPTION
- the change to mitigate the issue #3558: avoid crashing even if the resource bundle is not found.

Fixes: #3558.