### PR TITLE
Crashlytics move Update call from api. to update.

### DIFF
--- a/Crashlytics/Crashlytics/Settings/Operations/FIRCLSOnboardingOperation.m
+++ b/Crashlytics/Crashlytics/Settings/Operations/FIRCLSOnboardingOperation.m
@@ -164,7 +164,7 @@ typedef NS_ENUM(NSInteger, FIRCLSOnboardingError) {
 }
 
 - (NSURL *)appCreateURL {
-  // https://api.crashlytics.com/spi/v1/platforms/mac/apps/com.crashlytics.mac
+  // https://update.crashlytics.com/spi/v1/platforms/mac/apps/com.crashlytics.mac
 
   FIRCLSURLBuilder *url = [FIRCLSURLBuilder URLWithBase:self.appEndpoint];
 
@@ -176,7 +176,7 @@ typedef NS_ENUM(NSInteger, FIRCLSOnboardingError) {
 }
 
 - (NSURL *)appUpdateURL {
-  // https://api.crashlytics.com/spi/v1/platforms/mac/apps/com.crashlytics.mac
+  // https://update.crashlytics.com/spi/v1/platforms/mac/apps/com.crashlytics.mac
 
   FIRCLSURLBuilder *url = [FIRCLSURLBuilder URLWithBase:[self appEndpoint]];
 

--- a/Crashlytics/Shared/FIRCLSConstants.m
+++ b/Crashlytics/Shared/FIRCLSConstants.m
@@ -30,7 +30,7 @@ NSString* const FIRCLSException = @"FIRCLSException";
 
 // Endpoints
 NSString* const FIRCLSSettingsEndpoint = @"https://firebase-settings.crashlytics.com";
-NSString* const FIRCLSConfigureEndpoint = @"https://api.crashlytics.com";
+NSString* const FIRCLSConfigureEndpoint = @"https://update.crashlytics.com";
 NSString* const FIRCLSReportsEndpoint = @"https://reports.crashlytics.com";
 
 // Network requests


### PR DESCRIPTION
New DNS to facilitate backend migration