### PR TITLE
Fix a couple of race conditions and module import of a private header

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
@@ -231,6 +231,7 @@ static NSString *const ktargetToInFlightPackagesKey =
     if (targetToInFlightPackages) {
       [targetToInFlightPackages removeObjectForKey:targetNumber];
     }
+    NSSet<GDTCOREvent *> *packageEvents = [package.events copy];
     if (registrar) {
       id<GDTCORPrioritizer> prioritizer = registrar.targetToPrioritizer[targetNumber];
       if (!prioritizer) {
@@ -238,11 +239,11 @@ static NSString *const ktargetToInFlightPackagesKey =
                        @"A prioritizer should be registered for this target: %@", targetNumber);
       }
       if ([prioritizer respondsToSelector:@selector(packageDelivered:successful:)]) {
-        [prioritizer packageDelivered:package successful:successful];
+        [prioritizer packageDelivered:[package copy] successful:successful];
       }
     }
-    if (successful && package.events) {
-      [self.storage removeEvents:package.events];
+    if (successful && packageEvents.count) {
+      [self.storage removeEvents:packageEvents];
     }
   });
 }

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORUploadPackage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORUploadPackage.m
@@ -86,7 +86,7 @@
       [_handler respondsToSelector:@selector(packageDelivered:successful:)]) {
     [_expirationTimer invalidate];
     _isHandled = YES;
-    [_handler packageDelivered:self successful:YES];
+    [_handler packageDelivered:[self copy] successful:YES];
   }
   GDTCORLogDebug("Upload package delivered: %@", self);
 }
@@ -96,7 +96,7 @@
       [_handler respondsToSelector:@selector(packageDelivered:successful:)]) {
     [_expirationTimer invalidate];
     _isHandled = YES;
-    [_handler packageDelivered:self successful:NO];
+    [_handler packageDelivered:[self copy] successful:NO];
   }
   GDTCORLogDebug("Upload package will retry in the future: %@", self);
 }

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTPrioritizer.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTPrioritizer.m
@@ -320,11 +320,13 @@ static NSString *const GDTCCTUploaderCSHEventsKey = @"GDTCCTUploaderCSHEventsKey
 #pragma mark - GDTCORLifecycleProtocol
 
 - (void)appWillForeground:(GDTCORApplication *)app {
-  NSError *error;
-  GDTCORDecodeArchive([GDTCCTPrioritizer class], ArchivePath(), nil, &error);
-  if (error) {
-    GDTCORLogDebug(@"Deserializing GDTCCTPrioritizer from an archive failed: %@", error);
-  }
+  dispatch_async(_queue, ^{
+    NSError *error;
+    GDTCORDecodeArchive([GDTCCTPrioritizer class], ArchivePath(), nil, &error);
+    if (error) {
+      GDTCORLogDebug(@"Deserializing GDTCCTPrioritizer from an archive failed: %@", error);
+    }
+  });
 }
 
 - (void)appWillBackground:(GDTCORApplication *)app {

--- a/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/Helpers/GDTCCTEventGenerator.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/Helpers/GDTCCTEventGenerator.m
@@ -18,7 +18,6 @@
 
 #import <GoogleDataTransport/GDTCORAssert.h>
 #import <GoogleDataTransport/GDTCOREventDataObject.h>
-#import <GoogleDataTransport/GDTCOREvent_Private.h>
 #import <GoogleDataTransport/GDTCORPlatform.h>
 #import <GoogleDataTransport/GDTCORTargets.h>
 
@@ -55,6 +54,15 @@
   }
 }
 
