### PR TITLE
SPM - Initial Analytics

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -27,8 +27,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Xcode 12
       run: sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer
-    - name: Build
-      run: swift build
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: Core ObjC Unit Tests iOS
@@ -44,8 +42,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Xcode 12
       run: sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer
-    - name: Build
-      run: swift build
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: Core ObjC Unit Tests macOS

--- a/FirebaseAnalyticsWrapper/Public/FirebaseAnalytics/FIRAnalytics+AppDelegate.h
+++ b/FirebaseAnalyticsWrapper/Public/FirebaseAnalytics/FIRAnalytics+AppDelegate.h
@@ -1,0 +1,62 @@
+#import <Foundation/Foundation.h>
+
+#import "FIRAnalytics.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Provides App Delegate handlers to be used in your App Delegate.
+ *
+ * To save time integrating Firebase Analytics in an application, Firebase Analytics does not
+ * require delegation implementation from the AppDelegate. Instead this is automatically done by
+ * Firebase Analytics. Should you choose instead to delegate manually, you can turn off the App
+ * Delegate Proxy by adding FirebaseAppDelegateProxyEnabled into your app's Info.plist and setting
+ * it to NO, and adding the methods in this category to corresponding delegation handlers.
+ *
+ * To handle Universal Links, you must return YES in
+ * [UIApplicationDelegate application:didFinishLaunchingWithOptions:].
+ */
+@interface FIRAnalytics (AppDelegate)
+
+/**
+ * Handles events related to a URL session that are waiting to be processed.
+ *
+ * For optimal use of Firebase Analytics, call this method from the
+ * [UIApplicationDelegate application:handleEventsForBackgroundURLSession:completionHandler]
+ * method of the app delegate in your app.
+ *
+ * @param identifier The identifier of the URL session requiring attention.
+ * @param completionHandler The completion handler to call when you finish processing the events.
+ *     Calling this completion handler lets the system know that your app's user interface is
+ *     updated and a new snapshot can be taken.
+ */
++ (void)handleEventsForBackgroundURLSession:(NSString *)identifier
+                          completionHandler:(nullable void (^)(void))completionHandler;
+
+/**
+ * Handles the event when the app is launched by a URL.
+ *
+ * Call this method from [UIApplicationDelegate application:openURL:options:] &#40;on iOS 9.0 and
+ * above&#41;, or [UIApplicationDelegate application:openURL:sourceApplication:annotation:] &#40;on
+ * iOS 8.x and below&#41; in your app.
+ *
+ * @param url The URL resource to open. This resource can be a network resource or a file.
+ */
++ (void)handleOpenURL:(NSURL *)url;
+
+/**
+ * Handles the event when the app receives data associated with user activity that includes a
+ * Universal Link (on iOS 9.0 and above).
+ *
+ * Call this method from [UIApplication continueUserActivity:restorationHandler:] in your app
+ * delegate (on iOS 9.0 and above).
+ *
+ * @param userActivity The activity object containing the data associated with the task the user
+ *     was performing.
+ */
++ (void)handleUserActivity:(id)userActivity;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/FirebaseAnalyticsWrapper/Public/FirebaseAnalytics/FIRAnalytics.h
+++ b/FirebaseAnalyticsWrapper/Public/FirebaseAnalytics/FIRAnalytics.h
@@ -1,0 +1,154 @@
+#import <Foundation/Foundation.h>
+
+#import "FIREventNames.h"
+#import "FIRParameterNames.h"
+#import "FIRUserPropertyNames.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// The top level Firebase Analytics singleton that provides methods for logging events and setting
+/// user properties. See <a href="http://goo.gl/gz8SLz">the developer guides</a> for general
+/// information on using Firebase Analytics in your apps.
+///
+/// @note The Analytics SDK uses SQLite to persist events and other app-specific data. Calling
+///     certain thread-unsafe global SQLite methods like `sqlite3_shutdown()` can result in
+///     unexpected crashes at runtime.
+NS_SWIFT_NAME(Analytics)
+@interface FIRAnalytics : NSObject
+
+/// Logs an app event. The event can have up to 25 parameters. Events with the same name must have
+/// the same parameters. Up to 500 event names are supported. Using predefined events and/or
+/// parameters is recommended for optimal reporting.
+///
+/// The following event names are reserved and cannot be used:
+/// <ul>
+///     <li>ad_activeview</li>
+///     <li>ad_click</li>
+///     <li>ad_exposure</li>
+///     <li>ad_impression</li>
+///     <li>ad_query</li>
+///     <li>adunit_exposure</li>
+///     <li>app_clear_data</li>
+///     <li>app_remove</li>
+///     <li>app_update</li>
+///     <li>error</li>
+///     <li>first_open</li>
+///     <li>in_app_purchase</li>
+///     <li>notification_dismiss</li>
+///     <li>notification_foreground</li>
+///     <li>notification_open</li>
+///     <li>notification_receive</li>
+///     <li>os_update</li>
+///     <li>session_start</li>
+///     <li>user_engagement</li>
+/// </ul>
+///
+/// @param name The name of the event. Should contain 1 to 40 alphanumeric characters or
+///     underscores. The name must start with an alphabetic character. Some event names are
+///     reserved. See FIREventNames.h for the list of reserved event names. The "firebase_",
+///     "google_", and "ga_" prefixes are reserved and should not be used. Note that event names are
+///     case-sensitive and that logging two events whose names differ only in case will result in
+///     two distinct events. To manually log screen view events, use the `screen_view` event name.
+/// @param parameters The dictionary of event parameters. Passing nil indicates that the event has
+///     no parameters. Parameter names can be up to 40 characters long and must start with an
+///     alphabetic character and contain only alphanumeric characters and underscores. Only NSString
+///     and NSNumber (signed 64-bit integer and 64-bit floating-point number) parameter types are
+///     supported. NSString parameter values can be up to 100 characters long. The "firebase_",
+///     "google_", and "ga_" prefixes are reserved and should not be used for parameter names.
++ (void)logEventWithName:(NSString *)name
+              parameters:(nullable NSDictionary<NSString *, id> *)parameters
+    NS_SWIFT_NAME(logEvent(_:parameters:));
+
+/// Sets a user property to a given value. Up to 25 user property names are supported. Once set,
+/// user property values persist throughout the app lifecycle and across sessions.
+///
+/// The following user property names are reserved and cannot be used:
+/// <ul>
+///     <li>first_open_time</li>
+///     <li>last_deep_link_referrer</li>
+///     <li>user_id</li>
+/// </ul>
+///
+/// @param value The value of the user property. Values can be up to 36 characters long. Setting the
+///     value to nil removes the user property.
+/// @param name The name of the user property to set. Should contain 1 to 24 alphanumeric characters
+///     or underscores and must start with an alphabetic character. The "firebase_", "google_", and
+///     "ga_" prefixes are reserved and should not be used for user property names.
++ (void)setUserPropertyString:(nullable NSString *)value forName:(NSString *)name
+    NS_SWIFT_NAME(setUserProperty(_:forName:));
+
+/// Sets the user ID property. This feature must be used in accordance with
+/// <a href="https://www.google.com/policies/privacy">Google's Privacy Policy</a>
+///
+/// @param userID The user ID to ascribe to the user of this app on this device, which must be
+///     non-empty and no more than 256 characters long. Setting userID to nil removes the user ID.
++ (void)setUserID:(nullable NSString *)userID;
+
+/// This method was deprecated in Firebase 6.29.0.
+///
+/// Sets the current screen name, which specifies the current visual context in your app. This helps
+/// identify the areas in your app where users spend their time and how they interact with your app.
+/// Must be called on the main thread.
+///
+/// Note that screen reporting is enabled automatically and records the class name of the current
+/// UIViewController for you without requiring you to call this method. The class name can
+/// optionally be overridden by calling this method in the viewDidAppear callback of your
+/// UIViewController and specifying the screenClassOverride parameter.
+/// `setScreenName:screenClass:` must be called after `[super viewDidAppear:]`.
+///
+/// If your app does not use a distinct UIViewController for each screen, you should call this
+/// method and specify a distinct screenName each time a new screen is presented to the user.
+///
+/// The screen name and screen class remain in effect until the current UIViewController changes or
+/// a new call to setScreenName:screenClass: is made.
+///
+/// @warning If you override `viewDidAppear:` in your UIViewController but do not call
+///     `[super viewDidAppear:]`, that screen class will not be tracked.
+///
+/// @param screenName The name of the current screen. Should contain 1 to 100 characters. Set to nil
+///     to clear the current screen name.
+/// @param screenClassOverride The name of the screen class. Should contain 1 to 100 characters. By
+///     default this is the class name of the current UIViewController. Set to nil to revert to the
+///     default class name.
++ (void)setScreenName:(nullable NSString *)screenName
+          screenClass:(nullable NSString *)screenClassOverride
+    DEPRECATED_MSG_ATTRIBUTE(
+        "Use +[FIRAnalytics logEventWithName:kFIREventScreenView parameters:] instead.");
+
+/// Sets whether analytics collection is enabled for this app on this device. This setting is
+/// persisted across app sessions. By default it is enabled.
+///
+/// @param analyticsCollectionEnabled A flag that enables or disables Analytics collection.
++ (void)setAnalyticsCollectionEnabled:(BOOL)analyticsCollectionEnabled;
+
+/// Sets the interval of inactivity in seconds that terminates the current session. The default
+/// value is 1800 seconds (30 minutes).
+///
+/// @param sessionTimeoutInterval The custom time of inactivity in seconds before the current
+///     session terminates.
++ (void)setSessionTimeoutInterval:(NSTimeInterval)sessionTimeoutInterval;
+
+/// The unique ID for this instance of the application.
++ (NSString *)appInstanceID;
+
+/// Clears all analytics data for this instance from the device and resets the app instance ID.
+/// FIRAnalyticsConfiguration values will be reset to the default values.
++ (void)resetAnalyticsData;
+
+/// Adds parameters that will be set on every event logged from the SDK, including automatic ones.
+/// The values passed in the parameters dictionary will be added to the dictionary of default event
+/// parameters. These parameters persist across app runs. They are of lower precedence than event
+/// parameters, so if an event parameter and a parameter set using this API have the same name, the
+/// value of the event parameter will be used. The same limitations on event parameters apply to
+/// default event parameters.
+///
+/// @param parameters Parameters to be added to the dictionary of parameters added to every event.
+///     They will be added to the dictionary of default event parameters, replacing any existing
+///     parameter with the same name. Valid parameters are NSString and NSNumber (signed 64-bit
+///     integer and 64-bit floating-point number). Setting a key's value to [NSNull null] will clear
+///     that parameter. Passing in a nil dictionary will clear all parameters.
++ (void)setDefaultEventParameters:(nullable NSDictionary<NSString *, id> *)parameters;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseAnalyticsWrapper/Public/FirebaseAnalytics/FIREventNames.h
+++ b/FirebaseAnalyticsWrapper/Public/FirebaseAnalytics/FIREventNames.h
@@ -1,0 +1,480 @@
+/// @file FIREventNames.h
+///
+/// Predefined event names.
+///
+/// An Event is an important occurrence in your app that you want to measure. You can report up to
+/// 500 different types of Events per app and you can associate up to 25 unique parameters with each
+/// Event type. Some common events are suggested below, but you may also choose to specify custom
+/// Event types that are associated with your specific app. Each event type is identified by a
+/// unique name. Event names can be up to 40 characters long, may only contain alphanumeric
+/// characters and underscores ("_"), and must start with an alphabetic character. The "firebase_",
+/// "google_", and "ga_" prefixes are reserved and should not be used.
+
+#import <Foundation/Foundation.h>
+
+/// Add Payment Info event. This event signifies that a user has submitted their payment
+/// information. Note: If you supply the @c kFIRParameterValue parameter, you must also supply the
+/// @c kFIRParameterCurrency parameter so that revenue metrics can be computed accurately. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterCoupon (NSString) (optional)</li>
+///     <li>@c kFIRParameterCurrency (NSString) (optional)</li>
+///     <li>@c kFIRParameterItems (NSArray) (optional)</li>
+///     <li>@c kFIRParameterPaymentType (NSString) (optional)</li>
+///     <li>@c kFIRParameterValue (double as NSNumber) (optional)</li>
+/// </ul>
+static NSString *const kFIREventAddPaymentInfo NS_SWIFT_NAME(AnalyticsEventAddPaymentInfo) =
+    @"add_payment_info";
+
+/// E-Commerce Add To Cart event. This event signifies that an item(s) was added to a cart for
+/// purchase. Add this event to a funnel with @c kFIREventPurchase to gauge the effectiveness of
+/// your checkout process. Note: If you supply the @c kFIRParameterValue parameter, you must also
+/// supply the @c kFIRParameterCurrency parameter so that revenue metrics can be computed
+/// accurately. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterCurrency (NSString) (optional)</li>
+///     <li>@c kFIRParameterItems (NSArray) (optional)</li>
+///     <li>@c kFIRParameterValue (double as NSNumber) (optional)</li>
+/// </ul>
+static NSString *const kFIREventAddToCart NS_SWIFT_NAME(AnalyticsEventAddToCart) = @"add_to_cart";
+
+/// E-Commerce Add To Wishlist event. This event signifies that an item was added to a wishlist. Use
+/// this event to identify popular gift items. Note: If you supply the @c kFIRParameterValue
+/// parameter, you must also supply the @c kFIRParameterCurrency parameter so that revenue metrics
+/// can be computed accurately. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterCurrency (NSString) (optional)</li>
+///     <li>@c kFIRParameterItems (NSArray) (optional)</li>
+///     <li>@c kFIRParameterValue (double as NSNumber) (optional)</li>
+/// </ul>
+static NSString *const kFIREventAddToWishlist NS_SWIFT_NAME(AnalyticsEventAddToWishlist) =
+    @"add_to_wishlist";
+
+/// App Open event. By logging this event when an App becomes active, developers can understand how
+/// often users leave and return during the course of a Session. Although Sessions are automatically
+/// reported, this event can provide further clarification around the continuous engagement of
+/// app-users.
+static NSString *const kFIREventAppOpen NS_SWIFT_NAME(AnalyticsEventAppOpen) = @"app_open";
+
+/// E-Commerce Begin Checkout event. This event signifies that a user has begun the process of
+/// checking out. Add this event to a funnel with your @c kFIREventPurchase event to gauge the
+/// effectiveness of your checkout process. Note: If you supply the @c kFIRParameterValue parameter,
+/// you must also supply the @c kFIRParameterCurrency parameter so that revenue metrics can be
+/// computed accurately. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterCoupon (NSString) (optional)</li>
+///     <li>@c kFIRParameterCurrency (NSString) (optional)</li>
+///     <li>@c kFIRParameterItems (NSArray) (optional)</li>
+///     <li>@c kFIRParameterValue (double as NSNumber) (optional)</li>
+/// </ul>
+static NSString *const kFIREventBeginCheckout NS_SWIFT_NAME(AnalyticsEventBeginCheckout) =
+    @"begin_checkout";
+
+/// Campaign Detail event. Log this event to supply the referral details of a re-engagement
+/// campaign. Note: you must supply at least one of the required parameters kFIRParameterSource,
+/// kFIRParameterMedium or kFIRParameterCampaign. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterSource (NSString)</li>
+///     <li>@c kFIRParameterMedium (NSString)</li>
+///     <li>@c kFIRParameterCampaign (NSString)</li>
+///     <li>@c kFIRParameterTerm (NSString) (optional)</li>
+///     <li>@c kFIRParameterContent (NSString) (optional)</li>
+///     <li>@c kFIRParameterAdNetworkClickID (NSString) (optional)</li>
+///     <li>@c kFIRParameterCP1 (NSString) (optional)</li>
+/// </ul>
+static NSString *const kFIREventCampaignDetails NS_SWIFT_NAME(AnalyticsEventCampaignDetails) =
+    @"campaign_details";
+
+/// Checkout progress. Params:
+///
+/// <ul>
+///    <li>@c kFIRParameterCheckoutStep (unsigned 64-bit integer as NSNumber)</li>
+///    <li>@c kFIRParameterCheckoutOption (NSString) (optional)</li>
+/// </ul>
+/// <b>This constant has been deprecated.</b>
+static NSString *const kFIREventCheckoutProgress NS_SWIFT_NAME(AnalyticsEventCheckoutProgress) =
+    @"checkout_progress";
+
+/// Earn Virtual Currency event. This event tracks the awarding of virtual currency in your app. Log
+/// this along with @c kFIREventSpendVirtualCurrency to better understand your virtual economy.
+/// Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterVirtualCurrencyName (NSString)</li>
+///     <li>@c kFIRParameterValue (signed 64-bit integer or double as NSNumber)</li>
+/// </ul>
+static NSString *const kFIREventEarnVirtualCurrency
+    NS_SWIFT_NAME(AnalyticsEventEarnVirtualCurrency) = @"earn_virtual_currency";
+
+/// E-Commerce Purchase event. This event signifies that an item was purchased by a user. Note:
+/// This is different from the in-app purchase event, which is reported automatically for App
+/// Store-based apps. Note: If you supply the @c kFIRParameterValue parameter, you must also
+/// supply the @c kFIRParameterCurrency parameter so that revenue metrics can be computed
+/// accurately. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterCurrency (NSString) (optional)</li>
+///     <li>@c kFIRParameterValue (double as NSNumber) (optional)</li>
+///     <li>@c kFIRParameterTransactionID (NSString) (optional)</li>
+///     <li>@c kFIRParameterTax (double as NSNumber) (optional)</li>
+///     <li>@c kFIRParameterShipping (double as NSNumber) (optional)</li>
+///     <li>@c kFIRParameterCoupon (NSString) (optional)</li>
+///     <li>@c kFIRParameterLocation (NSString) (optional)</li>
+///     <li>@c kFIRParameterStartDate (NSString) (optional)</li>
+///     <li>@c kFIRParameterEndDate (NSString) (optional)</li>
+///     <li>@c kFIRParameterNumberOfNights (signed 64-bit integer as NSNumber) (optional) for
+///         hotel bookings</li>
+///     <li>@c kFIRParameterNumberOfRooms (signed 64-bit integer as NSNumber) (optional) for
+///         hotel bookings</li>
+///     <li>@c kFIRParameterNumberOfPassengers (signed 64-bit integer as NSNumber) (optional)
+///         for travel bookings</li>
+///     <li>@c kFIRParameterOrigin (NSString) (optional)</li>
+///     <li>@c kFIRParameterDestination (NSString) (optional)</li>
+///     <li>@c kFIRParameterTravelClass (NSString) (optional) for travel bookings</li>
+/// </ul>
+/// <b>This constant has been deprecated. Use @c kFIREventPurchase constant instead.</b>
+static NSString *const kFIREventEcommercePurchase NS_SWIFT_NAME(AnalyticsEventEcommercePurchase) =
+    @"ecommerce_purchase";
+
+/// Generate Lead event. Log this event when a lead has been generated in the app to understand the
+/// efficacy of your install and re-engagement campaigns. Note: If you supply the
+/// @c kFIRParameterValue parameter, you must also supply the @c kFIRParameterCurrency
+/// parameter so that revenue metrics can be computed accurately. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterCurrency (NSString) (optional)</li>
+///     <li>@c kFIRParameterValue (double as NSNumber) (optional)</li>
+/// </ul>
+static NSString *const kFIREventGenerateLead NS_SWIFT_NAME(AnalyticsEventGenerateLead) =
+    @"generate_lead";
+
+/// Join Group event. Log this event when a user joins a group such as a guild, team or family. Use
+/// this event to analyze how popular certain groups or social features are in your app. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterGroupID (NSString)</li>
+/// </ul>
+static NSString *const kFIREventJoinGroup NS_SWIFT_NAME(AnalyticsEventJoinGroup) = @"join_group";
+
+/// Level End event. Log this event when the user finishes a level. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterLevelName (NSString)</li>
+///     <li>@c kFIRParameterSuccess (NSString)</li>
+/// </ul>
+static NSString *const kFIREventLevelEnd NS_SWIFT_NAME(AnalyticsEventLevelEnd) = @"level_end";
+
+/// Level Start event. Log this event when the user starts a new level. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterLevelName (NSString)</li>
+/// </ul>
+static NSString *const kFIREventLevelStart NS_SWIFT_NAME(AnalyticsEventLevelStart) = @"level_start";
+
+/// Level Up event. This event signifies that a player has leveled up in your gaming app. It can
+/// help you gauge the level distribution of your userbase and help you identify certain levels that
+/// are difficult to pass. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterLevel (signed 64-bit integer as NSNumber)</li>
+///     <li>@c kFIRParameterCharacter (NSString) (optional)</li>
+/// </ul>
+static NSString *const kFIREventLevelUp NS_SWIFT_NAME(AnalyticsEventLevelUp) = @"level_up";
+
+/// Login event. Apps with a login feature can report this event to signify that a user has logged
+/// in.
+static NSString *const kFIREventLogin NS_SWIFT_NAME(AnalyticsEventLogin) = @"login";
+
+/// Post Score event. Log this event when the user posts a score in your gaming app. This event can
+/// help you understand how users are actually performing in your game and it can help you correlate
+/// high scores with certain audiences or behaviors. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterScore (signed 64-bit integer as NSNumber)</li>
+///     <li>@c kFIRParameterLevel (signed 64-bit integer as NSNumber) (optional)</li>
+///     <li>@c kFIRParameterCharacter (NSString) (optional)</li>
+/// </ul>
+static NSString *const kFIREventPostScore NS_SWIFT_NAME(AnalyticsEventPostScore) = @"post_score";
+
+/// Present Offer event. This event signifies that the app has presented a purchase offer to a user.
+/// Add this event to a funnel with the kFIREventAddToCart and kFIREventEcommercePurchase to gauge
+/// your conversion process. Note: If you supply the @c kFIRParameterValue parameter, you must
+/// also supply the @c kFIRParameterCurrency parameter so that revenue metrics can be computed
+/// accurately. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterQuantity (signed 64-bit integer as NSNumber)</li>
+///     <li>@c kFIRParameterItemID (NSString)</li>
+///     <li>@c kFIRParameterItemName (NSString)</li>
+///     <li>@c kFIRParameterItemCategory (NSString)</li>
+///     <li>@c kFIRParameterItemLocationID (NSString) (optional)</li>
+///     <li>@c kFIRParameterPrice (double as NSNumber) (optional)</li>
+///     <li>@c kFIRParameterCurrency (NSString) (optional)</li>
+///     <li>@c kFIRParameterValue (double as NSNumber) (optional)</li>
+/// </ul>
+/// <b>This constant has been deprecated. Use @c kFIREventViewPromotion constant instead.</b>
+static NSString *const kFIREventPresentOffer NS_SWIFT_NAME(AnalyticsEventPresentOffer) =
+    @"present_offer";
+
+/// E-Commerce Purchase Refund event. This event signifies that an item purchase was refunded.
+/// Note: If you supply the @c kFIRParameterValue parameter, you must also supply the
+/// @c kFIRParameterCurrency parameter so that revenue metrics can be computed accurately.
+/// Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterCurrency (NSString) (optional)</li>
+///     <li>@c kFIRParameterValue (double as NSNumber) (optional)</li>
+///     <li>@c kFIRParameterTransactionID (NSString) (optional)</li>
+/// </ul>
+/// <b>This constant has been deprecated. Use @c kFIREventRefund constant instead.</b>
+static NSString *const kFIREventPurchaseRefund NS_SWIFT_NAME(AnalyticsEventPurchaseRefund) =
+    @"purchase_refund";
+
+/// E-Commerce Remove from Cart event. This event signifies that an item(s) was removed from a cart.
+/// Note: If you supply the @c kFIRParameterValue parameter, you must also supply the @c
+/// kFIRParameterCurrency parameter so that revenue metrics can be computed accurately. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterCurrency (NSString) (optional)</li>
+///     <li>@c kFIRParameterItems (NSArray) (optional)</li>
+///     <li>@c kFIRParameterValue (double as NSNumber) (optional)</li>
+/// </ul>
+static NSString *const kFIREventRemoveFromCart NS_SWIFT_NAME(AnalyticsEventRemoveFromCart) =
+    @"remove_from_cart";
+
+/// Screen View event. This event signifies a screen view. Use this when a screen transition occurs.
+/// This event can be logged irrespective of whether automatic screen tracking is enabled. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterScreenClass (NSString) (optional)</li>
+///     <li>@c kFIRParameterScreenName (NSString) (optional)</li>
+/// </ul>
+static NSString *const kFIREventScreenView NS_SWIFT_NAME(AnalyticsEventScreenView) = @"screen_view";
+
+/// Search event. Apps that support search features can use this event to contextualize search
+/// operations by supplying the appropriate, corresponding parameters. This event can help you
+/// identify the most popular content in your app. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterSearchTerm (NSString)</li>
+///     <li>@c kFIRParameterStartDate (NSString) (optional)</li>
+///     <li>@c kFIRParameterEndDate (NSString) (optional)</li>
+///     <li>@c kFIRParameterNumberOfNights (signed 64-bit integer as NSNumber) (optional) for
+///         hotel bookings</li>
+///     <li>@c kFIRParameterNumberOfRooms (signed 64-bit integer as NSNumber) (optional) for
+///         hotel bookings</li>
+///     <li>@c kFIRParameterNumberOfPassengers (signed 64-bit integer as NSNumber) (optional)
+///         for travel bookings</li>
+///     <li>@c kFIRParameterOrigin (NSString) (optional)</li>
+///     <li>@c kFIRParameterDestination (NSString) (optional)</li>
+///     <li>@c kFIRParameterTravelClass (NSString) (optional) for travel bookings</li>
+/// </ul>
+static NSString *const kFIREventSearch NS_SWIFT_NAME(AnalyticsEventSearch) = @"search";
+
+/// Select Content event. This general purpose event signifies that a user has selected some content
+/// of a certain type in an app. The content can be any object in your app. This event can help you
+/// identify popular content and categories of content in your app. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterContentType (NSString)</li>
+///     <li>@c kFIRParameterItemID (NSString)</li>
+/// </ul>
+static NSString *const kFIREventSelectContent NS_SWIFT_NAME(AnalyticsEventSelectContent) =
+    @"select_content";
+
+/// Set checkout option. Params:
+///
+/// <ul>
+///    <li>@c kFIRParameterCheckoutStep (unsigned 64-bit integer as NSNumber)</li>
+///    <li>@c kFIRParameterCheckoutOption (NSString)</li>
+/// </ul>
+/// <b>This constant has been deprecated.</b>
+static NSString *const kFIREventSetCheckoutOption NS_SWIFT_NAME(AnalyticsEventSetCheckoutOption) =
+    @"set_checkout_option";
+
+/// Share event. Apps with social features can log the Share event to identify the most viral
+/// content. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterContentType (NSString)</li>
+///     <li>@c kFIRParameterItemID (NSString)</li>
+/// </ul>
+static NSString *const kFIREventShare NS_SWIFT_NAME(AnalyticsEventShare) = @"share";
+
+/// Sign Up event. This event indicates that a user has signed up for an account in your app. The
+/// parameter signifies the method by which the user signed up. Use this event to understand the
+/// different behaviors between logged in and logged out users. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterSignUpMethod (NSString)</li>
+/// </ul>
+static NSString *const kFIREventSignUp NS_SWIFT_NAME(AnalyticsEventSignUp) = @"sign_up";
+
+/// Spend Virtual Currency event. This event tracks the sale of virtual goods in your app and can
+/// help you identify which virtual goods are the most popular objects of purchase. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterItemName (NSString)</li>
+///     <li>@c kFIRParameterVirtualCurrencyName (NSString)</li>
+///     <li>@c kFIRParameterValue (signed 64-bit integer or double as NSNumber)</li>
+/// </ul>
+static NSString *const kFIREventSpendVirtualCurrency
+    NS_SWIFT_NAME(AnalyticsEventSpendVirtualCurrency) = @"spend_virtual_currency";
+
+/// Tutorial Begin event. This event signifies the start of the on-boarding process in your app. Use
+/// this in a funnel with kFIREventTutorialComplete to understand how many users complete this
+/// process and move on to the full app experience.
+static NSString *const kFIREventTutorialBegin NS_SWIFT_NAME(AnalyticsEventTutorialBegin) =
+    @"tutorial_begin";
+
+/// Tutorial End event. Use this event to signify the user's completion of your app's on-boarding
+/// process. Add this to a funnel with kFIREventTutorialBegin to gauge the completion rate of your
+/// on-boarding process.
+static NSString *const kFIREventTutorialComplete NS_SWIFT_NAME(AnalyticsEventTutorialComplete) =
+    @"tutorial_complete";
+
+/// Unlock Achievement event. Log this event when the user has unlocked an achievement in your
+/// game. Since achievements generally represent the breadth of a gaming experience, this event can
+/// help you understand how many users are experiencing all that your game has to offer. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterAchievementID (NSString)</li>
+/// </ul>
+static NSString *const kFIREventUnlockAchievement NS_SWIFT_NAME(AnalyticsEventUnlockAchievement) =
+    @"unlock_achievement";
+
+/// View Item event. This event signifies that a user has viewed an item. Use the appropriate
+/// parameters to contextualize the event. Use this event to discover the most popular items viewed
+/// in your app. Note: If you supply the @c kFIRParameterValue parameter, you must also supply the
+/// @c kFIRParameterCurrency parameter so that revenue metrics can be computed accurately. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterCurrency (NSString) (optional)</li>
+///     <li>@c kFIRParameterItems (NSArray) (optional)</li>
+///     <li>@c kFIRParameterValue (double as NSNumber) (optional)</li>
+/// </ul>
+static NSString *const kFIREventViewItem NS_SWIFT_NAME(AnalyticsEventViewItem) = @"view_item";
+
+/// View Item List event. Log this event when a user sees a list of items or offerings. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterItems (NSArray) (optional)</li>
+///     <li>@c kFIRParameterItemListID (NSString) (optional)</li>
+///     <li>@c kFIRParameterItemListName (NSString) (optional)</li>
+/// </ul>
+static NSString *const kFIREventViewItemList NS_SWIFT_NAME(AnalyticsEventViewItemList) =
+    @"view_item_list";
+
+/// View Search Results event. Log this event when the user has been presented with the results of a
+/// search. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterSearchTerm (NSString)</li>
+/// </ul>
+static NSString *const kFIREventViewSearchResults NS_SWIFT_NAME(AnalyticsEventViewSearchResults) =
+    @"view_search_results";
+
+/// Add Shipping Info event. This event signifies that a user has submitted their shipping
+/// information. Note: If you supply the @c kFIRParameterValue parameter, you must also supply the
+/// @c kFIRParameterCurrency parameter so that revenue metrics can be computed accurately. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterCoupon (NSString) (optional)</li>
+///     <li>@c kFIRParameterCurrency (NSString) (optional)</li>
+///     <li>@c kFIRParameterItems (NSArray) (optional)</li>
+///     <li>@c kFIRParameterShippingTier (NSString) (optional)</li>
+///     <li>@c kFIRParameterValue (double as NSNumber) (optional)</li>
+/// </ul>
+static NSString *const kFIREventAddShippingInfo NS_SWIFT_NAME(AnalyticsEventAddShippingInfo) =
+    @"add_shipping_info";
+
+/// E-Commerce Purchase event. This event signifies that an item(s) was purchased by a user. Note:
+/// This is different from the in-app purchase event, which is reported automatically for App
+/// Store-based apps. Note: If you supply the @c kFIRParameterValue parameter, you must also supply
+/// the @c kFIRParameterCurrency parameter so that revenue metrics can be computed accurately.
+/// Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterAffiliation (NSString) (optional)</li>
+///     <li>@c kFIRParameterCoupon (NSString) (optional)</li>
+///     <li>@c kFIRParameterCurrency (NSString) (optional)</li>
+///     <li>@c kFIRParameterItems (NSArray) (optional)</li>
+///     <li>@c kFIRParameterShipping (double as NSNumber) (optional)</li>
+///     <li>@c kFIRParameterTax (double as NSNumber) (optional)</li>
+///     <li>@c kFIRParameterTransactionID (NSString) (optional)</li>
+///     <li>@c kFIRParameterValue (double as NSNumber) (optional)</li>
+/// </ul>
+static NSString *const kFIREventPurchase NS_SWIFT_NAME(AnalyticsEventPurchase) = @"purchase";
+
+/// E-Commerce Refund event. This event signifies that a refund was issued. Note: If you supply the
+/// @c kFIRParameterValue parameter, you must also supply the @c kFIRParameterCurrency parameter so
+/// that revenue metrics can be computed accurately. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterAffiliation (NSString) (optional)</li>
+///     <li>@c kFIRParameterCoupon (NSString) (optional)</li>
+///     <li>@c kFIRParameterCurrency (NSString) (optional)</li>
+///     <li>@c kFIRParameterItems (NSArray) (optional)</li>
+///     <li>@c kFIRParameterShipping (double as NSNumber) (optional)</li>
+///     <li>@c kFIRParameterTax (double as NSNumber) (optional)</li>
+///     <li>@c kFIRParameterTransactionID (NSString) (optional)</li>
+///     <li>@c kFIRParameterValue (double as NSNumber) (optional)</li>
+/// </ul>
+static NSString *const kFIREventRefund NS_SWIFT_NAME(AnalyticsEventRefund) = @"refund";
+
+/// Select Item event. This event signifies that an item was selected by a user from a list. Use the
+/// appropriate parameters to contextualize the event. Use this event to discover the most popular
+/// items selected. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterItems (NSArray) (optional)</li>
+///     <li>@c kFIRParameterItemListID (NSString) (optional)</li>
+///     <li>@c kFIRParameterItemListName (NSString) (optional)</li>
+/// </ul>
+static NSString *const kFIREventSelectItem NS_SWIFT_NAME(AnalyticsEventSelectItem) = @"select_item";
+
+/// Select promotion event. This event signifies that a user has selected a promotion offer. Use the
+/// appropriate parameters to contextualize the event, such as the item(s) for which the promotion
+/// applies. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterCreativeName (NSString) (optional)</li>
+///     <li>@c kFIRParameterCreativeSlot (NSString) (optional)</li>
+///     <li>@c kFIRParameterItems (NSArray) (optional)</li>
+///     <li>@c kFIRParameterLocationID (NSString) (optional)</li>
+///     <li>@c kFIRParameterPromotionID (NSString) (optional)</li>
+///     <li>@c kFIRParameterPromotionName (NSString) (optional)</li>
+/// </ul>
+static NSString *const kFIREventSelectPromotion NS_SWIFT_NAME(AnalyticsEventSelectPromotion) =
+    @"select_promotion";
+
+/// E-commerce View Cart event. This event signifies that a user has viewed their cart. Use this to
+/// analyze your purchase funnel. Note: If you supply the @c kFIRParameterValue parameter, you must
+/// also supply the @c kFIRParameterCurrency parameter so that revenue metrics can be computed
+/// accurately. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterCurrency (NSString) (optional)</li>
+///     <li>@c kFIRParameterItems (NSArray) (optional)</li>
+///     <li>@c kFIRParameterValue (double as NSNumber) (optional)</li>
+/// </ul>
+static NSString *const kFIREventViewCart NS_SWIFT_NAME(AnalyticsEventViewCart) = @"view_cart";
+
+/// View Promotion event. This event signifies that a promotion was shown to a user. Add this event
+/// to a funnel with the @c kFIREventAddToCart and @c kFIREventPurchase to gauge your conversion
+/// process. Params:
+///
+/// <ul>
+///     <li>@c kFIRParameterCreativeName (NSString) (optional)</li>
+///     <li>@c kFIRParameterCreativeSlot (NSString) (optional)</li>
+///     <li>@c kFIRParameterItems (NSArray) (optional)</li>
+///     <li>@c kFIRParameterLocationID (NSString) (optional)</li>
+///     <li>@c kFIRParameterPromotionID (NSString) (optional)</li>
+///     <li>@c kFIRParameterPromotionName (NSString) (optional)</li>
+/// </ul>
+static NSString *const kFIREventViewPromotion NS_SWIFT_NAME(AnalyticsEventViewPromotion) =
+    @"view_promotion";

