### PR TITLE
Crashlytics GDT fill in Exception part of Proto

### DIFF
--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordFrame.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordFrame.h
@@ -22,6 +22,11 @@
 
 @property(nonatomic) NSUInteger pc;
 
+// This isn't required in the proto, but it is required for processing,
+// so marking as required here so we remember to fill it in.
+// This is also 32 bit, instead of 64 like a lot of the other fields
+@property(nonatomic) uint32_t importance;
+
 #pragma mark - optional attributes
 
 // Method / function call

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordFrame.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordFrame.m
@@ -16,6 +16,10 @@
 
 #import "FIRCLSRecordFrame.h"
 
+// Default importance for the Application.Execution.Exception frames when
+// there is no on-device symbolication
+const NSUInteger DEFAULT_IMPORTANCE_FOR_EXCEPTION = 0;
+
 @interface FIRCLSRecordFrame ()
 
 // Internal representation of optional numerical values in Frames
@@ -31,6 +35,8 @@
   self = [super initWithDict:dict];
   if (self) {
     _pc = [dict[@"pc"] unsignedIntegerValue];
+
+    _importance = DEFAULT_IMPORTANCE_FOR_EXCEPTION;
 
     _symbol = dict[@"symbol"];
     _lineNumber = dict[@"line"];

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
@@ -672,9 +672,8 @@ const NSUInteger IMPORTANCE_FOR_EXCEPTION = 0;
 
 - (google_crashlytics_Session_Event_Application_Execution_Thread_Frame *)protoFramesWithFrames:
     (NSArray<FIRCLSRecordFrame *> *)frames {
-  google_crashlytics_Session_Event_Application_Execution_Thread_Frame *framesProto =
-      malloc(sizeof(google_crashlytics_Session_Event_Application_Execution_Thread_Frame) *
-             frames.count);
+  google_crashlytics_Session_Event_Application_Execution_Thread_Frame *framesProto = malloc(
+      sizeof(google_crashlytics_Session_Event_Application_Execution_Thread_Frame) * frames.count);
 
   for (NSUInteger i = 0; i < frames.count; i++) {
     google_crashlytics_Session_Event_Application_Execution_Thread_Frame frameProto =

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
@@ -26,6 +26,8 @@
 #import <nanopb/pb_decode.h>
 #import <nanopb/pb_encode.h>
 
+const NSUInteger IMPORTANCE_FOR_EXCEPTION = 0;
+
 @implementation FIRCLSReportAdapter
 
 - (instancetype)initWithPath:(NSString *)folderPath
@@ -544,8 +546,6 @@
   app.execution.threads = [self protoThreadsWithArray:self.threads];
   app.execution.threads_count = (pb_size_t)self.threads.count;
 
-  // TODO: Fill in Exception object
-
   app.background = [self wasInBackground];
   app.has_background = true;
 
@@ -555,6 +555,13 @@
   // TODO: Add crash_info_entry values for Swift, Protobuf.scala:444
   app.custom_attributes = [self protoCustomAttributesWithKeyValues:self.userKeyValues];
   app.custom_attributes_count = (pb_size_t)self.userKeyValues.count;
+
+  if (self.exception) {
+    app.execution.exception.type = FIRCLSEncodeString(self.exception.name);
+    app.execution.exception.reason = FIRCLSEncodeString(self.exception.reason);
+    app.execution.exception.frames = [self protoFramesWithFrames:self.exception.frames];
+    app.execution.exception.frames_count = (pb_size_t)self.exception.frames.count;
+  }
 
   return app;
 }
@@ -663,6 +670,38 @@
   return frames;
 }
 
+- (google_crashlytics_Session_Event_Application_Execution_Thread_Frame *)protoFramesWithFrames:
+    (NSArray<FIRCLSRecordFrame *> *)frames {
+  google_crashlytics_Session_Event_Application_Execution_Thread_Frame *framesProto =
+      malloc(sizeof(google_crashlytics_Session_Event_Application_Execution_Thread_Frame) *
+             frames.count);
+
+  for (NSUInteger i = 0; i < frames.count; i++) {
+    google_crashlytics_Session_Event_Application_Execution_Thread_Frame frameProto =
+        google_crashlytics_Session_Event_Application_Execution_Thread_Frame_init_default;
+    FIRCLSRecordFrame *frame = frames[i];
+
+    frameProto.pc = frame.pc;
+    frameProto.importance = IMPORTANCE_FOR_EXCEPTION;
+    frameProto.symbol = FIRCLSEncodeString(frame.symbol);
+
+    if (frame.hasOffset) {
+      frameProto.offset = frame.offset;
+    }
+#warning Need line and file back in the proto
+//    if (frame.hasLine) {
+//      frameProto.line = frame.line;
+//    }
+//     Needs File
+
+    // TODO for symbolicated frames, set the importance Protobuf.scala#L383
+
+    framesProto[i] = frameProto;
+  }
+
+  return framesProto;
+}
+
 - (google_crashlytics_Session_Event_Application_Execution_Thread_Register *)protoRegistersWithArray:
     (NSArray<FIRCLSRecordRegister *> *)array {
   google_crashlytics_Session_Event_Application_Execution_Thread_Register *registers = malloc(
@@ -686,20 +725,19 @@
   google_crashlytics_Session_Event_Application_Execution_Signal signalProto =
       google_crashlytics_Session_Event_Application_Execution_Signal_init_default;
 
-  if (self.signal) {
-    signalProto.address = self.signal.address;
-    signalProto.code = FIRCLSEncodeString(self.signal.code_name);
-    signalProto.name = FIRCLSEncodeString(self.signal.name);
-  }
-
-  // The address is the second code, if we have 2 codes
-  // This is commented in Protobuilder
   if (self.mach_exception) {
+    // The address is the second code, if we have 2 codes
+    // This is commented in Protobuilder
     if (self.mach_exception.codes.count > 1) {
       signalProto.address = [self.mach_exception.codes[1] unsignedIntValue];
     }
     signalProto.code = FIRCLSEncodeString(self.mach_exception.code_name);
     signalProto.name = FIRCLSEncodeString(self.mach_exception.name);
+
+  } else if (self.signal) {
+    signalProto.address = self.signal.address;
+    signalProto.code = FIRCLSEncodeString(self.signal.code_name);
+    signalProto.name = FIRCLSEncodeString(self.signal.name);
   }
 
   return signalProto;

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
@@ -26,8 +26,6 @@
 #import <nanopb/pb_decode.h>
 #import <nanopb/pb_encode.h>
 
-const NSUInteger IMPORTANCE_FOR_EXCEPTION = 0;
-
 @implementation FIRCLSReportAdapter
 
 - (instancetype)initWithPath:(NSString *)folderPath
@@ -681,7 +679,7 @@ const NSUInteger IMPORTANCE_FOR_EXCEPTION = 0;
     FIRCLSRecordFrame *frame = frames[i];
 
     frameProto.pc = frame.pc;
-    frameProto.importance = IMPORTANCE_FOR_EXCEPTION;
+    frameProto.importance = frame.importance;
     frameProto.has_importance = true;
     frameProto.symbol = FIRCLSEncodeString(frame.symbol);
 

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
@@ -683,18 +683,19 @@ const NSUInteger IMPORTANCE_FOR_EXCEPTION = 0;
 
     frameProto.pc = frame.pc;
     frameProto.importance = IMPORTANCE_FOR_EXCEPTION;
+    frameProto.has_importance = true;
     frameProto.symbol = FIRCLSEncodeString(frame.symbol);
 
     if (frame.hasOffset) {
       frameProto.offset = frame.offset;
+      frameProto.has_offset = true;
     }
-#warning Need line and file back in the proto
-//    if (frame.hasLine) {
-//      frameProto.line = frame.line;
-//    }
-//     Needs File
+    if (frame.hasLine) {
+      frameProto.line_number = frame.line;
+      frameProto.has_line_number = true;
+    }
 
-    // TODO for symbolicated frames, set the importance Protobuf.scala#L383
+    // TODO for symbolicated frames, set the importance and file Protobuf.scala#L383
 
     framesProto[i] = frameProto;
   }

--- a/Crashlytics/ProtoSupport/Protos/crashlytics.options
+++ b/Crashlytics/ProtoSupport/Protos/crashlytics.options
@@ -50,6 +50,7 @@ google_crashlytics.Session.Event.Application.Execution.Thread.alternate_name typ
 google_crashlytics.Session.Event.Application.Execution.Thread.objc_selector_name type:FT_POINTER
 
 google_crashlytics.Session.Event.Application.Execution.Thread.Frame.symbol type:FT_POINTER
+google_crashlytics.Session.Event.Application.Execution.Thread.Frame.file type:FT_POINTER
 
 google_crashlytics.Session.Event.Application.Execution.Thread.Register.name type:FT_POINTER
 

--- a/Crashlytics/ProtoSupport/Protos/crashlytics.proto
+++ b/Crashlytics/ProtoSupport/Protos/crashlytics.proto
@@ -153,10 +153,12 @@ message Session {
           message Frame {
             required uint64 pc = 1;
             optional string symbol = 2;                // On macOS
+            optional string file = 3;
             optional uint64 offset = 4;                // On macOS
 
             // Bitfield of FrameImportance
             optional uint32 importance = 5;
+            optional uint64 line_number = 10;
           }
           repeated Frame frames = 3;
 

--- a/Crashlytics/Protogen/nanopb/crashlytics.nanopb.c
+++ b/Crashlytics/Protogen/nanopb/crashlytics.nanopb.c
@@ -117,7 +117,7 @@ const pb_field_t google_crashlytics_Session_Event_Application_Execution_Thread_f
 const pb_field_t google_crashlytics_Session_Event_Application_Execution_Thread_Frame_fields[7] = {
     PB_FIELD(  1, UINT64  , REQUIRED, STATIC  , FIRST, google_crashlytics_Session_Event_Application_Execution_Thread_Frame, pc, pc, 0),
     PB_FIELD(  2, BYTES   , OPTIONAL, POINTER , OTHER, google_crashlytics_Session_Event_Application_Execution_Thread_Frame, symbol, pc, 0),
-    PB_FIELD(  3, BYTES   , OPTIONAL, CALLBACK, OTHER, google_crashlytics_Session_Event_Application_Execution_Thread_Frame, file, symbol, 0),
+    PB_FIELD(  3, BYTES   , OPTIONAL, POINTER , OTHER, google_crashlytics_Session_Event_Application_Execution_Thread_Frame, file, symbol, 0),
     PB_FIELD(  4, UINT64  , OPTIONAL, STATIC  , OTHER, google_crashlytics_Session_Event_Application_Execution_Thread_Frame, offset, file, 0),
     PB_FIELD(  5, UINT32  , OPTIONAL, STATIC  , OTHER, google_crashlytics_Session_Event_Application_Execution_Thread_Frame, importance, offset, 0),
     PB_FIELD( 10, UINT64  , OPTIONAL, STATIC  , OTHER, google_crashlytics_Session_Event_Application_Execution_Thread_Frame, line_number, importance, 0),

--- a/Crashlytics/Protogen/nanopb/crashlytics.nanopb.c
+++ b/Crashlytics/Protogen/nanopb/crashlytics.nanopb.c
@@ -114,11 +114,13 @@ const pb_field_t google_crashlytics_Session_Event_Application_Execution_Thread_f
     PB_LAST_FIELD
 };
 
-const pb_field_t google_crashlytics_Session_Event_Application_Execution_Thread_Frame_fields[5] = {
+const pb_field_t google_crashlytics_Session_Event_Application_Execution_Thread_Frame_fields[7] = {
     PB_FIELD(  1, UINT64  , REQUIRED, STATIC  , FIRST, google_crashlytics_Session_Event_Application_Execution_Thread_Frame, pc, pc, 0),
     PB_FIELD(  2, BYTES   , OPTIONAL, POINTER , OTHER, google_crashlytics_Session_Event_Application_Execution_Thread_Frame, symbol, pc, 0),
-    PB_FIELD(  4, UINT64  , OPTIONAL, STATIC  , OTHER, google_crashlytics_Session_Event_Application_Execution_Thread_Frame, offset, symbol, 0),
+    PB_FIELD(  3, BYTES   , OPTIONAL, CALLBACK, OTHER, google_crashlytics_Session_Event_Application_Execution_Thread_Frame, file, symbol, 0),
+    PB_FIELD(  4, UINT64  , OPTIONAL, STATIC  , OTHER, google_crashlytics_Session_Event_Application_Execution_Thread_Frame, offset, file, 0),
     PB_FIELD(  5, UINT32  , OPTIONAL, STATIC  , OTHER, google_crashlytics_Session_Event_Application_Execution_Thread_Frame, importance, offset, 0),
+    PB_FIELD( 10, UINT64  , OPTIONAL, STATIC  , OTHER, google_crashlytics_Session_Event_Application_Execution_Thread_Frame, line_number, importance, 0),
     PB_LAST_FIELD
 };
 

--- a/Crashlytics/Protogen/nanopb/crashlytics.nanopb.h
+++ b/Crashlytics/Protogen/nanopb/crashlytics.nanopb.h
@@ -156,10 +156,13 @@ typedef struct _google_crashlytics_Session_Event_Application_Execution_Thread {
 typedef struct _google_crashlytics_Session_Event_Application_Execution_Thread_Frame {
     uint64_t pc;
     pb_bytes_array_t *symbol;
+    pb_callback_t file;
     bool has_offset;
     uint64_t offset;
     bool has_importance;
     uint32_t importance;
+    bool has_line_number;
+    uint64_t line_number;
 /* @@protoc_insertion_point(struct:google_crashlytics_Session_Event_Application_Execution_Thread_Frame) */
 } google_crashlytics_Session_Event_Application_Execution_Thread_Frame;
 
@@ -268,7 +271,7 @@ typedef struct _google_crashlytics_Session_Event {
 #define google_crashlytics_Session_Event_Application_init_default {google_crashlytics_Session_Event_Application_Execution_init_default, 0, NULL, false, 0, false, 0}
 #define google_crashlytics_Session_Event_Application_Execution_init_default {0, NULL, false, google_crashlytics_Session_Event_Application_Execution_Exception_init_default, google_crashlytics_Session_Event_Application_Execution_Signal_init_default, 0, NULL}
 #define google_crashlytics_Session_Event_Application_Execution_Thread_init_default {NULL, 0, 0, NULL, 0, NULL, NULL, NULL}
-#define google_crashlytics_Session_Event_Application_Execution_Thread_Frame_init_default {0, NULL, false, 0, false, 0}
+#define google_crashlytics_Session_Event_Application_Execution_Thread_Frame_init_default {0, NULL, {{NULL}, NULL}, false, 0, false, 0, false, 0}
 #define google_crashlytics_Session_Event_Application_Execution_Thread_Register_init_default {NULL, 0}
 #define google_crashlytics_Session_Event_Application_Execution_Exception_init_default {NULL, NULL, NULL, 0, NULL, false, 0}
 #define google_crashlytics_Session_Event_Application_Execution_Signal_init_default {NULL, NULL, 0}
@@ -287,7 +290,7 @@ typedef struct _google_crashlytics_Session_Event {
 #define google_crashlytics_Session_Event_Application_init_zero {google_crashlytics_Session_Event_Application_Execution_init_zero, 0, NULL, false, 0, false, 0}
 #define google_crashlytics_Session_Event_Application_Execution_init_zero {0, NULL, false, google_crashlytics_Session_Event_Application_Execution_Exception_init_zero, google_crashlytics_Session_Event_Application_Execution_Signal_init_zero, 0, NULL}
 #define google_crashlytics_Session_Event_Application_Execution_Thread_init_zero {NULL, 0, 0, NULL, 0, NULL, NULL, NULL}
-#define google_crashlytics_Session_Event_Application_Execution_Thread_Frame_init_zero {0, NULL, false, 0, false, 0}
+#define google_crashlytics_Session_Event_Application_Execution_Thread_Frame_init_zero {0, NULL, {{NULL}, NULL}, false, 0, false, 0, false, 0}
 #define google_crashlytics_Session_Event_Application_Execution_Thread_Register_init_zero {NULL, 0}
 #define google_crashlytics_Session_Event_Application_Execution_Exception_init_zero {NULL, NULL, NULL, 0, NULL, false, 0}
 #define google_crashlytics_Session_Event_Application_Execution_Signal_init_zero {NULL, NULL, 0}
@@ -336,8 +339,10 @@ typedef struct _google_crashlytics_Session_Event {
 #define google_crashlytics_Session_Event_Application_Execution_Thread_objc_selector_name_tag 6
 #define google_crashlytics_Session_Event_Application_Execution_Thread_Frame_pc_tag 1
 #define google_crashlytics_Session_Event_Application_Execution_Thread_Frame_symbol_tag 2
+#define google_crashlytics_Session_Event_Application_Execution_Thread_Frame_file_tag 3
 #define google_crashlytics_Session_Event_Application_Execution_Thread_Frame_offset_tag 4
 #define google_crashlytics_Session_Event_Application_Execution_Thread_Frame_importance_tag 5
+#define google_crashlytics_Session_Event_Application_Execution_Thread_Frame_line_number_tag 10
 #define google_crashlytics_Session_Event_Application_Execution_Thread_Register_name_tag 1
 #define google_crashlytics_Session_Event_Application_Execution_Thread_Register_value_tag 2
 #define google_crashlytics_Session_Event_Device_orientation_tag 4
@@ -390,7 +395,7 @@ extern const pb_field_t google_crashlytics_Session_Event_fields[6];
 extern const pb_field_t google_crashlytics_Session_Event_Application_fields[5];
 extern const pb_field_t google_crashlytics_Session_Event_Application_Execution_fields[5];
 extern const pb_field_t google_crashlytics_Session_Event_Application_Execution_Thread_fields[7];
-extern const pb_field_t google_crashlytics_Session_Event_Application_Execution_Thread_Frame_fields[5];
+extern const pb_field_t google_crashlytics_Session_Event_Application_Execution_Thread_Frame_fields[7];
 extern const pb_field_t google_crashlytics_Session_Event_Application_Execution_Thread_Register_fields[3];
 extern const pb_field_t google_crashlytics_Session_Event_Application_Execution_Exception_fields[6];
 extern const pb_field_t google_crashlytics_Session_Event_Application_Execution_Signal_fields[4];

--- a/Crashlytics/Protogen/nanopb/crashlytics.nanopb.h
+++ b/Crashlytics/Protogen/nanopb/crashlytics.nanopb.h
@@ -156,7 +156,7 @@ typedef struct _google_crashlytics_Session_Event_Application_Execution_Thread {
 typedef struct _google_crashlytics_Session_Event_Application_Execution_Thread_Frame {
     uint64_t pc;
     pb_bytes_array_t *symbol;
-    pb_callback_t file;
+    pb_bytes_array_t *file;
     bool has_offset;
     uint64_t offset;
     bool has_importance;
@@ -271,7 +271,7 @@ typedef struct _google_crashlytics_Session_Event {
 #define google_crashlytics_Session_Event_Application_init_default {google_crashlytics_Session_Event_Application_Execution_init_default, 0, NULL, false, 0, false, 0}
 #define google_crashlytics_Session_Event_Application_Execution_init_default {0, NULL, false, google_crashlytics_Session_Event_Application_Execution_Exception_init_default, google_crashlytics_Session_Event_Application_Execution_Signal_init_default, 0, NULL}
 #define google_crashlytics_Session_Event_Application_Execution_Thread_init_default {NULL, 0, 0, NULL, 0, NULL, NULL, NULL}
-#define google_crashlytics_Session_Event_Application_Execution_Thread_Frame_init_default {0, NULL, {{NULL}, NULL}, false, 0, false, 0, false, 0}
+#define google_crashlytics_Session_Event_Application_Execution_Thread_Frame_init_default {0, NULL, NULL, false, 0, false, 0, false, 0}
 #define google_crashlytics_Session_Event_Application_Execution_Thread_Register_init_default {NULL, 0}
 #define google_crashlytics_Session_Event_Application_Execution_Exception_init_default {NULL, NULL, NULL, 0, NULL, false, 0}
 #define google_crashlytics_Session_Event_Application_Execution_Signal_init_default {NULL, NULL, 0}
@@ -290,7 +290,7 @@ typedef struct _google_crashlytics_Session_Event {
 #define google_crashlytics_Session_Event_Application_init_zero {google_crashlytics_Session_Event_Application_Execution_init_zero, 0, NULL, false, 0, false, 0}
 #define google_crashlytics_Session_Event_Application_Execution_init_zero {0, NULL, false, google_crashlytics_Session_Event_Application_Execution_Exception_init_zero, google_crashlytics_Session_Event_Application_Execution_Signal_init_zero, 0, NULL}
 #define google_crashlytics_Session_Event_Application_Execution_Thread_init_zero {NULL, 0, 0, NULL, 0, NULL, NULL, NULL}
-#define google_crashlytics_Session_Event_Application_Execution_Thread_Frame_init_zero {0, NULL, {{NULL}, NULL}, false, 0, false, 0, false, 0}
+#define google_crashlytics_Session_Event_Application_Execution_Thread_Frame_init_zero {0, NULL, NULL, false, 0, false, 0, false, 0}
 #define google_crashlytics_Session_Event_Application_Execution_Thread_Register_init_zero {NULL, 0}
 #define google_crashlytics_Session_Event_Application_Execution_Exception_init_zero {NULL, NULL, NULL, 0, NULL, false, 0}
 #define google_crashlytics_Session_Event_Application_Execution_Signal_init_zero {NULL, NULL, 0}

--- a/Crashlytics/UnitTests/FIRCLSReportAdapterTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportAdapterTests.m
@@ -526,30 +526,36 @@
   google_crashlytics_Report reportProto = [adapter report];
   google_crashlytics_Session_Event lastEventProto = [self getLastEventProto:reportProto];
 
-  XCTAssertTrue([self isPBData:lastEventProto.app.execution.exception.type equalToString:@"46696c654e6f74466f756e64457863657074696f6e"]);
-  XCTAssertTrue([self isPBData:lastEventProto.app.execution.exception.reason equalToString:@"46696c65204e6f7420466f756e64206f6e2053797374656d"]);
+  XCTAssertTrue([self isPBData:lastEventProto.app.execution.exception.type
+                 equalToString:@"46696c654e6f74466f756e64457863657074696f6e"]);
+  XCTAssertTrue([self isPBData:lastEventProto.app.execution.exception.reason
+                 equalToString:@"46696c65204e6f7420466f756e64206f6e2053797374656d"]);
 
   XCTAssertEqual(lastEventProto.app.execution.exception.frames_count, 14);
 
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].pc, 140733792821726);
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].importance, 0);
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].has_importance, true);
-  XCTAssertTrue([self isPBData:lastEventProto.app.execution.exception.frames[0].symbol equalToString:@""]);
+  XCTAssertTrue([self isPBData:lastEventProto.app.execution.exception.frames[0].symbol
+                 equalToString:@""]);
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].offset, 101);
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].has_offset, true);
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].line_number, 405);
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].has_line_number, true);
-  XCTAssertTrue([self isPBData:lastEventProto.app.execution.exception.frames[0].file equalToString:@""]);
+  XCTAssertTrue([self isPBData:lastEventProto.app.execution.exception.frames[0].file
+                 equalToString:@""]);
 
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[13].pc, 140734559604009);
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[13].importance, 0);
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[13].has_importance, true);
-  XCTAssertTrue([self isPBData:lastEventProto.app.execution.exception.frames[13].symbol equalToString:@""]);
+  XCTAssertTrue([self isPBData:lastEventProto.app.execution.exception.frames[13].symbol
+                 equalToString:@""]);
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[13].offset, 1203);
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[13].has_offset, true);
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[13].line_number, 2003);
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[13].has_line_number, true);
-  XCTAssertTrue([self isPBData:lastEventProto.app.execution.exception.frames[13].file equalToString:@""]);
+  XCTAssertTrue([self isPBData:lastEventProto.app.execution.exception.frames[13].file
+                 equalToString:@""]);
 }
 
 // The session ends at the last event's timestamp, regardless if it's an error or crash

