### PR TITLE
Disable Firestore xcodebuild with tsan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -322,14 +322,6 @@ jobs:
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
 
-    - stage: test
-      env:
-        - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild SANITIZERS=tsan
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
-      script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
-
     # TODO(varconst): enable UBSan in xcodebuild. Right now if fails during
     # linkage (it works if enabled together with ASan, but it's supposed to be
     # usable on its own, too).
@@ -431,8 +423,6 @@ jobs:
       - PROJECT=Firestore PLATFORM=macOS METHOD=cmake SANITIZERS=tsan
     - env:
       - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild SANITIZERS=asan
-    - env:
-      - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild SANITIZERS=tsan
     - env:
       - PROJECT=GoogleDataTransportIntegrationTest PLATFORM=iOS METHOD=xcodebuild
     - env:


### PR DESCRIPTION
There's currently a nontrivial TSAN issue with LevelDB that causes these
to fail. Resolution of that issue is tracked as b/139669731. Once that
is resolved, we can revert this change.