### PR TITLE
Restore Firestore build in xcframework branch

### DIFF
--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -211,10 +211,11 @@ enum CocoaPodUtils {
 
     for (podName, version) in pods {
       let subspecArray = podName.components(separatedBy: "/")
-      if subspecArray.count > 2 {
+      if subspecArray.count == 1 || subspecArray[0] == "abseil" {
+        // Special case for abseil since it has two layers and no external deps.
+        versions[subspecArray[0]] = version
+      } else if subspecArray.count > 2 {
         fatalError("Multi-layered subspecs are not supported - \(podName)")
-      } else if subspecArray.count == 1 {
-        versions[podName] = version
       } else {
         if let previousVersion = versions[podName], version != previousVersion {
           fatalError("Different installed versions for \(podName)." +


### PR DESCRIPTION
Restore Firestore build after #4940 broke it because of the abseil dependency.

With this change, a zip with xcframeworks for all the Podfile dependencies of the Firestore quickstart now build.

The quickstart fails to build because FirebaseUI does not have an umbrella header necessary for Swift module imports.  The proper way to build static libs in CocoaPods with modular headers is the `use_modular_headers!` option but that does now work with Firestore because gRPC does not work with them. See https://github.com/grpc/grpc/issues/20631 and https://github.com/CocoaPods/CocoaPods/issues/9023.

Next step is to investigate the feasibility of fixing https://github.com/CocoaPods/CocoaPods/issues/9023. In the meantime sending the PR here to checkpoint.

Here is the json file for the Firestore quickstart:
```

[
  {
    "name": "FirebaseFirestore"
  },
   {
    "name": "FirebaseUI/Auth"
  },
   {
    "name": "FirebaseUI/Email"
  },
   {
    "name": "SDWebImage"
  },
   {
    "name": "FirebaseAuth"
  }
]
```