### PR TITLE
Revert "Revert "Address a few potential security issues (#5059)" (#5121)

### DIFF
--- a/Firebase/CoreDiagnostics/CHANGELOG.md
+++ b/Firebase/CoreDiagnostics/CHANGELOG.md
@@ -3,8 +3,6 @@
 
 # v1.2.2
 - Fixed a bug that would manifest if a proto ended up being > 16,320 bytes.
-
-# v1.2.2
 - Now checks the result of malloc. (#4872)
 
 # v1.2.0

--- a/Firebase/CoreDiagnostics/CHANGELOG.md
+++ b/Firebase/CoreDiagnostics/CHANGELOG.md
@@ -1,5 +1,10 @@
-# v1.2.1
+# v1.2.3
+- Remove usage of memcpy and convert calls from malloc to calloc.
+
+# v1.2.2
 - Fixed a bug that would manifest if a proto ended up being > 16,320 bytes.
+
+# v1.2.2
 - Now checks the result of malloc. (#4872)
 
 # v1.2.0

--- a/Firebase/CoreDiagnostics/FIRCDLibrary/FIRCoreDiagnostics.m
+++ b/Firebase/CoreDiagnostics/FIRCDLibrary/FIRCoreDiagnostics.m
@@ -220,7 +220,7 @@ NS_ASSUME_NONNULL_END
 
 #pragma mark - nanopb helper functions
 
-/** Mallocs a pb_bytes_array and copies the given NSString's bytes into the bytes array.
+/** Callocs a pb_bytes_array and copies the given NSString's bytes into the bytes array.
  *
  * @note Memory needs to be free manually, through pb_free or pb_release.
  * @param string The string to encode as pb_bytes.
@@ -230,15 +230,15 @@ pb_bytes_array_t *FIREncodeString(NSString *string) {
   return FIREncodeData(stringBytes);
 }
 
-/** Mallocs a pb_bytes_array and copies the given NSData bytes into the bytes array.
+/** Callocs a pb_bytes_array and copies the given NSData bytes into the bytes array.
  *
  * @note Memory needs to be free manually, through pb_free or pb_release.
  * @param data The data to copy into the new bytes array.
  */
 pb_bytes_array_t *FIREncodeData(NSData *data) {
-  pb_bytes_array_t *pbBytes = malloc(PB_BYTES_ARRAY_T_ALLOCSIZE(data.length));
+  pb_bytes_array_t *pbBytes = calloc(PB_BYTES_ARRAY_T_ALLOCSIZE(data.length), 1);
   if (pbBytes != NULL) {
-    memcpy(pbBytes->bytes, [data bytes], data.length);
+    [data getBytes:pbBytes range:NSMakeRange(0, data.length)];
     pbBytes->size = (pb_size_t)data.length;
   }
   return pbBytes;
@@ -510,7 +510,7 @@ void FIRPopulateProtoWithInstalledServices(logs_proto_mobilesdk_ios_ICoreConfigu
   }
 
   logs_proto_mobilesdk_ios_ICoreConfiguration_ServiceType *servicesInstalled =
-      malloc(sizeof(logs_proto_mobilesdk_ios_ICoreConfiguration_ServiceType) *
+      calloc(sizeof(logs_proto_mobilesdk_ios_ICoreConfiguration_ServiceType),
              sdkServiceInstalledArray.count);
   if (servicesInstalled == NULL) {
     return;

--- a/GoogleDataTransportCCTSupport/CHANGELOG.md
+++ b/GoogleDataTransportCCTSupport/CHANGELOG.md
@@ -1,4 +1,5 @@
 # v2.0.1
+- Remove usage of memcpy and convert calls from malloc to calloc.
 - Don't attempt to make NSData out of a nil file URL. (#5088)
 - Fix deprecation warnings. (#5086)
 - Prioritizer will now save state between app restarts.

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
@@ -43,9 +43,9 @@ pb_bytes_array_t *GDTCCTEncodeString(NSString *string) {
 }
 
 pb_bytes_array_t *GDTCCTEncodeData(NSData *data) {
-  pb_bytes_array_t *pbBytes = malloc(PB_BYTES_ARRAY_T_ALLOCSIZE(data.length));
+  pb_bytes_array_t *pbBytes = calloc(PB_BYTES_ARRAY_T_ALLOCSIZE(data.length), 1);
   if (pbBytes != NULL) {
-    memcpy(pbBytes->bytes, [data bytes], data.length);
+    [data getBytes:pbBytes range:NSMakeRange(0, data.length)];
     pbBytes->size = (pb_size_t)data.length;
   }
   return pbBytes;
@@ -78,7 +78,7 @@ gdt_cct_BatchedLogRequest GDTCCTConstructBatchedLogRequest(
     NSDictionary<NSString *, NSSet<GDTCOREvent *> *> *logMappingIDToLogSet) {
   gdt_cct_BatchedLogRequest batchedLogRequest = gdt_cct_BatchedLogRequest_init_default;
   NSUInteger numberOfLogRequests = logMappingIDToLogSet.count;
-  gdt_cct_LogRequest *logRequests = malloc(sizeof(gdt_cct_LogRequest) * numberOfLogRequests);
+  gdt_cct_LogRequest *logRequests = calloc(sizeof(gdt_cct_LogRequest), numberOfLogRequests);
   if (logRequests == NULL) {
     return batchedLogRequest;
   }
@@ -111,7 +111,7 @@ gdt_cct_LogRequest GDTCCTConstructLogRequest(int32_t logSource,
   logRequest.has_log_source = 1;
   logRequest.client_info = GDTCCTConstructClientInfo();
   logRequest.has_client_info = 1;
-  logRequest.log_event = malloc(sizeof(gdt_cct_LogEvent) * logSet.count);
+  logRequest.log_event = calloc(sizeof(gdt_cct_LogEvent), logSet.count);
   if (logRequest.log_event == NULL) {
     return logRequest;
   }

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTNanopbHelpers.h
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTNanopbHelpers.h
@@ -37,7 +37,7 @@ FOUNDATION_EXPORT NSString *const GDTCCTNetworkConnectionInfo;
 
 /** Converts an NSString* to a pb_bytes_array_t*.
  *
- * @note malloc is called in this method. Ensure that pb_release is called on this or the parent.
+ * @note calloc is called in this method. Ensure that pb_release is called on this or the parent.
  *
  * @param string The string to convert.
  * @return A newly allocated array of bytes representing the UTF8 encoding of the string.
@@ -46,7 +46,7 @@ pb_bytes_array_t *GDTCCTEncodeString(NSString *string);
 
 /** Converts an NSData to a pb_bytes_array_t*.
  *
- * @note malloc is called in this method. Ensure that pb_release is called on this or the parent.
+ * @note calloc is called in this method. Ensure that pb_release is called on this or the parent.
  *
  * @param data The data to convert.
  * @return A newly allocated array of bytes with [data bytes] copied into it.
@@ -67,7 +67,7 @@ NSData *GDTCCTEncodeBatchedLogRequest(gdt_cct_BatchedLogRequest *batchedLogReque
 
 /** Constructs a gdt_cct_BatchedLogRequest given sets of events segemented by mapping ID.
  *
- * @note malloc is called in this method. Ensure that pb_release is called on this or the parent.
+ * @note calloc is called in this method. Ensure that pb_release is called on this or the parent.
  *
  * @param logMappingIDToLogSet A map of mapping IDs to sets of events to convert into a batch.
  * @return A newly created gdt_cct_BatchedLogRequest.
@@ -78,7 +78,7 @@ gdt_cct_BatchedLogRequest GDTCCTConstructBatchedLogRequest(
 
 /** Constructs a log request given a log source and a set of events.
  *
- * @note malloc is called in this method. Ensure that pb_release is called on this or the parent.
+ * @note calloc is called in this method. Ensure that pb_release is called on this or the parent.
  * @param logSource The CCT log source to put into the log request.
  * @param logSet The set of events to send in this log request.
  */
@@ -126,7 +126,7 @@ gdt_cct_NetworkConnectionInfo_MobileSubtype GDTCCTNetworkConnectionInfoNetworkMo
 
 /** Decodes a gdt_cct_LogResponse given proto bytes.
  *
- * @note malloc is called in this method. Ensure that pb_release is called on the return value.
+ * @note calloc is called in this method. Ensure that pb_release is called on the return value.
  *
  * @param data The proto bytes of the gdt_cct_LogResponse.
  * @param error An error that will be populated if something went wrong during decoding.


### PR DESCRIPTION
This reverts commit b41410d149a5ad4f6a46b2f3a0ca91c17637af3b.

The reason for reverting is that the original revert seems to have been a red herring.