### PR TITLE
Rename GDTCORStorage to GDTCORFlatFileStorage

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -313,16 +313,15 @@ static NSString *GDTCORFlatFileStoragePath() {
 #pragma mark - NSSecureCoding
 
 /** The NSKeyedCoder key for the storedEvents property. */
-static NSString *const kGDTCORFlatFileStorageStoredEventsKey =
-    @"GDTCORFlatFileStorageStoredEventsKey";
+static NSString *const kGDTCORFlatFileStorageStoredEventsKey = @"GDTCORStorageStoredEventsKey";
 
 /** The NSKeyedCoder key for the targetToEventSet property. */
 static NSString *const kGDTCORFlatFileStorageTargetToEventSetKey =
-    @"GDTCORFlatFileStorageTargetToEventSetKey";
+    @"GDTCORStorageTargetToEventSetKey";
 
 /** The NSKeyedCoder key for the uploadCoordinator property. */
 static NSString *const kGDTCORFlatFileStorageUploadCoordinatorKey =
-    @"GDTCORFlatFileStorageUploadCoordinatorKey";
+    @"GDTCORStorageUploadCoordinatorKey";
 
 + (BOOL)supportsSecureCoding {
   return YES;

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -30,7 +30,7 @@
  *
  * @return The SDK event storage path.
  */
-static NSString *GDTCORStoragePath() {
+static NSString *GDTCORFlatFileStoragePath() {
   static NSString *storagePath;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
@@ -42,28 +42,36 @@ static NSString *GDTCORStoragePath() {
   return storagePath;
 }
 
-@implementation GDTCORStorage
+@implementation GDTCORFlatFileStorage
 
 + (void)load {
   [[GDTCORRegistrar sharedInstance] registerStorage:[self sharedInstance] target:kGDTCORTargetCCT];
   [[GDTCORRegistrar sharedInstance] registerStorage:[self sharedInstance] target:kGDTCORTargetFLL];
   [[GDTCORRegistrar sharedInstance] registerStorage:[self sharedInstance] target:kGDTCORTargetCSH];
+
+  // Sets a global translation mapping to decode GDTCORStoredEvent objects encoded as instances of
+  // GDTCOREvent instead. Then we do the same thing with GDTCORStorage. This must be done in load
+  // because there are no direct references to this class and the NSCoding methods won't be called
+  // unless the class name is mapped early.
+  [NSKeyedUnarchiver setClass:[GDTCOREvent class] forClassName:@"GDTCORStoredEvent"];
+  [NSKeyedUnarchiver setClass:[GDTCORFlatFileStorage class] forClassName:@"GDTCORStorage"];
 }
 
 + (NSString *)archivePath {
   static NSString *archivePath;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    archivePath = [GDTCORStoragePath() stringByAppendingPathComponent:@"GDTCORStorageArchive"];
+    archivePath = [GDTCORFlatFileStoragePath()
+        stringByAppendingPathComponent:@"GDTCORFlatFileStorageArchive"];
   });
   return archivePath;
 }
 
 + (instancetype)sharedInstance {
-  static GDTCORStorage *sharedStorage;
+  static GDTCORFlatFileStorage *sharedStorage;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    sharedStorage = [[GDTCORStorage alloc] init];
+    sharedStorage = [[GDTCORFlatFileStorage alloc] init];
   });
   return sharedStorage;
 }
