### PR TITLE
Auth: Repo-relative headers and SPM

### DIFF
--- a/FirebaseAuth/Sources/Auth/FIRActionCodeSettings.m
+++ b/FirebaseAuth/Sources/Auth/FIRActionCodeSettings.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRActionCodeSettings.h>
+#import "FirebaseAuth/Sources/Public/FIRActionCodeSettings.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -22,7 +22,7 @@
 #import <UIKit/UIKit.h>
 #endif
 
-#import <FirebaseAuth/FirebaseAuth.h>
+#import "FirebaseAuth/Sources/Public/FirebaseAuth.h"
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "GoogleUtilities/AppDelegateSwizzler/Private/GULAppDelegateSwizzler.h"
 #import "GoogleUtilities/Environment/Private/GULAppEnvironmentUtil.h"

--- a/FirebaseAuth/Sources/Auth/FIRAuthDataResult.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuthDataResult.m
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAdditionalUserInfo.h>
-#import <FirebaseAuth/FIROAuthCredential.h>
-#import <FirebaseAuth/FIRUser.h>
+#import "FirebaseAuth/Sources/Public/FIRAdditionalUserInfo.h"
+#import "FirebaseAuth/Sources/Public/FIROAuthCredential.h"
+#import "FirebaseAuth/Sources/Public/FIRUser.h"
 
 #import "FirebaseAuth/Sources/Auth/FIRAuthDataResult_Internal.h"
 

--- a/FirebaseAuth/Sources/Auth/FIRAuthDataResult_Internal.h
+++ b/FirebaseAuth/Sources/Auth/FIRAuthDataResult_Internal.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthDataResult.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthDataResult.h"
 
 @class FIROAuthCredential;
 

--- a/FirebaseAuth/Sources/Auth/FIRAuthSettings.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuthSettings.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthSettings.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthSettings.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAuth/Sources/Auth/FIRAuthTokenResult_Internal.h
+++ b/FirebaseAuth/Sources/Auth/FIRAuthTokenResult_Internal.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthTokenResult.h>
 #import <Foundation/Foundation.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthTokenResult.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAuth/Sources/Auth/FIRAuth_Internal.h
+++ b/FirebaseAuth/Sources/Auth/FIRAuth_Internal.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuth.h>
 #import <Foundation/Foundation.h>
+#import "FirebaseAuth/Sources/Public/FIRAuth.h"
 #import "Interop/Auth/Public/FIRAuthInterop.h"
 
 @class FIRAuthRequestConfiguration;

--- a/FirebaseAuth/Sources/AuthProvider/Email/FIREmailAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Email/FIREmailAuthProvider.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIREmailAuthProvider.h>
+#import "FirebaseAuth/Sources/Public/FIREmailAuthProvider.h"
 
 #import "FirebaseAuth/Sources/AuthProvider/Email/FIREmailPasswordAuthCredential.h"
 

--- a/FirebaseAuth/Sources/AuthProvider/Email/FIREmailPasswordAuthCredential.m
+++ b/FirebaseAuth/Sources/AuthProvider/Email/FIREmailPasswordAuthCredential.m
@@ -16,7 +16,7 @@
 
 #import "FirebaseAuth/Sources/AuthProvider/Email/FIREmailPasswordAuthCredential.h"
 
-#import <FirebaseAuth/FIREmailAuthProvider.h>
+#import "FirebaseAuth/Sources/Public/FIREmailAuthProvider.h"
 
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyAssertionRequest.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthExceptionUtils.h"

--- a/FirebaseAuth/Sources/AuthProvider/FIRAuthCredential_Internal.h
+++ b/FirebaseAuth/Sources/AuthProvider/FIRAuthCredential_Internal.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthCredential.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthCredential.h"
 
 @class FIRVerifyAssertionRequest;
 

--- a/FirebaseAuth/Sources/AuthProvider/Facebook/FIRFacebookAuthCredential.m
+++ b/FirebaseAuth/Sources/AuthProvider/Facebook/FIRFacebookAuthCredential.m
@@ -16,7 +16,7 @@
 
 #import "FirebaseAuth/Sources/AuthProvider/Facebook/FIRFacebookAuthCredential.h"
 
-#import <FirebaseAuth/FIRFacebookAuthProvider.h>
+#import "FirebaseAuth/Sources/Public/FIRFacebookAuthProvider.h"
 
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyAssertionRequest.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthExceptionUtils.h"

--- a/FirebaseAuth/Sources/AuthProvider/Facebook/FIRFacebookAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Facebook/FIRFacebookAuthProvider.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRFacebookAuthProvider.h>
+#import "FirebaseAuth/Sources/Public/FIRFacebookAuthProvider.h"
 
 #import "FirebaseAuth/Sources/AuthProvider/Facebook/FIRFacebookAuthCredential.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthExceptionUtils.h"

--- a/FirebaseAuth/Sources/AuthProvider/GameCenter/FIRGameCenterAuthCredential.h
+++ b/FirebaseAuth/Sources/AuthProvider/GameCenter/FIRGameCenterAuthCredential.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthCredential.h>
 #import <Foundation/Foundation.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthCredential.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAuth/Sources/AuthProvider/GameCenter/FIRGameCenterAuthCredential.m
+++ b/FirebaseAuth/Sources/AuthProvider/GameCenter/FIRGameCenterAuthCredential.m
@@ -16,7 +16,7 @@
 
 #import "FirebaseAuth/Sources/AuthProvider/GameCenter/FIRGameCenterAuthCredential.h"
 
