### PR TITLE
move database operation off main thread

### DIFF
--- a/Example/Messaging/Tests/FIRMessagingDataMessageManagerTest.m
+++ b/Example/Messaging/Tests/FIRMessagingDataMessageManagerTest.m
@@ -564,6 +564,7 @@ static NSString *const kRmqDatabaseName = @"gcm-dmm-test";
   // wait for 3 seconds (let the amessage get properly deleted)
   [NSThread sleepForTimeInterval:3.0];
   // rmq should not have any pending messages
+
   [newRmqManager scanWithRmqMessageHandler:^(NSDictionary *messages) {
     XCTAssertEqual(messages.allKeys.count, 1);
     [newRmqManager removeDatabase];

--- a/Example/Messaging/Tests/FIRMessagingDataMessageManagerTest.m
+++ b/Example/Messaging/Tests/FIRMessagingDataMessageManagerTest.m
@@ -508,14 +508,10 @@ static NSString *const kRmqDatabaseName = @"gcm-dmm-test";
         [expectation fulfill];
       }
       return YES;
-
     }
     return NO;
   };
-  [[[mockConnection stub] andDo:^(NSInvocation *invocation) {
-    // pass
-  }] sendProto:[OCMArg checkWithBlock:resendMessageBlock]];
-
+  [[mockConnection stub] sendProto:[OCMArg checkWithBlock:resendMessageBlock]];
   [self.dataMessageManager resendMessagesWithConnection:mockConnection];
 
   // should send both messages
@@ -545,7 +541,9 @@ static NSString *const kRmqDatabaseName = @"gcm-dmm-test";
 
   id mockConnection = OCMClassMock([FIRMessagingConnection class]);
   [[mockConnection reject] sendProto:[OCMArg any]];
-  OCMExpect([self.mockRmqManager scanWithRmqMessageHandler:[OCMArg any]]);
+  [[self.mockRmqManager stub] scanWithRmqMessageHandler:[OCMArg checkWithBlock:^BOOL(id obj) {
+        return YES;
+    }]];
 
   [self.dataMessageManager resendMessagesWithConnection:mockConnection];
   OCMVerifyAll(self.mockRmqManager);

--- a/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
+++ b/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
@@ -23,7 +23,7 @@
 
 static NSString *const kRmqDatabaseName = @"rmq-test-db";
 static NSString *const kRmqDataMessageCategory = @"com.google.gcm-rmq-test";
-
+static const NSTimeInterval kAsyncTestTimout = 0.5;
 
 @interface FIRMessagingRmqManager (ExposedForTest)
 
