### PR TITLE
Fix InstanceID cron build regression

### DIFF
--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -134,6 +134,7 @@ case "$project-$platform-$method" in
     install_secrets
     ;;
 
+  # There is purposefully not a dash to include InstanceIDCron.
   InstanceID*)
     install_secrets
     ;;

--- a/scripts/install_prereqs.sh
+++ b/scripts/install_prereqs.sh
@@ -134,7 +134,7 @@ case "$project-$platform-$method" in
     install_secrets
     ;;
 
-  InstanceID-*)
+  InstanceID*)
     install_secrets
     ;;
 


### PR DESCRIPTION
#5301 broke the InstanceID cron tests that depended on the dash not being in the switch.

See https://travis-ci.org/github/firebase/firebase-ios-sdk/jobs/680094682