### PR TITLE
Add `Error::kErrorNone` as a synonym for `kErrorOk`

### DIFF
--- a/Firestore/core/include/firebase/firestore/firestore_errors.h
+++ b/Firestore/core/include/firebase/firestore/firestore_errors.h
@@ -30,6 +30,8 @@ enum Error {
   // Note: NSError objects will never have a code with this value.
   kErrorOk = 0,
 
+  kErrorNone = 0,
+
   /** The operation was cancelled (typically by the caller). */
   kErrorCancelled = 1,
 


### PR DESCRIPTION
This is for consistency with other Firebase C++ SDKs.