### PR TITLE
Fix container instantiation timing, IID startup.

### DIFF
--- a/Example/Core/Tests/FIRComponentContainerTest.m
+++ b/Example/Core/Tests/FIRComponentContainerTest.m
@@ -207,6 +207,11 @@
   FIRComponentContainer *container = [[FIRComponentContainer alloc] initWithApp:_hostApp
                                                                     registrants:allRegistrants];
   _hostApp.container = container;
+
+  // Instantiate all the components that were eagerly registered now that all other properties are
+  // configured.
+  [container instantiateEagerComponents];
+
   return container;
 }
 

--- a/Example/Messaging/Tests/FIRInstanceIDWithFCMTest.m
+++ b/Example/Messaging/Tests/FIRInstanceIDWithFCMTest.m
@@ -58,11 +58,10 @@
 }
 
 - (void)testFCMAutoInitEnabled {
-  NSString *const kFIRMessagingTestsAutoInit = @"com.messaging.test_autoInit";
-  NSUserDefaults *defaults = [[NSUserDefaults alloc] initWithSuiteName:kFIRMessagingTestsAutoInit];
+  // Use the standardUserDefaults since that's what IID expects and depends on.
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
   FIRMessaging *messaging = [FIRMessagingTestUtilities messagingForTestsWithUserDefaults:defaults];
   id classMock = OCMClassMock([FIRMessaging class]);
-  OCMStub([classMock messaging]).andReturn(messaging);
   OCMStub([_mockFirebaseApp isDataCollectionDefaultEnabled]).andReturn(YES);
   messaging.autoInitEnabled = YES;
   XCTAssertTrue(

--- a/Example/Messaging/Tests/FIRMessagingTest.m
+++ b/Example/Messaging/Tests/FIRMessagingTest.m
@@ -22,7 +22,6 @@
 #import <FirebaseInstanceID/FirebaseInstanceID.h>
 #import <FirebaseAnalyticsInterop/FIRAnalyticsInterop.h>
 #import <FirebaseMessaging/FIRMessaging.h>
-#import <GoogleUtilities/GULUserDefaults.h>
 
 #import "Example/Messaging/Tests/FIRMessagingTestUtilities.h"
 #import "Firebase/Messaging/FIRMessaging_Private.h"

--- a/Example/Messaging/Tests/FIRMessagingTest.m
+++ b/Example/Messaging/Tests/FIRMessagingTest.m
@@ -22,6 +22,7 @@
 #import <FirebaseInstanceID/FirebaseInstanceID.h>
 #import <FirebaseAnalyticsInterop/FIRAnalyticsInterop.h>
 #import <FirebaseMessaging/FIRMessaging.h>
+#import <GoogleUtilities/GULUserDefaults.h>
 
 #import "Example/Messaging/Tests/FIRMessagingTestUtilities.h"
 #import "Firebase/Messaging/FIRMessaging_Private.h"
@@ -36,6 +37,9 @@ static NSString *const kFIRMessagingDefaultsTestDomain = @"com.messaging.tests";
 @property(nonatomic, readwrite, strong) NSString *defaultFcmToken;
 @property(nonatomic, readwrite, strong) NSData *apnsTokenData;
 @property(nonatomic, readwrite, strong) FIRInstanceID *instanceID;
+
+// Expose autoInitEnabled static method for IID.
++ (BOOL)isAutoInitEnabledWithUserDefaults:(NSUserDefaults *)userDefaults;
 
 // Direct Channel Methods
 - (void)updateAutomaticClientConnection;
@@ -126,6 +130,19 @@ static NSString *const kFIRMessagingDefaultsTestDomain = @"com.messaging.tests";
   OCMStub([bundleMock objectForInfoDictionaryKey:kFIRMessagingPlistAutoInitEnabled]).andReturn(nil);
 
   XCTAssertFalse(self.messaging.isAutoInitEnabled);
+  [bundleMock stopMocking];
+}
+
+- (void)testAutoInitEnableMatchesStaticMethod {
+//  OCMStub([_mockFirebaseApp isDataCollectionDefaultEnabled]).andReturn(YES);
+  // No explicit flag is set.
+  id bundleMock = OCMPartialMock([NSBundle mainBundle]);
+  OCMStub([bundleMock objectForInfoDictionaryKey:kFIRMessagingPlistAutoInitEnabled]).andReturn(nil);
+
+  NSUserDefaults *defaults = self.messaging.messagingUserDefaults;
+  XCTAssertEqual(self.messaging.isAutoInitEnabled,
+                 [FIRMessaging isAutoInitEnabledWithUserDefaults:defaults]);
+
   [bundleMock stopMocking];
 }
 

--- a/Example/Messaging/Tests/FIRMessagingTest.m
+++ b/Example/Messaging/Tests/FIRMessagingTest.m
@@ -133,17 +133,24 @@ static NSString *const kFIRMessagingDefaultsTestDomain = @"com.messaging.tests";
   [bundleMock stopMocking];
 }
 
-- (void)testAutoInitEnableMatchesStaticMethod {
-//  OCMStub([_mockFirebaseApp isDataCollectionDefaultEnabled]).andReturn(YES);
-  // No explicit flag is set.
-  id bundleMock = OCMPartialMock([NSBundle mainBundle]);
-  OCMStub([bundleMock objectForInfoDictionaryKey:kFIRMessagingPlistAutoInitEnabled]).andReturn(nil);
-
+- (void)testAutoInitEnabledMatchesStaticMethod {
+  // Flag is set to YES in user defaults.
   NSUserDefaults *defaults = self.messaging.messagingUserDefaults;
+  [defaults setObject:@YES forKey:kFIRMessagingUserDefaultsKeyAutoInitEnabled];
+
+  XCTAssertTrue(self.messaging.isAutoInitEnabled);
   XCTAssertEqual(self.messaging.isAutoInitEnabled,
                  [FIRMessaging isAutoInitEnabledWithUserDefaults:defaults]);
+}
 
-  [bundleMock stopMocking];
+- (void)testAutoInitDisabledMatchesStaticMethod {
+  // Flag is set to NO in user defaults.
+  NSUserDefaults *defaults = self.messaging.messagingUserDefaults;
+  [defaults setObject:@NO forKey:kFIRMessagingUserDefaultsKeyAutoInitEnabled];
+
+  XCTAssertFalse(self.messaging.isAutoInitEnabled);
+  XCTAssertEqual(self.messaging.isAutoInitEnabled,
+                 [FIRMessaging isAutoInitEnabledWithUserDefaults:defaults]);
 }
 
 #pragma mark - Direct Channel Establishment Testing

--- a/Firebase/Core/FIRApp.m
+++ b/Firebase/Core/FIRApp.m
@@ -191,6 +191,10 @@ static NSMutableDictionary *sLibraryVersions;
     }
 
     [FIRApp addAppToAppDictionary:app];
+
+    // The FIRApp instance is ready to go, `sDefaultApp` is assigned, other SDKs are now ready to be
+    // instantiated.
+    [app.container instantiateEagerComponents];
     [FIRApp sendNotificationsToSDKs:app];
   }
 }

