### PR TITLE
Use pre-release versions from release manifests.

### DIFF
--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -21,12 +21,22 @@ import Foundation
 enum CocoaPodUtils {
   // MARK: - Public API
 
-  struct VersionedPod: Decodable {
+  struct VersionedPod: Decodable, CustomDebugStringConvertible {
     /// Public name of the pod.
     let name: String
 
     /// The version of the requested pod.
     let version: String?
+
+    /// The debug description as required by `CustomDebugStringConvertible`.
+    var debugDescription: String {
+      var desc = name
+      if let version = version {
+        desc.append(" v\(version)")
+      }
+
+      return desc
+    }
   }
 
   /// Information associated with an installed pod.

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -190,7 +190,7 @@ struct ZipBuilder {
     // versions with `alpha` or `beta` in it, we'll need to explicitly specify the version here so
     // CocoaPods installs it properly.
     let prereleases = expectedVersions().filter { _, version in
-      return version.contains("alpha") || version.contains("beta")
+      version.contains("alpha") || version.contains("beta")
     }
 
     let podsToInstall: [CocoaPodUtils.VersionedPod] = inputPods.map { name in

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -190,7 +190,7 @@ struct ZipBuilder {
     // versions with `alpha` or `beta` in it, we'll need to explicitly specify the version here so
     // CocoaPods installs it properly.
     let prereleases = expectedVersions().filter { _, version in
-      version.contains("alpha") || version.contains("beta")
+      version.contains("alpha") || version.contains("beta") || version.contains("rc")
     }
 
     let podsToInstall: [CocoaPodUtils.VersionedPod] = inputPods.map { name in

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -185,7 +185,20 @@ struct ZipBuilder {
     // install a subset of pods, like the following line:
     // let inputPods: [String] = ["Firebase", "FirebaseCore", "FirebaseAnalytics", "FirebaseStorage"]
     let inputPods = FirebasePods.allCases.map { $0.rawValue }
-    let podsToInstall = inputPods.map { CocoaPodUtils.VersionedPod(name: $0, version: nil) }
+
+    // Get the expected versions based on the release manifests, if there are any. If there are any
+    // versions with `alpha` or `beta` in it, we'll need to explicitly specify the version here so
+    // CocoaPods installs it properly.
+    let prereleases = expectedVersions().filter { _, version in
+      return version.contains("alpha") || version.contains("beta")
+    }
+
+    let podsToInstall: [CocoaPodUtils.VersionedPod] = inputPods.map { name in
+      // If there's a pre-release version, include it here. Otherwise don't pass a version since we
+      // want the latest.
+      let version: String? = prereleases[name]
+      return CocoaPodUtils.VersionedPod(name: name, version: version)
+    }
 
     let (installedPods, frameworks) = buildAndAssembleZip(podsToInstall: podsToInstall)
 


### PR DESCRIPTION
This will allow installing pre-release versions since CocoaPods
complains otherwise. Note: this removes any version validation since
we're hardcoding the expected version as the version to install.

Also add `CustomDebugStringConvertible` support to `VersionedPod` for nicer printing when debugging.

#no-changelog