### PR TITLE
use UNNotificationRequest to schedule local notification for iOS 10 and above

### DIFF
--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2020-06 -- v4.4.2
-- [changed] Use UNNotificationRequest to schedule local notification for local timezone notification for iOS 10 ang above. (#5667)
+- [changed] Use UNNotificationRequest to schedule local notification for local timezone notification for iOS 10 and above. This should also fix the issue that '%' was not properly shown in title and body. (#5667)
 
 # 2020-05 -- v4.4.1
 - [changed] Updated NSError with a failure reason to give more details on the error. (#5511)

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 2020-06 -- v4.4.2
+# unreleased
 - [changed] Use UNNotificationRequest to schedule local notification for local timezone notification for iOS 10 and above. This should also fix the issue that '%' was not properly shown in title and body. (#5667)
 
 # 2020-05 -- v4.4.1

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2020-06 -- v4.4.2
+- [changed] Use UNNotificationRequest to schedule local notification for local timezone notification for iOS 10 ang above. (#5667)
+
 # 2020-05 -- v4.4.1
 - [changed] Updated NSError with a failure reason to give more details on the error. (#5511)
 

--- a/FirebaseMessaging/Sources/FIRMMessageCode.h
+++ b/FirebaseMessaging/Sources/FIRMMessageCode.h
@@ -96,7 +96,7 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingMessageCodeContextManagerService003 = 6003,                  // I-FCM006003
   kFIRMessagingMessageCodeContextManagerService004 = 6004,                  // I-FCM006004
   kFIRMessagingMessageCodeContextManagerService005 = 6005,                  // I-FCM006005
-  kFIRMessagingMessageCodeContextManagerServiceFailedLocalSchedule = 6006,  // I-FCM006005
+  kFIRMessagingMessageCodeContextManagerServiceFailedLocalSchedule = 6006,  // I-FCM006006
   // FIRMessagingDataMessageManager.m
   // DO NOT USE 7005
   kFIRMessagingMessageCodeDataMessageManager000 = 7000,  // I-FCM007000

--- a/FirebaseMessaging/Sources/FIRMMessageCode.h
+++ b/FirebaseMessaging/Sources/FIRMMessageCode.h
@@ -90,12 +90,13 @@ typedef NS_ENUM(NSInteger, FIRMessagingMessageCode) {
   kFIRMessagingMessageCodeConnection022 = 5022,  // I-FCM005022
   kFIRMessagingMessageCodeConnection023 = 5023,  // I-FCM005023
   // FIRMessagingContextManagerService.m
-  kFIRMessagingMessageCodeContextManagerService000 = 6000,  // I-FCM006000
-  kFIRMessagingMessageCodeContextManagerService001 = 6001,  // I-FCM006001
-  kFIRMessagingMessageCodeContextManagerService002 = 6002,  // I-FCM006002
-  kFIRMessagingMessageCodeContextManagerService003 = 6003,  // I-FCM006003
-  kFIRMessagingMessageCodeContextManagerService004 = 6004,  // I-FCM006004
-  kFIRMessagingMessageCodeContextManagerService005 = 6005,  // I-FCM006005
+  kFIRMessagingMessageCodeContextManagerService000 = 6000,                  // I-FCM006000
+  kFIRMessagingMessageCodeContextManagerService001 = 6001,                  // I-FCM006001
+  kFIRMessagingMessageCodeContextManagerService002 = 6002,                  // I-FCM006002
+  kFIRMessagingMessageCodeContextManagerService003 = 6003,                  // I-FCM006003
+  kFIRMessagingMessageCodeContextManagerService004 = 6004,                  // I-FCM006004
+  kFIRMessagingMessageCodeContextManagerService005 = 6005,                  // I-FCM006005
+  kFIRMessagingMessageCodeContextManagerServiceFailedLocalSchedule = 6006,  // I-FCM006005
   // FIRMessagingDataMessageManager.m
   // DO NOT USE 7005
   kFIRMessagingMessageCodeDataMessageManager000 = 7000,  // I-FCM007000

--- a/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
+++ b/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0 || \
-    __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_14 ||    \
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0 ||                                          \
+    __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_14 || __TV_OS_VERSION_MAX_ALLOWED >= __TV_10_0 || \
     __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_3_0 || TARGET_OS_MACCATALYST
 #import <UserNotifications/UserNotifications.h>
 #endif

--- a/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
+++ b/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
@@ -144,7 +144,7 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
     NSDateComponents *dateComponents = [calendar components:(NSCalendarUnit)unit fromDate:date];
     UNCalendarNotificationTrigger *trigger =
         [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:dateComponents
-                                                                 repeats:YES];
+                                                                 repeats:NO];
 
     UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
     NSDictionary *apsDictionary = message;

--- a/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
+++ b/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
@@ -138,7 +138,7 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
 
 + (void)scheduleiOS10LocalNotificationForMessage:(NSDictionary *)message atDate:(NSDate *)date {
   NSCalendar *calendar = [NSCalendar currentCalendar];
-  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, *)) {
+  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, tvOS 10.0, *)) {
     NSCalendarUnit unit = NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay |
                           NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
     NSDateComponents *dateComponents = [calendar components:(NSCalendarUnit)unit fromDate:date];
@@ -149,8 +149,12 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
     UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
     NSDictionary *apsDictionary = message;
 
-    // In the current solution all of the display stuff goes into a special "aps" dictionary
-    // being sent in the message.
+    // Badge is universal
+    if (apsDictionary[kFIRMessagingContextManagerBadgeKey]) {
+      content.badge = apsDictionary[kFIRMessagingContextManagerBadgeKey];
+    }
+#if TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_WATCH
+    // The following fields are not available on tvOS
     if ([apsDictionary[kFIRMessagingContextManagerBodyKey] length]) {
       content.body = apsDictionary[kFIRMessagingContextManagerBodyKey];
     }
@@ -161,9 +165,7 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
     if (apsDictionary[kFIRMessagingContextManagerSoundKey]) {
       content.sound = apsDictionary[kFIRMessagingContextManagerSoundKey];
     }
-    if (apsDictionary[kFIRMessagingContextManagerBadgeKey]) {
-      content.badge = apsDictionary[kFIRMessagingContextManagerBadgeKey];
-    }
+
     if (apsDictionary[kFIRMessagingContextManagerCategoryKey]) {
       content.categoryIdentifier = apsDictionary[kFIRMessagingContextManagerCategoryKey];
     }
@@ -172,6 +174,7 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
     if (userInfo.count) {
       content.userInfo = userInfo;
     }
+#endif
     NSString *identifier = apsDictionary[kFIRMessagingID];
     if (!identifier) {
       identifier = [NSUUID UUID].UUIDString;
@@ -193,7 +196,7 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
 }
 
 + (void)scheduleLocalNotificationForMessage:(NSDictionary *)message atDate:(NSDate *)date {
-  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, *)) {
+  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, tvOS 10.0, *)) {
     [self scheduleiOS10LocalNotificationForMessage:message atDate:date];
     return;
   }

--- a/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
+++ b/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
@@ -143,8 +143,7 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
                           NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
     NSDateComponents *dateComponents = [calendar components:(NSCalendarUnit)unit fromDate:date];
     UNCalendarNotificationTrigger *trigger =
-        [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:dateComponents
-                                                                 repeats:NO];
+        [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:dateComponents repeats:NO];
 
     UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
     NSDictionary *apsDictionary = message;

--- a/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
+++ b/FirebaseMessaging/Sources/FIRMessagingContextManagerService.m
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0 || \
+    __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_14 ||    \
+    __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_3_0 || TARGET_OS_MACCATALYST
+#import <UserNotifications/UserNotifications.h>
+#endif
 
 #import "FirebaseMessaging/Sources/FIRMessagingContextManagerService.h"
 
@@ -22,6 +27,7 @@
 
 #import <GoogleUtilities/GULAppDelegateSwizzler.h>
 
+#define kFIRMessagingContextManagerPrefix @"gcm."
 #define kFIRMessagingContextManagerPrefixKey @"google.c.cm."
 #define kFIRMessagingContextManagerNotificationKeyPrefix @"gcm.notification."
 
@@ -50,6 +56,7 @@ NSString *const kFIRMessagingContextManagerSoundKey =
     kFIRMessagingContextManagerNotificationKeyPrefix @"sound";
 NSString *const kFIRMessagingContextManagerContentAvailableKey =
     kFIRMessagingContextManagerNotificationKeyPrefix @"content-available";
+static NSString *const kFIRMessagingID = kFIRMessagingContextManagerPrefix @"message_id";
 static NSString *const kFIRMessagingAPNSPayloadKey = @"aps";
 
 typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
@@ -129,7 +136,67 @@ typedef NS_ENUM(NSUInteger, FIRMessagingContextManagerMessageType) {
   return YES;
 }
 
++ (void)scheduleiOS10LocalNotificationForMessage:(NSDictionary *)message atDate:(NSDate *)date {
+  NSCalendar *calendar = [NSCalendar currentCalendar];
+  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, *)) {
+    NSCalendarUnit unit = NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay |
+                          NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
+    NSDateComponents *dateComponents = [calendar components:(NSCalendarUnit)unit fromDate:date];
+    UNCalendarNotificationTrigger *trigger =
+        [UNCalendarNotificationTrigger triggerWithDateMatchingComponents:dateComponents
+                                                                 repeats:YES];
+
+    UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+    NSDictionary *apsDictionary = message;
+
+    // In the current solution all of the display stuff goes into a special "aps" dictionary
+    // being sent in the message.
+    if ([apsDictionary[kFIRMessagingContextManagerBodyKey] length]) {
+      content.body = apsDictionary[kFIRMessagingContextManagerBodyKey];
+    }
+    if ([apsDictionary[kFIRMessagingContextManagerTitleKey] length]) {
+      content.title = apsDictionary[kFIRMessagingContextManagerTitleKey];
+    }
+
+    if (apsDictionary[kFIRMessagingContextManagerSoundKey]) {
+      content.sound = apsDictionary[kFIRMessagingContextManagerSoundKey];
+    }
+    if (apsDictionary[kFIRMessagingContextManagerBadgeKey]) {
+      content.badge = apsDictionary[kFIRMessagingContextManagerBadgeKey];
+    }
+    if (apsDictionary[kFIRMessagingContextManagerCategoryKey]) {
+      content.categoryIdentifier = apsDictionary[kFIRMessagingContextManagerCategoryKey];
+    }
+
+    NSDictionary *userInfo = [self parseDataFromMessage:message];
+    if (userInfo.count) {
+      content.userInfo = userInfo;
+    }
+    NSString *identifier = apsDictionary[kFIRMessagingID];
+    if (!identifier) {
+      identifier = [NSUUID UUID].UUIDString;
+    }
+
+    UNNotificationRequest *request = [UNNotificationRequest requestWithIdentifier:identifier
+                                                                          content:content
+                                                                          trigger:trigger];
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    [center addNotificationRequest:request
+             withCompletionHandler:^(NSError *_Nullable error) {
+               if (error) {
+                 FIRMessagingLoggerError(
+                     kFIRMessagingMessageCodeContextManagerServiceFailedLocalSchedule,
+                     @"Failed scheduling local timezone notification: %@.", error);
+               }
+             }];
+  }
+}
+
 + (void)scheduleLocalNotificationForMessage:(NSDictionary *)message atDate:(NSDate *)date {
+  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, *)) {
+    [self scheduleiOS10LocalNotificationForMessage:message atDate:date];
+    return;
+  }
 #if TARGET_OS_IOS
   NSDictionary *apsDictionary = message;
 #pragma clang diagnostic push

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingContextManagerServiceTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingContextManagerServiceTest.m
@@ -99,9 +99,11 @@ static NSString *const kMessageIdentifierValue = @"1584748495200141";
     XCTAssertEqual(self.requests.count, 1);
     UNNotificationRequest *request = self.requests.firstObject;
     XCTAssertEqualObjects(request.identifier, kMessageIdentifierValue);
