### PR TITLE
Fix deprecation warnings by consolidating coding calls

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORStorage.m
@@ -129,16 +129,10 @@ static NSString *GDTCORStoragePath() {
     // Write state to disk if we're in the background.
     if ([[GDTCORApplication sharedApplication] isRunningInBackground]) {
       GDTCORLogDebug("%@", @"Saving storage state because the app is running in the background");
-      if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-        NSError *error;
-        NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self
-                                             requiringSecureCoding:YES
-                                                             error:&error];
-        [data writeToFile:[GDTCORStorage archivePath] atomically:YES];
-      } else {
-#if !TARGET_OS_MACCATALYST && !TARGET_OS_WATCH
-        [NSKeyedArchiver archiveRootObject:self toFile:[GDTCORStorage archivePath]];
-#endif
+      NSError *error;
+      GDTCOREncodeArchive(self, [GDTCORStorage archivePath], &error);
+      if (error) {
+        GDTCORLogDebug(@"Serializing GDTCORStorage to an archive failed: %@", error);
       }
     }
 
@@ -227,16 +221,10 @@ static NSString *GDTCORStoragePath() {
 #pragma mark - GDTCORLifecycleProtocol
 
 - (void)appWillForeground:(GDTCORApplication *)app {
-  if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-    NSError *error;
-    NSData *data = [NSData dataWithContentsOfFile:[GDTCORStorage archivePath]];
-    if (data) {
-      [NSKeyedUnarchiver unarchivedObjectOfClass:[GDTCORStorage class] fromData:data error:&error];
-    }
-  } else {
-#if !TARGET_OS_MACCATALYST && !TARGET_OS_WATCH
-    [NSKeyedUnarchiver unarchiveObjectWithFile:[GDTCORStorage archivePath]];
-#endif
+  NSError *error;
+  GDTCORDecodeArchive([GDTCORStorage class], [GDTCORStorage archivePath], &error);
+  if (error) {
+    GDTCORLogDebug(@"Deserializing GDTCORStorage from an archive failed: %@", error);
   }
 }
 
@@ -250,17 +238,10 @@ static NSString *GDTCORStoragePath() {
                          [app endBackgroundTask:bgID];
                          bgID = GDTCORBackgroundIdentifierInvalid;
                        }];
