### PR TITLE
Cleanup logging and error handling for initial auth persistence implementation

### DIFF
--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #import "FIRAppDistribution+Private.h"
-#import "FIRAppDistributionRelease+Private.h"
-#import "FIRAppDistributionMachO+Private.h"
 #import "FIRAppDistributionAuthPersistence+Private.h"
+#import "FIRAppDistributionMachO+Private.h"
+#import "FIRAppDistributionRelease+Private.h"
 
 #import <FirebaseCore/FIRAppInternal.h>
 #import <FirebaseCore/FIRComponent.h>
@@ -62,9 +62,9 @@ NSString *const kAppDistroLibraryName = @"fire-fad";
   }
 
   NSError *authRetrievalError;
-  self.authState = [FIRAppDistributionAuthPersistence retrieveAuthState error:&authRetrievalError];
-  //TODO (schnecle): replace NSLog statement with FIRLogger log statement
-  if(authRetrievalError){
+  self.authState = [FIRAppDistributionAuthPersistence retrieveAuthState:&authRetrievalError];
+  // TODO (schnecle): replace NSLog statement with FIRLogger log statement
+  if (authRetrievalError) {
     NSLog(@"Error retrieving token from keychain: %@", [authRetrievalError localizedDescription]);
   }
   self.isTesterSignedIn = self.authState ? YES : NO;
@@ -135,9 +135,9 @@ NSString *const kAppDistroLibraryName = @"fire-fad";
 
 - (void)signOutTester {
   NSError *error;
-  [FIRAppDistributionAuthPersistence clearAuthState error:&error];
+  [FIRAppDistributionAuthPersistence clearAuthState:&error];
   // TODO (schnecle): Add in FIRLogger to report when we have failed to clear auth state
-  if(error){
+  if (error) {
     NSLog(@"Error clearing token from keychain: %@", [error localizedDescription]);
   }
   self.authState = nil;
@@ -145,52 +145,50 @@ NSString *const kAppDistroLibraryName = @"fire-fad";
 }
 
 - (void)fetchReleases:(FIRAppDistributionUpdateCheckCompletion)completion {
+  [self.authState performActionWithFreshTokens:^(NSString *_Nonnull accessToken,
+                                                 NSString *_Nonnull idToken,
+                                                 NSError *_Nullable error) {
+    if (error) {
+      // TODO (schnecle): Add in FIRLogger log statement
+      NSLog(@"Error fetching fresh tokens: %@", [error localizedDescription]);
+      [self signOutTester];
+      return;
+    }
 
-    [self.authState performActionWithFreshTokens:^(NSString *_Nonnull accessToken,
-                                               NSString *_Nonnull idToken,
-                                               NSError *_Nullable error) {
-      if (error) {
-        // TODO (schnecle): Add in FIRLogger log statement
-        NSLog(@"Error fetching fresh tokens: %@", [error localizedDescription]);
-        [self signOutTester];
-        return;
-      }
+    // perform your API request using the tokens
+    NSURLSession *URLSession = [NSURLSession sharedSession];
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
+    NSString *URLString =
+        [NSString stringWithFormat:kReleasesEndpointURL, [[FIRApp defaultApp] options].googleAppID];
+    [request setURL:[NSURL URLWithString:URLString]];
+    [request setHTTPMethod:@"GET"];
+    [request setValue:[NSString stringWithFormat:@"Bearer %@", accessToken]
+        forHTTPHeaderField:@"Authorization"];
 
-      // perform your API request using the tokens
-        NSURLSession *URLSession = [NSURLSession sharedSession];
-        NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
-        NSString *URLString =
-            [NSString stringWithFormat:kReleasesEndpointURL, [[FIRApp defaultApp] options].googleAppID];
-        [request setURL:[NSURL URLWithString:URLString]];
-        [request setHTTPMethod:@"GET"];
-        [request setValue:[NSString
-                              stringWithFormat:@"Bearer %@", accessToken]
-            forHTTPHeaderField:@"Authorization"];
+    NSURLSessionDataTask *listReleasesDataTask = [URLSession
+        dataTaskWithRequest:request
+          completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            if (error) {
+              // TODO: Reformat error into error code
+              completion(nil, error);
+              return;
+            }
 
-        NSURLSessionDataTask *listReleasesDataTask = [URLSession
-            dataTaskWithRequest:request
-              completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                if (error) {
-                  // TODO: Reformat error into error code
-                  completion(nil, error);
-                  return;
-                }
+            NSHTTPURLResponse *HTTPResponse = (NSHTTPURLResponse *)response;
 
-                NSHTTPURLResponse *HTTPResponse = (NSHTTPURLResponse *)response;
+            if (HTTPResponse.statusCode == 200) {
+              [self handleReleasesAPIResponseWithData:data completion:completion];
+            } else {
+              // TODO: Handle non-200 http response
+              NSLog(@"ERROR - Non 200 service response - %@", HTTPResponse);
+              @throw([NSException exceptionWithName:@"NotImplementedException"
+                                             reason:@"This code path is not implemented yet"
+                                           userInfo:nil]);
+            }
+          }];
 
-                if (HTTPResponse.statusCode == 200) {
-                  [self handleReleasesAPIResponseWithData:data completion:completion];
-                } else {
-                  // TODO: Handle non-200 http response
-                  NSLog(@"ERROR - Non 200 service response - %@", HTTPResponse);
-                  @throw([NSException exceptionWithName:@"NotImplementedException"
-                                                 reason:@"This code path is not implemented yet"
-                                               userInfo:nil]);
-                }
-              }];
-
-        [listReleasesDataTask resume];
-    }];
+    [listReleasesDataTask resume];
+  }];
 }
 
 - (void)handleOauthDiscoveryCompletion:(OIDServiceConfiguration *_Nullable)configuration
