### PR TITLE
FirebaseInstallations: use ephemeral NSURLSession to prevent caching of request/response

### DIFF
--- a/FirebaseInstallations/CHANGELOG.md
+++ b/FirebaseInstallations/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.5.1 -- Unreleased
+- [changed] Use ephemeral `NSURLSession` to prevent caching of request/response. (#6226)
+
 # v1.5.0 -- M75
 - [changed] Functionally neutral source reorganization. (#5832)
 

--- a/FirebaseInstallations/Source/Library/InstallationsAPI/FIRInstallationsAPIService.m
+++ b/FirebaseInstallations/Source/Library/InstallationsAPI/FIRInstallationsAPIService.m
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_END
 
 - (instancetype)initWithAPIKey:(NSString *)APIKey projectID:(NSString *)projectID {
   NSURLSession *URLSession = [NSURLSession
-      sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
+      sessionWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration]];
   return [self initWithURLSession:URLSession APIKey:APIKey projectID:projectID];
 }
 


### PR DESCRIPTION
Fixes b/158644295.