### PR TITLE
Fix Xcode 8 builds (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -466,4 +466,3 @@ jobs:
 branches:
   only:
     - master
-    - wilhuff/local-sources


### PR DESCRIPTION
The fix in #3647 was essentially undone in #3648 because even though the
podspec no longer depends on FirebaseCoreDiagnostics, adding in local
pod declarations for these brought them back into the project.

This change removes local pod declarations for the dependencies that
break under Xcode 8 as well.