### PR TITLE
Fix Memory leak of NSTimer when before use [self copy]

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORUploadPackage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORUploadPackage.m
@@ -31,7 +31,7 @@
   BOOL _isHandled;
 
   /** A timer that will regularly check to see whether this package has expired or not. */
-  NSTimer *_expirationTimer;
+  __weak NSTimer *_expirationTimer;
 }
 
 - (instancetype)initWithTarget:(GDTCORTarget)target {
@@ -79,6 +79,7 @@
   if (!_isHandled && _handler &&
       [_handler respondsToSelector:@selector(packageDelivered:successful:)]) {
     [_expirationTimer invalidate];
+    _expirationTimer = nil;
     _isHandled = YES;
     [_handler packageDelivered:[self copy] successful:YES];
   }
@@ -89,6 +90,7 @@
   if (!_isHandled && _handler &&
       [_handler respondsToSelector:@selector(packageDelivered:successful:)]) {
     [_expirationTimer invalidate];
+    _expirationTimer = nil;
     _isHandled = YES;
     [_handler packageDelivered:[self copy] successful:NO];
   }


### PR DESCRIPTION
I make NSTimer to weak and force set it to nil after invalidate it 
I fix the leaks in this issue [https://github.com/firebase/firebase-ios-sdk/issues/5360](https://github.com/firebase/firebase-ios-sdk/issues/5360)
