### PR TITLE
Add Hashable conformance to wrappers

### DIFF
--- a/Firestore/Swift/Source/Codable/DocumentID+Hashable.swift
+++ b/Firestore/Swift/Source/Codable/DocumentID+Hashable.swift
@@ -1,0 +1,19 @@
+//
+//  DocumentID+Hashable.swift
+//  
+//
+//  Created by Lorenzo Fiamingo on 08/08/20.
+//
+
+import FirebaseFirestore
+
+extension DocumentID: Hashable where Value: Hashable {
+    
+    static func == (lhs: DocumentID, rhs: DocumentID) -> Bool {
+        lhs.wrappedValue == rhs.wrappedValue
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(wrappedValue)
+    }
+}

--- a/Firestore/Swift/Source/Codable/ExplicitNull+Hashable.swift
+++ b/Firestore/Swift/Source/Codable/ExplicitNull+Hashable.swift
@@ -1,0 +1,19 @@
+//
+//  ExplicitNull+Hashable.swift
+//  
+//
+//  Created by Lorenzo Fiamingo on 08/08/20.
+//
+
+import FirebaseFirestore
+
+extension ExplicitNull: Hashable where Value: Hashable {
+    
+    static func == (lhs: ExplicitNull, rhs: ExplicitNull) -> Bool {
+        lhs.wrappedValue == rhs.wrappedValue
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(wrappedValue)
+    }
+}

--- a/Firestore/Swift/Source/Codable/ServerTimestamp+Hashable.swift
+++ b/Firestore/Swift/Source/Codable/ServerTimestamp+Hashable.swift
@@ -1,0 +1,19 @@
+//
+//  ServerTimestamp+Hashable.swift
+//  
+//
+//  Created by Lorenzo Fiamingo on 08/08/20.
+//
+
+import FirebaseFirestore
+
+extension ServerTimestamp: Hashable where Value: Hashable {
+    
+    static func == (lhs: ServerTimestamp, rhs: ServerTimestamp) -> Bool {
+        lhs.wrappedValue == rhs.wrappedValue
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(wrappedValue)
+    }
+}


### PR DESCRIPTION
Hello,
I think would be great to add the Hashable conformance to property wrappers when their wrapped value is Hashable, just like Apple does for arrays, optionals, and ranges
In this way, a struct using these wrappers can easily inherit the Hashable conformance by default.
This is really useful in SwiftUI when you pull from Firestore a collection as an array of these Codable structs and use them in a ForEach view.

Fix #6237