### PR TITLE
Initializing UIWindow using initWithWindowScene for ios 13 and removing UI code from main FIRAppDistribution.m

### DIFF
--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -278,7 +278,7 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
   if ([self isTesterSignedIn]) {
     [self fetchNewLatestRelease:completion];
   } else {
-    FIRFADUIActionCompletion yesActionCompletion = ^(UIAlertAction *action){
+    FIRFADUIActionCompletion yesActionCompletion = ^(UIAlertAction *action) {
       [self signInTesterWithCompletion:^(NSError *_Nullable error) {
         if (error) {
           completion(nil, error);
@@ -289,11 +289,12 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
       }];
     };
 
-    FIRFADUIActionCompletion noActionCompletion = ^(UIAlertAction *action){
+    FIRFADUIActionCompletion noActionCompletion = ^(UIAlertAction *action) {
       completion(nil, nil);
     };
 
-    [[self uiService] showUIAlertWithYesCompletion:yesActionCompletion withNoCompletion:noActionCompletion];
+    [[self uiService] showUIAlertWithYesCompletion:yesActionCompletion
+                                  withNoCompletion:noActionCompletion];
   }
 }
 @end

--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -278,23 +278,24 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
   if ([self isTesterSignedIn]) {
     [self fetchNewLatestRelease:completion];
   } else {
-    FIRFADUIActionCompletion yesActionCompletion = ^(UIAlertAction *action) {
-      [self signInTesterWithCompletion:^(NSError *_Nullable error) {
-        if (error) {
-          completion(nil, error);
-          return;
-        }
+    FIRFADUIActionCompletion actionCompletion = ^(BOOL continued) {
+      if (continued) {
+        [self signInTesterWithCompletion:^(NSError *_Nullable error) {
+          if (error) {
+            completion(nil, error);
+            return;
+          }
 
-        [self fetchNewLatestRelease:completion];
-      }];
+          [self fetchNewLatestRelease:completion];
+        }];
+      } else {
+        completion(
+            nil, [self NSErrorForErrorCodeAndMessage:FIRAppDistributionErrorAuthenticationCancelled
+                                             message:@"Tester cancelled authentication flow."]);
+      }
     };
 
-    FIRFADUIActionCompletion noActionCompletion = ^(UIAlertAction *action) {
-      completion(nil, nil);
-    };
-
-    [[self uiService] showUIAlertWithYesCompletion:yesActionCompletion
-                                  withNoCompletion:noActionCompletion];
+    [[self uiService] showUIAlertWithCompletion:actionCompletion];
   }
 }
 @end

--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -32,7 +32,7 @@
 @interface FIRAppDistribution () <FIRLibrary, FIRAppDistributionInstanceProvider>
 @property(nonatomic) BOOL isTesterSignedIn;
 
-@property(nullable, nonatomic) FIRAppDistributionUIService *UIService;
+@property(nullable, nonatomic) FIRAppDistributionUIService *uiService;
 
 @end
 
@@ -71,8 +71,8 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
 
   if (self) {
     [GULAppDelegateSwizzler proxyOriginalDelegate];
-    self.UIService = [FIRAppDistributionUIService sharedInstance];
-    [GULAppDelegateSwizzler registerAppDelegateInterceptor:self.UIService];
+    self.uiService = [FIRAppDistributionUIService sharedInstance];
+    [GULAppDelegateSwizzler registerAppDelegateInterceptor:[self uiService]];
   }
 
   return self;
@@ -132,7 +132,7 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
     return;
   }
 
-  [self.UIService initializeUIState];
+  [[self uiService] initializeUIState];
   FIRInstallations *installations = [FIRInstallations installations];
 
   // Get a Firebase Installation ID (FID).
@@ -145,7 +145,7 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
       completion([self NSErrorForErrorCodeAndMessage:FIRAppDistributionErrorUnknown
                                              message:description]);
 
-      [self.UIService resetUIState];
+      [[self uiService] resetUIState];
       return;
     }
 
@@ -156,7 +156,7 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
 
     FIRFADDebugLog(@"Registration URL: %@", requestURL);
 
