### PR TITLE
Wrap SCNetworkReachabilityFlags and fix Catalyst warning

### DIFF
--- a/.github/workflows/datatransport.yml
+++ b/.github/workflows/datatransport.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        target: [ios, tvos, macos, watchos]
     steps:
     - uses: actions/checkout@v2
     - name: Setup Bundler
@@ -32,7 +32,7 @@ jobs:
     if: github.event_name == 'schedule'
     strategy:
       matrix:
-        target: [ios, tvos, macos]
+        target: [ios, tvos, macos, watchos]
         flags: [
           '--use-modular-headers',
           '--use-libraries'

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -50,6 +50,23 @@ BOOL GDTCORReachabilityFlagsContainWWAN(SCNetworkReachabilityFlags flags) {
 }
 #endif  // !TARGET_OS_WATCH
 
+GDTCORNetworkType GDTCORNetworkTypeMessage() {
+#if !TARGET_OS_WATCH
+  SCNetworkReachabilityFlags reachabilityFlags = [GDTCORReachability currentFlags];
+  if ((reachabilityFlags & kSCNetworkReachabilityFlagsReachable) ==
+      kSCNetworkReachabilityFlagsReachable) {
+    if (GDTCORReachabilityFlagsContainWWAN(reachabilityFlags)) {
+      return GDTCORNetworkTypeMobile;
+    } else {
+      return GDTCORNetworkTypeWIFI;
+    }
+  }
+#endif
+  return GDTCORNetworkTypeUNKNOWN;
+}
+
+
+
 GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
 #if TARGET_OS_IOS
   static NSDictionary<NSString *, NSNumber *> *CTRadioAccessTechnologyToNetworkSubTypeMessage;
@@ -72,7 +89,13 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
     networkInfo = [[CTTelephonyNetworkInfo alloc] init];
   });
   NSString *networkCurrentRadioAccessTechnology;
