### PR TITLE
Delete non-existent needs

### DIFF
--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -20,7 +20,6 @@ jobs:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     runs-on: macOS-latest
-    needs: check
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -32,7 +32,7 @@ jobs:
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
           quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
     - name: Setup custom URL scheme
-      run: sed -i '' 's/REVERSED_CLIENT_ID/com.googleusercontent.apps.1025801074639-6p6ebi8amuklcjrto20gvpe295smm8u6/'\
+      run: sed -i '' 's/REVERSED_CLIENT_ID/com.googleusercontent.apps.1025801074639-6p6ebi8amuklcjrto20gvpe295smm8u6/' \
              FunctionsExample/Info.plist
     - name: Test quickstart
       run: ([ -z $plist_secret ] ||

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -33,7 +33,7 @@ jobs:
           quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
     - name: Setup custom URL scheme
       run: sed -i '' 's/REVERSED_CLIENT_ID/com.googleusercontent.apps.1025801074639-6p6ebi8amuklcjrto20gvpe295smm8u6/' \
-             FunctionsExample/Info.plist
+             quickstart-ios/functions/FunctionsExample/Info.plist
     - name: Test quickstart
       run: ([ -z $plist_secret ] ||
             scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Functions)

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -31,6 +31,9 @@ jobs:
     - name: Install Secret FIREGSignInInfo.h
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
           quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
+    - name: Setup custom URL scheme
+      run: sed -i '' 's/REVERSED_CLIENT_ID/com.googleusercontent.apps.1025801074639-6p6ebi8amuklcjrto20gvpe295smm8u6/'\
+             FunctionsExample/Info.plist
     - name: Test quickstart
       run: ([ -z $plist_secret ] ||
             scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Functions)

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -32,8 +32,7 @@ jobs:
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
           quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
     - name: Setup custom URL scheme
-      run: sed -i '' 's/REVERSED_CLIENT_ID/com.googleusercontent.apps.1025801074639-6p6ebi8amuklcjrto20gvpe295smm8u6/' \
-             quickstart-ios/functions/FunctionsExample/Info.plist
+      run: sed -i '' 's/REVERSED_CLIENT_ID/com.googleusercontent.apps.1025801074639-6p6ebi8amuklcjrto20gvpe295smm8u6/' quickstart-ios/functions/FunctionsExample/Info.plist
     - name: Test quickstart
       run: ([ -z $plist_secret ] ||
             scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Functions)

--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -20,7 +20,6 @@ jobs:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
     runs-on: macOS-latest
-    needs: check
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     paths:
     - 'FirebaseInAppMessaging**'
-    - '.github/workflows/InAppMessaging.yml'
+    - '.github/workflows/inappmessaging.yml'
     - 'Gemfile'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times


### PR DESCRIPTION
The check job does not exist in the inappmessaging and functions jobs.

I'm not sure how these passed on the original PR.

They fail with 

"The workflow is not valid. The workflow must contain at least one job with no dependencies."

See https://github.com/firebase/firebase-ios-sdk/actions/runs/100454370

Fix Functions quickstart by adding custom URL setup from https://github.com/firebase/quickstart-ios/blob/master/scripts/install_prereqs/functions.sh

#no-changelog