### PR TITLE
Manually specify the authorization header

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -2,6 +2,8 @@
 - [changed] Firestore now limits the number of concurrent document lookups it
   will perform when resolving inconsistencies in the local cache
   (https://github.com/firebase/firebase-js-sdk/issues/2683).
+- [fixed] Firestore will now send Auth credentials to the Firestore Emulator
+  (#5072).
 
 # v1.12.1
 - [changed] Internal improvements for future C++ and Unity support.

--- a/Firestore/core/src/remote/grpc_connection.cc
+++ b/Firestore/core/src/remote/grpc_connection.cc
@@ -32,6 +32,7 @@
 #include "Firestore/core/src/util/statusor.h"
 #include "Firestore/core/src/util/string_format.h"
 #include "absl/memory/memory.h"
+#include "absl/strings/str_cat.h"
 #include "grpcpp/create_channel.h"
 
 namespace firebase {
@@ -49,6 +50,7 @@ using util::StringFormat;
 
 namespace {
 
+const char* const kAuthorizationHeader = "authorization";
 const char* const kXGoogAPIClientHeader = "x-goog-api-client";
 const char* const kGoogleCloudResourcePrefix = "google-cloud-resource-prefix";
 
@@ -151,7 +153,7 @@ std::unique_ptr<grpc::ClientContext> GrpcConnection::CreateContext(
 
   auto context = absl::make_unique<grpc::ClientContext>();
   if (token.data()) {
-    context->set_credentials(grpc::AccessTokenCredentials(MakeString(token)));
+    context->AddMetadata(kAuthorizationHeader, absl::StrCat("Bearer ", token));
   }
 
   // TODO(dimond): This should ideally also include the gRPC version, however,


### PR DESCRIPTION
This matches the [Android](https://github.com/firebase/firebase-android-sdk/blob/205b52314bfc1b6bac44958e5411134d6003a85c/firebase-firestore/src/main/java/com/google/firebase/firestore/remote/FirestoreCallCredentials.java#L55) and [JS](https://github.com/firebase/firebase-js-sdk/blob/ed9a7be7d5f65aa37c0c478021b15bd18166a515/packages/firestore/src/platform_browser/webchannel_connection.ts#L96) SDKs and works around a limitation in gRPC, whereby it silently drops credentials if the connection isn't using TLS. In Firestore's case, developers routinely run against an emulator on the local host with TLS disabled (because requiring developers to provision certificates for local development is too onerous).

Fixes #5072.