### PR TITLE
Add notification service extension target in gdtcct watch test app

### DIFF
--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTServiceExtension/Info.plist
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTServiceExtension/Info.plist
@@ -2,12 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>FirebaseAppDelegateProxyEnabled</key>
-	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>GDTCCTServiceExtension</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -24,17 +22,10 @@
 	<string>1</string>
 	<key>NSExtension</key>
 	<dict>
-		<key>NSExtensionAttributes</key>
-		<dict>
-			<key>WKAppBundleIdentifier</key>
-			<string>com.google.firebase.extensions.dev.WatchKitApp</string>
-		</dict>
 		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.watchkit</string>
+		<string>com.apple.usernotifications.service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
 	</dict>
-	<key>WKExtensionDelegateClassName</key>
-	<string>$(PRODUCT_MODULE_NAME).ExtensionDelegate</string>
-	<key>WKWatchOnly</key>
-	<true/>
 </dict>
 </plist>

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTServiceExtension/NotificationService.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTServiceExtension/NotificationService.swift
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import UserNotifications
+import FirebaseMessaging
+
+class NotificationService: UNNotificationServiceExtension {
+  var contentHandler: ((UNNotificationContent) -> Void)?
+  var bestAttemptContent: UNMutableNotificationContent?
+
+  override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
+    self.contentHandler = contentHandler
+    bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
+
+    if let bestAttemptContent = bestAttemptContent {
+      // Modify the notification content here...
+      bestAttemptContent.title = "\(bestAttemptContent.title) [modified]"
+
+      Messaging.serviceExtension().populateNotificationContent(bestAttemptContent, withContentHandler: self.contentHandler!)
+    }
+  }
+
+  override func serviceExtensionTimeWillExpire() {
+    // Called just before the extension will be terminated by the system.
+    // Use this as an opportunity to deliver your "best attempt" at modified content, otherwise the original push payload will be used.
+    if let contentHandler = contentHandler, let bestAttemptContent = bestAttemptContent {
+      contentHandler(bestAttemptContent)
+    }
+  }
+}

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSIndependentTestAppWatchKitExtension/ExtensionDelegate.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSIndependentTestAppWatchKitExtension/ExtensionDelegate.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,44 +41,5 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, MessagingDelegate {
   func didRegisterForRemoteNotifications(withDeviceToken deviceToken: Data) {
     // Swizzling should be disabled in Messaging for watchOS, set APNS token manually.
     Messaging.messaging().apnsToken = deviceToken
-  }
-
-  func applicationDidBecomeActive() {
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-  }
-
-  func applicationWillResignActive() {
-    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-    // Use this method to pause ongoing tasks, disable timers, etc.
-  }
-
-  func handle(_ backgroundTasks: Set<WKRefreshBackgroundTask>) {
-    // Sent when the system needs to launch the application in the background to process tasks. Tasks arrive in a set, so loop through and process each one.
-    for task in backgroundTasks {
-      // Use a switch statement to check the task type
-      switch task {
-      case let backgroundTask as WKApplicationRefreshBackgroundTask:
-        // Be sure to complete the background task once you’re done.
-        backgroundTask.setTaskCompletedWithSnapshot(false)
-      case let snapshotTask as WKSnapshotRefreshBackgroundTask:
-        // Snapshot tasks have a unique completion call, make sure to set your expiration date
-        snapshotTask.setTaskCompleted(restoredDefaultState: true, estimatedSnapshotExpiration: Date.distantFuture, userInfo: nil)
-      case let connectivityTask as WKWatchConnectivityRefreshBackgroundTask:
-        // Be sure to complete the connectivity task once you’re done.
-        connectivityTask.setTaskCompletedWithSnapshot(false)
-      case let urlSessionTask as WKURLSessionRefreshBackgroundTask:
-        // Be sure to complete the URL session task once you’re done.
-        urlSessionTask.setTaskCompletedWithSnapshot(false)
-      case let relevantShortcutTask as WKRelevantShortcutRefreshBackgroundTask:
-        // Be sure to complete the relevant-shortcut task once you're done.
-        relevantShortcutTask.setTaskCompletedWithSnapshot(false)
-      case let intentDidRunTask as WKIntentDidRunRefreshBackgroundTask:
-        // Be sure to complete the intent-did-run task once you're done.
-        intentDidRunTask.setTaskCompletedWithSnapshot(false)
-      default:
-        // make sure to complete unhandled task types
-        task.setTaskCompletedWithSnapshot(false)
-      }
-    }
   }
 }

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSIndependentTestAppWatchKitExtension/ExtensionDelegate.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSIndependentTestAppWatchKitExtension/ExtensionDelegate.swift
@@ -16,9 +16,31 @@
 
 import WatchKit
 
