### PR TITLE
Make FIAM tests more robust in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -256,7 +256,6 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --use-modular-headers
 
     - stage: test
-#      osx_image: xcode10.3
       env:
         - PROJECT=InAppMessaging PLATFORM=iOS METHOD=xcodebuild
       before_install:
@@ -265,7 +264,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
-#      osx_image: xcode10.3
+      osx_image: xcode10.3
       env:
         - PROJECT=InAppMessagingDisplay PLATFORM=iOS METHOD=xcodebuild
       before_install:
@@ -274,7 +273,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
-#      osx_image: xcode10.3
+      osx_image: xcode10.3
       env:
         - PROJECT=InAppMessagingDisplay PLATFORM=iPad METHOD=xcodebuild
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -257,16 +257,7 @@ jobs:
 
     - stage: test
       env:
-        - PROJECT=InAppMessaging PLATFORM=iOS METHOD=xcodebuild
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
-      script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
-
-    - stage: test
-#      osx_image: xcode10.3
-      env:
-        - PROJECT=InAppMessagingDisplay PLATFORM=iOS METHOD=xcodebuild
+        - PROJECT=FIAM PLATFORM=iOS METHOD=xcodebuild
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
@@ -275,7 +266,16 @@ jobs:
     - stage: test
       osx_image: xcode10.3
       env:
-        - PROJECT=InAppMessagingDisplay PLATFORM=iPad METHOD=xcodebuild
+        - PROJECT=FIAMDisplay PLATFORM=iOS METHOD=xcodebuild
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
+
+    - stage: test
+      osx_image: xcode10.3
+      env:
+        - PROJECT=FIAMDisplay PLATFORM=iPad METHOD=xcodebuild
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
@@ -573,4 +573,3 @@ jobs:
 branches:
   only:
     - master
-    - pb-split-iam-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -257,25 +257,25 @@ jobs:
 
     - stage: test
       env:
-        - PROJECT=FIAM PLATFORM=iOS METHOD=xcodebuild
+        - PROJECT=InAppMessaging PLATFORM=iOS METHOD=xcodebuild
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
-#      osx_image: xcode10.3
+      osx_image: xcode10.3
       env:
-        - PROJECT=FIAMDisplay PLATFORM=iOS METHOD=xcodebuild
+        - PROJECT=InAppMessagingDisplay PLATFORM=iOS METHOD=xcodebuild
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
-#      osx_image: xcode10.3
+      osx_image: xcode10.3
       env:
-        - PROJECT=FIAMDisplay PLATFORM=iPad METHOD=xcodebuild
+        - PROJECT=InAppMessagingDisplay PLATFORM=iPad METHOD=xcodebuild
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -264,7 +264,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
-      osx_image: xcode10.3
+#      osx_image: xcode10.3
       env:
         - PROJECT=InAppMessagingDisplay PLATFORM=iOS METHOD=xcodebuild
       before_install:
@@ -573,3 +573,4 @@ jobs:
 branches:
   only:
     - master
+    - pb-split-iam-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -256,9 +256,27 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --use-modular-headers
 
     - stage: test
-      osx_image: xcode10.3
+#      osx_image: xcode10.3
       env:
         - PROJECT=InAppMessaging PLATFORM=iOS METHOD=xcodebuild
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
+
+    - stage: test
+#      osx_image: xcode10.3
+      env:
+        - PROJECT=InAppMessagingDisplay PLATFORM=iOS METHOD=xcodebuild
+      before_install:
+        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
+      script:
+        - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
+
+    - stage: test
+#      osx_image: xcode10.3
+      env:
+        - PROJECT=InAppMessagingDisplay PLATFORM=iPad METHOD=xcodebuild
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
@@ -558,3 +576,4 @@ jobs:
 branches:
   only:
     - master
+    - pb-split-iam-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -573,4 +573,3 @@ jobs:
 branches:
   only:
     - master
