### PR TITLE
Add support for dynamic url schemes and fix two crashes

### DIFF
--- a/FirebaseAppDistribution/Sources/FIRAppDistributionAppDelegateInterceptor.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionAppDelegateInterceptor.m
@@ -56,7 +56,8 @@ SFAuthenticationSession *_safariAuthenticationVC;
 
 - (void)appDistributionRegistrationFlow:(NSURL *)URL
                          withCompletion:(void (^)(NSError *_Nullable error))completion {
-  NSString *callbackURL = [NSString stringWithFormat:@"appdistribution-%@", [[self class] encodedAppId]];
+  NSString *callbackURL =
+      [NSString stringWithFormat:@"appdistribution-%@", [[self class] encodedAppId]];
 
   FIRFADInfoLog(@"Registration URL: %@", URL);
   FIRFADInfoLog(@"Callback URL: %@", callbackURL);

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionAppDelegateInterceptor.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionAppDelegateInterceptor.m
@@ -49,9 +49,14 @@ SFAuthenticationSession *_safariAuthenticationVC;
   return sharedInstance;
 }
 
++ (NSString *)encodedAppId {
+  return [[[FIRApp defaultApp] options].googleAppID stringByReplacingOccurrencesOfString:@":"
+                                                                              withString:@""];
+}
+
 - (void)appDistributionRegistrationFlow:(NSURL *)URL
                          withCompletion:(void (^)(NSError *_Nullable error))completion {
-  NSString *callbackURL = [NSString stringWithFormat:@"appdistribution-%@", [self encodedAppId]];
+  NSString *callbackURL = [NSString stringWithFormat:@"appdistribution-%@", [[self class] encodedAppId]];
 
   FIRFADInfoLog(@"Registration URL: %@", URL);
   FIRFADInfoLog(@"Callback URL: %@", callbackURL);
@@ -96,11 +101,6 @@ SFAuthenticationSession *_safariAuthenticationVC;
     [self->_safariHostingViewController presentViewController:safariVC animated:YES completion:nil];
     self.registrationFlowCompletion = completion;
   }
