### PR TITLE
Provide an arbitrary data persistence mechanism on storage instances

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -211,12 +211,14 @@
 #pragma mark - GDTCORStorageProtocol
 
 - (void)libraryDataForKey:(nonnull NSString *)key
-               onComplete:(nonnull void (^)(NSData *_Nullable))onComplete {
+               onComplete:
+                   (nonnull void (^)(NSData *_Nullable, NSError *_Nullable error))onComplete {
   dispatch_async(_storageQueue, ^{
     NSString *dataPath = [[[self class] libraryDataPath] stringByAppendingPathComponent:key];
-    NSData *data = [NSData dataWithContentsOfFile:dataPath];
+    NSError *error;
+    NSData *data = [NSData dataWithContentsOfFile:dataPath options:0 error:&error];
     if (onComplete) {
-      onComplete(data);
+      onComplete(data, error);
     }
   });
 }

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -51,6 +51,27 @@
   return archivePath;
 }
 
++ (NSString *)libraryDataPath {
+  static NSString *libraryDataPath;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    libraryDataPath =
+        [GDTCORRootDirectory() URLByAppendingPathComponent:NSStringFromClass([self class])
+                                               isDirectory:YES]
+            .path;
+    libraryDataPath = [libraryDataPath stringByAppendingPathComponent:@"gdt_library_data"];
+    if (![[NSFileManager defaultManager] fileExistsAtPath:libraryDataPath isDirectory:NULL]) {
+      NSError *error;
+      [[NSFileManager defaultManager] createDirectoryAtPath:libraryDataPath
+                                withIntermediateDirectories:YES
+                                                 attributes:0
+                                                      error:&error];
+      GDTCORAssert(error == nil, @"Creating the library data path failed: %@", error);
+    }
+  });
+  return libraryDataPath;
+}
+
 + (instancetype)sharedInstance {
   static GDTCORFlatFileStorage *sharedStorage;
   static dispatch_once_t onceToken;
@@ -182,6 +203,39 @@
         // Remove from the tracking collections.
         [self.storedEvents removeObjectForKey:event.eventID];
         [self.targetToEventSet[@(event.target)] removeObject:event];
+      }
+    }
+  });
+}
+
+- (void)libraryDataForKey:(nonnull NSString *)key
+               onComplete:(nonnull void (^)(NSData *_Nullable))onComplete {
+  dispatch_async(_storageQueue, ^{
+    NSString *dataPath = [[[self class] libraryDataPath] stringByAppendingPathComponent:key];
+    NSData *data = [NSData dataWithContentsOfFile:dataPath];
+    if (onComplete) {
+      onComplete(data);
+    }
+  });
+}
+
+- (void)storeLibraryData:(nullable NSData *)data
+                  forKey:(nonnull NSString *)key
+              onComplete:(nonnull void (^)(NSError *_Nullable error))onComplete {
+  dispatch_async(_storageQueue, ^{
+    NSError *error;
+    NSString *dataPath = [[[self class] libraryDataPath] stringByAppendingPathComponent:key];
+    if (data && data.length > 0) {
+      [data writeToFile:dataPath options:NSDataWritingAtomic error:&error];
+      if (onComplete) {
+        onComplete(error);
+      }
+    } else {
+      if ([[NSFileManager defaultManager] fileExistsAtPath:dataPath]) {
+        [[NSFileManager defaultManager] removeItemAtPath:dataPath error:&error];
+        if (onComplete) {
+          onComplete(error);
+        }
       }
     }
   });

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h
@@ -25,6 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 /** Defines the interface a storage subsystem is expected to implement. */
 @protocol GDTCORStorageProtocol <NSObject, GDTCORLifecycleProtocol>
 
+@required
+
 /** Stores an event and calls onComplete with a non-nil error if anything went wrong.
  *
  * @param event The event to store
@@ -35,6 +37,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Removes the events from storage. */
 - (void)removeEvents:(NSSet<NSNumber *> *)eventIDs;
+
+/** Persists the given data with the given key.
+ *
+ * @param data The data to store.
+ * @param key The unique key to store it to.
+ * @param onComplete An block to be run when storage of the data is complete.
+ */
+- (void)storeLibraryData:(nullable NSData *)data
+                  forKey:(nonnull NSString *)key
+              onComplete:(void (^)(NSError *_Nullable error))onComplete;
+
+/** Retrieves the stored data for the given key.
+ *
+ * @param key The key corresponding to the desired data.
+ * @param onComplete The callback to invoke with the data once it's retrieved.
+ */
+- (void)libraryDataForKey:(NSString *)key onComplete:(void (^)(NSData *_Nullable data))onComplete;
 
 @end
 

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h
@@ -44,8 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @param key The unique key to store it to.
  * @param onComplete An block to be run when storage of the data is complete.
  */
-- (void)storeLibraryData:(nullable NSData *)data
-                  forKey:(nonnull NSString *)key
+- (void)storeLibraryData:(NSData *)data
+                  forKey:(NSString *)key
               onComplete:(void (^)(NSError *_Nullable error))onComplete;
 
 /** Retrieves the stored data for the given key.
@@ -54,6 +54,14 @@ NS_ASSUME_NONNULL_BEGIN
  * @param onComplete The callback to invoke with the data once it's retrieved.
  */
 - (void)libraryDataForKey:(NSString *)key onComplete:(void (^)(NSData *_Nullable data))onComplete;
+
+/** Removes data from storage and calls the callback when complete.
+ *
+ * @param key The key of the data to remove.
+ * @param onComplete The callback that will be invoked when removing the data is complete.
+ */
+- (void)removeLibraryDataForKey:(NSString *)key
+                     onComplete:(void (^)(NSError *_Nullable error))onComplete;
 
 @end
 

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h
@@ -53,7 +53,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @param key The key corresponding to the desired data.
  * @param onComplete The callback to invoke with the data once it's retrieved.
  */
-- (void)libraryDataForKey:(NSString *)key onComplete:(void (^)(NSData *_Nullable data))onComplete;
+- (void)libraryDataForKey:(NSString *)key
+               onComplete:(void (^)(NSData *_Nullable data, NSError *_Nullable error))onComplete;
 
 /** Removes data from storage and calls the callback when complete.
  *

--- a/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORStorageFake.m
+++ b/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORStorageFake.m
@@ -29,9 +29,10 @@
 }
 
 - (void)libraryDataForKey:(nonnull NSString *)key
-               onComplete:(nonnull void (^)(NSData *_Nullable))onComplete {
+               onComplete:
+                   (nonnull void (^)(NSData *_Nullable, NSError *_Nullable error))onComplete {
   if (onComplete) {
-    onComplete(nil);
+    onComplete(nil, nil);
   }
 }
 

--- a/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORStorageFake.m
+++ b/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORStorageFake.m
@@ -28,4 +28,19 @@
 - (void)removeEvents:(NSSet<NSNumber *> *)eventIDs {
 }
 
+- (void)libraryDataForKey:(nonnull NSString *)key
+               onComplete:(nonnull void (^)(NSData *_Nullable))onComplete {
+  if (onComplete) {
+    onComplete(nil);
+  }
+}
+
+- (void)storeLibraryData:(nullable NSData *)data
+                  forKey:(nonnull NSString *)key
+              onComplete:(nonnull void (^)(NSError *_Nullable error))onComplete {
+  if (onComplete) {
+    onComplete(nil);
+  }
+}
+
 @end

--- a/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORStorageFake.m
+++ b/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORStorageFake.m
@@ -35,9 +35,16 @@
   }
 }
 
-- (void)storeLibraryData:(nullable NSData *)data
+- (void)storeLibraryData:(NSData *)data
                   forKey:(nonnull NSString *)key
               onComplete:(nonnull void (^)(NSError *_Nullable error))onComplete {
+  if (onComplete) {
+    onComplete(nil);
+  }
+}
+
+- (void)removeLibraryDataForKey:(nonnull NSString *)key
+                     onComplete:(nonnull void (^)(NSError *_Nullable))onComplete {
   if (onComplete) {
     onComplete(nil);
   }

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
@@ -464,8 +464,9 @@ static NSInteger target = kGDTCORTargetCCT;
   XCTestExpectation *expectation = [self expectationWithDescription:@"retrieval completion called"];
   [[GDTCORFlatFileStorage sharedInstance]
       libraryDataForKey:dataKey
-             onComplete:^(NSData *_Nullable data) {
+             onComplete:^(NSData *_Nullable data, NSError *_Nullable error) {
                [expectation fulfill];
+               XCTAssertNil(error);
                XCTAssertEqualObjects(@"test data",
                                      [[NSString alloc] initWithData:data
                                                            encoding:NSUTF8StringEncoding]);
@@ -498,8 +499,9 @@ static NSInteger target = kGDTCORTargetCCT;
   expectation = [self expectationWithDescription:@"retrieval completion called"];
   [[GDTCORFlatFileStorage sharedInstance]
       libraryDataForKey:dataKey
-             onComplete:^(NSData *_Nullable data) {
+             onComplete:^(NSData *_Nullable data, NSError *_Nullable error) {
                [expectation fulfill];
+               XCTAssertNil(error);
                XCTAssertEqualObjects(@"test data",
                                      [[NSString alloc] initWithData:data
                                                            encoding:NSUTF8StringEncoding]);
@@ -513,11 +515,13 @@ static NSInteger target = kGDTCORTargetCCT;
                                                        }];
   [self waitForExpectations:@[ expectation ] timeout:10.0];
   expectation = [self expectationWithDescription:@"retrieval completion called"];
-  [[GDTCORFlatFileStorage sharedInstance] libraryDataForKey:dataKey
-                                                 onComplete:^(NSData *_Nullable data) {
-                                                   [expectation fulfill];
-                                                   XCTAssertNil(data);
-                                                 }];
+  [[GDTCORFlatFileStorage sharedInstance]
+      libraryDataForKey:dataKey
+             onComplete:^(NSData *_Nullable data, NSError *_Nullable error) {
+               [expectation fulfill];
+               XCTAssertNil(error);
+               XCTAssertNil(data);
+             }];
   [self waitForExpectations:@[ expectation ] timeout:10.0];
 }
 

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
@@ -445,6 +445,31 @@ static NSInteger target = kGDTCORTargetCCT;
   }
 }
 
+- (void)testSaveAndLoadLibraryData {
+  __weak NSData *weakData;
+  NSString *dataKey = @"GDTCORFlatFileStorageTestData";
+  @autoreleasepool {
+    NSData *data = [@"test data" dataUsingEncoding:NSUTF8StringEncoding];
+    weakData = data;
+    XCTestExpectation *expectation = [self expectationWithDescription:@"storage completion called"];
+    [[GDTCORFlatFileStorage sharedInstance] storeLibraryData:data
+                                                      forKey:dataKey
+                                                  onComplete:^(NSError *_Nullable error) {
+                                                    XCTAssertNil(error);
+                                                    [expectation fulfill];
+                                                  }];
+    [self waitForExpectations:@[ expectation ] timeout:1.0];
+  }
+  XCTAssertNil(weakData);
+  [[GDTCORFlatFileStorage sharedInstance]
+      libraryDataForKey:dataKey
+             onComplete:^(NSData *_Nullable data) {
+               XCTAssertEqualObjects(@"test data",
+                                     [[NSString alloc] initWithData:data
+                                                           encoding:NSUTF8StringEncoding]);
+             }];
+}
+
 /** Tests migration from v1 of the storage format to v2. */
 - (void)testMigrationFromOldVersion {
   static NSString *base64EncodedArchive =

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
@@ -447,7 +447,7 @@ static NSInteger target = kGDTCORTargetCCT;
 
 - (void)testSaveAndLoadLibraryData {
   __weak NSData *weakData;
-  NSString *dataKey = @"GDTCORFlatFileStorageTestData";
+  NSString *dataKey = NSStringFromSelector(_cmd);
   @autoreleasepool {
     NSData *data = [@"test data" dataUsingEncoding:NSUTF8StringEncoding];
     weakData = data;
@@ -486,7 +486,7 @@ static NSInteger target = kGDTCORTargetCCT;
 }
 
 - (void)testSaveAndRemoveLibraryData {
-  NSString *dataKey = @"GDTCORFlatFileStorageTestData";
+  NSString *dataKey = NSStringFromSelector(_cmd);
   NSData *data = [@"test data" dataUsingEncoding:NSUTF8StringEncoding];
   XCTestExpectation *expectation = [self expectationWithDescription:@"storage completion called"];
   [[GDTCORFlatFileStorage sharedInstance] storeLibraryData:data
@@ -519,7 +519,7 @@ static NSInteger target = kGDTCORTargetCCT;
       libraryDataForKey:dataKey
              onComplete:^(NSData *_Nullable data, NSError *_Nullable error) {
                [expectation fulfill];
-               XCTAssertNil(error);
+               XCTAssertNotNil(error);
                XCTAssertNil(data);
              }];
   [self waitForExpectations:@[ expectation ] timeout:10.0];


### PR DESCRIPTION
This could allow most singletons to no longer need NSCoding, they just store the individual fields they need with an appropriately unique key.

#no-changelog