### PR TITLE
Fix backgrounding in GDTStorage

### DIFF
--- a/GoogleDataTransport/CHANGELOG.md
+++ b/GoogleDataTransport/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v1.1.2
 - Add initial support for iOS 13.
 - Add initial support for Catalyst.
+- Backgrounding in GDTStorage is fixed. (#3627)
 
 # v1.1.1
 - Fixes a crash in GDTUploadPackage and GDTStorage. (#3547)

--- a/GoogleDataTransport/CHANGELOG.md
+++ b/GoogleDataTransport/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v1.1.2
 - Add initial support for iOS 13.
 - Add initial support for Catalyst.
-- Backgrounding in GDTStorage is fixed. (#3627)
+- Backgrounding in GDTStorage is fixed. (#3623 and #3625)
 
 # v1.1.1
 - Fixes a crash in GDTUploadPackage and GDTStorage. (#3547)

--- a/GoogleDataTransport/GDTLibrary/GDTStorage.m
+++ b/GoogleDataTransport/GDTLibrary/GDTStorage.m
@@ -225,16 +225,16 @@ static NSString *GDTStoragePath() {
     }];
   }
   dispatch_async(_storageQueue, ^{
-      if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-        NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self
-                                             requiringSecureCoding:YES
-                                                             error:nil];
-        [data writeToFile:[GDTStorage archivePath] atomically:YES];
-      } else {
-    #if !defined(TARGET_OS_MACCATALYST)
-        [NSKeyedArchiver archiveRootObject:self toFile:[GDTStorage archivePath]];
-    #endif
-      }
+    if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
+      NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self
+                                           requiringSecureCoding:YES
+                                                           error:nil];
+      [data writeToFile:[GDTStorage archivePath] atomically:YES];
+    } else {
+#if !defined(TARGET_OS_MACCATALYST)
+      [NSKeyedArchiver archiveRootObject:self toFile:[GDTStorage archivePath]];
+#endif
+    }
   });
   dispatch_async(_storageQueue, ^{
     if (self->_backgroundID != GDTBackgroundIdentifierInvalid) {

--- a/GoogleDataTransport/GDTLibrary/Private/GDTStorage_Private.h
+++ b/GoogleDataTransport/GDTLibrary/Private/GDTStorage_Private.h
@@ -35,9 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
 /** The upload coordinator instance used by this storage instance. */
 @property(nonatomic) GDTUploadCoordinator *uploadCoordinator;
 
-/** If YES, every call to -storeLog results in background task and serializes the singleton to disk.
- */
-@property(nonatomic, readonly) BOOL runningInBackground;
+/** The background identifier, not invalid if running in the background. */
+@property(nonatomic) GDTBackgroundIdentifier backgroundID;
 
 /** Returns the path to the keyed archive of the singleton. This is where the singleton is saved
  * to disk during certain app lifecycle events.

--- a/GoogleDataTransport/GDTLibrary/Public/GDTPlatform.h
+++ b/GoogleDataTransport/GDTLibrary/Public/GDTPlatform.h
@@ -42,7 +42,7 @@ FOUNDATION_EXPORT NSString *const kGDTApplicationWillTerminateNotification;
 BOOL GDTReachabilityFlagsContainWWAN(SCNetworkReachabilityFlags flags);
 
 /** A typedef identify background identifiers. */
-typedef NSUInteger GDTBackgroundIdentifier;
+typedef volatile NSUInteger GDTBackgroundIdentifier;
 
 /** A background task's invalid sentinel value. */
 FOUNDATION_EXPORT const GDTBackgroundIdentifier GDTBackgroundIdentifierInvalid;

--- a/GoogleDataTransport/GDTTests/Lifecycle/GDTLifecycleTest.m
+++ b/GoogleDataTransport/GDTTests/Lifecycle/GDTLifecycleTest.m
@@ -107,7 +107,6 @@
 
   NSNotificationCenter *notifCenter = [NSNotificationCenter defaultCenter];
   [notifCenter postNotificationName:kGDTApplicationDidEnterBackgroundNotification object:nil];
-  XCTAssertTrue([GDTStorage sharedInstance].runningInBackground);
   XCTAssertTrue([GDTUploadCoordinator sharedInstance].runningInBackground);
   GDTWaitForBlock(
       ^BOOL {
@@ -144,7 +143,6 @@
 
   [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
   [notifCenter postNotificationName:kGDTApplicationWillEnterForegroundNotification object:nil];
-  XCTAssertFalse([GDTStorage sharedInstance].runningInBackground);
   XCTAssertFalse([GDTUploadCoordinator sharedInstance].runningInBackground);
   GDTWaitForBlock(
       ^BOOL {

--- a/GoogleDataTransport/GDTTests/Unit/GDTStorageTest.m
+++ b/GoogleDataTransport/GDTTests/Unit/GDTStorageTest.m
@@ -63,7 +63,8 @@ static NSInteger target = kGDTTargetCCT;
 
 - (void)tearDown {
   [super tearDown];
-  dispatch_sync([GDTStorage sharedInstance].storageQueue, ^{});
+  dispatch_sync([GDTStorage sharedInstance].storageQueue, ^{
+                });
   // Destroy these objects before the next test begins.
   self.testBackend = nil;
   self.testPrioritizer = nil;
@@ -270,9 +271,9 @@ static NSInteger target = kGDTTargetCCT;
                                           requiringSecureCoding:YES
                                                           error:nil];
     } else {
-  #if !defined(TARGET_OS_MACCATALYST)
+#if !defined(TARGET_OS_MACCATALYST)
       storageData = [NSKeyedArchiver archivedDataWithRootObject:[GDTStorage sharedInstance]];
-  #endif
+#endif
     }
   });
   dispatch_sync([GDTStorage sharedInstance].storageQueue, ^{
@@ -310,9 +311,9 @@ static NSInteger target = kGDTTargetCCT;
                                           requiringSecureCoding:YES
                                                           error:nil];
     } else {
-  #if !defined(TARGET_OS_MACCATALYST)
+#if !defined(TARGET_OS_MACCATALYST)
       storageData = [NSKeyedArchiver archivedDataWithRootObject:[GDTStorage sharedInstance]];
-  #endif
+#endif
     }
   });
   dispatch_sync([GDTStorage sharedInstance].storageQueue, ^{
@@ -369,7 +370,8 @@ static NSInteger target = kGDTTargetCCT;
     event.clockSnapshot = [GDTClock snapshot];
     [[GDTStorage sharedInstance] storeEvent:event];
   }
-  dispatch_sync(dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^{});
+  dispatch_sync(dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^{
+                });
 }
 
 @end

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTUploader.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTUploader.m
@@ -192,7 +192,10 @@
 
 - (void)appWillBackground:(GDTApplication *)app {
   _backgroundID = [app beginBackgroundTaskWithExpirationHandler:^{
-    [app endBackgroundTask:self->_backgroundID];
+    if (self->_backgroundID != GDTBackgroundIdentifierInvalid) {
+      [app endBackgroundTask:self->_backgroundID];
+      self->_backgroundID = GDTBackgroundIdentifierInvalid;
+    }
   }];
 }
 

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTUploader.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTUploader.m
@@ -114,7 +114,9 @@
           [package completeDelivery];
           if (self->_backgroundID != GDTBackgroundIdentifierInvalid) {
             [[GDTApplication sharedApplication] endBackgroundTask:self->_backgroundID];
-            self->_backgroundID = GDTBackgroundIdentifierInvalid;
+            @synchronized(self) {
+              self->_backgroundID = GDTBackgroundIdentifierInvalid;
+            }
           }
           self.currentTask = nil;
           self.currentUploadPackage = nil;
@@ -194,7 +196,9 @@
   _backgroundID = [app beginBackgroundTaskWithExpirationHandler:^{
     if (self->_backgroundID != GDTBackgroundIdentifierInvalid) {
       [app endBackgroundTask:self->_backgroundID];
-      self->_backgroundID = GDTBackgroundIdentifierInvalid;
+      @synchronized(self) {
+        self->_backgroundID = GDTBackgroundIdentifierInvalid;
+      }
     }
   }];
 }

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTUploader.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTUploader.m
@@ -114,9 +114,7 @@
           [package completeDelivery];
           if (self->_backgroundID != GDTBackgroundIdentifierInvalid) {
             [[GDTApplication sharedApplication] endBackgroundTask:self->_backgroundID];
-            @synchronized(self) {
-              self->_backgroundID = GDTBackgroundIdentifierInvalid;
-            }
+            self->_backgroundID = GDTBackgroundIdentifierInvalid;
           }
           self.currentTask = nil;
           self.currentUploadPackage = nil;
@@ -196,9 +194,7 @@
   _backgroundID = [app beginBackgroundTaskWithExpirationHandler:^{
     if (self->_backgroundID != GDTBackgroundIdentifierInvalid) {
       [app endBackgroundTask:self->_backgroundID];
-      @synchronized(self) {
-        self->_backgroundID = GDTBackgroundIdentifierInvalid;
-      }
+      self->_backgroundID = GDTBackgroundIdentifierInvalid;
     }
   }];
 }


### PR DESCRIPTION
Fixes 3625.
Fixes 3623.

Backgrounding causes GDTStorage to exhibit a couple of issues:
- a deadlock when `-[NSKeyedArchiver archivedData...]` is called in the background in `-[GDTStorage storeEvent:]`
- multiple background tasks being created, at least 1 per call to `-storeEvent`, without sufficient state management or checks for background task ID validity