-#import <FirebaseAuth/FIRGameCenterAuthProvider.h>
+#import "FirebaseAuth/Sources/Public/FIRGameCenterAuthProvider.h"
 
 #import "FirebaseAuth/Sources/AuthProvider/FIRAuthCredential_Internal.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyAssertionRequest.h"

--- a/FirebaseAuth/Sources/AuthProvider/GameCenter/FIRGameCenterAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/GameCenter/FIRGameCenterAuthProvider.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRGameCenterAuthProvider.h>
+#import "FirebaseAuth/Sources/Public/FIRGameCenterAuthProvider.h"
 #import <GameKit/GameKit.h>
 
 #import "FirebaseAuth/Sources/AuthProvider/GameCenter/FIRGameCenterAuthCredential.h"

--- a/FirebaseAuth/Sources/AuthProvider/GitHub/FIRGitHubAuthCredential.m
+++ b/FirebaseAuth/Sources/AuthProvider/GitHub/FIRGitHubAuthCredential.m
@@ -16,7 +16,7 @@
 
 #import "FirebaseAuth/Sources/AuthProvider/GitHub/FIRGitHubAuthCredential.h"
 
-#import <FirebaseAuth/FIRGitHubAuthProvider.h>
+#import "FirebaseAuth/Sources/Public/FIRGitHubAuthProvider.h"
 
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyAssertionRequest.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthExceptionUtils.h"

--- a/FirebaseAuth/Sources/AuthProvider/GitHub/FIRGitHubAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/GitHub/FIRGitHubAuthProvider.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRGitHubAuthProvider.h>
+#import "FirebaseAuth/Sources/Public/FIRGitHubAuthProvider.h"
 
 #import "FirebaseAuth/Sources/AuthProvider/GitHub/FIRGitHubAuthCredential.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthExceptionUtils.h"

--- a/FirebaseAuth/Sources/AuthProvider/Google/FIRGoogleAuthCredential.m
+++ b/FirebaseAuth/Sources/AuthProvider/Google/FIRGoogleAuthCredential.m
@@ -16,7 +16,7 @@
 
 #import "FirebaseAuth/Sources/AuthProvider/Google/FIRGoogleAuthCredential.h"
 
-#import <FirebaseAuth/FIRGoogleAuthProvider.h>
+#import "FirebaseAuth/Sources/Public/FIRGoogleAuthProvider.h"
 
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyAssertionRequest.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthExceptionUtils.h"

--- a/FirebaseAuth/Sources/AuthProvider/Google/FIRGoogleAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Google/FIRGoogleAuthProvider.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRGoogleAuthProvider.h>
+#import "FirebaseAuth/Sources/Public/FIRGoogleAuthProvider.h"
 
 #import "FirebaseAuth/Sources/AuthProvider/Google/FIRGoogleAuthCredential.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthExceptionUtils.h"

--- a/FirebaseAuth/Sources/AuthProvider/OAuth/FIROAuthCredential.m
+++ b/FirebaseAuth/Sources/AuthProvider/OAuth/FIROAuthCredential.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIROAuthCredential.h>
+#import "FirebaseAuth/Sources/Public/FIROAuthCredential.h"
 
 #import "FirebaseAuth/Sources/AuthProvider/FIRAuthCredential_Internal.h"
 #import "FirebaseAuth/Sources/AuthProvider/OAuth/FIROAuthCredential_Internal.h"

--- a/FirebaseAuth/Sources/AuthProvider/OAuth/FIROAuthCredential_Internal.h
+++ b/FirebaseAuth/Sources/AuthProvider/OAuth/FIROAuthCredential_Internal.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIROAuthCredential.h>
 #import <Foundation/Foundation.h>
+#import "FirebaseAuth/Sources/Public/FIROAuthCredential.h"
 
 @class FIRVerifyAssertionResponse;
 

--- a/FirebaseAuth/Sources/AuthProvider/OAuth/FIROAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/OAuth/FIROAuthProvider.m
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+#import "FirebaseAuth/Sources/Public/FIROAuthProvider.h"
 #include <CommonCrypto/CommonCrypto.h>
-#import <FirebaseAuth/FIRFacebookAuthProvider.h>
-#import <FirebaseAuth/FIROAuthCredential.h>
-#import <FirebaseAuth/FIROAuthProvider.h>
+#import "FirebaseAuth/Sources/Public/FIRFacebookAuthProvider.h"
+#import "FirebaseAuth/Sources/Public/FIROAuthCredential.h"
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 
 #import "FirebaseAuth/Sources/Auth/FIRAuthGlobalWorkQueue.h"

--- a/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthCredential.m
+++ b/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthCredential.m
@@ -17,7 +17,7 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRPhoneAuthCredential.h>
+#import "FirebaseAuth/Sources/Public/FIRPhoneAuthCredential.h"
 
 #import "FirebaseAuth/Sources/AuthProvider/FIRAuthCredential_Internal.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyAssertionRequest.h"

--- a/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthCredential_Internal.h
+++ b/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthCredential_Internal.h
@@ -17,8 +17,8 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRPhoneAuthCredential.h>
 #import <Foundation/Foundation.h>
