### PR TITLE
Provide cleaner temporary directories.

### DIFF
--- a/ZipBuilder/Sources/ZipBuilder/FileManager+Utils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FileManager+Utils.swift
@@ -120,7 +120,7 @@ extension FileManager {
 
     // Organize all temporary directories into a "ZipRelease" directory.
     let unique = FileManager.unique
-    let zipDir = tempDir.appendingPathComponent("ZipRelease" + unique, isDirectory: true)
+    let zipDir = tempDir.appendingPathComponent("ZipRelease/" + unique, isDirectory: true)
     return zipDir.appendingPathComponent(name, isDirectory: true)
   }
 


### PR DESCRIPTION
This will make all temp directories sit under the `ZipRelease` directory instead of being in the temp directory itself with a long name.

#no-changelog