### PR TITLE
Add fallback for iOS 13 when not using scenes

### DIFF
--- a/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
@@ -208,8 +208,8 @@ SFAuthenticationSession *_safariAuthenticationVC;
     if (foregroundedScene) {
       self.window = [[UIWindow alloc] initWithWindowScene:foregroundedScene];
     } else {
-      FIRFADErrorLog(@"No foreground scene found. Cannot display new build alert.");
-      return;
+      FIRFADInfoLog(@"No foreground scene found.");
+      self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     }
   } else {
     self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];


### PR DESCRIPTION
When running on an iOS 13 device, but not using scenes, fallback to initWithFrame.

#no-changelog - the App Distribution SDK is not yet released