### PR TITLE
Make the prioritizer save state between app launches

### DIFF
--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTPrioritizer.h
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTPrioritizer.h
@@ -24,7 +24,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** Manages the prioritization of events from GoogleDataTransport. */
-@interface GDTCCTPrioritizer : NSObject <GDTCORPrioritizer>
+@interface GDTCCTPrioritizer : NSObject <NSSecureCoding, GDTCORPrioritizer>
 
 /** The queue on which this prioritizer operates. */
 @property(nonatomic) dispatch_queue_t queue;


### PR DESCRIPTION
The prioritizer currently does not maintain state between app restarts. It's possible for GDTCORStorage to have references to stored events that the prioritizer doesn't know about--this (sort of) fixes that. Ultimately, the prioritizer asking storage for events is probably the only reasonable solution long-term.