### PR TITLE
Cherry pick: Remove accessors for prioritizer internals onto 6.22.0

### DIFF
--- a/GoogleDataTransportCCTSupport.podspec
+++ b/GoogleDataTransportCCTSupport.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'GoogleDataTransportCCTSupport'
-  s.version          = '2.0.2'
+  s.version          = '2.0.3'
   s.summary          = 'Support library for the GoogleDataTransport CCT backend target.'
 
 

--- a/GoogleDataTransportCCTSupport/CHANGELOG.md
+++ b/GoogleDataTransportCCTSupport/CHANGELOG.md
@@ -1,4 +1,7 @@
-# Unreleased
+# v2.0.3
+- Synchronize prioritizer property access using a new method. (#5312)
+
+# v2.0.2
 - Remove usage of memcpy and convert calls from malloc to calloc.
 
 # v2.0.1

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTPrioritizer.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTPrioritizer.m
@@ -39,6 +39,20 @@ static NSString *ArchivePath() {
   return archivePath;
 }
 
+/** This class extension is for declaring private properties. */
+@interface GDTCCTPrioritizer ()
+
+/** All CCT events that have been processed by this prioritizer. */
+@property(nonatomic) NSMutableSet<GDTCOREvent *> *CCTEvents;
+
+/** All FLL events that have been processed by this prioritizer. */
+@property(nonatomic) NSMutableSet<GDTCOREvent *> *FLLEvents;
+
+/** All CSH events that have been processed by this prioritizer. */
+@property(nonatomic) NSMutableSet<GDTCOREvent *> *CSHEvents;
+
+@end
+
 @implementation GDTCCTPrioritizer
 
 + (void)load {
@@ -70,6 +84,29 @@ static NSString *ArchivePath() {
     _CSHEvents = [[NSMutableSet alloc] init];
   }
   return self;
+}
+
+- (nullable NSSet *)eventsForTarget:(GDTCORTarget)target {
+  __block NSSet *events;
+  dispatch_sync(_queue, ^{
+    switch (target) {
+      case kGDTCORTargetCCT:
+        events = [self->_CCTEvents copy];
+        break;
+
+      case kGDTCORTargetFLL:
+        events = [self->_FLLEvents copy];
+        break;
+
+      case kGDTCORTargetCSH:
+        events = [self->_CSHEvents copy];
+        break;
+
+      default:
+        break;
+    }
+  });
+  return events;
 }
 
 #pragma mark - GDTCORPrioritizer Protocol

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTUploader.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTUploader.m
@@ -276,13 +276,10 @@ NSNotificationName const GDTCCTUploadCompleteNotification = @"com.GDTCCTUploader
 
 - (BOOL)readyToUploadTarget:(GDTCORTarget)target conditions:(GDTCORUploadConditions)conditions {
   __block BOOL result = NO;
+  NSSet *CSHEvents = [[GDTCCTPrioritizer sharedInstance] eventsForTarget:kGDTCORTargetCSH];
   dispatch_sync(_uploaderQueue, ^{
     if (target == kGDTCORTargetCSH) {
-      if ([GDTCCTPrioritizer sharedInstance].CSHEvents.count > 0) {
-        result = YES;
-      } else {
-        result = NO;
-      }
+      result = CSHEvents.count > 0;
       return;
     }
 

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTPrioritizer.h
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTPrioritizer.h
@@ -29,15 +29,6 @@ NS_ASSUME_NONNULL_BEGIN
 /** The queue on which this prioritizer operates. */
 @property(nonatomic) dispatch_queue_t queue;
 
-/** All CCT events that have been processed by this prioritizer. */
-@property(nonatomic) NSMutableSet<GDTCOREvent *> *CCTEvents;
-
-/** All FLL events that have been processed by this prioritizer. */
-@property(nonatomic) NSMutableSet<GDTCOREvent *> *FLLEvents;
-
-/** All CSH events that have been processed by this prioritizer. */
-@property(nonatomic) NSMutableSet<GDTCOREvent *> *CSHEvents;
-
 /** The most recent attempted upload of CCT daily uploaded logs. */
 @property(nonatomic) GDTCORClock *CCTTimeOfLastDailyUpload;
 
@@ -49,6 +40,13 @@ NS_ASSUME_NONNULL_BEGIN
  * @return The singleton instance of this class.
  */
 + (instancetype)sharedInstance;
+
+/** Returns a set of events that have been prioritized for the given target.
+ *
+ * @param target The target to check. CCT, FLL, and CSH are currently supported by this class.
+ * @return The set of events prioritized so far.
+ */
+- (nullable NSSet *)eventsForTarget:(GDTCORTarget)target;
 
 NS_ASSUME_NONNULL_END
 

--- a/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/GDTCCTPrioritizerTest.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTTests/Unit/GDTCCTPrioritizerTest.m
@@ -55,11 +55,9 @@
   [prioritizer prioritizeEvent:[_CCTGenerator generateEvent:GDTCOREventQosDefault]];
   [prioritizer prioritizeEvent:[_FLLGenerator generateEvent:GDTCOREventQosDefault]];
   [prioritizer prioritizeEvent:[_CSHGenerator generateEvent:GDTCOREventQosDefault]];
-  dispatch_sync(prioritizer.queue, ^{
-    XCTAssertEqual(prioritizer.CCTEvents.count, 1);
-    XCTAssertEqual(prioritizer.FLLEvents.count, 1);
-    XCTAssertEqual(prioritizer.CSHEvents.count, 1);
-  });
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetCCT].count, 1);
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetFLL].count, 1);
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetCSH].count, 1);
 }
 
 /** Tests prioritizing multiple events. */