--- a/FirebaseAnalyticsWrapper/Public/FirebaseAnalytics/FIRParameterNames.h
+++ b/FirebaseAnalyticsWrapper/Public/FirebaseAnalytics/FIRParameterNames.h
@@ -1,0 +1,690 @@
+/// @file FIRParameterNames.h
+///
+/// Predefined event parameter names.
+///
+/// Params supply information that contextualize Events. You can associate up to 25 unique Params
+/// with each Event type. Some Params are suggested below for certain common Events, but you are
+/// not limited to these. You may supply extra Params for suggested Events or custom Params for
+/// Custom events. Param names can be up to 40 characters long, may only contain alphanumeric
+/// characters and underscores ("_"), and must start with an alphabetic character. Param values can
+/// be up to 100 characters long. The "firebase_", "google_", and "ga_" prefixes are reserved and
+/// should not be used.
+
+#import <Foundation/Foundation.h>
+
+/// Game achievement ID (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterAchievementID : @"10_matches_won",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterAchievementID NS_SWIFT_NAME(AnalyticsParameterAchievementID) =
+    @"achievement_id";
+
+/// Ad Network Click ID (NSString). Used for network-specific click IDs which vary in format.
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterAdNetworkClickID : @"1234567",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterAdNetworkClickID
+    NS_SWIFT_NAME(AnalyticsParameterAdNetworkClickID) = @"aclid";
+
+/// A product affiliation to designate a supplying company or brick and mortar store location
+/// (NSString). <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterAffiliation : @"Google Store",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterAffiliation NS_SWIFT_NAME(AnalyticsParameterAffiliation) =
+    @"affiliation";
+
+/// The individual campaign name, slogan, promo code, etc. Some networks have pre-defined macro to
+/// capture campaign information, otherwise can be populated by developer. Highly Recommended
+/// (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterCampaign : @"winter_promotion",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterCampaign NS_SWIFT_NAME(AnalyticsParameterCampaign) =
+    @"campaign";
+
+/// Character used in game (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterCharacter : @"beat_boss",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterCharacter NS_SWIFT_NAME(AnalyticsParameterCharacter) =
+    @"character";
+
+/// The checkout step (1..N) (unsigned 64-bit integer as NSNumber).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterCheckoutStep : @"1",
+///       // ...
+///     };
+/// </pre>
+/// <b>This constant has been deprecated.</b>
+static NSString *const kFIRParameterCheckoutStep NS_SWIFT_NAME(AnalyticsParameterCheckoutStep) =
+    @"checkout_step";
+
+/// Some option on a step in an ecommerce flow (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterCheckoutOption : @"Visa",
+///       // ...
+///     };
+/// </pre>
+/// <b>This constant has been deprecated.</b>
+static NSString *const kFIRParameterCheckoutOption
+    NS_SWIFT_NAME(AnalyticsParameterCheckoutOption) = @"checkout_option";
+
+/// Campaign content (NSString).
+static NSString *const kFIRParameterContent NS_SWIFT_NAME(AnalyticsParameterContent) = @"content";
+
+/// Type of content selected (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterContentType : @"news article",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterContentType NS_SWIFT_NAME(AnalyticsParameterContentType) =
+    @"content_type";
+
+/// Coupon code used for a purchase (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterCoupon : @"SUMMER_FUN",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterCoupon NS_SWIFT_NAME(AnalyticsParameterCoupon) = @"coupon";
+
+/// Campaign custom parameter (NSString). Used as a method of capturing custom data in a campaign.
+/// Use varies by network.
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterCP1 : @"custom_data",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterCP1 NS_SWIFT_NAME(AnalyticsParameterCP1) = @"cp1";
+
+/// The name of a creative used in a promotional spot (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterCreativeName : @"Summer Sale",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterCreativeName NS_SWIFT_NAME(AnalyticsParameterCreativeName) =
+    @"creative_name";
+
+/// The name of a creative slot (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterCreativeSlot : @"summer_banner2",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterCreativeSlot NS_SWIFT_NAME(AnalyticsParameterCreativeSlot) =
+    @"creative_slot";
+
+/// Currency of the purchase or items associated with the event, in 3-letter
+/// <a href="http://en.wikipedia.org/wiki/ISO_4217#Active_codes"> ISO_4217</a> format (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterCurrency : @"USD",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterCurrency NS_SWIFT_NAME(AnalyticsParameterCurrency) =
+    @"currency";
+
+/// Flight or Travel destination (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterDestination : @"Mountain View, CA",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterDestination NS_SWIFT_NAME(AnalyticsParameterDestination) =
+    @"destination";
+
+/// The arrival date, check-out date or rental end date for the item. This should be in
+/// YYYY-MM-DD format (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterEndDate : @"2015-09-14",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterEndDate NS_SWIFT_NAME(AnalyticsParameterEndDate) = @"end_date";
+
+/// Flight number for travel events (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterFlightNumber : @"ZZ800",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterFlightNumber NS_SWIFT_NAME(AnalyticsParameterFlightNumber) =
+    @"flight_number";
+
+/// Group/clan/guild ID (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterGroupID : @"g1",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterGroupID NS_SWIFT_NAME(AnalyticsParameterGroupID) = @"group_id";
+
+/// The index of the item in a list (signed 64-bit integer as NSNumber).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterIndex : @(5),
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterIndex NS_SWIFT_NAME(AnalyticsParameterIndex) = @"index";
+
+/// Item brand (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterItemBrand : @"Google",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterItemBrand NS_SWIFT_NAME(AnalyticsParameterItemBrand) =
+    @"item_brand";
+
+/// Item category (context-specific) (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterItemCategory : @"pants",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterItemCategory NS_SWIFT_NAME(AnalyticsParameterItemCategory) =
+    @"item_category";
+
+/// Item ID (context-specific) (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterItemID : @"SKU_12345",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterItemID NS_SWIFT_NAME(AnalyticsParameterItemID) = @"item_id";
+
+/// The Google <a href="https://developers.google.com/places/place-id">Place ID</a> (NSString) that
+/// corresponds to the associated item. Alternatively, you can supply your own custom Location ID.
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterItemLocationID : @"ChIJiyj437sx3YAR9kUWC8QkLzQ",
+///       // ...
+///     };
+/// </pre>
+/// <b>This constant has been deprecated. Use @c kFIRParameterLocationID constant instead.</b>
+static NSString *const kFIRParameterItemLocationID
+    NS_SWIFT_NAME(AnalyticsParameterItemLocationID) = @"item_location_id";
+
+/// Item Name (context-specific) (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterItemName : @"jeggings",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterItemName NS_SWIFT_NAME(AnalyticsParameterItemName) =
+    @"item_name";
+
+/// The list in which the item was presented to the user (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterItemList : @"Search Results",
+///       // ...
+///     };
+/// </pre>
+/// <b>This constant has been deprecated. Use @c kFIRParameterItemListName constant instead.</b>
+static NSString *const kFIRParameterItemList NS_SWIFT_NAME(AnalyticsParameterItemList) =
+    @"item_list";
+
+/// Item variant (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterItemVariant : @"Black",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterItemVariant NS_SWIFT_NAME(AnalyticsParameterItemVariant) =
+    @"item_variant";
+
+/// Level in game (signed 64-bit integer as NSNumber).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterLevel : @(42),
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterLevel NS_SWIFT_NAME(AnalyticsParameterLevel) = @"level";
+
+/// Location (NSString). The Google <a href="https://developers.google.com/places/place-id">Place ID
+/// </a> that corresponds to the associated event. Alternatively, you can supply your own custom
+/// Location ID.
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterLocation : @"ChIJiyj437sx3YAR9kUWC8QkLzQ",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterLocation NS_SWIFT_NAME(AnalyticsParameterLocation) =
+    @"location";
+
+/// The advertising or marketing medium, for example: cpc, banner, email, push. Highly recommended
+/// (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterMedium : @"email",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterMedium NS_SWIFT_NAME(AnalyticsParameterMedium) = @"medium";
+
+/// Number of nights staying at hotel (signed 64-bit integer as NSNumber).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterNumberOfNights : @(3),
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterNumberOfNights
+    NS_SWIFT_NAME(AnalyticsParameterNumberOfNights) = @"number_of_nights";
+
+/// Number of passengers traveling (signed 64-bit integer as NSNumber).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterNumberOfPassengers : @(11),
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterNumberOfPassengers
+    NS_SWIFT_NAME(AnalyticsParameterNumberOfPassengers) = @"number_of_passengers";
+
+/// Number of rooms for travel events (signed 64-bit integer as NSNumber).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterNumberOfRooms : @(2),
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterNumberOfRooms NS_SWIFT_NAME(AnalyticsParameterNumberOfRooms) =
+    @"number_of_rooms";
+
+/// Flight or Travel origin (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterOrigin : @"Mountain View, CA",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterOrigin NS_SWIFT_NAME(AnalyticsParameterOrigin) = @"origin";
+
+/// Purchase price (double as NSNumber).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterPrice : @(1.0),
+///       kFIRParameterCurrency : @"USD",  // e.g. $1.00 USD
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterPrice NS_SWIFT_NAME(AnalyticsParameterPrice) = @"price";
+
+/// Purchase quantity (signed 64-bit integer as NSNumber).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterQuantity : @(1),
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterQuantity NS_SWIFT_NAME(AnalyticsParameterQuantity) =
+    @"quantity";
+
+/// Score in game (signed 64-bit integer as NSNumber).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterScore : @(4200),
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterScore NS_SWIFT_NAME(AnalyticsParameterScore) = @"score";
+
+/// Current screen class, such as the class name of the UIViewController, logged with screen_view
+/// event and added to every event (NSString). <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterScreenClass : @"LoginViewController",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterScreenClass NS_SWIFT_NAME(AnalyticsParameterScreenClass) =
+    @"screen_class";
+
+/// Current screen name, such as the name of the UIViewController, logged with screen_view event and
+/// added to every event (NSString). <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterScreenName : @"LoginView",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterScreenName NS_SWIFT_NAME(AnalyticsParameterScreenName) =
+    @"screen_name";
+
+/// The search string/keywords used (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterSearchTerm : @"periodic table",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterSearchTerm NS_SWIFT_NAME(AnalyticsParameterSearchTerm) =
+    @"search_term";
+
+/// Shipping cost associated with a transaction (double as NSNumber).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterShipping : @(5.99),
+///       kFIRParameterCurrency : @"USD",  // e.g. $5.99 USD
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterShipping NS_SWIFT_NAME(AnalyticsParameterShipping) =
+    @"shipping";
+
+/// Sign up method (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterSignUpMethod : @"google",
+///       // ...
+///     };
+/// </pre>
+///
+/// <b>This constant has been deprecated. Use Method constant instead.</b>
+static NSString *const kFIRParameterSignUpMethod NS_SWIFT_NAME(AnalyticsParameterSignUpMethod) =
+    @"sign_up_method";
+
+/// A particular approach used in an operation; for example, "facebook" or "email" in the context
+/// of a sign_up or login event.  (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterMethod : @"google",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterMethod NS_SWIFT_NAME(AnalyticsParameterMethod) = @"method";
+
+/// The origin of your traffic, such as an Ad network (for example, google) or partner (urban
+/// airship). Identify the advertiser, site, publication, etc. that is sending traffic to your
+/// property. Highly recommended (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterSource : @"InMobi",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterSource NS_SWIFT_NAME(AnalyticsParameterSource) = @"source";
+
+/// The departure date, check-in date or rental start date for the item. This should be in
+/// YYYY-MM-DD format (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterStartDate : @"2015-09-14",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterStartDate NS_SWIFT_NAME(AnalyticsParameterStartDate) =
+    @"start_date";
+
+/// Tax cost associated with a transaction (double as NSNumber).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterTax : @(2.43),
+///       kFIRParameterCurrency : @"USD",  // e.g. $2.43 USD
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterTax NS_SWIFT_NAME(AnalyticsParameterTax) = @"tax";
+
+/// If you're manually tagging keyword campaigns, you should use utm_term to specify the keyword
+/// (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterTerm : @"game",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterTerm NS_SWIFT_NAME(AnalyticsParameterTerm) = @"term";
+
+/// The unique identifier of a transaction (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterTransactionID : @"T12345",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterTransactionID NS_SWIFT_NAME(AnalyticsParameterTransactionID) =
+    @"transaction_id";
+
+/// Travel class (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterTravelClass : @"business",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterTravelClass NS_SWIFT_NAME(AnalyticsParameterTravelClass) =
+    @"travel_class";
+
+/// A context-specific numeric value which is accumulated automatically for each event type. This is
+/// a general purpose parameter that is useful for accumulating a key metric that pertains to an
+/// event. Examples include revenue, distance, time and points. Value should be specified as signed
+/// 64-bit integer or double as NSNumber. Notes: Values for pre-defined currency-related events
+/// (such as @c kFIREventAddToCart) should be supplied using double as NSNumber and must be
+/// accompanied by a @c kFIRParameterCurrency parameter. The valid range of accumulated values is
+/// [-9,223,372,036,854.77, 9,223,372,036,854.77]. Supplying a non-numeric value, omitting the
+/// corresponding @c kFIRParameterCurrency parameter, or supplying an invalid
+/// <a href="https://goo.gl/qqX3J2">currency code</a> for conversion events will cause that
+/// conversion to be omitted from reporting.
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterValue : @(3.99),
+///       kFIRParameterCurrency : @"USD",  // e.g. $3.99 USD
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterValue NS_SWIFT_NAME(AnalyticsParameterValue) = @"value";
+
+/// Name of virtual currency type (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterVirtualCurrencyName : @"virtual_currency_name",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterVirtualCurrencyName
+    NS_SWIFT_NAME(AnalyticsParameterVirtualCurrencyName) = @"virtual_currency_name";
+
+/// The name of a level in a game (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterLevelName : @"room_1",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterLevelName NS_SWIFT_NAME(AnalyticsParameterLevelName) =
+    @"level_name";
+
+/// The result of an operation. Specify 1 to indicate success and 0 to indicate failure (unsigned
+/// integer as NSNumber).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterSuccess : @(1),
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterSuccess NS_SWIFT_NAME(AnalyticsParameterSuccess) = @"success";
+
+/// Indicates that the associated event should either extend the current session
+/// or start a new session if no session was active when the event was logged.
+/// Specify YES to extend the current session or to start a new session; any
+/// other value will not extend or start a session.
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterExtendSession : @YES,
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterExtendSession NS_SWIFT_NAME(AnalyticsParameterExtendSession) =
+    @"extend_session";
+
+/// Monetary value of discount associated with a purchase (double as NSNumber).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterDiscount : @(2.0),
+///       kFIRParameterCurrency : @"USD",  // e.g. $2.00 USD
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterDiscount NS_SWIFT_NAME(AnalyticsParameterDiscount) =
+    @"discount";
+
+/// Item Category (context-specific) (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterItemCategory2 : @"pants",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterItemCategory2 NS_SWIFT_NAME(AnalyticsParameterItemCategory2) =
+    @"item_category2";
+
+/// Item Category (context-specific) (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterItemCategory3 : @"pants",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterItemCategory3 NS_SWIFT_NAME(AnalyticsParameterItemCategory3) =
+    @"item_category3";
+
+/// Item Category (context-specific) (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterItemCategory4 : @"pants",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterItemCategory4 NS_SWIFT_NAME(AnalyticsParameterItemCategory4) =
+    @"item_category4";
+
+/// Item Category (context-specific) (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterItemCategory5 : @"pants",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterItemCategory5 NS_SWIFT_NAME(AnalyticsParameterItemCategory5) =
+    @"item_category5";
+
+/// The ID of the list in which the item was presented to the user (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterItemListID : @"ABC123",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterItemListID NS_SWIFT_NAME(AnalyticsParameterItemListID) =
+    @"item_list_id";
+
+/// The name of the list in which the item was presented to the user (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterItemListName : @"Related products",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterItemListName NS_SWIFT_NAME(AnalyticsParameterItemListName) =
+    @"item_list_name";
+
+/// The list of items involved in the transaction. (NSArray).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterItems : @[
+///         @{kFIRParameterItemName : @"jeggings", kFIRParameterItemCategory : @"pants"},
+///         @{kFIRParameterItemName : @"boots", kFIRParameterItemCategory : @"shoes"},
+///       ],
+///     };
+/// </pre>
+static NSString *const kFIRParameterItems NS_SWIFT_NAME(AnalyticsParameterItems) = @"items";
+
+/// The location associated with the event. Preferred to be the Google
+/// <a href="https://developers.google.com/places/place-id">Place ID</a> that corresponds to the
+/// associated item but could be overridden to a custom location ID string.(NSString). <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterLocationID : @"ChIJiyj437sx3YAR9kUWC8QkLzQ",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterLocationID NS_SWIFT_NAME(AnalyticsParameterLocationID) =
+    @"location_id";
+
+/// The chosen method of payment (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterPaymentType : @"Visa",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterPaymentType NS_SWIFT_NAME(AnalyticsParameterPaymentType) =
+    @"payment_type";
+
+/// The ID of a product promotion (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterPromotionID : @"ABC123",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterPromotionID NS_SWIFT_NAME(AnalyticsParameterPromotionID) =
+    @"promotion_id";
+
+/// The name of a product promotion (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterPromotionName : @"Summer Sale",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterPromotionName NS_SWIFT_NAME(AnalyticsParameterPromotionName) =
+    @"promotion_name";
+
+/// The shipping tier (e.g. Ground, Air, Next-day) selected for delivery of the purchased item
+/// (NSString).
+/// <pre>
+///     NSDictionary *params = @{
+///       kFIRParameterShippingTier : @"Ground",
+///       // ...
+///     };
+/// </pre>
+static NSString *const kFIRParameterShippingTier NS_SWIFT_NAME(AnalyticsParameterShippingTier) =
+    @"shipping_tier";

