### PR TITLE
GDTCORClock: use NSTimeZone to get a timezone with respect of daylight

### DIFF
--- a/GoogleDataTransport/CHANGELOG.md
+++ b/GoogleDataTransport/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v7.1.1
+- Use `NSTimeZone` instead of `CFTimeZone` to get time zone offset respecting daylight. (#6246)
+
 # v7.1.0
 - Device uptime calculation fixes. (#6102)
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORClock.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORClock.m
@@ -84,9 +84,7 @@ static int64_t UptimeInNanoseconds() {
     _uptimeNanoseconds = UptimeInNanoseconds();
     _timeMillis =
         (int64_t)((CFAbsoluteTimeGetCurrent() + kCFAbsoluteTimeIntervalSince1970) * NSEC_PER_USEC);
-    CFTimeZoneRef timeZoneRef = CFTimeZoneCopySystem();
-    _timezoneOffsetSeconds = CFTimeZoneGetSecondsFromGMT(timeZoneRef, 0);
-    CFRelease(timeZoneRef);
+    _timezoneOffsetSeconds = [[NSTimeZone systemTimeZone] secondsFromGMT];
   }
   return self;
 }

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORClockTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORClockTest.m
@@ -113,4 +113,10 @@
   XCTAssertLessThanOrEqual(ABS(uptimeDiff - timeDiff), accuracy);
 }
 
+- (void)testTimezoneOffsetSeconds {
+  GDTCORClock *snapshot = [GDTCORClock snapshot];
+  int64_t expectedTimeZoneOffset = [[NSTimeZone systemTimeZone] secondsFromGMT];
+  XCTAssertEqual(snapshot.timezoneOffsetSeconds, expectedTimeZoneOffset);
+}
+
 @end


### PR DESCRIPTION
- use Foundation instead of CoreFoundation API to get the system time zone, because `CFTimeZoneCopySystem()` and `CFTimeZoneCopyDefault()` don't respect current daylight offset.

Context: b/159368113.