### PR TITLE
Add --analyze to pod lib lint tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -320,9 +320,10 @@ jobs:
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh # Start integration test server
       script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --use-libraries
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --use-modular-headers
+        # Fix analyze (#4164)
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --skip-analyze
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --use-libraries --skip-analyze
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --use-modular-headers --skip-analyze
 
     - stage: test
       osx_image: xcode10.2
@@ -442,7 +443,8 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAnalyticsInterop.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuthInterop.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseCoreDiagnosticsInterop.podspec
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec
+        # Fix analyze (#4163)
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --skip-analyze
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInAppMessagingDisplay.podspec
 
     - stage: test
@@ -451,7 +453,8 @@ jobs:
       script:
         # Eliminate the one warning from BoringSSL when CocoaPods 1.6.0 is available.
         # The travis_wait is necessary because the command takes more than 10 minutes.
-        - travis_wait 30 ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFirestore.podspec --platforms=ios --allow-warnings --no-subspecs
+        # Some of the Firestore dependencies fail to analyze.
+        - travis_wait 30 ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFirestore.podspec --platforms=ios --allow-warnings --no-subspecs --skip-analyze
 
     # pod lib lint to check build and warnings for static library build - only on cron jobs
     - stage: test
@@ -459,8 +462,8 @@ jobs:
       env:
         - PROJECT=InAppMessagingCron METHOD=pod-lib-lint
       script:
-        - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --use-libraries
-        - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --use-modular-headers
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --use-libraries --skip-analyze
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --use-modular-headers --skip-analyze
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessagingDisplay.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessagingDisplay.podspec --use-modular-headers
 
@@ -471,7 +474,7 @@ jobs:
       script:
         # TBD - non-portable path warnings
         # The travis_wait is necessary because the command takes more than 10 minutes.
-        - travis_wait 45 ./scripts/pod_lib_lint.rb FirebaseFirestore.podspec --use-libraries --allow-warnings --no-subspecs
+        - travis_wait 45 ./scripts/pod_lib_lint.rb FirebaseFirestore.podspec --use-libraries --allow-warnings --no-subspecs --skip-analyze
 
     - stage: test
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -320,10 +320,9 @@ jobs:
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh # Start integration test server
       script:
-        # Fix analyze (#4164)
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --skip-analyze
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --use-libraries --skip-analyze
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --use-modular-headers --skip-analyze
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --use-libraries
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --use-modular-headers
 
     - stage: test
       osx_image: xcode10.2
@@ -332,7 +331,7 @@ jobs:
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh # Start integration test server
       script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --skip-analyze
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec
 
     - stage: test
       env:
@@ -444,7 +443,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuthInterop.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseCoreDiagnosticsInterop.podspec
         # Fix analyze (#4163)
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --skip-analyze
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --no-analyze
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInAppMessagingDisplay.podspec
 
     - stage: test
@@ -454,7 +453,7 @@ jobs:
         # Eliminate the one warning from BoringSSL when CocoaPods 1.6.0 is available.
         # The travis_wait is necessary because the command takes more than 10 minutes.
         # Some of the Firestore dependencies fail to analyze.
-        - travis_wait 30 ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFirestore.podspec --platforms=ios --allow-warnings --no-subspecs --skip-analyze
+        - travis_wait 30 ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFirestore.podspec --platforms=ios --allow-warnings --no-subspecs --no-analyze
 
     # pod lib lint to check build and warnings for static library build - only on cron jobs
     - stage: test
@@ -462,8 +461,8 @@ jobs:
       env:
         - PROJECT=InAppMessagingCron METHOD=pod-lib-lint
       script:
-        - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --use-libraries --skip-analyze
-        - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --use-modular-headers --skip-analyze
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --use-libraries --no-analyze
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --use-modular-headers --no-analyze
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessagingDisplay.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessagingDisplay.podspec --use-modular-headers
 
@@ -474,7 +473,7 @@ jobs:
       script:
         # TBD - non-portable path warnings
         # The travis_wait is necessary because the command takes more than 10 minutes.
