### PR TITLE
GoogleUtilities - Standardize imports and add LICENSE

### DIFF
--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -9,7 +9,7 @@ other Google CocoaPods. They're not intended for direct public usage.
                        DESC
 
   s.homepage         = 'https://github.com/firebase/firebase-ios-sdk/tree/master/GoogleUtilities'
-  s.license          = { :type => 'Apache', :file => 'LICENSE' }
+  s.license          = { :type => 'Apache', :file => 'GoogleUtilities/LICENSE' }
   s.authors          = 'Google, Inc.'
 
   s.source           = {

--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -25,6 +25,11 @@ other Google CocoaPods. They're not intended for direct public usage.
   s.cocoapods_version = '>= 1.4.0'
   s.prefix_header_file = false
 
+  s.pod_target_xcconfig = {
+    'GCC_C_LANGUAGE_STANDARD' => 'c99',
+    'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
+  }
+
   s.subspec 'Environment' do |es|
     es.source_files = 'GoogleUtilities/Environment/**/*.[mh]'
     es.public_header_files = 'GoogleUtilities/Environment/**/*.h'

--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -18,8 +18,8 @@
 #import <GoogleUtilities/GULAppEnvironmentUtil.h>
 #import <GoogleUtilities/GULLogger.h>
 #import <GoogleUtilities/GULMutableDictionary.h>
-#import "GoogleUtilities/Common/GULLoggerCodes.h"
 #import "GoogleUtilities/AppDelegateSwizzler/Internal/GULAppDelegateSwizzler_Private.h"
+#import "GoogleUtilities/Common/GULLoggerCodes.h"
 
 #import <objc/runtime.h>
 

--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -18,7 +18,7 @@
 #import <GoogleUtilities/GULAppEnvironmentUtil.h>
 #import <GoogleUtilities/GULLogger.h>
 #import <GoogleUtilities/GULMutableDictionary.h>
-#import "../Common/GULLoggerCodes.h"
+#import "GoogleUtilities/Common/GULLoggerCodes.h"
 #import "GoogleUtilities/AppDelegateSwizzler/Internal/GULAppDelegateSwizzler_Private.h"
 
 #import <objc/runtime.h>

--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -19,7 +19,7 @@
 #import <GoogleUtilities/GULLogger.h>
 #import <GoogleUtilities/GULMutableDictionary.h>
 #import "../Common/GULLoggerCodes.h"
-#import "Internal/GULAppDelegateSwizzler_Private.h"
+#import "GoogleUtilities/AppDelegateSwizzler/Internal/GULAppDelegateSwizzler_Private.h"
 
 #import <objc/runtime.h>
 

--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "TargetConditionals.h"
+#import <TargetConditionals.h>
 
 #import <GoogleUtilities/GULAppDelegateSwizzler.h>
 #import <GoogleUtilities/GULAppEnvironmentUtil.h>

--- a/GoogleUtilities/CHANGELOG.md
+++ b/GoogleUtilities/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+- Reorganized directory structure.
+
+# 6.5.0
+- Swizzler changes.
+
 # 6.4.0
 - Add function to gul secure encoding to encode multiple classes. (#4282)
 - Add heartbeat feature. (#4098)

--- a/GoogleUtilities/CHANGELOG.md
+++ b/GoogleUtilities/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- Reorganized directory structure.
+- Standardized import paths. (#4655)
 
 # 6.5.0
 - Swizzler changes.

--- a/GoogleUtilities/CMakeLists.txt
+++ b/GoogleUtilities/CMakeLists.txt
@@ -38,6 +38,7 @@ if(APPLE)
     INCLUDES
       Private
       Public
+      ${PROJECT_SOURCE_DIR}
     DEPENDS
       "-framework Foundation"
     EXCLUDE_FROM_ALL

--- a/GoogleUtilities/Environment/GULSecureCoding.m
+++ b/GoogleUtilities/Environment/GULSecureCoding.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "Public/GULSecureCoding.h"
+#import "GoogleUtilities/Environment/Public/GULSecureCoding.h"
 
 NSString *const kGULSecureCodingError = @"GULSecureCodingError";
 

--- a/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
+++ b/GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "GULAppEnvironmentUtil.h"
+#import "GoogleUtilities/Environment/third_party/GULAppEnvironmentUtil.h"
 
 #import <Foundation/Foundation.h>
 #import <dlfcn.h>

--- a/GoogleUtilities/Example/Tests/Network/GULNetworkTest.m
+++ b/GoogleUtilities/Example/Tests/Network/GULNetworkTest.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "GTMHTTPServer.h"
+#import "GoogleUtilities/Example/Tests/Network/third_party/GTMHTTPServer.h"
 
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>

--- a/GoogleUtilities/Example/Tests/Network/third_party/GTMHTTPServer.m
+++ b/GoogleUtilities/Example/Tests/Network/third_party/GTMHTTPServer.m
@@ -51,7 +51,7 @@
 #import <unistd.h>
 
 #define GTMHTTPSERVER_DEFINE_GLOBALS
-#import "GTMHTTPServer.h"
+#import "GoogleUtilities/Example/Tests/Network/third_party/GTMHTTPServer.h"
 
 // avoid some of GTM's promiscuous dependencies
 #ifndef _GTMDevLog

--- a/GoogleUtilities/Example/Tests/Reachability/GULReachabilityCheckerTest.m
+++ b/GoogleUtilities/Example/Tests/Reachability/GULReachabilityCheckerTest.m
@@ -16,7 +16,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "GULReachabilityChecker+Internal.h"
+#import "GoogleUtilities/Reachability/GULReachabilityChecker+Internal.h"
 
 @interface GULReachabilityCheckerTest : XCTestCase <GULReachabilityDelegate> {
  @private

--- a/GoogleUtilities/Example/Tests/Swizzler/GULAppDelegateSwizzlerTest.m
+++ b/GoogleUtilities/Example/Tests/Swizzler/GULAppDelegateSwizzlerTest.m
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #import <GoogleUtilities/GULAppDelegateSwizzler.h>
-#import "GULAppDelegateSwizzler_Private.h"
+#import "GoogleUtilities/AppDelegateSwizzler/Internal/GULAppDelegateSwizzler_Private.h"
 
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>

--- a/GoogleUtilities/Example/Tests/Swizzler/GULSceneDelegateSwizzlerTest.m
+++ b/GoogleUtilities/Example/Tests/Swizzler/GULSceneDelegateSwizzlerTest.m
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #import <GoogleUtilities/GULSceneDelegateSwizzler.h>
-#import "GULSceneDelegateSwizzler_Private.h"
+#import "GoogleUtilities/SceneDelegateSwizzler/Internal/GULSceneDelegateSwizzler_Private.h"
 
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>

--- a/GoogleUtilities/ISASwizzler/GULObjectSwizzler.m
+++ b/GoogleUtilities/ISASwizzler/GULObjectSwizzler.m
@@ -16,7 +16,7 @@
 
 #import <objc/runtime.h>
 
-#import "Private/GULSwizzledObject.h"
+#import "GoogleUtilities/ISASwizzler/Private/GULSwizzledObject.h"
 
 @implementation GULObjectSwizzler {
   // The swizzled object.

--- a/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
+++ b/GoogleUtilities/ISASwizzler/GULSwizzledObject.m
@@ -14,8 +14,8 @@
 
 #import <objc/runtime.h>
 
-#import "GULObjectSwizzler+Internal.h"
-#import "Private/GULSwizzledObject.h"
+#import "GoogleUtilities/ISASwizzler/GULObjectSwizzler+Internal.h"
+#import "GoogleUtilities/ISASwizzler/Private/GULSwizzledObject.h"
 
 NSString *kSwizzlerAssociatedObjectKey = @"gul_objectSwizzler";
 

--- a/GoogleUtilities/LICENSE
+++ b/GoogleUtilities/LICENSE
@@ -1,0 +1,247 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+================================================================================
+
+The following copyright from Landon J. Fuller applies to the isAppEncrypted
+function in Environment/third_party/GULAppEnvironmentUtil.m.
+
+Copyright (c) 2017 Landon J. Fuller <landon@landonf.org>
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Comment from
+<a href="http://iphonedevwiki.net/index.php/Crack_prevention">iPhone Dev Wiki
+Crack Prevention</a>: App Store binaries are signed by both their developer
+and Apple. This encrypts the binary so that decryption keys are needed in order
+to make the binary readable. When iOS executes the binary, the decryption keys
+are used to decrypt the binary into a readable state where it is then loaded
+into memory and executed. iOS can tell the encryption status of a binary via the
+cryptid structure member of LC_ENCRYPTION_INFO MachO load command. If cryptid is
+a non-zero value then the binary is encrypted.
+
+'Cracking' works by letting the kernel decrypt the binary then siphoning the
+decrypted data into a new binary file, resigning, and repackaging. This will
+only work on jailbroken devices as codesignature validation has been removed.
+Resigning takes place because while the codesignature doesn't have to be valid
+thanks to the jailbreak, it does have to be in place unless you have AppSync or
+similar to disable codesignature checks.
+
+More information at <a href="http://landonf.org/2009/02/index.html">Landon
+Fuller's blog</a>

--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "Private/GULLogger.h"
+#import "GoogleUtilities/Logger/Private/GULLogger.h"
 
 #include <asl.h>
 

--- a/GoogleUtilities/MethodSwizzler/GULSwizzler.m
+++ b/GoogleUtilities/MethodSwizzler/GULSwizzler.m
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "Private/GULSwizzler.h"
+#import "GoogleUtilities/MethodSwizzler/Private/GULSwizzler.h"
 
 #import <objc/runtime.h>
 
 #ifdef DEBUG
 #import <GoogleUtilities/GULLogger.h>
-#import "../Common/GULLoggerCodes.h"
+#import "GoogleUtilities/Common/GULLoggerCodes.h"
 
 static GULLoggerService kGULLoggerSwizzler = @"[GoogleUtilities/MethodSwizzler]";
 #endif

--- a/GoogleUtilities/NSData+zlib/GULNSData+zlib.m
+++ b/GoogleUtilities/NSData+zlib/GULNSData+zlib.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "GULNSData+zlib.h"
+#import "GoogleUtilities/NSData+zlib/GULNSData+zlib.h"
 
 #import <zlib.h>
 

--- a/GoogleUtilities/Network/GULMutableDictionary.m
+++ b/GoogleUtilities/Network/GULMutableDictionary.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "Private/GULMutableDictionary.h"
+#import "GoogleUtilities/Network/Private/GULMutableDictionary.h"
 
 @implementation GULMutableDictionary {
   /// The mutable dictionary.

--- a/GoogleUtilities/Network/GULNetwork.m
+++ b/GoogleUtilities/Network/GULNetwork.m
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "Private/GULNetwork.h"
-#import "Private/GULNetworkMessageCode.h"
+#import "GoogleUtilities/Network/Private/GULNetwork.h"
+#import "GoogleUtilities/Network/Private/GULNetworkMessageCode.h"
 
 #import <GoogleUtilities/GULLogger.h>
 #import <GoogleUtilities/GULNSData+zlib.h>
 #import <GoogleUtilities/GULReachabilityChecker.h>
-#import "Private/GULMutableDictionary.h"
-#import "Private/GULNetworkConstants.h"
+#import "GoogleUtilities/Network/Private/GULMutableDictionary.h"
+#import "GoogleUtilities/Network/Private/GULNetworkConstants.h"
 
 /// Constant string for request header Content-Encoding.
 static NSString *const kGULNetworkContentCompressionKey = @"Content-Encoding";

--- a/GoogleUtilities/Network/GULNetworkConstants.m
+++ b/GoogleUtilities/Network/GULNetworkConstants.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "Private/GULNetworkConstants.h"
+#import "GoogleUtilities/Network/Private/GULNetworkConstants.h"
 
 #import <Foundation/Foundation.h>
 

--- a/GoogleUtilities/Network/GULNetworkURLSession.m
+++ b/GoogleUtilities/Network/GULNetworkURLSession.m
@@ -14,12 +14,12 @@
 
 #import <Foundation/Foundation.h>
 
-#import "Private/GULNetworkURLSession.h"
+#import "GoogleUtilities/Network/Private/GULNetworkURLSession.h"
 
 #import <GoogleUtilities/GULLogger.h>
-#import "Private/GULMutableDictionary.h"
-#import "Private/GULNetworkConstants.h"
-#import "Private/GULNetworkMessageCode.h"
+#import "GoogleUtilities/Network/Private/GULMutableDictionary.h"
+#import "GoogleUtilities/Network/Private/GULNetworkConstants.h"
+#import "GoogleUtilities/Network/Private/GULNetworkMessageCode.h"
 
 @interface GULNetworkURLSession () <NSURLSessionDelegate,
                                     NSURLSessionDataDelegate,

--- a/GoogleUtilities/Reachability/GULReachabilityChecker.m
+++ b/GoogleUtilities/Reachability/GULReachabilityChecker.m
@@ -15,8 +15,8 @@
 #import <Foundation/Foundation.h>
 
 #import "GoogleUtilities/Reachability/GULReachabilityChecker+Internal.h"
-#import "Private/GULReachabilityChecker.h"
-#import "Private/GULReachabilityMessageCode.h"
+#import "GoogleUtilities/Reachability/Private/GULReachabilityChecker.h"
+#import "GoogleUtilities/Reachability/Private/GULReachabilityMessageCode.h"
 
 #import <GoogleUtilities/GULLogger.h>
 #import <GoogleUtilities/GULReachabilityChecker.h>

--- a/GoogleUtilities/Reachability/GULReachabilityChecker.m
+++ b/GoogleUtilities/Reachability/GULReachabilityChecker.m
@@ -14,7 +14,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "GULReachabilityChecker+Internal.h"
+#import "GoogleUtilities/Reachability/GULReachabilityChecker+Internal.h"
 #import "Private/GULReachabilityChecker.h"
 #import "Private/GULReachabilityMessageCode.h"
 

--- a/GoogleUtilities/SceneDelegateSwizzler/GULSceneDelegateSwizzler.m
+++ b/GoogleUtilities/SceneDelegateSwizzler/GULSceneDelegateSwizzler.m
@@ -19,8 +19,8 @@
 #import <GoogleUtilities/GULLogger.h>
 #import <GoogleUtilities/GULMutableDictionary.h>
 #import <GoogleUtilities/GULSceneDelegateSwizzler.h>
-#import "../Common/GULLoggerCodes.h"
-#import "Internal/GULSceneDelegateSwizzler_Private.h"
+#import "GoogleUtilities/Common/GULLoggerCodes.h"
+#import "GoogleUtilities/SceneDelegateSwizzler/Internal/GULSceneDelegateSwizzler_Private.h"
 
 #import <objc/runtime.h>
 


### PR DESCRIPTION
Standardize to repo-relative imports and add a GoogleUtilities specific license that includes the third_party isAppEncrypted code in the library.

Googlers: See also cl/289117496