### PR TITLE
FIRInstallationsAPIService: Retry API request on HTTP 500.

### DIFF
--- a/FirebaseInstallations/Source/Library/Errors/FIRInstallationsHTTPError.h
+++ b/FirebaseInstallations/Source/Library/Errors/FIRInstallationsHTTPError.h
@@ -42,3 +42,5 @@ typedef NS_ENUM(NSInteger, FIRInstallationsRegistrationHTTPCode) {
   FIRInstallationsRegistrationHTTPCodeTooManyRequests = 429,
   FIRInstallationsRegistrationHTTPCodeServerInternalError = 500
 };
+
+extern NSInteger const kFIRInstallationsAPIInternalErrorHTTPCode;

--- a/FirebaseInstallations/Source/Library/Errors/FIRInstallationsHTTPError.m
+++ b/FirebaseInstallations/Source/Library/Errors/FIRInstallationsHTTPError.m
@@ -76,3 +76,5 @@
 }
 
 @end
+
+NSInteger const kFIRInstallationsAPIInternalErrorHTTPCode = 500;

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -348,7 +348,7 @@ NSTimeInterval const kFIRInstallationsRegistrationErrorTimeout = 24 * 60 * 60;  
             [registeredInstallation.authToken.expirationDate timeIntervalSinceDate:[NSDate date]] <
             kFIRInstallationsTokenExpirationThreshold;
         if (forceRefresh || isTokenExpiredOrExpiresSoon) {
-          return [self refreshAuthTokenForInstallation:registeredInstallation];
+          return [self.APIService refreshAuthTokenForInstallation:registeredInstallation];
         } else {
           return registeredInstallation;
         }
@@ -356,18 +356,6 @@ NSTimeInterval const kFIRInstallationsRegistrationErrorTimeout = 24 * 60 * 60;  
       .catch(^void(NSError *error){
           // TODO: Handle the errors.
       });
-}
-
-- (FBLPromise<FIRInstallationsItem *> *)refreshAuthTokenForInstallation:
-    (FIRInstallationsItem *)installation {
-  return [FBLPromise attempts:1
-      delay:1
-      condition:^BOOL(NSInteger remainingAttempts, NSError *_Nonnull error) {
-        return [FIRInstallationsErrorUtil isAPIError:error withHTTPCode:500];
-      }
-      retry:^id _Nullable {
-        return [self.APIService refreshAuthTokenForInstallation:installation];
-      }];
 }
 
 #pragma mark - Delete FID

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
@@ -23,6 +23,7 @@
 
 #import "FIRInstallationsAPIService.h"
 #import "FIRInstallationsErrorUtil.h"
+#import "FIRInstallationsHTTPError.h"
 #import "FIRInstallationsStoredAuthToken.h"
 #import "FIRInstallationsVersion.h"
 
@@ -57,6 +58,9 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
   self.mockURLSession = nil;
   self.projectID = nil;
   self.APIKey = nil;
+
+  //  // Wait for any pending promises to complete.
+  //  XCTAssert(FBLWaitForPromisesWithTimeout(2));
 }
 
 - (void)testRegisterInstallationSuccess {
@@ -139,7 +143,67 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
       isApproximatelyEqualCurrentPlusTimeInterval:604800];
 }
 
