### PR TITLE
In banner view, pin top elements to the bottom of the status bar

### DIFF
--- a/FirebaseInAppMessaging/Resources/FIRInAppMessageDisplayStoryboard.storyboard
+++ b/FirebaseInAppMessaging/Resources/FIRInAppMessageDisplayStoryboard.storyboard
@@ -95,7 +95,7 @@
                             </constraint>
                             <constraint firstItem="GOK-vx-mU8" firstAttribute="leading" secondItem="rzo-9i-rXZ" secondAttribute="leading" id="J6L-hu-jV6"/>
                             <constraint firstItem="VfB-vw-7up" firstAttribute="leading" secondItem="vRb-yf-OWE" secondAttribute="leading" constant="5" id="gGt-ku-pPu"/>
-                            <constraint firstItem="rzo-9i-rXZ" firstAttribute="top" secondItem="lHf-Ux-dEc" secondAttribute="bottom" constant="3" id="hhi-1K-2YO"/>
+                            <constraint firstItem="rzo-9i-rXZ" firstAttribute="top" secondItem="lHf-Ux-dEc" secondAttribute="bottom" constant="3" placeholder="YES" id="hhi-1K-2YO"/>
                             <constraint firstItem="VfB-vw-7up" firstAttribute="top" secondItem="rzo-9i-rXZ" secondAttribute="top" id="nF9-EZ-bjS"/>
                             <constraint firstAttribute="trailingMargin" secondItem="rzo-9i-rXZ" secondAttribute="trailing" id="pOl-wC-mqq"/>
                             <constraint firstItem="rzo-9i-rXZ" firstAttribute="leading" secondItem="VfB-vw-7up" secondAttribute="trailing" constant="5" id="vSo-6t-cZ0"/>

--- a/FirebaseInAppMessaging/Sources/DefaultUI/Banner/FIRIAMBannerViewController.m
+++ b/FirebaseInAppMessaging/Sources/DefaultUI/Banner/FIRIAMBannerViewController.m
@@ -155,6 +155,21 @@ static const CGFloat kSwipeUpThreshold = -10.0f;
   self.view.layer.shadowRadius = 2;
   self.view.layer.shadowOpacity = 0.4;
 
+  // Calculate status bar height.
+  CGFloat statusBarHeight = 0;
+  if (@available(iOS 13.0, *)) {
+    UIStatusBarManager *manager =
+        [UIApplication sharedApplication].keyWindow.windowScene.statusBarManager;
+
+    statusBarHeight = manager.statusBarFrame.size.height;
+  } else {
+    statusBarHeight = [[UIApplication sharedApplication] statusBarFrame].size.height;
+  }
+
+  // Pin title label below status bar with cushion.
+  [[self.titleLabel.topAnchor constraintEqualToAnchor:self.view.topAnchor
+                                             constant:statusBarHeight + 3] setActive:YES];
+
   // When created, we are hiding it for later animation
   self.hidingForAnimation = YES;
   [self setupAutoDismissTimer];

--- a/FirebaseInAppMessaging/Sources/DefaultUI/Banner/FIRIAMBannerViewController.m
+++ b/FirebaseInAppMessaging/Sources/DefaultUI/Banner/FIRIAMBannerViewController.m
@@ -157,14 +157,18 @@ static const CGFloat kSwipeUpThreshold = -10.0f;
 
   // Calculate status bar height.
   CGFloat statusBarHeight = 0;
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
   if (@available(iOS 13.0, *)) {
     UIStatusBarManager *manager =
         [UIApplication sharedApplication].keyWindow.windowScene.statusBarManager;
 
     statusBarHeight = manager.statusBarFrame.size.height;
   } else {
+#endif
     statusBarHeight = [[UIApplication sharedApplication] statusBarFrame].size.height;
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
   }
+#endif
 
   // Pin title label below status bar with cushion.
   [[self.titleLabel.topAnchor constraintEqualToAnchor:self.view.topAnchor


### PR DESCRIPTION
- Removes storyboard constraint (at build time) that pins top level UI elements to the top layout guide
- Adds programmatic constraint that pins them to the bottom of the status bar

#fixes #4714 

After fix:
![new](https://user-images.githubusercontent.com/43829046/76621804-a2936800-6506-11ea-91af-c7be49404162.png)

Before fix:
![old](https://user-images.githubusercontent.com/43829046/76621807-a3c49500-6506-11ea-97c1-ff112ce9b2f7.png)
