### PR TITLE
Add API docs for FirebaseStorageSwift

### DIFF
--- a/FirebaseStorageSwift/Sources/SwiftAPIExtension.swift
+++ b/FirebaseStorageSwift/Sources/SwiftAPIExtension.swift
@@ -42,7 +42,7 @@ public extension StorageReference {
 
    - Parameters:
      - completion: A completion block returning a Result enum with either a URL or an NSError.
-  */
+   */
   func downloadURL(completion: @escaping (Result<URL, Error>) -> Void) {
     downloadURL(completion: getResultCallback(completion: completion))
   }
@@ -58,7 +58,7 @@ public extension StorageReference {
                    an NSError.
 
    - Returns: A StorageDownloadTask that can be used to monitor or manage the download.
-  */
+   */
   func getData(maxSize: Int64, completion: @escaping (Result<Data, Error>) -> Void)
     -> StorageDownloadTask {
     return getData(maxSize: maxSize, completion: getResultCallback(completion: completion))
@@ -70,7 +70,7 @@ public extension StorageReference {
    - Parameters:
      - completion: A completion block which returns a Result enum with either the
                    object metadata or an NSError.
-  */
+   */
   func getMetadata(completion: @escaping (Result<StorageMetadata, Error>) -> Void) {
     getMetadata(completion: getResultCallback(completion: completion))
   }
@@ -92,7 +92,7 @@ public extension StorageReference {
      - completion A completion handler that will be invoked with the next items and
                   prefixes under the current StorageReference. It returns a Result enum
                   with either the list or an NSError.
-  */
+   */
   func list(withMaxResults maxResults: Int64,
             pageToken: String,
             completion: @escaping (Result<StorageListResult, Error>) -> Void) {
@@ -102,21 +102,21 @@ public extension StorageReference {
   }
 
   /**
-   List up to `maxResults` items (files) and prefixes (folders) under this StorageReference.
+    List up to `maxResults` items (files) and prefixes (folders) under this StorageReference.
 
-   "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
-   paths that end with "/" or contain two consecutive "/"s. All invalid objects in GCS will be
-   filtered.
+    "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
+    paths that end with "/" or contain two consecutive "/"s. All invalid objects in GCS will be
+    filtered.
 
-  Only available for projects using Firebase Rules Version 2.
+   Only available for projects using Firebase Rules Version 2.
 
-  - Parameters:
-    - withMaxResults The maximum number of results to return in a single page. Must be
-                     greater than 0 and at most 1000.
-    - completion A completion handler that will be invoked with the next items and
-                 prefixes under the current StorageReference. It returns a Result enum
-                 with either the list or an NSError.
-  */
+   - Parameters:
+     - withMaxResults The maximum number of results to return in a single page. Must be
+                      greater than 0 and at most 1000.
+     - completion A completion handler that will be invoked with the next items and
+                  prefixes under the current StorageReference. It returns a Result enum
+                  with either the list or an NSError.
+   */
   func list(withMaxResults maxResults: Int64,
             completion: @escaping (Result<StorageListResult, Error>) -> Void) {
     list(withMaxResults: maxResults,
@@ -136,7 +136,7 @@ public extension StorageReference {
      - completion A completion handler that will be invoked with all items and prefixes
                   under the current StorageReference. It returns a Result enum with either the
                   list or an NSError.
-  */
+   */
   func listAll(completion: @escaping (Result<StorageListResult, Error>) -> Void) {
     listAll(completion: getResultCallback(completion: completion))
   }
@@ -154,7 +154,7 @@ public extension StorageReference {
 
    - Returns: An instance of FIRStorageUploadTask, which can be used to monitor or manage
               the upload.
-  */
+   */
   func putData(_ uploadData: Data,
                metadata: StorageMetadata? = nil,
                completion: @escaping (Result<StorageMetadata, Error>) -> Void)
@@ -165,18 +165,18 @@ public extension StorageReference {
   }
 
   /**
-   Asynchronously uploads a file to the currently specified FIRStorageReference.
+    Asynchronously uploads a file to the currently specified FIRStorageReference.
 
-   - Parameters:
-     - from A URL representing the system file path of the object to be uploaded.
-     - metadata StorageMetadata containing additional information (MIME type, etc.)
-                about the object being uploaded.
-     - completion A completion block that returns a Result enum with either the
-                  object metadata or an NSError.
+    - Parameters:
+      - from A URL representing the system file path of the object to be uploaded.
+      - metadata StorageMetadata containing additional information (MIME type, etc.)
+                 about the object being uploaded.
+      - completion A completion block that returns a Result enum with either the
+                   object metadata or an NSError.
 
-  - Returns: An instance of FIRStorageUploadTask, which can be used to monitor or manage
-             the upload.
-  */
+   - Returns: An instance of FIRStorageUploadTask, which can be used to monitor or manage
+              the upload.
+   */
   func putFile(from: URL,
                metadata: StorageMetadata? = nil,
                completion: @escaping (Result<StorageMetadata, Error>) -> Void)
@@ -193,7 +193,7 @@ public extension StorageReference {
      - metadata An StorageMetadata object with the metadata to update.
      - completion A completion block which returns a Result enum with either the
                   object metadata or an NSError.
-  */
+   */
   func updateMetadata(_ metadata: StorageMetadata,
                       completion: @escaping (Result<StorageMetadata, Error>) -> Void) {
     return updateMetadata(metadata, completion: getResultCallback(completion: completion))
@@ -208,8 +208,8 @@ public extension StorageReference {
                   block returns a Result enum with either an NSURL pointing to the file
                   path of the downloaded file or an NSError.
 
-  - Returns: A StorageDownloadTask that can be used to monitor or manage the download.
-  */
+   - Returns: A StorageDownloadTask that can be used to monitor or manage the download.
+   */
   func write(toFile: URL, completion: @escaping (Result<URL, Error>)
     -> Void) -> StorageDownloadTask {
     return write(toFile: toFile, completion: getResultCallback(completion: completion))

--- a/FirebaseStorageSwift/Sources/SwiftAPIExtension.swift
+++ b/FirebaseStorageSwift/Sources/SwiftAPIExtension.swift
@@ -14,13 +14,13 @@
 
 import FirebaseStorage
 
-/// Generates a closure that returns a Result type from a closure that returns an optional type and
-/// Error.
+/// Generates a closure that returns a `Result` type from a closure that returns an optional type
+/// and `Error`.
 ///
 /// - Parameters:
-///   - completion: A completion block returning a Result enum with either a generic object or
-///                 an NSError.
-/// - Returns: A closure parameterized with an optional generic and optional Error to match
+///   - completion: A completion block returning a `Result` enum with either a generic object or
+///                 an `Error`.
+/// - Returns: A closure parameterized with an optional generic and optional `Error` to match
 ///            Objective C APIs.
 private func getResultCallback<T>(
   completion: @escaping (Result<T, Error>) -> Void
@@ -46,19 +46,19 @@ public extension StorageReference {
   /// in the Firebase Console if desired.
   ///
   /// - Parameters:
-  ///   - completion: A completion block returning a Result enum with either a URL or an NSError.
+  ///   - completion: A completion block returning a `Result` enum with either a URL or an `Error`.
   func downloadURL(completion: @escaping (Result<URL, Error>) -> Void) {
     downloadURL(completion: getResultCallback(completion: completion))
   }
 
-  /// Asynchronously downloads the object at the FIRStorageReference to a Data object.
-  /// A Data of the provided max size will be allocated, so ensure that the device has enough
+  /// Asynchronously downloads the object at the `StorageReference` to a `Data` object.
+  /// A `Data` of the provided max size will be allocated, so ensure that the device has enough
   /// memory to complete. For downloading large files, writeToFile may be a better option.
 
   /// - Parameters:
   ///   - maxSize: The maximum size in bytes to download.
-  ///   - completion: A completion block returning a Result enum with either a Data object or
-  ///                 an NSError.
+  ///   - completion: A completion block returning a `Result` enum with either a `Data` object or
+  ///                 an `Error`.
   ///
   /// - Returns: A StorageDownloadTask that can be used to monitor or manage the download.
   func getData(maxSize: Int64, completion: @escaping (Result<Data, Error>) -> Void)
@@ -69,8 +69,8 @@ public extension StorageReference {
   /// Retrieves metadata associated with an object at the current path.
   ///
   /// - Parameters:
-  ///   - completion: A completion block which returns a Result enum with either the
-  ///                 object metadata or an NSError.
+  ///   - completion: A completion block which returns a `Result` enum with either the
+  ///                 object metadata or an `Error`.
   func getMetadata(completion: @escaping (Result<StorageMetadata, Error>) -> Void) {
     getMetadata(completion: getResultCallback(completion: completion))
   }
@@ -89,8 +89,8 @@ public extension StorageReference {
   ///                    greater than 0 and at most 1000.
   ///   - pageToken A page token from a previous call to list.
   ///   - completion A completion handler that will be invoked with the next items and
-  ///                prefixes under the current StorageReference. It returns a Result enum
-  ///                with either the list or an NSError.
+  ///                prefixes under the current StorageReference. It returns a `Result` enum
+  ///                with either the list or an `Error`.
   func list(withMaxResults maxResults: Int64,
             pageToken: String,
             completion: @escaping (Result<StorageListResult, Error>) -> Void) {
@@ -111,8 +111,8 @@ public extension StorageReference {
   ///   - withMaxResults The maximum number of results to return in a single page. Must be
   ///                    greater than 0 and at most 1000.
   ///   - completion A completion handler that will be invoked with the next items and
-  ///                prefixes under the current StorageReference. It returns a Result enum
-  ///                with either the list or an NSError.
+  ///                prefixes under the current `StorageReference`. It returns a `Result` enum
+  ///                with either the list or an `Error`.
   func list(withMaxResults maxResults: Int64,
             completion: @escaping (Result<StorageListResult, Error>) -> Void) {
     list(withMaxResults: maxResults,
@@ -129,23 +129,23 @@ public extension StorageReference {
   ///
   /// - Parameters:
   ///   - completion A completion handler that will be invoked with all items and prefixes
-  ///                under the current StorageReference. It returns a Result enum with either the
-  ///                list or an NSError.
+  ///                under the current StorageReference. It returns a `Result` enum with either the
+  ///                list or an `Error`.
   func listAll(completion: @escaping (Result<StorageListResult, Error>) -> Void) {
     listAll(completion: getResultCallback(completion: completion))
   }
 
-  /// Asynchronously uploads data to the currently specified FIRStorageReference.
+  /// Asynchronously uploads data to the currently specified `StorageReference`.
   /// This is not recommended for large files, and one should instead upload a file from disk.
   ///
   /// - Parameters:
-  ///   - uploadData The Data to upload.
-  ///   - metadata StorageMetadata containing additional information (MIME type, etc.)
+  ///   - uploadData The `Data` to upload.
+  ///   - metadata `StorageMetadata` containing additional information (MIME type, etc.)
   ///              about the object being uploaded.
-  ///   - completion A completion block that returns a Result enum with either the
-  ///                object metadata or an NSError.
+  ///   - completion A completion block that returns a `Result` enum with either the
+  ///                object metadata or an `Error`.
   ///
-  /// - Returns: An instance of FIRStorageUploadTask, which can be used to monitor or manage
+  /// - Returns: An instance of `StorageUploadTask`, which can be used to monitor or manage
   ///            the upload.
   func putData(_ uploadData: Data,
                metadata: StorageMetadata? = nil,
@@ -156,16 +156,16 @@ public extension StorageReference {
                    completion: getResultCallback(completion: completion))
   }
 
-  /// Asynchronously uploads a file to the currently specified FIRStorageReference.
+  /// Asynchronously uploads a file to the currently specified `StorageReference`.
   ///
   /// - Parameters:
   ///   - from A URL representing the system file path of the object to be uploaded.
-  ///   - metadata StorageMetadata containing additional information (MIME type, etc.)
+  ///   - metadata `StorageMetadata` containing additional information (MIME type, etc.)
   ///              about the object being uploaded.
-  ///   - completion A completion block that returns a Result enum with either the
-  ///                object metadata or an NSError.
+  ///   - completion A completion block that returns a `Result` enum with either the
+  ///                object metadata or an `Error`.
   ///
-  /// - Returns: An instance of FIRStorageUploadTask, which can be used to monitor or manage
+  /// - Returns: An instance of `StorageUploadTask`, which can be used to monitor or manage
   ///            the upload.
   func putFile(from: URL,
                metadata: StorageMetadata? = nil,
@@ -179,9 +179,9 @@ public extension StorageReference {
   /// Updates the metadata associated with an object at the current path.
   ///
   /// - Parameters:
-  ///   - metadata An StorageMetadata object with the metadata to update.
-  ///   - completion A completion block which returns a Result enum with either the
-  ///                object metadata or an NSError.
+  ///   - metadata A `StorageMetadata` object with the metadata to update.
+  ///   - completion A completion block which returns a `Result` enum with either the
+  ///                object metadata or an `Error`.
   func updateMetadata(_ metadata: StorageMetadata,
                       completion: @escaping (Result<StorageMetadata, Error>) -> Void) {
     return updateMetadata(metadata, completion: getResultCallback(completion: completion))
@@ -192,10 +192,10 @@ public extension StorageReference {
   /// - Parameters:
   ///   - toFile A file system URL representing the path the object should be downloaded to.
   ///   - completion A completion block that fires when the file download completes. The
-  ///                block returns a Result enum with either an NSURL pointing to the file
-  ///                path of the downloaded file or an NSError.
+  ///                block returns a `Result` enum with either an NSURL pointing to the file
+  ///                path of the downloaded file or an `Error`.
   ///
-  /// - Returns: A StorageDownloadTask that can be used to monitor or manage the download.
+  /// - Returns: A `StorageDownloadTask` that can be used to monitor or manage the download.
   func write(toFile: URL, completion: @escaping (Result<URL, Error>)
     -> Void) -> StorageDownloadTask {
     return write(toFile: toFile, completion: getResultCallback(completion: completion))

--- a/FirebaseStorageSwift/Sources/SwiftAPIExtension.swift
+++ b/FirebaseStorageSwift/Sources/SwiftAPIExtension.swift
@@ -35,19 +35,64 @@ private func getResultCallback<T>(
 }
 
 public extension StorageReference {
+  /**
+   Asynchronously retrieves a long lived download URL with a revokable token.
+   This can be used to share the file with others, but can be revoked by a developer
+   in the Firebase Console if desired.
+
+   - Parameters:
+     - completion: A completion block returning a Result enum with either a URL or an NSError.
+  */
   func downloadURL(completion: @escaping (Result<URL, Error>) -> Void) {
     downloadURL(completion: getResultCallback(completion: completion))
   }
 
+  /**
+   Asynchronously downloads the object at the FIRStorageReference to a Data object.
+   A Data of the provided max size will be allocated, so ensure that the device has enough
+   memory to complete. For downloading large files, writeToFile may be a better option.
+
+   - Parameters:
+     - maxSize: The maximum size in bytes to download.
+     - completion: A completion block returning a Result enum with either a Data object or
+                   an NSError.
+
+   - Returns: A StorageDownloadTask that can be used to monitor or manage the download.
+  */
   func getData(maxSize: Int64, completion: @escaping (Result<Data, Error>) -> Void)
     -> StorageDownloadTask {
     return getData(maxSize: maxSize, completion: getResultCallback(completion: completion))
   }
 
+  /**
+   Retrieves metadata associated with an object at the current path.
+
+   - Parameters:
+     - completion: A completion block which returns a Result enum with either the
+                   object metadata or an NSError.
+  */
   func getMetadata(completion: @escaping (Result<StorageMetadata, Error>) -> Void) {
     getMetadata(completion: getResultCallback(completion: completion))
   }
 
+  /**
+   Resumes a previous `list` call, starting after a pagination token.
+   Returns the next set of items (files) and prefixes (folders) under this StorageReference.
+
+   "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
+   paths that end with "/" or contain two consecutive "/"s. All invalid objects in GCS will be
+   filtered.
+
+   Only available for projects using Firebase Rules Version 2.
+
+   - Parameters:
+     - withMaxResults The maximum number of results to return in a single page. Must be
+                      greater than 0 and at most 1000.
+     - pageToken A page token from a previous call to list.
+     - completion A completion handler that will be invoked with the next items and
+                  prefixes under the current StorageReference. It returns a Result enum
+                  with either the list or an NSError.
+  */
   func list(withMaxResults maxResults: Int64,
             pageToken: String,
             completion: @escaping (Result<StorageListResult, Error>) -> Void) {
@@ -56,16 +101,60 @@ public extension StorageReference {
          completion: getResultCallback(completion: completion))
   }
 
+  /**
+   List up to `maxResults` items (files) and prefixes (folders) under this StorageReference.
+
+   "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
+   paths that end with "/" or contain two consecutive "/"s. All invalid objects in GCS will be
+   filtered.
+
+  Only available for projects using Firebase Rules Version 2.
+
+  - Parameters:
+    - withMaxResults The maximum number of results to return in a single page. Must be
+                     greater than 0 and at most 1000.
+    - completion A completion handler that will be invoked with the next items and
+                 prefixes under the current StorageReference. It returns a Result enum
+                 with either the list or an NSError.
+  */
   func list(withMaxResults maxResults: Int64,
             completion: @escaping (Result<StorageListResult, Error>) -> Void) {
     list(withMaxResults: maxResults,
          completion: getResultCallback(completion: completion))
   }
 
+  /**
+   List all items (files) and prefixes (folders) under this StorageReference.
+
+   This is a helper method for calling list() repeatedly until there are no more results.
+   Consistency of the result is not guaranteed if objects are inserted or removed while this
+   operation is executing. All results are buffered in memory.
+
+   Only available for projects using Firebase Rules Version 2.
+
+   - Parameters:
+     - completion A completion handler that will be invoked with all items and prefixes
+                  under the current StorageReference. It returns a Result enum with either the
+                  list or an NSError.
+  */
   func listAll(completion: @escaping (Result<StorageListResult, Error>) -> Void) {
     listAll(completion: getResultCallback(completion: completion))
   }
 
+  /**
+   Asynchronously uploads data to the currently specified FIRStorageReference.
+   This is not recommended for large files, and one should instead upload a file from disk.
+
+   - Parameters:
+     - uploadData The Data to upload.
+     - metadata StorageMetadata containing additional information (MIME type, etc.)
+                about the object being uploaded.
+     - completion A completion block that returns a Result enum with either the
+                  object metadata or an NSError.
+
+   - Returns: An instance of FIRStorageUploadTask, which can be used to monitor or manage
+              the upload.
+  */
   func putData(_ uploadData: Data,
                metadata: StorageMetadata? = nil,
                completion: @escaping (Result<StorageMetadata, Error>) -> Void)
@@ -75,6 +164,19 @@ public extension StorageReference {
                    completion: getResultCallback(completion: completion))
   }
 
+  /**
+   Asynchronously uploads a file to the currently specified FIRStorageReference.
+
+   - Parameters:
+     - from A URL representing the system file path of the object to be uploaded.
+     - metadata StorageMetadata containing additional information (MIME type, etc.)
+                about the object being uploaded.
+     - completion A completion block that returns a Result enum with either the
+                  object metadata or an NSError.
+
+  - Returns: An instance of FIRStorageUploadTask, which can be used to monitor or manage
+             the upload.
+  */
   func putFile(from: URL,
                metadata: StorageMetadata? = nil,
                completion: @escaping (Result<StorageMetadata, Error>) -> Void)
@@ -84,11 +186,30 @@ public extension StorageReference {
                    completion: getResultCallback(completion: completion))
   }
 
+  /**
+   Updates the metadata associated with an object at the current path.
+
+   - Parameters:
+     - metadata An StorageMetadata object with the metadata to update.
+     - completion A completion block which returns a Result enum with either the
+                  object metadata or an NSError.
+  */
   func updateMetadata(_ metadata: StorageMetadata,
                       completion: @escaping (Result<StorageMetadata, Error>) -> Void) {
     return updateMetadata(metadata, completion: getResultCallback(completion: completion))
   }
 
+  /**
+   Asynchronously downloads the object at the current path to a specified system filepath.
+
+   - Parameters:
+     - toFile A file system URL representing the path the object should be downloaded to.
+     - completion A completion block that fires when the file download completes. The
+                  block returns a Result enum with either an NSURL pointing to the file
+                  path of the downloaded file or an NSError.
+
+  - Returns: A StorageDownloadTask that can be used to monitor or manage the download.
+  */
   func write(toFile: URL, completion: @escaping (Result<URL, Error>)
     -> Void) -> StorageDownloadTask {
     return write(toFile: toFile, completion: getResultCallback(completion: completion))

--- a/FirebaseStorageSwift/Sources/SwiftAPIExtension.swift
+++ b/FirebaseStorageSwift/Sources/SwiftAPIExtension.swift
@@ -14,8 +14,8 @@
 
 import FirebaseStorage
 
-/// getResultCallback generates a closure that returns a Result type from a closure that returns an
-/// optional type and Error.
+///  getResultCallback generates a closure that returns a Result type from a closure that returns an
+///  optional type and Error.
 private func getResultCallback<T>(
   completion: @escaping (Result<T, Error>) -> Void
 ) -> (_: T?, _: Error?) -> Void {
@@ -35,64 +35,56 @@ private func getResultCallback<T>(
 }
 
 public extension StorageReference {
-  /**
-   Asynchronously retrieves a long lived download URL with a revokable token.
-   This can be used to share the file with others, but can be revoked by a developer
-   in the Firebase Console if desired.
-
-   - Parameters:
-     - completion: A completion block returning a Result enum with either a URL or an NSError.
-   */
+  /// Asynchronously retrieves a long lived download URL with a revokable token.
+  /// This can be used to share the file with others, but can be revoked by a developer
+  /// in the Firebase Console if desired.
+  ///
+  /// - Parameters:
+  ///   - completion: A completion block returning a Result enum with either a URL or an NSError.
   func downloadURL(completion: @escaping (Result<URL, Error>) -> Void) {
     downloadURL(completion: getResultCallback(completion: completion))
   }
 
-  /**
-   Asynchronously downloads the object at the FIRStorageReference to a Data object.
-   A Data of the provided max size will be allocated, so ensure that the device has enough
-   memory to complete. For downloading large files, writeToFile may be a better option.
+  ///  Asynchronously downloads the object at the FIRStorageReference to a Data object.
+  ///  A Data of the provided max size will be allocated, so ensure that the device has enough
+  ///  memory to complete. For downloading large files, writeToFile may be a better option.
 
-   - Parameters:
-     - maxSize: The maximum size in bytes to download.
-     - completion: A completion block returning a Result enum with either a Data object or
-                   an NSError.
-
-   - Returns: A StorageDownloadTask that can be used to monitor or manage the download.
-   */
+  ///  - Parameters:
+  ///    - maxSize: The maximum size in bytes to download.
+  ///    - completion: A completion block returning a Result enum with either a Data object or
+  ///                  an NSError.
+  ///
+  ///  - Returns: A StorageDownloadTask that can be used to monitor or manage the download.
   func getData(maxSize: Int64, completion: @escaping (Result<Data, Error>) -> Void)
     -> StorageDownloadTask {
     return getData(maxSize: maxSize, completion: getResultCallback(completion: completion))
   }
 
-  /**
-   Retrieves metadata associated with an object at the current path.
-
-   - Parameters:
-     - completion: A completion block which returns a Result enum with either the
-                   object metadata or an NSError.
-   */
+  ///  Retrieves metadata associated with an object at the current path.
+  ///
+  ///  - Parameters:
+  ///   - completion: A completion block which returns a Result enum with either the
+  ///                 object metadata or an NSError.
   func getMetadata(completion: @escaping (Result<StorageMetadata, Error>) -> Void) {
     getMetadata(completion: getResultCallback(completion: completion))
   }
 
-  /**
-   Resumes a previous `list` call, starting after a pagination token.
-   Returns the next set of items (files) and prefixes (folders) under this StorageReference.
-
-   "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
-   paths that end with "/" or contain two consecutive "/"s. All invalid objects in GCS will be
-   filtered.
-
-   Only available for projects using Firebase Rules Version 2.
-
-   - Parameters:
-     - withMaxResults The maximum number of results to return in a single page. Must be
-                      greater than 0 and at most 1000.
-     - pageToken A page token from a previous call to list.
-     - completion A completion handler that will be invoked with the next items and
-                  prefixes under the current StorageReference. It returns a Result enum
-                  with either the list or an NSError.
-   */
+  ///  Resumes a previous `list` call, starting after a pagination token.
+  ///  Returns the next set of items (files) and prefixes (folders) under this StorageReference.
+  ///
+  /// "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
+  ///  paths that end with "/" or contain two consecutive "/"s. All invalid objects in GCS will be
+  ///  filtered.
+  ///
+  ///  Only available for projects using Firebase Rules Version 2.
+  ///
+  ///  - Parameters:
+  ///    - withMaxResults The maximum number of results to return in a single page. Must be
+  ///                     greater than 0 and at most 1000.
+  ///    - pageToken A page token from a previous call to list.
+  ///    - completion A completion handler that will be invoked with the next items and
+  ///                 prefixes under the current StorageReference. It returns a Result enum
+  ///                 with either the list or an NSError.
   func list(withMaxResults maxResults: Int64,
             pageToken: String,
             completion: @escaping (Result<StorageListResult, Error>) -> Void) {
@@ -101,60 +93,54 @@ public extension StorageReference {
          completion: getResultCallback(completion: completion))
   }
 
-  /**
-    List up to `maxResults` items (files) and prefixes (folders) under this StorageReference.
-
-    "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
-    paths that end with "/" or contain two consecutive "/"s. All invalid objects in GCS will be
-    filtered.
-
-   Only available for projects using Firebase Rules Version 2.
-
-   - Parameters:
-     - withMaxResults The maximum number of results to return in a single page. Must be
-                      greater than 0 and at most 1000.
-     - completion A completion handler that will be invoked with the next items and
-                  prefixes under the current StorageReference. It returns a Result enum
-                  with either the list or an NSError.
-   */
+  ///   List up to `maxResults` items (files) and prefixes (folders) under this StorageReference.
+  ///
+  ///   "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
+  ///   paths that end with "/" or contain two consecutive "/"s. All invalid objects in GCS will be
+  ///   filtered.
+  ///
+  ///  Only available for projects using Firebase Rules Version 2.
+  ///
+  ///  - Parameters:
+  ///    - withMaxResults The maximum number of results to return in a single page. Must be
+  ///                     greater than 0 and at most 1000.
+  ///    - completion A completion handler that will be invoked with the next items and
+  ///                 prefixes under the current StorageReference. It returns a Result enum
+  ///                 with either the list or an NSError.
   func list(withMaxResults maxResults: Int64,
             completion: @escaping (Result<StorageListResult, Error>) -> Void) {
     list(withMaxResults: maxResults,
          completion: getResultCallback(completion: completion))
   }
 
-  /**
-   List all items (files) and prefixes (folders) under this StorageReference.
-
-   This is a helper method for calling list() repeatedly until there are no more results.
-   Consistency of the result is not guaranteed if objects are inserted or removed while this
-   operation is executing. All results are buffered in memory.
-
-   Only available for projects using Firebase Rules Version 2.
-
-   - Parameters:
-     - completion A completion handler that will be invoked with all items and prefixes
-                  under the current StorageReference. It returns a Result enum with either the
-                  list or an NSError.
-   */
+  ///  List all items (files) and prefixes (folders) under this StorageReference.
+  ///
+  ///  This is a helper method for calling list() repeatedly until there are no more results.
+  ///  Consistency of the result is not guaranteed if objects are inserted or removed while this
+  ///  operation is executing. All results are buffered in memory.
+  ///
+  ///  Only available for projects using Firebase Rules Version 2.
+  ///
+  ///  - Parameters:
+  ///    - completion A completion handler that will be invoked with all items and prefixes
+  ///                 under the current StorageReference. It returns a Result enum with either the
+  ///                 list or an NSError.
   func listAll(completion: @escaping (Result<StorageListResult, Error>) -> Void) {
     listAll(completion: getResultCallback(completion: completion))
   }
 
-  /**
-   Asynchronously uploads data to the currently specified FIRStorageReference.
-   This is not recommended for large files, and one should instead upload a file from disk.
-
-   - Parameters:
-     - uploadData The Data to upload.
-     - metadata StorageMetadata containing additional information (MIME type, etc.)
-                about the object being uploaded.
-     - completion A completion block that returns a Result enum with either the
-                  object metadata or an NSError.
-
-   - Returns: An instance of FIRStorageUploadTask, which can be used to monitor or manage
-              the upload.
-   */
+  ///  Asynchronously uploads data to the currently specified FIRStorageReference.
+  ///  This is not recommended for large files, and one should instead upload a file from disk.
+  ///
+  ///  - Parameters:
+  ///    - uploadData The Data to upload.
+  ///    - metadata StorageMetadata containing additional information (MIME type, etc.)
+  ///               about the object being uploaded.
+  ///    - completion A completion block that returns a Result enum with either the
+  ///                 object metadata or an NSError.
+  ///
+  ///  - Returns: An instance of FIRStorageUploadTask, which can be used to monitor or manage
+  ///             the upload.
   func putData(_ uploadData: Data,
                metadata: StorageMetadata? = nil,
                completion: @escaping (Result<StorageMetadata, Error>) -> Void)
@@ -164,19 +150,17 @@ public extension StorageReference {
                    completion: getResultCallback(completion: completion))
   }
 
-  /**
-    Asynchronously uploads a file to the currently specified FIRStorageReference.
-
-    - Parameters:
-      - from A URL representing the system file path of the object to be uploaded.
-      - metadata StorageMetadata containing additional information (MIME type, etc.)
-                 about the object being uploaded.
-      - completion A completion block that returns a Result enum with either the
-                   object metadata or an NSError.
-
-   - Returns: An instance of FIRStorageUploadTask, which can be used to monitor or manage
-              the upload.
-   */
+  ///   Asynchronously uploads a file to the currently specified FIRStorageReference.
+  ///
+  ///   - Parameters:
+  ///     - from A URL representing the system file path of the object to be uploaded.
+  ///     - metadata StorageMetadata containing additional information (MIME type, etc.)
+  ///                about the object being uploaded.
+  ///     - completion A completion block that returns a Result enum with either the
+  ///                  object metadata or an NSError.
+  ///
+  ///  - Returns: An instance of FIRStorageUploadTask, which can be used to monitor or manage
+  ///             the upload.
   func putFile(from: URL,
                metadata: StorageMetadata? = nil,
                completion: @escaping (Result<StorageMetadata, Error>) -> Void)
@@ -186,30 +170,26 @@ public extension StorageReference {
                    completion: getResultCallback(completion: completion))
   }
 
-  /**
-   Updates the metadata associated with an object at the current path.
-
-   - Parameters:
-     - metadata An StorageMetadata object with the metadata to update.
-     - completion A completion block which returns a Result enum with either the
-                  object metadata or an NSError.
-   */
+  ///  Updates the metadata associated with an object at the current path.
+  ///
+  ///  - Parameters:
+  ///    - metadata An StorageMetadata object with the metadata to update.
+  ///    - completion A completion block which returns a Result enum with either the
+  ///                 object metadata or an NSError.
   func updateMetadata(_ metadata: StorageMetadata,
                       completion: @escaping (Result<StorageMetadata, Error>) -> Void) {
     return updateMetadata(metadata, completion: getResultCallback(completion: completion))
   }
 
-  /**
-   Asynchronously downloads the object at the current path to a specified system filepath.
-
-   - Parameters:
-     - toFile A file system URL representing the path the object should be downloaded to.
-     - completion A completion block that fires when the file download completes. The
-                  block returns a Result enum with either an NSURL pointing to the file
-                  path of the downloaded file or an NSError.
-
-   - Returns: A StorageDownloadTask that can be used to monitor or manage the download.
-   */
+  ///  Asynchronously downloads the object at the current path to a specified system filepath.
+  ///
+  ///  - Parameters:
+  ///    - toFile A file system URL representing the path the object should be downloaded to.
+  ///    - completion A completion block that fires when the file download completes. The
+  ///                 block returns a Result enum with either an NSURL pointing to the file
+  ///                 path of the downloaded file or an NSError.
+  ///
+  ///  - Returns: A StorageDownloadTask that can be used to monitor or manage the download.
   func write(toFile: URL, completion: @escaping (Result<URL, Error>)
     -> Void) -> StorageDownloadTask {
     return write(toFile: toFile, completion: getResultCallback(completion: completion))

--- a/FirebaseStorageSwift/Sources/SwiftAPIExtension.swift
+++ b/FirebaseStorageSwift/Sources/SwiftAPIExtension.swift
@@ -14,8 +14,14 @@
 
 import FirebaseStorage
 
-///  getResultCallback generates a closure that returns a Result type from a closure that returns an
-///  optional type and Error.
+/// Generates a closure that returns a Result type from a closure that returns an optional type and
+/// Error.
+///
+/// - Parameters:
+///   - completion: A completion block returning a Result enum with either a generic object or
+///                 an NSError.
+/// - Returns: A closure parameterized with an optional generic and optional Error to match
+///            Objective C APIs.
 private func getResultCallback<T>(
   completion: @escaping (Result<T, Error>) -> Void
 ) -> (_: T?, _: Error?) -> Void {
@@ -45,46 +51,46 @@ public extension StorageReference {
     downloadURL(completion: getResultCallback(completion: completion))
   }
 
-  ///  Asynchronously downloads the object at the FIRStorageReference to a Data object.
-  ///  A Data of the provided max size will be allocated, so ensure that the device has enough
-  ///  memory to complete. For downloading large files, writeToFile may be a better option.
+  /// Asynchronously downloads the object at the FIRStorageReference to a Data object.
+  /// A Data of the provided max size will be allocated, so ensure that the device has enough
+  /// memory to complete. For downloading large files, writeToFile may be a better option.
 
-  ///  - Parameters:
-  ///    - maxSize: The maximum size in bytes to download.
-  ///    - completion: A completion block returning a Result enum with either a Data object or
-  ///                  an NSError.
+  /// - Parameters:
+  ///   - maxSize: The maximum size in bytes to download.
+  ///   - completion: A completion block returning a Result enum with either a Data object or
+  ///                 an NSError.
   ///
-  ///  - Returns: A StorageDownloadTask that can be used to monitor or manage the download.
+  /// - Returns: A StorageDownloadTask that can be used to monitor or manage the download.
   func getData(maxSize: Int64, completion: @escaping (Result<Data, Error>) -> Void)
     -> StorageDownloadTask {
     return getData(maxSize: maxSize, completion: getResultCallback(completion: completion))
   }
 
-  ///  Retrieves metadata associated with an object at the current path.
+  /// Retrieves metadata associated with an object at the current path.
   ///
-  ///  - Parameters:
+  /// - Parameters:
   ///   - completion: A completion block which returns a Result enum with either the
   ///                 object metadata or an NSError.
   func getMetadata(completion: @escaping (Result<StorageMetadata, Error>) -> Void) {
     getMetadata(completion: getResultCallback(completion: completion))
   }
 
-  ///  Resumes a previous `list` call, starting after a pagination token.
-  ///  Returns the next set of items (files) and prefixes (folders) under this StorageReference.
+  /// Resumes a previous `list` call, starting after a pagination token.
+  /// Returns the next set of items (files) and prefixes (folders) under this StorageReference.
   ///
   /// "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
-  ///  paths that end with "/" or contain two consecutive "/"s. All invalid objects in GCS will be
-  ///  filtered.
+  /// paths that end with "/" or contain two consecutive "/"s. All invalid objects in GCS will be
+  /// filtered.
   ///
-  ///  Only available for projects using Firebase Rules Version 2.
+  /// Only available for projects using Firebase Rules Version 2.
   ///
-  ///  - Parameters:
-  ///    - withMaxResults The maximum number of results to return in a single page. Must be
-  ///                     greater than 0 and at most 1000.
-  ///    - pageToken A page token from a previous call to list.
-  ///    - completion A completion handler that will be invoked with the next items and
-  ///                 prefixes under the current StorageReference. It returns a Result enum
-  ///                 with either the list or an NSError.
+  /// - Parameters:
+  ///   - withMaxResults The maximum number of results to return in a single page. Must be
+  ///                    greater than 0 and at most 1000.
+  ///   - pageToken A page token from a previous call to list.
+  ///   - completion A completion handler that will be invoked with the next items and
+  ///                prefixes under the current StorageReference. It returns a Result enum
+  ///                with either the list or an NSError.
   func list(withMaxResults maxResults: Int64,
             pageToken: String,
             completion: @escaping (Result<StorageListResult, Error>) -> Void) {
@@ -93,54 +99,54 @@ public extension StorageReference {
          completion: getResultCallback(completion: completion))
   }
 
-  ///   List up to `maxResults` items (files) and prefixes (folders) under this StorageReference.
+  /// List up to `maxResults` items (files) and prefixes (folders) under this StorageReference.
   ///
-  ///   "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
-  ///   paths that end with "/" or contain two consecutive "/"s. All invalid objects in GCS will be
-  ///   filtered.
+  /// "/" is treated as a path delimiter. Firebase Storage does not support unsupported object
+  /// paths that end with "/" or contain two consecutive "/"s. All invalid objects in GCS will be
+  /// filtered.
   ///
-  ///  Only available for projects using Firebase Rules Version 2.
+  /// Only available for projects using Firebase Rules Version 2.
   ///
-  ///  - Parameters:
-  ///    - withMaxResults The maximum number of results to return in a single page. Must be
-  ///                     greater than 0 and at most 1000.
-  ///    - completion A completion handler that will be invoked with the next items and
-  ///                 prefixes under the current StorageReference. It returns a Result enum
-  ///                 with either the list or an NSError.
+  /// - Parameters:
+  ///   - withMaxResults The maximum number of results to return in a single page. Must be
+  ///                    greater than 0 and at most 1000.
+  ///   - completion A completion handler that will be invoked with the next items and
+  ///                prefixes under the current StorageReference. It returns a Result enum
+  ///                with either the list or an NSError.
   func list(withMaxResults maxResults: Int64,
             completion: @escaping (Result<StorageListResult, Error>) -> Void) {
     list(withMaxResults: maxResults,
          completion: getResultCallback(completion: completion))
   }
 
-  ///  List all items (files) and prefixes (folders) under this StorageReference.
+  /// List all items (files) and prefixes (folders) under this StorageReference.
   ///
-  ///  This is a helper method for calling list() repeatedly until there are no more results.
-  ///  Consistency of the result is not guaranteed if objects are inserted or removed while this
-  ///  operation is executing. All results are buffered in memory.
+  /// This is a helper method for calling list() repeatedly until there are no more results.
+  /// Consistency of the result is not guaranteed if objects are inserted or removed while this
+  /// operation is executing. All results are buffered in memory.
   ///
-  ///  Only available for projects using Firebase Rules Version 2.
+  /// Only available for projects using Firebase Rules Version 2.
   ///
-  ///  - Parameters:
-  ///    - completion A completion handler that will be invoked with all items and prefixes
-  ///                 under the current StorageReference. It returns a Result enum with either the
-  ///                 list or an NSError.
+  /// - Parameters:
+  ///   - completion A completion handler that will be invoked with all items and prefixes
+  ///                under the current StorageReference. It returns a Result enum with either the
+  ///                list or an NSError.
   func listAll(completion: @escaping (Result<StorageListResult, Error>) -> Void) {
     listAll(completion: getResultCallback(completion: completion))
   }
 
-  ///  Asynchronously uploads data to the currently specified FIRStorageReference.
-  ///  This is not recommended for large files, and one should instead upload a file from disk.
+  /// Asynchronously uploads data to the currently specified FIRStorageReference.
+  /// This is not recommended for large files, and one should instead upload a file from disk.
   ///
-  ///  - Parameters:
-  ///    - uploadData The Data to upload.
-  ///    - metadata StorageMetadata containing additional information (MIME type, etc.)
-  ///               about the object being uploaded.
-  ///    - completion A completion block that returns a Result enum with either the
-  ///                 object metadata or an NSError.
+  /// - Parameters:
+  ///   - uploadData The Data to upload.
+  ///   - metadata StorageMetadata containing additional information (MIME type, etc.)
+  ///              about the object being uploaded.
+  ///   - completion A completion block that returns a Result enum with either the
+  ///                object metadata or an NSError.
   ///
-  ///  - Returns: An instance of FIRStorageUploadTask, which can be used to monitor or manage
-  ///             the upload.
+  /// - Returns: An instance of FIRStorageUploadTask, which can be used to monitor or manage
+  ///            the upload.
   func putData(_ uploadData: Data,
                metadata: StorageMetadata? = nil,
                completion: @escaping (Result<StorageMetadata, Error>) -> Void)
@@ -150,17 +156,17 @@ public extension StorageReference {
                    completion: getResultCallback(completion: completion))
   }
 
-  ///   Asynchronously uploads a file to the currently specified FIRStorageReference.
+  /// Asynchronously uploads a file to the currently specified FIRStorageReference.
   ///
-  ///   - Parameters:
-  ///     - from A URL representing the system file path of the object to be uploaded.
-  ///     - metadata StorageMetadata containing additional information (MIME type, etc.)
-  ///                about the object being uploaded.
-  ///     - completion A completion block that returns a Result enum with either the
-  ///                  object metadata or an NSError.
+  /// - Parameters:
+  ///   - from A URL representing the system file path of the object to be uploaded.
+  ///   - metadata StorageMetadata containing additional information (MIME type, etc.)
+  ///              about the object being uploaded.
+  ///   - completion A completion block that returns a Result enum with either the
+  ///                object metadata or an NSError.
   ///
-  ///  - Returns: An instance of FIRStorageUploadTask, which can be used to monitor or manage
-  ///             the upload.
+  /// - Returns: An instance of FIRStorageUploadTask, which can be used to monitor or manage
+  ///            the upload.
   func putFile(from: URL,
                metadata: StorageMetadata? = nil,
                completion: @escaping (Result<StorageMetadata, Error>) -> Void)
@@ -170,26 +176,26 @@ public extension StorageReference {
                    completion: getResultCallback(completion: completion))
   }
 
-  ///  Updates the metadata associated with an object at the current path.
+  /// Updates the metadata associated with an object at the current path.
   ///
-  ///  - Parameters:
-  ///    - metadata An StorageMetadata object with the metadata to update.
-  ///    - completion A completion block which returns a Result enum with either the
-  ///                 object metadata or an NSError.
+  /// - Parameters:
+  ///   - metadata An StorageMetadata object with the metadata to update.
+  ///   - completion A completion block which returns a Result enum with either the
+  ///                object metadata or an NSError.
   func updateMetadata(_ metadata: StorageMetadata,
                       completion: @escaping (Result<StorageMetadata, Error>) -> Void) {
     return updateMetadata(metadata, completion: getResultCallback(completion: completion))
   }
 
-  ///  Asynchronously downloads the object at the current path to a specified system filepath.
+  /// Asynchronously downloads the object at the current path to a specified system filepath.
   ///
-  ///  - Parameters:
-  ///    - toFile A file system URL representing the path the object should be downloaded to.
-  ///    - completion A completion block that fires when the file download completes. The
-  ///                 block returns a Result enum with either an NSURL pointing to the file
-  ///                 path of the downloaded file or an NSError.
+  /// - Parameters:
+  ///   - toFile A file system URL representing the path the object should be downloaded to.
+  ///   - completion A completion block that fires when the file download completes. The
+  ///                block returns a Result enum with either an NSURL pointing to the file
+  ///                path of the downloaded file or an NSError.
   ///
-  ///  - Returns: A StorageDownloadTask that can be used to monitor or manage the download.
+  /// - Returns: A StorageDownloadTask that can be used to monitor or manage the download.
   func write(toFile: URL, completion: @escaping (Result<URL, Error>)
     -> Void) -> StorageDownloadTask {
     return write(toFile: toFile, completion: getResultCallback(completion: completion))


### PR DESCRIPTION
Follows recommended formatting from https://nshipster.com/swift-documentation/ and kept consistent with FirebaseFirestoreSwift.

Content is adapted from https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseStorage/Sources/Public/FIRStorageReference.h

Looks like this in Xcode:

![Screen Shot 2020-04-01 at 10 24 25 AM](https://user-images.githubusercontent.com/73870/78167244-0244ab00-7403-11ea-9c6d-fa87df38009b.png)
