### PR TITLE
Add +[FIRServerValues increment:]

### DIFF
--- a/Example/Database/Tests/Integration/FData.m
+++ b/Example/Database/Tests/Integration/FData.m
@@ -21,6 +21,7 @@
 #import "FEventTester.h"
 #import "FIRDatabaseConfig_Private.h"
 #import "FIRDatabaseQuery_Private.h"
+#import "FIRServerValue_unreleased.h"
 #import "FRepo_Private.h"
 #import "FTestHelpers.h"
 #import "FTupleEventTypeString.h"
@@ -2571,7 +2572,7 @@
   WAIT_FOR(done);
 }
 
-- (void)testLocalServerValuesEventuallyButNotImmediatelyMatchServer {
+- (void)testLocalServerTimestampEventuallyButNotImmediatelyMatchServer {
   FTupleFirebase *refs = [FTestHelpers getRandomNodePair];
   FIRDatabaseReference *writer = refs.one;
   FIRDatabaseReference *reader = refs.two;
@@ -2635,7 +2636,7 @@
                         @"Eventual reader and writer priorities should be equal");
 }
 
-- (void)testServerValuesSetWithPriorityRemoteEvents {
+- (void)testServerTimestampSetWithPriorityRemoteEvents {
   FTupleFirebase *refs = [FTestHelpers getRandomNodePair];
   FIRDatabaseReference *writer = refs.one;
   FIRDatabaseReference *reader = refs.two;
@@ -2676,7 +2677,7 @@
        }];
 }
 
-- (void)testServerValuesSetPriorityRemoteEvents {
+- (void)testServerTimestampSetPriorityRemoteEvents {
   FTupleFirebase *refs = [FTestHelpers getRandomNodePair];
   FIRDatabaseReference *writer = refs.one;
   FIRDatabaseReference *reader = refs.two;
@@ -2708,7 +2709,7 @@
                 @"Number should be no more than 2 seconds ago");
 }
 
-- (void)testServerValuesUpdateRemoteEvents {
+- (void)testServerTimestampUpdateRemoteEvents {
   FTupleFirebase *refs = [FTestHelpers getRandomNodePair];
   FIRDatabaseReference *writer = refs.one;
   FIRDatabaseReference *reader = refs.two;
@@ -2738,7 +2739,7 @@
                 @"Number should be no more than 2 seconds ago");
 }
 
-- (void)testServerValuesSetWithPriorityLocalEvents {
+- (void)testServerTimestampSetWithPriorityLocalEvents {
   FIRDatabaseReference *node = [FTestHelpers getRandomNode];
 
   NSDictionary *data = @{
@@ -2783,7 +2784,7 @@
        }];
 }
 
-- (void)testServerValuesSetPriorityLocalEvents {
+- (void)testServerTimestampSetPriorityLocalEvents {
   FIRDatabaseReference *node = [FTestHelpers getRandomNode];
 
   __block FIRDataSnapshot *snap = nil;
@@ -2812,7 +2813,7 @@
                 @"Number should be no more than 2 seconds ago");
 }
 
-- (void)testServerValuesUpdateLocalEvents {
+- (void)testServerTimestampUpdateLocalEvents {
   FIRDatabaseReference *node1 = [FTestHelpers getRandomNode];
 
   __block FIRDataSnapshot *snap1 = nil;
@@ -2849,7 +2850,7 @@
                 @"Number should be no more than 2 seconds ago");
 }
 
