### PR TITLE
check_whitespaces.sh: ignore notice files

### DIFF
--- a/scripts/check_whitespace.sh
+++ b/scripts/check_whitespace.sh
@@ -29,6 +29,7 @@ git grep "${options[@]}" -- \
     ':(exclude)Firebase/CoreDiagnostics/FIRCDLibrary/Protogen/nanopb' \
     ':(exclude)Firebase/CoreDiagnostics/ProtoSupport' \
     ':(exclude)CoreOnly/NOTICES' \
+    ':(exclude)Firebase/Firebase/NOTICES' \
     ':(exclude)Firebase/InAppMessaging/ProtoSupport' \
     ':(exclude)Firebase/InAppMessaging/Analytics/Protogen/nanopb' \
     ':(exclude)Firestore/Protos/nanopb' \
@@ -36,7 +37,8 @@ git grep "${options[@]}" -- \
     ':(exclude)Firestore/Protos/objc' \
     ':(exclude)Firestore/third_party/abseil-cpp' \
     ':(exclude)GoogleDataTransportCCTSupport/GDTCCTLibrary/Protogen/nanopb' \
-    ':(exclude)GoogleDataTransportCCTSupport/ProtoSupport'
+    ':(exclude)GoogleDataTransportCCTSupport/ProtoSupport' \
+    ':(exclude)ZipBuilder/Template/NOTICES'
 
 if [[ $? == 0 ]]; then
   echo "ERROR: Trailing whitespace found in the files above. Please fix."


### PR DESCRIPTION
It is needed to be able to commit notices files without modifications.

#no-changelog