### PR TITLE
Remove log argument that causes SocketRocket crash

### DIFF
--- a/Firebase/Database/CHANGELOG.md
+++ b/Firebase/Database/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [fixed] Fixed an iOS 13 crash that occured in our WebSocket error handling. (#3950)
 
 # v6.1.0
 - [fixed] Fix Catalyst Build issue. (#3512)

--- a/Firebase/Database/third_party/SocketRocket/FSRWebSocket.m
+++ b/Firebase/Database/third_party/SocketRocket/FSRWebSocket.m
@@ -1510,7 +1510,9 @@ static const size_t SRFrameHeaderOverhead = 32;
         }
 
         case NSStreamEventErrorOccurred: {
-            SRFastLog(@"NSStreamEventErrorOccurred %@ %@", aStream, [[aStream streamError] copy]);
+            // Note: The upstream code for SocketRocket logs the error message, but this causes
+            // crashes on iOS 13 (https://github.com/firebase/firebase-ios-sdk/issues/3950)
+            SRFastLog(@"NSStreamEventErrorOccurred %@", aStream);
             /// TODO specify error better!
                     [self _failWithError:aStream.streamError];
             _readBufferOffset = 0;


### PR DESCRIPTION
This PR modifies the log line that caused the crash in #3950.

There are probably better fixes, but this is safe and isolated. The upstream library seems to be unmaintained at this point. 

Fixes #3950