### PR TITLE
[App Distribution] Add isExpired to FIRAppDistributionRelease

### DIFF
--- a/FirebaseAppDistribution/Sources/FIRAppDistributionRelease.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionRelease.m
@@ -19,9 +19,13 @@
 @property(nonatomic, copy) NSString *buildVersion;
 @property(nonatomic, copy) NSString *releaseNotes;
 @property(nonatomic, strong) NSURL *downloadURL;
+@property(nonatomic) NSDate *expirationTime;
 @end
 
 @implementation FIRAppDistributionRelease
+
+static const NSTimeInterval kDownloadUrlTimeToLive = 59 * 60;  // 59 minutes
+
 - (instancetype)initWithDictionary:(NSDictionary *)dict {
   self = [super init];
   if (self) {
@@ -30,7 +34,12 @@
 
     self.downloadURL = [[NSURL alloc] initWithString:[dict objectForKey:@"downloadUrl"]];
     self.releaseNotes = [dict objectForKey:@"releaseNotes"];
+    self.expirationTime = [NSDate dateWithTimeIntervalSinceNow:kDownloadUrlTimeToLive];
   }
   return self;
+}
+
+- (BOOL)isExpired {
+  return [[NSDate date] compare:_expirationTime] == NSOrderedDescending;
 }
 @end

--- a/FirebaseAppDistribution/Sources/Public/FIRAppDistributionRelease.h
+++ b/FirebaseAppDistribution/Sources/Public/FIRAppDistributionRelease.h
@@ -35,6 +35,9 @@ NS_SWIFT_NAME(AppDistributionRelease)
 // The URL for the build
 @property(nonatomic, strong, readonly) NSURL *downloadURL;
 
+// Whether the download URL for this release is expired
+@property(nonatomic, readonly) BOOL isExpired;
+
 /** :nodoc: */
 - (instancetype)init NS_UNAVAILABLE;
 


### PR DESCRIPTION
Add isExpired to FIRAppDistributionRelease to allow the user to verify that the Release's download URL is not expired

#no-changelog App Distribution is not released yet