+- (void)writeEvent:(GDTCOREvent *)event toGDTPath:(NSString *)path error:(NSError **)error {
+  SEL sel = NSSelectorFromString(@"writeToGDTPath:error:");
+  IMP imp = [event methodForSelector:sel];
+  if (imp) {
+    typedef void *(*WriteToGDTPathIMP)(id, SEL, NSString *, NSError **);
+    ((WriteToGDTPathIMP)imp)(event, sel, path, error);
+  }
+}
+
 - (GDTCOREvent *)generateEvent:(GDTCOREventQoS)qosTier {
   CFAbsoluteTime currentTime = CFAbsoluteTimeGetCurrent();
   NSURL *testDataFile = [GDTCORRootDirectory()
@@ -69,8 +77,9 @@
   GDTCCTEventGeneratorDataObject *dataObject = [[GDTCCTEventGeneratorDataObject alloc] init];
   dataObject.dataFile = testDataFile;
   event.dataObject = dataObject;
+  NSString *eventPath = [NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()];
   NSError *error;
-  [event writeToGDTPath:[NSString stringWithFormat:@"test-event-%lf", currentTime] error:&error];
+  [self writeEvent:event toGDTPath:eventPath error:&error];
   GDTCORFatalAssert(error == nil, @"Generating an event failed: %@", error);
   [self.allGeneratedEvents addObject:event];
   return event;
@@ -84,8 +93,9 @@
   dataObject.dataFile = fileURL;
   event.dataObject = dataObject;
   NSError *error;
-  [event writeToGDTPath:[NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()]
-                  error:&error];
+  [self writeEvent:event
+         toGDTPath:[NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()]
+             error:&error];
   GDTCORFatalAssert(error == nil, @"Generating an event failed: %@", error);
   [self.allGeneratedEvents addObject:event];
   return event;
@@ -123,8 +133,9 @@
     dataObject.dataFile = messageDataURL;
     event.dataObject = dataObject;
     NSError *error;
-    [event writeToGDTPath:[NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()]
-                    error:&error];
+    [self writeEvent:event
+           toGDTPath:[NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()]
+               error:&error];
     GDTCORFatalAssert(error == nil, @"Generating an event failed: %@", error);
     [events addObject:event];
   }
@@ -142,8 +153,9 @@
     dataObject.dataFile = messageDataURL;
     event.dataObject = dataObject;
     NSError *error;
-    [event writeToGDTPath:[NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()]
-                    error:&error];
+    [self writeEvent:event
+           toGDTPath:[NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()]
+               error:&error];
     GDTCORFatalAssert(error == nil, @"Generating an event failed: %@", error);
     [events addObject:event];
   }
@@ -161,8 +173,9 @@
     dataObject.dataFile = messageDataURL;
     event.dataObject = dataObject;
     NSError *error;
-    [event writeToGDTPath:[NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()]
-                    error:&error];
+    [self writeEvent:event
+           toGDTPath:[NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()]
+               error:&error];
     GDTCORFatalAssert(error == nil, @"Generating an event failed: %@", error);
     [events addObject:event];
   }
@@ -181,8 +194,9 @@
     dataObject.dataFile = messageDataURL;
     event.dataObject = dataObject;
     NSError *error;
-    [event writeToGDTPath:[NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()]
-                    error:&error];
+    [self writeEvent:event
+           toGDTPath:[NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()]
+               error:&error];
     GDTCORFatalAssert(error == nil, @"Generating an event failed: %@", error);
     [events addObject:event];
   }
@@ -201,8 +215,9 @@
     dataObject.dataFile = messageDataURL;
     event.dataObject = dataObject;
     NSError *error;
-    [event writeToGDTPath:[NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()]
-                    error:&error];
+    [self writeEvent:event
+           toGDTPath:[NSString stringWithFormat:@"test-event-%lf", CFAbsoluteTimeGetCurrent()]
+               error:&error];
     GDTCORFatalAssert(error == nil, @"Generating an event failed: %@", error);
     [events addObject:event];
   }

--- a/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/Helpers/GDTCCTEventGenerator.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/Helpers/GDTCCTEventGenerator.m
@@ -57,6 +57,7 @@
 - (void)writeEvent:(GDTCOREvent *)event toGDTPath:(NSString *)path error:(NSError **)error {
   SEL sel = NSSelectorFromString(@"writeToGDTPath:error:");
   IMP imp = [event methodForSelector:sel];
+  GDTCORFatalAssert(imp, @"writeToGDTPath:error: must be implemented by GDTCOREvent");
   if (imp) {
     typedef void *(*WriteToGDTPathIMP)(id, SEL, NSString *, NSError **);
     ((WriteToGDTPathIMP)imp)(event, sel, path, error);


### PR DESCRIPTION
The header and API in question should be considered hidden. An alternative would be expose the API in the private header .

A race condition existed in the upload package itself--it should hand copies of itself and not self to prevent asynchronous mutation whilst a different queue is also executing an asynchronous mutation. One alternative would be to create mutable an immutable variants of the package. This could manifest as an EXC_BAD_ACCESS in GDTCCTPrioritizer.m
