### PR TITLE
Update formatters

### DIFF
--- a/Example/tvOSSample/tvOSSample/AppDelegate.swift
+++ b/Example/tvOSSample/tvOSSample/AppDelegate.swift
@@ -20,7 +20,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
 
   func application(_ application: UIApplication,
-                   didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?)
+                   didFinishLaunchingWithOptions launchOptions: [
+                     UIApplicationLaunchOptionsKey: Any
+                   ]?)
     -> Bool {
     // Override point for customization after application launch.
     FirebaseApp.configure()

--- a/FirebaseAuth/Sources/User/FIRUser.m
+++ b/FirebaseAuth/Sources/User/FIRUser.m
@@ -324,7 +324,7 @@ static void callInMainThreadWithAuthDataResultAndError(
                                                  forKey:kPhoneNumberCodingKey];
   BOOL emailVerified = [aDecoder decodeBoolForKey:kEmailVerifiedCodingKey];
   NSSet *providerDataClasses =
-      [NSSet setWithArray:@ [[NSDictionary class], [NSString class], [FIRUserInfoImpl class]]];
+      [NSSet setWithArray:@[ [NSDictionary class], [NSString class], [FIRUserInfoImpl class] ]];
   NSDictionary<NSString *, FIRUserInfoImpl *> *providerData =
       [aDecoder decodeObjectOfClasses:providerDataClasses forKey:kProviderDataKey];
   FIRSecureTokenService *tokenService = [aDecoder decodeObjectOfClass:[FIRSecureTokenService class]

--- a/FirebaseCore/Tests/Unit/FIRAppTest.m
+++ b/FirebaseCore/Tests/Unit/FIRAppTest.m
@@ -88,8 +88,9 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 }
 
 - (void)testConfigure {
-  [self
-      registerLibrariesWithClasses:@ [[FIRTestClassCached class], [FIRTestClassEagerCached class]]];
+  [self registerLibrariesWithClasses:@[
+    [FIRTestClassCached class], [FIRTestClassEagerCached class]
+  ]];
 
   NSDictionary *expectedUserInfo = [self expectedUserInfoWithAppName:kFIRDefaultAppName
                                                         isDefaultApp:YES];
@@ -329,8 +330,9 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 }
 
 - (void)testDeleteApp {
-  [self
-      registerLibrariesWithClasses:@ [[FIRTestClassCached class], [FIRTestClassEagerCached class]]];
+  [self registerLibrariesWithClasses:@[
+    [FIRTestClassCached class], [FIRTestClassEagerCached class]
+  ]];
 
   NSString *name = NSStringFromSelector(_cmd);
   FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:kGoogleAppID

--- a/FirebaseCore/Tests/Unit/FIRComponentContainerTest.m
+++ b/FirebaseCore/Tests/Unit/FIRComponentContainerTest.m
@@ -71,7 +71,7 @@
 }
 
 - (void)testComponentsPopulatedOnInit {
-  FIRComponentContainer *container = [self containerWithRegistrants:@ [[FIRTestClass class]]];
+  FIRComponentContainer *container = [self containerWithRegistrants:@[ [FIRTestClass class] ]];
 
   // Verify that the block is stored.
   NSString *protocolName = NSStringFromProtocol(@protocol(FIRTestProtocol));
@@ -82,7 +82,8 @@
 #pragma mark - Caching Tests
 
 - (void)testInstanceCached {
-  FIRComponentContainer *container = [self containerWithRegistrants:@ [[FIRTestClassCached class]]];
+  FIRComponentContainer *container =
+      [self containerWithRegistrants:@[ [FIRTestClassCached class] ]];
 
   // Fetch an instance for `FIRTestProtocolCached`, then fetch it again to assert it's cached.
   id<FIRTestProtocolCached> instance1 = FIR_COMPONENT(FIRTestProtocolCached, container);
@@ -93,7 +94,7 @@
 }
 
 - (void)testInstanceNotCached {
-  FIRComponentContainer *container = [self containerWithRegistrants:@ [[FIRTestClass class]]];
+  FIRComponentContainer *container = [self containerWithRegistrants:@[ [FIRTestClass class] ]];
 
   // Retrieve an instance from the container, then fetch it again and ensure it's not the same
   // instance.
@@ -105,10 +106,10 @@
 }
 
 - (void)testRemoveAllCachedInstances {
-  FIRComponentContainer *container =
-      [self containerWithRegistrants:@ [[FIRTestClass class], [FIRTestClassCached class],
-                                        [FIRTestClassEagerCached class],
-                                        [FIRTestClassCachedWithDep class]]];
+  FIRComponentContainer *container = [self containerWithRegistrants:@[
+    [FIRTestClass class], [FIRTestClassCached class], [FIRTestClassEagerCached class],
+    [FIRTestClassCachedWithDep class]
+  ]];
 
   // Retrieve an instance of FIRTestClassCached to ensure it's cached.
   id<FIRTestProtocolCached> cachedInstance1 = FIR_COMPONENT(FIRTestProtocolCached, container);
@@ -131,10 +132,10 @@
 }
 
 - (void)testRemoveAllComponents {
-  FIRComponentContainer *container =
-      [self containerWithRegistrants:@ [[FIRTestClass class], [FIRTestClassCached class],
-                                        [FIRTestClassEagerCached class],
-                                        [FIRTestClassCachedWithDep class]]];
+  FIRComponentContainer *container = [self containerWithRegistrants:@[
+    [FIRTestClass class], [FIRTestClassCached class], [FIRTestClassEagerCached class],
+    [FIRTestClassCachedWithDep class]
+  ]];
 
   // Retrieve an instance of FIRTestClassCached to ensure it's cached.
   id<FIRTestProtocolCached> cachedInstance1 = FIR_COMPONENT(FIRTestProtocolCached, container);
@@ -167,7 +168,7 @@
   // implementation for `FIRTestProtocolEagerCached` and requires eager instantiation as well as
   // caching so the test can verify it was eagerly instantiated.
   FIRComponentContainer *container =
-      [self containerWithRegistrants:@ [[FIRTestClassEagerCached class]]];
+      [self containerWithRegistrants:@[ [FIRTestClassEagerCached class] ]];
   NSString *protocolName = NSStringFromProtocol(@protocol(FIRTestProtocolEagerCached));
   XCTAssertNotNil(container.cachedInstances[protocolName]);
 }
@@ -181,7 +182,7 @@
   // change in the future.
   // TODO(wilsonryan): Assert that the log gets called warning that it's already been registered.
   FIRComponentContainer *container =
-      [self containerWithRegistrants:@ [[FIRTestClass class], [FIRTestClassDuplicate class]]];
+      [self containerWithRegistrants:@[ [FIRTestClass class], [FIRTestClassDuplicate class] ]];
   XCTAssert(container.components.count == 1);
 }
 
@@ -190,7 +191,7 @@
 - (void)testDependencyDoesntBlock {
   /// Test a class that has a dependency, and fetching doesn't block the internal queue.
   FIRComponentContainer *container = [self
-      containerWithRegistrants:@ [[FIRTestClassCached class], [FIRTestClassCachedWithDep class]]];
+      containerWithRegistrants:@[ [FIRTestClassCached class], [FIRTestClassCachedWithDep class] ]];
   XCTAssert(container.components.count == 2);
 
   id<FIRTestProtocolCachedWithDep> instanceWithDep =
@@ -201,7 +202,7 @@
 - (void)testDependencyRemoveAllCachedInstancesDoesntBlock {
   /// Test a class that has a dependency, and fetching doesn't block the internal queue.
   FIRComponentContainer *container = [self
-      containerWithRegistrants:@ [[FIRTestClassCached class], [FIRTestClassCachedWithDep class]]];
+      containerWithRegistrants:@[ [FIRTestClassCached class], [FIRTestClassCachedWithDep class] ]];
   XCTAssert(container.components.count == 2);
 
   id<FIRTestProtocolCachedWithDep> instanceWithDep =

--- a/FirebaseDatabase/Sources/Core/FQueryParams.m
+++ b/FirebaseDatabase/Sources/Core/FQueryParams.m
@@ -358,8 +358,8 @@
         return NO;
     if (self->_limit != other->_limit)
         return NO;
-    if ((self->_index != other->_index) && !
-                                           [self->_index isEqual:other->_index])
+    if ((self->_index != other->_index) &&
+        ![self->_index isEqual:other->_index])
         return NO;
     if ((self->_indexStartKey != other->_indexStartKey) &&
         ![self->_indexStartKey isEqualToString:other->_indexStartKey])

--- a/FirebaseDatabase/Tests/Integration/FData.m
+++ b/FirebaseDatabase/Tests/Integration/FData.m
@@ -314,10 +314,9 @@ This test flakes frequently on the emulator on travis and almost always on GHA w
           ios - sdk / firebase - ios -
           sdk / Example / Database / Tests / Helpers /
               FEventTester
-                  .m : 123 because it was raised inside test case -
-              [FEventTester(
-                  null)] which has no associated XCTestRun object.This may happen when test cases
-                  are constructed and invoked independently of standard XCTest infrastructure,
+                  .m : 123 because it was raised inside test case -[FEventTester(null)] which has no
+                      associated XCTestRun object.This may happen when test cases are
+                          constructed and invoked independently of standard XCTest infrastructure,
       or when the test has already finished
                       ." - Expected http://localhost:9000/-M8IJYWb68MuqQKKz2IY/a aa (0) to match "
                        "http://localhost:9000/-M8IJYWb68MuqQKKz2IY/a (null) (4)' from "

--- a/FirebaseMessaging/Apps/Sample/Sample/SceneDelegate.swift
+++ b/FirebaseMessaging/Apps/Sample/Sample/SceneDelegate.swift
@@ -38,8 +38,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, MessagingDelegate {
       window
         .rootViewController = UIHostingController(rootView: contentView
           .environmentObject(identity)
-          .environmentObject(settings)
-        )
+          .environmentObject(settings))
 
       self.window = window
       window.makeKeyAndVisible()

--- a/FirebaseMessaging/Apps/Sample/iOS/AppDelegate.swift
+++ b/FirebaseMessaging/Apps/Sample/iOS/AppDelegate.swift
@@ -34,7 +34,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   static var hasPresentedInvalidServiceInfoPlistAlert = false
 
   func application(_ application: UIApplication,
-                   didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?)
+                   didFinishLaunchingWithOptions launchOptions: [
+                     UIApplicationLaunchOptionsKey: Any
+                   ]?)
     -> Bool {
     guard !AppDelegate.isWithinUnitTest else {
       // During unit tests, we don't want to initialize Firebase, since by default we want to able
@@ -91,7 +93,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                    didReceiveRemoteNotification userInfo: [AnyHashable: Any],
                    fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult)
                      -> Void) {
-    print("application:didReceiveRemoteNotification:fetchCompletionHandler: called, with notification:")
+    print(
+      "application:didReceiveRemoteNotification:fetchCompletionHandler: called, with notification:"
+    )
     print("\(userInfo.jsonString ?? "{}")")
     completionHandler(.newData)
   }
