### PR TITLE
Cherry-picks for M62.

### DIFF
--- a/Crashlytics/Crashlytics/Unwind/Compact/FIRCLSCompactUnwind.h
+++ b/Crashlytics/Crashlytics/Unwind/Compact/FIRCLSCompactUnwind.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "FIRCLSFeatures.h"
 #include "FIRCLSThreadState.h"
 
 #include <stdbool.h>

--- a/Releases/Manifests/6.15.0.json
+++ b/Releases/Manifests/6.15.0.json
@@ -14,5 +14,6 @@
   "FirebaseMessaging":"4.2.0",
   "FirebaseStorage":"3.5.0",
   "GoogleDataTransport":"3.3.0",
-  "GoogleDataTransportCCTSupport":"1.3.0"
+  "GoogleDataTransportCCTSupport":"1.3.0",
+  "GoogleUtilities":"6.5.0"
 }


### PR DESCRIPTION
- Include GoogleUtilities in the release manifest.
- Fix header import issue in Crashlytics (#4649)