### PR TITLE
Remove zip testings from sdk workflows

### DIFF
--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -43,45 +43,6 @@ jobs:
       # Only build the unit tests on Catalyst. Test stopped working when GHA moved to Xcode 11.4.1.
       run: scripts/test_catalyst.sh FirebaseABTesting build FirebaseABTesting-Unit-unit
 
-  quickstart_framework:
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_ZIP: "Firebase-actions-dir.zip"
-      SDK: "ABTesting"
-    runs-on: macOS-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Pull zip from GCS
-      run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseMessaging/FirebaseInstanceID.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCore.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/PromisesObjC.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseInstallations.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/GoogleUtilities.xcframework
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-abtesting.plist.gpg \
-        quickstart-ios/abtesting/GoogleService-Info.plist "$plist_secret"
-    - name: Install Secret FIREGSignInInfo.h
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
-        quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh "${SDK}"
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts
-        path: quickstart-ios/
-
   quickstart:
     # Don't run on private repo unless it is a PR.
     if: github.repository != 'FirebasePrivate/firebase-ios-sdk' || github.event_name == 'pull_request'

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -77,43 +77,6 @@ jobs:
       # Only build the unit tests on Catalyst
       run: scripts/test_catalyst.sh FirebaseAuth build FirebaseAuth-Unit-unit
 
-  quickstart_framework:
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_ZIP: "Firebase-actions-dir.zip"
-      SDK: "Authentication"
-    runs-on: macOS-latest
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-    steps:
-    - uses: actions/checkout@v2
-    - name: Pull zip from GCS
-      run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
-    - name: Setup Swift Quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FBSDKLoginKit FBSDKCoreKit" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
-                                               "${HOME}"/ios_frameworks/Firebase/GoogleSignIn/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-auth.plist.gpg \
-        quickstart-ios/authentication/GoogleService-Info.plist "$plist_secret"
-    - name: Install Secret FIREGSignInInfo.h
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
-        quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh "${SDK}"
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts
-        path: quickstart-ios/
-
   quickstart:
     # Don't run on private repo unless it is a PR.
     if: github.repository != 'FirebasePrivate/firebase-ios-sdk' || github.event_name == 'pull_request'

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -43,49 +43,6 @@ jobs:
     - name: Setup project and Build for Catalyst
       run: scripts/test_catalyst.sh FirebaseCrashlytics build FirebaseCrashlytics-Unit-unit
 
-  quickstart_framework:
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_ZIP: "Firebase-actions-dir.zip"
-      SDK: "Crashlytics"
-    runs-on: macOS-latest
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-    steps:
-    - uses: actions/checkout@v2
-    - name: Pull zip from GCS
-      run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
-    - name: Setup quickstart
-      run: |
-              SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseCrashlytics/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-              cp quickstart-ios/crashlytics/Firebase/run quickstart-ios/crashlytics
-              cp quickstart-ios/crashlytics/Firebase/upload-symbols quickstart-ios/crashlytics
-              chmod +x quickstart-ios/crashlytics/run
-              chmod +x quickstart-ios/crashlytics/upload-symbols
-    - name: Setup swift quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-crashlytics.plist.gpg \
-        quickstart-ios/crashlytics/GoogleService-Info.plist "$plist_secret"
-    - name: Install Secret FIREGSignInInfo.h
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
-        quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh "${SDK}"
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts
-        path: quickstart-ios/
-
   quickstart:
     # Don't run on private repo unless it is a PR.
     if: github.repository != 'FirebasePrivate/firebase-ios-sdk' || github.event_name == 'pull_request'

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -52,44 +52,6 @@ jobs:
       # Only build the unit tests on Catalyst. Test stopped working when GHA moved to Xcode 11.4.1.
       run: scripts/test_catalyst.sh FirebaseDatabase build FirebaseDatabase-Unit-unit
 
-  quickstart_framework:
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_ZIP: "Firebase-actions-dir.zip"
-      SDK: "Database"
-    runs-on: macOS-latest
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-    steps:
-    - uses: actions/checkout@v2
-    - name: Pull zip from GCS
-      run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="FirebaseUI/Database" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDatabase/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-database.plist.gpg \
-        quickstart-ios/database/GoogleService-Info.plist "$plist_secret"
-    - name: Install Secret FIREGSignInInfo.h
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
-        quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh "${SDK}"
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts
-        path: quickstart-ios/
-
   quickstart:
     # Don't run on private repo unless it is a PR.
     if: github.repository != 'FirebasePrivate/firebase-ios-sdk' || github.event_name == 'pull_request'

--- a/.github/workflows/dynamiclinks.yml
+++ b/.github/workflows/dynamiclinks.yml
@@ -43,49 +43,6 @@ jobs:
     - name: PodLibLint Storage Cron
       run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseDynamicLinks.podspec --platforms=ios ${{ matrix.flags }}
 
