### PR TITLE
Provide better error messages when encoding is not available

### DIFF
--- a/Firestore/Swift/Source/Codable/CodableErrors.swift
+++ b/Firestore/Swift/Source/Codable/CodableErrors.swift
@@ -15,10 +15,10 @@
  */
 
 public enum FirestoreDecodingError: Error {
-  case decodingIsNotSupported
+  case decodingIsNotSupported(String)
   case fieldNameConfict(String)
 }
 
 public enum FirestoreEncodingError: Error {
-  case encodingIsNotSupported
+  case encodingIsNotSupported(String)
 }

--- a/Firestore/Swift/Source/Codable/DocumentReference+Codable.swift
+++ b/Firestore/Swift/Source/Codable/DocumentReference+Codable.swift
@@ -30,15 +30,19 @@ private protocol CodableDocumentReference: Codable {}
 
 /**
  * DocumentReference's codable implmentation will just throw for most
- * encoder/decoder however. It is only meant to be encoded by FirestoreEncoder/FirestoreDecoder.
+ * encoder/decoder however. It is only meant to be encoded by Firestore.Encoder/Firestore.Decoder.
  */
 extension CodableDocumentReference {
   public init(from decoder: Decoder) throws {
-    throw FirestoreDecodingError.decodingIsNotSupported
+    throw FirestoreDecodingError.decodingIsNotSupported(
+      "DocumentReference values can only be decoded with Firestore.Decoder"
+    )
   }
 
   public func encode(to encoder: Encoder) throws {
-    throw FirestoreEncodingError.encodingIsNotSupported
+    throw FirestoreEncodingError.encodingIsNotSupported(
+      "DocumentReference values can only be encoded with Firestore.Encoder"
+    )
   }
 }
 

--- a/Firestore/Swift/Source/Codable/FieldValue+Encodable.swift
+++ b/Firestore/Swift/Source/Codable/FieldValue+Encodable.swift
@@ -19,9 +19,10 @@ import FirebaseFirestore
 /** Extends FieldValue to conform to Encodable. */
 extension FieldValue: Encodable {
   /// Encoding a FieldValue will throw by default unless the encoder implementation
-  /// explicitly handles it, which is what FirestoreEncoder does.
+  /// explicitly handles it, which is what Firestore.Encoder does.
   public func encode(to encoder: Encoder) throws {
-    throw FirestoreEncodingError.encodingIsNotSupported
+    throw FirestoreEncodingError.encodingIsNotSupported(
+      "FieldValue values can only be encoded with Firestore.Encoder")
   }
 }
 

--- a/Firestore/Swift/Source/Codable/SelfDocumentId.swift
+++ b/Firestore/Swift/Source/Codable/SelfDocumentId.swift
@@ -17,7 +17,7 @@
 import FirebaseFirestore
 
 /// A value that is populated in Codable objects with a `DocumentReference` by
-/// the FirestoreDecoder when a document is read.
+/// the Firestore.Decoder when a document is read.
 ///
 /// Note that limitations in Swift compiler-generated Codable implementations
 /// prevent using this type wrapped in an Optional. Optional SelfDocumentIDs
@@ -33,7 +33,7 @@ import FirebaseFirestore
 /// another without adjusting the value here.
 ///
 /// NOTE: Trying to encode/decode this type using encoders/decoders other than
