### PR TITLE
Add the ability to read persisted (.clsrecord) crash files

### DIFF
--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordAdapter.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordAdapter.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+/**
+ * The class will be responsible for aggregating the data from the persisted crash files
+ * and returning a report object used for FireLog.
+ **/
+@interface FIRCLSRecordAdapter : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
+/// Initializer
+/// @param folderPath Path where the persisted crash files reside
+- (instancetype)initWithPath:(NSString *)folderPath;
+
+// TODO: Add function to return the nanopb/FireLog report
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordAdapter.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordAdapter.m
@@ -88,7 +88,7 @@
   self.runtime = [[FIRCLSRecordRuntime alloc] initWithDict:dicts[@"runtime"]];
   self.processStats = [[FIRCLSRecordProcessStats alloc] initWithDict:dicts[@"process_stats"]];
   self.storage = [[FIRCLSRecordStorage alloc] initWithDict:dicts[@"storage"]];
-    
+
   // The thread's objc_selector_name is set with the runtime's info
   self.threads = [FIRCLSRecordThread threadsFromDictionaries:dicts[@"threads"]
                                                    withNames:dicts[@"thread_names"]

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordAdapter.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordAdapter.m
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordAdapter.h"
+
+#import "FIRCLSInternalReport.h"
+#import "FIRCLSLogger.h"
+#import "FIRCLSRecordApplication.h"
+#import "FIRCLSRecordBinaryImage.h"
+#import "FIRCLSRecordExecutable.h"
+#import "FIRCLSRecordHost.h"
+#import "FIRCLSRecordIdentity.h"
+#import "FIRCLSRecordKeyValue.h"
+#import "FIRCLSRecordProcessStats.h"
+#import "FIRCLSRecordRegister.h"
+#import "FIRCLSRecordRuntime.h"
+#import "FIRCLSRecordSignal.h"
+#import "FIRCLSRecordStorage.h"
+#import "FIRCLSRecordThread.h"
+
+@interface FIRCLSRecordAdapter ()
+
+@property(nonatomic, strong) NSString *folderPath;
+
+@property(nonatomic, strong) FIRCLSRecordSignal *signal;
+@property(nonatomic, strong) NSArray<FIRCLSRecordThread *> *threads;
+@property(nonatomic, strong) FIRCLSRecordProcessStats *processStats;
+@property(nonatomic, strong) FIRCLSRecordStorage *storage;
+@property(nonatomic, strong) NSArray<FIRCLSRecordBinaryImage *> *binaryImages;
+@property(nonatomic, strong) FIRCLSRecordRuntime *runtime;
+@property(nonatomic, strong) FIRCLSRecordIdentity *identity;
+@property(nonatomic, strong) FIRCLSRecordHost *host;
+@property(nonatomic, strong) FIRCLSRecordApplication *application;
+@property(nonatomic, strong) FIRCLSRecordExecutable *executable;
+@property(nonatomic, strong) NSArray<FIRCLSRecordKeyValue *> *keyValues;
+
+@end
+
+@implementation FIRCLSRecordAdapter
+
+- (instancetype)initWithPath:(NSString *)folderPath {
+  self = [super init];
+  if (self) {
+    _folderPath = folderPath;
+
+    [self loadBinaryImagesFile];
+    [self loadMetaDataFile];
+    [self loadSignalFile];
+    [self loadKeyValuesFile];
+  }
+  return self;
+}
+
+- (void)loadBinaryImagesFile {
+  NSString *path = [self.folderPath stringByAppendingPathComponent:CLSReportBinaryImageFile];
+  self.binaryImages = [FIRCLSRecordBinaryImage
+      binaryImagesFromDictionaries:[FIRCLSRecordAdapter dictionariesFromEachLineOfFile:path]];
+}
+
+- (void)loadMetaDataFile {
+  NSString *path = [self.folderPath stringByAppendingPathComponent:CLSReportMetadataFile];
+  NSDictionary *dict = [FIRCLSRecordAdapter combinedDictionariesFromFilePath:path];
+
+  self.identity = [[FIRCLSRecordIdentity alloc] initWithDict:dict[@"identity"]];
+  self.host = [[FIRCLSRecordHost alloc] initWithDict:dict[@"host"]];
+  self.application = [[FIRCLSRecordApplication alloc] initWithDict:dict[@"application"]];
+  self.executable = [[FIRCLSRecordExecutable alloc] initWithDict:dict[@"executable"]];
+}
+
+- (void)loadSignalFile {
+  NSString *path = [self.folderPath stringByAppendingPathComponent:CLSReportSignalFile];
+  NSDictionary *dicts = [FIRCLSRecordAdapter combinedDictionariesFromFilePath:path];
+
+  self.signal = [[FIRCLSRecordSignal alloc] initWithDict:dicts[@"signal"]];
+  self.runtime = [[FIRCLSRecordRuntime alloc] initWithDict:dicts[@"runtime"]];
+  self.processStats = [[FIRCLSRecordProcessStats alloc] initWithDict:dicts[@"process_stats"]];
+  self.storage = [[FIRCLSRecordStorage alloc] initWithDict:dicts[@"storage"]];
+  self.threads = [FIRCLSRecordThread threadsFromDictionaries:dicts[@"threads"]
+                                                   withNames:dicts[@"thread_names"]
+                                                 withRuntime:self.runtime];
+}
+
+- (void)loadKeyValuesFile {
+  NSString *path =
+      [self.folderPath stringByAppendingPathComponent:CLSReportInternalIncrementalKVFile];
+  self.keyValues = [FIRCLSRecordKeyValue
+      keyValuesFromDictionaries:[FIRCLSRecordAdapter dictionariesFromEachLineOfFile:path]];
+}
+
+/// Return the persisted crash file as a combined dictionary that way lookups can occur with a key
+/// (to avoid ordering dependency)
+/// @param filePath Persisted crash file path
++ (NSDictionary *)combinedDictionariesFromFilePath:(NSString *)filePath {
+  NSMutableDictionary *joinedDict = [[NSMutableDictionary alloc] init];
+  for (NSDictionary *dict in [self dictionariesFromEachLineOfFile:filePath]) {
+    [joinedDict addEntriesFromDictionary:dict];
+  }
+  return joinedDict;
+}
+
+/// The persisted crash files contains JSON on separate lines. Read each line and return the JSON
+/// data as a dictionary.
+/// @param filePath Persisted crash file path
++ (NSArray<NSDictionary *> *)dictionariesFromEachLineOfFile:(NSString *)filePath {
+  NSString *content = [[NSString alloc] initWithContentsOfFile:filePath
+                                                      encoding:NSUTF8StringEncoding
+                                                         error:nil];
+  NSArray *lines =
+      [content componentsSeparatedByCharactersInSet:NSCharacterSet.newlineCharacterSet];
+
+  NSMutableArray<NSDictionary *> *array = [[NSMutableArray<NSDictionary *> alloc] init];
+
+  int lineNum = 1;
+  for (NSString *line in lines) {
+    NSError *error;
+    NSDictionary *dict =
+        [NSJSONSerialization JSONObjectWithData:[line dataUsingEncoding:NSUTF8StringEncoding]
+                                        options:0
+                                          error:&error];
+
+    if (error) {
+      FIRCLSErrorLog(@"Failed to read JSON from file (%@) line (%d) with error: %@", filePath,
+                     lineNum, error);
+    } else {
+      [array addObject:dict];
+    }
+
+    lineNum++;
+  }
+
+  return array;
+}
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordAdapter.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordAdapter.m
@@ -88,6 +88,8 @@
   self.runtime = [[FIRCLSRecordRuntime alloc] initWithDict:dicts[@"runtime"]];
   self.processStats = [[FIRCLSRecordProcessStats alloc] initWithDict:dicts[@"process_stats"]];
   self.storage = [[FIRCLSRecordStorage alloc] initWithDict:dicts[@"storage"]];
+    
+  // The thread's objc_selector_name is set with the runtime's info
   self.threads = [FIRCLSRecordThread threadsFromDictionaries:dicts[@"threads"]
                                                    withNames:dicts[@"thread_names"]
                                                  withRuntime:self.runtime];

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordApplication.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordApplication.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordBase.h"
+
+@interface FIRCLSRecordApplication : FIRCLSRecordBase
+
+@property(nonatomic, copy) NSString *bundle_id;
+@property(nonatomic, copy) NSString *build_version;
+@property(nonatomic, copy) NSString *display_version;
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordApplication.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordApplication.m
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordApplication.h"
+
+@implementation FIRCLSRecordApplication
+
+- (instancetype)initWithDict:(NSDictionary *)dict {
+  self = [super initWithDict:dict];
+  if (self) {
+    _bundle_id = dict[@"bundle_id"];
+    _display_version = dict[@"display_version"];
+    _build_version = dict[@"build_version"];
+  }
+  return self;
+}
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordBase.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordBase.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+/**
+ * This is the base class to represent the data in the persisted crash (.clsrecord) files
+ **/
+@interface FIRCLSRecordBase : NSObject
+
+/**
+ * Mark the default initializer as unavailable so  the subclasses do not have to add the same line
+ **/
+- (instancetype)init NS_UNAVAILABLE;
+
+/**
+ * All subclasses should define an initializer taking in a dictionary
+ **/
+- (instancetype)initWithDict:(NSDictionary *)dict;
+
+/**
+ * Decode hex encoded string
+ **/
++ (NSString *)decodedHexStringWithValue:(NSString *)hexEncodedString;
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordBase.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordBase.h
@@ -17,7 +17,10 @@
 #import <Foundation/Foundation.h>
 
 /**
- * This is the base class to represent the data in the persisted crash (.clsrecord) files
+ * This is the base class to represent the data in the persisted crash (.clsrecord) files.
+ * The properties these subclasses are nullable on purpose. If there is an issue reading values
+ * from the crash files, continue as if those fields are optional so a report can still be uploaded.
+ * That way the issue can potentially be monitored through the backend.
  **/
 @interface FIRCLSRecordBase : NSObject
 

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordBase.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordBase.m
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordBase.h"
+
+@implementation FIRCLSRecordBase
+
+- (instancetype)initWithDict:(NSDictionary *)dict {
+  return [super init];
+}
+
++ (NSString *)decodedHexStringWithValue:(NSString *)hexEncodedString {
+  NSMutableString *decodedString = [[NSMutableString alloc] init];
+  int index = 0;
+  while (index < hexEncodedString.length) {
+    NSString *hexChar = [hexEncodedString substringWithRange:NSMakeRange(index, 2)];
+    int value = 0;
+    sscanf([hexChar cStringUsingEncoding:NSASCIIStringEncoding], "%x", &value);
+    [decodedString appendFormat:@"%c", (char)value];
+    index += 2;
+  }
+  return decodedString;
+}
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordBinaryImage.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordBinaryImage.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordBase.h"
+
+@interface FIRCLSRecordBinaryImage : FIRCLSRecordBase
+
+@property(nonatomic, copy) NSString *path;
+@property(nonatomic, copy) NSString *uuid;
+@property(nonatomic, assign) NSUInteger base;
+@property(nonatomic, assign) NSUInteger size;
+
+/// Return an array of binary images
+/// @param dicts Dictionary describing the binary images
++ (NSArray<FIRCLSRecordBinaryImage *> *)binaryImagesFromDictionaries:
+    (NSArray<NSDictionary *> *)dicts;
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordBinaryImage.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordBinaryImage.m
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordBinaryImage.h"
+
+@implementation FIRCLSRecordBinaryImage
+
++ (NSArray<FIRCLSRecordBinaryImage *> *)binaryImagesFromDictionaries:
+    (NSArray<NSDictionary *> *)dicts {
+  NSMutableArray<FIRCLSRecordBinaryImage *> *images =
+      [[NSMutableArray<FIRCLSRecordBinaryImage *> alloc] init];
+  for (NSDictionary *dict in dicts) {
+    [images addObject:[[FIRCLSRecordBinaryImage alloc] initWithDict:dict[@"load"]]];
+  }
+  return images;
+}
+
+- (instancetype)initWithDict:(NSDictionary *)dict {
+  self = [super initWithDict:dict];
+  if (self) {
+    _path = dict[@"path"];
+    _uuid = dict[@"uuid"];
+    _base = (NSUInteger)dict[@"base"];
+    _size = (NSUInteger)dict[@"size"];
+  }
+  return self;
+}
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordExecutable.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordExecutable.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordBase.h"
+
+@interface FIRCLSRecordExecutable : FIRCLSRecordBase
+
+@property(nonatomic, copy) NSString *architecture;
+@property(nonatomic, copy) NSString *uuid;
+@property(nonatomic, assign) NSUInteger base;
+@property(nonatomic, assign) NSUInteger size;
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordExecutable.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordExecutable.m
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordExecutable.h"
+
+@implementation FIRCLSRecordExecutable
+
+- (instancetype)initWithDict:(NSDictionary *)dict {
+  self = [super initWithDict:dict];
+  if (self) {
+    _architecture = dict[@"architecture"];
+    _uuid = dict[@"uuid"];
+    _base = (NSUInteger)dict[@"base"];
+    _size = (NSUInteger)dict[@"size"];
+  }
+  return self;
+}
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordFrame.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordFrame.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordBase.h"
+
+@interface FIRCLSRecordFrame : FIRCLSRecordBase
+
+@property(nonatomic) NSUInteger pc;
+
+// The fields below are only set on macOS where device symbolication occurs
+
+@property(nonatomic, copy) NSString *symbol;
+@property(nonatomic) NSUInteger offset;
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordFrame.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordFrame.m
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordFrame.h"
+
+@implementation FIRCLSRecordFrame
+
+- (instancetype)initWithDict:(NSDictionary *)dict {
+  self = [super initWithDict:dict];
+  if (self) {
+    _pc = (NSUInteger)dict[@"pc"];
+    _symbol = dict[@"symbol"];
+    _offset = (NSUInteger)dict[@"offset"];
+  }
+  return self;
+}
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordHost.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordHost.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordBase.h"
+
+@interface FIRCLSRecordHost : FIRCLSRecordBase
+
+@property(nonatomic, copy) NSString *model;
+@property(nonatomic, copy) NSString *machine;
+@property(nonatomic, copy) NSString *cpu;
+@property(nonatomic, copy) NSString *os_build_version;
+@property(nonatomic, copy) NSString *os_display_version;
+@property(nonatomic, copy) NSString *platform;
+@property(nonatomic, copy) NSString *locale;
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordHost.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordHost.m
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordHost.h"
+
+@implementation FIRCLSRecordHost
+
+- (instancetype)initWithDict:(NSDictionary *)dict {
+  self = [super initWithDict:dict];
+  if (self) {
+    _model = dict[@"model"];
+    _machine = dict[@"machine"];
+    _cpu = dict[@"cpu"];
+    _os_build_version = dict[@"os_build_version"];
+    _os_display_version = dict[@"os_display_version"];
+    _platform = dict[@"platform"];
+    _locale = dict[@"locale"];
+  }
+  return self;
+}
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordIdentity.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordIdentity.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordBase.h"
+
+@interface FIRCLSRecordIdentity : FIRCLSRecordBase
+
+@property(nonatomic, copy) NSString *generator;
+@property(nonatomic, copy) NSString *display_version;
+@property(nonatomic, copy) NSString *build_version;
+@property(nonatomic, copy) NSString *session_id;
+@property(nonatomic, copy) NSString *install_id;
+@property(nonatomic, assign) NSUInteger started_at;
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordIdentity.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordIdentity.m
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordIdentity.h"
+
+@implementation FIRCLSRecordIdentity
+
+- (instancetype)initWithDict:(NSDictionary *)dict {
+  self = [super initWithDict:dict];
+  if (self) {
+    _generator = dict[@"generator"];
+    _display_version = dict[@"display_version"];
+    _build_version = dict[@"build_version"];
+    _session_id = dict[@"session_id"];
+    _install_id = dict[@"install_id"];
+    _started_at = (NSUInteger)dict[@"started_at"];
+  }
+  return self;
+}
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordKeyValue.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordKeyValue.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordBase.h"
+
+@interface FIRCLSRecordKeyValue : FIRCLSRecordBase
+
+@property(nonatomic, copy) NSString *key;
+@property(nonatomic, copy) NSString *value;
+
++ (NSArray<FIRCLSRecordKeyValue *> *)keyValuesFromDictionaries:(NSArray<NSDictionary *> *)dicts;
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordKeyValue.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordKeyValue.m
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordKeyValue.h"
+
+@implementation FIRCLSRecordKeyValue
+
++ (NSArray<FIRCLSRecordKeyValue *> *)keyValuesFromDictionaries:(NSArray<NSDictionary *> *)dicts {
+  NSMutableArray<FIRCLSRecordKeyValue *> *keyValues =
+      [[NSMutableArray<FIRCLSRecordKeyValue *> alloc] init];
+  for (NSDictionary *dict in dicts) {
+    [keyValues addObject:[[FIRCLSRecordKeyValue alloc] initWithDict:dict[@"kv"]]];
+  }
+  return keyValues;
+}
+
+- (instancetype)initWithDict:(NSDictionary *)dict {
+  self = [super initWithDict:dict];
+  if (self) {
+    _key = [FIRCLSRecordBase decodedHexStringWithValue:dict[@"key"]];
+    _value = [FIRCLSRecordBase decodedHexStringWithValue:dict[@"value"]];
+  }
+  return self;
+}
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordProcessStats.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordProcessStats.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordBase.h"
+
+@interface FIRCLSRecordProcessStats : FIRCLSRecordBase
+
+@property(nonatomic, assign) NSUInteger active;
+@property(nonatomic, assign) NSUInteger inactive;
+@property(nonatomic, assign) NSUInteger wired;
+@property(nonatomic, assign) NSUInteger freeMem;
+@property(nonatomic, assign) NSUInteger virtualAddress;
+@property(nonatomic, assign) NSUInteger resident;
+@property(nonatomic, assign) NSUInteger user_time;
+@property(nonatomic, assign) NSUInteger sys_time;
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordProcessStats.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordProcessStats.m
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordProcessStats.h"
+
+@implementation FIRCLSRecordProcessStats
+
+- (instancetype)initWithDict:(NSDictionary *)dict {
+  self = [super initWithDict:dict];
+  if (self) {
+    _active = (NSUInteger)dict[@"active"];
+    _inactive = (NSUInteger)dict[@"inactive"];
+    _wired = (NSUInteger)dict[@"wired"];
+    _freeMem = (NSUInteger)dict[@"freeMem"];
+    _virtualAddress = (NSUInteger)dict[@"virtual"];
+    _resident = (NSUInteger)dict[@"resident"];
+    _user_time = (NSUInteger)dict[@"user_time"];
+    _sys_time = (NSUInteger)dict[@"user_time"];
+  }
+  return self;
+}
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordRegister.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordRegister.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordBase.h"
+
+@interface FIRCLSRecordRegister : FIRCLSRecordBase
+
+@property(nonatomic, copy) NSString *name;
+@property(nonatomic) NSUInteger value;
+
+/// Get all registers from a dictionary
+/// @param dict Dictionary of the registers where the key is the register's name and the value is
+/// the memory address
++ (NSArray<FIRCLSRecordRegister *> *)registersFromDictionary:(NSDictionary *)dict;
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordRegister.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordRegister.m
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordRegister.h"
+#import "FIRCLSLogger.h"
+
+@implementation FIRCLSRecordRegister
+
++ (NSArray<FIRCLSRecordRegister *> *)registersFromDictionary:(NSDictionary *)dict {
+  NSMutableArray<FIRCLSRecordRegister *> *registers =
+      [[NSMutableArray<FIRCLSRecordRegister *> alloc] init];
+  for (NSString *key in dict.allKeys) {
+    [registers addObject:[[FIRCLSRecordRegister alloc] initWithDict:@{key : dict[key]}]];
+  }
+  return registers;
+}
+
+- (instancetype)initWithDict:(NSDictionary *)dict {
+  self = [super initWithDict:dict];
+  if (self) {
+    if (dict.allKeys.count == 1) {
+      _name = dict.allKeys[0];
+      _value = (NSUInteger)dict[_name];
+    } else {
+      FIRCLSWarningLog(@"The key value dictionary has more than one entry: %@", dict);
+    }
+  }
+  return self;
+}
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordRuntime.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordRuntime.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordBase.h"
+
+@interface FIRCLSRecordRuntime : FIRCLSRecordBase
+
+@property(nonatomic, copy) NSString *objc_selector;
+@property(nonatomic, strong) NSArray<NSString *> *crash_info_entries;
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordRuntime.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordRuntime.m
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordRuntime.h"
+
+@implementation FIRCLSRecordRuntime
+
+- (instancetype)initWithDict:(NSDictionary *)dict {
+  self = [super initWithDict:dict];
+  if (self) {
+    _objc_selector = dict[@"objc_selector"] ?: @"";
+
+    NSMutableArray<NSString *> *entries = [[NSMutableArray<NSString *> alloc] init];
+    for (NSString *hexString in dict[@"crash_info_entries"]) {
+      [entries addObject:[FIRCLSRecordBase decodedHexStringWithValue:hexString]];
+    }
+    _crash_info_entries = entries;
+  }
+  return self;
+}
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordSignal.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordSignal.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordBase.h"
+
+@interface FIRCLSRecordSignal : FIRCLSRecordBase
+
+@property(nonatomic, copy) NSString *name;
+@property(nonatomic, copy) NSString *code;
+@property(nonatomic) NSUInteger address;
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordSignal.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordSignal.m
@@ -1,0 +1,29 @@
+// Copyright 2020 Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "FIRCLSRecordSignal.h"
+
+@implementation FIRCLSRecordSignal
+
+- (instancetype)initWithDict:(NSDictionary *)dict {
+  self = [super initWithDict:dict];
+  if (self) {
+    _name = dict[@"name"];
+    _code = dict[@"code"];
+    _address = (NSUInteger)dict[@"address"];
+  }
+  return self;
+}
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordStorage.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordStorage.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordBase.h"
+
+@interface FIRCLSRecordStorage : FIRCLSRecordBase
+
+@property(nonatomic, assign) NSUInteger free;
+@property(nonatomic, assign) NSUInteger total;
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordStorage.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordStorage.m
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordStorage.h"
+
+@implementation FIRCLSRecordStorage
+
+- (instancetype)initWithDict:(NSDictionary *)dict {
+  self = [super initWithDict:dict];
+  if (self) {
+    _free = (NSUInteger)dict[@"free"];
+    _total = (NSUInteger)dict[@"total"];
+  }
+  return self;
+}
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordThread.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordThread.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordBase.h"
+
+@class FIRCLSRecordFrame;
+@class FIRCLSRecordRegister;
+@class FIRCLSRecordRuntime;
+
+@interface FIRCLSRecordThread : FIRCLSRecordBase
+
+@property(nonatomic, copy) NSString *name;
+@property(nonatomic, copy) NSString *alternate_name;
+@property(nonatomic, copy) NSString *objc_selector_name;
+@property(nonatomic, assign) BOOL crashed;
+@property(nonatomic, strong) NSArray<FIRCLSRecordRegister *> *registers;
+@property(nonatomic, strong) NSArray<NSNumber *> *stacktrace;
+
+/// Aggregate data and returns a collection of populated threads
+/// @param threads Array of thread dictionaries
+/// @param names Array of thread name strings
+/// @param runtime Runtime object
++ (NSArray<FIRCLSRecordThread *> *)threadsFromDictionaries:(NSArray *)threads
+                                                 withNames:(NSArray *)names
+                                               withRuntime:(FIRCLSRecordRuntime *)runtime;
+
+@end

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordThread.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordThread.m
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "FIRCLSRecordThread.h"
+#import "FIRCLSRecordFrame.h"
+#import "FIRCLSRecordRegister.h"
+#import "FIRCLSRecordRuntime.h"
+
+@implementation FIRCLSRecordThread
+
++ (NSArray<FIRCLSRecordThread *> *)threadsFromDictionaries:(NSArray *)threads
+                                                 withNames:(NSArray *)names
+                                               withRuntime:(FIRCLSRecordRuntime *)runtime {
+  NSMutableArray<FIRCLSRecordThread *> *result =
+      [[NSMutableArray<FIRCLSRecordThread *> alloc] init];
+  for (int i = 0; i < threads.count; i++) {
+    FIRCLSRecordThread *thread = [[FIRCLSRecordThread alloc] initWithDict:threads[i]];
+
+    if (thread.crashed && runtime.objc_selector.length > 0) {
+      thread.objc_selector_name = runtime.objc_selector;
+    }
+
+    if (i < names.count) {
+      thread.name = names[i];
+    }
+
+    [result addObject:thread];
+  }
+
+  return result;
+}
+
+- (instancetype)initWithDict:(NSDictionary *)dict {
+  self = [super initWithDict:dict];
+  if (self) {
+    _alternate_name = dict[@"alternate_name"];
+    _crashed = [dict[@"crashed"] boolValue];
+    _stacktrace = dict[@"stacktrace"];
+    _registers = [FIRCLSRecordRegister registersFromDictionary:dict[@"registers"]];
+  }
+  return self;
+}
+
+@end


### PR DESCRIPTION
As part of the design to move the reporting upload to use GoogleDataTransport, the Crashlytics SDK needs the ability to read the persisted crash files on the device. Then the data can be used to populate the nanopb models which will be used for uploading.

Tests executed:
Unit tests for iOS, tvOS, macOS
(New unit tests will be added right after this PR is merged)

TODOs (after this PR):
1. Handle macOS crashes as other clsrecords are involved (ie .clsrecord.symbolicated)