-  quickstart_framework:
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_ZIP: "Firebase-actions-dir.zip"
-      SDK: "DynamicLinks"
-    runs-on: macOS-latest
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-    steps:
-    - uses: actions/checkout@v2
-    - name: Pull zip from GCS
-      run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
-    - name: Setup Objc Quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Setup Swift Quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-    - name: Update Environment Variable For DynamicLinks
-      run: |
-        sed -i '' 's#DYNAMIC_LINK_DOMAIN#https://qpf6m.app.goo.gl#' quickstart-ios/dynamiclinks/DynamicLinksExample/DynamicLinksExample.entitlements
-        sed -i '' 's#YOUR_DOMAIN_URI_PREFIX";#https://qpf6m.app.goo.gl";#' quickstart-ios/dynamiclinks/DynamicLinksExample/ViewController.m
-        sed -i '' 's#YOUR_DOMAIN_URI_PREFIX";#https://qpf6m.app.goo.gl";#' quickstart-ios/dynamiclinks/DynamicLinksExampleSwift/ViewController.swift
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-dynamiclinks.plist.gpg \
-        quickstart-ios/dynamiclinks/GoogleService-Info.plist "$plist_secret"
-    - name: Install Secret FIREGSignInInfo.h
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
-        quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
-    - name: Test Objc Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh dynamiclinks
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts
-        path: quickstart-ios/
-
   quickstart:
     # Don't run on private repo unless it is a PR.
     if: github.repository != 'FirebasePrivate/firebase-ios-sdk' || github.event_name == 'pull_request'

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -168,42 +168,6 @@ jobs:
             --platforms=ios \
             --allow-warnings
 
-  quickstart_framework:
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_ZIP: "Firebase-actions-dir.zip"
-      SDK: "Firestore"
-    runs-on: macOS-latest
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-    steps:
-    - uses: actions/checkout@v2
-    - name: Pull zip from GCS
-      run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" NON_FIREBASE_SDKS="SDWebImage FirebaseUI/Auth FirebaseUI/Email FirebaseFirestoreSwift" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseFirestore/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-firestore.plist.gpg \
-        quickstart-ios/firestore/GoogleService-Info.plist "$plist_secret"
-    - name: Install Secret FIREGSignInInfo.h
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
-        quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh "${SDK}"
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts
-        path: quickstart-ios/
-
   quickstart:
     # Don't run on private repo unless it is a PR.
     if: github.repository != 'FirebasePrivate/firebase-ios-sdk' || github.event_name == 'pull_request'

--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -14,46 +14,6 @@ on:
 
 jobs:
 
-  quickstart_framework:
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_ZIP: "Firebase-actions-dir.zip"
-      SDK: "InAppMessaging"
-    runs-on: macOS-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Pull zip from GCS
-      run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseDynamicLinks/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseInAppMessaging/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Setup swift quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-inappmessaging.plist.gpg \
-        quickstart-ios/inappmessaging/GoogleService-Info.plist "$plist_secret"
-    - name: Install Secret FIREGSignInInfo.h
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
-        quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh "${SDK}"
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts
-        path: quickstart-ios/
-
   quickstart:
     # Don't run on private repo unless it is a PR.
     if: github.repository != 'FirebasePrivate/firebase-ios-sdk' || github.event_name == 'pull_request'

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -55,39 +55,6 @@ jobs:
   #     # Only build the unit tests on Catalyst. Test stopped working when GHA moved to Xcode 11.4.1.
   #     run: scripts/test_catalyst.sh FirebaseInstallations build FirebaseInstallations-Unit-unit
 
-  quickstart_framework:
-    # Don't run on private repo
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_ZIP: "Firebase-actions-dir.zip"
-      SDK: "Installations"
-    runs-on: macOS-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Pull zip from GCS
-      run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/PromisesObjC.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseInstallations.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/FirebaseCore.xcframework \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/GoogleUtilities.xcframework
-    - name: Copy mock plist
-      run: cp quickstart-ios/mock-GoogleService-Info.plist quickstart-ios/"${SDK}"/GoogleService-Info.plist
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh "${SDK}"
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts
-        path: quickstart-ios/
-
   quickstart:
     # Don't run on private repo unless it is a PR.
     if: github.repository != 'FirebasePrivate/firebase-ios-sdk' || github.event_name == 'pull_request'

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -65,44 +65,6 @@ jobs:
     - name: Setup project and Build Catalyst
       run: scripts/test_catalyst.sh FirebaseMessaging build
 
