### PR TITLE
Make the CMake build warning free

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ include(cc_rules)
 include(compiler_id)
 include(external_rules)
 include(podspec_rules)
+include(archive_options)
 include(sanitizer_options)
 include(fuzzing_options)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,16 @@ set(old_build_testing ${BUILD_TESTING})
 set(ABSL_RUN_TESTS OFF CACHE BOOL "Disable Abseil tests" FORCE)
 add_external_subdirectory(abseil-cpp)
 
+if(CXX_CLANG)
+  target_compile_options(
+    absl_time_zone
+    PRIVATE
+      -Wno-unused-template
+      -Wno-shadow
+      -Wno-tautological-type-limit-compare
+  )
+endif()
+
 
 # gRPC
 find_package(OpenSSL QUIET)

--- a/cmake/archive_options.cmake
+++ b/cmake/archive_options.cmake
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 if(APPLE)
-  # When building on Apple platforms, ranlib complains about file has no
-  # symbols. Unfortunately, most of our dependencies implement their
+  # When building on Apple platforms, ranlib complains about "file has no
+  # symbols". Unfortunately, most of our dependencies implement their
   # cross-platform build with preprocessor symbols so translation units that
-  # don't target the current platform end up empty.
+  # don't target the current platform end up empty (and trigger this warning).
   #
-  # Note that compiler_setup.cmake is included late, so as not to affect
-  # dependencies so this can't be set there.
+  # Note this can't be set in compiler_setup.cmake because that is included
+  # late so as not to affect our dependencies. These variables have to be set
+  # early so that they do affect our dependencies.
   set(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
   set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
   set(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")

--- a/cmake/archive_options.cmake
+++ b/cmake/archive_options.cmake
@@ -1,0 +1,27 @@
+# Copyright 2019 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if(APPLE)
+  # When building on Apple platforms, ranlib complains about file has no
+  # symbols. Unfortunately, most of our dependencies implement their
+  # cross-platform build with preprocessor symbols so translation units that
+  # don't target the current platform end up empty.
+  #
+  # Note that compiler_setup.cmake is included late, so as not to affect
+  # dependencies so this can't be set there.
+  set(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+  set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+  set(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+  set(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+endif()


### PR DESCRIPTION
Silence warnings in Abseil that we're never going to care about (since upstream doesn't).

Also silence useless ranlib warnings like this:
```
/Applications/Xcode-11.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: external/src/grpc-build/libgrpc.a(iomgr_uv.cc.o) has no symbols
```

#no-changelog