### PR TITLE
fix messaging breakage

### DIFF
--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingRemoteNotificationsProxyTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingRemoteNotificationsProxyTest.m
@@ -159,8 +159,8 @@
   // Update +sharedProxy to always return our test instance
   OCMStub([_mockProxyClass sharedProxy]).andReturn(self.proxy);
   if (@available(macOS 10.14, iOS 10.0, *)) {
-    _mockUserNotificationCenter =
-        OCMPartialMock([UNUserNotificationCenter currentNotificationCenter]);
+    _mockUserNotificationCenter = OCMClassMock([UNUserNotificationCenter class]);
+    OCMStub([_mockUserNotificationCenter currentNotificationCenter]).andReturn(_mockUserNotificationCenter);
   }
 }
 

--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingRemoteNotificationsProxyTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingRemoteNotificationsProxyTest.m
@@ -160,7 +160,8 @@
   OCMStub([_mockProxyClass sharedProxy]).andReturn(self.proxy);
   if (@available(macOS 10.14, iOS 10.0, *)) {
     _mockUserNotificationCenter = OCMClassMock([UNUserNotificationCenter class]);
-    OCMStub([_mockUserNotificationCenter currentNotificationCenter]).andReturn(_mockUserNotificationCenter);
+    OCMStub([_mockUserNotificationCenter currentNotificationCenter])
+        .andReturn(_mockUserNotificationCenter);
   }
 }
 


### PR DESCRIPTION
Swizzling tests recently start failing after xcode version update. It reported the subclass mock of NotificationCenter was recreated by KVO. Mock singleton method the same way as it mock other class such as FIRMessaging, proxy class seems resolve the issue. 