### PR TITLE
Add Crashlytics to list of tvOS, macOS, and Catalyst Supported SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ To install, add a subset of the following to the Podfile:
 ```
 pod 'Firebase/ABTesting'
 pod 'Firebase/Auth'
+pod 'Firebase/Crashlytics'
 pod 'Firebase/Database'
 pod 'Firebase/Firestore'
 pod 'Firebase/Functions'


### PR DESCRIPTION
The new Beta FirebaseCrashlytics SDK supports these platforms, in addition to iOS

#no-changelog