### PR TITLE
Crashlytics: Add dispatch_once for opening sdk log file

### DIFF
--- a/Crashlytics/Crashlytics/Helpers/FIRCLSInternalLogging.c
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSInternalLogging.c
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <dispatch/dispatch.h>
+
 #include "FIRCLSInternalLogging.h"
 #include "FIRCLSContext.h"
 #include "FIRCLSGlobals.h"
@@ -31,9 +33,12 @@ void FIRCLSSDKFileLog(FIRCLSInternalLogLevel level, const char* format, ...) {
     return;
   }
 
-  if (_firclsContext.writable->internalLogging.logFd == -1) {
-    _firclsContext.writable->internalLogging.logFd = open(path, O_WRONLY | O_CREAT | O_APPEND, 0644);
-  }
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    if (_firclsContext.writable->internalLogging.logFd == -1) {
+      _firclsContext.writable->internalLogging.logFd = open(path, O_WRONLY | O_CREAT | O_APPEND, 0644);
+    }
+  });
 
   const int fd = _firclsContext.writable->internalLogging.logFd;
   if (fd < 0) {


### PR DESCRIPTION
Resolves #5903 

I had a more complicated change earlier, but settled on this. The file is never closed, so this will work, and should be better than using a queue or semaphore.