-
-    if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-      NSError *error;
-      NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self
-                                           requiringSecureCoding:YES
-                                                           error:&error];
-      [data writeToFile:[GDTCORStorage archivePath] atomically:YES];
-    } else {
-#if !TARGET_OS_MACCATALYST && !TARGET_OS_WATCH
-      [NSKeyedArchiver archiveRootObject:self toFile:[GDTCORStorage archivePath]];
-#endif
+    NSError *error;
+    GDTCOREncodeArchive(self, [GDTCORStorage archivePath], &error);
+    if (error) {
+      GDTCORLogDebug(@"Serializing GDTCORStorage to an archive failed: %@", error);
     }
 
     // End the background task if it's still valid.
@@ -271,16 +252,10 @@ static NSString *GDTCORStoragePath() {
 
 - (void)appWillTerminate:(GDTCORApplication *)application {
   dispatch_sync(_storageQueue, ^{
-    if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-      NSError *error;
-      NSData *data = [NSKeyedArchiver archivedDataWithRootObject:self
-                                           requiringSecureCoding:YES
-                                                           error:&error];
-      [data writeToFile:[GDTCORStorage archivePath] atomically:YES];
-    } else {
-#if !TARGET_OS_MACCATALYST && !TARGET_OS_WATCH
-      [NSKeyedArchiver archiveRootObject:self toFile:[GDTCORStorage archivePath]];
-#endif
+    NSError *error;
+    GDTCOREncodeArchive(self, [GDTCORStorage archivePath], &error);
+    if (error) {
+      GDTCORLogDebug(@"Serializing GDTCORStorage to an archive failed: %@", error);
     }
   });
 }

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORStorage.m
@@ -222,7 +222,7 @@ static NSString *GDTCORStoragePath() {
 
 - (void)appWillForeground:(GDTCORApplication *)app {
   NSError *error;
-  GDTCORDecodeArchive([GDTCORStorage class], [GDTCORStorage archivePath], &error);
+  GDTCORDecodeArchive([GDTCORStorage class], [GDTCORStorage archivePath], nil, &error);
   if (error) {
     GDTCORLogDebug(@"Deserializing GDTCORStorage from an archive failed: %@", error);
   }

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
@@ -177,9 +177,10 @@ static NSString *const ktargetToInFlightPackagesKey =
   GDTCORUploadCoordinator *sharedCoordinator = [GDTCORUploadCoordinator sharedInstance];
   dispatch_sync(sharedCoordinator->_coordinationQueue, ^{
     @try {
+      NSSet *classes =
+          [NSSet setWithObjects:[NSMutableDictionary class], [GDTCORUploadPackage class], nil];
       sharedCoordinator->_targetToInFlightPackages =
-          [aDecoder decodeObjectOfClass:[NSMutableDictionary class]
-                                 forKey:ktargetToInFlightPackagesKey];
+          [aDecoder decodeObjectOfClasses:classes forKey:ktargetToInFlightPackagesKey];
 
     } @catch (NSException *exception) {
       sharedCoordinator->_targetToInFlightPackages = [NSMutableDictionary dictionary];

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
@@ -88,6 +88,25 @@ GDTCORNetworkType GDTCORNetworkTypeMessage(void);
  */
 GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage(void);
 
+/** Writes the given object to the given fileURL and populates the given error if it fails.
+ *
+ * @param obj The object to encode.
+ * @param filePath The path to write the object to.
+ * @param error The error to populate if something goes wrong.
+ */
+void GDTCOREncodeArchive(id<NSSecureCoding> obj, NSString *filePath, NSError *_Nullable *error);
+
+/** Decodes an object of the given class from the given archive path and populates the given error
+ * if it fails.
+ *
+ * @param archiveClass The class of the archive's root object.
+ * @param archivePath The path to the archived data.
+ * @param error The error to populate if something goes wrong.
+ */
+id<NSSecureCoding> _Nullable GDTCORDecodeArchive(Class archiveClass,
+                                                 NSString *archivePath,
+                                                 NSError *_Nullable *error);
+
 /** A typedef identify background identifiers. */
 typedef volatile NSUInteger GDTCORBackgroundIdentifier;
 

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
@@ -91,20 +91,25 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage(void);
 /** Writes the given object to the given fileURL and populates the given error if it fails.
  *
  * @param obj The object to encode.
- * @param filePath The path to write the object to.
+ * @param filePath The path to write the object to. Can be nil if you just need the data.
  * @param error The error to populate if something goes wrong.
+ * @return The data of the archive. If error is nil, it's been written to disk.
  */
-void GDTCOREncodeArchive(id<NSSecureCoding> obj, NSString *filePath, NSError *_Nullable *error);
+NSData *_Nullable GDTCOREncodeArchive(id<NSSecureCoding> obj,
+                                      NSString *_Nullable filePath,
+                                      NSError *_Nullable *error);
 
-/** Decodes an object of the given class from the given archive path and populates the given error
- * if it fails.
+/** Decodes an object of the given class from the given archive path or data and populates the given
+ * error if it fails.
  *
  * @param archiveClass The class of the archive's root object.
- * @param archivePath The path to the archived data.
+ * @param archivePath The path to the archived data. Don't use with the archiveData param.
+ * @param archiveData The data to decode. Don't use with the archivePath param.
  * @param error The error to populate if something goes wrong.
  */
 id<NSSecureCoding> _Nullable GDTCORDecodeArchive(Class archiveClass,
-                                                 NSString *archivePath,
+                                                 NSString *_Nullable archivePath,
+                                                 NSData *_Nullable archiveData,
                                                  NSError *_Nullable *error);
 
 /** A typedef identify background identifiers. */

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCOREventTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCOREventTest.m
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-#import <GoogleDataTransport/GDTCORClock.h>
 #import <GoogleDataTransport/GDTCOREvent.h>
+
+#import <GoogleDataTransport/GDTCORClock.h>
+#import <GoogleDataTransport/GDTCORPlatform.h>
 
 #import "GDTCORTests/Unit/GDTCORTestCase.h"
 #import "GDTCORTests/Unit/Helpers/GDTCORDataObjectTesterClasses.h"
@@ -45,28 +47,18 @@
   event.qosTier = GDTCOREventQoSTelemetry;
   event.clockSnapshot = clockSnapshot;
 
-  NSData *archiveData;
-  if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-    archiveData = [NSKeyedArchiver archivedDataWithRootObject:event
-                                        requiringSecureCoding:YES
-                                                        error:nil];
-  } else {
-#if !TARGET_OS_MACCATALYST
-    archiveData = [NSKeyedArchiver archivedDataWithRootObject:event];
-#endif
-  }
+  NSError *error;
+  NSData *archiveData = GDTCOREncodeArchive(event, nil, &error);
+  XCTAssertNil(error);
+  XCTAssertNotNil(archiveData);
+
   // To ensure that all the objects being retained by the original event are dealloc'd.
   event = nil;
-  GDTCOREvent *decodedEvent;
-  if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-    decodedEvent = [NSKeyedUnarchiver unarchivedObjectOfClass:[GDTCOREvent class]
-                                                     fromData:archiveData
-                                                        error:nil];
-  } else {
-#if !TARGET_OS_MACCATALYST
-    decodedEvent = [NSKeyedUnarchiver unarchiveObjectWithData:archiveData];
-#endif
-  }
+  error = nil;
+  GDTCOREvent *decodedEvent =
+      (GDTCOREvent *)GDTCORDecodeArchive([GDTCOREvent class], nil, archiveData, &error);
+  XCTAssertNil(error);
+  XCTAssertNotNil(decodedEvent);
   XCTAssertEqualObjects(decodedEvent.mappingID, @"testID");
   XCTAssertEqual(decodedEvent.target, 42);
   event.dataObject = [[GDTCORDataObjectTesterSimple alloc] initWithString:@"someData"];

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORStorageTest.m
@@ -21,6 +21,7 @@
 #import "GDTCORLibrary/Private/GDTCORStorage_Private.h"
 
 #import "GDTCORLibrary/Public/GDTCOREvent.h"
+#import "GDTCORLibrary/Public/GDTCORPlatform.h"
 #import "GDTCORLibrary/Public/GDTCORRegistrar.h"
 
 #import "GDTCORTests/Unit/Helpers/GDTCORAssertHelper.h"
@@ -338,15 +339,10 @@ static NSInteger target = kGDTCORTargetCCT;
   event = nil;
   __block NSData *storageData;
   dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
-    if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-      storageData = [NSKeyedArchiver archivedDataWithRootObject:[GDTCORStorage sharedInstance]
-                                          requiringSecureCoding:YES
-                                                          error:nil];
-    } else {
-#if !TARGET_OS_MACCATALYST
-      storageData = [NSKeyedArchiver archivedDataWithRootObject:[GDTCORStorage sharedInstance]];
-#endif
-    }
+    NSError *error;
+    storageData = GDTCOREncodeArchive([GDTCORStorage sharedInstance], nil, &error);
+    XCTAssertNil(error);
+    XCTAssertNotNil(storageData);
   });
   dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
     XCTAssertNotNil([[GDTCORStorage sharedInstance].storedEvents lastObject]);
@@ -355,17 +351,11 @@ static NSInteger target = kGDTCORTargetCCT;
   dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
     XCTAssertNil([[GDTCORStorage sharedInstance].storedEvents lastObject]);
   });
