### PR TITLE
Add Catalyst testing for GHA

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -29,8 +29,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
-    - name: pod gen
-      run: scripts/test_catalyst FirebaseCore
+    - name: Setup project and Test Catalyst
+      run: scripts/test_catalyst.sh FirebaseCore
 
   core-cron-only:
     runs-on: macos-latest

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and Build Catalyst
-      run: scripts/test_catalyst.sh FirebaseCore build
+      run: scripts/test_catalyst.sh FirebaseCore test FirebaseCore-Unit-unit
 
   core-cron-only:
     runs-on: macos-latest

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and Test Catalyst
-      run: scripts/test_catalyst.sh FirebaseCore
+      run: scripts/test_catalyst.sh FirebaseCore test
 
   core-cron-only:
     runs-on: macos-latest

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and Build Catalyst
-      run: scripts/test_catalyst.sh FirebaseCore test FirebaseCore-Unit-unit
+      run: scripts/test_catalyst.sh FirebaseCore build
 
   core-cron-only:
     runs-on: macos-latest

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
-    - name: Setup project and Test Catalyst
+    - name: Setup project and Build Catalyst
       run: scripts/test_catalyst.sh FirebaseCore build
 
   core-cron-only:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and Test Catalyst
-      run: scripts/test_catalyst.sh FirebaseCore test
+      run: scripts/test_catalyst.sh FirebaseCore build
 
   core-cron-only:
     runs-on: macos-latest

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build and test
       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=${{ matrix.target }}
 
-  catalsyt:
+  catalyst:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -23,6 +23,15 @@ jobs:
     - name: Build and test
       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseCore.podspec --platforms=${{ matrix.target }}
 
+  catalsyt:
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: pod gen
+      run: scripts/test_catalyst FirebaseCore
+
   core-cron-only:
     runs-on: macos-latest
     if: github.event_name == 'schedule'

--- a/.github/workflows/datatransport.yml
+++ b/.github/workflows/datatransport.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and Test Catalyst
-      run: scripts/test_catalyst.sh {{ matrix.pod }} test
+      run: scripts/test_catalyst.sh ${{ matrix.pod }} test
 
 # Scheduled jobs
 

--- a/.github/workflows/datatransport.yml
+++ b/.github/workflows/datatransport.yml
@@ -25,6 +25,18 @@ jobs:
         ./scripts/third_party/travis/retry.sh ./scripts/pod_lib_lint.rb GoogleDataTransport.podspec --platforms=${{ matrix.target }}
         ./scripts/third_party/travis/retry.sh ./scripts/pod_lib_lint.rb GoogleDataTransportCCTSupport.podspec --platforms=${{ matrix.target }}
 
+  catalsyt:
+    runs-on: macOS-latest
+    strategy:
+      matrix:
+        pod: [GoogleDataTransport, GoogleDataTransportCCTSupport]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Setup project and Test Catalyst
+      run: scripts/test_catalyst.sh {{ matrix.pod }} test
+
 # Scheduled jobs
 
   datatransport-cron-only:

--- a/.github/workflows/datatransport.yml
+++ b/.github/workflows/datatransport.yml
@@ -25,7 +25,7 @@ jobs:
         ./scripts/third_party/travis/retry.sh ./scripts/pod_lib_lint.rb GoogleDataTransport.podspec --platforms=${{ matrix.target }}
         ./scripts/third_party/travis/retry.sh ./scripts/pod_lib_lint.rb GoogleDataTransportCCTSupport.podspec --platforms=${{ matrix.target }}
 
-  catalsyt:
+  catalyst:
     runs-on: macOS-latest
     strategy:
       matrix:

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -27,6 +27,15 @@ jobs:
     - name: Build and test
       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseMessaging.podspec --platforms=${{ matrix.target }}
 
