### PR TITLE
Work around spurious errors in GCC 4.8

### DIFF
--- a/Firestore/core/src/firebase/firestore/core/sync_engine.cc
+++ b/Firestore/core/src/firebase/firestore/core/sync_engine.cc
@@ -281,13 +281,19 @@ void SyncEngine::HandleRejectedListen(TargetId target_id, Status error) {
     // store's invariants with another method.
     NoDocument doc(limbo_key, SnapshotVersion::None(),
                    /* has_committed_mutations= */ false);
-    DocumentKeySet limbo_documents = DocumentKeySet{limbo_key};
-    RemoteEvent event{SnapshotVersion::None(), /*target_changes=*/{},
-                      /*target_mismatches=*/{},
-                      /*document_updates=*/{{limbo_key, doc}},
+
+    // Explicitly instantiate these to work around a spurious "chosen
+    // constructor is explicit in copy-initialization" error in the RemoteEvent
+    // constructor on GCC 4.9.
+    DocumentKeySet limbo_documents{limbo_key};
+    RemoteEvent::TargetChangeMap target_changes;
+    RemoteEvent::TargetSet target_mismatches;
+    RemoteEvent::DocumentUpdateMap document_updates{{limbo_key, doc}};
+
+    RemoteEvent event{SnapshotVersion::None(), std::move(target_changes),
+                      std::move(target_mismatches), std::move(document_updates),
                       std::move(limbo_documents)};
     ApplyRemoteEvent(event);
-
   } else {
     auto found = query_views_by_target_.find(target_id);
     HARD_ASSERT(found != query_views_by_target_.end(), "Unknown target id: %s",
@@ -308,10 +314,10 @@ void SyncEngine::HandleSuccessfulWrite(
     const model::MutationBatchResult& batch_result) {
   AssertCallbackExists("HandleSuccessfulWrite");
 
-  // The local store may or may not be able to apply the write result and raise
-  // events immediately (depending on whether the watcher is caught up), so we
-  // raise user callbacks first so that they consistently happen before listen
-  // events.
+  // The local store may or may not be able to apply the write result and
+  // raise events immediately (depending on whether the watcher is caught up),
+  // so we raise user callbacks first so that they consistently happen before
+  // listen events.
   NotifyUser(batch_result.batch().batch_id(), Status::OK());
 
   TriggerPendingWriteCallbacks(batch_result.batch().batch_id());
@@ -332,10 +338,10 @@ void SyncEngine::HandleRejectedWrite(
              error.error_message());
   }
 
-  // The local store may or may not be able to apply the write result and raise
-  // events immediately (depending on whether the watcher is caught up), so we
-  // raise user callbacks first so that they consistently happen before listen
-  // events.
+  // The local store may or may not be able to apply the write result and
+  // raise events immediately (depending on whether the watcher is caught up),
+  // so we raise user callbacks first so that they consistently happen before
+  // listen events.
   NotifyUser(batch_id, std::move(error));
 
   TriggerPendingWriteCallbacks(batch_id);
@@ -426,9 +432,9 @@ void SyncEngine::EmitNewSnapshotsAndNotifyLocalStore(
     View& view = query_view->view();
     ViewDocumentChanges view_doc_changes = view.ComputeDocumentChanges(changes);
     if (view_doc_changes.needs_refill()) {
-      // The query has a limit and some docs were removed/updated, so we need to
-      // re-run the query against the local store to make sure we didn't lose
-      // any good docs that had been past the limit.
+      // The query has a limit and some docs were removed/updated, so we need
+      // to re-run the query against the local store to make sure we didn't
+      // lose any good docs that had been past the limit.
       DocumentMap docs = local_store_->ExecuteQuery(query_view->query());
       view_doc_changes =
           view.ComputeDocumentChanges(docs.underlying_map(), view_doc_changes);

--- a/Firestore/core/src/firebase/firestore/core/sync_engine.cc
+++ b/Firestore/core/src/firebase/firestore/core/sync_engine.cc
@@ -282,9 +282,10 @@ void SyncEngine::HandleRejectedListen(TargetId target_id, Status error) {
     NoDocument doc(limbo_key, SnapshotVersion::None(),
                    /* has_committed_mutations= */ false);
 
-    // Explicitly instantiate these to work around a spurious "chosen
-    // constructor is explicit in copy-initialization" error in the RemoteEvent
-    // constructor on GCC 4.9.
+    // Explicitly instantiate these to work around a bug in the default
+    // constructor of the std::unordered_map that comes with GCC 4.8. Without
+    // this GCC emits a spurious "chosen constructor is explicit in
+    // copy-initialization" error.
     DocumentKeySet limbo_documents{limbo_key};
     RemoteEvent::TargetChangeMap target_changes;
     RemoteEvent::TargetSet target_mismatches;

--- a/Firestore/core/src/firebase/firestore/remote/remote_event.h
+++ b/Firestore/core/src/firebase/firestore/remote/remote_event.h
@@ -230,12 +230,16 @@ class TargetState {
  */
 class RemoteEvent {
  public:
+  using TargetChangeMap = std::unordered_map<model::TargetId, TargetChange>;
+  using TargetSet = std::unordered_set<model::TargetId>;
+  using DocumentUpdateMap = std::unordered_map<model::DocumentKey,
+                                               model::MaybeDocument,
+                                               model::DocumentKeyHash>;
+
   RemoteEvent(model::SnapshotVersion snapshot_version,
-              std::unordered_map<model::TargetId, TargetChange> target_changes,
-              std::unordered_set<model::TargetId> target_mismatches,
-              std::unordered_map<model::DocumentKey,
-                                 model::MaybeDocument,
-                                 model::DocumentKeyHash> document_updates,
+              TargetChangeMap target_changes,
+              TargetSet target_mismatches,
+              DocumentUpdateMap document_updates,
               model::DocumentKeySet limbo_document_changes)
       : snapshot_version_{snapshot_version},
         target_changes_{std::move(target_changes)},
@@ -250,8 +254,7 @@ class RemoteEvent {
   }
 
   /** A map from target to changes to the target. See `TargetChange`. */
-  const std::unordered_map<model::TargetId, TargetChange>& target_changes()
-      const {
+  const TargetChangeMap& target_changes() const {
     return target_changes_;
   }
 
@@ -259,7 +262,7 @@ class RemoteEvent {
    * A set of targets that is known to be inconsistent. Listens for these
    * targets should be re-established without resume tokens.
    */
-  const std::unordered_set<model::TargetId>& target_mismatches() const {
+  const TargetSet& target_mismatches() const {
     return target_mismatches_;
   }
 
@@ -267,10 +270,7 @@ class RemoteEvent {
    * A set of which documents have changed or been deleted, along with the doc's
    * new values (if not deleted).
    */
-  const std::unordered_map<model::DocumentKey,
-                           model::MaybeDocument,
-                           model::DocumentKeyHash>&
-  document_updates() const {
+  const DocumentUpdateMap& document_updates() const {
     return document_updates_;
   }
 
@@ -283,12 +283,9 @@ class RemoteEvent {
 
  private:
   model::SnapshotVersion snapshot_version_;
-  std::unordered_map<model::TargetId, TargetChange> target_changes_;
-  std::unordered_set<model::TargetId> target_mismatches_;
-  std::unordered_map<model::DocumentKey,
-                     model::MaybeDocument,
-                     model::DocumentKeyHash>
-      document_updates_;
+  TargetChangeMap target_changes_;
+  TargetSet target_mismatches_;
+  DocumentUpdateMap document_updates_;
   model::DocumentKeySet limbo_document_changes_;
 };
 
@@ -408,10 +405,7 @@ class WatchChangeAggregator {
   std::unordered_map<model::TargetId, TargetState> target_states_;
 
   /** Keeps track of the documents to update since the last raised snapshot. */
-  std::unordered_map<model::DocumentKey,
-                     model::MaybeDocument,
-                     model::DocumentKeyHash>
-      pending_document_updates_;
+  RemoteEvent::DocumentUpdateMap pending_document_updates_;
 
   /** A mapping of document keys to their set of target IDs. */
   std::unordered_map<model::DocumentKey,
@@ -424,7 +418,7 @@ class WatchChangeAggregator {
    * to be inconsistent and their listens needs to be re-established by
    * `RemoteStore`.
    */
-  std::unordered_set<model::TargetId> pending_target_resets_;
+  RemoteEvent::TargetSet pending_target_resets_;
 
   TargetMetadataProvider* target_metadata_provider_ = nullptr;
 };


### PR DESCRIPTION
GCC shows a "chosen constructor is explicit in copy-initialization" that
shouldn't occur. Also, since we're now explicitly instantiating these
values, add type aliases in RemoteEvent.

This effectively a port of cl/286120322 with cleanup.