### PR TITLE
Simplify Firebase pod naming

### DIFF
--- a/Firebase/Core/CHANGELOG.md
+++ b/Firebase/Core/CHANGELOG.md
@@ -2,8 +2,12 @@
 - [added] Updated the binary distributions to include arm64e slices. See
   https://developer.apple.com/documentation/security/preparing_your_app_to_work_with_pointer_authentication.
   Support for the open source libraries is now included in the zip and Carthage
-  distributions. Support for the closed source libraries (Analytics, Performance,
-  and MLKit will be included the next time they release. (#4110)
+  distributions. Support for the closed source libraries (Analytics and Performance)
+  will be included the next time they release. MLKit support is not yet planned. (#4110)
+
+- [changed] The directory structure of the zip distribution has changed to include
+  full name of each Firebase pod name in the directory structure. For example, the former
+  `Storage` directory is now `FirebaseStorage`.
 
 # v6.4.0 -- M60
 - [changed] Administrative minor version update to prepare for an upcoming Firebase pod

--- a/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
@@ -81,7 +81,7 @@ public extension CarthageUtils {
 
       // Analytics includes all the Core frameworks and Firebase module, do extra work to package
       // it.
-      if product == "Analytics" {
+      if product == "FirebaseAnalytics" {
         createFirebaseFramework(inDir: fullPath, rootDir: packagedDir, templateDir: templateDir)
 
         // Copy the NOTICES file from FirebaseCore.

--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -272,7 +272,7 @@ public enum CocoaPodUtils {
     // Loop through the subspecs passed in and use the actual Pod name.
     for pod in pods {
       let version = pod.version == nil ? "" : ", '\(pod.version!)'"
-      podfile += "  pod '\(FirebasePods.podName(pod: pod.name))'" + version + "\n"
+      podfile += "  pod '\(pod.name)'" + version + "\n"
     }
 
     podfile += "end"

--- a/ZipBuilder/Sources/ZipBuilder/FirebasePods.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FirebasePods.swift
@@ -19,35 +19,35 @@ import Foundation
 // TODO: Auto generate this list from the Firebase.podspec and others, probably with a script.
 /// All the CocoaPods related to packaging and distributing Firebase.
 public enum FirebasePods: String, CaseIterable {
-  case abTesting = "ABTesting"
+  case abTesting = "FirebaseABTesting"
   case adMob = "Google-Mobile-Ads-SDK"
-  case analytics = "Analytics"
-  case auth = "Auth"
-  case core = "Core"
-  case database = "Database"
-  case dynamicLinks = "DynamicLinks"
-  case firebase = "" // The Firebase pod
-  case firestore = "Firestore"
-  case functions = "Functions"
+  case analytics = "FirebaseAnalytics"
+  case auth = "FirebaseAuth"
+  case core = "FirebaseCore"
+  case database = "FirebaseDatabase"
+  case dynamicLinks = "FirebaseDynamicLinks"
+  case firebase = "Firebase"
+  case firestore = "FirebaseFirestore"
+  case functions = "FirebaseFunctions"
   case googleSignIn = "GoogleSignIn"
-  case inAppMessaging = "InAppMessaging"
-  case inAppMessagingDisplay = "InAppMessagingDisplay"
-  case messaging = "Messaging"
-  case mlModelInterpreter = "MLModelInterpreter"
-  case mlNaturalLanguage = "MLNaturalLanguage"
-  case mlNLLanguageID = "MLNLLanguageID"
-  case mlNLSmartReply = "MLNLSmartReply"
-  case mlNLTranslate = "MLNLTranslate"
-  case mlVision = "MLVision"
-  case mlVisionAutoML = "MLVisionAutoML"
-  case mlVisionObjectDetection = "MLVisionObjectDetection"
-  case mlVisionBarcodeModel = "MLVisionBarcodeModel"
-  case mlVisionFaceModel = "MLVisionFaceModel"
-  case mlVisionLabelModel = "MLVisionLabelModel"
-  case mlVisionTextModel = "MLVisionTextModel"
-  case performance = "Performance"
-  case remoteConfig = "RemoteConfig"
-  case storage = "Storage"
+  case inAppMessaging = "FirebaseInAppMessaging"
+  case inAppMessagingDisplay = "FirebaseInAppMessagingDisplay"
+  case messaging = "FirebaseMessaging"
+  case mlModelInterpreter = "FirebaseMLModelInterpreter"
+  case mlNaturalLanguage = "FirebaseMLNaturalLanguage"
+  case mlNLLanguageID = "FirebaseMLNLLanguageID"
+  case mlNLSmartReply = "FirebaseMLNLSmartReply"
+  case mlNLTranslate = "FirebaseMLNLTranslate"
+  case mlVision = "FirebaseMLVision"
+  case mlVisionAutoML = "FirebaseMLVisionAutoML"
+  case mlVisionObjectDetection = "FirebaseMLVisionObjectDetection"
+  case mlVisionBarcodeModel = "FirebaseMLVisionBarcodeModel"
+  case mlVisionFaceModel = "FirebaseMLVisionFaceModel"
+  case mlVisionLabelModel = "FirebaseMLVisionLabelModel"
+  case mlVisionTextModel = "FirebaseMLVisionTextModel"
+  case performance = "FirebasePerformance"
+  case remoteConfig = "FirebaseRemoteConfig"
+  case storage = "FirebaseStorage"
 
   /// Flag to explicitly exclude any Resources from being copied.
   public var excludeResources: Bool {
@@ -59,19 +59,11 @@ public enum FirebasePods: String, CaseIterable {
     }
   }
 
-  /// The name of the pod in the CocoaPods repo.
-  public static func podName(pod: String) -> String {
-    if (!pod.starts(with: "Google") && allCases.map { $0.rawValue }.contains(pod)) {
-      return "Firebase\(pod)"
-    }
-    return pod
-  }
-
   /// Describes the dependency on other frameworks for the README file.
   public static func readmeHeader(podName: String) -> String {
     var header = "## \(podName)"
-    if !(podName == "Analytics" || podName == "GoogleSignIn") {
-      header += " (~> Analytics)"
+    if !(podName == "FirebaseAnalytics" || podName == "GoogleSignIn") {
+      header += " (~> FirebaseAnalytics)"
     }
     header += "\n"
     return header
@@ -84,7 +76,8 @@ public enum FirebasePods: String, CaseIterable {
   /// of frameworks get pulled in.
   public static func duplicateFrameworksToRemove(pod: String) -> [String] {
     switch pod {
-    case "MLVisionBarcodeModel", "MLVisionFaceModel", "MLVisionLabelModel", "MLVisionTextModel":
+    case "FirebaseMLVisionBarcodeModel", "FirebaseMLVisionFaceModel", "FirebaseMLVisionLabelModel",
+         "FirebaseMLVisionTextModel":
       return ["GTMSessionFetcher.framework", "Protobuf.framework"]
     default:
       return []

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -276,7 +276,8 @@ struct ZipBuilder {
     // Loop through all the other subspecs that aren't Core and Analytics and write them to their
     // final destination, including resources.
     let remainingPods = podsToInstall.filter { $0.name != "FirebaseAnalytics" &&
-      $0.name != "FirebaseCore" && $0.name != "" }
+      $0.name != "FirebaseCore" && $0.name != ""
+    }
     for pod in remainingPods {
       do {
         let (productDir, podFrameworks) =

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -189,7 +189,7 @@ struct ZipBuilder {
 
     // Break the `inputPods` into a variable since it's helpful when debugging builds to just
     // install a subset of pods, like the following line:
-    // let inputPods: [String] = ["", "Core", "Analytics", "Storage"]
+    // let inputPods: [String] = ["", "FirebaseCore", "FirebaseAnalytics", "FirebaseStorage"]
     let inputPods = FirebasePods.allCases.map { $0.rawValue }
     let podsToInstall = inputPods.map { CocoaPodUtils.VersionedPod(name: $0, version: nil) }
 
@@ -257,7 +257,7 @@ struct ZipBuilder {
     do {
       // This returns the Analytics directory and a list of framework names that Analytics requires.
       /// Example: ["FirebaseInstanceID", "GoogleAppMeasurement", "nanopb", <...>]
-      let analyticsPod = podsToInstall.filter { $0.name == "Analytics" }
+      let analyticsPod = podsToInstall.filter { $0.name == "FirebaseAnalytics" }
       let (dir, frameworks) = try installAndCopyFrameworks(forPod: analyticsPod[0],
                                                            projectDir: projectDir,
                                                            rootZipDir: zipDir,
@@ -269,13 +269,14 @@ struct ZipBuilder {
     }
 
     // Start the README dependencies string with the frameworks built in Analytics.
-    var readmeDeps = dependencyString(for: "Analytics",
+    var readmeDeps = dependencyString(for: "FirebaseAnalytics",
                                       in: analyticsDir,
                                       frameworks: analyticsFrameworks)
 
     // Loop through all the other subspecs that aren't Core and Analytics and write them to their
     // final destination, including resources.
-    let remainingPods = podsToInstall.filter { $0.name != "Analytics" && $0.name != "Core" && $0.name != "" }
+    let remainingPods = podsToInstall.filter { $0.name != "FirebaseAnalytics" &&
+      $0.name != "FirebaseCore" && $0.name != "" }
     for pod in remainingPods {
       do {
         let (productDir, podFrameworks) =

--- a/ZipBuilder/Template/README.md
+++ b/ZipBuilder/Template/README.md
@@ -15,7 +15,7 @@ To integrate a Firebase SDK with your app:
 2. Make sure you have an Xcode project open in Xcode.
 3. In Xcode, hit `⌘-1` to open the Project Navigator pane. It will open on
    left side of the Xcode window if it wasn't already open.
-4. Drag each framework from the "Analytics" directory into the Project
+4. Drag each framework from the "FirebaseAnalytics" directory into the Project
    Navigator pane. In the dialog box that appears, make sure the target you
    want the framework to be added to has a checkmark next to it, and that
    you've selected "Copy items if needed". If you already have Firebase
@@ -66,11 +66,6 @@ frameworks and libraries listed in each Firebase framework's
 
 "(~> X)" below means that the SDK requires all of the frameworks from X. You
 should make sure to include all of the frameworks from X when including the SDK.
-
-NOTE: If you are upgrading FirebaseAnalytics from before Firebase 5.5.0,
-      `FirebaseNanoPB` has been renamed to `MeasurementNanoPB`. After you add
-      `MeasurementNanoPB` to your project, please remove `FirebaseNanoPB` as it
-      no longer provides any functionality.
 
 __INTEGRATION__
 # Samples


### PR DESCRIPTION
Get rid of the name adjustments for the Firebase pods and always calling them by the full name - eg "FirebaseAnalytics" instead of "Analytics". T he rename only increased complexity in both implementation and usage.

#no-changelog