### PR TITLE
Revert `Error` back to an unscoped enumeration

### DIFF
--- a/Firestore/core/include/firebase/firestore/firestore_errors.h
+++ b/Firestore/core/include/firebase/firestore/firestore_errors.h
@@ -25,7 +25,7 @@ namespace firestore {
  *
  * The codes are in sync across Firestore SDKs on various platforms.
  */
-enum class Error {
+enum Error {
   /** The operation completed successfully. */
   // Note: NSError objects will never have a code with this value.
   kOk = 0,

--- a/Firestore/core/src/firebase/firestore/util/status_apple.mm
+++ b/Firestore/core/src/firebase/firestore/util/status_apple.mm
@@ -70,9 +70,9 @@ namespace {
  */
 Status FromFirestoreNSError(NSError* error) {
   auto error_code = static_cast<int>(error.code);
-  HARD_ASSERT(error_code >= static_cast<int>(Error::kCancelled) &&
-                  error_code <= static_cast<int>(Error::kUnauthenticated),
-              "Unknown error code");
+  HARD_ASSERT(
+      error_code >= Error::kCancelled && error_code <= Error::kUnauthenticated,
+      "Unknown error code");
 
   auto original = UnderlyingNSError::Create(error);
 

--- a/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
+++ b/Firestore/core/test/firebase/firestore/remote/serializer_test.cc
@@ -1591,8 +1591,7 @@ TEST_F(SerializerTest, DecodesListenResponseWithRemovedTargetChange) {
   change->add_target_ids(1);
   change->add_target_ids(2);
   change->set_resume_token("resume_token");
-  change->mutable_cause()->set_code(
-      static_cast<int32_t>(Error::kPermissionDenied));
+  change->mutable_cause()->set_code(Error::kPermissionDenied);
   change->mutable_cause()->set_message("Error message");
 
   SCOPED_TRACE("DecodesListenResponseWithRemovedTargetChange");

--- a/Firestore/core/test/firebase/firestore/util/status_apple_test.mm
+++ b/Firestore/core/test/firebase/firestore/util/status_apple_test.mm
@@ -79,7 +79,7 @@ TEST(Status, CausedBy_Chain_NSError) {
           "Internal: Something broke: Some file not found \\(errno .*\\)"));
 
   NSError* error = result.ToNSError();
-  EXPECT_EQ(static_cast<int>(internal_error.code()), error.code);
+  EXPECT_EQ(internal_error.code(), error.code);
   EXPECT_EQ(FIRFirestoreErrorDomain, error.domain);
 
   NSError* cause = error.userInfo[NSUnderlyingErrorKey];
@@ -92,7 +92,7 @@ TEST(Status, MovedFromToNSError) {
   Status unused = std::move(not_found);
 
   EXPECT_EQ(not_found.ToNSError().domain, FIRFirestoreErrorDomain);
-  EXPECT_EQ(not_found.ToNSError().code, static_cast<int>(Error::kInternal));
+  EXPECT_EQ(not_found.ToNSError().code, Error::kInternal);
 }
 #endif  // !__clang_analyzer__
 


### PR DESCRIPTION
Making it a scoped enumeration, coupled with the fact that `firebase::Future::error()` returns a plain `int`, imposes a lot of casting.