### PR TITLE
Make `api::CollectionReference::collection_id` return a const reference

### DIFF
--- a/Firestore/core/src/firebase/firestore/api/collection_reference.cc
+++ b/Firestore/core/src/firebase/firestore/api/collection_reference.cc
@@ -63,7 +63,7 @@ size_t CollectionReference::Hash() const {
   return util::Hash(firestore().get(), query());
 }
 
-std::string CollectionReference::collection_id() const {
+const std::string& CollectionReference::collection_id() const {
   return query().path().last_segment();
 }
 

--- a/Firestore/core/src/firebase/firestore/api/collection_reference.h
+++ b/Firestore/core/src/firebase/firestore/api/collection_reference.h
@@ -46,7 +46,7 @@ class CollectionReference : public Query {
                       std::shared_ptr<Firestore> firestore);
 
   /** ID of the referenced collection. */
-  std::string collection_id() const;
+  const std::string& collection_id() const;
 
   /**
    * For subcollections, `parent` returns the containing `DocumentReference`.


### PR DESCRIPTION
Primarily for consistency with [`DocumentReference::document_id`](https://github.com/firebase/firebase-ios-sdk/blob/aeb4def61d42b74fc8a3834c35ab105b80258d50/Firestore/core/src/firebase/firestore/api/document_reference.h#L57). Note that `BasePath::last_segment` [returns a const reference](https://github.com/firebase/firebase-ios-sdk/blob/aeb4def61d42b74fc8a3834c35ab105b80258d50/Firestore/core/src/firebase/firestore/model/base_path.h#L71-L74).