### PR TITLE
Update FIAM for iOS 13 Scene lifecycle paradigm

### DIFF
--- a/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.m
+++ b/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.m
@@ -92,6 +92,14 @@ static NSString *const kEventExtensionJson = @"extension_js";
                                              selector:@selector(appWillBecomeInactive)
                                                  name:UIApplicationWillResignActiveNotification
                                                object:nil];
+    
+    if (@available(iOS 13.0, *)) {
+      [[NSNotificationCenter defaultCenter] addObserver:self
+                                               selector:@selector(appWillBecomeInactive)
+                                                   name:UISceneWillDeactivateNotification
+                                                 object:nil];
+    }
+    
     @try {
       [self loadFromCachePath:cachePath];
     } @catch (NSException *exception) {

--- a/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.m
+++ b/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.m
@@ -92,13 +92,14 @@ static NSString *const kEventExtensionJson = @"extension_js";
                                              selector:@selector(appWillBecomeInactive)
                                                  name:UIApplicationWillResignActiveNotification
                                                object:nil];
-
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     if (@available(iOS 13.0, *)) {
       [[NSNotificationCenter defaultCenter] addObserver:self
                                                selector:@selector(appWillBecomeInactive)
                                                    name:UISceneWillDeactivateNotification
                                                  object:nil];
     }
+#endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
 
     @try {
       [self loadFromCachePath:cachePath];

--- a/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.m
+++ b/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.m
@@ -89,13 +89,13 @@ static NSString *const kEventExtensionJson = @"extension_js";
     _timeFetcher = timeFetcher;
     _recordExpiresInSeconds = expireInSeconds;
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(appWillBecomeInactive)
+                                             selector:@selector(appWillBecomeInactive:)
                                                  name:UIApplicationWillResignActiveNotification
                                                object:nil];
 #if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     if (@available(iOS 13.0, *)) {
       [[NSNotificationCenter defaultCenter] addObserver:self
-                                               selector:@selector(appWillBecomeInactive)
+                                               selector:@selector(appWillBecomeInactive:)
                                                    name:UISceneWillDeactivateNotification
                                                  object:nil];
     }
@@ -119,7 +119,7 @@ static NSString *const kEventExtensionJson = @"extension_js";
                                   cachePath:nil];
 }
 
-- (void)appWillBecomeInactive {
+- (void)appWillBecomeInactive:(NSNotification *)notification {
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul), ^{
     [self saveIntoCacheWithPath:nil];
   });

--- a/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.m
+++ b/Firebase/InAppMessaging/Analytics/FIRIAMClearcutLogStorage.m
@@ -92,14 +92,14 @@ static NSString *const kEventExtensionJson = @"extension_js";
                                              selector:@selector(appWillBecomeInactive)
                                                  name:UIApplicationWillResignActiveNotification
                                                object:nil];
-    
+
     if (@available(iOS 13.0, *)) {
       [[NSNotificationCenter defaultCenter] addObserver:self
                                                selector:@selector(appWillBecomeInactive)
                                                    name:UISceneWillDeactivateNotification
                                                  object:nil];
     }
-    
+
     @try {
       [self loadFromCachePath:cachePath];
     } @catch (NSException *exception) {

--- a/Firebase/InAppMessaging/Analytics/FIRIAMClearcutUploader.m
+++ b/Firebase/InAppMessaging/Analytics/FIRIAMClearcutUploader.m
@@ -98,7 +98,7 @@ static NSString *FIRIAM_UserDefaultsKeyForNextValidClearcutUploadTimeInMills =
                                              selector:@selector(scheduleNextSendFromForeground)
                                                  name:UIApplicationWillEnterForegroundNotification
                                                object:nil];
