### PR TITLE
Update formatters for the Xcode 10.3 Travis image

### DIFF
--- a/Example/Database/Tests/Integration/FOrderByTests.m
+++ b/Example/Database/Tests/Integration/FOrderByTests.m
@@ -235,7 +235,9 @@
         moved = YES;
         XCTAssertEqualObjects(snapshot.key, @"greg", @"");
         XCTAssertEqualObjects(prevName, @"rob", @"");
-        XCTAssertEqualObjects(snapshot.value, @{@"nuggets" : @57}, @"");
+        XCTAssertEqualObjects(
+            snapshot.value,
+            @{@"nuggets" : @57}, @"");
       }];
 
   [ref setValue:initial];

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
@@ -436,9 +436,9 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
                                                            error:&error];
     XCTAssertNotNil(body, @"Error: %@, test: %@", error, self.name);
 
-    XCTAssertEqualObjects(body,
-                          @{@"installation" : @{@"sdkVersion" : [self SDKVersion]}}, @"%@",
-                          self.name);
+    XCTAssertEqualObjects(
+        body,
+        @{@"installation" : @{@"sdkVersion" : [self SDKVersion]}}, @"%@", self.name);
 
     return YES;
   }];

--- a/FirebaseRemoteConfig/Sources/RCNConfigDBManager.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigDBManager.m
@@ -762,10 +762,11 @@ static NSArray *RemoteConfigMetadataTableColumnsInOrder() {
 
     if (handler) {
       dispatch_async(dispatch_get_main_queue(), ^{
-        handler(YES, @{
-          @RCNExperimentTableKeyPayload : [experimentPayloads copy],
-          @RCNExperimentTableKeyMetadata : [experimentMetadata copy]
-        });
+        handler(
+            YES, @{
+              @RCNExperimentTableKeyPayload : [experimentPayloads copy],
+              @RCNExperimentTableKeyMetadata : [experimentMetadata copy]
+            });
       });
     }
   });

--- a/Firestore/Swift/Tests/Integration/CodableIntegrationTests.swift
+++ b/Firestore/Swift/Tests/Integration/CodableIntegrationTests.swift
@@ -67,7 +67,8 @@ class CodableIntegrationTests: FSTIntegrationTestCase {
         return nil
       }) { object, error in
         completion?(error)
-    } }
+      }
+    }
 
     awaitExpectations()
   }
@@ -147,7 +148,7 @@ class CodableIntegrationTests: FSTIntegrationTestCase {
     struct Model: Encodable {
       var name: String
       var explicitNull: ExplicitNull<String>
-      var optional: Optional<String>
+      var optional: String?
     }
     let model = Model(
       name: "name",

--- a/README.md
+++ b/README.md
@@ -98,12 +98,16 @@ Travis will verify that any code changes are done in a style compliant way. Inst
 These commands will get the right versions:
 
 ```
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/773cb75d360b58f32048f5964038d09825a507c8/Formula/clang-format.rb
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/3dfea1004e0736754bbf49673cca8aaed8a94089/Formula/swiftformat.rb
+brew upgrade https://raw.githubusercontent.com/Homebrew/homebrew-core/e3496d9/Formula/clang-format.rb
+brew upgrade https://raw.githubusercontent.com/Homebrew/homebrew-core/7963c3d/Formula/swiftformat.rb
 ```
 
 Note: if you already have a newer version of these installed you may need to
 `brew switch` to this version.
+
+To update this section, find the versions of clang-format and swiftformat.rb to
+match the versions in the CI failure logs
+[here](https://github.com/Homebrew/homebrew-core/tree/master/Formula).
 
 ### Running Unit Tests
 


### PR DESCRIPTION
Update the formatters now that we're checking with the Travis Xcode 10.3 image.

Make resulting source changes.

Update the instructions so this update process is easier the next time they change.