### PR TITLE
Avoid blocking access to the AsyncQueue during Dispose

### DIFF
--- a/Firestore/core/src/util/async_queue.cc
+++ b/Firestore/core/src/util/async_queue.cc
@@ -52,9 +52,11 @@ void AsyncQueue::EnterRestrictedMode() {
 }
 
 void AsyncQueue::Dispose() {
-  std::lock_guard<std::mutex> lock(mutex_);
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    mode_ = Mode::kDisposed;
+  }
 
-  mode_ = Mode::kDisposed;
   executor_->Dispose();
 }
 


### PR DESCRIPTION
This helps avoid deadlock during shutdown.