### PR TITLE
Remove setting CMAKE_BUILD_TYPE in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,11 +79,6 @@ include(podspec_rules)
 include(cc_rules)
 
 
-# If no build type is specified, make it a debug build
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Debug)
-endif()
-
 set(FIREBASE_SOURCE_DIR ${PROJECT_SOURCE_DIR})
 set(FIREBASE_BINARY_DIR ${PROJECT_BINARY_DIR})
 set(FIREBASE_INSTALL_DIR ${PROJECT_BINARY_DIR}/opt)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -256,6 +256,7 @@ xcb_flags+=(
 # dependencies don't build cleanly this way.
 cmake_options=(
   -Wdeprecated
+  -DCMAKE_BUILD_TYPE=Debug
 )
 
 if [[ -n "${SANITIZERS:-}" ]]; then


### PR DESCRIPTION
This really needs to be set on the command-line if it's to be effective,
and setting it here breaks downstream projects that include
firebase-ios-sdk as a subdirectory.