### PR TITLE
Fix Linux build with GCC 4.8.5

### DIFF
--- a/Firestore/core/src/firebase/firestore/util/comparison.h
+++ b/Firestore/core/src/firebase/firestore/util/comparison.h
@@ -149,6 +149,14 @@ struct Comparator<absl::string_view> {
 
 template <>
 struct Comparator<std::string> {
+  Comparator() = default;
+  // GCC 4.8.5 has trouble implicitly generating copy operations (`=default`
+  // doesn't work as well).
+  Comparator(const Comparator&) {
+  }
+  Comparator& operator=(const Comparator&) {
+  }
+
   ComparisonResult Compare(const std::string& left,
                            const std::string& right) const;
 };

--- a/Firestore/core/src/firebase/firestore/util/comparison.h
+++ b/Firestore/core/src/firebase/firestore/util/comparison.h
@@ -155,6 +155,7 @@ struct Comparator<std::string> {
   Comparator(const Comparator&) {
   }
   Comparator& operator=(const Comparator&) {
+    return *this;
   }
 
   ComparisonResult Compare(const std::string& left,


### PR DESCRIPTION
Looks like there's a compiler bug preventing the correct generation of an implicit copy constructor in certain circumstances.