+#if TARGET_OS_IOS || TARGET_OS_WATCH || TARGET_OS_OSX
     XCTAssertEqualObjects(request.content.body, kBody);
     XCTAssertEqualObjects(request.content.userInfo[kUserInfoKey1], kUserInfoValue1);
     XCTAssertEqualObjects(request.content.userInfo[kUserInfoKey2], kUserInfoValue2);
+#endif
     return;
   }
 

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingContextManagerServiceTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingContextManagerServiceTest.m
@@ -13,16 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0 ||                                          \
+    __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_14 || __TV_OS_VERSION_MAX_ALLOWED >= __TV_10_0 || \
+    __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_3_0 || TARGET_OS_MACCATALYST
+#import <UserNotifications/UserNotifications.h>
+#endif
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
 #import "FirebaseMessaging/Sources/FIRMessagingContextManagerService.h"
 
+static NSString *const kBody = @"Save 20% off!";
+static NSString *const kUserInfoKey1 = @"level";
+static NSString *const kUserInfoKey2 = @"isPayUser";
+static NSString *const kUserInfoValue1 = @"5";
+static NSString *const kUserInfoValue2 = @"Yes";
+static NSString *const kMessageIdentifierKey = @"gcm.message_id";
+static NSString *const kMessageIdentifierValue = @"1584748495200141";
+
 @interface FIRMessagingContextManagerServiceTest : XCTestCase
 
 @property(nonatomic, readwrite, strong) NSDateFormatter *dateFormatter;
 @property(nonatomic, readwrite, strong) NSMutableArray *scheduledLocalNotifications;
