### PR TITLE
[App Distribution] Remove typedefs

### DIFF
--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -247,7 +247,8 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
                                      message:@"Failed to fetch releases for unknown reason."];
 }
 
-- (void)fetchNewLatestRelease:(FIRAppDistributionUpdateCheckCompletion)completion {
+- (void)fetchNewLatestRelease:(void (^)(FIRAppDistributionRelease *_Nullable release,
+                                        NSError *_Nullable error))completion {
   [FIRFADApiService
       fetchReleasesWithCompletion:^(NSArray *_Nullable releases, NSError *_Nullable error) {
         if (error) {
@@ -283,7 +284,8 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
       }];
 }
 
-- (void)checkForUpdateWithCompletion:(FIRAppDistributionUpdateCheckCompletion)completion {
+- (void)checkForUpdateWithCompletion:(void (^)(FIRAppDistributionRelease *_Nullable release,
+                                               NSError *_Nullable error))completion {
   FIRFADInfoLog(@"CheckForUpdateWithCompletion");
   if ([self isTesterSignedIn]) {
     [self fetchNewLatestRelease:completion];

--- a/FirebaseAppDistribution/Sources/Public/FIRAppDistribution.h
+++ b/FirebaseAppDistribution/Sources/Public/FIRAppDistribution.h
@@ -13,23 +13,8 @@
 // limitations under the License.
 
 @class FIRAppDistributionRelease;
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
-
-/**
- *  @related AppDistributionError
- *
- *  The completion handler invoked when the new build request returns.
- *  If the call fails we return the appropriate `error code`, described by
- *  `AppDistributionError`.
- *
- *  @param release  The new release that is available to be installed.
- *  @param error     The error describing why the new build request failed.
- */
-typedef void (^FIRAppDistributionUpdateCheckCompletion)(
-    FIRAppDistributionRelease *_Nullable release, NSError *_Nullable error)
-    NS_SWIFT_NAME(AppDistributionUpdateCheckCompletion);
 
 /**
  * The Firebase App Distribution API provides methods to check for update to
@@ -58,7 +43,8 @@ NS_SWIFT_NAME(AppDistribution)
 /**
  * Check to see whether a new distribution is available
  */
-- (void)checkForUpdateWithCompletion:(FIRAppDistributionUpdateCheckCompletion)completion
+- (void)checkForUpdateWithCompletion:
+    (void (^)(FIRAppDistributionRelease *_Nullable release, NSError *_Nullable error))completion
     NS_SWIFT_NAME(checkForUpdate(completion:));
 
 /**


### PR DESCRIPTION
Stop using typedefs for completion blocks in public APIs so that Xcode is more usable in Swift:

#no-changelog App Distribution is not released yet