### PR TITLE
ABTesting - Repo-relative imports and SwiftPM

### DIFF
--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseABTesting'
-  s.version          = '4.0.0'
+  s.version          = '4.1.0'
   s.summary          = 'Firebase ABTesting'
 
   s.description      = <<-DESC

--- a/FirebaseABTesting/Sources/ABTConditionalUserPropertyController.m
+++ b/FirebaseABTesting/Sources/ABTConditionalUserPropertyController.m
@@ -14,8 +14,8 @@
 
 #import "FirebaseABTesting/Sources/ABTConditionalUserPropertyController.h"
 
-#import <FirebaseABTesting/FIRLifecycleEvents.h>
 #import "FirebaseABTesting/Sources/ABTConstants.h"
+#import "FirebaseABTesting/Sources/Public/FIRLifecycleEvents.h"
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "Interop/Analytics/Public/FIRAnalyticsInterop.h"
 

--- a/FirebaseABTesting/Sources/FIRExperimentController.m
+++ b/FirebaseABTesting/Sources/FIRExperimentController.m
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import <FirebaseABTesting/FIRExperimentController.h>
+#import "FirebaseABTesting/Sources/Public/FIRExperimentController.h"
 
-#import <FirebaseABTesting/FIRLifecycleEvents.h>
 #import "FirebaseABTesting/Sources/ABTConditionalUserPropertyController.h"
 #import "FirebaseABTesting/Sources/ABTConstants.h"
 #import "FirebaseABTesting/Sources/Private/ABTExperimentPayload.h"
+#import "FirebaseABTesting/Sources/Public/FIRLifecycleEvents.h"
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 
 #import "Interop/Analytics/Public/FIRAnalyticsInterop.h"

--- a/FirebaseABTesting/Sources/FIRLifecycleEvents.m
+++ b/FirebaseABTesting/Sources/FIRLifecycleEvents.m
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import <FirebaseABTesting/FIRLifecycleEvents.h>
+#import "FirebaseABTesting/Sources/Public/FIRLifecycleEvents.h"
 
-#import <FirebaseABTesting/FIRExperimentController.h>
+#import "FirebaseABTesting/Sources/Public/FIRExperimentController.h"
 
 /// Default name of the analytics event to be logged when an experiment is set.
 NSString *const FIRSetExperimentEventName = @"_exp_set";

--- a/FirebaseABTesting/Tests/Unit/ABTConditionalUserPropertyControllerTest.m
+++ b/FirebaseABTesting/Tests/Unit/ABTConditionalUserPropertyControllerTest.m
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #import <XCTest/XCTest.h>
+#import "OCMock.h"
 
-#import <FirebaseABTesting/FIRExperimentController.h>
-#import <FirebaseABTesting/FIRLifecycleEvents.h>
-#import <OCMock/OCMock.h>
 #import "FirebaseABTesting/Sources/ABTConditionalUserPropertyController.h"
 #import "FirebaseABTesting/Sources/ABTConstants.h"
 #import "FirebaseABTesting/Sources/Private/ABTExperimentPayload.h"
+#import "FirebaseABTesting/Sources/Public/FIRExperimentController.h"
+#import "FirebaseABTesting/Sources/Public/FIRLifecycleEvents.h"
 #import "FirebaseABTesting/Tests/Unit/ABTFakeFIRAConditionalUserPropertyController.h"
 #import "FirebaseABTesting/Tests/Unit/ABTTestUniversalConstants.h"
 #import "FirebaseABTesting/Tests/Unit/Utilities/ABTTestUtilities.h"

--- a/FirebaseABTesting/Tests/Unit/FIRExperimentControllerTest.m
+++ b/FirebaseABTesting/Tests/Unit/FIRExperimentControllerTest.m
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #import <XCTest/XCTest.h>
+#import "OCMock.h"
 
-#import <FirebaseABTesting/FIRExperimentController.h>
-#import <FirebaseABTesting/FIRLifecycleEvents.h>
-#import <OCMock/OCMock.h>
 #import "FirebaseABTesting/Sources/ABTConditionalUserPropertyController.h"
 #import "FirebaseABTesting/Sources/ABTConstants.h"
 #import "FirebaseABTesting/Sources/Private/ABTExperimentPayload.h"
