### PR TITLE
Resolve spm CI git error

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -94,7 +94,7 @@ let package = Package(
     .package(
       name: "nanopb",
       url: "https://github.com/paulb777/nanopb.git",
-      .revision("82230e9998a35a3d2144884204db64f045c880c4")
+      .branch("spm2")
     ),
     .package(
       name: "abseil",


### PR DESCRIPTION
It looks like SPM doesn't clone all of a repo's commits. See https://github.com/firebase/firebase-ios-sdk/runs/937613345

This PR resolves the failure and restores CI.

#no-changelog