### PR TITLE
Ensure that projectIDs are validated

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRValidationTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRValidationTests.mm
@@ -16,6 +16,8 @@
 
 #import <FirebaseFirestore/FirebaseFirestore.h>
 
+#import <FirebaseCore/FIRApp.h>
+#import <FirebaseCore/FIROptions.h>
 #import <XCTest/XCTest.h>
 
 #include <limits>
@@ -25,6 +27,10 @@
 
 #import "Firestore/Example/Tests/Util/FSTHelpers.h"
 #import "Firestore/Example/Tests/Util/FSTIntegrationTestCase.h"
+
+#include "Firestore/core/test/firebase/firestore/testutil/app_testing.h"
+
+namespace testutil = firebase::firestore::testutil;
 
 // We have tests for passing nil when nil is not supposed to be allowed. So suppress the warnings.
 #pragma clang diagnostic ignored "-Wnonnull"
@@ -68,6 +74,15 @@
       [FIRFirestore firestoreForApp:nil],
       @"FirebaseApp instance may not be nil. Use FirebaseApp.app() if you'd like to use the "
        "default FirebaseApp instance.");
+}
+
+- (void)testNilProjectIDFails {
+  FIROptions *options = testutil::OptionsForUnitTesting("ignored");
+  options.projectID = nil;
+  FIRApp *app = testutil::AppForUnitTesting(options);
+  FSTAssertThrows(
+      [FIRFirestore firestoreForApp:app],
+      @"FIROptions.projectID must be set to a valid project ID.");
 }
 
 // TODO(b/62410906): Test for firestoreForApp:database: with nil DatabaseID.

--- a/Firestore/Example/Tests/Integration/API/FIRValidationTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRValidationTests.mm
@@ -80,9 +80,8 @@ namespace testutil = firebase::firestore::testutil;
   FIROptions *options = testutil::OptionsForUnitTesting("ignored");
   options.projectID = nil;
   FIRApp *app = testutil::AppForUnitTesting(options);
-  FSTAssertThrows(
-      [FIRFirestore firestoreForApp:app],
-      @"FIROptions.projectID must be set to a valid project ID.");
+  FSTAssertThrows([FIRFirestore firestoreForApp:app],
+                  @"FIROptions.projectID must be set to a valid project ID.");
 }
 
 // TODO(b/62410906): Test for firestoreForApp:database: with nil DatabaseID.

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -170,6 +170,8 @@ class FakeCredentialsProvider : public EmptyCredentialsProvider {
  * values trigger which configurations.
  */
 + (void)setUpDefaults {
+  if (defaultSettings) return;
+
   defaultSettings = [[FIRFirestoreSettings alloc] init];
   defaultSettings.persistenceEnabled = YES;
 
@@ -245,10 +247,7 @@ class FakeCredentialsProvider : public EmptyCredentialsProvider {
 }
 
 + (FIRFirestoreSettings *)settings {
-  if (!defaultSettings) {
-    [self setUpDefaults];
-  }
-
+  [self setUpDefaults];
   return defaultSettings;
 }
 
@@ -283,6 +282,12 @@ class FakeCredentialsProvider : public EmptyCredentialsProvider {
 - (void)primeBackend {
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
+    [FSTIntegrationTestCase setUpDefaults];
+    if (runningAgainstEmulator) {
+      // Priming not required against the emulator.
+      return;
+    }
+
     FIRFirestore *db = [self firestore];
     XCTestExpectation *watchInitialized =
         [self expectationWithDescription:@"Prime backend: Watch initialized"];

--- a/Firestore/core/test/firebase/firestore/testutil/app_testing.h
+++ b/Firestore/core/test/firebase/firestore/testutil/app_testing.h
@@ -34,6 +34,9 @@ FIROptions* OptionsForUnitTesting(absl::string_view project_id = "project_id");
 /** Creates a new Firebase App for testing. */
 FIRApp* AppForUnitTesting(absl::string_view project_id = "project_id");
 
+/** Creates a new Firebase App for testing from the given options. */
+FIRApp* AppForUnitTesting(FIROptions* options);
+
 }  // namespace testutil
 }  // namespace firestore
 }  // namespace firebase

--- a/Firestore/core/test/firebase/firestore/testutil/app_testing.mm
+++ b/Firestore/core/test/firebase/firestore/testutil/app_testing.mm
@@ -33,13 +33,16 @@ FIROptions* OptionsForUnitTesting(absl::string_view project_id) {
 }
 
 FIRApp* AppForUnitTesting(absl::string_view project_id) {
+  FIROptions* options = OptionsForUnitTesting(project_id);
+  return AppForUnitTesting(options);
+}
+
+FIRApp* AppForUnitTesting(FIROptions* options) {
   static int counter = 0;
 
   NSString* appName =
       [NSString stringWithFormat:@"app_for_unit_testing_%d", counter++];
-  FIROptions* options = OptionsForUnitTesting(project_id);
   [FIRApp configureWithName:appName options:options];
-
   return [FIRApp appNamed:appName];
 }
 


### PR DESCRIPTION
Also avoid priming the backend when running tests against the emulator.

#no-changelog