### PR TITLE
Xcode 11.1 instead of 11.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: osx
-osx_image: xcode11.2
+osx_image: xcode11.1
 language: objective-c
 cache:
   - bundler


### PR DESCRIPTION
Fix the `/Users/travis/.travis/functions: line 109: pip: command not found` that broke all travis builds starting yesterday.