### PR TITLE
Revert "Revert "Migrate from using IID SDK for Remote Config to the new FIS SDK""

### DIFF
--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -41,7 +41,7 @@ app update.
   s.dependency 'FirebaseAnalyticsInterop', '~> 1.4'
   s.dependency 'FirebaseABTesting', '~> 3.1'
   s.dependency 'FirebaseCore', '~> 6.2'
-  s.dependency 'FirebaseInstanceID', '~> 4.2'
+  s.dependency 'FirebaseInstallations', '~> 1.1'
   s.dependency 'GoogleUtilities/Environment', '~> 6.2'
   s.dependency 'GoogleUtilities/NSData+zlib', '~> 6.2'
   s.dependency 'Protobuf', '~> 3.9', '>= 3.9.2'

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,3 +1,5 @@
+# v4.4.10
+- [changed] Internal code changes - migrate to using the FIS SDK. (#5096)
 # v4.4.9
 - [changed] Internal code changes. (#4934)
 # v4.4.8

--- a/FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h
+++ b/FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h
@@ -39,10 +39,10 @@
 @property(nonatomic, copy) NSString *secretToken;
 /// Device data version of checkin information.
 @property(nonatomic, copy) NSString *deviceDataVersion;
-/// InstanceID.
-@property(nonatomic, copy) NSString *configInstanceID;
-/// InstanceID token.
-@property(nonatomic, copy) NSString *configInstanceIDToken;
+/// InstallationsID.
+@property(nonatomic, copy) NSString *configInstallationsIdentifier;
+/// Installations token.
+@property(nonatomic, copy) NSString *configInstallationsToken;
 
 /// A list of successful fetch timestamps in milliseconds.
 /// TODO Not used anymore. Safe to remove.

--- a/FirebaseRemoteConfig/Sources/RCNConfigSettings.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigSettings.m
@@ -334,9 +334,9 @@ static const int kRCNExponentialBackoffMaximumInterval = 60 * 60 * 4;  // 4 hour
   // Note: We only set user properties as mentioned in the new REST API Design doc
   NSString *ret = [NSString stringWithFormat:@"{"];
   ret = [ret stringByAppendingString:[NSString stringWithFormat:@"app_instance_id:'%@'",
-                                                                _configInstanceID]];
+                                                                _configInstallationsIdentifier]];
   ret = [ret stringByAppendingString:[NSString stringWithFormat:@", app_instance_id_token:'%@'",
-                                                                _configInstanceIDToken]];
+                                                                _configInstallationsToken]];
   ret = [ret stringByAppendingString:[NSString stringWithFormat:@", app_id:'%@'", _googleAppID]];
 
   ret = [ret stringByAppendingString:[NSString stringWithFormat:@", country_code:'%@'",

--- a/FirebaseRemoteConfig/Sources/RCNFetch.m
+++ b/FirebaseRemoteConfig/Sources/RCNFetch.m
@@ -16,10 +16,10 @@
 
 #import "FirebaseRemoteConfig/Sources/RCNConfigFetch.h"
 
+#import <FirebaseCore/FIRApp.h>
 #import <FirebaseCore/FIRLogger.h>
 #import <FirebaseCore/FIROptions.h>
-#import <FirebaseInstanceID/FIRInstanceID+Private.h>
-#import <FirebaseInstanceID/FIRInstanceIDCheckinPreferences.h>
+#import <FirebaseInstallations/FirebaseInstallations.h>
 #import <GoogleUtilities/GULNSData+zlib.h>
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigConstants.h"
@@ -40,7 +40,6 @@ static NSString *const kServerURLNamespaces = @"/namespaces/";
 static NSString *const kServerURLQuery = @":fetch?";
 static NSString *const kServerURLKey = @"key=";
 static NSString *const kRequestJSONKeyAppID = @"app_id";
-static NSString *const kRequestJSONKeyAppInstanceID = @"app_instance_id";
 
 static NSString *const kHTTPMethodPost = @"POST";  ///< HTTP request method config fetch using
 static NSString *const kContentTypeHeaderName = @"Content-Type";  ///< HTTP Header Field Name
@@ -49,13 +48,13 @@ static NSString *const kContentEncodingHeaderName =
 static NSString *const kAcceptEncodingHeaderName = @"Accept-Encoding";  ///< HTTP Header Field Name
 static NSString *const kETagHeaderName = @"etag";                       ///< HTTP Header Field Name
 static NSString *const kIfNoneMatchETagHeaderName = @"if-none-match";   ///< HTTP Header Field Name
+static NSString *const kInstallationsAuthTokenHeaderName = @"x-goog-firebase-installations-auth";
 // Sends the bundle ID. Refer to b/130301479 for details.
 static NSString *const kiOSBundleIdentifierHeaderName =
     @"X-Ios-Bundle-Identifier";  ///< HTTP Header Field Name
 
 /// Config HTTP request content type proto buffer
 static NSString *const kContentTypeValueJSON = @"application/json";
-static NSString *const kInstanceIDScopeConfig = @"*";  /// InstanceID scope
 
 /// HTTP status codes. Ref: https://cloud.google.com/apis/design/errors#error_retries
 static NSInteger const kRCNFetchResponseHTTPStatusCodeOK = 200;
@@ -192,18 +191,22 @@ static RCNConfigFetcherTestBlock gGlobalTestBlock;
                                          withError:error];
     }
     strongSelf->_settings.isFetchInProgress = YES;
