### PR TITLE
Add Swift module support to ZipBuilder

### DIFF
--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -221,7 +221,7 @@ struct FrameworkBuilder {
                 "ARCHS=\(cleanArch)",
                 "VALID_ARCHS=\(cleanArch)",
                 "ONLY_ACTIVE_ARCH=NO",
-                // BUILD_LIBRARY_FOR_DISTRIBUTION=YES is Necessary for Swift libraries.
+                // BUILD_LIBRARY_FOR_DISTRIBUTION=YES is necessary for Swift libraries.
                 // See https://forums.developer.apple.com/thread/125646.
                 // Unlike the comment there, the option here is sufficient to cause .swiftinterface
                 // files to be generated in the .swiftmodule directory. The .swiftinterface files
@@ -619,17 +619,21 @@ struct FrameworkBuilder {
         } else {
           // If the Modules directory is already there, only copy in the architecture specific files
           // from the *.swiftmodule subdirectory.
-          let files = try fileManager.contentsOfDirectory(at: swiftModule,
-                                                          includingPropertiesForKeys: nil).compactMap { $0.absoluteString }
-          let destSwiftModuleDir = destModuleDir.appendingPathComponent(swiftModule.lastPathComponent)
-          for file in files {
-            let fileURL = URL(fileURLWithPath: file)
-            do {
-              try fileManager.copyItem(at: fileURL, to:
-                destSwiftModuleDir.appendingPathComponent(fileURL.lastPathComponent))
-            } catch {
-              fatalError("Could not copy Swift module file from \(fileURL) to " + "\(destSwiftModuleDir): \(error)")
+          do {
+            let files = try fileManager.contentsOfDirectory(at: swiftModule,
+                                                            includingPropertiesForKeys: nil).compactMap { $0.absoluteString }
+            let destSwiftModuleDir = destModuleDir.appendingPathComponent(swiftModule.lastPathComponent)
+            for file in files {
+              let fileURL = URL(fileURLWithPath: file)
+              do {
+                try fileManager.copyItem(at: fileURL, to:
+                  destSwiftModuleDir.appendingPathComponent(fileURL.lastPathComponent))
+              } catch {
+                fatalError("Could not copy Swift module file from \(fileURL) to " + "\(destSwiftModuleDir): \(error)")
+              }
             }
+          } catch {
+            fatalError("Failed to get Modules directory contents - \(moduleDir): \(error.localizedDescription)")
           }
         }
       } catch {

--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -446,7 +446,7 @@ struct FrameworkBuilder {
           fatalError("Did not find exactly one umbrella header in \(headersDir).")
         }
         guard let firstUmbrella = umbrellas.first,
-          let foundHeader = URL(string: firstUmbrella) else { /* error */
+          let foundHeader = URL(string: firstUmbrella) else {
           fatalError("Failed to get umbrella header in \(headersDir).")
         }
         umbrellaHeaderURL = foundHeader
@@ -608,7 +608,10 @@ struct FrameworkBuilder {
         if swiftModules.isEmpty {
           return false
         }
-        let swiftModule = URL(fileURLWithPath: swiftModules[0])
+        guard let first = swiftModules.first,
+          let swiftModule = URL(string: first) else {
+          fatalError("Failed to get swiftmodule in \(moduleDir).")
+        }
         let destModuleDir = destination.appendingPathComponent("Modules")
         if !fileManager.directoryExists(at: destModuleDir) {
           do {

--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -272,7 +272,7 @@ struct FrameworkBuilder {
       var actualFramework: String
       do {
         let files = try FileManager.default.contentsOfDirectory(at: frameworkPath,
-                                                                includingPropertiesForKeys: nil).compactMap { $0.absoluteString }
+                                                                includingPropertiesForKeys: nil).compactMap { $0.path }
         let frameworkDir = files.filter { $0.contains(".framework") }
         actualFramework = URL(fileURLWithPath: frameworkDir[0]).lastPathComponent
       } catch {
@@ -440,7 +440,7 @@ struct FrameworkBuilder {
       var umbrellaHeaderURL: URL
       do {
         let files = try fileManager.contentsOfDirectory(at: headersDir,
-                                                        includingPropertiesForKeys: nil).compactMap { $0.absoluteString }
+                                                        includingPropertiesForKeys: nil).compactMap { $0.path }
         let umbrellas = files.filter { $0.hasSuffix("umbrella.h") }
         if umbrellas.count != 1 {
           fatalError("Did not find exactly one umbrella header in \(headersDir).")
@@ -603,8 +603,8 @@ struct FrameworkBuilder {
       let moduleDir = frameworkDir.appendingPathComponent("Modules").resolvingSymlinksInPath()
       do {
         let files = try fileManager.contentsOfDirectory(at: moduleDir,
-                                                        includingPropertiesForKeys: nil).compactMap { $0.absoluteString }
-        let swiftModules = files.filter { $0.hasSuffix(".swiftmodule/") }
+                                                        includingPropertiesForKeys: nil).compactMap { $0.path }
+        let swiftModules = files.filter { $0.hasSuffix(".swiftmodule") }
         if swiftModules.isEmpty {
           return false
         }
@@ -624,7 +624,7 @@ struct FrameworkBuilder {
           // from the *.swiftmodule subdirectory.
           do {
             let files = try fileManager.contentsOfDirectory(at: swiftModule,
-                                                            includingPropertiesForKeys: nil).compactMap { $0.absoluteString }
+                                                            includingPropertiesForKeys: nil).compactMap { $0.path }
             let destSwiftModuleDir = destModuleDir.appendingPathComponent(swiftModule.lastPathComponent)
             for file in files {
               let fileURL = URL(fileURLWithPath: file)

--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -610,8 +610,7 @@ struct FrameworkBuilder {
         }
         let swiftModule = URL(fileURLWithPath: swiftModules[0])
         let destModuleDir = destination.appendingPathComponent("Modules")
-
-        if !fileManager.fileExists(atPath: destModuleDir.absoluteString) {
+        if !fileManager.directoryExists(at: destModuleDir) {
           do {
             try fileManager.copyItem(at: moduleDir, to: destModuleDir)
           } catch {
@@ -620,10 +619,8 @@ struct FrameworkBuilder {
         } else {
           // If the Modules directory is already there, only copy in the architecture specific files
           // from the *.swiftmodule subdirectory.
-
           let files = try fileManager.contentsOfDirectory(at: swiftModule,
                                                           includingPropertiesForKeys: nil).compactMap { $0.absoluteString }
-
           let destSwiftModuleDir = destModuleDir.appendingPathComponent(swiftModule.lastPathComponent)
           for file in files {
             let fileURL = URL(fileURLWithPath: file)


### PR DESCRIPTION
Build Swift modules for zip distributions.  Swift libraries need to include a .swiftmodule directory in the Modules directory of the framework.  This PR sets it up:

![Screen Shot 2020-03-07 at 8 29 45 AM](https://user-images.githubusercontent.com/73870/76147120-dfb2b280-604d-11ea-9dee-73ee6389a653.png)

The resulting xcframeworks now can be dragged and dropped into the Firestore quickstart and it runs correctly for iOS and Catalyst.

#no-changelog