### PR TITLE
Drop Firestore's Podfile dependency on Firebase

### DIFF
--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -56,7 +56,7 @@ end
 # required.
 def configure_local_pods()
   # Firestore is always local; that's what's under development here.
-  pod 'FirebaseFirestore', :path => '../../'
+  pod 'FirebaseFirestore', :path => '../..'
   pod 'GoogleUtilities', :path => '../..'
 
   # FirebaseCore must always be a local pod so that CI builds that make changes
@@ -114,11 +114,6 @@ end
 if is_platform(:ios)
   target 'Firestore_Example_iOS' do
     platform :ios, '8.0'
-
-    # The next line is the forcing function for the Firebase pod. The Firebase
-    # version's subspecs should depend on the component versions in their
-    # corresponding podspecs.
-    pod 'Firebase/CoreOnly', '6.16.0'
 
     configure_local_pods()
 

--- a/Firestore/Swift/Tests/API/BasicCompileTests.swift
+++ b/Firestore/Swift/Tests/API/BasicCompileTests.swift
@@ -20,14 +20,7 @@
 import Foundation
 import XCTest
 
-// The Firebase pod is only available on iOS. On other platforms, import
-// Firestore directly and disable any tests that inspect types at the Firebase
-// level.
-#if os(iOS)
-  import Firebase
-#else
-  import FirebaseFirestore
-#endif
+import FirebaseFirestore
 
 class BasicCompileTests: XCTestCase {
   func testCompiled() {
@@ -442,15 +435,7 @@ func types() {
   let _: Firestore
   let _: FirestoreSettings
   let _: GeoPoint
-  #if os(iOS)
-    let _: Firebase.GeoPoint
-  #endif
-  let _: FirebaseFirestore.GeoPoint
   let _: Timestamp
-  #if os(iOS)
-    let _: Firebase.Timestamp
-  #endif
-  let _: FirebaseFirestore.Timestamp
   let _: ListenerRegistration
   let _: Query
   let _: QuerySnapshot


### PR DESCRIPTION
This makes it possible to build and test on a release branch before the
Firebase pod is released.