-class ExtensionDelegate: NSObject, WKExtensionDelegate {
+import FirebaseCore
+import FirebaseMessaging
+
+class ExtensionDelegate: NSObject, WKExtensionDelegate, MessagingDelegate {
   func applicationDidFinishLaunching() {
     // Perform any final initialization of your application.
+    FirebaseApp.configure()
+    let center = UNUserNotificationCenter.current()
+    center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+      if granted {
+        WKExtension.shared().registerForRemoteNotifications()
+      }
+    }
+    Messaging.messaging().delegate = self
+  }
+
+  // MessagingDelegate
+  func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String) {
+    print("token:\n" + fcmToken)
+  }
+
+  // WKExtensionDelegate
+  func didRegisterForRemoteNotifications(withDeviceToken deviceToken: Data) {
+    // Swizzling should be disabled in Messaging for watchOS, set APNS token manually.
+    Messaging.messaging().apnsToken = deviceToken
   }
 
   func applicationDidBecomeActive() {

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSIndependentTestAppWatchKitExtension/GDTCCTWatchOSIndependentTestAppWatchKitExtension.entitlements
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSIndependentTestAppWatchKitExtension/GDTCCTWatchOSIndependentTestAppWatchKitExtension.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSIndependentTestAppWatchKitExtension/InterfaceController.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSIndependentTestAppWatchKitExtension/InterfaceController.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSIndependentTestAppWatchKitExtension/NotificationController.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSIndependentTestAppWatchKitExtension/NotificationController.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSTestApp.xcodeproj/project.pbxproj
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSTestApp.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2047C1CB51687B364624D62B /* Pods_GDTCCTWatchOSIndependentTestAppWatchKitExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C55DD3705E7AB41A8669604 /* Pods_GDTCCTWatchOSIndependentTestAppWatchKitExtension.framework */; };
-		5D60C62425D7154C58DA5496 /* Pods_GDTCCTWatchOSIndependentTestAppWatchKitApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0359026575A15A395D60C31D /* Pods_GDTCCTWatchOSIndependentTestAppWatchKitApp.framework */; };
+		728DFB6E3385B8289C3B4797 /* Pods_GDTCCTServiceExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 302CC4CD46E706F964D2896A /* Pods_GDTCCTServiceExtension.framework */; };
 		9528A921240D9C110092BB98 /* flltest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9528A920240D9C100092BB98 /* flltest.pb.swift */; };
 		957EE5A32406FDC5003B51B2 /* GDTCCTWatchOSIndependentTestAppWatchKitApp.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 957EE5A22406FDC5003B51B2 /* GDTCCTWatchOSIndependentTestAppWatchKitApp.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		957EE5A92406FDC5003B51B2 /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 957EE5A72406FDC5003B51B2 /* Interface.storyboard */; };
@@ -35,6 +35,8 @@
 		95B32912243D3347008C6971 /* GDTCCTWatchOSCompanionTestApp.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 95B328F5243D3345008C6971 /* GDTCCTWatchOSCompanionTestApp.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		95B3291C243D39B3008C6971 /* gdthelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B3291B243D39B3008C6971 /* gdthelpers.swift */; };
 		95B3291E243D39CB008C6971 /* flltest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B3291D243D39CB008C6971 /* flltest.pb.swift */; };
