### PR TITLE
Refactor event fileURLs to be derived

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCOREvent.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCOREvent.m
@@ -19,6 +19,7 @@
 #import <GoogleDataTransport/GDTCORAssert.h>
 #import <GoogleDataTransport/GDTCORClock.h>
 #import <GoogleDataTransport/GDTCORConsoleLogger.h>
+#import <GoogleDataTransport/GDTCORPlatform.h>
 
 #import "GDTCORLibrary/Private/GDTCORDataFuture.h"
 #import "GDTCORLibrary/Private/GDTCOREvent_Private.h"
@@ -66,6 +67,8 @@
   return [self hash] == [object hash];
 }
 
+#pragma mark - Property overrides
+
 - (void)setDataObject:(id<GDTCOREventDataObject>)dataObject {
   // If you're looking here because of a performance issue in -transportBytes slowing the assignment
   // of -dataObject, one way to address this is to add a queue to this class,
@@ -75,13 +78,16 @@
   }
 }
 
-- (BOOL)writeToURL:(NSURL *)fileURL error:(NSError **)error {
+#pragma mark - Private methods
+
+- (BOOL)writeToGDTPath:(NSString *)filePath error:(NSError **)error {
   NSData *dataTransportBytes = [_dataObject transportBytes];
   if (dataTransportBytes == nil) {
     _fileURL = nil;
     _dataObject = nil;
     return NO;
   }
+  NSURL *fileURL = [[NSURL alloc] initWithString:filePath relativeToURL:GDTCORRootDirectory()];
   BOOL writingSuccess = [dataTransportBytes writeToURL:fileURL
                                                options:NSDataWritingAtomic
                                                  error:error];

--- a/GoogleDataTransport/GDTCORLibrary/GDTCOREvent.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCOREvent.m
@@ -79,7 +79,10 @@
 }
 
 - (NSURL *)fileURL {
-  return [[NSURL alloc] initWithString:_GDTFilePath relativeToURL:GDTCORRootDirectory()];
+  if (!_GDTFilePath) {
+    _GDTFilePath = [NSString stringWithFormat:@"event-%lu", (unsigned long)self.hash];
+  }
+  return [GDTCORRootDirectory() URLByAppendingPathComponent:_GDTFilePath];
 }
 
 #pragma mark - Private methods

--- a/GoogleDataTransport/GDTCORLibrary/GDTCOREvent.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCOREvent.m
@@ -48,7 +48,7 @@
   copy.qosTier = _qosTier;
   copy.clockSnapshot = _clockSnapshot;
   copy.customPrioritizationParams = _customPrioritizationParams;
-  copy->_fileURL = _fileURL;
+  copy->_GDTFilePath = _GDTFilePath;
   GDTCORLogDebug("Copying event %@ to event %@", self, copy);
   return copy;
 }
@@ -58,7 +58,7 @@
   NSUInteger mappingIDHash = [_mappingID hash];
   NSUInteger timeHash = [_clockSnapshot hash];
   NSInteger dataObjectHash = [_dataObject hash];
-  NSUInteger fileURL = [_fileURL hash];
+  NSUInteger fileURL = [_GDTFilePath hash];
 
   return mappingIDHash ^ _target ^ _qosTier ^ timeHash ^ dataObjectHash ^ fileURL;
 }
@@ -78,25 +78,28 @@
   }
 }
 
+- (NSURL *)fileURL {
+  return [[NSURL alloc] initWithString:_GDTFilePath relativeToURL:GDTCORRootDirectory()];
+}
+
 #pragma mark - Private methods
 
 - (BOOL)writeToGDTPath:(NSString *)filePath error:(NSError **)error {
   NSData *dataTransportBytes = [_dataObject transportBytes];
   if (dataTransportBytes == nil) {
-    _fileURL = nil;
+    _GDTFilePath = nil;
     _dataObject = nil;
     return NO;
   }
-  NSURL *fileURL = [[NSURL alloc] initWithString:filePath relativeToURL:GDTCORRootDirectory()];
+  NSURL *fileURL = [GDTCORRootDirectory() URLByAppendingPathComponent:filePath];
   BOOL writingSuccess = [dataTransportBytes writeToURL:fileURL
                                                options:NSDataWritingAtomic
                                                  error:error];
   if (!writingSuccess) {
     GDTCORLogError(GDTCORMCEFileWriteError, @"An event file could not be written: %@", fileURL);
-    _fileURL = nil;
     return NO;
   }
-  _fileURL = fileURL;
+  _GDTFilePath = filePath;
   _dataObject = nil;
   return YES;
 }
