### PR TITLE
Crashlytics add missing headers for builds

### DIFF
--- a/Crashlytics/Crashlytics/Helpers/FIRCLSFile.h
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSFile.h
@@ -18,6 +18,11 @@
 #include <stdint.h>
 #include <sys/cdefs.h>
 
+// Required for 1P builds
+#include <stddef.h>
+#include <sys/types.h>
+#include <unistd.h>
+
 #if defined(__OBJC__)
 #import <Foundation/Foundation.h>
 #endif


### PR DESCRIPTION
Needed for 1P builds