-// TODO: More tests for Register Installation API
+- (void)testRegisterInstallation_WhenError500_ThenRetriesOnce {
+  FIRInstallationsItem *installation = [[FIRInstallationsItem alloc] initWithAppID:@"app-id"
+                                                                   firebaseAppName:@"name"];
+  installation.firebaseInstallationID = [FIRInstallationsItem generateFID];
+
+  // 1. Stub URL session:
+
+  // 1.2. Capture completion to call it later.
+  __block void (^taskCompletion)(NSData *, NSURLResponse *, NSError *);
+  id completionArg = [OCMArg checkWithBlock:^BOOL(id obj) {
+    taskCompletion = obj;
+    return YES;
+  }];
+
+  // 1.3. Create a data task mock.
+  id mockDataTask1 = OCMClassMock([NSURLSessionDataTask class]);
+  OCMExpect([(NSURLSessionDataTask *)mockDataTask1 resume]);
+
+  // 1.4. Expect `dataTaskWithRequest` to be called.
+  OCMExpect([self.mockURLSession dataTaskWithRequest:[OCMArg any] completionHandler:completionArg])
+      .andReturn(mockDataTask1);
+
+  // 2. Call
+  FBLPromise<FIRInstallationsItem *> *promise = [self.service registerInstallation:installation];
+
+  // 3. Wait for `[NSURLSession dataTaskWithRequest...]` to be called
+  OCMVerifyAllWithDelay(self.mockURLSession, 0.5);
+
+  // 4. Wait for the data task `resume` to be called.
+  OCMVerifyAllWithDelay(mockDataTask1, 0.5);
+
+  // 5. Call the data task completion.
+  NSData *successResponseData =
+      [self loadFixtureNamed:@"APIRegisterInstallationResponseSuccess.json"];
+  taskCompletion(successResponseData,
+                 [self responseWithStatusCode:kFIRInstallationsAPIInternalErrorHTTPCode], nil);
+
+  // 6.1. Expect network request to send again.
+  id mockDataTask2 = OCMClassMock([NSURLSessionDataTask class]);
+  OCMExpect([(NSURLSessionDataTask *)mockDataTask2 resume]);
+  OCMExpect([self.mockURLSession dataTaskWithRequest:[OCMArg any] completionHandler:completionArg])
+      .andReturn(mockDataTask2);
+
+  // 6.2. Wait for the second network request to complete.
+  OCMVerifyAllWithDelay(self.mockURLSession, 1.5);
+  OCMVerifyAllWithDelay(mockDataTask2, 1.5);
+
+  // 6.3. Send network response again.
+  taskCompletion(successResponseData,
+                 [self responseWithStatusCode:kFIRInstallationsAPIInternalErrorHTTPCode], nil);
+
+  // 7. Check result.
+  XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
+
+  XCTAssertNil(promise.value);
+  XCTAssertNotNil(promise.error);
+
+  XCTAssertTrue([promise.error isKindOfClass:[FIRInstallationsHTTPError class]]);
+  FIRInstallationsHTTPError *HTTPError = (FIRInstallationsHTTPError *)promise.error;
+  XCTAssertEqual(HTTPError.HTTPResponse.statusCode, kFIRInstallationsAPIInternalErrorHTTPCode);
+}
 
 - (void)testRefreshAuthTokenSuccess {
   FIRInstallationsItem *installation = [FIRInstallationsItem createRegisteredInstallationItem];
@@ -245,6 +309,72 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
   FBLWaitForPromisesWithTimeout(0.5);
 
   XCTAssertTrue([FIRInstallationsErrorUtil isAPIError:promise.error withHTTPCode:401]);
+  XCTAssertNil(promise.value);
+}
+
+- (void)testRefreshAuthToken_WhenAPIError500_ThenRetriesOnce {
+  FIRInstallationsItem *installation = [FIRInstallationsItem createRegisteredInstallationItem];
+  installation.firebaseInstallationID = @"qwertyuiopasdfghjklzxcvbnm";
+
+  // 1. Stub URL session:
+
+  // 1.1. URL request validation.
+  id URLRequestValidation = [self refreshTokenRequestValidationArgWithInstallation:installation];
+
+  // 1.2. Capture completion to call it later.
+  __block void (^taskCompletion)(NSData *, NSURLResponse *, NSError *);
+  id completionArg = [OCMArg checkWithBlock:^BOOL(id obj) {
+    taskCompletion = obj;
+    return YES;
+  }];
+
+  // 1.3. Create a data task mock.
+  id mockDataTask1 = OCMClassMock([NSURLSessionDataTask class]);
+  OCMExpect([(NSURLSessionDataTask *)mockDataTask1 resume]);
+
+  // 1.4. Expect `dataTaskWithRequest` to be called.
+  OCMExpect([self.mockURLSession dataTaskWithRequest:URLRequestValidation
+                                   completionHandler:completionArg])
+      .andReturn(mockDataTask1);
+
+  // 1.5. Prepare server response data.
+  NSData *errorResponseData =
+      [self loadFixtureNamed:@"APIGenerateTokenResponseInvalidRefreshToken.json"];
+
+  // 2. Call
+  FBLPromise<FIRInstallationsItem *> *promise =
+      [self.service refreshAuthTokenForInstallation:installation];
+
+  // 3. Wait for `[NSURLSession dataTaskWithRequest...]` to be called
+  OCMVerifyAllWithDelay(self.mockURLSession, 0.5);
+
+  // 4. Wait for the data task `resume` to be called.
+  OCMVerifyAllWithDelay(mockDataTask1, 0.5);
+
+  // 5. Call the data task completion.
+  taskCompletion(errorResponseData,
+                 [self responseWithStatusCode:kFIRInstallationsAPIInternalErrorHTTPCode], nil);
+
+  // 6. Retry:
+
+  // 6.1. Expect another API request to be sent.
+  id mockDataTask2 = OCMClassMock([NSURLSessionDataTask class]);
+  OCMExpect([(NSURLSessionDataTask *)mockDataTask2 resume]);
+  OCMExpect([self.mockURLSession dataTaskWithRequest:URLRequestValidation
+                                   completionHandler:completionArg])
+      .andReturn(mockDataTask2);
+  OCMVerifyAllWithDelay(self.mockURLSession, 1.5);
+  OCMVerifyAllWithDelay(mockDataTask2, 1.5);
+
+  // 6.2. Send the API response again.
+  taskCompletion(errorResponseData,
+                 [self responseWithStatusCode:kFIRInstallationsAPIInternalErrorHTTPCode], nil);
+
+  // 6. Check result.
+  XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
+
+  XCTAssertTrue([FIRInstallationsErrorUtil isAPIError:promise.error
+                                         withHTTPCode:kFIRInstallationsAPIInternalErrorHTTPCode]);
   XCTAssertNil(promise.value);
 }
 
