### PR TITLE
Fix Docs Regarding Carthage Integration

### DIFF
--- a/Carthage.md
+++ b/Carthage.md
@@ -99,7 +99,7 @@ binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseStorageBinary.jso
     - Paste the following into your new Run Script, replacing "scripts" with whatever you named your folder: `"${PROJECT_DIR}/scripts/run"`
     - Add the following dependencies as **Input Files** to the Run Script:
        - `${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}`
-       - `$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)`
+       - `$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)`
 
 ## Versioning
 


### PR DESCRIPTION
`$(SRCROOT)/$(BUILT_PRODUCTS_DIR)` is not a valid directory combination as far as I know. In my project I use just $(BUILT_PRODUCTS_DIR) and it seems to work.