### PR TITLE
Add assertion when in app message is in invalid state

### DIFF
--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
@@ -567,7 +567,7 @@
     case FIRIAMRenderAsCardView:
       // Image data should never nil for a valid card message.
       if (imageData == nil) {
-        NSAssert(imageData != nil, @"Image data should never nil for a valid card message.");
+        NSAssert(NO, @"Image data should never nil for a valid card message.");
         return nil;
       }
       return [self cardDisplayMessageWithMessageDefinition:definition

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
@@ -567,6 +567,7 @@
     case FIRIAMRenderAsCardView:
       // Image data should never nil for a valid card message.
       if (imageData == nil) {
+        NSAssert(imageData != nil, @"Image data should never nil for a valid card message.");
         return nil;
       }
       return [self cardDisplayMessageWithMessageDefinition:definition


### PR DESCRIPTION
# Context

In InAppMessaging, card messages require images.
However, in some situation, This SDK fails to parse API response from Firebase then imageURL set to `nil` even displaying type is Card.

If you upload images with non-ascii file names from Firebase console, This SDK can't parse image URLs. (`NSURL` fails to initialize from strings with non-ascii characters).
https://github.com/firebase/firebase-ios-sdk/blob/dbe900774974e36332decb75d1ba842e7faa2130/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m#L295

I hit this situation.  So I'd like to add an assertion on a development environment.

# Description

Added assertion when hit such a situation to notice the problems.