### PR TITLE
Start RemoteConfig CI and fix/ignore warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -220,7 +220,7 @@ jobs:
         - travis_retry ./scripts/pod_lib_lint.rb GoogleUtilities.podspec --use-modular-headers
 
     - stage: test
-#      if: type = cron
+      if: type = cron
       env:
         - PROJECT=FirebasePllRemoteConfigCron PLATFORM=iOS METHOD=pod-lib-lint
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,14 @@ jobs:
 
     - stage: test
       env:
+        - PROJECT=RemoteConfig PLATFORM=iOS METHOD=pod-lib-lint
+      script:
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseRemoteConfigpodspec --platforms=ios
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --platforms=tvos
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --platforms=macos
+
+    - stage: test
+      env:
         - PROJECT=Storage PLATFORM=all METHOD=xcodebuild
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
@@ -210,6 +218,18 @@ jobs:
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --use-modular-headers
         - travis_retry ./scripts/pod_lib_lint.rb GoogleUtilities.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.rb GoogleUtilities.podspec --use-modular-headers
+
+    - stage: test
+#      if: type = cron
+      env:
+        - PROJECT=FirebasePllRemoteConfigCron PLATFORM=iOS METHOD=pod-lib-lint
+      script:
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseRemoteConfigpodspec --use-libraries --allow-warnings --platforms=ios
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --use-libraries --allow-warnings --platforms=tvos
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --use-libraries --allow-warnings --platforms=macos
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseRemoteConfigpodspec --use-modular-headers --platforms=ios
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --use-modular-headers --platforms=tvos
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --use-modular-headers --platforms=macos
 
     - stage: test
       if: type = cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ jobs:
       env:
         - PROJECT=RemoteConfig PLATFORM=iOS METHOD=pod-lib-lint
       script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseRemoteConfigpodspec --platforms=ios
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --platforms=ios
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --platforms=tvos
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --platforms=macos
 
@@ -224,10 +224,10 @@ jobs:
       env:
         - PROJECT=FirebasePllRemoteConfigCron PLATFORM=iOS METHOD=pod-lib-lint
       script:
-        - travis_retry ./scripts/pod_lib_lint.rb FirebaseRemoteConfigpodspec --use-libraries --allow-warnings --platforms=ios
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --use-libraries --allow-warnings --platforms=ios
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --use-libraries --allow-warnings --platforms=tvos
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --use-libraries --allow-warnings --platforms=macos
-        - travis_retry ./scripts/pod_lib_lint.rb FirebaseRemoteConfigpodspec --use-modular-headers --platforms=ios
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --use-modular-headers --platforms=ios
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --use-modular-headers --platforms=tvos
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --use-modular-headers --platforms=macos
 

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -616,6 +616,6 @@ static NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, FIRRemote
   dispatch_async(_queue, setConfigSettingsBlock);
 }
 
-#pragma clang diagnostic push // "-Wdeprecated-declarations"
+#pragma clang diagnostic push  // "-Wdeprecated-declarations"
 
 @end

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -404,9 +404,9 @@ static NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, FIRRemote
   __block NSUInteger localValue;
   dispatch_sync(_queue, ^{
     localValue =
-        [self->_configContent.activeConfig[_FIRNamespace] countByEnumeratingWithState:state
-                                                                              objects:stackbuf
-                                                                                count:len];
+        [self->_configContent.activeConfig[self->_FIRNamespace] countByEnumeratingWithState:state
+                                                                                    objects:stackbuf
+                                                                                      count:len];
   });
   return localValue;
 }

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -49,6 +49,10 @@ static NSString *const kRemoteConfigFetchTimeoutKey = @"_rcn_fetch_timeout";
 }
 @end
 
+// Implementations depend upon multiple deprecated APIs
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 @implementation FIRRemoteConfigSettings
 - (instancetype)initWithDeveloperModeEnabled:(BOOL)developerModeEnabled {
   self = [self init];
@@ -611,5 +615,7 @@ static NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, FIRRemote
   };
   dispatch_async(_queue, setConfigSettingsBlock);
 }
