### PR TITLE
Fix nullability of configValueForKey:source:

### DIFF
--- a/FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h
+++ b/FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h
@@ -271,16 +271,18 @@ NS_SWIFT_NAME(RemoteConfig)
 /// Gets the config value of a given namespace and a given source.
 /// @param key              Config key.
 /// @param source           Config value source.
-- (nonnull FIRRemoteConfigValue *)configValueForKey:(nullable NSString *)key
-                                             source:(FIRRemoteConfigSource)source;
+/// @return                 Config value if the key exists in given source. Otherwise `nil`.
+- (nullable FIRRemoteConfigValue *)configValueForKey:(nullable NSString *)key
+                                              source:(FIRRemoteConfigSource)source;
 
 /// Gets the config value of a given namespace and a given source.
 /// @param key              Config key.
 /// @param aNamespace       Config results under a given namespace.
 /// @param source           Config value source.
-- (nonnull FIRRemoteConfigValue *)configValueForKey:(nullable NSString *)key
-                                          namespace:(nullable NSString *)aNamespace
-                                             source:(FIRRemoteConfigSource)source
+/// @return                 Config value if the key exists in given source. Otherwise `nil`.
+- (nullable FIRRemoteConfigValue *)configValueForKey:(nullable NSString *)key
+                                           namespace:(nullable NSString *)aNamespace
+                                              source:(FIRRemoteConfigSource)source
     DEPRECATED_MSG_ATTRIBUTE("Use -[FIRRemoteConfig configValueForKey:source:] "
                              "instead.");
 


### PR DESCRIPTION
The implementation of `-[FIRRemoteConfig configValueForKey:namespace:source:]` returns `nil` if no such key exists.

Accordingly, this fix in nullability annotation avoids potential crashes in Swift apps and allows for distinguishing between empty (`""`) and missing remote config values (`nil`).

Hey there! So you want to contribute to a Firebase SDK?
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here.
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help
    us make Firebase APIs better, please propose your change in a feature request so that we
    can discuss it together.