+@property(nonatomic, readwrite, strong)
+    NSMutableArray<UNNotificationRequest *> *requests API_AVAILABLE(ios(10.0));
 
 @end
 
@@ -33,7 +47,11 @@
   self.dateFormatter = [[NSDateFormatter alloc] init];
   self.dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
   [self.dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss"];
-  self.scheduledLocalNotifications = [NSMutableArray array];
+  self.scheduledLocalNotifications = [[NSMutableArray alloc] init];
+  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, tvOS 10.0, *)) {
+    self.requests = [[NSMutableArray alloc] init];
+  }
+
   [self mockSchedulingLocalNotifications];
 }
 
@@ -62,34 +80,42 @@
   XCTAssertTrue([FIRMessagingContextManagerService isContextManagerMessage:message]);
 }
 
-// TODO: Enable these tests. They fail because we cannot schedule local
-// notifications on OSX without permission. It's better to mock AppDelegate's
-// scheduleLocalNotification to mock scheduling behavior.
-
 /**
  *  Context Manager message with future start date should be successfully scheduled.
  */
 - (void)testMessageWithFutureStartTime {
-#if TARGET_OS_IOS
-  NSString *messageIdentifier = @"fcm-cm-test1";
   // way into the future
   NSString *startTimeString = [self.dateFormatter stringFromDate:[NSDate distantFuture]];
   NSDictionary *message = @{
     kFIRMessagingContextManagerLocalTimeStart : startTimeString,
-    kFIRMessagingContextManagerBodyKey : @"Hello world!",
-    @"id" : messageIdentifier,
-    @"hello" : @"world"
+    kFIRMessagingContextManagerBodyKey : kBody,
+    kMessageIdentifierKey : kMessageIdentifierValue,
+    kUserInfoKey1 : kUserInfoValue1,
+    kUserInfoKey2 : kUserInfoValue2
   };
-
   XCTAssertTrue([FIRMessagingContextManagerService handleContextManagerMessage:message]);
 
+  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, tvOS 10.0, *)) {
+    XCTAssertEqual(self.requests.count, 1);
+    UNNotificationRequest *request = self.requests.firstObject;
+    XCTAssertEqualObjects(request.identifier, kMessageIdentifierValue);
+    XCTAssertEqualObjects(request.content.body, kBody);
+    XCTAssertEqualObjects(request.content.userInfo[kUserInfoKey1], kUserInfoValue1);
+    XCTAssertEqualObjects(request.content.userInfo[kUserInfoKey2], kUserInfoValue2);
+    return;
+  }
+
+#if TARGET_OS_IOS
   XCTAssertEqual(self.scheduledLocalNotifications.count, 1);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  UILocalNotification *notification = [self.scheduledLocalNotifications firstObject];
