### PR TITLE
Use FIRInstallations SDK to fetch FID and FIS token, send those values in requests to FIAM backend

### DIFF
--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -43,7 +43,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
 
   s.dependency 'FirebaseCore', '~> 6.2'
   s.ios.dependency 'FirebaseAnalyticsInterop', '~> 1.3'
-  s.dependency 'FirebaseInstanceID', '~> 4.0'
+  s.dependency 'FirebaseInstallations', '~> 1.1'
   s.dependency 'GoogleDataTransportCCTSupport', '~> 2.0'
   s.dependency 'FirebaseABTesting', '~> 3.2'
 

--- a/FirebaseInAppMessaging/Sources/FIRInAppMessaging.m
+++ b/FirebaseInAppMessaging/Sources/FIRInAppMessaging.m
@@ -23,6 +23,7 @@
 #import <FirebaseCore/FIRComponent.h>
 #import <FirebaseCore/FIRComponentContainer.h>
 #import <FirebaseCore/FIRDependency.h>
+#import <FirebaseInstallations/FIRInstallations.h>
 
 #import "FIRCore+InAppMessaging.h"
 #import "FIRIAMDisplayExecutor.h"
@@ -62,7 +63,10 @@ static BOOL _autoBootstrapOnFIRAppInit = YES;
     // Ensure it's cached so it returns the same instance every time fiam is called.
     *isCacheable = YES;
     id<FIRAnalyticsInterop> analytics = FIR_COMPONENT(FIRAnalyticsInterop, container);
-    return [[FIRInAppMessaging alloc] initWithAnalytics:analytics];
+    FIRInstallations *installations =
+        [FIRInstallations installationsWithApp:container.app];
+    return [[FIRInAppMessaging alloc] initWithAnalytics:analytics
+                                          installations:installations];
   };
   FIRComponent *fiamProvider =
       [FIRComponent componentWithProtocol:@protocol(FIRInAppMessagingInstanceProvider)
@@ -93,10 +97,12 @@ static BOOL _autoBootstrapOnFIRAppInit = YES;
   }
 }
 
