### PR TITLE
Auth - no typedefs in public APIs

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - [added] Added basic watchOS support. (#4621)
-- [fixed] Improved Xcode completion of public API completion handlers in Swift. (#6283)
+- [channged] Improved Xcode completion of public API completion handlers in Swift. (#6283)
 
 # v6.8.0
 - [fixed] Fix bug where multiple keychain entries would result in user persistence failure. (#5906)

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [added] Added basic watchOS support. (#4621)
+- [fixed] Improved Xcode completion of public API completion handlers in Swift. (#6283)
 
 # v6.8.0
 - [fixed] Fix bug where multiple keychain entries would result in user persistence failure. (#5906)

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h
@@ -380,14 +380,16 @@ NS_SWIFT_NAME(Auth)
     @param completion Optionally; a block invoked after the user of the calling Auth instance has
         been updated or an error was encountered.
  */
-- (void)updateCurrentUser:(FIRUser *)user completion:(nullable FIRUserUpdateCallback)completion;
+- (void)updateCurrentUser:(FIRUser *)user
+               completion:(nullable void (^)(NSError *_Nullable error))completion;
 
 /** @fn fetchProvidersForEmail:completion:
     @brief Please use fetchSignInMethodsForEmail:completion: for Objective-C or
         fetchSignInMethods(forEmail:completion:) for Swift instead.
  */
 - (void)fetchProvidersForEmail:(NSString *)email
-                    completion:(nullable FIRProviderQueryCallback)completion
+                    completion:(nullable void (^)(NSArray<NSString *> *_Nullable providers,
+                                                  NSError *_Nullable error))completion
     DEPRECATED_MSG_ATTRIBUTE("Please use fetchSignInMethodsForEmail:completion: for Objective-C or "
                              "fetchSignInMethods(forEmail:completion:) for Swift instead.");
 
@@ -407,7 +409,8 @@ NS_SWIFT_NAME(Auth)
  */
 
 - (void)fetchSignInMethodsForEmail:(NSString *)email
-                        completion:(nullable FIRSignInMethodQueryCallback)completion;
+                        completion:(nullable void (^)(NSArray<NSString *> *_Nullable,
+                                                      NSError *_Nullable))completion;
 
 /** @fn signInWithEmail:password:completion:
     @brief Signs in using an email address and password.
@@ -432,7 +435,8 @@ NS_SWIFT_NAME(Auth)
  */
 - (void)signInWithEmail:(NSString *)email
                password:(NSString *)password
-             completion:(nullable FIRAuthDataResultCallback)completion;
+             completion:(nullable void (^)(FIRAuthDataResult *_Nullable authResult,
+                                           NSError *_Nullable error))completion;
 
 /** @fn signInWithEmail:link:completion:
     @brief Signs in using an email address and email sign-in link.
@@ -456,7 +460,9 @@ NS_SWIFT_NAME(Auth)
 
 - (void)signInWithEmail:(NSString *)email
                    link:(NSString *)link
-             completion:(nullable FIRAuthDataResultCallback)completion API_UNAVAILABLE(watchos);
+             completion:(nullable void (^)(FIRAuthDataResult *_Nullable authResult,
+                                           NSError *_Nullable error))completion
+    API_UNAVAILABLE(watchos);
 
 /** @fn signInWithProvider:UIDelegate:completion:
     @brief Signs in using the provided auth provider instance.
@@ -504,14 +510,18 @@ NS_SWIFT_NAME(Auth)
  */
 - (void)signInWithProvider:(id<FIRFederatedAuthProvider>)provider
                 UIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
-                completion:(nullable FIRAuthDataResultCallback)completion API_UNAVAILABLE(watchos);
+                completion:(nullable void (^)(FIRAuthDataResult *_Nullable authResult,
+                                              NSError *_Nullable error))completion
+    API_UNAVAILABLE(watchos);
 
 /** @fn signInAndRetrieveDataWithCredential:completion:
     @brief Please use signInWithCredential:completion: for Objective-C or "
         "signIn(with:completion:) for Swift instead.
  */
 - (void)signInAndRetrieveDataWithCredential:(FIRAuthCredential *)credential
-                                 completion:(nullable FIRAuthDataResultCallback)completion
+                                 completion:
+                                     (nullable void (^)(FIRAuthDataResult *_Nullable authResult,
+                                                        NSError *_Nullable error))completion
     DEPRECATED_MSG_ATTRIBUTE("Please use signInWithCredential:completion: for Objective-C or "
                              "signIn(with:completion:) for Swift instead.");
 
@@ -554,7 +564,8 @@ NS_SWIFT_NAME(Auth)
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods
 */
 - (void)signInWithCredential:(FIRAuthCredential *)credential
-                  completion:(nullable FIRAuthDataResultCallback)completion;
+                  completion:(nullable void (^)(FIRAuthDataResult *_Nullable authResult,
+                                                NSError *_Nullable error))completion;
 
 /** @fn signInAnonymouslyWithCompletion:
     @brief Asynchronously creates and becomes an anonymous user.
@@ -571,7 +582,8 @@ NS_SWIFT_NAME(Auth)
 
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods.
  */
-- (void)signInAnonymouslyWithCompletion:(nullable FIRAuthDataResultCallback)completion;
+- (void)signInAnonymouslyWithCompletion:(nullable void (^)(FIRAuthDataResult *_Nullable authResult,
+                                                           NSError *_Nullable error))completion;
 
 /** @fn signInWithCustomToken:completion:
     @brief Asynchronously signs in to Firebase with the given Auth token.
@@ -590,7 +602,8 @@ NS_SWIFT_NAME(Auth)
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods.
  */
 - (void)signInWithCustomToken:(NSString *)token
-                   completion:(nullable FIRAuthDataResultCallback)completion;
+                   completion:(nullable void (^)(FIRAuthDataResult *_Nullable authResult,
+                                                 NSError *_Nullable error))completion;
 
 /** @fn createUserWithEmail:password:completion:
     @brief Creates and, on success, signs in a user with the given email address and password.
@@ -616,7 +629,8 @@ NS_SWIFT_NAME(Auth)
  */
 - (void)createUserWithEmail:(NSString *)email
                    password:(NSString *)password
-                 completion:(nullable FIRAuthDataResultCallback)completion;
+                 completion:(nullable void (^)(FIRAuthDataResult *_Nullable authResult,
+                                               NSError *_Nullable error))completion;
 
 /** @fn confirmPasswordResetWithCode:newPassword:completion:
     @brief Resets the password given a code sent to the user outside of the app and a new password
@@ -639,7 +653,7 @@ NS_SWIFT_NAME(Auth)
  */
 - (void)confirmPasswordResetWithCode:(NSString *)code
                          newPassword:(NSString *)newPassword
-                          completion:(FIRConfirmPasswordResetCallback)completion;
+                          completion:(void (^)(NSError *_Nullable error))completion;
 
 /** @fn checkActionCode:completion:
     @brief Checks the validity of an out of band code.
@@ -658,7 +672,8 @@ NS_SWIFT_NAME(Auth)
         asynchronously on the main thread in the future.
  */
 - (void)verifyPasswordResetCode:(NSString *)code
-                     completion:(FIRVerifyPasswordResetCodeCallback)completion;
+                     completion:
+                         (void (^)(NSString *_Nullable email, NSError *_Nullable error))completion;
 
 /** @fn applyActionCode:completion:
     @brief Applies out of band code.
@@ -670,7 +685,7 @@ NS_SWIFT_NAME(Auth)
     @remarks This method will not work for out of band codes which require an additional parameter,
         such as password reset code.
  */
-- (void)applyActionCode:(NSString *)code completion:(FIRApplyActionCodeCallback)completion;
+- (void)applyActionCode:(NSString *)code completion:(void (^)(NSError *_Nullable error))completion;
 
 /** @fn sendPasswordResetWithEmail:completion:
     @brief Initiates a password reset for the given email address.
@@ -691,7 +706,7 @@ NS_SWIFT_NAME(Auth)
 
  */
 - (void)sendPasswordResetWithEmail:(NSString *)email
-                        completion:(nullable FIRSendPasswordResetCallback)completion;
+                        completion:(nullable void (^)(NSError *_Nullable error))completion;
 
 /** @fn sendPasswordResetWithEmail:actionCodeSetting:completion:
     @brief Initiates a password reset for the given email address and @FIRActionCodeSettings object.
@@ -723,7 +738,7 @@ NS_SWIFT_NAME(Auth)
  */
 - (void)sendPasswordResetWithEmail:(NSString *)email
                 actionCodeSettings:(FIRActionCodeSettings *)actionCodeSettings
-                        completion:(nullable FIRSendPasswordResetCallback)completion;
+                        completion:(nullable void (^)(NSError *_Nullable error))completion;
 
 /** @fn sendSignInLinkToEmail:actionCodeSettings:completion:
     @brief Sends a sign in with email link to provided email address.
@@ -736,7 +751,7 @@ NS_SWIFT_NAME(Auth)
  */
 - (void)sendSignInLinkToEmail:(NSString *)email
            actionCodeSettings:(FIRActionCodeSettings *)actionCodeSettings
-                   completion:(nullable FIRSendSignInLinkToEmailCallback)completion
+                   completion:(nullable void (^)(NSError *_Nullable error))completion
     API_UNAVAILABLE(watchos);
 
 /** @fn signOut:
@@ -751,8 +766,6 @@ NS_SWIFT_NAME(Auth)
         + `FIRAuthErrorCodeKeychainError` - Indicates an error occurred when accessing the
             keychain. The `NSLocalizedFailureReasonErrorKey` field in the `NSError.userInfo`
             dictionary will contain more information about the error encountered.
-
-
 
  */
 - (BOOL)signOut:(NSError *_Nullable *_Nullable)error;
@@ -783,8 +796,9 @@ NS_SWIFT_NAME(Auth)
 
     @return A handle useful for manually unregistering the block as a listener.
  */
+
 - (FIRAuthStateDidChangeListenerHandle)addAuthStateDidChangeListener:
-    (FIRAuthStateDidChangeListenerBlock)listener;
+    (void (^)(FIRAuth *auth, FIRUser *_Nullable user))listener;
 
 /** @fn removeAuthStateDidChangeListener:
     @brief Unregisters a block as an "auth state did change" listener.
@@ -813,7 +827,7 @@ NS_SWIFT_NAME(Auth)
     @return A handle useful for manually unregistering the block as a listener.
  */
 - (FIRIDTokenDidChangeListenerHandle)addIDTokenDidChangeListener:
-    (FIRIDTokenDidChangeListenerBlock)listener;
+    (void (^)(FIRAuth *auth, FIRUser *_Nullable user))listener;
 
 /** @fn removeIDTokenDidChangeListener:
     @brief Unregisters a block as an "ID token did change" listener.

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRFederatedAuthProvider.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRFederatedAuthProvider.h
@@ -47,7 +47,8 @@ typedef void (^FIRAuthCredentialCallback)(FIRAuthCredential *_Nullable credentia
         the mobile web flow is completed.
  */
 - (void)getCredentialWithUIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
-                         completion:(nullable FIRAuthCredentialCallback)completion;
+                         completion:(nullable void (^)(FIRAuthCredential *_Nullable credential,
+                                                       NSError *_Nullable error))completion;
 #endif  // TARGET_OS_IOS
 
 @end

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRGameCenterAuthProvider.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRGameCenterAuthProvider.h
@@ -51,7 +51,8 @@ NS_SWIFT_NAME(GameCenterAuthProvider)
 /** @fn getCredentialWithCompletion:
     @brief Creates a @c FIRAuthCredential for a Game Center sign in.
  */
-+ (void)getCredentialWithCompletion:(FIRGameCenterCredentialCallback)completion
++ (void)getCredentialWithCompletion:
+    (void (^)(FIRAuthCredential *_Nullable credential, NSError *_Nullable error))completion
     NS_SWIFT_NAME(getCredential(completion:));
 
 /** @fn init

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRMultiFactor.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRMultiFactor.h
@@ -54,7 +54,8 @@ NS_SWIFT_NAME(MultiFactor)
     @param completion A block with the session identifier for a second factor enrollment operation.
         This is used to identify the current user trying to enroll a second factor.
 */
-- (void)getSessionWithCompletion:(nullable FIRMultiFactorSessionCallback)completion;
+- (void)getSessionWithCompletion:(nullable void (^)(FIRMultiFactorSession *_Nullable credential,
+                                                    NSError *_Nullable error))completion;
 
 /** @fn enrollWithAssertion:displayName:completion:
     @brief Enrolls a second factor as identified by the `FIRMultiFactorAssertion` parameter for the
@@ -64,7 +65,7 @@ NS_SWIFT_NAME(MultiFactor)
 */
 - (void)enrollWithAssertion:(FIRMultiFactorAssertion *)assertion
                 displayName:(nullable NSString *)displayName
-                 completion:(nullable FIRAuthVoidErrorCallback)completion;
+                 completion:(nullable void (^)(NSError *_Nullable error))completion;
 
 /** @fn unenrollWithInfo:completion:
     @brief Unenroll the given multi factor.
@@ -72,7 +73,7 @@ NS_SWIFT_NAME(MultiFactor)
         or fails.
 */
 - (void)unenrollWithInfo:(FIRMultiFactorInfo *)factorInfo
-              completion:(nullable FIRAuthVoidErrorCallback)completion;
+              completion:(nullable void (^)(NSError *_Nullable error))completion;
 
 /** @fn unenrollWithFactorUID:completion:
     @brief Unenroll the given multi factor.
@@ -80,7 +81,7 @@ NS_SWIFT_NAME(MultiFactor)
         or fails.
 */
 - (void)unenrollWithFactorUID:(NSString *)factorUID
-                   completion:(nullable FIRAuthVoidErrorCallback)completion;
+                   completion:(nullable void (^)(NSError *_Nullable error))completion;
 
 @end
 

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRPhoneAuthProvider.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRPhoneAuthProvider.h
@@ -113,7 +113,9 @@ NS_SWIFT_NAME(PhoneAuthProvider)
 - (void)verifyPhoneNumberWithMultiFactorInfo:(FIRPhoneMultiFactorInfo *)phoneMultiFactorInfo
                                   UIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
                           multiFactorSession:(nullable FIRMultiFactorSession *)session
-                                  completion:(nullable FIRVerificationResultCallback)completion;
+                                  completion:
+                                      (nullable void (^)(NSString *_Nullable verificationID,
+                                                         NSError *_Nullable error))completion;
 
 /** @fn credentialWithVerificationID:verificationCode:
     @brief Creates an `FIRAuthCredential` for the phone number provider identified by the

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRUser.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRUser.h
@@ -154,7 +154,7 @@ NS_SWIFT_NAME(User)
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all FIRUser methods.
  */
 - (void)updateEmail:(NSString *)email
-         completion:(nullable FIRUserProfileChangeCallback)completion
+         completion:(nullable void (^)(NSError *_Nullable error))completion
     NS_SWIFT_NAME(updateEmail(to:completion:));
 
 /** @fn updatePassword:completion:
@@ -179,7 +179,7 @@ NS_SWIFT_NAME(User)
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all FIRUser methods.
  */
 - (void)updatePassword:(NSString *)password
-            completion:(nullable FIRUserProfileChangeCallback)completion
+            completion:(nullable void (^)(NSError *_Nullable error))completion
     NS_SWIFT_NAME(updatePassword(to:completion:));
 
 #if TARGET_OS_IOS
@@ -203,7 +203,7 @@ NS_SWIFT_NAME(User)
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all FIRUser methods.
  */
 - (void)updatePhoneNumberCredential:(FIRPhoneAuthCredential *)phoneNumberCredential
-                         completion:(nullable FIRUserProfileChangeCallback)completion;
+                         completion:(nullable void (^)(NSError *_Nullable error))completion;
 #endif
 
 /** @fn profileChangeRequest
@@ -228,7 +228,7 @@ NS_SWIFT_NAME(User)
 
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods.
  */
-- (void)reloadWithCompletion:(nullable FIRUserProfileChangeCallback)completion;
+- (void)reloadWithCompletion:(nullable void (^)(NSError *_Nullable error))completion;
 
 /** @fn reauthenticateWithCredential:completion:
     @brief Renews the user's authentication tokens by validating a fresh set of credentials supplied
@@ -267,14 +267,17 @@ NS_SWIFT_NAME(User)
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods.
  */
 - (void)reauthenticateWithCredential:(FIRAuthCredential *)credential
-                          completion:(nullable FIRAuthDataResultCallback)completion;
+                          completion:(nullable void (^)(FIRAuthDataResult *_Nullable authResult,
+                                                        NSError *_Nullable error))completion;
 
 /** @fn reauthenticateAndRetrieveDataWithCredential:completion:
     @brief Please use linkWithCredential:completion: for Objective-C
         or link(withCredential:completion:) for Swift instead.
  */
 - (void)reauthenticateAndRetrieveDataWithCredential:(FIRAuthCredential *)credential
-                                         completion:(nullable FIRAuthDataResultCallback)completion
+                                         completion:(nullable void (^)(
+                                                        FIRAuthDataResult *_Nullable authResult,
+                                                        NSError *_Nullable error))completion
     DEPRECATED_MSG_ATTRIBUTE("Please use reauthenticateWithCredential:completion: for"
                              " Objective-C or reauthenticate(withCredential:completion:)"
                              " for Swift instead.");
@@ -289,13 +292,11 @@ NS_SWIFT_NAME(User)
     @param completion Optionally; a block which is invoked when the reauthenticate flow finishes, or
         is canceled. Invoked asynchronously on the main thread in the future.
  */
-// clang-format off
 - (void)reauthenticateWithProvider:(id<FIRFederatedAuthProvider>)provider
                         UIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
-                        completion:(nullable FIRAuthDataResultCallback)completion
-                        NS_SWIFT_NAME(reauthenticate(with:uiDelegate:completion:))
-                        API_AVAILABLE(ios(8.0));
-// clang-format on
+                        completion:(nullable void (^)(FIRAuthDataResult *_Nullable authResult,
+                                                      NSError *_Nullable error))completion
+    NS_SWIFT_NAME(reauthenticate(with:uiDelegate:completion:));
 
 /** @fn getIDTokenResultWithCompletion:
     @brief Retrieves the Firebase authentication token, possibly refreshing it if it has expired.
@@ -305,7 +306,8 @@ NS_SWIFT_NAME(User)
 
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods.
  */
-- (void)getIDTokenResultWithCompletion:(nullable FIRAuthTokenResultCallback)completion
+- (void)getIDTokenResultWithCompletion:(nullable void (^)(FIRAuthTokenResult *_Nullable tokenResult,
+                                                          NSError *_Nullable error))completion
     NS_SWIFT_NAME(getIDTokenResult(completion:));
 
 /** @fn getIDTokenResultForcingRefresh:completion:
@@ -322,7 +324,8 @@ NS_SWIFT_NAME(User)
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods.
  */
 - (void)getIDTokenResultForcingRefresh:(BOOL)forceRefresh
-                            completion:(nullable FIRAuthTokenResultCallback)completion
+                            completion:(nullable void (^)(FIRAuthTokenResult *_Nullable tokenResult,
+                                                          NSError *_Nullable error))completion
     NS_SWIFT_NAME(getIDTokenResult(forcingRefresh:completion:));
 
 /** @fn getIDTokenWithCompletion:
@@ -333,7 +336,8 @@ NS_SWIFT_NAME(User)
 
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods.
  */
-- (void)getIDTokenWithCompletion:(nullable FIRAuthTokenCallback)completion
+- (void)getIDTokenWithCompletion:
+    (nullable void (^)(NSString *_Nullable token, NSError *_Nullable error))completion
     NS_SWIFT_NAME(getIDToken(completion:));
 
 /** @fn getIDTokenForcingRefresh:completion:
@@ -350,14 +354,17 @@ NS_SWIFT_NAME(User)
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all API methods.
  */
 - (void)getIDTokenForcingRefresh:(BOOL)forceRefresh
-                      completion:(nullable FIRAuthTokenCallback)completion;
+                      completion:(nullable void (^)(NSString *_Nullable token,
+                                                    NSError *_Nullable error))completion;
 
 /** @fn linkAndRetrieveDataWithCredential:completion:
     @brief Please use linkWithCredential:completion: for Objective-C
         or link(withCredential:completion:) for Swift instead.
  */
 - (void)linkAndRetrieveDataWithCredential:(FIRAuthCredential *)credential
-                               completion:(nullable FIRAuthDataResultCallback)completion
+                               completion:
+                                   (nullable void (^)(FIRAuthDataResult *_Nullable authResult,
+                                                      NSError *_Nullable error))completion
     DEPRECATED_MSG_ATTRIBUTE("Please use linkWithCredential:completion: for Objective-C "
                              "or link(withCredential:completion:) for Swift instead.");
 
@@ -385,7 +392,8 @@ NS_SWIFT_NAME(User)
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all FIRUser methods.
  */
 - (void)linkWithCredential:(FIRAuthCredential *)credential
-                completion:(nullable FIRAuthDataResultCallback)completion;
+                completion:(nullable void (^)(FIRAuthDataResult *_Nullable authResult,
+                                              NSError *_Nullable error))completion;
 
 /** @fn linkWithProvider:UIDelegate:completion:
     @brief link the user with the provided auth provider instance.
@@ -397,13 +405,11 @@ NS_SWIFT_NAME(User)
     @param completion Optionally; a block which is invoked when the link flow finishes, or
         is canceled. Invoked asynchronously on the main thread in the future.
  */
-// clang-format off
 - (void)linkWithProvider:(id<FIRFederatedAuthProvider>)provider
               UIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
-              completion:(nullable FIRAuthDataResultCallback)completion
-              NS_SWIFT_NAME(link(with:uiDelegate:completion:))
-              API_AVAILABLE(ios(8.0));
-// clang-format on
+              completion:(nullable void (^)(FIRAuthDataResult *_Nullable authResult,
+                                            NSError *_Nullable error))completion
+    NS_SWIFT_NAME(link(with:uiDelegate:completion:));
 
 /** @fn unlinkFromProvider:completion:
     @brief Disassociates a user account from a third-party identity provider with this user.
@@ -424,7 +430,8 @@ NS_SWIFT_NAME(User)
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all FIRUser methods.
  */
 - (void)unlinkFromProvider:(NSString *)provider
-                completion:(nullable FIRAuthResultCallback)completion;
+                completion:(nullable void (^)(FIRUser *_Nullable user,
+                                              NSError *_Nullable error))completion;
 
 /** @fn sendEmailVerificationWithCompletion:
     @brief Initiates email verification for the user.
@@ -444,7 +451,7 @@ NS_SWIFT_NAME(User)
 
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all FIRUser methods.
  */
-- (void)sendEmailVerificationWithCompletion:(nullable FIRSendEmailVerificationCallback)completion;
+- (void)sendEmailVerificationWithCompletion:(nullable void (^)(NSError *_Nullable error))completion;
 
 /** @fn sendEmailVerificationWithActionCodeSettings:completion:
     @brief Initiates email verification for the user.
@@ -471,8 +478,8 @@ NS_SWIFT_NAME(User)
             continue URI is not valid.
  */
 - (void)sendEmailVerificationWithActionCodeSettings:(FIRActionCodeSettings *)actionCodeSettings
-                                         completion:
-                                             (nullable FIRSendEmailVerificationCallback)completion;
+                                         completion:(nullable void (^)(NSError *_Nullable error))
+                                                        completion;
 
 /** @fn deleteWithCompletion:
     @brief Deletes the user account (also signs out the user, if this was the current user).
@@ -490,7 +497,7 @@ NS_SWIFT_NAME(User)
     @remarks See `FIRAuthErrors` for a list of error codes that are common to all FIRUser methods.
 
  */
-- (void)deleteWithCompletion:(nullable FIRUserProfileChangeCallback)completion;
+- (void)deleteWithCompletion:(nullable void (^)(NSError *_Nullable error))completion;
 
 /** @fn sendEmailVerificationBeforeUpdatingEmail:completion:
     @brief Send an email to verify the ownership of the account then update to the new email.
@@ -499,7 +506,8 @@ NS_SWIFT_NAME(User)
         email is complete, or fails.
 */
 - (void)sendEmailVerificationBeforeUpdatingEmail:(nonnull NSString *)email
-                                      completion:(nullable FIRAuthVoidErrorCallback)completion;
+                                      completion:
+                                          (nullable void (^)(NSError *_Nullable error))completion;
 
 /** @fn sendEmailVerificationBeforeUpdatingEmail:completion:
     @brief Send an email to verify the ownership of the account then update to the new email.
@@ -511,7 +519,8 @@ NS_SWIFT_NAME(User)
 */
 - (void)sendEmailVerificationBeforeUpdatingEmail:(nonnull NSString *)email
                               actionCodeSettings:(nonnull FIRActionCodeSettings *)actionCodeSettings
-                                      completion:(nullable FIRAuthVoidErrorCallback)completion;
+                                      completion:
+                                          (nullable void (^)(NSError *_Nullable error))completion;
 
 @end
 
@@ -550,7 +559,7 @@ NS_SWIFT_NAME(UserProfileChangeRequest)
     @param completion Optionally; the block invoked when the user profile change has been applied.
         Invoked asynchronously on the main thread in the future.
  */
-- (void)commitChangesWithCompletion:(nullable FIRUserProfileChangeCallback)completion;
+- (void)commitChangesWithCompletion:(nullable void (^)(NSError *_Nullable error))completion;
 
 @end
 


### PR DESCRIPTION
Improve Xcode usability of accessing APIs from Swift:

From 

![Screen Shot 2020-08-17 at 12 23 00 PM](https://user-images.githubusercontent.com/73870/90448214-ccdee800-e099-11ea-9f7e-255dd5a999e7.png)

to 

![Screen Shot 2020-08-17 at 12 28 31 PM](https://user-images.githubusercontent.com/73870/90448226-d2d4c900-e099-11ea-90de-157fbda9eee7.png)

- Enabled clang-format where it was disabled
- Removed unnecessary `API_AVAILABLE(ios(8.0))`