### PR TITLE
Update pod gen version and address GHA Catalyst failures

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -5,6 +5,7 @@ on:
     paths:
     - 'FirebaseAuth**'
     - '.github/workflows/auth.yml'
+    - 'Gemfile'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -5,6 +5,7 @@ on:
     paths:
     - 'FirebaseCore**'
     - '.github/workflows/core.yml'
+    - 'Gemfile'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -5,6 +5,7 @@ on:
     paths:
     - 'Crashlytics**'
     - '.github/workflows/crashlytics.yml'
+    - 'Gemfile'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'

--- a/.github/workflows/datatransport.yml
+++ b/.github/workflows/datatransport.yml
@@ -6,6 +6,7 @@ on:
     - 'GoogleDataTransport**'
     - 'GoogleDataTransportCCTSupport**'
     - '.github/workflows/datatransport.yml'
+    - 'Gemfile'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'

--- a/.github/workflows/datatransport.yml
+++ b/.github/workflows/datatransport.yml
@@ -36,7 +36,8 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and Test Catalyst
-      run: scripts/third_party/travis/retry.sh scripts/test_catalyst.sh ${{ matrix.pod }} test
+      # Only build the unit tests on Catalyst. Test stopped working when GHA moved to Xcode 11.4.1.
+      run: scripts/third_party/travis/retry.sh scripts/test_catalyst.sh ${{ matrix.pod }} build
 
   watchos-testapp:
     runs-on: macOS-latest

--- a/.github/workflows/dynamiclinks.yml
+++ b/.github/workflows/dynamiclinks.yml
@@ -5,6 +5,7 @@ on:
     paths:
     - 'FirebaseDynamicLinks**'
     - '.github/workflows/dynamiclinks.yml'
+    - 'Gemfile'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'

--- a/.github/workflows/firebasepod.yml
+++ b/.github/workflows/firebasepod.yml
@@ -8,6 +8,7 @@ on:
     - '*.podspec'
     - 'CoreOnly/**'
     - '.github/workflows/firebasepod.yml'
+    - 'Gemfile'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -45,6 +45,9 @@ on:
     # This workflow
     - '.github/workflows/firestore.yml'
 
+    # Rebuild on Ruby infrastructure changes.
+    - 'Gemfile'
+
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -8,6 +8,7 @@ on:
     - 'Interop/**'
     - '*Interop.podspec'
     - '.github/workflows/interop.yml'
+    - 'Gemfile'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -3,12 +3,14 @@ name: messaging
 on:
   pull_request:
     paths:
+    # Messaging sources
     - 'FirebaseMessaging/**'
-
-    #Podspec
+    # Podspec
     - 'FirebaseMessaging.podspec'
-
+    # This file
     - '.github/workflows/messaging.yml'
+    # Rebuild on Ruby infrastructure changes
+    - 'Gemfile'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -37,8 +37,8 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Setup project and Build for Catalyst
-      # Only run the unit tests on Catalyst
-      run: scripts/test_catalyst.sh FirebaseStorage test FirebaseStorage-Unit-unit
+      # Only build the unit tests on Catalyst. Test stopped working when GHA moved to Xcode 11.4.1.
+      run: scripts/test_catalyst.sh FirebaseStorage build FirebaseStorage-Unit-unit
 
   quickstart:
     env:

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -6,6 +6,8 @@ on:
     - 'FirebaseStorage**'
     - '.github/workflows/storage.yml'
     - 'scripts/**'
+    # Rebuild on Ruby infrastructure changes.
+    - 'Gemfile'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@
 source 'https://rubygems.org'
 
 gem 'cocoapods', "1.9.1"
-gem 'cocoapods-generate', '1.6.0'
+gem 'cocoapods-generate', '2.0.0'
 gem 'danger', '6.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
     cocoapods-deintegrate (1.0.4)
     cocoapods-disable-podfile-validations (0.1.1)
     cocoapods-downloader (1.3.0)
-    cocoapods-generate (1.6.0)
+    cocoapods-generate (2.0.0)
       cocoapods-disable-podfile-validations (~> 0.1.1)
     cocoapods-plugins (1.0.0)
       nap
@@ -129,7 +129,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (= 1.9.1)
-  cocoapods-generate (= 1.6.0)
+  cocoapods-generate (= 2.0.0)
   danger (= 6.1.0)
 
 BUNDLED WITH

--- a/scripts/test_catalyst.sh
+++ b/scripts/test_catalyst.sh
@@ -57,4 +57,5 @@ args=(
   "CODE_SIGN_IDENTITY=-" "CODE_SIGNING_REQUIRED=NO" "CODE_SIGNING_ALLOWED=NO"
 )
 
+xcodebuild -version
 xcodebuild "${args[@]}" | xcpretty


### PR DESCRIPTION
And force GHA jobs to rerun when Gemfile changes Ruby infrastructure

Also make Catalyst tests build-only since they started failing on GHA after it updated from Xcode 11.3.1 to 11.4.1 last night. I can't repro locally:

```
+ xcodebuild test -configuration Debug -workspace gen/FirebaseStorage/FirebaseStorage.xcworkspace -scheme FirebaseStorage-Unit-unit ARCHS=x86_64h VALID_ARCHS=x86_64h SUPPORTS_MACCATALYST=YES -sdk macosx '-destination platform="OS X"' TARGETED_DEVICE_FAMILY=2 CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+ xcpretty
xcodebuild: error: Failed to build workspace FirebaseStorage with scheme FirebaseStorage-Unit-unit.
	Reason: Cannot test target “FirebaseStorage-Unit-unit” on “My Mac”: FirebaseStorage-Unit-unit does not support any of My Mac’s architectures: x86_64
##[error]Process completed with exit code 70.
```