-    [self.UIService
+    [[self uiService]
         appDistributionRegistrationFlow:[[NSURL alloc] initWithString:requestURL]
                          withCompletion:^(NSError *_Nullable error) {
                            FIRFADInfoLog(@"Tester sign in complete.");
@@ -269,6 +269,7 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
             }
           }
         }
+        completion(nil, nil);
       }];
 }
 
@@ -277,39 +278,22 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
   if ([self isTesterSignedIn]) {
     [self fetchNewLatestRelease:completion];
   } else {
-    UIAlertController *alert = [UIAlertController
-        alertControllerWithTitle:@"Enable in-app alerts"
-                         message:@"Sign in with your Firebase App Distribution Google account to "
-                                 @"turn on in-app alerts for new test releases."
-                  preferredStyle:UIAlertControllerStyleAlert];
+    FIRFADUIActionCompletion yesActionCompletion = ^(UIAlertAction *action){
+      [self signInTesterWithCompletion:^(NSError *_Nullable error) {
+        if (error) {
+          completion(nil, error);
+          return;
+        }
 
-    UIAlertAction *yesButton =
-        [UIAlertAction actionWithTitle:@"Turn on"
-                                 style:UIAlertActionStyleDefault
-                               handler:^(UIAlertAction *action) {
-                                 [self signInTesterWithCompletion:^(NSError *_Nullable error) {
-                                   if (error) {
-                                     completion(nil, error);
-                                     return;
-                                   }
+        [self fetchNewLatestRelease:completion];
+      }];
+    };
 
-                                   [self fetchNewLatestRelease:completion];
-                                 }];
-                               }];
+    FIRFADUIActionCompletion noActionCompletion = ^(UIAlertAction *action){
+      completion(nil, nil);
+    };
 
-    UIAlertAction *noButton = [UIAlertAction actionWithTitle:@"Not now"
-                                                       style:UIAlertActionStyleDefault
-                                                     handler:^(UIAlertAction *action) {
-                                                       // precaution to ensure window gets destroyed
-                                                       [self.UIService resetUIState];
-                                                       completion(nil, nil);
-                                                     }];
-
-    [alert addAction:noButton];
-    [alert addAction:yesButton];
-
-    // Create an empty window + viewController to host the Safari UI.
-    [self.UIService showUIAlert:alert];
+    [[self uiService] showUIAlertWithYesCompletion:yesActionCompletion withNoCompletion:noActionCompletion];
   }
 }
 @end

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.h
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.h
@@ -20,6 +20,16 @@
 #import "FirebaseAppDistribution/Sources/Private/FIRAppDistribution.h"
 
 NS_ASSUME_NONNULL_BEGIN
+
+/**
+ *  The completion handler invoked when a button is clicked from the UI prompt
+ *
+ *  @param action  The UI action taken
+ */
+typedef void (^FIRFADUIActionCompletion)(UIAlertAction *_Nullable action)
+NS_SWIFT_NAME(AppDistributionActionCompletion);
+
+
 /// An instance of this class provides UI elements required for the App Distribution tester
 /// authentication flow as an AppDelegate interceptor.
 @interface FIRAppDistributionUIService : NSObject <UIApplicationDelegate,
@@ -43,6 +53,9 @@ typedef void (^AppDistributionRegistrationFlowCompletion)(NSError *_Nullable err
                          withCompletion:(AppDistributionRegistrationFlowCompletion)completion;
 
 - (void)showUIAlert:(UIAlertController *)alertController;
+
+- (void)showUIAlertWithYesCompletion:(FIRFADUIActionCompletion)yesAction
+                    withNoCompletion:(FIRFADUIActionCompletion)noAction;
 
 - (void)initializeUIState;
 

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.h
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.h
@@ -27,8 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param action  The UI action taken
  */
 typedef void (^FIRFADUIActionCompletion)(UIAlertAction *_Nullable action)
-NS_SWIFT_NAME(AppDistributionActionCompletion);
-
+    NS_SWIFT_NAME(AppDistributionActionCompletion);
 
 /// An instance of this class provides UI elements required for the App Distribution tester
 /// authentication flow as an AppDelegate interceptor.

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.h
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.h
@@ -22,11 +22,10 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- *  The completion handler invoked when a button is clicked from the UI prompt
- *
- *  @param action  The UI action taken
+ *  The completion handler invoked when a button is clicked from the UI prompt indicating if a user
+ * clicked continue YES or cancelled NO
  */
-typedef void (^FIRFADUIActionCompletion)(UIAlertAction *_Nullable action)
+typedef void (^FIRFADUIActionCompletion)(BOOL continued)
     NS_SWIFT_NAME(AppDistributionActionCompletion);
 
 /// An instance of this class provides UI elements required for the App Distribution tester
@@ -53,8 +52,7 @@ typedef void (^AppDistributionRegistrationFlowCompletion)(NSError *_Nullable err
 
 - (void)showUIAlert:(UIAlertController *)alertController;
 
-- (void)showUIAlertWithYesCompletion:(FIRFADUIActionCompletion)yesAction
-                    withNoCompletion:(FIRFADUIActionCompletion)noAction;
+- (void)showUIAlertWithCompletion:(FIRFADUIActionCompletion)completion;
 
 - (void)initializeUIState;
 

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
@@ -140,8 +140,7 @@ SFAuthenticationSession *_safariAuthenticationVC;
                                              completion:nil];
 }
 
