### PR TITLE
Handle Xcode 11.4 changes to Swift module maps

### DIFF
--- a/ZipBuilder/README.md
+++ b/ZipBuilder/README.md
@@ -24,6 +24,10 @@ In order to build the Zip file, you will need:
 You can run the tool with `swift run ReleasePackager [ARGS]` or generate an Xcode project with
 `swift package generate-xcodeproj` and run within Xcode.
 
+Since Apple does not support linking libraries built by future Xcode versions, make sure to builid with the
+earliest Xcode needed by any of the library clients. The Xcode command line tools must also be configured
+for that version. Check with `xcodebuild -version`.
+
 ### Launch Arguments
 
 See `main.swift` and the `LaunchArgs` struct for information on specific launch arguments.

--- a/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
+++ b/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
@@ -40,6 +40,7 @@ struct LaunchArgs {
   /// Keys associated with the launch args. See `Usage` for descriptions of each flag.
   private enum Key: String, CaseIterable {
     case archs
+    case buildDependencies
     case buildRoot
     case carthageDir
     case carthageSkipVersionCheck
@@ -62,6 +63,8 @@ struct LaunchArgs {
       case .archs:
         return "The list of architectures to build for. The default list is " +
           "\(Architecture.allCases.map { $0.rawValue })."
+      case .buildDependencies:
+        return "Whether or not to build dependencies of requested pods. The default is true."
       case .buildRoot:
         return "The root directory for build artifacts. If `nil`, a temporary directory will be " +
           "used."
@@ -108,6 +111,9 @@ struct LaunchArgs {
   /// A file URL to a textproto with the contents of a `ZipBuilder_FirebaseSDKs` object. Used to
   /// verify expected version numbers.
   let allSDKsPath: URL?
+
+  /// Build dependencies flag.
+  let buildDependencies: Bool
 
   /// The root directory for build artifacts. If `nil`, a temporary directory will be used.
   let buildRoot: URL?
@@ -170,6 +176,8 @@ struct LaunchArgs {
     // Override default values for specific keys.
     //   - Always run `pod repo update` and pod cache clean -all` unless explicitly set to false.
     defaults.register(defaults: [Key.updatePodRepo.rawValue: true])
+    //   - Always build dependencies unless explicitly set to false.
+    defaults.register(defaults: [Key.buildDependencies.rawValue: true])
 
     // Get the project template directory, and fail if it doesn't exist.
     guard let templatePath = defaults.string(forKey: Key.templateDir.rawValue) else {
@@ -336,6 +344,7 @@ struct LaunchArgs {
       minimumIOSVersion = "9.0"
     }
 
+    buildDependencies = defaults.bool(forKey: Key.buildDependencies.rawValue)
     carthageSkipVersionCheck = defaults.bool(forKey: Key.carthageSkipVersionCheck.rawValue)
     dynamic = defaults.bool(forKey: Key.dynamic.rawValue)
     updatePodRepo = defaults.bool(forKey: Key.updatePodRepo.rawValue)

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -153,14 +153,18 @@ struct ZipBuilder {
       ModuleMapBuilder(customSpecRepos: customSpecRepos, selectedPods: installedPods).build()
     }
 
+    let podsToBuild = LaunchArgs.shared.buildDependencies ? installedPods :
+      installedPods.filter { podsToInstall.map { $0.name }.contains($0.key) }
+
     // Generate the frameworks. Each key is the pod name and the URLs are all frameworks to be
     // copied in each product's directory.
-    let (frameworks, carthageFrameworks) = generateFrameworks(fromPods: installedPods, inProjectDir: projectDir)
+    let (frameworks, carthageFrameworks) = generateFrameworks(fromPods: podsToBuild,
+                                                              inProjectDir: projectDir)
 
     for (framework, paths) in frameworks {
       print("Frameworks for pod: \(framework) were compiled at \(paths)")
     }
-    return (installedPods, frameworks, carthageFrameworks)
+    return (podsToBuild, frameworks, carthageFrameworks)
   }
 
   // TODO: This function contains a lot of "copy these paths to this directory, fail if there are


### PR DESCRIPTION
Fix #5287

- Handle new file structure of Swift module maps in Xcode 11.4
- Add `-buildDependencies false` option to skip building dependencies of requested pods
- Update README to help ZipBuilder users choose the right Xcode version
- Fixed a crash from bad URL construction when both `-outputDir` and `-zipPods` options were used

Xcode 11.4 adds a `Project` subdirectory to Swift module maps that needs to be similarly merged when constructing .xcframeworks.

The `-buildDependencies false` flag will be useful for those who want to build add-on's to the default zip or Carthage distributions without the time consuming building of all the transitive dependencies.