+		95DC1489244107CF0025D52C /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95DC1488244107CF0025D52C /* NotificationService.swift */; };
+		95DC148D244107CF0025D52C /* GDTCCTServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 95DC1486244107CF0025D52C /* GDTCCTServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		BFA52AA947EC86815A8D31C7 /* Pods_GDTCCTWatchOSCompanionTestAppExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 07BEBC64EEDC2017032E076F /* Pods_GDTCCTWatchOSCompanionTestAppExtension.framework */; };
 /* End PBXBuildFile section */
 
@@ -66,6 +68,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 95B328F4243D3345008C6971;
 			remoteInfo = GDTCCTWatchOSCompanionTestApp;
+		};
+		95DC148B244107CF0025D52C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 957EE5982406FDC5003B51B2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 95DC1485244107CF0025D52C;
+			remoteInfo = GDTCCTServiceExtension;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -114,15 +123,25 @@
 			name = "Embed Watch Content";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		95DC148E244107CF0025D52C /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				95DC148D244107CF0025D52C /* GDTCCTServiceExtension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0359026575A15A395D60C31D /* Pods_GDTCCTWatchOSIndependentTestAppWatchKitApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GDTCCTWatchOSIndependentTestAppWatchKitApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		07BEBC64EEDC2017032E076F /* Pods_GDTCCTWatchOSCompanionTestAppExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GDTCCTWatchOSCompanionTestAppExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		0FD1D7F29BF594EE7B5B370C /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp.debug.xcconfig"; path = "Target Support Files/Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp/Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp.debug.xcconfig"; sourceTree = "<group>"; };
-		2A543946CE0D1755649E3022 /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp.release.xcconfig"; path = "Target Support Files/Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp/Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp.release.xcconfig"; sourceTree = "<group>"; };
+		302CC4CD46E706F964D2896A /* Pods_GDTCCTServiceExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GDTCCTServiceExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3E841C72AA54B4CD18A845E0 /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension.debug.xcconfig"; path = "Target Support Files/Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension/Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		5C55DD3705E7AB41A8669604 /* Pods_GDTCCTWatchOSIndependentTestAppWatchKitExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GDTCCTWatchOSIndependentTestAppWatchKitExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7482BF82A89E15B92F5B4D5F /* Pods-GDTCCTServiceExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GDTCCTServiceExtension.debug.xcconfig"; path = "Target Support Files/Pods-GDTCCTServiceExtension/Pods-GDTCCTServiceExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		77E102080D49A6C2889F0E3B /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension.release.xcconfig"; path = "Target Support Files/Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension/Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension.release.xcconfig"; sourceTree = "<group>"; };
 		9528A920240D9C100092BB98 /* flltest.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = flltest.pb.swift; path = ../../GDTCCTTestApp/proto/flltest.pb.swift; sourceTree = "<group>"; };
 		957EE59E2406FDC5003B51B2 /* GDTCCTWatchOSTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GDTCCTWatchOSTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -159,7 +178,12 @@
 		95B3290F243D3347008C6971 /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushNotificationPayload.apns; sourceTree = "<group>"; };
 		95B3291B243D39B3008C6971 /* gdthelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = gdthelpers.swift; path = ../../GDTCCTTestApp/gdthelpers.swift; sourceTree = "<group>"; };
 		95B3291D243D39CB008C6971 /* flltest.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = flltest.pb.swift; path = ../../GDTCCTTestApp/proto/flltest.pb.swift; sourceTree = "<group>"; };
+		95DC1486244107CF0025D52C /* GDTCCTServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = GDTCCTServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		95DC1488244107CF0025D52C /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		95DC148A244107CF0025D52C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		95DC1492244108180025D52C /* GDTCCTWatchOSIndependentTestAppWatchKitExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = GDTCCTWatchOSIndependentTestAppWatchKitExtension.entitlements; sourceTree = "<group>"; };
 		9FAF90EE01D0F55358194796 /* Pods-GDTCCTWatchOSCompanionTestAppExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GDTCCTWatchOSCompanionTestAppExtension.debug.xcconfig"; path = "Target Support Files/Pods-GDTCCTWatchOSCompanionTestAppExtension/Pods-GDTCCTWatchOSCompanionTestAppExtension.debug.xcconfig"; sourceTree = "<group>"; };
+		A86184986287A74A42BC25E8 /* Pods-GDTCCTServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GDTCCTServiceExtension.release.xcconfig"; path = "Target Support Files/Pods-GDTCCTServiceExtension/Pods-GDTCCTServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
 		FBDDEBD71C1B9E7464043558 /* Pods-GDTCCTWatchOSCompanionTestAppExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GDTCCTWatchOSCompanionTestAppExtension.release.xcconfig"; path = "Target Support Files/Pods-GDTCCTWatchOSCompanionTestAppExtension/Pods-GDTCCTWatchOSCompanionTestAppExtension.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -168,7 +192,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5D60C62425D7154C58DA5496 /* Pods_GDTCCTWatchOSIndependentTestAppWatchKitApp.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -195,6 +218,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		95DC1483244107CF0025D52C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				728DFB6E3385B8289C3B4797 /* Pods_GDTCCTServiceExtension.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9B0B02BD8C2FBD1421B489F6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -215,12 +246,12 @@
 		770E1356BCADE7C77E8F83ED /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				0FD1D7F29BF594EE7B5B370C /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp.debug.xcconfig */,
