### PR TITLE
Updating Database Changelog

### DIFF
--- a/Firebase/Database/CHANGELOG.md
+++ b/Firebase/Database/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v6.1.3
+- [changed] Internal changes.
+
 # v6.1.2
 - [fixed] Addressed an issue with `NSDecimalNumber` case that prevented decimals with
   high precision to be stored correctly in our persistence layer. (#4108)


### PR DESCRIPTION
The only change (https://github.com/firebase/firebase-ios-sdk/pull/4328) is not yet exposed in the Public API and blocked on the backend rollout.