### PR TITLE
Build GDT and nanopb with Swift Package Manager

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCOREvent.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCOREvent.m
@@ -16,10 +16,10 @@
 
 #import "GDTCORLibrary/Public/GDTCOREvent.h"
 
-#import <GoogleDataTransport/GDTCORAssert.h>
-#import <GoogleDataTransport/GDTCORClock.h>
-#import <GoogleDataTransport/GDTCORConsoleLogger.h>
-#import <GoogleDataTransport/GDTCORPlatform.h>
+#import "GDTCORLibrary/Public/GDTCORAssert.h"
+#import "GDTCORLibrary/Public/GDTCORClock.h"
+#import "GDTCORLibrary/Public/GDTCORConsoleLogger.h"
+#import "GDTCORLibrary/Public/GDTCORPlatform.h"
 
 #import "GDTCORLibrary/Private/GDTCORDataFuture.h"
 #import "GDTCORLibrary/Private/GDTCOREvent_Private.h"

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -16,11 +16,11 @@
 
 #import "GDTCORLibrary/Private/GDTCORFlatFileStorage.h"
 
-#import <GoogleDataTransport/GDTCORAssert.h>
-#import <GoogleDataTransport/GDTCORConsoleLogger.h>
-#import <GoogleDataTransport/GDTCOREvent.h>
-#import <GoogleDataTransport/GDTCORLifecycle.h>
-#import <GoogleDataTransport/GDTCORPrioritizer.h>
+#import "GDTCORLibrary/Public/GDTCORAssert.h"
+#import "GDTCORLibrary/Public/GDTCORConsoleLogger.h"
+#import "GDTCORLibrary/Public/GDTCOREvent.h"
+#import "GDTCORLibrary/Public/GDTCORLifecycle.h"
+#import "GDTCORLibrary/Public/GDTCORPrioritizer.h"
 
 #import "GDTCORLibrary/Private/GDTCOREvent_Private.h"
 #import "GDTCORLibrary/Private/GDTCORRegistrar_Private.h"

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORLifecycle.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORLifecycle.m
@@ -16,8 +16,8 @@
 
 #import "GDTCORLibrary/Public/GDTCORLifecycle.h"
 
-#import <GoogleDataTransport/GDTCORConsoleLogger.h>
-#import <GoogleDataTransport/GDTCOREvent.h>
+#import "GDTCORLibrary/Public/GDTCORConsoleLogger.h"
+#import "GDTCORLibrary/Public/GDTCOREvent.h"
 
 #import "GDTCORLibrary/Private/GDTCORRegistrar_Private.h"
 #import "GDTCORLibrary/Private/GDTCORTransformer_Private.h"

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -16,9 +16,9 @@
 
 #import "GDTCORLibrary/Public/GDTCORPlatform.h"
 
-#import <GoogleDataTransport/GDTCORAssert.h>
-#import <GoogleDataTransport/GDTCORConsoleLogger.h>
-#import <GoogleDataTransport/GDTCORReachability.h>
+#import "GDTCORLibrary/Public/GDTCORAssert.h"
+#import "GDTCORLibrary/Public/GDTCORConsoleLogger.h"
+#import "GDTCORLibrary/Public/GDTCORReachability.h"
 
 #import "GDTCORLibrary/Private/GDTCORRegistrar_Private.h"
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORReachability.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORReachability.m
@@ -17,7 +17,7 @@
 #import "GDTCORLibrary/Public/GDTCORReachability.h"
 #import "GDTCORLibrary/Private/GDTCORReachability_Private.h"
 
-#import <GoogleDataTransport/GDTCORConsoleLogger.h>
+#import "GDTCORLibrary/Public/GDTCORConsoleLogger.h"
 
 #import <netinet/in.h>
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORTransformer.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORTransformer.m
@@ -17,12 +17,12 @@
 #import "GDTCORLibrary/Private/GDTCORTransformer.h"
 #import "GDTCORLibrary/Private/GDTCORTransformer_Private.h"
 