@@ -117,6 +120,9 @@ static NSString *clockSnapshotKey = @"_clockSnapshot";
 
 /** NSCoding key for fileURL property. */
 static NSString *fileURLKey = @"_fileURL";
+
+/** NSCoding key for GDTFilePath property. */
+static NSString *kGDTFilePathKey = @"_GDTFilePath";
 
 /** NSCoding key for customPrioritizationParams property. */
 static NSString *customPrioritizationParams = @"_customPrioritizationParams";
@@ -158,7 +164,12 @@ static NSString *kStoredEventCustomPrioritizationParamsKey =
   if (self) {
     _qosTier = [aDecoder decodeIntegerForKey:qosTierKey];
     _clockSnapshot = [aDecoder decodeObjectOfClass:[GDTCORClock class] forKey:clockSnapshotKey];
-    _fileURL = [aDecoder decodeObjectOfClass:[NSURL class] forKey:fileURLKey];
+    NSURL *fileURL = [aDecoder decodeObjectOfClass:[NSURL class] forKey:fileURLKey];
+    if (fileURL) {
+      _GDTFilePath = [fileURL lastPathComponent];
+    } else {
+      _GDTFilePath = [aDecoder decodeObjectOfClass:[NSString class] forKey:kGDTFilePathKey];
+    }
     _customPrioritizationParams = [aDecoder decodeObjectOfClass:[NSDictionary class]
                                                          forKey:customPrioritizationParams];
   }
@@ -177,7 +188,11 @@ static NSString *kStoredEventCustomPrioritizationParamsKey =
                                        forKey:kStoredEventQosTierKey] integerValue];
     _clockSnapshot = [aDecoder decodeObjectOfClass:[GDTCORClock class]
                                             forKey:kStoredEventClockSnapshotKey];
-    _fileURL = fileURL;
+    if (fileURL) {
+      _GDTFilePath = [fileURL lastPathComponent];
+    } else {
+      _GDTFilePath = [aDecoder decodeObjectOfClass:[NSString class] forKey:kGDTFilePathKey];
+    }
     _customPrioritizationParams =
         [aDecoder decodeObjectOfClass:[NSDictionary class]
                                forKey:kStoredEventCustomPrioritizationParamsKey];
@@ -190,7 +205,7 @@ static NSString *kStoredEventCustomPrioritizationParamsKey =
   [aCoder encodeInteger:_target forKey:targetKey];
   [aCoder encodeInteger:_qosTier forKey:qosTierKey];
   [aCoder encodeObject:_clockSnapshot forKey:clockSnapshotKey];
-  [aCoder encodeObject:_fileURL forKey:fileURLKey];
+  [aCoder encodeObject:_GDTFilePath forKey:kGDTFilePathKey];
   [aCoder encodeObject:_customPrioritizationParams forKey:customPrioritizationParams];
 }
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -40,6 +40,20 @@ NSString *const kGDTCORApplicationWillEnterForegroundNotification =
 
 NSString *const kGDTCORApplicationWillTerminateNotification =
     @"GDTCORApplicationWillTerminateNotification";
