### PR TITLE
Update FIRDynamicLinkNetworking.m

### DIFF
--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.m
@@ -65,7 +65,8 @@ NSString *_Nullable FIRDynamicLinkAPIKeyParameter(NSString *apiKey) {
 }
 
 void FIRMakeHTTPRequest(NSURLRequest *request, FIRNetworkRequestCompletionHandler completion) {
-  NSURLSession *session = [NSURLSession sharedSession];
+  NSURLSessionConfiguration *sessionConfig = [NSURLSessionConfiguration defaultSessionConfiguration];
+  NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfig];
   NSURLSessionDataTask *dataTask =
       [session dataTaskWithRequest:request
                  completionHandler:^(NSData *_Nullable data, NSURLResponse *_Nullable response,

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.m
@@ -65,7 +65,8 @@ NSString *_Nullable FIRDynamicLinkAPIKeyParameter(NSString *apiKey) {
 }
 
 void FIRMakeHTTPRequest(NSURLRequest *request, FIRNetworkRequestCompletionHandler completion) {
-  NSURLSessionConfiguration *sessionConfig = [NSURLSessionConfiguration defaultSessionConfiguration];
+  NSURLSessionConfiguration *sessionConfig =
+      [NSURLSessionConfiguration defaultSessionConfiguration];
   NSURLSession *session = [NSURLSession sessionWithConfiguration:sessionConfig];
   NSURLSessionDataTask *dataTask =
       [session dataTaskWithRequest:request


### PR DESCRIPTION
Recreate the session to avoid crash when opening another or the same dynamic link (app already opened by a dynamic or have already processed one)
Thanks @rszalski for the solution!

Fix #5880
