### PR TITLE
Fixes for compatibility with builds in firebase-cpp-sdk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,6 @@ else()
   )
 endif()
 
-add_alias(protobuf::libprotobuf libprotobuf)
 if(CXX_CLANG OR CXX_GNU)
   target_compile_options(
     libprotobuf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,12 @@ endif()
 enable_language(C)
 enable_language(CXX)
 
+option(
+  FIREBASE_IOS_BUILD_TESTS
+  "Enable building of C++ and Objective-C tests for this project"
+  ON
+)
+
 
 list(INSERT CMAKE_MODULE_PATH 0 ${PROJECT_SOURCE_DIR}/cmake)
 include(compiler_id)
@@ -251,7 +257,9 @@ if(APPLE)
 endif()
 
 
-enable_testing()
+if(FIREBASE_IOS_BUILD_TESTS)
+  enable_testing()
+endif()
 include(compiler_setup)
 
 add_subdirectory(FirebaseCore)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,12 @@ endif()
 
 
 # gRPC
+
+# libcurl and c-ares conflict in their usage of this variable. Prevent
+# libcurl's setting of this variable from affecting the c-ares build that's
+# pulled in indirectly via gRPC.
+unset(RANDOM_FILE CACHE)
+
 find_package(OpenSSL QUIET)
 if(OPENSSL_FOUND)
   set(gRPC_SSL_PROVIDER package CACHE STRING "Use external OpenSSL")

--- a/cmake/cc_rules.cmake
+++ b/cmake/cc_rules.cmake
@@ -423,14 +423,14 @@ endfunction()
 #
 # Appends the generated source file name to the list named by sources_list.
 macro(generate_dummy_source name sources_list)
-  set(__empty_header_only_file "${CMAKE_CURRENT_BINARY_DIR}/${name}_header_only_empty.c")
+  set(__empty_header_only_file "${CMAKE_CURRENT_BINARY_DIR}/${name}_header_only_empty.cc")
 
   if(NOT EXISTS ${__empty_header_only_file})
     file(WRITE ${__empty_header_only_file}
       "// Generated file that keeps header-only CMake libraries happy.
 
       // single meaningless symbol
-      void ${name}_header_only_fakesym(void) {}
+      void ${name}_header_only_fakesym() {}
       "
     )
   endif()

--- a/cmake/cc_rules.cmake
+++ b/cmake/cc_rules.cmake
@@ -45,6 +45,7 @@ function(cc_library name)
     ${FIREBASE_SOURCE_DIR}
   )
 
+  target_compile_options(${name} PRIVATE ${FIREBASE_CXX_FLAGS})
   target_link_libraries(${name} PUBLIC ${ccl_DEPENDS})
 
   if(ccl_EXCLUDE_FROM_ALL)
@@ -184,6 +185,8 @@ function(cc_fuzz_test name)
     DEPENDS ${ccf_DEPENDS}
   )
 
+  target_compile_options(${name} PRIVATE ${FIREBASE_CXX_FLAGS})
+
   # Copy the dictionary file and corpus directory, if they are defined.
   if(DEFINED ccf_DICTIONARY)
     add_custom_command(
@@ -314,6 +317,7 @@ function(objc_framework target)
       INTERFACE
         -F${CMAKE_CURRENT_BINARY_DIR}
       PRIVATE
+        ${FIREBASE_CXX_FLAGS}
         ${OBJC_FLAGS}
         -fno-autolink
         -Wno-unused-parameter
@@ -373,11 +377,8 @@ function(objc_test target)
       ${ot_SOURCES}
     )
 
-    target_link_libraries(
-      ${target}
-      PRIVATE
-        ${ot_DEPENDS}
-    )
+    target_compile_options(${target} PRIVATE ${FIREBASE_CXX_FLAGS})
+    target_link_libraries(${target} PRIVATE ${ot_DEPENDS})
 
     xctest_add_test(
       ${target}

--- a/cmake/compiler_setup.cmake
+++ b/cmake/compiler_setup.cmake
@@ -117,14 +117,6 @@ if(MSVC)
 endif()
 
 foreach(flag ${common_flags} ${c_flags})
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${flag}")
-endforeach()
-
-foreach(flag ${common_flags} ${cxx_flags})
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}")
-endforeach()
-
-foreach(flag ${common_flags} ${c_flags})
   list(APPEND FIREBASE_C_FLAGS ${flag})
 endforeach()
 

