### PR TITLE
Add SimpleQueryEngine

### DIFF
--- a/Firestore/core/src/firebase/firestore/local/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/local/CMakeLists.txt
@@ -93,10 +93,13 @@ cc_library(
     query_cache.h
     query_data.cc
     query_data.h
+    query_engine.h
     reference_delegate.h
     reference_set.cc
     reference_set.h
     remote_document_cache.h
+    simple_query_engine.cc
+    simple_query_engine.h
     sizer.h
   DEPENDS
     # TODO(b/111328563) Force nanopb first to work around ODR violations

--- a/Firestore/core/src/firebase/firestore/local/query_engine.h
+++ b/Firestore/core/src/firebase/firestore/local/query_engine.h
@@ -59,7 +59,7 @@ class QueryEngine {
   virtual model::DocumentMap GetDocumentsMatchingQuery(
       const core::Query& query,
       const model::SnapshotVersion& last_limbo_free_snapshot_version,
-      model::DocumentKeySet remote_keys) const = 0;
+      const model::DocumentKeySet& remote_keys) const = 0;
 };
 
 }  // namespace local

--- a/Firestore/core/src/firebase/firestore/local/query_engine.h
+++ b/Firestore/core/src/firebase/firestore/local/query_engine.h
@@ -17,32 +17,48 @@
 #ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_QUERY_ENGINE_H_
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_QUERY_ENGINE_H_
 
-#include "Firestore/core/src/firebase/firestore/core/query.h"
-#include "Firestore/core/src/firebase/firestore/local/local_documents_view.h"
 #include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
