### PR TITLE
Switch watchOS applicationDelegate to WKExtensionDelegate

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -235,7 +235,7 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
     [[self sharedApplicationForBackgroundTask] endBackgroundTask:bgID];
     return;
   }
-#endif
+#endif  // !TARGET_OS_WATCH
 }
 
 #pragma mark - App environment helpers

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -224,7 +224,7 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
 #endif  // !NDEBUG
   return bgID;
 #endif  // !TARGET_OS_WATCH
-  // TODO: WKExtension backgound tasks handling.
+  // TODO: WKExtension background tasks handling.
   return GDTCORBackgroundIdentifierInvalid;
 }
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -194,7 +194,7 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
                            selector:@selector(macOSApplicationWillTerminate:)
                                name:NSApplicationWillTerminateNotification
                              object:nil];
-    
+
 #elif TARGET_OS_WATCH
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
     [notificationCenter addObserver:self
@@ -272,7 +272,8 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
   }
 #elif TARGET_OS_WATCH
   Class wkExtensionClass = NSClassFromString(@"WKExtension");
-  if(wkExtensionClass && [wkExtensionClass respondsToSelector:(NSSelectorFromString(@"sharedExtension"))]) {
+  if (wkExtensionClass &&
+      [wkExtensionClass respondsToSelector:(NSSelectorFromString(@"sharedExtension"))]) {
     sharedApplication = [wkExtensionClass sharedExtension];
   }
 #endif
@@ -281,7 +282,7 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
 
 #pragma mark - UIApplicationDelegate
 
-#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_WATCH
+#if TARGET_OS_IOS || TARGET_OS_TV
 - (void)iOSApplicationDidEnterBackground:(NSNotification *)notif {
   _isRunningInBackground = YES;
 
@@ -297,14 +298,32 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
   GDTCORLogDebug("%@", @"GDTCORPlatform is sending a notif that the app is foregrounding.");
   [notifCenter postNotificationName:kGDTCORApplicationWillEnterForegroundNotification object:nil];
 }
-  
-#elif TARGET_OS_IOS || TARGET_OS_TV
+
 - (void)iOSApplicationWillTerminate:(NSNotification *)notif {
   NSNotificationCenter *notifCenter = [NSNotificationCenter defaultCenter];
   GDTCORLogDebug("%@", @"GDTCORPlatform is sending a notif that the app is terminating.");
   [notifCenter postNotificationName:kGDTCORApplicationWillTerminateNotification object:nil];
 }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV
+
+#pragma mark - WKExtensionDelegate
+#if TARGET_OS_WATCH
+- (void)iOSApplicationDidEnterBackground:(NSNotification *)notif {
+  _isRunningInBackground = YES;
+
+  NSNotificationCenter *notifCenter = [NSNotificationCenter defaultCenter];
+  GDTCORLogDebug("%@", @"GDTCORPlatform is sending a notif that the app is backgrounding.");
+  [notifCenter postNotificationName:kGDTCORApplicationDidEnterBackgroundNotification object:nil];
+}
+
+- (void)iOSApplicationWillEnterForeground:(NSNotification *)notif {
+  _isRunningInBackground = NO;
+
+  NSNotificationCenter *notifCenter = [NSNotificationCenter defaultCenter];
+  GDTCORLogDebug("%@", @"GDTCORPlatform is sending a notif that the app is foregrounding.");
+  [notifCenter postNotificationName:kGDTCORApplicationWillEnterForegroundNotification object:nil];
+}
+#endif  // TARGET_OS_WATCH
 
 #pragma mark - NSApplicationDelegate
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -280,9 +280,9 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
   return sharedApplication;
 }
 
-#pragma mark - UIApplicationDelegate
+#pragma mark - UIApplicationDelegate and WKExtensionDelegate
 
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_WATCH
 - (void)iOSApplicationDidEnterBackground:(NSNotification *)notif {
   _isRunningInBackground = YES;
 
@@ -298,32 +298,17 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
   GDTCORLogDebug("%@", @"GDTCORPlatform is sending a notif that the app is foregrounding.");
   [notifCenter postNotificationName:kGDTCORApplicationWillEnterForegroundNotification object:nil];
 }
+#endif  // TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_WATCH
 
