### PR TITLE
Mark unused variables

### DIFF
--- a/GoogleUtilities/ISASwizzler/GULObjectSwizzler.m
+++ b/GoogleUtilities/ISASwizzler/GULObjectSwizzler.m
@@ -99,12 +99,9 @@
   Class targetClass = isClassSelector ? object_getClass(_generatedClass) : _generatedClass;
   IMP implementation = method_getImplementation(method);
   const char *typeEncoding = method_getTypeEncoding(method);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-variable"
-  BOOL success = class_addMethod(targetClass, selector, implementation, typeEncoding);
+  BOOL success __unused = class_addMethod(targetClass, selector, implementation, typeEncoding);
   NSAssert(success, @"Unable to add selector %@ to class %@", NSStringFromSelector(selector),
            NSStringFromClass(targetClass));
-#pragma clang diagnostic pop
 }
 
 - (void)setAssociatedObjectWithKey:(NSString *)key
@@ -139,12 +136,9 @@
     NSAssert(class_getInstanceSize(_originalClass) == class_getInstanceSize(_generatedClass),
              @"The instance size of the generated class must be equal to the original class.");
     objc_registerClassPair(_generatedClass);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-variable"
-    Class doubleCheckOriginalClass = object_setClass(_swizzledObject, _generatedClass);
+    Class doubleCheckOriginalClass __unused = object_setClass(_swizzledObject, _generatedClass);
     NSAssert(_originalClass == doubleCheckOriginalClass,
              @"The original class must be the same as the class returned by object_setClass");
-#pragma clang diagnostic pop
   } else {
     NSAssert(NO, @"You can't swizzle a nil object");
   }


### PR DESCRIPTION
Fix #3852 

Use `__unused` attribute instead of pragma to mark variables that are unused when compiling in release mode.