### PR TITLE
Wrap decoding targetToInflightPackages in a try/catch

### DIFF
--- a/GoogleDataTransport/GDTLibrary/GDTUploadCoordinator.m
+++ b/GoogleDataTransport/GDTLibrary/GDTUploadCoordinator.m
@@ -163,16 +163,23 @@ static NSString *const ktargetToInFlightPackagesKey =
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
   GDTUploadCoordinator *sharedCoordinator = [GDTUploadCoordinator sharedInstance];
-  sharedCoordinator->_targetToInFlightPackages =
-      [aDecoder decodeObjectOfClass:[NSMutableDictionary class]
-                             forKey:ktargetToInFlightPackagesKey];
+  @try {
+    sharedCoordinator->_targetToInFlightPackages =
+        [aDecoder decodeObjectOfClass:[NSMutableDictionary class]
+                               forKey:ktargetToInFlightPackagesKey];
+
+  } @catch (NSException *exception) {
+    sharedCoordinator->_targetToInFlightPackages = [NSMutableDictionary dictionary];
+  }
   return sharedCoordinator;
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
   // All packages that have been given to uploaders need to be tracked so that their expiration
   // timers can be called.
-  [aCoder encodeObject:_targetToInFlightPackages forKey:ktargetToInFlightPackagesKey];
+  if (_targetToInFlightPackages.count > 0) {
+    [aCoder encodeObject:_targetToInFlightPackages forKey:ktargetToInFlightPackagesKey];
+  }
 }
 
 #pragma mark - GDTLifecycleProtocol

--- a/GoogleDataTransport/GDTTests/Unit/GDTUploadCoordinatorTest.m
+++ b/GoogleDataTransport/GDTTests/Unit/GDTUploadCoordinatorTest.m
@@ -146,4 +146,16 @@
   });
 }
 
+/** Tests that encoding and decoding works without crashing. */
+- (void)testNSSecureCoding {
+  GDTUploadPackage *package = [[GDTUploadPackage alloc] initWithTarget:kGDTTargetTest];
+  GDTUploadCoordinator *coordinator = [[GDTUploadCoordinator alloc] init];
+  coordinator.targetToInFlightPackages[@(kGDTTargetTest)] = package;
+  NSData *data = [NSKeyedArchiver archivedDataWithRootObject:coordinator];
+
+  // Unarchiving the coordinator always ends up altering the singleton instance.
+  GDTUploadCoordinator *unarchivedCoordinator = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+  XCTAssertEqualObjects([GDTUploadCoordinator sharedInstance], unarchivedCoordinator);
+}
+
 @end


### PR DESCRIPTION
It's not apparent how a key could be stored with a nil object in the dictionary. Maybe it's possible that somehow a GDTUploadPackage fails to decode, but there aren't any indications that this is the case. This PR adds a check for contents of the dictionary, though encoding an empty dictionary should be fine. A try/catch is utilized to catch exceptions thrown in iOS's implementation of NSSecureCoding in NSMutableDictionary.

Fixes #3676 