### PR TITLE
Added Core Config & Options swift tests

### DIFF
--- a/FirebaseCore/Tests/Unit/Swift/FirebaseConfigurationTests.swift
+++ b/FirebaseCore/Tests/Unit/Swift/FirebaseConfigurationTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/FirebaseCore/Tests/Unit/Swift/FirebaseConfigurationTests.swift
+++ b/FirebaseCore/Tests/Unit/Swift/FirebaseConfigurationTests.swift
@@ -1,0 +1,25 @@
+// Copyright 2020 Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+@testable import FirebaseCore
+
+class FirebaseConfigurationTests: XCTestCase {
+  
+  func testSharedInstance() {
+    let config = FirebaseConfiguration.shared
+    XCTAssertNotNil(config)
+  }
+  
+}

--- a/FirebaseCore/Tests/Unit/Swift/FirebaseConfigurationTests.swift
+++ b/FirebaseCore/Tests/Unit/Swift/FirebaseConfigurationTests.swift
@@ -16,10 +16,8 @@ import XCTest
 @testable import FirebaseCore
 
 class FirebaseConfigurationTests: XCTestCase {
-  
   func testSharedInstance() {
     let config = FirebaseConfiguration.shared
     XCTAssertNotNil(config)
   }
-  
 }

--- a/FirebaseCore/Tests/Unit/Swift/FirebaseOptionsTests.swift
+++ b/FirebaseCore/Tests/Unit/Swift/FirebaseOptionsTests.swift
@@ -1,0 +1,182 @@
+// Copyright 2020 Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+@testable import FirebaseCore
+
+class FirebaseOptionsTests: XCTestCase {
+  func testDefaultOptions() throws {
+    let options = try XCTUnwrap(
+      FirebaseOptions.defaultOptions(),
+      "Default options could not be unwrapped"
+    )
+    assertOptionsMatchDefaultOptions(options: options)
+  }
+
+  func testInitEmptyOptions() {
+    let options = FirebaseOptions()
+    XCTAssertNotNil(options)
+
+    XCTAssertTrue(options.bundleID.isEmpty)
+    XCTAssertTrue(options.gcmSenderID.isEmpty)
+    XCTAssertTrue(options.googleAppID.isEmpty)
+
+    assertNullableOptionsAreEmpty(options: options)
+  }
+
+  func testInitWithContentsOfFile() throws {
+    let bundle = try XCTUnwrap(
+      Bundle(identifier: "org.cocoapods.FirebaseCore-Unit-swift-unit"),
+      "Could not find bundle"
+    )
+
+    let path = try XCTUnwrap(
+      bundle.path(forResource: "GoogleService-Info", ofType: "plist"),
+      "Could not find path for file"
+    )
+
+    let options = FirebaseOptions(contentsOfFile: path)
+    XCTAssertNotNil(options)
+  }
+
+  func testInitWithInvalidSourceFile() {
+    let invalidPath = "path/to/non-existing/plist"
+    let options = FirebaseOptions(contentsOfFile: invalidPath)
+    XCTAssertNil(options)
+  }
+
+  func testInitWithCustomFields() throws {
+    let googleAppID = "5:678:ios:678def"
+    let gcmSenderID = "custom_gcm_sender_id"
+    let options = FirebaseOptions(googleAppID: googleAppID,
+                                  gcmSenderID: gcmSenderID)
+
+    XCTAssertEqual(options.googleAppID, googleAppID)
+    XCTAssertEqual(options.gcmSenderID, gcmSenderID)
+
+    let bundleID =
+      try XCTUnwrap(Bundle.main.bundleIdentifier, "Could not unwrap bundle")
+    XCTAssertEqual(options.bundleID, bundleID)
+
+    assertNullableOptionsAreEmpty(options: options)
+  }
+
+  func testCustomizedOptions() {
+    let googleAppID = Constants.Options.googleAppID
+    let gcmSenderID = Constants.Options.gcmSenderID
+    let options = FirebaseOptions(googleAppID: googleAppID,
+                                  gcmSenderID: gcmSenderID)
+    options.bundleID = Constants.Options.bundleID
+    options.apiKey = Constants.Options.apiKey
+    options.clientID = Constants.Options.clientID
+    options.trackingID = Constants.Options.trackingID
+    options.projectID = Constants.Options.projectID
+    options.databaseURL = Constants.Options.databaseURL
+    options.storageBucket = Constants.Options.storageBucket
+    options.appGroupID = Constants.Options.appGroupID
+
+    assertOptionsMatchDefaultOptions(options: options)
+  }
+
+  func testEditingCustomOptions() {
+    let googleAppID = Constants.Options.googleAppID
+    let gcmSenderID = Constants.Options.gcmSenderID
+    let options = FirebaseOptions(googleAppID: googleAppID,
+                                  gcmSenderID: gcmSenderID)
+
+    let newGCMSenderID = "newgcmSenderID"
+    options.gcmSenderID = newGCMSenderID
+    XCTAssertEqual(options.gcmSenderID, newGCMSenderID)
+
+    let newGoogleAppID = "newGoogleAppID"
+    options.googleAppID = newGoogleAppID
+    XCTAssertEqual(options.googleAppID, newGoogleAppID)
+
+    XCTAssertNil(options.deepLinkURLScheme)
+    options.deepLinkURLScheme = Constants.Options.deepLinkURLScheme
+    XCTAssertEqual(options.deepLinkURLScheme, Constants.Options.deepLinkURLScheme)
+
+    XCTAssertNil(options.androidClientID)
+    options.androidClientID = Constants.Options.androidClientID
+    XCTAssertEqual(options.androidClientID, Constants.Options.androidClientID)
+
+    XCTAssertNil(options.appGroupID)
+    options.appGroupID = Constants.Options.appGroupID
+    XCTAssertEqual(options.appGroupID, Constants.Options.appGroupID)
+  }
+
+  func testCopyingProperties() {
+    let googleAppID = Constants.Options.googleAppID
+    let gcmSenderID = Constants.Options.gcmSenderID
+    let options = FirebaseOptions(googleAppID: googleAppID,
+                                  gcmSenderID: gcmSenderID)
+    var apiKey = "123456789"
+    options.apiKey = apiKey
+    XCTAssertEqual(options.apiKey, apiKey)
+    apiKey = "000000000"
+    XCTAssertNotEqual(options.apiKey, apiKey)
+
+    var deepLinkURLScheme = "comdeeplinkurl"
+    options.deepLinkURLScheme = deepLinkURLScheme
+    XCTAssertEqual(options.deepLinkURLScheme, deepLinkURLScheme)
+    deepLinkURLScheme = "comlinkurl"
+    XCTAssertNotEqual(options.deepLinkURLScheme, deepLinkURLScheme)
+  }
+
+  func testOptionsEquality() throws {
+    let defaultOptions1 = try XCTUnwrap(
+      FirebaseOptions.defaultOptions(),
+      "Default options could not be unwrapped"
+    )
+    let defaultOptions2 = try XCTUnwrap(
+      FirebaseOptions.defaultOptions(),
+      "Default options could not be unwrapped"
+    )
+
+    XCTAssertEqual(defaultOptions1.hash, defaultOptions2.hash)
+    XCTAssertTrue(defaultOptions1.isEqual(defaultOptions2))
+
+    let emptyOptions = FirebaseOptions()
+    XCTAssertFalse(emptyOptions.isEqual(defaultOptions1))
+  }
+
+  // MARK: - Helpers
+
+  private func assertOptionsMatchDefaultOptions(options: FirebaseOptions) {
+    XCTAssertEqual(options.apiKey, Constants.Options.apiKey)
+    XCTAssertEqual(options.bundleID, Constants.Options.bundleID)
+    XCTAssertEqual(options.clientID, Constants.Options.clientID)
+    XCTAssertEqual(options.trackingID, Constants.Options.trackingID)
+    XCTAssertEqual(options.gcmSenderID, Constants.Options.gcmSenderID)
+    XCTAssertEqual(options.projectID, Constants.Options.projectID)
+    XCTAssertNil(options.androidClientID)
+    XCTAssertEqual(options.googleAppID, Constants.Options.googleAppID)
+    XCTAssertEqual(options.databaseURL, Constants.Options.databaseURL)
+    XCTAssertNil(options.deepLinkURLScheme)
+    XCTAssertEqual(options.storageBucket, Constants.Options.storageBucket)
+    XCTAssertNil(options.appGroupID)
+  }
+
+  private func assertNullableOptionsAreEmpty(options: FirebaseOptions) {
+    XCTAssertNil(options.apiKey)
+    XCTAssertNil(options.clientID)
+    XCTAssertNil(options.trackingID)
+    XCTAssertNil(options.projectID)
+    XCTAssertNil(options.androidClientID)
+    XCTAssertNil(options.databaseURL)
+    XCTAssertNil(options.deepLinkURLScheme)
+    XCTAssertNil(options.storageBucket)
+    XCTAssertNil(options.appGroupID)
+  }
+}

