### PR TITLE
Upgrade Firestore emulator to 1.8.0

### DIFF
--- a/scripts/run_firestore_emulator.sh
+++ b/scripts/run_firestore_emulator.sh
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-VERSION='1.6.2'
+VERSION='1.8.0'
 FILENAME="cloud-firestore-emulator-v${VERSION}.jar"
 URL="https://storage.googleapis.com/firebase-preview-drop/emulator/${FILENAME}"
 


### PR DESCRIPTION
No functional changes for us, but does keep us up-to-date.