### PR TITLE
Remove the extension that makes NSDate ServerTimestampWrappable.

### DIFF
--- a/Firestore/Swift/CHANGELOG.md
+++ b/Firestore/Swift/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+- Removed support for wrapping `NSDate` in a `@ServerTimestamp` property
+  wrapper. This never actually worked because `NSDate` is not `Codable`.
 
 # v0.3
 - Renamed the misspelled `FirestoreDecodingError.fieldNameConfict` to

--- a/Firestore/Swift/Source/Codable/ServerTimestamp.swift
+++ b/Firestore/Swift/Source/Codable/ServerTimestamp.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import FirebaseFirestore
   /// A type that can initialize itself from a Firestore Timestamp, which makes
   /// it suitable for use with the `@ServerTimestamp` property wrapper.
   ///
-  /// Firestore includes extensions that make `Timestamp`, `Date`, and `NSDate`
-  /// conform to `ServerTimestampWrappable`.
+  /// Firestore includes extensions that make `Timestamp` and `Date` conform to
+  /// `ServerTimestampWrappable`.
   public protocol ServerTimestampWrappable {
     /// Creates a new instance by converting from the given `Timestamp`.
     ///
@@ -41,17 +41,6 @@ import FirebaseFirestore
 
     public static func unwrap(_ value: Self) throws -> Timestamp {
       return Timestamp(date: value)
-    }
-  }
-
-  extension NSDate: ServerTimestampWrappable {
-    public static func wrap(_ timestamp: Timestamp) throws -> Self {
-      let interval = timestamp.dateValue().timeIntervalSince1970
-      return NSDate(timeIntervalSince1970: interval) as! Self
-    }
-
-    public static func unwrap(_ value: NSDate) throws -> Timestamp {
-      return Timestamp(date: value as Date)
     }
   }
 

--- a/Firestore/Swift/Tests/Codable/FirestoreEncoderTests.swift
+++ b/Firestore/Swift/Tests/Codable/FirestoreEncoderTests.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -479,6 +479,27 @@ class FirestoreEncoderTests: XCTestCase {
       // Decoding a NSNull() leads to nil.
       assertThat(["timestamp": NSNull()])
         .decodes(to: Model(timestamp: nil))
+    }
+
+    func testServerTimestampOfDate() throws {
+      struct Model: Codable, Equatable {
+        @ServerTimestamp var date: Date? = nil
+      }
+
+      // Encoding a pending server timestamp
+      assertThat(Model())
+        .encodes(to: ["date": FieldValue.serverTimestamp()])
+
+      // Encoding a resolved server timestamp yields a timestamp; decoding
+      // yields it back.
+      let timestamp = Timestamp(seconds: 123_456_789, nanoseconds: 0)
+      let date: Date = timestamp.dateValue()
+      assertThat(Model(date: date))
+        .roundTrips(to: ["date": timestamp])
+
+      // Decoding a NSNull() leads to nil.
+      assertThat(["date": NSNull()])
+        .decodes(to: Model(date: nil))
     }
 
     func testServerTimestampUserType() throws {


### PR DESCRIPTION
This turns out not to actually work because `NSDate` does not conform to `Codable`. Users can supply their own extensions that make `NSDate` conform to `Codable` and also supply an extension like this one to make `NSDate` conform to `ServerTimestampWrappable`.

Add a test that verifies ServerTimestamps of Swift `Date` actually work. The equivalent test for `NSDate` does not compile.