### PR TITLE
Build Firestore with Xcode 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -270,9 +270,6 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
-      # TODO(paulb777,wilhuff) Replace with a solution that doesn't include multiple platforms in
-      # a single Podfile.
-      osx_image: xcode10.1
       env:
         - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild
       before_install:
@@ -403,9 +400,6 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
 
     - stage: test
-      # TODO(paulb777,wilhuff) Replace with a solution that doesn't include multiple platforms in
-      # a single Podfile.
-      osx_image: xcode10.1
       env:
         - PROJECT=Firestore PLATFORM=macOS METHOD=xcodebuild
       before_install:
@@ -414,9 +408,6 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
-      # TODO(paulb777,wilhuff) Replace with a solution that doesn't include multiple platforms in
-      # a single Podfile.
-      osx_image: xcode10.1
       env:
         - PROJECT=Firestore PLATFORM=tvOS METHOD=xcodebuild
       before_install:
@@ -427,9 +418,6 @@ jobs:
     # Firestore sanitizers
 
     - stage:
-      # TODO(paulb777,wilhuff) Replace with a solution that doesn't include multiple platforms in
-      # a single Podfile.
-      osx_image: xcode10.1
       env:
         - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild SANITIZERS=asan
       before_install:
@@ -438,9 +426,6 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
 
     - stage: test
-      # TODO(paulb777,wilhuff) Replace with a solution that doesn't include multiple platforms in
-      # a single Podfile.
-      osx_image: xcode10.1
       env:
         - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild SANITIZERS=tsan
       before_install:

