### PR TITLE
Update Podfile for GDTCCTWatchOSTestApp

### DIFF
--- a/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/Podfile
+++ b/GoogleDataTransportCCTSupport/GDTCCTWatchOSTestApp/Podfile
@@ -1,5 +1,8 @@
 use_frameworks!
 
+source 'https://github.com/firebase/SpecsStaging.git'
+source 'https://cdn.cocoapods.org/'
+
 target 'GDTCCTWatchOSIndependentTestAppWatchKitExtension' do
   platform :watchos, '6.0'
 


### PR DESCRIPTION
Fix GDTCCTWatchOSTestApp pod build failure caused by nanopb update https://github.com/firebase/firebase-ios-sdk/pull/4264, ref. https://github.com/firebase/firebase-ios-sdk/pull/5483

#no-changelog