-    - pb-split-iam-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -264,7 +264,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
-      osx_image: xcode10.3
+#      osx_image: xcode10.3
       env:
         - PROJECT=FIAMDisplay PLATFORM=iOS METHOD=xcodebuild
       before_install:
@@ -273,7 +273,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
-      osx_image: xcode10.3
+#      osx_image: xcode10.3
       env:
         - PROJECT=FIAMDisplay PLATFORM=iPad METHOD=xcodebuild
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -564,8 +564,6 @@ jobs:
       - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild SANITIZERS=tsan
     - env:
       - PROJECT=GoogleDataTransportIntegrationTest PLATFORM=iOS METHOD=xcodebuild
-  #  - env:
-  #    - PROJECT=InAppMessaging PLATFORM=iOS METHOD=xcodebuild
 
   # TODO(varconst): enable if it's possible to make this flag work on build
   # stages. It's supposed to avoid waiting for jobs that are allowed to fail

--- a/.travis.yml
+++ b/.travis.yml
@@ -564,8 +564,8 @@ jobs:
       - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild SANITIZERS=tsan
     - env:
       - PROJECT=GoogleDataTransportIntegrationTest PLATFORM=iOS METHOD=xcodebuild
-    - env:
-      - PROJECT=InAppMessaging PLATFORM=iOS METHOD=xcodebuild
+  #  - env:
+  #    - PROJECT=InAppMessaging PLATFORM=iOS METHOD=xcodebuild
 
   # TODO(varconst): enable if it's possible to make this flag work on build
   # stages. It's supposed to avoid waiting for jobs that are allowed to fail

--- a/Example/Core/App/iOS/FIRAppDelegate.m
+++ b/Example/Core/App/iOS/FIRAppDelegate.m
@@ -20,7 +20,6 @@
 
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-  [FIRApp configure];
   return YES;
 }
 

--- a/Example/Core/App/iOS/FIRAppDelegate.m
+++ b/Example/Core/App/iOS/FIRAppDelegate.m
@@ -20,6 +20,7 @@
 
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+  [FIRApp configure];
   return YES;
 }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -95,7 +95,7 @@ function RunXcodebuild() {
 # Remove each product when it moves up to Xcode 11
 if [[ $product == 'Firestore' || # #3949
       $product == 'GoogleDataTransport' || # #3947
-      $product == 'FIAM' # #3948 ||
+      $product == 'FIAM' || # #3948 ||
       $product == 'FIAMDisplay' # #3948
    ]]; then
   ios_flags=(

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -246,16 +246,7 @@ case "$product-$method-$platform" in
         test
   ;;
 
-  InAppMessagingDisplay-xcodebuild-iOS)
-    RunXcodebuild \
-        -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
-        -scheme 'FiamDisplaySwiftExample' \
-        "${xcb_flags[@]}" \
-        build \
-        test
-    ;;
-
-  InAppMessagingDisplay-xcodebuild-iPad)
+  InAppMessagingDisplay-xcodebuild-*)
     RunXcodebuild \
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
         -scheme 'FiamDisplaySwiftExample' \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -95,6 +95,7 @@ function RunXcodebuild() {
 # Remove each product when it moves up to Xcode 11
 if [[ $product == 'Firestore' || # #3949
       $product == 'GoogleDataTransport' || # #3947
+      $product == 'FIAM' # #3948 ||
       $product == 'FIAMDisplay' # #3948
    ]]; then
   ios_flags=(

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -107,6 +107,11 @@ else
   )
 fi
 
+ipad_flags=(
+  -sdk 'iphonesimulator'
+  -destination 'platform=iOS Simulator,name=iPad Pro (9.7-inch)'
+)
+
 macos_flags=(
   -sdk 'macosx'
   -destination 'platform=OS X,arch=x86_64'
@@ -121,6 +126,10 @@ case "$platform" in
   iOS)
     xcb_flags=("${ios_flags[@]}")
     ;;
+
+  iPad)
+    xcb_flags=("${ipad_flags[@]}")
+  ;;
 
   macOS)
     xcb_flags=("${macos_flags[@]}")