-				2A543946CE0D1755649E3022 /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp.release.xcconfig */,
 				3E841C72AA54B4CD18A845E0 /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension.debug.xcconfig */,
 				77E102080D49A6C2889F0E3B /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension.release.xcconfig */,
 				9FAF90EE01D0F55358194796 /* Pods-GDTCCTWatchOSCompanionTestAppExtension.debug.xcconfig */,
 				FBDDEBD71C1B9E7464043558 /* Pods-GDTCCTWatchOSCompanionTestAppExtension.release.xcconfig */,
+				7482BF82A89E15B92F5B4D5F /* Pods-GDTCCTServiceExtension.debug.xcconfig */,
+				A86184986287A74A42BC25E8 /* Pods-GDTCCTServiceExtension.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -228,9 +259,9 @@
 		7787C4E7768F3C6333331B64 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				0359026575A15A395D60C31D /* Pods_GDTCCTWatchOSIndependentTestAppWatchKitApp.framework */,
 				5C55DD3705E7AB41A8669604 /* Pods_GDTCCTWatchOSIndependentTestAppWatchKitExtension.framework */,
 				07BEBC64EEDC2017032E076F /* Pods_GDTCCTWatchOSCompanionTestAppExtension.framework */,
+				302CC4CD46E706F964D2896A /* Pods_GDTCCTServiceExtension.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -240,6 +271,7 @@
 			children = (
 				957EE5A62406FDC5003B51B2 /* GDTCCTWatchOSIndependentTestAppWatchKitApp */,
 				957EE5B52406FDC6003B51B2 /* GDTCCTWatchOSIndependentTestAppWatchKitExtension */,
+				95DC1487244107CF0025D52C /* GDTCCTServiceExtension */,
 				95B328E0243D30D4008C6971 /* GDTCCTiOSTestAppForCompanionWatchApp */,
 				95B328F6243D3345008C6971 /* GDTCCTWatchOSCompanionTestApp */,
 				95B32905243D3346008C6971 /* GDTCCTWatchOSCompanionTestAppExtension */,
@@ -258,6 +290,7 @@
 				95B328DF243D30D4008C6971 /* GDTCCTiOSTestAppForCompanionWatchApp.app */,
 				95B328F5243D3345008C6971 /* GDTCCTWatchOSCompanionTestApp.app */,
 				95B32901243D3346008C6971 /* GDTCCTWatchOSCompanionTestAppExtension.appex */,
