### PR TITLE
Prepare build scripts for building Firestore on GitHub Actions

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,6 +23,7 @@ function pod_gen() {
   bundle exec pod gen --local-sources=./ --sources=https://cdn.cocoapods.org/ "$@"
 }
 
+set -x
 set -euo pipefail
 
 if [[ $# -lt 1 ]]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -23,7 +23,6 @@ function pod_gen() {
   bundle exec pod gen --local-sources=./ --sources=https://cdn.cocoapods.org/ "$@"
 }
 
-set -x
 set -euo pipefail
 
 if [[ $# -lt 1 ]]; then

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -218,8 +218,8 @@ if [[ -n "${SANITIZERS:-}" ]]; then
   done
 fi
 
-case "$product-$method-$platform" in
-  FirebasePod-xcodebuild-*)
+case "$product-$platform-$method" in
+  FirebasePod-*-xcodebuild)
     RunXcodebuild \
         -workspace 'CoreOnly/Tests/FirebasePodTest/FirebasePodTest.xcworkspace' \
         -scheme "FirebasePodTest" \
@@ -227,7 +227,7 @@ case "$product-$method-$platform" in
         build
     ;;
 
-  Auth-xcodebuild-*)
+  Auth-*-xcodebuild)
     if [[ "$have_secrets" == true ]]; then
       RunXcodebuild \
         -workspace 'Example/Auth/AuthSample/AuthSample.xcworkspace' \
@@ -238,7 +238,7 @@ case "$product-$method-$platform" in
     fi
     ;;
 
-  InAppMessaging-xcodebuild-*)
+  InAppMessaging-*-xcodebuild)
     RunXcodebuild \
         -workspace 'FirebaseInAppMessaging/Tests/Integration/DefaultUITestApp/InAppMessagingDisplay-Sample.xcworkspace' \
         -scheme 'FiamDisplaySwiftExample' \
@@ -247,7 +247,7 @@ case "$product-$method-$platform" in
         test
     ;;
 
-  Firestore-xcodebuild-*)
+  Firestore-*-xcodebuild)
     "${firestore_emulator}" start
     trap '"${firestore_emulator}" stop' ERR EXIT
 
@@ -272,7 +272,7 @@ case "$product-$method-$platform" in
     fi
     ;;
 
-  Firestore-cmake-macOS)
+  Firestore-macOS-cmake)
     "${firestore_emulator}" start
     trap '"${firestore_emulator}" stop' ERR EXIT
 
@@ -286,7 +286,7 @@ case "$product-$method-$platform" in
     (cd build; env CTEST_OUTPUT_ON_FAILURE=1 make -j $cpus test)
     ;;
 
-  SymbolCollision-xcodebuild-*)
+  SymbolCollision-*-xcodebuild)
     RunXcodebuild \
         -workspace 'SymbolCollisionTest/SymbolCollisionTest.xcworkspace' \
         -scheme "SymbolCollisionTest" \
@@ -294,7 +294,7 @@ case "$product-$method-$platform" in
         build
     ;;
 
-  Database-xcodebuild-*)
+  Database-*-xcodebuild)
     pod_gen FirebaseDatabase.podspec --platforms=ios
     RunXcodebuild \
       -workspace 'gen/FirebaseDatabase/FirebaseDatabase.xcworkspace' \
@@ -334,7 +334,7 @@ case "$product-$method-$platform" in
       test
     ;;
 
-  Storage-xcodebuild-*)
+  Storage-*-xcodebuild)
     pod_gen FirebaseStorage.podspec --platforms=ios
     RunXcodebuild \
       -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -177,6 +177,7 @@ case "$project-$platform-$method" in
     brew outdated cmake || brew upgrade cmake
     brew outdated go || brew upgrade go # Somehow the build for Abseil requires this.
     brew install ccache
+    brew install ninja
 
     # Install python packages required to generate proto sources
     pip install six

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -21,7 +21,6 @@
 #   - PROJECT - Firebase or Firestore
 #   - METHOD - xcodebuild or cmake; default is xcodebuild
 
-set -x
 set -euo pipefail
 
 # Set up secrets for integration tests and metrics collection. This does not work for pull

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -143,9 +143,6 @@ case "$project-$platform-$method" in
     bundle exec pod install --project-directory=Firestore/Example --repo-update
     ;;
 