-    
+
     if (@available(iOS 13.0, *)) {
       [[NSNotificationCenter defaultCenter] addObserver:self
                                                selector:@selector(scheduleNextSendFromForeground)

--- a/Firebase/InAppMessaging/Analytics/FIRIAMClearcutUploader.m
+++ b/Firebase/InAppMessaging/Analytics/FIRIAMClearcutUploader.m
@@ -98,14 +98,14 @@ static NSString *FIRIAM_UserDefaultsKeyForNextValidClearcutUploadTimeInMills =
                                              selector:@selector(scheduleNextSendFromForeground)
                                                  name:UIApplicationWillEnterForegroundNotification
                                                object:nil];
-
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     if (@available(iOS 13.0, *)) {
       [[NSNotificationCenter defaultCenter] addObserver:self
                                                selector:@selector(scheduleNextSendFromForeground)
                                                    name:UISceneWillEnterForegroundNotification
                                                  object:nil];
     }
-
+#endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     _userDefaults = userDefaults ? userDefaults : [NSUserDefaults standardUserDefaults];
     // it would be 0 if it does not exist, which is equvilent to saying that
     // you can send now

--- a/Firebase/InAppMessaging/Analytics/FIRIAMClearcutUploader.m
+++ b/Firebase/InAppMessaging/Analytics/FIRIAMClearcutUploader.m
@@ -95,9 +95,16 @@ static NSString *FIRIAM_UserDefaultsKeyForNextValidClearcutUploadTimeInMills =
     _strategy = strategy;
     _queue = dispatch_queue_create("com.google.firebase.inappmessaging.clearcut_upload", NULL);
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(appWillEnterForeground:)
+                                             selector:@selector(scheduleNextSendFromForeground)
                                                  name:UIApplicationWillEnterForegroundNotification
                                                object:nil];
+    
+    if (@available(iOS 13.0, *)) {
+      [[NSNotificationCenter defaultCenter] addObserver:self
+                                               selector:@selector(scheduleNextSendFromForeground)
+                                                   name:UISceneWillEnterForegroundNotification
+                                                 object:nil];
+    }
 
     _userDefaults = userDefaults ? userDefaults : [NSUserDefaults standardUserDefaults];
     // it would be 0 if it does not exist, which is equvilent to saying that
@@ -121,7 +128,7 @@ static NSString *FIRIAM_UserDefaultsKeyForNextValidClearcutUploadTimeInMills =
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (void)appWillEnterForeground:(UIApplication *)application {
+- (void)scheduleNextSendFromForeground {
   FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM260010",
               @"App foregrounded, FIRIAMClearcutUploader will seed next send");
   [self scheduleNextSend];

--- a/Firebase/InAppMessaging/Analytics/FIRIAMClearcutUploader.m
+++ b/Firebase/InAppMessaging/Analytics/FIRIAMClearcutUploader.m
@@ -95,13 +95,13 @@ static NSString *FIRIAM_UserDefaultsKeyForNextValidClearcutUploadTimeInMills =
     _strategy = strategy;
     _queue = dispatch_queue_create("com.google.firebase.inappmessaging.clearcut_upload", NULL);
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(scheduleNextSendFromForeground)
+                                             selector:@selector(scheduleNextSendFromForeground:)
                                                  name:UIApplicationWillEnterForegroundNotification
                                                object:nil];
 #if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     if (@available(iOS 13.0, *)) {
       [[NSNotificationCenter defaultCenter] addObserver:self
-                                               selector:@selector(scheduleNextSendFromForeground)
+                                               selector:@selector(scheduleNextSendFromForeground:)
                                                    name:UISceneWillEnterForegroundNotification
                                                  object:nil];
     }
@@ -128,7 +128,7 @@ static NSString *FIRIAM_UserDefaultsKeyForNextValidClearcutUploadTimeInMills =
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (void)scheduleNextSendFromForeground {
+- (void)scheduleNextSendFromForeground:(NSNotification *)notification {
   FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM260010",
               @"App foregrounded, FIRIAMClearcutUploader will seed next send");
   [self scheduleNextSend];

--- a/Firebase/InAppMessaging/Flows/FIRIAMActivityLogger.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMActivityLogger.m
@@ -106,14 +106,14 @@ static NSString *const kDetailArchiveKey = @"detail";
                                              selector:@selector(appWillBecomeInactive)
                                                  name:UIApplicationWillResignActiveNotification
                                                object:nil];
-
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     if (@available(iOS 13.0, *)) {
       [[NSNotificationCenter defaultCenter] addObserver:self
                                                selector:@selector(appWillBecomeInactive)
                                                    name:UISceneWillDeactivateNotification
                                                  object:nil];
     }
