### PR TITLE
Add a travis output filter

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -115,14 +115,16 @@ function RunXcodebuild() {
     xcpretty_cmd+=(-f $(xcpretty-travis-formatter))
   fi
 
-  xcodebuild "$@" | "${xcpretty_cmd[@]}"; result=$?
+  xcodebuild "$@" | tee xcodebuild.log | "${xcpretty_cmd[@]}"; result=$?
   if [[ $result == 65 ]]; then
     echo "xcodebuild exited with 65, retrying" 1>&2
     sleep 5
 
-    xcodebuild "$@" | "${xcpretty_cmd[@]}"; result=$?
+    xcodebuild "$@" | tee xcodebuild.log | "${xcpretty_cmd[@]}"; result=$?
   fi
   if [[ $result != 0 ]]; then
+    echo "xcodebuild exited with $result; raw log follows" 1>&2
+    cat xcodebuild.log
     exit $result
   fi
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -108,12 +108,19 @@ fi
 function RunXcodebuild() {
   echo xcodebuild "$@"
 
-  xcodebuild "$@" | xcpretty; result=$?
+  xcpretty_cmd=(xcpretty)
+  if [[ -n "${TRAVIS:-}" ]]; then
+    # The formatter argument takes a file location of a formatter.
+    # The xcpretty-travis-formatter binary prints its location on stdout.
+    xcpretty_cmd+=(-f $(xcpretty-travis-formatter))
+  fi
+
+  xcodebuild "$@" | "${xcpretty_cmd[@]}"; result=$?
   if [[ $result == 65 ]]; then
     echo "xcodebuild exited with 65, retrying" 1>&2
     sleep 5
 
-    xcodebuild "$@" | xcpretty; result=$?
+    xcodebuild "$@" | "${xcpretty_cmd[@]}"; result=$?
   fi
   if [[ $result != 0 ]]; then
     exit $result

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -68,6 +68,13 @@ function apt_install() {
   which "$program" >& /dev/null || sudo apt-get install "$package"
 }
 
+function install_xcpretty() {
+  gem install xcpretty
+  if [[ -n "${TRAVIS:-}" ]]; then
+    gem install xcpretty-travis-formatter
+  fi
+}
+
 secrets_installed=false
 
 # Default values, if not supplied on the command line or environment
@@ -106,13 +113,13 @@ fi
 case "$project-$platform-$method" in
 
   FirebasePod-iOS-xcodebuild)
-    gem install xcpretty
+    install_xcpretty
     bundle exec pod install --project-directory=CoreOnly/Tests/FirebasePodTest --repo-update
     ;;
 
   Auth-*)
     # Install the workspace for integration testing.
-    gem install xcpretty
+    install_xcpretty
     bundle exec pod install --project-directory=Example/Auth/AuthSample --repo-update
     ;;
 
@@ -139,12 +146,12 @@ case "$project-$platform-$method" in
     ;;
 
   InAppMessaging-*-xcodebuild)
-    gem install xcpretty
+    install_xcpretty
     bundle exec pod install --project-directory=FirebaseInAppMessaging/Tests/Integration/DefaultUITestApp --no-repo-update
     ;;
 
   Firestore-*-xcodebuild | Firestore-*-fuzz)
-    gem install xcpretty
+    install_xcpretty
 
     # The Firestore Podfile is multi-platform by default, but this doesn't work
     # with command-line builds using xcodebuild. The PLATFORM environment
@@ -174,7 +181,7 @@ case "$project-$platform-$method" in
     ;;
 
   SymbolCollision-*-xcodebuild)
-    gem install xcpretty
+    install_xcpretty
     bundle exec pod install --project-directory=SymbolCollisionTest --repo-update
     ;;
 


### PR DESCRIPTION
Use `xcpretty-travis-formatter` to group output. It's not perfect, but it's an improvement.

Here's an example: https://travis-ci.org/firebase/firebase-ios-sdk/jobs/647887643 (note the Build, Test, and Warnings groups).