-- (void)testServerValuesTransactionLocalEvents {
+- (void)testServerTimestampTransactionLocalEvents {
   FIRDatabaseReference *node = [FTestHelpers getRandomNode];
 
   __block FIRDataSnapshot *snap = nil;
@@ -2871,6 +2872,137 @@
                 @"Should get back number");
   XCTAssertTrue([now doubleValue] - [timestamp doubleValue] < 2000,
                 @"Number should be no more than 2 seconds ago");
+}
+
+- (void)testServerIncrementOverwritesExistingData {
+  FIRDatabaseReference *ref = [FTestHelpers getRandomNode];
+  __block NSMutableArray *found = [NSMutableArray new];
+  NSMutableArray *expected = [NSMutableArray new];
+  [ref observeEventType:FIRDataEventTypeValue
+              withBlock:^(FIRDataSnapshot *snap) {
+                [found addObject:snap.value];
+              }];
+
+  // Going offline ensures that local events get queued up before server events
+  [ref.repo interrupt];
+
+  // null + incr
+  [ref setValue:[FIRServerValue increment:@1]];
+  [expected addObject:@1];
+
+  // number + incr
+  [ref setValue:@5];
+  [ref setValue:[FIRServerValue increment:@1]];
+  [expected addObject:@5];
+  [expected addObject:@6];
+
+  // string + incr
+  [ref setValue:@"hello"];
+  [ref setValue:[FIRServerValue increment:@1]];
+  [expected addObject:@"hello"];
+  [expected addObject:@1];
+
+  // object + incr
+  [ref setValue:@{@"hello" : @"world"}];
+  [ref setValue:[FIRServerValue increment:@1]];
+  [expected addObject:@{@"hello" : @"world"}];
+  [expected addObject:@1];
+
+  [self waitUntil:^BOOL {
+    return found.count == expected.count;
+  }];
+  XCTAssertEqualObjects(expected, found);
+  [ref.repo resume];
+}
+
+- (void)testServerIncrementPriority {
+  FIRDatabaseReference *ref = [FTestHelpers getRandomNode];
+  __block NSMutableArray *found = [NSMutableArray new];
+  NSMutableArray *expected = [NSMutableArray new];
+  [ref observeEventType:FIRDataEventTypeValue
+              withBlock:^(FIRDataSnapshot *snap) {
+                [found addObject:snap.priority];
+              }];
+
+  // Going offline ensures that local events get queued up before server events
+  // Also necessary because increment may not be live yet in the server.
+  [ref.repo interrupt];
+
+  // null + incr
+  [ref setValue:@0 andPriority:[FIRServerValue increment:@1]];
+  [expected addObject:@1];
+  [ref setValue:@0 andPriority:[FIRServerValue increment:@1.5]];
+  [expected addObject:@2.5];
+
+  [self waitUntil:^BOOL {
+    return found.count == expected.count;
+  }];
+  XCTAssertEqualObjects(expected, found);
+  [ref.repo resume];
+}
+
+- (void)testServerIncrementOverflowAndTypeCoercion {
+  FIRDatabaseReference *ref = [FTestHelpers getRandomNode];
+  __block NSMutableArray *found = [NSMutableArray new];
+  __block NSMutableArray *foundTypes = [NSMutableArray new];
+  NSMutableArray *expected = [NSMutableArray new];
+  NSMutableArray *expectedTypes = [NSMutableArray new];
+  [ref observeEventType:FIRDataEventTypeValue
+              withBlock:^(FIRDataSnapshot *snap) {
+                [found addObject:snap.value];
+                [foundTypes addObject:@([(NSNumber *)snap.value objCType])];
+              }];
+
+  // Going offline ensures that local events get queued up before server events
+  // Also necessary because increment may not be live yet in the server.
+  [ref.repo interrupt];
+
+  // long + double = double
+  [ref setValue:@1];
+  [ref setValue:[FIRServerValue increment:@1.0]];
+  [expected addObject:@1];
+  [expected addObject:@2.0];
+  [expectedTypes addObject:@(@encode(int))];
+  [expectedTypes addObject:@(@encode(double))];
+
+  // double + long = double
+  [ref setValue:@1.5];
+  [ref setValue:[FIRServerValue increment:@1]];
+  [expected addObject:@1.5];
+  [expected addObject:@2.5];
+  [expectedTypes addObject:@(@encode(double))];
+  [expectedTypes addObject:@(@encode(double))];
+
+  // long overflow = double
+  [ref setValue:@(1)];
+  [ref setValue:[FIRServerValue increment:@(LONG_MAX)]];
+  [expected addObject:@(1)];
+  [expected addObject:@(LONG_MAX + 1.0)];
+  [expectedTypes addObject:@(@encode(int))];
+  [expectedTypes addObject:@(@encode(double))];
+
+  // unsigned long long overflow = double
+  [ref setValue:@1];
+  [ref setValue:[FIRServerValue increment:@((unsigned long long)ULLONG_MAX)]];
+  [expected addObject:@1];
+  [expected addObject:@((double)ULLONG_MAX + 1)];
+  [expectedTypes addObject:@(@encode(int))];
+  [expectedTypes addObject:@(@encode(double))];
+
+  // long underflow = double
+  [ref setValue:@(-1)];
+  [ref setValue:[FIRServerValue increment:@(LONG_MIN)]];
+  [expected addObject:@(-1)];
+  [expected addObject:@(LONG_MIN - 1.0)];
+  [expectedTypes addObject:@(@encode(int))];
+  [expectedTypes addObject:@(@encode(double))];
+
+  [self waitUntil:^BOOL {
+    return found.count == expected.count && foundTypes.count == expectedTypes.count;
+  }];
+  XCTAssertEqualObjects(expectedTypes, foundTypes);
+  XCTAssertEqualObjects(expected, found);
+  [ref.repo resume];
 }
 
 - (void)testUpdateAfterChildSet {
@@ -2949,7 +3081,7 @@
   [FRepoManager disposeRepos:cfg];
 }
 
