### PR TITLE
Escapes link url string to avoid nil of NSURL

### DIFF
--- a/Firebase/DynamicLinks/FIRDynamicLinks.m
+++ b/Firebase/DynamicLinks/FIRDynamicLinks.m
@@ -419,7 +419,9 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
       if (parameters[kFIRDLParameterLink]) {
         FIRDynamicLink *dynamicLink = [[FIRDynamicLink alloc] init];
         NSString *urlString = parameters[kFIRDLParameterLink];
-        NSURL *deepLinkURL = [NSURL URLWithString:urlString];
+        NSString *escapedUrlString =
+            [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+        NSURL *deepLinkURL = [NSURL URLWithString:escapedUrlString];
         if (deepLinkURL) {
           dynamicLink.url = deepLinkURL;
           dynamicLink.matchType = FIRDLMatchTypeUnique;


### PR DESCRIPTION
Sorry for lately update about issue detail.

My dynamic links is
`https://kkboxkids.page.link/?link=https://itunes.apple.com/tw/app/kkbox-kids-%25E8%25A6%25AA%25E5%25AD%2590%25E4%25BA%25AB%25E6%25A8%2582%25E6%2599%2582%25E5%2585%2589%252D%25E8%2588%2587%25E5%25AF%25B6%25E8%25B2%259D%25E4%25B8%2580%25E8%25B5%25B7%25E6%2588%2590%25E9%2595%25B7/id1459755337&apn=com.kkbox.kids&isi=1459755337&ibi=com.kkbox.kids&utm_campaign=aug_kol&utm_source=column`

when SDK start parsing url by `FIRDLDictionaryFromQuery`, the output will transforms `link` query parameter into NSString `https://itunes.apple.com/tw/app/kkbox-kids-親子享樂時光-與寶貝一起成長/id1459755337`

Use this url string to instantiation NSUrl will get nil result.