### PR TITLE
Attempt to fix intermittent failing Crashlytics settings tests in CI

### DIFF
--- a/Crashlytics/UnitTests/FIRCLSSettingsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSettingsTests.m
@@ -49,6 +49,12 @@ NSString *FIRCLSDifferentMockBuildInstanceID = @"98765zyxwv";
 NSString *const TestGoogleAppID = @"1:test:google:app:id";
 NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
 
+@interface FIRCLSSettings (Testing)
+
+@property(nonatomic, strong) NSDictionary<NSString *, id> *settingsDictionary;
+
+@end
+
 @interface FIRCLSSettingsTests : XCTestCase
 
 @property(nonatomic, retain) FIRCLSMockFileManager *fileManager;
@@ -437,8 +443,11 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   [self.settings cacheSettingsWithGoogleAppID:TestGoogleAppID currentTimestamp:currentTimestamp];
 
   XCTAssertNil(error, "%@", error);
-//  XCTAssertTrue(self.settings.shouldUseNewReportEndpoint);
+  XCTAssertTrue(self.settings.settingsDictionary);
+  NSLog(@"[JH] %@", self.settings.settingsDictionary);
   XCTAssertNotNil(self.settings);
+
+  XCTAssertTrue(self.settings.shouldUseNewReportEndpoint);
 }
 
 - (void)testLegacyReportEndpointSettings {

--- a/Crashlytics/UnitTests/FIRCLSSettingsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSettingsTests.m
@@ -75,6 +75,10 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   _settings = [[FIRCLSSettings alloc] initWithFileManager:_fileManager appIDModel:_appIDModel];
 }
 
+- (void)tearDown {
+  [_fileManager removeContentsOfDirectoryAtPath:_fileManager.settingsDirectoryPath];
+}
+
 - (void)testDefaultSettings {
   XCTAssertEqual(self.settings.isCacheExpired, YES);
 

--- a/Crashlytics/UnitTests/FIRCLSSettingsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSettingsTests.m
@@ -426,19 +426,19 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertEqual(self.settings.errorLogBufferSize, 64 * 1000);
 }
 
-- (void)testNewReportEndpointSettings {
-  NSString *settingsJSON =
-      @"{\"settings_version\":3,\"cache_duration\":60,\"app\":{\"status\":\"activated\",\"update_"
-      @"required\":false,\"report_upload_variant\":2}}";
-
-  NSError *error = nil;
-  [self writeSettings:settingsJSON error:&error];
-  NSTimeInterval currentTimestamp = [NSDate timeIntervalSinceReferenceDate];
-  [self.settings cacheSettingsWithGoogleAppID:TestGoogleAppID currentTimestamp:currentTimestamp];
-
-  XCTAssertNil(error, "%@", error);
-  XCTAssertTrue(self.settings.shouldUseNewReportEndpoint);
-}
+//- (void)testNewReportEndpointSettings {
+//  NSString *settingsJSON =
+//      @"{\"settings_version\":3,\"cache_duration\":60,\"app\":{\"status\":\"activated\",\"update_"
+//      @"required\":false,\"report_upload_variant\":2}}";
+//
+//  NSError *error = nil;
+//  [self writeSettings:settingsJSON error:&error];
+//  NSTimeInterval currentTimestamp = [NSDate timeIntervalSinceReferenceDate];
+//  [self.settings cacheSettingsWithGoogleAppID:TestGoogleAppID currentTimestamp:currentTimestamp];
+//
+//  XCTAssertNil(error, "%@", error);
+//  XCTAssertTrue(self.settings.shouldUseNewReportEndpoint);
+//}
 
 - (void)testLegacyReportEndpointSettings {
   NSString *settingsJSON =

--- a/Crashlytics/UnitTests/FIRCLSSettingsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSettingsTests.m
@@ -441,14 +441,11 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   [self writeSettings:settingsJSON error:&error];
   NSTimeInterval currentTimestamp = [NSDate timeIntervalSinceReferenceDate];
   [self.settings cacheSettingsWithGoogleAppID:TestGoogleAppID currentTimestamp:currentTimestamp];
-
   XCTAssertNil(error, "%@", error);
-  XCTAssertTrue(self.settings.settingsDictionary);
-  NSLog(@"[JH] %@", self.settings.settingsDictionary);
+    
   XCTAssertNotNil(self.settings);
-
+  NSLog(@"[Debug Log] %@", self.settings.settingsDictionary);
   XCTAssertTrue(self.settings.shouldUseNewReportEndpoint);
-  NSLog(@"Test");
 }
 
 - (void)testLegacyReportEndpointSettings {

--- a/Crashlytics/UnitTests/FIRCLSSettingsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSettingsTests.m
@@ -443,7 +443,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   [self.settings cacheSettingsWithGoogleAppID:TestGoogleAppID currentTimestamp:currentTimestamp];
   XCTAssertNil(error, "%@", error);
 
-  XCTAssertNotNil(self.settings);
+  XCTAssertNotNil(self.settings.settingsDictionary);
   NSLog(@"[Debug Log] %@", self.settings.settingsDictionary);
   XCTAssertTrue(self.settings.shouldUseNewReportEndpoint);
 }