-    [strongSelf refreshInstanceIDTokenAndFetchCheckInInfoWithCompletionHandler:completionHandler];
+    [strongSelf refreshInstallationsTokenWithCompletionHandler:completionHandler];
   });
 }
 
 #pragma mark - Fetch helpers
 
-/// Refresh instance ID token before fetching config. Instance ID is now mandatory for fetch
+- (NSString *)FIRAppNameFromFullyQualifiedNamespace {
+  return [[_FIRNamespace componentsSeparatedByString:@":"] lastObject];
+}
+/// Refresh installation ID token before fetching config. installation ID is now mandatory for fetch
 /// requests to work.(b/14751422).
-- (void)refreshInstanceIDTokenAndFetchCheckInInfoWithCompletionHandler:
+- (void)refreshInstallationsTokenWithCompletionHandler:
     (FIRRemoteConfigFetchCompletion)completionHandler {
-  FIRInstanceID *instanceID = [FIRInstanceID instanceID];
-  if (!_options.GCMSenderID) {
+  FIRInstallations *installations = [FIRInstallations
+      installationsWithApp:[FIRApp appNamed:[self FIRAppNameFromFullyQualifiedNamespace]]];
+  if (!installations || !_options.GCMSenderID) {
     NSString *errorDescription = @"Failed to get GCMSenderID";
     FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000074", @"%@",
                 [NSString stringWithFormat:@"%@", errorDescription]);
@@ -217,10 +220,11 @@ static RCNConfigFetcherTestBlock gGlobalTestBlock;
                                                     NSLocalizedDescriptionKey : errorDescription
                                                   }]];
   }
-  FIRInstanceIDTokenHandler instanceIDHandler = ^(NSString *token, NSError *error) {
-    if (!token || error) {
+  FIRInstallationsTokenHandler installationsTokenHandler = ^(
+      FIRInstallationsAuthTokenResult *tokenResult, NSError *error) {
+    if (!tokenResult || !tokenResult.authToken || error) {
       NSString *errorDescription =
-          [NSString stringWithFormat:@"Failed to get InstanceID token. Error : %@.", error];
+          [NSString stringWithFormat:@"Failed to get installations token. Error : %@.", error];
       FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000073", @"%@",
                   [NSString stringWithFormat:@"%@", errorDescription]);
       self->_settings.isFetchInProgress = NO;
@@ -234,9 +238,10 @@ static RCNConfigFetcherTestBlock gGlobalTestBlock;
                                                     }]];
     }
 
-    // If the token is available, try to get the instanceID.
+    // We have a valid token. Get the backing installationID.
     __weak RCNConfigFetch *weakSelf = self;
