### PR TITLE
Revert "GULKeychainStorage: use dictionary instead of NSCache"

### DIFF
--- a/GoogleUtilities/CHANGELOG.md
+++ b/GoogleUtilities/CHANGELOG.md
@@ -1,6 +1,3 @@
-# 6.7.2
-- Use `NSMutableDictionary` for in-memory cache in `GULKeychainStorage`. (#6224)
-
 # 6.7.1
 - Fix import regression when mixing 6.7.0 with earlier Firebase versions. (#6047)
 

--- a/GoogleUtilities/Environment/SecureStorage/GULKeychainStorage.m
+++ b/GoogleUtilities/Environment/SecureStorage/GULKeychainStorage.m
@@ -30,16 +30,19 @@
 @property(nonatomic, readonly) dispatch_queue_t keychainQueue;
 @property(nonatomic, readonly) dispatch_queue_t inMemoryCacheQueue;
 @property(nonatomic, readonly) NSString *service;
-@property(nonatomic, readonly) NSMutableDictionary<NSString *, id<NSSecureCoding>> *inMemoryCache;
+@property(nonatomic, readonly) NSCache<NSString *, id<NSSecureCoding>> *inMemoryCache;
 @end
 
 @implementation GULKeychainStorage
 
 - (instancetype)initWithService:(NSString *)service {
-  return [self initWithService:service cache:[NSMutableDictionary dictionary]];
+  NSCache *cache = [[NSCache alloc] init];
+  // Cache up to 5 installations.
+  cache.countLimit = 5;
+  return [self initWithService:service cache:cache];
 }
 
-- (instancetype)initWithService:(NSString *)service cache:(NSMutableDictionary *)cache {
+- (instancetype)initWithService:(NSString *)service cache:(NSCache *)cache {
   self = [super init];
   if (self) {
     _keychainQueue =

--- a/GoogleUtilities/Tests/Unit/Environment/GULKeychainStorageTests.m
+++ b/GoogleUtilities/Tests/Unit/Environment/GULKeychainStorageTests.m
@@ -23,13 +23,13 @@
 #import "GoogleUtilities/Environment/Private/GULKeychainStorage.h"
 
 @interface GULKeychainStorage (Tests)
-- (instancetype)initWithService:(NSString *)service cache:(NSMutableDictionary *)cache;
+- (instancetype)initWithService:(NSString *)service cache:(NSCache *)cache;
 - (void)resetInMemoryCache;
 @end
 
 @interface GULKeychainStorageTests : XCTestCase
 @property(nonatomic, strong) GULKeychainStorage *storage;
-@property(nonatomic, strong) NSMutableDictionary *cache;
+@property(nonatomic, strong) NSCache *cache;
 @property(nonatomic, strong) id mockCache;
 
 #if TARGET_OS_OSX
@@ -41,7 +41,7 @@
 @implementation GULKeychainStorageTests
 
 - (void)setUp {
-  self.cache = [[NSMutableDictionary alloc] init];
+  self.cache = [[NSCache alloc] init];
   self.mockCache = OCMPartialMock(self.cache);
   self.storage = [[GULKeychainStorage alloc] initWithService:@"com.tests.GULKeychainStorageTests"
                                                        cache:self.mockCache];


### PR DESCRIPTION
Reverts firebase/firebase-ios-sdk#6224

The change was mistaken. `NSCache` is in-memory only and does never store data to disk, so can be safely used as a cache here.