@@ -71,7 +79,8 @@ static NSString *GDTCORStoragePath() {
 - (instancetype)init {
   self = [super init];
   if (self) {
-    _storageQueue = dispatch_queue_create("com.google.GDTCORStorage", DISPATCH_QUEUE_SERIAL);
+    _storageQueue =
+        dispatch_queue_create("com.google.GDTCORFlatFileStorage", DISPATCH_QUEUE_SERIAL);
     _targetToEventSet = [[NSMutableDictionary alloc] init];
     _storedEvents = [[NSMutableDictionary alloc] init];
     _uploadCoordinator = [GDTCORUploadCoordinator sharedInstance];
@@ -143,10 +152,10 @@ static NSString *GDTCORStoragePath() {
         NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self
                                              requiringSecureCoding:YES
                                                              error:&error];
-        [data writeToFile:[GDTCORStorage archivePath] atomically:YES];
+        [data writeToFile:[GDTCORFlatFileStorage archivePath] atomically:YES];
       } else {
 #if !TARGET_OS_MACCATALYST && !TARGET_OS_WATCH
-        [NSKeyedArchiver archiveRootObject:self toFile:[GDTCORStorage archivePath]];
+        [NSKeyedArchiver archiveRootObject:self toFile:[GDTCORFlatFileStorage archivePath]];
 #endif
       }
     }
@@ -187,7 +196,7 @@ static NSString *GDTCORStoragePath() {
 /** Creates the storage directory if it does not exist. */
 - (void)createEventDirectoryIfNotExists {
   NSError *error;
-  BOOL result = [[NSFileManager defaultManager] createDirectoryAtPath:GDTCORStoragePath()
+  BOOL result = [[NSFileManager defaultManager] createDirectoryAtPath:GDTCORFlatFileStoragePath()
                                           withIntermediateDirectories:YES
                                                            attributes:0
                                                                 error:&error];
@@ -208,7 +217,7 @@ static NSString *GDTCORStoragePath() {
 - (NSURL *)saveEventBytesToDisk:(GDTCOREvent *)event
                       eventHash:(NSUInteger)eventHash
                           error:(NSError **)error {
-  NSString *storagePath = GDTCORStoragePath();
+  NSString *storagePath = GDTCORFlatFileStoragePath();
   NSString *eventFileName = [NSString stringWithFormat:@"event-%lu", (unsigned long)eventHash];
   NSURL *eventFilePath =
       [NSURL fileURLWithPath:[storagePath stringByAppendingPathComponent:eventFileName]];
@@ -242,15 +251,15 @@ static NSString *GDTCORStoragePath() {
   dispatch_async(_storageQueue, ^{
     if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
       NSError *error;
-      NSData *data = [NSData dataWithContentsOfFile:[GDTCORStorage archivePath]];
+      NSData *data = [NSData dataWithContentsOfFile:[GDTCORFlatFileStorage archivePath]];
       if (data) {
-        [NSKeyedUnarchiver unarchivedObjectOfClass:[GDTCORStorage class]
+        [NSKeyedUnarchiver unarchivedObjectOfClass:[GDTCORFlatFileStorage class]
                                           fromData:data
                                              error:&error];
       }
     } else {
 #if !TARGET_OS_MACCATALYST && !TARGET_OS_WATCH
-      [NSKeyedUnarchiver unarchiveObjectWithFile:[GDTCORStorage archivePath]];
+      [NSKeyedUnarchiver unarchiveObjectWithFile:[GDTCORFlatFileStorage archivePath]];
 #endif
     }
   });
@@ -272,10 +281,10 @@ static NSString *GDTCORStoragePath() {
       NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self
                                            requiringSecureCoding:YES
                                                            error:&error];
-      [data writeToFile:[GDTCORStorage archivePath] atomically:YES];
+      [data writeToFile:[GDTCORFlatFileStorage archivePath] atomically:YES];
     } else {
 #if !TARGET_OS_MACCATALYST && !TARGET_OS_WATCH
-      [NSKeyedArchiver archiveRootObject:self toFile:[GDTCORStorage archivePath]];
+      [NSKeyedArchiver archiveRootObject:self toFile:[GDTCORFlatFileStorage archivePath]];
 #endif
     }
 
@@ -292,10 +301,10 @@ static NSString *GDTCORStoragePath() {
       NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self
                                            requiringSecureCoding:YES
                                                            error:&error];
-      [data writeToFile:[GDTCORStorage archivePath] atomically:YES];
+      [data writeToFile:[GDTCORFlatFileStorage archivePath] atomically:YES];
     } else {
 #if !TARGET_OS_MACCATALYST && !TARGET_OS_WATCH
-      [NSKeyedArchiver archiveRootObject:self toFile:[GDTCORStorage archivePath]];
+      [NSKeyedArchiver archiveRootObject:self toFile:[GDTCORFlatFileStorage archivePath]];
 #endif
     }
   });
@@ -304,28 +313,28 @@ static NSString *GDTCORStoragePath() {
 #pragma mark - NSSecureCoding
 
 /** The NSKeyedCoder key for the storedEvents property. */
-static NSString *const kGDTCORStorageStoredEventsKey = @"GDTCORStorageStoredEventsKey";
+static NSString *const kGDTCORFlatFileStorageStoredEventsKey =
+    @"GDTCORFlatFileStorageStoredEventsKey";
 
 /** The NSKeyedCoder key for the targetToEventSet property. */
-static NSString *const kGDTCORStorageTargetToEventSetKey = @"GDTCORStorageTargetToEventSetKey";
+static NSString *const kGDTCORFlatFileStorageTargetToEventSetKey =
+    @"GDTCORFlatFileStorageTargetToEventSetKey";
 
 /** The NSKeyedCoder key for the uploadCoordinator property. */
-static NSString *const kGDTCORStorageUploadCoordinatorKey = @"GDTCORStorageUploadCoordinatorKey";
+static NSString *const kGDTCORFlatFileStorageUploadCoordinatorKey =
+    @"GDTCORFlatFileStorageUploadCoordinatorKey";
 
 + (BOOL)supportsSecureCoding {
   return YES;
 }
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder {
-  // Sets a global translation mapping to decode GDTCORStoredEvent objects encoded as instances of
-  // GDTCOREvent instead.
-  [NSKeyedUnarchiver setClass:[GDTCOREvent class] forClassName:@"GDTCORStoredEvent"];
-
   // Create the singleton and populate its ivars.
-  GDTCORStorage *sharedInstance = [self.class sharedInstance];
+  GDTCORFlatFileStorage *sharedInstance = [self.class sharedInstance];
   NSSet *classes = [NSSet setWithObjects:[NSMutableOrderedSet class], [NSMutableDictionary class],
                                          [GDTCOREvent class], nil];
-  id storedEvents = [aDecoder decodeObjectOfClasses:classes forKey:kGDTCORStorageStoredEventsKey];
+  id storedEvents = [aDecoder decodeObjectOfClasses:classes
+                                             forKey:kGDTCORFlatFileStorageStoredEventsKey];
   NSMutableDictionary<NSNumber *, GDTCOREvent *> *events = [[NSMutableDictionary alloc] init];
   if ([storedEvents isKindOfClass:[NSMutableOrderedSet class]]) {
     [(NSMutableOrderedSet *)storedEvents
@@ -340,27 +349,27 @@ static NSString *const kGDTCORStorageUploadCoordinatorKey = @"GDTCORStorageUploa
   classes = [NSSet
       setWithObjects:[NSMutableDictionary class], [NSMutableSet class], [GDTCOREvent class], nil];
   sharedInstance->_targetToEventSet =
-      [aDecoder decodeObjectOfClasses:classes forKey:kGDTCORStorageTargetToEventSetKey];
+      [aDecoder decodeObjectOfClasses:classes forKey:kGDTCORFlatFileStorageTargetToEventSetKey];
   sharedInstance->_uploadCoordinator =
       [aDecoder decodeObjectOfClass:[GDTCORUploadCoordinator class]
-                             forKey:kGDTCORStorageUploadCoordinatorKey];
+                             forKey:kGDTCORFlatFileStorageUploadCoordinatorKey];
   return sharedInstance;
 }
 
 - (void)encodeWithCoder:(NSCoder *)aCoder {
-  GDTCORStorage *sharedInstance = [self.class sharedInstance];
+  GDTCORFlatFileStorage *sharedInstance = [self.class sharedInstance];
   NSMutableDictionary<NSNumber *, GDTCOREvent *> *storedEvents = sharedInstance->_storedEvents;
   if (storedEvents) {
-    [aCoder encodeObject:storedEvents forKey:kGDTCORStorageStoredEventsKey];
+    [aCoder encodeObject:storedEvents forKey:kGDTCORFlatFileStorageStoredEventsKey];
   }
   NSMutableDictionary<NSNumber *, NSMutableSet<GDTCOREvent *> *> *targetToEventSet =
       sharedInstance->_targetToEventSet;
   if (targetToEventSet) {
-    [aCoder encodeObject:targetToEventSet forKey:kGDTCORStorageTargetToEventSetKey];
+    [aCoder encodeObject:targetToEventSet forKey:kGDTCORFlatFileStorageTargetToEventSetKey];
   }
   GDTCORUploadCoordinator *uploadCoordinator = sharedInstance->_uploadCoordinator;
   if (uploadCoordinator) {
-    [aCoder encodeObject:uploadCoordinator forKey:kGDTCORStorageUploadCoordinatorKey];
+    [aCoder encodeObject:uploadCoordinator forKey:kGDTCORFlatFileStorageUploadCoordinatorKey];
   }
 }
 

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage.h
@@ -25,7 +25,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** Manages the storage of events. This class is thread-safe. */
-@interface GDTCORStorage : NSObject <NSSecureCoding, GDTCORStorageProtocol, GDTCORLifecycleProtocol>
+@interface GDTCORFlatFileStorage
+    : NSObject <NSSecureCoding, GDTCORStorageProtocol, GDTCORLifecycleProtocol>
 
 /** The queue on which all storage work will occur. */
 @property(nonatomic) dispatch_queue_t storageQueue;

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORLifecycle.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORLifecycle.h
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * When backgrounding, the library doesn't stop processing events, it's just that several background
  * tasks will end up being created for every event that's sent, and the stateful objects of the
- * library (GDTCORStorage and GDTCORUploadCoordinator singletons) will deserialize themselves from
+ * library (GDTCORStorage and GDTCORUploadCoordinator instances) will deserialize themselves from
  * and to disk before and after every operation, respectively.
  */
 @interface GDTCORLifecycle : NSObject <GDTCORApplicationDelegate>

--- a/GoogleDataTransport/GDTCORTests/Common/Categories/GDTCORFlatFileStorage+Testing.h
+++ b/GoogleDataTransport/GDTCORTests/Common/Categories/GDTCORFlatFileStorage+Testing.h
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-#import "GDTCORTests/Common/Categories/GDTCORStorage+Testing.h"
+#import <Foundation/Foundation.h>
 
-#import <GoogleDataTransport/GDTCORClock.h>
-#import <GoogleDataTransport/GDTCOREvent.h>
+#import "GDTCORLibrary/Private/GDTCORFlatFileStorage.h"
 
-@implementation GDTCORStorage (Testing)
+NS_ASSUME_NONNULL_BEGIN
 
-- (void)reset {
-  dispatch_sync(self.storageQueue, ^{
-    [self.targetToEventSet removeAllObjects];
-    [self.storedEvents removeAllObjects];
-    NSError *error;
-    [[NSFileManager defaultManager] removeItemAtPath:[GDTCORStorage archivePath] error:&error];
-  });
-}
+/** Testing-only methods for GDTCORFlatFileStorage. */
+@interface GDTCORFlatFileStorage (Testing)
+
+/** Resets the properties of the singleon, but does not reallocate a new singleton. This also
+ * doesn't remove stored files from disk.
+ */
+- (void)reset;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleDataTransport/GDTCORTests/Common/Categories/GDTCORFlatFileStorage+Testing.m
+++ b/GoogleDataTransport/GDTCORTests/Common/Categories/GDTCORFlatFileStorage+Testing.m
@@ -14,20 +14,21 @@
  * limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
+#import "GDTCORTests/Common/Categories/GDTCORFlatFileStorage+Testing.h"
 
-#import "GDTCORLibrary/Private/GDTCORFlatFileStorage.h"
+#import <GoogleDataTransport/GDTCORClock.h>
+#import <GoogleDataTransport/GDTCOREvent.h>
 
-NS_ASSUME_NONNULL_BEGIN
+@implementation GDTCORFlatFileStorage (Testing)
 
-/** Testing-only methods for GDTCORStorage. */
-@interface GDTCORStorage (Testing)
-
-/** Resets the properties of the singleon, but does not reallocate a new singleton. This also
- * doesn't remove stored files from disk.
- */
-- (void)reset;
+- (void)reset {
+  dispatch_sync(self.storageQueue, ^{
+    [self.targetToEventSet removeAllObjects];
+    [self.storedEvents removeAllObjects];
+    NSError *error;
+    [[NSFileManager defaultManager] removeItemAtPath:[GDTCORFlatFileStorage archivePath]
+                                               error:&error];
+  });
+}
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/GoogleDataTransport/GDTCORTests/Integration/GDTCORIntegrationTest.m
+++ b/GoogleDataTransport/GDTCORTests/Integration/GDTCORIntegrationTest.m
@@ -81,8 +81,8 @@
 @implementation GDTCORIntegrationTest
 
 - (void)tearDown {
-  dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
-    XCTAssertEqual([GDTCORStorage sharedInstance].storedEvents.count, 0);
+  dispatch_sync([GDTCORFlatFileStorage sharedInstance].storageQueue, ^{
+    XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].storedEvents.count, 0);
   });
 }
 
@@ -91,7 +91,7 @@
   expectation.assertForOverFulfill = NO;
 
   // Register storage to handle the test target.
-  [[GDTCORRegistrar sharedInstance] registerStorage:[GDTCORStorage sharedInstance]
+  [[GDTCORRegistrar sharedInstance] registerStorage:[GDTCORFlatFileStorage sharedInstance]
                                              target:kGDTCORTargetTest];
 
   // Manually set the reachability flag.
@@ -125,8 +125,8 @@
   [GDTCORUploadCoordinator sharedInstance].timerLeeway = NSEC_PER_SEC * 0.01;
 
   // Confirm no events are in disk.
-  XCTAssertEqual([GDTCORStorage sharedInstance].storedEvents.count, 0);
-  XCTAssertEqual([GDTCORStorage sharedInstance].targetToEventSet.count, 0);
+  XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].storedEvents.count, 0);
+  XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].targetToEventSet.count, 0);
 
   // Generate some events data.
   [self generateEvents];
