### PR TITLE
Update GDT dependencies for Crashlytics

### DIFF
--- a/Crashlytics/Protogen/nanopb/crashlytics.nanopb.c
+++ b/Crashlytics/Protogen/nanopb/crashlytics.nanopb.c
@@ -54,6 +54,7 @@ const pb_field_t google_crashlytics_FilesPayload_File_fields[3] = {
 #if !defined(PB_FIELD_32BIT)
 /* If you get an error here, it means that you need to define PB_FIELD_32BIT
  * compile-time option. You can do that in pb.h or on compiler command line.
+ * 
  * The reason you need to do this is that some of your messages contain tag
  * numbers or field sizes that are larger than what can fit in 8 or 16 bit
  * field descriptors.
@@ -64,6 +65,7 @@ PB_STATIC_ASSERT((pb_membersize(google_crashlytics_Report, apple_payload) < 6553
 #if !defined(PB_FIELD_16BIT) && !defined(PB_FIELD_32BIT)
 /* If you get an error here, it means that you need to define PB_FIELD_16BIT
  * compile-time option. You can do that in pb.h or on compiler command line.
+ * 
  * The reason you need to do this is that some of your messages contain tag
  * numbers or field sizes that are larger than what can fit in the default
  * 8 bit descriptors.

--- a/Crashlytics/Protogen/nanopb/crashlytics.nanopb.c
+++ b/Crashlytics/Protogen/nanopb/crashlytics.nanopb.c
@@ -54,7 +54,6 @@ const pb_field_t google_crashlytics_FilesPayload_File_fields[3] = {
 #if !defined(PB_FIELD_32BIT)
 /* If you get an error here, it means that you need to define PB_FIELD_32BIT
  * compile-time option. You can do that in pb.h or on compiler command line.
- * 
  * The reason you need to do this is that some of your messages contain tag
  * numbers or field sizes that are larger than what can fit in 8 or 16 bit
  * field descriptors.
@@ -65,7 +64,6 @@ PB_STATIC_ASSERT((pb_membersize(google_crashlytics_Report, apple_payload) < 6553
 #if !defined(PB_FIELD_16BIT) && !defined(PB_FIELD_32BIT)
 /* If you get an error here, it means that you need to define PB_FIELD_16BIT
  * compile-time option. You can do that in pb.h or on compiler command line.
- * 
  * The reason you need to do this is that some of your messages contain tag
  * numbers or field sizes that are larger than what can fit in the default
  * 8 bit descriptors.

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -45,8 +45,8 @@ Pod::Spec.new do |s|
   s.dependency 'FirebaseInstallations', '~> 1.1'
   s.dependency 'FirebaseAnalyticsInterop', '~> 1.2'
   s.dependency 'PromisesObjC', '~> 1.2'
-  s.dependency 'GoogleDataTransport', '~> 5.1'
-  s.dependency 'GoogleDataTransportCCTSupport', '~> 2.0', '>= 2.0.1'
+  s.dependency 'GoogleDataTransport', '~> 5.1', '>= 5.1.1'
+  s.dependency 'GoogleDataTransportCCTSupport', '~> 2.0', '>= 2.0.2'
   s.dependency 'nanopb', '~> 0.3.901'
 
   s.libraries = 'c++', 'z'

--- a/GoogleDataTransport.podspec
+++ b/GoogleDataTransport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleDataTransport'
-  s.version          = '5.1.0'
+  s.version          = '5.1.1'
   s.summary          = 'Google iOS SDK data transport.'
 
   s.description      = <<-DESC

--- a/GoogleDataTransportCCTSupport.podspec
+++ b/GoogleDataTransportCCTSupport.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'GoogleDataTransportCCTSupport'
-  s.version          = '2.0.1'
+  s.version          = '2.0.2'
   s.summary          = 'Support library for the GoogleDataTransport CCT backend target.'
 
 


### PR DESCRIPTION
 GoogleDataTransport >= 5.1.1
GoogleDataTransportCCTSupport >= 2.0.2

 #no-changelog