### PR TITLE
Upgrade LevelDB to 1.22

### DIFF
--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -31,7 +31,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.public_header_files = base_dir + 'Public/*.h'
   s.libraries = ['c++', 'icucore']
   s.frameworks = 'CFNetwork', 'Security', 'SystemConfiguration'
-  s.dependency 'leveldb-library', '~> 1.18'
+  s.dependency 'leveldb-library', '~> 1.22'
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
   s.dependency 'FirebaseCore', '~> 6.0'
   s.pod_target_xcconfig = {

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -50,7 +50,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.dependency 'FirebaseAuthInterop', '~> 1.0'
   s.dependency 'FirebaseCore', '~> 6.2'
   s.dependency 'gRPC-C++', '0.0.9'
-  s.dependency 'leveldb-library', '~> 1.20'
+  s.dependency 'leveldb-library', '~> 1.22'
   s.dependency 'Protobuf', '~> 3.1'
   s.dependency 'nanopb', '~> 0.3.901'
 


### PR DESCRIPTION
This can only be merged once we push the corresponding leveldb pod https://github.com/firebase/leveldb-library-podspec/pull/9.