### PR TITLE
Storage Integration Tests to Swift

### DIFF
--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -53,4 +53,12 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
     int_tests.resources = 'FirebaseStorage/Tests/Integration/Resources/1mb.dat',
                           'FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist'
   end
+
+  s.test_spec 'swift-integration' do |swift_int_tests|
+    swift_int_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}
+    swift_int_tests.source_files = 'FirebaseStorage/Tests/SwiftIntegration/*.swift'
+    swift_int_tests.requires_app_host = true
+    swift_int_tests.resources = 'FirebaseStorage/Tests/Integration/Resources/1mb.dat',
+                          'FirebaseStorage/Tests/Integration/Resources/GoogleService-Info.plist'
+  end
 end

--- a/FirebaseStorage/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/FirebaseStorage/Tests/Integration/FIRStorageIntegrationTests.m
@@ -496,7 +496,7 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 60;
 
 - (void)testUnauthenticatedSimpleGetFile {
   XCTestExpectation *expectation =
-      [self expectationWithDescription:@"testUnauthenticatedSimpleGetData"];
+      [self expectationWithDescription:@"testUnauthenticatedSimpleGetFile"];
 
   FIRStorageReference *ref = [self.storage referenceWithPath:@"ios/public/helloworld"];
 
@@ -529,7 +529,6 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 60;
         [task observeStatus:FIRStorageTaskStatusFailure
                     handler:^(FIRStorageTaskSnapshot *snapshot) {
                       XCTAssertNil(snapshot.error);
-                      [expectation fulfill];
                     }];
       }];
 
@@ -583,9 +582,7 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 60;
   XCTAssertNil(actualMetadata.contentLanguage);
   XCTAssertNil(actualMetadata.contentType);
   XCTAssertTrue([actualMetadata.md5Hash length] == 24);
