### PR TITLE
Don't use the address of a TimeSlot as a key for removal

### DIFF
--- a/Firestore/core/src/firebase/firestore/util/executor_libdispatch.h
+++ b/Firestore/core/src/firebase/firestore/util/executor_libdispatch.h
@@ -87,11 +87,13 @@ class ExecutorLibdispatch : public Executor {
   using ScheduleMap = std::unordered_map<TimeSlotId, TimeSlot*>;
   using ScheduleEntry = ScheduleMap::value_type;
 
+  TimeSlotId NextId();
+
   dispatch_queue_t dispatch_queue_;
   // Stores non-owned pointers to `TimeSlot`s.
   // Invariant: if a `TimeSlot` is in `schedule_`, it's a valid pointer.
   ScheduleMap schedule_;
-  TimeSlotId time_slot_counter_ = 0;
+  TimeSlotId current_id_ = 0;
 };
 
 }  // namespace util

--- a/Firestore/core/src/firebase/firestore/util/executor_libdispatch.h
+++ b/Firestore/core/src/firebase/firestore/util/executor_libdispatch.h
@@ -17,13 +17,14 @@
 #ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_EXECUTOR_LIBDISPATCH_H_
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_EXECUTOR_LIBDISPATCH_H_
 
+#include <dispatch/dispatch.h>
+
 #include <chrono>  // NOLINT(build/c++11)
 #include <functional>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-#include "dispatch/dispatch.h"
 
 #include "Firestore/core/src/firebase/firestore/util/executor.h"
 #include "absl/strings/string_view.h"
@@ -58,7 +59,7 @@ class TimeSlot;
 class ExecutorLibdispatch : public Executor {
  public:
   explicit ExecutorLibdispatch(dispatch_queue_t dispatch_queue);
-  ~ExecutorLibdispatch();
+  ~ExecutorLibdispatch() override;
 
   bool IsCurrentExecutor() const override;
   std::string CurrentExecutorName() const override;

--- a/Firestore/core/src/firebase/firestore/util/executor_libdispatch.mm
+++ b/Firestore/core/src/firebase/firestore/util/executor_libdispatch.mm
@@ -274,8 +274,8 @@ DelayedOperation ExecutorLibdispatch::Schedule(const Milliseconds delay,
   return DelayedOperation{[this, time_slot_id] {
     // `time_slot` might have been destroyed by the time cancellation function
     // runs, in which case it's guaranteed to have been removed from the
-    // schedule_. If the `time_slot_id` refers to a slot that has been removed,
-    // the call to `RemoveFromSchedule` will be a no-op.
+    // `schedule_`. If the `time_slot_id` refers to a slot that has been
+    // removed, the call to `RemoveFromSchedule` will be a no-op.
     RemoveFromSchedule(time_slot_id);
   }};
 }

--- a/Firestore/core/src/firebase/firestore/util/executor_libdispatch.mm
+++ b/Firestore/core/src/firebase/firestore/util/executor_libdispatch.mm
@@ -135,7 +135,7 @@ class TimeSlot {
     done_ = true;
   }
 
-  static void InvokedByLibdispatch(void* const raw_self);
+  static void InvokedByLibdispatch(void* raw_self);
 
  private:
   void Execute();
@@ -175,7 +175,7 @@ Executor::TaggedOperation TimeSlot::Unschedule() {
   return std::move(tagged_);
 }
 
-void TimeSlot::InvokedByLibdispatch(void* const raw_self) {
+void TimeSlot::InvokedByLibdispatch(void* raw_self) {
   auto const self = static_cast<TimeSlot*>(raw_self);
   self->Execute();
   delete self;
@@ -289,7 +289,7 @@ absl::optional<Executor::TaggedOperation>
 ExecutorLibdispatch::PopFromSchedule() {
   absl::optional<Executor::TaggedOperation> result;
 
-  RunSynchronized(this, [this, &result] {
+  RunSynchronized(this, [this, &result]() -> void {
     if (schedule_.empty()) {
       return;
     }


### PR DESCRIPTION
After a `TimeSlot` executes, it deletes itself and removes itself from `ExecutorLibdispatch`'s `schedule_`. The `DelayedOperation` still referred to this now freed address. If another `TimeSlot` is scheduled, operator `new` happens to allocate a `TimeSlot` that reuses the address, and the
`DelayedOperation` is subsequently canceled, this will cancel the new task before it has run.

This change fixes this by using a dedicated counter for `TimeSlot`s that effectively isn't reused. Note that while it is possible for the counter to wrap around, this would take tens of years of continuous execution to happen and require cancelation of a `TimeSlot` created tens of years ago to create the possibility of collision which is a sufficiently impractical problem as to be ignorable.

This fixes a flake in `FSTTransactionTests`, where we were actually seeing address reuse collisions in 1 out of ~50 test runs.

Also included are a few trivial fixes suggested by clang-tidy.