--- a/Crashlytics/UnitTests/FIRCLSReportAdapterTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportAdapterTests.m
@@ -521,6 +521,25 @@
   XCTAssertEqual(reportProto.session.events[3].app.execution.threads[0].frames[28].pc, 7020727833);
 }
 
+- (void)testExceptionProtoReport {
+  FIRCLSReportAdapter *adapter = [FIRCLSReportAdapterTests adapterForExceptionCrash];
+  google_crashlytics_Report reportProto = [adapter report];
+  google_crashlytics_Session_Event lastEventProto = [self getLastEventProto:reportProto];
+
+//  [self assertPBData:lastEventProto.app.execution.exception.type isEqualToString:@"a"];
+//  [self assertPBData:lastEventProto.app.execution.exception.reason isEqualToString:@"a"];
+  XCTAssertEqual(lastEventProto.app.execution.exception.frames_count, 14);
+  XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].pc, 140733792821726);
+  XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].importance, 0);
+  XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].has_importance, true);
+  [self assertPBData:lastEventProto.app.execution.exception.frames[0].symbol isEqualToString:@""];
+  XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].offset, 101);
+  XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].has_offset, true);
+  XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].line_number, 405);
+  XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].has_line_number, true);
+//  [self assertPBData:lastEventProto.app.execution.exception.frames[0].file isEqualToString:@""];
+}
+
 // The session ends at the last event's timestamp, regardless if it's an error or crash
 // Signal crash has errors and a signal crash file. Session should end at the signal crash
 - (void)testEndedAtErrorsAndCrash {

--- a/Crashlytics/UnitTests/FIRCLSReportAdapterTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportAdapterTests.m
@@ -458,8 +458,8 @@
   XCTAssertTrue(reportProto.session.crashed);
 
   XCTAssertEqual(signalProto.address, 7020687100);
-  [self assertPBData:signalProto.code isEqualToString:@"ABORT"];
-  [self assertPBData:signalProto.name isEqualToString:@"SIGABRT"];
+  XCTAssertTrue([self isPBData:signalProto.code equalToString:@"ABORT"]);
+  XCTAssertTrue([self isPBData:signalProto.name equalToString:@"SIGABRT"]);
 }
 
 // If there's both a Mach Exception and Signal file, the Mach Exception file takes precedence
