### PR TITLE
GHA for PRs from GitHub forks

### DIFF
--- a/.github/workflows/dynamiclinks.yml
+++ b/.github/workflows/dynamiclinks.yml
@@ -13,7 +13,7 @@ jobs:
   pod_lib_lint:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: FirebaseDynamicLinks

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -19,11 +19,13 @@ jobs:
       run: scripts/setup_bundler.sh
     - name: Install Secret GoogleService-Info.plist
       env:
-         plist_secret: ${{ secrets.StoragePlistSecret }}
-      run: ./scripts/decrypt_gha_secret.sh scripts/gha-encrypted/storage-db-plist.gpg \
+        plist_secret: ${{ secrets.StoragePlistSecret }}
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/storage-db-plist.gpg \
           FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist "$plist_secret"
     - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
-      run: scripts/third_party/travis/retry.sh scripts/build.sh Storage all
+      env:
+        plist_secret: ${{ secrets.StoragePlistSecret }}
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh Storage all)
 
   catalyst:
     runs-on: macOS-latest
@@ -43,16 +45,18 @@ jobs:
       run: scripts/setup_quickstart.sh storage
     - name: Install Secret GoogleService-Info.plist
       env:
-         plist_secret: ${{ secrets.QsStoragePlistSecret }}
+        plist_secret: ${{ secrets.QsStoragePlistSecret }}
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
           quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
     - name: Install Secret FIREGSignInInfo.h
       env:
-         signin_secret: ${{ secrets.QsSignInSecret }}
+        signin_secret: ${{ secrets.QsSignInSecret }}
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
           quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
     - name: Test quickstart
-      run: scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Storage
+      env:
+        plist_secret: ${{ secrets.QsStoragePlistSecret }}
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Storage)
 
   pod-lib-lint:
     runs-on: macOS-latest

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -14,7 +14,7 @@ jobs:
   storage:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Install Secret GoogleService-Info.plist

--- a/scripts/decrypt_gha_secret.sh
+++ b/scripts/decrypt_gha_secret.sh
@@ -20,4 +20,9 @@
 
 # Decrypt the file
 # --batch to prevent interactive command --yes to assume "yes" for questions
-gpg --quiet --batch --yes --decrypt --passphrase="$3" --output $2 $1
+
+file="$1"
+output="$2"
+passphrase="$3"
+[ -z "$passphrase"] ||
+  gpg --quiet --batch --yes --decrypt --passphrase="$passphrase" --output "$output" "$file"

--- a/scripts/decrypt_gha_secret.sh
+++ b/scripts/decrypt_gha_secret.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2020 Google
 #
@@ -24,5 +24,5 @@
 file="$1"
 output="$2"
 passphrase="$3"
-[ -z "$passphrase"] || \
+[ -z "$passphrase" ] || \
   gpg --quiet --batch --yes --decrypt --passphrase="$passphrase" --output "$output" "$file"

--- a/scripts/decrypt_gha_secret.sh
+++ b/scripts/decrypt_gha_secret.sh
@@ -24,5 +24,5 @@
 file="$1"
 output="$2"
 passphrase="$3"
-[ -z "$passphrase"] ||
+[ -z "$passphrase"] || \
   gpg --quiet --batch --yes --decrypt --passphrase="$passphrase" --output "$output" "$file"

--- a/scripts/decrypt_gha_secret.sh
+++ b/scripts/decrypt_gha_secret.sh
@@ -25,4 +25,4 @@ file="$1"
 output="$2"
 passphrase="$3"
 [ -z "$passphrase" ] || \
-  gpg --quiet --batch --yes --decrypt --passphrase="$passphrase" --output "$output" "$file"
+  gpg --quiet --batch --yes --decrypt --passphrase="$passphrase" --output $output "$file"


### PR DESCRIPTION
This PR updates the storage GHA workflow to work on PRs from both the main repo and forked repos by disabling the tests that depend upon secrets when the associated environment variable is not set.

It would be nice to do this at the job level, but I wasn't able to find a way. 

The change is verified here for the main repo and in #5179 for a forked repo.