### PR TITLE
Speedup SPM presubmit

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -6,9 +6,17 @@ on:
     - '.github/workflows/spm.yml'
     - 'Package.swift'
     - 'Firebase**'
+    - 'Google*'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'
+
+# This workflow builds and tests the Swift Package Manager. Only iOS runs on PRs
+# because each platform takes 15-20 minutes after adding Firestore.
+
+# TODO: Write a script to filter the Package.swift for each individual product
+# and run just those tests in the product specific workflows. Then this workflow
+# should be the full SPM tests for all platforms only on cron.
 
 jobs:
   swift-build-run:
@@ -23,11 +31,25 @@ jobs:
       run: swift build
     - name: Initialize xcodebuild
       run: xcodebuild -list
-    - name: Core ObjC Unit Tests macOS
-      run:  scripts/third_party/travis/retry.sh xcodebuild -scheme Firebase-Package test | xcpretty
     - name: Core ObjC Unit Tests iOS
       run: scripts/third_party/travis/retry.sh xcodebuild -scheme Firebase-Package test -sdk
            iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11' | xcpretty
+
+  cron-only:
+    # Don't run on private repo.
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Xcode 12
+      run: sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer
+    - name: Build
+      run: swift build
+    - name: Initialize xcodebuild
+      run: xcodebuild -list
+    - name: Core ObjC Unit Tests macOS
+      run:  scripts/third_party/travis/retry.sh xcodebuild -scheme Firebase-Package test | xcpretty
     - name: Core ObjC Unit Tests tvOS
       run: scripts/third_party/travis/retry.sh xcodebuild -scheme Firebase-Package test -sdk
            appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty


### PR DESCRIPTION
The SPM workflow takes over 45 minute with Firestore.

This PR changes it to only test iOS on PRs and leave the other platforms for the cron job.