### PR TITLE
[App Distribution] Show new build alert when version (or build) changes

### DIFF
--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -248,59 +248,39 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
 }
 
 - (void)fetchNewLatestRelease:(FIRAppDistributionUpdateCheckCompletion)completion {
-  [FIRFADApiService fetchReleasesWithCompletion:^(NSArray *_Nullable releases,
-                                                  NSError *_Nullable error) {
-    if (error) {
-      dispatch_async(dispatch_get_main_queue(), ^{
-        completion(nil, [self mapFetchReleasesError:error]);
-      });
-      return;
-    }
-
-    for (NSDictionary *releaseDict in releases) {
-      if ([[releaseDict objectForKey:kLatestReleaseKey] boolValue]) {
-        FIRFADInfoLog(@"Tester API - found latest release in response.");
-        NSString *displayVersion = [releaseDict objectForKey:kDisplayVersionKey];
-        NSString *buildVersion = [releaseDict objectForKey:kBuildVersionKey];
-
-        FIRFADInfoLog(@"Checking if version matches");
-        if (![self isCurrentVersion:displayVersion buildVersion:buildVersion]) {
-          FIRFADInfoLog(
-              @"Current version %@ (%@) does not match latest version %@ (%@) from the Tester API",
-              [self getAppVersion], [self getAppBuild], displayVersion, buildVersion);
-          FIRAppDistributionRelease *release =
-              [[FIRAppDistributionRelease alloc] initWithDictionary:releaseDict];
-          completion(release, nil);
-
-          return;
-        }
-
-        FIRFADInfoLog(@"Checking if code hash match");
-        NSString *codeHash = [releaseDict objectForKey:kCodeHashKey];
-        NSString *executablePath = [[NSBundle mainBundle] executablePath];
-        FIRAppDistributionMachO *machO =
-            [[FIRAppDistributionMachO alloc] initWithPath:executablePath];
-        FIRFADInfoLog(@"Code hash for the app on device - %@", machO.codeHash);
-        FIRFADInfoLog(@"Code hash for the release from the service response - %@", codeHash);
-        if (codeHash && ![codeHash isEqualToString:machO.codeHash]) {
-          FIRAppDistributionRelease *release =
-              [[FIRAppDistributionRelease alloc] initWithDictionary:releaseDict];
+  [FIRFADApiService
+      fetchReleasesWithCompletion:^(NSArray *_Nullable releases, NSError *_Nullable error) {
+        if (error) {
           dispatch_async(dispatch_get_main_queue(), ^{
-            FIRFADInfoLog(@"Found new release with version: %@", [release displayVersion]);
-            completion(release, nil);
+            completion(nil, [self mapFetchReleasesError:error]);
           });
-
           return;
         }
-      }
-    }
-    completion(nil, nil);
-  }];
-}
 
-- (BOOL)isCurrentVersion:(NSString *)displayVersion buildVersion:(NSString *)buildVersion {
-  return [displayVersion isEqualToString:[self getAppVersion]] &&
-         [buildVersion isEqualToString:[self getAppBuild]];
+        for (NSDictionary *releaseDict in releases) {
+          if ([[releaseDict objectForKey:kLatestReleaseKey] boolValue]) {
+            FIRFADInfoLog(@"Tester API - found latest release in response.");
+            NSString *displayVersion = [releaseDict objectForKey:kDisplayVersionKey];
+            NSString *buildVersion = [releaseDict objectForKey:kBuildVersionKey];
+
+            NSString *codeHash = [releaseDict objectForKey:kCodeHashKey];
+
+            if (![self isCurrentVersion:displayVersion buildVersion:buildVersion] ||
+                ![self isCodeHashIdentical:codeHash]) {
+              FIRAppDistributionRelease *release =
+                  [[FIRAppDistributionRelease alloc] initWithDictionary:releaseDict];
+              dispatch_async(dispatch_get_main_queue(), ^{
+                FIRFADInfoLog(@"Found new release with version: %@ (%@)", [release displayVersion],
+                              [release buildVersion]);
+                completion(release, nil);
+              });
+              return;
+            }
+          }
+        }
+
+        completion(nil, nil);
+      }];
 }
 
 - (void)checkForUpdateWithCompletion:(FIRAppDistributionUpdateCheckCompletion)completion {
@@ -327,5 +307,25 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
 
     [[self uiService] showUIAlertWithCompletion:actionCompletion];
   }
+}
+
+- (BOOL)isCurrentVersion:(NSString *)displayVersion buildVersion:(NSString *)buildVersion {
+  FIRFADInfoLog(@"Checking if version matches");
+  FIRFADInfoLog(@"App version: %@ (%@) Latest release version: %@ (%@)", [self getAppVersion],
+                [self getAppBuild], displayVersion, buildVersion);
+
+  return [displayVersion isEqualToString:[self getAppVersion]] &&
+         [buildVersion isEqualToString:[self getAppBuild]];
+}
+
+- (BOOL)isCodeHashIdentical:(NSString *)codeHash {
+  FIRFADInfoLog(@"Checking if code hash matches");
+
+  NSString *executablePath = [[NSBundle mainBundle] executablePath];
+  FIRAppDistributionMachO *machO = [[FIRAppDistributionMachO alloc] initWithPath:executablePath];
+
+  FIRFADInfoLog(@"App code hash: %@ Latest release code hash: %@", [machO codeHash], codeHash);
+
+  return codeHash && [codeHash isEqualToString:[machO codeHash]];
 }
 @end

