### PR TITLE
Add #ifndef/#error when expected defines are not defined.

### DIFF
--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -171,7 +171,9 @@ NS_ASSUME_NONNULL_BEGIN
     _settings = settings;
     _firestore->set_settings([settings internalSettings]);
 
-#if HAVE_LIBDISPATCH
+#ifndef HAVE_LIBDISPATCH
+#error HAVE_LIBDISPATCH must be set to 1 or 0; verify the #include directive for config.h.
+#elif HAVE_LIBDISPATCH
     std::unique_ptr<util::Executor> user_executor =
         absl::make_unique<util::ExecutorLibdispatch>(settings.dispatchQueue);
 #else

--- a/Firestore/Source/API/FIRFirestore.mm
+++ b/Firestore/Source/API/FIRFirestore.mm
@@ -172,7 +172,7 @@ NS_ASSUME_NONNULL_BEGIN
     _firestore->set_settings([settings internalSettings]);
 
 #ifndef HAVE_LIBDISPATCH
-#error HAVE_LIBDISPATCH must be set to 1 or 0; verify the #include directive for config.h.
+#error HAVE_LIBDISPATCH must be set to 1 or 0; verify the #include for config.h.
 #elif HAVE_LIBDISPATCH
     std::unique_ptr<util::Executor> user_executor =
         absl::make_unique<util::ExecutorLibdispatch>(settings.dispatchQueue);

--- a/Firestore/core/src/util/config.h.in
+++ b/Firestore/core/src/util/config.h.in
@@ -25,16 +25,16 @@
 // building this way we can't test the presence of features before building so
 // predefine all the platform-support feature macros to their expected values.
 
-#cmakedefine HAVE_ARC4RANDOM 1
+#cmakedefine01 HAVE_ARC4RANDOM
 #if COCOAPODS
 #  define HAVE_ARC4RANDOM 1
 #endif
 
-#cmakedefine HAVE_LIBDISPATCH 1
+#cmakedefine01 HAVE_LIBDISPATCH
 #if COCOAPODS
 #  define HAVE_LIBDISPATCH 1
 #endif
 
-#cmakedefine HAVE_OPENSSL_RAND_H 1
+#cmakedefine01 HAVE_OPENSSL_RAND_H
 
 #endif  // FIRESTORE_CORE_SRC_FIREBASE_FIRESTORE_UTIL_CONFIG_H_

--- a/Firestore/core/src/util/executor_std.cc
+++ b/Firestore/core/src/util/executor_std.cc
@@ -244,7 +244,7 @@ Task* ExecutorStd::PopFromSchedule() {
 // Only defined on non-Apple platforms. On Apple platforms, see the alternative
 // definition in executor_libdispatch.mm.
 #ifndef HAVE_LIBDISPATCH
-#error HAVE_LIBDISPATCH must be set to 1 or 0; verify the #include directive for config.h.
+#error HAVE_LIBDISPATCH must be set to 1 or 0; verify the #include for config.h.
 #elif !HAVE_LIBDISPATCH
 
 std::unique_ptr<Executor> Executor::CreateSerial(const char*) {

--- a/Firestore/core/src/util/executor_std.cc
+++ b/Firestore/core/src/util/executor_std.cc
@@ -243,7 +243,9 @@ Task* ExecutorStd::PopFromSchedule() {
 
 // Only defined on non-Apple platforms. On Apple platforms, see the alternative
 // definition in executor_libdispatch.mm.
-#if !HAVE_LIBDISPATCH
+#ifndef HAVE_LIBDISPATCH
+#error HAVE_LIBDISPATCH must be set to 1 or 0; verify the #include directive for config.h.
+#elif !HAVE_LIBDISPATCH
 
 std::unique_ptr<Executor> Executor::CreateSerial(const char*) {
   return absl::make_unique<ExecutorStd>(/*threads=*/1);

--- a/Firestore/core/src/util/secure_random_arc4random.cc
+++ b/Firestore/core/src/util/secure_random_arc4random.cc
@@ -19,7 +19,7 @@
 #include "Firestore/core/src/util/config.h"
 
 #ifndef HAVE_ARC4RANDOM
-#error HAVE_ARC4RANDOM must be set to 1 or 0; verify the #include directive for config.h.
+#error HAVE_ARC4RANDOM must be set to 1 or 0; verify the #include for config.h.
 #elif HAVE_ARC4RANDOM
 
 #include <cstdlib>

--- a/Firestore/core/src/util/secure_random_arc4random.cc
+++ b/Firestore/core/src/util/secure_random_arc4random.cc
@@ -18,7 +18,9 @@
 
 #include "Firestore/core/src/util/config.h"
 
-#if HAVE_ARC4RANDOM
+#ifndef HAVE_ARC4RANDOM
+#error HAVE_ARC4RANDOM must be set to 1 or 0; verify the #include directive for config.h.
+#elif HAVE_ARC4RANDOM
 
 #include <cstdlib>
 

--- a/Firestore/core/src/util/secure_random_openssl.cc
+++ b/Firestore/core/src/util/secure_random_openssl.cc
@@ -18,7 +18,9 @@
 
 #include "Firestore/core/src/util/config.h"
 
-#if HAVE_OPENSSL_RAND_H
+#ifndef HAVE_OPENSSL_RAND_H
+#error HAVE_OPENSSL_RAND_H must be set to 1 or 0; verify the #include directive for config.h.
+#elif HAVE_OPENSSL_RAND_H
 
 #include "openssl/err.h"
 #include "openssl/rand.h"

--- a/Firestore/core/src/util/secure_random_openssl.cc
+++ b/Firestore/core/src/util/secure_random_openssl.cc
@@ -19,7 +19,7 @@
 #include "Firestore/core/src/util/config.h"
 
 #ifndef HAVE_OPENSSL_RAND_H
-#error HAVE_OPENSSL_RAND_H must be set to 1 or 0; verify the #include directive for config.h.
+#error HAVE_OPENSSL_RAND_H must be set to 1 or 0; verify #include for config.h.
 #elif HAVE_OPENSSL_RAND_H
 
 #include "openssl/err.h"


### PR DESCRIPTION
This change helps to protect against the situation where a `#define` from `config.h` is used as the subject of an `#if` statement but `config.h` was accidentally not included. In this case, the `#if` will evaluate to false even though it would have evaluated to true had the correct header been included. This guard will help prevent bugs like the one fixed by #6041.

#no-changelog