-  GDTCORStorage *unarchivedStorage;
   NSError *error;
-  if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-    unarchivedStorage = [NSKeyedUnarchiver unarchivedObjectOfClass:[GDTCORStorage class]
-                                                          fromData:storageData
-                                                             error:&error];
-  } else {
-#if !TARGET_OS_MACCATALYST
-    unarchivedStorage = [NSKeyedUnarchiver unarchiveObjectWithData:storageData];
-#endif
-  }
+  GDTCORStorage *unarchivedStorage =
+      (GDTCORStorage *)GDTCORDecodeArchive([GDTCORStorage class], nil, storageData, &error);
+  XCTAssertNil(error);
+  XCTAssertNotNil(unarchivedStorage);
   XCTAssertNotNil([unarchivedStorage.storedEvents lastObject]);
 }
 
@@ -384,15 +374,10 @@ static NSInteger target = kGDTCORTargetCCT;
   event = nil;
   __block NSData *storageData;
   dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
-    if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-      storageData = [NSKeyedArchiver archivedDataWithRootObject:[GDTCORStorage sharedInstance]
-                                          requiringSecureCoding:YES
-                                                          error:nil];
-    } else {
-#if !TARGET_OS_MACCATALYST
-      storageData = [NSKeyedArchiver archivedDataWithRootObject:[GDTCORStorage sharedInstance]];
-#endif
-    }
+    NSError *error;
+    storageData = GDTCOREncodeArchive([GDTCORStorage sharedInstance], nil, &error);
+    XCTAssertNil(error);
+    XCTAssertNotNil(storageData);
   });
   dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
     XCTAssertNotNil([[GDTCORStorage sharedInstance].storedEvents lastObject]);
