### PR TITLE
FIS Keychain: Replace deprecated `kSecAttrAccessibleAlwaysThisDeviceOnly`

### DIFF
--- a/FirebaseInstallations/Source/Library/SecureStorage/FIRInstallationsKeychainUtils.m
+++ b/FirebaseInstallations/Source/Library/SecureStorage/FIRInstallationsKeychainUtils.m
@@ -62,7 +62,7 @@
 
   NSMutableDictionary *mutableQuery = [query mutableCopy];
   mutableQuery[(__bridge id)kSecAttrAccessible] =
-      (__bridge id)kSecAttrAccessibleAlwaysThisDeviceOnly;
+      (__bridge id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
 
   OSStatus status;
   if (!existingItem) {


### PR DESCRIPTION
- use `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` instead.