### PR TITLE
Fixes the count file not being found

### DIFF
--- a/GoogleDataTransport.podspec
+++ b/GoogleDataTransport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleDataTransport'
-  s.version          = '6.1.0'
+  s.version          = '6.1.1'
   s.summary          = 'Google iOS SDK data transport.'
 
   s.description      = <<-DESC

--- a/GoogleDataTransport/CHANGELOG.md
+++ b/GoogleDataTransport/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v6.1.1
+- Fixes writing event counts in a directory that doesn't yet exist. (#5549)
+
 # v6.1.0
 - watchOS extension and independent apps now supported. (#4292)
 - iOS extensions better supported.

--- a/GoogleDataTransport/GDTCORLibrary/GDTCOREvent.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCOREvent.m
@@ -33,8 +33,8 @@
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     eventIDQueue = dispatch_queue_create("com.google.GDTCOREventIDQueue", DISPATCH_QUEUE_SERIAL);
-    counterPath = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES)[0];
-    counterPath = [NSString stringWithFormat:@"%@/google-sdks-events/count", counterPath];
+    counterPath = GDTCORRootDirectory().path;
+    counterPath = [NSString stringWithFormat:@"%@/count", counterPath];
     NSError *error;
     NSString *countText = [NSString stringWithContentsOfFile:counterPath
                                                     encoding:NSUTF8StringEncoding


### PR DESCRIPTION
Calling the new GDTCORRootDirectory() function ensures that the directory needed is created before an attempt to write is made.

Fixes #5549
