### PR TITLE
Revert "Remove #if SWIFT_PACKAGE checks for nanopb (#6163)"

### DIFF
--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
@@ -22,9 +22,13 @@
 
 #import "Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h"
 
-#import "pb.h"
-#import "pb_decode.h"
-#import "pb_encode.h"
+#if SWIFT_PACKAGE
+@import nanopb;
+#else
+#import <nanopb/pb.h>
+#import <nanopb/pb_decode.h>
+#import <nanopb/pb_encode.h>
+#endif
 
 @implementation FIRCLSReportAdapter
 

--- a/Crashlytics/ProtoSupport/proto_generator.py
+++ b/Crashlytics/ProtoSupport/proto_generator.py
@@ -262,8 +262,8 @@ def nanopb_rename_delete(lines):
 
 
 def nanopb_use_module_import(lines):
-  """Changes #include <pb.h> to include "pb.h" """ # Don't let Copybara alter these lines.
-  return [line.replace('#include <pb.h>', '{}include "pb.h"'.format("#")) for line in lines]
+  """Changes #include <pb.h> to include <nanopb/pb.h>""" # Don't let Copybara alter these lines.
+  return [line.replace('#include <pb.h>', '{}include <nanopb/pb.h>'.format("#")) for line in lines]
 
 
 def strip_trailing_whitespace(lines):

--- a/Crashlytics/Protogen/nanopb/crashlytics.nanopb.h
+++ b/Crashlytics/Protogen/nanopb/crashlytics.nanopb.h
@@ -19,8 +19,11 @@
 
 #ifndef PB_GOOGLE_CRASHLYTICS_CRASHLYTICS_NANOPB_H_INCLUDED
 #define PB_GOOGLE_CRASHLYTICS_CRASHLYTICS_NANOPB_H_INCLUDED
-
-#include "pb.h"
+#if SWIFT_PACKAGE
+#include "nanopb.h"
+#else
+#include <nanopb/pb.h>
+#endif
 
 /* @@protoc_insertion_point(includes) */
 #if PB_PROTO_HEADER_VERSION != 30

--- a/FirebaseInAppMessaging/Analytics/Protogen/nanopb/fiam.nanopb.h
+++ b/FirebaseInAppMessaging/Analytics/Protogen/nanopb/fiam.nanopb.h
@@ -19,7 +19,7 @@
 
 #ifndef PB_LOGS_PROTO_FIREBASE_INAPPMESSAGING_FIAM_NANOPB_H_INCLUDED
 #define PB_LOGS_PROTO_FIREBASE_INAPPMESSAGING_FIAM_NANOPB_H_INCLUDED
-#include "pb.h"
+#include <nanopb/pb.h>
 
 /* @@protoc_insertion_point(includes) */
 #if PB_PROTO_HEADER_VERSION != 30

--- a/FirebaseInAppMessaging/ProtoSupport/nanopb_build_protos.py
+++ b/FirebaseInAppMessaging/ProtoSupport/nanopb_build_protos.py
@@ -262,8 +262,8 @@ def nanopb_rename_delete(lines):
 
 
 def nanopb_use_module_import(lines):
-  """Changes #include <pb.h> to include "pb.h" """ # Don't let Copybara alter these lines.
-  return [line.replace('#include <pb.h>', '{}include "pb.h"'.format("#")) for line in lines]
+  """Changes #include <pb.h> to include <nanopb/pb.h>""" # Don't let Copybara alter these lines.
+  return [line.replace('#include <pb.h>', '{}include <nanopb/pb.h>'.format("#")) for line in lines]
 
 
 def strip_trailing_whitespace(lines):

--- a/FirebaseInAppMessaging/Sources/Analytics/Protogen/nanopb/fiam.nanopb.h
+++ b/FirebaseInAppMessaging/Sources/Analytics/Protogen/nanopb/fiam.nanopb.h
@@ -19,7 +19,7 @@
 
 #ifndef PB_LOGS_PROTO_FIREBASE_INAPPMESSAGING_FIAM_NANOPB_H_INCLUDED
 #define PB_LOGS_PROTO_FIREBASE_INAPPMESSAGING_FIAM_NANOPB_H_INCLUDED
