### PR TITLE
Switch travis from Xcode 11.3 to 11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: osx
-osx_image: xcode11.3
+osx_image: xcode11
 language: objective-c
 cache:
   bundler: true


### PR DESCRIPTION
All of the `pod lib lint` runs started failing yesterday on the travis Xcode 11.3 travis configs with ruby errors like https://travis-ci.org/github/firebase/firebase-ios-sdk/jobs/672106386

Backing up to Xcode 11.0 fixes the build.

#no-changelog