### PR TITLE
Stop packaging GoogleSignIn

### DIFF
--- a/Firebase/Core/CHANGELOG.md
+++ b/Firebase/Core/CHANGELOG.md
@@ -2,6 +2,9 @@
 - [fixed] Fix container instantiation timing, IID startup. (#4030)
 - [changed] Open-sourced Firebase pod. This enables `import Firebase` module
   support for tvOS and macOS. (#4021)
+- [changed] The GoogleSignIn binary is no longer distributed in the Firebase zip
+  or Carthage distribution. Use
+  https://developers.google.com/identity/sign-in/ios/sdk instead.
 
 # v6.3.1 -- M57
 - [fixed] Fixed race condition in component container. (#3967, #3924)

--- a/ZipBuilder/Sources/ZipBuilder/CocoaPod.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPod.swift
@@ -28,7 +28,6 @@ public enum CocoaPod: String, CaseIterable {
   case dynamicLinks = "DynamicLinks"
   case firestore = "Firestore"
   case functions = "Functions"
-  case googleSignIn = "GoogleSignIn"
   case inAppMessaging = "InAppMessaging"
   case inAppMessagingDisplay = "InAppMessagingDisplay"
   case messaging = "Messaging"
@@ -61,7 +60,6 @@ public enum CocoaPod: String, CaseIterable {
   /// The name of the pod in the CocoaPods repo.
   public var podName: String {
     switch self {
-    case .googleSignIn: return rawValue
     default: return "Firebase/\(rawValue)"
     }
   }
@@ -79,7 +77,7 @@ public enum CocoaPod: String, CaseIterable {
   /// Describes the dependency on other frameworks for the README file.
   public func readmeHeader() -> String {
     var header = "## \(rawValue)"
-    if !(self == .analytics || self == .googleSignIn) {
+    if !(self == .analytics) {
       header += " (~> Analytics)"
     }
     header += "\n"
@@ -104,7 +102,6 @@ public enum CocoaPod: String, CaseIterable {
          .dynamicLinks,
          .firestore,
          .functions,
-         .googleSignIn,
          .inAppMessaging,
          .inAppMessagingDisplay,
          .messaging,


### PR DESCRIPTION
Close #3791 

The GoogleSignIn binary should now be accessed from https://developers.google.com/identity/sign-in/ios/sdk 