### PR TITLE
Fix FirebasePod test

### DIFF
--- a/CoreOnly/Tests/FirebasePodTest/Podfile
+++ b/CoreOnly/Tests/FirebasePodTest/Podfile
@@ -24,6 +24,13 @@ target 'FirebasePodTest' do
   pod 'FirebaseRemoteConfig', :path => '../../../'
   pod 'FirebaseStorage', :path => '../../../'
 
+  # Get dependent pods from the repo also
+  pod 'FirebaseCoreDiagnostics', :path => '../../../'
+  pod 'FirebaseCoreDiagnosticsInterop', :path => '../../../'
+  pod 'GoogleDataTransport', :path => '../../../'
+  pod 'GoogleDataTransportCCTSupport', :path => '../../../'
+  pod 'GoogleUtilities', :path => '../../../'
+
   pod 'FirebaseAnalytics' # Analytics is not open source
   pod 'FirebasePerformance' # Performance is not open source
 end


### PR DESCRIPTION
dependent pods need to come from the repo also, so that version updates stay in sync across pods.