### PR TITLE
tokenWithAuthorizedEntity: method should also check if token is fresh

### DIFF
--- a/Example/InstanceID/Tests/FIRInstanceIDTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTest.m
@@ -63,6 +63,11 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
 + (int64_t)maxRetryCountForDefaultToken;
 + (int64_t)minIntervalForDefaultTokenRetry;
 + (int64_t)maxRetryIntervalForDefaultTokenInSeconds;
+- (void)fetchNewTokenWithAuthorizedEntity:(NSString *)authorizedEntity
+                                    scope:(NSString *)scope
+                                  keyPair:(FIRInstanceIDKeyPair *)keyPair
+                                  options:(NSDictionary *)options
+                                  handler:(FIRInstanceIDTokenHandler)handler;
 
 @end
 
@@ -186,6 +191,35 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
   [self.mockInstanceID didCompleteConfigure];
 
   OCMVerify([self.mockInstanceID defaultTokenWithHandler:nil]);
+}
+
+- (void)testTokenShouldBeRefreshedIfIIDAndTokenAreNotConsistent {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"token request is complete"];
+    NSString *APNSKey = kFIRInstanceIDTokenOptionsAPNSKey;
+    NSString *serverKey = kFIRInstanceIDTokenOptionsAPNSIsSandboxKey;
+
+    [self stubKeyPairStoreToReturnValidKeypair];
+    [self mockAuthServiceToAlwaysReturnValidCheckin];
+
+    NSData *fakeAPNSDeviceToken = [kFakeAPNSToken dataUsingEncoding:NSUTF8StringEncoding];
+    BOOL isSandbox = YES;
+    NSDictionary *tokenOptions = @{
+      APNSKey : fakeAPNSDeviceToken,
+      serverKey : @(isSandbox),
+    };
+    FIRInstanceIDAPNSInfo *optionsAPNSInfo =
+    [[FIRInstanceIDAPNSInfo alloc] initWithTokenOptionsDictionary:tokenOptions];
+    sTokenInfo.APNSInfo = optionsAPNSInfo;
+    [[[self.mockTokenManager stub] andReturn:sTokenInfo]
+    cachedTokenInfoWithAuthorizedEntity:[OCMArg any]
+                                  scope:[OCMArg any]];
+    [[self.mockTokenManager stub] fetchNewTokenWithAuthorizedEntity:kGCMSenderID scope:@"*" keyPair:[OCMArg any] options:tokenOptions handler:[OCMArg invokeBlockWithArgs:@"newToken", [NSNull null], nil]];
+
+    [self.mockInstanceID tokenWithAuthorizedEntity:kGCMSenderID scope:@"*" options:tokenOptions handler:^(NSString * _Nullable token, NSError * _Nullable error) {
+        XCTAssertEqualObjects(token, @"newToken");
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:1.0 handler:NULL];
 }
 
 - (void)testTokenIsDeletedAlongWithIdentity {

--- a/Example/InstanceID/Tests/FIRInstanceIDTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTest.m
@@ -194,32 +194,42 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
 }
 
 - (void)testTokenShouldBeRefreshedIfIIDAndTokenAreNotConsistent {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"token request is complete"];
-    NSString *APNSKey = kFIRInstanceIDTokenOptionsAPNSKey;
-    NSString *serverKey = kFIRInstanceIDTokenOptionsAPNSIsSandboxKey;
+  XCTestExpectation *expectation = [self expectationWithDescription:@"token request is complete"];
+  NSString *APNSKey = kFIRInstanceIDTokenOptionsAPNSKey;
+  NSString *serverKey = kFIRInstanceIDTokenOptionsAPNSIsSandboxKey;
 
-    [self stubKeyPairStoreToReturnValidKeypair];
-    [self mockAuthServiceToAlwaysReturnValidCheckin];
+  [self stubKeyPairStoreToReturnValidKeypair];
+  [self mockAuthServiceToAlwaysReturnValidCheckin];
 
