### PR TITLE
Cherry-pick #4795 for the release-6.16 branch

### DIFF
--- a/Firestore/Source/API/FSTFirestoreComponent.mm
+++ b/Firestore/Source/API/FSTFirestoreComponent.mm
@@ -99,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
       }
 
       auto executor = Executor::CreateSerial(queue_name.c_str());
-      auto workerQueue = absl::make_unique<AsyncQueue>(std::move(executor));
+      auto workerQueue = AsyncQueue::Create(std::move(executor));
 
       id<FIRAuthInterop> auth = FIR_COMPONENT(FIRAuthInterop, self.app.container);
       auto credentialsProvider = std::make_shared<FirebaseCredentialsProvider>(self.app, auth);

--- a/Firestore/core/src/firebase/firestore/api/firestore.cc
+++ b/Firestore/core/src/firebase/firestore/api/firestore.cc
@@ -62,6 +62,16 @@ Firestore::Firestore(model::DatabaseId database_id,
       extension_{extension} {
 }
 
+Firestore::~Firestore() {
+  std::lock_guard<std::mutex> lock{mutex_};
+
+  // If the client hasn't been configured yet we don't need to create it just
+  // to tear it down.
+  if (!client_) return;
+
+  client_->Terminate();
+}
+
 const std::shared_ptr<FirestoreClient>& Firestore::client() {
   HARD_ASSERT(client_, "Client is not yet configured.");
   return client_;
@@ -133,7 +143,7 @@ void Firestore::Terminate(util::StatusCallback callback) {
   // The client must be initialized to ensure that all subsequent API usage
   // throws an exception.
   EnsureClientConfigured();
-  client_->Terminate(std::move(callback));
+  client_->TerminateAsync(std::move(callback));
 }
 
 void Firestore::WaitForPendingWrites(util::StatusCallback callback) {

--- a/Firestore/core/src/firebase/firestore/api/firestore.h
+++ b/Firestore/core/src/firebase/firestore/api/firestore.h
@@ -60,6 +60,8 @@ class Firestore : public std::enable_shared_from_this<Firestore> {
             std::shared_ptr<util::AsyncQueue> worker_queue,
             void* extension);
 
+  ~Firestore();
+
   const model::DatabaseId& database_id() const {
     return database_id_;
   }

--- a/Firestore/core/src/firebase/firestore/core/firestore_client.h
+++ b/Firestore/core/src/firebase/firestore/core/firestore_client.h
@@ -88,7 +88,13 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
    * Terminates this client, cancels all writes / listeners, and releases all
    * resources.
    */
-  void Terminate(util::StatusCallback callback);
+  void TerminateAsync(util::StatusCallback callback);
+
+  /**
+   * Synchronously terminates this client, cancels all writes / listeners, and
+   * releases all resources.
+   */
+  void Terminate();
 
   /**
    * Passes a callback that is triggered when all the pending writes at the
@@ -182,6 +188,8 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
   void Initialize(const auth::User& user, const api::Settings& settings);
 
   void VerifyNotTerminated();
+
+  void TerminateInternal();
 
   void ScheduleLruGarbageCollection();
 

--- a/Firestore/core/src/firebase/firestore/util/async_queue.h
+++ b/Firestore/core/src/firebase/firestore/util/async_queue.h
@@ -84,12 +84,12 @@ enum class TimerId {
 //
 // A significant portion of `AsyncQueue` interface only exists for test purposes
 // and must *not* be used in regular code.
-class AsyncQueue {
+class AsyncQueue : public std::enable_shared_from_this<AsyncQueue> {
  public:
   using Operation = Executor::Operation;
   using Milliseconds = Executor::Milliseconds;
 
-  explicit AsyncQueue(std::unique_ptr<Executor> executor);
+  static std::shared_ptr<AsyncQueue> Create(std::unique_ptr<Executor> executor);
 
   // Asserts for the caller that it is being invoked as part of an operation on
   // the `AsyncQueue`.
@@ -186,6 +186,8 @@ class AsyncQueue {
   void SkipDelaysForTimerId(TimerId timer_id);
 
  private:
+  explicit AsyncQueue(std::unique_ptr<Executor> executor);
+
   Operation Wrap(const Operation& operation);
 
   // Asserts that the current invocation happens asynchronously on the queue.

--- a/Firestore/core/src/firebase/firestore/util/executor_std.cc
+++ b/Firestore/core/src/firebase/firestore/util/executor_std.cc
@@ -40,7 +40,8 @@ std::string ThreadIdToString(const std::thread::id thread_id) {
 
 // MARK: - ExecutorStd
 
-ExecutorStd::ExecutorStd(int threads) {
+ExecutorStd::ExecutorStd(int threads)
+    : shutting_down_(std::make_shared<std::atomic<bool>>()) {
   HARD_ASSERT(threads > 0);
 
   // Somewhat counter-intuitively, constructor of `std::atomic` assigns the
@@ -49,14 +50,14 @@ ExecutorStd::ExecutorStd(int threads) {
   // See [this thread](https://stackoverflow.com/questions/25609858) for context
   // on the constructor.
   current_id_ = 0;
-  shutting_down_ = false;
+  *shutting_down_ = false;
   for (int i = 0; i < threads; ++i) {
     worker_thread_pool_.emplace_back(&ExecutorStd::PollingThread, this);
   }
 }
 
 ExecutorStd::~ExecutorStd() {
-  shutting_down_ = true;
+  *shutting_down_ = true;
 
   // Make sure the worker threads are not blocked, so that the call to `join`
   // doesn't hang. It's not deterministic which thread will pick up an entry,
@@ -66,7 +67,14 @@ ExecutorStd::~ExecutorStd() {
   }
 
   for (std::thread& thread : worker_thread_pool_) {
-    thread.join();
+    // If the current thread is running this destructor, we can't join the
+    // thread. Instead detach it and rely on PollingThread to notice that
+    // *shutting_down_ is now true.
+    if (std::this_thread::get_id() == thread.get_id()) {
+      thread.detach();
+    } else {
+      thread.join();
+    }
   }
 }
 
@@ -105,7 +113,10 @@ ExecutorStd::Id ExecutorStd::PushOnSchedule(Operation&& operation,
 }
 
 void ExecutorStd::PollingThread() {
-  while (!shutting_down_) {
+  // Keep a local shared_ptr here to ensure that the atomic pointed to by
+  // shutting_down_ remains valid even after the destruction of the executor.
+  std::shared_ptr<std::atomic<bool>> local_shutting_down = shutting_down_;
+  while (!*local_shutting_down) {
     Entry entry = schedule_.PopBlocking();
     if (entry.tagged.operation) {
       entry.tagged.operation();

--- a/Firestore/core/src/firebase/firestore/util/executor_std.h
+++ b/Firestore/core/src/firebase/firestore/util/executor_std.h
@@ -21,6 +21,7 @@
 #include <atomic>
 #include <condition_variable>  // NOLINT(build/c++11)
 #include <deque>
+#include <memory>
 #include <mutex>  // NOLINT(build/c++11)
 #include <string>
 #include <thread>  // NOLINT(build/c++11)
@@ -273,7 +274,7 @@ class ExecutorStd : public Executor {
 
   std::vector<std::thread> worker_thread_pool_;
   // Used to stop the worker thread.
-  std::atomic<bool> shutting_down_{false};
+  std::shared_ptr<std::atomic<bool>> shutting_down_;
 
   std::atomic<Id> current_id_{0};
 };

--- a/Firestore/core/src/firebase/firestore/util/filesystem.h
+++ b/Firestore/core/src/firebase/firestore/util/filesystem.h
@@ -37,6 +37,8 @@ class StatusOr;
  */
 class Filesystem {
  public:
+  virtual ~Filesystem() = default;
+
   Filesystem(const Filesystem&) = delete;
   Filesystem& operator=(const Filesystem&) = delete;
 

--- a/Firestore/core/test/firebase/firestore/testutil/async_testing.cc
+++ b/Firestore/core/test/firebase/firestore/testutil/async_testing.cc
@@ -37,7 +37,7 @@ std::unique_ptr<util::Executor> ExecutorForTesting(const char* name) {
 }
 
 std::shared_ptr<util::AsyncQueue> AsyncQueueForTesting() {
-  return std::make_shared<AsyncQueue>(ExecutorForTesting("worker"));
+  return AsyncQueue::Create(ExecutorForTesting("worker"));
 }
 
 // MARK: - Expectation

--- a/Firestore/core/test/firebase/firestore/util/async_queue_test.h
+++ b/Firestore/core/test/firebase/firestore/util/async_queue_test.h
@@ -34,10 +34,10 @@ class AsyncQueueTest : public ::testing::TestWithParam<FactoryFunc>,
                        public testutil::AsyncTest {
  public:
   // `GetParam()` must return a factory function.
-  AsyncQueueTest() : queue{GetParam()()} {
+  AsyncQueueTest() : queue{AsyncQueue::Create(GetParam()())} {
   }
 
-  AsyncQueue queue;
+  std::shared_ptr<AsyncQueue> queue;
 };
 
 }  // namespace util


### PR DESCRIPTION
Fixes for issues discovered in the Unity desktop build (#4795)

Ensure that Firestore properly shuts down when the Unity AppDomain is unloaded. Improper shutdown manifested as a crash the next time Firestore was used because the LevelDB database files were still locked by the prior instance.

AppDomain unload differs from typical iOS termination because we want Dispose to be synchronous so that we signal shutdown is complete by the time Dispose returns. Without this, there's a race between shutdown in the current domain and startup in the next domain. This poses a problem though because disposers are run on the main thread, and callbacks from Firestore's async operations also typically run on the main thread. This means that by default there's no great way to implement Dispose without deadlock.

This change makes it such that the `api::Firestore` destructor now synchronously terminates the instance. There are a few moving parts to making this work:

  * The AsyncQueue now extends `std::enable_shared_from_this` captures a `shared_ptr` to itself whenever it enqueues an asynchronous operation. This ensures that if an operation is enqueued and the user doesn't wait for it to complete, the queue won't deallocate itself before the operation completes.

  * Makes ExecutorStd handle the case where its destructor might be running on a thread that it owns. This can now happen if an AsyncQueue Operation is the last thing holding a reference to itself.

  * Adds a new, synchronous FirestoreClient::Terminate method that does not have a callback. This is used to avoid the deadlock inherent with cross-queue notifications when the caller may be trying to block synchronously in the queue to which the notification would go.

  * Changes scheduled operations to hold their their references to FirestoreClient via `weak_ptr`, to avoid accidentally preserving the life of the FirestoreClient past Terminate.

  * Makes the api::Firestore destructor call a new synchronous Terminate method.