### PR TITLE
Added storage integration tests for testing custom callback

### DIFF
--- a/FirebaseStorage/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/FirebaseStorage/Tests/Integration/FIRStorageIntegrationTests.m
@@ -423,13 +423,15 @@ NSString *const kTestPassword = KPASSWORD;
   FIRStorageReference *ref = [self.storage referenceWithPath:@"ios/public/1mb"];
   [ref dataWithMaxSize:1 * 1024 * 1024
             completion:^(NSData *data, NSError *error) {
-              if (@available(iOS 10.0, macOS 10.12, *)) {
-                dispatch_assert_queue(callbackQueue);
-              } else {
-                NSAssert(YES, @"Test requires iOS 10 or macOS 10.12");
-              }
               XCTAssertNotNil(data, "Data should not be nil");
               XCTAssertNil(error, "Error should be nil");
+
+              if (@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)) {
+                dispatch_assert_queue(callbackQueue);
+              } else {
+                XCTAssert(true, @"Test requires macOS 10.12, iOS 10.0, tvOS 10.0, or watchOS 3.0");
+              }
+
               [expectation fulfill];
 
               // reset the callbackQueue to default (main queue)

--- a/FirebaseStorage/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/FirebaseStorage/Tests/Integration/FIRStorageIntegrationTests.m
@@ -437,7 +437,7 @@ NSString *const kTestPassword = KPASSWORD;
 
               [expectation fulfill];
 
-              // reset the callbackQueue to default (main queue)
+              // Reset the callbackQueue to default (main queue).
               self.storage.callbackQueue = dispatch_get_main_queue();
               dispatch_queue_set_specific(callbackQueue, callbackQueueKey, NULL, NULL);
             }];

--- a/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
@@ -400,7 +400,7 @@ class StorageIntegration: XCTestCase {
 
       expectation.fulfill()
 
-      // reset the callbackQueue to default (main queue)
+      // Reset the callbackQueue to default (main queue).
       self.storage.callbackQueue = DispatchQueue.main
       callbackQueue.setSpecific(key: callbackQueueKey, value: nil)
     }

--- a/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
@@ -379,6 +379,35 @@ class StorageIntegration: XCTestCase {
     waitForExpectations()
   }
 