@@ -475,8 +475,8 @@
   XCTAssertTrue(reportProto.session.crashed);
 
   XCTAssertEqual(signalProto.address, 32);
-  [self assertPBData:signalProto.code isEqualToString:@"KERN_INVALID_ADDRESS"];
-  [self assertPBData:signalProto.name isEqualToString:@"EXC_BAD_ACCESS"];
+  XCTAssertTrue([self isPBData:signalProto.code equalToString:@"KERN_INVALID_ADDRESS"]);
+  XCTAssertTrue([self isPBData:signalProto.name equalToString:@"EXC_BAD_ACCESS"]);
 }
 
 // The order of precedence is Exception > Mach Exception > Signal. This test
@@ -526,18 +526,30 @@
   google_crashlytics_Report reportProto = [adapter report];
   google_crashlytics_Session_Event lastEventProto = [self getLastEventProto:reportProto];
 
-//  [self assertPBData:lastEventProto.app.execution.exception.type isEqualToString:@"a"];
-//  [self assertPBData:lastEventProto.app.execution.exception.reason isEqualToString:@"a"];
+  XCTAssertTrue([self isPBData:lastEventProto.app.execution.exception.type equalToString:@"46696c654e6f74466f756e64457863657074696f6e"]);
+  XCTAssertTrue([self isPBData:lastEventProto.app.execution.exception.reason equalToString:@"46696c65204e6f7420466f756e64206f6e2053797374656d"]);
+
   XCTAssertEqual(lastEventProto.app.execution.exception.frames_count, 14);
