### PR TITLE
Make sure `timestamp.h` compiles even in presence of `min` and `max` macros

### DIFF
--- a/Firestore/core/include/firebase/firestore/timestamp.h
+++ b/Firestore/core/include/firebase/firestore/timestamp.h
@@ -212,6 +212,15 @@ inline bool operator==(const Timestamp& lhs, const Timestamp& rhs) {
 }
 
 #if !defined(_STLPORT_VERSION)
+
+// Make sure the header compiles even when included after `<windows.h>` without
+// `NOMINMAX` defined. `push/pop_macro` pragmas are supported by Visual Studio
+// as well as Clang and GCC.
+#pragma push_macro("min")
+#pragma push_macro("max")
+#undef min
+#undef max
+
 template <typename Clock, typename Duration>
 std::chrono::time_point<Clock, Duration> Timestamp::ToTimePoint() const {
   namespace chr = std::chrono;
@@ -232,6 +241,10 @@ std::chrono::time_point<Clock, Duration> Timestamp::ToTimePoint() const {
       chr::duration_cast<Duration>(chr::nanoseconds(nanoseconds_));
   return TimePoint{seconds + nanoseconds};
 }
+
+#pragma pop_macro("max")
+#pragma pop_macro("min")
+
 #endif  // !defined(_STLPORT_VERSION)
 
 }  // namespace firebase


### PR DESCRIPTION
It is a well-known issue that `<windows.h>` Windows header defines macros `min` and `max`, causing compilation errors for code that uses `std::min/max`, `std::numeric_limits::min/max`, etc While users may work around the issue by defining the `NOMINMAX` macro before including Windows headers, this PR adds some preprocessor directives to temporarily undefine these macros then restore their previous values. While the relevant pragmas are non-standard, they are implemented in all Firestore-supported compilers (Visual Studio, Clang, GCC).