### PR TITLE
Test with Xcode 10.3 instead of 10.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=macos
 
     - stage: test
-      osx_image: xcode10.2
+      osx_image: xcode10.1
       env:
         - PROJECT=Core METHOD=pod-lib-lint
       script:
@@ -70,7 +70,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseCoreDiagnostics.podspec --platforms=macos
 
     - stage: test
-      osx_image: xcode10.2
+      osx_image: xcode10.1
       env:
         - PROJECT=CoreDiagnostics METHOD=pod-lib-lint
       script:
@@ -97,7 +97,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseABTesting.podspec --platforms=macos
 
     - stage: test
-      osx_image: xcode10.2
+      osx_image: xcode10.1
       env:
         - PROJECT=ABTesting METHOD=pod-lib-lint
       script:
@@ -128,7 +128,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
-      osx_image: xcode10.2
+      osx_image: xcode10.1
       env:
         - PROJECT=Auth PLATFORM=iOS METHOD=xcodebuild
       before_install:
@@ -158,7 +158,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --platforms=macos
 
     - stage: test
-      osx_image: xcode10.2
+      osx_image: xcode10.1
       env:
         - PROJECT=InstanceID METHOD=pod-lib-lint
       script:
@@ -189,7 +189,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseDatabase.podspec --skip-tests --platforms=macos
 
     - stage: test
-      osx_image: xcode10.2
+      osx_image: xcode10.1
       env:
         - PROJECT=Database PLATFORM=all METHOD=xcodebuild
       before_install:
@@ -218,7 +218,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseDynamicLinks.podspec --use-modular-headers
 
     - stage: test
-      osx_image: xcode10.2
+      osx_image: xcode10.1
       env:
         - PROJECT=DynamicLinks METHOD=pod-lib-lint
       script:
@@ -233,7 +233,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --platforms=macos
 
     - stage: test
-      osx_image: xcode10.2
+      osx_image: xcode10.1
       env:
         - PROJECT=Messaging METHOD=pod-lib-lint
       script:
@@ -263,7 +263,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --platforms=macos
 
     - stage: test
-      osx_image: xcode10.2
+      osx_image: xcode10.1
       env:
         - PROJECT=RemoteConfig METHOD=pod-lib-lint
       script:
@@ -294,7 +294,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseStorage.podspec --skip-tests --platforms=macos
 
     - stage: test
-      osx_image: xcode10.2
+      osx_image: xcode10.1
       env:
         - PROJECT=Storage PLATFORM=all METHOD=xcodebuild
       before_install:
@@ -325,7 +325,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --use-modular-headers
 
     - stage: test
-      osx_image: xcode10.2
+      osx_image: xcode10.1
       env:
         - PROJECT=Functions METHOD=pod-lib-lint
       before_install:
@@ -342,7 +342,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
-      osx_image: xcode10.2
+      osx_image: xcode10.1
       env:
         - PROJECT=InAppMessaging PLATFORM=iOS METHOD=xcodebuild
       before_install:
@@ -359,7 +359,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
-      osx_image: xcode10.2
+      osx_image: xcode10.1
       env:
         - PROJECT=InAppMessagingDisplay PLATFORM=iOS METHOD=xcodebuild
       before_install:
@@ -384,7 +384,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
 
     - stage: test
-      osx_image: xcode10.2
+      osx_image: xcode10.1
       env:
         - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild
       before_install:
@@ -399,7 +399,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleUtilities.podspec
 
     - stage: test
-      osx_image: xcode10.2
+      osx_image: xcode10.1
       env:
         - PROJECT=GoogleUtilities METHOD=pod-lib-lint
       script:
@@ -484,7 +484,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleDataTransport.podspec --platforms=tvos
 
     - stage: test
-      osx_image: xcode10.2
+      osx_image: xcode10.1
       env:
         - PROJECT=GoogleDataTransport METHOD=pod-lib-lint
       script:
@@ -511,7 +511,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleDataTransportCCTSupport.podspec --platforms=tvos
 
     - stage: test
-      osx_image: xcode10.2
+      osx_image: xcode10.1
       env:
         - PROJECT=GoogleDataTransportCCTSupport METHOD=pod-lib-lint
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=macos
 
     - stage: test
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - PROJECT=Core METHOD=pod-lib-lint
       script:
@@ -70,7 +70,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseCoreDiagnostics.podspec --platforms=macos
 
     - stage: test
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - PROJECT=CoreDiagnostics METHOD=pod-lib-lint
       script:
@@ -97,7 +97,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseABTesting.podspec --platforms=macos
 
     - stage: test
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - PROJECT=ABTesting METHOD=pod-lib-lint
       script:
@@ -128,7 +128,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - PROJECT=Auth PLATFORM=iOS METHOD=xcodebuild
       before_install:
@@ -158,7 +158,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInstanceID.podspec --platforms=macos
 
     - stage: test
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - PROJECT=InstanceID METHOD=pod-lib-lint
       script:
@@ -189,7 +189,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseDatabase.podspec --skip-tests --platforms=macos
 
     - stage: test
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - PROJECT=Database PLATFORM=all METHOD=xcodebuild
       before_install:
@@ -218,7 +218,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseDynamicLinks.podspec --use-modular-headers
 
     - stage: test
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - PROJECT=DynamicLinks METHOD=pod-lib-lint
       script:
@@ -233,7 +233,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseMessaging.podspec --platforms=macos
 
     - stage: test
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - PROJECT=Messaging METHOD=pod-lib-lint
       script:
@@ -263,7 +263,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseRemoteConfig.podspec --platforms=macos
 
     - stage: test
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - PROJECT=RemoteConfig METHOD=pod-lib-lint
       script:
@@ -294,7 +294,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseStorage.podspec --skip-tests --platforms=macos
 
     - stage: test
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - PROJECT=Storage PLATFORM=all METHOD=xcodebuild
       before_install:
@@ -325,7 +325,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --use-modular-headers
 
     - stage: test
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - PROJECT=Functions METHOD=pod-lib-lint
       before_install:
@@ -342,7 +342,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - PROJECT=InAppMessaging PLATFORM=iOS METHOD=xcodebuild
       before_install:
@@ -359,7 +359,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM
 
     - stage: test
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - PROJECT=InAppMessagingDisplay PLATFORM=iOS METHOD=xcodebuild
       before_install:
@@ -384,7 +384,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/build.sh $PROJECT $PLATFORM $METHOD
 
     - stage: test
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - PROJECT=Firestore PLATFORM=iOS METHOD=xcodebuild
       before_install:
@@ -399,7 +399,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleUtilities.podspec
 
     - stage: test
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - PROJECT=GoogleUtilities METHOD=pod-lib-lint
       script:
@@ -421,7 +421,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleUtilitiesComponents.podspec
 
     - stage: test
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - PROJECT=GoogleUtilitiesComponents METHOD=pod-lib-lint
       script:
@@ -484,7 +484,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleDataTransport.podspec --platforms=tvos
 
     - stage: test
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - PROJECT=GoogleDataTransport METHOD=pod-lib-lint
       script:
@@ -511,7 +511,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleDataTransportCCTSupport.podspec --platforms=tvos
 
     - stage: test
-      osx_image: xcode10.1
+      osx_image: xcode10.3
       env:
         - PROJECT=GoogleDataTransportCCTSupport METHOD=pod-lib-lint
       script:


### PR DESCRIPTION
All of the travis Xcode 10.2 builds started failing today without a change from our end.  Update to the travis 10.3 config for Xcode 10 testing.

#no-changelog

