### PR TITLE
Fix Xcode 11.4 analyze error

### DIFF
--- a/GoogleDataTransportCCTSupport/CHANGELOG.md
+++ b/GoogleDataTransportCCTSupport/CHANGELOG.md
@@ -1,8 +1,6 @@
-# Unreleased
-- Fix an Xcode 11.4 analyze error. (#4863)
-
 # v1.4.1
 - Fixed a bug that would manifest if a proto ended up being > 16,320 bytes.
+- Fix an Xcode 11.4 analyze error. (#4863)
 
 # v1.4.0
 - Added the CSH backend and consolidated the CCT, FLL, and CSH backends.

--- a/GoogleDataTransportCCTSupport/CHANGELOG.md
+++ b/GoogleDataTransportCCTSupport/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Fix an Xcode 11.4 analyze error. (#4863)
+
 # v1.4.1
 - Fixed a bug that would manifest if a proto ended up being > 16,320 bytes.
 

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTCompressionHelper.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTCompressionHelper.m
@@ -45,8 +45,8 @@
   int windowBits = 15 + 16;  // Enable gzip header instead of zlib header.
 
   int retCode;
-  if ((retCode = deflateInit2(&strm, level, Z_DEFLATED, windowBits, memLevel,
-                              Z_DEFAULT_STRATEGY)) != Z_OK) {
+  if (deflateInit2(&strm, level, Z_DEFLATED, windowBits, memLevel,
+                   Z_DEFAULT_STRATEGY) != Z_OK) {
     return nil;
   }
 

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTCompressionHelper.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTCompressionHelper.m
@@ -45,8 +45,7 @@
   int windowBits = 15 + 16;  // Enable gzip header instead of zlib header.
 
   int retCode;
-  if (deflateInit2(&strm, level, Z_DEFLATED, windowBits, memLevel,
-                   Z_DEFAULT_STRATEGY) != Z_OK) {
+  if (deflateInit2(&strm, level, Z_DEFLATED, windowBits, memLevel, Z_DEFAULT_STRATEGY) != Z_OK) {
     return nil;
   }
 


### PR DESCRIPTION
Fix new analyzer warning from Xcode 11.4

    - WARN  | [iOS] xcodebuild:  /Users/paulbeusterien/gh/firebase-ios-sdk/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTCompressionHelper.m:48:8: warning: Although the value stored to 'retCode' is used in the enclosing expression, the value is never actually read from 'retCode'