### PR TITLE
Add iOS dark mode support to GDT and GDTCCT test apps

### DIFF
--- a/GoogleDataTransportCCTSupport/GDTCCTTestApp/app.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTTestApp/app.swift
@@ -44,7 +44,7 @@ import GoogleDataTransport
           if Globals.IsMonkeyTesting {
             backendSwitch?.selectedSegmentIndex = Int(arc4random_uniform(3))
           }
-            switch(backendSwitch?.selectedSegmentIndex){
+            switch(backendSwitch?.selectedSegmentIndex) {
             case 0:
                 theTransport = cctTransport;
                 break;
@@ -59,6 +59,7 @@ import GoogleDataTransport
                 
             default:
                 theTransport = cctTransport;
+                break;
             }
         }
       } else {
@@ -66,7 +67,7 @@ import GoogleDataTransport
           backendSwitch?.selectedSegmentIndex = Int(arc4random_uniform(3))
         }
         
-        switch(backendSwitch?.selectedSegmentIndex){
+        switch(backendSwitch?.selectedSegmentIndex) {
         case 0:
             theTransport = cctTransport;
             break;
@@ -81,6 +82,7 @@ import GoogleDataTransport
             
         default:
             theTransport = cctTransport;
+            break;
         }
       }
       return theTransport
@@ -111,7 +113,7 @@ import GoogleDataTransport
           if Globals.IsMonkeyTesting {
             backendSwitch?.selectedSegment = Int(arc4random_uniform(3))
           }