+
+#pragma clang diagnostic push // "-Wdeprecated-declarations"
 
 @end

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigContentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigContentTest.m
@@ -229,7 +229,8 @@
                  numberValue]);
   NSDictionary<NSString *, NSString *> *sampleJSON = @{@"key1" : @"value1"};
   id configJSON = [(defaultConfig[@"default_namespace"][@"new_json_key"]) JSONValue];
-  XCTAssertEqualObjects([configJSON class], [sampleJSON class]);
+  XCTAssertTrue([configJSON isKindOfClass:[NSDictionary class]]);
+  XCTAssertTrue([sampleJSON isKindOfClass:[NSDictionary class]]);
   XCTAssertEqualObjects(sampleJSON, (NSDictionary *)configJSON);
   XCTAssertEqualObjects(dataValue,
                         [defaultConfig[@"default_namespace"][@"new_data_key"] dataValue]);

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigDBManagerTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigDBManagerTest.m
@@ -99,7 +99,7 @@
     };
     NSString *value = [NSString stringWithFormat:@"value%d", i];
     NSString *key = [NSString stringWithFormat:@"key%d", i];
-    NSArray<NSString *> *values =
+    NSArray<id> *values =
         @[ bundleIdentifier, namespace_p, key, [value dataUsingEncoding:NSUTF8StringEncoding] ];
     [_DBManager insertMainTableWithValues:values
                                fromSource:RCNDBSourceFetched

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m
@@ -52,7 +52,7 @@
   id _DBManagerMock;
   NSArray<NSDictionary<NSString *, id> *> *_payloads;
   NSArray<NSData *> *_payloadsData;
-  NSDictionary<NSString *, NSString *> *_metadata;
+  NSDictionary<NSString *, NSNumber *> *_metadata;
   NSString *_DBPath;
 }
 @end
@@ -74,7 +74,7 @@
   NSData *payloadData2 = [NSJSONSerialization dataWithJSONObject:payload2 options:0 error:&error];
   _payloadsData = @[ payloadData1, payloadData2 ];
   _metadata = @{@"last_know_start_time" : @12348765};
