### PR TITLE
Initialize and pass GDTCoreTransport  to FIRCLSReportManager

### DIFF
--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.h
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.h
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class FIRCLSInternalReport;
 @class FIRCLSSettings;
 @class FIRInstanceID;
+@class GDTCORTransport;
 @protocol FIRAnalyticsInterop;
 
 @interface FIRCLSReportManager : NSObject
@@ -35,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
                           analytics:(nullable id<FIRAnalyticsInterop>)analytics
                         googleAppID:(NSString *)googleAppID
                         dataArbiter:(FIRCLSDataCollectionArbiter *)dataArbiter
-    NS_DESIGNATED_INITIALIZER;
+                    googleTransport:(GDTCORTransport *)googleTransport NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -156,6 +156,8 @@ typedef NSNumber FIRCLSWrappedBool;
 // Runs the operations that fetch settings and call onboarding endpoints
 @property(nonatomic, strong) FIRCLSSettingsOnboardingManager *settingsAndOnboardingManager;
 
+@property(nonatomic, strong) GDTCORTransport *googleTransport;
+
 @end
 
 @implementation FIRCLSReportManager
@@ -167,7 +169,8 @@ static void (^reportSentCallback)(void);
                          instanceID:(FIRInstanceID *)instanceID
                           analytics:(id<FIRAnalyticsInterop>)analytics
                         googleAppID:(NSString *)googleAppID