@@ -136,9 +136,9 @@
                 });
 
   // Confirm events are on disk.
-  dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
-    XCTAssertGreaterThan([GDTCORStorage sharedInstance].storedEvents.count, 0);
-    XCTAssertGreaterThan([GDTCORStorage sharedInstance].targetToEventSet.count, 0);
+  dispatch_sync([GDTCORFlatFileStorage sharedInstance].storageQueue, ^{
+    XCTAssertGreaterThan([GDTCORFlatFileStorage sharedInstance].storedEvents.count, 0);
+    XCTAssertGreaterThan([GDTCORFlatFileStorage sharedInstance].targetToEventSet.count, 0);
   });
 
   // Confirm events were sent and received.

--- a/GoogleDataTransport/GDTCORTests/Lifecycle/GDTCORLifecycleTest.m
+++ b/GoogleDataTransport/GDTCORTests/Lifecycle/GDTCORLifecycleTest.m
@@ -26,8 +26,8 @@
 #import "GDTCORTests/Lifecycle/Helpers/GDTCORLifecycleTestPrioritizer.h"
 #import "GDTCORTests/Lifecycle/Helpers/GDTCORLifecycleTestUploader.h"
 
+#import "GDTCORTests/Common/Categories/GDTCORFlatFileStorage+Testing.h"
 #import "GDTCORTests/Common/Categories/GDTCORRegistrar+Testing.h"
