### PR TITLE
Fix comment for initializer for `FIRInAppMessagingAction` after deprecation

### DIFF
--- a/Firebase/InAppMessaging/Public/FIRInAppMessagingRendering.h
+++ b/Firebase/InAppMessaging/Public/FIRInAppMessagingRendering.h
@@ -135,7 +135,7 @@ NS_SWIFT_NAME(InAppMessagingAction)
 /// Unavailable.
 - (instancetype)init NS_UNAVAILABLE;
 
-/// Deprecated, this class shouldn't be directly instantiated.
+/// This class should only be initialized from a custom in-app message UI component implementation.
 - (instancetype)initWithActionText:(nullable NSString *)actionText actionURL:(NSURL *)actionURL;
 
 @end


### PR DESCRIPTION
Follow up to #3656 in a comment I missed.