### PR TITLE
Revert "Use secure encoding for messaging's pending topics (#4826)"

### DIFF
--- a/Firebase/Messaging/CHANGELOG.md
+++ b/Firebase/Messaging/CHANGELOG.md
@@ -2,7 +2,6 @@
 - [added] Firebase Pod support for watchOS: `pod 'Firebase/Messaging'` in addition to `pod 'FirebaseMessaging'`. (#4807)
 - [fixed] Fix FIRMessagingExtensionHelper crash in unit tests when `attachment == nil`. (#4689)
 - [fixed] Fix FIRMessagingRmqManager crash when database is removed. This only happens when device has a corrupted database file. (#4771)
-- [fixed] Use secure encoding for messaging's pending topics objects. (#3686)
 
 # 2020-01 -- v 4.2.0
 - [added] Added watchOS support for Firebase Messaging. This enables FCM push notification function on watch only app or independent watch app. (#4016)

--- a/Firebase/Messaging/FIRMessagingPendingTopicsList.h
+++ b/Firebase/Messaging/FIRMessagingPendingTopicsList.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  topics is unique, as it doesn't make sense to apply the same action to the same topic
  *  repeatedly; the result would be the same as the first time.
  */
-@interface FIRMessagingTopicBatch : NSObject <NSSecureCoding>
+@interface FIRMessagingTopicBatch : NSObject <NSCoding>
 
 @property(nonatomic, readonly, assign) FIRMessagingTopicAction action;
 @property(nonatomic, readonly, copy) NSMutableSet <NSString *> *topics;
@@ -101,7 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @see FIRMessagingPendingTopicsListDelegate
  */
-@interface FIRMessagingPendingTopicsList : NSObject <NSSecureCoding>
+@interface FIRMessagingPendingTopicsList : NSObject <NSCoding>
 
 @property(nonatomic, weak) NSObject <FIRMessagingPendingTopicsListDelegate> *delegate;
 

--- a/Firebase/Messaging/FIRMessagingPubSub.m
+++ b/Firebase/Messaging/FIRMessagingPubSub.m
@@ -183,14 +183,10 @@ static NSString *const kPendingSubscriptionsListKey =
 
 - (void)archivePendingTopicsList:(FIRMessagingPendingTopicsList *)topicsList {
   GULUserDefaults *defaults = [GULUserDefaults standardUserDefaults];
-
-  NSData *pendingData;
-  if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *)) {
-    NSError *error;
-    pendingData = [NSKeyedArchiver archivedDataWithRootObject:topicsList requiringSecureCoding:YES error:&error];
-  } else {
-    pendingData = [NSKeyedArchiver archivedDataWithRootObject:topicsList];
-  }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  NSData *pendingData = [NSKeyedArchiver archivedDataWithRootObject:topicsList];
+#pragma clang diagnostic pop
   [defaults setObject:pendingData forKey:kPendingSubscriptionsListKey];
   [defaults synchronize];
 }
@@ -199,17 +195,16 @@ static NSString *const kPendingSubscriptionsListKey =
   GULUserDefaults *defaults = [GULUserDefaults standardUserDefaults];
   NSData *pendingData = [defaults objectForKey:kPendingSubscriptionsListKey];
   FIRMessagingPendingTopicsList *subscriptions;
-  if (pendingData) {
-    if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *)) {
-      NSError *error;
-      subscriptions = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSData class] fromData:pendingData error:&error];
-    } else {
-      @try {
-        subscriptions = [NSKeyedUnarchiver unarchiveObjectWithData:pendingData];
-      } @catch (NSException *exception) {
-        // Nothing we can do, just continue as if we don't have pending subscriptions
-      }
+  @try {
+    if (pendingData) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+      subscriptions = [NSKeyedUnarchiver unarchiveObjectWithData:pendingData];
+#pragma clang diagnostic pop
     }
+  } @catch (NSException *exception) {
+    // Nothing we can do, just continue as if we don't have pending subscriptions
+  } @finally {
     if (subscriptions) {
       self.pendingTopicUpdates = subscriptions;
     } else {


### PR DESCRIPTION
This reverts commit b7fec9e2b82ef91fe4a2422d2f409cfd58c9b4fe.

Revert #4826 out of M64. It should have more testing before being merged.