### PR TITLE
Crashlytics pin on newer version of GDT

### DIFF
--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -45,8 +45,8 @@ Pod::Spec.new do |s|
   s.dependency 'FirebaseInstallations', '~> 1.1'
   s.dependency 'FirebaseAnalyticsInterop', '~> 1.2'
   s.dependency 'PromisesObjC', '~> 1.2'
-  s.dependency 'GoogleDataTransport', '~> 4.0'
-  s.dependency 'GoogleDataTransportCCTSupport', '~> 1.3'
+  s.dependency 'GoogleDataTransport', '~> 4.0', '>= 4.0.1'
+  s.dependency 'GoogleDataTransportCCTSupport', '~> 1.4', '>= 1.4.1'
   s.dependency 'nanopb', '~> 0.3.901'
 
   s.libraries = 'c++', 'z'


### PR DESCRIPTION
Need the change that allows for larger logs: https://github.com/firebase/firebase-ios-sdk/blob/master/GoogleDataTransportCCTSupport/CHANGELOG.md#v141