### PR TITLE
should not log context message

### DIFF
--- a/Example/Messaging/Tests/FIRMessagingClientTest.m
+++ b/Example/Messaging/Tests/FIRMessagingClientTest.m
@@ -15,9 +15,6 @@
  */
 
 #import <XCTest/XCTest.h>
-
-
-
 #import <OCMock/OCMock.h>
 
 #import <FirebaseInstanceID/FIRInstanceID_Private.h>

--- a/Example/Messaging/Tests/FIRMessagingHandlingTest.m
+++ b/Example/Messaging/Tests/FIRMessagingHandlingTest.m
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2017 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import <OCMock/OCMock.h>
+
+#import <FirebaseCore/FIRAppInternal.h>
+#import <FirebaseInstanceID/FirebaseInstanceID.h>
+#import <FirebaseAnalyticsInterop/FIRAnalyticsInterop.h>
+#import <FirebaseMessaging/FIRMessaging.h>
+
+#import "Example/Messaging/Tests/FIRMessagingTestUtilities.h"
+#import "Firebase/Messaging/FIRMessaging_Private.h"
+#import "Firebase/Messaging/FIRMessagingAnalytics.h"
+#import "Firebase/Messaging/FIRMessagingRmqManager.h"
+#import "Firebase/Messaging/FIRMessagingSyncMessageManager.h"
+
+extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
+
+/// The NSUserDefaults domain for testing.
+static NSString *const kFIRMessagingDefaultsTestDomain = @"com.messaging.tests";
+
+@interface FIRMessaging ()
+
+@property(nonatomic, readwrite, strong) NSString *defaultFcmToken;
+@property(nonatomic, readwrite, strong) FIRInstanceID *instanceID;
+@property(nonatomic, readwrite, strong) FIRMessagingRmqManager *rmq2Manager;
+
+- (BOOL)handleContextManagerMessage:(NSDictionary *)message;
+- (void)handleIncomingLinkIfNeededFromMessage:(NSDictionary *)message;
+
+@end
+
+@interface FIRMessagingHandlingTest : XCTestCase
+
+@property(nonatomic, readonly, strong) FIRMessaging *messaging;
+@property(nonatomic, strong) FIRMessagingAnalytics *messageAnalytics;
+@property(nonatomic, strong) id mockMessaging;
+@property(nonatomic, strong) id mockInstanceID;
+@property(nonatomic, strong) id mockFirebaseApp;
+@property(nonatomic, strong) id mockMessagingAnalytics;
+
+@end
+
+@implementation FIRMessagingHandlingTest
+
+- (void)setUp {
+  [super setUp];
+
+  // Create the messaging instance with all the necessary dependencies.
+  NSUserDefaults *defaults =
+      [[NSUserDefaults alloc] initWithSuiteName:kFIRMessagingDefaultsTestDomain];
+  _messaging = [FIRMessagingTestUtilities messagingForTestsWithUserDefaults:defaults];
+  _mockFirebaseApp = OCMClassMock([FIRApp class]);
+   OCMStub([_mockFirebaseApp defaultApp]).andReturn(_mockFirebaseApp);
+  _mockInstanceID = OCMPartialMock(self.messaging.instanceID);
+  [[NSUserDefaults standardUserDefaults]
+      removePersistentDomainForName:[NSBundle mainBundle].bundleIdentifier];
+  _mockMessaging = OCMPartialMock(_messaging);
+  _mockMessagingAnalytics = OCMClassMock([FIRMessagingAnalytics class]);
+}
+
+- (void)tearDown {
+  [self.messaging.messagingUserDefaults removePersistentDomainForName:kFIRMessagingDefaultsTestDomain];
+  self.messaging.shouldEstablishDirectChannel = NO;
+  self.messaging.defaultFcmToken = nil;
+  [_mockMessagingAnalytics stopMocking];
+  [_mockMessaging stopMocking];
+  [_mockInstanceID stopMocking];
+  [_mockFirebaseApp stopMocking];
+  _messaging = nil;
+  [super tearDown];
+}
+
+-(void)testEmptyNotification {
+  XCTAssertEqualObjects(@(FIRMessagingMessageStatusUnknown), @([_mockMessaging appDidReceiveMessage:@{}].status));
+}
+
+-(void)testAPNSDisplayNotification {
+  NSDictionary *notificationPayload = @{
+                                        @"aps": @{
+                                                @"alert" : @{
+                                                        @"body" : @"body of notification",
+                                                        @"title" : @"title of notification",
+                                                        }
+                                                },
+                                        @"gcm.message_id" : @"1566515013484879",
+                                        @"gcm.n.e" : @1,
+                                        @"google.c.a.c_id" : @"7379928225816991517",
+                                        @"google.c.a.e" : @1,
+                                        @"google.c.a.ts" : @1566515009,
+                                        @"google.c.a.udt" : @0
+                                        };
+  OCMExpect([_mockMessaging handleContextManagerMessage:notificationPayload]);
+  OCMExpect([_mockMessaging handleIncomingLinkIfNeededFromMessage:notificationPayload]);
+  OCMExpect([_mockMessagingAnalytics logMessage:notificationPayload toAnalytics:[OCMArg any]]);
+  XCTAssertEqualObjects(@(FIRMessagingMessageStatusNew),
+                        @([_messaging appDidReceiveMessage:notificationPayload].status));
+  OCMVerifyAll(_mockMessaging);
+  
+  OCMReject([_mockMessaging handleContextManagerMessage:notificationPayload]);
+  OCMReject([_mockMessaging handleIncomingLinkIfNeededFromMessage:notificationPayload]);
+  OCMReject([_mockMessagingAnalytics logMessage:notificationPayload toAnalytics:[OCMArg any]]);
+
+  XCTAssertEqualObjects(@(FIRMessagingMessageStatusNew),
+                          @([_messaging appDidReceiveMessage:notificationPayload].status));
+  OCMVerifyAll(_mockMessaging);
+  // Clear database
+  [_messaging.rmq2Manager deleteSyncMessageWithRmqID:@"1566515013484879"];
+}
+
+-(void)testAPNSContentAvailableNotification {
+  NSDictionary *notificationPayload = @{
+                                        @"aps": @{
+                                            @"content-available" : @1
+                                            },
+                                        @"gcm.message_id" : @"1566513591299872",
+                                        @"image" : @"bunny.png",
+                                        @"google.c.a.e" : @1
+                                        };
+  OCMExpect([_mockMessaging handleContextManagerMessage:notificationPayload]);
+  OCMExpect([_mockMessaging handleIncomingLinkIfNeededFromMessage:notificationPayload]);
+  OCMExpect([_mockMessagingAnalytics logMessage:notificationPayload toAnalytics:[OCMArg any]]);
+  XCTAssertEqualObjects(@(FIRMessagingMessageStatusNew),
+                        @([_messaging appDidReceiveMessage:notificationPayload].status));
+  OCMVerifyAll(_mockMessaging);
+  
+  OCMReject([_mockMessaging handleContextManagerMessage:notificationPayload]);
+  OCMReject([_mockMessaging handleIncomingLinkIfNeededFromMessage:notificationPayload]);
+  OCMReject([_mockMessagingAnalytics logMessage:notificationPayload toAnalytics:[OCMArg any]]);
+  
+  XCTAssertEqualObjects(@(FIRMessagingMessageStatusNew),
+                        @([_messaging appDidReceiveMessage:notificationPayload].status));
+  OCMVerifyAll(_mockMessaging);
+  [_messaging.rmq2Manager deleteSyncMessageWithRmqID:@"1566513591299872"];
+
+}
+
+-(void)testAPNSCOntentAvailableContextualNotification {
+  NSDictionary *notificationPayload = @{
+                                        @"aps" : @{
+                                            @"content-available": @1
+                                        },
+                                        @"gcm.message_id": @"1566515531287827",
+                                        @"gcm.n.e" : @1,
+                                        @"gcm.notification.body" : @"Local time zone message!",
+                                        @"gcm.notification.title" : @"Hello",
+                                        @"gcms" : @"gcm.gmsproc.cm",
+                                        @"google.c.a.c_id" : @"5941428497527920876",
+                                        @"google.c.a.e" : @1,
+                                        @"google.c.a.ts" : @1566565920,
+                                        @"google.c.a.udt" : @1,
+                                        @"google.c.cm.cat" : @"com.google.firebase.messaging.testapp.dev",
+                                        @"google.c.cm.lt_end" : @"2019-09-20 13:12:00",
+                                        @"google.c.cm.lt_start" : @"2019-08-23 13:12:00",
+                                        
+                                        };
+  OCMExpect([_mockMessaging handleContextManagerMessage:notificationPayload]);
+  OCMExpect([_mockMessaging handleIncomingLinkIfNeededFromMessage:notificationPayload]);
+  OCMExpect([_mockMessagingAnalytics logMessage:notificationPayload toAnalytics:[OCMArg any]]);
+  XCTAssertEqualObjects(@(FIRMessagingMessageStatusNew),
+                        @([_messaging appDidReceiveMessage:notificationPayload].status));
+  OCMVerifyAll(_mockMessaging);
+  
+  OCMReject([_mockMessaging handleContextManagerMessage:notificationPayload]);
+  OCMReject([_mockMessaging handleIncomingLinkIfNeededFromMessage:notificationPayload]);
+  OCMReject([_mockMessagingAnalytics logMessage:notificationPayload toAnalytics:[OCMArg any]]);
+  
+  XCTAssertEqualObjects(@(FIRMessagingMessageStatusNew),
+                        @([_messaging appDidReceiveMessage:notificationPayload].status));
+  OCMVerifyAll(_mockMessaging);
+  [_messaging.rmq2Manager deleteSyncMessageWithRmqID:@"1566515531287827"];
+
+}
+
+-(void)testMCSNotification {
+  NSDictionary *notificationPayload = @{
+                                        @"from" : @"35006771263",
+                                        @"image" : @"bunny.png"
+                                        };
+  OCMExpect([_mockMessaging handleContextManagerMessage:notificationPayload]);
+  OCMExpect([_mockMessaging handleIncomingLinkIfNeededFromMessage:notificationPayload]);
+  OCMExpect([_mockMessagingAnalytics logMessage:notificationPayload toAnalytics:[OCMArg any]]);
+  XCTAssertEqualObjects(@(FIRMessagingMessageStatusNew),
+                        @([_messaging appDidReceiveMessage:notificationPayload].status));
+  OCMVerifyAll(_mockMessaging);
+  
+  OCMExpect([_mockMessaging handleContextManagerMessage:notificationPayload]);
+  OCMExpect([_mockMessaging handleIncomingLinkIfNeededFromMessage:notificationPayload]);
+  OCMExpect([_mockMessagingAnalytics logMessage:notificationPayload toAnalytics:[OCMArg any]]);
+  
+  XCTAssertEqualObjects(@(FIRMessagingMessageStatusNew),
+                        @([_messaging appDidReceiveMessage:notificationPayload].status));
+  OCMVerifyAll(_mockMessaging);
+}
+
+@end

