### PR TITLE
Change C++ default log level to `kLogLevelNotice`

### DIFF
--- a/Firestore/core/src/firebase/firestore/util/log_stdio.cc
+++ b/Firestore/core/src/firebase/firestore/util/log_stdio.cc
@@ -27,7 +27,7 @@ namespace util {
 
 namespace {
 
-LogLevel g_log_level = kLogLevelWarning;
+LogLevel g_log_level = kLogLevelNotice;
 
 }  // namespace
 


### PR DESCRIPTION
This is for consistency with [iOS](https://github.com/firebase/firebase-ios-sdk/blob/master/GoogleUtilities/Logger/GULLogger.m#L66) and [C++ RTDB](https://github.com/firebase/firebase-cpp-sdk/blob/master/database/src/include/firebase/database.h#L175).