### PR TITLE
Add #include for config.h to get the value for HAVE_LIBDISPATCH.

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Unreleased
+# v1.16.2
+- [fixed] Fixed a configuration issue where listeners were no longer being
+  called back on the main thread by default.
 
 # v1.16.1
 - [fixed] Removed a delay that may have prevented Firestore from immediately

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Unreleased
+
 # v1.16.2
 - [fixed] Fixed a configuration issue where listeners were no longer being
   called back on the main thread by default.

--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -42,6 +42,7 @@
 #include "Firestore/core/src/core/transaction.h"
 #include "Firestore/core/src/model/database_id.h"
 #include "Firestore/core/src/util/async_queue.h"
+#include "Firestore/core/src/util/config.h"
 #include "Firestore/core/src/util/empty.h"
 #include "Firestore/core/src/util/error_apple.h"
 #include "Firestore/core/src/util/exception.h"


### PR DESCRIPTION
`FIRFirestore.mm` was updated in #5920 to use a non-libdispatch executor if `HAVE_LIBDISPATCH` is false; however, the `config.h` header file that defines `HAVE_LIBDISPATCH` was neither directly nor indirectly included, causing the `#if HAVE_LIBDISPATCH` statement to unconditionally evaluate to false. The effect of this was that callbacks from Firestore in iOS were changed to run on a non-main thread and should have been run on the main thread.