### PR TITLE
Crashlytics CHANGELOG 4.0.0-beta.4

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+# v4.0.0-beta.4
+
+- [fixed] Fixed symbol collisions with the legacy Fabric Crashlytics SDK and added a warning not to include both (#4753, #4755)
+- [fixed] Added crash prevention checks (#4661)
+
 # v4.0.0-beta.3
 
 - [fixed] Fixed symbol collisions with the legacy Fabric Crashlytics SDK and added a warning not to include both (#4753, #4755)


### PR DESCRIPTION
4.0.0-beta.3 was out of band. This CHANGELOG should be shipped with the next normal release