### PR TITLE
Explicitly state Firestore's dependency on UIKit

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -74,9 +74,9 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.dependency 'leveldb-library', '~> 1.22'
   s.dependency 'nanopb', '~> 0.3.901'
 
-  s.ios.frameworks = 'MobileCoreServices', 'SystemConfiguration'
+  s.ios.frameworks = 'MobileCoreServices', 'SystemConfiguration', 'UIKit'
   s.osx.frameworks = 'SystemConfiguration'
-  s.tvos.frameworks = 'SystemConfiguration'
+  s.tvos.frameworks = 'SystemConfiguration', 'UIKit'
 
   s.library = 'c++'
   s.pod_target_xcconfig = {


### PR DESCRIPTION
In #4985 we added support for listening to
`UIApplicationWillEnterForegroundNotification` notifications to better
handle situations where we may have missed callbacks from
`SCNetworkReachabilitySetCallback` while Firestore was in the background.

Fixes #5065.

@paulb777, should we cherry-pick this into the `release-6.19` branch and bump Firestore to 1.11.2?