+
+NSURL *GDTCORRootDirectory(void) {
+  static NSURL *GDTPath;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    NSString *cachePath =
+        NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES)[0];
+    GDTPath =
+        [NSURL fileURLWithPath:[NSString stringWithFormat:@"%@/google-sdks-events", cachePath]];
+    GDTCORLogDebug("GDT's state will be saved to: %@", GDTPath);
+  });
+  return GDTPath;
+}
+
 #if !TARGET_OS_WATCH
 BOOL GDTCORReachabilityFlagsContainWWAN(SCNetworkReachabilityFlags flags) {
 #if TARGET_OS_IOS
@@ -134,9 +148,16 @@ NSData *_Nullable GDTCOREncodeArchive(id<NSSecureCoding> obj,
     resultData = [NSKeyedArchiver archivedDataWithRootObject:obj
                                        requiringSecureCoding:YES
                                                        error:error];
-    BOOL result = [resultData writeToFile:archivePath atomically:YES];
-    result = result;  // To get rid of the warning.
-    GDTCORLogDebug(@"Attempt to write archive. successful:%@ path:%@", result, archivePath);
+    if (*error) {
+      GDTCORLogDebug(@"Encoding an object failed: %@", *error);
+      return nil;
+    }
+    BOOL result = [resultData writeToFile:archivePath options:NSDataWritingAtomic error:error];
+    if (result == NO || *error) {
+      GDTCORLogDebug(@"Attempt to write archive failed: URL:%@ error:%@", archivePath, *error);
+    } else {
+      GDTCORLogDebug(@"Writing archive succeeded: %@", archivePath);
+    }
   } else {
 #endif
     BOOL result = NO;
@@ -145,7 +166,12 @@ NSData *_Nullable GDTCOREncodeArchive(id<NSSecureCoding> obj,
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
       resultData = [NSKeyedArchiver archivedDataWithRootObject:obj];
 #pragma clang diagnostic pop
-      result = [resultData writeToFile:archivePath atomically:YES];
+      result = [resultData writeToFile:archivePath options:NSDataWritingAtomic error:error];
+      if (result == NO || *error) {
+        GDTCORLogDebug(@"Attempt to write archive failed: URL:%@ error:%@", archivePath, *error);
+      } else {
+        GDTCORLogDebug(@"Writing archive succeeded: %@", archivePath);
+      }
     } @catch (NSException *exception) {
       NSString *errorString =
           [NSString stringWithFormat:@"An exception was thrown during encoding: %@", exception];
@@ -153,7 +179,8 @@ NSData *_Nullable GDTCOREncodeArchive(id<NSSecureCoding> obj,
                                    code:-1
                                userInfo:@{NSLocalizedFailureReasonErrorKey : errorString}];
     }
-    GDTCORLogDebug(@"Attempt to write archive. successful:%@ path:%@", result, archivePath);
+    GDTCORLogDebug(@"Attempt to write archive. successful:%@ URL:%@ error:%@",
+                   result ? @"YES" : @"NO", archivePath, *error);
   }
   return resultData;
 }

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -152,11 +152,13 @@ NSData *_Nullable GDTCOREncodeArchive(id<NSSecureCoding> obj,
       GDTCORLogDebug(@"Encoding an object failed: %@", *error);
       return nil;
     }