@@ -220,27 +218,32 @@ NSString *const kAppDistroLibraryName = @"fire-fad";
   [self createUIWindowForLogin];
   // performs authentication request
   [FIRAppDistributionAppDelegatorInterceptor sharedInstance].currentAuthorizationFlow =
-      [OIDAuthState authStateByPresentingAuthorizationRequest:request
-                                     presentingViewController:self.safariHostingViewController
-                                                     callback:^(OIDAuthState *_Nullable authState,
-                                                                NSError *_Nullable error) {
-          self.authState = authState;
+      [OIDAuthState
+          authStateByPresentingAuthorizationRequest:request
+                           presentingViewController:self.safariHostingViewController
+                                           callback:^(OIDAuthState *_Nullable authState,
+                                                      NSError *_Nullable error) {
+                                             self.authState = authState;
 
-          // Capture errors in persistence but do not bubble them up
-          NSError *authPersistenceError;
-          if(authState) {
-            [FIRAppDistributionAuthPersistence persistAuthState:authState error:&authPersistenceError];
-          }
+                                             // Capture errors in persistence but do not bubble them
+                                             // up
+                                             NSError *authPersistenceError;
+                                             if (authState) {
+                                               [FIRAppDistributionAuthPersistence
+                                                   persistAuthState:authState
+                                                              error:&authPersistenceError];
+                                             }
 
-          // TODO (schnecle): Log errors in persistence using FIRLogger
-          if(authPersistenceError) {
-            NSLog(@"Error persisting token to keychain: %@", [error localizedDescription]);
-          }
-          self.isTesterSignedIn = self.authState ? YES : NO;
-          completion(error);
-        }];
+                                             // TODO (schnecle): Log errors in persistence using
+                                             // FIRLogger
+                                             if (authPersistenceError) {
+                                               NSLog(@"Error persisting token to keychain: %@",
+                                                     [error localizedDescription]);
+                                             }
+                                             self.isTesterSignedIn = self.authState ? YES : NO;
+                                             completion(error);
+                                           }];
 }
