### PR TITLE
Update CHANGELOG for Firestore v1.8.2

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v1.8.2
+- [changed] Internal improvements.
+
 # v1.8.1
 - [fixed] Firestore no longer loads its TLS certificates from a bundle, which
   fixes crashes at startup when the bundle can't be loaded. This fixes a


### PR DESCRIPTION
The only potentially changelog-worthy change in this list is #4418, but I don't think it has any practical effect that users can see or act on so it's probably not worth noting yet.