### PR TITLE
Make -[FIRInstanceID appInstanceID:] safe to be called from any thread

### DIFF
--- a/Firebase/InstanceID/FIRInstanceID+Private.m
+++ b/Firebase/InstanceID/FIRInstanceID+Private.m
@@ -40,6 +40,7 @@
 }
 
 - (NSString *)appInstanceID:(NSError **)outError {
+  // TODO: Delete the property and related code when the method is deleted.
   return self.firebaseInstallationsID;
 }
 

--- a/Firebase/InstanceID/FIRInstanceID+Private.m
+++ b/Firebase/InstanceID/FIRInstanceID+Private.m
@@ -39,8 +39,9 @@
   [self.tokenManager.authService fetchCheckinInfoWithHandler:handler];
 }
 
+// TODO(#4486): Delete the method, `self.firebaseInstallationsID` and related
+// code for Firebase 7 release.
 - (NSString *)appInstanceID:(NSError **)outError {
-  // TODO: Delete the property and related code when the method is deleted.
   return self.firebaseInstallationsID;
 }
 

--- a/Firebase/InstanceID/FIRInstanceID+Private.m
+++ b/Firebase/InstanceID/FIRInstanceID+Private.m
@@ -20,6 +20,7 @@
 
 #import <FirebaseInstanceID/FIRInstanceID_Private.h>
 #import "FIRInstanceIDAuthService.h"
+#import "FIRInstanceIDDefines.h"
 #import "FIRInstanceIDTokenManager.h"
 
 @class FIRInstallations;
@@ -39,22 +40,7 @@
 }
 
 - (NSString *)appInstanceID:(NSError **)outError {
-  dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-  __block NSString *instanceID;
-  __block NSError *error;
-  [self.installations installationIDWithCompletion:^(NSString *_Nullable identifier,
-                                                     NSError *_Nullable installationIDError) {
-    instanceID = identifier;
-    error = installationIDError;
-    dispatch_semaphore_signal(semaphore);
-  }];
-
-  dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
-  if (error && outError) {
-    *outError = error;
-  }
-
-  return instanceID;
+  return self.firebaseInstallationsID;
 }
 
 #pragma mark - Firebase Installations Compatibility

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -122,6 +122,9 @@ typedef NS_ENUM(NSInteger, FIRInstanceIDAPNSTokenType) {
 @property(atomic, strong, nullable)
     FIRInstanceIDCombinedHandler<NSString *> *defaultTokenFetchHandler;
 
+/// A cached value of FID. Should be used only for `-[FIRInstanceID appInstanceID:]`.
+@property(atomic, copy, nullable) NSString *firebaseInstallationsID;
+
 @end
 
 // InstanceID doesn't provide any functionality to other components,
@@ -611,6 +614,8 @@ static FIRInstanceID *gInstanceID;
   self.fcmSenderID = GCMSenderID;
   self.firebaseAppID = options.googleAppID;
 
+  [self updateFirebaseInstallationID];
+
   // FCM generates a FCM token during app start for sending push notification to device.
   // This is not needed for app extension.
   if (![GULAppEnvironmentUtil isAppExtension]) {
@@ -699,6 +704,7 @@ static FIRInstanceID *gInstanceID;
              selector:@selector(notifyAPNSTokenIsSet:)
                  name:kFIRInstanceIDAPNSTokenNotification
                object:nil];
+  [self observeFirebaseInstallationIDChanges];
 }
 
 #pragma mark - Private Helpers
@@ -1090,6 +1096,37 @@ static FIRInstanceID *gInstanceID;
   } else {
     FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeInstanceID015, @"%@", errorString);
   }
+}
+
+#pragma mark - Sync InstanceID
+
+- (void)updateFirebaseInstallationID {
+  FIRInstanceID_WEAKIFY(self);
+  [self.installations
+      installationIDWithCompletion:^(NSString *_Nullable installationID, NSError *_Nullable error) {
+        FIRInstanceID_STRONGIFY(self);
+        self.firebaseInstallationsID = installationID;
+      }];
+}
+
+- (void)installationIDDidChangeNotificationReceived:(NSNotification *)notification {
+  NSString *installationAppID =
+      notification.userInfo[kFIRInstallationIDDidChangeNotificationAppNameKey];
+  if ([installationAppID isKindOfClass:[NSString class]] &&
+      [installationAppID isEqual:self.firebaseAppID]) {
+    [self updateFirebaseInstallationID];
+  }
+}
+
+- (void)observeFirebaseInstallationIDChanges {
+  [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                  name:FIRInstallationIDDidChangeNotification
+                                                object:nil];
+  [[NSNotificationCenter defaultCenter]
+      addObserver:self
+         selector:@selector(installationIDDidChangeNotificationReceived:)
+             name:FIRInstallationIDDidChangeNotification
+           object:nil];
 }
 
 @end

--- a/Firebase/InstanceID/Private/FIRInstanceID_Private.h
+++ b/Firebase/InstanceID/Private/FIRInstanceID_Private.h
@@ -32,6 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, readonly, strong) FIRInstallations *installations;
 
+/// A cached value of FID. Should be used only for `-[FIRInstanceID appInstanceID:]`.
+@property(atomic, readonly, copy, nullable) NSString *firebaseInstallationsID;
+
 /**
  *  Private initializer.
  */


### PR DESCRIPTION
- use cached value of FID to be returned by `-[FIRInstanceID appInstanceID:]` instead of blocking thread waiting for `FirebaseInstallations` response.

b/145993195