### PR TITLE
Make APIs returning monitoring tasks discardable

### DIFF
--- a/FirebaseStorageSwift/Sources/SwiftAPIExtension.swift
+++ b/FirebaseStorageSwift/Sources/SwiftAPIExtension.swift
@@ -61,6 +61,7 @@ public extension StorageReference {
   ///                 an `Error`.
   ///
   /// - Returns: A StorageDownloadTask that can be used to monitor or manage the download.
+  @discardableResult
   func getData(maxSize: Int64, completion: @escaping (Result<Data, Error>) -> Void)
     -> StorageDownloadTask {
     return getData(maxSize: maxSize, completion: getResultCallback(completion: completion))
@@ -147,6 +148,7 @@ public extension StorageReference {
   ///
   /// - Returns: An instance of `StorageUploadTask`, which can be used to monitor or manage
   ///            the upload.
+  @discardableResult
   func putData(_ uploadData: Data,
                metadata: StorageMetadata? = nil,
                completion: @escaping (Result<StorageMetadata, Error>) -> Void)
@@ -167,6 +169,7 @@ public extension StorageReference {
   ///
   /// - Returns: An instance of `StorageUploadTask`, which can be used to monitor or manage
   ///            the upload.
+  @discardableResult
   func putFile(from: URL,
                metadata: StorageMetadata? = nil,
                completion: @escaping (Result<StorageMetadata, Error>) -> Void)
@@ -196,6 +199,7 @@ public extension StorageReference {
   ///                path of the downloaded file or an `Error`.
   ///
   /// - Returns: A `StorageDownloadTask` that can be used to monitor or manage the download.
+  @discardableResult
   func write(toFile: URL, completion: @escaping (Result<URL, Error>)
     -> Void) -> StorageDownloadTask {
     return write(toFile: toFile, completion: getResultCallback(completion: completion))

--- a/FirebaseStorageSwift/Sources/SwiftAPIExtension.swift
+++ b/FirebaseStorageSwift/Sources/SwiftAPIExtension.swift
@@ -187,7 +187,7 @@ public extension StorageReference {
   ///                object metadata or an `Error`.
   func updateMetadata(_ metadata: StorageMetadata,
                       completion: @escaping (Result<StorageMetadata, Error>) -> Void) {
-    return updateMetadata(metadata, completion: getResultCallback(completion: completion))
+    updateMetadata(metadata, completion: getResultCallback(completion: completion))
   }
 
   /// Asynchronously downloads the object at the current path to a specified system filepath.

--- a/FirebaseStorageSwift/Tests/Integration/StorageIntegration.swift
+++ b/FirebaseStorageSwift/Tests/Integration/StorageIntegration.swift
@@ -49,14 +49,14 @@ class StorageIntegration: XCTestCase {
 
         for largeFile in largeFiles {
           let ref = storage.reference().child(largeFile)
-          _ = ref.putData(data) { result in
+          ref.putData(data) { result in
             self.assertResultSuccess(result)
             setupExpectation.fulfill()
           }
         }
         for emptyFile in emptyFiles {
           let ref = storage.reference().child(emptyFile)
-          _ = ref.putData(data) { result in
+          ref.putData(data) { result in
             self.assertResultSuccess(result)
             setupExpectation.fulfill()
           }
@@ -114,7 +114,7 @@ class StorageIntegration: XCTestCase {
     let expectation = self.expectation(description: #function)
     let ref = storage.reference(withPath: "ios/public/fileToDelete")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-    _ = ref.putData(data) { result in
+    ref.putData(data) { result in
       self.assertResultSuccess(result)
       ref.delete() { error in
         XCTAssertNil(error, "Error should be nil")
@@ -128,7 +128,7 @@ class StorageIntegration: XCTestCase {
     let expectation = self.expectation(description: #function)
     let ref = storage.reference(withPath: "ios/public/fileToDelete")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-    _ = ref.putData(data) { result in
+    ref.putData(data) { result in
       self.assertResultSuccess(result)
       ref.delete(completion: nil)
       expectation.fulfill()
@@ -140,7 +140,7 @@ class StorageIntegration: XCTestCase {
     let expectation = self.expectation(description: #function)
     let ref = storage.reference(withPath: "ios/public/testBytesUpload")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-    _ = ref.putData(data) { result in
+    ref.putData(data) { result in
       self.assertResultSuccess(result)
       expectation.fulfill()
     }
@@ -151,7 +151,7 @@ class StorageIntegration: XCTestCase {
     let expectation = self.expectation(description: #function)
     let ref = storage.reference(withPath: "ios/public/-._~!$'()*,=:@&+;")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-    _ = ref.putData(data) { result in
+    ref.putData(data) { result in
       self.assertResultSuccess(result)
       expectation.fulfill()
     }
@@ -163,7 +163,7 @@ class StorageIntegration: XCTestCase {
     let ref = storage.reference(withPath: "ios/public/testBytesUpload")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
     DispatchQueue.global(qos: .background).async {
-      _ = ref.putData(data) { result in
+      ref.putData(data) { result in
         self.assertResultSuccess(result)
         expectation.fulfill()
       }
@@ -175,7 +175,7 @@ class StorageIntegration: XCTestCase {
     let expectation = self.expectation(description: #function)
     let ref = storage.reference(withPath: "ios/public/testUnauthenticatedSimplePutEmptyData")
     let data = Data()
-    _ = ref.putData(data) { result in
+    ref.putData(data) { result in
       self.assertResultSuccess(result)
       expectation.fulfill()
     }
@@ -186,7 +186,7 @@ class StorageIntegration: XCTestCase {
     let expectation = self.expectation(description: #function)
     let ref = storage.reference(withPath: "ios/private/secretfile.txt")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-    _ = ref.putData(data) { result in
+    ref.putData(data) { result in
       switch result {
       case .success:
         XCTFail("Unexpected success from unauthorized putData")
@@ -202,7 +202,7 @@ class StorageIntegration: XCTestCase {
     let expectation = self.expectation(description: #function)
     let ref = storage.reference(withPath: "ios/private/secretfile.txt")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
-    _ = ref.putData(data) { result in
+    ref.putData(data) { result in
       do {
         try _ = result.get() // .failure will throw
       } catch {
@@ -257,7 +257,7 @@ class StorageIntegration: XCTestCase {
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
     try data.write(to: fileURL, options: .atomicWrite)
-    _ = ref.putFile(from: fileURL) { result in
+    ref.putFile(from: fileURL) { result in
       switch result {
       case let .success(metadata):
         XCTAssertEqual(fileName, metadata.name)
@@ -278,7 +278,7 @@ class StorageIntegration: XCTestCase {
     let ref = storage.reference(withPath: "ios/public/testUnauthenticatedSimplePutDataNoMetadata")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
 
-    _ = ref.putData(data) { result in
+    ref.putData(data) { result in
       self.assertResultSuccess(result)
       expectation.fulfill()
     }
@@ -294,7 +294,7 @@ class StorageIntegration: XCTestCase {
     let tmpDirURL = URL(fileURLWithPath: NSTemporaryDirectory())
     let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
     try data.write(to: fileURL, options: .atomicWrite)
-    _ = ref.putFile(from: fileURL) { result in
+    ref.putFile(from: fileURL) { result in
       self.assertResultSuccess(result)
       expectation.fulfill()
     }
@@ -305,7 +305,7 @@ class StorageIntegration: XCTestCase {
     let expectation = self.expectation(description: #function)
 
     let ref = storage.reference(withPath: "ios/public/1mb")
-    _ = ref.getData(maxSize: 1024 * 1024) { result in
+    ref.getData(maxSize: 1024 * 1024) { result in
       self.assertResultSuccess(result)
       expectation.fulfill()
     }
@@ -317,7 +317,7 @@ class StorageIntegration: XCTestCase {
 
     let ref = storage.reference(withPath: "ios/public/1mb")
     DispatchQueue.global(qos: .background).async {
-      _ = ref.getData(maxSize: 1024 * 1024) { result in
+      ref.getData(maxSize: 1024 * 1024) { result in
         self.assertResultSuccess(result)
         expectation.fulfill()
       }
@@ -329,7 +329,7 @@ class StorageIntegration: XCTestCase {
     let expectation = self.expectation(description: #function)
 
     let ref = storage.reference(withPath: "ios/public/1mb")
-    _ = ref.getData(maxSize: 1024) { result in
+    ref.getData(maxSize: 1024) { result in
       switch result {
       case .success:
         XCTFail("Unexpected success from getData too small")
@@ -379,7 +379,7 @@ class StorageIntegration: XCTestCase {
     let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
 
-    _ = ref.putData(data) { result in
+    ref.putData(data) { result in
       switch result {
       case .success:
         let task = ref.write(toFile: fileURL)


### PR DESCRIPTION
Make the APIs that return a monitoring/management task `@discardableResult` to prevent the need for assignments to underscore when a task isn't needed.

This is comparable to [Firestore APIs like setData](https://github.com/firebase/firebase-ios-sdk/blob/master/Firestore/Swift/Source/Codable/Transaction%2BWriteEncodable.swift#L54). 