### PR TITLE
Add companion watchOS test app targets in GDTCCTWatchOSTestApp

### DIFF
--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,81 @@
+{
+  "images" : [
+    {
+      "size" : "24x24",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "notificationCenter",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "27.5x27.5",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "notificationCenter",
+      "subtype" : "42mm"
+    },
+    {
+      "size" : "29x29",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "2x"
+    },
+    {
+      "size" : "29x29",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "3x"
+    },
+    {
+      "size" : "40x40",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "appLauncher",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "44x44",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "appLauncher",
+      "subtype" : "40mm"
+    },
+    {
+      "size" : "50x50",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "appLauncher",
+      "subtype" : "44mm"
+    },
+    {
+      "size" : "86x86",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "quickLook",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "98x98",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "quickLook",
+      "subtype" : "42mm"
+    },
+    {
+      "size" : "108x108",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "quickLook",
+      "subtype" : "44mm"
+    },
+    {
+      "idiom" : "watch-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestApp/Assets.xcassets/Contents.json
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestApp/Base.lproj/Interface.storyboard
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestApp/Base.lproj/Interface.storyboard
@@ -9,33 +9,33 @@
         <!--Interface Controller-->
         <scene sceneID="aou-V4-d1y">
             <objects>
-                <controller id="AgC-eL-Hgc" customClass="InterfaceController" customModule="GDTCCTWatchOSIndependentTestAppWatchKitExtension">
+                <controller id="AgC-eL-Hgc" customClass="InterfaceController" customModule="GDTCCTWatchOSCompanionTestAppExtension">
                     <items>
-                        <label alignment="left" text="GDTCCT WatchOS" textAlignment="right" id="E4H-Lv-ipa"/>
-                        <label alignment="left" text="Independent App" id="f6I-UM-lxY"/>
-                        <button width="1" alignment="left" title="Generate data event" id="SDN-zp-3kg">
+                        <label alignment="left" text="GDTCCT WatchOS" id="enM-ff-MSy"/>
+                        <label alignment="left" text="Companion App" id="OLR-hF-Agn"/>
+                        <button width="1" alignment="left" title="Generate data event" id="dEM-Z3-j9g">
                             <connections>
-                                <action selector="generateDataEventWithSender:" destination="AgC-eL-Hgc" id="hI7-d4-EWo"/>
+                                <action selector="generateDataEventCompanionWithSender:" destination="AgC-eL-Hgc" id="RMn-3g-t3b"/>
                             </connections>
                         </button>
-                        <button width="1" alignment="left" title="Generate telemetry event" id="bRh-1z-40x">
+                        <button width="1" alignment="left" title="Generate telemetry event" id="gTg-To-hfh">
                             <connections>
-                                <action selector="generateTelemetryEventWithSender:" destination="AgC-eL-Hgc" id="aQO-I3-aFO"/>
+                                <action selector="generateTelemetryEventCompanionWithSender:" destination="AgC-eL-Hgc" id="lfu-Y3-vLm"/>
                             </connections>
                         </button>
-                        <button width="1" alignment="left" title="Generate high priority event (force uploads)" id="bzu-1O-6S2">
+                        <button width="1" alignment="left" title="Generate high priority event(force uploads)" id="5Xn-k8-nuY">
                             <connections>
-                                <action selector="generateHighPriorityEventWithSender:" destination="AgC-eL-Hgc" id="IAi-r4-KCA"/>
+                                <action selector="generateHighPriorityEventCompanionWithSender:" destination="AgC-eL-Hgc" id="1FC-XA-3lG"/>
                             </connections>
                         </button>
-                        <button width="1" alignment="left" title="Generate wifi only event" id="da7-Zz-zze">
+                        <button width="1" alignment="left" title="Generate wifi only event" id="bLI-vr-mjx">
                             <connections>
-                                <action selector="generateWifiOnlyEventWithSender:" destination="AgC-eL-Hgc" id="IC0-V3-uhA"/>
+                                <action selector="generateWifiOnlyEventCompanionWithSender:" destination="AgC-eL-Hgc" id="eyP-kf-ntj"/>
                             </connections>
                         </button>
-                        <button width="1" alignment="left" title="Generate daily event" id="3Nn-BQ-WRt">
+                        <button width="1" alignment="left" title="Generate daily event" id="CP1-1N-rkd">
                             <connections>
-                                <action selector="generateDailyEventWithSender:" destination="AgC-eL-Hgc" id="dSY-KB-Rcn"/>
+                                <action selector="generateDailyEventCompanionWithSender:" destination="AgC-eL-Hgc" id="8a4-di-RWZ"/>
                             </connections>
                         </button>
                     </items>
@@ -63,14 +63,14 @@
         <!--Notification Controller-->
         <scene sceneID="ZPc-GJ-vnh">
             <objects>
-                <controller id="4sK-HA-Art" customClass="NotificationController" customModule="GDTCCTWatchOSIndependentTestAppWatchKitApp" customModuleProvider="target"/>
+                <controller id="4sK-HA-Art" customClass="NotificationController" customModule="GDTCCTWatchOSCompanionTestApp" customModuleProvider="target"/>
             </objects>
             <point key="canvasLocation" x="468" y="643"/>
         </scene>
         <!--Notification Controller-->
         <scene sceneID="Niz-AI-uX2">
             <objects>
-                <controller id="eXb-UN-Cd0" customClass="NotificationController" customModule="GDTCCTWatchOSIndependentTestAppWatchKitApp" customModuleProvider="target"/>
+                <controller id="eXb-UN-Cd0" customClass="NotificationController" customModule="GDTCCTWatchOSCompanionTestApp" customModuleProvider="target"/>
             </objects>
             <point key="canvasLocation" x="468" y="345"/>
         </scene>

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestApp/Info.plist
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestApp/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>GDTCCTiOSTestAppForCompanionWatchApp</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>GoogleDataTransport.GDTCCTiOSTestAppForCompanionWatchApp</string>
+	<key>WKWatchKitApp</key>
+	<true/>
+</dict>
+</plist>

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Complication.complicationset/Circular.imageset/Contents.json
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Complication.complicationset/Circular.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Complication.complicationset/Contents.json
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Complication.complicationset/Contents.json
@@ -1,0 +1,48 @@
+{
+  "assets" : [
+    {
+      "idiom" : "watch",
+      "filename" : "Circular.imageset",
+      "role" : "circular"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Extra Large.imageset",
+      "role" : "extra-large"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Graphic Bezel.imageset",
+      "role" : "graphic-bezel"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Graphic Circular.imageset",
+      "role" : "graphic-circular"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Graphic Corner.imageset",
+      "role" : "graphic-corner"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Graphic Large Rectangular.imageset",
+      "role" : "graphic-large-rectangular"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Modular.imageset",
+      "role" : "modular"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Utilitarian.imageset",
+      "role" : "utilitarian"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Complication.complicationset/Extra Large.imageset/Contents.json
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Complication.complicationset/Extra Large.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Complication.complicationset/Graphic Bezel.imageset/Contents.json
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Complication.complicationset/Graphic Bezel.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Complication.complicationset/Graphic Circular.imageset/Contents.json
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Complication.complicationset/Graphic Circular.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Complication.complicationset/Graphic Corner.imageset/Contents.json
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Complication.complicationset/Graphic Corner.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Complication.complicationset/Graphic Large Rectangular.imageset/Contents.json
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Complication.complicationset/Graphic Large Rectangular.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Complication.complicationset/Modular.imageset/Contents.json
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Complication.complicationset/Modular.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Complication.complicationset/Utilitarian.imageset/Contents.json
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Complication.complicationset/Utilitarian.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Contents.json
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/ExtensionDelegate.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/ExtensionDelegate.swift
@@ -16,5 +16,4 @@
 
 import WatchKit
 
-class ExtensionDelegate: NSObject, WKExtensionDelegate {
-}
+class ExtensionDelegate: NSObject, WKExtensionDelegate {}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/ExtensionDelegate.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/ExtensionDelegate.swift
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import WatchKit
+
+class ExtensionDelegate: NSObject, WKExtensionDelegate {
+  func applicationDidFinishLaunching() {
+    // Perform any final initialization of your application.
+  }
+
+  func applicationDidBecomeActive() {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+  }
+
+  func applicationWillResignActive() {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, etc.
+  }
+
+  func handle(_ backgroundTasks: Set<WKRefreshBackgroundTask>) {
+    // Sent when the system needs to launch the application in the background to process tasks. Tasks arrive in a set, so loop through and process each one.
+    for task in backgroundTasks {
+      // Use a switch statement to check the task type
+      switch task {
+      case let backgroundTask as WKApplicationRefreshBackgroundTask:
+        // Be sure to complete the background task once you’re done.
+        backgroundTask.setTaskCompletedWithSnapshot(false)
+      case let snapshotTask as WKSnapshotRefreshBackgroundTask:
+        // Snapshot tasks have a unique completion call, make sure to set your expiration date
+        snapshotTask.setTaskCompleted(restoredDefaultState: true, estimatedSnapshotExpiration: Date.distantFuture, userInfo: nil)
+      case let connectivityTask as WKWatchConnectivityRefreshBackgroundTask:
+        // Be sure to complete the connectivity task once you’re done.
+        connectivityTask.setTaskCompletedWithSnapshot(false)
+      case let urlSessionTask as WKURLSessionRefreshBackgroundTask:
+        // Be sure to complete the URL session task once you’re done.
+        urlSessionTask.setTaskCompletedWithSnapshot(false)
+      case let relevantShortcutTask as WKRelevantShortcutRefreshBackgroundTask:
+        // Be sure to complete the relevant-shortcut task once you're done.
+        relevantShortcutTask.setTaskCompletedWithSnapshot(false)
+      case let intentDidRunTask as WKIntentDidRunRefreshBackgroundTask:
+        // Be sure to complete the intent-did-run task once you're done.
+        intentDidRunTask.setTaskCompletedWithSnapshot(false)
+      default:
+        // make sure to complete unhandled task types
+        task.setTaskCompletedWithSnapshot(false)
+      }
+    }
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/ExtensionDelegate.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/ExtensionDelegate.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,46 +17,4 @@
 import WatchKit
 
 class ExtensionDelegate: NSObject, WKExtensionDelegate {
-  func applicationDidFinishLaunching() {
-    // Perform any final initialization of your application.
-  }
-
-  func applicationDidBecomeActive() {
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-  }
-
-  func applicationWillResignActive() {
-    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-    // Use this method to pause ongoing tasks, disable timers, etc.
-  }
-
-  func handle(_ backgroundTasks: Set<WKRefreshBackgroundTask>) {
-    // Sent when the system needs to launch the application in the background to process tasks. Tasks arrive in a set, so loop through and process each one.
-    for task in backgroundTasks {
-      // Use a switch statement to check the task type
-      switch task {
-      case let backgroundTask as WKApplicationRefreshBackgroundTask:
-        // Be sure to complete the background task once you’re done.
-        backgroundTask.setTaskCompletedWithSnapshot(false)
-      case let snapshotTask as WKSnapshotRefreshBackgroundTask:
-        // Snapshot tasks have a unique completion call, make sure to set your expiration date
-        snapshotTask.setTaskCompleted(restoredDefaultState: true, estimatedSnapshotExpiration: Date.distantFuture, userInfo: nil)
-      case let connectivityTask as WKWatchConnectivityRefreshBackgroundTask:
-        // Be sure to complete the connectivity task once you’re done.
-        connectivityTask.setTaskCompletedWithSnapshot(false)
-      case let urlSessionTask as WKURLSessionRefreshBackgroundTask:
-        // Be sure to complete the URL session task once you’re done.
-        urlSessionTask.setTaskCompletedWithSnapshot(false)
-      case let relevantShortcutTask as WKRelevantShortcutRefreshBackgroundTask:
-        // Be sure to complete the relevant-shortcut task once you're done.
-        relevantShortcutTask.setTaskCompletedWithSnapshot(false)
-      case let intentDidRunTask as WKIntentDidRunRefreshBackgroundTask:
-        // Be sure to complete the intent-did-run task once you're done.
-        intentDidRunTask.setTaskCompletedWithSnapshot(false)
-      default:
-        // make sure to complete unhandled task types
-        task.setTaskCompletedWithSnapshot(false)
-      }
-    }
-  }
 }

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Info.plist
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>WKAppBundleIdentifier</key>
+			<string>GoogleDataTransport.GDTCCTiOSTestAppForCompanionWatchApp.watchkitapp</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.watchkit</string>
+	</dict>
+	<key>WKExtensionDelegateClassName</key>
+	<string>$(PRODUCT_MODULE_NAME).ExtensionDelegate</string>
+</dict>
+</plist>

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/InterfaceController.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/InterfaceController.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/InterfaceController.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/InterfaceController.swift
@@ -20,11 +20,9 @@ import GoogleDataTransport
 
 class InterfaceController: WKInterfaceController {
   var transport: GDTCORTransport = GDTCORTransport(mappingID: "1018", transformers: nil, target: GDTCORTarget.CCT.rawValue)!
-  // TODO: Segmented control for FLL and CSH
 
   override func awake(withContext context: Any?) {
     super.awake(withContext: context)
-
     // Configure interface objects here.
   }
 
@@ -38,12 +36,12 @@ class InterfaceController: WKInterfaceController {
     super.didDeactivate()
   }
 
-  @IBAction func generateDataEvent(sender: AnyObject?) {
-    print("Generating data event on independent watch app")
+  @IBAction func generateDataEventCompanion(sender: AnyObject?) {
+    print("Generating data event on Companion watch app")
     let transportToUse = transport
     let event: GDTCOREvent = transportToUse.eventForTransport()
     let testMessage = FirelogTestMessageHolder()
-    testMessage.root.identifier = "watchos_test_app_data_event"
+    testMessage.root.identifier = "watchos_companion_test_app_data_event"
     testMessage.root.repeatedID = ["id1", "id2", "id3"]
     testMessage.root.warriorChampionships = 1_111_110
     testMessage.root.subMessage.starTrekData = "technoBabble".data(using: String.Encoding.utf8)!
@@ -57,12 +55,12 @@ class InterfaceController: WKInterfaceController {
     transportToUse.sendDataEvent(event)
   }
 
-  @IBAction func generateTelemetryEvent(sender: AnyObject?) {
-    print("Generating telemetry event on independent watch app")
+  @IBAction func generateTelemetryEventCompanion(sender: AnyObject?) {
+    print("Generating telemetry event on Companion watch app")
     let transportToUse = transport
     let event: GDTCOREvent = transportToUse.eventForTransport()
     let testMessage = FirelogTestMessageHolder()
-    testMessage.root.identifier = "watchos_test_app_telemetry_event"
+    testMessage.root.identifier = "watchos_companion_test_app_telemetry_event"
     testMessage.root.warriorChampionships = 1000
     testMessage.root.subMessage.repeatedSubMessage = [
       SubMessageTwo(),
@@ -72,12 +70,12 @@ class InterfaceController: WKInterfaceController {
     transportToUse.sendTelemetryEvent(event)
   }
 
-  @IBAction func generateHighPriorityEvent(sender: AnyObject?) {
-    print("Generating high priority event on independent watch app")
+  @IBAction func generateHighPriorityEventCompanion(sender: AnyObject?) {
+    print("Generating high priority event on Companion watch app")
     let transportToUse = transport
     let event: GDTCOREvent = transportToUse.eventForTransport()
     let testMessage = FirelogTestMessageHolder()
-    testMessage.root.identifier = "watchos_test_app_high_priority_event"
+    testMessage.root.identifier = "watchos_companion_test_app_high_priority_event"
     testMessage.root.repeatedID = ["id1", "id2", "id3"]
     testMessage.root.warriorChampionships = 1337
     event.qosTier = GDTCOREventQoS.qoSFast
@@ -86,24 +84,24 @@ class InterfaceController: WKInterfaceController {
     transportToUse.sendDataEvent(event)
   }
 
-  @IBAction func generateWifiOnlyEvent(sender: AnyObject?) {
-    print("Generating wifi only event on independent watch app")
+  @IBAction func generateWifiOnlyEventCompanion(sender: AnyObject?) {
+    print("Generating wifi only event on Companion watch app")
     let transportToUse = transport
     let event: GDTCOREvent = transportToUse.eventForTransport()
     let testMessage = FirelogTestMessageHolder()
-    testMessage.root.identifier = "watchos_test_app_wifi_only_event"
+    testMessage.root.identifier = "watchos_companion_test_app_wifi_only_event"
     event.qosTier = GDTCOREventQoS.qoSWifiOnly
     event.dataObject = testMessage
     event.customPrioritizationParams = ["needs_network_connection_info": true]
     transportToUse.sendDataEvent(event)
   }
 
-  @IBAction func generateDailyEvent(sender: AnyObject?) {
-    print("Generating daily event on independent watch app")
+  @IBAction func generateDailyEventCompanion(sender: AnyObject?) {
+    print("Generating daily only event on Companion watch app")
     let transportToUse = transport
     let event: GDTCOREvent = transportToUse.eventForTransport()
     let testMessage = FirelogTestMessageHolder()
-    testMessage.root.identifier = "watchos_test_app_daily_event"
+    testMessage.root.identifier = "watchos_companion_test_app_daily_event"
     testMessage.root.repeatedID = ["id1", "id2", "id3"]
     testMessage.root.warriorChampionships = 9001
     testMessage.root.subMessage.starTrekData = "engage!".data(using: String.Encoding.utf8)!

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/InterfaceController.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/InterfaceController.swift
@@ -19,7 +19,7 @@ import Foundation
 import GoogleDataTransport
 
 class InterfaceController: WKInterfaceController {
-  var transport: GDTCORTransport = GDTCORTransport(mappingID: "1018", transformers: nil, target: GDTCORTarget.CCT.rawValue)!
+  var transport: GDTCORTransport = GDTCORTransport(mappingID: "1018", transformers: nil, target: GDTCORTarget.FLL.rawValue)!
 
   override func awake(withContext context: Any?) {
     super.awake(withContext: context)

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/NotificationController.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/NotificationController.swift
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import WatchKit
+import Foundation
+import UserNotifications
+
+class NotificationController: WKUserNotificationInterfaceController {
+  override init() {
+    // Initialize variables here.
+    super.init()
+
+    // Configure interface objects here.
+  }
+
+  override func willActivate() {
+    // This method is called when watch view controller is about to be visible to user
+    super.willActivate()
+  }
+
+  override func didDeactivate() {
+    // This method is called when watch view controller is no longer visible
+    super.didDeactivate()
+  }
+
+  override func didReceive(_ notification: UNNotification) {
+    // This method is called when a notification needs to be presented.
+    // Implement it if you use a dynamic notification interface.
+    // Populate your dynamic notification interface as quickly as possible.
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/NotificationController.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/NotificationController.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,23 +22,6 @@ class NotificationController: WKUserNotificationInterfaceController {
   override init() {
     // Initialize variables here.
     super.init()
-
     // Configure interface objects here.
-  }
-
-  override func willActivate() {
-    // This method is called when watch view controller is about to be visible to user
-    super.willActivate()
-  }
-
-  override func didDeactivate() {
-    // This method is called when watch view controller is no longer visible
-    super.didDeactivate()
-  }
-
-  override func didReceive(_ notification: UNNotification) {
-    // This method is called when a notification needs to be presented.
-    // Implement it if you use a dynamic notification interface.
-    // Populate your dynamic notification interface as quickly as possible.
   }
 }

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/PushNotificationPayload.apns
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/PushNotificationPayload.apns
@@ -1,0 +1,20 @@
+{
+    "aps": {
+        "alert": {
+            "body": "Test message",
+            "title": "Optional title",
+            "subtitle": "Optional subtitle"
+        },
+        "category": "myCategory",
+        "thread-id": "5280"
+    },
+    
+    "WatchKit Simulator Actions": [
+        {
+            "title": "First Button",
+            "identifier": "firstButtonAction"
+        }
+    ],
+    
+    "customKey": "Use this file to define a testing payload for your notifications. The aps dictionary specifies the category, alert text and title. The WatchKit Simulator Actions array can provide info for one or more action buttons in addition to the standard Dismiss button. Any other top level keys are custom payload. If you have multiple such JSON files in your project, you'll be able to select them when choosing to debug the notification interface of your Watch App."
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/PushNotificationPayload.apns
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/PushNotificationPayload.apns
@@ -8,13 +8,13 @@
         "category": "myCategory",
         "thread-id": "5280"
     },
-    
+
     "WatchKit Simulator Actions": [
         {
             "title": "First Button",
             "identifier": "firstButtonAction"
         }
     ],
-    
+
     "customKey": "Use this file to define a testing payload for your notifications. The aps dictionary specifies the category, alert text and title. The WatchKit Simulator Actions array can provide info for one or more action buttons in addition to the standard Dismiss button. Any other top level keys are custom payload. If you have multiple such JSON files in your project, you'll be able to select them when choosing to debug the notification interface of your Watch App."
 }

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSTestApp.xcodeproj/project.pbxproj
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSTestApp.xcodeproj/project.pbxproj
@@ -19,6 +19,23 @@
 		957EE5BB2406FDC6003B51B2 /* NotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957EE5BA2406FDC6003B51B2 /* NotificationController.swift */; };
 		957EE5BD2406FDC7003B51B2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 957EE5BC2406FDC7003B51B2 /* Assets.xcassets */; };
 		957EE5CE24070574003B51B2 /* gdthelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957EE5CD24070574003B51B2 /* gdthelpers.swift */; };
+		95B328E2243D30D4008C6971 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B328E1243D30D4008C6971 /* AppDelegate.swift */; };
+		95B328E4243D30D4008C6971 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B328E3243D30D4008C6971 /* SceneDelegate.swift */; };
+		95B328E6243D30D4008C6971 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B328E5243D30D4008C6971 /* ViewController.swift */; };
+		95B328E9243D30D4008C6971 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 95B328E7243D30D4008C6971 /* Main.storyboard */; };
+		95B328EB243D30D6008C6971 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 95B328EA243D30D6008C6971 /* Assets.xcassets */; };
+		95B328EE243D30D6008C6971 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 95B328EC243D30D6008C6971 /* LaunchScreen.storyboard */; };
+		95B328F9243D3345008C6971 /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 95B328F7243D3345008C6971 /* Interface.storyboard */; };
+		95B328FB243D3346008C6971 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 95B328FA243D3346008C6971 /* Assets.xcassets */; };
+		95B32902243D3346008C6971 /* GDTCCTWatchOSCompanionTestAppExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 95B32901243D3346008C6971 /* GDTCCTWatchOSCompanionTestAppExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		95B32907243D3346008C6971 /* InterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B32906243D3346008C6971 /* InterfaceController.swift */; };
+		95B32909243D3346008C6971 /* ExtensionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B32908243D3346008C6971 /* ExtensionDelegate.swift */; };
+		95B3290B243D3346008C6971 /* NotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B3290A243D3346008C6971 /* NotificationController.swift */; };
+		95B3290D243D3347008C6971 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 95B3290C243D3347008C6971 /* Assets.xcassets */; };
+		95B32912243D3347008C6971 /* GDTCCTWatchOSCompanionTestApp.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 95B328F5243D3345008C6971 /* GDTCCTWatchOSCompanionTestApp.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		95B3291C243D39B3008C6971 /* gdthelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B3291B243D39B3008C6971 /* gdthelpers.swift */; };
+		95B3291E243D39CB008C6971 /* flltest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B3291D243D39CB008C6971 /* flltest.pb.swift */; };
+		BFA52AA947EC86815A8D31C7 /* Pods_GDTCCTWatchOSCompanionTestAppExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07BEBC64EEDC2017032E076F /* Pods_GDTCCTWatchOSCompanionTestAppExtension.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -35,6 +52,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 957EE5B02406FDC6003B51B2;
 			remoteInfo = "GDTCCTWatchOSTestApp WatchKit Extension";
+		};
+		95B32903243D3346008C6971 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 957EE5982406FDC5003B51B2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 95B32900243D3346008C6971;
+			remoteInfo = "GDTCCTWatchOSCompanionTestApp Extension";
+		};
+		95B32910243D3347008C6971 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 957EE5982406FDC5003B51B2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 95B328F4243D3345008C6971;
+			remoteInfo = GDTCCTWatchOSCompanionTestApp;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -61,10 +92,33 @@
 			name = "Embed Watch Content";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		95B32916243D3347008C6971 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				95B32902243D3346008C6971 /* GDTCCTWatchOSCompanionTestAppExtension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		95B3291A243D3347008C6971 /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+				95B32912243D3347008C6971 /* GDTCCTWatchOSCompanionTestApp.app in Embed Watch Content */,
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		0359026575A15A395D60C31D /* Pods_GDTCCTWatchOSIndependentTestAppWatchKitApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GDTCCTWatchOSIndependentTestAppWatchKitApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		07BEBC64EEDC2017032E076F /* Pods_GDTCCTWatchOSCompanionTestAppExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GDTCCTWatchOSCompanionTestAppExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0FD1D7F29BF594EE7B5B370C /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp.debug.xcconfig"; path = "Target Support Files/Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp/Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp.debug.xcconfig"; sourceTree = "<group>"; };
 		2A543946CE0D1755649E3022 /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp.release.xcconfig"; path = "Target Support Files/Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp/Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp.release.xcconfig"; sourceTree = "<group>"; };
 		3E841C72AA54B4CD18A845E0 /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension.debug.xcconfig"; path = "Target Support Files/Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension/Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension.debug.xcconfig"; sourceTree = "<group>"; };
@@ -84,6 +138,29 @@
 		957EE5BE2406FDC7003B51B2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		957EE5BF2406FDC7003B51B2 /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushNotificationPayload.apns; sourceTree = "<group>"; };
 		957EE5CD24070574003B51B2 /* gdthelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = gdthelpers.swift; sourceTree = "<group>"; };
+		95B328DF243D30D4008C6971 /* GDTCCTiOSTestAppForCompanionWatchApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GDTCCTiOSTestAppForCompanionWatchApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		95B328E1243D30D4008C6971 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		95B328E3243D30D4008C6971 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		95B328E5243D30D4008C6971 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		95B328E8243D30D4008C6971 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		95B328EA243D30D6008C6971 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		95B328ED243D30D6008C6971 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		95B328EF243D30D6008C6971 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		95B328F5243D3345008C6971 /* GDTCCTWatchOSCompanionTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GDTCCTWatchOSCompanionTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		95B328F8243D3345008C6971 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Interface.storyboard; sourceTree = "<group>"; };
+		95B328FA243D3346008C6971 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		95B328FC243D3346008C6971 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		95B32901243D3346008C6971 /* GDTCCTWatchOSCompanionTestAppExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = GDTCCTWatchOSCompanionTestAppExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		95B32906243D3346008C6971 /* InterfaceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceController.swift; sourceTree = "<group>"; };
+		95B32908243D3346008C6971 /* ExtensionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDelegate.swift; sourceTree = "<group>"; };
+		95B3290A243D3346008C6971 /* NotificationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationController.swift; sourceTree = "<group>"; };
+		95B3290C243D3347008C6971 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		95B3290E243D3347008C6971 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		95B3290F243D3347008C6971 /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushNotificationPayload.apns; sourceTree = "<group>"; };
+		95B3291B243D39B3008C6971 /* gdthelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = gdthelpers.swift; path = ../../GDTCCTTestApp/gdthelpers.swift; sourceTree = "<group>"; };
+		95B3291D243D39CB008C6971 /* flltest.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = flltest.pb.swift; path = ../../GDTCCTTestApp/proto/flltest.pb.swift; sourceTree = "<group>"; };
+		9FAF90EE01D0F55358194796 /* Pods-GDTCCTWatchOSCompanionTestAppExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GDTCCTWatchOSCompanionTestAppExtension.debug.xcconfig"; path = "Target Support Files/Pods-GDTCCTWatchOSCompanionTestAppExtension/Pods-GDTCCTWatchOSCompanionTestAppExtension.debug.xcconfig"; sourceTree = "<group>"; };
+		FBDDEBD71C1B9E7464043558 /* Pods-GDTCCTWatchOSCompanionTestAppExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GDTCCTWatchOSCompanionTestAppExtension.release.xcconfig"; path = "Target Support Files/Pods-GDTCCTWatchOSCompanionTestAppExtension/Pods-GDTCCTWatchOSCompanionTestAppExtension.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -100,6 +177,28 @@
 			buildActionMask = 2147483647;
 			files = (
 				2047C1CB51687B364624D62B /* Pods_GDTCCTWatchOSIndependentTestAppWatchKitExtension.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		95B328DC243D30D4008C6971 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		95B328FE243D3346008C6971 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BFA52AA947EC86815A8D31C7 /* Pods_GDTCCTWatchOSCompanionTestAppExtension.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9B0B02BD8C2FBD1421B489F6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -120,6 +219,8 @@
 				2A543946CE0D1755649E3022 /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp.release.xcconfig */,
 				3E841C72AA54B4CD18A845E0 /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension.debug.xcconfig */,
 				77E102080D49A6C2889F0E3B /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension.release.xcconfig */,
+				9FAF90EE01D0F55358194796 /* Pods-GDTCCTWatchOSCompanionTestAppExtension.debug.xcconfig */,
+				FBDDEBD71C1B9E7464043558 /* Pods-GDTCCTWatchOSCompanionTestAppExtension.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -129,6 +230,7 @@
 			children = (
 				0359026575A15A395D60C31D /* Pods_GDTCCTWatchOSIndependentTestAppWatchKitApp.framework */,
 				5C55DD3705E7AB41A8669604 /* Pods_GDTCCTWatchOSIndependentTestAppWatchKitExtension.framework */,
+				07BEBC64EEDC2017032E076F /* Pods_GDTCCTWatchOSCompanionTestAppExtension.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -138,6 +240,9 @@
 			children = (
 				957EE5A62406FDC5003B51B2 /* GDTCCTWatchOSIndependentTestAppWatchKitApp */,
 				957EE5B52406FDC6003B51B2 /* GDTCCTWatchOSIndependentTestAppWatchKitExtension */,
+				95B328E0243D30D4008C6971 /* GDTCCTiOSTestAppForCompanionWatchApp */,
+				95B328F6243D3345008C6971 /* GDTCCTWatchOSCompanionTestApp */,
+				95B32905243D3346008C6971 /* GDTCCTWatchOSCompanionTestAppExtension */,
 				957EE59F2406FDC5003B51B2 /* Products */,
 				770E1356BCADE7C77E8F83ED /* Pods */,
 				7787C4E7768F3C6333331B64 /* Frameworks */,
@@ -150,6 +255,9 @@
 				957EE59E2406FDC5003B51B2 /* GDTCCTWatchOSTestApp.app */,
 				957EE5A22406FDC5003B51B2 /* GDTCCTWatchOSIndependentTestAppWatchKitApp.app */,
 				957EE5B12406FDC6003B51B2 /* GDTCCTWatchOSIndependentTestAppWatchKitExtension.appex */,
+				95B328DF243D30D4008C6971 /* GDTCCTiOSTestAppForCompanionWatchApp.app */,
+				95B328F5243D3345008C6971 /* GDTCCTWatchOSCompanionTestApp.app */,
+				95B32901243D3346008C6971 /* GDTCCTWatchOSCompanionTestAppExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -177,6 +285,45 @@
 				957EE5CD24070574003B51B2 /* gdthelpers.swift */,
 			);
 			path = GDTCCTWatchOSIndependentTestAppWatchKitExtension;
+			sourceTree = "<group>";
+		};
+		95B328E0243D30D4008C6971 /* GDTCCTiOSTestAppForCompanionWatchApp */ = {
+			isa = PBXGroup;
+			children = (
+				95B328E1243D30D4008C6971 /* AppDelegate.swift */,
+				95B328E3243D30D4008C6971 /* SceneDelegate.swift */,
+				95B328E5243D30D4008C6971 /* ViewController.swift */,
+				95B328E7243D30D4008C6971 /* Main.storyboard */,
+				95B328EA243D30D6008C6971 /* Assets.xcassets */,
+				95B328EC243D30D6008C6971 /* LaunchScreen.storyboard */,
+				95B328EF243D30D6008C6971 /* Info.plist */,
+			);
+			path = GDTCCTiOSTestAppForCompanionWatchApp;
+			sourceTree = "<group>";
+		};
+		95B328F6243D3345008C6971 /* GDTCCTWatchOSCompanionTestApp */ = {
+			isa = PBXGroup;
+			children = (
+				95B328F7243D3345008C6971 /* Interface.storyboard */,
+				95B328FA243D3346008C6971 /* Assets.xcassets */,
+				95B328FC243D3346008C6971 /* Info.plist */,
+			);
+			path = GDTCCTWatchOSCompanionTestApp;
+			sourceTree = "<group>";
+		};
+		95B32905243D3346008C6971 /* GDTCCTWatchOSCompanionTestAppExtension */ = {
+			isa = PBXGroup;
+			children = (
+				95B32906243D3346008C6971 /* InterfaceController.swift */,
+				95B32908243D3346008C6971 /* ExtensionDelegate.swift */,
+				95B3290A243D3346008C6971 /* NotificationController.swift */,
+				95B3291B243D39B3008C6971 /* gdthelpers.swift */,
+				95B3291D243D39CB008C6971 /* flltest.pb.swift */,
+				95B3290C243D3347008C6971 /* Assets.xcassets */,
+				95B3290E243D3347008C6971 /* Info.plist */,
+				95B3290F243D3347008C6971 /* PushNotificationPayload.apns */,
+			);
+			path = GDTCCTWatchOSCompanionTestAppExtension;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -238,6 +385,62 @@
 			productReference = 957EE5B12406FDC6003B51B2 /* GDTCCTWatchOSIndependentTestAppWatchKitExtension.appex */;
 			productType = "com.apple.product-type.watchkit2-extension";
 		};
+		95B328DE243D30D4008C6971 /* GDTCCTiOSTestAppForCompanionWatchApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 95B328F2243D30D6008C6971 /* Build configuration list for PBXNativeTarget "GDTCCTiOSTestAppForCompanionWatchApp" */;
+			buildPhases = (
+				95B328DB243D30D4008C6971 /* Sources */,
+				95B328DC243D30D4008C6971 /* Frameworks */,
+				95B328DD243D30D4008C6971 /* Resources */,
+				95B3291A243D3347008C6971 /* Embed Watch Content */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				95B32911243D3347008C6971 /* PBXTargetDependency */,
+			);
+			name = GDTCCTiOSTestAppForCompanionWatchApp;
+			productName = GDTCCTiOSTestAppForCompanionWatchApp;
+			productReference = 95B328DF243D30D4008C6971 /* GDTCCTiOSTestAppForCompanionWatchApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+		95B328F4243D3345008C6971 /* GDTCCTWatchOSCompanionTestApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 95B32917243D3347008C6971 /* Build configuration list for PBXNativeTarget "GDTCCTWatchOSCompanionTestApp" */;
+			buildPhases = (
+				95B328F3243D3345008C6971 /* Resources */,
+				95B32916243D3347008C6971 /* Embed App Extensions */,
+				9B0B02BD8C2FBD1421B489F6 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				95B32904243D3346008C6971 /* PBXTargetDependency */,
+			);
+			name = GDTCCTWatchOSCompanionTestApp;
+			productName = GDTCCTWatchOSCompanionTestApp;
+			productReference = 95B328F5243D3345008C6971 /* GDTCCTWatchOSCompanionTestApp.app */;
+			productType = "com.apple.product-type.application.watchapp2";
+		};
+		95B32900243D3346008C6971 /* GDTCCTWatchOSCompanionTestAppExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 95B32913243D3347008C6971 /* Build configuration list for PBXNativeTarget "GDTCCTWatchOSCompanionTestAppExtension" */;
+			buildPhases = (
+				22375B90055DAD70200F0958 /* [CP] Check Pods Manifest.lock */,
+				95B328FD243D3346008C6971 /* Sources */,
+				95B328FE243D3346008C6971 /* Frameworks */,
+				95B328FF243D3346008C6971 /* Resources */,
+				4D4FCC9AE3CA73E5C24DF4C5 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = GDTCCTWatchOSCompanionTestAppExtension;
+			productName = "GDTCCTWatchOSCompanionTestApp Extension";
+			productReference = 95B32901243D3346008C6971 /* GDTCCTWatchOSCompanionTestAppExtension.appex */;
+			productType = "com.apple.product-type.watchkit2-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -259,6 +462,15 @@
 					957EE5B02406FDC6003B51B2 = {
 						CreatedOnToolsVersion = 11.3;
 					};
+					95B328DE243D30D4008C6971 = {
+						CreatedOnToolsVersion = 11.3;
+					};
+					95B328F4243D3345008C6971 = {
+						CreatedOnToolsVersion = 11.3;
+					};
+					95B32900243D3346008C6971 = {
+						CreatedOnToolsVersion = 11.3;
+					};
 				};
 			};
 			buildConfigurationList = 957EE59B2406FDC5003B51B2 /* Build configuration list for PBXProject "GDTCCTWatchOSTestApp" */;
@@ -277,6 +489,9 @@
 				957EE59D2406FDC5003B51B2 /* GDTCCTWatchOSTestApp */,
 				957EE5A12406FDC5003B51B2 /* GDTCCTWatchOSIndependentTestAppWatchKitApp */,
 				957EE5B02406FDC6003B51B2 /* GDTCCTWatchOSIndependentTestAppWatchKitExtension */,
+				95B328DE243D30D4008C6971 /* GDTCCTiOSTestAppForCompanionWatchApp */,
+				95B328F4243D3345008C6971 /* GDTCCTWatchOSCompanionTestApp */,
+				95B32900243D3346008C6971 /* GDTCCTWatchOSCompanionTestAppExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -306,9 +521,58 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		95B328DD243D30D4008C6971 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				95B328EE243D30D6008C6971 /* LaunchScreen.storyboard in Resources */,
+				95B328EB243D30D6008C6971 /* Assets.xcassets in Resources */,
+				95B328E9243D30D4008C6971 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		95B328F3243D3345008C6971 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				95B328FB243D3346008C6971 /* Assets.xcassets in Resources */,
+				95B328F9243D3345008C6971 /* Interface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		95B328FF243D3346008C6971 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				95B3290D243D3347008C6971 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		22375B90055DAD70200F0958 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-GDTCCTWatchOSCompanionTestAppExtension-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		4CAC65BC31BE3D98BA423F8B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -329,6 +593,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		4D4FCC9AE3CA73E5C24DF4C5 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-GDTCCTWatchOSCompanionTestAppExtension/Pods-GDTCCTWatchOSCompanionTestAppExtension-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-GDTCCTWatchOSCompanionTestAppExtension/Pods-GDTCCTWatchOSCompanionTestAppExtension-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-GDTCCTWatchOSCompanionTestAppExtension/Pods-GDTCCTWatchOSCompanionTestAppExtension-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		79FF95479D2D864D65C8D48E /* [CP] Check Pods Manifest.lock */ = {
@@ -385,6 +666,28 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		95B328DB243D30D4008C6971 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				95B328E6243D30D4008C6971 /* ViewController.swift in Sources */,
+				95B328E2243D30D4008C6971 /* AppDelegate.swift in Sources */,
+				95B328E4243D30D4008C6971 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		95B328FD243D3346008C6971 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				95B3290B243D3346008C6971 /* NotificationController.swift in Sources */,
+				95B3291E243D39CB008C6971 /* flltest.pb.swift in Sources */,
+				95B3291C243D39B3008C6971 /* gdthelpers.swift in Sources */,
+				95B32909243D3346008C6971 /* ExtensionDelegate.swift in Sources */,
+				95B32907243D3346008C6971 /* InterfaceController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -398,6 +701,16 @@
 			target = 957EE5B02406FDC6003B51B2 /* GDTCCTWatchOSIndependentTestAppWatchKitExtension */;
 			targetProxy = 957EE5B32406FDC6003B51B2 /* PBXContainerItemProxy */;
 		};
+		95B32904243D3346008C6971 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 95B32900243D3346008C6971 /* GDTCCTWatchOSCompanionTestAppExtension */;
+			targetProxy = 95B32903243D3346008C6971 /* PBXContainerItemProxy */;
+		};
+		95B32911243D3347008C6971 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 95B328F4243D3345008C6971 /* GDTCCTWatchOSCompanionTestApp */;
+			targetProxy = 95B32910243D3347008C6971 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
@@ -405,6 +718,30 @@
 			isa = PBXVariantGroup;
 			children = (
 				957EE5A82406FDC5003B51B2 /* Base */,
+			);
+			name = Interface.storyboard;
+			sourceTree = "<group>";
+		};
+		95B328E7243D30D4008C6971 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				95B328E8243D30D4008C6971 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		95B328EC243D30D6008C6971 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				95B328ED243D30D6008C6971 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		95B328F7243D3345008C6971 /* Interface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				95B328F8243D3345008C6971 /* Base */,
 			);
 			name = Interface.storyboard;
 			sourceTree = "<group>";
