### PR TITLE
Delete unused commented asl tests

### DIFF
--- a/Example/Core/Tests/FIRLoggerTest.m
+++ b/Example/Core/Tests/FIRLoggerTest.m
@@ -178,46 +178,6 @@ static NSString *const kMessageCode = @"I-COR000001";
   XCTAssertNoThrow(FIRLogDebug(kFIRLoggerCore, kMessageCode, @"Configure %@.", @"blah"));
 }
 
-// asl_set_filter does not perform as expected in unit test environment with simulator. The
-// following test only checks whether the logs have been sent to system with the default settings in
-// the unit test environment.
-- (void)testSystemLogWithDefaultStatus {
-#if !(BUG128)  // Disable until https://github.com/firebase/firebase-ios-sdk/issues/128 is fixed
-  // Test fails on device and iOS 9 simulators - b/38130372
-  return;
-#else
-  // Sets the time interval that we need to wait in order to fetch all the logs.
-  NSTimeInterval timeInterval = 0.1f;
-  // Generates a random string each time and check whether it has been logged.
-  // Log messages with Notice level and below should be logged to system/device by default.
-  self.randomLogString = [NSUUID UUID].UUIDString;
-  FIRLogError(kFIRLoggerCore, kMessageCode, @"%@", self.randomLogString);
-  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:timeInterval]];
-  XCTAssertTrue([self logExists]);
-
-  self.randomLogString = [NSUUID UUID].UUIDString;
-  FIRLogWarning(kFIRLoggerCore, kMessageCode, @"%@", self.randomLogString);
-  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:timeInterval]];
-  XCTAssertTrue([self logExists]);
-
-  self.randomLogString = [NSUUID UUID].UUIDString;
-  FIRLogNotice(kFIRLoggerCore, kMessageCode, @"%@", self.randomLogString);
-  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:timeInterval]];
-  XCTAssertTrue([self logExists]);
-
-  // Log messages with Info level and above should NOT be logged to system/device by default.
-  self.randomLogString = [NSUUID UUID].UUIDString;
-  FIRLogInfo(kFIRLoggerCore, kMessageCode, @"%@", self.randomLogString);
-  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:timeInterval]];
-  XCTAssertFalse([self logExists]);
-
-  self.randomLogString = [NSUUID UUID].UUIDString;
-  FIRLogDebug(kFIRLoggerCore, kMessageCode, @"%@", self.randomLogString);
-  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:timeInterval]];
-  XCTAssertFalse([self logExists]);
-#endif
-}
-
 // The FIRLoggerLevel enum must match the ASL_LEVEL_* constants, but we manually redefine
 // them in FIRLoggerLevel.h since we cannot include <asl.h> (see b/34976089 for more details).
 // This test ensures the constants match.
@@ -227,44 +187,6 @@ static NSString *const kMessageCode = @"I-COR000001";
   XCTAssertEqual(FIRLoggerLevelNotice, ASL_LEVEL_NOTICE);
   XCTAssertEqual(FIRLoggerLevelInfo, ASL_LEVEL_INFO);
   XCTAssertEqual(FIRLoggerLevelDebug, ASL_LEVEL_DEBUG);
-}
-
-// Helper functions.
-- (BOOL)logExists {
-  [self drainFIRClientQueue];
-  NSString *correctMsg =
-      [NSString stringWithFormat:@"%@[%@] %@", kFIRLoggerCore, kMessageCode, self.randomLogString];
-  return [self messageWasLogged:correctMsg];
-}
-
-- (void)drainFIRClientQueue {
-  dispatch_semaphore_t workerSemaphore = dispatch_semaphore_create(0);
-  dispatch_async(getGULClientQueue(), ^{
-    dispatch_semaphore_signal(workerSemaphore);
-  });
-  dispatch_semaphore_wait(workerSemaphore, DISPATCH_TIME_FOREVER);
-}
-
-- (BOOL)messageWasLogged:(NSString *)message {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  aslmsg query = asl_new(ASL_TYPE_QUERY);
-  asl_set_query(query, ASL_KEY_FACILITY, kGULLoggerASLClientFacilityName, ASL_QUERY_OP_EQUAL);
-  aslresponse r = asl_search(getGULLoggerClient(), query);
-  asl_free(query);
-  aslmsg m;
-  const char *val;
-  NSMutableArray *allMsg = [[NSMutableArray alloc] init];
-  while ((m = asl_next(r)) != NULL) {
-    val = asl_get(m, ASL_KEY_MSG);
-    if (val) {
-      [allMsg addObject:[NSString stringWithUTF8String:val]];
-    }
-  }
-  asl_free(m);
-  asl_release(r);
-  return [allMsg containsObject:message];
-#pragma clang pop
 }
 
 @end

--- a/GoogleUtilities/Example/Tests/Logger/GULLoggerTest.m
+++ b/GoogleUtilities/Example/Tests/Logger/GULLoggerTest.m
@@ -102,45 +102,6 @@ static NSString *const kMessageCode = @"I-COR000001";
   XCTAssertNoThrow(GULLogDebug(@"my service", NO, kMessageCode, @"Configure %@.", @"blah"));
 }
 
