### PR TITLE
Firestore podspec: avoid adding Firestore headers to sources

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -25,6 +25,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.prefix_header_file = false
 
   s.source_files = [
+    'Firestore/Source/Public/*.h',
     'Firestore/Source/**/*.{m,mm}',
     'Firestore/Protos/nanopb/**/*.cc',
     'Firestore/Protos/objc/**/*.m',
@@ -32,7 +33,11 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
     'Firestore/core/src/**/*.{cc,mm}',
   ]
   s.preserve_paths = [
-    'Firestore/Source/**/*.h',
+    'Firestore/Source/API/*.h',
+    'Firestore/Source/Core/*.h',
+    'Firestore/Source/Local/*.h',
+    'Firestore/Source/Remote/*.h',
+    'Firestore/Source/Util/*.h',
     'Firestore/Protos/nanopb/**/*.h',
     'Firestore/Protos/objc/**/*.h',
     'Firestore/core/include/**/*.h',

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -25,11 +25,18 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.prefix_header_file = false
 
   s.source_files = [
-    'Firestore/Source/**/*.{h,m,mm}',
-    'Firestore/Protos/nanopb/**/*.{h,cc}',
-    'Firestore/Protos/objc/**/*.[hm]',
-    'Firestore/core/include/**/*.{h,cc,mm}',
-    'Firestore/core/src/**/*.{h,cc,mm}',
+    'Firestore/Source/**/*.{m,mm}',
+    'Firestore/Protos/nanopb/**/*.cc',
+    'Firestore/Protos/objc/**/*.m',
+    'Firestore/core/include/**/*.{cc,mm}',
+    'Firestore/core/src/**/*.{cc,mm}',
+  ]
+  s.preserve_paths = [
+    'Firestore/Source/**/*.h',
+    'Firestore/Protos/nanopb/**/*.h',
+    'Firestore/Protos/objc/**/*.h',
+    'Firestore/core/include/**/*.h',
+    'Firestore/core/src/**/*.h',
   ]
   s.requires_arc = [
     'Firestore/Source/**/*',
@@ -74,7 +81,11 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
       '"${PODS_TARGET_SRCROOT}/Firestore/Source/Public" ' +
       '"${PODS_TARGET_SRCROOT}/Firestore/third_party/abseil-cpp" ' +
       '"${PODS_ROOT}/nanopb" ' +
-      '"${PODS_TARGET_SRCROOT}/Firestore/Protos/nanopb"',
+      '"${PODS_TARGET_SRCROOT}/Firestore/Protos/nanopb" ' +
+      '"${PODS_TARGET_SRCROOT}/Firestore/Protos/objc/google/api" ' +
+      '"${PODS_TARGET_SRCROOT}/Firestore/Protos/objc/google/firestore/v1" ' +
+      '"${PODS_TARGET_SRCROOT}/Firestore/Protos/objc/google/rpc" ' +
+      '"${PODS_TARGET_SRCROOT}/Firestore/Protos/objc/google/type"',
   }
 
   # Generate a version of the config.h header suitable for building with

--- a/Firestore/Swift/Tests/API/BasicCompileTests.swift
+++ b/Firestore/Swift/Tests/API/BasicCompileTests.swift
@@ -25,6 +25,7 @@ import XCTest
 // level.
 #if os(iOS)
   import Firebase
+  //import FirebaseFirestore
 #else
   import FirebaseFirestore
 #endif
@@ -438,14 +439,14 @@ func types() {
   let _: Firestore
   let _: FirestoreSettings
   let _: GeoPoint
-  #if os(iOS)
-    let _: Firebase.GeoPoint
-  #endif
+  //#if os(iOS)
+  //  let _: Firebase.GeoPoint
+  //#endif
   let _: FirebaseFirestore.GeoPoint
   let _: Timestamp
-  #if os(iOS)
-    let _: Firebase.Timestamp
-  #endif
+  //#if os(iOS)
+  //  let _: Firebase.Timestamp
+  //#endif
   let _: FirebaseFirestore.Timestamp
   let _: ListenerRegistration
   let _: Query
@@ -479,3 +480,4 @@ func terminateDb(database db: Firestore) {
     }
   }
 }
+

--- a/Firestore/Swift/Tests/API/BasicCompileTests.swift
+++ b/Firestore/Swift/Tests/API/BasicCompileTests.swift
@@ -25,7 +25,6 @@ import XCTest
 // level.
 #if os(iOS)
   import Firebase
-  //import FirebaseFirestore
 #else
   import FirebaseFirestore
 #endif
@@ -439,14 +438,14 @@ func types() {
   let _: Firestore
   let _: FirestoreSettings
   let _: GeoPoint
-  //#if os(iOS)
-  //  let _: Firebase.GeoPoint
-  //#endif
+  #if os(iOS)
+    let _: Firebase.GeoPoint
+  #endif
   let _: FirebaseFirestore.GeoPoint
   let _: Timestamp
-  //#if os(iOS)
-  //  let _: Firebase.Timestamp
-  //#endif
+  #if os(iOS)
+    let _: Firebase.Timestamp
+  #endif
   let _: FirebaseFirestore.Timestamp
   let _: ListenerRegistration
   let _: Query
@@ -480,4 +479,3 @@ func terminateDb(database db: Firestore) {
     }
   }
 }
-


### PR DESCRIPTION
See #4035: a certain combination of pods can lead to a broken build. The underlying issue is that CocoaPods generate a header map that includes headers from _all_ the pods in a project. A header map maps short file names to full paths and is unable to handle collisions; thus, in a CocoaPods-based build, if one pod contains a header with a common name, and the other pod tries to import a header with the same short name by relying on header maps (without specifying a longer path), the header from one pod may end up getting erroneously picked up by the other pod.

In that particular case, `SVGKit` is relying on header maps and trying to import `Document.h`, which, for reasons described above, happens to pick up `document.h` from Firestore. However, since header maps cannot handle collisions, this could manifest with other pods as well.

The workaround is to avoid adding Firestore header files (except the public ones) to sources.

See https://github.com/facebook/react-native/issues/14326, which describes the same problem.

Fixes #4035.