### PR TITLE
Remove accessors for prioritizer internals

### DIFF
--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTPrioritizer.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTPrioritizer.m
@@ -40,6 +40,20 @@ static NSString *ArchivePath() {
   return archivePath;
 }
 
+/** This class extension isf or declaring private properties. */
+@interface GDTCCTPrioritizer ()
+
+/** All CCT events that have been processed by this prioritizer. */
+@property(nonatomic) NSMutableSet<GDTCOREvent *> *CCTEvents;
+
+/** All FLL events that have been processed by this prioritizer. */
+@property(nonatomic) NSMutableSet<GDTCOREvent *> *FLLEvents;
+
+/** All CSH events that have been processed by this prioritizer. */
+@property(nonatomic) NSMutableSet<GDTCOREvent *> *CSHEvents;
+
+@end
+
 @implementation GDTCCTPrioritizer
 
 + (void)load {
@@ -71,6 +85,29 @@ static NSString *ArchivePath() {
     _CSHEvents = [[NSMutableSet alloc] init];
   }
   return self;
+}
+
+- (nullable NSSet *)eventsForTarget:(GDTCORTarget)target {
+  __block NSSet *events;
+  dispatch_sync(_queue, ^{
+    switch (target) {
+      case kGDTCORTargetCCT:
+        events = [self->_CCTEvents copy];
+        break;
+
+      case kGDTCORTargetFLL:
+        events = [self->_FLLEvents copy];
+        break;
+
+      case kGDTCORTargetCSH:
+        events = [self->_CSHEvents copy];
+        break;
+
+      default:
+        break;
+    }
+  });
+  return events;
 }
 
 #pragma mark - GDTCORPrioritizer Protocol

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTPrioritizer.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTPrioritizer.m
@@ -40,7 +40,7 @@ static NSString *ArchivePath() {
   return archivePath;
 }
 
-/** This class extension isf or declaring private properties. */
+/** This class extension is for declaring private properties. */
 @interface GDTCCTPrioritizer ()
 
 /** All CCT events that have been processed by this prioritizer. */

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTUploader.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTUploader.m
@@ -276,13 +276,10 @@ NSNotificationName const GDTCCTUploadCompleteNotification = @"com.GDTCCTUploader
 
 - (BOOL)readyToUploadTarget:(GDTCORTarget)target conditions:(GDTCORUploadConditions)conditions {
   __block BOOL result = NO;
+  NSSet *CSHEvents = [[GDTCCTPrioritizer sharedInstance] eventsForTarget:kGDTCORTargetCSH];
   dispatch_sync(_uploaderQueue, ^{
     if (target == kGDTCORTargetCSH) {
-      if ([GDTCCTPrioritizer sharedInstance].CSHEvents.count > 0) {
-        result = YES;
-      } else {
-        result = NO;
-      }
+      result = CSHEvents.count > 0;
       return;
     }
 

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTPrioritizer.h
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTPrioritizer.h
@@ -29,15 +29,6 @@ NS_ASSUME_NONNULL_BEGIN
 /** The queue on which this prioritizer operates. */
 @property(nonatomic) dispatch_queue_t queue;
 
-/** All CCT events that have been processed by this prioritizer. */
-@property(nonatomic) NSMutableSet<GDTCOREvent *> *CCTEvents;
-
-/** All FLL events that have been processed by this prioritizer. */
-@property(nonatomic) NSMutableSet<GDTCOREvent *> *FLLEvents;
-
-/** All CSH events that have been processed by this prioritizer. */
-@property(nonatomic) NSMutableSet<GDTCOREvent *> *CSHEvents;
-
 /** The most recent attempted upload of CCT daily uploaded logs. */
 @property(nonatomic) GDTCORClock *CCTTimeOfLastDailyUpload;
 
@@ -49,6 +40,13 @@ NS_ASSUME_NONNULL_BEGIN
  * @return The singleton instance of this class.
  */
 + (instancetype)sharedInstance;
+
+/** Returns a set of events that have been prioritized for the given target.
+ *
+ * @param target The target to check. CCT, FLL, and CSH are currently supported by this class.
+ * @return The set of events prioritized so far.
+ */
+- (nullable NSSet *)eventsForTarget:(GDTCORTarget)target;
 
 NS_ASSUME_NONNULL_END
 

--- a/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/GDTCCTPrioritizerTest.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/GDTCCTPrioritizerTest.m
@@ -56,11 +56,9 @@
   [prioritizer prioritizeEvent:[_CCTGenerator generateEvent:GDTCOREventQosDefault]];
   [prioritizer prioritizeEvent:[_FLLGenerator generateEvent:GDTCOREventQosDefault]];
   [prioritizer prioritizeEvent:[_CSHGenerator generateEvent:GDTCOREventQosDefault]];
-  dispatch_sync(prioritizer.queue, ^{
-    XCTAssertEqual(prioritizer.CCTEvents.count, 1);
-    XCTAssertEqual(prioritizer.FLLEvents.count, 1);
-    XCTAssertEqual(prioritizer.CSHEvents.count, 1);
-  });
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetCCT].count, 1);
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetFLL].count, 1);
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetCSH].count, 1);
 }
 
 /** Tests prioritizing multiple events. */
