### PR TITLE
Allow multiple `configure` calls in an extension.

### DIFF
--- a/Firebase/Core/FIROptions.m
+++ b/Firebase/Core/FIROptions.m
@@ -346,6 +346,56 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
   _appGroupID = [appGroupID copy];
 }
 
+#pragma mark - Equality
+
+- (BOOL)isEqual:(id)object {
+  if (!object || ![object isKindOfClass:[FIROptions class]]) {
+    return NO;
+  }
+
+  return [self isEqualToOptions:(FIROptions *)object];
+}
+
+- (BOOL)isEqualToOptions:(FIROptions *)options {
+  // Skip any non-FIROptions classes.
+  if (![options isKindOfClass:[FIROptions class]]) {
+    return NO;
+  }
+
+  // Check the internal dictionary and custom properties for differences.
+  if (![options.optionsDictionary isEqualToDictionary:self.optionsDictionary]) {
+    return NO;
+  }
+
+  // Validate extra properties not contained in the dictionary. Only validate it if one of the
+  // objects has the property set.
+  if ((options.deepLinkURLScheme != nil || self.deepLinkURLScheme != nil) &&
+      ![options.deepLinkURLScheme isEqualToString:self.deepLinkURLScheme]) {
+    return NO;
+  }
+
+  if ((options.appGroupID != nil || self.appGroupID != nil) &&
+      ![options.appGroupID isEqualToString:self.appGroupID]) {
+    return NO;
+  }
+
+  // Validate the Analytics options haven't changed with the Info.plist.
+  if (![options.analyticsOptionsDictionary isEqualToDictionary:self.analyticsOptionsDictionary]) {
+    return NO;
+  }
+
+  // We don't care about the `editingLocked` or `usingOptionsFromDefaultPlist` properties since
+  // those relate to lifecycle and construction, we only care if the contents of the options
+  // themselves are equal.
+  return YES;
+}
+
+- (NSUInteger)hash {
+  // This is strongly recommended for any object that implements a custom `isEqual:` method to
+  // ensure that dictionary and set behavior matches other `isEqual:` checks.
+  return self.optionsDictionary.hash ^ self.deepLinkURLScheme.hash ^ self.appGroupID.hash;
+}
+
 #pragma mark - Internal instance methods
 
 - (NSDictionary *)analyticsOptionsDictionaryWithInfoDictionary:(NSDictionary *)infoDictionary {

--- a/Firebase/Core/FIROptions.m
+++ b/Firebase/Core/FIROptions.m
@@ -393,6 +393,9 @@ static NSDictionary *sDefaultOptionsDictionary = nil;
 - (NSUInteger)hash {
   // This is strongly recommended for any object that implements a custom `isEqual:` method to
   // ensure that dictionary and set behavior matches other `isEqual:` checks.
+  // Note: `self.analyticsOptionsDictionary` was left out here since it solely relies on the
+  // contents of the main bundle's `Info.plist`. We should avoid reading that file and the contents
+  // should be identical.
   return self.optionsDictionary.hash ^ self.deepLinkURLScheme.hash ^ self.appGroupID.hash;
 }
 


### PR DESCRIPTION
Some extensions have an entry point that gets called multiple times.
Instead of having to check if a default app has already been configured,
allow multiple `configure` calls if and only if it's in an extension and
the FIROptions contents are identical.