### PR TITLE
Adding plist property 'FirebaseDeepLinkPasteboardRetrievalEnabled'

### DIFF
--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,8 +1,6 @@
-# Unversioned
-- Adding plist property"FirebaseDeepLinkPasteBoardRetrievalEnabled" to enable/disable fetching dynamic links from PasteBoard.
+# v4.2.0
+- [Added] Plist property"FirebaseDeepLinkPasteBoardRetrievalEnabled" to enable/disable fetching dynamic links from PasteBoard.
 - [fixed] Reduce frequency of iOS14 pasteboard notifications by only reading from it when it contains URL(s). (#5905)
-
-# v4.3.0
 - [changed] Functionally neutral updated import references for dependencies. (#5824)
 
 # v4.1.0

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v4.2.0
-- [Added] Plist property 'FirebaseDeepLinkPasteboardRetrievalEnabled' to enable/disable fetching dynamic links from PasteBoard.
+- [Added] Plist property 'FirebaseDeepLinkPasteboardRetrievalEnabled' to enable/disable fetching dynamic links from Pasteboard.
 - [fixed] Reduce frequency of iOS14 pasteboard notifications by only reading from it when it contains URL(s). (#5905)
 - [changed] Functionally neutral updated import references for dependencies. (#5824)
 

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v4.2.0
-- [Added] Plist property 'FirebaseDeepLinkPasteboardRetrievalEnabled' to enable/disable fetching dynamic links from Pasteboard.
+- [Added] Plist property `FirebaseDeepLinkPasteboardRetrievalEnabled` to enable/disable fetching dynamic links from Pasteboard.
 - [fixed] Reduce frequency of iOS14 pasteboard notifications by only reading from it when it contains URL(s). (#5905)
 - [changed] Functionally neutral updated import references for dependencies. (#5824)
 

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v4.2.0
-- [Added] Plist property"FirebaseDeepLinkPasteBoardRetrievalEnabled" to enable/disable fetching dynamic links from PasteBoard.
+- [Added] Plist property 'FirebaseDeepLinkPasteboardRetrievalEnabled' to enable/disable fetching dynamic links from PasteBoard.
 - [fixed] Reduce frequency of iOS14 pasteboard notifications by only reading from it when it contains URL(s). (#5905)
 - [changed] Functionally neutral updated import references for dependencies. (#5824)
 

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unversioned
+- Adding plist property"FirebaseDeepLinkPasteBoardRetrievalEnabled" to enable/disable fetching dynamic links from PasteBoard.
 - [fixed] Reduce frequency of iOS14 pasteboard notifications by only reading from it when it contains URL(s). (#5905)
 
 # v4.3.0

--- a/FirebaseDynamicLinks/Sources/FIRDLDefaultRetrievalProcessV2.m
+++ b/FirebaseDynamicLinks/Sources/FIRDLDefaultRetrievalProcessV2.m
@@ -297,7 +297,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSString *)retrievePasteboardContents {
-  if (![self isPasteBoardRetrievalEnabled]) {
+  if (![self isPasteboardRetrievalEnabled]) {
     // Pasteboard check for dynamic link is disabled by user.
     return @"";
   }
@@ -314,12 +314,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 /**
- Property to enable or disable dynamic link retrieval from PasteBoard.
+ Property to enable or disable dynamic link retrieval from Pasteboard.
  This property is added because of iOS 14 feature where pop up is displayed while accessing
- PasteBoard. So if developers don't want their users to see the PasteBoard popup, they can set
- "FirebaseDeepLinkPasteBoardRetrievalEnabled" to false in their plist.
+ Pasteboard. So if developers don't want their users to see the Pasteboard popup, they can set
+ "FirebaseDeepLinkPasteboardRetrievalEnabled" to false in their plist.
  */
-- (BOOL)isPasteBoardRetrievalEnabled {
+- (BOOL)isPasteboardRetrievalEnabled {
   id retrievalEnabledValue =
       [[NSBundle mainBundle] infoDictionary][@"FirebaseDeepLinkPasteboardRetrievalEnabled"];
   if ([retrievalEnabledValue respondsToSelector:@selector(boolValue)]) {

--- a/FirebaseDynamicLinks/Sources/FIRDLDefaultRetrievalProcessV2.m
+++ b/FirebaseDynamicLinks/Sources/FIRDLDefaultRetrievalProcessV2.m
@@ -297,6 +297,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (NSString *)retrievePasteboardContents {
+  if (![self isPasteBoardRetrievalEnabled]) {
+    // Pasteboard check for dynamic link is disabled by user.
+    return @"";
+  }
+
   NSString *pasteboardContents = @"";
   if (@available(iOS 10.0, *)) {
     if ([[UIPasteboard generalPasteboard] hasURLs]) {
@@ -306,6 +311,21 @@ NS_ASSUME_NONNULL_BEGIN
     pasteboardContents = [UIPasteboard generalPasteboard].string;
   }
   return pasteboardContents;
+}
+
+/**
+ Property to enable or disable dynamic link retrieval from PasteBoard.
+ This property is added because of iOS 14 feature where pop up is displayed while accessing
+ PasteBoard. So if developers don't want their users to see the PasteBoard popup, they can set
+ "FirebaseDeepLinkPasteBoardRetrievalEnabled" to false in their plist.
+ */
+- (BOOL)isPasteBoardRetrievalEnabled {
+  id retrievalEnabledValue =
+      [[NSBundle mainBundle] infoDictionary][@"FirebaseDeepLinkPasteBoardRetrievalEnabled"];
+  if ([retrievalEnabledValue respondsToSelector:@selector(boolValue)]) {
+    return [retrievalEnabledValue boolValue];
+  }
+  return YES;
 }
 
 - (void)clearUsedUniqueMatchLinkToCheckFromClipboard {

--- a/FirebaseDynamicLinks/Sources/FIRDLDefaultRetrievalProcessV2.m
+++ b/FirebaseDynamicLinks/Sources/FIRDLDefaultRetrievalProcessV2.m
@@ -321,7 +321,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)isPasteBoardRetrievalEnabled {
   id retrievalEnabledValue =
-      [[NSBundle mainBundle] infoDictionary][@"FirebaseDeepLinkPasteBoardRetrievalEnabled"];
+      [[NSBundle mainBundle] infoDictionary][@"FirebaseDeepLinkPasteboardRetrievalEnabled"];
   if ([retrievalEnabledValue respondsToSelector:@selector(boolValue)]) {
     return [retrievalEnabledValue boolValue];
   }


### PR DESCRIPTION
Adding plist property"FirebaseDeepLinkPasteBoardRetrievalEnabled" to enable/disable fetching dynamic links from PasteBoard.

With iOS 14, when ever the PasteBoard contents are accessed, a pop up will be displayed. So for FDL clients who doesn't need the deeplinking based on PasteBoard contained dynamic link, can use this property to disable PasteBoard access there by not having a PastBoard access system popup.