### PR TITLE
Explicitly state InAppMessaging's dependency on GoogleUtilities

### DIFF
--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -46,6 +46,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
   s.dependency 'FirebaseInstallations', '~> 1.1'
   s.dependency 'GoogleDataTransportCCTSupport', '~> 2.0'
   s.dependency 'FirebaseABTesting', '~> 3.2'
+  s.dependency 'GoogleUtilities/Environment', '~> 6.5'
 
   s.test_spec 'unit' do |unit_tests|
       unit_tests.source_files = 'FirebaseInAppMessaging/Tests/Unit/*.[mh]'


### PR DESCRIPTION
In #2312 you added InAppMessaging to the repo and [here][1] you check if this is running on simulator using `GoogleUtilities`.

This adds `GoogleUtilities` explicitly to `FirebaseInAppMessaging.podspec` fixing #5282

[1]: https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseInAppMessaging/Sources/Runtime/FIRInAppMessaging%2BBootstrap.m#L105