--- a/Firebase/Core/FIRComponentContainer.m
+++ b/Firebase/Core/FIRComponentContainer.m
@@ -74,7 +74,7 @@ static NSMutableSet<Class> *sFIRComponentRegistrants;
 }
 
 - (void)populateComponentsFromRegisteredClasses:(NSSet<Class> *)classes forApp:(FIRApp *)app {
-  // Ensure no esternal access to the container happens during the population of components.
+  // Ensure no external access to the container happens during the population of components.
   @synchronized(self) {
     // Keep track of any components that need to eagerly instantiate after all components are added.
     NSMutableArray<Protocol *> *protocolsToInstantiate = [[NSMutableArray alloc] init];

--- a/Firebase/Core/FIRComponentContainer.m
+++ b/Firebase/Core/FIRComponentContainer.m
@@ -125,8 +125,7 @@ static NSMutableSet<Class> *sFIRComponentRegistrants;
       __unused id unusedInstance = [self instanceForProtocol:protocol];
     }
 
-    // All eager instantiation is complete, empty and clear the stored property now.
-    [self.eagerProtocolsToInstantiate removeAllObjects];
+    // All eager instantiation is complete, clear the stored property now.
     self.eagerProtocolsToInstantiate = nil;
   }
 }

--- a/Firebase/Core/FIRComponentContainer.m
+++ b/Firebase/Core/FIRComponentContainer.m
@@ -32,6 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Cached instances of components that requested to be cached.
 @property(nonatomic, strong) NSMutableDictionary<NSString *, id> *cachedInstances;
 
+/// Protocols of components that have requested to be eagerly instantiated.
+@property(nonatomic, strong, nullable) NSMutableArray<Protocol *> *eagerProtocolsToInstantiate;
+
 @end
 
 @implementation FIRComponentContainer
@@ -74,54 +77,59 @@ static NSMutableSet<Class> *sFIRComponentRegistrants;
 }
 
 - (void)populateComponentsFromRegisteredClasses:(NSSet<Class> *)classes forApp:(FIRApp *)app {
-  // Ensure no external access to the container happens during the population of components.
-  @synchronized(self) {
-    // Keep track of any components that need to eagerly instantiate after all components are added.
-    NSMutableArray<Protocol *> *protocolsToInstantiate = [[NSMutableArray alloc] init];
+  // Keep track of any components that need to eagerly instantiate after all components are added.
+  self.eagerProtocolsToInstantiate = [[NSMutableArray alloc] init];
 
-    // Loop through the verified component registrants and populate the components array.
-    for (Class<FIRLibrary> klass in classes) {
-      // Loop through all the components being registered and store them as appropriate.
-      // Classes which do not provide functionality should use a dummy FIRComponentRegistrant
-      // protocol.
-      for (FIRComponent *component in [klass componentsToRegister]) {
-        // Check if the component has been registered before, and error out if so.
-        NSString *protocolName = NSStringFromProtocol(component.protocol);
-        if (self.components[protocolName]) {
-          FIRLogError(kFIRLoggerCore, @"I-COR000029",
-                      @"Attempted to register protocol %@, but it already has an implementation.",
-                      protocolName);
-          continue;
-        }
-
-        // Store the creation block for later usage.
-        self.components[protocolName] = component.creationBlock;
-
-        // Queue any protocols that should be eagerly instantiated. Don't instantiate them yet
-        // because they could depend on other components that haven't been added to the components
-        // array yet.
-        BOOL shouldInstantiateEager =
-            (component.instantiationTiming == FIRInstantiationTimingAlwaysEager);
-        BOOL shouldInstantiateDefaultEager =
-            (component.instantiationTiming == FIRInstantiationTimingEagerInDefaultApp &&
-             [app isDefaultApp]);
-        if (shouldInstantiateEager || shouldInstantiateDefaultEager) {
-          [protocolsToInstantiate addObject:component.protocol];
-        }
+  // Loop through the verified component registrants and populate the components array.
+  for (Class<FIRLibrary> klass in classes) {
+    // Loop through all the components being registered and store them as appropriate.
+    // Classes which do not provide functionality should use a dummy FIRComponentRegistrant
+    // protocol.
+    for (FIRComponent *component in [klass componentsToRegister]) {
+      // Check if the component has been registered before, and error out if so.
+      NSString *protocolName = NSStringFromProtocol(component.protocol);
+      if (self.components[protocolName]) {
+        FIRLogError(kFIRLoggerCore, @"I-COR000029",
+                    @"Attempted to register protocol %@, but it already has an implementation.",
+                    protocolName);
+        continue;
       }
-    }
 
-    // After all components are registered, instantiate the ones that are requesting eager
-    // instantiation.
-    for (Protocol *protocol in protocolsToInstantiate) {
-      // Get an instance for the protocol, which will instantiate it since it couldn't have been
-      // cached yet. Ignore the instance coming back since we don't need it.
-      __unused id unusedInstance = [self instanceForProtocol:protocol];
+      // Store the creation block for later usage.
+      self.components[protocolName] = component.creationBlock;
+
+      // Queue any protocols that should be eagerly instantiated. Don't instantiate them yet
+      // because they could depend on other components that haven't been added to the components
+      // array yet.
+      BOOL shouldInstantiateEager =
+          (component.instantiationTiming == FIRInstantiationTimingAlwaysEager);
+      BOOL shouldInstantiateDefaultEager =
+          (component.instantiationTiming == FIRInstantiationTimingEagerInDefaultApp &&
+           [app isDefaultApp]);
+      if (shouldInstantiateEager || shouldInstantiateDefaultEager) {
+        [self.eagerProtocolsToInstantiate addObject:component.protocol];
+      }
     }
   }
 }
 
 #pragma mark - Instance Creation
+
+- (void)instantiateEagerComponents {
+  // After all components are registered, instantiate the ones that are requesting eager
+  // instantiation.
+  @synchronized(self) {
+    for (Protocol *protocol in self.eagerProtocolsToInstantiate) {
+      // Get an instance for the protocol, which will instantiate it since it couldn't have been
+      // cached yet. Ignore the instance coming back since we don't need it.
+      __unused id unusedInstance = [self instanceForProtocol:protocol];
+    }
+
+    // All eager instantiation is complete, empty and clear the stored property now.
+    [self.eagerProtocolsToInstantiate removeAllObjects];
+    self.eagerProtocolsToInstantiate = nil;
+  }
+}
 
 /// Instantiate an instance of a class that conforms to the specified protocol.
 /// This will:

--- a/Firebase/Core/Private/FIRComponentContainerInternal.h
+++ b/Firebase/Core/Private/FIRComponentContainerInternal.h
@@ -31,6 +31,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// protocol wasn't registered, or if the instance couldn't instantiate for the provided app.
 - (nullable id)instanceForProtocol:(Protocol *)protocol NS_SWIFT_NAME(instance(for:));
 
+/// Instantiates all the components that have registered as "eager" after initialization.
+- (void)instantiateEagerComponents;
+
 /// Remove all of the cached instances stored and allow them to clean up after themselves.
 - (void)removeAllCachedInstances;
 

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -725,7 +725,7 @@ static FIRInstanceID *gInstanceID;
 
   // Get the autoInitEnabled class method.
   IMP isAutoInitEnabledIMP = [messagingClass methodForSelector:autoInitSelector];
-  BOOL (*isAutoInitEnabled)
+  BOOL(*isAutoInitEnabled)
   (Class, SEL, GULUserDefaults *) = (BOOL(*)(id, SEL, GULUserDefaults *))isAutoInitEnabledIMP;
 
   // Check FCM's isAutoInitEnabled property.

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if !__has_feature(objc_arc)
+#if  !__has_feature(objc_arc)
 #error FIRMessagingLib should be compiled with ARC.
 #endif
 
@@ -24,13 +24,13 @@
 #import <FirebaseCore/FIRComponentContainer.h>
 #import <FirebaseCore/FIRDependency.h>
 #import <FirebaseCore/FIRLibrary.h>
-#import <FirebaseInstanceID/FIRInstanceID_Private.h>
 #import <FirebaseInstanceID/FirebaseInstanceID.h>
+#import <FirebaseInstanceID/FIRInstanceID_Private.h>
 #import <FirebaseMessaging/FIRMessaging.h>
 #import <FirebaseMessaging/FIRMessagingExtensionHelper.h>
-#import <GoogleUtilities/GULAppDelegateSwizzler.h>
 #import <GoogleUtilities/GULReachabilityChecker.h>
 #import <GoogleUtilities/GULUserDefaults.h>
+#import <GoogleUtilities/GULAppDelegateSwizzler.h>
 
 #import "Firebase/Messaging/FIRMessagingAnalytics.h"
 #import "Firebase/Messaging/FIRMessagingClient.h"
@@ -66,21 +66,22 @@ const NSNotificationName FIRMessagingConnectionStateChangedNotification =
 const NSNotificationName FIRMessagingRegistrationTokenRefreshedNotification =
     @"com.firebase.messaging.notif.fcm-token-refreshed";
 #else
-NSString *const FIRMessagingSendSuccessNotification = @"com.firebase.messaging.notif.send-success";
-NSString *const FIRMessagingSendErrorNotification = @"com.firebase.messaging.notif.send-error";
-NSString *const FIRMessagingMessagesDeletedNotification =
+NSString *const FIRMessagingSendSuccessNotification =
+    @"com.firebase.messaging.notif.send-success";
+NSString *const FIRMessagingSendErrorNotification =
+    @"com.firebase.messaging.notif.send-error";
+NSString * const FIRMessagingMessagesDeletedNotification =
     @"com.firebase.messaging.notif.messages-deleted";
-NSString *const FIRMessagingConnectionStateChangedNotification =
+NSString * const FIRMessagingConnectionStateChangedNotification =
     @"com.firebase.messaging.notif.connection-state-changed";
-NSString *const FIRMessagingRegistrationTokenRefreshedNotification =
+NSString * const FIRMessagingRegistrationTokenRefreshedNotification =
     @"com.firebase.messaging.notif.fcm-token-refreshed";
 #endif  // defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 
 NSString *const kFIRMessagingUserDefaultsKeyAutoInitEnabled =
     @"com.firebase.messaging.auto-init.enabled";  // Auto Init Enabled key stored in NSUserDefaults
 
-NSString *const kFIRMessagingAPNSTokenType =
-    @"APNSTokenType";  // APNS Token type key stored in user info.
+NSString *const kFIRMessagingAPNSTokenType = @"APNSTokenType"; // APNS Token type key stored in user info.
 
 NSString *const kFIRMessagingPlistAutoInitEnabled =
     @"FirebaseMessagingAutoInitEnabled";  // Auto Init Enabled key stored in Info.plist
@@ -95,7 +96,7 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
   return NO;
 }
 
-BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
+ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   return [FIRMessagingContextManagerService isContextManagerMessage:message];
 }
 
@@ -135,9 +136,8 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 
 @end
 
-@interface FIRMessaging () <FIRMessagingClientDelegate,
-                            FIRMessagingReceiverDelegate,
-                            GULReachabilityDelegate>
+@interface FIRMessaging ()<FIRMessagingClientDelegate, FIRMessagingReceiverDelegate,
+                           GULReachabilityDelegate>
 
 // FIRApp properties
 @property(nonatomic, readwrite, strong) NSData *apnsTokenData;
@@ -185,12 +185,12 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 }
 
 + (FIRMessagingExtensionHelper *)extensionHelper {
-  static dispatch_once_t once;
-  static FIRMessagingExtensionHelper *extensionHelper;
-  dispatch_once(&once, ^{
-    extensionHelper = [[FIRMessagingExtensionHelper alloc] init];
-  });
-  return extensionHelper;
+    static dispatch_once_t once;
+    static FIRMessagingExtensionHelper *extensionHelper;
+    dispatch_once(&once, ^{
+        extensionHelper = [[FIRMessagingExtensionHelper alloc] init];
+    });
+    return extensionHelper;
 }
 
 - (instancetype)initWithAnalytics:(nullable id<FIRAnalyticsInterop>)analytics
