### PR TITLE
Always check if IID and token are consistent

### DIFF
--- a/Example/InstanceID/Tests/FIRInstanceIDTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTest.m
@@ -161,7 +161,8 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
 
 - (void)testTokenShouldBeRefreshedIfCacheTokenNeedsToBeRefreshed {
   [[[self.mockInstanceID stub] andReturn:kToken] cachedTokenIfAvailable];
-  [[[self.mockTokenManager stub] andReturnValue:@(YES)] checkTokenRefreshPolicyWithIID:[OCMArg any]];
+  [[[self.mockTokenManager stub] andReturnValue:@(YES)]
+      checkTokenRefreshPolicyWithIID:[OCMArg any]];
   [[[self.mockInstanceID stub] andDo:^(NSInvocation *invocation){
   }] tokenWithAuthorizedEntity:[OCMArg any]
                          scope:[OCMArg any]

--- a/Example/InstanceID/Tests/FIRInstanceIDTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTest.m
@@ -35,7 +35,7 @@ static NSString *const kFakeIID = @"12345678";
 static NSString *const kFakeAPNSToken = @"this is a fake apns token";
 static NSString *const kAuthorizedEntity = @"test-audience";
 static NSString *const kScope = @"test-scope";
-static NSString *const kToken = @"test-token";
+static NSString *const kToken = @"12345678:test-token";
 static FIRInstanceIDTokenInfo *sTokenInfo;
 // Faking checkin calls
 static NSString *const kDeviceAuthId = @"device-id";
@@ -116,13 +116,13 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
   }] hasValidCheckinInfo];
 
   self.mockTokenManager = OCMClassMock([FIRInstanceIDTokenManager class]);
-  [[[self.mockTokenManager stub] andReturn:self.mockAuthService] authService];
 
   self.mockKeyPairStore = OCMClassMock([FIRInstanceIDKeyPairStore class]);
   _instanceID.fcmSenderID = kAuthorizedEntity;
   self.mockInstanceID = OCMPartialMock(_instanceID);
   [self.mockInstanceID setTokenManager:self.mockTokenManager];
   [self.mockInstanceID setKeyPairStore:self.mockKeyPairStore];
+  [[[self.mockTokenManager stub] andReturn:self.mockAuthService] authService];
 
   id instanceIDClassMock = OCMClassMock([FIRInstanceID class]);
   OCMStub(ClassMethod([instanceIDClassMock minIntervalForDefaultTokenRetry])).andReturn(2);
@@ -161,7 +161,7 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
 
 - (void)testTokenShouldBeRefreshedIfCacheTokenNeedsToBeRefreshed {
   [[[self.mockInstanceID stub] andReturn:kToken] cachedTokenIfAvailable];
-  [[[self.mockTokenManager stub] andReturnValue:@(YES)] checkForTokenRefreshPolicy];
+  [[[self.mockTokenManager stub] andReturnValue:@(YES)] checkTokenRefreshPolicyWithIID:[OCMArg any]];
   [[[self.mockInstanceID stub] andDo:^(NSInvocation *invocation){
   }] tokenWithAuthorizedEntity:[OCMArg any]
                          scope:[OCMArg any]

--- a/Example/InstanceID/Tests/FIRInstanceIDTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTest.m
@@ -116,13 +116,13 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
   }] hasValidCheckinInfo];
 
   self.mockTokenManager = OCMClassMock([FIRInstanceIDTokenManager class]);
+  [[[self.mockTokenManager stub] andReturn:self.mockAuthService] authService];
 
   self.mockKeyPairStore = OCMClassMock([FIRInstanceIDKeyPairStore class]);
   _instanceID.fcmSenderID = kAuthorizedEntity;
   self.mockInstanceID = OCMPartialMock(_instanceID);
   [self.mockInstanceID setTokenManager:self.mockTokenManager];
   [self.mockInstanceID setKeyPairStore:self.mockKeyPairStore];
-  [[[self.mockTokenManager stub] andReturn:self.mockAuthService] authService];
 
   id instanceIDClassMock = OCMClassMock([FIRInstanceID class]);
   OCMStub(ClassMethod([instanceIDClassMock minIntervalForDefaultTokenRetry])).andReturn(2);

--- a/Example/InstanceID/Tests/FIRInstanceIDTokenManagerTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTokenManagerTest.m
@@ -34,7 +34,7 @@ static NSString *const kSubDirectoryName = @"FirebaseInstanceIDTokenManagerTest"
 
 static NSString *const kAuthorizedEntity = @"test-authorized-entity";
 static NSString *const kScope = @"test-scope";