-    NSData *fakeAPNSDeviceToken = [kFakeAPNSToken dataUsingEncoding:NSUTF8StringEncoding];
-    BOOL isSandbox = YES;
-    NSDictionary *tokenOptions = @{
-      APNSKey : fakeAPNSDeviceToken,
-      serverKey : @(isSandbox),
-    };
-    FIRInstanceIDAPNSInfo *optionsAPNSInfo =
-    [[FIRInstanceIDAPNSInfo alloc] initWithTokenOptionsDictionary:tokenOptions];
-    sTokenInfo.APNSInfo = optionsAPNSInfo;
-    [[[self.mockTokenManager stub] andReturn:sTokenInfo]
-    cachedTokenInfoWithAuthorizedEntity:[OCMArg any]
-                                  scope:[OCMArg any]];
-    [[self.mockTokenManager stub] fetchNewTokenWithAuthorizedEntity:kGCMSenderID scope:@"*" keyPair:[OCMArg any] options:tokenOptions handler:[OCMArg invokeBlockWithArgs:@"newToken", [NSNull null], nil]];
+  NSData *fakeAPNSDeviceToken = [kFakeAPNSToken dataUsingEncoding:NSUTF8StringEncoding];
+  BOOL isSandbox = YES;
+  NSDictionary *tokenOptions = @{
+    APNSKey : fakeAPNSDeviceToken,
+    serverKey : @(isSandbox),
+  };
+  FIRInstanceIDAPNSInfo *optionsAPNSInfo =
+      [[FIRInstanceIDAPNSInfo alloc] initWithTokenOptionsDictionary:tokenOptions];
+  sTokenInfo.APNSInfo = optionsAPNSInfo;
+  [[[self.mockTokenManager stub] andReturn:sTokenInfo]
+      cachedTokenInfoWithAuthorizedEntity:[OCMArg any]
+                                    scope:[OCMArg any]];
+  [[self.mockTokenManager stub]
+      fetchNewTokenWithAuthorizedEntity:kGCMSenderID
+                                  scope:@"*"
+                                keyPair:[OCMArg any]
+                                options:tokenOptions
+                                handler:[OCMArg
+                                            invokeBlockWithArgs:@"newToken", [NSNull null], nil]];
 
-    [self.mockInstanceID tokenWithAuthorizedEntity:kGCMSenderID scope:@"*" options:tokenOptions handler:^(NSString * _Nullable token, NSError * _Nullable error) {
-        XCTAssertEqualObjects(token, @"newToken");
-        [expectation fulfill];
-    }];
-    [self waitForExpectationsWithTimeout:1.0 handler:NULL];
+  [self.mockInstanceID
+      tokenWithAuthorizedEntity:kGCMSenderID
+                          scope:@"*"
+                        options:tokenOptions
+                        handler:^(NSString *_Nullable token, NSError *_Nullable error) {
+                          XCTAssertEqualObjects(token, @"newToken");
+                          [expectation fulfill];
+                        }];
+  [self waitForExpectationsWithTimeout:1.0 handler:NULL];
 }
 
 - (void)testTokenIsDeletedAlongWithIdentity {

--- a/Example/InstanceID/Tests/FIRInstanceIDTokenInfoTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTokenInfoTest.m
@@ -26,7 +26,9 @@
 
 static NSString *const kAuthorizedEntity = @"authorizedEntity";
 static NSString *const kScope = @"scope";
-static NSString *const kToken = @"eMP633ZkDYA:APA91bGfnlnbinRVE7nUwJSr_k6cuSTKectOlt66dKv1r_-9Qvhy9XljAI62QPw307rgA0MaFHPnrU5sFxGZvsncRnkfuciwTUeyRpPNDZMFhNXt7h1BKq9Wb2A0LAANpQefrPHVUp4p";
+static NSString *const kToken = @"eMP633ZkDYA:APA91bGfnlnbinRVE7nUwJSr_k6cuSTKectOlt66dKv1r_-"
+                                @"9Qvhy9XljAI62QPw307rgA0MaFHPnrU5sFxGZvsncRnkfuciwTUeyRpPNDZMFhNXt"
+                                @"7h1BKq9Wb2A0LAANpQefrPHVUp4p";
 static NSString *const kFirebaseAppID = @"firebaseAppID";
 static NSString *const kIID = @"eMP633ZkDYA";
 static BOOL const kAPNSSandbox = NO;
@@ -179,15 +181,17 @@ static BOOL const kAPNSSandbox = NO;
   XCTAssertFalse([self.validTokenInfo isFreshWithIID:kIID]);
 }
 