@@ -216,13 +216,13 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 
 + (void)load {
   [FIRApp registerInternalLibrary:(Class<FIRLibrary>)self
-                         withName:@"fire-fcm"
-                      withVersion:FIRMessagingCurrentLibraryVersion()];
+                 withName:@"fire-fcm"
+              withVersion:FIRMessagingCurrentLibraryVersion()];
 }
 
 + (nonnull NSArray<FIRComponent *> *)componentsToRegister {
-  FIRDependency *analyticsDep = [FIRDependency dependencyWithProtocol:@protocol(FIRAnalyticsInterop)
-                                                           isRequired:NO];
+  FIRDependency *analyticsDep =
+      [FIRDependency dependencyWithProtocol:@protocol(FIRAnalyticsInterop) isRequired:NO];
   FIRComponentCreationBlock creationBlock =
       ^id _Nullable(FIRComponentContainer *container, BOOL *isCacheable) {
     // Ensure it's cached so it returns the same instance every time messaging is called.
@@ -239,7 +239,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
       [FIRComponent componentWithProtocol:@protocol(FIRMessagingInstanceProvider)
                       instantiationTiming:FIRInstantiationTimingLazy
                              dependencies:@[ analyticsDep ]
-                            creationBlock:creationBlock];
+                           creationBlock:creationBlock];
 
   return @[ messagingProvider ];
 }
@@ -275,7 +275,8 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   // Print the library version for logging.
   NSString *currentLibraryVersion = FIRMessagingCurrentLibraryVersion();
   FIRMessagingLoggerInfo(kFIRMessagingMessageCodeMessagingPrintLibraryVersion,
-                         @"FIRMessaging library version %@", currentLibraryVersion);
+                         @"FIRMessaging library version %@",
+                         currentLibraryVersion);
 
   [self setupReceiver];
 
