### PR TITLE
Change FServerValues to just-in-time read from SyncTrees.

### DIFF
--- a/Firebase/Database/Core/FRepo.m
+++ b/Firebase/Database/Core/FRepo.m
@@ -248,7 +248,7 @@
                       withCallback:callback];
           id<FNode> resolved =
               [FServerValues resolveDeferredValueSnapshot:write.overwrite
-                                             withSyncTree:self.serverSyncTree
+                                             withExisting:self.serverSyncTree
                                                    atPath:write.path
                                              serverValues:serverValues];
           [self.serverSyncTree applyUserOverwriteAtPath:write.path

--- a/Firebase/Database/Core/FServerValues.h
+++ b/Firebase/Database/Core/FServerValues.h
@@ -18,19 +18,23 @@
 #import "FCompoundWrite.h"
 #import "FNode.h"
 #import "FSparseSnapshotTree.h"
+#import "FSyncTree.h"
 #import <Foundation/Foundation.h>
 
 @interface FServerValues : NSObject
 
 + (NSDictionary *)generateServerValues:(id<FClock>)clock;
-+ (id)resolveDeferredValueCompoundWrite:(FCompoundWrite *)write
-                           withExisting:(id<FNode>)existing
-                           serverValues:(NSDictionary *)serverValues;
+
++ (FCompoundWrite *)resolveDeferredValueCompoundWrite:(FCompoundWrite *)write
+                                         withSyncTree:(FSyncTree *)tree
+                                               atPath:(FPath *)path
+                                         serverValues:
+                                             (NSDictionary *)serverValues;
++ (id<FNode>)resolveDeferredValueSnapshot:(id<FNode>)node
+                             withSyncTree:(id<FNode>)existing
+                                   atPath:(FPath *)path
+                             serverValues:(NSDictionary *)serverValues;
 + (id<FNode>)resolveDeferredValueSnapshot:(id<FNode>)node
                              withExisting:(id<FNode>)existing
                              serverValues:(NSDictionary *)serverValues;
-+ (id)resolveDeferredValueTree:(FSparseSnapshotTree *)tree
-                  withExisting:(id<FNode>)node
-                  serverValues:(NSDictionary *)serverValues;
-
 @end

--- a/Firebase/Database/Core/FServerValues.h
+++ b/Firebase/Database/Core/FServerValues.h
@@ -31,7 +31,7 @@
                                          serverValues:
                                              (NSDictionary *)serverValues;
 + (id<FNode>)resolveDeferredValueSnapshot:(id<FNode>)node
-                             withSyncTree:(id<FNode>)existing
+                             withExisting:(id<FNode>)existing
                                    atPath:(FPath *)path
                              serverValues:(NSDictionary *)serverValues;
 + (id<FNode>)resolveDeferredValueSnapshot:(id<FNode>)node

--- a/Firebase/Database/Core/FSyncTree.m
+++ b/Firebase/Database/Core/FSyncTree.m
@@ -234,7 +234,7 @@ static const NSUInteger kFSizeThresholdForCompoundHash = 1024;
             if ([write isOverwrite]) {
                 id<FNode> resolvedNode =
                     [FServerValues resolveDeferredValueSnapshot:write.overwrite
-                                                   withSyncTree:self
+                                                   withExisting:self
                                                          atPath:write.path
                                                    serverValues:serverValues];
                 [self.persistenceManager applyUserWrite:resolvedNode

--- a/Firebase/Database/Core/FSyncTree.m
+++ b/Firebase/Database/Core/FSyncTree.m
@@ -231,19 +231,19 @@ static const NSUInteger kFSizeThresholdForCompoundHash = 1024;
         if (!revert) {
             NSDictionary *serverValues =
                 [FServerValues generateServerValues:clock];
-            id<FNode> existing = [self calcCompleteEventCacheAtPath:write.path
-                                                    excludeWriteIds:@[]];
             if ([write isOverwrite]) {
                 id<FNode> resolvedNode =
                     [FServerValues resolveDeferredValueSnapshot:write.overwrite
-                                                   withExisting:existing
+                                                   withSyncTree:self
+                                                         atPath:write.path
                                                    serverValues:serverValues];
                 [self.persistenceManager applyUserWrite:resolvedNode
                                     toServerCacheAtPath:write.path];
             } else {
                 FCompoundWrite *resolvedMerge = [FServerValues
                     resolveDeferredValueCompoundWrite:write.merge
-                                         withExisting:existing
+                                         withSyncTree:self
+                                               atPath:write.path
                                          serverValues:serverValues];
                 [self.persistenceManager applyUserMerge:resolvedMerge
                                     toServerCacheAtPath:write.path];


### PR DESCRIPTION
Based on fix https://github.com/firebase/firebase-js-sdk/pull/2499 to bug https://github.com/firebase/firebase-js-sdk/issues/2487

Micro-benchmarking showed that N writes in succession led to N^2 performance when calcuating the resolved write tree for those writes (thankfully only at the subpath in this SDK). This change matches the optimization in JS that mitigated a 20% performance regression.