--(void)testTokenInconsistentWithIID {
+- (void)testTokenInconsistentWithIID {
   XCTAssertTrue([self.validTokenInfo isFreshWithIID:kIID]);
   // Change token.
-  self.validTokenInfo =
-    [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:kAuthorizedEntity
-                                                       scope:kScope token:@"cxhhwVY27AE:APA91bGfnlnbinRVE7nUwJSr_k6cuSTKectOlt66dKv1r_-9Qvhy9XljAI62QPw307rgA0MaFHPnrU5sFxGZvsncRnkfuciwTUeyRpPNDZMFhNXt7h1BKq9Wb2A0LAANpQefrPHVUp4p"
-                                                  appVersion:@"1.1"
-                                               firebaseAppID:FIRInstanceIDFirebaseAppID()];
+  self.validTokenInfo = [[FIRInstanceIDTokenInfo alloc]
+      initWithAuthorizedEntity:kAuthorizedEntity
+                         scope:kScope
+                         token:@"cxhhwVY27AE:APA91bGfnlnbinRVE7nUwJSr_k6cuSTKectOlt66dKv1r_-"
+                               @"9Qvhy9XljAI62QPw307rgA0MaFHPnrU5sFxGZvsncRnkfuciwTUeyRpPNDZMFhNXt7"
+                               @"h1BKq9Wb2A0LAANpQefrPHVUp4p"
+                    appVersion:@"1.1"
+                 firebaseAppID:FIRInstanceIDFirebaseAppID()];
   XCTAssertFalse([self.validTokenInfo isFreshWithIID:kIID]);
-
 }
 @end

--- a/Example/InstanceID/Tests/FIRInstanceIDTokenInfoTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTokenInfoTest.m
@@ -179,7 +179,7 @@ static BOOL const kAPNSSandbox = NO;
   XCTAssertFalse([self.validTokenInfo isFreshWithIID:kIID]);
 }
 
