### PR TITLE
Better Swift API completion usability

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,5 +1,5 @@
-# Unreleased.
-- [changed] Removed typedefs from public API method signatures to improve Swift API usage from Xcode. (#5710)
+# v4.5.1
+- [changed] Removed typedefs from public API method signatures to improve Swift API usage from Xcode. (#5748)
 
 # v4.5.0
 - [changed] Updated `fetchAndActivateWithCompletionHandler:` implementation to activate asynchronously. (#5617)

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased.
+- [changed] Removed typedefs from public API method signatures to improve Swift API usage from Xcode. (#5710)
+
 # v4.5.0
 - [changed] Updated `fetchAndActivateWithCompletionHandler:` implementation to activate asynchronously. (#5617)
 - [fixed] Remove undefined class via removing unused proto generated source files. (#4334)

--- a/FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h
+++ b/FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h
@@ -185,7 +185,7 @@ NS_SWIFT_NAME(RemoteConfig)
 - (nonnull instancetype)init __attribute__((unavailable("Use +remoteConfig instead.")));
 
 /// Ensures initialization is complete and clients can begin querying for Remote Config values.
-/// @param completionHandler Initialization complete callback.
+/// @param completionHandler Initialization complete callback with error parameter.
 - (void)ensureInitializedWithCompletionHandler:
     (void (^_Nonnull)(NSError *_Nullable initializationError))completionHandler;
 #pragma mark - Fetch
@@ -198,7 +198,7 @@ NS_SWIFT_NAME(RemoteConfig)
 /// To stop the periodic sync, developers need to call `[FIRInstallations deleteWithCompletion:]`
 /// and avoid calling this method again.
 ///
-/// @param completionHandler Fetch operation callback.
+/// @param completionHandler Fetch operation callback with status and error parameters.
 - (void)fetchWithCompletionHandler:(void (^_Nullable)(FIRRemoteConfigFetchStatus status,
                                                       NSError *_Nullable error))completionHandler;
 
@@ -214,7 +214,7 @@ NS_SWIFT_NAME(RemoteConfig)
 /// @param expirationDuration  Override the (default or optionally set minimumFetchInterval property
 /// in FIRRemoteConfigSettings) minimumFetchInterval for only the current request, in seconds.
 /// Setting a value of 0 seconds will force a fetch to the backend.
-/// @param completionHandler   Fetch operation callback.
+/// @param completionHandler   Fetch operation callback with status and error parameters.
 - (void)fetchWithExpirationDuration:(NSTimeInterval)expirationDuration
                   completionHandler:(void (^_Nullable)(FIRRemoteConfigFetchStatus status,
                                                        NSError *_Nullable error))completionHandler;
@@ -228,7 +228,7 @@ NS_SWIFT_NAME(RemoteConfig)
 /// To stop the periodic sync, developers need to call `[FIRInstallations deleteWithCompletion:]`
 /// and avoid calling this method again.
 ///
-/// @param completionHandler Fetch operation callback.
+/// @param completionHandler Fetch operation callback with status and error parameters.
 - (void)fetchAndActivateWithCompletionHandler:
     (void (^_Nullable)(FIRRemoteConfigFetchAndActivateStatus status,
                        NSError *_Nullable error))completionHandler;

--- a/FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h
+++ b/FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h
@@ -187,7 +187,7 @@ NS_SWIFT_NAME(RemoteConfig)
 /// Ensures initialization is complete and clients can begin querying for Remote Config values.
 /// @param completionHandler Initialization complete callback.
 - (void)ensureInitializedWithCompletionHandler:
-    (nonnull FIRRemoteConfigInitializationCompletion)completionHandler;
+    (void (^_Nonnull)(NSError *_Nullable initializationError))completionHandler;
 #pragma mark - Fetch
 /// Fetches Remote Config data with a callback. Call activateFetched to make fetched data available
 /// to your app.
@@ -199,7 +199,8 @@ NS_SWIFT_NAME(RemoteConfig)
 /// and avoid calling this method again.
 ///
 /// @param completionHandler Fetch operation callback.
-- (void)fetchWithCompletionHandler:(nullable FIRRemoteConfigFetchCompletion)completionHandler;
+- (void)fetchWithCompletionHandler:(void (^_Nullable)(FIRRemoteConfigFetchStatus status,
+                                                      NSError *_Nullable error))completionHandler;
 
 /// Fetches Remote Config data and sets a duration that specifies how long config data lasts.
 /// Call activateFetched to make fetched data available to your app.
@@ -215,7 +216,8 @@ NS_SWIFT_NAME(RemoteConfig)
 /// Setting a value of 0 seconds will force a fetch to the backend.
 /// @param completionHandler   Fetch operation callback.
 - (void)fetchWithExpirationDuration:(NSTimeInterval)expirationDuration
-                  completionHandler:(nullable FIRRemoteConfigFetchCompletion)completionHandler;
+                  completionHandler:(void (^_Nullable)(FIRRemoteConfigFetchStatus status,
+                                                       NSError *_Nullable error))completionHandler;
 
 /// Fetches Remote Config data and if successful, activates fetched data. Optional completion
 /// handler callback is invoked after the attempted activation of data, if the fetch call succeeded.
@@ -228,7 +230,8 @@ NS_SWIFT_NAME(RemoteConfig)
 ///
 /// @param completionHandler Fetch operation callback.
 - (void)fetchAndActivateWithCompletionHandler:
-    (nullable FIRRemoteConfigFetchAndActivateCompletion)completionHandler;
+    (void (^_Nullable)(FIRRemoteConfigFetchAndActivateStatus status,
+                       NSError *_Nullable error))completionHandler;
 
 #pragma mark - Apply
 


### PR DESCRIPTION
This PR splits #5710 between the Swift usability and the typedef deprecation since the typedef deprecation will require an API review process.

Stop using typedefs for completion blocks in public APIs so that Xcode is more usable in Swift:

<img width="721" alt="Screen Shot 2020-06-01 at 7 26 29 AM" src="https://user-images.githubusercontent.com/73870/83418999-40495580-a3d9-11ea-894b-8a8ab93e48a4.png">

There is no change/impact on Objective C usability.