### PR TITLE
FirebaseInstallations: require Core version with heartbeat

### DIFF
--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -29,9 +29,9 @@ Pod::Spec.new do |s|
   s.public_header_files = base_dir + 'Library/Public/*.h'
 
   s.framework = 'Security'
-  s.dependency 'FirebaseCore', '~> 6.0'
+  s.dependency 'FirebaseCore', '~> 6.4'
   s.dependency 'PromisesObjC', '~> 1.2'
-  s.dependency 'GoogleUtilities/UserDefaults', '~> 6.2'
+  s.dependency 'GoogleUtilities/UserDefaults', '~> 6.4'
 
   preprocessor_definitions = 'FIRInstallations_LIB_VERSION=' + String(s.version)
   if ENV['FIS_ALLOWS_INCOMPATIBLE_IID_VERSION'] && ENV['FIS_ALLOWS_INCOMPATIBLE_IID_VERSION'] == '1' then

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.public_header_files = base_dir + 'Library/Public/*.h'
 
   s.framework = 'Security'
-  s.dependency 'FirebaseCore', '~> 6.4'
+  s.dependency 'FirebaseCore', '~> 6.5'
   s.dependency 'PromisesObjC', '~> 1.2'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 6.4'
 


### PR DESCRIPTION
- FIS uses heartbeat code from Firebase Core, so it should require proper version of it.

#no-changelog