### PR TITLE
Add the ability to define an initialization priority when registering a library

### DIFF
--- a/Example/Core/Tests/FIRAppInitializationPriorityTests.m
+++ b/Example/Core/Tests/FIRAppInitializationPriorityTests.m
@@ -1,0 +1,118 @@
+// Copyright 2019 Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <XCTest/XCTest.h>
+#import "FIRTestCase.h"
+#import "FIRTestComponents.h"
+#import <FirebaseCore/FIRAppInternal.h>
+
+
+#pragma mark - Base class (FIRTestClassForInitiationPriority)
+
+/// A test class that is used for the initiation priority test cases.
+@interface FIRTestClassForInitiationPriority: FIRTestClass
+
++ (NSArray<Class<FIRLibrary>> *)initializationOrder;
+
+@end
+
+@implementation FIRTestClassForInitiationPriority
+
+static NSMutableArray<Class<FIRLibrary>> *_initializationOrder;
+
++ (NSArray<Class<FIRLibrary>> *)initializationOrder {
+    return _initializationOrder;
+}
+
++ (void)configureWithApp:(nonnull FIRApp *)app {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      _initializationOrder = [[NSMutableArray alloc] init];
+    });
+    
+    [_initializationOrder addObject:[self class]];
+}
+
+@end
+
+#pragma mark - Subclasses needed for tests
+
+@interface FIRTestClassForInitiationPriorityUrgent: FIRTestClassForInitiationPriority
+@end
+
+@implementation FIRTestClassForInitiationPriorityUrgent
+@end
+
+@interface FIRTestClassForInitiationPriorityHigh: FIRTestClassForInitiationPriority
+@end
+
+@implementation FIRTestClassForInitiationPriorityHigh
+@end
+
+@interface FIRTestClassForInitiationPriorityNormal: FIRTestClassForInitiationPriority
+@end
+
+@implementation FIRTestClassForInitiationPriorityNormal
+@end
+
+@interface FIRTestClassForInitiationPriorityNormal2: FIRTestClassForInitiationPriority
+@end
+
+@implementation FIRTestClassForInitiationPriorityNormal2
+@end
+
+@interface FIRTestClassForInitiationPriorityLow: FIRTestClassForInitiationPriority
+@end
+
+@implementation FIRTestClassForInitiationPriorityLow
+@end
+
+#pragma mark - Tests
+
+/** @class FIRAppInitializationPriorityTests
+    @brief Tests for @c FIRAppInitializationPriorityTests
+ */
+@interface FIRAppInitializationPriorityTests : XCTestCase
+@end
+
+@implementation FIRAppInitializationPriorityTests
+
+- (void)testRegisterLibraryHonorsInitializationPriority {
+    Class urgentClass = [FIRTestClassForInitiationPriorityUrgent class];
+    [FIRApp registerInternalLibrary:urgentClass withName:@"UrgentClass" withVersion:@"1.0.0" withPriority:FIRInitializationPriorityUrgent];
+    
+    Class lowClass = [FIRTestClassForInitiationPriorityLow class];
+    [FIRApp registerInternalLibrary:lowClass withName:@"LowClass" withVersion:@"1.0.0" withPriority:FIRInitializationPriorityLow];
+    
+  Class normalClass = [FIRTestClassForInitiationPriorityNormal class];
+  [FIRApp registerInternalLibrary:normalClass withName:@"NormalClass" withVersion:@"1.0.0" withPriority:FIRInitializationPriorityNormal];
+    
+    Class highClass = [FIRTestClassForInitiationPriorityHigh class];
+    [FIRApp registerInternalLibrary:highClass withName:@"HighClass" withVersion:@"1.0.0" withPriority:FIRInitializationPriorityHigh];
+    
+    Class normalClass2 = [FIRTestClassForInitiationPriorityNormal2 class];
+    [FIRApp registerInternalLibrary:normalClass2 withName:@"NormalClass2" withVersion:@"1.0.0" withPriority:FIRInitializationPriorityNormal];
+    
+  [FIRApp configure];
+    
+    NSArray<Class<FIRLibrary>> *ordering = FIRTestClassForInitiationPriority.initializationOrder;
+    XCTAssertEqual(ordering.count, 5);
+    XCTAssertEqual(ordering[0], urgentClass);
+    XCTAssertEqual(ordering[1], highClass);
+    XCTAssertEqual(ordering[2], normalClass);
+    XCTAssertEqual(ordering[3], normalClass2);
+    XCTAssertEqual(ordering[4], lowClass);
+}
+
+@end

