### PR TITLE
Lazy initialize auth state

### DIFF
--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -358,9 +358,15 @@ NSString *const kAuthCancelledErrorMessage = @"Tester cancelled sign-in";
   NSError *authRetrievalError;
   self.authState = [self.authPersistence retrieveAuthState:&authRetrievalError];
   // TODO (schnecle): replace NSLog statement with FIRLogger log statement
-  if (authRetrievalError) {
-    NSLog(@"Error retrieving tester auth token");
-    [self logUnderlyingKeychainError:authRetrievalError];
+  if (!self.authState) {
+    if (authRetrievalError) {
+      NSLog(@"Error retrieving tester auth token");
+      [self logUnderlyingKeychainError:authRetrievalError];
+    } else {
+      // If authState and error is nil, auth state is not persisted in the keychain.
+      NSLog(@"AuthState not persisted in the keychain");
+    }
+
     return false;
   }
 

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionAuthPersistence.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionAuthPersistence.m
@@ -80,20 +80,15 @@ static NSString *const kFIRAppDistributionAuthPersistenceErrorKeychainId =
   NSData *result = nil;
 
   if (!passwordData) {
-    NSString *description = NSLocalizedString(
-        @"Failed to retrieve auth state from keychain. Tester will have to sign in again.",
-        @"Error message for failure to retrieve auth state from keychain. ");
-    if (!keychainError) {
-      // If passwordData and keychain is nil, auth state is not persisted.
-      keychainError = [NSError
-          errorWithDomain:kFIRAppDistributionAuthPersistenceErrorDomain
-                     code:FIRAppDistributionErrorTokenRetrievalFailure
-                 userInfo:@{NSLocalizedDescriptionKey : @"Auth state not present in the keychain"}];
+    if (keychainError) {
+      NSString *description = NSLocalizedString(
+          @"Failed to retrieve auth state from keychain. Tester will have to sign in again.",
+          @"Error message for failure to retrieve auth state from keychain. ");
+      [self handleAuthStateError:error
+                     description:description
+                            code:FIRAppDistributionErrorTokenRetrievalFailure
+                 underlyingError:keychainError];
     }
-    [self handleAuthStateError:error
-                   description:description
-                          code:FIRAppDistributionErrorTokenRetrievalFailure
-               underlyingError:keychainError];
     return nil;
   }
 

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionAuthPersistence.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionAuthPersistence.m
@@ -83,6 +83,13 @@ static NSString *const kFIRAppDistributionAuthPersistenceErrorKeychainId =
     NSString *description = NSLocalizedString(
         @"Failed to retrieve auth state from keychain. Tester will have to sign in again.",
         @"Error message for failure to retrieve auth state from keychain. ");
+    if (!keychainError) {
+      // If passwordData and keychain is nil, auth state is not persisted.
+      keychainError = [NSError
+          errorWithDomain:kFIRAppDistributionAuthPersistenceErrorDomain
+                     code:FIRAppDistributionErrorTokenRetrievalFailure
+                 userInfo:@{NSLocalizedDescriptionKey : @"Auth state not present in the keychain"}];
+    }
     [self handleAuthStateError:error
                    description:description
                           code:FIRAppDistributionErrorTokenRetrievalFailure


### PR DESCRIPTION
1. Added a Getter for isTesterSignedIn and lazy initialized the auth state in the get method
2. Also added auth state lazy initialization logic in signInTester
3. Also added a log message for when we don't find the auth state in the keychain
