### PR TITLE
Fix Catalyst define checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -329,7 +329,6 @@ jobs:
         - travis_wait 45 ./scripts/pod_lib_lint.rb FirebaseFirestore.podspec --use-libraries --allow-warnings --no-subspecs
 
     - stage: test
-      osx_image: xcode10.3
       env:
         - PROJECT=GoogleDataTransport METHOD=pod-lib-lint
       script:

--- a/Example/InstanceID/Tests/FIRInstanceIDKeyPairMigrationTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDKeyPairMigrationTest.m
@@ -155,7 +155,6 @@ NSString *FIRInstanceIDPrivateTagWithSubtype(NSString *subtype);
 #endif
 }
 
-#if (TARGET_OS_IOS || TARGET_OS_TV) && !defined(TARGET_OS_MACCATALYST)
 - (void)testUpdateKeyRefWithTagRetainsAndReleasesKeyRef {
   __weak id weakKeyRef;
 
@@ -200,6 +199,6 @@ NSString *FIRInstanceIDPrivateTagWithSubtype(NSString *subtype);
 
   return publicKey;
 }
-#endif  // (TARGET_OS_IOS || TARGET_OS_TV) && !defined(TARGET_OS_MACCATALYST)
+#endif  // (TARGET_OS_IOS || TARGET_OS_TV) && !TARGET_OS_MACCATALYST
 
 @end

--- a/Example/InstanceID/Tests/FIRInstanceIDKeyPairMigrationTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDKeyPairMigrationTest.m
@@ -155,6 +155,7 @@ NSString *FIRInstanceIDPrivateTagWithSubtype(NSString *subtype);
 #endif
 }
 
+#if (TARGET_OS_IOS || TARGET_OS_TV) && !TARGET_OS_MACCATALYST
 - (void)testUpdateKeyRefWithTagRetainsAndReleasesKeyRef {
   __weak id weakKeyRef;
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORStorage.m
@@ -126,7 +126,7 @@ static NSString *GDTCORStoragePath() {
                                                              error:&error];
         [data writeToFile:[GDTCORStorage archivePath] atomically:YES];
       } else {
-#if !defined(TARGET_OS_MACCATALYST)
+#if !TARGET_OS_MACCATALYST
         [NSKeyedArchiver archiveRootObject:self toFile:[GDTCORStorage archivePath]];
 #endif
       }
@@ -222,7 +222,7 @@ static NSString *GDTCORStoragePath() {
     NSData *data = [NSData dataWithContentsOfFile:[GDTCORStorage archivePath]];
     [NSKeyedUnarchiver unarchivedObjectOfClass:[GDTCORStorage class] fromData:data error:&error];
   } else {
-#if !defined(TARGET_OS_MACCATALYST)
+#if !TARGET_OS_MACCATALYST
     [NSKeyedUnarchiver unarchiveObjectWithFile:[GDTCORStorage archivePath]];
 #endif
   }
@@ -238,7 +238,7 @@ static NSString *GDTCORStoragePath() {
                                                            error:&error];
       [data writeToFile:[GDTCORStorage archivePath] atomically:YES];
     } else {
-#if !defined(TARGET_OS_MACCATALYST)
+#if !TARGET_OS_MACCATALYST
       [NSKeyedArchiver archiveRootObject:self toFile:[GDTCORStorage archivePath]];
 #endif
     }
@@ -267,7 +267,7 @@ static NSString *GDTCORStoragePath() {
                                                          error:&error];
     [data writeToFile:[GDTCORStorage archivePath] atomically:YES];
   } else {
-#if !defined(TARGET_OS_MACCATALYST)
+#if !TARGET_OS_MACCATALYST
     [NSKeyedArchiver archiveRootObject:self toFile:[GDTCORStorage archivePath]];
 #endif
   }

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORClockTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORClockTest.m
@@ -60,7 +60,7 @@
                                                         fromData:clockData
                                                            error:nil];
   } else {
-#if !defined(TARGET_OS_MACCATALYST)
+#if !TARGET_OS_MACCATALYST
     NSData *clockData = [NSKeyedArchiver archivedDataWithRootObject:clock];
     unarchivedClock = [NSKeyedUnarchiver unarchiveObjectWithData:clockData];
 #endif

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCOREventTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCOREventTest.m
@@ -49,7 +49,7 @@
                                         requiringSecureCoding:YES
                                                         error:nil];
   } else {
-#if !defined(TARGET_OS_MACCATALYST)
+#if !TARGET_OS_MACCATALYST
     archiveData = [NSKeyedArchiver archivedDataWithRootObject:event];
 #endif
   }
@@ -61,7 +61,7 @@
                                                      fromData:archiveData
                                                         error:nil];
   } else {
-#if !defined(TARGET_OS_MACCATALYST)
+#if !TARGET_OS_MACCATALYST
     decodedEvent = [NSKeyedUnarchiver unarchiveObjectWithData:archiveData];
 #endif
   }

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORStorageTest.m
@@ -271,7 +271,7 @@ static NSInteger target = kGDTCORTargetCCT;
                                           requiringSecureCoding:YES
                                                           error:nil];
     } else {
-#if !defined(TARGET_OS_MACCATALYST)
+#if !TARGET_OS_MACCATALYST
       storageData = [NSKeyedArchiver archivedDataWithRootObject:[GDTCORStorage sharedInstance]];
 #endif
     }
@@ -290,7 +290,7 @@ static NSInteger target = kGDTCORTargetCCT;
                                                           fromData:storageData
                                                              error:&error];
   } else {
-#if !defined(TARGET_OS_MACCATALYST)
+#if !TARGET_OS_MACCATALYST
     unarchivedStorage = [NSKeyedUnarchiver unarchiveObjectWithData:storageData];
 #endif
   }
@@ -311,7 +311,7 @@ static NSInteger target = kGDTCORTargetCCT;
                                           requiringSecureCoding:YES
                                                           error:nil];
     } else {
-#if !defined(TARGET_OS_MACCATALYST)
+#if !TARGET_OS_MACCATALYST
       storageData = [NSKeyedArchiver archivedDataWithRootObject:[GDTCORStorage sharedInstance]];
 #endif
     }
@@ -329,7 +329,7 @@ static NSInteger target = kGDTCORTargetCCT;
                                                           fromData:storageData
                                                              error:nil];
   } else {
-#if !defined(TARGET_OS_MACCATALYST)
+#if !TARGET_OS_MACCATALYST
     unarchivedStorage = [NSKeyedUnarchiver unarchiveObjectWithData:storageData];
 #endif
   }

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORUploadPackageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORUploadPackageTest.m
@@ -124,7 +124,7 @@
                                                             error:&error];
     XCTAssertNil(error);
   } else {
-#if !defined(TARGET_OS_MACCATALYST)
+#if !TARGET_OS_MACCATALYST
     NSData *packageData = [NSKeyedArchiver archivedDataWithRootObject:uploadPackage];
     recreatedPackage = [NSKeyedUnarchiver unarchiveObjectWithData:packageData];
 #endif

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -93,7 +93,6 @@ function RunXcodebuild() {
 
 # Remove each product when it moves up to Xcode 11
 if [[ $product == 'Firestore' || # #3949
-      $product == 'GoogleDataTransport' || # #3947
       $product == 'InAppMessaging' # #3948
    ]]; then
   ios_flags=(


### PR DESCRIPTION
Fix #3947 

TARGET_OS_MACCATALYST is always defined in Xcode 11. It's just 0 for iOS builds. This bug was causing GDT to build incorrectly on Xcode 11 for ios versions 10 and under.