@@ -401,16 +386,11 @@ static NSInteger target = kGDTCORTargetCCT;
   dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
     XCTAssertNil([[GDTCORStorage sharedInstance].storedEvents lastObject]);
   });
-  GDTCORStorage *unarchivedStorage;
-  if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-    unarchivedStorage = [NSKeyedUnarchiver unarchivedObjectOfClass:[GDTCORStorage class]
-                                                          fromData:storageData
-                                                             error:nil];
-  } else {
-#if !TARGET_OS_MACCATALYST
-    unarchivedStorage = [NSKeyedUnarchiver unarchiveObjectWithData:storageData];
-#endif
-  }
+  NSError *error;
+  GDTCORStorage *unarchivedStorage =
+      (GDTCORStorage *)GDTCORDecodeArchive([GDTCORStorage class], nil, storageData, &error);
+  XCTAssertNil(error);
+  XCTAssertNotNil(unarchivedStorage);
   XCTAssertNotNil([unarchivedStorage.storedEvents lastObject]);
 }
 

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORUploadCoordinatorTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORUploadCoordinatorTest.m
@@ -16,6 +16,8 @@
 
 #import "GDTCORTests/Unit/GDTCORTestCase.h"
 
+#import <GoogleDataTransport/GDTCORPlatform.h>
+
 #import "GDTCORLibrary/Private/GDTCORUploadCoordinator.h"
 
 #import "GDTCORTests/Common/Categories/GDTCORRegistrar+Testing.h"
@@ -150,19 +152,19 @@
 
 /** Tests that encoding and decoding works without crashing. */
 - (void)testNSSecureCoding {
-#if TARGET_OS_MACCATALYST
-  // TODO - port the archiver calls to Catalyst API
-#else
   GDTCORUploadPackage *package = [[GDTCORUploadPackage alloc] initWithTarget:kGDTCORTargetTest];
   GDTCORUploadCoordinator *coordinator = [[GDTCORUploadCoordinator alloc] init];
   coordinator.targetToInFlightPackages[@(kGDTCORTargetTest)] = package;
-  NSData *data;
-  GDTCORUploadCoordinator *unarchivedCoordinator;
-  data = [NSKeyedArchiver archivedDataWithRootObject:coordinator];
-  unarchivedCoordinator = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-  // Unarchiving the coordinator always ends up altering the singleton instance.
+  NSError *error;
+  NSData *data = GDTCOREncodeArchive(coordinator, nil, &error);
+  XCTAssertNil(error);
+  XCTAssertNotNil(data);
+  error = nil;
+  GDTCORUploadCoordinator *unarchivedCoordinator = (GDTCORUploadCoordinator *)GDTCORDecodeArchive(
+      [GDTCORUploadCoordinator class], nil, data, &error);
+  XCTAssertNil(error);
+  XCTAssertNotNil(unarchivedCoordinator);
   XCTAssertEqualObjects([GDTCORUploadCoordinator sharedInstance], unarchivedCoordinator);
-#endif
 }
 
 @end

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTPrioritizer.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTPrioritizer.m
@@ -311,7 +311,7 @@ static NSString *const GDTCCTUploaderCSHEventsKey = @"GDTCCTUploaderCSHEventsKey
 
 - (void)appWillForeground:(GDTCORApplication *)app {
   NSError *error;
-  GDTCORDecodeArchive([GDTCCTPrioritizer class], ArchivePath(), &error);
+  GDTCORDecodeArchive([GDTCCTPrioritizer class], ArchivePath(), nil, &error);
   if (error) {
     GDTCORLogDebug(@"Deserializing GDTCCTPrioritizer from an archive failed: %@", error);
   }


### PR DESCRIPTION
Fixes #5086

Hopefully this catches all the deprecation warnings.

cc: @paulb777 Together, we need to write some test automation that sets the deployment version of all targets to the highest OS version for any particular platform.