### PR TITLE
Fix connectivity monitor redispatching.

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseFirestore'
-  s.version          = '1.4.4'
+  s.version          = '1.4.5'
   s.summary          = 'Google Cloud Firestore for iOS'
 
   s.description      = <<-DESC

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# v1.4.5
+- [fixed] Fixed a crash that would happen when changing networks or going from
+  online to offline. (#3661).
+
 # v1.4.4
 - [changed] Internal improvements.
 

--- a/Firestore/core/src/firebase/firestore/remote/connectivity_monitor_apple.mm
+++ b/Firestore/core/src/firebase/firestore/remote/connectivity_monitor_apple.mm
@@ -124,7 +124,7 @@ class ConnectivityMonitorApple : public ConnectivityMonitor {
   }
 
   void OnReachabilityChanged(SCNetworkReachabilityFlags flags) {
-    queue()->ExecuteBlocking(
+    queue()->Enqueue(
         [this, flags] { MaybeInvokeCallbacks(ToNetworkStatus(flags)); });
   }
 


### PR DESCRIPTION
In #3467, we changed the connectivity monitor to take callbacks from
SCNetworkReachability on the main thread but didn't make the
corresponding change to enqueue the notification back onto Firestore's
worker.

Bump Firestore to v1.4.5.