### PR TITLE
Error code mapping and DelegateInterceptor refactoring

### DIFF
--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistribution+Private.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistribution+Private.h
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #import "FIRAppDistribution.h"
-#import "FIRAppDistributionAppDelegateInterceptor.h"
 
 #define STR(x) STR_EXPAND(x)
 #define STR_EXPAND(x) #x

--- a/FirebaseAppDistribution/Sources/Private/FIRAppDistributionUIService.h
+++ b/FirebaseAppDistribution/Sources/Private/FIRAppDistributionUIService.h
@@ -19,13 +19,12 @@
 #import "FIRAppDistribution+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
-
+/// An instance of this class provides UI services required for the App Distribution sdk
 /// An instance of this class is meant to be registered as an AppDelegate interceptor, and
 /// implements the logic that my SDK needs to perform when certain app delegate methods are invoked.
-@interface FIRAppDistributionAppDelegateInterceptor
-    : NSObject <UIApplicationDelegate,
-                ASWebAuthenticationPresentationContextProviding,
-                SFSafariViewControllerDelegate>
+@interface FIRAppDistributionUIService : NSObject <UIApplicationDelegate,
+                                                   ASWebAuthenticationPresentationContextProviding,
+                                                   SFSafariViewControllerDelegate>
 
 /// Returns the FIRAppDistributionAppDelegatorInterceptor singleton.
 /// Always register just this singleton as the app delegate interceptor. This instance is
@@ -33,17 +32,13 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)sharedInstance;
 
 typedef void (^AppDistributionRegistrationFlowCompletion)(NSError *_Nullable error);
-/**
- * Current view controller presenting the `SFSafariViewController` if any.
- */
+
 @property(nullable, nonatomic) UIViewController *safariHostingViewController;
 
 @property(nullable, nonatomic) UIWindow *window;
 
 @property(nullable, nonatomic) AppDistributionRegistrationFlowCompletion registrationFlowCompletion;
 
-/** *
- */
 - (void)appDistributionRegistrationFlow:(NSURL *)URL
                          withCompletion:(AppDistributionRegistrationFlowCompletion)completion;
 

--- a/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionTests.m
+++ b/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionTests.m
@@ -193,7 +193,6 @@
 
   [[self appDistribution] signInTesterWithCompletion:^(NSError *_Nullable error) {
     XCTAssertNotNil(error);
-    // TODO (b/161538029): Map these errors to AppDistribution error codes
     XCTAssertEqual([error code], 4);
     [expectation fulfill];
   }];


### PR DESCRIPTION
* Mapping sign in flow errors to app distribution errors. 
* Also renaming AppDelegateInterceptor to FIRAppDistributionUIService