@@ -315,7 +316,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
              selector:@selector(defaultInstanceIDTokenWasRefreshed:)
                  name:kFIRMessagingRegistrationTokenRefreshNotification
                object:nil];
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS ||TARGET_OS_TV
   [center addObserver:self
              selector:@selector(applicationStateChanged)
                  name:UIApplicationDidBecomeActiveNotification
@@ -356,8 +357,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 
 - (void)setupTopics {
   if (!self.client) {
-    FIRMessagingLoggerWarn(kFIRMessagingMessageCodeInvalidClient,
-                           @"Invalid nil client before init pubsub.");
+     FIRMessagingLoggerWarn(kFIRMessagingMessageCodeInvalidClient, @"Invalid nil client before init pubsub.");
   }
   self.pubsub = [[FIRMessagingPubSub alloc] initWithClient:self.client];
 }
@@ -412,7 +412,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
     // We need to rule out the contextual message because it shares the same message ID
     // as the local notification it will schedule. And because it is also a APNSSync message
     // its duplication is already checked previously.
-    if (!isOldMessage && !FIRMessagingIsContextManagerMessage(message)) {
+   if (!isOldMessage && !FIRMessagingIsContextManagerMessage(message)) {
       isOldMessage = [self.loggedMessageIDs containsObject:messageID];
       if (!isOldMessage) {
         [self.loggedMessageIDs addObject:messageID];
@@ -444,6 +444,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   if (![NSThread isMainThread]) {
     dispatch_async(dispatch_get_main_queue(), ^{
       [self handleIncomingLinkIfNeededFromMessage:message];
+
     });
     return;
   }
@@ -452,12 +453,12 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
     return;
   }
   id<UIApplicationDelegate> appDelegate = application.delegate;
-  SEL continueUserActivitySelector = @selector(application:
-                                      continueUserActivity:restorationHandler:);
+  SEL continueUserActivitySelector =
+      @selector(application:continueUserActivity:restorationHandler:);
 
   SEL openURLWithOptionsSelector = @selector(application:openURL:options:);
-  SEL openURLWithSourceApplicationSelector = @selector(application:
-                                                           openURL:sourceApplication:annotation:);
+  SEL openURLWithSourceApplicationSelector =
+      @selector(application:openURL:sourceApplication:annotation:);
 #if TARGET_OS_IOS
   SEL handleOpenURLSelector = @selector(application:handleOpenURL:);
 #endif
@@ -472,17 +473,17 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
     userActivity.webpageURL = url;
     [appDelegate application:application
         continueUserActivity:userActivity
-          restorationHandler:^(NSArray *_Nullable restorableObjects){
-              // Do nothing, as we don't support the app calling this block
-          }];
+          restorationHandler:^(NSArray * _Nullable restorableObjects) {
+      // Do nothing, as we don't support the app calling this block
+    }];
 
   } else if ([appDelegate respondsToSelector:openURLWithOptionsSelector]) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability"
     [appDelegate application:application openURL:url options:@{}];
 #pragma clang diagnostic pop
-    // Similarly, |application:openURL:sourceApplication:annotation:| will also always be called,
-    // due to the default swizzling done by FIRAAppDelegateProxy in Firebase Analytics
+  // Similarly, |application:openURL:sourceApplication:annotation:| will also always be called, due
+  // to the default swizzling done by FIRAAppDelegateProxy in Firebase Analytics
   } else if ([appDelegate respondsToSelector:openURLWithSourceApplicationSelector]) {
 #if TARGET_OS_IOS
 #pragma clang diagnostic push
@@ -498,6 +499,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
     [appDelegate application:application handleOpenURL:url];
 #pragma clang diagnostic pop
 #endif
+
   }
 #endif
 }
@@ -610,8 +612,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
                            @"APNS device token not set before retrieving FCM Token for Sender ID "
                            @"'%@'. Notifications to this FCM Token will not be delivered over APNS."
                            @"Be sure to re-retrieve the FCM token once the APNS device token is "
-                           @"set.",
-                           senderID);
+                           @"set.", senderID);
   }
   [self.instanceID tokenWithAuthorizedEntity:senderID
                                        scope:kFIRMessagingDefaultTokenScope
@@ -649,14 +650,13 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 // NOTE: Once |didReceiveRegistrationToken:| can be made a required method, this
 // check can be removed.
 - (void)validateDelegateConformsToTokenAvailabilityMethods {
-  if (self.delegate && ![self.delegate respondsToSelector:@selector(messaging:
-                                                              didReceiveRegistrationToken:)]) {
+  if (self.delegate &&
+      ![self.delegate respondsToSelector:@selector(messaging:didReceiveRegistrationToken:)]) {
     FIRMessagingLoggerWarn(kFIRMessagingMessageCodeTokenDelegateMethodsNotImplemented,
                            @"The object %@ does not respond to "
                            @"-messaging:didReceiveRegistrationToken:. Please implement "
                            @"-messaging:didReceiveRegistrationToken: to be provided with an FCM "
-                           @"token.",
-                           self.delegate.description);
+                           @"token.", self.delegate.description);
   }
 }
 
@@ -697,7 +697,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 
 - (BOOL)shouldBeConnectedAutomatically {
 #if TARGET_OS_OSX
-  return NO;
+    return NO;
 #else
   // We require a token from Instance ID
   NSString *token = self.defaultFcmToken;
@@ -707,7 +707,8 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
     return NO;
   }
   UIApplicationState applicationState = application.applicationState;
-  BOOL shouldBeConnected = _shouldEstablishDirectChannel && (token.length > 0) &&
+  BOOL shouldBeConnected = _shouldEstablishDirectChannel &&
+                           (token.length > 0) &&
                            applicationState == UIApplicationStateActive;
   return shouldBeConnected;
 #endif
@@ -789,7 +790,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
       return;
     }
     FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging009,
-                            @"Cannot parse topic name %@. Will not subscribe.", topic);
+                          @"Cannot parse topic name %@. Will not subscribe.", topic);
     if (completion) {
       completion([NSError fcm_errorWithCode:FIRMessagingErrorInvalidTopicName userInfo:nil]);
     }
@@ -827,7 +828,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
       return;
     }
     FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging011,
-                            @"Cannot parse topic name %@. Will not unsubscribe.", topic);
+			  @"Cannot parse topic name %@. Will not unsubscribe.", topic);
     if (completion) {
       completion([NSError fcm_errorWithCode:FIRMessagingErrorInvalidTopicName userInfo:nil]);
     }
@@ -841,20 +842,20 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
       withMessageID:(NSString *)messageID
          timeToLive:(int64_t)ttl {
   NSMutableDictionary *fcmMessage = [[self class] createFIRMessagingMessageWithMessage:message
-                                                                                    to:to
-                                                                                withID:messageID
-                                                                            timeToLive:ttl
-                                                                                 delay:0];
-  FIRMessagingLoggerInfo(kFIRMessagingMessageCodeMessaging013,
-                         @"Sending message: %@ with id: %@ to %@.", message, messageID, to);
+                                                                           to:to
+                                                                       withID:messageID
+                                                                   timeToLive:ttl
+                                                                        delay:0];
+  FIRMessagingLoggerInfo(kFIRMessagingMessageCodeMessaging013, @"Sending message: %@ with id: %@ to %@.",
+                         message, messageID, to);
   [self.dataMessageManager sendDataMessageStanza:fcmMessage];
 }
 
 + (NSMutableDictionary *)createFIRMessagingMessageWithMessage:(NSDictionary *)message