-                        dataArbiter:(FIRCLSDataCollectionArbiter *)dataArbiter {
+                        dataArbiter:(FIRCLSDataCollectionArbiter *)dataArbiter
+                    googleTransport:(GDTCORTransport *)googleTransport {
   self = [super init];
   if (!self) {
     return nil;
@@ -177,6 +180,8 @@ static void (^reportSentCallback)(void);
   _analytics = analytics;
   _googleAppID = [googleAppID copy];
   _dataArbiter = dataArbiter;
+
+  _googleTransport = googleTransport;
 
   NSString *sdkBundleID = FIRCLSApplicationGetSDKBundleID();
 

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -62,6 +62,8 @@ dispatch_queue_t _firclsExceptionQueue;
 
 static atomic_bool _hasInitializedInstance;
 
+NSString *const FIRCLSGoogleTransportMappingID = @"1206";
+
 /// Empty protocol to register with FirebaseCore's component system.
 @protocol FIRCrashlyticsInstanceProvider <NSObject>
 @end
@@ -101,7 +103,7 @@ static atomic_bool _hasInitializedInstance;
     FIRCLSDeveloperLog("Crashlytics", @"Running on %@, %@ (%@)", FIRCLSHostModelInfo(),
                        FIRCLSHostOSDisplayVersion(), FIRCLSHostOSBuildVersion());
 
-    _googleTransport = [[GDTCORTransport alloc] initWithMappingID:@"1206"
+    _googleTransport = [[GDTCORTransport alloc] initWithMappingID:FIRCLSGoogleTransportMappingID
                                                      transformers:nil
                                                            target:kGDTCORTargetCSH];
 

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -48,6 +48,9 @@
 #import <FirebaseCore/FIROptionsInternal.h>
 #import <FirebaseInstanceID/FirebaseInstanceID.h>
 
+#import <GoogleDataTransport/GDTCORTargets.h>
+#import <GoogleDataTransport/GDTCORTransport.h>
+
 #if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 #endif
@@ -70,6 +73,7 @@ static atomic_bool _hasInitializedInstance;
 @property(nonatomic) FIRCLSDataCollectionArbiter *dataArbiter;
 @property(nonatomic) FIRCLSFileManager *fileManager;
 @property(nonatomic) FIRCLSReportManager *reportManager;
+@property(nonatomic) GDTCORTransport *googleTransport;
 
 @end
 
@@ -97,6 +101,10 @@ static atomic_bool _hasInitializedInstance;
     FIRCLSDeveloperLog("Crashlytics", @"Running on %@, %@ (%@)", FIRCLSHostModelInfo(),
                        FIRCLSHostOSDisplayVersion(), FIRCLSHostOSBuildVersion());
 
+    _googleTransport = [[GDTCORTransport alloc] initWithMappingID:@"1206"
+                                                     transformers:nil
+                                                           target:kGDTCORTargetCSH];
+
     _fileManager = [[FIRCLSFileManager alloc] init];
     _googleAppID = app.options.googleAppID;
     _dataArbiter = [[FIRCLSDataCollectionArbiter alloc] initWithApp:app withAppInfo:appInfo];
@@ -104,7 +112,8 @@ static atomic_bool _hasInitializedInstance;
                                                            instanceID:instanceID
                                                             analytics:analytics
                                                           googleAppID:_googleAppID
-                                                          dataArbiter:_dataArbiter];
+                                                          dataArbiter:_dataArbiter
+                                                      googleTransport:_googleTransport];
 
     // Process did crash during previous execution
     NSString *crashedMarkerFileName = [NSString stringWithUTF8String:FIRCLSCrashedMarkerFileName];

--- a/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
@@ -35,6 +35,7 @@
 #import "FIRCLSMockFileManager.h"
 #import "FIRCLSMockReportManager.h"
 #import "FIRCLSMockReportUploader.h"
+#import "FIRMockGDTCoreTransport.h"
 #import "FIRMockInstanceID.h"
 
 #define TEST_API_KEY (@"DB5C8FA65C0D43419120FB96CFDBDE0C")
@@ -73,15 +74,16 @@
 
   FIRMockInstanceID *iid = [[FIRMockInstanceID alloc] initWithIID:@"test_token"];
 
-  FABMockApplicationIdentifierModel *appIDModel = [[FABMockApplicationIdentifierModel alloc] init];
-  appIDModel.bundleID = TEST_BUNDLE_ID;
+  FIRMockGDTCORTransport *transport = [[FIRMockGDTCORTransport alloc] initWithMappingID:@"id"
+                                                                           transformers:nil
+                                                                                 target:0];
 
   self.reportManager = [[FIRCLSMockReportManager alloc] initWithFileManager:self.fileManager
                                                                  instanceID:iid
                                                                   analytics:nil
                                                                 googleAppID:TEST_GOOGLE_APP_ID
                                                                 dataArbiter:self.dataArbiter
-                                                                 appIDModel:appIDModel];
+                                                            googleTransport:transport];
   self.reportManager.bundleIdentifier = TEST_BUNDLE_ID;
 }
 

--- a/Crashlytics/UnitTests/Mocks/FIRCLSMockReportManager.h
+++ b/Crashlytics/UnitTests/Mocks/FIRCLSMockReportManager.h
@@ -27,14 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
                           analytics:(nullable id<FIRAnalyticsInterop>)analytics
                         googleAppID:(NSString *)googleAppID
                         dataArbiter:(FIRCLSDataCollectionArbiter *)dataArbiter
-                         appIDModel:(FIRCLSApplicationIdentifierModel *)appIDModel
-    NS_DESIGNATED_INITIALIZER;
-
-- (instancetype)initWithFileManager:(FIRCLSFileManager *)fileManager
-                         instanceID:(FIRInstanceID *)instanceID
-                          analytics:(nullable id<FIRAnalyticsInterop>)analytics
-                        googleAppID:(NSString *)googleAppID
-                        dataArbiter:(FIRCLSDataCollectionArbiter *)dataArbiter NS_UNAVAILABLE;
+                    googleTransport:(GDTCORTransport *)googleTransport NS_DESIGNATED_INITIALIZER;
 
 @property(nonatomic, copy) NSString *bundleIdentifier;
 

--- a/Crashlytics/UnitTests/Mocks/FIRCLSMockReportManager.m
+++ b/Crashlytics/UnitTests/Mocks/FIRCLSMockReportManager.m
@@ -14,7 +14,6 @@
 
 #import "FIRCLSMockReportManager.h"
 
