### PR TITLE
Fix Import of FirebaseInstallationsInternal to use public header

### DIFF
--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -42,7 +42,7 @@
 #import "FIRCLSReportManager.h"
 
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
-#import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
+#import "FirebaseInstallations/Source/Library/Public/FirebaseInstallations.h"
 #import "Interop/Analytics/Public/FIRAnalyticsInterop.h"
 
 #import "GoogleDataTransport/GDTCORLibrary/Internal/GoogleDataTransportInternal.h"

--- a/Crashlytics/Crashlytics/Models/FIRCLSInstallIdentifierModel.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSInstallIdentifierModel.m
@@ -14,7 +14,7 @@
 
 #import "FIRCLSInstallIdentifierModel.h"
 
-#import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
+#import "FirebaseInstallations/Source/Library/Public/FirebaseInstallations.h"
 
 #import "FIRCLSByteUtility.h"
 #import "FIRCLSLogger.h"

--- a/Crashlytics/UnitTests/Mocks/FIRCLSMockReportManager.m
+++ b/Crashlytics/UnitTests/Mocks/FIRCLSMockReportManager.m
@@ -18,7 +18,7 @@
 #import "FIRCLSMockNetworkClient.h"
 #import "FIRCLSMockReportUploader.h"
 
-#import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
+#import "FirebaseInstallations/Source/Library/Public/FirebaseInstallations.h"
 
 @interface FIRCLSMockReportManager () {
   FIRCLSMockReportUploader *_uploader;

--- a/Crashlytics/UnitTests/Mocks/FIRMockInstallations.h
+++ b/Crashlytics/UnitTests/Mocks/FIRMockInstallations.h
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
+#import "FirebaseInstallations/Source/Library/Public/FirebaseInstallations.h"
 
 @interface FIRMockInstallations : FIRInstallations
 

--- a/Example/InstanceID/Tests/FIRInstanceIDTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTest.m
@@ -16,7 +16,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
+#import "FirebaseInstallations/Source/Library/Public/FirebaseInstallations.h"
 
 #import <FirebaseInstanceID/FIRInstanceID_Private.h>
 #import <OCMock/OCMock.h>

--- a/Example/InstanceID/Tests/FIRInstanceIDTokenManagerTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTokenManagerTest.m
@@ -18,7 +18,7 @@
 
 #import <OCMock/OCMock.h>
 
-#import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
+#import "FirebaseInstallations/Source/Library/Public/FirebaseInstallations.h"
 
 #import "FIRInstanceIDFakeKeychain.h"
 #import "FIRInstanceIDTokenManager+Test.h"

--- a/Example/InstanceID/Tests/FIRInstanceIDTokenOperationsTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTokenOperationsTest.m
@@ -33,7 +33,7 @@
 #import "Firebase/InstanceID/NSError+FIRInstanceID.h"
 
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
-#import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
+#import "FirebaseInstallations/Source/Library/Public/FirebaseInstallations.h"
 #import "GoogleUtilities/Environment/Private/GULHeartbeatDateStorage.h"
 
 static NSString *kDeviceID = @"fakeDeviceID";

--- a/Firebase/InstanceID/FIRInstanceID+Private.m
+++ b/Firebase/InstanceID/FIRInstanceID+Private.m
@@ -16,7 +16,7 @@
 
 #import "FIRInstanceID+Private.h"
 
-#import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
+#import "FirebaseInstallations/Source/Library/Public/FirebaseInstallations.h"
 
 #import <FirebaseInstanceID/FIRInstanceID_Private.h>
 #import "FIRInstanceIDAuthService.h"

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -16,7 +16,7 @@
 
 #import "FIRInstanceID.h"
 
-#import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
+#import "FirebaseInstallations/Source/Library/Public/FirebaseInstallations.h"
 
 #import "FIRInstanceID+Private.h"
 #import "FIRInstanceIDAuthService.h"

--- a/Firebase/InstanceID/FIRInstanceIDTokenOperation.m
+++ b/Firebase/InstanceID/FIRInstanceIDTokenOperation.m
@@ -16,7 +16,7 @@
 
 #import "FIRInstanceIDTokenOperation.h"
 
-#import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
+#import "FirebaseInstallations/Source/Library/Public/FirebaseInstallations.h"
 
 #import "FIRInstanceIDCheckinPreferences.h"
 #import "FIRInstanceIDLogger.h"

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
     'Crashlytics/Shared/**/*.{c,h,m,mm}',
     'Crashlytics/third_party/**/*.{c,h,m,mm}',
     'FirebaseCore/Sources/Private/*.h',
-    'FirebaseInstallations/Source/Private/*.h',
+    'FirebaseInstallations/Source/Public/*.h',
     'GoogleDataTransport/GDTCORLibrary/Internal/*.h',
     'Interop/Analytics/Public/*.h',
   ]

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
     'Crashlytics/Shared/**/*.{c,h,m,mm}',
     'Crashlytics/third_party/**/*.{c,h,m,mm}',
     'FirebaseCore/Sources/Private/*.h',