@@ -674,6 +1011,140 @@
 			};
 			name = Release;
 		};
+		95B328F0243D30D6008C6971 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = GDTCCTiOSTestAppForCompanionWatchApp/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = GoogleDataTransport.GDTCCTiOSTestAppForCompanionWatchApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		95B328F1243D30D6008C6971 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = GDTCCTiOSTestAppForCompanionWatchApp/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = GoogleDataTransport.GDTCCTiOSTestAppForCompanionWatchApp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		95B32914243D3347008C6971 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9FAF90EE01D0F55358194796 /* Pods-GDTCCTWatchOSCompanionTestAppExtension.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = GDTCCTWatchOSCompanionTestAppExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = GoogleDataTransport.GDTCCTiOSTestAppForCompanionWatchApp.watchkitapp.watchkitextension;
+				PRODUCT_NAME = GDTCCTWatchOSCompanionTestAppExtension;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 6.1;
+			};
+			name = Debug;
+		};
+		95B32915243D3347008C6971 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FBDDEBD71C1B9E7464043558 /* Pods-GDTCCTWatchOSCompanionTestAppExtension.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = GDTCCTWatchOSCompanionTestAppExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = GoogleDataTransport.GDTCCTiOSTestAppForCompanionWatchApp.watchkitapp.watchkitextension;
+				PRODUCT_NAME = GDTCCTWatchOSCompanionTestAppExtension;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 6.1;
+			};
+			name = Release;
+		};
+		95B32918243D3347008C6971 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				IBSC_MODULE = GDTCCTWatchOSCompanionTestApp_Extension;
+				INFOPLIST_FILE = GDTCCTWatchOSCompanionTestApp/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = GoogleDataTransport.GDTCCTiOSTestAppForCompanionWatchApp.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 6.1;
+			};
+			name = Debug;
+		};
+		95B32919243D3347008C6971 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				IBSC_MODULE = GDTCCTWatchOSCompanionTestApp_Extension;
+				INFOPLIST_FILE = GDTCCTWatchOSCompanionTestApp/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = GoogleDataTransport.GDTCCTiOSTestAppForCompanionWatchApp.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 6.1;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -709,6 +1180,33 @@
 			buildConfigurations = (
 				957EE5CB2406FDC7003B51B2 /* Debug */,
 				957EE5CC2406FDC7003B51B2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		95B328F2243D30D6008C6971 /* Build configuration list for PBXNativeTarget "GDTCCTiOSTestAppForCompanionWatchApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				95B328F0243D30D6008C6971 /* Debug */,