-#import "FIRCLSApplicationIdentifierModel.h"
 #import "FIRCLSContext.h"
 #import "FIRCLSMockNetworkClient.h"
 #import "FIRCLSMockReportUploader.h"
@@ -22,9 +21,6 @@
 @interface FIRCLSMockReportManager () {
   FIRCLSMockReportUploader *_uploader;
 }
-
-// Made this a property so we can override this with mocked values
-@property(nonatomic, strong) FIRCLSApplicationIdentifierModel *appIDModel;
 
 @end
 
@@ -35,20 +31,19 @@
 
 - (instancetype)initWithFileManager:(FIRCLSFileManager *)fileManager
                          instanceID:(FIRInstanceID *)instanceID
-                          analytics:(id<FIRAnalyticsInterop>)analytics
-                        googleAppID:(nonnull NSString *)googleAppID
+                          analytics:(nullable id<FIRAnalyticsInterop>)analytics
+                        googleAppID:(NSString *)googleAppID
                         dataArbiter:(FIRCLSDataCollectionArbiter *)dataArbiter
-                         appIDModel:(FIRCLSApplicationIdentifierModel *)appIDModel {
+                    googleTransport:(GDTCORTransport *)googleTransport {
   self = [super initWithFileManager:fileManager
                          instanceID:instanceID
                           analytics:analytics
                         googleAppID:googleAppID
-                        dataArbiter:dataArbiter];
+                        dataArbiter:dataArbiter
+                    googleTransport:(GDTCORTransport *)googleTransport];
   if (!self) {
     return nil;
   }
-
-  _appIDModel = appIDModel;
 
   _uploader = [[FIRCLSMockReportUploader alloc] initWithQueue:self.operationQueue
                                                      delegate:self

--- a/Crashlytics/UnitTests/Mocks/FIRMockGDTCoreTransport.h
+++ b/Crashlytics/UnitTests/Mocks/FIRMockGDTCoreTransport.h
@@ -1,0 +1,24 @@
+// Copyright 2020 Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <GoogleDataTransport/GDTCORTransport.h>
+
+@interface FIRMockGDTCORTransport : GDTCORTransport
+
+- (nullable instancetype)initWithMappingID:(NSString *_Nonnull)mappingID
+                              transformers:
+                                  (nullable NSArray<id<GDTCOREventTransformer>> *)transformers
+                                    target:(NSInteger)target NS_DESIGNATED_INITIALIZER;
+
+@end

--- a/Crashlytics/UnitTests/Mocks/FIRMockGDTCoreTransport.m
+++ b/Crashlytics/UnitTests/Mocks/FIRMockGDTCoreTransport.m
@@ -1,0 +1,41 @@
+// Copyright 2020 Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "FIRMockGDTCoreTransport.h"
+
+@interface FIRMockGDTCORTransport ()
+
+@property(nonatomic, copy) NSString *mappingID;
+@property(nonatomic) NSInteger target;
+@property(nonatomic, strong) GDTCOREvent *dataEvent;
+
+@end
+
+@implementation FIRMockGDTCORTransport
+
+- (nullable instancetype)initWithMappingID:(NSString *)mappingID
+                              transformers:
+                                  (nullable NSArray<id<GDTCOREventTransformer>> *)transformers
+                                    target:(NSInteger)target {
+  _mappingID = mappingID;
+  _target = target;
+
+  return [super initWithMappingID:mappingID transformers:transformers target:target];
+}
+
+- (void)sendDataEvent:(GDTCOREvent *)event {
+  self.dataEvent = event;
+}
+
+@end


### PR DESCRIPTION
1. Initialize and pass GDTCoreTransport to FIRCLSReportManager
2. Create mock class for GDTCoreTransport (for future unit tests)
3. Clean up initializers in FIRCLSMockReportManager