### PR TITLE
Fix issue where Crash Free Users does not work with new GDT changes

### DIFF
--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportUploader.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportUploader.m
@@ -112,6 +112,10 @@
         FIRCLSDebugLog(@"Preparing the report for the new endpoint: %d",
                        self.dataSource.settings.shouldUseNewReportEndpoint);
 
+        // With the new report endpoint, the report is deleted once it is written to GDT
+        // Check if the report has a crash file before the report is moved or deleted
+        BOOL isCrash = report.isCrash;
+
         if (self.dataSource.settings.shouldUseNewReportEndpoint) {
           // For the new endpoint, just move the .clsrecords from "processing" -> "prepared"
           if (![self.fileManager moveItemAtPath:report.path
@@ -150,7 +154,7 @@
 
         // If the upload was successful and the report contained a crash forward it to Google
         // Analytics.
-        if (success && report.isCrash) {
+        if (success && isCrash) {
           [FIRCLSFCRAnalytics logCrashWithTimeStamp:report.crashedOnDate.timeIntervalSince1970
                                         toAnalytics:self->_analytics];
         }

--- a/Crashlytics/Crashlytics/Models/FIRCLSInternalReport.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSInternalReport.m
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO: This class should be removed the uploading of reports via GoogleDataTransport is no longer
+// an experiment
+
 #import "FIRCLSInternalReport.h"
 
 #import "FIRCLSFile.h"

--- a/Crashlytics/Crashlytics/Models/FIRCLSInternalReport.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSInternalReport.m
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO: This class should be removed the uploading of reports via GoogleDataTransport is no longer
-// an experiment
+// TODO: Remove this class after the uploading of reports via GoogleDataTransport is no longer an
+// experiment
 
 #import "FIRCLSInternalReport.h"
 


### PR DESCRIPTION
With the new GDT changes, Analytics might not be called because the logic is to detect certain crash files in a directory. However, in the GDT workflow, that directory may be moved or deleted. The fix is to check whether a report has a crash before any processing. 

Verified a "clx" event is sent when Google Analytics is included in the project after a crash has occurred.

<img width="842" alt="Screen Shot 2020-03-05 at 11 55 50 AM" src="https://user-images.githubusercontent.com/43789343/76004919-4a41e200-5ed8-11ea-825b-85d48df31e02.png">
