### PR TITLE
Don't attempt to create data if the event's fileURL is nil.

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCOREvent.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCOREvent.m
@@ -37,8 +37,7 @@
     _target = target;
     _qosTier = GDTCOREventQosDefault;
   }
-  GDTCORLogDebug("Event %@ created. mappingID: %@ target:%ld qos:%ld", self, _mappingID,
-                 (long)_target, (long)_qosTier);
+  GDTCORLogDebug("Event %@ created. mappingID: %@ target:%ld", self, mappingID, (long)target);
   return self;
 }
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORTransport.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORTransport.m
@@ -41,8 +41,8 @@
     _target = target;
     _transformerInstance = [GDTCORTransformer sharedInstance];
   }
-  GDTCORLogDebug("Transport object created. mappingID:%@ transformers:%@ target:%ld", _mappingID,
-                 _transformers, (long)_target);
+  GDTCORLogDebug("Transport object created. mappingID:%@ transformers:%@ target:%ld", mappingID,
+                 transformers, (long)target);
   return self;
 }
 

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORConsoleLogger.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORConsoleLogger.h
@@ -64,7 +64,10 @@ typedef NS_ENUM(NSInteger, GDTCORMessageCode) {
   /** For fatal errors. Please go to https://github.com/firebase/firebase-ios-sdk/issues and open
    * an issue if you encounter an error with this code.
    */
-  GDTCORMCEFatalAssertion = 1007
+  GDTCORMCEFatalAssertion = 1007,
+
+  /** For error messages concerning the reading of a event file. */
+  GDTCORMCEFileReadError = 1008
 };
 
 /** Prints the given code and format string to the console.

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
@@ -153,6 +153,7 @@ gdt_cct_LogEvent GDTCCTConstructLogEvent(GDTCOREvent *event) {
     extensionBytes = [NSData dataWithContentsOfURL:event.fileURL options:0 error:&error];
   } else {
     GDTCORLogError(GDTCORMCEFileWriteError, @"%@", @"An event's fileURL property was nil.");
+    return logEvent;
   }
   if (error) {
     GDTCORLogError(GDTCORMCEGeneralError,

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
@@ -152,7 +152,7 @@ gdt_cct_LogEvent GDTCCTConstructLogEvent(GDTCOREvent *event) {
   if (event.fileURL) {
     extensionBytes = [NSData dataWithContentsOfURL:event.fileURL options:0 error:&error];
   } else {
-    GDTCORLogError(GDTCORMCEFileWriteError, @"%@", @"An event's fileURL property was nil.");
+    GDTCORLogError(GDTCORMCEFileReadError, @"%@", @"An event's fileURL property was nil.");
     return logEvent;
   }
   if (error) {

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
@@ -148,7 +148,12 @@ gdt_cct_LogEvent GDTCCTConstructLogEvent(GDTCOREvent *event) {
     logEvent.has_network_connection_info = 1;
   }
   NSError *error;
-  NSData *extensionBytes = [NSData dataWithContentsOfURL:event.fileURL options:0 error:&error];
+  NSData *extensionBytes;
+  if (event.fileURL) {
+    extensionBytes = [NSData dataWithContentsOfURL:event.fileURL options:0 error:&error];
+  } else {
+    GDTCORLogError(GDTCORMCEFileWriteError, @"%@", @"An event's fileURL property was nil.");
+  }
   if (error) {
     GDTCORLogError(GDTCORMCEGeneralError,
                    @"There was an error reading extension bytes from disk: %@", error);


### PR DESCRIPTION
This could be because of changes to NSCoding w.r.t. transitioning from GDTCORStoredEvent to GDTCOREvent.

Fixes #5082 