### PR TITLE
Fix GDTCCT SPM build

### DIFF
--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
@@ -27,9 +27,13 @@
 #import "GoogleDataTransport/GDTCORLibrary/Public/GDTCOREvent.h"
 #import "GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h"
 
+#if SWIFT_PACKAGE
+#import "nanopb.h"
+#else
 #import <nanopb/pb.h>
 #import <nanopb/pb_decode.h>
 #import <nanopb/pb_encode.h>
+#endif
 
 #import "GoogleDataTransport/GDTCCTLibrary/Public/GDTCOREvent+GDTCCTSupport.h"
 

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
@@ -22,9 +22,13 @@
 #import "GoogleDataTransport/GDTCORLibrary/Public/GDTCORRegistrar.h"
 #import "GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h"
 
+#if SWIFT_PACKAGE
+#import "nanopb.h"
+#else
 #import <nanopb/pb.h>
 #import <nanopb/pb_decode.h>
 #import <nanopb/pb_encode.h>
+#endif
 
 #import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTCompressionHelper.h"
 #import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTNanopbHelpers.h"

--- a/GoogleDataTransport/GDTCCTLibrary/Protogen/nanopb/cct.nanopb.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Protogen/nanopb/cct.nanopb.h
@@ -19,7 +19,11 @@
 
 #ifndef PB_GDT_CCT_CCT_NANOPB_H_INCLUDED
 #define PB_GDT_CCT_CCT_NANOPB_H_INCLUDED
+#if SWIFT_PACKAGE
+#include "nanopb.h"
+#else
 #include <nanopb/pb.h>
+#endif
 
 /* @@protoc_insertion_point(includes) */
 #if PB_PROTO_HEADER_VERSION != 30

--- a/Package.swift
+++ b/Package.swift
@@ -268,7 +268,7 @@ let package = Package(
       path: ".",
       sources: [
         "GoogleDataTransport/GDTCORLibrary",
-        "GoogleDataTransportCCTSupport/GDTCCTLibrary",
+        "GoogleDataTransport/GDTCCTLibrary",
       ],
       publicHeadersPath: "GoogleDataTransport/GDTCORLibrary/Public",
       cSettings: [


### PR DESCRIPTION
The sources in GDTCCTLibrary weren't being built due to the error in Package.swift below.

TODO: explore ways to better consolidate nanopb imports

Next: Investigate options for testing SPM builds

#no-changelog