### PR TITLE
Update podspec dependencies for 6.30.0

### DIFF
--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -36,7 +36,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
   end
 
   s.subspec 'CoreOnly' do |ss|
-    ss.dependency 'FirebaseCore', '6.9.2'
+    ss.dependency 'FirebaseCore', '6.10.0'
     ss.source_files = 'CoreOnly/Sources/Firebase.h'
     ss.preserve_paths = 'CoreOnly/Sources/module.modulemap'
     if ENV['FIREBASE_POD_REPO_FOR_DEV_POD'] then
@@ -61,7 +61,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'ABTesting' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseABTesting', '~> 4.1.0'
+    ss.dependency 'FirebaseABTesting', '~> 4.2.0'
   end
 
   s.subspec 'AdMob' do |ss|

--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseABTesting'
-  s.version          = '4.1.0'
+  s.version          = '4.2.0'
   s.summary          = 'Firebase ABTesting'
 
   s.description      = <<-DESC
@@ -43,7 +43,7 @@ Firebase Cloud Messaging and Firebase Remote Config in your app.
       'FIRABTesting_VERSION=' + String(s.version),
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
   }
-  s.dependency 'FirebaseCore', '~> 6.8'
+  s.dependency 'FirebaseCore', '~> 6.10'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.source_files = 'FirebaseABTesting/Tests/Unit/**/*.[mh]'

--- a/FirebaseAppDistribution.podspec
+++ b/FirebaseAppDistribution.podspec
@@ -32,11 +32,11 @@ iOS SDK for App Distribution for Firebase.
   ]
   s.public_header_files = base_dir + 'Public/*.h'
 
-  s.dependency 'FirebaseCore', '~> 6.8'
+  s.dependency 'FirebaseCore', '~> 6.10'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 6.7'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 6.7'
-  s.dependency 'FirebaseInstallations', '~> 1.5'
-  s.dependency 'GoogleDataTransport', '~> 7.0'
+  s.dependency 'FirebaseInstallations', '~> 1.6'
+  s.dependency 'GoogleDataTransport', '~> 7.2'
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -48,7 +48,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
   }
   s.framework = 'Security'
   s.ios.framework = 'SafariServices'
-  s.dependency 'FirebaseCore', '~> 6.8'
+  s.dependency 'FirebaseCore', '~> 6.10'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 6.7'
   s.dependency 'GoogleUtilities/Environment', '~> 6.7'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCore'
-  s.version          = '6.9.2'
+  s.version          = '6.10.0'
   s.summary          = 'Firebase Core'
 
   s.description      = <<-DESC

--- a/FirebaseCoreDiagnostics.podspec
+++ b/FirebaseCoreDiagnostics.podspec
@@ -53,7 +53,7 @@ non-Cocoapod integration. This library also respects the Firebase global data co
 
   s.framework = 'Foundation'
 
-  s.dependency 'GoogleDataTransport', '~> 7.0'
+  s.dependency 'GoogleDataTransport', '~> 7.2'
   s.dependency 'GoogleUtilities/Environment', '~> 6.7'
   s.dependency 'GoogleUtilities/Logger', '~> 6.7'
   s.dependency 'nanopb', '~> 1.30905.0'

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -47,10 +47,10 @@ Pod::Spec.new do |s|
     cp -f ./Crashlytics/upload-symbols ./upload-symbols
   PREPARE_COMMAND_END
 
-  s.dependency 'FirebaseCore', '~> 6.8'
-  s.dependency 'FirebaseInstallations', '~> 1.1'
+  s.dependency 'FirebaseCore', '~> 6.10'
+  s.dependency 'FirebaseInstallations', '~> 1.6'
   s.dependency 'PromisesObjC', '~> 1.2'
-  s.dependency 'GoogleDataTransport', '~> 7.0'
+  s.dependency 'GoogleDataTransport', '~> 7.2'
   s.dependency 'nanopb', '~> 1.30905.0'
 
   s.libraries = 'c++', 'z'

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -36,7 +36,7 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
   s.libraries = ['c++', 'icucore']
   s.frameworks = 'CFNetwork', 'Security', 'SystemConfiguration'
   s.dependency 'leveldb-library', '~> 1.22'
-  s.dependency 'FirebaseCore', '~> 6.8'
+  s.dependency 'FirebaseCore', '~> 6.10'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'GCC_PREPROCESSOR_DEFINITIONS' => 'FIRDatabase_VERSION=' + s.version.to_s,

--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -30,7 +30,7 @@ Firebase Dynamic Links are deep links that enhance user experience and increase 
   s.public_header_files = 'FirebaseDynamicLinks/Sources/Public/*.h'
   s.frameworks = 'QuartzCore'
   s.weak_framework = 'WebKit'