-// asl_set_filter does not perform as expected in unit test environment with simulator. The
-// following test only checks whether the logs have been sent to system with the default settings in
-// the unit test environment.
-- (void)testSystemLogWithDefaultStatus {
-#if !(BUG128)  // Disable until https://github.com/firebase/firebase-ios-sdk/issues/128 is fixed
-  // Test fails on device and iOS 9 simulators - b/38130372
-  return;
-#else
-  // Sets the time interval that we need to wait in order to fetch all the logs.
-  NSTimeInterval timeInterval = 0.1f;
-  // Generates a random string each time and check whether it has been logged.
-  // Log messages with Notice level and below should be logged to system/device by default.
-  self.randomLogString = [NSUUID UUID].UUIDString;
-  GULLogError(@"my service", NO, kMessageCode, @"%@", self.randomLogString);
-  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:timeInterval]];
-  XCTAssertTrue([self logExists]);
-
-  self.randomLogString = [NSUUID UUID].UUIDString;
-  GULLogWarning(@"my service", kMessageCode, @"%@", self.randomLogString);
-  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:timeInterval]];
-  XCTAssertTrue([self logExists]);
-
-  self.randomLogString = [NSUUID UUID].UUIDString;
-  GULLogNotice(@"my service", kMessageCode, @"%@", self.randomLogString);
-  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:timeInterval]];
-  XCTAssertTrue([self logExists]);
-
-  // Log messages with Info level and above should NOT be logged to system/device by default.
-  self.randomLogString = [NSUUID UUID].UUIDString;
-  GULLogInfo(@"my service", kMessageCode, @"%@", self.randomLogString);
-  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:timeInterval]];
-  XCTAssertFalse([self logExists]);
-
-  self.randomLogString = [NSUUID UUID].UUIDString;
-  GULLogDebug(@"my service", kMessageCode, @"%@", self.randomLogString);
-  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:timeInterval]];
-  XCTAssertFalse([self logExists]);
-#endif
-}
 
 // The GULLoggerLevel enum must match the ASL_LEVEL_* constants, but we manually redefine
 // them in GULLoggerLevel.h since we cannot include <asl.h> (see b/34976089 for more details).
@@ -151,44 +112,6 @@ static NSString *const kMessageCode = @"I-COR000001";
   XCTAssertEqual(GULLoggerLevelNotice, ASL_LEVEL_NOTICE);
   XCTAssertEqual(GULLoggerLevelInfo, ASL_LEVEL_INFO);
   XCTAssertEqual(GULLoggerLevelDebug, ASL_LEVEL_DEBUG);
-}
-
-// Helper functions.
-- (BOOL)logExists {
-  [self drainGULClientQueue];
-  NSString *correctMsg =
-      [NSString stringWithFormat:@"%@[%@] %@", @"my service", kMessageCode, self.randomLogString];
-  return [self messageWasLogged:correctMsg];
-}
-
-- (void)drainGULClientQueue {
-  dispatch_semaphore_t workerSemaphore = dispatch_semaphore_create(0);
-  dispatch_async(getGULClientQueue(), ^{
-    dispatch_semaphore_signal(workerSemaphore);
-  });
-  dispatch_semaphore_wait(workerSemaphore, DISPATCH_TIME_FOREVER);
-}
-
-- (BOOL)messageWasLogged:(NSString *)message {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  aslmsg query = asl_new(ASL_TYPE_QUERY);
-  asl_set_query(query, ASL_KEY_FACILITY, kGULLoggerASLClientFacilityName, ASL_QUERY_OP_EQUAL);
-  aslresponse r = asl_search(getGULLoggerClient(), query);
-  asl_free(query);
-  aslmsg m;
-  const char *val;
-  NSMutableArray *allMsg = [[NSMutableArray alloc] init];
-  while ((m = asl_next(r)) != NULL) {
-    val = asl_get(m, ASL_KEY_MSG);
-    if (val) {
-      [allMsg addObject:[NSString stringWithUTF8String:val]];
-    }
-  }
-  asl_free(m);
-  asl_release(r);
-  return [allMsg containsObject:message];
-#pragma clang pop
 }
 
 @end

--- a/GoogleUtilities/Example/Tests/Logger/GULLoggerTest.m
+++ b/GoogleUtilities/Example/Tests/Logger/GULLoggerTest.m
@@ -102,7 +102,6 @@ static NSString *const kMessageCode = @"I-COR000001";
   XCTAssertNoThrow(GULLogDebug(@"my service", NO, kMessageCode, @"Configure %@.", @"blah"));
 }
 
-
 // The GULLoggerLevel enum must match the ASL_LEVEL_* constants, but we manually redefine
 // them in GULLoggerLevel.h since we cannot include <asl.h> (see b/34976089 for more details).
 // This test ensures the constants match.


### PR DESCRIPTION
These should be replaced when we fully migrate to os_log.

Close #128