### PR TITLE
Only assign errors if parameter is non-NULL.

### DIFF
--- a/Functions/CHANGELOG.md
+++ b/Functions/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fix internal analyzer issue with error assignment (#4164).
+
 # v2.4.0
 - [added] Introduce community support for tvOS and macOS (#2506).
 

--- a/Functions/FirebaseFunctions/FUNSerializer.m
+++ b/Functions/FirebaseFunctions/FUNSerializer.m
@@ -153,7 +153,6 @@ NSError *FUNInvalidNumberError(id value, id wrapped) {
     NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
     NSNumber *n = [formatter numberFromString:value];
     if (n == nil) {
-      // Only assign the `error` parameter if it was passed in.
       if (error != NULL) {
         *error = FUNInvalidNumberError(value, wrapped);
       }
@@ -166,15 +165,14 @@ NSError *FUNInvalidNumberError(id value, id wrapped) {
     char *end = NULL;
     unsigned long long n = strtoull(str, &end, 10);
     if (errno == ERANGE) {
-      // This number was actually too big for an unsigned long long. Only assign the `error`
-      // parameter if it was passed in.
+      // This number was actually too big for an unsigned long long.
       if (error != NULL) {
         *error = FUNInvalidNumberError(value, wrapped);
       }
       return nil;
     }
     if (*end) {
-      // The whole string wasn't parsed. Only assign the `error` parameter if it was passed in.
+      // The whole string wasn't parsed.
       if (error != NULL) {
         *error = FUNInvalidNumberError(value, wrapped);
       }

--- a/Functions/FirebaseFunctions/FUNSerializer.m
+++ b/Functions/FirebaseFunctions/FUNSerializer.m
@@ -153,7 +153,10 @@ NSError *FUNInvalidNumberError(id value, id wrapped) {
     NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
     NSNumber *n = [formatter numberFromString:value];
     if (n == nil) {
-      *error = FUNInvalidNumberError(value, wrapped);
+      // Only assign the `error` parameter if it was passed in.
+      if (error != NULL) {
+        *error = FUNInvalidNumberError(value, wrapped);
+      }
       return nil;
     }
     return n;
@@ -163,13 +166,18 @@ NSError *FUNInvalidNumberError(id value, id wrapped) {
     char *end = NULL;
     unsigned long long n = strtoull(str, &end, 10);
     if (errno == ERANGE) {
-      // This number was actually too big for an unsigned long long.
-      *error = FUNInvalidNumberError(value, wrapped);
+      // This number was actually too big for an unsigned long long. Only assign the `error`
+      // parameter if it was passed in.
+      if (error != NULL) {
+        *error = FUNInvalidNumberError(value, wrapped);
+      }
       return nil;
     }
     if (*end) {
-      // The whole string wasn't parsed.
-      *error = FUNInvalidNumberError(value, wrapped);
+      // The whole string wasn't parsed. Only assign the `error` parameter if it was passed in.
+      if (error != NULL) {
+        *error = FUNInvalidNumberError(value, wrapped);
+      }
       return nil;
     }
     return @(n);
@@ -202,7 +210,10 @@ NSError *FUNInvalidNumberError(id value, id wrapped) {
           decoded[key] = decodedItem;
         }];
     if (decodeError) {
-      *error = decodeError;
+      // Only assign the `error` parameter if it was passed in.
+      if (error != NULL) {
+        *error = decodeError;
+      }
       return nil;
     }
     return decoded;

--- a/Functions/FirebaseFunctions/FUNSerializer.m
+++ b/Functions/FirebaseFunctions/FUNSerializer.m
@@ -208,7 +208,6 @@ NSError *FUNInvalidNumberError(id value, id wrapped) {
           decoded[key] = decodedItem;
         }];
     if (decodeError) {
-      // Only assign the `error` parameter if it was passed in.
       if (error != NULL) {
         *error = decodeError;
       }


### PR DESCRIPTION
This fixes #4164.

```
pod lib lint --sources=https://cdn.cocoapods.org/ --analyze FirebaseFunctions.podspec

 -> FirebaseFunctions (2.5.1)
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | xcodebuild:  note: Planning build
    - NOTE  | xcodebuild:  note: Constructing build description
    - NOTE  | xcodebuild:  warning: Skipping code signing because the target does not have an Info.plist file. (in target 'App')

FirebaseFunctions passed validation.
```