### PR TITLE
Move FIRInstanceIDInstanceProvider into the private header file for components to look up an instance of FIRInstanceID

### DIFF
--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -22,6 +22,7 @@
 #import <FirebaseCore/FIRLibrary.h>
 #import <FirebaseCore/FIROptions.h>
 #import <GoogleUtilities/GULAppEnvironmentUtil.h>
+#import "FIRInstanceID_Private.h"
 #import "FIRInstanceID+Private.h"
 #import "FIRInstanceIDAuthService.h"
 #import "FIRInstanceIDCheckinPreferences.h"
@@ -124,12 +125,6 @@ typedef NS_ENUM(NSInteger, FIRInstanceIDAPNSTokenType) {
 @property(atomic, strong, nullable)
     FIRInstanceIDCombinedHandler<NSString *> *defaultTokenFetchHandler;
 
-@end
-
-// InstanceID doesn't provide any functionality to other components,
-// so it provides a private, empty protocol that it conforms to and use it for registration.
-
-@protocol FIRInstanceIDInstanceProvider
 @end
 
 @interface FIRInstanceID () <FIRInstanceIDInstanceProvider, FIRLibrary>

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -22,7 +22,6 @@
 #import <FirebaseCore/FIRLibrary.h>
 #import <FirebaseCore/FIROptions.h>
 #import <GoogleUtilities/GULAppEnvironmentUtil.h>
-#import "FIRInstanceID_Private.h"
 #import "FIRInstanceID+Private.h"
 #import "FIRInstanceIDAuthService.h"
 #import "FIRInstanceIDCheckinPreferences.h"
@@ -36,6 +35,7 @@
 #import "FIRInstanceIDTokenManager.h"
 #import "FIRInstanceIDUtilities.h"
 #import "FIRInstanceIDVersionUtilities.h"
+#import "FIRInstanceID_Private.h"
 #import "NSError+FIRInstanceID.h"
 
 // Public constants

--- a/Firebase/InstanceID/Private/FIRInstanceID_Private.h
+++ b/Firebase/InstanceID/Private/FIRInstanceID_Private.h
@@ -23,7 +23,6 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol FIRInstanceIDInstanceProvider
 @end
 
-@class FIRInstanceIDCheckinPreferences;
 /**
  * Private API used by other Firebase SDKs.
  */
@@ -45,13 +44,6 @@ NS_ASSUME_NONNULL_BEGIN
  *          returns nil.
  */
 - (nullable NSString *)token;
-
-/**
- *  Verify if valid checkin preferences have been loaded in memory.
- *
- *  @return YES if valid checkin preferences exist in memory else NO.
- */
-- (BOOL)hasValidCheckinInfo;
 
 /**
  *  Try to load prefetched checkin preferences from the cache. This supports the use case where

--- a/Firebase/InstanceID/Private/FIRInstanceID_Private.h
+++ b/Firebase/InstanceID/Private/FIRInstanceID_Private.h
@@ -18,6 +18,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// Empty protocol that is used for registration. Exposing this protocol
+// for other internal components to look up an instance of FIRInstanceID.
+@protocol FIRInstanceIDInstanceProvider
+@end
+
 @class FIRInstanceIDCheckinPreferences;
 /**
  * Private API used by other Firebase SDKs.


### PR DESCRIPTION
Move FIRInstanceIDInstanceProvider into the private header file for components to look up an instance of FIRInstanceID. This is needed when a components loads with componentsToRegister and depends on instanceID when initializing. 