### PR TITLE
Suppress deprecation warnings in Auth

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v6.5.4
+- [fixed] Suppress deprecation warnings when targeting iOS versions up to iOS 13. (#5437)
+
 # v6.5.3
 - [fixed] Handle calls to `useUserAccessGroup` soon after configure. (#4175)
 

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -1520,10 +1520,14 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
   [self canHandleNotification:userInfo];
 }
 
+// iOS 10 deprecation
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (void)application:(UIApplication *)application
     didReceiveRemoteNotification:(NSDictionary *)userInfo {
   [self canHandleNotification:userInfo];
 }
+#pragma clang diagnostic pop
 
 - (BOOL)application:(UIApplication *)app
             openURL:(NSURL *)url
@@ -1531,12 +1535,16 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
   return [self canHandleURL:url];
 }
 
+// iOS 10 deprecation
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-implementations"
 - (BOOL)application:(UIApplication *)application
               openURL:(NSURL *)url
     sourceApplication:(nullable NSString *)sourceApplication
            annotation:(id)annotation {
   return [self canHandleURL:url];
 }
+#pragma clang diagnostic pop
 
 - (void)setAPNSToken:(NSData *)token type:(FIRAuthAPNSTokenType)type {
   dispatch_sync(FIRAuthGlobalWorkQueue(), ^{
@@ -1999,8 +2007,12 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
     } else {
       // Encode the user object.
       NSMutableData *archiveData = [NSMutableData data];
+// iOS 12 deprecation
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
       NSKeyedArchiver *archiver =
           [[NSKeyedArchiver alloc] initForWritingWithMutableData:archiveData];
+#pragma clang diagnostic pop
       [archiver encodeObject:user forKey:userKey];
       [archiver finishEncoding];
 
@@ -2046,8 +2058,12 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
       *outUser = nil;
       return YES;
     }
+// iOS 12 deprecation
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSKeyedUnarchiver *unarchiver =
         [[NSKeyedUnarchiver alloc] initForReadingWithData:encodedUserData];
+#pragma clang diagnostic pop
     FIRUser *user = [unarchiver decodeObjectOfClass:[FIRUser class] forKey:userKey];
     user.auth = self;
     *outUser = user;
@@ -2214,8 +2230,12 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
       return nil;
     }
 
+// iOS 12 deprecation
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSKeyedUnarchiver *unarchiver =
         [[NSKeyedUnarchiver alloc] initForReadingWithData:encodedUserData];
+#pragma clang diagnostic pop
     user = [unarchiver decodeObjectOfClass:[FIRUser class] forKey:userKey];
   } else {
     user = [self.storedUserManager getStoredUserForAccessGroup:self.userAccessGroup

--- a/FirebaseAuth/Sources/AuthProvider/GameCenter/FIRGameCenterAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/GameCenter/FIRGameCenterAuthProvider.m
@@ -70,6 +70,9 @@ NS_ASSUME_NONNULL_BEGIN
          https://developer.apple.com/documentation/gamekit/gkplayer
          **/
         NSString *displayName = localPlayer.alias;
+// iOS 13 deprecation
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         FIRGameCenterAuthCredential *credential =
             [[FIRGameCenterAuthCredential alloc] initWithPlayerID:localPlayer.playerID
                                                      publicKeyURL:publicKeyURL
@@ -77,6 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                              salt:salt
                                                         timestamp:timestamp
                                                       displayName:displayName];
+#pragma clang diagnostic pop
         completion(credential, nil);
       }
     }

