### PR TITLE
Fix nanopb dependencies for CoreDiagnostics.

### DIFF
--- a/FirebaseCoreDiagnostics.podspec
+++ b/FirebaseCoreDiagnostics.podspec
@@ -48,6 +48,7 @@ non-Cocoapod integration. This library also respects the Firebase global data co
   s.dependency 'GoogleDataTransportCCTSupport', '~> 1.0'
   s.dependency 'GoogleUtilities/Environment', '~> 6.2'
   s.dependency 'GoogleUtilities/Logger', '~> 6.2'
+  s.dependency 'nanopb', '~> 0.3.901'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.dependency 'GoogleUtilities/UserDefaults', '~> 6.2'

--- a/GoogleDataTransportCCTSupport.podspec
+++ b/GoogleDataTransportCCTSupport.podspec
@@ -33,7 +33,7 @@ Support library to provide event prioritization and uploading for the GoogleData
   s.libraries = ['z']
 
   s.dependency 'GoogleDataTransport', '~> 2.0'
-  s.dependency 'nanopb'
+  s.dependency 'nanopb', '~> 0.3.901'
 
   header_search_paths = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}/GoogleDataTransportCCTSupport/"'


### PR DESCRIPTION
This fixes #3911 by explicitly stating the dependency on `nanopb` along with the version.