### PR TITLE
fix an issue that delete token does not trigger token refresh notification or delegate

### DIFF
--- a/Example/Messaging/Sample/Sample.xcodeproj/xcshareddata/xcschemes/Sample.xcscheme
+++ b/Example/Messaging/Sample/Sample.xcodeproj/xcshareddata/xcschemes/Sample.xcscheme
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1120"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5125CC982437F471006CA5D0"
+               BuildableName = "Sample.app"
+               BlueprintName = "Sample"
+               ReferencedContainer = "container:Sample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5125CC982437F471006CA5D0"
+            BuildableName = "Sample.app"
+            BlueprintName = "Sample"
+            ReferencedContainer = "container:Sample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-FIRDebugEnabled"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5125CC982437F471006CA5D0"
+            BuildableName = "Sample.app"
+            BlueprintName = "Sample"
+            ReferencedContainer = "container:Sample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/Messaging/Sample/Sample/AppDelegate.swift
+++ b/Example/Messaging/Sample/Sample/AppDelegate.swift
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 import UIKit
-import CoreData
 import FirebaseCore
-import FirebaseMessaging
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {

--- a/Example/Messaging/Sample/Sample/ContentView.swift
+++ b/Example/Messaging/Sample/Sample/ContentView.swift
@@ -109,7 +109,6 @@ struct ContentView: View {
         print("Failed delete token: ", error)
         return
       }
-      self.identity.token = nil
     }
   }
 
@@ -119,8 +118,6 @@ struct ContentView: View {
         print("Failed delete ID: ", error)
         return
       }
-      self.identity.instanceID = nil
-      self.identity.token = nil
     }
   }
 
@@ -130,7 +127,6 @@ struct ContentView: View {
         print("Failed delete FID: ", error)
         return
       }
-      self.identity.instanceID = nil
     }
   }
 }
@@ -162,8 +158,6 @@ struct ContentView_Previews: PreviewProvider {
 
   static var previews: some View {
     Group {
-      ContentView().environmentObject(Identity())
-
       ContentView().environmentObject(filledIdentity)
     }
   }

--- a/Example/Messaging/Sample/Sample/ContentView.swift
+++ b/Example/Messaging/Sample/Sample/ContentView.swift
@@ -21,6 +21,11 @@ import FirebaseInstallations
 struct ContentView: View {
   @EnvironmentObject var identity: Identity
 
+  let fisPub = NotificationCenter.default
+    .publisher(for: Notification.Name.FIRInstallationIDDidChange)
+    .map { _ in }
+    .receive(on: RunLoop.main)
+
   var body: some View {
     NavigationView {
       // Outer stack containing the list and the buttons.
@@ -85,6 +90,15 @@ struct ContentView: View {
         }
         .buttonStyle(IdentityButtonStyle())
       }
+    }.onReceive(fisPub) { () in
+      // Handling FID publisher
+      Installations.installations().installationID(completion: { fid, error in
+        if let error = error as NSError? {
+          print("Failed to get FID: ", error)
+          return
+        }
+        self.identity.instanceID = fid ?? "None"
+          })
     }
   }
 

--- a/Example/Messaging/Sample/Sample/ContentView.swift
+++ b/Example/Messaging/Sample/Sample/ContentView.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Combine
 import SwiftUI
 import FirebaseCore
 import FirebaseMessaging
@@ -20,11 +21,6 @@ import FirebaseInstallations
 
 struct ContentView: View {
   @EnvironmentObject var identity: Identity
-
-  let fisPub = NotificationCenter.default
-    .publisher(for: Notification.Name.FIRInstallationIDDidChange)
-    .map { _ in }
-    .receive(on: RunLoop.main)
 
   var body: some View {
     NavigationView {
@@ -90,15 +86,6 @@ struct ContentView: View {
         }
         .buttonStyle(IdentityButtonStyle())
       }
-    }.onReceive(fisPub) { () in
-      // Handling FID publisher
-      Installations.installations().installationID(completion: { fid, error in
-        if let error = error as NSError? {
-          print("Failed to get FID: ", error)
-          return
-        }
-        self.identity.instanceID = fid ?? "None"
-          })
     }
   }
 

--- a/Example/Messaging/Sample/Sample/Identity.swift
+++ b/Example/Messaging/Sample/Sample/Identity.swift
@@ -13,10 +13,22 @@
 // limitations under the License.
 
 import SwiftUI
+import FirebaseMessaging
+import FirebaseInstallations
 
 public final class Identity: ObservableObject {
   // Identity that is unique per app.
   @Published public var instanceID: String? = nil
   // The token that Firebase Messaging use to send notifications.
   @Published public var token: String? = nil
+
+  init() {
+    Installations.installations().installationID(completion: { fid, error in
+      if let error = error as NSError? {
+        print("Failed to get FID: ", error)
+        return
+      }
+      self.instanceID = fid ?? "None"
+    })
+  }
 }

--- a/Example/Messaging/Sample/Sample/SceneDelegate.swift
+++ b/Example/Messaging/Sample/Sample/SceneDelegate.swift
@@ -39,13 +39,5 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, MessagingDelegate {
 
   func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String) {
     identity.token = fcmToken
-
-    Installations.installations().installationID(completion: { fid, error in
-      if let error = error as NSError? {
-        print("Failed to get FID: ", error)
-        return
-      }
-      self.identity.instanceID = fid ?? "None"
-    })
   }
 }

