### PR TITLE
Miscellaneous fixes

### DIFF
--- a/Firestore/Example/Tests/Integration/FSTTransactionTests.mm
+++ b/Firestore/Example/Tests/Integration/FSTTransactionTests.mm
@@ -233,8 +233,8 @@ TransactionStage get = ^(FIRTransaction *transaction, FIRDocumentReference *doc)
       completion:^(id _Nullable result, NSError *_Nullable error) {
         [expectation fulfill];
         NSString *message =
-            [NSString stringWithFormat:@"Expected the sequence %@, to succeed, but got %ld.",
-                                       [self stageNames], [error code]];
+            [NSString stringWithFormat:@"Expected the sequence %@, to succeed, but got %d.",
+                                       [self stageNames], (int)[error code]];
         [self->_testCase assertNilError:error message:message];
       }];
 

--- a/Firestore/Source/API/FIRDocumentSnapshot.mm
+++ b/Firestore/Source/API/FIRDocumentSnapshot.mm
@@ -267,7 +267,7 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
 }
 
 - (id)convertedReference:(const FieldValue &)value {
-  auto ref = value.reference_value();
+  const auto &ref = value.reference_value();
   const DatabaseId &refDatabase = ref.database_id();
   const DatabaseId &database = _snapshot.firestore()->database_id();
   if (refDatabase != database) {

--- a/Firestore/Source/API/FIRDocumentSnapshot.mm
+++ b/Firestore/Source/API/FIRDocumentSnapshot.mm
@@ -53,11 +53,13 @@ using firebase::firestore::api::SnapshotMetadata;
 using firebase::firestore::model::DatabaseId;
 using firebase::firestore::model::Document;
 using firebase::firestore::model::DocumentKey;
+using firebase::firestore::model::FieldPath;
 using firebase::firestore::model::FieldValue;
 using firebase::firestore::model::FieldValueOptions;
 using firebase::firestore::model::ObjectValue;
 using firebase::firestore::model::ServerTimestampBehavior;
 using firebase::firestore::nanopb::MakeNSData;
+using firebase::firestore::util::MakeString;
 using firebase::firestore::util::ThrowInvalidArgument;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -180,16 +182,16 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
 
 - (nullable id)valueForField:(id)field
      serverTimestampBehavior:(FIRServerTimestampBehavior)serverTimestampBehavior {
-  FIRFieldPath *fieldPath;
+  FieldPath fieldPath;
   if ([field isKindOfClass:[NSString class]]) {
-    fieldPath = [FIRFieldPath pathWithDotSeparatedString:field];
+    fieldPath = FieldPath::FromDotSeparatedString(MakeString(field));
   } else if ([field isKindOfClass:[FIRFieldPath class]]) {
-    fieldPath = field;
+    fieldPath = ((FIRFieldPath *)field).internalValue;
   } else {
     ThrowInvalidArgument("Subscript key must be an NSString or FIRFieldPath.");
   }
 
-  absl::optional<FieldValue> fieldValue = _snapshot.GetValue(fieldPath.internalValue);
+  absl::optional<FieldValue> fieldValue = _snapshot.GetValue(fieldPath);
   FieldValueOptions options = [self optionsForServerTimestampBehavior:serverTimestampBehavior];
   return !fieldValue ? nil : [self convertedValue:*fieldValue options:options];
 }
@@ -265,7 +267,7 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
 }
 
 - (id)convertedReference:(const FieldValue &)value {
-  const auto &ref = value.reference_value();
+  auto ref = value.reference_value();
   const DatabaseId &refDatabase = ref.database_id();
   const DatabaseId &database = _snapshot.firestore()->database_id();
   if (refDatabase != database) {

--- a/Firestore/Source/API/FSTUserDataConverter.mm
+++ b/Firestore/Source/API/FSTUserDataConverter.mm
@@ -200,7 +200,7 @@ NS_ASSUME_NONNULL_BEGIN
     FieldPath path;
 
     if ([key isKindOfClass:[NSString class]]) {
-      path = [FIRFieldPath pathWithDotSeparatedString:key].internalValue;
+      path = FieldPath::FromDotSeparatedString(util::MakeString(key));
     } else if ([key isKindOfClass:[FIRFieldPath class]]) {
       path = ((FIRFieldPath *)key).internalValue;
     } else {

--- a/Firestore/Swift/Tests/Codable/FirestoreEncoderTests.swift
+++ b/Firestore/Swift/Tests/Codable/FirestoreEncoderTests.swift
@@ -229,7 +229,7 @@ class FirestoreEncoderTests: XCTestCase {
       "s": "abc",
       "d": 123,
       "f": -4,
-      "l": 1_234_567_890_123,
+      "l": Int64(1_234_567_890_123),
       "i": -4444,
       "b": false,
       "sh": 123,

--- a/Firestore/core/src/firebase/firestore/local/leveldb_mutation_queue.cc
+++ b/Firestore/core/src/firebase/firestore/local/leveldb_mutation_queue.cc
@@ -421,6 +421,8 @@ ByteString LevelDbMutationQueue::GetLastStreamToken() {
 }
 
 void LevelDbMutationQueue::SetLastStreamToken(ByteString stream_token) {
+  std::free(metadata_->last_stream_token);
+
   metadata_->last_stream_token = stream_token.release();
   db_->current_transaction()->Put(mutation_queue_key(), metadata_);
 }

--- a/Firestore/core/src/firebase/firestore/nanopb/byte_string.cc
+++ b/Firestore/core/src/firebase/firestore/nanopb/byte_string.cc
@@ -71,7 +71,7 @@ ByteString& ByteString::operator=(const ByteString& other) {
   return *this;
 }
 
-ByteString& ByteString::operator=(ByteString&& other) {
+ByteString& ByteString::operator=(ByteString&& other) noexcept {
   if (bytes_ != other.bytes_) {
     std::free(bytes_);
     bytes_ = other.bytes_;

--- a/Firestore/core/src/firebase/firestore/nanopb/byte_string.cc
+++ b/Firestore/core/src/firebase/firestore/nanopb/byte_string.cc
@@ -55,11 +55,29 @@ ByteString::ByteString(const ByteString& other)
 }
 
 ByteString::ByteString(ByteString&& other) noexcept {
-  swap(*this, other);
+  bytes_ = other.bytes_;
+  other.bytes_ = nullptr;
 }
 
 ByteString::~ByteString() {
   std::free(bytes_);
+}
+
+ByteString& ByteString::operator=(const ByteString& other) {
+  if (bytes_ != other.bytes_) {
+    std::free(bytes_);
+    bytes_ = MakeBytesArray(other.data(), other.size());
+  }
+  return *this;
+}
+
+ByteString& ByteString::operator=(ByteString&& other) {
+  if (bytes_ != other.bytes_) {
+    std::free(bytes_);
+    bytes_ = other.bytes_;
+    other.bytes_ = nullptr;
+  }
+  return *this;
 }
 
 /* static */ ByteString ByteString::Take(pb_bytes_array_t* bytes) {

--- a/Firestore/core/src/firebase/firestore/nanopb/byte_string.h
+++ b/Firestore/core/src/firebase/firestore/nanopb/byte_string.h
@@ -80,10 +80,8 @@ class ByteString : public util::Comparable<ByteString> {
 
   ~ByteString();
 
-  ByteString& operator=(ByteString other) {
-    swap(*this, other);
-    return *this;
-  }
+  ByteString& operator=(const ByteString& other);
+  ByteString& operator=(ByteString&& other);
 
   friend void swap(ByteString& lhs, ByteString& rhs) noexcept;
 

--- a/Firestore/core/src/firebase/firestore/nanopb/byte_string.h
+++ b/Firestore/core/src/firebase/firestore/nanopb/byte_string.h
@@ -81,7 +81,7 @@ class ByteString : public util::Comparable<ByteString> {
   ~ByteString();
 
   ByteString& operator=(const ByteString& other);
-  ByteString& operator=(ByteString&& other);
+  ByteString& operator=(ByteString&& other) noexcept;
 
   friend void swap(ByteString& lhs, ByteString& rhs) noexcept;
 

--- a/Firestore/core/src/firebase/firestore/remote/grpc_completion.cc
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_completion.cc
@@ -41,7 +41,7 @@ void GrpcCompletion::WaitUntilOffQueue() {
   worker_queue_->VerifyIsCurrentQueue();
 
   EnsureValidFuture();
-  return off_queue_future_.wait();
+  off_queue_future_.wait();
 }
 
 std::future_status GrpcCompletion::WaitUntilOffQueue(

--- a/Firestore/core/src/firebase/firestore/remote/grpc_completion.cc
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_completion.cc
@@ -35,10 +35,8 @@ std::shared_ptr<GrpcCompletion> GrpcCompletion::Create(
 
   // Prepare the `GrpcCompletion` for submission to gRPC.
   //
-  // Note: this is a separate step from the constructor due to limitations in
-  // std::enable_shared_from_this. The internal weak_ptr that makes that work
-  // is is not initialized until after the shared_ptr for this object is
-  // created, which is only done after construction is complete.
+  // Note: this is done in a separate step because `shared_from_this` cannot be
+  // called in a constructor.
   completion->grpc_ownership_ = completion;
 
   return completion;

--- a/Firestore/core/src/firebase/firestore/remote/grpc_stream.cc
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_stream.cc
@@ -246,7 +246,10 @@ void GrpcStream::FastFinishCompletionsBlocking() {
     // This is blocking.
     completion->WaitUntilOffQueue();
 
-    // If the queue is shutting down it won't allow any completions to fire.
+    // If the queue is shutting down, it won't allow any completions to fire.
+    // This, in turn, causes them to leak because the completions delete
+    // themselves after calling their completion.
+    // TODO(wilhuff): Rework ownership here to avoid this ambiguity.
     if (queue_shutting_down) {
       delete completion;
     }

--- a/Firestore/core/src/firebase/firestore/remote/grpc_stream.cc
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_stream.cc
@@ -128,11 +128,11 @@ void GrpcStream::Read() {
     return;
   }
 
-  GrpcCompletion* completion =
-      NewCompletion(Type::Read, [this](const GrpcCompletion* completion) {
+  auto completion = NewCompletion(
+      Type::Read, [this](const std::shared_ptr<GrpcCompletion>& completion) {
         OnRead(*completion->message());
       });
-  call_->Read(completion->message(), completion);
+  call_->Read(completion->message(), completion.get());
 }
 
 void GrpcStream::Write(grpc::ByteBuffer&& message) {
@@ -151,11 +151,12 @@ void GrpcStream::MaybeWrite(absl::optional<BufferedWrite> maybe_write) {
   }
 
   BufferedWrite write = std::move(maybe_write).value();
-  GrpcCompletion* completion =
-      NewCompletion(Type::Write, [this](const GrpcCompletion*) { OnWrite(); });
+  auto completion = NewCompletion(
+      Type::Write,
+      [this](const std::shared_ptr<GrpcCompletion>&) { OnWrite(); });
   *completion->message() = write.message;
 
-  call_->Write(*completion->message(), write.options, completion);
+  call_->Write(*completion->message(), write.options, completion.get());
 }
 
 void GrpcStream::FinishImmediately() {
@@ -223,8 +224,8 @@ void GrpcStream::FinishGrpcCall(const OnSuccess& callback) {
   // All completions issued by this call must be taken off the queue before
   // finish operation can be enqueued.
   FastFinishCompletionsBlocking();
-  GrpcCompletion* completion = NewCompletion(Type::Finish, callback);
-  call_->Finish(completion->status(), completion);
+  auto completion = NewCompletion(Type::Finish, callback);
+  call_->Finish(completion->status(), completion.get());
 }
 
 void GrpcStream::FastFinishCompletionsBlocking() {
@@ -234,26 +235,19 @@ void GrpcStream::FastFinishCompletionsBlocking() {
   // TODO(varconst): reset buffered_writer_? Should not be necessary, because it
   // should never be called again after a call to Finish.
 
-  for (auto completion : completions_) {
+  for (const auto& completion : completions_) {
     // `GrpcStream` cannot actually remove any of the completions that already
     // have been enqueued on the worker queue, so instead turn them into no-ops.
     completion->Cancel();
   }
 
-  bool queue_shutting_down = worker_queue_->is_shutting_down();
-
-  for (auto completion : completions_) {
+  for (const auto& completion : completions_) {
     // This is blocking.
     completion->WaitUntilOffQueue();
-
-    // If the queue is shutting down, it won't allow any completions to fire.
-    // This, in turn, causes them to leak because the completions delete
-    // themselves after calling their completion.
-    // TODO(wilhuff): Rework ownership here to avoid this ambiguity.
-    if (queue_shutting_down) {
-      delete completion;
-    }
   }
+
+  // This will release all the shared pointers to GrpcCompletion, leaving it
+  // up to gRPC to actually call Complete and trigger deletion.
   completions_.clear();
 }
 
@@ -275,9 +269,10 @@ bool GrpcStream::TryLastWrite(grpc::ByteBuffer&& message) {
   }
 
   BufferedWrite last_write = std::move(maybe_write).value();
-  GrpcCompletion* completion = NewCompletion(Type::Write, {});
+  auto completion = NewCompletion(Type::Write, {});
   *completion->message() = last_write.message;
-  call_->WriteLast(*completion->message(), grpc::WriteOptions{}, completion);
+  call_->WriteLast(*completion->message(), grpc::WriteOptions{},
+                   completion.get());
 
   // Empirically, the write normally takes less than a millisecond to finish
   // (both with and without network connection), and never more than several
@@ -321,23 +316,25 @@ void GrpcStream::OnOperationFailed() {
     return;
   }
 
-  FinishGrpcCall([this](const GrpcCompletion* completion) {
+  FinishGrpcCall([this](const std::shared_ptr<GrpcCompletion>& completion) {
     Status status = ConvertStatus(*completion->status());
     FinishAndNotify(status);
   });
 }
 
-void GrpcStream::RemoveCompletion(const GrpcCompletion* to_remove) {
+void GrpcStream::RemoveCompletion(
+    const std::shared_ptr<GrpcCompletion>& to_remove) {
   auto found = std::find(completions_.begin(), completions_.end(), to_remove);
   HARD_ASSERT(found != completions_.end(), "Missing GrpcCompletion");
   completions_.erase(found);
 }
 
-GrpcCompletion* GrpcStream::NewCompletion(Type tag,
-                                          const OnSuccess& on_success) {
+std::shared_ptr<GrpcCompletion> GrpcStream::NewCompletion(
+    Type tag, const OnSuccess& on_success) {
   // Can't move into lambda until C++14.
   GrpcCompletion::Callback decorated =
-      [this, on_success](bool ok, const GrpcCompletion* completion) {
+      [this, on_success](bool ok,
+                         const std::shared_ptr<GrpcCompletion>& completion) {
         RemoveCompletion(completion);
 
         if (ok) {
@@ -354,8 +351,9 @@ GrpcCompletion* GrpcStream::NewCompletion(Type tag,
       };
 
   // For lifetime details, see `GrpcCompletion` class comment.
-  auto* completion =
-      new GrpcCompletion{tag, worker_queue_, std::move(decorated)};
+  auto completion = std::make_shared<GrpcCompletion>(tag, worker_queue_,
+                                                     std::move(decorated));
+  completion->Retain();
   completions_.push_back(completion);
   return completion;
 }

--- a/Firestore/core/src/firebase/firestore/remote/grpc_stream.cc
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_stream.cc
@@ -351,9 +351,8 @@ std::shared_ptr<GrpcCompletion> GrpcStream::NewCompletion(
       };
 
   // For lifetime details, see `GrpcCompletion` class comment.
-  auto completion = std::make_shared<GrpcCompletion>(tag, worker_queue_,
-                                                     std::move(decorated));
-  completion->Retain();
+  auto completion =
+      GrpcCompletion::Create(tag, worker_queue_, std::move(decorated));
   completions_.push_back(completion);
   return completion;
 }

--- a/Firestore/core/src/firebase/firestore/remote/grpc_stream.cc
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_stream.cc
@@ -240,9 +240,16 @@ void GrpcStream::FastFinishCompletionsBlocking() {
     completion->Cancel();
   }
 
+  bool queue_shutting_down = worker_queue_->is_shutting_down();
+
   for (auto completion : completions_) {
     // This is blocking.
     completion->WaitUntilOffQueue();
+
+    // If the queue is shutting down it won't allow any completions to fire.
+    if (queue_shutting_down) {
+      delete completion;
+    }
   }
   completions_.clear();
 }

--- a/Firestore/core/src/firebase/firestore/remote/grpc_stream.h
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_stream.h
@@ -127,7 +127,7 @@ class GrpcStream : public GrpcCall {
              const std::shared_ptr<util::AsyncQueue>& worker_queue,
              GrpcConnection* grpc_connection,
              GrpcStreamObserver* observer);
-  ~GrpcStream();
+  ~GrpcStream() override;
 
   void Start();
 
@@ -196,11 +196,11 @@ class GrpcStream : public GrpcCall {
   void OnRead(const grpc::ByteBuffer& message);
   void OnWrite();
   void OnOperationFailed();
-  void RemoveCompletion(const GrpcCompletion* to_remove);
+  void RemoveCompletion(const std::shared_ptr<GrpcCompletion>& to_remove);
 
-  using OnSuccess = std::function<void(const GrpcCompletion*)>;
-  GrpcCompletion* NewCompletion(GrpcCompletion::Type type,
-                                const OnSuccess& callback);
+  using OnSuccess = std::function<void(const std::shared_ptr<GrpcCompletion>&)>;
+  std::shared_ptr<GrpcCompletion> NewCompletion(GrpcCompletion::Type type,
+                                                const OnSuccess& callback);
   // Finishes the underlying gRPC call. Must always be invoked on any call that
   // was started. Presumes that any pending completions will quickly come off
   // the queue and will block until they do, so this must only be invoked when
@@ -235,7 +235,7 @@ class GrpcStream : public GrpcCall {
   GrpcStreamObserver* observer_ = nullptr;
   internal::BufferedWriter buffered_writer_;
 
-  std::vector<GrpcCompletion*> completions_;
+  std::vector<std::shared_ptr<GrpcCompletion>> completions_;
 
   // gRPC asserts that a call is finished exactly once.
   bool is_grpc_call_finished_ = false;

--- a/Firestore/core/src/firebase/firestore/remote/grpc_unary_call.cc
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_unary_call.cc
@@ -55,7 +55,7 @@ void GrpcUnaryCall::Start(Callback&& callback) {
   call_->StartCall();
 
   // For lifetime details, see `GrpcCompletion` class comment.
-  finish_completion_ = std::make_shared<GrpcCompletion>(
+  finish_completion_ = GrpcCompletion::Create(
       Type::Finish, worker_queue_,
       [this](bool /*ignored_ok*/,
              const std::shared_ptr<GrpcCompletion>& completion) {
@@ -74,7 +74,7 @@ void GrpcUnaryCall::Start(Callback&& callback) {
       });
 
   call_->Finish(finish_completion_->message(), finish_completion_->status(),
-                finish_completion_->Retain());
+                finish_completion_.get());
 }
 
 void GrpcUnaryCall::FinishImmediately() {

--- a/Firestore/core/src/firebase/firestore/remote/grpc_unary_call.cc
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_unary_call.cc
@@ -55,11 +55,12 @@ void GrpcUnaryCall::Start(Callback&& callback) {
   call_->StartCall();
 
   // For lifetime details, see `GrpcCompletion` class comment.
-  finish_completion_ = new GrpcCompletion(
+  finish_completion_ = std::make_shared<GrpcCompletion>(
       Type::Finish, worker_queue_,
-      [this](bool /*ignored_ok*/, const GrpcCompletion* completion) {
+      [this](bool /*ignored_ok*/,
+             const std::shared_ptr<GrpcCompletion>& completion) {
         // Ignoring ok, status should contain all the relevant information.
-        finish_completion_ = nullptr;
+        finish_completion_.reset();
         Shutdown();
 
         auto callback = std::move(callback_);
@@ -73,7 +74,7 @@ void GrpcUnaryCall::Start(Callback&& callback) {
       });
 
   call_->Finish(finish_completion_->message(), finish_completion_->status(),
-                finish_completion_);
+                finish_completion_->Retain());
 }
 
 void GrpcUnaryCall::FinishImmediately() {
@@ -99,7 +100,7 @@ void GrpcUnaryCall::Shutdown() {
   finish_completion_->Cancel();
   // This function blocks.
   finish_completion_->WaitUntilOffQueue();
-  finish_completion_ = nullptr;
+  finish_completion_.reset();
 }
 
 void GrpcUnaryCall::MaybeUnregister() {

--- a/Firestore/core/src/firebase/firestore/remote/grpc_unary_call.h
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_unary_call.h
@@ -102,7 +102,7 @@ class GrpcUnaryCall : public GrpcCall {
   std::shared_ptr<util::AsyncQueue> worker_queue_;
   GrpcConnection* grpc_connection_ = nullptr;
 
-  GrpcCompletion* finish_completion_ = nullptr;
+  std::shared_ptr<GrpcCompletion> finish_completion_;
   Callback callback_;
 };
 

--- a/Firestore/core/src/firebase/firestore/util/async_queue.cc
+++ b/Firestore/core/src/firebase/firestore/util/async_queue.cc
@@ -75,8 +75,8 @@ void AsyncQueue::EnqueueAndInitiateShutdown(const Operation& operation) {
   if (is_shutting_down_) {
     return;
   }
-  executor_->Execute(Wrap(operation));
   is_shutting_down_ = true;
+  executor_->Execute(Wrap(operation));
 }
 
 void AsyncQueue::EnqueueEvenAfterShutdown(const Operation& operation) {

--- a/Firestore/core/test/firebase/firestore/local/lru_garbage_collector_test.cc
+++ b/Firestore/core/test/firebase/firestore/local/lru_garbage_collector_test.cc
@@ -655,7 +655,7 @@ TEST_P(LruGarbageCollectorTest, RemoveTargetsThenGC) {
 TEST_P(LruGarbageCollectorTest, GetsSize) {
   NewTestResources();
 
-  size_t initial_size = gc_->CalculateByteSize();
+  int64_t initial_size = gc_->CalculateByteSize();
 
   persistence_->Run("fill cache", [&] {
     // Simulate a bunch of ack'd mutations.
@@ -665,7 +665,7 @@ TEST_P(LruGarbageCollectorTest, GetsSize) {
     }
   });
 
-  size_t final_size = gc_->CalculateByteSize();
+  int64_t final_size = gc_->CalculateByteSize();
   ASSERT_GT(final_size, initial_size);
 }
 

--- a/Firestore/core/test/firebase/firestore/local/persistence_testing.cc
+++ b/Firestore/core/test/firebase/firestore/local/persistence_testing.cc
@@ -63,8 +63,8 @@ Path LevelDbDir() {
 
 std::unique_ptr<LevelDbPersistence> LevelDbPersistenceForTesting(
     Path dir, LruParams lru_params) {
-  auto created = LevelDbPersistence::Create(std::move(dir),
-                                            MakeLocalSerializer(), lru_params);
+  auto created =
+      LevelDbPersistence::Create(dir, MakeLocalSerializer(), lru_params);
   if (!created.ok()) {
     util::ThrowIllegalState("Failed to open leveldb in dir %s: %s",
                             dir.ToUtf8String(), created.status().ToString());

--- a/Firestore/core/test/firebase/firestore/nanopb/byte_string_test.cc
+++ b/Firestore/core/test/firebase/firestore/nanopb/byte_string_test.cc
@@ -31,6 +31,22 @@ using testing::ContainerEq;
 
 namespace {
 
+struct free_deleter {
+  template <typename T>
+  void operator()(T* value) const {
+    using non_const_T = typename std::remove_const<T*>::type;
+    free(const_cast<non_const_T>(value));
+  }
+};
+
+template <typename T>
+using freed_ptr = std::unique_ptr<T, free_deleter>;
+
+pb_bytes_array_t* MakeBytesArray(pb_size_t size) {
+  return static_cast<pb_bytes_array_t*>(
+      malloc(PB_BYTES_ARRAY_T_ALLOCSIZE(size)));
+}
+
 std::vector<uint8_t> MakeVector(const std::string& str) {
   auto begin = reinterpret_cast<const uint8_t*>(str.data());
   return {begin, begin + str.size()};
@@ -57,14 +73,13 @@ TEST(ByteStringTest, DefaultConstructor) {
 }
 
 TEST(ByteStringTest, Copy) {
-  auto original =
-      static_cast<pb_bytes_array_t*>(malloc(PB_BYTES_ARRAY_T_ALLOCSIZE(4)));
+  freed_ptr<pb_bytes_array_t> original(MakeBytesArray(4));
   memcpy(original->bytes, "foo", 4);  // null terminator
   original->size = 3;
 
-  ByteString copy{original};
+  ByteString copy{original.get()};
   EXPECT_THAT(copy, BytesEq("foo"));
-  EXPECT_NE(copy.get(), original);
+  EXPECT_NE(copy.get(), original.get());
 }
 
 TEST(ByteStringTest, FromStdString) {
@@ -86,8 +101,7 @@ TEST(ByteStringTest, FromCString) {
 }
 
 TEST(ByteStringTest, TakesNullTerminatedByteArray) {
-  auto original =
-      static_cast<pb_bytes_array_t*>(malloc(PB_BYTES_ARRAY_T_ALLOCSIZE(4)));
+  auto original = MakeBytesArray(4);
   memcpy(original->bytes, "foo", 4);  // null terminator
   original->size = 3;
 
@@ -99,8 +113,7 @@ TEST(ByteStringTest, TakesNullTerminatedByteArray) {
 }
 
 TEST(ByteStringTest, TakesUnterminatedByteArray) {
-  auto original =
-      static_cast<pb_bytes_array_t*>(malloc(PB_BYTES_ARRAY_T_ALLOCSIZE(3)));
+  auto original = MakeBytesArray(3);
   memcpy(original->bytes, "foo", 3);  // no null terminator
   original->size = 3;
 
@@ -112,8 +125,7 @@ TEST(ByteStringTest, TakesUnterminatedByteArray) {
 }
 
 TEST(ByteStringTest, TakesEmptyByteArray) {
-  auto original =
-      static_cast<pb_bytes_array_t*>(malloc(PB_BYTES_ARRAY_T_ALLOCSIZE(0)));
+  auto original = MakeBytesArray(0);
   original->size = 0;
 
   ByteString wrapper = ByteString::Take(original);

--- a/Firestore/core/test/firebase/firestore/nanopb/byte_string_test.cc
+++ b/Firestore/core/test/firebase/firestore/nanopb/byte_string_test.cc
@@ -34,8 +34,7 @@ namespace {
 struct free_deleter {
   template <typename T>
   void operator()(T* value) const {
-    using non_const_T = typename std::remove_const<T*>::type;
-    free(const_cast<non_const_T>(value));
+    std::free(value);
   }
 };
 

--- a/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
+++ b/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
@@ -121,7 +121,7 @@ const char* const kDatabaseId = "d";
 
 // These helper functions are just shorter aliases to reduce verbosity.
 ByteString ToBytes(const std::string& str) {
-  return ByteString{Serializer::EncodeString(str)};
+  return ByteString::Take(Serializer::EncodeString(str));
 }
 
 std::string FromBytes(pb_bytes_array_t*&& ptr) {
@@ -1516,6 +1516,8 @@ TEST_F(SerializerTest, EncodesListenRequestLabels) {
     for (auto& label_entry : result) {
       result_in_map[serializer.DecodeString(label_entry.key)] =
           serializer.DecodeString(label_entry.value);
+      pb_release(google_firestore_v1_ListenRequest_LabelsEntry_fields,
+                 &label_entry);
     }
 
     EXPECT_EQ(result_in_map, p.second);


### PR DESCRIPTION
See individual commits for descriptions.

The only ~serious issues are:

  * ba75105 Fixes a leaking stream token on every mutation acknowledgement
  * 6a34b23 Fixes leaking ByteStrings; clang wasn't using the by-value assignment operator correctly
  * f5f7980 Fixes leaking GrpcCompletions during shutdown.

With these changes in place, it's possible to get a relatively clean run of Instruments > Leaks during the integration tests, though occasionally the spec tests kick up a bunch of spurious leaks. Given that we're rewriting these in C++ I'm not inclined toward actually addressing this now.