### PR TITLE
Support AB testing of Firebase In-App Messages

### DIFF
--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseABTesting'
-  s.version          = '3.1.2'
+  s.version          = '3.2.0'
   s.summary          = 'Firebase ABTesting for iOS'
 
   s.description      = <<-DESC

--- a/FirebaseABTesting/Sources/FIRExperimentController.m
+++ b/FirebaseABTesting/Sources/FIRExperimentController.m
@@ -293,7 +293,7 @@ NSArray *ABTExperimentsToClearFromPayloads(
 }
 
 - (void)validateRunningExperimentsForServiceOrigin:(NSString *)origin
-                                          payloads:(NSArray<ABTExperimentPayload *> *)payloads {
+                         runningExperimentPayloads:(NSArray<ABTExperimentPayload *> *)payloads {
   ABTConditionalUserPropertyController *controller =
       [ABTConditionalUserPropertyController sharedInstanceWithAnalytics:_analytics];
 
@@ -309,9 +309,9 @@ NSArray *ABTExperimentsToClearFromPayloads(
   }
 
   for (NSDictionary<NSString *, NSString *> *activeExperimentDictionary in activeExperiments) {
-    NSString *experimentID = activeExperimentDictionary[@"experimentId"];
+    NSString *experimentID = activeExperimentDictionary[@"name"];
     if (![runningExperimentIDs containsObject:experimentID]) {
-      NSString *variantID = activeExperimentDictionary[@"variantId"];
+      NSString *variantID = activeExperimentDictionary[@"value"];
 
       [controller clearExperiment:experimentID
                         variantID:variantID

--- a/FirebaseABTesting/Sources/FIRExperimentController.m
+++ b/FirebaseABTesting/Sources/FIRExperimentController.m
@@ -323,8 +323,7 @@ NSArray *ABTExperimentsToClearFromPayloads(
 }
 
 - (void)activateExperiment:(ABTExperimentPayload *)experimentPayload
-          forServiceOrigin:(NSString *)origin
-            overflowPolicy:(ABTExperimentPayload_ExperimentOverflowPolicy)overflowPolicy {
+          forServiceOrigin:(NSString *)origin {
   ABTConditionalUserPropertyController *controller =
       [ABTConditionalUserPropertyController sharedInstanceWithAnalytics:_analytics];
 
@@ -336,7 +335,7 @@ NSArray *ABTExperimentsToClearFromPayloads(
   [controller setExperimentWithOrigin:origin
                               payload:experimentPayload
                                events:lifecycleEvents
-                               policy:overflowPolicy];
+                               policy:experimentPayload.overflowPolicy];
 }
 
 @end

--- a/FirebaseABTesting/Sources/Public/FIRExperimentController.h
+++ b/FirebaseABTesting/Sources/Public/FIRExperimentController.h
@@ -102,8 +102,7 @@ NS_SWIFT_NAME(ExperimentController)
 /// @param origin         The originating service affected by the experiment, it is defined at
 ///                       Firebase Analytics FIREventOrigins.h.
 - (void)activateExperiment:(ABTExperimentPayload *)experimentPayload
-          forServiceOrigin:(NSString *)origin
-            overflowPolicy:(ABTExperimentPayload_ExperimentOverflowPolicy)overflowPolicy;
+          forServiceOrigin:(NSString *)origin;
 
 @end
 

--- a/FirebaseABTesting/Sources/Public/FIRExperimentController.h
+++ b/FirebaseABTesting/Sources/Public/FIRExperimentController.h
@@ -88,14 +88,14 @@ NS_SWIFT_NAME(ExperimentController)
                                                      andPayloads:(NSArray<NSData *> *)payloads;
 
 /// Expires experiments that aren't in the list of running experiment payloads.
-/// @param origin         The originating service affected by the experiment.
-/// @param payloads     The list of valid, running experiments.
+/// @param origin The originating service affected by the experiment.
+/// @param payloads The list of valid, running experiments.
 - (void)validateRunningExperimentsForServiceOrigin:(NSString *)origin
                          runningExperimentPayloads:(NSArray<ABTExperimentPayload *> *)payloads;
 
 /// Directly sets a given experiment to be active.
 /// @param experimentPayload The payload for the experiment that should be activated.
-/// @param origin         The originating service affected by the experiment.
+/// @param origin The originating service affected by the experiment.
 - (void)activateExperiment:(ABTExperimentPayload *)experimentPayload
           forServiceOrigin:(NSString *)origin;
 

--- a/FirebaseABTesting/Sources/Public/FIRExperimentController.h
+++ b/FirebaseABTesting/Sources/Public/FIRExperimentController.h
@@ -39,8 +39,7 @@ NS_SWIFT_NAME(ExperimentController)
 /// existing in payloads are not affected, whose state and payload is preserved. This method
 /// compares whether the experiments have changed or not by their variant ID. This runs in a
 /// background queue and calls the completion handler when finished executing.
-/// @param origin         The originating service affected by the experiment, it is defined at
-///                       Firebase Analytics FIREventOrigins.h.
+/// @param origin         The originating service affected by the experiment.
 /// @param events         A list of event names to be used for logging experiment lifecycle events,
 ///                       if they are not defined in the payload.
 /// @param policy         The policy to handle new experiments when slots are full.
@@ -62,8 +61,7 @@ NS_SWIFT_NAME(ExperimentController)
 /// existing in payloads are not affected, whose state and payload is preserved. This method
 /// compares whether the experiments have changed or not by their variant ID. This runs in a
 /// background queue..
-/// @param origin         The originating service affected by the experiment, it is defined at
-///                       Firebase Analytics FIREventOrigins.h.
+/// @param origin         The originating service affected by the experiment.
 /// @param events         A list of event names to be used for logging experiment lifecycle events,
 ///                       if they are not defined in the payload.
 /// @param policy         The policy to handle new experiments when slots are full.
@@ -90,16 +88,14 @@ NS_SWIFT_NAME(ExperimentController)
                                                      andPayloads:(NSArray<NSData *> *)payloads;
 
 /// Expires experiments that aren't in the list of running experiment payloads.
-/// @param origin         The originating service affected by the experiment, it is defined at
-///                       Firebase Analytics FIREventOrigins.h.
+/// @param origin         The originating service affected by the experiment.
 /// @param payloads     The list of valid, running experiments.
 - (void)validateRunningExperimentsForServiceOrigin:(NSString *)origin
                          runningExperimentPayloads:(NSArray<ABTExperimentPayload *> *)payloads;
 
 /// Directly sets a given experiment to be active.
 /// @param experimentPayload The payload for the experiment that should be activated.
-/// @param origin         The originating service affected by the experiment, it is defined at
-///                       Firebase Analytics FIREventOrigins.h.
+/// @param origin         The originating service affected by the experiment.
 - (void)activateExperiment:(ABTExperimentPayload *)experimentPayload
           forServiceOrigin:(NSString *)origin;
 

--- a/FirebaseABTesting/Sources/Public/FIRExperimentController.h
+++ b/FirebaseABTesting/Sources/Public/FIRExperimentController.h
@@ -14,6 +14,8 @@
 
 #import <Foundation/Foundation.h>
 
+@class ABTExperimentPayload;
+
 // Forward declaration to avoid importing into the module header
 typedef NS_ENUM(int32_t, ABTExperimentPayload_ExperimentOverflowPolicy);
 
@@ -86,6 +88,11 @@ NS_SWIFT_NAME(ExperimentController)
 /// @param payloads   List of experiment metadata.
 - (NSTimeInterval)latestExperimentStartTimestampBetweenTimestamp:(NSTimeInterval)timestamp
                                                      andPayloads:(NSArray<NSData *> *)payloads;
+
+- (void)validateRunningExperimentsForServiceOrigin:(NSString *)origin
+                                          payloads:(NSArray<ABTExperimentPayload *> *)payloads;
+
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseABTesting/Sources/Public/FIRExperimentController.h
+++ b/FirebaseABTesting/Sources/Public/FIRExperimentController.h
@@ -89,13 +89,12 @@ NS_SWIFT_NAME(ExperimentController)
 - (NSTimeInterval)latestExperimentStartTimestampBetweenTimestamp:(NSTimeInterval)timestamp
                                                      andPayloads:(NSArray<NSData *> *)payloads;
 
-/// Replaces the list of running experiments for a given service origin with a list of payloads that
-/// represent the experiments that should be running.
+/// Expires experiments that aren't in the list of running experiment payloads.
 /// @param origin         The originating service affected by the experiment, it is defined at
 ///                       Firebase Analytics FIREventOrigins.h.
 /// @param payloads     The list of valid, running experiments.
 - (void)validateRunningExperimentsForServiceOrigin:(NSString *)origin
-                                          payloads:(NSArray<ABTExperimentPayload *> *)payloads;
+                         runningExperimentPayloads:(NSArray<ABTExperimentPayload *> *)payloads;
 
 /// Directly sets a given experiment to be active.
 /// @param experimentPayload The payload for the experiment that should be activated.

--- a/FirebaseABTesting/Sources/Public/FIRExperimentController.h
+++ b/FirebaseABTesting/Sources/Public/FIRExperimentController.h
@@ -89,9 +89,21 @@ NS_SWIFT_NAME(ExperimentController)
 - (NSTimeInterval)latestExperimentStartTimestampBetweenTimestamp:(NSTimeInterval)timestamp
                                                      andPayloads:(NSArray<NSData *> *)payloads;
 
+/// Replaces the list of running experiments for a given service origin with a list of payloads that
+/// represent the experiments that should be running.
+/// @param origin         The originating service affected by the experiment, it is defined at
+///                       Firebase Analytics FIREventOrigins.h.
+/// @param payloads     The list of valid, running experiments.
 - (void)validateRunningExperimentsForServiceOrigin:(NSString *)origin
                                           payloads:(NSArray<ABTExperimentPayload *> *)payloads;
 
+/// Directly sets a given experiment to be active.
+/// @param experimentPayload The payload for the experiment that should be activated.
+/// @param origin         The originating service affected by the experiment, it is defined at
+///                       Firebase Analytics FIREventOrigins.h.
+- (void)activateExperiment:(ABTExperimentPayload *)experimentPayload
+          forServiceOrigin:(NSString *)origin
+            overflowPolicy:(ABTExperimentPayload_ExperimentOverflowPolicy)overflowPolicy;
 
 @end
 

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -45,7 +45,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
   s.ios.dependency 'FirebaseAnalyticsInterop', '~> 1.3'
   s.dependency 'FirebaseInstanceID', '~> 4.0'
   s.dependency 'GoogleDataTransportCCTSupport', '~> 1.0'
-	s.dependency 'FirebaseABTesting'
+  s.dependency 'FirebaseABTesting', '~> 3.2.0'
 	
   s.test_spec 'unit' do |unit_tests|
       unit_tests.source_files = 'FirebaseInAppMessaging/Tests/Unit/*.[mh]'

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -35,6 +35,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
   }
 
   s.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' =>
+			'GPB_USE_PROTOBUF_FRAMEWORK_IMPORTS=1 ' +
       '$(inherited) ' +
       'FIRInAppMessaging_LIB_VERSION=' + String(s.version) + ' ' +
       'PB_FIELD_32BIT=1 PB_NO_PACKED_STRUCTS=1 PB_ENABLE_MALLOC=1'
@@ -44,6 +45,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
   s.ios.dependency 'FirebaseAnalyticsInterop', '~> 1.3'
   s.dependency 'FirebaseInstanceID', '~> 4.0'
   s.dependency 'GoogleDataTransportCCTSupport', '~> 1.0'
+	s.dependency 'FirebaseABTesting'
 	
   s.test_spec 'unit' do |unit_tests|
       unit_tests.source_files = 'FirebaseInAppMessaging/Tests/Unit/*.[mh]'

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -45,7 +45,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
   s.ios.dependency 'FirebaseAnalyticsInterop', '~> 1.3'
   s.dependency 'FirebaseInstanceID', '~> 4.0'
   s.dependency 'GoogleDataTransportCCTSupport', '~> 1.0'
-  s.dependency 'FirebaseABTesting', '~> 3.2.0'
+  s.dependency 'FirebaseABTesting', '~> 3.2'
 	
   s.test_spec 'unit' do |unit_tests|
       unit_tests.source_files = 'FirebaseInAppMessaging/Tests/Unit/*.[mh]'

--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
@@ -172,7 +172,7 @@
           [experimentPayloadDictionary[@"timeToLiveMillis"] integerValue];
       experimentPayload.triggerTimeoutMillis =
           [experimentPayloadDictionary[@"triggerTimeoutMillis"] integerValue];
-      experimentPayload.variantId = [experimentPayloadDictionary[@"variantId"] stringValue];
+      experimentPayload.variantId = experimentPayloadDictionary[@"variantId"];
     }
 
     NSTimeInterval startTimeInSeconds = 0;

--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
@@ -362,7 +362,8 @@
       dataBundle = dataBundleNode;
     }
     if (isTestMessage) {
-      return [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:renderData];
+      return [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:renderData
+                                                          experimentPayload:experimentPayload];
     } else {
       return [[FIRIAMMessageDefinition alloc] initWithRenderData:renderData
                                                        startTime:startTimeInSeconds

--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
@@ -156,7 +156,7 @@
     }
     
     FIRIAMExperimentalPayload *experimentalPayload = nil;
-    NSDictionary *experimentPayloadDictionary = payloadNode[@"experimentalPayload"];
+    NSDictionary *experimentPayloadDictionary = payloadNode[@"experimentPayload"];
     if (experimentPayloadDictionary) {
         experimentalPayload =
           [[FIRIAMExperimentalPayload alloc] initWithDictionary:experimentPayloadDictionary];

--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
@@ -25,6 +25,8 @@
 #import "FIRIAMTimeFetcher.h"
 #import "UIColor+FIRIAMHexString.h"
 
+// #import <FirebaseABTesting/ExperimentPayload.pbobjc.h>
+
 @interface FIRIAMFetchResponseParser ()
 @property(nonatomic) id<FIRIAMTimeFetcher> timeFetcher;
 @end
@@ -155,11 +157,18 @@
       return nil;
     }
     
-    FIRIAMExperimentalPayload *experimentalPayload = nil;
+    ABTExperimentPayload *experimentPayload = nil;
     NSDictionary *experimentPayloadDictionary = payloadNode[@"experimentPayload"];
+
     if (experimentPayloadDictionary) {
-        experimentalPayload =
-          [[FIRIAMExperimentalPayload alloc] initWithDictionary:experimentPayloadDictionary];
+      experimentPayload = [ABTExperimentPayload message];
+      experimentPayload.experimentId = experimentPayloadDictionary[@"experimentId"];
+      experimentPayload.experimentStartTimeMillis = [experimentPayloadDictionary[@"experimentStartTimeMillis"] integerValue];
+      // TODO Map this to an actual value
+      experimentPayload.overflowPolicy = ABTExperimentPayload_ExperimentOverflowPolicy_DiscardOldest;
+      experimentPayload.timeToLiveMillis = [experimentPayloadDictionary[@"timeToLiveMillis"] integerValue];
+      experimentPayload.triggerTimeoutMillis = [experimentPayloadDictionary[@"triggerTimeoutMillis"] integerValue];
+      experimentPayload.variantId = [experimentPayloadDictionary[@"variantId"] stringValue];
     }
 
     NSTimeInterval startTimeInSeconds = 0;
@@ -356,7 +365,7 @@
                                                          endTime:endTimeInSeconds
                                                triggerDefinition:triggersDefinition
                                                          appData:dataBundle
-                                             experimentalPayload:experimentalPayload
+                                               experimentPayload:experimentPayload
                                                    isTestMessage:NO];
     }
   } @catch (NSException *e) {

--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
@@ -25,7 +25,7 @@
 #import "FIRIAMTimeFetcher.h"
 #import "UIColor+FIRIAMHexString.h"
 
-// #import <FirebaseABTesting/ExperimentPayload.pbobjc.h>
+#import <FirebaseABTesting/ExperimentPayload.pbobjc.h>
 
 @interface FIRIAMFetchResponseParser ()
 @property(nonatomic) id<FIRIAMTimeFetcher> timeFetcher;
@@ -132,7 +132,7 @@
     if ([isTestCampaignNode isKindOfClass:[NSNumber class]]) {
       isTestMessage = [isTestCampaignNode boolValue];
     }
-    
+
     id payloadNode = messageNode[@"experimentalPayload"] ?: messageNode[@"vanillaPayload"];
 
     if (![payloadNode isKindOfClass:[NSDictionary class]]) {
@@ -156,18 +156,22 @@
                     @"campaign name is missing in non-test message node %@", messageNode);
       return nil;
     }
-    
+
     ABTExperimentPayload *experimentPayload = nil;
     NSDictionary *experimentPayloadDictionary = payloadNode[@"experimentPayload"];
 
     if (experimentPayloadDictionary) {
       experimentPayload = [ABTExperimentPayload message];
       experimentPayload.experimentId = experimentPayloadDictionary[@"experimentId"];
-      experimentPayload.experimentStartTimeMillis = [experimentPayloadDictionary[@"experimentStartTimeMillis"] integerValue];
-      // TODO Map this to an actual value
-      experimentPayload.overflowPolicy = ABTExperimentPayload_ExperimentOverflowPolicy_DiscardOldest;
-      experimentPayload.timeToLiveMillis = [experimentPayloadDictionary[@"timeToLiveMillis"] integerValue];
-      experimentPayload.triggerTimeoutMillis = [experimentPayloadDictionary[@"triggerTimeoutMillis"] integerValue];
+      experimentPayload.experimentStartTimeMillis =
+          [experimentPayloadDictionary[@"experimentStartTimeMillis"] integerValue];
+      // FIAM experiments always use the "discard oldest" overflow policy.
+      experimentPayload.overflowPolicy =
+          ABTExperimentPayload_ExperimentOverflowPolicy_DiscardOldest;
+      experimentPayload.timeToLiveMillis =
+          [experimentPayloadDictionary[@"timeToLiveMillis"] integerValue];
+      experimentPayload.triggerTimeoutMillis =
+          [experimentPayloadDictionary[@"triggerTimeoutMillis"] integerValue];
       experimentPayload.variantId = [experimentPayloadDictionary[@"variantId"] stringValue];
     }
 

--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMMessageDefinition.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMMessageDefinition.m
@@ -56,23 +56,25 @@
 - (instancetype)initWithRenderData:(FIRIAMMessageRenderData *)renderData
                          startTime:(NSTimeInterval)startTime
                            endTime:(NSTimeInterval)endTime
+                 experimentPayload:(nullable ABTExperimentPayload *)experimentPayload
                  triggerDefinition:(NSArray<FIRIAMDisplayTriggerDefinition *> *)renderTriggers {
   return [self initWithRenderData:renderData
                         startTime:startTime
                           endTime:endTime
                 triggerDefinition:renderTriggers
                           appData:nil
-                experimentPayload:nil
+                experimentPayload:experimentPayload
                     isTestMessage:NO];
 }
 
-- (instancetype)initTestMessageWithRenderData:(FIRIAMMessageRenderData *)renderData {
+- (instancetype)initTestMessageWithRenderData:(FIRIAMMessageRenderData *)renderData
+                            experimentPayload:(nullable ABTExperimentPayload *)experimentPayload {
   return [self initWithRenderData:renderData
                         startTime:0
                           endTime:0
                 triggerDefinition:@[]
                           appData:nil
-                experimentPayload:nil
+                experimentPayload:experimentPayload
                     isTestMessage:YES];
 }
 

--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMMessageDefinition.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMMessageDefinition.m
@@ -16,33 +16,6 @@
 
 #import "FIRIAMMessageDefinition.h"
 
-@implementation FIRIAMExperimentalPayload
-
-- (instancetype)initWithDictionary:(NSDictionary *)dictionary {
-  if (self = [super init]) {
-    _experimentID = [dictionary[@"experimentId"] stringValue];
-    _experimentStartTime = [dictionary[@"experimentStartTimeMillis"] integerValue];
-    _overflowPolicy = [dictionary[@"overflowPolicy"] stringValue];
-    _timeToLive = [dictionary[@"timeToLiveMillis"] integerValue];
-    _triggerTimeoutMillis = [dictionary[@"triggerTimeoutMillis"] integerValue];
-    _variantID = [dictionary[@"variantId"] integerValue];
-  }
-  return self;
-}
-
-- (id)copyWithZone:(NSZone *)zone {
-  FIRIAMExperimentalPayload *newPayload = [[FIRIAMExperimentalPayload alloc] init];
-  newPayload->_experimentID = [_experimentID copyWithZone:zone];
-  newPayload->_experimentStartTime = _experimentStartTime;
-  newPayload->_overflowPolicy = [_overflowPolicy copyWithZone:zone];
-  newPayload->_timeToLive = _timeToLive;
-  newPayload->_triggerTimeoutMillis = _triggerTimeoutMillis;
-  newPayload->_variantID = _variantID;
-  return newPayload;
-}
-
-@end
-
 @implementation FIRIAMMessageRenderData
 
 - (instancetype)initWithMessageID:(NSString *)messageID
@@ -60,12 +33,13 @@
 @end
 
 @implementation FIRIAMMessageDefinition
+
 - (instancetype)initWithRenderData:(FIRIAMMessageRenderData *)renderData
                          startTime:(NSTimeInterval)startTime
                            endTime:(NSTimeInterval)endTime
                  triggerDefinition:(NSArray<FIRIAMDisplayTriggerDefinition *> *)renderTriggers
                            appData:(nullable NSDictionary *)appData
-               experimentalPayload:(nullable FIRIAMExperimentalPayload *)experimentalPayload
+                 experimentPayload:(nullable ABTExperimentPayload *)experimentPayload
                      isTestMessage:(BOOL)isTestMessage {
   if (self = [super init]) {
     _renderData = renderData;
@@ -74,7 +48,7 @@
     _endTime = endTime;
     _isTestMessage = isTestMessage;
     _appData = [appData copy];
-    _experimentalPayload = [experimentalPayload copy];
+    _experimentPayload = experimentPayload;
   }
   return self;
 }
@@ -88,7 +62,7 @@
                           endTime:endTime
                 triggerDefinition:renderTriggers
                           appData:nil
-              experimentalPayload:nil
+                experimentPayload:nil
                     isTestMessage:NO];
 }
 