--- a/Example/Messaging/Sample/Sample/SceneDelegate.swift
+++ b/Example/Messaging/Sample/Sample/SceneDelegate.swift
@@ -39,8 +39,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, MessagingDelegate {
 
   func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String) {
     identity.token = fcmToken
-    InstanceID.instanceID().instanceID { result, error in
-      self.identity.instanceID = result?.instanceID
-    }
+
+    Installations.installations().installationID(completion: { fid, error in
+      if let error = error as NSError? {
+        print("Failed to get FID: ", error)
+        return
+      }
+      self.identity.instanceID = fid ?? "None"
+    })
   }
 }

--- a/Example/Messaging/Sample/Sample/SceneDelegate.swift
+++ b/Example/Messaging/Sample/Sample/SceneDelegate.swift
@@ -26,7 +26,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, MessagingDelegate {
              options connectionOptions: UIScene.ConnectionOptions) {
     let contentView = ContentView()
     // Use a UIHostingController as window root view controller.
-    Messaging.messaging().delegate = self
     if let windowScene = scene as? UIWindowScene {
       let window = UIWindow(windowScene: windowScene)
       window
@@ -35,9 +34,27 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, MessagingDelegate {
       self.window = window
       window.makeKeyAndVisible()
     }
-  }
 
-  func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String) {
-    identity.token = fcmToken
+    // Subscribe to token refresh
+    _ = NotificationCenter.default
+      .publisher(for: Notification.Name.MessagingRegistrationTokenRefreshed)
+      .map { $0.object as? String }
+      .receive(on: RunLoop.main)
+      .assign(to: \Identity.token, on: identity)
+
+    // Subscribe to fid changes
+    _ = NotificationCenter.default
+      .publisher(for: Notification.Name.FIRInstallationIDDidChange)
+      .map { _ in }
+      .receive(on: RunLoop.main)
+      .sink(receiveValue: {
+        Installations.installations().installationID(completion: { fid, error in
+          if let error = error as NSError? {
+            print("Failed to get FID: ", error)
+            return
+          }
+          self.identity.instanceID = fid ?? "None"
+          })
+        })
   }
 }

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -839,7 +839,6 @@ static FIRInstanceID *gInstanceID;
       // Post the required notifications if somebody is waiting.
       FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeInstanceID008, @"Got default token %@",
                                token);
