### PR TITLE
Add LLDB type summaries for Firestore types

### DIFF
--- a/Firestore/README.md
+++ b/Firestore/README.md
@@ -10,6 +10,17 @@
   * Select the Firestore_Tests_iOS scheme
   * ⌘-u to build and run the unit tests
 
+### Improving the debuger experience
+
+You can install a set of type formatters to improve the presentation of
+Firestore internals in LLDB and Xcode. Add the following to your `~/.lldbinit` file:
+
+```
+command script import ~/path/to/firebase-ios-sdk/scripts/lldb/firestore.py
+```
+
+(substitute the location of your checkout of the firebase-ios-sdk.)
+
 ### Running Integration Tests
 
   * [Set up a `GoogleServices-Info.plist`](//github.com/firebase/firebase-ios-sdk#running-sample-apps)

--- a/Firestore/README.md
+++ b/Firestore/README.md
@@ -10,7 +10,7 @@
   * Select the Firestore_Tests_iOS scheme
   * ⌘-u to build and run the unit tests
 
-### Improving the debuger experience
+### Improving the debugger experience
 
 You can install a set of type formatters to improve the presentation of
 Firestore internals in LLDB and Xcode. Add the following to your `~/.lldbinit` file:

--- a/scripts/lldb/firestore.py
+++ b/scripts/lldb/firestore.py
@@ -62,6 +62,18 @@ def ResourcePath_SummaryProvider(value, params):
   return text
 
 
+# api
+
+def DocumentReference_SummaryProvider(value, params):
+  return value.GetChildMemberWithName('key_').GetSummary()
+
+
+# Objective-C
+
+def FIRDocumentReference_SummaryProvider(value, params):
+  return value.GetChildMemberWithName('_documentReference').GetSummary()
+
+
 def get_string(value):
   """Returns a Python string from the underlying LLDB SBValue."""
   # TODO(wilhuff): This is gross hack. Actually use the SBData API to get this.
@@ -89,9 +101,14 @@ def __lldb_init_module(debugger, params):
     run('type summary add -w firestore -F {0} {1} {2}'.format(
       qname(provider), args, typename))
 
+  api = 'firebase::firestore::api::'
+  add_summary(DocumentReference_SummaryProvider, api + 'DocumentReference')
+
   model = 'firebase::firestore::model::'
   add_summary(DocumentKey_SummaryProvider, model + 'DocumentKey')
   add_summary(ResourcePath_SummaryProvider, model + 'ResourcePath')
+
+  add_summary(FIRDocumentReference_SummaryProvider, 'FIRDocumentReference')
 
   run('type category enable firestore')
 

--- a/scripts/lldb/firestore.py
+++ b/scripts/lldb/firestore.py
@@ -1,0 +1,101 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import json
+
+"""
+LLDB type summary providers for common Firestore types.
+
+This is primarily useful for debugging Firestore internals. It will add useful
+summaries and consolidate common types in a way that makes them easier to
+observe in the debugger.
+
+Use this by adding the following to your ~/.lldbinit file:
+
+    command script import ~/path/to/firebase-ios-sdk/scripts/lldb/firestore.py
+
+Most of this implementation is based on "Variable Formatting" in the LLDB online
+manual: https://lldb.llvm.org/use/variable.html. There are two major features
+we're making use of:
+
+  * Summary Providers: these are classes or functions that take an object and
+    produce a (typically one line) summary of the type
+
+  * Synthetic Children Providers: these are classes that provide an alternative
+    view of the data. The children that are synthesized here show up in the
+    graphical debugger.
+"""
+
+
+# model
+
+def DocumentKey_SummaryProvider(value, params):
+  """Summarizes DocumentKey as if path_->segments_ were inline and a single
+  string."""
+  return deref_shared(value.GetChildMemberWithName('path_')).GetSummary()
+
+
+def ResourcePath_SummaryProvider(value, params):
+  """Summarizes ResourcePath as if segments_ is a single string."""
+
+  segments = value.GetChildMemberWithName('segments_')
+  count = segments.GetNumChildren()
+
+  segment_text = []
+  for i in range(0, count):
+    child = segments.GetChildAtIndex(i)
+    segment_text.append(get_string(child))
+
+  text = format_string('/'.join(segment_text))
+  return text
+
+
+def get_string(value):
+  """Returns a Python string from the underlying LLDB SBValue."""
+  # TODO(wilhuff): This is gross hack. Actually use the SBData API to get this.
+  summary = value.GetSummary()
+  return ast.literal_eval(summary)
+
+
+def format_string(string):
+  """Formats a Python string as a C++ string literal."""
+  # JSON and C escapes work the ~same.
+  return json.dumps(string)
+
+
+def deref_shared(value):
+  """Dereference a shared_ptr."""
+  return value.GetChildMemberWithName('__ptr_').Dereference()
+
+
+def __lldb_init_module(debugger, params):
+  def run(command):
+    debugger.HandleCommand(command)
+
+  def add_summary(provider, typename, *args):
+    args = ' '.join(args)
+    run('type summary add -w firestore -F {0} {1} {2}'.format(
+      qname(provider), args, typename))
+
+  model = 'firebase::firestore::model::'
+  add_summary(DocumentKey_SummaryProvider, model + 'DocumentKey')
+  add_summary(ResourcePath_SummaryProvider, model + 'ResourcePath')
+
+  run('type category enable firestore')
+
+
+def qname(fn):
+  """Returns the module-qualified name of the given class or function."""
+  return '{0}.{1}'.format(__name__, fn.__name__)

--- a/scripts/lldb/firestore.py
+++ b/scripts/lldb/firestore.py
@@ -68,10 +68,18 @@ def DocumentReference_SummaryProvider(value, params):
   return value.GetChildMemberWithName('key_').GetSummary()
 
 
+def DocumentSnapshot_SummaryProvider(value, params):
+  return value.GetChildMemberWithName('internal_key_').GetSummary()
+
+
 # Objective-C
 
 def FIRDocumentReference_SummaryProvider(value, params):
   return value.GetChildMemberWithName('_documentReference').GetSummary()
+
+
+def FIRDocumentSnapshot_SummaryProvider(value, params):
+  return value.GetChildMemberWithName('_snapshot').GetSummary()
 
 
 def get_string(value):
@@ -103,12 +111,15 @@ def __lldb_init_module(debugger, params):
 
   api = 'firebase::firestore::api::'
   add_summary(DocumentReference_SummaryProvider, api + 'DocumentReference')
+  add_summary(DocumentSnapshot_SummaryProvider, api + 'DocumentSnapshot', '-e')
 
   model = 'firebase::firestore::model::'
   add_summary(DocumentKey_SummaryProvider, model + 'DocumentKey')
   add_summary(ResourcePath_SummaryProvider, model + 'ResourcePath')
 
   add_summary(FIRDocumentReference_SummaryProvider, 'FIRDocumentReference')
+
+  add_summary(FIRDocumentSnapshot_SummaryProvider, 'FIRDocumentSnapshot', '-e')
 
   run('type category enable firestore')
 

--- a/scripts/lldb/firestore.py
+++ b/scripts/lldb/firestore.py
@@ -139,8 +139,8 @@ class DatabaseId_SynthProvider(ForwardingSynthProvider):
 def DatabaseId_SummaryProvider(value, params):
   # Operates on the result of the SynthProvider; value is *rep_.
   parts = [
-    get_string(value.GetChildMemberWithName('project_id')),
-    get_string(value.GetChildMemberWithName('database_id'))
+      get_string(value.GetChildMemberWithName('project_id')),
+      get_string(value.GetChildMemberWithName('database_id'))
   ]
   return format_string('/'.join(parts))
 
@@ -216,12 +216,12 @@ def __lldb_init_module(debugger, params):
   def add_summary(provider, typename, *args):
     args = ' '.join(args)
     run('type summary add -w firestore -F {0} {1} {2}'.format(
-      qname(provider), args, typename))
+        qname(provider), args, typename))
 
   def add_synthetic(provider, typename, *args):
     args = ' '.join(args)
     run('type synthetic add -l {0} -w firestore {1} {2}'.format(
-      qname(provider), args, typename))
+        qname(provider), args, typename))
 
   optional_matcher = '-x absl::[^:]*::optional<.*>'
   add_summary(AbseilOptional_SummaryProvider, optional_matcher, '-e')