@@ -98,7 +72,7 @@
                           endTime:0
                 triggerDefinition:@[]
                           appData:nil
-              experimentalPayload:nil
+                experimentPayload:nil
                     isTestMessage:YES];
 }
 

--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMMessageDefinition.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMMessageDefinition.m
@@ -30,6 +30,17 @@
   return self;
 }
 
+- (id)copyWithZone:(NSZone *)zone {
+  FIRIAMExperimentalPayload *newPayload = [[FIRIAMExperimentalPayload alloc] init];
+  newPayload->_experimentID = [_experimentID copyWithZone:zone];
+  newPayload->_experimentStartTime = _experimentStartTime;
+  newPayload->_overflowPolicy = [_overflowPolicy copyWithZone:zone];
+  newPayload->_timeToLive = _timeToLive;
+  newPayload->_triggerTimeoutMillis = _triggerTimeoutMillis;
+  newPayload->_variantID = _variantID;
+  return newPayload;
+}
+
 @end
 
 @implementation FIRIAMMessageRenderData

--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMMessageDefinition.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMMessageDefinition.m
@@ -16,6 +16,22 @@
 
 #import "FIRIAMMessageDefinition.h"
 
+@implementation FIRIAMExperimentalPayload
+
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary {
+  if (self = [super init]) {
+    _experimentID = [dictionary[@"experimentId"] stringValue];
+    _experimentStartTime = [dictionary[@"experimentStartTimeMillis"] integerValue];
+    _overflowPolicy = [dictionary[@"overflowPolicy"] stringValue];
+    _timeToLive = [dictionary[@"timeToLiveMillis"] integerValue];
+    _triggerTimeoutMillis = [dictionary[@"triggerTimeoutMillis"] integerValue];
+    _variantID = [dictionary[@"variantId"] integerValue];
+  }
+  return self;
+}
+
+@end
+
 @implementation FIRIAMMessageRenderData
 
 - (instancetype)initWithMessageID:(NSString *)messageID
