### PR TITLE
Allow list() at root

### DIFF
--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [fixed] Fixed a crash when listAll() was called at the root location. (#5772)
 
 # 3.6.1
 - [fixed] Fix a rare case where a StorageTask would call its completion callbacks more than

--- a/FirebaseStorage/Sources/FIRStorageListResult.m
+++ b/FirebaseStorage/Sources/FIRStorageListResult.m
@@ -33,16 +33,12 @@
     }
 
     FIRStorageReference *prefixReference = [rootReference child:pathWithoutTrailingSlash];
-    NSAssert([prefixReference.fullPath hasPrefix:reference.fullPath],
-             @"Expected %@ to be a child element of %@", reference, prefixReference);
     [prefixes addObject:prefixReference];
   }
 
   NSArray<NSDictionary<NSString *, NSString *> *> *itemEntries = dictionary[kFIRStorageListItems];
   for (NSDictionary<NSString *, NSString *> *itemEntry in itemEntries) {
     FIRStorageReference *itemReference = [rootReference child:itemEntry[kFIRStorageListItemName]];
-    NSAssert([itemReference.fullPath hasPrefix:reference.fullPath],
-             @"Expected %@ to be a child element of %@", reference, itemReference);
     [items addObject:itemReference];
   }
 

--- a/FirebaseStorage/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/FirebaseStorage/Tests/Integration/FIRStorageIntegrationTests.m
@@ -31,6 +31,9 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 60;
   rules_version = '2';
   service firebase.storage {
     match /b/{bucket}/o {
+      match /{allPaths=**} {
+        allow read: if request.auth != null;
+      }
       match /ios {
         match /public/{allPaths=**} {
           allow write: if request.auth != null;
@@ -768,7 +771,7 @@ NSString *const kTestPassword = KPASSWORD;
 }
 
 - (void)testListAllFiles {
-  XCTestExpectation *expectation = [self expectationWithDescription:@"testPagedListFiles"];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"testListAllFiles"];
 
   FIRStorageReference *ref = [self.storage referenceWithPath:@"ios/public/list"];
 
@@ -781,6 +784,22 @@ NSString *const kTestPassword = KPASSWORD;
     XCTAssertEqualObjects(listResult.prefixes, @[ [ref child:@"prefix"] ]);
     XCTAssertNil(listResult.pageToken);
 
+    [expectation fulfill];
+  }];
+
+  [self waitForExpectations];
+}
+
+- (void)testListFilesAtRoot {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"testListFilesAtRoot"];
+
+  FIRStorageReference *ref = [self.storage referenceWithPath:@""];
+
+  [ref listAllWithCompletion:^(FIRStorageListResult *_Nullable listResult,
+                               NSError *_Nullable error) {
+    XCTAssertNotNil(listResult);
+    XCTAssertNil(error);
+    XCTAssertNil(listResult.pageToken);
     [expectation fulfill];
   }];
 

--- a/FirebaseStorage/Tests/Integration/FIRStorageIntegrationTests.m
+++ b/FirebaseStorage/Tests/Integration/FIRStorageIntegrationTests.m
@@ -31,7 +31,7 @@ NSTimeInterval kFIRStorageIntegrationTestTimeout = 60;
   rules_version = '2';
   service firebase.storage {
     match /b/{bucket}/o {
-      match /{allPaths=**} {
+      match /{directChild=*} {
         allow read: if request.auth != null;
       }
       match /ios {


### PR DESCRIPTION
Storage crashes with an assert because "hasPrefix" returns false if the prefix is empty. I decided to just remove the assert since it is not part of Android: https://github.com/firebase/firebase-android-sdk/blob/29a1573ac1c6b7765aa6ed95ceafc95ec3b670f0/firebase-storage/src/main/java/com/google/firebase/storage/ListResult.java#L43