-    [instanceID getIDWithHandler:^(NSString *_Nullable identity, NSError *_Nullable error) {
+    [installations installationIDWithCompletion:^(NSString *_Nullable identifier,
+                                                  NSError *_Nullable error) {
       RCNConfigFetch *strongSelf = weakSelf;
 
       // Dispatch to the RC serial queue to update settings on the queue.
@@ -244,10 +249,10 @@ static RCNConfigFetcherTestBlock gGlobalTestBlock;
         RCNConfigFetch *strongSelfQueue = weakSelf;
 
         // Update config settings with the IID and token.
-        strongSelfQueue->_settings.configInstanceIDToken = [token copy];
-        strongSelfQueue->_settings.configInstanceID = identity;
+        strongSelfQueue->_settings.configInstallationsToken = tokenResult.authToken;
+        strongSelfQueue->_settings.configInstallationsIdentifier = identifier;
 
-        if (!identity || error) {
+        if (!identifier || error) {
           NSString *errorDescription =
               [NSString stringWithFormat:@"Error getting iid : %@.", error];
           FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000055", @"%@",
@@ -265,56 +270,23 @@ static RCNConfigFetcherTestBlock gGlobalTestBlock;
         }
 
         FIRLogInfo(kFIRLoggerRemoteConfig, @"I-RCN000022", @"Success to get iid : %@.",
-                   strongSelfQueue->_settings.configInstanceID);
-
-        // Continue the fetch regardless of whether fetch of instance ID succeeded.
-        [strongSelfQueue fetchCheckinInfoWithCompletionHandler:completionHandler];
+                   strongSelfQueue->_settings.configInstallationsIdentifier);
+        [strongSelf
+            getAnalyticsUserPropertiesWithCompletionHandler:^(NSDictionary *userProperties) {
+              dispatch_async(strongSelf->_lockQueue, ^{
+                [strongSelf fetchWithUserProperties:userProperties
+                                  completionHandler:completionHandler];
+              });
+            }];
       });
     }];
   };
+
   FIRLogDebug(kFIRLoggerRemoteConfig, @"I-RCN000039", @"Starting requesting token.");
-  // Note: We expect the GCMSenderID to always be available by the time this request is made.
-  [instanceID tokenWithAuthorizedEntity:_options.GCMSenderID
-                                  scope:kInstanceIDScopeConfig
-                                options:nil
-                                handler:instanceIDHandler];
+  [installations authTokenWithCompletion:installationsTokenHandler];
 }
 
-/// Fetch checkin info before fetching config. Checkin info including device authentication ID,
-/// secret token and device data version are optional fields in config request.
-- (void)fetchCheckinInfoWithCompletionHandler:(FIRRemoteConfigFetchCompletion)completionHandler {
-  FIRInstanceID *instanceID = [FIRInstanceID instanceID];
-  __weak RCNConfigFetch *weakSelf = self;
-  [instanceID fetchCheckinInfoWithHandler:^(FIRInstanceIDCheckinPreferences *preferences,
-                                            NSError *error) {
-    RCNConfigFetch *fetchCheckinInfoWithHandlerSelf = weakSelf;
-    dispatch_async(fetchCheckinInfoWithHandlerSelf->_lockQueue, ^{
-      RCNConfigFetch *strongSelf = fetchCheckinInfoWithHandlerSelf;
-      if (error) {
-        FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000023", @"Failed to fetch checkin info: %@.",
-                    error);
-      } else {
-        strongSelf->_settings.deviceAuthID = preferences.deviceID;
-        strongSelf->_settings.secretToken = preferences.secretToken;
-        strongSelf->_settings.deviceDataVersion = preferences.deviceDataVersion;
-        if (strongSelf->_settings.deviceAuthID.length && strongSelf->_settings.secretToken.length) {
-          FIRLogInfo(kFIRLoggerRemoteConfig, @"I-RCN000024",
-                     @"Success to get device authentication ID: %@, security token: %@.",
-                     self->_settings.deviceAuthID, self->_settings.secretToken);
-        }
-      }
-      // Checkin info is optional, continue fetch config regardless fetch of checkin info
-      // succeeded.
-      [strongSelf fetchWithUserPropertiesCompletionHandler:^(NSDictionary *userProperties) {
-        dispatch_async(strongSelf->_lockQueue, ^{
-          [strongSelf fetchWithUserProperties:userProperties completionHandler:completionHandler];
-        });
-      }];
-    });
-  }];
-}
-
-- (void)fetchWithUserPropertiesCompletionHandler:
+- (void)getAnalyticsUserPropertiesWithCompletionHandler:
     (FIRAInteropUserPropertiesCallback)completionHandler {
   FIRLogDebug(kFIRLoggerRemoteConfig, @"I-RCN000060", @"Fetch with user properties completed.");
   id<FIRAnalyticsInterop> analytics = self->_analytics;
@@ -590,6 +562,8 @@ static RCNConfigFetcherTestBlock gGlobalTestBlock;
                                timeoutInterval:timeoutInterval];
   URLRequest.HTTPMethod = kHTTPMethodPost;
   [URLRequest setValue:kContentTypeValueJSON forHTTPHeaderField:kContentTypeHeaderName];