+#pragma mark - UIApplicationDelegate
+
+#if TARGET_OS_IOS || TARGET_OS_TV
 - (void)iOSApplicationWillTerminate:(NSNotification *)notif {
   NSNotificationCenter *notifCenter = [NSNotificationCenter defaultCenter];
   GDTCORLogDebug("%@", @"GDTCORPlatform is sending a notif that the app is terminating.");
   [notifCenter postNotificationName:kGDTCORApplicationWillTerminateNotification object:nil];
 }
 #endif  // TARGET_OS_IOS || TARGET_OS_TV
-
-#pragma mark - WKExtensionDelegate
-#if TARGET_OS_WATCH
-- (void)iOSApplicationDidEnterBackground:(NSNotification *)notif {
-  _isRunningInBackground = YES;
-
-  NSNotificationCenter *notifCenter = [NSNotificationCenter defaultCenter];
-  GDTCORLogDebug("%@", @"GDTCORPlatform is sending a notif that the app is backgrounding.");
-  [notifCenter postNotificationName:kGDTCORApplicationDidEnterBackgroundNotification object:nil];
-}
-
-- (void)iOSApplicationWillEnterForeground:(NSNotification *)notif {
-  _isRunningInBackground = NO;
-
-  NSNotificationCenter *notifCenter = [NSNotificationCenter defaultCenter];
-  GDTCORLogDebug("%@", @"GDTCORPlatform is sending a notif that the app is foregrounding.");
-  [notifCenter postNotificationName:kGDTCORApplicationWillEnterForegroundNotification object:nil];
-}
-#endif  // TARGET_OS_WATCH
 
 #pragma mark - NSApplicationDelegate
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
@@ -141,7 +141,8 @@
  */
 - (GDTCORUploadConditions)uploadConditions {
 #if TARGET_OS_WATCH
-  return GDTCORUploadConditionNoNetwork;
+  // Assume connected on watchOS.
+  return GDTCORUploadConditionUnclearConnection;
 #else
   SCNetworkReachabilityFlags currentFlags = [GDTCORReachability currentFlags];
   BOOL reachable =

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
@@ -19,10 +19,13 @@
 #if !TARGET_OS_WATCH
 #import <SystemConfiguration/SystemConfiguration.h>
 #endif
+
 #if TARGET_OS_IOS || TARGET_OS_TV
 #import <UIKit/UIKit.h>
 #elif TARGET_OS_OSX
 #import <AppKit/AppKit.h>
+#elif TARGET_OS_WATCH
+#import <WatchKit/WatchKit.h>
 #endif  // TARGET_OS_IOS || TARGET_OS_TV
 
 #if TARGET_OS_IOS
@@ -99,6 +102,8 @@ FOUNDATION_EXPORT const GDTCORBackgroundIdentifier GDTCORBackgroundIdentifierInv
 @protocol GDTCORApplicationDelegate <UIApplicationDelegate>
 #elif TARGET_OS_OSX
 @protocol GDTCORApplicationDelegate <NSApplicationDelegate>
+#elif TARGET_OS_WATCH
+@protocol GDTCORApplicationDelegate <WKExtensionDelegate>
 #else
 @protocol GDTCORApplicationDelegate <NSObject>
 #endif  // TARGET_OS_IOS || TARGET_OS_TV

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
@@ -98,7 +98,9 @@ typedef volatile NSUInteger GDTCORBackgroundIdentifier;
 FOUNDATION_EXPORT const GDTCORBackgroundIdentifier GDTCORBackgroundIdentifierInvalid;
 
 #if TARGET_OS_IOS || TARGET_OS_TV
-/** A protocol that wraps UIApplicationDelegate or NSObject protocol, depending on the platform. */
+/** A protocol that wraps UIApplicationDelegate, WKExtensionDelegate or NSObject protocol, depending
+ * on the platform.
+ */
 @protocol GDTCORApplicationDelegate <UIApplicationDelegate>
 #elif TARGET_OS_OSX
 @protocol GDTCORApplicationDelegate <NSApplicationDelegate>


### PR DESCRIPTION
- Switch watchOS applicationDelegate to WKExtensionDelegate
- sharedApplicationForBackgroundTask shared WKExtension in watchOS instead of UIApplication
- TODO: Implement beginBackgroundTaskWithName and endBackgroundTask for watchOS