### PR TITLE
Fix race condition between setting developer mode and config fetch

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v4.4.11
+- [fixed] Fixed a bug where settings updates weren't applied before fetches. (#4740)
+- [changed] Updated public API documentation for 4.4.10 change from FirebaseInstanceID to
+  FirebaseInstallations
 # v4.4.10
 - [changed] Internal code changes - migrate to using the FIS SDK. (#5096)
 - [changed] Include both CFBundleString and CFBundleShortVersionString in the outgoing fetch requests.

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v4.4.11
 - [fixed] Fixed a bug where settings updates weren't applied before fetches. (#4740)
 - [changed] Updated public API documentation for 4.4.10 change from FirebaseInstanceID to
-  FirebaseInstallations
+  FirebaseInstallations. (#5561)
 # v4.4.10
 - [changed] Internal code changes - migrate to using the FIS SDK. (#5096)
 - [changed] Include both CFBundleString and CFBundleShortVersionString in the outgoing fetch requests.

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -214,8 +214,11 @@ static NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, FIRRemote
 #pragma mark - fetch
 
 - (void)fetchWithCompletionHandler:(FIRRemoteConfigFetchCompletion)completionHandler {
-  [self fetchWithExpirationDuration:_settings.minimumFetchInterval
-                  completionHandler:completionHandler];
+  __block NSTimeInterval minimumFetchInterval;
+  dispatch_sync(_queue, ^{
+    minimumFetchInterval = self->_settings.minimumFetchInterval;
+  });
+  [self fetchWithExpirationDuration:minimumFetchInterval completionHandler:completionHandler];
 }
 
 - (void)fetchWithExpirationDuration:(NSTimeInterval)expirationDuration

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -214,11 +214,10 @@ static NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, FIRRemote
 #pragma mark - fetch
 
 - (void)fetchWithCompletionHandler:(FIRRemoteConfigFetchCompletion)completionHandler {
-  __block NSTimeInterval minimumFetchInterval;
-  dispatch_sync(_queue, ^{
-    minimumFetchInterval = self->_settings.minimumFetchInterval;
+  dispatch_async(_queue, ^{
+    [self fetchWithExpirationDuration:self->_settings.minimumFetchInterval
+                    completionHandler:completionHandler];
   });
-  [self fetchWithExpirationDuration:minimumFetchInterval completionHandler:completionHandler];
 }
 
 - (void)fetchWithExpirationDuration:(NSTimeInterval)expirationDuration


### PR DESCRIPTION
Fix #4740 

Insure that minimumFetchInterval setting is applied before fetching.  Otherwise there will be indeterministic behavior when trying to verify console changes in an app.

I've verified in a sample and will work on adding a unit test.

I'd like to get the review going since I'd like to get this fix in M71.
