### PR TITLE
Set suppressMessageDisplay on displayExecutor

### DIFF
--- a/Firebase/InAppMessaging/Runtime/FIRIAMRuntimeManager.m
+++ b/Firebase/InAppMessaging/Runtime/FIRIAMRuntimeManager.m
@@ -347,7 +347,7 @@ static NSString *const kFirebaseInAppMessagingAutoDataCollectionKey =
                                              activityLogger:self.activityLogger
                                        analyticsEventLogger:analyticsEventLogger];
 
-  // Setting the message display component and suppression. It's needed in case 
+  // Setting the message display component and suppression. It's needed in case
   // headless SDK is initialized after the these properties are already set on FIRInAppMessaging.
   self.displayExecutor.messageDisplayComponent =
       FIRInAppMessaging.inAppMessaging.messageDisplayComponent;

--- a/Firebase/InAppMessaging/Runtime/FIRIAMRuntimeManager.m
+++ b/Firebase/InAppMessaging/Runtime/FIRIAMRuntimeManager.m
@@ -347,10 +347,12 @@ static NSString *const kFirebaseInAppMessagingAutoDataCollectionKey =
                                              activityLogger:self.activityLogger
                                        analyticsEventLogger:analyticsEventLogger];
 
-  // Setting the display component. It's needed in case headless SDK is initialized after
-  // the display component is already set on FIRInAppMessaging.
+  // Setting the message display component and suppression. It's needed in case 
+  // headless SDK is initialized after the these properties are already set on FIRInAppMessaging.
   self.displayExecutor.messageDisplayComponent =
       FIRInAppMessaging.inAppMessaging.messageDisplayComponent;
+  self.displayExecutor.suppressMessageDisplay =
+      FIRInAppMessaging.inAppMessaging.messageDisplaySuppressed;
 
   // Both display flows are created on startup. But they would only be turned on (started) based on
   // the sdk mode for the current instance


### PR DESCRIPTION
This fixes the same issue as setting the `messageDisplayComponent `where the value could have been set before the SDK was initialized. I encountered this when trying to set `messageDisplaySuppressed` on `FIRInAppMessaging` after `[FIRApp configureApp]` to be able to suppress message display during onboarding and UI tests.