--- a/FirebaseCore/Tests/Unit/Swift/FirebaseOptionsTests.swift
+++ b/FirebaseCore/Tests/Unit/Swift/FirebaseOptionsTests.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import XCTest
-import FirebaseCore
+@testable import FirebaseCore
 
 class FirebaseOptionsTests: XCTestCase {
   func testDefaultOptions() throws {

--- a/FirebaseCore/Tests/Unit/Swift/FirebaseOptionsTests.swift
+++ b/FirebaseCore/Tests/Unit/Swift/FirebaseOptionsTests.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import XCTest
-@testable import FirebaseCore
+import FirebaseCore
 
 class FirebaseOptionsTests: XCTestCase {
   func testDefaultOptions() throws {
@@ -24,20 +24,9 @@ class FirebaseOptionsTests: XCTestCase {
     assertOptionsMatchDefaultOptions(options: options)
   }
 
-  func testInitEmptyOptions() {
-    let options = FirebaseOptions()
-    XCTAssertNotNil(options)
-
-    XCTAssertTrue(options.bundleID.isEmpty)
-    XCTAssertTrue(options.gcmSenderID.isEmpty)
-    XCTAssertTrue(options.googleAppID.isEmpty)
-
-    assertNullableOptionsAreEmpty(options: options)
-  }
-
   func testInitWithContentsOfFile() throws {
     let bundle = try XCTUnwrap(
-      Bundle(identifier: "org.cocoapods.FirebaseCore-Unit-swift-unit"),
+      Bundle(for: type(of: self)),
       "Could not find bundle"
     )
 
@@ -66,7 +55,7 @@ class FirebaseOptionsTests: XCTestCase {
     XCTAssertEqual(options.gcmSenderID, gcmSenderID)
 
     let bundleID =
-      try XCTUnwrap(Bundle.main.bundleIdentifier, "Could not unwrap bundle")
+      try XCTUnwrap(Bundle.main.bundleIdentifier, "Could not retrieve bundle identifier")
     XCTAssertEqual(options.bundleID, bundleID)
 
     assertNullableOptionsAreEmpty(options: options)


### PR DESCRIPTION
Adding swift unit tests for [FirebaseConfiguration](https://firebase.google.com/docs/reference/swift/firebasecore/api/reference/Classes/FirebaseConfiguration) & [FirebaseOptions](https://firebase.google.com/docs/reference/swift/firebasecore/api/reference/Classes/FirebaseOptions)

**Fun facts** 🥳 
`FirebaseConfigurationTests` have ~80% coverage
`FirebaseOptionsTests` have ~60% coverage

#no-changelog