@@ -384,6 +514,64 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
   XCTAssertNil(promise.value);
 }
 
+- (void)testDeleteInstallation_WhenAPIError500_ThenRetriesOnce {
+  FIRInstallationsItem *installation = [FIRInstallationsItem createRegisteredInstallationItem];
+
+  // 1. Stub URL session:
+
+  // 1.1. URL request validation.
+  id URLRequestValidation = [self deleteInstallationRequestValidationWithInstallation:installation];
+
+  // 1.2. Capture completion to call it later.
+  __block void (^taskCompletion)(NSData *, NSURLResponse *, NSError *);
+  id completionArg = [OCMArg checkWithBlock:^BOOL(id obj) {
+    taskCompletion = obj;
+    return YES;
+  }];
+
+  // 1.3. Create a data task mock.
+  id mockDataTask1 = OCMClassMock([NSURLSessionDataTask class]);
+  OCMExpect([(NSURLSessionDataTask *)mockDataTask1 resume]);
+
+  // 1.4. Expect `dataTaskWithRequest` to be called.
+  OCMExpect([self.mockURLSession dataTaskWithRequest:URLRequestValidation
+                                   completionHandler:completionArg])
+      .andReturn(mockDataTask1);
+
+  // 2. Call
+  FBLPromise<FIRInstallationsItem *> *promise = [self.service deleteInstallation:installation];
+
+  // 3. Wait for `[NSURLSession dataTaskWithRequest...]` to be called
+  OCMVerifyAllWithDelay(self.mockURLSession, 0.5);
+
+  // 4. Wait for the data task `resume` to be called.
+  OCMVerifyAllWithDelay(mockDataTask1, 0.5);
+
+  // 5. Call the data task completion.
+  // HTTP 200 but no data (a potential server failure).
+  taskCompletion(nil, [self responseWithStatusCode:kFIRInstallationsAPIInternalErrorHTTPCode], nil);
+
+  // 6. Retry:
+  // 6.1. Wait for the API request to be sent again.
+  id mockDataTask2 = OCMClassMock([NSURLSessionDataTask class]);
+  OCMExpect([(NSURLSessionDataTask *)mockDataTask2 resume]);
+  OCMExpect([self.mockURLSession dataTaskWithRequest:URLRequestValidation
+                                   completionHandler:completionArg])
+      .andReturn(mockDataTask2);
+  OCMVerifyAllWithDelay(self.mockURLSession, 1.5);
+  OCMVerifyAllWithDelay(mockDataTask1, 1.5);
+
+  // 6.1. Send another response.
+  taskCompletion(nil, [self responseWithStatusCode:kFIRInstallationsAPIInternalErrorHTTPCode], nil);
+
+  // 7. Check result.
+  FBLWaitForPromisesWithTimeout(0.5);
+
+  XCTAssertTrue([FIRInstallationsErrorUtil isAPIError:promise.error
+                                         withHTTPCode:kFIRInstallationsAPIInternalErrorHTTPCode]);
+  XCTAssertNil(promise.value);
+}
+
 #pragma mark - Helpers
 
 - (NSData *)loadFixtureNamed:(NSString *)fileName {
@@ -463,8 +651,6 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
     return YES;
   }];
 }
