### PR TITLE
Drop support for building Firestore with Xcode 8

### DIFF
--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -35,15 +35,6 @@ def use_local_sources()
   return ENV.has_key?('USE_LOCAL_SOURCES') || ENV['TRAVIS_PULL_REQUEST'] == 'false'
 end
 
-def xcode_major_version()
-  version = `xcodebuild -version`
-  if version =~ /^Xcode\s*(\d+)\./
-    return $1.to_i
-  else
-    raise "Could not find Xcode version in '$version'"
-  end
-end
-
 # Adds a `pod name, :path => ../..` declaration to use local sources if the
 # Podfile has been configured to operate that way.
 def maybe_local_pod(name)
@@ -68,26 +59,10 @@ def configure_local_pods()
   maybe_local_pod 'FirebaseAuth'
   maybe_local_pod 'FirebaseAuthInterop'
 
-  if xcode_major_version() >= 9
-    # Firestore still compiles with Xcode 8 to help verify general conformance
-    # with C++11 by using an older compiler that doesn't have as many
-    # extensions from later versions of the language. However, Firebase as a
-    # whole does not support this environment and @available checks in
-    # GoogleDataTransport would otherwise break this build.
-    #
-    # Firestore doesn't depend on GoogleDataTransport directly--it comes in as
-    # a dependency of FirebaseCoreDiagnostics. Luckily, FirebaseCore does not
-    # strongly depend on this, so we can edit the dependency out in the podspec
-    # and then avoid adding those dependencies here to prevent CocoaPods from
-    # importing it.
-    #
-    # This list should include the transitive closure of all dependencies of
-    # FirebaseCoreDiagnostics, except GoogleUtilities which we otherwise need.
-    maybe_local_pod 'FirebaseCoreDiagnostics'
-    maybe_local_pod 'FirebaseCoreDiagnosticsInterop'
-    maybe_local_pod 'GoogleDataTransport'
-    maybe_local_pod 'GoogleDataTransportCCTSupport'
-  end
+  maybe_local_pod 'FirebaseCoreDiagnostics'
+  maybe_local_pod 'FirebaseCoreDiagnosticsInterop'
+  maybe_local_pod 'GoogleDataTransport'
+  maybe_local_pod 'GoogleDataTransportCCTSupport'
 end
 
 # Reads the value of the PLATFORM environment variable, converts it to the

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -264,25 +264,12 @@ case "$product-$platform-$method" in
     "${firestore_emulator}" start
     trap '"${firestore_emulator}" stop' ERR EXIT
 
-    if [[ "$xcode_major" -lt 9 ]]; then
-      # When building and testing for Xcode 8, only test unit tests.
-      RunXcodebuild \
-          -workspace 'Firestore/Example/Firestore.xcworkspace' \
-          -scheme "Firestore_Tests_$platform" \
-          "${xcb_flags[@]}" \
-          build \
-          test
-
-    else
-      # IntegrationTests run all the tests, including Swift tests, which
-      # require Swift 4.0 and Xcode 9+.
-      RunXcodebuild \
-          -workspace 'Firestore/Example/Firestore.xcworkspace' \
-          -scheme "Firestore_IntegrationTests_$platform" \
-          "${xcb_flags[@]}" \
-          build \
-          test
-    fi
+    RunXcodebuild \
+        -workspace 'Firestore/Example/Firestore.xcworkspace' \
+        -scheme "Firestore_IntegrationTests_$platform" \
+        "${xcb_flags[@]}" \
+        build \
+        test
     ;;
 
   Firestore-macOS-cmake | Firestore-Linux-cmake)

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -103,18 +103,6 @@ if [[ ! -z "${QUICKSTART:-}" ]]; then
   scripts/setup_quickstart.sh "$QUICKSTART"
 fi
 
-system=$(uname -s)
-case "$system" in
-  Darwin)
-    xcode_version=$(xcodebuild -version | head -n 1)
-    xcode_version="${xcode_version/Xcode /}"
-    xcode_major="${xcode_version/.*/}"
-    ;;
-  *)
-    xcode_major="0"
-    ;;
-esac
-
 case "$project-$platform-$method" in
 
   FirebasePod-iOS-xcodebuild)
@@ -156,18 +144,6 @@ case "$project-$platform-$method" in
     ;;
 
   Firestore-*-xcodebuild | Firestore-*-fuzz)
-    if [[ $xcode_major -lt 9 ]]; then
-      # Firestore still compiles with Xcode 8 to help verify general
-      # conformance with C++11 by using an older compiler that doesn't have as
-      # many extensions from later versions of the language. However, Firebase
-      # as a whole does not support this environment and @available checks in
-      # GoogleDataTransport would otherwise break this build.
-      #
-      # This drops the dependency that adds GoogleDataTransport into
-      # Firestore's dependencies.
-      sed -i.bak "/s.dependency 'FirebaseCoreDiagnostics'/d" FirebaseCore.podspec
-    fi
-
     gem install xcpretty
 
     # The Firestore Podfile is multi-platform by default, but this doesn't work


### PR DESCRIPTION
This hasn't worked in a long time and is just clutter at this point.