### PR TITLE
Remove workarounds for nanopb ODR violations

### DIFF
--- a/Firestore/core/src/firebase/firestore/local/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/local/CMakeLists.txt
@@ -39,15 +39,13 @@ cc_library(
     leveldb_util.cc
     leveldb_util.h
   DEPENDS
-    # TODO(b/111328563) Force nanopb first to work around ODR violations
-    protobuf-nanopb-static
-
     LevelDB::LevelDB
     absl_strings
     firebase_firestore_model
     firebase_firestore_nanopb
     firebase_firestore_protos_nanopb
     firebase_firestore_util
+    protobuf-nanopb-static
   EXCLUDE_FROM_ALL
 )
 
@@ -99,9 +97,6 @@ cc_library(
     simple_query_engine.h
     sizer.h
   DEPENDS
-    # TODO(b/111328563) Force nanopb first to work around ODR violations
-    protobuf-nanopb-static
-
     absl_strings
     firebase_firestore_auth
     firebase_firestore_local_persistence_leveldb
@@ -110,4 +105,5 @@ cc_library(
     firebase_firestore_protos_nanopb
     firebase_firestore_remote
     firebase_firestore_util
+    protobuf-nanopb-static
 )

--- a/Firestore/core/src/firebase/firestore/model/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/model/CMakeLists.txt
@@ -66,12 +66,10 @@ cc_library(
     unknown_document.cc
     unknown_document.h
   DEPENDS
-    # TODO(b/111328563) Force nanopb first to work around ODR violations
-    firebase_firestore_nanopb
-
     absl_optional
     absl_strings
     firebase_firestore_immutable
+    firebase_firestore_nanopb
     firebase_firestore_objc
     firebase_firestore_util
     firebase_firestore_types

--- a/Firestore/core/src/firebase/firestore/nanopb/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/nanopb/CMakeLists.txt
@@ -29,13 +29,11 @@ cc_library(
     writer.cc
     writer.h
   DEPENDS
-    # TODO(b/111328563) Force nanopb first to work around ODR violations
-    protobuf-nanopb-static
-
     firebase_firestore_model
     firebase_firestore_util
     firebase_firestore_protos_nanopb
     grpc++
+    protobuf-nanopb-static
 )
 
 target_compile_definitions(

--- a/Firestore/core/src/firebase/firestore/remote/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/remote/CMakeLists.txt
@@ -112,9 +112,6 @@ cc_library(
     write_stream.h
 
   DEPENDS
-    # TODO(b/111328563) Force nanopb first to work around ODR violations
-    protobuf-nanopb-static
-
     firebase_firestore_core
     firebase_firestore_model
     firebase_firestore_nanopb
@@ -122,6 +119,6 @@ cc_library(
     firebase_firestore_remote_connectivity_monitor
     firebase_firestore_util
     firebase_firestore_version
-
     grpc++
+    protobuf-nanopb-static
 )

--- a/Firestore/core/test/firebase/firestore/testutil/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/testutil/CMakeLists.txt
@@ -43,14 +43,12 @@ cc_library(
     view_testing.cc
     view_testing.h
   DEPENDS
-    # TODO(b/111328563) Force nanopb first to work around ODR violations
-    firebase_firestore_nanopb
-
     ${TESTUTIL_DEPENDS}
     GTest::GTest
     absl_time
     firebase_firestore_core
     firebase_firestore_model
+    firebase_firestore_nanopb
     firebase_firestore_util
 )
 


### PR DESCRIPTION
Now that we depend upon gRPC 1.24+ (and it no longer includes nanopb) we
no longer need any build order workarounds.

Fixes b/111328563. #no-changelog