### PR TITLE
Add missing <TargetConditionals.h> before TARGET_OS_OSX test

### DIFF
--- a/FirebaseInstallations/Source/Tests/Integration/FIRInstallationsIntegrationTests.m
+++ b/FirebaseInstallations/Source/Tests/Integration/FIRInstallationsIntegrationTests.m
@@ -20,6 +20,8 @@
 // macOS requests a user password when accessing the Keychain for the first time,
 // so the tests may fail. Disable integration tests on macOS so far.
 // TODO: Configure the tests to run on macOS without requesting the keychain password.
+
+#import <TargetConditionals.h>
 #if !TARGET_OS_OSX
 
 #import <XCTest/XCTest.h>

--- a/FirebaseInstallations/Source/Tests/Utils/FIRTestKeychain.m
+++ b/FirebaseInstallations/Source/Tests/Utils/FIRTestKeychain.m
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#import <TargetConditionals.h>
 #if TARGET_OS_OSX
 
 #import "FirebaseInstallations/Source/Tests/Utils/FIRTestKeychain.h"

--- a/GoogleUtilities/Tests/Unit/Utils/GULTestKeychain.m
+++ b/GoogleUtilities/Tests/Unit/Utils/GULTestKeychain.m
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#import <TargetConditionals.h>
 #if TARGET_OS_OSX
 
 #import "GoogleUtilities/Tests/Unit/Utils/GULTestKeychain.h"


### PR DESCRIPTION
The CocoaPods 1.10 beta exposed this issue. I'm not sure why this didn't fail with 1.9, but it's definitely a test issue.

#no-changelog