-  *-pod-lib-lint)
-    ;;
-
   Firestore-*-cmake)
     brew outdated cmake || brew upgrade cmake
     brew outdated go || brew upgrade go # Somehow the build for Abseil requires this.
@@ -158,6 +155,9 @@ case "$project-$platform-$method" in
   SymbolCollision-*-xcodebuild)
     gem install xcpretty
     bundle exec pod install --project-directory=SymbolCollisionTest --repo-update
+    ;;
+
+  *-pod-lib-lint)
     ;;
 
   *)

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -94,13 +94,13 @@ fi
 
 echo "Installing prerequisites for $project for $platform using $method"
 
+if [[ "$method" != "cmake" ]]; then
+  scripts/setup_bundler.sh
+fi
+
 if [[ ! -z "${QUICKSTART:-}" ]]; then
   install_secrets
   scripts/setup_quickstart.sh "$QUICKSTART"
-fi
-
-if [[ "$method" != "cmake" ]]; then
-  scripts/setup_bundler.sh
 fi
 
 system=$(uname -s)

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -21,6 +21,7 @@
 #   - PROJECT - Firebase or Firestore
 #   - METHOD - xcodebuild or cmake; default is xcodebuild
 
+set -x
 set -euo pipefail
 
 # Set up secrets for integration tests and metrics collection. This does not work for pull

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -1,4 +1,4 @@
-# Copyright 2018 Google
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -79,11 +79,13 @@ fi
 
 echo "Installing prerequisites for $project for $platform using $method"
 
-bundle install
-
 if [[ ! -z "${QUICKSTART:-}" ]]; then
   install_secrets
-  ./scripts/setup_quickstart.sh "$QUICKSTART"
+  scripts/setup_quickstart.sh "$QUICKSTART"
+fi
+
+if [[ "$method" != "cmake" ]]; then
+  scripts/setup_bundler.sh
 fi
 
 case "$project-$platform-$method" in

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -19,7 +19,7 @@
 #   - PROJECT - Firebase or Firestore
 #   - METHOD - xcodebuild or cmake; default is xcodebuild
 
