### PR TITLE
Update the device model identified by GDTCCTLibrary to be more detailed and in parity with Clearcut.

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -158,7 +158,7 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
 }
 
 NSString *_Nonnull GDTCORDeviceModel() {
-  __block NSString *deviceModel = [UIDevice currentDevice].model;
+  __block NSString *deviceModel = @"";
   
   #if TARGET_OS_IOS || TARGET_OS_TV
     static dispatch_once_t onceToken;
@@ -171,6 +171,8 @@ NSString *_Nonnull GDTCORDeviceModel() {
         sysctlbyname(keyToExtract, machine, &size, NULL, 0);
         deviceModel = [NSString stringWithCString:machine encoding:NSUTF8StringEncoding];
         free(machine);
+      } else {
+        deviceModel = [UIDevice currentDevice].model;
       }
     });
   #endif

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -159,7 +159,7 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
 
 NSString *_Nonnull GDTCORDeviceModel() {
   __block NSString *deviceModel = @"Unknown";
-  
+
 #if TARGET_OS_IOS || TARGET_OS_TV
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -158,7 +158,7 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
 }
 
 NSString *_Nonnull GDTCORDeviceModel() {
-  __block NSString *deviceModel = @"";
+  __block NSString *deviceModel = @"Unknown";
   
 #if TARGET_OS_IOS || TARGET_OS_TV
   static dispatch_once_t onceToken;

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -16,6 +16,8 @@
 
 #import "GDTCORLibrary/Public/GDTCORPlatform.h"
 
+#import <sys/sysctl.h>
+
 #import <GoogleDataTransport/GDTCORAssert.h>
 #import <GoogleDataTransport/GDTCORConsoleLogger.h>
 #import <GoogleDataTransport/GDTCORReachability.h>
@@ -153,6 +155,27 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
 #else
   return GDTCORNetworkMobileSubtypeUNKNOWN;
 #endif
+}
+
+NSString *_Nonnull GDTCORDeviceModel() {
+  __block NSString *deviceModel = [UIDevice currentDevice].model;
+  
+  #if TARGET_OS_IOS || TARGET_OS_TV
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+      size_t size;
+      char *keyToExtract = "hw.machine";
+      sysctlbyname(keyToExtract, NULL, &size, NULL, 0);
+      if (size > 0) {
+        char *machine = calloc(1, size);
+        sysctlbyname(keyToExtract, machine, &size, NULL, 0);
+        deviceModel = [NSString stringWithCString:machine encoding:NSUTF8StringEncoding];
+        free(machine);
+      }
+    });
+  #endif
+
+  return deviceModel;
 }
 
 NSData *_Nullable GDTCOREncodeArchive(id<NSSecureCoding> obj,

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -160,22 +160,22 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
 NSString *_Nonnull GDTCORDeviceModel() {
   __block NSString *deviceModel = @"";
   
-  #if TARGET_OS_IOS || TARGET_OS_TV
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-      size_t size;
-      char *keyToExtract = "hw.machine";
-      sysctlbyname(keyToExtract, NULL, &size, NULL, 0);
-      if (size > 0) {
-        char *machine = calloc(1, size);
-        sysctlbyname(keyToExtract, machine, &size, NULL, 0);
-        deviceModel = [NSString stringWithCString:machine encoding:NSUTF8StringEncoding];
-        free(machine);
-      } else {
-        deviceModel = [UIDevice currentDevice].model;
-      }
-    });
-  #endif
+#if TARGET_OS_IOS || TARGET_OS_TV
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    size_t size;
+    char *keyToExtract = "hw.machine";
+    sysctlbyname(keyToExtract, NULL, &size, NULL, 0);
+    if (size > 0) {
+      char *machine = calloc(1, size);
+      sysctlbyname(keyToExtract, machine, &size, NULL, 0);
+      deviceModel = [NSString stringWithCString:machine encoding:NSUTF8StringEncoding];
+      free(machine);
+    } else {
+      deviceModel = [UIDevice currentDevice].model;
+    }
+  });
+#endif
 
   return deviceModel;
 }

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
@@ -126,6 +126,12 @@ GDTCORNetworkType GDTCORNetworkTypeMessage(void);
  */
 GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage(void);
 
+/** Identifies the model of the device on which the library is currently working on.
+ *
+ * @return A NSString representing the device model.
+ */
+NSString *_Nonnull GDTCORDeviceModel(void);
+
 /** Writes the given object to the given fileURL and populates the given error if it fails.
  *
  * @param obj The object to encode.

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
@@ -127,15 +127,9 @@ GDTCORNetworkType GDTCORNetworkTypeMessage(void);
 GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage(void);
 
 /** Identifies the model of the device on which the library is currently working on.
-<<<<<<< HEAD
  *
  * @return A NSString representing the device model.
  */
