### PR TITLE
Only check for active targets in GetTargetIds

### DIFF
--- a/Firestore/core/src/firebase/firestore/remote/remote_event.cc
+++ b/Firestore/core/src/firebase/firestore/remote/remote_event.cc
@@ -202,7 +202,9 @@ std::vector<TargetId> WatchChangeAggregator::GetTargetIds(
   std::vector<TargetId> result;
   result.reserve(target_states_.size());
   for (const auto& entry : target_states_) {
-    result.push_back(entry.first);
+    if (IsActiveTarget(entry.first)) {
+      result.push_back(entry.first);
+    }
   }
 
   return result;

--- a/Firestore/core/src/firebase/firestore/remote/remote_event.cc
+++ b/Firestore/core/src/firebase/firestore/remote/remote_event.cc
@@ -200,7 +200,6 @@ std::vector<TargetId> WatchChangeAggregator::GetTargetIds(
   }
 
   std::vector<TargetId> result;
-  result.reserve(target_states_.size());
   for (const auto& entry : target_states_) {
     if (IsActiveTarget(entry.first)) {
       result.push_back(entry.first);


### PR DESCRIPTION
Porting from [web](https://github.com/firebase/firebase-js-sdk/pull/2847).

Curious to know if it is still worth it `reserve()` the vector ahead of time, even if we can't guarantee that it'll be fully filled.