### PR TITLE
Fix crash in Scene delegate swizzling when delegate is nil

### DIFF
--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -1069,7 +1069,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
 
   // Skip proxying if the class has a prefix of kGULAppDelegatePrefix, which means it has been
   // proxied before.
-  if ([className hasPrefix:kGULAppDelegatePrefix]) {
+  if (className == nil || [className hasPrefix:kGULAppDelegatePrefix]) {
     return;
   }
 

--- a/GoogleUtilities/Example/Tests/Swizzler/GULAppDelegateSwizzlerTest.m
+++ b/GoogleUtilities/Example/Tests/Swizzler/GULAppDelegateSwizzlerTest.m
@@ -1319,6 +1319,14 @@ API_AVAILABLE(ios(13.0), tvos(13.0))
 
 #if ((TARGET_OS_IOS || TARGET_OS_TV) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= 130000))
 
+- (void)testProxySceneDelegateWithNoSceneDelegate {
+  if (@available(iOS 13, tvOS 13, *)) {
+    id mockSharedScene = OCMClassMock([UIScene class]);
+    OCMStub([mockSharedScene delegate]).andReturn(nil);
+    XCTAssertNoThrow([GULAppDelegateSwizzler proxySceneDelegateIfNeeded:mockSharedScene]);
+  }
+}
+
 - (void)testProxySceneDelegate {
   if (@available(iOS 13, tvOS 13, *)) {
     GULTestSceneDelegate *realSceneDelegate = [[GULTestSceneDelegate alloc] init];


### PR DESCRIPTION
- check on `UIScene.delegate` before swizzling

b/146216242