### PR TITLE
RC: Repo-relative imports and SwiftPM

### DIFF
--- a/FirebaseRemoteConfig/Sources/FIRConfigValue.m
+++ b/FirebaseRemoteConfig/Sources/FIRConfigValue.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <FirebaseRemoteConfig/FIRRemoteConfig.h>
+#import "FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h"
 
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigValue_Internal.h"

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <FirebaseRemoteConfig/FIRRemoteConfig.h>
+#import "FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h"
 
 #import "FirebaseABTesting/Sources/Public/FIRExperimentController.h"
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"

--- a/FirebaseRemoteConfig/Sources/Private/FIRRemoteConfig_Private.h
+++ b/FirebaseRemoteConfig/Sources/Private/FIRRemoteConfig_Private.h
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#import <FirebaseRemoteConfig/FIRRemoteConfig.h>
+#import "FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h"
 
-#import <FirebaseRemoteConfig/RCNConfigFetch.h>
-#import <FirebaseRemoteConfig/RCNConfigSettings.h>
+#import "FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h"
+#import "FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h"
 #import "Interop/Analytics/Public/FIRAnalyticsInterop.h"
 
 @class FIROptions;

--- a/FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h
+++ b/FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <FirebaseRemoteConfig/FIRRemoteConfig.h>
+#import "FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h"
 #import "Interop/Analytics/Public/FIRAnalyticsInterop.h"
 
 @class FIROptions;

--- a/FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h
+++ b/FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <FirebaseRemoteConfig/FIRRemoteConfig.h>
+#import "FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h"
 
 @class RCNConfigDBManager;
 

--- a/FirebaseRemoteConfig/Sources/RCNConfigContent.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigContent.m
@@ -16,7 +16,7 @@
 
 #import "FirebaseRemoteConfig/Sources/RCNConfigContent.h"
 
-#import <FirebaseRemoteConfig/FIRRemoteConfig.h>
+#import "FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigConstants.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigDBManager.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigDefines.h"

--- a/FirebaseRemoteConfig/Sources/RCNConfigValue_Internal.h
+++ b/FirebaseRemoteConfig/Sources/RCNConfigValue_Internal.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <FirebaseRemoteConfig/FIRRemoteConfig.h>
+#import "FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h"
 
 @interface FIRRemoteConfigValue ()
 @property(nonatomic, readwrite, assign) FIRRemoteConfigSource source;

--- a/FirebaseRemoteConfig/Sources/RCNConstants3P.m
+++ b/FirebaseRemoteConfig/Sources/RCNConstants3P.m
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#import <FirebaseRemoteConfig/FIRRemoteConfig.h>
+#import "FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h"
 
 /// Firebase Remote Config service default namespace.
 NSString *const FIRNamespaceGoogleMobilePlatform = @"firebase";

--- a/FirebaseRemoteConfig/Sources/RCNUserDefaultsManager.m
+++ b/FirebaseRemoteConfig/Sources/RCNUserDefaultsManager.m
@@ -15,8 +15,8 @@
  */
 
 #import "FirebaseRemoteConfig/Sources/RCNUserDefaultsManager.h"
-#import <FirebaseRemoteConfig/FIRRemoteConfig.h>
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
+#import "FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h"
 
 static NSString *const kRCNGroupPrefix = @"group";
 static NSString *const kRCNGroupSuffix = @"firebase";

--- a/FirebaseRemoteConfig/Tests/FakeUtils/Bridging-Header.h
+++ b/FirebaseRemoteConfig/Tests/FakeUtils/Bridging-Header.h
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import <FirebaseRemoteConfig/FIRRemoteConfig_Private.h>
-#import "FetchMocks.h"
+#import "FirebaseRemoteConfig/Sources/Private/FIRRemoteConfig_Private.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigConstants.h"
+#import "FirebaseRemoteConfig/Tests/FakeUtils/FetchMocks.h"

--- a/FirebaseRemoteConfig/Tests/FakeUtils/FetchMocks.m
+++ b/FirebaseRemoteConfig/Tests/FakeUtils/FetchMocks.m
@@ -14,8 +14,8 @@
 
 #import <OCMock/OCMock.h>
 
-#import "FetchMocks.h"
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h"
+#import "FirebaseRemoteConfig/Tests/FakeUtils/FetchMocks.h"
 
 @interface RCNConfigFetch (ExposedForTest)
 - (void)refreshInstallationsTokenWithCompletionHandler:

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigAnalyticsTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigAnalyticsTest.m
@@ -15,8 +15,8 @@
  */
 
 #import <XCTest/XCTest.h>
+#import "OCMock.h"
 
