### PR TITLE
FirebaseAuth should be in implicit pod list

### DIFF
--- a/scripts/localize_podfile.swift
+++ b/scripts/localize_podfile.swift
@@ -26,6 +26,7 @@ let podfile = CommandLine.arguments[1]
 // versions when they're dependencies of other requested local pods.
 let implicitPods = ["FirebaseCore", "FirebaseInstanceID", "FirebaseInstallations", "Firebase",
                     "GoogleDataTransport", "GoogleDataTransportCCTSupport", "GoogleUtilities",
+                    "FirebaseAuth",
                     "FirebaseAnalyticsInterop", "FirebaseAuthInterop", "FirebaseCoreDiagnostics",
                     "FirebaseCoreDiagnosticsInterop", "FirebaseRemoteConfig", "FirebaseAuthInterop"]
 var didImplicits = false


### PR DESCRIPTION
Fix travis cron failure at https://travis-ci.org/github/firebase/firebase-ios-sdk/jobs/661826491

FirebaseAuth is a quickstart dependency of the Functions quickstart via FirebaseUI so we need to ensure we get the local podspec when we get the local Firebase podspec.