### PR TITLE
Fix unit testing crash with localization on

### DIFF
--- a/GoogleUtilities/CHANGELOG.md
+++ b/GoogleUtilities/CHANGELOG.md
@@ -5,6 +5,7 @@
 # 6.3.0
 - GULSecureCoding introduced. (#3707)
 - Mark unused variables. (#3854)
+- Fix crash in GULLogBasic. (#3928)
 
 # 6.2.5
 - Remove test-only method and update tests to include Catalyst. (#3544)

--- a/GoogleUtilities/CHANGELOG.md
+++ b/GoogleUtilities/CHANGELOG.md
@@ -1,11 +1,11 @@
 # 6.3.1
 - Fix GULMutableDictionary keyed subscript methods. (#3882)
 - Update Networking to receive data for POST requests. (#3940)
+- Fix crash in GULLogBasic. (#3928)
 
 # 6.3.0
 - GULSecureCoding introduced. (#3707)
 - Mark unused variables. (#3854)
-- Fix crash in GULLogBasic. (#3928)
 
 # 6.2.5
 - Remove test-only method and update tests to include Catalyst. (#3544)

--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -161,7 +161,12 @@ void GULLogBasic(GULLoggerLevel level,
                                                                     range:messageCodeRange];
   NSCAssert(numberOfMatches == 1, @"Incorrect message code format.");
 #endif
-  NSString *logMsg = [[NSString alloc] initWithFormat:message arguments:args_ptr];
+  NSString *logMsg;
+  if (args_ptr == NULL) {
+    logMsg = [message copy];
+  } else {
+    logMsg = [[NSString alloc] initWithFormat:message arguments:args_ptr];
+  }
   logMsg = [NSString stringWithFormat:@"%s - %@[%@] %@", sVersion, service, messageCode, logMsg];
   dispatch_async(sGULClientQueue, ^{
     asl_log(sGULLoggerClient, NULL, (int)level, "%s", logMsg.UTF8String);

--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -163,7 +163,7 @@ void GULLogBasic(GULLoggerLevel level,
 #endif
   NSString *logMsg;
   if (args_ptr == NULL) {
-    logMsg = [message copy];
+    logMsg = message;
   } else {
     logMsg = [[NSString alloc] initWithFormat:message arguments:args_ptr];
   }


### PR DESCRIPTION
For whatever reason, `GULLogBasic` crashes when running a test plan with Localization Screenshots enabled. I can't figure out exactly why this throws but even assigning `logMsg = message;` triggers the same crash, leading me to believe that `message` is invalid at that point (even though the debugger can print the value).

Fixes #3928.  Thanks again @abotkin-cpi for the sample project, made it easy to track down!

I avoided copying in the regular path since we don't copy to begin with and it's working as expected.