-#import <GoogleDataTransport/GDTCORAssert.h>
-#import <GoogleDataTransport/GDTCORConsoleLogger.h>
-#import <GoogleDataTransport/GDTCOREvent.h>
-#import <GoogleDataTransport/GDTCOREventTransformer.h>
-#import <GoogleDataTransport/GDTCORLifecycle.h>
-#import <GoogleDataTransport/GDTCORStorageProtocol.h>
+#import "GDTCORLibrary/Public/GDTCORAssert.h"
+#import "GDTCORLibrary/Public/GDTCORConsoleLogger.h"
+#import "GDTCORLibrary/Public/GDTCOREvent.h"
+#import "GDTCORLibrary/Public/GDTCOREventTransformer.h"
+#import "GDTCORLibrary/Public/GDTCORLifecycle.h"
+#import "GDTCORLibrary/Public/GDTCORStorageProtocol.h"
 
 #import "GDTCORLibrary/Private/GDTCOREvent_Private.h"
 #import "GDTCORLibrary/Private/GDTCORRegistrar_Private.h"

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORTransport.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORTransport.m
@@ -17,9 +17,9 @@
 #import "GDTCORLibrary/Public/GDTCORTransport.h"
 #import "GDTCORLibrary/Private/GDTCORTransport_Private.h"
 
-#import <GoogleDataTransport/GDTCORAssert.h>
-#import <GoogleDataTransport/GDTCORClock.h>
-#import <GoogleDataTransport/GDTCOREvent.h>
+#import "GDTCORLibrary/Public/GDTCORAssert.h"
+#import "GDTCORLibrary/Public/GDTCORClock.h"
+#import "GDTCORLibrary/Public/GDTCOREvent.h"
 
 #import "GDTCORLibrary/Private/GDTCORTransformer.h"
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
@@ -16,10 +16,10 @@
 
 #import "GDTCORLibrary/Private/GDTCORUploadCoordinator.h"
 
-#import <GoogleDataTransport/GDTCORAssert.h>
-#import <GoogleDataTransport/GDTCORClock.h>
-#import <GoogleDataTransport/GDTCORConsoleLogger.h>
-#import <GoogleDataTransport/GDTCORReachability.h>
+#import "GDTCORLibrary/Public/GDTCORAssert.h"
+#import "GDTCORLibrary/Public/GDTCORClock.h"
+#import "GDTCORLibrary/Public/GDTCORConsoleLogger.h"
+#import "GDTCORLibrary/Public/GDTCORReachability.h"
 
 #import "GDTCORLibrary/Private/GDTCORRegistrar_Private.h"
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORUploadPackage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORUploadPackage.m
@@ -16,8 +16,8 @@
 
 #import "GDTCORLibrary/Public/GDTCORUploadPackage.h"
 
-#import <GoogleDataTransport/GDTCORClock.h>
-#import <GoogleDataTransport/GDTCORConsoleLogger.h>
+#import "GDTCORLibrary/Public/GDTCORClock.h"
+#import "GDTCORLibrary/Public/GDTCORConsoleLogger.h"
 
 #import "GDTCORLibrary/Private/GDTCORRegistrar_Private.h"
 #import "GDTCORLibrary/Private/GDTCORUploadCoordinator.h"

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCOREvent_Private.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCOREvent_Private.h
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#import <GoogleDataTransport/GDTCOREvent.h>
+#import "GDTCOREvent.h"
 