-  if (@available(iOS 12, *)) {
+#if TARGET_OS_MACCATALYST
+  NSDictionary<NSString *, NSString *> *networkCurrentRadioAccessTechnologyDict = networkInfo.serviceCurrentRadioAccessTechnology;
+  if (networkCurrentRadioAccessTechnologyDict.count) {
+    networkCurrentRadioAccessTechnology = networkCurrentRadioAccessTechnologyDict.allValues[0];
+  }
+#else
+  if (@available(iOS 12.0, *)) {
     NSDictionary<NSString *, NSString *> *networkCurrentRadioAccessTechnologyDict =
         networkInfo.serviceCurrentRadioAccessTechnology;
     if (networkCurrentRadioAccessTechnologyDict.count) {
@@ -83,6 +106,7 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
   } else {
     networkCurrentRadioAccessTechnology = networkInfo.currentRadioAccessTechnology;
   }
+#endif
   if (networkCurrentRadioAccessTechnology) {
     NSNumber *networkMobileSubtype =
         CTRadioAccessTechnologyToNetworkSubTypeMessage[networkCurrentRadioAccessTechnology];

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -65,8 +65,6 @@ GDTCORNetworkType GDTCORNetworkTypeMessage() {
   return GDTCORNetworkTypeUNKNOWN;
 }
 
-
-
 GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
 #if TARGET_OS_IOS
   static NSDictionary<NSString *, NSNumber *> *CTRadioAccessTechnologyToNetworkSubTypeMessage;
@@ -90,7 +88,8 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
   });
   NSString *networkCurrentRadioAccessTechnology;
 #if TARGET_OS_MACCATALYST
-  NSDictionary<NSString *, NSString *> *networkCurrentRadioAccessTechnologyDict = networkInfo.serviceCurrentRadioAccessTechnology;
+  NSDictionary<NSString *, NSString *> *networkCurrentRadioAccessTechnologyDict =
+      networkInfo.serviceCurrentRadioAccessTechnology;
   if (networkCurrentRadioAccessTechnologyDict.count) {
     networkCurrentRadioAccessTechnology = networkCurrentRadioAccessTechnologyDict.allValues[0];
   }

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
@@ -75,13 +75,13 @@ typedef NS_ENUM(NSInteger, GDTCORNetworkMobileSubtype) {
 BOOL GDTCORReachabilityFlagsContainWWAN(SCNetworkReachabilityFlags flags);
 #endif
 
-/** Generates an enum message GDTCORNetworkType representing Network connection type.
+/** Generates an enum message GDTCORNetworkType representing network connection type.
  *
  * @return A GDTCORNetworkType representing network connection type.
  */
 GDTCORNetworkType GDTCORNetworkTypeMessage(void);
 
-/** Generates an enum message GDTCORNetworkMobileSubtype representing Network connection mobile
+/** Generates an enum message GDTCORNetworkMobileSubtype representing network connection mobile
  * subtype.
  *
  * @return A GDTCORNetworkMobileSubtype representing network connection mobile subtype.

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
@@ -43,6 +43,13 @@ FOUNDATION_EXPORT NSString *const kGDTCORApplicationWillEnterForegroundNotificat
 /** A notification sent out if the app is terminating. */
 FOUNDATION_EXPORT NSString *const kGDTCORApplicationWillTerminateNotification;
 
+/** The different possible network connection type. */
+typedef NS_ENUM(NSInteger, GDTCORNetworkType) {
+  GDTCORNetworkTypeUNKNOWN = 0,
+  GDTCORNetworkTypeWIFI = 1,
+  GDTCORNetworkTypeMobile = 2,
+};
+
 /** The different possible network connection mobile subtype. */
 typedef NS_ENUM(NSInteger, GDTCORNetworkMobileSubtype) {
   GDTCORNetworkMobileSubtypeUNKNOWN = 0,
@@ -67,6 +74,12 @@ typedef NS_ENUM(NSInteger, GDTCORNetworkMobileSubtype) {
  */
 BOOL GDTCORReachabilityFlagsContainWWAN(SCNetworkReachabilityFlags flags);
 #endif
+
+/** Generates an enum message GDTCORNetworkType representing Network connection type.
+ *
+ * @return A GDTCORNetworkType representing network connection type.
+ */
+GDTCORNetworkType GDTCORNetworkTypeMessage(void);
 
 /** Generates an enum message GDTCORNetworkMobileSubtype representing Network connection mobile
  * subtype.

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
@@ -199,38 +199,22 @@ gdt_cct_IosClientInfo GDTCCTConstructiOSClientInfo() {
 
 NSData *GDTCCTConstructNetworkConnectionInfoData() {
   gdt_cct_NetworkConnectionInfo networkConnectionInfo = gdt_cct_NetworkConnectionInfo_init_default;
-  SCNetworkReachabilityFlags reachabilityFlags = [GDTCORReachability currentFlags];
-  if ((reachabilityFlags & kSCNetworkReachabilityFlagsReachable) ==
-      kSCNetworkReachabilityFlagsReachable) {
-    networkConnectionInfo.network_type = GDTCCTNetworkConnectonInfoNetworkType(reachabilityFlags);
-    if (networkConnectionInfo.network_type != gdt_cct_NetworkConnectionInfo_NetworkType_NONE) {
-      networkConnectionInfo.has_network_type = 1;
-      if (networkConnectionInfo.network_type == gdt_cct_NetworkConnectionInfo_NetworkType_MOBILE) {
-        networkConnectionInfo.mobile_subtype = GDTCCTNetworkConnectionInfoNetworkMobileSubtype();
-        if (networkConnectionInfo.mobile_subtype !=
-            gdt_cct_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE) {
-          networkConnectionInfo.has_mobile_subtype = 1;
-        }
+  NSInteger currentNetworkType = GDTCORNetworkTypeMessage();
+  if (currentNetworkType) {
+    networkConnectionInfo.has_network_type = 1;
+    if(currentNetworkType == GDTCORNetworkTypeMobile) {
+      networkConnectionInfo.network_type = gdt_cct_NetworkConnectionInfo_NetworkType_MOBILE;
+      networkConnectionInfo.mobile_subtype = GDTCCTNetworkConnectionInfoNetworkMobileSubtype();
+      if(networkConnectionInfo.mobile_subtype != gdt_cct_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE) {
+        networkConnectionInfo.has_mobile_subtype = 1;
       }
+    } else {
+      networkConnectionInfo.network_type = gdt_cct_NetworkConnectionInfo_NetworkType_WIFI;
     }
   }
   NSData *networkConnectionInfoData = [NSData dataWithBytes:&networkConnectionInfo
                                                      length:sizeof(networkConnectionInfo)];
   return networkConnectionInfoData;
-}
-
-gdt_cct_NetworkConnectionInfo_NetworkType GDTCCTNetworkConnectonInfoNetworkType(
-    SCNetworkReachabilityFlags flags) {
-  gdt_cct_NetworkConnectionInfo_NetworkType networkType =
-      gdt_cct_NetworkConnectionInfo_NetworkType_NONE;
-  if (GDTCORReachabilityFlagsContainWWAN(flags)) {
-    networkType = gdt_cct_NetworkConnectionInfo_NetworkType_MOBILE;
-    GDTCORLogDebug(@"%@", @"Event captured that it occurred whilst using mobile data.");
-  } else {
-    networkType = gdt_cct_NetworkConnectionInfo_NetworkType_WIFI;
-    GDTCORLogDebug(@"%@", @"Event captured that it occurred whilst using wifi data.");
-  }
-  return networkType;
 }
 
 gdt_cct_NetworkConnectionInfo_MobileSubtype GDTCCTNetworkConnectionInfoNetworkMobileSubtype() {

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
@@ -202,10 +202,11 @@ NSData *GDTCCTConstructNetworkConnectionInfoData() {
   NSInteger currentNetworkType = GDTCORNetworkTypeMessage();
   if (currentNetworkType) {
     networkConnectionInfo.has_network_type = 1;
-    if(currentNetworkType == GDTCORNetworkTypeMobile) {
+    if (currentNetworkType == GDTCORNetworkTypeMobile) {
       networkConnectionInfo.network_type = gdt_cct_NetworkConnectionInfo_NetworkType_MOBILE;
       networkConnectionInfo.mobile_subtype = GDTCCTNetworkConnectionInfoNetworkMobileSubtype();
-      if(networkConnectionInfo.mobile_subtype != gdt_cct_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE) {
+      if (networkConnectionInfo.mobile_subtype !=
+          gdt_cct_NetworkConnectionInfo_MobileSubtype_UNKNOWN_MOBILE_SUBTYPE) {
         networkConnectionInfo.has_mobile_subtype = 1;
       }
     } else {

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTNanopbHelpers.h
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTNanopbHelpers.h
@@ -115,14 +115,6 @@ gdt_cct_IosClientInfo GDTCCTConstructiOSClientInfo(void);
 FOUNDATION_EXPORT
 NSData *GDTCCTConstructNetworkConnectionInfoData(void);
 
-/** Return a gdt_cct_NetworkConnectionInfo_NetworkType representing the cilent network type.
- *
- * @return The gdt_cct_NetworkConnectionInfo_NetworkType.
- */
-FOUNDATION_EXPORT
-gdt_cct_NetworkConnectionInfo_NetworkType GDTCCTNetworkConnectonInfoNetworkType(
-    SCNetworkReachabilityFlags flags);
-
 /** Return a gdt_cct_NetworkConnectionInfo_MobileSubtype representing the client
  *
  * @return The gdt_cct_NetworkConnectionInfo_MobileSubtype.


### PR DESCRIPTION
1 Wrap SCNetworkReachabilityFlags in GDTCORPlatform.
2 Fix Catalyst warning in GDTCORPlatform.