### PR TITLE
Fix bits.h when compiled by MSVC after including <ciso646> (#4836)

### DIFF
--- a/Firestore/core/src/firebase/firestore/util/bits.h
+++ b/Firestore/core/src/firebase/firestore/util/bits.h
@@ -24,6 +24,24 @@
 
 #include <cstdint>
 
+#if _MSC_VER
+// The Microsoft implementation of iso646.h defines alternative operator names
+// as macros and this interferes with the inline assembly, below, which uses the
+// `and` and `xor` instructions. Defining these as macros is conforming behavior
+// for C but not C++, where these are keywords.
+//
+// Unfortunately, fixing this by undefining the macros can't be enabled
+// everywhere because other compilers (e.g. Clang) specifically prevent the use
+// of these keywords as macro names.
+#ifdef and
+#undef and
+#endif
+
+#ifdef xor
+#undef xor
+#endif
+#endif  // _MSC_VER
+
 namespace firebase {
 namespace firestore {
 namespace util {


### PR DESCRIPTION
This is a cherry-pick of #4836 for release-6.17.0.

This fixes builds on 32-bit Windows in google3 after cl/291012718, which added `#include <ciso646>` to `absl/base/options.h`.

This has no effect on any Apple platform so it doesn't warrant a respin of any iOS release candidates.