### PR TITLE
fix ordered code unit test for Release build

### DIFF
--- a/Firestore/core/test/unit/util/ordered_code_test.cc
+++ b/Firestore/core/test/unit/util/ordered_code_test.cc
@@ -349,7 +349,7 @@ TEST(OrderedCodeInvalidEncodingsTest, NonCanonical) {
     EXPECT_NE(OCWrite<uint64_t>(0, INCREASING), non_minimal);
 
 #if defined(NDEBUG)
-    TestRead<uint64_t>(INCREASING, non_minimal);
+    EXPECT_ANY_THROW(TestRead<uint64_t>(INCREASING, non_minimal));
 #else   // defined(NDEBUG)
     absl::string_view s(non_minimal);
     EXPECT_ANY_THROW(OrderedCode::ReadNumIncreasing(&s, NULL));
@@ -371,7 +371,7 @@ TEST(OrderedCodeInvalidEncodingsTest, NonCanonical) {
     EXPECT_NE(OCWrite<int64_t>(0, INCREASING), non_minimal);
 
 #if defined(NDEBUG)
-    TestRead<int64_t>(INCREASING, non_minimal);
+    EXPECT_ANY_THROW(TestRead<int64_t>(INCREASING, non_minimal));
 #else   // defined(NDEBUG)
     absl::string_view s(non_minimal);
     EXPECT_ANY_THROW(OrderedCode::ReadSignedNumIncreasing(&s, NULL));


### PR DESCRIPTION
Exception is thrown even in Release config. There was nothing catching the expected thrown exception. 
This was causing the "firestore_util_test" to fail, specifically "OrderedCodeInvalidEncodingsTest.NonCanonical".
Catching the expected exception now.