-- (void)showUIAlertWithYesCompletion:(FIRFADUIActionCompletion)yesAction
-                    withNoCompletion:(FIRFADUIActionCompletion)noAction {
+- (void)showUIAlertWithCompletion:(FIRFADUIActionCompletion)completion {
   UIAlertController *alert = [UIAlertController
       alertControllerWithTitle:@"Enable in-app alerts"
                        message:@"Sign in with your Firebase App Distribution Google account to "
@@ -151,14 +150,14 @@ SFAuthenticationSession *_safariAuthenticationVC;
   UIAlertAction *yesButton = [UIAlertAction actionWithTitle:@"Turn on"
                                                       style:UIAlertActionStyleDefault
                                                     handler:^(UIAlertAction *action) {
-                                                      yesAction(action);
+                                                      completion(YES);
                                                     }];
 
   UIAlertAction *noButton = [UIAlertAction actionWithTitle:@"Not now"
                                                      style:UIAlertActionStyleDefault
                                                    handler:^(UIAlertAction *action) {
                                                      [self resetUIState];
-                                                     noAction(action);
+                                                     completion(NO);
                                                    }];
 
   [alert addAction:noButton];

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
@@ -197,7 +197,6 @@ SFAuthenticationSession *_safariAuthenticationVC;
     return;
   }
 
-#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
   if (@available(iOS 13.0, *)) {
     UIWindowScene *foregroundedScene = nil;
     for (UIWindowScene *connectedScene in [UIApplication sharedApplication].connectedScenes) {
@@ -213,10 +212,9 @@ SFAuthenticationSession *_safariAuthenticationVC;
       FIRFADErrorLog(@"No foreground scene found. Cannot display new build alert.");
       return;
     }
+  } else {
+    self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   }
-#else
-  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-#endif
   self.window.rootViewController = self.safariHostingViewController;
 
   // Place it at the highest level within the stack.

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
@@ -143,24 +143,23 @@ SFAuthenticationSession *_safariAuthenticationVC;
 - (void)showUIAlertWithYesCompletion:(FIRFADUIActionCompletion)yesAction
                     withNoCompletion:(FIRFADUIActionCompletion)noAction {
   UIAlertController *alert = [UIAlertController
-                              alertControllerWithTitle:@"Enable in-app alerts"
-                              message:@"Sign in with your Firebase App Distribution Google account to "
-                              @"turn on in-app alerts for new test releases."
-                              preferredStyle:UIAlertControllerStyleAlert];
+      alertControllerWithTitle:@"Enable in-app alerts"
+                       message:@"Sign in with your Firebase App Distribution Google account to "
+                               @"turn on in-app alerts for new test releases."
+                preferredStyle:UIAlertControllerStyleAlert];
 
-  UIAlertAction *yesButton =
-  [UIAlertAction actionWithTitle:@"Turn on"
-                           style:UIAlertActionStyleDefault
-                         handler:^(UIAlertAction *action) {
-    yesAction(action);
-  }];
+  UIAlertAction *yesButton = [UIAlertAction actionWithTitle:@"Turn on"
+                                                      style:UIAlertActionStyleDefault
+                                                    handler:^(UIAlertAction *action) {
+                                                      yesAction(action);
+                                                    }];
 
   UIAlertAction *noButton = [UIAlertAction actionWithTitle:@"Not now"
                                                      style:UIAlertActionStyleDefault
                                                    handler:^(UIAlertAction *action) {
-    [self resetUIState];
-    noAction(action);
-  }];
+                                                     [self resetUIState];
+                                                     noAction(action);
+                                                   }];
 
   [alert addAction:noButton];
   [alert addAction:yesButton];

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
@@ -140,6 +140,35 @@ SFAuthenticationSession *_safariAuthenticationVC;
                                              completion:nil];
 }
 