--- a/Example/Core/Tests/FIRAppInitializationPriorityTests.m
+++ b/Example/Core/Tests/FIRAppInitializationPriorityTests.m
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <FirebaseCore/FIRAppInternal.h>
 #import <XCTest/XCTest.h>
 #import "FIRTestCase.h"
 #import "FIRTestComponents.h"
-#import <FirebaseCore/FIRAppInternal.h>
-
 
 #pragma mark - Base class (FIRTestClassForInitiationPriority)
 
 /// A test class that is used for the initiation priority test cases.
-@interface FIRTestClassForInitiationPriority: FIRTestClass
+@interface FIRTestClassForInitiationPriority : FIRTestClass
 
 + (NSArray<Class<FIRLibrary>> *)initializationOrder;
 
@@ -32,47 +31,47 @@
 static NSMutableArray<Class<FIRLibrary>> *_initializationOrder;
 
 + (NSArray<Class<FIRLibrary>> *)initializationOrder {
-    return _initializationOrder;
+  return _initializationOrder;
 }
 
 + (void)configureWithApp:(nonnull FIRApp *)app {
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-      _initializationOrder = [[NSMutableArray alloc] init];
-    });
-    
-    [_initializationOrder addObject:[self class]];
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    _initializationOrder = [[NSMutableArray alloc] init];
+  });
+
+  [_initializationOrder addObject:[self class]];
 }
 
 @end
 
 #pragma mark - Subclasses needed for tests
 
-@interface FIRTestClassForInitiationPriorityUrgent: FIRTestClassForInitiationPriority
+@interface FIRTestClassForInitiationPriorityUrgent : FIRTestClassForInitiationPriority
 @end
 
 @implementation FIRTestClassForInitiationPriorityUrgent
 @end
 
-@interface FIRTestClassForInitiationPriorityHigh: FIRTestClassForInitiationPriority
+@interface FIRTestClassForInitiationPriorityHigh : FIRTestClassForInitiationPriority
 @end
 
 @implementation FIRTestClassForInitiationPriorityHigh
 @end
 
-@interface FIRTestClassForInitiationPriorityNormal: FIRTestClassForInitiationPriority
+@interface FIRTestClassForInitiationPriorityNormal : FIRTestClassForInitiationPriority
 @end
 
 @implementation FIRTestClassForInitiationPriorityNormal
 @end
 
-@interface FIRTestClassForInitiationPriorityNormal2: FIRTestClassForInitiationPriority
+@interface FIRTestClassForInitiationPriorityNormal2 : FIRTestClassForInitiationPriority
 @end
 
 @implementation FIRTestClassForInitiationPriorityNormal2
 @end
 
-@interface FIRTestClassForInitiationPriorityLow: FIRTestClassForInitiationPriority
+@interface FIRTestClassForInitiationPriorityLow : FIRTestClassForInitiationPriority
 @end
 
 @implementation FIRTestClassForInitiationPriorityLow