@@ -111,43 +111,48 @@ static NSString *const kRmqDataMessageCategory = @"com.google.gcm-rmq-test";
  *  Test that outgoing RMQ messages are correctly saved
  */
 - (void)testOutgoingRmqWithValidMessages {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Messages are saved"];
+
   NSString *from = @"rmq-test";
   [self.rmqManager loadRmqId];
   GtalkDataMessageStanza *message1 = [self dataMessageWithMessageID:@"message1"
                                                                from:from
                                                                data:nil];
-  NSError *error = nil;
-
   // should successfully save the message to RMQ
-  XCTAssertTrue([self.rmqManager saveRmqMessage:message1 error:&error]);
-  XCTAssertNil(error);
+  [self.rmqManager saveRmqMessage:message1 withCompletionHandler:^(BOOL success) {
+    XCTAssertTrue(success);
+    GtalkDataMessageStanza *message2 = [self dataMessageWithMessageID:@"message2"
+                                                                 from:from
+                                                                 data:nil];
 
-  GtalkDataMessageStanza *message2 = [self dataMessageWithMessageID:@"message2"
-                                                               from:from
-                                                               data:nil];
+    // should successfully save the second message to RMQ
+    [self.rmqManager saveRmqMessage:message2 withCompletionHandler:^(BOOL success) {
+      XCTAssertTrue(success);
+      // message1 should have RMQ-ID = 2, message2 = 3
+      XCTAssertEqual(3, [self maxRmqIDInRmqStoreForD2SMessages]);
+      [self.rmqManager scanWithRmqMessageHandler:nil
+                              dataMessageHandler:^(int64_t rmqId, GtalkDataMessageStanza *stanza) {
+                                if (rmqId == 2) {
+                                  XCTAssertEqualObjects(@"message1", stanza.id_p);
+                                } else if (rmqId == 3) {
+                                  XCTAssertEqualObjects(@"message2", stanza.id_p);
+                                } else {
+                                  XCTFail(@"Invalid RmqID %lld for s2d message", rmqId);
+                                }
+        [expectation fulfill];
+                              }];
+    }];
+  }];
+  [self waitForExpectationsWithTimeout:kAsyncTestTimout handler:nil];
 
-  // should successfully save the second message to RMQ
-  XCTAssertTrue([self.rmqManager saveRmqMessage:message2 error:&error]);
-  XCTAssertNil(error);
-
-  // message1 should have RMQ-ID = 2, message2 = 3
-  XCTAssertEqual(3, [self maxRmqIDInRmqStoreForD2SMessages]);
-  [self.rmqManager scanWithRmqMessageHandler:nil
-                          dataMessageHandler:^(int64_t rmqId, GtalkDataMessageStanza *stanza) {
-                            if (rmqId == 2) {
-                              XCTAssertEqualObjects(@"message1", stanza.id_p);
-                            } else if (rmqId == 3) {
-                              XCTAssertEqualObjects(@"message2", stanza.id_p);
-                            } else {
-                              XCTFail(@"Invalid RmqID %lld for s2d message", rmqId);
-                            }
-                          }];
 }
 
 /**
  *  Test that an outgoing message with different properties is correctly saved to the RMQ.
  */
 - (void)testOutgoingDataMessageIsCorrectlySaved {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Messages are saved"];
+
   NSString *from = @"rmq-test";
   NSString *messageID = @"message123";
   NSString *to = @"to-senderID-123";
@@ -165,31 +170,33 @@ static NSString *const kRmqDataMessageCategory = @"com.google.gcm-rmq-test";
   [message setTo:to];
   [message setTtl:ttl];
   [message setRegId:registrationToken];
-  NSError *error = nil;
 
   // should successfully save the message to RMQ
-  XCTAssertTrue([self.rmqManager saveRmqMessage:message error:&error]);
-  XCTAssertNil(error);
-
-  [self.rmqManager scanWithRmqMessageHandler:nil
-                          dataMessageHandler:^(int64_t rmqId, GtalkDataMessageStanza *stanza) {
-                            XCTAssertEqualObjects(from, stanza.from);
-                            XCTAssertEqualObjects(messageID, stanza.id_p);
-                            XCTAssertEqualObjects(to, stanza.to);
-                            XCTAssertEqualObjects(registrationToken, stanza.regId);
-                            XCTAssertEqual(ttl, stanza.ttl);
-                            NSMutableDictionary *d = [NSMutableDictionary dictionary];
-                            for (GtalkAppData *appData in stanza.appDataArray) {
-                              d[appData.key] = appData.value;
-                            }
-                            XCTAssertTrue([data isEqualToDictionary:d]);
-                          }];
+  [self.rmqManager saveRmqMessage:message withCompletionHandler:^(BOOL success) {
+    XCTAssertTrue(success);
+    [self.rmqManager scanWithRmqMessageHandler:nil
+    dataMessageHandler:^(int64_t rmqId, GtalkDataMessageStanza *stanza) {
+      XCTAssertEqualObjects(from, stanza.from);
+      XCTAssertEqualObjects(messageID, stanza.id_p);
+      XCTAssertEqualObjects(to, stanza.to);
+      XCTAssertEqualObjects(registrationToken, stanza.regId);
+      XCTAssertEqual(ttl, stanza.ttl);
+      NSMutableDictionary *d = [NSMutableDictionary dictionary];
+      for (GtalkAppData *appData in stanza.appDataArray) {
+        d[appData.key] = appData.value;
+      }
+      XCTAssertTrue([data isEqualToDictionary:d]);
+      [expectation fulfill];
+    }];
+  }];
+  [self waitForExpectationsWithTimeout:kAsyncTestTimout handler:nil];
 }
 
 /**
  *  Test D2S messages being deleted from RMQ.
  */
 - (void)testDeletingD2SMessagesFromRMQ {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Messages are saved"];
   NSString *message1 = @"message123";
   NSString *ackedMessage = @"message234";
   NSString *from = @"from-rmq-test";
@@ -197,34 +204,37 @@ static NSString *const kRmqDataMessageCategory = @"com.google.gcm-rmq-test";
   GtalkDataMessageStanza *stanza2 = [self dataMessageWithMessageID:ackedMessage
                                                               from:from
                                                               data:nil];
-  NSError *error = nil;
-  XCTAssertTrue([self.rmqManager saveRmqMessage:stanza1 error:&error]);
-  XCTAssertNil(error);
-  XCTAssertTrue([self.rmqManager saveRmqMessage:stanza2 error:&error]);
-  XCTAssertNil(error);
+  [self.rmqManager saveRmqMessage:stanza1 withCompletionHandler:^(BOOL success) {
+    XCTAssertTrue(success);
+    [self.rmqManager saveRmqMessage:stanza2 withCompletionHandler:^(BOOL success) {
+      XCTAssertTrue(success);
+      __block int64_t ackedMessageRmqID = -1;
+       [self.rmqManager scanWithRmqMessageHandler:nil
+                               dataMessageHandler:^(int64_t rmqId, GtalkDataMessageStanza *stanza) {
+                                 if ([stanza.id_p isEqualToString:ackedMessage]) {
+                                   ackedMessageRmqID = rmqId;
+                                 }
+                               }];
+       // should be a valid RMQ ID
+       XCTAssertTrue(ackedMessageRmqID > 0);
 
-  __block int64_t ackedMessageRmqID = -1;
-  [self.rmqManager scanWithRmqMessageHandler:nil
-                          dataMessageHandler:^(int64_t rmqId, GtalkDataMessageStanza *stanza) {
-                            if ([stanza.id_p isEqualToString:ackedMessage]) {
-                              ackedMessageRmqID = rmqId;
-                            }
-                          }];
-  // should be a valid RMQ ID
-  XCTAssertTrue(ackedMessageRmqID > 0);
+       // delete the acked message
+       NSString *rmqIDString = [NSString stringWithFormat:@"%lld", ackedMessageRmqID];
+       [self.rmqManager removeRmqMessagesWithRmqIds:@[rmqIDString]];
 
-  // delete the acked message
-  NSString *rmqIDString = [NSString stringWithFormat:@"%lld", ackedMessageRmqID];
-  XCTAssertEqual(1, [self.rmqManager removeRmqMessagesWithRmqIds:@[rmqIDString]]);
-
-  // should only have one message in the d2s RMQ
-  [self.rmqManager scanWithRmqMessageHandler:nil
-                          dataMessageHandler:^(int64_t rmqId, GtalkDataMessageStanza *stanza) {
-                            // the acked message was queued later so should have
-                            // rmqID = ackedMessageRMQID - 1
-                            XCTAssertEqual(ackedMessageRmqID - 1, rmqId);
-                            XCTAssertEqual(message1, stanza2.id_p);
-                          }];
+       // should only have one message in the d2s RMQ
+       [self.rmqManager scanWithRmqMessageHandler:nil
+                               dataMessageHandler:^(int64_t rmqId, GtalkDataMessageStanza *stanza) {
+         // the acked message was queued later so should have
+         // rmqID = ackedMessageRMQID - 1
+         XCTAssertEqual(ackedMessageRmqID - 1, rmqId);
+         XCTAssertEqual(message1, stanza2.id_p);
+         [expectation fulfill];
+       }];
+    }];
+  }];
+ 
+  [self waitForExpectationsWithTimeout:kAsyncTestTimout handler:nil];
 }
 
 /**
@@ -233,11 +243,10 @@ static NSString *const kRmqDataMessageCategory = @"com.google.gcm-rmq-test";
 - (void)testSavingSyncMessage {
   NSString *rmqID = @"fake-rmq-id-1";
   int64_t expirationTime = FIRMessagingCurrentTimestampInSeconds() + 1;
-  XCTAssertTrue([self.rmqManager saveSyncMessageWithRmqID:rmqID
-                                           expirationTime:expirationTime
-                                             apnsReceived:YES
-                                              mcsReceived:NO
-                                                    error:nil]);
+  [self.rmqManager saveSyncMessageWithRmqID:rmqID
+                             expirationTime:expirationTime
+                               apnsReceived:YES
+                                mcsReceived:NO];
 
   FIRMessagingPersistentSyncMessage *persistentMessage = [self.rmqManager querySyncMessageWithRmqID:rmqID];
   XCTAssertEqual(persistentMessage.expirationTime, expirationTime);
@@ -251,14 +260,13 @@ static NSString *const kRmqDataMessageCategory = @"com.google.gcm-rmq-test";
 - (void)testUpdateMessageReceivedViaAPNS {
   NSString *rmqID = @"fake-rmq-id-1";
   int64_t expirationTime = FIRMessagingCurrentTimestampInSeconds() + 1;
-  XCTAssertTrue([self.rmqManager saveSyncMessageWithRmqID:rmqID
-                                           expirationTime:expirationTime
-                                             apnsReceived:NO
-                                              mcsReceived:YES
-                                                    error:nil]);
+  [self.rmqManager saveSyncMessageWithRmqID:rmqID
+                             expirationTime:expirationTime
+                               apnsReceived:NO
+                                mcsReceived:YES];
 
   // Message was now received via APNS
-  XCTAssertTrue([self.rmqManager updateSyncMessageViaAPNSWithRmqID:rmqID error:nil]);
+  [self.rmqManager updateSyncMessageViaAPNSWithRmqID:rmqID];
 
   FIRMessagingPersistentSyncMessage *persistentMessage = [self.rmqManager querySyncMessageWithRmqID:rmqID];
   XCTAssertTrue(persistentMessage.apnsReceived);
@@ -271,14 +279,13 @@ static NSString *const kRmqDataMessageCategory = @"com.google.gcm-rmq-test";
 - (void)testUpdateMessageReceivedViaMCS {
   NSString *rmqID = @"fake-rmq-id-1";
   int64_t expirationTime = FIRMessagingCurrentTimestampInSeconds() + 1;
-  XCTAssertTrue([self.rmqManager saveSyncMessageWithRmqID:rmqID
-                                           expirationTime:expirationTime
-                                             apnsReceived:YES
-                                              mcsReceived:NO
-                                                    error:nil]);
+  [self.rmqManager saveSyncMessageWithRmqID:rmqID
+                             expirationTime:expirationTime
+                               apnsReceived:YES
+                                mcsReceived:NO];
 
   // Message was now received via APNS
-  XCTAssertTrue([self.rmqManager updateSyncMessageViaMCSWithRmqID:rmqID error:nil]);
+  [self.rmqManager updateSyncMessageViaMCSWithRmqID:rmqID];
 
   FIRMessagingPersistentSyncMessage *persistentMessage = [self.rmqManager querySyncMessageWithRmqID:rmqID];
   XCTAssertTrue(persistentMessage.apnsReceived);
@@ -291,15 +298,14 @@ static NSString *const kRmqDataMessageCategory = @"com.google.gcm-rmq-test";
 - (void)testDeleteSyncMessage {
   NSString *rmqID = @"fake-rmq-id-1";
   int64_t expirationTime = FIRMessagingCurrentTimestampInSeconds() + 1;
-  XCTAssertTrue([self.rmqManager saveSyncMessageWithRmqID:rmqID
-                                           expirationTime:expirationTime
-                                             apnsReceived:YES
-                                              mcsReceived:NO
-                                                    error:nil]);
+  [self.rmqManager saveSyncMessageWithRmqID:rmqID
+                             expirationTime:expirationTime
+                               apnsReceived:YES
+                                mcsReceived:NO];
   XCTAssertNotNil([self.rmqManager querySyncMessageWithRmqID:rmqID]);
 
   // should successfully delete the message
-  XCTAssertTrue([self.rmqManager deleteSyncMessageWithRmqID:rmqID]);
+  [self.rmqManager deleteSyncMessageWithRmqID:rmqID];
   XCTAssertNil([self.rmqManager querySyncMessageWithRmqID:rmqID]);
 }
 

--- a/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
+++ b/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
@@ -227,7 +227,6 @@ static const NSTimeInterval kAsyncTestTimout = 0.5;
 
     }];
   }];
- 
   [self waitForExpectationsWithTimeout:kAsyncTestTimout handler:nil];
 }
 

--- a/Example/Messaging/Tests/FIRMessagingSyncMessageManagerTest.m
+++ b/Example/Messaging/Tests/FIRMessagingSyncMessageManagerTest.m
@@ -42,12 +42,12 @@ static NSString *const kRmqSqliteFilename = @"rmq-sync-manager-test";
 - (void)setUp {
   [super setUp];
   // Make sure the db state is clean before we begin.
-  self.rmqManager = [[FIRMessagingRmqManager alloc] initWithDatabaseName:kRmqSqliteFilename];
+  _rmqManager = [[FIRMessagingRmqManager alloc] initWithDatabaseName:kRmqSqliteFilename];
   self.syncMessageManager = [[FIRMessagingSyncMessageManager alloc] initWithRmqManager:self.rmqManager];
 }
 
 - (void)tearDown {
-  [self.rmqManager removeDatabase];
+  [_rmqManager removeDatabase];
   [super tearDown];
 }
 
@@ -213,7 +213,7 @@ static NSString *const kRmqSqliteFilename = @"rmq-sync-manager-test";
   XCTAssertFalse([self.syncMessageManager didReceiveAPNSSyncMessage:noTTLMessage]);
 
   // Mark the no-TTL message as received via MCS too
-  XCTAssertTrue([self.rmqManager updateSyncMessageViaMCSWithRmqID:noTTLMessageID error:nil]);
+  [self.rmqManager updateSyncMessageViaMCSWithRmqID:noTTLMessageID];
 
   [self.syncMessageManager removeExpiredSyncMessages];
 
@@ -248,7 +248,7 @@ static NSString *const kRmqSqliteFilename = @"rmq-sync-manager-test";
   XCTAssertFalse([self.syncMessageManager didReceiveAPNSSyncMessage:noTTLMessage]);
 
   // Mark the no-TTL message as received via MCS too
-  XCTAssertTrue([self.rmqManager updateSyncMessageViaMCSWithRmqID:noTTLMessageID error:nil]);
+  [self.rmqManager updateSyncMessageViaMCSWithRmqID:noTTLMessageID];
 
   // Remove expired or finished sync messages.
   [self.syncMessageManager removeExpiredSyncMessages];

--- a/Firebase/Messaging/FIRMMessageCode.h
+++ b/Firebase/Messaging/FIRMMessageCode.h
@@ -97,12 +97,12 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingMessageCodeContextManagerService004 = 6004,  // I-FCM006004
   kFIRMessagingMessageCodeContextManagerService005 = 6005,  // I-FCM006005
   // FIRMessagingDataMessageManager.m
+  // DO NOT USE 7005
   kFIRMessagingMessageCodeDataMessageManager000 = 7000,  // I-FCM007000
   kFIRMessagingMessageCodeDataMessageManager001 = 7001,  // I-FCM007001
   kFIRMessagingMessageCodeDataMessageManager002 = 7002,  // I-FCM007002
   kFIRMessagingMessageCodeDataMessageManager003 = 7003,  // I-FCM007003
   kFIRMessagingMessageCodeDataMessageManager004 = 7004,  // I-FCM007004
-  kFIRMessagingMessageCodeDataMessageManager005 = 7005,  // I-FCM007005
   kFIRMessagingMessageCodeDataMessageManager006 = 7006,  // I-FCM007006
   kFIRMessagingMessageCodeDataMessageManager007 = 7007,  // I-FCM007007
   kFIRMessagingMessageCodeDataMessageManager008 = 7008,  // I-FCM007008
@@ -164,10 +164,9 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingMessageCodeSecureSocket015 = 15015,  // I-FCM015015
   kFIRMessagingMessageCodeSecureSocket016 = 15016,  // I-FCM015016
   // FIRMessagingSyncMessageManager.m
-  kFIRMessagingMessageCodeSyncMessageManager000 = 16000,  // I-FCM016000
+  // DO NOT USE 16000, 16003
   kFIRMessagingMessageCodeSyncMessageManager001 = 16001,  // I-FCM016001
   kFIRMessagingMessageCodeSyncMessageManager002 = 16002,  // I-FCM016002
-  kFIRMessagingMessageCodeSyncMessageManager003 = 16003,  // I-FCM016003
   kFIRMessagingMessageCodeSyncMessageManager004 = 16004,  // I-FCM016004
   kFIRMessagingMessageCodeSyncMessageManager005 = 16005,  // I-FCM016005
   kFIRMessagingMessageCodeSyncMessageManager006 = 16006,  // I-FCM016006

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -365,15 +365,7 @@ const BOOL FIRMessagingIsAPNSSyncMessage(NSDictionary *message) {
 - (void)setupSyncMessageManager {
   self.syncMessageManager =
       [[FIRMessagingSyncMessageManager alloc] initWithRmqManager:self.rmq2Manager];
-
-  // Delete the expired messages with a delay. We don't want to block startup with a somewhat
-  // expensive db call.
-  FIRMessaging_WEAKIFY(self);
-  dispatch_time_t time = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC));
-  dispatch_after(time, dispatch_get_main_queue(), ^{
-    FIRMessaging_STRONGIFY(self);
-    [self.syncMessageManager removeExpiredSyncMessages];
-  });
+  [self.syncMessageManager removeExpiredSyncMessages];
 }
 
 - (void)teardown {

--- a/Firebase/Messaging/FIRMessagingClient.m
+++ b/Firebase/Messaging/FIRMessagingClient.m
@@ -393,7 +393,7 @@ static NSUInteger FIRMessagingServerPort() {
   }
 }
 
-- (int)connectionDidReceiveAckForRmqIds:(NSArray *)rmqIds {
+- (void)connectionDidReceiveAckForRmqIds:(NSArray *)rmqIds {
   NSSet *rmqIDSet = [NSSet setWithArray:rmqIds];
   NSMutableArray *messagesSent = [NSMutableArray arrayWithCapacity:rmqIds.count];
   [self.rmq2Manager scanWithRmqMessageHandler:nil
@@ -406,7 +406,7 @@ static NSUInteger FIRMessagingServerPort() {
   for (GtalkDataMessageStanza *message in messagesSent) {
     [self.dataMessageManager didSendDataMessageStanza:message];
   }
-  return [self.rmq2Manager removeRmqMessagesWithRmqIds:rmqIds];
+  [self.rmq2Manager removeRmqMessagesWithRmqIds:rmqIds];
 }
 
 #pragma mark - Private

--- a/Firebase/Messaging/FIRMessagingClient.m
+++ b/Firebase/Messaging/FIRMessagingClient.m
@@ -16,6 +16,8 @@
 
 #import "Firebase/Messaging/FIRMessagingClient.h"
 
+#import "Firebase/Messaging/Protos/GtalkCore.pbobjc.h"
+
 #import <FirebaseInstanceID/FIRInstanceID_Private.h>
 #import <FirebaseMessaging/FIRMessaging.h>
 #import <GoogleUtilities/GULReachabilityChecker.h>
@@ -396,13 +398,15 @@ static NSUInteger FIRMessagingServerPort() {
 - (void)connectionDidReceiveAckForRmqIds:(NSArray *)rmqIds {
   NSSet *rmqIDSet = [NSSet setWithArray:rmqIds];
   NSMutableArray *messagesSent = [NSMutableArray arrayWithCapacity:rmqIds.count];
-  [self.rmq2Manager scanWithRmqMessageHandler:nil
-                           dataMessageHandler:^(int64_t rmqId, GtalkDataMessageStanza *stanza) {
-                             NSString *rmqIdString = [NSString stringWithFormat:@"%lld", rmqId];
-                             if ([rmqIDSet containsObject:rmqIdString]) {
-                               [messagesSent addObject:stanza];
-                             }
-                           }];
+  [self.rmq2Manager scanWithRmqMessageHandler:^(NSDictionary *messages) {
+    for (NSString *rmqID in messages) {
+      GPBMessage *proto = messages[rmqID];
+      GtalkDataMessageStanza *stanza = (GtalkDataMessageStanza *)proto;
+      if ([rmqIDSet containsObject:rmqID]) {
+        [messagesSent addObject:stanza];
+      }
+    }
+  }];
   for (GtalkDataMessageStanza *message in messagesSent) {
     [self.dataMessageManager didSendDataMessageStanza:message];
   }

--- a/Firebase/Messaging/FIRMessagingConnection.h
+++ b/Firebase/Messaging/FIRMessagingConnection.h
@@ -47,9 +47,8 @@ typedef NS_ENUM(NSUInteger, FIRMessagingConnectionCloseReason) {
 /**
  * Called when a stream ACK or a selective ACK are received - this indicates the
  * message has been received by MCS.
- * @return The count of rmqIds deleted from the client RMQ store.
  */
-- (int)connectionDidReceiveAckForRmqIds:(NSArray *)rmqIds;
+- (void)connectionDidReceiveAckForRmqIds:(NSArray *)rmqIds;
 
 @end
 