-    BOOL result = [resultData writeToFile:archivePath options:NSDataWritingAtomic error:error];
-    if (result == NO || *error) {
-      GDTCORLogDebug(@"Attempt to write archive failed: URL:%@ error:%@", archivePath, *error);
-    } else {
-      GDTCORLogDebug(@"Writing archive succeeded: %@", archivePath);
+    if (archivePath) {
+      BOOL result = [resultData writeToFile:archivePath options:NSDataWritingAtomic error:error];
+      if (result == NO || *error) {
+        GDTCORLogDebug(@"Attempt to write archive failed: URL:%@ error:%@", archivePath, *error);
+      } else {
+        GDTCORLogDebug(@"Writing archive succeeded: %@", archivePath);
+      }
     }
   } else {
 #endif
@@ -166,11 +168,13 @@ NSData *_Nullable GDTCOREncodeArchive(id<NSSecureCoding> obj,
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
       resultData = [NSKeyedArchiver archivedDataWithRootObject:obj];
 #pragma clang diagnostic pop
-      result = [resultData writeToFile:archivePath options:NSDataWritingAtomic error:error];
-      if (result == NO || *error) {
-        GDTCORLogDebug(@"Attempt to write archive failed: URL:%@ error:%@", archivePath, *error);
-      } else {
-        GDTCORLogDebug(@"Writing archive succeeded: %@", archivePath);
+      if (archivePath) {
+        result = [resultData writeToFile:archivePath options:NSDataWritingAtomic error:error];
+        if (result == NO || *error) {
+          GDTCORLogDebug(@"Attempt to write archive failed: URL:%@ error:%@", archivePath, *error);
+        } else {
+          GDTCORLogDebug(@"Writing archive succeeded: %@", archivePath);
+        }
       }
     } @catch (NSException *exception) {
       NSString *errorString =

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORStorage.m
@@ -175,16 +175,12 @@
                       eventHash:(NSUInteger)eventHash
                           error:(NSError **)error {
   NSString *eventFileName = [NSString stringWithFormat:@"event-%lu", (unsigned long)eventHash];
-  NSURL *fileURL = [[NSURL alloc] initWithString:eventFileName relativeToURL:GDTCORRootDirectory()];
-  GDTCORAssert(![[NSFileManager defaultManager] fileExistsAtPath:fileURL.path],
-               @"An event shouldn't already exist at this path: %@", fileURL.path);
-
   NSError *writingError;
   [event writeToGDTPath:eventFileName error:&writingError];
   if (writingError) {
     GDTCORLogDebug(@"There was an error saving an event to disk: %@", writingError);
   }
-  return fileURL;
+  return event.fileURL;
 }
 
 /** Adds the event to internal tracking collections.

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCOREvent_Private.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCOREvent_Private.h
@@ -22,6 +22,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface GDTCOREvent ()
 
+/** The GDT relative file path of the event. */
+@property(nullable, nonatomic, readonly) NSString *GDTFilePath;
+
 /** Writes [dataObject transportBytes] to the given URL, populates fileURL with the filename, then
  * nils the dataObject property. This method should not be called twice on the same event.
  *

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCOREvent_Private.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCOREvent_Private.h
@@ -25,11 +25,11 @@ NS_ASSUME_NONNULL_BEGIN
 /** Writes [dataObject transportBytes] to the given URL, populates fileURL with the filename, then
  * nils the dataObject property. This method should not be called twice on the same event.
  *
- * @param fileURL The fileURL that dataObject will be written to.
+ * @param filePath The GDTCORRootDirectory-relative path that dataObject will be written to.
  * @param error If populated, the error encountered during writing to disk.
  * @return YES if writing dataObject to disk was successful, NO otherwise.
  */
-- (BOOL)writeToURL:(NSURL *)fileURL error:(NSError **)error;
+- (BOOL)writeToGDTPath:(NSString *)filePath error:(NSError **)error;
 
 @end
 

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
@@ -66,6 +66,12 @@ typedef NS_ENUM(NSInteger, GDTCORNetworkMobileSubtype) {
   GDTCORNetworkMobileSubtypeLTE = 11,
 };
 
+/** Returns a URL to the root directory under which all GDT-associated data must be saved.
+ *
+ * @return A URL to the root directory under which all GDT-associated data must be saved.
+ */
+NSURL *GDTCORRootDirectory(void);
+
 #if !TARGET_OS_WATCH
 /** Compares flags with the WWAN reachability flag, if available, and returns YES if present.
  *

--- a/GoogleDataTransport/GDTCORTests/Integration/GDTCORIntegrationTest.m
+++ b/GoogleDataTransport/GDTCORTests/Integration/GDTCORIntegrationTest.m
@@ -102,7 +102,7 @@
   [testServer registerTestPaths];
   [testServer start];
 
-  // Create eventgers.
+  // Create events.
   self.transport1 = [[GDTCORTransport alloc] initWithMappingID:@"eventMap1"
                                                   transformers:nil
                                                         target:kGDTCORIntegrationTestTarget];
@@ -168,7 +168,8 @@
 
 /** Generates a bunch of random events. */
 - (void)generateEvents {
-  for (int i = 0; i < arc4random_uniform(10) + 1; i++) {
+  int limit = arc4random_uniform(10) + 1;
+  for (int i = 0; i < limit; i++) {
     // Choose a random transport, and randomly choose if it's a telemetry event.
     GDTCORTransport *transport = arc4random_uniform(2) ? self.transport1 : self.transport2;
     BOOL isTelemetryEvent = arc4random_uniform(2);

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCOREventTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCOREventTest.m
@@ -92,7 +92,7 @@
   event1.qosTier = GDTCOREventQosDefault;
   event1.customPrioritizationParams = @{@"customParam1" : @"aValue1"};
   NSError *error1;
-  [event1 writeToURL:[NSURL fileURLWithPath:@"/tmp/fake.txt"] error:&error1];
+  [event1 writeToGDTPath:@"/tmp/fake.txt" error:&error1];
   XCTAssertNil(error1);
 
   GDTCOREvent *event2 = [[GDTCOREvent alloc] initWithMappingID:@"1018" target:1];
@@ -104,7 +104,7 @@
   event2.qosTier = GDTCOREventQosDefault;
   event2.customPrioritizationParams = @{@"customParam1" : @"aValue1"};
   NSError *error2;
-  [event2 writeToURL:[NSURL fileURLWithPath:@"/tmp/fake.txt"] error:&error2];
+  [event2 writeToGDTPath:@"/tmp/fake.txt" error:&error2];
   XCTAssertNil(error2);
 
   XCTAssertEqual([event1 hash], [event2 hash]);

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORStorageTest.m
@@ -596,18 +596,11 @@ static NSInteger target = kGDTCORTargetCCT;
   NSData *v1ArchiveData = [[NSData alloc] initWithBase64EncodedString:base64EncodedArchive
                                                               options:0];
   XCTAssertNotNil(v1ArchiveData);
-  GDTCORStorage *archiveStorage;
-  if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-    NSError *error;
-    XCTAssertNoThrow(archiveStorage =
-                         [NSKeyedUnarchiver unarchivedObjectOfClass:[GDTCORStorage class]
-                                                           fromData:v1ArchiveData
-                                                              error:&error]);
-  } else {
-#if !TARGET_OS_MACCATALYST && !TARGET_OS_WATCH
-    XCTAssertNoThrow(archiveStorage = [NSKeyedUnarchiver unarchiveObjectWithData:v1ArchiveData]);
-#endif
-  }
+  NSError *error;
+  GDTCORStorage *archiveStorage =
+      (GDTCORStorage *)GDTCORDecodeArchive([GDTCORStorage class], nil, v1ArchiveData, &error);
+  XCTAssertNil(error);
+  XCTAssertNotNil(archiveStorage);
   XCTAssertEqual(archiveStorage.targetToEventSet[@(kGDTCORTargetCCT)].count, 6);
   XCTAssertEqual(archiveStorage.targetToEventSet[@(kGDTCORTargetFLL)].count, 12);
   XCTAssertEqual(archiveStorage.storedEvents.count, 18);

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORUploadPackageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORUploadPackageTest.m
@@ -113,23 +113,15 @@
   NSMutableSet<GDTCOREvent *> *set = [GDTCOREventGenerator generate3Events];
   uploadPackage.events = set;
   uploadPackage.handler = self;
-  GDTCORUploadPackage *recreatedPackage;
   NSError *error;
-
-  if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, *)) {
-    NSData *packageData = [NSKeyedArchiver archivedDataWithRootObject:uploadPackage
-                                                requiringSecureCoding:YES
-                                                                error:&error];
-    recreatedPackage = [NSKeyedUnarchiver unarchivedObjectOfClass:[GDTCORUploadPackage class]
-                                                         fromData:packageData
-                                                            error:&error];
-    XCTAssertNil(error);
-  } else {
-#if !TARGET_OS_MACCATALYST
-    NSData *packageData = [NSKeyedArchiver archivedDataWithRootObject:uploadPackage];
-    recreatedPackage = [NSKeyedUnarchiver unarchiveObjectWithData:packageData];
-#endif
-  }
+  NSData *packageData = GDTCOREncodeArchive(uploadPackage, nil, &error);
+  XCTAssertNil(error);
+  XCTAssertNotNil(packageData);
+  error = nil;
+  GDTCORUploadPackage *recreatedPackage = (GDTCORUploadPackage *)GDTCORDecodeArchive(
+      [GDTCORUploadPackage class], nil, packageData, &error);
+  XCTAssertNil(error);
+  XCTAssertNotNil(recreatedPackage);
   XCTAssertEqualObjects(uploadPackage, recreatedPackage);
 }
 

--- a/GoogleDataTransport/GDTCORTests/Unit/Helpers/GDTCOREventGenerator.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/Helpers/GDTCOREventGenerator.m
@@ -26,10 +26,7 @@
 
 + (NSMutableSet<GDTCOREvent *> *)generate3Events {
   static NSUInteger counter = 0;
-  NSString *cachePath = NSTemporaryDirectory();
-  NSString *filePath =
-      [cachePath stringByAppendingPathComponent:[NSString stringWithFormat:@"test-%ld.txt",
-                                                                           (unsigned long)counter]];
+  NSString *filePath = [NSString stringWithFormat:@"test-%ld.txt", (unsigned long)counter];
   int howManyToGenerate = 3;
   NSMutableSet<GDTCOREvent *> *set = [[NSMutableSet alloc] initWithCapacity:howManyToGenerate];
   for (int i = 0; i < howManyToGenerate; i++) {
@@ -41,7 +38,7 @@
                                             contents:[NSData data]
                                           attributes:nil];
     NSError *error = nil;
-    [event writeToURL:[NSURL fileURLWithPath:filePath] error:&error];
+    [event writeToGDTPath:filePath error:&error];
     [set addObject:event];
     counter++;
   }

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTPrioritizer.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTPrioritizer.m
@@ -18,6 +18,7 @@
 
 #import <GoogleDataTransport/GDTCORConsoleLogger.h>
 #import <GoogleDataTransport/GDTCOREvent.h>
+#import <GoogleDataTransport/GDTCORPlatform.h>
 #import <GoogleDataTransport/GDTCORRegistrar.h>
 #import <GoogleDataTransport/GDTCORTargets.h>
 
@@ -33,9 +34,7 @@ static NSString *ArchivePath() {
   static NSString *archivePath;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    NSString *cachePath =
-        NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES)[0];
-    archivePath = [NSString stringWithFormat:@"%@/google-sdks-events/GDTCCTPrioritizer", cachePath];
+    archivePath = [GDTCORRootDirectory() URLByAppendingPathComponent:@"GDTCCTPrioritizer"].path;
   });
   return archivePath;
 }

