### PR TITLE
Fix Zip README blank line separator

### DIFF
--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -436,9 +436,6 @@ struct ZipBuilder {
     for framework in frameworks.sorted() {
       result += "- \(framework).framework\n"
     }
-
-    result += "\n"
-
     // Check if there is a Resources directory, and if so, add the disclaimer to the dependency
     // string.
     do {
@@ -454,6 +451,7 @@ struct ZipBuilder {
       occurred: \(error).
       """)
     }
+    result += "\n"
 
     return result
   }

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -436,6 +436,9 @@ struct ZipBuilder {
     for framework in frameworks.sorted() {
       result += "- \(framework).framework\n"
     }
+
+    result += "\n" // Necessary for Resource message to print properly in markdown.
+
     // Check if there is a Resources directory, and if so, add the disclaimer to the dependency
     // string.
     do {
@@ -444,6 +447,7 @@ struct ZipBuilder {
                                                            in: dir)
       if !resourceDirs.isEmpty {
         result += Constants.resourcesRequiredText
+        result += "\n" // Separate from next pod in listing for text version.
       }
     } catch {
       fatalError("""
@@ -451,7 +455,6 @@ struct ZipBuilder {
       occurred: \(error).
       """)
     }
-    result += "\n"
 
     return result
   }


### PR DESCRIPTION
For libraries with Resources, the blank line was missing in the text version (ok in markdown):

```
## GoogleSignIn
- AppAuth.framework
- GTMAppAuth.framework
- GTMSessionFetcher.framework
- GoogleSignIn.framework

You'll also need to add the resources in the Resources
directory into your target's main bundle.
## FirebaseInAppMessaging (~> FirebaseAnalytics)
- FirebaseInAppMessaging.framework
```

to 

```
## GoogleSignIn
- AppAuth.framework
- GTMAppAuth.framework
- GTMSessionFetcher.framework
- GoogleSignIn.framework

You'll also need to add the resources in the Resources
directory into your target's main bundle.

## FirebaseInAppMessaging (~> FirebaseAnalytics)
- FirebaseInAppMessaging.framework
```

#no-changelog