### PR TITLE
Prefer easy_install to pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
       before_install:
         - brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/e3496d9/Formula/clang-format.rb
         - brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/7963c3d/Formula/swiftformat.rb
-        - pip install flake8
+        - easy_install flake8
       script:
         - ./scripts/check.sh --test-only
 

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -122,7 +122,7 @@ case "$PROJECT-$PLATFORM-$METHOD" in
     brew outdated go || brew upgrade go # Somehow the build for Abseil requires this.
 
     # Install python packages required to generate proto sources
-    pip install six
+    easy_install install six
     ;;
 
   SymbolCollision-*-xcodebuild)


### PR DESCRIPTION
... in Travis scripts, for compatibility with recent changes that removed pip from the base image.