### PR TITLE
FirebaseInstallations: re-generate Installation on HTTP 401 and 404 

### DIFF
--- a/FirebaseInstallations/Source/Library/Errors/FIRInstallationsHTTPError.h
+++ b/FirebaseInstallations/Source/Library/Errors/FIRInstallationsHTTPError.h
@@ -52,5 +52,3 @@ typedef NS_ENUM(NSInteger, FIRInstallationsAuthTokenHTTPCode) {
   FIRInstallationsAuthTokenHTTPCodeInvalidAuthentication = 401,
   FIRInstallationsAuthTokenHTTPCodeFIDNotFound = 404,
 };
-
-extern NSInteger const kFIRInstallationsAPIInternalErrorHTTPCode;

--- a/FirebaseInstallations/Source/Library/Errors/FIRInstallationsHTTPError.h
+++ b/FirebaseInstallations/Source/Library/Errors/FIRInstallationsHTTPError.h
@@ -32,6 +32,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_ASSUME_NONNULL_END
 
+typedef NS_ENUM(NSInteger, FIRInstallationsHTTPCodes) {
+  FIRInstallationsHTTPCodesTooManyRequests = 429,
+  FIRInstallationsHTTPCodesServerInternalError = 500,
+};
+
 /** Possible response HTTP codes for `CreateInstallation` API request. */
 typedef NS_ENUM(NSInteger, FIRInstallationsRegistrationHTTPCode) {
   FIRInstallationsRegistrationHTTPCodeSuccess = 201,
@@ -41,6 +46,11 @@ typedef NS_ENUM(NSInteger, FIRInstallationsRegistrationHTTPCode) {
   FIRInstallationsRegistrationHTTPCodeProjectNotFound = 404,
   FIRInstallationsRegistrationHTTPCodeTooManyRequests = 429,
   FIRInstallationsRegistrationHTTPCodeServerInternalError = 500
+};
+
+typedef NS_ENUM(NSInteger, FIRInstallationsAuthTokenHTTPCode) {
+  FIRInstallationsAuthTokenHTTPCodeInvalidAuthentication = 401,
+  FIRInstallationsAuthTokenHTTPCodeFIDNotFound = 404,
 };
 
 extern NSInteger const kFIRInstallationsAPIInternalErrorHTTPCode;

--- a/FirebaseInstallations/Source/Library/Errors/FIRInstallationsHTTPError.m
+++ b/FirebaseInstallations/Source/Library/Errors/FIRInstallationsHTTPError.m
@@ -76,5 +76,3 @@
 }
 
 @end
-
-NSInteger const kFIRInstallationsAPIInternalErrorHTTPCode = 500;

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -325,7 +325,7 @@ NSTimeInterval const kFIRInstallationsRegistrationErrorTimeout = 24 * 60 * 60;  
 #pragma mark - Auth Token
 
 - (FBLPromise<FIRInstallationsItem *> *)getAuthTokenForcingRefresh:(BOOL)forceRefresh {
-  if (forceRefresh) {
+  if (forceRefresh || [self.authTokenForcingRefreshPromiseCache getExistingPendingPromise] != nil) {
     return [self.authTokenForcingRefreshPromiseCache getExistingPendingOrCreateNewPromise];
   } else {
     return [self.authTokenPromiseCache getExistingPendingOrCreateNewPromise];
@@ -371,12 +371,12 @@ NSTimeInterval const kFIRInstallationsRegistrationErrorTimeout = 24 * 60 * 60;  
       // The stored installation was damaged or blocked by the server.
       // Delete the stored installation then generate and register a new one.
       return [self getInstallationItem]
-      .then(^FBLPromise<NSNull *> *(FIRInstallationsItem *installation) {
-        return [self deleteInstallationLocally:installation];
-      })
-      .then(^FBLPromise<FIRInstallationsItem *> *(id result) {
-        return [self installationWithValidAuthTokenForcingRefresh:NO];
-      });
+          .then(^FBLPromise<NSNull *> *(FIRInstallationsItem *installation) {
+            return [self deleteInstallationLocally:installation];
+          })
+          .then(^FBLPromise<FIRInstallationsItem *> *(id result) {
+            return [self installationWithValidAuthTokenForcingRefresh:NO];
+          });
 
     default:
       // No recovery possible. Return the same error.

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -353,9 +353,35 @@ NSTimeInterval const kFIRInstallationsRegistrationErrorTimeout = 24 * 60 * 60;  
           return registeredInstallation;
         }
       })
