### PR TITLE
Fix header issues exposed by :generate_multiple_pod_projects

### DIFF
--- a/Example/InstanceID/Tests/FIRInstanceIDCheckinServiceTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDCheckinServiceTest.m
@@ -16,12 +16,12 @@
 
 #import <XCTest/XCTest.h>
 
+#import <FirebaseInstanceID/FIRInstanceIDCheckinPreferences.h>
 #import <OCMock/OCMock.h>
 #import "Firebase/InstanceID/FIRInstanceIDCheckinPreferences+Internal.h"
 #import "Firebase/InstanceID/FIRInstanceIDCheckinService.h"
 #import "Firebase/InstanceID/FIRInstanceIDUtilities.h"
 #import "Firebase/InstanceID/NSError+FIRInstanceID.h"
-#import <FirebaseInstanceID/FIRInstanceIDCheckinPreferences.h>
 
 static NSString *const kDeviceAuthId = @"1234";
 static NSString *const kSecretToken = @"567890";

--- a/Example/InstanceID/Tests/FIRInstanceIDCheckinServiceTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDCheckinServiceTest.m
@@ -21,7 +21,7 @@
 #import "Firebase/InstanceID/FIRInstanceIDCheckinService.h"
 #import "Firebase/InstanceID/FIRInstanceIDUtilities.h"
 #import "Firebase/InstanceID/NSError+FIRInstanceID.h"
-#import "Firebase/InstanceID/Private/FIRInstanceIDCheckinPreferences.h"
+#import <FirebaseInstanceID/FIRInstanceIDCheckinPreferences.h>
 
 static NSString *const kDeviceAuthId = @"1234";
 static NSString *const kSecretToken = @"567890";

--- a/Example/InstanceID/Tests/FIRInstanceIDCheckinStoreTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDCheckinStoreTest.m
@@ -18,6 +18,7 @@
 
 #import <OCMock/OCMock.h>
 
+#import <FirebaseInstanceID/FIRInstanceIDCheckinPreferences.h>
 #import "FIRInstanceIDFakeKeychain.h"
 #import "Firebase/InstanceID/FIRInstanceIDAuthKeyChain.h"
 #import "Firebase/InstanceID/FIRInstanceIDBackupExcludedPlist.h"
@@ -27,7 +28,6 @@
 #import "Firebase/InstanceID/FIRInstanceIDStore.h"
 #import "Firebase/InstanceID/FIRInstanceIDUtilities.h"
 #import "Firebase/InstanceID/FIRInstanceIDVersionUtilities.h"
-#import <FirebaseInstanceID/FIRInstanceIDCheckinPreferences.h>
 
 static const NSTimeInterval kExpectationTimeout = 12;
 

--- a/Example/InstanceID/Tests/FIRInstanceIDCheckinStoreTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDCheckinStoreTest.m
@@ -27,7 +27,7 @@
 #import "Firebase/InstanceID/FIRInstanceIDStore.h"
 #import "Firebase/InstanceID/FIRInstanceIDUtilities.h"
 #import "Firebase/InstanceID/FIRInstanceIDVersionUtilities.h"
-#import "Firebase/InstanceID/Private/FIRInstanceIDCheckinPreferences.h"
+#import <FirebaseInstanceID/FIRInstanceIDCheckinPreferences.h>
 
 static const NSTimeInterval kExpectationTimeout = 12;
 

--- a/Example/InstanceID/Tests/FIRInstanceIDStoreTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDStoreTest.m
@@ -16,6 +16,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import <FirebaseInstanceID/FIRInstanceIDCheckinPreferences.h>
 #import <OCMock/OCMock.h>
 #import "FIRInstanceIDFakeKeychain.h"
 #import "Firebase/InstanceID/FIRInstanceIDBackupExcludedPlist.h"
@@ -26,7 +27,6 @@
 #import "Firebase/InstanceID/FIRInstanceIDTokenInfo.h"
 #import "Firebase/InstanceID/FIRInstanceIDTokenStore.h"
 #import "Firebase/InstanceID/FIRInstanceIDUtilities.h"
-#import <FirebaseInstanceID/FIRInstanceIDCheckinPreferences.h>
 
 static NSString *const kSubDirectoryName = @"FirebaseInstanceIDStoreTest";
 

--- a/Example/InstanceID/Tests/FIRInstanceIDStoreTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDStoreTest.m
@@ -26,7 +26,7 @@
 #import "Firebase/InstanceID/FIRInstanceIDTokenInfo.h"
 #import "Firebase/InstanceID/FIRInstanceIDTokenStore.h"
 #import "Firebase/InstanceID/FIRInstanceIDUtilities.h"
-#import "Firebase/InstanceID/Private/FIRInstanceIDCheckinPreferences.h"
+#import <FirebaseInstanceID/FIRInstanceIDCheckinPreferences.h>
 
 static NSString *const kSubDirectoryName = @"FirebaseInstanceIDStoreTest";
 

--- a/Example/InstanceID/Tests/FIRInstanceIDTokenOperationsTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTokenOperationsTest.m
@@ -30,7 +30,7 @@
 #import "Firebase/InstanceID/FIRInstanceIDTokenOperation+Private.h"
 #import "Firebase/InstanceID/FIRInstanceIDTokenOperation.h"
 #import "Firebase/InstanceID/NSError+FIRInstanceID.h"
