### PR TITLE
Update swift-protobuf dependency

### DIFF
--- a/ZipBuilder/Package.swift
+++ b/ZipBuilder/Package.swift
@@ -26,6 +26,8 @@ let package = Package(
     .executable(name: "UpdateFirebasePod", targets: ["UpdateFirebasePod"]),
   ],
   dependencies: [
+    // Keep the generated protos in sync with the version below.
+    // See https://github.com/firebase/firebase-ios-sdk/tree/master/ZipBuilder#updating-protobuf-generated-swift-files.
     .package(url: "https://github.com/apple/swift-protobuf.git", .exact("1.7.0")),
   ],
   targets: [

--- a/ZipBuilder/Package.swift
+++ b/ZipBuilder/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     .executable(name: "UpdateFirebasePod", targets: ["UpdateFirebasePod"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-protobuf.git", .exact("1.2.0")),
+    .package(url: "https://github.com/apple/swift-protobuf.git", .exact("1.7.0")),
   ],
   targets: [
     .target(


### PR DESCRIPTION
This also fixes the ZipBuilder build warnings.

Verified that a release build matches M61 as expected.

#no-changelog
