### PR TITLE
Only delete events when package was successfully delivered (#5172)

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
@@ -241,7 +241,7 @@ static NSString *const ktargetToInFlightPackagesKey =
         [prioritizer packageDelivered:package successful:successful];
       }
     }
-    if (package.events != nil) {
+    if (successful && package.events) {
       [self.storage removeEvents:package.events];
     }
   });

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORUploadCoordinatorTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORUploadCoordinatorTest.m
@@ -18,6 +18,7 @@
 
 #import <GoogleDataTransport/GDTCORPlatform.h>
 
+#import "GDTCORLibrary/Private/GDTCORStorage_Private.h"
 #import "GDTCORLibrary/Private/GDTCORUploadCoordinator.h"
 
 #import "GDTCORTests/Common/Categories/GDTCORRegistrar+Testing.h"
@@ -165,6 +166,33 @@
   XCTAssertNil(error);
   XCTAssertNotNil(unarchivedCoordinator);
   XCTAssertEqualObjects([GDTCORUploadCoordinator sharedInstance], unarchivedCoordinator);
+}
+
+/** Tests that retrying a package delivery doesn't delete the file from disk. */
+- (void)testPackageRetrying {
+  [GDTCORUploadCoordinator sharedInstance].storage = [GDTCORStorage sharedInstance];
+  NSSet<GDTCOREvent *> *events = [GDTCOREventGenerator generate3Events];
+  self.prioritizer.events = events;
+  XCTestExpectation *expectation = [self expectationWithDescription:@"uploader will upload"];
+  expectation.assertForOverFulfill = NO;
+  self.uploader.uploadPackageBlock = ^(GDTCORUploadPackage *_Nonnull package) {
+    [expectation fulfill];
+    [package retryDeliveryInTheFuture];
+  };
+  [GDTCORUploadCoordinator sharedInstance].timerInterval = NSEC_PER_SEC / 10;
+  [GDTCORUploadCoordinator sharedInstance].timerLeeway = 0;
+
+  [[GDTCORUploadCoordinator sharedInstance] startTimer];
+  [self waitForExpectations:@[ expectation ] timeout:1.0];
+  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
+  dispatch_sync([GDTCORUploadCoordinator sharedInstance].coordinationQueue, ^{
+                });
+  dispatch_sync([GDTCORStorage sharedInstance].storageQueue, ^{
+                });
+  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1.0]];
+  for (GDTCOREvent *event in events) {
+    XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:event.fileURL.path]);
+  }
 }
 
 @end

--- a/GoogleDataTransport/GDTCORTests/Unit/Helpers/GDTCOREventGenerator.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/Helpers/GDTCOREventGenerator.m
@@ -26,7 +26,6 @@
 
 + (NSMutableSet<GDTCOREvent *> *)generate3Events {
   static NSUInteger counter = 0;
-  NSString *filePath = [NSString stringWithFormat:@"test-%ld.txt", (unsigned long)counter];
   int howManyToGenerate = 3;
   NSMutableSet<GDTCOREvent *> *set = [[NSMutableSet alloc] initWithCapacity:howManyToGenerate];
   for (int i = 0; i < howManyToGenerate; i++) {
@@ -34,6 +33,7 @@
     event.clockSnapshot = [GDTCORClock snapshot];
     event.qosTier = GDTCOREventQosDefault;
     event.dataObject = [[GDTCORDataObjectTesterSimple alloc] initWithString:@"testing!"];
+    NSString *filePath = [NSString stringWithFormat:@"test-%ld.txt", (unsigned long)counter];
     [[NSFileManager defaultManager] createFileAtPath:filePath
                                             contents:[NSData data]
                                           attributes:nil];


### PR DESCRIPTION
* Only delete events when package was successfully delivered
* Add unit test to check that retrying a package delivery doesn't delete an event file
