### PR TITLE
Stop sending logging ID as it is no longer used in backend

### DIFF
--- a/Firebase/InstanceID/CHANGELOG.md
+++ b/Firebase/InstanceID/CHANGELOG.md
@@ -1,5 +1,5 @@
-# unreleased
-- [changed] Stop collecting logging ID as it is not used anymore.(#4732)
+# 2020-02 -- 4.3.1
+- [changed] Stop collecting logging ID as it is not used anymore.(#4444)
 
 # 2020-01 -- 4.3.0
 - [added] Added watchOS support for InstanceID (#4016)

--- a/Firebase/InstanceID/CHANGELOG.md
+++ b/Firebase/InstanceID/CHANGELOG.md
@@ -1,3 +1,6 @@
+# unreleased
+- [changed] Stop collecting logging ID as it is not used anymore.(#4732)
+
 # 2020-01 -- 4.3.0
 - [added] Added watchOS support for InstanceID (#4016)
 - [added] Added a new dependency on the [Firebase Installations SDK](../../FirebaseInstallations/CHANGELOG.md). The Firebase Installations SDK introduces the [Firebase Installations API](https://console.cloud.google.com/apis/library/firebaseinstallations.googleapis.com). Developers that use API-restrictions for their API-Keys may experience blocked requests (https://stackoverflow.com/questions/58495985/). A solution is available [here](../../FirebaseInstallations/API_KEY_RESTRICTIONS.md). (#4533)

--- a/Firebase/InstanceID/FIRInstanceIDCheckinService.m
+++ b/Firebase/InstanceID/FIRInstanceIDCheckinService.m
@@ -213,7 +213,6 @@ static FIRInstanceIDURLRequestTestBlock testBlock;
   // This ID is generated for logging purpose and it is only logged for performance
   // information for backend, not secure information.
   // TODO(chliang): Talk to backend team to see if this ID is still needed.
-  uint32_t loggingID = arc4random();
   NSString *timeZone = [NSTimeZone localTimeZone].name;
   int64_t lastCheckingTimestampMillis = checkinPreferences.lastCheckinTimestampMillis;
 
@@ -225,7 +224,6 @@ static FIRInstanceIDURLRequestTestBlock testBlock;
       @"last_checkin_msec" : @(lastCheckingTimestampMillis),
     },
     @"fragment" : @(kFragment),
-    @"logging_id" : @(loggingID),
     @"locale" : locale,
     @"version" : @(kCheckinVersion),
     @"digest" : checkinPreferences.digest ?: @"",


### PR DESCRIPTION
The logging ID also uses simple random number generator that confuse people #4444. Since it's not used, remove it from logging.