### PR TITLE
Get integration tests fully working under CMake

### DIFF
--- a/Firestore/Example/App/CMakeLists.txt
+++ b/Firestore/Example/App/CMakeLists.txt
@@ -20,6 +20,11 @@ if(APPLE)
     macOS/AppDelegate.h
   )
 
+  set(
+    resources
+    GoogleService-Info.plist
+  )
+
   add_executable(
     firestore_example_app_macos MACOSX_BUNDLE
     ${sources}
@@ -38,6 +43,7 @@ if(APPLE)
   set_target_properties(
     firestore_example_app_macos PROPERTIES
     MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/macOS/Info.plist
+    RESOURCE "${resources}"
   )
 
 endif(APPLE)

--- a/Firestore/Example/App/CMakeLists.txt
+++ b/Firestore/Example/App/CMakeLists.txt
@@ -12,20 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(macOS_Example_App MACOSX_BUNDLE
-  macOS/main.m
-  macOS/AppDelegate.m
-  macOS/AppDelegate.h
-)
-
-add_objc_flags(macOS_Example_App
-  macOS/main.m
-  macOS/AppDelegate.m
-  macOS/AppDelegate.h
-)
-
-target_link_libraries(macOS_Example_App PRIVATE "-framework AppKit")
-
-set_target_properties(macOS_Example_App PROPERTIES
-  MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/macOS/Info.plist
+if(APPLE)
+  set(
+    sources
+    macOS/main.m
+    macOS/AppDelegate.m
+    macOS/AppDelegate.h
   )
+
+  add_executable(
+    firestore_example_app_macos MACOSX_BUNDLE
+    ${sources}
+  )
+
+  add_objc_flags(
+    firestore_example_app_macos
+    ${sources}
+  )
+
+  target_link_libraries(
+    firestore_example_app_macos
+    PRIVATE "-framework AppKit"
+  )
+
+  set_target_properties(
+    firestore_example_app_macos PROPERTIES
+    MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/macOS/Info.plist
+  )
+
+endif(APPLE)

--- a/Firestore/Example/Tests/Integration/CMakeLists.txt
+++ b/Firestore/Example/Tests/Integration/CMakeLists.txt
@@ -12,57 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_package(XCTest REQUIRED)
-enable_testing()
-
-xctest_add_bundle(firebase_firestore_objc_integration_tests
-  macOS_Example_App
-  FSTSmokeTests.mm
-  FSTDatastoreTests.mm
-  FSTTransactionTests.mm
-  API/FIRArrayTransformTests.mm
-  API/FIRFieldsTests.mm
-  API/FIRNumericTransformTests.mm
-  API/FIRTypeTests.mm
-  API/FIRCursorTests.mm
-  API/FIRFirestoreSourceTests.mm
-  API/FIRQueryTests.mm
-  # TODO(wuandy): Some tests interacting with FirebaseApp seem to fail.
-  # Investigate and enable them.
-  # API/FIRValidationTests.mm
-  # API/FIRDatabaseTests.mm
-  API/FIRListenerRegistrationTests.mm
-  API/FIRServerTimestampTests.mm
-  API/FIRWriteBatchTests.mm
+objc_test(
+  firebase_firestore_objc_integration_test
+  HOST firestore_example_app_macos
+  SOURCES
+    FSTSmokeTests.mm
+    FSTDatastoreTests.mm
+    FSTTransactionTests.mm
+    API/FIRArrayTransformTests.mm
+    API/FIRFieldsTests.mm
+    API/FIRNumericTransformTests.mm
+    API/FIRTypeTests.mm
+    API/FIRCursorTests.mm
+    API/FIRFirestoreSourceTests.mm
+    API/FIRQueryTests.mm
+    API/FIRValidationTests.mm
+    API/FIRDatabaseTests.mm
+    API/FIRListenerRegistrationTests.mm
+    API/FIRServerTimestampTests.mm
+    API/FIRWriteBatchTests.mm
+  DEPENDS
+    FirebaseFirestore
+    firebase_firestore_objc_test_util
 )
-
-add_objc_flags(firebase_firestore_objc_integration_tests
-  FSTSmokeTests.mm
-  FSTDatastoreTests.mm
-  FSTTransactionTests.mm
-  API/FIRArrayTransformTests.mm
-  API/FIRFieldsTests.mm
-  API/FIRNumericTransformTests.mm
-  API/FIRTypeTests.mm
-  API/FIRCursorTests.mm
-  API/FIRFirestoreSourceTests.mm
-  API/FIRQueryTests.mm
-  # API/FIRValidationTests.mm
-  # API/FIRDatabaseTests.mm
-  API/FIRListenerRegistrationTests.mm
-  API/FIRServerTimestampTests.mm
-  API/FIRWriteBatchTests.mm
-)
-
-target_include_directories(
-    firebase_firestore_objc_integration_tests
-    PUBLIC
-    ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public
-    ${FIREBASE_SOURCE_DIR}/Firestore/Example/Tests/Util
-  )
-
-target_link_libraries(firebase_firestore_objc_integration_tests PUBLIC FirebaseFirestore)
-target_link_libraries(firebase_firestore_objc_integration_tests PUBLIC firebase_firestore_tests_util)
-
-xctest_add_test(firebase_firestore_objc_integration_tests
-  firebase_firestore_objc_integration_tests)

--- a/Firestore/Example/Tests/Util/CMakeLists.txt
+++ b/Firestore/Example/Tests/Util/CMakeLists.txt
@@ -12,41 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_package(XCTest REQUIRED)
-
-objc_framework(
-  firebase_firestore_tests_util
-  HEADERS
-    FSTEventAccumulator.h
-    # XCTestCase+Await.h
-    FSTIntegrationTestCase.h
-    FIRFirestore+Testing.h
-    FSTHelpers.h
-  SOURCES
-    FSTEventAccumulator.mm
-    # XCTestCase+Await.mm
-    FSTIntegrationTestCase.mm
-    FSTHelpers.mm
-  DEPENDS
-    absl_any
-    absl_strings
-    FirebaseFirestore
-    firebase_firestore_auth
-    firebase_firestore_core
-    firebase_firestore_local
-    firebase_firestore_model
-    firebase_firestore_util
-    firebase_firestore_remote
-    firebase_firestore_remote_testing
-    firebase_firestore_nanopb
-    firebase_firestore_protos_nanopb
-    firebase_firestore_testutil
-    ${XCTest_LIBRARIES}
-    GTest::GTest
-)
-
-target_include_directories(
-    firebase_firestore_tests_util
-    PUBLIC
-    ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public
-)
+if(APPLE)
+  cc_library(
+    firebase_firestore_objc_test_util
+    HEADERS
+      FSTEventAccumulator.h
+      XCTestCase+Await.h
+      FSTIntegrationTestCase.h
+      FIRFirestore+Testing.h
+      FSTHelpers.h
+    SOURCES
+      FSTEventAccumulator.mm
+      XCTestCase+Await.mm
+      FSTIntegrationTestCase.mm
+      FSTHelpers.mm
+    DEPENDS
+      absl_any
+      absl_strings
+      FirebaseFirestore
+      firebase_firestore_auth
+      firebase_firestore_core
+      firebase_firestore_local
+      firebase_firestore_model
+      firebase_firestore_util
+      firebase_firestore_remote
+      firebase_firestore_remote_testing
+      firebase_firestore_nanopb
+      firebase_firestore_protos_nanopb
+      firebase_firestore_testutil
+      ${XCTest_LIBRARIES}
+      GTest::GTest
+  )
+endif(APPLE)

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -113,6 +113,8 @@ class FakeCredentialsProvider : public EmptyCredentialsProvider {
 - (void)setUp {
   [super setUp];
 
+  LoadXCTestCaseAwait();
+
   _fakeCredentialsProvider = std::make_shared<FakeCredentialsProvider>();
 
   [self clearPersistenceOnce];
@@ -511,29 +513,6 @@ class FakeCredentialsProvider : public EmptyCredentialsProvider {
   if (!predicate()) {
     XCTFail(@"Timeout");
   }
-}
-
-static const double kExpectationWaitSeconds = 25.0;
-
-- (void)awaitExpectations {
-  [self waitForExpectationsWithTimeout:kExpectationWaitSeconds
-                               handler:^(NSError *_Nullable expectationError) {
-                                 if (expectationError) {
-                                   XCTFail(@"Error waiting for timeout: %@", expectationError);
-                                 }
-                               }];
-}
-
-- (double)defaultExpectationWaitSeconds {
-  return kExpectationWaitSeconds;
-}
-
-- (FSTVoidErrorBlock)completionForExpectationWithName:(NSString *)expectationName {
-  XCTestExpectation *expectation = [self expectationWithDescription:expectationName];
-  return ^(NSError *error) {
-    XCTAssertNil(error);
-    [expectation fulfill];
-  };
 }
 
 extern "C" NSArray<NSDictionary<NSString *, id> *> *FIRQuerySnapshotGetData(

--- a/Firestore/Example/Tests/Util/XCTestCase+Await.h
+++ b/Firestore/Example/Tests/Util/XCTestCase+Await.h
@@ -18,6 +18,11 @@
 
 #import "Firestore/Source/Core/FSTTypes.h"
 
+/**
+ * Force the linker to see these extensions even if compiled without -ObjC.
+ */
+void LoadXCTestCaseAwait();
+
 @interface XCTestCase (Await)
 
 /**

--- a/Firestore/Example/Tests/Util/XCTestCase+Await.mm
+++ b/Firestore/Example/Tests/Util/XCTestCase+Await.mm
@@ -22,6 +22,9 @@
 // Conformance Tests flakiness or gotten answers from GRPC about reconnect delays.
 static const double kExpectationWaitSeconds = 25.0;
 
+void LoadXCTestCaseAwait() {
+}
+
 @implementation XCTestCase (Await)
 
 - (void)awaitExpectations {

--- a/Firestore/Protos/CMakeLists.txt
+++ b/Firestore/Protos/CMakeLists.txt
@@ -116,7 +116,7 @@ cc_library(
   SOURCES
     ${NANOPB_GENERATED_SOURCES}
   DEPENDS
-    firebase_firestore_nanopb
+    firebase_firestore_nanopb_runtime
     protobuf-nanopb-static
 )
 

--- a/Firestore/Source/CMakeLists.txt
+++ b/Firestore/Source/CMakeLists.txt
@@ -89,11 +89,4 @@ if(APPLE)
       absl_strings
       firebase_firestore_api
   )
-
-  target_include_directories(
-    FirebaseFirestore
-    PUBLIC
-    ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public
-  )
-
 endif()

--- a/Firestore/Source/CMakeLists.txt
+++ b/Firestore/Source/CMakeLists.txt
@@ -13,54 +13,15 @@
 # limitations under the License.
 
 if(APPLE)
-  podspec_version(firestore_version ${PROJECT_SOURCE_DIR}/FirebaseFirestore.podspec)
+  podspec_version(
+    firestore_version
+    ${PROJECT_SOURCE_DIR}/FirebaseFirestore.podspec
+  )
 
-  cc_library(
-    firebase_firestore_objc_api
-    SOURCES
-      API/FIRCollectionReference+Internal.h
-      API/FIRCollectionReference.mm
-      API/FIRDocumentChange+Internal.h
-      API/FIRDocumentChange.mm
-      API/FIRDocumentReference+Internal.h
-      API/FIRDocumentReference.mm
-      API/FIRDocumentSnapshot+Internal.h
-      API/FIRDocumentSnapshot.mm
-      API/FIRFieldPath+Internal.h
-      API/FIRFieldPath.mm
-      API/FIRFieldValue+Internal.h
-      API/FIRFieldValue.mm
-      API/FIRFirestore+Internal.h
-      API/FIRFirestore.mm
-      API/FIRFirestoreSettings+Internal.h
-      API/FIRFirestoreSettings.mm
-      API/FIRFirestoreSource+Internal.h
-      API/FIRFirestoreSource.mm
-      API/FIRFirestoreVersion.h
-      API/FIRFirestoreVersion.mm
-      API/FIRGeoPoint+Internal.h
-      API/FIRGeoPoint.mm
-      API/FIRListenerRegistration+Internal.h
-      API/FIRListenerRegistration.mm
-      API/FIRQuery+Internal.h
-      API/FIRQuery.mm
-      API/FIRQuerySnapshot+Internal.h
-      API/FIRQuerySnapshot.mm
-      API/FIRSnapshotMetadata+Internal.h
-      API/FIRSnapshotMetadata.mm
-      API/FIRTimestamp.m
-      API/FIRTimestamp+Internal.h
-      API/FIRTransaction+Internal.h
-      API/FIRTransaction.mm
-      API/FIRWriteBatch+Internal.h
-      API/FIRWriteBatch.mm
-      API/FSTFirestoreComponent.h
-      API/FSTFirestoreComponent.mm
-      API/FSTUserDataConverter.h
-      API/FSTUserDataConverter.mm
-      API/converters.h
-      API/converters.mm
-      Core/FSTTypes.h
+  objc_framework(
+    FirebaseFirestore
+    HEADERS
+      Public/FirebaseFirestore.h
       Public/FIRCollectionReference.h
       Public/FIRDocumentChange.h
       Public/FIRDocumentReference.h
@@ -79,41 +40,6 @@ if(APPLE)
       Public/FIRTimestamp.h
       Public/FIRTransaction.h
       Public/FIRWriteBatch.h
-      Public/FirebaseFirestore.h
-      Util/FSTClasses.h
-    DEPENDS
-      absl_strings
-      firebase_firestore_api
-  )
-
-  target_include_directories(
-    firebase_firestore_objc_api
-    PUBLIC
-    ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public
-  )
-
-  objc_framework(
-    FirebaseFirestore
-    HEADERS
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FirebaseFirestore.h
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FIRCollectionReference.h
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FIRDocumentChange.h
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FIRDocumentReference.h
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FIRDocumentSnapshot.h
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FIRFieldPath.h
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FIRFieldValue.h
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FIRFirestore.h
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FIRFirestoreErrors.h
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FIRFirestoreSettings.h
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FIRFirestoreSource.h
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FIRGeoPoint.h
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FIRListenerRegistration.h
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FIRQuery.h
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FIRQuerySnapshot.h
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FIRSnapshotMetadata.h
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FIRTimestamp.h
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FIRTransaction.h
-      ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public/FIRWriteBatch.h
     SOURCES
       API/FIRCollectionReference+Internal.h
       API/FIRCollectionReference.mm
@@ -170,4 +96,4 @@ if(APPLE)
     ${FIREBASE_SOURCE_DIR}/Firestore/Source/Public
   )
 
-  endif()
+endif()

--- a/Firestore/Source/CMakeLists.txt
+++ b/Firestore/Source/CMakeLists.txt
@@ -20,6 +20,7 @@ if(APPLE)
 
   objc_framework(
     FirebaseFirestore
+    SHARED
     HEADERS
       Public/FirebaseFirestore.h
       Public/FIRCollectionReference.h
@@ -86,7 +87,11 @@ if(APPLE)
       Core/FSTTypes.h
       Util/FSTClasses.h
     DEPENDS
+      absl_any
       absl_strings
       firebase_firestore_api
+      firebase_firestore_core_transaction
+      firebase_firestore_remote_datastore
+      firebase_firestore_version
   )
 endif()

--- a/Firestore/core/src/firebase/firestore/core/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/core/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 cc_library(
-  firebase_firestore_core
+  firebase_firestore_core_query
   SOURCES
     array_contains_any_filter.cc
     array_contains_any_filter.h
@@ -25,48 +25,85 @@ cc_library(
     database_info.h
     direction.cc
     direction.h
-    event_listener.h
-    event_manager.cc
-    event_manager.h
     field_filter.cc
     field_filter.h
     filter.cc
     filter.h
-    firestore_client.cc
-    firestore_client.h
     in_filter.cc
     in_filter.h
     key_field_in_filter.cc
     key_field_in_filter.h
     key_field_filter.cc
     key_field_filter.h
-    listen_options.h
     operator.h
     order_by.cc
     order_by.h
     query.cc
     query.h
-    query_listener.cc
-    query_listener.h
-    sync_engine.cc
-    sync_engine.h
-    sync_engine_callback.h
+  DEPENDS
+    absl_strings
+    firebase_firestore_model
+)
+
+cc_library(
+  firebase_firestore_core_target_id_generator
+  SOURCES
     target_id_generator.cc
     target_id_generator.h
+  DEPENDS
+    absl_strings
+    firebase_firestore_util
+)
+
+cc_library(
+  firebase_firestore_core_transaction
+  SOURCES
     transaction.cc
     transaction.h
-    transaction_runner.cc
-    transaction_runner.h
-    user_data.cc
-    user_data.h
+  DEPENDS
+    absl_strings
+    firebase_firestore_model
+    firebase_firestore_remote_datastore
+)
+
+
+cc_library(
+  firebase_firestore_core_view
+  SOURCES
+    query_listener.cc
+    query_listener.h
     view.cc
     view.h
     view_snapshot.cc
     view_snapshot.h
   DEPENDS
     absl_strings
+    firebase_firestore_core_query
+    firebase_firestore_model
+)
+
+cc_library(
+  firebase_firestore_core
+  SOURCES
+    event_listener.h
+    event_manager.cc
+    event_manager.h
+    firestore_client.cc
+    firestore_client.h
+    listen_options.h
+    sync_engine.cc
+    sync_engine.h
+    sync_engine_callback.h
+    transaction_runner.cc
+    transaction_runner.h
+    user_data.cc
+    user_data.h
+  DEPENDS
+    absl_strings
+    firebase_firestore_core_query
+    firebase_firestore_core_target_id_generator
+    firebase_firestore_core_view
     firebase_firestore_local
     firebase_firestore_model
-    firebase_firestore_objc
     firebase_firestore_remote
 )

--- a/Firestore/core/src/firebase/firestore/local/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/local/CMakeLists.txt
@@ -13,6 +13,32 @@
 # limitations under the License.
 
 cc_library(
+  firebase_firestore_local_base
+  SOURCES
+    document_key_reference.cc
+    document_key_reference.h
+    index_manager.h
+    local_serializer.cc
+    local_serializer.h
+    lru_garbage_collector.cc
+    lru_garbage_collector.h
+    memory_index_manager.cc
+    memory_index_manager.h
+    query_data.cc
+    query_data.h
+    reference_set.cc
+    reference_set.h
+  DEPENDS
+    absl_strings
+    firebase_firestore_core_query
+    firebase_firestore_immutable
+    firebase_firestore_model
+    firebase_firestore_remote_serializer
+  EXCLUDE_FROM_ALL
+)
+
+
+cc_library(
   firebase_firestore_local_persistence_leveldb
   SOURCES
     leveldb_index_manager.cc
@@ -43,7 +69,9 @@ cc_library(
     protobuf-nanopb-static
 
     LevelDB::LevelDB
+    absl_memory
     absl_strings
+    firebase_firestore_local_base
     firebase_firestore_model
     firebase_firestore_nanopb
     firebase_firestore_protos_nanopb
@@ -54,25 +82,16 @@ cc_library(
 cc_library(
   firebase_firestore_local
   SOURCES
-    document_key_reference.cc
-    document_key_reference.h
-    index_manager.h
     listen_sequence.h
     local_documents_view.cc
     local_documents_view.h
-    local_serializer.cc
-    local_serializer.h
     local_store.cc
     local_store.h
     local_view_changes.cc
     local_view_changes.h
     local_write_result.h
-    lru_garbage_collector.cc
-    lru_garbage_collector.h
     memory_eager_reference_delegate.cc
     memory_eager_reference_delegate.h
-    memory_index_manager.cc
-    memory_index_manager.h
     memory_lru_reference_delegate.cc
     memory_lru_reference_delegate.h
     memory_mutation_queue.cc
@@ -88,12 +107,8 @@ cc_library(
     proto_sizer.cc
     proto_sizer.h
     query_cache.h
-    query_data.cc
-    query_data.h
     query_engine.h
     reference_delegate.h
-    reference_set.cc
-    reference_set.h
     remote_document_cache.h
     simple_query_engine.cc
     simple_query_engine.h
@@ -104,10 +119,13 @@ cc_library(
 
     absl_strings
     firebase_firestore_auth
+    firebase_firestore_core_query
+    firebase_firestore_core_target_id_generator
+    firebase_firestore_core_view
+    firebase_firestore_local_base
     firebase_firestore_local_persistence_leveldb
     firebase_firestore_model
     firebase_firestore_nanopb
     firebase_firestore_protos_nanopb
-    firebase_firestore_remote
     firebase_firestore_util
 )

--- a/Firestore/core/src/firebase/firestore/nanopb/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/nanopb/CMakeLists.txt
@@ -13,17 +13,27 @@
 # limitations under the License.
 
 cc_library(
-  firebase_firestore_nanopb
+  firebase_firestore_nanopb_runtime
   SOURCES
     byte_string.cc
     byte_string.h
-    fields_array.h
-    message.cc
-    message.h
     nanopb_util.cc
     nanopb_util.h
     pretty_printing.cc
     pretty_printing.h
+
+  DEPENDS
+    absl_strings
+    firebase_firestore_util
+    protobuf-nanopb-static
+)
+
+cc_library(
+  firebase_firestore_nanopb
+  SOURCES
+    fields_array.h
+    message.cc
+    message.h
     reader.cc
     reader.h
     writer.cc
@@ -32,9 +42,9 @@ cc_library(
     # TODO(b/111328563) Force nanopb first to work around ODR violations
     protobuf-nanopb-static
 
-    firebase_firestore_model
-    firebase_firestore_util
+    firebase_firestore_nanopb_runtime
     firebase_firestore_protos_nanopb
+    firebase_firestore_util
     grpc++
 )
 

--- a/Firestore/core/src/firebase/firestore/remote/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/remote/CMakeLists.txt
@@ -64,13 +64,8 @@ add_custom_command(
 # TODO(wilhuff): Build grpc_root_certificate_finder_apple.mm NOLINT(not built)
 
 cc_library(
-  firebase_firestore_remote
+  firebase_firestore_remote_grpc
   SOURCES
-    datastore.cc
-    datastore.h
-    existence_filter.h
-    exponential_backoff.cc
-    exponential_backoff.h
     grpc_call.h
     grpc_completion.cc
     grpc_completion.h
@@ -92,16 +87,20 @@ cc_library(
     grpc_util.cc
     grpc_util.cc
     grpc_util.h
-    online_state_tracker.cc
-    online_state_tracker.h
-    remote_event.cc
-    remote_event.h
-    remote_objc_bridge.cc
-    remote_objc_bridge.h
-    remote_store.cc
-    remote_store.h
-    serializer.cc
-    serializer.h
+  DEPENDS
+    absl_optional
+    firebase_firestore_nanopb
+    firebase_firestore_protos_nanopb
+    firebase_firestore_version
+    grpc++
+    protobuf-nanopb-static
+)
+
+cc_library(
+  firebase_firestore_remote_datastore
+  SOURCES
+    datastore.cc
+    datastore.h
     stream.cc
     stream.h
     watch_change.cc
@@ -110,18 +109,49 @@ cc_library(
     watch_stream.h
     write_stream.cc
     write_stream.h
+  DEPENDS
+    absl_strings
+    firebase_firestore_remote_grpc
+)
+
+cc_library(
+  firebase_firestore_remote_serializer
+  SOURCES
+    serializer.cc
+    serializer.h
+  DEPENDS
+    firebase_firestore_core_query
+    firebase_firestore_model
+    protobuf-nanopb-static
+)
+
+cc_library(
+  firebase_firestore_remote
+  SOURCES
+    existence_filter.h
+    exponential_backoff.cc
+    exponential_backoff.h
+    online_state_tracker.cc
+    online_state_tracker.h
+    remote_event.cc
+    remote_event.h
+    remote_objc_bridge.cc
+    remote_objc_bridge.h
+    remote_store.cc
+    remote_store.h
 
   DEPENDS
     # TODO(b/111328563) Force nanopb first to work around ODR violations
     protobuf-nanopb-static
 
-    firebase_firestore_core
+    firebase_firestore_core_transaction
+    firebase_firestore_local
     firebase_firestore_model
     firebase_firestore_nanopb
     firebase_firestore_protos_nanopb
     firebase_firestore_remote_connectivity_monitor
+    firebase_firestore_remote_datastore
+    firebase_firestore_remote_serializer
     firebase_firestore_util
     firebase_firestore_version
-
-    grpc++
 )

--- a/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
+++ b/Firestore/core/src/firebase/firestore/util/CMakeLists.txt
@@ -208,6 +208,8 @@ cc_select(
 cc_library(
   firebase_firestore_util_status
   SOURCES
+    error_apple.h
+    error_apple.mm
     status.cc
     status.h
     status_apple.mm
@@ -253,8 +255,6 @@ cc_library(
     config.h
     delayed_constructor.h
     empty.h
-    error_apple.h
-    error_apple.mm
     equality.h
     hashing.h
     iterator_adaptors.h

--- a/Firestore/core/test/firebase/firestore/testutil/CMakeLists.txt
+++ b/Firestore/core/test/firebase/firestore/testutil/CMakeLists.txt
@@ -60,7 +60,7 @@ if(APPLE AND XCTest_FOUND)
     SOURCES
       xcgmock_test.mm
     DEPENDS
-      firebase_firestore_objc_api
+      FirebaseFirestore
       firebase_firestore_testutil
   )
 endif()

--- a/cmake/cc_rules.cmake
+++ b/cmake/cc_rules.cmake
@@ -272,7 +272,7 @@ endfunction()
 # If SOURCES is not included, a dummy file will be generated.
 function(objc_framework target)
   if(APPLE)
-    set(flag EXCLUDE_FROM_ALL)
+    set(flag SHARED EXCLUDE_FROM_ALL)
     set(single VERSION)
     set(multi DEPENDS DEFINES HEADERS INCLUDES SOURCES)
     cmake_parse_arguments(of "${flag}" "${single}" "${multi}" ${ARGN})
@@ -281,9 +281,13 @@ function(objc_framework target)
       generate_dummy_source(${target} of_SOURCES)
     endif()
 
+    if(of_SHARED)
+      set(of_SHARED_FLAG SHARED)
+    endif()
+
     add_library(
       ${target}
-      STATIC
+      ${of_SHARED_FLAG}
       ${of_HEADERS}
       ${of_SOURCES}
     )

--- a/cmake/cc_rules.cmake
+++ b/cmake/cc_rules.cmake
@@ -286,18 +286,18 @@ function(objc_framework target)
     add_library(
       ${target}
       STATIC
+      ${of_HEADERS}
       ${of_SOURCES}
     )
+
+    add_objc_flags(${target} ${of_SOURCES})
 
     set_property(TARGET ${target} PROPERTY PUBLIC_HEADER ${of_HEADERS})
     set_property(TARGET ${target} PROPERTY FRAMEWORK ON)
     set_property(TARGET ${target} PROPERTY VERSION ${of_VERSION})
 
     if(of_EXCLUDE_FROM_ALL)
-      set_property(
-        TARGET ${name}
-        PROPERTY EXCLUDE_FROM_ALL ON
-      )
+      set_property(TARGET ${name} PROPERTY EXCLUDE_FROM_ALL ON)
     endif()
 
     target_compile_definitions(

--- a/cmake/cc_rules.cmake
+++ b/cmake/cc_rules.cmake
@@ -342,6 +342,11 @@ function(objc_framework target)
       PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/${target}.framework/Headers
     )
 
+    target_link_options(
+      ${target} PRIVATE
+      -ObjC
+    )
+
     target_link_libraries(
       ${target} PUBLIC
       ${of_DEPENDS}

--- a/cmake/cc_rules.cmake
+++ b/cmake/cc_rules.cmake
@@ -277,8 +277,6 @@ function(objc_framework target)
     set(multi DEPENDS DEFINES HEADERS INCLUDES SOURCES)
     cmake_parse_arguments(of "${flag}" "${single}" "${multi}" ${ARGN})
 
-    podspec_prep_headers(${target} ${of_HEADERS})
-
     if (NOT cf_SOURCES)
       generate_dummy_source(${target} of_SOURCES)
     endif()
@@ -316,10 +314,28 @@ function(objc_framework target)
         -Wno-unused-parameter
     )
 
+    # Include directories are carefully crafted to support the following forms
+    # of import, both before and after the framework is built.
+    #   * #import <Framework/Header.h>
+    #   * #import "Header.h"
+    #
+    # Do not use #import "Firestore/Source/Public/Header.h".
+    podspec_prep_headers(${target} ${of_HEADERS})
     target_include_directories(
       ${target}
-      PUBLIC ${PROJECT_BINARY_DIR}/Headers
+      # Before the framework is built, Framework.framework/Headers isn't
+      # available yet, so use podspec_prep_headers to create symbolic links
+      # fitting the <Framework/Header.h> pattern.
+      PRIVATE ${PROJECT_BINARY_DIR}/Headers
       PRIVATE ${of_INCLUDES}
+
+      # Building the framework copies public headers into it. Unfortunately
+      # these copies defeat Clang's #import deduplication mechanism, so the
+      # podspec_prep_headers versions (and any original locations) must not be
+      # made available to clients of the framework. Clients get the qualified
+      # form through the public header support in Clang's module system, and
+      # unqualified names through this additional entry.
+      PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/${target}.framework/Headers
     )
 
     target_link_libraries(

--- a/cmake/cc_rules.cmake
+++ b/cmake/cc_rules.cmake
@@ -354,6 +354,37 @@ function(objc_framework target)
   endif()
 endfunction()
 
+function(objc_test target)
+  if(APPLE)
+    set(flag EXCLUDE_FROM_ALL)
+    set(single HOST VERSION)
+    set(multi DEPENDS DEFINES HEADERS INCLUDES SOURCES)
+    cmake_parse_arguments(ot "${flag}" "${single}" "${multi}" ${ARGN})
+
+    xctest_add_bundle(
+      ${target}
+      ${ot_HOST}
+      ${ot_SOURCES}
+    )
+
+    add_objc_flags(
+      ${target}
+      ${ot_SOURCES}
+    )
+
+    target_link_libraries(
+      ${target}
+      PRIVATE
+        ${ot_DEPENDS}
+    )
+
+    xctest_add_test(
+      ${target}
+      ${target}
+    )
+  endif()
+endfunction()
+
 # generate_dummy_source(name, sources_list)
 #
 # Generates a dummy source file containing a single symbol, suitable for use as


### PR DESCRIPTION
This implements a bunch of the feedback I called for in #4276, plus

  * Fixed `objc_framework`'s header copying
  * Added an `objc_test` rule to reduce verbosity
  * Added `GoogleService-Info.plist` as a resource to the example get tests that needed it working
  * Worked around categories not loading in `XCTest+Await`
  * Added Objective-C unit tests for `API` as well

Note that this is based on and intends to merge into #4276. We'll deal with other merges after.