-  XCTAssertNil([actualMetadata.customMetadata objectForKey:@"a"]);
-  XCTAssertNil([actualMetadata.customMetadata objectForKey:@"c"]);
-  XCTAssertNil([actualMetadata.customMetadata objectForKey:@"f"]);
+  XCTAssertNil(actualMetadata.customMetadata);
 }
 
 - (void)testUpdateMetadata {

--- a/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
@@ -143,7 +143,7 @@ class StorageIntegration: XCTestCase {
   func testUnauthenticatedSimplePutEmptyData() {
     let expectation = self.expectation(description: "testUnauthenticatedSimplePutEmptyData")
     let ref = storage?.reference(withPath: "ios/public/testUnauthenticatedSimplePutEmptyData")
-    let data = Data.init()
+    let data = Data()
     ref?.putData(data, metadata: nil, completion: { metadata, error in
       XCTAssertNotNil(metadata, "Metadata should not be nil")
       XCTAssertNil(error, "Error should be nil")
@@ -169,7 +169,7 @@ class StorageIntegration: XCTestCase {
     let expectation = self.expectation(description: "testUnauthenticatedSimplePutFile")
     let ref = storage?.reference(withPath: "ios/public/testUnauthenticatedSimplePutFile")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-    let tmpDirURL = URL.init(fileURLWithPath: NSTemporaryDirectory())
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
     do {
       try data.write(to: fileURL, options: Data.WritingOptions.atomicWrite)
@@ -186,11 +186,11 @@ class StorageIntegration: XCTestCase {
       expectation.fulfill()
     })
 
-    var uploadedBytes : Int64 = -1
+    var uploadedBytes: Int64 = -1
 
     task?.observe(StorageTaskStatus.progress, handler: { snapshot in
       XCTAssertTrue(snapshot.description.starts(with: "<State: Progress") ||
-                    snapshot.description.starts(with:"<State: Resume"))
+        snapshot.description.starts(with: "<State: Resume"))
       guard let progress = snapshot.progress else {
         XCTFail("Failed to get snapshot.progress")
         return
@@ -206,9 +206,9 @@ class StorageIntegration: XCTestCase {
     let expectation = self.expectation(description: "testPutFileWithSpecialCharacters")
 
     let fileName = "hello&+@_ .txt"
-    let ref = storage?.reference(withPath:"ios/public/" + fileName)
+    let ref = storage?.reference(withPath: "ios/public/" + fileName)
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-    let tmpDirURL = URL.init(fileURLWithPath: NSTemporaryDirectory())
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
     do {
       try data.write(to: fileURL, options: Data.WritingOptions.atomicWrite)
@@ -219,7 +219,7 @@ class StorageIntegration: XCTestCase {
       XCTAssertNotNil(metadata, "Metadata should not be nil")
       XCTAssertNil(error, "Error should be nil")
       XCTAssertEqual(fileName, metadata?.name)
-      ref?.getMetadata(completion: { (metadata, error) in
+      ref?.getMetadata(completion: { metadata, error in
         XCTAssertNotNil(metadata, "Metadata should not be nil")
         XCTAssertNil(error, "Error should be nil")
         XCTAssertEqual(fileName, metadata?.name)
@@ -233,7 +233,7 @@ class StorageIntegration: XCTestCase {
   func testUnauthenticatedSimplePutDataNoMetadata() throws {
     let expectation = self.expectation(description: "testUnauthenticatedSimplePutDataNoMetadata")
 
-    let ref = storage?.reference(withPath:"ios/public/testUnauthenticatedSimplePutDataNoMetadata")
+    let ref = storage?.reference(withPath: "ios/public/testUnauthenticatedSimplePutDataNoMetadata")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
     ref?.putData(data, metadata: nil, completion: { metadata, error in
       XCTAssertNotNil(metadata, "Metadata should not be nil")
@@ -248,9 +248,9 @@ class StorageIntegration: XCTestCase {
     let expectation = self.expectation(description: "testUnauthenticatedSimplePutFileNoMetadata")
 
     let fileName = "hello&+@_ .txt"
-    let ref = storage?.reference(withPath:"ios/public/" + fileName)
+    let ref = storage?.reference(withPath: "ios/public/" + fileName)
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-    let tmpDirURL = URL.init(fileURLWithPath: NSTemporaryDirectory())
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
     do {
       try data.write(to: fileURL, options: Data.WritingOptions.atomicWrite)
@@ -261,7 +261,7 @@ class StorageIntegration: XCTestCase {
       XCTAssertNotNil(metadata, "Metadata should not be nil")
       XCTAssertNil(error, "Error should be nil")
       XCTAssertEqual(fileName, metadata?.name)
-      ref?.getMetadata(completion: { (metadata, error) in
+      ref?.getMetadata(completion: { metadata, error in
         XCTAssertNotNil(metadata, "Metadata should not be nil")
         XCTAssertNil(error, "Error should be nil")
         XCTAssertEqual(fileName, metadata?.name)

--- a/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
@@ -19,15 +19,59 @@ import XCTest
 class StorageIntegration: XCTestCase {
   var app: FirebaseApp?
   var storage: Storage?
+  static var once = false
 
   override class func setUp() {
     FirebaseApp.configure()
   }
 
   override func setUp() {
+    super.setUp()
     app = FirebaseApp.app()
     storage = Storage.storage(app: app!)
-//    let setupExpectation = self.expectation(description: "foo")
+
+    if !StorageIntegration.once {
+      StorageIntegration.once = true
+      let setupExpectation = expectation(description: "setUp")
+
+      let largeFiles = ["ios/public/1mb"]
+      let emptyFiles =
+        ["ios/public/empty", "ios/public/list/a", "ios/public/list/b", "ios/public/list/prefix/c"]
+      setupExpectation.expectedFulfillmentCount = largeFiles.count + emptyFiles.count
+
+      do {
+        let bundle = Bundle(for: StorageIntegration.self)
+        let filePath = try XCTUnwrap(bundle.path(forResource: "1mb", ofType: "dat"),
+                                     "Failed to get filePath")
+        let data = try XCTUnwrap(try Data(contentsOf: URL(fileURLWithPath: filePath)),
+                                 "Failed to load file")
+
+        for largeFile in largeFiles {
+          let ref = storage?.reference().child(largeFile)
+          ref?.putData(data, metadata: nil, completion: { _, error in
+            XCTAssertNil(error, "Error should be nil")
+            setupExpectation.fulfill()
+          })
+        }
+        for emptyFile in emptyFiles {
+          let ref = storage?.reference().child(emptyFile)
+          ref?.putData(Data(), metadata: nil, completion: { _, error in
+            XCTAssertNil(error, "Error should be nil")
+            setupExpectation.fulfill()
+          })
+        }
+
+      } catch {
+        XCTFail("Exception thrown setting up files in setUp")
+      }
+      waitForExpectations()
+    }
+  }
+
+  override func tearDown() {
+    app = nil
+    storage = nil
+    super.tearDown()
   }
 
   func testName() {
@@ -198,7 +242,6 @@ class StorageIntegration: XCTestCase {
       XCTAssertGreaterThanOrEqual(progress.completedUnitCount, uploadedBytes)
       uploadedBytes = progress.completedUnitCount
     })
-
     waitForExpectations()
   }
 
@@ -226,7 +269,6 @@ class StorageIntegration: XCTestCase {
         expectation.fulfill()
       })
     })
-
     waitForExpectations()
   }
 
@@ -240,7 +282,6 @@ class StorageIntegration: XCTestCase {
       XCTAssertNil(error, "Error should be nil")
       expectation.fulfill()
     })
-
     waitForExpectations()
   }
 
@@ -268,7 +309,339 @@ class StorageIntegration: XCTestCase {
         expectation.fulfill()
       })
     })
+    waitForExpectations()
+  }
 
+  func testUnauthenticatedSimpleGetData() {
+    let expectation = self.expectation(description: "testUnauthenticatedSimpleGetData")
+
+    let ref = storage?.reference(withPath: "ios/public/1mb")
+    ref?.getData(maxSize: 1024 * 1024, completion: { data, error in
+      XCTAssertNotNil(data, "Data should not be nil")
+      XCTAssertNil(error, "Error should be nil")
+      expectation.fulfill()
+    })
+    waitForExpectations()
+  }
+
+  func testUnauthenticatedSimpleGetDataInBackgroundQueue() {
+    let expectation = self.expectation(description: "testUnauthenticatedSimpleGetDataInBackgroundQueue")
+
+    let ref = storage?.reference(withPath: "ios/public/1mb")
+    DispatchQueue.global(qos: .background).async {
+      ref?.getData(maxSize: 1024 * 1024, completion: { data, error in
+        XCTAssertNotNil(data, "Data should not be nil")
+        XCTAssertNil(error, "Error should be nil")
+        expectation.fulfill()
+      })
+    }
+    waitForExpectations()
+  }
+
+  func testUnauthenticatedSimpleGetDataTooSmall() {
+    let expectation = self.expectation(description: "testUnauthenticatedSimpleGetDataTooSmall")
+
+    let ref = storage?.reference(withPath: "ios/public/1mb")
+    ref?.getData(maxSize: 1024, completion: { data, error in
+      XCTAssertNil(data, "Data should be nil")
+      XCTAssertNotNil(error, "Error should not be nil")
+      XCTAssertEqual((error! as NSError).code, StorageErrorCode.downloadSizeExceeded.rawValue)
+      expectation.fulfill()
+    })
+    waitForExpectations()
+  }
+
+  func testUnauthenticatedSimpleGetDownloadURL() {
+    let expectation = self.expectation(description: "testUnauthenticatedSimpleGetDownloadURL")
+
+    let ref = storage?.reference(withPath: "ios/public/1mb")
+
+    // Download URL format is
+    // "https://firebasestorage.googleapis.com/v0/b/{bucket}/o/{path}?alt=media&token={token}"
+    let downloadURLPattern =
+      "^https:\\/\\/firebasestorage.googleapis.com\\/v0\\/b\\/[^\\/]*\\/o\\/" +
+      "ios%2Fpublic%2F1mb\\?alt=media&token=[a-z0-9-]*$"
+
+    ref?.downloadURL(completion: { downloadURL, error in
+      XCTAssertNil(error, "Error should be nil")
+      do {
+        let testRegex = try NSRegularExpression(pattern: downloadURLPattern)
+        let downloadURL = try XCTUnwrap(downloadURL, "Failed to unwrap downloadURL")
+        let urlString = downloadURL.absoluteString
+        XCTAssertEqual(testRegex.numberOfMatches(in: urlString,
+                                                 range: NSRange(location: 0,
+                                                                length: urlString.count)), 1)
+        expectation.fulfill()
+      } catch {
+        XCTFail("Throw in downloadURL completion block")
+      }
+    })
+    waitForExpectations()
+  }
+
+  func testUnauthenticatedSimpleGetFile() throws {
+    let expectation = self.expectation(description: "testUnauthenticatedSimpleGetFile")
+    let ref = storage?.reference(withPath: "ios/public/helloworld")
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
+    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+    let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
+
+    _ = [ref?.putData(data, metadata: nil, completion: { metadata, error in
+      XCTAssertNotNil(metadata, "Metadata should not be nil")
+      XCTAssertNil(error, "Error should be nil")
+      let task = ref?.write(toFile: fileURL)
+
+      task?.observe(StorageTaskStatus.success, handler: { snapshot in
+        do {
+          let stringData = try String(contentsOf: fileURL, encoding: .utf8)
+          XCTAssertEqual(stringData, "Hello Swift World")
+          XCTAssertEqual(snapshot.description, "<State: Success>")
+          expectation.fulfill()
+        } catch {
+          XCTFail("Exception processing success snapshot")
+        }
+      })
+
+      task?.observe(StorageTaskStatus.progress, handler: { snapshot in
+        XCTAssertNil(snapshot.error, "Error should be nil")
+        guard let progress = snapshot.progress else {
+          XCTFail("Missing progress")
+          return
+        }
+        print("\(progress.completedUnitCount) of \(progress.totalUnitCount)")
+      })
+      task?.observe(StorageTaskStatus.failure, handler: { snapshot in
+        XCTAssertNil(snapshot.error, "Error should be nil")
+      })
+    })]
+    waitForExpectations()
+  }
+
+  func testCancelDownload() throws {
+    let expectation = self.expectation(description: "testCancelDownload")
+    let ref = storage?.reference(withPath: "ios/public/1mb")
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
+    let fileURL = tmpDirURL.appendingPathComponent("hello.dat")
+
+    let task = ref?.write(toFile: fileURL)
+
+    task?.observe(StorageTaskStatus.failure, handler: { snapshot in
+      XCTAssertTrue(snapshot.description.starts(with: "<State: Failed"))
+      expectation.fulfill()
+    })
+
+    task?.observe(StorageTaskStatus.progress, handler: { _ in
+      task?.cancel()
+    })
+    waitForExpectations()
+  }
+
+  private func assertMetadata(actualMetadata: StorageMetadata,
+                              expectedContentType: String,
+                              expectedCustomMetadata: [String: String]) {
+    XCTAssertEqual(actualMetadata.cacheControl, "cache-control")
+    XCTAssertEqual(actualMetadata.contentDisposition, "content-disposition")
+    XCTAssertEqual(actualMetadata.contentEncoding, "gzip")
+    XCTAssertEqual(actualMetadata.contentLanguage, "de")
+    XCTAssertEqual(actualMetadata.contentType, expectedContentType)
+    XCTAssertTrue(actualMetadata.md5Hash!.count == 24)
+    for (key, value) in expectedCustomMetadata {
+      XCTAssertEqual(actualMetadata.customMetadata![key], value)
+    }
+  }
+
+  private func assertMetadataNil(actualMetadata: StorageMetadata) {
+    XCTAssertNil(actualMetadata.cacheControl)
+    XCTAssertNil(actualMetadata.contentDisposition)
+    XCTAssertEqual(actualMetadata.contentEncoding, "identity")
+    XCTAssertNil(actualMetadata.contentLanguage)
+    XCTAssertNil(actualMetadata.contentType)
+    XCTAssertTrue(actualMetadata.md5Hash!.count == 24)
+    XCTAssertNil(actualMetadata.customMetadata)
+  }
+
+  func testUpdateMetadata() {
+    let expectation = self.expectation(description: "testUpdateMetadata")
+    let ref = storage?.reference(withPath: "ios/public/1mb")
+
+    let metadata = StorageMetadata()
+    metadata.cacheControl = "cache-control"
+    metadata.contentDisposition = "content-disposition"
+    metadata.contentEncoding = "gzip"
+    metadata.contentLanguage = "de"
+    metadata.contentType = "content-type-a"
+    metadata.customMetadata = ["a": "b"]
+
+    ref?.updateMetadata(metadata, completion: { updatedMetadata, error in
+      XCTAssertNil(error, "Error should be nil")
+      guard let updatedMetadata = updatedMetadata else {
+        XCTFail("Metadata is nil")
+        return
+      }
+      self.assertMetadata(actualMetadata: updatedMetadata,
+                          expectedContentType: "content-type-a",
+                          expectedCustomMetadata: ["a": "b"])
+
+      let metadata = updatedMetadata
+      metadata.contentType = "content-type-b"
+      metadata.customMetadata = ["a": "b", "c": "d"]
+
+      ref?.updateMetadata(metadata, completion: { updatedMetadata, error in
+        XCTAssertNil(error, "Error should be nil")
+        self.assertMetadata(actualMetadata: updatedMetadata!,
+                            expectedContentType: "content-type-b",
+                            expectedCustomMetadata: ["a": "b", "c": "d"])
+        guard let metadata = updatedMetadata else {
+          XCTFail("Metadata is nil")
+          return
+        }
+        metadata.cacheControl = nil
+        metadata.contentDisposition = nil
+        metadata.contentEncoding = nil
+        metadata.contentLanguage = nil
+        metadata.contentType = nil
+        metadata.customMetadata = Dictionary()
+        ref?.updateMetadata(metadata, completion: { updatedMetadata, error in
+          XCTAssertNil(error, "Error should be nil")
+          self.assertMetadataNil(actualMetadata: updatedMetadata!)
+          expectation.fulfill()
+        })
+      })
+    })
+    waitForExpectations()
+  }
+
+  func testUnauthenticatedResumeGetFile() {
+    let expectation = self.expectation(description: "testUnauthenticatedResumeGetFile")
+    let ref = storage?.reference(withPath: "ios/public/1mb")
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
+    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+
+    let task = ref?.write(toFile: fileURL)
+
+    task?.observe(StorageTaskStatus.success, handler: { snapshot in
+      XCTAssertEqual(snapshot.description, "<State: Success>")
+      expectation.fulfill()
+    })
+
+    var resumeAtBytes: Int32 = 256 * 1024
+    var downloadedBytes: Int64 = 0
+    var computationResult: Double = 0.0
+
+    task?.observe(StorageTaskStatus.progress, handler: { snapshot in
+      XCTAssertTrue(snapshot.description.starts(with: "<State: Progress") ||
+        snapshot.description.starts(with: "<State: Resume"))
+      guard let progress = snapshot.progress else {
+        XCTFail("Failed to get snapshot.progress")
+        return
+      }
+      XCTAssertGreaterThanOrEqual(progress.completedUnitCount, downloadedBytes)
+      downloadedBytes = progress.completedUnitCount
+      if progress.completedUnitCount > resumeAtBytes {
+        // Making sure the main run loop is busy.
+        for i: Int32 in 0 ... 499 {
+          DispatchQueue.global(qos: .default).async {
+            computationResult = sqrt(Double(INT_MAX - i))
+          }
+        }
+        print("Pausing")
+        task?.pause()
+        resumeAtBytes = INT_MAX
+      }
+    })
+
+    task?.observe(StorageTaskStatus.pause, handler: { snapshot in
+      XCTAssertEqual(snapshot.description, "<State: Paused>")
+      print("Resuming")
+      task?.resume()
+    })
+    waitForExpectations()
+    XCTAssertEqual(INT_MAX, resumeAtBytes)
+    XCTAssertEqual(sqrt(Double(INT_MAX - 499)), computationResult, accuracy: 0.1)
+  }
+
+  func testUnauthenticatedResumeGetFileInBackgroundQueue() {
+    let expectation = self.expectation(description: "testUnauthenticatedResumeGetFileInBackgroundQueue")
+    let ref = storage?.reference(withPath: "ios/public/1mb")
+    let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
+    let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
+
+    let task = ref?.write(toFile: fileURL)
+
+    task?.observe(StorageTaskStatus.success, handler: { snapshot in
+      XCTAssertEqual(snapshot.description, "<State: Success>")
+      expectation.fulfill()
+    })
+
+    var resumeAtBytes: Int32 = 256 * 1024
+    var downloadedBytes: Int64 = 0
+
+    task?.observe(StorageTaskStatus.progress, handler: { snapshot in
+      XCTAssertTrue(snapshot.description.starts(with: "<State: Progress") ||
+        snapshot.description.starts(with: "<State: Resume"))
+      guard let progress = snapshot.progress else {
+        XCTFail("Failed to get snapshot.progress")
+        return
+      }
+      XCTAssertGreaterThanOrEqual(progress.completedUnitCount, downloadedBytes)
+      downloadedBytes = progress.completedUnitCount
+      if progress.completedUnitCount > resumeAtBytes {
+        print("Pausing")
+        DispatchQueue.global(qos: .background).async {
+          task?.pause()
+        }
+        resumeAtBytes = INT_MAX
+      }
+    })
+
+    task?.observe(StorageTaskStatus.pause, handler: { snapshot in
+      XCTAssertEqual(snapshot.description, "<State: Paused>")
+      print("Resuming")
+      task?.resume()
+    })
+    waitForExpectations()
+    XCTAssertEqual(INT_MAX, resumeAtBytes)
+  }
+
+  func testPagedListFiles() {
+    let expectation = self.expectation(description: "testPagedListFiles")
+    let ref = storage?.reference(withPath: "ios/public/list")
+
+    ref?.list(withMaxResults: 2, completion: { listResult, error in
+      XCTAssertNotNil(listResult, "listResult should not be nil")
+      XCTAssertNil(error, "Error should be nil")
+
+      XCTAssertEqual(listResult.items, [ref?.child("a"), ref?.child("b")])
+      XCTAssertEqual(listResult.prefixes, [])
+      guard let pageToken = listResult.pageToken else {
+        XCTFail("pageToken should not be nil")
+        return
+      }
+      ref?.list(withMaxResults: 2, pageToken: pageToken, completion: { listResult, error in
+        XCTAssertNotNil(listResult, "listResult should not be nil")
+        XCTAssertNil(error, "Error should be nil")
+
+        XCTAssertEqual(listResult.items, [])
+        XCTAssertEqual(listResult.prefixes, [ref!.child("prefix")])
+        XCTAssertNil(listResult.pageToken, "pageToken should be nil")
+        expectation.fulfill()
+      })
+    })
+    waitForExpectations()
+  }
+
+  func testListAllFiles() {
+    let expectation = self.expectation(description: "testListAllFiles")
+    let ref = storage?.reference(withPath: "ios/public/list")
+
+    ref?.listAll(completion: { listResult, error in
+      XCTAssertNotNil(listResult, "listResult should not be nil")
+      XCTAssertNil(error, "Error should be nil")
+      XCTAssertEqual(listResult.items, [ref?.child("a"), ref?.child("b")])
+      XCTAssertEqual(listResult.prefixes, [ref!.child("prefix")])
+      XCTAssertNil(listResult.pageToken, "pageToken should be nil")
+      expectation.fulfill()
+    })
     waitForExpectations()
   }
 

--- a/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
@@ -17,8 +17,8 @@ import FirebaseStorage
 import XCTest
 
 class StorageIntegration: XCTestCase {
-  var app: FirebaseApp?
-  var storage: Storage?
+  var app: FirebaseApp!
+  var storage: Storage!
   static var once = false
 
   override class func setUp() {
@@ -47,20 +47,14 @@ class StorageIntegration: XCTestCase {
                                  "Failed to load file")
 
         for largeFile in largeFiles {
-          guard let ref = storage?.reference().child(largeFile) else {
-            XCTFail("Failed to load: \(largeFile)")
-            continue
-          }
+          let ref = storage.reference().child(largeFile)
           ref.putData(data, metadata: nil, completion: { _, error in
             XCTAssertNil(error, "Error should be nil")
             setupExpectation.fulfill()
           })
         }
         for emptyFile in emptyFiles {
-          guard let ref = storage?.reference().child(emptyFile) else {
-            XCTFail("Failed to load: \(emptyFile)")
-            continue
-          }
+          let ref = storage.reference().child(emptyFile)
           ref.putData(Data(), metadata: nil, completion: { _, error in
             XCTAssertNil(error, "Error should be nil")
             setupExpectation.fulfill()
@@ -81,20 +75,16 @@ class StorageIntegration: XCTestCase {
   }
 
   func testName() {
-    guard let app = app else {
-      XCTFail()
-      return
-    }
     let aGS = app.options.projectID
     let aGSURI = "gs://\(aGS!).appspot.com/path/to"
-    let ref = storage?.reference(forURL: aGSURI)
-    XCTAssertEqual(ref?.description, aGSURI)
+    let ref = storage.reference(forURL: aGSURI)
+    XCTAssertEqual(ref.description, aGSURI)
   }
 
   func testUnauthenticatedGetMetadata() {
-    let expectation = self.expectation(description: "testUnauthenticatedGetMetadata")
-    let ref = storage?.reference().child("ios/public/1mb")
-    ref?.getMetadata(completion: { (metadata, error) -> Void in
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference().child("ios/public/1mb")
+    ref.getMetadata(completion: { (metadata, error) -> Void in
       XCTAssertNotNil(metadata, "Metadata should not be nil")
       XCTAssertNil(error, "Error should be nil")
       expectation.fulfill()
@@ -103,7 +93,7 @@ class StorageIntegration: XCTestCase {
   }
 
   func testUnauthenticatedUpdateMetadata() {
-    let expectation = self.expectation(description: "testUnauthenticatedUpdateMetadata")
+    let expectation = self.expectation(description: #function)
 
     let meta = StorageMetadata()
     meta.contentType = "lol/custom"
@@ -111,8 +101,8 @@ class StorageIntegration: XCTestCase {
                            "ちかてつ": "🚇",
                            "shinkansen": "新幹線"]
 
-    let ref = storage?.reference(withPath: "ios/public/1mb")
-    ref?.updateMetadata(meta, completion: { metadata, error in
+    let ref = storage.reference(withPath: "ios/public/1mb")
+    ref.updateMetadata(meta, completion: { metadata, error in
       XCTAssertEqual(meta.contentType, metadata!.contentType)
       XCTAssertEqual(meta.customMetadata!["lol"], metadata?.customMetadata!["lol"])
       XCTAssertEqual(meta.customMetadata!["ちかてつ"], metadata?.customMetadata!["ちかてつ"])
@@ -125,13 +115,13 @@ class StorageIntegration: XCTestCase {
   }
 
   func testUnauthenticatedDelete() throws {
-    let expectation = self.expectation(description: "testUnauthenticatedDelete")
-    let ref = storage?.reference(withPath: "ios/public/fileToDelete")
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference(withPath: "ios/public/fileToDelete")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-    ref?.putData(data, metadata: nil, completion: { metadata, error in
+    ref.putData(data, metadata: nil, completion: { metadata, error in
       XCTAssertNotNil(metadata, "Metadata should not be nil")
       XCTAssertNil(error, "Error should be nil")
-      ref?.delete(completion: { error in
+      ref.delete(completion: { error in
         XCTAssertNil(error, "Error should be nil")
         expectation.fulfill()
       })
@@ -140,23 +130,23 @@ class StorageIntegration: XCTestCase {
   }
 
   func testDeleteWithNilCompletion() throws {
-    let expectation = self.expectation(description: "testDeleteWithNilCompletion")
-    let ref = storage?.reference(withPath: "ios/public/fileToDelete")
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference(withPath: "ios/public/fileToDelete")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-    ref?.putData(data, metadata: nil, completion: { metadata, error in
+    ref.putData(data, metadata: nil, completion: { metadata, error in
       XCTAssertNotNil(metadata, "Metadata should not be nil")
       XCTAssertNil(error, "Error should be nil")
-      ref?.delete(completion: nil)
+      ref.delete(completion: nil)
       expectation.fulfill()
     })
     waitForExpectations()
   }
 
   func testUnauthenticatedSimplePutData() throws {
-    let expectation = self.expectation(description: "testUnauthenticatedSimplePutData")
-    let ref = storage?.reference(withPath: "ios/public/testBytesUpload")
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference(withPath: "ios/public/testBytesUpload")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-    ref?.putData(data, metadata: nil, completion: { metadata, error in
+    ref.putData(data, metadata: nil, completion: { metadata, error in
       XCTAssertNotNil(metadata, "Metadata should not be nil")
       XCTAssertNil(error, "Error should be nil")
       expectation.fulfill()
@@ -165,10 +155,10 @@ class StorageIntegration: XCTestCase {
   }
 
   func testUnauthenticatedSimplePutSpecialCharacter() throws {
-    let expectation = self.expectation(description: "testUnauthenticatedSimplePutSpecialCharacter")
-    let ref = storage?.reference(withPath: "ios/public/-._~!$'()*,=:@&+;")
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference(withPath: "ios/public/-._~!$'()*,=:@&+;")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-    ref?.putData(data, metadata: nil, completion: { metadata, error in
+    ref.putData(data, metadata: nil, completion: { metadata, error in
       XCTAssertNotNil(metadata, "Metadata should not be nil")
       XCTAssertNil(error, "Error should be nil")
       expectation.fulfill()
@@ -177,11 +167,11 @@ class StorageIntegration: XCTestCase {
   }
 
   func testUnauthenticatedSimplePutDataInBackgroundQueue() throws {
-    let expectation = self.expectation(description: "testUnauthenticatedSimplePutDataInBackgroundQueue")
-    let ref = storage?.reference(withPath: "ios/public/testBytesUpload")
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference(withPath: "ios/public/testBytesUpload")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
     DispatchQueue.global(qos: .background).async {
-      ref?.putData(data, metadata: nil, completion: { metadata, error in
+      ref.putData(data, metadata: nil, completion: { metadata, error in
         XCTAssertNotNil(metadata, "Metadata should not be nil")
         XCTAssertNil(error, "Error should be nil")
         expectation.fulfill()
@@ -191,10 +181,10 @@ class StorageIntegration: XCTestCase {
   }
 
   func testUnauthenticatedSimplePutEmptyData() {
-    let expectation = self.expectation(description: "testUnauthenticatedSimplePutEmptyData")
-    let ref = storage?.reference(withPath: "ios/public/testUnauthenticatedSimplePutEmptyData")
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference(withPath: "ios/public/testUnauthenticatedSimplePutEmptyData")
     let data = Data()
-    ref?.putData(data, metadata: nil, completion: { metadata, error in
+    ref.putData(data, metadata: nil, completion: { metadata, error in
       XCTAssertNotNil(metadata, "Metadata should not be nil")
       XCTAssertNil(error, "Error should be nil")
       expectation.fulfill()
@@ -203,10 +193,10 @@ class StorageIntegration: XCTestCase {
   }
 
   func testUnauthenticatedSimplePutDataUnauthorized() throws {
-    let expectation = self.expectation(description: "testUnauthenticatedSimplePutDataUnauthorized")
-    let ref = storage?.reference(withPath: "ios/private/secretfile.txt")
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference(withPath: "ios/private/secretfile.txt")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-    ref?.putData(data, metadata: nil, completion: { metadata, error in
+    ref.putData(data, metadata: nil, completion: { metadata, error in
       XCTAssertNil(metadata, "Metadata should be nil")
       XCTAssertNotNil(error, "Error should not be nil")
       XCTAssertEqual((error! as NSError).code, StorageErrorCode.unauthorized.rawValue)
@@ -216,23 +206,16 @@ class StorageIntegration: XCTestCase {
   }
 
   func testUnauthenticatedSimplePutFile() throws {
-    let expectation = self.expectation(description: "testUnauthenticatedSimplePutFile")
-    let ref = storage?.reference(withPath: "ios/public/testUnauthenticatedSimplePutFile")
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference(withPath: "ios/public/testUnauthenticatedSimplePutFile")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
-    do {
-      try data.write(to: fileURL, options: Data.WritingOptions.atomicWrite)
-    } catch {
-      XCTFail("Write to \(fileURL) failed")
-    }
-    guard let task = ref?.putFile(from: fileURL, metadata: nil, completion: { metadata, error in
+    try data.write(to: fileURL, options: .atomicWrite)
+    let task = ref.putFile(from: fileURL, metadata: nil, completion: { metadata, error in
       XCTAssertNotNil(metadata, "Metadata should not be nil")
       XCTAssertNil(error, "Error should be nil")
-    }) else {
-      XCTFail("Failed to put \(fileURL)")
-      return
-    }
+    })
 
     task.observe(StorageTaskStatus.success, handler: { snapshot in
       XCTAssertEqual(snapshot.description, "<State: Success>")
@@ -255,23 +238,19 @@ class StorageIntegration: XCTestCase {
   }
 
   func testPutFileWithSpecialCharacters() throws {
-    let expectation = self.expectation(description: "testPutFileWithSpecialCharacters")
+    let expectation = self.expectation(description: #function)
 
     let fileName = "hello&+@_ .txt"
-    let ref = storage?.reference(withPath: "ios/public/" + fileName)
+    let ref = storage.reference(withPath: "ios/public/" + fileName)
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
-    do {
-      try data.write(to: fileURL, options: Data.WritingOptions.atomicWrite)
-    } catch {
-      XCTFail("Write to \(fileURL) failed")
-    }
-    ref?.putFile(from: fileURL, metadata: nil, completion: { metadata, error in
+    try data.write(to: fileURL, options: .atomicWrite)
+    ref.putFile(from: fileURL, metadata: nil, completion: { metadata, error in
       XCTAssertNotNil(metadata, "Metadata should not be nil")
       XCTAssertNil(error, "Error should be nil")
       XCTAssertEqual(fileName, metadata?.name)
-      ref?.getMetadata(completion: { metadata, error in
+      ref.getMetadata(completion: { metadata, error in
         XCTAssertNotNil(metadata, "Metadata should not be nil")
         XCTAssertNil(error, "Error should be nil")
         XCTAssertEqual(fileName, metadata?.name)
@@ -282,11 +261,11 @@ class StorageIntegration: XCTestCase {
   }
 
   func testUnauthenticatedSimplePutDataNoMetadata() throws {
-    let expectation = self.expectation(description: "testUnauthenticatedSimplePutDataNoMetadata")
+    let expectation = self.expectation(description: #function)
 
-    let ref = storage?.reference(withPath: "ios/public/testUnauthenticatedSimplePutDataNoMetadata")
+    let ref = storage.reference(withPath: "ios/public/testUnauthenticatedSimplePutDataNoMetadata")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-    ref?.putData(data, metadata: nil, completion: { metadata, error in
+    ref.putData(data, metadata: nil, completion: { metadata, error in
       XCTAssertNotNil(metadata, "Metadata should not be nil")
       XCTAssertNil(error, "Error should be nil")
       expectation.fulfill()
@@ -295,19 +274,15 @@ class StorageIntegration: XCTestCase {
   }
 
   func testUnauthenticatedSimplePutFileNoMetadata() throws {
-    let expectation = self.expectation(description: "testUnauthenticatedSimplePutFileNoMetadata")
+    let expectation = self.expectation(description: #function)
 
     let fileName = "hello&+@_ .txt"
-    let ref = storage?.reference(withPath: "ios/public/" + fileName)
+    let ref = storage.reference(withPath: "ios/public/" + fileName)
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
-    do {
-      try data.write(to: fileURL, options: Data.WritingOptions.atomicWrite)
-    } catch {
-      XCTFail("Write to \(fileURL) failed")
-    }
-    ref?.putFile(from: fileURL, metadata: nil, completion: { metadata, error in
+    try data.write(to: fileURL, options: .atomicWrite)
+    ref.putFile(from: fileURL, metadata: nil, completion: { metadata, error in
       XCTAssertNotNil(metadata, "Metadata should not be nil")
       XCTAssertNil(error, "Error should be nil")
       expectation.fulfill()
@@ -316,10 +291,10 @@ class StorageIntegration: XCTestCase {
   }
 
   func testUnauthenticatedSimpleGetData() {
-    let expectation = self.expectation(description: "testUnauthenticatedSimpleGetData")
+    let expectation = self.expectation(description: #function)
 
-    let ref = storage?.reference(withPath: "ios/public/1mb")
-    ref?.getData(maxSize: 1024 * 1024, completion: { data, error in
+    let ref = storage.reference(withPath: "ios/public/1mb")
+    ref.getData(maxSize: 1024 * 1024, completion: { data, error in
       XCTAssertNotNil(data, "Data should not be nil")
       XCTAssertNil(error, "Error should be nil")
       expectation.fulfill()
@@ -328,11 +303,11 @@ class StorageIntegration: XCTestCase {
   }
 
   func testUnauthenticatedSimpleGetDataInBackgroundQueue() {
-    let expectation = self.expectation(description: "testUnauthenticatedSimpleGetDataInBackgroundQueue")
+    let expectation = self.expectation(description: #function)
 
-    let ref = storage?.reference(withPath: "ios/public/1mb")
+    let ref = storage.reference(withPath: "ios/public/1mb")
     DispatchQueue.global(qos: .background).async {
-      ref?.getData(maxSize: 1024 * 1024, completion: { data, error in
+      ref.getData(maxSize: 1024 * 1024, completion: { data, error in
         XCTAssertNotNil(data, "Data should not be nil")
         XCTAssertNil(error, "Error should be nil")
         expectation.fulfill()
@@ -342,10 +317,10 @@ class StorageIntegration: XCTestCase {
   }
 
   func testUnauthenticatedSimpleGetDataTooSmall() {
-    let expectation = self.expectation(description: "testUnauthenticatedSimpleGetDataTooSmall")
+    let expectation = self.expectation(description: #function)
 
-    let ref = storage?.reference(withPath: "ios/public/1mb")
-    ref?.getData(maxSize: 1024, completion: { data, error in
+    let ref = storage.reference(withPath: "ios/public/1mb")
+    ref.getData(maxSize: 1024, completion: { data, error in
       XCTAssertNil(data, "Data should be nil")
       XCTAssertNotNil(error, "Error should not be nil")
       XCTAssertEqual((error! as NSError).code, StorageErrorCode.downloadSizeExceeded.rawValue)
@@ -355,9 +330,9 @@ class StorageIntegration: XCTestCase {
   }
 
   func testUnauthenticatedSimpleGetDownloadURL() {
-    let expectation = self.expectation(description: "testUnauthenticatedSimpleGetDownloadURL")
+    let expectation = self.expectation(description: #function)
 
-    let ref = storage?.reference(withPath: "ios/public/1mb")
+    let ref = storage.reference(withPath: "ios/public/1mb")
 
     // Download URL format is
     // "https://firebasestorage.googleapis.com/v0/b/{bucket}/o/{path}?alt=media&token={token}"
@@ -365,7 +340,7 @@ class StorageIntegration: XCTestCase {
       "^https:\\/\\/firebasestorage.googleapis.com\\/v0\\/b\\/[^\\/]*\\/o\\/" +
       "ios%2Fpublic%2F1mb\\?alt=media&token=[a-z0-9-]*$"
 
-    ref?.downloadURL(completion: { downloadURL, error in
+    ref.downloadURL(completion: { downloadURL, error in
       XCTAssertNil(error, "Error should be nil")
       do {
         let testRegex = try NSRegularExpression(pattern: downloadURLPattern)
@@ -383,19 +358,16 @@ class StorageIntegration: XCTestCase {
   }
 
   func testUnauthenticatedSimpleGetFile() throws {
-    let expectation = self.expectation(description: "testUnauthenticatedSimpleGetFile")
-    let ref = storage?.reference(withPath: "ios/public/helloworld")
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference(withPath: "ios/public/helloworld")
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
 
-    _ = [ref?.putData(data, metadata: nil, completion: { metadata, error in
+    _ = [ref.putData(data, metadata: nil, completion: { metadata, error in
       XCTAssertNotNil(metadata, "Metadata should not be nil")
       XCTAssertNil(error, "Error should be nil")
-      guard let task = ref?.write(toFile: fileURL) else {
-        XCTFail("Failed to write to \(fileURL)")
-        return
-      }
+      let task = ref.write(toFile: fileURL)
 
       task.observe(StorageTaskStatus.success, handler: { snapshot in
         do {
@@ -424,15 +396,11 @@ class StorageIntegration: XCTestCase {
   }
 
   func testCancelDownload() throws {
-    let expectation = self.expectation(description: "testCancelDownload")
-    let ref = storage?.reference(withPath: "ios/public/1mb")
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference(withPath: "ios/public/1mb")
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent("hello.dat")
-
-    guard let task = ref?.write(toFile: fileURL) else {
-      XCTFail("Failed to write to \(fileURL)")
-      return
-    }
+    let task = ref.write(toFile: fileURL)
 
     task.observe(StorageTaskStatus.failure, handler: { snapshot in
       XCTAssertTrue(snapshot.description.starts(with: "<State: Failed"))
@@ -470,8 +438,8 @@ class StorageIntegration: XCTestCase {
   }
 
   func testUpdateMetadata() {
-    let expectation = self.expectation(description: "testUpdateMetadata")
-    let ref = storage?.reference(withPath: "ios/public/1mb")
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference(withPath: "ios/public/1mb")
 
     let metadata = StorageMetadata()
     metadata.cacheControl = "cache-control"
@@ -481,7 +449,7 @@ class StorageIntegration: XCTestCase {
     metadata.contentType = "content-type-a"
     metadata.customMetadata = ["a": "b"]
 
-    ref?.updateMetadata(metadata, completion: { updatedMetadata, error in
+    ref.updateMetadata(metadata, completion: { updatedMetadata, error in
       XCTAssertNil(error, "Error should be nil")
       guard let updatedMetadata = updatedMetadata else {
         XCTFail("Metadata is nil")
@@ -495,7 +463,7 @@ class StorageIntegration: XCTestCase {
       metadata.contentType = "content-type-b"
       metadata.customMetadata = ["a": "b", "c": "d"]
 
-      ref?.updateMetadata(metadata, completion: { updatedMetadata, error in
+      ref.updateMetadata(metadata, completion: { updatedMetadata, error in
         XCTAssertNil(error, "Error should be nil")
         self.assertMetadata(actualMetadata: updatedMetadata!,
                             expectedContentType: "content-type-b",
@@ -510,7 +478,7 @@ class StorageIntegration: XCTestCase {
         metadata.contentLanguage = nil
         metadata.contentType = nil
         metadata.customMetadata = Dictionary()
-        ref?.updateMetadata(metadata, completion: { updatedMetadata, error in
+        ref.updateMetadata(metadata, completion: { updatedMetadata, error in
           XCTAssertNil(error, "Error should be nil")
           self.assertMetadataNil(actualMetadata: updatedMetadata!)
           expectation.fulfill()
@@ -521,15 +489,11 @@ class StorageIntegration: XCTestCase {
   }
 
   func testUnauthenticatedResumeGetFile() {
-    let expectation = self.expectation(description: "testUnauthenticatedResumeGetFile")
-    let ref = storage?.reference(withPath: "ios/public/1mb")
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference(withPath: "ios/public/1mb")
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
-
-    guard let task = ref?.write(toFile: fileURL) else {
-      XCTFail("Failed to write to \(fileURL)")
-      return
-    }
+    let task = ref.write(toFile: fileURL)
 
     task.observe(StorageTaskStatus.success, handler: { snapshot in
       XCTAssertEqual(snapshot.description, "<State: Success>")
@@ -573,15 +537,11 @@ class StorageIntegration: XCTestCase {
   }
 
   func testUnauthenticatedResumeGetFileInBackgroundQueue() {
-    let expectation = self.expectation(description: "testUnauthenticatedResumeGetFileInBackgroundQueue")
-    let ref = storage?.reference(withPath: "ios/public/1mb")
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference(withPath: "ios/public/1mb")
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
-
-    guard let task = ref?.write(toFile: fileURL) else {
-      XCTFail("Failed to write to \(fileURL)")
-      return
-    }
+    let task = ref.write(toFile: fileURL)
 
     task.observe(StorageTaskStatus.success, handler: { snapshot in
       XCTAssertEqual(snapshot.description, "<State: Success>")
@@ -619,25 +579,25 @@ class StorageIntegration: XCTestCase {
   }
 
   func testPagedListFiles() {
-    let expectation = self.expectation(description: "testPagedListFiles")
-    let ref = storage?.reference(withPath: "ios/public/list")
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference(withPath: "ios/public/list")
 
-    ref?.list(withMaxResults: 2, completion: { listResult, error in
+    ref.list(withMaxResults: 2, completion: { listResult, error in
       XCTAssertNotNil(listResult, "listResult should not be nil")
       XCTAssertNil(error, "Error should be nil")
 
-      XCTAssertEqual(listResult.items, [ref?.child("a"), ref?.child("b")])
+      XCTAssertEqual(listResult.items, [ref.child("a"), ref.child("b")])
       XCTAssertEqual(listResult.prefixes, [])
       guard let pageToken = listResult.pageToken else {
         XCTFail("pageToken should not be nil")
         return
       }
-      ref?.list(withMaxResults: 2, pageToken: pageToken, completion: { listResult, error in
+      ref.list(withMaxResults: 2, pageToken: pageToken, completion: { listResult, error in
         XCTAssertNotNil(listResult, "listResult should not be nil")
         XCTAssertNil(error, "Error should be nil")
 
         XCTAssertEqual(listResult.items, [])
-        XCTAssertEqual(listResult.prefixes, [ref!.child("prefix")])
+        XCTAssertEqual(listResult.prefixes, [ref.child("prefix")])
         XCTAssertNil(listResult.pageToken, "pageToken should be nil")
         expectation.fulfill()
       })
@@ -646,14 +606,14 @@ class StorageIntegration: XCTestCase {
   }
 
   func testListAllFiles() {
-    let expectation = self.expectation(description: "testListAllFiles")
-    let ref = storage?.reference(withPath: "ios/public/list")
+    let expectation = self.expectation(description: #function)
+    let ref = storage.reference(withPath: "ios/public/list")
 
-    ref?.listAll(completion: { listResult, error in
+    ref.listAll(completion: { listResult, error in
       XCTAssertNotNil(listResult, "listResult should not be nil")
       XCTAssertNil(error, "Error should be nil")
-      XCTAssertEqual(listResult.items, [ref?.child("a"), ref?.child("b")])
-      XCTAssertEqual(listResult.prefixes, [ref!.child("prefix")])
+      XCTAssertEqual(listResult.items, [ref.child("a"), ref.child("b")])
+      XCTAssertEqual(listResult.prefixes, [ref.child("prefix")])
       XCTAssertNil(listResult.pageToken, "pageToken should be nil")
       expectation.fulfill()
     })

--- a/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
@@ -310,13 +310,7 @@ class StorageIntegration: XCTestCase {
     ref?.putFile(from: fileURL, metadata: nil, completion: { metadata, error in
       XCTAssertNotNil(metadata, "Metadata should not be nil")
       XCTAssertNil(error, "Error should be nil")
-      XCTAssertEqual(fileName, metadata?.name)
-      ref?.getMetadata(completion: { metadata, error in
-        XCTAssertNotNil(metadata, "Metadata should not be nil")
-        XCTAssertNil(error, "Error should be nil")
-        XCTAssertEqual(fileName, metadata?.name)
-        expectation.fulfill()
-      })
+      expectation.fulfill()
     })
     waitForExpectations()
   }

--- a/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
@@ -1,0 +1,87 @@
+// Copyright 2020 Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+@testable import FirebaseCore
+@testable import FirebaseStorage
+
+class StorageIntegration: XCTestCase {
+  var app : FirebaseApp? = nil
+  var storage : Storage? = nil
+
+  override class func setUp() {
+    FirebaseApp.configure()
+  }
+
+  override func setUp() {
+    app = FirebaseApp.app()
+    storage = Storage.storage(app: app!)
+//    let setupExpectation = self.expectation(description: "foo")
+  }
+
+  func testName() {
+    guard let app = app else {
+      XCTFail()
+      return
+    }
+    let aGS = app.options.projectID
+    let aGSURI = "gs://\(aGS!).appspot.com/path/to"
+    let ref = storage?.reference(forURL: aGSURI)
+    XCTAssertEqual(ref?.description, aGSURI)
+  }
+
+  func testUnauthenticatedGetMetadata() {
+    let expectation = self.expectation(description: "testUnauthenticatedGetMetadata")
+    let ref = storage?.reference().child("ios/public/1mb")
+    ref?.getMetadata(completion: { (metadata, error) -> Void in
+      XCTAssertNotNil(metadata, "Metadata should not be nil")
+      XCTAssertNil(error, "Error should be nil")
+      expectation.fulfill()
+    })
+    self.waitForExpectations()
+  }
+
+  func testUnauthenticatedUpdateMetadata() {
+    let expectation = self.expectation(description: "testUnauthenticatedUpdateMetadata")
+
+    let meta = StorageMetadata.init()
+    meta.contentType = "lol/custom"
+    meta.customMetadata = [ "lol" : "custom metadata is neat",
+                            "ちかてつ" : "🚇",
+                            "shinkansen" : "新幹線"]
+
+    let ref = storage?.reference().child("ios/public/1mb")
+    ref?.updateMetadata(meta, completion: { (metadata, error) in
+      XCTAssertEqual(meta.contentType, metadata!.contentType)
+      XCTAssertEqual(meta.customMetadata!["lol"], metadata?.customMetadata!["lol"])
+      XCTAssertEqual(meta.customMetadata!["ちかてつ"], metadata?.customMetadata!["ちかてつ"])
+      XCTAssertEqual(meta.customMetadata!["shinkansen"],
+                     metadata?.customMetadata!["shinkansen"])
+      XCTAssertNil(error, "Error should be nil")
+      expectation.fulfill()
+    })
+    self.waitForExpectations()
+  }
+
+
+  func waitForExpectations() {
+    let kFIRStorageIntegrationTestTimeout = 60.0
+    self.waitForExpectations(timeout: kFIRStorageIntegrationTestTimeout,
+                             handler: { (error) -> Void in
+                              if let error = error {
+                                print(error)
+                              }
+    })
+  }
+}

--- a/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import XCTest
 @testable import FirebaseCore
 @testable import FirebaseStorage
+import XCTest
 
 class StorageIntegration: XCTestCase {
   var app: FirebaseApp?

--- a/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@testable import FirebaseCore
-@testable import FirebaseStorage
+import FirebaseCore
+import FirebaseStorage
 import XCTest
 
 class StorageIntegration: XCTestCase {

--- a/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
@@ -17,8 +17,8 @@ import XCTest
 @testable import FirebaseStorage
 
 class StorageIntegration: XCTestCase {
-  var app : FirebaseApp? = nil
-  var storage : Storage? = nil
+  var app: FirebaseApp?
+  var storage: Storage?
 
   override class func setUp() {
     FirebaseApp.configure()
@@ -49,20 +49,20 @@ class StorageIntegration: XCTestCase {
       XCTAssertNil(error, "Error should be nil")
       expectation.fulfill()
     })
-    self.waitForExpectations()
+    waitForExpectations()
   }
 
   func testUnauthenticatedUpdateMetadata() {
     let expectation = self.expectation(description: "testUnauthenticatedUpdateMetadata")
 
-    let meta = StorageMetadata.init()
+    let meta = StorageMetadata()
     meta.contentType = "lol/custom"
-    meta.customMetadata = [ "lol" : "custom metadata is neat",
-                            "ちかてつ" : "🚇",
-                            "shinkansen" : "新幹線"]
+    meta.customMetadata = ["lol": "custom metadata is neat",
+                           "ちかてつ": "🚇",
+                           "shinkansen": "新幹線"]
 
     let ref = storage?.reference().child("ios/public/1mb")
-    ref?.updateMetadata(meta, completion: { (metadata, error) in
+    ref?.updateMetadata(meta, completion: { metadata, error in
       XCTAssertEqual(meta.contentType, metadata!.contentType)
       XCTAssertEqual(meta.customMetadata!["lol"], metadata?.customMetadata!["lol"])
       XCTAssertEqual(meta.customMetadata!["ちかてつ"], metadata?.customMetadata!["ちかてつ"])
@@ -71,17 +71,16 @@ class StorageIntegration: XCTestCase {
       XCTAssertNil(error, "Error should be nil")
       expectation.fulfill()
     })
-    self.waitForExpectations()
+    waitForExpectations()
   }
-
 
   func waitForExpectations() {
     let kFIRStorageIntegrationTestTimeout = 60.0
-    self.waitForExpectations(timeout: kFIRStorageIntegrationTestTimeout,
-                             handler: { (error) -> Void in
-                              if let error = error {
-                                print(error)
-                              }
+    waitForExpectations(timeout: kFIRStorageIntegrationTestTimeout,
+                        handler: { (error) -> Void in
+                          if let error = error {
+                            print(error)
+                          }
     })
   }
 }

--- a/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
@@ -61,7 +61,7 @@ class StorageIntegration: XCTestCase {
                            "ちかてつ": "🚇",
                            "shinkansen": "新幹線"]
 
-    let ref = storage?.reference().child("ios/public/1mb")
+    let ref = storage?.reference(withPath: "ios/public/1mb")
     ref?.updateMetadata(meta, completion: { metadata, error in
       XCTAssertEqual(meta.contentType, metadata!.contentType)
       XCTAssertEqual(meta.customMetadata!["lol"], metadata?.customMetadata!["lol"])
@@ -74,7 +74,71 @@ class StorageIntegration: XCTestCase {
     waitForExpectations()
   }
 
-  func waitForExpectations() {
+  func testUnauthenticatedDelete() {
+    let expectation = self.expectation(description: "testUnauthenticatedDelete")
+    let ref = storage?.reference(withPath: "ios/public/fileToDelete")
+    guard let data = "Delete me!!!!!!".data(using: .utf8) else {
+      XCTFail()
+      return
+    }
+    ref?.putData(data, metadata: nil, completion: { metadata, error in
+      XCTAssertNotNil(metadata, "Metadata should not be nil")
+      XCTAssertNil(error, "Error should be nil")
+      ref?.delete(completion: { error in
+        XCTAssertNil(error, "Error should be nil")
+        expectation.fulfill()
+      })
+    })
+    waitForExpectations()
+  }
+
+  func testDeleteWithNilCompletion() {
+    let expectation = self.expectation(description: "testDeleteWithNilCompletion")
+    let ref = storage?.reference(withPath: "ios/public/fileToDelete")
+    guard let data = "Delete me!!!!!!".data(using: .utf8) else {
+      XCTFail()
+      return
+    }
+    ref?.putData(data, metadata: nil, completion: { metadata, error in
+      XCTAssertNotNil(metadata, "Metadata should not be nil")
+      XCTAssertNil(error, "Error should be nil")
+      ref?.delete(completion: nil)
+      expectation.fulfill()
+    })
+    waitForExpectations()
+  }
+
+  func testUnauthenticatedSimplePutData() {
+    let expectation = self.expectation(description: "testUnauthenticatedSimplePutData")
+    let ref = storage?.reference(withPath: "ios/public/testBytesUpload")
+    guard let data = "Hello Swift World".data(using: .utf8) else {
+      XCTFail()
+      return
+    }
+    ref?.putData(data, metadata: nil, completion: { metadata, error in
+      XCTAssertNotNil(metadata, "Metadata should not be nil")
+      XCTAssertNil(error, "Error should be nil")
+      expectation.fulfill()
+    })
+    waitForExpectations()
+  }
+
+  func testUnauthenticatedSimplePutSpecialCharacter() {
+    let expectation = self.expectation(description: "testUnauthenticatedSimplePutSpecialCharacter")
+    let ref = storage?.reference(withPath: "ios/public/-._~!$'()*,=:@&+;")
+    guard let data = "Hello Swift World".data(using: .utf8) else {
+      XCTFail()
+      return
+    }
+    ref?.putData(data, metadata: nil, completion: { metadata, error in
+      XCTAssertNotNil(metadata, "Metadata should not be nil")
+      XCTAssertNil(error, "Error should be nil")
+      expectation.fulfill()
+    })
+    waitForExpectations()
+  }
+
+  private func waitForExpectations() {
     let kFIRStorageIntegrationTestTimeout = 60.0
     waitForExpectations(timeout: kFIRStorageIntegrationTestTimeout,
                         handler: { (error) -> Void in

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -409,6 +409,14 @@ case "$product-$platform-$method" in
         "${xcb_flags[@]}" \
         build \
         test
+
+      RunXcodebuild \
+        -workspace 'gen/FirebaseStorage/FirebaseStorage.xcworkspace' \
+        -scheme "FirebaseStorage-Unit-swift-integration" \
+        "${ios_flags[@]}" \
+        "${xcb_flags[@]}" \
+        build \
+        test
       fi
 
     pod_gen FirebaseStorage.podspec --platforms=macos --clean


### PR DESCRIPTION
Ports the 25 [Storage Integration Tests](https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseStorage/Tests/Integration/FIRStorageIntegrationTests.m) to Swift. The PR can be a basis for additional Swift integration tests and Swift API improvements.

The Swift tests are also added to a new testspec and the GHA CI.

The code is essentially a 1-1 translation from the Objective C. Any suggestions to make it more Swifty appreciated.