### PR TITLE
Add RemoteDocumentReadTimeKey to LevelDb

### DIFF
--- a/Firestore/core/src/firebase/firestore/local/leveldb_key.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_key.cc
@@ -46,6 +46,7 @@ const char* kTargetDocumentsTable = "target_document";
 const char* kDocumentTargetsTable = "document_target";
 const char* kRemoteDocumentsTable = "remote_document";
 const char* kCollectionParentsTable = "collection_parent";
+const char* kRemoteDocumentReadTimeTable = "remote_document_read_time";
 
 /**
  * Labels for the components of keys. These serve to make keys self-describing.
@@ -95,6 +96,9 @@ enum ComponentLabel {
    * collection_parent table, but not for collection IDs within paths).
    */
   CollectionId = 14,
+
+  /** A component containing a snapshot version. */
+  SnapshotVersion = 15,
 
   /**
    * A path segment describes just a single segment in a resource path. Path
@@ -169,6 +173,12 @@ class Reader {
   std::string ReadCollectionId() {
     return ReadLabeledString(ComponentLabel::CollectionId);
   }
+
+  /**
+   * Reads a snapshot version, encoded as a component label and a pair of seconds
+   * (int64) and nanoseconds (int32).
+   */
+  model::SnapshotVersion ReadSnapshotVersion();
 
   /**
    * Reads component labels and strings from the key until it finds a component
@@ -323,6 +333,26 @@ class Reader {
   }
 
   /**
+   * Reads a signed number from the key.
+   *
+   * If the read is unsuccessful, returns 0 and fails the Reader.
+   *
+   * Otherwise, returns the number and advances the Reader to the next unread
+   * byte.
+   */
+  int32_t ReadInt64() {
+    if (ok_) {
+      int64_t raw_result = ReadSignedNumIncreasing();
+      if (ok_) {
+        return raw_result;
+      }
+    }
+
+    Fail();
+    return 0;
+  }
+
+  /**
    * Reads a component label and a string from the key verifies that the label
    * matches the expected_label.
    *
@@ -408,6 +438,17 @@ DocumentKey Reader::ReadDocumentKey() {
   return DocumentKey{};
 }
 
+model::SnapshotVersion Reader::ReadSnapshotVersion() {
+  if (!ReadComponentLabelMatching(ComponentLabel::SnapshotVersion)) {
+    Fail();
+  }
+
+  int64_t seconds = ReadInt64();
+  int32_t nanos = ReadInt32();
+
+  return model::SnapshotVersion({seconds, nanos});
+}
+
 /**
  * Returns a base64-encoded string for an invalid key, used for debug-friendly
  * description text.
@@ -485,6 +526,12 @@ std::string Reader::Describe() {
         absl::StrAppend(&description, " collection_id=", collection_id);
       }
 
+    } else if (label == ComponentLabel::SnapshotVersion) {
+      model::SnapshotVersion snapshot_version = ReadSnapshotVersion();
+      if (ok_) {
+        absl::StrAppend(&description,
+                        " snapshot_version=", snapshot_version.ToString());
+      }
     } else {
       absl::StrAppend(&description, " unknown label=", static_cast<int>(label));
       Fail();
@@ -534,6 +581,14 @@ class Writer {
 
   void WriteCollectionId(absl::string_view collection_id) {
     WriteLabeledString(ComponentLabel::CollectionId, collection_id);
+  }
+
+  void WriteSnapshotVersion(model::SnapshotVersion snapshot_version) {
+    WriteComponentLabel(ComponentLabel::SnapshotVersion);
+    OrderedCode::WriteSignedNumIncreasing(
+        &dest_, snapshot_version.timestamp().seconds());
+    OrderedCode::WriteSignedNumIncreasing(
+        &dest_, snapshot_version.timestamp().nanoseconds());
   }
 
   /**
@@ -911,6 +966,26 @@ bool LevelDbCollectionParentKey::Decode(absl::string_view key) {
   reader.ReadTableNameMatching(kCollectionParentsTable);
   collection_id_ = reader.ReadCollectionId();
   parent_ = reader.ReadResourcePath();
+  reader.ReadTerminator();
+  return reader.ok();
+}
+
+std::string LevelDbRemoteDocumentReadTimeKey::Key(
+    const model::ResourcePath& collection_path,
+    model::SnapshotVersion read_time) {
+  Writer writer;
+  writer.WriteTableName(kRemoteDocumentReadTimeTable);
+  writer.WriteResourcePath(collection_path);
+  writer.WriteSnapshotVersion(read_time);
+  writer.WriteTerminator();
+  return writer.result();
+}
+
+bool LevelDbRemoteDocumentReadTimeKey::Decode(absl::string_view key) {
+  Reader reader{key};
+  reader.ReadTableNameMatching(kRemoteDocumentReadTimeTable);
+  collection_path_ = reader.ReadResourcePath();
+  read_time_ = reader.ReadSnapshotVersion();
   reader.ReadTerminator();
   return reader.ok();
 }

--- a/Firestore/core/src/firebase/firestore/local/leveldb_key.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_key.cc
@@ -350,16 +350,8 @@ class Reader {
    * Otherwise, returns the number and advances the Reader to the next unread
    * byte.
    */