@@ -38,6 +54,7 @@
                            endTime:(NSTimeInterval)endTime
                  triggerDefinition:(NSArray<FIRIAMDisplayTriggerDefinition *> *)renderTriggers
                            appData:(nullable NSDictionary *)appData
+               experimentalPayload:(nullable FIRIAMExperimentalPayload *)experimentalPayload
                      isTestMessage:(BOOL)isTestMessage {
   if (self = [super init]) {
     _renderData = renderData;
@@ -46,6 +63,7 @@
     _endTime = endTime;
     _isTestMessage = isTestMessage;
     _appData = [appData copy];
+    _experimentalPayload = [experimentalPayload copy];
   }
   return self;
 }
@@ -59,6 +77,7 @@
                           endTime:endTime
                 triggerDefinition:renderTriggers
                           appData:nil
+              experimentalPayload:nil
                     isTestMessage:NO];
 }
 
@@ -68,6 +87,7 @@
                           endTime:0
                 triggerDefinition:@[]
                           appData:nil
+              experimentalPayload:nil
                     isTestMessage:YES];
 }
 

--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMMessageDefinition.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMMessageDefinition.m
@@ -56,14 +56,13 @@
 - (instancetype)initWithRenderData:(FIRIAMMessageRenderData *)renderData
                          startTime:(NSTimeInterval)startTime
                            endTime:(NSTimeInterval)endTime
-                 experimentPayload:(nullable ABTExperimentPayload *)experimentPayload
                  triggerDefinition:(NSArray<FIRIAMDisplayTriggerDefinition *> *)renderTriggers {
   return [self initWithRenderData:renderData
                         startTime:startTime
                           endTime:endTime
                 triggerDefinition:renderTriggers
                           appData:nil
-                experimentPayload:experimentPayload
+                experimentPayload:nil
                     isTestMessage:NO];
 }
 

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
@@ -437,7 +437,9 @@
 
   FIRInAppMessagingCardDisplay *cardMessage = [[FIRInAppMessagingCardDisplay alloc]
         initWithMessageID:renderData.messageID
+
              campaignName:renderData.name
+        experimentPayload:definition.experimentPayload
       renderAsTestMessage:definition.isTestMessage
               triggerType:triggerType
                 titleText:title
@@ -468,6 +470,7 @@
   FIRInAppMessagingBannerDisplay *bannerMessage = [[FIRInAppMessagingBannerDisplay alloc]
         initWithMessageID:definition.renderData.messageID
              campaignName:definition.renderData.name
+        experimentPayload:definition.experimentPayload
       renderAsTestMessage:definition.isTestMessage
               triggerType:triggerType
                 titleText:title
@@ -491,6 +494,7 @@
   FIRInAppMessagingImageOnlyDisplay *imageOnlyMessage = [[FIRInAppMessagingImageOnlyDisplay alloc]
         initWithMessageID:definition.renderData.messageID
              campaignName:definition.renderData.name
+        experimentPayload:definition.experimentPayload
       renderAsTestMessage:definition.isTestMessage
               triggerType:triggerType
                 imageData:imageData
@@ -528,6 +532,7 @@
   FIRInAppMessagingModalDisplay *modalViewMessage = [[FIRInAppMessagingModalDisplay alloc]
         initWithMessageID:definition.renderData.messageID
              campaignName:definition.renderData.name
+        experimentPayload:definition.experimentPayload
       renderAsTestMessage:definition.isTestMessage
               triggerType:triggerType
                 titleText:title

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
@@ -215,8 +215,7 @@
   if (inAppMessage.campaignInfo.experimentPayload) {
     [[FIRExperimentController sharedInstance]
         activateExperiment:inAppMessage.campaignInfo.experimentPayload
-          forServiceOrigin:@"fiam"
-            overflowPolicy:ABTExperimentPayload_ExperimentOverflowPolicy_DiscardOldest];
+          forServiceOrigin:@"fiam"];
   }
 
   if (!_currentMsgBeingDisplayed.isTestMessage) {
@@ -447,7 +446,6 @@
 
   FIRInAppMessagingCardDisplay *cardMessage = [[FIRInAppMessagingCardDisplay alloc]
         initWithMessageID:renderData.messageID
-
              campaignName:renderData.name
         experimentPayload:definition.experimentPayload
       renderAsTestMessage:definition.isTestMessage

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
@@ -26,6 +26,8 @@
 #import "FIRInAppMessaging.h"
 #import "FIRInAppMessagingRenderingPrivate.h"
 
+#import <FirebaseABTesting/FIRExperimentController.h>
+
 @implementation FIRIAMDisplaySetting
 @end
 
@@ -207,6 +209,14 @@
                   @"impressionDetected called but "
                    "there is no current message ID.");
     return;
+  }
+
+  // If this is an experimental FIAM, activate the experiment.
+  if (inAppMessage.campaignInfo.experimentPayload) {
+    [[FIRExperimentController sharedInstance]
+        activateExperiment:inAppMessage.campaignInfo.experimentPayload
+          forServiceOrigin:@"fiam"
+            overflowPolicy:ABTExperimentPayload_ExperimentOverflowPolicy_DiscardOldest];
   }
 
   if (!_currentMsgBeingDisplayed.isTestMessage) {

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMMessageClientCache.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMMessageClientCache.m
@@ -225,6 +225,9 @@
                                         discardedMsgCount:&discardCount
                                    fetchWaitTimeInSeconds:&fetchWaitTime];
       [self setMessageData:messagesFromStorage];
+      
+      
+      
       completion(YES);
     } else {
       completion(NO);

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMMessageClientCache.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMMessageClientCache.m
@@ -225,9 +225,6 @@
                                         discardedMsgCount:&discardCount
                                    fetchWaitTimeInSeconds:&fetchWaitTime];
       [self setMessageData:messagesFromStorage];
-      
-      
-      
       completion(YES);
     } else {
       completion(NO);

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMMsgFetcherUsingRestful.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMMsgFetcherUsingRestful.m
@@ -186,7 +186,7 @@ static NSInteger const SuccessHTTPStatusCode = 200;
                     FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM130012",
                                 @"API request for fetching messages and parsing the response was "
                                  "successful.");
-                    
+
                     // Validate running experiments with ABT.
                     NSMutableArray *runningExperiments = [[NSArray array] mutableCopy];
                     for (FIRIAMMessageDefinition *messageDefinition in messages) {
@@ -194,13 +194,11 @@ static NSInteger const SuccessHTTPStatusCode = 200;
                         [runningExperiments addObject:messageDefinition.experimentPayload];
                       }
                     }
