### PR TITLE
Fix FIRMessagingExtensionHelper crash when `attachment == nil`

### DIFF
--- a/Firebase/Messaging/FIRMessagingExtensionHelper.m
+++ b/Firebase/Messaging/FIRMessagingExtensionHelper.m
@@ -46,7 +46,9 @@ static NSString *const kPayloadOptionsImageURLName = @"image";
   if (attachmentURL) {
     [self loadAttachmentForURL:attachmentURL
              completionHandler:^(UNNotificationAttachment *attachment) {
-               self.bestAttemptContent.attachments = @[ attachment ];
+               if (attachment != nil) {
+                 self.bestAttemptContent.attachments = @[ attachment ];
+               }
                [self deliverNotification];
              }];
   } else {


### PR DESCRIPTION
The crash was reviled by macOS test (e.g. see the [build](https://travis-ci.org/firebase/firebase-ios-sdk/jobs/637250784?utm_medium=notification&utm_source=github_status)). The crash leads to the tests hanging which looks like a timeout in Travis.