--- a/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/GDTCCTNanopbHelpersTest.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/GDTCCTNanopbHelpersTest.m
@@ -67,10 +67,7 @@
     NSData *messageData = [NSData dataWithContentsOfURL:[testBundle URLForResource:dataFile
                                                                      withExtension:nil]];
     XCTAssertNotNil(messageData);
-    NSString *cachePath = NSTemporaryDirectory();
-    NSString *filePath = [cachePath
-        stringByAppendingPathComponent:[NSString stringWithFormat:@"test-%lf.txt",
-                                                                  CFAbsoluteTimeGetCurrent()]];
+    NSString *filePath = [NSString stringWithFormat:@"test-%lf.txt", CFAbsoluteTimeGetCurrent()];
     [messageData writeToFile:filePath atomically:YES];
     NSURL *fileURL = [NSURL fileURLWithPath:filePath];
     XCTAssertNotNil(fileURL);
@@ -94,10 +91,7 @@
     NSData *messageData = [NSData dataWithContentsOfURL:[testBundle URLForResource:dataFile
                                                                      withExtension:nil]];
     XCTAssertNotNil(messageData);
-    NSString *cachePath = NSTemporaryDirectory();
-    NSString *filePath = [cachePath
-        stringByAppendingPathComponent:[NSString stringWithFormat:@"test-%lf.txt",
-                                                                  CFAbsoluteTimeGetCurrent()]];
+    NSString *filePath = [NSString stringWithFormat:@"test-%lf.txt", CFAbsoluteTimeGetCurrent()];
     [messageData writeToFile:filePath atomically:YES];
     NSURL *fileURL = [NSURL fileURLWithPath:filePath];
     XCTAssertNotNil(fileURL);
