### PR TITLE
Add forbidBackgroundSessions param to putData, putFile, writeToFile

### DIFF
--- a/FirebaseStorage/Sources/FIRStorageDownloadTask.m
+++ b/FirebaseStorage/Sources/FIRStorageDownloadTask.m
@@ -72,6 +72,10 @@
       fetcher = [strongSelf.fetcherService fetcherWithRequest:request];
       fetcher.comment = @"Starting DownloadTask";
     }
+      
+    if (strongSelf.forbidBackgroundSessions) {
+      [fetcher setUseBackgroundSession:NO];
+    }
 
     [fetcher setResumeDataBlock:^(NSData *data) {
       FIRStorageDownloadTask *strong = weakSelf;

--- a/FirebaseStorage/Sources/FIRStorageReference.m
+++ b/FirebaseStorage/Sources/FIRStorageReference.m
@@ -163,6 +163,13 @@
 - (FIRStorageUploadTask *)putData:(NSData *)uploadData
                          metadata:(nullable FIRStorageMetadata *)metadata
                        completion:(nullable FIRStorageVoidMetadataError)completion {
+  return [self putData:uploadData metadata:metadata forbidBackgroundSessions:NO completion:completion];
+}
+
+- (FIRStorageUploadTask *)putData:(NSData *)uploadData
+                         metadata:(nullable FIRStorageMetadata *)metadata
+         forbidBackgroundSessions:(BOOL)forbidBackgroundSessions
+                       completion:(nullable FIRStorageVoidMetadataError)completion {
   if (!metadata) {
     metadata = [[FIRStorageMetadata alloc] init];
   }
@@ -176,6 +183,7 @@
                                                  data:uploadData
                                              metadata:metadata];
 
+  task.forbidBackgroundSessions = forbidBackgroundSessions;
   if (completion) {
     __block BOOL completed = NO;
     dispatch_queue_t callbackQueue = _storage.fetcherServiceForApp.callbackQueue;
@@ -218,6 +226,13 @@
 - (FIRStorageUploadTask *)putFile:(NSURL *)fileURL
                          metadata:(nullable FIRStorageMetadata *)metadata
                        completion:(nullable FIRStorageVoidMetadataError)completion {
+  return [self putFile:fileURL metadata:metadata forbidBackgroundSessions:NO completion:completion];
+}
+
+- (FIRStorageUploadTask *)putFile:(NSURL *)fileURL
+                         metadata:(nullable FIRStorageMetadata *)metadata
+         forbidBackgroundSessions:(BOOL)forbidBackgroundSessions
+                       completion:(nullable FIRStorageVoidMetadataError)completion {
   if (!metadata) {
     metadata = [[FIRStorageMetadata alloc] init];
   }
@@ -231,6 +246,7 @@
                                                  file:fileURL
                                              metadata:metadata];
 
+  task.forbidBackgroundSessions = forbidBackgroundSessions;
   if (completion) {
     __block BOOL completed = NO;
     dispatch_queue_t callbackQueue = _storage.fetcherServiceForApp.callbackQueue;
@@ -321,11 +337,18 @@
 
 - (FIRStorageDownloadTask *)writeToFile:(NSURL *)fileURL
                              completion:(FIRStorageVoidURLError)completion {
+  return [self writeToFile:fileURL forbidBackgroundSessions:NO completion:completion];
+}
+
+- (FIRStorageDownloadTask *)writeToFile:(NSURL *)fileURL
+               forbidBackgroundSessions:(BOOL)forbidBackgroundSessions
+                             completion:(FIRStorageVoidURLError)completion {
   FIRStorageDownloadTask *task =
       [[FIRStorageDownloadTask alloc] initWithReference:self
                                          fetcherService:_storage.fetcherServiceForApp
                                           dispatchQueue:_storage.dispatchQueue
                                                    file:fileURL];
+  task.forbidBackgroundSessions = forbidBackgroundSessions;
   if (completion) {
     __block BOOL completed = NO;
     dispatch_queue_t callbackQueue = _storage.fetcherServiceForApp.callbackQueue;

--- a/FirebaseStorage/Sources/FIRStorageUploadTask.m
+++ b/FirebaseStorage/Sources/FIRStorageUploadTask.m
@@ -120,6 +120,9 @@
                                                 chunkSize:kGTMSessionUploadFetcherStandardChunkSize
                                            fetcherService:self.fetcherService];
 
+    if (strongSelf.forbidBackgroundSessions) {
+      [uploadFetcher setUseBackgroundSession:NO];
+    }
     if (strongSelf->_uploadData) {
       [uploadFetcher setUploadData:strongSelf->_uploadData];
       uploadFetcher.comment = @"Data UploadTask";

--- a/FirebaseStorage/Sources/Public/FIRStorageReference.h
+++ b/FirebaseStorage/Sources/Public/FIRStorageReference.h
@@ -135,6 +135,26 @@ NS_SWIFT_NAME(putData(_:metadata:));
 // clang-format on
 
 /**
+ * Asynchronously uploads data to the currently specified FIRStorageReference.
+ * This is not recommended for large files, and one should instead upload a file from disk.
+ * @param uploadData The NSData to upload.
+ * @param metadata FIRStorageMetadata containing additional information (MIME type, etc.)
+ * about the object being uploaded.
+ * @param forbidBackgroundSessions If set to true, prevents GTMSessionFetcher from creating background NSURLSession sessions.
+ * @param completion A completion block that either returns the object metadata on success,
+ * or an error on failure.
+ * @return An instance of FIRStorageUploadTask, which can be used to monitor or manage the upload.
+ */
+// clang-format off
+- (FIRStorageUploadTask *)putData:(NSData *)uploadData
+                         metadata:(nullable FIRStorageMetadata *)metadata
+         forbidBackgroundSessions:(BOOL)forbidBackgroundSessions
+                       completion:(nullable void (^)(FIRStorageMetadata *_Nullable metadata,
+                                                     NSError *_Nullable error))completion
+            NS_SWIFT_NAME(putData(_:metadata:forbidBackgroundSessions:completion:));
+// clang-format on
+
+/**
  * Asynchronously uploads a file to the currently specified FIRStorageReference,
  * without additional metadata.
  * @param fileURL A URL representing the system file path of the object to be uploaded.
@@ -170,6 +190,25 @@ NS_SWIFT_NAME(putData(_:metadata:));
                        completion:(nullable void (^)(FIRStorageMetadata *_Nullable metadata,
                                                      NSError *_Nullable error))completion
            NS_SWIFT_NAME(putFile(from:metadata:completion:));
+// clang-format on
+
+/**
+ * Asynchronously uploads a file to the currently specified FIRStorageReference.
+ * @param fileURL A URL representing the system file path of the object to be uploaded.
+ * @param metadata FIRStorageMetadata containing additional information (MIME type, etc.)
+ * about the object being uploaded.
+ * @param forbidBackgroundSessions If set to true, prevents GTMSessionFetcher from creating background NSURLSession sessions.
+ * @param completion A completion block that either returns the object metadata on success,
+ * or an error on failure.
+ * @return An instance of FIRStorageUploadTask, which can be used to monitor or manage the upload.
+ */
+// clang-format off
+- (FIRStorageUploadTask *)putFile:(NSURL *)fileURL
+                         metadata:(nullable FIRStorageMetadata *)metadata
+         forbidBackgroundSessions:(BOOL)forbidBackgroundSessions
+                       completion:(nullable void (^)(FIRStorageMetadata *_Nullable metadata,
+                                                     NSError *_Nullable error))completion
+           NS_SWIFT_NAME(putFile(from:metadata:forbidBackgroundSessions:completion:));
 // clang-format on
 
 #pragma mark - Downloads
@@ -219,6 +258,21 @@ NS_SWIFT_NAME(putData(_:metadata:));
 - (FIRStorageDownloadTask *)writeToFile:(NSURL *)fileURL
                              completion:(nullable void (^)(NSURL *_Nullable URL,
                                                            NSError *_Nullable error))completion;
+
+/**
+ * Asynchronously downloads the object at the current path to a specified system filepath.
+ * @param fileURL A file system URL representing the path the object should be downloaded to.
+ * @param forbidBackgroundSessions If set to true, prevents GTMSessionFetcher from creating background NSURLSession sessions.
+ * @param completion A completion block that fires when the file download completes.
+ * Returns an NSURL pointing to the file path of the downloaded file on success,
+ * or an error on failure.
+ * @return An FIRStorageDownloadTask that can be used to monitor or manage the download.
+ */
+- (FIRStorageDownloadTask *)writeToFile:(NSURL *)fileURL
+               forbidBackgroundSessions:(BOOL)forbidBackgroundSessions
+                             completion:(nullable void (^)(NSURL *_Nullable URL,
+                                                           NSError *_Nullable error))completion;
+
 #pragma mark - List Support
 
 /**

--- a/FirebaseStorage/Sources/Public/FIRStorageTask.h
+++ b/FirebaseStorage/Sources/Public/FIRStorageTask.h
@@ -37,6 +37,11 @@ NS_SWIFT_NAME(StorageTask)
  */
 @property(strong, readonly, nonatomic, nonnull) FIRStorageTaskSnapshot *snapshot;
 
+/**
+ * Set to YES to prevent GTMSessionFetcher from using background NSURLSession sessions
+ */
+@property BOOL forbidBackgroundSessions;
+
 @end
 
 /**


### PR DESCRIPTION
GTMSessionFetcher has its own internal logic of when to use a background NSURLSession session. Because the FIRStorage layer doesn't reconnect to background sessions, there's no way to have code executed upon success/failure of a background session transfer, which can lead to problems when apps have their own retry / offline logic. This commit adds a parameter to force GTMSessionFetcher to not create background sessions.

This is just a PR for discussion purposes - I have no expectations it'll get accepted