### PR TITLE
Make FIRDocumentChange a closed enum

### DIFF
--- a/Firestore/Source/Public/FIRDocumentChange.h
+++ b/Firestore/Source/Public/FIRDocumentChange.h
@@ -21,7 +21,12 @@ NS_ASSUME_NONNULL_BEGIN
 @class FIRQueryDocumentSnapshot;
 
 /** An enumeration of document change types. */
-typedef NS_ENUM(NSInteger, FIRDocumentChangeType) {
+#if defined(NS_CLOSED_ENUM)
+typedef NS_CLOSED_ENUM(NSInteger, FIRDocumentChangeType)
+#else
+typedef NS_ENUM(NSInteger, FIRDocumentChangeType)
+#endif
+{
   /** Indicates a new document was added to the set of documents matching the query. */
   FIRDocumentChangeTypeAdded,
   /** Indicates a document within the query was modified. */


### PR DESCRIPTION
As of Swift 5, the Swift compiler now distinguishes between [frozen and non-frozen enums](https://github.com/apple/swift-evolution/blob/master/proposals/0192-non-exhaustive-enums.md), and issues warnings if you don't handle possible future cases for non-frozen enums.

Making `DocumentChangeType` a frozen enum allows developers to avoid adding `@unknown default` this to all usages like this:

```swift
switch change.type {
case .added:
  print("New document: \(change.document.data())")
case .modified:
  print("Modified document: \(change.document.data())")
case .removed:
  print("Removed document: \(change.document.data())")
@unknown default:
  fatalError()
}
```

We haven't seen this previously because the Swift 5 compiler running in Swift 4 mode does not emit the warning. I tried upgrading the project to Swift 5 just to see what happened and this was showing as a warning in our `BasicCompileTests`.

From what I can tell none of our other enums should be frozen.