### PR TITLE
FIS: Thread safety monkey integration tests added.

### DIFF
--- a/FirebaseInstallations/Source/Tests/Integration/FIRInstallationsIntegrationTests.m
+++ b/FirebaseInstallations/Source/Tests/Integration/FIRInstallationsIntegrationTests.m
@@ -338,8 +338,7 @@ static BOOL sFIRInstallationsFirebaseDefaultAppConfigured = NO;
   }];
 }
 
-// 1. Creates an array with `totalTestsCount` consisting of repeating `tests`
-// 2. Shuffles the array
+// Creates an array with `totalTestsCount` consisting of shuffled repeating `tests`.
 - (NSArray *)shuffledThreadSafetyTestsWithTests:(NSArray<dispatch_block_t> *)tests
                                 totalTestsCount:(NSInteger)count {
   NSMutableArray *allTests = [NSMutableArray arrayWithCapacity:count];

--- a/FirebaseInstallations/Source/Tests/Integration/FIRInstallationsIntegrationTests.m
+++ b/FirebaseInstallations/Source/Tests/Integration/FIRInstallationsIntegrationTests.m
@@ -177,7 +177,7 @@ static BOOL sFIRInstallationsFirebaseDefaultAppConfigured = NO;
     });
   }
 
-  [self waitForExpectations:roundExpectations timeout:testRoundsCount];
+  [self waitForExpectations:roundExpectations timeout:testRoundsCount * 60];
 }
 
 #pragma mark - Helpers
@@ -332,7 +332,6 @@ static BOOL sFIRInstallationsFirebaseDefaultAppConfigured = NO;
   NSLog(@"Perform test: %s", __PRETTY_FUNCTION__);
 
   [self.installations deleteWithCompletion:^(NSError *_Nullable error) {
-    XCTAssertNil(error);
     [expectation fulfill];
   }];
 }

--- a/FirebaseInstallations/Source/Tests/Integration/FIRInstallationsIntegrationTests.m
+++ b/FirebaseInstallations/Source/Tests/Integration/FIRInstallationsIntegrationTests.m
@@ -55,7 +55,7 @@ static BOOL sFIRInstallationsFirebaseDefaultAppConfigured = NO;
 - (void)tearDown {
   // Delete the installation.
   [self.installations deleteWithCompletion:^(NSError *_Nullable error){
-//      XCTAssertNil(error);
+      //      XCTAssertNil(error);
   }];
 
   // Wait for any pending background job to be completed.

--- a/FirebaseInstallations/Source/Tests/Integration/FIRInstallationsIntegrationTests.m
+++ b/FirebaseInstallations/Source/Tests/Integration/FIRInstallationsIntegrationTests.m
@@ -55,7 +55,6 @@ static BOOL sFIRInstallationsFirebaseDefaultAppConfigured = NO;
 - (void)tearDown {
   // Delete the installation.
   [self.installations deleteWithCompletion:^(NSError *_Nullable error){
-      //      XCTAssertNil(error);
   }];
 
   // Wait for any pending background job to be completed.

--- a/FirebaseInstallations/Source/Tests/Integration/FIRInstallationsIntegrationTests.m
+++ b/FirebaseInstallations/Source/Tests/Integration/FIRInstallationsIntegrationTests.m
@@ -297,7 +297,7 @@ static BOOL sFIRInstallationsFirebaseDefaultAppConfigured = NO;
     });
   }
 
-  [self waitForExpectations:@[ expectation ] timeout:totalTestsCount * 1];
+  [self waitForExpectations:@[ expectation ] timeout:totalTestsCount * 10];
 }
 
 - (void)threadSafetyTestGetFIDWithExpectation:(XCTestExpectation *)expectation {


### PR DESCRIPTION
- a monkey test added as an attempt to catch concurrency issues earlier.

The test is expected to fail (or at least be flaky) until #4148 lends.