-
+#endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     if (loadFromCache) {
       @try {
         [self loadFromCachePath:nil];

--- a/Firebase/InAppMessaging/Flows/FIRIAMActivityLogger.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMActivityLogger.m
@@ -103,13 +103,13 @@ static NSString *const kDetailArchiveKey = @"detail";
     _isDirty = NO;
 
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(appWillBecomeInactive)
+                                             selector:@selector(appWillBecomeInactive:)
                                                  name:UIApplicationWillResignActiveNotification
                                                object:nil];
 #if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     if (@available(iOS 13.0, *)) {
       [[NSNotificationCenter defaultCenter] addObserver:self
-                                               selector:@selector(appWillBecomeInactive)
+                                               selector:@selector(appWillBecomeInactive:)
                                                    name:UISceneWillDeactivateNotification
                                                  object:nil];
     }
@@ -169,7 +169,7 @@ static NSString *const kDetailArchiveKey = @"detail";
   }
 }
 
-- (void)appWillBecomeInactive {
+- (void)appWillBecomeInactive:(NSNotification *)notification {
   FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM310004",
               @"App will become inactive, save"
                " activity logs");

--- a/Firebase/InAppMessaging/Flows/FIRIAMActivityLogger.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMActivityLogger.m
@@ -106,6 +106,13 @@ static NSString *const kDetailArchiveKey = @"detail";
                                              selector:@selector(appWillBecomeInactive)
                                                  name:UIApplicationWillResignActiveNotification
                                                object:nil];
+    
+    if (@available(iOS 13.0, *)) {
+      [[NSNotificationCenter defaultCenter] addObserver:self
+                                               selector:@selector(appWillBecomeInactive)
+                                                   name:UISceneWillDeactivateNotification
+                                                 object:nil];
+    }
 
     if (loadFromCache) {
       @try {

--- a/Firebase/InAppMessaging/Flows/FIRIAMActivityLogger.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMActivityLogger.m
@@ -106,7 +106,7 @@ static NSString *const kDetailArchiveKey = @"detail";
                                              selector:@selector(appWillBecomeInactive)
                                                  name:UIApplicationWillResignActiveNotification
                                                object:nil];
-    
+
     if (@available(iOS 13.0, *)) {
       [[NSNotificationCenter defaultCenter] addObserver:self
                                                selector:@selector(appWillBecomeInactive)

--- a/Firebase/InAppMessaging/Flows/FIRIAMDisplayCheckOnAppForegroundFlow.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMDisplayCheckOnAppForegroundFlow.m
@@ -25,16 +25,18 @@
 - (void)start {
   FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM500002",
               @"Start observing app foreground notifications for rendering messages.");
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(checkAndDisplayNextAppForegroundMessageFromForeground)
-                                               name:UIApplicationWillEnterForegroundNotification
-                                             object:nil];
-  
+  [[NSNotificationCenter defaultCenter]
+      addObserver:self
+         selector:@selector(checkAndDisplayNextAppForegroundMessageFromForeground)
+             name:UIApplicationWillEnterForegroundNotification
+           object:nil];
+
   if (@available(iOS 13.0, *)) {
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(checkAndDisplayNextAppForegroundMessageFromForeground)
-                                                 name:UISceneWillEnterForegroundNotification
-                                               object:nil];
+    [[NSNotificationCenter defaultCenter]
+        addObserver:self
+           selector:@selector(checkAndDisplayNextAppForegroundMessageFromForeground)
+               name:UISceneWillEnterForegroundNotification
+             object:nil];
   }
 }
 

--- a/Firebase/InAppMessaging/Flows/FIRIAMDisplayCheckOnAppForegroundFlow.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMDisplayCheckOnAppForegroundFlow.m
@@ -30,7 +30,7 @@
          selector:@selector(checkAndDisplayNextAppForegroundMessageFromForeground)
              name:UIApplicationWillEnterForegroundNotification
            object:nil];
-
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
   if (@available(iOS 13.0, *)) {
     [[NSNotificationCenter defaultCenter]
         addObserver:self
@@ -38,6 +38,7 @@
                name:UISceneWillEnterForegroundNotification
              object:nil];
   }
