### PR TITLE
Implement helpers for storing and finding events

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -79,7 +79,7 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
   return eventDataPath;
 }
 
-+ (NSString *)libraryDataPath {
++ (NSString *)libraryDataStoragePath {
   static NSString *libraryDataPath;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
@@ -88,15 +88,15 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
                                                isDirectory:YES]
             .path;
     libraryDataPath = [libraryDataPath stringByAppendingPathComponent:@"gdt_library_data"];
-    if (![[NSFileManager defaultManager] fileExistsAtPath:libraryDataPath isDirectory:NULL]) {
-      NSError *error;
-      [[NSFileManager defaultManager] createDirectoryAtPath:libraryDataPath
-                                withIntermediateDirectories:YES
-                                                 attributes:0
-                                                      error:&error];
-      GDTCORAssert(error == nil, @"Creating the library data path failed: %@", error);
-    }
   });
+  if (![[NSFileManager defaultManager] fileExistsAtPath:libraryDataPath isDirectory:NULL]) {
+    NSError *error;
+    [[NSFileManager defaultManager] createDirectoryAtPath:libraryDataPath
+                              withIntermediateDirectories:YES
+                                               attributes:0
+                                                    error:&error];
+    GDTCORAssert(error == nil, @"Creating the library data path failed: %@", error);
+  }
   return libraryDataPath;
 }
 
