### PR TITLE
Support concurrent Zip Builder runs

### DIFF
--- a/ZipBuilder/Sources/ZipBuilder/FileManager+Utils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FileManager+Utils.swift
@@ -102,7 +102,7 @@ public extension FileManager {
   }
 
   // Enable a single unique temporary workspace per execution.
-  static var uniq: String?
+  static var unique: String?
 
   /// Returns a deterministic path of a temporary directory for the given name. Note: This does
   /// *not* create the directory if it doesn't exist, merely generates the name for creation.
@@ -119,11 +119,11 @@ public extension FileManager {
     }
 
     // Organize all temporary directories into a "FirebaseZipRelease" directory.
-    if FileManager.uniq == nil {
-      FileManager.uniq = UUID().uuidString
+    if FileManager.unique == nil {
+      FileManager.unique = UUID().uuidString
     }
-    let uniq = FileManager.uniq!
-    let firebaseDir = tempDir.appendingPathComponent("ZipRelease" + uniq, isDirectory: true)
+    let unique = FileManager.unique!
+    let firebaseDir = tempDir.appendingPathComponent("ZipRelease" + unique, isDirectory: true)
     return firebaseDir.appendingPathComponent(name, isDirectory: true)
   }
 

--- a/ZipBuilder/Sources/ZipBuilder/FileManager+Utils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FileManager+Utils.swift
@@ -70,16 +70,10 @@ public extension FileManager {
     return directoryExists(at: url)
   }
 
-  /// Returns the URL to the Firebase cache directory, and creates it if it doesn't exist.
+  /// Returns the URL to the source Pod cache directory, and creates it if it doesn't exist.
   func sourcePodCacheDirectory(withSubdir subdir: String = "") throws -> URL {
-    // Get the URL for the cache directory.
-    let cacheDir: URL = try url(for: .cachesDirectory,
-                                in: .userDomainMask,
-                                appropriateFor: nil,
-                                create: true)
-
-    // Get the cache root path, and if it already exists just return the URL.
-    let cacheRoot = cacheDir.appendingPathComponents(["firebase_oss_framework_cache", subdir])
+    let cacheDir = FileManager.default.temporaryDirectory(withName: "cache")
+    let cacheRoot = cacheDir.appendingPathComponents([subdir])
     if directoryExists(at: cacheRoot) {
       return cacheRoot
     }
@@ -107,6 +101,9 @@ public extension FileManager {
     }
   }
 
+  // Enable a single unique temporary workspace per execution.
+  static var uniq: String?
+
   /// Returns a deterministic path of a temporary directory for the given name. Note: This does
   /// *not* create the directory if it doesn't exist, merely generates the name for creation.
   func temporaryDirectory(withName name: String) -> URL {
@@ -122,7 +119,11 @@ public extension FileManager {
     }
 
     // Organize all temporary directories into a "FirebaseZipRelease" directory.
-    let firebaseDir = tempDir.appendingPathComponent("FirebaseZipRelease", isDirectory: true)
+    if FileManager.uniq == nil {
+      FileManager.uniq = UUID().uuidString
+    }
+    let uniq = FileManager.uniq!
+    let firebaseDir = tempDir.appendingPathComponent("ZipRelease" + uniq, isDirectory: true)
     return firebaseDir.appendingPathComponent(name, isDirectory: true)
   }
 

--- a/ZipBuilder/Sources/ZipBuilder/FileManager+Utils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FileManager+Utils.swift
@@ -84,12 +84,12 @@ public extension FileManager {
     return cacheRoot
   }
 
-  /// Removes a directory if it exists. This is helpful to clean up error handling for checks that
+  /// Removes a directory or file if it exists. This is helpful to clean up error handling for checks that
   /// shouldn't fail. The only situation this could potentially fail is permission errors or if a
   /// folder is open in Finder, and in either state the user needs to close the window or fix the
   /// permissions. A fatal error will be thrown in those situations.
