### PR TITLE
Revert "Migrate from using IID SDK for Remote Config to the new FIS SDK"

### DIFF
--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -41,7 +41,7 @@ app update.
   s.dependency 'FirebaseAnalyticsInterop', '~> 1.4'
   s.dependency 'FirebaseABTesting', '~> 3.1'
   s.dependency 'FirebaseCore', '~> 6.2'
-  s.dependency 'FirebaseInstallations', '~> 1.1'
+  s.dependency 'FirebaseInstanceID', '~> 4.2'
   s.dependency 'GoogleUtilities/Environment', '~> 6.2'
   s.dependency 'GoogleUtilities/NSData+zlib', '~> 6.2'
   s.dependency 'Protobuf', '~> 3.9', '>= 3.9.2'

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,5 +1,3 @@
-# v4.4.10
-- [changed] Internal code changes - migrate to using the FIS SDK. (#5096)
 # v4.4.9
 - [changed] Internal code changes. (#4934)
 # v4.4.8

--- a/FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h
+++ b/FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h
@@ -39,10 +39,10 @@
 @property(nonatomic, copy) NSString *secretToken;
 /// Device data version of checkin information.
 @property(nonatomic, copy) NSString *deviceDataVersion;
-/// InstallationsID.
-@property(nonatomic, copy) NSString *configInstallationsIdentifier;
-/// Installations token.
-@property(nonatomic, copy) NSString *configInstallationsToken;
+/// InstanceID.
+@property(nonatomic, copy) NSString *configInstanceID;
+/// InstanceID token.
+@property(nonatomic, copy) NSString *configInstanceIDToken;
 
 /// A list of successful fetch timestamps in milliseconds.
 /// TODO Not used anymore. Safe to remove.

--- a/FirebaseRemoteConfig/Sources/RCNConfigSettings.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigSettings.m
@@ -334,9 +334,9 @@ static const int kRCNExponentialBackoffMaximumInterval = 60 * 60 * 4;  // 4 hour
   // Note: We only set user properties as mentioned in the new REST API Design doc
   NSString *ret = [NSString stringWithFormat:@"{"];
   ret = [ret stringByAppendingString:[NSString stringWithFormat:@"app_instance_id:'%@'",
-                                                                _configInstallationsIdentifier]];
+                                                                _configInstanceID]];
   ret = [ret stringByAppendingString:[NSString stringWithFormat:@", app_instance_id_token:'%@'",
-                                                                _configInstallationsToken]];
+                                                                _configInstanceIDToken]];
   ret = [ret stringByAppendingString:[NSString stringWithFormat:@", app_id:'%@'", _googleAppID]];
 
   ret = [ret stringByAppendingString:[NSString stringWithFormat:@", country_code:'%@'",

--- a/FirebaseRemoteConfig/Tests/Sample/Podfile
+++ b/FirebaseRemoteConfig/Tests/Sample/Podfile
@@ -7,6 +7,7 @@ target 'RemoteConfigSampleApp' do
   pod 'FirebaseAnalytics'
   pod 'FirebaseCore', :path => '../../../'
   pod 'FirebaseInstallations', :path => '../../../'
+  pod 'FirebaseInstanceID', :path => '../../../'
   pod 'FirebaseRemoteConfig', :path => '../../../'
 
   # Pods for RemoteConfigSampleApp

--- a/FirebaseRemoteConfig/Tests/Sample/RemoteConfigSampleApp/ViewController.m
+++ b/FirebaseRemoteConfig/Tests/Sample/RemoteConfigSampleApp/ViewController.m
@@ -17,7 +17,7 @@
 #import <FirebaseAnalytics/FirebaseAnalytics.h>
 #import <FirebaseCore/FIROptions.h>
 #import <FirebaseCore/FirebaseCore.h>
-#import <FirebaseInstallations/FirebaseInstallations.h>
+#import <FirebaseInstanceID/FIRInstanceID+Private.h>
 #import <FirebaseRemoteConfig/FIRRemoteConfig_Private.h>
 #import <FirebaseRemoteConfig/FirebaseRemoteConfig.h>
 #import "FRCLog.h"
@@ -355,19 +355,21 @@ static NSString *const FIRSecondFIRAppName = @"secondFIRApp";
                            stringWithFormat:@"%@\n",
                                             [self statusString:currentRCInstance.lastFetchStatus]]];
 
