### PR TITLE
Libraries should save state if a completion block is requested

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORStorage.m
@@ -118,7 +118,7 @@
       [self.uploadCoordinator forceUploadForTarget:target];
     }
 
-    // Write state to disk if we're in the background.
+    // Write state to disk if there was an onComplete block or if we're in the background.
     if (hadOriginalCompletion || [[GDTCORApplication sharedApplication] isRunningInBackground]) {
       if (hadOriginalCompletion) {
         GDTCORLogDebug("%@", @"Saving storage state because a completion block was passed.");

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORTransformer.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORTransformer.m
@@ -48,8 +48,9 @@
 
 - (void)transformEvent:(GDTCOREvent *)event
       withTransformers:(NSArray<id<GDTCOREventTransformer>> *)transformers
-            onComplete:(nonnull void (^)(BOOL wasWritten, NSError *error))completion {
+            onComplete:(void (^_Nullable)(BOOL wasWritten, NSError *error))completion {
   GDTCORAssert(event, @"You can't write a nil event");
+  BOOL hadOriginalCompletion = completion != nil;
   if (!completion) {
     completion = ^(BOOL wasWritten, NSError *_Nullable error) {
     };
@@ -79,7 +80,8 @@
         return;
       }
     }
-    [self.storageInstance storeEvent:transformedEvent onComplete:completion];
+    [self.storageInstance storeEvent:transformedEvent
+                          onComplete:hadOriginalCompletion ? completion : nil];
 
     // The work is done, cancel the background task if it's valid.
     [[GDTCORApplication sharedApplication] endBackgroundTask:bgID];

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORTransport.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORTransport.m
@@ -49,37 +49,21 @@
 - (void)sendTelemetryEvent:(GDTCOREvent *)event
                 onComplete:(void (^)(BOOL wasWritten, NSError *_Nullable error))completion {
   event.qosTier = GDTCOREventQoSTelemetry;
-  [self sendEvent:event
-       onComplete:^(BOOL wasWritten, NSError *error) {
-         GDTCORLogDebug("Telemetry event sent: %@", event);
-         if (completion) {
-           completion(wasWritten, nil);
-         }
-       }];
+  [self sendEvent:event onComplete:completion];
 }
 
 - (void)sendDataEvent:(GDTCOREvent *)event
            onComplete:(void (^)(BOOL wasWritten, NSError *_Nullable error))completion {
   GDTCORAssert(event.qosTier != GDTCOREventQoSTelemetry, @"Use -sendTelemetryEvent, please.");
-  [self sendEvent:event
-       onComplete:^(BOOL wasWritten, NSError *error) {
-         GDTCORLogDebug("Data event sent: %@", event);
-         if (completion) {
-           completion(wasWritten, nil);
-         }
-       }];
+  [self sendEvent:event onComplete:completion];
 }
 
 - (void)sendTelemetryEvent:(GDTCOREvent *)event {
-  [self sendTelemetryEvent:event
-                onComplete:^(BOOL wasWritten, NSError *_Nullable error){
-                }];
+  [self sendTelemetryEvent:event onComplete:nil];
 }
 
 - (void)sendDataEvent:(GDTCOREvent *)event {
-  [self sendDataEvent:event
-           onComplete:^(BOOL wasWritten, NSError *_Nullable error){
-           }];
+  [self sendDataEvent:event onComplete:nil];
 }
 
 - (GDTCOREvent *)eventForTransport {
@@ -94,7 +78,7 @@
  * @param completion A block that will be called when the event has been written or dropped.
  */
 - (void)sendEvent:(GDTCOREvent *)event
-       onComplete:(void (^)(BOOL wasWritten, NSError *error))completion {
+       onComplete:(void (^_Nullable)(BOOL wasWritten, NSError *error))completion {
   // TODO: Determine if sending an event before registration is allowed.
   GDTCORAssert(event, @"You can't send a nil event");
   GDTCOREvent *copiedEvent = [event copy];

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORStorage.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORStorage.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param completion A block to run when an event was written to disk or dropped.
  */
 - (void)storeEvent:(GDTCOREvent *)event
-        onComplete:(void (^)(BOOL wasWritten, NSError *error))completion;
+        onComplete:(void (^_Nullable)(BOOL wasWritten, NSError *error))completion;
 
 /** Removes a set of events from storage specified by their hash.
  *

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORTransformer.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORTransformer.h
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)transformEvent:(GDTCOREvent *)event
       withTransformers:(nullable NSArray<id<GDTCOREventTransformer>> *)transformers
-            onComplete:(void (^)(BOOL wasWritten, NSError *_Nullable error))completion;
+            onComplete:(void (^_Nullable)(BOOL wasWritten, NSError *_Nullable error))completion;
 
 @end
 

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPrioritizer.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPrioritizer.h
@@ -69,6 +69,11 @@ typedef NS_OPTIONS(NSInteger, GDTCORUploadConditions) {
 - (GDTCORUploadPackage *)uploadPackageWithTarget:(GDTCORTarget)target
                                       conditions:(GDTCORUploadConditions)conditions;
 
+@optional
+
+/** Saves the state of the prioritizer. */
+- (void)saveState;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORTransport.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORTransport.h
@@ -49,7 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param completion A block that will be called when the event has been written or dropped.
  */
 - (void)sendTelemetryEvent:(GDTCOREvent *)event
-                onComplete:(void (^)(BOOL wasWritten, NSError *_Nullable error))completion;
+                onComplete:(void (^_Nullable)(BOOL wasWritten, NSError *_Nullable error))completion;
 
 /** Copies and sends an internal telemetry event. Events sent using this API are lower in priority,
  * and sometimes won't be sent on their own.
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @param completion A block that will be called when the event has been written or dropped.
  */
 - (void)sendDataEvent:(GDTCOREvent *)event
-           onComplete:(void (^)(BOOL wasWritten, NSError *_Nullable error))completion;
+           onComplete:(void (^_Nullable)(BOOL wasWritten, NSError *_Nullable error))completion;
 
 /** Copies and sends an SDK service data event. Events send using this API are higher in priority,
  * and will cause a network request at some point in the relative near future.

--- a/GoogleDataTransport/GDTCORTests/Integration/Helpers/GDTCORIntegrationTestPrioritizer.m
+++ b/GoogleDataTransport/GDTCORTests/Integration/Helpers/GDTCORIntegrationTestPrioritizer.m
@@ -72,6 +72,9 @@
   return uploadPackage;
 }
 
+- (void)saveState {
+}
+
 - (void)packageDelivered:(GDTCORUploadPackage *)package successful:(BOOL)successful {
   dispatch_async(_queue, ^{
     for (GDTCOREvent *event in package.events) {

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTPrioritizer.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTPrioritizer.m
@@ -131,6 +131,17 @@ typedef NS_ENUM(NSInteger, GDTCCTQoSTier) {
   GDTCCTQoSWifiOnly = 5,
 };
 
+- (void)saveState {
+  dispatch_sync(_queue, ^{
+    NSError *error;
+    GDTCOREncodeArchive(self, ArchivePath(), &error);
+    if (error) {
+      GDTCORLogDebug(@"Serializing GDTCCTPrioritizer to an archive failed: %@", error);
+    }
+  });
+  GDTCORLogDebug(@"GDTCCTPrioritizer saved state to %@ as requested by GDT.", ArchivePath());
+}
+
 /** Converts a GDTCOREventQoS to a GDTCCTQoS tier.
  *
  * @param qosTier The GDTCOREventQoS value.

--- a/GoogleDataTransportCCTSupport/GDTCCTTests/Integration/GDTCCTIntegrationTest.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTTests/Integration/GDTCCTIntegrationTest.m
@@ -101,10 +101,6 @@ typedef void (^GDTCCTIntegrationTestBlock)(NSURLSessionUploadTask *_Nullable);
   [self.transport sendDataEvent:event
                      onComplete:^(BOOL wasWritten, NSError *_Nullable error) {
                        NSLog(@"Storing a data event completed.");
-                       XCTAssertTrue([[NSFileManager defaultManager]
-                           fileExistsAtPath:[GDTCORRootDirectory()
-                                                URLByAppendingPathComponent:@"GDTCCTPrioritizer"]
-                                                .path]);
                      }];
   dispatch_async(dispatch_get_main_queue(), ^{
     self.totalEventsGenerated += 1;

--- a/GoogleDataTransportCCTSupport/GDTCCTTests/Integration/GDTCCTIntegrationTest.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTTests/Integration/GDTCCTIntegrationTest.m
@@ -98,7 +98,14 @@ typedef void (^GDTCCTIntegrationTestBlock)(NSURLSessionUploadTask *_Nullable);
   GDTCOREvent *event = [self.transport eventForTransport];
   event.dataObject = [[GDTCCTTestDataObject alloc] init];
   event.qosTier = qosTier;
-  [self.transport sendDataEvent:event];
+  [self.transport sendDataEvent:event
+                     onComplete:^(BOOL wasWritten, NSError *_Nullable error) {
+                       NSLog(@"Storing a data event completed.");
+                       XCTAssertTrue([[NSFileManager defaultManager]
+                           fileExistsAtPath:[GDTCORRootDirectory()
+                                                URLByAppendingPathComponent:@"GDTCCTPrioritizer"]
+                                                .path]);
+                     }];
   dispatch_async(dispatch_get_main_queue(), ^{
     self.totalEventsGenerated += 1;
   });


### PR DESCRIPTION
Currently, the onComplete block of sendXEvent:onComplete: is invoked when the event bytes are written to disk. However, if the app crashes before a lifecycle event occurs (trigger GDTCORStorage to serialize to disk), that event is effectively lost because the metadata has all been lost. This change triggers the saving of state of GDTCORStorage and prioritizers (if they implement it) if an onComplete block has been given.