### PR TITLE
Crashlytics add to subspec and Firebase.h

### DIFF
--- a/CoreOnly/Sources/Firebase.h
+++ b/CoreOnly/Sources/Firebase.h
@@ -26,6 +26,10 @@
     #import <FirebaseAuth/FirebaseAuth.h>
   #endif
 
+  #if __has_include(<FirebaseCrashlytics/FirebaseCrashlytics.h>)
+    #import <FirebaseCrashlytics/FirebaseCrashlytics.h>
+  #endif
+
   #if __has_include(<FirebaseDatabase/FirebaseDatabase.h>)
     #import <FirebaseDatabase/FirebaseDatabase.h>
   #endif

--- a/CoreOnly/Tests/FirebasePodTest/Podfile
+++ b/CoreOnly/Tests/FirebasePodTest/Podfile
@@ -13,6 +13,7 @@ target 'FirebasePodTest' do
   pod 'FirebaseCore', :path => '../../../'
   pod 'FirebaseCoreDiagnostics', :path => '../../../'
   pod 'FirebaseCoreDiagnosticsInterop', :path => '../../../'
+  pod 'FirebaseCrashlytics', :path => '../../../'
   pod 'FirebaseDatabase', :path => '../../../'
   pod 'FirebaseDynamicLinks', :path => '../../../'
   pod 'FirebaseFirestore', :path => '../../../'

--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -69,6 +69,11 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
     ss.dependency 'FirebaseAuth', '~> 6.4.1'
   end
 
+  s.subspec 'Crashlytics' do |ss|
+    ss.dependency 'Firebase/CoreOnly'
+    ss.ios.dependency 'FirebaseCrashlytics', '~> 4.0.0-beta.1'
+  en
+
   s.subspec 'Database' do |ss|
     ss.dependency 'Firebase/CoreOnly'
     ss.dependency 'FirebaseDatabase', '~> 6.1.3'

--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -72,6 +72,8 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.subspec 'Crashlytics' do |ss|
     ss.dependency 'Firebase/CoreOnly'
     ss.ios.dependency 'FirebaseCrashlytics', '~> 4.0.0-beta.1'
+    ss.osx.dependency 'FirebaseCrashlytics', '~> 4.0.0-beta.1'
+    ss.tvos.dependency 'FirebaseCrashlytics', '~> 4.0.0-beta.1'
   en
 
   s.subspec 'Database' do |ss|

--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -72,7 +72,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.subspec 'Crashlytics' do |ss|
     ss.dependency 'Firebase/CoreOnly'
     ss.dependency 'FirebaseCrashlytics', '~> 4.0.0-beta.1'
-  en
+  end
 
   s.subspec 'Database' do |ss|
     ss.dependency 'Firebase/CoreOnly'

--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -71,9 +71,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
 
   s.subspec 'Crashlytics' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.ios.dependency 'FirebaseCrashlytics', '~> 4.0.0-beta.1'
-    ss.osx.dependency 'FirebaseCrashlytics', '~> 4.0.0-beta.1'
-    ss.tvos.dependency 'FirebaseCrashlytics', '~> 4.0.0-beta.1'
+    ss.dependency 'FirebaseCrashlytics', '~> 4.0.0-beta.1'
   en
 
   s.subspec 'Database' do |ss|


### PR DESCRIPTION
This will allow developers to include `pod 'Firebase/Crashlytics'` and import it with `@import Firebase;`