--- a/FirebaseAuth/Sources/SystemService/FIRAuthAppCredentialManager.m
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthAppCredentialManager.m
@@ -69,8 +69,12 @@ static const NSUInteger kMaximumNumberOfPendingReceipts = 32;
     NSError *error;
     NSData *encodedData = [_keychainServices dataForKey:kKeychainDataKey error:&error];
     if (!error && encodedData) {
+// iOS 12 deprecation
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
       NSKeyedUnarchiver *unarchiver =
           [[NSKeyedUnarchiver alloc] initForReadingWithData:encodedData];
+#pragma clang diagnostic pop
       FIRAuthAppCredential *credential =
           [unarchiver decodeObjectOfClass:[FIRAuthAppCredential class] forKey:kFullCredentialKey];
       if ([credential isKindOfClass:[FIRAuthAppCredential class]]) {
@@ -136,7 +140,11 @@ static const NSUInteger kMaximumNumberOfPendingReceipts = 32;
  */
 - (void)saveData {
   NSMutableData *archiveData = [NSMutableData data];
+// iOS 12 deprecation
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:archiveData];
+#pragma clang diagnostic pop
   [archiver encodeObject:_credential forKey:kFullCredentialKey];
   [archiver encodeObject:_pendingReceipts forKey:kPendingReceiptsKey];
   [archiver finishEncoding];

--- a/FirebaseAuth/Sources/SystemService/FIRAuthNotificationManager.m
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthNotificationManager.m
@@ -117,8 +117,12 @@ static const NSTimeInterval kProbingTimeout = 1;
 #if !TARGET_OS_TV
     } else if ([self->_application.delegate
                    respondsToSelector:@selector(application:didReceiveRemoteNotification:)]) {
+// iOS 10 deprecation
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
       [self->_application.delegate application:self->_application
                   didReceiveRemoteNotification:proberNotification];
+#pragma clang diagnostic pop
 #endif
     } else {
       FIRLogWarning(kFIRLoggerAuth, @"I-AUT000015",

--- a/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.m
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.m
@@ -80,7 +80,11 @@ static NSString *kStoredUserCoderKey = @"firebase_auth_stored_user_coder_key";
   query[(__bridge id)kSecAttrAccount] = kSharedKeychainAccountValue;
 
   NSData *data = [self.keychainServices getItemWithQuery:query error:outError];
+// iOS 12 deprecation
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:data];
+#pragma clang diagnostic pop
   FIRUser *user = [unarchiver decodeObjectOfClass:[FIRUser class] forKey:kStoredUserCoderKey];
 
   return user;
@@ -100,7 +104,11 @@ static NSString *kStoredUserCoderKey = @"firebase_auth_stored_user_coder_key";
   query[(__bridge id)kSecAttrAccount] = kSharedKeychainAccountValue;
 
   NSMutableData *data = [NSMutableData data];
+// iOS 12 deprecation
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:data];
+#pragma clang diagnostic pop
   [archiver encodeObject:user forKey:kStoredUserCoderKey];
   [archiver finishEncoding];
 

--- a/FirebaseAuth/Sources/Utilities/FIRAuthDefaultUIDelegate.m
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthDefaultUIDelegate.m
@@ -92,7 +92,11 @@ NS_ASSUME_NONNULL_BEGIN
     }
   } else {
     UIApplication *application = [applicationClass sharedApplication];
+// iOS 13 deprecation
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     topViewController = application.keyWindow.rootViewController;
+#pragma clang diagnostic pop
   }
 #else
   UIApplication *application = [applicationClass sharedApplication];

--- a/FirebaseAuth/Sources/Utilities/FIRAuthWebView.m
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthWebView.m
@@ -83,7 +83,11 @@ NS_ASSUME_NONNULL_BEGIN
   if (@available(iOS 13.0, *)) {
     spinnerStyle = UIActivityIndicatorViewStyleMedium;
   } else {
+// iOS 13 deprecation
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     spinnerStyle = UIActivityIndicatorViewStyleGray;
+#pragma clang diagnostic pop
   }
 #else
   spinnerStyle = UIActivityIndicatorViewStyleGray;


### PR DESCRIPTION
Fix #5437

Suppress deprecation warnings in Auth when targeting iOS versions up to iOS 13.