### PR TITLE
Cache ccache output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ os: osx
 osx_image: xcode11.3
 language: objective-c
 cache:
-  - bundler
-  - cocoapods
+  bundler: true
+  cocoapods: true
+  ccache: true
 
 stages:
   - checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ cache:
   bundler: true
   cocoapods: true
   directories:
-    - Firestore/Example/Pods
-    - gen/Pods
+    # Built-in support for ccache doesn't seem to pick this up
     - $HOME/.ccache
 
 stages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ language: objective-c
 cache:
   bundler: true
   cocoapods: true
-  ccache: true
   directories:
     - Firestore/Example/Pods
+    - gen/Pods
+    - $HOME/.ccache
 
 stages:
   - checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ cache:
   bundler: true
   cocoapods: true
   ccache: true
+  directories:
+    - Firestore/Example/Pods
 
 stages:
   - checks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ if(POLICY CMP0058)
 endif()
 
 # Enable the ccache compilation cache, if available.
+message("PATH is $ENV{PATH}")
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
   message("Using ccache: ${CCACHE_PROGRAM}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ endif()
 # Enable the ccache compilation cache, if available.
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
+  message("Using ccache: ${CCACHE_PROGRAM}")
   set(CMAKE_C_COMPILER_LAUNCHER   "${CCACHE_PROGRAM}")
   set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,10 +41,9 @@ if(POLICY CMP0058)
 endif()
 
 # Enable the ccache compilation cache, if available.
-message("PATH is $ENV{PATH}")
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
-  message("Using ccache: ${CCACHE_PROGRAM}")
+  message(STATUS "Found ccache: ${CCACHE_PROGRAM}")
   set(CMAKE_C_COMPILER_LAUNCHER   "${CCACHE_PROGRAM}")
   set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
 endif()

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -123,6 +123,7 @@ case "$PROJECT-$PLATFORM-$METHOD" in
   Firestore-*-cmake)
     brew outdated cmake || brew upgrade cmake
     brew outdated go || brew upgrade go # Somehow the build for Abseil requires this.
+    brew install ccache
 
     # Install python packages required to generate proto sources
     pip install six


### PR DESCRIPTION
Reuse object files from unchanged sources between builds.

This brings a rebuild of the Firestore CMake build down from 20 min 37 sec,  to 9 min 13 sec:

  * Before: https://travis-ci.org/firebase/firebase-ios-sdk/jobs/635423433
  * After: https://travis-ci.org/firebase/firebase-ios-sdk/jobs/635295223

#no-changelog