### PR TITLE
More safely handle event IDs in migrations

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCOREvent.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCOREvent.m
@@ -202,6 +202,9 @@ static NSString *kCustomDataKey = @"GDTCOREventCustomDataKey";
   self = [self initWithMappingID:mappingID target:target];
   if (self) {
     _eventID = [aDecoder decodeObjectOfClass:[NSNumber class] forKey:eventIDKey];
+    if (_eventID == nil) {
+      _eventID = [GDTCOREvent nextEventID];
+    }
     _qosTier = [aDecoder decodeIntegerForKey:qosTierKey];
     _clockSnapshot = [aDecoder decodeObjectOfClass:[GDTCORClock class] forKey:clockSnapshotKey];
     NSURL *fileURL = [aDecoder decodeObjectOfClass:[NSURL class] forKey:fileURLKey];

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
@@ -246,7 +246,7 @@ static NSString *const ktargetToInFlightPackagesKey =
       NSMutableSet *eventIDs = [[NSMutableSet alloc] init];
       for (GDTCOREvent *event in packageEvents) {
         NSNumber *eventID = event.eventID;
-        if (eventID) {
+        if (eventID != nil) {
           [eventIDs addObject:eventID];
         } else {
           GDTCORLogDebug(@"An event was missing its ID: %@", event);

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
@@ -245,7 +245,12 @@ static NSString *const ktargetToInFlightPackagesKey =
     if (successful && packageEvents.count) {
       NSMutableSet *eventIDs = [[NSMutableSet alloc] init];
       for (GDTCOREvent *event in packageEvents) {
-        [eventIDs addObject:[event.eventID copy]];
+        NSNumber *eventID = event.eventID;
+        if (eventID) {
+          [eventIDs addObject:eventID];
+        } else {
+          GDTCORLogDebug(@"An event was missing its ID: %@", event);
+        }
       }
       [[self storageForTarget:@(package.target)] removeEvents:eventIDs];
     }


### PR DESCRIPTION
Check for nil eventIDs in the encoder case and checks for nil before adding the event ID to a collection.