### PR TITLE
Stop using statics in header

### DIFF
--- a/FirebaseCoreDiagnosticsInterop.podspec
+++ b/FirebaseCoreDiagnosticsInterop.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCoreDiagnosticsInterop'
-  s.version          = '1.0.0'
+  s.version          = '1.1.0'
   s.summary          = 'Interfaces that allow other Firebase SDKs to use CoreDiagnostics functionality.'
 
   s.description      = <<-DESC

--- a/Interop/CoreDiagnostics/Public/FIRCoreDiagnosticsData.h
+++ b/Interop/CoreDiagnostics/Public/FIRCoreDiagnosticsData.h
@@ -19,36 +19,34 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** If present, is a BOOL wrapped in an NSNumber. */
-static NSString *const kFIRCDIsDataCollectionDefaultEnabledKey =
-    @"FIRCDIsDataCollectionDefaultEnabledKey";
+#define kFIRCDIsDataCollectionDefaultEnabledKey @"FIRCDIsDataCollectionDefaultEnabledKey"
 
 /** If present, is an int32_t wrapped in an NSNumber. */
-static NSString *const kFIRCDConfigurationTypeKey = @"FIRCDConfigurationTypeKey";
+#define kFIRCDConfigurationTypeKey @"FIRCDConfigurationTypeKey"
 
 /** If present, is an NSString. */
-static NSString *const kFIRCDSdkNameKey = @"FIRCDSdkNameKey";
+#define kFIRCDSdkNameKey @"FIRCDSdkNameKey"
 
 /** If present, is an NSString. */
-static NSString *const kFIRCDSdkVersionKey = @"FIRCDSdkVersionKey";
+#define kFIRCDSdkVersionKey @"FIRCDSdkVersionKey"
 
 /** If present, is an int32_t wrapped in an NSNumber. */
-static NSString *const kFIRCDllAppsCountKey = @"FIRCDllAppsCountKey";
+#define kFIRCDllAppsCountKey @"FIRCDllAppsCountKey"
 
 /** If present, is an NSString. */
-static NSString *const kFIRCDGoogleAppIDKey = @"FIRCDGoogleAppIDKey";
+#define kFIRCDGoogleAppIDKey @"FIRCDGoogleAppIDKey"
 
 /** If present, is an NSString. */
-static NSString *const kFIRCDBundleIDKey = @"FIRCDBundleID";
+#define kFIRCDBundleIDKey @"FIRCDBundleID"
 
 /** If present, is a BOOL wrapped in an NSNumber. */
-static NSString *const kFIRCDUsingOptionsFromDefaultPlistKey =
-    @"FIRCDUsingOptionsFromDefaultPlistKey";
+#define kFIRCDUsingOptionsFromDefaultPlistKey @"FIRCDUsingOptionsFromDefaultPlistKey"
 
 /** If present, is an NSString. */
-static NSString *const kFIRCDLibraryVersionIDKey = @"FIRCDLibraryVersionIDKey";
+#define kFIRCDLibraryVersionIDKey @"FIRCDLibraryVersionIDKey"
 
 /** If present, is an NSString. */
-static NSString *const kFIRCDFirebaseUserAgentKey = @"FIRCDFirebaseUserAgentKey";
+#define kFIRCDFirebaseUserAgentKey @"FIRCDFirebaseUserAgentKey"
 
 /** Defines the interface of a data object needed to log diagnostics data. */
 @protocol FIRCoreDiagnosticsData <NSObject>

--- a/scripts/if_changed.sh
+++ b/scripts/if_changed.sh
@@ -48,7 +48,7 @@ else
     Firebase-pod-lib-lint) # Combines Firebase-* and InAppMessaging*
       check_changes '^(Firebase/Auth|Firebase/Database|Firebase/DynamicLinks|'\
 'Firebase/Messaging|Firebase/Storage|GoogleUtilities|Interop|Example|'\
-'FirebaseAnalyticsIntop.podspec|FirebaseAuth.podspec|FirebaseAuthInterop.podspec|'\
+'FirebaseAnalyticsInterop.podspec|FirebaseAuth.podspec|FirebaseAuthInterop.podspec|'\
 'FirebaseCoreDiagnostics.podspec|FirebaseCoreDiagnosticsInterop.podspec|'\
 'FirebaseDatabase.podspec|FirebaseDynamicLinks.podspec|FirebaseMessaging.podspec|'\
 'FirebaseStorage.podspec|FirebaseStorage.podspec|Firebase/InAppMessagingDisplay|'\
@@ -71,7 +71,8 @@ else
       ;;
 
     Core-*)
-      check_changes '^(Firebase/Core|Example/Core/Tests|GoogleUtilities|FirebaseCore.podspec)'
+      check_changes '^(Firebase/Core|Example/Core/Tests|GoogleUtilities|FirebaseCore.podspec'\
+'FirebaseCoreDiagnostics.podspec|FirebaseCoreDiagnosticsInterop|FirebaseCoreDiagnosticsInterop.podspec)'
       ;;
 
     ABTesting-*)
@@ -166,7 +167,7 @@ fi
 # Always rebuild if Travis configuration and/or build scripts changed.
 check_changes '^.travis.yml'
 check_changes '^Gemfile.lock'
-check_changes '^scripts/(build|if_changed|install_prereqs|pod_lib_lint).(rb|sh)'
+check_changes '^scripts/(build|install_prereqs|pod_lib_lint).(rb|sh)'
 
 if [[ "$run" == true ]]; then
   "$@"


### PR DESCRIPTION
So they're not added to the size of every implementation file that includes them.

Update if_changed.sh to be more accurate for CoreDiagnostics changes and to make changes to itself testable.