+#endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
 }
 
 - (void)checkAndDisplayNextAppForegroundMessageFromForeground {

--- a/Firebase/InAppMessaging/Flows/FIRIAMDisplayCheckOnAppForegroundFlow.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMDisplayCheckOnAppForegroundFlow.m
@@ -27,21 +27,21 @@
               @"Start observing app foreground notifications for rendering messages.");
   [[NSNotificationCenter defaultCenter]
       addObserver:self
-         selector:@selector(checkAndDisplayNextAppForegroundMessageFromForeground)
+         selector:@selector(checkAndDisplayNextAppForegroundMessageFromForeground:)
              name:UIApplicationWillEnterForegroundNotification
            object:nil];
 #if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
   if (@available(iOS 13.0, *)) {
     [[NSNotificationCenter defaultCenter]
         addObserver:self
-           selector:@selector(checkAndDisplayNextAppForegroundMessageFromForeground)
+           selector:@selector(checkAndDisplayNextAppForegroundMessageFromForeground:)
                name:UISceneWillEnterForegroundNotification
              object:nil];
   }
 #endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
 }
 
-- (void)checkAndDisplayNextAppForegroundMessageFromForeground {
+- (void)checkAndDisplayNextAppForegroundMessageFromForeground:(NSNotification *)notification {
   FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM500001",
               @"App foregrounded, wake up to check in-app messaging.");
 

--- a/Firebase/InAppMessaging/Flows/FIRIAMDisplayCheckOnAppForegroundFlow.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMDisplayCheckOnAppForegroundFlow.m
@@ -26,12 +26,19 @@
   FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM500002",
               @"Start observing app foreground notifications for rendering messages.");
   [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(appWillEnterForeground:)
+                                           selector:@selector(checkAndDisplayNextAppForegroundMessageFromForeground)
                                                name:UIApplicationWillEnterForegroundNotification
                                              object:nil];
+  
+  if (@available(iOS 13.0, *)) {
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(checkAndDisplayNextAppForegroundMessageFromForeground)
+                                                 name:UISceneWillEnterForegroundNotification
+                                               object:nil];
+  }
 }
 
-- (void)appWillEnterForeground:(UIApplication *)application {
+- (void)checkAndDisplayNextAppForegroundMessageFromForeground {
   FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM500001",
               @"App foregrounded, wake up to check in-app messaging.");
 

--- a/Firebase/InAppMessaging/Flows/FIRIAMFetchOnAppForegroundFlow.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMFetchOnAppForegroundFlow.m
@@ -23,20 +23,20 @@
   FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM600002",
               @"Start observing app foreground notifications for message fetching.");
   [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(appWillEnterForeground)
+                                           selector:@selector(appWillEnterForeground:)
                                                name:UIApplicationWillEnterForegroundNotification
                                              object:nil];
 #if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
   if (@available(iOS 13.0, *)) {
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(appWillEnterForeground)
+                                             selector:@selector(appWillEnterForeground:)
                                                  name:UISceneWillEnterForegroundNotification
                                                object:nil];
   }
 #endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
 }
 
-- (void)appWillEnterForeground {
+- (void)appWillEnterForeground:(NSNotification *)notification {
   FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM600001",
               @"App foregrounded, wake up to see if we can fetch in-app messaging.");
   // for fetch operation, dispatch it to non main UI thread to avoid blocking. It's ok to dispatch

--- a/Firebase/InAppMessaging/Flows/FIRIAMFetchOnAppForegroundFlow.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMFetchOnAppForegroundFlow.m
@@ -26,13 +26,14 @@
                                            selector:@selector(appWillEnterForeground)
                                                name:UIApplicationWillEnterForegroundNotification
                                              object:nil];
-
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
   if (@available(iOS 13.0, *)) {
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(appWillEnterForeground)
                                                  name:UISceneWillEnterForegroundNotification
                                                object:nil];
   }
+#endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
 }
 
 - (void)appWillEnterForeground {

--- a/Firebase/InAppMessaging/Flows/FIRIAMFetchOnAppForegroundFlow.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMFetchOnAppForegroundFlow.m
@@ -23,12 +23,19 @@
   FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM600002",
               @"Start observing app foreground notifications for message fetching.");
   [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(appWillEnterForeground:)
+                                           selector:@selector(appWillEnterForeground)
                                                name:UIApplicationWillEnterForegroundNotification
                                              object:nil];
