### PR TITLE
Add ccache support to our CMakeLists.txt.

### DIFF
--- a/CMAKE.md
+++ b/CMAKE.md
@@ -30,6 +30,7 @@ needed for other package managers.
 ```
 brew install cmake
 brew install golang
+brew install ccache     # optional
 brew install ninja      # optional
 gem install cocoapods   # may need sudo
 ```
@@ -46,6 +47,7 @@ sufficient.
 ```
 sudo apt-get install build-essential
 sudo apt-get install cmake
+sudo apt-get install ccache       # optional
 sudo apt-get install ninja-build  # optional
 
 sudo apt-get install golang
@@ -68,7 +70,7 @@ choco install ninja  # optional
 
 choco install activeperl
 choco install golang
-choco install yasm
+choco install nasm
 ```
 
 ## Building

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,13 @@ if(POLICY CMP0058)
   cmake_policy(SET CMP0058 OLD)
 endif()
 
+# Enable the ccache compilation cache, if available.
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  set(CMAKE_C_COMPILER_LAUNCHER   "${CCACHE_PROGRAM}")
+  set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+endif()
+
 # Defer enabling any languages.
 project(firebase NONE)
 


### PR DESCRIPTION
This cuts the full rebuild-and-test time from 2m7s to 38s on Linux.

Also, boringssl now uses nasm on Windows rather than yasm so update instructions.