### PR TITLE
ZipBuilder: Get dependencies from the Podfile.lock

### DIFF
--- a/ZipBuilder/Sources/ZipBuilder/ModuleMapBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ModuleMapBuilder.swift
@@ -42,14 +42,18 @@ struct ModuleMapBuilder {
   private let customSpecRepos: [URL]?
 
   /// Dictionary of all installed pods.
+  private let allPods: [String: CocoaPodUtils.PodInfo]
+
+  /// Dictionary of installed pods required for this module.
   private var installedPods: [String: FrameworkInfo]
 
   /// Default initializer.
-  init(frameworks: [String: [URL]], customSpecRepos: [URL]?) {
+  init(frameworks: [String: [URL]], customSpecRepos: [URL]?, allPods: [String: CocoaPodUtils.PodInfo]) {
     projectDir = FileManager.default.temporaryDirectory(withName: "module")
     CocoaPodUtils.podInstallPrepare(inProjectDir: projectDir)
 
     self.customSpecRepos = customSpecRepos
+    self.allPods = allPods
 
     var cacheDir: URL
     do {
@@ -90,9 +94,15 @@ struct ModuleMapBuilder {
 
   // MARK: - Internal Functions
 
-  /// Build a module map for a single framework.
+  /// Build a module map for a single framework. A CocoaPod install is run to extract the required frameworks
+  /// and libraries from the generated xcconfig. All previously installed dependent pods are put into the Podfile
+  /// to make sure we install the right version and from the right location.
   private func generate(framework: FrameworkInfo) {
-    _ = CocoaPodUtils.installPods([framework.versionedPod], inDir: projectDir, customSpecRepos: customSpecRepos)
+    let podName = framework.versionedPod.name
+    let deps = CocoaPodUtils.transitiveVersionedPodDependencies(for: podName, in: allPods)
+    _ = CocoaPodUtils.installPods([framework.versionedPod] + deps,
+                                  inDir: projectDir,
+                                  customSpecRepos: customSpecRepos)
     let xcconfigFile = projectDir.appendingPathComponents(["Pods", "Target Support Files",
                                                            "Pods-FrameworkMaker",
                                                            "Pods-FrameworkMaker.release.xcconfig"])

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -154,7 +154,7 @@ struct ZipBuilder {
     // copied in each product's directory.
     let frameworks = generateFrameworks(fromPods: installedPods, inProjectDir: projectDir)
 
-      ModuleMapBuilder(frameworks: frameworks, customSpecRepos: customSpecRepos, allPods: installedPods).build()
+    ModuleMapBuilder(frameworks: frameworks, customSpecRepos: customSpecRepos, allPods: installedPods).build()
 
     for (framework, paths) in frameworks {
       print("Frameworks for pod: \(framework) were compiled at \(paths)")
@@ -183,7 +183,7 @@ struct ZipBuilder {
 
     // Break the `inputPods` into a variable since it's helpful when debugging builds to just
     // install a subset of pods, like the following line:
-    //let inputPods: [String] = ["Firebase", "FirebaseCore", "FirebaseAnalytics", "FirebaseStorage"]
+    // let inputPods: [String] = ["Firebase", "FirebaseCore", "FirebaseAnalytics", "FirebaseStorage"]
     let inputPods = FirebasePods.allCases.map { $0.rawValue }
     let podsToInstall = inputPods.map { CocoaPodUtils.VersionedPod(name: $0, version: nil) }
 
@@ -269,10 +269,10 @@ struct ZipBuilder {
     // final destination, including resources.
     let remainingPods = installedPods.filter {
       $0.key != "FirebaseAnalytics" &&
-      $0.key != "FirebaseCore" &&
-      $0.key != "Firebase" &&
-      podsToInstall.map { $0.name }.contains($0.key)
-    }.sorted{$0.key < $1.key}
+        $0.key != "FirebaseCore" &&
+        $0.key != "Firebase" &&
+        podsToInstall.map { $0.name }.contains($0.key)
+    }.sorted { $0.key < $1.key }
     for pod in remainingPods {
       do {
         let (productDir, podFrameworks) =
@@ -545,7 +545,7 @@ struct ZipBuilder {
   /// directory.
   ///
   /// - Parameter projectDir: The directory containing the Podfile.lock file of installed pods.
-  private func validateExpectedVersions(installedPods: [String : CocoaPodUtils.PodInfo]) {
+  private func validateExpectedVersions(installedPods: [String: CocoaPodUtils.PodInfo]) {
     // Get the expected versions based on the release manifests, if there are any. We'll use this to
     // validate the versions pulled from CocoaPods. Expected versions could be empty, in which case
     // validation succeeds.
@@ -638,7 +638,7 @@ struct ZipBuilder {
   /// CocoaPods. Returns a dictionary with the framework name for the key and all information for
   /// frameworks to install EXCLUDING resources, as they are handled later (if not included in the
   /// .framework file already).
-  private func generateFrameworks(fromPods pods: [String : CocoaPodUtils.PodInfo],
+  private func generateFrameworks(fromPods pods: [String: CocoaPodUtils.PodInfo],
                                   inProjectDir projectDir: URL,
                                   carthageBuild: Bool = false) -> [String: [URL]] {
     // Verify the Pods folder exists and we can get the contents of it.

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -341,15 +341,15 @@ struct ZipBuilder {
   /// them to the destination directory.
   ///
   /// - Parameters:
-  ///   - installedPods: All the Pods installed for a given set of pods, which will be used as a
-  ///               list to find out what frameworks to copy to the destination.
+  ///   - installedPods: Names of all the pods installed, which will be used as a
+  ///                    list to find out what frameworks to copy to the destination.
   ///   - dir: Destination directory for all the frameworks.
   ///   - frameworkLocations: A dictionary containing the pod name as the key and a location to
   ///                         the compiled frameworks.
   ///   - ignoreFrameworks: A list of Pod
   /// - Returns: The filenames of the frameworks that were copied.
   /// - Throws: Various FileManager errors in case the copying fails, or an error if the framework
-  //            doesn't exist in `frameworkLocations`.
+  ///           doesn't exist in `frameworkLocations`.
   @discardableResult
   func copyFrameworks(fromPods installedPods: [String],
                       toDirectory dir: URL,
@@ -544,7 +544,7 @@ struct ZipBuilder {
   /// one) match the expected versions installed and listed in the Podfile.lock in a project
   /// directory.
   ///
-  /// - Parameter projectDir: The directory containing the Podfile.lock file of installed pods.
+  /// - Parameter projectDir: The dictionary that summarizes the pod info parsed from the Podfile.lock.
   private func validateExpectedVersions(installedPods: [String: CocoaPodUtils.PodInfo]) {
     // Get the expected versions based on the release manifests, if there are any. We'll use this to
     // validate the versions pulled from CocoaPods. Expected versions could be empty, in which case

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -125,10 +125,12 @@ struct ZipBuilder {
   /// - Parameter podsToInstall: All pods to install.
   /// - Returns: Arrays of pod install info and the frameworks installed.
   func buildAndAssembleZip(podsToInstall: [CocoaPodUtils.VersionedPod]) ->
-    ([CocoaPodUtils.PodInfo], [String: [URL]]) {
+    ([String: CocoaPodUtils.PodInfo], [String: [URL]]) {
     // Remove CocoaPods cache so the build gets updates after a version is rebuilt during the
     // release process.
-    CocoaPodUtils.cleanPodCache()
+    if LaunchArgs.shared.updatePodRepo {
+      CocoaPodUtils.cleanPodCache()
+    }
 
     // We need to install all the pods in order to get every single framework that we'll need
     // for the zip file. We can't install each one individually since some pods depend on different
@@ -152,7 +154,7 @@ struct ZipBuilder {
     // copied in each product's directory.
     let frameworks = generateFrameworks(fromPods: installedPods, inProjectDir: projectDir)
 
-    ModuleMapBuilder(frameworks: frameworks, customSpecRepos: customSpecRepos).build()
+      ModuleMapBuilder(frameworks: frameworks, customSpecRepos: customSpecRepos, allPods: installedPods).build()
 
     for (framework, paths) in frameworks {
       print("Frameworks for pod: \(framework) were compiled at \(paths)")
@@ -181,7 +183,7 @@ struct ZipBuilder {
 
     // Break the `inputPods` into a variable since it's helpful when debugging builds to just
     // install a subset of pods, like the following line:
-    // let inputPods: [String] = ["", "FirebaseCore", "FirebaseAnalytics", "FirebaseStorage"]
+    //let inputPods: [String] = ["Firebase", "FirebaseCore", "FirebaseAnalytics", "FirebaseStorage"]
     let inputPods = FirebasePods.allCases.map { $0.rawValue }
     let podsToInstall = inputPods.map { CocoaPodUtils.VersionedPod(name: $0, version: nil) }
 
@@ -200,7 +202,8 @@ struct ZipBuilder {
     }
     let coreDiagnosticModuleMap = coreDiagnosticModuleMapLocation.appendingPathComponent("Modules")
     do {
-      try FileManager.default.copyItem(at: coreDiagnosticModuleMap, to: carthageCoreDiagnostics.appendingPathComponent("Modules"))
+      try FileManager.default.copyItem(at: coreDiagnosticModuleMap,
+                                       to: carthageCoreDiagnostics.appendingPathComponent("Modules"))
     } catch {
       fatalError("Failed to copy module map to \(carthageCoreDiagnostics)")
     }
@@ -231,7 +234,7 @@ struct ZipBuilder {
 
     // We need the Firebase pod to get the version for Carthage and to copy the `Firebase.h` and
     // `module.modulemap` file from it.
-    guard let firebasePod = installedPods.first(where: { $0.name == "Firebase" }) else {
+    guard let firebasePod = installedPods["Firebase"] else {
       fatalError("Could not get the Firebase pod from list of installed pods. All pods " +
         "installed: \(installedPods)")
     }
@@ -246,8 +249,8 @@ struct ZipBuilder {
     do {
       // This returns the Analytics directory and a list of framework names that Analytics requires.
       /// Example: ["FirebaseInstanceID", "GoogleAppMeasurement", "nanopb", <...>]
-      let analyticsPod = podsToInstall.filter { $0.name == "FirebaseAnalytics" }
-      let (dir, frameworks) = try installAndCopyFrameworks(forPod: analyticsPod[0],
+      let (dir, frameworks) = try installAndCopyFrameworks(forPod: "FirebaseAnalytics",
+                                                           withInstalledPods: installedPods,
                                                            projectDir: projectDir,
                                                            rootZipDir: zipDir,
                                                            builtFrameworks: frameworks)
@@ -264,20 +267,24 @@ struct ZipBuilder {
 
     // Loop through all the other subspecs that aren't Core and Analytics and write them to their
     // final destination, including resources.
-    let remainingPods = podsToInstall.filter { $0.name != "FirebaseAnalytics" &&
-      $0.name != "FirebaseCore" && $0.name != ""
-    }
+    let remainingPods = installedPods.filter {
+      $0.key != "FirebaseAnalytics" &&
+      $0.key != "FirebaseCore" &&
+      $0.key != "Firebase" &&
+      podsToInstall.map { $0.name }.contains($0.key)
+    }.sorted{$0.key < $1.key}
     for pod in remainingPods {
       do {
         let (productDir, podFrameworks) =
-          try installAndCopyFrameworks(forPod: pod,
+          try installAndCopyFrameworks(forPod: pod.key,
+                                       withInstalledPods: installedPods,
                                        projectDir: projectDir,
                                        rootZipDir: zipDir,
                                        builtFrameworks: frameworks,
                                        podsToIgnore: analyticsFrameworks)
 
         // Update the README.
-        readmeDeps += dependencyString(for: pod.name, in: productDir, frameworks: podFrameworks)
+        readmeDeps += dependencyString(for: pod.key, in: productDir, frameworks: podFrameworks)
       } catch {
         fatalError("Could not copy frameworks from \(pod) into the zip file: \(error)")
       }
@@ -304,17 +311,16 @@ struct ZipBuilder {
 
   // MARK: - Private
 
-  private func createCarthageCoreDiagnostics(fromPods pods: [CocoaPodUtils.PodInfo],
+  private func createCarthageCoreDiagnostics(fromPods pods: [String: CocoaPodUtils.PodInfo],
                                              inProjectDir projectDir: URL) -> URL {
     // FirebaseCoreDiagnostics needs to be re-compiled for Carthage. It should be included in all
     // builds, so ensure it's there.
-    guard let coreDiag = pods.first(where: { $0.name == Constants.coreDiagnosticsName }) else {
-      fatalError("Could not get FirebaseCoreDiagnostics pod to re-compile for Carthage. Pods " +
-        "installed: \(pods.map { $0.name })")
+    guard let coreDiag = pods[Constants.coreDiagnosticsName] else {
+      fatalError("Could not get FirebaseCoreDiagnostics pod to re-compile for Carthage.")
     }
 
     // Compile the CoreDiagnostics pod for Carthage.
-    let carthageFrameworks = generateFrameworks(fromPods: [coreDiag],
+    let carthageFrameworks = generateFrameworks(fromPods: [Constants.coreDiagnosticsName: coreDiag],
                                                 inProjectDir: projectDir,
                                                 carthageBuild: true)
     guard let coreDiagnosticsFrameworks = carthageFrameworks[Constants.coreDiagnosticsName] else {
@@ -345,7 +351,7 @@ struct ZipBuilder {
   /// - Throws: Various FileManager errors in case the copying fails, or an error if the framework
   //            doesn't exist in `frameworkLocations`.
   @discardableResult
-  func copyFrameworks(fromPods installedPods: [CocoaPodUtils.PodInfo],
+  func copyFrameworks(fromPods installedPods: [String],
                       toDirectory dir: URL,
                       frameworkLocations: [String: [URL]],
                       podsToIgnore: [String] = [],
@@ -360,16 +366,16 @@ struct ZipBuilder {
 
     // Loop through each InstalledPod item and get the name so we can fetch the framework and copy
     // it to the destination directory.
-    for pod in installedPods {
+    for podName in installedPods {
       // Skip the Firebase pod, any Interop pods, and specifically ignored frameworks.
-      guard pod.name != "Firebase",
-        !pod.name.contains("Interop"),
-        !podsToIgnore.contains(pod.name) else {
+      guard podName != "Firebase",
+        !podName.contains("Interop"),
+        !podsToIgnore.contains(podName) else {
         continue
       }
 
-      guard let frameworks = frameworkLocations[pod.name] else {
-        let reason = "Unable to find frameworks for \(pod.name) in cache of frameworks built to " +
+      guard let frameworks = frameworkLocations[podName] else {
+        let reason = "Unable to find frameworks for \(podName) in cache of frameworks built to " +
           "include in the Zip file for that framework's folder."
         let error = NSError(domain: "com.firebase.zipbuilder",
                             code: 1,
@@ -437,7 +443,7 @@ struct ZipBuilder {
       result += "- \(framework).framework\n"
     }
 
-    result += "\n"
+    result += "\n" // Necessary for Resource message to print properly in markdown.
 
     // Check if there is a Resources directory, and if so, add the disclaimer to the dependency
     // string.
@@ -447,6 +453,7 @@ struct ZipBuilder {
                                                            in: dir)
       if !resourceDirs.isEmpty {
         result += Constants.resourcesRequiredText
+        result += "\n" // Separate from next pod in listing for text version.
       }
     } catch {
       fatalError("""
@@ -508,20 +515,21 @@ struct ZipBuilder {
   ///            that were copied for this subspec.
   @discardableResult
   func installAndCopyFrameworks(
-    forPod pod: CocoaPodUtils.VersionedPod,
+    forPod podName: String,
+    withInstalledPods installedPods: [String: CocoaPodUtils.PodInfo],
     projectDir: URL,
     rootZipDir: URL,
     builtFrameworks: [String: [URL]],
     podsToIgnore: [String] = []
   ) throws -> (productDir: URL, frameworks: [String]) {
-    let installedPods = CocoaPodUtils.installPods([pod], inDir: projectDir, customSpecRepos: customSpecRepos)
+    let podsToCopy = [podName] + CocoaPodUtils.transitivePodDependencies(for: podName, in: installedPods)
     // Copy the frameworks into the proper product directory.
-    let productDir = rootZipDir.appendingPathComponent(pod.name)
-    let namedFrameworks = try copyFrameworks(fromPods: installedPods,
+    let productDir = rootZipDir.appendingPathComponent(podName)
+    let namedFrameworks = try copyFrameworks(fromPods: podsToCopy,
                                              toDirectory: productDir,
                                              frameworkLocations: builtFrameworks,
                                              podsToIgnore: podsToIgnore,
-                                             foldersToIgnore: FirebasePods.duplicateFrameworksToRemove(pod: pod.name))
+                                             foldersToIgnore: FirebasePods.duplicateFrameworksToRemove(pod: podName))
 
     let copiedFrameworks = namedFrameworks.filter {
       // Only return the frameworks that aren't contained in the "podsToIgnore" array, aren't an
@@ -537,27 +545,26 @@ struct ZipBuilder {
   /// directory.
   ///
   /// - Parameter projectDir: The directory containing the Podfile.lock file of installed pods.
-  private func validateExpectedVersions(installedPods: [CocoaPodUtils.PodInfo]) {
+  private func validateExpectedVersions(installedPods: [String : CocoaPodUtils.PodInfo]) {
     // Get the expected versions based on the release manifests, if there are any. We'll use this to
     // validate the versions pulled from CocoaPods. Expected versions could be empty, in which case
     // validation succeeds.
     let expected = expectedVersions()
     if !expected.isEmpty {
-      // If there are some expected versions,verify them.
-      for podInfo in installedPods {
-        let podName = podInfo.name
-        if podName.contains("SmartReply") {
-          continue
+      // Loop through the expected versions and verify the actual versions match.
+      for podName in expected.keys where !podName.contains("SmartReply") {
+        // If there are some expected versions,verify them.
+        guard let installedPod = installedPods[podName] else {
+          fatalError("Did not find expected pod \(podName) installed")
         }
-        guard let expectedVersion = expected[podName] else {
-          continue
-        }
-        guard expectedVersion == podInfo.version else {
+        let actualVersion = installedPod.version
+        guard let expectedVersion = expected[podName],
+          installedPod.version == expectedVersion else {
           fatalError("""
           Version mismatch from expected versions and version installed in CocoaPods:
           Pod Name: \(podName)
           Expected Version: \(String(describing: expected[podName]))
-          Actual Version: \(podInfo.version)
+          Actual Version: \(actualVersion)
           Please verify that the expected version is correct, and the Podspec dependencies are
           appropriately versioned.
           """)
@@ -571,17 +578,17 @@ struct ZipBuilder {
   ///
   /// - Parameter pods: All pods that were installed, with their versions.
   /// - Returns: A String to be added to the README.
-  private func versionsString(for pods: [CocoaPodUtils.PodInfo]) -> String {
+  private func versionsString(for pods: [String: CocoaPodUtils.PodInfo]) -> String {
     // Get the longest name in order to generate padding with spaces so it looks nicer.
     let maxLength: Int = {
-      guard let pod = pods.max(by: { $0.name.count < $1.name.count }) else {
+      guard let pod = pods.keys.max(by: { $0.count < $1.count }) else {
         // The longest pod as of this writing is 29 characters, if for whatever reason this fails
         // just assume 30 characters long.
         return 30
       }
 
       // Return room for a space afterwards.
-      return pod.name.count + 1
+      return pod.count + 1
     }()
 
     let header: String = {
@@ -608,17 +615,17 @@ struct ZipBuilder {
     }()
 
     // Sort the pods by name for a cleaner display.
-    let sortedPods = pods.sorted { $0.name < $1.name }
+    let sortedPods = pods.sorted { $0.key < $1.key }
 
     // Get the name and version of each pod, padding it along the way.
     var podVersions: String = ""
     for pod in sortedPods {
       // Insert the name and enough spaces to reach the end of the column.
-      let podName = pod.name
+      let podName = pod.key
       podVersions += podName + String(repeating: " ", count: maxLength - podName.count)
 
       // Add a pipe and the version.
-      podVersions += "| " + pod.version + "\n"
+      podVersions += "| " + pod.value.version + "\n"
     }
 
     return header + podVersions
@@ -631,7 +638,7 @@ struct ZipBuilder {
   /// CocoaPods. Returns a dictionary with the framework name for the key and all information for
   /// frameworks to install EXCLUDING resources, as they are handled later (if not included in the
   /// .framework file already).
-  private func generateFrameworks(fromPods pods: [CocoaPodUtils.PodInfo],
+  private func generateFrameworks(fromPods pods: [String : CocoaPodUtils.PodInfo],
                                   inProjectDir projectDir: URL,
                                   carthageBuild: Bool = false) -> [String: [URL]] {
     // Verify the Pods folder exists and we can get the contents of it.
@@ -656,10 +663,10 @@ struct ZipBuilder {
     // Loop through each pod folder and check if the frameworks already exist, or they need to be
     // compiled. If they exist, add them to the frameworks dictionary.
     var toInstall: [String: [URL]] = [:]
-    for pod in pods {
+    for (podName, podInfo) in pods {
       var frameworks: [URL] = []
       // Ignore any Interop pods or the Firebase umbrella pod.
-      guard !pod.name.contains("Interop"), pod.name != "Firebase" else {
+      guard !podName.contains("Interop"), podName != "Firebase" else {
         continue
       }
 
@@ -667,18 +674,18 @@ struct ZipBuilder {
       var foundFrameworks: [URL]
       do {
         foundFrameworks = try fileManager.recursivelySearch(for: .frameworks,
-                                                            in: pod.installedLocation)
+                                                            in: podInfo.installedLocation)
       } catch {
         fatalError("Cannot search for .framework files in Pods directory " +
-          "\(pod.installedLocation): \(error)")
+          "\(podInfo.installedLocation): \(error)")
       }
 
       // If there are no frameworks, it's an open source pod and we need to compile the source to
       // get a framework.
       if foundFrameworks.isEmpty {
         let builder = FrameworkBuilder(projectDir: projectDir, carthageBuild: carthageBuild)
-        let framework = builder.buildFramework(withName: pod.name,
-                                               version: pod.version,
+        let framework = builder.buildFramework(withName: podName,
+                                               version: podInfo.version,
                                                logsOutputDir: paths.logsOutputDir)
 
         frameworks = [framework]
@@ -686,9 +693,9 @@ struct ZipBuilder {
         // Package all resources into the frameworks since that's how Carthage needs it packaged.
         do {
           // TODO: Figure out if we need to exclude bundles here or not.
-          try ResourcesManager.packageAllResources(containedIn: pod.installedLocation)
+          try ResourcesManager.packageAllResources(containedIn: podInfo.installedLocation)
         } catch {
-          fatalError("Tried to package resources for \(pod.name) but it failed: \(error)")
+          fatalError("Tried to package resources for \(podName) but it failed: \(error)")
         }
 
         // Copy each of the frameworks to a known temporary directory and store the location.
@@ -709,7 +716,7 @@ struct ZipBuilder {
         }
       }
 
-      toInstall[pod.name] = frameworks
+      toInstall[podName] = frameworks
     }
 
     return toInstall

--- a/ZipBuilder/Sources/ZipBuilder/main.swift
+++ b/ZipBuilder/Sources/ZipBuilder/main.swift
@@ -58,7 +58,8 @@ if args.zipPods == nil {
 } else {
   let (installedPods, frameworks) = builder.buildAndAssembleZip(podsToInstall: LaunchArgs.shared.zipPods!)
   let staging = FileManager.default.temporaryDirectory(withName: "staging")
-  try builder.copyFrameworks(fromPods: installedPods, toDirectory: staging, frameworkLocations: frameworks)
+  try builder.copyFrameworks(fromPods: Array(installedPods.keys), toDirectory: staging,
+                             frameworkLocations: frameworks)
   zipped = Zip.zipContents(ofDir: staging, name: "Frameworks.zip")
   print(zipped.absoluteString)
   if let outputDir = args.outputDir {


### PR DESCRIPTION
This is a speedup and prerequisite for supporting local podspec's.

See embedded comments below for more detail on the implementation.

#no-changelog