+  
+  if (@available(iOS 13.0, *)) {
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(appWillEnterForeground)
+                                                 name:UISceneWillEnterForegroundNotification
+                                               object:nil];
+  }
 }
 
-- (void)appWillEnterForeground:(UIApplication *)application {
+- (void)appWillEnterForeground {
   FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM600001",
               @"App foregrounded, wake up to see if we can fetch in-app messaging.");
   // for fetch operation, dispatch it to non main UI thread to avoid blocking. It's ok to dispatch

--- a/Firebase/InAppMessaging/Flows/FIRIAMFetchOnAppForegroundFlow.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMFetchOnAppForegroundFlow.m
@@ -26,7 +26,7 @@
                                            selector:@selector(appWillEnterForeground)
                                                name:UIApplicationWillEnterForegroundNotification
                                              object:nil];
-  
+
   if (@available(iOS 13.0, *)) {
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(appWillEnterForeground)

--- a/Firebase/InAppMessagingDisplay/Banner/FIDBannerViewController.m
+++ b/Firebase/InAppMessagingDisplay/Banner/FIDBannerViewController.m
@@ -284,7 +284,7 @@ static const CGFloat kSwipeUpThreshold = -10.0f;
 
 // Handlers for app become active inactive so that we can better adjust our auto dismiss feature
 - (void)appWillBecomeInactive:(NSNotification *)notification {
-  [super appWillBecomeInactive:<#notification #>];
+  [super appWillBecomeInactive:notification];
   [self.autoDismissTimer invalidate];
 }
 

--- a/Firebase/InAppMessagingDisplay/Banner/FIDBannerViewController.m
+++ b/Firebase/InAppMessagingDisplay/Banner/FIDBannerViewController.m
@@ -283,13 +283,13 @@ static const CGFloat kSwipeUpThreshold = -10.0f;
 }
 
 // Handlers for app become active inactive so that we can better adjust our auto dismiss feature
-- (void)appWillBecomeInactive {
-  [super appWillBecomeInactive];
+- (void)appWillBecomeInactive:(NSNotification *)notification {
+  [super appWillBecomeInactive:<#notification #>];
   [self.autoDismissTimer invalidate];
 }
 
-- (void)appDidBecomeActive {
-  [super appDidBecomeActive];
+- (void)appDidBecomeActive:(NSNotification *)notification {
+  [super appDidBecomeActive:notification];
   [self setupAutoDismissTimer];
 }
 

--- a/Firebase/InAppMessagingDisplay/Banner/FIDBannerViewController.m
+++ b/Firebase/InAppMessagingDisplay/Banner/FIDBannerViewController.m
@@ -283,13 +283,13 @@ static const CGFloat kSwipeUpThreshold = -10.0f;
 }
 
 // Handlers for app become active inactive so that we can better adjust our auto dismiss feature
-- (void)appDidBecomeInactive:(UIApplication *)application {
-  [super appDidBecomeInactive:application];
+- (void)appWillBecomeInactive {
+  [super appWillBecomeInactive];
   [self.autoDismissTimer invalidate];
 }
 
-- (void)appDidBecomeActive:(UIApplication *)application {
-  [super appDidBecomeActive:application];
+- (void)appDidBecomeActive {
+  [super appDidBecomeActive];
   [self setupAutoDismissTimer];
 }
 

--- a/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.h
+++ b/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.h
@@ -30,8 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 // These are the two methods we use to respond to app state change for the purpose of
 // actual display time tracking. Subclass can override this one to have more logic for responding
 // to the two events, but remember to trigger super's implementation.
-- (void)appDidBecomeInactive:(UIApplication *)application;
-- (void)appDidBecomeActive:(UIApplication *)application;
+- (void)appWillBecomeInactive;
+- (void)appDidBecomeActive;
 
 // Tracking the aggregate impression time for the rendered message. Used to determine when
 // we are eaching the minimal iimpression time requirements. Exposed so that sub banner vc

--- a/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.h
+++ b/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.h
@@ -30,8 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 // These are the two methods we use to respond to app state change for the purpose of
 // actual display time tracking. Subclass can override this one to have more logic for responding
 // to the two events, but remember to trigger super's implementation.
-- (void)appWillBecomeInactive;
-- (void)appDidBecomeActive;
+- (void)appWillBecomeInactive:(NSNotification *)notification;
+- (void)appDidBecomeActive:(NSNotification *)notification;
 
 // Tracking the aggregate impression time for the rendered message. Used to determine when
 // we are eaching the minimal iimpression time requirements. Exposed so that sub banner vc

--- a/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.m
+++ b/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.m
@@ -52,7 +52,7 @@ static const NSTimeInterval kMinValidImpressionTime = 3.0;
                                            selector:@selector(appDidBecomeActive)
                                                name:UIApplicationDidBecomeActiveNotification
                                              object:nil];
-  
+
   if (@available(iOS 13.0, *)) {
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(appWillBecomeInactive)

--- a/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.m
+++ b/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.m
@@ -52,7 +52,7 @@ static const NSTimeInterval kMinValidImpressionTime = 3.0;
                                            selector:@selector(appDidBecomeActive)
                                                name:UIApplicationDidBecomeActiveNotification
                                              object:nil];
-
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
   if (@available(iOS 13.0, *)) {
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(appWillBecomeInactive)
@@ -64,7 +64,7 @@ static const NSTimeInterval kMinValidImpressionTime = 3.0;
                                                  name:UISceneDidActivateNotification
                                                object:nil];
   }
-
+#endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
   self.aggregateImpressionTimeInSeconds = 0;
 }
 

--- a/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.m
+++ b/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.m
@@ -44,14 +44,26 @@ static const NSTimeInterval kMinValidImpressionTime = 3.0;
   // app foreground/background events since viewDidAppear/viewDidDisappear are not
   // triggered when app switches happen.
   [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(appDidBecomeInactive:)
+                                           selector:@selector(appWillBecomeInactive)
                                                name:UIApplicationWillResignActiveNotification
                                              object:nil];
 
   [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(appDidBecomeActive:)
+                                           selector:@selector(appDidBecomeActive)
                                                name:UIApplicationDidBecomeActiveNotification
                                              object:nil];
+  
+  if (@available(iOS 13.0, *)) {
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(appWillBecomeInactive)
+                                                 name:UISceneWillDeactivateNotification
+                                               object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(appDidBecomeActive)
+                                                 name:UISceneDidActivateNotification
+                                               object:nil];
+  }
 
   self.aggregateImpressionTimeInSeconds = 0;
 }
