### PR TITLE
Don't leak upload packages or deadlock on lifecycle events

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORRegistrar.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORRegistrar.m
@@ -122,63 +122,66 @@
 #pragma mark - GDTCORLifecycleProtocol
 
 - (void)appWillBackground:(nonnull GDTCORApplication *)app {
-  dispatch_async(_registrarQueue, ^{
-    for (id<GDTCORUploader> uploader in [self->_targetToUploader allValues]) {
-      if ([uploader respondsToSelector:@selector(appWillBackground:)]) {
-        [uploader appWillBackground:app];
-      }
+  NSArray<id<GDTCORUploader>> *uploaders = [self.targetToUploader allValues];
+  for (id<GDTCORUploader> uploader in uploaders) {
+    if ([uploader respondsToSelector:@selector(appWillBackground:)]) {
+      [uploader appWillBackground:app];
     }
-    for (id<GDTCORPrioritizer> prioritizer in [self->_targetToPrioritizer allValues]) {
-      if ([prioritizer respondsToSelector:@selector(appWillBackground:)]) {
-        [prioritizer appWillBackground:app];
-      }
+  }
+  NSArray<id<GDTCORPrioritizer>> *prioritizers = [self.targetToPrioritizer allValues];
+  for (id<GDTCORPrioritizer> prioritizer in prioritizers) {
+    if ([prioritizer respondsToSelector:@selector(appWillBackground:)]) {
+      [prioritizer appWillBackground:app];
     }
-    for (id<GDTCORStorageProtocol> storage in [self->_targetToStorage allValues]) {
-      if ([storage respondsToSelector:@selector(appWillBackground:)]) {
-        [storage appWillBackground:app];
-      }
+  }
+  NSArray<id<GDTCORStorageProtocol>> *storages = [self.targetToStorage allValues];
+  for (id<GDTCORStorageProtocol> storage in storages) {
+    if ([storage respondsToSelector:@selector(appWillBackground:)]) {
+      [storage appWillBackground:app];
     }
-  });
+  }
 }
 
 - (void)appWillForeground:(nonnull GDTCORApplication *)app {
-  dispatch_async(_registrarQueue, ^{
-    for (id<GDTCORUploader> uploader in [self->_targetToUploader allValues]) {
-      if ([uploader respondsToSelector:@selector(appWillForeground:)]) {
-        [uploader appWillForeground:app];
-      }
+  NSArray<id<GDTCORUploader>> *uploaders = [self.targetToUploader allValues];
+  for (id<GDTCORUploader> uploader in uploaders) {
+    if ([uploader respondsToSelector:@selector(appWillForeground:)]) {
+      [uploader appWillForeground:app];
     }
-    for (id<GDTCORPrioritizer> prioritizer in [self->_targetToPrioritizer allValues]) {
-      if ([prioritizer respondsToSelector:@selector(appWillForeground:)]) {
-        [prioritizer appWillForeground:app];
-      }
+  }
+  NSArray<id<GDTCORPrioritizer>> *prioritizers = [self.targetToPrioritizer allValues];
+  for (id<GDTCORPrioritizer> prioritizer in prioritizers) {
+    if ([prioritizer respondsToSelector:@selector(appWillForeground:)]) {
+      [prioritizer appWillForeground:app];
     }
-    for (id<GDTCORStorageProtocol> storage in [self->_targetToStorage allValues]) {
-      if ([storage respondsToSelector:@selector(appWillForeground:)]) {
-        [storage appWillForeground:app];
-      }
+  }
+  NSArray<id<GDTCORStorageProtocol>> *storages = [self.targetToStorage allValues];
+  for (id<GDTCORStorageProtocol> storage in storages) {
+    if ([storage respondsToSelector:@selector(appWillForeground:)]) {
+      [storage appWillForeground:app];
     }
-  });
+  }
 }
 
 - (void)appWillTerminate:(nonnull GDTCORApplication *)app {
-  dispatch_sync(_registrarQueue, ^{
-    for (id<GDTCORUploader> uploader in [self->_targetToUploader allValues]) {
-      if ([uploader respondsToSelector:@selector(appWillTerminate:)]) {
-        [uploader appWillTerminate:app];
-      }
+  NSArray<id<GDTCORUploader>> *uploaders = [self.targetToUploader allValues];
+  for (id<GDTCORUploader> uploader in uploaders) {
+    if ([uploader respondsToSelector:@selector(appWillTerminate:)]) {
+      [uploader appWillTerminate:app];
     }
-    for (id<GDTCORPrioritizer> prioritizer in [self->_targetToPrioritizer allValues]) {
-      if ([prioritizer respondsToSelector:@selector(appWillTerminate:)]) {
-        [prioritizer appWillTerminate:app];
-      }
+  }
+  NSArray<id<GDTCORPrioritizer>> *prioritizers = [self.targetToPrioritizer allValues];
+  for (id<GDTCORPrioritizer> prioritizer in prioritizers) {
+    if ([prioritizer respondsToSelector:@selector(appWillTerminate:)]) {
+      [prioritizer appWillTerminate:app];
     }
-    for (id<GDTCORStorageProtocol> storage in [self->_targetToStorage allValues]) {
-      if ([storage respondsToSelector:@selector(appWillTerminate:)]) {
-        [storage appWillTerminate:app];
-      }
+  }
+  NSArray<id<GDTCORStorageProtocol>> *storages = [self.targetToStorage allValues];
+  for (id<GDTCORStorageProtocol> storage in storages) {
+    if ([storage respondsToSelector:@selector(appWillTerminate:)]) {
+      [storage appWillTerminate:app];
     }
-  });
+  }
 }
 
 @end

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORUploadPackage_Private.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORUploadPackage_Private.h
@@ -24,4 +24,7 @@
 /** A handler that will receive callbacks for certain events. */
 @property(nonatomic) id<NSSecureCoding, GDTCORUploadPackageProtocol> handler;
 
+/** Checks if the package is expired and calls -packageExpired: on the handler if necessary. */
+- (void)checkIfPackageIsExpired;
+
 @end

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORUploadPackage.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORUploadPackage.h
@@ -62,10 +62,7 @@
  * @param target The target/destination of this package.
  * @return An instance of this class.
  */
-- (instancetype)initWithTarget:(GDTCORTarget)target NS_DESIGNATED_INITIALIZER;
-
-// Please use the designated initializer.
-- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithTarget:(GDTCORTarget)target;
 
 /** Completes delivery of the package.
  *

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORUploadPackageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORUploadPackageTest.m
@@ -142,4 +142,15 @@
   [self waitForExpectations:@[ expectation ] timeout:30];
 }
 
+/** Tests that the upload package is not leaked by using an NSTimer. */
+- (void)testNoMemoryLeak {
+  __weak GDTCORUploadPackage *weakPackage;
+  @autoreleasepool {
+    GDTCORUploadPackage *package = [[GDTCORUploadPackage alloc] initWithTarget:kGDTCORTargetTest];
+    weakPackage = package;
+    package = nil;
+  }
+  XCTAssertNil(weakPackage);
+}
+
 @end


### PR DESCRIPTION
GDTCORUploadPackages would call targetToStorage in -initWithTarget. When this method was running during app terminate, this would cause a deadlock because calling targetToStorage is re-entrant while GDTCORRegistrar is sending lifecycle events to all the instances it's tracking.

NSTimer's invalidate method is also called whenever a package is completed, retried, or expired, without regard to the presence of a package handler.

A unit test is added to ensure that GDTCORUploadPackage's are not leaked by a retain

TSAN caught no issues

Fixes #5360 