-#include "pb.h"
+#include <nanopb/pb.h>
 
 /* @@protoc_insertion_point(includes) */
 #if PB_PROTO_HEADER_VERSION != 30

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
@@ -27,9 +27,13 @@
 #import "GoogleDataTransport/GDTCORLibrary/Public/GDTCOREvent.h"
 #import "GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h"
 
-#import "pb.h"
-#import "pb_decode.h"
-#import "pb_encode.h"
+#if SWIFT_PACKAGE
+#import "nanopb.h"
+#else
+#import <nanopb/pb.h>
+#import <nanopb/pb_decode.h>
+#import <nanopb/pb_encode.h>
+#endif
 
 #import "GoogleDataTransport/GDTCCTLibrary/Public/GDTCOREvent+GDTCCTSupport.h"
 

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
@@ -22,9 +22,13 @@
 #import "GoogleDataTransport/GDTCORLibrary/Public/GDTCORRegistrar.h"
 #import "GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h"
 
-#import "pb.h"
-#import "pb_decode.h"
-#import "pb_encode.h"
+#if SWIFT_PACKAGE
+#import "nanopb.h"
+#else
+#import <nanopb/pb.h>
+#import <nanopb/pb_decode.h>
+#import <nanopb/pb_encode.h>
+#endif
 
 #import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTCompressionHelper.h"
 #import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTNanopbHelpers.h"

--- a/GoogleDataTransport/GDTCCTLibrary/Protogen/nanopb/cct.nanopb.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Protogen/nanopb/cct.nanopb.h
@@ -19,8 +19,11 @@
 
 #ifndef PB_GDT_CCT_CCT_NANOPB_H_INCLUDED
 #define PB_GDT_CCT_CCT_NANOPB_H_INCLUDED
-
-#include "pb.h"
+#if SWIFT_PACKAGE
+#include "nanopb.h"
+#else
+#include <nanopb/pb.h>
+#endif
 
 /* @@protoc_insertion_point(includes) */
 #if PB_PROTO_HEADER_VERSION != 30

--- a/GoogleDataTransport/ProtoSupport/proto_generator.py
+++ b/GoogleDataTransport/ProtoSupport/proto_generator.py
@@ -262,8 +262,8 @@ def nanopb_rename_delete(lines):
 
 
 def nanopb_use_module_import(lines):
-  """Changes #include <pb.h> to include "pb.h" """ # Don't let Copybara alter these lines.
-  return [line.replace('#include <pb.h>', '{}include "pb.h"'.format("#")) for line in lines]
+  """Changes #include <pb.h> to include <nanopb/pb.h>""" # Don't let Copybara alter these lines.
+  return [line.replace('#include <pb.h>', '{}include <nanopb/pb.h>'.format("#")) for line in lines]
 
 
 def strip_trailing_whitespace(lines):

--- a/Package.swift
+++ b/Package.swift
@@ -82,7 +82,7 @@ let package = Package(
     .package(
       name: "nanopb",
       url: "https://github.com/paulb777/nanopb.git",
-      .revision("849a9b82233aaa5af4286c6c594cd831ca48651c")
+      .branch("swift-package-manager")
     ),
     .package(name: "OCMock", url: "https://github.com/paulb777/ocmock.git", .revision("7291762")),
     .package(name: "leveldb", url: "https://github.com/paulb777/leveldb.git", .revision("3f04697")),

--- a/scripts/check_imports.swift
+++ b/scripts/check_imports.swift
@@ -53,7 +53,6 @@ let skipImportPatterns = [
   "FBLPromise",
   "OCMock",
   "OCMStubRecorder",
-  "pb",
 ]
 
 private class ErrorLogger {


### PR DESCRIPTION
Reverting since it breaks Firestore build.

Will explore making Firestore's usage of nanopb consistent with rest of Firebase by using qualified nanopb imports instead of vice versa.

#no-changelog