@@ -92,11 +104,11 @@ static const NSTimeInterval kMinValidImpressionTime = 3.0;
   [NSNotificationCenter.defaultCenter removeObserver:self];
 }
 
-- (void)appDidBecomeInactive:(UIApplication *)application {
+- (void)appWillBecomeInactive {
   [self impressionStopCheckpoint];
 }
 
-- (void)appDidBecomeActive:(UIApplication *)application {
+- (void)appDidBecomeActive {
   [self impressionStartCheckpoint];
 }
 

--- a/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.m
+++ b/Firebase/InAppMessagingDisplay/FIDBaseRenderingViewController.m
@@ -44,23 +44,23 @@ static const NSTimeInterval kMinValidImpressionTime = 3.0;
   // app foreground/background events since viewDidAppear/viewDidDisappear are not
   // triggered when app switches happen.
   [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(appWillBecomeInactive)
+                                           selector:@selector(appWillBecomeInactive:)
                                                name:UIApplicationWillResignActiveNotification
                                              object:nil];
 
   [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(appDidBecomeActive)
+                                           selector:@selector(appDidBecomeActive:)
                                                name:UIApplicationDidBecomeActiveNotification
                                              object:nil];
 #if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
   if (@available(iOS 13.0, *)) {
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(appWillBecomeInactive)
+                                             selector:@selector(appWillBecomeInactive:)
                                                  name:UISceneWillDeactivateNotification
                                                object:nil];
 
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(appDidBecomeActive)
+                                             selector:@selector(appDidBecomeActive:)
                                                  name:UISceneDidActivateNotification
                                                object:nil];
   }
@@ -104,11 +104,11 @@ static const NSTimeInterval kMinValidImpressionTime = 3.0;
   [NSNotificationCenter.defaultCenter removeObserver:self];
 }
 
