### PR TITLE
Fix NSNull crash in string encode

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- [fixed] Fixed a crash that could occur if certian plist fields necessary to create Crashlytics records were missing at runtime. Also added some diagnostic logging to make the issue cause more explicit (#5565).
+
 # v4.1.0
 
 - [fixed] Fixed unchecked `malloc`s in Crashlytics (#5428).

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
@@ -219,10 +219,15 @@
 }
 
 /** Mallocs a pb_bytes_array and copies the given NSString's bytes into the bytes array.
- * @note Memory needs to be free manually, through pb_free or pb_release.
+ * @note Memory needs to be freed manually, through pb_free or pb_release.
  * @param string The string to encode as pb_bytes.
  */
 pb_bytes_array_t *FIRCLSEncodeString(NSString *string) {
+  if ([string isMemberOfClass:[NSNull class]]) {
+    FIRCLSErrorLog(@"Expected encodable string, but found NSNull instead. "
+                   @"Set a symbolic breakpoint at FIRCLSEncodeString to debug.");
+    string = nil;
+  }
   NSString *stringToEncode = string ? string : @"";
   NSData *stringBytes = [stringToEncode dataUsingEncoding:NSUTF8StringEncoding];
   return FIRCLSEncodeData(stringBytes);


### PR DESCRIPTION
This will fix the crash in #5565 and hopefully give devs a breadcrumb of sorts to identify the null field.