### PR TITLE
Fix calloc calls, which had the argument order reversed

### DIFF
--- a/Firebase/CoreDiagnostics/FIRCDLibrary/FIRCoreDiagnostics.m
+++ b/Firebase/CoreDiagnostics/FIRCDLibrary/FIRCoreDiagnostics.m
@@ -236,7 +236,7 @@ pb_bytes_array_t *FIREncodeString(NSString *string) {
  * @param data The data to copy into the new bytes array.
  */
 pb_bytes_array_t *FIREncodeData(NSData *data) {
-  pb_bytes_array_t *pbBytes = calloc(PB_BYTES_ARRAY_T_ALLOCSIZE(data.length), 1);
+  pb_bytes_array_t *pbBytes = calloc(1, PB_BYTES_ARRAY_T_ALLOCSIZE(data.length));
   if (pbBytes != NULL) {
     [data getBytes:pbBytes range:NSMakeRange(0, data.length)];
     pbBytes->size = (pb_size_t)data.length;
@@ -510,8 +510,8 @@ void FIRPopulateProtoWithInstalledServices(logs_proto_mobilesdk_ios_ICoreConfigu
   }
 
   logs_proto_mobilesdk_ios_ICoreConfiguration_ServiceType *servicesInstalled =
-      calloc(sizeof(logs_proto_mobilesdk_ios_ICoreConfiguration_ServiceType),
-             sdkServiceInstalledArray.count);
+      calloc(sdkServiceInstalledArray.count,
+             sizeof(logs_proto_mobilesdk_ios_ICoreConfiguration_ServiceType));
   if (servicesInstalled == NULL) {
     return;
   }

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
@@ -43,7 +43,7 @@ pb_bytes_array_t *GDTCCTEncodeString(NSString *string) {
 }
 
 pb_bytes_array_t *GDTCCTEncodeData(NSData *data) {
-  pb_bytes_array_t *pbBytes = calloc(PB_BYTES_ARRAY_T_ALLOCSIZE(data.length), 1);
+  pb_bytes_array_t *pbBytes = calloc(1, PB_BYTES_ARRAY_T_ALLOCSIZE(data.length));
   if (pbBytes != NULL) {
     [data getBytes:pbBytes range:NSMakeRange(0, data.length)];
     pbBytes->size = (pb_size_t)data.length;
@@ -78,7 +78,7 @@ gdt_cct_BatchedLogRequest GDTCCTConstructBatchedLogRequest(
     NSDictionary<NSString *, NSSet<GDTCOREvent *> *> *logMappingIDToLogSet) {
   gdt_cct_BatchedLogRequest batchedLogRequest = gdt_cct_BatchedLogRequest_init_default;
   NSUInteger numberOfLogRequests = logMappingIDToLogSet.count;
-  gdt_cct_LogRequest *logRequests = calloc(sizeof(gdt_cct_LogRequest), numberOfLogRequests);
+  gdt_cct_LogRequest *logRequests = calloc(numberOfLogRequests, sizeof(gdt_cct_LogRequest));
   if (logRequests == NULL) {
     return batchedLogRequest;
   }
@@ -111,7 +111,7 @@ gdt_cct_LogRequest GDTCCTConstructLogRequest(int32_t logSource,
   logRequest.has_log_source = 1;
   logRequest.client_info = GDTCCTConstructClientInfo();
   logRequest.has_client_info = 1;
-  logRequest.log_event = calloc(sizeof(gdt_cct_LogEvent), logSet.count);
+  logRequest.log_event = calloc(logSet.count, sizeof(gdt_cct_LogEvent));
   if (logRequest.log_event == NULL) {
     return logRequest;
   }


### PR DESCRIPTION
Also, maybe I should resign from software engineering

From `man calloc`, which was not the source I used (dumb).

```
     void *
     calloc(size_t count, size_t size);

```