### PR TITLE
fix why local timezone message is never logged

### DIFF
--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -386,6 +386,11 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
   NSString *messageID = message[kFIRMessagingMessageIDKey];
   if ([messageID length]) {
     [self.rmq2Manager saveS2dMessageWithRmqId:messageID];
+
+    BOOL isSyncMessage = [[self class] isAPNSSyncMessage:message];
+    if (isSyncMessage) {
+      isOldMessage = [self.syncMessageManager didReceiveAPNSSyncMessage:message];
+    }
   }
   // Prevent duplicates by keeping a cache of all the logged messages during each session.
   // The duplicates only happen when the 3P app calls `appDidReceiveMessage:` along with

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -386,11 +386,6 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
   NSString *messageID = message[kFIRMessagingMessageIDKey];
   if ([messageID length]) {
     [self.rmq2Manager saveS2dMessageWithRmqId:messageID];
-
-    BOOL isSyncMessage = [[self class] isAPNSSyncMessage:message];
-    if (isSyncMessage) {
-      isOldMessage = [self.syncMessageManager didReceiveAPNSSyncMessage:message];
-    }
   }
   // Prevent duplicates by keeping a cache of all the logged messages during each session.
   // The duplicates only happen when the 3P app calls `appDidReceiveMessage:` along with

--- a/Firebase/Messaging/FIRMessagingContextManagerService.m
+++ b/Firebase/Messaging/FIRMessagingContextManagerService.m
@@ -190,10 +190,10 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
       } else if ([keyString hasPrefix:kContextManagerPrefixKey]) {
         continue;
       } else if ([keyString isEqualToString:kFIRMessagingAPNSPayload]) {
-          // Local timezone message is scheduled with FCM payload. APNS payload with
-          // content_available should be ignored and not passed to the scheduled
-          // messages.
-          continue;
+        // Local timezone message is scheduled with FCM payload. APNS payload with
+        // content_available should be ignored and not passed to the scheduled
+        // messages.
+        continue;
       }
     }
     data[[key copy]] = message[key];

--- a/Firebase/Messaging/FIRMessagingContextManagerService.m
+++ b/Firebase/Messaging/FIRMessagingContextManagerService.m
@@ -44,7 +44,7 @@ NSString *const kFIRMessagingContextManagerCategoryKey =
 NSString *const kFIRMessagingContextManagerSoundKey = kFIRMessagingContextManagerNotificationKeyPrefix @"sound";
 NSString *const kFIRMessagingContextManagerContentAvailableKey =
     kFIRMessagingContextManagerNotificationKeyPrefix @"content-available";
-NSString *const kFIRMessagingAPNSPayload = @"aps";
+NSString *const kFIRMessagingAPNSPayloadKey = @"aps";
 
 
 typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
@@ -189,7 +189,7 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
         continue;
       } else if ([keyString hasPrefix:kContextManagerPrefixKey]) {
         continue;
-      } else if ([keyString isEqualToString:kFIRMessagingAPNSPayload]) {
+      } else if ([keyString isEqualToString:kFIRMessagingAPNSPayloadKey]) {
         // Local timezone message is scheduled with FCM payload. APNS payload with
         // content_available should be ignored and not passed to the scheduled
         // messages.

--- a/Firebase/Messaging/FIRMessagingContextManagerService.m
+++ b/Firebase/Messaging/FIRMessagingContextManagerService.m
@@ -44,6 +44,8 @@ NSString *const kFIRMessagingContextManagerCategoryKey =
 NSString *const kFIRMessagingContextManagerSoundKey = kFIRMessagingContextManagerNotificationKeyPrefix @"sound";
 NSString *const kFIRMessagingContextManagerContentAvailableKey =
     kFIRMessagingContextManagerNotificationKeyPrefix @"content-available";
+NSString *const kFIRMessagingAPNSPayload = @"aps";
+
 
 typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
   FIRMessagingContextManagerMessageTypeNone,
@@ -187,6 +189,11 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
         continue;
       } else if ([keyString hasPrefix:kContextManagerPrefixKey]) {
         continue;
+      } else if ([keyString isEqualToString:kFIRMessagingAPNSPayload]) {
+          // Local timezone message is scheduled with FCM payload. APNS payload with
+          // content_available should be ignored and not passed to the scheduled
+          // message.s
+          continue;
       }
     }
     data[[key copy]] = message[key];

--- a/Firebase/Messaging/FIRMessagingContextManagerService.m
+++ b/Firebase/Messaging/FIRMessagingContextManagerService.m
@@ -192,7 +192,7 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
       } else if ([keyString isEqualToString:kFIRMessagingAPNSPayload]) {
           // Local timezone message is scheduled with FCM payload. APNS payload with
           // content_available should be ignored and not passed to the scheduled
-          // message.s
+          // messages.
           continue;
       }
     }


### PR DESCRIPTION
Fix the issue local timezone message is not logged with "notification_open". b/137177917

Local timezone message is sent down ahead of time in hidden message ("content-available") and device schedule a local notification from the info provided by such hidden message.
When we schedule a local notification, the APNS payload inside "aps" key is copied over to the scheduled local notification. And when the local notification is delivered, device mistakenly thinks it's a duplicate message because it contains both gcm.message_id and "aps" payload. It thinks it's passed down in both direct channel and APNS channel.
In general, the APNS payload should not be copied over because we schedule local notification ONLY based on FCM payload, that is provided with "gcm.notification" prefix keys. 
