### PR TITLE
Crashlytics ignore deprecation warnings on macOS and Catalyst

### DIFF
--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -777,11 +777,16 @@ static void (^reportSentCallback)(void);
                                            selector:@selector(didChangeOrientation:)
                                                name:UIDeviceOrientationDidChangeNotification
                                              object:nil];
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [[NSNotificationCenter defaultCenter]
       addObserver:self
          selector:@selector(didChangeUIOrientation:)
              name:UIApplicationDidChangeStatusBarOrientationNotification
            object:nil];
+#pragma clang diagnostic pop
+
 #elif CLS_TARGET_OS_OSX
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(willBecomeActive:)

--- a/Crashlytics/Crashlytics/FIRCLSURLSession/Tasks/FIRCLSURLSessionDataTask.m
+++ b/Crashlytics/Crashlytics/FIRCLSURLSession/Tasks/FIRCLSURLSessionDataTask.m
@@ -49,9 +49,13 @@
       return;
     }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     connection = [[NSURLConnection alloc] initWithRequest:[self originalRequest]
                                                  delegate:self
                                          startImmediately:NO];
+#pragma clang diagnostic pop
+
     [self setConnection:connection];
 
     // bummer we have to do this on a runloop, but other mechanisms require iOS 5 or 10.7


### PR DESCRIPTION
There are two deprecation warnings, one on macOS and one Catalyst. We are tracking these here:
b/147357475
b/133755970