### PR TITLE
Add the ability to send to the new and legacy crash reporting endpoint

### DIFF
--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -12,6 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//
+// The report manager has the ability to send to two different endpoints.
+//
+// The old legacy flow for a report goes through the following states/folders:
+// 1. active - .clsrecords optimized for crash time persistance
+// 2. processing - .clsrecords with attempted symbolication
+// 3. prepared-legacy - .multipartmime of compressed .clsrecords
+//
+// The new legacy flow for a report goes through the following states/folders:
+// 1. active - .clsrecords optimized for crash time persistance
+// 2. processing - .clsrecords with attempted symbolication
+// 3. prepared - .clsrecords moved from processing with no changes
+//
+// The code was designed so the report processing workflows are not dramatically different from one another.
+// The design will help avoid having a lot of conditional code blocks throughout the codebase.
+//
+
 #include <stdatomic.h>
 
 #if __has_include(<FBLPromises/FBLPromises.h>)

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -25,8 +25,9 @@
 // 2. processing - .clsrecords with attempted symbolication
 // 3. prepared - .clsrecords moved from processing with no changes
 //
-// The code was designed so the report processing workflows are not dramatically different from one another.
-// The design will help avoid having a lot of conditional code blocks throughout the codebase.
+// The code was designed so the report processing workflows are not dramatically different from one
+// another. The design will help avoid having a lot of conditional code blocks throughout the
+// codebase.
 //
 
 #include <stdatomic.h>

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -16,12 +16,12 @@
 // The report manager has the ability to send to two different endpoints.
 //
 // The old legacy flow for a report goes through the following states/folders:
-// 1. active - .clsrecords optimized for crash time persistance
+// 1. active - .clsrecords optimized for crash time persistence
 // 2. processing - .clsrecords with attempted symbolication
 // 3. prepared-legacy - .multipartmime of compressed .clsrecords
 //
-// The new legacy flow for a report goes through the following states/folders:
-// 1. active - .clsrecords optimized for crash time persistance
+// The new flow for a report goes through the following states/folders:
+// 1. active - .clsrecords optimized for crash time persistence
 // 2. processing - .clsrecords with attempted symbolication
 // 3. prepared - .clsrecords moved from processing with no changes
 //

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportUploader.h
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportUploader.h
@@ -14,6 +14,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import <GoogleDataTransport/GDTCORTransport.h>
+
 @class FIRCLSDataCollectionToken;
 @class FIRCLSInternalReport;
 @class FIRCLSSettings;
@@ -73,5 +75,6 @@
 
 - (NSString *)googleAppID;
 - (FIRCLSSettings *)settings;
+- (GDTCORTransport *)googleTransport;
 
 @end

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportUploader.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportUploader.m
@@ -199,7 +199,8 @@
   FIRCLSDeveloperLog("Crashlytics:Crash:Reports", @"Submitting report%@",
                      urgent ? @" as urgent" : @"");
 
