### PR TITLE
Ignore deprecation warnings for FIRExperimentController.updateExperiments(serviceOrigin:events:policy:lastStartTime:payloads:)

### DIFF
--- a/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
@@ -183,13 +183,15 @@ static NSString *const kMethodNameLatestStartTime =
 
   // Update the last experiment start time with the latest payload.
   [self updateExperimentStartTime];
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [self.experimentController
       updateExperimentsWithServiceOrigin:kServiceOrigin
                                   events:lifecycleEvent
                                   policy:ABTExperimentPayload_ExperimentOverflowPolicy_DiscardOldest
                            lastStartTime:lastStartTime
                                 payloads:_experimentPayloads];
+#pragma clang diagnostic pop
 }
 
 - (void)updateExperimentStartTime {

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m
@@ -216,6 +216,8 @@
 
   NSTimeInterval lastStartTime =
       [experiment.experimentMetadata[@"last_experiment_start_time"] doubleValue];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   OCMStub(
       [mockExperimentController
           updateExperimentsWithServiceOrigin:[OCMArg any]
@@ -225,6 +227,7 @@
                                lastStartTime:lastStartTime
                                     payloads:[OCMArg any]])
       .andDo(nil);
+#pragma clang diagnostic pop
 
   ABTExperimentPayload *payload = [[ABTExperimentPayload alloc] init];
   payload.experimentStartTimeMillis = 12345678000;


### PR DESCRIPTION
Fixes #4933 .