### PR TITLE
Fix occasional NSURLSessionTask creation crash

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v4.5.0
 - [fixed] Fixed a compiler warning and removed unused networking code (#6210).
+- [fixed] Fixed a crash that occurred rarely when trying to restart a URL session task without a valid request (#5984).
 - [added] Introduced watchOS support (#6262).
 
 # v4.3.1

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSNetworkClient.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSNetworkClient.m
@@ -296,6 +296,12 @@ NSString *const FIRCLSNetworkClientBackgroundIdentifierSuffix = @".crash.backgro
 - (void)restartTask:(NSURLSessionTask *)task {
   NSURLRequest *request = [task originalRequest];
 
+  if (request == nil) {
+    FIRCLSWarningLog(@"Unable to restart task: Could not retrieve original request from task %@",
+                     task);
+    return;
+  }
+
   [self runAfterRetryValueFromResponse:[task response]
                                  block:^{
                                    NSString *path = [self


### PR DESCRIPTION
Fixes #5984.

NSURLSessionTask's original request is [documented as nullable](https://developer.apple.com/documentation/foundation/urlsessiontask/1411572-originalrequest).