### PR TITLE
Zip Carthage refactor

### DIFF
--- a/ZipBuilder/README.md
+++ b/ZipBuilder/README.md
@@ -8,14 +8,14 @@ you can fix issues or dig in without having to dig too deep into the code.
 
 ## Zip Builder
 
-This is a small Swift Package Manager project that allows users to package an iOS Zip file of binary
+This is a Swift Package Manager project that allows users to package an iOS Zip file of binary
 packages.
 
 ### Requirements
 
 In order to build the Zip file, you will need:
 
-- Xcode 10.1
+- Xcode 11.0
 - CocoaPods
 - An internet connection to fetch CocoaPods
 

--- a/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
@@ -106,11 +106,12 @@ extension CarthageUtils {
 
       // Parse the JSON file, ensure that we're not trying to overwrite a release.
       var jsonManifest = parseJSONFile(fromDir: jsonDir, product: product)
-      //  guard jsonManifest[firebaseVersion] == nil else {
-      //     print("Carthage release for \(product) \(firebaseVersion) already exists - skipping.")
-      // temporary disable
-      //      continue
-      //   }
+      if !args.carthageSkipVersionCheck {
+        guard jsonManifest[firebaseVersion] == nil else {
+          print("Carthage release for \(product) \(firebaseVersion) already exists - skipping.")
+              continue
+        }
+      }
 
       // Make updates to all frameworks to make Carthage happy. We don't worry about xcframeworks
       // here.

--- a/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
@@ -22,7 +22,6 @@ import Foundation
 enum CarthageUtils {}
 
 extension CarthageUtils {
-
   /// Package all required files for a Carthage release.
   ///
   /// - Parameters:
@@ -88,10 +87,10 @@ extension CarthageUtils {
   ///   - outputDir: The directory where all artifacts should be created.
 
   private static func generateCarthageRelease(fromPackagedDir packagedDir: URL,
-                                      templateDir: URL,
-                                      jsonDir: URL,
-                                      artifacts: ZipBuilder.ReleaseArtifacts,
-                                      outputDir: URL) {
+                                              templateDir: URL,
+                                              jsonDir: URL,
+                                              artifacts: ZipBuilder.ReleaseArtifacts,
+                                              outputDir: URL) {
     let directories: [String]
     do {
       directories = try FileManager.default.contentsOfDirectory(atPath: packagedDir.path)
@@ -107,16 +106,16 @@ extension CarthageUtils {
 
       // Parse the JSON file, ensure that we're not trying to overwrite a release.
       var jsonManifest = parseJSONFile(fromDir: jsonDir, product: product)
-    //  guard jsonManifest[firebaseVersion] == nil else {
-   //     print("Carthage release for \(product) \(firebaseVersion) already exists - skipping.")
-  // temporary disable
-  //      continue
-   //   }
+      //  guard jsonManifest[firebaseVersion] == nil else {
+      //     print("Carthage release for \(product) \(firebaseVersion) already exists - skipping.")
+      // temporary disable
+      //      continue
+      //   }
 
       // Make updates to all frameworks to make Carthage happy. We don't worry about xcframeworks
       // here.
-      let allFiles = FileManager.default.enumerator(atPath:fullPath.path)?.allObjects as! [String]
-      let frameworks = allFiles.filter{$0.hasSuffix(".framework")}
+      let allFiles = FileManager.default.enumerator(atPath: fullPath.path)?.allObjects as! [String]
+      let frameworks = allFiles.filter { $0.hasSuffix(".framework") }
       for framework in frameworks {
         let plistPath = fullPath.appendingPathComponents([framework, "Info.plist"])
         // Drop the extension of the framework name.

--- a/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
@@ -26,7 +26,7 @@ extension CarthageUtils {
   ///
   /// - Parameters:
   ///   - templateDir: The template project directory, contains the dummy Firebase library.
-  ///   - carthageKsonDir: Location of directory containing all JSON Carthage manifests.
+  ///   - carthageJSONDir: Location of directory containing all JSON Carthage manifests.
   ///   - artifacts: Release Artifacts from build.
   ///   - rcNumber: The RC number.
   /// - Returns: The path to the root of the Carthage installation.

--- a/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
@@ -109,7 +109,7 @@ extension CarthageUtils {
       if !args.carthageSkipVersionCheck {
         guard jsonManifest[firebaseVersion] == nil else {
           print("Carthage release for \(product) \(firebaseVersion) already exists - skipping.")
-              continue
+          continue
         }
       }
 

--- a/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
@@ -22,6 +22,61 @@ import Foundation
 enum CarthageUtils {}
 
 extension CarthageUtils {
+
+  /// Package all required files for a Carthage release.
+  ///
+  /// - Parameters:
+  ///   - templateDir: The template project directory, contains the dummy Firebase library.
+  ///   - carthageKsonDir: Location of directory containing all JSON Carthage manifests.
+  ///   - artifacts: Release Artifacts from build.
+  ///   - rcNumber: The RC number.
+  /// - Returns: The path to the root of the Carthage installation.
+  static func packageCarthageRelease(templateDir: URL,
+                                     carthageJSONDir: URL,
+                                     artifacts: ZipBuilder.ReleaseArtifacts,
+                                     rcNumber: Int?) -> URL? {
+    if let zipLocation = artifacts.carthageDir {
+      var carthageRoot: URL?
+      do {
+        print("Creating Carthage release...")
+        let carthagePath =
+          zipLocation.deletingLastPathComponent().appendingPathComponent("carthage_build")
+        // Create a copy of the release directory since we'll be modifying it.
+        let fileManager = FileManager.default
+        fileManager.removeIfExists(at: carthagePath)
+        try fileManager.copyItem(at: zipLocation, to: carthagePath)
+
+        // Package the Carthage distribution with the current directory structure.
+        let carthageDir = zipLocation.deletingLastPathComponent().appendingPathComponent("carthage")
+        fileManager.removeIfExists(at: carthageDir)
+        var output = carthageDir.appendingPathComponent(artifacts.firebaseVersion)
+        if let rcNumber = args.rcNumber {
+          output.appendPathComponent("rc\(rcNumber)")
+        } else {
+          output.appendPathComponent("latest-non-rc")
+        }
+        try fileManager.createDirectory(at: output, withIntermediateDirectories: true)
+        generateCarthageRelease(fromPackagedDir: carthagePath,
+                                templateDir: templateDir,
+                                jsonDir: carthageJSONDir,
+                                artifacts: artifacts,
+                                outputDir: output)
+
+        // Remove the duplicated Carthage build directory.
+        fileManager.removeIfExists(at: carthagePath)
+        print("Done creating Carthage release! Files written to \(output)")
+
+        // Save the directory for later copying.
+        carthageRoot = carthageDir
+      } catch {
+        fatalError("Could not copy output directory for Carthage build: \(error)")
+      }
+      return carthageRoot
+    } else {
+      return nil
+    }
+  }
+
   /// Generates all required files for a Carthage release.
   ///
   /// - Parameters:
@@ -31,11 +86,11 @@ extension CarthageUtils {
   ///   - firebaseVersion: The version of the Firebase pod.
   ///   - coreDiagnosticsPath: The path to the Core Diagnostics framework built for Carthage.
   ///   - outputDir: The directory where all artifacts should be created.
-  static func generateCarthageRelease(fromPackagedDir packagedDir: URL,
+
+  private static func generateCarthageRelease(fromPackagedDir packagedDir: URL,
                                       templateDir: URL,
                                       jsonDir: URL,
-                                      firebaseVersion: String,
-                                      coreDiagnosticsPath: URL,
+                                      artifacts: ZipBuilder.ReleaseArtifacts,
                                       outputDir: URL) {
     let directories: [String]
     do {
@@ -43,6 +98,7 @@ extension CarthageUtils {
     } catch {
       fatalError("Could not get contents of Firebase directory to package Carthage build. \(error)")
     }
+    let firebaseVersion = artifacts.firebaseVersion
 
     // Loop through each directory available and package it as a separate Zip file.
     for product in directories {
@@ -51,23 +107,16 @@ extension CarthageUtils {
 
       // Parse the JSON file, ensure that we're not trying to overwrite a release.
       var jsonManifest = parseJSONFile(fromDir: jsonDir, product: product)
-      guard jsonManifest[firebaseVersion] == nil else {
-        print("Carthage release for \(product) \(firebaseVersion) already exists - skipping.")
-        continue
-      }
+    //  guard jsonManifest[firebaseVersion] == nil else {
+   //     print("Carthage release for \(product) \(firebaseVersion) already exists - skipping.")
+  // temporary disable
+  //      continue
+   //   }
 
-      // Find all the .frameworks in this directory.
-      let allContents: [String]
-      do {
-        allContents = try FileManager.default.contentsOfDirectory(atPath: fullPath.path)
-      } catch {
-        fatalError("Could not get contents of \(product) for Carthage build in order to add " +
-          "an Info.plist in each framework. \(error)")
-      }
-
-      // Carthage will fail to install a framework if it doesn't have an Info.plist, even though
-      // they're not used for static frameworks. Generate one and write it to each framework.
-      let frameworks = allContents.filter { $0.hasSuffix(".framework") }
+      // Make updates to all frameworks to make Carthage happy. We don't worry about xcframeworks
+      // here.
+      let allFiles = FileManager.default.enumerator(atPath:fullPath.path)?.allObjects as! [String]
+      let frameworks = allFiles.filter{$0.hasSuffix(".framework")}
       for framework in frameworks {
         let plistPath = fullPath.appendingPathComponents([framework, "Info.plist"])
         // Drop the extension of the framework name.
@@ -92,17 +141,6 @@ extension CarthageUtils {
           try FileManager.default.copyItem(at: noticesPath, to: coreNotices)
         } catch {
           fatalError("Could not copy \(noticesName) to FirebaseCore for Carthage build. \(error)")
-        }
-
-        // Override the Core Diagnostics framework with one that includes the proper bit flipped.
-        let coreDiagnosticsFramework = Constants.coreDiagnosticsName + ".framework"
-        let destination = fullPath.appendingPathComponent(coreDiagnosticsFramework)
-        do {
-          // Remove the existing framework and replace it with the newly compiled one.
-          try FileManager.default.removeItem(at: destination)
-          try FileManager.default.copyItem(at: coreDiagnosticsPath, to: destination)
-        } catch {
-          fatalError("Could not replace \(coreDiagnosticsFramework) during Carthage build. \(error)")
         }
       }
 

--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -156,7 +156,7 @@ enum CocoaPodUtils {
 
     // Run pod install on the directory that contains the Podfile and blank Xcode project.
     // At least 1.9.0 is required for `use_frameworks! :linkage => :static`
-    let result = Shell.executeCommandFromScript("pod _1.9.0_ install", workingDir: directory)
+    let result = Shell.executeCommandFromScript("pod install", workingDir: directory)
     switch result {
     case let .error(code, output):
       fatalError("""
@@ -310,6 +310,16 @@ enum CocoaPodUtils {
     } while newDeps.count > 0
     return Array(returnDeps)
   }
+
+  /// Get all transitive pod dependencies for a pod with subspecs merged.
+  /// - Returns: An array of Strings of pod names.
+  static func transitiveMasterPodDependencies(for podName: String,
+                                        in installedPods: [String: PodInfo]) -> [String] {
+    return Array(Set(transitivePodDependencies(for: podName, in: installedPods).map {
+      $0.components(separatedBy: "/")[0]
+    }))
+  }
+
 
   /// Get all transitive pod dependencies for a pod.
   /// - Returns: An array of dependencies with versions for a given pod.

--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -314,12 +314,11 @@ enum CocoaPodUtils {
   /// Get all transitive pod dependencies for a pod with subspecs merged.
   /// - Returns: An array of Strings of pod names.
   static func transitiveMasterPodDependencies(for podName: String,
-                                        in installedPods: [String: PodInfo]) -> [String] {
+                                              in installedPods: [String: PodInfo]) -> [String] {
     return Array(Set(transitivePodDependencies(for: podName, in: installedPods).map {
       $0.components(separatedBy: "/")[0]
     }))
   }
-
 
   /// Get all transitive pod dependencies for a pod.
   /// - Returns: An array of dependencies with versions for a given pod.

--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -121,7 +121,7 @@ struct FrameworkBuilder {
       fileManager.removeIfExists(at: cachedFrameworkDir)
       fileManager.removeIfExists(at: cachedCarthageDir)
 
-      // Create the root cache directories if they doesn't exist.
+      // Create the root cache directories if they don't exist.
       if !fileManager.directoryExists(at: cachedFrameworkRoot) {
         // If the root directory doesn't exist, create it so the `moveItem` will succeed.
         try fileManager.createDirectory(at: cachedFrameworkRoot,
@@ -201,7 +201,7 @@ struct FrameworkBuilder {
   /// Build all thin slices for an open source pod.
   /// - Parameter framework: The name of the framework to be built.
   /// - Parameter logsDir: The path to the directory to place build logs.
-  /// - Returns: An dictionary of URLs to the built thin libraries keyed by architiecture
+  /// - Returns: An dictionary of URLs to the built thin libraries keyed by architecture
   private func buildAllThin(withName framework: String,
                             logsDir: URL,
                             carthageBuild: Bool = false) -> [Architecture: URL] {
@@ -343,7 +343,7 @@ struct FrameworkBuilder {
   /// - Parameter framework: The name of the framework to be built.
   /// - Parameter logsOutputDir: The path to the directory to place build logs.
   /// - Parameter moduleMapContents: Module map contents for all frameworks in this pod.
-  /// - Returns: A path to the newly compiled framework and the Carthage version if needed)
+  /// - Returns: A path to the newly compiled framework and the Carthage version if needed).
   private func compileFrameworkAndResources(withName framework: String,
                                             logsOutputDir: URL? = nil,
                                             podInfo: CocoaPodUtils.PodInfo) -> (URL, URL?) {

--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -203,8 +203,8 @@ struct FrameworkBuilder {
   /// - Parameter logsDir: The path to the directory to place build logs.
   /// - Returns: An dictionary of URLs to the built thin libraries keyed by architiecture
   private func buildAllThin(withName framework: String,
-                                      logsDir: URL,
-                                      carthageBuild: Bool = false) -> [Architecture: URL] {
+                            logsDir: URL,
+                            carthageBuild: Bool = false) -> [Architecture: URL] {
     // Build every architecture and save the locations in an array to be assembled.
     var thinArchives = [Architecture: URL]()
     for arch in LaunchArgs.shared.archs {
@@ -529,9 +529,9 @@ struct FrameworkBuilder {
     let xcframework = packageXCFramework(withName: framework,
                                          fromFolder: frameworkDir,
                                          thinArchives: thinArchives,
-                                         moduleMapContents:moduleMapContents)
+                                         moduleMapContents: moduleMapContents)
 
-    var carthageFramework : URL? = nil
+    var carthageFramework: URL?
     if args.carthageDir != nil {
       var carthageThinArchives: [Architecture: URL]
       if framework == "FirebaseCoreDiagnostics" {
@@ -787,15 +787,16 @@ struct FrameworkBuilder {
 
     return xcframework
   }
+
   /// Packages a Carthage framework. Carthage does not yet support xcframeworks, so we exclude the Catalyst slice.
   /// - Parameter withName: The framework name.
   /// - Parameter fromFolder: The almost complete framework folder. Includes everything but the binary.
   /// - Parameter thinArchives: All the thin archives.
   /// - Parameter moduleMapContents: Module map contents for all frameworks in this pod.
   private func packageCarthageFramework(withName framework: String,
-                                  fromFolder: URL,
-                                  thinArchives: [Architecture: URL],
-                                  moduleMapContents: String) -> URL {
+                                        fromFolder: URL,
+                                        thinArchives: [Architecture: URL],
+                                        moduleMapContents: String) -> URL {
     let fileManager = FileManager.default
 
     // Create a `.framework` for each of the thinArchives using the `fromFolder` as the base.

--- a/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
+++ b/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
@@ -42,6 +42,7 @@ struct LaunchArgs {
     case archs
     case buildRoot
     case carthageDir
+    case carthageSkipVersionCheck
     case customSpecRepos
     case dynamic
     case existingVersions
@@ -67,6 +68,8 @@ struct LaunchArgs {
       case .carthageDir:
         return "The directory pointing to all Carthage JSON manifests. Passing this flag enables" +
           "the Carthage build."
+      case .carthageSkipVersionCheck:
+        return "A flag to skip the Carthage version check for development iteration."
       case .customSpecRepos:
         return "A comma separated list of custom CocoaPod Spec repos."
       case .dynamic:
@@ -112,6 +115,9 @@ struct LaunchArgs {
   /// The directory pointing to all Carthage JSON manifests. Passing this flag enables the Carthage
   /// build.
   let carthageDir: URL?
+
+  /// Skip the Carthage version check
+  let carthageSkipVersionCheck: Bool
 
   /// A file URL to a textproto with the contents of a `ZipBuilder_Release` object. Used to verify
   /// expected version numbers.
@@ -330,6 +336,7 @@ struct LaunchArgs {
       minimumIOSVersion = "9.0"
     }
 
+    carthageSkipVersionCheck = defaults.bool(forKey: Key.carthageSkipVersionCheck.rawValue)
     dynamic = defaults.bool(forKey: Key.dynamic.rawValue)
     updatePodRepo = defaults.bool(forKey: Key.updatePodRepo.rawValue)
     keepBuildArtifacts = defaults.bool(forKey: Key.keepBuildArtifacts.rawValue)

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -180,7 +180,7 @@ struct ZipBuilder {
     // Break the `inputPods` into a variable since it's helpful when debugging builds to just
     // install a subset of pods, like the following line:
     let inputPods: [String] = ["Firebase", "FirebaseCore", "FirebaseAnalytics", "FirebaseStorage"]
-    //let inputPods = FirebasePods.allCases.map { $0.rawValue }
+    // let inputPods = FirebasePods.allCases.map { $0.rawValue }
 
     // Get the expected versions based on the release manifests, if there are any. If there are any
     // versions with `alpha` or `beta` in it, we'll need to explicitly specify the version here so
@@ -211,8 +211,8 @@ struct ZipBuilder {
     var carthageDir: URL?
     if let carthageFrameworks = carthageFrameworks {
       carthageDir = try assembleDistributions(inProjectDir: projectDir, withPackageKind: "CarthageFirebase",
-                                             podsToInstall: podsToInstall, installedPods: installedPods,
-                                             frameworksToAssemble: carthageFrameworks, firebasePod: firebasePod)
+                                              podsToInstall: podsToInstall, installedPods: installedPods,
+                                              frameworksToAssemble: carthageFrameworks, firebasePod: firebasePod)
     }
 
     return ReleaseArtifacts(firebaseVersion: firebasePod.version,
@@ -236,11 +236,11 @@ struct ZipBuilder {
   /// - Returns: Return the URL of the folder containing the contents of the Zip or Carthage distribution.
   /// - Throws: One of many errors that could have happened during the build phase.
   private func assembleDistributions(inProjectDir projectDir: URL,
-                             withPackageKind packageKind: String,
-                             podsToInstall: [CocoaPodUtils.VersionedPod],
-                             installedPods: [String: CocoaPodUtils.PodInfo],
-                             frameworksToAssemble: [String: [URL]],
-                             firebasePod: CocoaPodUtils.PodInfo) throws -> URL {
+                                     withPackageKind packageKind: String,
+                                     podsToInstall: [CocoaPodUtils.VersionedPod],
+                                     installedPods: [String: CocoaPodUtils.PodInfo],
+                                     frameworksToAssemble: [String: [URL]],
+                                     firebasePod: CocoaPodUtils.PodInfo) throws -> URL {
     // Create the directory that will hold all the contents of the Zip file.
     let zipDir = FileManager.default.temporaryDirectory(withName: packageKind)
     do {
@@ -287,9 +287,9 @@ struct ZipBuilder {
     }
     let remainingPods = installedPods.filter {
       $0.key != "FirebaseAnalytics" &&
-      $0.key != "FirebaseCore" &&
-      $0.key != "Firebase" &&
-      podsToInstall.map { $0.name }.contains($0.key)
+        $0.key != "FirebaseCore" &&
+        $0.key != "Firebase" &&
+        podsToInstall.map { $0.name }.contains($0.key)
     }.sorted { $0.key < $1.key }
     for pod in remainingPods {
       do {
@@ -539,7 +539,7 @@ struct ZipBuilder {
     podsToIgnore: [String] = []
   ) throws -> (productDir: URL, frameworks: [String]) {
     let podsToCopy = [podName] +
-        CocoaPodUtils.transitiveMasterPodDependencies(for: podName, in: installedPods)
+      CocoaPodUtils.transitiveMasterPodDependencies(for: podName, in: installedPods)
     // Copy the frameworks into the proper product directory.
     let productDir = rootZipDir.appendingPathComponent(podName)
     let namedFrameworks = try copyFrameworks(fromPods: podsToCopy,
@@ -693,8 +693,8 @@ struct ZipBuilder {
       if podInfo.isSourcePod {
         let builder = FrameworkBuilder(projectDir: projectDir)
         let (framework, carthageFramework) = builder.buildFramework(withName: podName,
-                                                                     podInfo: podInfo,
-                                                                 logsOutputDir: paths.logsOutputDir)
+                                                                    podInfo: podInfo,
+                                                                    logsOutputDir: paths.logsOutputDir)
 
         frameworks = [framework]
         if let carthageFramework = carthageFramework {

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -52,9 +52,6 @@ struct Constants {
 
   """
 
-  /// The name of the Core Diagnostics pod.
-  static let coreDiagnosticsName: String = "FirebaseCoreDiagnostics"
-
   // Make the struct un-initializable.
   @available(*, unavailable)
   init() { fatalError() }
@@ -64,14 +61,14 @@ struct Constants {
 struct ZipBuilder {
   /// Artifacts from building and assembling the release directory.
   struct ReleaseArtifacts {
-    /// The path to the compiled FirebaseCoreDiagnostics framework with the Carthage bit enabled.
-    let carthageDiagnostics: URL
-
     /// The Firebase version.
     let firebaseVersion: String
 
     /// The directory that contains the properly assembled release artifacts.
-    let outputDir: URL
+    let zipDir: URL
+
+    /// The directory that contains the properly assembled release artifacts for Carthage if building it.
+    let carthageDir: URL?
   }
 
   /// Relevant paths in the filesystem to build the release directory.
@@ -125,7 +122,7 @@ struct ZipBuilder {
   /// - Parameter podsToInstall: All pods to install.
   /// - Returns: Arrays of pod install info and the frameworks installed.
   func buildAndAssembleZip(podsToInstall: [CocoaPodUtils.VersionedPod]) ->
-    ([String: CocoaPodUtils.PodInfo], [String: [URL]]) {
+    ([String: CocoaPodUtils.PodInfo], [String: [URL]], [String: [URL]]?) {
     // Remove CocoaPods cache so the build gets updates after a version is rebuilt during the
     // release process.
     if LaunchArgs.shared.updatePodRepo {
@@ -158,12 +155,17 @@ struct ZipBuilder {
 
     // Generate the frameworks. Each key is the pod name and the URLs are all frameworks to be
     // copied in each product's directory.
-    let frameworks = generateFrameworks(fromPods: installedPods, inProjectDir: projectDir)
+    let (frameworks, carthageFrameworks) = generateFrameworks(fromPods: installedPods, inProjectDir: projectDir)
 
     for (framework, paths) in frameworks {
       print("Frameworks for pod: \(framework) were compiled at \(paths)")
     }
-    return (installedPods, frameworks)
+
+    // Create the CoreDiagnostics framework for Carthage, since it needs to be recompiled.
+//    let carthageCoreDiagnostics = createCarthageCoreDiagnostics(fromPods: installedPods,
+//                                                                frameworks: frameworks,
+//                                                                inProjectDir: projectDir)
+    return (installedPods, frameworks, carthageFrameworks)
   }
 
   // TODO: This function contains a lot of "copy these paths to this directory, fail if there are
@@ -175,20 +177,10 @@ struct ZipBuilder {
   /// - Returns: Information related to the built artifacts.
   /// - Throws: One of many errors that could have happened during the build phase.
   func buildAndAssembleFirebaseRelease(inProjectDir projectDir: URL) throws -> ReleaseArtifacts {
-    // Get the README template ready (before attempting to build everything in case this fails,
-    // otherwise debugging it will take a long time).
-    let readmePath = paths.templateDir.appendingPathComponent(Constants.ProjectPath.readmeName)
-    let readmeTemplate: String
-    do {
-      readmeTemplate = try String(contentsOf: readmePath)
-    } catch {
-      fatalError("Could not get contents of the README template: \(error)")
-    }
-
     // Break the `inputPods` into a variable since it's helpful when debugging builds to just
     // install a subset of pods, like the following line:
-    // let inputPods: [String] = ["Firebase", "FirebaseCore", "FirebaseAnalytics", "FirebaseStorage"]
-    let inputPods = FirebasePods.allCases.map { $0.rawValue }
+    let inputPods: [String] = ["Firebase", "FirebaseCore", "FirebaseAnalytics", "FirebaseStorage"]
+    //let inputPods = FirebasePods.allCases.map { $0.rawValue }
 
     // Get the expected versions based on the release manifests, if there are any. If there are any
     // versions with `alpha` or `beta` in it, we'll need to explicitly specify the version here so
@@ -204,41 +196,53 @@ struct ZipBuilder {
       return CocoaPodUtils.VersionedPod(name: name, version: version)
     }
 
-    let (installedPods, frameworks) = buildAndAssembleZip(podsToInstall: podsToInstall)
+    let (installedPods, frameworks, carthageFrameworks) = buildAndAssembleZip(podsToInstall: podsToInstall)
 
-    // Create the CoreDiagnostics framework for Carthage, since it needs to be recompiled.
-    let carthageCoreDiagnostics: URL = createCarthageCoreDiagnostics(fromPods: installedPods,
-                                                                     inProjectDir: projectDir)
-
-    // Copy the CoreDiagnostics zip module map to the Carthage build.
-    guard let coreDiagnosticsFramework = frameworks["FirebaseCoreDiagnostics"] else {
-      fatalError("Failed to find FirebaseCoreDiagnostics framework for Carthage copy.")
-    }
-    guard let coreDiagnosticModuleMapLocation = coreDiagnosticsFramework.first else {
-      fatalError("Failed to find FirebaseCoreDiagnostics module map location for Carthage copy.")
-    }
-    let coreDiagnosticModuleMap = coreDiagnosticModuleMapLocation.appendingPathComponent("Modules")
-    do {
-      try FileManager.default.copyItem(at: coreDiagnosticModuleMap,
-                                       to: carthageCoreDiagnostics.appendingPathComponent("Modules"))
-    } catch {
-      fatalError("Failed to copy module map to \(carthageCoreDiagnostics)")
+    // We need the Firebase pod to get the version for Carthage and to copy the `Firebase.h` and
+    // `module.modulemap` file from it.
+    guard let firebasePod = installedPods["Firebase"] else {
+      fatalError("Could not get the Firebase pod from list of installed pods. All pods " +
+        "installed: \(installedPods)")
     }
 
-    // Time to assemble the folder structure of the Zip file. In order to get the frameworks
-    // required, we will `pod install` only those subspecs and then fetch the information for all
-    // the frameworks that were installed, copying the frameworks from our list of compiled
-    // frameworks. The whole process is:
-    // 1. Copy any required files (headers, modulemap, etc) over beforehand to fail fast if anything
-    //    is misconfigured.
-    // 2. Get the frameworks required for Analytics, copy them to the Analytics folder.
-    // 3. Go through the rest of the subspecs (excluding those included in Analytics) and copy them
-    //    to a folder with the name of the subspec.
-    // 4. Assemble the `README` file based off the template and copy it to the directory.
-    // 5. Return the URL of the folder containing the contents of the Zip file.
+    let zipDir = try assembleDistributions(inProjectDir: projectDir, withPackageKind: "Firebase",
+                                           podsToInstall: podsToInstall, installedPods: installedPods,
+                                           frameworksToAssemble: frameworks, firebasePod: firebasePod)
+    var carthageDir: URL?
+    if let carthageFrameworks = carthageFrameworks {
+      carthageDir = try assembleDistributions(inProjectDir: projectDir, withPackageKind: "CarthageFirebase",
+                                             podsToInstall: podsToInstall, installedPods: installedPods,
+                                             frameworksToAssemble: carthageFrameworks, firebasePod: firebasePod)
+    }
 
+    return ReleaseArtifacts(firebaseVersion: firebasePod.version,
+                            zipDir: zipDir, carthageDir: carthageDir)
+  }
+
+  // MARK: - Private
+
+  /// Assemble the folder structure of the Zip file. In order to get the frameworks
+  /// required, we will `pod install` only those subspecs and then fetch the information for all
+  /// the frameworks that were installed, copying the frameworks from our list of compiled
+  /// frameworks. The whole process is:
+  /// 1. Copy any required files (headers, modulemap, etc) over beforehand to fail fast if anything
+  ///    is misconfigured.
+  /// 2. Get the frameworks required for Analytics, copy them to the Analytics folder.
+  /// 3. Go through the rest of the subspecs (excluding those included in Analytics) and copy them
+  ///    to a folder with the name of the subspec.
+  /// 4. Assemble the `README` file based off the template and copy it to the directory.
+  /// 5. Return the URL of the folder containing the contents of the Zip file.
+  ///
+  /// - Returns: Return the URL of the folder containing the contents of the Zip or Carthage distribution.
+  /// - Throws: One of many errors that could have happened during the build phase.
+  private func assembleDistributions(inProjectDir projectDir: URL,
+                             withPackageKind packageKind: String,
+                             podsToInstall: [CocoaPodUtils.VersionedPod],
+                             installedPods: [String: CocoaPodUtils.PodInfo],
+                             frameworksToAssemble: [String: [URL]],
+                             firebasePod: CocoaPodUtils.PodInfo) throws -> URL {
     // Create the directory that will hold all the contents of the Zip file.
-    let zipDir = FileManager.default.temporaryDirectory(withName: "Firebase")
+    let zipDir = FileManager.default.temporaryDirectory(withName: packageKind)
     do {
       if FileManager.default.directoryExists(at: zipDir) {
         try FileManager.default.removeItem(at: zipDir)
@@ -249,12 +253,6 @@ struct ZipBuilder {
                                               attributes: nil)
     }
 
-    // We need the Firebase pod to get the version for Carthage and to copy the `Firebase.h` and
-    // `module.modulemap` file from it.
-    guard let firebasePod = installedPods["Firebase"] else {
-      fatalError("Could not get the Firebase pod from list of installed pods. All pods " +
-        "installed: \(installedPods)")
-    }
     // Copy all required files from the Firebase pod. This will cause a fatalError if anything
     // fails.
     copyFirebasePodFiles(fromDir: firebasePod.installedLocation, to: zipDir)
@@ -270,7 +268,7 @@ struct ZipBuilder {
                                                            withInstalledPods: installedPods,
                                                            projectDir: projectDir,
                                                            rootZipDir: zipDir,
-                                                           builtFrameworks: frameworks)
+                                                           builtFrameworks: frameworksToAssemble)
       analyticsFrameworks = frameworks
       analyticsDir = dir
     } catch {
@@ -284,11 +282,14 @@ struct ZipBuilder {
 
     // Loop through all the other subspecs that aren't Core and Analytics and write them to their
     // final destination, including resources.
+    let analyticsPods = analyticsFrameworks.map {
+      $0.replacingOccurrences(of: ".framework", with: "")
+    }
     let remainingPods = installedPods.filter {
       $0.key != "FirebaseAnalytics" &&
-        $0.key != "FirebaseCore" &&
-        $0.key != "Firebase" &&
-        podsToInstall.map { $0.name }.contains($0.key)
+      $0.key != "FirebaseCore" &&
+      $0.key != "Firebase" &&
+      podsToInstall.map { $0.name }.contains($0.key)
     }.sorted { $0.key < $1.key }
     for pod in remainingPods {
       do {
@@ -297,8 +298,8 @@ struct ZipBuilder {
                                        withInstalledPods: installedPods,
                                        projectDir: projectDir,
                                        rootZipDir: zipDir,
-                                       builtFrameworks: frameworks,
-                                       podsToIgnore: analyticsFrameworks)
+                                       builtFrameworks: frameworksToAssemble,
+                                       podsToIgnore: analyticsPods)
 
         // Update the README.
         readmeDeps += dependencyString(for: pod.key, in: productDir, frameworks: podFrameworks)
@@ -325,6 +326,13 @@ struct ZipBuilder {
 
     // Assemble the README. Start with the version text, then use the template to inject the
     // versions and the list of frameworks to include for each pod.
+    let readmePath = paths.templateDir.appendingPathComponent(Constants.ProjectPath.readmeName)
+    let readmeTemplate: String
+    do {
+      readmeTemplate = try String(contentsOf: readmePath)
+    } catch {
+      fatalError("Could not get contents of the README template: \(error)")
+    }
     let versionsText = versionsString(for: installedPods)
     let readmeText = readmeTemplate.replacingOccurrences(of: "__INTEGRATION__", with: readmeDeps)
       .replacingOccurrences(of: "__VERSIONS__", with: versionsText)
@@ -337,37 +345,7 @@ struct ZipBuilder {
     }
 
     print("Contents of the packaged release were assembled at: \(zipDir)")
-    return ReleaseArtifacts(carthageDiagnostics: carthageCoreDiagnostics,
-                            firebaseVersion: firebasePod.version,
-                            outputDir: zipDir)
-  }
-
-  // MARK: - Private
-
-  private func createCarthageCoreDiagnostics(fromPods pods: [String: CocoaPodUtils.PodInfo],
-                                             inProjectDir projectDir: URL) -> URL {
-    // FirebaseCoreDiagnostics needs to be re-compiled for Carthage. It should be included in all
-    // builds, so ensure it's there.
-    guard let coreDiag = pods[Constants.coreDiagnosticsName] else {
-      fatalError("Could not get FirebaseCoreDiagnostics pod to re-compile for Carthage.")
-    }
-
-    // Compile the CoreDiagnostics pod for Carthage.
-    let carthageFrameworks = generateFrameworks(fromPods: [Constants.coreDiagnosticsName: coreDiag],
-                                                inProjectDir: projectDir,
-                                                carthageBuild: true)
-    guard let coreDiagnosticsFrameworks = carthageFrameworks[Constants.coreDiagnosticsName] else {
-      fatalError("Could not get the re-compiled \(Constants.coreDiagnosticsName) framework for " +
-        "Carthage packaging. Frameworks built: \(carthageFrameworks.keys)")
-    }
-
-    // All frameworks for the Core Diagnostics pod are included but we only need the one.
-    let frameworkName = Constants.coreDiagnosticsName + ".framework"
-    guard let carthageCoreDiag: URL = coreDiagnosticsFrameworks.first(where: { $0.lastPathComponent == frameworkName }) else {
-      fatalError("Could not get \(frameworkName) from compiled Carthage frameworks: \(coreDiagnosticsFrameworks)")
-    }
-
-    return carthageCoreDiag
+    return zipDir
   }
 
   /// Copies all frameworks from the `InstalledPod` (pulling from the `frameworkLocations`) and copy
@@ -473,7 +451,12 @@ struct ZipBuilder {
   private func dependencyString(for podName: String, in dir: URL, frameworks: [String]) -> String {
     var result = FirebasePods.readmeHeader(podName: podName)
     for framework in frameworks.sorted() {
-      result += "- \(framework).framework\n"
+      // The .xcframework suffix has been stripped. The .framework suffix has not been.
+      if framework.hasSuffix(".framework") {
+        result += "- \(framework)\n"
+      } else {
+        result += "- \(framework).xcframework\n"
+      }
     }
 
     result += "\n" // Necessary for Resource message to print properly in markdown.
@@ -555,7 +538,8 @@ struct ZipBuilder {
     builtFrameworks: [String: [URL]],
     podsToIgnore: [String] = []
   ) throws -> (productDir: URL, frameworks: [String]) {
-    let podsToCopy = [podName] + CocoaPodUtils.transitivePodDependencies(for: podName, in: installedPods)
+    let podsToCopy = [podName] +
+        CocoaPodUtils.transitiveMasterPodDependencies(for: podName, in: installedPods)
     // Copy the frameworks into the proper product directory.
     let productDir = rootZipDir.appendingPathComponent(podName)
     let namedFrameworks = try copyFrameworks(fromPods: podsToCopy,
@@ -672,8 +656,7 @@ struct ZipBuilder {
   /// frameworks to install EXCLUDING resources, as they are handled later (if not included in the
   /// .framework file already).
   private func generateFrameworks(fromPods pods: [String: CocoaPodUtils.PodInfo],
-                                  inProjectDir projectDir: URL,
-                                  carthageBuild: Bool = false) -> [String: [URL]] {
+                                  inProjectDir projectDir: URL) -> ([String: [URL]], [String: [URL]]?) {
     // Verify the Pods folder exists and we can get the contents of it.
     let fileManager = FileManager.default
 
@@ -696,8 +679,10 @@ struct ZipBuilder {
     // Loop through each pod folder and check if the frameworks already exist, or they need to be
     // compiled. If they exist, add them to the frameworks dictionary.
     var toInstall: [String: [URL]] = [:]
+    var carthageToInstall: [String: [URL]] = [:]
     for (podName, podInfo) in pods {
       var frameworks: [URL] = []
+      var carthageFrameworks: [URL] = []
       // Ignore any Interop pods or the Firebase umbrella pod.
       guard !podName.contains("Interop"),
         podName != "Firebase" else {
@@ -706,12 +691,15 @@ struct ZipBuilder {
 
       // If it's an open source pod and we need to compile the source to get a framework.
       if podInfo.isSourcePod {
-        let builder = FrameworkBuilder(projectDir: projectDir, carthageBuild: carthageBuild)
-        let framework = builder.buildFramework(withName: podName,
-                                               podInfo: podInfo,
-                                               logsOutputDir: paths.logsOutputDir)
+        let builder = FrameworkBuilder(projectDir: projectDir)
+        let (framework, carthageFramework) = builder.buildFramework(withName: podName,
+                                                                     podInfo: podInfo,
+                                                                 logsOutputDir: paths.logsOutputDir)
 
         frameworks = [framework]
+        if let carthageFramework = carthageFramework {
+          carthageFrameworks = [carthageFramework]
+        }
       } else {
         // Package all resources into the frameworks since that's how Carthage needs it packaged.
         do {
@@ -734,14 +722,17 @@ struct ZipBuilder {
             fatalError("Cannot copy framework at \(framework) to \(copiedLocation) while " +
               "attempting to generate frameworks. \(error)")
           }
-
           frameworks.append(copiedLocation)
+          // Same while both closed source and Carthage don't support xcframeworks.
+          carthageFrameworks.append(copiedLocation)
         }
       }
-
       toInstall[podName] = frameworks
+      carthageToInstall[podName] = carthageFrameworks
     }
-
-    return toInstall
+    if args.carthageDir == nil {
+      return (toInstall, nil)
+    }
+    return (toInstall, carthageToInstall)
   }
 }

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -160,11 +160,6 @@ struct ZipBuilder {
     for (framework, paths) in frameworks {
       print("Frameworks for pod: \(framework) were compiled at \(paths)")
     }
-
-    // Create the CoreDiagnostics framework for Carthage, since it needs to be recompiled.
-//    let carthageCoreDiagnostics = createCarthageCoreDiagnostics(fromPods: installedPods,
-//                                                                frameworks: frameworks,
-//                                                                inProjectDir: projectDir)
     return (installedPods, frameworks, carthageFrameworks)
   }
 

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -179,8 +179,8 @@ struct ZipBuilder {
   func buildAndAssembleFirebaseRelease(inProjectDir projectDir: URL) throws -> ReleaseArtifacts {
     // Break the `inputPods` into a variable since it's helpful when debugging builds to just
     // install a subset of pods, like the following line:
-    let inputPods: [String] = ["Firebase", "FirebaseCore", "FirebaseAnalytics", "FirebaseStorage"]
-    // let inputPods = FirebasePods.allCases.map { $0.rawValue }
+    // let inputPods: [String] = ["Firebase", "FirebaseCore", "FirebaseAnalytics", "FirebaseStorage"]
+    let inputPods = FirebasePods.allCases.map { $0.rawValue }
 
     // Get the expected versions based on the release manifests, if there are any. If there are any
     // versions with `alpha` or `beta` in it, we'll need to explicitly specify the version here so

--- a/ZipBuilder/Sources/ZipBuilder/main.swift
+++ b/ZipBuilder/Sources/ZipBuilder/main.swift
@@ -56,7 +56,7 @@ if args.zipPods == nil {
   // Do a Firebase build.
   FirebaseBuilder(zipBuilder: builder).build(in: projectDir)
 } else {
-  let (installedPods, frameworks) = builder.buildAndAssembleZip(podsToInstall: LaunchArgs.shared.zipPods!)
+  let (installedPods, frameworks, _) = builder.buildAndAssembleZip(podsToInstall: LaunchArgs.shared.zipPods!)
   let staging = FileManager.default.temporaryDirectory(withName: "staging")
   try builder.copyFrameworks(fromPods: Array(installedPods.keys), toDirectory: staging,
                              frameworkLocations: frameworks)

--- a/ZipBuilder/Template/README.md
+++ b/ZipBuilder/Template/README.md
@@ -15,13 +15,14 @@ To integrate a Firebase SDK with your app:
 2. Make sure you have an Xcode project open in Xcode.
 3. In Xcode, hit `⌘-1` to open the Project Navigator pane. It will open on
    left side of the Xcode window if it wasn't already open.
-4. Drag each framework from the "FirebaseAnalytics" directory into the Project
+4. Remove any existing Firebase frameworks from your project.
+5. Drag each framework from the "FirebaseAnalytics" directory into the Project
    Navigator pane. In the dialog box that appears, make sure the target you
    want the framework to be added to has a checkmark next to it, and that
-   you've selected "Copy items if needed". If you already have Firebase
-   frameworks in your project, make sure that you replace them with the new
-   versions.
-5. Drag each framework from the directory named after the SDK into the Project
+   you've selected "Copy items if needed". If you want to include
+   community-based Catalyst support, only drag the xcframeworks and skip the
+   plain frameworks.
+6. Drag each framework from the directory named after the SDK into the Project
    Navigator pane. Note that there may be no additional frameworks, in which
    case this directory will be empty. For instance, if you want the Database
    SDK, look in the Database folder for the required frameworks. In the dialog
@@ -33,24 +34,24 @@ To integrate a Firebase SDK with your app:
    [static frameworks](https://www.raywenderlich.com/65964/create-a-framework-for-ios)
    which cannot be embedded into your application's bundle.*
 
-6. If the SDK has resources, go into the Resources folders, which will be in
+7. If the SDK has resources, go into the Resources folders, which will be in
    the SDK folder. Drag all of those resources into the Project Navigator, just
    like the frameworks, again making sure that the target you want to add these
    resources to has a checkmark next to it, and that you've selected "Copy items
    if needed".
-7. Add the -ObjC flag to "Other Linker Settings":
+8. Add the -ObjC flag to "Other Linker Settings":
   a. In your project settings, open the Settings panel for your target
   b. Go to the Build Settings tab and find the "Other Linker Flags" setting
      in the Linking section.
   c. Double-click the setting, click the '+' button, and add "-ObjC" (without
      quotes)
-8. Drag the `Firebase.h` header in this directory into your project. This will
+9. Drag the `Firebase.h` header in this directory into your project. This will
    allow you to `#import "Firebase.h"` and start using any Firebase SDK that you
    have.
-9. If you're using Swift, or you want to use modules, drag module.modulemap into
+10. If you're using Swift want to use modules, drag `module.modulemap` into
    your project and update your User Header Search Paths to contain the
    directory that contains your module map.
-10. You're done! Compile your target and start using Firebase.
+11. You're done! Compile your target and start using Firebase.
 
 If you want to add another SDK, repeat the steps above with the frameworks for
 the new SDK. You only need to add each framework once, so if you've already
@@ -76,7 +77,9 @@ You can get samples for Firebase from https://github.com/firebase/quickstart-ios
 
 Note that several of the samples depend on SDKs that are not included with
 this archive; for example, FirebaseUI. For the samples that depend on SDKs not
-included in this archive, you'll need to use CocoaPods.
+included in this archive, you'll need to use CocoaPods or use the
+[ZipBuilder](https://github.com/firebase/firebase-ios-sdk/tree/master/ZipBuilder)
+to create your own custom binary frameworks.
 
 # Versions
 


### PR DESCRIPTION
Update and refactor Carthage build for the xcframework changes.

Carthage does not yet support xcframeworks, so this should generate the same build as before for Carthage.

In the refactor, Carthage builds and adaptations are pushed lower in the process to avoid complicated adjustments in the higher level functions that had to reach down to make changes into low-level generated build artifacts.

Both zip and Carthage share the same compile phases, but then separately package to xcframeworks and frameworks. Carthage rebuilds FirebaseCoreDiagnostics with the right flags and skips including the Catalyst slice.

Fix #4917 