### PR TITLE
update keychain access level

### DIFF
--- a/Example/InstanceID/Tests/FIRInstanceIDAuthKeyChainTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDAuthKeyChainTest.m
@@ -89,48 +89,47 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
                                                                      scope:kScope
                                                                      token:kToken2];
               [weakKeychain
-                        setData:tokenInfoData2
-                     forService:service
-                        account:account2
-                        handler:^(NSError *error) {
-                          XCTAssertNil(error);
-                          // Now query the token and compare, they should not corrupt
-                          // each other.
-                          NSData *data1 = [weakKeychain dataForService:service account:account1];
+                     setData:tokenInfoData2
+                  forService:service
+                     account:account2
+                     handler:^(NSError *error) {
+                       XCTAssertNil(error);
+                       // Now query the token and compare, they should not corrupt
+                       // each other.
+                       NSData *data1 = [weakKeychain dataForService:service account:account1];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                          FIRInstanceIDTokenInfo *tokenInfo1 =
-                              [NSKeyedUnarchiver unarchiveObjectWithData:data1];
-                          XCTAssertEqualObjects(kToken1, tokenInfo1.token);
+                       FIRInstanceIDTokenInfo *tokenInfo1 =
+                           [NSKeyedUnarchiver unarchiveObjectWithData:data1];
+                       XCTAssertEqualObjects(kToken1, tokenInfo1.token);
 
-                          NSData *data2 = [weakKeychain dataForService:service account:account2];
-                          FIRInstanceIDTokenInfo *tokenInfo2 =
-                              [NSKeyedUnarchiver unarchiveObjectWithData:data2];
+                       NSData *data2 = [weakKeychain dataForService:service account:account2];
+                       FIRInstanceIDTokenInfo *tokenInfo2 =
+                           [NSKeyedUnarchiver unarchiveObjectWithData:data2];
 #pragma clang diagnostic pop
-                          XCTAssertEqualObjects(kToken2, tokenInfo2.token);
-                          // Also check the cache data.
-                          XCTAssertEqual(weakKeychain.cachedKeychainData.count, 1);
-                          XCTAssertEqual(weakKeychain.cachedKeychainData[service].count, 2);
-                          XCTAssertEqualObjects(
-                              weakKeychain.cachedKeychainData[service][account1].firstObject,
-                              tokenInfoData1);
-                          XCTAssertEqualObjects(
-                              weakKeychain.cachedKeychainData[service][account2].firstObject,
-                              tokenInfoData2);
+                       XCTAssertEqualObjects(kToken2, tokenInfo2.token);
+                       // Also check the cache data.
+                       XCTAssertEqual(weakKeychain.cachedKeychainData.count, 1);
+                       XCTAssertEqual(weakKeychain.cachedKeychainData[service].count, 2);
+                       XCTAssertEqualObjects(
+                           weakKeychain.cachedKeychainData[service][account1].firstObject,
+                           tokenInfoData1);
+                       XCTAssertEqualObjects(
+                           weakKeychain.cachedKeychainData[service][account2].firstObject,
+                           tokenInfoData2);
 
-                          // Check wildcard query
-                          NSArray *results = [weakKeychain itemsMatchingService:service
-                                                                        account:@"*"];
-                          XCTAssertEqual(results.count, 2);
+                       // Check wildcard query
+                       NSArray *results = [weakKeychain itemsMatchingService:service account:@"*"];
+                       XCTAssertEqual(results.count, 2);
 
-                          // Clean up keychain at the end
-                          [weakKeychain removeItemsMatchingService:service
-                                                           account:@"*"
-                                                           handler:^(NSError *_Nonnull error) {
-                                                             XCTAssertNil(error);
-                                                             [noCurruptionExpectation fulfill];
-                                                           }];
-                        }];
+                       // Clean up keychain at the end
+                       [weakKeychain removeItemsMatchingService:service
+                                                        account:@"*"
+                                                        handler:^(NSError *_Nonnull error) {
+                                                          XCTAssertNil(error);
+                                                          [noCurruptionExpectation fulfill];
+                                                        }];
+                     }];
             }];
   [self waitForExpectationsWithTimeout:1.0 handler:NULL];
 #endif