### PR DESCRIPTION
There are some particular pain points debugging Firestore today because contents of variables are obscured due to information hiding and shared representation techniques we use. Also, we use elements of the Abseil library to supplement what's available in the C++11 standard library.

Taken together, these make our default experience in LLDB and the Xcode debugger quite painful: getting the path of a document currently takes 5 clicks. This change pulls the document path into the summary line, making it available with no clicks.

Only a small handful of types are included (see individual commits).

When printing a `FIRDocumentSnapshot`, here was before:

```
(lldb) p *snapshot
(FIRDocumentSnapshot) $1 = {
  NSObject = {
    isa = FIRDocumentSnapshot
  }
  _snapshot = {
    firestore_ = std::__1::shared_ptr<firebase::firestore::api::Firestore>::element_type @ 0x000060000233f318 strong=4 weak=2 {
      __ptr_ = 0x000060000233f318
    }
    internal_key_ = {
      path_ = std::__1::shared_ptr<const firebase::firestore::model::ResourcePath>::element_type @ 0x0000600001016f58 strong=3 weak=1 {
        __ptr_ = 0x0000600001016f58
      }
    }
    internal_document_ = {
      absl::lts_2020_02_25::optional_internal::optional_data<firebase::firestore::model::Document, false> = {
        absl::lts_2020_02_25::optional_internal::optional_data_base<firebase::firestore::model::Document> = {
          absl::lts_2020_02_25::optional_internal::optional_data_dtor_base<firebase::firestore::model::Document, false> = {
            engaged_ = true
             = {
              data_ = {
                firebase::firestore::model::MaybeDocument = {
                  rep_ = std::__1::shared_ptr<const firebase::firestore::model::MaybeDocument::Rep>::element_type @ 0x0000600003448da8 strong=5 weak=1 {
                    __ptr_ = 0x0000600003448da8
                  }
                }
              }
              dummy_ = {}
            }
          }
        }
      }
    }
    metadata_ = (pending_writes_ = false, from_cache_ = true)
  }
  _cachedMetadata = nil
}
```

... and after:

```
(lldb) p *snapshot
(FIRDocumentSnapshot) $0 = "test-collection/SXJOSv8YRvhc6EJih1xr" {
  NSObject = {
    isa = FIRDocumentSnapshot
  }
  _snapshot = "test-collection/SXJOSv8YRvhc6EJih1xr" {
    firestore_ = std::__1::shared_ptr<firebase::firestore::api::Firestore>::element_type @ 0x000060000233f318 strong=4 weak=2 {
      __ptr_ = 0x000060000233f318
    }
    internal_key_ = "test-collection/SXJOSv8YRvhc6EJih1xr"
    internal_document_ = engaged=true {
      engaged_ = true
      data_ = {
        firebase::firestore::model::MaybeDocument = {
          rep_ = std::__1::shared_ptr<const firebase::firestore::model::MaybeDocument::Rep>::element_type @ 0x0000600003448da8 strong=5 weak=1 {
            __ptr_ = 0x0000600003448da8
          }
        }
      }
    }
    metadata_ = (pending_writes_ = false, from_cache_ = true)
  }
  _cachedMetadata = nil
}
```

If we agree on approach, this can be extended to more types.