-          switch(backendSwitch?.selectedSegment){
+          switch(backendSwitch?.selectedSegment) {
           case 0:
               theTransport = cctTransport;
               break;
@@ -126,13 +128,14 @@ import GoogleDataTransport
               
           default:
               theTransport = cctTransport;
+              break;
           }
         }
       } else {
         if Globals.IsMonkeyTesting {
           backendSwitch?.selectedSegment = Int(arc4random_uniform(3))
         }
-        switch(backendSwitch?.selectedSegment){
+        switch(backendSwitch?.selectedSegment) {
         case 0:
             theTransport = cctTransport;
             break;
@@ -147,6 +150,7 @@ import GoogleDataTransport
             
         default:
             theTransport = cctTransport;
+            break;
         }
       }
       return theTransport

--- a/GoogleDataTransportCCTSupport/GDTCCTTestApp/app.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTTestApp/app.swift
@@ -32,6 +32,7 @@ import GoogleDataTransport
   public class ViewController: UIViewController {
     let cctTransport: GDTCORTransport = GDTCORTransport(mappingID: "1018", transformers: nil, target: GDTCORTarget.CCT.rawValue)!
     let fllTransport: GDTCORTransport = GDTCORTransport(mappingID: "1018", transformers: nil, target: GDTCORTarget.FLL.rawValue)!
+    let cshTransport: GDTCORTransport = GDTCORTransport(mappingID: "1018", transformers: nil, target: GDTCORTarget.CSH.rawValue)!
 
     @IBOutlet var backendSwitch: UISegmentedControl?
 
@@ -41,15 +42,46 @@ import GoogleDataTransport
       if !Thread.current.isMainThread {
         DispatchQueue.main.sync {
           if Globals.IsMonkeyTesting {
-            backendSwitch?.selectedSegmentIndex = Int(arc4random_uniform(2))
+            backendSwitch?.selectedSegmentIndex = Int(arc4random_uniform(3))
           }
-          theTransport = backendSwitch?.selectedSegmentIndex == 0 ? cctTransport : fllTransport
+            switch(backendSwitch?.selectedSegmentIndex){
+            case 0:
+                theTransport = cctTransport;
+                break;
+                
+            case 1:
+                theTransport = fllTransport;
+                break;
+                
+            case 2:
+                theTransport = cshTransport;
+                break;
+                
+            default:
+                theTransport = cctTransport;
+            }
         }
       } else {
         if Globals.IsMonkeyTesting {
-          backendSwitch?.selectedSegmentIndex = Int(arc4random_uniform(2))
+          backendSwitch?.selectedSegmentIndex = Int(arc4random_uniform(3))
         }
-        theTransport = backendSwitch?.selectedSegmentIndex == 0 ? cctTransport : fllTransport
+        
+        switch(backendSwitch?.selectedSegmentIndex){
+        case 0:
+            theTransport = cctTransport;
+            break;
+            
+        case 1:
+            theTransport = fllTransport;
+            break;
+            
+        case 2:
+            theTransport = cshTransport;
+            break;
+            
+        default:
+            theTransport = cctTransport;
+        }
       }
       return theTransport
     }
@@ -68,6 +100,7 @@ import GoogleDataTransport
   public class ViewController: NSViewController {
     let cctTransport: GDTCORTransport = GDTCORTransport(mappingID: "1018", transformers: nil, target: GDTCORTarget.CCT.rawValue)!
     let fllTransport: GDTCORTransport = GDTCORTransport(mappingID: "1018", transformers: nil, target: GDTCORTarget.FLL.rawValue)!
+    let cshTransport: GDTCORTransport = GDTCORTransport(mappingID: "1018", transformers: nil, target: GDTCORTarget.CSH.rawValue)!
 
     @IBOutlet var backendSwitch: NSSegmentedControl?
 
@@ -76,15 +109,45 @@ import GoogleDataTransport
       if !Thread.current.isMainThread {
         DispatchQueue.main.sync {
           if Globals.IsMonkeyTesting {
-            backendSwitch?.selectedSegment = Int(arc4random_uniform(2))
+            backendSwitch?.selectedSegment = Int(arc4random_uniform(3))
           }
-          theTransport = backendSwitch?.selectedSegment == 0 ? cctTransport : fllTransport
+          switch(backendSwitch?.selectedSegment){
+          case 0:
+              theTransport = cctTransport;
+              break;
+              
+          case 1:
+              theTransport = fllTransport;
+              break;
+              
+          case 2:
+              theTransport = cshTransport;
+              break;
+              
+          default:
+              theTransport = cctTransport;
+          }
         }
       } else {
         if Globals.IsMonkeyTesting {
-          backendSwitch?.selectedSegment = Int(arc4random_uniform(2))
+          backendSwitch?.selectedSegment = Int(arc4random_uniform(3))
         }
-        theTransport = backendSwitch?.selectedSegment == 0 ? cctTransport : fllTransport
+        switch(backendSwitch?.selectedSegment){
+        case 0:
+            theTransport = cctTransport;
+            break;
+            
+        case 1:
+            theTransport = fllTransport;
+            break;
+            
+        case 2:
+            theTransport = cshTransport;
+            break;
+            
+        default:
+            theTransport = cctTransport;
+        }
       }
       return theTransport
     }

--- a/GoogleDataTransportCCTSupport/GDTCCTTestApp/app.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTTestApp/app.swift
@@ -44,45 +44,37 @@ import GoogleDataTransport
           if Globals.IsMonkeyTesting {
             backendSwitch?.selectedSegmentIndex = Int(arc4random_uniform(3))
           }
-            switch(backendSwitch?.selectedSegmentIndex) {
-            case 0:
-                theTransport = cctTransport;
-                break;
-                
-            case 1:
-                theTransport = fllTransport;
-                break;
-                
-            case 2:
-                theTransport = cshTransport;
-                break;
-                
-            default:
-                theTransport = cctTransport;
-                break;
-            }
+          switch backendSwitch?.selectedSegmentIndex {
+          case 0:
+            theTransport = cctTransport
+
+          case 1:
+            theTransport = fllTransport
+
+          case 2:
+            theTransport = cshTransport
+
+          default:
+            theTransport = cctTransport
+          }
         }
       } else {
         if Globals.IsMonkeyTesting {
           backendSwitch?.selectedSegmentIndex = Int(arc4random_uniform(3))
         }
-        
-        switch(backendSwitch?.selectedSegmentIndex) {
+
+        switch backendSwitch?.selectedSegmentIndex {
         case 0:
-            theTransport = cctTransport;
-            break;
-            
+          theTransport = cctTransport
+
         case 1:
-            theTransport = fllTransport;
-            break;
-            
+          theTransport = fllTransport
+
         case 2:
-            theTransport = cshTransport;
-            break;
-            
+          theTransport = cshTransport
+
         default:
-            theTransport = cctTransport;
-            break;
+          theTransport = cctTransport
         }
       }
       return theTransport
@@ -113,44 +105,36 @@ import GoogleDataTransport
           if Globals.IsMonkeyTesting {
             backendSwitch?.selectedSegment = Int(arc4random_uniform(3))
           }
-          switch(backendSwitch?.selectedSegment) {
+          switch backendSwitch?.selectedSegment {
           case 0:
-              theTransport = cctTransport;
-              break;
-              
+            theTransport = cctTransport
+
           case 1:
-              theTransport = fllTransport;
-              break;
-              
+            theTransport = fllTransport
+
           case 2:
-              theTransport = cshTransport;
-              break;
-              
+            theTransport = cshTransport
+
           default:
-              theTransport = cctTransport;
-              break;
+            theTransport = cctTransport
           }
         }
       } else {
         if Globals.IsMonkeyTesting {
           backendSwitch?.selectedSegment = Int(arc4random_uniform(3))
         }
-        switch(backendSwitch?.selectedSegment) {
+        switch backendSwitch?.selectedSegment {
         case 0:
-            theTransport = cctTransport;
-            break;
-            
+          theTransport = cctTransport
+
         case 1:
-            theTransport = fllTransport;
-            break;
-            
+          theTransport = fllTransport
+
         case 2:
-            theTransport = cshTransport;
-            break;
-            
+          theTransport = cshTransport
+
         default:
-            theTransport = cctTransport;
-            break;
+          theTransport = cctTransport
         }
       }
       return theTransport

--- a/GoogleDataTransportCCTSupport/GDTCCTTestApp/ios/Main.storyboard
+++ b/GoogleDataTransportCCTSupport/GDTCCTTestApp/ios/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -26,14 +26,15 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="9fC-1b-Rvu">
-                                <rect key="frame" x="284" y="3" width="91" height="32"/>
+                                <rect key="frame" x="20" y="37" width="140" height="32"/>
                                 <segments>
                                     <segment title="CCT"/>
                                     <segment title="FLL"/>
+                                    <segment title="CSH"/>
                                 </segments>
                             </segmentedControl>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="674-uo-mtw">
-                                <rect key="frame" x="20" y="42" width="369" height="55"/>
+                                <rect key="frame" x="20" y="76" width="369" height="55"/>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="55" id="S2Z-8q-89v"/>
@@ -46,7 +47,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FD9-Mn-in7">
-                                <rect key="frame" x="20" y="105" width="369" height="55"/>
+                                <rect key="frame" x="20" y="139" width="369" height="55"/>
                                 <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="55" id="mYc-rL-3cW"/>
@@ -59,7 +60,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IFu-Rf-wNA">
-                                <rect key="frame" x="20" y="168" width="369" height="55"/>
+                                <rect key="frame" x="20" y="202" width="369" height="55"/>
                                 <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="55" id="Xp1-a8-nh0"/>
@@ -72,7 +73,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yTs-B1-Yoh">
-                                <rect key="frame" x="20" y="231" width="369" height="55"/>
+                                <rect key="frame" x="20" y="265" width="369" height="55"/>
                                 <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="55" id="jJR-dP-ezp"/>
@@ -85,7 +86,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QpN-cI-JZa">
-                                <rect key="frame" x="20" y="294" width="369" height="55"/>
+                                <rect key="frame" x="20" y="328" width="369" height="55"/>
                                 <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="55" id="LEk-X2-0qf"/>
@@ -103,7 +104,7 @@
                         <constraints>
                             <constraint firstItem="674-uo-mtw" firstAttribute="leading" secondItem="FD9-Mn-in7" secondAttribute="leading" id="2MG-RM-cIL"/>
                             <constraint firstItem="yTs-B1-Yoh" firstAttribute="leading" secondItem="QpN-cI-JZa" secondAttribute="leading" id="3AV-qq-ttG"/>
-                            <constraint firstItem="9fC-1b-Rvu" firstAttribute="leading" secondItem="L83-mC-jNW" secondAttribute="trailing" constant="28" id="F3k-xF-AZv"/>
+                            <constraint firstItem="9fC-1b-Rvu" firstAttribute="leading" secondItem="L83-mC-jNW" secondAttribute="trailing" constant="-236" id="F3k-xF-AZv"/>
                             <constraint firstItem="IFu-Rf-wNA" firstAttribute="leading" secondItem="yTs-B1-Yoh" secondAttribute="leading" id="J3A-D1-3Wc"/>
                             <constraint firstItem="QpN-cI-JZa" firstAttribute="top" secondItem="yTs-B1-Yoh" secondAttribute="bottom" constant="8" symbolic="YES" id="JwZ-sw-3Fd"/>
                             <constraint firstItem="674-uo-mtw" firstAttribute="trailing" secondItem="FD9-Mn-in7" secondAttribute="trailing" id="K5w-h4-9CX"/>
@@ -119,7 +120,7 @@
                             <constraint firstItem="yTs-B1-Yoh" firstAttribute="top" secondItem="IFu-Rf-wNA" secondAttribute="bottom" constant="8" symbolic="YES" id="pOu-Fj-7jV"/>
                             <constraint firstItem="674-uo-mtw" firstAttribute="top" secondItem="9fC-1b-Rvu" secondAttribute="bottom" constant="8" symbolic="YES" id="sw7-fX-DwC"/>
                             <constraint firstAttribute="trailingMargin" secondItem="674-uo-mtw" secondAttribute="trailing" constant="5" id="ySl-NP-P12"/>
-                            <constraint firstItem="L83-mC-jNW" firstAttribute="centerY" secondItem="9fC-1b-Rvu" secondAttribute="centerY" id="yh9-Qb-nF3"/>
+                            <constraint firstItem="L83-mC-jNW" firstAttribute="centerY" secondItem="9fC-1b-Rvu" secondAttribute="centerY" constant="-34" id="yh9-Qb-nF3"/>
                         </constraints>
                     </view>
                     <connections>

--- a/GoogleDataTransportCCTSupport/GDTCCTTestApp/ios/Main.storyboard
+++ b/GoogleDataTransportCCTSupport/GDTCCTTestApp/ios/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina5_5" orientation="portrait" appearance="light"/>
+    <device id="retina5_5" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
@@ -27,6 +27,7 @@
                             </label>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="9fC-1b-Rvu">
                                 <rect key="frame" x="20" y="37" width="140" height="32"/>
+                                <color key="backgroundColor" systemColor="opaqueSeparatorColor" red="0.77647058820000003" green="0.77647058820000003" blue="0.7843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <segments>
                                     <segment title="CCT"/>
                                     <segment title="FLL"/>
@@ -48,7 +49,7 @@
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FD9-Mn-in7">
                                 <rect key="frame" x="20" y="139" width="369" height="55"/>
-                                <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="55" id="mYc-rL-3cW"/>
                                 </constraints>
@@ -61,7 +62,7 @@
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IFu-Rf-wNA">
                                 <rect key="frame" x="20" y="202" width="369" height="55"/>
-                                <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="55" id="Xp1-a8-nh0"/>
                                 </constraints>
@@ -74,7 +75,7 @@
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yTs-B1-Yoh">
                                 <rect key="frame" x="20" y="265" width="369" height="55"/>
-                                <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="55" id="jJR-dP-ezp"/>
                                 </constraints>
@@ -87,7 +88,7 @@
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QpN-cI-JZa">
                                 <rect key="frame" x="20" y="328" width="369" height="55"/>
-                                <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="55" id="LEk-X2-0qf"/>
                                     <constraint firstAttribute="height" constant="55" id="qg8-hL-w44"/>
@@ -100,7 +101,7 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="674-uo-mtw" firstAttribute="leading" secondItem="FD9-Mn-in7" secondAttribute="leading" id="2MG-RM-cIL"/>
                             <constraint firstItem="yTs-B1-Yoh" firstAttribute="leading" secondItem="QpN-cI-JZa" secondAttribute="leading" id="3AV-qq-ttG"/>

--- a/GoogleDataTransportCCTSupport/GDTCCTTestApp/macos/Main.storyboard
+++ b/GoogleDataTransportCCTSupport/GDTCCTTestApp/macos/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14868"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -770,8 +770,8 @@
                                     <action selector="generateDailyEventWithSender:" target="XfG-lQ-9wD" id="nLB-7y-yWa"/>
                                 </connections>
                             </button>
-                            <segmentedControl verticalHuggingPriority="750" misplaced="YES" springLoaded="YES" translatesAutoresizingMaskIntoConstraints="NO" id="k6I-AV-bFw">
-                                <rect key="frame" x="358" y="177" width="104" height="24"/>
+                            <segmentedControl verticalHuggingPriority="750" springLoaded="YES" translatesAutoresizingMaskIntoConstraints="NO" id="k6I-AV-bFw">
+                                <rect key="frame" x="317" y="177" width="145" height="24"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="Rhk-Q2-W55"/>
                                 </constraints>
@@ -780,19 +780,20 @@
                                     <segments>
                                         <segment label="CCT" selected="YES"/>
                                         <segment label="FLL" tag="1"/>
+                                        <segment label="CSH"/>
                                     </segments>
                                 </segmentedCell>
                             </segmentedControl>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="aiw-VS-cNk" firstAttribute="top" secondItem="k6I-AV-bFw" secondAttribute="bottom" constant="5" id="4bB-Fp-all"/>
+                            <constraint firstItem="aiw-VS-cNk" firstAttribute="top" secondItem="k6I-AV-bFw" secondAttribute="bottom" constant="4" id="4bB-Fp-all"/>
                             <constraint firstItem="2ft-D0-CMq" firstAttribute="top" secondItem="aiw-VS-cNk" secondAttribute="bottom" constant="12" symbolic="YES" id="5of-K7-QY4"/>
                             <constraint firstItem="CDv-jq-Itb" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="20" symbolic="YES" id="IzD-5w-Bq1"/>
                             <constraint firstItem="2ft-D0-CMq" firstAttribute="trailing" secondItem="IlF-o2-Jac" secondAttribute="trailing" id="MZ4-Vp-Bk3"/>
                             <constraint firstItem="2ft-D0-CMq" firstAttribute="trailing" secondItem="Uh8-3g-UwR" secondAttribute="trailing" id="N94-GB-w24"/>
                             <constraint firstItem="CDv-jq-Itb" firstAttribute="leading" secondItem="aiw-VS-cNk" secondAttribute="leading" id="OBj-sJ-eFn"/>
                             <constraint firstItem="IlF-o2-Jac" firstAttribute="top" secondItem="aSo-QZ-e6X" secondAttribute="bottom" constant="12" symbolic="YES" id="PK3-yK-9bq"/>
-                            <constraint firstItem="k6I-AV-bFw" firstAttribute="centerY" secondItem="CDv-jq-Itb" secondAttribute="centerY" id="VcQ-7S-yQB"/>
+                            <constraint firstItem="k6I-AV-bFw" firstAttribute="centerY" secondItem="CDv-jq-Itb" secondAttribute="centerY" constant="1" id="VcQ-7S-yQB"/>
                             <constraint firstItem="CDv-jq-Itb" firstAttribute="leading" secondItem="2ft-D0-CMq" secondAttribute="leading" id="WS1-Ar-msV"/>
                             <constraint firstAttribute="trailing" secondItem="2ft-D0-CMq" secondAttribute="trailing" constant="20" symbolic="YES" id="X3u-Lt-dG9"/>
                             <constraint firstItem="2ft-D0-CMq" firstAttribute="trailing" secondItem="aiw-VS-cNk" secondAttribute="trailing" id="bWR-0E-3HY"/>

--- a/GoogleDataTransportCCTSupport/GDTCCTTestApp/tvos/Main.storyboard
+++ b/GoogleDataTransportCCTSupport/GDTCCTTestApp/tvos/Main.storyboard
@@ -68,7 +68,7 @@
                             </button>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="lrN-nC-pge">
                                 <rect key="frame" x="1442" y="48" width="372" height="70"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.10000000000000001" colorSpace="calibratedWhite"/>
+                                <color key="backgroundColor" systemColor="placeholderTextColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
                                 <segments>
                                     <segment title="CCT"/>
                                     <segment title="FLL"/>

--- a/GoogleDataTransportCCTSupport/GDTCCTTestApp/tvos/Main.storyboard
+++ b/GoogleDataTransportCCTSupport/GDTCCTTestApp/tvos/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="14868" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="15702" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="appleTV" appearance="light"/>
     <dependencies>
         <deployment identifier="tvOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -27,7 +27,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OZi-i7-uhg">
-                                <rect key="frame" x="106" y="130.5" width="1708" height="86"/>
+                                <rect key="frame" x="106" y="130" width="1708" height="86"/>
                                 <inset key="contentEdgeInsets" minX="40" minY="20" maxX="40" maxY="20"/>
                                 <state key="normal" title="Generate Data Event"/>
                                 <connections>
@@ -35,7 +35,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ydy-iV-b3g">
-                                <rect key="frame" x="106" y="240.5" width="1708" height="86"/>
+                                <rect key="frame" x="106" y="240" width="1708" height="86"/>
                                 <inset key="contentEdgeInsets" minX="40" minY="20" maxX="40" maxY="20"/>
                                 <state key="normal" title="Generate Telemetry Event"/>
                                 <connections>
@@ -43,7 +43,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Snj-cN-92G">
-                                <rect key="frame" x="106" y="350.5" width="1708" height="86"/>
+                                <rect key="frame" x="106" y="350" width="1708" height="86"/>
                                 <inset key="contentEdgeInsets" minX="40" minY="20" maxX="40" maxY="20"/>
                                 <state key="normal" title="Generate High Priority Event"/>
                                 <connections>
@@ -51,7 +51,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Sbe-wM-1b4">
-                                <rect key="frame" x="106" y="460.5" width="1708" height="86"/>
+                                <rect key="frame" x="106" y="460" width="1708" height="86"/>
                                 <inset key="contentEdgeInsets" minX="40" minY="20" maxX="40" maxY="20"/>
                                 <state key="normal" title="Generate Wifi Only Event"/>
                                 <connections>
@@ -59,7 +59,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wdl-V2-pfc">
-                                <rect key="frame" x="106" y="570.5" width="1708" height="86"/>
+                                <rect key="frame" x="106" y="570" width="1708" height="86"/>
                                 <inset key="contentEdgeInsets" minX="40" minY="20" maxX="40" maxY="20"/>
                                 <state key="normal" title="Generate Daily Event"/>
                                 <connections>
@@ -67,11 +67,12 @@
                                 </connections>
                             </button>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="lrN-nC-pge">
-                                <rect key="frame" x="1570" y="48" width="244" height="70"/>
+                                <rect key="frame" x="1442" y="48" width="372" height="70"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.10000000000000001" colorSpace="calibratedWhite"/>
                                 <segments>
                                     <segment title="CCT"/>
                                     <segment title="FLL"/>
+                                    <segment title="CSH"/>
                                 </segments>
                             </segmentedControl>
                         </subviews>


### PR DESCRIPTION
1. Add iOS dark mode support to testapp
2. Modify a button color in tvOS for better dark mode display
3. no change to MacOS, testapp for MacOS looks fine in dark mode