+
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].pc, 140733792821726);
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].importance, 0);
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].has_importance, true);
-  [self assertPBData:lastEventProto.app.execution.exception.frames[0].symbol isEqualToString:@""];
+  XCTAssertTrue([self isPBData:lastEventProto.app.execution.exception.frames[0].symbol equalToString:@""]);
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].offset, 101);
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].has_offset, true);
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].line_number, 405);
   XCTAssertEqual(lastEventProto.app.execution.exception.frames[0].has_line_number, true);
-//  [self assertPBData:lastEventProto.app.execution.exception.frames[0].file isEqualToString:@""];
+  XCTAssertTrue([self isPBData:lastEventProto.app.execution.exception.frames[0].file equalToString:@""]);
+
+  XCTAssertEqual(lastEventProto.app.execution.exception.frames[13].pc, 140734559604009);
+  XCTAssertEqual(lastEventProto.app.execution.exception.frames[13].importance, 0);
+  XCTAssertEqual(lastEventProto.app.execution.exception.frames[13].has_importance, true);
+  XCTAssertTrue([self isPBData:lastEventProto.app.execution.exception.frames[13].symbol equalToString:@""]);
+  XCTAssertEqual(lastEventProto.app.execution.exception.frames[13].offset, 1203);
+  XCTAssertEqual(lastEventProto.app.execution.exception.frames[13].has_offset, true);
+  XCTAssertEqual(lastEventProto.app.execution.exception.frames[13].line_number, 2003);
+  XCTAssertEqual(lastEventProto.app.execution.exception.frames[13].has_line_number, true);
+  XCTAssertTrue([self isPBData:lastEventProto.app.execution.exception.frames[13].file equalToString:@""]);
 }
 
 // The session ends at the last event's timestamp, regardless if it's an error or crash
