### PR TITLE
Add SPM support for CoreDiagnostics

### DIFF
--- a/Example/CoreDiagnostics/Tests/FIRCoreDiagnosticsTest.m
+++ b/Example/CoreDiagnostics/Tests/FIRCoreDiagnosticsTest.m
@@ -29,7 +29,7 @@
 #import "Interop/CoreDiagnostics/Public/FIRCoreDiagnosticsData.h"
 #import "Interop/CoreDiagnostics/Public/FIRCoreDiagnosticsInterop.h"
 
-#import "FIRCDLibrary/Protogen/nanopb/firebasecore.nanopb.h"
+#import "Firebase/CoreDiagnostics/FIRCDLibrary/Protogen/nanopb/firebasecore.nanopb.h"
 
 extern NSString *const kFIRAppDiagnosticsNotification;
 extern NSString *const kFIRLastCheckinDateKey;

--- a/Firebase/CoreDiagnostics/FIRCDLibrary/FIRCoreDiagnostics.m
+++ b/Firebase/CoreDiagnostics/FIRCDLibrary/FIRCoreDiagnostics.m
@@ -30,7 +30,7 @@
 #import <nanopb/pb_decode.h>
 #import <nanopb/pb_encode.h>
 
-#import "FIRCDLibrary/Protogen/nanopb/firebasecore.nanopb.h"
+#import "Firebase/CoreDiagnostics/FIRCDLibrary/Protogen/nanopb/firebasecore.nanopb.h"
 
 /** The logger service string to use when printing to the console. */
 static GULLoggerService kFIRCoreDiagnostics = @"[FirebaseCoreDiagnostics/FIRCoreDiagnostics]";
@@ -41,7 +41,9 @@ static BOOL kUsingZipFile = YES;
 static BOOL kUsingZipFile = NO;
 #endif  // FIREBASE_BUILD_ZIP_FILE
 
-#ifdef FIREBASE_BUILD_CARTHAGE
+#if SWIFT_PACKAGE
+#define kDeploymentType logs_proto_mobilesdk_ios_ICoreConfiguration_DeploymentType_SPM
+#elif FIREBASE_BUILD_CARTHAGE
 #define kDeploymentType logs_proto_mobilesdk_ios_ICoreConfiguration_DeploymentType_CARTHAGE
 #elif FIREBASE_BUILD_ZIP_FILE
 #define kDeploymentType logs_proto_mobilesdk_ios_ICoreConfiguration_DeploymentType_ZIP_FILE

--- a/FirebaseCoreDiagnostics.podspec
+++ b/FirebaseCoreDiagnostics.podspec
@@ -28,8 +28,7 @@ non-Cocoapod integration. This library also respects the Firebase global data co
   s.prefix_header_file = false
 
   header_search_paths = {
-    'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}" ' +
-                             '"${PODS_TARGET_SRCROOT}/Firebase/CoreDiagnostics/"'
+    'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
   }
 
   s.pod_target_xcconfig = {

--- a/Package.swift
+++ b/Package.swift
@@ -120,7 +120,11 @@ let package = Package(
     ),
     .target(
       name: "FirebaseCore",
-      dependencies: ["GoogleUtilities_Environment", "GoogleUtilities_Logger"],
+      dependencies: [
+        "FirebaseCoreDiagnostics",
+        "GoogleUtilities_Environment",
+        "GoogleUtilities_Logger"
+      ],
       path: "FirebaseCore/Sources",
       publicHeadersPath: "Public",
       cSettings: [
@@ -137,6 +141,23 @@ let package = Package(
       exclude: ["Resources/GoogleService-Info.plist"],
       cSettings: [
         .headerSearchPath("../../.."),
+      ]
+    ),
+    .target(
+      name: "FirebaseCoreDiagnostics",
+      dependencies: [
+        "GoogleDataTransport",
+        "GoogleUtilities_Environment",
+        "GoogleUtilities_Logger",
+        .product(name: "nanopb", package: "nanopb"),
+      ],
+      path: "Firebase/CoreDiagnostics/FIRCDLibrary",
+      publicHeadersPath: ".",
+      cSettings: [
+        .headerSearchPath("../../.."),
+        .define("PB_FIELD_32BIT", to: "1"),
+        .define("PB_NO_PACKED_STRUCTS", to: "1"),
+        .define("PB_ENABLE_MALLOC", to: "1"),
       ]
     ),
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -123,7 +123,7 @@ let package = Package(
       dependencies: [
         "FirebaseCoreDiagnostics",
         "GoogleUtilities_Environment",
-        "GoogleUtilities_Logger"
+        "GoogleUtilities_Logger",
       ],
       path: "FirebaseCore/Sources",
       publicHeadersPath: "Public",


### PR DESCRIPTION
- Repo-relative headers
- SPM Diagnostics logging
- SPM build
- Skipping standard directory structure because of upcoming deprecation

Verified deploymentType running the Analytics quickstart:

![Screen Shot 2020-08-07 at 2 17 49 PM](https://user-images.githubusercontent.com/73870/89689274-e1acc600-d8b8-11ea-865f-acc55e7dcb26.png)