-    'FirebaseInstallations/Source/Public/*.h',
+    'FirebaseInstallations/Source/Library/Public/*.h',
     'GoogleDataTransport/GDTCORLibrary/Internal/*.h',
     'Interop/Analytics/Public/*.h',
   ]

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -28,7 +28,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
     base_dir + "Sources/**/*.[cmh]",
     'Interop/Analytics/Public/*.h',
     'FirebaseCore/Sources/Private/*.h',
-    'FirebaseInstallations/Source/Private/*.h',
+    'FirebaseInstallations/Source/Public/*.h',
     'GoogleUtilities/Environment/Private/*.h',
   ]
   s.public_header_files = base_dir + 'Sources/Public/*.h'

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -28,7 +28,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
     base_dir + "Sources/**/*.[cmh]",
     'Interop/Analytics/Public/*.h',
     'FirebaseCore/Sources/Private/*.h',
-    'FirebaseInstallations/Source/Public/*.h',
+    'FirebaseInstallations/Source/Library/Public/*.h',
     'GoogleUtilities/Environment/Private/*.h',
   ]
   s.public_header_files = base_dir + 'Sources/Public/*.h'

--- a/FirebaseInAppMessaging/Sources/FIRInAppMessaging.m
+++ b/FirebaseInAppMessaging/Sources/FIRInAppMessaging.m
@@ -19,7 +19,7 @@
 #import <Foundation/Foundation.h>
 
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
-#import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
+#import "FirebaseInstallations/Source/Library/Public/FirebaseInstallations.h"
 #import "Interop/Analytics/Public/FIRAnalyticsInterop.h"
 
 #import "FIRCore+InAppMessaging.h"

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMClientInfoFetcher.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMClientInfoFetcher.m
@@ -15,7 +15,7 @@
  */
 
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
-#import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
+#import "FirebaseInstallations/Source/Library/Public/FirebaseInstallations.h"
 
 #import "FIRCore+InAppMessaging.h"
 #import "FIRIAMClientInfoFetcher.h"

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMClientInfoFetcherTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMClientInfoFetcherTests.m
@@ -20,7 +20,7 @@
 #import "FIRIAMClientInfoFetcher.h"
 #import "FIRIAMSDKRuntimeErrorCodes.h"
 
-#import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
+#import "FirebaseInstallations/Source/Library/Public/FirebaseInstallations.h"
 
 @interface FIRInstallationsAuthTokenResult (Tests)
 - (instancetype)initWithToken:(NSString *)token expirationDate:(NSDate *)expirationDate;

--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -31,7 +31,7 @@ services.
   s.source_files = [
     base_dir + '**/*.[mh]',
     'FirebaseCore/Sources/Private/*.h',
-    'FirebaseInstallations/Source/Private/*.h',
+    'FirebaseInstallations/Source/Public/*.h',
     'GoogleUtilities/Environment/Private/*.h',
     'GoogleUtilities/UserDefaults/Private/*.h',
   ]

--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -31,7 +31,7 @@ services.
   s.source_files = [
     base_dir + '**/*.[mh]',
     'FirebaseCore/Sources/Private/*.h',
-    'FirebaseInstallations/Source/Public/*.h',
+    'FirebaseInstallations/Source/Library/Public/*.h',
     'GoogleUtilities/Environment/Private/*.h',
     'GoogleUtilities/UserDefaults/Private/*.h',
   ]

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -33,7 +33,7 @@ device, and it is completely free.
     base_dir + 'Sources/**/*.[mh]',
     'Interop/Analytics/Public/*.h',
     'FirebaseCore/Sources/Private/*.h',
-    'FirebaseInstallations/Source/Public/*.h',
+    'FirebaseInstallations/Source/Library/Public/*.h',
     'GoogleUtilities/AppDelegateSwizzler/Private/*.h',
     'GoogleUtilities/Environment/Private/*.h',
     'GoogleUtilities/Reachability/Private/*.h',

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -33,7 +33,7 @@ device, and it is completely free.
     base_dir + 'Sources/**/*.[mh]',
     'Interop/Analytics/Public/*.h',
     'FirebaseCore/Sources/Private/*.h',
