### PR TITLE
Functions: Repo-relative headers and SPM

### DIFF
--- a/Functions/Example/IntegrationTests/FIRIntegrationTests.m
+++ b/Functions/Example/IntegrationTests/FIRIntegrationTests.m
@@ -17,11 +17,11 @@
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 
 #import "FIRAuthInteropFake.h"
-#import "FIRError.h"
-#import "FIRFunctions+Internal.h"
-#import "FIRFunctions.h"
-#import "FIRHTTPSCallable.h"
-#import "FUNFakeInstanceID.h"
+#import "Functions/Example/TestUtils/FUNFakeInstanceID.h"
+#import "Functions/FirebaseFunctions/FIRFunctions+Internal.h"
+#import "Functions/FirebaseFunctions/Public/FIRError.h"
+#import "Functions/FirebaseFunctions/Public/FIRFunctions.h"
+#import "Functions/FirebaseFunctions/Public/FIRHTTPSCallable.h"
 
 // Project ID used by these tests.
 static NSString *const kDefaultProjectID = @"functions-integration-test";

--- a/Functions/Example/TestUtils/FUNFakeInstanceID.m
+++ b/Functions/Example/TestUtils/FUNFakeInstanceID.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import "FUNFakeInstanceID.h"
+#import "Functions/Example/TestUtils/FUNFakeInstanceID.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Functions/Example/Tests/FIRFunctionsTests.m
+++ b/Functions/Example/Tests/FIRFunctionsTests.m
@@ -14,8 +14,8 @@
 
 #import <XCTest/XCTest.h>
 
-#import "FIRFunctions+Internal.h"
-#import "FIRFunctions.h"
+#import "Functions/FirebaseFunctions/FIRFunctions+Internal.h"
+#import "Functions/FirebaseFunctions/Public/FIRFunctions.h"
 
 @interface FIRFunctionsTests : XCTestCase
 @end

--- a/Functions/Example/Tests/FUNContextProviderTests.m
+++ b/Functions/Example/Tests/FUNContextProviderTests.m
@@ -15,7 +15,7 @@
 #import <XCTest/XCTest.h>
 
 #import "FIRAuthInteropFake.h"
-#import "FUNContext.h"
+#import "Functions/FirebaseFunctions/FUNContext.h"
 
 @interface FUNContextProviderTests : XCTestCase
 @end

--- a/Functions/Example/Tests/FUNSerializerTests.m
+++ b/Functions/Example/Tests/FUNSerializerTests.m
@@ -14,8 +14,8 @@
 
 #import <XCTest/XCTest.h>
 
-#import "FIRError.h"
-#import "FUNSerializer.h"
+#import "Functions/FirebaseFunctions/FUNSerializer.h"
+#import "Functions/FirebaseFunctions/Public/FIRError.h"
 
 @interface FUNSerializerTests : XCTestCase
 @end

--- a/Functions/FirebaseFunctions/FIRFunctions+Internal.h
+++ b/Functions/FirebaseFunctions/FIRFunctions+Internal.h
@@ -14,7 +14,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "FIRFunctions.h"
+#import "Functions/FirebaseFunctions/Public/FIRFunctions.h"
 
 @protocol FIRAuthInterop;
 @class FIRHTTPSCallableResult;

--- a/Functions/FirebaseFunctions/FIRFunctions.m
+++ b/Functions/FirebaseFunctions/FIRFunctions.m
@@ -12,21 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "FIRFunctions.h"
-#import "FIRFunctions+Internal.h"
+#import "Functions/FirebaseFunctions/Public/FIRFunctions.h"
+#import "Functions/FirebaseFunctions/FIRFunctions+Internal.h"
 
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "Interop/Auth/Public/FIRAuthInterop.h"
 
-#import "FIRError.h"
-#import "FIRHTTPSCallable+Internal.h"
-#import "FIRHTTPSCallable.h"
-#import "FUNContext.h"
-#import "FUNError.h"
-#import "FUNSerializer.h"
-#import "FUNUsageValidation.h"
+#import "Functions/FirebaseFunctions/FIRHTTPSCallable+Internal.h"
+#import "Functions/FirebaseFunctions/FUNContext.h"
+#import "Functions/FirebaseFunctions/FUNError.h"
+#import "Functions/FirebaseFunctions/FUNSerializer.h"
+#import "Functions/FirebaseFunctions/FUNUsageValidation.h"
+#import "Functions/FirebaseFunctions/Public/FIRError.h"
+#import "Functions/FirebaseFunctions/Public/FIRHTTPSCallable.h"
 
