### PR TITLE
Persist ReadTime in RemoteDocumentCache

### DIFF
--- a/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLRUGarbageCollectorTests.mm
@@ -228,7 +228,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (Document)cacheADocumentInTransaction {
   Document doc = [self nextTestDocument];
-  _documentCache->Add(doc);
+  _documentCache->Add(doc, doc.version());
   return doc;
 }
 
@@ -628,7 +628,7 @@ NS_ASSUME_NONNULL_BEGIN
     FSTTestSnapshotVersion version = 3;
     Document doc(ObjectValue(_testValue), middleDocToUpdate, Version(version),
                  DocumentState::kSynced);
-    _documentCache->Add(doc);
+    _documentCache->Add(doc, Version(version));
     [self updateTargetInTransaction:middleTarget];
   });
 

--- a/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
+++ b/Firestore/Example/Tests/Local/FSTLocalStoreTests.mm
@@ -722,7 +722,7 @@ NS_ASSUME_NONNULL_BEGIN
   core::Query query = Query("foo");
   TargetId targetID = [self allocateQuery:query];
 
-  [self applyRemoteEvent:FSTTestUpdateRemoteEvent(Doc("foo/bar", 0, Map("foo", "old")), {targetID},
+  [self applyRemoteEvent:FSTTestUpdateRemoteEvent(Doc("foo/bar", 1, Map("foo", "old")), {targetID},
                                                   {})];
   [self writeMutation:FSTTestPatchMutation("foo/bar", @{@"foo" : @"bar"}, {})];
   // Release the query so that our target count goes back to 0 and we are considered up-to-date.
@@ -730,7 +730,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   [self writeMutation:FSTTestSetMutation(@"foo/bah", @{@"foo" : @"bah"})];
   [self writeMutation:FSTTestDeleteMutation(@"foo/baz")];
-  FSTAssertContains(Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+  FSTAssertContains(Doc("foo/bar", 1, Map("foo", "bar"), DocumentState::kLocalMutations));
   FSTAssertContains(Doc("foo/bah", 0, Map("foo", "bah"), DocumentState::kLocalMutations));
   FSTAssertContains(DeletedDoc("foo/baz"));
 
@@ -757,7 +757,7 @@ NS_ASSUME_NONNULL_BEGIN
   core::Query query = Query("foo");
   TargetId targetID = [self allocateQuery:query];
 
-  [self applyRemoteEvent:FSTTestUpdateRemoteEvent(Doc("foo/bar", 0, Map("foo", "old")), {targetID},
+  [self applyRemoteEvent:FSTTestUpdateRemoteEvent(Doc("foo/bar", 1, Map("foo", "old")), {targetID},
                                                   {})];
   [self writeMutation:FSTTestPatchMutation("foo/bar", @{@"foo" : @"bar"}, {})];
   // Release the query so that our target count goes back to 0 and we are considered up-to-date.
@@ -765,7 +765,7 @@ NS_ASSUME_NONNULL_BEGIN
 
   [self writeMutation:FSTTestSetMutation(@"foo/bah", @{@"foo" : @"bah"})];
   [self writeMutation:FSTTestDeleteMutation(@"foo/baz")];
-  FSTAssertContains(Doc("foo/bar", 0, Map("foo", "bar"), DocumentState::kLocalMutations));
+  FSTAssertContains(Doc("foo/bar", 1, Map("foo", "bar"), DocumentState::kLocalMutations));
   FSTAssertContains(Doc("foo/bah", 0, Map("foo", "bah"), DocumentState::kLocalMutations));
   FSTAssertContains(DeletedDoc("foo/baz"));
 

--- a/Firestore/Example/Tests/Local/FSTRemoteDocumentCacheTests.mm
+++ b/Firestore/Example/Tests/Local/FSTRemoteDocumentCacheTests.mm
@@ -50,6 +50,7 @@ using testutil::DeletedDoc;
 using testutil::Doc;
 using testutil::Map;
 using testutil::Query;
+using testutil::Version;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -170,7 +171,7 @@ void ExpectMapHasDocs(XCTestCase *self,
 
   self.persistence->Run("testSetAndReadDeletedDocument", [&] {
     absl::optional<MaybeDocument> deletedDoc = DeletedDoc(kDocPath, kVersion);
-    self.remoteDocumentCache->Add(*deletedDoc);
+    self.remoteDocumentCache->Add(*deletedDoc, Version(kVersion));
 
     XCTAssertEqual(self.remoteDocumentCache->Get(testutil::Key(kDocPath)), deletedDoc);
   });
@@ -182,7 +183,7 @@ void ExpectMapHasDocs(XCTestCase *self,
   self.persistence->Run("testSetDocumentToNewValue", [&] {
     [self setTestDocumentAtPath:kDocPath];
     absl::optional<MaybeDocument> newDoc = Doc(kDocPath, kVersion, Map("data", 2));
-    self.remoteDocumentCache->Add(*newDoc);
+    self.remoteDocumentCache->Add(*newDoc, Version(kVersion));
     XCTAssertEqual(self.remoteDocumentCache->Get(testutil::Key(kDocPath)), newDoc);
   });
 }
@@ -233,7 +234,7 @@ void ExpectMapHasDocs(XCTestCase *self,
 #pragma mark - Helpers
 - (Document)setTestDocumentAtPath:(const absl::string_view)path {
   Document doc = Doc(path, kVersion, _kDocData);
-  self.remoteDocumentCache->Add(doc);
+  self.remoteDocumentCache->Add(doc, Version(kVersion));
   return doc;
 }
 

--- a/Firestore/core/src/firebase/firestore/local/leveldb_remote_document_cache.h
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_remote_document_cache.h
@@ -47,7 +47,8 @@ class LevelDbRemoteDocumentCache : public RemoteDocumentCache {
   LevelDbRemoteDocumentCache(LevelDbPersistence* db,
                              FSTLocalSerializer* serializer);
 
-  void Add(const model::MaybeDocument& document) override;
+  void Add(const model::MaybeDocument& document,
+           const model::SnapshotVersion& read_time) override;
   void Remove(const model::DocumentKey& key) override;
 
   absl::optional<model::MaybeDocument> Get(

--- a/Firestore/core/src/firebase/firestore/local/local_store.mm
+++ b/Firestore/core/src/firebase/firestore/local/local_store.mm
@@ -198,7 +198,7 @@ void LocalStore::ApplyBatchResult(const MutationBatchResult& batch_result) {
             "Mutation batch %s applied to document %s resulted in nullopt.",
             batch.ToString(), util::ToString(remote_doc));
       } else {
-        remote_document_cache_->Add(*doc);
+        remote_document_cache_->Add(*doc, batch_result.commit_version());
       }
     }
   }
@@ -313,11 +313,9 @@ model::MaybeDocumentMap LocalStore::ApplyRemoteEvent(
       } else if (!existing_doc || doc.version() > existing_doc->version() ||
                  (doc.version() == existing_doc->version() &&
                   existing_doc->has_pending_writes())) {
-        // TODO(index-free): Comment in this assert when we enable Index-Free
-        // queries HARD_ASSERT(remoteEvent.snapshot_version() !=
-        // SnapshotVersion::None(),
-        //            "Cannot add a document when the remote version is zero");
-        remote_document_cache_->Add(doc);
+        HARD_ASSERT(remote_event.snapshot_version() != SnapshotVersion::None(),
+                    "Cannot add a document when the remote version is zero");
+        remote_document_cache_->Add(doc, remote_event.snapshot_version());
         changed_docs = changed_docs.insert(key, doc);
       } else {
         LOG_DEBUG("LocalStore Ignoring outdated watch update for %s. "

--- a/Firestore/core/src/firebase/firestore/local/memory_remote_document_cache.h
+++ b/Firestore/core/src/firebase/firestore/local/memory_remote_document_cache.h
@@ -17,6 +17,7 @@
 #ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_MEMORY_REMOTE_DOCUMENT_CACHE_H_
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_LOCAL_MEMORY_REMOTE_DOCUMENT_CACHE_H_
 
+#include <utility>
 #include <vector>
 
 #include "Firestore/core/src/firebase/firestore/local/remote_document_cache.h"
@@ -37,7 +38,8 @@ class MemoryRemoteDocumentCache : public RemoteDocumentCache {
  public:
   explicit MemoryRemoteDocumentCache(MemoryPersistence* persistence);
 
-  void Add(const model::MaybeDocument& document) override;
+  void Add(const model::MaybeDocument& document,
+           const model::SnapshotVersion& read_time) override;
   void Remove(const model::DocumentKey& key) override;
 
   absl::optional<model::MaybeDocument> Get(
@@ -53,8 +55,10 @@ class MemoryRemoteDocumentCache : public RemoteDocumentCache {
   int64_t CalculateByteSize(const Sizer& sizer);
 
  private:
-  /** Underlying cache of documents. */
-  model::MaybeDocumentMap docs_;
+  /** Underlying cache of documents and their read times. */
+  immutable::SortedMap<model::DocumentKey,
+                       std::pair<model::MaybeDocument, model::SnapshotVersion>>
+      docs_;
 
   // This instance is owned by MemoryPersistence; avoid a retain cycle.
   MemoryPersistence* persistence_;

--- a/Firestore/core/src/firebase/firestore/local/memory_remote_document_cache.mm
+++ b/Firestore/core/src/firebase/firestore/local/memory_remote_document_cache.mm
@@ -43,9 +43,7 @@ MemoryRemoteDocumentCache::MemoryRemoteDocumentCache(
 
 void MemoryRemoteDocumentCache::Add(const MaybeDocument& document,
                                     const model::SnapshotVersion& read_time) {
-  docs_ = docs_.insert(
-      document.key(),
-      std::pair<MaybeDocument, SnapshotVersion>({document, read_time}));
+  docs_ = docs_.insert(document.key(), std::make_pair(document, read_time));
 
   persistence_->index_manager()->AddToCollectionParentIndex(
       document.key().path().PopLast());

--- a/Firestore/core/src/firebase/firestore/local/remote_document_cache.h
+++ b/Firestore/core/src/firebase/firestore/local/remote_document_cache.h
@@ -47,8 +47,10 @@ class RemoteDocumentCache {
    * entry for the key, it will be replaced.
    *
    * @param document A Document or DeletedDocument to put in the cache.
+   * @param read_time The time at which the document was read or committed.
    */
-  virtual void Add(const model::MaybeDocument& document) = 0;
+  virtual void Add(const model::MaybeDocument& document,
+                   const model::SnapshotVersion& read_time) = 0;
 
   /** Removes the cached entry for the given key (no-op if no entry exists). */
   virtual void Remove(const model::DocumentKey& key) = 0;


### PR DESCRIPTION
This adds the readTime argument to RemoteDocumentCache.Add() and persists in MemoryRemotedocumentCached and its LevelDB counterpart.

References:

- https://github.com/firebase/firebase-android-sdk/blob/master/firebase-firestore/src/main/java/com/google/firebase/firestore/local/RemoteDocumentCache.java#L43
- https://github.com/firebase/firebase-android-sdk/blob/master/firebase-firestore/src/main/java/com/google/firebase/firestore/local/MemoryRemoteDocumentCache.java#L38

Note that I did not implement the DocumentIterable that Android uses to hide the `std::pair` in the memory-backed implementation since it seemed overly complex in C++.