@@ -149,65 +148,64 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
   FIRInstanceIDAuthKeychain *keychain =
       [[FIRInstanceIDAuthKeychain alloc] initWithIdentifier:kFIRInstanceIDTestKeychainId];
   __weak FIRInstanceIDAuthKeychain *weakKeychain = keychain;
-  [keychain setData:tokenData
-         forService:service1
-            account:account
-            handler:^(NSError *error) {
-              XCTAssertNil(error);
-              // Store a checkin info using the same keychain account, but different service.
-              NSString *service2 = @"com.google.iid.checkin";
-              FIRInstanceIDCheckinPreferences *preferences =
-                  [[FIRInstanceIDCheckinPreferences alloc] initWithDeviceID:kAuthID
-                                                                secretToken:kSecret];
-              NSString *checkinKeychainContent = [preferences checkinKeychainContent];
-              NSData *checkinData = [checkinKeychainContent dataUsingEncoding:NSUTF8StringEncoding];
+  [keychain
+         setData:tokenData
+      forService:service1
+         account:account
+         handler:^(NSError *error) {
+           XCTAssertNil(error);
+           // Store a checkin info using the same keychain account, but different service.
+           NSString *service2 = @"com.google.iid.checkin";
+           FIRInstanceIDCheckinPreferences *preferences =
+               [[FIRInstanceIDCheckinPreferences alloc] initWithDeviceID:kAuthID
+                                                             secretToken:kSecret];
+           NSString *checkinKeychainContent = [preferences checkinKeychainContent];
+           NSData *checkinData = [checkinKeychainContent dataUsingEncoding:NSUTF8StringEncoding];
 
-              [weakKeychain
-                        setData:checkinData
-                     forService:service2
-                        account:account
-                        handler:^(NSError *error) {
-                          XCTAssertNil(error);
-                          // Now query the token and compare, they should not corrupt
-                          // each other.
-                          NSData *data1 = [weakKeychain dataForService:service1 account:account];
+           [weakKeychain
+                  setData:checkinData
+               forService:service2
+                  account:account
+                  handler:^(NSError *error) {
+                    XCTAssertNil(error);
+                    // Now query the token and compare, they should not corrupt
+                    // each other.
+                    NSData *data1 = [weakKeychain dataForService:service1 account:account];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                          FIRInstanceIDTokenInfo *tokenInfo1 =
-                              [NSKeyedUnarchiver unarchiveObjectWithData:data1];
+                    FIRInstanceIDTokenInfo *tokenInfo1 =
+                        [NSKeyedUnarchiver unarchiveObjectWithData:data1];
 #pragma clang diagnostic pop
-                          XCTAssertEqualObjects(kToken1, tokenInfo1.token);
+                    XCTAssertEqualObjects(kToken1, tokenInfo1.token);
 
-                          NSData *data2 = [weakKeychain dataForService:service2 account:account];
-                          NSString *checkinKeychainContent =
-                              [[NSString alloc] initWithData:data2 encoding:NSUTF8StringEncoding];
-                          FIRInstanceIDCheckinPreferences *checkinPreferences =
-                              [FIRInstanceIDCheckinPreferences
-                                  preferencesFromKeychainContents:checkinKeychainContent];
-                          XCTAssertEqualObjects(checkinPreferences.secretToken, kSecret);
-                          XCTAssertEqualObjects(checkinPreferences.deviceID, kAuthID);
+                    NSData *data2 = [weakKeychain dataForService:service2 account:account];
+                    NSString *checkinKeychainContent =
+                        [[NSString alloc] initWithData:data2 encoding:NSUTF8StringEncoding];
+                    FIRInstanceIDCheckinPreferences *checkinPreferences =
+                        [FIRInstanceIDCheckinPreferences
+                            preferencesFromKeychainContents:checkinKeychainContent];
+                    XCTAssertEqualObjects(checkinPreferences.secretToken, kSecret);
+                    XCTAssertEqualObjects(checkinPreferences.deviceID, kAuthID);
 
-                          NSArray *results = [weakKeychain itemsMatchingService:@"*"
-                                                                        account:account];
-                          XCTAssertEqual(results.count, 2);
-                          // Also check the cache data.
-                          XCTAssertEqual(weakKeychain.cachedKeychainData.count, 2);
-                          XCTAssertEqualObjects(
-                              weakKeychain.cachedKeychainData[service1][account].firstObject,
-                              tokenData);
-                          XCTAssertEqualObjects(
-                              weakKeychain.cachedKeychainData[service2][account].firstObject,
-                              checkinData);
+                    NSArray *results = [weakKeychain itemsMatchingService:@"*" account:account];
+                    XCTAssertEqual(results.count, 2);
+                    // Also check the cache data.
+                    XCTAssertEqual(weakKeychain.cachedKeychainData.count, 2);
+                    XCTAssertEqualObjects(
+                        weakKeychain.cachedKeychainData[service1][account].firstObject, tokenData);
+                    XCTAssertEqualObjects(
+                        weakKeychain.cachedKeychainData[service2][account].firstObject,
+                        checkinData);
 
-                          // Clean up keychain at the end
-                          [weakKeychain removeItemsMatchingService:@"*"
-                                                           account:@"*"
-                                                           handler:^(NSError *_Nonnull error) {
-                                                             XCTAssertNil(error);
-                                                             [noCurruptionExpectation fulfill];
-                                                           }];
-                        }];
-            }];
+                    // Clean up keychain at the end
+                    [weakKeychain removeItemsMatchingService:@"*"
+                                                     account:@"*"
+                                                     handler:^(NSError *_Nonnull error) {
+                                                       XCTAssertNil(error);
+                                                       [noCurruptionExpectation fulfill];
+                                                     }];
+                  }];
+         }];
   [self waitForExpectationsWithTimeout:1.0 handler:NULL];
 #endif
 }