-      NSString *previousFCMToken = self.defaultFCMToken;
       // Update default FCM token, this method also triggers sending notification if token has
       // changed.
       self.defaultFCMToken = token;

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -250,8 +250,7 @@ static FIRInstanceID *gInstanceID;
   // Only notify of token refresh if we have a new valid token that's different than before
   if ((defaultFCMToken.length && _defaultFCMToken.length &&
        ![defaultFCMToken isEqualToString:_defaultFCMToken]) ||
-      (defaultFCMToken.length && !_defaultFCMToken.length) ||
-      (!defaultFCMToken.length && _defaultFCMToken.length)) {
+      defaultFCMToken.length != _defaultFCMToken.length) {
     NSNotification *tokenRefreshNotification =
         [NSNotification notificationWithName:kFIRInstanceIDTokenRefreshNotification
                                       object:[defaultFCMToken copy]];

--- a/Firebase/InstanceID/FIRInstanceIDConstants.h
+++ b/Firebase/InstanceID/FIRInstanceIDConstants.h
@@ -29,7 +29,6 @@ FOUNDATION_EXPORT NSString *const kFIRInstanceID_CMD_RST;
 /// Notification used to deliver GCM messages for InstanceID.
 FOUNDATION_EXPORT NSString *const kFIRInstanceIDCheckinFetchedNotification;
 FOUNDATION_EXPORT NSString *const kFIRInstanceIDAPNSTokenNotification;
-FOUNDATION_EXPORT NSString *const kFIRInstanceIDDefaultGCMTokenNotification;
 FOUNDATION_EXPORT NSString *const kFIRInstanceIDDefaultGCMTokenFailNotification;
 
 FOUNDATION_EXPORT NSString *const kFIRInstanceIDIdentityInvalidatedNotification;

--- a/Firebase/InstanceID/FIRInstanceIDConstants.m
+++ b/Firebase/InstanceID/FIRInstanceIDConstants.m
@@ -22,7 +22,6 @@ NSString *const kFIRInstanceID_CMD_RST = @"RST";
 // NOTIFICATIONS
 NSString *const kFIRInstanceIDCheckinFetchedNotification = @"com.google.gcm.notif-checkin-fetched";
 NSString *const kFIRInstanceIDAPNSTokenNotification = @"com.firebase.iid.notif.apns-token";
-NSString *const kFIRInstanceIDDefaultGCMTokenNotification = @"com.firebase.iid.notif.fcm-token";
 NSString *const kFIRInstanceIDDefaultGCMTokenFailNotification =
     @"com.firebase.iid.notif.fcm-token-fail";
 

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -944,8 +944,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   self.defaultFcmToken = [token copy];
   if ((self.defaultFcmToken.length && oldToken.length &&
        ![self.defaultFcmToken isEqualToString:oldToken]) ||
-      (self.defaultFcmToken.length && !oldToken.length) ||
-      (!self.defaultFcmToken.length && oldToken.length)) {
+      self.defaultFcmToken.length != oldToken.length) {
     [self notifyDelegateOfFCMTokenAvailability];
     [self.pubsub scheduleSync:YES];
 #pragma clang diagnostic push

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -659,8 +659,10 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   if ([self.delegate respondsToSelector:@selector(messaging:didReceiveRegistrationToken:)]) {
     [self.delegate messaging:self didReceiveRegistrationToken:self.defaultFcmToken];
   }
+  // Should always trigger the token refresh notification when the delegate method is called
   NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-  [center postNotificationName:FIRMessagingRegistrationTokenRefreshedNotification object:nil];
+  [center postNotificationName:FIRMessagingRegistrationTokenRefreshedNotification
+                        object:self.defaultFcmToken];
 }
 
 #pragma mark - Application State Changes

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -954,7 +954,8 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 }
 
 - (void)defaultInstanceIDTokenWasRefreshed:(NSNotification *)notification {
-  // Retrieve the Instance ID default token, and if it is non-nil, post it
+  // Retrieve the Instance ID default token, and should notify delegate and
+  // trigger notification as long as the token is different from previous state.
   NSString *token = self.instanceID.token;
   NSString *oldToken = self.defaultFcmToken;
   self.defaultFcmToken = [token copy];

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -940,7 +940,8 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   }
   NSString *oldToken = self.defaultFcmToken;
   self.defaultFcmToken = [(NSString *)notification.object copy];
