### PR TITLE
Installations: access FIRHeartbeatInfo from a background thread

### DIFF
--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
@@ -56,6 +56,9 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
                                                               projectID:self.projectID];
   self.heartbeatMock = OCMClassMock([FIRHeartbeatInfo class]);
   OCMStub([self.heartbeatMock heartbeatCodeForTag:@"fire-installations"])
+      .andDo(^(NSInvocation *invocation) {
+        XCTAssertFalse([NSThread isMainThread]);
+      })
       .andReturn(FIRHeartbeatInfoCodeCombined);
 }
 


### PR DESCRIPTION
Fixes #5098.

Accessing `FIRHeartbeatInfo` implies accessing file system which may be a slow operation. The changes move all `FIRHeartbeatInfo` related operations to a background queue.