### PR TITLE
Update nanopb to 0.3.9.5 (CocoaPods 1.30905.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,6 @@ jobs:
       osx_image: xcode10.3
       env:
         - PROJECT=Auth PLATFORM=iOS METHOD=xcodebuild
-      before_install:
-        - ./scripts/if_changed.sh ./scripts/install_prereqs.sh
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=ios
 

--- a/CoreOnly/Tests/FirebasePodTest/Podfile
+++ b/CoreOnly/Tests/FirebasePodTest/Podfile
@@ -1,6 +1,9 @@
 # Uncomment the next line to define a global platform for your project
 # platform :ios, '9.0'
 
+source 'https://github.com/firebase/SpecsStaging.git'
+source 'https://cdn.cocoapods.org/'
+
 target 'FirebasePodTest' do
   # Comment the next line if you don't want to use dynamic frameworks
   use_frameworks!

--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -31,7 +31,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
   s.default_subspec = 'Core'
 
   s.subspec 'Core' do |ss|
-    ss.ios.dependency 'FirebaseAnalytics', '6.4.990'
+    ss.ios.dependency 'FirebaseAnalytics', '6.5.0'
     ss.dependency 'Firebase/CoreOnly'
   end
 

--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -36,7 +36,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
   end
 
   s.subspec 'CoreOnly' do |ss|
-    ss.dependency 'FirebaseCore', '6.6.7'
+    ss.dependency 'FirebaseCore', '6.7.0'
     ss.source_files = 'CoreOnly/Sources/Firebase.h'
     ss.preserve_paths = 'CoreOnly/Sources/module.modulemap'
     if ENV['FIREBASE_POD_REPO_FOR_DEV_POD'] then
@@ -76,7 +76,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Crashlytics' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseCrashlytics', '~> 4.0.0'
+    ss.dependency 'FirebaseCrashlytics', '~> 4.1.0'
   end
 
   s.subspec 'Database' do |ss|
@@ -91,7 +91,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Firestore' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseFirestore', '~> 1.12.1'
+    ss.dependency 'FirebaseFirestore', '~> 1.13.0'
   end
 
   s.subspec 'Functions' do |ss|

--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Firebase'
-  s.version          = '6.23.0'
+  s.version          = '6.24.0'
   s.summary          = 'Firebase'
 
   s.description      = <<-DESC
@@ -31,7 +31,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
   s.default_subspec = 'Core'
 
   s.subspec 'Core' do |ss|
-    ss.ios.dependency 'FirebaseAnalytics', '6.4.2'
+    ss.ios.dependency 'FirebaseAnalytics', '6.4.990'
     ss.dependency 'Firebase/CoreOnly'
   end
 

--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -101,7 +101,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'InAppMessaging' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.ios.dependency 'FirebaseInAppMessaging', '~> 0.19.3'
+    ss.ios.dependency 'FirebaseInAppMessaging', '~> 0.20.0'
     ss.ios.deployment_target = '9.0'
   end
 

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCore'
-  s.version          = '6.6.7'
+  s.version          = '6.7.0'
   s.summary          = 'Firebase Core'
 
   s.description      = <<-DESC
@@ -35,7 +35,7 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   s.dependency 'GoogleUtilities/Environment', '~> 6.5'
   s.dependency 'GoogleUtilities/Logger', '~> 6.5'
   s.dependency 'FirebaseCoreDiagnosticsInterop', '~> 1.2'
-  s.dependency 'FirebaseCoreDiagnostics', '~> 1.2'
+  s.dependency 'FirebaseCoreDiagnostics', '~> 1.3'
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v6.7.0 -- M70
+- [fixed] Updated the nanopb version dependency across Firebase to 0.3.9.5 that
+  includes a vulnerability fix. To properly manage nanopb versions, Firebase has
+  switched to a new versioning scheme in which the nanopb CocoaPods version 1.0.0
+  maps to nanopb version 0.3.9.5. Full details at
+  https://github.com/google/nanopb-podspec. (#5191)
+
 # v6.6.7 -- M69
 - [fixed] Fixed Carthage installation failures involving `Protobuf.framework`.
   `Protobuf.framework` is now separately installable via adding

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -2,7 +2,7 @@
 - [fixed] Updated the nanopb version dependency across Firebase to 0.3.9.5 that
   includes a vulnerability fix. To properly manage nanopb versions, Firebase has
   switched to a new versioning scheme in which the nanopb CocoaPods
-  version 1.300905.0 maps to nanopb version 0.3.9.5. Full details at
+  version 1.30905.0 maps to nanopb version 0.3.9.5. Full details at
   https://github.com/google/nanopb-podspec. (#5191)
 
 # v6.6.7 -- M69

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,8 +1,8 @@
 # v6.7.0 -- M70
 - [fixed] Updated the nanopb version dependency across Firebase to 0.3.9.5 that
   includes a vulnerability fix. To properly manage nanopb versions, Firebase has
-  switched to a new versioning scheme in which the nanopb CocoaPods version 1.0.0
-  maps to nanopb version 0.3.9.5. Full details at
+  switched to a new versioning scheme in which the nanopb CocoaPods
+  version 1.300905.0 maps to nanopb version 0.3.9.5. Full details at
   https://github.com/google/nanopb-podspec. (#5191)
 
 # v6.6.7 -- M69

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,9 +1,8 @@
 # v6.7.0 -- M70
-- [fixed] Updated the nanopb version dependency across Firebase to 0.3.9.5 that
-  includes a vulnerability fix. To properly manage nanopb versions, Firebase has
-  switched to a new versioning scheme in which the nanopb CocoaPods
-  version 1.30905.0 maps to nanopb version 0.3.9.5. Full details at
-  https://github.com/google/nanopb-podspec. (#5191)
+- [fixed] Updated nanopb to 0.3.9.5 (across all Firebase pods). This includes a fix for
+  [CVE-2020-5235](https://github.com/nanopb/nanopb/security/advisories/GHSA-gcx3-7m76-287p).
+  Note that the versioning scheme for the nanopb CocoaPod has changed;
+  see https://github.com/google/nanopb-podspec for more details. (#5191)
 
 # v6.6.7 -- M69
 - [fixed] Fixed Carthage installation failures involving `Protobuf.framework`.

--- a/FirebaseCoreDiagnostics.podspec
+++ b/FirebaseCoreDiagnostics.podspec
@@ -49,7 +49,7 @@ non-Cocoapod integration. This library also respects the Firebase global data co
   s.dependency 'GoogleDataTransportCCTSupport', '~> 3.0'
   s.dependency 'GoogleUtilities/Environment', '~> 6.5'
   s.dependency 'GoogleUtilities/Logger', '~> 6.5'
-  s.dependency 'nanopb', '~> 1.300905.0'
+  s.dependency 'nanopb', '~> 1.30905.0'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}

--- a/FirebaseCoreDiagnostics.podspec
+++ b/FirebaseCoreDiagnostics.podspec
@@ -49,7 +49,7 @@ non-Cocoapod integration. This library also respects the Firebase global data co
   s.dependency 'GoogleDataTransportCCTSupport', '~> 3.0'
   s.dependency 'GoogleUtilities/Environment', '~> 6.5'
   s.dependency 'GoogleUtilities/Logger', '~> 6.5'
-  s.dependency 'nanopb', '~> 1.0.0'
+  s.dependency 'nanopb', '~> 1.300905.0'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}

