### PR TITLE
Address GDT test issues

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -50,6 +50,14 @@ NSURL *GDTCORRootDirectory(void) {
     GDTPath =
         [NSURL fileURLWithPath:[NSString stringWithFormat:@"%@/google-sdks-events", cachePath]];
     GDTCORLogDebug("GDT's state will be saved to: %@", GDTPath);
+    if (![[NSFileManager defaultManager] fileExistsAtPath:GDTPath.path]) {
+      NSError *error;
+      [[NSFileManager defaultManager] createDirectoryAtPath:GDTPath.path
+                                withIntermediateDirectories:YES
+                                                 attributes:nil
+                                                      error:&error];
+      GDTCORAssert(error == nil, @"There was an error creating GDT's path");
+    }
   });
   return GDTPath;
 }

--- a/GoogleDataTransportCCTSupport/GDTCCTTests/Integration/GDTCCTIntegrationTest.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTTests/Integration/GDTCCTIntegrationTest.m
@@ -77,12 +77,15 @@ typedef void (^GDTCCTIntegrationTestBlock)(NSURLSessionUploadTask *_Nullable);
       [session dataTaskWithURL:[NSURL URLWithString:@"https://google.com"]
              completionHandler:^(NSData *_Nullable data, NSURLResponse *_Nullable response,
                                  NSError *_Nullable error) {
-               dispatch_semaphore_signal(sema);
                if (error) {
                  self.okToRunTest = NO;
                } else {
                  self.okToRunTest = YES;
                }
+               self.transport = [[GDTCORTransport alloc] initWithMappingID:@"1018"
+                                                              transformers:nil
+                                                                    target:kGDTCORTargetCSH];
+               dispatch_semaphore_signal(sema);
              }];
   [task resume];
   dispatch_semaphore_wait(sema, dispatch_time(DISPATCH_TIME_NOW, 10.0 * NSEC_PER_SEC));

--- a/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/Helpers/GDTCCTEventGenerator.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/Helpers/GDTCCTEventGenerator.m
@@ -18,6 +18,8 @@
 
 #import <GoogleDataTransport/GDTCORAssert.h>
 #import <GoogleDataTransport/GDTCOREventDataObject.h>
+#import <GoogleDataTransport/GDTCOREvent_Private.h>
+#import <GoogleDataTransport/GDTCORPlatform.h>
 #import <GoogleDataTransport/GDTCORTargets.h>
 
 @interface GDTCCTEventGeneratorDataObject : NSObject <GDTCOREventDataObject>
@@ -54,15 +56,22 @@
 }
 
 - (GDTCOREvent *)generateEvent:(GDTCOREventQoS)qosTier {
-  NSString *filePath = [NSString stringWithFormat:@"test-%lf.txt", CFAbsoluteTimeGetCurrent()];
+  CFAbsoluteTime currentTime = CFAbsoluteTimeGetCurrent();
+  NSURL *testDataFile = [GDTCORRootDirectory()
+      URLByAppendingPathComponent:[NSString stringWithFormat:@"test-data-%lf.txt", currentTime]];
+  [[NSFileManager defaultManager] createFileAtPath:testDataFile.path
+                                          contents:[@"test" dataUsingEncoding:NSUTF8StringEncoding]
+                                        attributes:nil];
+
   GDTCOREvent *event = [[GDTCOREvent alloc] initWithMappingID:@"1018" target:_target];
   event.clockSnapshot = [GDTCORClock snapshot];
   event.qosTier = qosTier;
-  [[NSFileManager defaultManager] createFileAtPath:filePath contents:[NSData data] attributes:nil];
-  NSURL *fileURL = [NSURL fileURLWithPath:filePath];
   GDTCCTEventGeneratorDataObject *dataObject = [[GDTCCTEventGeneratorDataObject alloc] init];
-  dataObject.dataFile = fileURL;
+  dataObject.dataFile = testDataFile;
   event.dataObject = dataObject;
+  NSError *error;
+  [event writeToGDTPath:[NSString stringWithFormat:@"test-event-%lf", currentTime] error:&error];
+  GDTCORFatalAssert(error == nil, @"Generating an event failed: %@", error);
   [self.allGeneratedEvents addObject:event];
   return event;
 }
