### PR TITLE
Persist auth information to the iOS keychain

### DIFF
--- a/FirebaseAppDistribution.podspec
+++ b/FirebaseAppDistribution.podspec
@@ -40,5 +40,9 @@ iOS SDK for App Distribution for Firebase.
     unit_tests.resources = 'FirebaseAppDistribution/Tests/Unit/Resources/*'
   end
 
+  # app_host is needed for tests with keychain
+  unit_tests.requires_app_host = true
+  unit_tests.dependency 'OCMock'
+
   # end
 end

--- a/FirebaseAppDistribution.podspec
+++ b/FirebaseAppDistribution.podspec
@@ -36,13 +36,9 @@ iOS SDK for App Distribution for Firebase.
   }
 
   s.test_spec 'unit' do |unit_tests|
-    unit_tests.source_files = 'FirebaseAppDistribution/Tests/Unit*/*.[mh]'
-    unit_tests.resources = 'FirebaseAppDistribution/Tests/Unit/Resources/*'
+   unit_tests.source_files = 'FirebaseAppDistribution/Tests/Unit*/*.[mh]'
+   unit_tests.dependency 'OCMock'
   end
-
-  # app_host is needed for tests with keychain
-  unit_tests.requires_app_host = true
-  unit_tests.dependency 'OCMock'
 
   # end
 end

--- a/FirebaseAppDistribution.podspec
+++ b/FirebaseAppDistribution.podspec
@@ -37,6 +37,7 @@ iOS SDK for App Distribution for Firebase.
 
   s.test_spec 'unit' do |unit_tests|
    unit_tests.source_files = 'FirebaseAppDistribution/Tests/Unit*/*.[mh]'
+   unit_tests.resources = 'FirebaseAppDistribution/Tests/Unit/Resources/*'
    unit_tests.dependency 'OCMock'
   end
 

--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -16,6 +16,7 @@
 #import "FIRAppDistributionAuthPersistence+Private.h"
 #import "FIRAppDistributionMachO+Private.h"
 #import "FIRAppDistributionRelease+Private.h"
+#import "FIRAppDistributionMachO+Private.h"
 
 #import <FirebaseCore/FIRAppInternal.h>
 #import <FirebaseCore/FIRComponent.h>

--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -15,6 +15,7 @@
 #import "FIRAppDistribution+Private.h"
 #import "FIRAppDistributionMachO+Private.h"
 #import "FIRAppDistributionRelease+Private.h"
+#import "FIRAppDistributionMachO+Private.h"
 
 #import <FirebaseCore/FIRAppInternal.h>
 #import <FirebaseCore/FIRComponent.h>

--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -73,6 +73,8 @@ NSString *const kAppDistroLibraryName = @"fire-fad";
   }
 
   self.isTesterSignedIn = self.authState ? YES : NO;
+
+  NSLog(@"Tester %@ already logged in", self.isTesterSignedIn ? @"is" : @"is not");
   return self;
 }
 

--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -16,8 +16,10 @@
 #import "FIRAppDistributionAuthPersistence+Private.h"
 #import "FIRAppDistributionMachO+Private.h"
 #import "FIRAppDistributionRelease+Private.h"
-#import "FIRAppDistributionMachO+Private.h"
+
 #import "FIRAppDistributionAuthPersistence+Private.h"
+#import "FIRAppDistributionMachO+Private.h"
+#import "FIRAppDistributionRelease+Private.h"
 
 #import <FirebaseCore/FIRAppInternal.h>
 #import <FirebaseCore/FIRComponent.h>

--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -17,10 +17,6 @@
 #import "FIRAppDistributionMachO+Private.h"
 #import "FIRAppDistributionRelease+Private.h"
 
-#import "FIRAppDistributionAuthPersistence+Private.h"
-#import "FIRAppDistributionMachO+Private.h"
-#import "FIRAppDistributionRelease+Private.h"
-
 #import <FirebaseCore/FIRAppInternal.h>
 #import <FirebaseCore/FIRComponent.h>
 #import <FirebaseCore/FIRComponentContainer.h>

--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -17,6 +17,7 @@
 #import "FIRAppDistributionMachO+Private.h"
 #import "FIRAppDistributionRelease+Private.h"
 #import "FIRAppDistributionMachO+Private.h"
+#import "FIRAppDistributionAuthPersistence+Private.h"
 
 #import <FirebaseCore/FIRAppInternal.h>
 #import <FirebaseCore/FIRComponent.h>
@@ -68,6 +69,7 @@ NSString *const kAppDistroLibraryName = @"fire-fad";
   if (authRetrievalError) {
     NSLog(@"Error retrieving token from keychain: %@", [authRetrievalError localizedDescription]);
   }
+
   self.isTesterSignedIn = self.authState ? YES : NO;
   return self;
 }
@@ -141,6 +143,7 @@ NSString *const kAppDistroLibraryName = @"fire-fad";
   if (!didClearAuthState) {
     NSLog(@"Error clearing token from keychain: %@", [error localizedDescription]);
   }
+
   self.authState = nil;
   self.isTesterSignedIn = false;
 }
@@ -249,7 +252,6 @@ NSString *const kAppDistroLibraryName = @"fire-fad";
   if (self.window) {
     return;
   }
-
   // Create an empty window + viewController to host the Safari UI.
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   self.window.rootViewController = self.safariHostingViewController;

--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -74,7 +74,6 @@ NSString *const kAppDistroLibraryName = @"fire-fad";
 
   self.isTesterSignedIn = self.authState ? YES : NO;
 