--- a/FirebaseCoreDiagnostics.podspec
+++ b/FirebaseCoreDiagnostics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCoreDiagnostics'
-  s.version          = '1.2.4'
+  s.version          = '1.3.0'
   s.summary          = 'Firebase Core Diagnostics'
 
   s.description      = <<-DESC
@@ -49,7 +49,7 @@ non-Cocoapod integration. This library also respects the Firebase global data co
   s.dependency 'GoogleDataTransportCCTSupport', '~> 3.0'
   s.dependency 'GoogleUtilities/Environment', '~> 6.5'
   s.dependency 'GoogleUtilities/Logger', '~> 6.5'
-  s.dependency 'nanopb', '~> 0.3.901'
+  s.dependency 'nanopb', '~> 1.0.0'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCrashlytics'
-  s.version          = '4.0.0'
+  s.version          = '4.1.0'
   s.summary          = 'Best and lightest-weight crash reporting for mobile, desktop and tvOS.'
   s.description      = 'Firebase Crashlytics helps you track, prioritize, and fix stability issues that erode app quality.'
   s.homepage         = 'https://firebase.google.com/'
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
   s.dependency 'PromisesObjC', '~> 1.2'
   s.dependency 'GoogleDataTransport', '~> 6.0'
   s.dependency 'GoogleDataTransportCCTSupport', '~> 3.0'
