### PR TITLE
Have ListenerRegistration::Remove block until callbacks are complete

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
@@ -566,6 +566,7 @@ using firebase::firestore::util::TimerId;
   }];
 
   [self writeDocumentRef:ref data:@{@"foo" : @3}];
+  [self awaitExpectation:done];
 }
 
 - (void)testSnapshotsInSyncRemoveIsIdempotent {

--- a/Firestore/Example/Tests/Integration/API/FIRListenerRegistrationTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRListenerRegistrationTests.mm
@@ -158,6 +158,7 @@
 
   FIRDocumentReference *docRef2 = [collectionRef documentWithPath:documentID];
   [self writeDocumentRef:docRef2 data:@{@"foo" : @"bar"}];
+  [self awaitExpectation:seen];
 
   [registration remove];
 }

--- a/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
+++ b/Firestore/Example/Tests/Util/FSTIntegrationTestCase.mm
@@ -311,7 +311,7 @@ class FakeCredentialsProvider : public EmptyCredentialsProvider {
         }];
 
     // Wait for watch to initialize and deliver first event.
-    [self awaitExpectations];
+    [self awaitExpectation:watchInitialized];
 
     watchUpdateReceived = [self expectationWithDescription:@"Prime backend: Watch update received"];
 
@@ -340,17 +340,18 @@ class FakeCredentialsProvider : public EmptyCredentialsProvider {
 }
 
 - (void)terminateFirestore:(FIRFirestore *)firestore {
-  [firestore terminateWithCompletion:[self completionForExpectationWithName:@"shutdown"]];
-  [self awaitExpectations];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"shutdown"];
+  [firestore terminateWithCompletion:[self completionForExpectation:expectation]];
+  [self awaitExpectation:expectation];
 }
 
 - (void)deleteApp:(FIRApp *)app {
-  XCTestExpectation *expectation = [self expectationWithDescription:@"Delete app"];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"deleteApp"];
   [app deleteApp:^(BOOL completion) {
     XCTAssertTrue(completion);
     [expectation fulfill];
   }];
-  [self awaitExpectations];
+  [self awaitExpectation:expectation];
 }
 
 - (NSString *)documentPath {
@@ -412,7 +413,7 @@ class FakeCredentialsProvider : public EmptyCredentialsProvider {
                     result = doc;
                     [expectation fulfill];
                   }];
-  [self awaitExpectations];
+  [self awaitExpectation:expectation];
 
   return result;
 }
@@ -431,7 +432,7 @@ class FakeCredentialsProvider : public EmptyCredentialsProvider {
                        result = documentSet;
                        [expectation fulfill];
                      }];
-  [self awaitExpectations];
+  [self awaitExpectation:expectation];
 
   return result;
 }
@@ -452,61 +453,63 @@ class FakeCredentialsProvider : public EmptyCredentialsProvider {
                                              }
                                            }];
 