--- a/Crashlytics/UnitTests/FIRCLSSettingsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSettingsTests.m
@@ -448,6 +448,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertNotNil(self.settings);
 
   XCTAssertTrue(self.settings.shouldUseNewReportEndpoint);
+  NSLog(@"Test");
 }
 
 - (void)testLegacyReportEndpointSettings {

--- a/Crashlytics/UnitTests/FIRCLSSettingsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSettingsTests.m
@@ -442,7 +442,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   NSTimeInterval currentTimestamp = [NSDate timeIntervalSinceReferenceDate];
   [self.settings cacheSettingsWithGoogleAppID:TestGoogleAppID currentTimestamp:currentTimestamp];
   XCTAssertNil(error, "%@", error);
-    
+
   XCTAssertNotNil(self.settings);
   NSLog(@"[Debug Log] %@", self.settings.settingsDictionary);
   XCTAssertTrue(self.settings.shouldUseNewReportEndpoint);

--- a/Crashlytics/UnitTests/FIRCLSSettingsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSettingsTests.m
@@ -426,19 +426,20 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertEqual(self.settings.errorLogBufferSize, 64 * 1000);
 }
 
-//- (void)testNewReportEndpointSettings {
-//  NSString *settingsJSON =
-//      @"{\"settings_version\":3,\"cache_duration\":60,\"app\":{\"status\":\"activated\",\"update_"
-//      @"required\":false,\"report_upload_variant\":2}}";
-//
-//  NSError *error = nil;
-//  [self writeSettings:settingsJSON error:&error];
-//  NSTimeInterval currentTimestamp = [NSDate timeIntervalSinceReferenceDate];
-//  [self.settings cacheSettingsWithGoogleAppID:TestGoogleAppID currentTimestamp:currentTimestamp];
-//
-//  XCTAssertNil(error, "%@", error);
+- (void)testNewReportEndpointSettings {
+  NSString *settingsJSON =
+      @"{\"settings_version\":3,\"cache_duration\":60,\"app\":{\"status\":\"activated\",\"update_"
+      @"required\":false,\"report_upload_variant\":2}}";
+
+  NSError *error = nil;
+  [self writeSettings:settingsJSON error:&error];
+  NSTimeInterval currentTimestamp = [NSDate timeIntervalSinceReferenceDate];
+  [self.settings cacheSettingsWithGoogleAppID:TestGoogleAppID currentTimestamp:currentTimestamp];
+
+  XCTAssertNil(error, "%@", error);
 //  XCTAssertTrue(self.settings.shouldUseNewReportEndpoint);
-//}
+  XCTAssertNotNil(self.settings);
+}
 
 - (void)testLegacyReportEndpointSettings {
   NSString *settingsJSON =


### PR DESCRIPTION
Ensure the settings directory gets cleared in between runs.

Ran CI ~5 times with the last change and the tests pass. Added a debug log in case the issue still occurs.