### PR TITLE
FCM: async remove database in FIRMessagingRmqManager

### DIFF
--- a/Example/Messaging/Tests/FIRInstanceIDWithFCMTest.m
+++ b/Example/Messaging/Tests/FIRInstanceIDWithFCMTest.m
@@ -54,7 +54,7 @@
 }
 
 - (void)tearDown {
-  [_testUtil cleanupAfterTest];
+  [_testUtil cleanupAfterTest:self];
   _instanceID = nil;
   _messaging = nil;
   [_mockFirebaseApp stopMocking];

--- a/Example/Messaging/Tests/FIRMessagingDataMessageManagerTest.m
+++ b/Example/Messaging/Tests/FIRMessagingDataMessageManagerTest.m
@@ -16,6 +16,7 @@
 
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
+#import "XCTestCase+FIRMessagingRmqManagerTests.h"
 
 #import <FirebaseMessaging/FIRMessaging.h>
 
@@ -90,6 +91,7 @@ static NSString *const kRmqDatabaseName = @"gcm-dmm-test";
 -(void)tearDown {
     if (_dataMessageManager.rmq2Manager) {
         [_dataMessageManager.rmq2Manager removeDatabase];
+        [self waitForDrainDatabaseQueueForRmqManager:_dataMessageManager.rmq2Manager];
     }
     [super tearDown];
 }

--- a/Example/Messaging/Tests/FIRMessagingHandlingTest.m
+++ b/Example/Messaging/Tests/FIRMessagingHandlingTest.m
@@ -76,7 +76,7 @@ static NSString *const kFIRMessagingDefaultsTestDomain = @"com.messaging.tests";
 }
 
 - (void)tearDown {
-  [_testUtil cleanupAfterTest];
+  [_testUtil cleanupAfterTest:self];
   [_mockMessagingAnalytics stopMocking];
   [_mockFirebaseApp stopMocking];
   [super tearDown];

--- a/Example/Messaging/Tests/FIRMessagingLinkHandlingTest.m
+++ b/Example/Messaging/Tests/FIRMessagingLinkHandlingTest.m
@@ -53,7 +53,7 @@ NSString *const kFIRMessagingTestsLinkHandlingSuiteName = @"com.messaging.test_l
 }
 
 - (void)tearDown {
-  [_testUtil cleanupAfterTest];
+  [_testUtil cleanupAfterTest:self];
   _messaging = nil;
   [[[NSUserDefaults alloc] initWithSuiteName:kFIRMessagingTestsLinkHandlingSuiteName] removePersistentDomainForName:kFIRMessagingTestsLinkHandlingSuiteName];
   [super tearDown];

--- a/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
+++ b/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
@@ -329,10 +329,16 @@ static const NSTimeInterval kAsyncTestTimout = 0.5;
   XCTestExpectation *assertionFailureExpectation = [self expectationWithDescription:@"assertionFailureExpectation"];
   assertionFailureExpectation.assertForOverFulfill = NO;
 
+#ifndef FIR_MESSAGING_ASSERTIONS_BLOCKED
   [self.testAssertionHandler setMethodFailureHandlerForClass:[FIRMessagingRmqManager class]
                                                      handler:^(id object, NSString *fileName, NSInteger lineNumber) {
     [assertionFailureExpectation fulfill];
   }];
+#else
+  // If FIR_MESSAGING_ASSERTIONS_BLOCKED is defined, then no assertion handlers will be called,
+  // so don't wait for it.
+  [assertionFailureExpectation fulfill];
+#endif // FIR_MESSAGING_ASSERTIONS_BLOCKED
 
   // Create `FIRMessagingRmqManager` instance with a broken database.
   FIRMessagingRmqManager *manager = [[FIRMessagingRmqManager alloc] initWithDatabaseName:databaseName];

--- a/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
+++ b/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
@@ -324,15 +324,16 @@ static const NSTimeInterval kAsyncTestTimout = 0.5;
   NSString *databasePath = [self createBrokenDatabaseWithName:databaseName];
   XCTAssert([[NSFileManager defaultManager] fileExistsAtPath:databasePath]);
 
-  XCTestExpectation *assertionFailureExpectation = [self expectationWithDescription:@"assertionFailureExpectation"];
   // Expect for at least one assertion.
+  XCTestExpectation *assertionFailureExpectation = [self expectationWithDescription:@"assertionFailureExpectation"];
   assertionFailureExpectation.assertForOverFulfill = NO;
 
   [self.testAssertionHandler setMethodFailureHandlerForClass:[FIRMessagingRmqManager class]
-                                                     handler:^(id object, NSInteger lineNumber) {
+                                                     handler:^(id object, NSString *fileName, NSInteger lineNumber) {
     [assertionFailureExpectation fulfill];
   }];
 
+  // Create `FIRMessagingRmqManager` instance with a broken database.
   FIRMessagingRmqManager *manager = [[FIRMessagingRmqManager alloc] initWithDatabaseName:databaseName];
   [self addTeardownBlock:^{
     [self drainDatabaseQueueForManager:manager];
@@ -342,6 +343,7 @@ static const NSTimeInterval kAsyncTestTimout = 0.5;
 
   [self drainDatabaseQueueForManager:manager];
 
+  // Check that the file was deleted.
   XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:databasePath]);
 }
 

--- a/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
+++ b/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
@@ -19,6 +19,7 @@
 #import <OCMock/OCMock.h>
 
 #import "FIRTestsAssertionHandler.h"
+#import "XCTestCase+FIRMessagingRmqManagerTests.h"
 
 #import "Firebase/Messaging/FIRMessagingPersistentSyncMessage.h"
 #import "Firebase/Messaging/FIRMessagingRmqManager.h"
@@ -59,7 +60,7 @@ static const NSTimeInterval kAsyncTestTimout = 0.5;
 
 - (void)tearDown {
   [self.rmqManager removeDatabase];
-  [self drainDatabaseQueueForManager:self.rmqManager];
+  [self waitForDrainDatabaseQueueForRmqManager:self.rmqManager];
 
   [self.assertionHandlerMock stopMocking];
   self.assertionHandlerMock = nil;
@@ -336,12 +337,12 @@ static const NSTimeInterval kAsyncTestTimout = 0.5;
   // Create `FIRMessagingRmqManager` instance with a broken database.
   FIRMessagingRmqManager *manager = [[FIRMessagingRmqManager alloc] initWithDatabaseName:databaseName];
   [self addTeardownBlock:^{
-    [self drainDatabaseQueueForManager:manager];
+    [self waitForDrainDatabaseQueueForRmqManager:manager];
   }];
 
   [self waitForExpectations:@[ assertionFailureExpectation ] timeout:0.5];
 
-  [self drainDatabaseQueueForManager:manager];
+  [self waitForDrainDatabaseQueueForRmqManager:manager];
 
   // Check that the file was deleted.
   XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:databasePath]);