@@ -74,11 +72,9 @@
   [prioritizer prioritizeEvent:[_CCTGenerator generateEvent:GDTCOREventQosDefault]];
   [prioritizer prioritizeEvent:[_CSHGenerator generateEvent:GDTCOREventQosDefault]];
   [prioritizer prioritizeEvent:[_CCTGenerator generateEvent:GDTCOREventQosDefault]];
-  dispatch_sync(prioritizer.queue, ^{
-    XCTAssertEqual(prioritizer.CCTEvents.count, 5);
-    XCTAssertEqual(prioritizer.FLLEvents.count, 2);
-    XCTAssertEqual(prioritizer.CSHEvents.count, 2);
-  });
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetCCT].count, 5);
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetFLL].count, 2);
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetCSH].count, 2);
 }
 
 /** Tests unprioritizing events. */
@@ -93,11 +89,9 @@
   [prioritizer prioritizeEvent:[_CCTGenerator generateEvent:GDTCOREventQosDefault]];
   [prioritizer prioritizeEvent:[_CSHGenerator generateEvent:GDTCOREventQosDefault]];
   [prioritizer prioritizeEvent:[_CCTGenerator generateEvent:GDTCOREventQosDefault]];
-  dispatch_sync(prioritizer.queue, ^{
-    XCTAssertEqual(prioritizer.CCTEvents.count, 5);
-    XCTAssertEqual(prioritizer.FLLEvents.count, 2);
-    XCTAssertEqual(prioritizer.CSHEvents.count, 2);
-  });
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetCCT].count, 5);
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetFLL].count, 2);
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetCSH].count, 2);
   GDTCORUploadPackage *package =
       [prioritizer uploadPackageWithTarget:kGDTCORTargetFLL
                                 conditions:GDTCORUploadConditionWifiData];
@@ -190,7 +184,7 @@
   NSError *error;
   dispatch_sync(prioritizer.queue, ^{
                 });
-  XCTAssertEqual(prioritizer.CCTEvents.count, 1);
+  XCTAssertEqual([prioritizer eventsForTarget:kGDTCORTargetCCT].count, 1);
   NSData *prioritizerData = GDTCOREncodeArchive(prioritizer, nil, &error);
   XCTAssertNil(error);
   XCTAssertNotNil(prioritizerData);
@@ -201,7 +195,8 @@
   XCTAssertNil(error);
   XCTAssertNotNil(unarchivedPrioritizer);
   XCTAssertEqual([prioritizer hash], [prioritizer hash]);
-  XCTAssertEqualObjects(prioritizer.CCTEvents, unarchivedPrioritizer.CCTEvents);
+  XCTAssertEqualObjects([prioritizer eventsForTarget:kGDTCORTargetCCT],
+                        [unarchivedPrioritizer eventsForTarget:kGDTCORTargetCCT]);
 }
 
 @end


### PR DESCRIPTION
Cherry picks #5352 onto release-6.22.0 for an ad-hoc release.
Increments GDTCCT patch version to v2.0.3

Fixes #5312