-
 
 - (UIWindow *)createUIWindowForLogin {
   // Create an empty window + viewController to host the Safari UI.
@@ -259,28 +262,27 @@ NSString *const kAppDistroLibraryName = @"fire-fad";
 - (void)handleReleasesAPIResponseWithData:data
                                completion:(FIRAppDistributionUpdateCheckCompletion)completion {
   NSError *error = nil;
-  NSDictionary *object = [NSJSONSerialization
-                          JSONObjectWithData:data
-                          options:0
-                          error:&error];
+  NSDictionary *object = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
 
-    NSArray *releaseList = [object objectForKey:@"releases"];
-    for (NSDictionary *releaseDict in releaseList) {
-        if([[releaseDict objectForKey:@"latest"] boolValue]) {
-            NSString *codeHash = [releaseDict objectForKey:@"codeHash"];
-            NSString *executablePath = [[NSBundle mainBundle] executablePath];
-            FIRAppDistributionMachO *machO = [[FIRAppDistributionMachO alloc] initWithPath:executablePath];
+  NSArray *releaseList = [object objectForKey:@"releases"];
+  for (NSDictionary *releaseDict in releaseList) {
+    if ([[releaseDict objectForKey:@"latest"] boolValue]) {
+      NSString *codeHash = [releaseDict objectForKey:@"codeHash"];
+      NSString *executablePath = [[NSBundle mainBundle] executablePath];
+      FIRAppDistributionMachO *machO =
+          [[FIRAppDistributionMachO alloc] initWithPath:executablePath];
 
-            if(![codeHash isEqualToString:machO.codeHash]) {
-                FIRAppDistributionRelease *release = [[FIRAppDistributionRelease alloc] initWithDictionary:releaseDict];
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    completion(release, nil);
-                });
-            }
+      if (![codeHash isEqualToString:machO.codeHash]) {
+        FIRAppDistributionRelease *release =
+            [[FIRAppDistributionRelease alloc] initWithDictionary:releaseDict];
+        dispatch_async(dispatch_get_main_queue(), ^{
+          completion(release, nil);
+        });
+      }
 
-            break;
-        }
+      break;
     }
+  }
 }
 - (void)checkForUpdateWithCompletion:(FIRAppDistributionUpdateCheckCompletion)completion {
   if (self.isTesterSignedIn) {

--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -135,9 +135,9 @@ NSString *const kAppDistroLibraryName = @"fire-fad";
 
 - (void)signOutTester {
   NSError *error;
-  [FIRAppDistributionAuthPersistence clearAuthState:&error];
+  BOOL didClearAuthState = [FIRAppDistributionAuthPersistence clearAuthState:&error];
   // TODO (schnecle): Add in FIRLogger to report when we have failed to clear auth state
-  if (error) {
+  if (!didClearAuthState) {
     NSLog(@"Error clearing token from keychain: %@", [error localizedDescription]);
   }
   self.authState = nil;

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionAuthPersistence.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionAuthPersistence.m
@@ -16,6 +16,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NSString *const kFIRAppDistributionKeychainErrorDomain = @"com.firebase.app_distribution.internal";
+
 @implementation FIRAppDistributionAuthPersistence
 
 + (BOOL)clearAuthState:(NSError **_Nullable)error {
@@ -27,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
         @"Failed to clear auth state from keychain. Tester will overwrite data on sign in.",
         @"Error message for failure to retrieve auth state from keychain");
     NSDictionary *userInfo = @{NSLocalizedDescriptionKey : desc};
-    *error = [NSError errorWithDomain:kFIRAppDistributionInternalErrorDomain
+    *error = [NSError errorWithDomain:kFIRAppDistributionKeychainErrorDomain
                                  code:FIRAppDistributionErrorTokenDeletionFailure
                              userInfo:userInfo];
   }
@@ -49,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
         @"Failed to retrieve auth state from keychain. Tester will have to sign in again.",
         @"Error message for failure to retrieve auth state from keychain");
     NSDictionary *userInfo = @{NSLocalizedDescriptionKey : desc};
-    *error = [NSError errorWithDomain:kFIRAppDistributionInternalErrorDomain
+    *error = [NSError errorWithDomain:kFIRAppDistributionKeychainErrorDomain
                                  code:FIRAppDistributionErrorTokenRetrievalFailure
                              userInfo:userInfo];
   }
@@ -62,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
         NSLocalizedString(@"Failed to unarchive auth state. Tester will have to sign in again.",
                           @"Error message for failure to copy password data from keychain");
     NSDictionary *userInfo = @{NSLocalizedDescriptionKey : desc};
-    *error = [NSError errorWithDomain:kFIRAppDistributionInternalErrorDomain
+    *error = [NSError errorWithDomain:kFIRAppDistributionKeychainErrorDomain
                                  code:FIRAppDistributionErrorTokenRetrievalFailure
                              userInfo:userInfo];
   }
@@ -91,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
         @"Failed to persist auth state. Tester will have to sign in again after app close.",
         @"Error message for failure to persist auth state to keychain");
     NSDictionary *userInfo = @{NSLocalizedDescriptionKey : desc};
-    *error = [NSError errorWithDomain:kFIRAppDistributionInternalErrorDomain
+    *error = [NSError errorWithDomain:kFIRAppDistributionKeychainErrorDomain
                                  code:FIRAppDistributionErrorTokenPersistenceFailure
                              userInfo:userInfo];
   }

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionAuthPersistence.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionAuthPersistence.m
@@ -18,75 +18,103 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FIRAppDistributionAuthPersistence
 
-+ (BOOL)clearAuthState {
-    NSMutableDictionary *keychainQuery = [self getKeyChainQuery];
-    OSStatus status = SecItemDelete((CFDictionaryRef)keychainQuery);
-    
-    if (status != errSecSuccess && status != errSecItemNotFound) {
-        NSLog(@"AUTH ERROR. Cant delete auth state in keychain");
-    } else {
-        NSLog(@"AUTH SUCCESS! deleted auth state in the keychain");
++ (BOOL)clearAuthState:(NSError **) error {
+  NSMutableDictionary *keychainQuery = [self getKeyChainQuery];
+  OSStatus status = SecItemDelete((CFDictionaryRef)keychainQuery);
+
+  if (status != errSecSuccess && status != errSecItemNotFound) {
+    NSString *desc = NSLocalizedString(
+      @"Failed to clear auth state from keychain. Tester will overwrite data on sign in.",
+      @"Error message for failure to retrieve auth state from keychain");
+    NSDictionary *userInfo = @{
+      kFIRAppDistributionUnderlyingErrorCode: status,
+      NSLocalizedDescriptionKey: desc
     }
-    return errSecSuccess || status == errSecItemNotFound;
+    *error = [NSError errorWithDomain:kFIRAppDistributionInternalErrorDomain
+                                 code:FIRAppDistributionErrorTokenDeletionFailure
+                             userInfo:userInfo]
+  }
+  return errSecSuccess || status == errSecItemNotFound;
 }
 
-+ (OIDAuthState*)retrieveAuthState {
-    NSMutableDictionary *keychainQuery = [self getKeyChainQuery];
-      [keychainQuery setObject:(id)kCFBooleanTrue forKey:(id)kSecReturnData];
-      [keychainQuery setObject:(id)kSecMatchLimitOne forKey:(id)kSecMatchLimit];
-      CFDataRef passwordData = NULL;
-      NSData *result = nil;
-      OSStatus status = SecItemCopyMatching((CFDictionaryRef)keychainQuery,
-                                         (CFTypeRef *)&passwordData);
-      if (status == noErr && 0 < [(__bridge NSData *)passwordData length]) {
-        result = [(__bridge NSData *)passwordData copy];
-      } else {
-          NSLog(@"AUTH ERROR - cannot lookup keystore config");
-      }
-      if (passwordData != NULL) {
-        CFRelease(passwordData);
-      }
-    
-    OIDAuthState *authState = nil;
-    if(result) {
-        authState = (OIDAuthState *)[NSKeyedUnarchiver unarchiveObjectWithData:result];
-    }
-    
-    return authState;
+
++ (OIDAuthState *)retrieveAuthState:(NSError **) error {
+  NSMutableDictionary *keychainQuery = [self getKeyChainQuery];
+  [keychainQuery setObject:(id)kCFBooleanTrue forKey:(id)kSecReturnData];
+  [keychainQuery setObject:(id)kSecMatchLimitOne forKey:(id)kSecMatchLimit];
+  CFDataRef passwordData = NULL;
+  NSData *result = nil;
+  OSStatus status = SecItemCopyMatching((CFDictionaryRef)keychainQuery, (CFTypeRef *)&passwordData);
+
+  if (status == noErr && 0 < [(__bridge NSData *)passwordData length]) {
+    result = [(__bridge NSData *)passwordData copy];
+  } else {
+    NSString *desc = NSLocalizedString(
+      @"Failed to retrieve auth state from keychain. Tester will have to sign in again.",
+      @"Error message for failure to retrieve auth state from keychain");
+    NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: desc };
+    *error = [NSError errorWithDomain:kFIRAppDistributionInternalErrorDomain
+                                 code:FIRAppDistributionErrorTokenRetrievalFailure
+                             userInfo:userInfo]
+  }
+
+  OIDAuthState *authState = nil;
+  if (result) {
+    authState = (OIDAuthState *)[NSKeyedUnarchiver unarchiveObjectWithData:result];
+  } else {
+    NSString *desc = NSLocalizedString(
+      @"Failed to unarchive auth state. Tester will have to sign in again.",
+      @"Error message for failure to copy password data from keychain");
+    NSDictionary *userInfo = @{ NSLocalizedDescriptionKey : desc };
+    *error = [NSError errorWithDomain:kFIRAppDistributionInternalErrorDomain
+                                 code:FIRAppDistributionErrorTokenRetrievalFailure
+                             userInfo:userInfo]
+  }
+
+  if (passwordData != NULL) {
+    CFRelease(passwordData);
+  }
+
+  return authState;
 }
 
-+ (BOOL)persistAuthState:(OIDAuthState *)authState {
-    NSData *authorizationData = [NSKeyedArchiver archivedDataWithRootObject:authState];
-    NSMutableDictionary *keychainQuery = [self getKeyChainQuery];
-    OSStatus status = noErr;
-    if([self retrieveAuthState]) {
-        NSLog(@"Auth state already persisted. Updating auth state");
-        status = SecItemUpdate((CFDictionaryRef)keychainQuery, (CFDictionaryRef)@{(id)kSecValueData: authorizationData});
-    } else {
-        [keychainQuery setObject:authorizationData forKey:(id)kSecValueData];
-        status = SecItemAdd((CFDictionaryRef)keychainQuery, NULL);
-    }
++ (BOOL)persistAuthState:(OIDAuthState *)authState
+                   error:(NSError **)error {
+  NSData *authorizationData = [NSKeyedArchiver archivedDataWithRootObject:authState];
+  NSMutableDictionary *keychainQuery = [self getKeyChainQuery];
+  OSStatus status = noErr;
+  if ([self retrieveAuthState]) {
+    status = SecItemUpdate((CFDictionaryRef)keychainQuery,
+                           (CFDictionaryRef) @{(id)kSecValueData : authorizationData});
+  } else {
+    [keychainQuery setObject:authorizationData forKey:(id)kSecValueData];
+    status = SecItemAdd((CFDictionaryRef)keychainQuery, NULL);
+  }
 
-      if (status != noErr) {
-          NSLog(@"AUTH ERROR. Cant store auth state in keychain");
-      } else {
-          NSLog(@"AUTH SUCCESS! Added auth state to keychain");
-      }
-    
-    return status == noErr;
+  if (status != noErr) {
+    NSString *desc = NSLocalizedString(
+      @"Failed to persist auth state. Tester will have to sign in again after app close.",
+      @"Error message for failure to persist auth state to keychain");
+    NSDictionary *userInfo = @{
+      kFIRAppDistributionUnderlyingErrorCode: status,
+      NSLocalizedDescriptionKey: desc
+    }
+    *error = [NSError errorWithDomain:kFIRAppDistributionInternalErrorDomain
+                                 code:FIRAppDistributionErrorTokenPersistenceFailure
+                             userInfo:userInfo]
+  }
+
+  return status == noErr;
 }
 
-+ (NSMutableDictionary*)getKeyChainQuery {
-    NSMutableDictionary *keychainQuery =
-         [NSMutableDictionary dictionaryWithObjectsAndKeys:(id)kSecClassGenericPassword, (id)kSecClass,
-                                                           @"OAuth", (id)kSecAttrGeneric,
-                                                           @"OAuth", (id)kSecAttrAccount,
-                                                           @"fire-fad-auth", (id)kSecAttrService,
-                                                           nil];
-    return keychainQuery;
++ (NSMutableDictionary *)getKeyChainQuery {
+  NSMutableDictionary *keychainQuery = [NSMutableDictionary
+      dictionaryWithObjectsAndKeys:(id)kSecClassGenericPassword, (id)kSecClass, @"OAuth",
+                                   (id)kSecAttrGeneric, @"OAuth", (id)kSecAttrAccount,
+                                   @"fire-fad-auth", (id)kSecAttrService, nil];
+  return keychainQuery;
 }
 
 @end
-
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionMachO.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionMachO.m
@@ -14,128 +14,129 @@
  * limitations under the License.
  */
 
+#import <CommonCrypto/CommonHMAC.h>
+#include <mach-o/arch.h>
 #import <mach-o/fat.h>
 #import <mach-o/loader.h>
-#include <mach-o/arch.h>
-#import <CommonCrypto/CommonHMAC.h>
 #import "FIRAppDistributionMachO+Private.h"
 #import "FIRAppDistributionMachOSlice+Private.h"
 
 @implementation FIRAppDistributionMachO
 
-- (instancetype)initWithPath:(NSString *)path {
-    self = [super init];
-    
-    if (self) {
-        _file = [NSFileHandle fileHandleForReadingAtPath:path];
-        [_file seekToFileOffset:0];
-        _slices = [NSMutableArray new];
-    }
-    
-    [self extractSlices];
-    
-    return self;
+- (instancetype)initWithPath:(NSString*)path {
+  self = [super init];
+
+  if (self) {
+    _file = [NSFileHandle fileHandleForReadingAtPath:path];
+    [_file seekToFileOffset:0];
+    _slices = [NSMutableArray new];
+  }
+
+  [self extractSlices];
+
+  return self;
 }
 
 - (void)extractSlices {
-    uint32_t magicValue;
-    
-    struct fat_header fheader;
-    NSData* data = [_file readDataOfLength:sizeof(fheader)];
-    [data getBytes:&fheader length:sizeof(fheader)];
+  uint32_t magicValue;
 
-    magicValue = CFSwapInt32HostToBig(fheader.magic);
+  struct fat_header fheader;
+  NSData* data = [_file readDataOfLength:sizeof(fheader)];
+  [data getBytes:&fheader length:sizeof(fheader)];
 
-    if (magicValue == FAT_MAGIC || magicValue == FAT_CIGAM) {
-        uint32_t archCount = CFSwapInt32HostToBig(fheader.nfat_arch);
-        NSUInteger archOffsets[archCount];
-        
-        // Gather the offsets
-        for (uint32_t i = 0; i < archCount; i++) {
-            struct fat_arch arch;
-            
-            data = [_file readDataOfLength:sizeof(arch)];
-            [data getBytes:&arch length:sizeof(arch)];
+  magicValue = CFSwapInt32HostToBig(fheader.magic);
 
-            archOffsets[i] = CFSwapInt32HostToBig(arch.offset);
-        }
+  if (magicValue == FAT_MAGIC || magicValue == FAT_CIGAM) {
+    uint32_t archCount = CFSwapInt32HostToBig(fheader.nfat_arch);
+    NSUInteger archOffsets[archCount];
 
-        // Iterate the slices
-        for (uint32_t i = 0; i < archCount; i++) {
-            FIRAppDistributionMachOSlice* slice = [self extractSliceAtOffset:archOffsets[i]];
-            [_slices addObject:slice];
-        }
+    // Gather the offsets
+    for (uint32_t i = 0; i < archCount; i++) {
+      struct fat_arch arch;
+
+      data = [_file readDataOfLength:sizeof(arch)];
+      [data getBytes:&arch length:sizeof(arch)];
+
+      archOffsets[i] = CFSwapInt32HostToBig(arch.offset);
+    }
+
+    // Iterate the slices
+    for (uint32_t i = 0; i < archCount; i++) {
+      FIRAppDistributionMachOSlice* slice = [self extractSliceAtOffset:archOffsets[i]];
+      [_slices addObject:slice];
+    }
+  } else {
+    FIRAppDistributionMachOSlice* slice = [self extractSliceAtOffset:0];
+    [_slices addObject:slice];
+  }
+}
+
+- (FIRAppDistributionMachOSlice*)extractSliceAtOffset:(NSUInteger)offset {
+  [_file seekToFileOffset:offset];
+
+  struct mach_header header;
+
+  NSData* data = [_file readDataOfLength:sizeof(header)];
+  [data getBytes:&header length:sizeof(header)];
+  uint32_t magicValue = CFSwapInt32HostToBig(header.magic);
+
+  // TODO: Verify Mach-O
+
+  // If binary is 64-bit, read reserved bit and discard it
+  if (magicValue == MH_CIGAM_64) {
+    uint32_t reserved;
+
+    [_file readDataOfLength:sizeof(reserved)];
+  }
+
+  for (uint32_t i = 0; i < header.ncmds; i++) {
+    struct load_command lc;
+
+    data = [_file readDataOfLength:sizeof(lc)];
+    [data getBytes:&lc length:sizeof(lc)];
+
+    if (lc.cmd == LC_UUID) {
+      [_file seekToFileOffset:[_file offsetInFile] - sizeof(lc)];
+      struct uuid_command uc;
+      data = [_file readDataOfLength:sizeof(uc)];
+      [data getBytes:&uc length:sizeof(uc)];
+
+      NSUUID* uuid = [[NSUUID alloc] initWithUUIDBytes:uc.uuid];
+      const NXArchInfo* arch = NXGetArchInfoFromCpuType(header.cputype, header.cpusubtype);
+
+      NSLog(@"Got Architecture %s UUID: %@", arch->name, [uuid UUIDString]);
+      return [[FIRAppDistributionMachOSlice alloc] initWithArch:arch uuid:uuid];
     } else {
-        FIRAppDistributionMachOSlice* slice = [self extractSliceAtOffset:0];
-        [_slices addObject:slice];
+      [_file seekToFileOffset:[_file offsetInFile] + lc.cmdsize - sizeof(lc)];
     }
+  }
+
+  return nil;
 }
 
--(FIRAppDistributionMachOSlice*)extractSliceAtOffset:(NSUInteger)offset {
-    [_file seekToFileOffset:offset];
-    
-    struct mach_header header;
-    
-    NSData *data = [_file readDataOfLength:sizeof(header)];
-    [data getBytes:&header length:sizeof(header)];
-    uint32_t magicValue = CFSwapInt32HostToBig(header.magic);
+- (NSString*)codeHash {
+  NSMutableString* prehashedString = [NSMutableString new];
 
-    // TODO: Verify Mach-O
-
-    // If binary is 64-bit, read reserved bit and discard it
-    if (magicValue == MH_CIGAM_64) {
-        uint32_t reserved;
-
-        [_file readDataOfLength:sizeof(reserved)];
-    }
-
-    for (uint32_t i = 0; i < header.ncmds; i++) {
-        struct load_command lc;
-        
-        data = [_file readDataOfLength:sizeof(lc)];
-        [data getBytes:&lc length:sizeof(lc)];
-        
-        if (lc.cmd == LC_UUID) {
-            [_file seekToFileOffset:[_file offsetInFile] - sizeof(lc)];
-            struct uuid_command uc;
-            data = [_file readDataOfLength:sizeof(uc)];
-            [data getBytes:&uc length:sizeof(uc)];
-            
-            NSUUID* uuid = [[NSUUID alloc] initWithUUIDBytes:uc.uuid];
-            const NXArchInfo* arch = NXGetArchInfoFromCpuType(header.cputype, header.cpusubtype);
-            
-            NSLog(@"Got Architecture %s UUID: %@", arch->name, [uuid UUIDString]);
-            return [[FIRAppDistributionMachOSlice alloc]initWithArch:arch uuid:uuid];
-        } else {
-            [_file seekToFileOffset:[_file offsetInFile] + lc.cmdsize - sizeof(lc)];
-        }
-    }
-
-    return nil;
-}
-
--(NSString*)codeHash {
-    NSMutableString* prehashedString = [NSMutableString new];
-    
-    NSArray* sortedSlices = [_slices sortedArrayUsingComparator:^NSComparisonResult(id obj1, id obj2) {
+  NSArray* sortedSlices =
+      [_slices sortedArrayUsingComparator:^NSComparisonResult(id obj1, id obj2) {
         return [[obj1 architectureName] compare:[obj2 architectureName]];
-    }];
-    
-    for (FIRAppDistributionMachOSlice* slice in sortedSlices) {
-        [prehashedString appendString:[slice uuidString]];
-    }
+      }];
 
-    return [self sha1:prehashedString];;
+  for (FIRAppDistributionMachOSlice* slice in sortedSlices) {
+    [prehashedString appendString:[slice uuidString]];
+  }
+
+  return [self sha1:prehashedString];
+  ;
 }
 
--(NSString*)sha1:(NSString*)prehashedString {
-    NSData *data = [prehashedString dataUsingEncoding:NSUTF8StringEncoding];
-     uint8_t digest[CC_SHA1_DIGEST_LENGTH];
-     CC_SHA1(data.bytes, (int)data.length, digest);
-     NSMutableString *hashedString = [NSMutableString stringWithCapacity:CC_SHA1_DIGEST_LENGTH * 2];
-     for (int i = 0; i < CC_SHA1_DIGEST_LENGTH; i++)
-         [hashedString appendFormat:@"%02x", digest[i]];
-    
-    return hashedString;
+- (NSString*)sha1:(NSString*)prehashedString {
+  NSData* data = [prehashedString dataUsingEncoding:NSUTF8StringEncoding];
+  uint8_t digest[CC_SHA1_DIGEST_LENGTH];
+  CC_SHA1(data.bytes, (int)data.length, digest);
+  NSMutableString* hashedString = [NSMutableString stringWithCapacity:CC_SHA1_DIGEST_LENGTH * 2];
+  for (int i = 0; i < CC_SHA1_DIGEST_LENGTH; i++) [hashedString appendFormat:@"%02x", digest[i]];
+
+  return hashedString;
 }
 @end

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionMachOSlice.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionMachOSlice.m
@@ -22,23 +22,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FIRAppDistributionMachOSlice
 
-- (instancetype)initWithArch:(const NXArchInfo *)arch uuid:(NSUUID*)uuid {
-    self = [super init];
-    if (!self)
-        return nil;
-    
-    _arch = arch;
-    _uuid = uuid;
-    return self;
+- (instancetype)initWithArch:(const NXArchInfo *)arch uuid:(NSUUID *)uuid {
+  self = [super init];
+  if (!self) return nil;
+
+  _arch = arch;
+  _uuid = uuid;
+  return self;
 }
 
-- (NSString*)architectureName {
-    return [NSString stringWithUTF8String:_arch->name];
+- (NSString *)architectureName {
+  return [NSString stringWithUTF8String:_arch->name];
 }
 
-- (NSString*)uuidString {
-    return [[[_uuid UUIDString] lowercaseString]
-            stringByReplacingOccurrencesOfString:@"-" withString:@""];
+- (NSString *)uuidString {
+  return [[[_uuid UUIDString] lowercaseString] stringByReplacingOccurrencesOfString:@"-"
+                                                                         withString:@""];
 }
 @end
 

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistribution+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistribution+Private.h
@@ -21,11 +21,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 // Label exceptions from private App Distribution calls.
-NSString *const kFIRAppDistributionInternalErrorDomain =
-@"com.firebase.app_distribution.internal";
-
-// A key that 
-NSString *const kFIRAppDistributionUnderlyingErrorCode = @"UnderlyingErrorCode";
+NSString *const kFIRAppDistributionInternalErrorDomain = @"com.firebase.app_distribution.internal";
 
 @interface FIRAppDistribution ()
 /**
@@ -43,7 +39,8 @@ NSString *const kFIRAppDistributionUnderlyingErrorCode = @"UnderlyingErrorCode";
 @end
 
 /**
- *  The set of error codes that may be returned from internal SDK calls. These should never be returned to the user.
+ *  The set of error codes that may be returned from internal SDK calls. These should never be
+ * returned to the user.
  *  @enum AppDistributionInternalError
  */
 typedef NS_ENUM(NSUInteger, FIRAppDistributionInternalError) {

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistribution+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistribution+Private.h
@@ -20,9 +20,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-// Label exceptions from private App Distribution calls.
-NSString *const kFIRAppDistributionInternalErrorDomain = @"com.firebase.app_distribution.internal";
-
 @interface FIRAppDistribution ()
 /**
  * Current view controller presenting the `SFSafariViewController` if any.
@@ -37,21 +34,5 @@ NSString *const kFIRAppDistributionInternalErrorDomain = @"com.firebase.app_dist
 @property(nullable, nonatomic) UIWindow *window;
 
 @end
-
-/**
- *  The set of error codes that may be returned from internal SDK calls. These should never be
- * returned to the user.
- *  @enum AppDistributionInternalError
- */
-typedef NS_ENUM(NSUInteger, FIRAppDistributionInternalError) {
-  // Authentication token persistence error
-  FIRAppDistributionErrorTokenPersistenceFailure = 0,
-
-  // Authentication token retrieval error
-  FIRAppDistributionErrorTokenRetrievalFailure = 1,
-
-  // Authentication token deletion error
-  FIRAppDistributionErrorTokenDeletionFailure = 2,
-} NS_SWIFT_NAME(AppDistributionInternalError);
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistribution+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistribution+Private.h
@@ -20,6 +20,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// Label exceptions from private App Distribution calls.
+NSString *const kFIRAppDistributionInternalErrorDomain =
+@"com.firebase.app_distribution.internal";
+
+// A key that 
+NSString *const kFIRAppDistributionUnderlyingErrorCode = @"UnderlyingErrorCode";
+
 @interface FIRAppDistribution ()
 /**
  * Current view controller presenting the `SFSafariViewController` if any.
@@ -34,5 +41,20 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nullable, nonatomic) UIWindow *window;
 
 @end
+
+/**
+ *  The set of error codes that may be returned from internal SDK calls. These should never be returned to the user.
+ *  @enum AppDistributionInternalError
+ */
+typedef NS_ENUM(NSUInteger, FIRAppDistributionInternalError) {
+  // Authentication token persistence error
+  FIRAppDistributionErrorTokenPersistenceFailure = 0,
+
+  // Authentication token retrieval error
+  FIRAppDistributionErrorTokenRetrievalFailure = 1,
+
+  // Authentication token deletion error
+  FIRAppDistributionErrorTokenDeletionFailure = 2,
+} NS_SWIFT_NAME(AppDistributionInternalError);
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
@@ -11,11 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 #import <AppAuth/AppAuth.h>
-#import "FIRAppDistribution+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
+
+// Label exceptions from AppDistributionAuthPersistence calls.
+FOUNDATION_EXPORT NSString *const kFIRAppDistributionKeychainErrorDomain;
 
 @interface FIRAppDistributionAuthPersistence : NSObject
 
@@ -28,5 +29,21 @@ NS_ASSUME_NONNULL_BEGIN
 + (OIDAuthState *)retrieveAuthState:(NSError **_Nullable)error;
 
 @end
+
+/**
+ *  The set of error codes that may be returned from internal calls to persist Tester authentication
+ *  to the keychain. These should never be returned to the user.
+ *  @enum FIRAppDistributionKeychainError
+ */
+typedef NS_ENUM(NSUInteger, FIRAppDistributionKeychainError) {
+  // Authentication token persistence error
+  FIRAppDistributionErrorTokenPersistenceFailure = 0,
+
+  // Authentication token retrieval error
+  FIRAppDistributionErrorTokenRetrievalFailure = 1,
+
+  // Authentication token deletion error
+  FIRAppDistributionErrorTokenDeletionFailure = 2,
+} NS_SWIFT_NAME(AppDistributionKeychainError);
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
@@ -21,14 +21,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 
-+ (BOOL)persistAuthState:(OIDAuthState *)authState
-                   error:(NSError **)error;
++ (BOOL)persistAuthState:(OIDAuthState *)authState error:(NSError **_Nullable)error;
 
-+ (BOOL)clearAuthState:(NSError **)error;
++ (BOOL)clearAuthState:(NSError **_Nullable)error;
 
-+ (OIDAuthState*)retrieveAuthState:(NSError **)error;
++ (OIDAuthState *)retrieveAuthState:(NSError **_Nullable)error;
 
 @end
-
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
@@ -18,18 +18,6 @@ NS_ASSUME_NONNULL_BEGIN
 // Label exceptions from AppDistributionAuthPersistence calls.
 FOUNDATION_EXPORT NSString *const kFIRAppDistributionKeychainErrorDomain;
 
-@interface FIRAppDistributionAuthPersistence : NSObject
-
-- (instancetype)init NS_UNAVAILABLE;
-
-+ (BOOL)persistAuthState:(OIDAuthState *)authState error:(NSError **_Nullable)error;
-
-+ (BOOL)clearAuthState:(NSError **_Nullable)error;
-
-+ (OIDAuthState *)retrieveAuthState:(NSError **_Nullable)error;
-
-@end
-
 /**
  *  The set of error codes that may be returned from internal calls to persist Tester authentication
  *  to the keychain. These should never be returned to the user.
@@ -45,5 +33,22 @@ typedef NS_ENUM(NSUInteger, FIRAppDistributionKeychainError) {
   // Authentication token deletion error
   FIRAppDistributionErrorTokenDeletionFailure = 2,
 } NS_SWIFT_NAME(AppDistributionKeychainError);
+
+@interface FIRAppDistributionAuthPersistence : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
+// Handle null checking, creation, and formatting of an error encountered
++ (void)handleAuthStateError:(NSError **_Nullable)error
+                 description:(NSString *)description
+                        code:(FIRAppDistributionKeychainError)code;
+
++ (BOOL)persistAuthState:(OIDAuthState *)authState error:(NSError **_Nullable)error;
+
++ (BOOL)clearAuthState:(NSError **_Nullable)error;
+
++ (OIDAuthState *)retrieveAuthState:(NSError **_Nullable)error;
+
+@end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #import <AppAuth/AppAuth.h>
+#import "FIRAppDistribution+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -20,11 +21,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 
-+ (BOOL)persistAuthState:(OIDAuthState *)authState;
++ (BOOL)persistAuthState:(OIDAuthState *)authState
+                   error:(NSError **)error;
 
-+ (BOOL)clearAuthState;
++ (BOOL)clearAuthState:(NSError **)error;
 
-+ (OIDAuthState*)retrieveAuthState;
++ (OIDAuthState*)retrieveAuthState:(NSError **)error;
 
 @end
 

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistributionMachO+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistributionMachO+Private.h
@@ -1,18 +1,18 @@
 /*
-* Copyright 2019 Google
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*      http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #import <Foundation/Foundation.h>
 #import "FIRAppDistributionMachOSlice+Private.h"
@@ -21,11 +21,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FIRAppDistributionMachO : NSObject
 
-@property (nonatomic, copy) NSFileHandle* file;
-@property (nonatomic, copy) NSMutableArray *slices;
+@property(nonatomic, copy) NSFileHandle *file;
+@property(nonatomic, copy) NSMutableArray *slices;
 
 - (instancetype)initWithPath:(NSString *)path;
-- (NSString*)codeHash;
+- (NSString *)codeHash;
 
 @end
 

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistributionMachOSlice+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistributionMachOSlice+Private.h
@@ -1,18 +1,18 @@
 /*
-* Copyright 2019 Google
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*      http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2019 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #import <Foundation/Foundation.h>
 #import <mach-o/arch.h>
@@ -21,10 +21,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FIRAppDistributionMachOSlice : NSObject
 
-@property (nonatomic, assign) const NXArchInfo* arch;
-@property (nonatomic, copy) NSUUID* uuid;
+@property(nonatomic, assign) const NXArchInfo* arch;
+@property(nonatomic, copy) NSUUID* uuid;
 
-- (instancetype)initWithArch:(const NXArchInfo *)arch uuid:(NSUUID*)uuid;
+- (instancetype)initWithArch:(const NXArchInfo*)arch uuid:(NSUUID*)uuid;
 
 - (NSString*)architectureName;
 - (NSString*)uuidString;


### PR DESCRIPTION
* Remove NSLog statements from AuthPersistence
* Add error pointers to all calls into AuthPersistence
* Add logging to calling methods based on errors bubbled up but do not bubble errors up to the user
* Add TODO's for adding in the FIRLogger

### Testing

  * Running locally e2e - will post screen grab

### API Changes

  * N/A