--- a/Example/Messaging/Tests/FIRMessagingTest.m
+++ b/Example/Messaging/Tests/FIRMessagingTest.m
@@ -29,7 +29,7 @@
 extern NSString *const kFIRMessagingFCMTokenFetchAPNSOption;
 
 /// The NSUserDefaults domain for testing.
-NSString *const kFIRMessagingDefaultsTestDomain = @"com.messaging.tests";
+static NSString *const kFIRMessagingDefaultsTestDomain = @"com.messaging.tests";
 
 @interface FIRMessaging ()
 

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -86,6 +86,18 @@ NSString *const kFIRMessagingAPNSTokenType = @"APNSTokenType"; // APNS Token typ
 NSString *const kFIRMessagingPlistAutoInitEnabled =
     @"FirebaseMessagingAutoInitEnabled";  // Auto Init Enabled key stored in Info.plist
 
+const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
+  if ([message[kFIRMessagingMessageViaAPNSRootKey] isKindOfClass:[NSDictionary class]]) {
+    NSDictionary *aps = message[kFIRMessagingMessageViaAPNSRootKey];
+    return [aps[kFIRMessagingMessageAPNSContentAvailableKey] boolValue];
+  }
+  return NO;
+}
+
+ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
+  return [FIRMessagingContextManagerService isContextManagerMessage:message];
+}
+
 @interface FIRMessagingMessageInfo ()
 
 @property(nonatomic, readwrite, assign) FIRMessagingMessageStatus status;
