### PR TITLE
Skip pod lib lint tests now that watchos is coming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,7 +124,7 @@ jobs:
       env:
         - PROJECT=Crashlytics METHOD=pod-lib-lint
       script:
-        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseCrashlytics.podspec
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseCrashlytics.podspec --skip-tests
 
     - stage: test
       env:


### PR DESCRIPTION
Skip travis `pod lib lint` test_spec executions since they're not supported with watchOS and these tests are redundant with GHA testing.

#no-changelog