### PR TITLE
Zip fixes

### DIFF
--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -134,8 +134,6 @@ enum CocoaPodUtils {
 
     // Force unwrap the regular expression since we know it will work, it's a constant being passed
     // in. If any changes are made, be sure to run this script to ensure it works.
-    let podRegex = try! NSRegularExpression(pattern: " - (.+) \\((\\d+\\.\\d+\\.?\\d*)\\)",
-                                            options: [])
     let depRegex: NSRegularExpression = try! NSRegularExpression(pattern: " - (.+).*",
                                                                  options: [])
     let quotes = CharacterSet(charactersIn: "\"")
@@ -146,7 +144,7 @@ enum CocoaPodUtils {
       if line.starts(with: "DEPENDENCIES:") {
         break
       }
-      if let (pod, version) = detectVersion(fromLine: line, matching: podRegex) {
+      if let (pod, version) = detectVersion(fromLine: line) {
         let corePod = pod.components(separatedBy: "/")[0]
         currentPod = corePod.trimmingCharacters(in: quotes)
         pods[currentPod!] = version
@@ -262,24 +260,26 @@ enum CocoaPodUtils {
   ///
   /// - Parameters:
   ///   - input: A line entry from Podfile.lock.
-  ///   - regex: The regex to match compared to the input.
   /// - Returns: A tuple of the framework and version, if it can be parsed.
-  private static func detectVersion(fromLine input: String,
-                                    matching regex: NSRegularExpression) -> (framework: String, version: String)? {
-    let matches = regex.matches(in: input, range: NSRange(location: 0, length: input.utf8.count))
-    let nsString = input as NSString
+  private static func detectVersion(fromLine input: String) -> (framework: String, version: String)? {
+    // Get the components of the line to parse them individually. Ignore any whitespace only Strings.
+    let components = input.components(separatedBy: " ").filter { !$0.isEmpty }
 
-    guard let match = matches.first else {
-      return nil
-    }
+    // Expect three components: the `-`, the pod name, and the version in parens. This will filter out
+    // dependencies that have version requirements like `(~> 3.2.1)` in it.
+    guard components.count == 3 else { return nil }
 
-    guard match.numberOfRanges == 3 else {
-      print("Version number regex matches: expected 3, but found \(match.numberOfRanges).")
-      return nil
-    }
+    // The first component is simple, just the `-`.
+    guard components.first == "-" else { return nil }
 
-    let framework = nsString.substring(with: match.range(at: 1)) as String
-    let version = nsString.substring(with: match.range(at: 2)) as String
+    // The second component is a pod/framework name, which we want to return eventually.
+    let framework = components[1]
+
+    // The third component is the version in parentheses, potentially with a `:` at the end. Let's
+    // just strip the unused characters and return the version. We don't necesarily have to match
+    // against semver since it's a non trivial regex and we don't actually care, `Podfile.lock` has a
+    // standard format that we know will be valid.
+    let version = components[2].trimmingCharacters(in: CharacterSet(charactersIn: "():"))
 
     return (framework, version)
   }

--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -272,14 +272,16 @@ enum CocoaPodUtils {
     // The first component is simple, just the `-`.
     guard components.first == "-" else { return nil }
 
-    // The second component is a pod/framework name, which we want to return eventually.
-    let framework = components[1]
+    // The second component is a pod/framework name, which we want to return eventually. Remove any
+    // extraneous quotes.
+    let framework = components[1].trimmingCharacters(in: CharacterSet(charactersIn: "\""))
 
     // The third component is the version in parentheses, potentially with a `:` at the end. Let's
-    // just strip the unused characters and return the version. We don't necesarily have to match
-    // against semver since it's a non trivial regex and we don't actually care, `Podfile.lock` has a
-    // standard format that we know will be valid.
-    let version = components[2].trimmingCharacters(in: CharacterSet(charactersIn: "():"))
+    // just strip the unused characters (including quotes) and return the version. We don't
+    // necesarily have to match against semver since it's a non trivial regex and we don't actually
+    // care, `Podfile.lock` has a standard format that we know will be valid. Also strip out any
+    // extra quotes.
+    let version = components[2].trimmingCharacters(in: CharacterSet(charactersIn: "():\""))
 
     return (framework, version)
   }


### PR DESCRIPTION
Cherry pick recent release branch fixes #4652 and #4654 to address GHA cron infinite loop.

The dependency parsing was broken and exposed by adding Crashlytics.

The Podfile.lock included

  - FirebaseCoreDiagnosticsInterop (1.1.0)
  - FirebaseCrashlytics (4.0.0-beta.1):
    - FirebaseAnalyticsInterop (~> 1.2)
    - FirebaseCore (>= 6.3.2, ~> 6.3)
    - FirebaseInstanceID (~> 4.1)

The parsing mistakenly add Crashlytics as a dep of FirebaseCoreDiagnosticsInterop which led to an infinite loop while constructing the module maps.