-        - travis_wait 45 ./scripts/pod_lib_lint.rb FirebaseFirestore.podspec --use-libraries --allow-warnings --no-subspecs --skip-analyze
+        - travis_wait 45 ./scripts/pod_lib_lint.rb FirebaseFirestore.podspec --use-libraries --allow-warnings --no-subspecs --no-analyze
 
     - stage: test
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -332,7 +332,7 @@ jobs:
       before_install:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh # Start integration test server
       script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --skip-analyze
 
     - stage: test
       env:

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -31,7 +31,7 @@ def usage()
   options can be any options for pod spec lint
 
   script options:
-    --skip-analyze: don't run Xcod analyze on this podspec
+    --skip-analyze: don't run Xcode analyze on this podspec
     --ignore-local-podspecs: list of podspecs that should not be added to
       "--include-podspecs" list. If not specified, then all podspec
       dependencies will be passed to "--include-podspecs".

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -47,7 +47,7 @@ def main(args)
 
   STDOUT.sync = true
 
-  command = %w(bundle exec pod lib lint --sources=https://cdn.cocoapods.org/ --analyze)
+  command = %w(bundle exec pod lib lint --sources=https://cdn.cocoapods.org/)
 
   # Split arguments that need to be processed by the script itself and passed
   # to the pod command.

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -46,7 +46,7 @@ def main(args)
 
   STDOUT.sync = true
 
-  command = %w(bundle exec pod lib lint --sources=https://cdn.cocoapods.org/)
+  command = %w(bundle exec pod lib lint --sources=https://cdn.cocoapods.org/ --analyze)
 
   # Split arguments that need to be processed by the script itself and passed
   # to the pod command.

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -31,7 +31,7 @@ def usage()
   options can be any options for pod spec lint
 
   script options:
-    --skip-analyze: don't run Xcode analyze on this podspec
+    --no-analyze: don't run Xcode analyze on this podspec
     --ignore-local-podspecs: list of podspecs that should not be added to
       "--include-podspecs" list. If not specified, then all podspec
       dependencies will be passed to "--include-podspecs".
@@ -53,13 +53,13 @@ def main(args)
   # to the pod command.
   pod_args = []
   ignore_local_podspecs = []
-  skip_analyze = false
+  analyze = true
 
   args.each do |arg|
     if arg =~ /--ignore-local-podspecs=(.*)/
       ignore_local_podspecs = $1.split(',')
-    elsif arg =~ /--skip-analyze/
-      skip_analyze = true
+    elsif arg =~ /--no-analyze/
+      analyze = false
     else
       pod_args.push(arg)
     end
@@ -70,7 +70,7 @@ def main(args)
   deps = find_local_deps(podspec_file, ignore_local_podspecs.to_set)
   arg = make_include_podspecs(deps)
   command.push(arg) if arg
-  command.push('--analyze') if not skip_analyze
+  command.push('--analyze') if analyze
 
   command.push(*pod_args)
   puts command.join(' ')

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -31,6 +31,7 @@ def usage()
   options can be any options for pod spec lint
 
   script options:
+    --skip-analyze: don't run Xcod analyze on this podspec
     --ignore-local-podspecs: list of podspecs that should not be added to
       "--include-podspecs" list. If not specified, then all podspec
       dependencies will be passed to "--include-podspecs".
@@ -52,9 +53,13 @@ def main(args)
   # to the pod command.
   pod_args = []
   ignore_local_podspecs = []
+  skip_analyze = false
+
   args.each do |arg|
     if arg =~ /--ignore-local-podspecs=(.*)/
       ignore_local_podspecs = $1.split(',')
+    elsif arg =~ /--skip-analyze/
+      skip_analyze = true
     else
       pod_args.push(arg)
     end
@@ -65,6 +70,7 @@ def main(args)
   deps = find_local_deps(podspec_file, ignore_local_podspecs.to_set)
   arg = make_include_podspecs(deps)
   command.push(arg) if arg
+  command.push('--analyze') if not skip_analyze
 
   command.push(*pod_args)
   puts command.join(' ')


### PR DESCRIPTION
Fix #1744

Now that we're using CocoaPods 1.8.x, we can take advantage of the new `--analyze` option to run the Xcode analyzer on presubmits.

This PR adds it, along with disabling for FIAM(#4163), Functions(#4164) and Firestore(#4165).

#no-changelog