+- (void)showUIAlertWithYesCompletion:(FIRFADUIActionCompletion)yesAction
+                    withNoCompletion:(FIRFADUIActionCompletion)noAction {
+  UIAlertController *alert = [UIAlertController
+                              alertControllerWithTitle:@"Enable in-app alerts"
+                              message:@"Sign in with your Firebase App Distribution Google account to "
+                              @"turn on in-app alerts for new test releases."
+                              preferredStyle:UIAlertControllerStyleAlert];
+
+  UIAlertAction *yesButton =
+  [UIAlertAction actionWithTitle:@"Turn on"
+                           style:UIAlertActionStyleDefault
+                         handler:^(UIAlertAction *action) {
+    yesAction(action);
+  }];
+
+  UIAlertAction *noButton = [UIAlertAction actionWithTitle:@"Not now"
+                                                     style:UIAlertActionStyleDefault
+                                                   handler:^(UIAlertAction *action) {
+    [self resetUIState];
+    noAction(action);
+  }];
+
+  [alert addAction:noButton];
+  [alert addAction:yesButton];
+
+  // Create an empty window + viewController to host the Safari UI.
+  [self showUIAlert:alert];
+}
+
 - (BOOL)application:(UIApplication *)application
             openURL:(NSURL *)URL
             options:(NSDictionary<NSString *, id> *)options {
@@ -182,11 +211,11 @@ SFAuthenticationSession *_safariAuthenticationVC;
     if (foregroundedScene) {
       self.window = [[UIWindow alloc] initWithWindowScene:foregroundedScene];
     } else {
-      // TODO: figure out if foregroundScene can be nil. If yes, should we return error?
+      FIRFADErrorLog(@"No foreground scene found. Cannot display new build alert.");
       return;
     }
   }
-#else  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+#else
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
 #endif
   self.window.rootViewController = self.safariHostingViewController;
@@ -196,9 +225,6 @@ SFAuthenticationSession *_safariAuthenticationVC;
 
   // Run it.
   [self.window makeKeyAndVisible];
-
-  if (self.window) {
-  }
 }
 
 - (void)resetUIState {

--- a/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionTests.m
+++ b/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionTests.m
@@ -48,7 +48,7 @@
   id _mockFIRInstallations;
   id _mockInstallationToken;
   id _mockMachO;
-  UIAlertAction* _mockAlertAction;
+  UIAlertAction *_mockAlertAction;
   NSString *_mockAuthToken;
   NSString *_mockInstallationId;
   NSArray *_mockReleases;
@@ -65,9 +65,11 @@
   _mockFIRInstallations = OCMClassMock([FIRInstallations class]);
   _mockInstallationToken = OCMClassMock([FIRInstallationsAuthTokenResult class]);
   _mockMachO = OCMClassMock([FIRAppDistributionMachO class]);
-  _mockAlertAction = [UIAlertAction actionWithTitle:@"This is a fake action" style: UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-    return;
-  }];
+  _mockAlertAction = [UIAlertAction actionWithTitle:@"This is a fake action"
+                                              style:UIAlertActionStyleDefault
+                                            handler:^(UIAlertAction *_Nonnull action) {
+                                              return;
+                                            }];
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub([_mockFIRAppClass defaultApp]).andReturn(_mockFIRAppClass);
   OCMStub([_mockFIRAppDistributionUIService initializeUIState]);