--- a/FirebaseAnalyticsWrapper/Public/FirebaseAnalytics/FIRUserPropertyNames.h
+++ b/FirebaseAnalyticsWrapper/Public/FirebaseAnalytics/FIRUserPropertyNames.h
@@ -1,0 +1,29 @@
+/// @file FIRUserPropertyNames.h
+///
+/// Predefined user property names.
+///
+/// A UserProperty is an attribute that describes the app-user. By supplying UserProperties, you can
+/// later analyze different behaviors of various segments of your userbase. You may supply up to 25
+/// unique UserProperties per app, and you can use the name and value of your choosing for each one.
+/// UserProperty names can be up to 24 characters long, may only contain alphanumeric characters and
+/// underscores ("_"), and must start with an alphabetic character. UserProperty values can be up to
+/// 36 characters long. The "firebase_", "google_", and "ga_" prefixes are reserved and should not
+/// be used.
+
+#import <Foundation/Foundation.h>
+
+/// The method used to sign in. For example, "google", "facebook" or "twitter".
+static NSString *const kFIRUserPropertySignUpMethod
+    NS_SWIFT_NAME(AnalyticsUserPropertySignUpMethod) = @"sign_up_method";
+
+/// Indicates whether events logged by Google Analytics can be used to personalize ads for the user.
+/// Set to "YES" to enable, or "NO" to disable. Default is enabled. See the
+/// <a href="https://firebase.google.com/support/guides/disable-analytics">documentation</a> for
+/// more details and information about related settings.
+///
+/// <pre>
+///     [FIRAnalytics setUserPropertyString:@"NO"
+///                                 forName:kFIRUserPropertyAllowAdPersonalizationSignals];
+/// </pre>
+static NSString *const kFIRUserPropertyAllowAdPersonalizationSignals
+    NS_SWIFT_NAME(AnalyticsUserPropertyAllowAdPersonalizationSignals) = @"allow_personalized_ads";

