### PR TITLE
Nullable +[FIRInstallations installations]

### DIFF
--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -153,21 +153,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Public
 
-+ (FIRInstallations *)installations {
-  FIRApp *defaultApp = [FIRApp defaultApp];
++ (nullable FIRInstallations *)installations {
+  FIRApp *defaultApp = [FIRApp defaultApp]; // Missing configure will be logged here.
   if (!defaultApp) {
-    [NSException raise:kFirebaseInstallationsErrorDomain
-                format:@"The default FirebaseApp instance must be configured before the default"
-                       @"FirebaseApp instance can be initialized. One way to ensure that is to "
-                       @"call `[FIRApp configure];` (`FirebaseApp.configure()` in Swift) in the App"
-                       @" Delegate's `application:didFinishLaunchingWithOptions:` "
-                       @"(`application(_:didFinishLaunchingWithOptions:)` in Swift)."];
+    return nil;
   }
 
   return [self installationsWithApp:defaultApp];
 }
 
-+ (FIRInstallations *)installationsWithApp:(FIRApp *)app {
++ (nullable FIRInstallations *)installationsWithApp:(FIRApp *)app {
+  if (!app) {
+    // TODO: Add a log message
+    return nil;
+  }
+
   id<FIRInstallationsInstanceProvider> installations =
       FIR_COMPONENT(FIRInstallationsInstanceProvider, app.container);
   return (FIRInstallations *)installations;

--- a/FirebaseInstallations/Source/Library/FIRInstallations.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallations.m
@@ -154,7 +154,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Public
 
 + (nullable FIRInstallations *)installations {
-  FIRApp *defaultApp = [FIRApp defaultApp]; // Missing configure will be logged here.
+  FIRApp *defaultApp = [FIRApp defaultApp];  // Missing configure will be logged here.
   if (!defaultApp) {
     return nil;
   }
@@ -164,7 +164,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable FIRInstallations *)installationsWithApp:(FIRApp *)app {
   if (!app) {
-    // TODO: Add a log message
     return nil;
   }
 

--- a/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
+++ b/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
@@ -63,7 +63,7 @@ NS_SWIFT_NAME(Installations)
  * @throw Throws an exception if the default app is not configured yet or required  `FirebaseApp`
  * options are missing.
  */
-+ (FIRInstallations *)installations NS_SWIFT_NAME(installations());
++ (nullable FIRInstallations *)installations NS_SWIFT_NAME(installations());
 
 /**
  * Returns an instance of `Installations` for an application.
@@ -71,7 +71,7 @@ NS_SWIFT_NAME(Installations)
  * @returns An instance of `Installations` corresponding to the passed application.
  * @throw Throws an exception if required `FirebaseApp` options are missing.
  */
-+ (FIRInstallations *)installationsWithApp:(FIRApp *)application NS_SWIFT_NAME(installations(app:));
++ (nullable FIRInstallations *)installationsWithApp:(FIRApp *)application NS_SWIFT_NAME(installations(app:));
 
 /**
  * The method creates or retrieves an installation ID. The installation ID is a stable identifier

--- a/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
+++ b/FirebaseInstallations/Source/Library/Public/FIRInstallations.h
@@ -59,19 +59,19 @@ NS_SWIFT_NAME(Installations)
 
 /**
  * Returns a default instance of `Installations`.
- * @returns An instance of `Installations` for `FirebaseApp.defaultApp().
- * @throw Throws an exception if the default app is not configured yet or required  `FirebaseApp`
- * options are missing.
+ * @returns An instance of `Installations` for `FirebaseApp.defaultApp()` or `nil` if the
+ * application is not configured yet.
  */
 + (nullable FIRInstallations *)installations NS_SWIFT_NAME(installations());
 
 /**
  * Returns an instance of `Installations` for an application.
  * @param application A configured `FirebaseApp` instance.
- * @returns An instance of `Installations` corresponding to the passed application.
- * @throw Throws an exception if required `FirebaseApp` options are missing.
+ * @returns An instance of `Installations` corresponding to the passed application or `nil` if
+ * the application is not configured yet.
  */
-+ (nullable FIRInstallations *)installationsWithApp:(FIRApp *)application NS_SWIFT_NAME(installations(app:));
++ (nullable FIRInstallations *)installationsWithApp:(FIRApp *)application
+    NS_SWIFT_NAME(installations(app:));
 
 /**
  * The method creates or retrieves an installation ID. The installation ID is a stable identifier

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsTests.m
@@ -62,7 +62,7 @@
 }
 
 - (void)testDefaultInstallationWhenNoDefaultAppThenIsNil {
-  XCTAssertThrows([FIRInstallations installations]);
+  XCTAssertNil([FIRInstallations installations]);
 }
 
 - (void)testInstallationIDSuccess {


### PR DESCRIPTION
A quick fix for issues like #4906. 
- `+[FIRInstallations installations]`, `+[FIRInstallations installationsWithApp:]`:  don't throw an exception if a corresponding app is not configured or is `nil`.

Before IID started using Firebase Installations the method `+[FIRInstanceID instanceID]` didn't throw an exception and returned `nil` in the case when `FIRApp` is not configured yet. Now `+[FIRInstanceID instanceID]` calls `+[FIRInstallations installations]` that throws an exception in this case. 

The exception revealed a race condition in `-[FIRApp deleteApp:]` method. Some SDKs like Analytics Performance, IID, etc. may have a background operation started before the app deletion and attempting to call `+[FIRInstallations installations]` after the deletion. The race condition will need to be addressed, but it may require significant changes so the current PR should provide a quick fix for the issue without a significant downside.  

cl/295207830 for global TAP presubmit