### PR TITLE
Add ComponentContainer tests for dependencies.

### DIFF
--- a/Example/Core/Tests/FIRComponentContainerTest.m
+++ b/Example/Core/Tests/FIRComponentContainerTest.m
@@ -100,8 +100,10 @@
 
 - (void)testRemoveAllCachedInstances {
   FIRComponentContainer *container =
-      [self containerWithRegistrants:@ [[FIRTestClass class], [FIRTestClassCached class],
-                                        [FIRTestClassEagerCached class]]];
+      [self containerWithRegistrants:@ [[FIRTestClass class],
+                                        [FIRTestClassCached class],
+                                        [FIRTestClassEagerCached class],
+                                        [FIRTestClassWithDep class]]];
 
   // Retrieve an instance of FIRTestClassCached to ensure it's cached.
   id<FIRTestProtocolCached> cachedInstance1 = FIR_COMPONENT(FIRTestProtocolCached, container);
@@ -146,6 +148,18 @@
   FIRComponentContainer *container =
       [self containerWithRegistrants:@ [[FIRTestClass class], [FIRTestClassDuplicate class]]];
   XCTAssert(container.components.count == 1);
+}
+
+#pragma mark - Dependency Tests
+
+- (void)testDependencyDoesntBlock {
+  /// Test a class that has a dependency, and fetching doesn't block the internal queue.
+  FIRComponentContainer *container =
+      [self containerWithRegistrants:@ [[FIRTestClass class], [FIRTestClassWithDep class]]];
+  XCTAssert(container.components.count == 2);
+
+  id<FIRTestProtocolWithDep> instanceWithDep = FIR_COMPONENT(FIRTestProtocolWithDep, container);
+  XCTAssertNotNil(instanceWithDep);
 }
 
 #pragma mark - Convenience Methods

--- a/Example/Core/Tests/FIRTestComponents.h
+++ b/Example/Core/Tests/FIRTestComponents.h
@@ -60,3 +60,17 @@
 @interface FIRTestClassCached
     : NSObject <FIRTestProtocol, FIRComponentLifecycleMaintainer, FIRLibrary>
 @end
+
+#pragma mark - Dependency on Standard
+
+/// A test protocol to be used for container testing.
+@protocol FIRTestProtocolWithDep
+@end
+
+/// A test class that is a component registrant that provides a component with a dependency on
+// `FIRTestProtocol`.
+@interface FIRTestClassWithDep
+    : NSObject <FIRTestProtocolWithDep, FIRComponentLifecycleMaintainer, FIRLibrary>
+@property(nonatomic, strong) id<FIRTestProtocol>testProperty;
+- (instancetype)initWithTest:(id<FIRTestProtocol>)testInstance;
+@end

--- a/Example/Core/Tests/FIRTestComponents.h
+++ b/Example/Core/Tests/FIRTestComponents.h
@@ -46,31 +46,33 @@
 /// A test class that is a component registrant that provides a component requiring eager
 /// instantiation, and is cached for easier validation that it was instantiated.
 @interface FIRTestClassEagerCached
-    : NSObject <FIRTestProtocol, FIRComponentLifecycleMaintainer, FIRLibrary>
+    : NSObject <FIRTestProtocolEagerCached, FIRComponentLifecycleMaintainer, FIRLibrary>
 @end
 
 #pragma mark - Cached Component
 
 /// A test protocol to be used for container testing.
 @protocol FIRTestProtocolCached
+- (void)cacheCow;
 @end
 
 /// A test class that is a component registrant that provides a component that requests to be
 /// cached.
 @interface FIRTestClassCached
-    : NSObject <FIRTestProtocol, FIRComponentLifecycleMaintainer, FIRLibrary>
+    : NSObject <FIRTestProtocolCached, FIRComponentLifecycleMaintainer, FIRLibrary>
 @end
 
 #pragma mark - Dependency on Standard
 
 /// A test protocol to be used for container testing.
-@protocol FIRTestProtocolWithDep
+@protocol FIRTestProtocolCachedWithDep
+@property(nonatomic, strong) id<FIRTestProtocolCached> testProperty;
 @end
 
 /// A test class that is a component registrant that provides a component with a dependency on
-// `FIRTestProtocol`.
-@interface FIRTestClassWithDep
-    : NSObject <FIRTestProtocolWithDep, FIRComponentLifecycleMaintainer, FIRLibrary>
-@property(nonatomic, strong) id<FIRTestProtocol>testProperty;
-- (instancetype)initWithTest:(id<FIRTestProtocol>)testInstance;
+// `FIRTestProtocolCached`.
+@interface FIRTestClassCachedWithDep
+    : NSObject <FIRTestProtocolCachedWithDep, FIRComponentLifecycleMaintainer, FIRLibrary>
+@property(nonatomic, strong) id<FIRTestProtocolCached> testProperty;
+- (instancetype)initWithTest:(id<FIRTestProtocolCached>)testInstance;
 @end


### PR DESCRIPTION
This ensures that no deadlocking occurs when fetching from the
container, and when a delete occurs.