### PR TITLE
Update CHANGELOG for Firestore v1.12.1

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -4,7 +4,9 @@
 - [changed] Internal improvements for future C++ and Unity support.
 
 # v1.12.0
-- [changed] Internal improvements.
+- [changed] Internal improvements for future C++ and Unity support. The minor
+  version bump here represents a breaking change for the Firestore C++ Alpha
+  SDK, but does not affect Objective-C or Swift users.
 
 # v1.11.2
 - [fixed] Fixed the FirebaseFirestore podspec to properly declare its

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -4,9 +4,9 @@
 - [changed] Internal improvements for future C++ and Unity support.
 
 # v1.12.0
-- [changed] Internal improvements for future C++ and Unity support. The minor
-  version bump here represents a breaking change for the Firestore C++ Alpha
-  SDK, but does not affect Objective-C or Swift users.
+- [changed] Internal improvements for future C++ and Unity support. Includes a
+  breaking change for the Firestore C++ Alpha SDK, but does not affect
+  Objective-C or Swift users.
 
 # v1.11.2
 - [fixed] Fixed the FirebaseFirestore podspec to properly declare its

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Unreleased
 
-# v1.11.3
-- [changed] Internal changes.
+# v1.12.1
+- [changed] Internal improvements for future C++ and Unity support.
+
+# v1.12.0
+- [changed] Internal improvements.
 
 # v1.11.2
 - [fixed] Fixed the FirebaseFirestore podspec to properly declare its


### PR DESCRIPTION
Also fix the version entry for the previous release. The last Firestore
release was 1.12.0, not 1.11.3.