--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -1230,7 +1230,7 @@
 		2E48431B0EDA400BEA91D4AB /* Pods-Firestore_Tests_tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Tests_tvOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Tests_tvOS/Pods-Firestore_Tests_tvOS.debug.xcconfig"; sourceTree = "<group>"; };
 		2F901F31BC62444A476B779F /* Pods-Firestore_IntegrationTests_macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_IntegrationTests_macOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_IntegrationTests_macOS/Pods-Firestore_IntegrationTests_macOS.debug.xcconfig"; sourceTree = "<group>"; };
 		332485C4DCC6BA0DBB5E31B7 /* leveldb_util_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = leveldb_util_test.cc; sourceTree = "<group>"; };
-		33607A3AE91548BD219EC9C6 /* transform_operation_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = transform_operation_test.cc; sourceTree = "<group>"; };
+		33607A3AE91548BD219EC9C6 /* transform_operation_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = transform_operation_test.cc; sourceTree = "<group>"; };
 		358C3B5FE573B1D60A4F7592 /* strerror_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = strerror_test.cc; sourceTree = "<group>"; };
 		36D235D9F1240D5195CDB670 /* Pods-Firestore_IntegrationTests_tvOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_IntegrationTests_tvOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_IntegrationTests_tvOS/Pods-Firestore_IntegrationTests_tvOS.release.xcconfig"; sourceTree = "<group>"; };
 		397FB002E298B780F1E223E2 /* Pods-Firestore_Tests_macOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Tests_macOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Tests_macOS/Pods-Firestore_Tests_macOS.release.xcconfig"; sourceTree = "<group>"; };
@@ -1367,7 +1367,7 @@
 		54E9281E1F33950B00C1953E /* FSTIntegrationTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FSTIntegrationTestCase.h; sourceTree = "<group>"; };
 		54E9282A1F339CAD00C1953E /* XCTestCase+Await.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCTestCase+Await.h"; sourceTree = "<group>"; };
 		54EB764C202277B30088B8F3 /* array_sorted_map_test.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = array_sorted_map_test.cc; sourceTree = "<group>"; };
-		584AE2C37A55B408541A6FF3 /* remote_event_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = remote_event_test.cc; sourceTree = "<group>"; };
+		584AE2C37A55B408541A6FF3 /* remote_event_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = remote_event_test.cc; sourceTree = "<group>"; };
 		5918805E993304321A05E82B /* Pods_Firestore_Example_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Firestore_Example_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CAE131920FFFED600BE9A4A /* Firestore_Benchmarks_iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Firestore_Benchmarks_iOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CAE131D20FFFED600BE9A4A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1421,7 +1421,7 @@
 		6EDD3B5B20BF247500C33877 /* Firestore_FuzzTests_iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Firestore_FuzzTests_iOS.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6EDD3B5C20BF247500C33877 /* Firestore_FuzzTests_iOS-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Firestore_FuzzTests_iOS-Info.plist"; sourceTree = "<group>"; };
 		6EDD3B5E20BF24D000C33877 /* FSTFuzzTestsPrincipal.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FSTFuzzTestsPrincipal.mm; sourceTree = "<group>"; };
-		71140E5D09C6E76F7C71B2FC /* fake_target_metadata_provider.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = fake_target_metadata_provider.cc; sourceTree = "<group>"; };
+		71140E5D09C6E76F7C71B2FC /* fake_target_metadata_provider.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = fake_target_metadata_provider.cc; sourceTree = "<group>"; };
 		71719F9E1E33DC2100824A3D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		731541602214AFFA0037F4DC /* query_spec_test.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = query_spec_test.json; sourceTree = "<group>"; };
 		73866A9F2082B069009BB4FF /* FIRArrayTransformTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FIRArrayTransformTests.mm; sourceTree = "<group>"; };
@@ -1430,12 +1430,12 @@
 		73F1F73B2210F3D800E1F692 /* index_manager_test.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = index_manager_test.mm; sourceTree = "<group>"; };
 		73F1F7402211FEF300E1F692 /* leveldb_index_manager_test.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = leveldb_index_manager_test.mm; sourceTree = "<group>"; };
 		74AC2ADBF1BAD9A8EF30CF41 /* Pods-Firestore_IntegrationTests_tvOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_IntegrationTests_tvOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_IntegrationTests_tvOS/Pods-Firestore_IntegrationTests_tvOS.debug.xcconfig"; sourceTree = "<group>"; };
-		7515B47C92ABEEC66864B55C /* field_transform_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = field_transform_test.cc; sourceTree = "<group>"; };
+		7515B47C92ABEEC66864B55C /* field_transform_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = field_transform_test.cc; sourceTree = "<group>"; };
 		759E964B6A03E6775C992710 /* Pods_Firestore_Tests_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Firestore_Tests_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		79507DF8378D3C42F5B36268 /* string_win_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = string_win_test.cc; sourceTree = "<group>"; };
 		79D4CD6A707ED3F7A6D2ECF5 /* view_testing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = view_testing.h; sourceTree = "<group>"; };
 		7B65C996438B84DBC7616640 /* CodableTimestampTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CodableTimestampTests.swift; sourceTree = "<group>"; };
-		7C3F995E040E9E9C5E8514BB /* query_listener_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = query_listener_test.cc; sourceTree = "<group>"; };
+		7C3F995E040E9E9C5E8514BB /* query_listener_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = query_listener_test.cc; sourceTree = "<group>"; };
 		84434E57CA72951015FC71BC /* Pods-Firestore_FuzzTests_iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_FuzzTests_iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_FuzzTests_iOS/Pods-Firestore_FuzzTests_iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		872C92ABD71B12784A1C5520 /* async_testing.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = async_testing.cc; sourceTree = "<group>"; };
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -1505,7 +1505,7 @@
 		BD01F0E43E4E2A07B8B05099 /* Pods-Firestore_Tests_macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Tests_macOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Tests_macOS/Pods-Firestore_Tests_macOS.debug.xcconfig"; sourceTree = "<group>"; };
 		C7429071B33BDF80A7FA2F8A /* view_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = view_test.cc; sourceTree = "<group>"; };
 		C8522DE226C467C54E6788D8 /* mutation_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = mutation_test.cc; sourceTree = "<group>"; };
-		CC572A9168BBEF7B83E4BBC5 /* view_snapshot_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = view_snapshot_test.cc; sourceTree = "<group>"; };
+		CC572A9168BBEF7B83E4BBC5 /* view_snapshot_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = view_snapshot_test.cc; sourceTree = "<group>"; };
 		CD422AF3E4515FB8E9BE67A0 /* equals_tester.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = equals_tester.h; sourceTree = "<group>"; };
 		D0A6E9136804A41CEC9D55D4 /* delayed_constructor_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = delayed_constructor_test.cc; sourceTree = "<group>"; };
 		D3CC3DC5338DCAF43A211155 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
@@ -4552,6 +4552,8 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
@@ -4575,6 +4577,8 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEVELOPMENT_TEAM = "";
@@ -4743,6 +4747,8 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
@@ -4766,6 +4772,8 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEVELOPMENT_TEAM = "";
@@ -5202,6 +5210,8 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = "";
@@ -5239,6 +5249,8 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -90,106 +90,133 @@ def configure_local_pods()
   end
 end
 
-target 'Firestore_Example_iOS' do
-  platform :ios, '8.0'
+# Reads the value of the PLATFORM environment variable, converts it to the
+# equivalent symbol (e.g. 'iOS' => :ios, 'macOS' => :osx) and returns true if
+# the argument matches.
+def is_platform(symbol)
+  platform = ENV['PLATFORM'] || 'all'
+  platform = platform.downcase  # If set, will be frozen.
 
-  # The next line is the forcing function for the Firebase pod. The Firebase
-  # version's subspecs should depend on the component versions in their
-  # corresponding podspecs.
-  pod 'Firebase/CoreOnly', '6.9.0'
-
-  configure_local_pods()
-
-  target 'Firestore_Tests_iOS' do
-    inherit! :search_paths
-
-    pod 'GoogleBenchmark', :podspec => 'GoogleBenchmark.podspec'
-    pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
-    pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
-
-    pod 'leveldb-library'
+  if platform == 'macos'
+    # CocoaPods calls this osx
+    platform = 'osx'
   end
+  platform = platform.to_sym
 
-  target 'Firestore_Benchmarks_iOS' do
-    inherit! :search_paths
-
-    pod 'GoogleBenchmark', :podspec => 'GoogleBenchmark.podspec'
-  end
-
-  target 'Firestore_IntegrationTests_iOS' do
-    inherit! :search_paths
-
-    pod 'FirebaseFirestoreSwift', :path => '../../'
-    pod 'GoogleBenchmark', :podspec => 'GoogleBenchmark.podspec'
-    pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
-    pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
-
-    pod 'leveldb-library'
-  end
-
-  target 'Firestore_SwiftTests_iOS' do
-    pod 'FirebaseFirestoreSwift', :path => '../../'
-  end
-
-  target 'Firestore_FuzzTests_iOS' do
-    inherit! :search_paths
-    platform :ios, '9.0'
-
-    pod 'LibFuzzer', :podspec => 'LibFuzzer.podspec', :inhibit_warnings => true
-    pod '!ProtoCompiler'
+  if symbol == platform || platform == :all
+    puts "Adding #{symbol} targets to the project"
+    return true
+  else
+    return false
   end
 end
 
-target 'Firestore_Example_macOS' do
-  platform :osx, '10.11'
+if is_platform(:ios)
+  target 'Firestore_Example_iOS' do
+    platform :ios, '8.0'
 
-  configure_local_pods()
+    # The next line is the forcing function for the Firebase pod. The Firebase
+    # version's subspecs should depend on the component versions in their
+    # corresponding podspecs.
+    pod 'Firebase/CoreOnly', '6.9.0'
 
-  target 'Firestore_Tests_macOS' do
-    inherit! :search_paths
+    configure_local_pods()
 
-    pod 'GoogleBenchmark', :podspec => 'GoogleBenchmark.podspec'
-    pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
-    pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
+    target 'Firestore_Tests_iOS' do
+      inherit! :search_paths
 
-    pod 'leveldb-library'
-  end
+      pod 'GoogleBenchmark', :podspec => 'GoogleBenchmark.podspec'
+      pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
+      pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
 
-  target 'Firestore_IntegrationTests_macOS' do
-    inherit! :search_paths
+      pod 'leveldb-library'
+    end
 
-    pod 'FirebaseFirestoreSwift', :path => '../../'
-    pod 'GoogleBenchmark', :podspec => 'GoogleBenchmark.podspec'
-    pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
-    pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
+    target 'Firestore_Benchmarks_iOS' do
+      inherit! :search_paths
 
-    pod 'leveldb-library'
+      pod 'GoogleBenchmark', :podspec => 'GoogleBenchmark.podspec'
+    end
+
+    target 'Firestore_IntegrationTests_iOS' do
+      inherit! :search_paths
+
+      pod 'FirebaseFirestoreSwift', :path => '../../'
+      pod 'GoogleBenchmark', :podspec => 'GoogleBenchmark.podspec'
+      pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
+      pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
+
+      pod 'leveldb-library'
+    end
+
+    target 'Firestore_SwiftTests_iOS' do
+      pod 'FirebaseFirestoreSwift', :path => '../../'
+    end
+
+    target 'Firestore_FuzzTests_iOS' do
+      inherit! :search_paths
+      platform :ios, '9.0'
+
+      pod 'LibFuzzer', :podspec => 'LibFuzzer.podspec', :inhibit_warnings => true
+      pod '!ProtoCompiler'
+    end
   end
 end
 
-target 'Firestore_Example_tvOS' do
-  platform :tvos, '10.0'
+if is_platform(:osx)
+  target 'Firestore_Example_macOS' do
+    platform :osx, '10.11'
 
-  configure_local_pods()
+    configure_local_pods()
 
-  target 'Firestore_Tests_tvOS' do
-    inherit! :search_paths
+    target 'Firestore_Tests_macOS' do
+      inherit! :search_paths
 
-    pod 'GoogleBenchmark', :podspec => 'GoogleBenchmark.podspec'
-    pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
-    pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
+      pod 'GoogleBenchmark', :podspec => 'GoogleBenchmark.podspec'
+      pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
+      pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
 
-    pod 'leveldb-library'
+      pod 'leveldb-library'
+    end
+
+    target 'Firestore_IntegrationTests_macOS' do
+      inherit! :search_paths
+
+      pod 'FirebaseFirestoreSwift', :path => '../../'
+      pod 'GoogleBenchmark', :podspec => 'GoogleBenchmark.podspec'
+      pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
+      pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
+
+      pod 'leveldb-library'
+    end
   end
+end
 
-  target 'Firestore_IntegrationTests_tvOS' do
-    inherit! :search_paths
+if is_platform(:tvos)
+  target 'Firestore_Example_tvOS' do
+    platform :tvos, '10.0'
 
-    pod 'FirebaseFirestoreSwift', :path => '../../'
-    pod 'GoogleBenchmark', :podspec => 'GoogleBenchmark.podspec'
-    pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
-    pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
+    configure_local_pods()
 
-    pod 'leveldb-library'
+    target 'Firestore_Tests_tvOS' do
+      inherit! :search_paths
+
+      pod 'GoogleBenchmark', :podspec => 'GoogleBenchmark.podspec'
+      pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
+      pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
+
+      pod 'leveldb-library'
+    end
+
+    target 'Firestore_IntegrationTests_tvOS' do
+      inherit! :search_paths
+
+      pod 'FirebaseFirestoreSwift', :path => '../../'
+      pod 'GoogleBenchmark', :podspec => 'GoogleBenchmark.podspec'
+      pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
+      pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
+
+      pod 'leveldb-library'
+    end
   end
 end

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -107,7 +107,6 @@ target 'Firestore_Example_iOS' do
     pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
     pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
 
-    pod 'OCMock'
     pod 'leveldb-library'
   end
 
@@ -125,7 +124,6 @@ target 'Firestore_Example_iOS' do
     pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
     pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
 
-    pod 'OCMock'
     pod 'leveldb-library'
   end
 
@@ -154,7 +152,6 @@ target 'Firestore_Example_macOS' do
     pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
     pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
 
-    pod 'OCMock'
     pod 'leveldb-library'
   end
 
@@ -166,7 +163,6 @@ target 'Firestore_Example_macOS' do
     pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
     pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
 
-    pod 'OCMock'
     pod 'leveldb-library'
   end
 end
@@ -183,7 +179,6 @@ target 'Firestore_Example_tvOS' do
     pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
     pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
 
-    pod 'OCMock'
     pod 'leveldb-library'
   end
 
@@ -195,7 +190,6 @@ target 'Firestore_Example_tvOS' do
     pod 'GoogleTest', :podspec => 'GoogleTest.podspec'
     pod 'ProtobufCpp', :podspec => 'ProtobufCpp.podspec'
 
-    pod 'OCMock'
     pod 'leveldb-library'
   end
 end

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -75,6 +75,10 @@ fi
 scripts_dir=$(dirname "${BASH_SOURCE[0]}")
 firestore_emulator="${scripts_dir}/run_firestore_emulator.sh"
 
+xcode_version=$(xcodebuild -version | head -n 1)
+xcode_version="${xcode_version/Xcode /}"
+xcode_major="${xcode_version/.*/}"
+
 # Runs xcodebuild with the given flags, piping output to xcpretty
 # If xcodebuild fails with known error codes, retries once.
 function RunXcodebuild() {
@@ -92,8 +96,7 @@ function RunXcodebuild() {
   fi
 }
 
-# Remove Firestore when it moves up to Xcode 11
-if [[ $product == 'Firestore' ]]; then # #3949
+if [[ "$xcode_major" -lt 11 ]]; then
   ios_flags=(
     -sdk 'iphonesimulator'
     -destination 'platform=iOS Simulator,name=iPhone 7'
@@ -160,10 +163,6 @@ xcb_flags+=(
 cmake_options=(
   -Wdeprecated
 )
-
-xcode_version=$(xcodebuild -version | head -n 1)
-xcode_version="${xcode_version/Xcode /}"
-xcode_major="${xcode_version/.*/}"
 
 if [[ -n "${SANITIZERS:-}" ]]; then
   for sanitizer in $SANITIZERS; do

--- a/scripts/sync_project.rb
+++ b/scripts/sync_project.rb
@@ -538,7 +538,20 @@ class Syncer
     target.build_configurations.each do |config|
       requested = flatten(target_def.xcconfig)
 
+      if config.base_configuration_reference.nil?
+        # Running pod install with PLATFORM set to something other than "all"
+        # ends up removing baseConfigurationReference entries from the project
+        # file. Skip these entries when re-running.
+        puts "Skipping #{target.name} (#{config.name})"
+        next
+      end
+
       path = PODFILE_DIR.join(config.base_configuration_reference.path)
+      if !File.file?(path)
+        puts "Skipping #{target.name} (#{config.name}); missing xcconfig"
+        next
+      end
+
       contents = Xcodeproj::Config.new(path)
       contents.merge!(requested)
       contents.save_as(path)


### PR DESCRIPTION
This adds logic to the Firestore `Podfile` that allows it to install only one platform at a time, making it possible to run builds from the command-line again with Xcode 10.2+.

This uses the `PLATFORM` environment variable we set in our Travis configuration to limit which targets are modified by `pod install`. This makes the selected platform work but leaves the other platforms in a broken state.

The default with `PLATFORM` unset is `all`, which makes development continue to work as usual for now.

Fixes #3949