### PR TITLE
Move all ReferenceDelegate handling to .cc file

### DIFF
--- a/Firestore/core/src/firebase/firestore/local/memory_persistence.cc
+++ b/Firestore/core/src/firebase/firestore/local/memory_persistence.cc
@@ -58,8 +58,15 @@ MemoryPersistence::MemoryPersistence()
     : query_cache_(this), remote_document_cache_(this), started_(true) {
 }
 
+MemoryPersistence::~MemoryPersistence() = default;
+
 ListenSequenceNumber MemoryPersistence::current_sequence_number() const {
   return reference_delegate_->current_sequence_number();
+}
+
+void MemoryPersistence::set_reference_delegate(
+    std::unique_ptr<ReferenceDelegate> delegate) {
+  reference_delegate_ = std::move(delegate);
 }
 
 void MemoryPersistence::Shutdown() {

--- a/Firestore/core/src/firebase/firestore/local/memory_persistence.h
+++ b/Firestore/core/src/firebase/firestore/local/memory_persistence.h
@@ -61,6 +61,8 @@ class MemoryPersistence : public Persistence {
   static std::unique_ptr<MemoryPersistence> WithLruGarbageCollector(
       LruParams params, std::unique_ptr<Sizer> sizer);
 
+  ~MemoryPersistence() override;
+
   const MutationQueues& mutation_queues() const {
     return mutation_queues_;
   }
@@ -88,9 +90,7 @@ class MemoryPersistence : public Persistence {
  private:
   MemoryPersistence();
 
-  void set_reference_delegate(std::unique_ptr<ReferenceDelegate> delegate) {
-    reference_delegate_ = std::move(delegate);
-  }
+  void set_reference_delegate(std::unique_ptr<ReferenceDelegate> delegate);
 
   MutationQueues mutation_queues_;
 


### PR DESCRIPTION
This removes the requirement to include reference_delegate.h in consuming tests.

#no-changelog FTW