+  catalsyt:
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Setup project and Test Catalyst
+      run: scripts/test_catalyst.sh FirebaseMessaging test
+
   pod-lib-lint-watchos:
     runs-on: macOS-latest
 

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
-    - name: Setup project and Test Catalyst
+    - name: Setup project and Build Catalyst
       run: scripts/test_catalyst.sh FirebaseMessaging build
 
   pod-lib-lint-watchos:

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and Test Catalyst
-      run: scripts/test_catalyst.sh FirebaseMessaging test
+      run: scripts/test_catalyst.sh FirebaseMessaging build
 
   pod-lib-lint-watchos:
     runs-on: macOS-latest

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and Build Catalyst
-      run: scripts/test_catalyst.sh FirebaseMessaging test FirebaseMessaging-Unit-unit
+      run: scripts/test_catalyst.sh FirebaseMessaging build
 
   pod-lib-lint-watchos:
     runs-on: macOS-latest

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Build and test
       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseMessaging.podspec --platforms=${{ matrix.target }}
 
-  catalsyt:
+  catalyst:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and Build Catalyst
-      run: scripts/test_catalyst.sh FirebaseMessaging build
+      run: scripts/test_catalyst.sh FirebaseMessaging test FirebaseMessaging-Unit-unit
 
   pod-lib-lint-watchos:
     runs-on: macOS-latest

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
-    - name: Setup project and Test Catalyst
+    - name: Setup project and Build for Catalyst
       # TODO - Change the "build" to "test" when CocoaPods 1.10.0 is available
       # and it becomes possible to select only the unit tests.
       run: scripts/test_catalyst.sh FirebaseStorage build

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -31,7 +31,8 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and Build for Catalyst
-      run: scripts/test_catalyst.sh FirebaseStorage test
+      # Only run the unit tests on Catalyst
+      run: scripts/test_catalyst.sh FirebaseStorage test FirebaseStorage-Unit-unit
 
   pod-lib-lint:
     runs-on: macOS-latest

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -31,9 +31,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and Build for Catalyst
-      # TODO - Change the "build" to "test" when CocoaPods 1.10.0 is available
-      # and it becomes possible to select only the unit tests.
-      run: scripts/test_catalyst.sh FirebaseStorage build
+      run: scripts/test_catalyst.sh FirebaseStorage test
 
   pod-lib-lint:
     runs-on: macOS-latest

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -24,6 +24,17 @@ jobs:
     - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
       run: scripts/third_party/travis/retry.sh scripts/build.sh Storage all
 
+  catalsyt:
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Setup project and Test Catalyst
+      # TODO - Change the "build" to "test" when CocoaPods 1.10.0 is available
+      # and it becomes possible to select only the unit tests.
+      run: scripts/test_catalyst.sh FirebaseStorage build
+
   pod-lib-lint:
     runs-on: macOS-latest
 

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -24,7 +24,7 @@ jobs:
     - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
       run: scripts/third_party/travis/retry.sh scripts/build.sh Storage all
 
-  catalsyt:
+  catalyst:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORStorageTest.m
@@ -617,7 +617,15 @@ static NSInteger target = kGDTCORTargetCCT;
                                                               options:0];
   XCTAssertNotNil(v1ArchiveData);
   GDTCORStorage *archiveStorage;
-  XCTAssertNoThrow(archiveStorage = [NSKeyedUnarchiver unarchiveObjectWithData:v1ArchiveData]);
+  if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
+    NSError *error;
+    XCTAssertNoThrow(archiveStorage = [NSKeyedUnarchiver unarchivedObjectOfClass:[GDTCORStorage class]
+                                                            fromData:v1ArchiveData error:&error]);
+  } else {
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_WATCH
+    XCTAssertNoThrow(archiveStorage = [NSKeyedUnarchiver unarchiveObjectWithData:v1ArchiveData]);
+#endif
+  }
   XCTAssertEqual(archiveStorage.targetToEventSet[@(kGDTCORTargetCCT)].count, 6);
   XCTAssertEqual(archiveStorage.targetToEventSet[@(kGDTCORTargetFLL)].count, 12);
   XCTAssertEqual(archiveStorage.storedEvents.count, 18);

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORStorageTest.m
@@ -619,8 +619,10 @@ static NSInteger target = kGDTCORTargetCCT;
   GDTCORStorage *archiveStorage;
   if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
     NSError *error;