-                                                           to:(NSString *)to
-                                                       withID:(NSString *)msgID
-                                                   timeToLive:(int64_t)ttl
-                                                        delay:(int)delay {
+                                                  to:(NSString *)to
+                                              withID:(NSString *)msgID
+                                          timeToLive:(int64_t)ttl
+                                               delay:(int)delay {
   NSMutableDictionary *fcmMessage = [NSMutableDictionary dictionary];
   fcmMessage[kFIRMessagingSendTo] = [to copy];
   fcmMessage[kFIRMessagingSendMessageID] = msgID ? [msgID copy] : @"";
@@ -878,7 +879,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 #pragma mark - FIRMessagingReceiverDelegate
 
 - (void)receiver:(FIRMessagingReceiver *)receiver
-    receivedRemoteMessage:(FIRMessagingRemoteMessage *)remoteMessage {
+      receivedRemoteMessage:(FIRMessagingRemoteMessage *)remoteMessage {
   if ([self.delegate respondsToSelector:@selector(messaging:didReceiveMessage:)]) {
     [self appDidReceiveMessage:remoteMessage.appData];
 #pragma clang diagnostic push
@@ -981,10 +982,10 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 }
 
 + (NSString *)pathForSubDirectory:(NSString *)subDirectoryName {
-  NSArray *directoryPaths =
-      NSSearchPathForDirectoriesInDomains(FIRMessagingSupportedDirectory(), NSUserDomainMask, YES);
+  NSArray *directoryPaths = NSSearchPathForDirectoriesInDomains(FIRMessagingSupportedDirectory(),
+                                                                NSUserDomainMask, YES);
   NSString *dirPath = directoryPaths.lastObject;
-  NSArray *components = @[ dirPath, subDirectoryName ];
+  NSArray *components = @[dirPath, subDirectoryName];
   return [NSString pathWithComponents:components];
 }
 
@@ -1019,8 +1020,8 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 + (NSString *)currentLocale {
   NSArray *locales = [self firebaseLocales];
   NSArray *preferredLocalizations =
-      [NSBundle preferredLocalizationsFromArray:locales
-                                 forPreferences:[NSLocale preferredLanguages]];
+    [NSBundle preferredLocalizationsFromArray:locales
+                               forPreferences:[NSLocale preferredLanguages]];
   NSString *legalDocsLanguage = [preferredLocalizations firstObject];
   // Use en as the default language
   return legalDocsLanguage ? legalDocsLanguage : @"en";
@@ -1101,9 +1102,27 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
     // language).
     // Arabic
     @"ar" : @[
-      @"ar",    @"ar_DZ", @"ar_BH", @"ar_EG", @"ar_IQ", @"ar_JO", @"ar_KW",
-      @"ar_LB", @"ar_LY", @"ar_MA", @"ar_OM", @"ar_QA", @"ar_SA", @"ar_SD",
-      @"ar_SY", @"ar_TN", @"ar_AE", @"ar_YE", @"ar_GB", @"ar-IQ", @"ar_US"
+      @"ar",
+      @"ar_DZ",
+      @"ar_BH",
+      @"ar_EG",
+      @"ar_IQ",
+      @"ar_JO",
+      @"ar_KW",
+      @"ar_LB",
+      @"ar_LY",
+      @"ar_MA",
+      @"ar_OM",
+      @"ar_QA",
+      @"ar_SA",
+      @"ar_SD",
+      @"ar_SY",
+      @"ar_TN",
+      @"ar_AE",
+      @"ar_YE",
+      @"ar_GB",
+      @"ar-IQ",
+      @"ar_US"
     ],
     // Simplified Chinese
     @"zh_Hans" : @[ @"zh_CN", @"zh_SG", @"zh-Hans" ],
@@ -1113,15 +1132,50 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
     @"nl" : @[ @"nl", @"nl_BE", @"nl_NL", @"nl-NL" ],
     // English
     @"en" : @[
-      @"en",    @"en_AU", @"en_CA", @"en_IN", @"en_IE", @"en_MT", @"en_NZ", @"en_PH",
-      @"en_SG", @"en_ZA", @"en_GB", @"en_US", @"en_AE", @"en-AE", @"en_AS", @"en-AU",
-      @"en_BD", @"en-CA", @"en_EG", @"en_ES", @"en_GB", @"en-GB", @"en_HK", @"en_ID",
-      @"en-IN", @"en_NG", @"en-PH", @"en_PK", @"en-SG", @"en-US"
+      @"en",
+      @"en_AU",
+      @"en_CA",
+      @"en_IN",
+      @"en_IE",
+      @"en_MT",
+      @"en_NZ",
+      @"en_PH",
+      @"en_SG",
+      @"en_ZA",
+      @"en_GB",
+      @"en_US",
+      @"en_AE",
+      @"en-AE",
+      @"en_AS",
+      @"en-AU",
+      @"en_BD",
+      @"en-CA",
+      @"en_EG",
+      @"en_ES",
+      @"en_GB",
+      @"en-GB",
+      @"en_HK",
+      @"en_ID",
+      @"en-IN",
+      @"en_NG",
+      @"en-PH",
+      @"en_PK",
+      @"en-SG",
+      @"en-US"
     ],
     // French
 
-    @"fr" :
-        @[ @"fr", @"fr_BE", @"fr_CA", @"fr_FR", @"fr_LU", @"fr_CH", @"fr-CA", @"fr-FR", @"fr_MA" ],
+    @"fr" : @[
+      @"fr",
+      @"fr_BE",
+      @"fr_CA",
+      @"fr_FR",
+      @"fr_LU",
+      @"fr_CH",
+      @"fr-CA",
+      @"fr-FR",
+      @"fr_MA"
+    ],
     // German
     @"de" : @[ @"de", @"de_AT", @"de_DE", @"de_LU", @"de_CH", @"de-DE" ],
     // Greek
@@ -1137,16 +1191,40 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
     // European Portuguese
     @"pt_PT" : @[ @"pt", @"pt_PT", @"pt-PT" ],
     // Serbian
-    @"sr" : @[ @"sr_BA", @"sr_ME", @"sr_RS", @"sr_Latn_BA", @"sr_Latn_ME", @"sr_Latn_RS" ],
+    @"sr" : @[
+      @"sr_BA",
+      @"sr_ME",
+      @"sr_RS",
+      @"sr_Latn_BA",
+      @"sr_Latn_ME",
+      @"sr_Latn_RS"
+    ],
     // European Spanish
     @"es_ES" : @[ @"es", @"es_ES", @"es-ES" ],
     // Mexican Spanish
     @"es_MX" : @[ @"es-MX", @"es_MX", @"es_US", @"es-US" ],
     // Latin American Spanish
     @"es_419" : @[
-      @"es_AR", @"es_BO", @"es_CL", @"es_CO", @"es_CR", @"es_DO", @"es_EC",
-      @"es_SV", @"es_GT", @"es_HN", @"es_NI", @"es_PA", @"es_PY", @"es_PE",
-      @"es_PR", @"es_UY", @"es_VE", @"es-AR", @"es-CL", @"es-CO"
+      @"es_AR",
+      @"es_BO",
+      @"es_CL",
+      @"es_CO",
+      @"es_CR",
+      @"es_DO",
+      @"es_EC",
+      @"es_SV",
+      @"es_GT",
+      @"es_HN",
+      @"es_NI",
+      @"es_PA",
+      @"es_PY",
+      @"es_PE",
+      @"es_PR",
+      @"es_UY",
+      @"es_VE",
+      @"es-AR",
+      @"es-CL",
+      @"es-CO"
     ],
     // Thai
     @"th" : @[ @"th", @"th_TH", @"th_TH_TH" ],

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if  !__has_feature(objc_arc)
+#if !__has_feature(objc_arc)
 #error FIRMessagingLib should be compiled with ARC.
 #endif
 
@@ -24,13 +24,13 @@
 #import <FirebaseCore/FIRComponentContainer.h>
 #import <FirebaseCore/FIRDependency.h>
 #import <FirebaseCore/FIRLibrary.h>
-#import <FirebaseInstanceID/FirebaseInstanceID.h>
 #import <FirebaseInstanceID/FIRInstanceID_Private.h>
+#import <FirebaseInstanceID/FirebaseInstanceID.h>
 #import <FirebaseMessaging/FIRMessaging.h>
 #import <FirebaseMessaging/FIRMessagingExtensionHelper.h>
+#import <GoogleUtilities/GULAppDelegateSwizzler.h>
 #import <GoogleUtilities/GULReachabilityChecker.h>
 #import <GoogleUtilities/GULUserDefaults.h>
-#import <GoogleUtilities/GULAppDelegateSwizzler.h>
 
 #import "Firebase/Messaging/FIRMessagingAnalytics.h"
 #import "Firebase/Messaging/FIRMessagingClient.h"
@@ -66,22 +66,21 @@ const NSNotificationName FIRMessagingConnectionStateChangedNotification =
 const NSNotificationName FIRMessagingRegistrationTokenRefreshedNotification =
     @"com.firebase.messaging.notif.fcm-token-refreshed";
 #else
-NSString *const FIRMessagingSendSuccessNotification =
-    @"com.firebase.messaging.notif.send-success";
-NSString *const FIRMessagingSendErrorNotification =
-    @"com.firebase.messaging.notif.send-error";
-NSString * const FIRMessagingMessagesDeletedNotification =
+NSString *const FIRMessagingSendSuccessNotification = @"com.firebase.messaging.notif.send-success";
+NSString *const FIRMessagingSendErrorNotification = @"com.firebase.messaging.notif.send-error";
+NSString *const FIRMessagingMessagesDeletedNotification =
     @"com.firebase.messaging.notif.messages-deleted";
-NSString * const FIRMessagingConnectionStateChangedNotification =
+NSString *const FIRMessagingConnectionStateChangedNotification =
     @"com.firebase.messaging.notif.connection-state-changed";
-NSString * const FIRMessagingRegistrationTokenRefreshedNotification =
+NSString *const FIRMessagingRegistrationTokenRefreshedNotification =
     @"com.firebase.messaging.notif.fcm-token-refreshed";
 #endif  // defined(__IPHONE_10_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0
 
 NSString *const kFIRMessagingUserDefaultsKeyAutoInitEnabled =
     @"com.firebase.messaging.auto-init.enabled";  // Auto Init Enabled key stored in NSUserDefaults
 
-NSString *const kFIRMessagingAPNSTokenType = @"APNSTokenType"; // APNS Token type key stored in user info.
+NSString *const kFIRMessagingAPNSTokenType =
+    @"APNSTokenType";  // APNS Token type key stored in user info.
 
 NSString *const kFIRMessagingPlistAutoInitEnabled =
     @"FirebaseMessagingAutoInitEnabled";  // Auto Init Enabled key stored in Info.plist
@@ -96,7 +95,7 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
   return NO;
 }
 
- BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
+BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   return [FIRMessagingContextManagerService isContextManagerMessage:message];
 }
 
@@ -136,8 +135,9 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
 
 @end
 
-@interface FIRMessaging ()<FIRMessagingClientDelegate, FIRMessagingReceiverDelegate,
-                           GULReachabilityDelegate>
+@interface FIRMessaging () <FIRMessagingClientDelegate,
+                            FIRMessagingReceiverDelegate,
+                            GULReachabilityDelegate>
 
 // FIRApp properties
 @property(nonatomic, readwrite, strong) NSData *apnsTokenData;
@@ -185,12 +185,12 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
 }
 
 + (FIRMessagingExtensionHelper *)extensionHelper {
-    static dispatch_once_t once;
-    static FIRMessagingExtensionHelper *extensionHelper;
-    dispatch_once(&once, ^{
-        extensionHelper = [[FIRMessagingExtensionHelper alloc] init];
-    });
-    return extensionHelper;
+  static dispatch_once_t once;
+  static FIRMessagingExtensionHelper *extensionHelper;
+  dispatch_once(&once, ^{
+    extensionHelper = [[FIRMessagingExtensionHelper alloc] init];
+  });
+  return extensionHelper;
 }
 
 - (instancetype)initWithAnalytics:(nullable id<FIRAnalyticsInterop>)analytics
@@ -216,13 +216,13 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
 
 + (void)load {
   [FIRApp registerInternalLibrary:(Class<FIRLibrary>)self
-                 withName:@"fire-fcm"
-              withVersion:FIRMessagingCurrentLibraryVersion()];
+                         withName:@"fire-fcm"
+                      withVersion:FIRMessagingCurrentLibraryVersion()];
 }
 
 + (nonnull NSArray<FIRComponent *> *)componentsToRegister {
-  FIRDependency *analyticsDep =
-      [FIRDependency dependencyWithProtocol:@protocol(FIRAnalyticsInterop) isRequired:NO];
+  FIRDependency *analyticsDep = [FIRDependency dependencyWithProtocol:@protocol(FIRAnalyticsInterop)
+                                                           isRequired:NO];
   FIRComponentCreationBlock creationBlock =
       ^id _Nullable(FIRComponentContainer *container, BOOL *isCacheable) {
     // Ensure it's cached so it returns the same instance every time messaging is called.
@@ -239,7 +239,7 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
       [FIRComponent componentWithProtocol:@protocol(FIRMessagingInstanceProvider)
                       instantiationTiming:FIRInstantiationTimingLazy
                              dependencies:@[ analyticsDep ]
-                           creationBlock:creationBlock];
+                            creationBlock:creationBlock];
 
   return @[ messagingProvider ];
 }
@@ -275,8 +275,7 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
   // Print the library version for logging.
   NSString *currentLibraryVersion = FIRMessagingCurrentLibraryVersion();
   FIRMessagingLoggerInfo(kFIRMessagingMessageCodeMessagingPrintLibraryVersion,
-                         @"FIRMessaging library version %@",
-                         currentLibraryVersion);
+                         @"FIRMessaging library version %@", currentLibraryVersion);
 
   [self setupReceiver];
 