-  int32_t ReadInt64() {
-    if (ok_) {
-      int64_t raw_result = ReadSignedNumIncreasing();
-      if (ok_) {
-        return raw_result;
-      }
-    }
-
-    Fail();
-    return 0;
+  int64_t ReadInt64() {
+    return ReadSignedNumIncreasing();
   }
 
   /**

--- a/Firestore/core/src/firebase/firestore/local/leveldb_key.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_key.h
@@ -88,6 +88,7 @@ namespace local {
 //   - table_name: string = "remote_document_read_time"
 //   - collection: ResourcePath
 //   - read_time: SnapshotVersion
+//   - document_id: string
 
 /**
  * Parses the given key and returns a human readable description of its

--- a/Firestore/core/src/firebase/firestore/local/leveldb_key.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_key.h
@@ -83,6 +83,11 @@ namespace local {
 //   - table_name: string = "collection_parent"
 //   - collectionId: string
 //   - parent: ResourcePath
+//
+// remote_document_read_time:
+//   - table_name: string = "remote_document_read_time"
+//   - collection: ResourcePath
+//   - read_time: SnapshotVersion
 
 /**
  * Parses the given key and returns a human readable description of its
@@ -575,6 +580,42 @@ class LevelDbCollectionParentKey {
   // Deliberately uninitialized: will be assigned in Decode
   std::string collection_id_;
   model::ResourcePath parent_;
+};
+
+/** A key in the remote documents read time table. */
+class LevelDbRemoteDocumentReadTimeKey {
+ public:
+
+  /**
+   * Creates a key prefix that points just before the first key for the given
+   * collection_path and read_time.
+   */
+  static std::string Key(const model::ResourcePath& collection_path,
+                         model::SnapshotVersion read_time);
+  /**
+   * Decodes the given complete key, storing the decoded values in this
+   * instance.
+   *
+   * @return true if the key successfully decoded, false otherwise. If false is
+   * returned, this instance is in an undefined state until the next call to
+   * `Decode()`.
+   */
+  ABSL_MUST_USE_RESULT
+  bool Decode(absl::string_view key);
+
+  /** The collection path for all corresponding entries. */
+  const model::ResourcePath& collection_path() const {
+    return collection_path_;
+  }
+
+  /** The read time for all corresponding entries. */
+  model::SnapshotVersion read_time() const {
+    return read_time_;
+  }
+
+ private:
+  model::ResourcePath collection_path_;
+  model::SnapshotVersion read_time_;
 };
 
 }  // namespace local

--- a/Firestore/core/src/firebase/firestore/local/leveldb_key.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_key.h
@@ -582,16 +582,26 @@ class LevelDbCollectionParentKey {
   model::ResourcePath parent_;
 };
 
-/** A key in the remote documents read time table. */
+/**
+ * A key in the remote documents read time table, storing the collection path,
+ * read time and document ID for each entry.
+ */
 class LevelDbRemoteDocumentReadTimeKey {
  public:
-
   /**
    * Creates a key prefix that points just before the first key for the given
    * collection_path and read_time.
    */
+  static std::string KeyPrefix(const model::ResourcePath& collection_path,
+                               model::SnapshotVersion read_time);
+
+  /**
+   * Creates a key that points to the key for the given collection_path,
+   * read_time and document_id.
+   */
   static std::string Key(const model::ResourcePath& collection_path,
-                         model::SnapshotVersion read_time);
+                         model::SnapshotVersion read_time,
+                         absl::string_view document_id);
   /**
    * Decodes the given complete key, storing the decoded values in this
    * instance.
@@ -603,17 +613,23 @@ class LevelDbRemoteDocumentReadTimeKey {
   ABSL_MUST_USE_RESULT
   bool Decode(absl::string_view key);
 
-  /** The collection path for all corresponding entries. */
+  /** The collection path for this entry. */
   const model::ResourcePath& collection_path() const {
     return collection_path_;
   }
 
-  /** The read time for all corresponding entries. */
+  /** The read time for for this entry. */
   model::SnapshotVersion read_time() const {
     return read_time_;
   }
 
+  /** The document ID for this entry. */
+  const std::string& document_id() const {
+    return document_id_;
+  }
+
  private:
+  std::string document_id_;
   model::ResourcePath collection_path_;
   model::SnapshotVersion read_time_;
 };

--- a/Firestore/core/test/firebase/firestore/local/leveldb_key_test.cc
+++ b/Firestore/core/test/firebase/firestore/local/leveldb_key_test.cc
@@ -401,9 +401,9 @@ TEST(RemoteDocumentReadTimeKeyTest, EncodeDecodeCycle) {
   std::vector<int64_t> versions{1, 1000000, 1000001};
   std::vector<std::string> document_ids{"docA", "docB"};
 
-  for (auto&& collection_path : collection_paths) {
+  for (const auto& collection_path : collection_paths) {
     for (auto version : versions) {
-      for (auto&& document_id : document_ids) {
+      for (const auto& document_id : document_ids) {
         auto encoded =
             RemoteDocumentReadTimeKey(collection_path, version, document_id);
         bool ok = key.Decode(encoded);


### PR DESCRIPTION
This PR adds encode/decode functionality to store keys for the RemoteDocumentReadTime index in LevelDB.

The proposed format of the entries is:

Key: Collection Path, Read Time
Value: List of Document Ids