### PR TITLE
Fix CMake build with Clang 10

### DIFF
--- a/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
+++ b/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
@@ -426,26 +426,30 @@ TEST_F(SerializerTest, EncodesDoubles) {
   static_assert(std::numeric_limits<double>::is_iec559,
                 "IEC559/IEEE764 floating point required");
 
-  std::vector<double> cases{-std::numeric_limits<double>::infinity(),
-                            std::numeric_limits<double>::lowest(),
-                            std::numeric_limits<int64_t>::min() - 1.0,
-                            -2.0,
-                            -1.1,
-                            -1.0,
-                            -std::numeric_limits<double>::epsilon(),
-                            -std::numeric_limits<double>::min(),
-                            -std::numeric_limits<double>::denorm_min(),
-                            -0.0,
-                            0.0,
-                            std::numeric_limits<double>::denorm_min(),
-                            std::numeric_limits<double>::min(),
-                            std::numeric_limits<double>::epsilon(),
-                            1.0,
-                            1.1,
-                            2.0,
-                            std::numeric_limits<int64_t>::max() + 1.0,
-                            std::numeric_limits<double>::max(),
-                            std::numeric_limits<double>::infinity()};
+  std::vector<double> cases{
+      -std::numeric_limits<double>::infinity(),
+      std::numeric_limits<double>::lowest(),
+      std::numeric_limits<int64_t>::min() - 1.0,
+      -2.0,
+      -1.1,
+      -1.0,
+      -std::numeric_limits<double>::epsilon(),
+      -std::numeric_limits<double>::min(),
+      -std::numeric_limits<double>::denorm_min(),
+      -0.0,
+      0.0,
+      std::numeric_limits<double>::denorm_min(),
+      std::numeric_limits<double>::min(),
+      std::numeric_limits<double>::epsilon(),
+      1.0,
+      1.1,
+      2.0,
+      // Static cast silences warning about the conversion changing the value.
+      static_cast<double>(std::numeric_limits<int64_t>::max()) - 1.0,
+      static_cast<double>(std::numeric_limits<int64_t>::max()),
+      static_cast<double>(std::numeric_limits<int64_t>::max()) + 1.0,
+      std::numeric_limits<double>::max(),
+      std::numeric_limits<double>::infinity()};
 
   for (double double_value : cases) {
     FieldValue model = FieldValue::FromDouble(double_value);

--- a/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
+++ b/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
@@ -449,7 +449,8 @@ TEST_F(SerializerTest, EncodesDoubles) {
       static_cast<double>(std::numeric_limits<int64_t>::max()),
       static_cast<double>(std::numeric_limits<int64_t>::max()) + 1.0,
       std::numeric_limits<double>::max(),
-      std::numeric_limits<double>::infinity()};
+      std::numeric_limits<double>::infinity(),
+  };
 
   for (double double_value : cases) {
     FieldValue model = FieldValue::FromDouble(double_value);

--- a/cmake/external/boringssl.cmake
+++ b/cmake/external/boringssl.cmake
@@ -26,7 +26,7 @@ endif()
 # (2017-02-03). Unfortunately, that boringssl includes a conflicting gtest
 # target that makes it unsuitable for use via add_subdirectory.
 
-set(commit e0afc85719db9a0842bcfddcf4b15e856b253ee2)  # master@{2018-07-10}
+set(commit 9638f8fba961a593c064e3036bb580bdace29e8f)  # master@{2019-10-01}
 
 ExternalProject_Add(
   boringssl
@@ -36,7 +36,7 @@ ExternalProject_Add(
   DOWNLOAD_DIR ${FIREBASE_DOWNLOAD_DIR}
   DOWNLOAD_NAME boringssl-${commit}.tar.gz
   URL https://github.com/google/boringssl/archive/${commit}.tar.gz
-  URL_HASH SHA256=2aa66e912651d2256ab266b712a2647c22e7e9347a09544e684732a599a194a8
+  URL_HASH SHA256=cfd843fda9fdf9ea92b1ae5f5d379ec7d7cb09d5c7d41197ee935a0e30aecb23
 
   PREFIX ${PROJECT_BINARY_DIR}
   SOURCE_DIR ${PROJECT_BINARY_DIR}/src/grpc/third_party/boringssl


### PR DESCRIPTION
The as-of-yet-unreleased Clang 10 adds some new warnings which make the CMake build fail (due to `-Werror`):
* BoringSSL build now fails because some of its C code contains fallthroughs in switch statements that aren't properly annotated. This wasn't an issue before because previous versions of Clang ignored `-Wimplicit-fallthrough` in C mode;
* serializer test contains an expression that produces the following warning:
```
/src/firebase-ios-sdk/Firestore/core/test/firebase/firestore/remote/serializer_test.cc:446:29:
error: implicit conversion from 'std::__1::numeric_limits<long>::type' (aka 'long') to 'double'
changes value from 9223372036854775807 to 9223372036854775808 [-Werror,
-Wimplicit-int-float-conversion]
```

Fixes:
* upgrade the version of BoringSSL used to the latest master. There's no particular reason to choose this commit, other than it happens to be the latest. The actual fixes we need are [this](https://github.com/google/boringssl/commit/05cd93068b0a553afc48f69acbceae10c6a17593) and [this](https://github.com/google/boringssl/commit/fbebe833b180a1a0685803c59bba38916826dd2b);
* apply `static_cast` to the serializer test. Also, because the cast produces a different value, add a couple of additional values to test.

The breakage was discovered thanks to the fuzz build (which already uses Clang 10 from trunk).