### PR TITLE
Remove Firebase Database specific log levels in favour FIRLoggerLevel

### DIFF
--- a/Firebase/Database/Api/FIRDatabase.m
+++ b/Firebase/Database/Api/FIRDatabase.m
@@ -110,7 +110,7 @@ static const char *FIREBASE_SEMVER = (const char *)STR(FIRDatabase_VERSION);
 }
 
 + (void)setLoggingEnabled:(BOOL)enabled {
-    [FUtilities setLoggingEnabled:enabled];
+    FIRSetLoggerLevel(FIRLoggerLevelDebug);
     FFLog(@"I-RDB024001", @"BUILD Version: %@", [FIRDatabase buildVersion]);
 }
 

--- a/Firebase/Database/Public/FIRDatabase.h
+++ b/Firebase/Database/Public/FIRDatabase.h
@@ -172,7 +172,9 @@ NS_SWIFT_NAME(Database)
  *
  * @param enabled YES to enable logging, NO to disable.
  */
-+ (void)setLoggingEnabled:(BOOL)enabled;
++ (void)setLoggingEnabled:(BOOL)enabled
+    __deprecated_msg(
+        "Please use FIRSetLoggerLevel() function of FIRLogger instead.");
 
 /** Retrieve the Firebase Database SDK version. */
 + (NSString *)sdkVersion;

--- a/Firebase/Database/Utilities/FUtilities.h
+++ b/Firebase/Database/Utilities/FUtilities.h
@@ -28,8 +28,6 @@
 + (NSError *)errorForStatus:(NSString *)status andReason:(NSString *)reason;
 + (NSNumber *)intForString:(NSString *)string;
 + (NSString *)ieee754StringForNumber:(NSNumber *)val;
-+ (void)setLoggingEnabled:(BOOL)enabled;
-+ (BOOL)getLoggingEnabled;
 
 + (NSString *)minName;
 + (NSString *)maxName;
@@ -41,14 +39,6 @@
 
 @end
 
-typedef enum {
-    FLogLevelDebug = 1,
-    FLogLevelInfo = 2,
-    FLogLevelWarn = 3,
-    FLogLevelError = 4,
-    FLogLevelNone = 5
-} FLogLevel;
-
 // Log tags
 FOUNDATION_EXPORT NSString *const kFPersistenceLogTag;
 
@@ -56,27 +46,19 @@ FOUNDATION_EXPORT NSString *const kFPersistenceLogTag;
 
 #define FFDebug(code, format, ...)                                             \
     do {                                                                       \
-        if (FFIsLoggingEnabled(FLogLevelDebug)) {                              \
-            FIRLogDebug(kFIRLoggerDatabase, (code), (format), ##__VA_ARGS__);  \
-        }                                                                      \
+        FIRLogDebug(kFIRLoggerDatabase, (code), (format), ##__VA_ARGS__);      \
     } while (0)
 
 #define FFInfo(code, format, ...)                                              \
     do {                                                                       \
-        if (FFIsLoggingEnabled(FLogLevelInfo)) {                               \
-            FIRLogError(kFIRLoggerDatabase, (code), (format), ##__VA_ARGS__);  \
-        }                                                                      \
+        FIRLogError(kFIRLoggerDatabase, (code), (format), ##__VA_ARGS__);      \
     } while (0)
 
 #define FFWarn(code, format, ...)                                              \
     do {                                                                       \
-        if (FFIsLoggingEnabled(FLogLevelWarn)) {                               \
-            FIRLogWarning(kFIRLoggerDatabase, (code), (format),                \
-                          ##__VA_ARGS__);                                      \
-        }                                                                      \
+        FIRLogWarning(kFIRLoggerDatabase, (code), (format), ##__VA_ARGS__);    \
     } while (0)
 
 extern FIRLoggerService kFIRLoggerDatabase;
-BOOL FFIsLoggingEnabled(FLogLevel logLevel);
 void firebaseUncaughtExceptionHandler(NSException *exception);
 void firebaseJobsTroll(void);

--- a/Firebase/Database/Utilities/FUtilities.m
+++ b/Firebase/Database/Utilities/FUtilities.m
@@ -28,10 +28,7 @@
 #pragma mark C functions
 
 FIRLoggerService kFIRLoggerDatabase = @"[Firebase/Database]";
-static FLogLevel logLevel = FLogLevelInfo; // Default log level is info
 static NSMutableDictionary *options = nil;
-
-BOOL FFIsLoggingEnabled(FLogLevel level) { return level >= logLevel; }
 
 void firebaseJobsTroll(void) {
     FFLog(@"I-RDB095001",
@@ -61,15 +58,6 @@ void firebaseJobsTroll(void) {
         self.localUid = [[FAtomicNumber alloc] init];
     }
     return self;
-}
-
-// TODO: We really want to be able to set the log level
-+ (void)setLoggingEnabled:(BOOL)enabled {
-    logLevel = enabled ? FLogLevelDebug : FLogLevelInfo;
-}
-
-+ (BOOL)getLoggingEnabled {
-    return logLevel == FLogLevelDebug;
 }
 
 + (FUtilities *)singleton {


### PR DESCRIPTION
Fixes #4958.

Currently Firebase Database SDK uses additional log levels on top of `FIRLoggerLevel` which is a bit confusing and inconsistent with other Firebase SDK.

- `FLogLevel` and related code from Database SDK removed
- `+ [FIRDatabase setLoggingEnabled:]` method deprecated