### PR TITLE
Remove migration logic from document folder to application folder

### DIFF
--- a/Example/InstanceID/Tests/FIRInstanceIDBackupExcludedPlistTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDBackupExcludedPlistTest.m
@@ -79,48 +79,6 @@ static NSString *const kTestPlistFileName = @"com.google.test.IIDBackupExcludedP
   XCTAssertTrue([self doesPlistFileExist]);
 }
 
-- (void)testMovePlistToApplicationSupportDirectorySuccess {
-  NSDictionary *plistContents = @{@"hello" : @"world", @"id" : @123};
-  [self.plist writeDictionary:plistContents error:nil];
-  [self.plist moveToApplicationSupportSubDirectory:kSubDirectoryName];
-  XCTAssertTrue([self doesPlistFileExist]);
-  XCTAssertFalse([self isPlistInDocumentsDirectory]);
-
-  NSDictionary *newPlistContents = @{@"world" : @"hello"};
-  [self.plist writeDictionary:newPlistContents error:nil];
-  XCTAssertEqualObjects(newPlistContents, [self.plist contentAsDictionary]);
-}
-
-- (void)testMovePlistToApplicationSupportDirectoryFailure {
-  // This is to test moving data from deprecated document folder to application folder
-  // which should only apply to iOS.
-#if TARGET_OS_IOS
-  // Delete the subdirectory
-  [FIRInstanceIDStore removeSubDirectory:kSubDirectoryName error:nil];
-
-  // Create a new plistl This would try to move or write to the ApplicationSupport directory
-  // but since the subdirectory is not there anymore it will fail and rather write to the
-  // Documents folder.
-  self.plist = [[FIRInstanceIDBackupExcludedPlist alloc] initWithFileName:kTestPlistFileName
-                                                             subDirectory:kSubDirectoryName];
-
-  NSDictionary *plistContents = @{@"hello" : @"world", @"id" : @123};
-  [self.plist writeDictionary:plistContents error:nil];
-
-  XCTAssertFalse([self doesPlistFileExist]);
-  XCTAssertTrue([self isPlistInDocumentsDirectory]);
-
-  NSDictionary *newPlistContents = @{@"world" : @"hello"};
-  [self.plist writeDictionary:newPlistContents error:nil];
-
-  XCTAssertEqualObjects(newPlistContents, [self.plist contentAsDictionary]);
-
-  // The new file should still be written to the Documents folder.
-  XCTAssertFalse([self doesPlistFileExist]);
-  XCTAssertTrue([self isPlistInDocumentsDirectory]);
-#endif
-}
-
 #pragma mark - Private Helpers
 
 - (BOOL)doesPlistFileExist {

--- a/Example/Messaging/Tests/FIRMessagingDataMessageManagerTest.m
+++ b/Example/Messaging/Tests/FIRMessagingDataMessageManagerTest.m
@@ -22,6 +22,7 @@
 #import "Firebase/Messaging/FIRMessagingClient.h"
 #import "Firebase/Messaging/FIRMessagingConnection.h"
 #import "Firebase/Messaging/FIRMessagingDataMessageManager.h"
+#import "Firebase/Messaging/FIRMessagingRmq2PersistentStore.h"
 #import "Firebase/Messaging/FIRMessagingReceiver.h"
 #import "Firebase/Messaging/FIRMessagingRmqManager.h"
 #import "Firebase/Messaging/FIRMessagingSyncMessageManager.h"
@@ -47,6 +48,18 @@ static NSString *const kRmqDatabaseName = @"gcm-dmm-test";
 @property(nonatomic, readwrite, weak) FIRMessagingRmqManager *rmq2Manager;
 
 - (NSString *)categoryForUpstreamMessages;
+
+@end
+
+@interface FIRMessagingRmqManager (ExposedForTest)
+
+@property(nonatomic, readwrite, strong) FIRMessagingRmq2PersistentStore *rmq2Store;
+
+@end
+
+@interface FIRMessagingRmq2PersistentStore (ExposedForTest)
+
+- (void)removeDatabase;
 
 @end
 
@@ -78,6 +91,12 @@ static NSString *const kRmqDatabaseName = @"gcm-dmm-test";
   _mockDataMessageManager = OCMPartialMock(_dataMessageManager);
 }
 
