### PR TITLE
Fix a possible crash in encoding when sharedInstance is nil (#5267)

### DIFF
--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTPrioritizer.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTPrioritizer.m
@@ -303,6 +303,9 @@ static NSString *const GDTCCTUploaderCSHEventsKey = @"GDTCCTUploaderCSHEventsKey
 
 - (void)encodeWithCoder:(NSCoder *)coder {
   GDTCCTPrioritizer *sharedInstance = [GDTCCTPrioritizer sharedInstance];
+  if (!sharedInstance) {
+    return;
+  }
   NSMutableSet<GDTCOREvent *> *CCTEvents = sharedInstance->_CCTEvents;
   if (CCTEvents) {
     [coder encodeObject:CCTEvents forKey:GDTCCTUploaderCCTEventsKey];

--- a/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/GDTCCTPrioritizerTest.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/GDTCCTPrioritizerTest.m
@@ -181,4 +181,27 @@
   XCTAssertNotEqual(info.network_type, gdt_cct_NetworkConnectionInfo_NetworkType_NONE);
 }
 
+/** Tests encoding and decoding a clock using a keyed archiver. */
+- (void)testEncodingAndDecoding {
+  GDTCCTPrioritizer *prioritizer = [GDTCCTPrioritizer sharedInstance];
+  GDTCOREvent *event = [_CCTGenerator generateEvent:GDTCOREventQosDefault];
+  event.customPrioritizationParams = @{GDTCCTNeedsNetworkConnectionInfo : @YES};
+  [prioritizer prioritizeEvent:event];
+  NSError *error;
+  dispatch_sync(prioritizer.queue, ^{
+                });
+  XCTAssertEqual(prioritizer.CCTEvents.count, 1);
+  NSData *prioritizerData = GDTCOREncodeArchive(prioritizer, nil, &error);
+  XCTAssertNil(error);
+  XCTAssertNotNil(prioritizerData);
+
+  error = nil;
+  GDTCCTPrioritizer *unarchivedPrioritizer = (GDTCCTPrioritizer *)GDTCORDecodeArchive(
+      [GDTCCTPrioritizer class], nil, prioritizerData, &error);
+  XCTAssertNil(error);
+  XCTAssertNotNil(unarchivedPrioritizer);
+  XCTAssertEqual([prioritizer hash], [prioritizer hash]);
+  XCTAssertEqualObjects(prioritizer.CCTEvents, unarchivedPrioritizer.CCTEvents);
+}
+
 @end


### PR DESCRIPTION
EXC_BAD_ACCESS comes from ivar access of a nil object.

Fixes #5264