+				95DC1486244107CF0025D52C /* GDTCCTServiceExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -275,6 +308,7 @@
 		957EE5B52406FDC6003B51B2 /* GDTCCTWatchOSIndependentTestAppWatchKitExtension */ = {
 			isa = PBXGroup;
 			children = (
+				95DC1492244108180025D52C /* GDTCCTWatchOSIndependentTestAppWatchKitExtension.entitlements */,
 				9528A920240D9C100092BB98 /* flltest.pb.swift */,
 				957EE5B62406FDC6003B51B2 /* InterfaceController.swift */,
 				957EE5B82406FDC6003B51B2 /* ExtensionDelegate.swift */,
@@ -326,6 +360,15 @@
 			path = GDTCCTWatchOSCompanionTestAppExtension;
 			sourceTree = "<group>";
 		};
+		95DC1487244107CF0025D52C /* GDTCCTServiceExtension */ = {
+			isa = PBXGroup;
+			children = (
+				95DC1488244107CF0025D52C /* NotificationService.swift */,
+				95DC148A244107CF0025D52C /* Info.plist */,
+			);
+			path = GDTCCTServiceExtension;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -351,7 +394,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 957EE5C62406FDC7003B51B2 /* Build configuration list for PBXNativeTarget "GDTCCTWatchOSIndependentTestAppWatchKitApp" */;
 			buildPhases = (
-				79FF95479D2D864D65C8D48E /* [CP] Check Pods Manifest.lock */,
 				957EE5A02406FDC5003B51B2 /* Resources */,
 				957EE5C52406FDC7003B51B2 /* Embed App Extensions */,
 				327115F7150225E2FA2658E4 /* Frameworks */,
@@ -375,10 +417,12 @@
 				957EE5AE2406FDC6003B51B2 /* Frameworks */,
 				957EE5AF2406FDC6003B51B2 /* Resources */,
 				9C2381C8CEF29E14EB01607B /* [CP] Embed Pods Frameworks */,
+				95DC148E244107CF0025D52C /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				95DC148C244107CF0025D52C /* PBXTargetDependency */,
 			);
 			name = GDTCCTWatchOSIndependentTestAppWatchKitExtension;
 			productName = "GDTCCTWatchOSTestApp WatchKit Extension";
@@ -441,13 +485,31 @@
 			productReference = 95B32901243D3346008C6971 /* GDTCCTWatchOSCompanionTestAppExtension.appex */;
 			productType = "com.apple.product-type.watchkit2-extension";
 		};
+		95DC1485244107CF0025D52C /* GDTCCTServiceExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 95DC1491244107CF0025D52C /* Build configuration list for PBXNativeTarget "GDTCCTServiceExtension" */;
+			buildPhases = (
+				87ED1A734D0B237CB085B09F /* [CP] Check Pods Manifest.lock */,
+				95DC1482244107CF0025D52C /* Sources */,
+				95DC1483244107CF0025D52C /* Frameworks */,
+				95DC1484244107CF0025D52C /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = GDTCCTServiceExtension;
+			productName = GDTCCTServiceExtension;
+			productReference = 95DC1486244107CF0025D52C /* GDTCCTServiceExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		957EE5982406FDC5003B51B2 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1130;
+				LastSwiftUpdateCheck = 1140;
 				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = Google;
 				TargetAttributes = {
@@ -471,6 +533,9 @@
 					95B32900243D3346008C6971 = {
 						CreatedOnToolsVersion = 11.3;
 					};
+					95DC1485244107CF0025D52C = {
+						CreatedOnToolsVersion = 11.4;
+					};
 				};
 			};
 			buildConfigurationList = 957EE59B2406FDC5003B51B2 /* Build configuration list for PBXProject "GDTCCTWatchOSTestApp" */;
@@ -489,6 +554,7 @@
 				957EE59D2406FDC5003B51B2 /* GDTCCTWatchOSTestApp */,
 				957EE5A12406FDC5003B51B2 /* GDTCCTWatchOSIndependentTestAppWatchKitApp */,
 				957EE5B02406FDC6003B51B2 /* GDTCCTWatchOSIndependentTestAppWatchKitExtension */,
+				95DC1485244107CF0025D52C /* GDTCCTServiceExtension */,
 				95B328DE243D30D4008C6971 /* GDTCCTiOSTestAppForCompanionWatchApp */,
 				95B328F4243D3345008C6971 /* GDTCCTWatchOSCompanionTestApp */,
 				95B32900243D3346008C6971 /* GDTCCTWatchOSCompanionTestAppExtension */,
@@ -545,6 +611,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				95B3290D243D3347008C6971 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		95DC1484244107CF0025D52C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -612,7 +685,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-GDTCCTWatchOSCompanionTestAppExtension/Pods-GDTCCTWatchOSCompanionTestAppExtension-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		79FF95479D2D864D65C8D48E /* [CP] Check Pods Manifest.lock */ = {
+		87ED1A734D0B237CB085B09F /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -627,7 +700,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-GDTCCTServiceExtension-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -688,6 +761,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		95DC1482244107CF0025D52C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				95DC1489244107CF0025D52C /* NotificationService.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -710,6 +791,11 @@
 			isa = PBXTargetDependency;
 			target = 95B328F4243D3345008C6971 /* GDTCCTWatchOSCompanionTestApp */;
 			targetProxy = 95B32910243D3347008C6971 /* PBXContainerItemProxy */;
+		};
+		95DC148C244107CF0025D52C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 95DC1485244107CF0025D52C /* GDTCCTServiceExtension */;
+			targetProxy = 95DC148B244107CF0025D52C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -866,6 +952,7 @@
 			baseConfigurationReference = 3E841C72AA54B4CD18A845E0 /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				CODE_SIGN_ENTITLEMENTS = GDTCCTWatchOSIndependentTestAppWatchKitExtension/GDTCCTWatchOSIndependentTestAppWatchKitExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
@@ -875,7 +962,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = GoogleDataTransport.GDTCCTWatchOSIndependentTestApp.watchkitapp.watchkitextension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.extensions.dev.WatchKitApp.WatchKitExtension;
 				PRODUCT_NAME = GDTCCTWatchOSIndependentTestAppWatchKitExtension;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = watchos;
@@ -891,6 +978,7 @@
 			baseConfigurationReference = 77E102080D49A6C2889F0E3B /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				CODE_SIGN_ENTITLEMENTS = GDTCCTWatchOSIndependentTestAppWatchKitExtension/GDTCCTWatchOSIndependentTestAppWatchKitExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
@@ -900,7 +988,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = GoogleDataTransport.GDTCCTWatchOSIndependentTestApp.watchkitapp.watchkitextension;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.extensions.dev.WatchKitApp.WatchKitExtension;
 				PRODUCT_NAME = GDTCCTWatchOSIndependentTestAppWatchKitExtension;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = watchos;
@@ -913,7 +1001,6 @@
 		};
 		957EE5C72406FDC7003B51B2 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0FD1D7F29BF594EE7B5B370C /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -928,7 +1015,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = GoogleDataTransport.GDTCCTWatchOSIndependentTestApp.watchkitapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.extensions.dev.WatchKitApp;
 				PRODUCT_NAME = GDTCCTWatchOSIndependentTestAppWatchKitApp;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = watchos;
@@ -942,7 +1029,6 @@
 		};
 		957EE5C82406FDC7003B51B2 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2A543946CE0D1755649E3022 /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitApp.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -957,7 +1043,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = GoogleDataTransport.GDTCCTWatchOSIndependentTestApp.watchkitapp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.extensions.dev.WatchKitApp;
 				PRODUCT_NAME = GDTCCTWatchOSIndependentTestAppWatchKitApp;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = watchos;
