### PR TITLE
Fixing Dynamic Links open events.

### DIFF
--- a/Firebase/DynamicLinks/FIRDynamicLinks.m
+++ b/Firebase/DynamicLinks/FIRDynamicLinks.m
@@ -395,7 +395,7 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
 
 #ifdef GIN_SCION_LOGGING
       if (dynamicLink.url) {
-        BOOL isFirstOpen = ![_userDefaults boolForKey:kFIRDLReadDeepLinkAfterInstallKey];
+        BOOL isFirstOpen = [_userDefaults boolForKey:kFIRDLReadDeepLinkAfterInstallKey];
         FIRDLLogEvent event = isFirstOpen ? FIRDLLogEventFirstOpen : FIRDLLogEventAppOpen;
         FIRDLLogEventToScion(event, parameters[kFIRDLParameterSource],
                              parameters[kFIRDLParameterMedium], parameters[kFIRDLParameterCampaign],


### PR DESCRIPTION
I'm tracking events on DebugView and I noticed this:

dynamic_link_app_open is sent when the user opens the app for the first time through a DL.
dynamic_link_first_open is sent when the user opens the app through a DL (if it already had the app installed)

This has beed discussed here:
[](https://github.com/firebase/firebase-ios-sdk/issues/4461)