### PR TITLE
Disable use-libraries pod-lib-lint tests for Core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,13 +54,13 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseCoreDiagnostics.podspec --platforms=ios
 
     - stage: test
-      if: type = cron
+#      if: type = cron
       env:
         - PROJECT=CoreCron METHOD=pod-lib-lint
       script:
-        - travis_retry ./scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=ios --use-libraries
-        - travis_retry ./scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=tvos --use-libraries
-        - travis_retry ./scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=macos --use-libraries
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=ios --use-libraries --skip-tests
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=tvos --use-libraries --skip-tests
+        - travis_retry ./scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=macos --use-libraries --skip-tests
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=ios --use-modular-headers
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=tvos --use-modular-headers
         - travis_retry ./scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=macos --use-modular-headers

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseCoreDiagnostics.podspec --platforms=ios
 
     - stage: test
-#      if: type = cron
+      if: type = cron
       env:
         - PROJECT=CoreCron METHOD=pod-lib-lint
       script:


### PR DESCRIPTION
Disable pod lib lint testing with `--use-libraries` now that Core has Swift tests - introduced in #4448.  The cron tests [started failing](https://travis-ci.org/firebase/firebase-ios-sdk/jobs/621899598). 

Filed a CocoaPods feature request(https://github.com/CocoaPods/CocoaPods/issues/9392) to add support for selective test spec testing. 

#no-changelog