### PR TITLE
Add end to end integration tests with RC+ABT

### DIFF
--- a/FirebaseABTesting/Tests/Integration/ABTQA.xcodeproj/project.pbxproj
+++ b/FirebaseABTesting/Tests/Integration/ABTQA.xcodeproj/project.pbxproj
@@ -1,0 +1,643 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 51;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		255D24A5243E32BB00198B35 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255D24A4243E32BB00198B35 /* AppDelegate.swift */; };
+		255D24A7243E32BB00198B35 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255D24A6243E32BB00198B35 /* SceneDelegate.swift */; };
+		255D24A9243E32BB00198B35 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 255D24A8243E32BB00198B35 /* ViewController.swift */; };
+		255D24AC243E32BB00198B35 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 255D24AA243E32BB00198B35 /* Main.storyboard */; };
+		255D24AE243E32BE00198B35 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 255D24AD243E32BE00198B35 /* Assets.xcassets */; };
+		255D24B1243E32BE00198B35 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 255D24AF243E32BE00198B35 /* LaunchScreen.storyboard */; };
+		25FFEDEE243E35BF00C2A81F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 25FFEDED243E35BF00C2A81F /* GoogleService-Info.plist */; };
+		AD17158819149A200736C73C /* Pods_ABTQA.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C35C0A4297077A1FB0E6D7B /* Pods_ABTQA.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		255D24B8243E32BE00198B35 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 255D2499243E32BB00198B35 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 255D24A0243E32BB00198B35;
+			remoteInfo = ABTQA;
+		};
+		255D24C3243E32BE00198B35 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 255D2499243E32BB00198B35 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 255D24A0243E32BB00198B35;
+			remoteInfo = ABTQA;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		255D24A1243E32BB00198B35 /* ABTQA.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ABTQA.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		255D24A4243E32BB00198B35 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		255D24A6243E32BB00198B35 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		255D24A8243E32BB00198B35 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		255D24AB243E32BB00198B35 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		255D24AD243E32BE00198B35 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		255D24B0243E32BE00198B35 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		255D24B2243E32BE00198B35 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		255D24B7243E32BE00198B35 /* ABTQATests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ABTQATests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		255D24C2243E32BE00198B35 /* ABTQAUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ABTQAUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		25FFEDED243E35BF00C2A81F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		7C35C0A4297077A1FB0E6D7B /* Pods_ABTQA.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ABTQA.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9F7FA3676E99EC590CEEAC0F /* Pods-ABTQA.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ABTQA.debug.xcconfig"; path = "Target Support Files/Pods-ABTQA/Pods-ABTQA.debug.xcconfig"; sourceTree = "<group>"; };
+		C102C1701D9907088D93DB4D /* Pods-ABTQA.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ABTQA.release.xcconfig"; path = "Target Support Files/Pods-ABTQA/Pods-ABTQA.release.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		255D249E243E32BB00198B35 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AD17158819149A200736C73C /* Pods_ABTQA.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		255D24B4243E32BE00198B35 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		255D24BF243E32BE00198B35 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		255D2498243E32BB00198B35 = {
+			isa = PBXGroup;
+			children = (
+				255D24A3243E32BB00198B35 /* ABTQA */,
+				255D24A2243E32BB00198B35 /* Products */,
+				FC73BA2658C640D2CEB51416 /* Pods */,
+				A6341FFA37CD381C238CFACD /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		255D24A2243E32BB00198B35 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				255D24A1243E32BB00198B35 /* ABTQA.app */,
+				255D24B7243E32BE00198B35 /* ABTQATests.xctest */,
+				255D24C2243E32BE00198B35 /* ABTQAUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		255D24A3243E32BB00198B35 /* ABTQA */ = {
+			isa = PBXGroup;
+			children = (
+				25FFEDED243E35BF00C2A81F /* GoogleService-Info.plist */,
+				255D24A4243E32BB00198B35 /* AppDelegate.swift */,
+				255D24A6243E32BB00198B35 /* SceneDelegate.swift */,
+				255D24A8243E32BB00198B35 /* ViewController.swift */,
+				255D24AA243E32BB00198B35 /* Main.storyboard */,
+				255D24AD243E32BE00198B35 /* Assets.xcassets */,
+				255D24AF243E32BE00198B35 /* LaunchScreen.storyboard */,
+				255D24B2243E32BE00198B35 /* Info.plist */,
+			);
+			path = ABTQA;
+			sourceTree = "<group>";
+		};
+		A6341FFA37CD381C238CFACD /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				7C35C0A4297077A1FB0E6D7B /* Pods_ABTQA.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		FC73BA2658C640D2CEB51416 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				9F7FA3676E99EC590CEEAC0F /* Pods-ABTQA.debug.xcconfig */,
+				C102C1701D9907088D93DB4D /* Pods-ABTQA.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		255D24A0243E32BB00198B35 /* ABTQA */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 255D24CB243E32BE00198B35 /* Build configuration list for PBXNativeTarget "ABTQA" */;
+			buildPhases = (
+				2FD2371C77637C00228E0222 /* [CP] Check Pods Manifest.lock */,
+				255D249D243E32BB00198B35 /* Sources */,
+				255D249E243E32BB00198B35 /* Frameworks */,
+				255D249F243E32BB00198B35 /* Resources */,
+				C335D81655632B345829C5CC /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ABTQA;
+			productName = ABTQA;
+			productReference = 255D24A1243E32BB00198B35 /* ABTQA.app */;
+			productType = "com.apple.product-type.application";
+		};
+		255D24B6243E32BE00198B35 /* ABTQATests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 255D24CE243E32BE00198B35 /* Build configuration list for PBXNativeTarget "ABTQATests" */;
+			buildPhases = (
+				255D24B3243E32BE00198B35 /* Sources */,
+				255D24B4243E32BE00198B35 /* Frameworks */,
+				255D24B5243E32BE00198B35 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				255D24B9243E32BE00198B35 /* PBXTargetDependency */,
+			);
+			name = ABTQATests;
+			productName = ABTQATests;
+			productReference = 255D24B7243E32BE00198B35 /* ABTQATests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		255D24C1243E32BE00198B35 /* ABTQAUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 255D24D1243E32BE00198B35 /* Build configuration list for PBXNativeTarget "ABTQAUITests" */;
+			buildPhases = (
+				255D24BE243E32BE00198B35 /* Sources */,
+				255D24BF243E32BE00198B35 /* Frameworks */,
+				255D24C0243E32BE00198B35 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				255D24C4243E32BE00198B35 /* PBXTargetDependency */,
+			);
+			name = ABTQAUITests;
+			productName = ABTQAUITests;
+			productReference = 255D24C2243E32BE00198B35 /* ABTQAUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		255D2499243E32BB00198B35 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1140;
+				LastUpgradeCheck = 1140;
+				ORGANIZATIONNAME = Firebase;
+				TargetAttributes = {
+					255D24A0243E32BB00198B35 = {
+						CreatedOnToolsVersion = 11.4;
+					};
+					255D24B6243E32BE00198B35 = {
+						CreatedOnToolsVersion = 11.4;
+						TestTargetID = 255D24A0243E32BB00198B35;
+					};
+					255D24C1243E32BE00198B35 = {
+						CreatedOnToolsVersion = 11.4;
+						TestTargetID = 255D24A0243E32BB00198B35;
+					};
+				};
+			};
+			buildConfigurationList = 255D249C243E32BB00198B35 /* Build configuration list for PBXProject "ABTQA" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 255D2498243E32BB00198B35;
+			productRefGroup = 255D24A2243E32BB00198B35 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				255D24A0243E32BB00198B35 /* ABTQA */,
+				255D24B6243E32BE00198B35 /* ABTQATests */,
+				255D24C1243E32BE00198B35 /* ABTQAUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		255D249F243E32BB00198B35 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				255D24B1243E32BE00198B35 /* LaunchScreen.storyboard in Resources */,
+				25FFEDEE243E35BF00C2A81F /* GoogleService-Info.plist in Resources */,
+				255D24AE243E32BE00198B35 /* Assets.xcassets in Resources */,
+				255D24AC243E32BB00198B35 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		255D24B5243E32BE00198B35 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		255D24C0243E32BE00198B35 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		2FD2371C77637C00228E0222 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ABTQA-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C335D81655632B345829C5CC /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ABTQA/Pods-ABTQA-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ABTQA/Pods-ABTQA-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ABTQA/Pods-ABTQA-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		255D249D243E32BB00198B35 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				255D24A9243E32BB00198B35 /* ViewController.swift in Sources */,
+				255D24A5243E32BB00198B35 /* AppDelegate.swift in Sources */,
+				255D24A7243E32BB00198B35 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		255D24B3243E32BE00198B35 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		255D24BE243E32BE00198B35 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		255D24B9243E32BE00198B35 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 255D24A0243E32BB00198B35 /* ABTQA */;
+			targetProxy = 255D24B8243E32BE00198B35 /* PBXContainerItemProxy */;
+		};
+		255D24C4243E32BE00198B35 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 255D24A0243E32BB00198B35 /* ABTQA */;
+			targetProxy = 255D24C3243E32BE00198B35 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		255D24AA243E32BB00198B35 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				255D24AB243E32BB00198B35 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		255D24AF243E32BE00198B35 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				255D24B0243E32BE00198B35 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		255D24C9243E32BE00198B35 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		255D24CA243E32BE00198B35 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		255D24CC243E32BE00198B35 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9F7FA3676E99EC590CEEAC0F /* Pods-ABTQA.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 965RJH2QM8;
+				INFOPLIST_FILE = ABTQA/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.firebase.ABTQA;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		255D24CD243E32BE00198B35 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C102C1701D9907088D93DB4D /* Pods-ABTQA.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 965RJH2QM8;
+				INFOPLIST_FILE = ABTQA/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.firebase.ABTQA;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		255D24CF243E32BE00198B35 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 965RJH2QM8;
+				INFOPLIST_FILE = ABTQATests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.firebase.ABTQATests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ABTQA.app/ABTQA";
+			};
+			name = Debug;
+		};
+		255D24D0243E32BE00198B35 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 965RJH2QM8;
+				INFOPLIST_FILE = ABTQATests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.firebase.ABTQATests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ABTQA.app/ABTQA";
+			};
+			name = Release;
+		};
+		255D24D2243E32BE00198B35 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 965RJH2QM8;
+				INFOPLIST_FILE = ABTQAUITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.firebase.ABTQAUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = ABTQA;
+			};
+			name = Debug;
+		};
+		255D24D3243E32BE00198B35 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 965RJH2QM8;
+				INFOPLIST_FILE = ABTQAUITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.firebase.ABTQAUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = ABTQA;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		255D249C243E32BB00198B35 /* Build configuration list for PBXProject "ABTQA" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				255D24C9243E32BE00198B35 /* Debug */,
+				255D24CA243E32BE00198B35 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		255D24CB243E32BE00198B35 /* Build configuration list for PBXNativeTarget "ABTQA" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				255D24CC243E32BE00198B35 /* Debug */,
+				255D24CD243E32BE00198B35 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		255D24CE243E32BE00198B35 /* Build configuration list for PBXNativeTarget "ABTQATests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				255D24CF243E32BE00198B35 /* Debug */,
+				255D24D0243E32BE00198B35 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		255D24D1243E32BE00198B35 /* Build configuration list for PBXNativeTarget "ABTQAUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				255D24D2243E32BE00198B35 /* Debug */,
+				255D24D3243E32BE00198B35 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 255D2499243E32BB00198B35 /* Project object */;
+}

