### PR TITLE
FIS: stored registration error timeout

### DIFF
--- a/FirebaseInstallations/Source/Library/FIRInstallationsItem.h
+++ b/FirebaseInstallations/Source/Library/FIRInstallationsItem.h
@@ -84,9 +84,11 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Updates `registrationStatus` and `registrationError` accordingly.
  * @param error The error for the Installation Registration API request.
+ * @param date The date when the error occurred.
  * @param registrationParameters The parameters used for the  Installation Registration API request.
  */
 - (void)updateWithRegistrationError:(NSError *)error
+                               date:(NSDate *)date
              registrationParameters:
                  (FIRInstallationsStoredRegistrationParameters *)registrationParameters;
 

--- a/FirebaseInstallations/Source/Library/FIRInstallationsItem.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallationsItem.m
@@ -103,11 +103,13 @@
 }
 
 - (void)updateWithRegistrationError:(NSError *)error
+                               date:(NSDate *)date
              registrationParameters:
                  (FIRInstallationsStoredRegistrationParameters *)registrationParameters {
   self.registrationStatus = FIRInstallationStatusRegistrationFailed;
   self.registrationError = [[FIRInstallationsStoredRegistrationError alloc]
       initWithRegistrationParameters:registrationParameters
+                            date:date
                             APIError:error];
   self.authToken = nil;
   self.refreshToken = nil;

--- a/FirebaseInstallations/Source/Library/FIRInstallationsItem.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallationsItem.m
@@ -109,7 +109,7 @@
   self.registrationStatus = FIRInstallationStatusRegistrationFailed;
   self.registrationError = [[FIRInstallationsStoredRegistrationError alloc]
       initWithRegistrationParameters:registrationParameters
-                            date:date
+                                date:date
                             APIError:error];
   self.authToken = nil;
   self.refreshToken = nil;

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -45,7 +45,7 @@ NSString *const kFIRInstallationIDDidChangeNotificationAppNameKey =
 
 NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 hour.
 
-NSTimeInterval const kFIRInstallationsRegistrationErrorTimeout = 24 * 60 * 60; // 1 day.
+NSTimeInterval const kFIRInstallationsRegistrationErrorTimeout = 24 * 60 * 60;  // 1 day.
 
 @interface FIRInstallationsIDController ()
 @property(nonatomic, readonly) NSString *appID;
@@ -231,7 +231,7 @@ NSTimeInterval const kFIRInstallationsRegistrationErrorTimeout = 24 * 60 * 60; /
 
 - (BOOL)isRegistrationErrorWithDateUpToDate:(NSDate *)errorDate {
   return errorDate != nil &&
-      -[errorDate timeIntervalSinceNow] <= kFIRInstallationsRegistrationErrorTimeout;
+         -[errorDate timeIntervalSinceNow] <= kFIRInstallationsRegistrationErrorTimeout;
 }
 
 #pragma mark - FID registration

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -274,6 +274,7 @@ NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 
 
     FIRInstallationsItem *failedInstallation = [installation copy];
     [failedInstallation updateWithRegistrationError:error
+                                               date:[NSDate date]
                              registrationParameters:[self currentRegistrationParameters]];
 
     // Save the error and then fail with the API error.

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -45,6 +45,8 @@ NSString *const kFIRInstallationIDDidChangeNotificationAppNameKey =
 
 NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 hour.
 
+NSTimeInterval const kFIRInstallationsRegistrationErrorTimeout = 24 * 60 * 60; // 1 day.
+
 @interface FIRInstallationsIDController ()
 @property(nonatomic, readonly) NSString *appID;
 @property(nonatomic, readonly) NSString *appName;
@@ -147,6 +149,7 @@ NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 
             // Validate if a previous registration attempt failed with an error requiring Firebase
             // configuration changes.
             if (installation.registrationStatus == FIRInstallationStatusRegistrationFailed &&
+                [self isRegistrationErrorWithDateUpToDate:installation.registrationError.date] &&
                 [self areInstallationRegistrationParametersEqualToCurrent:
                           installation.registrationError.registrationParameters]) {
               return installation.registrationError.APIError;
@@ -224,6 +227,11 @@ NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 
   NSString *projectID = self.APIService.projectID;
   return (parameters.APIKey == APIKey || [parameters.APIKey isEqual:APIKey]) &&
          (parameters.projectID == projectID || [parameters.projectID isEqual:projectID]);
+}
+
+- (BOOL)isRegistrationErrorWithDateUpToDate:(NSDate *)errorDate {
+  return errorDate != nil &&
+      -[errorDate timeIntervalSinceNow] <= kFIRInstallationsRegistrationErrorTimeout;
 }
 
 #pragma mark - FID registration

--- a/FirebaseInstallations/Source/Library/InstallationsStore/FIRInstallationsStoredRegistrationError.h
+++ b/FirebaseInstallations/Source/Library/InstallationsStore/FIRInstallationsStoredRegistrationError.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FIRInstallationsStoredRegistrationError : NSObject <NSSecureCoding>
 
 @property(nonatomic, readonly) FIRInstallationsStoredRegistrationParameters *registrationParameters;
+@property(nonatomic, readonly) NSDate *date;
 @property(nonatomic, readonly) NSError *APIError;
 
 /// The version of local storage.
@@ -40,6 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithRegistrationParameters:
                     (FIRInstallationsStoredRegistrationParameters *)registrationParameters
+                                          date:(NSDate *)date
                                       APIError:(NSError *)error;
 
 @end

--- a/FirebaseInstallations/Source/Library/InstallationsStore/FIRInstallationsStoredRegistrationError.m
+++ b/FirebaseInstallations/Source/Library/InstallationsStore/FIRInstallationsStoredRegistrationError.m
@@ -32,9 +32,9 @@ NSInteger const kFIRInstallationsStoredRegistrationErrorStorageVersion = 1;
 @implementation FIRInstallationsStoredRegistrationError
 
 - (instancetype)initWithRegistrationParameters:
-(FIRInstallationsStoredRegistrationParameters *)registrationParameters
-                      date:(NSDate *)date
-                  APIError:(NSError *)error {
+                    (FIRInstallationsStoredRegistrationParameters *)registrationParameters
+                                          date:(NSDate *)date
+                                      APIError:(NSError *)error {
   self = [super init];
   if (self) {
     _registrationParameters = registrationParameters;
@@ -77,7 +77,8 @@ NSInteger const kFIRInstallationsStoredRegistrationErrorStorageVersion = 1;
   FIRInstallationsStoredRegistrationParameters *registrationParameters =
       [coder decodeObjectOfClass:[FIRInstallationsStoredRegistrationParameters class]
                           forKey:kFIRInstallationsStoredRegistrationErrorRegistrationParametersKey];
-  NSDate *date = [coder decodeObjectOfClass:[NSDate class] forKey:kFIRInstallationsStoredRegistrationErrorDateKey];
+  NSDate *date = [coder decodeObjectOfClass:[NSDate class]
+                                     forKey:kFIRInstallationsStoredRegistrationErrorDateKey];
 
   NSSet<Class> *allowedErrorClasses =
       [NSSet setWithArray:@ [[FIRInstallationsHTTPError class], [NSError class]]];

--- a/FirebaseInstallations/Source/Library/InstallationsStore/FIRInstallationsStoredRegistrationError.m
+++ b/FirebaseInstallations/Source/Library/InstallationsStore/FIRInstallationsStoredRegistrationError.m
@@ -25,17 +25,20 @@ NSString *const kFIRInstallationsStoredRegistrationErrorRegistrationParametersKe
     @"registrationParameters";
 NSString *const kFIRInstallationsStoredRegistrationErrorAPIErrorKey = @"APIError";
 NSString *const kFIRInstallationsStoredRegistrationErrorStorageVersionKey = @"storageVersion";
+NSString *const kFIRInstallationsStoredRegistrationErrorDateKey = @"date";
 
 NSInteger const kFIRInstallationsStoredRegistrationErrorStorageVersion = 1;
 
 @implementation FIRInstallationsStoredRegistrationError
 
 - (instancetype)initWithRegistrationParameters:
-                    (FIRInstallationsStoredRegistrationParameters *)registrationParameters
-                                      APIError:(NSError *)error {
+(FIRInstallationsStoredRegistrationParameters *)registrationParameters
+                      date:(NSDate *)date
+                  APIError:(NSError *)error {
   self = [super init];
   if (self) {
     _registrationParameters = registrationParameters;
+    _date = date;
     _APIError = error;
   }
   return self;
@@ -54,6 +57,7 @@ NSInteger const kFIRInstallationsStoredRegistrationErrorStorageVersion = 1;
 - (void)encodeWithCoder:(nonnull NSCoder *)coder {
   [coder encodeObject:self.registrationParameters
                forKey:kFIRInstallationsStoredRegistrationErrorRegistrationParametersKey];
+  [coder encodeObject:self.date forKey:kFIRInstallationsStoredRegistrationErrorDateKey];
   [coder encodeObject:self.APIError forKey:kFIRInstallationsStoredRegistrationErrorAPIErrorKey];
   [coder encodeInteger:kFIRInstallationsStoredRegistrationErrorStorageVersion
                 forKey:kFIRInstallationsStoredRegistrationErrorStorageVersionKey];
@@ -73,6 +77,7 @@ NSInteger const kFIRInstallationsStoredRegistrationErrorStorageVersion = 1;
   FIRInstallationsStoredRegistrationParameters *registrationParameters =
       [coder decodeObjectOfClass:[FIRInstallationsStoredRegistrationParameters class]
                           forKey:kFIRInstallationsStoredRegistrationErrorRegistrationParametersKey];
+  NSDate *date = [coder decodeObjectOfClass:[NSDate class] forKey:kFIRInstallationsStoredRegistrationErrorDateKey];
 
   NSSet<Class> *allowedErrorClasses =
       [NSSet setWithArray:@ [[FIRInstallationsHTTPError class], [NSError class]]];
@@ -87,7 +92,7 @@ NSInteger const kFIRInstallationsStoredRegistrationErrorStorageVersion = 1;
     return nil;
   }
 
-  return [self initWithRegistrationParameters:registrationParameters APIError:APIError];
+  return [self initWithRegistrationParameters:registrationParameters date:date APIError:APIError];
 }
 
 @end

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
@@ -19,6 +19,7 @@
 #import <OCMock/OCMock.h>
 #import "FBLPromise+Testing.h"
 #import "FIRInstallationsItem+Tests.h"
+#import "XCTestCase+DateAsserts.h"
 
 #import "FIRInstallationsAPIService.h"
 #import "FIRInstallationsErrorUtil.h"
@@ -403,16 +404,6 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
                                                            HTTPVersion:nil
                                                           headerFields:nil];
   return response;
-}
-
-- (void)assertDate:(NSDate *)date
-    isApproximatelyEqualCurrentPlusTimeInterval:(NSTimeInterval)timeInterval {
-  NSDate *expectedDate = [NSDate dateWithTimeIntervalSinceNow:timeInterval];
-
-  NSTimeInterval precision = 10;
-  XCTAssert(ABS([date timeIntervalSinceDate:expectedDate]) <= precision,
-            @"date: %@ is not equal to expected %@ with precision %f - %@", date, expectedDate,
-            precision, self.name);
 }
 
 - (id)refreshTokenRequestValidationArgWithInstallation:(FIRInstallationsItem *)installation {

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
@@ -1104,6 +1104,47 @@
   OCMVerifyAll(self.mockAPIService);
 }
 
+- (void)
+    testGetInstallation_WhenStoredRegistrationErrorIsOutdated_ThenSendsAPIRequest {
+  __block FBLPromise<FIRInstallationsItem *> *storedInstallationPromise;
+  OCMExpect([self.mockInstallationsStore installationForAppID:self.appID appName:self.appName])
+      .andDo(^(NSInvocation *invocation) {
+        [invocation setReturnValue:&storedInstallationPromise];
+      });
+
+  // 1.1. Expect installation to be requested from the store.
+  NSDate *date25HoursAgo = [NSDate dateWithTimeIntervalSinceNow:-25 * 60 * 60];
+  FIRInstallationsItem *storedInstallation =
+  [self createFailedToRegisterInstallationWithParameters:[self currentRegistrationParameters] date:date25HoursAgo];
+  storedInstallationPromise = [FBLPromise resolvedWith:storedInstallation];
+
+  // 1.2. Expect registration API request to be sent.
+  FIRInstallationsItem *registeredInstallation =
+      [FIRInstallationsItem createRegisteredInstallationItem];
+  OCMExpect([self.mockAPIService registerInstallation:storedInstallation])
+      .andReturn([FBLPromise resolvedWith:registeredInstallation]);
+
+  // 1.3. Expect registered Installation to be stored.
+  OCMExpect([self.mockInstallationsStore saveInstallation:[OCMArg checkWithBlock:^BOOL(id obj) {
+                                           XCTAssertEqualObjects(obj, registeredInstallation);
+                                           storedInstallationPromise =
+                                               [FBLPromise resolvedWith:obj];
+                                           return YES;
+                                         }]])
+      .andReturn([FBLPromise resolvedWith:[NSNull null]]);
+
+  // 2. Request Installation.
+  FBLPromise<FIRInstallationsItem *> *promise = [self.controller getInstallationItem];
+  XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
+
+  // 3. Check.
+  XCTAssertEqualObjects(promise.value.identifier, registeredInstallation.identifier);
+  XCTAssertNil(promise.error);
+
+  OCMVerifyAll(self.mockInstallationsStore);
+  OCMVerifyAll(self.mockAPIService);
+}
+
 #pragma mark - Helpers
 
 - (void)expectInstallationsStoreGetInstallationNotFound {
@@ -1139,12 +1180,18 @@
 }
 
 - (FIRInstallationsItem *)createFailedToRegisterInstallationWithParameters:
-    (FIRInstallationsStoredRegistrationParameters *)registrationParameters {
+(FIRInstallationsStoredRegistrationParameters *)registrationParameters date:(NSDate *)date {
   FIRInstallationsStoredRegistrationError *error = [[FIRInstallationsStoredRegistrationError alloc]
       initWithRegistrationParameters:registrationParameters
+                                                    date:date
                             APIError:[FIRInstallationsErrorUtil APIErrorWithHTTPCode:400]];
   FIRInstallationsItem *installation = [FIRInstallationsItem createWithRegistrationFailure:error];
   return installation;
+}
+
+- (FIRInstallationsItem *)createFailedToRegisterInstallationWithParameters:
+    (FIRInstallationsStoredRegistrationParameters *)registrationParameters {
+  return [self createFailedToRegisterInstallationWithParameters:registrationParameters date:[NSDate date]];
 }
 
 - (FIRInstallationsStoredRegistrationParameters *)currentRegistrationParameters {

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsStoredItemTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsStoredItemTests.m
@@ -59,6 +59,7 @@
   XCTAssertEqual(unarchivedItem.registrationStatus, item.registrationStatus);
 
   XCTAssertEqualObjects(unarchivedItem.registrationError.APIError, item.registrationError.APIError);
+  XCTAssertEqualObjects(unarchivedItem.registrationError.date, item.registrationError.date);
   XCTAssertEqualObjects(unarchivedItem.registrationError.registrationParameters.APIKey,
                         item.registrationError.registrationParameters.APIKey);
   XCTAssertEqualObjects(unarchivedItem.registrationError.registrationParameters.projectID,

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsStoredItemTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsStoredItemTests.m
@@ -76,6 +76,7 @@
                                    userInfo:@{NSLocalizedFailureReasonErrorKey : @"value"}];
   FIRInstallationsStoredRegistrationError *registrationError =
       [[FIRInstallationsStoredRegistrationError alloc] initWithRegistrationParameters:params
+                                                                                 date:[NSDate date]
                                                                              APIError:error];
   XCTAssertEqualObjects(registrationError.APIError, error);
   XCTAssertEqualObjects(registrationError.registrationParameters, params);

--- a/FirebaseInstallations/Source/Tests/Utils/XCTestCase+DateAsserts.h
+++ b/FirebaseInstallations/Source/Tests/Utils/XCTestCase+DateAsserts.h
@@ -14,21 +14,15 @@
  * limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
-#import <Security/Security.h>
+#import <XCTest/XCTest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-#if TARGET_OS_OSX
+@interface XCTestCase (FIRTestsDateUtils)
 
-@interface FIRTestKeychain : NSObject
-
-- (nullable instancetype)init;
-
-@property(nonatomic, readonly, nullable) SecKeychainRef testKeychainRef;
+- (void)assertDate:(NSDate *)date
+    isApproximatelyEqualCurrentPlusTimeInterval:(NSTimeInterval)timeInterval;
 
 @end
-
-#endif  // TARGET_OSX
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseInstallations/Source/Tests/Utils/XCTestCase+DateAsserts.m
+++ b/FirebaseInstallations/Source/Tests/Utils/XCTestCase+DateAsserts.m
@@ -14,21 +14,18 @@
  * limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
-#import <Security/Security.h>
+#import "XCTestCase+DateAsserts.h"
 
-NS_ASSUME_NONNULL_BEGIN
+@implementation XCTestCase (FIRTestsDateUtils)
 
-#if TARGET_OS_OSX
+- (void)assertDate:(NSDate *)date
+    isApproximatelyEqualCurrentPlusTimeInterval:(NSTimeInterval)timeInterval {
+  NSDate *expectedDate = [NSDate dateWithTimeIntervalSinceNow:timeInterval];
 
-@interface FIRTestKeychain : NSObject
-
-- (nullable instancetype)init;
-
-@property(nonatomic, readonly, nullable) SecKeychainRef testKeychainRef;
+  NSTimeInterval precision = 10;
+  XCTAssert(ABS([date timeIntervalSinceDate:expectedDate]) <= precision,
+            @"date: %@ is not equal to expected %@ with precision %f - %@", date, expectedDate,
+            precision, self.name);
+}
 
 @end
-
-#endif  // TARGET_OSX
-
-NS_ASSUME_NONNULL_END


### PR DESCRIPTION
- the stored FIS registration error expiring in 24h (see go/fis-ios-error-handling for details)

This is a follow up on #4024.