+  UILocalNotification *notification = self.scheduledLocalNotifications.firstObject;
 #pragma clang diagnostic pop
   NSDate *date = [self.dateFormatter dateFromString:startTimeString];
   XCTAssertEqual([notification.fireDate compare:date], NSOrderedSame);
+  XCTAssertEqualObjects(notification.alertBody, kBody);
+  XCTAssertEqualObjects(notification.userInfo[kUserInfoKey1], kUserInfoValue1);
+  XCTAssertEqualObjects(notification.userInfo[kUserInfoKey2], kUserInfoValue2);
 #endif
 }
 
@@ -98,18 +124,21 @@
  */
 - (void)testMessageWithPastEndTime {
 #if TARGET_OS_IOS
-  NSString *messageIdentifier = @"fcm-cm-test1";
   NSString *startTimeString = @"2010-01-12 12:00:00";  // way into the past
   NSString *endTimeString = @"2011-01-12 12:00:00";    // way into the past
   NSDictionary *message = @{
     kFIRMessagingContextManagerLocalTimeStart : startTimeString,
     kFIRMessagingContextManagerLocalTimeEnd : endTimeString,
-    kFIRMessagingContextManagerBodyKey : @"Hello world!",
-    @"id" : messageIdentifier,
+    kFIRMessagingContextManagerBodyKey : kBody,
+    kMessageIdentifierKey : kMessageIdentifierValue,
     @"hello" : @"world"
   };
 
   XCTAssertTrue([FIRMessagingContextManagerService handleContextManagerMessage:message]);
+  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, tvOS 10.0, *)) {
+    XCTAssertEqual(self.requests.count, 0);
+    return;
+  }
   XCTAssertEqual(self.scheduledLocalNotifications.count, 0);
 #endif
 }
