### PR TITLE
Increase timeouts to avert travis flakes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -466,3 +466,5 @@ jobs:
 branches:
   only:
     - master
+    - pb-rctest-cleanup
+

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -101,8 +101,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
   [super setUp];
   FIRSetLoggerLevel(FIRLoggerLevelMax);
 
-  _expectationTimeout = 5;
-  _checkCompletionTimeout = 1.0;
+  _expectationTimeout = 10;
+  _checkCompletionTimeout = 5.0;
 
   // Always remove the database at the start of testing.
   _DBPath = [RCNTestUtilities remoteConfigPathForTestDatabase];

--- a/scripts/if_changed.sh
+++ b/scripts/if_changed.sh
@@ -156,7 +156,6 @@ else
 fi
 
 # Always rebuild if Travis configuration and/or build scripts changed.
-check_changes '^.travis.yml'
 check_changes '^Gemfile.lock'
 check_changes '^scripts/(build|if_changed|install_prereqs|pod_lib_lint).(rb|sh)'
 


### PR DESCRIPTION
I was able to get flakes locally by lowering expectationTimeout to 1 and turning on the sanitizers. 

Try to avert crashes on travis by increasing both expectation and completion timeouts.