@@ -316,7 +315,7 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
              selector:@selector(defaultInstanceIDTokenWasRefreshed:)
                  name:kFIRMessagingRegistrationTokenRefreshNotification
                object:nil];
-#if TARGET_OS_IOS ||TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV
   [center addObserver:self
              selector:@selector(applicationStateChanged)
                  name:UIApplicationDidBecomeActiveNotification
@@ -357,7 +356,8 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
 
 - (void)setupTopics {
   if (!self.client) {
-     FIRMessagingLoggerWarn(kFIRMessagingMessageCodeInvalidClient, @"Invalid nil client before init pubsub.");
+    FIRMessagingLoggerWarn(kFIRMessagingMessageCodeInvalidClient,
+                           @"Invalid nil client before init pubsub.");
   }
   self.pubsub = [[FIRMessagingPubSub alloc] initWithClient:self.client];
 }
@@ -412,7 +412,7 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
     // We need to rule out the contextual message because it shares the same message ID
     // as the local notification it will schedule. And because it is also a APNSSync message
     // its duplication is already checked previously.
-   if (!isOldMessage && !FIRMessagingIsContextManagerMessage(message)) {
+    if (!isOldMessage && !FIRMessagingIsContextManagerMessage(message)) {
       isOldMessage = [self.loggedMessageIDs containsObject:messageID];
       if (!isOldMessage) {
         [self.loggedMessageIDs addObject:messageID];
@@ -444,7 +444,6 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
   if (![NSThread isMainThread]) {
     dispatch_async(dispatch_get_main_queue(), ^{
       [self handleIncomingLinkIfNeededFromMessage:message];
-
     });
     return;
   }
@@ -453,12 +452,12 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
     return;
   }
   id<UIApplicationDelegate> appDelegate = application.delegate;
-  SEL continueUserActivitySelector =
-      @selector(application:continueUserActivity:restorationHandler:);
+  SEL continueUserActivitySelector = @selector(application:
+                                      continueUserActivity:restorationHandler:);
 
   SEL openURLWithOptionsSelector = @selector(application:openURL:options:);
-  SEL openURLWithSourceApplicationSelector =
-      @selector(application:openURL:sourceApplication:annotation:);
+  SEL openURLWithSourceApplicationSelector = @selector(application:
+                                                           openURL:sourceApplication:annotation:);
 #if TARGET_OS_IOS
   SEL handleOpenURLSelector = @selector(application:handleOpenURL:);
 #endif
@@ -473,17 +472,17 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
     userActivity.webpageURL = url;
     [appDelegate application:application
         continueUserActivity:userActivity
-          restorationHandler:^(NSArray * _Nullable restorableObjects) {
-      // Do nothing, as we don't support the app calling this block
-    }];
+          restorationHandler:^(NSArray *_Nullable restorableObjects){
+              // Do nothing, as we don't support the app calling this block
+          }];
 
   } else if ([appDelegate respondsToSelector:openURLWithOptionsSelector]) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability"
     [appDelegate application:application openURL:url options:@{}];
 #pragma clang diagnostic pop
-  // Similarly, |application:openURL:sourceApplication:annotation:| will also always be called, due
-  // to the default swizzling done by FIRAAppDelegateProxy in Firebase Analytics
+    // Similarly, |application:openURL:sourceApplication:annotation:| will also always be called,
+    // due to the default swizzling done by FIRAAppDelegateProxy in Firebase Analytics
   } else if ([appDelegate respondsToSelector:openURLWithSourceApplicationSelector]) {
 #if TARGET_OS_IOS
 #pragma clang diagnostic push
@@ -499,7 +498,6 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
     [appDelegate application:application handleOpenURL:url];
 #pragma clang diagnostic pop
 #endif
-
   }
 #endif
 }
