### PR TITLE
Include transitive deps in module maps

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Fix Zip Builder module map generation that could cause linker missing
+  symbol errors in the 6.14.0 through 6.16.0 binary release distributions. (#4819)
+
 # v6.6.1 -- M63
 - [changed] Minimum required Xcode version changed to 10.3 (was 10.1).
 

--- a/ZipBuilder/Sources/ZipBuilder/ModuleMapBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ModuleMapBuilder.swift
@@ -172,11 +172,9 @@ struct ModuleMapBuilder {
           podLibraryDeps = dependencyPod.transitiveLibraries
         }
         if let fdeps = podFrameworkDeps {
-          myFrameworkDeps.subtract(fdeps)
           transitiveFrameworkDeps.formUnion(fdeps)
         }
         if let ldeps = podLibraryDeps {
-          myLibraryDeps.subtract(ldeps)
           transitiveLibraryDeps.formUnion(ldeps)
         }
       }


### PR DESCRIPTION
Fix #4819 

Include transitive library and framework dependencies in generated module maps since they may not be pulled in if the dependency is not referenced as a module.

This change causes the following modulemap diffs from the 6.17.0 binary distribution:

```
/var/folders/mk/9ccbvq8x00q20q0f7mfxbtrw00bzqz/T/ZipRelease/96E84341-22B2-426D-A8B2-922AC87656B0/Firebase  $ diff -r  ~/Downloads/Firebase-6.17.0/ ./ | grep -v differ | grep -v nib
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseABTesting/FirebaseABTesting.framework/Modules/module.modulemap ./FirebaseABTesting/FirebaseABTesting.framework/Modules/module.modulemap
4a5,9
>   link framework "Foundation"
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseAnalytics/FirebaseCore.framework/Modules/module.modulemap ./FirebaseAnalytics/FirebaseCore.framework/Modules/module.modulemap
4a5,7
>   link framework "Foundation"
>   link framework "Security"
>   link framework "SystemConfiguration"
5a9
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseAnalytics/FirebaseCoreDiagnostics.framework/Modules/module.modulemap ./FirebaseAnalytics/FirebaseCoreDiagnostics.framework/Modules/module.modulemap
5a6,8
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseAnalytics/FirebaseInstallations.framework/Modules/module.modulemap ./FirebaseAnalytics/FirebaseInstallations.framework/Modules/module.modulemap
4a5,9
>   link framework "Foundation"
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseAnalytics/FirebaseInstanceID.framework/Modules/module.modulemap ./FirebaseAnalytics/FirebaseInstanceID.framework/Modules/module.modulemap
4a5,9
>   link framework "Foundation"
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
>   link "z"
Only in /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseAuth: .DS_Store
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseAuth/FirebaseAuth.framework/Modules/module.modulemap ./FirebaseAuth/FirebaseAuth.framework/Modules/module.modulemap
4a5
>   link framework "Foundation"
5a7,10
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
>   link "z"
Only in /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseAuth/GTMSessionFetcher.framework: .DS_Store
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseCrashlytics/FirebaseCrashlytics.framework/Modules/module.modulemap ./FirebaseCrashlytics/FirebaseCrashlytics.framework/Modules/module.modulemap
4a5,8
>   link framework "Foundation"
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
5a10
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseDatabase/FirebaseDatabase.framework/Modules/module.modulemap ./FirebaseDatabase/FirebaseDatabase.framework/Modules/module.modulemap
5a6,10
>   link framework "Foundation"
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
>   link "c++"
6a12
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseDynamicLinks/FirebaseDynamicLinks.framework/Modules/module.modulemap ./FirebaseDynamicLinks/FirebaseDynamicLinks.framework/Modules/module.modulemap
5a6
>   link framework "Foundation"
7a9,12
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseFirestore/FirebaseFirestore.framework/Modules/module.modulemap ./FirebaseFirestore/FirebaseFirestore.framework/Modules/module.modulemap
4a5
>   link framework "Foundation"
5a7,11
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
>   link "c++"
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseFirestore/gRPC-C++.framework/Modules/module.modulemap ./FirebaseFirestore/gRPC-C++.framework/Modules/module.modulemap
4a5,6
>   link "c++"
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseFunctions/FirebaseFunctions.framework/Modules/module.modulemap ./FirebaseFunctions/FirebaseFunctions.framework/Modules/module.modulemap
4a5,9
>   link framework "Foundation"
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseInAppMessaging/FirebaseInAppMessaging.framework/Modules/module.modulemap ./FirebaseInAppMessaging/FirebaseInAppMessaging.framework/Modules/module.modulemap
4a5,9
>   link framework "Foundation"
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseMLModelInterpreter/TensorFlowLiteObjC.framework/Modules/module.modulemap ./FirebaseMLModelInterpreter/TensorFlowLiteObjC.framework/Modules/module.modulemap
4a5
>   link "c++"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseMLNLSmartReply/FirebaseABTesting.framework/Modules/module.modulemap ./FirebaseMLNLSmartReply/FirebaseABTesting.framework/Modules/module.modulemap
4a5,9
>   link framework "Foundation"
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseMLNLSmartReply/FirebaseRemoteConfig.framework/Modules/module.modulemap ./FirebaseMLNLSmartReply/FirebaseRemoteConfig.framework/Modules/module.modulemap
4a5,9
>   link framework "Foundation"
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseMLNLTranslate/FirebaseABTesting.framework/Modules/module.modulemap ./FirebaseMLNLTranslate/FirebaseABTesting.framework/Modules/module.modulemap
4a5,9
>   link framework "Foundation"
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseMLNLTranslate/FirebaseRemoteConfig.framework/Modules/module.modulemap ./FirebaseMLNLTranslate/FirebaseRemoteConfig.framework/Modules/module.modulemap
4a5,9
>   link framework "Foundation"
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseMLVision/GoogleAPIClientForREST.framework/Modules/module.modulemap ./FirebaseMLVision/GoogleAPIClientForREST.framework/Modules/module.modulemap
4a5
>   link framework "Security"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseMLVisionAutoML/GoogleAPIClientForREST.framework/Modules/module.modulemap ./FirebaseMLVisionAutoML/GoogleAPIClientForREST.framework/Modules/module.modulemap
4a5
>   link framework "Security"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseMLVisionAutoML/TensorFlowLiteObjC.framework/Modules/module.modulemap ./FirebaseMLVisionAutoML/TensorFlowLiteObjC.framework/Modules/module.modulemap
4a5
>   link "c++"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseMLVisionBarcodeModel/GoogleAPIClientForREST.framework/Modules/module.modulemap ./FirebaseMLVisionBarcodeModel/GoogleAPIClientForREST.framework/Modules/module.modulemap
4a5
>   link framework "Security"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseMLVisionFaceModel/GoogleAPIClientForREST.framework/Modules/module.modulemap ./FirebaseMLVisionFaceModel/GoogleAPIClientForREST.framework/Modules/module.modulemap
4a5
>   link framework "Security"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseMLVisionLabelModel/GoogleAPIClientForREST.framework/Modules/module.modulemap ./FirebaseMLVisionLabelModel/GoogleAPIClientForREST.framework/Modules/module.modulemap
4a5
>   link framework "Security"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseMLVisionObjectDetection/GoogleAPIClientForREST.framework/Modules/module.modulemap ./FirebaseMLVisionObjectDetection/GoogleAPIClientForREST.framework/Modules/module.modulemap
4a5
>   link framework "Security"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseMLVisionTextModel/GoogleAPIClientForREST.framework/Modules/module.modulemap ./FirebaseMLVisionTextModel/GoogleAPIClientForREST.framework/Modules/module.modulemap
4a5
>   link framework "Security"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseMessaging/FirebaseMessaging.framework/Modules/module.modulemap ./FirebaseMessaging/FirebaseMessaging.framework/Modules/module.modulemap
4a5,8
>   link framework "Foundation"
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
5a10
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebasePerformance/FirebaseABTesting.framework/Modules/module.modulemap ./FirebasePerformance/FirebaseABTesting.framework/Modules/module.modulemap
4a5,9
>   link framework "Foundation"
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebasePerformance/FirebaseRemoteConfig.framework/Modules/module.modulemap ./FirebasePerformance/FirebaseRemoteConfig.framework/Modules/module.modulemap
4a5,9
>   link framework "Foundation"
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseRemoteConfig/FirebaseABTesting.framework/Modules/module.modulemap ./FirebaseRemoteConfig/FirebaseABTesting.framework/Modules/module.modulemap
4a5,9
>   link framework "Foundation"
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseRemoteConfig/FirebaseRemoteConfig.framework/Modules/module.modulemap ./FirebaseRemoteConfig/FirebaseRemoteConfig.framework/Modules/module.modulemap
4a5,9
>   link framework "Foundation"
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/FirebaseStorage/FirebaseStorage.framework/Modules/module.modulemap ./FirebaseStorage/FirebaseStorage.framework/Modules/module.modulemap
4a5
>   link framework "Foundation"
5a7,10
>   link framework "Security"
>   link framework "SystemConfiguration"
>   link framework "UIKit"
>   link "z"
diff -r /Users/paulbeusterien/Downloads/Firebase-6.17.0/GoogleSignIn/GTMAppAuth.framework/Modules/module.modulemap ./GoogleSignIn/GTMAppAuth.framework/Modules/module.modulemap
4a5,6
>   link framework "SafariServices"
>   link framework "Security"
/var/folders/mk/9ccbvq8x00q20q0f7mfxbtrw00bzqz/T/ZipRelease/96E84341-22B2-426D-A8B2-922AC87656B0/Firebase  $
```