### PR TITLE
Mute FCM deprecated warnings with Xcode 11 and min iOS >= 10

### DIFF
--- a/Example/Messaging/Tests/FIRMessagingContextManagerServiceTest.m
+++ b/Example/Messaging/Tests/FIRMessagingContextManagerServiceTest.m
@@ -83,8 +83,10 @@
   XCTAssertTrue([FIRMessagingContextManagerService handleContextManagerMessage:message]);
 
   XCTAssertEqual(self.scheduledLocalNotifications.count, 1);
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   UILocalNotification *notification = [self.scheduledLocalNotifications firstObject];
+#pragma pop
   NSDate *date = [self.dateFormatter dateFromString:startTimeString];
   XCTAssertEqual([notification.fireDate compare:date], NSOrderedSame);
 #endif
@@ -134,7 +136,10 @@
   XCTAssertTrue([FIRMessagingContextManagerService handleContextManagerMessage:message]);
 
   XCTAssertEqual(self.scheduledLocalNotifications.count, 1);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   UILocalNotification *notification = [self.scheduledLocalNotifications firstObject];
+#pragma pop
   // schedule notification after start date
   XCTAssertEqual([notification.fireDate compare:startDate], NSOrderedDescending);
   // schedule notification after end date
@@ -163,7 +168,10 @@
   XCTAssertTrue([FIRMessagingContextManagerService handleContextManagerMessage:message]);
 
   XCTAssertEqual(self.scheduledLocalNotifications.count, 1);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   UILocalNotification *notification = [self.scheduledLocalNotifications firstObject];
+#pragma pop
   XCTAssertEqualObjects(notification.userInfo[messageIdentifierKey], messageIdentifier);
   XCTAssertEqualObjects(notification.userInfo[customDataKey], customData);
 #endif
@@ -175,6 +183,8 @@
 - (void)mockSchedulingLocalNotifications {
 #if TARGET_OS_IOS
   id mockApplication = OCMPartialMock([UIApplication sharedApplication]);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   __block UILocalNotification *notificationToSchedule;
   [[[mockApplication stub]
       andDo:^(NSInvocation *invocation) {
@@ -189,6 +199,7 @@
         }
         return NO;
       }]];
+#pragma pop
 #endif
 }
 

--- a/Example/Messaging/Tests/FIRMessagingContextManagerServiceTest.m
+++ b/Example/Messaging/Tests/FIRMessagingContextManagerServiceTest.m
@@ -86,7 +86,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   UILocalNotification *notification = [self.scheduledLocalNotifications firstObject];
-#pragma pop
+#pragma clang diagnostic pop
   NSDate *date = [self.dateFormatter dateFromString:startTimeString];
   XCTAssertEqual([notification.fireDate compare:date], NSOrderedSame);
 #endif
@@ -139,7 +139,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   UILocalNotification *notification = [self.scheduledLocalNotifications firstObject];
-#pragma pop
+#pragma clang diagnostic pop
   // schedule notification after start date
   XCTAssertEqual([notification.fireDate compare:startDate], NSOrderedDescending);
   // schedule notification after end date
@@ -171,7 +171,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   UILocalNotification *notification = [self.scheduledLocalNotifications firstObject];
-#pragma pop
+#pragma clang diagnostic pop
   XCTAssertEqualObjects(notification.userInfo[messageIdentifierKey], messageIdentifier);
   XCTAssertEqualObjects(notification.userInfo[customDataKey], customData);
 #endif
@@ -199,7 +199,7 @@
         }
         return NO;
       }]];
-#pragma pop
+#pragma clang diagnostic pop
 #endif
 }
 

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -874,7 +874,7 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability"
     [self.delegate messaging:self didReceiveMessage:remoteMessage];
-#pragma pop
+#pragma clang diagnostic pop
   } else {
     // Delegate methods weren't implemented, so messages are being dropped, log a warning
     FIRMessagingLoggerWarn(kFIRMessagingMessageCodeRemoteMessageDelegateMethodNotImplemented,

--- a/Firebase/Messaging/FIRMessagingContextManagerService.m
+++ b/Firebase/Messaging/FIRMessagingContextManagerService.m
@@ -175,7 +175,10 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
   if (!application) {
     return;
   }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [application scheduleLocalNotification:notification];
+#pragma pop
 #endif
 }
 

--- a/Firebase/Messaging/FIRMessagingContextManagerService.m
+++ b/Firebase/Messaging/FIRMessagingContextManagerService.m
@@ -149,7 +149,7 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability"
       notification.alertTitle = apsDictionary[kFIRMessagingContextManagerTitleKey];
-#pragma pop
+#pragma clang diagnostic pop
     }
   }
 
@@ -178,7 +178,7 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [application scheduleLocalNotification:notification];
-#pragma pop
+#pragma clang diagnostic pop
 #endif
 }
 

--- a/Firebase/Messaging/FIRMessagingRmq2PersistentStore.m
+++ b/Firebase/Messaging/FIRMessagingRmq2PersistentStore.m
@@ -106,7 +106,7 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability"
   const char *errorStr = sqlite3_errstr(result);
-#pragma pop
+#pragma clang diagnostic pop
   NSString *errorString = [NSString stringWithFormat:@"%d - %s", result, errorStr];
   return errorString;
 }


### PR DESCRIPTION
Fix #3856