### PR TITLE
Travis to Xcode 11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: osx
-osx_image: xcode10.3
+osx_image: xcode11
 language: objective-c
 cache:
   - bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -256,6 +256,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --use-modular-headers
 
     - stage: test
+      osx_image: xcode10.3
       env:
         - PROJECT=InAppMessaging PLATFORM=iOS METHOD=xcodebuild
       before_install:
@@ -328,6 +329,7 @@ jobs:
         - travis_wait 45 ./scripts/pod_lib_lint.rb FirebaseFirestore.podspec --use-libraries --allow-warnings --no-subspecs
 
     - stage: test
+      osx_image: xcode10.3
       env:
         - PROJECT=GoogleDataTransport METHOD=pod-lib-lint
       script:

--- a/Example/Core/App/iOS/FIRAppDelegate.m
+++ b/Example/Core/App/iOS/FIRAppDelegate.m
@@ -20,7 +20,6 @@
 
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-  [FIRApp configure];
   return YES;
 }
 

--- a/Example/Core/App/iOS/FIRAppDelegate.m
+++ b/Example/Core/App/iOS/FIRAppDelegate.m
@@ -20,6 +20,7 @@
 
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+  [FIRApp configure];
   return YES;
 }
 

--- a/Example/Database/Tests/Unit/FLevelDBStorageEngineTests.m
+++ b/Example/Database/Tests/Unit/FLevelDBStorageEngineTests.m
@@ -473,7 +473,7 @@
 // It is kind of bad we raise "invalid" data, but at least we don't crash *trollface*
 - (void)testExtremeDoublesAsServerCache {
 #ifdef TARGET_OS_IOS
-  if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion == 11) {
+  if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion >= 11) {
     // NSJSONSerialization on iOS 11 correctly serializes small and large doubles.
     return;
   }
@@ -532,8 +532,12 @@
   XCTAssertEqual(CFNumberGetType((CFNumberRef)actualInt), kCFNumberSInt64Type);
   XCTAssertEqualObjects([actualLong stringValue], [longValue stringValue]);
   XCTAssertEqual(CFNumberGetType((CFNumberRef)actualLong), kCFNumberSInt64Type);
-#if TARGET_OS_MACCATALYST
-  // Catalyst uses int128_t but CFNumber still calls it 64 bits
+#ifdef TARGET_OS_IOS
+  // Catalyst and iOS 13 use int128_t but CFNumber still calls it 64 bits.
+  if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion >= 13) {
+    XCTAssertEqual(CFNumberGetType((CFNumberRef)actualDouble), kCFNumberSInt64Type);
+  }
+#elif TARGET_OS_MACCATALYST
   XCTAssertEqual(CFNumberGetType((CFNumberRef)actualDouble), kCFNumberSInt64Type);
 #else
   XCTAssertEqual(CFNumberGetType((CFNumberRef)actualDouble), kCFNumberFloat64Type);

--- a/Example/Database/Tests/Unit/FLevelDBStorageEngineTests.m
+++ b/Example/Database/Tests/Unit/FLevelDBStorageEngineTests.m
@@ -536,6 +536,8 @@
   // Catalyst and iOS 13 use int128_t but CFNumber still calls it 64 bits.
   if ([[NSProcessInfo processInfo] operatingSystemVersion].majorVersion >= 13) {
     XCTAssertEqual(CFNumberGetType((CFNumberRef)actualDouble), kCFNumberSInt64Type);
+  } else {
+    XCTAssertEqual(CFNumberGetType((CFNumberRef)actualDouble), kCFNumberFloat64Type);
   }
 #elif TARGET_OS_MACCATALYST
   XCTAssertEqual(CFNumberGetType((CFNumberRef)actualDouble), kCFNumberSInt64Type);

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -93,7 +93,7 @@ function RunXcodebuild() {
 
 ios_flags=(
   -sdk 'iphonesimulator'
-  -destination 'platform=iOS Simulator,name=iPhone 11'
+  -destination 'platform=iOS Simulator'
 )
 macos_flags=(
   -sdk 'macosx'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -93,7 +93,7 @@ function RunXcodebuild() {
 
 ios_flags=(
   -sdk 'iphonesimulator'
-  -destination 'platform=iOS Simulator,name=iPhone 7'
+  -destination 'platform=iOS Simulator,name=iPhone 11'
 )
 macos_flags=(
   -sdk 'macosx'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -91,10 +91,10 @@ function RunXcodebuild() {
   fi
 }
 
-# Remove this if test when Firestore moves up to Xcode 11
-if [[ $product == 'Firestore' ||
-      $product == 'GoogleDataTransport' ||
-      $product == 'InAppMessaging'
+# Remove each product when it moves up to Xcode 11
+if [[ $product == 'Firestore' || # #3949
+      $product == 'GoogleDataTransport' || # #3947
+      $product == 'InAppMessaging' # #3948
    ]]; then
   ios_flags=(
     -sdk 'iphonesimulator'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -92,7 +92,10 @@ function RunXcodebuild() {
 }
 
 # Remove this if test when Firestore moves up to Xcode 11
-if [[ $product == 'Firestore' ]]; then
+if [[ $product == 'Firestore' ||
+      $product == 'GoogleDataTransport' ||
+      $product == 'InAppMessaging'
+   ]]; then
   ios_flags=(
     -sdk 'iphonesimulator'
     -destination 'platform=iOS Simulator,name=iPhone 7'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -213,18 +213,6 @@ case "$product-$method-$platform" in
     if [[ $platform == 'iOS' ]]; then
       # Code Coverage collection is only working on iOS currently.
       ./scripts/collect_metrics.sh 'Example/Firebase.xcworkspace' "AllUnitTests_$platform"
-
-      # Test iOS Objective-C static library build
-      cd Example
-      sed -i -e 's/use_frameworks/\#use_frameworks/' Podfile
-      pod update --no-repo-update
-      cd ..
-      RunXcodebuild \
-          -workspace 'Example/Firebase.xcworkspace' \
-          -scheme "AllUnitTests_$platform" \
-          "${xcb_flags[@]}" \
-          build \
-          test
     fi
     ;;
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -91,10 +91,19 @@ function RunXcodebuild() {
   fi
 }
 
-ios_flags=(
-  -sdk 'iphonesimulator'
-  -destination 'platform=iOS Simulator'
-)
+# Remove this if test when Firestore moves up to Xcode 11
+if [[ $product == 'Firestore' ]]; then
+  ios_flags=(
+    -sdk 'iphonesimulator'
+    -destination 'platform=iOS Simulator,name=iPhone 7'
+  )
+else
+  ios_flags=(
+    -sdk 'iphonesimulator'
+    -destination 'platform=iOS Simulator,name=iPhone 11'
+  )
+fi
+
 macos_flags=(
   -sdk 'macosx'
   -destination 'platform=OS X,arch=x86_64'


### PR DESCRIPTION
- Update default travis builds to Xcode 11
- Update Core and Database unit tests for minor issues
- Disable FIAM(#3948) and GDT(#3947) in addition to Firestore(#3949) until their Xcode 11 issues get resolved
- Stop doing static library build via Xcode project. It's a source of flakes and static library builds are sufficiently tested by `pod lib lint`