### PR TITLE
Fixing unwanted pending dynamic links checks on subsequent app restarts

### DIFF
--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fixing unwanted pending dynamic links checks on subsequent app restarts
+
 # v4.0.8 -- M67
 - [fixed] Fix Catalyst build - removed deprecated unused Apple framework dependencies. (#5139)
 

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
@@ -554,9 +554,14 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
   self.retrievingPendingDynamicLink = NO;
   _retrievalProcess = nil;
 
-  if (!result.error && ![_userDefaults boolForKey:kFIRDLOpenURLKey]) {
+  if (![_userDefaults boolForKey:kFIRDLOpenURLKey]) {
+    //Once we complete the Pending dynamic link retrival, regardless of whether the retrival is
+    //success or failure, we don't want to do the retrival again on next app start.
+    //If we try to redo the retrival again because of some error, the user will experiance unwanted
+    //deeplinking when they restart the app next time.
     [_userDefaults setBool:YES forKey:kFIRDLOpenURLKey];
   }
+
   NSURL *linkToPassToApp = [result URLWithCustomURLScheme:_URLScheme];
   [self passRetrievedDynamicLinkToApplication:linkToPassToApp];
 }

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
@@ -555,10 +555,10 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
   _retrievalProcess = nil;
 
   if (![_userDefaults boolForKey:kFIRDLOpenURLKey]) {
-    //Once we complete the Pending dynamic link retrival, regardless of whether the retrival is
-    //success or failure, we don't want to do the retrival again on next app start.
-    //If we try to redo the retrival again because of some error, the user will experiance unwanted
-    //deeplinking when they restart the app next time.
+    // Once we complete the Pending dynamic link retrival, regardless of whether the retrival is
+    // success or failure, we don't want to do the retrival again on next app start.
+    // If we try to redo the retrival again because of some error, the user will experiance unwanted
+    // deeplinking when they restart the app next time.
     [_userDefaults setBool:YES forKey:kFIRDLOpenURLKey];
   }
 

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
@@ -555,10 +555,10 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
   _retrievalProcess = nil;
 
   if (![_userDefaults boolForKey:kFIRDLOpenURLKey]) {
-    // Once we complete the Pending dynamic link retrieval, regardless of whether the retrival is
-    // success or failure, we don't want to do the retrival again on next app start.
-    // If we try to redo the retrival again because of some error, the user will experiance unwanted
-    // deeplinking when they restart the app next time.
+    // Once we complete the Pending dynamic link retrieval, regardless of whether the retrieval is
+    // success or failure, we don't want to do the retrieval again on next app start.
+    // If we try to redo the retrieval again because of some error, the user will experience
+    // unwanted deeplinking when they restart the app next time.
     [_userDefaults setBool:YES forKey:kFIRDLOpenURLKey];
   }
 

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
@@ -555,7 +555,7 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
   _retrievalProcess = nil;
 
   if (![_userDefaults boolForKey:kFIRDLOpenURLKey]) {
-    // Once we complete the Pending dynamic link retrival, regardless of whether the retrival is
+    // Once we complete the Pending dynamic link retrieval, regardless of whether the retrival is
     // success or failure, we don't want to do the retrival again on next app start.
     // If we try to redo the retrival again because of some error, the user will experiance unwanted
     // deeplinking when they restart the app next time.

--- a/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
+++ b/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
@@ -23,6 +23,7 @@
 #import <GoogleUtilities/GULSwizzler+Unswizzle.h>
 #import <GoogleUtilities/GULSwizzler.h>
 #import <OCMock/OCMock.h>
+#import "FirebaseDynamicLinks/Sources/FIRDLDefaultRetrievalProcessV2.h"
 #import "FirebaseDynamicLinks/Sources/FIRDLRetrievalProcessFactory.h"
 #import "FirebaseDynamicLinks/Sources/FIRDLRetrievalProcessResult+Private.h"
 #import "FirebaseDynamicLinks/Sources/FIRDynamicLink+Private.h"
@@ -1169,6 +1170,31 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
   [GULSwizzler unswizzleClass:[FIRDLRetrievalProcessFactory class]
                      selector:selectorToSwizzle
               isClassSelector:NO];
+}
+
+- (void)test_retrievePendingDeepLinkShouldSetkFIRDLOpenURLKeyRegardlessOfFailures {
+  [self.service setUpWithLaunchOptions:nil
+                                apiKey:kAPIKey
+                              clientID:kClientID
+                             urlScheme:nil
+                          userDefaults:[NSUserDefaults standardUserDefaults]];
+  FIRDynamicLinks<FIRDLRetrievalProcessDelegate> *deleagte =
+      (FIRDynamicLinks<FIRDLRetrievalProcessDelegate> *)self.service;
+
+  // Error Result to pass
+  FIRDLRetrievalProcessResult *result = [[FIRDLRetrievalProcessResult alloc]
+      initWithDynamicLink:nil
+                    error:[NSError errorWithDomain:@"unknown domain" code:500 userInfo:nil]
+                  message:nil
+              matchSource:nil];
+
+  FIRDLDefaultRetrievalProcessV2 *defaultRetrievalProcess = [FIRDLDefaultRetrievalProcessV2 alloc];
+
+  [deleagte retrievalProcess:defaultRetrievalProcess completedWithResult:result];
+
+  NSString *kFIRDLOpenURLKey = @"com.google.appinvite.openURL";
+  XCTAssertEqual([[NSUserDefaults standardUserDefaults] boolForKey:kFIRDLOpenURLKey], YES,
+                 @"kFIRDLOpenURL key should be set regardless of failures");
 }
 
 #pragma mark - Self-diagnose tests


### PR DESCRIPTION
Fix for b/154589338

Most of the times, when the app is cold started, we are making api calls to:

https://firebasedynamiclinks-ipv4.googleapis.com/v1
https://firebasedynamiclinks-ipv6.googleapis.com/v1

Until we get a successful response. But sometimes, if the device doesn’t have support for v6 endpoint and if the v4 endpoint doesn’t retrieve a valid dynamic link, it will return error. This mostly happens when user directly goes to App Store and installs an app which has fdl sdk integrated.

For dynamic links, we want the app to retrieve the pending dynamic link on the very first start of the app after install so that 3p developers can deeplink to a particular page in the app. If the pending links retrieval failed during the first start, there is no point in retrying the retrieval during next restart since it could result in an un expected  deep link for the user when they opens up the app for subsequent restarts (if a valid dynamic link is returned).
