### PR TITLE
Fix flakiness in Firestore integration tests

### DIFF
--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -113,7 +113,7 @@ static bool runningAgainstEmulator = false;
 - (void)clearPersistenceOnce {
   static bool clearedPersistence = false;
 
-  @synchronized ([FSTIntegrationTestCase class]) {
+  @synchronized([FSTIntegrationTestCase class]) {
     if (clearedPersistence) return;
 
     Path levelDBDir = [FSTLevelDB documentsDirectory];


### PR DESCRIPTION
The problem was essentially that each test instance was deleting the
documents directory which contains all persistent data for all
instances.

Unfortunately our tests aren't entirely deterministic and rarely one
test would overlap with another. When this happened the setup code for
the next test would delete the data out from underneath the previous
one.

Before this fix we'd see frequent travis failures and I would see an
occasional local failure (1 out of ~5 runs). With this fix I've seen no
failures in 30 cycles.