-/// FirestoreEncoder leads to an error.
+/// Firestore.Encoder leads to an error.
 public final class SelfDocumentID: Equatable, Codable {
   // MARK: - Initializers
 
@@ -48,11 +48,13 @@ public final class SelfDocumentID: Equatable, Codable {
   // MARK: - `Codable` implemention.
 
   public init(from decoder: Decoder) throws {
-    throw FirestoreDecodingError.decodingIsNotSupported
+    throw FirestoreDecodingError.decodingIsNotSupported(
+      "SelfDocumentID values can only be decoded with Firestore.Decoder")
   }
 
   public func encode(to encoder: Encoder) throws {
-    throw FirestoreEncodingError.encodingIsNotSupported
+    throw FirestoreEncodingError.encodingIsNotSupported(
+      "SelfDocumentID values can only be encoded with Firestore.Encoder")
   }
 
   // MARK: - Properties

--- a/Firestore/Swift/Tests/Codable/FirestoreEncoderTests.swift
+++ b/Firestore/Swift/Tests/Codable/FirestoreEncoderTests.swift
@@ -594,7 +594,7 @@ private class EncodableSubject<X: Equatable & Encodable> {
     do {
       _ = try Firestore.Encoder().encode(subject)
       XCTFail("Failed to throw", file: file, line: line)
-    } catch FirestoreEncodingError.encodingIsNotSupported {
+    } catch EncodingError.invalidValue(_, _) {
       return
     } catch {
       XCTFail("Unrecognized error: \(error)", file: file, line: line)

--- a/Firestore/Swift/Tests/Codable/FirestoreEncoderTests.swift
+++ b/Firestore/Swift/Tests/Codable/FirestoreEncoderTests.swift
@@ -19,49 +19,6 @@ import FirebaseFirestore
 import FirebaseFirestoreSwift
 import XCTest
 
-private func assertRoundTrip<X: Equatable & Codable>(model: X, encoded: [String: Any]) -> Void {
-  let enc = assertEncodes(model, to: encoded)
-  assertDecodes(enc, to: model)
-}
-
-private func assertEncodes<X: Equatable & Codable>(_ model: X, to expected: [String: Any]) -> [String: Any] {
-  do {
-    let enc = try Firestore.Encoder().encode(model)
-    XCTAssertEqual(enc as NSDictionary, expected as NSDictionary)
-    return enc
-  } catch {
-    XCTFail("Failed to encode \(X.self): error: \(error)")
-  }
-  return ["": -1]
-}
-
-private func assertDecodes<X: Equatable & Codable>(_ model: [String: Any], to expected: X) -> Void {
-  do {
-    let decoded = try Firestore.Decoder().decode(X.self, from: model)
-    XCTAssertEqual(decoded, expected)
-  } catch {
-    XCTFail("Failed to decode \(X.self): \(error)")
-  }
-}
-
-private func assertEncodingThrows<X: Equatable & Codable>(_ model: X) -> Void {
-  do {
-    _ = try Firestore.Encoder().encode(model)
-  } catch {
-    return
-  }
-  XCTFail("Failed to throw")
-}
-
-private func assertDecodingThrows<X: Equatable & Codable>(_ model: [String: Any], encoded: X) -> Void {
-  do {
-    _ = try Firestore.Decoder().decode(X.self, from: model)
-  } catch {
-    return
-  }
-  XCTFail("Failed to throw")
-}
-
 class FirestoreEncoderTests: XCTestCase {
   func testInt() {
     struct Model: Codable, Equatable {
@@ -69,21 +26,19 @@ class FirestoreEncoderTests: XCTestCase {
     }
     let model = Model(x: 42)
     let dict = ["x": 42]
-    assertRoundTrip(model: model, encoded: dict)
+    assertThat(model).roundTrips(to: dict)
   }
 
   func testEmpty() {
     struct Model: Codable, Equatable {}
-    _ = assertEncodes(Model(), to: [String: Any]())
+    assertThat(Model()).roundTrips(to: [String: Any]())
   }
 
-  func testString() {
+  func testString() throws {
     struct Model: Codable, Equatable {
       let s: String
     }
-    let model = Model(s: "abc")
-    let encodedDict = try! Firestore.Encoder().encode(model)
-    XCTAssertEqual(encodedDict["s"] as! String, "abc")
+    assertThat(Model(s: "abc")).roundTrips(to: ["s": "abc"])
   }
 
   func testOptional() {
@@ -91,13 +46,13 @@ class FirestoreEncoderTests: XCTestCase {
       let x: Int
       let opt: Int?
     }
-    assertRoundTrip(model: Model(x: 42, opt: nil), encoded: ["x": 42])
-    assertRoundTrip(model: Model(x: 42, opt: 7), encoded: ["x": 42, "opt": 7])
-    assertDecodes(["x": 42, "opt": 5], to: Model(x: 42, opt: 5))
-    assertDecodingThrows(["x": 42, "opt": true], encoded: Model(x: 42, opt: nil))
-    assertDecodingThrows(["x": 42, "opt": "abc"], encoded: Model(x: 42, opt: nil))
-    assertDecodingThrows(["x": 45.55, "opt": 5], encoded: Model(x: 42, opt: nil))
-    assertDecodingThrows(["opt": 5], encoded: Model(x: 42, opt: nil))
+    assertThat(Model(x: 42, opt: nil)).roundTrips(to: ["x": 42])
+    assertThat(Model(x: 42, opt: 7)).roundTrips(to: ["x": 42, "opt": 7])
+    assertThat(["x": 42, "opt": 5]).decodes(to: Model(x: 42, opt: 5))
+    assertThat(["x": 42, "opt": true]).failsDecoding(to: Model.self)
+    assertThat(["x": 42, "opt": "abc"]).failsDecoding(to: Model.self)
+    assertThat(["x": 45.55, "opt": 5]).failsDecoding(to: Model.self)
+    assertThat(["opt": 5]).failsDecoding(to: Model.self)
 
     // TODO: - handle encoding keys with nil values
     // See https://stackoverflow.com/questions/47266862/encode-nil-value-as-null-with-jsonencoder
@@ -155,13 +110,15 @@ class FirestoreEncoderTests: XCTestCase {
       let e: MyEnum
     }
 
-    let model = Model(x: 42, e: MyEnum.num(number: 4))
-    assertRoundTrip(model: model, encoded: ["x": 42, "e": ["num": 4]])
-    let model2 = Model(x: 43, e: MyEnum.text("abc"))
-    assertRoundTrip(model: model2, encoded: ["x": 43, "e": ["text": "abc"]])
+    assertThat(Model(x: 42, e: MyEnum.num(number: 4)))
+      .roundTrips(to: ["x": 42, "e": ["num": 4]])
+
+    assertThat(Model(x: 43, e: MyEnum.text("abc")))
+      .roundTrips(to: ["x": 43, "e": ["text": "abc"]])
+
     let timestamp = Timestamp(date: Date())
-    let model3 = Model(x: 43, e: MyEnum.timestamp(timestamp))
-    assertRoundTrip(model: model3, encoded: ["x": 43, "e": ["timestamp": timestamp]])
+    assertThat(Model(x: 43, e: MyEnum.timestamp(timestamp)))
+      .roundTrips(to: ["x": 43, "e": ["timestamp": timestamp]])
   }
 
   func testGeoPoint() {
@@ -169,8 +126,7 @@ class FirestoreEncoderTests: XCTestCase {
       let p: GeoPoint
     }
     let geopoint = GeoPoint(latitude: 1, longitude: -2)
-    let model = Model(p: geopoint)
-    assertRoundTrip(model: model, encoded: ["p": geopoint])
+    assertThat(Model(p: geopoint)).roundTrips(to: ["p": geopoint])
   }
 
   func testDate() {
@@ -178,8 +134,7 @@ class FirestoreEncoderTests: XCTestCase {
       let date: Date
     }
     let date = Date(timeIntervalSinceReferenceDate: 0)
-    let model = Model(date: date)
-    assertRoundTrip(model: model, encoded: ["date": date])
+    assertThat(Model(date: date)).roundTrips(to: ["date": date])
   }
 
   func testTimestampCanDecodeAsDate() {
@@ -189,12 +144,12 @@ class FirestoreEncoderTests: XCTestCase {
     struct DecodingModel: Codable, Equatable {
       let date: Date
     }
+
     let date = Date(timeIntervalSinceReferenceDate: 0)
     let timestamp = Timestamp(date: date)
-    let model = EncodingModel(date: timestamp)
-    let decoded = DecodingModel(date: date)
-    let encoded = assertEncodes(model, to: ["date": timestamp])
-    assertDecodes(encoded, to: decoded)
+    assertThat(EncodingModel(date: timestamp))
+      .encodes(to: ["date": timestamp])
+      .decodes(to: DecodingModel(date: date))
   }
 
   func testDocumentReference() {
@@ -202,32 +157,15 @@ class FirestoreEncoderTests: XCTestCase {
       let doc: DocumentReference
     }
     let d = FSTTestDocRef("abc/xyz")
-    let model = Model(doc: d)
-    assertRoundTrip(model: model, encoded: ["doc": d])
+    assertThat(Model(doc: d)).roundTrips(to: ["doc": d])
   }
 
   func testEncodingDocumentReferenceThrowsWithJSONEncoder() {
-    let doc = FSTTestDocRef("abc/xyz")
-    do {
-      _ = try JSONEncoder().encode(doc)
-      XCTFail("Failed to throw")
-    } catch FirebaseFirestoreSwift.FirestoreEncodingError.encodingIsNotSupported {
-      return
-    } catch {
-      XCTFail("Unrecognized error: \(error)")
-    }
+    assertThat(FSTTestDocRef("abc/xyz")).failsEncodingWithJSONEncoder()
   }
 
   func testEncodingDocumentReferenceNotEmbeddedThrows() {
-    let doc = FSTTestDocRef("abc/xyz")
-    do {
-      _ = try Firestore.Encoder().encode(doc)
-      XCTFail("Failed to throw")
-    } catch FirebaseFirestoreSwift.FirestoreEncodingError.encodingIsNotSupported {
-      return
-    } catch {
-      XCTFail("Unrecognized error: \(error)")
-    }
+    assertThat(FSTTestDocRef("abc/xyz")).failsEncodingAtTopLevel()
   }
 
   func testTimestamp() {
@@ -235,27 +173,22 @@ class FirestoreEncoderTests: XCTestCase {
       let timestamp: Timestamp
     }
     let t = Timestamp(date: Date())
-    let model = Model(timestamp: t)
-    assertRoundTrip(model: model, encoded: ["timestamp": t])
+    assertThat(Model(timestamp: t)).roundTrips(to: ["timestamp": t])
   }
 
   func testBadValue() {
     struct Model: Codable, Equatable {
       let x: Int
     }
-    let dict = ["x": "abc"] // Wrong type;
-    let model = Model(x: 42)
-    assertDecodingThrows(dict, encoded: model)
+    assertThat(["x": "abc"]).failsDecoding(to: Model.self) // Wrong type
   }
 
   func testValueTooBig() {
     struct Model: Codable, Equatable {
       let x: CChar
     }
-    let dict = ["x": 12345] // Overflow
-    let model = Model(x: 42)
-    assertDecodingThrows(dict, encoded: model)
-    assertRoundTrip(model: model, encoded: ["x": 42])
+    assertThat(Model(x: 42)).roundTrips(to: ["x": 42])
+    assertThat(["x": 12345]).failsDecoding(to: Model.self) // Overflow
   }
 
   // Inspired by https://github.com/firebase/firebase-android-sdk/blob/master/firebase-firestore/src/test/java/com/google/firebase/firestore/util/MapperTest.java
@@ -309,59 +242,26 @@ class FirestoreEncoderTests: XCTestCase {
       "casESensitivE": "ccc",
     ] as [String: Any]
 
-    assertRoundTrip(model: model, encoded: dict)
+    assertThat(model).roundTrips(to: dict)
   }
 
-  func testCodingKeysCanCustomizeEncodingAndDecoding() {
+  func testCodingKeysCanCustomizeEncodingAndDecoding() throws {
     struct Model: Codable, Equatable {
       var s: String
-      var ms: String
+      var ms: String = "filler"
       var d: Double
-      var md: Double
+      var md: Double = 42.42
 
       // Use CodingKeys to only encode part of the struct.
       enum CodingKeys: String, CodingKey {
         case s
         case d
       }
-
-      public init(from decoder: Decoder) throws {
-        let values = try decoder.container(keyedBy: CodingKeys.self)
-        s = try values.decode(String.self, forKey: .s)
-        d = try values.decode(Double.self, forKey: .d)
-        ms = "filler"
-        md = 42.42
-      }
-
-      public init(ins: String, inms: String, ind: Double, inmd: Double) {
-        s = ins
-        d = ind
-        ms = inms
-        md = inmd
-      }
     }
-    let model = Model(
-      ins: "abc",
-      inms: "dummy",
-      ind: 123.3,
-      inmd: 0
-    )
-    let dict = [
-      "s": "abc",
-      "d": 123.3,
-    ] as [String: Any]
 
-    let model2 = try! Firestore.Decoder().decode(Model.self, from: dict)
-    XCTAssertEqual(model.s, model2.s)
-    XCTAssertEqual(model.d, model2.d)
-    XCTAssertEqual(model2.ms, "filler")
-    XCTAssertEqual(model2.md, 42.42)
-
-    let encodedDict = try! Firestore.Encoder().encode(model)
-    XCTAssertEqual(encodedDict["s"] as! String, "abc")
-    XCTAssertEqual(encodedDict["d"] as! Double, 123.3)
-    XCTAssertNil(encodedDict["ms"])
-    XCTAssertNil(encodedDict["md"])
+    assertThat(Model(s: "abc", ms: "dummy", d: 123.3, md: 0))
+      .encodes(to: ["s": "abc", "d": 123.3])
+      .decodes(to: Model(s: "abc", ms: "filler", d: 123.3, md: 42.42))
   }
 
   func testNestedObjects() {
@@ -380,35 +280,51 @@ class FirestoreEncoderTests: XCTestCase {
       var group: NestedModel
     }
 
-    let model = Model(id: 123, group: NestedModel(group: "g1", groupList: [SecondLevelNestedModel(age: 20, weight: 80.1), SecondLevelNestedModel(age: 25, weight: 85.1)], groupMap: ["name1": SecondLevelNestedModel(age: 30, weight: 64.2), "name2": SecondLevelNestedModel(age: 35, weight: 79.2)],
-                                                  point: GeoPoint(latitude: 12.0, longitude: 9.1)))
-
-    let dict = ["group": [
-      "group": "g1",
-      "point": GeoPoint(latitude: 12.0, longitude: 9.1),
-      "groupList": [
-        [
-          "age": 20,
-          "weight": 80.1,
+    let model = Model(
+      id: 123,
+      group: NestedModel(
+        group: "g1",
+        groupList: [
+          SecondLevelNestedModel(age: 20, weight: 80.1),
+          SecondLevelNestedModel(age: 25, weight: 85.1),
         ],
-        [
-          "age": 25,
-          "weight": 85.1,
+        groupMap: [
+          "name1": SecondLevelNestedModel(age: 30, weight: 64.2),
+          "name2": SecondLevelNestedModel(age: 35, weight: 79.2),
+        ],
+        point: GeoPoint(latitude: 12.0, longitude: 9.1)
+      )
+    )
+
+    let dict = [
+      "group": [
+        "group": "g1",
+        "point": GeoPoint(latitude: 12.0, longitude: 9.1),
+        "groupList": [
+          [
+            "age": 20,
+            "weight": 80.1,
+          ],
+          [
+            "age": 25,
+            "weight": 85.1,
+          ],
+        ],
+        "groupMap": [
+          "name1": [
+            "age": 30,
+            "weight": 64.2,
+          ],
+          "name2": [
+            "age": 35,
+            "weight": 79.2,
+          ],
         ],
       ],
-      "groupMap": [
-        "name1": [
-          "age": 30,
-          "weight": 64.2,
-        ],
-        "name2": [
-          "age": 35,
-          "weight": 79.2,
-        ],
-      ],
-    ], "id": 123] as [String: Any]
+      "id": 123,
+    ] as [String: Any]
 
-    assertRoundTrip(model: model, encoded: dict)
+    assertThat(model).roundTrips(to: dict)
   }
 
   func testCollapsingNestedObjects() {
@@ -447,11 +363,11 @@ class FirestoreEncoderTests: XCTestCase {
       }
     }
 
-    let model = Model(id: 12345, name: "ModelName")
-    let dict = ["id": 12345,
-                "nested": ["name": "ModelName"]] as [String: Any]
-
-    assertRoundTrip(model: model, encoded: dict)
+    assertThat(Model(id: 12345, name: "ModelName"))
+      .roundTrips(to: [
+        "id": 12345,
+        "nested": ["name": "ModelName"],
+      ])
   }
 
   class SuperModel: Codable, Equatable {
@@ -515,70 +431,51 @@ class FirestoreEncoderTests: XCTestCase {
   }
 
   func testClassHierarchy() {
-    let model = SubModel(power: 100, name: "name", seconds: 123_456_789, nano: 654_321)
-    let dict = ["super": ["superPower": 100, "superName": "name"],
-                "timestamp": Timestamp(seconds: 123_456_789, nanoseconds: 654_321)] as [String: Any]
-
-    assertRoundTrip(model: model, encoded: dict)
+    assertThat(SubModel(power: 100, name: "name", seconds: 123_456_789, nano: 654_321))
+      .roundTrips(to: [
+        "super": ["superPower": 100, "superName": "name"],
+        "timestamp": Timestamp(seconds: 123_456_789, nanoseconds: 654_321),
+      ])
   }
 
   func testEncodingEncodableArrayNotSupported() {
     struct Model: Codable, Equatable {
       var name: String
     }
-    assertEncodingThrows([Model(name: "1")])
+    assertThat([Model(name: "1")]).failsToEncode()
   }
 
-  func testFieldValuePassthrough() {
+  func testFieldValuePassthrough() throws {
     struct Model: Encodable, Equatable {
       var fieldValue: FieldValue
     }
-
-    let model = Model(fieldValue: FieldValue.delete())
-    let dict = ["fieldValue": FieldValue.delete()]
-
-    let encoded = try! Firestore.Encoder().encode(model)
-
-    XCTAssertEqual(dict, encoded as! [String: FieldValue])
+    assertThat(Model(fieldValue: FieldValue.delete()))
+      .encodes(to: ["fieldValue": FieldValue.delete()])
   }
 
   func testEncodingFieldValueNotEmbeddedThrows() {
     let ts = FieldValue.serverTimestamp()
-    do {
-      _ = try Firestore.Encoder().encode(ts)
-      XCTFail("Failed to throw")
-    } catch FirebaseFirestoreSwift.FirestoreEncodingError.encodingIsNotSupported {
-      return
-    } catch {
-      XCTFail("Unrecognized error: \(error)")
-    }
+    assertThat(ts).failsEncodingAtTopLevel()
   }
 
-  func testServerTimestamp() {
-    struct Model: Codable {
+  func testServerTimestamp() throws {
+    struct Model: Codable, Equatable {
       var timestamp: ServerTimestamp
     }
 
-    // Encoding `pending`
-    var encoded = try! Firestore.Encoder().encode(Model(timestamp: .pending))
-    XCTAssertEqual(encoded["timestamp"] as! FieldValue, FieldValue.serverTimestamp())
+    // Encoding a pending server timestamp
+    assertThat(Model(timestamp: .pending))
+      .encodes(to: ["timestamp": FieldValue.serverTimestamp()])
 
-    // Encoding `resolved`
-    encoded = try! Firestore.Encoder().encode(Model(timestamp: .resolved(Timestamp(seconds: 123_456_789, nanoseconds: 4321))))
-    XCTAssertEqual(encoded["timestamp"] as! Timestamp,
-                   Timestamp(seconds: 123_456_789, nanoseconds: 4321))
+    // Encoding a resolved server timestamp yields a timestamp; decoding yields
+    // it back.
+    let timestamp = Timestamp(seconds: 123_456_789, nanoseconds: 4321)
+    assertThat(Model(timestamp: .resolved(timestamp)))
+      .roundTrips(to: ["timestamp": timestamp])
 
-    // Decoding a Timestamp leads to `resolved`
-    var dict = ["timestamp": Timestamp(seconds: 123_456_789, nanoseconds: 4321)] as [String: Any]
-    var decoded = try! Firestore.Decoder().decode(Model.self, from: dict)
-    XCTAssertEqual(decoded.timestamp,
-                   ServerTimestamp.resolved(Timestamp(seconds: 123_456_789, nanoseconds: 4321)))
-
-    // Decoding a NSNull() leads to `pending`.
-    dict = ["timestamp": NSNull()] as [String: Any]
-    decoded = try! Firestore.Decoder().decode(Model.self, from: dict)
-    XCTAssertEqual(decoded.timestamp,
-                   ServerTimestamp.pending)
+    // Decoding a NSNull() leads to nil.
+    assertThat(["timestamp": NSNull()])
+      .decodes(to: Model(timestamp: .pending))
   }
 
   func testExplicitNull() throws {
@@ -586,24 +483,11 @@ class FirestoreEncoderTests: XCTestCase {
       var name: ExplicitNull<String>
     }
 
-    // Encoding 'none'
-    let fieldIsNull = Model(name: .none)
-    var encoded = try Firestore.Encoder().encode(fieldIsNull)
-    XCTAssertTrue(encoded.keys.contains("name"))
-    XCTAssertEqual(encoded["name"]! as! NSNull, NSNull())
+    assertThat(Model(name: .none))
+      .roundTrips(to: ["name": NSNull()])
 
-    // Decoding null
-    var decoded = try Firestore.Decoder().decode(Model.self, from: encoded)
-    XCTAssertEqual(decoded, fieldIsNull)
-
-    // Encoding 'some'
-    let fieldIsNotNull = Model(name: .some("good name"))
-    encoded = try Firestore.Encoder().encode(fieldIsNotNull)
-    XCTAssertEqual(encoded["name"]! as! String, "good name")
-
-    // Decoding not-null value
-    decoded = try Firestore.Decoder().decode(Model.self, from: encoded)
-    XCTAssertEqual(decoded, fieldIsNotNull)
+    assertThat(Model(name: .some("good name")))
+      .roundTrips(to: ["name": "good name"])
   }
 
   func testAutomaticallyPopulatesSelfDocumentIDField() throws {
@@ -611,9 +495,8 @@ class FirestoreEncoderTests: XCTestCase {
       var name: String
       var docId: SelfDocumentID
     }
-
-    let decoded = try Firestore.Decoder().decode(Model.self, from: ["name": "abc"], in: FSTTestDocRef("abc/123"))
-    XCTAssertEqual(decoded, Model(name: "abc", docId: SelfDocumentID(from: FSTTestDocRef("abc/123"))))
+    assertThat(["name": "abc"], in: "abc/123")
+      .decodes(to: Model(name: "abc", docId: SelfDocumentID(from: FSTTestDocRef("abc/123"))))
   }
 
   func testSelfDocumentIDIgnoredInEncoding() throws {
@@ -621,33 +504,18 @@ class FirestoreEncoderTests: XCTestCase {
       var name: String
       var docId: SelfDocumentID
     }
-
-    let model = Model(name: "abc", docId: SelfDocumentID(from: FSTTestDocRef("abc/123")))
-    _ = assertEncodes(model, to: ["name": "abc"])
+    assertThat(Model(name: "abc", docId: SelfDocumentID(from: FSTTestDocRef("abc/123"))))
+      .encodes(to: ["name": "abc"])
   }
 
   func testEncodingSelfDocumentIDNotEmbeddedThrows() {
-    let doc = SelfDocumentID(from: FSTTestDocRef("abc/xyz"))
-    do {
-      _ = try Firestore.Encoder().encode(doc)
-      XCTFail("Failed to throw")
-    } catch FirestoreEncodingError.encodingIsNotSupported {
-      return
-    } catch {
-      XCTFail("Unrecognized error: \(error)")
-    }
+    assertThat(SelfDocumentID(from: FSTTestDocRef("abc/xyz")))
+      .failsEncodingAtTopLevel()
   }
 
   func testSelfDocumentIDWithJsonEncoderThrows() {
-    let doc = SelfDocumentID(from: FSTTestDocRef("abc/xyz"))
-    do {
-      _ = try JSONEncoder().encode(doc)
-      XCTFail("Failed to throw")
-    } catch FirestoreEncodingError.encodingIsNotSupported {
-      return
-    } catch {
-      XCTFail("Unrecognized error: \(error)")
-    }
+    assertThat(SelfDocumentID(from: FSTTestDocRef("abc/xyz")))
+      .failsEncodingWithJSONEncoder()
   }
 
   func testDecodingSelfDocumentIDWithConfictingFieldsThrows() throws {
@@ -664,10 +532,119 @@ class FirestoreEncoderTests: XCTestCase {
       )
       XCTFail("Failed to throw")
     } catch let FirestoreDecodingError.fieldNameConfict(msg) {
-      XCTAssertEqual(msg, "Field name [\"docId\"] was found from document \"abc/123\"," + " cannot assign the document reference to this field.")
+      XCTAssertEqual(msg, "Field name [\"docId\"] was found from document \"abc/123\", "
+        + "cannot assign the document reference to this field.")
       return
     } catch {
       XCTFail("Unrecognized error: \(error)")
     }
+  }
+}
+
+private func assertThat(_ dictionary: [String: Any], in document: String? = nil, file: StaticString = #file, line: UInt = #line) -> DictionarySubject {
+  return DictionarySubject(dictionary, in: document, file: file, line: line)
+}
+
+private func assertThat<X: Equatable & Codable>(_ model: X, file: StaticString = #file, line: UInt = #line) -> CodableSubject<X> {
+  return CodableSubject(model, file: file, line: line)
+}
+
+private func assertThat<X: Equatable & Encodable>(_ model: X, file: StaticString = #file, line: UInt = #line) -> EncodableSubject<X> {
+  return EncodableSubject(model, file: file, line: line)
+}
+
+private class EncodableSubject<X: Equatable & Encodable> {
+  var subject: X
+  var file: StaticString
+  var line: UInt
+
+  init(_ subject: X, file: StaticString, line: UInt) {
+    self.subject = subject
+    self.file = file
+    self.line = line
+  }
+
+  @discardableResult
+  func encodes(to expected: [String: Any]) -> DictionarySubject {
+    let encoded = assertEncodes(to: expected)
+    return DictionarySubject(encoded, file: file, line: line)
+  }
+
+  func failsToEncode() {
+    do {
+      _ = try Firestore.Encoder().encode(subject)
+    } catch {
+      return
+    }
+    XCTFail("Failed to throw")
+  }
+
+  func failsEncodingWithJSONEncoder() {
+    do {
+      _ = try JSONEncoder().encode(subject)
+      XCTFail("Failed to throw", file: file, line: line)
+    } catch FirestoreEncodingError.encodingIsNotSupported {
+      return
+    } catch {
+      XCTFail("Unrecognized error: \(error)", file: file, line: line)
+    }
+  }
+
+  func failsEncodingAtTopLevel() {
+    do {
+      _ = try Firestore.Encoder().encode(subject)
+      XCTFail("Failed to throw", file: file, line: line)
+    } catch FirestoreEncodingError.encodingIsNotSupported {
+      return
+    } catch {
+      XCTFail("Unrecognized error: \(error)", file: file, line: line)
+    }
+  }
+
+  private func assertEncodes(to expected: [String: Any]) -> [String: Any] {
+    do {
+      let enc = try Firestore.Encoder().encode(subject)
+      XCTAssertEqual(enc as NSDictionary, expected as NSDictionary, file: file, line: line)
+      return enc
+    } catch {
+      XCTFail("Failed to encode \(X.self): error: \(error)")
+      return ["": -1]
+    }
+  }
+}
+
+private class CodableSubject<X: Equatable & Codable>: EncodableSubject<X> {
+  func roundTrips(to expected: [String: Any]) {
+    let reverseSubject = encodes(to: expected)
+    reverseSubject.decodes(to: subject)
+  }
+}
+
+private class DictionarySubject {
+  var subject: [String: Any]
+  var document: DocumentReference?
+  var file: StaticString
+  var line: UInt
+
+  init(_ subject: [String: Any], in documentName: String? = nil, file: StaticString, line: UInt) {
+    self.subject = subject
+    if let documentName = documentName {
+      document = FSTTestDocRef(documentName)
+    }
+    self.file = file
+    self.line = line
+  }
+
+  func decodes<X: Equatable & Codable>(to expected: X) -> Void {
+    do {
+      let decoded = try Firestore.Decoder().decode(X.self, from: subject, in: document)
+      XCTAssertEqual(decoded, expected)
+    } catch {
+      XCTFail("Failed to decode \(X.self): \(error)", file: file, line: line)
+    }
+  }
+
+  func failsDecoding<X: Equatable & Codable>(to _: X.Type) -> Void {
+    XCTAssertThrowsError(try Firestore.Decoder().decode(X.self, from: subject), file: file, line: line)
   }
 }

--- a/Firestore/third_party/FirestoreEncoder/FirestoreEncoder.swift
+++ b/Firestore/third_party/FirestoreEncoder/FirestoreEncoder.swift
@@ -41,7 +41,8 @@ extension Firestore {
       guard T.self != SelfDocumentID.self,
         T.self != DocumentReference.self,
         T.self != FieldValue.self else {
-        throw FirestoreEncodingError.encodingIsNotSupported
+        throw EncodingError.invalidValue(value, EncodingError.Context(codingPath: [], debugDescription: "Top-level \(T.self) is not allowed."))
+
       }
       guard let topLevel = try _FirestoreEncoder().box_(value) else {
         throw EncodingError.invalidValue(value,


### PR DESCRIPTION
Also rewrite the FirestoreEncoderTests using a more concise set of
assertions.