@@ -144,10 +138,7 @@
     NSData *messageData = [NSData dataWithContentsOfURL:[testBundle URLForResource:dataFile
                                                                      withExtension:nil]];
     XCTAssertNotNil(messageData);
-    NSString *cachePath = NSTemporaryDirectory();
-    NSString *filePath = [cachePath
-        stringByAppendingPathComponent:[NSString stringWithFormat:@"test-%lf.txt",
-                                                                  CFAbsoluteTimeGetCurrent()]];
+    NSString *filePath = [NSString stringWithFormat:@"test-%lf.txt", CFAbsoluteTimeGetCurrent()];
     [messageData writeToFile:filePath atomically:YES];
     NSURL *fileURL = [NSURL fileURLWithPath:filePath];
     XCTAssertNotNil(fileURL);

--- a/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/Helpers/GDTCCTEventGenerator.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/Helpers/GDTCCTEventGenerator.m
@@ -20,6 +20,20 @@
 #import <GoogleDataTransport/GDTCOREventDataObject.h>
 #import <GoogleDataTransport/GDTCORTargets.h>
 
+@interface GDTCCTEventGeneratorDataObject : NSObject <GDTCOREventDataObject>
+
+@property(nullable, nonatomic) NSURL *dataFile;
+
+@end
+
+@implementation GDTCCTEventGeneratorDataObject
+
+- (NSData *)transportBytes {
+  return [NSData dataWithContentsOfURL:self.dataFile];
+}
+
+@end
+
 @implementation GDTCCTEventGenerator
 
 - (instancetype)initWithTarget:(GDTCORTarget)target {
@@ -46,7 +60,9 @@
   event.qosTier = qosTier;
   [[NSFileManager defaultManager] createFileAtPath:filePath contents:[NSData data] attributes:nil];
   NSURL *fileURL = [NSURL fileURLWithPath:filePath];
-  [event setValue:fileURL forKeyPath:@"fileURL"];
+  GDTCCTEventGeneratorDataObject *dataObject = [[GDTCCTEventGeneratorDataObject alloc] init];
+  dataObject.dataFile = fileURL;
+  event.dataObject = dataObject;
   [self.allGeneratedEvents addObject:event];
   return event;
 }
