### PR TITLE
Fix FIAM --analyze nullability issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -409,8 +409,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAnalyticsInterop.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseAuthInterop.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseCoreDiagnosticsInterop.podspec
-        # Fix analyze (#4163)
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --no-analyze
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInAppMessagingDisplay.podspec
 
     - stage: test
@@ -428,8 +427,8 @@ jobs:
       env:
         - PROJECT=InAppMessagingCron METHOD=pod-lib-lint
       script:
-        - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --use-libraries --no-analyze
-        - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --use-modular-headers --no-analyze
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --use-libraries
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --use-modular-headers
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessagingDisplay.podspec --use-libraries
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseInAppMessagingDisplay.podspec --use-modular-headers
 

--- a/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.m
@@ -389,10 +389,6 @@
   NSString *body = renderData.contentData.bodyText;
 
   // Action button data is never nil for a card message.
-  assert(renderData.contentData.actionButtonText != nil);
-  assert(renderData.renderingEffectSettings.btnTextColor != nil);
-  assert(renderData.renderingEffectSettings.btnBGColor != nil);
-
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   FIRInAppMessagingActionButton *primaryActionButton = [[FIRInAppMessagingActionButton alloc]
@@ -524,8 +520,10 @@
                             triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType {
   switch (definition.renderData.renderingEffectSettings.viewMode) {
     case FIRIAMRenderAsCardView:
-      // Image data is never nil for a card message.
-      assert(imageData != nil);
+      // Image data should never nil for a valid card message.
+      if (imageData == nil) {
+        return nil;
+      }
       return [self cardDisplayMessageWithMessageDefinition:definition
                                          portraitImageData:imageData
                                         landscapeImageData:landscapeImageData

--- a/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.m
+++ b/Firebase/InAppMessaging/Flows/FIRIAMDisplayExecutor.m
@@ -378,7 +378,7 @@
 
 - (FIRInAppMessagingCardDisplay *)
     cardDisplayMessageWithMessageDefinition:(FIRIAMMessageDefinition *)definition
-                          portraitImageData:(FIRInAppMessagingImageData *)portraitImageData
+                          portraitImageData:(nonnull FIRInAppMessagingImageData *)portraitImageData
                          landscapeImageData:
                              (nullable FIRInAppMessagingImageData *)landscapeImageData
                                 triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType {
@@ -388,16 +388,19 @@
   NSString *title = renderData.contentData.titleText;
   NSString *body = renderData.contentData.bodyText;
 
-  FIRInAppMessagingActionButton *primaryActionButton = nil;
-  if (definition.renderData.contentData.actionButtonText) {
+  // Action button data is never nil for a card message.
+  assert(renderData.contentData.actionButtonText != nil);
+  assert(renderData.renderingEffectSettings.btnTextColor != nil);
+  assert(renderData.renderingEffectSettings.btnBGColor != nil);
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    primaryActionButton = [[FIRInAppMessagingActionButton alloc]
-        initWithButtonText:renderData.contentData.actionButtonText
-           buttonTextColor:renderData.renderingEffectSettings.btnTextColor
-           backgroundColor:renderData.renderingEffectSettings.btnBGColor];
+  FIRInAppMessagingActionButton *primaryActionButton = [[FIRInAppMessagingActionButton alloc]
+      initWithButtonText:renderData.contentData.actionButtonText
+         buttonTextColor:renderData.renderingEffectSettings.btnTextColor
+         backgroundColor:renderData.renderingEffectSettings.btnBGColor];
+
 #pragma clang diagnostic pop
-  }
 
   FIRInAppMessagingActionButton *secondaryActionButton = nil;
   if (definition.renderData.contentData.secondaryActionButtonText) {
@@ -521,6 +524,8 @@
                             triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType {
   switch (definition.renderData.renderingEffectSettings.viewMode) {
     case FIRIAMRenderAsCardView:
+      // Image data is never nil for a card message.
+      assert(imageData != nil);
       return [self cardDisplayMessageWithMessageDefinition:definition
                                          portraitImageData:imageData
                                         landscapeImageData:landscapeImageData


### PR DESCRIPTION
- Update card message creation method to require portrait image to be non-null
    - In calling method, return `nil` if imageData isn't present
- Always instantiate an action button for a card message

#fixes #4163