-  NSDictionary<NSString *, NSString *> *mockResults = @{
+  NSDictionary<NSString *, id> *mockResults = @{
     @RCNExperimentTableKeyPayload : _payloadsData,
     @RCNExperimentTableKeyMetadata : _metadata,
   };

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -259,7 +259,10 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
         ^void(FIRRemoteConfigFetchStatus status, NSError *error) {
           XCTAssertEqual(_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusSuccess);
           XCTAssertNil(error);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
           XCTAssertTrue([_configInstances[i] activateFetched]);
+#pragma clang diagnostic pop
           NSString *key1 = [NSString stringWithFormat:@"key1-%d", i];
           NSString *key2 = [NSString stringWithFormat:@"key2-%d", i];
           NSString *value1 = [NSString stringWithFormat:@"value1-%d", i];
@@ -388,7 +391,10 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
         ^void(FIRRemoteConfigFetchStatus status, NSError *error) {
           XCTAssertEqual(_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusSuccess);
           XCTAssertNil(error);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
           XCTAssertTrue([_configInstances[i] activateFetched]);
+#pragma clang diagnostic pop
           NSString *key5 = [NSString stringWithFormat:@"key5-%d", i];
           NSString *key19 = [NSString stringWithFormat:@"key19-%d", i];
           NSString *value5 = [NSString stringWithFormat:@"value5-%d", i];
@@ -515,7 +521,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
                                                configSettings:settings
                                              configExperiment:nil];
   }
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   // Make the fetch calls for all instances.
   NSMutableArray<XCTestExpectation *> *expectations =
       [[NSMutableArray alloc] initWithCapacity:RCNTestRCNumTotalInstances];
@@ -601,7 +608,6 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
     NSString *key0 = [NSString stringWithFormat:@"key0-%d", i];
     NSString *value1 = [NSString stringWithFormat:@"value1-%d", i];
     NSString *value2 = [NSString stringWithFormat:@"value2-%d", i];
-    NSString *value0 = [NSString stringWithFormat:@"value0-%d", i];
 
     XCTestExpectation *fetchConfigsExpectation =
         [self expectationWithDescription:@"Test fetch configs with defaults set."];
@@ -615,15 +621,20 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
           XCTAssertNil(error);
           XCTAssertEqualObjects(_configInstances[i][key1].stringValue, @"default key1");
           XCTAssertEqual(_configInstances[i][key1].source, FIRRemoteConfigSourceDefault);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
           XCTAssertTrue([_configInstances[i] activateFetched]);
+#pragma clang diagnostic pop
           XCTAssertEqualObjects(_configInstances[i][key1].stringValue, value1);
           XCTAssertEqual(_configInstances[i][key1].source, FIRRemoteConfigSourceRemote);
           XCTAssertEqualObjects([_configInstances[i] defaultValueForKey:key1].stringValue,
                                 @"default key1");
           XCTAssertEqualObjects(_configInstances[i][key2].stringValue, value2);
           XCTAssertEqualObjects(_configInstances[i][key0].stringValue, @"value0-0");
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
           XCTAssertNil([_configInstances[i] defaultValueForKey:nil namespace:nil]);
-
+#pragma clang diagnostic pop
           OCMVerify([_configInstances[i] objectForKeyedSubscript:key1]);
           XCTAssertEqual(status, FIRRemoteConfigFetchStatusSuccess,
                          @"Callback of first successful config "
@@ -991,6 +1002,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
           XCTAssertEqual(status, FIRRemoteConfigFetchStatusSuccess);
           XCTAssertNil(error);
           NSLog(@"Testing _configInstances %d", i);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
           XCTAssertTrue([_configInstances[i] activateFetched]);
 
           // Test keysWithPrefix:namespace: method.
@@ -1010,6 +1023,7 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
 
           XCTAssertNotNil([_configInstances[i] keysWithPrefix:nil namespace:nil]);
           XCTAssertEqual([_configInstances[i] keysWithPrefix:nil namespace:nil].count, 0);
+#pragma clang diagnostic pop
 
           // Test keysWithPrefix: method.
           XCTAssertEqual([_configInstances[i] keysWithPrefix:@"key1"].count, 12);
@@ -1031,6 +1045,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
 
 - (void)testSetDeveloperModeConfigSetting {
   for (int i = 0; i < RCNTestRCNumTotalInstances; i++) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     FIRRemoteConfigSettings *settings =
         [[FIRRemoteConfigSettings alloc] initWithDeveloperModeEnabled:YES];
     [_configInstances[i] setConfigSettings:settings];
@@ -1039,6 +1055,7 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
     settings = [[FIRRemoteConfigSettings alloc] initWithDeveloperModeEnabled:NO];
     [_configInstances[i] setConfigSettings:settings];
     XCTAssertFalse([_configInstances[i] configSettings].isDeveloperModeEnabled);
+#pragma clang diagnostic pop
   }
 }
 

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -886,7 +886,7 @@ static NSString *UTCToLocal(NSString *utcTime) {
       XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"lastCheckTime"
                                                          namespace:RCNTestsPerfNamespace]
                                 .stringValue,
-                             UTCToLocal(@"2016-02-28 18:33:31"));
+                            UTCToLocal(@"2016-02-28 18:33:31"));
       XCTAssertEqual([_configInstances[i] configValueForKey:@"isPaidUser"
                                                   namespace:RCNTestsPerfNamespace]
                          .boolValue,

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -839,11 +839,24 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
   }
 }
 