+  [URLRequest setValue:_settings.configInstallationsToken
+      forHTTPHeaderField:kInstallationsAuthTokenHeaderName];
   [URLRequest setValue:[[NSBundle mainBundle] bundleIdentifier]
       forHTTPHeaderField:kiOSBundleIdentifierHeaderName];
   [URLRequest setValue:@"gzip" forHTTPHeaderField:kContentEncodingHeaderName];

--- a/FirebaseRemoteConfig/Tests/Sample/Podfile
+++ b/FirebaseRemoteConfig/Tests/Sample/Podfile
@@ -7,7 +7,6 @@ target 'RemoteConfigSampleApp' do
   pod 'FirebaseAnalytics'
   pod 'FirebaseCore', :path => '../../../'
   pod 'FirebaseInstallations', :path => '../../../'
-  pod 'FirebaseInstanceID', :path => '../../../'
   pod 'FirebaseRemoteConfig', :path => '../../../'
 
   # Pods for RemoteConfigSampleApp

--- a/FirebaseRemoteConfig/Tests/Unit/RCNInstanceIDTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNInstanceIDTest.m
@@ -28,7 +28,7 @@
 #import <FirebaseCore/FIRAppInternal.h>
 #import <FirebaseCore/FIRLogger.h>
 #import <FirebaseCore/FIROptions.h>
-#import <FirebaseInstanceID/FirebaseInstanceID.h>
+#import <FirebaseInstallations/FirebaseInstallations.h>
 #import <GoogleUtilities/GULNSData+zlib.h>
 #import <OCMock/OCMock.h>
 
@@ -50,6 +50,10 @@
 + (NSUserDefaults *)sharedUserDefaultsForBundleIdentifier:(NSString *)bundleIdentifier;
 @end
 
+@interface FIRInstallationsAuthTokenResult (Test)
+- (instancetype)initWithToken:(NSString *)token expirationDate:(NSDate *)expirationDate;
+@end
+
 typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
   RCNTestRCInstanceDefault,
   RCNTestRCNumTotalInstances,  // TODO(mandard): Remove once OCMock issue is resolved (#4877).
@@ -57,11 +61,15 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
   RCNTestRCInstanceSecondApp,
 };
 
-@interface FIRInstanceID (Tests)
-+ (FIRInstanceID *)instanceIDForTests;
+@class FIRInstallationsIDController;
+@interface FIRInstallations (Tests)
+- (instancetype)initWithAppOptions:(FIROptions *)appOptions
+                           appName:(NSString *)appName
+         installationsIDController:(FIRInstallationsIDController *)installationsIDController
+                 prefetchAuthToken:(BOOL)prefetchAuthToken;
 @end
 