-  BOOL isNewPreparedPath = [path containsString:self.fileManager.preparedPath];
+  // Check with the legacy path as the new path will always be contained in the legacy path
+  BOOL isNewPreparedPath = ![path containsString:self.fileManager.legacyPreparedPath];
 
   if (isNewPreparedPath && self.dataSource.settings.shouldUseNewReportEndpoint) {
     FIRCLSReportAdapter *adapter =
@@ -219,22 +220,23 @@
     [self.dataSource.googleTransport
         sendDataEvent:event
            onComplete:^(BOOL wasWritten, NSError *error) {
-        
              if (!wasWritten) {
-               FIRCLSDeveloperLog("Crashlytics:Crash:Reports", @"Failed to send crash report due to gdt write failure.");
+               FIRCLSDeveloperLog("Crashlytics:Crash:Reports",
+                                  @"Failed to send crash report due to gdt write failure.");
                success = NO;
                return;
              }
 
              if (error) {
-               FIRCLSDeveloperLog("Crashlytics:Crash:Reports", @"Failed to send crash report due to gdt error: %@",
+               FIRCLSDeveloperLog("Crashlytics:Crash:Reports",
+                                  @"Failed to send crash report due to gdt error: %@",
                                   error.localizedDescription);
                success = NO;
                return;
              }
 
-             FIRCLSDeveloperLog("Crashlytics:Crash:Reports", @"Completed report submission with id: %@",
-                                path.lastPathComponent);
+             FIRCLSDeveloperLog("Crashlytics:Crash:Reports",
+                                @"Completed report submission with id: %@", path.lastPathComponent);
 
              if (urgent) {
                dispatch_semaphore_signal(semaphore);

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportUploader.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportUploader.m
@@ -25,6 +25,7 @@
 #import "FIRCLSNetworkClient.h"
 #import "FIRCLSPackageReportOperation.h"
 #import "FIRCLSProcessReportOperation.h"
+#import "FIRCLSReportAdapter.h"
 #import "FIRCLSReportUploader_Private.h"
 #import "FIRCLSSettings.h"
 #import "FIRCLSSymbolResolver.h"
@@ -34,6 +35,9 @@
 #import "FIRCLSConstants.h"
 #import "FIRCLSMultipartMimeStreamEncoder.h"
 #import "FIRCLSURLBuilder.h"
+
+#import <GoogleDataTransport/GDTCOREvent.h>
+#import <GoogleDataTransport/GDTCORTransport.h>
 
 @interface FIRCLSReportUploader () {
   id<FIRAnalyticsInterop> _analytics;
@@ -63,7 +67,222 @@
   return self;
 }
 
-#pragma mark - Properties
+#pragma mark - Packaging and Submission
+- (BOOL)prepareAndSubmitReport:(FIRCLSInternalReport *)report
+           dataCollectionToken:(FIRCLSDataCollectionToken *)dataCollectionToken
+                      asUrgent:(BOOL)urgent
+                withProcessing:(BOOL)shouldProcess {
+  __block BOOL success = NO;
+
+  if (![dataCollectionToken isValid]) {
+    FIRCLSErrorLog(@"Data collection disabled and report will not be submitted");
+    return NO;
+  }
+
+  if (!self.dataSource.settings.orgID) {
+    FIRCLSDebugLog(@"Skipping report with id '%@' this run of the app because Organization ID was "
+                   @"nil. Report will upload once settings are download successfully",
+                   report.identifier);
+    return YES;
+  }
+
+  FIRCLSApplicationActivity(
+      FIRCLSApplicationActivityDefault, @"Crashlytics Crash Report Processing", ^{
+        if (shouldProcess) {
+          if (![self.fileManager moveItemAtPath:[report path]
+                                    toDirectory:self.fileManager.processingPath]) {
+            FIRCLSErrorLog(@"Unable to move report for processing");
+            return;
+          }
+
+          // adjust the report's path, and process it
+          [report setPath:[self.fileManager.processingPath
+                              stringByAppendingPathComponent:report.directoryName]];
+
+          FIRCLSSymbolResolver *resolver = [[FIRCLSSymbolResolver alloc] init];
+
+          FIRCLSProcessReportOperation *processOperation =
+              [[FIRCLSProcessReportOperation alloc] initWithReport:report resolver:resolver];
+
+          [processOperation start];
+        }
+
+        NSString *packagedPath;
+
+        FIRCLSDebugLog(@"Preparing the report for the new endpoint: %d",
+                       self.dataSource.settings.shouldUseNewReportEndpoint);
+
+        if (self.dataSource.settings.shouldUseNewReportEndpoint) {
+          // For the new endpoint, just move the .clsrecords from "processing" -> "prepared"
+          packagedPath =
+              [self.fileManager.preparedPath stringByAppendingPathComponent:report.directoryName];
+          NSError *moveError = nil;
+          [self.fileManager moveItemAtPath:report.path toPath:packagedPath error:&moveError];
+          if (moveError) {
+            FIRCLSErrorLog(@"Unable to move report to prepared");
+          }
+        } else {
+          // For the legacy endpoint, continue generate the multipartmime file in "prepared-legacy"
+          FIRCLSPackageReportOperation *packageOperation =
+              [[FIRCLSPackageReportOperation alloc] initWithReport:report
+                                                       fileManager:self.fileManager
+                                                          settings:self.dataSource.settings];
+
+          [packageOperation start];
+          packagedPath = [packageOperation finalPath];
+          if (!packagedPath) {
+            FIRCLSErrorLog(@"Unable to package report");
+            return;
+          }
+        }
+
+        if (![[self fileManager] removeItemAtPath:[report path]]) {
+          FIRCLSErrorLog(@"Unable to remove a processing item");
+        }
+
+        NSLog(@"[Firebase/Crashlytics] Packaged report with id '%@' for submission",
+              report.identifier);
+
+        success = [self uploadPackagedReportAtPath:packagedPath
+                               dataCollectionToken:dataCollectionToken
+                                          asUrgent:urgent];
+
+        // If the upload was successful and the report contained a crash forward it to Google
+        // Analytics.
+        if (success && report.isCrash) {
+          [FIRCLSFCRAnalytics logCrashWithTimeStamp:report.crashedOnDate.timeIntervalSince1970
+                                        toAnalytics:self->_analytics];
+        }
+      });
+
+  return success;
+}
+
+- (BOOL)submitPackageMultipartMimeAtPath:(NSString *)multipartmimePath
+                     dataCollectionToken:(FIRCLSDataCollectionToken *)dataCollectionToken
+                           synchronously:(BOOL)synchronous {
+  FIRCLSDeveloperLog(@"Crashlytics:Crash:Reports", "Submitting %@ %@",
+                     synchronous ? @"sync" : @"async", multipartmimePath);
+
+  if ([[[self fileManager] fileSizeAtPath:multipartmimePath] unsignedIntegerValue] == 0) {
+    FIRCLSDeveloperLog("Crashlytics:Crash:Reports", @"Already-submitted report being ignored");
+    return NO;
+  }
+
+  NSTimeInterval timeout = 10.0;
+
+  // If we are submitting synchronously, be more aggressive with the timeout. However,
+  // we only need this if the client does not support background requests.
+  if (synchronous && ![[self networkClient] supportsBackgroundRequests]) {
+    timeout = 2.0;
+  }
+
+  NSMutableURLRequest *request = [self mutableRequestWithURL:[self reportURL] timeout:timeout];
+
+  [request setHTTPMethod:@"POST"];
+
+  if (![self fillInRequest:request forMultipartMimeDataAtPath:multipartmimePath]) {
+    return NO;
+  }
+
+  [[self networkClient] startUploadRequest:request
+                                  filePath:multipartmimePath
+                       dataCollectionToken:dataCollectionToken
+                               immediately:synchronous];
+
+  return YES;
+}
+
+- (BOOL)uploadPackagedReportAtPath:(NSString *)path
+               dataCollectionToken:(FIRCLSDataCollectionToken *)dataCollectionToken
+                          asUrgent:(BOOL)urgent {
+  FIRCLSDeveloperLog("Crashlytics:Crash:Reports", @"Submitting report%@",
+                     urgent ? @" as urgent" : @"");
+
+  BOOL isNewPreparedPath = [path containsString:self.fileManager.preparedPath];
+
+  if (isNewPreparedPath && self.dataSource.settings.shouldUseNewReportEndpoint) {
+    FIRCLSReportAdapter *adapter =
+        [[FIRCLSReportAdapter alloc] initWithPath:path
+                                      googleAppId:self.dataSource.googleAppID
+                                            orgId:self.dataSource.settings.orgID];
+
+    GDTCOREvent *event = [self.dataSource.googleTransport eventForTransport];
+    event.dataObject = adapter;
+    event.qosTier = GDTCOREventQoSFast;  // Bypass batching, send immediately
+
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+    // If async, then always return success. TODO: Is this an ok assumption?
+    __block BOOL success = YES;
+
+    [self.dataSource.googleTransport
+        sendDataEvent:event
+           onComplete:^(BOOL wasWritten, NSError *error) {
+        
+             if (!wasWritten) {
+               FIRCLSDeveloperLog("Crashlytics:Crash:Reports", @"Failed to send crash report due to gdt write failure.");
+               success = NO;
+               return;
+             }
+
+             if (error) {
+               FIRCLSDeveloperLog("Crashlytics:Crash:Reports", @"Failed to send crash report due to gdt error: %@",
+                                  error.localizedDescription);
+               success = NO;
+               return;
+             }
+
+             FIRCLSDeveloperLog("Crashlytics:Crash:Reports", @"Completed report submission with id: %@",
+                                path.lastPathComponent);
+
+             if (urgent) {
+               dispatch_semaphore_signal(semaphore);
+             }
+
+             [self cleanUpSubmittedReportAtPath:path];
+           }];
+
+    if (urgent) {
+      dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+    }
+
+    return success;
+
+  } else if (!isNewPreparedPath && !self.dataSource.settings.shouldUseNewReportEndpoint) {
+    return [self submitPackageMultipartMimeAtPath:path
+                              dataCollectionToken:dataCollectionToken
+                                    synchronously:urgent];
+  }
+
+  // Unsupported state
+  return NO;
+}
+
+- (BOOL)cleanUpSubmittedReportAtPath:(NSString *)path {
+  if (![[self fileManager] removeItemAtPath:path]) {
+    FIRCLSErrorLog(@"Unable to remove packaged submission");
+    return NO;
+  }
+
+  return YES;
+}
+
+- (void)reportUploadAtPath:(NSString *)path
+       dataCollectionToken:(FIRCLSDataCollectionToken *)dataCollectionToken
+        completedWithError:(NSError *)error {
+  FIRCLSDeveloperLog("Crashlytics:Crash:Reports", @"completed submission of %@", path);
+
+  if (!error) {
+    [self cleanUpSubmittedReportAtPath:path];
+  }
+
+  [[self delegate] didCompletePackageSubmission:path
+                            dataCollectionToken:dataCollectionToken
+                                          error:error];
+}
+
+#pragma mark - Properties (TODO: Can delete once the experiment is over)
 
 - (NSURL *)reportURL {
   FIRCLSURLBuilder *url = [FIRCLSURLBuilder URLWithBase:FIRCLSReportsEndpoint];
@@ -122,153 +341,6 @@
   [request setValue:[fileSize stringValue] forHTTPHeaderField:@"Content-Length"];
 
   return YES;
-}
-
-#pragma mark - Packaging and Submission
-- (BOOL)prepareAndSubmitReport:(FIRCLSInternalReport *)report
-           dataCollectionToken:(FIRCLSDataCollectionToken *)dataCollectionToken
-                      asUrgent:(BOOL)urgent
-                withProcessing:(BOOL)shouldProcess {
-  __block BOOL success = NO;
-
-  if (![dataCollectionToken isValid]) {
-    FIRCLSErrorLog(@"Data collection disabled and report will not be submitted");
-    return NO;
-  }
-
-  NSString *reportOrgID = self.dataSource.settings.orgID;
-  if (!reportOrgID) {
-    FIRCLSDebugLog(@"Skipping report with id '%@' this run of the app because Organization ID was "
-                   @"nil. Report will upload once settings are download successfully",
-                   report.identifier);
-    return YES;
-  }
-
-  FIRCLSApplicationActivity(
-      FIRCLSApplicationActivityDefault, @"Crashlytics Crash Report Processing", ^{
-        if (shouldProcess) {
-          if (![self.fileManager moveItemAtPath:[report path]
-                                    toDirectory:self.fileManager.processingPath]) {
-            FIRCLSErrorLog(@"Unable to move report for processing");
-            return;
-          }
-
-          // adjust the report's path, and process it
-          [report setPath:[self.fileManager.processingPath
-                              stringByAppendingPathComponent:report.directoryName]];
-
-          FIRCLSSymbolResolver *resolver = [[FIRCLSSymbolResolver alloc] init];
-
-          FIRCLSProcessReportOperation *processOperation =
-              [[FIRCLSProcessReportOperation alloc] initWithReport:report resolver:resolver];
-
-          [processOperation start];
-        }
-
-        FIRCLSPackageReportOperation *packageOperation =
-            [[FIRCLSPackageReportOperation alloc] initWithReport:report
-                                                     fileManager:self.fileManager
-                                                        settings:self.dataSource.settings];
-
-        [packageOperation start];
-
-        NSString *packagedPath = [packageOperation finalPath];
-        if (!packagedPath) {
-          FIRCLSErrorLog(@"Unable to package report");
-          return;
-        }
-
-        // Save the crashed on date for potential scion event sending.
-        NSTimeInterval crashedOnDate = report.crashedOnDate.timeIntervalSince1970;
-        // We only want to forward crash events to scion, storing this for later use.
-        BOOL isCrash = report.isCrash;
-
-        if (![[self fileManager] removeItemAtPath:[report path]]) {
-          FIRCLSErrorLog(@"Unable to remove a processing item");
-        }
-
-        NSLog(@"[Firebase/Crashlytics] Packaged report with id '%@' for submission",
-              report.identifier);
-
-        success = [self uploadPackagedReportAtPath:packagedPath
-                               dataCollectionToken:dataCollectionToken
-                                          asUrgent:urgent];
-
-        // If the upload was successful and the report contained a crash forward it to scion.
-        if (success && isCrash) {
-          [FIRCLSFCRAnalytics logCrashWithTimeStamp:crashedOnDate toAnalytics:self->_analytics];
-        }
-      });
-
-  return success;
-}
-
-- (BOOL)submitPackageMultipartMimeAtPath:(NSString *)multipartmimePath
-                     dataCollectionToken:(FIRCLSDataCollectionToken *)dataCollectionToken
-                           synchronously:(BOOL)synchronous {
-  FIRCLSDeveloperLog(@"Crashlytics:Crash:Reports", "Submitting %@ %@",
-                     synchronous ? @"sync" : @"async", multipartmimePath);
-
-  if ([[[self fileManager] fileSizeAtPath:multipartmimePath] unsignedIntegerValue] == 0) {
-    FIRCLSDeveloperLog("Crashlytics:Crash:Reports", @"Already-submitted report being ignored");
-    return NO;
-  }
-
-  NSTimeInterval timeout = 10.0;
-
-  // If we are submitting synchronously, be more aggressive with the timeout. However,
-  // we only need this if the client does not support background requests.
-  if (synchronous && ![[self networkClient] supportsBackgroundRequests]) {
-    timeout = 2.0;
-  }
-
-  NSMutableURLRequest *request = [self mutableRequestWithURL:[self reportURL] timeout:timeout];
-
-  [request setHTTPMethod:@"POST"];
-
-  if (![self fillInRequest:request forMultipartMimeDataAtPath:multipartmimePath]) {
-    return NO;
-  }
-
-  [[self networkClient] startUploadRequest:request
-                                  filePath:multipartmimePath
-                       dataCollectionToken:dataCollectionToken
-                               immediately:synchronous];
-
-  return YES;
-}
-
-- (BOOL)uploadPackagedReportAtPath:(NSString *)path
-               dataCollectionToken:(FIRCLSDataCollectionToken *)dataCollectionToken
-                          asUrgent:(BOOL)urgent {
-  FIRCLSDeveloperLog("Crashlytics:Crash:Reports", @"Submitting report%@",
-                     urgent ? @" as urgent" : @"");
-  return [self submitPackageMultipartMimeAtPath:path
-                            dataCollectionToken:dataCollectionToken
-                                  synchronously:urgent];
-}
-
-- (BOOL)cleanUpSubmittedReportAtPath:(NSString *)path {
-  if (![[self fileManager] removeItemAtPath:path]) {
-    FIRCLSErrorLog(@"Unable to remove packaged submission");
-    return NO;
-  }
-
-  return YES;
-}
-
-- (void)reportUploadAtPath:(NSString *)path
-       dataCollectionToken:(FIRCLSDataCollectionToken *)dataCollectionToken
-        completedWithError:(NSError *)error {
-  FIRCLSDeveloperLog("Crashlytics:Crash:Reports", @"completed submission of %@", path);
-
-  if (!error) {
-    [self cleanUpSubmittedReportAtPath:path];
-  }
-
-  [[self delegate] didCompletePackageSubmission:path
-                            dataCollectionToken:dataCollectionToken
-                                          error:error];
 }
 
 @end

--- a/Crashlytics/Crashlytics/Models/FIRCLSFileManager.h
+++ b/Crashlytics/Crashlytics/Models/FIRCLSFileManager.h
@@ -45,6 +45,7 @@
 @property(nonatomic, readonly) NSString *preparedPath;
 @property(nonatomic, readonly) NSString *legacyPreparedPath;
 @property(nonatomic, readonly) NSArray *activePathContents;
+@property(nonatomic, readonly) NSArray *legacyPreparedPathContents;
 @property(nonatomic, readonly) NSArray *preparedPathContents;
 @property(nonatomic, readonly) NSArray *processingPathContents;
 
@@ -73,7 +74,6 @@
 - (void)enumerateFilesInPreparedDirectoryUsingBlock:(void (^)(NSString *path,
                                                               NSString *extension))block;
 
-- (BOOL)moveProcessingContentsToPrepared;
 - (BOOL)movePendingToProcessing;
 
 - (BOOL)removeContentsOfProcessingPath;

--- a/Crashlytics/Crashlytics/Models/FIRCLSFileManager.h
+++ b/Crashlytics/Crashlytics/Models/FIRCLSFileManager.h
@@ -43,6 +43,7 @@
 @property(nonatomic, readonly) NSString *processingPath;
 @property(nonatomic, readonly) NSString *pendingPath;
 @property(nonatomic, readonly) NSString *preparedPath;
+@property(nonatomic, readonly) NSString *legacyPreparedPath;
 @property(nonatomic, readonly) NSArray *activePathContents;
 @property(nonatomic, readonly) NSArray *preparedPathContents;
 @property(nonatomic, readonly) NSArray *processingPathContents;
@@ -78,5 +79,7 @@
 - (BOOL)removeContentsOfProcessingPath;
 - (BOOL)removeContentsOfPendingPath;
 - (BOOL)removeContentsOfAllPaths;
+
+- (BOOL)moveItemAtPath:(NSString *)srcPath toPath:(NSString *)dstPath error:(NSError **)error;
 
 @end

--- a/Crashlytics/Crashlytics/Models/FIRCLSFileManager.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSFileManager.m
@@ -223,6 +223,11 @@ NSString *const FIRCLSCacheVersion = @"v4";
   return [[self structurePath] stringByAppendingPathComponent:@"processing"];
 }
 
+// TODO: v4 -> v5
+- (NSString *)legacyPreparedPath {
+  return [[self structurePath] stringByAppendingPathComponent:@"prepared-legacy"];
+}
+
 - (NSString *)preparedPath {
   return [[self structurePath] stringByAppendingPathComponent:@"prepared"];
 }
@@ -232,7 +237,7 @@ NSString *const FIRCLSCacheVersion = @"v4";
 }
 
 - (NSArray *)preparedPathContents {
-  return [self contentsOfDirectory:[self preparedPath]];
+  return [self contentsOfDirectory:[self legacyPreparedPath]];
 }
 
 - (NSArray *)processingPathContents {
@@ -249,6 +254,10 @@ NSString *const FIRCLSCacheVersion = @"v4";
     return NO;
   }
 
+  if (![self createDirectoryAtPath:[self legacyPreparedPath]]) {
+    return NO;
+  }
+    
   if (![self createDirectoryAtPath:[self preparedPath]]) {
     return NO;
   }
@@ -285,11 +294,11 @@ NSString *const FIRCLSCacheVersion = @"v4";
 
 - (void)enumerateFilesInPreparedDirectoryUsingBlock:(void (^)(NSString *path,
                                                               NSString *extension))block {
-  [self enumerateFilesInDirectory:[self preparedPath] usingBlock:block];
+  [self enumerateFilesInDirectory:[self legacyPreparedPath] usingBlock:block];
 }
 
 - (BOOL)moveProcessingContentsToPrepared {
-  return [self moveItemsFromDirectory:[self processingPath] toDirectory:[self preparedPath]];
+  return [self moveItemsFromDirectory:[self processingPath] toDirectory:[self legacyPreparedPath]];
 }
 
 - (BOOL)movePendingToProcessing {
@@ -308,12 +317,16 @@ NSString *const FIRCLSCacheVersion = @"v4";
   BOOL contentsOfProcessingPathRemoved = [self removeContentsOfProcessingPath];
   BOOL contentsOfPendingPathRemoved = [self removeContentsOfPendingPath];
   BOOL contentsOfDirectoryAtPreparedPathRemoved =
-      [self removeContentsOfDirectoryAtPath:self.preparedPath];
+      [self removeContentsOfDirectoryAtPath:self.legacyPreparedPath];
   BOOL contentsOfDirectoryAtActivePathRemoved =
       [self removeContentsOfDirectoryAtPath:self.activePath];
   BOOL success = contentsOfProcessingPathRemoved && contentsOfPendingPathRemoved &&
                  contentsOfDirectoryAtPreparedPathRemoved && contentsOfDirectoryAtActivePathRemoved;
   return success;
+}
+
+- (BOOL)moveItemAtPath:(NSString *)srcPath toPath:(NSString *)dstPath error:(NSError **)error {
+  return [self.underlyingFileManager moveItemAtPath:srcPath toPath:dstPath error:error];
 }
 
 @end

--- a/Crashlytics/Crashlytics/Models/FIRCLSFileManager.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSFileManager.m
@@ -19,7 +19,7 @@
 #import "FIRCLSLogger.h"
 
 NSString *const FIRCLSCacheDirectoryName = @"com.crashlytics.data";
-NSString *const FIRCLSCacheVersion = @"v4";
+NSString *const FIRCLSCacheVersion = @"v5";
 
 @interface FIRCLSFileManager () {
   NSString *_rootPath;
@@ -236,8 +236,12 @@ NSString *const FIRCLSCacheVersion = @"v4";
   return [self contentsOfDirectory:[self activePath]];
 }
 
-- (NSArray *)preparedPathContents {
+- (NSArray *)legacyPreparedPathContents {
   return [self contentsOfDirectory:[self legacyPreparedPath]];
+}
+
+- (NSArray *)preparedPathContents {
+  return [self contentsOfDirectory:[self preparedPath]];
 }
 
 - (NSArray *)processingPathContents {
@@ -257,7 +261,7 @@ NSString *const FIRCLSCacheVersion = @"v4";
   if (![self createDirectoryAtPath:[self legacyPreparedPath]]) {
     return NO;
   }
-    
+
   if (![self createDirectoryAtPath:[self preparedPath]]) {
     return NO;
   }
@@ -297,10 +301,6 @@ NSString *const FIRCLSCacheVersion = @"v4";
   [self enumerateFilesInDirectory:[self legacyPreparedPath] usingBlock:block];
 }
 
-- (BOOL)moveProcessingContentsToPrepared {
-  return [self moveItemsFromDirectory:[self processingPath] toDirectory:[self legacyPreparedPath]];
-}
-
 - (BOOL)movePendingToProcessing {
   return [self moveItemsFromDirectory:[self pendingPath] toDirectory:[self processingPath]];
 }
@@ -317,11 +317,15 @@ NSString *const FIRCLSCacheVersion = @"v4";
   BOOL contentsOfProcessingPathRemoved = [self removeContentsOfProcessingPath];
   BOOL contentsOfPendingPathRemoved = [self removeContentsOfPendingPath];
   BOOL contentsOfDirectoryAtPreparedPathRemoved =
+      [self removeContentsOfDirectoryAtPath:self.preparedPath];
+  BOOL contentsOfDirectoryAtLegacyPreparedPathRemoved =
       [self removeContentsOfDirectoryAtPath:self.legacyPreparedPath];
   BOOL contentsOfDirectoryAtActivePathRemoved =
       [self removeContentsOfDirectoryAtPath:self.activePath];
   BOOL success = contentsOfProcessingPathRemoved && contentsOfPendingPathRemoved &&
-                 contentsOfDirectoryAtPreparedPathRemoved && contentsOfDirectoryAtActivePathRemoved;
+                 contentsOfDirectoryAtPreparedPathRemoved &&
+                 contentsOfDirectoryAtActivePathRemoved &&
+                 contentsOfDirectoryAtLegacyPreparedPathRemoved;
   return success;
 }
 

--- a/Crashlytics/Crashlytics/Operations/Reports/FIRCLSPackageReportOperation.m
+++ b/Crashlytics/Crashlytics/Operations/Reports/FIRCLSPackageReportOperation.m
@@ -97,7 +97,7 @@
 }
 
 - (NSString *)destinationDirectory {
-  return [self.fileManager preparedPath];
+  return [self.fileManager legacyPreparedPath];
 }
 
 - (NSString *)packagedPathWithName:(NSString *)name {

--- a/Crashlytics/UnitTests/FIRCLSFileManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSFileManagerTests.m
@@ -65,7 +65,7 @@
 
   XCTAssertTrue([self doesFileExist:path], @"");
 
-  path = [path stringByAppendingPathComponent:@"v4/reports"];
+  path = [path stringByAppendingPathComponent:@"v5/reports"];
   XCTAssertTrue([self doesFileExist:path], @"");
 
   for (NSString* subpath in @[ @"active", @"prepared", @"processing" ]) {

--- a/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportManagerTests.m
@@ -110,8 +110,9 @@
 }
 
 - (NSArray *)contentsOfPreparedPath {
-  return [[NSFileManager defaultManager] contentsOfDirectoryAtPath:self.fileManager.preparedPath
-                                                             error:nil];
+  return
+      [[NSFileManager defaultManager] contentsOfDirectoryAtPath:self.fileManager.legacyPreparedPath
+                                                          error:nil];
 }
 
 - (NSArray *)contentsOfProcessingPath {
@@ -482,8 +483,8 @@
 
 - (void)testFilesLeftInPrepared {
   // Drop a phony multipart-mime file in here, with non-zero contents.
-  XCTAssert([_fileManager createDirectoryAtPath:_fileManager.preparedPath]);
-  NSString *path = [_fileManager.preparedPath stringByAppendingPathComponent:@"phony-report"];
+  XCTAssert([_fileManager createDirectoryAtPath:_fileManager.legacyPreparedPath]);
+  NSString *path = [_fileManager.legacyPreparedPath stringByAppendingPathComponent:@"phony-report"];
   path = [path stringByAppendingPathExtension:@".multipart-mime"];
 
   XCTAssertTrue([[_fileManager underlyingFileManager]
@@ -503,8 +504,8 @@
 
 - (void)testFilesLeftInPreparedWithDataCollectionDisabled {
   // drop a phony multipart-mime file in here, with non-zero contents
-  XCTAssert([_fileManager createDirectoryAtPath:_fileManager.preparedPath]);
-  NSString *path = [_fileManager.preparedPath stringByAppendingPathComponent:@"phony-report"];
+  XCTAssert([_fileManager createDirectoryAtPath:_fileManager.legacyPreparedPath]);
+  NSString *path = [_fileManager.legacyPreparedPath stringByAppendingPathComponent:@"phony-report"];
   path = [path stringByAppendingPathExtension:@".multipart-mime"];
 
   XCTAssertTrue([[_fileManager underlyingFileManager]
@@ -531,8 +532,8 @@
 
 - (void)testSuccessfulSubmission {
   // drop a phony multipart-mime file in here, with non-zero contents
-  XCTAssert([_fileManager createDirectoryAtPath:_fileManager.preparedPath]);
-  NSString *path = [_fileManager.preparedPath stringByAppendingPathComponent:@"phony-report"];
+  XCTAssert([_fileManager createDirectoryAtPath:_fileManager.legacyPreparedPath]);
+  NSString *path = [_fileManager.legacyPreparedPath stringByAppendingPathComponent:@"phony-report"];
   path = [path stringByAppendingPathExtension:@".multipart-mime"];
 
   XCTAssertTrue([[_fileManager underlyingFileManager]

--- a/Crashlytics/UnitTests/FIRCLSReportUploaderTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportUploaderTests.m
@@ -23,6 +23,7 @@
 #include "FIRCLSFileManager.h"
 #include "FIRCLSMockSettings.h"
 #include "FIRCLSSettings.h"
+#include "FIRMockGDTCoreTransport.h"
 
 NSString *const TestEndpoint = @"https://reports.crashlytics.com";
 
@@ -89,6 +90,10 @@ NSString *const TestEndpoint = @"https://reports.crashlytics.com";
                                                                       appIDModel:appIDModel];
   settings.fetchedBundleID = self.bundleIdentifier;
   return settings;
+}
+
+- (GDTCORTransport *)googleTransport {
+  return [[FIRMockGDTCORTransport alloc] initWithMappingID:@"mappingID" transformers:nil target:0];
 }
 
 - (void)didCompleteAllSubmissions {


### PR DESCRIPTION
 The report manager has the ability to send to two different endpoints.

The old legacy flow for a report goes through the following states/folders:
1. active - .clsrecords optimized for crash time persistence
2. processing - .clsrecords with attempted symbolication
3. prepared-legacy - .multipartmime of compressed .clsrecords

The legacy flow for a report goes through the following states/folders:
1. active - .clsrecords optimized for crash time persistence
2. processing - .clsrecords with attempted symbolication
3. prepared - .clsrecords moved from processing with no changes

The code was designed so the report processing workflows are not dramatically different from one another. The design will help avoid having a lot of conditional code blocks throughout the codebase.