-- (void)testServerValuesEventualConsistencyBetweenLocalAndRemote {
+- (void)testServerTimestampEventualConsistencyBetweenLocalAndRemote {
   FTupleFirebase *refs = [FTestHelpers getRandomNodePair];
   FIRDatabaseReference *writer = refs.one;
   FIRDatabaseReference *reader = refs.two;

--- a/Firebase/Database/Api/FIRServerValue.m
+++ b/Firebase/Database/Api/FIRServerValue.m
@@ -15,7 +15,7 @@
  */
 
 #import "FIRServerValue.h"
-#import "FIRDatabaseReference.h"
+#import "FIRServerValue_unreleased.h"
 
 @implementation FIRServerValue
 
@@ -25,6 +25,10 @@
         timestamp = @{@".sv" : @"timestamp"};
     }
     return timestamp;
+}
+
++ (NSDictionary *)increment:(NSNumber *)delta {
+    return @{@".sv" : @{@"increment" : delta}};
 }
 
 @end

--- a/Firebase/Database/Api/FIRServerValue_unreleased.h
+++ b/Firebase/Database/Api/FIRServerValue_unreleased.h
@@ -24,12 +24,13 @@
 /**
  * Adds the given delta to the current value at a location.
  *
- * The delta must be an long or a double value. If the current value is not an integer or
- * double, or if the data does not yet exist, the transformation will set the data
- * to the delta value. If either of the delta value or the existing data
- * are doubles, both values will be interpreted as doubles. Double arithmetic
- * and representation of double values follow IEEE 754 semantics. If there is
- * positive/negative integer overflow, the sum is calculated as a  a double.
+ * The delta must be an long or a double value. If the current value is not an
+ * integer or double, or if the data does not yet exist, the transformation will
+ * set the data to the delta value. If either of the delta value or the existing
+ * data are doubles, both values will be interpreted as doubles. Double
+ * arithmetic and representation of double values follow IEEE 754 semantics. If
+ * there is positive/negative integer overflow, the sum is calculated as a  a
+ * double.
  *
  * @param delta the amount to modify the current value atomically.
  * @return a placeholder value for modifying data atomically server-side.

--- a/Firebase/Database/Api/FIRServerValue_unreleased.h
+++ b/Firebase/Database/Api/FIRServerValue_unreleased.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRServerValue_unreleased_h
+#define FIRServerValue_unreleased_h
+
+#import "FIRServerValue.h"
+
+@interface FIRServerValue (Unreleased)
+
+/**
+ * Adds the given delta to the ref's current value.
+ *
+ * This must be an long or a double value. If the ref is not an integer or
+ * double, or if the ref does not yet exist, the transformation will set the ref
+ * to the given value. If either of the given value or the current field value
+ * are doubles, both values will be interpreted as doubles. Double arithmetic
+ * and representation of double values follow IEEE 754 semantics. If there is
+ * positive/negative integer overflow, the field is resolved to a double.
+ * @param delta the amount to modify the ref's current value atomically.
+ * @return a placeholder value for modifying a ref atomically server-side.
+ */
++ (NSDictionary *)increment:(NSNumber *)delta NS_SWIFT_NAME(increment(_:));
+
+@end
+
+#endif /* FIRServerValue_unreleased_h */

