### PR TITLE
b/151167694 - sendUnsentReport might not upload until the second time the API is called

### DIFF
--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -365,6 +365,7 @@ static void (^reportSentCallback)(void);
     FIRCLSDataCollectionToken *dataCollectionToken = [FIRCLSDataCollectionToken validToken];
     [self startNetworkRequestsWithToken:dataCollectionToken
                  preexistingReportPaths:preexistingReportPaths
+                 waitForSettingsRequest:NO
                            blockingSend:launchFailure
                                  report:report];
 
@@ -395,6 +396,7 @@ static void (^reportSentCallback)(void);
                      [FIRCLSDataCollectionToken validToken];
                  [self startNetworkRequestsWithToken:dataCollectionToken
                               preexistingReportPaths:preexistingReportPaths
+                              waitForSettingsRequest:YES
                                         blockingSend:NO
                                               report:report];
 
@@ -451,6 +453,7 @@ static void (^reportSentCallback)(void);
 
 - (void)startNetworkRequestsWithToken:(FIRCLSDataCollectionToken *)token
                preexistingReportPaths:(NSArray *)preexistingReportPaths
+               waitForSettingsRequest:(BOOL)waitForSettings
                          blockingSend:(BOOL)blockingSend
                                report:(FIRCLSInternalReport *)report {
   if (self.settings.isCacheExpired) {
@@ -459,7 +462,8 @@ static void (^reportSentCallback)(void);
     static dispatch_once_t settingsFetchOnceToken;
     dispatch_once(&settingsFetchOnceToken, ^{
       [self.settingsAndOnboardingManager beginSettingsAndOnboardingWithGoogleAppId:self.googleAppID
-                                                                             token:token];
+                                                                             token:token
+                                                                 waitForCompletion:waitForSettings];
     });
   }
 

--- a/Crashlytics/Crashlytics/Settings/FIRCLSSettingsOnboardingManager.h
+++ b/Crashlytics/Crashlytics/Settings/FIRCLSSettingsOnboardingManager.h
@@ -51,7 +51,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @param token (required) Data collection token signifying we can make network calls
  */
 - (void)beginSettingsAndOnboardingWithGoogleAppId:(NSString *)googleAppID
-                                            token:(FIRCLSDataCollectionToken *)token;
+                                            token:(FIRCLSDataCollectionToken *)token
+                                waitForCompletion:(BOOL)waitForCompletion;
 
 @end
 

--- a/Crashlytics/Crashlytics/Settings/FIRCLSSettingsOnboardingManager.m
+++ b/Crashlytics/Crashlytics/Settings/FIRCLSSettingsOnboardingManager.m
@@ -73,7 +73,8 @@
 }
 
 - (void)beginSettingsAndOnboardingWithGoogleAppId:(NSString *)googleAppID
-                                            token:(FIRCLSDataCollectionToken *)token {
+                                            token:(FIRCLSDataCollectionToken *)token
+                                waitForCompletion:(BOOL)waitForCompletion {
   NSParameterAssert(googleAppID);
 
   self.googleAppID = googleAppID;
@@ -86,7 +87,7 @@
     FIRCLSApplicationGetSDKBundleID() : @CLS_SDK_DISPLAY_VERSION,
   };
 
-  [self beginSettingsDownload:token];
+  [self beginSettingsDownload:token waitForCompletion:waitForCompletion];
 }
 
 #pragma mark Helper methods
@@ -97,7 +98,10 @@
  * to the server. If the onboarding request fails, the error is handled silently(with a log
  * statement).
  */
-- (void)beginSettingsDownload:(FIRCLSDataCollectionToken *)token {
+- (void)beginSettingsDownload:(FIRCLSDataCollectionToken *)token
+            waitForCompletion:(BOOL)waitForCompletion {
+  dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
   FIRCLSDownloadAndSaveSettingsOperation *operation = nil;
   operation = [[FIRCLSDownloadAndSaveSettingsOperation alloc]
         initWithGoogleAppID:self.googleAppID
@@ -110,6 +114,14 @@
                       token:token];
 
   [operation startWithToken:token];
+
+  if (waitForCompletion) {
+    operation.asyncCompletion = ^(NSError *error) {
+      dispatch_semaphore_signal(semaphore);
+    };
+
+    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+  }
 }
 
 - (void)beginOnboarding:(BOOL)appCreate
@@ -148,7 +160,7 @@
   FIRCLSDebugLog(@"Completed configure");
 
   // now, go get settings, as they can change (and it completes the onboarding process)
-  [self beginSettingsDownload:operation.token];
+  [self beginSettingsDownload:operation.token waitForCompletion:NO];
 }
 
 - (void)onboardingOperation:(FIRCLSOnboardingOperation *)operation

--- a/Crashlytics/Crashlytics/Settings/FIRCLSSettingsOnboardingManager.m
+++ b/Crashlytics/Crashlytics/Settings/FIRCLSSettingsOnboardingManager.m
@@ -113,13 +113,15 @@
               networkClient:self.networkClient
                       token:token];
 
-  [operation startWithToken:token];
-
   if (waitForCompletion) {
     operation.asyncCompletion = ^(NSError *error) {
       dispatch_semaphore_signal(semaphore);
     };
+  }
 
+  [operation startWithToken:token];
+
+  if (waitForCompletion) {
     dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
   }
 }


### PR DESCRIPTION
Scenario:
1. Developer has automatic data collection disabled inside the app plist
2. A crash occurred
3. The app relaunches and the developer calls sendUnsentReport

Result:
1. The crash report does not get uploaded because there's a race condition:
 -  Settings is triggered async
 -  The report is not uploaded because the org id from settings is not available

Validation:
1. E2E scenario 
2. Unit tests
3. Verified even when FIRCrashlytics.sendUnsentReport is on the main thread, waiting for the semaphore is not on the main thread.