-=======
-*
-* @return A NSString representing the device model.
-*/
->>>>>>> 28d7e54c6... Address comments to centralize the device model extraction.
 NSString *_Nonnull GDTCORDeviceModel(void);
 
 /** Writes the given object to the given fileURL and populates the given error if it fails.

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h
@@ -127,9 +127,15 @@ GDTCORNetworkType GDTCORNetworkTypeMessage(void);
 GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage(void);
 
 /** Identifies the model of the device on which the library is currently working on.
+<<<<<<< HEAD
  *
  * @return A NSString representing the device model.
  */
+=======
+*
+* @return A NSString representing the device model.
+*/
+>>>>>>> 28d7e54c6... Address comments to centralize the device model extraction.
 NSString *_Nonnull GDTCORDeviceModel(void);
 
 /** Writes the given object to the given fileURL and populates the given error if it fails.

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
@@ -18,6 +18,7 @@
 
 #if TARGET_OS_IOS || TARGET_OS_TV
 #import <UIKit/UIKit.h>
+#import <sys/sysctl.h>
 #elif TARGET_OS_OSX
 #import <AppKit/AppKit.h>
 #endif  // TARGET_OS_IOS || TARGET_OS_TV
@@ -48,6 +49,37 @@ pb_bytes_array_t *GDTCCTEncodeData(NSData *data) {
   }
   return pbBytesArray;
 }
+
+#pragma mark - General purpose device info collectors
+
+#if TARGET_OS_IOS || TARGET_OS_TV
+
+static NSString *CCTSystemInfo(const char *name) {
+  size_t size;
+  sysctlbyname(name, NULL, &size, NULL, 0);
+  if (size <= 0) {
+    return @"";
+  }
+
+  char *machine = malloc(size);
+  sysctlbyname(name, machine, &size, NULL, 0);
+  NSString *value = [NSString stringWithCString:machine encoding:NSUTF8StringEncoding];
+  free(machine);
+
+  return value;
+}
+
+static NSString *CCTDeviceModel() {
+  static NSString *deviceModel;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    deviceModel = CCTSystemInfo("hw.machine");
+  });
+
+  return deviceModel;
+}
+
+#endif
 
 #pragma mark - CCT object constructors
 
@@ -198,7 +230,7 @@ gdt_cct_IosClientInfo GDTCCTConstructiOSClientInfo() {
   if (countryCode) {
     iOSClientInfo.country = GDTCCTEncodeString([locale objectForKey:NSLocaleCountryCode]);
   }
-  iOSClientInfo.model = GDTCCTEncodeString(device.model);
+  iOSClientInfo.model = GDTCCTEncodeString(CCTDeviceModel());
   NSString *languageCode = bundle.preferredLocalizations.firstObject;
   iOSClientInfo.language_code =
       languageCode ? GDTCCTEncodeString(languageCode) : GDTCCTEncodeString(@"en");

--- a/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
+++ b/GoogleDataTransportCCTSupport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
@@ -18,7 +18,6 @@
 
 #if TARGET_OS_IOS || TARGET_OS_TV
 #import <UIKit/UIKit.h>
-#import <sys/sysctl.h>
 #elif TARGET_OS_OSX
 #import <AppKit/AppKit.h>
 #endif  // TARGET_OS_IOS || TARGET_OS_TV
@@ -49,37 +48,6 @@ pb_bytes_array_t *GDTCCTEncodeData(NSData *data) {
   }
   return pbBytesArray;
 }
-
-#pragma mark - General purpose device info collectors
-
-#if TARGET_OS_IOS || TARGET_OS_TV
-
-static NSString *CCTSystemInfo(const char *name) {
-  size_t size;
-  sysctlbyname(name, NULL, &size, NULL, 0);
-  if (size <= 0) {
-    return @"";
-  }
-
-  char *machine = malloc(size);
-  sysctlbyname(name, machine, &size, NULL, 0);
-  NSString *value = [NSString stringWithCString:machine encoding:NSUTF8StringEncoding];
-  free(machine);
-
-  return value;
-}
-
-static NSString *CCTDeviceModel() {
-  static NSString *deviceModel;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    deviceModel = CCTSystemInfo("hw.machine");
-  });
-
-  return deviceModel;
-}
-
-#endif
 
 #pragma mark - CCT object constructors
 
@@ -230,7 +198,7 @@ gdt_cct_IosClientInfo GDTCCTConstructiOSClientInfo() {
   if (countryCode) {
     iOSClientInfo.country = GDTCCTEncodeString([locale objectForKey:NSLocaleCountryCode]);
   }
-  iOSClientInfo.model = GDTCCTEncodeString(CCTDeviceModel());
+  iOSClientInfo.model = GDTCCTEncodeString(GDTCORDeviceModel());
   NSString *languageCode = bundle.preferredLocalizations.firstObject;
   iOSClientInfo.language_code =
       languageCode ? GDTCCTEncodeString(languageCode) : GDTCCTEncodeString(@"en");


### PR DESCRIPTION
Current GDT implementation returns "iPhone". With this change, the device model identified would be iPhoneA,B (Eg. iPhone 8,1).

Hey there! So you want to contribute to a Firebase SDK?
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here.
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help
    us make Firebase APIs better, please propose your change in a feature request so that we
    can discuss it together.