@@ -982,7 +1068,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = GoogleDataTransport.GDTCCTWatchOSTestApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.extensions.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1004,7 +1090,7 @@
 					"@loader_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = GoogleDataTransport.GDTCCTWatchOSTestApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.extensions.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -1145,6 +1231,56 @@
 			};
 			name = Release;
 		};
+		95DC148F244107CF0025D52C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7482BF82A89E15B92F5B4D5F /* Pods-GDTCCTServiceExtension.debug.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = GDTCCTServiceExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.extensions.dev.WatchKitApp.WatchKitExtension.ServiceExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 6.1;
+			};
+			name = Debug;
+		};
+		95DC1490244107CF0025D52C /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A86184986287A74A42BC25E8 /* Pods-GDTCCTServiceExtension.release.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = GDTCCTServiceExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.firebase.extensions.dev.WatchKitApp.WatchKitExtension.ServiceExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 6.1;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1207,6 +1343,15 @@
 			buildConfigurations = (
 				95B32918243D3347008C6971 /* Debug */,
 				95B32919243D3347008C6971 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		95DC1491244107CF0025D52C /* Build configuration list for PBXNativeTarget "GDTCCTServiceExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				95DC148F244107CF0025D52C /* Debug */,
+				95DC1490244107CF0025D52C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSTestApp.xcodeproj/project.pbxproj
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSTestApp.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		2047C1CB51687B364624D62B /* Pods_GDTCCTWatchOSIndependentTestAppWatchKitExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C55DD3705E7AB41A8669604 /* Pods_GDTCCTWatchOSIndependentTestAppWatchKitExtension.framework */; };
 		728DFB6E3385B8289C3B4797 /* Pods_GDTCCTServiceExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 302CC4CD46E706F964D2896A /* Pods_GDTCCTServiceExtension.framework */; };
 		9528A921240D9C110092BB98 /* flltest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9528A920240D9C100092BB98 /* flltest.pb.swift */; };
