### PR TITLE
Add failure reason to messaging NSError 

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# unreleased
+- [changed] Updated NSError with a failure reason to give more details on the error.
+
 # 2020-04 -- v4.4.0
 - [changed] Changed the location of source under FirebaseMessaging folder to fit the current repository organization.
 

--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -583,9 +583,8 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
     FIRMessagingLoggerError(kFIRMessagingMessageCodeSenderIDNotSuppliedForTokenFetch, @"%@",
                             description);
     if (completion) {
-      NSError *error = [NSError
-          messagingErrorWithCode:(FIRMessagingInternalErrorCode)FIRMessagingErrorInvalidRequest
-                   failureReason:description];
+      NSError *error = [NSError messagingErrorWithCode:kFIRMessagingErrorCodeInvalidRequest
+                                         failureReason:description];
       completion(nil, error);
     }
     return;
@@ -615,9 +614,8 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
     FIRMessagingLoggerError(kFIRMessagingMessageCodeSenderIDNotSuppliedForTokenDelete, @"%@",
                             description);
     if (completion) {
-      NSError *error = [NSError
-          messagingErrorWithCode:(FIRMessagingInternalErrorCode)FIRMessagingErrorInvalidRequest
-                   failureReason:description];
+      NSError *error = [NSError messagingErrorWithCode:kFIRMessagingErrorCodeInvalidRequest
+                                         failureReason:description];
       completion(error);
     }
     return;
@@ -791,9 +789,8 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
         [NSString stringWithFormat:@"Cannot parse topic name: '%@'. Will not subscribe.", topic];
     FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging009, @"%@", failureReason);
     if (completion) {
-      completion([NSError
-          messagingErrorWithCode:(FIRMessagingInternalErrorCode)FIRMessagingErrorInvalidTopicName
-                   failureReason:failureReason]);
+      completion([NSError messagingErrorWithCode:kFIRMessagingErrorCodeInvalidTopicName
+                                   failureReason:failureReason]);
     }
   }];
 }
@@ -832,9 +829,8 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
         [NSString stringWithFormat:@"Cannot parse topic name: '%@'. Will not unsubscribe.", topic];
     FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging011, @"%@", failureReason);
     if (completion) {
-      completion([NSError
-          messagingErrorWithCode:(FIRMessagingInternalErrorCode)FIRMessagingErrorInvalidTopicName
-                   failureReason:failureReason]);
+      completion([NSError messagingErrorWithCode:kFIRMessagingErrorCodeInvalidTopicName
+                                   failureReason:failureReason]);
     }
   }];
 }

--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -610,11 +610,11 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 - (void)deleteFCMTokenForSenderID:(nonnull NSString *)senderID
                        completion:(nonnull FIRMessagingDeleteFCMTokenCompletion)completion {
   if (!senderID.length) {
-    FIRMessagingLoggerError(kFIRMessagingMessageCodeSenderIDNotSuppliedForTokenDelete,
-                            @"Sender ID not supplied. It is required to delete an FCM token.");
+    NSString *description = @"Couldn't delete token because a Sender ID was not supplied. A "
+                            @"valid Sender ID is required to delete an FCM token";
+    FIRMessagingLoggerError(kFIRMessagingMessageCodeSenderIDNotSuppliedForTokenDelete, @"%@",
+                            description);
     if (completion) {
-      NSString *description = @"Couldn't delete token because a Sender ID was not supplied. A "
-                              @"valid Sender ID is required to delete an FCM token";
       NSError *error = [NSError
           messagingErrorWithCode:(FIRMessagingInternalErrorCode)FIRMessagingErrorInvalidRequest
                    failureReason:description];

--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -578,14 +578,14 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
 - (void)retrieveFCMTokenForSenderID:(nonnull NSString *)senderID
                          completion:(nonnull FIRMessagingFCMTokenFetchCompletion)completion {
   if (!senderID.length) {
-    FIRMessagingLoggerError(kFIRMessagingMessageCodeSenderIDNotSuppliedForTokenFetch,
-                            @"Sender ID not supplied. It is required for a token fetch, "
-                            @"to identify the sender.");
+    NSString *description = @"Couldn't fetch token because a Sender ID was not supplied. A valid "
+                            @"Sender ID is required to fetch an FCM token";
+    FIRMessagingLoggerError(kFIRMessagingMessageCodeSenderIDNotSuppliedForTokenFetch, @"%@",
+                            description);
     if (completion) {
-      NSString *description = @"Couldn't fetch token because a Sender ID was not supplied. A valid "
-                              @"Sender ID is required to fetch an FCM token";
-      NSError *error = [NSError fcm_errorWithCode:FIRMessagingErrorInvalidRequest
-                                         userInfo:@{NSLocalizedDescriptionKey : description}];
+      NSError *error = [NSError
+          messagingErrorWithCode:(FIRMessagingInternalErrorCode)FIRMessagingErrorInvalidRequest
+                   failureReason:description];
       completion(nil, error);
     }
     return;
@@ -615,8 +615,9 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
     if (completion) {
       NSString *description = @"Couldn't delete token because a Sender ID was not supplied. A "
                               @"valid Sender ID is required to delete an FCM token";
-      NSError *error = [NSError fcm_errorWithCode:FIRMessagingErrorInvalidRequest
-                                         userInfo:@{NSLocalizedDescriptionKey : description}];
+      NSError *error = [NSError
+          messagingErrorWithCode:(FIRMessagingInternalErrorCode)FIRMessagingErrorInvalidRequest
+                   failureReason:description];
       completion(error);
     }
     return;
@@ -786,10 +787,13 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
       [strongSelf.pubsub subscribeToTopic:normalizeTopic handler:completion];
       return;
     }
-    FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging009,
-                            @"Cannot parse topic name %@. Will not subscribe.", topic);
+    NSString *failureReason =
+        [NSString stringWithFormat:@"Cannot parse topic name %@. Will not subscribe.", topic];
+    FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging009, @"%@", failureReason);
     if (completion) {
-      completion([NSError fcm_errorWithCode:FIRMessagingErrorInvalidTopicName userInfo:nil]);
+      completion([NSError
+          messagingErrorWithCode:(FIRMessagingInternalErrorCode)FIRMessagingErrorInvalidTopicName
+                   failureReason:failureReason]);
     }
   }];
 }
