### PR TITLE
Deprecate Remote Config typedefs

### DIFF
--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -235,7 +235,7 @@ static NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, FIRRemote
 - (void)fetchAndActivateWithCompletionHandler:
     (FIRRemoteConfigFetchAndActivateCompletion)completionHandler {
   __weak FIRRemoteConfig *weakSelf = self;
-  FIRRemoteConfigFetchCompletion fetchCompletion =
+  void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) =
       ^(FIRRemoteConfigFetchStatus fetchStatus, NSError *fetchError) {
         FIRRemoteConfig *strongSelf = weakSelf;
         if (!strongSelf) {

--- a/FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h
+++ b/FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h
@@ -48,7 +48,9 @@ typedef void (^RCNConfigFetcherCompletion)(NSData *data, NSURLResponse *response
 /// @param expirationDuration  Expiration duration, in seconds.
 /// @param completionHandler   Callback handler.
 - (void)fetchConfigWithExpirationDuration:(NSTimeInterval)expirationDuration
-                        completionHandler:(FIRRemoteConfigFetchCompletion)completionHandler;
+                        completionHandler:
+                            (void (^_Nullable)(FIRRemoteConfigFetchStatus status,
+                                               NSError *_Nullable error))completionHandler;
 
 /// Add the ability to update NSURLSession's timeout after a session has already been created.
 - (void)recreateNetworkSession;

--- a/FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h
+++ b/FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h
@@ -80,18 +80,18 @@ typedef NS_ENUM(NSInteger, FIRRemoteConfigSource) {
 /// @param error  Error message on failure.
 typedef void (^FIRRemoteConfigFetchCompletion)(FIRRemoteConfigFetchStatus status,
                                                NSError *_Nullable error)
-    NS_SWIFT_NAME(RemoteConfigFetchCompletion);
+    NS_SWIFT_NAME(RemoteConfigFetchCompletion) DEPRECATED_ATTRIBUTE;
 
 /// Completion handler invoked by activate method upon completion.
 /// @param error  Error message on failure. Nil if activation was successful.
 typedef void (^FIRRemoteConfigActivateCompletion)(NSError *_Nullable error)
-    NS_SWIFT_NAME(RemoteConfigActivateCompletion);
+    NS_SWIFT_NAME(RemoteConfigActivateCompletion) DEPRECATED_ATTRIBUTE;
 
 /// Completion handler invoked upon completion of Remote Config initialization.
 ///
 /// @param initializationError nil if initialization succeeded.
 typedef void (^FIRRemoteConfigInitializationCompletion)(NSError *_Nullable initializationError)
-    NS_SWIFT_NAME(RemoteConfigInitializationCompletion);
+    NS_SWIFT_NAME(RemoteConfigInitializationCompletion) DEPRECATED_ATTRIBUTE;
 
 /// Completion handler invoked by the fetchAndActivate method. Used to convey status of fetch and,
 /// if successful, resultant activate call
@@ -99,7 +99,7 @@ typedef void (^FIRRemoteConfigInitializationCompletion)(NSError *_Nullable initi
 /// @param error  Error message on failure of config fetch
 typedef void (^FIRRemoteConfigFetchAndActivateCompletion)(
     FIRRemoteConfigFetchAndActivateStatus status, NSError *_Nullable error)
-    NS_SWIFT_NAME(RemoteConfigFetchAndActivateCompletion);
+    NS_SWIFT_NAME(RemoteConfigFetchAndActivateCompletion) DEPRECATED_ATTRIBUTE;
 
 #pragma mark - FIRRemoteConfigValue
 /// This class provides a wrapper for Remote Config parameter values, with methods to get parameter

--- a/FirebaseRemoteConfig/Sources/RCNFetch.m
+++ b/FirebaseRemoteConfig/Sources/RCNFetch.m
@@ -127,7 +127,9 @@ static const NSInteger FIRErrorCodeConfigFailed = -114;
 #pragma mark - Fetch Config API
 
 - (void)fetchConfigWithExpirationDuration:(NSTimeInterval)expirationDuration
-                        completionHandler:(FIRRemoteConfigFetchCompletion)completionHandler {
+                        completionHandler:
+                            (void (^_Nullable)(FIRRemoteConfigFetchStatus status,
+                                               NSError *_Nullable error))completionHandler {
   // Note: We expect the googleAppID to always be available.
   BOOL hasDeviceContextChanged =
       FIRRemoteConfigHasDeviceContextChanged(_settings.deviceContext, _options.googleAppID);
@@ -201,7 +203,8 @@ static const NSInteger FIRErrorCodeConfigFailed = -114;
 /// Refresh installation ID token before fetching config. installation ID is now mandatory for fetch
 /// requests to work.(b/14751422).
 - (void)refreshInstallationsTokenWithCompletionHandler:
-    (FIRRemoteConfigFetchCompletion)completionHandler {
+    (void (^_Nullable)(FIRRemoteConfigFetchStatus status,
+                       NSError *_Nullable error))completionHandler {
   FIRInstallations *installations = [FIRInstallations
       installationsWithApp:[FIRApp appNamed:[self FIRAppNameFromFullyQualifiedNamespace]]];
   if (!installations || !_options.GCMSenderID) {
@@ -278,7 +281,8 @@ static const NSInteger FIRErrorCodeConfigFailed = -114;
   [installations authTokenWithCompletion:installationsTokenHandler];
 }
 
-- (void)doFetchCall:(FIRRemoteConfigFetchCompletion)completionHandler {
+- (void)doFetchCall:(void (^_Nullable)(FIRRemoteConfigFetchStatus status,
+                                       NSError *_Nullable error))completionHandler {
   [self getAnalyticsUserPropertiesWithCompletionHandler:^(NSDictionary *userProperties) {
     dispatch_async(self->_lockQueue, ^{
       [self fetchWithUserProperties:userProperties completionHandler:completionHandler];
@@ -297,7 +301,8 @@ static const NSInteger FIRErrorCodeConfigFailed = -114;
   }
 }
 
-- (void)reportCompletionOnHandler:(FIRRemoteConfigFetchCompletion)completionHandler
+- (void)reportCompletionOnHandler:(void (^_Nullable)(FIRRemoteConfigFetchStatus status,
+                                                     NSError *_Nullable error))completionHandler
                        withStatus:(FIRRemoteConfigFetchStatus)status
                         withError:(NSError *)error {
   if (completionHandler) {
@@ -308,7 +313,8 @@ static const NSInteger FIRErrorCodeConfigFailed = -114;
 }
 
 - (void)fetchWithUserProperties:(NSDictionary *)userProperties
-              completionHandler:(FIRRemoteConfigFetchCompletion)completionHandler {
+              completionHandler:(void (^_Nullable)(FIRRemoteConfigFetchStatus status,
+                                                   NSError *_Nullable error))completionHandler {
   FIRLogDebug(kFIRLoggerRemoteConfig, @"I-RCN000061", @"Fetch with user properties initiated.");
 
   NSString *postRequestString = [_settings nextRequestWithUserProperties:userProperties];

--- a/FirebaseRemoteConfig/Tests/Unit/RCNInstanceIDTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNInstanceIDTest.m
@@ -243,7 +243,7 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
         [self expectationWithDescription:
                   [NSString stringWithFormat:@"Test fetch configs successfully - instance %d", i]];
     XCTAssertEqual(_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusNoFetchYet);
-    FIRRemoteConfigFetchCompletion fetchCompletion =
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) =
         ^void(FIRRemoteConfigFetchStatus status, NSError *error) {
           XCTAssertNotNil(error);
           [expectations[i] fulfill];
@@ -276,7 +276,7 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
         [self expectationWithDescription:
                   [NSString stringWithFormat:@"Test fetch configs successfully - instance %d", i]];
     XCTAssertEqual(_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusNoFetchYet);
-    FIRRemoteConfigFetchCompletion fetchCompletion =
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) =
         ^void(FIRRemoteConfigFetchStatus status, NSError *error) {
           XCTAssertNotNil(error);
           XCTAssert([[error.userInfo objectForKey:@"NSLocalizedDescription"]
@@ -320,7 +320,7 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
         [self expectationWithDescription:
                   [NSString stringWithFormat:@"Test fetch configs successfully - instance %d", i]];
     XCTAssertEqual(_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusNoFetchYet);
-    FIRRemoteConfigFetchCompletion fetchCompletion =
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) =
         ^void(FIRRemoteConfigFetchStatus status, NSError *error) {
           XCTAssertNotNil(error);
           [expectations[i] fulfill];
@@ -351,7 +351,7 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
         [self expectationWithDescription:
                   [NSString stringWithFormat:@"Test fetch configs successfully - instance %d", i]];
     XCTAssertEqual(_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusNoFetchYet);
-    FIRRemoteConfigFetchCompletion fetchCompletion =
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) =
         ^void(FIRRemoteConfigFetchStatus status, NSError *error) {
           XCTAssertNotNil(error);
           [expectations[i] fulfill];
@@ -382,7 +382,7 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
         [self expectationWithDescription:
                   [NSString stringWithFormat:@"Test fetch configs successfully - instance %d", i]];
     XCTAssertEqual(_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusNoFetchYet);
-    FIRRemoteConfigFetchCompletion fetchCompletion =
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) =
         ^void(FIRRemoteConfigFetchStatus status, NSError *error) {
           XCTAssertNotNil(error);
           [expectations[i] fulfill];
@@ -416,7 +416,7 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
         [self expectationWithDescription:
                   [NSString stringWithFormat:@"Test fetch configs successfully - instance %d", i]];
     XCTAssertEqual(_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusNoFetchYet);
-    FIRRemoteConfigFetchCompletion fetchCompletion =
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) =
         ^void(FIRRemoteConfigFetchStatus status, NSError *error) {
           XCTAssertNotNil(error);
           [expectations[i] fulfill];

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -48,7 +48,8 @@
                                           (RCNConfigFetcherCompletion)fetcherCompletion;
 
 - (void)fetchWithUserProperties:(NSDictionary *)userProperties
-              completionHandler:(FIRRemoteConfigFetchCompletion)completionHandler;
+              completionHandler:(void (^_Nullable)(FIRRemoteConfigFetchStatus status,
+                                                   NSError *_Nullable error))completionHandler;
 - (NSString *)constructServerURL;
 - (NSURLSession *)currentNetworkSession;
 @end
@@ -275,8 +276,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
         [self expectationWithDescription:
                   [NSString stringWithFormat:@"Test fetch configs successfully - instance %d", i]];
     XCTAssertEqual(_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusNoFetchYet);
-    FIRRemoteConfigFetchCompletion fetchCompletion = ^void(FIRRemoteConfigFetchStatus status,
-                                                           NSError *error) {
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) = ^void(
+        FIRRemoteConfigFetchStatus status, NSError *error) {
       XCTAssertEqual(self->_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusSuccess);
       XCTAssertNil(error);
 #pragma clang diagnostic push
@@ -318,8 +319,9 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
         [self expectationWithDescription:
                   [NSString stringWithFormat:@"Test fetch configs successfully - instance %d", i]];
     XCTAssertEqual(_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusNoFetchYet);
-    FIRRemoteConfigFetchAndActivateCompletion fetchAndActivateCompletion = ^void(
-        FIRRemoteConfigFetchAndActivateStatus status, NSError *error) {
+    void (^fetchAndActivateCompletion)(
+        FIRRemoteConfigFetchAndActivateStatus status,
+        NSError *error) = ^void(FIRRemoteConfigFetchAndActivateStatus status, NSError *error) {
       XCTAssertEqual(self->_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusSuccess);
       XCTAssertNil(error);
 
@@ -365,8 +367,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
         [self expectationWithDescription:
                   [NSString stringWithFormat:@"Test fetch configs successfully - instance %d", i]];
     XCTAssertEqual(_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusNoFetchYet);
-    FIRRemoteConfigFetchCompletion fetchCompletion = ^(FIRRemoteConfigFetchStatus status,
-                                                       NSError *error) {
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) = ^(
+        FIRRemoteConfigFetchStatus status, NSError *error) {
       XCTAssertEqual(self->_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusSuccess);
       XCTAssertNil(error);
       [self->_configInstances[i] activateWithCompletionHandler:^(NSError *_Nullable error) {
@@ -412,8 +414,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
         expectationWithDescription:
             [NSString stringWithFormat:@"Test enumerating configs successfully - instance %d", i]];
     XCTAssertEqual(_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusNoFetchYet);
-    FIRRemoteConfigFetchCompletion fetchCompletion = ^void(FIRRemoteConfigFetchStatus status,
-                                                           NSError *error) {
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) = ^void(
+        FIRRemoteConfigFetchStatus status, NSError *error) {
       XCTAssertEqual(self->_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusSuccess);
       XCTAssertNil(error);
 #pragma clang diagnostic push
@@ -557,8 +559,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
         expectationWithDescription:
             [NSString stringWithFormat:@"Test enumerating configs successfully - instance %d", i]];
     XCTAssertEqual(_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusNoFetchYet);
-    FIRRemoteConfigFetchCompletion fetchCompletion = ^void(FIRRemoteConfigFetchStatus status,
-                                                           NSError *error) {
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) = ^void(
+        FIRRemoteConfigFetchStatus status, NSError *error) {
       XCTAssertEqual(self->_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusFailure);
       XCTAssertFalse([self->_configInstances[i] activateFetched]);
       XCTAssertNotNil(error);
@@ -681,8 +683,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
         expectationWithDescription:
             [NSString stringWithFormat:@"Test enumerating configs successfully - instance %d", i]];
     XCTAssertEqual(_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusNoFetchYet);
-    FIRRemoteConfigFetchCompletion fetchCompletion = ^void(FIRRemoteConfigFetchStatus status,
-                                                           NSError *error) {
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) = ^void(
+        FIRRemoteConfigFetchStatus status, NSError *error) {
       XCTAssertEqual(self->_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusFailure);
       XCTAssertFalse([self->_configInstances[i] activateFetched]);
       XCTAssertNotNil(error);
@@ -812,8 +814,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
     XCTAssertEqual(_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusNoFetchYet);
 
     // Make sure activate returns false in fetch completion.
-    FIRRemoteConfigFetchCompletion fetchCompletion = ^void(FIRRemoteConfigFetchStatus status,
-                                                           NSError *error) {
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) = ^void(
+        FIRRemoteConfigFetchStatus status, NSError *error) {
       XCTAssertEqual(self->_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusSuccess);
       XCTAssertFalse([self->_configInstances[i] activateFetched]);
       XCTAssertNil(error);
@@ -835,8 +837,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
         [self expectationWithDescription:
                   [NSString stringWithFormat:@"Test configValueForKey: method - instance %d", i]];
     XCTAssertEqual(_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusNoFetchYet);
-    FIRRemoteConfigFetchCompletion fetchCompletion = ^void(FIRRemoteConfigFetchStatus status,
-                                                           NSError *error) {
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) = ^void(
+        FIRRemoteConfigFetchStatus status, NSError *error) {
       XCTAssertEqual(status, FIRRemoteConfigFetchStatusSuccess);
       XCTAssertNil(error);
       XCTAssertTrue([self->_configInstances[i] activateFetched]);
@@ -897,8 +899,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
     NSDictionary<NSString *, NSString *> *defaults = @{key1 : @"default key1", key0 : @"value0-0"};
     [_configInstances[i] setDefaults:defaults];
 
-    FIRRemoteConfigFetchCompletion fetchCompletion = ^void(FIRRemoteConfigFetchStatus status,
-                                                           NSError *error) {
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) = ^void(
+        FIRRemoteConfigFetchStatus status, NSError *error) {
       XCTAssertEqual(self->_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusSuccess);
       XCTAssertNil(error);
       XCTAssertEqualObjects(self->_configInstances[i][key1].stringValue, @"default key1");
@@ -1033,8 +1035,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
     value = _configInstances[i][@"A key doesn't exist"];
     XCTAssertEqual(value.source, FIRRemoteConfigSourceStatic);
 
-    FIRRemoteConfigFetchCompletion fetchCompletion = ^void(FIRRemoteConfigFetchStatus status,
-                                                           NSError *error) {
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) = ^void(
+        FIRRemoteConfigFetchStatus status, NSError *error) {
       XCTAssertEqual(self->_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusSuccess);
       XCTAssertNil(error);
       XCTAssertTrue([self->_configInstances[i] activateFetched]);
@@ -1071,8 +1073,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
     NSDictionary<NSString *, NSString *> *defaults = @{key1 : @"default value1"};
     [_configInstances[i] setDefaults:defaults];
 
-    FIRRemoteConfigFetchCompletion fetchCompletion = ^void(FIRRemoteConfigFetchStatus status,
-                                                           NSError *error) {
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) = ^void(
+        FIRRemoteConfigFetchStatus status, NSError *error) {
       XCTAssertEqual(self->_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusSuccess);
       XCTAssertNil(error);
       XCTAssertEqualObjects(self->_configInstances[i][key1].stringValue, @"default value1");
@@ -1247,8 +1249,8 @@ static NSString *UTCToLocal(NSString *utcTime) {
     NSDictionary<NSString *, NSString *> *defaults = @{key1 : @"default key1", key0 : @"value0-0"};
     [_configInstances[i] setDefaults:defaults];
 
-    FIRRemoteConfigFetchCompletion fetchCompletion = ^void(FIRRemoteConfigFetchStatus status,
-                                                           NSError *error) {
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) = ^void(
+        FIRRemoteConfigFetchStatus status, NSError *error) {
       XCTAssertEqual(status, FIRRemoteConfigFetchStatusSuccess);
       XCTAssertNil(error);
       XCTAssertTrue([self->_configInstances[i] activateFetched]);
@@ -1314,8 +1316,8 @@ static NSString *UTCToLocal(NSString *utcTime) {
     fetchConfigsExpectation[i] = [self
         expectationWithDescription:[NSString
                                        stringWithFormat:@"Test allKeys methods - instance %d", i]];
-    FIRRemoteConfigFetchCompletion fetchCompletion = ^void(FIRRemoteConfigFetchStatus status,
-                                                           NSError *error) {
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) = ^void(
+        FIRRemoteConfigFetchStatus status, NSError *error) {
       XCTAssertEqual(status, FIRRemoteConfigFetchStatusSuccess);
       XCTAssertNil(error);
       NSLog(@"Testing _configInstances %d", i);
@@ -1389,7 +1391,7 @@ static NSString *UTCToLocal(NSString *utcTime) {
     [_configInstances[i] setConfigSettings:settings];
     XCTAssertEqual([_configInstances[i] configSettings].minimumFetchInterval, 123);
 
-    FIRRemoteConfigFetchCompletion fetchCompletion =
+    void (^fetchCompletion)(FIRRemoteConfigFetchStatus status, NSError *error) =
         ^void(FIRRemoteConfigFetchStatus status, NSError *error) {
           XCTAssertFalse([self->_configInstances[i].settings hasMinimumFetchIntervalElapsed:43200]);
 


### PR DESCRIPTION
Stop using typedefs for completion blocks in public APIs so that Xcode is more usable in Swift:

<img width="721" alt="Screen Shot 2020-06-01 at 7 26 29 AM" src="https://user-images.githubusercontent.com/73870/83418999-40495580-a3d9-11ea-894b-8a8ab93e48a4.png">

There is no change/impact on Objective C usability.

The API council suggested this change.  We're piloting in RemoteConfig and will follow up with the other libraries.