### PR TITLE
Fix removal of view references in FSTLocalStore

### DIFF
--- a/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
@@ -806,10 +806,10 @@ NS_ASSUME_NONNULL_BEGIN
   FSTAssertContains(Doc("foo/baz", 2, Map("foo", "baz")));
 
   [self notifyLocalViewChanges:TestViewChanges(targetID, @[], @[ @"foo/bar", @"foo/baz" ])];
-  [self.localStore releaseQuery:query];
-
   FSTAssertNotContains("foo/bar");
   FSTAssertNotContains("foo/baz");
+
+  [self.localStore releaseQuery:query];
 }
 
 - (void)testThrowsAwayDocumentsWithUnknownTargetIDsImmediately {

--- a/Firestore/Source/Local/FSTLocalStore.mm
+++ b/Firestore/Source/Local/FSTLocalStore.mm
@@ -414,7 +414,7 @@ static const int64_t kResumeTokenMaxAgeSeconds = 5 * 60;  // 5 minutes
         [self->_persistence.referenceDelegate removeReference:key];
       }
       _localViewReferences.AddReferences(viewChange.added_keys(), viewChange.target_id());
-      _localViewReferences.AddReferences(viewChange.removed_keys(), viewChange.target_id());
+      _localViewReferences.RemoveReferences(viewChange.removed_keys(), viewChange.target_id());
     }
   });
 }


### PR DESCRIPTION
This was introduced during porting in #2213.

This would manifest as a slight memory leak of documents removed from a view when running with persistence disabled.