-#import "GDTCORTests/Common/Categories/GDTCORStorage+Testing.h"
 #import "GDTCORTests/Common/Categories/GDTCORUploadCoordinator+Testing.h"
 
 /** Waits for the result of waitBlock to be YES, or times out and fails.
@@ -78,18 +78,19 @@
 
 - (void)setUp {
   [super setUp];
-  [[GDTCORRegistrar sharedInstance] registerStorage:[GDTCORStorage sharedInstance]
+  [[GDTCORRegistrar sharedInstance] registerStorage:[GDTCORFlatFileStorage sharedInstance]
                                              target:kGDTCORTargetTest];
 
   // Don't check the error, because it'll be populated in cases where the file doesn't exist.
   NSError *error;
-  [[NSFileManager defaultManager] removeItemAtPath:[GDTCORStorage archivePath] error:&error];
+  [[NSFileManager defaultManager] removeItemAtPath:[GDTCORFlatFileStorage archivePath]
+                                             error:&error];
   self.uploader = [[GDTCORLifecycleTestUploader alloc] init];
   [[GDTCORRegistrar sharedInstance] registerUploader:self.uploader target:kGDTCORTargetTest];
 
   self.prioritizer = [[GDTCORLifecycleTestPrioritizer alloc] init];
   [[GDTCORRegistrar sharedInstance] registerPrioritizer:self.prioritizer target:kGDTCORTargetTest];
-  [[GDTCORStorage sharedInstance] reset];
+  [[GDTCORFlatFileStorage sharedInstance] reset];
   [[GDTCORUploadCoordinator sharedInstance] reset];
 }
 
@@ -103,11 +104,11 @@
                                                                    target:kGDTCORTargetTest];
   GDTCOREvent *event = [transport eventForTransport];
   event.dataObject = [[GDTCORLifecycleTestEvent alloc] init];
-  XCTAssertEqual([GDTCORStorage sharedInstance].storedEvents.count, 0);
+  XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].storedEvents.count, 0);
   [transport sendDataEvent:event];
   GDTCORWaitForBlock(
       ^BOOL {
-        return [GDTCORStorage sharedInstance].storedEvents.count > 0;
+        return [GDTCORFlatFileStorage sharedInstance].storedEvents.count > 0;
       },
       5.0);
 
@@ -118,7 +119,7 @@
   GDTCORWaitForBlock(
       ^BOOL {
         NSFileManager *fm = [NSFileManager defaultManager];
-        return [fm fileExistsAtPath:[GDTCORStorage archivePath] isDirectory:NULL];
+        return [fm fileExistsAtPath:[GDTCORFlatFileStorage archivePath] isDirectory:NULL];
       },
       5.0);
 }
@@ -130,11 +131,11 @@
                                                                    target:kGDTCORTargetTest];
   GDTCOREvent *event = [transport eventForTransport];
   event.dataObject = [[GDTCORLifecycleTestEvent alloc] init];
-  XCTAssertEqual([GDTCORStorage sharedInstance].storedEvents.count, 0);
+  XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].storedEvents.count, 0);
   [transport sendDataEvent:event];
   GDTCORWaitForBlock(
       ^BOOL {
-        return [GDTCORStorage sharedInstance].storedEvents.count > 0;
+        return [GDTCORFlatFileStorage sharedInstance].storedEvents.count > 0;
       },
       5.0);
 
@@ -144,7 +145,7 @@
   GDTCORWaitForBlock(
       ^BOOL {
         NSFileManager *fm = [NSFileManager defaultManager];
-        return [fm fileExistsAtPath:[GDTCORStorage archivePath] isDirectory:NULL];
+        return [fm fileExistsAtPath:[GDTCORFlatFileStorage archivePath] isDirectory:NULL];
       },
       5.0);
 
@@ -153,7 +154,7 @@
   XCTAssertFalse([GDTCORApplication sharedApplication].isRunningInBackground);
   GDTCORWaitForBlock(
       ^BOOL {
-        return [GDTCORStorage sharedInstance].storedEvents.count > 0;
+        return [GDTCORFlatFileStorage sharedInstance].storedEvents.count > 0;
       },
       5.0);
 }
@@ -166,11 +167,11 @@
                                                                    target:kGDTCORTargetTest];
   GDTCOREvent *event = [transport eventForTransport];
   event.dataObject = [[GDTCORLifecycleTestEvent alloc] init];
-  XCTAssertEqual([GDTCORStorage sharedInstance].storedEvents.count, 0);
+  XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].storedEvents.count, 0);
   [transport sendDataEvent:event];
   GDTCORWaitForBlock(
       ^BOOL {
-        return [GDTCORStorage sharedInstance].storedEvents.count > 0;
+        return [GDTCORFlatFileStorage sharedInstance].storedEvents.count > 0;
       },
       5.0);
 
@@ -179,7 +180,7 @@
   GDTCORWaitForBlock(
       ^BOOL {
         NSFileManager *fm = [NSFileManager defaultManager];
-        return [fm fileExistsAtPath:[GDTCORStorage archivePath] isDirectory:NULL];
+        return [fm fileExistsAtPath:[GDTCORFlatFileStorage archivePath] isDirectory:NULL];
       },
       5.0);
 }

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
@@ -438,8 +438,9 @@ static NSInteger target = kGDTCORTargetCCT;
 }
 
 /** Fuzz tests the storing of events at the same time as a terminate lifecycle notification. This
- * test can fail if there's simultaneous access to ivars of GDTCORStorage with one access being
- * off the storage's queue. The terminate lifecycle event should operate on and flush the queue.
+ * test can fail if there's simultaneous access to ivars of GDTCORFlatFileStorage with one access
+ * being off the storage's queue. The terminate lifecycle event should operate on and flush the
+ * queue.
  */
 - (void)testStoringEventsDuringTerminate {
   int numberOfIterations = 1000;

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
@@ -29,12 +29,12 @@
 
 #import "GDTCORTests/Common/Fakes/GDTCORUploadCoordinatorFake.h"
 
+#import "GDTCORTests/Common/Categories/GDTCORFlatFileStorage+Testing.h"
 #import "GDTCORTests/Common/Categories/GDTCORRegistrar+Testing.h"
-#import "GDTCORTests/Common/Categories/GDTCORStorage+Testing.h"
 
 static NSInteger target = kGDTCORTargetCCT;
 
-@interface GDTCORStorageTest : GDTCORTestCase
+@interface GDTCORFlatFileStorageTest : GDTCORTestCase
 
 /** The test backend implementation. */
 @property(nullable, nonatomic) GDTCORTestUploader *testBackend;
@@ -47,7 +47,7 @@ static NSInteger target = kGDTCORTargetCCT;
 
 @end
 
-@implementation GDTCORStorageTest
+@implementation GDTCORFlatFileStorageTest
 
 - (void)setUp {
   [super setUp];
@@ -56,25 +56,26 @@ static NSInteger target = kGDTCORTargetCCT;
   [[GDTCORRegistrar sharedInstance] registerUploader:_testBackend target:target];
   [[GDTCORRegistrar sharedInstance] registerPrioritizer:_testPrioritizer target:target];
   self.uploaderFake = [[GDTCORUploadCoordinatorFake alloc] init];
-  [GDTCORStorage sharedInstance].uploadCoordinator = self.uploaderFake;
+  [GDTCORFlatFileStorage sharedInstance].uploadCoordinator = self.uploaderFake;
 }
 
 - (void)tearDown {
   [super tearDown];
-  dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
+  dispatch_sync([GDTCORFlatFileStorage sharedInstance].storageQueue, ^{
                 });
   // Destroy these objects before the next test begins.
   self.testBackend = nil;
   self.testPrioritizer = nil;
   [[GDTCORRegistrar sharedInstance] reset];
-  [[GDTCORStorage sharedInstance] reset];
-  [GDTCORStorage sharedInstance].uploadCoordinator = [GDTCORUploadCoordinator sharedInstance];
+  [[GDTCORFlatFileStorage sharedInstance] reset];
+  [GDTCORFlatFileStorage sharedInstance].uploadCoordinator =
+      [GDTCORUploadCoordinator sharedInstance];
   self.uploaderFake = nil;
 }
 
 /** Tests the singleton pattern. */
 - (void)testInit {
-  XCTAssertEqual([GDTCORStorage sharedInstance], [GDTCORStorage sharedInstance]);
+  XCTAssertEqual([GDTCORFlatFileStorage sharedInstance], [GDTCORFlatFileStorage sharedInstance]);
 }
 
 /** Tests storing an event. */
@@ -83,17 +84,18 @@ static NSInteger target = kGDTCORTargetCCT;
   event.dataObject = [[GDTCORDataObjectTesterSimple alloc] initWithString:@"testString"];
   event.clockSnapshot = [GDTCORClock snapshot];
   XCTestExpectation *writtenExpectation = [self expectationWithDescription:@"event written"];
-  XCTAssertNoThrow([[GDTCORStorage sharedInstance] storeEvent:event
-                                                   onComplete:^(NSError *error) {
-                                                     XCTAssertNotEqualObjects(event.eventID, @0);
-                                                     XCTAssertNil(error);
-                                                     [writtenExpectation fulfill];
-                                                   }]);
+  XCTAssertNoThrow([[GDTCORFlatFileStorage sharedInstance] storeEvent:event
+                                                           onComplete:^(NSError *error) {
+                                                             XCTAssertNotEqualObjects(event.eventID,
+                                                                                      @0);
+                                                             XCTAssertNil(error);
+                                                             [writtenExpectation fulfill];
+                                                           }]);
   [self waitForExpectations:@[ writtenExpectation ] timeout:10.0];
 
-  dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
-    XCTAssertEqual([GDTCORStorage sharedInstance].storedEvents.count, 1);
-    XCTAssertEqual([GDTCORStorage sharedInstance].targetToEventSet[@(target)].count, 1);
+  dispatch_sync([GDTCORFlatFileStorage sharedInstance].storageQueue, ^{
+    XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].storedEvents.count, 1);
+    XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].targetToEventSet[@(target)].count, 1);
     NSURL *eventFile = event.fileURL;
     XCTAssertNotNil(eventFile);
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:eventFile.path]);
@@ -109,63 +111,68 @@ static NSInteger target = kGDTCORTargetCCT;
   event.dataObject = [[GDTCORDataObjectTesterSimple alloc] initWithString:@"testString"];
   event.clockSnapshot = [GDTCORClock snapshot];
   XCTestExpectation *writtenExpectation = [self expectationWithDescription:@"event written"];
