### PR TITLE
Crashlytics cache key app version

### DIFF
--- a/Crashlytics/Crashlytics/Models/FIRCLSSettings.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSSettings.m
@@ -29,6 +29,7 @@
 NSString *const CreatedAtKey = @"created_at";
 NSString *const GoogleAppIDKey = @"google_app_id";
 NSString *const BuildInstanceID = @"build_instance_id";
+NSString *const AppVersion = @"app_version";
 
 @interface FIRCLSSettings ()
 
@@ -120,6 +121,15 @@ NSString *const BuildInstanceID = @"build_instance_id";
       self.isCacheKeyExpired = YES;
     }
   }
+
+  NSString *cacheAppVersion = cacheKey[AppVersion];
+  if (![cacheAppVersion isEqualToString:self.appIDModel.synthesizedVersion]) {
+    FIRCLSDebugLog(@"[Crashlytics:Settings] Settings expired because app version changed");
+
+    @synchronized(self) {
+      self.isCacheKeyExpired = YES;
+    }
+  }
 }
 
 - (void)cacheSettingsWithGoogleAppID:(NSString *)googleAppID
@@ -129,6 +139,7 @@ NSString *const BuildInstanceID = @"build_instance_id";
     CreatedAtKey : createdAtTimestamp,
     GoogleAppIDKey : googleAppID,
     BuildInstanceID : self.appIDModel.buildInstanceID,
+    AppVersion : self.appIDModel.synthesizedVersion,
   };
 
   NSError *error = nil;

--- a/Crashlytics/Crashlytics/Settings/Models/FIRCLSApplicationIdentifierModel.h
+++ b/Crashlytics/Crashlytics/Settings/Models/FIRCLSApplicationIdentifierModel.h
@@ -34,6 +34,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly, nullable) NSString* platform;
 @property(nonatomic, readonly, nullable) NSString* buildVersion;
 @property(nonatomic, readonly, nullable) NSString* displayVersion;
+
+/**
+ * Returns the synthesized app version, similar to how the backend does it
+ * <displayVersion> (<buildVersion>)
+*/
+@property(nonatomic, readonly, nullable) NSString* synthesizedVersion;
+
 @property(nonatomic, readonly) FIRCLSApplicationInstallationSourceType installSource;
 
 /**

--- a/Crashlytics/Crashlytics/Settings/Models/FIRCLSApplicationIdentifierModel.h
+++ b/Crashlytics/Crashlytics/Settings/Models/FIRCLSApplicationIdentifierModel.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Returns the synthesized app version, similar to how the backend does it
  * <displayVersion> (<buildVersion>)
-*/
+ */
 @property(nonatomic, readonly, nullable) NSString* synthesizedVersion;
 
 @property(nonatomic, readonly) FIRCLSApplicationInstallationSourceType installSource;

--- a/Crashlytics/Crashlytics/Settings/Models/FIRCLSApplicationIdentifierModel.m
+++ b/Crashlytics/Crashlytics/Settings/Models/FIRCLSApplicationIdentifierModel.m
@@ -66,6 +66,10 @@
   return FIRCLSApplicationGetShortBundleVersion();
 }
 
+- (NSString *)synthesizedVersion {
+  return [NSString stringWithFormat:@"%@ (%@)", self.displayName, self.buildVersion];
+}
+
 - (FIRCLSApplicationInstallationSourceType)installSource {
   return FIRCLSApplicationInstallationSource();
 }

--- a/Crashlytics/UnitTests/Mocks/FABMockApplicationIdentifierModel.h
+++ b/Crashlytics/UnitTests/Mocks/FABMockApplicationIdentifierModel.h
@@ -23,6 +23,12 @@ NS_ASSUME_NONNULL_BEGIN
 // Allows us to set this value in FIRCLSSettingsTests
 @property(nonatomic, copy) NSString* buildInstanceID;
 
+// Allows us to set this value in FIRCLSSettingsTests
+@property(nonatomic, copy) NSString* displayVersion;
+
+// Allows us to set this value in FIRCLSSettingsTests
+@property(nonatomic, copy) NSString* buildVersion;
+
 // Allows us to set this value in FIRCLSReportManagerTests
 @property(nonatomic, copy) NSString* bundleID;
 

--- a/Crashlytics/UnitTests/Mocks/FABMockApplicationIdentifierModel.m
+++ b/Crashlytics/UnitTests/Mocks/FABMockApplicationIdentifierModel.m
@@ -19,6 +19,8 @@
 // Don't call the custom methods that compute this value, so we can
 // set it in FIRCLSSettingsTests
 @synthesize buildInstanceID;
+@synthesize displayVersion;
+@synthesize buildVersion;
 
 // Set in FIRCLSReportManagerTests
 @synthesize bundleID;


### PR DESCRIPTION
Sometimes devs will change the app version without making a codechange. In these cases, clear the cache just in case so we register the build.