+#import "FirebaseABTesting/Sources/Public/FIRExperimentController.h"
+#import "FirebaseABTesting/Sources/Public/FIRLifecycleEvents.h"
 #import "FirebaseABTesting/Tests/Unit/ABTFakeFIRAConditionalUserPropertyController.h"
 #import "FirebaseABTesting/Tests/Unit/ABTTestUniversalConstants.h"
 #import "FirebaseABTesting/Tests/Unit/Utilities/ABTTestUtilities.h"

--- a/FirebaseABTesting/Tests/Unit/Utilities/ABTTestUtilities.m
+++ b/FirebaseABTesting/Tests/Unit/Utilities/ABTTestUtilities.m
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import "ABTTestUtilities.h"
+#import "FirebaseABTesting/Tests/Unit/Utilities/ABTTestUtilities.h"
 
 #import "FirebaseABTesting/Sources/Private/ABTExperimentPayload.h"
 

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -51,7 +51,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
 
   s.dependency 'FirebaseCore', '~> 6.8'
   s.dependency 'FirebaseInstallations', '~> 1.1'
-  s.dependency 'FirebaseABTesting', '~> 4.0'
+  s.dependency 'FirebaseABTesting', '~> 4.1'
   s.dependency 'GoogleUtilities/Environment', '~> 6.7'
   s.dependency 'nanopb', '~> 1.30905.0'
 

--- a/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
+++ b/FirebaseInAppMessaging/Sources/Data/FIRIAMFetchResponseParser.m
@@ -25,7 +25,7 @@
 #import "FIRIAMTimeFetcher.h"
 #import "UIColor+FIRIAMHexString.h"
 
-#import <FirebaseABTesting/ABTExperimentPayload.h>
+#import "FirebaseABTesting/Sources/Private/ABTExperimentPayload.h"
 
 @interface FIRIAMFetchResponseParser ()
 @property(nonatomic) id<FIRIAMTimeFetcher> timeFetcher;

--- a/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
+++ b/FirebaseInAppMessaging/Sources/Flows/FIRIAMDisplayExecutor.m
@@ -26,7 +26,7 @@
 #import "FIRInAppMessaging.h"
 #import "FIRInAppMessagingRenderingPrivate.h"
 
-#import <FirebaseABTesting/FIRExperimentController.h>
+#import "FirebaseABTesting/Sources/Public/FIRExperimentController.h"
 
 @implementation FIRIAMDisplaySetting
 @end

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMDisplayExecutorTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMDisplayExecutorTests.m
@@ -24,7 +24,7 @@
 #import "FIRInAppMessaging.h"
 #import "FIRInAppMessagingRenderingPrivate.h"
 
-#import <FirebaseABTesting/ABTExperimentPayload.h>
+#import "FirebaseABTesting/Sources/Private/ABTExperimentPayload.h"
 
 // A class implementing protocol FIRIAMMessageContentData to be used for unit testing
 @interface FIRIAMMessageContentDataForTesting : NSObject <FIRIAMMessageContentData>

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -44,7 +44,7 @@ app update.
       'FIRRemoteConfig_VERSION=' + String(s.version),
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
   }
-  s.dependency 'FirebaseABTesting', '~> 4.0'
+  s.dependency 'FirebaseABTesting', '~> 4.1'
   s.dependency 'FirebaseCore', '~> 6.8'
   s.dependency 'FirebaseInstallations', '~> 1.1'
   s.dependency 'GoogleUtilities/Environment', '~> 6.7'

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -16,7 +16,7 @@
 
 #import <FirebaseRemoteConfig/FIRRemoteConfig.h>
 
-#import <FirebaseABTesting/FIRExperimentController.h>
+#import "FirebaseABTesting/Sources/Public/FIRExperimentController.h"
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "FirebaseRemoteConfig/Sources/FIRRemoteConfigComponent.h"
 #import "FirebaseRemoteConfig/Sources/Private/FIRRemoteConfig_Private.h"

--- a/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
@@ -16,9 +16,9 @@
 
 #import "FirebaseRemoteConfig/Sources/RCNConfigExperiment.h"
 
