### PR TITLE
Send pod SDK version instead of hardcoded value in RC fetch request

### DIFF
--- a/FirebaseRemoteConfig/Sources/RCNConfigConstants.h
+++ b/FirebaseRemoteConfig/Sources/RCNConfigConstants.h
@@ -19,13 +19,6 @@
 #define RCN_SEC_PER_MIN 60
 #define RCN_MSEC_PER_SEC 1000
 
-/// Remote Config SDK internal version that is different than
-/// FIRRemoteConfigPodVersion. This is for config server to track down iOS
-/// client app version. Each version can only go up to 99.
-static const int kRCNMajorVersion = 1;
-static const int kRCNMinorVersion = 2;
-static const int kRCNPatchVersion = 10;
-
 /// Key prefix applied to all the packages (bundle IDs) in internal metadata.
 static NSString *const RCNInternalMetadataAllPackagesPrefix = @"all_packages";
 

--- a/FirebaseRemoteConfig/Sources/RCNConfigSettings.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigSettings.m
@@ -354,8 +354,8 @@ static const int kRCNExponentialBackoffMaximumInterval = 60 * 60 * 4;  // 4 hour
                                                                 FIRRemoteConfigAppVersion()]];
   ret = [ret stringByAppendingString:[NSString stringWithFormat:@", app_build:'%@'",
                                                                 FIRRemoteConfigAppBuildVersion()]];
-  ret = [ret stringByAppendingString:[NSString stringWithFormat:@", sdk_version:'%d'",
-                                                                FIRRemoteConfigSDKVersion()]];
+  ret = [ret stringByAppendingString:[NSString stringWithFormat:@", sdk_version:'%@'",
+                                                                FIRRemoteConfigPodVersion()]];
 
   if (userProperties && userProperties.count > 0) {
     NSError *error;

--- a/FirebaseRemoteConfig/Sources/RCNDevice.h
+++ b/FirebaseRemoteConfig/Sources/RCNDevice.h
@@ -47,11 +47,6 @@ RCNDeviceModel FIRRemoteConfigDeviceSubtype(void);
 /// Device timezone.
 NSString *FIRRemoteConfigTimezone(void);
 
-/// SDK version. This is different than CocoaPods SDK version.
-/// It is used for config server to keep track iOS client version.
-/// major * 10000 + minor + 100 + patch.
-int FIRRemoteConfigSDKVersion(void);
-
 /// Update device context to the given dictionary.
 NSMutableDictionary *FIRRemoteConfigDeviceContextWithProjectIdentifier(
     NSString *GMPProjectIdentifier);

--- a/FirebaseRemoteConfig/Sources/RCNDevice.m
+++ b/FirebaseRemoteConfig/Sources/RCNDevice.m
@@ -202,10 +202,6 @@ NSString *FIRRemoteConfigTimezone() {
   return timezone.name;
 }
 
-int FIRRemoteConfigSDKVersion() {
-  return kRCNMajorVersion * 10000 + kRCNMinorVersion * 100 + kRCNPatchVersion;
-}
-
 NSMutableDictionary *FIRRemoteConfigDeviceContextWithProjectIdentifier(
     NSString *GMPProjectIdentifier) {
   NSMutableDictionary *deviceContext = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
Currently we are sending an "internal" SDK version that is never updated. Using `FIRRemoteConfigPodVersion` to reflect actual SDK version usage

Tracked in internal bug 157147675

This change only affects internal logging #no-changelog