--- a/cmake/external_rules.cmake
+++ b/cmake/external_rules.cmake
@@ -36,9 +36,22 @@ function(download_external_sources)
 endfunction()
 
 function(add_external_subdirectory NAME)
-  add_subdirectory(
-    ${FIREBASE_BINARY_DIR}/external/src/${NAME}
-    ${FIREBASE_BINARY_DIR}/external/src/${NAME}-build
-    EXCLUDE_FROM_ALL
-  )
+  string(TOUPPER ${NAME} UPPER_NAME)
+  if (NOT EXISTS ${${UPPER_NAME}_SOURCE_DIR})
+    set(${UPPER_NAME}_SOURCE_DIR "${FIREBASE_BINARY_DIR}/external/src/${NAME}")
+    set(${UPPER_NAME}_SOURCE_DIR "${${UPPER_NAME}_SOURCE_DIR}" PARENT_SCOPE)
+  endif()
+
+  if (NOT EXISTS ${${UPPER_NAME}_BINARY_DIR})
+    set(${UPPER_NAME}_BINARY_DIR "${${UPPER_NAME}_SOURCE_DIR}-build")
+    set(${UPPER_NAME}_BINARY_DIR "${${UPPER_NAME}_BINARY_DIR}" PARENT_SCOPE)
+  endif()
+
+  if (EXISTS "${${UPPER_NAME}_SOURCE_DIR}/CMakeLists.txt")
+    add_subdirectory(
+      ${${UPPER_NAME}_SOURCE_DIR}
+      ${${UPPER_NAME}_BINARY_DIR}
+      EXCLUDE_FROM_ALL
+    )
+  endif()
 endfunction()

--- a/scripts/binary_to_array.py
+++ b/scripts/binary_to_array.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 
-# Copyright 2018 Google
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,8 +47,6 @@ from re import sub
 import argparse
 import logging
 import os
-
-from lib import git
 
 arg_parser = argparse.ArgumentParser()
 
@@ -223,26 +221,16 @@ def source(namespaces, array_name, array_size_name, fileid, filename,
   return data
 
 
-def _get_repo_root(filename):
-  """Returns the root of the repository containing the given file.
-
-  Args:
-    filename: A source file or directory in the repository.
+def _get_repo_root():
+  """Returns the root of the source repository.
   """
 
-  # CMake builds can be run out of source tree, so use the directory containing
-  # a source file as the starting point for the calculation.
-  if os.path.isdir(filename):
-    dir_in_repo = filename
-  else:
-    dir_in_repo = os.path.dirname(filename)
+  scripts_dir = os.path.abspath(os.path.dirname(__file__))
+  assert os.path.basename(scripts_dir) == 'scripts'
 
-  starting_dir = os.getcwd()
+  root_dir = os.path.dirname(scripts_dir)
+  assert os.path.isdir(os.path.join(root_dir, '.github'))
 
-  os.chdir(dir_in_repo)
-  root_dir = git.get_repo_root()
-
-  os.chdir(starting_dir)
   return root_dir
 
 
@@ -265,8 +253,8 @@ def main():
     output_header = input_file_base + ".h"
     logging.debug("Using default --output_header='%s'", output_header)
 
+  root_dir = _get_repo_root()
   absolute_dir = path.dirname(output_header)
-  root_dir = _get_repo_root(absolute_dir)
 
   relative_dir = path.relpath(absolute_dir, root_dir)
   relative_header_path = path.join(relative_dir, path.basename(output_header))


### PR DESCRIPTION
This makes it possible to embed the Firestore CMake build contained in this repo in the public C++ CMake build.

This is enough to get the firebase-cpp-sdk build working with tests disabled. More changes may be required for tests enabled.