@@ -120,7 +149,6 @@
  */
 - (void)testMessageWithPastStartAndFutureEndTime {
 #if TARGET_OS_IOS
-  NSString *messageIdentifier = @"fcm-cm-test1";
   NSDate *startDate = [NSDate dateWithTimeIntervalSinceNow:-1000];  // past
   NSDate *endDate = [NSDate dateWithTimeIntervalSinceNow:1000];     // future
   NSString *startTimeString = [self.dateFormatter stringFromDate:startDate];
@@ -129,13 +157,23 @@
   NSDictionary *message = @{
     kFIRMessagingContextManagerLocalTimeStart : startTimeString,
     kFIRMessagingContextManagerLocalTimeEnd : endTimeString,
-    kFIRMessagingContextManagerBodyKey : @"Hello world!",
-    @"id" : messageIdentifier,
-    @"hello" : @"world"
+    kFIRMessagingContextManagerBodyKey : kBody,
+    kMessageIdentifierKey : kMessageIdentifierValue,
+    kUserInfoKey1 : kUserInfoValue1,
+    kUserInfoKey2 : kUserInfoValue2
   };
 
   XCTAssertTrue([FIRMessagingContextManagerService handleContextManagerMessage:message]);
 
+  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, tvOS 10.0, *)) {
+    XCTAssertEqual(self.requests.count, 1);
+    UNNotificationRequest *request = self.requests.firstObject;
+    XCTAssertEqualObjects(request.identifier, kMessageIdentifierValue);
+    XCTAssertEqualObjects(request.content.body, kBody);
+    XCTAssertEqualObjects(request.content.userInfo[kUserInfoKey1], kUserInfoValue1);
+    XCTAssertEqualObjects(request.content.userInfo[kUserInfoKey2], kUserInfoValue2);
+    return;
+  }
   XCTAssertEqual(self.scheduledLocalNotifications.count, 1);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -145,6 +183,8 @@
   XCTAssertEqual([notification.fireDate compare:startDate], NSOrderedDescending);
   // schedule notification after end date
   XCTAssertEqual([notification.fireDate compare:endDate], NSOrderedAscending);