-  FIRInstallations *installations = [FIRInstallations installations];
-  [installations installationIDWithCompletion:^(NSString *_Nullable identifier,
-                                                NSError *_Nullable error) {
-    [output appendString:@"\n-----------Installation ID------------------\n"];
-    [output appendString:[NSString stringWithFormat:@"%@\n", identifier]];
+  FIRInstanceID *instanceID = [FIRInstanceID instanceID];
+  [instanceID getIDWithHandler:^(NSString *_Nullable identity, NSError *_Nullable error) {
+    [output appendString:@"\n-----------Instance ID------------------\n"];
+    [output appendString:[NSString stringWithFormat:@"%@\n", identity]];
 
-    [output appendString:@"\n-----------Installation ID token------------\n"];
+    [output appendString:@"\n-----------Instance ID token------------\n"];
+    [output
+        appendString:[NSString stringWithFormat:@"%@\n",
+                                                currentRCInstance.settings.configInstanceIDToken]];
 
-    [installations authTokenWithCompletion:^(FIRInstallationsAuthTokenResult *_Nullable tokenResult,
-                                             NSError *_Nullable error) {
-      [output appendString:[NSString stringWithFormat:@"%@\n", tokenResult.authToken]];
-      [[FRCLog sharedInstance] logToConsole:output];
-    }];
+    [output appendString:@"\n-----------Android ID------------\n"];
+    [output
+        appendString:[NSString stringWithFormat:@"%@\n", currentRCInstance.settings.deviceAuthID]];
+
+    [[FRCLog sharedInstance] logToConsole:output];
   }];
 }
 
@@ -407,28 +409,27 @@ static NSString *const FIRSecondFIRAppName = @"secondFIRApp";
 }
 
 - (IBAction)fetchIIDButtonClicked:(id)sender {
-  FIRInstallations *installations =
-      [FIRInstallations installationsWithApp:[FIRApp appNamed:self.FIRAppName]];
-  [installations installationIDWithCompletion:^(NSString *_Nullable identifier,
-                                                NSError *_Nullable error) {
+  FIRInstanceID *instanceID = [FIRInstanceID instanceID];
+  FIRInstanceIDTokenHandler instanceIDHandler = ^(NSString *token, NSError *error) {
     if (error) {
       [[FRCLog sharedInstance] logToConsole:[NSString stringWithFormat:@"%@", error]];
-    } else {
-      [installations authTokenWithCompletion:^(
-                         FIRInstallationsAuthTokenResult *_Nullable tokenResult,
-                         NSError *_Nullable error) {
-        if (tokenResult.authToken) {
-          ((FIRRemoteConfig *)self.RCInstances[self.currentNamespace][self.FIRAppName])
-              .settings.configInstallationsToken = tokenResult.authToken;
-          [[FRCLog sharedInstance]
-              logToConsole:[NSString
-                               stringWithFormat:
-                                   @"Successfully got installation ID : \n\n%@\n\nToken : \n\n%@\n",
-                                   identifier, tokenResult.authToken]];
-        }
+    }
+    if (token) {
+      ((FIRRemoteConfig *)self.RCInstances[self.currentNamespace][self.FIRAppName])
+          .settings.configInstanceIDToken = token;
+      [instanceID getIDWithHandler:^(NSString *_Nullable identity, NSError *_Nullable error) {
+        [[FRCLog sharedInstance]
+            logToConsole:[NSString
+                             stringWithFormat:
+                                 @"Successfully getting InstanceID : \n\n%@\n\nToken : \n\n%@\n",
+                                 identity, token]];
       }];
     }
-  }];
+  };
+  [instanceID tokenWithAuthorizedEntity:[FIRApp appNamed:self.FIRAppName].options.GCMSenderID
+                                  scope:@"*"
+                                options:nil
+                                handler:instanceIDHandler];
 }
 
 - (IBAction)searchButtonClicked:(id)sender {


### PR DESCRIPTION
Reverts firebase/firebase-ios-sdk#5096

We have to revert it so far because AB Testing backend is not ready for the migration at the moment.