-  if (self.defaultFcmToken && ![self.defaultFcmToken isEqualToString:oldToken]) {
+  if ((self.defaultFcmToken && ![self.defaultFcmToken isEqualToString:oldToken]) ||
+      (self.defaultFcmToken && !oldToken) || (!self.defaultFcmToken && oldToken)) {
     [self notifyDelegateOfFCMTokenAvailability];
   }
   [self.pubsub scheduleSync:YES];
@@ -955,18 +956,14 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 - (void)defaultInstanceIDTokenWasRefreshed:(NSNotification *)notification {
   // Retrieve the Instance ID default token, and if it is non-nil, post it
   NSString *token = self.instanceID.token;
-  // Sometimes Instance ID doesn't yet have a token, so wait until the default
-  // token is fetched, and then notify. This ensures that this token should not
-  // be nil when the developer accesses it.
-  if (token != nil) {
-    NSString *oldToken = self.defaultFcmToken;
-    self.defaultFcmToken = [token copy];
-    if (self.defaultFcmToken && ![self.defaultFcmToken isEqualToString:oldToken]) {
-      [self notifyDelegateOfFCMTokenAvailability];
-    }
-    NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-    [center postNotificationName:FIRMessagingRegistrationTokenRefreshedNotification object:nil];
+  NSString *oldToken = self.defaultFcmToken;
+  self.defaultFcmToken = [token copy];
+  if ((self.defaultFcmToken && ![self.defaultFcmToken isEqualToString:oldToken]) ||
+      (self.defaultFcmToken && !oldToken) || (!self.defaultFcmToken && oldToken)) {
+    [self notifyDelegateOfFCMTokenAvailability];
   }
+  NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+  [center postNotificationName:FIRMessagingRegistrationTokenRefreshedNotification object:nil];
 }
 
 #pragma mark - Application Support Directory

--- a/Firebase/Messaging/FIRMessaging.m
+++ b/Firebase/Messaging/FIRMessaging.m
@@ -664,6 +664,8 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
   if ([self.delegate respondsToSelector:@selector(messaging:didReceiveRegistrationToken:)]) {
     [self.delegate messaging:self didReceiveRegistrationToken:self.defaultFcmToken];
   }
+  NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
+  [center postNotificationName:FIRMessagingRegistrationTokenRefreshedNotification object:nil];
 }
 
 #pragma mark - Application State Changes
@@ -963,8 +965,6 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
       (self.defaultFcmToken && !oldToken) || (!self.defaultFcmToken && oldToken)) {
     [self notifyDelegateOfFCMTokenAvailability];
   }
-  NSNotificationCenter *center = [NSNotificationCenter defaultCenter];
-  [center postNotificationName:FIRMessagingRegistrationTokenRefreshedNotification object:nil];
 }
 
 #pragma mark - Application Support Directory

--- a/Firebase/Messaging/FIRMessagingConstants.h
+++ b/Firebase/Messaging/FIRMessagingConstants.h
@@ -50,8 +50,6 @@ FOUNDATION_EXPORT NSString *const kFIRMessagingSubDirectoryName;
 FOUNDATION_EXPORT NSString *const kFIRMessagingCheckinFetchedNotification;
 FOUNDATION_EXPORT NSString *const kFIRMessagingAPNSTokenNotification;
 FOUNDATION_EXPORT NSString *const kFIRMessagingFCMTokenNotification;
