### PR TITLE
FIRApp: don't create new component instances while deleting the app

### DIFF
--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -287,6 +287,8 @@ static dispatch_once_t sFirebaseUserAgentOnceToken;
     if (sAllApps && sAllApps[self.name]) {
       FIRLogDebug(kFIRLoggerCore, @"I-COR000006", @"Deleting app named %@", self.name);
 
+      // Remove all registered libraries from the container to avoid creating new instances.
+      [self.container removeAllComponents];
       // Remove all cached instances from the container before deleting the app.
       [self.container removeAllCachedInstances];
 

--- a/FirebaseCore/Sources/FIRComponentContainer.m
+++ b/FirebaseCore/Sources/FIRComponentContainer.m
@@ -203,6 +203,12 @@ static NSMutableSet<Class> *sFIRComponentRegistrants;
   }
 }
 
+- (void)removeAllComponents {
+  @synchronized(self) {
+    [self.components removeAllObjects];
+  }
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseCore/Sources/Private/FIRComponentContainerInternal.h
+++ b/FirebaseCore/Sources/Private/FIRComponentContainerInternal.h
@@ -37,6 +37,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Remove all of the cached instances stored and allow them to clean up after themselves.
 - (void)removeAllCachedInstances;
 
+/// Removes all the components. After calling this method no new instances will be created.
+- (void)removeAllComponents;
+
 /// Register a class to provide components for the interoperability system. The class should conform
 /// to `FIRComponentRegistrant` and provide an array of `FIRComponent` objects.
 + (void)registerAsComponentRegistrant:(Class<FIRLibrary>)klass;

--- a/FirebaseCore/Tests/Unit/FIRAppTest.m
+++ b/FirebaseCore/Tests/Unit/FIRAppTest.m
@@ -88,7 +88,8 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 }
 
 - (void)testConfigure {
-  [self registerLibrariesWithClasses:@[[FIRTestClassCached class], [FIRTestClassEagerCached class]]];
+  [self
+      registerLibrariesWithClasses:@ [[FIRTestClassCached class], [FIRTestClassEagerCached class]]];
 
   NSDictionary *expectedUserInfo = [self expectedUserInfoWithAppName:kFIRDefaultAppName
                                                         isDefaultApp:YES];
@@ -328,7 +329,8 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 }
 
 - (void)testDeleteApp {
-  [self registerLibrariesWithClasses:@[[FIRTestClassCached class], [FIRTestClassEagerCached class]]];
+  [self
+      registerLibrariesWithClasses:@ [[FIRTestClassCached class], [FIRTestClassEagerCached class]]];
 
   NSString *name = NSStringFromSelector(_cmd);
   FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID

--- a/FirebaseCore/Tests/Unit/FIRAppTest.m
+++ b/FirebaseCore/Tests/Unit/FIRAppTest.m
@@ -88,6 +88,8 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 }
 
 - (void)testConfigure {
+  [self registerLibrariesWithClasses:@[[FIRTestClassCached class], [FIRTestClassEagerCached class]]];
+
   NSDictionary *expectedUserInfo = [self expectedUserInfoWithAppName:kFIRDefaultAppName
                                                         isDefaultApp:YES];
   [self expectNotificationForObserver:self.observerMock
@@ -102,6 +104,11 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   XCTAssertEqualObjects(app.name, kFIRDefaultAppName);
   XCTAssertEqualObjects(app.options.clientID, kClientID);
   XCTAssertTrue([FIRApp allApps].count == 1);
+
+  // Check the registered libraries instances available.
+  XCTAssertNotNil(FIR_COMPONENT(FIRTestProtocolCached, app.container));
+  XCTAssertNotNil(FIR_COMPONENT(FIRTestProtocolEagerCached, app.container));
+  XCTAssertNil(FIR_COMPONENT(FIRTestProtocol, app.container));
 }
 
 - (void)testConfigureWithNoDefaultOptions {
@@ -321,6 +328,8 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 }
 
 - (void)testDeleteApp {
+  [self registerLibrariesWithClasses:@[[FIRTestClassCached class], [FIRTestClassEagerCached class]]];
+
   NSString *name = NSStringFromSelector(_cmd);
   FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID
                                                     GCMSenderID:kGCMSenderID];
@@ -328,6 +337,12 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   FIRApp *app = [FIRApp appNamed:name];
   XCTAssertNotNil(app);
   XCTAssertTrue([FIRApp allApps].count == 1);
+
+  // Check the registered libraries instances available.
+  XCTAssertNotNil(FIR_COMPONENT(FIRTestProtocolCached, app.container));
+  XCTAssertNotNil(FIR_COMPONENT(FIRTestProtocolEagerCached, app.container));
+  XCTAssertNil(FIR_COMPONENT(FIRTestProtocol, app.container));
+
   [self expectNotificationForObserver:self.observerMock
                      notificationName:kFIRAppDeleteNotification
                                object:[FIRApp class]
@@ -342,6 +357,10 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   [self waitForExpectations:@[ expectation ] timeout:1];
   OCMVerifyAll(self.observerMock);
   XCTAssertTrue([FIRApp allApps].count == 0);
+
+  // Check no new library instances created after the app delete.
+  XCTAssertNil(FIR_COMPONENT(FIRTestProtocolCached, app.container));
+  XCTAssertNil(FIR_COMPONENT(FIRTestProtocolEagerCached, app.container));
 }
 
 - (void)testErrorForSubspecConfigurationFailure {
@@ -887,6 +906,12 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 
 - (FIROptions *)appOptions {
   return [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID GCMSenderID:kGCMSenderID];
+}
+
+- (void)registerLibrariesWithClasses:(NSArray<Class> *)classes {
+  for (Class klass in classes) {
+    [FIRApp registerInternalLibrary:klass withName:NSStringFromClass(klass) withVersion:@"1.0"];
+  }
 }
 
 @end

--- a/FirebaseCore/Tests/Unit/FIRComponentContainerTest.m
+++ b/FirebaseCore/Tests/Unit/FIRComponentContainerTest.m
@@ -132,6 +132,36 @@
   XCTAssertNotEqual(eagerInstance1, eagerInstance2);
 }
 
+- (void)testRemoveAllComponents {
+  FIRComponentContainer *container =
+      [self containerWithRegistrants:@ [[FIRTestClass class], [FIRTestClassCached class],
+                                        [FIRTestClassEagerCached class],
+                                        [FIRTestClassCachedWithDep class]]];
+
+  // Retrieve an instance of FIRTestClassCached to ensure it's cached.
+  id<FIRTestProtocolCached> cachedInstance1 = FIR_COMPONENT(FIRTestProtocolCached, container);
+  XCTAssertNotNil(cachedInstance1);
+  id<FIRTestProtocolEagerCached> eagerInstance1 =
+      FIR_COMPONENT(FIRTestProtocolEagerCached, container);
+  XCTAssertNotNil(eagerInstance1);
+
+  // FIRTestClassEagerCached and FIRTestClassCached instances should be cached at this point.
+  XCTAssertTrue(container.cachedInstances.count == 2);
+
+  // Remove all components.
+  [container removeAllComponents];
+
+  // Remove the instances.
+  [container removeAllCachedInstances];
+
+  // Verify that no new instances are created.
+  id<FIRTestProtocolCached> cachedInstance2 = FIR_COMPONENT(FIRTestProtocolCached, container);
+  XCTAssertNil(cachedInstance2);
+  id<FIRTestProtocolEagerCached> eagerInstance2 =
+      FIR_COMPONENT(FIRTestProtocolEagerCached, container);
+  XCTAssertNil(eagerInstance2);
+}
+
 #pragma mark - Instantiation Tests
 
 - (void)testEagerInstantiation {


### PR DESCRIPTION
Part of the fix for #4906