### PR TITLE
Added the actual error string that is intermittently encountered during manual install of Firebase SDK iOS

### DIFF
--- a/ZipBuilder/Template/README.md
+++ b/ZipBuilder/Template/README.md
@@ -66,7 +66,7 @@ option in your Xcode project/workspace, you will need to add the system
 frameworks and libraries listed in each Firebase framework's
 <Name>.framework/Modules/module.modulemap file to your target's or targets'
 "Link Binary With Libraries" build phase.  Specifically, you may see the error
-'ld: warning: Could not find or use auto-linked framework...' which is an
+`ld: warning: Could not find or use auto-linked framework...` which is an
 indicator that not all system libraries are being brought into your build
 automatically.
 

--- a/ZipBuilder/Template/README.md
+++ b/ZipBuilder/Template/README.md
@@ -65,7 +65,10 @@ in their modulemaps. If you have disabled the "Link Frameworks Automatically"
 option in your Xcode project/workspace, you will need to add the system
 frameworks and libraries listed in each Firebase framework's
 <Name>.framework/Modules/module.modulemap file to your target's or targets'
-"Link Binary With Libraries" build phase.
+"Link Binary With Libraries" build phase.  Specifically, you may see the error
+'ld: warning: Could not find or use auto-linked framework...' which is an
+indicator that not all system libraries are being brought into your build
+automatically.
 
 "(~> X)" below means that the SDK requires all of the frameworks from X. You
 should make sure to include all of the frameworks from X when including the SDK.


### PR DESCRIPTION
To ease users who google the error message encountered when installing Firebase-SDK-iOS manually and do not have frameworks automatically linking added the precise error string to tie their error to the solution presented.

Hey there! So you want to contribute to a Firebase SDK?
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here.
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help
    us make Firebase APIs better, please propose your change in a feature request so that we
    can discuss it together.