+		955035B92445189800E00D70 /* flltest.pb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955035B82445189800E00D70 /* flltest.pb.swift */; };
+		955035BB244518A300E00D70 /* gdthelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955035BA244518A300E00D70 /* gdthelpers.swift */; };
 		957EE5A32406FDC5003B51B2 /* GDTCCTWatchOSIndependentTestAppWatchKitApp.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 957EE5A22406FDC5003B51B2 /* GDTCCTWatchOSIndependentTestAppWatchKitApp.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		957EE5A92406FDC5003B51B2 /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 957EE5A72406FDC5003B51B2 /* Interface.storyboard */; };
 		957EE5AB2406FDC6003B51B2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 957EE5AA2406FDC6003B51B2 /* Assets.xcassets */; };
@@ -144,6 +146,8 @@
 		7482BF82A89E15B92F5B4D5F /* Pods-GDTCCTServiceExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GDTCCTServiceExtension.debug.xcconfig"; path = "Target Support Files/Pods-GDTCCTServiceExtension/Pods-GDTCCTServiceExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		77E102080D49A6C2889F0E3B /* Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension.release.xcconfig"; path = "Target Support Files/Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension/Pods-GDTCCTWatchOSIndependentTestAppWatchKitExtension.release.xcconfig"; sourceTree = "<group>"; };
 		9528A920240D9C100092BB98 /* flltest.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = flltest.pb.swift; path = ../../GDTCCTTestApp/proto/flltest.pb.swift; sourceTree = "<group>"; };
+		955035B82445189800E00D70 /* flltest.pb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = flltest.pb.swift; path = ../../GDTCCTTestApp/proto/flltest.pb.swift; sourceTree = "<group>"; };
+		955035BA244518A300E00D70 /* gdthelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = gdthelpers.swift; path = ../../GDTCCTTestApp/gdthelpers.swift; sourceTree = "<group>"; };
 		957EE59E2406FDC5003B51B2 /* GDTCCTWatchOSTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GDTCCTWatchOSTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		957EE5A22406FDC5003B51B2 /* GDTCCTWatchOSIndependentTestAppWatchKitApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GDTCCTWatchOSIndependentTestAppWatchKitApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		957EE5A82406FDC5003B51B2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Interface.storyboard; sourceTree = "<group>"; };
@@ -364,6 +368,8 @@
 			isa = PBXGroup;
 			children = (
 				95DC1488244107CF0025D52C /* NotificationService.swift */,
+				955035BA244518A300E00D70 /* gdthelpers.swift */,
+				955035B82445189800E00D70 /* flltest.pb.swift */,
 				95DC148A244107CF0025D52C /* Info.plist */,
 			);
 			path = GDTCCTServiceExtension;
@@ -765,7 +771,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				955035BB244518A300E00D70 /* gdthelpers.swift in Sources */,
 				95DC1489244107CF0025D52C /* NotificationService.swift in Sources */,
