### PR TITLE
Update version for Firestore 1.8.3

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseFirestore'
-  s.version          = '1.8.2'
+  s.version          = '1.8.3'
   s.summary          = 'Google Cloud Firestore for iOS'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Firestore 1.8.3 is ready to go. The changelog has already been updated. Is there anything else that needs updating?