-  quickstart_framework:
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_ZIP: "Firebase-actions-dir.zip"
-      SDK: "Messaging"
-    runs-on: macOS-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Pull zip from GCS
-      run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseMessaging/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Setup swift quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" scripts/setup_quickstart_framework.sh
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-messaging.plist.gpg \
-        quickstart-ios/messaging/GoogleService-Info.plist "$plist_secret"
-    - name: Install Secret FIREGSignInInfo.h
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
-        quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh "${SDK}"
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts
-        path: quickstart-ios/
-
   quickstart:
     # Don't run on private repo unless it is a PR.
     if: github.repository != 'FirebasePrivate/firebase-ios-sdk' || github.event_name == 'pull_request'

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -70,40 +70,6 @@ jobs:
       # Only build the unit tests on Catalyst. Test stopped working when GHA moved to Xcode 11.4.1.
       run: scripts/test_catalyst.sh FirebaseRemoteConfig build FirebaseRemoteConfig-Unit-unit
 
-  quickstart_framework:
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_ZIP: "Firebase-actions-dir.zip"
-      SDK: "Config"
-    runs-on: macOS-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Pull zip from GCS
-      run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
-    - name: Setup Swift Quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseRemoteConfig/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-config.plist.gpg \
-        quickstart-ios/config/GoogleService-Info.plist "$plist_secret"
-    - name: Install Secret FIREGSignInInfo.h
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
-        quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh "${SDK}"
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts
-        path: quickstart-ios/
-
   quickstart:
     # Don't run on private repo unless it is a PR.
     if: github.repository != 'FirebasePrivate/firebase-ios-sdk' || github.event_name == 'pull_request'

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -54,46 +54,6 @@ jobs:
       # Only build the unit tests on Catalyst. Test stopped working when GHA moved to Xcode 11.4.1.
       run: scripts/test_catalyst.sh FirebaseStorage build FirebaseStorage-Unit-unit
 
-  quickstart_framework:
-    env:
-      plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      signin_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
-      FRAMEWORK_ZIP: "Firebase-actions-dir.zip"
-      SDK: "Storage"
-    runs-on: macOS-latest
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-    steps:
-    - uses: actions/checkout@v2
-    - name: Pull zip from GCS
-      run: scripts/pull_zip_gcloud.sh "$plist_secret" "$FRAMEWORK_ZIP" "${HOME}/ios_frameworks"
-    - name: Setup quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}Example" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseStorage/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAuth/* \
-                                               "${HOME}"/ios_frameworks/Firebase/FirebaseAnalytics/*
-    - name: Setup swift quickstart
-      run: SAMPLE="$SDK" TARGET="${SDK}ExampleSwift" NON_FIREBASE_SDKS="FirebaseStorageSwift" scripts/setup_quickstart_framework.sh \
-                                               "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/*
-    - name: Install Secret GoogleService-Info.plist
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/qs-storage.plist.gpg \
-        quickstart-ios/storage/GoogleService-Info.plist "$plist_secret"
-    - name: Install Secret FIREGSignInInfo.h
-      run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/FIREGSignInInfo.h.gpg \
-        quickstart-ios/TestUtils/FIREGSignInInfo.h "$signin_secret"
-    - name: Test Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}")
-    - name: Test Swift Quickstart
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/test_quickstart_framework.sh "${SDK}" swift)
-    - name: Remove data before upload
-      if: ${{ failure() }}
-      run: scripts/remove_data.sh "${SDK}"
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: quickstart_artifacts
-        path: quickstart-ios/
-
   quickstart:
     # Don't run on private repo unless it is a PR.
     if: github.repository != 'FirebasePrivate/firebase-ios-sdk' || github.event_name == 'pull_request'

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -27,8 +27,6 @@ jobs:
     # Don't run on private repo.
     if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     needs: build
-    env:
-      gcs_key: ${{ secrets.GHASecretsGPGPassphrase1 }}
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2
@@ -44,22 +42,6 @@ jobs:
         # Zip the entire output directory since the builder adds subdirectories we don't know the
         # name of.
         path: zip_output_dir
-    - name: Install gcloud tool
-      if: ${{ always() }}
-      run: |
-              curl https://sdk.cloud.google.com > install.sh
-              bash install.sh --disable-prompts
-              echo "::add-path::${HOME}/google-cloud-sdk/bin/"
-    - name: Access gcloud account
-      if: ${{ always() }}
-      run: |
-         scripts/decrypt_gha_secret.sh scripts/gha-encrypted/firebase-ios-testing.json.gpg firebase-ios-testing.json "$gcs_key"
-         gcloud auth activate-service-account --key-file firebase-ios-testing.json
-    - name: Update commit hash on GCS if any previous steps failed
-      if: ${{ failure() }}
-      run: scripts/upload_to_gcs.sh "${GITHUB_SHA}" "Fail"
-    - name: Upload zip file to GCS
-      run: scripts/upload_to_gcs.sh "${GITHUB_SHA}" "zip_output_dir"
 
   quickstart_framework_abtesting:
     # Don't run on private repo.


### PR DESCRIPTION
Remove all zip testings from sdk workflows since these testings are compacted in zip workflows.
e.g. https://github.com/firebase/firebase-ios-sdk/actions/runs/175398687