### PR TITLE
Fix symbol collision failure introduced by 6.8.0 release

### DIFF
--- a/SymbolCollisionTest/Podfile
+++ b/SymbolCollisionTest/Podfile
@@ -8,7 +8,7 @@ target 'SymbolCollisionTest' do
   # use_frameworks!
 
   # Firebase Pods
-    pod 'Firebase', '6.7.0'
+    pod 'Firebase', '6.8.0'
     pod 'FirebaseAnalytics'
     pod 'FirebaseAuth'
     pod 'FirebaseCore'
@@ -48,7 +48,7 @@ target 'SymbolCollisionTest' do
     pod 'GoogleIDFASupport'
     pod 'GoogleInterchangeUtilities'
     pod 'GoogleMaps'
-    pod 'GoogleMobileVision'
+#    pod 'GoogleMobileVision' # After Firebase 6.8.0, conflicts with FirebaseML
     pod 'GoogleNetworkingUtilities'
     pod 'GoogleParsingUtilities'
     pod 'GooglePlacePicker'


### PR DESCRIPTION
The cron tests failed last night. See https://travis-ci.org/firebase/firebase-ios-sdk/jobs/581517301

With the Firebase 6.8.0 release, GoogleMobileVision is now incorporated into FirebaseML and the old GMV pod is no longer compatible.