### PR TITLE
Import updates in unported tests

### DIFF
--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigSettingsTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigSettingsTest.m
@@ -16,8 +16,6 @@
 
 #import <XCTest/XCTest.h>
 
-#import "FirebaseRemoteConfig/Sources/Protos/wireless/android/config/proto/Config.pbobjc.h"
-
 #import <OCMock/OCMock.h>
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigConstants.h"

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigTest.m
@@ -16,15 +16,13 @@
 
 #import <XCTest/XCTest.h>
 
-#import "FirebaseRemoteConfig/Sources/Protos/wireless/android/config/proto/Config.pbobjc.h"
-
 #import <FirebaseInstanceID/FIRInstanceID+Private.h>
 #import <FirebaseInstanceID/FIRInstanceIDCheckinPreferences.h>
 #import <OCMock/OCMock.h>
+#import "FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigConstants.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigContent.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigExperiment.h"
-#import "FirebaseRemoteConfig/Sources/RCNConfigFetch.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigValue_Internal.h"
 #import "FirebaseRemoteConfig/Tests/Unit/RCNTestUtilities.h"
 

--- a/FirebaseRemoteConfig/Tests/Unit/RCNThrottlingTests.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNThrottlingTests.m
@@ -16,11 +16,11 @@
 
 #import <XCTest/XCTest.h>
 
+#import "FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h"
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigContent.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigDBManager.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigExperiment.h"
-#import "FirebaseRemoteConfig/Sources/RCNConfigFetch.h"
 #import "FirebaseRemoteConfig/Tests/Unit/RCNTestUtilities.h"
 
 #import <FirebaseCore/FIRApp.h>


### PR DESCRIPTION
Fix imports in unit tests that have not yet been ported from v1 to v2

This addresses deleted file reference presubmit errors after copybara