@@ -312,7 +312,7 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
                onComplete:
                    (nonnull void (^)(NSData *_Nullable, NSError *_Nullable error))onComplete {
   dispatch_async(_storageQueue, ^{
-    NSString *dataPath = [[[self class] libraryDataPath] stringByAppendingPathComponent:key];
+    NSString *dataPath = [[[self class] libraryDataStoragePath] stringByAppendingPathComponent:key];
     NSError *error;
     NSData *data = [NSData dataWithContentsOfFile:dataPath options:0 error:&error];
     if (onComplete) {
@@ -332,7 +332,7 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
   }
   dispatch_async(_storageQueue, ^{
     NSError *error;
-    NSString *dataPath = [[[self class] libraryDataPath] stringByAppendingPathComponent:key];
+    NSString *dataPath = [[[self class] libraryDataStoragePath] stringByAppendingPathComponent:key];
     [data writeToFile:dataPath options:NSDataWritingAtomic error:&error];
     if (onComplete) {
       onComplete(error);
@@ -344,7 +344,7 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
                      onComplete:(nonnull void (^)(NSError *_Nullable error))onComplete {
   dispatch_async(_storageQueue, ^{
     NSError *error;
-    NSString *dataPath = [[[self class] libraryDataPath] stringByAppendingPathComponent:key];
+    NSString *dataPath = [[[self class] libraryDataStoragePath] stringByAppendingPathComponent:key];
     if ([[NSFileManager defaultManager] fileExistsAtPath:dataPath]) {
       [[NSFileManager defaultManager] removeItemAtPath:dataPath error:&error];
       if (onComplete) {

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -101,14 +101,15 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
 }
 
 + (NSDictionary<NSString *, NSString *> *)pathsForEvent:(GDTCOREvent *)event {
-  NSString *dataPath = [NSString
-      stringWithFormat:@"%@/%@", [GDTCORFlatFileStorage baseEventStoragePath], event.eventID];
+  NSString *dataPath =
+      [NSString stringWithFormat:@"%@/%ld/%@", [GDTCORFlatFileStorage baseEventStoragePath],
+                                 (long)event.target, event.eventID];
   NSString *mappingIDPath =
-      [NSString stringWithFormat:@"%@/%@/%ld/%@", [GDTCORFlatFileStorage baseEventStoragePath],
-                                 event.mappingID, (long)event.qosTier, event.eventID];
-  NSString *qosTierPath = [NSString
-      stringWithFormat:@"%@/%ld/%ld/%@/%@", [GDTCORFlatFileStorage baseEventStoragePath],
-                       (long)event.target, (long)event.qosTier, event.mappingID, event.eventID];
+      [NSString stringWithFormat:@"%@/%ld/%@/%@", [GDTCORFlatFileStorage baseEventStoragePath],
+                                 (long)event.target, event.mappingID, event.eventID];
+  NSString *qosTierPath =
+      [NSString stringWithFormat:@"%@/%ld/%ld/%@", [GDTCORFlatFileStorage baseEventStoragePath],
+                                 (long)event.target, (long)event.qosTier, event.eventID];
   return @{
     gGDTCORFlatFileStorageEventDataPathKey : dataPath,
     gGDTCORFlatFileStorageMappingIDPathKey : mappingIDPath,
@@ -141,21 +142,30 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
       [NSString stringWithFormat:@"%@/%ld/%@/%@", baseEventPath, (long)target, qosTier, mappingID];
 }
 
-+ (nullable NSArray<NSString *> *)searchPathsWithEventSelector:
-    (GDTCORStorageEventSelector *)eventSelector {
++ (NSArray<NSString *> *)searchPathsWithEventSelector:(GDTCORStorageEventSelector *)eventSelector {
   NSMutableArray<NSString *> *searchPaths = [[NSMutableArray alloc] init];
   if (eventSelector.selectedQosTiers && eventSelector.selectedQosTiers.count > 0) {
     for (NSNumber *qosTier in eventSelector.selectedQosTiers) {
       NSString *searchPath = [self pathForTarget:eventSelector.selectedTarget
                                          qosTier:qosTier
                                        mappingID:eventSelector.selectedMappingID];
-      [searchPaths addObject:searchPath];
+      BOOL isDirectory;
+      if ([[NSFileManager defaultManager] fileExistsAtPath:searchPath isDirectory:&isDirectory]) {
+        if (isDirectory) {
+          [searchPaths addObject:searchPath];
+        }
+      }
     }
   } else {
     NSString *searchPath = [self pathForTarget:eventSelector.selectedTarget
                                        qosTier:nil
                                      mappingID:eventSelector.selectedMappingID];
-    [searchPaths addObject:searchPath];
+    BOOL isDirectory;
+    if ([[NSFileManager defaultManager] fileExistsAtPath:searchPath isDirectory:&isDirectory]) {
+      if (isDirectory) {
+        [searchPaths addObject:searchPath];
+      }
+    }
   }
   return searchPaths;
 }

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -21,6 +21,7 @@
 #import <GoogleDataTransport/GDTCOREvent.h>
 #import <GoogleDataTransport/GDTCORLifecycle.h>
 #import <GoogleDataTransport/GDTCORPrioritizer.h>
+#import <GoogleDataTransport/GDTCORStorageEventSelector.h>
 
 #import "GDTCORLibrary/Private/GDTCOREvent_Private.h"
 #import "GDTCORLibrary/Private/GDTCORRegistrar_Private.h"

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORStorageEventSelector.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORStorageEventSelector.m
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GDTCORLibrary/Public/GDTCORStorageEventSelector.h"
+
+@implementation GDTCORStorageEventSelector
+
+- (instancetype)initWithTarget:(GDTCORTarget)target
+                eventIDEqualTo:(nullable NSNumber *)eventID
+              mappingIDEqualTo:(nullable NSString *)mappingID
+                      qosTiers:(nullable NSArray<NSNumber *> *)qosTiers {
+  self = [super init];
+  if (self) {
+    _selectedTarget = target;
+    _selectedEventID = eventID;
+    _selectedMappingID = mappingID;
+    _selectedQosTiers = qosTiers;
+  }
+  return self;
+}
+
+@end

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage.h
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 
 #import <GoogleDataTransport/GDTCORLifecycle.h>
+#import <GoogleDataTransport/GDTCORStorageEventSelector.h>
 #import <GoogleDataTransport/GDTCORStorageProtocol.h>
 
 @class GDTCOREvent;

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage.h
@@ -34,7 +34,16 @@ FOUNDATION_EXPORT NSString *const gGDTCORFlatFileStorageMappingIDPathKey;
 /** The key of the event's qos tier path if a path dictionary is returned. */
 FOUNDATION_EXPORT NSString *const gGDTCORFlatFileStorageQoSTierPathKey;
 
-/** Manages the storage of events. This class is thread-safe. */
+/** Manages the storage of events. This class is thread-safe.
+ *
+ * Event files will be stored as follows:
+ *   <app cache>/gdt_event_data/<target>/<eventID> as a normal file write
+ *   <app cache>/gdt_event_data/<target>/<qosTier>/<eventID> as a symbolic link
+ *   <app cache>/gdt_event_data/<target>/<mappingID>/<eventID> as a symbolic link
+ *
+ * Library data will be stored as follows:
+ *   <app cache>/gdt_library_data/<key of library data>
+ */
 @interface GDTCORFlatFileStorage
     : NSObject <NSSecureCoding, GDTCORStorageProtocol, GDTCORLifecycleProtocol>
 
@@ -88,8 +97,7 @@ FOUNDATION_EXPORT NSString *const gGDTCORFlatFileStorageQoSTierPathKey;
  * @param eventSelector The event selector to process.
  * @return A list of paths that exist and could contain events.
  */
-+ (nullable NSArray<NSString *> *)searchPathsWithEventSelector:
-    (GDTCORStorageEventSelector *)eventSelector;
++ (NSArray<NSString *> *)searchPathsWithEventSelector:(GDTCORStorageEventSelector *)eventSelector;
 
 @end
 

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage.h
@@ -24,6 +24,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/** The key of the event data path if a path dictionary is returned. */
+FOUNDATION_EXPORT NSString *const gGDTCORFlatFileStorageEventDataPathKey;
+
+/** The key of the event's mapping ID path if a path dictionary is returned. */
+FOUNDATION_EXPORT NSString *const gGDTCORFlatFileStorageMappingIDPathKey;
+
+/** The key of the event's qos tier path if a path dictionary is returned. */
+FOUNDATION_EXPORT NSString *const gGDTCORFlatFileStorageQoSTierPathKey;
+
 /** Manages the storage of events. This class is thread-safe. */
 @interface GDTCORFlatFileStorage
     : NSObject <NSSecureCoding, GDTCORStorageProtocol, GDTCORLifecycleProtocol>
@@ -53,6 +62,33 @@ NS_ASSUME_NONNULL_BEGIN
  * @return File path to serialized singleton.
  */
 + (NSString *)archivePath;
+
+/** Returns storage paths for the given event, though the paths may not exist.
+ *
+ * @note The keys of this dictionary are declared in this header.
+ * @param event The event to map to storage paths.
+ */
++ (NSDictionary<NSString *, NSString *> *)pathsForEvent:(GDTCOREvent *)event;
+
+/** Returns a storage path to events for the given target, qosTier, and mapping ID. The path may not
+ * exist.
+ *
+ * @param target The target, which is necessary to be given a path.
+ * @param qosTier An optional parameter to get a more specific path.
+ * @param mappingID An optional parameter to get a more specific path.
+ * @return The path representing the combination of the given parameters.
+ */
++ (NSString *)pathForTarget:(GDTCORTarget)target
+                    qosTier:(nullable NSNumber *)qosTier
+                  mappingID:(nullable NSString *)mappingID;
+
+/** Returns a list of paths that will contain events for the given event selector.
+ *
+ * @param eventSelector The event selector to process.
+ * @return A list of paths that exist and could contain events.
+ */
++ (nullable NSArray<NSString *> *)searchPathsWithEventSelector:
+    (GDTCORStorageEventSelector *)eventSelector;
 
 @end
 

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage.h
@@ -73,6 +73,18 @@ FOUNDATION_EXPORT NSString *const gGDTCORFlatFileStorageQoSTierPathKey;
  */
 + (NSString *)archivePath;
 
+/** Returns the base directory under which all events will be stored.
+ *
+ * @return The base directory under which all events will be stored.
+ */
++ (NSString *)baseEventStoragePath;
+
+/** Returns the base directory under which all library data will be stored.
+ *
+ * @return The base directory under which all library data will be stored.
+ */
++ (NSString *)libraryDataStoragePath;
+
 /** Returns storage paths for the given event, though the paths may not exist.
  *
  * @note The keys of this dictionary are declared in this header.

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageEventSelector.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageEventSelector.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <GoogleDataTransport/GDTCORTargets.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** This class enables the finding of events by matching events with the properties of this class.
+ */
+@interface GDTCORStorageEventSelector : NSObject
+
+/** The target to find events for. Required. */
+@property(readonly, nonatomic) GDTCORTarget selectedTarget;
+
+/** Finds a specific event. */
+@property(nullable, readonly, nonatomic) NSNumber *selectedEventID;
+
+/** Finds all events of a mappingID. */
+@property(nullable, readonly, nonatomic) NSString *selectedMappingID;
+
+/** Finds all events matching the qosTiers in this list. */
+@property(nullable, readonly, nonatomic) NSArray<NSNumber *> *selectedQosTiers;
+
+/** Instantiates an event selector.
+ *
+ * @param target The selected target.
+ * @param eventID Optional param to find an event matching this eventID.
+ * @param mappingID Optional param to find events matching this mappingID.
+ * @param qosTiers Optional param to find events matching the given QoS tiers.
+ * @return An immutable event selector instance.
+ */
+- (instancetype)initWithTarget:(GDTCORTarget)target
+                eventIDEqualTo:(nullable NSNumber *)eventID
+              mappingIDEqualTo:(nullable NSString *)mappingID
+                      qosTiers:(nullable NSArray<NSNumber *> *)qosTiers;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleDataTransport/GDTCORTests/Common/Categories/GDTCORFlatFileStorage+Testing.m
+++ b/GoogleDataTransport/GDTCORTests/Common/Categories/GDTCORFlatFileStorage+Testing.m
@@ -25,9 +25,11 @@
   dispatch_sync(self.storageQueue, ^{
     [self.targetToEventSet removeAllObjects];
     [self.storedEvents removeAllObjects];
-    NSError *error;
-    [[NSFileManager defaultManager] removeItemAtPath:[GDTCORFlatFileStorage archivePath]
-                                               error:&error];
+    [[NSFileManager defaultManager] removeItemAtPath:[GDTCORFlatFileStorage archivePath] error:nil];
+    [[NSFileManager defaultManager] removeItemAtPath:[GDTCORFlatFileStorage baseEventStoragePath]
+                                               error:nil];
+    [[NSFileManager defaultManager] removeItemAtPath:[GDTCORFlatFileStorage libraryDataStoragePath]
+                                               error:nil];
   });
 }
 

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
@@ -534,11 +534,11 @@ static NSInteger target = kGDTCORTargetCCT;
   XCTAssertTrue([eventPaths[gGDTCORFlatFileStorageEventDataPathKey] hasSuffix:dataPathSuffix]);
 
   NSString *qosTierSuffix =
-      [NSString stringWithFormat:@"%@/%@/%@", @(event.qosTier), event.mappingID, event.eventID];
+      [NSString stringWithFormat:@"%ld/%@/%@", (long)event.target, @(event.qosTier), event.eventID];
   XCTAssertTrue([eventPaths[gGDTCORFlatFileStorageQoSTierPathKey] hasSuffix:qosTierSuffix]);
 
   NSString *mappingIDSuffix =
-      [NSString stringWithFormat:@"%@/%@/%@", event.mappingID, @(event.qosTier), event.eventID];
+      [NSString stringWithFormat:@"%ld/%@/%@", (long)event.target, event.mappingID, event.eventID];
   XCTAssertTrue([eventPaths[gGDTCORFlatFileStorageMappingIDPathKey] hasSuffix:mappingIDSuffix]);
 }
 
@@ -572,51 +572,7 @@ static NSInteger target = kGDTCORTargetCCT;
 
 /** Tests that searchPathsWithEventSelector: returns the appropriate event search paths. */
 - (void)testSearchPathsWithEventSelector {
-  GDTCORStorageEventSelector *eventSelector =
-      [[GDTCORStorageEventSelector alloc] initWithTarget:kGDTCORTargetTest
-                                          eventIDEqualTo:nil
-                                        mappingIDEqualTo:nil
-                                                qosTiers:nil];
-
-  NSArray<NSString *> *paths = [GDTCORFlatFileStorage searchPathsWithEventSelector:eventSelector];
-  XCTAssertEqual(paths.count, 1);
-  XCTAssertTrue([paths[0] hasSuffix:@(kGDTCORTargetTest).stringValue]);
-
-  eventSelector = [[GDTCORStorageEventSelector alloc] initWithTarget:kGDTCORTargetTest
-                                                      eventIDEqualTo:nil
-                                                    mappingIDEqualTo:nil
-                                                            qosTiers:@[ @(GDTCOREventQoSFast) ]];
-
-  paths = [GDTCORFlatFileStorage searchPathsWithEventSelector:eventSelector];
-  XCTAssertEqual(paths.count, 1);
-  NSString *expectedSuffix = [@(kGDTCORTargetTest).stringValue
-      stringByAppendingPathComponent:@(GDTCOREventQoSFast).stringValue];
-  XCTAssertTrue([paths[0] hasSuffix:expectedSuffix]);
-
-  eventSelector = [[GDTCORStorageEventSelector alloc]
-        initWithTarget:kGDTCORTargetTest
-        eventIDEqualTo:nil
-      mappingIDEqualTo:NSStringFromSelector(_cmd)
-              qosTiers:@[ @(GDTCOREventQoSFast), @(GDTCOREventQoSDaily) ]];
-
-  paths = [GDTCORFlatFileStorage searchPathsWithEventSelector:eventSelector];
-  XCTAssertEqual(paths.count, 2);
-  BOOL qosFastPathFound = NO;
-  BOOL qosDailyPathFound = NO;
-  for (NSString *path in paths) {
-    if ([path hasSuffix:[NSString stringWithFormat:@"%@/%@/%@", @(kGDTCORTargetTest),
-                                                   @(GDTCOREventQoSFast),
-                                                   NSStringFromSelector(_cmd)]]) {
-      qosFastPathFound = YES;
-    }
-    if ([path hasSuffix:[NSString stringWithFormat:@"%@/%@/%@", @(kGDTCORTargetTest),
-                                                   @(GDTCOREventQoSDaily),
-                                                   NSStringFromSelector(_cmd)]]) {
-      qosDailyPathFound = YES;
-    }
-  }
-  XCTAssertTrue(qosFastPathFound);
-  XCTAssertTrue(qosDailyPathFound);
+  // TODO(mikehaney24): Implement when events are actually being stored.
 }
 
 /** Tests migration from v1 of the storage format to v2. */


### PR DESCRIPTION
#no-changelog because more changes are incoming.

Essentially, this change is to allow the storing of events to the filesystem in 3 ways:
- A direct write of a GDTCOREvent to the root data path, using the eventID as the filename. This will allow fast finding of events by target.
- A symbolic link to the direct write that allows fast finding of events via the mappingID.
- A symbolic link to the direct write that allow fast finding of events via the qosTier.