### PR TITLE
Revert "FitebaseInstallations: fix create FID race condition"

### DIFF
--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -137,8 +137,7 @@ NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 
 #pragma mark - Get Installation.
 
 - (FBLPromise<FIRInstallationsItem *> *)getInstallationItem {
-  return [self mostRecentInstallationOperation]
-             ?: [self.getInstallationPromiseCache getExistingPendingOrCreateNewPromise];
+  return [self.getInstallationPromiseCache getExistingPendingOrCreateNewPromise];
 }
 
 - (FBLPromise<FIRInstallationsItem *> *)createGetInstallationItemPromise {
@@ -306,7 +305,7 @@ NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 
               @"appName: %@",
               @(forceRefresh), self.appName);
 
-  return [self.getInstallationPromiseCache getExistingPendingOrCreateNewPromise]
+  return [self getInstallationItem]
       .then(^FBLPromise<FIRInstallationsItem *> *(FIRInstallationsItem *installation) {
         return [self registerInstallationIfNeeded:installation];
       })
@@ -345,7 +344,7 @@ NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 
     case FIRInstallationsAuthTokenHTTPCodeFIDNotFound:
       // The stored installation was damaged or blocked by the server.
       // Delete the stored installation then generate and register a new one.
-      return [self getStoredInstallation]
+      return [self getInstallationItem]
           .then(^FBLPromise<NSNull *> *(FIRInstallationsItem *installation) {
             return [self deleteInstallationLocally:installation];
           })

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
@@ -177,7 +177,6 @@
   // 5.5. Verify registered installation was saved.
   OCMVerifyAll(self.mockInstallationsStore);
   OCMVerifyAll(self.mockIIDStore);
-  OCMVerifyAll(self.mockAPIService);
 }
 
 - (void)testGetInstallationItem_WhenThereIsIIDAndNoFIDNotDefaultApp_ThenIIDIsUsedAsFID {
@@ -334,16 +333,10 @@
 - (void)testGetInstallationItem_WhenCalledSeveralTimes_OnlyOneOperationIsPerformed {
   // 1. Expect the installation to be requested from the store only once.
   FIRInstallationsItem *storedInstallation1 =
-      [FIRInstallationsItem createUnregisteredInstallationItem];
+      [FIRInstallationsItem createRegisteredInstallationItem];
   FBLPromise<FIRInstallationsItem *> *pendingStorePromise = [FBLPromise pendingPromise];
   OCMExpect([self.mockInstallationsStore installationForAppID:self.appID appName:self.appName])
       .andReturn(pendingStorePromise);
-
-  // 2. Expect Create FID API request to be sent once.
-  FBLPromise<FIRInstallationsItem *> *registrationErrorPromise = [FBLPromise pendingPromise];
-  [registrationErrorPromise reject:[FIRInstallationsErrorUtil APIErrorWithHTTPCode:400]];
-  OCMExpect([self.mockAPIService registerInstallation:storedInstallation1])
-      .andReturn(registrationErrorPromise);
 
   // 3. Request installation n times
   NSInteger requestCount = 10;


### PR DESCRIPTION
Reverts firebase/firebase-ios-sdk#4576

The PR is to be reverted because:
- the test introduced in #4576 was incorrect and didn't reflect a real world scenario. With actual usage this type of race condition does not occur. 
- the fix introduces another issue(b/147230513) .