--- a/FirebaseAnalyticsWrapper/Public/FirebaseAnalytics/FirebaseAnalytics.h
+++ b/FirebaseAnalyticsWrapper/Public/FirebaseAnalytics/FirebaseAnalytics.h
@@ -1,0 +1,5 @@
+#import "FIRAnalytics+AppDelegate.h"
+#import "FIRAnalytics.h"
+#import "FIREventNames.h"
+#import "FIRParameterNames.h"
+#import "FIRUserPropertyNames.h"

--- a/Package.swift
+++ b/Package.swift
@@ -173,7 +173,13 @@ let package = Package(
         .product(name: "nanopb", package: "nanopb"),
       ],
       path: "FirebaseAnalyticsWrapper",
-      publicHeadersPath: "Public"
+      publicHeadersPath: "Public",
+      linkerSettings: [
+        .linkedLibrary("sqlite3"),
+        .linkedLibrary("c++"),
+        .linkedLibrary("z"),
+        .linkedFramework("StoreKit"),
+      ]
     ),
     .binaryTarget(
       name: "FirebaseAnalytics",

--- a/Package.swift
+++ b/Package.swift
@@ -174,6 +174,8 @@ let package = Package(
       ],
       path: "FirebaseAnalyticsWrapper",
       publicHeadersPath: "Public",
+      // linkerSettings doesn't seem to work. See
+      // https://forums.swift.org/t/swiftpm-binary-linker-questions/39100
       linkerSettings: [
         .linkedLibrary("sqlite3"),
         .linkedLibrary("c++"),

--- a/Package.swift
+++ b/Package.swift
@@ -164,6 +164,11 @@ let package = Package(
         "FirebaseAnalytics",
         "FIRAnalyticsConnector",
         "GoogleAppMeasurement",
+        "FirebaseCore",
+        "GoogleUtilities_AppDelegateSwizzler",
+        "GoogleUtilities_MethodSwizzler",
+        "GoogleUtilities_NSData",
+        "GoogleUtilities_Network",
       ],
       path: "FirebaseAnalyticsWrapper",
       publicHeadersPath: "Public"

--- a/Package.swift
+++ b/Package.swift
@@ -165,6 +165,7 @@ let package = Package(
         "FIRAnalyticsConnector",
         "GoogleAppMeasurement",
         "FirebaseCore",
+        "FirebaseInstallations",
         "GoogleUtilities_AppDelegateSwizzler",
         "GoogleUtilities_MethodSwizzler",
         "GoogleUtilities_NSData",

--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,10 @@ let package = Package(
       targets: ["FirebaseCore"]
     ),
     .library(
+      name: "FirebaseAnalytics",
+      targets: ["FirebaseAnalyticsWrapper"]
+    ),
+    .library(
       name: "FirebaseAuth",
       targets: ["FirebaseAuth"]
     ),
@@ -153,6 +157,31 @@ let package = Package(
       cSettings: [
         .headerSearchPath("../../.."),
       ]
+    ),
+    .target(
+      name: "FirebaseAnalyticsWrapper",
+      dependencies: [
+        "FirebaseAnalytics",
+        "FIRAnalyticsConnector",
+        "GoogleAppMeasurement",
+      ],
+      path: "FirebaseAnalyticsWrapper",
+      publicHeadersPath: "Public"
+    ),
+    .binaryTarget(
+      name: "FirebaseAnalytics",
+      url: "https://dl.google.com/firebase/ios/swiftpm/6.30.0/FirebaseAnalytics.zip",
+      checksum: "47c403aeac1ad35dc6dccb3e57256d5ca65863970ebe3ea8407e4220c9f16ea7"
+    ),
+    .binaryTarget(
+      name: "FIRAnalyticsConnector",
+      url: "https://dl.google.com/firebase/ios/swiftpm/6.30.0/FIRAnalyticsConnector.zip",
+      checksum: "b809e8c352ea2e7788d4ee1c6e191de2666582ec616572ea2568420b2d524532"
+    ),
+    .binaryTarget(
+      name: "GoogleAppMeasurement",
+      url: "https://dl.google.com/firebase/ios/swiftpm/6.30.0/GoogleAppMeasurement.zip",
+      checksum: "1cbd0f708981e3bcb7b84399a635c469c9e994bf38266d3e4f1e0caae54eda72"
     ),
     .target(
       name: "FirebaseAuth",
@@ -475,6 +504,7 @@ let package = Package(
       dependencies: [
         "FirebaseAuth",
         "FirebaseABTesting",
+        "FirebaseAnalyticsWrapper",
         "FirebaseFunctions",
         "Firebase",
         "FirebaseCrashlytics",

--- a/Package.swift
+++ b/Package.swift
@@ -174,8 +174,6 @@ let package = Package(
       ],
       path: "FirebaseAnalyticsWrapper",
       publicHeadersPath: "Public",
-      // linkerSettings doesn't seem to work. See
-      // https://forums.swift.org/t/swiftpm-binary-linker-questions/39100
       linkerSettings: [
         .linkedLibrary("sqlite3"),
         .linkedLibrary("c++"),

--- a/Package.swift
+++ b/Package.swift
@@ -169,6 +169,7 @@ let package = Package(
         "GoogleUtilities_MethodSwizzler",
         "GoogleUtilities_NSData",
         "GoogleUtilities_Network",
+        .product(name: "nanopb", package: "nanopb"),
       ],
       path: "FirebaseAnalyticsWrapper",
       publicHeadersPath: "Public"

--- a/Package.swift
+++ b/Package.swift
@@ -517,7 +517,6 @@ let package = Package(
       dependencies: [
         "FirebaseAuth",
         "FirebaseABTesting",
-        "FirebaseAnalyticsWrapper",
         "FirebaseFunctions",
         "Firebase",
         "FirebaseCrashlytics",

--- a/scripts/check_copyright.sh
+++ b/scripts/check_copyright.sh
@@ -24,7 +24,8 @@ options=(
 list=$(git grep "${options[@]}" -- \
     '*.'{c,cc,cmake,h,js,m,mm,py,rb,sh,swift} \
     CMakeLists.txt '**/CMakeLists.txt' \
-    ':(exclude)**/third_party/**')
+    ':(exclude)**/third_party/**' \
+    ':(exclude)FirebaseAnalyticsWrapper/**')
 
 # Allow copyrights before 2020 without LLC.
 result=$(grep -L 'Copyright 20[0-1][0-9].*Google' $list)

--- a/scripts/style.sh
+++ b/scripts/style.sh
@@ -152,6 +152,9 @@ s%^./%%
 # Sources controlled outside this tree
 \%/third_party/% d
 
+# Public headers for closed sourced FirebaseAnalytics
+\%^(FirebaseAnalyticsWrapper)/% d
+
 # Generated source
 \%/Firestore/core/src/util/config.h% d
 


### PR DESCRIPTION
Initial implementation of Swift Package Manager and FirebaseAnalytics

- Successfully ran the SPM tests for iOS (we don't currently support CI for single platform targets)
- Ran the Analytics Objective C and Swift Quickstarts with the `-ObjC` workaround
- Clients must add `-ObjC` to `Other Linker Flags`
- Before Xcode12 beta 4, clients may need to manually add the system frameworks and libraries
- Details at https://forums.swift.org/t/swiftpm-binary-linker-questions/39100
- Added the Analytics public headers to make them available for SPM clients and disabled checks for them
- Disabled `swift build` CI since it is macOS only and is a pure subset of the `xcodebuild` testing

#no-changelog