### PR TITLE
Optimize `DocumentKey` comparisons

### DIFF
--- a/Firestore/core/src/firebase/firestore/model/base_path.h
+++ b/Firestore/core/src/firebase/firestore/model/base_path.h
@@ -154,7 +154,7 @@ class BasePath {
     return util::CompareContainer(segments_, rhs.segments_);
   }
 
-  bool IsEqual(const T& rhs) const {
+  bool IsEqualTo(const T& rhs) const {
     return segments_ == rhs.segments_;
   }
 

--- a/Firestore/core/src/firebase/firestore/model/base_path.h
+++ b/Firestore/core/src/firebase/firestore/model/base_path.h
@@ -152,6 +152,7 @@ class BasePath {
 
   util::ComparisonResult CompareTo(const T& rhs) const {
     return util::Compare(segments_, rhs.segments_);
+    //return util::CompareContainer(segments_, rhs.segments_);
   }
 
   size_t Hash() const {

--- a/Firestore/core/src/firebase/firestore/model/base_path.h
+++ b/Firestore/core/src/firebase/firestore/model/base_path.h
@@ -151,7 +151,6 @@ class BasePath {
   }
 
   util::ComparisonResult CompareTo(const T& rhs) const {
-    //return util::Compare(segments_, rhs.segments_);
     return util::CompareContainer(segments_, rhs.segments_);
   }
 

--- a/Firestore/core/src/firebase/firestore/model/base_path.h
+++ b/Firestore/core/src/firebase/firestore/model/base_path.h
@@ -151,8 +151,12 @@ class BasePath {
   }
 
   util::ComparisonResult CompareTo(const T& rhs) const {
-    return util::Compare(segments_, rhs.segments_);
-    //return util::CompareContainer(segments_, rhs.segments_);
+    //return util::Compare(segments_, rhs.segments_);
+    return util::CompareContainer(segments_, rhs.segments_);
+  }
+
+  bool IsEqual(const T& rhs) const {
+    return segments_ == rhs.segments_;
   }
 
   size_t Hash() const {

--- a/Firestore/core/src/firebase/firestore/model/base_path.h
+++ b/Firestore/core/src/firebase/firestore/model/base_path.h
@@ -154,8 +154,8 @@ class BasePath {
     return util::CompareContainer(segments_, rhs.segments_);
   }
 
-  bool IsEqualTo(const T& rhs) const {
-    return segments_ == rhs.segments_;
+  friend bool operator==(const BasePath& lhs, const BasePath& rhs) {
+    return lhs.segments_ == rhs.segments_;
   }
 
   size_t Hash() const {

--- a/Firestore/core/src/firebase/firestore/model/document_key.cc
+++ b/Firestore/core/src/firebase/firestore/model/document_key.cc
@@ -53,6 +53,10 @@ util::ComparisonResult DocumentKey::CompareTo(const DocumentKey& other) const {
   return path().CompareTo(other.path());
 }
 
+bool DocumentKey::IsEqual(const DocumentKey& other) const {
+  return path().IsEqual(other.path());
+}
+
 std::string DocumentKey::ToString() const {
   return path().CanonicalString();
 }

--- a/Firestore/core/src/firebase/firestore/model/document_key.cc
+++ b/Firestore/core/src/firebase/firestore/model/document_key.cc
@@ -53,10 +53,6 @@ util::ComparisonResult DocumentKey::CompareTo(const DocumentKey& other) const {
   return path().CompareTo(other.path());
 }
 
-bool DocumentKey::IsEqualTo(const DocumentKey& other) const {
-  return path().IsEqualTo(other.path());
-}
-
 std::string DocumentKey::ToString() const {
   return path().CanonicalString();
 }

--- a/Firestore/core/src/firebase/firestore/model/document_key.cc
+++ b/Firestore/core/src/firebase/firestore/model/document_key.cc
@@ -53,8 +53,8 @@ util::ComparisonResult DocumentKey::CompareTo(const DocumentKey& other) const {
   return path().CompareTo(other.path());
 }
 
-bool DocumentKey::IsEqual(const DocumentKey& other) const {
-  return path().IsEqual(other.path());
+bool DocumentKey::IsEqualTo(const DocumentKey& other) const {
+  return path().IsEqualTo(other.path());
 }
 
 std::string DocumentKey::ToString() const {

--- a/Firestore/core/src/firebase/firestore/model/document_key.h
+++ b/Firestore/core/src/firebase/firestore/model/document_key.h
@@ -35,7 +35,7 @@ namespace model {
 /**
  * DocumentKey represents the location of a document in the Firestore database.
  */
-class DocumentKey : public util::Comparable<DocumentKey> {
+class DocumentKey : public util::ComparableWithEqual<DocumentKey> {
  public:
   /** Creates a "blank" document key not associated with any document. */
   DocumentKey() : path_{std::make_shared<ResourcePath>()} {
@@ -69,6 +69,8 @@ class DocumentKey : public util::Comparable<DocumentKey> {
   }
 
   util::ComparisonResult CompareTo(const DocumentKey& other) const;
+
+  bool IsEqual(const DocumentKey& other) const;
 
   size_t Hash() const {
     return util::Hash(ToString());

--- a/Firestore/core/src/firebase/firestore/model/document_key.h
+++ b/Firestore/core/src/firebase/firestore/model/document_key.h
@@ -70,7 +70,7 @@ class DocumentKey : public util::ComparableWithEqual<DocumentKey> {
 
   util::ComparisonResult CompareTo(const DocumentKey& other) const;
 
-  bool IsEqual(const DocumentKey& other) const;
+  bool IsEqualTo(const DocumentKey& other) const;
 
   size_t Hash() const {
     return util::Hash(ToString());

--- a/Firestore/core/src/firebase/firestore/model/document_key.h
+++ b/Firestore/core/src/firebase/firestore/model/document_key.h
@@ -35,7 +35,7 @@ namespace model {
 /**
  * DocumentKey represents the location of a document in the Firestore database.
  */
-class DocumentKey : public util::ComparableWithEqual<DocumentKey> {
+class DocumentKey : public util::InequalityComparable<DocumentKey> {
  public:
   /** Creates a "blank" document key not associated with any document. */
   DocumentKey() : path_{std::make_shared<ResourcePath>()} {
@@ -70,7 +70,9 @@ class DocumentKey : public util::ComparableWithEqual<DocumentKey> {
 
   util::ComparisonResult CompareTo(const DocumentKey& other) const;
 
-  bool IsEqualTo(const DocumentKey& other) const;
+  friend bool operator==(const DocumentKey& lhs, const DocumentKey& rhs) {
+    return lhs.path() == rhs.path();
+  }
 
   size_t Hash() const {
     return util::Hash(ToString());

--- a/Firestore/core/src/firebase/firestore/model/resource_path.h
+++ b/Firestore/core/src/firebase/firestore/model/resource_path.h
@@ -34,7 +34,7 @@ namespace model {
  * within Firestore. Immutable; all instances are fully independent.
  */
 class ResourcePath : public impl::BasePath<ResourcePath>,
-                     public util::Comparable<ResourcePath> {
+                     public util::InequalityComparable<ResourcePath> {
  public:
   ResourcePath() = default;
   /** Constructs the path from segments. */

--- a/Firestore/core/src/firebase/firestore/util/comparison.h
+++ b/Firestore/core/src/firebase/firestore/util/comparison.h
@@ -353,6 +353,35 @@ class Comparable {
   }
 };
 
+/**
+ * Same as `Comparable`, but `operator==` is delegated to a function called
+ * `IsEqual`. This is an optimization that avoids doing an extra comparison when
+ * comparing for equality (`Comparable` would have to check for both "less-than"
+ * and "greater-than" to determine whether two values are equal).
+ */
+template <typename T>
+class ComparableWithEqual {
+ public:
+  friend bool operator==(const T& lhs, const T& rhs) {
+    return lhs.IsEqual(rhs);
+  }
+  friend bool operator!=(const T& lhs, const T& rhs) {
+    return !(lhs == rhs);
+  }
+  friend bool operator<(const T& lhs, const T& rhs) {
+    return Ascending(lhs.CompareTo(rhs));
+  }
+  friend bool operator>(const T& lhs, const T& rhs) {
+    return Descending(lhs.CompareTo(rhs));
+  }
+  friend bool operator<=(const T& lhs, const T& rhs) {
+    return !(rhs < lhs);
+  }
+  friend bool operator>=(const T& lhs, const T& rhs) {
+    return !(lhs < rhs);
+  }
+};
+
 }  // namespace util
 }  // namespace firestore
 }  // namespace firebase

--- a/Firestore/core/src/firebase/firestore/util/comparison.h
+++ b/Firestore/core/src/firebase/firestore/util/comparison.h
@@ -355,15 +355,15 @@ class Comparable {
 
 /**
  * Same as `Comparable`, but `operator==` is delegated to a function called
- * `IsEqual`. This is an optimization that avoids doing an extra comparison when
- * comparing for equality (`Comparable` would have to check for both "less-than"
- * and "greater-than" to determine whether two values are equal).
+ * `IsEqualTo`. This is an optimization that avoids doing an extra comparison
+ * when comparing for equality (`Comparable` would have to check for both
+ * "less-than" and "greater-than" to determine whether two values are equal).
  */
 template <typename T>
 class ComparableWithEqual {
  public:
   friend bool operator==(const T& lhs, const T& rhs) {
-    return lhs.IsEqual(rhs);
+    return lhs.IsEqualTo(rhs);
   }
   friend bool operator!=(const T& lhs, const T& rhs) {
     return !(lhs == rhs);

--- a/Firestore/core/src/firebase/firestore/util/comparison.h
+++ b/Firestore/core/src/firebase/firestore/util/comparison.h
@@ -354,17 +354,15 @@ class Comparable {
 };
 
 /**
- * Same as `Comparable`, but `operator==` is delegated to a function called
- * `IsEqualTo`. This is an optimization that avoids doing an extra comparison
- * when comparing for equality (`Comparable` would have to check for both
- * "less-than" and "greater-than" to determine whether two values are equal).
+ * Same as `Comparable`, but deliberately not defining `operator==`, which
+ * instead is left for the class inheriting from this mixin to implement. This
+ * is an optimization that avoids doing an extra comparison when comparing for
+ * equality (`Comparable` would have to check for both "less-than" and
+ * "greater-than" to determine whether two values are equal).
  */
 template <typename T>
-class ComparableWithEqual {
+class InequalityComparable {
  public:
-  friend bool operator==(const T& lhs, const T& rhs) {
-    return lhs.IsEqualTo(rhs);
-  }
   friend bool operator!=(const T& lhs, const T& rhs) {
     return !(lhs == rhs);
   }


### PR DESCRIPTION
This came up while I was investigating the effect of new C++ serializers on performance. When writing large batches, one of the hottest functions turned out to be `firebase::firestore::util::operator==(const DocumentKey& lhs, const DocumentKey& rhs)`, accounting for 15-20% of total CPU time. There are two reasons why comparing keys is currently not very efficient:
* `BasePath::CompareTo`, to which this comparison eventually resolves, mistakenly uses the general-purpose `util::Compare` function rather than the more efficient `util::CompareContainer`;
* the default implementation of `Comparable::operator==` results in two comparisons per element ("less-than" followed by "greater-than"), even though one would be sufficient.

Fixing these issues results in 8-10% CPU time improvement when writing large batches.

To work around the latter, I defined a new mixin `ComparableWithEqual` that is exactly the same as `Comparable`, except its `operator==` delegates to `T::IsEqualTo`, avoiding the extra comparison.

Some measurements (all done on the emulator in release mode with no logging) follow; the test case was to write 10 batches of 500 very small documents. Note that I found wall clock to fluctuate too much to be reliable and instead use the measurements from XCode's Time Profiler, which (presumably) shows CPU time. Each measurement shows total CPU time spent on `firebase::firestore::util::operator==` (all instantiations, not just for `DocumentKey`), followed by the percentage of time spent in this function compared to total runtime:
* no optimization:
    * 275ms/18.8%;
    * 245ms/16.9%;
    * 252ms/18.5%.
* `CompareContainer` optimization:
    * 124ms/9.7%;
    * 110ms/8.5%;
    * 128ms/10.0%.
* `CompareContainer` + `ComparableWithEqual` optimizations:
    * 95ms/7.3%;
    * 100ms/8.0%;
    * 112ms/9.2%.