### PR TITLE
FitebaseInstallations: fix create FID race condition

### DIFF
--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -137,7 +137,8 @@ NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 
 #pragma mark - Get Installation.
 
 - (FBLPromise<FIRInstallationsItem *> *)getInstallationItem {
-  return [self.getInstallationPromiseCache getExistingPendingOrCreateNewPromise];
+  return [self mostRecentInstallationOperation]
+             ?: [self.getInstallationPromiseCache getExistingPendingOrCreateNewPromise];
 }
 
 - (FBLPromise<FIRInstallationsItem *> *)createGetInstallationItemPromise {
@@ -305,7 +306,7 @@ NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 
               @"appName: %@",
               @(forceRefresh), self.appName);
 
-  return [self getInstallationItem]
+  return [self.getInstallationPromiseCache getExistingPendingOrCreateNewPromise]
       .then(^FBLPromise<FIRInstallationsItem *> *(FIRInstallationsItem *installation) {
         return [self registerInstallationIfNeeded:installation];
       })
@@ -344,7 +345,7 @@ NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 
     case FIRInstallationsAuthTokenHTTPCodeFIDNotFound:
       // The stored installation was damaged or blocked by the server.
       // Delete the stored installation then generate and register a new one.
-      return [self getInstallationItem]
+      return [self getStoredInstallation]
           .then(^FBLPromise<NSNull *> *(FIRInstallationsItem *installation) {
             return [self deleteInstallationLocally:installation];
           })

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
@@ -339,11 +339,7 @@
   OCMExpect([self.mockInstallationsStore installationForAppID:self.appID appName:self.appName])
       .andReturn(pendingStorePromise);
 
-  // 2. Expect FID registration to be done once.
-  // 2.1 Expect stored installation to be requested from the storage.
-  OCMExpect([self.mockInstallationsStore installationForAppID:self.appID appName:self.appName])
-      .andReturn([FBLPromise resolvedWith:storedInstallation1]);
-  // 2.2 Expect Create FID API request to be sent once.
+  // 2. Expect Create FID API request to be sent once.
   FBLPromise<FIRInstallationsItem *> *registrationErrorPromise = [FBLPromise pendingPromise];
   [registrationErrorPromise reject:[FIRInstallationsErrorUtil APIErrorWithHTTPCode:400]];
   OCMExpect([self.mockAPIService registerInstallation:storedInstallation1])

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
@@ -177,6 +177,7 @@
   // 5.5. Verify registered installation was saved.
   OCMVerifyAll(self.mockInstallationsStore);
   OCMVerifyAll(self.mockIIDStore);
+  OCMVerifyAll(self.mockAPIService);
 }
 
 - (void)testGetInstallationItem_WhenThereIsIIDAndNoFIDNotDefaultApp_ThenIIDIsUsedAsFID {
@@ -333,10 +334,20 @@
 - (void)testGetInstallationItem_WhenCalledSeveralTimes_OnlyOneOperationIsPerformed {
   // 1. Expect the installation to be requested from the store only once.
   FIRInstallationsItem *storedInstallation1 =
-      [FIRInstallationsItem createRegisteredInstallationItem];
+      [FIRInstallationsItem createUnregisteredInstallationItem];
   FBLPromise<FIRInstallationsItem *> *pendingStorePromise = [FBLPromise pendingPromise];
   OCMExpect([self.mockInstallationsStore installationForAppID:self.appID appName:self.appName])
       .andReturn(pendingStorePromise);
+
+  // 2. Expect FID registration to be done once.
+  // 2.1 Expect stored installation to be requested from the storage.
+  OCMExpect([self.mockInstallationsStore installationForAppID:self.appID appName:self.appName])
+      .andReturn([FBLPromise resolvedWith:storedInstallation1]);
+  // 2.2 Expect Create FID API request to be sent once.
+  FBLPromise<FIRInstallationsItem *> *registrationErrorPromise = [FBLPromise pendingPromise];
+  [registrationErrorPromise reject:[FIRInstallationsErrorUtil APIErrorWithHTTPCode:400]];
+  OCMExpect([self.mockAPIService registerInstallation:storedInstallation1])
+      .andReturn(registrationErrorPromise);
 
   // 3. Request installation n times
   NSInteger requestCount = 10;


### PR DESCRIPTION
If the method `-[FIRInstallationsIDController getInstallationItem]` is called multiple times while SDK is waiting for response for Create FID API request then other Create FID API requests with the same FID may be sent which. If such requests are sent then FIS server will treat the duplicated requests as FID conflict and reply with a new FID which will replace initial one.