### PR TITLE
Update GUComponents OCMock dependency.

### DIFF
--- a/GoogleUtilitiesComponents.podspec
+++ b/GoogleUtilitiesComponents.podspec
@@ -35,6 +35,6 @@ Not intended for direct public usage.
     unit_tests.source_files = 'GoogleUtilitiesComponents/Tests/**/*.[mh]'
     unit_tests.requires_arc = 'GoogleUtilitiesComponents/Tests/*/*.[mh]'
     unit_tests.requires_app_host = true
-    unit_tests.dependency 'OCMock', '~> 3.4.0'
+    unit_tests.dependency 'OCMock'
   end
 end


### PR DESCRIPTION
This issue was fixed previously and there's no need to lock versions now.

#no-changelog Updating pod's test dependency.