### PR TITLE
Undeprecate initializer for FIRInAppMessagingAction

### DIFF
--- a/Firebase/InAppMessaging/Public/FIRInAppMessagingRendering.h
+++ b/Firebase/InAppMessaging/Public/FIRInAppMessagingRendering.h
@@ -137,7 +137,7 @@ NS_SWIFT_NAME(InAppMessagingAction)
 
 /// Deprecated, this class shouldn't be directly instantiated.
 - (instancetype)initWithActionText:(nullable NSString *)actionText
-                         actionURL:(NSURL *)actionURL __deprecated;
+                         actionURL:(NSURL *)actionURL;
 
 @end
 


### PR DESCRIPTION
This initializer is necessary for developers that integrate only the headless SDK and provide their own logic for displaying messages (see: 3545).