+#import "FirebaseAuth/Sources/Public/FIRPhoneAuthCredential.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthProvider.m
@@ -17,10 +17,10 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRAuthSettings.h>
-#import <FirebaseAuth/FIRMultiFactorResolver.h>
-#import <FirebaseAuth/FIRPhoneAuthProvider.h>
-#import <FirebaseAuth/FirebaseAuthVersion.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthSettings.h"
+#import "FirebaseAuth/Sources/Public/FIRMultiFactorResolver.h"
+#import "FirebaseAuth/Sources/Public/FIRPhoneAuthProvider.h"
+#import "FirebaseAuth/Sources/Public/FirebaseAuthVersion.h"
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 
 #import "FirebaseAuth/Sources/Auth/FIRAuthGlobalWorkQueue.h"

--- a/FirebaseAuth/Sources/AuthProvider/Twitter/FIRTwitterAuthCredential.m
+++ b/FirebaseAuth/Sources/AuthProvider/Twitter/FIRTwitterAuthCredential.m
@@ -16,7 +16,7 @@
 
 #import "FirebaseAuth/Sources/AuthProvider/Twitter/FIRTwitterAuthCredential.h"
 
-#import <FirebaseAuth/FIRTwitterAuthProvider.h>
+#import "FirebaseAuth/Sources/Public/FIRTwitterAuthProvider.h"
 
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyAssertionRequest.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthExceptionUtils.h"

--- a/FirebaseAuth/Sources/AuthProvider/Twitter/FIRTwitterAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/Twitter/FIRTwitterAuthProvider.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRTwitterAuthProvider.h>
+#import "FirebaseAuth/Sources/Public/FIRTwitterAuthProvider.h"
 
 #import "FirebaseAuth/Sources/AuthProvider/Twitter/FIRTwitterAuthCredential.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthExceptionUtils.h"

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -16,9 +16,14 @@
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 
-#import <FirebaseAuth/FirebaseAuth.h>
+#if SWIFT_PACKAGE
+@import GTMSessionFetcherCore;
+#else
 #import <GTMSessionFetcher/GTMSessionFetcher.h>
 #import <GTMSessionFetcher/GTMSessionFetcherService.h>
+#endif
+
+#import "FirebaseAuth/Sources/Public/FirebaseAuth.h"
 
 #import "FirebaseAuth/Sources/Auth/FIRAuthGlobalWorkQueue.h"
 #import "FirebaseAuth/Sources/AuthProvider/OAuth/FIROAuthCredential_Internal.h"
@@ -59,7 +64,7 @@
 #import "FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h"
 
 #if TARGET_OS_IOS
-#import <FirebaseAuth/FIRPhoneAuthProvider.h>
+#import "FirebaseAuth/Sources/Public/FIRPhoneAuthProvider.h"
 
 #import "FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthCredential_Internal.h"
 #import "FirebaseAuth/Sources/MultiFactor/Phone/FIRPhoneMultiFactorInfo+Internal.h"

--- a/FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.m
+++ b/FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.m
@@ -16,7 +16,7 @@
 
 #import "FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.h"
 
-#import <FirebaseAuth/FIRActionCodeSettings.h>
+#import "FirebaseAuth/Sources/Public/FIRActionCodeSettings.h"
 
 #import "FirebaseAuth/Sources/Auth/FIRAuth_Internal.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h"

--- a/FirebaseAuth/Sources/FirebaseAuthVersion.m
+++ b/FirebaseAuth/Sources/FirebaseAuthVersion.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FirebaseAuthVersion.h>
+#import "FirebaseAuth/Sources/Public/FirebaseAuthVersion.h"
 
 // Convert the macro to a string
 #define STR(x) STR_EXPAND(x)

--- a/FirebaseAuth/Sources/MultiFactor/FIRMultiFactor+Internal.h
+++ b/FirebaseAuth/Sources/MultiFactor/FIRMultiFactor+Internal.h
@@ -17,7 +17,7 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRMultiFactor.h>
+#import "FirebaseAuth/Sources/Public/FIRMultiFactor.h"
 
 #import "FirebaseAuth/Sources/Backend/RPC/Proto/FIRAuthProtoMFAEnrollment.h"
 

--- a/FirebaseAuth/Sources/MultiFactor/FIRMultiFactor.m
+++ b/FirebaseAuth/Sources/MultiFactor/FIRMultiFactor.m
@@ -16,7 +16,7 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRMultiFactor.h>
+#import "FirebaseAuth/Sources/Public/FIRMultiFactor.h"
 
 #import "FirebaseAuth/Sources/Auth/FIRAuthDataResult_Internal.h"
 #import "FirebaseAuth/Sources/Auth/FIRAuth_Internal.h"
@@ -28,7 +28,7 @@
 #import "FirebaseAuth/Sources/User/FIRUser_Internal.h"
 
 #if TARGET_OS_IOS
-#import <FirebaseAuth/FIRPhoneMultiFactorAssertion.h>
+#import "FirebaseAuth/Sources/Public/FIRPhoneMultiFactorAssertion.h"
 
 #import "FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthCredential_Internal.h"
 #import "FirebaseAuth/Sources/MultiFactor/Phone/FIRPhoneMultiFactorAssertion+Internal.h"

--- a/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorAssertion+Internal.h
+++ b/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorAssertion+Internal.h
@@ -17,7 +17,7 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRMultiFactorAssertion.h>
+#import "FirebaseAuth/Sources/Public/FIRMultiFactorAssertion.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorAssertion.m
+++ b/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorAssertion.m
@@ -17,7 +17,7 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRMultiFactorAssertion.h>
+#import "FirebaseAuth/Sources/Public/FIRMultiFactorAssertion.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorInfo+Internal.h
+++ b/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorInfo+Internal.h
@@ -17,7 +17,7 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRMultiFactorInfo.h>
+#import "FirebaseAuth/Sources/Public/FIRMultiFactorInfo.h"
 
 #import "FirebaseAuth/Sources/Backend/RPC/Proto/FIRAuthProtoMFAEnrollment.h"
 

