### PR TITLE
Add a global function to get storage instances

### DIFF
--- a/GoogleDataTransport/CHANGELOG.md
+++ b/GoogleDataTransport/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Added new API for fetching storage instances specific to a target.
+
 # v6.1.1
 - Fixes writing event counts in a directory that doesn't yet exist. (#5549)
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORRegistrar.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORRegistrar.m
@@ -19,6 +19,10 @@
 
 #import "GDTCORLibrary/Public/GDTCORConsoleLogger.h"
 
+id<GDTCORStorageProtocol> _Nullable GDTCORStorageInstanceForTarget(GDTCORTarget target) {
+  return [GDTCORRegistrar sharedInstance].targetToStorage[@(target)];
+}
+
 @implementation GDTCORRegistrar {
   /** Backing ivar for targetToUploader property. */
   NSMutableDictionary<NSNumber *, id<GDTCORUploader>> *_targetToUploader;

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h
@@ -66,4 +66,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+/** Retrieves the storage instance for the given target.
+ *
+ * @param target The target.
+ * * @return The storage instance registered for the target, or nil if there is none.
+ */
+FOUNDATION_EXPORT
+id<GDTCORStorageProtocol> _Nullable GDTCORStorageInstanceForTarget(GDTCORTarget target);
+
 NS_ASSUME_NONNULL_END

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 
 #import <GoogleDataTransport/GDTCORLifecycle.h>
+#import <GoogleDataTransport/GDTCORTargets.h>
 
 @class GDTCOREvent;
 


### PR DESCRIPTION
Needed to find storage instances internal _and_ external to this library.

#no-changelog