@@ -89,30 +88,45 @@ static NSMutableArray<Class<FIRLibrary>> *_initializationOrder;
 @implementation FIRAppInitializationPriorityTests
 
 - (void)testRegisterLibraryHonorsInitializationPriority {
-    Class urgentClass = [FIRTestClassForInitiationPriorityUrgent class];
-    [FIRApp registerInternalLibrary:urgentClass withName:@"UrgentClass" withVersion:@"1.0.0" withPriority:FIRInitializationPriorityUrgent];
-    
-    Class lowClass = [FIRTestClassForInitiationPriorityLow class];
-    [FIRApp registerInternalLibrary:lowClass withName:@"LowClass" withVersion:@"1.0.0" withPriority:FIRInitializationPriorityLow];
-    
+  Class urgentClass = [FIRTestClassForInitiationPriorityUrgent class];
+  [FIRApp registerInternalLibrary:urgentClass
+                         withName:@"UrgentClass"
+                      withVersion:@"1.0.0"
+                     withPriority:FIRInitializationPriorityUrgent];
+
+  Class lowClass = [FIRTestClassForInitiationPriorityLow class];
+  [FIRApp registerInternalLibrary:lowClass
+                         withName:@"LowClass"
+                      withVersion:@"1.0.0"
+                     withPriority:FIRInitializationPriorityLow];
+
   Class normalClass = [FIRTestClassForInitiationPriorityNormal class];
-  [FIRApp registerInternalLibrary:normalClass withName:@"NormalClass" withVersion:@"1.0.0" withPriority:FIRInitializationPriorityNormal];
-    
-    Class highClass = [FIRTestClassForInitiationPriorityHigh class];
-    [FIRApp registerInternalLibrary:highClass withName:@"HighClass" withVersion:@"1.0.0" withPriority:FIRInitializationPriorityHigh];
-    
-    Class normalClass2 = [FIRTestClassForInitiationPriorityNormal2 class];
-    [FIRApp registerInternalLibrary:normalClass2 withName:@"NormalClass2" withVersion:@"1.0.0" withPriority:FIRInitializationPriorityNormal];
-    
+  [FIRApp registerInternalLibrary:normalClass
+                         withName:@"NormalClass"
+                      withVersion:@"1.0.0"
+                     withPriority:FIRInitializationPriorityNormal];
+
+  Class highClass = [FIRTestClassForInitiationPriorityHigh class];
+  [FIRApp registerInternalLibrary:highClass
+                         withName:@"HighClass"
+                      withVersion:@"1.0.0"
+                     withPriority:FIRInitializationPriorityHigh];
+
+  Class normalClass2 = [FIRTestClassForInitiationPriorityNormal2 class];
+  [FIRApp registerInternalLibrary:normalClass2
+                         withName:@"NormalClass2"
+                      withVersion:@"1.0.0"
+                     withPriority:FIRInitializationPriorityNormal];
+
   [FIRApp configure];
-    
-    NSArray<Class<FIRLibrary>> *ordering = FIRTestClassForInitiationPriority.initializationOrder;
-    XCTAssertEqual(ordering.count, 5);
-    XCTAssertEqual(ordering[0], urgentClass);
-    XCTAssertEqual(ordering[1], highClass);
-    XCTAssertEqual(ordering[2], normalClass);
-    XCTAssertEqual(ordering[3], normalClass2);
-    XCTAssertEqual(ordering[4], lowClass);
+
+  NSArray<Class<FIRLibrary>> *ordering = FIRTestClassForInitiationPriority.initializationOrder;
+  XCTAssertEqual(ordering.count, 5);
+  XCTAssertEqual(ordering[0], urgentClass);
+  XCTAssertEqual(ordering[1], highClass);
+  XCTAssertEqual(ordering[2], normalClass);
+  XCTAssertEqual(ordering[3], normalClass2);
+  XCTAssertEqual(ordering[4], lowClass);
 }
 
 @end

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -86,8 +86,8 @@ NSString *const FIRAuthStateDidChangeInternalNotificationUIDKey =
 
 // Internal class used to associate an initialization priority to a library
 @interface FIRLibraryRegistration : NSObject
-@property (nonatomic, strong) Class<FIRLibrary> library;
-@property (nonatomic, assign) FIRInitializationPriority priority;
+@property(nonatomic, strong) Class<FIRLibrary> library;
+@property(nonatomic, assign) FIRInitializationPriority priority;
 
 - (id)initWithLibrary:(Class<FIRLibrary>)library withPriority:(FIRInitializationPriority)priority;
 
@@ -441,14 +441,15 @@ static NSMutableDictionary *sLibraryVersions;
   // This is the new way of sending information to SDKs.
   // TODO: Do we want this on a background thread, maybe?
   @synchronized(self) {
-    NSArray<FIRLibraryRegistration *> *sortedRegistration;
-    sortedRegistration = [sRegisteredAsConfigurable sortedArrayUsingComparator:^NSComparisonResult(FIRLibraryRegistration *a, FIRLibraryRegistration *b) {
-      NSNumber *firstPriority = [[NSNumber alloc] initWithLong:a.priority];
-      NSNumber *secondPriority = [[NSNumber alloc] initWithLong:b.priority];
-      return [firstPriority compare: secondPriority];
-    }];
+    NSArray<FIRLibraryRegistration *> *sortedRegistrations =
+        [sRegisteredAsConfigurable sortedArrayUsingComparator:^NSComparisonResult(
+                                       FIRLibraryRegistration *a, FIRLibraryRegistration *b) {
+          NSNumber *firstPriority = [[NSNumber alloc] initWithLong:a.priority];
+          NSNumber *secondPriority = [[NSNumber alloc] initWithLong:b.priority];
+          return [firstPriority compare:secondPriority];
+        }];
 
-    for (FIRLibraryRegistration *registration in sortedRegistration) {
+    for (FIRLibraryRegistration *registration in sortedRegistrations) {
       [registration.library configureWithApp:app];
     }
   }
@@ -517,11 +518,14 @@ static NSMutableDictionary *sLibraryVersions;
 }
 
 + (void)registerInternalLibrary:(nonnull Class<FIRLibrary>)library