--- a/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorInfo.m
+++ b/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorInfo.m
@@ -17,7 +17,7 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRMultiFactorInfo.h>
+#import "FirebaseAuth/Sources/Public/FIRMultiFactorInfo.h"
 
 #import "FirebaseAuth/Sources/Backend/RPC/Proto/FIRAuthProtoMFAEnrollment.h"
 

--- a/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver+Internal.h
+++ b/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver+Internal.h
@@ -16,7 +16,7 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRMultiFactorResolver.h>
+#import "FirebaseAuth/Sources/Public/FIRMultiFactorResolver.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver.m
+++ b/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver.m
@@ -16,8 +16,8 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRAdditionalUserInfo.h>
-#import <FirebaseAuth/FIRMultiFactorResolver.h>
+#import "FirebaseAuth/Sources/Public/FIRAdditionalUserInfo.h"
+#import "FirebaseAuth/Sources/Public/FIRMultiFactorResolver.h"
 
 #import "FirebaseAuth/Sources/Auth/FIRAuthDataResult_Internal.h"
 #import "FirebaseAuth/Sources/Auth/FIRAuth_Internal.h"
@@ -28,7 +28,7 @@
 #import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorSession+Internal.h"
 
 #if TARGET_OS_IOS
-#import <FirebaseAuth/FIRPhoneMultiFactorAssertion.h>
+#import "FirebaseAuth/Sources/Public/FIRPhoneMultiFactorAssertion.h"
 
 #import "FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthCredential_Internal.h"
 #import "FirebaseAuth/Sources/MultiFactor/Phone/FIRPhoneMultiFactorAssertion+Internal.h"

--- a/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorSession+Internal.h
+++ b/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorSession+Internal.h
@@ -17,8 +17,8 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRMultiFactorInfo.h>
-#import <FirebaseAuth/FIRMultiFactorSession.h>
+#import "FirebaseAuth/Sources/Public/FIRMultiFactorInfo.h"
+#import "FirebaseAuth/Sources/Public/FIRMultiFactorSession.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorSession.m
+++ b/FirebaseAuth/Sources/MultiFactor/FIRMultiFactorSession.m
@@ -16,8 +16,8 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRAuth.h>
-#import <FirebaseAuth/FIRMultiFactorSession.h>
+#import "FirebaseAuth/Sources/Public/FIRAuth.h"
+#import "FirebaseAuth/Sources/Public/FIRMultiFactorSession.h"
 
 #import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorSession+Internal.h"
 #import "FirebaseAuth/Sources/User/FIRUser_Internal.h"

--- a/FirebaseAuth/Sources/MultiFactor/Phone/FIRPhoneMultiFactorAssertion+Internal.h
+++ b/FirebaseAuth/Sources/MultiFactor/Phone/FIRPhoneMultiFactorAssertion+Internal.h
@@ -17,8 +17,8 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRPhoneAuthCredential.h>
-#import <FirebaseAuth/FIRPhoneMultiFactorAssertion.h>
+#import "FirebaseAuth/Sources/Public/FIRPhoneAuthCredential.h"
+#import "FirebaseAuth/Sources/Public/FIRPhoneMultiFactorAssertion.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAuth/Sources/MultiFactor/Phone/FIRPhoneMultiFactorAssertion.m
+++ b/FirebaseAuth/Sources/MultiFactor/Phone/FIRPhoneMultiFactorAssertion.m
@@ -17,7 +17,7 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRPhoneMultiFactorAssertion.h>
+#import "FirebaseAuth/Sources/Public/FIRPhoneMultiFactorAssertion.h"
 
 #import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorAssertion+Internal.h"
 #import "FirebaseAuth/Sources/MultiFactor/Phone/FIRPhoneMultiFactorAssertion+Internal.h"

--- a/FirebaseAuth/Sources/MultiFactor/Phone/FIRPhoneMultiFactorGenerator.m
+++ b/FirebaseAuth/Sources/MultiFactor/Phone/FIRPhoneMultiFactorGenerator.m
@@ -17,8 +17,8 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRPhoneMultiFactorAssertion.h>
-#import <FirebaseAuth/FIRPhoneMultiFactorGenerator.h>
+#import "FirebaseAuth/Sources/Public/FIRPhoneMultiFactorAssertion.h"
+#import "FirebaseAuth/Sources/Public/FIRPhoneMultiFactorGenerator.h"
 
 #import "FirebaseAuth/Sources/MultiFactor/Phone/FIRPhoneMultiFactorAssertion+Internal.h"
 

--- a/FirebaseAuth/Sources/MultiFactor/Phone/FIRPhoneMultiFactorInfo+Internal.h
+++ b/FirebaseAuth/Sources/MultiFactor/Phone/FIRPhoneMultiFactorInfo+Internal.h
@@ -17,7 +17,7 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRPhoneMultiFactorInfo.h>
+#import "FirebaseAuth/Sources/Public/FIRPhoneMultiFactorInfo.h"
 
 @class FIRAuthProtoMFAEnrollment;
 