-    'FirebaseInstallations/Source/Private/*.h',
+    'FirebaseInstallations/Source/Public/*.h',
     'GoogleUtilities/AppDelegateSwizzler/Private/*.h',
     'GoogleUtilities/Environment/Private/*.h',
     'GoogleUtilities/Reachability/Private/*.h',

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingClientTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingClientTest.m
@@ -18,7 +18,7 @@
 #import <XCTest/XCTest.h>
 
 #import <FirebaseInstanceID/FIRInstanceID_Private.h>
-#import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
+#import "FirebaseInstallations/Source/Library/Public/FirebaseInstallations.h"
 #import "GoogleUtilities/Reachability/Private/GULReachabilityChecker.h"
 
 #import "FirebaseMessaging/Sources/FIRMessagingClient.h"

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingTestUtilities.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingTestUtilities.m
@@ -21,7 +21,7 @@
 #import "FirebaseMessaging/Tests/UnitTests/FIRMessagingTestUtilities.h"
 
 #import <FirebaseInstanceID/FirebaseInstanceID.h>
-#import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
+#import "FirebaseInstallations/Source/Library/Public/FirebaseInstallations.h"
 #import "GoogleUtilities/UserDefaults/Private/GULUserDefaults.h"
 #import "Interop/Analytics/Public/FIRAnalyticsInterop.h"
 

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -31,7 +31,7 @@ app update.
     base_dir + '**/*.[mh]',
     'Interop/Analytics/Public/*.h',
     'FirebaseCore/Sources/Private/*.h',
-    'FirebaseInstallations/Source/Public/*.h',
+    'FirebaseInstallations/Source/Library/Public/*.h',
     'GoogleUtilities/Environment/Private/*.h',
     'GoogleUtilities/NSData+zlib/Private/*.h',
   ]

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -31,7 +31,7 @@ app update.
     base_dir + '**/*.[mh]',
     'Interop/Analytics/Public/*.h',
     'FirebaseCore/Sources/Private/*.h',
-    'FirebaseInstallations/Source/Private/*.h',
+    'FirebaseInstallations/Source/Public/*.h',
     'GoogleUtilities/Environment/Private/*.h',
     'GoogleUtilities/NSData+zlib/Private/*.h',
   ]

--- a/FirebaseRemoteConfig/Sources/RCNFetch.m
+++ b/FirebaseRemoteConfig/Sources/RCNFetch.m
@@ -17,7 +17,7 @@
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h"
 
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
-#import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
+#import "FirebaseInstallations/Source/Library/Public/FirebaseInstallations.h"
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigConstants.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigContent.h"

--- a/FirebaseRemoteConfig/Tests/Unit/RCNInstanceIDTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNInstanceIDTest.m
@@ -27,7 +27,7 @@
 
 #import <OCMock/OCMock.h>
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
-#import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
+#import "FirebaseInstallations/Source/Library/Public/FirebaseInstallations.h"
 #import "GoogleUtilities/NSData+zlib/Private/GULNSDataInternal.h"
 
 @interface RCNConfigFetch (ForTest)

--- a/scripts/check_no_module_imports.sh
+++ b/scripts/check_no_module_imports.sh
@@ -31,7 +31,7 @@ git grep "${options[@]}" \
   -- ':(exclude,glob)**/Example/**' ':(exclude,glob)**/Sample/**' \
      ':(exclude)FirebaseAuth/Sources/Backend/FIRAuthBackend.m' \
      ':(exclude)FirebaseCore/Sources/Private/FirebaseCoreInternal.h' \
-     ':(exclude)FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h' \
+     ':(exclude)FirebaseInstallations/Source/Library/Public/FirebaseInstallations.h' \
      ':(exclude,glob)FirebaseStorage/**' \
      ':(exclude)Functions/FirebaseFunctions/FIRFunctions.m' \
      ':(exclude)GoogleDataTransport/GDTCORLibrary/Internal/GoogleDataTransportInternal.h' \


### PR DESCRIPTION
 - It seems the Private FirebaseInstallationsInternal.h header is gone
 - I think the methods we use moved to the public header for Crashlytics
 - This updates all references, but I haven't tested the other SDKs that I changed in this PR

#no-changelog