@@ -595,13 +607,25 @@
 
 #pragma mark - Assertion Helpers for NanoPB Types
 
-- (void)assertPBData:(pb_bytes_array_t *)pbString isEqualToString:(NSString *)expected {
+- (BOOL)isPBData:(pb_bytes_array_t *)pbString equalToString:(NSString *)expected {
   pb_bytes_array_t *expectedProtoBytes = FIRCLSEncodeString(expected);
-  XCTAssertEqual(pbString->size, expectedProtoBytes->size);
+
+  // We're treating the empty string as the same as a missing field
+  if ((!pbString) && expectedProtoBytes->size == 0) {
+    return true;
+  }
+
+  if (pbString->size != expectedProtoBytes->size) {
+    return false;
+  }
 
   for (int i = 0; i < pbString->size; i++) {
-    XCTAssertEqual(expectedProtoBytes->bytes[i], pbString->bytes[i]);
+    if (expectedProtoBytes->bytes[i] != pbString->bytes[i]) {
+      return false;
+    }
   }
+
+  return true;
 }
 
 #pragma mark - Getting Portions of the Proto


### PR DESCRIPTION
 - Sets the fields in the `Exception` part of the app execution.
 - Also fixes the analysis issue with `signalProto`

Does not fill in symbolicated files or importance for symbolicated.