### PR TITLE
Upgrade Firestore emulator to 1.10.4

### DIFF
--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -27,6 +27,19 @@ on:
     - 'CMakeLists.txt'
     - 'cmake/**'
 
+    # Build scripts
+    # Note that this doesn't include check scripts because changing those will
+    # already trigger the check workflow.
+    - 'scripts/binary_to_array.py'
+    - 'scripts/build.sh'
+    - 'scripts/install_prereqs.sh'
+    - 'scripts/localize_podfile.swift'
+    - 'scripts/pod_lib_lint.rb'
+    - 'scripts/run_firestore_emulator.sh'
+    - 'scripts/setup_*'
+    - 'scripts/sync_project.rb'
+    - 'scripts/test_quickstart.sh'
+
     # This workflow
     - '.github/workflows/firestore.yml'
 

--- a/scripts/if_changed.sh
+++ b/scripts/if_changed.sh
@@ -115,11 +115,12 @@ else
 
     Firestore-xcodebuild|Firestore-pod-lib-lint)
       check_changes '^(Firestore|FirebaseFirestore.podspec|FirebaseFirestoreSwift.podspec|'\
-'GoogleUtilities)'
+'GoogleUtilities|scripts/run_firestore_emulator.sh)'
       ;;
 
     Firestore-cmake)
-      check_changes '^(Firestore/(core|third_party)|cmake|FirebaseCore|GoogleUtilities)'
+      check_changes '^(Firestore/(core|third_party)|cmake|FirebaseCore|GoogleUtilities|)'\
+'scripts/run_firestore_emulator.sh)'
       ;;
 
     GoogleDataTransport-*)

--- a/scripts/run_firestore_emulator.sh
+++ b/scripts/run_firestore_emulator.sh
@@ -20,7 +20,7 @@
 
 set -euo pipefail
 
-VERSION='1.10.2'
+VERSION='1.10.4'
 FILENAME="cloud-firestore-emulator-v${VERSION}.jar"
 URL="https://storage.googleapis.com/firebase-preview-drop/emulator/${FILENAME}"
 

--- a/scripts/run_firestore_emulator.sh
+++ b/scripts/run_firestore_emulator.sh
@@ -84,8 +84,11 @@ function stop() {
   fi
 }
 
-command="${1:-run}"
-shift
+command=run
+if [[ $# -gt 0 ]]; then
+  command="$1"
+  shift
+fi
 
 case "${command}" in
   run)


### PR DESCRIPTION
The emulator now sends resume tokens, which exercises more of the system.
In particular, this means that resuming queries now uses the index-free
query engine.