--- a/FirebaseAuth/Sources/MultiFactor/Phone/FIRPhoneMultiFactorInfo.m
+++ b/FirebaseAuth/Sources/MultiFactor/Phone/FIRPhoneMultiFactorInfo.m
@@ -17,8 +17,8 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRMultiFactorInfo.h>
-#import <FirebaseAuth/FIRPhoneMultiFactorInfo.h>
+#import "FirebaseAuth/Sources/Public/FIRMultiFactorInfo.h"
+#import "FirebaseAuth/Sources/Public/FIRPhoneMultiFactorInfo.h"
 
 #import "FirebaseAuth/Sources/Backend/RPC/Proto/FIRAuthProtoMFAEnrollment.h"
 #import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorInfo+Internal.h"

--- a/FirebaseAuth/Sources/SystemService/FIRAuthAPNSToken.h
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthAPNSToken.h
@@ -17,8 +17,8 @@
 #include <TargetConditionals.h>
 #if !TARGET_OS_OSX
 
-#import <FirebaseAuth/FIRAuthAPNSTokenType.h>
 #import <Foundation/Foundation.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthAPNSTokenType.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.h
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRUser.h>
 #import <Foundation/Foundation.h>
+#import "FirebaseAuth/Sources/Public/FIRUser.h"
 
 #import "FirebaseAuth/Sources/Storage/FIRAuthKeychainServices.h"
 #import "FirebaseAuth/Sources/Storage/FIRAuthUserDefaults.h"

--- a/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.m
+++ b/FirebaseAuth/Sources/SystemService/FIRSecureTokenService.m
@@ -16,7 +16,7 @@
 
 #import "FirebaseAuth/Sources/SystemService/FIRSecureTokenService.h"
 
-#import <FirebaseAuth/FIRAuth.h>
+#import "FirebaseAuth/Sources/Public/FIRAuth.h"
 
 #import "FirebaseAuth/Sources/Auth/FIRAuthSerialTaskQueue.h"
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"

--- a/FirebaseAuth/Sources/User/FIRAdditionalUserInfo_Internal.h
+++ b/FirebaseAuth/Sources/User/FIRAdditionalUserInfo_Internal.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAdditionalUserInfo.h>
+#import "FirebaseAuth/Sources/Public/FIRAdditionalUserInfo.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAuth/Sources/User/FIRUser.m
+++ b/FirebaseAuth/Sources/User/FIRUser.m
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuth.h>
-#import <FirebaseAuth/FIREmailAuthProvider.h>
-#import <FirebaseAuth/FIRFederatedAuthProvider.h>
+#import "FirebaseAuth/Sources/Public/FIRAuth.h"
+#import "FirebaseAuth/Sources/Public/FIREmailAuthProvider.h"
+#import "FirebaseAuth/Sources/Public/FIRFederatedAuthProvider.h"
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 
 #import "FirebaseAuth/Sources/Auth/FIRAuthDataResult_Internal.h"
@@ -60,7 +60,7 @@
 #import "FirebaseAuth/Sources/Utilities/FIRAuthWebUtils.h"
 
 #if TARGET_OS_IOS
-#import <FirebaseAuth/FIRPhoneAuthProvider.h>
+#import "FirebaseAuth/Sources/Public/FIRPhoneAuthProvider.h"
 
 #import "FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthCredential_Internal.h"
 #endif

--- a/FirebaseAuth/Sources/User/FIRUserInfoImpl.h
+++ b/FirebaseAuth/Sources/User/FIRUserInfoImpl.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRUserInfo.h>
 #import <Foundation/Foundation.h>
+#import "FirebaseAuth/Sources/Public/FIRUserInfo.h"
 
 @class FIRGetAccountInfoResponseProviderUserInfo;
 

--- a/FirebaseAuth/Sources/User/FIRUserMetadata_Internal.h
+++ b/FirebaseAuth/Sources/User/FIRUserMetadata_Internal.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRUserMetadata.h>
 #import <Foundation/Foundation.h>
+#import "FirebaseAuth/Sources/Public/FIRUserMetadata.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAuth/Sources/User/FIRUser_Internal.h
+++ b/FirebaseAuth/Sources/User/FIRUser_Internal.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRUser.h>
+#import "FirebaseAuth/Sources/Public/FIRUser.h"
 
 @class FIRAuth;
 @class FIRAuthRequestConfiguration;

--- a/FirebaseAuth/Sources/Utilities/FIRAuthDefaultUIDelegate.h
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthDefaultUIDelegate.h
@@ -17,8 +17,8 @@
 #include <TargetConditionals.h>
 #if !TARGET_OS_OSX
 
-#import <FirebaseAuth/FIRAuthUIDelegate.h>
 #import <Foundation/Foundation.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthUIDelegate.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRMultiFactorInfo.h>
 #import <Foundation/Foundation.h>
+#import "FirebaseAuth/Sources/Public/FIRMultiFactorInfo.h"
 
 #import "FirebaseAuth/Sources/Utilities/FIRAuthInternalErrors.h"
 

--- a/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.m
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.m
@@ -16,7 +16,7 @@
 
 #import "FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h"
 
-#import <FirebaseAuth/FIRAuthCredential.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthCredential.h"
 
 #import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver+Internal.h"
 

--- a/FirebaseAuth/Sources/Utilities/FIRAuthInternalErrors.h
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthInternalErrors.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <Foundation/Foundation.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseAuth/Sources/Utilities/FIRAuthURLPresenter.m
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthURLPresenter.m
@@ -17,8 +17,8 @@
 #include <TargetConditionals.h>
 #if TARGET_OS_IOS
 