@@ -250,8 +259,7 @@ case "$product-$method-$platform" in
     RunXcodebuild \
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
         -scheme 'FiamDisplaySwiftExample' \
-        -sdk 'iphonesimulator' \
-        -destination 'platform=iOS Simulator,name=iPad Pro (9.7-inch)' \
+        "${xcb_flags[@]}" \
         build \
         test
     ;;

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -94,7 +94,7 @@ function RunXcodebuild() {
 # Remove each product when it moves up to Xcode 11
 if [[ $product == 'Firestore' || # #3949
       $product == 'GoogleDataTransport' || # #3947
-      $product == 'InAppMessaging' # #3948
+      $product == 'InAppMessagingDisplay' # #3948
    ]]; then
   ios_flags=(
     -sdk 'iphonesimulator'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -239,7 +239,7 @@ case "$product-$method-$platform" in
 
   InAppMessaging-xcodebuild-iOS)
     RunXcodebuild \
-        -workspace 'InAppMessaging/Example/InAppMessaging-Example-iOS.xcworkspace'  \
+        -workspace 'InAppMessaging/Example/InAppMessaging-Example-iOS.xcworkspace' \
         -scheme 'InAppMessaging_Example_iOS' \
         "${xcb_flags[@]}" \
         build \
@@ -248,7 +248,7 @@ case "$product-$method-$platform" in
 
   InAppMessagingDisplay-xcodebuild-*)
     RunXcodebuild \
-        -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
+        -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace' \
         -scheme 'FiamDisplaySwiftExample' \
         "${xcb_flags[@]}" \
         build \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -235,48 +235,18 @@ case "$product-$method-$platform" in
         "${xcb_flags[@]}" \
         build \
         test
+  ;;
 
-    cd InAppMessaging/Example
-    sed -i -e 's/use_frameworks/\#use_frameworks/' Podfile
-    pod update --no-repo-update
-    cd ../..
-    RunXcodebuild \
-        -workspace 'InAppMessaging/Example/InAppMessaging-Example-iOS.xcworkspace'  \
-        -scheme 'InAppMessaging_Example_iOS' \
-        "${xcb_flags[@]}" \
-        build \
-        test
-
-    # Run UI tests on both iPad and iPhone simulators
-    # TODO: Running two destinations from one xcodebuild command stopped working with Xcode 10.
-    # Consider separating static library tests to a separate job.
+  InAppMessagingDisplay-xcodebuild-iOS)
     RunXcodebuild \
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
         -scheme 'FiamDisplaySwiftExample' \
         "${xcb_flags[@]}" \
         build \
         test
+    ;;
 
-    RunXcodebuild \
-        -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
-        -scheme 'FiamDisplaySwiftExample' \
-        -sdk 'iphonesimulator' \
-        -destination 'platform=iOS Simulator,name=iPad Pro (9.7-inch)' \
-        build \
-        test
-
-    cd InAppMessagingDisplay/Example
-    sed -i -e 's/use_frameworks/\#use_frameworks/' Podfile
-    pod update --no-repo-update
-    cd ../..
-    # Run UI tests on both iPad and iPhone simulators
-    RunXcodebuild \
-        -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
-        -scheme 'FiamDisplaySwiftExample' \
-        "${xcb_flags[@]}" \
-        build \
-        test
-
+  InAppMessagingDisplay-xcodebuild-iPad)
     RunXcodebuild \
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace'  \
         -scheme 'FiamDisplaySwiftExample' \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,7 +32,8 @@ USAGE: $0 product [platform] [method]
 product can be one of:
   Firebase
   Firestore
-  InAppMessaging
+  FIAM
+  FIAMDisplay
   SymbolCollision
 
 platform can be one of:
@@ -94,7 +95,7 @@ function RunXcodebuild() {
 # Remove each product when it moves up to Xcode 11
 if [[ $product == 'Firestore' || # #3949
       $product == 'GoogleDataTransport' || # #3947
-      $product == 'InAppMessagingDisplay' # #3948
+      $product == 'FIAMDisplay' # #3948
    ]]; then
   ios_flags=(
     -sdk 'iphonesimulator'
@@ -237,7 +238,7 @@ case "$product-$method-$platform" in
     fi
     ;;
 
-  InAppMessaging-xcodebuild-iOS)
+  FIAM-xcodebuild-iOS)
     RunXcodebuild \
         -workspace 'InAppMessaging/Example/InAppMessaging-Example-iOS.xcworkspace' \
         -scheme 'InAppMessaging_Example_iOS' \
@@ -246,7 +247,7 @@ case "$product-$method-$platform" in
         test
   ;;
 
-  InAppMessagingDisplay-xcodebuild-*)
+  FIAMDisplay-xcodebuild-*)
     RunXcodebuild \
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace' \
         -scheme 'FiamDisplaySwiftExample' \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -95,8 +95,7 @@ function RunXcodebuild() {
 # Remove each product when it moves up to Xcode 11
 if [[ $product == 'Firestore' || # #3949
       $product == 'GoogleDataTransport' || # #3947
-      $product == 'FIAM' || # #3948 ||
-      $product == 'FIAMDisplay' # #3948
+      $product == 'FIAMDisplayXXXXXX' # #3948
    ]]; then
   ios_flags=(
     -sdk 'iphonesimulator'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -32,8 +32,8 @@ USAGE: $0 product [platform] [method]
 product can be one of:
   Firebase
   Firestore
-  FIAM
-  FIAMDisplay
+  InAppMessaging
+  InAppMessagingDisplay
   SymbolCollision
 
 platform can be one of:
@@ -95,7 +95,7 @@ function RunXcodebuild() {
 # Remove each product when it moves up to Xcode 11
 if [[ $product == 'Firestore' || # #3949
       $product == 'GoogleDataTransport' || # #3947
-      $product == 'FIAMDisplayXXXXXX' # #3948
+      $product == 'InAppMessagingDisplay' # #3948
    ]]; then
   ios_flags=(
     -sdk 'iphonesimulator'
@@ -238,7 +238,7 @@ case "$product-$method-$platform" in
     fi
     ;;
 
-  FIAM-xcodebuild-iOS)
+  InAppMessaging-xcodebuild-iOS)
     RunXcodebuild \
         -workspace 'InAppMessaging/Example/InAppMessaging-Example-iOS.xcworkspace' \
         -scheme 'InAppMessaging_Example_iOS' \
@@ -247,7 +247,7 @@ case "$product-$method-$platform" in
         test
   ;;
 
-  FIAMDisplay-xcodebuild-*)
+  InAppMessagingDisplay-xcodebuild-*)
     RunXcodebuild \
         -workspace 'InAppMessagingDisplay/Example/InAppMessagingDisplay-Sample.xcworkspace' \
         -scheme 'FiamDisplaySwiftExample' \

--- a/scripts/if_changed.sh
+++ b/scripts/if_changed.sh
@@ -100,6 +100,10 @@ else
       ;;
 
     InAppMessaging-*)
+      check_changes '^(InAppMessaging|Firebase/InAppMessaging)'
+      ;;
+
+    InAppMessagingDisplay-*)
       check_changes '^(Firebase/InAppMessagingDisplay|InAppMessagingDisplay|InAppMessaging|'\
 'Firebase/InAppMessaging)'
       ;;

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -90,8 +90,12 @@ case "$PROJECT-$PLATFORM-$METHOD" in
 
   InAppMessaging-iOS-xcodebuild)
     gem install xcpretty
-    bundle exec pod install --project-directory=InAppMessagingDisplay/Example --repo-update
     bundle exec pod install --project-directory=InAppMessaging/Example --repo-update
