### PR TITLE
Update copyright presubmit and fix 2020 copyrights

### DIFF
--- a/Crashlytics/Crashlytics/FIRExceptionModel.m
+++ b/Crashlytics/Crashlytics/FIRExceptionModel.m
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Crashlytics/Crashlytics/FIRStackFrame.m
+++ b/Crashlytics/Crashlytics/FIRStackFrame.m
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordApplication.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordApplication.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordApplication.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordApplication.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordBase.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordBase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordBase.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordBase.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordHost.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordHost.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordHost.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordHost.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordIdentity.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordIdentity.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordIdentity.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSRecordIdentity.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter_Private.h
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter_Private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Crashlytics/Crashlytics/Private/FIRExceptionModel_Private.h
+++ b/Crashlytics/Crashlytics/Private/FIRExceptionModel_Private.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Crashlytics/Crashlytics/Private/FIRStackFrame_Private.h
+++ b/Crashlytics/Crashlytics/Private/FIRStackFrame_Private.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Crashlytics/Crashlytics/Public/FIRExceptionModel.h
+++ b/Crashlytics/Crashlytics/Public/FIRExceptionModel.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Crashlytics/Crashlytics/Public/FIRStackFrame.h
+++ b/Crashlytics/Crashlytics/Public/FIRStackFrame.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Crashlytics/ProtoSupport/Protos/crashlytics.options
+++ b/Crashlytics/ProtoSupport/Protos/crashlytics.options
@@ -1,4 +1,4 @@
-# Copyright 2020 Google
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Crashlytics/ProtoSupport/Protos/crashlytics.proto
+++ b/Crashlytics/ProtoSupport/Protos/crashlytics.proto
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Crashlytics/ProtoSupport/generate_crashlytics_protos.sh
+++ b/Crashlytics/ProtoSupport/generate_crashlytics_protos.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Crashlytics/ProtoSupport/nanopb_objc_generator.py
+++ b/Crashlytics/ProtoSupport/nanopb_objc_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2020 Google
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Crashlytics/ProtoSupport/proto_generator.py
+++ b/Crashlytics/ProtoSupport/proto_generator.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-# Copyright 2020 Google
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Crashlytics/UnitTests/FIRCLSReportAdapterTests.m
+++ b/Crashlytics/UnitTests/FIRCLSReportAdapterTests.m
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Crashlytics/UnitTests/FIRExceptionModelTests.m
+++ b/Crashlytics/UnitTests/FIRExceptionModelTests.m
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
+++ b/Crashlytics/UnitTests/FIRRecordExceptionModelTests.m
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Crashlytics/UnitTests/FIRStackFrameTests.m
+++ b/Crashlytics/UnitTests/FIRStackFrameTests.m
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Crashlytics/UnitTests/Mocks/FIRCLSMockFileManager.m
+++ b/Crashlytics/UnitTests/Mocks/FIRCLSMockFileManager.m
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Crashlytics/UnitTests/Mocks/FIRMockGDTCoreTransport.h
+++ b/Crashlytics/UnitTests/Mocks/FIRMockGDTCoreTransport.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Crashlytics/UnitTests/Mocks/FIRMockGDTCoreTransport.m
+++ b/Crashlytics/UnitTests/Mocks/FIRMockGDTCoreTransport.m
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Crashlytics/UnitTests/Mocks/FIRMockInstallations.h
+++ b/Crashlytics/UnitTests/Mocks/FIRMockInstallations.h
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Crashlytics/UnitTests/Mocks/FIRMockInstallations.m
+++ b/Crashlytics/UnitTests/Mocks/FIRMockInstallations.m
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Crashlytics/generate_project.sh
+++ b/Crashlytics/generate_project.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Example/watchOSSample/SampleWatchAppWatchKitExtension/ComplicationController.swift
+++ b/Example/watchOSSample/SampleWatchAppWatchKitExtension/ComplicationController.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Example/watchOSSample/SampleWatchAppWatchKitExtension/ExtensionDelegate.swift
+++ b/Example/watchOSSample/SampleWatchAppWatchKitExtension/ExtensionDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Example/watchOSSample/SampleWatchAppWatchKitExtension/InterfaceController.swift
+++ b/Example/watchOSSample/SampleWatchAppWatchKitExtension/InterfaceController.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Example/watchOSSample/SampleWatchAppWatchKitExtension/NotificationController.swift
+++ b/Example/watchOSSample/SampleWatchAppWatchKitExtension/NotificationController.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/Example/watchOSSample/ServiceExtension/NotificationService.swift
+++ b/Example/watchOSSample/ServiceExtension/NotificationService.swift
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/FirebaseABTesting/Tests/Integration/ABTQA/AppDelegate.swift
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/AppDelegate.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseABTesting/Tests/Integration/ABTQA/SceneDelegate.swift
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/SceneDelegate.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseABTesting/Tests/Integration/ABTQA/ViewController.swift
+++ b/FirebaseABTesting/Tests/Integration/ABTQA/ViewController.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionMachOTests.m
+++ b/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionMachOTests.m
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionTests.m
+++ b/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionTests.m
@@ -1,4 +1,4 @@
-// Copyright 2020 Google
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/FirebaseDynamicLinks/Tests/Sample/FDLBuilderTestAppObjC/SceneDelegate.h
+++ b/FirebaseDynamicLinks/Tests/Sample/FDLBuilderTestAppObjC/SceneDelegate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseDynamicLinks/Tests/Sample/FDLBuilderTestAppObjC/SceneDelegate.m
+++ b/FirebaseDynamicLinks/Tests/Sample/FDLBuilderTestAppObjC/SceneDelegate.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseInAppMessaging/Sources/Public/FirebaseInAppMessaging.h
+++ b/FirebaseInAppMessaging/Sources/Public/FirebaseInAppMessaging.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMClientInfoFetcherTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMClientInfoFetcherTests.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseMessaging/Tests/UnitTests/FIRTestsAssertionHandler.h
+++ b/FirebaseMessaging/Tests/UnitTests/FIRTestsAssertionHandler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseMessaging/Tests/UnitTests/FIRTestsAssertionHandler.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRTestsAssertionHandler.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseMessaging/Tests/UnitTests/XCTestCase+FIRMessagingRmqManagerTests.h
+++ b/FirebaseMessaging/Tests/UnitTests/XCTestCase+FIRMessagingRmqManagerTests.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/FirebaseMessaging/Tests/UnitTests/XCTestCase+FIRMessagingRmqManagerTests.m
+++ b/FirebaseMessaging/Tests/UnitTests/XCTestCase+FIRMessagingRmqManagerTests.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/local/leveldb_opener.cc
+++ b/Firestore/core/src/local/leveldb_opener.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/local/leveldb_opener.h
+++ b/Firestore/core/src/local/leveldb_opener.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/model/verify_mutation.cc
+++ b/Firestore/core/src/model/verify_mutation.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/src/model/verify_mutation.h
+++ b/Firestore/core/src/model/verify_mutation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/test/unit/local/leveldb_opener_test.cc
+++ b/Firestore/core/test/unit/local/leveldb_opener_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/test/unit/testutil/filesystem_testing.cc
+++ b/Firestore/core/test/unit/testutil/filesystem_testing.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Firestore/core/test/unit/testutil/filesystem_testing.h
+++ b/Firestore/core/test/unit/testutil/filesystem_testing.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTCompressionHelper.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTCompressionHelper.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCOREvent+GDTCCTSupport.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCOREvent+GDTCCTSupport.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTCompressionHelper.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTCompressionHelper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataTransport/GDTCCTLibrary/Public/GDTCOREvent+GDTCCTSupport.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Public/GDTCOREvent+GDTCCTSupport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataTransport/GDTCCTWatchOSTestApp/GDTCCTWatchOSIndependentTestAppWatchKitExtension/gdthelpers.swift
+++ b/GoogleDataTransport/GDTCCTWatchOSTestApp/GDTCCTWatchOSIndependentTestAppWatchKitExtension/gdthelpers.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORPlatformTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORPlatformTest.m
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/build_zip.sh
+++ b/scripts/build_zip.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google
+# Copyright 2020 Google LLC
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/scripts/change_headers.swift
+++ b/scripts/change_headers.swift
@@ -1,6 +1,6 @@
 #!/usr/bin/swift
 /*
- * Copyright 2020 LLC Google
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/check_copyright.sh
+++ b/scripts/check_copyright.sh
@@ -18,13 +18,15 @@ options=(
   -E  # Use extended regexps
   -I  # Exclude binary files
   -L  # Show files that don't have a match
-  'Copyright [0-9]{4}.*Google'
+  'Copyright [0-9]{4}.*Google LLC'
 )
 
-git grep "${options[@]}" -- \
+# Allow copyrights before 2020 without LLC.
+grep -L 'Copyright 201[0-9].*Google' \
+$(git grep "${options[@]}" -- \
     '*.'{c,cc,cmake,h,js,m,mm,py,rb,sh,swift} \
     CMakeLists.txt '**/CMakeLists.txt' \
-    ':(exclude)**/third_party/**'
+    ':(exclude)**/third_party/**')
 if [[ $? == 0 ]]; then
   echo "ERROR: Missing copyright notices in the files above. Please fix."
   exit 1

--- a/scripts/check_copyright.sh
+++ b/scripts/check_copyright.sh
@@ -21,14 +21,16 @@ options=(
   'Copyright [0-9]{4}.*Google LLC'
 )
 
-# Allow copyrights before 2020 without LLC.
-grep -L 'Copyright 201[0-9].*Google' \
-$(git grep "${options[@]}" -- \
+list=$(git grep "${options[@]}" -- \
     '*.'{c,cc,cmake,h,js,m,mm,py,rb,sh,swift} \
     CMakeLists.txt '**/CMakeLists.txt' \
     ':(exclude)**/third_party/**')
-if [[ $? == 0 ]]; then
-  echo "ERROR: Missing copyright notices in the files above. Please fix."
-  exit 1
-fi
 
+# Allow copyrights before 2020 without LLC.
+result=$(grep -L 'Copyright 20[0-1][0-9].*Google' $list)
+
+if [[ $result ]]; then
+    echo "$result"
+    echo "ERROR: Missing copyright notices in the files above. Please fix."
+    exit 1
+fi

--- a/scripts/decrypt_gha_secret.sh
+++ b/scripts/decrypt_gha_secret.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 Google
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Verify that new copyright syntax with "Google LLC" is used.

Googlers see go/copyright