### PR TITLE
Fix nightly zip GHA build

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -29,13 +29,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Bundler
-      run: |
-        pod --version
-        scripts/setup_bundler.sh
-        bundle exec pod --version
+      run: ./scripts/setup_bundler.sh
     - name: ZipBuildingTest
       run: |
-         bundle exec pod --version
          mkdir -p zip_output_dir
          sh -x scripts/build_zip.sh zip_output_dir
 

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -25,7 +25,7 @@ jobs:
     needs: build
     runs-on: macOS-latest
     # Only run the `package` job for the cron job, not PRs.
-    if: github.event_name == 'schedule'
+#    if: github.event_name == 'schedule'
     steps:
     - uses: actions/checkout@v2
     - name: Setup Bundler

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -29,9 +29,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Bundler
-      run: ./scripts/setup_bundler.sh
+      run: |
+        pod --version
+        scripts/setup_bundler.sh
+        bundle exec pod --version
     - name: ZipBuildingTest
       run: |
+         bundle exec pod --version
          mkdir -p zip_output_dir
          sh -x scripts/build_zip.sh zip_output_dir
 

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -25,7 +25,7 @@ jobs:
     needs: build
     runs-on: macOS-latest
     # Only run the `package` job for the cron job, not PRs.
-#    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule'
     steps:
     - uses: actions/checkout@v2
     - name: Setup Bundler

--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -115,7 +115,7 @@ enum CocoaPodUtils {
     }
 
     // Run pod install on the directory that contains the Podfile and blank Xcode project.
-    let result = Shell.executeCommandFromScript("pod _1.8.4_ install", workingDir: directory)
+    let result = Shell.executeCommandFromScript("pod install", workingDir: directory)
     switch result {
     case let .error(code, output):
       fatalError("""

--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -116,7 +116,7 @@ enum CocoaPodUtils {
 
     // Run pod install on the directory that contains the Podfile and blank Xcode project.
     checkCocoaPodsVersion(directory: directory)
-    let result = Shell.executeCommandFromScript("pod install", workingDir: directory)
+    let result = Shell.executeCommandFromScript("bundle exec pod install", workingDir: directory)
     switch result {
     case let .error(code, output):
       fatalError("""
@@ -393,7 +393,8 @@ enum CocoaPodUtils {
       return
     }
     checkedCocoaPodsVersion = true
-    let podVersion = Shell.executeCommandFromScript("pod --version", workingDir: directory)
+    let podVersion =
+      Shell.executeCommandFromScript("bundle exec pod --version", workingDir: directory)
     switch podVersion {
     case let .error(code, output):
       fatalError("""

--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -116,7 +116,7 @@ enum CocoaPodUtils {
 
     // Run pod install on the directory that contains the Podfile and blank Xcode project.
     checkCocoaPodsVersion(directory: directory)
-    let result = Shell.executeCommandFromScript("bundle exec pod install", workingDir: directory)
+    let result = Shell.executeCommandFromScript("pod install", workingDir: directory)
     switch result {
     case let .error(code, output):
       fatalError("""
@@ -393,8 +393,7 @@ enum CocoaPodUtils {
       return
     }
     checkedCocoaPodsVersion = true
-    let podVersion =
-      Shell.executeCommandFromScript("bundle exec pod --version", workingDir: directory)
+    let podVersion = Shell.executeCommandFromScript("pod --version", workingDir: directory)
     switch podVersion {
     case let .error(code, output):
       fatalError("""

--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -407,7 +407,7 @@ enum CocoaPodUtils {
       guard let minor = Int(version[1]) else {
         fatalError("Failed to parse minor version from \(version)")
       }
-      if major == 1 && minor < 9 {
+      if major == 1, minor < 9 {
         fatalError("CocoaPods version must be at least 1.9.0. Using \(output)")
       }
     }

--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -385,7 +385,7 @@ enum CocoaPodUtils {
 
   private static var checkedCocoaPodsVersion = false
 
-  /// At least 1.9.0 is required for `use_frameworks! :linkage => :static
+  /// At least 1.9.0 is required for `use_frameworks! :linkage => :static`
   /// - Parameters:
   ///   - directory: Destination directory for the pods.
   private static func checkCocoaPodsVersion(directory: URL) {


### PR DESCRIPTION
Fix nightly GHA build that started failing after repo switched to CocoaPods 1.9.0.

Remove the specification from the zip builder so it uses the CocoaPods installed by scripts/setup_bundler.sh.