### PR TITLE
Release 6.8.0 cherry pick: conflicting Dynamic Links changelog changes.

### DIFF
--- a/Firebase/DynamicLinks/CHANGELOG.md
+++ b/Firebase/DynamicLinks/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v4.0.4
-- [changed] Removed iOS 7 WebView code causing App Store complaints. (#3722)
+- [fixed] Removed references to UIWebView to comply with App Store Submission warning. (#3723)
 
 # v4.0.3
 - [added] Added support for custom domains for internal Google apps. (#3540)

--- a/Firebase/DynamicLinks/CHANGELOG.md
+++ b/Firebase/DynamicLinks/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v4.0.4
-- [fixed] Removed references to UIWebView to comply with App Store Submission warning. (#3723)
+- [fixed] Removed references to UIWebView to comply with App Store Submission warning. (#3722)
 
 # v4.0.3
 - [added] Added support for custom domains for internal Google apps. (#3540)


### PR DESCRIPTION
FDL changelog was modified in both release and master branches. The version from master was used to generate changelog for Firebase site:
- cherry pick #3781 
- cherry pick #3785 