-    XCTAssertNoThrow(archiveStorage = [NSKeyedUnarchiver unarchivedObjectOfClass:[GDTCORStorage class]
-                                                            fromData:v1ArchiveData error:&error]);
+    XCTAssertNoThrow(archiveStorage =
+                         [NSKeyedUnarchiver unarchivedObjectOfClass:[GDTCORStorage class]
+                                                           fromData:v1ArchiveData
+                                                              error:&error]);
   } else {
 #if !TARGET_OS_MACCATALYST && !TARGET_OS_WATCH
     XCTAssertNoThrow(archiveStorage = [NSKeyedUnarchiver unarchiveObjectWithData:v1ArchiveData]);

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORUploadCoordinatorTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORUploadCoordinatorTest.m
@@ -158,10 +158,11 @@
   if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
     NSError *error;
     data = [NSKeyedArchiver archivedDataWithRootObject:coordinator
-                                         requiringSecureCoding:YES
-                                                         error:&error];
+                                 requiringSecureCoding:YES
+                                                 error:&error];
     unarchivedCoordinator = [NSKeyedUnarchiver unarchivedObjectOfClass:[GDTCORStorage class]
-                                                              fromData:data error:&error];
+                                                              fromData:data
+                                                                 error:&error];
   } else {
 #if !TARGET_OS_MACCATALYST && !TARGET_OS_WATCH
     data = [NSKeyedArchiver archivedDataWithRootObject:coordinator];

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORUploadCoordinatorTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORUploadCoordinatorTest.m
@@ -150,27 +150,19 @@
 
 /** Tests that encoding and decoding works without crashing. */
 - (void)testNSSecureCoding {
+#if TARGET_OS_MACCATALYST
+  // TODO - port the archiver calls to Catalyst API
+#else
   GDTCORUploadPackage *package = [[GDTCORUploadPackage alloc] initWithTarget:kGDTCORTargetTest];
   GDTCORUploadCoordinator *coordinator = [[GDTCORUploadCoordinator alloc] init];
   coordinator.targetToInFlightPackages[@(kGDTCORTargetTest)] = package;
   NSData *data;
   GDTCORUploadCoordinator *unarchivedCoordinator;
-  if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-    NSError *error;
-    data = [NSKeyedArchiver archivedDataWithRootObject:coordinator
-                                 requiringSecureCoding:YES
-                                                 error:&error];
-    unarchivedCoordinator = [NSKeyedUnarchiver unarchivedObjectOfClass:[GDTCORStorage class]
-                                                              fromData:data
-                                                                 error:&error];
-  } else {
-#if !TARGET_OS_MACCATALYST && !TARGET_OS_WATCH
-    data = [NSKeyedArchiver archivedDataWithRootObject:coordinator];
-    unarchivedCoordinator = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-#endif
-  }
+  data = [NSKeyedArchiver archivedDataWithRootObject:coordinator];
+  unarchivedCoordinator = [NSKeyedUnarchiver unarchiveObjectWithData:data];
   // Unarchiving the coordinator always ends up altering the singleton instance.
   XCTAssertEqualObjects([GDTCORUploadCoordinator sharedInstance], unarchivedCoordinator);
+#endif
 }
 
 @end

--- a/scripts/test_catalyst.sh
+++ b/scripts/test_catalyst.sh
@@ -23,9 +23,9 @@
 # and test.
 
 # TODO - Determine why test specs that include `requires_app_host` fail to
-# launch tests. Locally, they will pass if the unit test scheme is specified.
-# However, on GHA, they fail to launch both from the test scheme and the app
-# scheme.
+# launch tests. Locally, they will pass if the only Objective C unit test scheme
+# is specified. However, on GHA, they fail to launch both from the test scheme
+# and the app scheme.
 
 set -xeuo pipefail
 pod="$1"

--- a/scripts/test_catalyst.sh
+++ b/scripts/test_catalyst.sh
@@ -24,8 +24,8 @@
 
 # TODO - Determine why test specs that include `requires_app_host` fail to
 # launch tests. Locally, they will pass if the unit test scheme is specified.