+    ;;
+
+  InAppMessagingDisplay-*-xcodebuild)
+    gem install xcpretty
+    bundle exec pod install --project-directory=InAppMessagingDisplay/Example --repo-update
     ;;
 
   Firestore-*-xcodebuild | Firestore-*-fuzz)

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -91,10 +91,12 @@ case "$PROJECT-$PLATFORM-$METHOD" in
   FIAM-*-xcodebuild)
     gem install xcpretty
     bundle exec pod install --project-directory=InAppMessaging/Example --repo-update
+    bundle exec pod install --project-directory=InAppMessagingDisplay/Example --repo-update
     ;;
 
   FIAMDisplay-*-xcodebuild)
     gem install xcpretty
+    bundle exec pod install --project-directory=InAppMessaging/Example --repo-update
     bundle exec pod install --project-directory=InAppMessagingDisplay/Example --repo-update
     ;;
 

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -91,13 +91,12 @@ case "$PROJECT-$PLATFORM-$METHOD" in
   FIAM-*-xcodebuild)
     gem install xcpretty
     bundle exec pod install --project-directory=InAppMessaging/Example --repo-update
-    bundle exec pod install --project-directory=InAppMessagingDisplay/Example --repo-update
     ;;
 
   FIAMDisplay-*-xcodebuild)
     gem install xcpretty
-    bundle exec pod install --project-directory=InAppMessaging/Example --repo-update
-    bundle exec pod install --project-directory=InAppMessagingDisplay/Example --repo-update
+    bundle exec pod repo update
+    bundle exec pod install --project-directory=InAppMessagingDisplay/Example
     ;;
 
   Firestore-*-xcodebuild | Firestore-*-fuzz)

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -88,12 +88,12 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     install_secrets
     ;;
 
-  InAppMessaging-iOS-xcodebuild)
+  FIAM-*-xcodebuild)
     gem install xcpretty
     bundle exec pod install --project-directory=InAppMessaging/Example --repo-update
     ;;
 
-  InAppMessagingDisplay-*-xcodebuild)
+  FIAMDisplay-*-xcodebuild)
     gem install xcpretty
     bundle exec pod install --project-directory=InAppMessagingDisplay/Example --repo-update
     ;;

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -82,12 +82,12 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     install_secrets
     ;;
 
-  FIAM-iOS-xcodebuild)
+  InAppMessaging-iOS-xcodebuild)
     gem install xcpretty
     bundle exec pod install --project-directory=InAppMessaging/Example --repo-update
     ;;
 
-  FIAMDisplay-iOS-xcodebuild)
+  InAppMessagingDisplay-*-xcodebuild)
     gem install xcpretty
     bundle exec pod install --project-directory=InAppMessagingDisplay/Example --repo-update
     ;;

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -58,12 +58,6 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     install_secrets
     ;;
 
-  Firebase-*-xcodebuild)
-    gem install xcpretty
-    bundle exec pod install --project-directory=Example --repo-update
-    bundle exec pod install --project-directory=GoogleUtilities/Example
-    ;;
-
   Auth-*)
     # Install the workspace for integration testing.
     gem install xcpretty
@@ -88,15 +82,14 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     install_secrets
     ;;
 
-  FIAM-*-xcodebuild)
+  FIAM-iOS-xcodebuild)
     gem install xcpretty
     bundle exec pod install --project-directory=InAppMessaging/Example --repo-update
     ;;
 
-  FIAMDisplay-*-xcodebuild)
+  FIAMDisplay-iOS-xcodebuild)
     gem install xcpretty
-    bundle exec pod repo update
-    bundle exec pod install --project-directory=InAppMessagingDisplay/Example
+    bundle exec pod install --project-directory=InAppMessagingDisplay/Example --repo-update
     ;;
 
   Firestore-*-xcodebuild | Firestore-*-fuzz)


### PR DESCRIPTION
- Split FIAM from FIAM display to separate stages
- Split iOS and iPad to separate stages
- Stop running static library tests from xcodebuild. `pod lib lint` tests are sufficient for that
- Require FIAM tests to pass for overall run to pass
- Xcode 11 build issue remains. See #3948

There's now enough time in each stage for travis_retry to eliminate flakes.