-FOUNDATION_EXPORT NSString *const kFIRMessagingInstanceIDTokenRefreshNotification
-    __deprecated_msg("Use kFIRMessagingRegistrationTokenRefreshNotification instead");
 FOUNDATION_EXPORT NSString *const kFIRMessagingRegistrationTokenRefreshNotification;
 
 FOUNDATION_EXPORT const int kFIRMessagingSendTtlDefault;  // 24 hours

--- a/Firebase/Messaging/FIRMessagingConstants.h
+++ b/Firebase/Messaging/FIRMessagingConstants.h
@@ -49,7 +49,6 @@ FOUNDATION_EXPORT NSString *const kFIRMessagingSubDirectoryName;
 // Notifications
 FOUNDATION_EXPORT NSString *const kFIRMessagingCheckinFetchedNotification;
 FOUNDATION_EXPORT NSString *const kFIRMessagingAPNSTokenNotification;
-FOUNDATION_EXPORT NSString *const kFIRMessagingFCMTokenNotification;
 FOUNDATION_EXPORT NSString *const kFIRMessagingRegistrationTokenRefreshNotification;
 
 FOUNDATION_EXPORT const int kFIRMessagingSendTtlDefault;  // 24 hours

--- a/Firebase/Messaging/FIRMessagingConstants.m
+++ b/Firebase/Messaging/FIRMessagingConstants.m
@@ -53,8 +53,6 @@ NSString *const kFIRMessagingSubDirectoryName = @"Google/FirebaseMessaging";
 NSString *const kFIRMessagingCheckinFetchedNotification = @"com.google.gcm.notif-checkin-fetched";
 NSString *const kFIRMessagingAPNSTokenNotification = @"com.firebase.iid.notif.apns-token";
 NSString *const kFIRMessagingFCMTokenNotification = @"com.firebase.iid.notif.fcm-token";
-NSString *const kFIRMessagingInstanceIDTokenRefreshNotification =
-    @"com.firebase.iid.notif.refresh-token";
 NSString *const kFIRMessagingRegistrationTokenRefreshNotification =
     @"com.firebase.iid.notif.refresh-token";
 

--- a/Firebase/Messaging/FIRMessagingConstants.m
+++ b/Firebase/Messaging/FIRMessagingConstants.m
@@ -52,7 +52,6 @@ NSString *const kFIRMessagingSubDirectoryName = @"Google/FirebaseMessaging";
 // Notifications
 NSString *const kFIRMessagingCheckinFetchedNotification = @"com.google.gcm.notif-checkin-fetched";
 NSString *const kFIRMessagingAPNSTokenNotification = @"com.firebase.iid.notif.apns-token";
-NSString *const kFIRMessagingFCMTokenNotification = @"com.firebase.iid.notif.fcm-token";
 NSString *const kFIRMessagingRegistrationTokenRefreshNotification =
     @"com.firebase.iid.notif.refresh-token";
 


### PR DESCRIPTION
Fix #5338: When a token is deleted by calling `deleteToken` method, messaging doesn't trigger FIRMessagingRegistrationTokenRefreshedNotification notification or calling the FIRMessagingDelegate `messaging:didReceiveRegistrationToken:` method.

Hence the token parameter in the delegate API `messaging:didReceiveRegistrationToken:`should be nullable, a change we might need to get in the next breaking change API.

Update:
I also cleanup the code and realize IID send out two notifications  (kFIRInstanceIDDefaultGCMTokenNotification, kFIRInstanceIDTokenRefreshNotification) when fcm token is updated. Sometimes it calls one, while other time it calls the other. These two notifications are essentially doing the exactly the same thing. So I replaced one that is not in the public API of IID.

Note: I was trying out combine with FIRMessagingRegistrationTokenRefreshedNotification and want to use token refresh notification/delegate to update the environment variable identity to reflect on UI  on demand rather than manual update, then I discover this issue. 