-  func removeDirectoryIfExists(at url: URL) {
-    guard directoryExists(at: url) else { return }
+  func removeIfExists(at url: URL) {
+    guard directoryExists(at: url) || fileExists(atPath: url.path) else { return }
 
     do {
       try removeItem(at: url)

--- a/ZipBuilder/Sources/ZipBuilder/FileManager+Utils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FileManager+Utils.swift
@@ -102,7 +102,7 @@ public extension FileManager {
   }
 
   // Enable a single unique temporary workspace per execution.
-  static var unique: String?
+  static let unique: String = UUID().uuidString
 
   /// Returns a deterministic path of a temporary directory for the given name. Note: This does
   /// *not* create the directory if it doesn't exist, merely generates the name for creation.
@@ -119,10 +119,7 @@ public extension FileManager {
     }
 
     // Organize all temporary directories into a "FirebaseZipRelease" directory.
-    if FileManager.unique == nil {
-      FileManager.unique = UUID().uuidString
-    }
-    let unique = FileManager.unique!
+    let unique = FileManager.unique
     let firebaseDir = tempDir.appendingPathComponent("ZipRelease" + unique, isDirectory: true)
     return firebaseDir.appendingPathComponent(name, isDirectory: true)
   }

--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -101,7 +101,7 @@ struct FrameworkBuilder {
     do {
       // Remove the previously cached framework if it exists, otherwise the `moveItem` call will
       // fail.
-      fileManager.removeDirectoryIfExists(at: cachedFrameworkDir)
+      fileManager.removeIfExists(at: cachedFrameworkDir)
 
       // Create the root cache directory if it doesn't exist.
       if !fileManager.directoryExists(at: cachedFrameworkRoot) {

--- a/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
+++ b/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
@@ -44,6 +44,7 @@ struct LaunchArgs {
     case carthageDir
     case customSpecRepos
     case existingVersions
+    case keepBuildArtifacts
     case minimumIOSVersion
     case outputDir
     case releasingSDKs
@@ -68,6 +69,8 @@ struct LaunchArgs {
       case .existingVersions:
         return "The file path to a textproto file containing the existing released SDK versions, " +
           "of type `ZipBuilder_FirebaseSDKs`."
+      case .keepBuildArtifacts:
+        return "A flag to indicate keeping (not deleting) the build artifacts."
       case .minimumIOSVersion:
         return "The minimum supported iOS version. The default is 9.0."
       case .outputDir:
@@ -107,6 +110,9 @@ struct LaunchArgs {
   /// Custom CocoaPods spec repos to be used. If not provided, the tool will only use the CocoaPods
   /// master repo.
   let customSpecRepos: [URL]?
+
+  /// A flag to keep the build artifacts after this script completes.
+  let keepBuildArtifacts: Bool
 
   /// The minimum iOS Version to build for.
   let minimumIOSVersion: String
@@ -274,6 +280,7 @@ struct LaunchArgs {
     }
 
     updatePodRepo = defaults.bool(forKey: Key.updatePodRepo.rawValue)
+    keepBuildArtifacts = defaults.bool(forKey: Key.keepBuildArtifacts.rawValue)
 
     // Check for extra invalid options.
     let validArgs = Key.allCases.map { $0.rawValue }

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -160,7 +160,7 @@ struct ZipBuilder {
 
     // Break the `inputPods` into a variable since it's helpful when debugging builds to just
     // install a subset of pods, like the following line:
-    //    let inputPods: [String] = ["", "Core", "Analytics", "Storage"]
+    // let inputPods: [String] = ["", "Core", "Analytics", "Storage"]
     let inputPods = CocoaPod.allCases.map { $0.rawValue }
     let podsToInstall = inputPods.map { CocoaPodUtils.VersionedPod(name: $0, version: nil) }
 
@@ -734,7 +734,7 @@ struct ZipBuilder {
           let copiedLocation = tempDir.appendingPathComponent(framework.lastPathComponent)
 
           // Remove the framework if it exists since it could be out of date.
-          fileManager.removeDirectoryIfExists(at: copiedLocation)
+          fileManager.removeIfExists(at: copiedLocation)
           do {
             try fileManager.copyItem(at: framework, to: copiedLocation)
           } catch {

--- a/ZipBuilder/Sources/ZipBuilder/main.swift
+++ b/ZipBuilder/Sources/ZipBuilder/main.swift
@@ -145,7 +145,19 @@ do {
       }
     }
   } else {
-    print("Success! Zip file can be found at \(zipped.path)")
+    // Move zip to parent directory so it doesn't get removed with other artifacts.
+    let parentLocation =
+      zipped.deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent(zipped.lastPathComponent)
+    do {
+      try FileManager.default.moveItem(at: zipped, to: parentLocation)
+    } catch {
+      fatalError("Could not move Zip file to output directory: \(error)")
+    }
+    print("Success! Zip file can be found at \(parentLocation.path)")
+  }
+
+  if !args.keepBuildArtifacts {
+    FileManager.default.removeDirectoryIfExists(at: projectDir.deletingLastPathComponent())
   }
 
   // Get the time since the start of the build to get the full time.

--- a/ZipBuilder/Sources/ZipBuilder/main.swift
+++ b/ZipBuilder/Sources/ZipBuilder/main.swift
@@ -52,12 +52,12 @@ do {
       let carthagePath =
         location.deletingLastPathComponent().appendingPathComponent("carthage_build")
       let fileManager = FileManager.default
-      fileManager.removeDirectoryIfExists(at: carthagePath)
+      fileManager.removeIfExists(at: carthagePath)
       try fileManager.copyItem(at: location, to: carthagePath)
 
       // Package the Carthage distribution with the current directory structure.
       let carthageDir = location.deletingLastPathComponent().appendingPathComponent("carthage")
-      fileManager.removeDirectoryIfExists(at: carthageDir)
+      fileManager.removeIfExists(at: carthageDir)
       var output = carthageDir.appendingPathComponent(firebaseVersion)
       if let rcNumber = args.rcNumber {
         output.appendPathComponent("rc\(rcNumber)")
@@ -73,7 +73,7 @@ do {
                                             outputDir: output)
 
       // Remove the duplicated Carthage build directory.
-      fileManager.removeDirectoryIfExists(at: carthagePath)
+      fileManager.removeIfExists(at: carthagePath)
       print("Done creating Carthage release! Files written to \(output)")
 
       // Save the directory for later copying.
@@ -121,7 +121,7 @@ do {
   if let outputDir = args.outputDir {
     do {
       // Clear out the output directory if it exists.
-      FileManager.default.removeDirectoryIfExists(at: outputDir)
+      FileManager.default.removeIfExists(at: outputDir)
       try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
 
       // We want the output to be in the X_Y_Z directory.
@@ -148,6 +148,8 @@ do {
     // Move zip to parent directory so it doesn't get removed with other artifacts.
     let parentLocation =
       zipped.deletingLastPathComponent().deletingLastPathComponent().appendingPathComponent(zipped.lastPathComponent)
+    // Clear out the output file if it exists.
+    FileManager.default.removeIfExists(at: parentLocation)
     do {
       try FileManager.default.moveItem(at: zipped, to: parentLocation)
     } catch {
@@ -157,7 +159,7 @@ do {
   }
 
   if !args.keepBuildArtifacts {
-    FileManager.default.removeDirectoryIfExists(at: projectDir.deletingLastPathComponent())
+    FileManager.default.removeIfExists(at: projectDir.deletingLastPathComponent())
   }
 
   // Get the time since the start of the build to get the full time.

--- a/ZipBuilder/Sources/ZipBuilder/main.swift
+++ b/ZipBuilder/Sources/ZipBuilder/main.swift
@@ -16,14 +16,6 @@
 
 import Foundation
 
-// Delete the cache directory, if it exists.
-do {
-  let cacheDir = try FileManager.default.sourcePodCacheDirectory()
-  FileManager.default.removeDirectoryIfExists(at: cacheDir)
-} catch {
-  fatalError("Could not remove the cache before packaging the release: \(error)")
-}
-
 // Get the launch arguments, parsed by user defaults.
 let args = LaunchArgs.shared
 


### PR DESCRIPTION
Use a unique temp folder per run so that multiple Zip Builder's can coexist on the same build/dev machine.

Add -keepBuildArtifacts option to keep the temp folder around. By default it will be deleted after a successful run.

Also integrate the cache into the temp folder since it is rebuilt every run anyway.

#no-changelog