### PR TITLE
Change log message to reference FID instead of IID

### DIFF
--- a/FirebaseInAppMessaging/CHANGELOG.md
+++ b/FirebaseInAppMessaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2020-06-02 -- v0.20.2
+- [fixed] Log message for in-app messaging test on device flow (#5680).
+
 # 2020-05-19 -- v0.20.1
 - [fixed] Fixed an issue where clicks were counted for messages with no action URL (#5564).
 

--- a/FirebaseInAppMessaging/CHANGELOG.md
+++ b/FirebaseInAppMessaging/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2020-06-02 -- v0.20.2
-- [fixed] Log message for in-app messaging test on device flow (#5680).
+- [fixed] Fixed log message for in-app messaging test on device flow (#5680).
 
 # 2020-05-19 -- v0.20.1
 - [fixed] Fixed an issue where clicks were counted for messages with no action URL (#5564).

--- a/FirebaseInAppMessaging/Sources/Runtime/FIRIAMRuntimeManager.m
+++ b/FirebaseInAppMessaging/Sources/Runtime/FIRIAMRuntimeManager.m
@@ -385,10 +385,11 @@ static NSString *const kFirebaseInAppMessagingAutoDataCollectionKey =
                                                                          NSString
                                                                              *_Nullable FISToken,
                                                                          NSError *_Nullable error) {
-                                                                       // Always dump the instance
-                                                                       // id into log on startup to
-                                                                       // help developers to find it
-                                                                       // for their app instance.
+                                                                       // Always dump the
+                                                                       // installation ID into log
+                                                                       // on startup to help
+                                                                       // developers to find it for
+                                                                       // their app instance.
                                                                        FIRLogDebug(
                                                                            kFIRLoggerInAppMessaging,
                                                                            @"I-IAM180017",
@@ -396,7 +397,8 @@ static NSString *const kFirebaseInAppMessagingAutoDataCollectionKey =
                                                                            @"InAppMessaging "
                                                                            @"runtime "
                                                                            @"with "
-                                                                            "Instance ID %@",
+                                                                            "Firebase Installation "
+                                                                            "ID %@",
                                                                            FID);
                                                                      }];
 


### PR DESCRIPTION
We integrated FIS a few months ago, but never changed the log message that devs use to grab a token for testing FIAM on device.