### PR TITLE
Crashlytics collect on-device symbolication for GDT

### DIFF
--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
@@ -191,7 +191,8 @@
   [files enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
     NSString *filename = (NSString *)obj;
     NSString *lowerExtension = filename.pathExtension.lowercaseString;
-    if ([lowerExtension isEqualToString:@"clsrecord"] || [lowerExtension isEqualToString:@"symbolicated"]) {
+    if ([lowerExtension isEqualToString:@"clsrecord"] ||
+        [lowerExtension isEqualToString:@"symbolicated"]) {
       [clsRecords addObject:[self.folderPath stringByAppendingPathComponent:filename]];
     }
   }];

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
@@ -193,6 +193,9 @@
     if ([filename.pathExtension.lowercaseString isEqualToString:@"clsrecord"]) {
       [clsRecords addObject:[self.folderPath stringByAppendingPathComponent:filename]];
     }
+    if ([filename.pathExtension.lowercaseString isEqualToString:@"symbolicated"]) {
+      [clsRecords addObject:[self.folderPath stringByAppendingPathComponent:filename]];
+    }
   }];
 
   return [clsRecords sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)];

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
@@ -190,10 +190,8 @@
 
   [files enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
     NSString *filename = (NSString *)obj;
-    if ([filename.pathExtension.lowercaseString isEqualToString:@"clsrecord"]) {
-      [clsRecords addObject:[self.folderPath stringByAppendingPathComponent:filename]];
-    }
-    if ([filename.pathExtension.lowercaseString isEqualToString:@"symbolicated"]) {
+    NSString *lowerExtension = filename.pathExtension.lowercaseString;
+    if ([lowerExtension isEqualToString:@"clsrecord"] || [lowerExtension isEqualToString:@"symbolicated"]) {
       [clsRecords addObject:[self.folderPath stringByAppendingPathComponent:filename]];
     }
   }];


### PR DESCRIPTION
 - On-device symbolication happens upon next startup, not during crash. These files are unique because they end in `.symbolicated` instead of `.clsrecord`. We need to collect and upload these files for GDT in addition to the `.clsrecord` files