### PR TITLE
Better completion callback for activate

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,7 +1,11 @@
-# Unreleased
+# v4.5.0
 - [changed] Updated `fetchAndActivateWithCompletionHandler:` implementation to activate asynchronously. (#5617)
 - [fixed] Remove undefined class via removing unused proto generated source files. (#4334)
 - [added] Add an URLSession Partial Mock to enable testing without a backend. (#5633)
+- [added] Added activate API that returns a callback with an additional `bool` parameter indicating
+if the config has changed or not. The new API does not error if the console is unchanged. The old
+activate API with only an error parameter is deprecated and will be removed at the next major
+release. (#3586)
 
 # v4.4.11
 - [fixed] Fixed a bug where settings updates weren't applied before fetches. (#4740)

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -278,7 +278,16 @@ static NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, FIRRemote
   return didActivate;
 }
 
+- (void)activateWithCompletion:(FIRRemoteConfigActivateChangeCompletion)completion {
+  [self activateWithEitherHandler:completion deprecatedHandler:nil];
+}
+
 - (void)activateWithCompletionHandler:(FIRRemoteConfigActivateCompletion)completionHandler {
+  [self activateWithEitherHandler:nil deprecatedHandler:completionHandler];
+}
+
+- (void)activateWithEitherHandler:(FIRRemoteConfigActivateChangeCompletion)completion
+                deprecatedHandler:(FIRRemoteConfigActivateCompletion)deprecatedHandler {
   __weak FIRRemoteConfig *weakSelf = self;
   void (^applyBlock)(void) = ^(void) {
     FIRRemoteConfig *strongSelf = weakSelf;
@@ -286,29 +295,36 @@ static NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, FIRRemote
       NSError *error = [NSError errorWithDomain:FIRRemoteConfigErrorDomain
                                            code:FIRRemoteConfigErrorInternalError
                                        userInfo:@{@"ActivationFailureReason" : @"Internal Error."}];
-      if (completionHandler) {
+      if (completion) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-          completionHandler(error);
+          completion(NO, error);
         });
+      } else if (deprecatedHandler) {
+        deprecatedHandler(error);
       }
       FIRLogError(kFIRLoggerRemoteConfig, @"I-RCN000068", @"Internal error activating config.");
       return;
     }
     // Check if the last fetched config has already been activated. Fetches with no data change are
     // ignored.
+    NSLog(@"%f %f", strongSelf->_settings.lastETagUpdateTime, strongSelf->_settings.lastApplyTimeInterval);
     if (strongSelf->_settings.lastETagUpdateTime == 0 ||
         strongSelf->_settings.lastETagUpdateTime <= strongSelf->_settings.lastApplyTimeInterval) {
       FIRLogWarning(kFIRLoggerRemoteConfig, @"I-RCN000069",
                     @"Most recently fetched config is already activated.");
-      NSError *error = [NSError
-          errorWithDomain:FIRRemoteConfigErrorDomain
-                     code:FIRRemoteConfigErrorInternalError
-                 userInfo:@{
-                   @"ActivationFailureReason" : @"Most recently fetched config is already activated"
-                 }];
-      if (completionHandler) {
+      if (completion) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-          completionHandler(error);
+          completion(NO, nil);
+        });
+      } else if (deprecatedHandler) {
+        NSError *error = [NSError
+            errorWithDomain:FIRRemoteConfigErrorDomain
+                       code:FIRRemoteConfigErrorInternalError
+                   userInfo:@{
+                     @"ActivationFailureReason" : @"Most recently fetched config already activated"
+                   }];
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+          deprecatedHandler(error);
         });
       }
       return;
@@ -319,9 +335,13 @@ static NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, FIRRemote
     [strongSelf updateExperiments];
     strongSelf->_settings.lastApplyTimeInterval = [[NSDate date] timeIntervalSince1970];
     FIRLogDebug(kFIRLoggerRemoteConfig, @"I-RCN000069", @"Config activated.");