--(void)testTokenInconsistentWithToken {
+-(void)testTokenInconsistentWithIID {
   XCTAssertTrue([self.validTokenInfo isFreshWithIID:kIID]);
   // Change token.
   self.validTokenInfo =

--- a/Example/InstanceID/Tests/FIRInstanceIDTokenInfoTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTokenInfoTest.m
@@ -26,8 +26,9 @@
 
 static NSString *const kAuthorizedEntity = @"authorizedEntity";
 static NSString *const kScope = @"scope";
-static NSString *const kToken = @"validToken";
+static NSString *const kToken = @"eMP633ZkDYA:APA91bGfnlnbinRVE7nUwJSr_k6cuSTKectOlt66dKv1r_-9Qvhy9XljAI62QPw307rgA0MaFHPnrU5sFxGZvsncRnkfuciwTUeyRpPNDZMFhNXt7h1BKq9Wb2A0LAANpQefrPHVUp4p";
 static NSString *const kFirebaseAppID = @"firebaseAppID";
+static NSString *const kIID = @"eMP633ZkDYA";
 static BOOL const kAPNSSandbox = NO;
 
 @interface FIRInstanceIDTokenInfoTest : XCTestCase
@@ -126,14 +127,14 @@ static BOOL const kAPNSSandbox = NO;
 
 - (void)testTokenFreshnessWithLocaleChange {
   // Default should be fresh because we mock last fetch token time just now.
-  XCTAssertTrue([self.validTokenInfo isFresh]);
+  XCTAssertTrue([self.validTokenInfo isFreshWithIID:kIID]);
 
   // Locale change should affect token refreshness.
   // Set to a different locale than the current locale.
   [[NSUserDefaults standardUserDefaults] setObject:@"zh-Hant"
                                             forKey:kFIRInstanceIDUserDefaultsKeyLocale];
   [[NSUserDefaults standardUserDefaults] synchronize];
-  XCTAssertFalse([self.validTokenInfo isFresh]);
+  XCTAssertFalse([self.validTokenInfo isFreshWithIID:kIID]);
   // Reset locale
   [[NSUserDefaults standardUserDefaults] setObject:FIRInstanceIDCurrentLocale()
                                             forKey:kFIRInstanceIDUserDefaultsKeyLocale];
@@ -141,33 +142,33 @@ static BOOL const kAPNSSandbox = NO;
 }
 
 - (void)testTokenFreshnessWithTokenTimestampChange {
-  XCTAssertTrue([self.validTokenInfo isFresh]);
+  XCTAssertTrue([self.validTokenInfo isFreshWithIID:kIID]);
   // Set last fetch token time 7 days ago.
   NSTimeInterval lastFetchTokenTimestamp =
       FIRInstanceIDCurrentTimestampInSeconds() - 7 * 24 * 60 * 60;
   self.validTokenInfo.cacheTime = [NSDate dateWithTimeIntervalSince1970:lastFetchTokenTimestamp];
-  XCTAssertFalse([self.validTokenInfo isFresh]);
+  XCTAssertFalse([self.validTokenInfo isFreshWithIID:kIID]);
 
   // Set last fetch token time more than 7 days ago.
   lastFetchTokenTimestamp = FIRInstanceIDCurrentTimestampInSeconds() - 8 * 24 * 60 * 60;
   self.validTokenInfo.cacheTime = [NSDate dateWithTimeIntervalSince1970:lastFetchTokenTimestamp];
-  XCTAssertFalse([self.validTokenInfo isFresh]);
+  XCTAssertFalse([self.validTokenInfo isFreshWithIID:kIID]);
 
   // Set last fetch token time nil to mock legacy storage format. Token should be considered not
   // fresh.
   self.validTokenInfo.cacheTime = nil;
-  XCTAssertFalse([self.validTokenInfo isFresh]);
+  XCTAssertFalse([self.validTokenInfo isFreshWithIID:kIID]);
 }
 
 - (void)testTokenFreshnessWithFirebaseAppIDChange {
-  XCTAssertTrue([self.validTokenInfo isFresh]);
+  XCTAssertTrue([self.validTokenInfo isFreshWithIID:kIID]);
   // Change Firebase App ID.
   [FIROptions defaultOptions].googleAppID = @"newFirebaseAppID:ios:abcdefg";
-  XCTAssertFalse([self.validTokenInfo isFresh]);
+  XCTAssertFalse([self.validTokenInfo isFreshWithIID:kIID]);
 }
 
 - (void)testTokenFreshnessWithAppVersionChange {
-  XCTAssertTrue([self.validTokenInfo isFresh]);
+  XCTAssertTrue([self.validTokenInfo isFreshWithIID:kIID]);
   // Change app version.
   self.validTokenInfo =
       [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:kAuthorizedEntity
@@ -175,6 +176,18 @@ static BOOL const kAPNSSandbox = NO;
                                                          token:kToken
                                                     appVersion:@"1.1"
                                                  firebaseAppID:FIRInstanceIDFirebaseAppID()];
-  XCTAssertFalse([self.validTokenInfo isFresh]);
+  XCTAssertFalse([self.validTokenInfo isFreshWithIID:kIID]);
+}
+
+-(void)testTokenInconsistentWithToken {
+  XCTAssertTrue([self.validTokenInfo isFreshWithIID:kIID]);
+  // Change token.
+  self.validTokenInfo =
+    [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:kAuthorizedEntity
+                                                       scope:kScope token:@"cxhhwVY27AE:APA91bGfnlnbinRVE7nUwJSr_k6cuSTKectOlt66dKv1r_-9Qvhy9XljAI62QPw307rgA0MaFHPnrU5sFxGZvsncRnkfuciwTUeyRpPNDZMFhNXt7h1BKq9Wb2A0LAANpQefrPHVUp4p"
+                                                  appVersion:@"1.1"
+                                               firebaseAppID:FIRInstanceIDFirebaseAppID()];
+  XCTAssertFalse([self.validTokenInfo isFreshWithIID:kIID]);
+
 }
 @end

--- a/Firebase/InstanceID/CHANGELOG.md
+++ b/Firebase/InstanceID/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [changed] Ensure tokenWithAuthorizedEntity:scope:options:handler method is refreshing token if token is not feshed any more. (#4096)
+
 # 2019-10-22 -- 4.2.6
 - [fixed] Fixed InstanceID initialization timing issue (#4030).
 - [changed] Added check to see if token and IID are inconsistent (#4025).

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -316,48 +316,48 @@ static FIRInstanceID *gInstanceID;
 
   FIRInstanceID_WEAKIFY(self);
   FIRInstanceIDAuthService *authService = self.tokenManager.authService;
-  [authService
-      fetchCheckinInfoWithHandler:^(FIRInstanceIDCheckinPreferences *preferences, NSError *error) {
-        FIRInstanceID_STRONGIFY(self);
-        if (error) {
-          newHandler(nil, error);
-          return;
-        }
+  [authService fetchCheckinInfoWithHandler:^(FIRInstanceIDCheckinPreferences *preferences,
+                                             NSError *error) {
+    FIRInstanceID_STRONGIFY(self);
+    if (error) {
+      newHandler(nil, error);
+      return;
+    }
 
-        FIRInstanceID_WEAKIFY(self);
-        [self asyncLoadKeyPairWithHandler:^(FIRInstanceIDKeyPair *keyPair, NSError *error) {
-          FIRInstanceID_STRONGIFY(self);
+    FIRInstanceID_WEAKIFY(self);
+    [self asyncLoadKeyPairWithHandler:^(FIRInstanceIDKeyPair *keyPair, NSError *error) {
+      FIRInstanceID_STRONGIFY(self);
 
-          if (error) {
-            NSError *newError =
-                [NSError errorWithFIRInstanceIDErrorCode:kFIRInstanceIDErrorCodeInvalidKeyPair];
-            newHandler(nil, newError);
+      if (error) {
+        NSError *newError =
+            [NSError errorWithFIRInstanceIDErrorCode:kFIRInstanceIDErrorCodeInvalidKeyPair];
+        newHandler(nil, newError);
 
-          } else {
-            FIRInstanceIDTokenInfo *cachedTokenInfo =
-              [self.tokenManager cachedTokenInfoWithAuthorizedEntity:authorizedEntity scope:scope];
-            if (cachedTokenInfo) {
-              FIRInstanceIDAPNSInfo *optionsAPNSInfo =
-                [[FIRInstanceIDAPNSInfo alloc] initWithTokenOptionsDictionary:tokenOptions];
-              // Check if APNS Info is changed
-              if ((!cachedTokenInfo.APNSInfo && !optionsAPNSInfo) ||
-                [cachedTokenInfo.APNSInfo isEqualToAPNSInfo:optionsAPNSInfo]) {
-                // check if token is fresh
-                NSString *appIdentity = FIRInstanceIDAppIdentity(keyPair);
-                if ([cachedTokenInfo isFreshWithIID:appIdentity]) {
-                  newHandler(cachedTokenInfo.token, nil);
-                  return;
-                }
-              }
+      } else {
+        FIRInstanceIDTokenInfo *cachedTokenInfo =
+            [self.tokenManager cachedTokenInfoWithAuthorizedEntity:authorizedEntity scope:scope];
+        if (cachedTokenInfo) {
+          FIRInstanceIDAPNSInfo *optionsAPNSInfo =
+              [[FIRInstanceIDAPNSInfo alloc] initWithTokenOptionsDictionary:tokenOptions];
+          // Check if APNS Info is changed
+          if ((!cachedTokenInfo.APNSInfo && !optionsAPNSInfo) ||
+              [cachedTokenInfo.APNSInfo isEqualToAPNSInfo:optionsAPNSInfo]) {
+            // check if token is fresh
+            NSString *appIdentity = FIRInstanceIDAppIdentity(keyPair);
+            if ([cachedTokenInfo isFreshWithIID:appIdentity]) {
+              newHandler(cachedTokenInfo.token, nil);
+              return;
             }
-            [self.tokenManager fetchNewTokenWithAuthorizedEntity:[authorizedEntity copy]
-                                                           scope:[scope copy]
-                                                         keyPair:keyPair
-                                                         options:tokenOptions
-                                                         handler:newHandler];
           }
-        }];
-      }];
+        }
+        [self.tokenManager fetchNewTokenWithAuthorizedEntity:[authorizedEntity copy]
+                                                       scope:[scope copy]
+                                                     keyPair:keyPair
+                                                     options:tokenOptions
+                                                     handler:newHandler];
+      }
+    }];
+  }];
 }
 
 - (void)deleteTokenWithAuthorizedEntity:(NSString *)authorizedEntity

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -30,6 +30,7 @@
 #import "FIRInstanceIDConstants.h"
 #import "FIRInstanceIDDefines.h"
 #import "FIRInstanceIDKeyPairStore.h"
+#import "FIRInstanceIDKeyPairUtilities.h"
 #import "FIRInstanceIDLogger.h"
 #import "FIRInstanceIDStore.h"
 #import "FIRInstanceIDTokenInfo.h"
@@ -268,6 +269,7 @@ static FIRInstanceID *gInstanceID;
     return;
   }
 
+  // Add internal options
   NSMutableDictionary *tokenOptions = [NSMutableDictionary dictionary];
   if (options.count) {
     [tokenOptions addEntriesFromDictionary:options];
@@ -275,12 +277,14 @@ static FIRInstanceID *gInstanceID;
 
   NSString *APNSKey = kFIRInstanceIDTokenOptionsAPNSKey;
   NSString *serverTypeKey = kFIRInstanceIDTokenOptionsAPNSIsSandboxKey;
-
   if (tokenOptions[APNSKey] != nil && tokenOptions[serverTypeKey] == nil) {
     // APNS key was given, but server type is missing. Supply the server type with automatic
     // checking. This can happen when the token is requested from FCM, which does not include a
     // server type during its request.
     tokenOptions[serverTypeKey] = @([self isSandboxApp]);
+  }
+  if (self.firebaseAppID) {
+    tokenOptions[kFIRInstanceIDTokenOptionsFirebaseAppIDKey] = self.firebaseAppID;
   }
 
   // comparing enums to ints directly throws a warning
@@ -310,14 +314,6 @@ static FIRInstanceID *gInstanceID;
     return;
   }
 
-  // TODO(chliangGoogle): Add some validation logic that the APNs token data and sandbox value are
-  // supplied in the valid format (NSData and BOOL, respectively).
-
-  // Add internal options
-  if (self.firebaseAppID) {
-    tokenOptions[kFIRInstanceIDTokenOptionsFirebaseAppIDKey] = self.firebaseAppID;
-  }
-
   FIRInstanceID_WEAKIFY(self);
   FIRInstanceIDAuthService *authService = self.tokenManager.authService;
   [authService
@@ -326,24 +322,6 @@ static FIRInstanceID *gInstanceID;
         if (error) {
           newHandler(nil, error);
           return;
-        }
-
-        // Only use the token in the cache if the APNSInfo matches what the request's options has.
-        // It's possible for the request to be with a newer APNs device token, which should be
-        // honored.
-        FIRInstanceIDTokenInfo *cachedTokenInfo =
-            [self.tokenManager cachedTokenInfoWithAuthorizedEntity:authorizedEntity scope:scope];
-        if (cachedTokenInfo) {
-          // Ensure that the cached token matches APNs data before returning it.
-          FIRInstanceIDAPNSInfo *optionsAPNSInfo =
-              [[FIRInstanceIDAPNSInfo alloc] initWithTokenOptionsDictionary:tokenOptions];
-          // If either the APNs info is missing in both, or if they are an exact match, then we can
-          // use this cached token.
-          if ((!cachedTokenInfo.APNSInfo && !optionsAPNSInfo) ||
-              [cachedTokenInfo.APNSInfo isEqualToAPNSInfo:optionsAPNSInfo]) {
-            newHandler(cachedTokenInfo.token, nil);
-            return;
-          }
         }
 
         FIRInstanceID_WEAKIFY(self);
@@ -356,6 +334,24 @@ static FIRInstanceID *gInstanceID;
             newHandler(nil, newError);
 
           } else {
+            FIRInstanceIDTokenInfo *cachedTokenInfo =
+              [self.tokenManager cachedTokenInfoWithAuthorizedEntity:authorizedEntity scope:scope];
+            if (cachedTokenInfo) {
+              FIRInstanceIDAPNSInfo *optionsAPNSInfo =
+                [[FIRInstanceIDAPNSInfo alloc] initWithTokenOptionsDictionary:tokenOptions];
+              // If either the APNs info is missing in both, or if they are an exact match, then we can
+              // use this cached token.
+              if ((!cachedTokenInfo.APNSInfo && !optionsAPNSInfo) ||
+                [cachedTokenInfo.APNSInfo isEqualToAPNSInfo:optionsAPNSInfo]) {
+                newHandler(cachedTokenInfo.token, nil);
+                return;
+              }
+              NSString *appIdentity = FIRInstanceIDAppIdentity(keyPair);
+              if ([cachedTokenInfo isFreshWithIID:appIdentity]) {
+                newHandler(cachedTokenInfo.token, nil);
+                return;
+              }
+            }
             [self.tokenManager fetchNewTokenWithAuthorizedEntity:[authorizedEntity copy]
                                                            scope:[scope copy]
                                                          keyPair:keyPair

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -339,17 +339,15 @@ static FIRInstanceID *gInstanceID;
             if (cachedTokenInfo) {
               FIRInstanceIDAPNSInfo *optionsAPNSInfo =
                 [[FIRInstanceIDAPNSInfo alloc] initWithTokenOptionsDictionary:tokenOptions];
-              // If either the APNs info is missing in both, or if they are an exact match, then we can
-              // use this cached token.
+              // Check if APNS Info is changed
               if ((!cachedTokenInfo.APNSInfo && !optionsAPNSInfo) ||
                 [cachedTokenInfo.APNSInfo isEqualToAPNSInfo:optionsAPNSInfo]) {
-                newHandler(cachedTokenInfo.token, nil);
-                return;
-              }
-              NSString *appIdentity = FIRInstanceIDAppIdentity(keyPair);
-              if ([cachedTokenInfo isFreshWithIID:appIdentity]) {
-                newHandler(cachedTokenInfo.token, nil);
-                return;
+                // check if token is fresh
+                NSString *appIdentity = FIRInstanceIDAppIdentity(keyPair);
+                if ([cachedTokenInfo isFreshWithIID:appIdentity]) {
+                  newHandler(cachedTokenInfo.token, nil);
+                  return;
+                }
               }
             }
             [self.tokenManager fetchNewTokenWithAuthorizedEntity:[authorizedEntity copy]

--- a/Firebase/InstanceID/FIRInstanceIDTokenInfo.h
+++ b/Firebase/InstanceID/FIRInstanceIDTokenInfo.h
@@ -74,8 +74,18 @@ NS_ASSUME_NONNULL_BEGIN
  * 2. Language setting is not changed.
  * 3. App version is current.
  * 4. GMP App ID is current.
+ * 5. token is consistent with the current IID.
+ * 6. APNS info has changed.
+ * @param IID  The app identifiier that is used to check if token is prefixed with.
+ * @return If token is fresh.
+ *
  */
-- (BOOL)isFresh;
+- (BOOL)isFreshWithIID:(NSString *)IID;
+
+/*
+ * Check wehther the token is default token.
+ */
+- (BOOL)isDefaultToken;
 
 @end
 

--- a/Firebase/InstanceID/FIRInstanceIDTokenInfo.h
+++ b/Firebase/InstanceID/FIRInstanceIDTokenInfo.h
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isFreshWithIID:(NSString *)IID;
 
 /*
- * Check wehther the token is default token.
+ * Check whether the token is default token.
  */
 - (BOOL)isDefaultToken;
 

--- a/Firebase/InstanceID/FIRInstanceIDTokenInfo.m
+++ b/Firebase/InstanceID/FIRInstanceIDTokenInfo.m
@@ -69,6 +69,9 @@ const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7 days.
 - (BOOL)isFreshWithIID:(NSString *)IID {
   // Last fetch token cache time could be null if token is from legacy storage format. Then token is
   // considered not fresh and should be refreshed and overwrite with the latest storage format.
+  if (!IID) {
+    return NO;
+  }
   if (!_cacheTime) {
     return NO;
   }

--- a/Firebase/InstanceID/FIRInstanceIDTokenInfo.m
+++ b/Firebase/InstanceID/FIRInstanceIDTokenInfo.m
@@ -18,6 +18,7 @@
 
 #import "FIRInstanceIDLogger.h"
 #import "FIRInstanceIDUtilities.h"
+#import "FIRInstanceIDConstants.h"
 
 /**
  *  @enum Token Info Dictionary Key Constants
@@ -65,10 +66,15 @@ const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7 days.
   return self;
 }
 
-- (BOOL)isFresh {
+- (BOOL)isFreshWithIID:(NSString *)IID {
   // Last fetch token cache time could be null if token is from legacy storage format. Then token is
   // considered not fresh and should be refreshed and overwrite with the latest storage format.
   if (!_cacheTime) {
+    return NO;
+  }
+
+  // Check if it's consistent with IID
+  if (![self.token hasPrefix:IID]) {
     return NO;
   }
 
@@ -105,6 +111,11 @@ const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7 days.
   NSTimeInterval timeSinceLastFetchToken = currentTimestamp - lastFetchTokenTimestamp;
   return (timeSinceLastFetchToken < kDefaultFetchTokenInterval);
 }
+
+- (BOOL)isDefaultToken {
+    return [self.scope isEqualToString:kFIRInstanceIDDefaultTokenScope];
+}
+
 #pragma mark - NSCoding
 
 - (nullable instancetype)initWithCoder:(NSCoder *)aDecoder {

--- a/Firebase/InstanceID/FIRInstanceIDTokenInfo.m
+++ b/Firebase/InstanceID/FIRInstanceIDTokenInfo.m
@@ -16,9 +16,9 @@
 
 #import "FIRInstanceIDTokenInfo.h"
 
+#import "FIRInstanceIDConstants.h"
 #import "FIRInstanceIDLogger.h"
 #import "FIRInstanceIDUtilities.h"
-#import "FIRInstanceIDConstants.h"
 
 /**
  *  @enum Token Info Dictionary Key Constants
@@ -116,7 +116,7 @@ const NSTimeInterval kDefaultFetchTokenInterval = 7 * 24 * 60 * 60;  // 7 days.
 }
 
 - (BOOL)isDefaultToken {
-    return [self.scope isEqualToString:kFIRInstanceIDDefaultTokenScope];
+  return [self.scope isEqualToString:kFIRInstanceIDDefaultTokenScope];
 }
 
 #pragma mark - NSCoding

--- a/Firebase/InstanceID/FIRInstanceIDTokenManager.m
+++ b/Firebase/InstanceID/FIRInstanceIDTokenManager.m
@@ -281,12 +281,12 @@
   NSMutableArray<FIRInstanceIDTokenInfo *> *tokenInfosToDelete =
       [NSMutableArray arrayWithCapacity:tokenInfos.count];
   for (FIRInstanceIDTokenInfo *tokenInfo in tokenInfos) {
-    BOOL isTokenFresh = [tokenInfo isFresh];
-    if (isTokenFresh && [tokenInfo.token hasPrefix:IID]) {
+    BOOL isTokenFresh = [tokenInfo isFreshWithIID:IID];
+    if (isTokenFresh) {
       // Token is fresh and in right format, do nothing
       continue;
     }
-    if ([tokenInfo.scope isEqualToString:kFIRInstanceIDDefaultTokenScope]) {
+    if ([tokenInfo isDefaultToken]) {
       // Default token is expired, do not mark for deletion. Fetch directly from server to
       // replace the current one.
       shouldFetchDefaultToken = YES;

--- a/Firebase/InstanceID/FIRInstanceIDTokenManager.m
+++ b/Firebase/InstanceID/FIRInstanceIDTokenManager.m
@@ -281,8 +281,7 @@
   NSMutableArray<FIRInstanceIDTokenInfo *> *tokenInfosToDelete =
       [NSMutableArray arrayWithCapacity:tokenInfos.count];
   for (FIRInstanceIDTokenInfo *tokenInfo in tokenInfos) {
-    BOOL isTokenFresh = [tokenInfo isFreshWithIID:IID];
-    if (isTokenFresh) {
+    if ([tokenInfo isFreshWithIID:IID]) {
       // Token is fresh and in right format, do nothing
       continue;
     }


### PR DESCRIPTION
This API is used to fetch token directly from server. Right now if APNS info is not changed, the client will simply use cached token.
We should also check token freshness, which checks if IID and token is consistent or if app version has changed, etc. This helps us migrate to FIS. (b/140506963)