-  XCTAssertNoThrow([[GDTCORStorage sharedInstance] storeEvent:event
-                                                   onComplete:^(NSError *error) {
-                                                     XCTAssertNotEqualObjects(event.eventID, @0);
-                                                     XCTAssertNil(error);
-                                                     [writtenExpectation fulfill];
-                                                   }]);
+  XCTAssertNoThrow([[GDTCORFlatFileStorage sharedInstance] storeEvent:event
+                                                           onComplete:^(NSError *error) {
+                                                             XCTAssertNotEqualObjects(event.eventID,
+                                                                                      @0);
+                                                             XCTAssertNil(error);
+                                                             [writtenExpectation fulfill];
+                                                           }]);
   [self waitForExpectations:@[ writtenExpectation ] timeout:10.0];
 
   __block NSURL *eventFile;
-  dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
+  dispatch_sync([GDTCORFlatFileStorage sharedInstance].storageQueue, ^{
     eventFile = event.fileURL;
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:eventFile.path]);
   });
-  NSSet *eventIDs = [NSSet setWithArray:[[GDTCORStorage sharedInstance].storedEvents allKeys]];
-  [[GDTCORStorage sharedInstance] removeEvents:eventIDs];
-  dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
+  NSSet *eventIDs =
+      [NSSet setWithArray:[[GDTCORFlatFileStorage sharedInstance].storedEvents allKeys]];
+  [[GDTCORFlatFileStorage sharedInstance] removeEvents:eventIDs];
+  dispatch_sync([GDTCORFlatFileStorage sharedInstance].storageQueue, ^{
     XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:eventFile.path]);