@@ -384,22 +396,26 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
   // the message to the device.
   BOOL isOldMessage = NO;
   NSString *messageID = message[kFIRMessagingMessageIDKey];
-  if ([messageID length]) {
+  if (messageID.length) {
     [self.rmq2Manager saveS2dMessageWithRmqId:messageID];
 
     BOOL isSyncMessage = [[self class] isAPNSSyncMessage:message];
     if (isSyncMessage) {
       isOldMessage = [self.syncMessageManager didReceiveAPNSSyncMessage:message];
     }
-  }
-  // Prevent duplicates by keeping a cache of all the logged messages during each session.
-  // The duplicates only happen when the 3P app calls `appDidReceiveMessage:` along with
-  // us swizzling their implementation to call the same method implicitly.
-  if (!isOldMessage && messageID.length) {
-    isOldMessage = [self.loggedMessageIDs containsObject:messageID];
-    if (!isOldMessage) {
-      [self.loggedMessageIDs addObject:messageID];
-    }
+  
+		// Prevent duplicates by keeping a cache of all the logged messages during each session.
+		// The duplicates only happen when the 3P app calls `appDidReceiveMessage:` along with
+		// us swizzling their implementation to call the same method implicitly.
+    // We need to rule out the contextual message because it shares the same message ID
+    // as the local notification it will schedule. And because it is also a APNSSync message
+    // its duplication is already checked previously.
+		if (!isOldMessage && !FIRMessagingIsContextManagerMessage(message)) {
+			isOldMessage = [self.loggedMessageIDs containsObject:messageID];
+			if (!isOldMessage) {
+				[self.loggedMessageIDs addObject:messageID];
+			}
+		}
   }
 
   if (!isOldMessage) {
@@ -411,16 +427,8 @@ NSString *const kFIRMessagingPlistAutoInitEnabled =
 }
 
 - (BOOL)handleContextManagerMessage:(NSDictionary *)message {
-  if ([FIRMessagingContextManagerService isContextManagerMessage:message]) {
+  if (FIRMessagingIsContextManagerMessage(message)) {
     return [FIRMessagingContextManagerService handleContextManagerMessage:message];
-  }
-  return NO;
-}
-
-+ (BOOL)isAPNSSyncMessage:(NSDictionary *)message {
-  if ([message[kFIRMessagingMessageViaAPNSRootKey] isKindOfClass:[NSDictionary class]]) {
-    NSDictionary *aps = message[kFIRMessagingMessageViaAPNSRootKey];
-    return [aps[kFIRMessagingMessageAPNSContentAvailableKey] boolValue];
   }
   return NO;
 }

--- a/Firebase/Messaging/FIRMessagingContextManagerService.m
+++ b/Firebase/Messaging/FIRMessagingContextManagerService.m
@@ -44,7 +44,7 @@ NSString *const kFIRMessagingContextManagerCategoryKey =
 NSString *const kFIRMessagingContextManagerSoundKey = kFIRMessagingContextManagerNotificationKeyPrefix @"sound";
 NSString *const kFIRMessagingContextManagerContentAvailableKey =
     kFIRMessagingContextManagerNotificationKeyPrefix @"content-available";
-NSString *const kFIRMessagingAPNSPayloadKey = @"aps";
+const NSString *const kFIRMessagingAPNSPayloadKey = @"aps";
 
 
 typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {


### PR DESCRIPTION
contextual messages should not be logged its message ID as they are used for local notification scheduling. They share the same message ID, so when local notification is delivered, it is considered duplicate so it will not be logged by analytics. 
