### PR TITLE
Migrate FetchAndActivate from deprecated implementation

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,14 +1,21 @@
+# Unreleased
+- [changed] Updated `fetchAndActivateWithCompletionHandler:` implementation to activate asynchronously. (#5617)
+
 # v4.4.11
 - [fixed] Fixed a bug where settings updates weren't applied before fetches. (#4740)
 - [changed] Updated public API documentation for 4.4.10 change from FirebaseInstanceID to
   FirebaseInstallations. (#5561)
+
 # v4.4.10
 - [changed] Internal code changes - migrate to using the FIS SDK. (#5096)
 - [changed] Include both CFBundleString and CFBundleShortVersionString in the outgoing fetch requests.
+
 # v4.4.9
 - [changed] Internal code changes. (#4934)
+
 # v4.4.8
 - [fixed] Fixed a bug (#4677, #4734) where Remote Config does not work after a restore of a previous backup of the device. (#4896).
+
 # v4.4.7
 - [fixed] Fixed a crash that could occur when attempting a remote config fetch before a valid Instance ID was available. (#4622)
 - [fixed] Fixed an issue where config fetch would sometimes fail with a duplicate fetch error when no other fetches were in progress. (#3802)

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -244,18 +244,19 @@ static NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, FIRRemote
         // Fetch completed. We are being called on the main queue.
         // If fetch is successful, try to activate the fetched config
         if (fetchStatus == FIRRemoteConfigFetchStatusSuccess && !fetchError) {
-          [strongSelf activateWithCompletionHandler:^(NSError * _Nullable activateError) {
+          [strongSelf activateWithCompletionHandler:^(NSError *_Nullable activateError) {
             if (completionHandler) {
-              FIRRemoteConfigFetchAndActivateStatus status = activateError ?
-                FIRRemoteConfigFetchAndActivateStatusSuccessUsingPreFetchedData :
-                FIRRemoteConfigFetchAndActivateStatusSuccessFetchedFromRemote;
+              FIRRemoteConfigFetchAndActivateStatus status =
+                  activateError ? FIRRemoteConfigFetchAndActivateStatusSuccessUsingPreFetchedData
+                                : FIRRemoteConfigFetchAndActivateStatusSuccessFetchedFromRemote;
               completionHandler(status, fetchError);
             }
           }];
         } else if (completionHandler) {
-          FIRRemoteConfigFetchAndActivateStatus status = fetchStatus ?
-            FIRRemoteConfigFetchAndActivateStatusSuccessUsingPreFetchedData :
-            FIRRemoteConfigFetchAndActivateStatusError;
+          FIRRemoteConfigFetchAndActivateStatus status =
+              fetchStatus == FIRRemoteConfigFetchStatusSuccess
+                  ? FIRRemoteConfigFetchAndActivateStatusSuccessUsingPreFetchedData
+                  : FIRRemoteConfigFetchAndActivateStatusError;
           completionHandler(status, fetchError);
         }
       };

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -249,7 +249,7 @@ static NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, FIRRemote
               FIRRemoteConfigFetchAndActivateStatus status =
                   activateError ? FIRRemoteConfigFetchAndActivateStatusSuccessUsingPreFetchedData
                                 : FIRRemoteConfigFetchAndActivateStatusSuccessFetchedFromRemote;
-              completionHandler(status, fetchError);
+              completionHandler(status, nil);
             }
           }];
         } else if (completionHandler) {

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -236,27 +236,27 @@ static NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, FIRRemote
     (FIRRemoteConfigFetchAndActivateCompletion)completionHandler {
   __weak FIRRemoteConfig *weakSelf = self;
   FIRRemoteConfigFetchCompletion fetchCompletion =
-      ^(FIRRemoteConfigFetchStatus fetchStatus, NSError *error) {
+      ^(FIRRemoteConfigFetchStatus fetchStatus, NSError *fetchError) {
         FIRRemoteConfig *strongSelf = weakSelf;
         if (!strongSelf) {
           return;
         }
         // Fetch completed. We are being called on the main queue.
         // If fetch is successful, try to activate the fetched config
-        bool didActivate = false;
-        if (fetchStatus == FIRRemoteConfigFetchStatusSuccess && !error) {
-          didActivate = [strongSelf activateFetched];
-        }
-        if (completionHandler) {
-          FIRRemoteConfigFetchAndActivateStatus status = FIRRemoteConfigFetchAndActivateStatusError;
-          if (fetchStatus == FIRRemoteConfigFetchStatusSuccess) {
-            status = didActivate ? FIRRemoteConfigFetchAndActivateStatusSuccessFetchedFromRemote
-                                 : FIRRemoteConfigFetchAndActivateStatusSuccessUsingPreFetchedData;
-          } else {
-            status = FIRRemoteConfigFetchAndActivateStatusError;
-          }
-          // Pass along the fetch error e.g. throttled.
-          completionHandler(status, error);
+        if (fetchStatus == FIRRemoteConfigFetchStatusSuccess && !fetchError) {
+          [strongSelf activateWithCompletionHandler:^(NSError * _Nullable activateError) {
+            if (completionHandler) {
+              FIRRemoteConfigFetchAndActivateStatus status = activateError ?
+                FIRRemoteConfigFetchAndActivateStatusSuccessUsingPreFetchedData :
+                FIRRemoteConfigFetchAndActivateStatusSuccessFetchedFromRemote;
+              completionHandler(status, fetchError);
+            }
+          }];
+        } else if (completionHandler) {
+          FIRRemoteConfigFetchAndActivateStatus status = fetchStatus ?
+            FIRRemoteConfigFetchAndActivateStatusSuccessUsingPreFetchedData :
+            FIRRemoteConfigFetchAndActivateStatusError;
+          completionHandler(status, fetchError);
         }
       };
   [self fetchWithCompletionHandler:fetchCompletion];


### PR DESCRIPTION
Migrate `fetchAndActivateWithCompletionHandler:` implementation from using the deprecated `activateFetched` API to the async `activateWithCompletionHandler:`

Working on integration tests, I was getting a deadlock in `activateFetched` so thought it would be good to move this forward.