-      .catch(^void(NSError *error){
-          // TODO: Handle the errors.
+      .recover(^id(NSError *error) {
+        return [self regenerateFIDOnRefreshTokenErrorIfNeeded:error];
       });
+}
+
+- (id)regenerateFIDOnRefreshTokenErrorIfNeeded:(NSError *)error {
+  if (![error isKindOfClass:[FIRInstallationsHTTPError class]]) {
+    // No recovery possible. Return the same error.
+    return error;
+  }
+
+  FIRInstallationsHTTPError *HTTPError = (FIRInstallationsHTTPError *)error;
+  switch (HTTPError.HTTPResponse.statusCode) {
+    case FIRInstallationsAuthTokenHTTPCodeInvalidAuthentication:
+    case FIRInstallationsAuthTokenHTTPCodeFIDNotFound:
+      // The stored installation was damaged or blocked by the server.
+      // Delete the stored installation then generate and register a new one.
+      return [self getInstallationItem]
+      .then(^FBLPromise<NSNull *> *(FIRInstallationsItem *installation) {
+        return [self deleteInstallationLocally:installation];
+      })
+      .then(^FBLPromise<FIRInstallationsItem *> *(id result) {
+        return [self installationWithValidAuthTokenForcingRefresh:NO];
+      });
+
+    default:
+      // No recovery possible. Return the same error.
+      return error;
+  }
 }
 
 #pragma mark - Delete FID
@@ -380,9 +406,13 @@ NSTimeInterval const kFIRInstallationsRegistrationErrorTimeout = 24 * 60 * 60;  
       })
       .then(^id(FIRInstallationsItem *installation) {
         // Remove the installation from the local storage.
-        return [self.installationsStore removeInstallationForAppID:installation.appID
-                                                           appName:installation.firebaseAppName];
-      })
+        return [self deleteInstallationLocally:installation];
+      });
+}
+
+- (FBLPromise<NSNull *> *)deleteInstallationLocally:(FIRInstallationsItem *)installation {
+  return [self.installationsStore removeInstallationForAppID:installation.appID
+                                                     appName:installation.firebaseAppName]
       .then(^FBLPromise<NSNull *> *(NSNull *result) {
         return [self deleteExistingIIDIfNeeded];
       })

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
@@ -178,7 +178,7 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
   NSData *successResponseData =
       [self loadFixtureNamed:@"APIRegisterInstallationResponseSuccess.json"];
   taskCompletion(successResponseData,
-                 [self responseWithStatusCode:kFIRInstallationsAPIInternalErrorHTTPCode], nil);
+                 [self responseWithStatusCode:FIRInstallationsHTTPCodesServerInternalError], nil);
 
   // 6.1. Expect network request to send again.
   id mockDataTask2 = OCMClassMock([NSURLSessionDataTask class]);
@@ -192,7 +192,7 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
 
   // 6.3. Send network response again.
   taskCompletion(successResponseData,
-                 [self responseWithStatusCode:kFIRInstallationsAPIInternalErrorHTTPCode], nil);
+                 [self responseWithStatusCode:FIRInstallationsHTTPCodesServerInternalError], nil);
 
   // 7. Check result.
   XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
@@ -202,7 +202,7 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
 
   XCTAssertTrue([promise.error isKindOfClass:[FIRInstallationsHTTPError class]]);
   FIRInstallationsHTTPError *HTTPError = (FIRInstallationsHTTPError *)promise.error;
