### PR TITLE
Speed up zip builder development iteration

### DIFF
--- a/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
+++ b/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
@@ -85,7 +85,8 @@ struct LaunchArgs {
         return "The path to the directory containing the blank xcodeproj and Info.plist for " +
           "building source based frameworks"
       case .updatePodRepo:
-        return "A flag to run `pod repo update` before building the zip file."
+        return "A flag to run `pod repo update` and `pod cache clean -all` before building the " +
+          "zip file."
       case .zipPods:
         return "The path to a JSON file of the pods (with optional version) to package into a zip."
       }
@@ -149,7 +150,7 @@ struct LaunchArgs {
   init(userDefaults defaults: UserDefaults = UserDefaults.standard,
        fileChecker: FileChecker = FileManager.default) {
     // Override default values for specific keys.
-    //   - Always run `pod repo update` unless explicitly set to false.
+    //   - Always run `pod repo update` and pod cache clean -all` unless explicitly set to false.
     defaults.register(defaults: [Key.updatePodRepo.rawValue: true])
 
     // Get the project template directory, and fail if it doesn't exist.

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -128,7 +128,9 @@ struct ZipBuilder {
     ([CocoaPodUtils.PodInfo], [String: [URL]]) {
     // Remove CocoaPods cache so the build gets updates after a version is rebuilt during the
     // release process.
-    CocoaPodUtils.cleanPodCache()
+    if LaunchArgs.shared.updatePodRepo {
+      CocoaPodUtils.cleanPodCache()
+    }
 
     // We need to install all the pods in order to get every single framework that we'll need
     // for the zip file. We can't install each one individually since some pods depend on different


### PR DESCRIPTION
Doing the full `pod install` can take a long time especially with a slow network.

This speeds up a Firebase build by three minutes on a fast connection and much more on a slow one.

#no-changelog