### PR TITLE
Crashlytics allow for both types of Promise imports

### DIFF
--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -14,7 +14,11 @@
 
 #include <stdatomic.h>
 
+#if __has_include(<FBLPromises/FBLPromises.h>)
+#import <FBLPromises/FBLPromises.h>
+#else
 #import "FBLPromises.h"
+#endif
 
 #import "FIRCLSApplication.h"
 #import "FIRCLSDataCollectionArbiter.h"

--- a/Crashlytics/Crashlytics/DataCollection/FIRCLSDataCollectionArbiter.m
+++ b/Crashlytics/Crashlytics/DataCollection/FIRCLSDataCollectionArbiter.m
@@ -14,7 +14,11 @@
 
 #import "FIRCLSDataCollectionArbiter.h"
 
+#if __has_include(<FBLPromises/FBLPromises.h>)
+#import <FBLPromises/FBLPromises.h>
+#else
 #import "FBLPromises.h"
+#endif
 
 #import "FIRApp.h"
 #import "FIRCLSUserDefaults.h"

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -14,7 +14,11 @@
 
 #include <stdatomic.h>
 
+#if __has_include(<FBLPromises/FBLPromises.h>)
+#import <FBLPromises/FBLPromises.h>
+#else
 #import "FBLPromises.h"
+#endif
 
 #include "FIRCLSCrashedMarkerFile.h"
 #import "FIRCLSDataCollectionArbiter.h"

--- a/Crashlytics/Crashlytics/Models/FIRCLSSettings.h
+++ b/Crashlytics/Crashlytics/Models/FIRCLSSettings.h
@@ -14,7 +14,11 @@
 
 #import <Foundation/Foundation.h>
 
-#import "FBLPromise.h"
+#if __has_include(<FBLPromises/FBLPromises.h>)
+#import <FBLPromises/FBLPromises.h>
+#else
+#import "FBLPromises.h"
+#endif
 
 @class FIRCLSApplicationIdentifierModel;
 @class FIRCLSFileManager;

--- a/Crashlytics/Crashlytics/Models/FIRCLSSettings.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSSettings.m
@@ -14,7 +14,11 @@
 
 #import "FIRCLSSettings.h"
 
-#import "FBLPromise.h"
+#if __has_include(<FBLPromises/FBLPromises.h>)
+#import <FBLPromises/FBLPromises.h>
+#else
+#import "FBLPromises.h"
+#endif
 
 #import "FIRCLSApplicationIdentifierModel.h"
 #import "FIRCLSConstants.h"

--- a/Crashlytics/Crashlytics/Settings/FIRCLSSettingsOnboardingManager.h
+++ b/Crashlytics/Crashlytics/Settings/FIRCLSSettingsOnboardingManager.h
@@ -14,7 +14,11 @@
 
 #import <Foundation/Foundation.h>
 
-#import "FBLPromise.h"
+#if __has_include(<FBLPromises/FBLPromises.h>)
+#import <FBLPromises/FBLPromises.h>
+#else
+#import "FBLPromises.h"
+#endif
 
 @class FIRCLSApplicationIdentifierModel;
 @class FIRCLSDataCollectionToken;

--- a/Crashlytics/UnitTests/FIRCLSDataCollectionArbiterTest.m
+++ b/Crashlytics/UnitTests/FIRCLSDataCollectionArbiterTest.m
@@ -16,7 +16,11 @@
 
 #import <XCTest/XCTest.h>
 
+#if __has_include(<FBLPromises/FBLPromises.h>)
+#import <FBLPromises/FBLPromises.h>
+#else
 #import "FBLPromises.h"
+#endif
 
 #import "FIRAppFake.h"
 #import "FIRCLSUserDefaults.h"

--- a/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
@@ -17,7 +17,11 @@
 
 #import <FirebaseCore/FIRLogger.h>
 
+#if __has_include(<FBLPromises/FBLPromises.h>)
+#import <FBLPromises/FBLPromises.h>
+#else
 #import "FBLPromises.h"
+#endif
 
 #include "FIRAEvent+Internal.h"
 #include "FIRCLSContext.h"

--- a/Crashlytics/UnitTests/FIRCLSSettingsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSettingsTests.m
@@ -17,7 +17,11 @@
 #import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
+#if __has_include(<FBLPromises/FBLPromises.h>)
+#import <FBLPromises/FBLPromises.h>
+#else
 #import "FBLPromises.h"
+#endif
 
 #import "FABMockApplicationIdentifierModel.h"
 #import "FIRCLSFileManager.h"


### PR DESCRIPTION
In response to a tip from @maksymmalyhin https://github.com/firebase/firebase-ios-sdk/pull/4610#issuecomment-572124334, allow for both types of imports depending on what cocoapods configuration is being used.