### PR TITLE
Remove cleanup of experiments that are no longer running

### DIFF
--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -45,7 +45,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
   s.ios.dependency 'FirebaseAnalyticsInterop', '~> 1.3'
   s.dependency 'FirebaseInstanceID', '~> 4.0'
   s.dependency 'GoogleDataTransportCCTSupport', '~> 2.0'
-  s.dependency 'FirebaseABTesting', '~> 3.2'
+  s.dependency 'FirebaseABTesting', '~> 3.2.0'
 
   s.test_spec 'unit' do |unit_tests|
       unit_tests.source_files = 'FirebaseInAppMessaging/Tests/Unit/*.[mh]'

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -45,7 +45,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
   s.ios.dependency 'FirebaseAnalyticsInterop', '~> 1.3'
   s.dependency 'FirebaseInstanceID', '~> 4.0'
   s.dependency 'GoogleDataTransportCCTSupport', '~> 2.0'
-  s.dependency 'FirebaseABTesting', '~> 3.2.0'
+  s.dependency 'FirebaseABTesting', '~> 3.2'
 
   s.test_spec 'unit' do |unit_tests|
       unit_tests.source_files = 'FirebaseInAppMessaging/Tests/Unit/*.[mh]'

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMMsgFetcherUsingRestful.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMMsgFetcherUsingRestful.m
@@ -25,8 +25,6 @@
 #import "FIRIAMMsgFetcherUsingRestful.h"
 #import "FIRIAMSDKSettings.h"
 
-#import <FirebaseABTesting/FIRExperimentController.h>
-
 static NSInteger const SuccessHTTPStatusCode = 200;
 
 @interface FIRIAMMsgFetcherUsingRestful ()
@@ -186,18 +184,6 @@ static NSInteger const SuccessHTTPStatusCode = 200;
                     FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM130012",
                                 @"API request for fetching messages and parsing the response was "
                                  "successful.");
-
-                    // Validate running experiments with ABT.
-                    NSMutableArray *runningExperiments = [[NSMutableArray alloc] init];
-                    for (FIRIAMMessageDefinition *messageDefinition in messages) {
-                      if (messageDefinition.experimentPayload) {
-                        [runningExperiments addObject:messageDefinition.experimentPayload];
-                      }
-                    }
-
-                    [[FIRExperimentController sharedInstance]
-                        validateRunningExperimentsForServiceOrigin:@"fiam"
-                                         runningExperimentPayloads:[runningExperiments copy]];
 
                     [self.fetchStorage
                         saveResponseDictionary:responseDict


### PR DESCRIPTION
We've made a product decision to not clean these up for now.

Impact: if a user stops an experiment via the console, all events will continue to be striped with the CUP for that experiment.

Also fixed the version number for the ABT dependency, which somehow got reverted. FIAM should update on minor ABT releases.