+#if SWIFT_PACKAGE
+@import GTMSessionFetcherCore;
+#else
 #import <GTMSessionFetcher/GTMSessionFetcherService.h>
+#endif
 
 // The following two macros supply the incantation so that the C
 // preprocessor does not try to parse the version as a floating

--- a/Functions/FirebaseFunctions/FIRHTTPSCallable+Internal.h
+++ b/Functions/FirebaseFunctions/FIRHTTPSCallable+Internal.h
@@ -14,7 +14,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "FIRHTTPSCallable.h"
+#import "Functions/FirebaseFunctions/Public/FIRHTTPSCallable.h"
 
 @class FIRFunctions;
 

--- a/Functions/FirebaseFunctions/FIRHTTPSCallable.m
+++ b/Functions/FirebaseFunctions/FIRHTTPSCallable.m
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "FIRHTTPSCallable.h"
-#import "FIRHTTPSCallable+Internal.h"
+#import "Functions/FirebaseFunctions/Public/FIRHTTPSCallable.h"
+#import "Functions/FirebaseFunctions/FIRHTTPSCallable+Internal.h"
 
-#import "FIRFunctions+Internal.h"
-#import "FUNUsageValidation.h"
+#import "Functions/FirebaseFunctions/FIRFunctions+Internal.h"
+#import "Functions/FirebaseFunctions/FUNUsageValidation.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Functions/FirebaseFunctions/FUNContext.m
+++ b/Functions/FirebaseFunctions/FUNContext.m
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "FUNContext.h"
+#import "Functions/FirebaseFunctions/FUNContext.h"
 
 #import "Interop/Auth/Public/FIRAuthInterop.h"
 
-#import "FUNInstanceIDProxy.h"
+#import "Functions/FirebaseFunctions/FUNInstanceIDProxy.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Functions/FirebaseFunctions/FUNError.h
+++ b/Functions/FirebaseFunctions/FUNError.h
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 #import <Foundation/Foundation.h>
-#import "FIRError.h"
+#import "Functions/FirebaseFunctions/Public/FIRError.h"
 
 @class FUNSerializer;
 

--- a/Functions/FirebaseFunctions/FUNError.m
+++ b/Functions/FirebaseFunctions/FUNError.m
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "FUNError.h"
+#import "Functions/FirebaseFunctions/FUNError.h"
 
-#import "FUNSerializer.h"
+#import "Functions/FirebaseFunctions/FUNSerializer.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Functions/FirebaseFunctions/FUNInstanceIDProxy.m
+++ b/Functions/FirebaseFunctions/FUNInstanceIDProxy.m
@@ -16,7 +16,7 @@
 
 // Note: This is forked from FIRMessagingInstanceIDProxy.m
 
-#import "FUNInstanceIDProxy.h"
+#import "Functions/FirebaseFunctions/FUNInstanceIDProxy.h"
 
 @implementation FUNInstanceIDProxy
 

--- a/Functions/FirebaseFunctions/FUNSerializer.m
+++ b/Functions/FirebaseFunctions/FUNSerializer.m
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "FUNSerializer.h"
+#import "Functions/FirebaseFunctions/FUNSerializer.h"
 
