### PR TITLE
Fix compilation with older versions of Visual Studio

### DIFF
--- a/Firestore/core/src/firebase/firestore/api/settings.cc
+++ b/Firestore/core/src/firebase/firestore/api/settings.cc
@@ -22,7 +22,7 @@ namespace firebase {
 namespace firestore {
 namespace api {
 
-constexpr char Settings::DefaultHost[];
+constexpr const char* Settings::DefaultHost;
 constexpr bool Settings::DefaultSslEnabled;
 constexpr bool Settings::DefaultPersistenceEnabled;
 constexpr int64_t Settings::DefaultCacheSizeBytes;

--- a/Firestore/core/src/firebase/firestore/api/settings.h
+++ b/Firestore/core/src/firebase/firestore/api/settings.h
@@ -32,8 +32,8 @@ namespace api {
  */
 class Settings {
  public:
-  // Note: a constexpr array of char (`char[]`) doesn't work with older versions
-  // of Visual Studio.
+  // Note: a constexpr array of char (`char[]`) doesn't work with Visual Studio
+  // 2015.
   static constexpr const char* DefaultHost = "firestore.googleapis.com";
   static constexpr bool DefaultSslEnabled = true;
   static constexpr bool DefaultPersistenceEnabled = true;

--- a/Firestore/core/src/firebase/firestore/api/settings.h
+++ b/Firestore/core/src/firebase/firestore/api/settings.h
@@ -32,7 +32,7 @@ namespace api {
  */
 class Settings {
  public:
-  static constexpr char DefaultHost[] = "firestore.googleapis.com";
+  static constexpr const char* DefaultHost = "firestore.googleapis.com";
   static constexpr bool DefaultSslEnabled = true;
   static constexpr bool DefaultPersistenceEnabled = true;
   static constexpr int64_t DefaultCacheSizeBytes = 100 * 1024 * 1024;

--- a/Firestore/core/src/firebase/firestore/api/settings.h
+++ b/Firestore/core/src/firebase/firestore/api/settings.h
@@ -32,6 +32,8 @@ namespace api {
  */
 class Settings {
  public:
+  // Note: a constexpr array of char (`char[]`) doesn't work with older versions
+  // of Visual Studio.
   static constexpr const char* DefaultHost = "firestore.googleapis.com";
   static constexpr bool DefaultSslEnabled = true;
   static constexpr bool DefaultPersistenceEnabled = true;


### PR DESCRIPTION
Looks like Visual Studio 2015 has trouble with `constexpr` arrays:
```cpp
constexpr char Foo[] = "abc";
```
but not with `constexpr` pointers to `char`:
```cpp
constexpr const char* Foo = "abc";
```