@@ -127,7 +131,9 @@ extension AppDelegate: MessagingDelegate {
   func messaging(_ messaging: Messaging, didReceive remoteMessage: MessagingRemoteMessage) {
     // Convert to pretty-print JSON
     guard let prettyPrinted = remoteMessage.appData.jsonString else {
-      print("Received direct channel message, but could not parse as JSON: \(remoteMessage.appData)")
+      print(
+        "Received direct channel message, but could not parse as JSON: \(remoteMessage.appData)"
+      )
       return
     }
     print("Received direct channel message:\n\(prettyPrinted)")

--- a/FirebaseRemoteConfig/Sources/RCNDevice.m
+++ b/FirebaseRemoteConfig/Sources/RCNDevice.m
@@ -224,8 +224,8 @@ BOOL FIRRemoteConfigHasDeviceContextChanged(NSDictionary *deviceContext,
   if (![deviceContext[RCNDeviceContextKeyBuild] isEqual:FIRRemoteConfigAppBuildVersion()]) {
     return YES;
   }
-  if (!
-      [deviceContext[RCNDeviceContextKeyOSVersion] isEqual:[GULAppEnvironmentUtil systemVersion]]) {
+  if (![deviceContext[RCNDeviceContextKeyOSVersion]
+          isEqual:[GULAppEnvironmentUtil systemVersion]]) {
     return YES;
   }
   if (![deviceContext[RCNDeviceContextKeyDeviceLocale] isEqual:FIRRemoteConfigDeviceLocale()]) {

--- a/FirebaseStorageSwift/Sources/SwiftAPIExtension.swift
+++ b/FirebaseStorageSwift/Sources/SwiftAPIExtension.swift
@@ -22,9 +22,9 @@ import FirebaseStorage
 ///                 an `Error`.
 /// - Returns: A closure parameterized with an optional generic and optional `Error` to match
 ///            Objective C APIs.
-private func getResultCallback<T>(
-  completion: @escaping (Result<T, Error>) -> Void
-) -> (_: T?, _: Error?) -> Void {
+private func getResultCallback<T>(completion: @escaping (Result<T, Error>) -> Void) -> (_: T?,
+                                                                                        _: Error?)
+  -> Void {
   return { (value: T?, error: Error?) -> Void in
     if let value = value {
       completion(.success(value))

--- a/Firestore/Swift/Source/Codable/FieldValue+Encodable.swift
+++ b/Firestore/Swift/Source/Codable/FieldValue+Encodable.swift
@@ -22,6 +22,7 @@ extension FieldValue: Encodable {
   /// explicitly handles it, which is what Firestore.Encoder does.
   public func encode(to encoder: Encoder) throws {
     throw FirestoreEncodingError.encodingIsNotSupported(
-      "FieldValue values can only be encoded with Firestore.Encoder")
+      "FieldValue values can only be encoded with Firestore.Encoder"
+    )
   }
 }

--- a/Firestore/third_party/FirestoreEncoder/FirestoreEncoder.swift
+++ b/Firestore/third_party/FirestoreEncoder/FirestoreEncoder.swift
@@ -103,7 +103,9 @@ private class _FirestoreEncoder: Encoder {
       topContainer = storage.pushKeyedContainer()
     } else {
       guard let container = storage.containers.last as? NSMutableDictionary else {
-        preconditionFailure("Attempt to push new keyed encoding container when already previously encoded at this path.")
+        preconditionFailure(
+          "Attempt to push new keyed encoding container when already previously encoded at this path."
+        )
       }
 
       topContainer = container
@@ -122,7 +124,9 @@ private class _FirestoreEncoder: Encoder {
       topContainer = storage.pushUnkeyedContainer()
     } else {
       guard let container = storage.containers.last as? NSMutableArray else {
-        preconditionFailure("Attempt to push new unkeyed encoding container when already previously encoded at this path.")
+        preconditionFailure(
+          "Attempt to push new unkeyed encoding container when already previously encoded at this path."
+        )
       }
 
       topContainer = container
@@ -622,7 +626,7 @@ private class _FirestoreReferencingEncoder: _FirestoreEncoder {
 
   // MARK: - Coding Path Operations
 
-  fileprivate override var shouldAllocateNewContainer: Bool {
+  override fileprivate var shouldAllocateNewContainer: Bool {
     // With a regular encoder, the storage and coding path grow together.
     // A referencing encoder, however, inherits its parents coding path, as well as the key it was created for.
     // We have to take this into account.

--- a/GoogleUtilitiesComponents/Tests/GULCCComponentContainerTest.m
+++ b/GoogleUtilitiesComponents/Tests/GULCCComponentContainerTest.m
@@ -75,7 +75,7 @@
 }
 
 - (void)testComponentsPopulatedOnInit {
-  GULCCComponentContainer *container = [self containerWithRegistrants:@ [[GULCCTestClass class]]];
+  GULCCComponentContainer *container = [self containerWithRegistrants:@[ [GULCCTestClass class] ]];
 
   // Verify that the block is stored.
   NSString *protocolName = NSStringFromProtocol(@protocol(GULCCTestProtocol));
@@ -87,7 +87,7 @@
 
 - (void)testInstanceCached {
   GULCCComponentContainer *container =
-      [self containerWithRegistrants:@ [[GULCCTestClassCached class]]];
+      [self containerWithRegistrants:@[ [GULCCTestClassCached class] ]];
 
   // Fetch an instance for `GULCCTestProtocolCached`, then fetch it again to assert it's cached.
   id<GULCCTestProtocolCached> instance1 = GUL_COMPONENT(GULCCTestProtocolCached, container);
@@ -98,7 +98,7 @@
 }
 
 - (void)testInstanceNotCached {
-  GULCCComponentContainer *container = [self containerWithRegistrants:@ [[GULCCTestClass class]]];
+  GULCCComponentContainer *container = [self containerWithRegistrants:@[ [GULCCTestClass class] ]];
 
   // Retrieve an instance from the container, then fetch it again and ensure it's not the same
   // instance.
@@ -110,10 +110,10 @@
 }
 
 - (void)testRemoveAllCachedInstances {
-  GULCCComponentContainer *container =
-      [self containerWithRegistrants:@ [[GULCCTestClass class], [GULCCTestClassCached class],
-                                        [GULCCTestClassEagerCached class],
-                                        [GULCCTestClassCachedWithDep class]]];
+  GULCCComponentContainer *container = [self containerWithRegistrants:@[
+    [GULCCTestClass class], [GULCCTestClassCached class], [GULCCTestClassEagerCached class],
+    [GULCCTestClassCachedWithDep class]
+  ]];
 
   // Retrieve an instance of GULCCTestClassCached to ensure it's cached.
   id<GULCCTestProtocolCached> cachedInstance1 = GUL_COMPONENT(GULCCTestProtocolCached, container);
@@ -142,7 +142,7 @@
   // implementation for `GULCCTestProtocolEagerCached` and requires eager instantiation as well as
   // caching so the test can verify it was eagerly instantiated.
   GULCCComponentContainer *container =
-      [self containerWithRegistrants:@ [[GULCCTestClassEagerCached class]]];
+      [self containerWithRegistrants:@[ [GULCCTestClassEagerCached class] ]];
   NSString *protocolName = NSStringFromProtocol(@protocol(GULCCTestProtocolEagerCached));
   XCTAssertNotNil(container.cachedInstances[protocolName]);
 }
@@ -156,7 +156,7 @@
   // change in the future.
   // TODO(wilsonryan): Assert that the log gets called warning that it's already been registered.
   GULCCComponentContainer *container =
-      [self containerWithRegistrants:@ [[GULCCTestClass class], [GULCCTestClassDuplicate class]]];
+      [self containerWithRegistrants:@[ [GULCCTestClass class], [GULCCTestClassDuplicate class] ]];
   XCTAssert(container.components.count == 1);
 }
 
@@ -164,9 +164,9 @@
 
 - (void)testDependencyDoesntBlock {
   /// Test a class that has a dependency, and fetching doesn't block the internal queue.
-  GULCCComponentContainer *container =
-      [self containerWithRegistrants:@ [[GULCCTestClassCached class],
-                                        [GULCCTestClassCachedWithDep class]]];
+  GULCCComponentContainer *container = [self containerWithRegistrants:@[
+    [GULCCTestClassCached class], [GULCCTestClassCachedWithDep class]
+  ]];
   XCTAssert(container.components.count == 2);
 
   id<GULCCTestProtocolCachedWithDep> instanceWithDep =
@@ -176,9 +176,9 @@
 
 - (void)testDependencyRemoveAllCachedInstancesDoesntBlock {
   /// Test a class that has a dependency, and fetching doesn't block the internal queue.
-  GULCCComponentContainer *container =
-      [self containerWithRegistrants:@ [[GULCCTestClassCached class],
-                                        [GULCCTestClassCachedWithDep class]]];
+  GULCCComponentContainer *container = [self containerWithRegistrants:@[
+    [GULCCTestClassCached class], [GULCCTestClassCachedWithDep class]
+  ]];
   XCTAssert(container.components.count == 2);
 
   id<GULCCTestProtocolCachedWithDep> instanceWithDep =

--- a/Metrics/Sources/MetricsLib/UploadMetrics.swift
+++ b/Metrics/Sources/MetricsLib/UploadMetrics.swift
@@ -68,7 +68,9 @@ public struct TableUpdate: Encodable {
         row.append(currentTime)
         metrics.append(row)
       } else {
-        print("WARNING - target \(target.name) is being filtered out from coverage collection. Skipping...")
+        print(
+          "WARNING - target \(target.name) is being filtered out from coverage collection. Skipping..."
+        )
       }
     }
     let columnNames = ["product_name", "pull_request_id", "coverage_total", "collection_time"]

--- a/README.md
+++ b/README.md
@@ -140,20 +140,12 @@ To ensure that the code is formatted consistently, run the script
 before creating a PR.
 
 Travis will verify that any code changes are done in a style compliant way. Install
-`clang-format` and `swiftformat`.
-These commands will get the right versions:
+`clang-format` and `swiftformat`:
 
 ```
-brew upgrade https://raw.githubusercontent.com/Homebrew/homebrew-core/c6f1cbd/Formula/clang-format.rb
-brew upgrade https://raw.githubusercontent.com/Homebrew/homebrew-core/c13eda8/Formula/swiftformat.rb
+brew install clang-format
+brew install swiftformat
 ```
-
-Note: if you already have a newer version of these installed you may need to
-`brew switch` to this version.
-
-To update this section, find the versions of clang-format and swiftformat.rb to
-match the versions in the CI failure logs
-[here](https://github.com/Homebrew/homebrew-core/tree/master/Formula).
 
 ### Running Unit Tests
 

--- a/ZipBuilder/Sources/oss-manifest-generator/main.swift
+++ b/ZipBuilder/Sources/oss-manifest-generator/main.swift
@@ -32,8 +32,10 @@ struct OSSManifestGenerator: ParsableCommand {
           transform: URL.init(fileURLWithPath:))
   var currentRelease: URL
 
-  @Option(help: "The file path to a textproto file containing all existing Pods, of type `ZipBuilder_FirebaseSDKs.",
-          transform: URL.init(fileURLWithPath:))
+  @Option(
+    help: "The file path to a textproto file containing all existing Pods, of type `ZipBuilder_FirebaseSDKs.",
+    transform: URL.init(fileURLWithPath:)
+  )
   var existingVersions: URL
 
   mutating func validate() throws {

--- a/scripts/setup_check.sh
+++ b/scripts/setup_check.sh
@@ -21,8 +21,11 @@ set -euo pipefail
 export HOMEBREW_NO_ANALYTICS=1
 export HOMEBREW_NO_AUTO_UPDATE=1
 
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/c6f1cbd/Formula/clang-format.rb
-brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/c13eda8/Formula/swiftformat.rb
+brew install clang-format
+brew install swiftformat
+
+clang-format -version
+swiftformat -version
 
 pip install flake8
 pip install six

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -39,7 +39,7 @@ version="${version/ (*)/}"
 version="${version/.*/}"
 
 case "$version" in
-  9)
+  10)
     ;;
   google3-trunk)
     echo "Please use a publicly released clang-format; a recent LLVM release"
@@ -48,9 +48,9 @@ case "$version" in
     exit 1
     ;;
   *)
-    echo "Please upgrade to clang-format version 9."
+    echo "Please upgrade to clang-format version 10."
     echo "If it's installed via homebrew you can run:"
-    echo "brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/c6f1cbd/Formula/clang-format.rb"
+    echo "brew install clang-format"
     exit 1
     ;;
 esac

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -63,12 +63,12 @@ if [[ "$system" == "Darwin" ]]; then
     echo "Found: $version"
   fi
   version="${version/*version /}"
-  # Ensure the swiftformat version is at least 0.35.x since (as of 2019-02-01)
-  # travis runs 0.35.7. We may need to be more strict about version checks in
+  # Ensure the swiftformat version is at least 0.44.14 since (as of 2020-06-26)
+  # We may need to be more strict about version checks in
   # the future if we run into different versions making incompatible format
   # changes.
   if [[ ! "$version" =~ ^0.[4-9] ]]; then
-    echo "Version $version installed. Please upgrade to at least swiftformat 0.44.6"
+    echo "Version $version installed. Please upgrade to at least swiftformat 0.44.14"
     echo "If it's installed via homebrew you can run: brew upgrade swiftformat"
     exit 1
   fi


### PR DESCRIPTION
Update to clang-format 10.0.0 and swiftformat 0.44.14

brew has stopped supporting installing from git tags - failing with 
```
Warning: Calling Non-checksummed download of clang-format formula file from an arbitrary URL is deprecated! Use 'brew extract' or 'brew create' and 'brew tap-new' to create a formula file in a tap on GitHub instead.
######################################################################## 100.0%
Error: clang-format not installed
```

TBD: find a way to lock versions so that brew version updates don't break CI
