### PR TITLE
Use static frameworks to build zip

### DIFF
--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -121,11 +121,14 @@ enum CocoaPodUtils {
   ///   - pods: List of VersionedPods to install
   ///   - directory: Destination directory for the pods.
   ///   - customSpecRepos: Additional spec repos to check for installation.
+  ///   - forceStaticLibs: Force a static library pod install. For the module map construction, we want pod names not module
+  ///                      names in the generated OTHER_LD_FLAGS options.
   /// - Returns: A dictionary of PodInfo's keyed by the pod name.
   @discardableResult
   static func installPods(_ pods: [VersionedPod],
                           inDir directory: URL,
-                          customSpecRepos: [URL]? = nil) -> [String: PodInfo] {
+                          customSpecRepos: [URL]?,
+                          forceStaticLibs: Bool = false) -> [String: PodInfo] {
     let fileManager = FileManager.default
     // Ensure the directory exists, otherwise we can't install all subspecs.
     guard fileManager.directoryExists(at: directory) else {
@@ -140,7 +143,10 @@ enum CocoaPodUtils {
 
     // Attempt to write the Podfile to disk.
     do {
-      try writePodfile(for: pods, toDirectory: directory, customSpecRepos: customSpecRepos)
+      try writePodfile(for: pods,
+                       toDirectory: directory,
+                       customSpecRepos: customSpecRepos,
+                       forceStaticLibs: forceStaticLibs)
     } catch let FileManager.FileError.directoryNotFound(path) {
       fatalError("Failed to write Podfile with pods \(pods) at path \(path)")
     } catch let FileManager.FileError.writeToFileFailed(path, error) {
@@ -150,7 +156,8 @@ enum CocoaPodUtils {
     }
 
     // Run pod install on the directory that contains the Podfile and blank Xcode project.
-    let result = Shell.executeCommandFromScript("pod _1.8.4_ install", workingDir: directory)
+    // At least 1.9.0 is required for `use_frameworks! :linkage => :static`
+    let result = Shell.executeCommandFromScript("pod _1.9.0_ install", workingDir: directory)
     switch result {
     case let .error(code, output):
       fatalError("""
@@ -354,7 +361,8 @@ enum CocoaPodUtils {
   /// Create the contents of a Podfile for an array of subspecs. This assumes the array of subspecs
   /// is not empty.
   private static func generatePodfile(for pods: [VersionedPod],
-                                      customSpecsRepos: [URL]? = nil) -> String {
+                                      customSpecsRepos: [URL]?,
+                                      forceStaticLibs: Bool) -> String {
     // Start assembling the Podfile.
     var podfile: String = ""
 
@@ -369,8 +377,12 @@ enum CocoaPodUtils {
       """ // Explicit newline above to ensure it's included in the String.
     }
 
-    if LaunchArgs.shared.dynamic {
+    if forceStaticLibs {
+      podfile += "  use_modular_headers!\n"
+    } else if LaunchArgs.shared.dynamic {
       podfile += "  use_frameworks!\n"
+    } else {
+      podfile += "  use_frameworks! :linkage => :static\n"
     }
     // Include the minimum iOS version.
     podfile += """
@@ -421,7 +433,8 @@ enum CocoaPodUtils {
   /// "Podfile".
   private static func writePodfile(for pods: [VersionedPod],
                                    toDirectory directory: URL,
-                                   customSpecRepos: [URL]?) throws {
+                                   customSpecRepos: [URL]?,
+                                   forceStaticLibs: Bool) throws {
     guard FileManager.default.directoryExists(at: directory) else {
       // Throw an error so the caller can provide a better error message.
       throw FileManager.FileError.directoryNotFound(path: directory.path)
@@ -429,7 +442,7 @@ enum CocoaPodUtils {
 
     // Generate the full path of the Podfile and attempt to write it to disk.
     let path = directory.appendingPathComponent("Podfile")
-    let podfile = generatePodfile(for: pods, customSpecsRepos: customSpecRepos)
+    let podfile = generatePodfile(for: pods, customSpecsRepos: customSpecRepos, forceStaticLibs: forceStaticLibs)
     do {
       try podfile.write(toFile: path.path, atomically: true, encoding: .utf8)
     } catch {

--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -61,14 +61,13 @@ enum CocoaPodUtils {
     let subspecs: Set<String>
 
     /// The contents of the module map for all frameworks associated with the pod.
-    var moduleMapContents: String
+    var moduleMapContents: ModuleMapBuilder.ModuleMapContents?
 
     init(version: String, dependencies: [String], installedLocation: URL, subspecs: Set<String>) {
       self.version = version
       self.dependencies = dependencies
       self.installedLocation = installedLocation
       self.subspecs = subspecs
-      moduleMapContents = ""
 
       // Get all the frameworks contained in this directory.
       var binaryFrameworks: [URL] = []

--- a/ZipBuilder/Sources/ZipBuilder/FileManager+Utils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FileManager+Utils.swift
@@ -106,7 +106,8 @@ extension FileManager {
     if #available(OSX 10.12, *) {
       let formatter = ISO8601DateFormatter()
       formatter.formatOptions.insert(.withInternetDateTime)
-      return formatter.string(from: Date())
+      // Replace ":" with "-" so that bash file completion still works.
+      return formatter.string(from: Date()).replacingOccurrences(of: ":", with: "-")
     } else {
       return UUID().uuidString
     }

--- a/ZipBuilder/Sources/ZipBuilder/FileManager+Utils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FileManager+Utils.swift
@@ -101,16 +101,11 @@ extension FileManager {
     }
   }
 
-  /// Enable a single unique temporary workspace per execution.
+  /// Enable a single unique temporary workspace per execution with a sortable and readable timestamp.
   private static func timeStamp() -> String {
-    if #available(OSX 10.12, *) {
-      let formatter = ISO8601DateFormatter()
-      formatter.formatOptions.insert(.withInternetDateTime)
-      // Replace ":" with "-" so that bash file completion still works.
-      return formatter.string(from: Date()).replacingOccurrences(of: ":", with: "-")
-    } else {
-      return UUID().uuidString
-    }
+    let formatter = DateFormatter()
+    formatter.dateFormat = "YYYY-MM-dd'T'HH-mm-ss"
+    return formatter.string(from: Date())
   }
 
   static let unique: String = timeStamp()

--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -440,7 +440,11 @@ struct FrameworkBuilder {
         if umbrellas.count != 1 {
           fatalError("Did not find exactly one umbrella header in \(headersDir).")
         }
-        umbrellaHeaderURL = URL(string: umbrellas[0])!
+        guard let firstUmbrella = umbrellas.first,
+          let foundHeader = URL(string: firstUmbrella) else { /* error */
+          fatalError("Failed to get umbrella header in \(headersDir).")
+        }
+        umbrellaHeaderURL = foundHeader
       } catch {
         fatalError("Error while enumerating files \(headersDir): \(error.localizedDescription)")
       }
@@ -490,11 +494,14 @@ struct FrameworkBuilder {
         "\(error)")
     }
 
+    guard let moduleMapContents = podInfo.moduleMapContents else {
+      fatalError("Module map contents missing for framework \(framework)")
+    }
     let xcframework = packageXCFramework(withName: framework,
                                          fromFolder: frameworkDir,
                                          thinArchives: thinArchives,
                                          moduleMapContents:
-                                         podInfo.moduleMapContents!.get(umbrellaHeader: umbrellaHeader))
+                                         moduleMapContents.get(umbrellaHeader: umbrellaHeader))
 
     // Remove the temporary thin archives.
     for thinArchive in thinArchives.values {

--- a/ZipBuilder/Sources/ZipBuilder/ModuleMapBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ModuleMapBuilder.swift
@@ -34,6 +34,35 @@ struct ModuleMapBuilder {
     }
   }
 
+  struct ModuleMapContents {
+    /// Placeholder to fill in umbrella header.
+    static let umbrellaPlaceholder = "UMBRELLA_PLACEHOLDER"
+    let contents: String
+    init(module: String, frameworks: Set<String>, libraries: Set<String>) {
+      var content = """
+      framework module \(module) {
+      umbrella header "\(ModuleMapBuilder.ModuleMapContents.umbrellaPlaceholder)"
+      export *
+      module * { export * }
+
+      """
+      for framework in frameworks.sorted() {
+        content += "  link framework " + framework + "\n"
+      }
+      for library in libraries.sorted() {
+        content += "  link " + library + "\n"
+      }
+      // The empty line at the end is intentional, do not remove it.
+      content += "}\n"
+      contents = content
+    }
+
+    func get(umbrellaHeader: String) -> String {
+      return contents.replacingOccurrences(of:
+        ModuleMapBuilder.ModuleMapContents.umbrellaPlaceholder, with: umbrellaHeader)
+    }
+  }
+
   /// The directory containing the Xcode project and Pods folder.
   private let projectDir: URL
 
@@ -144,7 +173,7 @@ struct ModuleMapBuilder {
   }
 
   private func makeModuleMap(forFramework framework: FrameworkInfo,
-                             withXcconfigFile xcconfigFile: URL) -> String {
+                             withXcconfigFile xcconfigFile: URL) -> ModuleMapContents {
     let name = framework.versionedPod.name
     let dependencies = getModuleDependencies(withXcconfigFile: xcconfigFile)
     let frameworkDeps = Set(dependencies.frameworks)
@@ -182,21 +211,6 @@ struct ModuleMapBuilder {
     installedPods[name]?.transitiveFrameworks = transitiveFrameworkDeps
     installedPods[name]?.transitiveLibraries = transitiveLibraryDeps
 
-    // The base of the module map. The empty line at the end is intentional, do not remove it.
-    var content = """
-    framework module \(name) {
-    umbrella header "INSERT_UMBRELLA_HEADER_HERE"
-    export *
-    module * { export * }
-
-    """
-    for framework in myFrameworkDeps.sorted() {
-      content += "  link framework " + framework + "\n"
-    }
-    for library in myLibraryDeps.sorted() {
-      content += "  link " + library + "\n"
-    }
-    content += "}\n"
-    return content
+    return ModuleMapContents(module: name, frameworks: myFrameworkDeps, libraries: myLibraryDeps)
   }
 }

--- a/ZipBuilder/Sources/ZipBuilder/ModuleMapBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ModuleMapBuilder.swift
@@ -86,7 +86,8 @@ struct ModuleMapBuilder {
     let deps = CocoaPodUtils.transitiveVersionedPodDependencies(for: podName, in: allPods)
     _ = CocoaPodUtils.installPods(allSubspecList(framework: framework) + deps,
                                   inDir: projectDir,
-                                  customSpecRepos: customSpecRepos)
+                                  customSpecRepos: customSpecRepos,
+                                  forceStaticLibs: true)
     let xcconfigFile = projectDir.appendingPathComponents(["Pods", "Target Support Files",
                                                            "Pods-FrameworkMaker",
                                                            "Pods-FrameworkMaker.release.xcconfig"])
@@ -184,7 +185,7 @@ struct ModuleMapBuilder {
     // The base of the module map. The empty line at the end is intentional, do not remove it.
     var content = """
     framework module \(name) {
-    umbrella header "\(name).h"
+    umbrella header "INSERT_UMBRELLA_HEADER_HERE"
     export *
     module * { export * }
 

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -708,9 +708,8 @@ struct ZipBuilder {
       if podInfo.isSourcePod {
         let builder = FrameworkBuilder(projectDir: projectDir, carthageBuild: carthageBuild)
         let framework = builder.buildFramework(withName: podName,
-                                               version: podInfo.version,
-                                               logsOutputDir: paths.logsOutputDir,
-                                               moduleMapContents: pods[podName]!.moduleMapContents)
+                                               podInfo: podInfo,
+                                               logsOutputDir: paths.logsOutputDir)
 
         frameworks = [framework]
       } else {


### PR DESCRIPTION
Take advantage of new CocoaPods 1.9.0 functionality to use static frameworks instead of static libs to build zip.  It now can build Swift pods, but still more to figure out for managing bridging headers.

The static library `pod install` is still necessary for calculating the module map dependencies.

Also some additional minor improvements:
- Use dashes instead of colons in temp file name so command line completion works
- Only adjust signing for building Catalyst library
- Stop assuming that arm64 is always built
- Support xcframeworks that don't have all possible slices built
- Handle umbrella header specification for non-Firebase pods
- Delete no longer necessary code for copying symbolic linked header directories - because Headers are not links in the framework build.

Future tasks:
- Figure out how to access binary Swift frameworks from the zip
- More robust handling of module maps specified by podspecs
- Include PrivateHeaders directories in zip archive