--- a/Firebase/Messaging/FIRMessagingConnection.m
+++ b/Firebase/Messaging/FIRMessagingConnection.m
@@ -33,8 +33,6 @@
 static NSInteger const kIqSelectiveAck = 12;
 static NSInteger const kIqStreamAck = 13;
 static int const kInvalidStreamId = -1;
-// Threshold for number of messages removed that we will ack, for short lived connections
-static int const kMessageRemoveAckThresholdCount = 5;
 
 static NSTimeInterval const kHeartbeatInterval = 30.0;
 static NSTimeInterval const kConnectionTimeout = 20.0;
@@ -588,12 +586,6 @@ static NSString *const kRemoteFromAddress = @"from";
     [self.d2sInfos removeObject:d2sInfo];
   }
   [self.delegate connectionDidReceiveAckForRmqIds:rmqIds];
-  int count = [self.delegate connectionDidReceiveAckForRmqIds:rmqIds];
-  if (kMessageRemoveAckThresholdCount > 0 && count >= kMessageRemoveAckThresholdCount) {
-    // For short lived connections, if a large number of messages are removed, send an
-    // ack straight away so the server knows that this message was received.
-    [self sendStreamAck];
-  }
 }
 
 - (void)confirmAckedS2dIdsWithStreamId:(int)lastReceivedStreamId {

--- a/Firebase/Messaging/FIRMessagingDataMessageManager.m
+++ b/Firebase/Messaging/FIRMessagingDataMessageManager.m
@@ -439,7 +439,7 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
                              rmqIdsResent);
     }
     if ([toRemoveRmqIds count]) {
-      [self.rmq2Manager removeRmqMessagesWithRmqIds:toRemoveRmqIds];
+      [self.rmq2Manager removeRmqMessagesWithRmqIds:[toRemoveRmqIds copy]];
     }
   }];
 }

--- a/Firebase/Messaging/FIRMessagingDataMessageManager.m
+++ b/Firebase/Messaging/FIRMessagingDataMessageManager.m
@@ -417,7 +417,7 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
   NSMutableArray *toRemoveRmqIds = [NSMutableArray array];
   FIRMessaging_WEAKIFY(self);
   FIRMessaging_WEAKIFY(connection);