-#import <GoogleDataTransport/GDTCORClock.h>
+#import "GDTCORClock.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage.h
@@ -16,8 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import <GoogleDataTransport/GDTCORLifecycle.h>
-#import <GoogleDataTransport/GDTCORStorageProtocol.h>
+#import "GDTCORLifecycle.h"
+#import "GDTCORStorageProtocol.h"
 
 @class GDTCOREvent;
 @class GDTCORUploadCoordinator;

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORReachability_Private.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORReachability_Private.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "GDTCORLibrary/Public/GDTCORReachability.h"
+#import "GDTCORReachability.h"
 
 @interface GDTCORReachability ()
 

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORRegistrar_Private.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORRegistrar_Private.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <GoogleDataTransport/GDTCORRegistrar.h>
+#import "GDTCORRegistrar.h"
 
 @interface GDTCORRegistrar ()
 

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORTransformer.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORTransformer.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <GoogleDataTransport/GDTCORLifecycle.h>
+#import "GDTCORLifecycle.h"
 
 @class GDTCOREvent;
 

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORTransport_Private.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORTransport_Private.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <GoogleDataTransport/GDTCORTransport.h>
+#import "GDTCORUploadPackage.h"
 
 @class GDTCORTransformer;
 

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORUploadCoordinator.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORUploadCoordinator.h
@@ -16,8 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import <GoogleDataTransport/GDTCORLifecycle.h>
-#import <GoogleDataTransport/GDTCORRegistrar.h>
+#import "GDTCORLifecycle.h"
+#import "GDTCORRegistrar.h"
 
 #import "GDTCORLibrary/Private/GDTCORUploadPackage_Private.h"
 

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORUploadPackage_Private.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORUploadPackage_Private.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <GoogleDataTransport/GDTCORUploadPackage.h>
+#import "GDTCORUploadPackage.h"
 
 @interface GDTCORUploadPackage ()
 

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORAssert.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORAssert.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <GoogleDataTransport/GDTCORConsoleLogger.h>
+#import "GDTCORConsoleLogger.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCOREvent.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCOREvent.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <GoogleDataTransport/GDTCOREventDataObject.h>
+#import "GDTCOREventDataObject.h"
 
 @class GDTCORClock;
 

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORLifecycle.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORLifecycle.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <GoogleDataTransport/GDTCORPlatform.h>
+#import "GDTCORPlatform.h"
 
 @class GDTCOREvent;
 

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPrioritizer.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPrioritizer.h
@@ -16,9 +16,9 @@
 
 #import <Foundation/Foundation.h>
 
-#import <GoogleDataTransport/GDTCOREvent.h>
-#import <GoogleDataTransport/GDTCORLifecycle.h>
-#import <GoogleDataTransport/GDTCORUploadPackage.h>
+#import "GDTCOREvent.h"
+#import "GDTCORLifecycle.h"
+#import "GDTCORUploadPackage.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORReachability.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORReachability.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <GoogleDataTransport/GDTCORPlatform.h>
+#import "GDTCORPlatform.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORRegistrar.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORRegistrar.h
@@ -16,10 +16,10 @@
 
 #import <Foundation/Foundation.h>
 
-#import <GoogleDataTransport/GDTCORPrioritizer.h>
-#import <GoogleDataTransport/GDTCORStorageProtocol.h>
-#import <GoogleDataTransport/GDTCORTargets.h>
-#import <GoogleDataTransport/GDTCORUploader.h>
+#import "GDTCORPrioritizer.h"
+#import "GDTCORStorageProtocol.h"
+#import "GDTCORTargets.h"
+#import "GDTCORUploader.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h
@@ -16,8 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import <GoogleDataTransport/GDTCORLifecycle.h>
-#import <GoogleDataTransport/GDTCORTargets.h>
+#import "GDTCORLifecycle.h"
+#import "GDTCORTargets.h"
 
 @class GDTCOREvent;
 

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORTransport.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORTransport.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <GoogleDataTransport/GDTCOREventTransformer.h>
+#import "GDTCOREventTransformer.h"
 
 @class GDTCOREvent;
 

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORUploadPackage.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORUploadPackage.h
@@ -15,7 +15,7 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <GoogleDataTransport/GDTCORTargets.h>
+#import "GDTCORTargets.h"
 
 @class GDTCORClock;
 @class GDTCOREvent;

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORUploader.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORUploader.h
@@ -16,11 +16,11 @@
 
 #import <Foundation/Foundation.h>
 
-#import <GoogleDataTransport/GDTCORClock.h>
-#import <GoogleDataTransport/GDTCORLifecycle.h>
-#import <GoogleDataTransport/GDTCORPrioritizer.h>
-#import <GoogleDataTransport/GDTCORTargets.h>
-#import <GoogleDataTransport/GDTCORUploadPackage.h>
+#import "GDTCORClock.h"
+#import "GDTCORLifecycle.h"
+#import "GDTCORPrioritizer.h"
+#import "GDTCORTargets.h"
+#import "GDTCORUploadPackage.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
@@ -22,6 +22,10 @@
 #import <AppKit/AppKit.h>
 #endif  // TARGET_OS_IOS || TARGET_OS_TV
 
