### PR TITLE
Make sync_project work after pod deintegrate

### DIFF
--- a/scripts/sync_project.rb
+++ b/scripts/sync_project.rb
@@ -546,7 +546,7 @@ class Syncer
         next
       end
 
-      path = PODFILE_DIR.join(config.base_configuration_reference.path)
+      path = PODFILE_DIR.join(config.base_configuration_reference.real_path)
       if !File.file?(path)
         puts "Skipping #{target.name} (#{config.name}); missing xcconfig"
         next


### PR DESCRIPTION
Use base_configuration_reference.real_path rather than path

real_path has the correct value after a pod deintegrate/pod install
cycle, while path has some nearly correct value. No idea why these are
different.

#no-changelog