### PR TITLE
Set mutable data ref lengths, otherwise iOS will 0 out the buffer

### DIFF
--- a/Firebase/CoreDiagnostics/CHANGELOG.md
+++ b/Firebase/CoreDiagnostics/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.2.1
+- Fixed a bug that would manifest if a proto ended up being > 16,320 bytes.
+
+# v1.2.0
+- Added basic watchOS support.
+
 # v1.1.2
 - Switch the backend for diagnostics to FLL from CCT.
 

--- a/Firebase/CoreDiagnostics/FIRCDLibrary/FIRCoreDiagnostics.m
+++ b/Firebase/CoreDiagnostics/FIRCDLibrary/FIRCoreDiagnostics.m
@@ -125,6 +125,7 @@ NSString *const kFIRCoreDiagnosticsHeartbeatDateFileName = @"FIREBASE_DIAGNOSTIC
   // Encode a 2nd time to actually get the bytes from it.
   size_t bufferSize = sizestream.bytes_written;
   CFMutableDataRef dataRef = CFDataCreateMutable(CFAllocatorGetDefault(), bufferSize);
+  CFDataSetLength(dataRef, bufferSize);
   pb_ostream_t ostream = pb_ostream_from_buffer((void *)CFDataGetBytePtr(dataRef), bufferSize);
   if (!pb_encode(&ostream, logs_proto_mobilesdk_ios_ICoreConfiguration_fields, &_config)) {
     GDTCORLogError(GDTCORMCETransportBytesError, @"Error in nanopb encoding for bytes: %s",

--- a/GoogleDataTransportCCTSupport/CHANGELOG.md
+++ b/GoogleDataTransportCCTSupport/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.4.1
+- Fixed a bug that would manifest if a proto ended up being > 16,320 bytes.
+
 # v1.4.0
 - Added the CSH backend and consolidated the CCT, FLL, and CSH backends.
 

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
@@ -63,7 +63,6 @@ NSData *_Nullable GDTCCTEncodeBatchedLogRequest(gdt_cct_BatchedLogRequest *batch
     GDTCORLogError(GDTCORMCEGeneralError, @"Error in nanopb encoding for bytes: %s",
                    PB_GET_ERROR(&ostream));
   }
-  CFDataSetLength(dataRef, ostream.bytes_written);
 
   return CFBridgingRelease(dataRef);
 }

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
@@ -57,6 +57,7 @@ NSData *_Nullable GDTCCTEncodeBatchedLogRequest(gdt_cct_BatchedLogRequest *batch
   // Encode a 2nd time to actually get the bytes from it.
   size_t bufferSize = sizestream.bytes_written;
   CFMutableDataRef dataRef = CFDataCreateMutable(CFAllocatorGetDefault(), bufferSize);
+  CFDataSetLength(dataRef, bufferSize);
   pb_ostream_t ostream = pb_ostream_from_buffer((void *)CFDataGetBytePtr(dataRef), bufferSize);
   if (!pb_encode(&ostream, gdt_cct_BatchedLogRequest_fields, batchedLogRequest)) {
     GDTCORLogError(GDTCORMCEGeneralError, @"Error in nanopb encoding for bytes: %s",

--- a/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/GDTCCTNanopbHelpersTest.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/GDTCCTNanopbHelpersTest.m
@@ -138,8 +138,9 @@
     @"message-40043840.dat", @"message-40657984.dat"
   ];
   NSMutableSet *storedEvents = [[NSMutableSet alloc] init];
-  // 250 messages results in a total size of 16337 which is > 16320, the apparent OS limit.
-  for (int i = 0; i < 250; i++) {  // Changing to 249 would've caused test to pass previously.
+  // 250 messages results in a total size of 16337 which is > 16320, the apparent OS limit. Changing
+  // to 249 would've caused test to pass previously.
+  for (int i = 0; i < 250; i++) {
     NSString *dataFile = testData[arc4random_uniform((uint32_t)testData.count)];
     NSData *messageData = [NSData dataWithContentsOfURL:[testBundle URLForResource:dataFile
                                                                      withExtension:nil]];

--- a/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/GDTCCTNanopbHelpersTest.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/GDTCCTNanopbHelpersTest.m
@@ -130,4 +130,44 @@
   pb_release(gdt_cct_BatchedLogRequest_fields, &decodedBatch);
 }
 
+/** Tests that creating a message above the apparent threshold of 16320 bytes works. */
+- (void)testEncodingProtoAboveDefaultOSThreshold {
+  NSBundle *testBundle = [NSBundle bundleForClass:[self class]];
+  NSArray *testData = @[
+    @"message-32347456.dat", @"message-35458880.dat", @"message-39882816.dat",
+    @"message-40043840.dat", @"message-40657984.dat"
+  ];
+  NSMutableSet *storedEvents = [[NSMutableSet alloc] init];
+  // 250 messages results in a total size of 16337 which is > 16320, the apparent OS limit.
+  for (int i = 0; i < 250; i++) {  // Changing to 249 would've caused test to pass previously.
+    NSString *dataFile = testData[arc4random_uniform((uint32_t)testData.count)];
+    NSData *messageData = [NSData dataWithContentsOfURL:[testBundle URLForResource:dataFile
+                                                                     withExtension:nil]];
+    XCTAssertNotNil(messageData);
+    NSString *cachePath = NSTemporaryDirectory();
+    NSString *filePath = [cachePath
+        stringByAppendingPathComponent:[NSString stringWithFormat:@"test-%lf.txt",
+                                                                  CFAbsoluteTimeGetCurrent()]];
+    [messageData writeToFile:filePath atomically:YES];
+    NSURL *fileURL = [NSURL fileURLWithPath:filePath];
+    XCTAssertNotNil(fileURL);
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:filePath]);
+    [storedEvents addObject:[_generator generateStoredEvent:GDTCOREventQosDefault fileURL:fileURL]];
+  }
+  gdt_cct_BatchedLogRequest batch = gdt_cct_BatchedLogRequest_init_default;
+  XCTAssertNoThrow((batch = GDTCCTConstructBatchedLogRequest(@{@"1018" : storedEvents})));
+  NSData *data = GDTCCTEncodeBatchedLogRequest(&batch);
+  XCTAssertNotNil(data);
+  const char *bytes = (const char *)[data bytes];
+  BOOL allZeroes = YES;
+  for (int i = 0; i < data.length; i++) {
+    char aByte = bytes[i];
+    if (aByte != '\0') {
+      allZeroes = NO;
+    }
+  }
+  XCTAssertFalse(allZeroes);
+  pb_release(gdt_cct_BatchedLogRequest_fields, &batch);
+}
+
 @end

--- a/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/TestServer/GDTCCTTestServer.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/TestServer/GDTCCTTestServer.m
@@ -93,11 +93,11 @@
   // Encode a 2nd time to actually get the bytes from it.
   size_t bufferSize = sizestream.bytes_written;
   CFMutableDataRef dataRef = CFDataCreateMutable(CFAllocatorGetDefault(), bufferSize);
+  CFDataSetLength(dataRef, bufferSize);
   pb_ostream_t ostream = pb_ostream_from_buffer((void *)CFDataGetBytePtr(dataRef), bufferSize);
   if (!pb_encode(&sizestream, gdt_cct_LogResponse_fields, &logResponse)) {
     GDTCORAssert(NO, @"Error in nanopb encoding for bytes: %s", PB_GET_ERROR(&ostream));
   }
-  CFDataSetLength(dataRef, ostream.bytes_written);
   pb_release(gdt_cct_LogResponse_fields, &logResponse);
   return CFBridgingRelease(dataRef);
 }


### PR DESCRIPTION
iOS seems to do this when the buffer becomes > 16320 bytes.