-  XCTAssertEqual(HTTPError.HTTPResponse.statusCode, kFIRInstallationsAPIInternalErrorHTTPCode);
+  XCTAssertEqual(HTTPError.HTTPResponse.statusCode, FIRInstallationsHTTPCodesServerInternalError);
 }
 
 - (void)testRefreshAuthTokenSuccess {
@@ -353,7 +353,7 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
 
   // 5. Call the data task completion.
   taskCompletion(errorResponseData,
-                 [self responseWithStatusCode:kFIRInstallationsAPIInternalErrorHTTPCode], nil);
+                 [self responseWithStatusCode:FIRInstallationsHTTPCodesServerInternalError], nil);
 
   // 6. Retry:
 
@@ -368,13 +368,14 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
 
   // 6.2. Send the API response again.
   taskCompletion(errorResponseData,
-                 [self responseWithStatusCode:kFIRInstallationsAPIInternalErrorHTTPCode], nil);
+                 [self responseWithStatusCode:FIRInstallationsHTTPCodesServerInternalError], nil);
 
   // 6. Check result.
   XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
 
-  XCTAssertTrue([FIRInstallationsErrorUtil isAPIError:promise.error
-                                         withHTTPCode:kFIRInstallationsAPIInternalErrorHTTPCode]);
+  XCTAssertTrue([FIRInstallationsErrorUtil
+        isAPIError:promise.error
+      withHTTPCode:FIRInstallationsHTTPCodesServerInternalError]);
   XCTAssertNil(promise.value);
 }
 
@@ -549,7 +550,8 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
 
   // 5. Call the data task completion.
   // HTTP 200 but no data (a potential server failure).
-  taskCompletion(nil, [self responseWithStatusCode:kFIRInstallationsAPIInternalErrorHTTPCode], nil);
+  taskCompletion(nil, [self responseWithStatusCode:FIRInstallationsHTTPCodesServerInternalError],
+                 nil);
 
   // 6. Retry:
   // 6.1. Wait for the API request to be sent again.
@@ -562,13 +564,15 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
   OCMVerifyAllWithDelay(mockDataTask1, 1.5);
 
   // 6.1. Send another response.
-  taskCompletion(nil, [self responseWithStatusCode:kFIRInstallationsAPIInternalErrorHTTPCode], nil);
+  taskCompletion(nil, [self responseWithStatusCode:FIRInstallationsHTTPCodesServerInternalError],
+                 nil);
 
   // 7. Check result.
   FBLWaitForPromisesWithTimeout(0.5);
 
-  XCTAssertTrue([FIRInstallationsErrorUtil isAPIError:promise.error
-                                         withHTTPCode:kFIRInstallationsAPIInternalErrorHTTPCode]);
+  XCTAssertTrue([FIRInstallationsErrorUtil
+        isAPIError:promise.error
+      withHTTPCode:FIRInstallationsHTTPCodesServerInternalError]);
   XCTAssertNil(promise.value);
 }
 

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
@@ -381,6 +381,68 @@
   OCMVerifyAll(self.mockAPIService);
 }
 