-
-#pragma mark - Helpers
 
 - (NSString *)SDKVersion {
   return [NSString stringWithFormat:@"i:%s", FIRInstallationsVersionStr];

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
@@ -136,7 +136,8 @@
 
 - (void)testAuthTokenError {
   FBLPromise *errorPromise = [FBLPromise pendingPromise];
-  [errorPromise reject:[FIRInstallationsErrorUtil APIErrorWithHTTPCode:500]];
+  [errorPromise reject:[FIRInstallationsErrorUtil
+                           APIErrorWithHTTPCode:kFIRInstallationsAPIInternalErrorHTTPCode]];
   OCMExpect([self.mockIDController getAuthTokenForcingRefresh:NO]).andReturn(errorPromise);
 
   XCTestExpectation *tokenExpectation = [self expectationWithDescription:@"AuthTokenSuccess"];
@@ -184,7 +185,8 @@
 
 - (void)testAuthTokenForcingRefreshError {
   FBLPromise *errorPromise = [FBLPromise pendingPromise];
-  [errorPromise reject:[FIRInstallationsErrorUtil APIErrorWithHTTPCode:500]];
+  [errorPromise reject:[FIRInstallationsErrorUtil
+                           APIErrorWithHTTPCode:kFIRInstallationsAPIInternalErrorHTTPCode]];
   OCMExpect([self.mockIDController getAuthTokenForcingRefresh:YES]).andReturn(errorPromise);
 
   XCTestExpectation *tokenExpectation = [self expectationWithDescription:@"AuthTokenSuccess"];
@@ -218,14 +220,14 @@
 
 - (void)testDeleteError {
   FBLPromise *errorPromise = [FBLPromise pendingPromise];
-  [errorPromise reject:[FIRInstallationsErrorUtil APIErrorWithHTTPCode:500]];
+  NSError *APIError =
+      [FIRInstallationsErrorUtil APIErrorWithHTTPCode:kFIRInstallationsAPIInternalErrorHTTPCode];
+  [errorPromise reject:APIError];
   OCMExpect([self.mockIDController deleteInstallation]).andReturn(errorPromise);
 
-  XCTestExpectation *deleteExpectation = [self expectationWithDescription:@"DeleteSuccess"];
+  XCTestExpectation *deleteExpectation = [self expectationWithDescription:@"deleteExpectation"];
   [self.installations deleteWithCompletion:^(NSError *_Nullable error) {
-    XCTAssertNotNil(error);
-    // TODO: Verify the error content.
-
+    XCTAssertEqualObjects(error, APIError);
     [deleteExpectation fulfill];
   }];
 


### PR DESCRIPTION
- logic to retry API request on response HTTP 500 was moved to the API service and applied to all requests.