-    withName:(nonnull NSString *)name
- withVersion:(nonnull NSString *)version {
-  [FIRApp registerInternalLibrary:library withName:name withVersion:version withPriority:FIRInitializationPriorityNormal];
+                       withName:(nonnull NSString *)name
+                    withVersion:(nonnull NSString *)version {
+  [FIRApp registerInternalLibrary:library
+                         withName:name
+                      withVersion:version
+                     withPriority:FIRInitializationPriorityNormal];
 }
-    
+
 + (void)registerInternalLibrary:(nonnull Class<FIRLibrary>)library
                        withName:(nonnull NSString *)name
                     withVersion:(nonnull NSString *)version
@@ -544,9 +548,8 @@ static NSMutableDictionary *sLibraryVersions;
       sRegisteredAsConfigurable = [[NSMutableArray alloc] init];
     });
     @synchronized(self) {
-      [sRegisteredAsConfigurable addObject:
-        [[FIRLibraryRegistration alloc] initWithLibrary:library
-                                           withPriority:priority]];
+      [sRegisteredAsConfigurable
+          addObject:[[FIRLibraryRegistration alloc] initWithLibrary:library withPriority:priority]];
     }
   }
   [self registerLibrary:name withVersion:version];

--- a/Firebase/Core/Private/FIRAppInternal.h
+++ b/Firebase/Core/Private/FIRAppInternal.h
@@ -141,18 +141,18 @@ extern NSString *const FIRAuthStateDidChangeInternalNotificationUIDKey;
                     withVersion:(nonnull NSString *)version;
 
 /**
-* Registers a given internal library with the given version number to be reported for
-* analytics.
-*
-* @param library Optional parameter for component registration.
-* @param name Name of the library.
-* @param version Version of the library.
-* @param priority Initialization priority of the library.
-*/
+ * Registers a given internal library with the given version number to be reported for
+ * analytics.
+ *
+ * @param library Optional parameter for component registration.
+ * @param name Name of the library.
+ * @param version Version of the library.
+ * @param priority Initialization priority of the library.
+ */
 + (void)registerInternalLibrary:(nonnull Class<FIRLibrary>)library
-   withName:(nonnull NSString *)name
-withVersion:(nonnull NSString *)version
-                   withPriority:(FIRInitializationPriority) priority;
+                       withName:(nonnull NSString *)name
+                    withVersion:(nonnull NSString *)version
+                   withPriority:(FIRInitializationPriority)priority;
 
 /**
  * A concatenated string representing all the third-party libraries and version numbers.

--- a/Firebase/Core/Private/FIRAppInternal.h
+++ b/Firebase/Core/Private/FIRAppInternal.h
@@ -34,6 +34,13 @@ typedef NS_ENUM(NSInteger, FIRConfigType) {
   FIRConfigTypeSDK = 2,
 };
 
+typedef NS_ENUM(NSUInteger, FIRInitializationPriority) {
+  FIRInitializationPriorityUrgent = 1,
+  FIRInitializationPriorityHigh = 2,
+  FIRInitializationPriorityNormal = 3,
+  FIRInitializationPriorityLow = 4,
+};
+
 extern NSString *const kFIRDefaultAppName;
 extern NSString *const kFIRAppReadyToConfigureSDKNotification;
 extern NSString *const kFIRAppDeleteNotification;
@@ -132,6 +139,20 @@ extern NSString *const FIRAuthStateDidChangeInternalNotificationUIDKey;
 + (void)registerInternalLibrary:(nonnull Class<FIRLibrary>)library
                        withName:(nonnull NSString *)name
                     withVersion:(nonnull NSString *)version;
+
+/**
+* Registers a given internal library with the given version number to be reported for
+* analytics.
+*
+* @param library Optional parameter for component registration.
+* @param name Name of the library.
+* @param version Version of the library.
+* @param priority Initialization priority of the library.
+*/
++ (void)registerInternalLibrary:(nonnull Class<FIRLibrary>)library
+   withName:(nonnull NSString *)name
+withVersion:(nonnull NSString *)version
+                   withPriority:(FIRInitializationPriority) priority;
 
 /**
  * A concatenated string representing all the third-party libraries and version numbers.


### PR DESCRIPTION
There are useful cases where it will be good to define some ordering to the initialization of registered Firebase libraries. 

An example is to have Crashlytics startup before other Firebase SDKs (not implemented yet) so it can collect crashes from other SDK's initializations as well as just being able to collect crashes earlier in app initialization.