### PR TITLE
More safely manage background tasks

### DIFF
--- a/GoogleDataTransport/GDTLibrary/GDTPlatform.m
+++ b/GoogleDataTransport/GDTLibrary/GDTPlatform.m
@@ -105,7 +105,9 @@ BOOL GDTReachabilityFlagsContainWWAN(SCNetworkReachabilityFlags flags) {
 }
 
 - (void)endBackgroundTask:(GDTBackgroundIdentifier)bgID {
-  [[self sharedApplicationForBackgroundTask] endBackgroundTask:bgID];
+  if (bgID != GDTBackgroundIdentifierInvalid) {
+    [[self sharedApplicationForBackgroundTask] endBackgroundTask:bgID];
+  }
 }
 
 #pragma mark - App environment helpers

--- a/GoogleDataTransport/GDTLibrary/GDTTransformer.m
+++ b/GoogleDataTransport/GDTLibrary/GDTTransformer.m
@@ -51,7 +51,10 @@
   __block GDTBackgroundIdentifier bgID = GDTBackgroundIdentifierInvalid;
   if (_runningInBackground) {
     bgID = [[GDTApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
-      [[GDTApplication sharedApplication] endBackgroundTask:bgID];
+      if (bgID != GDTBackgroundIdentifierInvalid) {
+        [[GDTApplication sharedApplication] endBackgroundTask:bgID];
+        bgID = GDTBackgroundIdentifierInvalid;
+      }
     }];
   }
   dispatch_async(_eventWritingQueue, ^{
@@ -71,6 +74,7 @@
     [self.storageInstance storeEvent:transformedEvent];
     if (self->_runningInBackground) {
       [[GDTApplication sharedApplication] endBackgroundTask:bgID];
+      bgID = GDTBackgroundIdentifierInvalid;
     }
   });
 }
@@ -86,10 +90,16 @@
 - (void)appWillBackground:(GDTApplication *)app {
   // Create an immediate background task to run until the end of the current queue of work.
   __block GDTBackgroundIdentifier bgID = [app beginBackgroundTaskWithExpirationHandler:^{
-    [app endBackgroundTask:bgID];
+    if (bgID != GDTBackgroundIdentifierInvalid) {
+      [app endBackgroundTask:bgID];
+      bgID = GDTBackgroundIdentifierInvalid;
+    }
   }];
   dispatch_async(_eventWritingQueue, ^{
-    [app endBackgroundTask:bgID];
+    if (bgID != GDTBackgroundIdentifierInvalid) {
+      [app endBackgroundTask:bgID];
+      bgID = GDTBackgroundIdentifierInvalid;
+    }
   });
 }
 

--- a/GoogleDataTransport/GDTLibrary/GDTUploadCoordinator.m
+++ b/GoogleDataTransport/GDTLibrary/GDTUploadCoordinator.m
@@ -192,10 +192,16 @@ static NSString *const ktargetToInFlightPackagesKey =
 
   // Create an immediate background task to run until the end of the current queue of work.
   __block GDTBackgroundIdentifier bgID = [app beginBackgroundTaskWithExpirationHandler:^{
-    [app endBackgroundTask:bgID];
+    if (bgID != GDTBackgroundIdentifierInvalid) {
+      [app endBackgroundTask:bgID];
+      bgID = GDTBackgroundIdentifierInvalid;
+    }
   }];
   dispatch_async(_coordinationQueue, ^{
-    [app endBackgroundTask:bgID];
+    if (bgID != GDTBackgroundIdentifierInvalid) {
+      [app endBackgroundTask:bgID];
+      bgID = GDTBackgroundIdentifierInvalid;
+    }
   });
 }
 

--- a/GoogleDataTransport/GDTLibrary/Private/GDTStorage_Private.h
+++ b/GoogleDataTransport/GDTLibrary/Private/GDTStorage_Private.h
@@ -35,8 +35,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** The upload coordinator instance used by this storage instance. */
 @property(nonatomic) GDTUploadCoordinator *uploadCoordinator;
 
-/** The background identifier, not invalid if running in the background. */
-@property(nonatomic) GDTBackgroundIdentifier backgroundID;
+/** If YES, every call to -storeLog results in background task and serializes the singleton to disk.
+ */
+@property(nonatomic) BOOL runningInBackground;
 
 /** Returns the path to the keyed archive of the singleton. This is where the singleton is saved
  * to disk during certain app lifecycle events.

--- a/GoogleDataTransport/GDTTests/Unit/GDTStorageTest.m
+++ b/GoogleDataTransport/GDTTests/Unit/GDTStorageTest.m
@@ -360,18 +360,4 @@ static NSInteger target = kGDTTargetCCT;
   });
 }
 
-/** Tests a deadlock condition in which a background signal is sent during -storeEvent:. */
-- (void)testStoreEventDeadlockFromBackgrounding {
-  [GDTStorage sharedInstance].backgroundID = 1234;
-  for (int i = 0; i < 10000; i++) {
-    GDTEvent *event = [[GDTEvent alloc] initWithMappingID:@"404" target:kGDTTargetCCT];
-    event.dataObjectTransportBytes = [@"testString" dataUsingEncoding:NSUTF8StringEncoding];
-    event.qosTier = GDTEventQoSFast;
-    event.clockSnapshot = [GDTClock snapshot];
-    [[GDTStorage sharedInstance] storeEvent:event];
-  }
-  dispatch_sync(dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^{
-                });
-}
-
 @end


### PR DESCRIPTION
Also deletes a test that can't be run now.

Fixes #3625 

I believe there's still an issue on iOS 13 beta 5 on device, but I think it's an issue in iOS. I created a reduced test case, you see the entirety of the code and the warning below. The warning does not occur on a device that's iOS 12.

![image](https://user-images.githubusercontent.com/1082754/63309345-4c7d7f80-c2ab-11e9-814d-1edc2c9bbb9f.png)

