### PR TITLE
FirebaseStorage.podspec - update Core dependency version to one supporting watchOS

### DIFF
--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -31,7 +31,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   s.osx.framework = 'CoreServices'
 
   s.dependency 'FirebaseAuthInterop', '~> 1.1'
-  s.dependency 'FirebaseCore', '~> 6.0'
+  s.dependency 'FirebaseCore', '~> 6.6'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',


### PR DESCRIPTION
Firebase Core watch OS support was added in M62 (FirebaseCore 6.6.0) by #4016

#no-changelog