### PR TITLE
Turn off Messaging Swift Tests for macos

### DIFF
--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -65,7 +65,7 @@ device, and it is completely free.
   end
 
   s.test_spec 'integration' do |int_tests|
-    int_tests.platforms = {:ios => '8.0', :tvos => '10.0'}
+    int_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}
     int_tests.source_files = 'FirebaseMessaging/Tests/IntegrationTests/*.swift'
     int_tests.requires_app_host = true
     int_tests.resources = 'FirebaseMessaging/Tests/IntegrationTests/Resources/GoogleService-Info.plist'

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -65,7 +65,7 @@ device, and it is completely free.
   end
 
   s.test_spec 'integration' do |int_tests|
-    int_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}
+    int_tests.platforms = {:ios => '8.0', :tvos => '10.0'}
     int_tests.source_files = 'FirebaseMessaging/Tests/IntegrationTests/*.swift'
     int_tests.requires_app_host = true
     int_tests.resources = 'FirebaseMessaging/Tests/IntegrationTests/Resources/GoogleService-Info.plist'

--- a/FirebaseMessaging/Tests/IntegrationTests/FIRMessagingTokenRefreshTests.swift
+++ b/FirebaseMessaging/Tests/IntegrationTests/FIRMessagingTokenRefreshTests.swift
@@ -29,7 +29,7 @@
     var messaging = Messaging.messaging()
     var delegateIsCalled = false
 
-    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String) {
+    func messaging(_: Messaging, didReceiveRegistrationToken _: String) {
       delegateIsCalled = true
     }
   }

--- a/FirebaseMessaging/Tests/IntegrationTests/FIRMessagingTokenRefreshTests.swift
+++ b/FirebaseMessaging/Tests/IntegrationTests/FIRMessagingTokenRefreshTests.swift
@@ -17,6 +17,7 @@
 // macOS requests a user password when accessing the Keychain for the first time,
 // so the tests may fail. Disable integration tests on macOS so far.
 // TODO: Configure the tests to run on macOS without requesting the keychain password.
+#if !os(OSX)
 
   import FirebaseCore
   import FirebaseInstanceID
@@ -52,7 +53,6 @@
       messaging = nil
     }
 
-    #if !os(OSX) // OSX does not support NSNotification.
     func testDeleteTokenWithTokenRefreshDelegatesAndNotifications() {
       let expectation = self.expectation(description: "delegate method and notification are called")
       assertTokenWithAuthorizedEntity()
@@ -76,7 +76,6 @@
       })
       wait(for: [expectation, notificationExpectation], timeout: 5)
     }
-    #endif
 
     // pragma mark - Helpers
     func assertTokenWithAuthorizedEntity() {
@@ -99,3 +98,4 @@
       return app.options.gcmSenderID
     }
   }
+#endif // !TARGET_OS_OSX

--- a/FirebaseMessaging/Tests/IntegrationTests/FIRMessagingTokenRefreshTests.swift
+++ b/FirebaseMessaging/Tests/IntegrationTests/FIRMessagingTokenRefreshTests.swift
@@ -17,7 +17,6 @@
 // macOS requests a user password when accessing the Keychain for the first time,
 // so the tests may fail. Disable integration tests on macOS so far.
 // TODO: Configure the tests to run on macOS without requesting the keychain password.
-#if !TARGET_OS_OSX
 
   import FirebaseCore
   import FirebaseInstanceID
@@ -53,6 +52,7 @@
       messaging = nil
     }
 
+    #if !os(OSX) // OSX does not support NSNotification.
     func testDeleteTokenWithTokenRefreshDelegatesAndNotifications() {
       let expectation = self.expectation(description: "delegate method and notification are called")
       assertTokenWithAuthorizedEntity()
@@ -76,6 +76,7 @@
       })
       wait(for: [expectation, notificationExpectation], timeout: 5)
     }
+    #endif
 
     // pragma mark - Helpers
     func assertTokenWithAuthorizedEntity() {
@@ -98,4 +99,3 @@
       return app.options.gcmSenderID
     }
   }
-#endif // !TARGET_OS_OSX


### PR DESCRIPTION
The tests do not build for macos because of their use of NSNotification.

See https://travis-ci.org/github/firebase/firebase-ios-sdk/jobs/680094689

    - ERROR | [OSX] xcodebuild:  /Users/travis/build/firebase/firebase-ios-sdk/FirebaseMessaging/Tests/IntegrationTests/FIRMessagingTokenRefreshTests.swift:61:10: error: type 'NSNotification.Name' has no member 'MessagingRegistrationTokenRefreshed'