@@ -75,11 +73,9 @@
   [prioritizer prioritizeEvent:[_CCTGenerator generateEvent:GDTCOREventQosDefault]];
   [prioritizer prioritizeEvent:[_CSHGenerator generateEvent:GDTCOREventQosDefault]];
   [prioritizer prioritizeEvent:[_CCTGenerator generateEvent:GDTCOREventQosDefault]];
-  dispatch_sync(prioritizer.queue, ^{
-    XCTAssertEqual(prioritizer.CCTEvents.count, 5);
-    XCTAssertEqual(prioritizer.FLLEvents.count, 2);
-    XCTAssertEqual(prioritizer.CSHEvents.count, 2);
-  });
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetCCT].count, 5);
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetFLL].count, 2);
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetCSH].count, 2);
 }
 
 /** Tests unprioritizing events. */
@@ -94,11 +90,9 @@
   [prioritizer prioritizeEvent:[_CCTGenerator generateEvent:GDTCOREventQosDefault]];
   [prioritizer prioritizeEvent:[_CSHGenerator generateEvent:GDTCOREventQosDefault]];
   [prioritizer prioritizeEvent:[_CCTGenerator generateEvent:GDTCOREventQosDefault]];
-  dispatch_sync(prioritizer.queue, ^{
-    XCTAssertEqual(prioritizer.CCTEvents.count, 5);
-    XCTAssertEqual(prioritizer.FLLEvents.count, 2);
-    XCTAssertEqual(prioritizer.CSHEvents.count, 2);
-  });
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetCCT].count, 5);
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetFLL].count, 2);
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetCSH].count, 2);
   GDTCORUploadPackage *package =
       [prioritizer uploadPackageWithTarget:kGDTCORTargetFLL
                                 conditions:GDTCORUploadConditionWifiData];
@@ -191,7 +185,7 @@
   NSError *error;
   dispatch_sync(prioritizer.queue, ^{
                 });
-  XCTAssertEqual(prioritizer.CCTEvents.count, 1);
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetCCT].count, 1);
   NSData *prioritizerData = GDTCOREncodeArchive(prioritizer, nil, &error);
   XCTAssertNil(error);
   XCTAssertNotNil(prioritizerData);
@@ -202,7 +196,8 @@
   XCTAssertNil(error);
   XCTAssertNotNil(unarchivedPrioritizer);
   XCTAssertEqual([prioritizer hash], [prioritizer hash]);
-  XCTAssertEqualObjects(prioritizer.CCTEvents, unarchivedPrioritizer.CCTEvents);
+  XCTAssertEqualObjects([prioritizer eventsForTarget:kGDTCORTargetCCT],
+                        [unarchivedPrioritizer eventsForTarget:kGDTCORTargetCCT]);
 }
 
 @end


### PR DESCRIPTION
This effectively makes it impossible to access the event sets in an unsynchronized way.

Fixes #5312