@@ -824,10 +828,13 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
       [strongSelf.pubsub unsubscribeFromTopic:normalizeTopic handler:completion];
       return;
     }
-    FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging011,
-                            @"Cannot parse topic name %@. Will not unsubscribe.", topic);
+    NSString *failureReason =
+        [NSString stringWithFormat:@"Cannot parse topic name %@. Will not unsubscribe.", topic];
+    FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging011, @"%@", failureReason);
     if (completion) {
-      completion([NSError fcm_errorWithCode:FIRMessagingErrorInvalidTopicName userInfo:nil]);
+      completion([NSError
+          messagingErrorWithCode:(FIRMessagingInternalErrorCode)FIRMessagingErrorInvalidTopicName
+                   failureReason:failureReason]);
     }
   }];
 }

--- a/FirebaseMessaging/Sources/FIRMessaging.m
+++ b/FirebaseMessaging/Sources/FIRMessaging.m
@@ -788,7 +788,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
       return;
     }
     NSString *failureReason =
-        [NSString stringWithFormat:@"Cannot parse topic name %@. Will not subscribe.", topic];
+        [NSString stringWithFormat:@"Cannot parse topic name: '%@'. Will not subscribe.", topic];
     FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging009, @"%@", failureReason);
     if (completion) {
       completion([NSError
@@ -829,7 +829,7 @@ BOOL FIRMessagingIsContextManagerMessage(NSDictionary *message) {
       return;
     }
     NSString *failureReason =
-        [NSString stringWithFormat:@"Cannot parse topic name %@. Will not unsubscribe.", topic];
+        [NSString stringWithFormat:@"Cannot parse topic name: '%@'. Will not unsubscribe.", topic];
     FIRMessagingLoggerError(kFIRMessagingMessageCodeMessaging011, @"%@", failureReason);
     if (completion) {
       completion([NSError

--- a/FirebaseMessaging/Sources/FIRMessagingClient.m
+++ b/FirebaseMessaging/Sources/FIRMessagingClient.m
@@ -494,7 +494,7 @@ static NSUInteger FIRMessagingServerPort() {
     // disconnect before issuing a callback
     [self disconnectWithTryToConnectLater:YES];
     NSError *error =
-        [NSError messagingErrorWithCode:(FIRMessagingInternalErrorCode)FIRMessagingErrorNetwork
+        [NSError messagingErrorWithCode:kFIRMessagingErrorCodeNetwork
                           failureReason:@"No internet available, cannot connect to FIRMessaging"];
     if (handler) {
       handler(error);

--- a/FirebaseMessaging/Sources/FIRMessagingClient.m
+++ b/FirebaseMessaging/Sources/FIRMessagingClient.m
@@ -491,9 +491,8 @@ static NSUInteger FIRMessagingServerPort() {
     // disconnect before issuing a callback
     [self disconnectWithTryToConnectLater:YES];
     NSError *error =
-        [NSError errorWithDomain:@"No internet available, cannot connect to FIRMessaging"
-                            code:kFIRMessagingErrorCodeNetwork
-                        userInfo:nil];
+        [NSError messagingErrorWithCode:(FIRMessagingInternalErrorCode)FIRMessagingErrorNetwork
+                          failureReason:@"No internet available, cannot connect to FIRMessaging"];
     if (handler) {
       handler(error);
       self.connectHandler = nil;

--- a/FirebaseMessaging/Sources/FIRMessagingClient.m
+++ b/FirebaseMessaging/Sources/FIRMessagingClient.m
@@ -195,7 +195,8 @@ static NSUInteger FIRMessagingServerPort() {
                                  shouldDelete:shouldDelete
                                       handler:completion];
   } else {
-    NSString *failureReason = @"Device check in error, no auth credentials found";
+    NSString *failureReason = @"Device ID and checkin info is not found. Will not proceed with "
+                              @"subscription/unsubscription.";
     FIRMessagingLoggerDebug(kFIRMessagingMessageCodeRegistrar000, @"%@", failureReason);
     NSError *error = [NSError messagingErrorWithCode:kFIRMessagingErrorCodeMissingDeviceID
                                        failureReason:failureReason];
@@ -267,8 +268,10 @@ static NSUInteger FIRMessagingServerPort() {
 
 - (void)connectWithHandler:(FIRMessagingConnectCompletionHandler)handler {
   if (self.isConnected) {
-    NSError *error = [NSError messagingErrorWithCode:kFIRMessagingErrorCodeAlreadyConnected
-                                       failureReason:@"FIRMessaging is already connected"];
+    NSError *error =
+        [NSError messagingErrorWithCode:kFIRMessagingErrorCodeAlreadyConnected
+                          failureReason:
+                              @"FIRMessaging is already connected. Will not try to connect again."];
     handler(error);
     return;
   }

--- a/FirebaseMessaging/Sources/FIRMessagingDataMessageManager.m
+++ b/FirebaseMessaging/Sources/FIRMessagingDataMessageManager.m
@@ -274,7 +274,7 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
   }
 
   if (![to length]) {
-    [self willSendDataMessageFail:stanza withMessageId:msgId error:kFIRMessagingErrorMissingTo];
+    [self willSendDataMessageFail:stanza withMessageId:msgId error:kFIRMessagingErrorCodeMissingTo];
     return;
   }
   [stanza setTo:to];
@@ -288,7 +288,9 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
 
   int size = [self addData:dataMessage[KFIRMessagingSendMessageAppData] toStanza:stanza];
   if (size > kMaxAppDataSizeDefault) {
-    [self willSendDataMessageFail:stanza withMessageId:msgId error:kFIRMessagingErrorSizeExceeded];
+    [self willSendDataMessageFail:stanza
+                    withMessageId:msgId
+                            error:kFIRMessagingErrorCodeSizeExceeded];
     return;
   }
 
@@ -299,7 +301,7 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
                  if (!success) {
                    [self willSendDataMessageFail:stanza
                                    withMessageId:msgId
-                                           error:kFIRMessagingErrorSave];
+                                           error:kFIRMessagingErrorCodeSave];
                    return;
                  }
                  [self willSendDataMessageSuccess:stanza withMessageId:msgId];
@@ -322,9 +324,7 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
       NSString *event __unused = [NSString stringWithFormat:@"Queued message: %@", [stanza id_p]];
       FIRMessagingLoggerDebug(kFIRMessagingMessageCodeDataMessageManager007, @"%@", event);
     } else {
-      [self willSendDataMessageFail:stanza
-                      withMessageId:msgId
-                              error:(FIRMessagingInternalErrorCode)FIRMessagingErrorNetwork];
+      [self willSendDataMessageFail:stanza withMessageId:msgId error:kFIRMessagingErrorCodeNetwork];
       return;
     }
   }
@@ -405,7 +405,7 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
  */
 - (void)willSendDataMessageFail:(GtalkDataMessageStanza *)stanza
                   withMessageId:(NSString *)messageId
-                          error:(FIRMessagingInternalErrorCode)errorCode {
+                          error:(FIRMessagingErrorCode)errorCode {
   NSString *failureReason = [NSString
       stringWithFormat:@"Send message fail: %@ error: %lu", messageId, (unsigned long)errorCode];
   FIRMessagingLoggerDebug(kFIRMessagingMessageCodeDataMessageManager011, @"%@", failureReason);
@@ -462,7 +462,7 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
   if (now > message.sent + message.ttl) {
     [self willSendDataMessageFail:message
                     withMessageId:message.id_p
-                            error:kFIRMessagingErrorServiceNotAvailable];
+                            error:kFIRMessagingErrorCodeServiceNotAvailable];
     return NO;
   }
   return YES;

--- a/FirebaseMessaging/Sources/FIRMessagingDataMessageManager.m
+++ b/FirebaseMessaging/Sources/FIRMessagingDataMessageManager.m
@@ -322,7 +322,9 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
       NSString *event __unused = [NSString stringWithFormat:@"Queued message: %@", [stanza id_p]];
       FIRMessagingLoggerDebug(kFIRMessagingMessageCodeDataMessageManager007, @"%@", event);
     } else {
-      [self willSendDataMessageFail:stanza withMessageId:msgId error:kFIRMessagingErrorCodeNetwork];
+      [self willSendDataMessageFail:stanza
+                      withMessageId:msgId
+                              error:(FIRMessagingInternalErrorCode)FIRMessagingErrorNetwork];
       return;
     }
   }

--- a/FirebaseMessaging/Sources/FIRMessagingDataMessageManager.m
+++ b/FirebaseMessaging/Sources/FIRMessagingDataMessageManager.m
@@ -404,10 +404,11 @@ typedef NS_ENUM(int8_t, UpstreamForceReconnect) {
 - (void)willSendDataMessageFail:(GtalkDataMessageStanza *)stanza
                   withMessageId:(NSString *)messageId
                           error:(FIRMessagingInternalErrorCode)errorCode {
-  FIRMessagingLoggerDebug(kFIRMessagingMessageCodeDataMessageManager011,
-                          @"Send message fail: %@ error: %lu", messageId, (unsigned long)errorCode);
+  NSString *failureReason = [NSString
+      stringWithFormat:@"Send message fail: %@ error: %lu", messageId, (unsigned long)errorCode];
+  FIRMessagingLoggerDebug(kFIRMessagingMessageCodeDataMessageManager011, @"%@", failureReason);
 
-  NSError *error = [NSError errorWithFCMErrorCode:errorCode];
+  NSError *error = [NSError messagingErrorWithCode:errorCode failureReason:failureReason];
   if ([self.delegate respondsToSelector:@selector(willSendDataMessageWithID:error:)]) {
     [self.delegate willSendDataMessageWithID:messageId error:error];
   }

--- a/FirebaseMessaging/Sources/FIRMessagingPubSub.m
+++ b/FirebaseMessaging/Sources/FIRMessagingPubSub.m
@@ -78,8 +78,9 @@ static NSString *const kPendingSubscriptionsListKey =
   if (![[self class] isValidTopicWithPrefix:topic]) {
     NSString *failureReason = [NSString stringWithFormat:@"Invalid subscription topic %@", topic];
     FIRMessagingLoggerError(kFIRMessagingMessageCodePubSub000, @"%@", failureReason);
-    handler([NSError messagingErrorWithCode:kFIRMessagingErrorCodePubSubInvalidTopic
-                              failureReason:failureReason]);
+    handler([NSError
+        messagingErrorWithCode:(FIRMessagingInternalErrorCode)FIRMessagingErrorInvalidTopicName
+                 failureReason:failureReason]);
     return;
   }
 
@@ -122,8 +123,9 @@ static NSString *const kPendingSubscriptionsListKey =
     NSString *failureReason =
         [NSString stringWithFormat:@"Invalid FIRMessaging Pubsub topic %@", topic];
     FIRMessagingLoggerError(kFIRMessagingMessageCodePubSub002, @"%@", failureReason);
-    handler([NSError messagingErrorWithCode:kFIRMessagingErrorCodePubSubInvalidTopic
-                              failureReason:failureReason]);
+    handler([NSError
+        messagingErrorWithCode:(FIRMessagingInternalErrorCode)FIRMessagingErrorInvalidTopicName
+                 failureReason:failureReason]);
     return;
   }
   if (![self verifyPubSubOptions:options]) {

--- a/FirebaseMessaging/Sources/FIRMessagingPubSub.m
+++ b/FirebaseMessaging/Sources/FIRMessagingPubSub.m
@@ -76,7 +76,8 @@ static NSString *const kPendingSubscriptionsListKey =
   }
 
   if (![[self class] isValidTopicWithPrefix:topic]) {
-    NSString *failureReason = [NSString stringWithFormat:@"Invalid subscription topic %@", topic];
+    NSString *failureReason =
+        [NSString stringWithFormat:@"Invalid subscription topic :'%@'", topic];
     FIRMessagingLoggerError(kFIRMessagingMessageCodePubSub000, @"%@", failureReason);
     handler([NSError
         messagingErrorWithCode:(FIRMessagingInternalErrorCode)FIRMessagingErrorInvalidTopicName
@@ -121,7 +122,7 @@ static NSString *const kPendingSubscriptionsListKey =
 
   if (![[self class] isValidTopicWithPrefix:topic]) {
     NSString *failureReason =
-        [NSString stringWithFormat:@"Invalid FIRMessaging Pubsub topic %@", topic];
+        [NSString stringWithFormat:@"Invalid topic name : '%@' for unsubscription.", topic];
     FIRMessagingLoggerError(kFIRMessagingMessageCodePubSub002, @"%@", failureReason);
     handler([NSError
         messagingErrorWithCode:(FIRMessagingInternalErrorCode)FIRMessagingErrorInvalidTopicName

--- a/FirebaseMessaging/Sources/FIRMessagingPubSub.m
+++ b/FirebaseMessaging/Sources/FIRMessagingPubSub.m
@@ -61,7 +61,10 @@ static NSString *const kPendingSubscriptionsListKey =
                    options:(NSDictionary *)options
                    handler:(FIRMessagingTopicOperationCompletion)handler {
   if (!self.client) {
-    handler([NSError errorWithFCMErrorCode:kFIRMessagingErrorCodePubSubFIRMessagingNotSetup]);
+    handler([NSError
+        messagingErrorWithCode:kFIRMessagingErrorCodePubSubClientNotSetup
+                 failureReason:@"Firebase Messaging Client does not exist. Firebase Messaging was "
+                               @"not setup property and subscription failed."]);
     return;
   }
 
@@ -73,9 +76,10 @@ static NSString *const kPendingSubscriptionsListKey =
   }
 
   if (![[self class] isValidTopicWithPrefix:topic]) {
-    FIRMessagingLoggerError(kFIRMessagingMessageCodePubSub000,
-                            @"Invalid FIRMessaging Pubsub topic %@", topic);
-    handler([NSError errorWithFCMErrorCode:kFIRMessagingErrorCodePubSubInvalidTopic]);
+    NSString *failureReason = [NSString stringWithFormat:@"Invalid subscription topic %@", topic];
+    FIRMessagingLoggerError(kFIRMessagingMessageCodePubSub000, @"%@", failureReason);
+    handler([NSError messagingErrorWithCode:kFIRMessagingErrorCodePubSubInvalidTopic
+                              failureReason:failureReason]);
     return;
   }
 
@@ -102,7 +106,10 @@ static NSString *const kPendingSubscriptionsListKey =
                      options:(NSDictionary *)options
                      handler:(FIRMessagingTopicOperationCompletion)handler {
   if (!self.client) {
-    handler([NSError errorWithFCMErrorCode:kFIRMessagingErrorCodePubSubFIRMessagingNotSetup]);
+    handler([NSError
+        messagingErrorWithCode:kFIRMessagingErrorCodePubSubClientNotSetup
+                 failureReason:@"Firebase Messaging Client does not exist. Firebase Messaging was "
+                               @"not setup property and subscription failed."]);
     return;
   }
   token = [token copy];
@@ -112,9 +119,11 @@ static NSString *const kPendingSubscriptionsListKey =
   }
 
   if (![[self class] isValidTopicWithPrefix:topic]) {
-    FIRMessagingLoggerError(kFIRMessagingMessageCodePubSub002,
-                            @"Invalid FIRMessaging Pubsub topic %@", topic);
-    handler([NSError errorWithFCMErrorCode:kFIRMessagingErrorCodePubSubInvalidTopic]);
+    NSString *failureReason =
+        [NSString stringWithFormat:@"Invalid FIRMessaging Pubsub topic %@", topic];
+    FIRMessagingLoggerError(kFIRMessagingMessageCodePubSub002, @"%@", failureReason);
+    handler([NSError messagingErrorWithCode:kFIRMessagingErrorCodePubSubInvalidTopic
+                              failureReason:failureReason]);
     return;
   }
   if (![self verifyPubSubOptions:options]) {

--- a/FirebaseMessaging/Sources/FIRMessagingPubSub.m
+++ b/FirebaseMessaging/Sources/FIRMessagingPubSub.m
@@ -79,9 +79,8 @@ static NSString *const kPendingSubscriptionsListKey =
     NSString *failureReason =
         [NSString stringWithFormat:@"Invalid subscription topic :'%@'", topic];
     FIRMessagingLoggerError(kFIRMessagingMessageCodePubSub000, @"%@", failureReason);
-    handler([NSError
-        messagingErrorWithCode:(FIRMessagingInternalErrorCode)FIRMessagingErrorInvalidTopicName
-                 failureReason:failureReason]);
+    handler([NSError messagingErrorWithCode:kFIRMessagingErrorCodeInvalidTopicName
+                              failureReason:failureReason]);
     return;
   }
 
@@ -124,9 +123,8 @@ static NSString *const kPendingSubscriptionsListKey =
     NSString *failureReason =
         [NSString stringWithFormat:@"Invalid topic name : '%@' for unsubscription.", topic];
     FIRMessagingLoggerError(kFIRMessagingMessageCodePubSub002, @"%@", failureReason);
-    handler([NSError
-        messagingErrorWithCode:(FIRMessagingInternalErrorCode)FIRMessagingErrorInvalidTopicName
-                 failureReason:failureReason]);
+    handler([NSError messagingErrorWithCode:kFIRMessagingErrorCodeInvalidTopicName
+                              failureReason:failureReason]);
     return;
   }
   if (![self verifyPubSubOptions:options]) {

--- a/FirebaseMessaging/Sources/FIRMessagingTopicOperation.m
+++ b/FirebaseMessaging/Sources/FIRMessagingTopicOperation.m
@@ -120,10 +120,10 @@ NSString *FIRMessagingSubscriptionsServer() {
 
 - (void)start {
   if (self.isCancelled) {
-    NSError *error =
-        [NSError messagingErrorWithCode:kFIRMessagingErrorCodePubSubOperationIsCancelled
-                          failureReason:
-                              @"Failed to start the pubsub service as the operation is cancelled."];
+    NSError *error = [NSError
+        messagingErrorWithCode:kFIRMessagingErrorCodePubSubOperationIsCancelled
+                 failureReason:
+                     @"Failed to start the pubsub service as the topic operation is cancelled."];
     [self finishWithError:error];
     return;
   }
@@ -151,7 +151,7 @@ NSString *FIRMessagingSubscriptionsServer() {
   [super cancel];
   [self.dataTask cancel];
   NSError *error = [NSError messagingErrorWithCode:kFIRMessagingErrorCodePubSubOperationIsCancelled
-                                     failureReason:@"The pubsub service is cancelled."];
+                                     failureReason:@"The topic operation is cancelled."];
   [self finishWithError:error];
 }
 
@@ -223,8 +223,9 @@ NSString *FIRMessagingSubscriptionsServer() {
         }
         NSArray *parts = [response componentsSeparatedByString:@"="];
         if (![parts[0] isEqualToString:@"token"] || parts.count <= 1) {
-          NSString *failureReason =
-              [NSString stringWithFormat:@"Invalid registration response %@", response];
+          NSString *failureReason = [NSString
+              stringWithFormat:@"Invalid registration response :'%@'. It is missing 'token' field.",
+                               response];
           FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTopicOption002, @"%@", failureReason);
           [self finishWithError:[NSError messagingErrorWithCode:(FIRMessagingInternalErrorCode)
                                                                     FIRMessagingErrorUnknown

--- a/FirebaseMessaging/Sources/FIRMessagingTopicOperation.m
+++ b/FirebaseMessaging/Sources/FIRMessagingTopicOperation.m
@@ -216,8 +216,7 @@ NSString *FIRMessagingSubscriptionsServer() {
           NSString *failureReason = @"Invalid registration response - zero length.";
           FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTopicOperationEmptyResponse, @"%@",
                                   failureReason);
-          [self finishWithError:[NSError messagingErrorWithCode:(FIRMessagingInternalErrorCode)
-                                                                    FIRMessagingErrorUnknown
+          [self finishWithError:[NSError messagingErrorWithCode:kFIRMessagingErrorCodeUnknown
                                                   failureReason:failureReason]];
           return;
         }
@@ -227,8 +226,7 @@ NSString *FIRMessagingSubscriptionsServer() {
               stringWithFormat:@"Invalid registration response :'%@'. It is missing 'token' field.",
                                response];
           FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTopicOption002, @"%@", failureReason);
-          [self finishWithError:[NSError messagingErrorWithCode:(FIRMessagingInternalErrorCode)
-                                                                    FIRMessagingErrorUnknown
+          [self finishWithError:[NSError messagingErrorWithCode:kFIRMessagingErrorCodeUnknown
                                                   failureReason:failureReason]];
           return;
         }

--- a/FirebaseMessaging/Sources/FIRMessagingTopicOperation.m
+++ b/FirebaseMessaging/Sources/FIRMessagingTopicOperation.m
@@ -121,7 +121,9 @@ NSString *FIRMessagingSubscriptionsServer() {
 - (void)start {
   if (self.isCancelled) {
     NSError *error =
-        [NSError errorWithFCMErrorCode:kFIRMessagingErrorCodePubSubOperationIsCancelled];
+        [NSError messagingErrorWithCode:kFIRMessagingErrorCodePubSubOperationIsCancelled
+                          failureReason:
+                              @"Failed to start the pubsub service as the operation is cancelled."];
     [self finishWithError:error];
     return;
   }
@@ -148,7 +150,8 @@ NSString *FIRMessagingSubscriptionsServer() {
 - (void)cancel {
   [super cancel];
   [self.dataTask cancel];
-  NSError *error = [NSError errorWithFCMErrorCode:kFIRMessagingErrorCodePubSubOperationIsCancelled];
+  NSError *error = [NSError messagingErrorWithCode:kFIRMessagingErrorCodePubSubOperationIsCancelled
+                                     failureReason:@"The pubsub service is cancelled."];
   [self finishWithError:error];
 }
 
@@ -210,16 +213,20 @@ NSString *FIRMessagingSubscriptionsServer() {
         }
         NSString *response = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
         if (response.length == 0) {
-          FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTopicOperationEmptyResponse,
-                                  @"Invalid registration response - zero length.");
-          [self finishWithError:[NSError errorWithFCMErrorCode:kFIRMessagingErrorCodeUnknown]];
+          NSString *failureReason = @"Invalid registration response - zero length.";
+          FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTopicOperationEmptyResponse, @"%@",
+                                  failureReason);
+          [self finishWithError:[NSError messagingErrorWithCode:kFIRMessagingErrorCodeUnknown
+                                                  failureReason:failureReason]];
           return;
         }
         NSArray *parts = [response componentsSeparatedByString:@"="];
         if (![parts[0] isEqualToString:@"token"] || parts.count <= 1) {
-          FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTopicOption002,
-                                  @"Invalid registration response %@", response);
-          [self finishWithError:[NSError errorWithFCMErrorCode:kFIRMessagingErrorCodeUnknown]];
+          NSString *failureReason =
+              [NSString stringWithFormat:@"Invalid registration response %@", response];
+          FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTopicOption002, @"%@", failureReason);
+          [self finishWithError:[NSError messagingErrorWithCode:kFIRMessagingErrorCodeUnknown
+                                                  failureReason:failureReason]];
           return;
         }
         [self finishWithError:nil];

--- a/FirebaseMessaging/Sources/FIRMessagingTopicOperation.m
+++ b/FirebaseMessaging/Sources/FIRMessagingTopicOperation.m
@@ -216,7 +216,8 @@ NSString *FIRMessagingSubscriptionsServer() {
           NSString *failureReason = @"Invalid registration response - zero length.";
           FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTopicOperationEmptyResponse, @"%@",
                                   failureReason);
-          [self finishWithError:[NSError messagingErrorWithCode:kFIRMessagingErrorCodeUnknown
+          [self finishWithError:[NSError messagingErrorWithCode:(FIRMessagingInternalErrorCode)
+                                                                    FIRMessagingErrorUnknown
                                                   failureReason:failureReason]];
           return;
         }
@@ -225,7 +226,8 @@ NSString *FIRMessagingSubscriptionsServer() {
           NSString *failureReason =
               [NSString stringWithFormat:@"Invalid registration response %@", response];
           FIRMessagingLoggerDebug(kFIRMessagingMessageCodeTopicOption002, @"%@", failureReason);
-          [self finishWithError:[NSError messagingErrorWithCode:kFIRMessagingErrorCodeUnknown
+          [self finishWithError:[NSError messagingErrorWithCode:(FIRMessagingInternalErrorCode)
+                                                                    FIRMessagingErrorUnknown
                                                   failureReason:failureReason]];
           return;
         }

--- a/FirebaseMessaging/Sources/NSError+FIRMessaging.h
+++ b/FirebaseMessaging/Sources/NSError+FIRMessaging.h
@@ -24,38 +24,25 @@ typedef NS_ENUM(NSUInteger, FIRMessagingInternalErrorCode) {
   // Unknown error.
   kFIRMessagingErrorCodeUnknown = 0,
 
-  // HTTP related errors.
-  kFIRMessagingErrorCodeAuthentication = 1,
-  kFIRMessagingErrorCodeNoAccess = 2,
-  kFIRMessagingErrorCodeTimeout = 3,
   kFIRMessagingErrorCodeNetwork = 4,
 
-  // Another operation is in progress.
-  kFIRMessagingErrorCodeOperationInProgress = 5,
-
-  // Failed to perform device check in.
-  kFIRMessagingErrorCodeRegistrarFailedToCheckIn = 6,
-
   kFIRMessagingErrorCodeInvalidRequest = 7,
+
+  kFIRMessagingErrorInvalidTopicName = 8,
 
   // FIRMessaging generic errors
   kFIRMessagingErrorCodeMissingDeviceID = 501,
 
   // Upstream send errors
   kFIRMessagingErrorServiceNotAvailable = 1001,
-  kFIRMessagingErrorInvalidParameters = 1002,
   kFIRMessagingErrorMissingTo = 1003,
   kFIRMessagingErrorSave = 1004,
   kFIRMessagingErrorSizeExceeded = 1005,
 
-  // MCS errors
   // Already connected with MCS
   kFIRMessagingErrorCodeAlreadyConnected = 2001,
 
   // PubSub errors
-  kFIRMessagingErrorCodePubSubAlreadySubscribed = 3001,
-  kFIRMessagingErrorCodePubSubAlreadyUnsubscribed = 3002,
-  kFIRMessagingErrorCodePubSubInvalidTopic = 3003,
   kFIRMessagingErrorCodePubSubClientNotSetup = 3004,
   kFIRMessagingErrorCodePubSubOperationIsCancelled = 3005,
 };

--- a/FirebaseMessaging/Sources/NSError+FIRMessaging.h
+++ b/FirebaseMessaging/Sources/NSError+FIRMessaging.h
@@ -18,6 +18,8 @@
 
 #import <FirebaseMessaging/FIRMessaging.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 FOUNDATION_EXPORT NSString *const kFIRMessagingDomain;
 
 typedef NS_ENUM(NSUInteger, FIRMessagingInternalErrorCode) {
@@ -53,3 +55,5 @@ typedef NS_ENUM(NSUInteger, FIRMessagingInternalErrorCode) {
                       failureReason:(NSString *)failureReason;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseMessaging/Sources/NSError+FIRMessaging.h
+++ b/FirebaseMessaging/Sources/NSError+FIRMessaging.h
@@ -22,24 +22,24 @@ NS_ASSUME_NONNULL_BEGIN
 
 FOUNDATION_EXPORT NSString *const kFIRMessagingDomain;
 
-typedef NS_ENUM(NSUInteger, FIRMessagingInternalErrorCode) {
-  // Unknown error.
+// FIRMessaging Internal Error Code
+typedef NS_ENUM(NSUInteger, FIRMessagingErrorCode) {
   kFIRMessagingErrorCodeUnknown = 0,
 
   kFIRMessagingErrorCodeNetwork = 4,
 
   kFIRMessagingErrorCodeInvalidRequest = 7,
 
-  kFIRMessagingErrorInvalidTopicName = 8,
+  kFIRMessagingErrorCodeInvalidTopicName = 8,
 
   // FIRMessaging generic errors
   kFIRMessagingErrorCodeMissingDeviceID = 501,
 
   // Upstream send errors
-  kFIRMessagingErrorServiceNotAvailable = 1001,
-  kFIRMessagingErrorMissingTo = 1003,
-  kFIRMessagingErrorSave = 1004,
-  kFIRMessagingErrorSizeExceeded = 1005,
+  kFIRMessagingErrorCodeServiceNotAvailable = 1001,
+  kFIRMessagingErrorCodeMissingTo = 1003,
+  kFIRMessagingErrorCodeSave = 1004,
+  kFIRMessagingErrorCodeSizeExceeded = 1005,
 
   // Already connected with MCS
   kFIRMessagingErrorCodeAlreadyConnected = 2001,
@@ -51,7 +51,7 @@ typedef NS_ENUM(NSUInteger, FIRMessagingInternalErrorCode) {
 
 @interface NSError (FIRMessaging)
 
-+ (NSError *)messagingErrorWithCode:(FIRMessagingInternalErrorCode)fcmErrorCode
++ (NSError *)messagingErrorWithCode:(FIRMessagingErrorCode)fcmErrorCode
                       failureReason:(NSString *)failureReason;
 
 @end

--- a/FirebaseMessaging/Sources/NSError+FIRMessaging.h
+++ b/FirebaseMessaging/Sources/NSError+FIRMessaging.h
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import <FirebaseMessaging/FIRMessaging.h>
+
 FOUNDATION_EXPORT NSString *const kFIRMessagingDomain;
 
 typedef NS_ENUM(NSUInteger, FIRMessagingInternalErrorCode) {
@@ -39,13 +41,12 @@ typedef NS_ENUM(NSUInteger, FIRMessagingInternalErrorCode) {
   // FIRMessaging generic errors
   kFIRMessagingErrorCodeMissingDeviceID = 501,
 
-  // upstream send errors
+  // Upstream send errors
   kFIRMessagingErrorServiceNotAvailable = 1001,
   kFIRMessagingErrorInvalidParameters = 1002,
   kFIRMessagingErrorMissingTo = 1003,
   kFIRMessagingErrorSave = 1004,
   kFIRMessagingErrorSizeExceeded = 1005,
-  // Future Send Errors
 
   // MCS errors
   // Already connected with MCS
@@ -55,15 +56,13 @@ typedef NS_ENUM(NSUInteger, FIRMessagingInternalErrorCode) {
   kFIRMessagingErrorCodePubSubAlreadySubscribed = 3001,
   kFIRMessagingErrorCodePubSubAlreadyUnsubscribed = 3002,
   kFIRMessagingErrorCodePubSubInvalidTopic = 3003,
-  kFIRMessagingErrorCodePubSubFIRMessagingNotSetup = 3004,
+  kFIRMessagingErrorCodePubSubClientNotSetup = 3004,
   kFIRMessagingErrorCodePubSubOperationIsCancelled = 3005,
 };
 
 @interface NSError (FIRMessaging)
 
-@property(nonatomic, readonly) FIRMessagingInternalErrorCode fcmErrorCode;
-
-+ (NSError *)errorWithFCMErrorCode:(FIRMessagingInternalErrorCode)fcmErrorCode;
-+ (NSError *)fcm_errorWithCode:(NSInteger)code userInfo:(NSDictionary *)userInfo;
++ (NSError *)messagingErrorWithCode:(FIRMessagingInternalErrorCode)fcmErrorCode
+                      failureReason:(NSString *)failureReason;
 
 @end

--- a/FirebaseMessaging/Sources/NSError+FIRMessaging.m
+++ b/FirebaseMessaging/Sources/NSError+FIRMessaging.m
@@ -20,16 +20,11 @@ NSString *const kFIRMessagingDomain = @"com.google.fcm";
 
 @implementation NSError (FIRMessaging)
 
-- (FIRMessagingInternalErrorCode)fcmErrorCode {
-  return (FIRMessagingInternalErrorCode)self.code;
-}
-
-+ (NSError *)errorWithFCMErrorCode:(FIRMessagingInternalErrorCode)fcmErrorCode {
-  return [NSError errorWithDomain:kFIRMessagingDomain code:fcmErrorCode userInfo:nil];
-}
-
-+ (NSError *)fcm_errorWithCode:(NSInteger)code userInfo:(NSDictionary *)userInfo {
-  return [NSError errorWithDomain:kFIRMessagingDomain code:code userInfo:userInfo];
++ (NSError *)messagingErrorWithCode:(FIRMessagingInternalErrorCode)fcmErrorCode
+                      failureReason:(NSString *)failureReason {
+  NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
+  userInfo[NSLocalizedFailureReasonErrorKey] = failureReason;
+  return [NSError errorWithDomain:kFIRMessagingDomain code:fcmErrorCode userInfo:userInfo];
 }
 
 @end

--- a/FirebaseMessaging/Sources/NSError+FIRMessaging.m
+++ b/FirebaseMessaging/Sources/NSError+FIRMessaging.m
@@ -20,11 +20,11 @@ NSString *const kFIRMessagingDomain = @"com.google.fcm";
 
 @implementation NSError (FIRMessaging)
 
-+ (NSError *)messagingErrorWithCode:(FIRMessagingInternalErrorCode)fcmErrorCode
++ (NSError *)messagingErrorWithCode:(FIRMessagingErrorCode)errorCode
                       failureReason:(NSString *)failureReason {
   NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
   userInfo[NSLocalizedFailureReasonErrorKey] = failureReason;
-  return [NSError errorWithDomain:kFIRMessagingDomain code:fcmErrorCode userInfo:userInfo];
+  return [NSError errorWithDomain:kFIRMessagingDomain code:errorCode userInfo:userInfo];
 }
 
 @end

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingDataMessageManagerTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingDataMessageManagerTest.m
@@ -161,7 +161,7 @@ static NSString *const kRmqDatabaseName = @"gcm-dmm-test";
                                                      if ([obj isKindOfClass:[NSError class]]) {
                                                        NSError *error = (NSError *)obj;
                                                        return error.code ==
-                                                              kFIRMessagingErrorMissingTo;
+                                                              kFIRMessagingErrorCodeMissingTo;
                                                      }
                                                      return NO;
                                                    }]]);
@@ -190,7 +190,7 @@ static NSString *const kRmqDatabaseName = @"gcm-dmm-test";
                                                      if ([obj isKindOfClass:[NSError class]]) {
                                                        NSError *error = (NSError *)obj;
                                                        return error.code ==
-                                                              kFIRMessagingErrorSizeExceeded;
+                                                              kFIRMessagingErrorCodeSizeExceeded;
                                                      }
                                                      return NO;
                                                    }]]);
@@ -214,7 +214,8 @@ static NSString *const kRmqDatabaseName = @"gcm-dmm-test";
                                                    error:[OCMArg checkWithBlock:^BOOL(id obj) {
                                                      if ([obj isKindOfClass:[NSError class]]) {
                                                        NSError *error = (NSError *)obj;
-                                                       return error.code == kFIRMessagingErrorSave;
+                                                       return error.code ==
+                                                              kFIRMessagingErrorCodeSave;
                                                      }
                                                      return NO;
                                                    }]]);


### PR DESCRIPTION
Currently Messaging returns a NSError with an internal error code (integer) and they don't mean anything to developers and very hard to track the cause. e.g. when subscribing to a empty topic, it returns error code 8.
Add failure reason to each error to what went wrong.
Also remove unused the error code.
At some point we should deprecate the FIRMessagingErrorCode as many is unused and not very useful for developers to debug.