### PR TITLE
Update Crashlytics CHANGELOG for beta.3 out of band release

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v4.0.0-beta.3
 
 - [fixed] Fixed symbol collisions with the legacy Fabric Crashlytics SDK and added a warning not to include both (#4753, #4755)
+- [fixed] Fixed an import declaration when installing using CocoaPods with the `generate_multiple_pod_projects` flag set to true (#4786)
 
 # v4.0.0-beta.2
 

--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [fixed] Fixed symbol collisions with the legacy Fabric Crashlytics SDK and added a warning not to include both (#4753, #4755)
 - [fixed] Fixed an import declaration when installing using CocoaPods with the `generate_multiple_pod_projects` flag set to true (#4786)
+- [fixed] Added preventative crash prevention checks (#4661)
 
 # v4.0.0-beta.2
 

--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v4.0.0-beta.3
 
-- [fixed] Fixed an import declaration when installing using CocoaPods with the `generate_multiple_pod_projects` flag set to true (#4786)
+- [fixed] Fixed an import declaration for installing Crashlytics using CocoaPods. Previously, the declaration caused a compile error when you installed using CocoaPods with the `generate_multiple_pods_project` flag set to true (#4786)
 
 # v4.0.0-beta.2
 

--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,8 +1,6 @@
 # v4.0.0-beta.3
 
-- [fixed] Fixed symbol collisions with the legacy Fabric Crashlytics SDK and added a warning not to include both (#4753, #4755)
 - [fixed] Fixed an import declaration when installing using CocoaPods with the `generate_multiple_pod_projects` flag set to true (#4786)
-- [fixed] Added preventative crash prevention checks (#4661)
 
 # v4.0.0-beta.2
 

--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v4.0.0-beta.3
 
-- [fixed] Fixed an import declaration for installing Crashlytics using CocoaPods. Previously, the declaration caused a compile error when you installed using CocoaPods with the `generate_multiple_pods_project` flag set to true (#4786)
+- [fixed] Fixed an import declaration for installing Crashlytics. Previously, the declaration caused a compile error when you installed using CocoaPods with the `generate_multiple_pods_project` flag set to true (#4786)
 
 # v4.0.0-beta.2
 


### PR DESCRIPTION
Crashlytics is doing an out of band release for beta.3 to fix https://github.com/firebase/firebase-ios-sdk/pull/4786

Later, I will open a PR for the following changes that will be released with the other Firebase SDKs in a following release:

# v4.0.0-beta.4

- [fixed] Fixed symbol collisions with the legacy Fabric Crashlytics SDK and added a warning not to include both (#4753, #4755)
- [fixed] Added preventative crash prevention checks (#4661)