-#import <FirebaseAuth/FIRAuthUIDelegate.h>
 #import <SafariServices/SafariServices.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthUIDelegate.h"
 
 #import "FirebaseAuth/Sources/Auth/FIRAuthGlobalWorkQueue.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthDefaultUIDelegate.h"

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+Email.m
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+Email.m
@@ -17,8 +17,6 @@
 #import "MainViewController+Email.h"
 
 #import "AppManager.h"
-#import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorResolver+Internal.h"
-#import "FirebaseAuth/Sources/MultiFactor/FIRMultiFactorSession+Internal.h"
 #import <FirebaseAuth/FIRPhoneMultiFactorInfo.h>
 #import "MainViewController+Internal.h"
 

--- a/FirebaseAuth/Tests/Unit/FIRAuthTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthTests.m
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRActionCodeSettings.h>
-#import <FirebaseAuth/FIRAdditionalUserInfo.h>
-#import <FirebaseAuth/FIREmailAuthProvider.h>
-#import <FirebaseAuth/FIRFacebookAuthProvider.h>
-#import <FirebaseAuth/FIRGoogleAuthProvider.h>
-#import <FirebaseAuth/FIROAuthProvider.h>
 #import <Foundation/Foundation.h>
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRActionCodeSettings.h"
+#import "FirebaseAuth/Sources/Public/FIRAdditionalUserInfo.h"
+#import "FirebaseAuth/Sources/Public/FIREmailAuthProvider.h"
+#import "FirebaseAuth/Sources/Public/FIRFacebookAuthProvider.h"
+#import "FirebaseAuth/Sources/Public/FIRGoogleAuthProvider.h"
+#import "FirebaseAuth/Sources/Public/FIROAuthProvider.h"
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "GoogleUtilities/AppDelegateSwizzler/Private/GULAppDelegateSwizzler.h"
 #import "Interop/Auth/Public/FIRAuthInterop.h"
@@ -63,9 +63,9 @@
 #import "FirebaseAuth/Tests/Unit/OCMStubRecorder+FIRAuthUnitTests.h"
 
 #if TARGET_OS_IOS
-#import <FirebaseAuth/FIRAuthUIDelegate.h>
-#import <FirebaseAuth/FIRPhoneAuthCredential.h>
-#import <FirebaseAuth/FIRPhoneAuthProvider.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthUIDelegate.h"
+#import "FirebaseAuth/Sources/Public/FIRPhoneAuthCredential.h"
+#import "FirebaseAuth/Sources/Public/FIRPhoneAuthProvider.h"
 
 #import "FirebaseAuth/Sources/SystemService/FIRAuthAPNSToken.h"
 #import "FirebaseAuth/Sources/SystemService/FIRAuthAPNSTokenManager.h"

--- a/FirebaseAuth/Tests/Unit/FIRAuthURLPresenterTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthURLPresenterTests.m
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthUIDelegate.h>
 #import <Foundation/Foundation.h>
 #import <OCMock/OCMock.h>
 #import <SafariServices/SafariServices.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthUIDelegate.h"
 
 #import "FirebaseAuth/Sources/Utilities/FIRAuthURLPresenter.h"
 #import "FirebaseAuth/Sources/Utilities/FIRAuthWebViewController.h"

--- a/FirebaseAuth/Tests/Unit/FIRAuthUseUserAccessGroupTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthUseUserAccessGroupTests.m
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FirebaseAuth.h>
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FirebaseAuth.h"
 
 #import "FirebaseAuth/Sources/SystemService/FIRAuthStoredUserManager.h"
 #import "FirebaseAuth/Tests/Unit/FIRApp+FIRAuthUnitTests.h"

--- a/FirebaseAuth/Tests/Unit/FIRCreateAuthURIRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRCreateAuthURIRequestTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRCreateAuthURIRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRCreateAuthURIResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRCreateAuthURIResponseTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRCreateAuthURIRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRDeleteAccountRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRDeleteAccountRequestTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRDeleteAccountRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRDeleteAccountResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRDeleteAccountResponseTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRDeleteAccountRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIREmailLinkRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIREmailLinkRequestTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIREmailLinkSignInRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIREmailLinkSignInResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIREmailLinkSignInResponseTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIREmailLinkSignInRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRGetAccountInfoResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGetAccountInfoResponseTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRGetAccountInfoRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRGetOOBConfirmationCodeRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGetOOBConfirmationCodeRequestTests.m
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRActionCodeSettings.h>
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRActionCodeSettings.h"
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRGetOOBConfirmationCodeResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGetOOBConfirmationCodeResponseTests.m
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRActionCodeSettings.h>
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRActionCodeSettings.h"
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRGetProjectConfigResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGetProjectConfigResponseTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRGetProjectConfigRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRGitHubAuthProviderTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRGitHubAuthProviderTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRGitHubAuthProvider.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRGitHubAuthProvider.h"
 
 #import "FirebaseAuth/Sources/AuthProvider/FIRAuthCredential_Internal.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyAssertionRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIROAuthProviderTests.m
+++ b/FirebaseAuth/Tests/Unit/FIROAuthProviderTests.m
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
-#import <FirebaseAuth/FIRAuthUIDelegate.h>
-#import <FirebaseAuth/FIROAuthProvider.h>
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
+#import "FirebaseAuth/Sources/Public/FIRAuthUIDelegate.h"
+#import "FirebaseAuth/Sources/Public/FIROAuthProvider.h"
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 
 #import "FirebaseAuth/Sources/Auth/FIRAuthGlobalWorkQueue.h"

