### PR TITLE
Fix ignore paths for Check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,8 +2,8 @@ name: check
 
 on:
   pull_request:
-    paths:
-      - '!Firestore/**'
+    paths-ignore:
+      - 'Firestore/**'
 
 jobs:
   check:


### PR DESCRIPTION
Based on [the docs](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onpushpull_requestpaths), `paths` should be used for excluding only when it's also specifying which paths to include. Otherwise, `paths-ignore` should be used.