### PR TITLE
Only fail a StorageTask once

### DIFF
--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Fix the rare case where a StorageTask would call its completion callbacks more than
+  once. (#5245)
+
 # 3.6.0
 - [added] Added watchOS support for Firebase Storage. (#4955)
 

--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [fixed] Fix the rare case where a StorageTask would call its completion callbacks more than
+- [fixed] Fix a rare case where a StorageTask would call its completion callbacks more than
   once. (#5245)
 
 # 3.6.0

--- a/FirebaseStorage/Sources/FIRStorageReference.m
+++ b/FirebaseStorage/Sources/FIRStorageReference.m
@@ -266,10 +266,15 @@
                   completion(task.downloadData, nil);
                 });
               }];
+
+  __block BOOL failed = NO;
   [task observeStatus:FIRStorageTaskStatusFailure
               handler:^(FIRStorageTaskSnapshot *_Nonnull snapshot) {
                 dispatch_async(callbackQueue, ^{
-                  completion(nil, snapshot.error);
+                  if (!failed) {
+                    failed = YES;
+                    completion(nil, snapshot.error);
+                  }
                 });
               }];
   [task

--- a/FirebaseStorage/Sources/FIRStorageReference.m
+++ b/FirebaseStorage/Sources/FIRStorageReference.m
@@ -174,6 +174,7 @@
                                              metadata:metadata];
 
   if (completion) {
+    __block BOOL completed = NO;
     dispatch_queue_t callbackQueue = _storage.fetcherServiceForApp.callbackQueue;
     if (!callbackQueue) {
       callbackQueue = dispatch_get_main_queue();
@@ -182,13 +183,19 @@
     [task observeStatus:FIRStorageTaskStatusSuccess
                 handler:^(FIRStorageTaskSnapshot *_Nonnull snapshot) {
                   dispatch_async(callbackQueue, ^{
-                    completion(snapshot.metadata, nil);
+                    if (!completed) {
+                      completed = YES;
+                      completion(snapshot.metadata, nil);
+                    }
                   });
                 }];
     [task observeStatus:FIRStorageTaskStatusFailure
                 handler:^(FIRStorageTaskSnapshot *_Nonnull snapshot) {
                   dispatch_async(callbackQueue, ^{
-                    completion(nil, snapshot.error);
+                    if (!completed) {
+                      completed = YES;
+                      completion(nil, snapshot.error);
+                    }
                   });
                 }];
   }
@@ -222,6 +229,7 @@
                                              metadata:metadata];
 
   if (completion) {
+    __block BOOL completed = NO;
     dispatch_queue_t callbackQueue = _storage.fetcherServiceForApp.callbackQueue;
     if (!callbackQueue) {
       callbackQueue = dispatch_get_main_queue();
@@ -230,13 +238,19 @@
     [task observeStatus:FIRStorageTaskStatusSuccess
                 handler:^(FIRStorageTaskSnapshot *_Nonnull snapshot) {
                   dispatch_async(callbackQueue, ^{
-                    completion(snapshot.metadata, nil);
+                    if (!completed) {
+                      completed = YES;
+                      completion(snapshot.metadata, nil);
+                    }
                   });
                 }];
     [task observeStatus:FIRStorageTaskStatusFailure
                 handler:^(FIRStorageTaskSnapshot *_Nonnull snapshot) {
                   dispatch_async(callbackQueue, ^{
-                    completion(nil, snapshot.error);
+                    if (!completed) {
+                      completed = YES;
+                      completion(nil, snapshot.error);
+                    }
                   });
                 }];
   }
@@ -248,6 +262,7 @@
 
 - (FIRStorageDownloadTask *)dataWithMaxSize:(int64_t)size
                                  completion:(FIRStorageVoidDataError)completion {
+  __block BOOL completed = NO;
   FIRStorageDownloadTask *task =
       [[FIRStorageDownloadTask alloc] initWithReference:self
                                          fetcherService:_storage.fetcherServiceForApp
@@ -263,16 +278,18 @@
               handler:^(FIRStorageTaskSnapshot *_Nonnull snapshot) {
                 FIRStorageDownloadTask *task = snapshot.task;
                 dispatch_async(callbackQueue, ^{
-                  completion(task.downloadData, nil);
+                  if (!completed) {
+                    completed = YES;
+                    completion(task.downloadData, nil);
+                  }
                 });
               }];
 
-  __block BOOL failed = NO;
   [task observeStatus:FIRStorageTaskStatusFailure
               handler:^(FIRStorageTaskSnapshot *_Nonnull snapshot) {
                 dispatch_async(callbackQueue, ^{
-                  if (!failed) {
-                    failed = YES;
+                  if (!completed) {
+                    completed = YES;
                     completion(nil, snapshot.error);
                   }
                 });
@@ -307,6 +324,7 @@
                                           dispatchQueue:_storage.dispatchQueue
                                                    file:fileURL];
   if (completion) {
+    __block BOOL completed = NO;
     dispatch_queue_t callbackQueue = _storage.fetcherServiceForApp.callbackQueue;
     if (!callbackQueue) {
       callbackQueue = dispatch_get_main_queue();
@@ -315,13 +333,19 @@
     [task observeStatus:FIRStorageTaskStatusSuccess
                 handler:^(FIRStorageTaskSnapshot *_Nonnull snapshot) {
                   dispatch_async(callbackQueue, ^{
-                    completion(fileURL, nil);
+                    if (!completed) {
+                      completed = YES;
+                      completion(fileURL, nil);
+                    }
                   });
                 }];
     [task observeStatus:FIRStorageTaskStatusFailure
                 handler:^(FIRStorageTaskSnapshot *_Nonnull snapshot) {
                   dispatch_async(callbackQueue, ^{
-                    completion(nil, snapshot.error);
+                    if (!completed) {
+                      completed = YES;
+                      completion(nil, snapshot.error);
+                    }
                   });
                 }];
   }


### PR DESCRIPTION
This should fix an occasional flake I was seeing in [testUnauthenticatedSimpleGetDataTooSmall](https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseStorageSwift/Tests/Integration/StorageIntegration.swift#L328) where the expectation was getting fulfilled twice.