### PR TITLE
Remove travis check stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ cache:
     - $HOME/.ccache
 
 stages:
-  - checks
   - test
 
 before_script:
@@ -17,15 +16,6 @@ before_script:
 
 jobs:
   include:
-    - stage: checks
-      # This only needs to be run once, so restrict it to an arbitrary combination
-      before_install:
-        - brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/e3496d9/Formula/clang-format.rb
-        - brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/7963c3d/Formula/swiftformat.rb
-        - pip install flake8
-      script:
-        - ./scripts/check.sh --test-only
-
     # The order of builds matters (even though they are run in parallel):
     # Travis will schedule them in the same order they are listed here.
 


### PR DESCRIPTION
Remove travis check stage in favor of the GHA version

It is now currently broken on travis because of missing `pip`:

From https://travis-ci.org/github/firebase/firebase-ios-sdk/jobs/666963230
```
$ pip install flake8
/Users/travis/.travis/functions: line 109: pip: command not found
The command "pip install flake8" failed and exited with 127 during .
```

