### PR TITLE
Fixed linting for Combine APIs.

### DIFF
--- a/Firestore/Swift/Source/Combine/DocumentReference+Combine.swift
+++ b/Firestore/Swift/Source/Combine/DocumentReference+Combine.swift
@@ -16,13 +16,13 @@
 
 #if canImport(Combine)
   import Combine
-#endif
-import Foundation
-import FirebaseFirestore
+  import Foundation
+  import FirebaseFirestore
 
-extension DocumentReference {
-  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-  public func dummyPublisher() -> AnyPublisher<Int, Never> {
-    return Just(42).eraseToAnyPublisher()
+  extension DocumentReference {
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+    public func dummyPublisher() -> AnyPublisher<Int, Never> {
+      return Just(42).eraseToAnyPublisher()
+    }
   }
-}
+#endif


### PR DESCRIPTION
This will likely cause a merge conflict if you've added anything to this class. In that case, I'm fine just closing this once a new API is added with this change integrated as well (moving the `#endif` to the end of the file)