+#if SWIFT_PACKAGE
+@import GoogleDataTransport;
+@import nanopb;
+#else
 #import <GoogleDataTransport/GDTCORClock.h>
 #import <GoogleDataTransport/GDTCORConsoleLogger.h>
 #import <GoogleDataTransport/GDTCOREvent.h>
@@ -30,6 +34,7 @@
 #import <nanopb/pb.h>
 #import <nanopb/pb_decode.h>
 #import <nanopb/pb_encode.h>
+#endif
 
 #import "GDTCCTLibrary/Private/GDTCOREvent+NetworkConnectionInfo.h"
 

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTPrioritizer.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTPrioritizer.m
@@ -16,11 +16,15 @@
 
 #import "GDTCCTLibrary/Private/GDTCCTPrioritizer.h"
 
+#if SWIFT_PACKAGE
+@import GoogleDataTransport;
+#else
 #import <GoogleDataTransport/GDTCORConsoleLogger.h>
 #import <GoogleDataTransport/GDTCOREvent.h>
 #import <GoogleDataTransport/GDTCORPlatform.h>
 #import <GoogleDataTransport/GDTCORRegistrar.h>
 #import <GoogleDataTransport/GDTCORTargets.h>
+#endif
 
 #import "GDTCCTLibrary/Private/GDTCCTNanopbHelpers.h"
 #import "GDTCCTLibrary/Private/GDTCOREvent+NetworkConnectionInfo.h"

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTUploader.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTUploader.m
@@ -16,6 +16,10 @@
 
 #import "GDTCCTLibrary/Private/GDTCCTUploader.h"
 
+#if SWIFT_PACKAGE
+@import GoogleDataTransport;
+@import nanopb;
+#else
 #import <GoogleDataTransport/GDTCORConsoleLogger.h>
 #import <GoogleDataTransport/GDTCORPlatform.h>
 #import <GoogleDataTransport/GDTCORRegistrar.h>
@@ -23,6 +27,7 @@
 #import <nanopb/pb.h>
 #import <nanopb/pb_decode.h>
 #import <nanopb/pb_encode.h>
+#endif
 
 #import "GDTCCTLibrary/Private/GDTCCTCompressionHelper.h"
 #import "GDTCCTLibrary/Private/GDTCCTNanopbHelpers.h"

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCOREvent+NetworkConnectionInfo.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCOREvent+NetworkConnectionInfo.m
@@ -16,7 +16,11 @@
 
 #import "GDTCCTLibrary/Private/GDTCOREvent+NetworkConnectionInfo.h"
 
+#if SWIFT_PACKAGE
+@import GoogleDataTransport;
+#else
 #import <GoogleDataTransport/GDTCORConsoleLogger.h>
+#endif
 
 NSString *const GDTCCTNeedsNetworkConnectionInfo = @"needs_network_connection_info";
 

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTNanopbHelpers.h
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTNanopbHelpers.h
@@ -16,8 +16,12 @@
 
 #import <Foundation/Foundation.h>
 
+#if SWIFT_PACKAGE
+@import GoogleDataTransport;
+#else
 #import <GoogleDataTransport/GDTCOREvent.h>
 #import <GoogleDataTransport/GDTCORReachability.h>
+#endif
 
 #import "GDTCCTLibrary/Protogen/nanopb/cct.nanopb.h"
 

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTPrioritizer.h
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTPrioritizer.h
@@ -16,10 +16,14 @@
 
 #import <Foundation/Foundation.h>
 
+#if SWIFT_PACKAGE
+@import GoogleDataTransport;
+#else
 #import <GoogleDataTransport/GDTCORClock.h>
 #import <GoogleDataTransport/GDTCOREvent.h>
 #import <GoogleDataTransport/GDTCORPrioritizer.h>
 #import <GoogleDataTransport/GDTCORTargets.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTUploader.h
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCCTUploader.h
@@ -16,7 +16,11 @@
 
 #import <Foundation/Foundation.h>
 