@@ -128,7 +130,7 @@
 
 - (void)mockUIServiceRegistrationCompletion:(NSError *_Nullable)error {
   [OCMStub([_mockFIRAppDistributionUIService appDistributionRegistrationFlow:OCMOCK_ANY
-                                                         withCompletion:OCMOCK_ANY])
+                                                              withCompletion:OCMOCK_ANY])
       andDo:^(NSInvocation *invocation) {
         __unsafe_unretained void (^handler)(NSError *_Nullable error);
         [invocation getArgument:&handler atIndex:3];
@@ -138,32 +140,32 @@
 
 - (void)verifyRegistrationCompletion {
   OCMVerify([_mockFIRAppDistributionUIService appDistributionRegistrationFlow:OCMOCK_ANY
-                                                          withCompletion:OCMOCK_ANY]);
+                                                               withCompletion:OCMOCK_ANY]);
 }
 
 - (void)rejectRegistrationCompletion {
   OCMReject([_mockFIRAppDistributionUIService appDistributionRegistrationFlow:OCMOCK_ANY
-                                                          withCompletion:OCMOCK_ANY]);
+                                                               withCompletion:OCMOCK_ANY]);
 }
 
 - (void)mockUIServiceShowUIYesCompletion {
   [OCMStub([_mockFIRAppDistributionUIService showUIAlertWithYesCompletion:OCMOCK_ANY
-                                                              withNoCompletion:OCMOCK_ANY])
-   andDo:^(NSInvocation *invocation) {
-    __unsafe_unretained void (^handler)(UIAlertAction *action);
-    [invocation getArgument:&handler atIndex:2];
-    handler(self->_mockAlertAction);
-  }];
+                                                         withNoCompletion:OCMOCK_ANY])
+      andDo:^(NSInvocation *invocation) {
+        __unsafe_unretained void (^handler)(UIAlertAction *action);
+        [invocation getArgument:&handler atIndex:2];
+        handler(self->_mockAlertAction);
+      }];
 }
 
 - (void)mockUIServiceShowUINoCompletion {
   [OCMStub([_mockFIRAppDistributionUIService showUIAlertWithYesCompletion:OCMOCK_ANY
                                                          withNoCompletion:OCMOCK_ANY])
-   andDo:^(NSInvocation *invocation) {
-    __unsafe_unretained void (^handler)(UIAlertAction *action);
-    [invocation getArgument:&handler atIndex:3];
-    handler(self->_mockAlertAction);
-  }];
+      andDo:^(NSInvocation *invocation) {
+        __unsafe_unretained void (^handler)(UIAlertAction *action);
+        [invocation getArgument:&handler atIndex:3];
+        handler(self->_mockAlertAction);
+      }];
 }
 
 - (void)verifyShowUICompletion {
@@ -371,7 +373,7 @@
 
   // Sign in the tester
   XCTestExpectation *expectation =
-  [self expectationWithDescription:@"Persist sign in state succeeds."];
+      [self expectationWithDescription:@"Persist sign in state succeeds."];
 
   [[self appDistribution] signInTesterWithCompletion:^(NSError *_Nullable error) {
     XCTAssertNil(error);
@@ -381,12 +383,15 @@
   XCTAssertTrue([[self appDistribution] isTesterSignedIn]);
 
   // Should Call check for update without calling the UIService
-  XCTestExpectation *checkForUpdateExpectation = [self expectationWithDescription:@"Check for update does not prompt user"];
-  [[self appDistribution] checkForUpdateWithCompletion:^(FIRAppDistributionRelease * _Nullable release, NSError * _Nullable error) {
-    XCTAssertNil(error);
-    XCTAssertNotNil(release);
-    [checkForUpdateExpectation fulfill];
-  }];
+  XCTestExpectation *checkForUpdateExpectation =
+      [self expectationWithDescription:@"Check for update does not prompt user"];
+  [[self appDistribution]
+      checkForUpdateWithCompletion:^(FIRAppDistributionRelease *_Nullable release,
+                                     NSError *_Nullable error) {
+        XCTAssertNil(error);
+        XCTAssertNotNil(release);
+        [checkForUpdateExpectation fulfill];
+      }];
 
   [self waitForExpectations:@[ checkForUpdateExpectation ] timeout:5.0];
   [self rejectShowUICompletion];
@@ -399,12 +404,15 @@
   [self mockUIServiceShowUIYesCompletion];
   OCMStub([_mockMachO codeHash]).andReturn(@"this-is-old");
 
-  XCTestExpectation *checkForUpdateExpectation = [self expectationWithDescription:@"Check for update does prompt user"];
-  [[self appDistribution] checkForUpdateWithCompletion:^(FIRAppDistributionRelease * _Nullable release, NSError * _Nullable error) {
-    XCTAssertNil(error);
-    XCTAssertNotNil(release);
-    [checkForUpdateExpectation fulfill];
-  }];
+  XCTestExpectation *checkForUpdateExpectation =
+      [self expectationWithDescription:@"Check for update does prompt user"];
+  [[self appDistribution]
+      checkForUpdateWithCompletion:^(FIRAppDistributionRelease *_Nullable release,
+                                     NSError *_Nullable error) {
+        XCTAssertNil(error);
+        XCTAssertNotNil(release);
+        [checkForUpdateExpectation fulfill];
+      }];
 
   [self waitForExpectations:@[ checkForUpdateExpectation ] timeout:5.0];
   [self verifyShowUICompletion];
@@ -413,20 +421,23 @@
 
 - (void)testCheckForUpdateWithCompletionClicksYesFailure {
   NSError *mockError =
-  [NSError errorWithDomain:@"this.is.fake"
-                      code:3
-                  userInfo:@{NSLocalizedDescriptionKey : @"This is unfortunate."}];
+      [NSError errorWithDomain:@"this.is.fake"
+                          code:3
+                      userInfo:@{NSLocalizedDescriptionKey : @"This is unfortunate."}];
   [self mockInstallationIdCompletion:_mockInstallationId error:mockError];
   [self mockUIServiceRegistrationCompletion:nil];
   [self mockFetchReleasesCompletion:_mockReleases error:nil];
   [self mockUIServiceShowUIYesCompletion];
 
-  XCTestExpectation *checkForUpdateExpectation = [self expectationWithDescription:@"Check for update does prompt user"];
-  [[self appDistribution] checkForUpdateWithCompletion:^(FIRAppDistributionRelease * _Nullable release, NSError * _Nullable error) {
-    XCTAssertNotNil(error);
-    XCTAssertNil(release);
-    [checkForUpdateExpectation fulfill];
-  }];
+  XCTestExpectation *checkForUpdateExpectation =
+      [self expectationWithDescription:@"Check for update does prompt user"];
+  [[self appDistribution]
+      checkForUpdateWithCompletion:^(FIRAppDistributionRelease *_Nullable release,
+                                     NSError *_Nullable error) {
+        XCTAssertNotNil(error);
+        XCTAssertNil(release);
+        [checkForUpdateExpectation fulfill];
+      }];
 
   [self waitForExpectations:@[ checkForUpdateExpectation ] timeout:5.0];
   [self verifyShowUICompletion];
@@ -438,12 +449,15 @@
   [self mockFetchReleasesCompletion:_mockReleases error:nil];
   [self mockUIServiceShowUINoCompletion];
 
-  XCTestExpectation *checkForUpdateExpectation = [self expectationWithDescription:@"Check for update does prompt user"];
-  [[self appDistribution] checkForUpdateWithCompletion:^(FIRAppDistributionRelease * _Nullable release, NSError * _Nullable error) {
-    XCTAssertNil(error);
-    XCTAssertNil(release);
-    [checkForUpdateExpectation fulfill];
-  }];
+  XCTestExpectation *checkForUpdateExpectation =
+      [self expectationWithDescription:@"Check for update does prompt user"];
+  [[self appDistribution]
+      checkForUpdateWithCompletion:^(FIRAppDistributionRelease *_Nullable release,
+                                     NSError *_Nullable error) {
+        XCTAssertNil(error);
+        XCTAssertNil(release);
+        [checkForUpdateExpectation fulfill];
+      }];
 
   [self waitForExpectations:@[ checkForUpdateExpectation ] timeout:5.0];
   [self verifyShowUICompletion];


### PR DESCRIPTION
* Initializing UIWindow using initWithWindowScene for ios 13 
* Also making sure we only reset window in the App delegate if a registration flow is in progress.

#no-changelog this is being merged into another branch