### PR TITLE
Updated dynamic links ipv4 and ipv6 endpoints to use single endpoint

### DIFF
--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,4 +1,5 @@
 # v4.2.0
+- [fixed] Fix attempts to connect to invalid ipv6 domain by updating ipv4 and ipv6 to use a single, valid endpoint (#5032)
 - [Added] Plist property `FirebaseDeepLinkPasteboardRetrievalEnabled` to enable/disable fetching dynamic links from Pasteboard.
 - [fixed] Reduce frequency of iOS14 pasteboard notifications by only reading from it when it contains URL(s). (#5905)
 - [changed] Functionally neutral updated import references for dependencies. (#5824)

--- a/FirebaseDynamicLinks/Sources/FIRDLDefaultRetrievalProcessV2.m
+++ b/FirebaseDynamicLinks/Sources/FIRDLDefaultRetrievalProcessV2.m
@@ -157,8 +157,7 @@ NS_ASSUME_NONNULL_BEGIN
   // Disable deprecated warning for internal methods.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  // If not unique match, we send request twice, since there are two server calls:
-  // one for IPv4, another for IPV6.
+  // If there is not a unique match, we will send an additional request for fingerprinting.
   [_networkingService
       retrievePendingDynamicLinkWithIOSVersion:[UIDevice currentDevice].systemVersion
                               resolutionHeight:resolutionHeight

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.m
@@ -25,16 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 NSString *const kApiaryRestBaseUrl = @"https://appinvite-pa.googleapis.com/v1";
 static NSString *const kiOSReopenRestBaseUrl = @"https://firebasedynamiclinks.googleapis.com/v1";
 
-// IPv4 and IPv6 Endpoints.
-static NSString *const kApiaryRestBaseUrlIPV4 = @"https://appinvite-ipv4-pa.googleapis.com/v1";
-static NSString *const kApiaryRestBaseUrlIPV6 = @"https://appinvite-ipv6-pa.googleapis.com/v1";
-
-// IPv4 and IPv6 Endpoints for default retrieval process V2. (Endpoint version is V1)
-static NSString *const kIosPostInstallAttributionRestBaseUrlIPV4 =
-    @"https://firebasedynamiclinks-ipv4.googleapis.com/v1";
-static NSString *const kIosPostInstallAttributionRestBaseUrlIPV6 =
-    @"https://firebasedynamiclinks-ipv6.googleapis.com/v1";
-static NSString *const kIosPostInstallAttributionRestBaseUrlUniqueMatch =
+// Endpoint for default retrieval process V2. (Endpoint version is V1)
+static NSString *const kIosPostInstallAttributionRestBaseUrl =
     @"https://firebasedynamiclinks.googleapis.com/v1";
 
 static NSString *const kReasonString = @"reason";
@@ -230,19 +222,11 @@ NSData *_Nullable FIRDataWithDictionary(NSDictionary *dictionary, NSError **_Nul
     return [dynamicLinkParameters copy];
   };
 
-  // If uniqueMatch link available send to the unique match endpoint,
-  // else send requests to both IPv4 and IPv6 endpoints.
-  NSArray *baseURLs =
-      uniqueMatchLinkToCheck ? @[ kIosPostInstallAttributionRestBaseUrlUniqueMatch ] : @[
-        kIosPostInstallAttributionRestBaseUrlIPV4, kIosPostInstallAttributionRestBaseUrlIPV6
-      ];
-  for (NSString *baseURL in baseURLs) {
-    [self sendRequestWithBaseURLString:baseURL
-                           requestBody:requestBody
-                          endpointPath:@"installAttribution"
-                           parserBlock:responseParserBlock
-                            completion:handler];
-  }
+  [self sendRequestWithBaseURLString:kIosPostInstallAttributionRestBaseUrl
+                         requestBody:requestBody
+                        endpointPath:@"installAttribution"
+                         parserBlock:responseParserBlock
+                          completion:handler];
 }
 
 - (void)convertInvitation:(NSString *)invitationID
@@ -286,54 +270,40 @@ NSData *_Nullable FIRDataWithDictionary(NSDictionary *dictionary, NSError **_Nul
   NSString *requestURLString = [NSString
       stringWithFormat:@"%@/%@%@", baseURL, endpointPath, FIRDynamicLinkAPIKeyParameter(_APIKey)];
 
-  FIRNetworkRequestCompletionHandler completeInvitationByDeviceCallback = ^(NSData *data,
-                                                                            NSError *error) {
-    if (error || !data) {
-      dispatch_async(dispatch_get_main_queue(), ^{
-        handler(nil, nil, error);
-      });
-      return;
-    }
-    NSString *matchMessage = nil;
-    NSError *parsingError = nil;
-    NSDictionary *parsedDynamicLinkParameters =
-        parserBlock(requestURLString, data, &matchMessage, &parsingError);
-
-    // If request was made with pasteboard contents, verify if we got a unique match. If we got
-    // a "none" match, we were unable to get a unique match or deduce using fingerprinting.
-    // In this case, resend requests to IPV4 and IPV6 endpoints for fingerprinting. b/79704203
-    if (requestBody[@"uniqueMatchLinkToCheck"] && parsedDynamicLinkParameters &&
-        (!parsedDynamicLinkParameters[kFIRDLParameterMatchType] ||
-         [parsedDynamicLinkParameters[kFIRDLParameterMatchType] isEqualToString:@"none"])) {
-      NSMutableDictionary *requestBodyMutable = [requestBody mutableCopy];
-      [requestBodyMutable removeObjectForKey:@"uniqueMatchLinkToCheck"];
-      NSMutableArray *baseURLs =
-          [@[ kIosPostInstallAttributionRestBaseUrlIPV4, kIosPostInstallAttributionRestBaseUrlIPV6 ]
-              mutableCopy];
-      if (parsedDynamicLinkParameters[kFIRDLParameterRequestIPVersion]) {
-        if ([parsedDynamicLinkParameters[kFIRDLParameterRequestIPVersion]
-                isEqualToString:@"IP_V4"]) {
-          [baseURLs removeObject:kIosPostInstallAttributionRestBaseUrlIPV4];
-        } else if ([parsedDynamicLinkParameters[kFIRDLParameterRequestIPVersion]
-                       isEqualToString:@"IP_V6"]) {
-          [baseURLs removeObject:kIosPostInstallAttributionRestBaseUrlIPV6];
+  FIRNetworkRequestCompletionHandler completeInvitationByDeviceCallback =
+      ^(NSData *data, NSError *error) {
+        if (error || !data) {
+          dispatch_async(dispatch_get_main_queue(), ^{
+            handler(nil, nil, error);
+          });
+          return;
         }
-      }
+        NSString *matchMessage = nil;
+        NSError *parsingError = nil;
+        NSDictionary *parsedDynamicLinkParameters =
+            parserBlock(requestURLString, data, &matchMessage, &parsingError);
 
-      for (NSString *baseURL in baseURLs) {
-        [self sendRequestWithBaseURLString:baseURL
-                               requestBody:requestBodyMutable
-                              endpointPath:@"installAttribution"
-                               parserBlock:parserBlock
-                                completion:handler];
-      }
-    }
-    // We want to return out the result of the unique match check irrespective of success/failure as
-    // it is the first fingerprinting request as well.
-    dispatch_async(dispatch_get_main_queue(), ^{
-      handler(parsedDynamicLinkParameters, matchMessage, parsingError);
-    });
-  };
+        // If request was made with pasteboard contents, verify if we got a unique match. If we got
+        // a "none" match, we were unable to get a unique match or deduce using fingerprinting.
+        // In this case, resend requests to IPV4 and IPV6 endpoints for fingerprinting. b/79704203
+        if (requestBody[@"uniqueMatchLinkToCheck"] && parsedDynamicLinkParameters &&
+            (!parsedDynamicLinkParameters[kFIRDLParameterMatchType] ||
+             [parsedDynamicLinkParameters[kFIRDLParameterMatchType] isEqualToString:@"none"])) {
+          NSMutableDictionary *requestBodyMutable = [requestBody mutableCopy];
+          [requestBodyMutable removeObjectForKey:@"uniqueMatchLinkToCheck"];
+
+          [self sendRequestWithBaseURLString:kIosPostInstallAttributionRestBaseUrl
+                                 requestBody:requestBodyMutable
+                                endpointPath:@"installAttribution"
+                                 parserBlock:parserBlock
+                                  completion:handler];
+        }
+        // We want to return out the result of the unique match check irrespective of
+        // success/failure as it is the first fingerprinting request as well.
+        dispatch_async(dispatch_get_main_queue(), ^{
+          handler(parsedDynamicLinkParameters, matchMessage, parsingError);
+        });
+      };
 
   [self executeOnePlatformRequest:requestBody
                            forURL:requestURLString

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.m
@@ -278,28 +278,12 @@ NSData *_Nullable FIRDataWithDictionary(NSDictionary *dictionary, NSError **_Nul
           });
           return;
         }
+
         NSString *matchMessage = nil;
         NSError *parsingError = nil;
         NSDictionary *parsedDynamicLinkParameters =
             parserBlock(requestURLString, data, &matchMessage, &parsingError);
 
-        // If request was made with pasteboard contents, verify if we got a unique match. If we got
-        // a "none" match, we were unable to get a unique match or deduce using fingerprinting.
-        // In this case, resend requests to IPV4 and IPV6 endpoints for fingerprinting. b/79704203
-        if (requestBody[@"uniqueMatchLinkToCheck"] && parsedDynamicLinkParameters &&
-            (!parsedDynamicLinkParameters[kFIRDLParameterMatchType] ||
-             [parsedDynamicLinkParameters[kFIRDLParameterMatchType] isEqualToString:@"none"])) {
-          NSMutableDictionary *requestBodyMutable = [requestBody mutableCopy];
-          [requestBodyMutable removeObjectForKey:@"uniqueMatchLinkToCheck"];
-
-          [self sendRequestWithBaseURLString:kIosPostInstallAttributionRestBaseUrl
-                                 requestBody:requestBodyMutable
-                                endpointPath:@"installAttribution"
-                                 parserBlock:parserBlock
-                                  completion:handler];
-        }
-        // We want to return out the result of the unique match check irrespective of
-        // success/failure as it is the first fingerprinting request as well.
         dispatch_async(dispatch_get_main_queue(), ^{
           handler(parsedDynamicLinkParameters, matchMessage, parsingError);
         });


### PR DESCRIPTION
It looks like the [`firebasedynamiclinks.googleapis`](https://github.com/googleapis/google-api-dotnet-client/blob/master/DiscoveryJson/firebasedynamiclinks_v1.json#L12) hostname can resolve both ip-v4 and ip-v6. Currently on app startup, dynamic links will make calls to Dynamic Links's ip-v4 and ip-v6 endpoints. Calls to the `firebasedynamiclinks-ipv6.googleapis` endpoint result is an error with description: "A server with the specified hostname could not be found." 

Since `firebasedynamiclinks.googleapis` can handle both ip-v4 and ip-v6, we simplify things and instead make a single call to this endpoint.

The following changes seem to have eliminated the ipv6 hostname error in my manual testing. As discussed in #5032, the issue can lead to apps hanging on startup as dynamic links attempt to connect with a `firebasedynamiclinks` server. I would like to make sure this proposed cleanup/fix addresses that too.

Fixes #5032