+  XCTAssertEqualObjects(notification.userInfo[kUserInfoKey1], kUserInfoValue1);
+  XCTAssertEqualObjects(notification.userInfo[kUserInfoKey2], kUserInfoValue2);
 #endif
 }
 
@@ -153,35 +193,58 @@
  */
 - (void)testTimedNotificationsUserInfo {
 #if TARGET_OS_IOS
-  NSString *messageIdentifierKey = @"message.id";
-  NSString *messageIdentifier = @"fcm-cm-test1";
   // way into the future
   NSString *startTimeString = [self.dateFormatter stringFromDate:[NSDate distantFuture]];
 
-  NSString *customDataKey = @"hello";
-  NSString *customData = @"world";
   NSDictionary *message = @{
     kFIRMessagingContextManagerLocalTimeStart : startTimeString,
-    kFIRMessagingContextManagerBodyKey : @"Hello world!",
-    messageIdentifierKey : messageIdentifier,
-    customDataKey : customData,
+    kFIRMessagingContextManagerBodyKey : kBody,
+    kMessageIdentifierKey : kMessageIdentifierValue,
+    kUserInfoKey1 : kUserInfoValue1,
+    kUserInfoKey2 : kUserInfoValue2
   };
 
   XCTAssertTrue([FIRMessagingContextManagerService handleContextManagerMessage:message]);
-
+  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, tvOS 10.0, *)) {
+    XCTAssertEqual(self.requests.count, 1);
+    UNNotificationRequest *request = self.requests.firstObject;
+    XCTAssertEqualObjects(request.identifier, kMessageIdentifierValue);
+    XCTAssertEqualObjects(request.content.body, kBody);
+    XCTAssertEqualObjects(request.content.userInfo[kUserInfoKey1], kUserInfoValue1);
+    XCTAssertEqualObjects(request.content.userInfo[kUserInfoKey2], kUserInfoValue2);
+    return;
+  }
   XCTAssertEqual(self.scheduledLocalNotifications.count, 1);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   UILocalNotification *notification = [self.scheduledLocalNotifications firstObject];
 #pragma clang diagnostic pop
-  XCTAssertEqualObjects(notification.userInfo[messageIdentifierKey], messageIdentifier);
-  XCTAssertEqualObjects(notification.userInfo[customDataKey], customData);
+  XCTAssertEqualObjects(notification.userInfo[kUserInfoKey1], kUserInfoValue1);
+  XCTAssertEqualObjects(notification.userInfo[kUserInfoKey2], kUserInfoValue2);
 #endif
 }
 
 #pragma mark - Private Helpers
 
 - (void)mockSchedulingLocalNotifications {
+  if (@available(macOS 10.14, iOS 10.0, watchOS 3.0, tvOS 10.0, *)) {
+    id mockNotificationCenter =
+        OCMPartialMock([UNUserNotificationCenter currentNotificationCenter]);
+    __block UNNotificationRequest *request;
+    [[[mockNotificationCenter stub] andDo:^(NSInvocation *invocation) {
+      [self.requests addObject:request];
+    }] addNotificationRequest:[OCMArg checkWithBlock:^BOOL(id obj) {
+         if ([obj isKindOfClass:[UNNotificationRequest class]]) {
+           request = obj;
+           [self.requests addObject:request];
+           return YES;
+         }
+         return NO;
+       }]
+        withCompletionHandler:^(NSError *_Nullable error){
+        }];
+    return;
+  }
 #if TARGET_OS_IOS
   id mockApplication = OCMPartialMock([UIApplication sharedApplication]);
 #pragma clang diagnostic push


### PR DESCRIPTION
This fixes b/156310608 also as the UILocalNotification doesn't properly process "%", where it escape it in notification title and body.

Also UILocalNotification is deprecated, so use them for iOS 10 above.

