### PR TITLE
Crashlytics add warning about including new and old SDK

### DIFF
--- a/Crashlytics/Crashlytics/Public/FIRCrashlytics.h
+++ b/Crashlytics/Crashlytics/Public/FIRCrashlytics.h
@@ -14,6 +14,10 @@
 
 #import <Foundation/Foundation.h>
 
+#if __has_include(<Crashlytics/Crashlytics.h>)
+#warn "FirebaseCrashlytics and Crashlytics are not compatible in the same app because including multiple crash reporters can cause problems when registering exception handlers."
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**

--- a/Crashlytics/Crashlytics/Public/FIRCrashlytics.h
+++ b/Crashlytics/Crashlytics/Public/FIRCrashlytics.h
@@ -15,7 +15,7 @@
 #import <Foundation/Foundation.h>
 
 #if __has_include(<Crashlytics/Crashlytics.h>)
-#warn "FirebaseCrashlytics and Crashlytics are not compatible in the same app because including multiple crash reporters can cause problems when registering exception handlers."
+#warning "FirebaseCrashlytics and Crashlytics are not compatible in the same app because including multiple crash reporters can cause problems when registering exception handlers."
 #endif
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Crashlytics/Crashlytics/Public/FIRCrashlytics.h
+++ b/Crashlytics/Crashlytics/Public/FIRCrashlytics.h
@@ -15,7 +15,9 @@
 #import <Foundation/Foundation.h>
 
 #if __has_include(<Crashlytics/Crashlytics.h>)
-#warning "FirebaseCrashlytics and Crashlytics are not compatible in the same app because including multiple crash reporters can cause problems when registering exception handlers."
+#warning "FirebaseCrashlytics and Crashlytics are not compatible \
+in the same app because including multiple crash reporters can \
+cause problems when registering exception handlers."
 #endif
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
Including multiple crash reporters tends to cause issues with registering exception handlers. Making this a warning so that we don't break builds. Putting in the public header so that zip install / Carthage users get the same warning.

Related to https://github.com/firebase/firebase-ios-sdk/pull/4753