-- (void)appWillBecomeInactive {
+- (void)appWillBecomeInactive:(NSNotification *)notification {
   [self impressionStopCheckpoint];
 }
 
-- (void)appDidBecomeActive {
+- (void)appDidBecomeActive:(NSNotification *)notification {
   [self impressionStartCheckpoint];
 }
 

--- a/Firebase/InAppMessagingDisplay/FIDRenderingWindowHelper.m
+++ b/Firebase/InAppMessagingDisplay/FIDRenderingWindowHelper.m
@@ -25,13 +25,7 @@
 
   dispatch_once(&onceToken, ^{
     if (@available(iOS 13.0, *)) {
-      UIWindowScene *foregroundedScene = nil;
-      for (UIWindowScene *connectedScene in [UIApplication sharedApplication].connectedScenes) {
-        if (connectedScene.activationState == UISceneActivationStateForegroundActive) {
-          foregroundedScene = connectedScene;
-          break;
-        }
-      }
+      UIWindowScene *foregroundedScene = [[self class] foregroundedScene];
       UIWindowForModal = [[UIWindow alloc] initWithWindowScene:foregroundedScene];
     } else {
       UIWindowForModal = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
@@ -47,13 +41,7 @@
 
   dispatch_once(&onceToken, ^{
     if (@available(iOS 13.0, *)) {
-      UIWindowScene *foregroundedScene = nil;
-      for (UIWindowScene *connectedScene in [UIApplication sharedApplication].connectedScenes) {
-        if (connectedScene.activationState == UISceneActivationStateForegroundActive) {
-          foregroundedScene = connectedScene;
-          break;
-        }
-      }
+      UIWindowScene *foregroundedScene = [[self class] foregroundedScene];
       UIWindowForBanner = [[FIDBannerViewUIWindow alloc] initWithWindowScene:foregroundedScene];
     } else {
       UIWindowForBanner =
@@ -71,13 +59,7 @@
 
   dispatch_once(&onceToken, ^{
     if (@available(iOS 13.0, *)) {
-      UIWindowScene *foregroundedScene = nil;
-      for (UIWindowScene *connectedScene in [UIApplication sharedApplication].connectedScenes) {
-        if (connectedScene.activationState == UISceneActivationStateForegroundActive) {
-          foregroundedScene = connectedScene;
-          break;
-        }
-      }
+      UIWindowScene *foregroundedScene = [[self class] foregroundedScene];
       UIWindowForImageOnly = [[UIWindow alloc] initWithWindowScene:foregroundedScene];
     } else {
       UIWindowForImageOnly = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
@@ -86,5 +68,14 @@
   });
 
   return UIWindowForImageOnly;
+}
+
++ (UIWindowScene *)foregroundedScene API_AVAILABLE(ios(13.0)) {
+  for (UIWindowScene *connectedScene in [UIApplication sharedApplication].connectedScenes) {
+    if (connectedScene.activationState == UISceneActivationStateForegroundActive) {
+      return connectedScene;
+    }
+  }
+  return nil;
 }
 @end

--- a/Firebase/InAppMessagingDisplay/FIDRenderingWindowHelper.m
+++ b/Firebase/InAppMessagingDisplay/FIDRenderingWindowHelper.m
@@ -24,7 +24,18 @@
   static dispatch_once_t onceToken;
 
   dispatch_once(&onceToken, ^{
-    UIWindowForModal = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+    if (@available(iOS 13.0, *)) {
+      UIWindowScene *foregroundedScene = nil;
+      for (UIWindowScene *connectedScene in [UIApplication sharedApplication].connectedScenes) {
+        if (connectedScene.activationState == UISceneActivationStateForegroundActive) {
+          foregroundedScene = connectedScene;
+          break;
+        }
+      }
+      UIWindowForModal = [[UIWindow alloc] initWithWindowScene:foregroundedScene];
+    } else {
+      UIWindowForModal = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+    }
     UIWindowForModal.windowLevel = UIWindowLevelNormal;
   });
   return UIWindowForModal;
@@ -35,7 +46,19 @@
   static dispatch_once_t onceToken;
 
   dispatch_once(&onceToken, ^{
-    UIWindowForBanner = [[FIDBannerViewUIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+    if (@available(iOS 13.0, *)) {
+      UIWindowScene *foregroundedScene = nil;
+      for (UIWindowScene *connectedScene in [UIApplication sharedApplication].connectedScenes) {
+        if (connectedScene.activationState == UISceneActivationStateForegroundActive) {
+          foregroundedScene = connectedScene;
+          break;
+        }
+      }
+      UIWindowForBanner = [[FIDBannerViewUIWindow alloc] initWithWindowScene:foregroundedScene];
+    } else {
+      UIWindowForBanner =
+          [[FIDBannerViewUIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+    }
     UIWindowForBanner.windowLevel = UIWindowLevelNormal;
   });
 
@@ -47,7 +70,18 @@
   static dispatch_once_t onceToken;
 
   dispatch_once(&onceToken, ^{
-    UIWindowForImageOnly = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+    if (@available(iOS 13.0, *)) {
+      UIWindowScene *foregroundedScene = nil;
+      for (UIWindowScene *connectedScene in [UIApplication sharedApplication].connectedScenes) {
+        if (connectedScene.activationState == UISceneActivationStateForegroundActive) {
+          foregroundedScene = connectedScene;
+          break;
+        }
+      }
+      UIWindowForImageOnly = [[UIWindow alloc] initWithWindowScene:foregroundedScene];
+    } else {
+      UIWindowForImageOnly = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+    }
     UIWindowForImageOnly.windowLevel = UIWindowLevelNormal;
   });
 

--- a/Firebase/InAppMessagingDisplay/FIDRenderingWindowHelper.m
+++ b/Firebase/InAppMessagingDisplay/FIDRenderingWindowHelper.m
@@ -24,12 +24,16 @@
   static dispatch_once_t onceToken;
 
   dispatch_once(&onceToken, ^{
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     if (@available(iOS 13.0, *)) {
       UIWindowScene *foregroundedScene = [[self class] foregroundedScene];
       UIWindowForModal = [[UIWindow alloc] initWithWindowScene:foregroundedScene];
     } else {
+#endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
       UIWindowForModal = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     }
+#endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     UIWindowForModal.windowLevel = UIWindowLevelNormal;
   });
   return UIWindowForModal;
@@ -40,13 +44,17 @@
   static dispatch_once_t onceToken;
 
   dispatch_once(&onceToken, ^{
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     if (@available(iOS 13.0, *)) {
       UIWindowScene *foregroundedScene = [[self class] foregroundedScene];
       UIWindowForBanner = [[FIDBannerViewUIWindow alloc] initWithWindowScene:foregroundedScene];
     } else {
+#endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
       UIWindowForBanner =
           [[FIDBannerViewUIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     }
+#endif
     UIWindowForBanner.windowLevel = UIWindowLevelNormal;
   });
 
@@ -58,18 +66,23 @@
   static dispatch_once_t onceToken;
 
   dispatch_once(&onceToken, ^{
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     if (@available(iOS 13.0, *)) {
       UIWindowScene *foregroundedScene = [[self class] foregroundedScene];
       UIWindowForImageOnly = [[UIWindow alloc] initWithWindowScene:foregroundedScene];
     } else {
+#endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
       UIWindowForImageOnly = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     }
+#endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     UIWindowForImageOnly.windowLevel = UIWindowLevelNormal;
   });
 
   return UIWindowForImageOnly;
 }
 
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
 + (UIWindowScene *)foregroundedScene API_AVAILABLE(ios(13.0)) {
   for (UIWindowScene *connectedScene in [UIApplication sharedApplication].connectedScenes) {
     if (connectedScene.activationState == UISceneActivationStateForegroundActive) {
@@ -78,4 +91,5 @@
   }
   return nil;
 }
+#endif
 @end


### PR DESCRIPTION
Two key fixes:
- Throw both `UIScene` and `UIApplication` lifecycle notifications
- Update `UIWindow` creation logic to initialize based on a foregrounded scene (if iOS 13 is available)

Fixes https://github.com/firebase/firebase-ios-sdk/issues/3524 with the exception around concerns with opening URL from a scene. From testing, though, current URL opening logic still works as intended.