### PR TITLE
Manually created dynamic links should be subject to allowed/blocked check

### DIFF
--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.h
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.h
@@ -31,6 +31,7 @@ typedef void (^FIRPostInstallAttributionCompletionHandler)(
 
 /** A definition for a block used to return data and errors after an asynchronous task. */
 typedef void (^FIRNetworkRequestCompletionHandler)(NSData *_Nullable data,
+                                                   NSURLResponse *_Nullable response,
                                                    NSError *_Nullable error);
 
 // these enums must be in sync with google/firebase/dynamiclinks/v1/dynamic_links.proto

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.m
@@ -312,7 +312,7 @@ NSData *_Nullable FIRDataWithDictionary(NSDictionary *dictionary, NSError **_Nul
       stringWithFormat:@"%@/%@%@", baseURL, endpointPath, FIRDynamicLinkAPIKeyParameter(_APIKey)];
 
   FIRNetworkRequestCompletionHandler completeInvitationByDeviceCallback =
-      ^(NSData *data, NSError *error) {
+      ^(NSData *data, NSURLResponse *response, NSError *error) {
         if (error || !data) {
           dispatch_async(dispatch_get_main_queue(), ^{
             handler(nil, nil, error);

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.m
@@ -311,24 +311,24 @@ NSData *_Nullable FIRDataWithDictionary(NSDictionary *dictionary, NSError **_Nul
   NSString *requestURLString = [NSString
       stringWithFormat:@"%@/%@%@", baseURL, endpointPath, FIRDynamicLinkAPIKeyParameter(_APIKey)];
 
-  FIRNetworkRequestCompletionHandler completeInvitationByDeviceCallback = 
-    ^(NSData *data, NSError *error) {
-      if (error || !data) {
+  FIRNetworkRequestCompletionHandler completeInvitationByDeviceCallback =
+      ^(NSData *data, NSError *error) {
+        if (error || !data) {
+          dispatch_async(dispatch_get_main_queue(), ^{
+            handler(nil, nil, error);
+          });
+          return;
+        }
+
+        NSString *matchMessage = nil;
+        NSError *parsingError = nil;
+        NSDictionary *parsedDynamicLinkParameters =
+            parserBlock(requestURLString, data, &matchMessage, &parsingError);
+
         dispatch_async(dispatch_get_main_queue(), ^{
-          handler(nil, nil, error);
+          handler(parsedDynamicLinkParameters, matchMessage, parsingError);
         });
-        return;
-      }
-
-      NSString *matchMessage = nil;
-      NSError *parsingError = nil;
-      NSDictionary *parsedDynamicLinkParameters =
-          parserBlock(requestURLString, data, &matchMessage, &parsingError);
-
-      dispatch_async(dispatch_get_main_queue(), ^{
-        handler(parsedDynamicLinkParameters, matchMessage, parsingError);
-      });
-    };
+      };
 
   [self executeOnePlatformRequest:requestBody
                            forURL:requestURLString

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.m
@@ -112,17 +112,16 @@ NSData *_Nullable FIRDataWithDictionary(NSDictionary *dictionary, NSError **_Nul
   FIRNetworkRequestCompletionHandler resolveLinkCallback = ^(NSData *data, NSURLResponse *response,
                                                              NSError *error) {
     NSURL *resolvedURL = nil;
-    NSHTTPURLResponse *resp = nil;
 
     if (![response isKindOfClass:[NSHTTPURLResponse class]]) {
-      NSError *err = [NSError
+      NSError *responseTypeError = [NSError
           errorWithDomain:kGenericErrorDomain
                      code:0
                  userInfo:@{@"message" : @"Response should be of type NSHTTPURLResponse."}];
-      handler(resolvedURL, error ? error : err);
+      handler(resolvedURL, error ? error : responseTypeError);
     } else {
-      resp = (NSHTTPURLResponse *)response;
-      if (resp.statusCode >= 200 && resp.statusCode < 300) {
+      NSInteger statusCode = [(NSHTTPURLResponse *)response statusCode];
+      if (statusCode >= 200 && statusCode < 300) {
         if (!error && data) {
           NSDictionary *result = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
           if ([result isKindOfClass:[NSDictionary class]]) {
@@ -154,7 +153,7 @@ NSData *_Nullable FIRDataWithDictionary(NSDictionary *dictionary, NSError **_Nul
         if ([result isKindOfClass:[NSDictionary class]] && [result objectForKey:@"error"]) {
           id err = [result objectForKey:@"error"];
           NSError *customError = [NSError errorWithDomain:kGenericErrorDomain
-                                                     code:resp.statusCode
+                                                     code:statusCode
                                                  userInfo:err];
           handler(resolvedURL, customError);
         } else {

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.m
@@ -92,15 +92,6 @@ NSData *_Nullable FIRDataWithDictionary(NSDictionary *dictionary, NSError **_Nul
   return self;
 }
 
-+ (NSError *)genericErrorForUrl:(NSURL *)url {
-  return [NSError errorWithDomain:kGenericErrorDomain
-                             code:0
-                         userInfo:@{
-                           @"message" : [NSString
-                               stringWithFormat:@"Failed to resolve link: %@", url.absoluteString]
-                         }];
-}
-
 + (nullable NSError *)extractErrorForShortLink:(NSURL *)url
                                           data:(NSData *)data
                                       response:(NSURLResponse *)response
@@ -117,19 +108,19 @@ NSData *_Nullable FIRDataWithDictionary(NSDictionary *dictionary, NSError **_Nul
         [NSError errorWithDomain:kGenericErrorDomain
                             code:0
                         userInfo:@{@"message" : @"Response should be of type NSHTTPURLResponse."}];
-  } else if (statusCode < 200 || statusCode >= 300) {
-    if (data) {
-      NSDictionary *result = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
-      if ([result isKindOfClass:[NSDictionary class]] && [result objectForKey:@"error"]) {
-        id err = [result objectForKey:@"error"];
-        customError = [NSError errorWithDomain:kGenericErrorDomain
-                                                   code:statusCode
-                                               userInfo:err];
-      } else {
-        customError = [FIRDynamicLinkNetworking genericErrorForUrl:url];
-      }
+  } else if ((statusCode < 200 || statusCode >= 300) && data) {
+    NSDictionary *result = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+    if ([result isKindOfClass:[NSDictionary class]] && [result objectForKey:@"error"]) {
+      id err = [result objectForKey:@"error"];
+      customError = [NSError errorWithDomain:kGenericErrorDomain code:statusCode userInfo:err];
     } else {
-      customError = [FIRDynamicLinkNetworking genericErrorForUrl:url];
+      customError = [NSError
+          errorWithDomain:kGenericErrorDomain
+                     code:0
+                 userInfo:@{
+                   @"message" :
+                       [NSString stringWithFormat:@"Failed to resolve link: %@", url.absoluteString]
+                 }];
     }
   }
 

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks+FirstParty.h
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks+FirstParty.h
@@ -107,8 +107,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @abstract Method for compatibility with old interface of the GINDurableDeepLinkService
  */
 - (nullable FIRDynamicLink *)deepLinkFromUniversalLinkURL:(NSURL *)url
-    __attribute__((
-        unavailable("Use [FIRDynamicLinks dynamicLinkFromUniversalLinkURL:completion:] instead.")));
+    DEPRECATED_MSG_ATTRIBUTE("Use [FIRDynamicLinks dynamicLinkFromUniversalLinkURL:] instead.");
 
 /**
  * @method shouldHandleDeepLinkFromCustomSchemeURL:

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks+FirstParty.h
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks+FirstParty.h
@@ -107,7 +107,8 @@ NS_ASSUME_NONNULL_BEGIN
  * @abstract Method for compatibility with old interface of the GINDurableDeepLinkService
  */
 - (nullable FIRDynamicLink *)deepLinkFromUniversalLinkURL:(NSURL *)url
-    DEPRECATED_MSG_ATTRIBUTE("Use [FIRDynamicLinks dynamicLinkFromUniversalLinkURL:] instead.");
+    __attribute__((
+        unavailable("Use [FIRDynamicLinks dynamicLinkFromUniversalLinkURL:completion:] instead.")));
 
 /**
  * @method shouldHandleDeepLinkFromCustomSchemeURL:

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
@@ -446,7 +446,7 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
           [self.dynamicLinkNetworking
               resolveShortLink:url
                  FDLSDKVersion:FIRFirebaseVersion()
-                    completion:^(NSURL *_Nullable resolverURL, NSError *_Nullable resolverError){
+                    completion:^(NSURL *_Nullable resolverURL, NSError *_Nullable resolverError) {
                       completion(dynamicLink, resolverError);
                     }];
 #ifdef GIN_SCION_LOGGING

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
@@ -413,7 +413,7 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
           // TODO: Create dedicated logging function to prevent this.
           [self.dynamicLinkNetworking
               resolveShortLink:url
-                 FDLSDKVersion:kFIRDLVersion
+                 FDLSDKVersion:FIRFirebaseVersion()
                     completion:^(NSURL *_Nullable resolverURL, NSError *_Nullable resolverError){
                         // Nothing to do
                     }];

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
@@ -480,20 +480,11 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
                 }];
     return YES;
   } else {
-    if ([self respondsToSelector:@selector(dynamicLinkFromUniversalLinkURL:completion:)]) {
-      [self dynamicLinkFromUniversalLinkURL:universalLinkURL completion:completion];
-      BOOL canHandleUniversalLink =
-          [self canParseUniversalLinkURL:universalLinkURL] && universalLinkURL.query.length > 0 &&
-          FIRDLDictionaryFromQuery(universalLinkURL.query)[kFIRDLParameterLink];
-      return canHandleUniversalLink;
-    } else {
-      FIRDynamicLink *dynamicLink = [self dynamicLinkFromUniversalLinkURL:universalLinkURL];
-      if (dynamicLink) {
-        completion(dynamicLink, nil);
-        return YES;
-      }
-      return NO;
-    }
+    [self dynamicLinkFromUniversalLinkURL:universalLinkURL completion:completion];
+    BOOL canHandleUniversalLink =
+        [self canParseUniversalLinkURL:universalLinkURL] && universalLinkURL.query.length > 0 &&
+        FIRDLDictionaryFromQuery(universalLinkURL.query)[kFIRDLParameterLink];
+    return canHandleUniversalLink;
   }
 }
 

--- a/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FIRDynamicLinks.h
+++ b/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FIRDynamicLinks.h
@@ -68,6 +68,22 @@ NS_SWIFT_NAME(DynamicLinks)
     NS_SWIFT_NAME(dynamicLink(fromCustomSchemeURL:));
 
 /**
+ * @method dynamicLinkFromUniversalLinkURL:completion:
+ * @abstract Get a Dynamic Link from a universal link URL. This method parses universal link
+ *     URLs, for instance,
+ *     "https://example.page.link?link=https://www.google.com&ibi=com.google.app&ius=comgoogleapp".
+ *     It is suggested to call it inside your |UIApplicationDelegate|'s
+ *     |application:continueUserActivity:restorationHandler:| method.
+ * @param url Custom scheme URL.
+ * @param completion A block that handles the outcome of attempting to get a Dynamic Link from a
+ * universal link URL.
+ */
+- (void)dynamicLinkFromUniversalLinkURL:(NSURL *)url
+                             completion:(FIRDynamicLinkUniversalLinkHandler)completion
+    NS_SWIFT_NAME(dynamicLink(fromUniversalLink:completion:));
+
+/**
+ * @deprecated Use the `dynamicLinkFromUniversalLinkURL:completion:` instead.
  * @method dynamicLinkFromUniversalLinkURL:
  * @abstract Get a Dynamic Link from a universal link URL. This method parses universal link
  *     URLs, for instance,
@@ -78,12 +94,12 @@ NS_SWIFT_NAME(DynamicLinks)
  * @return Dynamic Link object if the URL is valid and has link parameter, otherwise nil.
  */
 - (nullable FIRDynamicLink *)dynamicLinkFromUniversalLinkURL:(NSURL *)url
-    NS_SWIFT_NAME(dynamicLink(fromUniversalLink:));
+    NS_SWIFT_NAME(dynamicLink(fromUniversalLink:))
+        __attribute__((unavailable("Use dynamicLinkFromUniversalLinkURL:completion: instead.")));
 
 /**
  * @method handleUniversalLink:completion:
- * @abstract Convenience method to handle a Universal Link whether it is long or short. A long link
- *     will call the handler immediately, but a short link may not.
+ * @abstract Convenience method to handle a Universal Link whether it is long or short.
  * @param url A Universal Link URL.
  * @param completion A block that handles the outcome of attempting to create a FIRDynamicLink.
  * @return YES if FIRDynamicLinks is handling the link, otherwise, NO.

--- a/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FIRDynamicLinks.h
+++ b/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FIRDynamicLinks.h
@@ -83,7 +83,6 @@ NS_SWIFT_NAME(DynamicLinks)
     NS_SWIFT_NAME(dynamicLink(fromUniversalLink:completion:));
 
 /**
- * @deprecated Use the `dynamicLinkFromUniversalLinkURL:completion:` instead.
  * @method dynamicLinkFromUniversalLinkURL:
  * @abstract Get a Dynamic Link from a universal link URL. This method parses universal link
  *     URLs, for instance,
@@ -95,7 +94,7 @@ NS_SWIFT_NAME(DynamicLinks)
  */
 - (nullable FIRDynamicLink *)dynamicLinkFromUniversalLinkURL:(NSURL *)url
     NS_SWIFT_NAME(dynamicLink(fromUniversalLink:))
-        __attribute__((unavailable("Use dynamicLinkFromUniversalLinkURL:completion: instead.")));
+        DEPRECATED_MSG_ATTRIBUTE("Use dynamicLinkFromUniversalLinkURL:completion: instead.");
 
 /**
  * @method handleUniversalLink:completion:

--- a/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinkNetworkingTests.m
+++ b/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinkNetworkingTests.m
@@ -73,7 +73,7 @@ static const NSTimeInterval kAsyncTestTimout = 0.5;
   void (^executeRequestBlock)(id, NSDictionary *, NSString *, FIRNetworkRequestCompletionHandler) =
       ^(id p1, NSDictionary *requestBody, NSString *requestURLString,
         FIRNetworkRequestCompletionHandler handler) {
-        handler(nil, nil);
+        handler(nil, nil, nil);
       };
 
   SEL executeRequestSelector = @selector(executeOnePlatformRequest:forURL:completionHandler:);

--- a/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
+++ b/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
@@ -496,13 +496,21 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   SwizzleDynamicLinkNetworkingWithMock();
 
-  FIRDynamicLink *dynamicLink = [self.service dynamicLinkFromUniversalLinkURL:durabledeepLinkURL];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completion called"];
+  [self.service
+      dynamicLinkFromUniversalLinkURL:durabledeepLinkURL
+                           completion:^(FIRDynamicLink *_Nullable dynamicLink,
+                                        NSError *_Nullable error) {
+                             XCTAssertNotNil(dynamicLink);
+                             NSString *deepLinkURLString = dynamicLink.url.absoluteString;
 
-  XCTAssertNotNil(dynamicLink);
-  NSString *deepLinkURLString = dynamicLink.url.absoluteString;
+                             XCTAssertEqualObjects(
+                                 @"abcd", deepLinkURLString,
+                                 @"ddl url parameter and deep link url should be the same");
+                             [expectation fulfill];
+                           }];
+  [self waitForExpectationsWithTimeout:kAsyncTestTimout handler:nil];
 
-  XCTAssertEqualObjects(@"abcd", deepLinkURLString,
-                        @"ddl url parameter and deep link url should be the same");
   UnswizzleDynamicLinkNetworking();
 }
 
@@ -513,12 +521,20 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   SwizzleDynamicLinkNetworkingWithMock();
 
-  FIRDynamicLink *dynamicLink = [self.service dynamicLinkFromUniversalLinkURL:durabledeepLinkURL];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completion called"];
+  [self.service
+      dynamicLinkFromUniversalLinkURL:durabledeepLinkURL
+                           completion:^(FIRDynamicLink *_Nullable dynamicLink,
+                                        NSError *_Nullable error) {
+                             NSString *deepLinkURLString = dynamicLink.url.absoluteString;
 
-  NSString *deepLinkURLString = dynamicLink.url.absoluteString;
+                             XCTAssertEqualObjects(
+                                 kDecodedComplicatedURLString, deepLinkURLString,
+                                 @"ddl url parameter and deep link url should be the same");
+                             [expectation fulfill];
+                           }];
+  [self waitForExpectationsWithTimeout:kAsyncTestTimout handler:nil];
 
-  XCTAssertEqualObjects(kDecodedComplicatedURLString, deepLinkURLString,
-                        @"ddl url parameter and deep link url should be the same");
   UnswizzleDynamicLinkNetworking();
 }
 
@@ -529,12 +545,20 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   SwizzleDynamicLinkNetworkingWithMock();
 
-  FIRDynamicLink *dynamicLink = [self.service dynamicLinkFromUniversalLinkURL:durabledeepLinkURL];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completion called"];
+  [self.service
+      dynamicLinkFromUniversalLinkURL:durabledeepLinkURL
+                           completion:^(FIRDynamicLink *_Nullable dynamicLink,
+                                        NSError *_Nullable error) {
+                             NSString *deepLinkURLString = dynamicLink.url.absoluteString;
 
-  NSString *deepLinkURLString = dynamicLink.url.absoluteString;
+                             XCTAssertEqualObjects(
+                                 kDecodedComplicatedURLString, deepLinkURLString,
+                                 @"ddl url parameter and deep link url should be the same");
+                             [expectation fulfill];
+                           }];
+  [self waitForExpectationsWithTimeout:kAsyncTestTimout handler:nil];
 
-  XCTAssertEqualObjects(kDecodedComplicatedURLString, deepLinkURLString,
-                        @"ddl url parameter and deep link url should be the same");
   UnswizzleDynamicLinkNetworking();
 }
 
@@ -551,10 +575,18 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   SwizzleDynamicLinkNetworkingWithMock();
 
-  FIRDynamicLink *dynamicLink = [self.service dynamicLinkFromUniversalLinkURL:url];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completion called"];
+  [self.service
+      dynamicLinkFromUniversalLinkURL:url
+                           completion:^(FIRDynamicLink *_Nullable dynamicLink,
+                                        NSError *_Nullable error) {
+                             XCTAssertEqual(dynamicLink.matchConfidence,
+                                            FIRDynamicLinkMatchConfidenceStrong);
+                             XCTAssertEqualObjects(dynamicLink.url.absoluteString, deepLinkString);
+                             [expectation fulfill];
+                           }];
+  [self waitForExpectationsWithTimeout:kAsyncTestTimout handler:nil];
 
-  XCTAssertEqual(dynamicLink.matchConfidence, FIRDynamicLinkMatchConfidenceStrong);
-  XCTAssertEqualObjects(dynamicLink.url.absoluteString, deepLinkString);
   UnswizzleDynamicLinkNetworking();
 }
 
@@ -572,9 +604,17 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   SwizzleDynamicLinkNetworkingWithMock();
 
-  FIRDynamicLink *dynamicLink = [self.service dynamicLinkFromUniversalLinkURL:url];
-  XCTAssertEqual(dynamicLink.matchConfidence, FIRDynamicLinkMatchConfidenceStrong);
-  XCTAssertEqualObjects(dynamicLink.url.absoluteString, parsedDeepLinkString);
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completion called"];
+  [self.service dynamicLinkFromUniversalLinkURL:url
+                                     completion:^(FIRDynamicLink *_Nullable dynamicLink,
+                                                  NSError *_Nullable error) {
+                                       XCTAssertEqual(dynamicLink.matchConfidence,
+                                                      FIRDynamicLinkMatchConfidenceStrong);
+                                       XCTAssertEqualObjects(dynamicLink.url.absoluteString,
+                                                             parsedDeepLinkString);
+                                       [expectation fulfill];
+                                     }];
+  [self waitForExpectationsWithTimeout:kAsyncTestTimout handler:nil];
   UnswizzleDynamicLinkNetworking();
 }
 
@@ -593,7 +633,7 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
         NSDictionary *dictionary = @{kFDLResolvedLinkDeepLinkURLKey : kEncodedComplicatedURLString};
         NSData *data = FIRDataWithDictionary(dictionary, nil);
 
-        handler(data, nil);
+        handler(data, nil, nil);
       };
 
   SEL executeRequestSelector = @selector(executeOnePlatformRequest:forURL:completionHandler:);
@@ -634,8 +674,11 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
           kFDLResolvedLinkMinAppVersionKey : expectedMinVersion,
         };
         NSData *data = FIRDataWithDictionary(dictionary, nil);
-
-        handler(data, nil);
+        NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url
+                                                                  statusCode:200
+                                                                 HTTPVersion:nil
+                                                                headerFields:nil];
+        handler(data, response, nil);
       };
 
   SEL executeRequestSelector = @selector(executeOnePlatformRequest:forURL:completionHandler:);
@@ -708,11 +751,17 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
   NSURL *url = FIRDLDeepLinkURLWithInviteID(nil, kEncodedComplicatedURLString, nil, nil, nil, NO,
                                             nil, nil, kURLScheme, nil);
 
-  FIRDynamicLink *dynamicLink = [self.service dynamicLinkFromUniversalLinkURL:url];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completion called"];
+  [self.service
+      dynamicLinkFromUniversalLinkURL:url
+                           completion:^(FIRDynamicLink *_Nullable dynamicLink,
+                                        NSError *_Nullable error) {
+                             NSString *minVersion = dynamicLink.minimumAppVersion;
 
-  NSString *minVersion = dynamicLink.minimumAppVersion;
-
-  XCTAssertNil(minVersion, @"Min app version was not nil when not set.");
+                             XCTAssertNil(minVersion, @"Min app version was not nil when not set.");
+                             [expectation fulfill];
+                           }];
+  [self waitForExpectationsWithTimeout:kAsyncTestTimout handler:nil];
 }
 
 - (void)testDynamicLinkFromUniversalLinkURLReturnsDLMinimumVersion {
@@ -728,11 +777,18 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
                              urlScheme:kURLScheme
                           userDefaults:self.userDefaults];
 
-  FIRDynamicLink *dynamicLink = [self.service dynamicLinkFromUniversalLinkURL:url];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completion called"];
+  [self.service
+      dynamicLinkFromUniversalLinkURL:url
+                           completion:^(FIRDynamicLink *_Nullable dynamicLink,
+                                        NSError *_Nullable error) {
+                             NSString *minVersion = dynamicLink.minimumAppVersion;
 
-  NSString *minVersion = dynamicLink.minimumAppVersion;
-
-  XCTAssertEqualObjects(expectedMinVersion, minVersion, @"Min version didn't match imv= parameter");
+                             XCTAssertEqualObjects(expectedMinVersion, minVersion,
+                                                   @"Min version didn't match imv= parameter");
+                             [expectation fulfill];
+                           }];
+  [self waitForExpectationsWithTimeout:kAsyncTestTimout handler:nil];
 }
 
 - (void)testUniversalLinkWithSubdomain_DeepLink {
@@ -748,9 +804,18 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   SwizzleDynamicLinkNetworkingWithMock();
 
-  FIRDynamicLink *dynamicLink = [self.service dynamicLinkFromUniversalLinkURL:url];
-  XCTAssertEqual(dynamicLink.matchConfidence, FIRDynamicLinkMatchConfidenceStrong);
-  XCTAssertEqualObjects(dynamicLink.url.absoluteString, deepLinkString);
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completion called"];
+  [self.service
+      dynamicLinkFromUniversalLinkURL:url
+                           completion:^(FIRDynamicLink *_Nullable dynamicLink,
+                                        NSError *_Nullable error) {
+                             XCTAssertEqual(dynamicLink.matchConfidence,
+                                            FIRDynamicLinkMatchConfidenceStrong);
+                             XCTAssertEqualObjects(dynamicLink.url.absoluteString, deepLinkString);
+                             [expectation fulfill];
+                           }];
+  [self waitForExpectationsWithTimeout:kAsyncTestTimout handler:nil];
+
   UnswizzleDynamicLinkNetworking();
 }
 
@@ -766,9 +831,104 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
                              urlScheme:kURLScheme
                           userDefaults:self.userDefaults];
 
-  FIRDynamicLink *dynamicLink = [self.service dynamicLinkFromUniversalLinkURL:url];
-  XCTAssertEqual(dynamicLink.matchConfidence, FIRDynamicLinkMatchConfidenceStrong);
-  XCTAssertEqualObjects(dynamicLink.url.absoluteString, parsedDeepLinkString);
+  XCTestExpectation *expectation = [self expectationWithDescription:@"completion called"];
+  [self.service dynamicLinkFromUniversalLinkURL:url
+                                     completion:^(FIRDynamicLink *_Nullable dynamicLink,
+                                                  NSError *_Nullable error) {
+                                       XCTAssertEqual(dynamicLink.matchConfidence,
+                                                      FIRDynamicLinkMatchConfidenceStrong);
+                                       XCTAssertEqualObjects(dynamicLink.url.absoluteString,
+                                                             parsedDeepLinkString);
+                                       [expectation fulfill];
+                                     }];
+  [self waitForExpectationsWithTimeout:kAsyncTestTimout handler:nil];
+}
+
+- (void)testResolveLinkRespectsResponseSuccessStatusCode {
+  [self.service setUpWithLaunchOptions:nil
+                                apiKey:kAPIKey
+                              clientID:kClientID
+                             urlScheme:kURLScheme
+                          userDefaults:self.userDefaults];
+
+  NSString *urlString = @"http://domain";
+  NSURL *url = [NSURL URLWithString:urlString];
+
+  void (^executeRequestBlock)(id, NSDictionary *, NSString *, FIRNetworkRequestCompletionHandler) =
+      ^(id p1, NSDictionary *requestBody, NSString *requestURLString,
+        FIRNetworkRequestCompletionHandler handler) {
+        NSData *data = FIRDataWithDictionary(@{}, nil);
+        NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url
+                                                                  statusCode:200
+                                                                 HTTPVersion:nil
+                                                                headerFields:nil];
+        handler(data, response, nil);
+      };
+
+  SEL executeRequestSelector = @selector(executeOnePlatformRequest:forURL:completionHandler:);
+  [GULSwizzler swizzleClass:[FIRDynamicLinkNetworking class]
+                   selector:executeRequestSelector
+            isClassSelector:NO
+                  withBlock:executeRequestBlock];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"handler called"];
+
+  [self.service resolveShortLink:url
+                      completion:^(NSURL *_Nullable url, NSError *_Nullable error) {
+                        XCTAssertNotNil(url);
+                        XCTAssertNil(error);
+                        [expectation fulfill];
+                      }];
+
+  [self waitForExpectationsWithTimeout:kAsyncTestTimout handler:nil];
+}
+
+- (void)testResolveLinkRespectsResponseErrorStatusCode {
+  [self.service setUpWithLaunchOptions:nil
+                                apiKey:kAPIKey
+                              clientID:kClientID
+                             urlScheme:kURLScheme
+                          userDefaults:self.userDefaults];
+
+  NSString *urlString = @"http://domain";
+  NSURL *url = [NSURL URLWithString:urlString];
+
+  NSError *expectedError = [NSError
+      errorWithDomain:@"com.firebase.dynamicLinks"
+                 code:0
+             userInfo:@{
+               @"message" : [NSString stringWithFormat:@"Failed to resolve link: %@", urlString]
+             }];
+
+  void (^executeRequestBlock)(id, NSDictionary *, NSString *, FIRNetworkRequestCompletionHandler) =
+      ^(id p1, NSDictionary *requestBody, NSString *requestURLString,
+        FIRNetworkRequestCompletionHandler handler) {
+        NSData *data = FIRDataWithDictionary(@{}, nil);
+        NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url
+                                                                  statusCode:400
+                                                                 HTTPVersion:nil
+                                                                headerFields:nil];
+        handler(data, response, nil);
+      };
+
+  SEL executeRequestSelector = @selector(executeOnePlatformRequest:forURL:completionHandler:);
+  [GULSwizzler swizzleClass:[FIRDynamicLinkNetworking class]
+                   selector:executeRequestSelector
+            isClassSelector:NO
+                  withBlock:executeRequestBlock];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"handler called"];
+
+  [self.service resolveShortLink:url
+                      completion:^(NSURL *_Nullable url, NSError *_Nullable error) {
+                        XCTAssertNil(url);
+                        XCTAssertNotNil(error);
+                        XCTAssertEqualObjects(error, expectedError,
+                                              @"Handle universal link returned unexpected error");
+                        [expectation fulfill];
+                      }];
+
+  [self waitForExpectationsWithTimeout:kAsyncTestTimout handler:nil];
 }
 
 - (void)testMatchesShortLinkFormat {

--- a/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
+++ b/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
@@ -496,6 +496,23 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   SwizzleDynamicLinkNetworkingWithMock();
 
+  FIRDynamicLink *dynamicLink = [self.service dynamicLinkFromUniversalLinkURL:durabledeepLinkURL];
+
+  XCTAssertNotNil(dynamicLink);
+  NSString *deepLinkURLString = dynamicLink.url.absoluteString;
+
+  XCTAssertEqualObjects(@"abcd", deepLinkURLString,
+                        @"ddl url parameter and deep link url should be the same");
+  UnswizzleDynamicLinkNetworking();
+}
+
+- (void)testDynamicLinkFromUniversalLinkURLCompletionWithCustomDomainLink {
+  self.service = [[FIRDynamicLinks alloc] init];
+  NSString *durableDeepLinkString = @"https://a.firebase.com/mypath/?link=abcd";
+  NSURL *durabledeepLinkURL = [NSURL URLWithString:durableDeepLinkString];
+
+  SwizzleDynamicLinkNetworkingWithMock();
+
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion called"];
   [self.service
       dynamicLinkFromUniversalLinkURL:durabledeepLinkURL
@@ -521,6 +538,22 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   SwizzleDynamicLinkNetworkingWithMock();
 
+  FIRDynamicLink *dynamicLink = [self.service dynamicLinkFromUniversalLinkURL:durabledeepLinkURL];
+
+  NSString *deepLinkURLString = dynamicLink.url.absoluteString;
+
+  XCTAssertEqualObjects(kDecodedComplicatedURLString, deepLinkURLString,
+                        @"ddl url parameter and deep link url should be the same");
+  UnswizzleDynamicLinkNetworking();
+}
+
+- (void)testDynamicLinkFromUniversalLinkURLCompletionWithSpecialCharacters {
+  NSString *durableDeepLinkString =
+      [NSString stringWithFormat:@"https://xyz.page.link/?link=%@", kEncodedComplicatedURLString];
+  NSURL *durabledeepLinkURL = [NSURL URLWithString:durableDeepLinkString];
+
+  SwizzleDynamicLinkNetworkingWithMock();
+
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion called"];
   [self.service
       dynamicLinkFromUniversalLinkURL:durabledeepLinkURL
@@ -539,6 +572,22 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 }
 
 - (void)testDynamicLinkFromUniversalLinkURLWithEncodedCharacters {
+  NSString *durableDeepLinkString =
+      [NSString stringWithFormat:@"https://xyz.page.link/?link=%@", kEncodedComplicatedURLString];
+  NSURL *durabledeepLinkURL = [NSURL URLWithString:durableDeepLinkString];
+
+  SwizzleDynamicLinkNetworkingWithMock();
+
+  FIRDynamicLink *dynamicLink = [self.service dynamicLinkFromUniversalLinkURL:durabledeepLinkURL];
+
+  NSString *deepLinkURLString = dynamicLink.url.absoluteString;
+
+  XCTAssertEqualObjects(kDecodedComplicatedURLString, deepLinkURLString,
+                        @"ddl url parameter and deep link url should be the same");
+  UnswizzleDynamicLinkNetworking();
+}
+
+- (void)testDynamicLinkFromUniversalLinkURLCompletionWithEncodedCharacters {
   NSString *durableDeepLinkString =
       [NSString stringWithFormat:@"https://xyz.page.link/?link=%@", kEncodedComplicatedURLString];
   NSURL *durabledeepLinkURL = [NSURL URLWithString:durableDeepLinkString];
@@ -575,6 +624,27 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   SwizzleDynamicLinkNetworkingWithMock();
 
+  FIRDynamicLink *dynamicLink = [self.service dynamicLinkFromUniversalLinkURL:url];
+
+  XCTAssertEqual(dynamicLink.matchConfidence, FIRDynamicLinkMatchConfidenceStrong);
+  XCTAssertEqualObjects(dynamicLink.url.absoluteString, deepLinkString);
+  UnswizzleDynamicLinkNetworking();
+}
+
+- (void)testUniversalLinkWithCompletion_DeepLink {
+  NSString *deepLinkString = @"https://www.google.com/maps/place/Minneapolis";
+  NSString *webPageURLString =
+      [NSString stringWithFormat:kStructuredUniversalLinkFmtDeepLink, deepLinkString];
+  NSURL *url = [NSURL URLWithString:webPageURLString];
+
+  [self.service setUpWithLaunchOptions:nil
+                                apiKey:kAPIKey
+                              clientID:kClientID
+                             urlScheme:kURLScheme
+                          userDefaults:self.userDefaults];
+
+  SwizzleDynamicLinkNetworkingWithMock();
+
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion called"];
   [self.service
       dynamicLinkFromUniversalLinkURL:url
@@ -599,6 +669,27 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   [self.service setUpWithLaunchOptions:nil
                                 apiKey:kAPIKey
+                             urlScheme:kURLScheme
+                          userDefaults:self.userDefaults];
+
+  SwizzleDynamicLinkNetworkingWithMock();
+
+  FIRDynamicLink *dynamicLink = [self.service dynamicLinkFromUniversalLinkURL:url];
+  XCTAssertEqual(dynamicLink.matchConfidence, FIRDynamicLinkMatchConfidenceStrong);
+  XCTAssertEqualObjects(dynamicLink.url.absoluteString, parsedDeepLinkString);
+  UnswizzleDynamicLinkNetworking();
+}
+
+- (void)testUniversalLinkWithCompletion_DeepLinkWithParameters {
+  NSString *deepLinkString = @"https://www.google.com?key1%3Dvalue1%26key2%3Dvalue2";
+  NSString *parsedDeepLinkString = @"https://www.google.com?key1=value1&key2=value2";
+  NSString *webPageURLString =
+      [NSString stringWithFormat:kStructuredUniversalLinkFmtDeepLink, deepLinkString];
+  NSURL *url = [NSURL URLWithString:webPageURLString];
+
+  [self.service setUpWithLaunchOptions:nil
+                                apiKey:kAPIKey
+                              clientID:kClientID
                              urlScheme:kURLScheme
                           userDefaults:self.userDefaults];
 
@@ -751,6 +842,23 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
   NSURL *url = FIRDLDeepLinkURLWithInviteID(nil, kEncodedComplicatedURLString, nil, nil, nil, NO,
                                             nil, nil, kURLScheme, nil);
 
+  FIRDynamicLink *dynamicLink = [self.service dynamicLinkFromUniversalLinkURL:url];
+
+  NSString *minVersion = dynamicLink.minimumAppVersion;
+
+  XCTAssertNil(minVersion, @"Min app version was not nil when not set.");
+}
+
+- (void)testDynamicLinkFromUniversalLinkURLCompletionReturnsDLWithNilMinimumVersion {
+  [self.service setUpWithLaunchOptions:nil
+                                apiKey:kAPIKey
+                              clientID:kClientID
+                             urlScheme:kURLScheme
+                          userDefaults:self.userDefaults];
+
+  NSURL *url = FIRDLDeepLinkURLWithInviteID(nil, kEncodedComplicatedURLString, nil, nil, nil, NO,
+                                            nil, nil, kURLScheme, nil);
+
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion called"];
   [self.service
       dynamicLinkFromUniversalLinkURL:url
@@ -774,6 +882,27 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   [self.service setUpWithLaunchOptions:nil
                                 apiKey:kAPIKey
+                             urlScheme:kURLScheme
+                          userDefaults:self.userDefaults];
+
+  FIRDynamicLink *dynamicLink = [self.service dynamicLinkFromUniversalLinkURL:url];
+
+  NSString *minVersion = dynamicLink.minimumAppVersion;
+
+  XCTAssertEqualObjects(expectedMinVersion, minVersion, @"Min version didn't match imv= parameter");
+}
+
+- (void)testDynamicLinkFromUniversalLinkURLCompletionReturnsDLMinimumVersion {
+  NSString *expectedMinVersion = @"03-9g03hfd";
+  NSString *urlSuffix =
+      [NSString stringWithFormat:@"%@&imv=%@", kEncodedComplicatedURLString, expectedMinVersion];
+  NSString *urlString =
+      [NSString stringWithFormat:kStructuredUniversalLinkFmtSubdomainDeepLink, urlSuffix];
+  NSURL *url = [NSURL URLWithString:urlString];
+
+  [self.service setUpWithLaunchOptions:nil
+                                apiKey:kAPIKey
+                              clientID:kClientID
                              urlScheme:kURLScheme
                           userDefaults:self.userDefaults];
 
@@ -804,6 +933,26 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   SwizzleDynamicLinkNetworkingWithMock();
 
+  FIRDynamicLink *dynamicLink = [self.service dynamicLinkFromUniversalLinkURL:url];
+  XCTAssertEqual(dynamicLink.matchConfidence, FIRDynamicLinkMatchConfidenceStrong);
+  XCTAssertEqualObjects(dynamicLink.url.absoluteString, deepLinkString);
+  UnswizzleDynamicLinkNetworking();
+}
+
+- (void)testUniversalLinkWithCompletionWithSubdomain_DeepLink {
+  NSString *deepLinkString = @"https://www.google.com/maps/place/Minneapolis";
+  NSString *webPageURLString =
+      [NSString stringWithFormat:kStructuredUniversalLinkFmtSubdomainDeepLink, deepLinkString];
+  NSURL *url = [NSURL URLWithString:webPageURLString];
+
+  [self.service setUpWithLaunchOptions:nil
+                                apiKey:kAPIKey
+                              clientID:kClientID
+                             urlScheme:kURLScheme
+                          userDefaults:self.userDefaults];
+
+  SwizzleDynamicLinkNetworkingWithMock();
+
   XCTestExpectation *expectation = [self expectationWithDescription:@"completion called"];
   [self.service
       dynamicLinkFromUniversalLinkURL:url
@@ -828,6 +977,24 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   [self.service setUpWithLaunchOptions:nil
                                 apiKey:kAPIKey
+                             urlScheme:kURLScheme
+                          userDefaults:self.userDefaults];
+
+  FIRDynamicLink *dynamicLink = [self.service dynamicLinkFromUniversalLinkURL:url];
+  XCTAssertEqual(dynamicLink.matchConfidence, FIRDynamicLinkMatchConfidenceStrong);
+  XCTAssertEqualObjects(dynamicLink.url.absoluteString, parsedDeepLinkString);
+}
+
+- (void)testUniversalLinkWithCompletionWithSubdomain_DeepLinkWithParameters {
+  NSString *deepLinkString = @"https://www.google.com?key1%3Dvalue1%26key2%3Dvalue2";
+  NSString *parsedDeepLinkString = @"https://www.google.com?key1=value1&key2=value2";
+  NSString *webPageURLString =
+      [NSString stringWithFormat:kStructuredUniversalLinkFmtSubdomainDeepLink, deepLinkString];
+  NSURL *url = [NSURL URLWithString:webPageURLString];
+
+  [self.service setUpWithLaunchOptions:nil
+                                apiKey:kAPIKey
+                              clientID:kClientID
                              urlScheme:kURLScheme
                           userDefaults:self.userDefaults];
 

--- a/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
+++ b/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
@@ -639,7 +639,6 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   [self.service setUpWithLaunchOptions:nil
                                 apiKey:kAPIKey
-                              clientID:kClientID
                              urlScheme:kURLScheme
                           userDefaults:self.userDefaults];
 
@@ -689,7 +688,6 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   [self.service setUpWithLaunchOptions:nil
                                 apiKey:kAPIKey
-                              clientID:kClientID
                              urlScheme:kURLScheme
                           userDefaults:self.userDefaults];
 
@@ -852,7 +850,6 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 - (void)testDynamicLinkFromUniversalLinkURLCompletionReturnsDLWithNilMinimumVersion {
   [self.service setUpWithLaunchOptions:nil
                                 apiKey:kAPIKey
-                              clientID:kClientID
                              urlScheme:kURLScheme
                           userDefaults:self.userDefaults];
 
@@ -902,7 +899,6 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   [self.service setUpWithLaunchOptions:nil
                                 apiKey:kAPIKey
-                              clientID:kClientID
                              urlScheme:kURLScheme
                           userDefaults:self.userDefaults];
 
@@ -947,7 +943,6 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   [self.service setUpWithLaunchOptions:nil
                                 apiKey:kAPIKey
-                              clientID:kClientID
                              urlScheme:kURLScheme
                           userDefaults:self.userDefaults];
 
@@ -994,7 +989,6 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 
   [self.service setUpWithLaunchOptions:nil
                                 apiKey:kAPIKey
-                              clientID:kClientID
                              urlScheme:kURLScheme
                           userDefaults:self.userDefaults];
 
@@ -1014,7 +1008,6 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 - (void)testResolveLinkRespectsResponseSuccessStatusCode {
   [self.service setUpWithLaunchOptions:nil
                                 apiKey:kAPIKey
-                              clientID:kClientID
                              urlScheme:kURLScheme
                           userDefaults:self.userDefaults];
 
@@ -1053,7 +1046,6 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
 - (void)testResolveLinkRespectsResponseErrorStatusCode {
   [self.service setUpWithLaunchOptions:nil
                                 apiKey:kAPIKey
-                              clientID:kClientID
                              urlScheme:kURLScheme
                           userDefaults:self.userDefaults];
 


### PR DESCRIPTION
- **Description**: Dynamic links can be validated against a block/allow list, which is defined server side in the Firebase Console. This verification should apply to both short and long dynamic links, and be supported by both iOS and Android SDKs.
- **What’s expected**: It’s expected that both iOS and Android will verify both kinds of dynamic link, and if it passes the verification rules defined server side, allow the link to be processed.
- **What’s observed**: On iOS, long dynamic links are not verified, and it’s possible for a link that doesn’t pass the "allowed link" rules to be treated as verified. Short dynamic links are verified, that’s not an issue. This also isn’t an issue on Android, which verifies both short and long dynamic links.
- **Proposed solution**: Ensure the error response from `reopenAttribution` (which contains information to whether the link was verified or not), should be propagated further up for long dynamic links, so the appropriate decision on whether it’s a verified link can be made. Some method definitions have changed as well to accommodate this, which have now made them asynchronous.

According to the source code all short links are checked when a call to `FIRDynamicLinkNetworking` class method `resolveShortLink:completion:` takes place. This method does a HTTP call to `reopenAttribution` endpoint and receives a response with an error, if the URL is not allowed. The problem is that the same is not true for long dynamic links (aka [manually created links](https://firebase.google.com/docs/dynamic-links/create-manually)) - no call to `resolveShortLink:completion:` method (or its long links counterpart) is done. Thus all URLs are accepted and considered allowed.
Another part of the problem is that when a call to `reopenAttribution` endpoint is done the response with the error description is ignored and and error equal to `nil` is passed to completion callback. Thus, all traces of the issue (the URL being not allowed) are lost.