### PR TITLE
Add a product to the SwiftPM manifest.

### DIFF
--- a/ZipBuilder/Package.swift
+++ b/ZipBuilder/Package.swift
@@ -21,6 +21,9 @@ import PackageDescription
 
 let package = Package(
   name: "ZipBuilder",
+  products: [
+    .executable(name: "ReleasePackager", targets: ["ZipBuilder"]),
+  ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-protobuf.git", .exact("1.2.0")),
   ],


### PR DESCRIPTION
It's named `ReleasePackager` instead of `ZipBuilder` since we should change the name now that it packages Zip and Carthage builds.