### PR TITLE
Collect reports refetch

### DIFF
--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -619,7 +619,7 @@ static void (^reportSentCallback)(void);
 }
 
 // This is the side-effect of calling deleteUnsentReports, or collect_reports setting
-// being galse
+// being false
 - (void)deleteUnsentReportsWithPreexisting:(NSArray *)preexistingReportPaths {
   [self removeExistingReportPaths:preexistingReportPaths];
 

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -359,8 +359,7 @@ static void (^reportSentCallback)(void);
     FIRCLSDebugLog(@"Unsent reports will be uploaded at startup");
     FIRCLSDataCollectionToken *dataCollectionToken = [FIRCLSDataCollectionToken validToken];
 
-    [self beginSettingsAndOnboardingWithToken:dataCollectionToken
-                       waitForSettingsRequest:NO];
+    [self beginSettingsAndOnboardingWithToken:dataCollectionToken waitForSettingsRequest:NO];
 
     [self beginReportUploadsWithToken:dataCollectionToken
                preexistingReportPaths:preexistingReportPaths
@@ -457,7 +456,6 @@ static void (^reportSentCallback)(void);
 
 - (void)beginSettingsAndOnboardingWithToken:(FIRCLSDataCollectionToken *)token
                      waitForSettingsRequest:(BOOL)waitForSettings {
-
   if (self.settings.isCacheExpired) {
     // This method can be called more than once if the user calls
     // SendUnsentReports again, so don't repeat the settings fetch
@@ -474,7 +472,6 @@ static void (^reportSentCallback)(void);
              preexistingReportPaths:(NSArray *)preexistingReportPaths
                        blockingSend:(BOOL)blockingSend
                              report:(FIRCLSInternalReport *)report {
-
   if (self.settings.collectReportsEnabled) {
     [self processExistingReportPaths:preexistingReportPaths
                  dataCollectionToken:token

--- a/Crashlytics/Crashlytics/Models/FIRCLSFileManager.h
+++ b/Crashlytics/Crashlytics/Models/FIRCLSFileManager.h
@@ -59,24 +59,12 @@
 - (BOOL)moveItemAtPath:(NSString *)path toDirectory:(NSString *)destDir;
 - (void)enumerateFilesInDirectory:(NSString *)directory
                        usingBlock:(void (^)(NSString *filePath, NSString *extension))block;
-- (BOOL)moveItemsFromDirectory:(NSString *)srcDir toDirectory:(NSString *)destDir;
 - (NSNumber *)fileSizeAtPath:(NSString *)path;
 - (NSArray *)contentsOfDirectory:(NSString *)path;
 
 // logic of managing files/directories
 - (BOOL)createReportDirectories;
 - (NSString *)setupNewPathForExecutionIdentifier:(NSString *)identifier;
-
-- (void)enumerateFilesInActiveDirectoryUsingBlock:(void (^)(NSString *path,
-                                                            NSString *extension))block;
-- (void)enumerateReportsInProcessingDirectoryUsingBlock:(void (^)(FIRCLSInternalReport *report,
-                                                                  NSString *path))block;
-- (void)enumerateFilesInPreparedDirectoryUsingBlock:(void (^)(NSString *path,
-                                                              NSString *extension))block;
-
-- (BOOL)movePendingToProcessing;
-
-- (BOOL)removeContentsOfAllPathsExceptActive;
 
 - (BOOL)moveItemAtPath:(NSString *)srcPath toPath:(NSString *)dstPath error:(NSError **)error;
 

--- a/Crashlytics/Crashlytics/Models/FIRCLSFileManager.h
+++ b/Crashlytics/Crashlytics/Models/FIRCLSFileManager.h
@@ -76,9 +76,7 @@
 
 - (BOOL)movePendingToProcessing;
 
-- (BOOL)removeContentsOfProcessingPath;
-- (BOOL)removeContentsOfPendingPath;
-- (BOOL)removeContentsOfAllPaths;
+- (BOOL)removeContentsOfAllPathsExceptActive;
 
 - (BOOL)moveItemAtPath:(NSString *)srcPath toPath:(NSString *)dstPath error:(NSError **)error;
 

--- a/Crashlytics/Crashlytics/Models/FIRCLSFileManager.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSFileManager.m
@@ -146,17 +146,6 @@ NSString *const FIRCLSCacheVersion = @"v5";
   }
 }
 
-- (BOOL)moveItemsFromDirectory:(NSString *)srcDir toDirectory:(NSString *)destDir {
-  __block BOOL success = YES;
-
-  [self enumerateFilesInDirectory:srcDir
-                       usingBlock:^(NSString *filePath, NSString *extension) {
-                         success = success && [self moveItemAtPath:filePath toDirectory:destDir];
-                       }];
-
-  return success;
-}
-
 - (NSNumber *)fileSizeAtPath:(NSString *)path {
   NSError *error = nil;
   NSDictionary *attrs = [[self underlyingFileManager] attributesOfItemAtPath:path error:&error];
@@ -276,45 +265,6 @@ NSString *const FIRCLSCacheVersion = @"v5";
   }
 
   return path;
-}
-
-- (void)enumerateReportsInProcessingDirectoryUsingBlock:(void (^)(FIRCLSInternalReport *report,
-                                                                  NSString *path))block {
-  [self enumerateFilesInDirectory:[self processingPath]
-                       usingBlock:^(NSString *filePath, NSString *extension) {
-                         FIRCLSInternalReport *report =
-                             [FIRCLSInternalReport reportWithPath:filePath];
-                         if (block) {
-                           block(report, filePath);
-                         }
-                       }];
-}
-
-- (void)enumerateFilesInActiveDirectoryUsingBlock:(void (^)(NSString *path,
-                                                            NSString *extension))block {
-  [self enumerateFilesInDirectory:[self activePath] usingBlock:block];
-}
-
-- (void)enumerateFilesInPreparedDirectoryUsingBlock:(void (^)(NSString *path,
-                                                              NSString *extension))block {
-  [self enumerateFilesInDirectory:[self legacyPreparedPath] usingBlock:block];
-}
-
-- (BOOL)movePendingToProcessing {
-  return [self moveItemsFromDirectory:[self pendingPath] toDirectory:[self processingPath]];
-}
-
-- (BOOL)removeContentsOfAllPathsExceptActive {
-  BOOL contentsOfProcessingPathRemoved = [self removeContentsOfDirectoryAtPath:self.processingPath];
-  BOOL contentsOfPendingPathRemoved = [self removeContentsOfDirectoryAtPath:self.pendingPath];
-  BOOL contentsOfDirectoryAtPreparedPathRemoved =
-      [self removeContentsOfDirectoryAtPath:self.preparedPath];
-  BOOL contentsOfDirectoryAtLegacyPreparedPathRemoved =
-      [self removeContentsOfDirectoryAtPath:self.legacyPreparedPath];
-  BOOL success = contentsOfProcessingPathRemoved && contentsOfPendingPathRemoved &&
-                 contentsOfDirectoryAtPreparedPathRemoved &&
-                 contentsOfDirectoryAtLegacyPreparedPathRemoved;
-  return success;
 }
 
 - (BOOL)moveItemAtPath:(NSString *)srcPath toPath:(NSString *)dstPath error:(NSError **)error {

--- a/Crashlytics/Crashlytics/Models/FIRCLSFileManager.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSFileManager.m
@@ -304,26 +304,15 @@ NSString *const FIRCLSCacheVersion = @"v5";
   return [self moveItemsFromDirectory:[self pendingPath] toDirectory:[self processingPath]];
 }
 
-- (BOOL)removeContentsOfProcessingPath {
-  return [self removeContentsOfDirectoryAtPath:[self processingPath]];
-}
-
-- (BOOL)removeContentsOfPendingPath {
-  return [self removeContentsOfDirectoryAtPath:[self pendingPath]];
-}
-
-- (BOOL)removeContentsOfAllPaths {
-  BOOL contentsOfProcessingPathRemoved = [self removeContentsOfProcessingPath];
-  BOOL contentsOfPendingPathRemoved = [self removeContentsOfPendingPath];
+- (BOOL)removeContentsOfAllPathsExceptActive {
+  BOOL contentsOfProcessingPathRemoved = [self removeContentsOfDirectoryAtPath:self.processingPath];
+  BOOL contentsOfPendingPathRemoved = [self removeContentsOfDirectoryAtPath:self.pendingPath];
   BOOL contentsOfDirectoryAtPreparedPathRemoved =
       [self removeContentsOfDirectoryAtPath:self.preparedPath];
   BOOL contentsOfDirectoryAtLegacyPreparedPathRemoved =
       [self removeContentsOfDirectoryAtPath:self.legacyPreparedPath];
-  BOOL contentsOfDirectoryAtActivePathRemoved =
-      [self removeContentsOfDirectoryAtPath:self.activePath];
   BOOL success = contentsOfProcessingPathRemoved && contentsOfPendingPathRemoved &&
                  contentsOfDirectoryAtPreparedPathRemoved &&
-                 contentsOfDirectoryAtActivePathRemoved &&
                  contentsOfDirectoryAtLegacyPreparedPathRemoved;
   return success;
 }

--- a/Crashlytics/Crashlytics/Models/FIRCLSSettings.h
+++ b/Crashlytics/Crashlytics/Models/FIRCLSSettings.h
@@ -89,7 +89,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * When this is false, Crashlytics will not start up
  */
-@property(nonatomic, readonly) BOOL crashReportingEnabled;
+@property(nonatomic, readonly) BOOL collectReportsEnabled;
 
 /**
  * When this is false, Crashlytics will not collect non-fatal errors and errors

--- a/Crashlytics/Crashlytics/Models/FIRCLSSettings.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSSettings.m
@@ -293,7 +293,7 @@ NSString *const AppVersion = @"app_version";
   return [self errorReportingEnabled];
 }
 
-- (BOOL)crashReportingEnabled {
+- (BOOL)collectReportsEnabled {
   NSNumber *value = [self featuresSettings][@"collect_reports"];
 
   if (value != nil) {

--- a/Crashlytics/UnitTests/FIRCLSSettingsTests.m
+++ b/Crashlytics/UnitTests/FIRCLSSettingsTests.m
@@ -97,7 +97,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertFalse(self.settings.appNeedsOnboarding);
   XCTAssertFalse(self.settings.appUpdateRequired);
 
-  XCTAssertTrue(self.settings.crashReportingEnabled);
+  XCTAssertTrue(self.settings.collectReportsEnabled);
   XCTAssertTrue(self.settings.errorReportingEnabled);
   XCTAssertTrue(self.settings.customExceptionsEnabled);
 
@@ -170,7 +170,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertFalse(self.settings.appNeedsOnboarding);
   XCTAssertFalse(self.settings.appUpdateRequired);
 
-  XCTAssertTrue(self.settings.crashReportingEnabled);
+  XCTAssertTrue(self.settings.collectReportsEnabled);
   XCTAssertTrue(self.settings.errorReportingEnabled);
   XCTAssertTrue(self.settings.customExceptionsEnabled);
 
@@ -197,7 +197,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertTrue(self.settings.appNeedsOnboarding);
   XCTAssertTrue(self.settings.appUpdateRequired);
 
-  XCTAssertFalse(self.settings.crashReportingEnabled);
+  XCTAssertFalse(self.settings.collectReportsEnabled);
   XCTAssertFalse(self.settings.errorReportingEnabled);
   XCTAssertFalse(self.settings.customExceptionsEnabled);
 
@@ -379,7 +379,7 @@ NSString *const TestChangedGoogleAppID = @"2:changed:google:app:id";
   XCTAssertFalse(self.settings.appNeedsOnboarding);
   XCTAssertFalse(self.settings.appUpdateRequired);
 
-  XCTAssertTrue(self.settings.crashReportingEnabled);
+  XCTAssertTrue(self.settings.collectReportsEnabled);
   XCTAssertTrue(self.settings.errorReportingEnabled);
   XCTAssertTrue(self.settings.customExceptionsEnabled);
 


### PR DESCRIPTION
 - When collect_reports is false, Crashlytics currently doesn't start up at all. We want to continue to fetch settings in this situation, but never upload crash reports