### PR TITLE
Fix import regression when mixing 6.7.0 with earlier Firebase versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -293,3 +293,4 @@ jobs:
 branches:
   only:
     - master
+    - pb-fix6047

--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleUtilities'
-  s.version          = '6.7.0'
+  s.version          = '6.7.1'
   s.summary          = 'Google Utilities for iOS (plus community support for macOS and tvOS)'
 
   s.description      = <<-DESC

--- a/GoogleUtilities/AppDelegateSwizzler/Private/GULAppDelegateSwizzler.h
+++ b/GoogleUtilities/AppDelegateSwizzler/Private/GULAppDelegateSwizzler.h
@@ -16,7 +16,11 @@
 
 #import <Foundation/Foundation.h>
 
+#if SWIFT_PACKAGE
 #import "GoogleUtilities/AppDelegateSwizzler/Private/GULApplication.h"
+#else
+#import <GoogleUtilities/GULApplication.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/GoogleUtilities/CHANGELOG.md
+++ b/GoogleUtilities/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 6.7.1
+- Fix import regression when mixing 6.7.0 with earlier Firebase versions. (#6047)
+
 # 6.7.0 -- M75
 - Lazily access filesystem outside of `GULHeartbeatDateStorage` initializer. (#5969)
 - Update source imports to use repo-relative headers. (#5824)


### PR DESCRIPTION
Fix #6047 

Repo-relative imports don't work from .h files that are imported from other pods (even though it works in development pods.)