### PR TITLE
GDT: fix time units for the request and events uptime

### DIFF
--- a/GoogleDataTransport/CHANGELOG.md
+++ b/GoogleDataTransport/CHANGELOG.md
@@ -1,5 +1,5 @@
-# v7.0.1
-- `GDTCORFlatFileStorage`: keep not expired events when expired batch removed. (#6010)
+# v7.1.0
+- Device uptime calculation fixes. (#6102)
 
 # v7.0.0
 - Storage has been completely reimplemented to a flat-file system. It
@@ -7,6 +7,7 @@ is not backwards compatible with previously saved events.
 - Prioritizers, data futures, and upload packages have been removed.
 - Consolidated GoogleDataTransportCCTSupport with GoogleDataTransport. Starting
 with this version, GoogleDataTransportCCTSupport should no longer be linked.
+- `GDTCORFlatFileStorage`: keep not expired events when expired batch removed. (#6010)
 
 # v6.2.1
 - Stopped GDTCORUploadCoordinator from blocking main thread. (#5707, #5708)

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
@@ -128,7 +128,7 @@ gdt_cct_LogRequest GDTCCTConstructLogRequest(int32_t logSource,
   GDTCORClock *currentTime = [GDTCORClock snapshot];
   logRequest.request_time_ms = currentTime.timeMillis;
   logRequest.has_request_time_ms = 1;
-  logRequest.request_uptime_ms = currentTime.uptime;
+  logRequest.request_uptime_ms = [currentTime uptimeMilliseconds];
   logRequest.has_request_uptime_ms = 1;
 
   return logRequest;
@@ -138,7 +138,7 @@ gdt_cct_LogEvent GDTCCTConstructLogEvent(GDTCOREvent *event) {
   gdt_cct_LogEvent logEvent = gdt_cct_LogEvent_init_default;
   logEvent.event_time_ms = event.clockSnapshot.timeMillis;
   logEvent.has_event_time_ms = 1;
-  logEvent.event_uptime_ms = event.clockSnapshot.uptime;
+  logEvent.event_uptime_ms = [event.clockSnapshot uptimeMilliseconds];
   logEvent.has_event_uptime_ms = 1;
   logEvent.timezone_offset_seconds = event.clockSnapshot.timezoneOffsetSeconds;
   logEvent.has_timezone_offset_seconds = 1;

--- a/GoogleDataTransport/GDTCCTTests/Unit/Helpers/GDTCCTEventGenerator.m
+++ b/GoogleDataTransport/GDTCCTTests/Unit/Helpers/GDTCCTEventGenerator.m
@@ -117,8 +117,8 @@
     event.clockSnapshot = [GDTCORClock snapshot];
     [event.clockSnapshot setValue:@(1111111111111) forKeyPath:@"timeMillis"];
     [event.clockSnapshot setValue:@(-25200) forKeyPath:@"timezoneOffsetSeconds"];
-    [event.clockSnapshot setValue:@(1111111111111222) forKeyPath:@"kernelBootTime"];
-    [event.clockSnapshot setValue:@(1235567890) forKeyPath:@"uptime"];
+    [event.clockSnapshot setValue:@(1111111111111222) forKeyPath:@"kernelBootTimeNanoseconds"];
+    [event.clockSnapshot setValue:@(1235567890) forKeyPath:@"uptimeNanoseconds"];
     event.qosTier = GDTCOREventQosDefault;
     event.eventCode = @1986;
     NSError *error;
@@ -147,8 +147,8 @@
     event.clockSnapshot = [GDTCORClock snapshot];
     [event.clockSnapshot setValue:@(1111111111111) forKeyPath:@"timeMillis"];
     [event.clockSnapshot setValue:@(-25200) forKeyPath:@"timezoneOffsetSeconds"];
-    [event.clockSnapshot setValue:@(1111111111111333) forKeyPath:@"kernelBootTime"];
-    [event.clockSnapshot setValue:@(1236567890) forKeyPath:@"uptime"];
+    [event.clockSnapshot setValue:@(1111111111111333) forKeyPath:@"kernelBootTimeNanoseconds"];
+    [event.clockSnapshot setValue:@(1236567890) forKeyPath:@"uptimeNanoseconds"];
     event.qosTier = GDTCOREventQoSWifiOnly;
     NSURL *messageDataURL = [self writeConsistentMessageToDisk:@"message-35458880.dat"];
     GDTCCTEventGeneratorDataObject *dataObject = [[GDTCCTEventGeneratorDataObject alloc] init];
@@ -170,8 +170,8 @@
     event.clockSnapshot = [GDTCORClock snapshot];
     [event.clockSnapshot setValue:@(1111111111111) forKeyPath:@"timeMillis"];
     [event.clockSnapshot setValue:@(-25200) forKeyPath:@"timezoneOffsetSeconds"];
-    [event.clockSnapshot setValue:@(1111111111111444) forKeyPath:@"kernelBootTime"];
-    [event.clockSnapshot setValue:@(1237567890) forKeyPath:@"uptime"];
+    [event.clockSnapshot setValue:@(1111111111111444) forKeyPath:@"kernelBootTimeNanoseconds"];
+    [event.clockSnapshot setValue:@(1237567890) forKeyPath:@"uptimeNanoseconds"];
     event.qosTier = GDTCOREventQosDefault;
     NSURL *messageDataURL = [self writeConsistentMessageToDisk:@"message-39882816.dat"];
     GDTCCTEventGeneratorDataObject *dataObject = [[GDTCCTEventGeneratorDataObject alloc] init];
@@ -192,8 +192,8 @@
     event.clockSnapshot = [GDTCORClock snapshot];
     [event.clockSnapshot setValue:@(1111111111111) forKeyPath:@"timeMillis"];
     [event.clockSnapshot setValue:@(-25200) forKeyPath:@"timezoneOffsetSeconds"];
-    [event.clockSnapshot setValue:@(1111111111111555) forKeyPath:@"kernelBootTime"];
-    [event.clockSnapshot setValue:@(1238567890) forKeyPath:@"uptime"];
+    [event.clockSnapshot setValue:@(1111111111111555) forKeyPath:@"kernelBootTimeNanoseconds"];
+    [event.clockSnapshot setValue:@(1238567890) forKeyPath:@"uptimeNanoseconds"];
     event.qosTier = GDTCOREventQosDefault;
     NSError *error;
     event.customBytes = [NSJSONSerialization dataWithJSONObject:@{@"customParam1" : @"aValue1"}
@@ -219,8 +219,8 @@
     event.clockSnapshot = [GDTCORClock snapshot];
     [event.clockSnapshot setValue:@(1111111111111) forKeyPath:@"timeMillis"];
     [event.clockSnapshot setValue:@(-25200) forKeyPath:@"timezoneOffsetSeconds"];
-    [event.clockSnapshot setValue:@(1111111111111666) forKeyPath:@"kernelBootTime"];
-    [event.clockSnapshot setValue:@(1239567890) forKeyPath:@"uptime"];
+    [event.clockSnapshot setValue:@(1111111111111666) forKeyPath:@"kernelBootTimeNanoseconds"];
+    [event.clockSnapshot setValue:@(1239567890) forKeyPath:@"uptimeNanoseconds"];
     event.qosTier = GDTCOREventQoSTelemetry;
     NSError *error;
     event.customBytes = [NSJSONSerialization dataWithJSONObject:@{

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORClock.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORClock.h
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)isAfter:(GDTCORClock *)otherClock;
 
-/**Returns value of `uptime` property in milliseconds. */
+/** Returns value of `uptime` property in milliseconds. */
 - (int64_t)uptimeMilliseconds;
 
 @end

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORClock.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORClock.h
@@ -28,10 +28,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) int64_t timezoneOffsetSeconds;
 
 /** The kernel boot time when this clock was created in nanoseconds. */
-@property(nonatomic, readonly) int64_t kernelBootTime;
+@property(nonatomic, readonly) int64_t kernelBootTimeNanoseconds;
 
 /** The device uptime when this clock was created in nanoseconds. */
-@property(nonatomic, readonly) int64_t uptime;
+@property(nonatomic, readonly) int64_t uptimeNanoseconds;
+
+@property(nonatomic, readonly) int64_t kernelBootTime DEPRECATED_MSG_ATTRIBUTE(
+    "Please use `kernelBootTimeNanoseconds` instead");
+
+@property(nonatomic, readonly)
+    int64_t uptime DEPRECATED_MSG_ATTRIBUTE("Please use `uptimeNanoseconds` instead");
 
 /** Creates a GDTCORClock object using the current time and offsets.
  *

--- a/GoogleDataTransport/GDTCORLibrary/Public/GDTCORClock.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GDTCORClock.h
@@ -27,10 +27,10 @@ NS_ASSUME_NONNULL_BEGIN
 /** The offset from UTC in seconds. */
 @property(nonatomic, readonly) int64_t timezoneOffsetSeconds;
 
-/** The kernel boot time when this clock was created. */
+/** The kernel boot time when this clock was created in nanoseconds. */
 @property(nonatomic, readonly) int64_t kernelBootTime;
 
-/** The device uptime when this clock was created. */
+/** The device uptime when this clock was created in nanoseconds. */
 @property(nonatomic, readonly) int64_t uptime;
 
 /** Creates a GDTCORClock object using the current time and offsets.
@@ -51,6 +51,9 @@ NS_ASSUME_NONNULL_BEGIN
  * @return YES if the calling clock's time is after the given clock's time.
  */
 - (BOOL)isAfter:(GDTCORClock *)otherClock;
+
+/**Returns value of `uptime` property in milliseconds. */
+- (int64_t)uptimeMilliseconds;
 
 @end
 

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORClockTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORClockTest.m
@@ -87,8 +87,9 @@
   [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:timeDiff]];
   GDTCORClock *clock2 = [GDTCORClock snapshot];
 
-  XCTAssertGreaterThan(clock2.uptime, clock1.uptime);
-  NSTimeInterval uptimeDiff = (clock2.uptime - clock1.uptime) / (NSTimeInterval)NSEC_PER_SEC;
+  XCTAssertGreaterThan(clock2.uptimeNanoseconds, clock1.uptimeNanoseconds);
+  NSTimeInterval uptimeDiff =
+      (clock2.uptimeNanoseconds - clock1.uptimeNanoseconds) / (NSTimeInterval)NSEC_PER_SEC;
   NSTimeInterval accuracy = 0.01;
 
   // Assert that uptime difference reflects the actually passed time.
@@ -101,7 +102,7 @@
   [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:timeDiff]];
   GDTCORClock *clock2 = [GDTCORClock snapshot];
 
-  XCTAssertGreaterThan(clock2.uptime, clock1.uptime);
+  XCTAssertGreaterThan(clock2.uptimeNanoseconds, clock1.uptimeNanoseconds);
 
   NSTimeInterval millisecondsPerSecond = 1000;
   NSTimeInterval uptimeDiff =

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORClockTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORClockTest.m
@@ -90,7 +90,7 @@
   XCTAssertGreaterThan(clock2.uptimeNanoseconds, clock1.uptimeNanoseconds);
   NSTimeInterval uptimeDiff =
       (clock2.uptimeNanoseconds - clock1.uptimeNanoseconds) / (double)NSEC_PER_SEC;
-  NSTimeInterval accuracy = 0.01;
+  NSTimeInterval accuracy = 0.1;
 
   // Assert that uptime difference reflects the actually passed time.
   XCTAssertLessThanOrEqual(ABS(uptimeDiff - timeDiff), accuracy);
@@ -107,7 +107,7 @@
   NSTimeInterval millisecondsPerSecond = 1000;
   NSTimeInterval uptimeDiff =
       ([clock2 uptimeMilliseconds] - [clock1 uptimeMilliseconds]) / millisecondsPerSecond;
-  NSTimeInterval accuracy = 0.01;
+  NSTimeInterval accuracy = 0.1;
 
   // Assert that uptime difference reflects the actually passed time.
   XCTAssertLessThanOrEqual(ABS(uptimeDiff - timeDiff), accuracy);

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORClockTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORClockTest.m
@@ -81,4 +81,35 @@
   XCTAssertFalse([clock2 isAfter:clock1]);
 }
 
+- (void)testUptime {
+  NSTimeInterval timeDiff = 1;
+  GDTCORClock *clock1 = [GDTCORClock snapshot];
+  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:timeDiff]];
+  GDTCORClock *clock2 = [GDTCORClock snapshot];
+
+  XCTAssertGreaterThan(clock2.uptime, clock1.uptime);
+  NSTimeInterval uptimeDiff = (clock2.uptime - clock1.uptime) / (NSTimeInterval)NSEC_PER_SEC;
+  NSTimeInterval accuracy = 0.01;
+
+  // Assert that uptime difference reflects the actually passed time.
+  XCTAssertLessThanOrEqual(ABS(uptimeDiff - timeDiff), accuracy);
+}
+
+- (void)testUptimeMilliseconds {
+  NSTimeInterval timeDiff = 1;
+  GDTCORClock *clock1 = [GDTCORClock snapshot];
+  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:timeDiff]];
+  GDTCORClock *clock2 = [GDTCORClock snapshot];
+
+  XCTAssertGreaterThan(clock2.uptime, clock1.uptime);
+
+  NSTimeInterval millisecondsPerSecond = 1000;
+  NSTimeInterval uptimeDiff =
+      ([clock2 uptimeMilliseconds] - [clock1 uptimeMilliseconds]) / millisecondsPerSecond;
+  NSTimeInterval accuracy = 0.01;
+
+  // Assert that uptime difference reflects the actually passed time.
+  XCTAssertLessThanOrEqual(ABS(uptimeDiff - timeDiff), accuracy);
+}
+
 @end

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORClockTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORClockTest.m
@@ -89,7 +89,7 @@
 
   XCTAssertGreaterThan(clock2.uptimeNanoseconds, clock1.uptimeNanoseconds);
   NSTimeInterval uptimeDiff =
