### PR TITLE
Unset window.rootViewController when resetting UI

### DIFF
--- a/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
@@ -225,6 +225,7 @@ SFAuthenticationSession *_safariAuthenticationVC;
 
 - (void)resetUIState {
   if (self.window) {
+    self.window.rootViewController = nil;
     self.window.hidden = YES;
     self.window = nil;
   }


### PR DESCRIPTION
This fixes an issue where displaying the UI window, resetting the UI state and then displaying the window again causes an error.

#no-changelog