### PR TITLE
Lock OCMock to 3.4 while investigating test failures with 3.5.0

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -25,7 +25,7 @@ target 'Core_Example_iOS' do
 
   target 'Core_Tests_iOS' do
     inherit! :search_paths
-    pod 'OCMock'
+    pod 'OCMock', '~> 3.4.0'
   end
 end
 
@@ -36,7 +36,7 @@ target 'Auth_Example_iOS' do
 
   target 'Auth_Tests_iOS' do
     inherit! :search_paths
-    pod 'OCMock'
+    pod 'OCMock', '~> 3.4.0'
   end
 end
 
@@ -63,7 +63,7 @@ target 'DynamicLinks_Example_iOS' do
 
   target 'DynamicLinks_Tests_iOS' do
     inherit! :search_paths
-    pod 'OCMock'
+    pod 'OCMock', '~> 3.4.0'
   end
 end
 
@@ -85,7 +85,7 @@ target 'InstanceID_Example_iOS' do
 
   target 'InstanceID_Tests_iOS' do
     inherit! :search_paths
-    pod 'OCMock'
+    pod 'OCMock', '~> 3.4.0'
   end
 end
 
@@ -96,7 +96,7 @@ target 'Messaging_Example_iOS' do
 
   target 'Messaging_Tests_iOS' do
     inherit! :search_paths
-    pod 'OCMock'
+    pod 'OCMock', '~> 3.4.0'
   end
 end
 
@@ -118,7 +118,7 @@ target 'Storage_Example_iOS' do
 
   target 'Storage_Tests_iOS' do
     inherit! :search_paths
-    pod 'OCMock'
+    pod 'OCMock', '~> 3.4.0'
   end
 
   target 'Storage_IntegrationTests_iOS' do

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -45,7 +45,7 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   s.test_spec 'unit' do |unit_tests|
     unit_tests.source_files = 'Example/Core/Tests/**/*.[mh]'
     unit_tests.requires_app_host = true
-    unit_tests.dependency 'OCMock'
+    unit_tests.dependency 'OCMock', '~> 3.4.0'
     unit_tests.resources = 'Example/Core/App/GoogleService-Info.plist'
   end
 end

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -45,7 +45,7 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   s.test_spec 'unit' do |unit_tests|
     unit_tests.source_files = 'Example/Core/Tests/**/*.[mh]'
     unit_tests.requires_app_host = true
-    unit_tests.dependency 'OCMock', '~> 3.4.0'
+    unit_tests.dependency 'OCMock'
     unit_tests.resources = 'Example/Core/App/GoogleService-Info.plist'
   end
 end

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -48,7 +48,7 @@ Pod::Spec.new do |s|
                               base_dir + 'Tests/Utils/**/*.[mh]'
     unit_tests.resources = base_dir + 'Tests/Fixture/**/*'
     unit_tests.requires_app_host = true
-    unit_tests.dependency 'OCMock'
+    unit_tests.dependency 'OCMock', '~> 3.4.0'
     unit_tests.dependency 'FirebaseInstanceID', '~> 4.2.0' # The version before FirebaseInstanceID updated to use FirebaseInstallations under the hood.
 
   end
@@ -63,6 +63,6 @@ Pod::Spec.new do |s|
       }
     end
     int_tests.requires_app_host = true
-    int_tests.dependency 'OCMock'
+    int_tests.dependency 'OCMock', '~> 3.4.0'
   end
 end

--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -44,7 +44,7 @@ services.
   s.test_spec 'unit' do |unit_tests|
     unit_tests.source_files = 'Example/InstanceID/Tests/*.[mh]'
     unit_tests.requires_app_host = true
-    unit_tests.dependency 'OCMock'
+    unit_tests.dependency 'OCMock', '~> 3.4.0'
     unit_tests.pod_target_xcconfig = {
       # Unit tests do library imports using repo-root relative paths.
       'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -57,6 +57,6 @@ device, and it is completely free.
     unit_tests.pod_target_xcconfig = {
      'CLANG_ENABLE_OBJC_WEAK' => 'YES'
     }
-    unit_tests.dependency 'OCMock'
+    unit_tests.dependency 'OCMock', '~> 3.4.0'
   end
 end

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -67,6 +67,6 @@ app update.
         'FirebaseRemoteConfig/Tests/Unit/Defaults-testInfo.plist',
         'FirebaseRemoteConfig/Tests/Unit/SecondApp-GoogleService-Info.plist'
     unit_tests.requires_app_host = true
-    unit_tests.dependency 'OCMock'
+    unit_tests.dependency 'OCMock', '~> 3.4.0'
   end
 end

--- a/GoogleUtilitiesComponents.podspec
+++ b/GoogleUtilitiesComponents.podspec
@@ -35,6 +35,6 @@ Not intended for direct public usage.
     unit_tests.source_files = 'GoogleUtilitiesComponents/Tests/**/*.[mh]'
     unit_tests.requires_arc = 'GoogleUtilitiesComponents/Tests/*/*.[mh]'
     unit_tests.requires_app_host = true
-    unit_tests.dependency 'OCMock'
+    unit_tests.dependency 'OCMock', '~> 3.4.0'
   end
 end

--- a/InAppMessaging/Example/Podfile
+++ b/InAppMessaging/Example/Podfile
@@ -26,5 +26,5 @@ target 'InAppMessaging_Tests_iOS' do
   pod 'FirebaseInAppMessaging', :path => '../..'
   pod 'FirebaseInstanceID',  :path => '../..'
   pod 'FirebaseAnalyticsInterop',  :path => '../..'
-  pod 'OCMock'
+  pod 'OCMock', '~> 3.4.0'
 end


### PR DESCRIPTION
OCMock caused unit tests to fail in seven libraries.

This PR locks the dependency to 3.4.0 while we investigate.

#no-changelog