--- a/Example/InstanceID/Tests/FIRInstanceIDAuthKeyChainTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDAuthKeyChainTest.m
@@ -80,7 +80,6 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
   __weak FIRInstanceIDAuthKeychain *weakKeychain = keychain;
   [keychain setData:tokenInfoData1
          forService:service
-      accessibility:NULL
             account:account1
             handler:^(NSError *error) {
               XCTAssertNil(error);
@@ -92,7 +91,6 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
               [weakKeychain
                         setData:tokenInfoData2
                      forService:service
-                  accessibility:NULL
                         account:account2
                         handler:^(NSError *error) {
                           XCTAssertNil(error);
@@ -153,7 +151,6 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
   __weak FIRInstanceIDAuthKeychain *weakKeychain = keychain;
   [keychain setData:tokenData
          forService:service1
-      accessibility:NULL
             account:account
             handler:^(NSError *error) {
               XCTAssertNil(error);
@@ -168,7 +165,6 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
               [weakKeychain
                         setData:checkinData
                      forService:service2
-                  accessibility:NULL
                         account:account
                         handler:^(NSError *error) {
                           XCTAssertNil(error);
@@ -237,7 +233,6 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
   __weak id weakKeychainMock = keychainMock;
   [keychain setData:tokenData
          forService:service
-      accessibility:NULL
             account:account
             handler:^(NSError *error) {
               XCTAssertNil(error);
@@ -299,7 +294,6 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
   __weak FIRInstanceIDAuthKeychain *weakKeychain = keychain;
   [keychain setData:tokenData
          forService:service
-      accessibility:NULL
             account:account
             handler:^(NSError *error) {
               XCTAssertNil(error);
@@ -344,7 +338,6 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
   __weak FIRInstanceIDAuthKeychain *weakKeychain = keychain;
   [keychain setData:tokenData
          forService:service
-      accessibility:NULL
             account:account
             handler:^(NSError *error) {
               XCTAssertNil(error);
@@ -374,7 +367,6 @@ static NSString *const kBundleID2 = @"com.google.abtesting.dev";
   NSData *data = [[NSData alloc] init];
   [keychain setData:data
          forService:@"*"
-      accessibility:NULL
             account:@"*"
             handler:^(NSError *error) {
               XCTAssertNotNil(error);

--- a/Example/InstanceID/Tests/FIRInstanceIDCheckinStoreTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDCheckinStoreTest.m
@@ -213,7 +213,6 @@ static int64_t const kLastCheckinTimestamp = 123456;
   NSData *data = [checkinKeychainContent dataUsingEncoding:NSUTF8StringEncoding];
   [fakeKeychain setData:data
              forService:kFIRInstanceIDLegacyCheckinKeychainService
-          accessibility:nil
                 account:kFIRInstanceIDLegacyCheckinKeychainAccount
                 handler:^(NSError *error) {
                   XCTAssertNil(error);

--- a/Example/InstanceID/Tests/FIRInstanceIDFakeKeychain.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDFakeKeychain.m
@@ -90,9 +90,9 @@ static NSString *const kFakeKeychainErrorDomain = @"com.google.iid";
 }
 
 - (void)setData:(NSData *)data
-       forService:(NSString *)service
-          account:(NSString *)account
-          handler:(void (^)(NSError *error))handler {
+     forService:(NSString *)service
+        account:(NSString *)account
+        handler:(void (^)(NSError *error))handler {
   if (self.cannotWriteToKeychain) {
     if (handler) {
       handler([NSError errorWithDomain:kFakeKeychainErrorDomain code:1001 userInfo:nil]);

--- a/Example/InstanceID/Tests/FIRInstanceIDFakeKeychain.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDFakeKeychain.m
@@ -91,7 +91,6 @@ static NSString *const kFakeKeychainErrorDomain = @"com.google.iid";
 
 - (void)setData:(NSData *)data
        forService:(NSString *)service
-    accessibility:(nullable CFTypeRef)accessibility
           account:(NSString *)account
           handler:(void (^)(NSError *error))handler {
   if (self.cannotWriteToKeychain) {

--- a/Firebase/InstanceID/FIRInstanceIDAuthKeyChain.h
+++ b/Firebase/InstanceID/FIRInstanceIDAuthKeyChain.h
@@ -73,8 +73,8 @@ NS_ASSUME_NONNULL_BEGIN
                            handler:(nullable void (^)(NSError *error))handler;
 
 /**
- *  Set the data for a given service and account with a specific accessibility. If
- *  accessibility is NULL we use `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` which
+ *  Set the data for a given service and account.
+ *  We use `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` which
  *  prevents backup and restore to iCloud, and works for app extension that can
  *  execute right after a device is restarted (and not unlocked).
  *

--- a/Firebase/InstanceID/FIRInstanceIDAuthKeyChain.h
+++ b/Firebase/InstanceID/FIRInstanceIDAuthKeyChain.h
@@ -86,9 +86,9 @@ NS_ASSUME_NONNULL_BEGIN
  *
  */
 - (void)setData:(NSData *)data
-       forService:(NSString *)service
-          account:(NSString *)account
-          handler:(nullable void (^)(NSError *))handler;
+     forService:(NSString *)service
+        account:(NSString *)account
+        handler:(nullable void (^)(NSError *))handler;
 
 @end
 

--- a/Firebase/InstanceID/FIRInstanceIDAuthKeyChain.h
+++ b/Firebase/InstanceID/FIRInstanceIDAuthKeyChain.h
@@ -74,14 +74,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  Set the data for a given service and account with a specific accessibility. If
- *  accessibility is NULL we use `kSecAttrAccessibleAlwaysThisDeviceOnly` which
+ *  accessibility is NULL we use `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` which
  *  prevents backup and restore to iCloud, and works for app extension that can
  *  execute right after a device is restarted (and not unlocked).
  *
  *  @param data          The data to save.
  *  @param service       The `kSecAttrService` used to save the password.
- *  @param accessibility The `kSecAttrAccessibility` used to save the password. If NULL
- *                       set this to `kSecAttrAccessibleAlwaysThisDeviceOnly`.
  *  @param account       The `kSecAttrAccount` used to save the password.
  *  @param handler       The callback handler which is invoked when the add operation is complete,
  *                       with an error if there is any.
@@ -89,7 +87,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setData:(NSData *)data
        forService:(NSString *)service
-    accessibility:(nullable CFTypeRef)accessibility
           account:(NSString *)account
           handler:(nullable void (^)(NSError *))handler;
 

--- a/Firebase/InstanceID/FIRInstanceIDAuthKeyChain.m
+++ b/Firebase/InstanceID/FIRInstanceIDAuthKeyChain.m
@@ -167,9 +167,9 @@ NSString *const kFIRInstanceIDKeychainWildcardIdentifier = @"*";
 }
 
 - (void)setData:(NSData *)data
-       forService:(NSString *)service
-          account:(NSString *)account
-          handler:(void (^)(NSError *))handler {
+     forService:(NSString *)service
+        account:(NSString *)account
+        handler:(void (^)(NSError *))handler {
   if ([service isEqualToString:kFIRInstanceIDKeychainWildcardIdentifier] ||
       [account isEqualToString:kFIRInstanceIDKeychainWildcardIdentifier]) {
     if (handler) {
@@ -194,7 +194,7 @@ NSString *const kFIRInstanceIDKeychainWildcardIdentifier = @"*";
                                keychainQuery[(__bridge id)kSecValueData] = data;
 
                                keychainQuery[(__bridge id)kSecAttrAccessible] =
-                                     (__bridge id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
+                                   (__bridge id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
                                [[FIRInstanceIDKeychain sharedInstance]
                                    addItemWithQuery:keychainQuery
                                             handler:handler];

--- a/Firebase/InstanceID/FIRInstanceIDAuthKeyChain.m
+++ b/Firebase/InstanceID/FIRInstanceIDAuthKeyChain.m
@@ -168,7 +168,6 @@ NSString *const kFIRInstanceIDKeychainWildcardIdentifier = @"*";
 
 - (void)setData:(NSData *)data
        forService:(NSString *)service
-    accessibility:(CFTypeRef)accessibility
           account:(NSString *)account
           handler:(void (^)(NSError *))handler {
   if ([service isEqualToString:kFIRInstanceIDKeychainWildcardIdentifier] ||
@@ -194,14 +193,8 @@ NSString *const kFIRInstanceIDKeychainWildcardIdentifier = @"*";
                                    [self keychainQueryForService:service account:account];
                                keychainQuery[(__bridge id)kSecValueData] = data;
 
-                               if (accessibility != NULL) {
-                                 keychainQuery[(__bridge id)kSecAttrAccessible] =
-                                     (__bridge id)accessibility;
-                               } else {
-                                 // Defaults to No backup
-                                 keychainQuery[(__bridge id)kSecAttrAccessible] =
-                                     (__bridge id)kSecAttrAccessibleAlwaysThisDeviceOnly;
-                               }
+                               keychainQuery[(__bridge id)kSecAttrAccessible] =
+                                     (__bridge id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
                                [[FIRInstanceIDKeychain sharedInstance]
                                    addItemWithQuery:keychainQuery
                                             handler:handler];

--- a/Firebase/InstanceID/FIRInstanceIDCheckinStore.m
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinStore.m
@@ -130,7 +130,6 @@ static const NSInteger kOldCheckinPlistCount = 6;
     NSData *data = [checkinKeychainContent dataUsingEncoding:NSUTF8StringEncoding];
     [self.keychain setData:data
                 forService:kFIRInstanceIDCheckinKeychainService
-             accessibility:nil
                    account:self.bundleIdentifierForKeychainAccount
                    handler:^(NSError *error) {
                      if (error) {
@@ -225,7 +224,6 @@ static const NSInteger kOldCheckinPlistCount = 6;
     // Save to new location
     [self.keychain setData:dataInOldLocation
                 forService:kFIRInstanceIDCheckinKeychainService
-             accessibility:NULL
                    account:self.bundleIdentifierForKeychainAccount
                    handler:nil];
     // Remove from old location

--- a/Firebase/InstanceID/FIRInstanceIDKeyPairStore.m
+++ b/Firebase/InstanceID/FIRInstanceIDKeyPairStore.m
@@ -416,7 +416,7 @@ NSString *FIRInstanceIDCreationTimeKeyWithSubtype(NSString *subtype) {
     (__bridge id)kSecAttrApplicationTag : updatedTagData,
     (__bridge id)kSecClass : (__bridge id)kSecClassKey,
     (__bridge id)kSecValueRef : (__bridge id)keyRef,
-    (__bridge id)kSecAttrAccessible : (__bridge id)kSecAttrAccessibleAlwaysThisDeviceOnly,
+    (__bridge id)kSecAttrAccessible : (__bridge id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
   };
   [[FIRInstanceIDKeychain sharedInstance] addItemWithQuery:addQuery
                                                    handler:^(NSError *addError) {

--- a/Firebase/InstanceID/FIRInstanceIDKeychain.m
+++ b/Firebase/InstanceID/FIRInstanceIDKeychain.m
@@ -126,14 +126,14 @@ static const NSUInteger kRSA2048KeyPairSize = 2048;
     (__bridge id)kSecAttrIsPermanent : @YES,
     (__bridge id)kSecAttrApplicationTag : privateTagData,
     (__bridge id)kSecAttrLabel : @"Firebase InstanceID Key Pair Private Key",
-    (__bridge id)kSecAttrAccessible : (__bridge id)kSecAttrAccessibleAlwaysThisDeviceOnly,
+    (__bridge id)kSecAttrAccessible : (__bridge id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
   };
 
   NSDictionary *publicKeyAttr = @{
     (__bridge id)kSecAttrIsPermanent : @YES,
     (__bridge id)kSecAttrApplicationTag : publicTagData,
     (__bridge id)kSecAttrLabel : @"Firebase InstanceID Key Pair Public Key",
-    (__bridge id)kSecAttrAccessible : (__bridge id)kSecAttrAccessibleAlwaysThisDeviceOnly,
+    (__bridge id)kSecAttrAccessible : (__bridge id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
   };
 
   NSDictionary *keyPairAttributes = @{

--- a/Firebase/InstanceID/FIRInstanceIDTokenStore.m
+++ b/Firebase/InstanceID/FIRInstanceIDTokenStore.m
@@ -123,7 +123,6 @@ static NSString *const kFIRInstanceIDTokenKeychainId = @"com.google.iid-tokens";
                                                             scope:tokenInfo.scope];
   [self.keychain setData:tokenInfoData
               forService:service
-           accessibility:NULL
                  account:account
                  handler:handler];
 }

--- a/Firebase/InstanceID/FIRInstanceIDTokenStore.m
+++ b/Firebase/InstanceID/FIRInstanceIDTokenStore.m
@@ -121,10 +121,7 @@ static NSString *const kFIRInstanceIDTokenKeychainId = @"com.google.iid-tokens";
   NSString *account = FIRInstanceIDAppIdentifier();
   NSString *service = [[self class] serviceKeyForAuthorizedEntity:tokenInfo.authorizedEntity
                                                             scope:tokenInfo.scope];
-  [self.keychain setData:tokenInfoData
-              forService:service
-                 account:account
-                 handler:handler];
+  [self.keychain setData:tokenInfoData forService:service account:account handler:handler];
 }
 
 #pragma mark - Delete


### PR DESCRIPTION
#4167 user reports getting IID becomes nil when a token exists. We suspect this is due to a security issue while keychain access level is set to kSecAttrAccessibleAlwaysThisDeviceOnly that is deprecated in iOS 13. Neitherless we should update it to kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly since app only works in foreground so this is the proper access.

Also remove a parameter to set a optional access level for keychain cuz this parameter was never used.