### PR TITLE
Edit Feature Request link to link to the template

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ Check out the [issue list](https://github.com/firebase/firebase-ios-sdk/issues)
 to see more detail about plans and desires.
 
 If you don't see the feature you're looking for, please add a
-[Feature Request](https://github.com/firebase/firebase-ios-sdk/issues/new).
+[Feature Request](https://github.com/firebase/firebase-ios-sdk/issues/new?labels=type%3A+feature+request&template=feature_request.md).
 
 ## Contributing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ Check out the [issue list](https://github.com/firebase/firebase-ios-sdk/issues)
 to see more detail about plans and desires.
 
 If you don't see the feature you're looking for, please add a
-[Feature Request](https://github.com/firebase/firebase-ios-sdk/issues/new?labels=type%3A+feature+request&template=feature_request.md).
+[Feature Request](https://github.com/firebase/firebase-ios-sdk/issues/new/choose).
 
 ## Contributing
 


### PR DESCRIPTION
I followed the link in `ROADMAP.md` and accidentally opened a regular issue without a template in https://github.com/firebase/firebase-ios-sdk/issues/6007. Changing the link should prevent this from happening in the future.

If you believe this link might change often in the future, an alternative would be https://github.com/firebase/firebase-ios-sdk/issues/new/choose.