### PR TITLE
Fix GoogleTest failure mechanism on CI

### DIFF
--- a/Firestore/core/src/util/log_apple.mm
+++ b/Firestore/core/src/util/log_apple.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,16 @@ void LogMessageV(LogLevel level, NSString* format, ...) {
 void LogSetLevel(LogLevel level) {
   FIRSetLoggerLevel(ToFIRLoggerLevel(level));
 }
+
+// Note that FIRLogger's default level can be changed by persisting a
+// debug_mode setting in user defaults. Check for defaults getting in your way
+// with:
+//
+//   defaults read firestore_util_test
+//
+// You can change it with:
+//
+//   defaults write firestore_util_test /google/firebase/debug_mode NO
 
 bool LogIsLoggable(LogLevel level) {
   return FIRIsLoggableLevel(ToFIRLoggerLevel(level), false);

--- a/Firestore/core/test/unit/FSTGoogleTestTests.mm
+++ b/Firestore/core/test/unit/FSTGoogleTestTests.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,8 @@ NSDictionary<NSString*, NSValue*>* testInfosByKey;
 // If the user focuses on GoogleTests itself, this means force all C++ tests to
 // run.
 bool forceAllTests = false;
+
+void RunGoogleTestTests();
 
 /**
  * Loads this XCTest runner's configuration file and figures out which tests to
@@ -186,6 +188,8 @@ NSString* TestInfoKey(Class testClass, SEL testSelector) {
  * this way here allows XCTAssert and friends to work.
  */
 void ReportTestResult(XCTestCase* self, SEL _cmd) {
+  RunGoogleTestTests();
+
   NSString* testInfoKey = TestInfoKey([self class], _cmd);
   NSValue* holder = testInfosByKey[testInfoKey];
   auto testInfo = static_cast<const testing::TestInfo*>(holder.pointerValue);
@@ -222,7 +226,7 @@ void ReportTestResult(XCTestCase* self, SEL _cmd) {
 
 /**
  * Generates a new subclass of XCTestCase for the given GoogleTest TestCase.
- * Each TestInfo (which represents an indivudal test method execution) is
+ * Each TestInfo (which represents an individual test method execution) is
  * translated into a method on the test case.
  *
  * @param testCase The testing::TestCase of interest to translate.
@@ -294,7 +298,7 @@ XCTestSuite* CreateAllTestsTestSuite() {
  * Finds and runs googletest-based tests based on the XCTestConfiguration of the
  * current test invocation.
  */
-void RunGoogleTestTests() {
+void CreateGoogleTestTests() {
   NSString* masterTestCaseName = NSStringFromClass([GoogleTests class]);
 
   // Initialize GoogleTest but don't run the tests yet.
@@ -333,6 +337,10 @@ void RunGoogleTestTests() {
     CreateXCTestCaseClass(testCase, infoMap);
   }
   testInfosByKey = infoMap;
+}
+
+void RunGoogleTestTests() {
+  static bool firstRun = true;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-result"
@@ -341,7 +349,10 @@ void RunGoogleTestTests() {
   // again by XCTest). Test failures are reported via
   // -recordFailureWithDescription:inFile:atLine:expected: which then causes
   // XCTest itself to fail the run.
-  RUN_ALL_TESTS();
+  if (firstRun) {
+    firstRun = false;
+    RUN_ALL_TESTS();
+  }
 #pragma clang diagnostic pop
 }
 
@@ -383,7 +394,7 @@ void RunGoogleTestTests() {
 
 - (instancetype)init {
   self = [super init];
-  RunGoogleTestTests();
+  CreateGoogleTestTests();
   return self;
 }
 

--- a/Firestore/core/test/unit/util/bits_test.cc
+++ b/Firestore/core/test/unit/util/bits_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,6 @@ class BitsTest : public testing::Test {
 };
 
 TEST_F(BitsTest, Log2EdgeCases) {
-  std::cout << "TestLog2EdgeCases" << std::endl;
-
   EXPECT_EQ(-1, Bits::Log2Floor(0));
   EXPECT_EQ(-1, Bits::Log2Floor64(0));
 
@@ -66,8 +64,6 @@ TEST_F(BitsTest, Log2EdgeCases) {
 }
 
 TEST_F(BitsTest, Log2Random) {
-  std::cout << "TestLog2Random" << std::endl;
-
   for (int i = 0; i < kNumIterations; i++) {
     int max_bit = -1;
     uint32_t n = 0;
@@ -84,8 +80,6 @@ TEST_F(BitsTest, Log2Random) {
 }
 
 TEST_F(BitsTest, Log2Random64) {
-  std::cout << "TestLog2Random64" << std::endl;
-
   for (int i = 0; i < kNumIterations; i++) {
     int max_bit = -1;
     uint64_t n = 0;

--- a/Firestore/core/test/unit/util/log_test.cc
+++ b/Firestore/core/test/unit/util/log_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,26 +22,32 @@ namespace firebase {
 namespace firestore {
 namespace util {
 
-// When running against the log_apple.mm implementation (backed by FIRLogger)
-// this test can fail if debug_mode gets persisted in the user defaults. Check
-// for defaults getting in your way with
-//
-//   defaults read firestore_util_test
-//
-// You can fix it with:
-//
-//   defaults write firestore_util_test /google/firebase/debug_mode NO
-TEST(Log, SetAndGet) {
-  EXPECT_FALSE(LogIsDebugEnabled());
+TEST(LogTest, SetAndGet) {
+  LogLevel previous_level = kLogLevelError;
+  if (LogIsLoggable(kLogLevelWarning)) previous_level = kLogLevelWarning;
+  if (LogIsLoggable(kLogLevelNotice)) previous_level = kLogLevelNotice;
+  if (LogIsLoggable(kLogLevelDebug)) previous_level = kLogLevelDebug;
 
   LogSetLevel(kLogLevelDebug);
   EXPECT_TRUE(LogIsDebugEnabled());
 
+  EXPECT_TRUE(LogIsLoggable(kLogLevelDebug));
+  EXPECT_TRUE(LogIsLoggable(kLogLevelNotice));
+  EXPECT_TRUE(LogIsLoggable(kLogLevelWarning));
+  EXPECT_TRUE(LogIsLoggable(kLogLevelError));
+
   LogSetLevel(kLogLevelWarning);
   EXPECT_FALSE(LogIsDebugEnabled());
+
+  EXPECT_FALSE(LogIsLoggable(kLogLevelDebug));
+  EXPECT_FALSE(LogIsLoggable(kLogLevelNotice));
+  EXPECT_TRUE(LogIsLoggable(kLogLevelWarning));
+  EXPECT_TRUE(LogIsLoggable(kLogLevelError));
+
+  LogSetLevel(previous_level);
 }
 
-TEST(Log, LogAllKinds) {
+TEST(LogTest, LogAllKinds) {
   LOG_DEBUG("test debug logging %s", 1);
   LOG_WARN("test warning logging %s", 3);
   LOG_DEBUG("test va-args %s %s %s", "abc", std::string{"def"}, 123);


### PR DESCRIPTION
Previously, a crash in a GoogleTest test would register as happening prior to XCTest being being fully set up, which would cause CI to report the error as a simulator startup failure. This made GoogleTest failures harder to diagnose, especially if it was due to flakes. Deferring error reporting until XCTest has started running prevents this error.

This makes it less likely we'll need to fall back on the backstop established in #4867.

Unfortunately, this makes it possible for other XCTest cases to precede FSTGoogleTestTests in the execution order, and the integration tests enable logging. This also fixes a test that broken when that happens.

Note that this was reviewed as a part of #4912, but that massive PR is flawed and I don't want to rescue it in-place. Instead this pulls out one of the interesting parts.