### PR TITLE
Zip Resource handling for xcframeworks

### DIFF
--- a/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
@@ -109,24 +109,6 @@ extension CarthageUtils {
         }
       }
 
-      // Make updates to all frameworks to make Carthage happy. We don't worry about xcframeworks
-      // here.
-      let allFileObjects = FileManager.default.enumerator(atPath: fullPath.path)?.allObjects
-      guard let allFiles = allFileObjects as? [String] else {
-        fatalError("Failed to get file list for Carthage construction at \(fullPath.path)")
-      }
-      let frameworks = allFiles.filter { $0.hasSuffix(".framework") }
-      for framework in frameworks {
-        let plistPath = fullPath.appendingPathComponents([framework, "Info.plist"])
-        // Drop the extension of the framework name.
-        let plist = generatePlistContents(forName: framework.components(separatedBy: ".").first!)
-        do {
-          try plist.write(to: plistPath)
-        } catch {
-          fatalError("Could not copy plist for \(framework) for Carthage release. \(error)")
-        }
-      }
-
       // Analytics includes all the Core frameworks and Firebase module, do extra work to package
       // it.
       if product == "FirebaseAnalytics" {
@@ -266,7 +248,7 @@ extension CarthageUtils {
     }
   }
 
-  private static func generatePlistContents(forName name: String) -> Data {
+  static func generatePlistContents(forName name: String) -> Data {
     let plist: [String: String] = ["CFBundleIdentifier": "com.firebase.Firebase",
                                    "CFBundleInfoDictionaryVersion": "6.0",
                                    "CFBundlePackageType": "FMWK",

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -658,16 +658,12 @@ struct ZipBuilder {
     // Create the temporary directory we'll be storing the build/assembled frameworks in, and remove
     // the Resources directory if it already exists.
     let tempDir = fileManager.temporaryDirectory(withName: "all_frameworks")
-    let tempResourceDir = tempDir.appendingPathComponent("Resources")
     do {
       try fileManager.createDirectory(at: tempDir,
                                       withIntermediateDirectories: true,
                                       attributes: nil)
-      if fileManager.directoryExists(at: tempResourceDir) {
-        try fileManager.removeItem(at: tempResourceDir)
-      }
     } catch {
-      fatalError("Cannot create temporary directory to store frameworks and resources from the " +
+      fatalError("Cannot create temporary directory to store frameworks from the " +
         "full build: \(error)")
     }
 


### PR DESCRIPTION
Storing resources in the frameworks embedded in the xcframework was causing a crash when the resources were moved to the top of the folder since there were three copies instead of one.

This PR refactors the resource to build them into Carthage frameworks from the start and at the top of an xcframework (so there's only one copy) that can be then moved out to the enclosing folder for the Firebase zip distribution.