### PR TITLE
Enable cron job schedule for Firebase Performance tests on private repository

### DIFF
--- a/.github/workflows/performance-integration-tests.yml
+++ b/.github/workflows/performance-integration-tests.yml
@@ -1,0 +1,29 @@
+# Merge the yml file to master branch for the cron job schedule to be effective.
+# Reference: https://github.community/t/on-schedule-per-branch/17525
+name: performance-integration-tests
+
+on:
+  # See cron syntax references:
+  #   - https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule
+  #   - https://crontab.guru/
+  schedule:
+    # Runs every 1 hours.
+    # TODO: It is unclear when the timer starts.
+    - cron:  '0 */1 * * *'
+
+jobs:
+
+  # Build and run the Integration Tests for the Firebase performance E2E Test App.
+  performance-integration-tests:
+    # Firebase Performance lives in private repository only currently.
+    # Remove the check after Firebase Performance is open sourced.
+    if: github.repository == 'FirebasePrivate/firebase-ios-sdk'
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: perf
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
+      run: scripts/third_party/travis/retry.sh scripts/build.sh Performance all integration

--- a/.github/workflows/performance-integration-tests.yml
+++ b/.github/workflows/performance-integration-tests.yml
@@ -8,7 +8,8 @@ on:
   #   - https://crontab.guru/
   schedule:
     # Runs every 1 hours.
-    # TODO: It is unclear when the timer starts.
+    # TODO: Revert job run frequency back to 4 hours after validation.
+    # TODO: Validate when the timer starts after job is triggered.
     - cron:  '0 */1 * * *'
 
 jobs:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,0 +1,56 @@
+# Merge the yml file to master branch for the cron job schedule to be effective.
+# Reference: https://github.community/t/on-schedule-per-branch/17525
+name: performance
+
+on:
+  pull_request:
+    paths:
+    # Performance sources
+    - 'FirebasePerformance/**'
+    # Podspec
+    - 'FirebasePerformance.podspec'
+    # YML configuration file
+    - '.github/workflows/performance.yml'
+    # Rebuild on Ruby infrastructure changes
+    - 'Gemfile'
+  schedule:
+    # Run every day at 3am (PST) - cron uses UTC times
+    # This is set to 3 hours after zip workflow so zip testing can run after.
+    # Specified in format 'minutes hours day month dayofweek'
+    - cron:  '0 11 * * *'
+
+jobs:
+
+  # Build and run the unit tests for Firebase performance SDK.
+  performance:
+    # Firebase Performance lives in private repository only currently.
+    # Remove the check after Firebase Performance is open sourced.
+    if: github.repository == 'FirebasePrivate/firebase-ios-sdk'
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: perf
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: BuildAndTest # can be replaced with pod lib lint with CocoaPods 1.10
+      run: scripts/third_party/travis/retry.sh scripts/build.sh Performance all xcodebuild
+
+  # Podspec lint check for Firebase Performance
+  pod-lib-lint:
+    # Firebase Performance lives in private repository only currently.
+    # Remove the check after Firebase Performance is open sourced.
+    if: github.repository == 'FirebasePrivate/firebase-ios-sdk'
+    runs-on: macOS-latest
+
+    strategy:
+      matrix:
+        target: [ios]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: perf
+    - name: Setup Bundler
+      run: scripts/setup_bundler.sh
+    - name: Build
+      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebasePerformance.podspec --skip-tests --platforms=${{ matrix.target }}


### PR DESCRIPTION
Add yml files for triggering Firebase Performance related tests on `private` repository `perf` branch.

### Explanation

Firebase Performance is currently on private repository only, and `private` repository `master` branch is in sync with `public` repository `master` branch. Any changes to `master` branch needs to happen on `public` repository only.

On private repository, currently Firebase Performance is working on a branch called `perf`, we have scheduled cron job for running tests to validate the most recent changes. 

However, `on.schedule` will run on `master` branch only: See [reference to on.schedule](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onschedule).

In order to trigger jobs on `perf` branch, we need to add yml files to master branch, and enable its reference branch to `perf`. See [GitHub Answer](https://github.community/t/on-schedule-per-branch/17525).

### Process

Change in Github public repository master branch -> Change is synced back to private repository master branch -> Trigger scheduled job based on cron tab -> Run tests on Private repository only -> Checkout code from `perf` branch -> Finish test.
