### PR TITLE
add missing return when delete token handler is nil

### DIFF
--- a/Firebase/InstanceID/CHANGELOG.md
+++ b/Firebase/InstanceID/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2020-03 -- 4.3.3
 - [fixed] Fixed provisioning profile location for catalyst. (#5048)
+- [fixed] Fixed crash when passing a nil handler to deleteToken request. (#5247)
 - [changed] Remove obsolete logic to improve performance and reduce keychain operations. (#5211, #5237)
 
 # 2020-02 -- 4.3.2

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -367,6 +367,7 @@ static FIRInstanceID *gInstanceID;
   if (!handler) {
     FIRInstanceIDLoggerError(kFIRInstanceIDMessageCodeInstanceID001,
                              kFIRInstanceIDInvalidNilHandlerError);
+    return;
   }
 
   // comparing enums to ints directly throws a warning


### PR DESCRIPTION
This fixes crash if passing a nil handler