+// Remote Config converts UTC times in the plists to local times. This utility function makes it
+// possible to check the times when running the tests in any timezone.
+static NSString *UTCToLocal(NSString *utcTime) {
+  // Create a UTC dateFormatter.
+  NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+  [dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
+  [dateFormatter setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"UTC"]];
+  NSDate *date = [dateFormatter dateFromString:utcTime];
+  [dateFormatter setTimeZone:[NSTimeZone localTimeZone]];
+  return [dateFormatter stringFromDate:date];
+}
+
 - (void)testSetDefaultsFromPlist {
   for (int i = 0; i < RCNTestRCNumTotalInstances; i++) {
-    [_configInstances[i] setDefaultsFromPlistFileName:@"Defaults-testInfo"];
+    FIRRemoteConfig *config = _configInstances[i];
+    [config setDefaultsFromPlistFileName:@"Defaults-testInfo"];
     XCTAssertEqualObjects(_configInstances[i][@"lastCheckTime"].stringValue,
-                          @"2016-02-28 10:33:31");
+                          UTCToLocal(@"2016-02-28 18:33:31"));
     XCTAssertEqual(_configInstances[i][@"isPaidUser"].boolValue, YES);
     XCTAssertEqualObjects(_configInstances[i][@"dataValue"].stringValue, @"2.4");
     XCTAssertEqualObjects(_configInstances[i][@"New item"].numberValue, @(2.4));
@@ -855,7 +868,7 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
     // If given a wrong file name, the default will not be set and kept as previous results.
     [_configInstances[i] setDefaultsFromPlistFileName:@""];
     XCTAssertEqualObjects(_configInstances[i][@"lastCheckTime"].stringValue,
-                          @"2016-02-28 10:33:31");
+                          UTCToLocal(@"2016-02-28 18:33:31"));
     [_configInstances[i] setDefaultsFromPlistFileName:@"non-existed_file"];
     XCTAssertEqualObjects(_configInstances[i][@"dataValue"].stringValue, @"2.4");
     [_configInstances[i] setDefaultsFromPlistFileName:nil namespace:nil];
@@ -873,7 +886,7 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
       XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"lastCheckTime"
                                                          namespace:RCNTestsPerfNamespace]
                                 .stringValue,
-                            @"2016-02-28 10:33:31");
+                             UTCToLocal(@"2016-02-28 18:33:31"));
       XCTAssertEqual([_configInstances[i] configValueForKey:@"isPaidUser"
                                                   namespace:RCNTestsPerfNamespace]
                          .boolValue,
@@ -901,7 +914,7 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
     } else {
       [_configInstances[i] setDefaultsFromPlistFileName:@"Defaults-testInfo"];
       XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"lastCheckTime"].stringValue,
-                            @"2016-02-28 10:33:31");
+                            UTCToLocal(@"2016-02-28 18:33:31"));
       XCTAssertEqual([_configInstances[i] configValueForKey:@"isPaidUser"].boolValue, YES);
       XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"dataValue"].stringValue,
                             @"2.4");

--- a/FirebaseRemoteConfig/Tests/Unit/RCNTestUtilities.h
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNTestUtilities.h
@@ -26,19 +26,6 @@ extern NSString *const RCNTestsSecondFIRAppName;
 
 @interface RCNTestUtilities : NSObject
 
-/// Fake a fetch response with a given dictionary of namespace to config and their fetch status
-/// accordingly.
-/// @param namespaceToConfig  Dictionary of namespace to a dictionary of config key value pairs.
-/// @param statusArray        Response update status for each namespace in namespaceToConfig.
-+ (NSMutableDictionary<NSString *, NSString *> *)
-    responseWithNamespaceToConfig:(NSDictionary<NSString *, NSDictionary *> *)namespaceToConfig
-                      statusArray:(NSArray *)statusArray;
-
-/// Fake an internal metadata array with a given dictionary for a fake response.
-///
-/// @param aDictionary  Dictionary with content to mock an internal metadata array.
-+ (NSMutableArray *)entryArrayWithKeyValuePair:(NSDictionary *)aDictionary;
-
 /// Returns the name of the test that's compatible with configuring a FIRApp name to ensure
 /// uniqueness. `testName` is the `name` property of the `XCTest` running.
 + (NSString *)generatedTestAppNameForTest:(NSString *)testName;

--- a/scripts/if_changed.sh
+++ b/scripts/if_changed.sh
@@ -134,6 +134,10 @@ else
       check_changes '^(Firebase/Core|Firebase/Messaging|Example/Messaging|GoogleUtilities|FirebaseMessaging.podspec|Firebase/InstanceID)'
       ;;
 
+    RemoteConfig-*)
+      check_changes '^(Firebase/Core|FirebaseRemoteConfig)'
+      ;;
+
     Storage-*)
       check_changes '^(Firebase/Core|Firebase/Storage|Example/Storage|GoogleUtilities|FirebaseStorage.podspec)'
       ;;


### PR DESCRIPTION
Set up CI for Remote Config and make fixes for successful `pod lib lint` tests
- Fix warnings
- Ignore deprecations
- Fix tests that were dependent upon running in Pacific time zone
- Fix travis-only test failure relying upon non-deterministic NSDictionary factory types