### PR TITLE
Expand the storage protocol and provide an event iterator

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -408,8 +408,7 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
     NSString *libraryDataPath = [GDTCORFlatFileStorage libraryDataStoragePath];
     NSDirectoryEnumerator *enumerator =
         [[NSFileManager defaultManager] enumeratorAtPath:eventDataPath];
-    NSString *nextFile;
-    while ((nextFile = [enumerator nextObject])) {
+    while ([enumerator nextObject]) {
       NSFileAttributeType fileType = enumerator.fileAttributes[NSFileType];
       if ([fileType isEqual:NSFileTypeDirectory] == NO &&
           [fileType isEqual:NSFileTypeSymbolicLink] == NO) {
@@ -418,8 +417,7 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
       }
     }
     enumerator = [[NSFileManager defaultManager] enumeratorAtPath:libraryDataPath];
-    nextFile = nil;
-    while ((nextFile = [enumerator nextObject])) {
+    while ([enumerator nextObject]) {
       NSFileAttributeType fileType = enumerator.fileAttributes[NSFileType];
       if ([fileType isEqual:NSFileTypeDirectory] == NO &&
           [fileType isEqual:NSFileTypeSymbolicLink] == NO) {

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -361,8 +361,7 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
   NSFileManager *fm = [NSFileManager defaultManager];
   NSDirectoryEnumerator *enumerator = [fm enumeratorAtPath:searchPath];
   while ([enumerator nextObject]) {
-    if ([enumerator.fileAttributes[NSFileType] isEqual:NSFileTypeDirectory] == NO &&
-        [enumerator.fileAttributes[NSFileType] isEqual:NSFileTypeSymbolicLink] == NO) {
+    if ([enumerator.fileAttributes[NSFileType] isEqual:NSFileTypeRegular]) {
       return YES;
     }
   }
@@ -382,8 +381,7 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
       NSString *nextFile;
       while ((nextFile = [enumerator nextObject])) {
         NSFileAttributeType fileType = enumerator.fileAttributes[NSFileType];
-        if ([fileType isEqual:NSFileTypeDirectory] == NO &&
-            [fileType isEqual:NSFileTypeSymbolicLink] == NO) {
+        if ([fileType isEqual:NSFileTypeRegular]) {
           [filePaths addObject:nextFile];
         }
       }
@@ -397,7 +395,7 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
 
 - (void)purgeEventsFromBefore:(GDTCORClock *)beforeSnapshot
                    onComplete:(void (^)(NSError *_Nullable error))onComplete {
-  // TODO(mikehaney24): Figure out how we're going to deal with an NS
+  // TODO(mikehaney24): Figure out how we're going to deal with this.
 }
 
 - (void)storageSizeWithCallback:(void (^)(uint64_t storageSize))onComplete {
@@ -409,8 +407,7 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
         [[NSFileManager defaultManager] enumeratorAtPath:eventDataPath];
     while ([enumerator nextObject]) {
       NSFileAttributeType fileType = enumerator.fileAttributes[NSFileType];
-      if ([fileType isEqual:NSFileTypeDirectory] == NO &&
-          [fileType isEqual:NSFileTypeSymbolicLink] == NO) {
+      if ([fileType isEqual:NSFileTypeRegular]) {
         NSNumber *fileSize = enumerator.fileAttributes[NSFileSize];
         totalBytes += fileSize.unsignedLongLongValue;
       }
@@ -418,8 +415,7 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
     enumerator = [[NSFileManager defaultManager] enumeratorAtPath:libraryDataPath];
     while ([enumerator nextObject]) {
       NSFileAttributeType fileType = enumerator.fileAttributes[NSFileType];
-      if ([fileType isEqual:NSFileTypeDirectory] == NO &&
-          [fileType isEqual:NSFileTypeSymbolicLink] == NO) {
+      if ([fileType isEqual:NSFileTypeRegular]) {
         NSNumber *fileSize = enumerator.fileAttributes[NSFileSize];
         totalBytes += fileSize.unsignedLongLongValue;
       }

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -386,7 +386,7 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
         }
       }
       iterator = [[GDTCORFlatFileStorageIterator alloc] initWithTarget:eventSelector.selectedTarget
-                                                                 queue:_storageQueue];
+                                                                 queue:self->_storageQueue];
       iterator.eventFiles = filePaths;
     }
   });

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -325,7 +325,7 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
 
 - (void)storeLibraryData:(NSData *)data
                   forKey:(nonnull NSString *)key
-              onComplete:(nonnull void (^)(NSError *_Nullable error))onComplete {
+              onComplete:(nullable void (^)(NSError *_Nullable error))onComplete {
   if (!data || data.length <= 0) {
     if (onComplete) {
       onComplete([NSError errorWithDomain:NSInternalInconsistencyException code:-1 userInfo:nil]);

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -360,8 +360,7 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
   NSString *searchPath = [GDTCORFlatFileStorage pathForTarget:target qosTier:nil mappingID:nil];
   NSFileManager *fm = [NSFileManager defaultManager];
   NSDirectoryEnumerator *enumerator = [fm enumeratorAtPath:searchPath];
-  NSString *nextFile;
-  while ((nextFile = [enumerator nextObject])) {
+  while ([enumerator nextObject]) {
     if ([enumerator.fileAttributes[NSFileType] isEqual:NSFileTypeDirectory] == NO &&
         [enumerator.fileAttributes[NSFileType] isEqual:NSFileTypeSymbolicLink] == NO) {
       return YES;

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorageIterator.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorageIterator.m
@@ -48,14 +48,14 @@
   }
   __block GDTCOREvent *nextEvent;
   dispatch_sync(queue, ^{
-    NSData *data = [NSData dataWithContentsOfFile:_eventFiles[_currentIndex]];
+    NSData *data = [NSData dataWithContentsOfFile:self->_eventFiles[_currentIndex]];
     if (data) {
       NSError *error;
       nextEvent = (GDTCOREvent *)GDTCORDecodeArchive([GDTCOREvent class], nil, data, &error);
       if (error || nextEvent == nil) {
         GDTCORLogDebug(@"Unarchiving an event failed: %@", error);
         nextEvent = nil;
-        _currentIndex = -1;
+        self->_currentIndex = -1;
         return;
       }
     }

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorageIterator.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorageIterator.m
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GDTCORLibrary/Private/GDTCORFlatFileStorageIterator.h"
+
+#import <GoogleDataTransport/GDTCORConsoleLogger.h>
+#import <GoogleDataTransport/GDTCOREvent.h>
+
+@implementation GDTCORFlatFileStorageIterator {
+  /** The current eventFiles array index, incremented in -nextEvent. */
+  NSInteger _currentIndex;
+}
+
+- (instancetype)initWithTarget:(GDTCORTarget)target queue:(dispatch_queue_t)queue {
+  self = [super init];
+  if (self) {
+    _queue = queue;
+    _target = target;
+  }
+  return self;
+}
+
+- (nullable GDTCOREvent *)nextEvent {
+  if (_currentIndex == -1) {
+    return nil;
+  }
+  if (!_eventFiles) {
+    GDTCORLogDebug(@"%@", @"eventFiles property not set, so -nextEvent will be nil.");
+    return nil;
+  }
+  dispatch_queue_t queue = _queue;
+  if (!queue) {
+    GDTCORLogDebug(@"%@", @"iterator queue was nil, so -nextEvent will be nil.");
+    return nil;
+  }
+  __block GDTCOREvent *nextEvent;
+  dispatch_sync(queue, ^{
+    NSData *data = [NSData dataWithContentsOfFile:_eventFiles[_currentIndex]];
+    if (data) {
+      NSError *error;
+      nextEvent = (GDTCOREvent *)GDTCORDecodeArchive([GDTCOREvent class], nil, data, &error);
+      if (error || nextEvent == nil) {
+        GDTCORLogDebug(@"Unarchiving an event failed: %@", error);
+        nextEvent = nil;
+        _currentIndex = -1;
+        return;
+      }
+    }
+  });
+  return nextEvent;
+}
+
+@end

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorageIterator.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorageIterator.m
@@ -48,7 +48,7 @@
   }
   __block GDTCOREvent *nextEvent;
   dispatch_sync(queue, ^{
-    NSData *data = [NSData dataWithContentsOfFile:self->_eventFiles[_currentIndex]];
+    NSData *data = [NSData dataWithContentsOfFile:self->_eventFiles[self->_currentIndex]];
     if (data) {
       NSError *error;
       nextEvent = (GDTCOREvent *)GDTCORDecodeArchive([GDTCOREvent class], nil, data, &error);

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorageIterator.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorageIterator.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <GoogleDataTransport/GDTCORStorageProtocol.h>
+
+/** The flat file storage iterator. */
+@interface GDTCORFlatFileStorageIterator : NSObject <GDTCORStorageEventIterator>
+
+/** The queue on which the iterator will run. */
+@property(nonatomic, readonly) dispatch_queue_t queue;
+
+/** The target the iterator will work on. */
+@property(nonatomic, readonly) GDTCORTarget target;
+
+/** The list of event files to iterate over. This should be set before calling -nextEvent. */
+@property(nonatomic) NSArray<NSString *> *eventFiles;
+
+@end

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)storeLibraryData:(NSData *)data
                   forKey:(NSString *)key
-              onComplete:(void (^)(NSError *_Nullable error))onComplete;
+              onComplete:(nullable void (^)(NSError *_Nullable error))onComplete;
 
 /** Retrieves the stored data for the given key.
  *

--- a/GoogleDataTransport/GDTCORTests/Common/Categories/GDTCORFlatFileStorage+Testing.m
+++ b/GoogleDataTransport/GDTCORTests/Common/Categories/GDTCORFlatFileStorage+Testing.m
@@ -31,6 +31,12 @@
     [[NSFileManager defaultManager] removeItemAtPath:[GDTCORFlatFileStorage libraryDataStoragePath]
                                                error:nil];
   });
+  dispatch_semaphore_t sema = dispatch_semaphore_create(0);
+  [[GDTCORFlatFileStorage sharedInstance] storageSizeWithCallback:^(uint64_t storageSize) {
+    NSAssert(storageSize == 0, @"Storage should contain nothing after a reset");
+    dispatch_semaphore_signal(sema);
+  }];
+  dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
 }
 
 @end

--- a/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORStorageFake.m
+++ b/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORStorageFake.m
@@ -51,4 +51,20 @@
   }
 }
 
+- (BOOL)hasEventsForTarget:(GDTCORTarget)target {
+  return NO;
+}
+
+- (nullable id<GDTCORStorageEventIterator>)iteratorWithSelector:
+    (nonnull GDTCORStorageEventSelector *)eventSelector {
+  return nil;
+}
+
+- (void)purgeEventsFromBefore:(GDTCORClock *)beforeSnapshot
+                   onComplete:(void (^)(NSError *_Nullable error))onComplete {
+}
+
+- (void)storageSizeWithCallback:(void (^)(uint64_t storageSize))onComplete {
+}
+
 @end

--- a/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORStorageFake.m
+++ b/GoogleDataTransport/GDTCORTests/Common/Fakes/GDTCORStorageFake.m
@@ -38,7 +38,7 @@
 
 - (void)storeLibraryData:(NSData *)data
                   forKey:(nonnull NSString *)key
-              onComplete:(nonnull void (^)(NSError *_Nullable error))onComplete {
+              onComplete:(nullable void (^)(NSError *_Nullable error))onComplete {
   if (onComplete) {
     onComplete(nil);
   }

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
@@ -575,6 +575,53 @@ static NSInteger target = kGDTCORTargetCCT;
   // TODO(mikehaney24): Implement when events are actually being stored.
 }
 
+/** Tests hasEventsForTarget: returns YES when events are stored and NO otherwise. */
+- (void)testHasEventsForTarget {
+  XCTAssertFalse([[GDTCORFlatFileStorage sharedInstance] hasEventsForTarget:kGDTCORTargetTest]);
+
+  // TODO(mikehaney24): Store events and test for YES.
+}
+
+/** Tests -iteratorWithSelector produces a usable iterator. */
+- (void)testIteratorWithSelector {
+  GDTCORStorageEventSelector *eventSelector =
+      [[GDTCORStorageEventSelector alloc] initWithTarget:kGDTCORTargetTest
+                                          eventIDEqualTo:nil
+                                        mappingIDEqualTo:nil
+                                                qosTiers:nil];
+  id<GDTCORStorageEventIterator> iter =
+      [[GDTCORFlatFileStorage sharedInstance] iteratorWithSelector:eventSelector];
+  XCTAssertNil([iter nextEvent]);
+
+  // TODO(mikehaney24): Store events and test.
+}
+
+/** Tests -purgeEventsFromBefore:onComplete: removes prior to an arbitrary time. */
+- (void)testPurgeEvents {
+  // TODO(mikehaney24): Complete when purge events is implemented.
+}
+
+/** Tests that the size of the storage is returned accurately. */
+- (void)testStorageSizeWithCallback {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"storageSize complete"];
+  [[GDTCORFlatFileStorage sharedInstance] storageSizeWithCallback:^(uint64_t storageSize) {
+    XCTAssertEqual(storageSize, 0);
+    [expectation fulfill];
+  }];
+  [self waitForExpectations:@[ expectation ] timeout:10.0];
+
+  expectation = [self expectationWithDescription:@"storageSize complete"];
+  NSData *data = [@"this is a test" dataUsingEncoding:NSUTF8StringEncoding];
+  [[GDTCORFlatFileStorage sharedInstance] storeLibraryData:data forKey:@"testKey" onComplete:nil];
+  [[GDTCORFlatFileStorage sharedInstance] storageSizeWithCallback:^(uint64_t storageSize) {
+    XCTAssertEqual(storageSize, data.length);
+    [expectation fulfill];
+  }];
+  [self waitForExpectations:@[ expectation ] timeout:10.0];
+
+  // TODO(mikehaney24): Complete this test when events are actually being stored.
+}
+
 /** Tests migration from v1 of the storage format to v2. */
 - (void)testMigrationFromOldVersion {
   static NSString *base64EncodedArchive =


### PR DESCRIPTION
#no-changelog because more changes are incoming.

This change expands the storage protocol API so that prioritizers don't need to exist. An uploader can complete the following by itself:

- Find the storage instance for the target it cares about
- Query storage if there are events
- Get an event iterator and process the events to construct a request
- Store uploader state using the library data API