### PR TITLE
Revert "Forward declare class to fix linting. (#4935)"

### DIFF
--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTPrioritizer.h
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTPrioritizer.h
@@ -19,8 +19,6 @@
 #import <GoogleDataTransport/GDTCORClock.h>
 #import <GoogleDataTransport/GDTCORPrioritizer.h>
 
-@class GDTCORStoredEvent;
-
 NS_ASSUME_NONNULL_BEGIN
 
 /** Manages the prioritization of events from GoogleDataTransport. */


### PR DESCRIPTION
This reverts commit 64bbf378bb509e20ba97af731971906f008301c9.

Turns out it was a `pod cache` problem.