-    XCTAssertEqual([GDTCORStorage sharedInstance].storedEvents.count, 0);
-    XCTAssertEqual([GDTCORStorage sharedInstance].targetToEventSet[@(target)].count, 0);
+    XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].storedEvents.count, 0);
+    XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].targetToEventSet[@(target)].count, 0);
   });
 }
 
 /** Tests removing a set of events. */
 - (void)testRemoveEvents {
-  GDTCORStorage *storage = [GDTCORStorage sharedInstance];
+  GDTCORFlatFileStorage *storage = [GDTCORFlatFileStorage sharedInstance];
 
   GDTCOREvent *event1 = [[GDTCOREvent alloc] initWithMappingID:@"404" target:target];
   event1.dataObject = [[GDTCORDataObjectTesterSimple alloc] initWithString:@"testString1"];
   XCTestExpectation *writtenExpectation = [self expectationWithDescription:@"event written"];
-  XCTAssertNoThrow([[GDTCORStorage sharedInstance] storeEvent:event1
-                                                   onComplete:^(NSError *error) {
-                                                     XCTAssertNotEqualObjects(event1.eventID, @0);
-                                                     XCTAssertNil(error);
-                                                     [writtenExpectation fulfill];
-                                                   }]);
+  XCTAssertNoThrow([[GDTCORFlatFileStorage sharedInstance] storeEvent:event1
+                                                           onComplete:^(NSError *error) {
+                                                             XCTAssertNotEqualObjects(
+                                                                 event1.eventID, @0);
+                                                             XCTAssertNil(error);
+                                                             [writtenExpectation fulfill];
+                                                           }]);
   [self waitForExpectations:@[ writtenExpectation ] timeout:10.0];
 
   GDTCOREvent *event2 = [[GDTCOREvent alloc] initWithMappingID:@"100" target:target];
   event2.dataObject = [[GDTCORDataObjectTesterSimple alloc] initWithString:@"testString2"];
   writtenExpectation = [self expectationWithDescription:@"event written"];
-  XCTAssertNoThrow([[GDTCORStorage sharedInstance] storeEvent:event2
-                                                   onComplete:^(NSError *error) {
-                                                     XCTAssertNotEqualObjects(event2.eventID, @0);
-                                                     XCTAssertNil(error);
-                                                     [writtenExpectation fulfill];
-                                                   }]);
+  XCTAssertNoThrow([[GDTCORFlatFileStorage sharedInstance] storeEvent:event2
+                                                           onComplete:^(NSError *error) {
+                                                             XCTAssertNotEqualObjects(
+                                                                 event2.eventID, @0);
+                                                             XCTAssertNil(error);
+                                                             [writtenExpectation fulfill];
+                                                           }]);
   [self waitForExpectations:@[ writtenExpectation ] timeout:10.0];
 
   GDTCOREvent *event3 = [[GDTCOREvent alloc] initWithMappingID:@"404" target:target];
   event3.dataObject = [[GDTCORDataObjectTesterSimple alloc] initWithString:@"testString3"];
   writtenExpectation = [self expectationWithDescription:@"event written"];
-  XCTAssertNoThrow([[GDTCORStorage sharedInstance] storeEvent:event3
-                                                   onComplete:^(NSError *error) {
-                                                     XCTAssertNotEqualObjects(event3.eventID, @0);
-                                                     XCTAssertNil(error);
-                                                     [writtenExpectation fulfill];
-                                                   }]);
+  XCTAssertNoThrow([[GDTCORFlatFileStorage sharedInstance] storeEvent:event3
+                                                           onComplete:^(NSError *error) {
+                                                             XCTAssertNotEqualObjects(
+                                                                 event3.eventID, @0);
+                                                             XCTAssertNil(error);
+                                                             [writtenExpectation fulfill];
+                                                           }]);
   [self waitForExpectations:@[ writtenExpectation ] timeout:10.0];
 
   NSSet<NSNumber *> *eventIDSet =
@@ -188,42 +195,45 @@ static NSInteger target = kGDTCORTargetCCT;
   GDTCOREvent *event1 = [[GDTCOREvent alloc] initWithMappingID:@"404" target:target];
   event1.dataObject = [[GDTCORDataObjectTesterSimple alloc] initWithString:@"testString1"];
   XCTestExpectation *writtenExpectation = [self expectationWithDescription:@"event written"];
-  XCTAssertNoThrow([[GDTCORStorage sharedInstance] storeEvent:event1
-                                                   onComplete:^(NSError *error) {
-                                                     XCTAssertNotEqualObjects(event1.eventID, @0);
-                                                     XCTAssertNil(error);
-                                                     [writtenExpectation fulfill];
-                                                   }]);
+  XCTAssertNoThrow([[GDTCORFlatFileStorage sharedInstance] storeEvent:event1
+                                                           onComplete:^(NSError *error) {
+                                                             XCTAssertNotEqualObjects(
+                                                                 event1.eventID, @0);
+                                                             XCTAssertNil(error);
+                                                             [writtenExpectation fulfill];
+                                                           }]);
   [self waitForExpectations:@[ writtenExpectation ] timeout:10.0];
   XCTAssertNotNil(event1.fileURL);
 
   GDTCOREvent *event2 = [[GDTCOREvent alloc] initWithMappingID:@"100" target:target];
   event2.dataObject = [[GDTCORDataObjectTesterSimple alloc] initWithString:@"testString2"];
   writtenExpectation = [self expectationWithDescription:@"event written"];
-  XCTAssertNoThrow([[GDTCORStorage sharedInstance] storeEvent:event2
-                                                   onComplete:^(NSError *error) {
-                                                     XCTAssertNotEqualObjects(event2.eventID, @0);
-                                                     XCTAssertNil(error);
-                                                     [writtenExpectation fulfill];
-                                                   }]);
+  XCTAssertNoThrow([[GDTCORFlatFileStorage sharedInstance] storeEvent:event2
+                                                           onComplete:^(NSError *error) {
+                                                             XCTAssertNotEqualObjects(
+                                                                 event2.eventID, @0);
+                                                             XCTAssertNil(error);
+                                                             [writtenExpectation fulfill];
+                                                           }]);
   [self waitForExpectations:@[ writtenExpectation ] timeout:10.0];
   XCTAssertNotNil(event2.fileURL);
 
   GDTCOREvent *event3 = [[GDTCOREvent alloc] initWithMappingID:@"404" target:target];
   event3.dataObject = [[GDTCORDataObjectTesterSimple alloc] initWithString:@"testString3"];
   writtenExpectation = [self expectationWithDescription:@"event written"];
-  XCTAssertNoThrow([[GDTCORStorage sharedInstance] storeEvent:event3
-                                                   onComplete:^(NSError *error) {
-                                                     XCTAssertNotEqualObjects(event3.eventID, @0);
-                                                     XCTAssertNil(error);
-                                                     [writtenExpectation fulfill];
-                                                   }]);
+  XCTAssertNoThrow([[GDTCORFlatFileStorage sharedInstance] storeEvent:event3
+                                                           onComplete:^(NSError *error) {
+                                                             XCTAssertNotEqualObjects(
+                                                                 event3.eventID, @0);
+                                                             XCTAssertNil(error);
+                                                             [writtenExpectation fulfill];
+                                                           }]);
   [self waitForExpectations:@[ writtenExpectation ] timeout:10.0];
   XCTAssertNotNil(event3.fileURL);
 
-  dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
-    XCTAssertEqual([GDTCORStorage sharedInstance].storedEvents.count, 3);
-    XCTAssertEqual([GDTCORStorage sharedInstance].targetToEventSet[@(target)].count, 3);
+  dispatch_sync([GDTCORFlatFileStorage sharedInstance].storageQueue, ^{
+    XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].storedEvents.count, 3);
+    XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].targetToEventSet[@(target)].count, 3);
 
     NSURL *event1File = event1.fileURL;
     XCTAssertNotNil(event1File);
@@ -261,15 +271,16 @@ static NSInteger target = kGDTCORTargetCCT;
     event.clockSnapshot = [GDTCORClock snapshot];
     // Store the event and wait for the expectation.
     XCTestExpectation *writtenExpectation = [self expectationWithDescription:@"event written"];