+  func testSimpleGetDataWithCustomCallbackQueue() {
+    let expectation = self.expectation(description: #function)
+
+    let callbackQueueLabel = "customCallbackQueue"
+    let callbackQueueKey = DispatchSpecificKey<String>()
+    let callbackQueue = DispatchQueue(label: callbackQueueLabel)
+    callbackQueue.setSpecific(key: callbackQueueKey, value: callbackQueueLabel)
+    storage.callbackQueue = callbackQueue
+
+    let ref = storage.reference(withPath: "ios/public/1mb")
+    ref.getData(maxSize: 1024 * 1024) { data, error in
+      XCTAssertNotNil(data, "Data should not be nil")
+      XCTAssertNil(error, "Error should be nil")
+
+      XCTAssertFalse(Thread.isMainThread)
+
+      let currentQueueLabel = DispatchQueue.getSpecific(key: callbackQueueKey)
+      XCTAssertEqual(currentQueueLabel, callbackQueueLabel)
+
+      expectation.fulfill()
+
+      // reset the callbackQueue to default (main queue)
+      self.storage.callbackQueue = DispatchQueue.main
+      callbackQueue.setSpecific(key: callbackQueueKey, value: nil)
+    }
+
+    waitForExpectations()
+  }
+
   func testSimpleGetDataTooSmall() {
     let expectation = self.expectation(description: #function)
 
@@ -460,7 +489,7 @@ class StorageIntegration: XCTestCase {
     let fileURL = tmpDirURL.appendingPathComponent("hello.txt")
     let data = try XCTUnwrap("Hello Swift World".data(using: .utf8), "Data construction failed")
 
-    _ = [ref.putData(data, metadata: nil, completion: { metadata, error in
+    ref.putData(data, metadata: nil, completion: { metadata, error in
       XCTAssertNotNil(metadata, "Metadata should not be nil")
       XCTAssertNil(error, "Error should be nil")
       let task = ref.write(toFile: fileURL)
@@ -487,7 +516,7 @@ class StorageIntegration: XCTestCase {
       task.observe(StorageTaskStatus.failure, handler: { snapshot in
         XCTAssertNil(snapshot.error, "Error should be nil")
       })
-    })]
+    })
     waitForExpectations()
   }
 

--- a/FirebaseStorageSwift/Tests/Integration/StorageIntegration.swift
+++ b/FirebaseStorageSwift/Tests/Integration/StorageIntegration.swift
@@ -336,23 +336,26 @@ class StorageIntegration: XCTestCase {
   func testSimpleGetDataWithCustomCallbackQueue() {
     let expectation = self.expectation(description: #function)
 
-    let callbackQueue = DispatchQueue(label: "customCallbackQueue")
+    let callbackQueueLabel = "customCallbackQueue"
+    let callbackQueueKey = DispatchSpecificKey<String>()
+    let callbackQueue = DispatchQueue(label: callbackQueueLabel)
+    callbackQueue.setSpecific(key: callbackQueueKey, value: callbackQueueLabel)
     storage.callbackQueue = callbackQueue
 
     let ref = storage.reference(withPath: "ios/public/1mb")
     ref.getData(maxSize: 1024 * 1024) { result in
       self.assertResultSuccess(result)
 
-      if #available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *) {
-        dispatchPrecondition(condition: .onQueue(callbackQueue))
-      } else {
-        XCTAssert(true, "Test requires OSX 10.12, iOS 10.0, tvOS 10.0, or watchOS 3.0")
-      }
+      XCTAssertFalse(Thread.isMainThread)
+
+      let currentQueueLabel = DispatchQueue.getSpecific(key: callbackQueueKey)
+      XCTAssertEqual(currentQueueLabel, callbackQueueLabel)
 
       expectation.fulfill()
 
       // reset the callbackQueue to default (main queue)
       self.storage.callbackQueue = DispatchQueue.main
+      callbackQueue.setSpecific(key: callbackQueueKey, value: nil)
     }
     waitForExpectations()
   }

--- a/FirebaseStorageSwift/Tests/Integration/StorageIntegration.swift
+++ b/FirebaseStorageSwift/Tests/Integration/StorageIntegration.swift
@@ -353,7 +353,7 @@ class StorageIntegration: XCTestCase {
 
       expectation.fulfill()
 
-      // reset the callbackQueue to default (main queue)
+      // Reset the callbackQueue to default (main queue).
       self.storage.callbackQueue = DispatchQueue.main
       callbackQueue.setSpecific(key: callbackQueueKey, value: nil)
     }

--- a/FirebaseStorageSwift/Tests/Integration/StorageIntegration.swift
+++ b/FirebaseStorageSwift/Tests/Integration/StorageIntegration.swift
@@ -333,6 +333,30 @@ class StorageIntegration: XCTestCase {
     waitForExpectations()
   }
 
+  func testSimpleGetDataWithCustomCallbackQueue() {
+    let expectation = self.expectation(description: #function)
+
+    let callbackQueue = DispatchQueue(label: "customCallbackQueue")
+    storage.callbackQueue = callbackQueue
+
+    let ref = storage.reference(withPath: "ios/public/1mb")
+    ref.getData(maxSize: 1024 * 1024) { result in
+      self.assertResultSuccess(result)
+
+      if #available(OSX 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *) {
+        dispatchPrecondition(condition: .onQueue(callbackQueue))
+      } else {
+        XCTAssert(true, "Test requires OSX 10.12, iOS 10.0, tvOS 10.0, or watchOS 3.0")
+      }
+
+      expectation.fulfill()
+
+      // reset the callbackQueue to default (main queue)
+      self.storage.callbackQueue = DispatchQueue.main
+    }
+    waitForExpectations()
+  }
+
   func testSimpleGetDataTooSmall() {
     let expectation = self.expectation(description: #function)
 


### PR DESCRIPTION
This PR adds storage integration tests to test [the `callbackQueue` property of Firebase Storage](https://firebase.google.com/docs/reference/swift/firebasestorage/api/reference/Classes/Storage#callbackqueue).

**`FIRStorageIntegrationTests.m`**
• `testGetDataWithCustomCallbackQueue:`

**`SwiftIntegration/StorageIntegration.swift`**
•  `testSimpleGetDataWithCustomCallbackQueue()`
•  Removed unnecessary syntax in `testSimpleGetDataTooSmall()` 

#no-changelog