-#import <OCMock/OCMock.h>
 #import "RCNConfigAnalytics.h"
 
 @interface RCNConfigAnalyticsTest : XCTestCase {

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigAnalyticsTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigAnalyticsTest.m
@@ -17,7 +17,7 @@
 #import <XCTest/XCTest.h>
 #import "OCMock.h"
 
-#import "RCNConfigAnalytics.h"
+//#import "RCNConfigAnalytics.h"
 
 @interface RCNConfigAnalyticsTest : XCTestCase {
   id _mockAnalytics;

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigContentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigContentTest.m
@@ -15,8 +15,8 @@
  */
 
 #import <XCTest/XCTest.h>
+#import "OCMock.h"
 
-#import <OCMock/OCMock.h>
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h"
 #import "FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigContent.h"

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigDBManagerTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigDBManagerTest.m
@@ -15,10 +15,10 @@
  */
 
 #import <XCTest/XCTest.h>
+#import "OCMock.h"
 
 #import "sqlite3.h"
 
-#import <OCMock/OCMock.h>
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigConstants.h"

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigDBManagerTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigDBManagerTest.m
@@ -17,7 +17,7 @@
 #import <XCTest/XCTest.h>
 #import "OCMock.h"
 
-#import "sqlite3.h"
+#import <sqlite3.h>
 
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h"

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
+#import <XCTest/XCTest.h>
+#import "OCMock.h"
+
 #import "FirebaseRemoteConfig/Sources/RCNConfigExperiment.h"
 
-#import <XCTest/XCTest.h>
-
-#import <FirebaseRemoteConfig/FIRRemoteConfig.h>
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h"
+#import "FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigDBManager.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigDefines.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigValue_Internal.h"
@@ -28,7 +29,6 @@
 #import "FirebaseABTesting/Sources/Private/ABTExperimentPayload.h"
 #import "FirebaseABTesting/Sources/Public/FIRExperimentController.h"
 
-#import <OCMock/OCMock.h>
 #import "Interop/Analytics/Public/FIRAnalyticsInterop.h"
 
 // Surface the internal FIRExperimentController initializer.
@@ -203,6 +203,7 @@
   XCTAssertEqual(time, originalTime);
 }
 
+#if !SWIFT_PACKAGE
 - (void)testUpdateExperiments {
   FIRExperimentController *experimentController =
       [[FIRExperimentController alloc] initWithAnalytics:nil];
@@ -233,6 +234,7 @@
   [experiment updateExperiments];
   XCTAssertEqualObjects(experiment.experimentMetadata[@"last_experiment_start_time"], @(12345678));
 }
+#endif
 
 #pragma mark Helpers.
 

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m
@@ -203,7 +203,6 @@
   XCTAssertEqual(time, originalTime);
 }
 
-#if !SWIFT_PACKAGE
 - (void)testUpdateExperiments {
   FIRExperimentController *experimentController =
       [[FIRExperimentController alloc] initWithAnalytics:nil];
@@ -234,7 +233,6 @@
   [experiment updateExperiments];
   XCTAssertEqualObjects(experiment.experimentMetadata[@"last_experiment_start_time"], @(12345678));
 }
-#endif
 
 #pragma mark Helpers.
 
