### PR TITLE
Fix generate_protos

### DIFF
--- a/Firestore/Protos/CMakeLists.txt
+++ b/Firestore/Protos/CMakeLists.txt
@@ -256,6 +256,7 @@ endif()
 if(FIREBASE_IOS_PROTOC_GENERATE_SOURCES)
   add_custom_target(
     generate_protos
+    DEPENDS
     generate_nanopb_protos
     generate_cpp_protos
   )

--- a/Firestore/Protos/README.md
+++ b/Firestore/Protos/README.md
@@ -7,7 +7,7 @@ brew install automake libtool protobuf golang
 
 Take a nap while that completes. Then, build the protos:
 ```
-cd firebase-ios-sdk
+cd firebase-ios-sdk  # the root of this repo, not Firestore/Protos
 mkdir -p build
 cd build
 cmake ..


### PR DESCRIPTION
Fix the `generate_protos` alias to actually depend on the other targets. Without that, CMake considered these sources and then couldn't find them.