### PR TITLE
Update the zip distribution from frameworks to xcframeworks

### DIFF
--- a/ZipBuilder/README.md
+++ b/ZipBuilder/README.md
@@ -8,14 +8,14 @@ you can fix issues or dig in without having to dig too deep into the code.
 
 ## Zip Builder
 
-This is a small Swift Package Manager project that allows users to package an iOS Zip file of binary
+This is a Swift Package Manager project that allows users to package an iOS Zip file of binary
 packages.
 
 ### Requirements
 
 In order to build the Zip file, you will need:
 
-- Xcode 10.1
+- Xcode 11.0
 - CocoaPods
 - An internet connection to fetch CocoaPods
 

--- a/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
@@ -22,6 +22,56 @@ import Foundation
 enum CarthageUtils {}
 
 extension CarthageUtils {
+  /// Package all required files for a Carthage release.
+  ///
+  /// - Parameters:
+  ///   - templateDir: The template project directory, contains the dummy Firebase library.
+  ///   - carthageJSONDir: Location of directory containing all JSON Carthage manifests.
+  ///   - artifacts: Release Artifacts from build.
+  ///   - rcNumber: The RC number.
+  /// - Returns: The path to the root of the Carthage installation.
+  static func packageCarthageRelease(templateDir: URL,
+                                     carthageJSONDir: URL,
+                                     artifacts: ZipBuilder.ReleaseArtifacts,
+                                     rcNumber: Int?) -> URL? {
+    guard let zipLocation = artifacts.carthageDir else { return nil }
+
+    do {
+      print("Creating Carthage release...")
+      let carthagePath =
+        zipLocation.deletingLastPathComponent().appendingPathComponent("carthage_build")
+      // Create a copy of the release directory since we'll be modifying it.
+      let fileManager = FileManager.default
+      fileManager.removeIfExists(at: carthagePath)
+      try fileManager.copyItem(at: zipLocation, to: carthagePath)
+
+      // Package the Carthage distribution with the current directory structure.
+      let carthageDir = zipLocation.deletingLastPathComponent().appendingPathComponent("carthage")
+      fileManager.removeIfExists(at: carthageDir)
+      var output = carthageDir.appendingPathComponent(artifacts.firebaseVersion)
+      if let rcNumber = args.rcNumber {
+        output.appendPathComponent("rc\(rcNumber)")
+      } else {
+        output.appendPathComponent("latest-non-rc")
+      }
+      try fileManager.createDirectory(at: output, withIntermediateDirectories: true)
+      generateCarthageRelease(fromPackagedDir: carthagePath,
+                              templateDir: templateDir,
+                              jsonDir: carthageJSONDir,
+                              artifacts: artifacts,
+                              outputDir: output)
+
+      // Remove the duplicated Carthage build directory.
+      fileManager.removeIfExists(at: carthagePath)
+      print("Done creating Carthage release! Files written to \(output)")
+
+      // Save the directory for later copying.
+      return carthageDir
+    } catch {
+      fatalError("Could not copy output directory for Carthage build: \(error)")
+    }
+  }
+
   /// Generates all required files for a Carthage release.
   ///
   /// - Parameters:
@@ -31,18 +81,19 @@ extension CarthageUtils {
   ///   - firebaseVersion: The version of the Firebase pod.
   ///   - coreDiagnosticsPath: The path to the Core Diagnostics framework built for Carthage.
   ///   - outputDir: The directory where all artifacts should be created.
-  static func generateCarthageRelease(fromPackagedDir packagedDir: URL,
-                                      templateDir: URL,
-                                      jsonDir: URL,
-                                      firebaseVersion: String,
-                                      coreDiagnosticsPath: URL,
-                                      outputDir: URL) {
+
+  private static func generateCarthageRelease(fromPackagedDir packagedDir: URL,
+                                              templateDir: URL,
+                                              jsonDir: URL,
+                                              artifacts: ZipBuilder.ReleaseArtifacts,
+                                              outputDir: URL) {
     let directories: [String]
     do {
       directories = try FileManager.default.contentsOfDirectory(atPath: packagedDir.path)
     } catch {
       fatalError("Could not get contents of Firebase directory to package Carthage build. \(error)")
     }
+    let firebaseVersion = artifacts.firebaseVersion
 
     // Loop through each directory available and package it as a separate Zip file.
     for product in directories {
@@ -51,23 +102,20 @@ extension CarthageUtils {
 
       // Parse the JSON file, ensure that we're not trying to overwrite a release.
       var jsonManifest = parseJSONFile(fromDir: jsonDir, product: product)
-      guard jsonManifest[firebaseVersion] == nil else {
-        print("Carthage release for \(product) \(firebaseVersion) already exists - skipping.")
-        continue
+      if !args.carthageSkipVersionCheck {
+        guard jsonManifest[firebaseVersion] == nil else {
+          print("Carthage release for \(product) \(firebaseVersion) already exists - skipping.")
+          continue
+        }
       }
 
-      // Find all the .frameworks in this directory.
-      let allContents: [String]
-      do {
-        allContents = try FileManager.default.contentsOfDirectory(atPath: fullPath.path)
-      } catch {
-        fatalError("Could not get contents of \(product) for Carthage build in order to add " +
-          "an Info.plist in each framework. \(error)")
+      // Make updates to all frameworks to make Carthage happy. We don't worry about xcframeworks
+      // here.
+      let allFileObjects = FileManager.default.enumerator(atPath: fullPath.path)?.allObjects
+      guard let allFiles = allFileObjects as? [String] else {
+        fatalError("Failed to get file list for Carthage construction at \(fullPath.path)")
       }
-
-      // Carthage will fail to install a framework if it doesn't have an Info.plist, even though
-      // they're not used for static frameworks. Generate one and write it to each framework.
-      let frameworks = allContents.filter { $0.hasSuffix(".framework") }
+      let frameworks = allFiles.filter { $0.hasSuffix(".framework") }
       for framework in frameworks {
         let plistPath = fullPath.appendingPathComponents([framework, "Info.plist"])
         // Drop the extension of the framework name.
@@ -92,17 +140,6 @@ extension CarthageUtils {
           try FileManager.default.copyItem(at: noticesPath, to: coreNotices)
         } catch {
           fatalError("Could not copy \(noticesName) to FirebaseCore for Carthage build. \(error)")
-        }
-
-        // Override the Core Diagnostics framework with one that includes the proper bit flipped.
-        let coreDiagnosticsFramework = Constants.coreDiagnosticsName + ".framework"
-        let destination = fullPath.appendingPathComponent(coreDiagnosticsFramework)
-        do {
-          // Remove the existing framework and replace it with the newly compiled one.
-          try FileManager.default.removeItem(at: destination)
-          try FileManager.default.copyItem(at: coreDiagnosticsPath, to: destination)
-        } catch {
-          fatalError("Could not replace \(coreDiagnosticsFramework) during Carthage build. \(error)")
         }
       }
 

--- a/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
@@ -109,24 +109,6 @@ extension CarthageUtils {
         }
       }
 
-      // Make updates to all frameworks to make Carthage happy. We don't worry about xcframeworks
-      // here.
-      let allFileObjects = FileManager.default.enumerator(atPath: fullPath.path)?.allObjects
-      guard let allFiles = allFileObjects as? [String] else {
-        fatalError("Failed to get file list for Carthage construction at \(fullPath.path)")
-      }
-      let frameworks = allFiles.filter { $0.hasSuffix(".framework") }
-      for framework in frameworks {
-        let plistPath = fullPath.appendingPathComponents([framework, "Info.plist"])
-        // Drop the extension of the framework name.
-        let plist = generatePlistContents(forName: framework.components(separatedBy: ".").first!)
-        do {
-          try plist.write(to: plistPath)
-        } catch {
-          fatalError("Could not copy plist for \(framework) for Carthage release. \(error)")
-        }
-      }
-
       // Analytics includes all the Core frameworks and Firebase module, do extra work to package
       // it.
       if product == "FirebaseAnalytics" {
@@ -266,7 +248,7 @@ extension CarthageUtils {
     }
   }
 
-  private static func generatePlistContents(forName name: String) -> Data {
+  static func generatePlistContents(forName name: String) -> Data {
     let plist: [String: String] = ["CFBundleIdentifier": "com.firebase.Firebase",
                                    "CFBundleInfoDictionaryVersion": "6.0",
                                    "CFBundlePackageType": "FMWK",

--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -311,6 +311,15 @@ enum CocoaPodUtils {
     return Array(returnDeps)
   }
 
+  /// Get all transitive pod dependencies for a pod with subspecs merged.
+  /// - Returns: An array of Strings of pod names.
+  static func transitiveMasterPodDependencies(for podName: String,
+                                              in installedPods: [String: PodInfo]) -> [String] {
+    return Array(Set(transitivePodDependencies(for: podName, in: installedPods).map {
+      $0.components(separatedBy: "/")[0]
+    }))
+  }
+
   /// Get all transitive pod dependencies for a pod.
   /// - Returns: An array of dependencies with versions for a given pod.
   static func transitiveVersionedPodDependencies(for podName: String,

--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -212,10 +212,11 @@ enum CocoaPodUtils {
 
     for (podName, version) in pods {
       let subspecArray = podName.components(separatedBy: "/")
-      if subspecArray.count > 2 {
+      if subspecArray.count == 1 || subspecArray[0] == "abseil" {
+        // Special case for abseil since it has two layers and no external deps.
+        versions[subspecArray[0]] = version
+      } else if subspecArray.count > 2 {
         fatalError("Multi-layered subspecs are not supported - \(podName)")
-      } else if subspecArray.count == 1 {
-        versions[podName] = version
       } else {
         if let previousVersion = versions[podName], version != previousVersion {
           fatalError("Different installed versions for \(podName)." +

--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -317,6 +317,7 @@ enum CocoaPodUtils {
 
     // Include the minimum iOS version.
     podfile += """
+    use_frameworks!
     platform :ios, '\(LaunchArgs.shared.minimumIOSVersion)'
     target 'FrameworkMaker' do\n
     """

--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -61,14 +61,13 @@ enum CocoaPodUtils {
     let subspecs: Set<String>
 
     /// The contents of the module map for all frameworks associated with the pod.
-    var moduleMapContents: String
+    var moduleMapContents: ModuleMapBuilder.ModuleMapContents?
 
     init(version: String, dependencies: [String], installedLocation: URL, subspecs: Set<String>) {
       self.version = version
       self.dependencies = dependencies
       self.installedLocation = installedLocation
       self.subspecs = subspecs
-      moduleMapContents = ""
 
       // Get all the frameworks contained in this directory.
       var binaryFrameworks: [URL] = []
@@ -121,11 +120,14 @@ enum CocoaPodUtils {
   ///   - pods: List of VersionedPods to install
   ///   - directory: Destination directory for the pods.
   ///   - customSpecRepos: Additional spec repos to check for installation.
+  ///   - forceStaticLibs: Force a static library pod install. For the module map construction, we want pod names not module
+  ///                      names in the generated OTHER_LD_FLAGS options.
   /// - Returns: A dictionary of PodInfo's keyed by the pod name.
   @discardableResult
   static func installPods(_ pods: [VersionedPod],
                           inDir directory: URL,
-                          customSpecRepos: [URL]? = nil) -> [String: PodInfo] {
+                          customSpecRepos: [URL]?,
+                          forceStaticLibs: Bool = false) -> [String: PodInfo] {
     let fileManager = FileManager.default
     // Ensure the directory exists, otherwise we can't install all subspecs.
     guard fileManager.directoryExists(at: directory) else {
@@ -140,7 +142,10 @@ enum CocoaPodUtils {
 
     // Attempt to write the Podfile to disk.
     do {
-      try writePodfile(for: pods, toDirectory: directory, customSpecRepos: customSpecRepos)
+      try writePodfile(for: pods,
+                       toDirectory: directory,
+                       customSpecRepos: customSpecRepos,
+                       forceStaticLibs: forceStaticLibs)
     } catch let FileManager.FileError.directoryNotFound(path) {
       fatalError("Failed to write Podfile with pods \(pods) at path \(path)")
     } catch let FileManager.FileError.writeToFileFailed(path, error) {
@@ -355,7 +360,8 @@ enum CocoaPodUtils {
   /// Create the contents of a Podfile for an array of subspecs. This assumes the array of subspecs
   /// is not empty.
   private static func generatePodfile(for pods: [VersionedPod],
-                                      customSpecsRepos: [URL]? = nil) -> String {
+                                      customSpecsRepos: [URL]?,
+                                      forceStaticLibs: Bool) -> String {
     // Start assembling the Podfile.
     var podfile: String = ""
 
@@ -370,8 +376,12 @@ enum CocoaPodUtils {
       """ // Explicit newline above to ensure it's included in the String.
     }
 
-    if LaunchArgs.shared.dynamic {
+    if forceStaticLibs {
+      podfile += "  use_modular_headers!\n"
+    } else if LaunchArgs.shared.dynamic {
       podfile += "  use_frameworks!\n"
+    } else {
+      podfile += "  use_frameworks! :linkage => :static\n"
     }
     // Include the minimum iOS version.
     podfile += """
@@ -425,7 +435,8 @@ enum CocoaPodUtils {
   /// "Podfile".
   private static func writePodfile(for pods: [VersionedPod],
                                    toDirectory directory: URL,
-                                   customSpecRepos: [URL]?) throws {
+                                   customSpecRepos: [URL]?,
+                                   forceStaticLibs: Bool) throws {
     guard FileManager.default.directoryExists(at: directory) else {
       // Throw an error so the caller can provide a better error message.
       throw FileManager.FileError.directoryNotFound(path: directory.path)
@@ -433,7 +444,7 @@ enum CocoaPodUtils {
 
     // Generate the full path of the Podfile and attempt to write it to disk.
     let path = directory.appendingPathComponent("Podfile")
-    let podfile = generatePodfile(for: pods, customSpecsRepos: customSpecRepos)
+    let podfile = generatePodfile(for: pods, customSpecsRepos: customSpecRepos, forceStaticLibs: forceStaticLibs)
     do {
       try podfile.write(toFile: path.path, atomically: true, encoding: .utf8)
     } catch {

--- a/ZipBuilder/Sources/ZipBuilder/FileManager+Utils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FileManager+Utils.swift
@@ -101,8 +101,18 @@ extension FileManager {
     }
   }
 
-  // Enable a single unique temporary workspace per execution.
-  static let unique: String = UUID().uuidString
+  /// Enable a single unique temporary workspace per execution.
+  private static func timeStamp() -> String {
+    if #available(OSX 10.12, *) {
+      let formatter = ISO8601DateFormatter()
+      formatter.formatOptions.insert(.withInternetDateTime)
+      return formatter.string(from: Date())
+    } else {
+      return UUID().uuidString
+    }
+  }
+
+  static let unique: String = timeStamp()
 
   /// Returns a deterministic path of a temporary directory for the given name. Note: This does
   /// *not* create the directory if it doesn't exist, merely generates the name for creation.

--- a/ZipBuilder/Sources/ZipBuilder/FileManager+Utils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FileManager+Utils.swift
@@ -101,15 +101,11 @@ extension FileManager {
     }
   }
 
-  /// Enable a single unique temporary workspace per execution.
+  /// Enable a single unique temporary workspace per execution with a sortable and readable timestamp.
   private static func timeStamp() -> String {
-    if #available(OSX 10.12, *) {
-      let formatter = ISO8601DateFormatter()
-      formatter.formatOptions.insert(.withInternetDateTime)
-      return formatter.string(from: Date())
-    } else {
-      return UUID().uuidString
-    }
+    let formatter = DateFormatter()
+    formatter.dateFormat = "YYYY-MM-dd'T'HH-mm-ss"
+    return formatter.string(from: Date())
   }
 
   static let unique: String = timeStamp()

--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -408,7 +408,9 @@ struct FrameworkBuilder {
     }
     // Verify Firebase frameworks include an explicit umbrella header for Firebase.h.
     let headersDir = podsDir.appendingPathComponents(["Headers", "Public", framework])
-    if framework.hasPrefix("Firebase"), framework != "FirebaseCoreDiagnostics" {
+    if framework.hasPrefix("Firebase"),
+      framework != "FirebaseCoreDiagnostics",
+      framework != "FirebaseUI" {
       let frameworkHeader = headersDir.appendingPathComponent("\(framework).h")
       guard fileManager.fileExists(atPath: frameworkHeader.path) else {
         fatalError("Missing explicit umbrella header for \(framework).")

--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -72,18 +72,14 @@ struct FrameworkBuilder {
   /// The directory containing the Xcode project and Pods folder.
   private let projectDir: URL
 
-  /// A flag to indicate this build is for carthage. This is primarily used for CoreDiagnostics.
-  private let carthageBuild: Bool
-
   /// The Pods directory for building the framework.
   private var podsDir: URL {
     return projectDir.appendingPathComponent("Pods", isDirectory: true)
   }
 
   /// Default initializer.
-  init(projectDir: URL, carthageBuild: Bool = false) {
+  init(projectDir: URL) {
     self.projectDir = projectDir
-    self.carthageBuild = carthageBuild
   }
 
   // MARK: - Public Functions
@@ -95,19 +91,21 @@ struct FrameworkBuilder {
   ///   - version: String representation of the version.
   /// - Parameter logsOutputDir: The path to the directory to place build logs.
   /// - Parameter moduleMapContents: Module map contents for all frameworks in this pod.
-  /// - Returns: A URL to the framework that was built (or pulled from the cache).
+  /// - Returns: A URL to the framework that was built (or pulled from the cache) and the Carthage version.
   func buildFramework(withName podName: String,
                       podInfo: CocoaPodUtils.PodInfo,
-                      logsOutputDir: URL? = nil) -> URL {
+                      logsOutputDir: URL? = nil) -> (URL, URL?) {
     print("Building \(podName)")
 
     // Get (or create) the cache directory for storing built frameworks.
     let fileManager = FileManager.default
     var cachedFrameworkRoot: URL
+    var cachedCarthageRoot: URL
     do {
-      let subDir = carthageBuild ? "carthage" : ""
-      let cacheDir = try fileManager.sourcePodCacheDirectory(withSubdir: subDir)
+      let cacheDir = try fileManager.sourcePodCacheDirectory(withSubdir: "zip")
+      let carthageCacheDir = try fileManager.sourcePodCacheDirectory(withSubdir: "carthage")
       cachedFrameworkRoot = cacheDir.appendingPathComponents([podName, podInfo.version])
+      cachedCarthageRoot = carthageCacheDir.appendingPathComponents([podName, podInfo.version])
     } catch {
       fatalError("Could not create caches directory for building frameworks: \(error)")
     }
@@ -115,22 +113,32 @@ struct FrameworkBuilder {
     // Build the full cached framework path.
     let realFramework = frameworkBuildName(podName)
     let cachedFrameworkDir = cachedFrameworkRoot.appendingPathComponent("\(realFramework).xcframework")
-    let frameworkDir = compileFrameworkAndResources(withName: podName, podInfo: podInfo)
+    let cachedCarthageDir = cachedCarthageRoot.appendingPathComponent("\(realFramework).framework")
+    let (frameworkDir, carthageDir) = compileFrameworkAndResources(withName: podName, podInfo: podInfo)
     do {
       // Remove the previously cached framework if it exists, otherwise the `moveItem` call will
       // fail.
       fileManager.removeIfExists(at: cachedFrameworkDir)
+      fileManager.removeIfExists(at: cachedCarthageDir)
 
-      // Create the root cache directory if it doesn't exist.
+      // Create the root cache directories if they don't exist.
       if !fileManager.directoryExists(at: cachedFrameworkRoot) {
         // If the root directory doesn't exist, create it so the `moveItem` will succeed.
         try fileManager.createDirectory(at: cachedFrameworkRoot,
                                         withIntermediateDirectories: true)
       }
+      if !fileManager.directoryExists(at: cachedCarthageRoot) {
+        // If the root directory doesn't exist, create it so the `moveItem` will succeed.
+        try fileManager.createDirectory(at: cachedCarthageRoot,
+                                        withIntermediateDirectories: true)
+      }
 
       // Move the newly built framework to the cache directory.
       try fileManager.moveItem(at: frameworkDir, to: cachedFrameworkDir)
-      return cachedFrameworkDir
+      if let carthageDir = carthageDir {
+        try fileManager.moveItem(at: carthageDir, to: cachedCarthageDir)
+      }
+      return (cachedFrameworkDir, cachedCarthageDir)
     } catch {
       fatalError("Could not move built frameworks into the cached frameworks directory: \(error)")
     }
@@ -190,6 +198,27 @@ struct FrameworkBuilder {
     return .success(output: fullOutput)
   }
 
+  /// Build all thin slices for an open source pod.
+  /// - Parameter framework: The name of the framework to be built.
+  /// - Parameter logsDir: The path to the directory to place build logs.
+  /// - Returns: An dictionary of URLs to the built thin libraries keyed by architecture
+  private func buildAllThin(withName framework: String,
+                            logsDir: URL,
+                            carthageBuild: Bool = false) -> [Architecture: URL] {
+    // Build every architecture and save the locations in an array to be assembled.
+    var thinArchives = [Architecture: URL]()
+    for arch in LaunchArgs.shared.archs {
+      let buildDir = projectDir.appendingPathComponent(arch.rawValue)
+      let thinArchive = buildThin(framework: framework,
+                                  archs: [arch],
+                                  buildDir: buildDir,
+                                  logRoot: logsDir,
+                                  carthageBuild: carthageBuild)
+      thinArchives[arch] = thinArchive
+    }
+    return thinArchives
+  }
+
   /// Uses `xcodebuild` to build a framework for a specific architecture slice.
   ///
   /// - Parameters:
@@ -201,7 +230,8 @@ struct FrameworkBuilder {
   private func buildThin(framework: String,
                          archs: [Architecture],
                          buildDir: URL,
-                         logRoot: URL) -> URL {
+                         logRoot: URL,
+                         carthageBuild: Bool = false) -> URL {
     let arch = archs[0]
     let isMacCatalyst = arch == Architecture.x86_64h
     let isMacCatalystString = isMacCatalyst ? "YES" : "NO"
@@ -313,10 +343,10 @@ struct FrameworkBuilder {
   /// - Parameter framework: The name of the framework to be built.
   /// - Parameter logsOutputDir: The path to the directory to place build logs.
   /// - Parameter moduleMapContents: Module map contents for all frameworks in this pod.
-  /// - Returns: A path to the newly compiled framework (with any included Resources embedded).
+  /// - Returns: A path to the newly compiled framework and the Carthage version if needed).
   private func compileFrameworkAndResources(withName framework: String,
                                             logsOutputDir: URL? = nil,
-                                            podInfo: CocoaPodUtils.PodInfo) -> URL {
+                                            podInfo: CocoaPodUtils.PodInfo) -> (URL, URL?) {
     let fileManager = FileManager.default
     let outputDir = fileManager.temporaryDirectory(withName: "frameworks_being_built")
     let logsDir = logsOutputDir ?? fileManager.temporaryDirectory(withName: "build_logs")
@@ -337,7 +367,8 @@ struct FrameworkBuilder {
     }
 
     if LaunchArgs.shared.dynamic {
-      return buildDynamicXCFramework(withName: framework, logsDir: logsDir, outputDir: outputDir)
+      return (buildDynamicXCFramework(withName: framework, logsDir: logsDir, outputDir: outputDir),
+              nil)
     } else {
       return buildStaticXCFramework(withName: framework, logsDir: logsDir, outputDir: outputDir,
                                     podInfo: podInfo)
@@ -403,17 +434,9 @@ struct FrameworkBuilder {
   private func buildStaticXCFramework(withName framework: String,
                                       logsDir: URL,
                                       outputDir: URL,
-                                      podInfo: CocoaPodUtils.PodInfo) -> URL {
+                                      podInfo: CocoaPodUtils.PodInfo) -> (URL, URL?) {
     // Build every architecture and save the locations in an array to be assembled.
-    var thinArchives = [Architecture: URL]()
-    for arch in LaunchArgs.shared.archs {
-      let buildDir = projectDir.appendingPathComponent(arch.rawValue)
-      let thinArchive = buildThin(framework: framework,
-                                  archs: [arch],
-                                  buildDir: buildDir,
-                                  logRoot: logsDir)
-      thinArchives[arch] = thinArchive
-    }
+    let thinArchives = buildAllThin(withName: framework, logsDir: logsDir)
 
     // Create the framework directory in the filesystem for the thin archives to go.
     let fileManager = FileManager.default
@@ -454,7 +477,7 @@ struct FrameworkBuilder {
         fatalError("Error while enumerating files \(headersDir): \(error.localizedDescription)")
       }
       // Verify Firebase frameworks include an explicit umbrella header for Firebase.h.
-      if framework.hasPrefix("Firebase"),
+      if framework.hasPrefix("Firebase") || framework == "GoogleDataTransport",
         framework != "FirebaseCoreDiagnostics",
         framework != "FirebaseUI",
         !framework.hasSuffix("Swift") {
@@ -499,15 +522,31 @@ struct FrameworkBuilder {
         "\(error)")
     }
 
-    guard let moduleMapContents = podInfo.moduleMapContents else {
+    guard let moduleMapContentsTemplate = podInfo.moduleMapContents else {
       fatalError("Module map contents missing for framework \(framework)")
     }
+    let moduleMapContents = moduleMapContentsTemplate.get(umbrellaHeader: umbrellaHeader)
     let xcframework = packageXCFramework(withName: framework,
                                          fromFolder: frameworkDir,
                                          thinArchives: thinArchives,
-                                         moduleMapContents:
-                                         moduleMapContents.get(umbrellaHeader: umbrellaHeader))
+                                         moduleMapContents: moduleMapContents)
 
+    var carthageFramework: URL?
+    if args.carthageDir != nil {
+      var carthageThinArchives: [Architecture: URL]
+      if framework == "FirebaseCoreDiagnostics" {
+        // FirebaseCoreDiagnostics needs to be built with a different ifdef for the Carthage distro.
+        carthageThinArchives = buildAllThin(withName: framework,
+                                            logsDir: logsDir,
+                                            carthageBuild: true)
+      } else {
+        carthageThinArchives = thinArchives
+      }
+      carthageFramework = packageCarthageFramework(withName: framework,
+                                                   fromFolder: frameworkDir,
+                                                   thinArchives: carthageThinArchives,
+                                                   moduleMapContents: moduleMapContents)
+    }
     // Remove the temporary thin archives.
     for thinArchive in thinArchives.values {
       do {
@@ -523,8 +562,7 @@ struct FrameworkBuilder {
         """)
       }
     }
-
-    return xcframework
+    return (xcframework, carthageFramework)
   }
 
   private func packageFramework(withName framework: String,
@@ -733,9 +771,12 @@ struct FrameworkBuilder {
     }
 
     let outputArgs = ["-output", xcframework.path]
-    let result = syncExec(command: "/usr/bin/xcodebuild",
-                          args: ["-create-xcframework"] + frameworkArgs + outputArgs,
-                          captureOutput: true)
+    let args = ["-create-xcframework"] + frameworkArgs + outputArgs
+    print("""
+    Building \(xcframework) with command:
+    /usr/bin/xcodebuild \(args.joined(separator: " "))
+    """)
+    let result = syncExec(command: "/usr/bin/xcodebuild", args: args, captureOutput: true)
     switch result {
     case let .error(code, output):
       fatalError("Could not build xcframework for \(framework) exit code \(code): \(output)")
@@ -745,5 +786,40 @@ struct FrameworkBuilder {
     }
 
     return xcframework
+  }
+
+  /// Packages a Carthage framework. Carthage does not yet support xcframeworks, so we exclude the Catalyst slice.
+  /// - Parameter withName: The framework name.
+  /// - Parameter fromFolder: The almost complete framework folder. Includes everything but the binary.
+  /// - Parameter thinArchives: All the thin archives.
+  /// - Parameter moduleMapContents: Module map contents for all frameworks in this pod.
+  private func packageCarthageFramework(withName framework: String,
+                                        fromFolder: URL,
+                                        thinArchives: [Architecture: URL],
+                                        moduleMapContents: String) -> URL {
+    let fileManager = FileManager.default
+
+    // Create a `.framework` for each of the thinArchives using the `fromFolder` as the base.
+    let platformFrameworksDir = fileManager.temporaryDirectory(withName: "carthage_frameworks")
+    if !fileManager.directoryExists(at: platformFrameworksDir) {
+      do {
+        try fileManager.createDirectory(at: platformFrameworksDir,
+                                        withIntermediateDirectories: true)
+      } catch {
+        fatalError("Could not create a temp directory to store all thin frameworks: \(error)")
+      }
+    }
+
+    // Exclude Catalyst.
+    let slices = thinArchives.filter { $0.key != Architecture.x86_64h }
+
+    // Package a normal .framework with the given slices.
+    let destination = platformFrameworksDir.appendingPathComponent(fromFolder.lastPathComponent)
+    packageFramework(withName: framework,
+                     fromFolder: fromFolder,
+                     thinArchives: slices,
+                     destination: destination,
+                     moduleMapContents: moduleMapContents)
+    return destination
   }
 }

--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -189,7 +189,6 @@ struct FrameworkBuilder {
                          archs: [Architecture],
                          buildDir: URL,
                          logRoot: URL) -> URL {
-
     let arch = archs[0]
     let isMacCatalyst = arch == Architecture.x86_64h
     let isMacCatalystString = isMacCatalyst ? "YES" : "NO"
@@ -199,7 +198,7 @@ struct FrameworkBuilder {
     let distributionFlag = carthageBuild ? "-DFIREBASE_BUILD_CARTHAGE" : "-DFIREBASE_BUILD_ZIP_FILE"
     let platformSpecificFlags = platform.otherCFlags().joined(separator: " ")
     let cFlags = "OTHER_CFLAGS=$(value) \(distributionFlag) \(platformSpecificFlags)"
-    let cleanArch = isMacCatalyst ? Architecture.x86_64.rawValue : archs.map{$0.rawValue}.joined(separator: " ")
+    let cleanArch = isMacCatalyst ? Architecture.x86_64.rawValue : archs.map { $0.rawValue }.joined(separator: " ")
 
     let args = ["build",
                 "-configuration", "release",
@@ -253,17 +252,17 @@ struct FrameworkBuilder {
     }
   }
 
-    // Cries in Google. Why is this not the same?
-    private func realFrameworkName(_ framework: String) -> String {
-        switch framework {
-        case "PromisesObjC":
-            return "FBLPromises"
-        case "Protobuf":
-            return "protobuf"
-        default:
-            return framework
-        }
+  // Cries in Google. Why is this not the same?
+  private func realFrameworkName(_ framework: String) -> String {
+    switch framework {
+    case "PromisesObjC":
+      return "FBLPromises"
+    case "Protobuf":
+      return "protobuf"
+    default:
+      return framework
     }
+  }
 
   /// Compiles the specified framework in a temporary directory and writes the build logs to file.
   /// This will compile all architectures and use the -create-xcframework command to create a modern "fat" framework.
@@ -302,14 +301,14 @@ struct FrameworkBuilder {
     var groupedArchs: [[Architecture]] = []
 
     for pair in [[Architecture.armv7, .arm64], [Architecture.i386, .x86_64]] {
-        if archs.contains(pair[0]) && archs.contains(pair[1]) {
-            groupedArchs.append(pair)
-            archs = archs.filter() { !pair.contains($0) }
-        }
+      if archs.contains(pair[0]), archs.contains(pair[1]) {
+        groupedArchs.append(pair)
+        archs = archs.filter { !pair.contains($0) }
+      }
     }
     // Add remaining ungrouped
     for arch in archs {
-        groupedArchs.append([arch])
+      groupedArchs.append([arch])
     }
 
     var thinArchives = [URL]()
@@ -325,7 +324,7 @@ struct FrameworkBuilder {
     let frameworkDir = outputDir.appendingPathComponent("\(framework).xcframework")
 
     let inputArgs = thinArchives.flatMap { url -> [String] in
-        return ["-framework", url.path]
+      ["-framework", url.path]
     }
 
     print("About to create xcframework for \(frameworkDir.path) with \(inputArgs)")

--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -97,9 +97,8 @@ struct FrameworkBuilder {
   /// - Parameter moduleMapContents: Module map contents for all frameworks in this pod.
   /// - Returns: A URL to the framework that was built (or pulled from the cache).
   func buildFramework(withName podName: String,
-                      version: String,
-                      logsOutputDir: URL? = nil,
-                      moduleMapContents: String) -> URL {
+                      podInfo: CocoaPodUtils.PodInfo,
+                      logsOutputDir: URL? = nil) -> URL {
     print("Building \(podName)")
 
     // Get (or create) the cache directory for storing built frameworks.
@@ -108,7 +107,7 @@ struct FrameworkBuilder {
     do {
       let subDir = carthageBuild ? "carthage" : ""
       let cacheDir = try fileManager.sourcePodCacheDirectory(withSubdir: subDir)
-      cachedFrameworkRoot = cacheDir.appendingPathComponents([podName, version])
+      cachedFrameworkRoot = cacheDir.appendingPathComponents([podName, podInfo.version])
     } catch {
       fatalError("Could not create caches directory for building frameworks: \(error)")
     }
@@ -116,7 +115,7 @@ struct FrameworkBuilder {
     // Build the full cached framework path.
     let realFramework = frameworkBuildName(podName)
     let cachedFrameworkDir = cachedFrameworkRoot.appendingPathComponent("\(realFramework).xcframework")
-    let frameworkDir = compileFrameworkAndResources(withName: podName, moduleMapContents: moduleMapContents)
+    let frameworkDir = compileFrameworkAndResources(withName: podName, podInfo: podInfo)
     do {
       // Remove the previously cached framework if it exists, otherwise the `moveItem` call will
       // fail.
@@ -214,7 +213,7 @@ struct FrameworkBuilder {
     let cFlags = "OTHER_CFLAGS=$(value) \(distributionFlag) \(platformSpecificFlags)"
     let cleanArch = isMacCatalyst ? Architecture.x86_64.rawValue : archs.map { $0.rawValue }.joined(separator: " ")
 
-    let args = ["build",
+    var args = ["build",
                 "-configuration", "release",
                 "-workspace", workspacePath,
                 "-scheme", framework,
@@ -225,12 +224,14 @@ struct FrameworkBuilder {
                 "BUILD_LIBRARIES_FOR_DISTRIBUTION=YES",
                 "SUPPORTS_MACCATALYST=\(isMacCatalystString)",
                 "BUILD_DIR=\(buildDir.path)",
-                // Code signing isn't needed for libraries. Disabling signing is required for
-                // Catalyst libs with resources. See
-                // https://github.com/CocoaPods/CocoaPods/issues/8891#issuecomment-573301570
-                "CODE_SIGN_IDENTITY=-",
                 "-sdk", platform.rawValue,
                 cFlags]
+    // Code signing isn't needed for libraries. Disabling signing is required for
+    // Catalyst libs with resources. See
+    // https://github.com/CocoaPods/CocoaPods/issues/8891#issuecomment-573301570
+    if isMacCatalyst {
+      args.append("CODE_SIGN_IDENTITY=-")
+    }
     print("""
     Compiling \(framework) for \(arch.rawValue) with command:
     /usr/bin/xcodebuild \(args.joined(separator: " "))
@@ -260,10 +261,22 @@ struct FrameworkBuilder {
       """)
 
       // Use the Xcode-generated path to return the path to the compiled library.
-      let buildName = frameworkBuildName(framework)
-      let fileName = LaunchArgs.shared.dynamic ? "\(buildName).framework" : "lib\(buildName).a"
-      let libPath = buildDir.appendingPathComponents(["Release-\(platformFolder)", framework,
-                                                      fileName])
+      // The framework name may be different from the pod name if the module is reset in the
+      // podspec - like Release-iphonesimulator/BoringSSL-GRPC/openssl_grpc.framework.
+      let frameworkPath = buildDir.appendingPathComponents(["Release-\(platformFolder)", framework])
+      var actualFramework: String
+      do {
+        let files = try FileManager.default.contentsOfDirectory(at: frameworkPath,
+                                                                includingPropertiesForKeys: nil).compactMap { $0.absoluteString }
+        let frameworkDir = files.filter { $0.contains(".framework") }
+        actualFramework = URL(fileURLWithPath: frameworkDir[0]).lastPathComponent
+      } catch {
+        fatalError("Error while enumerating files \(frameworkPath): \(error.localizedDescription)")
+      }
+      var libPath = frameworkPath.appendingPathComponent(actualFramework)
+      if !LaunchArgs.shared.dynamic {
+        libPath = libPath.appendingPathComponent(actualFramework.replacingOccurrences(of: ".framework", with: ""))
+      }
       print("buildThin returns \(libPath)")
       return libPath
     }
@@ -298,7 +311,7 @@ struct FrameworkBuilder {
   /// - Returns: A path to the newly compiled framework (with any included Resources embedded).
   private func compileFrameworkAndResources(withName framework: String,
                                             logsOutputDir: URL? = nil,
-                                            moduleMapContents: String) -> URL {
+                                            podInfo: CocoaPodUtils.PodInfo) -> URL {
     let fileManager = FileManager.default
     let outputDir = fileManager.temporaryDirectory(withName: "frameworks_being_built")
     let logsDir = logsOutputDir ?? fileManager.temporaryDirectory(withName: "build_logs")
@@ -322,7 +335,7 @@ struct FrameworkBuilder {
       return buildDynamicXCFramework(withName: framework, logsDir: logsDir, outputDir: outputDir)
     } else {
       return buildStaticXCFramework(withName: framework, logsDir: logsDir, outputDir: outputDir,
-                                    moduleMapContents: moduleMapContents)
+                                    podInfo: podInfo)
     }
   }
 
@@ -385,7 +398,7 @@ struct FrameworkBuilder {
   private func buildStaticXCFramework(withName framework: String,
                                       logsDir: URL,
                                       outputDir: URL,
-                                      moduleMapContents: String) -> URL {
+                                      podInfo: CocoaPodUtils.PodInfo) -> URL {
     // Build every architecture and save the locations in an array to be assembled.
     var thinArchives = [Architecture: URL]()
     for arch in LaunchArgs.shared.archs {
@@ -406,32 +419,72 @@ struct FrameworkBuilder {
       fatalError("Could not create framework directory while building framework \(framework). " +
         "\(error)")
     }
-    // Verify Firebase frameworks include an explicit umbrella header for Firebase.h.
-    let headersDir = podsDir.appendingPathComponents(["Headers", "Public", framework])
-    if framework.hasPrefix("Firebase"),
-      framework != "FirebaseCoreDiagnostics",
-      framework != "FirebaseUI" {
-      let frameworkHeader = headersDir.appendingPathComponent("\(framework).h")
-      guard fileManager.fileExists(atPath: frameworkHeader.path) else {
-        fatalError("Missing explicit umbrella header for \(framework).")
+
+    // Find the location of the public headers.
+    let anyArch = LaunchArgs.shared.archs[0] // any arch is ok, but need to make sure we're building it
+    let archivePath = thinArchives[anyArch]!
+    let headersDir = archivePath.deletingLastPathComponent().appendingPathComponent("Headers")
+
+    // Find CocoaPods generated umbrella header.
+    var umbrellaHeader = ""
+    if framework == "gRPC-Core" {
+      // TODO: Proper handling of podspec-specified module.modulemap files with customized umbrella
+      // headers. This is good enough for Firebase since it doesn't need these modules.
+      umbrellaHeader = "\(framework)-umbrella.h"
+    } else {
+      var umbrellaHeaderURL: URL
+      do {
+        let files = try fileManager.contentsOfDirectory(at: headersDir,
+                                                        includingPropertiesForKeys: nil).compactMap { $0.absoluteString }
+        let umbrellas = files.filter { $0.contains("umbrella.h") }
+        if umbrellas.count != 1 {
+          fatalError("Did not find exactly one umbrella header in \(headersDir).")
+        }
+        guard let firstUmbrella = umbrellas.first,
+          let foundHeader = URL(string: firstUmbrella) else { /* error */
+          fatalError("Failed to get umbrella header in \(headersDir).")
+        }
+        umbrellaHeaderURL = foundHeader
+      } catch {
+        fatalError("Error while enumerating files \(headersDir): \(error.localizedDescription)")
+      }
+      // Verify Firebase frameworks include an explicit umbrella header for Firebase.h.
+      if framework.hasPrefix("Firebase"),
+        framework != "FirebaseCoreDiagnostics",
+        framework != "FirebaseUI",
+        !framework.hasSuffix("Swift") {
+        // Delete CocoaPods generated umbrella and use pre-generated one.
+        do {
+          try fileManager.removeItem(at: umbrellaHeaderURL)
+        } catch let error as NSError {
+          print("Failed to delete: \(umbrellaHeaderURL). Error: \(error.domain)")
+        }
+        umbrellaHeader = "\(framework).h"
+        let frameworkHeader = headersDir.appendingPathComponent(umbrellaHeader)
+        guard fileManager.fileExists(atPath: frameworkHeader.path) else {
+          fatalError("Missing explicit umbrella header for \(framework).")
+        }
+      } else {
+        umbrellaHeader = umbrellaHeaderURL.lastPathComponent
       }
     }
-    // Copy the Headers over. Pass in the prefix to remove in order to generate the relative paths
-    // for some frameworks that have nested folders in their public headers.
+    // Copy the Headers over.
     let headersDestination = frameworkDir.appendingPathComponent("Headers")
     do {
-      try recursivelyCopyHeaders(from: headersDir, to: headersDestination)
+      try fileManager.copyItem(at: headersDir, to: headersDestination)
     } catch {
       fatalError("Could not copy headers from \(headersDir) to Headers directory in " +
         "\(headersDestination): \(error)")
     }
 
+    // TODO: copy PrivateHeaders directory as well if it exists. SDWebImage is an example pod.
+
     // Move all the Resources into .bundle directories in the destination Resources dir. The
     // Resources live are contained within the folder structure:
     // `projectDir/arch/Release-platform/FrameworkName`
-    let arch = Architecture.arm64
-    let contentsDir = projectDir.appendingPathComponents([arch.rawValue,
-                                                          "Release-\(arch.platform.rawValue)",
+
+    let contentsDir = projectDir.appendingPathComponents([anyArch.rawValue,
+                                                          "Release-\(anyArch.platform.rawValue)",
                                                           framework])
     let resourceDir = frameworkDir.appendingPathComponent("Resources")
     do {
@@ -441,10 +494,14 @@ struct FrameworkBuilder {
         "\(error)")
     }
 
+    guard let moduleMapContents = podInfo.moduleMapContents else {
+      fatalError("Module map contents missing for framework \(framework)")
+    }
     let xcframework = packageXCFramework(withName: framework,
                                          fromFolder: frameworkDir,
                                          thinArchives: thinArchives,
-                                         moduleMapContents: moduleMapContents)
+                                         moduleMapContents:
+                                         moduleMapContents.get(umbrellaHeader: umbrellaHeader))
 
     // Remove the temporary thin archives.
     for thinArchive in thinArchives.values {
@@ -562,6 +619,9 @@ struct FrameworkBuilder {
     for platform in Architecture.TargetPlatform.allCases {
       // Get all the slices that belong to the specific platform in order to lipo them together.
       let slices = thinArchives.filter { $0.key.platform == platform }
+      if slices.count == 0 {
+        continue
+      }
       let platformDir = platformFrameworksDir.appendingPathComponent(platform.rawValue)
       do {
         try fileManager.createDirectory(at: platformDir, withIntermediateDirectories: true)
@@ -617,72 +677,5 @@ struct FrameworkBuilder {
     }
 
     return xcframework
-  }
-
-  /// Recursively copies headers from the given directory to the destination directory. This does a
-  /// deep copy and resolves and symlinks (which CocoaPods uses in the Public headers folder).
-  /// Throws FileManager errors if something goes wrong during the operations.
-  /// Note: This is only needed now because the `cp` command has a flag that did this for us, but
-  /// FileManager does not.
-  private func recursivelyCopyHeaders(from headersDir: URL,
-                                      to destinationDir: URL,
-                                      fileManager: FileManager = FileManager.default) throws {
-    // Copy the public headers into the new framework. Unfortunately we can't just copy the
-    // `Headers` directory since it uses aliases, so we'll recursively search the public Headers
-    // directory from CocoaPods and resolve all the aliases manually.
-    let fileManager = FileManager.default
-
-    // Create the Headers directory if it doesn't exist.
-    try fileManager.createDirectory(at: destinationDir, withIntermediateDirectories: true)
-
-    // Get all the header aliases from the CocoaPods directory and get their real path as well as
-    // their relative path to the Headers directory they are in. This is needed to preserve proper
-    // imports for nested folders.
-    let aliasedHeaders = try fileManager.recursivelySearch(for: .headers, in: headersDir)
-    let mappedHeaders: [(relativePath: String, resolvedLocation: URL)] = aliasedHeaders.map {
-      // The `headersDir` and `aliasedHeader` prefixes may be different, but they both should have
-      // `Pods/Headers/` in the path. Ignore everything up until that, then strip the remainder of
-      // the `headersDir` from the `aliasedHeader` in order to get path relative to the headers
-      // directory.
-      let trimmedHeader = removeHeaderPathPrefix(from: $0)
-      let trimmedDir = removeHeaderPathPrefix(from: headersDir)
-      var relativePath = trimmedHeader.replacingOccurrences(of: trimmedDir, with: "")
-
-      // Remove any leading `/` for the relative path.
-      if relativePath.starts(with: "/") {
-        _ = relativePath.removeFirst()
-      }
-
-      // Standardize the URL because the aliasedHeaders could be at `/private/var` or `/var` which
-      // are symlinked to each other on macOS.
-      let resolvedLocation = $0.standardizedFileURL.resolvingSymlinksInPath()
-      return (relativePath, resolvedLocation)
-    }
-
-    // Copy all the headers into the Headers directory created above.
-    for (relativePath, location) in mappedHeaders {
-      // Append the proper filename to our Headers directory, then try copying it over.
-      let finalPath = destinationDir.appendingPathComponent(relativePath)
-
-      // Create the destination folder if it doesn't exist.
-      let parentDir = finalPath.deletingLastPathComponent()
-      if !fileManager.directoryExists(at: parentDir) {
-        try fileManager.createDirectory(at: parentDir, withIntermediateDirectories: true)
-      }
-
-      try fileManager.copyItem(at: location, to: finalPath)
-    }
-  }
-
-  private func removeHeaderPathPrefix(from url: URL) -> String {
-    let fullPath = url.standardizedFileURL.path
-    guard let foundRange = fullPath.range(of: "Pods/Headers/") else {
-      fatalError("Could not copy headers for framework: full path do not contain `Pods/Headers`:" +
-        fullPath)
-    }
-
-    // Replace everything from the start of the string until the end of the `Pods/Headers/`.
-    let toRemove = fullPath.startIndex ..< foundRange.upperBound
-    return fullPath.replacingCharacters(in: toRemove, with: "")
   }
 }

--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -218,13 +218,17 @@ struct FrameworkBuilder {
                 "-configuration", "release",
                 "-workspace", workspacePath,
                 "-scheme", framework,
-                "GCC_GENERATE_DEBUGGING_SYMBOLS=No",
+                "GCC_GENERATE_DEBUGGING_SYMBOLS=NO",
                 "ARCHS=\(cleanArch)",
                 "VALID_ARCHS=\(cleanArch)",
                 "ONLY_ACTIVE_ARCH=NO",
                 "BUILD_LIBRARIES_FOR_DISTRIBUTION=YES",
                 "SUPPORTS_MACCATALYST=\(isMacCatalystString)",
                 "BUILD_DIR=\(buildDir.path)",
+                // Code signing isn't needed for libraries. Disabling signing is required for
+                // Catalyst libs with resources. See
+                // https://github.com/CocoaPods/CocoaPods/issues/8891#issuecomment-573301570
+                "CODE_SIGN_IDENTITY=-",
                 "-sdk", platform.rawValue,
                 cFlags]
     print("""

--- a/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
+++ b/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
@@ -42,6 +42,7 @@ struct LaunchArgs {
     case archs
     case buildRoot
     case carthageDir
+    case carthageSkipVersionCheck
     case customSpecRepos
     case dynamic
     case existingVersions
@@ -67,6 +68,8 @@ struct LaunchArgs {
       case .carthageDir:
         return "The directory pointing to all Carthage JSON manifests. Passing this flag enables" +
           "the Carthage build."
+      case .carthageSkipVersionCheck:
+        return "A flag to skip the Carthage version check for development iteration."
       case .customSpecRepos:
         return "A comma separated list of custom CocoaPod Spec repos."
       case .dynamic:
@@ -112,6 +115,9 @@ struct LaunchArgs {
   /// The directory pointing to all Carthage JSON manifests. Passing this flag enables the Carthage
   /// build.
   let carthageDir: URL?
+
+  /// Skip the Carthage version check
+  let carthageSkipVersionCheck: Bool
 
   /// A file URL to a textproto with the contents of a `ZipBuilder_Release` object. Used to verify
   /// expected version numbers.
@@ -330,6 +336,7 @@ struct LaunchArgs {
       minimumIOSVersion = "9.0"
     }
 
+    carthageSkipVersionCheck = defaults.bool(forKey: Key.carthageSkipVersionCheck.rawValue)
     dynamic = defaults.bool(forKey: Key.dynamic.rawValue)
     updatePodRepo = defaults.bool(forKey: Key.updatePodRepo.rawValue)
     keepBuildArtifacts = defaults.bool(forKey: Key.keepBuildArtifacts.rawValue)

--- a/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
+++ b/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
@@ -43,6 +43,7 @@ struct LaunchArgs {
     case buildRoot
     case carthageDir
     case customSpecRepos
+    case dynamic
     case existingVersions
     case keepBuildArtifacts
     case localPodspecPath
@@ -68,6 +69,8 @@ struct LaunchArgs {
           "the Carthage build."
       case .customSpecRepos:
         return "A comma separated list of custom CocoaPod Spec repos."
+      case .dynamic:
+        return "A flag specifying to build dynamic library frameworks."
       case .existingVersions:
         return "The file path to a textproto file containing the existing released SDK versions, " +
           "of type `ZipBuilder_FirebaseSDKs`."
@@ -117,6 +120,9 @@ struct LaunchArgs {
   /// Custom CocoaPods spec repos to be used. If not provided, the tool will only use the CocoaPods
   /// master repo.
   let customSpecRepos: [URL]?
+
+  /// A flag that indicates to build dynamic library frameworks. The default is false and static linkage.
+  let dynamic: Bool
 
   /// A flag to keep the build artifacts after this script completes.
   let keepBuildArtifacts: Bool
@@ -324,6 +330,7 @@ struct LaunchArgs {
       minimumIOSVersion = "9.0"
     }
 
+    dynamic = defaults.bool(forKey: Key.dynamic.rawValue)
     updatePodRepo = defaults.bool(forKey: Key.updatePodRepo.rawValue)
     keepBuildArtifacts = defaults.bool(forKey: Key.keepBuildArtifacts.rawValue)
 

--- a/ZipBuilder/Sources/ZipBuilder/Zip.swift
+++ b/ZipBuilder/Sources/ZipBuilder/Zip.swift
@@ -40,7 +40,7 @@ struct Zip {
     }
 
     // Run the `zip` command. This could be replaced with a proper Zip library in the future.
-    let command = "zip -q -r -dg \(zip.lastPathComponent) \(directory.lastPathComponent)"
+    let command = "zip --symlinks -q -r -dg \(zip.lastPathComponent) \(directory.lastPathComponent)"
     let result = Shell.executeCommandFromScript(command, workingDir: parentDir)
     switch result {
     case .success:

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -154,7 +154,7 @@ struct ZipBuilder {
     // copied in each product's directory.
     let frameworks = generateFrameworks(fromPods: installedPods, inProjectDir: projectDir)
 
-    ModuleMapBuilder(frameworks: frameworks, customSpecRepos: customSpecRepos, allPods: installedPods).build()
+    //ModuleMapBuilder(frameworks: frameworks, customSpecRepos: customSpecRepos, allPods: installedPods).build()
 
     for (framework, paths) in frameworks {
       print("Frameworks for pod: \(framework) were compiled at \(paths)")
@@ -305,8 +305,8 @@ struct ZipBuilder {
         if pod.key == crashlyticsPodName {
           for file in ["upload-symbols", "run"] {
             let source = pod.value.installedLocation.appendingPathComponent(file)
-            let target = zipDir.appendingPathComponent(crashlyticsPodName).appendingPathComponent(file)
 
+            let target = zipDir.appendingPathComponent(crashlyticsPodName).appendingPathComponent(file)
             do {
               try FileManager.default.copyItem(at: source, to: target)
             } catch {
@@ -419,7 +419,8 @@ struct ZipBuilder {
           continue
         }
 
-        let destination = dir.appendingPathComponent(frameworkName)
+        let xcFrameworkName = frameworkName.replacingOccurrences(of: ".framework", with: ".xcframework")
+        let destination = dir.appendingPathComponent(xcFrameworkName)
         try fileManager.copyItem(at: framework, to: destination)
         copiedFrameworkNames.append(frameworkName.replacingOccurrences(of: ".framework", with: ""))
       }

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -708,9 +708,8 @@ struct ZipBuilder {
       if podInfo.isSourcePod {
         let builder = FrameworkBuilder(projectDir: projectDir, carthageBuild: carthageBuild)
         let framework = builder.buildFramework(withName: podName,
-                                               version: podInfo.version,
-                                               logsOutputDir: paths.logsOutputDir,
-                                               moduleMapContents: pods[podName]!.moduleMapContents)
+                                               podInfo: podInfo,
+                                               logsOutputDir: paths.logsOutputDir)
 
         frameworks = [framework]
       } else {

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -658,16 +658,12 @@ struct ZipBuilder {
     // Create the temporary directory we'll be storing the build/assembled frameworks in, and remove
     // the Resources directory if it already exists.
     let tempDir = fileManager.temporaryDirectory(withName: "all_frameworks")
-    let tempResourceDir = tempDir.appendingPathComponent("Resources")
     do {
       try fileManager.createDirectory(at: tempDir,
                                       withIntermediateDirectories: true,
                                       attributes: nil)
-      if fileManager.directoryExists(at: tempResourceDir) {
-        try fileManager.removeItem(at: tempResourceDir)
-      }
     } catch {
-      fatalError("Cannot create temporary directory to store frameworks and resources from the " +
+      fatalError("Cannot create temporary directory to store frameworks from the " +
         "full build: \(error)")
     }
 

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -154,7 +154,7 @@ struct ZipBuilder {
     // copied in each product's directory.
     let frameworks = generateFrameworks(fromPods: installedPods, inProjectDir: projectDir)
 
-    //ModuleMapBuilder(frameworks: frameworks, customSpecRepos: customSpecRepos, allPods: installedPods).build()
+    // ModuleMapBuilder(frameworks: frameworks, customSpecRepos: customSpecRepos, allPods: installedPods).build()
 
     for (framework, paths) in frameworks {
       print("Frameworks for pod: \(framework) were compiled at \(paths)")

--- a/ZipBuilder/Sources/ZipBuilder/main.swift
+++ b/ZipBuilder/Sources/ZipBuilder/main.swift
@@ -56,7 +56,7 @@ if args.zipPods == nil {
   // Do a Firebase build.
   FirebaseBuilder(zipBuilder: builder).build(in: projectDir)
 } else {
-  let (installedPods, frameworks) = builder.buildAndAssembleZip(podsToInstall: LaunchArgs.shared.zipPods!)
+  let (installedPods, frameworks, _) = builder.buildAndAssembleZip(podsToInstall: LaunchArgs.shared.zipPods!)
   let staging = FileManager.default.temporaryDirectory(withName: "staging")
   try builder.copyFrameworks(fromPods: Array(installedPods.keys), toDirectory: staging,
                              frameworkLocations: frameworks)

--- a/ZipBuilder/Template/FrameworkMaker.entitlements
+++ b/ZipBuilder/Template/FrameworkMaker.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/ZipBuilder/Template/FrameworkMaker.xcodeproj/project.pbxproj
+++ b/ZipBuilder/Template/FrameworkMaker.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXFileReference section */
 		05A46BD71CC9B2BE007BDB33 /* FrameworkMaker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FrameworkMaker.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		784BA73523D9E621003FCA76 /* FrameworkMaker.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = FrameworkMaker.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -24,6 +25,7 @@
 		05A46BCE1CC9B2BE007BDB33 = {
 			isa = PBXGroup;
 			children = (
+				784BA73523D9E621003FCA76 /* FrameworkMaker.entitlements */,
 				05A46BD81CC9B2BE007BDB33 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -75,6 +77,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -150,6 +153,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				VALID_ARCHS = "arm64 arm64e armv7 armv7s x86_64 x86_64h i386";
 			};
 			name = Debug;
 		};
@@ -188,6 +192,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
+				VALID_ARCHS = "arm64 arm64e armv7 armv7s x86_64 x86_64h i386";
 			};
 			name = Release;
 		};
@@ -195,10 +200,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = FrameworkMaker.entitlements;
+				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = YES;
 				INFOPLIST_FILE = Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = google.FrameworkMaker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTS_MACCATALYST = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -206,10 +215,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = FrameworkMaker.entitlements;
+				DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = YES;
 				INFOPLIST_FILE = Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = google.FrameworkMaker;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTS_MACCATALYST = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/ZipBuilder/Template/README.md
+++ b/ZipBuilder/Template/README.md
@@ -15,13 +15,14 @@ To integrate a Firebase SDK with your app:
 2. Make sure you have an Xcode project open in Xcode.
 3. In Xcode, hit `⌘-1` to open the Project Navigator pane. It will open on
    left side of the Xcode window if it wasn't already open.
-4. Drag each framework from the "FirebaseAnalytics" directory into the Project
+4. Remove any existing Firebase frameworks from your project.
+5. Drag each framework from the "FirebaseAnalytics" directory into the Project
    Navigator pane. In the dialog box that appears, make sure the target you
    want the framework to be added to has a checkmark next to it, and that
-   you've selected "Copy items if needed". If you already have Firebase
-   frameworks in your project, make sure that you replace them with the new
-   versions.
-5. Drag each framework from the directory named after the SDK into the Project
+   you've selected "Copy items if needed". If you want to include
+   community-based Catalyst support, only drag the xcframeworks and skip the
+   plain frameworks.
+6. Drag each framework from the directory named after the SDK into the Project
    Navigator pane. Note that there may be no additional frameworks, in which
    case this directory will be empty. For instance, if you want the Database
    SDK, look in the Database folder for the required frameworks. In the dialog
@@ -33,24 +34,24 @@ To integrate a Firebase SDK with your app:
    [static frameworks](https://www.raywenderlich.com/65964/create-a-framework-for-ios)
    which cannot be embedded into your application's bundle.*
 
-6. If the SDK has resources, go into the Resources folders, which will be in
+7. If the SDK has resources, go into the Resources folders, which will be in
    the SDK folder. Drag all of those resources into the Project Navigator, just
    like the frameworks, again making sure that the target you want to add these
    resources to has a checkmark next to it, and that you've selected "Copy items
    if needed".
-7. Add the -ObjC flag to "Other Linker Settings":
+8. Add the -ObjC flag to "Other Linker Settings":
   a. In your project settings, open the Settings panel for your target
   b. Go to the Build Settings tab and find the "Other Linker Flags" setting
      in the Linking section.
   c. Double-click the setting, click the '+' button, and add "-ObjC" (without
      quotes)
-8. Drag the `Firebase.h` header in this directory into your project. This will
+9. Drag the `Firebase.h` header in this directory into your project. This will
    allow you to `#import "Firebase.h"` and start using any Firebase SDK that you
    have.
-9. If you're using Swift, or you want to use modules, drag module.modulemap into
+10. If you're using Swift want to use modules, drag `module.modulemap` into
    your project and update your User Header Search Paths to contain the
    directory that contains your module map.
-10. You're done! Compile your target and start using Firebase.
+11. You're done! Compile your target and start using Firebase.
 
 If you want to add another SDK, repeat the steps above with the frameworks for
 the new SDK. You only need to add each framework once, so if you've already
@@ -76,7 +77,9 @@ You can get samples for Firebase from https://github.com/firebase/quickstart-ios
 
 Note that several of the samples depend on SDKs that are not included with
 this archive; for example, FirebaseUI. For the samples that depend on SDKs not
-included in this archive, you'll need to use CocoaPods.
+included in this archive, you'll need to use CocoaPods or use the
+[ZipBuilder](https://github.com/firebase/firebase-ios-sdk/tree/master/ZipBuilder)
+to create your own custom binary frameworks.
 
 # Versions
 


### PR DESCRIPTION
Update the distribution of source pods in the zip distribution from frameworks to xcframeworks.  The result is that the community-supported Catalyst support is now available via the zip distribution in addition the CocoaPods.

Everything in this PR has already been reviewed and the plan is to merge this from the command line to avoid squashing the individual PRs on the xcframework-master branch.

The release notes will be updated after this merges to master.

#no-changelog