-#import "Firebase/InstanceID/Public/FIRInstanceID.h"
+#import <FirebaseInstanceID/FIRInstanceID.h>
 
 #import <FirebaseCore/FIRAppInternal.h>
 

--- a/Example/InstanceID/Tests/FIRInstanceIDTokenOperationsTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTokenOperationsTest.m
@@ -16,6 +16,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import <FirebaseInstanceID/FIRInstanceID.h>
 #import <OCMock/OCMock.h>
 #import "Firebase/InstanceID/FIRInstanceIDAuthService.h"
 #import "Firebase/InstanceID/FIRInstanceIDCheckinPreferences+Internal.h"
@@ -30,7 +31,6 @@
 #import "Firebase/InstanceID/FIRInstanceIDTokenOperation+Private.h"
 #import "Firebase/InstanceID/FIRInstanceIDTokenOperation.h"
 #import "Firebase/InstanceID/NSError+FIRInstanceID.h"
-#import <FirebaseInstanceID/FIRInstanceID.h>
 
 #import <FirebaseCore/FIRAppInternal.h>
 

--- a/Firebase/InstanceID/CHANGELOG.md
+++ b/Firebase/InstanceID/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2019-09 -- 4.2.5
+- [fixed] Fix private header imports (#3796).
+
 # 2019-09 -- 4.2.4
 - [changed] Moved two headers from internal to private for Remote Config open sourcing (#3621).
 

--- a/Firebase/InstanceID/FIRInstanceIDCheckinPreferences+Internal.h
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinPreferences+Internal.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "Private/FIRInstanceIDCheckinPreferences.h"
+#import <FirebaseInstanceID/FIRInstanceIDCheckinPreferences.h>
 
 @interface FIRInstanceIDCheckinPreferences (Internal)
 

--- a/Firebase/InstanceID/FIRInstanceIDCheckinPreferences_Private.h
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinPreferences_Private.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "Private/FIRInstanceIDCheckinPreferences.h"
+#import <FirebaseInstanceID/FIRInstanceIDCheckinPreferences.h>
 
 /** Checkin refresh interval. **/
 FOUNDATION_EXPORT const NSTimeInterval kFIRInstanceIDDefaultCheckinInterval;

--- a/Firebase/InstanceID/FIRInstanceIDCheckinService.h
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinService.h
@@ -17,7 +17,7 @@
 #import <Foundation/Foundation.h>
 
 #import "FIRInstanceIDUtilities.h"
-#import "Private/FIRInstanceID+Private.h"
+#import <FirebaseInstanceID/FIRInstanceID+Private.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firebase/InstanceID/FIRInstanceIDCheckinService.h
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinService.h
@@ -16,8 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import "FIRInstanceIDUtilities.h"
 #import <FirebaseInstanceID/FIRInstanceID+Private.h>
+#import "FIRInstanceIDUtilities.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Firebase/InstanceID/FIRInstanceIDCheckinService.h
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinService.h
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 
 #import "FIRInstanceIDUtilities.h"
+#import "Private/FIRInstanceID+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -30,20 +31,6 @@ FOUNDATION_EXPORT NSString *const kFIRInstanceIDGServicesDictionaryKey;
 FOUNDATION_EXPORT NSString *const kFIRInstanceIDDeviceDataVersionKey;
 
 @class FIRInstanceIDCheckinPreferences;
-
-/**
- *  @related FIRInstanceIDCheckinService
- *
- *  The completion handler invoked once the fetch from Checkin server finishes.
- *  For successful fetches we returned checkin information by the checkin service
- *  and `nil` error, else we return the appropriate error object as reported by the
- *  Checkin Service.
- *
- *  @param checkinPreferences The checkin preferences as fetched from the server.
- *  @param error              The error object which fetching GServices data.
- */
-typedef void (^FIRInstanceIDDeviceCheckinCompletion)(
-    FIRInstanceIDCheckinPreferences *_Nullable checkinPreferences, NSError *_Nullable error);
 
 /**
  *  Register the device with Checkin Service and get back the `authID`, `secret

--- a/Firebase/InstanceID/Private/FIRInstanceID+Private.h
+++ b/Firebase/InstanceID/Private/FIRInstanceID+Private.h
@@ -14,9 +14,22 @@
  * limitations under the License.
  */
 
-#import "FIRInstanceID.h"
+#import <FirebaseInstanceID/FIRInstanceID.h>
+#import <FirebaseInstanceID/FIRInstanceIDCheckinPreferences.h>
 
-#import "FIRInstanceIDCheckinService.h"
+/**
+ *  @related FIRInstanceIDCheckinService
+ *
+ *  The completion handler invoked once the fetch from Checkin server finishes.
+ *  For successful fetches we returned checkin information by the checkin service
+ *  and `nil` error, else we return the appropriate error object as reported by the
+ *  Checkin Service.
+ *
+ *  @param checkinPreferences The checkin preferences as fetched from the server.
+ *  @param error              The error object which fetching GServices data.
+ */
+typedef void (^FIRInstanceIDDeviceCheckinCompletion)(
+    FIRInstanceIDCheckinPreferences *_Nullable checkinPreferences, NSError *_Nullable error);
 
 /**
  * Private API used by Firebase SDK teams by calling in reflection or internal teams.


### PR DESCRIPTION
Fix #3796

- Fix imports in Private headers. 
- Stop referencing an internal typedef from a private header.