### PR TITLE
cocoapod-generate 1.6.0 released

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,4 @@
 source 'https://rubygems.org'
 
 gem 'cocoapods', "1.7.5"
-# TODO(paulb777): The GitHub install is needed for the --platforms feature.
-# Change it back to a version specification when the 1.6.0 gem publishes.
-gem 'cocoapods-generate', :git => 'https://github.com/square/cocoapods-generate.git', :ref => 'ada3b8f'
+gem 'cocoapods-generate', '1.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/square/cocoapods-generate.git
-  revision: ada3b8f1b76248ed4b3ac9cd3a4d8b0e281f2b7a
-  ref: ada3b8f
-  specs:
-    cocoapods-generate (1.5.0)
-      cocoapods-disable-podfile-validations (~> 0.1.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -43,6 +35,8 @@ GEM
     cocoapods-deintegrate (1.0.4)
     cocoapods-disable-podfile-validations (0.1.1)
     cocoapods-downloader (1.2.2)
+    cocoapods-generate (1.6.0)
+      cocoapods-disable-podfile-validations (~> 0.1.1)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
@@ -80,7 +74,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (= 1.7.5)
-  cocoapods-generate!
+  cocoapods-generate (= 1.6.0)
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
Stop getting cocoapods-generate from a github tag now that 1.6.0 has released with the `--platforms` option.