### PR TITLE
Forward declare class to fix linting.

### DIFF
--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTPrioritizer.h
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTPrioritizer.h
@@ -19,6 +19,8 @@
 #import <GoogleDataTransport/GDTCORClock.h>
 #import <GoogleDataTransport/GDTCORPrioritizer.h>
 
+@class GDTCORStoredEvent;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /** Manages the prioritization of events from GoogleDataTransport. */


### PR DESCRIPTION
This will need to be excluded in the merge, but is required to get GDTCCTSupport linting.

```
- ERROR | xcodebuild:  GoogleDataTransportCCTSupport/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTPrioritizer.h:37:35: error: unknown type name 'GDTCORStoredEvent'

```