### PR TITLE
Bump Firestore to 1.12.0

### DIFF
--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -91,7 +91,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Firestore' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseFirestore', '~> 1.11.3'
+    ss.dependency 'FirebaseFirestore', '~> 1.12.0'
   end
 
   s.subspec 'Functions' do |ss|

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseFirestore'
-  s.version          = '1.11.3'
+  s.version          = '1.12.0'
   s.summary          = 'Google Cloud Firestore'
 
   s.description      = <<-DESC

--- a/Releases/Manifests/6.22.0.json
+++ b/Releases/Manifests/6.22.0.json
@@ -3,7 +3,7 @@
   "FirebaseCore":"6.6.6",
   "FirebaseCoreDiagnostics":"1.2.3",
   "FirebaseCrashlytics":"4.0.0-beta.7",
-  "FirebaseFirestore":"1.11.3",
+  "FirebaseFirestore":"1.12.0",
   "FirebaseInAppMessaging":"0.19.2",
   "FirebaseInstanceID":"4.3.3",
   "GoogleDataTransport":"5.1.1",


### PR DESCRIPTION
M68 Firestore includes a change to an internal header used by the
Firestore C++ SDK that isn't backwards compatible. Naming this 1.11.3
would allow older Firestore C++ installs for iOS to upgrade to this
version which would break them.

Numbering this 1.12.0 prevents automatic upgrades within the
patch-level.