-                    
-                    if (runningExperiments.count) {
-                      [[FIRExperimentController sharedInstance]
-                          validateRunningExperimentsForServiceOrigin:@"fiam"
-                                                            payloads:[runningExperiments copy]];
-                    }
-                    
+
+                    [[FIRExperimentController sharedInstance]
+                        validateRunningExperimentsForServiceOrigin:@"fiam"
+                                         runningExperimentPayloads:[runningExperiments copy]];
+
                     [self.fetchStorage
                         saveResponseDictionary:responseDict
                                 withCompletion:^(BOOL success) {

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMMsgFetcherUsingRestful.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMMsgFetcherUsingRestful.m
@@ -25,6 +25,8 @@
 #import "FIRIAMMsgFetcherUsingRestful.h"
 #import "FIRIAMSDKSettings.h"
 
+#import <FirebaseABTesting/FIRExperimentController.h>
+
 static NSInteger const SuccessHTTPStatusCode = 200;
 
 @interface FIRIAMMsgFetcherUsingRestful ()
@@ -184,6 +186,21 @@ static NSInteger const SuccessHTTPStatusCode = 200;
                     FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM130012",
                                 @"API request for fetching messages and parsing the response was "
                                  "successful.");
+                    
+                    // Validate running experiments with ABT.
+                    NSMutableArray *runningExperiments = [[NSArray array] mutableCopy];
+                    for (FIRIAMMessageDefinition *messageDefinition in messages) {
+                      if (messageDefinition.experimentPayload) {
+                        [runningExperiments addObject:messageDefinition.experimentPayload];
+                      }
+                    }
+                    
+                    if (runningExperiments.count) {
+                      [[FIRExperimentController sharedInstance]
+                          validateRunningExperimentsForServiceOrigin:@"fiam"
+                                                            payloads:[runningExperiments copy]];
+                    }
+                    
                     [self.fetchStorage
                         saveResponseDictionary:responseDict
                                 withCompletion:^(BOOL success) {

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMMsgFetcherUsingRestful.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMMsgFetcherUsingRestful.m
@@ -188,7 +188,7 @@ static NSInteger const SuccessHTTPStatusCode = 200;
                                  "successful.");
 
                     // Validate running experiments with ABT.
-                    NSMutableArray *runningExperiments = [[NSArray array] mutableCopy];
+                    NSMutableArray *runningExperiments = [[NSMutableArray alloc] init];
                     for (FIRIAMMessageDefinition *messageDefinition in messages) {
                       if (messageDefinition.experimentPayload) {
                         [runningExperiments addObject:messageDefinition.experimentPayload];

--- a/FirebaseInAppMessaging/Sources/Private/Data/FIRIAMMessageDefinition.h
+++ b/FirebaseInAppMessaging/Sources/Private/Data/FIRIAMMessageDefinition.h
@@ -59,7 +59,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithRenderData:(FIRIAMMessageRenderData *)renderData
                          startTime:(NSTimeInterval)startTime
                            endTime:(NSTimeInterval)endTime
-                 experimentPayload:(nullable ABTExperimentPayload *)experimentPayload
                  triggerDefinition:(NSArray<FIRIAMDisplayTriggerDefinition *> *)renderTriggers;
 
 /**

--- a/FirebaseInAppMessaging/Sources/Private/Data/FIRIAMMessageDefinition.h
+++ b/FirebaseInAppMessaging/Sources/Private/Data/FIRIAMMessageDefinition.h
@@ -59,12 +59,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithRenderData:(FIRIAMMessageRenderData *)renderData
                          startTime:(NSTimeInterval)startTime
                            endTime:(NSTimeInterval)endTime
+                 experimentPayload:(nullable ABTExperimentPayload *)experimentPayload
                  triggerDefinition:(NSArray<FIRIAMDisplayTriggerDefinition *> *)renderTriggers;
 
 /**
  * Create a test message definition.
  */
-- (instancetype)initTestMessageWithRenderData:(FIRIAMMessageRenderData *)renderData;
+- (instancetype)initTestMessageWithRenderData:(FIRIAMMessageRenderData *)renderData
+                            experimentPayload:(nullable ABTExperimentPayload *)experimentPayload;
 
 - (BOOL)messageHasExpired;
 - (BOOL)messageHasStarted;

--- a/FirebaseInAppMessaging/Sources/Private/Data/FIRIAMMessageDefinition.h
+++ b/FirebaseInAppMessaging/Sources/Private/Data/FIRIAMMessageDefinition.h
@@ -21,6 +21,20 @@
 @class FIRIAMDisplayTriggerDefinition;
 
 NS_ASSUME_NONNULL_BEGIN
+
+@interface FIRIAMExperimentalPayload : NSObject
+
+@property(nonatomic, copy) NSString *experimentID;
+@property(nonatomic) NSTimeInterval experimentStartTime;
+@property(nonatomic, copy) NSString *overflowPolicy;
+@property(nonatomic) NSTimeInterval timeToLive;
+@property(nonatomic) NSTimeInterval triggerTimeoutMillis;
+@property(nonatomic) NSInteger variantID;
+
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary;
+
+@end
+
 @interface FIRIAMMessageDefinition : NSObject
 @property(nonatomic, nonnull, readonly) FIRIAMMessageRenderData *renderData;
 
@@ -38,6 +52,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// Additional key-value pairs that can be optionally sent along with the FIAM
 @property(nonatomic, nullable, readonly) NSDictionary *appData;
 
+@property(nonatomic, nullable, copy) NSDictionary *experimentalPayload;
+
 - (instancetype)init NS_UNAVAILABLE;
 
 /**
@@ -48,6 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
                            endTime:(NSTimeInterval)endTime
                  triggerDefinition:(NSArray<FIRIAMDisplayTriggerDefinition *> *)renderTriggers
                            appData:appData
+               experimentalPayload:(nullable FIRIAMExperimentalPayload *)experimentalPayload
                      isTestMessage:(BOOL)isTestMessage NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)initWithRenderData:(FIRIAMMessageRenderData *)renderData

--- a/FirebaseInAppMessaging/Sources/Private/Data/FIRIAMMessageDefinition.h
+++ b/FirebaseInAppMessaging/Sources/Private/Data/FIRIAMMessageDefinition.h
@@ -22,7 +22,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface FIRIAMExperimentalPayload : NSObject
+@interface FIRIAMExperimentalPayload : NSObject <NSCopying>
 
 @property(nonatomic, copy) NSString *experimentID;
 @property(nonatomic) NSTimeInterval experimentStartTime;

--- a/FirebaseInAppMessaging/Sources/Private/Data/FIRIAMMessageDefinition.h
+++ b/FirebaseInAppMessaging/Sources/Private/Data/FIRIAMMessageDefinition.h
@@ -20,20 +20,9 @@
 
 @class FIRIAMDisplayTriggerDefinition;
 
+#import <FirebaseABTesting/ExperimentPayload.pbobjc.h>
+
 NS_ASSUME_NONNULL_BEGIN
-
-@interface FIRIAMExperimentalPayload : NSObject <NSCopying>
-
-@property(nonatomic, copy) NSString *experimentID;
-@property(nonatomic) NSTimeInterval experimentStartTime;
-@property(nonatomic, copy) NSString *overflowPolicy;
-@property(nonatomic) NSTimeInterval timeToLive;
-@property(nonatomic) NSTimeInterval triggerTimeoutMillis;
-@property(nonatomic) NSInteger variantID;
-
-- (instancetype)initWithDictionary:(NSDictionary *)dictionary;
-
-@end
 
 @interface FIRIAMMessageDefinition : NSObject
 @property(nonatomic, nonnull, readonly) FIRIAMMessageRenderData *renderData;
@@ -52,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// Additional key-value pairs that can be optionally sent along with the FIAM
 @property(nonatomic, nullable, readonly) NSDictionary *appData;
 
-@property(nonatomic, nullable, copy) NSDictionary *experimentalPayload;
+@property(nonatomic, nullable, readonly) ABTExperimentPayload *experimentPayload;
 
 - (instancetype)init NS_UNAVAILABLE;
 
@@ -63,8 +52,8 @@ NS_ASSUME_NONNULL_BEGIN
                          startTime:(NSTimeInterval)startTime
                            endTime:(NSTimeInterval)endTime
                  triggerDefinition:(NSArray<FIRIAMDisplayTriggerDefinition *> *)renderTriggers
-                           appData:appData
-               experimentalPayload:(nullable FIRIAMExperimentalPayload *)experimentalPayload
+                           appData:(nullable NSDictionary *)appData
+                 experimentPayload:(nullable ABTExperimentPayload *)experimentPayload
                      isTestMessage:(BOOL)isTestMessage NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)initWithRenderData:(FIRIAMMessageRenderData *)renderData

--- a/FirebaseInAppMessaging/Sources/Public/FIRInAppMessagingRendering.h
+++ b/FirebaseInAppMessaging/Sources/Public/FIRInAppMessagingRendering.h
@@ -107,11 +107,6 @@ NS_SWIFT_NAME(InAppMessagingCampaignInfo)
 @property(nonatomic, nonnull, copy, readonly) NSString *campaignName;
 
 /**
- * Optional experiment metadata for this message.
- */
-@property(nonatomic, nullable, copy, readonly) ABTExperimentPayload *experimentPayload;
-
-/**
  * Whether or not this message is being rendered in Test On Device mode.
  */
 @property(nonatomic, readonly) BOOL renderAsTestMessage;

--- a/FirebaseInAppMessaging/Sources/Public/FIRInAppMessagingRendering.h
+++ b/FirebaseInAppMessaging/Sources/Public/FIRInAppMessagingRendering.h
@@ -119,6 +119,11 @@ NS_SWIFT_NAME(InAppMessagingCampaignInfo)
 /// Unavailable.
 - (instancetype)init NS_UNAVAILABLE;
 
+/// Deprecated, this class shouldn't be directly instantiated.
+- (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage __deprecated;
+
 @end
 
 /** Defines the metadata for a FIAM action.
@@ -173,6 +178,13 @@ NS_SWIFT_NAME(InAppMessagingDisplayMessage)
 
 /// Unavailable.
 - (instancetype)init NS_UNAVAILABLE;
+
+/// Deprecated, this class shouldn't be directly instantiated.
+- (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage
+                      messageType:(FIRInAppMessagingDisplayMessageType)messageType
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType __deprecated;
 
 @end
 
@@ -277,6 +289,18 @@ NS_SWIFT_NAME(InAppMessagingModalDisplay)
 /// Unavailable.
 - (instancetype)init NS_UNAVAILABLE;
 
+/// Deprecated, this class shouldn't be directly instantiated.
+- (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
+                        titleText:(NSString *)title
+                         bodyText:(NSString *)bodyText
+                        textColor:(UIColor *)textColor
+                  backgroundColor:(UIColor *)backgroundColor
+                        imageData:(nullable FIRInAppMessagingImageData *)imageData
+                     actionButton:(nullable FIRInAppMessagingActionButton *)actionButton
+                        actionURL:(nullable NSURL *)actionURL __deprecated;
 @end
 
 /** Class for defining a banner message for display.
@@ -317,6 +341,17 @@ NS_SWIFT_NAME(InAppMessagingBannerDisplay)
 /// Unavailable.
 - (instancetype)init NS_UNAVAILABLE;
 
+/// Deprecated, this class shouldn't be directly instantiated.
+- (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
+                        titleText:(NSString *)title
+                         bodyText:(NSString *)bodyText
+                        textColor:(UIColor *)textColor
+                  backgroundColor:(UIColor *)backgroundColor
+                        imageData:(nullable FIRInAppMessagingImageData *)imageData
+                        actionURL:(nullable NSURL *)actionURL __deprecated;
 @end
 
 /** Class for defining a image-only message for display.
@@ -336,6 +371,14 @@ NS_SWIFT_NAME(InAppMessagingImageOnlyDisplay)
 
 /// Unavailable.
 - (instancetype)init NS_UNAVAILABLE;
+
+/// Deprecated, this class shouldn't be directly instantiated.
+- (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
+                        imageData:(nullable FIRInAppMessagingImageData *)imageData
+                        actionURL:(nullable NSURL *)actionURL __deprecated;
 
 @end
 

--- a/FirebaseInAppMessaging/Sources/Public/FIRInAppMessagingRendering.h
+++ b/FirebaseInAppMessaging/Sources/Public/FIRInAppMessagingRendering.h
@@ -16,6 +16,8 @@
 
 #import <UIKit/UIKit.h>
 
+@class ABTExperimentPayload;
+
 NS_ASSUME_NONNULL_BEGIN
 
 /// The type and UI style of an in-app message.
@@ -105,17 +107,17 @@ NS_SWIFT_NAME(InAppMessagingCampaignInfo)
 @property(nonatomic, nonnull, copy, readonly) NSString *campaignName;
 
 /**
+ * Optional experiment metadata for this message.
+ */
+@property(nonatomic, nullable, copy, readonly) ABTExperimentPayload *experimentPayload;
+
+/**
  * Whether or not this message is being rendered in Test On Device mode.
  */
 @property(nonatomic, readonly) BOOL renderAsTestMessage;
 
 /// Unavailable.
 - (instancetype)init NS_UNAVAILABLE;
-
-/// Deprecated, this class shouldn't be directly instantiated.
-- (instancetype)initWithMessageID:(NSString *)messageID
-                     campaignName:(NSString *)campaignName
-              renderAsTestMessage:(BOOL)renderAsTestMessage __deprecated;
 
 @end
 
@@ -172,12 +174,6 @@ NS_SWIFT_NAME(InAppMessagingDisplayMessage)
 /// Unavailable.
 - (instancetype)init NS_UNAVAILABLE;
 
-/// Deprecated, this class shouldn't be directly instantiated.
-- (instancetype)initWithMessageID:(NSString *)messageID
-                     campaignName:(NSString *)campaignName
-              renderAsTestMessage:(BOOL)renderAsTestMessage
-                      messageType:(FIRInAppMessagingDisplayMessageType)messageType
-                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType __deprecated;
 @end
 
 NS_SWIFT_NAME(InAppMessagingCardDisplay)
@@ -281,18 +277,6 @@ NS_SWIFT_NAME(InAppMessagingModalDisplay)
 /// Unavailable.
 - (instancetype)init NS_UNAVAILABLE;
 
-/// Deprecated, this class shouldn't be directly instantiated.
-- (instancetype)initWithMessageID:(NSString *)messageID
-                     campaignName:(NSString *)campaignName
-              renderAsTestMessage:(BOOL)renderAsTestMessage
-                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
-                        titleText:(NSString *)title
-                         bodyText:(NSString *)bodyText
-                        textColor:(UIColor *)textColor
-                  backgroundColor:(UIColor *)backgroundColor
-                        imageData:(nullable FIRInAppMessagingImageData *)imageData
-                     actionButton:(nullable FIRInAppMessagingActionButton *)actionButton
-                        actionURL:(nullable NSURL *)actionURL __deprecated;
 @end
 
 /** Class for defining a banner message for display.
@@ -333,17 +317,6 @@ NS_SWIFT_NAME(InAppMessagingBannerDisplay)
 /// Unavailable.
 - (instancetype)init NS_UNAVAILABLE;
 
-/// Deprecated, this class shouldn't be directly instantiated.
-- (instancetype)initWithMessageID:(NSString *)messageID
-                     campaignName:(NSString *)campaignName
-              renderAsTestMessage:(BOOL)renderAsTestMessage
-                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
-                        titleText:(NSString *)title
-                         bodyText:(NSString *)bodyText
-                        textColor:(UIColor *)textColor
-                  backgroundColor:(UIColor *)backgroundColor
-                        imageData:(nullable FIRInAppMessagingImageData *)imageData
-                        actionURL:(nullable NSURL *)actionURL __deprecated;
 @end
 
 /** Class for defining a image-only message for display.
@@ -364,13 +337,6 @@ NS_SWIFT_NAME(InAppMessagingImageOnlyDisplay)
 /// Unavailable.
 - (instancetype)init NS_UNAVAILABLE;
 
-/// Deprecated, this class shouldn't be directly instantiated.
-- (instancetype)initWithMessageID:(NSString *)messageID
-                     campaignName:(NSString *)campaignName
-              renderAsTestMessage:(BOOL)renderAsTestMessage
-                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
-                        imageData:(nullable FIRInAppMessagingImageData *)imageData
-                        actionURL:(nullable NSURL *)actionURL __deprecated;
 @end
 
 /// The way that an in-app message was dismissed.

--- a/FirebaseInAppMessaging/Sources/Public/FIRInAppMessagingRendering.h
+++ b/FirebaseInAppMessaging/Sources/Public/FIRInAppMessagingRendering.h
@@ -16,8 +16,6 @@
 
 #import <UIKit/UIKit.h>
 
-@class ABTExperimentPayload;
-
 NS_ASSUME_NONNULL_BEGIN
 
 /// The type and UI style of an in-app message.

--- a/FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingDataClasses.m
+++ b/FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingDataClasses.m
@@ -17,11 +17,13 @@
 #import <Foundation/Foundation.h>
 
 #import "FIRInAppMessagingRendering.h"
+#import "FIRInAppMessagingRenderingPrivate.h"
 
 @implementation FIRInAppMessagingDisplayMessage
 
 - (instancetype)initWithMessageID:(NSString *)messageID
                      campaignName:(NSString *)campaignName
+                experimentPayload:(nullable ABTExperimentPayload *)experimentPayload
               renderAsTestMessage:(BOOL)renderAsTestMessage
                       messageType:(FIRInAppMessagingDisplayMessageType)messageType
                       triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
@@ -31,27 +33,12 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     _campaignInfo = [[FIRInAppMessagingCampaignInfo alloc] initWithMessageID:messageID
                                                                 campaignName:campaignName
+                                                           experimentPayload:experimentPayload
                                                          renderAsTestMessage:renderAsTestMessage];
 #pragma clang diagnostic pop
     _type = messageType;
     _triggerType = triggerType;
     _appData = [appData copy];
-  }
-  return self;
-}
-
-- (instancetype)initWithMessageID:(NSString *)messageID
-                     campaignName:(NSString *)campaignName
-              renderAsTestMessage:(BOOL)renderAsTestMessage
-                      messageType:(FIRInAppMessagingDisplayMessageType)messageType
-                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType {
-  if (self = [super init]) {
-    _campaignInfo = [[FIRInAppMessagingCampaignInfo alloc] initWithMessageID:messageID
-                                                                campaignName:campaignName
-                                                         renderAsTestMessage:renderAsTestMessage];
-    _type = messageType;
-    _triggerType = triggerType;
-    _appData = nil;
   }
   return self;
 }
@@ -78,6 +65,7 @@
 
 - (instancetype)initWithMessageID:(NSString *)messageID
                      campaignName:(NSString *)campaignName
+                experimentPayload:(nullable ABTExperimentPayload *)experimentPayload
               renderAsTestMessage:(BOOL)renderAsTestMessage
                       triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
                         titleText:(NSString *)title
@@ -91,39 +79,11 @@
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   if (self = [super initWithMessageID:messageID
                          campaignName:campaignName
+                    experimentPayload:experimentPayload
                   renderAsTestMessage:renderAsTestMessage
                           messageType:FIRInAppMessagingDisplayMessageTypeCard
                           triggerType:triggerType
                               appData:appData]) {
-#pragma clang diagnostic pop
-    _title = title;
-    _textColor = textColor;
-    _portraitImageData = portraitImageData;
-    _displayBackgroundColor = backgroundColor;
-    _primaryActionButton = primaryActionButton;
-    _primaryActionURL = primaryActionURL;
-  }
-  return self;
-}
-
-- (instancetype)initWithMessageID:(NSString *)messageID
-                     campaignName:(NSString *)campaignName
-              renderAsTestMessage:(BOOL)renderAsTestMessage
-                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
-                        titleText:(NSString *)title
-                        textColor:(UIColor *)textColor
-                portraitImageData:(FIRInAppMessagingImageData *)portraitImageData
-                  backgroundColor:(UIColor *)backgroundColor
-              primaryActionButton:(FIRInAppMessagingActionButton *)primaryActionButton
-                 primaryActionURL:(NSURL *)primaryActionURL {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  if (self = [super initWithMessageID:messageID
-                         campaignName:campaignName
-                  renderAsTestMessage:renderAsTestMessage
-                          messageType:FIRInAppMessagingDisplayMessageTypeCard
-                          triggerType:triggerType
-                              appData:nil]) {
 #pragma clang diagnostic pop
     _title = title;
     _textColor = textColor;
@@ -140,6 +100,7 @@
 @implementation FIRInAppMessagingBannerDisplay
 - (instancetype)initWithMessageID:(NSString *)messageID
                      campaignName:(NSString *)campaignName
+                experimentPayload:(nullable ABTExperimentPayload *)experimentPayload
               renderAsTestMessage:(BOOL)renderAsTestMessage
                       triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
                         titleText:(NSString *)title
@@ -151,36 +112,11 @@
                           appData:(NSDictionary *)appData {
   if (self = [super initWithMessageID:messageID
                          campaignName:campaignName
+                    experimentPayload:experimentPayload
                   renderAsTestMessage:renderAsTestMessage
                           messageType:FIRInAppMessagingDisplayMessageTypeBanner
                           triggerType:triggerType
                               appData:appData]) {
-    _title = title;
-    _bodyText = bodyText;
-    _textColor = textColor;
-    _displayBackgroundColor = backgroundColor;
-    _imageData = imageData;
-    _actionURL = actionURL;
-  }
-  return self;
-}
-
-- (instancetype)initWithMessageID:(NSString *)messageID
-                     campaignName:(NSString *)campaignName
-              renderAsTestMessage:(BOOL)renderAsTestMessage
-                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
-                        titleText:(NSString *)title
-                         bodyText:(NSString *)bodyText
-                        textColor:(UIColor *)textColor
-                  backgroundColor:(UIColor *)backgroundColor
-                        imageData:(nullable FIRInAppMessagingImageData *)imageData
-                        actionURL:(nullable NSURL *)actionURL {
-  if (self = [super initWithMessageID:messageID
-                         campaignName:campaignName
-                  renderAsTestMessage:renderAsTestMessage
-                          messageType:FIRInAppMessagingDisplayMessageTypeBanner
-                          triggerType:triggerType
-                              appData:nil]) {
     _title = title;
     _bodyText = bodyText;
     _textColor = textColor;
@@ -197,6 +133,7 @@
 
 - (instancetype)initWithMessageID:(NSString *)messageID
                      campaignName:(NSString *)campaignName
+                experimentPayload:(nullable ABTExperimentPayload *)experimentPayload
               renderAsTestMessage:(BOOL)renderAsTestMessage
                       triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
                         titleText:(NSString *)title
@@ -209,6 +146,7 @@
                           appData:(nullable NSDictionary *)appData {
   if (self = [super initWithMessageID:messageID
                          campaignName:campaignName
+                    experimentPayload:experimentPayload
                   renderAsTestMessage:renderAsTestMessage
                           messageType:FIRInAppMessagingDisplayMessageTypeModal
                           triggerType:triggerType
@@ -224,39 +162,13 @@
   return self;
 }
 
-- (instancetype)initWithMessageID:(NSString *)messageID
-                     campaignName:(NSString *)campaignName
-              renderAsTestMessage:(BOOL)renderAsTestMessage
-                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
-                        titleText:(NSString *)title
-                         bodyText:(NSString *)bodyText
-                        textColor:(UIColor *)textColor
-                  backgroundColor:(UIColor *)backgroundColor
-                        imageData:(nullable FIRInAppMessagingImageData *)imageData
-                     actionButton:(nullable FIRInAppMessagingActionButton *)actionButton
-                        actionURL:(nullable NSURL *)actionURL {
-  if (self = [super initWithMessageID:messageID
-                         campaignName:campaignName
-                  renderAsTestMessage:renderAsTestMessage
-                          messageType:FIRInAppMessagingDisplayMessageTypeModal
-                          triggerType:triggerType
-                              appData:nil]) {
-    _title = title;
-    _bodyText = bodyText;
-    _textColor = textColor;
-    _displayBackgroundColor = backgroundColor;
-    _imageData = imageData;
-    _actionButton = actionButton;
-    _actionURL = actionURL;
-  }
-  return self;
-}
 @end
 
 @implementation FIRInAppMessagingImageOnlyDisplay
 
 - (instancetype)initWithMessageID:(NSString *)messageID
                      campaignName:(NSString *)campaignName
+                experimentPayload:(nullable ABTExperimentPayload *)experimentPayload
               renderAsTestMessage:(BOOL)renderAsTestMessage
                       triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
                         imageData:(nullable FIRInAppMessagingImageData *)imageData
@@ -264,6 +176,7 @@
                           appData:(nullable NSDictionary *)appData {
   if (self = [super initWithMessageID:messageID
                          campaignName:campaignName
+                    experimentPayload:experimentPayload
                   renderAsTestMessage:renderAsTestMessage
                           messageType:FIRInAppMessagingDisplayMessageTypeModal
                           triggerType:triggerType
@@ -274,23 +187,6 @@
   return self;
 }
 
-- (instancetype)initWithMessageID:(NSString *)messageID
-                     campaignName:(NSString *)campaignName
-              renderAsTestMessage:(BOOL)renderAsTestMessage
-                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
-                        imageData:(nullable FIRInAppMessagingImageData *)imageData
-                        actionURL:(nullable NSURL *)actionURL {
-  if (self = [super initWithMessageID:messageID
-                         campaignName:campaignName
-                  renderAsTestMessage:renderAsTestMessage
-                          messageType:FIRInAppMessagingDisplayMessageTypeModal
-                          triggerType:triggerType
-                              appData:nil]) {
-    _imageData = imageData;
-    _actionURL = actionURL;
-  }
-  return self;
-}
 @end
 
 @implementation FIRInAppMessagingActionButton
@@ -329,10 +225,12 @@
 @implementation FIRInAppMessagingCampaignInfo
 - (instancetype)initWithMessageID:(NSString *)messageID
                      campaignName:(NSString *)campaignName
+                experimentPayload:(nullable ABTExperimentPayload *)experimentPayload
               renderAsTestMessage:(BOOL)renderAsTestMessage {
   if (self = [super init]) {
     _messageID = messageID;
     _campaignName = campaignName;
+    _experimentPayload = experimentPayload;
     _renderAsTestMessage = renderAsTestMessage;
   }
   return self;

--- a/FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingDataClasses.m
+++ b/FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingDataClasses.m
@@ -43,6 +43,20 @@
   return self;
 }
 
+- (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage
+                      messageType:(FIRInAppMessagingDisplayMessageType)messageType
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType {
+  return [self initWithMessageID:messageID
+                    campaignName:campaignName
+               experimentPayload:nil
+             renderAsTestMessage:renderAsTestMessage
+                     messageType:messageType
+                     triggerType:triggerType
+                         appData:nil];
+}
+
 @end
 
 @implementation FIRInAppMessagingCardDisplay
@@ -95,6 +109,30 @@
   return self;
 }
 
+- (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
+                        titleText:(NSString *)title
+                        textColor:(UIColor *)textColor
+                portraitImageData:(FIRInAppMessagingImageData *)portraitImageData
+                  backgroundColor:(UIColor *)backgroundColor
+              primaryActionButton:(FIRInAppMessagingActionButton *)primaryActionButton
+                 primaryActionURL:(NSURL *)primaryActionURL {
+  return [self initWithMessageID:messageID
+                    campaignName:campaignName
+               experimentPayload:nil
+             renderAsTestMessage:renderAsTestMessage
+                     triggerType:triggerType
+                       titleText:title
+                       textColor:textColor
+               portraitImageData:portraitImageData
+                 backgroundColor:backgroundColor
+             primaryActionButton:primaryActionButton
+                primaryActionURL:primaryActionURL
+                         appData:nil];
+}
+
 @end
 
 @implementation FIRInAppMessagingBannerDisplay
@@ -125,6 +163,30 @@
     _actionURL = actionURL;
   }
   return self;
+}
+
+- (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
+                        titleText:(NSString *)title
+                         bodyText:(NSString *)bodyText
+                        textColor:(UIColor *)textColor
+                  backgroundColor:(UIColor *)backgroundColor
+                        imageData:(nullable FIRInAppMessagingImageData *)imageData
+                        actionURL:(nullable NSURL *)actionURL {
+  return [self initWithMessageID:messageID
+                    campaignName:campaignName
+               experimentPayload:nil
+             renderAsTestMessage:renderAsTestMessage
+                     triggerType:triggerType
+                       titleText:title
+                        bodyText:bodyText
+                       textColor:textColor
+                 backgroundColor:backgroundColor
+                       imageData:imageData
+                       actionURL:actionURL
+                         appData:nil];
 }
 
 @end
@@ -162,6 +224,32 @@
   return self;
 }
 
+- (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
+                        titleText:(NSString *)title
+                         bodyText:(NSString *)bodyText
+                        textColor:(UIColor *)textColor
+                  backgroundColor:(UIColor *)backgroundColor
+                        imageData:(nullable FIRInAppMessagingImageData *)imageData
+                     actionButton:(nullable FIRInAppMessagingActionButton *)actionButton
+                        actionURL:(nullable NSURL *)actionURL {
+  return [self initWithMessageID:messageID
+                    campaignName:campaignName
+               experimentPayload:nil
+             renderAsTestMessage:renderAsTestMessage
+                     triggerType:triggerType
+                       titleText:title
+                        bodyText:bodyText
+                       textColor:textColor
+                 backgroundColor:backgroundColor
+                       imageData:imageData
+                    actionButton:actionButton
+                       actionURL:actionURL
+                         appData:nil];
+}
+
 @end
 
 @implementation FIRInAppMessagingImageOnlyDisplay
@@ -185,6 +273,22 @@
     _actionURL = actionURL;
   }
   return self;
+}
+
+- (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage
+                      triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
+                        imageData:(nullable FIRInAppMessagingImageData *)imageData
+                        actionURL:(nullable NSURL *)actionURL {
+  return [self initWithMessageID:messageID
+                    campaignName:campaignName
+               experimentPayload:nil
+             renderAsTestMessage:renderAsTestMessage
+                     triggerType:triggerType
+                       imageData:imageData
+                       actionURL:actionURL
+                         appData:nil];
 }
 
 @end
@@ -234,6 +338,15 @@
     _renderAsTestMessage = renderAsTestMessage;
   }
   return self;
+}
+
+- (instancetype)initWithMessageID:(NSString *)messageID
+                     campaignName:(NSString *)campaignName
+              renderAsTestMessage:(BOOL)renderAsTestMessage {
+  return [self initWithMessageID:messageID
+                    campaignName:campaignName
+               experimentPayload:nil
+             renderAsTestMessage:renderAsTestMessage];
 }
 @end
 

--- a/FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingDataClasses.m
+++ b/FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingDataClasses.m
@@ -326,6 +326,15 @@
 
 @end
 
+@interface FIRInAppMessagingCampaignInfo()
+
+/**
+ * Optional experiment metadata for this message.
+ */
+@property(nonatomic, nullable, copy, readonly) ABTExperimentPayload *experimentPayload;
+
+@end
+
 @implementation FIRInAppMessagingCampaignInfo
 - (instancetype)initWithMessageID:(NSString *)messageID
                      campaignName:(NSString *)campaignName

--- a/FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingDataClasses.m
+++ b/FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingDataClasses.m
@@ -326,7 +326,7 @@
 
 @end
 
-@interface FIRInAppMessagingCampaignInfo()
+@interface FIRInAppMessagingCampaignInfo ()
 
 /**
  * Optional experiment metadata for this message.

--- a/FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingPrivate.h
+++ b/FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingPrivate.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@class ABTExperimentPayload;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface FIRInAppMessagingCardDisplay (Private)

--- a/FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingPrivate.h
+++ b/FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingPrivate.h
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithMessageID:(NSString *)messageID
                      campaignName:(NSString *)campaignName
+                experimentPayload:(nullable ABTExperimentPayload *)experimentPayload
               renderAsTestMessage:(BOOL)renderAsTestMessage
                       triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
                         titleText:(NSString *)title
@@ -33,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
                   backgroundColor:(UIColor *)backgroundColor
               primaryActionButton:(FIRInAppMessagingActionButton *)primaryActionButton
                  primaryActionURL:(nullable NSURL *)primaryActionURL
-                          appData:(NSDictionary *)appData;
+                          appData:(nullable NSDictionary *)appData;
 
 @end
 
@@ -55,6 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithMessageID:(NSString *)messageID
                      campaignName:(NSString *)campaignName
+                experimentPayload:(nullable ABTExperimentPayload *)experimentPayload
               renderAsTestMessage:(BOOL)renderAsTestMessage;
 
 @end
@@ -69,10 +71,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithMessageID:(NSString *)messageID
                      campaignName:(NSString *)campaignName
+                experimentPayload:(nullable ABTExperimentPayload *)experimentPayload
               renderAsTestMessage:(BOOL)renderAsTestMessage
                       messageType:(FIRInAppMessagingDisplayMessageType)messageType
                       triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
-                          appData:(NSDictionary *)appData;
+                          appData:(nullable NSDictionary *)appData;
 
 @end
 
@@ -80,6 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithMessageID:(NSString *)messageID
                      campaignName:(NSString *)campaignName
+                experimentPayload:(nullable ABTExperimentPayload *)experimentPayload
               renderAsTestMessage:(BOOL)renderAsTestMessage
                       triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
                         titleText:(NSString *)title
@@ -89,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
                         imageData:(nullable FIRInAppMessagingImageData *)imageData
                      actionButton:(nullable FIRInAppMessagingActionButton *)actionButton
                         actionURL:(nullable NSURL *)actionURL
-                          appData:(NSDictionary *)appData;
+                          appData:(nullable NSDictionary *)appData;
 
 @end
 
@@ -97,6 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithMessageID:(NSString *)messageID
                      campaignName:(NSString *)campaignName
+                experimentPayload:(nullable ABTExperimentPayload *)experimentPayload
               renderAsTestMessage:(BOOL)renderAsTestMessage
                       triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
                         titleText:(NSString *)title
@@ -105,7 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
                   backgroundColor:(UIColor *)backgroundColor
                         imageData:(nullable FIRInAppMessagingImageData *)imageData
                         actionURL:(nullable NSURL *)actionURL
-                          appData:(NSDictionary *)appData;
+                          appData:(nullable NSDictionary *)appData;
 
 @end
 
@@ -113,11 +118,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithMessageID:(NSString *)messageID
                      campaignName:(NSString *)campaignName
+                experimentPayload:(nullable ABTExperimentPayload *)experimentPayload
               renderAsTestMessage:(BOOL)renderAsTestMessage
                       triggerType:(FIRInAppMessagingDisplayTriggerType)triggerType
                         imageData:(nullable FIRInAppMessagingImageData *)imageData
                         actionURL:(nullable NSURL *)actionURL
-                          appData:(NSDictionary *)appData;
+                          appData:(nullable NSDictionary *)appData;
 
 @end
 

--- a/FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingPrivate.h
+++ b/FirebaseInAppMessaging/Sources/RenderingObjects/FIRInAppMessagingRenderingPrivate.h
@@ -54,6 +54,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FIRInAppMessagingCampaignInfo (Private)
 
+- (nullable ABTExperimentPayload *)experimentPayload;
+
 - (instancetype)initWithMessageID:(NSString *)messageID
                      campaignName:(NSString *)campaignName
                 experimentPayload:(nullable ABTExperimentPayload *)experimentPayload

--- a/FirebaseInAppMessaging/Tests/Integration/DefaultUITestApp/Podfile
+++ b/FirebaseInAppMessaging/Tests/Integration/DefaultUITestApp/Podfile
@@ -9,6 +9,7 @@ pod 'FirebaseCoreDiagnosticsInterop', :path => '../../../..'
 pod 'GoogleDataTransport', :path => '../../../..'
 pod 'GoogleDataTransportCCTSupport', :path => '../../../..'
 pod 'GoogleUtilities', :path => '../../../..'
+pod 'FirebaseABTesting', :path => '../../../..'
 
 target 'FiamDisplaySwiftExample' do
   platform :ios, '9.0'

--- a/FirebaseInAppMessaging/Tests/Integration/FunctionalTestApp/Podfile
+++ b/FirebaseInAppMessaging/Tests/Integration/FunctionalTestApp/Podfile
@@ -11,6 +11,7 @@ pod 'FirebaseCoreDiagnosticsInterop', :path => '../../../..'
 pod 'GoogleDataTransport', :path => '../../../..'
 pod 'GoogleDataTransportCCTSupport', :path => '../../../..'
 pod 'GoogleUtilities', :path => '../../../..'
+pod 'FirebaseABTesting', :path => '../../../..'
 
 target 'InAppMessaging_Example_iOS' do
   platform :ios, '9.0'

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMDisplayExecutorTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMDisplayExecutorTests.m
@@ -329,7 +329,7 @@ typedef NS_ENUM(NSInteger, FIRInAppMessagingDelegateInteraction) {
   experimentPayload.timeToLiveMillis = 15552000000;
   experimentPayload.triggerTimeoutMillis = 15552000000;
   experimentPayload.variantId = @"1";
-  
+
   self.m4 = [[FIRIAMMessageDefinition alloc] initWithRenderData:renderData4
                                                       startTime:activeStartTime
                                                         endTime:activeEndTime

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMDisplayExecutorTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMDisplayExecutorTests.m
@@ -22,6 +22,7 @@
 #import "FIRIAMDisplayTriggerDefinition.h"
 #import "FIRIAMMessageContentData.h"
 #import "FIRInAppMessaging.h"
+#import "FIRInAppMessagingRenderingPrivate.h"
 
 // A class implementing protocol FIRIAMMessageContentData to be used for unit testing
 @interface FIRIAMMessageContentDataForTesting : NSObject <FIRIAMMessageContentData>

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMDisplayExecutorTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMDisplayExecutorTests.m
@@ -204,7 +204,7 @@ typedef NS_ENUM(NSInteger, FIRInAppMessagingDelegateInteraction) {
 
 @property id<FIRInAppMessagingDisplay> mockMessageDisplayComponent;
 
-// three pre-defined messages
+// four pre-defined messages
 @property FIRIAMMessageDefinition *m1, *m2, *m3, *m4;
 @end
 
@@ -322,12 +322,20 @@ typedef NS_ENUM(NSInteger, FIRInAppMessagingDelegateInteraction) {
                                              contentData:m4ContentData
                                          renderingEffect:renderSetting4];
 
+  ABTExperimentPayload *experimentPayload = [ABTExperimentPayload message];
+  experimentPayload.experimentId = @"_exp_1";
+  experimentPayload.experimentStartTimeMillis = 1582143484729;
+  experimentPayload.overflowPolicy = ABTExperimentPayload_ExperimentOverflowPolicy_DiscardOldest;
+  experimentPayload.timeToLiveMillis = 15552000000;
+  experimentPayload.triggerTimeoutMillis = 15552000000;
+  experimentPayload.variantId = @"1";
+  
   self.m4 = [[FIRIAMMessageDefinition alloc] initWithRenderData:renderData4
                                                       startTime:activeStartTime
                                                         endTime:activeEndTime
                                               triggerDefinition:@[ appOpentriggerDefinition ]
                                                         appData:@{@"a" : @"b", @"up" : @"dog"}
-                                              experimentPayload:nil
+                                              experimentPayload:experimentPayload
                                                   isTestMessage:NO];
 }
 
@@ -945,5 +953,14 @@ NSTimeInterval DISPLAY_MIN_INTERVALS = 1;
                        landscapeImageData:nil
                               triggerType:FIRInAppMessagingDisplayTriggerTypeOnAppForeground];
   XCTAssertNil(displayMessage.appData);
+}
+
+- (void)testMessageWithExperimentPayload {
+  FIRInAppMessagingDisplayMessage *displayMessage = [self.displayExecutor
+      displayMessageWithMessageDefinition:self.m4
+                                imageData:nil
+                       landscapeImageData:nil
+                              triggerType:FIRInAppMessagingDisplayTriggerTypeOnAppForeground];
+  XCTAssertNotNil(displayMessage.campaignInfo.experimentPayload);
 }
 @end

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMDisplayExecutorTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMDisplayExecutorTests.m
@@ -327,6 +327,7 @@ typedef NS_ENUM(NSInteger, FIRInAppMessagingDelegateInteraction) {
                                                         endTime:activeEndTime
                                               triggerDefinition:@[ appOpentriggerDefinition ]
                                                         appData:@{@"a" : @"b", @"up" : @"dog"}
+                                              experimentPayload:nil
                                                   isTestMessage:NO];
 }
 
@@ -411,7 +412,8 @@ NSTimeInterval DISPLAY_MIN_INTERVALS = 1;
       .andReturn(DISPLAY_MIN_INTERVALS * 60 + 100);
 
   FIRIAMMessageDefinition *testMessage =
-      [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m1.renderData];
+      [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m1.renderData
+                                                   experimentPayload:nil];
 
   FIRInAppMessagingAction *testAction = [[FIRInAppMessagingAction alloc]
       initWithActionText:@"test"
@@ -439,7 +441,8 @@ NSTimeInterval DISPLAY_MIN_INTERVALS = 1;
   // minimal display time interval yet.
   OCMStub([self.mockTimeFetcher currentTimestampInSeconds]).andReturn(10);
   FIRIAMMessageDefinition *testMessage =
-      [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m1.renderData];
+      [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m1.renderData
+                                                   experimentPayload:nil];
 
   [self.clientMessageCache setMessageData:@[ self.m2, testMessage, self.m4 ]];
 
@@ -617,7 +620,8 @@ NSTimeInterval DISPLAY_MIN_INTERVALS = 1;
                     completion:[OCMArg any]]);
 
   FIRIAMMessageDefinition *testMessage =
-      [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m2.renderData];
+      [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m2.renderData
+                                                   experimentPayload:nil];
 
   [self.clientMessageCache setMessageData:@[ testMessage ]];
 
@@ -650,7 +654,8 @@ NSTimeInterval DISPLAY_MIN_INTERVALS = 1;
                     completion:[OCMArg any]]);
 
   FIRIAMMessageDefinition *testMessage =
-      [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m2.renderData];
+      [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m2.renderData
+                                                   experimentPayload:nil];
 
   [self.clientMessageCache setMessageData:@[ testMessage ]];
 
@@ -691,7 +696,8 @@ NSTimeInterval DISPLAY_MIN_INTERVALS = 1;
       .andReturn(DISPLAY_MIN_INTERVALS * 60 + 100);
 
   FIRIAMMessageDefinition *testMessage =
-      [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m1.renderData];
+      [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m1.renderData
+                                                   experimentPayload:nil];
 
   // not expecting triggering analytics recording
   OCMReject([self.mockAnalyticsEventLogger

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMFetchFlowTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMFetchFlowTests.m
@@ -313,7 +313,8 @@ CGFloat FETCH_MIN_INTERVALS = 1;
   OCMStub([self.mockSDKModeManager currentMode]).andReturn(FIRIAMSDKModeNewlyInstalled);
 
   FIRIAMMessageDefinition *testMessage =
-      [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m2.renderData];
+      [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m2.renderData
+                                                   experimentPayload:nil];
 
   OCMStub([self.mockMessageFetcher
       fetchMessagesWithImpressionList:[OCMArg any]
@@ -335,7 +336,8 @@ CGFloat FETCH_MIN_INTERVALS = 1;
   OCMStub([self.mockSDKModeManager currentMode]).andReturn(FIRIAMSDKModeTesting);
 
   FIRIAMMessageDefinition *testMessage =
-      [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m2.renderData];
+      [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:self.m2.renderData
+                                                   experimentPayload:nil];
 
   OCMStub([self.mockMessageFetcher
       fetchMessagesWithImpressionList:[OCMArg any]

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMFetchResponseParserTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMFetchResponseParserTests.m
@@ -72,7 +72,7 @@
   XCTAssertEqualWithAccuracy([fetchWaitTime doubleValue],
                              nextFetchEpochTimeInResponse / 1000 - currentMoment, 0.1);
 
-  XCTAssertEqual(5, [results count]);
+  XCTAssertEqual(6, [results count]);
   XCTAssertEqual(0, discardCount);
 
   FIRIAMMessageDefinition *first = results[0];
@@ -135,6 +135,22 @@
                         fifth.renderData.contentData.secondaryActionURL.absoluteString);
   XCTAssertEqualObjects(@"Win Super Bowl LV",
                         fifth.renderData.contentData.secondaryActionButtonText);
+
+  FIRIAMMessageDefinition *sixth = results[5];
+  XCTAssertEqualObjects(@"687787988989", sixth.renderData.messageID);
+  XCTAssertEqualObjects(@"Super Bowl LV", sixth.renderData.name);
+  XCTAssertEqualObjects(@"Eagles are going to win", sixth.renderData.contentData.titleText);
+  XCTAssertNil(sixth.renderData.contentData.bodyText);
+  XCTAssertNil(sixth.appData);
+  XCTAssertEqualObjects(sixth.experimentPayload.experimentId, @"_exp_1");
+  XCTAssertEqual(sixth.experimentPayload.experimentStartTimeMillis, 1582143484729);
+  XCTAssertEqual(sixth.experimentPayload.timeToLiveMillis, 15552000000);
+  XCTAssertEqual(sixth.experimentPayload.triggerTimeoutMillis, 15552000000);
+  XCTAssertEqualObjects(sixth.experimentPayload.variantId, @"1");
+  XCTAssertEqual(sixth.experimentPayload.overflowPolicy,
+                 ABTExperimentPayload_ExperimentOverflowPolicy_DiscardOldest);
+  XCTAssertEqual(FIRIAMRenderAsModalView, sixth.renderData.renderingEffectSettings.viewMode);
+  XCTAssertEqual(1, sixth.renderTriggers.count);
 }
 
 - (void)testParsingTestMessage {

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMFetchResponseParserTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMFetchResponseParserTests.m
@@ -142,13 +142,7 @@
   XCTAssertEqualObjects(@"Eagles are going to win", sixth.renderData.contentData.titleText);
   XCTAssertNil(sixth.renderData.contentData.bodyText);
   XCTAssertNil(sixth.appData);
-  XCTAssertEqualObjects(sixth.experimentPayload.experimentId, @"_exp_1");
-  XCTAssertEqual(sixth.experimentPayload.experimentStartTimeMillis, 1582143484729);
-  XCTAssertEqual(sixth.experimentPayload.timeToLiveMillis, 15552000000);
-  XCTAssertEqual(sixth.experimentPayload.triggerTimeoutMillis, 15552000000);
-  XCTAssertEqualObjects(sixth.experimentPayload.variantId, @"1");
-  XCTAssertEqual(sixth.experimentPayload.overflowPolicy,
-                 ABTExperimentPayload_ExperimentOverflowPolicy_DiscardOldest);
+  XCTAssertNotNil(sixth.experimentPayload);
   XCTAssertEqual(FIRIAMRenderAsModalView, sixth.renderData.renderingEffectSettings.viewMode);
   XCTAssertEqual(1, sixth.renderTriggers.count);
 }

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMMessageClientCacheTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMMessageClientCacheTests.m
@@ -369,7 +369,8 @@
   OCMStub([self.mockBookkeeper getImpressions]).andReturn(@[]);
 
   FIRIAMMessageDefinition *testMessage =
-      [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:m2.renderData];
+      [[FIRIAMMessageDefinition alloc] initTestMessageWithRenderData:m2.renderData
+                                                   experimentPayload:nil];
 
   // m1 and m3 are messages rendered on app open
   [self.clientCache setMessageData:@[ m1, m2, testMessage, m3, m4 ]];

--- a/FirebaseInAppMessaging/Tests/Unit/TestJsonDataFromFetch.txt
+++ b/FirebaseInAppMessaging/Tests/Unit/TestJsonDataFromFetch.txt
@@ -218,6 +218,36 @@
           "fiamTrigger": "ON_FOREGROUND"
         }
       ]
+    },
+    {
+      "experimentalPayload": {
+        "campaignId": "687787988989",
+        "campaignStartTimeMillis": "1519934650000",
+        "campaignEndTimeMillis": "9223372036854775807",
+        "campaignName": "Super Bowl LV",
+        "experimentPayload" : {
+          "experimentId": "_exp_1",
+          "experimentStartTimeMillis": "1582143484729",
+          "overflowPolicy": "DISCARD_OLDEST",
+          "timeToLiveMillis": "15552000000",
+          "triggerTimeoutMillis": "15552000000",
+          "variantId": "1"
+        }
+      },
+      "content": {
+        "modal": {
+          "title": {
+            "text": "Eagles are going to win",
+            "hexColor": "#004953"
+          },
+          "backgroundHexColor": "#ffffff"
+        }
+      },
+      "triggeringConditions": [
+        {
+          "fiamTrigger": "ON_FOREGROUND"
+        }
+      ]
     }
   ],
   "expirationEpochTimestampMillis": "1537896430193"


### PR DESCRIPTION
Supports experimental Firebase in-app messages (cross-functional with Firebase AB Testing).

Adds functionality to the ABT SDK:
- A method that cleans up old experiments that are no longer running
- A method that directly activates an experiment

FIAM SDK changes:
- Parses experimental metadata from FIAM backend, attaches the experiment payload to `InAppMessageDisplayMessage`
- On message fetch, cleans up experiments that are no longer running
- On message impression, sets the experiment to be activated
- ~~Removes deprecated initializers for message subclasses (internal bug ID 134409779).~~ Removed this for now, looks like the UI test app uses them