### PR TITLE
Remove Crashlytics OTHER_LD_FLAGS for Swift Package Manager

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- [changed] Removed an unnecessary linker rule for embedding the Info.plist (#5804)
+
 # v4.1.1
 
 - [fixed] Fixed a crash that could occur if certain plist fields necessary to create Crashlytics records were missing at runtime. Also added some diagnostic logging to make the issue cause more explicit (#5565).

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -63,7 +63,6 @@ Pod::Spec.new do |s|
       # For nanopb:
       'PB_FIELD_32BIT=1 PB_NO_PACKED_STRUCTS=1 PB_ENABLE_MALLOC=1',
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
-    'OTHER_LD_FLAGS' => '$(inherited) -sectcreate __TEXT __info_plist'
   }
 
   s.osx.pod_target_xcconfig = {
@@ -74,7 +73,6 @@ Pod::Spec.new do |s|
       # For nanopb:
       'PB_FIELD_32BIT=1 PB_NO_PACKED_STRUCTS=1 PB_ENABLE_MALLOC=1',
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
-    'OTHER_LD_FLAGS' => '$(inherited) -sectcreate __TEXT __info_plist'
   }
 
   s.tvos.pod_target_xcconfig = {
@@ -85,7 +83,6 @@ Pod::Spec.new do |s|
       # For nanopb:
       'PB_FIELD_32BIT=1 PB_NO_PACKED_STRUCTS=1 PB_ENABLE_MALLOC=1',
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"',
-    'OTHER_LD_FLAGS' => '$(inherited) -sectcreate __TEXT __info_plist'
   }
 
   s.test_spec 'unit' do |unit_tests|


### PR DESCRIPTION
This linker flag creates a section in the binary containing the Info.plist.

 - Swift Package Manager can't set `OTHER_LD_FLAGS` as of now
 - This may be unnecessary

Took a look at the old codebase - I believe it was a mistake to add this to the cocoapod in the first place. The use case for this rule is creating a section in the binary when no Info.plist is present, but there will always be an Info.plist in the bundle for iOS / macOS / tvOS apps.

This rule is used for upload-symbols so that it can read its own version. Since upload-symbols is binary only, there's no Info.plist, so this linker rule is necessary.

We must have just accidentally applied the linker rule to the SDK too.