### PR TITLE
Set networkReachabilityFlags on watchOS

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <GoogleDataTransport/GDTCORPlatform.h>
+#import "GDTCORLibrary/Public/GDTCORPlatform.h"
 
 #import <GoogleDataTransport/GDTCORAssert.h>
 #import <GoogleDataTransport/GDTCORConsoleLogger.h>
@@ -54,15 +54,9 @@ NSURL *GDTCORRootDirectory(void) {
   return GDTPath;
 }
 
-#if !TARGET_OS_WATCH
-BOOL GDTCORReachabilityFlagsContainWWAN(SCNetworkReachabilityFlags flags) {
-#if TARGET_OS_IOS
-  return (flags & kSCNetworkReachabilityFlagsIsWWAN) == kSCNetworkReachabilityFlagsIsWWAN;
-#else
-  return NO;
-#endif  // TARGET_OS_IOS
+BOOL GDTCORReachabilityFlagsContainWWAN(GDTCORNetworkReachabilityFlags flags) {
+  return (flags & kGDTCORNetworkReachabilityFlagsIsWWAN) == kGDTCORNetworkReachabilityFlagsIsWWAN;
 }
-#endif  // !TARGET_OS_WATCH
 
 GDTCORNetworkType GDTCORNetworkTypeMessage() {
 #if !TARGET_OS_WATCH
@@ -76,6 +70,7 @@ GDTCORNetworkType GDTCORNetworkTypeMessage() {
     }
   }
 #endif
+  // Leaves unknown for network connection type on watchOS
   return GDTCORNetworkTypeUNKNOWN;
 }
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -73,7 +73,7 @@ BOOL GDTCORReachabilityFlagsContainWWAN(GDTCORNetworkReachabilityFlags flags) {
 #else
   // Assume network connection not WWAN on macOS, tvOS, watchOS.
   return NO;
-#endif // TARGET_OS_IOS
+#endif  // TARGET_OS_IOS
 }
 
 GDTCORNetworkType GDTCORNetworkTypeMessage() {

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -68,10 +68,10 @@ BOOL GDTCORReachabilityFlagsReachable(GDTCORNetworkReachabilityFlags flags) {
 }
 
 BOOL GDTCORReachabilityFlagsContainWWAN(GDTCORNetworkReachabilityFlags flags) {
-#if !TARGET_OS_WATCH
+#if TARGET_OS_IOS
   return (flags & kSCNetworkReachabilityFlagsIsWWAN) == kSCNetworkReachabilityFlagsIsWWAN;
 #else
-  // Assume network connection not WWAN on watchOS.
+  // Assume network connection not WWAN on macOS, tvOS, watchOS.
   return NO;
 #endif
 }

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -54,8 +54,26 @@ NSURL *GDTCORRootDirectory(void) {
   return GDTPath;
 }
 
+BOOL GDTCORReachabilityFlagsReachable(GDTCORNetworkReachabilityFlags flags) {
+#if !TARGET_OS_WATCH
+  BOOL reachable =
+      (flags & kSCNetworkReachabilityFlagsReachable) == kSCNetworkReachabilityFlagsReachable;
+  BOOL connectionRequired = (flags & kSCNetworkReachabilityFlagsConnectionRequired) ==
+                            kSCNetworkReachabilityFlagsConnectionRequired;
+  return reachable && !connectionRequired;
+#else
+  return (flags & kGDTCORNetworkReachabilityFlagsReachable) ==
+         kGDTCORNetworkReachabilityFlagsReachable;
+#endif
+}
+
 BOOL GDTCORReachabilityFlagsContainWWAN(GDTCORNetworkReachabilityFlags flags) {
-  return (flags & kGDTCORNetworkReachabilityFlagsIsWWAN) == kGDTCORNetworkReachabilityFlagsIsWWAN;
+#if !TARGET_OS_WATCH
+  return (flags & kSCNetworkReachabilityFlagsIsWWAN) == kSCNetworkReachabilityFlagsIsWWAN;
+#else
+  // Assume network connection not WWAN on watchOS.
+  return NO;
+#endif
 }
 
 GDTCORNetworkType GDTCORNetworkTypeMessage() {

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -73,7 +73,7 @@ BOOL GDTCORReachabilityFlagsContainWWAN(GDTCORNetworkReachabilityFlags flags) {
 #else
   // Assume network connection not WWAN on macOS, tvOS, watchOS.
   return NO;
-#endif
+#endif // TARGET_OS_IOS
 }
 
 GDTCORNetworkType GDTCORNetworkTypeMessage() {
@@ -88,7 +88,6 @@ GDTCORNetworkType GDTCORNetworkTypeMessage() {
     }
   }
 #endif
-  // Leaves unknown for network connection type on watchOS
   return GDTCORNetworkTypeUNKNOWN;
 }
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORReachability.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORReachability.m
@@ -114,6 +114,7 @@ static void GDTCORReachabilityCallback(GDTCORNetworkReachabilityRef reachability
 
 @end
 
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
 static void GDTCORReachabilityCallback(GDTCORNetworkReachabilityRef reachability,
                                        GDTCORNetworkReachabilityFlags flags,
@@ -121,3 +122,4 @@ static void GDTCORReachabilityCallback(GDTCORNetworkReachabilityRef reachability
   GDTCORLogDebug("Reachability changed, new flags: %d", flags);
   [[GDTCORReachability sharedInstance] setCallbackFlags:flags];
 }
+#pragma clang diagnostic pop

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORReachability.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORReachability.m
@@ -27,11 +27,9 @@
  * @param flags The new flag values.
  * @param info Any data that might be passed in by the callback.
  */
-#if !TARGET_OS_WATCH
 static void GDTCORReachabilityCallback(GDTCORNetworkReachabilityRef reachability,
                                        GDTCORNetworkReachabilityFlags flags,
                                        void *info);
-#endif
 
 @implementation GDTCORReachability {
   /** The reachability object. */
@@ -66,7 +64,7 @@ static void GDTCORReachabilityCallback(GDTCORNetworkReachabilityRef reachability
         reachability->_callbackFlags ? reachability->_callbackFlags : reachability->_flags;
     GDTCORLogDebug("Initial reachability flags determined: %d", currentFlags);
   });
-#elif TARGET_OS_WATCH
+#else
   currentFlags = kGDTCORNetworkReachabilityFlagsReachable;
 #endif
   return currentFlags;
@@ -108,21 +106,18 @@ static void GDTCORReachabilityCallback(GDTCORNetworkReachabilityRef reachability
   return self;
 }
 
-#if !TARGET_OS_WATCH
 - (void)setCallbackFlags:(GDTCORNetworkReachabilityFlags)flags {
   if (_callbackFlags != flags) {
     self->_callbackFlags = flags;
   }
 }
-#endif
 
 @end
 
-#if !TARGET_OS_WATCH
+#pragma clang diagnostic ignored "-Wunused-function"
 static void GDTCORReachabilityCallback(GDTCORNetworkReachabilityRef reachability,
                                        GDTCORNetworkReachabilityFlags flags,
                                        void *info) {
   GDTCORLogDebug("Reachability changed, new flags: %d", flags);
   [[GDTCORReachability sharedInstance] setCallbackFlags:flags];
 }
-#endif

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORReachability.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORReachability.m
@@ -119,7 +119,7 @@ static void GDTCORReachabilityCallback(GDTCORNetworkReachabilityRef reachability
 static void GDTCORReachabilityCallback(GDTCORNetworkReachabilityRef reachability,
                                        GDTCORNetworkReachabilityFlags flags,
                                        void *info) {
+#pragma clang diagnostic pop
   GDTCORLogDebug("Reachability changed, new flags: %d", flags);
   [[GDTCORReachability sharedInstance] setCallbackFlags:flags];
 }
-#pragma clang diagnostic pop

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
@@ -140,28 +140,23 @@
  * @return The current upload conditions.
  */
 - (GDTCORUploadConditions)uploadConditions {
-#if TARGET_OS_WATCH
-  // Assume connected on watchOS.
-  return GDTCORUploadConditionUnclearConnection;
-#else
-  SCNetworkReachabilityFlags currentFlags = [GDTCORReachability currentFlags];
-  BOOL reachable =
-      (currentFlags & kSCNetworkReachabilityFlagsReachable) == kSCNetworkReachabilityFlagsReachable;
-  BOOL connectionRequired = (currentFlags & kSCNetworkReachabilityFlagsConnectionRequired) ==
-                            kSCNetworkReachabilityFlagsConnectionRequired;
+  GDTCORNetworkReachabilityFlags currentFlags = [GDTCORReachability currentFlags];
+  BOOL reachable = (currentFlags & kGDTCORNetworkReachabilityFlagsReachable) ==
+                   kGDTCORNetworkReachabilityFlagsReachable;
+  BOOL connectionRequired = (currentFlags & kGDTCORNetworkReachabilityFlagsConnectionRequired) ==
+                            kGDTCORNetworkReachabilityFlagsConnectionRequired;
   BOOL networkConnected = reachable && !connectionRequired;
 
   if (!networkConnected) {
     return GDTCORUploadConditionNoNetwork;
   }
-
+  // Assume always wifi conncetion on watchOS
   BOOL isWWAN = GDTCORReachabilityFlagsContainWWAN(currentFlags);
   if (isWWAN) {
     return GDTCORUploadConditionMobileData;
   } else {
     return GDTCORUploadConditionWifiData;
   }
-#endif
 }
 
 #pragma mark - NSSecureCoding support

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
@@ -141,16 +141,11 @@
  */
 - (GDTCORUploadConditions)uploadConditions {
   GDTCORNetworkReachabilityFlags currentFlags = [GDTCORReachability currentFlags];
-  BOOL reachable = (currentFlags & kGDTCORNetworkReachabilityFlagsReachable) ==
-                   kGDTCORNetworkReachabilityFlagsReachable;
-  BOOL connectionRequired = (currentFlags & kGDTCORNetworkReachabilityFlagsConnectionRequired) ==
-                            kGDTCORNetworkReachabilityFlagsConnectionRequired;
-  BOOL networkConnected = reachable && !connectionRequired;
-
+  BOOL networkConnected = GDTCORReachabilityFlagsReachable(currentFlags);
   if (!networkConnected) {
     return GDTCORUploadConditionNoNetwork;
   }
-  // Assume always wifi conncetion on watchOS
+  // Assume always wifi connection on watchOS.
   BOOL isWWAN = GDTCORReachabilityFlagsContainWWAN(currentFlags);
   if (isWWAN) {
     return GDTCORUploadConditionMobileData;

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
@@ -145,7 +145,6 @@
   if (!networkConnected) {
     return GDTCORUploadConditionNoNetwork;
   }
-  // Assume always wifi connection on watchOS.
   BOOL isWWAN = GDTCORReachabilityFlagsContainWWAN(currentFlags);
   if (isWWAN) {
     return GDTCORUploadConditionMobileData;

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORReachability_Private.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORReachability_Private.h
@@ -18,10 +18,8 @@
 
 @interface GDTCORReachability ()
 
-#if !TARGET_OS_WATCH
 /** Allows manually setting the flags for testing purposes. */
-@property(nonatomic, readwrite) SCNetworkReachabilityFlags flags;
-#endif
+@property(nonatomic, readwrite) GDTCORNetworkReachabilityFlags flags;
 
 /** Creates/returns the singleton instance of this class.
  *

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
@@ -96,8 +96,8 @@ typedef struct {
  */
 NSURL *GDTCORRootDirectory(void);
 
-/** Compares flags with the reachable flag(on non-watchos with both reachable and connectionRequired
- * flags), if available, and returns YES if network reachable.
+/** Compares flags with the reachable flag (on non-watchos with both reachable and
+ * connectionRequired flags), if available, and returns YES if network reachable.
  *
  * @param flags The set of reachability flags.
  * @return YES if the network is reachable, NO otherwise.

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
@@ -76,10 +76,10 @@ typedef NS_ENUM(NSInteger, GDTCORReachabilityFlagsOption) {
   kGDTCORNetworkReachabilityFlagsConnectionRequired = 1 << 2,
   kGDTCORNetworkReachabilityFlagsConnectionOnTraffic = 1 << 3,
   kGDTCORNetworkReachabilityFlagsInterventionRequired = 1 << 4,
-  kGDTCORNetworkReachabilityFlagsConnectionOnDemand API_AVAILABLE(macos(6.0), ios(3.0)) = 1 << 5,
+  kGDTCORNetworkReachabilityFlagsConnectionOnDemand = 1 << 5,
   kGDTCORNetworkReachabilityFlagsIsLocalAddress = 1 << 16,
   kGDTCORNetworkReachabilityFlagsIsDirect = 1 << 17,
-  kGDTCORNetworkReachabilityFlagsIsWWAN API_UNAVAILABLE(macos) API_AVAILABLE(ios(2.0)) = 1 << 18,
+  kGDTCORNetworkReachabilityFlagsIsWWAN = 1 << 18,
 
   kGDTCORNetworkReachabilityFlagsConnectionAutomatic =
       kGDTCORNetworkReachabilityFlagsConnectionOnTraffic

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
@@ -69,22 +69,6 @@ typedef NS_ENUM(NSInteger, GDTCORNetworkMobileSubtype) {
   GDTCORNetworkMobileSubtypeLTE = 11,
 };
 
-/** The different possible reachabilityFlags option. */
-typedef NS_ENUM(NSInteger, GDTCORReachabilityFlagsOption) {
-  kGDTCORNetworkReachabilityFlagsTransientConnection = 1 << 0,
-  kGDTCORNetworkReachabilityFlagsReachable = 1 << 1,
-  kGDTCORNetworkReachabilityFlagsConnectionRequired = 1 << 2,
-  kGDTCORNetworkReachabilityFlagsConnectionOnTraffic = 1 << 3,
-  kGDTCORNetworkReachabilityFlagsInterventionRequired = 1 << 4,
-  kGDTCORNetworkReachabilityFlagsConnectionOnDemand = 1 << 5,
-  kGDTCORNetworkReachabilityFlagsIsLocalAddress = 1 << 16,
-  kGDTCORNetworkReachabilityFlagsIsDirect = 1 << 17,
-  kGDTCORNetworkReachabilityFlagsIsWWAN = 1 << 18,
-
-  kGDTCORNetworkReachabilityFlagsConnectionAutomatic =
-      kGDTCORNetworkReachabilityFlagsConnectionOnTraffic
-};
-
 #if !TARGET_OS_WATCH
 /** Define SCNetworkReachabilityFlags as GDTCORNetworkReachabilityFlags on non-watchOS. */
 typedef SCNetworkReachabilityFlags GDTCORNetworkReachabilityFlags;
@@ -92,14 +76,17 @@ typedef SCNetworkReachabilityFlags GDTCORNetworkReachabilityFlags;
 /** Define SCNetworkReachabilityRef as GDTCORNetworkReachabilityRef on non-watchOS. */
 typedef SCNetworkReachabilityRef GDTCORNetworkReachabilityRef;
 
-#elif TARGET_OS_WATCH
-/** Define an NSInteger as GDTCORNetworkReachabilityFlags on watchOS. */
-typedef NSInteger GDTCORNetworkReachabilityFlags;
+#else
+/** The different possible reachabilityFlags option on watchOS. */
+typedef NS_OPTIONS(uint32_t, GDTCORNetworkReachabilityFlags) {
+  kGDTCORNetworkReachabilityFlagsReachable = 1 << 1,
+  // TODO: Add more options on watchOS if needed.
+};
 
 /** Define a struct as GDTCORNetworkReachabilityRef on watchOS to store network connection
  * information. */
 typedef struct {
-  // TODO: Store network connection information on WatchOS if needed.
+  // TODO: Store network connection information on watchOS if needed.
 } GDTCORNetworkReachabilityRef;
 #endif
 
@@ -108,6 +95,14 @@ typedef struct {
  * @return A URL to the root directory under which all GDT-associated data must be saved.
  */
 NSURL *GDTCORRootDirectory(void);
+
+/** Compares flags with the reachable flag(on non-watchos with both reachable and connectionRequired
+ * flags), if available, and returns YES if network reachable.
+ *
+ * @param flags The set of reachability flags.
+ * @return YES if the network is reachable, NO otherwise.
+ */
+BOOL GDTCORReachabilityFlagsReachable(GDTCORNetworkReachabilityFlags flags);
 
 /** Compares flags with the WWAN reachability flag, if available, and returns YES if present.
  *

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
@@ -80,13 +80,13 @@ typedef SCNetworkReachabilityRef GDTCORNetworkReachabilityRef;
 /** The different possible reachabilityFlags option on watchOS. */
 typedef NS_OPTIONS(uint32_t, GDTCORNetworkReachabilityFlags) {
   kGDTCORNetworkReachabilityFlagsReachable = 1 << 1,
-  // TODO: Add more options on watchOS if needed.
+  // TODO(doudounan): Add more options on watchOS if needed.
 };
 
 /** Define a struct as GDTCORNetworkReachabilityRef on watchOS to store network connection
  * information. */
 typedef struct {
-  // TODO: Store network connection information on watchOS if needed.
+  // TODO(doudounan): Store network connection information on watchOS if needed.
 } GDTCORNetworkReachabilityRef;
 #endif
 

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
@@ -69,20 +69,52 @@ typedef NS_ENUM(NSInteger, GDTCORNetworkMobileSubtype) {
   GDTCORNetworkMobileSubtypeLTE = 11,
 };
 
+/** The different possible reachabilityFlags option. */
+typedef NS_ENUM(NSInteger, GDTCORReachabilityFlagsOption) {
+  kGDTCORNetworkReachabilityFlagsTransientConnection = 1 << 0,
+  kGDTCORNetworkReachabilityFlagsReachable = 1 << 1,
+  kGDTCORNetworkReachabilityFlagsConnectionRequired = 1 << 2,
+  kGDTCORNetworkReachabilityFlagsConnectionOnTraffic = 1 << 3,
+  kGDTCORNetworkReachabilityFlagsInterventionRequired = 1 << 4,
+  kGDTCORNetworkReachabilityFlagsConnectionOnDemand API_AVAILABLE(macos(6.0), ios(3.0)) = 1 << 5,
+  kGDTCORNetworkReachabilityFlagsIsLocalAddress = 1 << 16,
+  kGDTCORNetworkReachabilityFlagsIsDirect = 1 << 17,
+  kGDTCORNetworkReachabilityFlagsIsWWAN API_UNAVAILABLE(macos) API_AVAILABLE(ios(2.0)) = 1 << 18,
+
+  kGDTCORNetworkReachabilityFlagsConnectionAutomatic =
+      kGDTCORNetworkReachabilityFlagsConnectionOnTraffic
+};
+
+#if !TARGET_OS_WATCH
+/** Define SCNetworkReachabilityFlags as GDTCORNetworkReachabilityFlags on non-watchOS. */
+typedef SCNetworkReachabilityFlags GDTCORNetworkReachabilityFlags;
+
+/** Define SCNetworkReachabilityRef as GDTCORNetworkReachabilityRef on non-watchOS. */
+typedef SCNetworkReachabilityRef GDTCORNetworkReachabilityRef;
+
+#elif TARGET_OS_WATCH
+/** Define an NSInteger as GDTCORNetworkReachabilityFlags on watchOS. */
+typedef NSInteger GDTCORNetworkReachabilityFlags;
+
+/** Define a struct as GDTCORNetworkReachabilityRef on watchOS to store network connection
+ * information. */
+typedef struct {
+  // TODO: Store network connection information on WatchOS if needed.
+} GDTCORNetworkReachabilityRef;
+#endif
+
 /** Returns a URL to the root directory under which all GDT-associated data must be saved.
  *
  * @return A URL to the root directory under which all GDT-associated data must be saved.
  */
 NSURL *GDTCORRootDirectory(void);
 
-#if !TARGET_OS_WATCH
 /** Compares flags with the WWAN reachability flag, if available, and returns YES if present.
  *
  * @param flags The set of reachability flags.
  * @return YES if the WWAN flag is set, NO otherwise.
  */
-BOOL GDTCORReachabilityFlagsContainWWAN(SCNetworkReachabilityFlags flags);
-#endif
+BOOL GDTCORReachabilityFlagsContainWWAN(GDTCORNetworkReachabilityFlags flags);
 
 /** Generates an enum message GDTCORNetworkType representing network connection type.
  *

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORReachability.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORReachability.h
@@ -16,18 +16,15 @@
 
 #import <Foundation/Foundation.h>
 
-#if !TARGET_OS_WATCH
-#import <SystemConfiguration/SCNetworkReachability.h>
-#endif
+#import <GoogleDataTransport/GDTCORPlatform.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 /** This class helps determine upload conditions by determining connectivity. */
 @interface GDTCORReachability : NSObject
-#if !TARGET_OS_WATCH
+
 /** The current set flags indicating network conditions */
-+ (SCNetworkReachabilityFlags)currentFlags;
-#endif
++ (GDTCORNetworkReachabilityFlags)currentFlags;
 
 @end
 


### PR DESCRIPTION
- Wrap reachabilityRef and ReachabilityFlags in GDTCORPlatform

- Define reachabilityRef and ReachabilityFlags for watchOS and set default flag value equal to wifi only for uploader checking. Leave unknown for networkinfo populating in log event.