### PR TITLE
Fix radioacesstechnology api deprecated for ios 12.0 or newer

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -72,7 +72,7 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
     networkInfo = [[CTTelephonyNetworkInfo alloc] init];
   });
   NSString *networkCurrentRadioAccessTechnology;
-  if(@available(iOS 13, *)) {
+  if(@available(iOS 12, *)) {
     NSDictionary<NSString *, NSString *> *networkCurrentRadioAccessTechnologyDict = networkInfo.serviceCurrentRadioAccessTechnology;
     if(networkCurrentRadioAccessTechnologyDict){
       networkCurrentRadioAccessTechnology = networkCurrentRadioAccessTechnologyDict.allValues[0];

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -75,7 +75,9 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
   if (@available(iOS 12, *)) {
     NSDictionary<NSString *, NSString *> *networkCurrentRadioAccessTechnologyDict =
         networkInfo.serviceCurrentRadioAccessTechnology;
-    if (networkCurrentRadioAccessTechnologyDict) {
+    if (networkCurrentRadioAccessTechnologyDict.count) {
+      // In iOS 12, multiple radio technologies can be captured. We prefer not particular radio
+      // tech to another, so we'll just return the first value in the dictionary.
       networkCurrentRadioAccessTechnology = networkCurrentRadioAccessTechnologyDict.allValues[0];
     }
   } else {

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -71,7 +71,15 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
     };
     networkInfo = [[CTTelephonyNetworkInfo alloc] init];
   });
-  NSString *networkCurrentRadioAccessTechnology = networkInfo.currentRadioAccessTechnology;
+  NSString *networkCurrentRadioAccessTechnology;
+  if(@available(iOS 13, *)) {
+    NSDictionary<NSString *, NSString *> *networkCurrentRadioAccessTechnologyDict = networkInfo.serviceCurrentRadioAccessTechnology;
+    if(networkCurrentRadioAccessTechnologyDict){
+      networkCurrentRadioAccessTechnology = networkCurrentRadioAccessTechnologyDict.allValues[0];
+    }
+  } else {
+    networkCurrentRadioAccessTechnology = networkInfo.currentRadioAccessTechnology;
+  }
   if (networkCurrentRadioAccessTechnology) {
     NSNumber *networkMobileSubtype =
         CTRadioAccessTechnologyToNetworkSubTypeMessage[networkCurrentRadioAccessTechnology];

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -72,9 +72,10 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
     networkInfo = [[CTTelephonyNetworkInfo alloc] init];
   });
   NSString *networkCurrentRadioAccessTechnology;
-  if(@available(iOS 12, *)) {
-    NSDictionary<NSString *, NSString *> *networkCurrentRadioAccessTechnologyDict = networkInfo.serviceCurrentRadioAccessTechnology;
-    if(networkCurrentRadioAccessTechnologyDict){
+  if (@available(iOS 12, *)) {
+    NSDictionary<NSString *, NSString *> *networkCurrentRadioAccessTechnologyDict =
+        networkInfo.serviceCurrentRadioAccessTechnology;
+    if (networkCurrentRadioAccessTechnologyDict) {
       networkCurrentRadioAccessTechnology = networkCurrentRadioAccessTechnologyDict.allValues[0];
     }
   } else {


### PR DESCRIPTION
Fix radioacesstechnology api deprecated for ios 12.0 or newer