-  s.dependency 'nanopb', '~> 0.3.901'
+  s.dependency 'nanopb', '~> 1.0.0'
 
   s.libraries = 'c++', 'z'
   s.frameworks = 'Security', 'SystemConfiguration'

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
   s.dependency 'PromisesObjC', '~> 1.2'
   s.dependency 'GoogleDataTransport', '~> 6.0'
   s.dependency 'GoogleDataTransportCCTSupport', '~> 3.0'
-  s.dependency 'nanopb', '~> 1.300905.0'
+  s.dependency 'nanopb', '~> 1.30905.0'
 
   s.libraries = 'c++', 'z'
   s.frameworks = 'Security', 'SystemConfiguration'

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
   s.dependency 'PromisesObjC', '~> 1.2'
   s.dependency 'GoogleDataTransport', '~> 6.0'
   s.dependency 'GoogleDataTransportCCTSupport', '~> 3.0'
-  s.dependency 'nanopb', '~> 1.0.0'
+  s.dependency 'nanopb', '~> 1.300905.0'
 
   s.libraries = 'c++', 'z'
   s.frameworks = 'Security', 'SystemConfiguration'

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -72,7 +72,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
 
   s.dependency 'gRPC-C++', '~> 1.28.0'
   s.dependency 'leveldb-library', '~> 1.22'
-  s.dependency 'nanopb', '~> 1.0.0'
+  s.dependency 'nanopb', '~> 1.300905.0'
 
   s.ios.frameworks = 'MobileCoreServices', 'SystemConfiguration', 'UIKit'
   s.osx.frameworks = 'SystemConfiguration'

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -72,7 +72,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
 
   s.dependency 'gRPC-C++', '~> 1.28.0'
   s.dependency 'leveldb-library', '~> 1.22'
-  s.dependency 'nanopb', '~> 1.300905.0'
+  s.dependency 'nanopb', '~> 1.30905.0'
 
   s.ios.frameworks = 'MobileCoreServices', 'SystemConfiguration', 'UIKit'
   s.osx.frameworks = 'SystemConfiguration'

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseFirestore'
-  s.version          = '1.12.1'
+  s.version          = '1.13.0'
   s.summary          = 'Google Cloud Firestore'
 
   s.description      = <<-DESC
@@ -72,7 +72,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
 
   s.dependency 'gRPC-C++', '~> 1.28.0'
   s.dependency 'leveldb-library', '~> 1.22'
-  s.dependency 'nanopb', '~> 0.3.901'
+  s.dependency 'nanopb', '~> 1.0.0'
 
   s.ios.frameworks = 'MobileCoreServices', 'SystemConfiguration', 'UIKit'
   s.osx.frameworks = 'SystemConfiguration'

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -47,7 +47,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
   s.dependency 'GoogleDataTransportCCTSupport', '~> 3.0'
   s.dependency 'FirebaseABTesting', '~> 3.2'
   s.dependency 'GoogleUtilities/Environment', '~> 6.5'
-  s.dependency 'nanopb', '~> 1.300905.0'
+  s.dependency 'nanopb', '~> 1.30905.0'
 
   s.test_spec 'unit' do |unit_tests|
       unit_tests.source_files = 'FirebaseInAppMessaging/Tests/Unit/*.[mh]'

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -47,7 +47,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
   s.dependency 'GoogleDataTransportCCTSupport', '~> 3.0'
   s.dependency 'FirebaseABTesting', '~> 3.2'
   s.dependency 'GoogleUtilities/Environment', '~> 6.5'
