### PR TITLE
Fix potential race during client initialization

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,9 +1,6 @@
-# Unreleased
+# v1.6.1
 - [fixed] Fix a race condition that could cause a segmentation fault during
   client initialization.
-  
-# v1.6.1
-- [changed] Internal improvements.
 
 # v1.6.0
 - [feature] Added an `addSnapshotsInSyncListener()` method to

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Unreleased
+
 # v1.6.1
 - [fixed] Fix a race condition that could cause a segmentation fault during
   client initialization.

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
-
+- [fixed] Fix a race condition that could cause a segmentation fault during
+  client initialization.
+  
 # v1.6.1
 - [changed] Internal improvements.
 

--- a/Firestore/core/src/firebase/firestore/core/firestore_client.h
+++ b/Firestore/core/src/firebase/firestore/core/firestore_client.h
@@ -207,6 +207,7 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
   std::chrono::milliseconds initial_gc_delay_ = std::chrono::minutes(1);
   std::chrono::milliseconds regular_gc_delay_ = std::chrono::minutes(5);
   bool gc_has_run_ = false;
+  bool credentials_initialized_ = false;
   local::LruDelegate* _Nullable lru_delegate_;
   util::DelayedOperation lru_callback_;
 };

--- a/Firestore/core/src/firebase/firestore/core/firestore_client.mm
+++ b/Firestore/core/src/firebase/firestore/core/firestore_client.mm
@@ -94,18 +94,20 @@ std::shared_ptr<FirestoreClient> FirestoreClient::Create(
       new FirestoreClient(database_info, std::move(credentials_provider),
                           std::move(user_executor), std::move(worker_queue)));
 
-  auto user_promise = std::make_shared<std::promise<User>>();
   bool credentials_initialized = false;
 
   std::weak_ptr<FirestoreClient> weak_client(shared_client);
-  auto credential_change_listener = [credentials_initialized, user_promise,
-                                     weak_client](User user) mutable {
+  auto credential_change_listener = [credentials_initialized, weak_client,
+                                     settings](User user) mutable {
     auto shared_client = weak_client.lock();
     if (!shared_client) return;
 
     if (!credentials_initialized) {
       credentials_initialized = true;
-      user_promise->set_value(user);
+
+      shared_client->worker_queue()->Enqueue([shared_client, user, settings] {
+        shared_client->Initialize(user, settings);
+      });
     } else {
       shared_client->worker_queue()->Enqueue([shared_client, user] {
         shared_client->worker_queue()->VerifyIsCurrentQueue();
@@ -118,16 +120,6 @@ std::shared_ptr<FirestoreClient> FirestoreClient::Create(
 
   shared_client->credentials_provider_->SetCredentialChangeListener(
       credential_change_listener);
-
-  // Defer initialization until we get the current user from the
-  // credential_change_listener. This is guaranteed to be synchronously
-  // dispatched onto our worker queue, so we will be initialized before any
-  // subsequently queued work runs.
-  shared_client->worker_queue()->Enqueue(
-      [shared_client, user_promise, settings] {
-        User user = user_promise->get_future().get();
-        shared_client->Initialize(user, settings);
-      });
 
   return shared_client;
 }


### PR DESCRIPTION
Ports the fix from https://github.com/firebase/firebase-android-sdk/commit/0213e1e81bf9bc61806496cb07ba1797c2628acf, but using the logic of the Web client (https://github.com/firebase/firebase-js-sdk/blob/master/packages/firestore/src/core/firestore_client.ts#L184)