### PR TITLE
Dynamic Links: cleanup Apple framework dependencies

### DIFF
--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -24,7 +24,7 @@ Firebase Dynamic Links are deep links that enhance user experience and increase 
 
   s.source_files = 'FirebaseDynamicLinks/Sources/**/*.[mh]'
   s.public_header_files = 'FirebaseDynamicLinks/Sources/Public/*.h'
-  s.frameworks = 'AssetsLibrary', 'MessageUI', 'QuartzCore'
+  s.frameworks = 'QuartzCore'
   s.weak_framework = 'WebKit'
   s.dependency 'FirebaseCore', '~> 6.2'
   s.dependency 'FirebaseAnalyticsInterop', '~> 1.3'


### PR DESCRIPTION
Fixes #5139.

I cannot find usage of the removed Apple frameworks.