-      (clock2.uptimeNanoseconds - clock1.uptimeNanoseconds) / (NSTimeInterval)NSEC_PER_SEC;
+      (clock2.uptimeNanoseconds - clock1.uptimeNanoseconds) / (double)NSEC_PER_SEC;
   NSTimeInterval accuracy = 0.01;
 
   // Assert that uptime difference reflects the actually passed time.

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCOREventTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCOREventTest.m
@@ -93,8 +93,8 @@
   event1.clockSnapshot = [GDTCORClock snapshot];
   [event1.clockSnapshot setValue:@(1553534573010) forKeyPath:@"timeMillis"];
   [event1.clockSnapshot setValue:@(-25200) forKeyPath:@"timezoneOffsetSeconds"];
-  [event1.clockSnapshot setValue:@(1552576634359451) forKeyPath:@"kernelBootTime"];
-  [event1.clockSnapshot setValue:@(961141365197) forKeyPath:@"uptime"];
+  [event1.clockSnapshot setValue:@(1552576634359451) forKeyPath:@"kernelBootTimeNanoseconds"];
+  [event1.clockSnapshot setValue:@(961141365197) forKeyPath:@"uptimeNanoseconds"];
   event1.qosTier = GDTCOREventQosDefault;
   event1.dataObject = [[GDTCORDataObjectTesterSimple alloc] initWithString:@"someData"];
   NSError *error1;
@@ -108,8 +108,8 @@
   event2.clockSnapshot = [GDTCORClock snapshot];
   [event2.clockSnapshot setValue:@(1553534573010) forKeyPath:@"timeMillis"];
   [event2.clockSnapshot setValue:@(-25200) forKeyPath:@"timezoneOffsetSeconds"];
-  [event2.clockSnapshot setValue:@(1552576634359451) forKeyPath:@"kernelBootTime"];
-  [event2.clockSnapshot setValue:@(961141365197) forKeyPath:@"uptime"];
+  [event2.clockSnapshot setValue:@(1552576634359451) forKeyPath:@"kernelBootTimeNanoseconds"];
+  [event2.clockSnapshot setValue:@(961141365197) forKeyPath:@"uptimeNanoseconds"];
   event2.qosTier = GDTCOREventQosDefault;
   event2.dataObject = [[GDTCORDataObjectTesterSimple alloc] initWithString:@"someData"];
   NSError *error2;


### PR DESCRIPTION
Fixes b/161747889

- `GDTCORClock.uptime` actual time units aligned with method names
- `GDTCCTNanopbHelpers` - assign actual milliseconds to `..._uptime_ms` proto fields
- tests