### PR TITLE
Fix connectivity monitor redispatching

### DIFF
--- a/Firestore/core/src/firebase/firestore/remote/connectivity_monitor_apple.mm
+++ b/Firestore/core/src/firebase/firestore/remote/connectivity_monitor_apple.mm
@@ -124,7 +124,7 @@ class ConnectivityMonitorApple : public ConnectivityMonitor {
   }
 
   void OnReachabilityChanged(SCNetworkReachabilityFlags flags) {
-    queue()->ExecuteBlocking(
+    queue()->Enqueue(
         [this, flags] { MaybeInvokeCallbacks(ToNetworkStatus(flags)); });
   }
 


### PR DESCRIPTION
In #3467, we changed the connectivity monitor to take callbacks from
SCNetworkReachability on the main thread but didn't make the
corresponding change to enqueue the notification back onto Firestore's
worker.

Fixes #3661.