### PR TITLE
Add scripts to generate non firebase sdks for zip testing.

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -81,8 +81,9 @@ jobs:
     - name: Pull zip from GCS
       run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
     - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit FBSDKCoreKit GoogleSignIn AppAuth GTMAppAuth GTMSessionFetcher" scripts/setup_quickstart_framework.sh \
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit FBSDKCoreKit" scripts/setup_quickstart_framework.sh \
                                                "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
+                                               "${HOME}"/ios_frameworks/Firebase/GoogleSignIn/* \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
     - name: Install Secret GoogleService-Info.plist

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Pull zip from GCS
       run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
     - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit FBSDKCoreKit GoogleSignIn" scripts/setup_quickstart_framework.sh \
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit FBSDKCoreKit GoogleSignIn AppAuth GTMAppAuth GTMSessionFetcher" scripts/setup_quickstart_framework.sh \
                                                "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -82,6 +82,7 @@ jobs:
       run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
     - name: Setup quickstart
       run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit GoogleSignIn" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
     - name: Install Secret GoogleService-Info.plist

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -75,7 +75,7 @@ jobs:
       SDK: "Authentication"
     runs-on: macOS-latest
     # Make sure tests run after the zip workflow finishes.
-    if: github.event_name == 'schedule'
+    # if: github.event_name == 'schedule'
     steps:
     - uses: actions/checkout@v2
     - name: Pull zip from GCS

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Pull zip from GCS
       run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
     - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit GoogleSignIn" scripts/setup_quickstart_framework.sh \
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit FBSDKCoreKit GoogleSignIn" scripts/setup_quickstart_framework.sh \
                                                "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -67,6 +67,40 @@ jobs:
       # Only build the unit tests on Catalyst
       run: scripts/test_catalyst.sh FirebaseAuth build FirebaseAuth-Unit-unit
 
+  quickstart_framework:
+    env:
+      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
+      FRAMEWORK_ZIP: "Firebase-actions-dir.zip"
+      SDK: "Authentication"
+    runs-on: macOS-latest
+    # Make sure tests run after the zip workflow finishes.
+    if: github.event_name == 'schedule'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Pull zip from GCS
+      run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
+    - name: Setup quickstart
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
+                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
+    - name: Install Secret GoogleService-Info.plist
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-auth.plist.gpg \
+        quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
+    - name: Install Secret FIREGSignInInfo.h
+      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
+        quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
+    - name: Test Quickstart
+      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
+    - name: Remove data before upload
+      if: ${{ failure() }}
+      run: scripts/remove_data.sh "${SDK}"
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: quickstart_artifacts
+        path: quickstart-ios/
+
   quickstart:
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -80,8 +80,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Pull zip from GCS
       run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
+    - name: Build Non Firebase SDKs
+      run: scripts/build_non_firebase_sdks.sh FBSDKLoginKit GoogleSignIn
     - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
+      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit GoogleSignIn" scripts/setup_quickstart_framework.sh \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
     - name: Install Secret GoogleService-Info.plist

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -67,42 +67,6 @@ jobs:
       # Only build the unit tests on Catalyst
       run: scripts/test_catalyst.sh FirebaseAuth build FirebaseAuth-Unit-unit
 
-  quickstart_framework:
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_ZIP: "Firebase-actions-dir.zip"
-      SDK: "Authentication"
-    runs-on: macOS-latest
-    # Make sure tests run after the zip workflow finishes.
-    # if: github.event_name == 'schedule'
-    steps:
-    - uses: actions/checkout@v2
-    - name: Pull zip from GCS
-      run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit FBSDKCoreKit" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-                                               "${HOME}"/ios_frameworks/Firebase/GoogleSignIn/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-auth.plist.gpg \
-        quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
-    - name: Install Secret FIREGSignInInfo.h
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
-        quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh "${SDK}"
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts
-        path: quickstart-ios/
-
   quickstart:
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -80,8 +80,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Pull zip from GCS
       run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
-    - name: Build Non Firebase SDKs
-      run: scripts/build_non_firebase_sdks.sh FBSDKLoginKit GoogleSignIn
     - name: Setup quickstart
       run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit GoogleSignIn" scripts/setup_quickstart_framework.sh \
                                                "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \

--- a/scripts/build_non_firebase_sdks.sh
+++ b/scripts/build_non_firebase_sdks.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+cd "${REPO}"/ZipBuilder
+ZIP_POD_JSON="non_firebase_sdk.json"
+echo "${REPO}"
+rm -f "${ZIP_POD_JSON}"
+IFS=' ,' read -a NON_FIREBASE_SDKS <<< "${NON_FIREBASE_SDKS}"
+
+num_sdk="${#NON_FIREBASE_SDKS[@]}"
+echo "[" >> "${ZIP_POD_JSON}"
+for sdk in "${NON_FIREBASE_SDKS[@]}"
+do
+				echo "{\"name\":\"${sdk}\"}" >>  "${ZIP_POD_JSON}"
+				if [ "$num_sdk" -ne 1 ]; then
+								echo ",">>  "${ZIP_POD_JSON}"
+				fi
+				num_sdk=$((num_sdk-1))
+done
+echo "]" >>  "${ZIP_POD_JSON}"
+mkdir -p "${REPO}"/sdk_zip
+swift run ReleasePackager -keepBuildArtifacts true -updatePodRepo true -templateDir "${REPO}"/ZipBuilder/Template -zipPods "${ZIP_POD_JSON}" -outputDir "${REPO}"/sdk_zip -buildDependencies false 
+
+unzip "${REPO}"/sdk_zip/Frameworks.zip -d "${HOME}"/ios_frameworks/Firebase/
+
+mv "${HOME}"/ios_frameworks/Firebase/staging "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/
+
+

--- a/scripts/build_non_firebase_sdks.sh
+++ b/scripts/build_non_firebase_sdks.sh
@@ -18,7 +18,6 @@ set -ex
 
 cd "${REPO}"/ZipBuilder
 ZIP_POD_JSON="non_firebase_sdk.json"
-echo "${REPO}"
 rm -f "${ZIP_POD_JSON}"
 IFS=' ,' read -a NON_FIREBASE_SDKS <<< "${NON_FIREBASE_SDKS}"
 

--- a/scripts/build_non_firebase_sdks.sh
+++ b/scripts/build_non_firebase_sdks.sh
@@ -17,6 +17,8 @@
 set -ex
 
 cd "${REPO}"/ZipBuilder
+
+# This file will have non Firebase SDKs that will be built by ZipBuilder.
 ZIP_POD_JSON="non_firebase_sdk.json"
 rm -f "${ZIP_POD_JSON}"
 IFS=' ,' read -a NON_FIREBASE_SDKS <<< "${NON_FIREBASE_SDKS}"
@@ -25,11 +27,11 @@ num_sdk="${#NON_FIREBASE_SDKS[@]}"
 echo "[" >> "${ZIP_POD_JSON}"
 for sdk in "${NON_FIREBASE_SDKS[@]}"
 do
-				echo "{\"name\":\"${sdk}\"}" >>  "${ZIP_POD_JSON}"
-				if [ "$num_sdk" -ne 1 ]; then
-								echo ",">>  "${ZIP_POD_JSON}"
-				fi
-				num_sdk=$((num_sdk-1))
+  echo "{\"name\":\"${sdk}\"}" >>  "${ZIP_POD_JSON}"
+  if [ "$num_sdk" -ne 1 ]; then
+    echo ",">>  "${ZIP_POD_JSON}"
+  fi
+  num_sdk=$((num_sdk-1))
 done
 echo "]" >>  "${ZIP_POD_JSON}"
 mkdir -p "${REPO}"/sdk_zip
@@ -37,6 +39,7 @@ swift run ReleasePackager -keepBuildArtifacts true -updatePodRepo true -template
 
 unzip "${REPO}"/sdk_zip/Frameworks.zip -d "${HOME}"/ios_frameworks/Firebase/
 
+# Move Frameworks to Firebase dir, so be align with Firebase SDKs.
 mv "${HOME}"/ios_frameworks/Firebase/staging "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/
 
 

--- a/scripts/build_non_firebase_sdks.sh
+++ b/scripts/build_non_firebase_sdks.sh
@@ -34,7 +34,7 @@ do
 done
 echo "]" >>  "${ZIP_POD_JSON}"
 mkdir -p "${REPO}"/sdk_zip
-swift run ReleasePackager -keepBuildArtifacts true -updatePodRepo true -templateDir "${REPO}"/ZipBuilder/Template -zipPods "${ZIP_POD_JSON}" -outputDir "${REPO}"/sdk_zip -buildDependencies false 
+swift run ReleasePackager -keepBuildArtifacts true -updatePodRepo true -templateDir "${REPO}"/ZipBuilder/Template -zipPods "${ZIP_POD_JSON}" -outputDir "${REPO}"/sdk_zip -buildDependencies false
 
 unzip "${REPO}"/sdk_zip/Frameworks.zip -d "${HOME}"/ios_frameworks/Firebase/
 

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -28,7 +28,8 @@ mv "${HOME}"/ios_frameworks/Firebase/Firebase.h Firebase/
 mv "${HOME}"/ios_frameworks/Firebase/module.modulemap Firebase/
 for file in "$@"
 do
-  mv ${file} Firebase/
+  # Not override framework if a framework with the same name was moved early..
+  mv -n ${file} Firebase/
 done
 
 ../scripts/add_framework_script.rb  "${SAMPLE}" "${TARGET}" Firebase

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -29,6 +29,6 @@ do
 done
 
 if [[ ! -z "$NON_FIREBASE_SDKS" ]]; then
-  NON_FIREBASE_SDKS="${NON_FIREBASE_SDKS}" "${REPO}"/scripts/build_non_firebase_sdks.sh
+  REPO="$REPO" NON_FIREBASE_SDKS="${NON_FIREBASE_SDKS}" "${REPO}"/scripts/build_non_firebase_sdks.sh
 fi
 ../scripts/add_framework_script.rb  "${SAMPLE}" "${TARGET}" Firebase

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -14,6 +14,7 @@
 
 set -ex
 
+REPO=`pwd`
 git clone https://github.com/firebase/quickstart-ios.git
 cd quickstart-ios/"${SAMPLE}"
 chmod +x ../scripts/info_script.rb
@@ -26,4 +27,8 @@ for file in "$@"
 do
   mv ${file} Firebase/
 done
+
+if [[ ! -z "$NON_FIREBASE_SDKS" ]]; then
+  NON_FIREBASE_SDKS="${NON_FIREBASE_SDKS}" "${REPO}"/scripts/build_non_firebase_sdks.sh
+fi
 ../scripts/add_framework_script.rb  "${SAMPLE}" "${TARGET}" Firebase

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -21,6 +21,9 @@ chmod +x ../scripts/info_script.rb
 ruby ../scripts/info_script.rb "${SAMPLE}"
 
 mkdir -p Firebase/
+if [[ ! -z "$NON_FIREBASE_SDKS" ]]; then
+  REPO="${REPO}" NON_FIREBASE_SDKS="${NON_FIREBASE_SDKS}" "${REPO}"/scripts/build_non_firebase_sdks.sh
+fi
 mv "${HOME}"/ios_frameworks/Firebase/Firebase.h Firebase/
 mv "${HOME}"/ios_frameworks/Firebase/module.modulemap Firebase/
 for file in "$@"
@@ -28,7 +31,4 @@ do
   mv ${file} Firebase/
 done
 
-if [[ ! -z "$NON_FIREBASE_SDKS" ]]; then
-  REPO="${REPO}" NON_FIREBASE_SDKS="${NON_FIREBASE_SDKS}" "${REPO}"/scripts/build_non_firebase_sdks.sh
-fi
 ../scripts/add_framework_script.rb  "${SAMPLE}" "${TARGET}" Firebase

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -29,6 +29,6 @@ do
 done
 
 if [[ ! -z "$NON_FIREBASE_SDKS" ]]; then
-  REPO="$REPO" NON_FIREBASE_SDKS="${NON_FIREBASE_SDKS}" "${REPO}"/scripts/build_non_firebase_sdks.sh
+  NON_FIREBASE_SDKS="${NON_FIREBASE_SDKS}" "${REPO}"/scripts/build_non_firebase_sdks.sh
 fi
 ../scripts/add_framework_script.rb  "${SAMPLE}" "${TARGET}" Firebase

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -21,6 +21,7 @@ chmod +x ../scripts/info_script.rb
 ruby ../scripts/info_script.rb "${SAMPLE}"
 
 mkdir -p Firebase/
+# Create non Firebase Frameworks and move to Firebase/ dir.
 if [[ ! -z "$NON_FIREBASE_SDKS" ]]; then
   REPO="${REPO}" NON_FIREBASE_SDKS="${NON_FIREBASE_SDKS}" "${REPO}"/scripts/build_non_firebase_sdks.sh
 fi

--- a/scripts/setup_quickstart_framework.sh
+++ b/scripts/setup_quickstart_framework.sh
@@ -29,6 +29,6 @@ do
 done
 
 if [[ ! -z "$NON_FIREBASE_SDKS" ]]; then
-  NON_FIREBASE_SDKS="${NON_FIREBASE_SDKS}" "${REPO}"/scripts/build_non_firebase_sdks.sh
+  REPO="${REPO}" NON_FIREBASE_SDKS="${NON_FIREBASE_SDKS}" "${REPO}"/scripts/build_non_firebase_sdks.sh
 fi
 ../scripts/add_framework_script.rb  "${SAMPLE}" "${TARGET}" Firebase


### PR DESCRIPTION
This will can be used to generate a customized set of non Firebase frameworks to test some Quickstarts. E.g. Auth Quickstart reqeust FBSDKLogin frameworks.