--- a/FirebaseABTesting/Tests/Integration/ABTQA.xcodeproj/xcshareddata/xcschemes/ABTQA.xcscheme
+++ b/FirebaseABTesting/Tests/Integration/ABTQA.xcodeproj/xcshareddata/xcschemes/ABTQA.xcscheme
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "255D24A0243E32BB00198B35"
+               BuildableName = "ABTQA.app"
+               BlueprintName = "ABTQA"
+               ReferencedContainer = "container:ABTQA.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "255D24B6243E32BE00198B35"
+               BuildableName = "ABTQATests.xctest"
+               BlueprintName = "ABTQATests"
+               ReferencedContainer = "container:ABTQA.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "255D24C1243E32BE00198B35"
+               BuildableName = "ABTQAUITests.xctest"
+               BlueprintName = "ABTQAUITests"
+               ReferencedContainer = "container:ABTQA.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "255D24A0243E32BB00198B35"
+            BuildableName = "ABTQA.app"
+            BlueprintName = "ABTQA"
+            ReferencedContainer = "container:ABTQA.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-FIRDebugEnabled"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "255D24A0243E32BB00198B35"
+            BuildableName = "ABTQA.app"
+            BlueprintName = "ABTQA"
+            ReferencedContainer = "container:ABTQA.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FirebaseABTesting/Tests/Integration/ABTQA/AppDelegate.swift
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/AppDelegate.swift
@@ -1,28 +1,27 @@
 /*
-* Copyright 2020 Google
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*      http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import UIKit
 import Firebase
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
   func application(_ application: UIApplication,
                    didFinishLaunchingWithOptions
-                      launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+                   launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // Override point for customization after application launch.
     FirebaseApp.configure()
     return true

--- a/FirebaseABTesting/Tests/Integration/ABTQA/AppDelegate.swift
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/AppDelegate.swift
@@ -20,16 +20,18 @@ import Firebase
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+  func application(_ application: UIApplication,
+                   didFinishLaunchingWithOptions
+                      launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     // Override point for customization after application launch.
     FirebaseApp.configure()
     return true
   }
 
-  // MARK: UISceneSession Lifecycle
-
-  func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-    return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+  func application(_ application: UIApplication,
+                   configurationForConnecting connectingSceneSession: UISceneSession,
+                   options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    return UISceneConfiguration(name: "Default Configuration",
+                                sessionRole: connectingSceneSession.role)
   }
 }
-

--- a/FirebaseABTesting/Tests/Integration/ABTQA/AppDelegate.swift
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/AppDelegate.swift
@@ -1,0 +1,35 @@
+/*
+* Copyright 2020 Google
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import UIKit
+import Firebase
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    // Override point for customization after application launch.
+    FirebaseApp.configure()
+    return true
+  }
+
+  // MARK: UISceneSession Lifecycle
+
+  func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+    return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+  }
+}
+

--- a/FirebaseABTesting/Tests/Integration/ABTQA/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/FirebaseABTesting/Tests/Integration/ABTQA/Assets.xcassets/Contents.json
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/FirebaseABTesting/Tests/Integration/ABTQA/Base.lproj/LaunchScreen.storyboard
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/FirebaseABTesting/Tests/Integration/ABTQA/Base.lproj/Main.storyboard
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/Base.lproj/Main.storyboard
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="ABTQA" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="leJ-st-KAV">
+                                <rect key="frame" x="22" y="174" width="370" height="130.5"/>
+                                <string key="text">This will make a call to fetch the latest values from Remote Config. This project has a running A/B test with a parameter `bg_color`. Based on the result, the background color of the screen with either turn red or green based on variant assignment.</string>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KLS-Wd-htS">
+                                <rect key="frame" x="62.5" y="124" width="289" height="42"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                <state key="normal" title="Fetch remote config values"/>
+                                <connections>
+                                    <action selector="checkTestButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="tbq-Rk-knJ"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PD9-Py-SZW">
+                                <rect key="frame" x="52" y="427" width="310" height="42"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                <state key="normal" title="Fire a custom analytics event"/>
+                                <connections>
+                                    <action selector="fireAnalyticsEventButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="kgU-vo-FSg"/>
+                                </connections>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This opens a text field where you can enter the name of a custom analytics event, which will then be fired." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XJp-Bw-Rfp">
+                                <rect key="frame" x="20" y="477" width="374" height="64.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="XJp-Bw-Rfp" firstAttribute="top" secondItem="PD9-Py-SZW" secondAttribute="bottom" constant="8" id="GGg-up-bp6"/>
+                            <constraint firstItem="PD9-Py-SZW" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="Hlb-Oc-fRL"/>
+                            <constraint firstItem="KLS-Wd-htS" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="IYs-Wo-iR7"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="leJ-st-KAV" secondAttribute="trailing" constant="20" id="Ji6-Oq-YP4"/>
+                            <constraint firstItem="PD9-Py-SZW" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="MMF-eJ-aK8"/>
+                            <constraint firstItem="XJp-Bw-Rfp" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="OVz-W2-lIw"/>
+                            <constraint firstItem="leJ-st-KAV" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="8bC-Xf-vdC" secondAttribute="leading" constant="20" id="PpX-Ah-EAp"/>
+                            <constraint firstItem="XJp-Bw-Rfp" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="8bC-Xf-vdC" secondAttribute="leading" constant="20" id="YYV-YD-dRt"/>
+                            <constraint firstItem="leJ-st-KAV" firstAttribute="top" secondItem="KLS-Wd-htS" secondAttribute="bottom" constant="8" id="ghI-kV-JTk"/>
+                            <constraint firstItem="leJ-st-KAV" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="mDt-we-Cds"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="XJp-Bw-Rfp" secondAttribute="trailing" constant="20" id="ndW-B7-DAa"/>
+                            <constraint firstItem="KLS-Wd-htS" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="80" id="rE4-d6-WYc"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="139" y="118"/>
+        </scene>
+    </scenes>
+</document>

--- a/FirebaseABTesting/Tests/Integration/ABTQA/GoogleService-Info.plist
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/GoogleService-Info.plist
@@ -3,13 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>CLIENT_ID</key>
-	<string>107203219749-87mjoo1vngte8p28stfpg7ga26o6rpvl.apps.googleusercontent.com</string>
+	<string>correct_client_id</string>
 	<key>REVERSED_CLIENT_ID</key>
-	<string>com.googleusercontent.apps.107203219749-87mjoo1vngte8p28stfpg7ga26o6rpvl</string>
+	<string>correct_reversed_client_id</string>
 	<key>API_KEY</key>
-	<string>AIzaSyCbahgfywbxGTG6QHAZODzSvhS7Zawth7w</string>
+	<string>correct_api_key</string>
 	<key>GCM_SENDER_ID</key>
-	<string>107203219749</string>
+	<string>correct_gcm_sender_id</string>
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
@@ -17,7 +17,7 @@
 	<key>PROJECT_ID</key>
 	<string>abt-qa</string>
 	<key>STORAGE_BUCKET</key>
-	<string>abt-qa.appspot.com</string>
+	<string>project-id-123.storage.firebase.com</string>
 	<key>IS_ADS_ENABLED</key>
 	<false></false>
 	<key>IS_ANALYTICS_ENABLED</key>
@@ -29,8 +29,8 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:107203219749:ios:863e50c4ee07f90e3c0acc</string>
+	<string>1:123:ios:123abc</string>
 	<key>DATABASE_URL</key>
-	<string>https://abt-qa.firebaseio.com</string>
+	<string>https://abc-xyz-123.firebaseio.com</string>
 </dict>
 </plist>

--- a/FirebaseABTesting/Tests/Integration/ABTQA/GoogleService-Info.plist
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/GoogleService-Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>107203219749-87mjoo1vngte8p28stfpg7ga26o6rpvl.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.107203219749-87mjoo1vngte8p28stfpg7ga26o6rpvl</string>
+	<key>API_KEY</key>
+	<string>AIzaSyCbahgfywbxGTG6QHAZODzSvhS7Zawth7w</string>
+	<key>GCM_SENDER_ID</key>
+	<string>107203219749</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.firebase.ABTQA</string>
+	<key>PROJECT_ID</key>
+	<string>abt-qa</string>
+	<key>STORAGE_BUCKET</key>
+	<string>abt-qa.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:107203219749:ios:863e50c4ee07f90e3c0acc</string>
+	<key>DATABASE_URL</key>
+	<string>https://abt-qa.firebaseio.com</string>
+</dict>
+</plist>

--- a/FirebaseABTesting/Tests/Integration/ABTQA/Info.plist
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/Info.plist
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/FirebaseABTesting/Tests/Integration/ABTQA/SceneDelegate.swift
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/SceneDelegate.swift
@@ -1,23 +1,22 @@
 /*
-* Copyright 2020 Google
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*      http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
   var window: UIWindow?
 
   func scene(_ scene: UIScene,

--- a/FirebaseABTesting/Tests/Integration/ABTQA/SceneDelegate.swift
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/SceneDelegate.swift
@@ -20,8 +20,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
   var window: UIWindow?
 
-  func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+  func scene(_ scene: UIScene,
+             willConnectTo session: UISceneSession,
+             options connectionOptions: UIScene.ConnectionOptions) {
     guard let _ = (scene as? UIWindowScene) else { return }
   }
 }
-

--- a/FirebaseABTesting/Tests/Integration/ABTQA/SceneDelegate.swift
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/SceneDelegate.swift
@@ -1,0 +1,27 @@
+/*
+* Copyright 2020 Google
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+  var window: UIWindow?
+
+  func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+    guard let _ = (scene as? UIWindowScene) else { return }
+  }
+}
+

--- a/FirebaseABTesting/Tests/Integration/ABTQA/ViewController.swift
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/ViewController.swift
@@ -29,6 +29,7 @@ class ViewController: UIViewController {
       alert.dismiss(animated: true, completion: nil)
     }))
     
+    // Fire Analytics event based on text field content.
     alert.addAction(UIAlertAction(title: "Fire event", style: .default, handler: { (action) in
       guard let textField = alert.textFields?.first else {
         assertionFailure("Alert has no text field. Something went wrong.")
@@ -51,12 +52,15 @@ class ViewController: UIViewController {
     let remoteConfig = RemoteConfig.remoteConfig()
     
     remoteConfig.fetchAndActivate { (status, error) in
+      // Fetch `bg_color` from remote config after activating.
       guard let color = remoteConfig.configValue(forKey: "bg_color").stringValue else {
         assertionFailure("Failed to fetch `bg_color` config value. Check the ABT console.")
         return
       }
       
+      // Set background color.
       DispatchQueue.main.async {
+        // The AB test has two values for `bg_color`: "green or "red".
         if color == "green" {
           self.view.backgroundColor = UIColor.green
         } else {
@@ -66,4 +70,3 @@ class ViewController: UIViewController {
     }
   }
 }
-

--- a/FirebaseABTesting/Tests/Integration/ABTQA/ViewController.swift
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/ViewController.swift
@@ -1,0 +1,69 @@
+/*
+* Copyright 2020 Google
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import UIKit
+import FirebaseAnalytics
+import FirebaseRemoteConfig
+
+class ViewController: UIViewController {
+  
+  @IBAction func fireAnalyticsEventButtonTapped(_ sender: Any) {
+    let alert = UIAlertController(title: "Fire custom analytics event",
+                                  message: "Enter the name of a custom event",
+                                  preferredStyle: .alert)
+    
+    alert.addAction(UIAlertAction(title: "Dismiss", style: .cancel, handler: { (action) in
+      alert.dismiss(animated: true, completion: nil)
+    }))
+    
+    alert.addAction(UIAlertAction(title: "Fire event", style: .default, handler: { (action) in
+      guard let textField = alert.textFields?.first else {
+        assertionFailure("Alert has no text field. Something went wrong.")
+        return
+      }
+      
+      if let event = textField.text {
+        Analytics.logEvent(event, parameters: nil)
+      }
+    }))
+    
+    alert.addTextField { (textField) in
+      textField.placeholder = "e.g.: tapped_close_button"
+    }
+    
+    self.present(alert, animated: true, completion: nil)
+  }
+  
+  @IBAction func checkTestButtonTapped(_ sender: Any) {
+    let remoteConfig = RemoteConfig.remoteConfig()
+    
+    remoteConfig.fetchAndActivate { (status, error) in
+      guard let color = remoteConfig.configValue(forKey: "bg_color").stringValue else {
+        assertionFailure("Failed to fetch `bg_color` config value. Check the ABT console.")
+        return
+      }
+      
+      DispatchQueue.main.async {
+        if color == "green" {
+          self.view.backgroundColor = UIColor.green
+        } else {
+          self.view.backgroundColor = UIColor.red
+        }
+      }
+    }
+  }
+}
+

--- a/FirebaseABTesting/Tests/Integration/ABTQA/ViewController.swift
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/ViewController.swift
@@ -1,63 +1,62 @@
 /*
-* Copyright 2020 Google
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*      http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import UIKit
 import FirebaseAnalytics
 import FirebaseRemoteConfig
 
 class ViewController: UIViewController {
-  
   @IBAction func fireAnalyticsEventButtonTapped(_ sender: Any) {
     let alert = UIAlertController(title: "Fire custom analytics event",
                                   message: "Enter the name of a custom event",
                                   preferredStyle: .alert)
-    
-    alert.addAction(UIAlertAction(title: "Dismiss", style: .cancel, handler: { (action) in
+
+    alert.addAction(UIAlertAction(title: "Dismiss", style: .cancel, handler: { action in
       alert.dismiss(animated: true, completion: nil)
     }))
-    
+
     // Fire Analytics event based on text field content.
-    alert.addAction(UIAlertAction(title: "Fire event", style: .default, handler: { (action) in
+    alert.addAction(UIAlertAction(title: "Fire event", style: .default, handler: { action in
       guard let textField = alert.textFields?.first else {
         assertionFailure("Alert has no text field. Something went wrong.")
         return
       }
-      
+
       if let event = textField.text {
         Analytics.logEvent(event, parameters: nil)
       }
     }))
-    
-    alert.addTextField { (textField) in
+
+    alert.addTextField { textField in
       textField.placeholder = "e.g.: tapped_close_button"
     }
-    
-    self.present(alert, animated: true, completion: nil)
+
+    present(alert, animated: true, completion: nil)
   }
-  
+
   @IBAction func checkTestButtonTapped(_ sender: Any) {
     let remoteConfig = RemoteConfig.remoteConfig()
-    
-    remoteConfig.fetchAndActivate { (status, error) in
+
+    remoteConfig.fetchAndActivate { status, error in
       // Fetch `bg_color` from remote config after activating.
       guard let color = remoteConfig.configValue(forKey: "bg_color").stringValue else {
         assertionFailure("Failed to fetch `bg_color` config value. Check the ABT console.")
         return
       }
-      
+
       // Set background color.
       DispatchQueue.main.async {
         // The AB test has two values for `bg_color`: "green or "red".

--- a/FirebaseABTesting/Tests/Integration/Podfile
+++ b/FirebaseABTesting/Tests/Integration/Podfile
@@ -1,15 +1,8 @@
-# Uncomment the next line to define a global platform for your project
-# platform :ios, '9.0'
-
 target 'ABTQA' do
-  # Comment the next line if you don't want to use dynamic frameworks
   use_frameworks!
 
-  # Pods for ABTQA
-  # add the Firebase pod for Google Analytics
   pod 'Firebase/Analytics'
-  pod 'Firebase/RemoteConfig'
-  # add pods for any other desired Firebase products
-  # https://firebase.google.com/docs/ios/setup#available-pods
-
+  pod 'FirebaseCore', :path => '../../..'
+  pod 'FirebaseRemoteConfig', :path => '../../..'
+  pod 'FirebaseABTesting', :path => '../../..'
 end

--- a/FirebaseABTesting/Tests/Integration/Podfile
+++ b/FirebaseABTesting/Tests/Integration/Podfile
@@ -1,0 +1,15 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '9.0'
+
+target 'ABTQA' do
+  # Comment the next line if you don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for ABTQA
+  # add the Firebase pod for Google Analytics
+  pod 'Firebase/Analytics'
+  pod 'Firebase/RemoteConfig'
+  # add pods for any other desired Firebase products
+  # https://firebase.google.com/docs/ios/setup#available-pods
+
+end


### PR DESCRIPTION
Adds an integration testing app that fetches an A/B tested parameter from Remote Config using development versions of the RC and ABT SDKs. There is also functionality to fire custom events to Analytics.

Links up to an existing Firebase project, but API keys in `GoogleService-Info.plist` are obfuscated.

#no-changelog