-  NSLog(@"Tester %@ already logged in", self.isTesterSignedIn ? @"is" : @"is not");
   return self;
 }
 

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionAuthPersistence.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionAuthPersistence.m
@@ -16,77 +16,106 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NSString *const kFIRAppDistributionKeychainErrorDomain = @"com.firebase.app_distribution.internal";
+
 @implementation FIRAppDistributionAuthPersistence
 
-+ (BOOL)clearAuthState {
-    NSMutableDictionary *keychainQuery = [self getKeyChainQuery];
-    OSStatus status = SecItemDelete((CFDictionaryRef)keychainQuery);
-    
-    if (status != errSecSuccess && status != errSecItemNotFound) {
-        NSLog(@"AUTH ERROR. Cant delete auth state in keychain");
-    } else {
-        NSLog(@"AUTH SUCCESS! deleted auth state in the keychain");
-    }
-    return errSecSuccess || status == errSecItemNotFound;
++ (void)handleAuthStateError:(NSError **_Nullable)error
+                 description:(NSString *)description
+                        code:(FIRAppDistributionKeychainError)code {
+  if (error) {
+    NSDictionary *userInfo = @{NSLocalizedDescriptionKey : description};
+    *error = [NSError errorWithDomain:kFIRAppDistributionKeychainErrorDomain
+                                 code:code
+                             userInfo:userInfo];
+  }
 }
 
-+ (OIDAuthState*)retrieveAuthState {
-    NSMutableDictionary *keychainQuery = [self getKeyChainQuery];
-      [keychainQuery setObject:(id)kCFBooleanTrue forKey:(id)kSecReturnData];
-      [keychainQuery setObject:(id)kSecMatchLimitOne forKey:(id)kSecMatchLimit];
-      CFDataRef passwordData = NULL;
-      NSData *result = nil;
-      OSStatus status = SecItemCopyMatching((CFDictionaryRef)keychainQuery,
-                                         (CFTypeRef *)&passwordData);
-      if (status == noErr && 0 < [(__bridge NSData *)passwordData length]) {
-        result = [(__bridge NSData *)passwordData copy];
-      } else {
-          NSLog(@"AUTH ERROR - cannot lookup keystore config");
-      }
-      if (passwordData != NULL) {
-        CFRelease(passwordData);
-      }
-    
-    OIDAuthState *authState = nil;
-    if(result) {
-        authState = (OIDAuthState *)[NSKeyedUnarchiver unarchiveObjectWithData:result];
-    }
-    
-    return authState;
++ (BOOL)clearAuthState:(NSError **_Nullable)error {
+  NSMutableDictionary *keychainQuery = [self getKeyChainQuery];
+  OSStatus status = SecItemDelete((CFDictionaryRef)keychainQuery);
+
+  if (status != errSecSuccess && status != errSecItemNotFound) {
+    NSString *description = NSLocalizedString(
+        @"Failed to clear auth state from keychain. Tester will overwrite data on sign in.",
+        @"Error message for failure to retrieve auth state from keychain");
+    [self handleAuthStateError:error
+                   description:description
+                          code:FIRAppDistributionErrorTokenDeletionFailure];
+    return NO;
+  }
+
+  return YES;
 }
 
-+ (BOOL)persistAuthState:(OIDAuthState *)authState {
-    NSData *authorizationData = [NSKeyedArchiver archivedDataWithRootObject:authState];
-    NSMutableDictionary *keychainQuery = [self getKeyChainQuery];
-    OSStatus status = noErr;
-    if([self retrieveAuthState]) {
-        NSLog(@"Auth state already persisted. Updating auth state");
-        status = SecItemUpdate((CFDictionaryRef)keychainQuery, (CFDictionaryRef)@{(id)kSecValueData: authorizationData});
-    } else {
-        [keychainQuery setObject:authorizationData forKey:(id)kSecValueData];
-        status = SecItemAdd((CFDictionaryRef)keychainQuery, NULL);
-    }
++ (OIDAuthState *)retrieveAuthState:(NSError **_Nullable)error {
+  NSMutableDictionary *keychainQuery = [self getKeyChainQuery];
+  [keychainQuery setObject:(id)kCFBooleanTrue forKey:(id)kSecReturnData];
+  [keychainQuery setObject:(id)kSecMatchLimitOne forKey:(id)kSecMatchLimit];
+  NSData *passwordData = NULL;
+  NSData *result = nil;
+  OSStatus status = SecItemCopyMatching((CFDictionaryRef)keychainQuery, (void *)&passwordData);
 
-      if (status != noErr) {
-          NSLog(@"AUTH ERROR. Cant store auth state in keychain");
-      } else {
-          NSLog(@"AUTH SUCCESS! Added auth state to keychain");
-      }
-    
-    return status == noErr;
+  if (status != noErr || 0 == [passwordData length]) {
+    NSString *description = NSLocalizedString(
+        @"Failed to retrieve auth state from keychain. Tester will have to sign in again.",
+        @"Error message for failure to retrieve auth state from keychain");
+    [self handleAuthStateError:error
+                   description:description
+                          code:FIRAppDistributionErrorTokenRetrievalFailure];
+    return nil;
+  }
+
+  result = [passwordData copy];
+
+  if (!result) {
+    NSString *description =
+        NSLocalizedString(@"Failed to unarchive auth state. Tester will have to sign in again.",
+                          @"Error message for failure to retrieve auth state from keychain");
+    [self handleAuthStateError:error
+                   description:description
+                          code:FIRAppDistributionErrorTokenRetrievalFailure];
+    return nil;
+  }
+
+  OIDAuthState *authState = (OIDAuthState *)[NSKeyedUnarchiver unarchiveObjectWithData:result];
+
+  return authState;
 }
 
-+ (NSMutableDictionary*)getKeyChainQuery {
-    NSMutableDictionary *keychainQuery =
-         [NSMutableDictionary dictionaryWithObjectsAndKeys:(id)kSecClassGenericPassword, (id)kSecClass,
-                                                           @"OAuth", (id)kSecAttrGeneric,
-                                                           @"OAuth", (id)kSecAttrAccount,
-                                                           @"fire-fad-auth", (id)kSecAttrService,
-                                                           nil];
-    return keychainQuery;
++ (BOOL)persistAuthState:(OIDAuthState *)authState error:(NSError **_Nullable)error {
+  NSData *authorizationData = [NSKeyedArchiver archivedDataWithRootObject:authState];
+  NSMutableDictionary *keychainQuery = [self getKeyChainQuery];
+  OSStatus status = noErr;
+  if ([self retrieveAuthState:NULL]) {
+    status = SecItemUpdate((CFDictionaryRef)keychainQuery,
+                           (CFDictionaryRef) @{(id)kSecValueData : authorizationData});
+  } else {
+    [keychainQuery setObject:authorizationData forKey:(id)kSecValueData];
+    status = SecItemAdd((CFDictionaryRef)keychainQuery, NULL);
+  }
+
+  if (status != noErr) {
+    NSString *description = NSLocalizedString(
+        @"Failed to persist auth state. Tester will have to sign in again after app close.",
+        @"Error message for failure to persist auth state to keychain");
+    [self handleAuthStateError:error
+                   description:description
+                          code:FIRAppDistributionErrorTokenPersistenceFailure];
+    return NO;
+  }
+
+  return YES;
+}
+
++ (NSMutableDictionary *)getKeyChainQuery {
+  NSMutableDictionary *keychainQuery = [NSMutableDictionary
+      dictionaryWithObjectsAndKeys:(id)kSecClassGenericPassword, (id)kSecClass, @"OAuth",
+                                   (id)kSecAttrGeneric, @"OAuth", (id)kSecAttrAccount,
+                                   @"fire-fad-auth", (id)kSecAttrService, nil];
+  return keychainQuery;
 }
 
 @end
-
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionAuthPersistence.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionAuthPersistence.m
@@ -15,7 +15,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NSString *const kFIRAppDistributionAuthPersistenceErrorDomain = @"com.firebase.app_distribution.auth_persistence";
+NSString *const kFIRAppDistributionAuthPersistenceErrorDomain =
+    @"com.firebase.app_distribution.auth_persistence";
 
 @implementation FIRAppDistributionAuthPersistence
 
@@ -51,7 +52,8 @@ NSString *const kFIRAppDistributionAuthPersistenceErrorDomain = @"com.firebase.a
   NSMutableDictionary *keychainQuery = [self getKeyChainQuery];
   [keychainQuery setObject:(id)kCFBooleanTrue forKey:(id)kSecReturnData];
   [keychainQuery setObject:(id)kSecMatchLimitOne forKey:(id)kSecMatchLimit];
-  NSData *passwordData = [FIRAppDistributionKeychainUtility fetchKeychainItemMatching:keychainQuery error:NULL];
+  NSData *passwordData = [FIRAppDistributionKeychainUtility fetchKeychainItemMatching:keychainQuery
+                                                                                error:NULL];
   NSData *result = nil;
 
   if (!passwordData) {
@@ -87,9 +89,11 @@ NSString *const kFIRAppDistributionAuthPersistenceErrorDomain = @"com.firebase.a
   BOOL success = NO;
   BOOL hasAuthState = [self retrieveAuthState:NULL];
   if (hasAuthState) {
-    success =[FIRAppDistributionKeychainUtility updateKeychainItem:keychainQuery withDataDictionary:authorizationData];
+    success = [FIRAppDistributionKeychainUtility updateKeychainItem:keychainQuery
+                                                 withDataDictionary:authorizationData];
   } else {
-    success =[FIRAppDistributionKeychainUtility addKeychainItem:keychainQuery withDataDictionary:authorizationData];
+    success = [FIRAppDistributionKeychainUtility addKeychainItem:keychainQuery
+                                              withDataDictionary:authorizationData];
   }
 
   if (!success) {

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionAuthPersistence.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionAuthPersistence.m
@@ -1,0 +1,92 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#import <AppAuth/AppAuth.h>
+#import "FIRAppDistributionAuthPersistence+Private.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation FIRAppDistributionAuthPersistence
+
++ (BOOL)clearAuthState {
+    NSMutableDictionary *keychainQuery = [self getKeyChainQuery];
+    OSStatus status = SecItemDelete((CFDictionaryRef)keychainQuery);
+    
+    if (status != errSecSuccess && status != errSecItemNotFound) {
+        NSLog(@"AUTH ERROR. Cant delete auth state in keychain");
+    } else {
+        NSLog(@"AUTH SUCCESS! deleted auth state in the keychain");
+    }
+    return errSecSuccess || status == errSecItemNotFound;
+}
+
++ (OIDAuthState*)retrieveAuthState {
+    NSMutableDictionary *keychainQuery = [self getKeyChainQuery];
+      [keychainQuery setObject:(id)kCFBooleanTrue forKey:(id)kSecReturnData];
+      [keychainQuery setObject:(id)kSecMatchLimitOne forKey:(id)kSecMatchLimit];
+      CFDataRef passwordData = NULL;
+      NSData *result = nil;
+      OSStatus status = SecItemCopyMatching((CFDictionaryRef)keychainQuery,
+                                         (CFTypeRef *)&passwordData);
+      if (status == noErr && 0 < [(__bridge NSData *)passwordData length]) {
+        result = [(__bridge NSData *)passwordData copy];
+      } else {
+          NSLog(@"AUTH ERROR - cannot lookup keystore config");
+      }
+      if (passwordData != NULL) {
+        CFRelease(passwordData);
+      }
+    
+    OIDAuthState *authState = nil;
+    if(result) {
+        authState = (OIDAuthState *)[NSKeyedUnarchiver unarchiveObjectWithData:result];
+    }
+    
+    return authState;
+}
+
++ (BOOL)persistAuthState:(OIDAuthState *)authState {
+    NSData *authorizationData = [NSKeyedArchiver archivedDataWithRootObject:authState];
+    NSMutableDictionary *keychainQuery = [self getKeyChainQuery];
+    OSStatus status = noErr;
+    if([self retrieveAuthState]) {
+        NSLog(@"Auth state already persisted. Updating auth state");
+        status = SecItemUpdate((CFDictionaryRef)keychainQuery, (CFDictionaryRef)@{(id)kSecValueData: authorizationData});
+    } else {
+        [keychainQuery setObject:authorizationData forKey:(id)kSecValueData];
+        status = SecItemAdd((CFDictionaryRef)keychainQuery, NULL);
+    }
+
+      if (status != noErr) {
+          NSLog(@"AUTH ERROR. Cant store auth state in keychain");
+      } else {
+          NSLog(@"AUTH SUCCESS! Added auth state to keychain");
+      }
+    
+    return status == noErr;
+}
+
++ (NSMutableDictionary*)getKeyChainQuery {
+    NSMutableDictionary *keychainQuery =
+         [NSMutableDictionary dictionaryWithObjectsAndKeys:(id)kSecClassGenericPassword, (id)kSecClass,
+                                                           @"OAuth", (id)kSecAttrGeneric,
+                                                           @"OAuth", (id)kSecAttrAccount,
+                                                           @"fire-fad-auth", (id)kSecAttrService,
+                                                           nil];
+    return keychainQuery;
+}
+
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionKeychainUtility.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionKeychainUtility.m
@@ -1,0 +1,52 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#import <AppAuth/AppAuth.h>
+#import "FIRAppDistributionKeychainUtility+Private.h"
+
+@implementation FIRAppDistributionKeychainUtility
+
++ (BOOL)addKeychainItem:(nonnull NSMutableDictionary *)keychainQuery withDataDictionary:(nonnull NSData *)data {
+  [keychainQuery setObject:data forKey:(id)kSecValueData];
+  OSStatus status = SecItemAdd((CFDictionaryRef)keychainQuery, NULL);
+
+  return status == noErr ? YES : NO;
+}
+
++ (BOOL)updateKeychainItem:(nonnull NSMutableDictionary *)keychainQuery withDataDictionary:(nonnull NSData *)data {
+  OSStatus status = SecItemUpdate((CFDictionaryRef)keychainQuery,
+                                  (CFDictionaryRef) @{(id)kSecValueData : data});
+  return status == noErr ? YES : NO;
+}
+
++ (BOOL)deleteKeychainItem:(nonnull NSMutableDictionary *)keychainQuery {
+  OSStatus status = SecItemDelete((CFDictionaryRef)keychainQuery);
+  
+  return status != errSecSuccess && status != errSecItemNotFound ? NO : YES;
+}
+
++ (BOOL)fetchKeychainItemMatching:(nonnull NSMutableDictionary *)keychainQuery keychainItem:(nonnull NSData *)keychainItem {
+  OSStatus status = SecItemCopyMatching((CFDictionaryRef)keychainQuery, (void *)&keychainItem);
+
+  return status != noErr || 0 == [keychainItem length] ? NO : YES;
+}
+
++ (OIDAuthState *)unarchiveKeychainResult:(NSData *)result {
+  return (OIDAuthState *)[NSKeyedUnarchiver unarchiveObjectWithData:result];
+}
+
++ (NSData *)archiveDataForKeychain:(OIDAuthState *)data {
+  return [NSKeyedArchiver archivedDataWithRootObject:data];
+}
+
+@end

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionKeychainUtility.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionKeychainUtility.m
@@ -29,37 +29,38 @@ NSString *const kFIRAppDistributionKeychainErrorDomain = @"com.firebase.app_dist
   }
 }
 
-+ (BOOL)addKeychainItem:(nonnull NSMutableDictionary *)keychainQuery withDataDictionary:(nonnull NSData *)data {
++ (BOOL)addKeychainItem:(nonnull NSMutableDictionary *)keychainQuery
+     withDataDictionary:(nonnull NSData *)data {
   [keychainQuery setObject:data forKey:(id)kSecValueData];
   OSStatus status = SecItemAdd((CFDictionaryRef)keychainQuery, NULL);
 
   return status == noErr ? YES : NO;
 }
 
-+ (BOOL)updateKeychainItem:(nonnull NSMutableDictionary *)keychainQuery withDataDictionary:(nonnull NSData *)data {
-  OSStatus status = SecItemUpdate((CFDictionaryRef)keychainQuery,
-                                  (CFDictionaryRef) @{(id)kSecValueData : data});
++ (BOOL)updateKeychainItem:(nonnull NSMutableDictionary *)keychainQuery
+        withDataDictionary:(nonnull NSData *)data {
+  OSStatus status =
+      SecItemUpdate((CFDictionaryRef)keychainQuery, (CFDictionaryRef) @{(id)kSecValueData : data});
   return status == noErr ? YES : NO;
 }
 
 + (BOOL)deleteKeychainItem:(nonnull NSMutableDictionary *)keychainQuery {
   OSStatus status = SecItemDelete((CFDictionaryRef)keychainQuery);
-  
+
   return status != errSecSuccess && status != errSecItemNotFound ? NO : YES;
 }
 
-+ (NSData *)fetchKeychainItemMatching:(nonnull NSMutableDictionary *)keychainQuery error:(NSError **_Nullable)error {
++ (NSData *)fetchKeychainItemMatching:(nonnull NSMutableDictionary *)keychainQuery
+                                error:(NSError **_Nullable)error {
   NSData *keychainItem;
   OSStatus status = SecItemCopyMatching((CFDictionaryRef)keychainQuery, (void *)&keychainItem);
 
-  if(status != noErr || 0 == [keychainItem length]){
-    if(error){
-      NSString *description = NSLocalizedString(
-        @"Failed to fetch keychain item.",
-        @"Error message for failure to retrieve auth state from keychain");
-      [self handleAuthStateError:error
-                     description:description
-                            code:0];
+  if (status != noErr || 0 == [keychainItem length]) {
+    if (error) {
+      NSString *description =
+          NSLocalizedString(@"Failed to fetch keychain item.",
+                            @"Error message for failure to retrieve auth state from keychain");
+      [self handleAuthStateError:error description:description code:0];
       return nil;
     }
   }

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionMachO.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionMachO.m
@@ -36,7 +36,6 @@
     _slices = [NSMutableArray new];
     [self extractSlices];
   }
-
   return self;
 }
 

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
@@ -17,7 +17,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 // Label exceptions from AppDistributionAuthPersistence calls.
-FOUNDATION_EXPORT NSString *const kFIRAppDistributionKeychainErrorDomain;
+FOUNDATION_EXPORT NSString *const kFIRAppDistributionAuthPersistenceErrorDomain;
 
 /**
  *  The set of error codes that may be returned from internal calls to persist Tester authentication
@@ -36,9 +36,6 @@ typedef NS_ENUM(NSUInteger, FIRAppDistributionKeychainError) {
 } NS_SWIFT_NAME(AppDistributionKeychainError);
 
 @interface FIRAppDistributionAuthPersistence : NSObject
-
-// A Keychain persistence implementation
-@property (class, nonatomic, readonly) Class<FIRAppDistributionKeychainProtocol> keychainUtility;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
@@ -1,0 +1,32 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <AppAuth/AppAuth.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FIRAppDistributionAuthPersistence : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+
++ (BOOL)persistAuthState:(OIDAuthState *)authState;
+
++ (BOOL)clearAuthState;
+
++ (OIDAuthState*)retrieveAuthState;
+
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
@@ -11,10 +11,12 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 #import <AppAuth/AppAuth.h>
 
 NS_ASSUME_NONNULL_BEGIN
+
+// Label exceptions from AppDistributionAuthPersistence calls.
+FOUNDATION_EXPORT NSString *const kFIRAppDistributionKeychainErrorDomain;
 
 /**
  *  The set of error codes that may be returned from internal calls to persist Tester authentication

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
@@ -11,22 +11,44 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 #import <AppAuth/AppAuth.h>
 
 NS_ASSUME_NONNULL_BEGIN
+
+// Label exceptions from AppDistributionAuthPersistence calls.
+FOUNDATION_EXPORT NSString *const kFIRAppDistributionKeychainErrorDomain;
+
+/**
+ *  The set of error codes that may be returned from internal calls to persist Tester authentication
+ *  to the keychain. These should never be returned to the user.
+ *  @enum FIRAppDistributionKeychainError
+ */
+typedef NS_ENUM(NSUInteger, FIRAppDistributionKeychainError) {
+  // Authentication token persistence error
+  FIRAppDistributionErrorTokenPersistenceFailure = 0,
+
+  // Authentication token retrieval error
+  FIRAppDistributionErrorTokenRetrievalFailure = 1,
+
+  // Authentication token deletion error
+  FIRAppDistributionErrorTokenDeletionFailure = 2,
+} NS_SWIFT_NAME(AppDistributionKeychainError);
 
 @interface FIRAppDistributionAuthPersistence : NSObject
 
 - (instancetype)init NS_UNAVAILABLE;
 
-+ (BOOL)persistAuthState:(OIDAuthState *)authState;
+// Handle null checking, creation, and formatting of an error encountered
++ (void)handleAuthStateError:(NSError **_Nullable)error
+                 description:(NSString *)description
+                        code:(FIRAppDistributionKeychainError)code;
 
-+ (BOOL)clearAuthState;
++ (BOOL)persistAuthState:(OIDAuthState *)authState error:(NSError **_Nullable)error;
 
-+ (OIDAuthState*)retrieveAuthState;
++ (BOOL)clearAuthState:(NSError **_Nullable)error;
+
++ (OIDAuthState *)retrieveAuthState:(NSError **_Nullable)error;
 
 @end
-
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
@@ -11,12 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #import <AppAuth/AppAuth.h>
 
 NS_ASSUME_NONNULL_BEGIN
-
-// Label exceptions from AppDistributionAuthPersistence calls.
-FOUNDATION_EXPORT NSString *const kFIRAppDistributionKeychainErrorDomain;
 
 /**
  *  The set of error codes that may be returned from internal calls to persist Tester authentication

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistributionAuthPersistence+Private.h
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #import <AppAuth/AppAuth.h>
+#import "FIRAppDistributionKeychainUtility+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -35,6 +36,9 @@ typedef NS_ENUM(NSUInteger, FIRAppDistributionKeychainError) {
 } NS_SWIFT_NAME(AppDistributionKeychainError);
 
 @interface FIRAppDistributionAuthPersistence : NSObject
+
+// A Keychain persistence implementation
+@property (class, nonatomic, readonly) Class<FIRAppDistributionKeychainProtocol> keychainUtility;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistributionKeychainUtility+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistributionKeychainUtility+Private.h
@@ -1,0 +1,43 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#import <AppAuth/AppAuth.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// @brief Wraps keychain operations to encapsulate interactions with CF data structures
+@protocol FIRAppDistributionKeychainProtocol
+
+/// @brief Store an item in the keychain
++ (BOOL)addKeychainItem:(NSMutableDictionary *)keychainQuery withDataDictionary:(NSData *)data;
+
+/// @brief Update an item in the keychain
++ (BOOL)updateKeychainItem:(NSMutableDictionary *)keychainQuery withDataDictionary:(NSData *)data;
+
+/// @brief Delete an item in the keychain
++ (BOOL)deleteKeychainItem:(NSMutableDictionary *)keychainQuery;
+
+/// @brief Fetch the item matching the keychain query from the keychain
++ (BOOL)fetchKeychainItemMatching:(NSMutableDictionary *)keychainQuery keychainItem:(NSData *)keychainItem;
+
+/// @brief Unarchive the authentication state from the keychain result
++ (OIDAuthState *)unarchiveKeychainResult:(NSData *)result;
+
+/// @brief Archive the authentication data for persistence to the keychain
++ (NSData *)archiveDataForKeychain:(OIDAuthState *)data;
+@end
+
+@interface FIRAppDistributionKeychainUtility: NSObject<FIRAppDistributionKeychainProtocol>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistributionKeychainUtility+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistributionKeychainUtility+Private.h
@@ -16,7 +16,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// @brief Wraps keychain operations to encapsulate interactions with CF data structures
-@interface FIRAppDistributionKeychainUtility: NSObject
+@interface FIRAppDistributionKeychainUtility : NSObject
 
 /// @brief Store an item in the keychain
 + (BOOL)addKeychainItem:(NSMutableDictionary *)keychainQuery withDataDictionary:(NSData *)data;
@@ -28,7 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)deleteKeychainItem:(NSMutableDictionary *)keychainQuery;
 
 /// @brief Fetch the item matching the keychain query from the keychain
-+ (NSData *)fetchKeychainItemMatching:(nonnull NSMutableDictionary *)keychainQuery error:(NSError **_Nullable)error;
++ (NSData *)fetchKeychainItemMatching:(nonnull NSMutableDictionary *)keychainQuery
+                                error:(NSError **_Nullable)error;
 
 /// @brief Unarchive the authentication state from the keychain result
 + (OIDAuthState *)unarchiveKeychainResult:(NSData *)result;

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistributionKeychainUtility+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistributionKeychainUtility+Private.h
@@ -16,7 +16,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /// @brief Wraps keychain operations to encapsulate interactions with CF data structures
-@protocol FIRAppDistributionKeychainProtocol
+@interface FIRAppDistributionKeychainUtility: NSObject
 
 /// @brief Store an item in the keychain
 + (BOOL)addKeychainItem:(NSMutableDictionary *)keychainQuery withDataDictionary:(NSData *)data;
@@ -28,16 +28,13 @@ NS_ASSUME_NONNULL_BEGIN
 + (BOOL)deleteKeychainItem:(NSMutableDictionary *)keychainQuery;
 
 /// @brief Fetch the item matching the keychain query from the keychain
-+ (BOOL)fetchKeychainItemMatching:(NSMutableDictionary *)keychainQuery keychainItem:(NSData *)keychainItem;
++ (NSData *)fetchKeychainItemMatching:(nonnull NSMutableDictionary *)keychainQuery error:(NSError **_Nullable)error;
 
 /// @brief Unarchive the authentication state from the keychain result
 + (OIDAuthState *)unarchiveKeychainResult:(NSData *)result;
 
 /// @brief Archive the authentication data for persistence to the keychain
 + (NSData *)archiveDataForKeychain:(OIDAuthState *)data;
-@end
-
-@interface FIRAppDistributionKeychainUtility: NSObject<FIRAppDistributionKeychainProtocol>
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistributionMachOSlice+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistributionMachOSlice+Private.h
@@ -1,5 +1,4 @@
 /*
-<<<<<<< HEAD
  * Copyright 2019 Google
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistributionMachOSlice+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistributionMachOSlice+Private.h
@@ -1,4 +1,5 @@
 /*
+<<<<<<< HEAD
  * Copyright 2019 Google
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionAuthPersistenceTests.m
+++ b/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionAuthPersistenceTests.m
@@ -12,8 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#import <XCTest/XCTest.h>
 #import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
 
 #import <AppAuth/AppAuth.h>
 #import <FirebaseAppDistribution/FIRAppDistributionAuthPersistence+Private.h>
@@ -33,13 +33,14 @@
 - (void)setUp {
   [super setUp];
   _mockKeychainQuery = [NSMutableDictionary
-                        dictionaryWithObjectsAndKeys:(id)@"thing one", (id)@"another thing", nil];
+      dictionaryWithObjectsAndKeys:(id) @"thing one", (id) @"another thing", nil];
   _mockKeychainUtility = OCMClassMock([FIRAppDistributionKeychainUtility class]);
   _mockAuthorizationData = [@"this is some password stuff" dataUsingEncoding:NSUTF8StringEncoding];
   _mockOIDAuthState = OCMClassMock([OIDAuthState class]);
-  OCMStub(ClassMethod([_mockKeychainUtility unarchiveKeychainResult:[OCMArg any]])).andReturn(_mockOIDAuthState);
-  OCMStub(ClassMethod([_mockKeychainUtility archiveDataForKeychain:[OCMArg any]])).andReturn(_mockAuthorizationData);
-
+  OCMStub(ClassMethod([_mockKeychainUtility unarchiveKeychainResult:[OCMArg any]]))
+      .andReturn(_mockOIDAuthState);
+  OCMStub(ClassMethod([_mockKeychainUtility archiveDataForKeychain:[OCMArg any]]))
+      .andReturn(_mockAuthorizationData);
 }
 
 - (void)tearDown {
@@ -48,17 +49,21 @@
 
 - (void)testPersistAuthStateSuccess {
   OCMStub(ClassMethod([_mockKeychainUtility addKeychainItem:[OCMArg any]
-                                         withDataDictionary:[OCMArg any] ])).andReturn(YES);
+                                         withDataDictionary:[OCMArg any]]))
+      .andReturn(YES);
   NSError *error;
-  XCTAssertTrue([FIRAppDistributionAuthPersistence persistAuthState:_mockOIDAuthState error:&error]);
+  XCTAssertTrue([FIRAppDistributionAuthPersistence persistAuthState:_mockOIDAuthState
+                                                              error:&error]);
   XCTAssertNil(error);
 }
 
 - (void)testPersistAuthStateFailure {
   OCMStub(ClassMethod([_mockKeychainUtility addKeychainItem:[OCMArg any]
-                                         withDataDictionary:[OCMArg any] ])).andReturn(NO);
+                                         withDataDictionary:[OCMArg any]]))
+      .andReturn(NO);
   NSError *error;
-  XCTAssertFalse([FIRAppDistributionAuthPersistence persistAuthState:_mockOIDAuthState error:&error]);
+  XCTAssertFalse([FIRAppDistributionAuthPersistence persistAuthState:_mockOIDAuthState
+                                                               error:&error]);
   XCTAssertNotNil(error);
   XCTAssertEqual([error domain], kFIRAppDistributionAuthPersistenceErrorDomain);
   XCTAssertEqual([error code], FIRAppDistributionErrorTokenPersistenceFailure);
@@ -66,38 +71,46 @@
 
 - (void)testOverwriteAuthStateSuccess {
   OCMStub(ClassMethod([_mockKeychainUtility fetchKeychainItemMatching:[OCMArg any]
-                                                                error:[OCMArg setTo:nil]])).andReturn(_mockAuthorizationData);
+                                                                error:[OCMArg setTo:nil]]))
+      .andReturn(_mockAuthorizationData);
   OCMStub(ClassMethod([_mockKeychainUtility updateKeychainItem:[OCMArg any]
-                                            withDataDictionary:[OCMArg any]])).andReturn(YES);
+                                            withDataDictionary:[OCMArg any]]))
+      .andReturn(YES);
   NSError *error;
-  XCTAssertTrue([FIRAppDistributionAuthPersistence persistAuthState:_mockOIDAuthState error:&error]);
+  XCTAssertTrue([FIRAppDistributionAuthPersistence persistAuthState:_mockOIDAuthState
+                                                              error:&error]);
   XCTAssertNil(error);
 }
 
 - (void)testOverwriteAuthStateFailure {
   OCMStub(ClassMethod([_mockKeychainUtility fetchKeychainItemMatching:[OCMArg any]
-                                                                error:[OCMArg setTo:nil]])).andReturn(_mockAuthorizationData);
+                                                                error:[OCMArg setTo:nil]]))
+      .andReturn(_mockAuthorizationData);
   OCMStub(ClassMethod([_mockKeychainUtility updateKeychainItem:[OCMArg any]
-                                            withDataDictionary:[OCMArg any]])).andReturn(NO);
+                                            withDataDictionary:[OCMArg any]]))
+      .andReturn(NO);
   NSError *error;
-  XCTAssertFalse([FIRAppDistributionAuthPersistence persistAuthState:_mockOIDAuthState error:&error]);
+  XCTAssertFalse([FIRAppDistributionAuthPersistence persistAuthState:_mockOIDAuthState
+                                                               error:&error]);
   XCTAssertNotNil(error);
   XCTAssertEqual([error domain], kFIRAppDistributionAuthPersistenceErrorDomain);
   XCTAssertEqual([error code], FIRAppDistributionErrorTokenPersistenceFailure);
 }
 
-- (void) testRetrieveAuthStateSuccess {
+- (void)testRetrieveAuthStateSuccess {
   OCMStub(ClassMethod([_mockKeychainUtility fetchKeychainItemMatching:[OCMArg any]
-                                                                error:[OCMArg setTo:nil]])).andReturn(_mockAuthorizationData);
+                                                                error:[OCMArg setTo:nil]]))
+      .andReturn(_mockAuthorizationData);
   NSError *error;
-  XCTAssertTrue([[FIRAppDistributionAuthPersistence retrieveAuthState:&error] isKindOfClass:[OIDAuthState class]]);
+  XCTAssertTrue([[FIRAppDistributionAuthPersistence retrieveAuthState:&error]
+      isKindOfClass:[OIDAuthState class]]);
   XCTAssertNil(error);
 }
 
-
-- (void) testRetrieveAuthStateFailure {
+- (void)testRetrieveAuthStateFailure {
   OCMStub(ClassMethod([_mockKeychainUtility fetchKeychainItemMatching:[OCMArg any]
-                                                         error:[OCMArg setTo:nil]])).andReturn(nil);
+                                                                error:[OCMArg setTo:nil]]))
+      .andReturn(nil);
   NSError *error;
   XCTAssertFalse([FIRAppDistributionAuthPersistence retrieveAuthState:&error]);
   XCTAssertNotNil(error);
@@ -105,16 +118,14 @@
   XCTAssertEqual([error code], FIRAppDistributionErrorTokenRetrievalFailure);
 }
 
-
-- (void) testClearAuthStateSuccess {
+- (void)testClearAuthStateSuccess {
   OCMStub(ClassMethod([_mockKeychainUtility deleteKeychainItem:[OCMArg any]])).andReturn(YES);
   NSError *error;
   XCTAssertTrue([FIRAppDistributionAuthPersistence clearAuthState:&error]);
   XCTAssertNil(error);
 }
 
-
-- (void) testClearAuthStateFailure {
+- (void)testClearAuthStateFailure {
   OCMStub(ClassMethod([_mockKeychainUtility deleteKeychainItem:[OCMArg any]])).andReturn(NO);
   NSError *error;
   XCTAssertFalse([FIRAppDistributionAuthPersistence clearAuthState:&error]);

--- a/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionAuthPersistenceTests.m
+++ b/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionAuthPersistenceTests.m
@@ -1,0 +1,95 @@
+//
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// FIRAppDistributionAuthPersistenceTests.m
+// FirebaseAppDistribution
+//
+// Created by Cleo Schneider on 4/17/20.
+
+#import <Foundation/Foundation.h>
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#import "FIRAppDistributionAuthPersistence+Private.h"
+
+@interface FIRAppDistributionAuthPersistenceTests : XCTestCase
+@end
+
+static NSString *const kTestCode = @"ThisCode";
+
+static NSString *const kTestVerifier = @"ThisVerifier";
+
+static NSString *const kTestState = @"ThisState";
+
+static NSString *const kTestAccessToken = @"ThisToken";
+
+static long const kTestExpirationSeconds = 45;
+
+static NSString *const kTestIdToken = @"ThisIdToken";
+
+static NSString *const kTestTokenType = @"ThisTokenType";
+
+static NSString *const kTestScope = @"ThisScope";
+
+@implementation FIRAppDistributionAuthPersistenceTests {
+  /** @var _mockAuthState
+      @brief The mock OIDAuthState  instance
+   */
+  OIDAuthState *_mockAuthState;
+}
+
+- (void)setUp {
+  [super setUp];
+  OIDAuthorizationRequest *mockAuthorizationRequest = OCMClassMock([OIDAuthorizationRequest class]);
+  OIDAuthorizationResponse *testAuthorizationResponse =
+      [[OIDAuthorizationResponse alloc] initWithRequest:mockAuthorizationRequest
+                                             parameters:@{
+                                               @"code" : @"AuthCode",
+                                               @"code_verifier" : @"AuthVerifier",
+                                               @"state" : @"AuthState",
+                                               @"access_token" : @"AuthToken",
+                                               @"expires_in" : @(45),
+                                               @"id_token" : @"AuthIdToken",
+                                               @"token_type" : @"AuthTokenType",
+                                               @"scope" : "AuthScope"
+                                             }];
+  OIDTokenRequest *mockTokenRequest = OCMClassMock([OIDTokenRequest class]);
+  OIDTokenResponse *testTokenResponse =
+      [[OIDTokenResponse alloc] initWithRequest:mockTokenRequest
+                                     parameters:@{
+                                       @"access_token" : @"TokenToken",
+                                       @"expires_in" : @(45),
+                                       @"id_token" : @"TokenIdToken",
+                                       @"refresh_token" : @"TokenRefreshToken",
+                                       @"scope" : @"TokenScope"
+                                     }];
+
+  _mockAuthState = [[OIDAuthState alloc] initWithAuthorizationResponse:testAuthorizationResponse
+                                                         tokenResponse:testTokenResponse]
+}
+
+- (void)tearDown {
+  // Put teardown code here. This method is called after the invocation of each test method in the
+  // class.
+  [super tearDown];
+}
+
+- (void)testPersistAuthState {
+  NSError *error;
+  BOOL success = [FIRAppDistributionAuthPersistence persistAuthState:_mockAuthState error:&error];
+  XCTAssertTrue(success);
+}
+
+@end

--- a/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionTests.m
+++ b/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionTests.m
@@ -16,7 +16,7 @@
 #import <XCTest/XCTest.h>
 
 #import <FirebaseCore/FIRAppInternal.h>
-#import "FIRAppDistribution.h"
+#import "FirebaseAppDistribution/FIRAppDistribution.h"
 
 @interface FIRAppDistributionSampleTests : XCTestCase
 


### PR DESCRIPTION
* Add persistence to keychain with error handling
* Add a wrapper around the keychain interactions to facilitate unit testing
* Add unit tests for FIRAppDistributionAuthPersistence

### Testing

  * Added unit tests for FIRAppDistributionAuthPersistence
  * Ran end to end locally to ensure that basic functionality works on device