+#if SWIFT_PACKAGE
+@import GoogleDataTransport;
+#else
 #import <GoogleDataTransport/GDTCORUploader.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCOREvent+NetworkConnectionInfo.h
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/Private/GDTCOREvent+NetworkConnectionInfo.h
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
+#if SWIFT_PACKAGE
+@import GoogleDataTransport;
+#else
 #import <GoogleDataTransport/GDTCOREvent.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/Protogen/nanopb/cct.nanopb.h
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/Protogen/nanopb/cct.nanopb.h
@@ -19,7 +19,11 @@
 
 #ifndef PB_GDT_CCT_CCT_NANOPB_H_INCLUDED
 #define PB_GDT_CCT_CCT_NANOPB_H_INCLUDED
+#if SWIFT_PACKAGE
+#include "nanopb.h"
+#else
 #include <nanopb/pb.h>
+#endif
 
 /* @@protoc_insertion_point(includes) */
 #if PB_PROTO_HEADER_VERSION != 30

--- a/Package.swift
+++ b/Package.swift
@@ -66,6 +66,8 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/google/promises.git", "1.2.8" ..< "1.3.0"),
     .package(url: "https://github.com/google/gtm-session-fetcher.git", "1.4.0" ..< "2.0.0"),
+    .package(url: "https://github.com/paulb777/nanopb.git", .branch("swift-package-manager")),
+ //   .package(url: "https://github.com/paulb777/nanopb.git", .revision("564392bd87bd093c308a3aaed3997466efb95f74"))
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -242,6 +244,27 @@ let package = Package(
       name: "FirebaseStorageSwift",
       dependencies: ["FirebaseStorage"],
       path: "FirebaseStorageSwift/Sources"
+    ),
+    .target(
+      name: "GoogleDataTransport",
+      path: "GoogleDataTransport/GDTCORLibrary",
+      publicHeadersPath: "Public",
+      cSettings: [
+        .headerSearchPath("../"),
+        .define("GDTCOR_VERSION", to: "0.0.1"),
+      ]
+    ),
+    .target(
+      name: "GoogleDataTransportCCTSupport",
+      dependencies: ["GoogleDataTransport", "nanopb"],
+      path: "GoogleDataTransportCCTSupport/GDTCCTLibrary",
+      publicHeadersPath: "Private",
+      cSettings: [
+        .headerSearchPath("../"),
+        .define("PB_FIELD_32BIT", to: "1"),
+        .define("PB_NO_PACKED_STRUCTS", to: "1"),
+        .define("PB_ENABLE_MALLOC", to: "1"),
+      ]
     ),
 //       linkerSettings: [
 //         .linkedFramework("CoreServices", .when(platforms: [.macOS])),

--- a/Package.swift
+++ b/Package.swift
@@ -67,7 +67,8 @@ let package = Package(
     .package(url: "https://github.com/google/promises.git", "1.2.8" ..< "1.3.0"),
     .package(url: "https://github.com/google/gtm-session-fetcher.git", "1.4.0" ..< "2.0.0"),
     .package(url: "https://github.com/paulb777/nanopb.git", .branch("swift-package-manager")),
- //   .package(url: "https://github.com/paulb777/nanopb.git", .revision("564392bd87bd093c308a3aaed3997466efb95f74"))
+    // Branches need a force update with a run with the revision set like below.
+    //   .package(url: "https://github.com/paulb777/nanopb.git", .revision("564392bd87bd093c308a3aaed3997466efb95f74"))
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/scripts/check_no_module_imports.sh
+++ b/scripts/check_no_module_imports.sh
@@ -31,7 +31,7 @@ function exit_with_error {
 git grep "${options[@]}" \
   -- ':(exclude,glob)**/Example/**' ':(exclude,glob)**/Sample/**' \
   ':(exclude,glob)FirebaseStorage/**' ':(exclude,glob)FirebaseAuth/**' \
-  ':(exclude,glob)FirebaseCore/**' \
+  ':(exclude,glob)FirebaseCore/**' ':(exclude,glob)GoogleDataTransportCCTSupport/**'  \
   ':(exclude)Firebase/Sources/Public/Firebase.h' && exit_with_error
 
 # We need to explicitly exit 0, since we expect `git grep` to return an error


### PR DESCRIPTION
Public header Imports in .m's use relative path
PubIic imports in .h's use simple file name for intra-module publics
Public imports from other modules use module import for SPM

Using forked repo for nanopb for now.