### PR TITLE
Fix compilation under Linux/GCC 9.2.1 in Release mode

### DIFF
--- a/Firestore/Protos/CMakeLists.txt
+++ b/Firestore/Protos/CMakeLists.txt
@@ -128,13 +128,10 @@ target_include_directories(
 # libprotobuf based generated protos. Expected only to be used in test (as
 # libprotobuf[-lite] is too large; we're using nanopb instead. But we do want
 # to test our serialization logic against libprotobuf.)
-cc_library(
+add_library(
   firebase_firestore_protos_libprotobuf
-  SOURCES
-    ${PROTOBUF_CPP_GENERATED_SOURCES}
-  DEPENDS
-    protobuf::libprotobuf
   EXCLUDE_FROM_ALL
+  ${PROTOBUF_CPP_GENERATED_SOURCES}
 )
 
 if(CXX_CLANG OR CXX_GNU)
@@ -148,6 +145,12 @@ endif()
 target_include_directories(
   firebase_firestore_protos_libprotobuf PUBLIC
   ${FIREBASE_SOURCE_DIR}/Firestore/Protos/cpp
+)
+
+target_link_libraries(
+  firebase_firestore_protos_libprotobuf
+  PUBLIC
+    protobuf::libprotobuf
 )
 
 # Generate the python representation of descriptor.proto.


### PR DESCRIPTION
The `firebase_firestore_protos_libprotobuf` library contains protoc-generated code. Compile with standard flags rather than Firestore's default of `-Wall -Wextra -Werror`.

This avoids errors like these:

```
Firestore/Protos/cpp/google/firestore/v1/firestore.pb.cc:1669:11: error: ‘void* memset(void*, int, size_t)’ offset [57, 61] from the object at ‘google::firestore::v1::_ListDocumentsRequest_default_instance_’ is out of the bounds of referenced subobject ‘google::firestore::v1::ListDocumentsRequest::mask_’ with type ‘google::firestore::v1::DocumentMask*’ at offset 48 [-Werror=array-bounds]
 1669 |   ::memset(&mask_, 0, static_cast<size_t>(
      |   ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1670 |       reinterpret_cast<char*>(&show_missing_) -
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1671 |       reinterpret_cast<char*>(&mask_)) + sizeof(show_missing_));
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```