--- a/Firebase/Database/Api/FIRServerValue_unreleased.h
+++ b/Firebase/Database/Api/FIRServerValue_unreleased.h
@@ -22,16 +22,17 @@
 @interface FIRServerValue (Unreleased)
 
 /**
- * Adds the given delta to the ref's current value.
+ * Adds the given delta to the current value at a location.
  *
- * This must be an long or a double value. If the ref is not an integer or
- * double, or if the ref does not yet exist, the transformation will set the ref
- * to the given value. If either of the given value or the current field value
+ * The delta must be an long or a double value. If the current value is not an integer or
+ * double, or if the data does not yet exist, the transformation will set the data
+ * to the delta value. If either of the delta value or the existing data
  * are doubles, both values will be interpreted as doubles. Double arithmetic
  * and representation of double values follow IEEE 754 semantics. If there is
- * positive/negative integer overflow, the field is resolved to a double.
- * @param delta the amount to modify the ref's current value atomically.
- * @return a placeholder value for modifying a ref atomically server-side.
+ * positive/negative integer overflow, the sum is calculated as a  a double.
+ *
+ * @param delta the amount to modify the current value atomically.
+ * @return a placeholder value for modifying data atomically server-side.
  */
 + (NSDictionary *)increment:(NSNumber *)delta NS_SWIFT_NAME(increment(_:));
 

--- a/Firebase/Database/Core/FServerValues.h
+++ b/Firebase/Database/Core/FServerValues.h
@@ -24,10 +24,13 @@
 
 + (NSDictionary *)generateServerValues:(id<FClock>)clock;
 + (id)resolveDeferredValueCompoundWrite:(FCompoundWrite *)write
-                       withServerValues:(NSDictionary *)serverValues;
+                           withExisting:(id<FNode>)existing
+                           serverValues:(NSDictionary *)serverValues;
 + (id<FNode>)resolveDeferredValueSnapshot:(id<FNode>)node
-                         withServerValues:(NSDictionary *)serverValues;
+                             withExisting:(id<FNode>)existing
+                             serverValues:(NSDictionary *)serverValues;
 + (id)resolveDeferredValueTree:(FSparseSnapshotTree *)tree
-              withServerValues:(NSDictionary *)serverValues;
+                  withExisting:(id<FNode>)node
+                  serverValues:(NSDictionary *)serverValues;
 
 @end

--- a/Firebase/Database/Core/FServerValues.m
+++ b/Firebase/Database/Core/FServerValues.m
@@ -103,15 +103,15 @@ BOOL canBeRepresentedAsLong(NSNumber *num) {
     BOOL baseLong = canBeRepresentedAsLong(existingNum);
 
     if (incrLong && baseLong) {
-      long x = delta.longValue;
-      long y = existingNum.longValue;
-      long r = x + y;
+        long x = delta.longValue;
+        long y = existingNum.longValue;
+        long r = x + y;
 
-      // See "Hacker's Delight" 2-12: Overflow if both arguments have the opposite
-      // sign of the result
-      if (((x ^ r) & (y ^ r)) >= 0) {
-          return @(r);
-      }
+        // See "Hacker's Delight" 2-12: Overflow if both arguments have the
+        // opposite sign of the result
+        if (((x ^ r) & (y ^ r)) >= 0) {
+            return @(r);
+        }
     }
     return @(delta.doubleValue + existingNum.doubleValue);
 }

--- a/Firebase/Database/Core/FServerValues.m
+++ b/Firebase/Database/Core/FServerValues.m
@@ -20,37 +20,118 @@
 #import "FLeafNode.h"
 #import "FSnapshotUtilities.h"
 
