### PR TITLE
GULAppDelegateSwizzlerTest: use OCMClassMock for application to avoid mock conflicts with KVO

### DIFF
--- a/GoogleUtilities/Tests/Unit/Swizzler/GULAppDelegateSwizzlerTest.m
+++ b/GoogleUtilities/Tests/Unit/Swizzler/GULAppDelegateSwizzlerTest.m
@@ -288,7 +288,8 @@ static BOOL gRespondsToHandleBackgroundSession;
 
 - (void)setUp {
   [super setUp];
-  self.mockSharedApplication = OCMPartialMock([GULApplication sharedApplication]);
+  self.mockSharedApplication = OCMClassMock([GULApplication class]);
+  OCMStub([self.mockSharedApplication sharedApplication]).andReturn(self.mockSharedApplication);
 }
 
 - (void)tearDown {


### PR DESCRIPTION
Fixes #6140

#no-changelog for tests fixes.