-#include "Firestore/core/src/firebase/firestore/model/document_map.h"
-#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 
 namespace firebase {
 namespace firestore {
+
+namespace model {
+
+class DocumentMap;
+class SnapshotVersion;
+
+}  // namespace model
+
+namespace core {
+
+class Query;
+
+}  // namespace core
+
 namespace local {
+
+class LocalDocumentsView;
 
 /**
  * Represents a query engine capable of performing queries over the local
- * document cache. You must call setLocalDocumentsView() before using.
+ * document cache. You must call `SetLocalDocumentsView()` before using.
  */
 class QueryEngine {
  public:
-  virtual ~QueryEngine() {
-  }
+  virtual ~QueryEngine() = default;
 
-  /** Sets the document view to query against. */
+  /**
+   * Sets the document view to query against.
+   *
+   * The caller owns the LocalDocumentView and must ensure that it outlives the
+   * QueryEngine.
+   */
   virtual void SetLocalDocumentsView(LocalDocumentsView* local_documents) = 0;
 
   /** Returns all local documents matching the specified query. */
   virtual model::DocumentMap GetDocumentsMatchingQuery(
-      core::Query query,
-      model::SnapshotVersion last_limbo_free_snapshot_version,
+      const core::Query& query,
+      const model::SnapshotVersion& last_limbo_free_snapshot_version,
       model::DocumentKeySet remote_keys) const = 0;
 };
 

--- a/Firestore/core/src/firebase/firestore/local/query_engine.h
+++ b/Firestore/core/src/firebase/firestore/local/query_engine.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_QUERY_ENGINE_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_QUERY_ENGINE_H_
+
+#include "Firestore/core/src/firebase/firestore/core/query.h"
+#include "Firestore/core/src/firebase/firestore/local/local_documents_view.h"
+#include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
+#include "Firestore/core/src/firebase/firestore/model/document_map.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
+
+namespace firebase {
+namespace firestore {
+namespace local {
+
+/**
+ * Represents a query engine capable of performing queries over the local
+ * document cache. You must call setLocalDocumentsView() before using.
+ */
+class QueryEngine {
+ public:
+  virtual ~QueryEngine() {
+  }
+
+  /** Sets the document view to query against. */
+  virtual void SetLocalDocumentsView(LocalDocumentsView* local_documents) = 0;
+
+  /** Returns all local documents matching the specified query. */
+  virtual model::DocumentMap GetDocumentsMatchingQuery(
+      core::Query query,
+      model::SnapshotVersion last_limbo_free_snapshot_version,
+      model::DocumentKeySet remote_keys) const = 0;
+};
+
+}  // namespace local
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_QUERY_ENGINE_H_

--- a/Firestore/core/src/firebase/firestore/local/simple_query_engine.cc
+++ b/Firestore/core/src/firebase/firestore/local/simple_query_engine.cc
@@ -16,13 +16,18 @@
 
 #include "Firestore/core/src/firebase/firestore/local/simple_query_engine.h"
 
+#include "Firestore/core/src/firebase/firestore/core/query.h"
+#include "Firestore/core/src/firebase/firestore/local/local_documents_view.h"
+#include "Firestore/core/src/firebase/firestore/model/document_map.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
+
 namespace firebase {
 namespace firestore {
 namespace local {
 
 model::DocumentMap SimpleQueryEngine::GetDocumentsMatchingQuery(
-    core::Query query,
-    model::SnapshotVersion last_limbo_free_snapshot_version,
+    const core::Query& query,
+    const model::SnapshotVersion& last_limbo_free_snapshot_version,
     model::DocumentKeySet remote_keys) const {
   HARD_ASSERT(local_documents_view_, "SetLocalDocumentsView() not called");
 

--- a/Firestore/core/src/firebase/firestore/local/simple_query_engine.cc
+++ b/Firestore/core/src/firebase/firestore/local/simple_query_engine.cc
@@ -28,7 +28,7 @@ namespace local {
 model::DocumentMap SimpleQueryEngine::GetDocumentsMatchingQuery(
     const core::Query& query,
     const model::SnapshotVersion& last_limbo_free_snapshot_version,
-    model::DocumentKeySet remote_keys) const {
+    const model::DocumentKeySet& remote_keys) const {
   HARD_ASSERT(local_documents_view_, "SetLocalDocumentsView() not called");
 
   return local_documents_view_->GetDocumentsMatchingQuery(query);

--- a/Firestore/core/src/firebase/firestore/local/simple_query_engine.cc
+++ b/Firestore/core/src/firebase/firestore/local/simple_query_engine.cc
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Firestore/core/src/firebase/firestore/local/simple_query_engine.h"
+
+namespace firebase {
+namespace firestore {
+namespace local {
+
+model::DocumentMap SimpleQueryEngine::GetDocumentsMatchingQuery(
+    core::Query query,
+    model::SnapshotVersion last_limbo_free_snapshot_version,
+    model::DocumentKeySet remote_keys) const {
+  HARD_ASSERT(local_documents_view_, "SetLocalDocumentsView() not called");
+
+  return local_documents_view_->GetDocumentsMatchingQuery(query);
+}
+
+}  // namespace local
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/core/src/firebase/firestore/local/simple_query_engine.h
+++ b/Firestore/core/src/firebase/firestore/local/simple_query_engine.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_SIMPLE_QUERY_ENGINE_H_
+#define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_SIMPLE_QUERY_ENGINE_H_
+
+#include "Firestore/core/src/firebase/firestore/core/query.h"
+#include "Firestore/core/src/firebase/firestore/local/local_documents_view.h"
+#include "Firestore/core/src/firebase/firestore/local/query_engine.h"
+#include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
+#include "Firestore/core/src/firebase/firestore/model/document_map.h"
+#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
+
+namespace firebase {
+namespace firestore {
+namespace local {
+
+class SimpleQueryEngine : public QueryEngine {
+ public:
+  void SetLocalDocumentsView(LocalDocumentsView* local_documents) override {
+    local_documents_view_ = local_documents;
+  }
+
+  model::DocumentMap GetDocumentsMatchingQuery(
+      core::Query query,
+      model::SnapshotVersion last_limbo_free_snapshot_version,
+      model::DocumentKeySet remote_keys) const override;
+
+ private:
+  LocalDocumentsView* local_documents_view_;
+};
+}  // namespace local
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_SIMPLE_QUERY_ENGINE_H_

--- a/Firestore/core/src/firebase/firestore/local/simple_query_engine.h
+++ b/Firestore/core/src/firebase/firestore/local/simple_query_engine.h
@@ -32,7 +32,7 @@ class SimpleQueryEngine : public QueryEngine {
   model::DocumentMap GetDocumentsMatchingQuery(
       const core::Query& query,
       const model::SnapshotVersion& last_limbo_free_snapshot_version,
-      model::DocumentKeySet remote_keys) const override;
+      const model::DocumentKeySet& remote_keys) const override;
 
  private:
   LocalDocumentsView* local_documents_view_;

--- a/Firestore/core/src/firebase/firestore/local/simple_query_engine.h
+++ b/Firestore/core/src/firebase/firestore/local/simple_query_engine.h
@@ -17,12 +17,7 @@
 #ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_SIMPLE_QUERY_ENGINE_H_
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_SIMPLE_QUERY_ENGINE_H_
 
-#include "Firestore/core/src/firebase/firestore/core/query.h"
-#include "Firestore/core/src/firebase/firestore/local/local_documents_view.h"
 #include "Firestore/core/src/firebase/firestore/local/query_engine.h"
-#include "Firestore/core/src/firebase/firestore/model/document_key_set.h"
-#include "Firestore/core/src/firebase/firestore/model/document_map.h"
-#include "Firestore/core/src/firebase/firestore/model/snapshot_version.h"
 
 namespace firebase {
 namespace firestore {
@@ -35,13 +30,14 @@ class SimpleQueryEngine : public QueryEngine {
   }
 
   model::DocumentMap GetDocumentsMatchingQuery(
-      core::Query query,
-      model::SnapshotVersion last_limbo_free_snapshot_version,
+      const core::Query& query,
+      const model::SnapshotVersion& last_limbo_free_snapshot_version,
       model::DocumentKeySet remote_keys) const override;
 
  private:
   LocalDocumentsView* local_documents_view_;
 };
+
 }  // namespace local
 }  // namespace firestore
 }  // namespace firebase


### PR DESCRIPTION
This PR just adds SimpleQueryEngine, but leaves it unused for now.

Port of https://github.com/firebase/firebase-js-sdk/blob/master/packages/firestore/src/local/simple_query_engine.ts and https://github.com/firebase/firebase-js-sdk/blob/master/packages/firestore/src/local/query_engine.ts