### PR TITLE
Introduce Query.getDocument() publisher

### DIFF
--- a/Firestore/Swift/Source/Combine/Query+Combine.swift
+++ b/Firestore/Swift/Source/Combine/Query+Combine.swift
@@ -27,8 +27,8 @@ extension Query {
    * Reads the documents matching this query.
    *
    * This method returns a publisher that yields an array
-   * of `DocumentSnapshot`s, allowing the user to easily iterate over
-   * the documents themselves:
+   * of `QuerySnapshot`s, requiring the user to extract the underlying
+   * `DocumentSnapshot`s before using them:
    *
    * ```
    * let noBooks = [Book]()

--- a/Firestore/Swift/Source/Combine/Query+Combine.swift
+++ b/Firestore/Swift/Source/Combine/Query+Combine.swift
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if canImport(Combine)
+  import Combine
+#endif
+import Foundation
+import FirebaseFirestore
+
+extension Query {
+
+  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+  struct DocumentPublisher<Output: DocumentSnapshot>: Publisher {
+    typealias Output = DocumentSnapshot
+    typealias Failure = Error
+    
+    private let query: Query
+    
+    init(query: Query) {
+      self.query = query
+    }
+    
+    func receive<S>(subscriber: S) where S : Subscriber, Self.Failure == S.Failure, Self.Output == S.Input {
+      let subscription = DocumentSubscription(subscriber: subscriber, query: query)
+      subscriber.receive(subscription: subscription)
+    }
+    
+  }
+  
+  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+  public func getDocuments() -> AnyPublisher<DocumentSnapshot, Error> {
+    return DocumentPublisher(query: self).eraseToAnyPublisher()
+  }
+
+  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+  public func dummyPublisher() -> AnyPublisher<Int, Never> {
+    return Just(42).eraseToAnyPublisher()
+  }  
+  
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+extension Query.DocumentPublisher {
+  
+  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+  class DocumentSubscription<S: Subscriber>: Subscription where S.Input == DocumentSnapshot, S.Failure == Error {
+    private let query: Query
+    private var subscriber: S?
+    
+    init(subscriber: S, query: Query) {
+      self.subscriber = subscriber
+      self.query = query
+    }
+    
+    func request(_ demand: Subscribers.Demand) {
+      if (demand > 0) {
+      }
+    }
+    
+    func cancel() {
+      subscriber = nil
+    }
+  }
+
+}

--- a/Firestore/Swift/Source/Combine/Query+Combine.swift
+++ b/Firestore/Swift/Source/Combine/Query+Combine.swift
@@ -22,7 +22,6 @@
 
   @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
   extension Query {
-    
     /**
      * Reads the documents matching this query.
      *
@@ -54,8 +53,8 @@
             promise(.failure(NSError(domain: "FirebaseFirestoreSwift",
                                      code: -1,
                                      userInfo: [NSLocalizedDescriptionKey:
-                                        "InternalError - Return type and Error code both nil in " +
-                                        "getDocuments publisher"])))
+                                       "InternalError - Return type and Error code both nil in " +
+                                       "getDocuments publisher"])))
           }
         }
       }
@@ -108,7 +107,6 @@
     public func snapshotPublisher() -> QuerySnapshotPublisher {
       return QuerySnapshotPublisher(self)
     }
-    
   }
 
 #endif

--- a/Firestore/Swift/Source/Combine/Query+Combine.swift
+++ b/Firestore/Swift/Source/Combine/Query+Combine.swift
@@ -16,79 +16,78 @@
 
 #if canImport(Combine)
   import Combine
-#endif
-import Foundation
-import FirebaseFirestore
 
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-extension Query {
+  import Foundation
+  import FirebaseFirestore
 
-  /**
-   * Reads the documents matching this query.
-   *
-   * This method returns a publisher that yields an array
-   * of `QuerySnapshot`s, requiring the user to extract the underlying
-   * `DocumentSnapshot`s before using them:
-   *
-   * ```
-   * let noBooks = [Book]()
-   * db.collection("books").getDocuments()
-   *   .map { querySnapshot in
-   *     querySnapshot.documents.compactMap { (queryDocumentSnapshot) in
-   *       return try? queryDocumentSnapshot.data(as: Book.self)
-   *     }
-   *   }
-   *   .replaceError(with: noBooks)
-   *   .assign(to: \.books, on: self)
-   *   .store(in: &cancellables)
-   * ```
-   */
-  public func getDocuments() -> AnyPublisher<QuerySnapshot, Error> {
-    Future<QuerySnapshot, Error> { [weak self] promise in
-      self?.getDocuments { (querySnapshot, error) in
-        if let error = error {
-          promise(.failure(error))
-        }
-        else if let querySnapshot = querySnapshot {
-          promise(.success(querySnapshot))
+  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
+  extension Query {
+    /**
+     * Reads the documents matching this query.
+     *
+     * This method returns a publisher that yields an array
+     * of `QuerySnapshot`s, requiring the user to extract the underlying
+     * `DocumentSnapshot`s before using them:
+     *
+     * ```
+     * let noBooks = [Book]()
+     * db.collection("books").getDocuments()
+     *   .map { querySnapshot in
+     *     querySnapshot.documents.compactMap { (queryDocumentSnapshot) in
+     *       return try? queryDocumentSnapshot.data(as: Book.self)
+     *     }
+     *   }
+     *   .replaceError(with: noBooks)
+     *   .assign(to: \.books, on: self)
+     *   .store(in: &cancellables)
+     * ```
+     */
+    public func getDocuments() -> AnyPublisher<QuerySnapshot, Error> {
+      Future<QuerySnapshot, Error> { [weak self] promise in
+        self?.getDocuments { querySnapshot, error in
+          if let error = error {
+            promise(.failure(error))
+          } 
+          else if let querySnapshot = querySnapshot {
+            promise(.success(querySnapshot))
+          }
         }
       }
+      .eraseToAnyPublisher()
     }
-    .eraseToAnyPublisher()
-  }
-  
-  /**
-   * Reads the documents matching this query.
-   *
-   * This method returns a publisher that yields an array
-   * of `DocumentSnapshot`s, allowing the user to easily iterate over
-   * the documents themselves:
-   *
-   * ```
-   * let noBooks = [Book]()
-   * db.collection("books").getDocuments2()
-   *   .map { documentSnapshots in
-   *     documentSnapshots.compactMap { documentSnapshot -> Book? in
-   *       return try? documentSnapshot.data(as: Book.self)
-   *     }
-   *   }
-   *   .replaceError(with: noBooks)
-   *   .assign(to: \.books, on: self)
-   *   .store(in: &cancellables)
-   * ```
-   */
-  public func getDocuments2() -> AnyPublisher<[DocumentSnapshot], Error> {
-    Future<[DocumentSnapshot], Error> { [weak self] promise in
-      self?.getDocuments(completion: { (querySnapshot, error) in
-        if let error = error {
-          promise(.failure(error))
-        }
-        else if let querySnapshot = querySnapshot {
-          promise(.success(querySnapshot.documents))
-        }
-      })
-    }
-    .eraseToAnyPublisher()
-  }
 
-}
+    /**
+     * Reads the documents matching this query.
+     *
+     * This method returns a publisher that yields an array
+     * of `DocumentSnapshot`s, allowing the user to easily iterate over
+     * the documents themselves:
+     *
+     * ```
+     * let noBooks = [Book]()
+     * db.collection("books").getDocuments2()
+     *   .map { documentSnapshots in
+     *     documentSnapshots.compactMap { documentSnapshot -> Book? in
+     *       return try? documentSnapshot.data(as: Book.self)
+     *     }
+     *   }
+     *   .replaceError(with: noBooks)
+     *   .assign(to: \.books, on: self)
+     *   .store(in: &cancellables)
+     * ```
+     */
+    public func getDocuments2() -> AnyPublisher<[DocumentSnapshot], Error> {
+      Future<[DocumentSnapshot], Error> { [weak self] promise in
+        self?.getDocuments(completion: { querySnapshot, error in
+          if let error = error {
+            promise(.failure(error))
+          } 
+          else if let querySnapshot = querySnapshot {
+            promise(.success(querySnapshot.documents))
+          }
+        })
+      }
+      .eraseToAnyPublisher()
+    }
+  }
+#endif

--- a/Firestore/Swift/Source/Combine/Query+Combine.swift
+++ b/Firestore/Swift/Source/Combine/Query+Combine.swift
@@ -47,8 +47,7 @@
         self?.getDocuments { querySnapshot, error in
           if let error = error {
             promise(.failure(error))
-          } 
-          else if let querySnapshot = querySnapshot {
+          } else if let querySnapshot = querySnapshot {
             promise(.success(querySnapshot))
           }
         }
@@ -81,8 +80,7 @@
         self?.getDocuments(completion: { querySnapshot, error in
           if let error = error {
             promise(.failure(error))
-          } 
-          else if let querySnapshot = querySnapshot {
+          } else if let querySnapshot = querySnapshot {
             promise(.success(querySnapshot.documents))
           }
         })

--- a/Firestore/Swift/Source/Combine/Query+Combine.swift
+++ b/Firestore/Swift/Source/Combine/Query+Combine.swift
@@ -22,6 +22,7 @@
 
   @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
   extension Query {
+    
     /**
      * Reads the documents matching this query.
      *
@@ -49,43 +50,17 @@
             promise(.failure(error))
           } else if let querySnapshot = querySnapshot {
             promise(.success(querySnapshot))
+          } else {
+            promise(.failure(NSError(domain: "FirebaseFirestoreSwift",
+                                     code: -1,
+                                     userInfo: [NSLocalizedDescriptionKey:
+                                        "InternalError - Return type and Error code both nil in " +
+                                        "getDocuments publisher"])))
           }
         }
       }
       .eraseToAnyPublisher()
     }
 
-    /**
-     * Reads the documents matching this query.
-     *
-     * This method returns a publisher that yields an array
-     * of `DocumentSnapshot`s, allowing the user to easily iterate over
-     * the documents themselves:
-     *
-     * ```
-     * let noBooks = [Book]()
-     * db.collection("books").getDocuments2()
-     *   .map { documentSnapshots in
-     *     documentSnapshots.compactMap { documentSnapshot -> Book? in
-     *       return try? documentSnapshot.data(as: Book.self)
-     *     }
-     *   }
-     *   .replaceError(with: noBooks)
-     *   .assign(to: \.books, on: self)
-     *   .store(in: &cancellables)
-     * ```
-     */
-    public func getDocuments2() -> AnyPublisher<[DocumentSnapshot], Error> {
-      Future<[DocumentSnapshot], Error> { [weak self] promise in
-        self?.getDocuments(completion: { querySnapshot, error in
-          if let error = error {
-            promise(.failure(error))
-          } else if let querySnapshot = querySnapshot {
-            promise(.success(querySnapshot.documents))
-          }
-        })
-      }
-      .eraseToAnyPublisher()
-    }
   }
 #endif

--- a/Firestore/Swift/Source/Combine/Query+Combine.swift
+++ b/Firestore/Swift/Source/Combine/Query+Combine.swift
@@ -20,59 +20,75 @@
 import Foundation
 import FirebaseFirestore
 
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
 extension Query {
 
-  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-  struct DocumentPublisher<Output: DocumentSnapshot>: Publisher {
-    typealias Output = DocumentSnapshot
-    typealias Failure = Error
-    
-    private let query: Query
-    
-    init(query: Query) {
-      self.query = query
-    }
-    
-    func receive<S>(subscriber: S) where S : Subscriber, Self.Failure == S.Failure, Self.Output == S.Input {
-      let subscription = DocumentSubscription(subscriber: subscriber, query: query)
-      subscriber.receive(subscription: subscription)
-    }
-    
-  }
-  
-  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-  public func getDocuments() -> AnyPublisher<DocumentSnapshot, Error> {
-    return DocumentPublisher(query: self).eraseToAnyPublisher()
-  }
-
-  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-  public func dummyPublisher() -> AnyPublisher<Int, Never> {
-    return Just(42).eraseToAnyPublisher()
-  }  
-  
-}
-
-@available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-extension Query.DocumentPublisher {
-  
-  @available(iOS 13.0, macOS 10.15, tvOS 13.0, *)
-  class DocumentSubscription<S: Subscriber>: Subscription where S.Input == DocumentSnapshot, S.Failure == Error {
-    private let query: Query
-    private var subscriber: S?
-    
-    init(subscriber: S, query: Query) {
-      self.subscriber = subscriber
-      self.query = query
-    }
-    
-    func request(_ demand: Subscribers.Demand) {
-      if (demand > 0) {
+  /**
+   * Reads the documents matching this query.
+   *
+   * This method returns a publisher that yields an array
+   * of `DocumentSnapshot`s, allowing the user to easily iterate over
+   * the documents themselves:
+   *
+   * ```
+   * let noBooks = [Book]()
+   * db.collection("books").getDocuments()
+   *   .map { querySnapshot in
+   *     querySnapshot.documents.compactMap { (queryDocumentSnapshot) in
+   *       return try? queryDocumentSnapshot.data(as: Book.self)
+   *     }
+   *   }
+   *   .replaceError(with: noBooks)
+   *   .assign(to: \.books, on: self)
+   *   .store(in: &cancellables)
+   * ```
+   */
+  public func getDocuments() -> AnyPublisher<QuerySnapshot, Error> {
+    Future<QuerySnapshot, Error> { [weak self] promise in
+      self?.getDocuments { (querySnapshot, error) in
+        if let error = error {
+          promise(.failure(error))
+        }
+        else if let querySnapshot = querySnapshot {
+          promise(.success(querySnapshot))
+        }
       }
     }
-    
-    func cancel() {
-      subscriber = nil
+    .eraseToAnyPublisher()
+  }
+  
+  /**
+   * Reads the documents matching this query.
+   *
+   * This method returns a publisher that yields an array
+   * of `DocumentSnapshot`s, allowing the user to easily iterate over
+   * the documents themselves:
+   *
+   * ```
+   * let noBooks = [Book]()
+   * db.collection("books").getDocuments2()
+   *   .map { documentSnapshots in
+   *     documentSnapshots.compactMap { documentSnapshot -> Book? in
+   *       return try? documentSnapshot.data(as: Book.self)
+   *     }
+   *   }
+   *   .replaceError(with: noBooks)
+   *   .assign(to: \.books, on: self)
+   *   .store(in: &cancellables)
+   * ```
+   */
+  public func getDocuments2() -> AnyPublisher<[DocumentSnapshot], Error> {
+    Future<[DocumentSnapshot], Error> { [weak self] promise in
+      self?.getDocuments(completion: { (querySnapshot, error) in
+        if let error = error {
+          promise(.failure(error))
+        }
+        else if let querySnapshot = querySnapshot {
+          promise(.success(querySnapshot.documents))
+        }
+      })
     }
+    .eraseToAnyPublisher()
   }
 
 }


### PR DESCRIPTION
Here are two proposals for a publisher for Query.getDocuments().

There are two versions, one yielding `QuerySnapshot`s, the other one yielding `DocumentSnapshot`s.

Here is a code snippet using the traditional APIs:

```swift
    db.collection("books").getDocuments { (querySnapshot, error) in
      guard let documents = querySnapshot?.documents else {
        print("No documents")
        return
      }

      self.books = documents.compactMap { queryDocumentSnapshot -> Book? in
        return try? queryDocumentSnapshot.data(as: Book.self)
      }
    }
```

Here is how this looks with the publisher yielding `QuerySnapshot`s:

```swift
    let noBooks = [Book]()
    db.collection("books").getDocuments()
      .map { querySnapshot in
        querySnapshot.documents.compactMap { (queryDocumentSnapshot) in
          return try? queryDocumentSnapshot.data(as: Book.self)
        }
      }
      .replaceError(with: noBooks)
      .assign(to: \.books, on: self)
      .store(in: &cancellables)
```

And here is how it looks for the publisher yielding `DocumentSnapshot`s:

```swift
    db.collection("books").getDocuments2()
      .map { documentSnapshots in
        documentSnapshots.compactMap { documentSnapshot -> Book? in
          return try? documentSnapshot.data(as: Book.self)
        }
      }
      .replaceError(with: noBooks)
      .assign(to: \.books, on: self)
      .store(in: &cancellables)
```