-    if (completionHandler) {
+    if (completion) {
       dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        completionHandler(nil);
+        completion(YES, nil);
+      });
+    } else if (deprecatedHandler) {
+      dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        deprecatedHandler(nil);
       });
     }
   };

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -278,6 +278,8 @@ static NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, FIRRemote
   return didActivate;
 }
 
+typedef void (^FIRRemoteConfigActivateChangeCompletion)(BOOL changed, NSError *_Nullable error);
+
 - (void)activateWithCompletion:(FIRRemoteConfigActivateChangeCompletion)completion {
   [self activateWithEitherHandler:completion deprecatedHandler:nil];
 }

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -307,7 +307,8 @@ static NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, FIRRemote
     }
     // Check if the last fetched config has already been activated. Fetches with no data change are
     // ignored.
-    NSLog(@"%f %f", strongSelf->_settings.lastETagUpdateTime, strongSelf->_settings.lastApplyTimeInterval);
+    NSLog(@"%f %f", strongSelf->_settings.lastETagUpdateTime,
+          strongSelf->_settings.lastApplyTimeInterval);
     if (strongSelf->_settings.lastETagUpdateTime == 0 ||
         strongSelf->_settings.lastETagUpdateTime <= strongSelf->_settings.lastApplyTimeInterval) {
       FIRLogWarning(kFIRLoggerRemoteConfig, @"I-RCN000069",

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -311,8 +311,8 @@ typedef void (^FIRRemoteConfigActivateChangeCompletion)(BOOL changed, NSError *_
     // ignored.
     if (strongSelf->_settings.lastETagUpdateTime == 0 ||
         strongSelf->_settings.lastETagUpdateTime <= strongSelf->_settings.lastApplyTimeInterval) {
-      FIRLogWarning(kFIRLoggerRemoteConfig, @"I-RCN000069",
-                    @"Most recently fetched config is already activated.");
+      FIRLogDebug(kFIRLoggerRemoteConfig, @"I-RCN000069",
+                  @"Most recently fetched config is already activated.");
       if (completion) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
           completion(NO, nil);

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -309,8 +309,6 @@ typedef void (^FIRRemoteConfigActivateChangeCompletion)(BOOL changed, NSError *_
     }
     // Check if the last fetched config has already been activated. Fetches with no data change are
     // ignored.
-    NSLog(@"%f %f", strongSelf->_settings.lastETagUpdateTime,
-          strongSelf->_settings.lastApplyTimeInterval);
     if (strongSelf->_settings.lastETagUpdateTime == 0 ||
         strongSelf->_settings.lastETagUpdateTime <= strongSelf->_settings.lastApplyTimeInterval) {
       FIRLogWarning(kFIRLoggerRemoteConfig, @"I-RCN000069",

--- a/FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h
+++ b/FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h
@@ -87,6 +87,12 @@ typedef void (^FIRRemoteConfigFetchCompletion)(FIRRemoteConfigFetchStatus status
 typedef void (^FIRRemoteConfigActivateCompletion)(NSError *_Nullable error)
     NS_SWIFT_NAME(RemoteConfigActivateCompletion);
 
+/// Completion handler invoked by activate method upon completion.
+/// @param changed  Flag indicating whether or not the configuration changed.
+/// @param error  Error message on failure. Nil if activation was successful.
+typedef void (^FIRRemoteConfigActivateChangeCompletion)(BOOL changed, NSError *_Nullable error)
+    NS_SWIFT_NAME(RemoteConfigActivateChangeCompletion);
+
 /// Completion handler invoked upon completion of Remote Config initialization.
 ///
 /// @param initializationError nil if initialization succeeded.
@@ -234,16 +240,21 @@ NS_SWIFT_NAME(RemoteConfig)
 
 /// Applies Fetched Config data to the Active Config, causing updates to the behavior and appearance
 /// of the app to take effect (depending on how config data is used in the app).
+/// @param completion Activate operation callback.
+- (void)activateWithCompletion:(nullable FIRRemoteConfigActivateChangeCompletion)completion;
+
+/// Applies Fetched Config data to the Active Config, causing updates to the behavior and appearance
+/// of the app to take effect (depending on how config data is used in the app).
 /// @param completionHandler Activate operation callback.
-- (void)activateWithCompletionHandler:(nullable FIRRemoteConfigActivateCompletion)completionHandler;
+- (void)activateWithCompletionHandler:(nullable FIRRemoteConfigActivateCompletion)completionHandler
+    DEPRECATED_MSG_ATTRIBUTE("Use -[FIRRemoteConfig activateWithHandler:] instead.");
 
 /// This method is deprecated. Please use -[FIRRemoteConfig activateWithCompletionHandler:] instead.
 /// Applies Fetched Config data to the Active Config, causing updates to the behavior and appearance
 /// of the app to take effect (depending on how config data is used in the app).
 /// Returns true if there was a Fetched Config, and it was activated.
 /// Returns false if no Fetched Config was found, or the Fetched Config was already activated.
-- (BOOL)activateFetched DEPRECATED_MSG_ATTRIBUTE("Use -[FIRRemoteConfig activate] "
-                                                 "instead.");
+- (BOOL)activateFetched DEPRECATED_MSG_ATTRIBUTE("Use -[FIRRemoteConfig activate] instead.");
 
 #pragma mark - Get Config
 /// Enables access to configuration values by using object subscripting syntax.
@@ -265,8 +276,7 @@ NS_SWIFT_NAME(RemoteConfig)
 /// @param aNamespace       Config results under a given namespace.
 - (nonnull FIRRemoteConfigValue *)configValueForKey:(nullable NSString *)key
                                           namespace:(nullable NSString *)aNamespace
-    DEPRECATED_MSG_ATTRIBUTE("Use -[FIRRemoteConfig configValueForKey:] "
-                             "instead.");
+    DEPRECATED_MSG_ATTRIBUTE("Use -[FIRRemoteConfig configValueForKey:] instead.");
 
 /// Gets the config value of a given namespace and a given source.
 /// @param key              Config key.
@@ -281,8 +291,7 @@ NS_SWIFT_NAME(RemoteConfig)
 - (nonnull FIRRemoteConfigValue *)configValueForKey:(nullable NSString *)key
                                           namespace:(nullable NSString *)aNamespace
                                              source:(FIRRemoteConfigSource)source
-    DEPRECATED_MSG_ATTRIBUTE("Use -[FIRRemoteConfig configValueForKey:source:] "
-                             "instead.");
+    DEPRECATED_MSG_ATTRIBUTE("Use -[FIRRemoteConfig configValueForKey:source:] instead.");
 
 /// Gets all the parameter keys from a given source and a given namespace.
 ///

--- a/FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h
+++ b/FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h
@@ -87,12 +87,6 @@ typedef void (^FIRRemoteConfigFetchCompletion)(FIRRemoteConfigFetchStatus status
 typedef void (^FIRRemoteConfigActivateCompletion)(NSError *_Nullable error)
     NS_SWIFT_NAME(RemoteConfigActivateCompletion);
 
-/// Completion handler invoked by activate method upon completion.
-/// @param changed  Flag indicating whether or not the configuration changed.
-/// @param error  Error message on failure. Nil if activation was successful.
-typedef void (^FIRRemoteConfigActivateChangeCompletion)(BOOL changed, NSError *_Nullable error)
-    NS_SWIFT_NAME(RemoteConfigActivateChangeCompletion);
-
 /// Completion handler invoked upon completion of Remote Config initialization.
 ///
 /// @param initializationError nil if initialization succeeded.
@@ -240,8 +234,9 @@ NS_SWIFT_NAME(RemoteConfig)
 
 /// Applies Fetched Config data to the Active Config, causing updates to the behavior and appearance
 /// of the app to take effect (depending on how config data is used in the app).
-/// @param completion Activate operation callback.
-- (void)activateWithCompletion:(nullable FIRRemoteConfigActivateChangeCompletion)completion;
+/// @param completion Activate operation callback with changed and error parameters.
+- (void)activateWithCompletion:(void (^_Nullable)(BOOL changed,
+                                                  NSError *_Nullable error))completion;
 
 /// Applies Fetched Config data to the Active Config, causing updates to the behavior and appearance
 /// of the app to take effect (depending on how config data is used in the app).

--- a/FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h
+++ b/FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h
@@ -242,7 +242,7 @@ NS_SWIFT_NAME(RemoteConfig)
 /// of the app to take effect (depending on how config data is used in the app).
 /// @param completionHandler Activate operation callback.
 - (void)activateWithCompletionHandler:(nullable FIRRemoteConfigActivateCompletion)completionHandler
-    DEPRECATED_MSG_ATTRIBUTE("Use -[FIRRemoteConfig activateWithHandler:] instead.");
+    DEPRECATED_MSG_ATTRIBUTE("Use -[FIRRemoteConfig activateWithCompletion:] instead.");
 
 /// This method is deprecated. Please use -[FIRRemoteConfig activateWithCompletionHandler:] instead.
 /// Applies Fetched Config data to the Active Config, causing updates to the behavior and appearance

--- a/FirebaseRemoteConfig/Tests/FakeConsole/FakeConsoleTests.swift
+++ b/FirebaseRemoteConfig/Tests/FakeConsole/FakeConsoleTests.swift
@@ -71,7 +71,7 @@ class FakeConsoleTests: APITestBase {
       XCTAssertEqual(status, RemoteConfigFetchStatus.success)
       self.config.activate { changed, error in
         XCTAssertNil(error)
-        XCTAssert(changed)
+        XCTAssertTrue(changed)
         XCTAssertEqual(self.config["Key1"].stringValue, "Value1")
         expectation.fulfill()
       }

--- a/FirebaseRemoteConfig/Tests/FakeConsole/FakeConsoleTests.swift
+++ b/FirebaseRemoteConfig/Tests/FakeConsole/FakeConsoleTests.swift
@@ -23,6 +23,7 @@ class FakeConsoleTests: APITestBase {
     fakeConsole.config = ["Key1": "Value1"]
   }
 
+  // Test old API.
   // Contrast with testUnchangedActivateWillError in APITests.swift.
   func testChangedActivateWillNotError() {
     let expectation = self.expectation(description: #function)
@@ -52,6 +53,43 @@ class FakeConsoleTests: APITestBase {
       XCTAssertEqual(status, RemoteConfigFetchStatus.success)
       self.config.activate { error in
         XCTAssertNil(error)
+        XCTAssertEqual(self.config["Key1"].stringValue, "Value2")
+        expectation2.fulfill()
+      }
+    }
+    waitForExpectations()
+  }
+
+  // Test New API.
+  // Contrast with testUnchangedActivateWillFlag in APITests.swift.
+  func testChangedActivateWillNotFlag() {
+    let expectation = self.expectation(description: #function)
+    config.fetch { status, error in
+      if let error = error {
+        XCTFail("Fetch Error \(error)")
+      }
+      XCTAssertEqual(status, RemoteConfigFetchStatus.success)
+      self.config.activate { changed, error in
+        XCTAssertNil(error)
+        XCTAssert(changed)
+        XCTAssertEqual(self.config["Key1"].stringValue, "Value1")
+        expectation.fulfill()
+      }
+    }
+    waitForExpectations()
+
+    // Simulate updating console.
+    fakeConsole.config = ["Key1": "Value2"]
+
+    let expectation2 = self.expectation(description: #function + "2")
+    config.fetch { status, error in
+      if let error = error {
+        XCTFail("Fetch Error \(error)")
+      }
+      XCTAssertEqual(status, RemoteConfigFetchStatus.success)
+      self.config.activate { changed, error in
+        XCTAssertNil(error)
+        XCTAssert(changed)
         XCTAssertEqual(self.config["Key1"].stringValue, "Value2")
         expectation2.fulfill()
       }

--- a/FirebaseRemoteConfig/Tests/SwiftAPI/APITests.swift
+++ b/FirebaseRemoteConfig/Tests/SwiftAPI/APITests.swift
@@ -116,9 +116,7 @@ class APITests: APITestBase {
       XCTAssertEqual(status, RemoteConfigFetchStatus.success)
       self.config.activate { changed, error in
         XCTAssertTrue(!APITests.useFakeConfig || changed)
-        if let error = error {
-          print("Activate Error \(error)")
-        }
+        XCTAssertNil(error)
         XCTAssertEqual(self.config["Key1"].stringValue, "Value1")
         expectation.fulfill()
       }

--- a/FirebaseRemoteConfig/Tests/SwiftAPI/APITests.swift
+++ b/FirebaseRemoteConfig/Tests/SwiftAPI/APITests.swift
@@ -32,11 +32,8 @@ class APITests: APITestBase {
         XCTFail("Fetch Error \(error)")
       }
       XCTAssertEqual(status, RemoteConfigFetchStatus.success)
-      self.config.activate { error in
-        if let error = error {
-          // This API returns an error if the config was unchanged.
-          print("Activate Error \(error)")
-        }
+      self.config.activate { _, error in
+        XCTAssertNil(error)
         XCTAssertEqual(self.config["Key1"].stringValue, "Value1")
         expectation.fulfill()
       }
@@ -51,11 +48,8 @@ class APITests: APITestBase {
         XCTFail("Fetch Error \(error)")
       }
       XCTAssertEqual(status, RemoteConfigFetchStatus.success)
-      self.config.activate { error in
-        if let error = error {
-          // This API returns an error if the config was unchanged.
-          print("Activate Error \(error)")
-        }
+      self.config.activate { _, error in
+        XCTAssertNil(error)
         XCTAssertEqual(self.config["Key1"].stringValue, "Value1")
         expectation.fulfill()
       }

--- a/FirebaseRemoteConfig/Tests/SwiftAPI/APITests.swift
+++ b/FirebaseRemoteConfig/Tests/SwiftAPI/APITests.swift
@@ -69,6 +69,7 @@ class APITests: APITestBase {
     waitForExpectations()
   }
 
+  // Test old API.
   // Contrast with testChangedActivateWillNotError in FakeConsole.swift.
   func testUnchangedActivateWillError() {
     let expectation = self.expectation(description: #function)
@@ -97,6 +98,41 @@ class APITests: APITestBase {
         if let error = error {
           XCTAssertEqual((error as NSError).code, RemoteConfigError.internalError.rawValue)
         }
+        XCTAssertEqual(self.config["Key1"].stringValue, "Value1")
+        expectation2.fulfill()
+      }
+    }
+    waitForExpectations()
+  }
+
+  // Test New API.
+  // Contrast with testChangedActivateWillNotFlag in FakeConsole.swift.
+  func testUnchangedActivateWillFlag() {
+    let expectation = self.expectation(description: #function)
+    config.fetch { status, error in
+      if let error = error {
+        XCTFail("Fetch Error \(error)")
+      }
+      XCTAssertEqual(status, RemoteConfigFetchStatus.success)
+      self.config.activate { changed, error in
+        XCTAssertTrue(!APITests.useFakeConfig || changed)
+        if let error = error {
+          print("Activate Error \(error)")
+        }
+        XCTAssertEqual(self.config["Key1"].stringValue, "Value1")
+        expectation.fulfill()
+      }
+    }
+    waitForExpectations()
+    let expectation2 = self.expectation(description: #function + "2")
+    config.fetch { status, error in
+      if let error = error {
+        XCTFail("Fetch Error \(error)")
+      }
+      XCTAssertEqual(status, RemoteConfigFetchStatus.success)
+      self.config.activate { changed, error in
+        XCTAssertFalse(changed)
+        XCTAssertNil(error)
         XCTAssertEqual(self.config["Key1"].stringValue, "Value1")
         expectation2.fulfill()
       }


### PR DESCRIPTION
Adds an activate API with a changed parameter in the callback. It replaces a deprecated API that set an internal error if there was no change.

Fixes #3586 

The integration test infrastructure is implemented in #5633 

Googlers: See accompanying API proposal.