### PR TITLE
Fix a few misuse of OCMock in Messaging and InstanceID

### DIFF
--- a/Example/InstanceID/Tests/FIRInstanceIDStoreTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDStoreTest.m
@@ -248,7 +248,7 @@ static NSString *const kSecret = @"test-secret";
   [[niceMockCheckinStore reject]
       removeCheckinPreferencesWithHandler:[OCMArg invokeBlockWithArgs:[NSNull null], nil]];
   // Always setting up stub after expect.
-  OCMStub([_checkinStore cachedCheckinPreferences]).andReturn(nil);
+  OCMStub([_mockCheckinStore cachedCheckinPreferences]).andReturn(nil);
 
   [_instanceIDStore resetCredentialsIfNeeded];
   OCMVerifyAll(niceMockCheckinStore);

--- a/Example/InstanceID/Tests/FIRInstanceIDTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTest.m
@@ -580,7 +580,6 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
   XCTAssertNil([self.mockInstanceID token]);
   OCMVerify([self.mockInstanceID defaultTokenWithHandler:nil]);
   [self.mockInstanceID stopMocking];
-
 }
 
 /**

--- a/Example/InstanceID/Tests/FIRInstanceIDTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTest.m
@@ -578,8 +578,9 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
 
   OCMExpect([self.mockInstanceID defaultTokenWithHandler:nil]);
   XCTAssertNil([self.mockInstanceID token]);
-  [self.mockInstanceID stopMocking];
   OCMVerify([self.mockInstanceID defaultTokenWithHandler:nil]);
+  [self.mockInstanceID stopMocking];
+
 }
 
 /**

--- a/Example/Messaging/Tests/FIRMessagingConnectionTest.m
+++ b/Example/Messaging/Tests/FIRMessagingConnectionTest.m
@@ -207,8 +207,8 @@ static FIRMessagingProtoTag currentProtoSendTag;
          rmqId:[OCMArg isNil]];
 
   // swizzle disconnect socket
-  OCMVerify([[[socketMock stub] andCall:@selector(_disconnectSocket)
-                               onObject:self] disconnect]);
+  [[[socketMock stub] andCall:@selector(_disconnectSocket)
+                     onObject:self] disconnect];
 
   currentProtoSendTag = kFIRMessagingProtoTagLoginRequest;
   // send login request
@@ -217,6 +217,7 @@ static FIRMessagingProtoTag currentProtoSendTag;
   // verify login request sent
   XCTAssertEqual(1, self.fakeConnection.outStreamId);
   XCTAssertTrue(self.didSuccessfullySendData);
+  [socketMock verify];
 }
 
 - (void)testLoginRequest_withPendingMessagesInRmq {

--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -44,7 +44,7 @@ services.
   s.test_spec 'unit' do |unit_tests|
     unit_tests.source_files = 'Example/InstanceID/Tests/*.[mh]'
     unit_tests.requires_app_host = true
-    unit_tests.dependency 'OCMock', '~> 3.4.0'
+    unit_tests.dependency 'OCMock'
     unit_tests.pod_target_xcconfig = {
       # Unit tests do library imports using repo-root relative paths.
       'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -57,6 +57,6 @@ device, and it is completely free.
     unit_tests.pod_target_xcconfig = {
      'CLANG_ENABLE_OBJC_WEAK' => 'YES'
     }
-    unit_tests.dependency 'OCMock', '~> 3.4.0'
+    unit_tests.dependency 'OCMock'
   end
 end


### PR DESCRIPTION
This fixes #4345, #4347.