-}
-
-- (NSString *)encodedAppId {
-  return [[[FIRApp defaultApp] options].googleAppID stringByReplacingOccurrencesOfString:@":"
-                                                                              withString:@""];
 }
 
 - (void)showUIAlert:(UIAlertController *)alertController {

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionAppDelegateInterceptor.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionAppDelegateInterceptor.m
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 #import "FIRAppDistributionAppDelegateInterceptor.h"
+#import "FIRFADLogger+Private.h"
+#import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
+
 #import <AuthenticationServices/AuthenticationServices.h>
 #import <SafariServices/SafariServices.h>
 #import <UIKit/UIKit.h>
@@ -48,16 +51,20 @@ SFAuthenticationSession *_safariAuthenticationVC;
 
 - (void)appDistributionRegistrationFlow:(NSURL *)URL
                          withCompletion:(void (^)(NSError *_Nullable error))completion {
-  NSLog(@"Registration URL: %@", URL);
+  NSString *callbackURL = [NSString stringWithFormat:@"appdistribution-%@", [self encodedAppId]];
+
+  FIRFADInfoLog(@"Registration URL: %@", URL);
+  FIRFADInfoLog(@"Callback URL: %@", callbackURL);
 
   if (@available(iOS 12.0, *)) {
     ASWebAuthenticationSession *authenticationVC = [[ASWebAuthenticationSession alloc]
               initWithURL:URL
-        callbackURLScheme:@"com.firebase.appdistribution"
+        callbackURLScheme:callbackURL
         completionHandler:^(NSURL *_Nullable callbackURL, NSError *_Nullable error) {
           [self resetUIState];
-          NSLog(@"Testing: Sign in Complete!");
+          FIRFADInfoLog(@"Sign in complete using ASWebAuthenticationSession");
           // TODO (b/161538029): Map these errors to AppDistribution error codes
+
           completion(error);
         }];
 
@@ -71,16 +78,17 @@ SFAuthenticationSession *_safariAuthenticationVC;
   } else if (@available(iOS 11.0, *)) {
     _safariAuthenticationVC = [[SFAuthenticationSession alloc]
               initWithURL:URL
-        callbackURLScheme:@"com.firebase.appdistribution"
+        callbackURLScheme:callbackURL
         completionHandler:^(NSURL *_Nullable callbackURL, NSError *_Nullable error) {
           [self resetUIState];
-          NSLog(@"Testing: Sign in Complete!");
+          FIRFADInfoLog(@"Sign in complete using SFAuthenticationSession");
           // TODO (b/161538029): Map these errors to AppDistribution error codes
+
           completion(error);
         }];
 
     [_safariAuthenticationVC start];
-  } else {
+  } else if (@available(iOS 9.0, *)) {
     SFSafariViewController *safariVC = [[SFSafariViewController alloc] initWithURL:URL];
 
     safariVC.delegate = self;
@@ -88,6 +96,11 @@ SFAuthenticationSession *_safariAuthenticationVC;
     [self->_safariHostingViewController presentViewController:safariVC animated:YES completion:nil];
     self.registrationFlowCompletion = completion;
   }
+}
+
+- (NSString *)encodedAppId {
+  return [[[FIRApp defaultApp] options].googleAppID stringByReplacingOccurrencesOfString:@":"
+                                                                              withString:@""];
 }
 
 - (void)showUIAlert:(UIAlertController *)alertController {
@@ -100,7 +113,8 @@ SFAuthenticationSession *_safariAuthenticationVC;
 - (BOOL)application:(UIApplication *)application
             openURL:(NSURL *)URL
             options:(NSDictionary<NSString *, id> *)options {
-  self.registrationFlowCompletion(nil);
+  FIRFADDebugLog(@"Continuing registration flow: %@", [self registrationFlowCompletion]);
+  if (self.registrationFlowCompletion) self.registrationFlowCompletion(nil);
   [self resetUIState];
   return NO;
 }

--- a/FirebaseAppDistribution/Sources/FIRFADLogger.m
+++ b/FirebaseAppDistribution/Sources/FIRFADLogger.m
@@ -23,7 +23,6 @@ NSString *const AppDistributionMessageCode = @"I-FAD000000";
 void FIRFADDebugLog(NSString *message, ...) {
   va_list args_ptr;
   va_start(args_ptr, message);
-  NSLogv(message, args_ptr);
   FIRLogBasic(FIRLoggerLevelDebug, kFIRLoggerAppDistribution, AppDistributionMessageCode, message,
               args_ptr);
   va_end(args_ptr);
@@ -32,7 +31,6 @@ void FIRFADDebugLog(NSString *message, ...) {
 void FIRFADInfoLog(NSString *message, ...) {
   va_list args_ptr;
   va_start(args_ptr, message);
-  NSLogv(message, args_ptr);
   FIRLogBasic(FIRLoggerLevelInfo, kFIRLoggerAppDistribution, AppDistributionMessageCode, message,
               args_ptr);
   va_end(args_ptr);
@@ -41,7 +39,6 @@ void FIRFADInfoLog(NSString *message, ...) {
 void FIRFADWarningLog(NSString *message, ...) {
   va_list args_ptr;
   va_start(args_ptr, message);
-  NSLogv(message, args_ptr);
   FIRLogBasic(FIRLoggerLevelWarning, kFIRLoggerAppDistribution, AppDistributionMessageCode, message,
               args_ptr);
   va_end(args_ptr);
@@ -50,7 +47,6 @@ void FIRFADWarningLog(NSString *message, ...) {
 void FIRFADErrorLog(NSString *message, ...) {
   va_list args_ptr;
   va_start(args_ptr, message);
-  NSLogv(message, args_ptr);
   FIRLogBasic(FIRLoggerLevelError, kFIRLoggerAppDistribution, AppDistributionMessageCode, message,
               args_ptr);
   va_end(args_ptr);

--- a/FirebaseAppDistribution/Sources/Private/FIRFADApiService+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRFADApiService+Private.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  If the call fails we return the appropriate `error code`, described by
  *  `AppDistributionApiError`.
  *
- *  @param release  The new release that is available to be installed.
+ *  @param releases  The releases that are available to be installed.
  *  @param error     The error describing why the new build request failed.
  */
 typedef void (^FIRFADFetchReleasesCompletion)(NSArray *_Nullable releases, NSError *_Nullable error)


### PR DESCRIPTION
  * Add support for dynamic url schemes in the format appdistribution-<app id without colons>
  * Fix crash when launching an app directly via a URL scheme
  * Fix a crash on iOS 10 simulator caused by calling NSLogv twice
  * Remove uses of NSLog
  * Fix warnings