--- a/FirebaseAuth/Tests/Unit/FIRPhoneAuthProviderTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRPhoneAuthProviderTests.m
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuth.h>
-#import <FirebaseAuth/FIRAuthSettings.h>
-#import <FirebaseAuth/FIRAuthUIDelegate.h>
-#import <FirebaseAuth/FIRPhoneAuthProvider.h>
 #import <OCMock/OCMock.h>
 #import <SafariServices/SafariServices.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuth.h"
+#import "FirebaseAuth/Sources/Public/FIRAuthSettings.h"
+#import "FirebaseAuth/Sources/Public/FIRAuthUIDelegate.h"
+#import "FirebaseAuth/Sources/Public/FIRPhoneAuthProvider.h"
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 
 #import "FirebaseAuth/Sources/Auth/FIRAuthGlobalWorkQueue.h"

--- a/FirebaseAuth/Tests/Unit/FIRResetPasswordRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRResetPasswordRequestTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRResetPasswordRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRResetPasswordResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRResetPasswordResponseTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRResetPasswordRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRSendVerificationCodeResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRSendVerificationCodeResponseTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRSendVerificationCodeRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRSetAccountInfoRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRSetAccountInfoRequestTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRSetAccountInfoRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRSetAccountInfoResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRSetAccountInfoResponseTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRSetAccountInfoRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRSignUpNewUserRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRSignUpNewUserRequestTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeResponse.h"

--- a/FirebaseAuth/Tests/Unit/FIRSignUpNewUserResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRSignUpNewUserResponseTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRSignUpNewUserRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRTwitterAuthProviderTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRTwitterAuthProviderTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRTwitterAuthProvider.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRTwitterAuthProvider.h"
 
 #import "FirebaseAuth/Sources/AuthProvider/FIRAuthCredential_Internal.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyAssertionRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRUserTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRUserTests.m
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthTokenResult.h>
-#import <FirebaseAuth/FIREmailAuthProvider.h>
-#import <FirebaseAuth/FIRFacebookAuthProvider.h>
-#import <FirebaseAuth/FIRGoogleAuthProvider.h>
-#import <FirebaseAuth/FIRUserInfo.h>
-#import <FirebaseAuth/FIRUserMetadata.h>
 #import <Foundation/Foundation.h>
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthTokenResult.h"
+#import "FirebaseAuth/Sources/Public/FIREmailAuthProvider.h"
+#import "FirebaseAuth/Sources/Public/FIRFacebookAuthProvider.h"
+#import "FirebaseAuth/Sources/Public/FIRGoogleAuthProvider.h"
+#import "FirebaseAuth/Sources/Public/FIRUserInfo.h"
+#import "FirebaseAuth/Sources/Public/FIRUserMetadata.h"
 
 #import "FirebaseAuth/Sources/Auth/FIRAuthGlobalWorkQueue.h"
 #import "FirebaseAuth/Sources/Auth/FIRAuthOperationType.h"
@@ -50,7 +50,7 @@
 #import "FirebaseAuth/Tests/Unit/OCMStubRecorder+FIRAuthUnitTests.h"
 
 #if TARGET_OS_IOS
-#import <FirebaseAuth/FIRPhoneAuthProvider.h>
+#import "FirebaseAuth/Sources/Public/FIRPhoneAuthProvider.h"
 
 #import "FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthCredential_Internal.h"
 #endif

--- a/FirebaseAuth/Tests/Unit/FIRVerifyAssertionRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyAssertionRequestTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeResponse.h"

--- a/FirebaseAuth/Tests/Unit/FIRVerifyAssertionResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyAssertionResponseTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeResponse.h"

--- a/FirebaseAuth/Tests/Unit/FIRVerifyClientResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyClientResponseTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyClientRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRVerifyCustomTokenRequestTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyCustomTokenRequestTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRGetOOBConfirmationCodeResponse.h"

--- a/FirebaseAuth/Tests/Unit/FIRVerifyCustomTokenResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyCustomTokenResponseTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyCustomTokenRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRVerifyPasswordRequestTest.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyPasswordRequestTest.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRVerifyPasswordResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyPasswordResponseTests.m
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"
 #import "FirebaseAuth/Sources/Backend/RPC/FIRVerifyPasswordRequest.h"

--- a/FirebaseAuth/Tests/Unit/FIRVerifyPhoneNumberResponseTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRVerifyPhoneNumberResponseTests.m
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#import <FirebaseAuth/FIRAuthErrors.h>
 #import <XCTest/XCTest.h>
+#import "FirebaseAuth/Sources/Public/FIRAuthErrors.h"
 
 #import "FirebaseAuth/Sources/Auth/FIRAuthOperationType.h"
 #import "FirebaseAuth/Sources/AuthProvider/Phone/FIRPhoneAuthCredential_Internal.h"

--- a/Package.swift
+++ b/Package.swift
@@ -39,10 +39,10 @@ let package = Package(
       name: "FirebaseCore",
       targets: ["FirebaseCore"]
     ),
-    // .library(
-    //   name: "FirebaseAuth",
-    //   targets: ["FirebaseAuth"]
-    // ),
+    .library(
+      name: "FirebaseAuth",
+      targets: ["FirebaseAuth"]
+    ),
     // .library(
     //   name: "FirebaseCrashlytics",
     //   targets: ["FirebaseCrashlytics"]