+				955035B92445189800E00D70 /* flltest.pb.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/Podfile
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/Podfile
@@ -1,10 +1,5 @@
 use_frameworks!
 
-target 'GDTCCTWatchOSIndependentTestAppWatchKitApp' do
-  platform :watchos, '6.0'
-
-end
-
 target 'GDTCCTWatchOSIndependentTestAppWatchKitExtension' do
   platform :watchos, '6.0'
 
@@ -12,8 +7,28 @@ target 'GDTCCTWatchOSIndependentTestAppWatchKitExtension' do
   pod 'SwiftProtobuf', '~> 1.0'
   pod 'GoogleDataTransport', :path => '../../'
   pod 'GoogleDataTransportCCTSupport', :path => '../../'
+  # Pods for firebase and Messaging
+  pod 'FirebaseAnalyticsInterop', :path => '../../'
+  pod 'FirebaseAuthInterop', :path => '../../'
+  pod 'FirebaseCore', :path => '../../'
+  pod 'GoogleUtilities', :path => '../../'
+  pod 'FirebaseMessaging', :path => '../../'
+  pod 'FirebaseInstanceID', :path => '../../'
+  pod 'FirebaseCoreDiagnostics', :path => '../../'
+  pod 'FirebaseCoreDiagnosticsInterop', :path => '../../'
+  pod 'FirebaseInstallations', :path => '../../'
+  pod 'FirebaseStorage', :path => '../../'
 
 end
+
+target 'GDTCCTServiceExtension' do
+  platform :watchos, '6.0'
+  
+  # Pods for GDTCCTServiceExtension
+  pod 'FirebaseMessaging', :path => '../../'
+  pod 'FirebaseInstanceID', :path => '../../'
+end
+
 
 target 'GDTCCTWatchOSCompanionTestAppExtension' do
   platform :watchos, '6.0'

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/Podfile
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/Podfile
@@ -7,7 +7,6 @@ target 'GDTCCTWatchOSIndependentTestAppWatchKitExtension' do
   pod 'SwiftProtobuf', '~> 1.0'
   pod 'GoogleDataTransport', :path => '../../'
   pod 'GoogleDataTransportCCTSupport', :path => '../../'
-  # Pods for firebase and Messaging
   pod 'FirebaseAnalyticsInterop', :path => '../../'
   pod 'FirebaseAuthInterop', :path => '../../'
   pod 'FirebaseCore', :path => '../../'
@@ -27,12 +26,15 @@ target 'GDTCCTServiceExtension' do
   # Pods for GDTCCTServiceExtension
   pod 'FirebaseMessaging', :path => '../../'
   pod 'FirebaseInstanceID', :path => '../../'
+  pod 'SwiftProtobuf', '~> 1.0'
+  pod 'GoogleDataTransport', :path => '../../'
+  pod 'GoogleDataTransportCCTSupport', :path => '../../'
 end
 
 
 target 'GDTCCTWatchOSCompanionTestAppExtension' do
   platform :watchos, '6.0'
-
+   
   # Pods for GDTCCTWatchOSCompanionTestAppExtension
   pod 'SwiftProtobuf', '~> 1.0'
   pod 'GoogleDataTransport', :path => '../../'

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/Podfile
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/Podfile
@@ -22,7 +22,7 @@ end
 
 target 'GDTCCTServiceExtension' do
   platform :watchos, '6.0'
-  
+
   # Pods for GDTCCTServiceExtension
   pod 'FirebaseMessaging', :path => '../../'
   pod 'FirebaseInstanceID', :path => '../../'
@@ -31,10 +31,9 @@ target 'GDTCCTServiceExtension' do
   pod 'GoogleDataTransportCCTSupport', :path => '../../'
 end
 
-
 target 'GDTCCTWatchOSCompanionTestAppExtension' do
   platform :watchos, '6.0'
-   
+
   # Pods for GDTCCTWatchOSCompanionTestAppExtension
   pod 'SwiftProtobuf', '~> 1.0'
   pod 'GoogleDataTransport', :path => '../../'


### PR DESCRIPTION
- Add new target ServiceExtension for watchOS independent test app
- Integrate firebase cloud messaging into ServiceExtension to test remote notification
- Add generating high priority event in ServiceExtension to test GDT functionality in watch app extension.
