### PR TITLE
Allow Zip build to continue if Carthage fails.

### DIFF
--- a/ZipBuilder/Sources/ZipBuilder/main.swift
+++ b/ZipBuilder/Sources/ZipBuilder/main.swift
@@ -87,7 +87,12 @@ do {
       // Save the directory for later copying.
       carthageRoot = carthageDir
     } catch {
-      fatalError("Could not copy output directory for Carthage build: \(error)")
+      // TODO: This can fail on CI due to size requirements, let's fail gracefully in the meantime
+      //       and not block the rest of the build.
+      //      fatalError("Could not copy output directory for Carthage build: \(error)")
+      print("--------- CARTHAGE ERROR ---------")
+      print("Could not copy output directory for Carthage build: \(error)")
+      print("------- END CARTHAGE ERROR -------")
     }
   }
 


### PR DESCRIPTION
This should help alleviate CI issues we're seeing.