### PR TITLE
Refactor event saving and searching

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -359,7 +359,7 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
                                               mappingIDs:nil
                                                 qosTiers:nil];
   id<GDTCORStorageEventIterator> iter = [self iteratorWithSelector:eventSelector];
-  return [iter nextEvent];
+  return [iter nextEvent] != nil;
 }
 
 - (nullable id<GDTCORStorageEventIterator>)iteratorWithSelector:

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -125,9 +125,9 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
     GDTCORLogDebug(@"There was an error reading the contents of the target path: %@", error);
     return paths;
   }
-  BOOL checkingIDs = eventIDs != nil && eventIDs.count > 0;
-  BOOL checkingQosTiers = qosTiers != nil && qosTiers.count > 0;
-  BOOL checkingMappingIDs = mappingIDs != nil && mappingIDs.count > 0;
+  BOOL checkingIDs = eventIDs.count > 0;
+  BOOL checkingQosTiers = qosTiers.count > 0;
+  BOOL checkingMappingIDs = mappingIDs.count > 0;
   BOOL checkingAnything = checkingIDs == NO && checkingQosTiers == NO && checkingMappingIDs == NO;
   for (NSString *path in dirPaths) {
     if (checkingAnything) {
@@ -138,14 +138,16 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
     NSArray<NSString *> *components = [filename componentsSeparatedByString:@"."];
     if (components.count != 3) {
       GDTCORLogDebug(@"There was an error reading the filename components: %@", components);
-      return paths;
+      [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
+      continue;
     }
     NSNumber *eventID = @(components[0].integerValue);
     NSNumber *qosTier = @(components[1].integerValue);
     NSString *mappingID = components[2];
     if (eventID == nil || qosTier == nil) {
       GDTCORLogDebug(@"There was an error parsing the filename components: %@", components);
-      return paths;
+      [[NSFileManager defaultManager] removeItemAtPath:path error:nil];
+      continue;
     }
     NSNumber *eventIDMatch = checkingIDs ? @([eventIDs containsObject:eventID]) : nil;
     NSNumber *qosTierMatch = checkingQosTiers ? @([qosTiers containsObject:qosTier]) : nil;

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -107,8 +107,8 @@ NSString *const gGDTCORFlatFileStorageQoSTierPathKey = @"QoSTierPath";
                     qosTier:(NSNumber *)qosTier
                   mappingID:(NSNumber *)mappingID {
   return
-      [NSString stringWithFormat:@"%@/%ld/%@.%ld.%@", [GDTCORFlatFileStorage baseEventStoragePath],
-                                 (long)target, eventID, (long)qosTier, mappingID];
+      [NSString stringWithFormat:@"%@/%ld/%@.%@.%@", [GDTCORFlatFileStorage baseEventStoragePath],
+                                 (long)target, eventID, qosTier, mappingID];
 }
 
 + (NSSet<NSString *> *)pathsForTarget:(GDTCORTarget)target

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORStorageEventSelector.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORStorageEventSelector.m
@@ -19,14 +19,14 @@
 @implementation GDTCORStorageEventSelector
 
 - (instancetype)initWithTarget:(GDTCORTarget)target
-                eventIDEqualTo:(nullable NSNumber *)eventID
-              mappingIDEqualTo:(nullable NSString *)mappingID
-                      qosTiers:(nullable NSArray<NSNumber *> *)qosTiers {
+                      eventIDs:(nullable NSSet<NSNumber *> *)eventIDs
+                    mappingIDs:(nullable NSSet<NSString *> *)mappingIDs
+                      qosTiers:(nullable NSSet<NSNumber *> *)qosTiers {
   self = [super init];
   if (self) {
     _selectedTarget = target;
-    _selectedEventID = eventID;
-    _selectedMappingID = mappingID;
+    _selectedEventIDs = eventIDs;
+    _selectedMappingIDs = mappingIDs;
     _selectedQosTiers = qosTiers;
   }
   return self;

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage.h
@@ -25,21 +25,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/** The key of the event data path if a path dictionary is returned. */
-FOUNDATION_EXPORT NSString *const gGDTCORFlatFileStorageEventDataPathKey;
-
-/** The key of the event's mapping ID path if a path dictionary is returned. */
-FOUNDATION_EXPORT NSString *const gGDTCORFlatFileStorageMappingIDPathKey;
-
-/** The key of the event's qos tier path if a path dictionary is returned. */
-FOUNDATION_EXPORT NSString *const gGDTCORFlatFileStorageQoSTierPathKey;
-
 /** Manages the storage of events. This class is thread-safe.
  *
  * Event files will be stored as follows:
- *   <app cache>/gdt_event_data/<target>/<eventID> as a normal file write
- *   <app cache>/gdt_event_data/<target>/<qosTier>/<eventID> as a symbolic link
- *   <app cache>/gdt_event_data/<target>/<mappingID>/<eventID> as a symbolic link
+ *   <app cache>/gdt_event_data/<target>/<eventID>.<qosTier>.<mappingID>
  *
  * Library data will be stored as follows:
  *   <app cache>/gdt_library_data/<key of library data>
@@ -85,24 +74,29 @@ FOUNDATION_EXPORT NSString *const gGDTCORFlatFileStorageQoSTierPathKey;
  */
 + (NSString *)libraryDataStoragePath;
 
-/** Returns storage paths for the given event, though the paths may not exist.
- *
- * @note The keys of this dictionary are declared in this header.
- * @param event The event to map to storage paths.
- */
-+ (NSDictionary<NSString *, NSString *> *)pathsForEvent:(GDTCOREvent *)event;
-
-/** Returns a storage path to events for the given target, qosTier, and mapping ID. The path may not
- * exist.
+/** Returns a constructed storage path based on the given values. This path may not exist.
  *
  * @param target The target, which is necessary to be given a path.
- * @param qosTier An optional parameter to get a more specific path.
- * @param mappingID An optional parameter to get a more specific path.
+ * @param eventID The eventID.
+ * @param qosTier The qosTier.
+ * @param mappingID The mappingID.
  * @return The path representing the combination of the given parameters.
  */
 + (NSString *)pathForTarget:(GDTCORTarget)target
-                    qosTier:(nullable NSNumber *)qosTier
-                  mappingID:(nullable NSString *)mappingID;
+                    eventID:(NSNumber *)eventID
+                    qosTier:(NSNumber *)qosTier
+                  mappingID:(NSNumber *)mappingID;
+
+/** Returns extant paths that match all of the given parameters.
+ *
+ * @param eventIDs The list of eventIDs to look for, or nil for any.
+ * @param qosTiers The list of qosTiers to look for, or nil for any.
+ * @param mappingIDs The list of mappingIDs to look for, or nil for any.
+ */
++ (NSSet<NSString *> *)pathsForTarget:(GDTCORTarget)target
+                             eventIDs:(nullable NSSet<NSNumber *> *)eventIDs
+                             qosTiers:(nullable NSSet<NSNumber *> *)qosTiers
+                           mappingIDs:(nullable NSSet<NSString *> *)mappingIDs;
 
 /** Returns a list of paths that will contain events for the given event selector.
  *

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage.h
@@ -85,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)pathForTarget:(GDTCORTarget)target
                     eventID:(NSNumber *)eventID
                     qosTier:(NSNumber *)qosTier
-                  mappingID:(NSNumber *)mappingID;
+                  mappingID:(NSString *)mappingID;
 
 /** Returns extant paths that match all of the given parameters.
  *

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageEventSelector.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageEventSelector.h
@@ -28,26 +28,26 @@ NS_ASSUME_NONNULL_BEGIN
 @property(readonly, nonatomic) GDTCORTarget selectedTarget;
 
 /** Finds a specific event. */
-@property(nullable, readonly, nonatomic) NSNumber *selectedEventID;
+@property(nullable, readonly, nonatomic) NSSet<NSNumber *> *selectedEventIDs;
 
 /** Finds all events of a mappingID. */
-@property(nullable, readonly, nonatomic) NSString *selectedMappingID;
+@property(nullable, readonly, nonatomic) NSSet<NSString *> *selectedMappingIDs;
 
 /** Finds all events matching the qosTiers in this list. */
-@property(nullable, readonly, nonatomic) NSArray<NSNumber *> *selectedQosTiers;
+@property(nullable, readonly, nonatomic) NSSet<NSNumber *> *selectedQosTiers;
 
 /** Instantiates an event selector.
  *
  * @param target The selected target.
- * @param eventID Optional param to find an event matching this eventID.
- * @param mappingID Optional param to find events matching this mappingID.
+ * @param eventIDs Optional param to find an event matching this eventID.
+ * @param mappingIDs Optional param to find events matching this mappingID.
  * @param qosTiers Optional param to find events matching the given QoS tiers.
  * @return An immutable event selector instance.
  */
 - (instancetype)initWithTarget:(GDTCORTarget)target
-                eventIDEqualTo:(nullable NSNumber *)eventID
-              mappingIDEqualTo:(nullable NSString *)mappingID
-                      qosTiers:(nullable NSArray<NSNumber *> *)qosTiers;
+                      eventIDs:(nullable NSSet<NSNumber *> *)eventIDs
+                    mappingIDs:(nullable NSSet<NSString *> *)mappingIDs
+                      qosTiers:(nullable NSSet<NSNumber *> *)qosTiers;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
@@ -525,49 +525,23 @@ static NSInteger target = kGDTCORTargetCCT;
   [self waitForExpectations:@[ expectation ] timeout:10.0];
 }
 
-/** Tests that -pathsForEvent returns 3 file paths of the appropriate structure. */
-- (void)testPathsForEvent {
-  GDTCOREvent *event = [[GDTCOREvent alloc] initWithMappingID:@"test" target:kGDTCORTargetTest];
-  NSDictionary<NSString *, NSString *> *eventPaths = [GDTCORFlatFileStorage pathsForEvent:event];
-
-  NSString *dataPathSuffix = event.eventID.stringValue;
-  XCTAssertTrue([eventPaths[gGDTCORFlatFileStorageEventDataPathKey] hasSuffix:dataPathSuffix]);
-
-  NSString *qosTierSuffix =
-      [NSString stringWithFormat:@"%ld/%@/%@", (long)event.target, @(event.qosTier), event.eventID];
-  XCTAssertTrue([eventPaths[gGDTCORFlatFileStorageQoSTierPathKey] hasSuffix:qosTierSuffix]);
-
-  NSString *mappingIDSuffix =
-      [NSString stringWithFormat:@"%ld/%@/%@", (long)event.target, event.mappingID, event.eventID];
-  XCTAssertTrue([eventPaths[gGDTCORFlatFileStorageMappingIDPathKey] hasSuffix:mappingIDSuffix]);
-}
-
 /** Tests that -pathForTarget:qosTier:mappingID: returns the correctly structured path. */
-- (void)testPathForTargetQoSTier {
-  // Target only.
-  NSString *expectedSuffix = [NSString stringWithFormat:@"%ld", (long)kGDTCORTargetTest];
-  NSString *path = [GDTCORFlatFileStorage pathForTarget:kGDTCORTargetTest
-                                                qosTier:nil
-                                              mappingID:nil];
-  XCTAssertTrue([path hasSuffix:expectedSuffix]);
+- (void)testPathsForTargetEventIDQoSTierMappingID {
+  // TODO(mikehaney24): Complete below tests once events are being saved to disk.
 
-  // qosTier is given.
-  path = [GDTCORFlatFileStorage pathForTarget:kGDTCORTargetTest
-                                      qosTier:@(GDTCOREventQoSFast)
-                                    mappingID:nil];
-  XCTAssertTrue([path hasSuffix:@(GDTCOREventQoSFast).stringValue]);
+  // Store some predictably generated events across > 1 target.
 
-  // mappingID is given.
-  path = [GDTCORFlatFileStorage pathForTarget:kGDTCORTargetTest qosTier:nil mappingID:@"test"];
-  XCTAssertTrue([path hasSuffix:@"test"]);
+  // Search for all events (by target).
 
-  // Both qosTier and mappingID are given.
-  path = [GDTCORFlatFileStorage pathForTarget:kGDTCORTargetTest
-                                      qosTier:@(GDTCOREventQoSFast)
-                                    mappingID:@"test"];
-  expectedSuffix = [NSString
-      stringWithFormat:@"%ld/%ld/%@", (long)kGDTCORTargetTest, (long)GDTCOREventQoSFast, @"test"];
-  XCTAssertTrue([path hasSuffix:expectedSuffix]);
+  // Search for events by eventID.
+
+  // Search for events by qosTier.
+
+  // Search for events by mappingID.
+
+  // Search for events by eventID and qosTier.
+
+  // Search for events by qosTier and mappingID.
 }
 
 /** Tests that searchPathsWithEventSelector: returns the appropriate event search paths. */
@@ -586,8 +560,8 @@ static NSInteger target = kGDTCORTargetCCT;
 - (void)testIteratorWithSelector {
   GDTCORStorageEventSelector *eventSelector =
       [[GDTCORStorageEventSelector alloc] initWithTarget:kGDTCORTargetTest
-                                          eventIDEqualTo:nil
-                                        mappingIDEqualTo:nil
+                                                eventIDs:nil
+                                              mappingIDs:nil
                                                 qosTiers:nil];
   id<GDTCORStorageEventIterator> iter =
       [[GDTCORFlatFileStorage sharedInstance] iteratorWithSelector:eventSelector];


### PR DESCRIPTION
No more symlinks to try and speed searching. Just get a directory's contents and check the filename, which will contain metadata about the event.

#no-changelog because it's parter of a larger change
