### PR TITLE
Workaround Carthage Protobuf parallel install issue

### DIFF
--- a/Carthage.md
+++ b/Carthage.md
@@ -28,6 +28,10 @@ more details and additional installation methods.
 - Create a Cartfile with a **subset** of the following components - choosing the
 Firebase components that you want to include in your app. Note that
 **FirebaseAnalyticsBinary** must always be included.
+
+- If you're using FirebaseMessaging, FirebasePerformance, FirebaserRemoteConfig,
+FirebaseABTesting, FirebaseInAppMessaging, or FirebaseML,
+**FirebaseProtobufBinary** must also be included.
 ```
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseABTestingBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAdMobBinary.json"
@@ -54,6 +58,7 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMLVisionLabelMode
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMLVisionObjectDetectionBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMLVisionTextModelBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebasePerformanceBinary.json"
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseProtobufBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseRemoteConfigBinary.json"
 binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseStorageBinary.json"
 ```

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,9 +1,8 @@
 # v6.6.7 -- M69
 - [fixed] Fixed Carthage installation failures involving `Protobuf.framework`.
   `Protobuf.framework` is now separately installable via adding
-  `FirebaseProtobufBinary.json` to the Cartfile. Full details in the [Carthage
-  usage instructions]
-  (https://github.com/firebase/firebase-ios-sdk/blob/master/Carthage.md#carthage-usage).
+  `FirebaseProtobufBinary.json` to the Cartfile. Full details in the [Carthage usage
+  instructions](https://github.com/firebase/firebase-ios-sdk/blob/master/Carthage.md#carthage-usage).
   (#5276)
 
 # v6.6.6 -- M68

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,5 +1,13 @@
+# v6.6.7 -- M69
+- [fixed] Fixed Carthage installation failures involving `Protobuf.framework`.
+  `Protobuf.framework` is now separately installable via adding
+  `FirebaseProtobufBinary.json` to the Cartfile. Full details in the [Carthage
+  usage instructions]
+  (https://github.com/firebase/firebase-ios-sdk/blob/master/Carthage.md#carthage-usage).
+  (#5276)
+
 # v6.6.6 -- M68
-- [fixed] Unincluded umbrella header warnings in Carthage and zip distributions
+- [fixed] Fixed unincluded umbrella header warnings in Carthage and zip distributions
   introduced in Firebase 6.21.0. (#5209)
 
 # v6.6.5 -- M67

--- a/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
@@ -75,7 +75,7 @@ extension CarthageUtils {
   /// Generates all required files for a Carthage release.
   ///
   /// - Parameters:
-  ///   - packagedDir: The packaged directory assembled for Carthage and Zip distribution.
+  ///   - packagedDir: The packaged directory assembled for the Carthage distribution.
   ///   - templateDir: The template project directory, contains the dummy Firebase library.
   ///   - jsonDir: Location of directory containing all JSON Carthage manifests.
   ///   - firebaseVersion: The version of the Firebase pod.
@@ -87,6 +87,7 @@ extension CarthageUtils {
                                               jsonDir: URL,
                                               artifacts: ZipBuilder.ReleaseArtifacts,
                                               outputDir: URL) {
+    factorProtobuf(inPackagedDir: packagedDir)
     let directories: [String]
     do {
       directories = try FileManager.default.contentsOfDirectory(atPath: packagedDir.path)
@@ -186,6 +187,44 @@ extension CarthageUtils {
         print("Successfully written Carthage JSON manifest for \(product).")
       } catch {
         fatalError("Could not write new Carthage JSON manifest to disk for \(product). \(error)")
+      }
+    }
+  }
+
+  /// Factor Protobuf into a separate Carthage distribution to avoid Carthage install issues
+  /// trying to install the same framework from multiple bundles(#5276).
+  ///
+  /// - Parameters:
+  ///   - packagedDir: The packaged directory assembled for Carthage and Zip distribution.
+
+  private static func factorProtobuf(inPackagedDir packagedDir: URL) {
+    let directories: [String]
+    let protobufDir = packagedDir.appendingPathComponent("FirebaseProtobuf")
+    do {
+      directories = try FileManager.default.contentsOfDirectory(atPath: packagedDir.path)
+    } catch {
+      fatalError("Could not get contents of Firebase directory to package Carthage build. \(error)")
+    }
+    let fileManager = FileManager.default
+    var didMove = false
+    // Loop through each directory to see if it includes Protobuf.framework.
+    for package in directories {
+      let fullPath = packagedDir.appendingPathComponent(package)
+        .appendingPathComponent("Protobuf.framework")
+      if fileManager.fileExists(atPath: fullPath.path) {
+        if didMove == false {
+          didMove = true
+          do {
+            try fileManager.createDirectory(at: protobufDir, withIntermediateDirectories: true)
+            try fileManager
+              .moveItem(at: fullPath, to: protobufDir.appendingPathComponent("Protobuf.framework"))
+          } catch {
+            fatalError("Failed to create Carthage protobuf directory at \(protobufDir) \(error)")
+          }
+
+        } else {
+          fileManager.removeIfExists(at: fullPath)
+        }
       }
     }
   }


### PR DESCRIPTION
Fix #5276. Carthage can fail to install if two binary installs include the same framework. This PR factors Protobuf.framework out of the several bundles it was included in into a single Carthage bundle. 

The instructions are updated to describe when the new `FirebaseProtobufBinary.json` must now be included in the Cartfile.