@@ -55,7 +71,9 @@
   GDTCOREvent *event = [[GDTCOREvent alloc] initWithMappingID:@"1018" target:_target];
   event.clockSnapshot = [GDTCORClock snapshot];
   event.qosTier = qosTier;
-  [event setValue:fileURL forKeyPath:@"fileURL"];
+  GDTCCTEventGeneratorDataObject *dataObject = [[GDTCCTEventGeneratorDataObject alloc] init];
+  dataObject.dataFile = fileURL;
+  event.dataObject = dataObject;
   [self.allGeneratedEvents addObject:event];
   return event;
 }
@@ -88,7 +106,9 @@
     event.qosTier = GDTCOREventQosDefault;
     event.customPrioritizationParams = @{@"customParam" : @1337};
     NSURL *messageDataURL = [self writeConsistentMessageToDisk:@"message-32347456.dat"];
-    [event setValue:messageDataURL forKeyPath:@"fileURL"];
+    GDTCCTEventGeneratorDataObject *dataObject = [[GDTCCTEventGeneratorDataObject alloc] init];
+    dataObject.dataFile = messageDataURL;
+    event.dataObject = dataObject;
     [events addObject:event];
   }
 
@@ -101,7 +121,9 @@
     [event.clockSnapshot setValue:@(1236567890) forKeyPath:@"uptime"];
     event.qosTier = GDTCOREventQoSWifiOnly;
     NSURL *messageDataURL = [self writeConsistentMessageToDisk:@"message-35458880.dat"];
