### PR TITLE
Fix networkinfo population in GDTCCT watchos testapp events

### DIFF
--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTServiceExtension/NotificationService.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTServiceExtension/NotificationService.swift
@@ -45,7 +45,10 @@ class NotificationService: UNNotificationServiceExtension {
       testMessage.root.warriorChampionships = 1337
       event.qosTier = GDTCOREventQoS.qoSFast
       event.dataObject = testMessage
-      event.customPrioritizationParams = ["needs_network_connection_info": true]
+      let encoder = JSONEncoder()
+      if let jsonData = try? encoder.encode(["needs_network_connection_info": true]) {
+        event.customBytes = jsonData
+      }
       transportToUse.sendDataEvent(event)
 
       bestAttemptContent.title = "\(bestAttemptContent.title) [Priority Event]"

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/InterfaceController.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSCompanionTestAppExtension/InterfaceController.swift
@@ -52,7 +52,10 @@ class InterfaceController: WKInterfaceController {
     ]
     testMessage.root.subMessage.repeatedSubMessage[0].samplingPercentage = 13.37
     event.dataObject = testMessage
-    event.customPrioritizationParams = ["needs_network_connection_info": true]
+    let encoder = JSONEncoder()
+    if let jsonData = try? encoder.encode(["needs_network_connection_info": true]) {
+      event.customBytes = jsonData
+    }
     transportToUse.sendDataEvent(event)
   }
 
@@ -67,7 +70,10 @@ class InterfaceController: WKInterfaceController {
       SubMessageTwo(),
     ]
     event.dataObject = testMessage
-    event.customPrioritizationParams = ["needs_network_connection_info": true]
+    let encoder = JSONEncoder()
+    if let jsonData = try? encoder.encode(["needs_network_connection_info": true]) {
+      event.customBytes = jsonData
+    }
     transportToUse.sendTelemetryEvent(event)
   }
 
@@ -81,7 +87,10 @@ class InterfaceController: WKInterfaceController {
     testMessage.root.warriorChampionships = 1337
     event.qosTier = GDTCOREventQoS.qoSFast
     event.dataObject = testMessage
-    event.customPrioritizationParams = ["needs_network_connection_info": true]
+    let encoder = JSONEncoder()
+    if let jsonData = try? encoder.encode(["needs_network_connection_info": true]) {
+      event.customBytes = jsonData
+    }
     transportToUse.sendDataEvent(event)
   }
 
@@ -93,7 +102,10 @@ class InterfaceController: WKInterfaceController {
     testMessage.root.identifier = "watchos_companion_test_app_wifi_only_event"
     event.qosTier = GDTCOREventQoS.qoSWifiOnly
     event.dataObject = testMessage
-    event.customPrioritizationParams = ["needs_network_connection_info": true]
+    let encoder = JSONEncoder()
+    if let jsonData = try? encoder.encode(["needs_network_connection_info": true]) {
+      event.customBytes = jsonData
+    }
     transportToUse.sendDataEvent(event)
   }
 
@@ -112,7 +124,10 @@ class InterfaceController: WKInterfaceController {
     testMessage.root.subMessage.repeatedSubMessage[0].samplingPercentage = 100.0
     event.qosTier = GDTCOREventQoS.qoSDaily
     event.dataObject = testMessage
-    event.customPrioritizationParams = ["needs_network_connection_info": true]
+    let encoder = JSONEncoder()
+    if let jsonData = try? encoder.encode(["needs_network_connection_info": true]) {
+      event.customBytes = jsonData
+    }
     transportToUse.sendDataEvent(event)
   }
 }

--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSIndependentTestAppWatchKitExtension/InterfaceController.swift
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/GDTCCTWatchOSIndependentTestAppWatchKitExtension/InterfaceController.swift
@@ -53,7 +53,10 @@ class InterfaceController: WKInterfaceController {
     ]
     testMessage.root.subMessage.repeatedSubMessage[0].samplingPercentage = 13.37
     event.dataObject = testMessage
-    event.customPrioritizationParams = ["needs_network_connection_info": true]
+    let encoder = JSONEncoder()
+    if let jsonData = try? encoder.encode(["needs_network_connection_info": true]) {
+      event.customBytes = jsonData
+    }
     transportToUse.sendDataEvent(event)
   }
 
@@ -68,7 +71,10 @@ class InterfaceController: WKInterfaceController {
       SubMessageTwo(),
     ]
     event.dataObject = testMessage
-    event.customPrioritizationParams = ["needs_network_connection_info": true]
+    let encoder = JSONEncoder()
+    if let jsonData = try? encoder.encode(["needs_network_connection_info": true]) {
+      event.customBytes = jsonData
+    }
     transportToUse.sendTelemetryEvent(event)
   }
 
@@ -82,7 +88,10 @@ class InterfaceController: WKInterfaceController {
     testMessage.root.warriorChampionships = 1337
     event.qosTier = GDTCOREventQoS.qoSFast
     event.dataObject = testMessage
-    event.customPrioritizationParams = ["needs_network_connection_info": true]
+    let encoder = JSONEncoder()
+    if let jsonData = try? encoder.encode(["needs_network_connection_info": true]) {
+      event.customBytes = jsonData
+    }
     transportToUse.sendDataEvent(event)
   }
 
@@ -94,7 +103,10 @@ class InterfaceController: WKInterfaceController {
     testMessage.root.identifier = "watchos_test_app_wifi_only_event"
     event.qosTier = GDTCOREventQoS.qoSWifiOnly
     event.dataObject = testMessage
-    event.customPrioritizationParams = ["needs_network_connection_info": true]
+    let encoder = JSONEncoder()
+    if let jsonData = try? encoder.encode(["needs_network_connection_info": true]) {
+      event.customBytes = jsonData
+    }
     transportToUse.sendDataEvent(event)
   }
 
@@ -113,7 +125,10 @@ class InterfaceController: WKInterfaceController {
     testMessage.root.subMessage.repeatedSubMessage[0].samplingPercentage = 100.0
     event.qosTier = GDTCOREventQoS.qoSDaily
     event.dataObject = testMessage
-    event.customPrioritizationParams = ["needs_network_connection_info": true]
+    let encoder = JSONEncoder()
+    if let jsonData = try? encoder.encode(["needs_network_connection_info": true]) {
+      event.customBytes = jsonData
+    }
     transportToUse.sendDataEvent(event)
   }
 }


### PR DESCRIPTION
Change `customPrioritizationParams` to `customBytes`, according to https://github.com/firebase/firebase-ios-sdk/pull/4534