### PR TITLE
Always retry pod lib lint

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Build and test
-      run: third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=${{ matrix.target }}
+      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=${{ matrix.target }}
 
   core-cron-only:
     runs-on: macos-latest

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Build and test
-      run: scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=${{ matrix.target }}
+      run: third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=${{ matrix.target }}
 
   core-cron-only:
     runs-on: macos-latest
@@ -40,4 +40,4 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: PodLibLint Core Cron
-      run: scripts/third_party/travis/retry.sh ./scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
+      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/dynamiclinks.yml
+++ b/.github/workflows/dynamiclinks.yml
@@ -10,7 +10,7 @@ on:
     - cron:  '0 7 * * *'
 
 jobs:
-  dynamiclinks:
+  pod_lib_lint:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/dynamiclinks.yml
+++ b/.github/workflows/dynamiclinks.yml
@@ -15,6 +15,24 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
+      run: scripts/setup_bundler.sh
     - name: FirebaseDynamicLinks
-      run: ./scripts/pod_lib_lint.rb FirebaseDynamicLinks.podspec
+      run: third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseDynamicLinks.podspec
+
+  dynamiclinks-cron-only:
+    runs-on: macos-latest
+    if: github.event_name == 'schedule'
+    strategy:
+      matrix:
+        target: [ios, tvos, macos]
+        flags: [
+          '--use-modular-headers',
+          '--use-libraries'
+        ]
+    needs: pod_lib_lint
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: PodLibLint Storage Cron
+      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseDynamicLinks.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/dynamiclinks.yml
+++ b/.github/workflows/dynamiclinks.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: FirebaseDynamicLinks
-      run: third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseDynamicLinks.podspec
+      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseDynamicLinks.podspec
 
   dynamiclinks-cron-only:
     runs-on: macos-latest

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -145,6 +145,6 @@ jobs:
 
     - name: Pod lib lint
       run: |
-        scripts/pod_lib_lint.rb FirebaseFirestore.podspec \
+        third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseFirestore.podspec \
             --platforms=ios \
             --allow-warnings

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -145,6 +145,6 @@ jobs:
 
     - name: Pod lib lint
       run: |
-        third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseFirestore.podspec \
+        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseFirestore.podspec \
             --platforms=ios \
             --allow-warnings

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -15,17 +15,42 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
+      run: scripts/setup_bundler.sh
     - name: Install Secret GoogleService-Info.plist
       env:
          plist_secret: ${{ secrets.StoragePlistSecret }}
       run: ./scripts/decrypt_gha_secret.sh scripts/gha-encrypted/storage-db-plist.gpg \
           FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist "$plist_secret"
     - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh Storage all
-    - name: PodLibLint iOS
-      run: ./scripts/pod_lib_lint.rb FirebaseStorage.podspec --skip-tests --platforms=ios
-    - name: PodLibLint macOS
-      run: ./scripts/pod_lib_lint.rb FirebaseStorage.podspec --skip-tests --platforms=macos
-    - name: PodLibLint tvOS
-      run: ./scripts/pod_lib_lint.rb FirebaseStorage.podspec --skip-tests --platforms=tvos
+      run: scripts/third_party/travis/retry.sh scripts/build.sh Storage all
+
+  pod_lib_lint:
+    runs-on: macOS-latest
+
+    strategy:
+      matrix:
+        target: [ios, tvos, macos]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Build and test
+      run: third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorage.podspec --skip-tests --platforms=${{ matrix.target }}
+
+  core-cron-only:
+    runs-on: macos-latest
+    if: github.event_name == 'schedule'
+    strategy:
+      matrix:
+        target: [ios, tvos, macos]
+        flags: [
+          '--skip-tests --use-modular-headers',
+          '--skip-tests --use-libraries'
+        ]
+    needs: pod_lib_lint
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: PodLibLint Storage Cron
+      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorage.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -35,9 +35,9 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Build and test
-      run: third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorage.podspec --skip-tests --platforms=${{ matrix.target }}
+      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorage.podspec --skip-tests --platforms=${{ matrix.target }}
 
-  core-cron-only:
+  storage-cron-only:
     runs-on: macos-latest
     if: github.event_name == 'schedule'
     strategy:


### PR DESCRIPTION
Use travis_retry to avoid failures on iOS simulator flakes

Add storage and dynamic links cron job tests for `--use-libraries` and `--use-modular-headers`

cc: @schmidt-sebastian @wilhuff @dmandar 

#no-changelog