### PR TITLE
Require CMake 3.5.1; upgrade Google Benchmark to 1.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 # Superbuild for Firebase
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Disallow mixing keyword and non-keyword forms of target_link_libraries
 if(POLICY CMP0023)
@@ -208,11 +208,7 @@ target_include_directories(
 
 
 # XCTest
-if(${CMAKE_VERSION} VERSION_LESS "3.3.0")
-  set(XCTest_FOUND OFF)
-else()
-  find_package(XCTest)
-endif()
+find_package(XCTest)
 
 
 enable_testing()

--- a/Firestore/Example/GoogleBenchmark.podspec
+++ b/Firestore/Example/GoogleBenchmark.podspec
@@ -17,7 +17,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'GoogleBenchmark'
-  s.version          = '1.4.0'
+  s.version          = '1.5.0'
   s.summary          = 'Google Benchmark'
 
   s.description      = <<-DESC
@@ -56,6 +56,8 @@ Google's C++ benchmark framework.
       'HEADER_SEARCH_PATHS' =>
         '"${PODS_ROOT}/GoogleBenchmark/include" "${PODS_ROOT}/GoogleBenchmark/src"'
   }
+
+  s.compiler_flags = '$(inherited) -Wno-deprecated-declarations'
 
   s.library = 'c++'
 end

--- a/Firestore/core/src/firebase/firestore/remote/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/remote/CMakeLists.txt
@@ -119,6 +119,7 @@ cc_library(
     firebase_firestore_model
     firebase_firestore_nanopb
     firebase_firestore_protos_nanopb
+    firebase_firestore_protos_objc
     firebase_firestore_remote_connectivity_monitor
     firebase_firestore_util
     firebase_firestore_version

--- a/cmake/external/benchmark.cmake
+++ b/cmake/external/benchmark.cmake
@@ -18,15 +18,15 @@ if(TARGET benchmark)
   return()
 endif()
 
-set(commit v1.4.1)
+set(version v1.5.0)
 
 ExternalProject_Add(
   benchmark
 
   DOWNLOAD_DIR ${FIREBASE_DOWNLOAD_DIR}
-  DOWNLOAD_NAME benchmark-${commit}.tar.gz
-  URL https://github.com/google/benchmark/archive/${commit}.tar.gz
-  URL_HASH SHA256=f8e525db3c42efc9c7f3bc5176a8fa893a9a9920bbd08cef30fb56a51854d60d
+  DOWNLOAD_NAME benchmark-${version}.tar.gz
+  URL https://github.com/google/benchmark/archive/${version}.tar.gz
+  URL_HASH SHA256=3c6a165b6ecc948967a1ead710d4a181d7b0fbcaa183ef7ea84604994966221a
 
   PREFIX ${PROJECT_BINARY_DIR}
 


### PR DESCRIPTION
CMake 3.5.1 is the version required by the latest versions of gRPC and Google Benchmark. See discussion google/benchmark#613.

Remove version check around find_package(XCTest).

Also, add a dependency on objc protos that was missing but somehow implicitly being added before.

#no-changelog