### PR TITLE
Standardize headers for SPM and Auth

### DIFF
--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -22,11 +22,7 @@
 #import <UIKit/UIKit.h>
 #endif
 
-#import "FIROptions.h"
 #import "FirebaseAuth.h"
-
-#import "GULAppDelegateSwizzler.h"
-#import "GULAppEnvironmentUtil.h"
 
 #if SWIFT_PACKAGE
 @import FirebaseCore;

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -24,13 +24,25 @@
 
 #import "FIROptions.h"
 #import "FirebaseAuth.h"
+
+#import "GULAppDelegateSwizzler.h"
+#import "GULAppEnvironmentUtil.h"
+
+#if SWIFT_PACKAGE
+@import FirebaseCore;
+@import GoogleUtilities_Environment;
+@import GoogleUtilities_AppDelegateSwizzler;
+#else
+#import <FirebaseCore/FIROptions.h>
+#import <GoogleUtilities/GULAppDelegateSwizzler.h>
+#import <GoogleUtilities/GULAppEnvironmentUtil.h>
+#endif
+
 #import "FirebaseCore/Sources/Private/FIRAppInternal.h"
 #import "FirebaseCore/Sources/Private/FIRComponent.h"
 #import "FirebaseCore/Sources/Private/FIRComponentContainer.h"
 #import "FirebaseCore/Sources/Private/FIRLibrary.h"
 #import "FirebaseCore/Sources/Private/FIRLogger.h"
-#import "GULAppDelegateSwizzler.h"
-#import "GULAppEnvironmentUtil.h"
 #import "GoogleUtilities/SceneDelegateSwizzler/Private/GULSceneDelegateSwizzler.h"
 
 #import "FirebaseAuth/Sources/Auth/FIRAuthDataResult_Internal.h"

--- a/FirebaseAuth/Sources/AuthProvider/OAuth/FIROAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/OAuth/FIROAuthProvider.m
@@ -15,11 +15,17 @@
  */
 
 #import "FIROAuthProvider.h"
+
 #include <CommonCrypto/CommonCrypto.h>
-#import "FIRApp.h"
 #import "FIRFacebookAuthProvider.h"
 #import "FIROAuthCredential.h"
-#import "FIROptions.h"
+
+#if SWIFT_PACKAGE
+@import FirebaseCore;
+#else
+#import <FirebaseCore/FIRApp.h>
+#import <FirebaseCore/FIROptions.h>
+#endif
 
 #import "FirebaseAuth/Sources/Auth/FIRAuthGlobalWorkQueue.h"
 #import "FirebaseAuth/Sources/Auth/FIRAuth_Internal.h"

--- a/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
@@ -17,13 +17,17 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import "FIRApp.h"
 #import "FIRAuthSettings.h"
 #import "FIRMultiFactorResolver.h"
-#import "FIROptions.h"
 #import "FIRPhoneAuthProvider.h"
 #import "FirebaseAuthVersion.h"
-#import "FirebaseCore/Sources/Private/FIRLogger.h"
+
+#if SWIFT_PACKAGE
+@import FirebaseCore;
+#else
+#import <FirebaseCore/FIRApp.h>
+#import <FirebaseCore/FIROptions.h>
+#endif
 
 #import "FirebaseAuth/Sources/Auth/FIRAuthGlobalWorkQueue.h"
 #import "FirebaseAuth/Sources/Auth/FIRAuth_Internal.h"
@@ -47,6 +51,7 @@
 #import "FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthURLPresenter.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthWebUtils.h"
+#import "FirebaseCore/Sources/Private/FIRLogger.h"
 
 #if TARGET_OS_IOS
 #import "FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthCredential_Internal.h"

--- a/FirebaseAuth/Tests/Sample/ApiTests/FIRAuthApiTestsBase.h
+++ b/FirebaseAuth/Tests/Sample/ApiTests/FIRAuthApiTestsBase.h
@@ -16,9 +16,9 @@
 
 #import <XCTest/XCTest.h>
 
-#import "FIRApp.h"
+#import <FirebaseCore/FIRApp.h>
 #import "AuthCredentials.h"
-#import "FirebaseAuth.h"
+#import <FirebaseAuth/FirebaseAuth.h>
 
 #ifdef NO_NETWORK
 #import "ITUIOSTestUtil.h"

--- a/FirebaseAuth/Tests/Sample/E2eTests/FIRAuthE2eTestsBase.h
+++ b/FirebaseAuth/Tests/Sample/E2eTests/FIRAuthE2eTestsBase.h
@@ -18,7 +18,7 @@
 
 #import <EarlGrey/EarlGrey.h>
 