--- a/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionTests.m
+++ b/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionTests.m
@@ -39,6 +39,8 @@
 
 - (NSError *)mapFetchReleasesError:(NSError *)error;
 
+- (NSString *)getAppVersion;
+- (NSString *)getAppBuild;
 @end
 
 @implementation FIRAppDistributionTests {
@@ -52,12 +54,16 @@
   NSString *_mockInstallationId;
   NSArray *_mockReleases;
   NSString *_mockCodeHash;
+  NSString *_mockDisplayVersion;
+  NSString *_mockBuildVersion;
 }
 
 - (void)setUp {
   [super setUp];
   _mockAuthToken = @"this-is-an-auth-token";
   _mockCodeHash = @"this-is-a-fake-code-hash";
+  _mockDisplayVersion = @"mock-display-version";
+  _mockBuildVersion = @"mock-build-version";
   _mockFIRAppClass = OCMClassMock([FIRApp class]);
   _mockFIRFADApiService = OCMClassMock([FIRFADApiService class]);
   _mockFIRAppDistributionUIService = OCMPartialMock([FIRAppDistributionUIService sharedInstance]);
@@ -89,8 +95,8 @@
     @{
       @"latest" : @YES,
       @"codeHash" : _mockCodeHash,
-      @"displayVersion" : @"1.0.1",
-      @"buildVersion" : @"112",
+      @"displayVersion" : _mockDisplayVersion,
+      @"buildVersion" : _mockBuildVersion,
       @"releaseNotes" : @"This is a release too",
       @"downloadUrl" : @"http://faketyfakefake.download"
     }
@@ -307,6 +313,8 @@
 - (void)testFetchNewLatestReleaseNoNewRelease {
   [self mockFetchReleasesCompletion:_mockReleases error:nil];
   OCMStub([_mockMachO codeHash]).andReturn(_mockCodeHash);
+  OCMStub([[self appDistribution] getAppVersion]).andReturn(_mockDisplayVersion);
+  OCMStub([[self appDistribution] getAppBuild]).andReturn(_mockBuildVersion);
 
   XCTestExpectation *expectation =
       [self expectationWithDescription:@"Fetch latest release with no new release succeeds."];
@@ -378,11 +386,13 @@
   [self rejectShowUICompletion];
 }
 
-- (void)testCheckForUpdateWithCompletionClicksYesSuccess {
+- (void)testCheckForUpdateWithCompletionDifferentCodeHashClicksYesSuccess {
   [self mockInstallationIdCompletion:_mockInstallationId error:nil];
   [self mockUIServiceRegistrationCompletion:nil];
   [self mockFetchReleasesCompletion:_mockReleases error:nil];
   [self mockUIServiceShowUICompletion:YES];
+  OCMStub([[self appDistribution] getAppVersion]).andReturn(_mockDisplayVersion);
+  OCMStub([[self appDistribution] getAppBuild]).andReturn(_mockBuildVersion);
   OCMStub([_mockMachO codeHash]).andReturn(@"this-is-old");
 
   XCTestExpectation *checkForUpdateExpectation =
@@ -398,6 +408,75 @@
   [self waitForExpectations:@[ checkForUpdateExpectation ] timeout:5.0];
   [self verifyShowUICompletion];
   OCMVerify([_mockMachO codeHash]);
+}
+
+- (void)testCheckForUpdateWithCompletionDifferentVersionAndBuildClicksYesSuccess {
+  [self mockInstallationIdCompletion:_mockInstallationId error:nil];
+  [self mockUIServiceRegistrationCompletion:nil];
+  [self mockFetchReleasesCompletion:_mockReleases error:nil];
+  [self mockUIServiceShowUICompletion:YES];
+  OCMStub([[self appDistribution] getAppVersion]).andReturn(@"different-version");
+  OCMStub([[self appDistribution] getAppBuild]).andReturn(@"different-build");
+  OCMReject([_mockMachO codeHash]);
+
+  XCTestExpectation *checkForUpdateExpectation =
+      [self expectationWithDescription:@"Check for update does prompt user"];
+  [[self appDistribution]
+      checkForUpdateWithCompletion:^(FIRAppDistributionRelease *_Nullable release,
+                                     NSError *_Nullable error) {
+        XCTAssertNil(error);
+        XCTAssertNotNil(release);
+        [checkForUpdateExpectation fulfill];
+      }];
+
+  [self waitForExpectations:@[ checkForUpdateExpectation ] timeout:5.0];
+  [self verifyShowUICompletion];
+}
+
+- (void)testCheckForUpdateWithCompletionDifferentVersionClicksYesSuccess {
+  [self mockInstallationIdCompletion:_mockInstallationId error:nil];
+  [self mockUIServiceRegistrationCompletion:nil];
+  [self mockFetchReleasesCompletion:_mockReleases error:nil];
+  [self mockUIServiceShowUICompletion:YES];
+  OCMStub([[self appDistribution] getAppVersion]).andReturn(@"different-version");
+  OCMStub([[self appDistribution] getAppBuild]).andReturn(_mockBuildVersion);
+  OCMReject([_mockMachO codeHash]);
+
+  XCTestExpectation *checkForUpdateExpectation =
+      [self expectationWithDescription:@"Check for update does prompt user"];
+  [[self appDistribution]
+      checkForUpdateWithCompletion:^(FIRAppDistributionRelease *_Nullable release,
+                                     NSError *_Nullable error) {
+        XCTAssertNil(error);
+        XCTAssertNotNil(release);
+        [checkForUpdateExpectation fulfill];
+      }];
+
+  [self waitForExpectations:@[ checkForUpdateExpectation ] timeout:5.0];
+  [self verifyShowUICompletion];
+}
+
+- (void)testCheckForUpdateWithCompletionDifferentBuildClicksYesSuccess {
+  [self mockInstallationIdCompletion:_mockInstallationId error:nil];
+  [self mockUIServiceRegistrationCompletion:nil];
+  [self mockFetchReleasesCompletion:_mockReleases error:nil];
+  [self mockUIServiceShowUICompletion:YES];
+  OCMStub([[self appDistribution] getAppVersion]).andReturn(_mockDisplayVersion);
+  OCMStub([[self appDistribution] getAppBuild]).andReturn(@"different-build");
+  OCMReject([_mockMachO codeHash]);
+
+  XCTestExpectation *checkForUpdateExpectation =
+      [self expectationWithDescription:@"Check for update does prompt user"];
+  [[self appDistribution]
+      checkForUpdateWithCompletion:^(FIRAppDistributionRelease *_Nullable release,
+                                     NSError *_Nullable error) {
+        XCTAssertNil(error);
+        XCTAssertNotNil(release);
+        [checkForUpdateExpectation fulfill];
+      }];
+
+  [self waitForExpectations:@[ checkForUpdateExpectation ] timeout:5.0];
+  [self verifyShowUICompletion];
 }
 
 - (void)testCheckForUpdateWithCompletionClicksYesFailure {


### PR DESCRIPTION
When the version (or build) of the current app is different than the version or build of the latest release, show the prompt to update to the latest version.

#no-changelog app distibution is not released yet