-    [event setValue:messageDataURL forKeyPath:@"fileURL"];
+    GDTCCTEventGeneratorDataObject *dataObject = [[GDTCCTEventGeneratorDataObject alloc] init];
+    dataObject.dataFile = messageDataURL;
+    event.dataObject = dataObject;
     [events addObject:event];
   }
 
@@ -114,7 +136,9 @@
     [event.clockSnapshot setValue:@(1237567890) forKeyPath:@"uptime"];
     event.qosTier = GDTCOREventQosDefault;
     NSURL *messageDataURL = [self writeConsistentMessageToDisk:@"message-39882816.dat"];
-    [event setValue:messageDataURL forKeyPath:@"fileURL"];
+    GDTCCTEventGeneratorDataObject *dataObject = [[GDTCCTEventGeneratorDataObject alloc] init];
+    dataObject.dataFile = messageDataURL;
+    event.dataObject = dataObject;
     [events addObject:event];
   }
 
@@ -128,7 +152,9 @@
     event.qosTier = GDTCOREventQosDefault;
     event.customPrioritizationParams = @{@"customParam1" : @"aValue1"};
     NSURL *messageDataURL = [self writeConsistentMessageToDisk:@"message-40043840.dat"];
-    [event setValue:messageDataURL forKeyPath:@"fileURL"];
+    GDTCCTEventGeneratorDataObject *dataObject = [[GDTCCTEventGeneratorDataObject alloc] init];
+    dataObject.dataFile = messageDataURL;
+    event.dataObject = dataObject;
     [events addObject:event];
   }
 
@@ -142,7 +168,9 @@
     event.qosTier = GDTCOREventQoSTelemetry;
     event.customPrioritizationParams = @{@"customParam2" : @(34)};
     NSURL *messageDataURL = [self writeConsistentMessageToDisk:@"message-40657984.dat"];
-    [event setValue:messageDataURL forKeyPath:@"fileURL"];
+    GDTCCTEventGeneratorDataObject *dataObject = [[GDTCCTEventGeneratorDataObject alloc] init];
+    dataObject.dataFile = messageDataURL;
+    event.dataObject = dataObject;
     [events addObject:event];
   }
   return events;

--- a/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/Helpers/GDTCCTEventGenerator.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/Helpers/GDTCCTEventGenerator.m
@@ -40,10 +40,7 @@
 }
 
 - (GDTCOREvent *)generateEvent:(GDTCOREventQoS)qosTier {
-  NSString *cachePath = NSTemporaryDirectory();
-  NSString *filePath = [cachePath
-      stringByAppendingPathComponent:[NSString stringWithFormat:@"test-%lf.txt",
-                                                                CFAbsoluteTimeGetCurrent()]];
+  NSString *filePath = [NSString stringWithFormat:@"test-%lf.txt", CFAbsoluteTimeGetCurrent()];
   GDTCOREvent *event = [[GDTCOREvent alloc] initWithMappingID:@"1018" target:_target];
   event.clockSnapshot = [GDTCORClock snapshot];
   event.qosTier = qosTier;
@@ -70,10 +67,7 @@
  */
 - (NSURL *)writeConsistentMessageToDisk:(NSString *)messageResource {
   NSBundle *testBundle = [NSBundle bundleForClass:[self class]];
-  NSString *cachePath = NSTemporaryDirectory();
-  NSString *filePath = [cachePath
-      stringByAppendingPathComponent:[NSString stringWithFormat:@"test-%lf.txt",
-                                                                CFAbsoluteTimeGetCurrent()]];
+  NSString *filePath = [NSString stringWithFormat:@"test-%lf.txt", CFAbsoluteTimeGetCurrent()];
   NSAssert([[NSFileManager defaultManager] fileExistsAtPath:filePath] == NO,
            @"There should be no duplicate files generated.");
   NSData *messageData = [NSData dataWithContentsOfURL:[testBundle URLForResource:messageResource


### PR DESCRIPTION
Apparently, since iOS 8, it's possible for the app's bundle to change directories as often as every launch. This is a mechanism that's hopefully slightly more robust against that, as data is supposed to carry over, the UUID component of the app's absolute directory might just change.