### PR TITLE
FirebaseInstallations - extensions support

### DIFF
--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -86,7 +86,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                         appName:appName
                                                          APIKey:appOptions.APIKey
                                                       projectID:appOptions.projectID
-                                                    GCMSenderID:appOptions.GCMSenderID];
+                                                    GCMSenderID:appOptions.GCMSenderID
+                                                    accessGroup:appOptions.appGroupID];
   return [self initWithAppOptions:appOptions
                           appName:appName
         installationsIDController:IDController

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.h
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.h
@@ -30,7 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
                             appName:(NSString *)appName
                              APIKey:(NSString *)APIKey
                           projectID:(NSString *)projectID
-                        GCMSenderID:(NSString *)GCMSenderID;
+                        GCMSenderID:(NSString *)GCMSenderID
+                        accessGroup:(NSString *)accessGroup;
 
 - (FBLPromise<FIRInstallationsItem *> *)getInstallationItem;
 

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -70,10 +70,11 @@ NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 
                             appName:(NSString *)appName
                              APIKey:(NSString *)APIKey
                           projectID:(NSString *)projectID
-                        GCMSenderID:(NSString *)GCMSenderID {
+                        GCMSenderID:(NSString *)GCMSenderID
+                        accessGroup:(NSString *)accessGroup {
   FIRSecureStorage *secureStorage = [[FIRSecureStorage alloc] init];
   FIRInstallationsStore *installationsStore =
-      [[FIRInstallationsStore alloc] initWithSecureStorage:secureStorage accessGroup:nil];
+      [[FIRInstallationsStore alloc] initWithSecureStorage:secureStorage accessGroup:accessGroup];
   FIRInstallationsAPIService *apiService =
       [[FIRInstallationsAPIService alloc] initWithAPIKey:APIKey projectID:projectID];
   FIRInstallationsIIDStore *IIDStore = [[FIRInstallationsIIDStore alloc] init];

--- a/FirebaseInstallations/Source/Library/InstallationsStore/FIRInstallationsStore.m
+++ b/FirebaseInstallations/Source/Library/InstallationsStore/FIRInstallationsStore.m
@@ -35,6 +35,7 @@ NSString *const kFIRInstallationsStoreUserDefaultsID = @"com.firebase.FIRInstall
 @property(nonatomic, readonly) FIRSecureStorage *secureStorage;
 @property(nonatomic, readonly, nullable) NSString *accessGroup;
 @property(nonatomic, readonly) dispatch_queue_t queue;
+@property(nonatomic, readonly) GULUserDefaults *userDefaults;
 @end
 
 @implementation FIRInstallationsStore
@@ -46,6 +47,9 @@ NSString *const kFIRInstallationsStoreUserDefaultsID = @"com.firebase.FIRInstall
     _secureStorage = storage;
     _accessGroup = [accessGroup copy];
     _queue = dispatch_queue_create("com.firebase.FIRInstallationsStore", DISPATCH_QUEUE_SERIAL);
+
+    NSString *userDefaultsSuiteName = _accessGroup ?: kFIRInstallationsStoreUserDefaultsID;
+    _userDefaults = [[GULUserDefaults alloc] initWithSuiteName:userDefaultsSuiteName];
   }
   return self;
 }
@@ -116,16 +120,6 @@ NSString *const kFIRInstallationsStoreUserDefaultsID = @"com.firebase.FIRInstall
 
                             return [NSNull null];
                           }];
-}
-
-- (GULUserDefaults *)userDefaults {
-  static GULUserDefaults *userDefaults;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    userDefaults = [[GULUserDefaults alloc] initWithSuiteName:kFIRInstallationsStoreUserDefaultsID];
-  });
-
-  return userDefaults;
 }
 
 @end

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsStoreTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsStoreTests.m
@@ -44,8 +44,7 @@
 
   // TODO: Replace real user defaults by an injected mock or a test specific user defaults instance
   // with a specific suite name.
-  self.userDefaults =
-      [[GULUserDefaults alloc] initWithSuiteName:self.accessGroup];
+  self.userDefaults = [[GULUserDefaults alloc] initWithSuiteName:self.accessGroup];
 }
 
 - (void)tearDown {

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsStoreTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsStoreTests.m
@@ -45,7 +45,7 @@
   // TODO: Replace real user defaults by an injected mock or a test specific user defaults instance
   // with a specific suite name.
   self.userDefaults =
-      [[GULUserDefaults alloc] initWithSuiteName:kFIRInstallationsStoreUserDefaultsID];
+      [[GULUserDefaults alloc] initWithSuiteName:self.accessGroup];
 }
 
 - (void)tearDown {


### PR DESCRIPTION
- use `FIROptions.appGroupID` as a user defaults suite name to keep secure storage in sync between the host app and extensions