### PR TITLE
GDTCORFlatFileStorage: keep not expired events when expired batch removed

### DIFF
--- a/GoogleDataTransport/CHANGELOG.md
+++ b/GoogleDataTransport/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v7.0.1
+- `GDTCORFlatFileStorage`: keep not expired events when expired batch removed. (#6010)
+
 # v7.0.0
 - Storage has been completely reimplemented to a flat-file system. It
 is not backwards compatible with previously saved events.

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -348,7 +348,7 @@ NSString *const kGDTCORBatchComponentsExpirationKey = @"GDTCORBatchComponentsExp
     // TODO: Storage may not have enough context to remove batches because a batch may be being
     // uploaded but the storage has not context of it.
 
-    // Find expired batches and remove them moving the events back to the main storage.
+    // Find expired batches and move their events back to the main storage.
     NSString *batchDataPath = [GDTCORFlatFileStorage batchDataStoragePath];
     NSArray<NSString *> *batchDataPaths = [fileManager contentsOfDirectoryAtPath:batchDataPath
                                                                            error:nil];

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -349,6 +349,8 @@ NSString *const kGDTCORBatchComponentsExpirationKey = @"GDTCORBatchComponentsExp
     // uploaded but the storage has not context of it.
 
     // Find expired batches and move their events back to the main storage.
+    // If a batch contains expired events they are expected to be removed further in the method
+    // together with other expired events in the main storage.
     NSString *batchDataPath = [GDTCORFlatFileStorage batchDataStoragePath];
     NSArray<NSString *> *batchDataPaths = [fileManager contentsOfDirectoryAtPath:batchDataPath
                                                                            error:nil];
@@ -527,7 +529,7 @@ NSString *const kGDTCORBatchComponentsExpirationKey = @"GDTCORBatchComponentsExp
       NSString *destinationPath = [[GDTCORFlatFileStorage eventDataStoragePath]
           stringByAppendingPathComponent:target.stringValue];
 
-      // `- [NSFileManager moveItemAtPath:toPath:error:] method fails if an item by the
+      // `- [NSFileManager moveItemAtPath:toPath:error:]` method fails if an item by the
       // destination path already exists (which usually is the case for the current method). Move
       // the events one by one instead.
       if ([self moveContentsOfDirectoryAtPath:batchDirPath to:destinationPath error:&error]) {

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -348,7 +348,7 @@ NSString *const kGDTCORBatchComponentsExpirationKey = @"GDTCORBatchComponentsExp
     // TODO: Storage may not have enough context to remove batches because a batch may be being
     // uploaded but the storage has not context of it.
 
-    // Find expired and remove them moving the events back to the main storage.
+    // Find expired batches and remove them moving the events back to the main storage.
     NSString *batchDataPath = [GDTCORFlatFileStorage batchDataStoragePath];
     NSArray<NSString *> *batchDataPaths = [fileManager contentsOfDirectoryAtPath:batchDataPath
                                                                            error:nil];

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
@@ -899,8 +899,6 @@
   // 0.1. Generate and batch events
   __unused __auto_type generatedBatch = [self generateAndBatchEventsExpiringIn:eventsExpireIn
                                                                batchExpiringIn:batchExpiresIn];
-  //  NSNumber *generatedBatchID = [[generatedBatch allKeys] firstObject];
-  //  NSSet<GDTCOREvent *> *generatedEvents = generatedBatch[generatedBatchID];
   // 0.2. Wait for batch expiration.
   [[NSRunLoop currentRunLoop]
       runUntilDate:[NSDate dateWithTimeIntervalSinceNow:batchExpiresIn + 0.5]];

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
@@ -857,8 +857,7 @@
   NSNumber *generatedBatchID = [[generatedBatch allKeys] firstObject];
   NSSet<GDTCOREvent *> *generatedEvents = generatedBatch[generatedBatchID];
   // 0.2. Wait for batch expiration.
-  [[NSRunLoop currentRunLoop]
-      runUntilDate:[NSDate dateWithTimeIntervalSinceNow:batchExpiresIn]];
+  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:batchExpiresIn]];
 
   // 1. Check for expiration.
   [[GDTCORFlatFileStorage sharedInstance] checkForExpirations];
@@ -900,8 +899,7 @@
   __unused __auto_type generatedBatch = [self generateAndBatchEventsExpiringIn:eventsExpireIn
                                                                batchExpiringIn:batchExpiresIn];
   // 0.2. Wait for batch expiration.
-  [[NSRunLoop currentRunLoop]
-      runUntilDate:[NSDate dateWithTimeIntervalSinceNow:batchExpiresIn]];
+  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:batchExpiresIn]];
 
   // 1. Check for expiration.
   [[GDTCORFlatFileStorage sharedInstance] checkForExpirations];

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
@@ -858,7 +858,7 @@
   NSSet<GDTCOREvent *> *generatedEvents = generatedBatch[generatedBatchID];
   // 0.2. Wait for batch expiration.
   [[NSRunLoop currentRunLoop]
-      runUntilDate:[NSDate dateWithTimeIntervalSinceNow:batchExpiresIn + 0.5]];
+      runUntilDate:[NSDate dateWithTimeIntervalSinceNow:batchExpiresIn]];
 
   // 1. Check for expiration.
   [[GDTCORFlatFileStorage sharedInstance] checkForExpirations];
@@ -901,7 +901,7 @@
                                                                batchExpiringIn:batchExpiresIn];
   // 0.2. Wait for batch expiration.
   [[NSRunLoop currentRunLoop]
-      runUntilDate:[NSDate dateWithTimeIntervalSinceNow:batchExpiresIn + 0.5]];
+      runUntilDate:[NSDate dateWithTimeIntervalSinceNow:batchExpiresIn]];
 
   // 1. Check for expiration.
   [[GDTCORFlatFileStorage sharedInstance] checkForExpirations];


### PR DESCRIPTION
Fixes the following issue. It it possible that a batch expiration time is shorter than an event expiration time. With the old implementation in this case when the batch expires it will lead to removing all the events in it disregarding the event expiration time. 

The proposed fix:
- check batches for expiration first
- remove expired batches and move events from them back to the main location (unconditionally) 
- check and remove expired events from the main location (expired events from expired batches will also be there)