### PR TITLE
Fix main thread crashing issue, reenable tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -570,4 +570,3 @@ jobs:
 branches:
   only:
     - master
-    - rw-gdt-background-mainthread

--- a/.travis.yml
+++ b/.travis.yml
@@ -570,3 +570,4 @@ jobs:
 branches:
   only:
     - master
+    - rw-gdt-background-mainthread

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -37,10 +37,12 @@ BOOL GDTCORReachabilityFlagsContainWWAN(SCNetworkReachabilityFlags flags) {
 #endif  // TARGET_OS_IOS
 }
 
-@interface GDTCORApplication () {
-  /** Private flag to match the existing `readonly` public flag. */
-  BOOL _isRunningInBackground;
-}
+@interface GDTCORApplication ()
+/**
+ Private flag to match the existing `readonly` public flag. This will be accurate for all platforms,
+ since we handle each platform's lifecycle notifications separately.
+ */
+@property(atomic, readwrite) BOOL isRunningInBackground;
 
 @end
 
@@ -133,12 +135,6 @@ BOOL GDTCORReachabilityFlagsContainWWAN(SCNetworkReachabilityFlags flags) {
 #elif TARGET_OS_OSX
   return NO;
 #endif
-}
-
-- (BOOL)isRunningInBackground {
-  // This will be accurate for all platforms, since we handle each platform's lifecycle
-  // notifications separately.
-  return _isRunningInBackground;
 }
 
 /** Returns a UIApplication instance if on the appropriate platform.

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
@@ -62,7 +62,7 @@ FOUNDATION_EXPORT const GDTCORBackgroundIdentifier GDTCORBackgroundIdentifierInv
 @interface GDTCORApplication : NSObject <GDTCORApplicationDelegate>
 
 /** Flag to determine if the application is running in the background. */
-@property(nonatomic, readonly) BOOL isRunningInBackground;
+@property(atomic, readonly) BOOL isRunningInBackground;
 
 /** Creates and/or returns the shared application instance.
  *

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
@@ -61,17 +61,14 @@ FOUNDATION_EXPORT const GDTCORBackgroundIdentifier GDTCORBackgroundIdentifierInv
 /** A cross-platform application class. */
 @interface GDTCORApplication : NSObject <GDTCORApplicationDelegate>
 
+/** Flag to determine if the application is running in the background. */
+@property(nonatomic, readonly) BOOL isRunningInBackground;
+
 /** Creates and/or returns the shared application instance.
  *
  * @return The shared application instance.
  */
 + (nullable GDTCORApplication *)sharedApplication;
-
-/** Flag to determine if the application is running in the background.
- *
- * @return YES if the app is running in the background, otherwise NO.
- */
-- (BOOL)isRunningInBackground;
 
 /** Creates a background task with the returned identifier if on a suitable platform.
  *

--- a/GoogleDataTransport/GDTCORTests/Lifecycle/GDTCORLifecycleTest.m
+++ b/GoogleDataTransport/GDTCORTests/Lifecycle/GDTCORLifecycleTest.m
@@ -90,8 +90,11 @@
   [[GDTCORUploadCoordinator sharedInstance] reset];
 }
 
+// Backgrounding and foregrounding are only applicable for iOS and tvOS.
+#if TARGET_OS_IOS || TARGET_OS_TV
+
 /** Tests that the library serializes itself to disk when the app backgrounds. */
-- (void)DISABLED_testBackgrounding {
+- (void)testBackgrounding {
   GDTCORTransport *transport = [[GDTCORTransport alloc] initWithMappingID:@"test"
                                                              transformers:nil
                                                                    target:kGDTCORTargetTest];
@@ -105,10 +108,8 @@
       },
       5.0);
 
-  // TODO(#3973): This notification no longer triggers the `isRunningInBackground` flag. Find
-  // another way to test it.
   NSNotificationCenter *notifCenter = [NSNotificationCenter defaultCenter];
-  [notifCenter postNotificationName:kGDTCORApplicationDidEnterBackgroundNotification object:nil];
+  [notifCenter postNotificationName:UIApplicationDidEnterBackgroundNotification object:nil];
   XCTAssertTrue([GDTCORApplication sharedApplication].isRunningInBackground);
 
   GDTCORWaitForBlock(
@@ -120,7 +121,7 @@
 }
 
 /** Tests that the library deserializes itself from disk when the app foregrounds. */
-- (void)DISABLED_testForegrounding {
+- (void)testForegrounding {
   GDTCORTransport *transport = [[GDTCORTransport alloc] initWithMappingID:@"test"
                                                              transformers:nil
                                                                    target:kGDTCORTargetTest];
@@ -134,10 +135,8 @@
       },
       5.0);
 
-  // TODO(#3973): This notification no longer triggers the `isRunningInBackground` flag. Find
-  // another way to test it.
   NSNotificationCenter *notifCenter = [NSNotificationCenter defaultCenter];
-  [notifCenter postNotificationName:kGDTCORApplicationDidEnterBackgroundNotification object:nil];
+  [notifCenter postNotificationName:UIApplicationDidEnterBackgroundNotification object:nil];
 
   GDTCORWaitForBlock(
       ^BOOL {
@@ -146,10 +145,8 @@
       },
       5.0);
 
-  // TODO(#3973): This notification no longer triggers the `isRunningInBackground` flag. Find
-  // another way to test it.
   [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
-  [notifCenter postNotificationName:kGDTCORApplicationWillEnterForegroundNotification object:nil];
+  [notifCenter postNotificationName:UIApplicationWillEnterForegroundNotification object:nil];
   XCTAssertFalse([GDTCORApplication sharedApplication].isRunningInBackground);
   GDTCORWaitForBlock(
       ^BOOL {
@@ -157,6 +154,7 @@
       },
       5.0);
 }
+#endif  // #if TARGET_OS_IOS || TARGET_OS_TV
 
 /** Tests that the library gracefully stops doing stuff when terminating. */
 - (void)testTermination {

--- a/GoogleDataTransportCCTSupport/GDTCCTTests/Integration/GDTCCTIntegrationTest.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTTests/Integration/GDTCCTIntegrationTest.m
@@ -157,7 +157,11 @@ typedef void (^GDTCCTIntegrationTestBlock)(NSURLSessionUploadTask *_Nullable);
                 }
 
                 eventsSent += eventsUploaded.integerValue;
-                if (eventsSent == self.totalEventsGenerated) {
+                NSLog(@"Single upload event of %ld, combined for %ld/%ld total expected.",
+                      (long)eventsUploaded.integerValue, (long)eventsSent,
+                      (long)self.totalEventsGenerated);
+                // Only fulfill the expectation once event generation is done and the numbers match.
+                if (self.generateEvents == NO && eventsSent == self.totalEventsGenerated) {
                   [eventCountsMatchExpectation fulfill];
                 }
               }];


### PR DESCRIPTION
Checking `applicationState` while not on the  main thread results in a crash. Revert to using notifications and a flag to track this, but with a single source of truth.

Fixes #3973.