-#import "FIRError.h"
-#import "FUNUsageValidation.h"
+#import "Functions/FirebaseFunctions/FUNUsageValidation.h"
+#import "Functions/FirebaseFunctions/Public/FIRError.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Functions/FirebaseFunctions/FUNUsageValidation.m
+++ b/Functions/FirebaseFunctions/FUNUsageValidation.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "FUNUsageValidation.h"
+#import "Functions/FirebaseFunctions/FUNUsageValidation.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Package.swift
+++ b/Package.swift
@@ -47,9 +47,10 @@ let package = Package(
     //   name: "FirebaseCrashlytics",
     //   targets: ["FirebaseCrashlytics"]
     // ),
-    // .library(
-    //   name: "FirebaseFunctions",
-    //   targets: ["FirebaseFunctions"]),
+    .library(
+      name: "FirebaseFunctions",
+      targets: ["FirebaseFunctions"]
+    ),
     .library(
       name: "FirebaseInstallations",
       targets: ["FirebaseInstallations"]
@@ -81,7 +82,7 @@ let package = Package(
       name: "firebase-test",
       dependencies: [
         "FirebaseAuth",
-        // "FirebaseFunctions",
+        "FirebaseFunctions",
         //  "Firebase",
         "FirebaseCore",
         "FirebaseInstallations",
@@ -220,17 +221,17 @@ let package = Package(
         .define("FIRAuth_MINOR_VERSION", to: "1.1"), // TODO: Fix version
       ]
     ),
-//     .target(
-//       name: "FirebaseFunctions",
-//       dependencies: ["FirebaseCore", "GTMSessionFetcher_Core"],
-//       path: "Functions/FirebaseFunctions",
-//       publicHeadersPath: "Public",
-//       cSettings: [
-//          // SPM doesn't support interface frameworks or private headers
-//         .headerSearchPath("../../"),
-//         .define("FIRFunctions_VERSION", to: "0.0.1"),  // TODO Fix version
-//         .define("SWIFT_PACKAGE", to: "1"),  // SPM loses defaults if other cSettings
-//       ]),
+    .target(
+      name: "FirebaseFunctions",
+      dependencies: ["FirebaseCore", "GTMSessionFetcherCore"],
+      path: "Functions/FirebaseFunctions",
+      publicHeadersPath: "Public",
+      cSettings: [
+        .headerSearchPath("../../"),
+        .define("FIRFunctions_VERSION", to: "0.0.1"), // TODO: Fix version
+        .define("SWIFT_PACKAGE", to: "1"), // SPM loses defaults if other cSettings
+      ]
+    ),
     // .target(
     //   name: "FirebaseInstanceID",
     //   dependencies: ["FirebaseCore", "FirebaseInstallations",

--- a/Package.swift
+++ b/Package.swift
@@ -229,7 +229,6 @@ let package = Package(
       cSettings: [
         .headerSearchPath("../../"),
         .define("FIRFunctions_VERSION", to: "0.0.1"), // TODO: Fix version
-        .define("SWIFT_PACKAGE", to: "1"), // SPM loses defaults if other cSettings
       ]
     ),
     // .target(

--- a/Sources/firebase-test/main.swift
+++ b/Sources/firebase-test/main.swift
@@ -16,7 +16,7 @@ import Foundation
 // import Firebase
 import FirebaseCore
 import FirebaseAuth
-// import FirebaseFunctions
+import FirebaseFunctions
 import FirebaseInstallations
 // import FirebaseInstanceID
 import FirebaseStorage

--- a/scripts/change_headers.swift
+++ b/scripts/change_headers.swift
@@ -20,19 +20,19 @@
 import Foundation
 
 // Update with directories in which to find headers.
-let findHeaders = ["FirebaseAuth"]
+let findHeaders = ["Functions"]
 
 // Update with directories in which to change imports.
 let changeImports = ["GoogleUtilities", "FirebaseAuth", "FirebaseCore", "Firebase",
                      "FirebaseDynamicLinks", "FirebaseInAppMessaging", "FirebaseMessaging",
-                     "FirebaseRemoteConfig", "FirebaseInstallations",
+                     "FirebaseRemoteConfig", "FirebaseInstallations", "Functions",
                      "FirebaseAppDistribution", "Example", "Crashlytics", "FirebaseStorage"]
 
 // Skip these directories. Imports should only be repo-relative in libraries
 // and unit tests.
 let skipDirPatterns = ["/Sample/", "/Pods/", "Tests/Integration",
                        "FirebaseInAppMessaging/Tests/Integration/", "Example/Database/App",
-                       "Example/InstanceID/App", ".build/"]
+                       "Example/InstanceID/App", ".build/", "Functions/Example/FirebaseFunctions"]
 
 // Get a Dictionary mapping a simple header name to a repo-relative path.
 

--- a/scripts/check_imports.swift
+++ b/scripts/check_imports.swift
@@ -48,7 +48,6 @@ let skipDirPatterns = ["/Sample/", "/Pods/", "/Tests/Integration",
     "FirebaseRemoteConfig",
     "Crashlytics",
     "Firestore",
-    "Functions",
     "GoogleDataTransport",
     "GoogleUtilitiesComponents",
   ]

--- a/scripts/check_no_module_imports.sh
+++ b/scripts/check_no_module_imports.sh
@@ -33,6 +33,7 @@ git grep "${options[@]}" \
      ':(exclude)FirebaseCore/Sources/Private/FirebaseCoreInternal.h' \
      ':(exclude)FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h' \
      ':(exclude,glob)FirebaseStorage/**' \
+     ':(exclude)Functions/FirebaseFunctions/FIRFunctions.m' \
      ':(exclude)GoogleUtilities/NSData+zlib/Private/GULNSDataInternal.h' \
      ':(exclude)GoogleUtilities/Logger/Private/GULLogger.h' \
      ':(exclude)HeadersImports.md' && exit_with_error


### PR DESCRIPTION
- Run ./scripts/change_headers.swift to update all Functions library and unit tests to be repo-relative
- Turn on Swift Package Manager build and CI

#no-changelog - Will be part of a global M74 changelog