@@ -74,6 +83,10 @@
   GDTCCTEventGeneratorDataObject *dataObject = [[GDTCCTEventGeneratorDataObject alloc] init];
   dataObject.dataFile = fileURL;
   event.dataObject = dataObject;
+  NSError *error;
+  [event writeToGDTPath:[NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()]
+                  error:&error];
+  GDTCORFatalAssert(error == nil, @"Generating an event failed: %@", error);
   [self.allGeneratedEvents addObject:event];
   return event;
 }
@@ -85,7 +98,7 @@
  */
 - (NSURL *)writeConsistentMessageToDisk:(NSString *)messageResource {
   NSBundle *testBundle = [NSBundle bundleForClass:[self class]];
-  NSString *filePath = [NSString stringWithFormat:@"test-%lf.txt", CFAbsoluteTimeGetCurrent()];
+  NSString *filePath = [NSString stringWithFormat:@"test-data-%lf.txt", CFAbsoluteTimeGetCurrent()];
   NSAssert([[NSFileManager defaultManager] fileExistsAtPath:filePath] == NO,
            @"There should be no duplicate files generated.");
   NSData *messageData = [NSData dataWithContentsOfURL:[testBundle URLForResource:messageResource
@@ -109,6 +122,10 @@
     GDTCCTEventGeneratorDataObject *dataObject = [[GDTCCTEventGeneratorDataObject alloc] init];
     dataObject.dataFile = messageDataURL;
     event.dataObject = dataObject;
+    NSError *error;
+    [event writeToGDTPath:[NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()]
+                    error:&error];
+    GDTCORFatalAssert(error == nil, @"Generating an event failed: %@", error);
     [events addObject:event];
   }
 
@@ -124,6 +141,10 @@
     GDTCCTEventGeneratorDataObject *dataObject = [[GDTCCTEventGeneratorDataObject alloc] init];
     dataObject.dataFile = messageDataURL;
     event.dataObject = dataObject;
+    NSError *error;
+    [event writeToGDTPath:[NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()]
+                    error:&error];
+    GDTCORFatalAssert(error == nil, @"Generating an event failed: %@", error);
     [events addObject:event];
   }
 
@@ -139,6 +160,10 @@
     GDTCCTEventGeneratorDataObject *dataObject = [[GDTCCTEventGeneratorDataObject alloc] init];
     dataObject.dataFile = messageDataURL;
     event.dataObject = dataObject;
+    NSError *error;
+    [event writeToGDTPath:[NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()]
+                    error:&error];
+    GDTCORFatalAssert(error == nil, @"Generating an event failed: %@", error);
     [events addObject:event];
   }
 
@@ -155,6 +180,10 @@
     GDTCCTEventGeneratorDataObject *dataObject = [[GDTCCTEventGeneratorDataObject alloc] init];
     dataObject.dataFile = messageDataURL;
     event.dataObject = dataObject;
+    NSError *error;
+    [event writeToGDTPath:[NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()]
+                    error:&error];
+    GDTCORFatalAssert(error == nil, @"Generating an event failed: %@", error);
     [events addObject:event];
   }
 
@@ -171,6 +200,10 @@
     GDTCCTEventGeneratorDataObject *dataObject = [[GDTCCTEventGeneratorDataObject alloc] init];
     dataObject.dataFile = messageDataURL;
     event.dataObject = dataObject;
+    NSError *error;
+    [event writeToGDTPath:[NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()]
+                    error:&error];
+    GDTCORFatalAssert(error == nil, @"Generating an event failed: %@", error);
     [events addObject:event];
   }
   return events;


### PR DESCRIPTION
1. Fixes the event  generator such that derived event fileURL will now be non-nil
2. Removes reachability check for integration tests since being locally connected via LAN but not connected to the internet would cause the test disabling check to pass. Instead, we attempt an actual NSURLRequest to a WAN target and set the value based on the success of that request.