### PR TITLE
Fix tests to run individually.

### DIFF
--- a/FirebaseCore/Tests/Unit/FIROptionsTest.m
+++ b/FirebaseCore/Tests/Unit/FIROptionsTest.m
@@ -576,6 +576,12 @@ extern NSString *const kFIRLibraryVersionID;
 }
 
 - (void)testVersionFormat {
+  // `kFIRLibraryVersionID` is `nil` until `libraryVersion` is called on `FIROptions`.
+   FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
+                                                     GCMSenderID:kGCMSenderID];
+   __unused NSString *libraryVersion = options.libraryVersionID;
+   options = nil;
+
   NSRegularExpression *sLibraryVersionRegex =
       [NSRegularExpression regularExpressionWithPattern:@"^[0-9]{8,}$" options:0 error:NULL];
   NSUInteger numberOfMatches =
@@ -587,6 +593,13 @@ extern NSString *const kFIRLibraryVersionID;
 
 // TODO: The version test will break when the Firebase major version hits 10.
 - (void)testVersionConsistency {
+  // `kFIRLibraryVersionID` is `nil` until `libraryVersion` is called on `FIROptions`.
+  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
+                                                    GCMSenderID:kGCMSenderID];
+  __unused NSString *libraryVersion = options.libraryVersionID;
+  options = nil;
+
+  // Now `kFIRLibraryVersionID` is assigned, test that it is formatted correctly.
   const char *versionString = [kFIRLibraryVersionID UTF8String];
   int major = versionString[0] - '0';
   int minor = (versionString[1] - '0') * 10 + versionString[2] - '0';
@@ -598,6 +611,12 @@ extern NSString *const kFIRLibraryVersionID;
 // Repeat test with more Objective-C.
 // TODO: The version test will break when the Firebase major version hits 10.
 - (void)testVersionConsistency2 {
+  // `kFIRLibraryVersionID` is `nil` until `libraryVersion` is called on `FIROptions`.
+   FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
+                                                     GCMSenderID:kGCMSenderID];
+   __unused NSString *libraryVersion = options.libraryVersionID;
+   options = nil;
+
   NSRange major = NSMakeRange(0, 1);
   NSRange minor = NSMakeRange(1, 2);
   NSRange patch = NSMakeRange(3, 2);

--- a/FirebaseCore/Tests/Unit/FIROptionsTest.m
+++ b/FirebaseCore/Tests/Unit/FIROptionsTest.m
@@ -577,10 +577,10 @@ extern NSString *const kFIRLibraryVersionID;
 
 - (void)testVersionFormat {
   // `kFIRLibraryVersionID` is `nil` until `libraryVersion` is called on `FIROptions`.
-   FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
-                                                     GCMSenderID:kGCMSenderID];
-   __unused NSString *libraryVersion = options.libraryVersionID;
-   options = nil;
+  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
+                                                    GCMSenderID:kGCMSenderID];
+  __unused NSString *libraryVersion = options.libraryVersionID;
+  options = nil;
 
   NSRegularExpression *sLibraryVersionRegex =
       [NSRegularExpression regularExpressionWithPattern:@"^[0-9]{8,}$" options:0 error:NULL];
@@ -612,10 +612,10 @@ extern NSString *const kFIRLibraryVersionID;
 // TODO: The version test will break when the Firebase major version hits 10.
 - (void)testVersionConsistency2 {
   // `kFIRLibraryVersionID` is `nil` until `libraryVersion` is called on `FIROptions`.
-   FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
-                                                     GCMSenderID:kGCMSenderID];
-   __unused NSString *libraryVersion = options.libraryVersionID;
-   options = nil;
+  FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
+                                                    GCMSenderID:kGCMSenderID];
+  __unused NSString *libraryVersion = options.libraryVersionID;
+  options = nil;
 
   NSRange major = NSMakeRange(0, 1);
   NSRange minor = NSMakeRange(1, 2);


### PR DESCRIPTION
Currently these tests rely on other tests to be run first in order for
`kFIRLibraryVersionID` to be assigned. If run alone, these tests crash.
This will prevent that from occurring.

Also fixes b/147988498.