### PR TITLE
Import nanopb without touching CocoaPods imports

### DIFF
--- a/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
+++ b/Crashlytics/Crashlytics/Models/Record/FIRCLSReportAdapter.m
@@ -22,13 +22,9 @@
 
 #import "Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h"
 
-#if SWIFT_PACKAGE
-@import nanopb;
-#else
 #import <nanopb/pb.h>
 #import <nanopb/pb_decode.h>
 #import <nanopb/pb_encode.h>
-#endif
 
 @implementation FIRCLSReportAdapter
 

--- a/Crashlytics/Protogen/nanopb/crashlytics.nanopb.h
+++ b/Crashlytics/Protogen/nanopb/crashlytics.nanopb.h
@@ -19,11 +19,7 @@
 
 #ifndef PB_GOOGLE_CRASHLYTICS_CRASHLYTICS_NANOPB_H_INCLUDED
 #define PB_GOOGLE_CRASHLYTICS_CRASHLYTICS_NANOPB_H_INCLUDED
-#if SWIFT_PACKAGE
-#include "nanopb.h"
-#else
 #include <nanopb/pb.h>
-#endif
 
 /* @@protoc_insertion_point(includes) */
 #if PB_PROTO_HEADER_VERSION != 30

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTNanopbHelpers.m
@@ -27,13 +27,9 @@
 #import "GoogleDataTransport/GDTCORLibrary/Public/GDTCOREvent.h"
 #import "GoogleDataTransport/GDTCORLibrary/Public/GDTCORPlatform.h"
 
-#if SWIFT_PACKAGE
-#import "nanopb.h"
-#else
 #import <nanopb/pb.h>
 #import <nanopb/pb_decode.h>
 #import <nanopb/pb_encode.h>
-#endif
 
 #import "GoogleDataTransport/GDTCCTLibrary/Public/GDTCOREvent+GDTCCTSupport.h"
 

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
@@ -22,13 +22,9 @@
 #import "GoogleDataTransport/GDTCORLibrary/Public/GDTCORRegistrar.h"
 #import "GoogleDataTransport/GDTCORLibrary/Public/GDTCORStorageProtocol.h"
 
-#if SWIFT_PACKAGE
-#import "nanopb.h"
-#else
 #import <nanopb/pb.h>
 #import <nanopb/pb_decode.h>
 #import <nanopb/pb_encode.h>
-#endif
 
 #import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTCompressionHelper.h"
 #import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTNanopbHelpers.h"

--- a/GoogleDataTransport/GDTCCTLibrary/Protogen/nanopb/cct.nanopb.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Protogen/nanopb/cct.nanopb.h
@@ -19,11 +19,7 @@
 
 #ifndef PB_GDT_CCT_CCT_NANOPB_H_INCLUDED
 #define PB_GDT_CCT_CCT_NANOPB_H_INCLUDED
-#if SWIFT_PACKAGE
-#include "nanopb.h"
-#else
 #include <nanopb/pb.h>
-#endif
 
 /* @@protoc_insertion_point(includes) */
 #if PB_PROTO_HEADER_VERSION != 30

--- a/Package.swift
+++ b/Package.swift
@@ -82,7 +82,7 @@ let package = Package(
     .package(
       name: "nanopb",
       url: "https://github.com/paulb777/nanopb.git",
-      .branch("swift-package-manager")
+      .revision("82230e9998a35a3d2144884204db64f045c880c4")
     ),
     .package(name: "OCMock", url: "https://github.com/paulb777/ocmock.git", .revision("7291762")),
     .package(name: "leveldb", url: "https://github.com/paulb777/leveldb.git", .revision("3f04697")),


### PR DESCRIPTION
This is the right way to do #6162. Nothing about the CocoaPods implementation is changed and no `#if SWIFT_PACKAGE` tests are needed.

I updated the nanopb SPM implementation so that all the existing Firebase nanopb imports would be supported.

In addition to Crashlytics and GDT, Firestore is validate with this change in #6072

See https://github.com/paulb777/nanopb/tree/spm2