### PR TITLE
Three ZipBuilder Fixes

### DIFF
--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -327,12 +327,12 @@ enum CocoaPodUtils {
                                                  in installedPods: [String: PodInfo])
     -> [VersionedPod] {
     return transitivePodDependencies(for: podName, in: installedPods).map {
-      var podVersion : String?
+      var podVersion: String?
       if let version = installedPods[$0]?.version {
         podVersion = version
       } else {
         // See if there's a version on the base pod.
-        let basePod = String($0.split(separator:"/")[0])
+        let basePod = String($0.split(separator: "/")[0])
         podVersion = installedPods[basePod]?.version
       }
       return CocoaPodUtils.VersionedPod(name: $0, version: podVersion)
@@ -414,7 +414,7 @@ enum CocoaPodUtils {
     // Loop through the subspecs passed in and use the actual Pod name.
     for pod in pods {
       podfile += "  pod '\(pod.name)'"
-      let podspec = String(pod.name.split(separator:"/")[0] + ".podspec")
+      let podspec = String(pod.name.split(separator: "/")[0] + ".podspec")
       // Check if we want to use a local version of the podspec.
       if let localURL = LaunchArgs.shared.localPodspecPath,
         FileManager.default

--- a/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -327,7 +327,15 @@ enum CocoaPodUtils {
                                                  in installedPods: [String: PodInfo])
     -> [VersionedPod] {
     return transitivePodDependencies(for: podName, in: installedPods).map {
-      CocoaPodUtils.VersionedPod(name: $0, version: installedPods[$0]?.version)
+      var podVersion : String?
+      if let version = installedPods[$0]?.version {
+        podVersion = version
+      } else {
+        // See if there's a version on the base pod.
+        let basePod = String($0.split(separator:"/")[0])
+        podVersion = installedPods[basePod]?.version
+      }
+      return CocoaPodUtils.VersionedPod(name: $0, version: podVersion)
     }
   }
 
@@ -406,10 +414,11 @@ enum CocoaPodUtils {
     // Loop through the subspecs passed in and use the actual Pod name.
     for pod in pods {
       podfile += "  pod '\(pod.name)'"
+      let podspec = String(pod.name.split(separator:"/")[0] + ".podspec")
       // Check if we want to use a local version of the podspec.
       if let localURL = LaunchArgs.shared.localPodspecPath,
         FileManager.default
-        .fileExists(atPath: localURL.appendingPathComponent(pod.name + ".podspec").path) {
+        .fileExists(atPath: localURL.appendingPathComponent(podspec).path) {
         podfile += ", :path => '\(localURL.path)'"
       } else if let podVersion = pod.version {
         podfile += ", '\(podVersion)'"

--- a/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
+++ b/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
@@ -352,7 +352,7 @@ struct LaunchArgs {
 
     if !buildDependencies && zipPods == nil {
       LaunchArgs.exitWithUsageAndLog("The -buildDependencies option cannot be false unless a " +
-                                     "list of pods is specified with the -zipPods option.")
+        "list of pods is specified with the -zipPods option.")
     }
 
     // Check for extra invalid options.

--- a/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
+++ b/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
@@ -350,6 +350,11 @@ struct LaunchArgs {
     updatePodRepo = defaults.bool(forKey: Key.updatePodRepo.rawValue)
     keepBuildArtifacts = defaults.bool(forKey: Key.keepBuildArtifacts.rawValue)
 
+    if !buildDependencies && zipPods == nil {
+      LaunchArgs.exitWithUsageAndLog("The -buildDependencies option cannot be false unless a " +
+                                     "list of pods is specified with the -zipPods option.")
+    }
+
     // Check for extra invalid options.
     let validArgs = Key.allCases.map { $0.rawValue }
     for arg in ProcessInfo.processInfo.arguments {

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -382,7 +382,7 @@ struct ZipBuilder {
     // Keep track of the names of the frameworks copied over.
     var copiedFrameworkNames: [String] = []
 
-    // Loop through each InstalledPod item and get the name so we can fetch the framework and copy
+    // Loop through each installedPod item and get the name so we can fetch the framework and copy
     // it to the destination directory.
     for podName in installedPods {
       // Skip the Firebase pod, any Interop pods, and specifically ignored frameworks.


### PR DESCRIPTION
Last night's zip build cron job failed because of a bug exposed by #5329 updating the `GoogleUtilities` version locally.  We were getting the podspec name from the podname without truncating subspec's from the podname.

Also fixed a warning from `pod install` if a subspec install was requested without a version along with a request to install the base spec with a version.

I also added a check to only allow `-buildDependencies false` option when `-zipPods` is used since it does not make sense (nor work) for Firebase product builds.