### PR TITLE
Double timeouts to address RC travis flakes

### DIFF
--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -106,7 +106,7 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
   [super setUp];
   FIRSetLoggerLevel(FIRLoggerLevelMax);
 
-  _expectationTimeout = 10;
+  _expectationTimeout = 20;
   _checkCompletionTimeout = 1.0;
 
   // Always remove the database at the start of testing.

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -106,7 +106,7 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
   [super setUp];
   FIRSetLoggerLevel(FIRLoggerLevelMax);
 
-  _expectationTimeout = 5;
+  _expectationTimeout = 10;
   _checkCompletionTimeout = 1.0;
 
   // Always remove the database at the start of testing.


### PR DESCRIPTION
RC failed on travis at https://travis-ci.org/firebase/firebase-ios-sdk/jobs/575573395 due to several timeouts in RCNRemoteConfigTest.m.

Double the timeout value.