### PR TITLE
Fix import path for copybara

### DIFF
--- a/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
+++ b/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
@@ -18,11 +18,11 @@
 
 #import <FirebaseAnalyticsInterop/FIRAnalyticsInterop.h>
 #import <FirebaseCore/FIRApp.h>
+#import <FirebaseCore/FIRAppInternal.h>
 #import <FirebaseCore/FIROptions.h>
 #import <GoogleUtilities/GULSwizzler+Unswizzle.h>
 #import <GoogleUtilities/GULSwizzler.h>
 #import <OCMock/OCMock.h>
-#import "FirebaseCore/Sources/Private/FIRAppInternal.h"
 #import "FirebaseDynamicLinks/Sources/FIRDLRetrievalProcessFactory.h"
 #import "FirebaseDynamicLinks/Sources/FIRDLRetrievalProcessResult+Private.h"
 #import "FirebaseDynamicLinks/Sources/FIRDynamicLink+Private.h"


### PR DESCRIPTION
Imports from other pods should use module import syntax

#no-changelog