@@ -386,12 +387,6 @@ static const NSTimeInterval kAsyncTestTimout = 0.5;
   return databasePath;
 }
 
-- (void)drainDatabaseQueueForManager:(FIRMessagingRmqManager *)manager {
-  XCTestExpectation *drainDatabaseQueueExpectation = [self expectationWithDescription:@"drainDatabaseQueue"];
-  dispatch_async([manager databaseOperationQueue], ^{
-    [drainDatabaseQueueExpectation fulfill];
-  });
-  [self waitForExpectations:@[drainDatabaseQueueExpectation] timeout:1.5];
-}
+
 
 @end

--- a/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
+++ b/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
@@ -328,10 +328,9 @@ static const NSTimeInterval kAsyncTestTimout = 0.5;
   // Expect for at least one assertion.
   assertionFailureExpectation.assertForOverFulfill = NO;
 
-  [self.testAssertionHandler setMethodFailureHandlerForClass:[FIRMessagingRmqManager class] handler:^(id object, NSInteger lineNumber) {
+  [self.testAssertionHandler setMethodFailureHandlerForClass:[FIRMessagingRmqManager class]
+                                                     handler:^(id object, NSInteger lineNumber) {
     [assertionFailureExpectation fulfill];
-
-    [self.testAssertionHandler setMethodFailureHandlerForClass:[FIRMessagingRmqManager class] handler:^(id object, NSInteger lineNumber){}];
   }];
 
   FIRMessagingRmqManager *manager = [[FIRMessagingRmqManager alloc] initWithDatabaseName:databaseName];

--- a/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
+++ b/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
@@ -329,6 +329,7 @@ static const NSTimeInterval kAsyncTestTimout = 0.5;
   XCTestExpectation *assertionFailureExpectation = [self expectationWithDescription:@"assertionFailureExpectation"];
   assertionFailureExpectation.assertForOverFulfill = NO;
 
+// The flag FIR_MESSAGING_ASSERTIONS_BLOCKED can be set by blaze when running tests from google3.
 #ifndef FIR_MESSAGING_ASSERTIONS_BLOCKED
   [self.testAssertionHandler setMethodFailureHandlerForClass:[FIRMessagingRmqManager class]
                                                      handler:^(id object, NSString *fileName, NSInteger lineNumber) {
@@ -337,7 +338,9 @@ static const NSTimeInterval kAsyncTestTimout = 0.5;
 #else
   // If FIR_MESSAGING_ASSERTIONS_BLOCKED is defined, then no assertion handlers will be called,
   // so don't wait for it.
-  [assertionFailureExpectation fulfill];
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    [assertionFailureExpectation fulfill];
+  });
 #endif // FIR_MESSAGING_ASSERTIONS_BLOCKED
 
   // Create `FIRMessagingRmqManager` instance with a broken database.

--- a/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
+++ b/Example/Messaging/Tests/FIRMessagingRmqManagerTest.m
@@ -336,9 +336,6 @@ static const NSTimeInterval kAsyncTestTimout = 0.5;
 
   // Create `FIRMessagingRmqManager` instance with a broken database.
   FIRMessagingRmqManager *manager = [[FIRMessagingRmqManager alloc] initWithDatabaseName:databaseName];
-  [self addTeardownBlock:^{
-    [self waitForDrainDatabaseQueueForRmqManager:manager];
-  }];
 
   [self waitForExpectations:@[ assertionFailureExpectation ] timeout:0.5];
 

--- a/Example/Messaging/Tests/FIRMessagingServiceTest.m
+++ b/Example/Messaging/Tests/FIRMessagingServiceTest.m
@@ -85,7 +85,7 @@ static NSString *const kFIRMessagingTestsServiceSuiteName = @"com.messaging.test
 }
 
 - (void)tearDown {
-  [_testUtil cleanupAfterTest];
+  [_testUtil cleanupAfterTest:self];
   _messaging = nil;
   [_mockPubSub stopMocking];
   [[[NSUserDefaults alloc] initWithSuiteName:kFIRMessagingTestsServiceSuiteName] removePersistentDomainForName:kFIRMessagingTestsServiceSuiteName];

--- a/Example/Messaging/Tests/FIRMessagingSyncMessageManagerTest.m
+++ b/Example/Messaging/Tests/FIRMessagingSyncMessageManagerTest.m
@@ -16,6 +16,8 @@
 
 #import <XCTest/XCTest.h>
 
+#import "XCTestCase+FIRMessagingRmqManagerTests.h"
+
 #import "Firebase/Messaging/FIRMessagingPersistentSyncMessage.h"
 #import "Firebase/Messaging/FIRMessagingRmqManager.h"
 #import "Firebase/Messaging/FIRMessagingSyncMessageManager.h"
@@ -48,6 +50,7 @@ static NSString *const kRmqSqliteFilename = @"rmq-sync-manager-test";
 
 - (void)tearDown {
   [_rmqManager removeDatabase];
+  [self waitForDrainDatabaseQueueForRmqManager:_rmqManager];
   [super tearDown];
 }
 

--- a/Example/Messaging/Tests/FIRMessagingTest.m
+++ b/Example/Messaging/Tests/FIRMessagingTest.m
@@ -82,7 +82,7 @@ static NSString *const kFIRMessagingDefaultsTestDomain = @"com.messaging.tests";
 }
 
 - (void)tearDown {
-  [_testUtil cleanupAfterTest];
+  [_testUtil cleanupAfterTest:self];
   [_mockFirebaseApp stopMocking];
   _messaging = nil;
   [[[NSUserDefaults alloc] initWithSuiteName:kFIRMessagingDefaultsTestDomain]

--- a/Example/Messaging/Tests/FIRMessagingTestUtilities.h
+++ b/Example/Messaging/Tests/FIRMessagingTestUtilities.h
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithUserDefaults:(NSUserDefaults *)userDefaults withRMQManager:(BOOL)withRMQManager;
 
-- (void)cleanupAfterTest;
+- (void)cleanupAfterTest:(XCTestCase *)testCase;
 
 @end
 

--- a/Example/Messaging/Tests/FIRMessagingTestUtilities.m
+++ b/Example/Messaging/Tests/FIRMessagingTestUtilities.m
@@ -16,6 +16,8 @@
 
 #import <OCMock/OCMock.h>
 
+#import "XCTestCase+FIRMessagingRmqManagerTests.h"
+
 #import "Example/Messaging/Tests/FIRMessagingTestUtilities.h"
 
 #import <FirebaseAnalyticsInterop/FIRAnalyticsInterop.h>
@@ -95,8 +97,9 @@ static NSString *const kFIRMessagingDefaultsTestDomain = @"com.messaging.tests";
   return self;
 }
 
-- (void)cleanupAfterTest {
+- (void)cleanupAfterTest:(XCTestCase *)testCase {
   [_messaging.rmq2Manager removeDatabase];
+  [testCase waitForDrainDatabaseQueueForRmqManager:_messaging.rmq2Manager];
   [_messaging.messagingUserDefaults removePersistentDomainForName:kFIRMessagingDefaultsTestDomain];
   _messaging.shouldEstablishDirectChannel = NO;
   [_mockPubsub stopMocking];

--- a/Example/Messaging/Tests/FIRTestsAssertionHandler.h
+++ b/Example/Messaging/Tests/FIRTestsAssertionHandler.h
@@ -18,11 +18,19 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void(^FIRTestsAssertionHandlerBlock)(id object, NSInteger lineNumber);
+typedef void(^FIRTestsAssertionHandlerBlock)(id object, NSString *fileName, NSInteger lineNumber);
 
 @interface FIRTestsAssertionHandler : NSAssertionHandler
 
-- (void)setMethodFailureHandlerForClass:(Class)aClass handler:(FIRTestsAssertionHandlerBlock)handler;
+/**
+ * Sets a handler for assertions in objects of the specified class.
+ * @param aClass A class to set an assertion method failure handler.
+ * @param handler A custom handler that will be called each time when
+ * `-[FIRTestsAssertionHandler handleFailureInMethod:object:file:lineNumber:description:]` is called. If `nil` then
+ * `-[super handleFailureInMethod:object:file:lineNumber:description:]` (default implementation) will be called.
+ */
+- (void)setMethodFailureHandlerForClass:(Class)aClass
+                                handler:(nullable FIRTestsAssertionHandlerBlock)handler;
 
 @end
 

--- a/Example/Messaging/Tests/FIRTestsAssertionHandler.h
+++ b/Example/Messaging/Tests/FIRTestsAssertionHandler.h
@@ -1,0 +1,29 @@
+/*
+* Copyright 2020 Google
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void(^FIRTestsAssertionHandlerBlock)(id object, NSInteger lineNumber);
+
+@interface FIRTestsAssertionHandler : NSAssertionHandler
+
+- (void)setMethodFailureHandlerForClass:(Class)aClass handler:(FIRTestsAssertionHandlerBlock)handler;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example/Messaging/Tests/FIRTestsAssertionHandler.m
+++ b/Example/Messaging/Tests/FIRTestsAssertionHandler.m
@@ -1,0 +1,55 @@
+/*
+* Copyright 2020 Google
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#import "FIRTestsAssertionHandler.h"
+
+@interface FIRTestsAssertionHandler ()
+
+@property (nonatomic) NSMutableDictionary<NSString *, FIRTestsAssertionHandlerBlock> *methodFailureHandlers;
+
+@end
+
+@implementation FIRTestsAssertionHandler
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    _methodFailureHandlers = [NSMutableDictionary dictionary];
+  }
+  return self;
+}
+
+- (void)handleFailureInMethod:(SEL)selector object:(id<NSObject>)object file:(NSString *)fileName lineNumber:(NSInteger)line description:(NSString *)format, ... {
+  FIRTestsAssertionHandlerBlock handler;
+  @synchronized (self) {
+    handler = self.methodFailureHandlers[NSStringFromClass([object class])];
+  }
+
+  if (handler) {
+    handler(object, line);
+  } else {
+    [super handleFailureInMethod:selector object:object file:fileName lineNumber:line description:@"%@", format];
+  }
+}
+
+- (void)setMethodFailureHandlerForClass:(Class)aClass handler:(FIRTestsAssertionHandlerBlock)handler {
+  @synchronized (self) {
+    self.methodFailureHandlers[NSStringFromClass(aClass)]  = [handler copy];
+  }
+}
+
+@end

--- a/Example/Messaging/Tests/FIRTestsAssertionHandler.m
+++ b/Example/Messaging/Tests/FIRTestsAssertionHandler.m
@@ -18,7 +18,7 @@
 
 @interface FIRTestsAssertionHandler ()
 
-@property (nonatomic) NSMutableDictionary<NSString *, FIRTestsAssertionHandlerBlock> *methodFailureHandlers;
+@property(nonatomic) NSMutableDictionary<NSString *, FIRTestsAssertionHandlerBlock> *methodFailureHandlers;
 
 @end
 
@@ -33,14 +33,18 @@
   return self;
 }
 
-- (void)handleFailureInMethod:(SEL)selector object:(id<NSObject>)object file:(NSString *)fileName lineNumber:(NSInteger)line description:(NSString *)format, ... {
+- (void)handleFailureInMethod:(SEL)selector
+                       object:(id<NSObject>)object
+                         file:(NSString *)fileName
+                   lineNumber:(NSInteger)line
+                  description:(NSString *)format, ... {
   FIRTestsAssertionHandlerBlock handler;
   @synchronized (self) {
     handler = self.methodFailureHandlers[NSStringFromClass([object class])];
   }
 
   if (handler) {
-    handler(object, line);
+    handler(object, fileName, line);
   } else {
     [super handleFailureInMethod:selector object:object file:fileName lineNumber:line description:@"%@", format];
   }

--- a/Example/Messaging/Tests/XCTestCase+FIRMessagingRmqManagerTests.h
+++ b/Example/Messaging/Tests/XCTestCase+FIRMessagingRmqManagerTests.h
@@ -1,0 +1,29 @@
+/*
+* Copyright 2020 Google
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#import <XCTest/XCTest.h>
+
+@class FIRMessagingRmqManager;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface XCTestCase (FIRMessagingRmqManagerTests)
+
+- (void)waitForDrainDatabaseQueueForRmqManager:(FIRMessagingRmqManager *)manager;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example/Messaging/Tests/XCTestCase+FIRMessagingRmqManagerTests.m
+++ b/Example/Messaging/Tests/XCTestCase+FIRMessagingRmqManagerTests.m
@@ -1,0 +1,42 @@
+/*
+* Copyright 2020 Google
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#import "XCTestCase+FIRMessagingRmqManagerTests.h"
+
+#import <Foundation/Foundation.h>
+
+#import "Firebase/Messaging/FIRMessagingRmqManager.h"
+
+@interface FIRMessagingRmqManager (FIRMessagingRmqManagerTests)
+- (dispatch_queue_t)databaseOperationQueue;
+@end
+
+@implementation XCTestCase (FIRMessagingRmqManagerTests)
+
+- (void)waitForDrainDatabaseQueueForRmqManager:(FIRMessagingRmqManager *)manager {
+  dispatch_queue_t databaseQueue = [manager databaseOperationQueue];
+  if (databaseQueue == nil) {
+    return;
+  }
+  
+  XCTestExpectation *drainDatabaseQueueExpectation = [self expectationWithDescription:@"drainDatabaseQueue"];
+  dispatch_async([manager databaseOperationQueue], ^{
+    [drainDatabaseQueueExpectation fulfill];
+  });
+  [self waitForExpectations:@[drainDatabaseQueueExpectation] timeout:1.5];
+}
+
+@end

--- a/Example/Messaging/Tests/XCTestCase+FIRMessagingRmqManagerTests.m
+++ b/Example/Messaging/Tests/XCTestCase+FIRMessagingRmqManagerTests.m
@@ -31,7 +31,7 @@
   if (databaseQueue == nil) {
     return;
   }
-  
+
   XCTestExpectation *drainDatabaseQueueExpectation = [self expectationWithDescription:@"drainDatabaseQueue"];
   dispatch_async([manager databaseOperationQueue], ^{
     [drainDatabaseQueueExpectation fulfill];

--- a/Firebase/Messaging/FIRMessagingRmqManager.h
+++ b/Firebase/Messaging/FIRMessagingRmqManager.h
@@ -154,4 +154,11 @@ typedef void(^FIRMessagingRmqMessageHandler)(NSDictionary<NSString *, GPBMessage
  */
 - (void)updateSyncMessageViaMCSWithRmqID:(NSString *)rmqID;
 
+/**
+ * Returns path for database with specified name.
+ * @param databaseName The database name without extension: "<databaseName>.sqlite".
+ * @returns Path to the database with the specified name.
+ */
++ (NSString *)pathForDatabaseWithName:(NSString *)databaseName;
+
 @end

--- a/Firebase/Messaging/FIRMessagingRmqManager.m
+++ b/Firebase/Messaging/FIRMessagingRmqManager.m
@@ -589,7 +589,7 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 
 - (void)removeDatabase {
   // Ensure database is removed in a sync queue as this sometimes makes test have race conditions.
-  dispatch_sync(_databaseOperationQueue, ^{
+  dispatch_async(_databaseOperationQueue, ^{
     NSString *path = [self pathForDatabase];
     [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
   });

--- a/Firebase/Messaging/FIRMessagingRmqManager.m
+++ b/Firebase/Messaging/FIRMessagingRmqManager.m
@@ -544,7 +544,11 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
 # pragma mark - Database
 
 - (NSString *)pathForDatabase {
-  NSString *dbNameWithExtension = [NSString stringWithFormat:@"%@.sqlite", _databaseName];
+  return [[self class] pathForDatabaseWithName:_databaseName];
+}
+
++ (NSString *)pathForDatabaseWithName:(NSString *)databaseName {
+  NSString *dbNameWithExtension = [NSString stringWithFormat:@"%@.sqlite", databaseName];
   NSArray *paths = NSSearchPathForDirectoriesInDomains(FIRMessagingSupportedDirectory(),
                                                   NSUserDomainMask,
                                                   YES);
@@ -853,4 +857,9 @@ NSString * _Nonnull FIRMessagingStringFromSQLiteResult(int result) {
   [self logError];
   sqlite3_finalize(stmt);
 }
+
+- (dispatch_queue_t)databaseOperationQueue {
+  return _databaseOperationQueue;
+}
+
 @end


### PR DESCRIPTION
- tests for the deadlock b/148389485
- fix for the deadlock b/148389485
- test fixes to support async `FIRMessagingRmqManager` database removing
- `FIRTestsAssertionHandler` to override default assertion handler for a specific class