+- (FBLPromise<FIRInstallationsItem *> *)assertNewInstallationCreatedAndRegistered {
+  // 1. Stub store get installation.
+  [self expectInstallationsStoreGetInstallationNotFound];
+
+  // 2. Stub store save installation.
+  __block FIRInstallationsItem *createdInstallation;
+
+  OCMExpect([self.mockInstallationsStore
+                saveInstallation:[OCMArg checkWithBlock:^BOOL(FIRInstallationsItem *obj) {
+                  [self assertValidCreatedInstallation:obj];
+
+                  createdInstallation = obj;
+                  return YES;
+                }]])
+      .andReturn([FBLPromise resolvedWith:[NSNull null]]);
+
+  // 3. Stub API register installation.
+  // 3.1. Verify installation to be registered.
+  id registerInstallationValidation = [OCMArg checkWithBlock:^BOOL(FIRInstallationsItem *obj) {
+    [self assertValidCreatedInstallation:obj];
+    XCTAssertEqual(obj.firebaseInstallationID.length, 22);
+    return YES;
+  }];
+
+  // 3.2. Expect for `registerInstallation` to be called.
+  FBLPromise<FIRInstallationsItem *> *registerPromise = [FBLPromise pendingPromise];
+  OCMExpect([self.mockAPIService registerInstallation:registerInstallationValidation])
+      .andReturn(registerPromise);
+
+  // 4. Expect IIDStore to be checked for existing IID.
+  FBLPromise *rejectedPromise = [FBLPromise pendingPromise];
+  [rejectedPromise reject:[FIRInstallationsErrorUtil keychainErrorWithFunction:@"" status:-1]];
+  OCMExpect([self.mockIIDStore existingIID]).andReturn(rejectedPromise);
+
+  // 5. Call get installation and check.
+  FBLPromise<FIRInstallationsItem *> *getInstallationPromise =
+      [self.controller getInstallationItem];
+
+  // 5.1. Wait for the stored item to be read and saved.
+  OCMVerifyAllWithDelay(self.mockInstallationsStore, 0.5);
+
+  // 5.2. Wait for `registerInstallation` to be called.
+  OCMVerifyAllWithDelay(self.mockAPIService, 0.5);
+
+  // 5.3. Expect for the registered installation to be saved.
+  FIRInstallationsItem *registeredInstallation = [FIRInstallationsItem
+      createRegisteredInstallationItemWithAppID:createdInstallation.appID
+                                        appName:createdInstallation.firebaseAppName];
+
+  OCMExpect([self.mockInstallationsStore
+                saveInstallation:[OCMArg checkWithBlock:^BOOL(FIRInstallationsItem *obj) {
+                  XCTAssertEqual(registeredInstallation, obj);
+                  return YES;
+                }]])
+      .andReturn([FBLPromise resolvedWith:[NSNull null]]);
+
+  // 5.5. Resolve `registerPromise` to simulate finished registration.
+  [registerPromise fulfill:registeredInstallation];
+
+  return getInstallationPromise;
+}
+
 #pragma mark - Get Auth Token
 
 - (void)testGetAuthToken_WhenValidInstallationExists_ThenItIsReturned {
@@ -551,6 +613,43 @@
     XCTAssertEqualObjects(authPromise.value.authToken.expirationDate,
                           responseInstallation.authToken.expirationDate);
   }
+}
+
+- (void)testGetAuthToken_WhenAPIResponse401_ThenFISResetAndReregistered {
+  // 1.1. Expect installation to be requested from the store.
+  FIRInstallationsItem *storedInstallation =
+      [FIRInstallationsItem createRegisteredInstallationItem];
+  OCMExpect([self.mockInstallationsStore installationForAppID:self.appID appName:self.appName])
+      .andReturn([FBLPromise resolvedWith:storedInstallation]);
+
+  // 1.2. Expect API request.
+  NSError *error401 = [FIRInstallationsErrorUtil APIErrorWithHTTPCode:404];
+  FBLPromise *rejectedAPIPromise = [FBLPromise pendingPromise];
+  [rejectedAPIPromise reject:error401];
+  OCMExpect([self.mockAPIService refreshAuthTokenForInstallation:storedInstallation])
+      .andReturn(rejectedAPIPromise);
+
+  // 2. Request auth token.
+  FBLPromise<FIRInstallationsItem *> *promise = [self.controller getAuthTokenForcingRefresh:YES];
+
+  // 3. Wait for refresh token request.
+  OCMVerifyAllWithDelay(self.mockAPIService, 0.5);
+
+  // 4. Expect
+
+  // 3. Wait for the promise to resolve.
+  XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
+
+  // 4. Check.
+  OCMVerifyAll(self.mockInstallationsStore);
+  OCMVerifyAll(self.mockAPIService);
+
+  XCTAssertNil(promise.error);
+  XCTAssertNotNil(promise.value);
+
+  XCTAssertEqualObjects(promise.value.authToken.token, responseInstallation.authToken.token);
+  XCTAssertEqualObjects(promise.value.authToken.expirationDate,
+                        responseInstallation.authToken.expirationDate);
 }
 
 #pragma mark - FID Deletion
