### PR TITLE
Bump Firestore conformance test to 9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -399,9 +399,9 @@ jobs:
 
     # Test Firestore on Xcode 8 to use old llvm to ensure C++ portability.
     - stage: test
-      osx_image: xcode8.3
+      osx_image: xcode9.4
       env:
-        - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild XCODE_VERSION=8.3.3
+        - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild XCODE_VERSION=9.4.1
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:


### PR DESCRIPTION
Based on discussion in #4084 

I would like to get one of these two PRs approved ASAP to get a clean travis run before the 6.11.0 release.