### PR TITLE
Don't run unit test spec on watchOS.

### DIFF
--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -45,6 +45,7 @@ Pod::Spec.new do |s|
   }
 
   s.test_spec 'unit' do |unit_tests|
+    unit_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}
     unit_tests.source_files = base_dir + 'Tests/Unit/**/*.[mh]',
                               base_dir + 'Tests/Utils/**/*.[mh]'
     unit_tests.resources = base_dir + 'Tests/Fixture/**/*'


### PR DESCRIPTION
This won't run because the required version of InstanceID doesn't work
on watchOS (and watchOS doesn't have XCTests). This is a blocker for
publishing the pod.

#no-changelog