### PR TITLE
Add ability to read to report_upload_variant from settings

### DIFF
--- a/Crashlytics/Crashlytics/Models/FIRCLSSettings.h
+++ b/Crashlytics/Crashlytics/Models/FIRCLSSettings.h
@@ -103,6 +103,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) BOOL customExceptionsEnabled;
 
 /**
+ * Determine if the SDK should use the new endpoint for uploading reports
+ */
+@property(nonatomic, readonly) BOOL shouldUseNewReportEndpoint;
+
+/**
  * Returns the maximum number of custom exception events that will be
  * recorded in a session.
  */

--- a/Crashlytics/Crashlytics/Models/FIRCLSSettings.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSSettings.m
@@ -290,6 +290,15 @@ NSString *const BuildInstanceID = @"build_instance_id";
   return YES;
 }
 
+- (BOOL)shouldUseNewReportEndpoint {
+  NSNumber *value = [self appSettings][@"report_upload_variant"];
+
+  // 0 - Unknown
+  // 1 - Legacy
+  // 2 - New
+  return value.intValue == 2;
+}
+
 #pragma mark - Optional Limit Overrides
 
 - (uint32_t)errorLogBufferSize {

--- a/Crashlytics/UnitTests/FIRCLSSettingsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSettingsTests.m
@@ -419,4 +419,59 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertEqual(self.settings.errorLogBufferSize, 64 * 1000);
 }
 
+- (void)testNewReportEndpointSettings {
+  NSString *settingsJSON =
+      @"{\"settings_version\":3,\"cache_duration\":60,\"app\":{\"status\":\"activated\",\"update_"
+      @"required\":false,\"report_upload_variant\":2}}";
+
+  NSError *error = nil;
+  [self writeSettings:settingsJSON error:&error];
+  NSTimeInterval currentTimestamp = [NSDate timeIntervalSinceReferenceDate];
+  [self.settings cacheSettingsWithGoogleAppID:TestGoogleAppID currentTimestamp:currentTimestamp];
+
+  XCTAssertNil(error, "%@", error);
+  XCTAssertTrue(self.settings.shouldUseNewReportEndpoint);
+}
+
+- (void)testLegacyReportEndpointSettings {
+  NSString *settingsJSON =
+      @"{\"settings_version\":3,\"cache_duration\":60,\"app\":{\"status\":\"activated\",\"update_"
+      @"required\":false,\"report_upload_variant\":1}}";
+
+  NSError *error = nil;
+  [self writeSettings:settingsJSON error:&error];
+  NSTimeInterval currentTimestamp = [NSDate timeIntervalSinceReferenceDate];
+  [self.settings cacheSettingsWithGoogleAppID:TestGoogleAppID currentTimestamp:currentTimestamp];
+
+  XCTAssertNil(error, "%@", error);
+  XCTAssertFalse(self.settings.shouldUseNewReportEndpoint);
+}
+
+- (void)testLegacyReportEndpointSettingsWithNonExistentKey {
+  NSString *settingsJSON = @"{\"settings_version\":3,\"cache_duration\":60,\"app\":{\"status\":"
+                              @"\"activated\",\"update_required\":false}}";
+
+  NSError *error = nil;
+  [self writeSettings:settingsJSON error:&error];
+  NSTimeInterval currentTimestamp = [NSDate timeIntervalSinceReferenceDate];
+  [self.settings cacheSettingsWithGoogleAppID:TestGoogleAppID currentTimestamp:currentTimestamp];
+
+  XCTAssertNil(error, "%@", error);
+  XCTAssertFalse(self.settings.shouldUseNewReportEndpoint);
+}
+
+- (void)testLegacyReportEndpointSettingsWithUnknownValue {
+  NSString *newEndpointJSON =
+      @"{\"settings_version\":3,\"cache_duration\":60,\"app\":{\"status\":\"activated\",\"update_"
+      @"required\":false,\"report_upload_variant\":xyz}}";
+
+  NSError *error = nil;
+  [self writeSettings:newEndpointJSON error:&error];
+  NSTimeInterval currentTimestamp = [NSDate timeIntervalSinceReferenceDate];
+  [self.settings cacheSettingsWithGoogleAppID:TestGoogleAppID currentTimestamp:currentTimestamp];
+
+  XCTAssertNil(error, "%@", error);
+  XCTAssertFalse(self.settings.shouldUseNewReportEndpoint);
+}
+
 @end

--- a/Crashlytics/UnitTests/FIRCLSSettingsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSettingsTests.m
@@ -95,6 +95,8 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertEqual(self.settings.logBufferSize, 64 * 1000);
   XCTAssertEqual(self.settings.maxCustomExceptions, 8);
   XCTAssertEqual(self.settings.maxCustomKeys, 64);
+
+  XCTAssertFalse(self.settings.shouldUseNewReportEndpoint);
 }
 
 - (BOOL)writeSettings:(const NSString *)settings error:(NSError **)error {
@@ -382,6 +384,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertEqualObjects(self.settings.fetchedBundleID, nil);
   XCTAssertFalse(self.settings.appNeedsOnboarding);
   XCTAssertEqual(self.settings.errorLogBufferSize, 64 * 1000);
+  XCTAssertFalse(self.settings.shouldUseNewReportEndpoint);
 }
 
 - (void)testCorruptCacheKey {
@@ -449,7 +452,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
 
 - (void)testLegacyReportEndpointSettingsWithNonExistentKey {
   NSString *settingsJSON = @"{\"settings_version\":3,\"cache_duration\":60,\"app\":{\"status\":"
-                              @"\"activated\",\"update_required\":false}}";
+                           @"\"activated\",\"update_required\":false}}";
 
   NSError *error = nil;
   [self writeSettings:settingsJSON error:&error];


### PR DESCRIPTION
Add the ability to read from settings whether crash reports should be upload to legacy endpoint or the GoogleDataTransport endpoint.