### PR TITLE
Actually don't run zip on markdown changes.

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -6,7 +6,7 @@ on:
     - 'ZipBuilder/**'
     - '.github/workflows/zip.yml'
     # Don't run based on any markdown only changes.
-    - '!ZipBuilder/**/*.md'
+    - '!ZipBuilder/*.md'
   schedule:
     # Run every day at midnight(PST) - cron uses UTC times
     - cron:  '0 8 * * *'


### PR DESCRIPTION
The nested folder regex did not work as expected.

#no-changelog