-   
+
   [self.rmq2Manager scanWithRmqMessageHandler:^(NSDictionary *messages) {
     FIRMessaging_STRONGIFY(self);
     FIRMessaging_STRONGIFY(connection);

--- a/Firebase/Messaging/FIRMessagingDataMessageManager.m
+++ b/Firebase/Messaging/FIRMessagingDataMessageManager.m
@@ -294,9 +294,6 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
 
   BOOL useRmq = (ttl != 0) && (msgId != nil);
   if (useRmq) {
-    if (!self.client.isConnected) {
-      // do nothing assuming rmq save is enabled
-    }
     [self.rmq2Manager saveRmqMessage:stanza withCompletionHandler:^(BOOL success) {
       if (!success) {
         [self willSendDataMessageFail:stanza withMessageId:msgId error:kFIRMessagingErrorSave];
@@ -420,35 +417,31 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
   NSMutableArray *toRemoveRmqIds = [NSMutableArray array];
   FIRMessaging_WEAKIFY(self);
   FIRMessaging_WEAKIFY(connection);
-  FIRMessagingRmqMessageHandler messageHandler = ^(int64_t rmqId, int8_t tag, NSData *data) {
+   
+  [self.rmq2Manager scanWithRmqMessageHandler:^(NSDictionary *messages) {
     FIRMessaging_STRONGIFY(self);
     FIRMessaging_STRONGIFY(connection);
-    GPBMessage *proto =
-        [FIRMessagingGetClassForTag((FIRMessagingProtoTag)tag) parseFromData:data error:NULL];
-    if ([proto isKindOfClass:GtalkDataMessageStanza.class]) {
+    for (NSString *rmqID in messages) {
+      GPBMessage *proto = messages[rmqID];
+      if ([proto isKindOfClass:GtalkDataMessageStanza.class]) {
       GtalkDataMessageStanza *stanza = (GtalkDataMessageStanza *)proto;
-
-      if (![self handleExpirationForDataMessage:stanza]) {
-        // time expired let's delete from RMQ
-        [toRemoveRmqIds addObject:stanza.persistentId];
-        return;
+        if (![self handleExpirationForDataMessage:stanza]) {
+          // time expired let's delete from RMQ
+          [toRemoveRmqIds addObject:stanza.persistentId];
+          continue;
+        }
+        [rmqIdsResent appendString:[NSString stringWithFormat:@"%@,", stanza.id_p]];
       }
-      [rmqIdsResent appendString:[NSString stringWithFormat:@"%@,", stanza.id_p]];
+      [connection sendProto:proto];
     }
-
-    [connection sendProto:proto];
-  };
-  [self.rmq2Manager scanWithRmqMessageHandler:messageHandler
-                           dataMessageHandler:nil];
-
-  if ([rmqIdsResent length]) {
-    FIRMessagingLoggerDebug(kFIRMessagingMessageCodeDataMessageManager012, @"Resent: %@",
-                            rmqIdsResent);
-  }
-
-  if ([toRemoveRmqIds count]) {
-    [self.rmq2Manager removeRmqMessagesWithRmqIds:toRemoveRmqIds];
-  }
+    if ([rmqIdsResent length]) {
+      FIRMessagingLoggerDebug(kFIRMessagingMessageCodeDataMessageManager012, @"Resent: %@",
+                             rmqIdsResent);
+    }
+    if ([toRemoveRmqIds count]) {
+      [self.rmq2Manager removeRmqMessagesWithRmqIds:toRemoveRmqIds];
+    }
+  }];
 }
 
 /**

--- a/Firebase/Messaging/FIRMessagingDataMessageManager.m
+++ b/Firebase/Messaging/FIRMessagingDataMessageManager.m
@@ -297,15 +297,13 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
     if (!self.client.isConnected) {
       // do nothing assuming rmq save is enabled
     }
-
-    NSError *error;
-    if (![self.rmq2Manager saveRmqMessage:stanza error:&error]) {
-      FIRMessagingLoggerDebug(kFIRMessagingMessageCodeDataMessageManager005, @"%@", error);
-      [self willSendDataMessageFail:stanza withMessageId:msgId error:kFIRMessagingErrorSave];
-      return;
-    }
-
-    [self willSendDataMessageSuccess:stanza withMessageId:msgId];
+    [self.rmq2Manager saveRmqMessage:stanza withCompletionHandler:^(BOOL success) {
+      if (!success) {
+        [self willSendDataMessageFail:stanza withMessageId:msgId error:kFIRMessagingErrorSave];
+        return;
+      }
+      [self willSendDataMessageSuccess:stanza withMessageId:msgId];
+    }];
   }
 
   // if delay > 0 we don't really care about sending the message right now

--- a/Firebase/Messaging/FIRMessagingRmqManager.h
+++ b/Firebase/Messaging/FIRMessagingRmqManager.h
@@ -24,7 +24,6 @@
 /**
  * Called on each raw message.
  */
-//typedef void(^FIRMessagingRmqMessageHandler)(int64_t rmqId, int8_t tag, NSData *data);
 typedef void(^FIRMessagingRmqMessageHandler)(NSDictionary<NSString *, GPBMessage *> *messages);
 
 /**

--- a/Firebase/Messaging/FIRMessagingRmqManager.h
+++ b/Firebase/Messaging/FIRMessagingRmqManager.h
@@ -24,12 +24,8 @@
 /**
  * Called on each raw message.
  */
-typedef void(^FIRMessagingRmqMessageHandler)(int64_t rmqId, int8_t tag, NSData *data);
-
-/**
- * Called on each DataMessageStanza.
- */
-typedef void(^FIRMessagingDataMessageHandler)(int64_t rmqId, GtalkDataMessageStanza *stanza);
+//typedef void(^FIRMessagingRmqMessageHandler)(int64_t rmqId, int8_t tag, NSData *data);
+typedef void(^FIRMessagingRmqMessageHandler)(NSDictionary<NSString *, GPBMessage *> *messages);
 
 /**
  *  Used to scan through the rmq and perform actions on messages as required.
@@ -39,8 +35,7 @@ typedef void(^FIRMessagingDataMessageHandler)(int64_t rmqId, GtalkDataMessageSta
 /**
  *  Scan the RMQ for outgoing messages and process them as required.
  */
-- (void)scanWithRmqMessageHandler:(FIRMessagingRmqMessageHandler)rmqMessageHandler
-               dataMessageHandler:(FIRMessagingDataMessageHandler)dataMessageHandler;
+- (void)scanWithRmqMessageHandler:(FIRMessagingRmqMessageHandler)rmqMessageHandler;
 
 @end
 

--- a/Firebase/Messaging/FIRMessagingRmqManager.h
+++ b/Firebase/Messaging/FIRMessagingRmqManager.h
@@ -68,20 +68,18 @@ typedef void(^FIRMessagingDataMessageHandler)(int64_t rmqId, GtalkDataMessageSta
  *  lose the message since it would be saved in the RMQ.
  *
  *  @param message The upstream message to be saved.
- *  @param error   The error if any while saving the message else nil.
+ *  @param handler   The handler to invoke when the database operation completes with response.
  *
- *  @return YES if the message was successfully saved to RMQ else NO.
  */
-- (BOOL)saveRmqMessage:(GPBMessage *)message error:(NSError **)error;
+- (void)saveRmqMessage:(GPBMessage *)message withCompletionHandler:(void(^)(BOOL success))handler;
 
 /**
  *  Save Server to device message with the given RMQ-ID.
  *
  *  @param rmqID The rmqID of the s2d message to save.
  *
- *  @return YES if the save was successfull else NO.
  */
-- (BOOL)saveS2dMessageWithRmqId:(NSString *)rmqID;
+- (void)saveS2dMessageWithRmqId:(NSString *)rmqID;
 
 /**
  *  A list of all unacked Server to device RMQ IDs.
@@ -95,9 +93,8 @@ typedef void(^FIRMessagingDataMessageHandler)(int64_t rmqId, GtalkDataMessageSta
  *
  *  @param rmqIds The lsit of rmqID's to remove from the store.
  *
- *  @return The number of messages deleted successfully.
  */
-- (int)removeRmqMessagesWithRmqIds:(NSArray *)rmqIds;
+- (void)removeRmqMessagesWithRmqIds:(NSArray *)rmqIds;
 
 /**
  *  Removes a list of downstream messages from the RMQ.
@@ -123,19 +120,15 @@ typedef void(^FIRMessagingDataMessageHandler)(int64_t rmqId, GtalkDataMessageSta
  *
  *  @param rmqID The rmqID of the persisted sync message.
  *
- *  @return YES if the message was successfully deleted else NO.
  */
-- (BOOL)deleteSyncMessageWithRmqID:(NSString *)rmqID;
+- (void)deleteSyncMessageWithRmqID:(NSString *)rmqID;
 
 /**
  *  Delete the expired sync messages from persisten store. Also deletes messages that have been
  *  delivered both via APNS and MCS.
  *
- *  @param error The error if any while deleting the messages.
- *
- *  @return The total number of messages that were deleted from the persistent store.
  */
-- (int)deleteExpiredOrFinishedSyncMessages:(NSError **)error;
+- (void)deleteExpiredOrFinishedSyncMessages;
 
 /**
  *  Save sync message received by the device.
@@ -144,34 +137,27 @@ typedef void(^FIRMessagingDataMessageHandler)(int64_t rmqId, GtalkDataMessageSta
  *  @param expirationTime The expiration time of the sync message received.
  *  @param apnsReceived   YES if the message was received via APNS else NO.
  *  @param mcsReceived    YES if the message was received via MCS else NO.
- *  @param error          The error if any while saving the sync message to persistent store.
  *
- *  @return YES if the message save was successful else NO.
  */
-- (BOOL)saveSyncMessageWithRmqID:(NSString *)rmqID
+- (void)saveSyncMessageWithRmqID:(NSString *)rmqID
                   expirationTime:(int64_t)expirationTime
                     apnsReceived:(BOOL)apnsReceived
-                     mcsReceived:(BOOL)mcsReceived
-                           error:(NSError **)error;
+                     mcsReceived:(BOOL)mcsReceived;
 
 /**
  *  Update sync message received via APNS.
  *
  *  @param rmqID The rmqID of the received message.
- *  @param error The error if any while updating the sync message.
  *
- *  @return YES if the persistent sync message was successfully updated else NO.
  */
-- (BOOL)updateSyncMessageViaAPNSWithRmqID:(NSString *)rmqID error:(NSError **)error;
+- (void)updateSyncMessageViaAPNSWithRmqID:(NSString *)rmqID;
 
 /**
  *  Update sync message received via MCS.
  *
  *  @param rmqID The rmqID of the received message.
- *  @param error The error if any while updating the sync message.
  *
- *  @return YES if the persistent sync message was successfully updated else NO.
  */
-- (BOOL)updateSyncMessageViaMCSWithRmqID:(NSString *)rmqID error:(NSError **)error;
+- (void)updateSyncMessageViaMCSWithRmqID:(NSString *)rmqID;
 
 @end

--- a/Firebase/Messaging/FIRMessagingRmqManager.m
+++ b/Firebase/Messaging/FIRMessagingRmqManager.m
@@ -677,7 +677,11 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
     if (sqlite3_prepare_v2(self->_database, [query UTF8String], -1, &statement, NULL) != SQLITE_OK) {
       [self logError];
       sqlite3_finalize(statement);
-      return;
+      if (rmqMessageHandler) {
+        dispatch_async(dispatch_get_main_queue(),^{
+          rmqMessageHandler(messages);
+        });
+      }
     }
     // can query sqlite3 for this but this is fine
     const int rmqIdColumnNumber = 0;

--- a/Firebase/Messaging/FIRMessagingRmqManager.m
+++ b/Firebase/Messaging/FIRMessagingRmqManager.m
@@ -739,7 +739,7 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
   return YES;
 }
 
--(void)deleteMessagesFromTable:(NSString *)tableName
+- (void)deleteMessagesFromTable:(NSString *)tableName
                     withRmqIds:(NSArray *)rmqIds {
   dispatch_async(_databaseOperationQueue, ^{
     BOOL isRmqIDString = NO;

--- a/Firebase/Messaging/FIRMessagingRmqManager.m
+++ b/Firebase/Messaging/FIRMessagingRmqManager.m
@@ -589,19 +589,19 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 
 - (void)createTableWithName:(NSString *)tableName command:(NSString *)command {
   FIRMessaging_MUST_NOT_BE_MAIN_THREAD();
-    char *error;
-    NSString *createDatabase = [NSString stringWithFormat:command, kTablePrefix, tableName];
-    if (sqlite3_exec(self->_database, [createDatabase UTF8String], NULL, NULL, &error) != SQLITE_OK) {
-      // remove db before failing
-      [self removeDatabase];
-      NSString *errorMessage = [NSString stringWithFormat:@"Couldn't create table: %@ %@",
-                                kCreateTableOutgoingRmqMessages,
-                                [NSString stringWithCString:error encoding:NSUTF8StringEncoding]];
-      FIRMessagingLoggerError(kFIRMessagingMessageCodeRmq2PersistentStoreErrorCreatingTable,
-                              @"%@",
-                              errorMessage);
-      NSAssert(NO, errorMessage);
-    }
+  char *error;
+  NSString *createDatabase = [NSString stringWithFormat:command, kTablePrefix, tableName];
+  if (sqlite3_exec(self->_database, [createDatabase UTF8String], NULL, NULL, &error) != SQLITE_OK) {
+    // remove db before failing
+    [self removeDatabase];
+    NSString *errorMessage = [NSString stringWithFormat:@"Couldn't create table: %@ %@",
+                              kCreateTableOutgoingRmqMessages,
+                              [NSString stringWithCString:error encoding:NSUTF8StringEncoding]];
+    FIRMessagingLoggerError(kFIRMessagingMessageCodeRmq2PersistentStoreErrorCreatingTable,
+                            @"%@",
+                            errorMessage);
+    NSAssert(NO, errorMessage);
+  }
 }
 
 - (void)dropTableWithName:(NSString *)tableName {
@@ -827,7 +827,7 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
         FIRMessagingRmqLogAndReturn(delete_statement);
       }
       sqlite3_finalize(delete_statement);
-      deleteCount += sqlite3_changes(_database);
+      deleteCount += sqlite3_changes(self->_database);
       start = end;
     }
 
@@ -836,7 +836,6 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
                             @"Trying to delete %d s2D ID's, successfully deleted %d",
                             toDelete, deleteCount);
   });
-  
 }
 
 - (int64_t)nextRmqId {

--- a/Firebase/Messaging/FIRMessagingRmqManager.m
+++ b/Firebase/Messaging/FIRMessagingRmqManager.m
@@ -229,49 +229,49 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
  */
 - (void)saveLastOutgoingRmqId:(int64_t)rmqID {
   dispatch_async(_databaseOperationQueue, ^{
-  NSString *queryFormat = @"INSERT OR REPLACE INTO %@ (%@, %@) VALUES (?, ?)";
-  NSString *query = [NSString stringWithFormat:queryFormat,
-                     kTableLastRmqId, // table
-                     kIdColumn, kRmqIdColumn]; // columns
-  sqlite3_stmt *statement;
-  if (sqlite3_prepare_v2(self->_database, [query UTF8String], -1, &statement, NULL) != SQLITE_OK) {
-    FIRMessagingRmqLogAndReturn(statement);
-  }
-  if (sqlite3_bind_int(statement, 1, 1) != SQLITE_OK) {
-    FIRMessagingRmqLogAndReturn(statement);
-  }
-  if (sqlite3_bind_int64(statement, 2, rmqID) != SQLITE_OK) {
-    FIRMessagingRmqLogAndReturn(statement);
-  }
-  if (sqlite3_step(statement) != SQLITE_DONE) {
-    FIRMessagingRmqLogAndReturn(statement);
-  }
-  sqlite3_finalize(statement);
+    NSString *queryFormat = @"INSERT OR REPLACE INTO %@ (%@, %@) VALUES (?, ?)";
+    NSString *query = [NSString stringWithFormat:queryFormat,
+                       kTableLastRmqId, // table
+                       kIdColumn, kRmqIdColumn]; // columns
+    sqlite3_stmt *statement;
+    if (sqlite3_prepare_v2(self->_database, [query UTF8String], -1, &statement, NULL) != SQLITE_OK) {
+      FIRMessagingRmqLogAndReturn(statement);
+    }
+    if (sqlite3_bind_int(statement, 1, 1) != SQLITE_OK) {
+      FIRMessagingRmqLogAndReturn(statement);
+    }
+    if (sqlite3_bind_int64(statement, 2, rmqID) != SQLITE_OK) {
+      FIRMessagingRmqLogAndReturn(statement);
+    }
+    if (sqlite3_step(statement) != SQLITE_DONE) {
+      FIRMessagingRmqLogAndReturn(statement);
+    }
+    sqlite3_finalize(statement);
   });
 }
 
 - (void)saveS2dMessageWithRmqId:(NSString *)rmqId {
   dispatch_async(_databaseOperationQueue, ^{
-  NSString *insertFormat = @"INSERT INTO %@ (%@) VALUES (?)";
-  NSString *insertSQL = [NSString stringWithFormat:insertFormat,
-                         kTableS2DRmqIds,
-                         kRmqIdColumn];
-  sqlite3_stmt *insert_statement;
-  if (sqlite3_prepare_v2(self->_database, [insertSQL UTF8String], -1, &insert_statement, NULL)
-      != SQLITE_OK) {
-    FIRMessagingRmqLogAndReturn(insert_statement);
-  }
-  if (sqlite3_bind_text(insert_statement,
-                        1,
-                        [rmqId UTF8String],
-                        (int)[rmqId length],
-                        SQLITE_STATIC) != SQLITE_OK) {
-    FIRMessagingRmqLogAndReturn(insert_statement);
-  }
-  if (sqlite3_step(insert_statement) != SQLITE_DONE) {
-    FIRMessagingRmqLogAndReturn(insert_statement);
-  }
-  sqlite3_finalize(insert_statement);
+    NSString *insertFormat = @"INSERT INTO %@ (%@) VALUES (?)";
+    NSString *insertSQL = [NSString stringWithFormat:insertFormat,
+                           kTableS2DRmqIds,
+                           kRmqIdColumn];
+    sqlite3_stmt *insert_statement;
+    if (sqlite3_prepare_v2(self->_database, [insertSQL UTF8String], -1, &insert_statement, NULL)
+        != SQLITE_OK) {
+      FIRMessagingRmqLogAndReturn(insert_statement);
+    }
+    if (sqlite3_bind_text(insert_statement,
+                          1,
+                          [rmqId UTF8String],
+                          (int)[rmqId length],
+                          SQLITE_STATIC) != SQLITE_OK) {
+      FIRMessagingRmqLogAndReturn(insert_statement);
+    }
+    if (sqlite3_step(insert_statement) != SQLITE_DONE) {
+      FIRMessagingRmqLogAndReturn(insert_statement);
+    }
+    sqlite3_finalize(insert_statement);
   });
 }
 
@@ -320,22 +320,22 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 - (NSArray *)unackedS2dRmqIds {
   __block NSMutableArray *rmqIDArray = [NSMutableArray array];
   dispatch_sync(_databaseOperationQueue, ^{
-  NSString *queryFormat = @"SELECT %@ FROM %@ ORDER BY %@ ASC";
-  NSString *query = [NSString stringWithFormat:queryFormat,
-                     kRmqIdColumn,
-                     kTableS2DRmqIds,
-                     kRmqIdColumn];
-  sqlite3_stmt *statement;
-  if (sqlite3_prepare_v2(self->_database, [query UTF8String], -1, &statement, NULL) != SQLITE_OK) {
-    FIRMessagingLoggerDebug(kFIRMessagingMessageCodeRmq2PersistentStore005,
-                            @"Could not find s2d ids");
-    FIRMessagingRmqLogAndReturn(statement);
-  }
-  while (sqlite3_step(statement) == SQLITE_ROW) {
-    const char *rmqID = (char *)sqlite3_column_text(statement, 0);
-    [rmqIDArray addObject:[NSString stringWithUTF8String:rmqID]];
-  }
-  sqlite3_finalize(statement);
+    NSString *queryFormat = @"SELECT %@ FROM %@ ORDER BY %@ ASC";
+    NSString *query = [NSString stringWithFormat:queryFormat,
+                       kRmqIdColumn,
+                       kTableS2DRmqIds,
+                       kRmqIdColumn];
+    sqlite3_stmt *statement;
+    if (sqlite3_prepare_v2(self->_database, [query UTF8String], -1, &statement, NULL) != SQLITE_OK) {
+      FIRMessagingLoggerDebug(kFIRMessagingMessageCodeRmq2PersistentStore005,
+                              @"Could not find s2d ids");
+      FIRMessagingRmqLogAndReturn(statement);
+    }
+    while (sqlite3_step(statement) == SQLITE_ROW) {
+      const char *rmqID = (char *)sqlite3_column_text(statement, 0);
+      [rmqIDArray addObject:[NSString stringWithUTF8String:rmqID]];
+    }
+    sqlite3_finalize(statement);
   });
   return rmqIDArray;
 }
@@ -398,43 +398,43 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 - (FIRMessagingPersistentSyncMessage *)querySyncMessageWithRmqID:(NSString *)rmqID {
   __block FIRMessagingPersistentSyncMessage *persistentMessage;
   dispatch_sync(_databaseOperationQueue, ^{
-  NSString *queryFormat = @"SELECT %@ FROM %@ WHERE %@ = '%@'";
-  NSString *query = [NSString stringWithFormat:queryFormat,
-                     kSyncMessagesColumns, // SELECT (rmq_id, expiration_ts, apns_recv, mcs_recv)
-                     kTableSyncMessages,   // FROM sync_rmq
-                     kRmqIdColumn,         // WHERE rmq_id
-                     rmqID];
+    NSString *queryFormat = @"SELECT %@ FROM %@ WHERE %@ = '%@'";
+    NSString *query = [NSString stringWithFormat:queryFormat,
+                       kSyncMessagesColumns, // SELECT (rmq_id, expiration_ts, apns_recv, mcs_recv)
+                       kTableSyncMessages,   // FROM sync_rmq
+                       kRmqIdColumn,         // WHERE rmq_id
+                       rmqID];
 
-  sqlite3_stmt *stmt;
-  if (sqlite3_prepare_v2(_database, [query UTF8String], -1, &stmt, NULL) != SQLITE_OK) {
-    [self logError];
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(_database, [query UTF8String], -1, &stmt, NULL) != SQLITE_OK) {
+      [self logError];
+      sqlite3_finalize(stmt);
+      return;
+    }
+
+    const int rmqIDColumn = 0;
+    const int expirationTimestampColumn = 1;
+    const int apnsReceivedColumn = 2;
+    const int mcsReceivedColumn = 3;
+
+    int count = 0;
+
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+      NSString *rmqID =
+          [NSString stringWithUTF8String:(char *)sqlite3_column_text(stmt, rmqIDColumn)];
+      int64_t expirationTimestamp = sqlite3_column_int64(stmt, expirationTimestampColumn);
+      BOOL apnsReceived = sqlite3_column_int(stmt, apnsReceivedColumn);
+      BOOL mcsReceived = sqlite3_column_int(stmt, mcsReceivedColumn);
+
+      // create a new persistent message
+      persistentMessage =
+          [[FIRMessagingPersistentSyncMessage alloc] initWithRMQID:rmqID expirationTime:expirationTimestamp];
+      persistentMessage.apnsReceived = apnsReceived;
+      persistentMessage.mcsReceived = mcsReceived;
+
+      count++;
+    }
     sqlite3_finalize(stmt);
-    return;
-  }
-
-  const int rmqIDColumn = 0;
-  const int expirationTimestampColumn = 1;
-  const int apnsReceivedColumn = 2;
-  const int mcsReceivedColumn = 3;
-
-  int count = 0;
-
-  while (sqlite3_step(stmt) == SQLITE_ROW) {
-    NSString *rmqID =
-        [NSString stringWithUTF8String:(char *)sqlite3_column_text(stmt, rmqIDColumn)];
-    int64_t expirationTimestamp = sqlite3_column_int64(stmt, expirationTimestampColumn);
-    BOOL apnsReceived = sqlite3_column_int(stmt, apnsReceivedColumn);
-    BOOL mcsReceived = sqlite3_column_int(stmt, mcsReceivedColumn);
-
-    // create a new persistent message
-    persistentMessage =
-        [[FIRMessagingPersistentSyncMessage alloc] initWithRMQID:rmqID expirationTime:expirationTimestamp];
-    persistentMessage.apnsReceived = apnsReceived;
-    persistentMessage.mcsReceived = mcsReceived;
-
-    count++;
-  }
-  sqlite3_finalize(stmt);
   });
 
   return persistentMessage;
@@ -446,31 +446,31 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 
 - (void)deleteExpiredOrFinishedSyncMessages {
   dispatch_async(_databaseOperationQueue, ^{
-  int64_t now = FIRMessagingCurrentTimestampInSeconds();
-  NSString *deleteSQL = @"DELETE FROM %@ "
-                        @"WHERE %@ < %lld OR "  // expirationTime < now
-                        @"(%@ = 1 AND %@ = 1)";  // apns_received = 1 AND mcs_received = 1
-  NSString *query = [NSString stringWithFormat:deleteSQL,
-                     kTableSyncMessages,
-                     kSyncMessageExpirationTimestampColumn,
-                     now,
-                     kSyncMessageAPNSReceivedColumn,
-                     kSyncMessageMCSReceivedColumn];
-  sqlite3_stmt *stmt;
-  if (sqlite3_prepare_v2(self->_database, [query UTF8String], -1, &stmt, NULL) != SQLITE_OK) {
-    FIRMessagingRmqLogAndReturn(stmt);
-  }
+    int64_t now = FIRMessagingCurrentTimestampInSeconds();
+    NSString *deleteSQL = @"DELETE FROM %@ "
+                          @"WHERE %@ < %lld OR "  // expirationTime < now
+                          @"(%@ = 1 AND %@ = 1)";  // apns_received = 1 AND mcs_received = 1
+    NSString *query = [NSString stringWithFormat:deleteSQL,
+                       kTableSyncMessages,
+                       kSyncMessageExpirationTimestampColumn,
+                       now,
+                       kSyncMessageAPNSReceivedColumn,
+                       kSyncMessageMCSReceivedColumn];
+    sqlite3_stmt *stmt;
+    if (sqlite3_prepare_v2(self->_database, [query UTF8String], -1, &stmt, NULL) != SQLITE_OK) {
+      FIRMessagingRmqLogAndReturn(stmt);
+    }
 
-  if (sqlite3_step(stmt) != SQLITE_DONE) {
-    FIRMessagingRmqLogAndReturn(stmt);
-  }
+    if (sqlite3_step(stmt) != SQLITE_DONE) {
+      FIRMessagingRmqLogAndReturn(stmt);
+    }
 
-  sqlite3_finalize(stmt);
-  int deleteCount = sqlite3_changes(self->_database);
-  if (deleteCount > 0) {
-    FIRMessagingLoggerDebug(kFIRMessagingMessageCodeSyncMessageManager001,
-                            @"Successfully deleted %d sync messages from store", deleteCount);
-  }
+    sqlite3_finalize(stmt);
+    int deleteCount = sqlite3_changes(self->_database);
+    if (deleteCount > 0) {
+      FIRMessagingLoggerDebug(kFIRMessagingMessageCodeSyncMessageManager001,
+                              @"Successfully deleted %d sync messages from store", deleteCount);
+    }
   });
 }
 
@@ -479,65 +479,65 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
                     apnsReceived:(BOOL)apnsReceived
                      mcsReceived:(BOOL)mcsReceived {
   dispatch_async(_databaseOperationQueue, ^{
-  NSString *insertFormat = @"INSERT INTO %@ (%@, %@, %@, %@) VALUES (?, ?, ?, ?)";
-  NSString *insertSQL = [NSString stringWithFormat:insertFormat,
-                         kTableSyncMessages, // Table name
-                         kRmqIdColumn, // rmq_id
-                         kSyncMessageExpirationTimestampColumn, // expiration_ts
-                         kSyncMessageAPNSReceivedColumn, // apns_recv
-                         kSyncMessageMCSReceivedColumn /* mcs_recv */];
+    NSString *insertFormat = @"INSERT INTO %@ (%@, %@, %@, %@) VALUES (?, ?, ?, ?)";
+    NSString *insertSQL = [NSString stringWithFormat:insertFormat,
+                           kTableSyncMessages, // Table name
+                           kRmqIdColumn, // rmq_id
+                           kSyncMessageExpirationTimestampColumn, // expiration_ts
+                           kSyncMessageAPNSReceivedColumn, // apns_recv
+                           kSyncMessageMCSReceivedColumn /* mcs_recv */];
 
-  sqlite3_stmt *stmt;
+    sqlite3_stmt *stmt;
 
-  if (sqlite3_prepare_v2(self->_database, [insertSQL UTF8String], -1, &stmt, NULL) != SQLITE_OK) {
-    FIRMessagingRmqLogAndReturn(stmt);
-  }
+    if (sqlite3_prepare_v2(self->_database, [insertSQL UTF8String], -1, &stmt, NULL) != SQLITE_OK) {
+      FIRMessagingRmqLogAndReturn(stmt);
+    }
 
-  if (sqlite3_bind_text(stmt, 1, [rmqID UTF8String], (int)[rmqID length], NULL) != SQLITE_OK) {
-    FIRMessagingRmqLogAndReturn(stmt);
-  }
+    if (sqlite3_bind_text(stmt, 1, [rmqID UTF8String], (int)[rmqID length], NULL) != SQLITE_OK) {
+      FIRMessagingRmqLogAndReturn(stmt);
+    }
 
-  if (sqlite3_bind_int64(stmt, 2, expirationTime) != SQLITE_OK) {
-    FIRMessagingRmqLogAndReturn(stmt);
-  }
+    if (sqlite3_bind_int64(stmt, 2, expirationTime) != SQLITE_OK) {
+      FIRMessagingRmqLogAndReturn(stmt);
+    }
 
-  if (sqlite3_bind_int(stmt, 3, apnsReceived ? 1 : 0) != SQLITE_OK) {
-    FIRMessagingRmqLogAndReturn(stmt);
-  }
+    if (sqlite3_bind_int(stmt, 3, apnsReceived ? 1 : 0) != SQLITE_OK) {
+      FIRMessagingRmqLogAndReturn(stmt);
+    }
 
-  if (sqlite3_bind_int(stmt, 4, mcsReceived ? 1 : 0) != SQLITE_OK) {
-    FIRMessagingRmqLogAndReturn(stmt);
-  }
+    if (sqlite3_bind_int(stmt, 4, mcsReceived ? 1 : 0) != SQLITE_OK) {
+      FIRMessagingRmqLogAndReturn(stmt);
+    }
 
-  if (sqlite3_step(stmt) != SQLITE_DONE) {
-    FIRMessagingRmqLogAndReturn(stmt);
-  }
-  sqlite3_finalize(stmt);
-  FIRMessagingLoggerInfo(kFIRMessagingMessageCodeSyncMessageManager004,
-                           @"Added sync message to cache: %@", rmqID);
+    if (sqlite3_step(stmt) != SQLITE_DONE) {
+      FIRMessagingRmqLogAndReturn(stmt);
+    }
+    sqlite3_finalize(stmt);
+    FIRMessagingLoggerInfo(kFIRMessagingMessageCodeSyncMessageManager004,
+                             @"Added sync message to cache: %@", rmqID);
   });
 
 }
 
 - (void)updateSyncMessageViaAPNSWithRmqID:(NSString *)rmqID {
   dispatch_async(_databaseOperationQueue, ^{
-  if (![self updateSyncMessageWithRmqID:rmqID
-                                   column:kSyncMessageAPNSReceivedColumn
-                                    value:YES]) {
-    FIRMessagingLoggerError(kFIRMessagingMessageCodeSyncMessageManager005,
-                            @"Failed to update APNS state for sync message %@", rmqID);
-  }
+    if (![self updateSyncMessageWithRmqID:rmqID
+                                     column:kSyncMessageAPNSReceivedColumn
+                                      value:YES]) {
+      FIRMessagingLoggerError(kFIRMessagingMessageCodeSyncMessageManager005,
+                              @"Failed to update APNS state for sync message %@", rmqID);
+    }
   });
 }
 
 - (void)updateSyncMessageViaMCSWithRmqID:(NSString *)rmqID {
   dispatch_async(_databaseOperationQueue, ^{
-  if (![self updateSyncMessageWithRmqID:rmqID
-                                   column:kSyncMessageMCSReceivedColumn
-                                    value:YES]) {
-    FIRMessagingLoggerError(kFIRMessagingMessageCodeSyncMessageManager006,
-                                 @"Failed to update MCS state for sync message %@", rmqID);
-  }
+    if (![self updateSyncMessageWithRmqID:rmqID
+                                     column:kSyncMessageMCSReceivedColumn
+                                      value:YES]) {
+      FIRMessagingLoggerError(kFIRMessagingMessageCodeSyncMessageManager006,
+                                   @"Failed to update MCS state for sync message %@", rmqID);
+    }
   });
 }
 
@@ -678,9 +678,8 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 
 - (void)updateDBWithStringRmqID {
   dispatch_async(_databaseOperationQueue, ^{
-
-  [self createTableWithName:kTableS2DRmqIds command:kCreateTableS2DRmqIds];
-  [self dropTableWithName:kOldTableS2DRmqIds];
+    [self createTableWithName:kTableS2DRmqIds command:kCreateTableS2DRmqIds];
+    [self dropTableWithName:kOldTableS2DRmqIds];
   });
 }
 
@@ -688,32 +687,32 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 
 - (void)scanOutgoingRmqMessagesWithHandler:(FCMOutgoingRmqMessagesTableHandler)handler {
   dispatch_async(_databaseOperationQueue, ^{
-  static NSString *queryFormat = @"SELECT %@ FROM %@ WHERE %@ != 0 ORDER BY %@ ASC";
-  NSString *query = [NSString stringWithFormat:queryFormat,
-                     kOutgoingRmqMessagesColumns, // select (rmq_id, type, data)
-                     kTableOutgoingRmqMessages, // from table
-                     kRmqIdColumn, // where
-                     kRmqIdColumn]; // order by
-  sqlite3_stmt *statement;
-  if (sqlite3_prepare_v2(self->_database, [query UTF8String], -1, &statement, NULL) != SQLITE_OK) {
-    [self logError];
-    sqlite3_finalize(statement);
-    return;
-  }
-  // can query sqlite3 for this but this is fine
-  const int rmqIdColumnNumber = 0;
-  const int typeColumnNumber = 1;
-  const int dataColumnNumber = 2;
-  while (sqlite3_step(statement) == SQLITE_ROW) {
-    int64_t rmqId = sqlite3_column_int64(statement, rmqIdColumnNumber);
-    int8_t type = sqlite3_column_int(statement, typeColumnNumber);
-    const void *bytes = sqlite3_column_blob(statement, dataColumnNumber);
-    int length = sqlite3_column_bytes(statement, dataColumnNumber);
+    static NSString *queryFormat = @"SELECT %@ FROM %@ WHERE %@ != 0 ORDER BY %@ ASC";
+    NSString *query = [NSString stringWithFormat:queryFormat,
+                       kOutgoingRmqMessagesColumns, // select (rmq_id, type, data)
+                       kTableOutgoingRmqMessages, // from table
+                       kRmqIdColumn, // where
+                       kRmqIdColumn]; // order by
+    sqlite3_stmt *statement;
+    if (sqlite3_prepare_v2(self->_database, [query UTF8String], -1, &statement, NULL) != SQLITE_OK) {
+      [self logError];
+      sqlite3_finalize(statement);
+      return;
+    }
+    // can query sqlite3 for this but this is fine
+    const int rmqIdColumnNumber = 0;
+    const int typeColumnNumber = 1;
+    const int dataColumnNumber = 2;
+    while (sqlite3_step(statement) == SQLITE_ROW) {
+      int64_t rmqId = sqlite3_column_int64(statement, rmqIdColumnNumber);
+      int8_t type = sqlite3_column_int(statement, typeColumnNumber);
+      const void *bytes = sqlite3_column_blob(statement, dataColumnNumber);
+      int length = sqlite3_column_bytes(statement, dataColumnNumber);
 
-    NSData *data = [NSData dataWithBytes:bytes length:length];
-    handler(rmqId, type, data);
-  }
-  sqlite3_finalize(statement);
+      NSData *data = [NSData dataWithBytes:bytes length:length];
+      handler(rmqId, type, data);
+    }
+    sqlite3_finalize(statement);
   });
 }
 
@@ -753,89 +752,89 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 -(void)deleteMessagesFromTable:(NSString *)tableName
                     withRmqIds:(NSArray *)rmqIds {
   dispatch_async(_databaseOperationQueue, ^{
-  BOOL isRmqIDString = NO;
-  // RmqID is a string only for outgoing messages
-  if ([tableName isEqualToString:kTableS2DRmqIds] ||
-      [tableName isEqualToString:kTableSyncMessages]) {
-    isRmqIDString = YES;
-  }
-
-  NSMutableString *delete = [NSMutableString stringWithFormat:@"DELETE FROM %@ WHERE ", tableName];
-
-  NSString *toDeleteArgument = [NSString stringWithFormat:@"%@ = ? OR ", kRmqIdColumn];
-
-  int toDelete = (int)[rmqIds count];
-  if (toDelete == 0) {
-    return;
-  }
-  int maxBatchSize = 100;
-  int start = 0;
-  int deleteCount = 0;
-  while (start < toDelete) {
-
-    // construct the WHERE argument
-    int end = MIN(start + maxBatchSize, toDelete);
-    NSMutableString *whereArgument = [NSMutableString string];
-    for (int i = start; i < end; i++) {
-      [whereArgument appendString:toDeleteArgument];
-    }
-    // remove the last * OR * from argument
-    NSRange range = NSMakeRange([whereArgument length] -4, 4);
-    [whereArgument deleteCharactersInRange:range];
-    NSString *deleteQuery = [NSString stringWithFormat:@"%@ %@", delete, whereArgument];
-
-
-    // sqlite update
-    sqlite3_stmt *delete_statement;
-    if (sqlite3_prepare_v2(self->_database, [deleteQuery UTF8String],
-                           -1, &delete_statement, NULL) != SQLITE_OK) {
-      FIRMessagingRmqLogAndReturn(delete_statement);
+    BOOL isRmqIDString = NO;
+    // RmqID is a string only for outgoing messages
+    if ([tableName isEqualToString:kTableS2DRmqIds] ||
+        [tableName isEqualToString:kTableSyncMessages]) {
+      isRmqIDString = YES;
     }
 
-    // bind values
-    int rmqIndex = 0;
-    int placeholderIndex = 1; // placeholders in sqlite3 start with 1
-    for (NSString *rmqId in rmqIds) { // objectAtIndex: is O(n) -- would make it slow
-      if (rmqIndex < start) {
-        rmqIndex++;
-        continue;
-      } else if (rmqIndex >= end) {
-        break;
-      } else {
-        if (isRmqIDString) {
-          if (sqlite3_bind_text(delete_statement,
-                                placeholderIndex,
-                                [rmqId UTF8String],
-                                (int)[rmqId length],
-                                SQLITE_STATIC) != SQLITE_OK) {
-            FIRMessagingLoggerDebug(kFIRMessagingMessageCodeRmq2PersistentStore003,
-                                    @"Failed to bind rmqID %@", rmqId);
-            FIRMessagingLoggerError(kFIRMessagingMessageCodeSyncMessageManager007,
-              @"Failed to delete sync message %@", rmqId);
-            continue;
-          }
-        } else {
-          int64_t rmqIdValue = [rmqId longLongValue];
-          sqlite3_bind_int64(delete_statement, placeholderIndex, rmqIdValue);
-        }
-        placeholderIndex++;
+    NSMutableString *delete = [NSMutableString stringWithFormat:@"DELETE FROM %@ WHERE ", tableName];
+
+    NSString *toDeleteArgument = [NSString stringWithFormat:@"%@ = ? OR ", kRmqIdColumn];
+
+    int toDelete = (int)[rmqIds count];
+    if (toDelete == 0) {
+      return;
+    }
+    int maxBatchSize = 100;
+    int start = 0;
+    int deleteCount = 0;
+    while (start < toDelete) {
+
+      // construct the WHERE argument
+      int end = MIN(start + maxBatchSize, toDelete);
+      NSMutableString *whereArgument = [NSMutableString string];
+      for (int i = start; i < end; i++) {
+        [whereArgument appendString:toDeleteArgument];
       }
-      rmqIndex++;
-      FIRMessagingLoggerInfo(kFIRMessagingMessageCodeSyncMessageManager008,
-                             @"Successfully deleted sync message from cache %@", rmqId);
-    }
-    if (sqlite3_step(delete_statement) != SQLITE_DONE) {
-      FIRMessagingRmqLogAndReturn(delete_statement);
-    }
-    sqlite3_finalize(delete_statement);
-    deleteCount += sqlite3_changes(_database);
-    start = end;
-  }
+      // remove the last * OR * from argument
+      NSRange range = NSMakeRange([whereArgument length] -4, 4);
+      [whereArgument deleteCharactersInRange:range];
+      NSString *deleteQuery = [NSString stringWithFormat:@"%@ %@", delete, whereArgument];
 
-  // if we are here all of our sqlite queries should have succeeded
-  FIRMessagingLoggerDebug(kFIRMessagingMessageCodeRmq2PersistentStore004,
-                          @"Trying to delete %d s2D ID's, successfully deleted %d",
-                          toDelete, deleteCount);
+
+      // sqlite update
+      sqlite3_stmt *delete_statement;
+      if (sqlite3_prepare_v2(self->_database, [deleteQuery UTF8String],
+                             -1, &delete_statement, NULL) != SQLITE_OK) {
+        FIRMessagingRmqLogAndReturn(delete_statement);
+      }
+
+      // bind values
+      int rmqIndex = 0;
+      int placeholderIndex = 1; // placeholders in sqlite3 start with 1
+      for (NSString *rmqId in rmqIds) { // objectAtIndex: is O(n) -- would make it slow
+        if (rmqIndex < start) {
+          rmqIndex++;
+          continue;
+        } else if (rmqIndex >= end) {
+          break;
+        } else {
+          if (isRmqIDString) {
+            if (sqlite3_bind_text(delete_statement,
+                                  placeholderIndex,
+                                  [rmqId UTF8String],
+                                  (int)[rmqId length],
+                                  SQLITE_STATIC) != SQLITE_OK) {
+              FIRMessagingLoggerDebug(kFIRMessagingMessageCodeRmq2PersistentStore003,
+                                      @"Failed to bind rmqID %@", rmqId);
+              FIRMessagingLoggerError(kFIRMessagingMessageCodeSyncMessageManager007,
+                @"Failed to delete sync message %@", rmqId);
+              continue;
+            }
+          } else {
+            int64_t rmqIdValue = [rmqId longLongValue];
+            sqlite3_bind_int64(delete_statement, placeholderIndex, rmqIdValue);
+          }
+          placeholderIndex++;
+        }
+        rmqIndex++;
+        FIRMessagingLoggerInfo(kFIRMessagingMessageCodeSyncMessageManager008,
+                               @"Successfully deleted sync message from cache %@", rmqId);
+      }
+      if (sqlite3_step(delete_statement) != SQLITE_DONE) {
+        FIRMessagingRmqLogAndReturn(delete_statement);
+      }
+      sqlite3_finalize(delete_statement);
+      deleteCount += sqlite3_changes(_database);
+      start = end;
+    }
+
+    // if we are here all of our sqlite queries should have succeeded
+    FIRMessagingLoggerDebug(kFIRMessagingMessageCodeRmq2PersistentStore004,
+                            @"Trying to delete %d s2D ID's, successfully deleted %d",
+                            toDelete, deleteCount);
   });
   
 }

--- a/Firebase/Messaging/FIRMessagingRmqManager.m
+++ b/Firebase/Messaging/FIRMessagingRmqManager.m
@@ -34,6 +34,22 @@ return return_value; \
 } while(0)
 #endif
 
+#ifndef FIRMessagingRmqLogAndReturn
+#define FIRMessagingRmqLogAndReturn(stmt)   \
+do {                              \
+[self logErrorAndFinalizeStatement:stmt];  \
+return; \
+} while(0)
+#endif
+
+#ifndef FIRMessaging_MUST_NOT_BE_MAIN_THREAD
+#define FIRMessaging_MUST_NOT_BE_MAIN_THREAD()                                                 \
+  do {                                                                                \
+    NSAssert(![NSThread isMainThread], @"Must not be executing on the main thread."); \
+  } while (0);
+#endif
+
+
 
 // table names
 NSString *const kTableOutgoingRmqMessages = @"outgoingRmqMessages";
@@ -106,6 +122,8 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 
 @interface FIRMessagingRmqManager () {
   sqlite3 *_database;
+  /// Serial queue for database read/write operations.
+  dispatch_queue_t _databaseOperationQueue;
 }
 
 @property(nonatomic, readwrite, strong) NSString *databaseName;
@@ -122,6 +140,8 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 - (instancetype)initWithDatabaseName:(NSString *)databaseName {
   self = [super init];
   if (self) {
+    _databaseOperationQueue =
+        dispatch_queue_create("com.google.firebase.messaging.database.rmq", DISPATCH_QUEUE_SERIAL);
     _databaseName = [databaseName copy];
     [self openDatabase];
     _outstandingMessages = [NSMutableDictionary dictionaryWithCapacity:2];
@@ -164,9 +184,14 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
   // by the server after reconnect, and after getting a rmq ack from the server). The
   // rmq message with the highest rmq id tells the real story, so check against that first.
 
-  int64_t rmqId = [self queryHighestRmqId];
+  __block int64_t rmqId;
+  dispatch_sync(_databaseOperationQueue, ^{
+    rmqId = [self queryHighestRmqId];
+  });
   if (rmqId == 0) {
-    rmqId = [self queryLastRmqId];
+    dispatch_sync(_databaseOperationQueue, ^{
+      rmqId = [self queryLastRmqId];
+    });
   }
   self.rmqId = rmqId + 1;
 }
@@ -176,8 +201,7 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 /**
  * Save a message to RMQ2. Will populate the rmq2 persistent ID.
  */
-- (BOOL)saveRmqMessage:(GPBMessage *)message
-                 error:(NSError **)error {
+- (void)saveRmqMessage:(GPBMessage *)message withCompletionHandler:(void(^)(BOOL success))handler {
   // send using rmq2manager
   // the wire format of rmq2 id is a string. However, we keep it as a long internally
   // in the database. So only convert the id to string when preparing for sending over
@@ -190,56 +214,65 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
   }
   FIRMessagingProtoTag tag = FIRMessagingGetTagForProto(message);
   NSData *data = [message data];
-  return [self saveMessageWithRmqId:[rmq2Id integerValue] tag:tag data:data error:error];
+  dispatch_async(_databaseOperationQueue, ^{
+    BOOL success = [self saveMessageWithRmqId:[rmq2Id integerValue] tag:tag data:data];
+    if (handler) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        handler(success);
+      });
+    }
+  });
 }
 
 /**
  * This is called when we delete the largest outgoing message from queue.
  */
-- (BOOL)saveLastOutgoingRmqId:(int64_t)rmqID {
+- (void)saveLastOutgoingRmqId:(int64_t)rmqID {
+  dispatch_async(_databaseOperationQueue, ^{
   NSString *queryFormat = @"INSERT OR REPLACE INTO %@ (%@, %@) VALUES (?, ?)";
   NSString *query = [NSString stringWithFormat:queryFormat,
                      kTableLastRmqId, // table
                      kIdColumn, kRmqIdColumn]; // columns
   sqlite3_stmt *statement;
-  if (sqlite3_prepare_v2(_database, [query UTF8String], -1, &statement, NULL) != SQLITE_OK) {
-    _FIRMessagingRmqLogAndExit(statement, NO);
+  if (sqlite3_prepare_v2(self->_database, [query UTF8String], -1, &statement, NULL) != SQLITE_OK) {
+    FIRMessagingRmqLogAndReturn(statement);
   }
   if (sqlite3_bind_int(statement, 1, 1) != SQLITE_OK) {
-    _FIRMessagingRmqLogAndExit(statement, NO);
+    FIRMessagingRmqLogAndReturn(statement);
   }
   if (sqlite3_bind_int64(statement, 2, rmqID) != SQLITE_OK) {
-    _FIRMessagingRmqLogAndExit(statement, NO);
+    FIRMessagingRmqLogAndReturn(statement);
   }
   if (sqlite3_step(statement) != SQLITE_DONE) {
-    _FIRMessagingRmqLogAndExit(statement, NO);
+    FIRMessagingRmqLogAndReturn(statement);
   }
   sqlite3_finalize(statement);
-  return YES;
+  });
 }
 
-- (BOOL)saveS2dMessageWithRmqId:(NSString *)rmqId {
+- (void)saveS2dMessageWithRmqId:(NSString *)rmqId {
+  dispatch_async(_databaseOperationQueue, ^{
   NSString *insertFormat = @"INSERT INTO %@ (%@) VALUES (?)";
   NSString *insertSQL = [NSString stringWithFormat:insertFormat,
                          kTableS2DRmqIds,
                          kRmqIdColumn];
   sqlite3_stmt *insert_statement;
-  if (sqlite3_prepare_v2(_database, [insertSQL UTF8String], -1, &insert_statement, NULL)
+  if (sqlite3_prepare_v2(self->_database, [insertSQL UTF8String], -1, &insert_statement, NULL)
       != SQLITE_OK) {
-    _FIRMessagingRmqLogAndExit(insert_statement, NO);
+    FIRMessagingRmqLogAndReturn(insert_statement);
   }
   if (sqlite3_bind_text(insert_statement,
                         1,
                         [rmqId UTF8String],
                         (int)[rmqId length],
                         SQLITE_STATIC) != SQLITE_OK) {
-    _FIRMessagingRmqLogAndExit(insert_statement, NO);
+    FIRMessagingRmqLogAndReturn(insert_statement);
   }
   if (sqlite3_step(insert_statement) != SQLITE_DONE) {
-    _FIRMessagingRmqLogAndExit(insert_statement, NO);
+    FIRMessagingRmqLogAndReturn(insert_statement);
   }
   sqlite3_finalize(insert_statement);
-  return YES;
+  });
 }
 
 #pragma mark - Query
@@ -285,23 +318,25 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 }
 
 - (NSArray *)unackedS2dRmqIds {
+  __block NSMutableArray *rmqIDArray = [NSMutableArray array];
+  dispatch_sync(_databaseOperationQueue, ^{
   NSString *queryFormat = @"SELECT %@ FROM %@ ORDER BY %@ ASC";
   NSString *query = [NSString stringWithFormat:queryFormat,
                      kRmqIdColumn,
                      kTableS2DRmqIds,
                      kRmqIdColumn];
   sqlite3_stmt *statement;
-  if (sqlite3_prepare_v2(_database, [query UTF8String], -1, &statement, NULL) != SQLITE_OK) {
+  if (sqlite3_prepare_v2(self->_database, [query UTF8String], -1, &statement, NULL) != SQLITE_OK) {
     FIRMessagingLoggerDebug(kFIRMessagingMessageCodeRmq2PersistentStore005,
                             @"Could not find s2d ids");
-    _FIRMessagingRmqLogAndExit(statement, @[]);
+    FIRMessagingRmqLogAndReturn(statement);
   }
-  NSMutableArray *rmqIDArray = [NSMutableArray array];
   while (sqlite3_step(statement) == SQLITE_ROW) {
     const char *rmqID = (char *)sqlite3_column_text(statement, 0);
     [rmqIDArray addObject:[NSString stringWithUTF8String:rmqID]];
   }
   sqlite3_finalize(statement);
+  });
   return rmqIDArray;
 }
 
@@ -336,9 +371,9 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 }
 
 #pragma mark - Remove
-- (int)removeRmqMessagesWithRmqIds:(NSArray *)rmqIds {
+- (void)removeRmqMessagesWithRmqIds:(NSArray *)rmqIds {
   if (![rmqIds count]) {
-    return 0;
+    return;
   }
   int64_t maxRmqId = -1;
   for (NSString *rmqId in rmqIds) {
@@ -351,7 +386,7 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
   if (maxRmqId >= self.rmqId) {
     [self saveLastOutgoingRmqId:maxRmqId];
   }
-  return [self deleteMessagesFromTable:kTableOutgoingRmqMessages withRmqIds:rmqIds];
+  [self deleteMessagesFromTable:kTableOutgoingRmqMessages withRmqIds:rmqIds];
 }
 
 - (void)removeS2dIds:(NSArray *)s2dIds {
@@ -362,7 +397,7 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 
 - (FIRMessagingPersistentSyncMessage *)querySyncMessageWithRmqID:(NSString *)rmqID {
   __block FIRMessagingPersistentSyncMessage *persistentMessage;
-
+  dispatch_sync(_databaseOperationQueue, ^{
   NSString *queryFormat = @"SELECT %@ FROM %@ WHERE %@ = '%@'";
   NSString *query = [NSString stringWithFormat:queryFormat,
                      kSyncMessagesColumns, // SELECT (rmq_id, expiration_ts, apns_recv, mcs_recv)
@@ -374,7 +409,7 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
   if (sqlite3_prepare_v2(_database, [query UTF8String], -1, &stmt, NULL) != SQLITE_OK) {
     [self logError];
     sqlite3_finalize(stmt);
-    return nil;
+    return;
   }
 
   const int rmqIDColumn = 0;
@@ -400,15 +435,17 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
     count++;
   }
   sqlite3_finalize(stmt);
+  });
 
   return persistentMessage;
 }
 
-- (BOOL)deleteSyncMessageWithRmqID:(NSString *)rmqID {
-  return [self deleteMessagesFromTable:kTableSyncMessages withRmqIds:@[rmqID]] > 0;
+- (void)deleteSyncMessageWithRmqID:(NSString *)rmqID {
+  [self deleteMessagesFromTable:kTableSyncMessages withRmqIds:@[rmqID]];
 }
 
-- (int)deleteExpiredOrFinishedSyncMessages:(NSError *__autoreleasing *)error {
+- (void)deleteExpiredOrFinishedSyncMessages {
+  dispatch_async(_databaseOperationQueue, ^{
   int64_t now = FIRMessagingCurrentTimestampInSeconds();
   NSString *deleteSQL = @"DELETE FROM %@ "
                         @"WHERE %@ < %lld OR "  // expirationTime < now
@@ -419,36 +456,29 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
                      now,
                      kSyncMessageAPNSReceivedColumn,
                      kSyncMessageMCSReceivedColumn];
-
-  NSString *errorReason = @"Failed to save delete expired sync messages from store.";
-
   sqlite3_stmt *stmt;
-  if (sqlite3_prepare_v2(_database, [query UTF8String], -1, &stmt, NULL) != SQLITE_OK) {
-    if (error) {
-      *error = [NSError fcm_errorWithCode:sqlite3_errcode(_database)
-                                 userInfo:@{ @"error" : errorReason }];
-    }
-    _FIRMessagingRmqLogAndExit(stmt, 0);
+  if (sqlite3_prepare_v2(self->_database, [query UTF8String], -1, &stmt, NULL) != SQLITE_OK) {
+    FIRMessagingRmqLogAndReturn(stmt);
   }
 
   if (sqlite3_step(stmt) != SQLITE_DONE) {
-    if (error) {
-      *error = [NSError fcm_errorWithCode:sqlite3_errcode(_database)
-                                 userInfo:@{ @"error" : errorReason }];
-    }
-    _FIRMessagingRmqLogAndExit(stmt, 0);
+    FIRMessagingRmqLogAndReturn(stmt);
   }
 
   sqlite3_finalize(stmt);
-  int deleteCount = sqlite3_changes(_database);
-  return deleteCount;
+  int deleteCount = sqlite3_changes(self->_database);
+  if (deleteCount > 0) {
+    FIRMessagingLoggerDebug(kFIRMessagingMessageCodeSyncMessageManager001,
+                            @"Successfully deleted %d sync messages from store", deleteCount);
+  }
+  });
 }
 
-- (BOOL)saveSyncMessageWithRmqID:(NSString *)rmqID
+- (void)saveSyncMessageWithRmqID:(NSString *)rmqID
                   expirationTime:(int64_t)expirationTime
                     apnsReceived:(BOOL)apnsReceived
-                     mcsReceived:(BOOL)mcsReceived
-                           error:(NSError **)error {
+                     mcsReceived:(BOOL)mcsReceived {
+  dispatch_async(_databaseOperationQueue, ^{
   NSString *insertFormat = @"INSERT INTO %@ (%@, %@, %@, %@) VALUES (?, ?, ?, ?)";
   NSString *insertSQL = [NSString stringWithFormat:insertFormat,
                          kTableSyncMessages, // Table name
@@ -459,58 +489,62 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 
   sqlite3_stmt *stmt;
 
-  if (sqlite3_prepare_v2(_database, [insertSQL UTF8String], -1, &stmt, NULL) != SQLITE_OK) {
-    if (error) {
-      *error = [NSError fcm_errorWithCode:sqlite3_errcode(_database)
-                                 userInfo:@{ @"error" : @"Failed to save sync message to store." }];
-    }
-    _FIRMessagingRmqLogAndExit(stmt, NO);
+  if (sqlite3_prepare_v2(self->_database, [insertSQL UTF8String], -1, &stmt, NULL) != SQLITE_OK) {
+    FIRMessagingRmqLogAndReturn(stmt);
   }
 
   if (sqlite3_bind_text(stmt, 1, [rmqID UTF8String], (int)[rmqID length], NULL) != SQLITE_OK) {
-    _FIRMessagingRmqLogAndExit(stmt, NO);
+    FIRMessagingRmqLogAndReturn(stmt);
   }
 
   if (sqlite3_bind_int64(stmt, 2, expirationTime) != SQLITE_OK) {
-    _FIRMessagingRmqLogAndExit(stmt, NO);
+    FIRMessagingRmqLogAndReturn(stmt);
   }
 
   if (sqlite3_bind_int(stmt, 3, apnsReceived ? 1 : 0) != SQLITE_OK) {
-    _FIRMessagingRmqLogAndExit(stmt, NO);
+    FIRMessagingRmqLogAndReturn(stmt);
   }
 
   if (sqlite3_bind_int(stmt, 4, mcsReceived ? 1 : 0) != SQLITE_OK) {
-    _FIRMessagingRmqLogAndExit(stmt, NO);
+    FIRMessagingRmqLogAndReturn(stmt);
   }
 
   if (sqlite3_step(stmt) != SQLITE_DONE) {
-    _FIRMessagingRmqLogAndExit(stmt, NO);
+    FIRMessagingRmqLogAndReturn(stmt);
   }
-
   sqlite3_finalize(stmt);
-  return YES;
+  FIRMessagingLoggerInfo(kFIRMessagingMessageCodeSyncMessageManager004,
+                           @"Added sync message to cache: %@", rmqID);
+  });
+
 }
 
-- (BOOL)updateSyncMessageViaAPNSWithRmqID:(NSString *)rmqID
-                                    error:(NSError **)error {
-  return [self updateSyncMessageWithRmqID:rmqID
+- (void)updateSyncMessageViaAPNSWithRmqID:(NSString *)rmqID {
+  dispatch_async(_databaseOperationQueue, ^{
+  if (![self updateSyncMessageWithRmqID:rmqID
                                    column:kSyncMessageAPNSReceivedColumn
-                                    value:YES
-                                    error:error];
+                                    value:YES]) {
+    FIRMessagingLoggerError(kFIRMessagingMessageCodeSyncMessageManager005,
+                            @"Failed to update APNS state for sync message %@", rmqID);
+  }
+  });
 }
 
-- (BOOL)updateSyncMessageViaMCSWithRmqID:(NSString *)rmqID
-                                   error:(NSError *__autoreleasing *)error {
-  return [self updateSyncMessageWithRmqID:rmqID
+- (void)updateSyncMessageViaMCSWithRmqID:(NSString *)rmqID {
+  dispatch_async(_databaseOperationQueue, ^{
+  if (![self updateSyncMessageWithRmqID:rmqID
                                    column:kSyncMessageMCSReceivedColumn
-                                    value:YES
-                                    error:error];
+                                    value:YES]) {
+    FIRMessagingLoggerError(kFIRMessagingMessageCodeSyncMessageManager006,
+                                 @"Failed to update MCS state for sync message %@", rmqID);
+  }
+  });
 }
 
 - (BOOL)updateSyncMessageWithRmqID:(NSString *)rmqID
                             column:(NSString *)column
-                             value:(BOOL)value
-                             error:(NSError **)error {
+                             value:(BOOL)value{
+  FIRMessaging_MUST_NOT_BE_MAIN_THREAD();
   NSString *queryFormat = @"UPDATE %@ "  // Table name
                           @"SET %@ = %d "  // column=value
                           @"WHERE %@ = ?";  // condition
@@ -522,10 +556,6 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
   sqlite3_stmt *stmt;
 
   if (sqlite3_prepare_v2(_database, [query UTF8String], -1, &stmt, NULL) != SQLITE_OK) {
-    if (error) {
-      *error = [NSError fcm_errorWithCode:sqlite3_errcode(_database)
-                                 userInfo:@{ @"error" : @"Failed to update sync message"}];
-    }
     _FIRMessagingRmqLogAndExit(stmt, NO);
   }
 
@@ -558,6 +588,7 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 }
 
 - (void)createTableWithName:(NSString *)tableName command:(NSString *)command {
+  FIRMessaging_MUST_NOT_BE_MAIN_THREAD();
     char *error;
     NSString *createDatabase = [NSString stringWithFormat:command, kTablePrefix, tableName];
     if (sqlite3_exec(self->_database, [createDatabase UTF8String], NULL, NULL, &error) != SQLITE_OK) {
@@ -574,7 +605,8 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 }
 
 - (void)dropTableWithName:(NSString *)tableName {
-    char *error;
+  FIRMessaging_MUST_NOT_BE_MAIN_THREAD();
+  char *error;
     NSString *dropTableSQL = [NSString stringWithFormat:kDropTableCommand, kTablePrefix, tableName];
     if (sqlite3_exec(self->_database, [dropTableSQL UTF8String], NULL, NULL, &error) != SQLITE_OK) {
       FIRMessagingLoggerError(kFIRMessagingMessageCodeRmq2PersistentStore002,
@@ -588,6 +620,7 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 }
 
 - (void)openDatabase {
+  dispatch_async(_databaseOperationQueue, ^{
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSString *path = [self pathForDatabase];
 
@@ -640,17 +673,21 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
     if (didOpenDatabase) {
       [self createTableWithName:kTableSyncMessages command:kCreateTableSyncMessages];
     }
+  });
 }
 
 - (void)updateDBWithStringRmqID {
+  dispatch_async(_databaseOperationQueue, ^{
+
   [self createTableWithName:kTableS2DRmqIds command:kCreateTableS2DRmqIds];
   [self dropTableWithName:kOldTableS2DRmqIds];
+  });
 }
 
 #pragma mark - Scan
 
 - (void)scanOutgoingRmqMessagesWithHandler:(FCMOutgoingRmqMessagesTableHandler)handler {
-
+  dispatch_async(_databaseOperationQueue, ^{
   static NSString *queryFormat = @"SELECT %@ FROM %@ WHERE %@ != 0 ORDER BY %@ ASC";
   NSString *query = [NSString stringWithFormat:queryFormat,
                      kOutgoingRmqMessagesColumns, // select (rmq_id, type, data)
@@ -677,14 +714,15 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
     handler(rmqId, type, data);
   }
   sqlite3_finalize(statement);
+  });
 }
 
 #pragma mark - Private
 
 - (BOOL)saveMessageWithRmqId:(int64_t)rmqId
                          tag:(int8_t)tag
-                        data:(NSData *)data
-                       error:(NSError **)error {
+                        data:(NSData *)data {
+  FIRMessaging_MUST_NOT_BE_MAIN_THREAD();
   NSString *insertFormat = @"INSERT INTO %@ (%@, %@, %@) VALUES (?, ?, ?)";
   NSString *insertSQL = [NSString stringWithFormat:insertFormat,
                          kTableOutgoingRmqMessages, // table
@@ -692,11 +730,6 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
   sqlite3_stmt *insert_statement;
   if (sqlite3_prepare_v2(self->_database, [insertSQL UTF8String], -1, &insert_statement, NULL)
       != SQLITE_OK) {
-    if (error) {
-      *error = [NSError errorWithDomain:[NSString stringWithFormat:@"%s", sqlite3_errmsg(self->_database)]
-                                   code:sqlite3_errcode(self->_database)
-                               userInfo:nil];
-    }
     _FIRMessagingRmqLogAndExit(insert_statement, NO);
   }
   if (sqlite3_bind_int64(insert_statement, 1, rmqId) != SQLITE_OK) {
@@ -717,8 +750,9 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
   return YES;
 }
 
-- (int)deleteMessagesFromTable:(NSString *)tableName
+-(void)deleteMessagesFromTable:(NSString *)tableName
                     withRmqIds:(NSArray *)rmqIds {
+  dispatch_async(_databaseOperationQueue, ^{
   BOOL isRmqIDString = NO;
   // RmqID is a string only for outgoing messages
   if ([tableName isEqualToString:kTableS2DRmqIds] ||
@@ -732,7 +766,7 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 
   int toDelete = (int)[rmqIds count];
   if (toDelete == 0) {
-    return 0;
+    return;
   }
   int maxBatchSize = 100;
   int start = 0;
@@ -753,9 +787,9 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 
     // sqlite update
     sqlite3_stmt *delete_statement;
-    if (sqlite3_prepare_v2(_database, [deleteQuery UTF8String],
+    if (sqlite3_prepare_v2(self->_database, [deleteQuery UTF8String],
                            -1, &delete_statement, NULL) != SQLITE_OK) {
-      _FIRMessagingRmqLogAndExit(delete_statement, 0);
+      FIRMessagingRmqLogAndReturn(delete_statement);
     }
 
     // bind values
@@ -776,6 +810,8 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
                                 SQLITE_STATIC) != SQLITE_OK) {
             FIRMessagingLoggerDebug(kFIRMessagingMessageCodeRmq2PersistentStore003,
                                     @"Failed to bind rmqID %@", rmqId);
+            FIRMessagingLoggerError(kFIRMessagingMessageCodeSyncMessageManager007,
+              @"Failed to delete sync message %@", rmqId);
             continue;
           }
         } else {
@@ -785,9 +821,11 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
         placeholderIndex++;
       }
       rmqIndex++;
+      FIRMessagingLoggerInfo(kFIRMessagingMessageCodeSyncMessageManager008,
+                             @"Successfully deleted sync message from cache %@", rmqId);
     }
     if (sqlite3_step(delete_statement) != SQLITE_DONE) {
-      _FIRMessagingRmqLogAndExit(delete_statement, deleteCount);
+      FIRMessagingRmqLogAndReturn(delete_statement);
     }
     sqlite3_finalize(delete_statement);
     deleteCount += sqlite3_changes(_database);
@@ -798,7 +836,8 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
   FIRMessagingLoggerDebug(kFIRMessagingMessageCodeRmq2PersistentStore004,
                           @"Trying to delete %d s2D ID's, successfully deleted %d",
                           toDelete, deleteCount);
-  return deleteCount;
+  });
+  
 }
 
 - (int64_t)nextRmqId {

--- a/Firebase/Messaging/FIRMessagingSyncMessageManager.m
+++ b/Firebase/Messaging/FIRMessagingSyncMessageManager.m
@@ -49,7 +49,6 @@ static const uint64_t kMinFreeDiskSpaceInMB = 1;
 
 - (void)removeExpiredSyncMessages {
   [self.rmqManager deleteExpiredOrFinishedSyncMessages];
-  
 }
 
 - (BOOL)didReceiveAPNSSyncMessage:(NSDictionary *)message {
@@ -94,7 +93,6 @@ static const uint64_t kMinFreeDiskSpaceInMB = 1;
   } else if (viaMCS && !persistentMessage.mcsReceived) {
     persistentMessage.mcsReceived = YES;
     [self.rmqManager updateSyncMessageViaMCSWithRmqID:rmqID];
-     
   }
 
   // Received message via both ways we can safely delete it.

--- a/Firebase/Messaging/FIRMessagingSyncMessageManager.m
+++ b/Firebase/Messaging/FIRMessagingSyncMessageManager.m
@@ -85,6 +85,7 @@ static const uint64_t kMinFreeDiskSpaceInMB = 1;
                                     expirationTime:expirationTime
                                       apnsReceived:viaAPNS
                                        mcsReceived:viaMCS];
+    return NO;
   }
 
   if (viaAPNS && !persistentMessage.apnsReceived) {

--- a/Firebase/Messaging/FIRMessagingSyncMessageManager.m
+++ b/Firebase/Messaging/FIRMessagingSyncMessageManager.m
@@ -48,15 +48,8 @@ static const uint64_t kMinFreeDiskSpaceInMB = 1;
 }
 
 - (void)removeExpiredSyncMessages {
-  NSError *error;
-  int deleteCount = [self.rmqManager deleteExpiredOrFinishedSyncMessages:&error];
-  if (error) {
-    FIRMessagingLoggerError(kFIRMessagingMessageCodeSyncMessageManager000,
-                            @"Error while deleting expired sync messages %@", error);
-  } else if (deleteCount > 0) {
-    FIRMessagingLoggerDebug(kFIRMessagingMessageCodeSyncMessageManager001,
-                            @"Successfully deleted %d sync messages from store", deleteCount);
-  }
+  [self.rmqManager deleteExpiredOrFinishedSyncMessages];
+  
 }
 
 - (BOOL)didReceiveAPNSSyncMessage:(NSDictionary *)message {
@@ -80,7 +73,6 @@ static const uint64_t kMinFreeDiskSpaceInMB = 1;
   FIRMessagingPersistentSyncMessage *persistentMessage =
       [self.rmqManager querySyncMessageWithRmqID:rmqID];
 
-  NSError *error;
   if (!persistentMessage) {
 
     // Do not persist the new message if we don't have enough disk space
@@ -90,43 +82,24 @@ static const uint64_t kMinFreeDiskSpaceInMB = 1;
     }
 
     int64_t expirationTime = [[self class] expirationTimeForSyncMessage:message];
-    if (![self.rmqManager saveSyncMessageWithRmqID:rmqID
+    [self.rmqManager saveSyncMessageWithRmqID:rmqID
                                     expirationTime:expirationTime
                                       apnsReceived:viaAPNS
-                                       mcsReceived:viaMCS
-                                             error:&error]) {
-      FIRMessagingLoggerError(kFIRMessagingMessageCodeSyncMessageManager003,
-                              @"Failed to save sync message with rmqID %@", rmqID);
-    } else {
-      FIRMessagingLoggerInfo(kFIRMessagingMessageCodeSyncMessageManager004,
-                             @"Added sync message to cache: %@", rmqID);
-    }
-    return NO;
+                                       mcsReceived:viaMCS];
   }
 
   if (viaAPNS && !persistentMessage.apnsReceived) {
     persistentMessage.apnsReceived = YES;
-    if (![self.rmqManager updateSyncMessageViaAPNSWithRmqID:rmqID error:&error]) {
-      FIRMessagingLoggerError(kFIRMessagingMessageCodeSyncMessageManager005,
-                              @"Failed to update APNS state for sync message %@", rmqID);
-    }
+    [self.rmqManager updateSyncMessageViaAPNSWithRmqID:rmqID];
   } else if (viaMCS && !persistentMessage.mcsReceived) {
     persistentMessage.mcsReceived = YES;
-    if (![self.rmqManager updateSyncMessageViaMCSWithRmqID:rmqID error:&error]) {
-      FIRMessagingLoggerError(kFIRMessagingMessageCodeSyncMessageManager006,
-                              @"Failed to update MCS state for sync message %@", rmqID);
-    }
+    [self.rmqManager updateSyncMessageViaMCSWithRmqID:rmqID];
+     
   }
 
   // Received message via both ways we can safely delete it.
   if (persistentMessage.apnsReceived && persistentMessage.mcsReceived) {
-    if (![self.rmqManager deleteSyncMessageWithRmqID:rmqID]) {
-      FIRMessagingLoggerError(kFIRMessagingMessageCodeSyncMessageManager007,
-                              @"Failed to delete sync message %@", rmqID);
-    } else {
-      FIRMessagingLoggerInfo(kFIRMessagingMessageCodeSyncMessageManager008,
-                             @"Successfully deleted sync message from cache %@", rmqID);
-    }
+    [self.rmqManager deleteSyncMessageWithRmqID:rmqID];
   }
 
   // Already received this message either via MCS or APNS.


### PR DESCRIPTION
b/142357385 People find the app stuck on RMQ database write operation as they are on main thread.
Moving all the write operations off main thread.

Some of the sync methods used to return a value, it is used to tell the operation succeed and print error if not. We will remove those return value and print error inside the method.
There are other return values are not used at all by the parent class. Remove those and make them async method.

Also refactor the method scanWithRmqMessageHandler: which is very interesting. It has two callbacks as parameters, each is used on different occasions. This function reads data from database, instead of return the results at once, it triggers callback per row of database read. This used to work because database operation is blocking, so client just blocking read each row of database and return a callback to continue the next step. Unified both callback to one and trigger the callback after database read is complete and return with the database results. 