-  s.dependency 'FirebaseCore', '~> 6.8'
+  s.dependency 'FirebaseCore', '~> 6.10'
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -58,7 +58,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   ]
   s.public_header_files = 'Firestore/Source/Public/FirebaseFirestore/*.h'
 
-  s.dependency 'FirebaseCore', '~> 6.8'
+  s.dependency 'FirebaseCore', '~> 6.10'
 
   abseil_version = '0.20200225.0'
   s.dependency 'abseil/algorithm', abseil_version

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -30,7 +30,7 @@ Cloud Functions for Firebase.
   ]
   s.public_header_files = 'Functions/FirebaseFunctions/Public/FirebaseFunctions/*.h'
 
-  s.dependency 'FirebaseCore', '~> 6.8'
+  s.dependency 'FirebaseCore', '~> 6.10'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
 
   s.pod_target_xcconfig = {

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -50,9 +50,9 @@ See more product details at https://firebase.google.com/products/in-app-messagin
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
   }
 
-  s.dependency 'FirebaseCore', '~> 6.8'
-  s.dependency 'FirebaseInstallations', '~> 1.1'
-  s.dependency 'FirebaseABTesting', '~> 4.1'
+  s.dependency 'FirebaseCore', '~> 6.10'
+  s.dependency 'FirebaseInstallations', '~> 1.6'
+  s.dependency 'FirebaseABTesting', '~> 4.2'
   s.dependency 'GoogleUtilities/Environment', '~> 6.7'
   s.dependency 'nanopb', '~> 1.30905.0'
 

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInstallations'
-  s.version          = '1.5.0'
+  s.version          = '1.6.0'
   s.summary          = 'Firebase Installations'
 
   s.description      = <<-DESC
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   s.private_header_files = base_dir + 'Library/Private/*.h'
 
   s.framework = 'Security'
-  s.dependency 'FirebaseCore', '~> 6.8'
+  s.dependency 'FirebaseCore', '~> 6.10'
   s.dependency 'PromisesObjC', '~> 1.2'
   s.dependency 'GoogleUtilities/Environment', '~> 6.7'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 6.7'

--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -44,8 +44,8 @@ services.
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
   }
   s.framework = 'Security'
-  s.dependency 'FirebaseCore', '~> 6.8'
-  s.dependency 'FirebaseInstallations', '~> 1.0'
+  s.dependency 'FirebaseCore', '~> 6.10'
+  s.dependency 'FirebaseInstallations', '~> 1.6'
   s.dependency 'GoogleUtilities/UserDefaults', '~> 6.7'
   s.dependency 'GoogleUtilities/Environment', '~> 6.7'
 

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -54,7 +54,7 @@ device, and it is completely free.
   s.tvos.framework = 'SystemConfiguration'
   s.osx.framework = 'SystemConfiguration'
   s.weak_framework = 'UserNotifications'
-  s.dependency 'FirebaseCore', '~> 6.8'
+  s.dependency 'FirebaseCore', '~> 6.10'
   s.dependency 'FirebaseInstanceID', '~> 4.3'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 6.7'
   s.dependency 'GoogleUtilities/Reachability', '~> 6.7'

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -45,9 +45,9 @@ app update.
       'FIRRemoteConfig_VERSION=' + String(s.version),
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
   }
-  s.dependency 'FirebaseABTesting', '~> 4.1'
-  s.dependency 'FirebaseCore', '~> 6.8'
-  s.dependency 'FirebaseInstallations', '~> 1.1'
+  s.dependency 'FirebaseABTesting', '~> 4.2'
+  s.dependency 'FirebaseCore', '~> 6.10'
+  s.dependency 'FirebaseInstallations', '~> 1.6'
   s.dependency 'GoogleUtilities/Environment', '~> 6.7'
   s.dependency 'GoogleUtilities/NSData+zlib', '~> 6.7'
 

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -36,7 +36,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   s.ios.framework = 'MobileCoreServices'
   s.osx.framework = 'CoreServices'
 
-  s.dependency 'FirebaseCore', '~> 6.8'
+  s.dependency 'FirebaseCore', '~> 6.10'
   s.dependency 'GTMSessionFetcher/Core', '~> 1.1'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/GoogleDataTransport.podspec
+++ b/GoogleDataTransport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'GoogleDataTransport'
-  s.version          = '7.1.0'
+  s.version          = '7.2.0'
   s.summary          = 'Google iOS SDK data transport.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
Restructuring the public headers looks to be  safe and non-impactful, but updating the required dependencies in an abundance of caution to minimize the test and support footprint.

#no-changelog