### PR TITLE
Update GHA badge list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # Firebase iOS Open Source Development
+ [![Actions Status][gh-auth-badge]][gh-actions]
  [![Actions Status][gh-core-badge]][gh-actions]
- [![Actions Status][gh-dynamiclinks-badge]][gh-actions]
  [![Actions Status][gh-datatransport-badge]][gh-actions]
+ [![Actions Status][gh-dynamiclinks-badge]][gh-actions]
+ [![Actions Status][gh-firebasepod-badge]][gh-actions]
+ [![Actions Status][gh-firestore-badge]][gh-actions]
+ [![Actions Status][gh-interop-badge]][gh-actions]
+ [![Actions Status][gh-messaging-badge]][gh-actions]
  [![Actions Status][gh-storage-badge]][gh-actions]
+ [![Actions Status][gh-symbolcollision-badge]][gh-actions]
  [![Actions Status][gh-zip-badge]][gh-actions]
  [![Travis](https://travis-ci.org/firebase/firebase-ios-sdk.svg?branch=master)](https://travis-ci.org/firebase/firebase-ios-sdk)
 
@@ -263,8 +269,14 @@ Your use of Firebase is governed by the
 [Terms of Service for Firebase Services](https://firebase.google.com/terms/).
 
 [gh-actions]: https://github.com/firebase/firebase-ios-sdk/actions
+[gh-auth-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/auth/badge.svg
 [gh-core-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/core/badge.svg
 [gh-datatransport-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/datatransport/badge.svg
 [gh-dynamiclinks-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/dynamiclinks/badge.svg
+[gh-firebasepod-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/firebasepod/badge.svg
+[gh-firestore-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/firestore/badge.svg
+[gh-interop-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/interop/badge.svg
+[gh-messaging-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/messaging/badge.svg
 [gh-storage-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/storage/badge.svg
+[gh-symbolcollision-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/symbolcollision/badge.svg
 [gh-zip-badge]: https://github.com/firebase/firebase-ios-sdk/workflows/zip/badge.svg


### PR DESCRIPTION
See badges at https://github.com/firebase/firebase-ios-sdk/tree/pb-gha-badges#firebase-ios-open-source-development

One approval and fyi for others should be sufficient for this one.

#no-changelog