### PR TITLE
Crashlytics resolve symbol collisions with old SDK

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSBinaryImage.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSBinaryImage.m
@@ -54,11 +54,11 @@ static void FIRCLSBinaryImageRecordSlice(bool added, const FIRCLSBinaryImageDeta
 void FIRCLSBinaryImageInit(FIRCLSBinaryImageReadOnlyContext* roContext,
                            FIRCLSBinaryImageReadWriteContext* rwContext) {
   // initialize our node array to all zeros
-  memset(&_clsContext.writable->binaryImage, 0, sizeof(_clsContext.writable->binaryImage));
-  _clsContext.writable->binaryImage.file.fd = -1;
+  memset(&_firclsContext.writable->binaryImage, 0, sizeof(_firclsContext.writable->binaryImage));
+  _firclsContext.writable->binaryImage.file.fd = -1;
 
   dispatch_async(FIRCLSGetBinaryImageQueue(), ^{
-    if (!FIRCLSUnlinkIfExists(_clsContext.readonly->binaryimage.path)) {
+    if (!FIRCLSUnlinkIfExists(_firclsContext.readonly->binaryimage.path)) {
       FIRCLSSDKLog("Unable to reset the binary image log file %s\n", strerror(errno));
     }
 
@@ -72,16 +72,16 @@ void FIRCLSBinaryImageInit(FIRCLSBinaryImageReadOnlyContext* roContext,
   _dyld_register_func_for_remove_image(FIRCLSBinaryImageRemovedCallback);
 
   dispatch_async(FIRCLSGetBinaryImageQueue(), ^{
-    FIRCLSFileClose(&_clsContext.writable->binaryImage.file);
+    FIRCLSFileClose(&_firclsContext.writable->binaryImage.file);
   });
 }
 
 static bool FIRCLSBinaryImageOpenIfNeeded(bool* needsClosing) {
-  if (!FIRCLSIsValidPointer(_clsContext.writable)) {
+  if (!FIRCLSIsValidPointer(_firclsContext.writable)) {
     return false;
   }
 
-  if (!FIRCLSIsValidPointer(_clsContext.readonly)) {
+  if (!FIRCLSIsValidPointer(_firclsContext.readonly)) {
     return false;
   }
 
@@ -91,12 +91,12 @@ static bool FIRCLSBinaryImageOpenIfNeeded(bool* needsClosing) {
 
   *needsClosing = false;
 
-  if (FIRCLSFileIsOpen(&_clsContext.writable->binaryImage.file)) {
+  if (FIRCLSFileIsOpen(&_firclsContext.writable->binaryImage.file)) {
     return true;
   }
 
-  if (!FIRCLSFileInitWithPath(&_clsContext.writable->binaryImage.file,
-                              _clsContext.readonly->binaryimage.path, false)) {
+  if (!FIRCLSFileInitWithPath(&_firclsContext.writable->binaryImage.file,
+                              _firclsContext.readonly->binaryimage.path, false)) {
     FIRCLSSDKLog("Error: unable to open binary image log file\n");
     return false;
   }
@@ -121,7 +121,7 @@ bool FIRCLSBinaryImageSafeFindImageForAddress(uintptr_t address,
     return false;
   }
 
-  FIRCLSBinaryImageRuntimeNode* nodes = _clsContext.writable->binaryImage.nodes;
+  FIRCLSBinaryImageRuntimeNode* nodes = _firclsContext.writable->binaryImage.nodes;
   if (!nodes) {
     FIRCLSSDKLogError("The node structure is NULL\n");
     return false;
@@ -388,14 +388,14 @@ static void FIRCLSBinaryImageStoreNode(bool added, FIRCLSBinaryImageDetails imag
   //    FIRCLSSDKLog("Storing %s node %p\n", added ? "loaded" : "unloaded",
   //    (void*)imageDetails.node.baseAddress);
 
-  if (!_clsContext.writable) {
+  if (!_firclsContext.writable) {
     FIRCLSSDKLog("Error: Writable context is NULL\n");
     return;
   }
 
   void* searchAddress = NULL;
   bool success = false;
-  FIRCLSBinaryImageRuntimeNode* nodes = _clsContext.writable->binaryImage.nodes;
+  FIRCLSBinaryImageRuntimeNode* nodes = _firclsContext.writable->binaryImage.nodes;
 
   if (!added) {
     // capture the search address first
@@ -517,7 +517,7 @@ static void FIRCLSBinaryImageRecordSlice(bool added, const FIRCLSBinaryImageDeta
     return;
   }
 
-  FIRCLSFile* file = &_clsContext.writable->binaryImage.file;
+  FIRCLSFile* file = &_firclsContext.writable->binaryImage.file;
 
   FIRCLSFileWriteSectionStart(file, added ? "load" : "unload");
 

--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.m
@@ -62,101 +62,101 @@ bool FIRCLSContextInitialize(const FIRCLSContextInitData* initData) {
   NSString* rootPath = [NSString stringWithUTF8String:initData->rootPath];
 
   // setup our SDK log file synchronously, because other calls may depend on it
-  _clsContext.readonly->logPath = FIRCLSContextAppendToRoot(rootPath, @"sdk.log");
-  if (!FIRCLSUnlinkIfExists(_clsContext.readonly->logPath)) {
+  _firclsContext.readonly->logPath = FIRCLSContextAppendToRoot(rootPath, @"sdk.log");
+  if (!FIRCLSUnlinkIfExists(_firclsContext.readonly->logPath)) {
     FIRCLSErrorLog(@"Unable to write initialize SDK write paths %s", strerror(errno));
   }
 
   // some values that aren't tied to particular subsystem
-  _clsContext.readonly->debuggerAttached = FIRCLSProcessDebuggerAttached();
-  _clsContext.readonly->delegate = initData->delegate;
+  _firclsContext.readonly->debuggerAttached = FIRCLSProcessDebuggerAttached();
+  _firclsContext.readonly->delegate = initData->delegate;
 
   dispatch_group_async(group, queue, ^{
-    FIRCLSHostInitialize(&_clsContext.readonly->host);
+    FIRCLSHostInitialize(&_firclsContext.readonly->host);
   });
 
   dispatch_group_async(group, queue, ^{
-    _clsContext.readonly->logging.errorStorage.maxSize = 0;
-    _clsContext.readonly->logging.errorStorage.maxEntries =
+    _firclsContext.readonly->logging.errorStorage.maxSize = 0;
+    _firclsContext.readonly->logging.errorStorage.maxEntries =
         initData->errorsEnabled ? initData->maxCustomExceptions : 0;
-    _clsContext.readonly->logging.errorStorage.restrictBySize = false;
-    _clsContext.readonly->logging.errorStorage.entryCount =
-        &_clsContext.writable->logging.errorsCount;
-    _clsContext.readonly->logging.errorStorage.aPath =
+    _firclsContext.readonly->logging.errorStorage.restrictBySize = false;
+    _firclsContext.readonly->logging.errorStorage.entryCount =
+        &_firclsContext.writable->logging.errorsCount;
+    _firclsContext.readonly->logging.errorStorage.aPath =
         FIRCLSContextAppendToRoot(rootPath, FIRCLSReportErrorAFile);
-    _clsContext.readonly->logging.errorStorage.bPath =
+    _firclsContext.readonly->logging.errorStorage.bPath =
         FIRCLSContextAppendToRoot(rootPath, FIRCLSReportErrorBFile);
 
-    _clsContext.readonly->logging.logStorage.maxSize = initData->maxLogSize;
-    _clsContext.readonly->logging.logStorage.maxEntries = 0;
-    _clsContext.readonly->logging.logStorage.restrictBySize = true;
-    _clsContext.readonly->logging.logStorage.entryCount = NULL;
-    _clsContext.readonly->logging.logStorage.aPath =
+    _firclsContext.readonly->logging.logStorage.maxSize = initData->maxLogSize;
+    _firclsContext.readonly->logging.logStorage.maxEntries = 0;
+    _firclsContext.readonly->logging.logStorage.restrictBySize = true;
+    _firclsContext.readonly->logging.logStorage.entryCount = NULL;
+    _firclsContext.readonly->logging.logStorage.aPath =
         FIRCLSContextAppendToRoot(rootPath, @"log_a.clsrecord");
-    _clsContext.readonly->logging.logStorage.bPath =
+    _firclsContext.readonly->logging.logStorage.bPath =
         FIRCLSContextAppendToRoot(rootPath, @"log_b.clsrecord");
-    _clsContext.readonly->logging.customExceptionStorage.aPath =
+    _firclsContext.readonly->logging.customExceptionStorage.aPath =
         FIRCLSContextAppendToRoot(rootPath, FIRCLSReportCustomExceptionAFile);
-    _clsContext.readonly->logging.customExceptionStorage.bPath =
+    _firclsContext.readonly->logging.customExceptionStorage.bPath =
         FIRCLSContextAppendToRoot(rootPath, FIRCLSReportCustomExceptionBFile);
-    _clsContext.readonly->logging.customExceptionStorage.maxSize = 0;
-    _clsContext.readonly->logging.customExceptionStorage.restrictBySize = false;
-    _clsContext.readonly->logging.customExceptionStorage.maxEntries = initData->maxCustomExceptions;
-    _clsContext.readonly->logging.customExceptionStorage.entryCount =
-        &_clsContext.writable->exception.customExceptionCount;
+    _firclsContext.readonly->logging.customExceptionStorage.maxSize = 0;
+    _firclsContext.readonly->logging.customExceptionStorage.restrictBySize = false;
+    _firclsContext.readonly->logging.customExceptionStorage.maxEntries = initData->maxCustomExceptions;
+    _firclsContext.readonly->logging.customExceptionStorage.entryCount =
+        &_firclsContext.writable->exception.customExceptionCount;
 
-    _clsContext.readonly->logging.userKVStorage.maxCount = initData->maxKeyValues;
-    _clsContext.readonly->logging.userKVStorage.incrementalPath =
+    _firclsContext.readonly->logging.userKVStorage.maxCount = initData->maxKeyValues;
+    _firclsContext.readonly->logging.userKVStorage.incrementalPath =
         FIRCLSContextAppendToRoot(rootPath, FIRCLSReportUserIncrementalKVFile);
-    _clsContext.readonly->logging.userKVStorage.compactedPath =
+    _firclsContext.readonly->logging.userKVStorage.compactedPath =
         FIRCLSContextAppendToRoot(rootPath, FIRCLSReportUserCompactedKVFile);
 
-    _clsContext.readonly->logging.internalKVStorage.maxCount = 32;  // Hardcode = bad
-    _clsContext.readonly->logging.internalKVStorage.incrementalPath =
+    _firclsContext.readonly->logging.internalKVStorage.maxCount = 32;  // Hardcode = bad
+    _firclsContext.readonly->logging.internalKVStorage.incrementalPath =
         FIRCLSContextAppendToRoot(rootPath, FIRCLSReportInternalIncrementalKVFile);
-    _clsContext.readonly->logging.internalKVStorage.compactedPath =
+    _firclsContext.readonly->logging.internalKVStorage.compactedPath =
         FIRCLSContextAppendToRoot(rootPath, FIRCLSReportInternalCompactedKVFile);
 
-    FIRCLSUserLoggingInit(&_clsContext.readonly->logging, &_clsContext.writable->logging);
+    FIRCLSUserLoggingInit(&_firclsContext.readonly->logging, &_firclsContext.writable->logging);
   });
 
   dispatch_group_async(group, queue, ^{
-    _clsContext.readonly->binaryimage.path =
+    _firclsContext.readonly->binaryimage.path =
         FIRCLSContextAppendToRoot(rootPath, FIRCLSReportBinaryImageFile);
 
-    FIRCLSBinaryImageInit(&_clsContext.readonly->binaryimage, &_clsContext.writable->binaryImage);
+    FIRCLSBinaryImageInit(&_firclsContext.readonly->binaryimage, &_firclsContext.writable->binaryImage);
   });
 
   dispatch_group_async(group, queue, ^{
     NSString* rootPath = [NSString stringWithUTF8String:initData->previouslyCrashedFileRootPath];
     NSString* fileName = [NSString stringWithUTF8String:FIRCLSCrashedMarkerFileName];
-    _clsContext.readonly->previouslyCrashedFileFullPath =
+    _firclsContext.readonly->previouslyCrashedFileFullPath =
         FIRCLSContextAppendToRoot(rootPath, fileName);
   });
 
-  if (!_clsContext.readonly->debuggerAttached) {
+  if (!_firclsContext.readonly->debuggerAttached) {
     dispatch_group_async(group, queue, ^{
-      _clsContext.readonly->signal.path = FIRCLSContextAppendToRoot(rootPath, FIRCLSReportSignalFile);
+      _firclsContext.readonly->signal.path = FIRCLSContextAppendToRoot(rootPath, FIRCLSReportSignalFile);
 
-      FIRCLSSignalInitialize(&_clsContext.readonly->signal);
+      FIRCLSSignalInitialize(&_firclsContext.readonly->signal);
     });
 
 #if CLS_MACH_EXCEPTION_SUPPORTED
     dispatch_group_async(group, queue, ^{
-      _clsContext.readonly->machException.path =
+      _firclsContext.readonly->machException.path =
           FIRCLSContextAppendToRoot(rootPath, FIRCLSReportMachExceptionFile);
 
-      FIRCLSMachExceptionInit(&_clsContext.readonly->machException, initData->machExceptionMask);
+      FIRCLSMachExceptionInit(&_firclsContext.readonly->machException, initData->machExceptionMask);
     });
 #endif
 
     dispatch_group_async(group, queue, ^{
-      _clsContext.readonly->exception.path =
+      _firclsContext.readonly->exception.path =
           FIRCLSContextAppendToRoot(rootPath, FIRCLSReportExceptionFile);
-      _clsContext.readonly->exception.maxCustomExceptions =
+      _firclsContext.readonly->exception.maxCustomExceptions =
           initData->customExceptionsEnabled ? initData->maxCustomExceptions : 0;
 
-      FIRCLSExceptionInitialize(&_clsContext.readonly->exception, &_clsContext.writable->exception,
+      FIRCLSExceptionInitialize(&_firclsContext.readonly->exception, &_firclsContext.writable->exception,
                                 initData->delegate);
     });
   } else {
@@ -178,10 +178,10 @@ bool FIRCLSContextInitialize(const FIRCLSContextInitData* initData) {
 
   // Note at this will retain the group, so its totally fine to release the group here.
   dispatch_group_notify(group, queue, ^{
-    _clsContext.readonly->initialized = true;
+    _firclsContext.readonly->initialized = true;
     __sync_synchronize();
 
-    if (!FIRCLSAllocatorProtect(_clsContext.allocator)) {
+    if (!FIRCLSAllocatorProtect(_firclsContext.allocator)) {
       FIRCLSSDKLog("Error: Memory protection failed\n");
     }
   });
@@ -218,13 +218,13 @@ void FIRCLSContextBaseInit(void) {
   _firclsExceptionQueue =
       dispatch_queue_create([exceptionQueueName UTF8String], DISPATCH_QUEUE_SERIAL);
 
-  FIRCLSContextAllocate(&_clsContext);
+  FIRCLSContextAllocate(&_firclsContext);
 
-  _clsContext.writable->internalLogging.logFd = -1;
-  _clsContext.writable->internalLogging.logLevel = FIRCLSInternalLogLevelDebug;
-  _clsContext.writable->crashOccurred = false;
+  _firclsContext.writable->internalLogging.logFd = -1;
+  _firclsContext.writable->internalLogging.logLevel = FIRCLSInternalLogLevelDebug;
+  _firclsContext.writable->crashOccurred = false;
 
-  _clsContext.readonly->initialized = false;
+  _firclsContext.readonly->initialized = false;
 
   __sync_synchronize();
 }
@@ -260,10 +260,10 @@ static void FIRCLSContextAllocate(FIRCLSContext* context) {
 #endif
 
 #if CLS_MACH_EXCEPTION_SUPPORTED
-  memset(_clsContext.readonly->machStack, 0, CLS_MACH_EXCEPTION_HANDLER_STACK_SIZE);
+  memset(_firclsContext.readonly->machStack, 0, CLS_MACH_EXCEPTION_HANDLER_STACK_SIZE);
 #endif
 #if CLS_USE_SIGALTSTACK
-  memset(_clsContext.readonly->signalStack, 0, CLS_SIGNAL_HANDLER_STACK_SIZE);
+  memset(_firclsContext.readonly->signalStack, 0, CLS_SIGNAL_HANDLER_STACK_SIZE);
 #endif
 
   context->writable = FIRCLSAllocatorSafeAllocate(context->allocator,
@@ -272,18 +272,18 @@ static void FIRCLSContextAllocate(FIRCLSContext* context) {
 }
 
 void FIRCLSContextBaseDeinit(void) {
-  _clsContext.readonly->initialized = false;
+  _firclsContext.readonly->initialized = false;
 
-  FIRCLSAllocatorDestroy(_clsContext.allocator);
+  FIRCLSAllocatorDestroy(_firclsContext.allocator);
 }
 
 bool FIRCLSContextIsInitialized(void) {
   __sync_synchronize();
-  if (!FIRCLSIsValidPointer(_clsContext.readonly)) {
+  if (!FIRCLSIsValidPointer(_firclsContext.readonly)) {
     return false;
   }
 
-  return _clsContext.readonly->initialized;
+  return _firclsContext.readonly->initialized;
 }
 
 bool FIRCLSContextHasCrashed(void) {
@@ -292,7 +292,7 @@ bool FIRCLSContextHasCrashed(void) {
   }
 
   // we've already run a full barrier above, so this read is ok
-  return _clsContext.writable->crashOccurred;
+  return _firclsContext.writable->crashOccurred;
 }
 
 void FIRCLSContextMarkHasCrashed(void) {
@@ -300,7 +300,7 @@ void FIRCLSContextMarkHasCrashed(void) {
     return;
   }
 
-  _clsContext.writable->crashOccurred = true;
+  _firclsContext.writable->crashOccurred = true;
   __sync_synchronize();
 }
 
@@ -309,11 +309,11 @@ bool FIRCLSContextMarkAndCheckIfCrashed(void) {
     return false;
   }
 
-  if (_clsContext.writable->crashOccurred) {
+  if (_firclsContext.writable->crashOccurred) {
     return true;
   }
 
-  _clsContext.writable->crashOccurred = true;
+  _firclsContext.writable->crashOccurred = true;
   __sync_synchronize();
 
   return false;

--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.m
@@ -101,7 +101,8 @@ bool FIRCLSContextInitialize(const FIRCLSContextInitData* initData) {
         FIRCLSContextAppendToRoot(rootPath, FIRCLSReportCustomExceptionBFile);
     _firclsContext.readonly->logging.customExceptionStorage.maxSize = 0;
     _firclsContext.readonly->logging.customExceptionStorage.restrictBySize = false;
-    _firclsContext.readonly->logging.customExceptionStorage.maxEntries = initData->maxCustomExceptions;
+    _firclsContext.readonly->logging.customExceptionStorage.maxEntries =
+        initData->maxCustomExceptions;
     _firclsContext.readonly->logging.customExceptionStorage.entryCount =
         &_firclsContext.writable->exception.customExceptionCount;
 
@@ -124,7 +125,8 @@ bool FIRCLSContextInitialize(const FIRCLSContextInitData* initData) {
     _firclsContext.readonly->binaryimage.path =
         FIRCLSContextAppendToRoot(rootPath, FIRCLSReportBinaryImageFile);
 
-    FIRCLSBinaryImageInit(&_firclsContext.readonly->binaryimage, &_firclsContext.writable->binaryImage);
+    FIRCLSBinaryImageInit(&_firclsContext.readonly->binaryimage,
+                          &_firclsContext.writable->binaryImage);
   });
 
   dispatch_group_async(group, queue, ^{
@@ -136,7 +138,8 @@ bool FIRCLSContextInitialize(const FIRCLSContextInitData* initData) {
 
   if (!_firclsContext.readonly->debuggerAttached) {
     dispatch_group_async(group, queue, ^{
-      _firclsContext.readonly->signal.path = FIRCLSContextAppendToRoot(rootPath, FIRCLSReportSignalFile);
+      _firclsContext.readonly->signal.path =
+          FIRCLSContextAppendToRoot(rootPath, FIRCLSReportSignalFile);
 
       FIRCLSSignalInitialize(&_firclsContext.readonly->signal);
     });
@@ -156,16 +159,16 @@ bool FIRCLSContextInitialize(const FIRCLSContextInitData* initData) {
       _firclsContext.readonly->exception.maxCustomExceptions =
           initData->customExceptionsEnabled ? initData->maxCustomExceptions : 0;
 
-      FIRCLSExceptionInitialize(&_firclsContext.readonly->exception, &_firclsContext.writable->exception,
-                                initData->delegate);
+      FIRCLSExceptionInitialize(&_firclsContext.readonly->exception,
+                                &_firclsContext.writable->exception, initData->delegate);
     });
   } else {
     FIRCLSSDKLog("Debugger present - not installing handlers\n");
   }
 
   dispatch_group_async(group, queue, ^{
-    const char* metaDataPath =
-        [[rootPath stringByAppendingPathComponent:FIRCLSReportMetadataFile] fileSystemRepresentation];
+    const char* metaDataPath = [[rootPath stringByAppendingPathComponent:FIRCLSReportMetadataFile]
+        fileSystemRepresentation];
     if (!FIRCLSContextRecordMetadata(metaDataPath, initData)) {
       FIRCLSSDKLog("Unable to record context metadata\n");
     }

--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.m
@@ -83,9 +83,9 @@ bool FIRCLSContextInitialize(const FIRCLSContextInitData* initData) {
     _clsContext.readonly->logging.errorStorage.entryCount =
         &_clsContext.writable->logging.errorsCount;
     _clsContext.readonly->logging.errorStorage.aPath =
-        FIRCLSContextAppendToRoot(rootPath, CLSReportErrorAFile);
+        FIRCLSContextAppendToRoot(rootPath, FIRCLSReportErrorAFile);
     _clsContext.readonly->logging.errorStorage.bPath =
-        FIRCLSContextAppendToRoot(rootPath, CLSReportErrorBFile);
+        FIRCLSContextAppendToRoot(rootPath, FIRCLSReportErrorBFile);
 
     _clsContext.readonly->logging.logStorage.maxSize = initData->maxLogSize;
     _clsContext.readonly->logging.logStorage.maxEntries = 0;
@@ -96,9 +96,9 @@ bool FIRCLSContextInitialize(const FIRCLSContextInitData* initData) {
     _clsContext.readonly->logging.logStorage.bPath =
         FIRCLSContextAppendToRoot(rootPath, @"log_b.clsrecord");
     _clsContext.readonly->logging.customExceptionStorage.aPath =
-        FIRCLSContextAppendToRoot(rootPath, CLSReportCustomExceptionAFile);
+        FIRCLSContextAppendToRoot(rootPath, FIRCLSReportCustomExceptionAFile);
     _clsContext.readonly->logging.customExceptionStorage.bPath =
-        FIRCLSContextAppendToRoot(rootPath, CLSReportCustomExceptionBFile);
+        FIRCLSContextAppendToRoot(rootPath, FIRCLSReportCustomExceptionBFile);
     _clsContext.readonly->logging.customExceptionStorage.maxSize = 0;
     _clsContext.readonly->logging.customExceptionStorage.restrictBySize = false;
     _clsContext.readonly->logging.customExceptionStorage.maxEntries = initData->maxCustomExceptions;
@@ -107,22 +107,22 @@ bool FIRCLSContextInitialize(const FIRCLSContextInitData* initData) {
 
     _clsContext.readonly->logging.userKVStorage.maxCount = initData->maxKeyValues;
     _clsContext.readonly->logging.userKVStorage.incrementalPath =
-        FIRCLSContextAppendToRoot(rootPath, CLSReportUserIncrementalKVFile);
+        FIRCLSContextAppendToRoot(rootPath, FIRCLSReportUserIncrementalKVFile);
     _clsContext.readonly->logging.userKVStorage.compactedPath =
-        FIRCLSContextAppendToRoot(rootPath, CLSReportUserCompactedKVFile);
+        FIRCLSContextAppendToRoot(rootPath, FIRCLSReportUserCompactedKVFile);
 
     _clsContext.readonly->logging.internalKVStorage.maxCount = 32;  // Hardcode = bad
     _clsContext.readonly->logging.internalKVStorage.incrementalPath =
-        FIRCLSContextAppendToRoot(rootPath, CLSReportInternalIncrementalKVFile);
+        FIRCLSContextAppendToRoot(rootPath, FIRCLSReportInternalIncrementalKVFile);
     _clsContext.readonly->logging.internalKVStorage.compactedPath =
-        FIRCLSContextAppendToRoot(rootPath, CLSReportInternalCompactedKVFile);
+        FIRCLSContextAppendToRoot(rootPath, FIRCLSReportInternalCompactedKVFile);
 
     FIRCLSUserLoggingInit(&_clsContext.readonly->logging, &_clsContext.writable->logging);
   });
 
   dispatch_group_async(group, queue, ^{
     _clsContext.readonly->binaryimage.path =
-        FIRCLSContextAppendToRoot(rootPath, CLSReportBinaryImageFile);
+        FIRCLSContextAppendToRoot(rootPath, FIRCLSReportBinaryImageFile);
 
     FIRCLSBinaryImageInit(&_clsContext.readonly->binaryimage, &_clsContext.writable->binaryImage);
   });
@@ -136,7 +136,7 @@ bool FIRCLSContextInitialize(const FIRCLSContextInitData* initData) {
 
   if (!_clsContext.readonly->debuggerAttached) {
     dispatch_group_async(group, queue, ^{
-      _clsContext.readonly->signal.path = FIRCLSContextAppendToRoot(rootPath, CLSReportSignalFile);
+      _clsContext.readonly->signal.path = FIRCLSContextAppendToRoot(rootPath, FIRCLSReportSignalFile);
 
       FIRCLSSignalInitialize(&_clsContext.readonly->signal);
     });
@@ -144,7 +144,7 @@ bool FIRCLSContextInitialize(const FIRCLSContextInitData* initData) {
 #if CLS_MACH_EXCEPTION_SUPPORTED
     dispatch_group_async(group, queue, ^{
       _clsContext.readonly->machException.path =
-          FIRCLSContextAppendToRoot(rootPath, CLSReportMachExceptionFile);
+          FIRCLSContextAppendToRoot(rootPath, FIRCLSReportMachExceptionFile);
 
       FIRCLSMachExceptionInit(&_clsContext.readonly->machException, initData->machExceptionMask);
     });
@@ -152,7 +152,7 @@ bool FIRCLSContextInitialize(const FIRCLSContextInitData* initData) {
 
     dispatch_group_async(group, queue, ^{
       _clsContext.readonly->exception.path =
-          FIRCLSContextAppendToRoot(rootPath, CLSReportExceptionFile);
+          FIRCLSContextAppendToRoot(rootPath, FIRCLSReportExceptionFile);
       _clsContext.readonly->exception.maxCustomExceptions =
           initData->customExceptionsEnabled ? initData->maxCustomExceptions : 0;
 
@@ -165,7 +165,7 @@ bool FIRCLSContextInitialize(const FIRCLSContextInitData* initData) {
 
   dispatch_group_async(group, queue, ^{
     const char* metaDataPath =
-        [[rootPath stringByAppendingPathComponent:CLSReportMetadataFile] fileSystemRepresentation];
+        [[rootPath stringByAppendingPathComponent:FIRCLSReportMetadataFile] fileSystemRepresentation];
     if (!FIRCLSContextRecordMetadata(metaDataPath, initData)) {
       FIRCLSSDKLog("Unable to record context metadata\n");
     }
@@ -198,7 +198,7 @@ void FIRCLSContextUpdateMetadata(const FIRCLSContextInitData* initData) {
   NSString* rootPath = [NSString stringWithUTF8String:initData->rootPath];
 
   const char* metaDataPath =
-      [[rootPath stringByAppendingPathComponent:CLSReportMetadataFile] fileSystemRepresentation];
+      [[rootPath stringByAppendingPathComponent:FIRCLSReportMetadataFile] fileSystemRepresentation];
 
   if (!FIRCLSContextRecordMetadata(metaDataPath, initData)) {
     FIRCLSErrorLog(@"Unable to update context metadata");
@@ -212,10 +212,10 @@ void FIRCLSContextBaseInit(void) {
   NSString* binaryImagesQueueName = [sdkBundleID stringByAppendingString:@".binary-images"];
   NSString* exceptionQueueName = [sdkBundleID stringByAppendingString:@".exception"];
 
-  _clsLoggingQueue = dispatch_queue_create([loggingQueueName UTF8String], DISPATCH_QUEUE_SERIAL);
-  _clsBinaryImageQueue =
+  _firclsLoggingQueue = dispatch_queue_create([loggingQueueName UTF8String], DISPATCH_QUEUE_SERIAL);
+  _firclsBinaryImageQueue =
       dispatch_queue_create([binaryImagesQueueName UTF8String], DISPATCH_QUEUE_SERIAL);
-  _clsExceptionQueue =
+  _firclsExceptionQueue =
       dispatch_queue_create([exceptionQueueName UTF8String], DISPATCH_QUEUE_SERIAL);
 
   FIRCLSContextAllocate(&_clsContext);

--- a/Crashlytics/Crashlytics/Components/FIRCLSCrashedMarkerFile.c
+++ b/Crashlytics/Crashlytics/Components/FIRCLSCrashedMarkerFile.c
@@ -21,7 +21,7 @@ const char *FIRCLSCrashedMarkerFileName = "previously-crashed";
 void FIRCLSCreateCrashedMarkerFile() {
   FIRCLSFile file;
 
-  if (!FIRCLSFileInitWithPath(&file, _clsContext.readonly->previouslyCrashedFileFullPath, false)) {
+  if (!FIRCLSFileInitWithPath(&file, _firclsContext.readonly->previouslyCrashedFileFullPath, false)) {
     FIRCLSSDKLog("Unable to create the crashed marker file\n");
     return;
   }

--- a/Crashlytics/Crashlytics/Components/FIRCLSGlobals.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSGlobals.h
@@ -16,7 +16,7 @@
 
 __BEGIN_DECLS
 
-extern FIRCLSContext _clsContext;
+extern FIRCLSContext _firclsContext;
 extern dispatch_queue_t _firclsLoggingQueue;
 extern dispatch_queue_t _firclsBinaryImageQueue;
 extern dispatch_queue_t _firclsExceptionQueue;

--- a/Crashlytics/Crashlytics/Components/FIRCLSGlobals.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSGlobals.h
@@ -21,8 +21,8 @@ extern dispatch_queue_t _firclsLoggingQueue;
 extern dispatch_queue_t _firclsBinaryImageQueue;
 extern dispatch_queue_t _firclsExceptionQueue;
 
-#define FIRCLSGetLoggingQueue() (_clsLoggingQueue)
-#define FIRCLSGetBinaryImageQueue() (_clsBinaryImageQueue)
-#define FIRCLSGetExceptionQueue() (_clsExceptionQueue)
+#define FIRCLSGetLoggingQueue() (_firclsLoggingQueue)
+#define FIRCLSGetBinaryImageQueue() (_firclsBinaryImageQueue)
+#define FIRCLSGetExceptionQueue() (_firclsExceptionQueue)
 
 __END_DECLS

--- a/Crashlytics/Crashlytics/Components/FIRCLSGlobals.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSGlobals.h
@@ -17,9 +17,9 @@
 __BEGIN_DECLS
 
 extern FIRCLSContext _clsContext;
-extern dispatch_queue_t _clsLoggingQueue;
-extern dispatch_queue_t _clsBinaryImageQueue;
-extern dispatch_queue_t _clsExceptionQueue;
+extern dispatch_queue_t _firclsLoggingQueue;
+extern dispatch_queue_t _firclsBinaryImageQueue;
+extern dispatch_queue_t _firclsExceptionQueue;
 
 #define FIRCLSGetLoggingQueue() (_clsLoggingQueue)
 #define FIRCLSGetBinaryImageQueue() (_clsBinaryImageQueue)

--- a/Crashlytics/Crashlytics/Components/FIRCLSHost.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSHost.m
@@ -49,13 +49,13 @@ static void FIRCLSHostWriteOSVersionInfo(FIRCLSFile* file);
 
 #pragma mark - API
 void FIRCLSHostInitialize(FIRCLSHostReadOnlyContext* roContext) {
-  _clsContext.readonly->host.pageSize = FIRCLSHostGetPageSize();
-  _clsContext.readonly->host.documentDirectoryPath = NULL;
+  _firclsContext.readonly->host.pageSize = FIRCLSHostGetPageSize();
+  _firclsContext.readonly->host.documentDirectoryPath = NULL;
 
   // determine where the document directory is mounted, so we can get file system statistics later
   NSArray* paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
   if ([paths count]) {
-    _clsContext.readonly->host.documentDirectoryPath =
+    _firclsContext.readonly->host.documentDirectoryPath =
         FIRCLSDupString([[paths objectAtIndex:0] fileSystemRepresentation]);
   }
 }
@@ -150,7 +150,7 @@ void FIRCLSHostWriteDiskUsage(FIRCLSFile* file) {
 
   FIRCLSFileWriteHashStart(file);
 
-  if (statfs(_clsContext.readonly->host.documentDirectoryPath, &tStats) == 0) {
+  if (statfs(_firclsContext.readonly->host.documentDirectoryPath, &tStats) == 0) {
     FIRCLSFileWriteHashEntryUint64(file, "free", tStats.f_bavail * tStats.f_bsize);
     FIRCLSFileWriteHashEntryUint64(file, "total", tStats.f_blocks * tStats.f_bsize);
   }

--- a/Crashlytics/Crashlytics/Components/FIRCLSProcess.c
+++ b/Crashlytics/Crashlytics/Components/FIRCLSProcess.c
@@ -418,7 +418,7 @@ static bool FIRCLSProcessRecordThread(FIRCLSProcess *process, thread_t thread, F
 
   uint32_t repeatedPCCount = 0;
   uint64_t repeatedPC = 0;
-  const FIRCLSInternalLogLevel level = _clsContext.writable->internalLogging.logLevel;
+  const FIRCLSInternalLogLevel level = _firclsContext.writable->internalLogging.logLevel;
 
   while (FIRCLSUnwindNextFrame(&unwindContext)) {
     const uintptr_t pc = FIRCLSUnwindGetPC(&unwindContext);
@@ -433,14 +433,14 @@ static bool FIRCLSProcessRecordThread(FIRCLSProcess *process, thread_t thread, F
     if (frameCount >= FIRCLSUnwindInfiniteRecursionCountThreshold && repeatedPC == 0) {
       repeatedPC = pc;
       FIRCLSSDKLogWarn("Possible infinite recursion - suppressing logging\n");
-      _clsContext.writable->internalLogging.logLevel = FIRCLSInternalLogLevelWarn;
+      _firclsContext.writable->internalLogging.logLevel = FIRCLSInternalLogLevelWarn;
       continue;
     }
 
     if (repeatedPC != 0) {
       // at this point, we've recorded a repeated PC, but it is now no longer
       // repeating, so we can restore the logging
-      _clsContext.writable->internalLogging.logLevel = level;
+      _firclsContext.writable->internalLogging.logLevel = level;
     }
 
     FIRCLSFileWriteArrayEntryUint64(file, pc);
@@ -460,7 +460,7 @@ static bool FIRCLSProcessRecordThread(FIRCLSProcess *process, thread_t thread, F
 
   // Just for extra safety, restore the logging level again. The logic
   // above is fairly tricky, this is cheap, and no logging is a real pain.
-  _clsContext.writable->internalLogging.logLevel = level;
+  _firclsContext.writable->internalLogging.logLevel = level;
 
   // end thread info
   FIRCLSFileWriteHashEnd(file);
@@ -562,7 +562,7 @@ bool FIRCLSProcessGetMemoryUsage(uint64_t *active,
 
   hostSize = sizeof(vm_statistics_data_t) / sizeof(integer_t);
 
-  pageSize = _clsContext.readonly->host.pageSize;
+  pageSize = _firclsContext.readonly->host.pageSize;
 
   if (host_statistics(hostPort, HOST_VM_INFO, (host_info_t)&vmStat, &hostSize) != KERN_SUCCESS) {
     FIRCLSSDKLog("Failed to get vm statistics\n");
@@ -750,7 +750,7 @@ typedef struct {
 
 static void FIRCLSProcessRecordCrashInfo(FIRCLSFile *file) {
   // TODO: this should be abstracted into binary images, if possible
-  FIRCLSBinaryImageRuntimeNode *nodes = _clsContext.writable->binaryImage.nodes;
+  FIRCLSBinaryImageRuntimeNode *nodes = _firclsContext.writable->binaryImage.nodes;
   if (!nodes) {
     FIRCLSSDKLogError("The node structure is NULL\n");
     return;

--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h
@@ -73,8 +73,6 @@ typedef struct {
 void FIRCLSUserLoggingInit(FIRCLSUserLoggingReadOnlyContext* roContext,
                            FIRCLSUserLoggingWritableContext* rwContext);
 
-void CLSLogDisableUninitializedKitMessaging(void);
-
 #ifdef __OBJC__
 void FIRCLSUserLoggingRecordUserKeyValue(NSString* key, id value);
 void FIRCLSUserLoggingRecordInternalKeyValue(NSString* key, id value);

--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
@@ -35,8 +35,6 @@ NSString *const FIRCLSDevelopmentPlatformVersionKey =
 
 const uint32_t FIRCLSUserLoggingMaxKVEntries = 64;
 
-static bool clsDisableUninitializedKitMessaging = false;
-
 #pragma mark - Prototypes
 static void FIRCLSUserLoggingWriteKeyValue(NSString *key,
                                            NSString *value,
@@ -60,10 +58,6 @@ void FIRCLSUserLoggingInit(FIRCLSUserLoggingReadOnlyContext *roContext,
 
   roContext->userKVStorage.maxIncrementalCount = FIRCLSUserLoggingMaxKVEntries;
   roContext->internalKVStorage.maxIncrementalCount = roContext->userKVStorage.maxIncrementalCount;
-}
-
-void CLSLogDisableUninitializedKitMessaging(void) {
-  clsDisableUninitializedKitMessaging = true;
 }
 
 #pragma mark - KV Logging
@@ -496,11 +490,9 @@ void FIRCLSLogInternal(NSString *message) {
   }
 
   if (!FIRCLSContextIsInitialized()) {
-    if (!clsDisableUninitializedKitMessaging) {
-      FIRCLSWarningLog(@"WARNING: FIRCLSLog has been used before (or concurrently with) "
-                       @"Crashlytics initialization and cannot be recorded. The message was: \n%@",
-                       message);
-    }
+    FIRCLSWarningLog(@"WARNING: FIRCLSLog has been used before (or concurrently with) "
+                     @"Crashlytics initialization and cannot be recorded. The message was: \n%@",
+                     message);
     return;
   }
   struct timeval te;

--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
@@ -68,19 +68,19 @@ void CLSLogDisableUninitializedKitMessaging(void) {
 
 #pragma mark - KV Logging
 void FIRCLSUserLoggingRecordInternalKeyValue(NSString *key, id value) {
-  FIRCLSUserLoggingRecordKeyValue(key, value, &_clsContext.readonly->logging.internalKVStorage,
-                                  &_clsContext.writable->logging.internalKVCount);
+  FIRCLSUserLoggingRecordKeyValue(key, value, &_firclsContext.readonly->logging.internalKVStorage,
+                                  &_firclsContext.writable->logging.internalKVCount);
 }
 
 void FIRCLSUserLoggingWriteInternalKeyValue(NSString *key, NSString *value) {
   // Unsynchronized - must be run on the correct queue
-  FIRCLSUserLoggingWriteKeyValue(key, value, &_clsContext.readonly->logging.internalKVStorage,
-                                 &_clsContext.writable->logging.internalKVCount);
+  FIRCLSUserLoggingWriteKeyValue(key, value, &_firclsContext.readonly->logging.internalKVStorage,
+                                 &_firclsContext.writable->logging.internalKVCount);
 }
 
 void FIRCLSUserLoggingRecordUserKeyValue(NSString *key, id value) {
-  FIRCLSUserLoggingRecordKeyValue(key, value, &_clsContext.readonly->logging.userKVStorage,
-                                  &_clsContext.writable->logging.userKVCount);
+  FIRCLSUserLoggingRecordKeyValue(key, value, &_firclsContext.readonly->logging.userKVStorage,
+                                  &_firclsContext.writable->logging.userKVCount);
 }
 
 static id FIRCLSUserLoggingGetComponent(NSDictionary *entry,
@@ -344,8 +344,8 @@ void FIRCLSUserLoggingRecordError(NSError *error,
   uint64_t timestamp = time(NULL);
 
   FIRCLSUserLoggingWriteAndCheckABFiles(
-      &_clsContext.readonly->logging.errorStorage,
-      &_clsContext.writable->logging.activeErrorLogPath, ^(FIRCLSFile *file) {
+      &_firclsContext.readonly->logging.errorStorage,
+      &_firclsContext.writable->logging.activeErrorLogPath, ^(FIRCLSFile *file) {
         FIRCLSUserLoggingWriteError(file, error, additionalUserInfo, addresses, timestamp);
       });
 }
@@ -506,7 +506,7 @@ void FIRCLSLogInternal(NSString *message) {
   struct timeval te;
 
   NSUInteger messageLength = [message length];
-  int maxLogSize = _clsContext.readonly->logging.logStorage.maxSize;
+  int maxLogSize = _firclsContext.readonly->logging.logStorage.maxSize;
 
   if (messageLength > maxLogSize) {
     FIRCLSWarningLog(
@@ -523,8 +523,8 @@ void FIRCLSLogInternal(NSString *message) {
 
   const uint64_t time = te.tv_sec * 1000LL + te.tv_usec / 1000;
 
-  FIRCLSUserLoggingWriteAndCheckABFiles(&_clsContext.readonly->logging.logStorage,
-                                        &_clsContext.writable->logging.activeUserLogPath,
+  FIRCLSUserLoggingWriteAndCheckABFiles(&_firclsContext.readonly->logging.logStorage,
+                                        &_firclsContext.writable->logging.activeUserLogPath,
                                         ^(FIRCLSFile *file) {
                                           FIRCLSLogInternalWrite(file, message, time);
                                         });

--- a/Crashlytics/Crashlytics/FIRCLSURLSession/FIRCLSURLSessionAvailability.h
+++ b/Crashlytics/Crashlytics/FIRCLSURLSession/FIRCLSURLSessionAvailability.h
@@ -22,7 +22,7 @@
 // where strip will not strip debug information without a symbol to strip.
 #define CONCAT_EXPANDED(a, b) a##b
 #define CONCAT(a, b) CONCAT_EXPANDED(a, b)
-#define DUMMY_FUNCTION_NAME(x) CONCAT(strip_this_, x)
+#define DUMMY_FUNCTION_NAME(x) CONCAT(fircls_strip_this_, x)
 #define INJECT_STRIP_SYMBOL(x)        \
   void DUMMY_FUNCTION_NAME(x)(void) { \
   }

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -52,7 +52,7 @@
 #import <UIKit/UIKit.h>
 #endif
 
-FIRCLSContext _clsContext;
+FIRCLSContext _firclsContext;
 dispatch_queue_t _firclsLoggingQueue;
 dispatch_queue_t _firclsBinaryImageQueue;
 dispatch_queue_t _firclsExceptionQueue;

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -53,9 +53,9 @@
 #endif
 
 FIRCLSContext _clsContext;
-dispatch_queue_t _clsLoggingQueue;
-dispatch_queue_t _clsBinaryImageQueue;
-dispatch_queue_t _clsExceptionQueue;
+dispatch_queue_t _firclsLoggingQueue;
+dispatch_queue_t _firclsBinaryImageQueue;
+dispatch_queue_t _firclsExceptionQueue;
 
 static atomic_bool _hasInitializedInstance;
 

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSException.mm
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSException.mm
@@ -76,19 +76,6 @@ void FIRCLSExceptionInitialize(FIRCLSExceptionReadOnlyContext *roContext,
   rwContext->customExceptionCount = 0;
 }
 
-#if 0
-// This bit of code might be useful at some point. But, currently it isn't needed.
-static void FIRCLSExceptionUninstallHandlers(void) {
-    std::set_terminate(_clsContext.readonly->exception.originalTerminateHandler);
-
-#if !TARGET_OS_IPHONE
-    Method m = FIRCLSGetNSApplicationReportExceptionMethod();
-
-    method_setImplementation(m, (IMP)FIRCLSOriginalNSExceptionReportExceptionFunction());
-#endif
-}
-#endif
-
 void FIRCLSExceptionRecordNSException(NSException *exception) {
   FIRCLSSDKLog("Recording an NSException\n");
 

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSException.mm
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSException.mm
@@ -205,7 +205,7 @@ void FIRCLSExceptionRecord(FIRCLSExceptionType type,
   // exceptions can happen on multiple threads at the same time
   if (native) {
     dispatch_sync(_firclsExceptionQueue, ^{
-      const char *path = _clsContext.readonly->exception.path;
+      const char *path = _firclsContext.readonly->exception.path;
       FIRCLSFile file;
 
       if (!FIRCLSFileInitWithPath(&file, path, false)) {
@@ -226,8 +226,8 @@ void FIRCLSExceptionRecord(FIRCLSExceptionType type,
       }
     });
   } else {
-    FIRCLSUserLoggingWriteAndCheckABFiles(&_clsContext.readonly->logging.customExceptionStorage,
-                                          &_clsContext.writable->logging.activeCustomExceptionPath,
+    FIRCLSUserLoggingWriteAndCheckABFiles(&_firclsContext.readonly->logging.customExceptionStorage,
+                                          &_firclsContext.writable->logging.activeCustomExceptionPath,
                                           ^(FIRCLSFile *file) {
                                             FIRCLSExceptionWrite(file, type, name, reason, frames);
                                           });
@@ -303,7 +303,7 @@ static void FIRCLSCatchAndRecordActiveException(std::type_info *typeInfo) {
 static void FIRCLSTerminateHandler(void) {
   FIRCLSSDKLog("C++ terminate handler invoked\n");
 
-  void (*handler)(void) = _clsContext.readonly->exception.originalTerminateHandler;
+  void (*handler)(void) = _firclsContext.readonly->exception.originalTerminateHandler;
   if (handler == FIRCLSTerminateHandler) {
     FIRCLSSDKLog("Error: original handler was set recursively\n");
     handler = NULL;
@@ -354,7 +354,7 @@ void FIRCLSExceptionCheckHandlers(void *delegate) {
   }
 #endif
 
-  if (_clsContext.readonly->debuggerAttached) {
+  if (_firclsContext.readonly->debuggerAttached) {
     return;
   }
 
@@ -400,7 +400,7 @@ static Method FIRCLSGetNSApplicationReportExceptionMethod(void) {
 
 static NSApplicationReportExceptionFunction FIRCLSOriginalNSExceptionReportExceptionFunction(void) {
   return (NSApplicationReportExceptionFunction)
-      _clsContext.readonly->exception.originalNSApplicationReportException;
+      _firclsContext.readonly->exception.originalNSApplicationReportException;
 }
 
 void FIRCLSNSApplicationReportException(id self, SEL cmd, NSException *exception) {

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSException.mm
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSException.mm
@@ -204,7 +204,7 @@ void FIRCLSExceptionRecord(FIRCLSExceptionType type,
 
   // exceptions can happen on multiple threads at the same time
   if (native) {
-    dispatch_sync(_clsExceptionQueue, ^{
+    dispatch_sync(_firclsExceptionQueue, ^{
       const char *path = _clsContext.readonly->exception.path;
       FIRCLSFile file;
 

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSException.mm
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSException.mm
@@ -226,11 +226,11 @@ void FIRCLSExceptionRecord(FIRCLSExceptionType type,
       }
     });
   } else {
-    FIRCLSUserLoggingWriteAndCheckABFiles(&_firclsContext.readonly->logging.customExceptionStorage,
-                                          &_firclsContext.writable->logging.activeCustomExceptionPath,
-                                          ^(FIRCLSFile *file) {
-                                            FIRCLSExceptionWrite(file, type, name, reason, frames);
-                                          });
+    FIRCLSUserLoggingWriteAndCheckABFiles(
+        &_firclsContext.readonly->logging.customExceptionStorage,
+        &_firclsContext.writable->logging.activeCustomExceptionPath, ^(FIRCLSFile *file) {
+          FIRCLSExceptionWrite(file, type, name, reason, frames);
+        });
   }
 
   FIRCLSSDKLog("Finished recording an exception structure\n");

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSHandler.m
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSHandler.m
@@ -53,7 +53,7 @@ void FIRCLSHandler(FIRCLSFile* file, thread_t crashedThread, void* uapVoid) {
 
 void FIRCLSHandlerAttemptImmediateDelivery(void) {
   // now, attempt to relay the event to the delegate
-  FIRCLSReportManager* manager = (__bridge id)_clsContext.readonly->delegate;
+  FIRCLSReportManager* manager = (__bridge id)_firclsContext.readonly->delegate;
 
   if ([manager respondsToSelector:@selector(potentiallySubmittableCrashOccurred)]) {
     [manager potentiallySubmittableCrashOccurred];

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSMachException.c
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSMachException.c
@@ -65,7 +65,7 @@ void FIRCLSMachExceptionInit(FIRCLSMachExceptionReadContext* context, exception_
 }
 
 void FIRCLSMachExceptionCheckHandlers(void) {
-  if (_clsContext.readonly->debuggerAttached) {
+  if (_firclsContext.readonly->debuggerAttached) {
     return;
   }
 
@@ -120,7 +120,7 @@ static bool FIRCLSMachExceptionThreadStart(FIRCLSMachExceptionReadContext* conte
 
   // Use to pre-allocate a stack for this thread
   // The stack must be page-aligned
-  if (pthread_attr_setstack(&attr, _clsContext.readonly->machStack,
+  if (pthread_attr_setstack(&attr, _firclsContext.readonly->machStack,
                             CLS_MACH_EXCEPTION_HANDLER_STACK_SIZE) != 0) {
     FIRCLSSDKLog("pthread_attr_setstack %s\n", strerror(errno));
     return false;
@@ -223,7 +223,7 @@ static kern_return_t FIRCLSMachExceptionDispatchMessage(FIRCLSMachExceptionReadC
   }
 
   FIRCLSSDKLog("Restoring original signal handlers\n");
-  if (!FIRCLSSignalSafeInstallPreexistingHandlers(&_clsContext.readonly->signal)) {
+  if (!FIRCLSSignalSafeInstallPreexistingHandlers(&_firclsContext.readonly->signal)) {
     FIRCLSSDKLog("Failed to restore signal handlers\n");
     return KERN_FAILURE;
   }

--- a/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.c
+++ b/Crashlytics/Crashlytics/Handlers/FIRCLSSignal.c
@@ -61,7 +61,7 @@ static void FIRCLSSignalInstallAltStack(FIRCLSSignalReadContext *roContext) {
   stack_t signalStack;
   stack_t originalStack;
 
-  signalStack.ss_sp = _clsContext.readonly->signalStack;
+  signalStack.ss_sp = _firclsContext.readonly->signalStack;
   signalStack.ss_size = CLS_SIGNAL_HANDLER_STACK_SIZE;
   signalStack.ss_flags = 0;
 
@@ -107,7 +107,7 @@ static void FIRCLSSignalInstallHandlers(FIRCLSSignalReadContext *roContext) {
 }
 
 void FIRCLSSignalCheckHandlers(void) {
-  if (_clsContext.readonly->debuggerAttached) {
+  if (_firclsContext.readonly->debuggerAttached) {
     return;
   }
 
@@ -230,7 +230,7 @@ void FIRCLSSignalNameLookup(int number, int code, const char **name, const char 
 }
 
 static void FIRCLSSignalRecordSignal(int savedErrno, siginfo_t *info, void *uapVoid) {
-  if (!_clsContext.readonly) {
+  if (!_firclsContext.readonly) {
     return;
   }
 
@@ -242,7 +242,7 @@ static void FIRCLSSignalRecordSignal(int savedErrno, siginfo_t *info, void *uapV
 
   FIRCLSFile file;
 
-  if (!FIRCLSFileInitWithPath(&file, _clsContext.readonly->signal.path, false)) {
+  if (!FIRCLSFileInitWithPath(&file, _firclsContext.readonly->signal.path, false)) {
     FIRCLSSDKLog("Unable to open signal file\n");
     return;
   }
@@ -309,8 +309,8 @@ static void FIRCLSSignalHandler(int signal, siginfo_t *info, void *uapVoid) {
   FIRCLSSignalRecordSignal(savedErrno, info, uapVoid);
 
   // re-install original handlers
-  if (_clsContext.readonly) {
-    FIRCLSSignalSafeInstallPreexistingHandlers(&_clsContext.readonly->signal);
+  if (_firclsContext.readonly) {
+    FIRCLSSignalSafeInstallPreexistingHandlers(&_firclsContext.readonly->signal);
   }
 
   // restore errno

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSAllocate.h
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSAllocate.h
@@ -46,4 +46,3 @@ void* FIRCLSAllocatorSafeAllocate(FIRCLSAllocatorRef allocator,
                                   FIRCLSAllocationType type);
 const char* FIRCLSAllocatorSafeStrdup(FIRCLSAllocatorRef allocator, const char* string);
 void FIRCLSAllocatorFree(FIRCLSAllocatorRef allocator, void* ptr);
-

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSAllocate.h
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSAllocate.h
@@ -47,8 +47,3 @@ void* FIRCLSAllocatorSafeAllocate(FIRCLSAllocatorRef allocator,
 const char* FIRCLSAllocatorSafeStrdup(FIRCLSAllocatorRef allocator, const char* string);
 void FIRCLSAllocatorFree(FIRCLSAllocatorRef allocator, void* ptr);
 
-#if CLS_MEMORY_PROTECTION_ENABLED
-#define FIRCLSFree(x) FIRCLSAllocatorFree(_clsContext.allocator, (void*)(x));
-#else
-#define FIRCLSFree(x) free((void*)(x))
-#endif

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSDefines.h
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSDefines.h
@@ -24,7 +24,7 @@
 
 // These macros generate a function to force a symbol for the containing .o, to work around an issue
 // where strip will not strip debug information without a symbol to strip.
-#define DUMMY_FUNCTION_NAME(x) CONCAT(strip_this_, x)
+#define DUMMY_FUNCTION_NAME(x) CONCAT(fircls_strip_this_, x)
 #define INJECT_STRIP_SYMBOL(x)        \
   void DUMMY_FUNCTION_NAME(x)(void) { \
   }

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSInternalLogging.c
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSInternalLogging.c
@@ -18,24 +18,24 @@
 #include "FIRCLSUtility.h"
 
 void FIRCLSSDKFileLog(FIRCLSInternalLogLevel level, const char* format, ...) {
-  if (!_clsContext.readonly || !_clsContext.writable) {
+  if (!_firclsContext.readonly || !_firclsContext.writable) {
     return;
   }
 
-  const char* path = _clsContext.readonly->logPath;
+  const char* path = _firclsContext.readonly->logPath;
   if (!FIRCLSIsValidPointer(path)) {
     return;
   }
 
-  if (_clsContext.writable->internalLogging.logLevel > level) {
+  if (_firclsContext.writable->internalLogging.logLevel > level) {
     return;
   }
 
-  if (_clsContext.writable->internalLogging.logFd == -1) {
-    _clsContext.writable->internalLogging.logFd = open(path, O_WRONLY | O_CREAT | O_APPEND, 0644);
+  if (_firclsContext.writable->internalLogging.logFd == -1) {
+    _firclsContext.writable->internalLogging.logFd = open(path, O_WRONLY | O_CREAT | O_APPEND, 0644);
   }
 
-  const int fd = _clsContext.writable->internalLogging.logFd;
+  const int fd = _firclsContext.writable->internalLogging.logFd;
   if (fd < 0) {
     return;
   }

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSUtility.m
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSUtility.m
@@ -109,7 +109,7 @@ const char* FIRCLSDupString(const char* string) {
   }
 
   length = strlen(string);
-  buffer = FIRCLSAllocatorSafeAllocate(_clsContext.allocator, length + 1, CLS_READONLY);
+  buffer = FIRCLSAllocatorSafeAllocate(_firclsContext.allocator, length + 1, CLS_READONLY);
 
   memcpy(buffer, string, length);
 

--- a/Crashlytics/Crashlytics/Models/FIRCLSInternalReport.h
+++ b/Crashlytics/Crashlytics/Models/FIRCLSInternalReport.h
@@ -16,21 +16,21 @@
 
 #include "FIRCLSFeatures.h"
 
-extern NSString *const CLSReportBinaryImageFile;
-extern NSString *const CLSReportExceptionFile;
-extern NSString *const CLSReportCustomExceptionAFile;
-extern NSString *const CLSReportCustomExceptionBFile;
-extern NSString *const CLSReportSignalFile;
+extern NSString *const FIRCLSReportBinaryImageFile;
+extern NSString *const FIRCLSReportExceptionFile;
+extern NSString *const FIRCLSReportCustomExceptionAFile;
+extern NSString *const FIRCLSReportCustomExceptionBFile;
+extern NSString *const FIRCLSReportSignalFile;
 #if CLS_MACH_EXCEPTION_SUPPORTED
-extern NSString *const CLSReportMachExceptionFile;
+extern NSString *const FIRCLSReportMachExceptionFile;
 #endif
-extern NSString *const CLSReportErrorAFile;
-extern NSString *const CLSReportErrorBFile;
-extern NSString *const CLSReportMetadataFile;
-extern NSString *const CLSReportInternalIncrementalKVFile;
-extern NSString *const CLSReportInternalCompactedKVFile;
-extern NSString *const CLSReportUserIncrementalKVFile;
-extern NSString *const CLSReportUserCompactedKVFile;
+extern NSString *const FIRCLSReportErrorAFile;
+extern NSString *const FIRCLSReportErrorBFile;
+extern NSString *const FIRCLSReportMetadataFile;
+extern NSString *const FIRCLSReportInternalIncrementalKVFile;
+extern NSString *const FIRCLSReportInternalCompactedKVFile;
+extern NSString *const FIRCLSReportUserIncrementalKVFile;
+extern NSString *const FIRCLSReportUserCompactedKVFile;
 
 @class FIRCLSFileManager;
 

--- a/Crashlytics/Crashlytics/Models/FIRCLSInternalReport.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSInternalReport.m
@@ -18,21 +18,21 @@
 #import "FIRCLSFileManager.h"
 #import "FIRCLSLogger.h"
 
-NSString *const CLSReportBinaryImageFile = @"binary_images.clsrecord";
-NSString *const CLSReportExceptionFile = @"exception.clsrecord";
-NSString *const CLSReportCustomExceptionAFile = @"custom_exception_a.clsrecord";
-NSString *const CLSReportCustomExceptionBFile = @"custom_exception_b.clsrecord";
-NSString *const CLSReportSignalFile = @"signal.clsrecord";
+NSString *const FIRCLSReportBinaryImageFile = @"binary_images.clsrecord";
+NSString *const FIRCLSReportExceptionFile = @"exception.clsrecord";
+NSString *const FIRCLSReportCustomExceptionAFile = @"custom_exception_a.clsrecord";
+NSString *const FIRCLSReportCustomExceptionBFile = @"custom_exception_b.clsrecord";
+NSString *const FIRCLSReportSignalFile = @"signal.clsrecord";
 #if CLS_MACH_EXCEPTION_SUPPORTED
-NSString *const CLSReportMachExceptionFile = @"mach_exception.clsrecord";
+NSString *const FIRCLSReportMachExceptionFile = @"mach_exception.clsrecord";
 #endif
-NSString *const CLSReportMetadataFile = @"metadata.clsrecord";
-NSString *const CLSReportErrorAFile = @"errors_a.clsrecord";
-NSString *const CLSReportErrorBFile = @"errors_b.clsrecord";
-NSString *const CLSReportInternalIncrementalKVFile = @"internal_incremental_kv.clsrecord";
-NSString *const CLSReportInternalCompactedKVFile = @"internal_compacted_kv.clsrecord";
-NSString *const CLSReportUserIncrementalKVFile = @"user_incremental_kv.clsrecord";
-NSString *const CLSReportUserCompactedKVFile = @"user_compacted_kv.clsrecord";
+NSString *const FIRCLSReportMetadataFile = @"metadata.clsrecord";
+NSString *const FIRCLSReportErrorAFile = @"errors_a.clsrecord";
+NSString *const FIRCLSReportErrorBFile = @"errors_b.clsrecord";
+NSString *const FIRCLSReportInternalIncrementalKVFile = @"internal_incremental_kv.clsrecord";
+NSString *const FIRCLSReportInternalCompactedKVFile = @"internal_compacted_kv.clsrecord";
+NSString *const FIRCLSReportUserIncrementalKVFile = @"user_incremental_kv.clsrecord";
+NSString *const FIRCLSReportUserCompactedKVFile = @"user_compacted_kv.clsrecord";
 
 @interface FIRCLSInternalReport () {
   NSString *_identifier;
@@ -73,7 +73,7 @@ NSString *const CLSReportUserCompactedKVFile = @"user_compacted_kv.clsrecord";
  * Initializes a pre-existing report, i.e. one with metadata on the file system.
  */
 - (instancetype)initWithPath:(NSString *)path {
-  NSString *metadataPath = [path stringByAppendingPathComponent:CLSReportMetadataFile];
+  NSString *metadataPath = [path stringByAppendingPathComponent:FIRCLSReportMetadataFile];
   NSString *identifier = [[[[self.class readFIRCLSFileAtPath:metadataPath] objectAtIndex:0]
       objectForKey:@"identity"] objectForKey:@"session_id"];
   if (!identifier) {
@@ -92,22 +92,22 @@ NSString *const CLSReportUserCompactedKVFile = @"user_compacted_kv.clsrecord";
 }
 
 - (NSString *)metadataPath {
-  return [[self path] stringByAppendingPathComponent:CLSReportMetadataFile];
+  return [[self path] stringByAppendingPathComponent:FIRCLSReportMetadataFile];
 }
 
 - (NSString *)binaryImagePath {
-  return [self pathForContentFile:CLSReportBinaryImageFile];
+  return [self pathForContentFile:FIRCLSReportBinaryImageFile];
 }
 
 #pragma mark - Processing Methods
 - (BOOL)needsToBeSubmitted {
   NSArray *reportFiles = @[
-    CLSReportExceptionFile, CLSReportSignalFile, CLSReportCustomExceptionAFile,
-    CLSReportCustomExceptionBFile,
+    FIRCLSReportExceptionFile, FIRCLSReportSignalFile, FIRCLSReportCustomExceptionAFile,
+    FIRCLSReportCustomExceptionBFile,
 #if CLS_MACH_EXCEPTION_SUPPORTED
-    CLSReportMachExceptionFile,
+    FIRCLSReportMachExceptionFile,
 #endif
-    CLSReportErrorAFile, CLSReportErrorBFile
+    FIRCLSReportErrorAFile, FIRCLSReportErrorBFile
   ];
   return [self checkExistenceOfAtLeastOnceFileInArray:reportFiles];
 }
@@ -117,11 +117,11 @@ NSString *const CLSReportUserCompactedKVFile = @"user_compacted_kv.clsrecord";
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     files = @[
-      CLSReportExceptionFile,
+      FIRCLSReportExceptionFile,
 #if CLS_MACH_EXCEPTION_SUPPORTED
-      CLSReportMachExceptionFile,
+      FIRCLSReportMachExceptionFile,
 #endif
-      CLSReportSignalFile
+      FIRCLSReportSignalFile
     ];
   });
   return files;
@@ -205,14 +205,14 @@ NSString *const CLSReportUserCompactedKVFile = @"user_compacted_kv.clsrecord";
 
 #if CLS_MACH_EXCEPTION_SUPPORTED
   // try the mach exception first, because it is more common
-  NSDate *date = [self timeFromCrashContentFile:CLSReportMachExceptionFile
+  NSDate *date = [self timeFromCrashContentFile:FIRCLSReportMachExceptionFile
                                     sectionName:@"mach_exception"];
   if (date) {
     return date;
   }
 #endif
 
-  return [self timeFromCrashContentFile:CLSReportSignalFile sectionName:@"signal"];
+  return [self timeFromCrashContentFile:FIRCLSReportSignalFile sectionName:@"signal"];
 }
 
 - (NSDate *)timeFromCrashContentFile:(NSString *)fileName sectionName:(NSString *)sectionName {

--- a/Crashlytics/Crashlytics/Models/FIRCLSReport.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSReport.m
@@ -98,8 +98,8 @@
 - (FIRCLSUserLoggingKVStorage)internalKVStorage {
   FIRCLSUserLoggingKVStorage storage;
 
-  storage.maxCount = _clsContext.readonly->logging.internalKVStorage.maxCount;
-  storage.maxIncrementalCount = _clsContext.readonly->logging.internalKVStorage.maxIncrementalCount;
+  storage.maxCount = _firclsContext.readonly->logging.internalKVStorage.maxCount;
+  storage.maxIncrementalCount = _firclsContext.readonly->logging.internalKVStorage.maxIncrementalCount;
   storage.compactedPath = [_internalCompactedKVFile fileSystemRepresentation];
   storage.incrementalPath = [_internalIncrementalKVFile fileSystemRepresentation];
 
@@ -109,8 +109,8 @@
 - (FIRCLSUserLoggingKVStorage)userKVStorage {
   FIRCLSUserLoggingKVStorage storage;
 
-  storage.maxCount = _clsContext.readonly->logging.userKVStorage.maxCount;
-  storage.maxIncrementalCount = _clsContext.readonly->logging.userKVStorage.maxIncrementalCount;
+  storage.maxCount = _firclsContext.readonly->logging.userKVStorage.maxCount;
+  storage.maxIncrementalCount = _firclsContext.readonly->logging.userKVStorage.maxIncrementalCount;
   storage.compactedPath = [_userCompactedKVFile fileSystemRepresentation];
   storage.incrementalPath = [_userIncrementalKVFile fileSystemRepresentation];
 

--- a/Crashlytics/Crashlytics/Models/FIRCLSReport.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSReport.m
@@ -66,11 +66,11 @@
   _userKVCounter = 0;
 
   _internalCompactedKVFile =
-      [self.internalReport pathForContentFile:CLSReportInternalCompactedKVFile];
+      [self.internalReport pathForContentFile:FIRCLSReportInternalCompactedKVFile];
   _internalIncrementalKVFile =
-      [self.internalReport pathForContentFile:CLSReportInternalIncrementalKVFile];
-  _userCompactedKVFile = [self.internalReport pathForContentFile:CLSReportUserCompactedKVFile];
-  _userIncrementalKVFile = [self.internalReport pathForContentFile:CLSReportUserIncrementalKVFile];
+      [self.internalReport pathForContentFile:FIRCLSReportInternalIncrementalKVFile];
+  _userCompactedKVFile = [self.internalReport pathForContentFile:FIRCLSReportUserCompactedKVFile];
+  _userIncrementalKVFile = [self.internalReport pathForContentFile:FIRCLSReportUserIncrementalKVFile];
 
   _readOnly = shouldPrefetch;
 

--- a/Crashlytics/Crashlytics/Models/FIRCLSReport.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSReport.m
@@ -70,7 +70,8 @@
   _internalIncrementalKVFile =
       [self.internalReport pathForContentFile:FIRCLSReportInternalIncrementalKVFile];
   _userCompactedKVFile = [self.internalReport pathForContentFile:FIRCLSReportUserCompactedKVFile];
-  _userIncrementalKVFile = [self.internalReport pathForContentFile:FIRCLSReportUserIncrementalKVFile];
+  _userIncrementalKVFile =
+      [self.internalReport pathForContentFile:FIRCLSReportUserIncrementalKVFile];
 
   _readOnly = shouldPrefetch;
 
@@ -99,7 +100,8 @@
   FIRCLSUserLoggingKVStorage storage;
 
   storage.maxCount = _firclsContext.readonly->logging.internalKVStorage.maxCount;
-  storage.maxIncrementalCount = _firclsContext.readonly->logging.internalKVStorage.maxIncrementalCount;
+  storage.maxIncrementalCount =
+      _firclsContext.readonly->logging.internalKVStorage.maxIncrementalCount;
   storage.compactedPath = [_internalCompactedKVFile fileSystemRepresentation];
   storage.incrementalPath = [_internalIncrementalKVFile fileSystemRepresentation];
 

--- a/Crashlytics/UnitTests/FIRCLSCompactUnwindTests.m
+++ b/Crashlytics/UnitTests/FIRCLSCompactUnwindTests.m
@@ -33,8 +33,8 @@
 - (void)setUp {
   [super setUp];
 
-  _clsContext.readonly = malloc(sizeof(FIRCLSReadOnlyContext));
-  _clsContext.readonly->logPath = "/tmp/test.log";
+  _firclsContext.readonly = malloc(sizeof(FIRCLSReadOnlyContext));
+  _firclsContext.readonly->logPath = "/tmp/test.log";
 }
 
 - (void)tearDown {

--- a/Crashlytics/UnitTests/FIRCLSDwarfTests.m
+++ b/Crashlytics/UnitTests/FIRCLSDwarfTests.m
@@ -33,8 +33,8 @@
 - (void)setUp {
   [super setUp];
 
-  _clsContext.readonly = malloc(sizeof(FIRCLSReadOnlyContext));
-  _clsContext.readonly->logPath = "/tmp/test.log";
+  _firclsContext.readonly = malloc(sizeof(FIRCLSReadOnlyContext));
+  _firclsContext.readonly->logPath = "/tmp/test.log";
 }
 
 - (void)tearDown {

--- a/Crashlytics/UnitTests/FIRCLSInternalReportTests.m
+++ b/Crashlytics/UnitTests/FIRCLSInternalReportTests.m
@@ -44,8 +44,8 @@
 
   FIRCLSInternalReport *report = [[FIRCLSInternalReport alloc] initWithPath:tempPath];
 
-  NSString *customAPath = [report pathForContentFile:CLSReportCustomExceptionAFile];
-  NSString *customBPath = [report pathForContentFile:CLSReportCustomExceptionBFile];
+  NSString *customAPath = [report pathForContentFile:FIRCLSReportCustomExceptionAFile];
+  NSString *customBPath = [report pathForContentFile:FIRCLSReportCustomExceptionBFile];
 
   XCTAssertFalse(report.needsToBeSubmitted, @"metadata only should not need to be submitted");
 

--- a/Crashlytics/UnitTests/FIRCLSLoggingTests.m
+++ b/Crashlytics/UnitTests/FIRCLSLoggingTests.m
@@ -20,7 +20,7 @@
 #import "FIRCLSInternalReport.h"
 #include "FIRCLSUserLogging.h"
 
-@interface CLSLoggingTests : XCTestCase
+@interface FIRCLSLoggingTests : XCTestCase
 
 @property(nonatomic, strong) NSString* kvPath;
 @property(nonatomic, strong) NSString* compactedKVPath;
@@ -31,7 +31,7 @@
 
 @end
 
-@implementation CLSLoggingTests
+@implementation FIRCLSLoggingTests
 
 - (void)setUp {
   [super setUp];

--- a/Crashlytics/UnitTests/FIRCLSLoggingTests.m
+++ b/Crashlytics/UnitTests/FIRCLSLoggingTests.m
@@ -46,35 +46,35 @@
   self.errorAPath = [tempDir stringByAppendingPathComponent:FIRCLSReportErrorAFile];
   self.errorBPath = [tempDir stringByAppendingPathComponent:FIRCLSReportErrorBFile];
 
-  _clsContext.readonly->logging.userKVStorage.incrementalPath =
+  _firclsContext.readonly->logging.userKVStorage.incrementalPath =
       strdup([self.kvPath fileSystemRepresentation]);
-  _clsContext.readonly->logging.userKVStorage.compactedPath =
+  _firclsContext.readonly->logging.userKVStorage.compactedPath =
       strdup([self.compactedKVPath fileSystemRepresentation]);
-  _clsContext.readonly->logging.logStorage.aPath = strdup([self.logAPath fileSystemRepresentation]);
-  _clsContext.readonly->logging.logStorage.bPath = strdup([self.logBPath fileSystemRepresentation]);
-  _clsContext.readonly->logging.errorStorage.aPath =
+  _firclsContext.readonly->logging.logStorage.aPath = strdup([self.logAPath fileSystemRepresentation]);
+  _firclsContext.readonly->logging.logStorage.bPath = strdup([self.logBPath fileSystemRepresentation]);
+  _firclsContext.readonly->logging.errorStorage.aPath =
       strdup([self.errorAPath fileSystemRepresentation]);
-  _clsContext.readonly->logging.errorStorage.bPath =
+  _firclsContext.readonly->logging.errorStorage.bPath =
       strdup([self.errorBPath fileSystemRepresentation]);
-  _clsContext.readonly->logging.userKVStorage.maxIncrementalCount = FIRCLSUserLoggingMaxKVEntries;
+  _firclsContext.readonly->logging.userKVStorage.maxIncrementalCount = FIRCLSUserLoggingMaxKVEntries;
 
-  _clsContext.readonly->logging.logStorage.maxSize = 64 * 1024;
-  _clsContext.readonly->logging.logStorage.restrictBySize = true;
-  _clsContext.readonly->logging.errorStorage.maxSize = 64 * 1024;
-  _clsContext.readonly->logging.errorStorage.restrictBySize = false;
-  _clsContext.readonly->logging.errorStorage.maxEntries = 8;
-  _clsContext.readonly->logging.errorStorage.entryCount =
-      &_clsContext.writable->logging.errorsCount;
-  _clsContext.readonly->logging.userKVStorage.maxCount = 64;
+  _firclsContext.readonly->logging.logStorage.maxSize = 64 * 1024;
+  _firclsContext.readonly->logging.logStorage.restrictBySize = true;
+  _firclsContext.readonly->logging.errorStorage.maxSize = 64 * 1024;
+  _firclsContext.readonly->logging.errorStorage.restrictBySize = false;
+  _firclsContext.readonly->logging.errorStorage.maxEntries = 8;
+  _firclsContext.readonly->logging.errorStorage.entryCount =
+      &_firclsContext.writable->logging.errorsCount;
+  _firclsContext.readonly->logging.userKVStorage.maxCount = 64;
 
-  _clsContext.writable->logging.activeUserLogPath = _clsContext.readonly->logging.logStorage.aPath;
-  _clsContext.writable->logging.activeErrorLogPath =
-      _clsContext.readonly->logging.errorStorage.aPath;
-  _clsContext.writable->logging.userKVCount = 0;
-  _clsContext.writable->logging.internalKVCount = 0;
-  _clsContext.writable->logging.errorsCount = 0;
+  _firclsContext.writable->logging.activeUserLogPath = _firclsContext.readonly->logging.logStorage.aPath;
+  _firclsContext.writable->logging.activeErrorLogPath =
+      _firclsContext.readonly->logging.errorStorage.aPath;
+  _firclsContext.writable->logging.userKVCount = 0;
+  _firclsContext.writable->logging.internalKVCount = 0;
+  _firclsContext.writable->logging.errorsCount = 0;
 
-  _clsContext.readonly->initialized = true;
+  _firclsContext.readonly->initialized = true;
 
   for (NSString* path in @[
          self.kvPath, self.compactedKVPath, self.logAPath, self.logBPath, self.errorAPath,
@@ -85,12 +85,12 @@
 }
 
 - (void)tearDown {
-  free((void*)_clsContext.readonly->logging.userKVStorage.incrementalPath);
-  free((void*)_clsContext.readonly->logging.userKVStorage.compactedPath);
-  free((void*)_clsContext.readonly->logging.logStorage.aPath);
-  free((void*)_clsContext.readonly->logging.logStorage.bPath);
-  free((void*)_clsContext.readonly->logging.errorStorage.aPath);
-  free((void*)_clsContext.readonly->logging.errorStorage.bPath);
+  free((void*)_firclsContext.readonly->logging.userKVStorage.incrementalPath);
+  free((void*)_firclsContext.readonly->logging.userKVStorage.compactedPath);
+  free((void*)_firclsContext.readonly->logging.logStorage.aPath);
+  free((void*)_firclsContext.readonly->logging.logStorage.bPath);
+  free((void*)_firclsContext.readonly->logging.errorStorage.aPath);
+  free((void*)_firclsContext.readonly->logging.errorStorage.bPath);
 
   FIRCLSContextBaseDeinit();
 
@@ -99,12 +99,12 @@
 
 - (NSArray*)incrementalKeyValues {
   return FIRCLSUserLoggingStoredKeyValues(
-      _clsContext.readonly->logging.userKVStorage.incrementalPath);
+      _firclsContext.readonly->logging.userKVStorage.incrementalPath);
 }
 
 - (NSArray*)compactedKeyValues {
   return FIRCLSUserLoggingStoredKeyValues(
-      _clsContext.readonly->logging.userKVStorage.compactedPath);
+      _firclsContext.readonly->logging.userKVStorage.compactedPath);
 }
 
 - (NSArray*)logAContents {
@@ -186,7 +186,7 @@
 
 - (void)testKeyValueLogMoreThanMaxKeys {
   // we need to end up with max + 1 keys written
-  for (NSUInteger i = 0; i <= _clsContext.readonly->logging.userKVStorage.maxCount + 1; ++i) {
+  for (NSUInteger i = 0; i <= _firclsContext.readonly->logging.userKVStorage.maxCount + 1; ++i) {
     NSString* key = [NSString stringWithFormat:@"key%lu", (unsigned long)i];
     NSString* value = [NSString stringWithFormat:@"some string value: %lu", (unsigned long)i];
 
@@ -197,7 +197,7 @@
   // we don't have any incremental keys. It also accounts for differences between
   // the max and incremental values.
   dispatch_sync(FIRCLSGetLoggingQueue(), ^{
-    FIRCLSUserLoggingCompactKVEntries(&_clsContext.readonly->logging.userKVStorage);
+    FIRCLSUserLoggingCompactKVEntries(&_firclsContext.readonly->logging.userKVStorage);
   });
 
   NSArray* keyValues = [self incrementalKeyValues];
@@ -230,7 +230,7 @@
 
   NSArray* array = [self logAContents];
   NSString* message = array[0][@"log"][@"msg"];
-  XCTAssertEqual(message.length, _clsContext.readonly->logging.logStorage.maxSize * 2,
+  XCTAssertEqual(message.length, _firclsContext.readonly->logging.logStorage.maxSize * 2,
                  "message: \"%@\"", message);
 }
 
@@ -320,7 +320,7 @@
                                        code:-1
                                    userInfo:@{@"key1" : @"value", @"key2" : @"value2"}];
 
-  for (size_t i = 0; i < _clsContext.readonly->logging.errorStorage.maxEntries; ++i) {
+  for (size_t i = 0; i < _firclsContext.readonly->logging.errorStorage.maxEntries; ++i) {
     FIRCLSUserLoggingRecordError(error, nil);
   }
 
@@ -334,7 +334,7 @@
 
   XCTAssertEqual([[self errorAContents] count], 8, @"");
   XCTAssertEqual([[self errorBContents] count], 1, @"");
-  XCTAssertEqual(*_clsContext.readonly->logging.errorStorage.entryCount, 1);
+  XCTAssertEqual(*_firclsContext.readonly->logging.errorStorage.entryCount, 1);
 
   // and our next entry should continue into the B file
 
@@ -342,7 +342,7 @@
 
   XCTAssertEqual([[self errorAContents] count], 8, @"");
   XCTAssertEqual([[self errorBContents] count], 2, @"");
-  XCTAssertEqual(*_clsContext.readonly->logging.errorStorage.entryCount, 2);
+  XCTAssertEqual(*_firclsContext.readonly->logging.errorStorage.entryCount, 2);
 }
 
 - (void)testLoggedErrorWithNullsInAdditionalInfo {

--- a/Crashlytics/UnitTests/FIRCLSLoggingTests.m
+++ b/Crashlytics/UnitTests/FIRCLSLoggingTests.m
@@ -50,13 +50,16 @@
       strdup([self.kvPath fileSystemRepresentation]);
   _firclsContext.readonly->logging.userKVStorage.compactedPath =
       strdup([self.compactedKVPath fileSystemRepresentation]);
-  _firclsContext.readonly->logging.logStorage.aPath = strdup([self.logAPath fileSystemRepresentation]);
-  _firclsContext.readonly->logging.logStorage.bPath = strdup([self.logBPath fileSystemRepresentation]);
+  _firclsContext.readonly->logging.logStorage.aPath =
+      strdup([self.logAPath fileSystemRepresentation]);
+  _firclsContext.readonly->logging.logStorage.bPath =
+      strdup([self.logBPath fileSystemRepresentation]);
   _firclsContext.readonly->logging.errorStorage.aPath =
       strdup([self.errorAPath fileSystemRepresentation]);
   _firclsContext.readonly->logging.errorStorage.bPath =
       strdup([self.errorBPath fileSystemRepresentation]);
-  _firclsContext.readonly->logging.userKVStorage.maxIncrementalCount = FIRCLSUserLoggingMaxKVEntries;
+  _firclsContext.readonly->logging.userKVStorage.maxIncrementalCount =
+      FIRCLSUserLoggingMaxKVEntries;
 
   _firclsContext.readonly->logging.logStorage.maxSize = 64 * 1024;
   _firclsContext.readonly->logging.logStorage.restrictBySize = true;
@@ -67,7 +70,8 @@
       &_firclsContext.writable->logging.errorsCount;
   _firclsContext.readonly->logging.userKVStorage.maxCount = 64;
 
-  _firclsContext.writable->logging.activeUserLogPath = _firclsContext.readonly->logging.logStorage.aPath;
+  _firclsContext.writable->logging.activeUserLogPath =
+      _firclsContext.readonly->logging.logStorage.aPath;
   _firclsContext.writable->logging.activeErrorLogPath =
       _firclsContext.readonly->logging.errorStorage.aPath;
   _firclsContext.writable->logging.userKVCount = 0;

--- a/Crashlytics/UnitTests/FIRCLSLoggingTests.m
+++ b/Crashlytics/UnitTests/FIRCLSLoggingTests.m
@@ -43,8 +43,8 @@
   self.compactedKVPath = [tempDir stringByAppendingPathComponent:@"compacted_kv.clsrecord"];
   self.logAPath = [tempDir stringByAppendingPathComponent:@"loga.clsrecord"];
   self.logBPath = [tempDir stringByAppendingPathComponent:@"logb.clsrecord"];
-  self.errorAPath = [tempDir stringByAppendingPathComponent:CLSReportErrorAFile];
-  self.errorBPath = [tempDir stringByAppendingPathComponent:CLSReportErrorBFile];
+  self.errorAPath = [tempDir stringByAppendingPathComponent:FIRCLSReportErrorAFile];
+  self.errorBPath = [tempDir stringByAppendingPathComponent:FIRCLSReportErrorBFile];
 
   _clsContext.readonly->logging.userKVStorage.incrementalPath =
       strdup([self.kvPath fileSystemRepresentation]);

--- a/Crashlytics/UnitTests/FIRCLSProcessReportOperationTests.m
+++ b/Crashlytics/UnitTests/FIRCLSProcessReportOperationTests.m
@@ -83,8 +83,8 @@
   NSFileManager *fileManager = [NSFileManager defaultManager];
 
   // put an exception in place
-  XCTAssertTrue([fileManager copyItemAtPath:[self pathForResource:CLSReportExceptionFile]
-                                     toPath:[report pathForContentFile:CLSReportExceptionFile]
+  XCTAssertTrue([fileManager copyItemAtPath:[self pathForResource:FIRCLSReportExceptionFile]
+                                     toPath:[report pathForContentFile:FIRCLSReportExceptionFile]
                                       error:nil],
                 @"");
 

--- a/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
@@ -279,7 +279,7 @@
 
   // create a signal file so it is considering worth reporting
   XCTAssertTrue([self createFileWithContents:@"signal"
-                                      atPath:[report pathForContentFile:CLSReportSignalFile]]);
+                                      atPath:[report pathForContentFile:FIRCLSReportSignalFile]]);
 
   XCTAssertEqual([[self contentsOfActivePath] count], 1);
 
@@ -302,7 +302,7 @@
 
   // create a signal file so it is considering worth reporting
   XCTAssertTrue([self createFileWithContents:@"signal"
-                                      atPath:[report pathForContentFile:CLSReportSignalFile]]);
+                                      atPath:[report pathForContentFile:FIRCLSReportSignalFile]]);
 
   XCTAssertEqual([[self contentsOfActivePath] count], 1);
 
@@ -332,7 +332,7 @@
 
   // create a signal file so it is considering worth reporting
   XCTAssertTrue([self createFileWithContents:@"signal"
-                                      atPath:[report pathForContentFile:CLSReportSignalFile]]);
+                                      atPath:[report pathForContentFile:FIRCLSReportSignalFile]]);
 
   XCTAssertEqual([[self contentsOfActivePath] count], 1);
 
@@ -364,7 +364,7 @@
 
   // create a signal file so it is considering worth reporting
   XCTAssertTrue([self createFileWithContents:@"signal"
-                                      atPath:[report pathForContentFile:CLSReportSignalFile]]);
+                                      atPath:[report pathForContentFile:FIRCLSReportSignalFile]]);
 
   XCTAssertEqual([[self contentsOfActivePath] count], 1);
 
@@ -390,7 +390,7 @@
 
   // create a signal file so it is considering worth reporting
   XCTAssertTrue([self createFileWithContents:@"signal"
-                                      atPath:[report pathForContentFile:CLSReportSignalFile]]);
+                                      atPath:[report pathForContentFile:FIRCLSReportSignalFile]]);
 
   XCTAssertEqual([[self contentsOfActivePath] count], 1);
 
@@ -413,7 +413,7 @@
 
   // create a signal file so it is considering worth reporting
   XCTAssertTrue([self createFileWithContents:@"signal"
-                                      atPath:[report pathForContentFile:CLSReportSignalFile]]);
+                                      atPath:[report pathForContentFile:FIRCLSReportSignalFile]]);
 
   XCTAssertEqual([[self contentsOfActivePath] count], 1);
 

--- a/Crashlytics/UnitTests/FIRCLSReportTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportTests.m
@@ -22,11 +22,11 @@
 #import "FIRCLSReport.h"
 #import "FIRCLSReport_Private.h"
 
-@interface CLSReportTests : XCTestCase
+@interface FIRCLSReportTests : XCTestCase
 
 @end
 
-@implementation CLSReportTests
+@implementation FIRCLSReportTests
 
 - (void)setUp {
   [super setUp];

--- a/Crashlytics/UnitTests/FIRCLSReportTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportTests.m
@@ -34,12 +34,12 @@
   FIRCLSContextBaseInit();
 
   // these values must be set for the internals of logging to work
-  _clsContext.readonly->logging.userKVStorage.maxCount = 16;
-  _clsContext.readonly->logging.userKVStorage.maxIncrementalCount = 16;
-  _clsContext.readonly->logging.internalKVStorage.maxCount = 32;
-  _clsContext.readonly->logging.internalKVStorage.maxIncrementalCount = 16;
+  _firclsContext.readonly->logging.userKVStorage.maxCount = 16;
+  _firclsContext.readonly->logging.userKVStorage.maxIncrementalCount = 16;
+  _firclsContext.readonly->logging.internalKVStorage.maxCount = 32;
+  _firclsContext.readonly->logging.internalKVStorage.maxIncrementalCount = 16;
 
-  _clsContext.readonly->initialized = true;
+  _firclsContext.readonly->initialized = true;
 }
 
 - (void)tearDown {

--- a/Crashlytics/UnitTests/FIRCLSReportTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportTests.m
@@ -94,7 +94,7 @@
   [report setUserIdentifier:@"12345-6"];
 
   NSArray *entries = FIRCLSFileReadSections(
-      [[report.internalReport pathForContentFile:CLSReportInternalIncrementalKVFile]
+      [[report.internalReport pathForContentFile:FIRCLSReportInternalIncrementalKVFile]
           fileSystemRepresentation],
       false, nil);
 
@@ -112,7 +112,7 @@
   [report setObjectValue:@"goodbye" forKey:@"anotherkey"];
 
   NSArray *entries = FIRCLSFileReadSections(
-      [[report.internalReport pathForContentFile:CLSReportUserIncrementalKVFile]
+      [[report.internalReport pathForContentFile:FIRCLSReportUserIncrementalKVFile]
           fileSystemRepresentation],
       false, nil);
 

--- a/SymbolCollisionTest/Podfile
+++ b/SymbolCollisionTest/Podfile
@@ -12,7 +12,7 @@ target 'SymbolCollisionTest' do
     pod 'FirebaseAnalytics'
     pod 'FirebaseAuth', :path => '../'
     pod 'FirebaseCore', :path => '../'
-#    pod 'FirebaseCrashlytics', :path => '../'  #4746
+    pod 'FirebaseCrashlytics', :path => '../'  #4746
     pod 'FirebaseDatabase', :path => '../'
     pod 'FirebaseDynamicLinks', :path => '../'
     pod 'FirebaseFirestore', :path => '../'

--- a/SymbolCollisionTest/Podfile
+++ b/SymbolCollisionTest/Podfile
@@ -12,7 +12,7 @@ target 'SymbolCollisionTest' do
     pod 'FirebaseAnalytics'
     pod 'FirebaseAuth', :path => '../'
     pod 'FirebaseCore', :path => '../'
-    pod 'FirebaseCrashlytics', :path => '../'  #4746
+    pod 'FirebaseCrashlytics', :path => '../'
     pod 'FirebaseDatabase', :path => '../'
     pod 'FirebaseDynamicLinks', :path => '../'
     pod 'FirebaseFirestore', :path => '../'


### PR DESCRIPTION
 - Resolves symbol collisions https://github.com/firebase/firebase-ios-sdk/issues/4746

Old and New SDK are not compatible in the same app, but symbol collisions are not a great way to discover that. Going to add a warning when both SDKs are included.