-#import "FirebaseAuth.h"
+#import <FirebaseAuth/FirebaseAuth.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAuth/Tests/Sample/Sample/AppManager.m
+++ b/FirebaseAuth/Tests/Sample/Sample/AppManager.m
@@ -16,9 +16,9 @@
 
 #import "AppManager.h"
 
-#import "FIRApp.h"
-#import "FIRPhoneAuthProvider.h"
-#import "FirebaseAuth.h"
+#import <FirebaseCore/FIRApp.h>
+#import <FirebaseAuth/FIRPhoneAuthProvider.h>
+#import <FirebaseAuth/FirebaseAuth.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAuth/Tests/Sample/Sample/ApplicationDelegate.m
+++ b/FirebaseAuth/Tests/Sample/Sample/ApplicationDelegate.m
@@ -17,10 +17,10 @@
 #import "ApplicationDelegate.h"
 
 #import <FirebaseCore/FIRApp.h>
-#import "FirebaseCore/Sources/Private/FIRLogger.h"
+#import <FirebaseCore/FIRLogger.h>
 
 #import "AuthProviders.h"
-#import "FirebaseAuth.h"
+#import <FirebaseAuth/FirebaseAuth.h>
 #import "GTMSessionFetcherLogging.h"
 #import "MainViewController.h"
 

--- a/FirebaseAuth/Tests/Sample/Sample/FacebookAuthProvider.m
+++ b/FirebaseAuth/Tests/Sample/Sample/FacebookAuthProvider.m
@@ -19,7 +19,7 @@
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #import <FBSDKLoginKit/FBSDKLoginKit.h>
 
-#import "FIRFacebookAuthProvider.h"
+#import <FirebaseAuth/FIRFacebookAuthProvider.h>
 #import "ApplicationDelegate.h"
 #import "AuthCredentials.h"
 

--- a/FirebaseAuth/Tests/Sample/Sample/GoogleAuthProvider.m
+++ b/FirebaseAuth/Tests/Sample/Sample/GoogleAuthProvider.m
@@ -19,9 +19,9 @@
 #import <GoogleSignIn/GoogleSignIn.h>
 
 #import "AppManager.h"