-# However, on GHA, the they fail to launch both from the test scheme and the
-# app scheme.
+# However, on GHA, they fail to launch both from the test scheme and the app
+# scheme.
 
 set -xeuo pipefail
 pod="$1"

--- a/scripts/test_catalyst.sh
+++ b/scripts/test_catalyst.sh
@@ -31,7 +31,7 @@ else
 fi
 
 bundle exec pod gen --local-sources=./ --sources=https://cdn.cocoapods.org/ "$pod".podspec --platforms=ios
-xcodebuild $build_mode -configuration Debug -workspace "gen/$pod/$pod.xcworkspace"  -scheme "$pod"\
+xcodebuild $build_mode -configuration Debug -workspace "gen/$pod/$pod.xcworkspace"  -scheme "$scheme"\
  ARCHS=x86_64h VALID_ARCHS=x86_64h ONLY_ACTIVE_ARCH=NO  SUPPORTS_MACCATALYST=YES  -sdk macosx \
  CODE_SIGN_IDENTITY=- SUPPORTS_UIKITFORMAC=YES CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
  -destination platform="OS X" TARGETED_DEVICE_FAMILY=2 | xcpretty

--- a/scripts/test_catalyst.sh
+++ b/scripts/test_catalyst.sh
@@ -51,7 +51,7 @@ args=(
   "-scheme" "$scheme"
   # Specify Catalyst.
   "ARCHS=x86_64h" "VALID_ARCHS=x86_64h" "SUPPORTS_MACCATALYST=YES"
-  # Run on macOS
+  # Run on macOS.
   "-sdk" "macosx" "-destination platform=\"OS X\"" "TARGETED_DEVICE_FAMILY=2"
   # Disable signing.
   "CODE_SIGN_IDENTITY=-" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"

--- a/scripts/test_catalyst.sh
+++ b/scripts/test_catalyst.sh
@@ -18,9 +18,10 @@
 # USAGE: test_catalyst.sh pod
 #
 # Builds and run tests for Catalyst since it's not yet supported by `pod lib lint`
+# The second argument should be "build" or "test". "Test" indicates both build and test.
 
 set -x
 bundle exec pod gen --local-sources=./ --sources=https://cdn.cocoapods.org/ "$1".podspec --platforms=ios
-xcodebuild  test -configuration Debug -workspace "gen/$1/$1.xcworkspace"  -scheme "$1-Unit-unit"\
+xcodebuild $2 -configuration Debug -workspace "gen/$1/$1.xcworkspace"  -scheme "$1-Unit-unit"\
  ARCHS=x86_64h VALID_ARCHS=x86_64h ONLY_ACTIVE_ARCH=NO  SUPPORTS_MACCATALYST=YES  -sdk macosx \
  CODE_SIGN_IDENTITY=- SUPPORTS_UIKITFORMAC=YES CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | xcpretty

--- a/scripts/test_catalyst.sh
+++ b/scripts/test_catalyst.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# USAGE: test_catalyst.sh pod
+#
+# Builds and run tests for Catalyst since it's not yet supported by `pod lib lint`
+
+set -x
+bundle exec pod gen --local-sources=./ --sources=https://cdn.cocoapods.org/ "$1".podspec --platforms=ios
+xcodebuild  test -configuration Debug -workspace "gen/$1/$1.xcworkspace"  -scheme "$1-Unit-unit"\
+ ARCHS=x86_64h VALID_ARCHS=x86_64h ONLY_ACTIVE_ARCH=NO  SUPPORTS_MACCATALYST=YES  -sdk macosx \
+ CODE_SIGN_IDENTITY=- SUPPORTS_UIKITFORMAC=YES CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | xcpretty

--- a/scripts/test_catalyst.sh
+++ b/scripts/test_catalyst.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-# USAGE: test_catalyst.sh pod build_mode
+# USAGE: test_catalyst.sh pod build_mode [scheme]
 #
 # Builds and run tests for Catalyst since it's not yet supported by `pod lib lint`
 # The second argument should be "build" or "test". "test" indicates both build and test.
@@ -23,6 +23,12 @@
 set -xeuo pipefail
 pod="$1"
 build_mode="$2"
+
+if [[ $# -gt 2 ]]; then
+  scheme="$3"
+else
+  scheme="$pod"
+fi
 
 bundle exec pod gen --local-sources=./ --sources=https://cdn.cocoapods.org/ "$pod".podspec --platforms=ios
 xcodebuild $build_mode -configuration Debug -workspace "gen/$pod/$pod.xcworkspace"  -scheme "$pod-Unit-unit"\

--- a/scripts/test_catalyst.sh
+++ b/scripts/test_catalyst.sh
@@ -28,4 +28,4 @@ bundle exec pod gen --local-sources=./ --sources=https://cdn.cocoapods.org/ "$po
 xcodebuild $build_mode -configuration Debug -workspace "gen/$pod/$pod.xcworkspace"  -scheme "$pod-Unit-unit"\
  ARCHS=x86_64h VALID_ARCHS=x86_64h ONLY_ACTIVE_ARCH=NO  SUPPORTS_MACCATALYST=YES  -sdk macosx \
  CODE_SIGN_IDENTITY=- SUPPORTS_UIKITFORMAC=YES CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
- -destination platform="OS X" | xcpretty
+ -destination platform="OS X" TARGETED_DEVICE_FAMILY=2 | xcpretty

--- a/scripts/test_catalyst.sh
+++ b/scripts/test_catalyst.sh
@@ -20,7 +20,7 @@
 # Builds and run tests for Catalyst since it's not yet supported by `pod lib lint`
 # The second argument should be "build" or "test". "Test" indicates both build and test.
 
-set -x
+set -xeuo pipefail
 bundle exec pod gen --local-sources=./ --sources=https://cdn.cocoapods.org/ "$1".podspec --platforms=ios
 xcodebuild $2 -configuration Debug -workspace "gen/$1/$1.xcworkspace"  -scheme "$1-Unit-unit"\
  ARCHS=x86_64h VALID_ARCHS=x86_64h ONLY_ACTIVE_ARCH=NO  SUPPORTS_MACCATALYST=YES  -sdk macosx \

--- a/scripts/test_catalyst.sh
+++ b/scripts/test_catalyst.sh
@@ -20,10 +20,10 @@
 # Builds and run tests for Catalyst since it's not yet supported by `pod lib lint`
 # The second argument should be "build" or "test". "test" indicates both build and test.
 
+set -xeuo pipefail
 pod="$1"
 build_mode="$2"
 
-set -xeuo pipefail
 bundle exec pod gen --local-sources=./ --sources=https://cdn.cocoapods.org/ "$pod".podspec --platforms=ios
 xcodebuild $build_mode -configuration Debug -workspace "gen/$pod/$pod.xcworkspace"  -scheme "$pod-Unit-unit"\
  ARCHS=x86_64h VALID_ARCHS=x86_64h ONLY_ACTIVE_ARCH=NO  SUPPORTS_MACCATALYST=YES  -sdk macosx \

--- a/scripts/test_catalyst.sh
+++ b/scripts/test_catalyst.sh
@@ -31,7 +31,7 @@ else
 fi
 
 bundle exec pod gen --local-sources=./ --sources=https://cdn.cocoapods.org/ "$pod".podspec --platforms=ios
-xcodebuild $build_mode -configuration Debug -workspace "gen/$pod/$pod.xcworkspace"  -scheme "$pod-Unit-unit"\
+xcodebuild $build_mode -configuration Debug -workspace "gen/$pod/$pod.xcworkspace"  -scheme "$pod"\
  ARCHS=x86_64h VALID_ARCHS=x86_64h ONLY_ACTIVE_ARCH=NO  SUPPORTS_MACCATALYST=YES  -sdk macosx \
  CODE_SIGN_IDENTITY=- SUPPORTS_UIKITFORMAC=YES CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
  -destination platform="OS X" TARGETED_DEVICE_FAMILY=2 | xcpretty

--- a/scripts/test_catalyst.sh
+++ b/scripts/test_catalyst.sh
@@ -27,4 +27,5 @@ build_mode="$2"
 bundle exec pod gen --local-sources=./ --sources=https://cdn.cocoapods.org/ "$pod".podspec --platforms=ios
 xcodebuild $build_mode -configuration Debug -workspace "gen/$pod/$pod.xcworkspace"  -scheme "$pod-Unit-unit"\
  ARCHS=x86_64h VALID_ARCHS=x86_64h ONLY_ACTIVE_ARCH=NO  SUPPORTS_MACCATALYST=YES  -sdk macosx \
- CODE_SIGN_IDENTITY=- SUPPORTS_UIKITFORMAC=YES CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | xcpretty
+ CODE_SIGN_IDENTITY=- SUPPORTS_UIKITFORMAC=YES CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
+ -destination platform="OS X" | xcpretty

--- a/scripts/test_catalyst.sh
+++ b/scripts/test_catalyst.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2020 Google
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,13 +15,16 @@
 # limitations under the License.
 
 
-# USAGE: test_catalyst.sh pod
+# USAGE: test_catalyst.sh pod build_mode
 #
 # Builds and run tests for Catalyst since it's not yet supported by `pod lib lint`
-# The second argument should be "build" or "test". "Test" indicates both build and test.
+# The second argument should be "build" or "test". "test" indicates both build and test.
+
+pod="$1"
+build_mode="$2"
 
 set -xeuo pipefail
-bundle exec pod gen --local-sources=./ --sources=https://cdn.cocoapods.org/ "$1".podspec --platforms=ios
-xcodebuild $2 -configuration Debug -workspace "gen/$1/$1.xcworkspace"  -scheme "$1-Unit-unit"\
+bundle exec pod gen --local-sources=./ --sources=https://cdn.cocoapods.org/ "$pod".podspec --platforms=ios
+xcodebuild $build_mode -configuration Debug -workspace "gen/$pod/$pod.xcworkspace"  -scheme "$pod-Unit-unit"\
  ARCHS=x86_64h VALID_ARCHS=x86_64h ONLY_ACTIVE_ARCH=NO  SUPPORTS_MACCATALYST=YES  -sdk macosx \
  CODE_SIGN_IDENTITY=- SUPPORTS_UIKITFORMAC=YES CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | xcpretty


### PR DESCRIPTION
This is a start at adding Catalyst to GHA CI.

Building and unit tests are enabled for GDT and Storage.
Building is enabled for Core and Messaging.

One test had to be disabled in GDT for Catalyst because it didn't seem like an easy port and it relies upon the NSKeyedArchiver which is going away.

A future task is to figure out how to run tests for testspecs that have `requires_app_host` enabled.

[FirebaseCore](https://github.com/firebase/firebase-ios-sdk/runs/512270812?check_suite_focus=true) and [FirebaseMessaging](https://github.com/firebase/firebase-ios-sdk/runs/512270895?check_suite_focus=true) fail with:

```
Testing failed:
	Unable to load standard library for target 'x86_64h-apple-ios13.1-macabi'
	Testing cancelled because the build failed.

** TEST FAILED **
```

Specifying only the Objective C test target instead of the App target scheme is a workaround locally, but it still fails on GHA with:
 
```
2020-03-17 14:32:47.672 xcodebuild[1564:26786] [MT] IDETestOperationsObserverDebug: 0.589 elapsed -- Testing started completed.
2020-03-17 14:32:47.672 xcodebuild[1564:26786] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
2020-03-17 14:32:47.673 xcodebuild[1564:26786] [MT] IDETestOperationsObserverDebug: 0.589 sec, +0.589 sec -- end
2020-03-17 14:32:47.673 xcodebuild[1564:26786] Error Domain=IDELaunchErrorDomain Code=9 "Launch error" UserInfo={NSLocalizedDescription=Launch error, NSLocalizedRecoverySuggestion=There is a problem launching using posix_spawn (error code: 86).}
Testing failed:
	FirebaseCore-Unit-unit:
		AppHost-FirebaseCore-Unit-Tests.app encountered an error (Failed to install or launch the test runner. (Underlying error: Launch error))

** TEST FAILED **

##[error]Process completed with exit code 65.
```


#no-changelog