### PR TITLE
Remove platforms from podspec summaries

### DIFF
--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary          = 'Firebase'
 
   s.description      = <<-DESC
-Simplify your Apple development, grow your user base, and monetize more effectively with Firebase.
+Simplify your app development, grow your user base, and monetize more effectively with Firebase.
                        DESC
 
   s.homepage         = 'https://firebase.google.com'

--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'Firebase'
   s.version          = '6.21.0'
-  s.summary          = 'Firebase for iOS (plus community support for macOS and tvOS)'
+  s.summary          = 'Firebase'
 
   s.description      = <<-DESC
-Simplify your iOS development, grow your user base, and monetize more effectively with Firebase.
+Simplify your Apple development, grow your user base, and monetize more effectively with Firebase.
                        DESC
 
   s.homepage         = 'https://firebase.google.com'

--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseABTesting'
   s.version          = '3.2.0'
-  s.summary          = 'Firebase ABTesting for iOS'
+  s.summary          = 'Firebase ABTesting'
 
   s.description      = <<-DESC
 A/B testing is a Firebase service that lets you run experiments across users of
-your iOS and Android apps. It lets you learn how well one or more changes to
+your mobile apps. It lets you learn how well one or more changes to
 your app work with a smaller set of users before you roll out changes to all
 users. You can run experiments to find the most effective ways to use
 Firebase Cloud Messaging and Firebase Remote Config in your app.

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseAuth'
   s.version          = '6.5.1'
-  s.summary          = 'The official iOS client for Firebase Authentication (plus community support for macOS and tvOS)'
+  s.summary          = 'Apple platform client for Firebase Authentication'
 
   s.description      = <<-DESC
 Firebase Authentication allows you to manage your own account system without any backend code. It

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCore'
   s.version          = '6.6.5'
-  s.summary          = 'Firebase Core for iOS (plus community support for macOS and tvOS)'
+  s.summary          = 'Firebase Core'
 
   s.description      = <<-DESC
 Firebase Core includes FIRApp and FIROptions which provide central configuration for other Firebase services.

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseDatabase'
   s.version          = '6.1.4'
-  s.summary          = 'Firebase Open Source Libraries for iOS (plus community support for macOS and tvOS)'
+  s.summary          = 'Firebase Realtime Database'
 
   s.description      = <<-DESC
 Simplify your iOS development, grow your user base, and monetize more effectively with Firebase.

--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseDynamicLinks'
   s.version          = '4.0.8'
-  s.summary          = 'Firebase DynamicLinks'
+  s.summary          = 'Firebase Dynamic Links'
 
   s.description      = <<-DESC
 Firebase Dynamic Links are deep links that enhance user experience and increase engagement by retaining context post-install, across platforms.

--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseDynamicLinks'
   s.version          = '4.0.8'
-  s.summary          = 'Firebase DynamicLinks for iOS'
+  s.summary          = 'Firebase DynamicLinks'
 
   s.description      = <<-DESC
 Firebase Dynamic Links are deep links that enhance user experience and increase engagement by retaining context post-install, across platforms.

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseFirestore'
   s.version          = '1.11.2'
-  s.summary          = 'Google Cloud Firestore for iOS'
+  s.summary          = 'Google Cloud Firestore'
 
   s.description      = <<-DESC
 Google Cloud Firestore is a NoSQL document database built for automatic scaling, high performance, and ease of application development.

--- a/FirebaseFirestoreSwift.podspec
+++ b/FirebaseFirestoreSwift.podspec
@@ -6,7 +6,7 @@
 Pod::Spec.new do |s|
   s.name                    = 'FirebaseFirestoreSwift'
   s.version                 = '0.2'
-  s.summary                 = 'Swift Extensions for Google Cloud Firestore for iOS'
+  s.summary                 = 'Swift Extensions for Google Cloud Firestore'
 
   s.description      = <<-DESC
 Google Cloud Firestore is a NoSQL document database built for automatic scaling, high performance, and ease of application development.

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseFunctions'
   s.version          = '2.5.1'
-  s.summary          = 'Cloud Functions for Firebase iOS SDK.'
+  s.summary          = 'Cloud Functions for Firebase'
 
   s.description      = <<-DESC
-iOS SDK for Cloud Functions for Firebase.
+Cloud Functions for Firebase.
                        DESC
 
   s.homepage         = 'https://developers.google.com/'

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInstallations'
   s.version          = '1.1.1'
-  s.summary          = 'Firebase Installations for iOS'
+  s.summary          = 'Firebase Installations'
 
   s.description      = <<-DESC
-  Firebase Installations for iOS.
+  Firebase Installations.
                        DESC
 
   s.homepage         = 'https://firebase.google.com'

--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInstanceID'
   s.version          = '4.3.2'
-  s.summary          = 'Firebase InstanceID for iOS'
+  s.summary          = 'Firebase InstanceID'
 
   s.description      = <<-DESC
 Instance ID provides a unique ID per instance of your iOS apps. In addition to providing
-unique IDs for authentication,Instance ID can generate security tokens for use with other
+unique IDs for authentication, Instance ID can generate security tokens for use with other
 services.
                        DESC
 

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseMessaging'
   s.version          = '4.3.0'
-  s.summary          = 'Firebase Messaging for iOS'
+  s.summary          = 'Firebase Messaging'
 
   s.description      = <<-DESC
-Firebase Messaging for iOS is a service that allows you to send data from your server to your users'
+Firebase Messaging is a service that allows you to send data from your server to your users'
 iOS device, and also to receive messages from devices on the same connection. The service handles
-all aspects of queueing of messages and delivery to the target iOS application running on the target
+all aspects of queueing of messages and delivery to the target application running on the target
 device, and it is completely free.
                        DESC
 

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseRemoteConfig'
   s.version          = '4.4.9'
-  s.summary          = 'Firebase RemoteConfig for iOS'
+  s.summary          = 'Firebase RemoteConfig'
 
   s.description      = <<-DESC
 Firebase Remote Config is a cloud service that lets you change the

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseRemoteConfig'
   s.version          = '4.4.9'
-  s.summary          = 'Firebase RemoteConfig'
+  s.summary          = 'Firebase Remote Config'
 
   s.description      = <<-DESC
 Firebase Remote Config is a cloud service that lets you change the

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseStorage'
   s.version          = '3.6.0'
-  s.summary          = 'Firebase Storage for iOS (plus community support for macOS and tvOS)'
+  s.summary          = 'Firebase Storage'
 
   s.description      = <<-DESC
 Firebase Storage provides robust, secure file uploads and downloads from Firebase SDKs, powered by Google Cloud Storage.


### PR DESCRIPTION
Remove most platform references from podspec summaries and descriptions.

These haven't been kept up-to-date and are better documented by the podspec platform specifications themselves and the repo README.