### PR TITLE
Fix file prefix on CI.

### DIFF
--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -439,13 +439,15 @@ struct FrameworkBuilder {
     // Get all the header aliases from the CocoaPods directory and get their real path as well as
     // their relative path to the Headers directory they are in. This is needed to preserve proper
     // imports for nested folders.
+    let standardizedHeaders = headersDir.standardizedFileURL
     let aliasedHeaders = try fileManager.recursivelySearch(for: .headers, in: headersDir)
     let mappedHeaders: [(relativePath: String, resolvedLocation: URL)] = aliasedHeaders.map {
       // Standardize the URL because the aliasedHeaders could be at `/private/var` or `/var` which
       // are symlinked to each other on macOS. This will let us remove the `headersDir` prefix and
       // be left with just the relative path we need.
       let standardized = $0.standardizedFileURL
-      let relativePath = standardized.path.replacingOccurrences(of: "\(headersDir.path)/", with: "")
+      let relativePath = standardized.path.replacingOccurrences(of: "\(standardizedHeaders.path)/",
+                                                                with: "")
       let resolvedLocation = standardized.resolvingSymlinksInPath()
       return (relativePath, resolvedLocation)
     }


### PR DESCRIPTION
... Hopefully :)

The M56 release candidate unfortunately added a prefix to headers, likely due to the `standardizedFileURL` changing to a different path for the one set of URLs but we didn't use it previously.

When building on the same volume, this is a no-op, but hopefully this fixes the issue working on CI where the filesystem is on a different volume and aliased away.