-#import "FIRApp.h"
-#import "FIROptions.h"
-#import "FIRGoogleAuthProvider.h"
+#import <FirebaseCore/FIRApp.h>
+#import <FirebaseCore/FIROptions.h>
+#import <FirebaseAuth/FIRGoogleAuthProvider.h>
 #import "ApplicationDelegate.h"
 
 /** @typedef GoogleSignInCallback

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+App.m
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+App.m
@@ -27,7 +27,7 @@
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyClientResponse.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRSendVerificationCodeRequest.h"
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
-#import "FIRApp.h"
+#import <FirebaseCore/FIRApp.h>
 
 static NSString *const kTokenRefreshErrorAlertTitle = @"Get Token Error";
 

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+Auth.h
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+Auth.h
@@ -18,7 +18,7 @@
 
 #import "MainViewController.h"
 
-#import "FIRAuth.h"
+#import <FirebaseAuth/FIRAuth.h>
 #import "StaticContentTableViewManager.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+Email.h
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+Email.h
@@ -18,8 +18,8 @@
 
 #import "MainViewController.h"
 
-#import "FIRAuth.h"
-#import "FIRAuthCredential.h"
+#import <FirebaseAuth/FIRAuth.h>
+#import <FirebaseAuth/FIRAuthCredential.h>
 #import "StaticContentTableViewManager.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+Email.m
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+Email.m
@@ -19,7 +19,7 @@
 #import "AppManager.h"
 #import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver+Internal.h"
 #import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorSession+Internal.h"
-#import "FIRPhoneMultiFactorInfo.h"
+#import <FirebaseAuth/FIRPhoneMultiFactorInfo.h>
 #import "MainViewController+Internal.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+GameCenter.h
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+GameCenter.h
@@ -19,7 +19,7 @@
 
 #import "MainViewController.h"
 
-#import "FIRGameCenterAuthProvider.h"
+#import <FirebaseAuth/FIRGameCenterAuthProvider.h>
 #import "StaticContentTableViewManager.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+GameCenter.m
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+GameCenter.m
@@ -17,7 +17,7 @@
 #import "MainViewController+GameCenter.h"
 
 #import "AppManager.h"
-#import "FirebaseAuth.h"
+#import <FirebaseAuth/FirebaseAuth.h>
 #import "MainViewController+Internal.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+Google.m
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+Google.m
@@ -20,8 +20,8 @@
 #import "AuthProviders.h"
 #import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver+Internal.h"
 #import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorSession+Internal.h"
-#import "FIROAuthProvider.h"
-#import "FIRPhoneMultiFactorInfo.h"
+#import <FirebaseAuth/FIROAuthProvider.h>
+#import <FirebaseAuth/FIRPhoneMultiFactorInfo.h>
 #import "MainViewController+Internal.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+MultiFactor.m
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+MultiFactor.m
@@ -18,8 +18,8 @@
 
 #import "FirebaseAuth/Sources/Auth/FIRAuth_Internal.h"
 #import "FirebaseAuth/Sources/User/FIRUser_Internal.h"
-#import "FIRMultiFactorInfo.h"
-#import "FIRPhoneAuthProvider.h"
+#import <FirebaseAuth/FIRMultiFactorInfo.h>
+#import <FirebaseAuth/FIRPhoneAuthProvider.h>
 #import "MainViewController+Internal.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+OAuth.m
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+OAuth.m
@@ -19,7 +19,7 @@
 #import <AuthenticationServices/AuthenticationServices.h>
 
 #import "AppManager.h"
-#import "FIROAuthProvider.h"
+#import <FirebaseAuth/FIROAuthProvider.h>
 #import "MainViewController+Internal.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+OOB.h
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+OOB.h
@@ -18,7 +18,7 @@
 
 #import "MainViewController.h"
 
-#import "FirebaseAuth.h"
+#import <FirebaseAuth/FirebaseAuth.h>
 #import "StaticContentTableViewManager.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController.m
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController.m
@@ -16,13 +16,13 @@
 
 #import <objc/runtime.h>
 
-#import "FIRApp.h"
-#import "FirebaseCore/Sources/Private/FIRAppInternal.h"
+#import <FirebaseCore/FIRApp.h>
+#import <FirebaseCore/FIRAppInternal.h>
 
 #import "AppManager.h"
 #import "AuthCredentials.h"
 #import "FacebookAuthProvider.h"
-#import "FirebaseAuth.h"
+#import <FirebaseAuth/FirebaseAuth.h>
 #import "GoogleAuthProvider.h"
 #import "MainViewController+App.h"
 #import "MainViewController+Auth.h"

--- a/FirebaseAuth/Tests/Sample/Sample/SettingsViewController.m
+++ b/FirebaseAuth/Tests/Sample/Sample/SettingsViewController.m
@@ -19,14 +19,14 @@
 #import <objc/runtime.h>
 
 #import "AppManager.h"
-#import "FIRApp.h"
+#import <FirebaseCore/FIRApp.h>
 #import "FirebaseAuth/Sources/Auth/FIRAuth_Internal.h"
 #import "FirebaseAuth/Sources/SystemService/FIRAuthAPNSToken.h"
 #import "FirebaseAuth/Sources/SystemService/FIRAuthAPNSTokenManager.h"
 #import "FirebaseAuth/Sources/SystemService/FIRAuthAppCredential.h"
 #import "FirebaseAuth/Sources/SystemService/FIRAuthAppCredentialManager.h"
-#import "FIROptions.h"
-#import "FirebaseAuth.h"
+#import <FirebaseCore/FIROptions.h>
+#import <FirebaseAuth/FirebaseAuth.h>
 #import "StaticContentTableViewManager.h"
 #import "UIViewController+Alerts.h"
 

--- a/FirebaseAuth/Tests/Sample/Sample/UserInfoViewController.m
+++ b/FirebaseAuth/Tests/Sample/Sample/UserInfoViewController.m
@@ -16,9 +16,9 @@
 
 #import "UserInfoViewController.h"
 
-#import "FIRUser.h"
-#import "FIRUserInfo.h"
-#import "FIRUserMetadata.h"
+#import <FirebaseAuth/FIRUser.h>
+#import <FirebaseAuth/FIRUserInfo.h>
+#import <FirebaseAuth/FIRUserMetadata.h>
 #import "StaticContentTableViewManager.h"
 
 /** @fn stringWithBool

--- a/FirebaseAuth/Tests/Sample/Sample/UserTableViewCell.m
+++ b/FirebaseAuth/Tests/Sample/Sample/UserTableViewCell.m
@@ -16,7 +16,7 @@
 
 #import "UserTableViewCell.h"
 
-#import "FIRUser.h"
+#import <FirebaseAuth/FIRUser.h>
 
 @implementation UserTableViewCell {
   /** @var _lastPhotoURL

--- a/FirebaseAuth/Tests/Unit/FIRAuthTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthTests.m
@@ -64,9 +64,9 @@
 #import "FirebaseAuth/Tests/Unit/OCMStubRecorder+FIRAuthUnitTests.h"
 
 #if SWIFT_PACKAGE
-@import GoogleUtilities_Environment;
+@import GoogleUtilities_AppDelegateSwizzler;
 #else
-#import <GoogleUtilities/GULAppEnvironmentUtil.h>
+#import <GoogleUtilities/GULAppDelegateSwizzler.h>
 #endif
 
 #if TARGET_OS_IOS

--- a/FirebaseAuth/Tests/Unit/FIRAuthTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthTests.m
@@ -16,7 +16,6 @@
 
 #import <FirebaseCore/FIRLibrary.h>
 #import <Foundation/Foundation.h>
-#import <GoogleUtilities/GULAppDelegateSwizzler.h>
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 #import "FIRActionCodeSettings.h"
@@ -63,6 +62,12 @@
 #import "FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h"
 #import "FirebaseAuth/Tests/Unit/FIRApp+FIRAuthUnitTests.h"
 #import "FirebaseAuth/Tests/Unit/OCMStubRecorder+FIRAuthUnitTests.h"
+
+#if SWIFT_PACKAGE
+@import GoogleUtilities_Environment;
+#else
+#import <GoogleUtilities/GULAppEnvironmentUtil.h>
+#endif
 
 #if TARGET_OS_IOS
 #import "FIRAuthUIDelegate.h"

--- a/FirebaseAuth/Tests/Unit/FIROAuthProviderTests.m
+++ b/FirebaseAuth/Tests/Unit/FIROAuthProviderTests.m
@@ -16,11 +16,17 @@
 
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
-#import "FIRApp.h"
+
 #import "FIRAuthErrors.h"
 #import "FIRAuthUIDelegate.h"
 #import "FIROAuthProvider.h"
-#import "FIROptions.h"
+
+#if SWIFT_PACKAGE
+@import FirebaseCore;
+#else
+#import <FirebaseCore/FIRApp.h>
+#import <FirebaseCore/FIROptions.h>
+#endif
 
 #import "FirebaseAuth/Sources/Auth/FIRAuthGlobalWorkQueue.h"
 #import "FirebaseAuth/Sources/Auth/FIRAuth_Internal.h"

--- a/FirebaseAuth/Tests/Unit/FIRPhoneAuthProviderTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRPhoneAuthProviderTests.m
@@ -17,12 +17,18 @@
 #import <OCMock/OCMock.h>
 #import <SafariServices/SafariServices.h>
 #import <XCTest/XCTest.h>
-#import "FIRApp.h"
+
 #import "FIRAuth.h"
 #import "FIRAuthSettings.h"
 #import "FIRAuthUIDelegate.h"
-#import "FIROptions.h"
 #import "FIRPhoneAuthProvider.h"
+
+#if SWIFT_PACKAGE
+@import FirebaseCore;
+#else
+#import <FirebaseCore/FIRApp.h>
+#import <FirebaseCore/FIROptions.h>
+#endif
 
 #import "FirebaseAuth/Sources/Auth/FIRAuthGlobalWorkQueue.h"
 #import "FirebaseAuth/Sources/Auth/FIRAuth_Internal.h"

--- a/scripts/check_no_module_imports.sh
+++ b/scripts/check_no_module_imports.sh
@@ -33,12 +33,6 @@ git grep "${options[@]}" \
   ':(exclude,glob)FirebaseStorage/**' ':(exclude,glob)FirebaseAuth/**' \
   ':(exclude)Firebase/Firebase/Public/Firebase.h' && exit_with_error
 
-# Tests are under the Example directory, so we have to separately grep them for
-# @import statements (otherwise they'd be excluded).
-git grep "${options[@]}" \
-  -- ':(glob)**/Tests/**' ':(glob)**/TestUtils/**' ':(glob)**/IntegrationTests/**' && \
-  exit_with_error
-
 # We need to explicitly exit 0, since we expect `git grep` to return an error
 # if no @import calls are found.
 exit 0


### PR DESCRIPTION
Simple name for public headers in the library
Module imports for public headers from dependencies like:

```
#if SWIFT_PACKAGE
@import FirebaseCore;
#else
#import <FirebaseCore/FIRApp.h>
#import <FirebaseCore/FIROptions.h>
#endif
```

Also restore Sample to master until we're ready to get it working with SPM