### PR TITLE
Only log the URL follow event in messageClicked:withAction: if there's a URL to follow

### DIFF
--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
@@ -105,16 +105,18 @@
     [self recordValidImpression:_currentMsgBeingDisplayed.renderData.messageID
                 withMessageName:_currentMsgBeingDisplayed.renderData.name];
 
-    [self.analyticsEventLogger
-        logAnalyticsEventForType:FIRIAMAnalyticsEventActionURLFollow
-                   forCampaignID:_currentMsgBeingDisplayed.renderData.messageID
-                withCampaignName:_currentMsgBeingDisplayed.renderData.name
-                   eventTimeInMs:nil
-                      completion:^(BOOL success) {
-                        FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400032",
-                                    @"Logging analytics event for url following %@",
-                                    success ? @"succeeded" : @"failed");
-                      }];
+    if (action.actionURL) {
+      [self.analyticsEventLogger
+          logAnalyticsEventForType:FIRIAMAnalyticsEventActionURLFollow
+                     forCampaignID:_currentMsgBeingDisplayed.renderData.messageID
+                  withCampaignName:_currentMsgBeingDisplayed.renderData.name
+                     eventTimeInMs:nil
+                        completion:^(BOOL success) {
+                          FIRLogDebug(kFIRLoggerInAppMessaging, @"I-IAM400032",
+                                      @"Logging analytics event for url following %@",
+                                      success ? @"succeeded" : @"failed");
+                        }];
+    }
   }
 
   NSURL *actionURL = action.actionURL;

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMDisplayExecutorTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMDisplayExecutorTests.m
@@ -599,8 +599,12 @@ NSTimeInterval DISPLAY_MIN_INTERVALS = 1;
 
   [self.clientMessageCache setMessageData:@[ self.m2 ]];
 
+  FIRInAppMessagingAction *m2Action = [[FIRInAppMessagingAction alloc]
+      initWithActionText:self.m2.renderData.contentData.actionButtonText
+               actionURL:self.m2.renderData.contentData.actionURL];
   FIRIAMMessageDisplayForTesting *display = [[FIRIAMMessageDisplayForTesting alloc]
-      initWithDelegateInteraction:FIRInAppMessagingDelegateInteractionClick];
+      initWithDelegateInteraction:FIRInAppMessagingDelegateInteractionClick
+                           action:m2Action];
   self.displayExecutor.messageDisplayComponent = display;
 
   [self.displayExecutor checkAndDisplayNextAppForegroundMessage];


### PR DESCRIPTION
Fix for internal bug #155959022 to not count clicks if an in-app messaging campaign has no URL to follow.