### PR TITLE
Reset RC per-instance userdefaults if config database was not found.

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,3 +1,5 @@
+# v4.4.8
+- [fixed] Fixed a bug (#4677, #4734) where Remote Config does not work after a restore of a previous backup of the device. (#4896).
 # v4.4.7
 - [fixed] Fixed a crash that could occur when attempting a remote config fetch before a valid Instance ID was available. (#4622)
 - [fixed] Fixed an issue where config fetch would sometimes fail with a duplicate fetch error when no other fetches were in progress. (#3802)

--- a/FirebaseRemoteConfig/Sources/RCNConfigDBManager.h
+++ b/FirebaseRemoteConfig/Sources/RCNConfigDBManager.h
@@ -115,4 +115,7 @@ typedef void (^RCNDBLoadCompletion)(BOOL success,
 /// Remove all the records from experiment table with given key.
 /// @param key  The key of experiment data belongs to, which are defined in RCNConfigDefines.h.
 - (void)deleteExperimentTableForKey:(NSString *)key;
+
+/// Returns true if this a new install of the Config database.
+- (BOOL)isNewDatabase;
 @end

--- a/FirebaseRemoteConfig/Sources/RCNConfigDBManager.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigDBManager.m
@@ -31,6 +31,7 @@
 #define RCNTableNameInternalMetadata "internal_metadata"
 #define RCNTableNameExperiment "experiment"
 
+static BOOL gIsNewDatabase;
 /// SQLite file name in versions 0, 1 and 2.
 static NSString *const RCNDatabaseName = @"RemoteConfig.sqlite3";
 /// The application support sub-directory that the Remote Config database resides in.
@@ -77,6 +78,7 @@ static BOOL RemoteConfigCreateFilePathIfNotExist(NSString *filePath) {
   }
   NSFileManager *fileManager = [NSFileManager defaultManager];
   if (![fileManager fileExistsAtPath:filePath]) {
+    gIsNewDatabase = YES;
     NSError *error;
     [fileManager createDirectoryAtPath:[filePath stringByDeletingLastPathComponent]
            withIntermediateDirectories:YES
@@ -203,6 +205,7 @@ static NSArray *RemoteConfigMetadataTableColumnsInOrder() {
     NSString *dbPath = [RCNConfigDBManager remoteConfigPathForDatabase];
     FIRLogInfo(kFIRLoggerRemoteConfig, @"I-RCN000062", @"Loading database at path %@", dbPath);
     const char *databasePath = dbPath.UTF8String;
+
     // Create or open database path.
     if (!RemoteConfigCreateFilePathIfNotExist(dbPath)) {
       return;
@@ -1034,6 +1037,10 @@ static NSArray *RemoteConfigMetadataTableColumnsInOrder() {
   }
 
   return returnValue;
+}
+
+- (BOOL)isNewDatabase {
+  return gIsNewDatabase;
 }
 
 @end

--- a/FirebaseRemoteConfig/Sources/RCNConfigSettings.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigSettings.m
@@ -102,6 +102,14 @@ static const int kRCNExponentialBackoffMaximumInterval = 60 * 60 * 4;  // 4 hour
     _userDefaultsManager = [[RCNUserDefaultsManager alloc] initWithAppName:appName
                                                                   bundleID:_bundleIdentifier
                                                                  namespace:_FIRNamespace];
+
+    // Check if the config database is new. If so, clear the configs saved in userDefaults.
+    if ([_DBManager isNewDatabase]) {
+      FIRLogNotice(kFIRLoggerRemoteConfig, @"I-RCN000072",
+                   @"New config database created. Resetting user defaults.");
+      [_userDefaultsManager resetUserDefaults];
+    }
+
     _isFetchInProgress = NO;
   }
   return self;

--- a/FirebaseRemoteConfig/Sources/RCNUserDefaultsManager.h
+++ b/FirebaseRemoteConfig/Sources/RCNUserDefaultsManager.h
@@ -48,6 +48,8 @@ NS_ASSUME_NONNULL_BEGIN
     __attribute__((unavailable("Use `initWithAppName:bundleID:namespace:` instead.")));
 // NOLINTEND
 
+/// Delete all saved userdefaults for this instance.
+- (void)resetUserDefaults;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseRemoteConfig/Sources/RCNUserDefaultsManager.m
+++ b/FirebaseRemoteConfig/Sources/RCNUserDefaultsManager.m
@@ -174,6 +174,11 @@ static NSString *const kRCNUserDefaultsKeyNamecurrentThrottlingRetryInterval =
                               forKey:kRCNUserDefaultsKeyNamecurrentThrottlingRetryInterval];
 }
 
+#pragma mark Public methods.
+- (void)resetUserDefaults {
+  [self resetInstanceUserDefaults];
+}
+
 #pragma mark Private methods.
 
 // There is a nested hierarchy for the userdefaults as follows:
@@ -205,6 +210,19 @@ static NSString *const kRCNUserDefaultsKeyNamecurrentThrottlingRetryInterval =
     NSMutableDictionary *appUserDefaults = [[self appUserDefaults] mutableCopy];
     NSMutableDictionary *appNamespaceUserDefaults = [[self instanceUserDefaults] mutableCopy];
     [appNamespaceUserDefaults setObject:value forKey:key];
+    [appUserDefaults setObject:appNamespaceUserDefaults forKey:_firebaseNamespace];
+    [_userDefaults setObject:appUserDefaults forKey:_firebaseAppName];
+    // We need to synchronize to have this value updated for the extension.
+    [_userDefaults synchronize];
+  }
+}
+
+// Delete any existing userdefaults for this instance.
+- (void)resetInstanceUserDefaults {
+  @synchronized(_userDefaults) {
+    NSMutableDictionary *appUserDefaults = [[self appUserDefaults] mutableCopy];
+    NSMutableDictionary *appNamespaceUserDefaults = [[self instanceUserDefaults] mutableCopy];
+    [appNamespaceUserDefaults removeAllObjects];
     [appUserDefaults setObject:appNamespaceUserDefaults forKey:_firebaseNamespace];
     [_userDefaults setObject:appUserDefaults forKey:_firebaseAppName];
     // We need to synchronize to have this value updated for the extension.

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -192,7 +192,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
                                                                    namespace:fullyQualifiedNamespace
                                                                      options:currentOptions]);
 
-    OCMStub([_configFetch[i] fetchConfigWithExpirationDuration:43200 completionHandler:OCMOCK_ANY])
+    OCMStub([_configFetch[i] fetchConfigWithExpirationDuration:0 completionHandler:OCMOCK_ANY])
+        .ignoringNonObjectArgs()
         .andDo(^(NSInvocation *invocation) {
           void (^handler)(FIRRemoteConfigFetchStatus status, NSError *_Nullable error) = nil;
           [invocation getArgument:&handler atIndex:3];

--- a/FirebaseRemoteConfig/Tests/Unit/RCNUserDefaultsManagerTests.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNUserDefaultsManagerTests.m
@@ -170,4 +170,14 @@ static NSTimeInterval RCNUserDefaultsSampleTimeStamp = 0;
                  RCNUserDefaultsSampleTimeStamp - 2.0);
 }
 
+- (void)testUserDefaultsReset {
+  RCNUserDefaultsManager* manager =
+      [[RCNUserDefaultsManager alloc] initWithAppName:@"TESTING"
+                                             bundleID:[NSBundle mainBundle].bundleIdentifier
+                                            namespace:@"testNamespace1"];
+  [manager setLastETag:@"testETag"];
+  [manager resetUserDefaults];
+  XCTAssertNil([manager lastETag]);
+}
+
 @end


### PR DESCRIPTION
Addresses b/148386739, #4677 , #4734. Backgroubd: We explicitly disable backup of the sqlite database. Hence upon restore, we do not have any data. This causes a fetch to be made, but we send the last eTag (which is saved in userdefaults and cannot be opted out of backup) along with the fetch request which causes the RC backend to send a NO_CHANGE back. Fix is to identify if the database is gone, and if so, reset the userdefaults.