### PR TITLE
Build fix

### DIFF
--- a/FirebaseABTesting/Tests/Unit/FIRExperimentControllerTest.m
+++ b/FirebaseABTesting/Tests/Unit/FIRExperimentControllerTest.m
@@ -535,7 +535,7 @@ extern NSArray *ABTExperimentsToClearFromPayloads(
 
   NSArray *experiments = [_mockCUPController experimentsWithOrigin:gABTTestOrigin];
 
-  FIRAConditionalUserProperty *userPropertyForExperiment = [experiments firstObject];
+  NSDictionary *userPropertyForExperiment = [experiments firstObject];
 
   // Verify that the triggerEventName is cleared, making this experiment active.
   XCTAssertNil([userPropertyForExperiment valueForKeyPath:@"triggerEventName"]);


### PR DESCRIPTION
Fix internal test build failure:

```
third_party/firebase/ios/Releases/FirebaseABTesting/Tests/Unit/FIRExperimentControllerTest.m:541:17: error: receiver type 'FIRAConditionalUserProperty' for instance message is a forward declaration
  XCTAssertNil([userPropertyForExperiment valueForKeyPath:@"triggerEventName"]);
                ^~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode_11.3.1.app/Contents/Developer//Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestAssertions.h:51:34: note: expanded from macro 'XCTAssertNil'
    _XCTPrimitiveAssertNil(self, expression, @#expression, __VA_ARGS__)
                                 ^~~~~~~~~~
/Applications/Xcode_11.3.1.app/Contents/Developer//Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCTestAssertionsImpl.h:107:31: note: expanded from macro '_XCTPrimitiveAssertNil'
        id expressionValue = (expression); \
                              ^~~~~~~~~~
./third_party/firebase/ios/Releases/FirebaseABTesting/Tests/Unit/ABTFakeFIRAConditionalUserPropertyController.h:23:8: note: forward declaration of class here
@class FIRAConditionalUserProperty;
```