+-(void)tearDown {
+    if (_dataMessageManager.rmq2Manager) {
+        [_dataMessageManager.rmq2Manager.rmq2Store removeDatabase];
+    }
+    [super tearDown];
+}
 
 - (void)testSendValidMessage_withNoConnection {
   // mock no connection initially
@@ -477,7 +496,6 @@ static NSString *const kRmqDatabaseName = @"gcm-dmm-test";
   // Set a fake, valid bundle identifier
   [[[self.mockDataMessageManager stub] andReturn:@"gcm-dmm-test"] categoryForUpstreamMessages];
 
-  [FIRMessagingRmqManager removeDatabaseWithName:kRmqDatabaseName];
   FIRMessagingRmqManager *newRmqManager =
       [[FIRMessagingRmqManager alloc] initWithDatabaseName:kRmqDatabaseName];
   [newRmqManager loadRmqId];
@@ -535,7 +553,6 @@ static NSString *const kRmqDatabaseName = @"gcm-dmm-test";
   // Set a fake, valid bundle identifier
   [[[self.mockDataMessageManager stub] andReturn:@"gcm-dmm-test"] categoryForUpstreamMessages];
 
-  [FIRMessagingRmqManager removeDatabaseWithName:kRmqDatabaseName];
   FIRMessagingRmqManager *newRmqManager =
       [[FIRMessagingRmqManager alloc] initWithDatabaseName:kRmqDatabaseName];
   [newRmqManager loadRmqId];

--- a/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
+++ b/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
@@ -19,10 +19,23 @@
 #import "Firebase/Messaging/FIRMessagingPersistentSyncMessage.h"
 #import "Firebase/Messaging/FIRMessagingRmqManager.h"
 #import "Firebase/Messaging/FIRMessagingUtilities.h"
+#import "Firebase/Messaging/FIRMessagingRmq2PersistentStore.h"
 #import "Firebase/Messaging/Protos/GtalkCore.pbobjc.h"
 
 static NSString *const kRmqDatabaseName = @"rmq-test-db";
 static NSString *const kRmqDataMessageCategory = @"com.google.gcm-rmq-test";
+
+@interface FIRMessagingRmqManager (ExposedForTest)
+
+@property(nonatomic, readwrite, strong) FIRMessagingRmq2PersistentStore *rmq2Store;
+
+@end
+
+@interface FIRMessagingRmq2PersistentStore (ExposedForTest)
+
+- (void)removeDatabase;
+
+@end
 
 @interface FIRMessagingRmqManagerTest : XCTestCase
 
@@ -35,13 +48,13 @@ static NSString *const kRmqDataMessageCategory = @"com.google.gcm-rmq-test";
 - (void)setUp {
   [super setUp];
   // Make sure we start off with a clean state each time
-  [FIRMessagingRmqManager removeDatabaseWithName:kRmqDatabaseName];
   _rmqManager = [[FIRMessagingRmqManager alloc] initWithDatabaseName:kRmqDatabaseName];
+
 }
 
 - (void)tearDown {
+  [self.rmqManager.rmq2Store removeDatabase];
   [super tearDown];
-  [FIRMessagingRmqManager removeDatabaseWithName:kRmqDatabaseName];
 }
 
 /**

--- a/Example/Messaging/Tests/FIRMessagingSyncMessageManagerTest.m
+++ b/Example/Messaging/Tests/FIRMessagingSyncMessageManagerTest.m
@@ -17,12 +17,25 @@
 #import <XCTest/XCTest.h>
 
 #import "Firebase/Messaging/FIRMessagingPersistentSyncMessage.h"
+#import "Firebase/Messaging/FIRMessagingRmq2PersistentStore.h"
 #import "Firebase/Messaging/FIRMessagingRmqManager.h"
 #import "Firebase/Messaging/FIRMessagingSyncMessageManager.h"
 #import "Firebase/Messaging/FIRMessagingUtilities.h"
 #import "Firebase/Messaging/FIRMessagingConstants.h"
 
 static NSString *const kRmqSqliteFilename = @"rmq-sync-manager-test";
+
+@interface FIRMessagingRmqManager (ExposedForTest)
+
+@property(nonatomic, readwrite, strong) FIRMessagingRmq2PersistentStore *rmq2Store;
+
+@end
+
+@interface FIRMessagingRmq2PersistentStore (ExposedForTest)
+
+- (void)removeDatabase;
+
+@end
 
 @interface FIRMessagingSyncMessageManagerTest : XCTestCase
 
@@ -36,13 +49,12 @@ static NSString *const kRmqSqliteFilename = @"rmq-sync-manager-test";
 - (void)setUp {
   [super setUp];
   // Make sure the db state is clean before we begin.
-  [FIRMessagingRmqManager removeDatabaseWithName:kRmqSqliteFilename];
   self.rmqManager = [[FIRMessagingRmqManager alloc] initWithDatabaseName:kRmqSqliteFilename];
   self.syncMessageManager = [[FIRMessagingSyncMessageManager alloc] initWithRmqManager:self.rmqManager];
 }
 
 - (void)tearDown {
-  [[self.rmqManager class] removeDatabaseWithName:kRmqSqliteFilename];
+  [self.rmqManager.rmq2Store removeDatabase];
   [super tearDown];
 }
 

--- a/Firebase/InstanceID/FIRIMessageCode.h
+++ b/Firebase/InstanceID/FIRIMessageCode.h
@@ -55,10 +55,10 @@ typedef NS_ENUM(NSInteger, FIRInstanceIDMessageCode) {
   kFIRInstanceIDMessageCodeAuthServiceCheckinInProgress = 5004,
 
   // FIRInstanceIDBackupExcludedPlist.m
+  // Do NOT USE 6003
   kFIRInstanceIDMessageCodeBackupExcludedPlist000 = 6000,
   kFIRInstanceIDMessageCodeBackupExcludedPlist001 = 6001,
   kFIRInstanceIDMessageCodeBackupExcludedPlist002 = 6002,
-  kFIRInstanceIDMessageCodeBackupExcludedPlistInvalidPlistEnum = 6003,
   // FIRInstanceIDCheckinService.m
   kFIRInstanceIDMessageCodeService000 = 7000,
   kFIRInstanceIDMessageCodeService001 = 7001,

--- a/Firebase/InstanceID/FIRInstanceIDBackupExcludedPlist.m
+++ b/Firebase/InstanceID/FIRInstanceIDBackupExcludedPlist.m
@@ -33,7 +33,6 @@
   if (self) {
     _fileName = [fileName copy];
     _subDirectoryName = [subDirectory copy];
-    _fileInStandardDirectory = YES;
   }
   return self;
 }

--- a/Firebase/InstanceID/FIRInstanceIDBackupExcludedPlist.m
+++ b/Firebase/InstanceID/FIRInstanceIDBackupExcludedPlist.m
@@ -98,11 +98,10 @@
 
 - (NSString *)plistPathInDirectory {
   NSArray *directoryPaths;
-  NSArray *components = @[];
   NSString *plistNameWithExtension = [NSString stringWithFormat:@"%@.plist", self.fileName];
   directoryPaths =
       NSSearchPathForDirectoriesInDomains([self supportedDirectory], NSUserDomainMask, YES);
-  components = @[ directoryPaths.lastObject, _subDirectoryName, plistNameWithExtension ];
+  NSArray *components = @[ directoryPaths.lastObject, _subDirectoryName, plistNameWithExtension ];
 
   return [NSString pathWithComponents:components];
 }

--- a/Firebase/InstanceID/FIRInstanceIDBackupExcludedPlist.m
+++ b/Firebase/InstanceID/FIRInstanceIDBackupExcludedPlist.m
@@ -18,18 +18,10 @@
 
 #import "FIRInstanceIDLogger.h"
 
-typedef enum : NSUInteger {
-  FIRInstanceIDPlistDirectoryUnknown,
-  FIRInstanceIDPlistDirectoryDocuments,
-  FIRInstanceIDPlistDirectoryApplicationSupport,
-} FIRInstanceIDPlistDirectory;
-
 @interface FIRInstanceIDBackupExcludedPlist ()
 
 @property(nonatomic, readwrite, copy) NSString *fileName;
 @property(nonatomic, readwrite, copy) NSString *subDirectoryName;
-@property(nonatomic, readwrite, assign) BOOL fileInStandardDirectory;
-
 @property(nonatomic, readwrite, strong) NSDictionary *cachedPlistContents;
 
 @end
@@ -41,19 +33,13 @@ typedef enum : NSUInteger {
   if (self) {
     _fileName = [fileName copy];
     _subDirectoryName = [subDirectory copy];
-#if TARGET_OS_IOS
-    _fileInStandardDirectory = [self moveToApplicationSupportSubDirectory:subDirectory];
-#else
-    // For tvOS and macOS, we never store the content in document folder, so
-    // the migration is unnecessary.
     _fileInStandardDirectory = YES;
-#endif
   }
   return self;
 }
 
 - (BOOL)writeDictionary:(NSDictionary *)dict error:(NSError **)error {
-  NSString *path = [self plistPathInDirectory:[self plistDirectory]];
+  NSString *path = [self plistPathInDirectory];
   if (![dict writeToFile:path atomically:YES]) {
     FIRInstanceIDLoggerError(kFIRInstanceIDMessageCodeBackupExcludedPlist000,
                              @"Failed to write to %@.plist", self.fileName);
@@ -85,7 +71,7 @@ typedef enum : NSUInteger {
 
 - (BOOL)deleteFile:(NSError **)error {
   BOOL success = YES;
-  NSString *path = [self plistPathInDirectory:[self plistDirectory]];
+  NSString *path = [self plistPathInDirectory];
   if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
     success = [[NSFileManager defaultManager] removeItemAtPath:path error:error];
   }
@@ -96,7 +82,7 @@ typedef enum : NSUInteger {
 
 - (NSDictionary *)contentAsDictionary {
   if (!self.cachedPlistContents) {
-    NSString *path = [self plistPathInDirectory:[self plistDirectory]];
+    NSString *path = [self plistPathInDirectory];
     if ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
       self.cachedPlistContents = [[NSDictionary alloc] initWithContentsOfFile:path];
     }
@@ -104,91 +90,22 @@ typedef enum : NSUInteger {
   return self.cachedPlistContents;
 }
 
-- (BOOL)moveToApplicationSupportSubDirectory:(NSString *)subDirectoryName {
-  NSArray *directoryPaths =
-      NSSearchPathForDirectoriesInDomains([self supportedDirectory], NSUserDomainMask, YES);
-  // This only going to happen inside iOS so it is an applicationSupportDirectory.
-  NSString *applicationSupportDirPath = directoryPaths.lastObject;
-  NSArray *components = @[ applicationSupportDirPath, subDirectoryName ];
-  NSString *subDirectoryPath = [NSString pathWithComponents:components];
-  BOOL hasSubDirectory;
-  if (![[NSFileManager defaultManager] fileExistsAtPath:subDirectoryPath
-                                            isDirectory:&hasSubDirectory]) {
-    // Cannot move to non-existent directory
-    return NO;
-  }
-
-  if ([self doesFileExistInDirectory:FIRInstanceIDPlistDirectoryDocuments]) {
-    NSString *oldPlistPath = [self plistPathInDirectory:FIRInstanceIDPlistDirectoryDocuments];
-    NSString *newPlistPath =
-        [self plistPathInDirectory:FIRInstanceIDPlistDirectoryApplicationSupport];
-    if ([self doesFileExistInDirectory:FIRInstanceIDPlistDirectoryApplicationSupport]) {
-      // File exists in both Documents and ApplicationSupport
-      return NO;
-    }
-    NSError *moveError;
-    if (![[NSFileManager defaultManager] moveItemAtPath:oldPlistPath
-                                                 toPath:newPlistPath
-                                                  error:&moveError]) {
-      FIRInstanceIDLoggerError(kFIRInstanceIDMessageCodeBackupExcludedPlist002,
-                               @"Failed to move file %@ from %@ to %@. Error: %@", self.fileName,
-                               oldPlistPath, newPlistPath, moveError);
-      return NO;
-    }
-  }
-  // We moved the file if it existed, otherwise we didn't need to do anything
-  return YES;
-}
-
 - (BOOL)doesFileExist {
-  return [self doesFileExistInDirectory:[self plistDirectory]];
+  NSString *path = [self plistPathInDirectory];
+  return [[NSFileManager defaultManager] fileExistsAtPath:path];
 }
 
 #pragma mark - Private
 
-- (FIRInstanceIDPlistDirectory)plistDirectory {
-  if (_fileInStandardDirectory) {
-    return FIRInstanceIDPlistDirectoryApplicationSupport;
-  } else {
-    return FIRInstanceIDPlistDirectoryDocuments;
-  };
-}
-
-- (NSString *)plistPathInDirectory:(FIRInstanceIDPlistDirectory)directory {
-  return [self pathWithName:self.fileName inDirectory:directory];
-}
-
-- (NSString *)pathWithName:(NSString *)plistName
-               inDirectory:(FIRInstanceIDPlistDirectory)directory {
+- (NSString *)plistPathInDirectory {
   NSArray *directoryPaths;
   NSArray *components = @[];
-  NSString *plistNameWithExtension = [NSString stringWithFormat:@"%@.plist", plistName];
-  switch (directory) {
-    case FIRInstanceIDPlistDirectoryDocuments:
-      directoryPaths =
-          NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-      components = @[ directoryPaths.lastObject, plistNameWithExtension ];
-      break;
-
-    case FIRInstanceIDPlistDirectoryApplicationSupport:
+  NSString *plistNameWithExtension = [NSString stringWithFormat:@"%@.plist", self.fileName];
       directoryPaths =
           NSSearchPathForDirectoriesInDomains([self supportedDirectory], NSUserDomainMask, YES);
       components = @[ directoryPaths.lastObject, _subDirectoryName, plistNameWithExtension ];
-      break;
-
-    default:
-      FIRInstanceIDLoggerError(kFIRInstanceIDMessageCodeBackupExcludedPlistInvalidPlistEnum,
-                               @"Invalid plist directory type: %lu", (unsigned long)directory);
-      NSAssert(NO, @"Invalid plist directory type: %lu", (unsigned long)directory);
-      break;
-  }
 
   return [NSString pathWithComponents:components];
-}
-
-- (BOOL)doesFileExistInDirectory:(FIRInstanceIDPlistDirectory)directory {
-  NSString *path = [self plistPathInDirectory:directory];
-  return [[NSFileManager defaultManager] fileExistsAtPath:path];
 }
 
 - (NSSearchPathDirectory)supportedDirectory {

--- a/Firebase/InstanceID/FIRInstanceIDBackupExcludedPlist.m
+++ b/Firebase/InstanceID/FIRInstanceIDBackupExcludedPlist.m
@@ -100,9 +100,9 @@
   NSArray *directoryPaths;
   NSArray *components = @[];
   NSString *plistNameWithExtension = [NSString stringWithFormat:@"%@.plist", self.fileName];
-      directoryPaths =
-          NSSearchPathForDirectoriesInDomains([self supportedDirectory], NSUserDomainMask, YES);
-      components = @[ directoryPaths.lastObject, _subDirectoryName, plistNameWithExtension ];
+  directoryPaths =
+      NSSearchPathForDirectoriesInDomains([self supportedDirectory], NSUserDomainMask, YES);
+  components = @[ directoryPaths.lastObject, _subDirectoryName, plistNameWithExtension ];
 
   return [NSString pathWithComponents:components];
 }

--- a/Firebase/Messaging/FIRMMessageCode.h
+++ b/Firebase/Messaging/FIRMMessageCode.h
@@ -143,7 +143,7 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingMessageCodeRmq2PersistentStore006 = 13006,  // I-FCM013006
   kFIRMessagingMessageCodeRmq2PersistentStoreErrorCreatingDatabase = 13007,  // I-FCM013007
   kFIRMessagingMessageCodeRmq2PersistentStoreErrorOpeningDatabase = 13008,  // I-FCM013008
-  kFIRMessagingMessageCodeRmq2PersistentStoreInvalidRmqDirectory = 13009,  // I-FCM013009
+  kFIRMessagingMessageCodeRmq2PersistentStoreInvalidRmqDirectory = 13009,  // no longer used 
   kFIRMessagingMessageCodeRmq2PersistentStoreErrorCreatingTable = 13010,  // I-FCM013010
   // FIRMessagingRmqManager.m
   kFIRMessagingMessageCodeRmqManager000 = 14000,  // I-FCM014000

--- a/Firebase/Messaging/FIRMMessageCode.h
+++ b/Firebase/Messaging/FIRMMessageCode.h
@@ -143,7 +143,7 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingMessageCodeRmq2PersistentStore006 = 13006,  // I-FCM013006
   kFIRMessagingMessageCodeRmq2PersistentStoreErrorCreatingDatabase = 13007,  // I-FCM013007
   kFIRMessagingMessageCodeRmq2PersistentStoreErrorOpeningDatabase = 13008,  // I-FCM013008
-  kFIRMessagingMessageCodeRmq2PersistentStoreInvalidRmqDirectory = 13009,  // no longer used 
+  kFIRMessagingMessageCodeRmq2PersistentStoreInvalidRmqDirectory = 13009,  // no longer used
   kFIRMessagingMessageCodeRmq2PersistentStoreErrorCreatingTable = 13010,  // I-FCM013010
   // FIRMessagingRmqManager.m
   kFIRMessagingMessageCodeRmqManager000 = 14000,  // I-FCM014000

--- a/Firebase/Messaging/FIRMessagingRmq2PersistentStore.h
+++ b/Firebase/Messaging/FIRMessagingRmq2PersistentStore.h
@@ -121,13 +121,6 @@ extern NSString *const kTableS2DRmqIds;
 - (int)deleteMessagesFromTable:(NSString *)tableName
                     withRmqIds:(NSArray *)rmqIds;
 
-/**
- *  Remove database from the device.
- *
- *  @param dbName The database name to be deleted.
- */
-+ (void)removeDatabase:(NSString *)dbName;
-
 #pragma mark - Sync Messages
 
 /**

--- a/Firebase/Messaging/FIRMessagingRmq2PersistentStore.m
+++ b/Firebase/Messaging/FIRMessagingRmq2PersistentStore.m
@@ -119,7 +119,7 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
   self = [super init];
   if (self) {
     _databaseName = [databaseName copy];
-    [self openDatabase:_databaseName];
+    [self openDatabase];
   }
   return self;
 }
@@ -171,14 +171,9 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
   [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
 }
 
-+ (void)removeDatabase:(NSString *)dbName {
-  NSString *standardDirPath = [self pathForDatabase:dbName];
-  [[NSFileManager defaultManager] removeItemAtPath:standardDirPath error:nil];
-}
-
-- (void)openDatabase:(NSString *)dbName {
+- (void)openDatabase {
   NSFileManager *fileManager = [NSFileManager defaultManager];
-  NSString *path = [[self class] pathForDatabase:dbName];
+  NSString *path = [[self class] pathForDatabase:_databaseName];
 
   BOOL didOpenDatabase = YES;
   if (![fileManager fileExistsAtPath:path]) {

--- a/Firebase/Messaging/FIRMessagingRmq2PersistentStore.m
+++ b/Firebase/Messaging/FIRMessagingRmq2PersistentStore.m
@@ -128,8 +128,8 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
   sqlite3_close(_database);
 }
 
-+ (NSString *)pathForDatabase:(NSString *)dbName {
-  NSString *dbNameWithExtension = [NSString stringWithFormat:@"%@.sqlite", dbName];
+- (NSString *)pathForDatabase {
+  NSString *dbNameWithExtension = [NSString stringWithFormat:@"%@.sqlite", _databaseName];
   NSArray *paths = NSSearchPathForDirectoriesInDomains(FIRMessagingSupportedDirectory(),
                                                   NSUserDomainMask,
                                                   YES);
@@ -167,13 +167,13 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 }
 
 - (void)removeDatabase {
-  NSString *path = [[self class] pathForDatabase:self.databaseName];
+  NSString *path = [self pathForDatabase];
   [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
 }
 
 - (void)openDatabase {
   NSFileManager *fileManager = [NSFileManager defaultManager];
-  NSString *path = [[self class] pathForDatabase:_databaseName];
+  NSString *path = [self pathForDatabase];
 
   BOOL didOpenDatabase = YES;
   if (![fileManager fileExistsAtPath:path]) {

--- a/Firebase/Messaging/FIRMessagingRmq2PersistentStore.m
+++ b/Firebase/Messaging/FIRMessagingRmq2PersistentStore.m
@@ -34,12 +34,6 @@ return return_value; \
 } while(0)
 #endif
 
-typedef enum : NSUInteger {
-  FIRMessagingRmqDirectoryUnknown,
-  FIRMessagingRmqDirectoryDocuments,
-  FIRMessagingRmqDirectoryApplicationSupport,
-} FIRMessagingRmqDirectory;
-
 static NSString *const kFCMRmqStoreTag = @"FIRMessagingRmqStore:";
 
 // table names
@@ -116,7 +110,6 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 }
 
 @property(nonatomic, readwrite, strong) NSString *databaseName;
-@property(nonatomic, readwrite, assign) FIRMessagingRmqDirectory currentDirectory;
 
 @end
 
@@ -126,17 +119,6 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
   self = [super init];
   if (self) {
     _databaseName = [databaseName copy];
-#if TARGET_OS_IOS
-    BOOL didMoveToApplicationSupport =
-        [self moveToApplicationSupportSubDirectory:kFIRMessagingSubDirectoryName];
-
-    _currentDirectory = didMoveToApplicationSupport
-                            ? FIRMessagingRmqDirectoryApplicationSupport
-                            : FIRMessagingRmqDirectoryDocuments;
-#else
-    _currentDirectory = FIRMessagingRmqDirectoryApplicationSupport;
-#endif
-
     [self openDatabase:_databaseName];
   }
   return self;
@@ -146,89 +128,16 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
   sqlite3_close(_database);
 }
 
-- (BOOL)moveToApplicationSupportSubDirectory:(NSString *)subDirectoryName {
-  NSArray *directoryPaths = NSSearchPathForDirectoriesInDomains(FIRMessagingSupportedDirectory(),
-                                                                NSUserDomainMask, YES);
-  NSString *applicationSupportDirPath = directoryPaths.lastObject;
-  NSArray *components = @[applicationSupportDirPath, subDirectoryName];
-  NSString *subDirectoryPath = [NSString pathWithComponents:components];
-  BOOL hasSubDirectory;
-
-  if (![[NSFileManager defaultManager] fileExistsAtPath:subDirectoryPath
-                                            isDirectory:&hasSubDirectory]) {
-    // Cannot move to non-existent directory
-    return NO;
-  }
-
-  if ([self doesFileExistInDirectory:FIRMessagingRmqDirectoryDocuments]) {
-    NSString *oldPlistPath = [[self class] pathForDatabase:self.databaseName
-                                               inDirectory:FIRMessagingRmqDirectoryDocuments];
-    NSString *newPlistPath = [[self class]
-        pathForDatabase:self.databaseName
-            inDirectory:FIRMessagingRmqDirectoryApplicationSupport];
-
-    if ([self doesFileExistInDirectory:FIRMessagingRmqDirectoryApplicationSupport]) {
-      // File exists in both Documents and ApplicationSupport, delete the one in Documents
-      NSError *deleteError;
-      if (![[NSFileManager defaultManager] removeItemAtPath:oldPlistPath error:&deleteError]) {
-        FIRMessagingLoggerError(kFIRMessagingMessageCodeRmq2PersistentStore000,
-                                @"Failed to delete old copy of %@.sqlite in Documents %@",
-                                self.databaseName, deleteError);
-      }
-      return NO;
-    }
-    NSError *moveError;
-    if (![[NSFileManager defaultManager] moveItemAtPath:oldPlistPath
-                                                 toPath:newPlistPath
-                                                  error:&moveError]) {
-      FIRMessagingLoggerError(kFIRMessagingMessageCodeRmq2PersistentStore001,
-                              @"Failed to move file %@ from %@ to %@. Error: %@", self.databaseName,
-                              oldPlistPath, newPlistPath, moveError);
-      return NO;
-    }
-  }
-  // We moved the file if it existed, otherwise we didn't need to do anything
-  return YES;
-}
-
-- (BOOL)doesFileExistInDirectory:(FIRMessagingRmqDirectory)directory {
-  NSString *path = [[self class] pathForDatabase:self.databaseName inDirectory:directory];
-  return [[NSFileManager defaultManager] fileExistsAtPath:path];
-}
-
-+ (NSString *)pathForDatabase:(NSString *)dbName inDirectory:(FIRMessagingRmqDirectory)directory {
-  NSArray *paths;
-  NSArray *components;
++ (NSString *)pathForDatabase:(NSString *)dbName {
   NSString *dbNameWithExtension = [NSString stringWithFormat:@"%@.sqlite", dbName];
-  NSString *errorMessage;
-
-  switch (directory) {
-    case FIRMessagingRmqDirectoryDocuments:
-      paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-      components = @[paths.lastObject, dbNameWithExtension];
-      break;
-
-    case FIRMessagingRmqDirectoryApplicationSupport:
-      paths = NSSearchPathForDirectoriesInDomains(FIRMessagingSupportedDirectory(),
+  NSArray *paths = NSSearchPathForDirectoriesInDomains(FIRMessagingSupportedDirectory(),
                                                   NSUserDomainMask,
                                                   YES);
-      components = @[
+  NSArray *components = @[
                      paths.lastObject,
                      kFIRMessagingSubDirectoryName,
                      dbNameWithExtension
                      ];
-      break;
-
-    default:
-      errorMessage = [NSString stringWithFormat:@"Invalid directory type %lu",
-                      (unsigned long)directory];
-      FIRMessagingLoggerError(kFIRMessagingMessageCodeRmq2PersistentStoreInvalidRmqDirectory,
-                              @"%@",
-                              errorMessage);
-      NSAssert(NO, errorMessage);
-      break;
-  }
-
   return [NSString pathWithComponents:components];
 }
 
@@ -258,23 +167,18 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 }
 
 - (void)removeDatabase {
-  NSString *path = [[self class] pathForDatabase:self.databaseName
-                                     inDirectory:self.currentDirectory];
+  NSString *path = [[self class] pathForDatabase:self.databaseName];
   [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
 }
 
 + (void)removeDatabase:(NSString *)dbName {
-  NSString *documentsDirPath = [self pathForDatabase:dbName
-                                         inDirectory:FIRMessagingRmqDirectoryDocuments];
-  NSString *standardDirPath =
-      [self pathForDatabase:dbName inDirectory:FIRMessagingRmqDirectoryApplicationSupport];
-  [[NSFileManager defaultManager] removeItemAtPath:documentsDirPath error:nil];
+  NSString *standardDirPath = [self pathForDatabase:dbName];
   [[NSFileManager defaultManager] removeItemAtPath:standardDirPath error:nil];
 }
 
 - (void)openDatabase:(NSString *)dbName {
   NSFileManager *fileManager = [NSFileManager defaultManager];
-  NSString *path = [[self class] pathForDatabase:dbName inDirectory:self.currentDirectory];
+  NSString *path = [[self class] pathForDatabase:dbName];
 
   BOOL didOpenDatabase = YES;
   if (![fileManager fileExistsAtPath:path]) {

--- a/Firebase/Messaging/FIRMessagingRmqManager.h
+++ b/Firebase/Messaging/FIRMessagingRmqManager.h
@@ -183,8 +183,4 @@ typedef void(^FIRMessagingDataMessageHandler)(int64_t rmqId, GtalkDataMessageSta
  */
 - (BOOL)updateSyncMessageViaMCSWithRmqID:(NSString *)rmqID error:(NSError **)error;
 
-#pragma mark - Testing
-
-+ (void)removeDatabaseWithName:(NSString *)dbName;
-
 @end

--- a/Firebase/Messaging/FIRMessagingRmqManager.m
+++ b/Firebase/Messaging/FIRMessagingRmqManager.m
@@ -248,12 +248,6 @@ static NSString *const kFCMRmqTag = @"FIRMessagingRmq:";
   return [self.rmq2Store updateSyncMessageViaMCSWithRmqID:rmqID error:error];
 }
 
-#pragma mark - Testing
-
-+ (void)removeDatabaseWithName:(NSString *)dbName {
-  [FIRMessagingRmq2PersistentStore removeDatabase:dbName];
-}
-
 #pragma mark - Private
 
 - (int64_t)nextRmqId {


### PR DESCRIPTION
We used to store files in document folder (more than 2 years ago) and had migration logic that if document folder exist, move the content to application folder. 

Remove the migration logic since the majority of the users already store data in the application folder. The data we wrote in the disks are plist file and cached non-ack mcs channel message IDs, which are not critical information even if a very old user still kept the document folder (who hasn't opened his app for more than 2 years).

Also remove production code that is only used for testing, should expose the method through category instead.