@@ -812,6 +911,23 @@
   OCMVerifyAll(self.mockInstallationsStore);
   OCMVerifyAll(self.mockAPIService);
   OCMVerifyAll(self.mockIIDStore);
+}
+
+- (NSArray<XCTestExpectation *> *)expectInstallationToBeDeletedLocally:(FIRInstallationsItem *)installation {
+  // 3.1. Expect the installation to be removed from the storage.
+  OCMExpect([self.mockInstallationsStore removeInstallationForAppID:installation.appID
+                                                            appName:installation.firebaseAppName])
+      .andReturn([FBLPromise resolvedWith:[NSNull null]]);
+
+  // 3.2. Expect IID to be deleted, because it is default app.
+  OCMExpect([self.mockIIDStore deleteExistingIID])
+      .andReturn([FBLPromise resolvedWith:[NSNull null]]);
+
+  // 4. Expect FIRInstallationIDDidChangeNotification to be sent.
+  XCTestExpectation *notificationExpectation =
+      [self installationIDDidChangeNotificationExpectation];
+
+  return @[ notificationExpectation ];
 }
 
 // TODO: Test a single delete installation request at a time.

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
@@ -725,7 +725,7 @@
   // 2. Expect API request to delete installation.
   FBLPromise *rejectedAPIPromise = [FBLPromise pendingPromise];
   NSError *error500 =
-      [FIRInstallationsErrorUtil APIErrorWithHTTPCode:kFIRInstallationsAPIInternalErrorHTTPCode];
+      [FIRInstallationsErrorUtil APIErrorWithHTTPCode:FIRInstallationsHTTPCodesServerInternalError];
   [rejectedAPIPromise reject:error500];
   OCMExpect([self.mockAPIService deleteInstallation:installation]).andReturn(rejectedAPIPromise);
 

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
@@ -137,7 +137,7 @@
 - (void)testAuthTokenError {
   FBLPromise *errorPromise = [FBLPromise pendingPromise];
   [errorPromise reject:[FIRInstallationsErrorUtil
-                           APIErrorWithHTTPCode:kFIRInstallationsAPIInternalErrorHTTPCode]];
+                           APIErrorWithHTTPCode:FIRInstallationsHTTPCodesServerInternalError]];
   OCMExpect([self.mockIDController getAuthTokenForcingRefresh:NO]).andReturn(errorPromise);
 
   XCTestExpectation *tokenExpectation = [self expectationWithDescription:@"AuthTokenSuccess"];
@@ -186,7 +186,7 @@
 - (void)testAuthTokenForcingRefreshError {
   FBLPromise *errorPromise = [FBLPromise pendingPromise];
   [errorPromise reject:[FIRInstallationsErrorUtil
-                           APIErrorWithHTTPCode:kFIRInstallationsAPIInternalErrorHTTPCode]];
+                           APIErrorWithHTTPCode:FIRInstallationsHTTPCodesServerInternalError]];
   OCMExpect([self.mockIDController getAuthTokenForcingRefresh:YES]).andReturn(errorPromise);
 
   XCTestExpectation *tokenExpectation = [self expectationWithDescription:@"AuthTokenSuccess"];
@@ -221,7 +221,7 @@
 - (void)testDeleteError {
   FBLPromise *errorPromise = [FBLPromise pendingPromise];
   NSError *APIError =
-      [FIRInstallationsErrorUtil APIErrorWithHTTPCode:kFIRInstallationsAPIInternalErrorHTTPCode];
+      [FIRInstallationsErrorUtil APIErrorWithHTTPCode:FIRInstallationsHTTPCodesServerInternalError];
   [errorPromise reject:APIError];
   OCMExpect([self.mockIDController deleteInstallation]).andReturn(errorPromise);
 


### PR DESCRIPTION
- If HTTP 401 or 404 is received on token refresh API request then the installation is deleted and a new one is created and registered (see go/fis-ios-sdk-design#heading=h.4ylovir3dwsk for more details)

cc @ankitaj224 