### PR TITLE
Add NSLogv to help debug end user issues

### DIFF
--- a/FirebaseAppDistribution/Sources/FIRFADLogger.m
+++ b/FirebaseAppDistribution/Sources/FIRFADLogger.m
@@ -23,6 +23,7 @@ NSString *const AppDistributionMessageCode = @"I-FAD000000";
 void FIRFADDebugLog(NSString *message, ...) {
   va_list args_ptr;
   va_start(args_ptr, message);
+  NSLogv(message, args_ptr);
   FIRLogBasic(FIRLoggerLevelDebug, kFIRLoggerAppDistribution, AppDistributionMessageCode, message,
               args_ptr);
   va_end(args_ptr);
@@ -31,6 +32,7 @@ void FIRFADDebugLog(NSString *message, ...) {
 void FIRFADInfoLog(NSString *message, ...) {
   va_list args_ptr;
   va_start(args_ptr, message);
+  NSLogv(message, args_ptr);
   FIRLogBasic(FIRLoggerLevelInfo, kFIRLoggerAppDistribution, AppDistributionMessageCode, message,
               args_ptr);
   va_end(args_ptr);
@@ -39,6 +41,7 @@ void FIRFADInfoLog(NSString *message, ...) {
 void FIRFADWarningLog(NSString *message, ...) {
   va_list args_ptr;
   va_start(args_ptr, message);
+  NSLogv(message, args_ptr);
   FIRLogBasic(FIRLoggerLevelWarning, kFIRLoggerAppDistribution, AppDistributionMessageCode, message,
               args_ptr);
   va_end(args_ptr);
@@ -47,6 +50,7 @@ void FIRFADWarningLog(NSString *message, ...) {
 void FIRFADErrorLog(NSString *message, ...) {
   va_list args_ptr;
   va_start(args_ptr, message);
+  NSLogv(message, args_ptr);
   FIRLogBasic(FIRLoggerLevelError, kFIRLoggerAppDistribution, AppDistributionMessageCode, message,
               args_ptr);
   va_end(args_ptr);


### PR DESCRIPTION
Add NSLog to go along with FIRLogBasic so we are logging even running outside of the simulator to help debug customer issues during the EAP