+const NSString *kTimestamp = @"timestamp";
+const NSString *kIncrement = @"increment";
+
+BOOL longCanHold(NSNumber *num) {
+    switch (num.objCType[0]) {
+    case 'f': // float; fallthrough
+    case 'd': // double
+        break;
+    case 'L': // unsigned long; fallthrough
+    case 'Q': // unsigned long long; fallthrough
+        // Only use ulong(long) if there isn't an overflow.
+        if (num.unsignedLongLongValue > LONG_MAX) {
+            break;
+        }
+    default:
+        return YES;
+    }
+    return NO;
+}
+
+NSNumber *overflowAwareAddLong(long x, long y) {
+    long r = x + y;
+
+    // See "Hacker's Delight" 2-12: Overflow if both arguments have the opposite
+    // sign of the result
+    if (((x ^ r) & (y ^ r)) >= 0) {
+        return @(r);
+    }
+
+  return [NSNumber numberWithDouble:(double)x + y];
+}
+
+@interface FServerValues ()
++ (id)resolveScalarServerOp:(NSString *)op
+           withServerValues:(NSDictionary *)serverValues;
++ (id)resolveComplexServerOp:(NSDictionary *)op
+                withExisting:(id<FNode>)existing
+                serverValues:(NSDictionary *)serverValues;
+@end
+
 @implementation FServerValues
 
 + (NSDictionary *)generateServerValues:(id<FClock>)clock {
     long long millis = (long long)([clock currentTime] * 1000);
-    return @{@"timestamp" : [NSNumber numberWithLongLong:millis]};
+    return @{kTimestamp : [NSNumber numberWithLongLong:millis]};
 }
 
 + (id)resolveDeferredValue:(id)val