-    XCTAssertNoThrow([[GDTCORStorage sharedInstance] storeEvent:event
-                                                     onComplete:^(NSError *error) {
-                                                       XCTAssertNotEqualObjects(event.eventID, @0);
-                                                       XCTAssertNil(error);
-                                                       [writtenExpectation fulfill];
-                                                     }]);
+    XCTAssertNoThrow([[GDTCORFlatFileStorage sharedInstance] storeEvent:event
+                                                             onComplete:^(NSError *error) {
+                                                               XCTAssertNotEqualObjects(
+                                                                   event.eventID, @0);
+                                                               XCTAssertNil(error);
+                                                               [writtenExpectation fulfill];
+                                                             }]);
     [self waitForExpectations:@[ writtenExpectation ] timeout:10.0];
   }
-  dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
+  dispatch_sync([GDTCORFlatFileStorage sharedInstance].storageQueue, ^{
     XCTAssertNil(weakDataObjectTransportBytes);
     XCTAssertNotNil(event);
   });
@@ -277,58 +288,63 @@ static NSInteger target = kGDTCORTargetCCT;
   NSURL *eventFile = event.fileURL;
 
   // This isn't strictly necessary because of the -waitForExpectations above.
-  dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
+  dispatch_sync([GDTCORFlatFileStorage sharedInstance].storageQueue, ^{
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:eventFile.path]);
   });
 
   // Ensure event was removed.
-  NSSet *eventIDs = [NSSet setWithArray:[[GDTCORStorage sharedInstance].storedEvents allKeys]];
-  [[GDTCORStorage sharedInstance] removeEvents:eventIDs];
-  dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
+  NSSet *eventIDs =
+      [NSSet setWithArray:[[GDTCORFlatFileStorage sharedInstance].storedEvents allKeys]];
+  [[GDTCORFlatFileStorage sharedInstance] removeEvents:eventIDs];
+  dispatch_sync([GDTCORFlatFileStorage sharedInstance].storageQueue, ^{
     XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:eventFile.path]);
-    XCTAssertEqual([GDTCORStorage sharedInstance].storedEvents.count, 0);
-    XCTAssertEqual([GDTCORStorage sharedInstance].targetToEventSet[@(target)].count, 0);
+    XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].storedEvents.count, 0);
+    XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].targetToEventSet[@(target)].count, 0);
   });
 }
 
 /** Tests encoding and decoding the storage singleton correctly. */
 - (void)testNSSecureCoding {
-  XCTAssertTrue([GDTCORStorage supportsSecureCoding]);
+  XCTAssertTrue([GDTCORFlatFileStorage supportsSecureCoding]);
   GDTCOREvent *event = [[GDTCOREvent alloc] initWithMappingID:@"404" target:target];
   event.clockSnapshot = [GDTCORClock snapshot];
   event.dataObject = [[GDTCORDataObjectTesterSimple alloc] initWithString:@"testString"];
   XCTestExpectation *writtenExpectation = [self expectationWithDescription:@"event written"];
-  XCTAssertNoThrow([[GDTCORStorage sharedInstance] storeEvent:event
-                                                   onComplete:^(NSError *error) {
-                                                     XCTAssertNotEqualObjects(event.eventID, @0);
-                                                     [writtenExpectation fulfill];
-                                                   }]);
+  XCTAssertNoThrow([[GDTCORFlatFileStorage sharedInstance] storeEvent:event
+                                                           onComplete:^(NSError *error) {
+                                                             XCTAssertNotEqualObjects(event.eventID,
+                                                                                      @0);
+                                                             [writtenExpectation fulfill];
+                                                           }]);
   [self waitForExpectations:@[ writtenExpectation ] timeout:10.0];
   event = nil;
   __block NSData *storageData;
-  dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
+  dispatch_sync([GDTCORFlatFileStorage sharedInstance].storageQueue, ^{
     if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-      storageData = [NSKeyedArchiver archivedDataWithRootObject:[GDTCORStorage sharedInstance]
-                                          requiringSecureCoding:YES
-                                                          error:nil];
+      storageData =
+          [NSKeyedArchiver archivedDataWithRootObject:[GDTCORFlatFileStorage sharedInstance]
+                                requiringSecureCoding:YES
+                                                error:nil];
     } else {
 #if !TARGET_OS_MACCATALYST
-      storageData = [NSKeyedArchiver archivedDataWithRootObject:[GDTCORStorage sharedInstance]];
+      storageData =
+          [NSKeyedArchiver archivedDataWithRootObject:[GDTCORFlatFileStorage sharedInstance]];
 #endif
     }
   });
-  dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
-    XCTAssertEqual([GDTCORStorage sharedInstance].storedEvents.count, 1);
+  dispatch_sync([GDTCORFlatFileStorage sharedInstance].storageQueue, ^{
+    XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].storedEvents.count, 1);
   });
-  NSSet *eventIDs = [NSSet setWithArray:[[GDTCORStorage sharedInstance].storedEvents allKeys]];
-  [[GDTCORStorage sharedInstance] removeEvents:eventIDs];
-  dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
-    XCTAssertEqual([GDTCORStorage sharedInstance].storedEvents.count, 0);
+  NSSet *eventIDs =
+      [NSSet setWithArray:[[GDTCORFlatFileStorage sharedInstance].storedEvents allKeys]];
+  [[GDTCORFlatFileStorage sharedInstance] removeEvents:eventIDs];
+  dispatch_sync([GDTCORFlatFileStorage sharedInstance].storageQueue, ^{
+    XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].storedEvents.count, 0);
   });
-  GDTCORStorage *unarchivedStorage;
+  GDTCORFlatFileStorage *unarchivedStorage;
   NSError *error;
   if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-    unarchivedStorage = [NSKeyedUnarchiver unarchivedObjectOfClass:[GDTCORStorage class]
+    unarchivedStorage = [NSKeyedUnarchiver unarchivedObjectOfClass:[GDTCORFlatFileStorage class]
                                                           fromData:storageData
                                                              error:&error];
   } else {
@@ -346,36 +362,40 @@ static NSInteger target = kGDTCORTargetCCT;
   event.dataObject = [[GDTCORDataObjectTesterSimple alloc] initWithString:@"testString"];
   event.clockSnapshot = [GDTCORClock snapshot];
   XCTestExpectation *writtenExpectation = [self expectationWithDescription:@"event written"];
-  XCTAssertNoThrow([[GDTCORStorage sharedInstance] storeEvent:event
-                                                   onComplete:^(NSError *error) {
-                                                     XCTAssertNotEqualObjects(event.eventID, @0);
-                                                     [writtenExpectation fulfill];
-                                                   }]);
+  XCTAssertNoThrow([[GDTCORFlatFileStorage sharedInstance] storeEvent:event
+                                                           onComplete:^(NSError *error) {
+                                                             XCTAssertNotEqualObjects(event.eventID,
+                                                                                      @0);
+                                                             [writtenExpectation fulfill];
+                                                           }]);
   [self waitForExpectations:@[ writtenExpectation ] timeout:10.0];
   event = nil;
   __block NSData *storageData;
-  dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
+  dispatch_sync([GDTCORFlatFileStorage sharedInstance].storageQueue, ^{
     if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-      storageData = [NSKeyedArchiver archivedDataWithRootObject:[GDTCORStorage sharedInstance]
-                                          requiringSecureCoding:YES
-                                                          error:nil];
+      storageData =
+          [NSKeyedArchiver archivedDataWithRootObject:[GDTCORFlatFileStorage sharedInstance]
+                                requiringSecureCoding:YES
+                                                error:nil];
     } else {
 #if !TARGET_OS_MACCATALYST
-      storageData = [NSKeyedArchiver archivedDataWithRootObject:[GDTCORStorage sharedInstance]];
+      storageData =
+          [NSKeyedArchiver archivedDataWithRootObject:[GDTCORFlatFileStorage sharedInstance]];
 #endif
     }
   });
