### PR TITLE
FIS - make server error logs more readable

### DIFF
--- a/FirebaseInstallations/CHANGELOG.md
+++ b/FirebaseInstallations/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [changed] Mac OS Keychain storage changes: use a unique (per app) Keychain Service name to isolate Keychain items for different Mac OS applications.
   NOTE: Installation Identifiers created by previous versions will be reset on Mac OS which can affect e.g. A/B Testing variants or debug device targeting for Firebase Messaging.
   iOS, TVOS and watchOS Installation Identifiers will not be affected. (#5603)
+- [changed] More readable server error console messages. (#5654)
 
 # v1.2.0 -- M69
 

--- a/FirebaseInstallations/Source/Library/Errors/FIRInstallationsHTTPError.m
+++ b/FirebaseInstallations/Source/Library/Errors/FIRInstallationsHTTPError.m
@@ -41,9 +41,10 @@
 + (NSDictionary *)userInfoWithHTTPResponse:(NSHTTPURLResponse *)HTTPResponse
                                       data:(nullable NSData *)data {
   NSString *responseString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
-  NSString *failureReason = [NSString
-      stringWithFormat:@"The server responded with an error. HTTP response: %@\nResponse body: %@",
-                       HTTPResponse, responseString];
+  NSString *failureReason =
+      [NSString stringWithFormat:@"The server responded with an error: \n - URL: %@ \n - HTTP "
+                                 @"status code: %ld \n - Response body: %@",
+                                 HTTPResponse.URL, (long)HTTPResponse.statusCode, responseString];
   return @{NSLocalizedFailureReasonErrorKey : failureReason};
 }
 

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -258,9 +258,9 @@ static NSString *const kKeychainService = @"com.firebase.FIRInstallations.instal
         if ([self doesRegistrationErrorRequireConfigChange:error]) {
           FIRLogError(kFIRLoggerInstallations,
                       kFIRInstallationsMessageCodeInvalidFirebaseConfiguration,
-                      @"Firebase Installation registration failed for app with name: %@, error: "
+                      @"Firebase Installation registration failed for app with name: %@, error:\n"
                       @"%@\nPlease make sure you use valid GoogleService-Info.plist",
-                      self.appName, error);
+                      self.appName, error.userInfo[NSLocalizedFailureReasonErrorKey]);
         }
       })
       .then(^id(FIRInstallationsItem *registeredInstallation) {

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsHTTPErrorTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsHTTPErrorTests.m
@@ -48,8 +48,6 @@
   XCTAssertTrue([failureReason containsString:HTTPResponse.URL.absoluteString]);
   XCTAssertTrue([failureReason containsString:@(HTTPResponse.statusCode).stringValue]);
   XCTAssertTrue([failureReason containsString:@(HTTPResponse.statusCode).stringValue]);
-  XCTAssertTrue([failureReason containsString:@"header1"]);
-  XCTAssertTrue([failureReason containsString:@"value1"]);
 
   // Validate response data content.
   XCTAssertTrue([failureReason containsString:@"invalid request"]);


### PR DESCRIPTION
- remove extra information from the log
- improve formatting

Example:
<img width="651" alt="Screen Shot 2020-05-20 at 11 06 32 AM" src="https://user-images.githubusercontent.com/1841926/82462850-182d2e80-9a8a-11ea-9ac9-234d61819e4f.png">
