### PR TITLE
Force synchronous AsyncQueue shutdown

### DIFF
--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -270,8 +270,8 @@ class FakeCredentialsProvider : public EmptyCredentialsProvider {
 - (FIRApp *)appWithProjectID:(NSString *)projectID {
   FIRApp *app = _apps[projectID];
   if (!app) {
-    // Use the same appName across integration tests to ensure that terminating
-    // Firestore is is actually completing before the next test starts.
+    // Use the same appName across integration tests to ensure that Firestore termination is
+    // actually complete before the next test starts.
     NSString *appName = [NSString stringWithFormat:@"firestore-integration-tests-%@", projectID];
     FIROptions *options = OptionsForUnitTesting(util::MakeString(projectID));
 

--- a/Firestore/core/src/firebase/firestore/api/firestore.cc
+++ b/Firestore/core/src/firebase/firestore/api/firestore.cc
@@ -63,13 +63,7 @@ Firestore::Firestore(model::DatabaseId database_id,
 }
 
 Firestore::~Firestore() {
-  std::lock_guard<std::mutex> lock{mutex_};
-
-  // If the client hasn't been configured yet we don't need to create it just
-  // to tear it down.
-  if (!client_) return;
-
-  client_->Dispose();
+  Dispose();
 }
 
 const std::shared_ptr<FirestoreClient>& Firestore::client() {
@@ -144,6 +138,17 @@ void Firestore::Terminate(util::StatusCallback callback) {
   // throws an exception.
   EnsureClientConfigured();
   client_->TerminateAsync(std::move(callback));
+}
+
+void Firestore::Dispose() {
+  std::lock_guard<std::mutex> lock{mutex_};
+
+  // If the client hasn't been configured yet we don't need to create it just
+  // to dispose of it.
+  if (!client_) return;
+
+  client_->Dispose();
+  client_.reset();
 }
 
 void Firestore::WaitForPendingWrites(util::StatusCallback callback) {

--- a/Firestore/core/src/firebase/firestore/api/firestore.cc
+++ b/Firestore/core/src/firebase/firestore/api/firestore.cc
@@ -69,7 +69,7 @@ Firestore::~Firestore() {
   // to tear it down.
   if (!client_) return;
 
-  client_->Stop();
+  client_->Dispose();
 }
 
 const std::shared_ptr<FirestoreClient>& Firestore::client() {

--- a/Firestore/core/src/firebase/firestore/api/firestore.cc
+++ b/Firestore/core/src/firebase/firestore/api/firestore.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ Firestore::~Firestore() {
   // to tear it down.
   if (!client_) return;
 
-  client_->Terminate();
+  client_->Stop();
 }
 
 const std::shared_ptr<FirestoreClient>& Firestore::client() {
@@ -152,7 +152,7 @@ void Firestore::WaitForPendingWrites(util::StatusCallback callback) {
 }
 
 void Firestore::ClearPersistence(util::StatusCallback callback) {
-  worker_queue()->EnqueueEvenAfterShutdown([this, callback] {
+  worker_queue()->EnqueueEvenWhileRestricted([this, callback] {
     auto Yield = [=](Status status) {
       if (callback) {
         this->user_executor_->Execute([=] { callback(status); });

--- a/Firestore/core/src/firebase/firestore/api/firestore.h
+++ b/Firestore/core/src/firebase/firestore/api/firestore.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,6 +92,16 @@ class Firestore : public std::enable_shared_from_this<Firestore> {
                       core::TransactionResultCallback result_callback);
 
   void Terminate(util::StatusCallback callback);
+
+  /**
+   * Synchronously terminates this Firestore instance including its
+   * `FirestoreClient`. Waits for all outstanding operations to complete.
+   *
+   * See `FirestoreClient::Dispose` for more details on exactly what is
+   * disposed.
+   */
+  void Dispose();
+
   void ClearPersistence(util::StatusCallback callback);
   void WaitForPendingWrites(util::StatusCallback callback);
   std::unique_ptr<ListenerRegistration> AddSnapshotsInSyncListener(

--- a/Firestore/core/src/firebase/firestore/core/event_listener.h
+++ b/Firestore/core/src/firebase/firestore/core/event_listener.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@
 #ifndef FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_EVENT_LISTENER_H_
 #define FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_CORE_EVENT_LISTENER_H_
 
-#include <atomic>
 #include <memory>
+#include <mutex>  // NOLINT(build/c++11)
 #include <utility>
 
 #include "Firestore/core/src/firebase/firestore/util/executor.h"
@@ -64,9 +64,6 @@ class AsyncEventListener
   AsyncEventListener(const std::shared_ptr<util::Executor>& executor,
                      DelegateListener&& delegate)
       : executor_(executor), delegate_(std::move(delegate)) {
-    // std::atomic's constructor is not atomic, so assign after contruction
-    // (since assignment is atomic).
-    muted_ = false;
   }
 
   static std::shared_ptr<AsyncEventListener<T>> Create(
@@ -87,9 +84,32 @@ class AsyncEventListener
   void Mute();
 
  private:
-  std::atomic<bool> muted_;
   std::shared_ptr<util::Executor> executor_;
   DelegateListener delegate_;
+
+  // A mutex that protects both muting the AsyncEventListener and also calling
+  // out to the delegate.
+  //
+  // Mute calls must be synchronized because users expect that when they call
+  // `ListenerRegistration::Remove` that they don't get notifications pretty
+  // much immediately upon return of that method. That is, we can't afford to
+  // wait for the `Remove` to be submitted through the `AsyncQueue`.
+  //
+  // The call to delegate_->OnEvent must also be protected in order to ensure
+  // that The `Firestore` instance isn't destroyed while we're calling out to
+  // user code. `Firestore::Dispose` (eventually) calls `Mute` on each listener
+  // and forcing `Mute` and `OnEvent` to be mutually exclusive avoids a race.
+  //
+  // This must be a recursive mutex because the `DelegateListener` may be user
+  // code, and that we must allow that user code to invoke
+  // `ListenerRegistration::Remove` (which calls `Mute` on this class). If this
+  // were a non-recursive mutex such a call would deadlock.
+  //
+  // PORTING NOTE: On Android there's only a `volatile bool muted` because
+  // there's no race with destruction; the only thing that needs protection is
+  // that the listener immediately stops emitting events.
+  std::recursive_mutex mutex_;
+  bool muted_ = false;
 };
 
 template <typename T>
@@ -120,6 +140,7 @@ std::shared_ptr<AsyncEventListener<T>> AsyncEventListener<T>::Create(
 
 template <typename T>
 void AsyncEventListener<T>::Mute() {
+  std::lock_guard<std::recursive_mutex> lock(mutex_);
   muted_ = true;
 }
 
@@ -132,6 +153,9 @@ void AsyncEventListener<T>::OnEvent(util::StatusOr<T> maybe_value) {
   std::shared_ptr<AsyncEventListener<T>> shared_this = this->shared_from_this();
 
   executor_->Execute([shared_this, maybe_value]() {
+    // Hold the lock while calling the delegate in order to prevent concurrent
+    // destruction of the Firestore instance.
+    std::lock_guard<std::recursive_mutex> lock(shared_this->mutex_);
     if (!shared_this->muted_) {
       shared_this->delegate_->OnEvent(std::move(maybe_value));
     }

--- a/Firestore/core/src/firebase/firestore/core/firestore_client.cc
+++ b/Firestore/core/src/firebase/firestore/core/firestore_client.cc
@@ -311,9 +311,8 @@ void FirestoreClient::VerifyNotTerminated() {
 }
 
 bool FirestoreClient::is_terminated() const {
-  // Technically, the worker queue is still running, but only accepting tasks
-  // related to termination or supposed to be run after termination. It is
-  // effectively terminated to the eyes of users.
+  // When the user calls Terminate, this puts the AsyncQueue into restricted
+  // mode. There's no need to track termination separately.
   return worker_queue()->is_restricted();
 }
 

--- a/Firestore/core/src/firebase/firestore/core/firestore_client.h
+++ b/Firestore/core/src/firebase/firestore/core/firestore_client.h
@@ -86,15 +86,16 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
 
   /**
    * Terminates this client, cancels all writes / listeners, and releases all
-   * resources.
+   * resources. The client enters a restricted mode where only a few methods
+   * like ClearPersistence are allowed.
    */
   void TerminateAsync(util::StatusCallback callback);
 
   /**
-   * Synchronously terminates this client, cancels all writes / listeners, and
-   * releases all resources.
+   * Synchronously terminates this client, cancels all writes / listeners,
+   * releases all resources, and prepares for destruction.
    */
-  void Terminate();
+  void Stop();
 
   /**
    * Passes a callback that is triggered when all the pending writes at the

--- a/Firestore/core/src/firebase/firestore/core/firestore_client.h
+++ b/Firestore/core/src/firebase/firestore/core/firestore_client.h
@@ -94,6 +94,8 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
   /**
    * Synchronously terminates this client, cancels all writes / listeners,
    * releases all resources, and prepares for destruction.
+   *
+   * This also synchronously waits for the last pending operation to complete.
    */
   void Stop();
 

--- a/Firestore/core/src/firebase/firestore/core/firestore_client.h
+++ b/Firestore/core/src/firebase/firestore/core/firestore_client.h
@@ -84,6 +84,8 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
       std::shared_ptr<util::Executor> user_executor,
       std::shared_ptr<util::AsyncQueue> worker_queue);
 
+  ~FirestoreClient();
+
   /**
    * Terminates this client, cancels all writes / listeners, and releases all
    * resources. The client enters a restricted mode where only a few methods
@@ -93,11 +95,15 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
 
   /**
    * Synchronously terminates this client, cancels all writes / listeners,
-   * releases all resources, and prepares for destruction.
+   * releases all resources, synchronously waits for the last pending operation
+   * to complete, and all but destroys this instance.
    *
-   * This also synchronously waits for the last pending operation to complete.
+   * Note: Dispose exists separately from the destructor because shared_ptrs to
+   * FirestoreClient are captured frequently in ways that are hard to audit.
+   * This in turn makes it difficult to rely on the last shared owner to
+   * destroy the instance in a timely manner. All asynchronous operations
    */
-  void Stop();
+  void Dispose();
 
   /**
    * Passes a callback that is triggered when all the pending writes at the

--- a/Firestore/core/src/firebase/firestore/core/firestore_client.h
+++ b/Firestore/core/src/firebase/firestore/core/firestore_client.h
@@ -101,7 +101,7 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
    * Note: Dispose exists separately from the destructor because shared_ptrs to
    * FirestoreClient are captured frequently in ways that are hard to audit.
    * This in turn makes it difficult to rely on the last shared owner to
-   * destroy the instance in a timely manner. All asynchronous operations
+   * destroy the instance in a timely manner.
    */
   void Dispose();
 

--- a/Firestore/core/src/firebase/firestore/local/index_free_query_engine.cc
+++ b/Firestore/core/src/firebase/firestore/local/index_free_query_engine.cc
@@ -78,7 +78,7 @@ DocumentMap IndexFreeQueryEngine::GetDocumentsMatchingQuery(
       local_documents_view_->GetDocumentsMatchingQuery(
           query, last_limbo_free_snapshot_version);
 
-  // We merge `previous_results` into `update_results`, since `update_results`
+  // We merge `previous_results` into `updated_results`, since `updated_results`
   // is already a DocumentMap. If a document is contained in both lists, then
   // its contents are the same.
   for (const Document& result : previous_results) {

--- a/Firestore/core/src/firebase/firestore/remote/grpc_stream.cc
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_stream.cc
@@ -99,8 +99,8 @@ GrpcStream::GrpcStream(
 
 GrpcStream::~GrpcStream() {
   LOG_DEBUG("GrpcStream('%s'): destroying stream", this);
-  HARD_ASSERT(completions_.empty(),
-              "GrpcStream is being destroyed without proper shutdown");
+  HARD_ASSERT_NOTHROW(completions_.empty(),
+                      "GrpcStream is being destroyed without proper shutdown");
   MaybeUnregister();
 }
 

--- a/Firestore/core/src/firebase/firestore/remote/grpc_unary_call.cc
+++ b/Firestore/core/src/firebase/firestore/remote/grpc_unary_call.cc
@@ -45,8 +45,9 @@ GrpcUnaryCall::GrpcUnaryCall(
 }
 
 GrpcUnaryCall::~GrpcUnaryCall() {
-  HARD_ASSERT(!finish_completion_,
-              "GrpcUnaryCall is being destroyed without proper shutdown");
+  HARD_ASSERT_NOTHROW(
+      !finish_completion_,
+      "GrpcUnaryCall is being destroyed without proper shutdown");
   MaybeUnregister();
 }
 

--- a/Firestore/core/src/firebase/firestore/util/async_queue.h
+++ b/Firestore/core/src/firebase/firestore/util/async_queue.h
@@ -91,12 +91,13 @@ class AsyncQueue : public std::enable_shared_from_this<AsyncQueue> {
 
   enum class Mode {
     /**
-     * The default mode of an AsyncQueue after creation. All tasks are allowed.
+     * The default mode of an `AsyncQueue` after creation. All tasks are
+     * allowed.
      */
     Running,
 
     /**
-     * The AsyncQueue enters Mode::Restricted after the a user terminates an
+     * The `AsyncQueue` enters `Mode::Restricted` after the a user terminates an
      * instance of Firestore. In this mode, most tasks are not allowed: only a
      * special limited set of operations are still allowed to run.
      */
@@ -104,7 +105,7 @@ class AsyncQueue : public std::enable_shared_from_this<AsyncQueue> {
 
     /**
      * Finally, once the Firestore instance is in the process of being destroyed
-     * the AsyncQueue stops accepting all tasks.
+     * the `AsyncQueue` stops accepting all tasks.
      */
     Stopped,
   };
@@ -134,18 +135,18 @@ class AsyncQueue : public std::enable_shared_from_this<AsyncQueue> {
   // Puts the `AsyncQueue` into restricted mode, where calling any Enqueue*
   // methods becomes a no-op.
   //
-  // The exception is `EnqueueEvenWhileRestricted`, where operations are still
-  // scheduled even while in restricted mode.
+  // The exception is `EnqueueEvenWhileRestricted`, which would still enqueue
+  // operations even while in restricted mode.
   void EnterRestrictedMode();
 
-  // Puts the `AsyncQueue` into the stopped mode, where calling any Enqueue*
-  // methods becomes a no-op without exception.
+  // Puts the `AsyncQueue` into stopped mode, where calling any Enqueue* methods
+  // becomes a no-op without exception.
   //
   // This also synchronously waits for the last pending operation to complete.
   void Stop();
 
   // Like `Enqueue`, but it will proceed scheduling the requested operation
-  // regardless of whether the queue is shut down or not.
+  // regardless of whether the queue is in restricted mode or not.
   void EnqueueEvenWhileRestricted(const Operation& operation);
 
   // Like `Enqueue`, but without applying any prerequisite checks.

--- a/Firestore/core/src/firebase/firestore/util/async_queue.h
+++ b/Firestore/core/src/firebase/firestore/util/async_queue.h
@@ -104,8 +104,8 @@ class AsyncQueue : public std::enable_shared_from_this<AsyncQueue> {
     Restricted,
 
     /**
-     * Finally, once the Firestore instance is in the process of being destroyed
-     * the `AsyncQueue` stops accepting all tasks.
+     * Finally, once the Firestore instance is in the process of being
+     * destroyed, the `AsyncQueue` stops accepting all tasks.
      */
     Disposed,
   };

--- a/Firestore/core/src/firebase/firestore/util/exception.cc
+++ b/Firestore/core/src/firebase/firestore/util/exception.cc
@@ -31,6 +31,7 @@ namespace {
 const char* ExceptionName(ExceptionType exception) {
   switch (exception) {
     case ExceptionType::AssertionFailure:
+    case ExceptionType::AssertionFailureNoThrow:
       return "FIRESTORE INTERNAL ASSERTION FAILED";
     case ExceptionType::IllegalState:
       return "Illegal state";
@@ -39,6 +40,8 @@ const char* ExceptionName(ExceptionType exception) {
   }
   UNREACHABLE();
 }
+
+}  // namespace
 
 ABSL_ATTRIBUTE_NORETURN void DefaultThrowHandler(ExceptionType type,
                                                  const char* file,
@@ -55,6 +58,10 @@ ABSL_ATTRIBUTE_NORETURN void DefaultThrowHandler(ExceptionType type,
   switch (type) {
     case ExceptionType::AssertionFailure:
       throw FirestoreInternalError(what);
+    case ExceptionType::AssertionFailureNoThrow:
+      LOG_ERROR("%s", what);
+      std::terminate();
+      break;
     case ExceptionType::IllegalState:
       throw std::logic_error(what);
     case ExceptionType::InvalidArgument:
@@ -67,6 +74,8 @@ ABSL_ATTRIBUTE_NORETURN void DefaultThrowHandler(ExceptionType type,
 
   UNREACHABLE();
 }
+
+namespace {
 
 ThrowHandler throw_handler = DefaultThrowHandler;
 

--- a/Firestore/core/src/firebase/firestore/util/exception.h
+++ b/Firestore/core/src/firebase/firestore/util/exception.h
@@ -90,7 +90,7 @@ using ThrowHandler = void (*)(ExceptionType type,
 /**
  * The default throw handler implementation, suitable for C++. If exceptions are
  * enabled, throws a C++ exception, except for AssertionFailureNoThrow, which
- * unconditionally aborts.
+ * unconditionally terminates.
  */
 ABSL_ATTRIBUTE_NORETURN void DefaultThrowHandler(ExceptionType type,
                                                  const char* file,

--- a/Firestore/core/src/firebase/firestore/util/exception.h
+++ b/Firestore/core/src/firebase/firestore/util/exception.h
@@ -58,8 +58,26 @@ class FirestoreInternalError : public std::logic_error {
  * interaction with the Firestore API.
  */
 enum class ExceptionType {
+  /** An assertion failure. */
   AssertionFailure,
+
+  /**
+   * An assertion failure in a code location that cannot throw a C++ exception,
+   * typically in a destructor.
+   */
+  AssertionFailureNoThrow,
+
+  /**
+   * A user visible illegal state exception, indicating that the user has
+   * invoked the API in a way that is invalid (e.g. two methods consecutively
+   * that aren't allowed in combination).
+   */
   IllegalState,
+
+  /**
+   * A user visible invalid argument exception, indicating that the user has
+   * passed something invalid to a public API.
+   */
   InvalidArgument,
 };
 
@@ -68,6 +86,17 @@ using ThrowHandler = void (*)(ExceptionType type,
                               const char* func,
                               int line,
                               const std::string& message);
+
+/**
+ * The default throw handler implementation, suitable for C++. If exceptions are
+ * enabled, throws a C++ exception, except for AssertionFailureNoThrow, which
+ * unconditionally aborts.
+ */
+ABSL_ATTRIBUTE_NORETURN void DefaultThrowHandler(ExceptionType type,
+                                                 const char* file,
+                                                 const char* func,
+                                                 int line,
+                                                 const std::string& message);
 
 /**
  * Overrides the default exception throw handler.

--- a/Firestore/core/src/firebase/firestore/util/exception_apple.mm
+++ b/Firestore/core/src/firebase/firestore/util/exception_apple.mm
@@ -33,6 +33,7 @@ namespace {
 NSString* ExceptionName(ExceptionType exception) {
   switch (exception) {
     case ExceptionType::AssertionFailure:
+    case ExceptionType::AssertionFailureNoThrow:
       return @"FIRESTORE INTERNAL ASSERTION FAILED";
     case ExceptionType::IllegalState:
       return @"FIRIllegalStateException";
@@ -55,7 +56,8 @@ ABSL_ATTRIBUTE_NORETURN void ObjcThrowHandler(ExceptionType type,
                                               const char* func,
                                               int line,
                                               const std::string& message) {
-  if (type == ExceptionType::AssertionFailure) {
+  if (type == ExceptionType::AssertionFailure ||
+      type == ExceptionType::AssertionFailureNoThrow) {
     [[NSAssertionHandler currentHandler]
         handleFailureInFunction:MakeNSString(func)
                            file:MakeNSString(file)

--- a/Firestore/core/src/firebase/firestore/util/executor.h
+++ b/Firestore/core/src/firebase/firestore/util/executor.h
@@ -110,9 +110,11 @@ class Executor {
   // Schedules the `operation` to be asynchronously executed as soon as
   // possible, in FIFO order.
   virtual void Execute(Operation&& operation) = 0;
+
   // Like `Execute`, but blocks until the `operation` finishes, consequently
   // draining immediate operations from the executor.
   virtual void ExecuteBlocking(Operation&& operation) = 0;
+
   // Scheduled the given `operation` to be executed after `delay` milliseconds
   // from now, and returns a handle that allows to cancel the operation
   // (provided it hasn't been run already). The operation is tagged to allow
@@ -125,10 +127,12 @@ class Executor {
 
   // Checks for the caller whether it is being invoked by this executor.
   virtual bool IsCurrentExecutor() const = 0;
+
   // Returns some sort of an identifier for the current execution context. The
   // only guarantee is that it will return different values depending on whether
   // this function is invoked by this executor or not.
   virtual std::string CurrentExecutorName() const = 0;
+
   // Like `CurrentExecutorName`, but returns an identifier for this executor,
   // whether the caller code currently runs on this executor or not.
   virtual std::string Name() const = 0;
@@ -136,6 +140,7 @@ class Executor {
   // Checks whether an operation tagged with the given `tag` is currently
   // scheduled for future execution.
   virtual bool IsScheduled(Tag tag) const = 0;
+
   // Removes the nearest due scheduled operation from the schedule and returns
   // it to the caller. This function may be used to reschedule operations.
   // Immediate operations don't count; only operations scheduled for delayed

--- a/Firestore/core/src/firebase/firestore/util/executor_libdispatch.mm
+++ b/Firestore/core/src/firebase/firestore/util/executor_libdispatch.mm
@@ -256,7 +256,8 @@ DelayedOperation ExecutorLibdispatch::Schedule(const Milliseconds delay,
   // stores an observer pointer to the operation.
   TimeSlot* time_slot = nullptr;
   TimeSlotId time_slot_id = 0;
-  DispatchSync(dispatch_queue_, [this, delay, &operation, &time_slot, &time_slot_id] {
+  DispatchSync(dispatch_queue_, [this, delay, &operation, &time_slot,
+                                 &time_slot_id] {
     time_slot_id = NextId();
     time_slot = new TimeSlot{this, delay, std::move(operation), time_slot_id};
     schedule_[time_slot_id] = time_slot;

--- a/Firestore/core/src/firebase/firestore/util/hard_assert.cc
+++ b/Firestore/core/src/firebase/firestore/util/hard_assert.cc
@@ -28,14 +28,16 @@ namespace firestore {
 namespace util {
 namespace internal {
 
-void FailAssertion(const char* file,
+void FailAssertion(ExceptionType exception_type,
+                   const char* file,
                    const char* func,
                    const int line,
                    const std::string& message) {
-  Throw(ExceptionType::AssertionFailure, file, func, line, message);
+  Throw(exception_type, file, func, line, message);
 }
 
-void FailAssertion(const char* file,
+void FailAssertion(ExceptionType exception_type,
+                   const char* file,
                    const char* func,
                    const int line,
                    const std::string& message,
@@ -46,7 +48,7 @@ void FailAssertion(const char* file,
   } else {
     failure = StringFormat("%s (expected %s)", message, condition);
   }
-  FailAssertion(file, func, line, failure);
+  Throw(exception_type, file, func, line, failure);
 }
 
 }  // namespace internal

--- a/Firestore/core/src/firebase/firestore/util/hard_assert.h
+++ b/Firestore/core/src/firebase/firestore/util/hard_assert.h
@@ -37,8 +37,14 @@
  * @param message The failure message.
  * @param condition The string form of the expression that failed (optional)
  */
-#define INVOKE_INTERNAL_FAIL(...)                     \
-  firebase::firestore::util::internal::FailAssertion( \
+#define INVOKE_INTERNAL_FAIL(...)                                           \
+  firebase::firestore::util::internal::FailAssertion(                       \
+      firebase::firestore::util::ExceptionType::AssertionFailure, __FILE__, \
+      FIRESTORE_FUNCTION_NAME, __LINE__, __VA_ARGS__)
+
+#define INVOKE_INTERNAL_FAIL_NOTHROW(...)                                \
+  firebase::firestore::util::internal::FailAssertion(                    \
+      firebase::firestore::util::ExceptionType::AssertionFailureNoThrow, \
       __FILE__, FIRESTORE_FUNCTION_NAME, __LINE__, __VA_ARGS__)
 
 /**
@@ -56,6 +62,15 @@
       std::string _message =                                    \
           firebase::firestore::util::StringFormat(__VA_ARGS__); \
       INVOKE_INTERNAL_FAIL(_message, #condition);               \
+    }                                                           \
+  } while (0)
+
+#define HARD_ASSERT_NOTHROW(condition, ...)                     \
+  do {                                                          \
+    if (!ABSL_PREDICT_TRUE(condition)) {                        \
+      std::string _message =                                    \
+          firebase::firestore::util::StringFormat(__VA_ARGS__); \
+      INVOKE_INTERNAL_FAIL_NOTHROW(_message, #condition);       \
     }                                                           \
   } while (0)
 
@@ -105,12 +120,14 @@ namespace util {
 namespace internal {
 
 // A no-return helper function. To raise an assertion, use Macro instead.
-ABSL_ATTRIBUTE_NORETURN void FailAssertion(const char* file,
+ABSL_ATTRIBUTE_NORETURN void FailAssertion(ExceptionType exception_type,
+                                           const char* file,
                                            const char* func,
                                            int line,
                                            const std::string& message);
 
-ABSL_ATTRIBUTE_NORETURN void FailAssertion(const char* file,
+ABSL_ATTRIBUTE_NORETURN void FailAssertion(ExceptionType exception_type,
+                                           const char* file,
                                            const char* func,
                                            int line,
                                            const std::string& message,

--- a/Firestore/core/src/firebase/firestore/util/log_apple.mm
+++ b/Firestore/core/src/firebase/firestore/util/log_apple.mm
@@ -69,6 +69,16 @@ void LogSetLevel(LogLevel level) {
   FIRSetLoggerLevel(ToFIRLoggerLevel(level));
 }
 
+// Note that FIRLogger's default level can be changed by persisting a debug_mode
+// setting in user defaults. Check for defaults getting in your way with:
+//
+//   defaults read firebase_firestore_util_log_apple_test
+//
+// You can change it with:
+//
+//   defaults write firebase_firestore_util_log_apple_test
+//       /google/firebase/debug_mode NO
+
 bool LogIsLoggable(LogLevel level) {
   return FIRIsLoggableLevel(ToFIRLoggerLevel(level), false);
 }

--- a/Firestore/core/test/firebase/firestore/FSTGoogleTestTests.mm
+++ b/Firestore/core/test/firebase/firestore/FSTGoogleTestTests.mm
@@ -52,6 +52,8 @@ NSDictionary<NSString*, NSValue*>* testInfosByKey;
 // run.
 bool forceAllTests = false;
 
+void RunGoogleTestTests();
+
 /**
  * Loads this XCTest runner's configuration file and figures out which tests to
  * run based on the contents of that configuration file.
@@ -186,6 +188,8 @@ NSString* TestInfoKey(Class testClass, SEL testSelector) {
  * this way here allows XCTAssert and friends to work.
  */
 void ReportTestResult(XCTestCase* self, SEL _cmd) {
+  RunGoogleTestTests();
+
   NSString* testInfoKey = TestInfoKey([self class], _cmd);
   NSValue* holder = testInfosByKey[testInfoKey];
   auto testInfo = static_cast<const testing::TestInfo*>(holder.pointerValue);
@@ -222,7 +226,7 @@ void ReportTestResult(XCTestCase* self, SEL _cmd) {
 
 /**
  * Generates a new subclass of XCTestCase for the given GoogleTest TestCase.
- * Each TestInfo (which represents an indivudal test method execution) is
+ * Each TestInfo (which represents an individual test method execution) is
  * translated into a method on the test case.
  *
  * @param testCase The testing::TestCase of interest to translate.
@@ -294,7 +298,7 @@ XCTestSuite* CreateAllTestsTestSuite() {
  * Finds and runs googletest-based tests based on the XCTestConfiguration of the
  * current test invocation.
  */
-void RunGoogleTestTests() {
+void CreateGoogleTestTests() {
   NSString* masterTestCaseName = NSStringFromClass([GoogleTests class]);
 
   // Initialize GoogleTest but don't run the tests yet.
@@ -333,6 +337,10 @@ void RunGoogleTestTests() {
     CreateXCTestCaseClass(testCase, infoMap);
   }
   testInfosByKey = infoMap;
+}
+
+void RunGoogleTestTests() {
+  static bool firstRun = true;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-result"
@@ -341,7 +349,10 @@ void RunGoogleTestTests() {
   // again by XCTest). Test failures are reported via
   // -recordFailureWithDescription:inFile:atLine:expected: which then causes
   // XCTest itself to fail the run.
-  RUN_ALL_TESTS();
+  if (firstRun) {
+    firstRun = false;
+    RUN_ALL_TESTS();
+  }
 #pragma clang diagnostic pop
 }
 
@@ -383,7 +394,7 @@ void RunGoogleTestTests() {
 
 - (instancetype)init {
   self = [super init];
-  RunGoogleTestTests();
+  CreateGoogleTestTests();
   return self;
 }
 

--- a/Firestore/core/test/firebase/firestore/remote/exponential_backoff_test.cc
+++ b/Firestore/core/test/firebase/firestore/remote/exponential_backoff_test.cc
@@ -42,12 +42,6 @@ class ExponentialBackoffTest : public testing::Test,
         backoff{queue, timer_id, 1.5, chr::seconds{5}, chr::seconds{30}} {
   }
 
-  void TearDown() override {
-    queue->Stop();
-
-    testing::Test::TearDown();
-  }
-
   TimerId timer_id = TimerId::ListenStreamConnectionBackoff;
   std::shared_ptr<AsyncQueue> queue;
   ExponentialBackoff backoff;

--- a/Firestore/core/test/firebase/firestore/remote/exponential_backoff_test.cc
+++ b/Firestore/core/test/firebase/firestore/remote/exponential_backoff_test.cc
@@ -42,6 +42,12 @@ class ExponentialBackoffTest : public testing::Test,
         backoff{queue, timer_id, 1.5, chr::seconds{5}, chr::seconds{30}} {
   }
 
+  void TearDown() override {
+    queue->Stop();
+
+    testing::Test::TearDown();
+  }
+
   TimerId timer_id = TimerId::ListenStreamConnectionBackoff;
   std::shared_ptr<AsyncQueue> queue;
   ExponentialBackoff backoff;

--- a/Firestore/core/test/firebase/firestore/testutil/async_testing.cc
+++ b/Firestore/core/test/firebase/firestore/testutil/async_testing.cc
@@ -28,11 +28,20 @@ namespace firebase {
 namespace firestore {
 namespace testutil {
 
+using testing::TestInfo;
+using testing::UnitTest;
 using util::AsyncQueue;
 using util::Executor;
 
 std::unique_ptr<util::Executor> ExecutorForTesting(const char* name) {
+  const TestInfo* test_info = UnitTest::GetInstance()->current_test_info();
+
   std::string label = absl::StrCat("firestore.testing.", name);
+  if (test_info) {
+    absl::StrAppend(&label, ".", test_info->test_suite_name(), ".",
+                    test_info->name());
+  }
+
   return Executor::CreateSerial(label.c_str());
 }
 

--- a/Firestore/core/test/firebase/firestore/util/async_queue_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/async_queue_test.cc
@@ -38,12 +38,6 @@ const TimerId kTimerId3 = TimerId::WriteStreamConnectionBackoff;
 
 }  // namespace
 
-AsyncQueueTest::~AsyncQueueTest() {
-  if (queue) {
-    queue->EnqueueBlocking([] {});
-  }
-}
-
 TEST_P(AsyncQueueTest, Enqueue) {
   Expectation ran;
   queue->Enqueue(ran.AsCallback());

--- a/Firestore/core/test/firebase/firestore/util/async_queue_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/async_queue_test.cc
@@ -208,13 +208,13 @@ TEST_P(AsyncQueueTest, CanScheduleOprationsRespectingRestrictedMode) {
   queue->EnqueueEvenWhileRestricted([&] { steps += '4'; });
   queue->EnqueueEvenWhileRestricted(ran.AsCallback());
 
-  queue->Stop();
+  queue->Dispose();
   queue->Enqueue([&] { steps += '5'; });
   queue->EnqueueEvenWhileRestricted([&] { steps += '6'; });
 
-  // If any action were enqueued after Stop (above) this will force it to
+  // If any action were enqueued after Dispose (above) this will force it to
   // complete.
-  queue->Stop();
+  queue->Dispose();
 
   Await(ran);
   EXPECT_EQ(steps, "124");

--- a/Firestore/core/test/firebase/firestore/util/async_queue_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/async_queue_test.cc
@@ -212,6 +212,10 @@ TEST_P(AsyncQueueTest, CanScheduleOprationsRespectingRestrictedMode) {
   queue->Enqueue([&] { steps += '5'; });
   queue->EnqueueEvenWhileRestricted([&] { steps += '6'; });
 
+  // If any action were enqueued after Stop (above) this will force it to
+  // complete.
+  queue->Stop();
+
   Await(ran);
   EXPECT_EQ(steps, "124");
 }

--- a/Firestore/core/test/firebase/firestore/util/async_queue_test.h
+++ b/Firestore/core/test/firebase/firestore/util/async_queue_test.h
@@ -37,8 +37,6 @@ class AsyncQueueTest : public ::testing::TestWithParam<FactoryFunc>,
   AsyncQueueTest() : queue{AsyncQueue::Create(GetParam()())} {
   }
 
-  ~AsyncQueueTest();
-
   std::shared_ptr<AsyncQueue> queue;
 };
 

--- a/Firestore/core/test/firebase/firestore/util/async_queue_test.h
+++ b/Firestore/core/test/firebase/firestore/util/async_queue_test.h
@@ -37,6 +37,8 @@ class AsyncQueueTest : public ::testing::TestWithParam<FactoryFunc>,
   AsyncQueueTest() : queue{AsyncQueue::Create(GetParam()())} {
   }
 
+  ~AsyncQueueTest();
+
   std::shared_ptr<AsyncQueue> queue;
 };
 

--- a/Firestore/core/test/firebase/firestore/util/bits_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/bits_test.cc
@@ -35,8 +35,6 @@ class BitsTest : public testing::Test {
 };
 
 TEST_F(BitsTest, Log2EdgeCases) {
-  std::cout << "TestLog2EdgeCases" << std::endl;
-
   EXPECT_EQ(-1, Bits::Log2Floor(0));
   EXPECT_EQ(-1, Bits::Log2Floor64(0));
 
@@ -66,8 +64,6 @@ TEST_F(BitsTest, Log2EdgeCases) {
 }
 
 TEST_F(BitsTest, Log2Random) {
-  std::cout << "TestLog2Random" << std::endl;
-
   for (int i = 0; i < kNumIterations; i++) {
     int max_bit = -1;
     uint32_t n = 0;
@@ -84,8 +80,6 @@ TEST_F(BitsTest, Log2Random) {
 }
 
 TEST_F(BitsTest, Log2Random64) {
-  std::cout << "TestLog2Random64" << std::endl;
-
   for (int i = 0; i < kNumIterations; i++) {
     int max_bit = -1;
     uint64_t n = 0;

--- a/Firestore/core/test/firebase/firestore/util/executor_libdispatch_test.mm
+++ b/Firestore/core/test/firebase/firestore/util/executor_libdispatch_test.mm
@@ -65,11 +65,11 @@ TEST_F(ExecutorLibdispatchOnlyTests, NameReturnsLabelOfTheQueue) {
 }
 
 TEST_F(ExecutorLibdispatchOnlyTests,
-       ExecuteBlockingOnTheCurrentQueueIsNotAllowed) {
+       ExecuteBlockingOnTheCurrentQueueIsAllowed) {
   Expectation ran;
   EXPECT_NO_THROW(executor->ExecuteBlocking([] {}));
   executor->Execute([&] {
-    EXPECT_ANY_THROW(executor->ExecuteBlocking([] {}));
+    EXPECT_NO_THROW(executor->ExecuteBlocking([] {}));
     ran.Fulfill();
   });
   Await(ran);

--- a/Firestore/core/test/firebase/firestore/util/log_test.cc
+++ b/Firestore/core/test/firebase/firestore/util/log_test.cc
@@ -22,27 +22,32 @@ namespace firebase {
 namespace firestore {
 namespace util {
 
-// When running against the log_apple.mm implementation (backed by FIRLogger)
-// this test can fail if debug_mode gets persisted in the user defaults. Check
-// for defaults getting in your way with
-//
-//   defaults read firebase_firestore_util_log_apple_test
-//
-// You can fix it with:
-//
-//   defaults write firebase_firestore_util_log_apple_test
-//       /google/firebase/debug_mode NO
-TEST(Log, SetAndGet) {
-  EXPECT_FALSE(LogIsDebugEnabled());
+TEST(LogTest, SetAndGet) {
+  LogLevel previous_level = kLogLevelError;
+  if (LogIsLoggable(kLogLevelWarning)) previous_level = kLogLevelWarning;
+  if (LogIsLoggable(kLogLevelNotice)) previous_level = kLogLevelNotice;
+  if (LogIsLoggable(kLogLevelDebug)) previous_level = kLogLevelDebug;
 
   LogSetLevel(kLogLevelDebug);
   EXPECT_TRUE(LogIsDebugEnabled());
 
+  EXPECT_TRUE(LogIsLoggable(kLogLevelDebug));
+  EXPECT_TRUE(LogIsLoggable(kLogLevelNotice));
+  EXPECT_TRUE(LogIsLoggable(kLogLevelWarning));
+  EXPECT_TRUE(LogIsLoggable(kLogLevelError));
+
   LogSetLevel(kLogLevelWarning);
   EXPECT_FALSE(LogIsDebugEnabled());
+
+  EXPECT_FALSE(LogIsLoggable(kLogLevelDebug));
+  EXPECT_FALSE(LogIsLoggable(kLogLevelNotice));
+  EXPECT_TRUE(LogIsLoggable(kLogLevelWarning));
+  EXPECT_TRUE(LogIsLoggable(kLogLevelError));
+
+  LogSetLevel(previous_level);
 }
 
-TEST(Log, LogAllKinds) {
+TEST(LogTest, LogAllKinds) {
   LOG_DEBUG("test debug logging %s", 1);
   LOG_WARN("test warning logging %s", 3);
   LOG_DEBUG("test va-args %s %s %s", "abc", std::string{"def"}, 123);


### PR DESCRIPTION
Absolutely prevent tasks on the `AsyncQueue` from running after it has shut down.

Also rework the `AsyncQueue::Shutdown` interface to more closely match the actual behavior. Now instead of shutting down, the `AsyncQueue` enters a restricted mode--this more clearly conveys that work can continue, but now it's only restricted tasks.

This also adds an `AsyncQueue::Stop` interface after which no new work will be accepted.

With these changes it's possible to guarantee that tests will actually be done executing by the time they're torn down so this includes changes to the integration tests such that they'll reuse the database across tests, essentially validating that each test really is fully releasing its state.

Also fix the use of `HARD_ASSERT` in destructors by adding a `HARD_ASSERT_NOTHROW` variant. When exceptions are enabled, an assertion failure results in an immediate call to `std::terminate` because destructors are implicitly `noexcept`.

Finally, this also fixes a long-standing bug encountered on Travis where we'd see failures indicating that the test operation never finished bootstrapping. The issue was that we ran GoogleTest tests very early, essentially before XCTest had a chance to start. If there was a crash in the GoogleTests the test runner wouldn't count the test as properly having started. `FSTGoogleTestTests` now defers running tests until later.