-bundle install
+set -euo pipefail
 
 function install_secrets() {
   # Set up secrets for integration tests and metrics collection. This does not work for pull
@@ -57,12 +57,36 @@ function install_secrets() {
   fi
 }
 
-if [[ ! -z $QUICKSTART ]]; then
+if [[ $# -eq 0 ]]; then
+  # Take arguments from the environment
+  project=$PROJECT
+  platform=$PLATFORM
+  method=$METHOD
+
+else
+  project="$1"
+
+  platform="iOS"
+  if [[ $# -gt 1 ]]; then
+    platform="$2"
+  fi
+
+  method="xcodebuild"
+  if [[ $# -gt 2 ]]; then
+    method="$3"
+  fi
+fi
+
+echo "Installing prerequisites for $project for $platform using $method"
+
+bundle install
+
+if [[ ! -z "${QUICKSTART:-}" ]]; then
   install_secrets
   ./scripts/setup_quickstart.sh "$QUICKSTART"
 fi
 
-case "$PROJECT-$PLATFORM-$METHOD" in
+case "$project-$platform-$method" in
 
   FirebasePod-iOS-xcodebuild)
     gem install xcpretty
@@ -138,9 +162,9 @@ case "$PROJECT-$PLATFORM-$METHOD" in
 
   *)
     echo "Unknown project-platform-method combo" 1>&2
-    echo "  PROJECT=$PROJECT" 1>&2
-    echo "  PLATFORM=$PLATFORM" 1>&2
-    echo "  METHOD=$METHOD" 1>&2
+    echo "  PROJECT=$project" 1>&2
+    echo "  PLATFORM=$platform" 1>&2
+    echo "  METHOD=$method" 1>&2
     exit 1
     ;;
 esac

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -165,6 +165,11 @@ case "$project-$platform-$method" in
     fi
 
     gem install xcpretty
+
+    # The Firestore Podfile is multi-platform by default, but this doesn't work
+    # with command-line builds using xcodebuild. The PLATFORM environment
+    # variable forces the project to be set for just that single platform.
+    export PLATFORM="$platform"
     bundle exec pod install --project-directory=Firestore/Example --repo-update
     ;;
 

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -28,7 +28,7 @@ set -euo pipefail
 # requests from forks. See
 # https://docs.travis-ci.com/user/pull-requests#pull-requests-and-security-restrictions
 function install_secrets() {
-  if [[ ! -z $encrypted_d6a88994a5ab_key && $secrets_installed != true ]]; then
+  if [[ -n "${encrypted_d6a88994a5ab_key:-}" && $secrets_installed != true ]]; then
     secrets_installed=true
     openssl aes-256-cbc -K $encrypted_5dda5f491369_key -iv $encrypted_5dda5f491369_iv \
     -in scripts/travis-encrypted/Secrets.tar.enc \
@@ -68,6 +68,8 @@ function apt_install() {
   local package="$2"
   which "$program" >& /dev/null || sudo apt-get install "$package"
 }
+
+secrets_installed=false
 
 # Default values, if not supplied on the command line or environment
 platform="iOS"

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -68,21 +68,23 @@ function apt_install() {
   which "$program" >& /dev/null || sudo apt-get install "$package"
 }
 
+# Default values, if not supplied on the command line or environment
+platform="iOS"
+method="xcodebuild"
+
 if [[ $# -eq 0 ]]; then
   # Take arguments from the environment
   project=$PROJECT
-  platform=$PLATFORM
-  method=$METHOD
+  platform=${PLATFORM:-${platform}}
+  method=${METHOD:-${method}}
 
 else
   project="$1"
 
-  platform="iOS"
   if [[ $# -gt 1 ]]; then
     platform="$2"
   fi
 
-  method="xcodebuild"
   if [[ $# -gt 2 ]]; then
     method="$3"
   fi

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -97,6 +99,18 @@ if [[ "$method" != "cmake" ]]; then
   scripts/setup_bundler.sh
 fi
 
+system=$(uname -s)
+case "$system" in
+  Darwin)
+    xcode_version=$(xcodebuild -version | head -n 1)
+    xcode_version="${xcode_version/Xcode /}"
+    xcode_major="${xcode_version/.*/}"
+    ;;
+  *)
+    xcode_major="0"
+    ;;
+esac
+
 case "$project-$platform-$method" in
 
   FirebasePod-iOS-xcodebuild)
@@ -138,7 +152,7 @@ case "$project-$platform-$method" in
     ;;
 
   Firestore-*-xcodebuild | Firestore-*-fuzz)
-    if [[ $XCODE_VERSION == "8."* ]]; then
+    if [[ $xcode_major -lt 9 ]]; then
       # Firestore still compiles with Xcode 8 to help verify general
       # conformance with C++11 by using an older compiler that doesn't have as
       # many extensions from later versions of the language. However, Firebase

--- a/scripts/setup_bundler.sh
+++ b/scripts/setup_bundler.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-bundle update --bundler #insure bundler version is high enough for Gemfile.lock
+bundle update --bundler # ensure bundler version is high enough for Gemfile.lock
 bundle install
 bundle exec pod --version


### PR DESCRIPTION
This includes a bunch of fixes that come primarily from the fact that our Travis build is configured by the environment while so far we've been trending toward configuring GHA explicitly.

Specifically:
  * This makes it possible to invoke `install_prereqs.sh` with command-line arguments;
  * Ensures that bundler is up-to-date by invoking `setup_bundler.sh` from `install_prereqs.sh`;
  * Adds Linux build support to `install_prereqs.sh` and `build.sh`; and
  * Converts Firestore CMake builds to use `ninja` instead of `make` for a ~20% improvement in build time.

These changes should make it straightforward to port any Travis build that requires `install_prereqs.sh` to GHA:

```yaml
  xcodebuild:
    runs-on: macos-latest

    strategy:
      matrix:
        target: [iOS, tvOS, macOS]

    steps:
    - uses: actions/checkout@v2

    - name: Setup build
      run:  scripts/install_prereqs.sh Firestore ${{ matrix.target }} xcodebuild

    - name: Build and test
      run:  scripts/third_party/travis/retry.sh scripts/build.sh Firestore ${{ matrix.target }} xcodebuild
```