+				95B328F1243D30D6008C6971 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		95B32913243D3347008C6971 /* Build configuration list for PBXNativeTarget "GDTCCTWatchOSCompanionTestAppExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				95B32914243D3347008C6971 /* Debug */,
+				95B32915243D3347008C6971 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		95B32917243D3347008C6971 /* Build configuration list for PBXNativeTarget "GDTCCTWatchOSCompanionTestApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				95B32918243D3347008C6971 /* Debug */,
+				95B32919243D3347008C6971 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSTestApp.xcodeproj/xcshareddata/xcschemes/GDTCCTWatchOSCompanionTestApp.xcscheme
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSTestApp.xcodeproj/xcshareddata/xcschemes/GDTCCTWatchOSCompanionTestApp.xcscheme
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "95B328F4243D3345008C6971"
+               BuildableName = "GDTCCTWatchOSCompanionTestApp.app"
+               BlueprintName = "GDTCCTWatchOSCompanionTestApp"
+               ReferencedContainer = "container:GDTCCTWatchOSTestApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "95B328DE243D30D4008C6971"
+               BuildableName = "GDTCCTiOSTestAppForCompanionWatchApp.app"
+               BlueprintName = "GDTCCTiOSTestAppForCompanionWatchApp"
+               ReferencedContainer = "container:GDTCCTWatchOSTestApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/GDTCCTiOSTestAppForCompanionWatchApp">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "95B328F4243D3345008C6971"
+            BuildableName = "GDTCCTWatchOSCompanionTestApp.app"
+            BlueprintName = "GDTCCTWatchOSCompanionTestApp"
+            ReferencedContainer = "container:GDTCCTWatchOSTestApp.xcodeproj">
+         </BuildableReference>
+      </RemoteRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/GDTCCTiOSTestAppForCompanionWatchApp">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "95B328F4243D3345008C6971"
+            BuildableName = "GDTCCTWatchOSCompanionTestApp.app"
+            BlueprintName = "GDTCCTWatchOSCompanionTestApp"
+            ReferencedContainer = "container:GDTCCTWatchOSTestApp.xcodeproj">
+         </BuildableReference>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "95B328F4243D3345008C6971"
+            BuildableName = "GDTCCTWatchOSCompanionTestApp.app"
+            BlueprintName = "GDTCCTWatchOSCompanionTestApp"
+            ReferencedContainer = "container:GDTCCTWatchOSTestApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSTestApp.xcodeproj/xcshareddata/xcschemes/GDTCCTWatchOSIndependentTestAppWatchKitApp.xcscheme
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSTestApp.xcodeproj/xcshareddata/xcschemes/GDTCCTWatchOSIndependentTestAppWatchKitApp.xcscheme
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "957EE5A12406FDC5003B51B2"
+               BuildableName = "GDTCCTWatchOSIndependentTestAppWatchKitApp.app"
+               BlueprintName = "GDTCCTWatchOSIndependentTestAppWatchKitApp"
+               ReferencedContainer = "container:GDTCCTWatchOSTestApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "957EE59D2406FDC5003B51B2"
+               BuildableName = "GDTCCTWatchOSTestApp.app"
+               BlueprintName = "GDTCCTWatchOSTestApp"
+               ReferencedContainer = "container:GDTCCTWatchOSTestApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/GDTCCTWatchOSTestAppWatchKitApp">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "957EE5A12406FDC5003B51B2"
+            BuildableName = "GDTCCTWatchOSIndependentTestAppWatchKitApp.app"
+            BlueprintName = "GDTCCTWatchOSIndependentTestAppWatchKitApp"
+            ReferencedContainer = "container:GDTCCTWatchOSTestApp.xcodeproj">
+         </BuildableReference>
+      </RemoteRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/GDTCCTWatchOSTestAppWatchKitApp">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "957EE5A12406FDC5003B51B2"
+            BuildableName = "GDTCCTWatchOSIndependentTestAppWatchKitApp.app"
+            BlueprintName = "GDTCCTWatchOSIndependentTestAppWatchKitApp"
+            ReferencedContainer = "container:GDTCCTWatchOSTestApp.xcodeproj">
+         </BuildableReference>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "957EE5A12406FDC5003B51B2"
+            BuildableName = "GDTCCTWatchOSIndependentTestAppWatchKitApp.app"
+            BlueprintName = "GDTCCTWatchOSIndependentTestAppWatchKitApp"
+            ReferencedContainer = "container:GDTCCTWatchOSTestApp.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSTestApp.xcodeproj/xcshareddata/xcschemes/GDTCCTWatchOSTestApp.xcscheme
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSTestApp.xcodeproj/xcshareddata/xcschemes/GDTCCTWatchOSTestApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "957EE59D2406FDC5003B51B2"
+               BuildableName = "GDTCCTWatchOSTestApp.app"
+               BlueprintName = "GDTCCTWatchOSTestApp"
+               ReferencedContainer = "container:GDTCCTWatchOSTestApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "957EE59D2406FDC5003B51B2"
+            BuildableName = "GDTCCTWatchOSTestApp.app"
+            BlueprintName = "GDTCCTWatchOSTestApp"
+            ReferencedContainer = "container:GDTCCTWatchOSTestApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "957EE59D2406FDC5003B51B2"
+            BuildableName = "GDTCCTWatchOSTestApp.app"
+            BlueprintName = "GDTCCTWatchOSTestApp"
+            ReferencedContainer = "container:GDTCCTWatchOSTestApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSTestApp.xcodeproj/xcshareddata/xcschemes/GDTCCTiOSTestAppForCompanionWatchApp.xcscheme
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSTestApp.xcodeproj/xcshareddata/xcschemes/GDTCCTiOSTestAppForCompanionWatchApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "95B328DE243D30D4008C6971"
+               BuildableName = "GDTCCTiOSTestAppForCompanionWatchApp.app"
+               BlueprintName = "GDTCCTiOSTestAppForCompanionWatchApp"
+               ReferencedContainer = "container:GDTCCTWatchOSTestApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "95B328DE243D30D4008C6971"
+            BuildableName = "GDTCCTiOSTestAppForCompanionWatchApp.app"
+            BlueprintName = "GDTCCTiOSTestAppForCompanionWatchApp"
+            ReferencedContainer = "container:GDTCCTWatchOSTestApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "95B328DE243D30D4008C6971"
+            BuildableName = "GDTCCTiOSTestAppForCompanionWatchApp.app"
+            BlueprintName = "GDTCCTiOSTestAppForCompanionWatchApp"
+            ReferencedContainer = "container:GDTCCTWatchOSTestApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/AppDelegate.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/AppDelegate.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/AppDelegate.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/AppDelegate.swift
@@ -1,0 +1,31 @@
+//
+//  AppDelegate.swift
+//  GDTCCTiOSTestAppForCompanionWatchApp
+//
+//  Created by Doudou Nan on 4/7/20.
+//  Copyright © 2020 Google. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    // Override point for customization after application launch.
+    return true
+  }
+
+  // MARK: UISceneSession Lifecycle
+
+  func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    // Called when a new scene session is being created.
+    // Use this method to select a configuration to create the new scene with.
+    return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+  }
+
+  func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+    // Called when the user discards a scene session.
+    // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+    // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/AppDelegate.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/AppDelegate.swift
@@ -1,10 +1,18 @@
-//
-//  AppDelegate.swift
-//  GDTCCTiOSTestAppForCompanionWatchApp
-//
-//  Created by Doudou Nan on 4/7/20.
-//  Copyright © 2020 Google. All rights reserved.
-//
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import UIKit
 

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/Assets.xcassets/Contents.json
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/Base.lproj/LaunchScreen.storyboard
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/Base.lproj/Main.storyboard
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/Base.lproj/Main.storyboard
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="GDTCCTiOSTestAppForCompanionWatchApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="This is an iOS app for " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lvx-ZU-rCg">
+                                <rect key="frame" x="124" y="122" width="167" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="watchOS companion test app" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hv3-xy-gMN">
+                                <rect key="frame" x="94" y="151" width="226" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="lvx-ZU-rCg" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="KgG-v0-Gb2"/>
+                            <constraint firstItem="lvx-ZU-rCg" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="124" id="cvr-6X-84h"/>
+                            <constraint firstItem="lvx-ZU-rCg" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="78" id="dH8-lN-e7k"/>
+                            <constraint firstItem="hv3-xy-gMN" firstAttribute="top" secondItem="lvx-ZU-rCg" secondAttribute="bottom" constant="8" id="jb9-i6-NpS"/>
+                            <constraint firstItem="lvx-ZU-rCg" firstAttribute="centerX" secondItem="hv3-xy-gMN" secondAttribute="centerX" id="ynZ-ae-NSt"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="131.8840579710145" y="138.61607142857142"/>
+        </scene>
+    </scenes>
+</document>

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/Info.plist
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/Info.plist
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/SceneDelegate.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/SceneDelegate.swift
@@ -1,10 +1,18 @@
-//
-//  SceneDelegate.swift
-//  GDTCCTiOSTestAppForCompanionWatchApp
-//
-//  Created by Doudou Nan on 4/7/20.
-//  Copyright © 2020 Google. All rights reserved.
-//
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import UIKit
 

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/SceneDelegate.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/SceneDelegate.swift
@@ -1,0 +1,48 @@
+//
+//  SceneDelegate.swift
+//  GDTCCTiOSTestAppForCompanionWatchApp
+//
+//  Created by Doudou Nan on 4/7/20.
+//  Copyright © 2020 Google. All rights reserved.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow?
+
+  func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+    // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+    // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+    // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+    guard let _ = (scene as? UIWindowScene) else { return }
+  }
+
+  func sceneDidDisconnect(_ scene: UIScene) {
+    // Called as the scene is being released by the system.
+    // This occurs shortly after the scene enters the background, or when its session is discarded.
+    // Release any resources associated with this scene that can be re-created the next time the scene connects.
+    // The scene may re-connect later, as its session was not neccessarily discarded (see `application:didDiscardSceneSessions` instead).
+  }
+
+  func sceneDidBecomeActive(_ scene: UIScene) {
+    // Called when the scene has moved from an inactive state to an active state.
+    // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+  }
+
+  func sceneWillResignActive(_ scene: UIScene) {
+    // Called when the scene will move from an active state to an inactive state.
+    // This may occur due to temporary interruptions (ex. an incoming phone call).
+  }
+
+  func sceneWillEnterForeground(_ scene: UIScene) {
+    // Called as the scene transitions from the background to the foreground.
+    // Use this method to undo the changes made on entering the background.
+  }
+
+  func sceneDidEnterBackground(_ scene: UIScene) {
+    // Called as the scene transitions from the foreground to the background.
+    // Use this method to save data, release shared resources, and store enough scene-specific state information
+    // to restore the scene back to its current state.
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/SceneDelegate.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/SceneDelegate.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,33 +24,5 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
     // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
     guard let _ = (scene as? UIWindowScene) else { return }
-  }
-
-  func sceneDidDisconnect(_ scene: UIScene) {
-    // Called as the scene is being released by the system.
-    // This occurs shortly after the scene enters the background, or when its session is discarded.
-    // Release any resources associated with this scene that can be re-created the next time the scene connects.
-    // The scene may re-connect later, as its session was not neccessarily discarded (see `application:didDiscardSceneSessions` instead).
-  }
-
-  func sceneDidBecomeActive(_ scene: UIScene) {
-    // Called when the scene has moved from an inactive state to an active state.
-    // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
-  }
-
-  func sceneWillResignActive(_ scene: UIScene) {
-    // Called when the scene will move from an active state to an inactive state.
-    // This may occur due to temporary interruptions (ex. an incoming phone call).
-  }
-
-  func sceneWillEnterForeground(_ scene: UIScene) {
-    // Called as the scene transitions from the background to the foreground.
-    // Use this method to undo the changes made on entering the background.
-  }
-
-  func sceneDidEnterBackground(_ scene: UIScene) {
-    // Called as the scene transitions from the foreground to the background.
-    // Use this method to save data, release shared resources, and store enough scene-specific state information
-    // to restore the scene back to its current state.
   }
 }

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/ViewController.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/ViewController.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/ViewController.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/ViewController.swift
@@ -1,10 +1,18 @@
-//
-//  ViewController.swift
-//  GDTCCTiOSTestAppForCompanionWatchApp
-//
-//  Created by Doudou Nan on 4/7/20.
-//  Copyright © 2020 Google. All rights reserved.
-//
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import UIKit
 

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/ViewController.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTiOSTestAppForCompanionWatchApp/ViewController.swift
@@ -1,0 +1,16 @@
+//
+//  ViewController.swift
+//  GDTCCTiOSTestAppForCompanionWatchApp
+//
+//  Created by Doudou Nan on 4/7/20.
+//  Copyright © 2020 Google. All rights reserved.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    // Do any additional setup after loading the view.
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/Podfile
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/Podfile
@@ -17,7 +17,7 @@ end
 
 target 'GDTCCTWatchOSCompanionTestAppExtension' do
   platform :watchos, '6.0'
-   
+
   # Pods for GDTCCTWatchOSCompanionTestAppExtension
   pod 'SwiftProtobuf', '~> 1.0'
   pod 'GoogleDataTransport', :path => '../../'

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/Podfile
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/Podfile
@@ -14,3 +14,13 @@ target 'GDTCCTWatchOSIndependentTestAppWatchKitExtension' do
   pod 'GoogleDataTransportCCTSupport', :path => '../../'
 
 end
+
+target 'GDTCCTWatchOSCompanionTestAppExtension' do
+  platform :watchos, '6.0'
+   
+  # Pods for GDTCCTWatchOSCompanionTestAppExtension
+  pod 'SwiftProtobuf', '~> 1.0'
+  pod 'GoogleDataTransport', :path => '../../'
+  pod 'GoogleDataTransportCCTSupport', :path => '../../'
+
+end


### PR DESCRIPTION
- Add an iOS test app target for companion watchOS test app

- Add a companion watchOS test app watchkit target

- Add a companion watchOS test app watchkit extension target with interface controller to test upload gdtcct events.