@@ -255,8 +253,12 @@
 }
 
 + (NSData *)payloadDataFromTestFile {
-  NSString *testJsonDataFilePath =
-      [[NSBundle bundleForClass:[self class]] pathForResource:@"TestABTPayload" ofType:@"txt"];
+#if SWIFT_PACKAGE
+  NSBundle *bundle = Firebase_RemoteConfigUnit_SWIFTPM_MODULE_BUNDLE();
+#else
+  NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+#endif
+  NSString *testJsonDataFilePath = [bundle pathForResource:@"TestABTPayload" ofType:@"txt"];
   NSError *readTextError = nil;
   NSString *fileText = [[NSString alloc] initWithContentsOfFile:testJsonDataFilePath
                                                        encoding:NSUTF8StringEncoding

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigSettingsTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigSettingsTest.m
@@ -15,8 +15,8 @@
  */
 
 #import <XCTest/XCTest.h>
+#import "OCMock.h"
 
-#import <OCMock/OCMock.h>
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigConstants.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigDBManager.h"

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigTest.m
@@ -17,8 +17,8 @@
 #import <XCTest/XCTest.h>
 #import "OCMock.h"
 
-#import <FirebaseInstanceID/FIRInstanceID+Private.h>
-#import <FirebaseInstanceID/FIRInstanceIDCheckinPreferences.h>
+//#import <FirebaseInstanceID/FIRInstanceID+Private.h>
+//#import <FirebaseInstanceID/FIRInstanceIDCheckinPreferences.h>
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigConstants.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigContent.h"

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigTest.m
@@ -15,10 +15,10 @@
  */
 
 #import <XCTest/XCTest.h>
+#import "OCMock.h"
 
 #import <FirebaseInstanceID/FIRInstanceID+Private.h>
 #import <FirebaseInstanceID/FIRInstanceIDCheckinPreferences.h>
-#import <OCMock/OCMock.h>
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigConstants.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigContent.h"

--- a/FirebaseRemoteConfig/Tests/Unit/RCNInstanceIDTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNInstanceIDTest.m
@@ -15,17 +15,17 @@
  */
 
 #import <XCTest/XCTest.h>
+#import "OCMock.h"
 
-#import <FirebaseRemoteConfig/FIRRemoteConfig.h>
 #import "FirebaseRemoteConfig/Sources/Private/FIRRemoteConfig_Private.h"
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h"
+#import "FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigConstants.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigDBManager.h"
 #import "FirebaseRemoteConfig/Sources/RCNUserDefaultsManager.h"
 
 #import "FirebaseRemoteConfig/Tests/Unit/RCNTestUtilities.h"
 
-#import <OCMock/OCMock.h>
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "FirebaseInstallations/Source/Library/Private/FirebaseInstallationsInternal.h"
 #import "GoogleUtilities/NSData+zlib/Private/GULNSDataInternal.h"

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfig+FIRAppTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfig+FIRAppTest.m
@@ -20,7 +20,7 @@
 //#import "FIRRemoteConfig+FIRApp.h"
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "FirebaseRemoteConfig/Sources/Private/FIRRemoteConfig_Private.h"
-#import "third_party/firebase/ios/Releases/FirebaseCore/Tests/FIRTestCase.h"
+//#import "third_party/firebase/ios/Releases/FirebaseCore/Tests/FIRTestCase.h"
 
 @interface RCNRemoteConfig_FIRAppTest : FIRTestCase
 

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfig+FIRAppTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfig+FIRAppTest.m
@@ -15,11 +15,11 @@
  */
 
 #import <XCTest/XCTest.h>
+#import "OCMock.h"
 
 //#import "FIRRemoteConfig+FIRApp.h"
-#import <OCMock/OCMock.h>
-#import "FIRRemoteConfig_Private.h"
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
+#import "FirebaseRemoteConfig/Sources/Private/FIRRemoteConfig_Private.h"
 #import "third_party/firebase/ios/Releases/FirebaseCore/Tests/FIRTestCase.h"
 
 @interface RCNRemoteConfig_FIRAppTest : FIRTestCase

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -15,18 +15,18 @@
  */
 
 #import <XCTest/XCTest.h>
+#import "OCMStubRecorder.h"
+#import "OCMock.h"
 
-#import <FirebaseRemoteConfig/FIRRemoteConfig.h>
 #import "FirebaseRemoteConfig/Sources/Private/FIRRemoteConfig_Private.h"
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h"
+#import "FirebaseRemoteConfig/Sources/Public/FIRRemoteConfig.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigConstants.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigDBManager.h"
 #import "FirebaseRemoteConfig/Sources/RCNUserDefaultsManager.h"
 
 #import "FirebaseRemoteConfig/Tests/Unit/RCNTestUtilities.h"
 
-#import <OCMock/OCMStubRecorder.h>
-#import <OCMock/OCMock.h>
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "GoogleUtilities/NSData+zlib/Private/GULNSDataInternal.h"
 
@@ -1143,6 +1143,7 @@ static NSString *UTCToLocal(NSString *utcTime) {
   return [dateFormatter stringFromDate:date];
 }
 
+#if !SWIFT_PACKAGE
 - (void)testSetDefaultsFromPlist {
   for (int i = 0; i < RCNTestRCNumTotalInstances; i++) {
     FIRRemoteConfig *config = _configInstances[i];
@@ -1221,6 +1222,7 @@ static NSString *UTCToLocal(NSString *utcTime) {
     }
   }
 }
+#endif
 
 - (void)testSetDeveloperMode {
   for (int i = 0; i < RCNTestRCNumTotalInstances; i++) {

--- a/FirebaseRemoteConfig/Tests/Unit/RCNThrottlingTests.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNThrottlingTests.m
@@ -15,6 +15,7 @@
  */
 
 #import <XCTest/XCTest.h>
+#import "OCMock.h"
 
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigFetch.h"
 #import "FirebaseRemoteConfig/Sources/Private/RCNConfigSettings.h"
@@ -23,7 +24,6 @@
 #import "FirebaseRemoteConfig/Sources/RCNConfigExperiment.h"
 #import "FirebaseRemoteConfig/Tests/Unit/RCNTestUtilities.h"
 
-#import <OCMock/OCMock.h>
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 
 @interface RCNThrottlingTests : XCTestCase {

--- a/Package.swift
+++ b/Package.swift
@@ -95,6 +95,7 @@ let package = Package(
         "FirebaseCore",
         "FirebaseInstallations",
         // "FirebaseInstanceID",
+        "FirebaseRemoteConfig",
         "FirebaseStorage",
         "FirebaseStorageSwift",
         "GoogleDataTransport",
@@ -394,6 +395,41 @@ let package = Package(
       publicHeadersPath: "Public",
       cSettings: [
         .headerSearchPath("../"),
+      ]
+    ),
+    .target(
+      name: "FirebaseRemoteConfig",
+      dependencies: [
+        "FirebaseCore",
+        "FirebaseABTesting",
+        "FirebaseInstallations",
+        "GoogleUtilities_NSData",
+      ],
+      path: "FirebaseRemoteConfig/Sources",
+      publicHeadersPath: "Public",
+      cSettings: [
+        .headerSearchPath("../../"),
+        .define("FIRRemoteConfig_VERSION", to: "0.0.1"), // TODO: Fix version
+      ]
+    ),
+    .testTarget(
+      name: "RemoteConfigUnit",
+      dependencies: ["FirebaseRemoteConfig", "OCMock"],
+      path: "FirebaseRemoteConfig/Tests/Unit",
+      exclude: [
+        // Need to be evaluated/ported to RC V2.
+        "RCNConfigAnalyticsTest.m",
+        "RCNConfigSettingsTest.m",
+        "RCNConfigTest.m",
+        "RCNRemoteConfig+FIRAppTest.m",
+        "RCNThrottlingTests.m",
+        // Handle Resources.
+        "SecondApp-GoogleService-Info.plist",
+        "Defaults-testInfo.plist",
+        "TestABTPayload.txt",
+      ],
+      cSettings: [
+        .headerSearchPath("../../.."),
       ]
     ),
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -423,11 +423,12 @@ let package = Package(
         "RCNConfigTest.m",
         "RCNRemoteConfig+FIRAppTest.m",
         "RCNThrottlingTests.m",
-        // Handle Resources.
-        "SecondApp-GoogleService-Info.plist",
-        "Defaults-testInfo.plist",
-        "TestABTPayload.txt",
       ],
+      resources: [
+        .process("SecondApp-GoogleService-Info.plist"),
+        .process("Defaults-testInfo.plist"),
+        .process("TestABTPayload.txt"),
+        ],
       cSettings: [
         .headerSearchPath("../../.."),
       ]

--- a/Package.swift
+++ b/Package.swift
@@ -428,7 +428,7 @@ let package = Package(
         .process("SecondApp-GoogleService-Info.plist"),
         .process("Defaults-testInfo.plist"),
         .process("TestABTPayload.txt"),
-        ],
+      ],
       cSettings: [
         .headerSearchPath("../../.."),
       ]

--- a/Tests/firebase-test/main.swift
+++ b/Tests/firebase-test/main.swift
@@ -21,6 +21,7 @@ import FirebaseCrashlytics
 import FirebaseFunctions
 import FirebaseInstallations
 // import FirebaseInstanceID
+import FirebaseRemoteConfig
 import FirebaseStorage
 import FirebaseStorageSwift
 import GoogleDataTransport

--- a/scripts/change_headers.swift
+++ b/scripts/change_headers.swift
@@ -20,7 +20,7 @@
 import Foundation
 
 // Update with directories in which to find headers.
-let findHeaders = ["FirebaseABTesting"]
+let findHeaders = ["FirebaseRemoteConfig"]
 
 // Update with directories in which to change imports.
 let changeImports = ["GoogleUtilities", "FirebaseAuth", "FirebaseCore", "Firebase",

--- a/scripts/check_imports.swift
+++ b/scripts/check_imports.swift
@@ -44,7 +44,6 @@ let skipDirPatterns = ["/Sample/", "/Pods/", "FirebaseStorage/Tests/Integration"
     "FirebaseInstallations/Source/Tests/Unit/",
     "Firebase/InstanceID",
     "FirebaseMessaging",
-    "FirebaseRemoteConfig",
     "Firestore",
     "GoogleUtilitiesComponents",
   ]


### PR DESCRIPTION
- Run ./scripts/change_headers.swift to update all RC source to be repo-relative
- Turn on Swift Package Manager build and CI
- Update three tests that require resources to use SPM bundle on ifdef

#no-changelog - Will be updated in M76 release process