### PR TITLE
Map the read values from user key value, error and log .clsrecords into the Report nanopb model

### DIFF
--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
@@ -288,7 +288,6 @@
   NSMutableDictionary<NSString *, NSString *> *kvs = [self.userKeyValues mutableCopy];
   kvs[@"nserror-domain"] = error.domain;
   kvs[@"nserror-code"] = [NSString stringWithFormat:@"%li", (long)error.code];
-  ;
 
   return kvs;
 }
@@ -407,7 +406,7 @@
   }
 
   // Add crash event
-  if (numberOfEvents > 0) {
+  if ([self hasCrashed]) {
     events[numberOfEvents - 1] = [self protoEventForCrash];
   }
 


### PR DESCRIPTION
This is a follow up to: https://github.com/firebase/firebase-ios-sdk/pull/4793

1. Map the read values from user key value, error and log .clsrecords into the Report nanopb models
2. Add TODOs to track potential logic that we have to move from protobuilder into the SDK

The next related PR will be to add unit tests for protobuilder logic that has been moved into the SDK. 