### PR TITLE
Default to use new report upload endpoint when settings were failed to be fetched

### DIFF
--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -246,7 +246,7 @@ static void (^reportSentCallback)(void);
 
   count += _fileManager.processingPathContents.count;
 
-  if (self.settings.shouldUseNewReportEndpoint) {
+  if ([FIRCLSSettings shouldUseNewReportEndpointWithSettings:self.settings]) {
     count += _fileManager.preparedPathContents.count;
   } else {
     count += _fileManager.legacyPreparedPathContents.count;
@@ -682,7 +682,7 @@ static void (^reportSentCallback)(void);
 
 - (void)removeContentsInOtherReportingDirectories {
   [self removeExistingReportPaths:self.fileManager.processingPathContents];
-  if (self.settings.shouldUseNewReportEndpoint) {
+  if ([FIRCLSSettings shouldUseNewReportEndpointWithSettings:self.settings]) {
     [self removeExistingReportPaths:self.fileManager.preparedPathContents];
   } else {
     [self removeExistingReportPaths:self.fileManager.legacyPreparedPathContents];
@@ -710,7 +710,7 @@ static void (^reportSentCallback)(void);
 }
 
 - (void)handleExistingFilesInPreparedWithToken:(FIRCLSDataCollectionToken *)token {
-  NSArray *preparedPaths = self.settings.shouldUseNewReportEndpoint
+  NSArray *preparedPaths = [FIRCLSSettings shouldUseNewReportEndpointWithSettings:self.settings]
                                ? _fileManager.preparedPathContents
                                : _fileManager.legacyPreparedPathContents;
 

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportUploader.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportUploader.m
@@ -108,15 +108,16 @@
         }
 
         NSString *packagedPath;
+        BOOL shouldUseNewEndpoint =
+            [FIRCLSSettings shouldUseNewReportEndpointWithSettings:self.dataSource.settings];
 
-        FIRCLSDebugLog(@"Preparing the report for the new endpoint: %d",
-                       self.dataSource.settings.shouldUseNewReportEndpoint);
+        FIRCLSDebugLog(@"Preparing the report for the new endpoint: %d", shouldUseNewEndpoint);
 
         // With the new report endpoint, the report is deleted once it is written to GDT
         // Check if the report has a crash file before the report is moved or deleted
         BOOL isCrash = report.isCrash;
 
-        if (self.dataSource.settings.shouldUseNewReportEndpoint) {
+        if (shouldUseNewEndpoint) {
           // For the new endpoint, just move the .clsrecords from "processing" -> "prepared"
           if (![self.fileManager moveItemAtPath:report.path
                                     toDirectory:self.fileManager.preparedPath]) {
@@ -204,10 +205,13 @@
   FIRCLSDeveloperLog("Crashlytics:Crash:Reports", @"Submitting report%@",
                      urgent ? @" as urgent" : @"");
 
+  BOOL shouldUseNewEndpoint =
+      [FIRCLSSettings shouldUseNewReportEndpointWithSettings:self.dataSource.settings];
+
   // Check with the legacy path as the new path will always be contained in the legacy path
   BOOL isNewPreparedPath = ![path containsString:self.fileManager.legacyPreparedPath];
 
-  if (isNewPreparedPath && self.dataSource.settings.shouldUseNewReportEndpoint) {
+  if (isNewPreparedPath && shouldUseNewEndpoint) {
     if (![dataCollectionToken isValid]) {
       FIRCLSErrorLog(@"A report upload was requested with an invalid data collection token.");
       return NO;
@@ -260,7 +264,7 @@
 
     return success;
 
-  } else if (!isNewPreparedPath && !self.dataSource.settings.shouldUseNewReportEndpoint) {
+  } else if (!isNewPreparedPath && !shouldUseNewEndpoint) {
     return [self submitPackageMultipartMimeAtPath:path
                               dataCollectionToken:dataCollectionToken
                                     synchronously:urgent];

--- a/Crashlytics/Crashlytics/Models/FIRCLSSettings.h
+++ b/Crashlytics/Crashlytics/Models/FIRCLSSettings.h
@@ -103,11 +103,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) BOOL customExceptionsEnabled;
 
 /**
- * Determine if the SDK should use the new endpoint for uploading reports
- */
-@property(nonatomic, readonly) BOOL shouldUseNewReportEndpoint;
-
-/**
  * Returns the maximum number of custom exception events that will be
  * recorded in a session.
  */
@@ -128,6 +123,10 @@ NS_ASSUME_NONNULL_BEGIN
  * Returns the maximum number of custom key-value pair keys (not bytes).
  */
 @property(nonatomic, readonly) uint32_t maxCustomKeys;
+
+/// Determine if the SDK should use the new endpoint for uploading reports
+/// @param settings Fetched settings
++ (BOOL)shouldUseNewReportEndpointWithSettings:(nullable FIRCLSSettings *)settings;
 
 @end
 

--- a/Crashlytics/Crashlytics/Models/FIRCLSSettings.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSSettings.m
@@ -301,7 +301,7 @@ NSString *const BuildInstanceID = @"build_instance_id";
 
 + (BOOL)shouldUseNewReportEndpointWithSettings:(nullable FIRCLSSettings *)settings {
   // Default to use the new endpoint when settings were not successfully fetched 
-  if (!settings) {
+  if (!settings.settingsDictionary) {
     return YES;
   }
 

--- a/Crashlytics/Crashlytics/Models/FIRCLSSettings.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSSettings.m
@@ -300,7 +300,7 @@ NSString *const BuildInstanceID = @"build_instance_id";
 }
 
 + (BOOL)shouldUseNewReportEndpointWithSettings:(nullable FIRCLSSettings *)settings {
-  // Default to use the new endpoint when settings were not successfully fetched 
+  // Default to use the new endpoint when settings were not successfully fetched
   if (!settings.settingsDictionary) {
     return YES;
   }

--- a/Crashlytics/Crashlytics/Models/FIRCLSSettings.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSSettings.m
@@ -299,6 +299,15 @@ NSString *const BuildInstanceID = @"build_instance_id";
   return value.intValue == 2;
 }
 
++ (BOOL)shouldUseNewReportEndpointWithSettings:(nullable FIRCLSSettings *)settings {
+  // Default to use the new endpoint when settings were not successfully fetched 
+  if (!settings) {
+    return YES;
+  }
+
+  return settings.shouldUseNewReportEndpoint;
+}
+
 #pragma mark - Optional Limit Overrides
 
 - (uint32_t)errorLogBufferSize {

--- a/Crashlytics/UnitTests/FIRCLSSettingsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSettingsTests.m
@@ -479,6 +479,12 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
 
 - (void)testShouldUseNewReportEndpointWithNoSettings {
   XCTAssertTrue([FIRCLSSettings shouldUseNewReportEndpointWithSettings:nil]);
+    
+  NSError *error = nil;
+  [self writeSettings:nil error:&error];
+  XCTAssertNil(error, "%@", error);
+  XCTAssertNotNil(self.settings);
+  XCTAssertTrue([FIRCLSSettings shouldUseNewReportEndpointWithSettings:self.settings]);
 }
 
 @end

--- a/Crashlytics/UnitTests/FIRCLSSettingsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSettingsTests.m
@@ -96,7 +96,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertEqual(self.settings.maxCustomExceptions, 8);
   XCTAssertEqual(self.settings.maxCustomKeys, 64);
 
-  XCTAssertFalse(self.settings.shouldUseNewReportEndpoint);
+  XCTAssertFalse([FIRCLSSettings shouldUseNewReportEndpointWithSettings:self.settings]);
 }
 
 - (BOOL)writeSettings:(const NSString *)settings error:(NSError **)error {
@@ -384,7 +384,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertEqualObjects(self.settings.fetchedBundleID, nil);
   XCTAssertFalse(self.settings.appNeedsOnboarding);
   XCTAssertEqual(self.settings.errorLogBufferSize, 64 * 1000);
-  XCTAssertFalse(self.settings.shouldUseNewReportEndpoint);
+  XCTAssertFalse([FIRCLSSettings shouldUseNewReportEndpointWithSettings:self.settings]);
 }
 
 - (void)testCorruptCacheKey {
@@ -433,7 +433,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   [self.settings cacheSettingsWithGoogleAppID:TestGoogleAppID currentTimestamp:currentTimestamp];
 
   XCTAssertNil(error, "%@", error);
-  XCTAssertTrue(self.settings.shouldUseNewReportEndpoint);
+  XCTAssertTrue([FIRCLSSettings shouldUseNewReportEndpointWithSettings:self.settings]);
 }
 
 - (void)testLegacyReportEndpointSettings {
@@ -447,7 +447,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   [self.settings cacheSettingsWithGoogleAppID:TestGoogleAppID currentTimestamp:currentTimestamp];
 
   XCTAssertNil(error, "%@", error);
-  XCTAssertFalse(self.settings.shouldUseNewReportEndpoint);
+  XCTAssertFalse([FIRCLSSettings shouldUseNewReportEndpointWithSettings:self.settings]);
 }
 
 - (void)testLegacyReportEndpointSettingsWithNonExistentKey {
@@ -460,7 +460,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   [self.settings cacheSettingsWithGoogleAppID:TestGoogleAppID currentTimestamp:currentTimestamp];
 
   XCTAssertNil(error, "%@", error);
-  XCTAssertFalse(self.settings.shouldUseNewReportEndpoint);
+  XCTAssertFalse([FIRCLSSettings shouldUseNewReportEndpointWithSettings:self.settings]);
 }
 
 - (void)testLegacyReportEndpointSettingsWithUnknownValue {
@@ -474,7 +474,11 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   [self.settings cacheSettingsWithGoogleAppID:TestGoogleAppID currentTimestamp:currentTimestamp];
 
   XCTAssertNil(error, "%@", error);
-  XCTAssertFalse(self.settings.shouldUseNewReportEndpoint);
+  XCTAssertFalse([FIRCLSSettings shouldUseNewReportEndpointWithSettings:self.settings]);
+}
+
+- (void)testShouldUseNewReportEndpointWithNoSettings {
+  XCTAssertTrue([FIRCLSSettings shouldUseNewReportEndpointWithSettings:nil]);
 }
 
 @end

--- a/Crashlytics/UnitTests/FIRCLSSettingsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSettingsTests.m
@@ -479,7 +479,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
 
 - (void)testShouldUseNewReportEndpointWithNoSettings {
   XCTAssertTrue([FIRCLSSettings shouldUseNewReportEndpointWithSettings:nil]);
-    
+
   NSError *error = nil;
   [self writeSettings:nil error:&error];
   XCTAssertNil(error, "%@", error);


### PR DESCRIPTION
Successful tests:
1. Unit tests
2. Verified when there's no internet, the crash report is enqueued to GDT