-static NSString *const kToken = @"test-token";
+static NSString *const kToken = @"cHu_lDPF4EXfo3cdVQhfGg:APA91bGHesgrEsM5j8afb8kKKVwr2Q82NrX_mhLT0URVLYP_MVJgvrdNfYfgoiPO4NG8SYA2SsZofP0iRXUv9vKREhLPQh0JDOiQ1MO0ivJyDeRo6_5e8VXLeGTTa0StpzfqETEhMaW7";
 
 // Use a string (which is converted to NSData) as a placeholder for an actual APNs device token.
 static NSString *const kNewAPNSTokenString = @"newAPNSData";
@@ -50,7 +50,7 @@ static NSString *const kNewAPNSTokenString = @"newAPNSData";
 
 @interface FIRInstanceIDTokenManager (ExposedForTests)
 
-- (BOOL)checkForTokenRefreshPolicy;
+- (BOOL)checkTokenRefreshPolicyForIID:(NSString *)IID;
 - (void)updateToAPNSDeviceToken:(NSData *)deviceToken isSandbox:(BOOL)isSandbox;
 /**
  *  Create a fetch operation. This method can be stubbed to return a particular operation instance,
@@ -426,7 +426,7 @@ static NSString *const kNewAPNSTokenString = @"newAPNSData";
 
   // Trigger a potential reset, the current app version is 1.0 which is newer than
   // the one set in tokenInfo.
-  [self.tokenManager checkForTokenRefreshPolicy];
+  [self.tokenManager checkTokenRefreshPolicyWithIID:@"abc"];
 
   // Ensure that token data is now missing
   for (NSString *entity in entities) {
@@ -436,6 +436,38 @@ static NSString *const kNewAPNSTokenString = @"newAPNSData";
   }
 }
 
+
+-(void)testTokenShouldBeDeletedIfWrongFormat {    
+    // Cache some token
+    NSArray<NSString *> *entities = @[ @"entity1", @"entity2"];
+    for (NSString *entity in entities) {
+      FIRInstanceIDTokenInfo *info =
+          [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:entity
+                                                             scope:kScope
+                                                             token:kToken
+                                                        appVersion:nil
+                                                     firebaseAppID:nil];
+      [self.tokenStore saveTokenInfo:info handler:nil];
+    }
+
+    // Ensure they tokens now exist.
+    for (NSString *entity in entities) {
+      FIRInstanceIDTokenInfo *cachedTokenInfo =
+          [self.tokenManager cachedTokenInfoWithAuthorizedEntity:entity scope:kScope];
+      XCTAssertNotNil(cachedTokenInfo);
+    }
+
+    // Trigger a potential reset, the current IID is sth differnt than the token
+    [self.tokenManager checkTokenRefreshPolicyWithIID:@"d8xQyABOoV8"];
+
+    // Ensure that token data is now missing
+    for (NSString *entity in entities) {
+      FIRInstanceIDTokenInfo *cachedTokenInfo =
+          [self.tokenManager cachedTokenInfoWithAuthorizedEntity:entity scope:kScope];
+      XCTAssertNil(cachedTokenInfo);
+    }
+}
+
 - (void)testCachedTokensInvalidatedOnAPNSAddition {
   // Write some fake tokens to cache, which have no APNs info
   NSArray<NSString *> *entities = @[ @"entity1", @"entity2" ];
@@ -443,7 +475,7 @@ static NSString *const kNewAPNSTokenString = @"newAPNSData";
     FIRInstanceIDTokenInfo *info =
         [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:entity
                                                            scope:kScope
-                                                           token:@"abcdef"
+                                                           token:kToken
                                                       appVersion:nil
                                                    firebaseAppID:nil];
     [self.tokenStore saveTokenInfo:info handler:nil];
@@ -475,7 +507,7 @@ static NSString *const kNewAPNSTokenString = @"newAPNSData";
     FIRInstanceIDTokenInfo *info =
         [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:entity
                                                            scope:kScope
-                                                           token:@"abcdef"
+                                                           token:kToken
                                                       appVersion:nil
                                                    firebaseAppID:nil];
     info.APNSInfo = [[FIRInstanceIDAPNSInfo alloc] initWithDeviceToken:oldAPNSData isSandbox:NO];
@@ -509,7 +541,7 @@ static NSString *const kNewAPNSTokenString = @"newAPNSData";
     FIRInstanceIDTokenInfo *info =
         [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:entity
                                                            scope:kScope
-                                                           token:@"abcdef"
+                                                           token:kToken
                                                       appVersion:nil
                                                    firebaseAppID:nil];
     info.APNSInfo = [[FIRInstanceIDAPNSInfo alloc] initWithDeviceToken:currentAPNSData

--- a/Example/InstanceID/Tests/FIRInstanceIDTokenManagerTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTokenManagerTest.m
@@ -34,7 +34,9 @@ static NSString *const kSubDirectoryName = @"FirebaseInstanceIDTokenManagerTest"
 
 static NSString *const kAuthorizedEntity = @"test-authorized-entity";
 static NSString *const kScope = @"test-scope";
-static NSString *const kToken = @"cHu_lDPF4EXfo3cdVQhfGg:APA91bGHesgrEsM5j8afb8kKKVwr2Q82NrX_mhLT0URVLYP_MVJgvrdNfYfgoiPO4NG8SYA2SsZofP0iRXUv9vKREhLPQh0JDOiQ1MO0ivJyDeRo6_5e8VXLeGTTa0StpzfqETEhMaW7";
+static NSString *const kToken =
+    @"cHu_lDPF4EXfo3cdVQhfGg:APA91bGHesgrEsM5j8afb8kKKVwr2Q82NrX_mhLT0URVLYP_"
+    @"MVJgvrdNfYfgoiPO4NG8SYA2SsZofP0iRXUv9vKREhLPQh0JDOiQ1MO0ivJyDeRo6_5e8VXLeGTTa0StpzfqETEhMaW7";
 
 // Use a string (which is converted to NSData) as a placeholder for an actual APNs device token.
 static NSString *const kNewAPNSTokenString = @"newAPNSData";
@@ -436,48 +438,45 @@ static NSString *const kNewAPNSTokenString = @"newAPNSData";
   }
 }
 
+- (void)testTokenShouldBeDeletedIfWrongFormat {
+  // Cache some token
+  NSArray<NSString *> *entities = @[ @"entity1", @"entity2" ];
+  for (NSString *entity in entities) {
+    FIRInstanceIDTokenInfo *info = [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:entity
+                                                                                      scope:kScope
+                                                                                      token:kToken
+                                                                                 appVersion:nil
+                                                                              firebaseAppID:nil];
+    [self.tokenStore saveTokenInfo:info handler:nil];
+  }
 
--(void)testTokenShouldBeDeletedIfWrongFormat {    
-    // Cache some token
-    NSArray<NSString *> *entities = @[ @"entity1", @"entity2"];
-    for (NSString *entity in entities) {
-      FIRInstanceIDTokenInfo *info =
-          [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:entity
-                                                             scope:kScope
-                                                             token:kToken
-                                                        appVersion:nil
-                                                     firebaseAppID:nil];
-      [self.tokenStore saveTokenInfo:info handler:nil];
-    }
+  // Ensure they tokens now exist.
+  for (NSString *entity in entities) {
+    FIRInstanceIDTokenInfo *cachedTokenInfo =
+        [self.tokenManager cachedTokenInfoWithAuthorizedEntity:entity scope:kScope];
+    XCTAssertNotNil(cachedTokenInfo);
+  }
 
-    // Ensure they tokens now exist.
-    for (NSString *entity in entities) {
-      FIRInstanceIDTokenInfo *cachedTokenInfo =
-          [self.tokenManager cachedTokenInfoWithAuthorizedEntity:entity scope:kScope];
-      XCTAssertNotNil(cachedTokenInfo);
-    }
+  // Trigger a potential reset, the current IID is sth differnt than the token
+  [self.tokenManager checkTokenRefreshPolicyWithIID:@"d8xQyABOoV8"];
 
-    // Trigger a potential reset, the current IID is sth differnt than the token
-    [self.tokenManager checkTokenRefreshPolicyWithIID:@"d8xQyABOoV8"];
-
-    // Ensure that token data is now missing
-    for (NSString *entity in entities) {
-      FIRInstanceIDTokenInfo *cachedTokenInfo =
-          [self.tokenManager cachedTokenInfoWithAuthorizedEntity:entity scope:kScope];
-      XCTAssertNil(cachedTokenInfo);
-    }
+  // Ensure that token data is now missing
+  for (NSString *entity in entities) {
+    FIRInstanceIDTokenInfo *cachedTokenInfo =
+        [self.tokenManager cachedTokenInfoWithAuthorizedEntity:entity scope:kScope];
+    XCTAssertNil(cachedTokenInfo);
+  }
 }
 
 - (void)testCachedTokensInvalidatedOnAPNSAddition {
   // Write some fake tokens to cache, which have no APNs info
   NSArray<NSString *> *entities = @[ @"entity1", @"entity2" ];
   for (NSString *entity in entities) {
-    FIRInstanceIDTokenInfo *info =
-        [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:entity
-                                                           scope:kScope
-                                                           token:kToken
-                                                      appVersion:nil
-                                                   firebaseAppID:nil];
+    FIRInstanceIDTokenInfo *info = [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:entity
+                                                                                      scope:kScope
+                                                                                      token:kToken
+                                                                                 appVersion:nil
+                                                                              firebaseAppID:nil];
     [self.tokenStore saveTokenInfo:info handler:nil];
   }
 
@@ -504,12 +503,11 @@ static NSString *const kNewAPNSTokenString = @"newAPNSData";
   NSArray<NSString *> *entities = @[ @"entity1", @"entity2" ];
   NSData *oldAPNSData = [@"oldAPNSToken" dataUsingEncoding:NSUTF8StringEncoding];
   for (NSString *entity in entities) {
-    FIRInstanceIDTokenInfo *info =
-        [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:entity
-                                                           scope:kScope
-                                                           token:kToken
-                                                      appVersion:nil
-                                                   firebaseAppID:nil];
+    FIRInstanceIDTokenInfo *info = [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:entity
+                                                                                      scope:kScope
+                                                                                      token:kToken
+                                                                                 appVersion:nil
+                                                                              firebaseAppID:nil];
     info.APNSInfo = [[FIRInstanceIDAPNSInfo alloc] initWithDeviceToken:oldAPNSData isSandbox:NO];
     [self.tokenStore saveTokenInfo:info handler:nil];
   }
@@ -538,12 +536,11 @@ static NSString *const kNewAPNSTokenString = @"newAPNSData";
   NSString *apnsDataString = kNewAPNSTokenString;
   NSData *currentAPNSData = [apnsDataString dataUsingEncoding:NSUTF8StringEncoding];
   for (NSString *entity in entities) {
-    FIRInstanceIDTokenInfo *info =
-        [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:entity
-                                                           scope:kScope
-                                                           token:kToken
-                                                      appVersion:nil
-                                                   firebaseAppID:nil];
+    FIRInstanceIDTokenInfo *info = [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:entity
+                                                                                      scope:kScope
+                                                                                      token:kToken
+                                                                                 appVersion:nil
+                                                                              firebaseAppID:nil];
     info.APNSInfo = [[FIRInstanceIDAPNSInfo alloc] initWithDeviceToken:currentAPNSData
                                                              isSandbox:NO];
     [self.tokenStore saveTokenInfo:info handler:nil];

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -709,7 +709,9 @@ static FIRInstanceID *gInstanceID;
   // When there is a cached token, do the token refresh.
   if (cachedToken) {
     // Clean up expired tokens by checking the token refresh policy.
-    if ([self.tokenManager checkForTokenRefreshPolicy]) {
+    NSError *error;
+    NSString *cachedIID = [self.keyPairStore appIdentityWithError:&error];
+    if ([self.tokenManager checkTokenRefreshPolicyWithIID:cachedIID]) {
       // Default token is expired, fetch default token from server.
       [self defaultTokenWithHandler:nil];
     }

--- a/Firebase/InstanceID/FIRInstanceIDTokenManager.h
+++ b/Firebase/InstanceID/FIRInstanceIDTokenManager.h
@@ -121,13 +121,14 @@ typedef NS_OPTIONS(NSUInteger, FIRInstanceIDInvalidTokenReason) {
 /**
  *  Invalidate any cached tokens, if the app version has changed since last launch or if the token
  *  is cached for more than 7 days.
+ *  @param IID The cached instanceID, check if token is prefixed by such IID.
  *
  *  @return Whether we should fetch default token from server.
  *
  *  @discussion This should safely be called prior to any tokens being retrieved from
  *  the cache or being fetched from the network.
  */
