### PR TITLE
Fix multithreaded _completion access

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fixed a multithreaded memory access issue on iOS (#5979).
+
 # v6.7.0
 - [changed] Functionally neutral source reorganization for preliminary Swift Package Manager support. (#5856)
 

--- a/FirebaseAuth/Sources/Utilities/FIRAuthURLPresenter.m
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthURLPresenter.m
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// The completion handler for the current presentation, if one is active.
 /// Prefer using this over the _completion instance variable directly because
 /// this property is thread-safe.
-@property (nonatomic, copy, nullable) FIRAuthURLPresentationCompletion completion;
+@property(nonatomic, copy, nullable) FIRAuthURLPresentationCompletion completion;
 
 @end
 
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
       @brief A lock object used to serialize access to `_completion`, which may be
       set on one thread and read from another.
    */
-   NSLock *_completionLock;
+  NSLock *_completionLock;
 }
 
 - (instancetype)init {
@@ -207,7 +207,7 @@ NS_ASSUME_NONNULL_BEGIN
   }
 }
 
-- (FIRAuthURLPresentationCompletion)completion {
+- (FIRAuthURLPresentationCompletion _Nullable)completion {
   FIRAuthURLPresentationCompletion value = NULL;
   [_completionLock lock];
   value = [_completion copy];
@@ -215,7 +215,7 @@ NS_ASSUME_NONNULL_BEGIN
   return value;
 }
 
-- (void)setCompletion:(FIRAuthURLPresentationCompletion)completion {
+- (void)setCompletion:(FIRAuthURLPresentationCompletion _Nullable)completion {
   [_completionLock lock];
   _completion = [completion copy];
   [_completionLock unlock];

--- a/FirebaseAuth/Sources/Utilities/FIRAuthURLPresenter.m
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthURLPresenter.m
@@ -71,20 +71,6 @@ NS_ASSUME_NONNULL_BEGIN
       @remarks This variable is also used as a flag to indicate a presentation is active.
    */
   FIRAuthURLPresentationCompletion _Nullable _completion;
-
-  /** @var _completionLock
-      @brief A lock object used to serialize access to `_completion`, which may be
-      set on one thread and read from another.
-   */
-  NSLock *_completionLock;
-}
-
-- (instancetype)init {
-  self = [super init];
-  if (self != nil) {
-    _completionLock = [[NSLock alloc] init];
-  }
-  return self;
 }
 
 - (void)presentURL:(NSURL *)URL

--- a/FirebaseAuth/Sources/Utilities/FIRAuthURLPresenter.m
+++ b/FirebaseAuth/Sources/Utilities/FIRAuthURLPresenter.m
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FIRAuthURLPresenter () <SFSafariViewControllerDelegate, FIRAuthWebViewControllerDelegate>
 
-/// The completion handler for the current presentaion, if one is active.
+/// The completion handler for the current presentation, if one is active.
 /// Prefer using this over the _completion instance variable directly because
 /// this property is thread-safe.
 @property (nonatomic, copy, nullable) FIRAuthURLPresentationCompletion completion;
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
   id<FIRAuthUIDelegate> _UIDelegate;
 
   /** @var _completion
-      @brief The completion handler for the current presentaion, if one is active.
+      @brief The completion handler for the current presentation, if one is active.
       @remarks This variable is also used as a flag to indicate a presentation is active.
    */
   FIRAuthURLPresentationCompletion _Nullable _completion;


### PR DESCRIPTION
Probably fixes #5979. Without a repro, who knows.

Fixes an issue where if an attempt to present a web URL via SFSafariViewController happened while there was already a URL being presented the error handler callback would be invoked on the wrong thread.
Also added some copies when moving blocks around.