### PR TITLE
Update CHANGELOG for Firestore v1.16.3

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v1.16.3
+- [changed] Internal improvements for future C++ and Unity support.
+
 # v1.16.2
 - [fixed] Fixed a configuration issue where listeners were no longer being
   called back on the main thread by default.


### PR DESCRIPTION
The only change since 6.28.0 is #6024 since #6041 was cherry-picked as #6042.