### PR TITLE
GHA cron updates

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -4,15 +4,21 @@ on:
   pull_request:
     paths:
     - 'FirebaseCore**'
+    - '.github/workflows/core.yml'
+  schedule:
+    # Run every day at 1am (PST) - cron uses UTC times
+    - cron:  '0 7 * * *'
 
 jobs:
   core:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up
-      run: |
-        bundle install
-        bundle exec pod --version
-    - name: FirebaseCore
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
+    - name: FirebaseCore iOS
       run: ./scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=ios
+    - name: FirebaseCore macOS
+      run: ./scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=macos
+    - name: FirebaseCore tvOS
+      run: ./scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=tvos

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -6,7 +6,7 @@ on:
     - 'FirebaseCore**'
     - '.github/workflows/core.yml'
   schedule:
-    # Run every day at 1am (PST) - cron uses UTC times
+    # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'
 
 jobs:

--- a/.github/workflows/dynamiclinks.yml
+++ b/.github/workflows/dynamiclinks.yml
@@ -6,15 +6,17 @@ on:
     - 'Firebase/DynamicLinks**'
     - 'FirebaseDynamicLinks**'
     - 'Example/DynamicLinks**'
+    - '.github/workflows/dynamiclinks.yml'
+  schedule:
+    # Run every day at 1am (PST) - cron uses UTC times
+    - cron:  '0 7 * * *'
 
 jobs:
   dynamiclinks:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up
-      run: |
-        bundle install
-        bundle exec pod --version
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
     - name: FirebaseDynamicLinks
       run: ./scripts/pod_lib_lint.rb FirebaseDynamicLinks.podspec

--- a/.github/workflows/dynamiclinks.yml
+++ b/.github/workflows/dynamiclinks.yml
@@ -8,7 +8,7 @@ on:
     - 'Example/DynamicLinks**'
     - '.github/workflows/dynamiclinks.yml'
   schedule:
-    # Run every day at 1am (PST) - cron uses UTC times
+    # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'
 
 jobs:

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -18,6 +18,7 @@ jobs:
       env:
          plist_secret: ${{ secrets.StoragePlistSecret }}
       run: |
+        bundle update --bundler
         bundle install
         bundle exec pod --version
         ./scripts/decrypt_gha_secret.sh scripts/gha-encrypted/storage-db-plist.gpg \

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -5,6 +5,9 @@ on:
    paths:
    - 'FirebaseStorage**'
    - '.github/workflows/storage.yml'
+ schedule:
+   # Run every day at 1am (PST) - cron uses UTC times
+   - cron:  '0 7 * * *'
 
 jobs:
   storage:

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -1,13 +1,13 @@
 name: storage
 
 on:
- pull_request:
-   paths:
-   - 'FirebaseStorage**'
-   - '.github/workflows/storage.yml'
- schedule:
-   # Run every day at 1am (PST) - cron uses UTC times
-   - cron:  '0 7 * * *'
+  pull_request:
+    paths:
+    - 'FirebaseStorage**'
+    - '.github/workflows/storage.yml'
+  schedule:
+    # Run every day at 11pm (PST) - cron uses UTC times
+    - cron:  '0 7 * * *'
 
 jobs:
   storage:

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -23,8 +23,9 @@ jobs:
           FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist "$plist_secret"
     - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh Storage all
-    - name: PodLibLint
-      run: |
-        ./scripts/pod_lib_lint.rb FirebaseStorage.podspec --skip-tests --platforms=ios
-        ./scripts/pod_lib_lint.rb FirebaseStorage.podspec --skip-tests --platforms=macos
-        ./scripts/pod_lib_lint.rb FirebaseStorage.podspec --skip-tests --platforms=tvos
+    - name: PodLibLint iOS
+      run: ./scripts/pod_lib_lint.rb FirebaseStorage.podspec --skip-tests --platforms=ios
+    - name: PodLibLint macOS
+      run: ./scripts/pod_lib_lint.rb FirebaseStorage.podspec --skip-tests --platforms=macos
+    - name: PodLibLint tvOS
+      run: ./scripts/pod_lib_lint.rb FirebaseStorage.podspec --skip-tests --platforms=tvos

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -14,14 +14,12 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up
+    - name: Setup Bundler
+      run: .scripts/setup_bundler.sh
+    - name: Install Secret GoogleService-Info.plist
       env:
          plist_secret: ${{ secrets.StoragePlistSecret }}
-      run: |
-        bundle update --bundler
-        bundle install
-        bundle exec pod --version
-        ./scripts/decrypt_gha_secret.sh scripts/gha-encrypted/storage-db-plist.gpg \
+      run: ./scripts/decrypt_gha_secret.sh scripts/gha-encrypted/storage-db-plist.gpg \
           FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist "$plist_secret"
     - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh Storage all

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Setup Bundler
-      run: .scripts/setup_bundler.sh
+      run: ./scripts/setup_bundler.sh
     - name: Install Secret GoogleService-Info.plist
       env:
          plist_secret: ${{ secrets.StoragePlistSecret }}

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -1,12 +1,12 @@
-name: CRON
+name: zip
 
 on:
   schedule:
-    # Run every day at 1am (PST) - cron uses UTC times
-    - cron:  '0 7 * * *'
+    # Run every day at 2am (PST) - cron uses UTC times
+    - cron:  '0 8 * * *'
 
 jobs:
-  zip:
+  build:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -2,7 +2,7 @@ name: zip
 
 on:
   schedule:
-    # Run every day at 2am (PST) - cron uses UTC times
+    # Run every day at midnight(PST) - cron uses UTC times
     - cron:  '0 8 * * *'
 
 jobs:

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -10,9 +10,7 @@ jobs:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up
-      run: |
-        bundle install
-        bundle exec pod --version
+    - name: Setup Bundler
+      run: ./scripts/setup_bundler.sh
     - name: ZipBuildingTest
       run: ./scripts/build_zip.sh

--- a/scripts/setup_bundler.sh
+++ b/scripts/setup_bundler.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright 2020 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bundle update --bundler #insure bundler version is high enough for Gemfile.lock
+bundle install
+bundle exec pod --version


### PR DESCRIPTION
- Add a cron job for storage to insure it runs at least once a day
- More specific name for the zip builder cron job
- Setup the bundler in a separate script
- Standardize existing GHA yml files

#no-changelog