### PR TITLE
Modify watchOS platform notification name

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -196,6 +196,8 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
                              object:nil];
 
 #elif TARGET_OS_WATCH
+    // TODO: Notification on watchOS platform is currently posted by strings which are frangible.
+    // TODO: Needs improvments here.
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
     [notificationCenter addObserver:self
                            selector:@selector(iOSApplicationDidEnterBackground:)
@@ -206,7 +208,22 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
                                name:@"UIApplicationWillEnterForegroundNotification"
                              object:nil];
 
-#endif  // TARGET_OS_IOS || TARGET_OS_TV
+#endif
+
+#if !TARGET_OS_OSX
+    // Takes care of extension application on non-macOS platform.
+    if (isAppExtension) {
+      NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+      [notificationCenter addObserver:self
+                             selector:@selector(iOSApplicationDidEnterBackground:)
+                                 name:NSExtensionHostDidEnterBackgroundNotification
+                               object:nil];
+      [notificationCenter addObserver:self
+                             selector:@selector(iOSApplicationWillEnterForeground:)
+                                 name:NSExtensionHostWillEnterForegroundNotification
+                               object:nil];
+    }
+#endif
   }
   return self;
 }

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -212,7 +212,7 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
 
 #if !TARGET_OS_OSX
     // Takes care of extension application on non-macOS platform.
-    if (isAppExtension) {
+    if ([self isAppExtension]) {
       NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
       [notificationCenter addObserver:self
                              selector:@selector(iOSApplicationDidEnterBackground:)

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -199,11 +199,11 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
     [notificationCenter addObserver:self
                            selector:@selector(iOSApplicationDidEnterBackground:)
-                               name:NSExtensionHostDidEnterBackgroundNotification
+                               name:@"UIApplicationDidEnterBackgroundNotification"
                              object:nil];
     [notificationCenter addObserver:self
                            selector:@selector(iOSApplicationWillEnterForeground:)
-                               name:NSExtensionHostWillEnterForegroundNotification
+                               name:@"UIApplicationWillEnterForegroundNotification"
                              object:nil];
 
 #endif  // TARGET_OS_IOS || TARGET_OS_TV
@@ -241,12 +241,8 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
 #pragma mark - App environment helpers
 
 - (BOOL)isAppExtension {
-#if TARGET_OS_IOS || TARGET_OS_TV || TARGET_OS_WATCH
   BOOL appExtension = [[[NSBundle mainBundle] bundlePath] hasSuffix:@".appex"];
   return appExtension;
-#elif TARGET_OS_OSX
-  return NO;
-#endif
 }
 
 /** Returns a UIApplication or WKExtension instance if on the appropriate platform.
@@ -260,24 +256,15 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
 #else
 - (nullable id)sharedApplicationForBackgroundTask {
 #endif
-  if ([self isAppExtension]) {
-    return nil;
-  }
-  id sharedApplication = nil;
+  id sharedInstance = nil;
 #if TARGET_OS_IOS || TARGET_OS_TV
-  Class uiApplicationClass = NSClassFromString(@"UIApplication");
-  if (uiApplicationClass &&
-      [uiApplicationClass respondsToSelector:(NSSelectorFromString(@"sharedApplication"))]) {
-    sharedApplication = [uiApplicationClass sharedApplication];
+  if (![self isAppExtension]) {
+    sharedInstance = [UIApplication sharedApplication];
   }
 #elif TARGET_OS_WATCH
-  Class wkExtensionClass = NSClassFromString(@"WKExtension");
-  if (wkExtensionClass &&
-      [wkExtensionClass respondsToSelector:(NSSelectorFromString(@"sharedExtension"))]) {
-    sharedApplication = [wkExtensionClass sharedExtension];
-  }
+  sharedInstance = [WKExtension sharedExtension];
 #endif
-  return sharedApplication;
+  return sharedInstance;
 }
 
 #pragma mark - UIApplicationDelegate and WKExtensionDelegate

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -208,23 +208,15 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
                                name:@"UIApplicationWillEnterForegroundNotification"
                              object:nil];
 
-#endif
-
-#if !TARGET_OS_OSX
-    // Takes care of extension application on non-macOS platform.
-    if ([self isAppExtension]) {
-      NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
-      if (@available(iOS 8.2, tvOS 9.0, watchOS 2.0, *)) {
-        [notificationCenter addObserver:self
-                               selector:@selector(iOSApplicationDidEnterBackground:)
-                                   name:NSExtensionHostDidEnterBackgroundNotification
-                                 object:nil];
-        [notificationCenter addObserver:self
-                               selector:@selector(iOSApplicationWillEnterForeground:)
-                                   name:NSExtensionHostWillEnterForegroundNotification
-                                 object:nil];
-      }
-    }
+    // Adds observers for app extension on watchOS platform
+    [notificationCenter addObserver:self
+                           selector:@selector(iOSApplicationDidEnterBackground:)
+                               name:NSExtensionHostDidEnterBackgroundNotification
+                             object:nil];
+    [notificationCenter addObserver:self
+                           selector:@selector(iOSApplicationWillEnterForeground:)
+                               name:NSExtensionHostWillEnterForegroundNotification
+                             object:nil];
 #endif
   }
   return self;

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -197,7 +197,7 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
 
 #elif TARGET_OS_WATCH
     // TODO: Notification on watchOS platform is currently posted by strings which are frangible.
-    // TODO: Needs improvments here.
+    // TODO: Needs improvements here.
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
     [notificationCenter addObserver:self
                            selector:@selector(iOSApplicationDidEnterBackground:)

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -214,14 +214,16 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
     // Takes care of extension application on non-macOS platform.
     if ([self isAppExtension]) {
       NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
-      [notificationCenter addObserver:self
-                             selector:@selector(iOSApplicationDidEnterBackground:)
-                                 name:NSExtensionHostDidEnterBackgroundNotification
-                               object:nil];
-      [notificationCenter addObserver:self
-                             selector:@selector(iOSApplicationWillEnterForeground:)
-                                 name:NSExtensionHostWillEnterForegroundNotification
-                               object:nil];
+      if (@available(iOS 8.2, tvOS 9.0, watchOS 2.0, *)) {
+        [notificationCenter addObserver:self
+                               selector:@selector(iOSApplicationDidEnterBackground:)
+                                   name:NSExtensionHostDidEnterBackgroundNotification
+                                 object:nil];
+        [notificationCenter addObserver:self
+                               selector:@selector(iOSApplicationWillEnterForeground:)
+                                   name:NSExtensionHostWillEnterForegroundNotification
+                                 object:nil];
+      }
     }
 #endif
   }


### PR DESCRIPTION
- Modify Platform switch in sharedApplicationForBackgroundTask and isAppExtension.

- Change notification name for watchOS in GDTCORApplication init. 

- Add notification listener for extension app for iOS, tvOS, watchOS