-#import <FirebaseABTesting/ABTExperimentPayload.h>
-#import <FirebaseABTesting/FIRExperimentController.h>
-#import <FirebaseABTesting/FIRLifecycleEvents.h>
+#import "FirebaseABTesting/Sources/Private/ABTExperimentPayload.h"
+#import "FirebaseABTesting/Sources/Public/FIRExperimentController.h"
+#import "FirebaseABTesting/Sources/Public/FIRLifecycleEvents.h"
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigDBManager.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigDefines.h"

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m
@@ -25,8 +25,8 @@
 #import "FirebaseRemoteConfig/Sources/RCNConfigValue_Internal.h"
 #import "FirebaseRemoteConfig/Tests/Unit/RCNTestUtilities.h"
 
-#import <FirebaseABTesting/ABTExperimentPayload.h>
-#import <FirebaseABTesting/FIRExperimentController.h>
+#import "FirebaseABTesting/Sources/Private/ABTExperimentPayload.h"
+#import "FirebaseABTesting/Sources/Public/FIRExperimentController.h"
 
 #import <OCMock/OCMock.h>
 #import "Interop/Analytics/Public/FIRAnalyticsInterop.h"

--- a/Package.swift
+++ b/Package.swift
@@ -88,6 +88,7 @@ let package = Package(
       name: "firebase-test",
       dependencies: [
         "FirebaseAuth",
+        "FirebaseABTesting",
         "FirebaseFunctions",
         "Firebase",
         "FirebaseCrashlytics",
@@ -264,6 +265,30 @@ let package = Package(
         .headerSearchPath("../../.."),
       ]
     ),
+    .target(
+      name: "FirebaseABTesting",
+      dependencies: ["FirebaseCore"],
+      path: "FirebaseABTesting/Sources",
+      publicHeadersPath: "Public",
+      cSettings: [
+        .headerSearchPath("../../"),
+        .define("FIRABTesting_VERSION", to: "0.0.1"), // TODO: Fix version
+      ]
+    ),
+    // Disabled. Pending resolution of accessing SPM resources from Objective C.
+    // See https://forums.swift.org/t/finding-swift-package-manager-resources/38058
+//    .testTarget(
+//      name: "ABTestingUnit",
+//      dependencies: ["FirebaseABTesting", "OCMock"],
+//      path: "FirebaseABTesting/Tests/Unit",
+//      resources: [.process("Resources")],
+    ////      resources: [
+    ////
+    ////        "Resources/TestABTPayload1.txt"],
+//      cSettings: [
+//        .headerSearchPath("../../.."),
+//      ]
+//    ),
     .target(
       name: "FirebaseAuth",
       dependencies: ["FirebaseCore",

--- a/Tests/firebase-test/main.swift
+++ b/Tests/firebase-test/main.swift
@@ -16,6 +16,7 @@ import Foundation
 import Firebase
 import FirebaseCore
 import FirebaseAuth
+import FirebaseABTesting
 import FirebaseCrashlytics
 import FirebaseFunctions
 import FirebaseInstallations

--- a/scripts/change_headers.swift
+++ b/scripts/change_headers.swift
@@ -20,13 +20,14 @@
 import Foundation
 
 // Update with directories in which to find headers.
-let findHeaders = ["Crashlytics"]
+let findHeaders = ["FirebaseABTesting"]
 
 // Update with directories in which to change imports.
 let changeImports = ["GoogleUtilities", "FirebaseAuth", "FirebaseCore", "Firebase",
                      "FirebaseDatabase", "GoogleDataTransport",
                      "FirebaseDynamicLinks", "FirebaseInAppMessaging", "FirebaseMessaging",
                      "FirebaseRemoteConfig", "FirebaseInstallations", "Functions",
+                     "FirebaseABTesting",
                      "FirebaseAppDistribution", "Example", "Crashlytics", "FirebaseStorage"]
 
 // Skip these directories. Imports should only be repo-relative in libraries

--- a/scripts/check_imports.swift
+++ b/scripts/check_imports.swift
@@ -34,7 +34,6 @@ let skipDirPatterns = ["/Sample/", "/Pods/", "FirebaseStorage/Tests/Integration"
 
   // The following are temporary skips pending working through a first pass of the repo:
   [
-    "FirebaseABTesting",
     "FirebaseAppDistribution",
     "FirebaseCore/Sources/Private", // Fixes require breaking private API changes. For Firebase 7.
     "FirebaseDynamicLinks",


### PR DESCRIPTION
Run ./scripts/change_headers.swift to update all ABT source to be repo-relative
Turn on Swift Package Manager build and CI

#no-changelog - Will be updated in M76 release process