### PR TITLE
Prep for forward declarations

### DIFF
--- a/Firestore/Source/API/FIRDocumentReference.mm
+++ b/Firestore/Source/API/FIRDocumentReference.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Source/API/FIRDocumentReference.mm
+++ b/Firestore/Source/API/FIRDocumentReference.mm
@@ -45,6 +45,7 @@ namespace util = firebase::firestore::util;
 using firebase::firestore::api::CollectionReference;
 using firebase::firestore::api::DocumentReference;
 using firebase::firestore::api::DocumentSnapshot;
+using firebase::firestore::api::DocumentSnapshotListener;
 using firebase::firestore::api::Firestore;
 using firebase::firestore::api::ListenerRegistration;
 using firebase::firestore::api::Source;
@@ -213,7 +214,7 @@ NS_ASSUME_NONNULL_BEGIN
   return [[FSTListenerRegistration alloc] initWithRegistration:std::move(result)];
 }
 
-- (DocumentSnapshot::Listener)wrapDocumentSnapshotBlock:(FIRDocumentSnapshotBlock)block {
+- (DocumentSnapshotListener)wrapDocumentSnapshotBlock:(FIRDocumentSnapshotBlock)block {
   class Converter : public EventListener<DocumentSnapshot> {
    public:
     explicit Converter(FIRDocumentSnapshotBlock block) : block_(block) {

--- a/Firestore/Source/API/FIRQuery.mm
+++ b/Firestore/Source/API/FIRQuery.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/Source/API/FIRQuery.mm
+++ b/Firestore/Source/API/FIRQuery.mm
@@ -36,6 +36,7 @@
 
 #include "Firestore/core/src/firebase/firestore/api/query_core.h"
 #include "Firestore/core/src/firebase/firestore/api/query_listener_registration.h"
+#include "Firestore/core/src/firebase/firestore/api/query_snapshot.h"
 #include "Firestore/core/src/firebase/firestore/core/bound.h"
 #include "Firestore/core/src/firebase/firestore/core/direction.h"
 #include "Firestore/core/src/firebase/firestore/core/filter.h"
@@ -59,6 +60,7 @@ using firebase::firestore::api::ListenerRegistration;
 using firebase::firestore::api::Query;
 using firebase::firestore::api::QueryListenerRegistration;
 using firebase::firestore::api::QuerySnapshot;
+using firebase::firestore::api::QuerySnapshotListener;
 using firebase::firestore::api::SnapshotMetadata;
 using firebase::firestore::api::Source;
 using firebase::firestore::core::AsyncEventListener;
@@ -446,7 +448,7 @@ int32_t SaturatedLimitValue(NSInteger limit) {
   return [self.firestore.dataConverter parsedQueryValue:value allowArrays:allowArrays];
 }
 
-- (QuerySnapshot::Listener)wrapQuerySnapshotBlock:(FIRQuerySnapshotBlock)block {
+- (QuerySnapshotListener)wrapQuerySnapshotBlock:(FIRQuerySnapshotBlock)block {
   class Converter : public EventListener<QuerySnapshot> {
    public:
     explicit Converter(FIRQuerySnapshotBlock block) : block_(block) {

--- a/Firestore/core/src/firebase/firestore/api/document_reference.cc
+++ b/Firestore/core/src/firebase/firestore/api/document_reference.cc
@@ -110,7 +110,7 @@ void DocumentReference::DeleteDocument(util::StatusCallback callback) {
 }
 
 void DocumentReference::GetDocument(Source source,
-                                    DocumentSnapshot::Listener&& callback) {
+                                    DocumentSnapshotListener&& callback) {
   if (source == Source::Cache) {
     firestore_->client()->GetDocumentFromLocalCache(*this, std::move(callback));
     return;
@@ -123,7 +123,7 @@ void DocumentReference::GetDocument(Source source,
 
   class ListenOnce : public EventListener<DocumentSnapshot> {
    public:
-    ListenOnce(Source source, DocumentSnapshot::Listener&& listener)
+    ListenOnce(Source source, DocumentSnapshotListener&& listener)
         : source_(source), listener_(std::move(listener)) {
     }
 
@@ -173,7 +173,7 @@ void DocumentReference::GetDocument(Source source,
 
    private:
     Source source_;
-    DocumentSnapshot::Listener listener_;
+    DocumentSnapshotListener listener_;
 
     std::promise<std::unique_ptr<ListenerRegistration>> registration_promise_;
   };
@@ -187,12 +187,12 @@ void DocumentReference::GetDocument(Source source,
 }
 
 std::unique_ptr<ListenerRegistration> DocumentReference::AddSnapshotListener(
-    ListenOptions options, DocumentSnapshot::Listener&& user_listener) {
+    ListenOptions options, DocumentSnapshotListener&& user_listener) {
   // Convert from ViewSnapshots to DocumentSnapshots.
   class Converter : public EventListener<ViewSnapshot> {
    public:
     Converter(DocumentReference* parent,
-              DocumentSnapshot::Listener&& user_listener)
+              DocumentSnapshotListener&& user_listener)
         : firestore_(parent->firestore_),
           key_(parent->key_),
           user_listener_(std::move(user_listener)) {
@@ -224,7 +224,7 @@ std::unique_ptr<ListenerRegistration> DocumentReference::AddSnapshotListener(
    private:
     std::shared_ptr<Firestore> firestore_;
     DocumentKey key_;
-    DocumentSnapshot::Listener user_listener_;
+    DocumentSnapshotListener user_listener_;
   };
   auto view_listener =
       absl::make_unique<Converter>(this, std::move(user_listener));

--- a/Firestore/core/src/firebase/firestore/api/document_reference.cc
+++ b/Firestore/core/src/firebase/firestore/api/document_reference.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/firebase/firestore/api/document_reference.h
+++ b/Firestore/core/src/firebase/firestore/api/document_reference.h
@@ -80,10 +80,10 @@ class DocumentReference {
 
   void DeleteDocument(util::StatusCallback callback);
 
-  void GetDocument(Source source, DocumentSnapshot::Listener&& callback);
+  void GetDocument(Source source, DocumentSnapshotListener&& callback);
 
   std::unique_ptr<ListenerRegistration> AddSnapshotListener(
-      core::ListenOptions options, DocumentSnapshot::Listener&& listener);
+      core::ListenOptions options, DocumentSnapshotListener&& listener);
 
  private:
   std::shared_ptr<Firestore> firestore_;

--- a/Firestore/core/src/firebase/firestore/api/document_reference.h
+++ b/Firestore/core/src/firebase/firestore/api/document_reference.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/firebase/firestore/api/document_snapshot.h
+++ b/Firestore/core/src/firebase/firestore/api/document_snapshot.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/firebase/firestore/api/document_snapshot.h
+++ b/Firestore/core/src/firebase/firestore/api/document_snapshot.h
@@ -38,8 +38,6 @@ class Firestore;
 
 class DocumentSnapshot {
  public:
-  using Listener = std::unique_ptr<core::EventListener<DocumentSnapshot>>;
-
   DocumentSnapshot() = default;
 
   static DocumentSnapshot FromDocument(std::shared_ptr<Firestore> firestore,
@@ -89,6 +87,9 @@ class DocumentSnapshot {
   absl::optional<model::Document> internal_document_;
   SnapshotMetadata metadata_;
 };
+
+using DocumentSnapshotListener =
+    std::unique_ptr<core::EventListener<DocumentSnapshot>>;
 
 inline bool operator!=(const DocumentSnapshot& lhs,
                        const DocumentSnapshot& rhs) {

--- a/Firestore/core/src/firebase/firestore/api/query_core.cc
+++ b/Firestore/core/src/firebase/firestore/api/query_core.cc
@@ -69,7 +69,7 @@ size_t Query::Hash() const {
   return util::Hash(firestore_.get(), query());
 }
 
-void Query::GetDocuments(Source source, QuerySnapshot::Listener&& callback) {
+void Query::GetDocuments(Source source, QuerySnapshotListener&& callback) {
   ValidateHasExplicitOrderByForLimitToLast();
   if (source == Source::Cache) {
     firestore_->client()->GetDocumentsFromLocalCache(*this,
@@ -84,7 +84,7 @@ void Query::GetDocuments(Source source, QuerySnapshot::Listener&& callback) {
 
   class ListenOnce : public EventListener<QuerySnapshot> {
    public:
-    ListenOnce(Source source, QuerySnapshot::Listener&& listener)
+    ListenOnce(Source source, QuerySnapshotListener&& listener)
         : source_(source), listener_(std::move(listener)) {
     }
 
@@ -119,7 +119,7 @@ void Query::GetDocuments(Source source, QuerySnapshot::Listener&& callback) {
 
    private:
     Source source_;
-    QuerySnapshot::Listener listener_;
+    QuerySnapshotListener listener_;
 
     std::promise<std::unique_ptr<ListenerRegistration>> registration_promise_;
   };
@@ -134,12 +134,12 @@ void Query::GetDocuments(Source source, QuerySnapshot::Listener&& callback) {
 }
 
 std::unique_ptr<ListenerRegistration> Query::AddSnapshotListener(
-    ListenOptions options, QuerySnapshot::Listener&& user_listener) {
+    ListenOptions options, QuerySnapshotListener&& user_listener) {
   ValidateHasExplicitOrderByForLimitToLast();
   // Convert from ViewSnapshots to QuerySnapshots.
   class Converter : public EventListener<ViewSnapshot> {
    public:
-    Converter(Query* parent, QuerySnapshot::Listener&& user_listener)
+    Converter(Query* parent, QuerySnapshotListener&& user_listener)
         : firestore_(parent->firestore()),
           query_(parent->query()),
           user_listener_(std::move(user_listener)) {
@@ -164,7 +164,7 @@ std::unique_ptr<ListenerRegistration> Query::AddSnapshotListener(
    private:
     std::shared_ptr<Firestore> firestore_;
     core::Query query_;
-    QuerySnapshot::Listener user_listener_;
+    QuerySnapshotListener user_listener_;
   };
   auto view_listener =
       absl::make_unique<Converter>(this, std::move(user_listener));

--- a/Firestore/core/src/firebase/firestore/api/query_core.cc
+++ b/Firestore/core/src/firebase/firestore/api/query_core.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/firebase/firestore/api/query_core.h
+++ b/Firestore/core/src/firebase/firestore/api/query_core.h
@@ -66,7 +66,7 @@ class Query {
    * @param callback a callback to execute once the documents have been
    *     successfully read.
    */
-  void GetDocuments(Source source, QuerySnapshot::Listener&& callback);
+  void GetDocuments(Source source, QuerySnapshotListener&& callback);
 
   /**
    * Attaches a listener for QuerySnapshot events.
@@ -78,7 +78,7 @@ class Query {
    * @return A ListenerRegistration that can be used to remove this listener.
    */
   std::unique_ptr<ListenerRegistration> AddSnapshotListener(
-      core::ListenOptions options, QuerySnapshot::Listener&& listener);
+      core::ListenOptions options, QuerySnapshotListener&& listener);
 
   /**
    * Creates and returns a new `Query` with the additional filter that documents

--- a/Firestore/core/src/firebase/firestore/api/query_core.h
+++ b/Firestore/core/src/firebase/firestore/api/query_core.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/firebase/firestore/api/query_snapshot.h
+++ b/Firestore/core/src/firebase/firestore/api/query_snapshot.h
@@ -40,8 +40,6 @@ class Query;
  */
 class QuerySnapshot {
  public:
-  using Listener = std::unique_ptr<core::EventListener<QuerySnapshot>>;
-
   QuerySnapshot(std::shared_ptr<Firestore> firestore,
                 core::Query query,
                 core::ViewSnapshot&& snapshot,
@@ -96,6 +94,9 @@ class QuerySnapshot {
   core::ViewSnapshot snapshot_;
   SnapshotMetadata metadata_;
 };
+
+using QuerySnapshotListener =
+    std::unique_ptr<core::EventListener<QuerySnapshot>>;
 
 }  // namespace api
 }  // namespace firestore

--- a/Firestore/core/src/firebase/firestore/api/query_snapshot.h
+++ b/Firestore/core/src/firebase/firestore/api/query_snapshot.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/firebase/firestore/core/event_manager.cc
+++ b/Firestore/core/src/firebase/firestore/core/event_manager.cc
@@ -17,6 +17,7 @@
 #include <utility>
 
 #include "Firestore/core/src/firebase/firestore/core/event_manager.h"
+#include "Firestore/core/src/firebase/firestore/core/sync_engine.h"
 #include "Firestore/core/src/firebase/firestore/util/hard_assert.h"
 
 namespace firebase {

--- a/Firestore/core/src/firebase/firestore/core/event_manager.cc
+++ b/Firestore/core/src/firebase/firestore/core/event_manager.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/firebase/firestore/core/event_manager.h
+++ b/Firestore/core/src/firebase/firestore/core/event_manager.h
@@ -24,7 +24,7 @@
 
 #include "Firestore/core/src/firebase/firestore/core/query.h"
 #include "Firestore/core/src/firebase/firestore/core/query_listener.h"
-#include "Firestore/core/src/firebase/firestore/core/sync_engine.h"
+#include "Firestore/core/src/firebase/firestore/core/sync_engine_callback.h"
 #include "Firestore/core/src/firebase/firestore/core/view_snapshot.h"
 #include "Firestore/core/src/firebase/firestore/model/types.h"
 #include "Firestore/core/src/firebase/firestore/util/empty.h"
@@ -36,6 +36,8 @@
 namespace firebase {
 namespace firestore {
 namespace core {
+
+class QueryEventSource;
 
 /**
  * EventManager is responsible for mapping queries to query event listeners.

--- a/Firestore/core/src/firebase/firestore/core/event_manager.h
+++ b/Firestore/core/src/firebase/firestore/core/event_manager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/firebase/firestore/core/firestore_client.cc
+++ b/Firestore/core/src/firebase/firestore/core/firestore_client.cc
@@ -20,6 +20,8 @@
 #include <memory>
 #include <utility>
 
+#include "Firestore/core/src/firebase/firestore/api/query_core.h"
+#include "Firestore/core/src/firebase/firestore/api/query_snapshot.h"
 #include "Firestore/core/src/firebase/firestore/api/settings.h"
 #include "Firestore/core/src/firebase/firestore/auth/credentials_provider.h"
 #include "Firestore/core/src/firebase/firestore/core/database_info.h"
@@ -55,6 +57,7 @@ using api::DocumentReference;
 using api::DocumentSnapshot;
 using api::ListenerRegistration;
 using api::QuerySnapshot;
+using api::QuerySnapshotListener;
 using api::Settings;
 using api::SnapshotMetadata;
 using auth::CredentialsProvider;
@@ -385,7 +388,7 @@ void FirestoreClient::GetDocumentFromLocalCache(
 }
 
 void FirestoreClient::GetDocumentsFromLocalCache(
-    const api::Query& query, QuerySnapshot::Listener&& callback) {
+    const api::Query& query, QuerySnapshotListener&& callback) {
   VerifyNotTerminated();
 
   // TODO(c++14): move `callback` into lambda.

--- a/Firestore/core/src/firebase/firestore/core/firestore_client.cc
+++ b/Firestore/core/src/firebase/firestore/core/firestore_client.cc
@@ -320,9 +320,7 @@ bool FirestoreClient::is_terminated() const {
 }
 
 std::shared_ptr<QueryListener> FirestoreClient::ListenToQuery(
-    Query query,
-    ListenOptions options,
-    ViewSnapshot::SharedListener&& listener) {
+    Query query, ListenOptions options, ViewSnapshotSharedListener&& listener) {
   VerifyNotTerminated();
 
   auto query_listener = QueryListener::Create(

--- a/Firestore/core/src/firebase/firestore/core/firestore_client.cc
+++ b/Firestore/core/src/firebase/firestore/core/firestore_client.cc
@@ -26,6 +26,7 @@
 #include "Firestore/core/src/firebase/firestore/auth/credentials_provider.h"
 #include "Firestore/core/src/firebase/firestore/core/database_info.h"
 #include "Firestore/core/src/firebase/firestore/core/event_manager.h"
+#include "Firestore/core/src/firebase/firestore/core/sync_engine.h"
 #include "Firestore/core/src/firebase/firestore/core/view.h"
 #include "Firestore/core/src/firebase/firestore/local/index_free_query_engine.h"
 #include "Firestore/core/src/firebase/firestore/local/leveldb_opener.h"

--- a/Firestore/core/src/firebase/firestore/core/firestore_client.cc
+++ b/Firestore/core/src/firebase/firestore/core/firestore_client.cc
@@ -55,6 +55,7 @@ namespace core {
 
 using api::DocumentReference;
 using api::DocumentSnapshot;
+using api::DocumentSnapshotListener;
 using api::ListenerRegistration;
 using api::QuerySnapshot;
 using api::QuerySnapshotListener;
@@ -349,7 +350,7 @@ void FirestoreClient::RemoveListener(
 }
 
 void FirestoreClient::GetDocumentFromLocalCache(
-    const DocumentReference& doc, DocumentSnapshot::Listener&& callback) {
+    const DocumentReference& doc, DocumentSnapshotListener&& callback) {
   VerifyNotTerminated();
 
   // TODO(c++14): move `callback` into lambda.

--- a/Firestore/core/src/firebase/firestore/core/firestore_client.cc
+++ b/Firestore/core/src/firebase/firestore/core/firestore_client.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/firebase/firestore/core/firestore_client.h
+++ b/Firestore/core/src/firebase/firestore/core/firestore_client.h
@@ -123,7 +123,7 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
    * doesn't exist, an error will be sent to the callback.
    */
   void GetDocumentFromLocalCache(const api::DocumentReference& doc,
-                                 api::DocumentSnapshot::Listener&& callback);
+                                 api::DocumentSnapshotListener&& callback);
 
   /**
    * Retrieves a (possibly empty) set of documents from the cache via the

--- a/Firestore/core/src/firebase/firestore/core/firestore_client.h
+++ b/Firestore/core/src/firebase/firestore/core/firestore_client.h
@@ -113,7 +113,7 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
   std::shared_ptr<QueryListener> ListenToQuery(
       Query query,
       ListenOptions options,
-      ViewSnapshot::SharedListener&& listener);
+      ViewSnapshotSharedListener&& listener);
 
   /** Stops listening to a query previously listened to. */
   void RemoveListener(const std::shared_ptr<core::QueryListener>& listener);

--- a/Firestore/core/src/firebase/firestore/core/firestore_client.h
+++ b/Firestore/core/src/firebase/firestore/core/firestore_client.h
@@ -130,7 +130,7 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
    * indicated callback.
    */
   void GetDocumentsFromLocalCache(const api::Query& query,
-                                  api::QuerySnapshot::Listener&& callback);
+                                  api::QuerySnapshotListener&& callback);
 
   /**
    * Write mutations. callback will be notified when it's written to the

--- a/Firestore/core/src/firebase/firestore/core/firestore_client.h
+++ b/Firestore/core/src/firebase/firestore/core/firestore_client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/firebase/firestore/core/query_listener.cc
+++ b/Firestore/core/src/firebase/firestore/core/query_listener.cc
@@ -34,7 +34,7 @@ using util::Status;
 
 QueryListener::QueryListener(Query query,
                              ListenOptions options,
-                             ViewSnapshot::SharedListener&& listener)
+                             ViewSnapshotSharedListener&& listener)
     : query_(std::move(query)),
       options_(std::move(options)),
       listener_(std::move(listener)) {

--- a/Firestore/core/src/firebase/firestore/core/query_listener.cc
+++ b/Firestore/core/src/firebase/firestore/core/query_listener.cc
@@ -32,6 +32,34 @@ using model::OnlineState;
 using model::TargetId;
 using util::Status;
 
+std::shared_ptr<QueryListener> QueryListener::Create(
+    Query query, ListenOptions options, ViewSnapshotSharedListener&& listener) {
+  return std::make_shared<QueryListener>(std::move(query), std::move(options),
+                                         std::move(listener));
+}
+
+std::shared_ptr<QueryListener> QueryListener::Create(
+    Query query, ViewSnapshotSharedListener&& listener) {
+  return Create(std::move(query), ListenOptions::DefaultOptions(),
+                std::move(listener));
+}
+
+std::shared_ptr<QueryListener> QueryListener::Create(
+    Query query,
+    ListenOptions options,
+    util::StatusOrCallback<ViewSnapshot>&& listener) {
+  auto event_listener =
+      EventListener<ViewSnapshot>::Create(std::move(listener));
+  return Create(std::move(query), std::move(options),
+                std::move(event_listener));
+}
+
+std::shared_ptr<QueryListener> QueryListener::Create(
+    Query query, util::StatusOrCallback<ViewSnapshot>&& listener) {
+  return Create(std::move(query), ListenOptions::DefaultOptions(),
+                std::move(listener));
+}
+
 QueryListener::QueryListener(Query query,
                              ListenOptions options,
                              ViewSnapshotSharedListener&& listener)

--- a/Firestore/core/src/firebase/firestore/core/query_listener.cc
+++ b/Firestore/core/src/firebase/firestore/core/query_listener.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/firebase/firestore/core/query_listener.h
+++ b/Firestore/core/src/firebase/firestore/core/query_listener.h
@@ -40,39 +40,24 @@ class QueryListener {
   static std::shared_ptr<QueryListener> Create(
       Query query,
       ListenOptions options,
-      ViewSnapshotSharedListener&& listener) {
-    return std::make_shared<QueryListener>(std::move(query), std::move(options),
-                                           std::move(listener));
-  }
+      ViewSnapshotSharedListener&& listener);
 
   static std::shared_ptr<QueryListener> Create(
-      Query query, ViewSnapshotSharedListener&& listener) {
-    return Create(std::move(query), ListenOptions::DefaultOptions(),
-                  std::move(listener));
-  }
+      Query query, ViewSnapshotSharedListener&& listener);
 
   static std::shared_ptr<QueryListener> Create(
       Query query,
       ListenOptions options,
-      util::StatusOrCallback<ViewSnapshot>&& listener) {
-    auto event_listener =
-        EventListener<ViewSnapshot>::Create(std::move(listener));
-    return Create(std::move(query), std::move(options),
-                  std::move(event_listener));
-  }
+      util::StatusOrCallback<ViewSnapshot>&& listener);
 
   static std::shared_ptr<QueryListener> Create(
-      Query query, util::StatusOrCallback<ViewSnapshot>&& listener) {
-    return Create(std::move(query), ListenOptions::DefaultOptions(),
-                  std::move(listener));
-  }
+      Query query, util::StatusOrCallback<ViewSnapshot>&& listener);
 
   QueryListener(Query query,
                 ListenOptions options,
                 ViewSnapshotSharedListener&& listener);
 
-  virtual ~QueryListener() {
-  }
+  virtual ~QueryListener() = default;
 
   const Query& query() const {
     return query_;

--- a/Firestore/core/src/firebase/firestore/core/query_listener.h
+++ b/Firestore/core/src/firebase/firestore/core/query_listener.h
@@ -40,13 +40,13 @@ class QueryListener {
   static std::shared_ptr<QueryListener> Create(
       Query query,
       ListenOptions options,
-      ViewSnapshot::SharedListener&& listener) {
+      ViewSnapshotSharedListener&& listener) {
     return std::make_shared<QueryListener>(std::move(query), std::move(options),
                                            std::move(listener));
   }
 
   static std::shared_ptr<QueryListener> Create(
-      Query query, ViewSnapshot::SharedListener&& listener) {
+      Query query, ViewSnapshotSharedListener&& listener) {
     return Create(std::move(query), ListenOptions::DefaultOptions(),
                   std::move(listener));
   }
@@ -69,7 +69,7 @@ class QueryListener {
 
   QueryListener(Query query,
                 ListenOptions options,
-                ViewSnapshot::SharedListener&& listener);
+                ViewSnapshotSharedListener&& listener);
 
   virtual ~QueryListener() {
   }
@@ -109,7 +109,7 @@ class QueryListener {
    * The EventListener that will process ViewSnapshots associated with this
    * query listener.
    */
-  ViewSnapshot::SharedListener listener_;
+  ViewSnapshotSharedListener listener_;
 
   /**
    * Initial snapshots (e.g. from cache) may not be propagated to the

--- a/Firestore/core/src/firebase/firestore/core/query_listener.h
+++ b/Firestore/core/src/firebase/firestore/core/query_listener.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/firebase/firestore/core/sync_engine.cc
+++ b/Firestore/core/src/firebase/firestore/core/sync_engine.cc
@@ -17,6 +17,7 @@
 #include "Firestore/core/src/firebase/firestore/core/sync_engine.h"
 
 #include "Firestore/core/include/firebase/firestore/firestore_errors.h"
+#include "Firestore/core/src/firebase/firestore/core/sync_engine_callback.h"
 #include "Firestore/core/src/firebase/firestore/core/transaction.h"
 #include "Firestore/core/src/firebase/firestore/core/transaction_runner.h"
 #include "Firestore/core/src/firebase/firestore/local/query_result.h"

--- a/Firestore/core/src/firebase/firestore/core/sync_engine.cc
+++ b/Firestore/core/src/firebase/firestore/core/sync_engine.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/firebase/firestore/core/sync_engine.h
+++ b/Firestore/core/src/firebase/firestore/core/sync_engine.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/firebase/firestore/core/sync_engine.h
+++ b/Firestore/core/src/firebase/firestore/core/sync_engine.h
@@ -41,21 +41,7 @@ namespace firebase {
 namespace firestore {
 namespace core {
 
-/**
- * Interface implemented by `EventManager` to handle notifications from
- * `SyncEngine`.
- */
-class SyncEngineCallback {
- public:
-  virtual ~SyncEngineCallback() = default;
-
-  /** Handles a change in online state. */
-  virtual void HandleOnlineStateChange(model::OnlineState online_state) = 0;
-  /** Handles new view snapshots. */
-  virtual void OnViewSnapshots(std::vector<core::ViewSnapshot>&& snapshots) = 0;
-  /** Handles the failure of a query. */
-  virtual void OnError(const core::Query& query, const util::Status& error) = 0;
-};
+class SyncEngineCallback;
 
 /**
  * Interface implemented by `SyncEngine` to receive requests from

--- a/Firestore/core/src/firebase/firestore/core/view_snapshot.h
+++ b/Firestore/core/src/firebase/firestore/core/view_snapshot.h
@@ -97,9 +97,6 @@ class DocumentViewChangeSet {
  */
 class ViewSnapshot {
  public:
-  using Listener = std::unique_ptr<EventListener<ViewSnapshot>>;
-  using SharedListener = std::shared_ptr<EventListener<ViewSnapshot>>;
-
   ViewSnapshot(Query query,
                model::DocumentSet documents,
                model::DocumentSet old_documents,
@@ -178,6 +175,9 @@ class ViewSnapshot {
   bool sync_state_changed_ = false;
   bool excludes_metadata_changes_ = false;
 };
+
+using ViewSnapshotListener = std::unique_ptr<EventListener<ViewSnapshot>>;
+using ViewSnapshotSharedListener = std::shared_ptr<EventListener<ViewSnapshot>>;
 
 bool operator==(const ViewSnapshot& lhs, const ViewSnapshot& rhs);
 

--- a/Firestore/core/src/firebase/firestore/core/view_snapshot.h
+++ b/Firestore/core/src/firebase/firestore/core/view_snapshot.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/firebase/firestore/immutable/sorted_set.h
+++ b/Firestore/core/src/firebase/firestore/immutable/sorted_set.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/firebase/firestore/immutable/sorted_set.h
+++ b/Firestore/core/src/firebase/firestore/immutable/sorted_set.h
@@ -32,24 +32,23 @@ namespace firebase {
 namespace firestore {
 namespace immutable {
 
-template <typename K,
-          typename C = util::Comparator<K>,
-          typename V = util::Empty,
-          typename M = SortedMap<K, V, C>>
+template <typename K, typename C = util::Comparator<K>>
 class SortedSet : public SortedContainer {
  public:
-  using size_type = typename M::size_type;
+  using map_type = SortedMap<K, util::Empty, C>;
+
+  using size_type = typename map_type::size_type;
   using value_type = K;
 
-  using const_iterator = typename M::const_key_iterator;
+  using const_iterator = typename map_type::const_key_iterator;
 
   explicit SortedSet(const C& comparator = C()) : map_{comparator} {
   }
 
-  explicit SortedSet(const M& map) : map_{map} {
+  explicit SortedSet(const map_type& map) : map_{map} {
   }
 
-  explicit SortedSet(M&& map) : map_{std::move(map)} {
+  explicit SortedSet(map_type&& map) : map_{std::move(map)} {
   }
 
   SortedSet(std::initializer_list<value_type> entries, const C& comparator = {})
@@ -137,13 +136,8 @@ class SortedSet : public SortedContainer {
   }
 
  private:
-  M map_;
+  map_type map_;
 };
-
-template <typename K, typename C, typename V>
-SortedSet<K, C, V> MakeSortedSet(const SortedMap<K, V, C>& map) {
-  return SortedSet<K, C, V>{map};
-}
 
 }  // namespace immutable
 }  // namespace firestore

--- a/Firestore/core/src/firebase/firestore/util/status.h
+++ b/Firestore/core/src/firebase/firestore/util/status.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, 2018 Google
+ * Copyright 2015, 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/firebase/firestore/util/status.h
+++ b/Firestore/core/src/firebase/firestore/util/status.h
@@ -233,12 +233,6 @@ inline bool Status::operator!=(const Status& x) const {
 
 typedef std::function<void(Status)> StatusCallback;
 
-extern std::string StatusCheckOpHelperOutOfLine(const Status& v,
-                                                const char* msg);
-
-#define STATUS_CHECK_OK(val) \
-  HARD_ASSERT(val.ok(), "%s", StatusCheckOpHelperOutOfLine(val, #val))
-
 }  // namespace util
 }  // namespace firestore
 }  // namespace firebase

--- a/Firestore/core/test/firebase/firestore/core/event_manager_test.cc
+++ b/Firestore/core/test/firebase/firestore/core/event_manager_test.cc
@@ -44,7 +44,7 @@ using testutil::Query;
 using util::StatusOr;
 using util::StatusOrCallback;
 
-ViewSnapshot::Listener NoopViewSnapshotHandler() {
+ViewSnapshotListener NoopViewSnapshotHandler() {
   return EventListener<ViewSnapshot>::Create(
       [](const StatusOr<ViewSnapshot>&) {});
 }

--- a/Firestore/core/test/firebase/firestore/core/event_manager_test.cc
+++ b/Firestore/core/test/firebase/firestore/core/event_manager_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/test/firebase/firestore/core/query_listener_test.cc
+++ b/Firestore/core/test/firebase/firestore/core/query_listener_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/test/firebase/firestore/core/query_listener_test.cc
+++ b/Firestore/core/test/firebase/firestore/core/query_listener_test.cc
@@ -77,7 +77,7 @@ ViewSnapshot ExcludingMetadataChanges(const ViewSnapshot& snapshot) {
   };
 }
 
-ViewSnapshot::Listener Accumulating(std::vector<ViewSnapshot>* values) {
+ViewSnapshotListener Accumulating(std::vector<ViewSnapshot>* values) {
   return EventListener<ViewSnapshot>::Create(
       [values](const StatusOr<ViewSnapshot>& maybe_snapshot) {
         values->push_back(maybe_snapshot.ValueOrDie());

--- a/Firestore/core/test/firebase/firestore/immutable/sorted_set_test.cc
+++ b/Firestore/core/test/firebase/firestore/immutable/sorted_set_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/test/firebase/firestore/immutable/sorted_set_test.cc
+++ b/Firestore/core/test/firebase/firestore/immutable/sorted_set_test.cc
@@ -94,21 +94,6 @@ TEST(SortedSetTest, IteratorsAreDefaultConstructible) {
       "is default constructible");
 }
 
-TEST(SortedSetTest, CanBeConstructedFromSortedMap) {
-  using Map = SortedMap<int, int>;
-
-  Map map = Map{}.insert(1, 2).insert(3, 4);
-  auto set = MakeSortedSet(map);
-
-  ASSERT_TRUE(Found(set, 1));
-  ASSERT_TRUE(NotFound(set, 2));
-
-  // Set insertion does not modify the underlying map
-  set = set.insert(2);
-  ASSERT_TRUE(Found(set, 2));
-  ASSERT_TRUE(NotFound(map, 2));
-}
-
 TEST(SortedSetTest, Iterator) {
   std::vector<int> all = Sequence(kLargeNumber);
   SortedSet<int> set = ToSet(Shuffled(all));

--- a/Firestore/core/test/firebase/firestore/util/status_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/status_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, 2018 Google
+ * Copyright 2015, 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/test/firebase/firestore/util/status_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/status_test.cc
@@ -31,15 +31,9 @@ TEST(Status, OK) {
   EXPECT_EQ(Status::OK().error_message(), "");
   EXPECT_OK(Status::OK());
   ASSERT_OK(Status::OK());
-  STATUS_CHECK_OK(Status::OK());
   EXPECT_EQ(Status::OK(), Status());
   Status s;
   EXPECT_TRUE(s.ok());
-}
-
-TEST(Status, DeathCheckOK) {
-  Status status(Error::InvalidArgument, "Invalid");
-  ASSERT_ANY_THROW(STATUS_CHECK_OK(status));
 }
 
 TEST(Status, Set) {


### PR DESCRIPTION
Fix a bunch of issues that make it hard to pervasively use forward declarations in our code.

Also, remove some dead code.