@@ -80,7 +80,8 @@ let package = Package(
     .target(
       name: "firebase-test",
       dependencies: [
-        // "FirebaseAuth", "FirebaseFunctions",
+        "FirebaseAuth",
+        // "FirebaseFunctions",
         //  "Firebase",
         "FirebaseCore",
         "FirebaseInstallations",
@@ -205,23 +206,20 @@ let package = Package(
         // TODO: - Add support for cflags cSetting so that we can set the -fno-autolink option
       ]
     ),
-//     .target(
-//       name: "FirebaseAuth",
-//       dependencies: ["FirebaseCore", "GoogleUtilities_Environment",
-//                      "GoogleUtilities_AppDelegateSwizzler",
-//                      "GTMSessionFetcherCore"],
-//       path: "FirebaseAuth/Sources",
-//       publicHeadersPath: "Public",
-//       cSettings: [
-//         .headerSearchPath("../../"),
-//         .define("FIRAuth_VERSION", to: "0.0.1"), // TODO: Fix version
-//         .define("FIRAuth_MINOR_VERSION", to: "1.1"), // TODO: Fix version
-    // //        .define("DEBUG", .when(configuration: .debug)), // TODO - destroys other settings in DEBUG config
-//         // linkerSettings: [
-//         //   .linkedFramework("Security"),
-//         //  .linkedFramework("SafariServices", .when(platforms: [.iOS])),
-//       ]
-//    ),
+    .target(
+      name: "FirebaseAuth",
+      dependencies: ["FirebaseCore",
+                     "GoogleUtilities_Environment",
+                     "GoogleUtilities_AppDelegateSwizzler",
+                     "GTMSessionFetcherCore"],
+      path: "FirebaseAuth/Sources",
+      publicHeadersPath: "Public",
+      cSettings: [
+        .headerSearchPath("../../"),
+        .define("FIRAuth_VERSION", to: "0.0.1"), // TODO: Fix version
+        .define("FIRAuth_MINOR_VERSION", to: "1.1"), // TODO: Fix version
+      ]
+    ),
 //     .target(
 //       name: "FirebaseFunctions",
 //       dependencies: ["FirebaseCore", "GTMSessionFetcher_Core"],

--- a/Sources/firebase-test/main.swift
+++ b/Sources/firebase-test/main.swift
@@ -15,7 +15,7 @@
 import Foundation
 // import Firebase
 import FirebaseCore
-// import FirebaseAuth
+import FirebaseAuth
 // import FirebaseFunctions
 import FirebaseInstallations
 // import FirebaseInstanceID
@@ -39,7 +39,6 @@ print("Is this the simulator? Answer: \(GULAppEnvironmentUtil.isSimulator())")
 print("Device model? Answer: \(GULAppEnvironmentUtil.deviceModel() ?? "NONE")")
 print("System version? Answer: \(GULAppEnvironmentUtil.systemVersion() ?? "NONE")")
 print("Is App extension? Answer: \(GULAppEnvironmentUtil.isAppExtension())")
-print("Is iOS 7 or higher? Answer: \(GULAppEnvironmentUtil.isIOS7OrHigher())")
 
 print("Is there a default app? Answer: \(FirebaseApp.app() != nil)")
 // print("Storage Version String? Answer: \(String(cString: StorageVersionString))")

--- a/scripts/change_headers.swift
+++ b/scripts/change_headers.swift
@@ -20,7 +20,7 @@
 import Foundation
 
 // Update with directories in which to find headers.
-let findHeaders = ["FirebaseStorage"]
+let findHeaders = ["FirebaseAuth"]
 
 // Update with directories in which to change imports.
 let changeImports = ["GoogleUtilities", "FirebaseAuth", "FirebaseCore", "Firebase",
@@ -30,9 +30,9 @@ let changeImports = ["GoogleUtilities", "FirebaseAuth", "FirebaseCore", "Firebas
 
 // Skip these directories. Imports should only be repo-relative in libraries
 // and unit tests.
-let skipDirPatterns = ["/Sample/", "/Pods/", "FirebaseABTesting/Tests/Integration",
+let skipDirPatterns = ["/Sample/", "/Pods/", "Tests/Integration",
                        "FirebaseInAppMessaging/Tests/Integration/", "Example/Database/App",
-                       "Example/InstanceID/App"]
+                       "Example/InstanceID/App", ".build/"]
 
 // Get a Dictionary mapping a simple header name to a repo-relative path.
 

--- a/scripts/check_imports.swift
+++ b/scripts/check_imports.swift
@@ -36,7 +36,6 @@ let skipDirPatterns = ["/Sample/", "/Pods/", "/Tests/Integration",
   [
     "FirebaseABTesting",
     "FirebaseAppDistribution",
-    "FirebaseAuth",
     "FirebaseCore/Sources/Private", // Fixes require breaking private API changes. For Firebase 7.
     "FirebaseDynamicLinks",
     "Firebase/CoreDiagnostics",

--- a/scripts/check_no_module_imports.sh
+++ b/scripts/check_no_module_imports.sh
@@ -29,6 +29,7 @@ function exit_with_error {
 
 git grep "${options[@]}" \
   -- ':(exclude,glob)**/Example/**' ':(exclude,glob)**/Sample/**' \
+     ':(exclude)FirebaseAuth/Sources/Backend/FIRAuthBackend.m' \
      ':(exclude)FirebaseCore/Sources/Private/FirebaseCoreInternal.h' \
      ':(exclude)FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h' \
      ':(exclude,glob)FirebaseStorage/**' \


### PR DESCRIPTION
- Run ./scripts/change_headers.swift to update all Auth library and unit tests to be repo-relative
- Fix an exposed integration test build failure from importing internal headers
- Turn on Swift Package Manager build and CI

#no-changelog - Will be part of a global M74 changelog