### PR TITLE
Integration tests need SpecStaging

### DIFF
--- a/FirebaseAuth/Tests/Sample/Podfile
+++ b/FirebaseAuth/Tests/Sample/Podfile
@@ -2,6 +2,7 @@
 #source 'sso://cpdc-internal/firebase'
 #source 'https://cdn.cocoapods.org/'
 
+source 'https://github.com/firebase/SpecsStaging.git'
 source 'https://cdn.cocoapods.org/'
 
 use_frameworks!

--- a/FirebaseMessaging/Apps/Sample/Podfile
+++ b/FirebaseMessaging/Apps/Sample/Podfile
@@ -1,5 +1,8 @@
 use_frameworks!
 
+source 'https://github.com/firebase/SpecsStaging.git'
+source 'https://cdn.cocoapods.org/'
+
 target 'Sample' do
   platform :ios, '13.0'
 


### PR DESCRIPTION
Fix build failures caused by needing pre-released nanopb and FirebaseAnalytics

#no-changelog