-  dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
-    XCTAssertGreaterThan([GDTCORStorage sharedInstance].storedEvents.count, 0);
+  dispatch_sync([GDTCORFlatFileStorage sharedInstance].storageQueue, ^{
+    XCTAssertGreaterThan([GDTCORFlatFileStorage sharedInstance].storedEvents.count, 0);
   });
-  NSSet *eventIDs = [NSSet setWithArray:[[GDTCORStorage sharedInstance].storedEvents allKeys]];
-  [[GDTCORStorage sharedInstance] removeEvents:eventIDs];
-  dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
-    XCTAssertEqual([GDTCORStorage sharedInstance].storedEvents.count, 0);
+  NSSet *eventIDs =
+      [NSSet setWithArray:[[GDTCORFlatFileStorage sharedInstance].storedEvents allKeys]];
+  [[GDTCORFlatFileStorage sharedInstance] removeEvents:eventIDs];
+  dispatch_sync([GDTCORFlatFileStorage sharedInstance].storageQueue, ^{
+    XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].storedEvents.count, 0);
   });
-  GDTCORStorage *unarchivedStorage;
+  GDTCORFlatFileStorage *unarchivedStorage;
   if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-    unarchivedStorage = [NSKeyedUnarchiver unarchivedObjectOfClass:[GDTCORStorage class]
+    unarchivedStorage = [NSKeyedUnarchiver unarchivedObjectOfClass:[GDTCORFlatFileStorage class]
                                                           fromData:storageData
                                                              error:nil];
   } else {
@@ -395,18 +415,19 @@ static NSInteger target = kGDTCORTargetCCT;
   event.clockSnapshot = [GDTCORClock snapshot];
   XCTAssertFalse(self.uploaderFake.forceUploadCalled);
   XCTestExpectation *writtenExpectation = [self expectationWithDescription:@"event written"];
-  XCTAssertNoThrow([[GDTCORStorage sharedInstance] storeEvent:event
-                                                   onComplete:^(NSError *error) {
-                                                     XCTAssertNotEqualObjects(event.eventID, @0);
-                                                     XCTAssertNil(error);
-                                                     [writtenExpectation fulfill];
-                                                   }]);
+  XCTAssertNoThrow([[GDTCORFlatFileStorage sharedInstance] storeEvent:event
+                                                           onComplete:^(NSError *error) {
+                                                             XCTAssertNotEqualObjects(event.eventID,
+                                                                                      @0);
+                                                             XCTAssertNil(error);
+                                                             [writtenExpectation fulfill];
+                                                           }]);
   [self waitForExpectations:@[ writtenExpectation ] timeout:10.0];
 
-  dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
+  dispatch_sync([GDTCORFlatFileStorage sharedInstance].storageQueue, ^{
     XCTAssertTrue(self.uploaderFake.forceUploadCalled);
-    XCTAssertEqual([GDTCORStorage sharedInstance].storedEvents.count, 1);
-    XCTAssertEqual([GDTCORStorage sharedInstance].targetToEventSet[@(target)].count, 1);
+    XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].storedEvents.count, 1);
+    XCTAssertEqual([GDTCORFlatFileStorage sharedInstance].targetToEventSet[@(target)].count, 1);
     NSURL *eventFile = event.fileURL;
     XCTAssertNotNil(eventFile);
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:eventFile.path]);
@@ -428,15 +449,17 @@ static NSInteger target = kGDTCORTargetCCT;
     event.dataObject = [[GDTCORDataObjectTesterSimple alloc] initWithString:testString];
     event.clockSnapshot = [GDTCORClock snapshot];
     XCTestExpectation *writtenExpectation = [self expectationWithDescription:@"event written"];
-    XCTAssertNoThrow([[GDTCORStorage sharedInstance] storeEvent:event
-                                                     onComplete:^(NSError *error) {
-                                                       XCTAssertNotEqualObjects(event.eventID, @0);
-                                                       [writtenExpectation fulfill];
-                                                     }]);
+    XCTAssertNoThrow([[GDTCORFlatFileStorage sharedInstance] storeEvent:event
+                                                             onComplete:^(NSError *error) {
+                                                               XCTAssertNotEqualObjects(
+                                                                   event.eventID, @0);
+                                                               [writtenExpectation fulfill];
+                                                             }]);
     [self waitForExpectationsWithTimeout:10 handler:nil];
     if (i % 5 == 0) {
-      NSSet *eventIDs = [NSSet setWithArray:[[GDTCORStorage sharedInstance].storedEvents allKeys]];
-      [[GDTCORStorage sharedInstance] removeEvents:eventIDs];
+      NSSet *eventIDs =
+          [NSSet setWithArray:[[GDTCORFlatFileStorage sharedInstance].storedEvents allKeys]];
+      [[GDTCORFlatFileStorage sharedInstance] removeEvents:eventIDs];
     }
     [NSNotificationCenter.defaultCenter
         postNotificationName:kGDTCORApplicationWillTerminateNotification
@@ -588,7 +611,7 @@ static NSInteger target = kGDTCORTargetCCT;
   NSData *v1ArchiveData = [[NSData alloc] initWithBase64EncodedString:base64EncodedArchive
                                                               options:0];
   XCTAssertNotNil(v1ArchiveData);
-  GDTCORStorage *archiveStorage;
+  GDTCORFlatFileStorage *archiveStorage;
   XCTAssertNoThrow(archiveStorage = [NSKeyedUnarchiver unarchiveObjectWithData:v1ArchiveData]);
   XCTAssertEqual(archiveStorage.targetToEventSet[@(kGDTCORTargetCCT)].count, 6);
   XCTAssertEqual(archiveStorage.targetToEventSet[@(kGDTCORTargetFLL)].count, 12);


### PR DESCRIPTION
Renames GDTCORStorage to GDTCORFlatFileStorage to be more descriptive of the actual functionality and because of potential confusion due to the creation of GDTCORStorageProtocol.