### PR TITLE
Tweak code that breaks older versions of Visual Studio

### DIFF
--- a/Firestore/core/src/firebase/firestore/model/field_path.cc
+++ b/Firestore/core/src/firebase/firestore/model/field_path.cc
@@ -81,7 +81,7 @@ struct JoinEscaped {
 };
 }  // namespace
 
-constexpr char FieldPath::kDocumentKeyPath[];
+constexpr const char* FieldPath::kDocumentKeyPath;
 
 FieldPath FieldPath::FromDotSeparatedString(absl::string_view path) {
   if (path.find_first_of("~*/[]") != absl::string_view::npos) {

--- a/Firestore/core/src/firebase/firestore/model/field_path.h
+++ b/Firestore/core/src/firebase/firestore/model/field_path.h
@@ -38,7 +38,7 @@ class FieldPath : public impl::BasePath<FieldPath>,
                   public util::Comparable<FieldPath> {
  public:
   /** The field path string that represents the document's key. */
-  static constexpr char kDocumentKeyPath[] = "__name__";
+  static constexpr const char* kDocumentKeyPath = "__name__";
 
   // Note: Xcode 8.2 requires explicit specification of the constructor.
   FieldPath() : impl::BasePath<FieldPath>() {


### PR DESCRIPTION
VS2015 apparently has trouble with a `constexpr`-qualified array. Changing this back to the largely equivalent `const char*` form works fine.