-- (BOOL)checkForTokenRefreshPolicy;
+- (BOOL)checkTokenRefreshPolicyWithIID:(NSString *)IID;
 
 /**
  *  Upon being provided with different APNs or sandbox, any locally cached tokens

--- a/Firebase/InstanceID/FIRInstanceIDTokenManager.m
+++ b/Firebase/InstanceID/FIRInstanceIDTokenManager.m
@@ -273,7 +273,7 @@
 }
 
 #pragma mark - Invalidating Cached Tokens
-- (BOOL)checkForTokenRefreshPolicy {
+- (BOOL)checkTokenRefreshPolicyWithIID:(NSString *)IID {
   // We know at least one cached token exists.
   BOOL shouldFetchDefaultToken = NO;
   NSArray<FIRInstanceIDTokenInfo *> *tokenInfos = [self.instanceIDStore cachedTokenInfos];
@@ -282,8 +282,8 @@
       [NSMutableArray arrayWithCapacity:tokenInfos.count];
   for (FIRInstanceIDTokenInfo *tokenInfo in tokenInfos) {
     BOOL isTokenFresh = [tokenInfo isFresh];
-    if (isTokenFresh) {
-      // Token is fresh, do nothing.
+    if (isTokenFresh && [tokenInfo.token hasPrefix:IID]) {
+      // Token is fresh and in right format, do nothing
       continue;
     }
     if ([tokenInfo.scope isEqualToString:kFIRInstanceIDDefaultTokenScope]) {


### PR DESCRIPTION
If they don't have the same prefix, refresh the token from backend with the current IID.  This helps with backward compatibility when we adopt FIS

