### PR TITLE
FIS backoff adjustments and tests

### DIFF
--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsBackoffController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsBackoffController.m
@@ -17,6 +17,7 @@
 #import "FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsBackoffController.h"
 
 static const NSTimeInterval k24Hours = 24 * 60 * 60;
+static const NSTimeInterval k30Minutes = 30 * 60;
 
 /** The class represents `FIRInstallationsBackoffController` sate required to calculate next allowed
  request time. The properties of the class are intentionally immutable because changing them
@@ -67,8 +68,7 @@ static const NSTimeInterval k24Hours = 24 * 60 * 60;
 
 + (NSTimeInterval)recoverableErrorBackoffTimeForAttemptNumber:(NSInteger)attemptNumber {
   NSTimeInterval exponentialInterval = pow(2, attemptNumber) + [self randomMilliseconds];
-  // TODO(mmaksym): Double check the maximum interval value.
-  return MIN(exponentialInterval, k24Hours);
+  return MIN(exponentialInterval, k30Minutes);
 }
 
 + (NSTimeInterval)randomMilliseconds {

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -481,7 +481,11 @@ static NSString *const kKeychainService = @"com.firebase.FIRInstallations.instal
     FIRInstallationsHTTPError *HTTPResponseError = (FIRInstallationsHTTPError *)APIError;
     NSInteger statusCode = HTTPResponseError.HTTPResponse.statusCode;
 
-    if (statusCode == 400 || statusCode == 403) {  // Explicitly unrecoverable errors.
+    if (statusCode == FIRInstallationsAuthTokenHTTPCodeInvalidAuthentication ||
+        statusCode == FIRInstallationsAuthTokenHTTPCodeFIDNotFound) {
+      // These errors are explicitly excluded because they are handled by FIS SDK itself so don't
+      // require backoff.
+    } else if (statusCode == 400 || statusCode == 403) {  // Explicitly unrecoverable errors.
       [self.backoffController registerEvent:FIRInstallationsBackoffEventUnrecoverableFailure];
     } else if (statusCode == 429 ||
                (statusCode >= 500 && statusCode < 600)) {  // Explicitly recoverable errors.

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -495,8 +495,8 @@ static NSString *const kKeychainService = @"com.firebase.FIRInstallations.instal
     }
   }
 
-  // If the error class is not `FIRInstallationsHTTPError` class it indicates a connection error.
-  // Such errors should not change backoff interval.
+  // If the error class is not `FIRInstallationsHTTPError` it indicates a connection error. Such
+  // errors should not change backoff interval.
 }
 
 #pragma mark - Notifications

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsBackoffControllerTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsBackoffControllerTests.m
@@ -60,7 +60,7 @@
   XCTAssertTrue([self.backoffController isNextRequestAllowed]);
 
   for (NSInteger attempt = 1; attempt < 21; attempt++) {
-    NSTimeInterval expectedBackoffInterval = MIN(pow(2, attempt), 24 * 60 * 60 /*24h*/);
+    NSTimeInterval expectedBackoffInterval = MIN(pow(2, attempt), 30 * 60 /*30min*/);
 
     [self.backoffController registerEvent:FIRInstallationsBackoffEventRecoverableFailure];
     [self assertBackoffTimeInterval:expectedBackoffInterval];

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
@@ -906,10 +906,6 @@
   XCTAssertEqualObjects(promise.value, registeredInstallation);
 }
 
-- (void)testGetAuthToken_WhenResponse401_ThenCreateNewFID {
-  // TODO: Implement.
-}
-
 - (void)testGetAuthToken_WhenNextRequestIsNotAllowed {
   // 1.1. Expect installation to be requested from the store.
   FIRInstallationsItem *storedInstallation =


### PR DESCRIPTION
- 403 - unrecoverable
- 401 and 404 - no backoff as they are auto-recoverable by the SDK
- connection errors - no backoff
- 429, 5xx - maximum backoff interval 30 min
- tests 