### PR TITLE
Trigger settings call even when build version changes without the code changing

### DIFF
--- a/Crashlytics/Crashlytics/Settings/Models/FIRCLSApplicationIdentifierModel.m
+++ b/Crashlytics/Crashlytics/Settings/Models/FIRCLSApplicationIdentifierModel.m
@@ -67,7 +67,7 @@
 }
 
 - (NSString *)synthesizedVersion {
-  return [NSString stringWithFormat:@"%@ (%@)", self.displayName, self.buildVersion];
+  return [NSString stringWithFormat:@"%@ (%@)", self.displayVersion, self.buildVersion];
 }
 
 - (FIRCLSApplicationInstallationSourceType)installSource {


### PR DESCRIPTION
The settings call is needed so the SDK knows that an app update needs to happen.