-          withServerValues:(NSDictionary *)serverValues {
-    if ([val isKindOfClass:[NSDictionary class]]) {
-        NSDictionary *dict = val;
-        if (dict[kServerValueSubKey] != nil) {
-            NSString *serverValueType = [dict objectForKey:kServerValueSubKey];
-            if (serverValues[serverValueType] != nil) {
-                return [serverValues objectForKey:serverValueType];
-            } else {
-                // TODO: Throw unrecognizedServerValue error here
-            }
-        }
+              withExisting:(id<FNode>)existing
+              serverValues:(NSDictionary *)serverValues {
+    if (![val isKindOfClass:[NSDictionary class]]) {
+        return val;
+    }
+    NSDictionary *dict = val;
+    id op = dict[kServerValueSubKey];
+
+    if (op == nil) {
+        return val;
+    } else if ([op isKindOfClass:NSString.class]) {
+        return [FServerValues resolveScalarServerOp:op
+                                   withServerValues:serverValues];
+    } else if ([op isKindOfClass:NSDictionary.class]) {
+        return [FServerValues resolveComplexServerOp:op
+                                        withExisting:existing
+                                        serverValues:serverValues];
     }
     return val;
 }
 
++ (id)resolveScalarServerOp:(NSString *)op
+           withServerValues:(NSDictionary *)serverValues {
+    return serverValues[op];
+}
+
++ (id)resolveComplexServerOp:(NSDictionary *)op
+                withExisting:(id<FNode>)existing
+                serverValues:(NSDictionary *)serverValues {
+    // Only increment is supported as of now
+    if (op[kIncrement] == nil) {
+        return nil;
+    }
+
+    // Incrementing a non-number sets the value to the incremented amount
+    NSNumber *delta = op[kIncrement];
+    if (![existing isLeafNode]) {
+        return delta;
+    }
+    FLeafNode *existingLeaf = existing;
+    if (![existingLeaf.value isKindOfClass:NSNumber.class]) {
+        return delta;
+    }
+
+    NSNumber *existingNum = existingLeaf.value;
+    BOOL incrLong = longCanHold(delta);
+    BOOL baseLong = longCanHold(existingNum);
+
+    if (incrLong && baseLong) {
+      return overflowAwareAddLong(delta.longValue, existingNum.longValue);
+    }
+    return @(delta.doubleValue + existingNum.doubleValue);
+}
+
 + (FCompoundWrite *)resolveDeferredValueCompoundWrite:(FCompoundWrite *)write
-                                     withServerValues:
-                                         (NSDictionary *)serverValues {
+                                         withExisting:(id<FNode>)existing
+                                         serverValues:
+                                             (NSDictionary *)serverValues {
     __block FCompoundWrite *resolved = write;
     [write enumerateWrites:^(FPath *path, id<FNode> node, BOOL *stop) {
       id<FNode> resolvedNode =
           [FServerValues resolveDeferredValueSnapshot:node
-                                     withServerValues:serverValues];
+                                         withExisting:existing
+                                         serverValues:serverValues];
       // Node actually changed, use pointer inequality here
       if (resolvedNode != node) {
           resolved = [resolved addWrite:resolvedNode atPath:path];
@@ -60,7 +141,8 @@
 }
 
 + (id)resolveDeferredValueTree:(FSparseSnapshotTree *)tree
-              withServerValues:(NSDictionary *)serverValues {
+                  withExisting:(id<FNode>)existing
+                  serverValues:(NSDictionary *)serverValues {
     FSparseSnapshotTree *resolvedTree = [[FSparseSnapshotTree alloc] init];
     [tree
         forEachTreeAtPath:[FPath empty]
@@ -69,22 +151,28 @@
                              rememberData:
                                  [FServerValues
                                      resolveDeferredValueSnapshot:node
-                                                 withServerValues:serverValues]
+                                                     withExisting:
+                                                         [existing
+                                                             getChild:path]
+                                                     serverValues:serverValues]
                                    onPath:path];
                        }];
     return resolvedTree;
 }
 
 + (id<FNode>)resolveDeferredValueSnapshot:(id<FNode>)node
-                         withServerValues:(NSDictionary *)serverValues {
+                             withExisting:(id<FNode>)existing
+                             serverValues:(NSDictionary *)serverValues {
     id priorityVal =
         [FServerValues resolveDeferredValue:[[node getPriority] val]
-                           withServerValues:serverValues];
+                               withExisting:existing.getPriority
+                               serverValues:serverValues];
     id<FNode> priority = [FSnapshotUtilities nodeFrom:priorityVal];
 
     if ([node isLeafNode]) {
         id value = [self resolveDeferredValue:[node val]
-                             withServerValues:serverValues];
+                                 withExisting:existing
+                                 serverValues:serverValues];
         if (![value isEqual:[node val]] ||
             ![priority isEqual:[node getPriority]]) {
             return [[FLeafNode alloc] initWithValue:value
@@ -100,9 +188,10 @@
 
         [node enumerateChildrenUsingBlock:^(NSString *childKey,
                                             id<FNode> childNode, BOOL *stop) {
-          id newChildNode =
-              [FServerValues resolveDeferredValueSnapshot:childNode
-                                         withServerValues:serverValues];
+          id newChildNode = [FServerValues
+              resolveDeferredValueSnapshot:childNode
+                              withExisting:[existing getImmediateChild:childKey]
+                              serverValues:serverValues];
           if (![newChildNode isEqual:childNode]) {
               newNode = [newNode updateImmediateChild:childKey
                                          withNewChild:newChildNode];

--- a/Firebase/Database/Core/FSyncTree.m
+++ b/Firebase/Database/Core/FSyncTree.m
@@ -231,16 +231,20 @@ static const NSUInteger kFSizeThresholdForCompoundHash = 1024;
         if (!revert) {
             NSDictionary *serverValues =
                 [FServerValues generateServerValues:clock];
+            id<FNode> existing = [self calcCompleteEventCacheAtPath:write.path
+                                                    excludeWriteIds:@[]];
             if ([write isOverwrite]) {
                 id<FNode> resolvedNode =
                     [FServerValues resolveDeferredValueSnapshot:write.overwrite
-                                               withServerValues:serverValues];
+                                                   withExisting:existing
+                                                   serverValues:serverValues];
                 [self.persistenceManager applyUserWrite:resolvedNode
                                     toServerCacheAtPath:write.path];
             } else {
                 FCompoundWrite *resolvedMerge = [FServerValues
                     resolveDeferredValueCompoundWrite:write.merge
-                                     withServerValues:serverValues];
+                                         withExisting:existing
+                                         serverValues:serverValues];
                 [self.persistenceManager applyUserMerge:resolvedMerge
                                     toServerCacheAtPath:write.path];
             }


### PR DESCRIPTION
* Definition is currently in an "unreleased" extension to FIRServerValues
* Functions that resolve server values now need access to any existing snapshot; please help ensure that this is not done wastefully.
* Tests are added to FData.m (integration tests); please let me know if a more appropriate place exists.
* Some tests are renamed to make it clear that ServerValues != timestamps