### PR TITLE
Firebase Installations: validation of FIROptions parameters

### DIFF
--- a/Example/InstanceID/Tests/FIRInstanceIDTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTest.m
@@ -156,6 +156,8 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
   // The shared instance relies on the default app being configured. Configure it.
   FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
                                                     GCMSenderID:kGCMSenderID];
+  options.APIKey = @"api-key";
+  options.projectID = @"project-id";
   [FIRApp configureWithName:kFIRDefaultAppName options:options];
   FIRInstanceID *instanceID = [FIRInstanceID instanceID];
   XCTAssertNotNil(instanceID);

--- a/Example/Messaging/Tests/FIRMessagingInstanceTest.swift
+++ b/Example/Messaging/Tests/FIRMessagingInstanceTest.swift
@@ -24,6 +24,8 @@ class FIRMessagingInstanceTest: XCTestCase {
     // This is an example of a functional test case.
     // Use XCTAssert and related functions to verify your tests produce the correct results.
     let options = FirebaseOptions(googleAppID: "1:123:ios:123abc", gcmSenderID: "valid-sender-id")
+    options.apiKey = "api-key"
+    options.projectID = "project-id"
     FirebaseApp.configure(options: options)
     let original = Messaging.messaging()
 

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v6.6.0 -- M62
 - [changed] Reorganized directory structure.
+- [changed] Firebase Installations(../../FirebaseInstallations/CHANGELOG.md) throws an exception when there are missing required `FirebaseOptions` parameters (`APIKey`, `googleAppID`, and `projectID` or `GCMSenderID`). Please make sure your `GoogleServices-Info.plist` (or `FirebaseOptions` if you configure Firebase in code) are up to date. The file and settings can be downoaded from the [Firebase Console](https://console.firebase.google.com/). (#4683)
 - [changed] The following SDKs introduce a new transitive dependency on the [Firebase Installations API](https://console.cloud.google.com/apis/library/firebaseinstallations.googleapis.com):
   - Analytics
   - Cloud Messaging

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,5 @@
 # v6.6.0 -- M62
 - [changed] Reorganized directory structure.
-- [changed] [Firebase Installations](../FirebaseInstallations/CHANGELOG.md) throws an exception when there are missing required `FirebaseOptions` parameters (`APIKey`, `googleAppID`, and `projectID`). Please make sure your `GoogleServices-Info.plist` (or `FirebaseOptions` if you configure Firebase in code) are up to date. The file and settings can be downloaded from the [Firebase Console](https://console.firebase.google.com/). (#4683)
 - [changed] The following SDKs introduce a new transitive dependency on the [Firebase Installations API](https://console.cloud.google.com/apis/library/firebaseinstallations.googleapis.com):
   - Analytics
   - Cloud Messaging

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v6.6.0 -- M62
 - [changed] Reorganized directory structure.
-- [changed] [Firebase Installations](../../FirebaseInstallations/CHANGELOG.md) throws an exception when there are missing required `FirebaseOptions` parameters (`APIKey`, `googleAppID`, and `projectID`). Please make sure your `GoogleServices-Info.plist` (or `FirebaseOptions` if you configure Firebase in code) are up to date. The file and settings can be downloaded from the [Firebase Console](https://console.firebase.google.com/). (#4683)
+- [changed] [Firebase Installations](../FirebaseInstallations/CHANGELOG.md) throws an exception when there are missing required `FirebaseOptions` parameters (`APIKey`, `googleAppID`, and `projectID`). Please make sure your `GoogleServices-Info.plist` (or `FirebaseOptions` if you configure Firebase in code) are up to date. The file and settings can be downloaded from the [Firebase Console](https://console.firebase.google.com/). (#4683)
 - [changed] The following SDKs introduce a new transitive dependency on the [Firebase Installations API](https://console.cloud.google.com/apis/library/firebaseinstallations.googleapis.com):
   - Analytics
   - Cloud Messaging

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v6.6.0 -- M62
 - [changed] Reorganized directory structure.
-- [changed] Firebase Installations(../../FirebaseInstallations/CHANGELOG.md) throws an exception when there are missing required `FirebaseOptions` parameters (`APIKey`, `googleAppID`, and `projectID` or `GCMSenderID`). Please make sure your `GoogleServices-Info.plist` (or `FirebaseOptions` if you configure Firebase in code) are up to date. The file and settings can be downoaded from the [Firebase Console](https://console.firebase.google.com/). (#4683)
+- [changed] Firebase Installations(../../FirebaseInstallations/CHANGELOG.md) throws an exception when there are missing required `FirebaseOptions` parameters (`APIKey`, `googleAppID`, and `projectID`). Please make sure your `GoogleServices-Info.plist` (or `FirebaseOptions` if you configure Firebase in code) are up to date. The file and settings can be downoaded from the [Firebase Console](https://console.firebase.google.com/). (#4683)
 - [changed] The following SDKs introduce a new transitive dependency on the [Firebase Installations API](https://console.cloud.google.com/apis/library/firebaseinstallations.googleapis.com):
   - Analytics
   - Cloud Messaging

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v6.6.0 -- M62
 - [changed] Reorganized directory structure.
-- [changed] Firebase Installations(../../FirebaseInstallations/CHANGELOG.md) throws an exception when there are missing required `FirebaseOptions` parameters (`APIKey`, `googleAppID`, and `projectID`). Please make sure your `GoogleServices-Info.plist` (or `FirebaseOptions` if you configure Firebase in code) are up to date. The file and settings can be downoaded from the [Firebase Console](https://console.firebase.google.com/). (#4683)
+- [changed] Firebase Installations(../../FirebaseInstallations/CHANGELOG.md) throws an exception when there are missing required `FirebaseOptions` parameters (`APIKey`, `googleAppID`, and `projectID`). Please make sure your `GoogleServices-Info.plist` (or `FirebaseOptions` if you configure Firebase in code) are up to date. The file and settings can be downloaded from the [Firebase Console](https://console.firebase.google.com/). (#4683)
 - [changed] The following SDKs introduce a new transitive dependency on the [Firebase Installations API](https://console.cloud.google.com/apis/library/firebaseinstallations.googleapis.com):
   - Analytics
   - Cloud Messaging

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v6.6.0 -- M62
 - [changed] Reorganized directory structure.
-- [changed] Firebase Installations(../../FirebaseInstallations/CHANGELOG.md) throws an exception when there are missing required `FirebaseOptions` parameters (`APIKey`, `googleAppID`, and `projectID`). Please make sure your `GoogleServices-Info.plist` (or `FirebaseOptions` if you configure Firebase in code) are up to date. The file and settings can be downloaded from the [Firebase Console](https://console.firebase.google.com/). (#4683)
+- [changed] [Firebase Installations](../../FirebaseInstallations/CHANGELOG.md) throws an exception when there are missing required `FirebaseOptions` parameters (`APIKey`, `googleAppID`, and `projectID`). Please make sure your `GoogleServices-Info.plist` (or `FirebaseOptions` if you configure Firebase in code) are up to date. The file and settings can be downloaded from the [Firebase Console](https://console.firebase.google.com/). (#4683)
 - [changed] The following SDKs introduce a new transitive dependency on the [Firebase Installations API](https://console.cloud.google.com/apis/library/firebaseinstallations.googleapis.com):
   - Analytics
   - Cloud Messaging

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInstallations'
-  s.version          = '1.0.0'
+  s.version          = '1.1.0'
   s.summary          = 'Firebase Installations for iOS'
 
   s.description      = <<-DESC

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInstallations'
-  s.version          = '1.1.0'
+  s.version          = '1.0.1'
   s.summary          = 'Firebase Installations for iOS'
 
   s.description      = <<-DESC

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInstallations'
-  s.version          = '1.0.1'
+  s.version          = '1.1.0'
   s.summary          = 'Firebase Installations for iOS'
 
   s.description      = <<-DESC

--- a/FirebaseInstallations/CHANGELOG.md
+++ b/FirebaseInstallations/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v1.1.0 -- M62.1
 
-- [changed] Throw an exception when there are missing required `FirebaseOptions` parameters (`APIKey`, `googleAppID`, and `projectID` or `GCMSenderID`). Please make sure your `GoogleServices-Info.plist` (or `FirebaseOptions` if you configure Firebase in code) are up to date. The file and settings can be downoaded from the [Firebase Console](https://console.firebase.google.com/).  (#4683)
+- [changed] Throw an exception when there are missing required `FirebaseOptions` parameters (`APIKey`, `googleAppID`, and `projectID`). Please make sure your `GoogleServices-Info.plist` (or `FirebaseOptions` if you configure Firebase in code) are up to date. The file and settings can be downoaded from the [Firebase Console](https://console.firebase.google.com/).  (#4683)
 
 # v1.0.0 -- M62
 

--- a/FirebaseInstallations/CHANGELOG.md
+++ b/FirebaseInstallations/CHANGELOG.md
@@ -1,6 +1,6 @@
-# v1.0.1 -- M62
+# v1.1.0 -- M62.1
 
-- [changed] Throw an exception when there are missing required `FIROptions` parameters. (#4683)
+- [changed] Throw an exception when there are missing required `FirebaseOptions` parameters (`APIKey`, `googleAppID`, and `projectID` or `GCMSenderID`). Please make sure your `GoogleServices-Info.plist` (or `FirebaseOptions` if you configure Firebase in code) are up to date. The file and settings can be downoaded from the [Firebase Console](https://console.firebase.google.com/).  (#4683)
 
 # v1.0.0 -- M62
 

--- a/FirebaseInstallations/CHANGELOG.md
+++ b/FirebaseInstallations/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.0.1 -- M62
+
+- [changed] Throw an exception when there are missing required `FIROptions` parameters. (#4683)
+
 # v1.0.0 -- M62
 
 - [added] The Firebase Installations Service is an infrastructure service for Firebase services that creates unique identifiers and authentication tokens for Firebase clients (called "Firebase Installations") enabling Firebase Targeting, i.e. interoperation between Firebase services.

--- a/FirebaseInstallations/CHANGELOG.md
+++ b/FirebaseInstallations/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v1.1.0 -- M62.1
 
-- [changed] Throw an exception when there are missing required `FirebaseOptions` parameters (`APIKey`, `googleAppID`, and `projectID`). Please make sure your `GoogleServices-Info.plist` (or `FirebaseOptions` if you configure Firebase in code) are up to date. The file and settings can be downloaded from the [Firebase Console](https://console.firebase.google.com/).  (#4683)
+- [changed] Throw an exception when there are missing required `FirebaseOptions` parameters (`APIKey`, `googleAppID`, and `projectID`). Please make sure your `GoogleServices-Info.plist` (or `FirebaseOptions` if you configure Firebase in code) is up to date. The file and settings can be downloaded from the [Firebase Console](https://console.firebase.google.com/).  (#4683)
 
 # v1.0.0 -- M62
 

--- a/FirebaseInstallations/CHANGELOG.md
+++ b/FirebaseInstallations/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v1.1.0 -- M62.1
 
-- [changed] Throw an exception when there are missing required `FirebaseOptions` parameters (`APIKey`, `googleAppID`, and `projectID`). Please make sure your `GoogleServices-Info.plist` (or `FirebaseOptions` if you configure Firebase in code) are up to date. The file and settings can be downoaded from the [Firebase Console](https://console.firebase.google.com/).  (#4683)
+- [changed] Throw an exception when there are missing required `FirebaseOptions` parameters (`APIKey`, `googleAppID`, and `projectID`). Please make sure your `GoogleServices-Info.plist` (or `FirebaseOptions` if you configure Firebase in code) are up to date. The file and settings can be downloaded from the [Firebase Console](https://console.firebase.google.com/).  (#4683)
 
 # v1.0.0 -- M62
 

--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -127,9 +127,6 @@ NS_ASSUME_NONNULL_BEGIN
   if (appOptions.APIKey.length < 1) {
     [missingFields addObject:@"`FirebaseOptions.APIKey`"];
   }
-  if (appOptions.projectID.length < 1) {
-    [missingFields addObject:@"`FirebaseOptions.projectID`"];
-  }
   if (appOptions.googleAppID.length < 1) {
     [missingFields addObject:@"`FirebaseOptions.googleAppID`"];
   }

--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -130,8 +130,11 @@ NS_ASSUME_NONNULL_BEGIN
   if (appOptions.googleAppID.length < 1) {
     [missingFields addObject:@"`FirebaseOptions.googleAppID`"];
   }
-  if (appOptions.GCMSenderID.length < 1) {
-    [missingFields addObject:@"`FirebaseOptions.GCMSenderID`"];
+
+  // TODO(#4692): Check for `appOptions.projectID.length < 1` only.
+  // We can use `GCMSenderID` instead of `projectID` temporary.
+  if (appOptions.projectID.length < 1 && appOptions.GCMSenderID.length < 1) {
+    [missingFields addObject:@"`FirebaseOptions.projectID`"];
   }
 
   if (missingFields.count > 0) {

--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -133,7 +133,7 @@ NS_ASSUME_NONNULL_BEGIN
     [missingFields addObject:@"`FirebaseOptions.googleAppID`"];
   }
   if (appOptions.GCMSenderID.length < 1) {
-    [missingFields addObject:@"`FirebaseOptions.googleAppID`"];
+    [missingFields addObject:@"`FirebaseOptions.GCMSenderID`"];
   }
 
   if (missingFields.count > 0) {

--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -140,13 +140,14 @@ NS_ASSUME_NONNULL_BEGIN
   if (missingFields.count > 0) {
     [NSException
          raise:kFirebaseInstallationsErrorDomain
-        format:@"%@[%@] Could not configure Firebase Installations due to invalid FirebaseApp "
-               @"options. The following parameters are nil or empty: %@. If you use "
-               @"GoogleServices-Info.plist please download the most recent version from Firebase "
-               @"Console. If you configure Firebase in code, please make sure you specify all "
-               @"required parameters.",
-               kFIRLoggerInstallations, kFIRInstallationsMessageCodeInvalidFirebaseAppOptions,
-               [missingFields componentsJoinedByString:@", "]];
+        format:
+            @"%@[%@] Could not configure Firebase Installations due to invalid FirebaseApp "
+            @"options. The following parameters are nil or empty: %@. If you use "
+            @"GoogleServices-Info.plist please download the most recent version from the Firebase "
+            @"Console. If you configure Firebase in code, please make sure you specify all "
+            @"required parameters.",
+            kFIRLoggerInstallations, kFIRInstallationsMessageCodeInvalidFirebaseAppOptions,
+            [missingFields componentsJoinedByString:@", "]];
   }
 }
 

--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -34,6 +34,7 @@
 #import "FIRInstallationsErrorUtil.h"
 #import "FIRInstallationsIDController.h"
 #import "FIRInstallationsItem.h"
+#import "FIRInstallationsLogger.h"
 #import "FIRInstallationsStoredAuthToken.h"
 #import "FIRInstallationsVersion.h"
 
@@ -137,10 +138,15 @@ NS_ASSUME_NONNULL_BEGIN
   }
 
   if (missingFields.count > 0) {
-    [NSException raise:kFirebaseInstallationsErrorDomain
-                format:@"Could not configure Firebase Installations due to invalid FirebaseApp "
-                       @"options. The following parameters are nil or empty: %@",
-                       [missingFields componentsJoinedByString:@", "]];
+    [NSException
+         raise:kFirebaseInstallationsErrorDomain
+        format:@"%@[%@] Could not configure Firebase Installations due to invalid FirebaseApp "
+               @"options. The following parameters are nil or empty: %@. If you use "
+               @"GoogleServices-Info.plist please download the most recent version from Firebase "
+               @"Console. If you configure Firebase in code, please make sure you specify all "
+               @"required parameters.",
+               kFIRLoggerInstallations, kFIRInstallationsMessageCodeInvalidFirebaseAppOptions,
+               [missingFields componentsJoinedByString:@", "]];
   }
 }
 

--- a/FirebaseInstallations/Source/Library/FIRInstallationsLogger.h
+++ b/FirebaseInstallations/Source/Library/FIRInstallationsLogger.h
@@ -46,3 +46,6 @@ extern NSString *const kFIRInstallationsMessageCodeAuthTokenCoderVersionMismatch
 // FIRInstallationsStoredIIDCheckin.m
 extern NSString *const kFIRInstallationsMessageCodeIIDCheckinCoderVersionMismatch;
 extern NSString *const kFIRInstallationsMessageCodeIIDCheckinFailedToDecode;
+
+// FIRInstallations.m
+extern NSString *const kFIRInstallationsMessageCodeInvalidFirebaseAppOptions;

--- a/FirebaseInstallations/Source/Library/FIRInstallationsLogger.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallationsLogger.m
@@ -44,3 +44,6 @@ NSString *const kFIRInstallationsMessageCodeAuthTokenCoderVersionMismatch = @"I-
 // FIRInstallationsStoredIIDCheckin.m
 NSString *const kFIRInstallationsMessageCodeIIDCheckinCoderVersionMismatch = @"I-FIS007000";
 NSString *const kFIRInstallationsMessageCodeIIDCheckinFailedToDecode = @"I-FIS007001";
+
+// FIRInstallations.m
+NSString *const kFIRInstallationsMessageCodeInvalidFirebaseAppOptions = @"I-FIS008000";

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.h
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
                              APIKey:(NSString *)APIKey
                           projectID:(NSString *)projectID
                         GCMSenderID:(NSString *)GCMSenderID
-                        accessGroup:(NSString *)accessGroup;
+                        accessGroup:(nullable NSString *)accessGroup;
 
 - (FBLPromise<FIRInstallationsItem *> *)getInstallationItem;
 

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -75,8 +75,12 @@ NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 
   FIRSecureStorage *secureStorage = [[FIRSecureStorage alloc] init];
   FIRInstallationsStore *installationsStore =
       [[FIRInstallationsStore alloc] initWithSecureStorage:secureStorage accessGroup:accessGroup];
+
+  // Use `GCMSenderID` as `projectID` is not available.
+  NSString *APIServiceProjectID = (projectID.length > 0) ? projectID : GCMSenderID;
   FIRInstallationsAPIService *apiService =
-      [[FIRInstallationsAPIService alloc] initWithAPIKey:APIKey projectID:projectID];
+      [[FIRInstallationsAPIService alloc] initWithAPIKey:APIKey projectID:APIServiceProjectID];
+
   FIRInstallationsIIDStore *IIDStore = [[FIRInstallationsIIDStore alloc] init];
   FIRInstallationsIIDTokenStore *IIDCheckingStore =
       [[FIRInstallationsIIDTokenStore alloc] initWithGCMSenderID:GCMSenderID];

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -76,7 +76,7 @@ NSTimeInterval const kFIRInstallationsTokenExpirationThreshold = 60 * 60;  // 1 
   FIRInstallationsStore *installationsStore =
       [[FIRInstallationsStore alloc] initWithSecureStorage:secureStorage accessGroup:accessGroup];
 
-  // Use `GCMSenderID` as `projectID` is not available.
+  // Use `GCMSenderID` as project identifier when `projectID` is not available.
   NSString *APIServiceProjectID = (projectID.length > 0) ? projectID : GCMSenderID;
   FIRInstallationsAPIService *apiService =
       [[FIRInstallationsAPIService alloc] initWithAPIKey:APIKey projectID:APIServiceProjectID];

--- a/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
+++ b/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
@@ -59,7 +59,7 @@ NS_SWIFT_NAME(Installations)
 
 /**
  * Returns a default instance of `Installations`.
- * @return Returns an instance of `Installations` for `FirebaseApp.defaultApp().
+ * @returns An instance of `Installations` for `FirebaseApp.defaultApp().
  * @throw Throws an exception if the default app is not configured yet or required  `FirebaseApp`
  * options are missing.
  */
@@ -68,7 +68,7 @@ NS_SWIFT_NAME(Installations)
 /**
  * Returns an instance of `Installations` for an application.
  * @param application A configured `FirebaseApp` instance.
- * @return Returns an instance of `Installations` corresponding to the passed application.
+ * @returns An instance of `Installations` corresponding to the passed application.
  * @throw Throws an exception if required `FirebaseApp` options are missing.
  */
 + (FIRInstallations *)installationsWithApp:(FIRApp *)application NS_SWIFT_NAME(installations(app:));

--- a/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
+++ b/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
@@ -59,8 +59,9 @@ NS_SWIFT_NAME(Installations)
 
 /**
  * Returns a default instance of `Installations`.
- * @return Returns an instance of `Installations` for `FirebaseApp.defaultApp(). Throws an exception
- * if the default app is not configured yet.
+ * @return Returns an instance of `Installations` for `FirebaseApp.defaultApp().
+ * @throw Throws an exception if the default app is not configured yet or required  `FirebaseApp`
+ * options are missing.
  */
 + (FIRInstallations *)installations NS_SWIFT_NAME(installations());
 
@@ -68,6 +69,7 @@ NS_SWIFT_NAME(Installations)
  * Returns an instance of `Installations` for an application.
  * @param application A configured `FirebaseApp` instance.
  * @return Returns an instance of `Installations` corresponding to the passed application.
+ * @throw Throws an exception if required `FirebaseApp` options are missing.
  */
 + (FIRInstallations *)installationsWithApp:(FIRApp *)application NS_SWIFT_NAME(installations(app:));
 

--- a/FirebaseInstallations/Source/Tests/Integration/FIRInstallationsIntegrationTests.m
+++ b/FirebaseInstallations/Source/Tests/Integration/FIRInstallationsIntegrationTests.m
@@ -205,6 +205,8 @@ static BOOL sFIRInstallationsFirebaseDefaultAppConfigured = NO;
   FIROptions *options =
       [[FIROptions alloc] initWithGoogleAppID:@"1:100000000000:ios:aaaaaaaaaaaaaaaaaaaaaaaa"
                                   GCMSenderID:@"valid_sender_id"];
+  options.APIKey = @"some_api_key";
+  options.projectID = @"project_id";
   [FIRApp configureWithName:name options:options];
 
   return [FIRApp appNamed:name];

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
@@ -87,6 +87,32 @@
   self.appName = nil;
 }
 
+#pragma mark - Initialization
+
+- (void)testInitWhenProjectIDSetThenItIsPassedToAPIService {
+  NSString *APIKey = @"api-key";
+  NSString *projectID = @"project-id";
+  OCMExpect([self.mockAPIService alloc]).andReturn(self.mockAPIService);
+  OCMExpect([self.mockAPIService initWithAPIKey:APIKey projectID:projectID]).andReturn(self.mockAPIService);
+
+  FIRInstallationsIDController *controller = [[FIRInstallationsIDController alloc] initWithGoogleAppID:@"app-id" appName:@"app-name" APIKey:APIKey projectID:projectID GCMSenderID:@"sender-id" accessGroup:nil];
+  XCTAssertNotNil(controller);
+
+  OCMVerifyAll(self.mockAPIService);
+}
+
+- (void)testInitWhenProjectIDIsNilThenGCMSenderIDIsPassedToAPIServiceAsProjectID {
+  NSString *APIKey = @"api-key";
+  NSString *GCMSenderID = @"sender-id";
+  OCMExpect([self.mockAPIService alloc]).andReturn(self.mockAPIService);
+  OCMExpect([self.mockAPIService initWithAPIKey:APIKey projectID:GCMSenderID]).andReturn(self.mockAPIService);
+
+  FIRInstallationsIDController *controller = [[FIRInstallationsIDController alloc] initWithGoogleAppID:@"app-id" appName:@"app-name" APIKey:APIKey projectID:@"" GCMSenderID:GCMSenderID accessGroup:nil];
+  XCTAssertNotNil(controller);
+
+  OCMVerifyAll(self.mockAPIService);
+}
+
 #pragma mark - Get Installation
 
 - (void)testGetInstallationItem_WhenFIDExists_ThenItIsReturned {
@@ -1132,6 +1158,10 @@
       .andReturn([FBLPromise resolvedWith:[NSNull null]]);
 
   return responseInstallation;
+}
+
+- (void)expectAPIServiceInitWithAPIKey:(NSString *)APIKey projectID:(NSString *)projectID {
+  OCMExpect([self.mockAPIService initWithAPIKey:APIKey projectID:projectID]);
 }
 
 @end

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
@@ -93,9 +93,16 @@
   NSString *APIKey = @"api-key";
   NSString *projectID = @"project-id";
   OCMExpect([self.mockAPIService alloc]).andReturn(self.mockAPIService);
-  OCMExpect([self.mockAPIService initWithAPIKey:APIKey projectID:projectID]).andReturn(self.mockAPIService);
+  OCMExpect([self.mockAPIService initWithAPIKey:APIKey projectID:projectID])
+      .andReturn(self.mockAPIService);
 
-  FIRInstallationsIDController *controller = [[FIRInstallationsIDController alloc] initWithGoogleAppID:@"app-id" appName:@"app-name" APIKey:APIKey projectID:projectID GCMSenderID:@"sender-id" accessGroup:nil];
+  FIRInstallationsIDController *controller =
+      [[FIRInstallationsIDController alloc] initWithGoogleAppID:@"app-id"
+                                                        appName:@"app-name"
+                                                         APIKey:APIKey
+                                                      projectID:projectID
+                                                    GCMSenderID:@"sender-id"
+                                                    accessGroup:nil];
   XCTAssertNotNil(controller);
 
   OCMVerifyAll(self.mockAPIService);
@@ -105,9 +112,16 @@
   NSString *APIKey = @"api-key";
   NSString *GCMSenderID = @"sender-id";
   OCMExpect([self.mockAPIService alloc]).andReturn(self.mockAPIService);
-  OCMExpect([self.mockAPIService initWithAPIKey:APIKey projectID:GCMSenderID]).andReturn(self.mockAPIService);
+  OCMExpect([self.mockAPIService initWithAPIKey:APIKey projectID:GCMSenderID])
+      .andReturn(self.mockAPIService);
 
-  FIRInstallationsIDController *controller = [[FIRInstallationsIDController alloc] initWithGoogleAppID:@"app-id" appName:@"app-name" APIKey:APIKey projectID:@"" GCMSenderID:GCMSenderID accessGroup:nil];
+  FIRInstallationsIDController *controller =
+      [[FIRInstallationsIDController alloc] initWithGoogleAppID:@"app-id"
+                                                        appName:@"app-name"
+                                                         APIKey:APIKey
+                                                      projectID:@""
+                                                    GCMSenderID:GCMSenderID
+                                                    accessGroup:nil];
   XCTAssertNotNil(controller);
 
   OCMVerifyAll(self.mockAPIService);

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
@@ -45,6 +45,9 @@
 
   self.appOptions = [[FIROptions alloc] initWithGoogleAppID:@"GoogleAppID"
                                                 GCMSenderID:@"GCMSenderID"];
+  self.appOptions.APIKey = @"APIKey";
+  self.appOptions.projectID = @"ProjectID";
+
   self.mockIDController = OCMClassMock([FIRInstallationsIDController class]);
   self.installations = [[FIRInstallations alloc] initWithAppOptions:self.appOptions
                                                             appName:@"appName"
@@ -232,6 +235,59 @@
   }];
 
   [self waitForExpectations:@[ deleteExpectation ] timeout:0.5];
+}
+
+#pragma mark - Invalid Firebase configuration
+
+- (void)testInitWhenProjectIDMissingThenThrows {
+  FIROptions *options = [self.appOptions copy];
+  options.projectID = nil;
+  XCTAssertThrows([self createInstallationsWithAppOptions:options appName:@"missingProjectID"]);
+
+  options.projectID = @"";
+  XCTAssertThrows([self createInstallationsWithAppOptions:options appName:@"emptyProjectID"]);
+}
+
+- (void)testInitWhenAPIKeyMissingThenThrows {
+  FIROptions *options = [self.appOptions copy];
+  options.APIKey = nil;
+  XCTAssertThrows([self createInstallationsWithAppOptions:options appName:@"missingAPIKey"]);
+
+  options.APIKey = @"";
+  XCTAssertThrows([self createInstallationsWithAppOptions:options appName:@"emptyAPIKey"]);
+}
+
+- (void)testInitWhenGoogleAppIDMissingThenThrows {
+  FIROptions *options = [self.appOptions copy];
+  options.googleAppID = @"";
+  XCTAssertThrows([self createInstallationsWithAppOptions:options appName:@"emptyGoogleAppID"]);
+}
+
+- (void)testInitWhenGCMSenderIDMissingThenThrows {
+  FIROptions *options = [self.appOptions copy];
+  options.GCMSenderID = @"";
+  XCTAssertThrows([self createInstallationsWithAppOptions:options appName:@"emptyGCMSenderID"]);
+}
+
+- (void)testInitWhenAppNameMissingThenThrows {
+  FIROptions *options = [self.appOptions copy];
+  XCTAssertThrows([self createInstallationsWithAppOptions:options appName:@""]);
+  XCTAssertThrows([self createInstallationsWithAppOptions:options appName:nil]);
+}
+
+- (void)testInitWhenAppOptionsMissingThenThrows {
+  XCTAssertThrows([self createInstallationsWithAppOptions:nil appName:@"missingOptions"]);
+}
+
+#pragma mark - Helpers
+
+- (FIRInstallations *)createInstallationsWithAppOptions:(FIROptions *)options
+                                                appName:(NSString *)appName {
+  id mockIDController = OCMClassMock([FIRInstallationsIDController class]);
+  return [[FIRInstallations alloc] initWithAppOptions:options
+                                              appName:appName
+                            installationsIDController:mockIDController
+                                    prefetchAuthToken:NO];
 }
 
 @end

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
@@ -266,7 +266,18 @@
 - (void)testInitWhenGCMSenderIDMissingThenThrows {
   FIROptions *options = [self.appOptions copy];
   options.GCMSenderID = @"";
-  XCTAssertThrows([self createInstallationsWithAppOptions:options appName:@"emptyGCMSenderID"]);
+  XCTAssertNoThrow([self createInstallationsWithAppOptions:options appName:@"emptyGCMSenderID"]);
+}
+
+- (void)testInitWhenProjectIDAndGCMSenderIDMissingThenNoThrow {
+  FIROptions *options = [self.appOptions copy];
+  options.GCMSenderID = @"";
+
+  options.projectID = nil;
+  XCTAssertThrows([self createInstallationsWithAppOptions:options appName:@"missingProjectID"]);
+
+  options.projectID = @"";
+  XCTAssertThrows([self createInstallationsWithAppOptions:options appName:@"emptyProjectID"]);
 }
 
 - (void)testInitWhenAppNameMissingThenThrows {

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
@@ -239,13 +239,13 @@
 
 #pragma mark - Invalid Firebase configuration
 
-- (void)testInitWhenProjectIDMissingThenThrows {
+- (void)testInitWhenProjectIDMissingThenNoThrow {
   FIROptions *options = [self.appOptions copy];
   options.projectID = nil;
-  XCTAssertThrows([self createInstallationsWithAppOptions:options appName:@"missingProjectID"]);
+  XCTAssertNoThrow([self createInstallationsWithAppOptions:options appName:@"missingProjectID"]);
 
   options.projectID = @"";
-  XCTAssertThrows([self createInstallationsWithAppOptions:options appName:@"emptyProjectID"]);
+  XCTAssertNoThrow([self createInstallationsWithAppOptions:options appName:@"emptyProjectID"]);
 }
 
 - (void)testInitWhenAPIKeyMissingThenThrows {

--- a/FirebaseRemoteConfig/Tests/Unit/FIRRemoteConfigComponentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/FIRRemoteConfigComponentTest.m
@@ -173,8 +173,11 @@
 #pragma mark - Helpers
 
 - (FIROptions *)fakeOptions {
-  return [[FIROptions alloc] initWithGoogleAppID:@"1:123:ios:123abc"
-                                     GCMSenderID:@"correct_gcm_sender_id"];
+  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:@"1:123:ios:123abc"
+                                                    GCMSenderID:@"correct_gcm_sender_id"];
+  options.APIKey = @"api-key";
+  options.projectID = @"project-id";
+  return options;
 }
 
 - (NSString *)generatedTestAppName {


### PR DESCRIPTION
Do validation of missing `FIROptions` fields at configuration as other Firebase SDKs do:
- throw in case of missing `FIROptions.APIKey`:
  - the parameter is required by Auth, Dynamic links, Firestore, etc.
  - this parameter was not required by the old InstanceID version, so there  is a slight chance there are projects that will have to missing `APIKey` after updating
- throw in case of missing `FIROptions.GCMSenderID`: 
  - this parameter is already validated by Firebase Core
- use `FIROptions.GCMSenderID` instead of  `FIROptions.projectID` (when unavailable)

See #4692 for additional details.