@@ -541,9 +539,20 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
 #pragma mark - FCM
 
 - (BOOL)isAutoInitEnabled {
+  // Defer to the class method since we're just reading from regular userDefaults and we need to
+  // read this from IID without instantiating the Messaging singleton.
+  return [[self class] isAutoInitEnabledWithUserDefaults:_messagingUserDefaults];
+}
+
+/// Checks if Messaging auto-init is enabled in the user defaults instance passed in. This is
+/// exposed as a class property for IID to fetch the property without instantiating an instance of
+/// Messaging. Since Messaging can only be used with the default FIRApp, we can have one point of
+/// entry without context of which FIRApp instance is being used.
+/// ** THIS METHOD IS DEPENDED ON INTERNALLY BY IID. PLEASE DO NOT CHANGE THE SIGNATURE. **
++ (BOOL)isAutoInitEnabledWithUserDefaults:(GULUserDefaults *)userDefaults {
   // Check storage
   id isAutoInitEnabledObject =
-      [_messagingUserDefaults objectForKey:kFIRMessagingUserDefaultsKeyAutoInitEnabled];
+      [userDefaults objectForKey:kFIRMessagingUserDefaultsKeyAutoInitEnabled];
   if (isAutoInitEnabledObject) {
     return [isAutoInitEnabledObject boolValue];
   }
@@ -601,7 +610,8 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
                            @"APNS device token not set before retrieving FCM Token for Sender ID "
                            @"'%@'. Notifications to this FCM Token will not be delivered over APNS."
                            @"Be sure to re-retrieve the FCM token once the APNS device token is "
-                           @"set.", senderID);
+                           @"set.",
+                           senderID);
   }
   [self.instanceID tokenWithAuthorizedEntity:senderID
                                        scope:kFIRMessagingDefaultTokenScope
@@ -639,13 +649,14 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
 // NOTE: Once |didReceiveRegistrationToken:| can be made a required method, this
 // check can be removed.
 - (void)validateDelegateConformsToTokenAvailabilityMethods {
-  if (self.delegate &&
-      ![self.delegate respondsToSelector:@selector(messaging:didReceiveRegistrationToken:)]) {
+  if (self.delegate && ![self.delegate respondsToSelector:@selector(messaging:
+                                                              didReceiveRegistrationToken:)]) {
     FIRMessagingLoggerWarn(kFIRMessagingMessageCodeTokenDelegateMethodsNotImplemented,
                            @"The object %@ does not respond to "
                            @"-messaging:didReceiveRegistrationToken:. Please implement "
                            @"-messaging:didReceiveRegistrationToken: to be provided with an FCM "
-                           @"token.", self.delegate.description);
+                           @"token.",
+                           self.delegate.description);
   }
 }
 
@@ -686,7 +697,7 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
 
 - (BOOL)shouldBeConnectedAutomatically {
 #if TARGET_OS_OSX
-    return NO;
+  return NO;
 #else
   // We require a token from Instance ID
   NSString *token = self.defaultFcmToken;
@@ -696,8 +707,7 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
     return NO;
   }
   UIApplicationState applicationState = application.applicationState;
-  BOOL shouldBeConnected = _shouldEstablishDirectChannel &&
-                           (token.length > 0) &&
+  BOOL shouldBeConnected = _shouldEstablishDirectChannel && (token.length > 0) &&
                            applicationState == UIApplicationStateActive;
   return shouldBeConnected;
 #endif
@@ -779,7 +789,7 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
       return;
     }
     FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging009,
-                          @"Cannot parse topic name %@. Will not subscribe.", topic);
+                            @"Cannot parse topic name %@. Will not subscribe.", topic);
     if (completion) {
       completion([NSError fcm_errorWithCode:FIRMessagingErrorInvalidTopicName userInfo:nil]);
     }
@@ -817,7 +827,7 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
       return;
     }
     FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging011,
-			  @"Cannot parse topic name %@. Will not unsubscribe.", topic);
+                            @"Cannot parse topic name %@. Will not unsubscribe.", topic);
     if (completion) {
       completion([NSError fcm_errorWithCode:FIRMessagingErrorInvalidTopicName userInfo:nil]);
     }
@@ -831,20 +841,20 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
       withMessageID:(NSString *)messageID
          timeToLive:(int64_t)ttl {
   NSMutableDictionary *fcmMessage = [[self class] createFIRMessagingMessageWithMessage:message
-                                                                           to:to
-                                                                       withID:messageID
-                                                                   timeToLive:ttl
-                                                                        delay:0];
-  FIRMessagingLoggerInfo(kFIRMessagingMessageCodeMessaging013, @"Sending message: %@ with id: %@ to %@.",
-                         message, messageID, to);
+                                                                                    to:to
+                                                                                withID:messageID
+                                                                            timeToLive:ttl
+                                                                                 delay:0];
+  FIRMessagingLoggerInfo(kFIRMessagingMessageCodeMessaging013,
+                         @"Sending message: %@ with id: %@ to %@.", message, messageID, to);
   [self.dataMessageManager sendDataMessageStanza:fcmMessage];
 }
 
 + (NSMutableDictionary *)createFIRMessagingMessageWithMessage:(NSDictionary *)message