-  s.dependency 'nanopb', '~> 1.0.0'
+  s.dependency 'nanopb', '~> 1.300905.0'
 
   s.test_spec 'unit' do |unit_tests|
       unit_tests.source_files = 'FirebaseInAppMessaging/Tests/Unit/*.[mh]'

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInAppMessaging'
-  s.version          = '0.19.3'
+  s.version          = '0.20.0'
   s.summary          = 'Firebase In-App Messaging for iOS'
 
   s.description      = <<-DESC

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -47,6 +47,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
   s.dependency 'GoogleDataTransportCCTSupport', '~> 3.0'
   s.dependency 'FirebaseABTesting', '~> 3.2'
   s.dependency 'GoogleUtilities/Environment', '~> 6.5'
+  s.dependency 'nanopb', '~> 1.0.0'
 
   s.test_spec 'unit' do |unit_tests|
       unit_tests.source_files = 'FirebaseInAppMessaging/Tests/Unit/*.[mh]'

--- a/FirebaseInAppMessaging/Tests/Integration/DefaultUITestApp/Podfile
+++ b/FirebaseInAppMessaging/Tests/Integration/DefaultUITestApp/Podfile
@@ -1,3 +1,4 @@
+source 'https://github.com/firebase/SpecsStaging.git'
 source 'https://cdn.cocoapods.org/'
 
 use_frameworks!

--- a/FirebaseInAppMessaging/Tests/Integration/FunctionalTestApp/Podfile
+++ b/FirebaseInAppMessaging/Tests/Integration/FunctionalTestApp/Podfile
@@ -1,5 +1,6 @@
 use_frameworks!
 
+source 'https://github.com/firebase/SpecsStaging.git'
 source 'https://cdn.cocoapods.org/'
 
 pod 'FirebaseAnalytics'

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -56,6 +56,7 @@ def configure_local_pods()
   # scripts/install_prereqs.sh for more details.
   pod 'FirebaseCore', :path => '../..'
   pod 'FirebaseCoreDiagnostics', :path => '../..'
+  pod 'GoogleDataTransportCCTSupport', :path => '../..'
 
   # Pull in local sources conditionally.
   maybe_local_pod 'FirebaseAuth'

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -5,6 +5,7 @@ require 'pathname'
 #source 'sso://cpdc-internal/firebase'
 #source 'https://cdn.cocoapods.org/'
 
+source 'https://github.com/firebase/SpecsStaging.git'
 source 'https://cdn.cocoapods.org/'
 
 use_frameworks!

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -55,6 +55,7 @@ def configure_local_pods()
   # to its podspec can still function. See Firestore-*-xcodebuild in
   # scripts/install_prereqs.sh for more details.
   pod 'FirebaseCore', :path => '../..'
+  pod 'FirebaseCoreDiagnostics', :path => '../..'
 
   # Pull in local sources conditionally.
   maybe_local_pod 'FirebaseAuth'

--- a/GoogleDataTransportCCTSupport.podspec
+++ b/GoogleDataTransportCCTSupport.podspec
@@ -37,7 +37,7 @@ Support library to provide event prioritization and uploading for the GoogleData
   s.libraries = ['z']
 
   s.dependency 'GoogleDataTransport', '~> 6.0'
-  s.dependency 'nanopb', '~> 1.300905.0'
+  s.dependency 'nanopb', '~> 1.30905.0'
 
   header_search_paths = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}/GoogleDataTransportCCTSupport/"'

--- a/GoogleDataTransportCCTSupport.podspec
+++ b/GoogleDataTransportCCTSupport.podspec
@@ -37,7 +37,7 @@ Support library to provide event prioritization and uploading for the GoogleData
   s.libraries = ['z']
 
   s.dependency 'GoogleDataTransport', '~> 6.0'
-  s.dependency 'nanopb', '~> 1.0.0'
+  s.dependency 'nanopb', '~> 1.300905.0'
 
   header_search_paths = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}/GoogleDataTransportCCTSupport/"'

