### PR TITLE
Log stream errors

### DIFF
--- a/Firestore/core/src/firebase/firestore/remote/stream.mm
+++ b/Firestore/core/src/firebase/firestore/remote/stream.mm
@@ -292,9 +292,8 @@ void Stream::HandleErrorStatus(const Status& status) {
 
 void Stream::OnStreamFinish(const Status& status) {
   EnsureOnQueue();
-  // TODO(varconst): log error here?
-  LOG_DEBUG("%s Stream error", GetDebugDescription());
 
+  LOG_DEBUG("%s Stream error: '%s'", GetDebugDescription(), status.ToString());
   Close(status);
 }
 


### PR DESCRIPTION
This is in response to #3817. This is also more consistent with other platforms (e.g., Android [does](https://github.com/firebase/firebase-android-sdk/blob/master/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/AbstractStream.java#L147) log the error).

The resulting log message look like this:
```
2019-09-11 14:44:03.939778-0400 Firestore_Example_iOS[30490:61949945] 6.8.1 - [Firebase/Firestore][I-FST000001] WriteStream (7f92506abd20) Stream error: 'Not found: No document to update: <document id here, omitted>'
2019-09-11 14:45:01.067452-0400 Firestore_Example_iOS[30490:61949544] 6.8.1 - [Firebase/Firestore][I-FST000001] WriteStream (7f9212de8040) Stream error: 'Permission denied: Missing or insufficient permissions.'
```