-                                                  to:(NSString *)to
-                                              withID:(NSString *)msgID
-                                          timeToLive:(int64_t)ttl
-                                               delay:(int)delay {
+                                                           to:(NSString *)to
+                                                       withID:(NSString *)msgID
+                                                   timeToLive:(int64_t)ttl
+                                                        delay:(int)delay {
   NSMutableDictionary *fcmMessage = [NSMutableDictionary dictionary];
   fcmMessage[kFIRMessagingSendTo] = [to copy];
   fcmMessage[kFIRMessagingSendMessageID] = msgID ? [msgID copy] : @"";
@@ -868,7 +878,7 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
 #pragma mark - FIRMessagingReceiverDelegate
 
 - (void)receiver:(FIRMessagingReceiver *)receiver
-      receivedRemoteMessage:(FIRMessagingRemoteMessage *)remoteMessage {
+    receivedRemoteMessage:(FIRMessagingRemoteMessage *)remoteMessage {
   if ([self.delegate respondsToSelector:@selector(messaging:didReceiveMessage:)]) {
     [self appDidReceiveMessage:remoteMessage.appData];
 #pragma clang diagnostic push
@@ -971,10 +981,10 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
 }
 
 + (NSString *)pathForSubDirectory:(NSString *)subDirectoryName {
-  NSArray *directoryPaths = NSSearchPathForDirectoriesInDomains(FIRMessagingSupportedDirectory(),
-                                                                NSUserDomainMask, YES);
+  NSArray *directoryPaths =
+      NSSearchPathForDirectoriesInDomains(FIRMessagingSupportedDirectory(), NSUserDomainMask, YES);
   NSString *dirPath = directoryPaths.lastObject;
-  NSArray *components = @[dirPath, subDirectoryName];
+  NSArray *components = @[ dirPath, subDirectoryName ];
   return [NSString pathWithComponents:components];
 }
 
@@ -1009,8 +1019,8 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
 + (NSString *)currentLocale {
   NSArray *locales = [self firebaseLocales];
   NSArray *preferredLocalizations =
-    [NSBundle preferredLocalizationsFromArray:locales
-                               forPreferences:[NSLocale preferredLanguages]];
+      [NSBundle preferredLocalizationsFromArray:locales
+                                 forPreferences:[NSLocale preferredLanguages]];
   NSString *legalDocsLanguage = [preferredLocalizations firstObject];
   // Use en as the default language
   return legalDocsLanguage ? legalDocsLanguage : @"en";
@@ -1091,27 +1101,9 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
     // language).
     // Arabic
     @"ar" : @[
-      @"ar",
-      @"ar_DZ",
-      @"ar_BH",
-      @"ar_EG",
-      @"ar_IQ",
-      @"ar_JO",
-      @"ar_KW",
-      @"ar_LB",
-      @"ar_LY",
-      @"ar_MA",
-      @"ar_OM",
-      @"ar_QA",
-      @"ar_SA",
-      @"ar_SD",
-      @"ar_SY",
-      @"ar_TN",
-      @"ar_AE",
-      @"ar_YE",
-      @"ar_GB",
-      @"ar-IQ",
-      @"ar_US"
+      @"ar",    @"ar_DZ", @"ar_BH", @"ar_EG", @"ar_IQ", @"ar_JO", @"ar_KW",
+      @"ar_LB", @"ar_LY", @"ar_MA", @"ar_OM", @"ar_QA", @"ar_SA", @"ar_SD",
+      @"ar_SY", @"ar_TN", @"ar_AE", @"ar_YE", @"ar_GB", @"ar-IQ", @"ar_US"
     ],
     // Simplified Chinese
     @"zh_Hans" : @[ @"zh_CN", @"zh_SG", @"zh-Hans" ],
@@ -1121,50 +1113,15 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
     @"nl" : @[ @"nl", @"nl_BE", @"nl_NL", @"nl-NL" ],
     // English
     @"en" : @[
-      @"en",
-      @"en_AU",
-      @"en_CA",
-      @"en_IN",
-      @"en_IE",
-      @"en_MT",
-      @"en_NZ",
-      @"en_PH",
-      @"en_SG",
-      @"en_ZA",
-      @"en_GB",
-      @"en_US",
-      @"en_AE",
-      @"en-AE",
-      @"en_AS",
-      @"en-AU",
-      @"en_BD",
-      @"en-CA",
-      @"en_EG",
-      @"en_ES",
-      @"en_GB",
-      @"en-GB",
-      @"en_HK",
-      @"en_ID",
-      @"en-IN",
-      @"en_NG",
-      @"en-PH",
-      @"en_PK",
-      @"en-SG",
-      @"en-US"
+      @"en",    @"en_AU", @"en_CA", @"en_IN", @"en_IE", @"en_MT", @"en_NZ", @"en_PH",
+      @"en_SG", @"en_ZA", @"en_GB", @"en_US", @"en_AE", @"en-AE", @"en_AS", @"en-AU",
+      @"en_BD", @"en-CA", @"en_EG", @"en_ES", @"en_GB", @"en-GB", @"en_HK", @"en_ID",
+      @"en-IN", @"en_NG", @"en-PH", @"en_PK", @"en-SG", @"en-US"
     ],
     // French
 
-    @"fr" : @[
-      @"fr",
-      @"fr_BE",
-      @"fr_CA",
-      @"fr_FR",
-      @"fr_LU",
-      @"fr_CH",
-      @"fr-CA",
-      @"fr-FR",
-      @"fr_MA"
-    ],
+    @"fr" :
+        @[ @"fr", @"fr_BE", @"fr_CA", @"fr_FR", @"fr_LU", @"fr_CH", @"fr-CA", @"fr-FR", @"fr_MA" ],
     // German
     @"de" : @[ @"de", @"de_AT", @"de_DE", @"de_LU", @"de_CH", @"de-DE" ],
     // Greek
@@ -1180,40 +1137,16 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
     // European Portuguese
     @"pt_PT" : @[ @"pt", @"pt_PT", @"pt-PT" ],
     // Serbian
-    @"sr" : @[
-      @"sr_BA",
-      @"sr_ME",
-      @"sr_RS",
-      @"sr_Latn_BA",
-      @"sr_Latn_ME",
-      @"sr_Latn_RS"
-    ],
+    @"sr" : @[ @"sr_BA", @"sr_ME", @"sr_RS", @"sr_Latn_BA", @"sr_Latn_ME", @"sr_Latn_RS" ],
     // European Spanish
     @"es_ES" : @[ @"es", @"es_ES", @"es-ES" ],
     // Mexican Spanish
     @"es_MX" : @[ @"es-MX", @"es_MX", @"es_US", @"es-US" ],
     // Latin American Spanish
     @"es_419" : @[
-      @"es_AR",
-      @"es_BO",
-      @"es_CL",
-      @"es_CO",
-      @"es_CR",
-      @"es_DO",
-      @"es_EC",
-      @"es_SV",
-      @"es_GT",
-      @"es_HN",
-      @"es_NI",
-      @"es_PA",
-      @"es_PY",
-      @"es_PE",
-      @"es_PR",
-      @"es_UY",
-      @"es_VE",
-      @"es-AR",
-      @"es-CL",
-      @"es-CO"
+      @"es_AR", @"es_BO", @"es_CL", @"es_CO", @"es_CR", @"es_DO", @"es_EC",
+      @"es_SV", @"es_GT", @"es_HN", @"es_NI", @"es_PA", @"es_PY", @"es_PE",
+      @"es_PR", @"es_UY", @"es_VE", @"es-AR", @"es-CL", @"es-CO"
     ],
     // Thai
     @"th" : @[ @"th", @"th_TH", @"th_TH_TH" ],

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -550,7 +550,8 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
 /// exposed as a class property for IID to fetch the property without instantiating an instance of
 /// Messaging. Since Messaging can only be used with the default FIRApp, we can have one point of
 /// entry without context of which FIRApp instance is being used.
-/// ** THIS METHOD IS DEPENDED ON INTERNALLY BY IID. PLEASE DO NOT CHANGE THE SIGNATURE. **
+/// ** THIS METHOD IS DEPENDED ON INTERNALLY BY IID USING REFLECTION. PLEASE DO NOT CHANGE THE
+///  SIGNATURE, AS IT WOULD BREAK AUTOINIT FUNCTIONALITY WITHIN IID. **
 + (BOOL)isAutoInitEnabledWithUserDefaults:(GULUserDefaults *)userDefaults {
   // Check storage
   id isAutoInitEnabledObject =


### PR DESCRIPTION
The container instantiation could happen at the wrong time, before all
components have been added to the container. This fixes it, and also
moves IID to use the proper instantiation timing instead of relying on
the `configureWithApp:` call. This is part continuation of #3147, where
I'll be fixing the rest of the SDKs in follow up PRs.

Edit: Further work...

This moves the instantiation of components to after the FirebaseApp is
completely configured and assigned, as it should be. This also exposed
a recursive issue with IID calling the Messaging singleton, which in
turn called IID and instantiated multiple instances.

A change was made to break the cycle: the Messaging `isAutoInitEnabled`
call was changed to a static method vs an instance method, allowing IID
to call it during initialization without instantiating the Messaging
instance (since it doesn't have a direct dependency on it).