-- (instancetype)initWithAnalytics:(id<FIRAnalyticsInterop>)analytics {
+- (instancetype)initWithAnalytics:(id<FIRAnalyticsInterop>)analytics
+                    installations:(FIRInstallations *)installations {
   if (self = [super init]) {
     _messageDisplaySuppressed = NO;
     _analytics = analytics;
+    _installations = installations;
   }
   return self;
 }

--- a/FirebaseInAppMessaging/Sources/FIRInAppMessaging.m
+++ b/FirebaseInAppMessaging/Sources/FIRInAppMessaging.m
@@ -63,10 +63,8 @@ static BOOL _autoBootstrapOnFIRAppInit = YES;
     // Ensure it's cached so it returns the same instance every time fiam is called.
     *isCacheable = YES;
     id<FIRAnalyticsInterop> analytics = FIR_COMPONENT(FIRAnalyticsInterop, container);
-    FIRInstallations *installations =
-        [FIRInstallations installationsWithApp:container.app];
-    return [[FIRInAppMessaging alloc] initWithAnalytics:analytics
-                                          installations:installations];
+    FIRInstallations *installations = [FIRInstallations installationsWithApp:container.app];
+    return [[FIRInAppMessaging alloc] initWithAnalytics:analytics installations:installations];
   };
   FIRComponent *fiamProvider =
       [FIRComponent componentWithProtocol:@protocol(FIRInAppMessagingInstanceProvider)

--- a/FirebaseInAppMessaging/Sources/FIRInAppMessagingPrivate.h
+++ b/FirebaseInAppMessaging/Sources/FIRInAppMessagingPrivate.h
@@ -18,9 +18,12 @@
 #import "FIRCore+InAppMessaging.h"
 #import "FIRInAppMessaging.h"
 
+@class FIRInstallations;
+
 @protocol FIRInAppMessagingInstanceProvider;
 @protocol FIRLibrary;
 
 @interface FIRInAppMessaging () <FIRInAppMessagingInstanceProvider, FIRLibrary>
 @property(nonatomic, readwrite, strong) id<FIRAnalyticsInterop> _Nullable analytics;
+@property(nonatomic, readwrite, strong) FIRInstallations  * _Nonnull installations;
 @end

--- a/FirebaseInAppMessaging/Sources/FIRInAppMessagingPrivate.h
+++ b/FirebaseInAppMessaging/Sources/FIRInAppMessagingPrivate.h
@@ -22,8 +22,9 @@
 
 @protocol FIRInAppMessagingInstanceProvider;
 @protocol FIRLibrary;
+@protocol FIRAnalyticsInterop;
 
 @interface FIRInAppMessaging () <FIRInAppMessagingInstanceProvider, FIRLibrary>
 @property(nonatomic, readwrite, strong) id<FIRAnalyticsInterop> _Nullable analytics;
-@property(nonatomic, readwrite, strong) FIRInstallations  * _Nonnull installations;
+@property(nonatomic, readwrite, strong) FIRInstallations* _Nonnull installations;
 @end

--- a/FirebaseInAppMessaging/Sources/FIRInAppMessagingPrivate.h
+++ b/FirebaseInAppMessaging/Sources/FIRInAppMessagingPrivate.h
@@ -24,7 +24,9 @@
 @protocol FIRLibrary;
 @protocol FIRAnalyticsInterop;
 
+NS_ASSUME_NONNULL_BEGIN
 @interface FIRInAppMessaging () <FIRInAppMessagingInstanceProvider, FIRLibrary>
 @property(nonatomic, readwrite, strong) id<FIRAnalyticsInterop> _Nullable analytics;
-@property(nonatomic, readwrite, strong) FIRInstallations* _Nonnull installations;
+@property(nonatomic, readwrite, strong) FIRInstallations* _Nullable installations;
 @end
+NS_ASSUME_NONNULL_END

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMClientInfoFetcher.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMClientInfoFetcher.m
@@ -43,8 +43,6 @@
                                             (void (^)(NSString *_Nullable FID,
                                                       NSString *_Nullable FISToken,
                                                       NSError *_Nullable error))completion {
-  // FIRInstallations *installations = [FIRInAppMessaging inAppMessaging].installations;
-
   if (!self.installations) {
     NSString *errorDesc = @"Couldn't generate Firebase Installation info";
     FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM190010", @"%@", errorDesc);

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMClientInfoFetcher.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMClientInfoFetcher.m
@@ -20,6 +20,7 @@
 
 #import "FIRCore+InAppMessaging.h"
 #import "FIRIAMClientInfoFetcher.h"
+#import "FIRIAMSDKRuntimeErrorCodes.h"
 #import "FIRInAppMessagingPrivate.h"
 
 @implementation FIRIAMClientInfoFetcher
@@ -32,8 +33,12 @@
   FIRInstallations *installations = [FIRInAppMessaging inAppMessaging].installations;
 
   if (!installations) {
-    FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM190010",
-                @"Couldn't generate Firebase Installation info");
+    NSString *errorDesc = @"Couldn't generate Firebase Installation info";
+    FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM190010", @"%@", errorDesc);
+    NSError *error = [NSError errorWithDomain:kFirebaseInAppMessagingErrorDomain
+                                         code:FIRIAMSDKRuntimeErrorNoFirebaseInstallationsObject
+                                     userInfo:@{NSLocalizedDescriptionKey : errorDesc}];
+    completion(nil, nil, error);
     return;
   }
 

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMClientInfoFetcher.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMClientInfoFetcher.m
@@ -51,6 +51,7 @@
             if (error) {
               FIRLogWarning(kFIRLoggerInAppMessaging, @"I-IAM190008", @"Error in fetching FID: %@",
                             error.localizedDescription);
+              completion(nil, tokenResult.authToken, error);
             } else {
               FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM190009",
                           @"Successfully in fetching both FID as %@ and FIS token as %@",

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMClientInfoFetcher.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMClientInfoFetcher.m
@@ -23,16 +23,29 @@
 #import "FIRIAMSDKRuntimeErrorCodes.h"
 #import "FIRInAppMessagingPrivate.h"
 
+@interface FIRIAMClientInfoFetcher ()
+
+@property(nonatomic, strong, nullable, readonly) FIRInstallations *installations;
+
+@end
+
 @implementation FIRIAMClientInfoFetcher
+
+- (instancetype)initWithFirebaseInstallations:(FIRInstallations *)installations {
+  if (self = [super init]) {
+    _installations = installations;
+  }
+  return self;
+}
 
 - (void)fetchFirebaseInstallationDataWithProjectNumber:(NSString *)projectNumber
                                         withCompletion:
                                             (void (^)(NSString *_Nullable FID,
                                                       NSString *_Nullable FISToken,
                                                       NSError *_Nullable error))completion {
-  FIRInstallations *installations = [FIRInAppMessaging inAppMessaging].installations;
+  // FIRInstallations *installations = [FIRInAppMessaging inAppMessaging].installations;
 
-  if (!installations) {
+  if (!self.installations) {
     NSString *errorDesc = @"Couldn't generate Firebase Installation info";
     FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM190010", @"%@", errorDesc);
     NSError *error = [NSError errorWithDomain:kFirebaseInAppMessagingErrorDomain
@@ -42,8 +55,9 @@
     return;
   }
 
-  [installations authTokenWithCompletion:^(FIRInstallationsAuthTokenResult *_Nullable tokenResult,
-                                           NSError *_Nullable error) {
+  [self.installations authTokenWithCompletion:^(
+                          FIRInstallationsAuthTokenResult *_Nullable tokenResult,
+                          NSError *_Nullable error) {
     if (error) {
       FIRLogWarning(kFIRLoggerInAppMessaging, @"I-IAM190006", @"Error in fetching FIS token: %@",
                     error.localizedDescription);
@@ -51,7 +65,7 @@
     } else {
       FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM190007", @"Successfully generated FIS token");
 
-      [installations
+      [self.installations
           installationIDWithCompletion:^(NSString *_Nullable identifier, NSError *_Nullable error) {
             if (error) {
               FIRLogWarning(kFIRLoggerInAppMessaging, @"I-IAM190008", @"Error in fetching FID: %@",

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMClientInfoFetcher.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMClientInfoFetcher.m
@@ -31,6 +31,12 @@
                                                       NSError *_Nullable error))completion {
   FIRInstallations *installations = [FIRInAppMessaging inAppMessaging].installations;
 
+  if (!installations) {
+    FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM190010",
+                @"Couldn't generate Firebase Installation info");
+    return;
+  }
+
   [installations authTokenWithCompletion:^(FIRInstallationsAuthTokenResult *_Nullable tokenResult,
                                            NSError *_Nullable error) {
     if (error) {

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMMsgFetcherUsingRestful.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMMsgFetcherUsingRestful.m
@@ -127,6 +127,7 @@ static NSInteger const SuccessHTTPStatusCode = 200;
 
   [request addValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
   [request addValue:@"application/json" forHTTPHeaderField:@"Accept"];
+  [request addValue:iidToken forHTTPHeaderField:@"x-goog-firebase-installations-auth"];
 
   NSMutableDictionary *postFetchDict = [[NSMutableDictionary alloc] init];
   [self updatePostFetchData:postFetchDict

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMMsgFetcherUsingRestful.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMMsgFetcherUsingRestful.m
@@ -267,21 +267,23 @@ static NSInteger const SuccessHTTPStatusCode = 200;
   // since the fetch operation frequency is low enough that we are not concerned about its impact
   // on server load and this guarantees that we always have an up-to-date iid values and tokens.
   [self.clientInfoFetcher
-      fetchFirebaseIIDDataWithProjectNumber:self.fbProjectNumber
-                             withCompletion:^(NSString *_Nullable iid, NSString *_Nullable token,
-                                              NSError *_Nullable error) {
-                               if (error) {
-                                 FIRLogWarning(kFIRLoggerInAppMessaging, @"I-IAM130008",
-                                               @"Not able to get iid value and/or token for "
-                                               @"talking to server: %@",
-                                               error.localizedDescription);
-                                 completion(nil, nil, 0, error);
-                               } else {
-                                 [self fetchMessagesWithImpressionList:impressonList
-                                                          withIIDvalue:iid
-                                                              IIDToken:token
-                                                            completion:completion];
-                               }
-                             }];
+      fetchFirebaseInstallationDataWithProjectNumber:self.fbProjectNumber
+                                      withCompletion:^(NSString *_Nullable FID,
+                                                       NSString *_Nullable FISToken,
+                                                       NSError *_Nullable error) {
+                                        if (error) {
+                                          FIRLogWarning(
+                                              kFIRLoggerInAppMessaging, @"I-IAM130008",
+                                              @"Not able to get iid value and/or token for "
+                                              @"talking to server: %@",
+                                              error.localizedDescription);
+                                          completion(nil, nil, 0, error);
+                                        } else {
+                                          [self fetchMessagesWithImpressionList:impressonList
+                                                                   withIIDvalue:FID
+                                                                       IIDToken:FISToken
+                                                                     completion:completion];
+                                        }
+                                      }];
 }
 @end

--- a/FirebaseInAppMessaging/Sources/Private/Analytics/FIRIAMClientInfoFetcher.h
+++ b/FirebaseInAppMessaging/Sources/Private/Analytics/FIRIAMClientInfoFetcher.h
@@ -24,7 +24,7 @@
 NS_ASSUME_NONNULL_BEGIN
 @interface FIRIAMClientInfoFetcher : NSObject
 
-- (instancetype)initWithFirebaseInstallations:(FIRInstallations *)installations;
+- (instancetype)initWithFirebaseInstallations:(nullable FIRInstallations *)installations;
 - (instancetype)init NS_UNAVAILABLE;
 
 // Fetch the up-to-date Firebase Installation ID (FID) and Firebase Installation Service (FIS) token

--- a/FirebaseInAppMessaging/Sources/Private/Analytics/FIRIAMClientInfoFetcher.h
+++ b/FirebaseInAppMessaging/Sources/Private/Analytics/FIRIAMClientInfoFetcher.h
@@ -16,17 +16,18 @@
 
 #import <Foundation/Foundation.h>
 
-// A class for wrapping the interactions for retrieving client side info to be used in request
-// parameter for interacting with Firebase iam servers.
+// A class for wrapping the interactions for retrieving client side info to be used in
+// request parameter for interacting with Firebase iam servers.
 
 NS_ASSUME_NONNULL_BEGIN
 @interface FIRIAMClientInfoFetcher : NSObject
-// Fetch the up-to-date Firebase instance id and token data. Since it involves a server interaction,
+// Fetch the up-to-date FID and FIS token data. Since it involves a server interaction,
 // completion callback is provided for receiving the result.
-- (void)fetchFirebaseIIDDataWithProjectNumber:(NSString *)projectNumber
-                               withCompletion:(void (^)(NSString *_Nullable iid,
-                                                        NSString *_Nullable token,
-                                                        NSError *_Nullable error))completion;
+- (void)fetchFirebaseInstallationDataWithProjectNumber:(NSString *)projectNumber
+                                        withCompletion:
+                                            (void (^)(NSString *_Nullable FID,
+                                                      NSString *_Nullable FISToken,
+                                                      NSError *_Nullable error))completion;
 
 // Following are synchronous methods for fetching data
 - (nullable NSString *)getDeviceLanguageCode;

--- a/FirebaseInAppMessaging/Sources/Private/Analytics/FIRIAMClientInfoFetcher.h
+++ b/FirebaseInAppMessaging/Sources/Private/Analytics/FIRIAMClientInfoFetcher.h
@@ -16,11 +16,17 @@
 
 #import <Foundation/Foundation.h>
 
+@class FIRInstallations;
+
 // A class for wrapping the interactions for retrieving client side info to be used in
 // request parameter for interacting with Firebase iam servers.
 
 NS_ASSUME_NONNULL_BEGIN
 @interface FIRIAMClientInfoFetcher : NSObject
+
+- (instancetype)initWithFirebaseInstallations:(FIRInstallations *)installations;
+- (instancetype)init NS_UNAVAILABLE;
+
 // Fetch the up-to-date Firebase Installation ID (FID) and Firebase Installation Service (FIS) token
 // data. Since it involves a server interaction, completion callback is provided for receiving the
 // result.

--- a/FirebaseInAppMessaging/Sources/Private/Analytics/FIRIAMClientInfoFetcher.h
+++ b/FirebaseInAppMessaging/Sources/Private/Analytics/FIRIAMClientInfoFetcher.h
@@ -21,8 +21,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 @interface FIRIAMClientInfoFetcher : NSObject
-// Fetch the up-to-date FID and FIS token data. Since it involves a server interaction,
-// completion callback is provided for receiving the result.
+// Fetch the up-to-date Firebase Installation ID (FID) and Firebase Installation Service (FIS) token
+// data. Since it involves a server interaction, completion callback is provided for receiving the
+// result.
 - (void)fetchFirebaseInstallationDataWithProjectNumber:(NSString *)projectNumber
                                         withCompletion:
                                             (void (^)(NSString *_Nullable FID,

--- a/FirebaseInAppMessaging/Sources/Runtime/FIRIAMRuntimeManager.m
+++ b/FirebaseInAppMessaging/Sources/Runtime/FIRIAMRuntimeManager.m
@@ -379,23 +379,27 @@ static NSString *const kFirebaseInAppMessagingAutoDataCollectionKey =
                                              @"Start SDK runtime components.");
 
                                  [self.clientInfoFetcher
-                                     fetchFirebaseIIDDataWithProjectNumber:
+                                     fetchFirebaseInstallationDataWithProjectNumber:
                                          self.currentSetting.firebaseProjectNumber
-                                                            withCompletion:^(
-                                                                NSString *_Nullable iid,
-                                                                NSString *_Nullable token,
-                                                                NSError *_Nullable error) {
-                                                              // Always dump the instance id into
-                                                              // log on startup to help developers
-                                                              // to find it for their app instance.
-                                                              FIRLogDebug(kFIRLoggerInAppMessaging,
-                                                                          @"I-IAM180017",
-                                                                          @"Starting "
-                                                                          @"InAppMessaging runtime "
-                                                                          @"with "
-                                                                           "Instance ID %@",
-                                                                          iid);
-                                                            }];
+                                                                     withCompletion:^(
+                                                                         NSString *_Nullable FID,
+                                                                         NSString
+                                                                             *_Nullable FISToken,
+                                                                         NSError *_Nullable error) {
+                                                                       // Always dump the instance
+                                                                       // id into log on startup to
+                                                                       // help developers to find it
+                                                                       // for their app instance.
+                                                                       FIRLogDebug(
+                                                                           kFIRLoggerInAppMessaging,
+                                                                           @"I-IAM180017",
+                                                                           @"Starting "
+                                                                           @"InAppMessaging "
+                                                                           @"runtime "
+                                                                           @"with "
+                                                                            "Instance ID %@",
+                                                                           FID);
+                                                                     }];
 
                                  [self.fetchOnAppForegroundFlow start];
                                  [self.displayOnFIRAnalyticEventsFlow start];

--- a/FirebaseInAppMessaging/Sources/Runtime/FIRIAMRuntimeManager.m
+++ b/FirebaseInAppMessaging/Sources/Runtime/FIRIAMRuntimeManager.m
@@ -36,10 +36,7 @@
 #import "FIRIAMRuntimeManager.h"
 #import "FIRIAMSDKModeManager.h"
 #import "FIRInAppMessaging.h"
-
-@interface FIRInAppMessaging ()
-@property(nonatomic, readwrite, strong) id<FIRAnalyticsInterop> _Nullable analytics;
-@end
+#import "FIRInAppMessagingPrivate.h"
 
 // A enum indicating 3 different possiblities of a setting about auto data collection.
 typedef NS_ENUM(NSInteger, FIRIAMAutoDataCollectionSetting) {
@@ -267,7 +264,9 @@ static NSString *const kFirebaseInAppMessagingAutoDataCollectionKey =
   self.messageCache = [[FIRIAMMessageClientCache alloc] initWithBookkeeper:self.bookKeeper
                                                        usingResponseParser:self.responseParser];
   self.fetchResultStorage = [[FIRIAMServerMsgFetchStorage alloc] init];
-  self.clientInfoFetcher = [[FIRIAMClientInfoFetcher alloc] init];
+
+  self.clientInfoFetcher = [[FIRIAMClientInfoFetcher alloc]
+      initWithFirebaseInstallations:[FIRInAppMessaging inAppMessaging].installations];
 
   self.restfulFetcher =
       [[FIRIAMMsgFetcherUsingRestful alloc] initWithHost:settings.apiServerHost

--- a/FirebaseInAppMessaging/Sources/Runtime/FIRIAMSDKRuntimeErrorCodes.h
+++ b/FirebaseInAppMessaging/Sources/Runtime/FIRIAMSDKRuntimeErrorCodes.h
@@ -27,5 +27,5 @@ typedef NS_ENUM(NSInteger, FIRIAMSDKRuntimeError) {
   FIRIAMSDKRuntimeErrorNonHTTPResponseForImage = 2,
 
   // Failed to fetch Firebase Installations object.
-  FIRIAMSDKRuntimeErrorNoFirebaseInstallationsObject = 2,
+  FIRIAMSDKRuntimeErrorNoFirebaseInstallationsObject = 3,
 };

--- a/FirebaseInAppMessaging/Sources/Runtime/FIRIAMSDKRuntimeErrorCodes.h
+++ b/FirebaseInAppMessaging/Sources/Runtime/FIRIAMSDKRuntimeErrorCodes.h
@@ -25,4 +25,7 @@ typedef NS_ENUM(NSInteger, FIRIAMSDKRuntimeError) {
 
   // The response when fetching the image is non-HTTP.
   FIRIAMSDKRuntimeErrorNonHTTPResponseForImage = 2,
+
+  // Failed to fetch Firebase Installations object.
+  FIRIAMSDKRuntimeErrorNoFirebaseInstallationsObject = 2,
 };

--- a/FirebaseInAppMessaging/Tests/Integration/FunctionalTestApp/Podfile
+++ b/FirebaseInAppMessaging/Tests/Integration/FunctionalTestApp/Podfile
@@ -4,7 +4,6 @@ source 'https://cdn.cocoapods.org/'
 
 pod 'FirebaseAnalytics'
 pod 'FirebaseCore', :path => '../../../..'
-pod 'FirebaseInstanceID',  :path => '../../../..'
 pod 'FirebaseInstallations', :path => '../../../..'
 pod 'FirebaseCoreDiagnostics', :path => '../../../..'
 pod 'FirebaseCoreDiagnosticsInterop', :path => '../../../..'

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMClearcutLoggerTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMClearcutLoggerTests.m
@@ -56,9 +56,10 @@ NSString *sdkVersion = @"SDK version";
   self.mockCtUploader = OCMClassMock(FIRIAMClearcutUploader.class);
 
   OCMStub([self.mockClientInfoFetcher
-      fetchFirebaseIIDDataWithProjectNumber:[OCMArg any]
-                             withCompletion:([OCMArg invokeBlockWithArgs:iid, @"token",
-                                                                         [NSNull null], nil])]);
+      fetchFirebaseInstallationDataWithProjectNumber:[OCMArg any]
+                                      withCompletion:([OCMArg invokeBlockWithArgs:iid, @"token",
+                                                                                  [NSNull null],
+                                                                                  nil])]);
 
   OCMStub([self.mockClientInfoFetcher getIAMSDKVersion]).andReturn(sdkVersion);
   OCMStub([self.mockClientInfoFetcher getOSVersion]).andReturn(osVersion);

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMClientInfoFetcherTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMClientInfoFetcherTests.m
@@ -1,51 +1,139 @@
 /*
-* Copyright 2020 Google
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*      http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-#import <XCTest/XCTest.h>
 #import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
 
 #import "FIRIAMClientInfoFetcher.h"
 
 #import <FirebaseInstallations/FIRInstallations.h>
+#import <FirebaseInstallations/FIRInstallationsAuthTokenResult.h>
+
+@interface FIRInstallationsAuthTokenResult (Tests)
+- (instancetype)initWithToken:(NSString *)token expirationDate:(NSDate *)expirationDate;
+@end
 
 @interface FIRIAMClientInfoFetcherTests : XCTestCase
+
+@property(nonatomic, strong) FIRIAMClientInfoFetcher *clientInfoFetcher;
 
 @end
 
 @implementation FIRIAMClientInfoFetcherTests
 
+- (NSDate *)future {
+  return [[NSDate date] dateByAddingTimeInterval:10000];
+}
+
 - (void)setUp {
-  [self mockInstanceIDMethodForTokenAndIdentity:@"hey_im_token" tokenError:nil identity:@"hey_im" identityError:nil];
+  // Set up for the happy bath where both FID and FIS token are returned.
+  FIRInstallationsAuthTokenResult *tokenResult =
+      [[FIRInstallationsAuthTokenResult alloc] initWithToken:@"mock_token"
+                                              expirationDate:[self future]];
+  id mockInstallations = [self mockInstanceIDMethodForTokenAndIdentity:tokenResult
+                                                            tokenError:nil
+                                                              identity:@"mock_id"
+                                                         identityError:nil];
+
+  self.clientInfoFetcher =
+      [[FIRIAMClientInfoFetcher alloc] initWithFirebaseInstallations:mockInstallations];
 }
 
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
+- (void)testReturnsBothFIDAndToken {
+  [self.clientInfoFetcher
+      fetchFirebaseInstallationDataWithProjectNumber:@"my project number"
+                                      withCompletion:^(NSString *_Nullable FID,
+                                                       NSString *_Nullable FISToken,
+                                                       NSError *_Nullable error) {
+                                        XCTAssertEqualObjects(FID, @"mock_id");
+                                        XCTAssertEqualObjects(FISToken, @"mock_token");
+                                        XCTAssertNil(error);
+                                      }];
 }
 
-- (void)testExample {
-    // This is an example of a functional test case.
-    // Use XCTAssert and related functions to verify your tests produce the correct results.
+- (void)testReturnsTokenButNotFID {
+  // Mock error where no installations ID was fetched.
+  NSError *error =
+      [NSError errorWithDomain:@"com.mock.installations"
+                          code:0
+                      userInfo:@{NSLocalizedDescriptionKey : @"Installations couldn't return FID"}];
+
+  FIRInstallationsAuthTokenResult *tokenResult =
+      [[FIRInstallationsAuthTokenResult alloc] initWithToken:@"mock_token"
+                                              expirationDate:[self future]];
+  id mockInstallations = [self mockInstanceIDMethodForTokenAndIdentity:tokenResult
+                                                            tokenError:nil
+                                                              identity:nil
+                                                         identityError:error];
+
+  self.clientInfoFetcher =
+      [[FIRIAMClientInfoFetcher alloc] initWithFirebaseInstallations:mockInstallations];
+
+  [self.clientInfoFetcher
+      fetchFirebaseInstallationDataWithProjectNumber:@"my project number"
+                                      withCompletion:^(NSString *_Nullable FID,
+                                                       NSString *_Nullable FISToken,
+                                                       NSError *_Nullable error) {
+                                        // FID should be nil.
+                                        XCTAssertNil(FID);
+                                        // FIS token is still passed.
+                                        XCTAssertEqualObjects(FISToken, @"mock_token");
+                                        // Validate error gets propagated.
+                                        XCTAssertEqualObjects(error.localizedDescription,
+                                                              @"Installations couldn't return FID");
+                                      }];
 }
 
-// Mock instance ID methods.
-- (void)mockInstanceIDMethodForTokenAndIdentity:(nullable NSString *)token
-                                     tokenError:(nullable NSError *)tokenError
-                                       identity:(nullable NSString *)identity
-                                  identityError:(nullable NSError *)identityError {
-  // Mock the installations retreival method.
+- (void)testDoesntReturnToken {
+  // Mock error where no auth token was fetched.
+  NSError *error = [NSError
+      errorWithDomain:@"com.mock.installations"
+                 code:0
+             userInfo:@{NSLocalizedDescriptionKey : @"Installations couldn't return FIS token"}];
+
+  id mockInstallations = [self mockInstanceIDMethodForTokenAndIdentity:nil
+                                                            tokenError:error
+                                                              identity:nil
+                                                         identityError:nil];
+
+  self.clientInfoFetcher =
+      [[FIRIAMClientInfoFetcher alloc] initWithFirebaseInstallations:mockInstallations];
+
+  OCMReject([mockInstallations installationIDWithCompletion:[OCMArg any]]);
+
+  [self.clientInfoFetcher
+      fetchFirebaseInstallationDataWithProjectNumber:@"my project number"
+                                      withCompletion:^(NSString *_Nullable FID,
+                                                       NSString *_Nullable FISToken,
+                                                       NSError *_Nullable error) {
+                                        XCTAssertNil(FID);
+                                        XCTAssertNil(FISToken);
+                                        // Validate error gets propagated.
+                                        XCTAssertEqualObjects(
+                                            error.localizedDescription,
+                                            @"Installations couldn't return FIS token");
+                                      }];
+}
+
+// Mock FIRInstallations methods.
+- (id)mockInstanceIDMethodForTokenAndIdentity:
+          (nullable FIRInstallationsAuthTokenResult *)tokenResult
+                                   tokenError:(nullable NSError *)tokenError
+                                     identity:(nullable NSString *)identity
+                                identityError:(nullable NSError *)identityError {
   id installationsMock = OCMClassMock([FIRInstallations class]);
   OCMStub([installationsMock
       installationIDWithCompletion:([OCMArg
@@ -54,10 +142,11 @@
                                                                           : [NSNull null]),
                                                            nil])]);
   OCMStub([installationsMock
-      authTokenWithCompletion:([OCMArg invokeBlockWithArgs:(identity ? identity : [NSNull null]),
-                                                           (identityError ? identityError
-                                                                          : [NSNull null]),
-                                                           nil])]);
+      authTokenWithCompletion:([OCMArg
+                                  invokeBlockWithArgs:(tokenResult ? tokenResult : [NSNull null]),
+                                                      (tokenError ? tokenError : [NSNull null]),
+                                                      nil])]);
+  return installationsMock;
 }
 
 @end

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMClientInfoFetcherTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMClientInfoFetcherTests.m
@@ -1,0 +1,63 @@
+/*
+* Copyright 2020 Google
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#import <XCTest/XCTest.h>
+#import <OCMock/OCMock.h>
+
+#import "FIRIAMClientInfoFetcher.h"
+
+#import <FirebaseInstallations/FIRInstallations.h>
+
+@interface FIRIAMClientInfoFetcherTests : XCTestCase
+
+@end
+
+@implementation FIRIAMClientInfoFetcherTests
+
+- (void)setUp {
+  [self mockInstanceIDMethodForTokenAndIdentity:@"hey_im_token" tokenError:nil identity:@"hey_im" identityError:nil];
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+// Mock instance ID methods.
+- (void)mockInstanceIDMethodForTokenAndIdentity:(nullable NSString *)token
+                                     tokenError:(nullable NSError *)tokenError
+                                       identity:(nullable NSString *)identity
+                                  identityError:(nullable NSError *)identityError {
+  // Mock the installations retreival method.
+  id installationsMock = OCMClassMock([FIRInstallations class]);
+  OCMStub([installationsMock
+      installationIDWithCompletion:([OCMArg
+                                       invokeBlockWithArgs:(identity ? identity : [NSNull null]),
+                                                           (identityError ? identityError
+                                                                          : [NSNull null]),
+                                                           nil])]);
+  OCMStub([installationsMock
+      authTokenWithCompletion:([OCMArg invokeBlockWithArgs:(identity ? identity : [NSNull null]),
+                                                           (identityError ? identityError
+                                                                          : [NSNull null]),
+                                                           nil])]);
+}
+
+@end

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMMsgFetcherUsingRestfulTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMMsgFetcherUsingRestfulTests.m
@@ -75,12 +75,13 @@ static NSString *apiKey = @"Api-key";
                                         // this unit testing
   ]);
 
-  NSString *iidValue = @"my iid";
-  NSString *iidToken = @"my iid token";
+  NSString *FIDValue = @"my FID";
+  NSString *FISToken = @"my FIS token";
   OCMStub([self.mockclientInfoFetcher
-      fetchFirebaseIIDDataWithProjectNumber:[OCMArg any]
-                             withCompletion:([OCMArg invokeBlockWithArgs:iidValue, iidToken,
-                                                                         [NSNull null], nil])]);
+      fetchFirebaseInstallationDataWithProjectNumber:[OCMArg any]
+                                      withCompletion:([OCMArg
+                                                         invokeBlockWithArgs:FIDValue, FISToken,
+                                                                             [NSNull null], nil])]);
 
   NSString *osVersion = @"OS Version";
   OCMStub([self.mockclientInfoFetcher getOSVersion]).andReturn(osVersion);
@@ -126,8 +127,8 @@ static NSString *apiKey = @"Api-key";
                                       options:kNilOptions
                                         error:&errorJson];
   XCTAssertEqualObjects(appId, requestBodyDict[@"requesting_client_app"][@"gmp_app_id"]);
-  XCTAssertEqualObjects(iidValue, requestBodyDict[@"requesting_client_app"][@"app_instance_id"]);
-  XCTAssertEqualObjects(iidToken,
+  XCTAssertEqualObjects(FIDValue, requestBodyDict[@"requesting_client_app"][@"app_instance_id"]);
+  XCTAssertEqualObjects(FISToken,
                         requestBodyDict[@"requesting_client_app"][@"app_instance_id_token"]);
 
   XCTAssertEqualObjects(osVersion, requestBodyDict[@"client_signals"][@"platform_version"]);
@@ -147,12 +148,13 @@ static NSString *apiKey = @"Api-key";
                                         // this unit testing
   ]);
 
-  NSString *iidValue = @"my iid";
-  NSString *iidToken = @"my iid token";
+  NSString *FIDValue = @"my FID";
+  NSString *FISToken = @"my FIS token";
   OCMStub([self.mockclientInfoFetcher
-      fetchFirebaseIIDDataWithProjectNumber:[OCMArg any]
-                             withCompletion:([OCMArg invokeBlockWithArgs:iidValue, iidToken,
-                                                                         [NSNull null], nil])]);
+      fetchFirebaseInstallationDataWithProjectNumber:[OCMArg any]
+                                      withCompletion:([OCMArg
+                                                         invokeBlockWithArgs:FIDValue, FISToken,
+                                                                             [NSNull null], nil])]);
 
   // this is to test the case that only partial client signal fields are available
   NSString *osVersion = @"OS Version";
@@ -205,15 +207,15 @@ static NSString *apiKey = @"Api-key";
   XCTAssertNil(requestBodyDict[@"client_signals"][@"language_code"]);
 }
 
-- (void)testBailoutOnIIDError {
+- (void)testBailoutOnFIDError {
   // in this test, the attempt to fetch iid data failed and as a result, we expect the whole
   // fetch operation attempt to fail with that error
-  NSError *iidError = [[NSError alloc] initWithDomain:@"Error Domain" code:100 userInfo:nil];
+  NSError *FIDError = [[NSError alloc] initWithDomain:@"Error Domain" code:100 userInfo:nil];
   OCMStub([self.mockclientInfoFetcher
-      fetchFirebaseIIDDataWithProjectNumber:[OCMArg any]
-                             withCompletion:([OCMArg invokeBlockWithArgs:[NSNull null],
-                                                                         [NSNull null], iidError,
-                                                                         nil])]);
+      fetchFirebaseInstallationDataWithProjectNumber:[OCMArg any]
+                                      withCompletion:([OCMArg invokeBlockWithArgs:[NSNull null],
+                                                                                  [NSNull null],
+                                                                                  FIDError, nil])]);
 
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"fetch callback block triggered."];
@@ -224,7 +226,7 @@ static NSString *apiKey = @"Api-key";
                                         NSInteger discardCount, NSError *_Nullable error) {
                          // expecting triggering the completion callback with error
                          XCTAssertNil(messages);
-                         XCTAssertEqualObjects(iidError, error);
+                         XCTAssertEqualObjects(FIDError, error);
                          [expectation fulfill];
                        }];
 


### PR DESCRIPTION
This is an initial FIS integration step, using FID and the FIS token in place of where we are currently using IID and the IID token.

Will follow up with another PR to replace all usages of `iid` or `instanceID` to avoid confusion-- this one has already gotten fairly large.

Next step is to only use FIS token in the server request, see internal bug #148729615.

#fixes #3887