--- a/GoogleDataTransportCCTSupport.podspec
+++ b/GoogleDataTransportCCTSupport.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'GoogleDataTransportCCTSupport'
-  s.version          = '3.0.0'
+  s.version          = '3.1.0'
   s.summary          = 'Support library for the GoogleDataTransport CCT backend target.'
 
 
@@ -37,7 +37,7 @@ Support library to provide event prioritization and uploading for the GoogleData
   s.libraries = ['z']
 
   s.dependency 'GoogleDataTransport', '~> 6.0'
-  s.dependency 'nanopb', '~> 0.3.901'
+  s.dependency 'nanopb', '~> 1.0.0'
 
   header_search_paths = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}/GoogleDataTransportCCTSupport/"'

--- a/SymbolCollisionTest/Podfile
+++ b/SymbolCollisionTest/Podfile
@@ -1,6 +1,8 @@
 # Uncomment the next line to define a global platform for your project
 platform :ios, '9.0'
 
+
+source 'https://github.com/firebase/SpecsStaging.git'
 source 'https://cdn.cocoapods.org/'
 
 target 'SymbolCollisionTest' do

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,7 +20,7 @@
 
 function pod_gen() {
   # Call pod gen with a podspec and additional optional arguments.
-  bundle exec pod gen --local-sources=./ --sources=https://cdn.cocoapods.org/ "$@"
+  bundle exec pod gen --local-sources=./ --sources=https://github.com/firebase/SpecsStaging.git,https://cdn.cocoapods.org/ "$@"
 }
 
 set -euo pipefail

--- a/scripts/localize_podfile.swift
+++ b/scripts/localize_podfile.swift
@@ -47,7 +47,7 @@ while url.path != "/", url.lastPathComponent != "firebase-ios-sdk" {
 let repo = url
 let lines = fileContents.components(separatedBy: .newlines)
 var outBuffer = "source 'https://github.com/firebase/SpecsStaging.git'\n" +
-                "source 'https://cdn.cocoapods.org/'\n"
+  "source 'https://cdn.cocoapods.org/'\n"
 for line in lines {
   var newLine = line
   let tokens = line.components(separatedBy: [" ", ","] as CharacterSet)

--- a/scripts/localize_podfile.swift
+++ b/scripts/localize_podfile.swift
@@ -46,7 +46,8 @@ while url.path != "/", url.lastPathComponent != "firebase-ios-sdk" {
 
 let repo = url
 let lines = fileContents.components(separatedBy: .newlines)
-var outBuffer = ""
+var outBuffer = "source 'https://github.com/firebase/SpecsStaging.git'\n" +
+                "source 'https://cdn.cocoapods.org/'\n"
 for line in lines {
   var newLine = line
   let tokens = line.components(separatedBy: [" ", ","] as CharacterSet)

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -47,7 +47,7 @@ def main(args)
 
   STDOUT.sync = true
 
-  command = %w(bundle exec pod lib lint --sources=https://cdn.cocoapods.org/)
+  command = %w(bundle exec pod lib lint --sources=https://github.com/firebase/SpecsStaging.git,https://cdn.cocoapods.org/)
 
   # Split arguments that need to be processed by the script itself and passed
   # to the pod command.

--- a/scripts/test_catalyst.sh
+++ b/scripts/test_catalyst.sh
@@ -37,7 +37,7 @@ else
   scheme="$pod"
 fi
 
-bundle exec pod gen --local-sources=./ --sources=https://cdn.cocoapods.org/ \
+bundle exec pod gen --local-sources=./ --sources=https://github.com/firebase/SpecsStaging.git,https://cdn.cocoapods.org/ \
   "$pod".podspec --platforms=ios
 
 args=(


### PR DESCRIPTION
Fix #5191 

See https://github.com/google/nanopb-podspec/pull/13 for a description of the new nanopb CocoaPods versioning scheme.

Updates test infrastructure to test preliminary versions of Analytics pod structure (but not functional) changes.

See #5455 for the corresponding no-op nanopb code gen changes.

Googlers - see also cl/308045137

#no-changelog