### PR TITLE
Crashlytics/issues/5020

### DIFF
--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -527,7 +527,7 @@ static void (^reportSentCallback)(void);
   // failing computeExecutableInfo. This can happen if the user sets the
   // Exported Symbols File in Build Settings, and leaves off the one symbol
   // that Crashlytics needs, "__mh_execute_header" (wich is defined in mach-o/ldsyms.h as
-  // _MH_EXECUTE_SYM) From https://github.com/firebase/firebase-ios-sdk/issues/5020
+  // _MH_EXECUTE_SYM). From https://github.com/firebase/firebase-ios-sdk/issues/5020
   if (!self.appIDModel) {
     FIRCLSErrorLog(
         @"Crashlytics could not find the main file symbol, and cannot start up. This can happen "

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -526,8 +526,8 @@ static void (^reportSentCallback)(void);
   // When the ApplicationIdentifierModel fails to initialize, it is usually due to
   // failing computeExecutableInfo. This can happen if the user sets the
   // Exported Symbols File in Build Settings, and leaves off the one symbol
-  // that Crashlytics needs, "__mh_execute_header" (wich is defined in mach-o/ldsyms.h as _MH_EXECUTE_SYM)
-  // From https://github.com/firebase/firebase-ios-sdk/issues/5020
+  // that Crashlytics needs, "__mh_execute_header" (wich is defined in mach-o/ldsyms.h as
+  // _MH_EXECUTE_SYM) From https://github.com/firebase/firebase-ios-sdk/issues/5020
   if (!self.appIDModel) {
     FIRCLSErrorLog(
         @"Crashlytics could not find the main file symbol, and cannot start up. This can happen "

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -529,8 +529,10 @@ static void (^reportSentCallback)(void);
   // that Crashlytics needs, "__mh_execute_header" (wich is defined in mach-o/ldsyms.h as
   // _MH_EXECUTE_SYM). From https://github.com/firebase/firebase-ios-sdk/issues/5020
   if (!self.appIDModel) {
-    FIRCLSErrorLog(@"Crashlytics could not find the symbol for the app's main function and cannot "
-                   @"start up. This can happen when Exported Symbols File is set in Build Settings. To resolve this, add \"__mh_execute_header\" as a newline to your Exported Symbols File.");
+    FIRCLSErrorLog(
+        @"Crashlytics could not find the symbol for the app's main function and cannot "
+        @"start up. This can happen when Exported Symbols File is set in Build Settings. To "
+        @"resolve this, add \"__mh_execute_header\" as a newline to your Exported Symbols File.");
     return NO;
   }
 

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -529,7 +529,10 @@ static void (^reportSentCallback)(void);
   // that Crashlytics needs, "__mh_execute_header" defined as _MH_EXECUTE_SYM
   // From https://github.com/firebase/firebase-ios-sdk/issues/5020
   if (!self.appIDModel) {
-    FIRCLSErrorLog(@"Crashlytics could not find the main file symbol, and cannot start up. This can happen when Exported Symbols File is set in Build Settings. To resolve this, add \"__mh_execute_header\" as a newline to your Exported Symbols File.");
+    FIRCLSErrorLog(
+        @"Crashlytics could not find the main file symbol, and cannot start up. This can happen "
+        @"when Exported Symbols File is set in Build Settings. To resolve this, add "
+        @"\"__mh_execute_header\" as a newline to your Exported Symbols File.");
     return NO;
   }
 

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -530,7 +530,7 @@ static void (^reportSentCallback)(void);
   // _MH_EXECUTE_SYM). From https://github.com/firebase/firebase-ios-sdk/issues/5020
   if (!self.appIDModel) {
     FIRCLSErrorLog(
-        @"Crashlytics could not find the main file symbol, and cannot start up. This can happen "
+        @"Crashlytics could not find the symbol for the app's main function and cannot start up. This can happen "
         @"when Exported Symbols File is set in Build Settings. To resolve this, add "
         @"\"__mh_execute_header\" as a newline to your Exported Symbols File.");
     return NO;

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -530,9 +530,7 @@ static void (^reportSentCallback)(void);
   // _MH_EXECUTE_SYM). From https://github.com/firebase/firebase-ios-sdk/issues/5020
   if (!self.appIDModel) {
     FIRCLSErrorLog(@"Crashlytics could not find the symbol for the app's main function and cannot "
-                   @"start up. This can happen "
-                   @"when Exported Symbols File is set in Build Settings. To resolve this, add "
-                   @"\"__mh_execute_header\" as a newline to your Exported Symbols File.");
+                   @"start up. This can happen when Exported Symbols File is set in Build Settings. To resolve this, add \"__mh_execute_header\" as a newline to your Exported Symbols File.");
     return NO;
   }
 

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -529,10 +529,10 @@ static void (^reportSentCallback)(void);
   // that Crashlytics needs, "__mh_execute_header" (wich is defined in mach-o/ldsyms.h as
   // _MH_EXECUTE_SYM). From https://github.com/firebase/firebase-ios-sdk/issues/5020
   if (!self.appIDModel) {
-    FIRCLSErrorLog(
-        @"Crashlytics could not find the symbol for the app's main function and cannot start up. This can happen "
-        @"when Exported Symbols File is set in Build Settings. To resolve this, add "
-        @"\"__mh_execute_header\" as a newline to your Exported Symbols File.");
+    FIRCLSErrorLog(@"Crashlytics could not find the symbol for the app's main function and cannot "
+                   @"start up. This can happen "
+                   @"when Exported Symbols File is set in Build Settings. To resolve this, add "
+                   @"\"__mh_execute_header\" as a newline to your Exported Symbols File.");
     return NO;
   }
 

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -305,7 +305,7 @@ static void (^reportSentCallback)(void);
   NSTimeInterval currentTimestamp = [NSDate timeIntervalSinceReferenceDate];
   [self.settings reloadFromCacheWithGoogleAppID:self.googleAppID currentTimestamp:currentTimestamp];
 
-  if (![self checkBundleIDExists]) {
+  if (![self validateAppIdentifiers]) {
     return [FBLPromise resolvedWith:@NO];
   }
 
@@ -522,7 +522,17 @@ static void (^reportSentCallback)(void);
   });
 }
 
-- (BOOL)checkBundleIDExists {
+- (BOOL)validateAppIdentifiers {
+  // When the ApplicationIdentifierModel fails to initialize, it is usually due to
+  // failing computeExecutableInfo. This can happen if the user sets the
+  // Exported Symbols File in Build Settings, and leaves off the one symbol
+  // that Crashlytics needs, "__mh_execute_header" defined as _MH_EXECUTE_SYM
+  // From https://github.com/firebase/firebase-ios-sdk/issues/5020
+  if (!self.appIDModel) {
+    FIRCLSErrorLog(@"Crashlytics could not find the main file symbol, and cannot start up. This can happen when Exported Symbols File is set in Build Settings. To resolve this, add \"__mh_execute_header\" as a newline to your Exported Symbols File.");
+    return NO;
+  }
+
   if (self.appIDModel.bundleID.length == 0) {
     FIRCLSErrorLog(@"An application must have a valid bundle identifier in its Info.plist");
     return NO;

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -526,7 +526,7 @@ static void (^reportSentCallback)(void);
   // When the ApplicationIdentifierModel fails to initialize, it is usually due to
   // failing computeExecutableInfo. This can happen if the user sets the
   // Exported Symbols File in Build Settings, and leaves off the one symbol
-  // that Crashlytics needs, "__mh_execute_header" defined as _MH_EXECUTE_SYM
+  // that Crashlytics needs, "__mh_execute_header" (wich is defined in mach-o/ldsyms.h as _MH_EXECUTE_SYM)
   // From https://github.com/firebase/firebase-ios-sdk/issues/5020
   if (!self.appIDModel) {
     FIRCLSErrorLog(

--- a/Crashlytics/Shared/FIRCLSMachO/FIRCLSMachO.m
+++ b/Crashlytics/Shared/FIRCLSMachO/FIRCLSMachO.m
@@ -255,6 +255,8 @@ struct FIRCLSMachOSlice FIRCLSMachOSliceGetCurrent(void) {
 
   slice.startAddress = NULL;
 
+  // This call can fail when Exported Symbols File in Build Settings is missing the symbol value
+  // defined as _MH_EXECUTE_SYM (if you look in the header the underscored MH_EXECUTE_SYM define is there)
   executableSymbol = dlsym(RTLD_MAIN_ONLY, MH_EXECUTE_SYM);
 
   // get the address of the main function

--- a/Crashlytics/Shared/FIRCLSMachO/FIRCLSMachO.m
+++ b/Crashlytics/Shared/FIRCLSMachO/FIRCLSMachO.m
@@ -256,7 +256,8 @@ struct FIRCLSMachOSlice FIRCLSMachOSliceGetCurrent(void) {
   slice.startAddress = NULL;
 
   // This call can fail when Exported Symbols File in Build Settings is missing the symbol value
-  // defined as _MH_EXECUTE_SYM (if you look in the header the underscored MH_EXECUTE_SYM define is there)
+  // defined as _MH_EXECUTE_SYM (if you look in the header the underscored MH_EXECUTE_SYM define is
+  // there)
   executableSymbol = dlsym(RTLD_MAIN_ONLY, MH_EXECUTE_SYM);
 
   // get the address of the main function


### PR DESCRIPTION
Reported in: https://github.com/firebase/firebase-ios-sdk/issues/5020

Adds a clear error message for customers to self-resolve Crashlytics not starting up (usually in Release Builds) because Exported Symbols File is set in Build Settings, and the file is missing `__mh_execute_header`.