-@interface RCNInstanceIDTest : XCTestCase {
+@interface RCNInstallationsTests : XCTestCase {
   NSTimeInterval _expectationTimeout;
   NSTimeInterval _checkCompletionTimeout;
   NSMutableArray<FIRRemoteConfig *> *_configInstances;
@@ -74,18 +82,18 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
   NSUserDefaults *_userDefaults;
   NSString *_userDefaultsSuiteName;
   NSString *_DBPath;
+
+  id _installationsMock;
 }
 @end
 
-@implementation RCNInstanceIDTest
+@implementation RCNInstallationsTests
 
-- (void)setUp {
-  [super setUp];
+- (void)setUpConfigMock {
   FIRSetLoggerLevel(FIRLoggerLevelMax);
-  //@@if (![FIRApp isDefaultAppConfigured]) {
-  [FIRApp configureWithOptions:[self firstAppOptions]];
   _expectationTimeout = 5;
   _checkCompletionTimeout = 1.0;
+  [FIRApp configureWithOptions:[self firstAppOptions]];
 
   // Always remove the database at the start of testing.
   _DBPath = [RCNTestUtilities remoteConfigPathForTestDatabase];
@@ -174,41 +182,61 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
                                      tokenError:(nullable NSError *)tokenError
                                        identity:(nullable NSString *)identity
                                   identityError:(nullable NSError *)identityError {
-  // Mock the instanceID retreival method.
-  id instanceIDMock = OCMPartialMock([FIRInstanceID instanceIDForTests]);
-  OCMStub([instanceIDMock
-      tokenWithAuthorizedEntity:[OCMArg any]
-                          scope:[OCMArg any]
-                        options:[OCMArg any]
-                        handler:([OCMArg
-                                    invokeBlockWithArgs:(token ? token : [NSNull null]),
-                                                        (tokenError ? tokenError : [NSNull null]),
-                                                        nil])]);
-  OCMStub([instanceIDMock
-      getIDWithHandler:([OCMArg invokeBlockWithArgs:(identity ? identity : [NSNull null]),
-                                                    (identityError ? identityError : [NSNull null]),
-                                                    nil])]);
+  // Mock the installations retreival method.
+  _installationsMock = OCMClassMock([FIRInstallations class]);
+
+  id installationIDCompletionArg =
+      [OCMArg checkWithBlock:^BOOL(FIRInstallationsIDHandler completion) {
+        if (completion) {
+          completion(identity, identityError);
+        }
+        return YES;
+      }];
+  OCMStub([_installationsMock installationIDWithCompletion:installationIDCompletionArg]);
+
+  FIRInstallationsAuthTokenResult *tokenResult;
+  if (token) {
+    tokenResult = [[FIRInstallationsAuthTokenResult alloc] initWithToken:token
+                                                          expirationDate:[NSDate distantFuture]];
+  }
+
+  id authTokenCompletionArg =
+      [OCMArg checkWithBlock:^BOOL(FIRInstallationsTokenHandler completion) {
+        if (completion) {
+          completion(tokenResult, tokenError);
+        }
+        return YES;
+      }];
+  OCMStub([_installationsMock authTokenWithCompletion:authTokenCompletionArg]);
+
+  OCMStub([_installationsMock installationsWithApp:[OCMArg any]]).andReturn(_installationsMock);
+
+  [self setUpConfigMock];
 }
 
 - (void)tearDown {
   [_DBManager removeDatabaseOnDatabaseQueueAtPath:_DBPath];
   [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:_userDefaultsSuiteName];
   [FIRApp resetApps];
+  [_installationsMock stopMocking];
+  _installationsMock = nil;
   [super tearDown];
 }
 
 // Instance ID token is nil. Error is not nil. Verify fetch fails.
-- (void)testNilInstanceIDTokenAndError {
+- (void)testNilInstallationsAuthTokenAndError {
   NSMutableArray<XCTestExpectation *> *expectations =
       [[NSMutableArray alloc] initWithCapacity:RCNTestRCNumTotalInstances];
 
   // Set the token as nil.
-  [self mockInstanceIDMethodForTokenAndIdentity:nil
-                                     tokenError:[NSError errorWithDomain:@"com.google.instanceid"
-                                                                    code:FIRInstanceIDErrorUnknown
-                                                                userInfo:nil]
-                                       identity:nil
-                                  identityError:nil];
+  [self
+      mockInstanceIDMethodForTokenAndIdentity:nil
+                                   tokenError:[NSError
+                                                  errorWithDomain:kFirebaseInstallationsErrorDomain
+                                                             code:FIRInstallationsErrorCodeUnknown
+                                                         userInfo:nil]
+                                     identity:nil
+                                identityError:nil];
   // Test for each RC FIRApp, namespace instance.
   for (int i = 0; i < RCNTestRCNumTotalInstances; i++) {
     expectations[i] =
@@ -235,10 +263,11 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
       [[NSMutableArray alloc] initWithCapacity:RCNTestRCNumTotalInstances];
 
   // Set the token as nil.
+  NSError *tokenError = [NSError errorWithDomain:kFirebaseInstallationsErrorDomain
+                                            code:FIRInstallationsErrorCodeUnknown
+                                        userInfo:nil];
   [self mockInstanceIDMethodForTokenAndIdentity:nil
-                                     tokenError:[NSError errorWithDomain:@"com.google.instanceid"
-                                                                    code:FIRInstanceIDErrorUnknown
-                                                                userInfo:nil]
+                                     tokenError:tokenError
                                        identity:nil
                                   identityError:nil];
   // Test for each RC FIRApp, namespace instance.
@@ -250,17 +279,15 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
     FIRRemoteConfigFetchCompletion fetchCompletion =
         ^void(FIRRemoteConfigFetchStatus status, NSError *error) {
           XCTAssertNotNil(error);
-          XCTAssertFalse([[error.userInfo objectForKey:@"NSLocalizedDescription"]
-                             rangeOfString:@"Failed to get InstanceID token"]
-                             .location == NSNotFound);
+          XCTAssert([[error.userInfo objectForKey:@"NSLocalizedDescription"]
+              containsString:@"Failed to get installations token"]);
           // Make a second fetch call.
           [self->_configInstances[i]
               fetchWithExpirationDuration:43200
                         completionHandler:^void(FIRRemoteConfigFetchStatus status, NSError *error) {
                           XCTAssertNotNil(error);
-                          XCTAssertFalse([[error.userInfo objectForKey:@"NSLocalizedDescription"]
-                                             rangeOfString:@"Failed to get InstanceID token"]
-                                             .location == NSNotFound);
+                          XCTAssert([[error.userInfo objectForKey:@"NSLocalizedDescription"]
+                              containsString:@"Failed to get installations token"]);
                           [expectations[i] fulfill];
                         }];
         };
@@ -281,10 +308,11 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
   // Test for each RC FIRApp, namespace instance.
   for (int i = 0; i < RCNTestRCNumTotalInstances; i++) {
     // Set the token as nil.
+    NSError *tokenError = [NSError errorWithDomain:kFirebaseInstallationsErrorDomain
+                                              code:FIRInstallationsErrorCodeUnknown
+                                          userInfo:nil];
     [self mockInstanceIDMethodForTokenAndIdentity:@"abcd"
-                                       tokenError:[NSError errorWithDomain:@"com.google.instanceid"
-                                                                      code:FIRInstanceIDErrorUnknown
-                                                                  userInfo:nil]
+                                       tokenError:tokenError
                                          identity:nil
                                     identityError:nil];
 
@@ -376,12 +404,13 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
   // Test for each RC FIRApp, namespace instance.
   for (int i = 0; i < RCNTestRCNumTotalInstances; i++) {
     // Set the token as nil.
+    NSError *identityError = [NSError errorWithDomain:kFirebaseInstallationsErrorDomain
+                                                 code:FIRInstallationsErrorCodeUnknown
+                                             userInfo:nil];
     [self mockInstanceIDMethodForTokenAndIdentity:@"abcd"
                                        tokenError:nil
                                          identity:@"test-id"
-                                    identityError:[NSError errorWithDomain:@"com.google.instanceid"
-                                                                      code:FIRInstanceIDErrorUnknown
-                                                                  userInfo:nil]];
+                                    identityError:identityError];
 
     expectations[i] =
         [self expectationWithDescription:


### PR DESCRIPTION
Reverts firebase/firebase-ios-sdk#5159

Server side support is expected to be rolled out by the end of the week (b/152426175).