### PR TITLE
Fix erroneous move

### DIFF
--- a/Firestore/core/src/firebase/firestore/core/event_manager.h
+++ b/Firestore/core/src/firebase/firestore/core/event_manager.h
@@ -67,7 +67,7 @@ class EventManager : public SyncEngineCallback {
   // Implements `SyncEngineCallback`.
   void HandleOnlineStateChange(model::OnlineState online_state) override;
   void OnViewSnapshots(std::vector<core::ViewSnapshot>&& snapshots) override;
-  void OnError(const core::Query& query, util::Status error) override;
+  void OnError(const core::Query& query, const util::Status& error) override;
 
  private:
   /**

--- a/Firestore/core/src/firebase/firestore/core/event_manager.mm
+++ b/Firestore/core/src/firebase/firestore/core/event_manager.mm
@@ -95,18 +95,21 @@ void EventManager::OnViewSnapshots(
   }
 }
 
-void EventManager::OnError(const core::Query& query, util::Status error) {
+void EventManager::OnError(const core::Query& query,
+                           const util::Status& error) {
   auto found_iter = queries_.find(query);
-  if (found_iter != queries_.end()) {
-    QueryListenersInfo& query_info = found_iter->second;
-    for (const auto& listener : query_info.listeners) {
-      listener->OnError(std::move(error));
-    }
-
-    // Remove all listeners. NOTE: We don't need to call [FSTSyncEngine
-    // stopListening] after an error.
-    queries_.erase(found_iter);
+  if (found_iter == queries_.end()) {
+    return;
   }
+
+  QueryListenersInfo& query_info = found_iter->second;
+  for (const auto& listener : query_info.listeners) {
+    listener->OnError(error);
+  }
+
+  // Remove all listeners. NOTE: We don't need to call [FSTSyncEngine
+  // stopListening] after an error.
+  queries_.erase(found_iter);
 }
 
 }  // namespace core

--- a/Firestore/core/src/firebase/firestore/core/sync_engine_callback.h
+++ b/Firestore/core/src/firebase/firestore/core/sync_engine_callback.h
@@ -39,7 +39,7 @@ class SyncEngineCallback {
   /** Handles new view snapshots. */
   virtual void OnViewSnapshots(std::vector<core::ViewSnapshot>&& snapshots) = 0;
   /** Handles the failure of a query. */
-  virtual void OnError(const core::Query& query, util::Status error) = 0;
+  virtual void OnError(const core::Query& query, const util::Status& error) = 0;
 };
 
 }  // namespace core

--- a/Firestore/core/src/firebase/firestore/remote/stream.mm
+++ b/Firestore/core/src/firebase/firestore/remote/stream.mm
@@ -67,16 +67,7 @@ Stream::Stream(const std::shared_ptr<AsyncQueue>& worker_queue,
 
 // Check state
 
-struct Foo {
-  std::string id() const {
-    return id_;
-  }
-  std::string id_;
-};
-
 bool Stream::IsOpen() const {
-  Foo foo;
-  auto f = foo.id();
   EnsureOnQueue();
   return state_ == State::Open;
 }

--- a/Firestore/core/src/firebase/firestore/remote/stream.mm
+++ b/Firestore/core/src/firebase/firestore/remote/stream.mm
@@ -67,7 +67,16 @@ Stream::Stream(const std::shared_ptr<AsyncQueue>& worker_queue,
 
 // Check state
 
+struct Foo {
+  std::string id() const {
+    return id_;
+  }
+  std::string id_;
+};
+
 bool Stream::IsOpen() const {
+  Foo foo;
+  auto f = foo.id();
   EnsureOnQueue();
   return state_ == State::Open;
 }


### PR DESCRIPTION
Here, the error actually has to be copied because it is passed to more than one listener. Currently, this doesn't make a difference because `util::Status` has no move constructor.

Also, make the relevant method take the status by const reference.