### PR TITLE
Fix Crashlytics C imports

### DIFF
--- a/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.c
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.c
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "FIRCLSSignal.h"
-#include "FIRCLSFeatures.h"
 #include "FIRCLSGlobals.h"
 #include "FIRCLSHandler.h"
 #include "FIRCLSUtility.h"

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.h
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "FIRCLSFeatures.h"
 #include "FIRCLSFile.h"
 
 #include <signal.h>

--- a/Crashlytics/Crashlytics/Unwind/Dwarf/FIRCLSDwarfExpressionMachine.c
+++ b/Crashlytics/Crashlytics/Unwind/Dwarf/FIRCLSDwarfExpressionMachine.c
@@ -16,7 +16,6 @@
 #include "FIRCLSDataParsing.h"
 #include "FIRCLSDefines.h"
 #include "FIRCLSDwarfUnwindRegisters.h"
-#include "FIRCLSFeatures.h"
 #include "FIRCLSUnwind_arch.h"
 #include "FIRCLSUtility.h"
 #include "dwarf.h"

--- a/Crashlytics/Crashlytics/Unwind/Dwarf/FIRCLSDwarfExpressionMachine.h
+++ b/Crashlytics/Crashlytics/Unwind/Dwarf/FIRCLSDwarfExpressionMachine.h
@@ -16,6 +16,8 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+
+#include "FIRCLSFeatures.h"
 #include "FIRCLSThreadState.h"
 
 #define CLS_DWARF_EXPRESSION_STACK_SIZE (100)

--- a/Crashlytics/Crashlytics/Unwind/Dwarf/FIRCLSDwarfUnwind.h
+++ b/Crashlytics/Crashlytics/Unwind/Dwarf/FIRCLSDwarfUnwind.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include "FIRCLSDwarfUnwindRegisters.h"
-#include "FIRCLSFeatures.h"
 #include "FIRCLSThreadState.h"
 
 #include <stdbool.h>

--- a/Crashlytics/Crashlytics/Unwind/Dwarf/FIRCLSDwarfUnwindRegisters.h
+++ b/Crashlytics/Crashlytics/Unwind/Dwarf/FIRCLSDwarfUnwindRegisters.h
@@ -16,6 +16,8 @@
 
 #include <stdint.h>
 
+#include "FIRCLSFeatures.h"
+
 #if CLS_CPU_X86_64
 enum {
   CLS_DWARF_X86_64_RAX = 0,


### PR DESCRIPTION
Running `clang-format` exposed some places where headers needed to be imported.