### PR TITLE
Factor out nullability.h

### DIFF
--- a/Firestore/core/src/firebase/firestore/api/document_snapshot.h
+++ b/Firestore/core/src/firebase/firestore/api/document_snapshot.h
@@ -27,7 +27,6 @@
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/field_path.h"
 #include "Firestore/core/src/firebase/firestore/model/field_value.h"
-#include "Firestore/core/src/firebase/firestore/objc/objc_class.h"
 #include "absl/types/optional.h"
 
 namespace firebase {

--- a/Firestore/core/src/firebase/firestore/api/firestore.h
+++ b/Firestore/core/src/firebase/firestore/api/firestore.h
@@ -31,6 +31,7 @@
 #include "Firestore/core/src/firebase/firestore/model/database_id.h"
 #include "Firestore/core/src/firebase/firestore/objc/objc_class.h"
 #include "Firestore/core/src/firebase/firestore/util/async_queue.h"
+#include "Firestore/core/src/firebase/firestore/util/nullability.h"
 #include "Firestore/core/src/firebase/firestore/util/status.h"
 #include "Firestore/core/src/firebase/firestore/util/statusor_callback.h"
 #include "absl/types/any.h"

--- a/Firestore/core/src/firebase/firestore/api/listener_registration.h
+++ b/Firestore/core/src/firebase/firestore/api/listener_registration.h
@@ -23,6 +23,7 @@
 #include "Firestore/core/src/firebase/firestore/core/event_listener.h"
 #include "Firestore/core/src/firebase/firestore/core/query_listener.h"
 #include "Firestore/core/src/firebase/firestore/objc/objc_class.h"
+#include "Firestore/core/src/firebase/firestore/util/nullability.h"
 
 OBJC_CLASS(FSTFirestoreClient);
 

--- a/Firestore/core/src/firebase/firestore/api/write_batch.h
+++ b/Firestore/core/src/firebase/firestore/api/write_batch.h
@@ -23,10 +23,7 @@
 
 #include "Firestore/core/src/firebase/firestore/api/document_reference.h"
 #include "Firestore/core/src/firebase/firestore/model/mutation.h"
-#include "Firestore/core/src/firebase/firestore/objc/objc_class.h"
 #include "Firestore/core/src/firebase/firestore/util/status.h"
-
-NS_ASSUME_NONNULL_BEGIN
 
 namespace firebase {
 namespace firestore {
@@ -71,7 +68,5 @@ class WriteBatch {
 }  // namespace api
 }  // namespace firestore
 }  // namespace firebase
-
-NS_ASSUME_NONNULL_END
 
 #endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_API_WRITE_BATCH_H_

--- a/Firestore/core/src/firebase/firestore/core/event_manager.h
+++ b/Firestore/core/src/firebase/firestore/core/event_manager.h
@@ -27,11 +27,14 @@
 #include "Firestore/core/src/firebase/firestore/core/view_snapshot.h"
 #include "Firestore/core/src/firebase/firestore/model/types.h"
 #include "Firestore/core/src/firebase/firestore/objc/objc_class.h"
+#include "Firestore/core/src/firebase/firestore/util/nullability.h"
 #include "Firestore/core/src/firebase/firestore/util/status.h"
 #include "absl/algorithm/container.h"
 #include "absl/types/optional.h"
 
 OBJC_CLASS(FSTSyncEngine);
+
+NS_ASSUME_NONNULL_BEGIN
 
 namespace firebase {
 namespace firestore {
@@ -106,5 +109,7 @@ class EventManager : public SyncEngineCallback {
 }  // namespace core
 }  // namespace firestore
 }  // namespace firebase
+
+NS_ASSUME_NONNULL_END
 
 #endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_EVENT_MANAGER_H_

--- a/Firestore/core/src/firebase/firestore/core/query_listener.h
+++ b/Firestore/core/src/firebase/firestore/core/query_listener.h
@@ -28,8 +28,6 @@
 #include "Firestore/core/src/firebase/firestore/util/statusor_callback.h"
 #include "absl/types/optional.h"
 
-NS_ASSUME_NONNULL_BEGIN
-
 namespace firebase {
 namespace firestore {
 namespace core {
@@ -121,7 +119,5 @@ class QueryListener {
 }  // namespace core
 }  // namespace firestore
 }  // namespace firebase
-
-NS_ASSUME_NONNULL_END
 
 #endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_QUERY_LISTENER_H_

--- a/Firestore/core/src/firebase/firestore/core/view_snapshot.h
+++ b/Firestore/core/src/firebase/firestore/core/view_snapshot.h
@@ -31,7 +31,6 @@
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
 #include "Firestore/core/src/firebase/firestore/model/document_set.h"
-#include "Firestore/core/src/firebase/firestore/objc/objc_class.h"
 #include "Firestore/core/src/firebase/firestore/util/statusor.h"
 
 namespace firebase {

--- a/Firestore/core/src/firebase/firestore/model/document_map.h
+++ b/Firestore/core/src/firebase/firestore/model/document_map.h
@@ -23,7 +23,6 @@
 #include "Firestore/core/src/firebase/firestore/model/document.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key.h"
 #include "Firestore/core/src/firebase/firestore/model/maybe_document.h"
-#include "Firestore/core/src/firebase/firestore/objc/objc_class.h"
 #include "absl/base/attributes.h"
 #include "absl/types/optional.h"
 

--- a/Firestore/core/src/firebase/firestore/objc/objc_class.h
+++ b/Firestore/core/src/firebase/firestore/objc/objc_class.h
@@ -154,20 +154,6 @@ bool Equals(const Handle<T>& lhs, const Handle<T>& rhs) {
 }
 #endif
 
-// Define NS_ASSUME_NONNULL_BEGIN for straight C++ so that everything gets the
-// correct nullability specifier.
-#if !defined(NS_ASSUME_NONNULL_BEGIN)
-#if __clang__
-#define NS_ASSUME_NONNULL_BEGIN _Pragma("clang assume_nonnull begin")
-#define NS_ASSUME_NONNULL_END _Pragma("clang assume_nonnull end")
-
-#else  // !__clang__
-#define NS_ASSUME_NONNULL_BEGIN
-#define NS_ASSUME_NONNULL_END
-#define _Nullable
-#endif  // __clang__
-#endif  // !defined(NS_ASSUME_NONNULL_BEGIN)
-
 }  // namespace objc
 }  // namespace firestore
 }  // namespace firebase

--- a/Firestore/core/src/firebase/firestore/util/nullability.h
+++ b/Firestore/core/src/firebase/firestore/util/nullability.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_NULLABILITY_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_NULLABILITY_H_
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+// Define NS_ASSUME_NONNULL_BEGIN for straight C++ so that everything gets the
+// correct nullability specifier.
+#if !defined(NS_ASSUME_NONNULL_BEGIN)
+#if __clang__
+#define NS_ASSUME_NONNULL_BEGIN _Pragma("clang assume_nonnull begin")
+#define NS_ASSUME_NONNULL_END _Pragma("clang assume_nonnull end")
+
+#else  // !__clang__
+#define NS_ASSUME_NONNULL_BEGIN
+#define NS_ASSUME_NONNULL_END
+#define _Nonnull
+#define _Nullable
+
+#endif  // __clang__
+#endif  // !defined(NS_ASSUME_NONNULL_BEGIN)
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_NULLABILITY_H_


### PR DESCRIPTION
This will make it such that nullability macros can survive even after we remove `OBJC_CLASS`.