### PR TITLE
Make the deviceModel to be a static variable to avoid overwrites.

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -158,7 +158,7 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
 }
 
 NSString *_Nonnull GDTCORDeviceModel() {
-  __block NSString *deviceModel = @"Unknown";
+  static NSString *deviceModel = @"Unknown";
 
 #if TARGET_OS_IOS || TARGET_OS_TV
   static dispatch_once_t onceToken;


### PR DESCRIPTION
Having the device model as a state variable gets the value of deviceModel to be set to "Unknown" everytime called, but the actual model extraction block will be called just once. So the first time, deviceModel will extract the right value and subsequent time will just return "Unknown".

This fix to make it a static variable to not lose the value extracted.

Hey there! So you want to contribute to a Firebase SDK?
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here.
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help
    us make Firebase APIs better, please propose your change in a feature request so that we
    can discuss it together.
