### PR TITLE
Fix several small linter issues

### DIFF
--- a/Firestore/core/src/firebase/firestore/core/sync_engine_callback.h
+++ b/Firestore/core/src/firebase/firestore/core/sync_engine_callback.h
@@ -34,6 +34,8 @@ namespace core {
  */
 class SyncEngineCallback {
  public:
+  virtual ~SyncEngineCallback() = default;
+
   /** Handles a change in online state. */
   virtual void HandleOnlineStateChange(model::OnlineState online_state) = 0;
   /** Handles new view snapshots. */

--- a/Firestore/core/src/firebase/firestore/core/user_data.cc
+++ b/Firestore/core/src/firebase/firestore/core/user_data.cc
@@ -24,6 +24,7 @@
 #include "Firestore/core/src/firebase/firestore/model/transform_mutation.h"
 #include "Firestore/core/src/firebase/firestore/model/transform_operation.h"
 #include "Firestore/core/src/firebase/firestore/util/exception.h"
+#include "absl/memory/memory.h"
 #include "absl/strings/match.h"
 
 namespace firebase {

--- a/Firestore/core/src/firebase/firestore/immutable/llrb_node.h
+++ b/Firestore/core/src/firebase/firestore/immutable/llrb_node.h
@@ -22,6 +22,7 @@
 
 #include "Firestore/core/src/firebase/firestore/immutable/llrb_node_iterator.h"
 #include "Firestore/core/src/firebase/firestore/immutable/sorted_container.h"
+#include "Firestore/core/src/firebase/firestore/util/comparison.h"
 
 namespace firebase {
 namespace firestore {

--- a/Firestore/core/src/firebase/firestore/immutable/llrb_node_iterator.h
+++ b/Firestore/core/src/firebase/firestore/immutable/llrb_node_iterator.h
@@ -21,7 +21,6 @@
 #include <stack>
 #include <utility>
 
-#include "Firestore/core/src/firebase/firestore/immutable/llrb_node.h"
 #include "Firestore/core/src/firebase/firestore/util/comparison.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 

--- a/Firestore/core/src/firebase/firestore/local/leveldb_lru_reference_delegate.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_lru_reference_delegate.cc
@@ -25,6 +25,7 @@
 #include "Firestore/core/src/firebase/firestore/local/reference_set.h"
 #include "Firestore/core/src/firebase/firestore/model/resource_path.h"
 #include "Firestore/core/src/firebase/firestore/model/types.h"
+#include "absl/memory/memory.h"
 #include "absl/strings/match.h"
 
 namespace firebase {

--- a/Firestore/core/src/firebase/firestore/local/memory_lru_reference_delegate.cc
+++ b/Firestore/core/src/firebase/firestore/local/memory_lru_reference_delegate.cc
@@ -26,6 +26,7 @@
 #include "Firestore/core/src/firebase/firestore/local/reference_set.h"
 #include "Firestore/core/src/firebase/firestore/local/remote_document_cache.h"
 #include "Firestore/core/src/firebase/firestore/local/sizer.h"
+#include "absl/memory/memory.h"
 
 namespace firebase {
 namespace firestore {

--- a/Firestore/core/src/firebase/firestore/remote/grpc_streaming_reader.cc
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_streaming_reader.cc
@@ -22,6 +22,7 @@
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 #include "Firestore/core/src/firebase/firestore/util/status.h"
 #include "Firestore/core/src/firebase/firestore/util/statusor.h"
+#include "absl/memory/memory.h"
 
 namespace firebase {
 namespace firestore {

--- a/Firestore/core/src/firebase/firestore/remote/remote_store.h
+++ b/Firestore/core/src/firebase/firestore/remote/remote_store.h
@@ -46,6 +46,8 @@ namespace remote {
  */
 class RemoteStoreCallback {
  public:
+  virtual ~RemoteStoreCallback() = default;
+
   /**
    * Applies a remote event to the sync engine, notifying any views of the
    * changes, and releasing any pending mutation batches that would become

--- a/Firestore/core/src/firebase/firestore/remote/watch_stream.h
+++ b/Firestore/core/src/firebase/firestore/remote/watch_stream.h
@@ -43,8 +43,12 @@ class Serializer;
  */
 class WatchStreamCallback {
  public:
-  /** Called by the `WatchStream` when it is ready to accept outbound request
-   * messages. */
+  virtual ~WatchStreamCallback() = default;
+
+  /**
+   * Called by the `WatchStream` when it is ready to accept outbound request
+   * messages.
+   */
   virtual void OnWatchStreamOpen() = 0;
 
   /**

--- a/Firestore/core/src/firebase/firestore/remote/write_stream.h
+++ b/Firestore/core/src/firebase/firestore/remote/write_stream.h
@@ -38,6 +38,8 @@ class Serializer;
 
 class WriteStreamCallback {
  public:
+  virtual ~WriteStreamCallback() = default;
+
   /**
    * Called by the `WriteStream` when it is ready to accept outbound request
    * messages.

--- a/Firestore/core/src/firebase/firestore/util/executor_std.cc
+++ b/Firestore/core/src/firebase/firestore/util/executor_std.cc
@@ -20,6 +20,8 @@
 #include <memory>
 #include <sstream>
 
+#include "absl/memory/memory.h"
+
 namespace firebase {
 namespace firestore {
 namespace util {

--- a/Firestore/core/src/firebase/firestore/util/log_stdio.cc
+++ b/Firestore/core/src/firebase/firestore/util/log_stdio.cc
@@ -25,7 +25,11 @@ namespace firebase {
 namespace firestore {
 namespace util {
 
+namespace {
+
 LogLevel g_log_level = kLogLevelWarning;
+
+}  // namespace
 
 void LogSetLevel(LogLevel level) {
   g_log_level = level;


### PR DESCRIPTION
These fixes allow Firestore to build on Linux with IWYU checks:
* include some headers that are used, mostly `absl/memory/memory.h`;
* add some virtual destructors;
* fix one cyclic dependency;
* fix one potential case of ODR violation.