-  [self awaitExpectations];
+  [self awaitExpectation:expectation];
   [listener remove];
 
   return result;
 }
 
 - (void)writeDocumentRef:(FIRDocumentReference *)ref data:(NSDictionary<NSString *, id> *)data {
-  [ref setData:data completion:[self completionForExpectationWithName:@"setData"]];
-  [self awaitExpectations];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"setData"];
+  [ref setData:data completion:[self completionForExpectation:expectation]];
+  [self awaitExpectation:expectation];
 }
 
 - (void)updateDocumentRef:(FIRDocumentReference *)ref data:(NSDictionary<id, id> *)data {
-  [ref updateData:data completion:[self completionForExpectationWithName:@"updateData"]];
-  [self awaitExpectations];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"updateData"];
+  [ref updateData:data completion:[self completionForExpectation:expectation]];
+  [self awaitExpectation:expectation];
 }
 
 - (void)deleteDocumentRef:(FIRDocumentReference *)ref {
-  [ref deleteDocumentWithCompletion:[self completionForExpectationWithName:@"deleteDocument"]];
-  [self awaitExpectations];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"deleteDocument"];
+  [ref deleteDocumentWithCompletion:[self completionForExpectation:expectation]];
+  [self awaitExpectation:expectation];
 }
 
 - (FIRDocumentReference *)addDocumentRef:(FIRCollectionReference *)ref
                                     data:(NSDictionary<NSString *, id> *)data {
-  FIRDocumentReference *doc =
-      [ref addDocumentWithData:data
-                    completion:[self completionForExpectationWithName:@"addDocument"]];
-  [self awaitExpectations];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"addDocument"];
+  FIRDocumentReference *doc = [ref addDocumentWithData:data
+                                            completion:[self completionForExpectation:expectation]];
+  [self awaitExpectation:expectation];
   return doc;
 }
 
 - (void)mergeDocumentRef:(FIRDocumentReference *)ref data:(NSDictionary<NSString *, id> *)data {
-  [ref setData:data
-           merge:YES
-      completion:[self completionForExpectationWithName:@"setDataWithMerge"]];
-  [self awaitExpectations];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"setDataWithMerge"];
+  [ref setData:data merge:YES completion:[self completionForExpectation:expectation]];
+  [self awaitExpectation:expectation];
 }
 
 - (void)mergeDocumentRef:(FIRDocumentReference *)ref
                     data:(NSDictionary<NSString *, id> *)data
                   fields:(NSArray<id> *)fields {
-  [ref setData:data
-      mergeFields:fields
-       completion:[self completionForExpectationWithName:@"setDataWithMerge"]];
-  [self awaitExpectations];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"setDataWithMerge"];
+  [ref setData:data mergeFields:fields completion:[self completionForExpectation:expectation]];
+  [self awaitExpectation:expectation];
 }
 
 - (void)disableNetwork {
-  [self.db
-      disableNetworkWithCompletion:[self completionForExpectationWithName:@"Disable Network."]];
-  [self awaitExpectations];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"disableNetwork"];
+  [self.db disableNetworkWithCompletion:[self completionForExpectation:expectation]];
+  [self awaitExpectation:expectation];
 }
 
 - (void)enableNetwork {
-  [self.db enableNetworkWithCompletion:[self completionForExpectationWithName:@"Enable Network."]];
-  [self awaitExpectations];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"enableNetwork"];
+  [self.db enableNetworkWithCompletion:[self completionForExpectation:expectation]];
+  [self awaitExpectation:expectation];
 }
 
 - (const std::shared_ptr<util::AsyncQueue> &)queueForFirestore:(FIRFirestore *)firestore {

--- a/Firestore/Example/Tests/Util/XCTestCase+Await.h
+++ b/Firestore/Example/Tests/Util/XCTestCase+Await.h
@@ -39,6 +39,12 @@ typedef void (^FSTVoidErrorBlock)(NSError *_Nullable error);
 - (void)awaitExpectations;
 
 /**
+ * Await a specific expectation with a reasonable timeout. If the expectation fails, XCTFail the
+ * test.
+ */
+- (void)awaitExpectation:(XCTestExpectation *)expectation;
+
+/**
  * Returns a reasonable timeout for testing against Firestore.
  */
 - (double)defaultExpectationWaitSeconds;
@@ -48,6 +54,11 @@ typedef void (^FSTVoidErrorBlock)(NSError *_Nullable error);
  * name.
  */
 - (FSTVoidErrorBlock)completionForExpectationWithName:(NSString *)expectationName;
+
+/**
+ * Returns a completion block that fulfills the given expectation.
+ */
+- (FSTVoidErrorBlock)completionForExpectation:(XCTestExpectation *)expectation;
 
 @end
 

--- a/Firestore/Example/Tests/Util/XCTestCase+Await.mm
+++ b/Firestore/Example/Tests/Util/XCTestCase+Await.mm
@@ -36,12 +36,20 @@ void LoadXCTestCaseAwait() {
                                }];
 }
 
+- (void)awaitExpectation:(XCTestExpectation *)expectation {
+  [self waitForExpectations:@[ expectation ] timeout:kExpectationWaitSeconds];
+}
+
 - (double)defaultExpectationWaitSeconds {
   return kExpectationWaitSeconds;
 }
 
 - (FSTVoidErrorBlock)completionForExpectationWithName:(NSString *)expectationName {
   XCTestExpectation *expectation = [self expectationWithDescription:expectationName];
+  return [self completionForExpectation:expectation];
+}
+
+- (FSTVoidErrorBlock)completionForExpectation:(XCTestExpectation *)expectation {
   return ^(NSError *error) {
     XCTAssertNil(error);
     [expectation fulfill];

--- a/Firestore/core/src/api/query_core.cc
+++ b/Firestore/core/src/api/query_core.cc
@@ -163,7 +163,7 @@ std::unique_ptr<ListenerRegistration> Query::AddSnapshotListener(
       QuerySnapshot result(firestore_, query_, std::move(snapshot),
                            std::move(metadata));
 
-      user_listener_->OnEvent(result);
+      user_listener_->OnEvent(std::move(result));
     }
 
    private:


### PR DESCRIPTION
This fixes a test flake observed very rarely in internal testing, where the callback starts processing, checks to see if it's muted, sees that it's not, and proceeds; meanwhile the test calls remove, and deletes state to which the listener was referring and by the time the callback happens in user code the listener callback now refers to the deleted state.