### PR TITLE
Update InstanceID to listen to a notification from Messaging

### DIFF
--- a/Firebase/InstanceID/CHANGELOG.md
+++ b/Firebase/InstanceID/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 2020-08 -- 4.5.2
+# 2020-08 -- 4.6.0
+- [added] Added a new notification listening token refresh from Messaging and update its cache. (#6286)
 - [fixed] Fixed an issue that token refresh notification is not triggered when use `tokenWithAuthorizedEntity:scope:options:handler` to get token. (#6286)
-- [changed] Added a new notification listening token refresh from Messaging and update its cache. (#6286)
 
 # 2020-07 -- 4.5.1
 - [changed] Remove FIRInstanceIDURLQueryItem in favor of NSURLQueryItem. (#5835)

--- a/Firebase/InstanceID/CHANGELOG.md
+++ b/Firebase/InstanceID/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 2020-08 -- 4.5.2
+- [fixed] Fixed an issue that token refresh notification is not triggered when use `tokenWithAuthorizedEntity:scope:options:handler` to get token. (#6286)
 - [changed] Added a new notification listening token refresh from Messaging and update its cache. (#6286)
 
 # 2020-07 -- 4.5.1

--- a/Firebase/InstanceID/CHANGELOG.md
+++ b/Firebase/InstanceID/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2020-08 -- 4.5.2
+- [changed] Added a new notification listening token refresh from Messaging and update its cache. (#6286)
+
 # 2020-07 -- 4.5.1
 - [changed] Remove FIRInstanceIDURLQueryItem in favor of NSURLQueryItem. (#5835)
 

--- a/Firebase/InstanceID/CHANGELOG.md
+++ b/Firebase/InstanceID/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2020-08 -- 4.6.0
-- [added] Added a new notification listening token refresh from Messaging and update its cache. (#6286)
+- [added] Added a new notification listening token refresh from Messaging and update the token cache in InstanceID. (#6286)
 - [fixed] Fixed an issue that token refresh notification is not triggered when use `tokenWithAuthorizedEntity:scope:options:handler` to get token. (#6286)
 
 # 2020-07 -- 4.5.1

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -302,8 +302,13 @@ static FIRInstanceID *gInstanceID;
   }
 
   FIRInstanceIDTokenHandler newHandler = ^(NSString *token, NSError *error) {
-    self.defaultFCMToken = token;
-    handler(token, error);
+    if (!error) {
+      // The local cache should be updated as it is critical for sending token updates.
+      self.defaultFCMToken = token;
+    }
+    dispatch_async(dispatch_get_main_queue(), ^{
+      handler(token, error);
+    });
   };
 
   if (errorCode != noError) {

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -302,7 +302,7 @@ static FIRInstanceID *gInstanceID;
   }
 
   FIRInstanceIDTokenHandler newHandler = ^(NSString *token, NSError *error) {
-    if (!error) {
+    if (!error && [self isDefaultTokenWithAuthorizedEntity:authorizedEntity scope:scope]) {
       // The local cache should be updated as it is critical for sending token updates.
       self.defaultFCMToken = token;
     }
@@ -385,8 +385,7 @@ static FIRInstanceID *gInstanceID;
 
   FIRInstanceIDDeleteTokenHandler newHandler = ^(NSError *error) {
     // If a default token is deleted successfully, reset the defaultFCMToken too.
-    if (!error && [authorizedEntity isEqualToString:self.fcmSenderID] &&
-        [scope isEqualToString:kFIRInstanceIDDefaultTokenScope]) {
+    if (!error && [self isDefaultTokenWithAuthorizedEntity:authorizedEntity scope:scope]) {
       self.defaultFCMToken = nil;
     }
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -867,6 +866,11 @@ static FIRInstanceID *gInstanceID;
                    // will be called
                    [self defaultTokenWithRetry:YES handler:nil];
                  });
+}
+
+- (BOOL)isDefaultTokenWithAuthorizedEntity:(NSString *)authorizedEntity scope:(NSString *)scope {
+  return [authorizedEntity isEqualToString:self.fcmSenderID] &&
+         [scope isEqualToString:kFIRInstanceIDDefaultTokenScope];
 }
 
 #pragma mark - APNS Token

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -1133,7 +1133,7 @@ static FIRInstanceID *gInstanceID;
 
 - (void)messagingTokenDidChangeNotificationReceived:(NSNotification *)notification {
   NSString *tokenUpdatedFromMessaging = notification.object;
-  if ([tokenUpdatedFromMessaging isKindOfClass:[NSString class]]) {
+  if (!tokenUpdatedFromMessaging || [tokenUpdatedFromMessaging isKindOfClass:[NSString class]]) {
     self.defaultFCMToken = tokenUpdatedFromMessaging;
     [self.tokenManager saveDefaultToken:tokenUpdatedFromMessaging
                             withOptions:[self defaultTokenOptions]];

--- a/Firebase/InstanceID/FIRInstanceIDAuthKeyChain.h
+++ b/Firebase/InstanceID/FIRInstanceIDAuthKeyChain.h
@@ -90,6 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
         account:(NSString *)account
         handler:(nullable void (^)(NSError *))handler;
 
+- (void)setDataInCache:(NSData *)data forService:(NSString *)service account:(NSString *)account;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Firebase/InstanceID/FIRInstanceIDAuthKeyChain.m
+++ b/Firebase/InstanceID/FIRInstanceIDAuthKeyChain.m
@@ -213,4 +213,16 @@ NSString *const kFIRInstanceIDKeychainWildcardIdentifier = @"*";
   }
 }
 
+- (void)setDataInCache:(NSData *)data forService:(NSString *)service account:(NSString *)account {
+  if (_cachedKeychainData[service]) {
+    if (_cachedKeychainData[service][account]) {
+      _cachedKeychainData[service][account] = @[ data ];
+    } else {
+      [_cachedKeychainData[service] setObject:@[ data ] forKey:account];
+    }
+  } else {
+    [_cachedKeychainData setObject:[@{account : @[ data ]} mutableCopy] forKey:service];
+  }
+}
+
 @end

--- a/Firebase/InstanceID/FIRInstanceIDConstants.h
+++ b/Firebase/InstanceID/FIRInstanceIDConstants.h
@@ -30,7 +30,7 @@ FOUNDATION_EXPORT NSString *const kFIRInstanceID_CMD_RST;
 FOUNDATION_EXPORT NSString *const kFIRInstanceIDCheckinFetchedNotification;
 FOUNDATION_EXPORT NSString *const kFIRInstanceIDAPNSTokenNotification;
 FOUNDATION_EXPORT NSString *const kFIRInstanceIDDefaultGCMTokenFailNotification;
-
+FOUNDATION_EXPORT NSString *const kFIRInstanceIDMessagingUpdateTokenNotification;
 FOUNDATION_EXPORT NSString *const kFIRInstanceIDIdentityInvalidatedNotification;
 
 #pragma mark - Miscellaneous

--- a/Firebase/InstanceID/FIRInstanceIDConstants.m
+++ b/Firebase/InstanceID/FIRInstanceIDConstants.m
@@ -24,7 +24,8 @@ NSString *const kFIRInstanceIDCheckinFetchedNotification = @"com.google.gcm.noti
 NSString *const kFIRInstanceIDAPNSTokenNotification = @"com.firebase.iid.notif.apns-token";
 NSString *const kFIRInstanceIDDefaultGCMTokenFailNotification =
     @"com.firebase.iid.notif.fcm-token-fail";
-
+NSString *const kFIRInstanceIDMessagingUpdateTokenNotification =
+    @"com.firebase.messaging.notif.fcm-token-refreshed";
 NSString *const kFIRInstanceIDIdentityInvalidatedNotification = @"com.google.iid.identity-invalid";
 
 // Miscellaneous

--- a/Firebase/InstanceID/FIRInstanceIDStore.h
+++ b/Firebase/InstanceID/FIRInstanceIDStore.h
@@ -85,6 +85,11 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)saveTokenInfo:(FIRInstanceIDTokenInfo *)tokenInfo handler:(void (^)(NSError *))handler;
 
+/*
+ * Save instanceID token info to cache only.
+ */
+- (void)saveTokenInfoInCacheOnly:(FIRInstanceIDTokenInfo *)tokenInfo;
+
 #pragma mark - Get
 
 /**

--- a/Firebase/InstanceID/FIRInstanceIDStore.m
+++ b/Firebase/InstanceID/FIRInstanceIDStore.m
@@ -202,6 +202,10 @@ static NSString *const kFIRInstanceIDLibraryVersion = @"GMSInstanceID-version";
   [self.tokenStore saveTokenInfo:tokenInfo handler:handler];
 }
 
+- (void)saveTokenInfoInCacheOnly:(FIRInstanceIDTokenInfo *)tokenInfo {
+  [self.tokenStore saveTokenInfoInCacheOnly:tokenInfo];
+}
+
 #pragma mark - Delete
 
 - (void)removeCachedTokenWithAuthorizedEntity:(NSString *)authorizedEntity scope:(NSString *)scope {

--- a/Firebase/InstanceID/FIRInstanceIDTokenManager.h
+++ b/Firebase/InstanceID/FIRInstanceIDTokenManager.h
@@ -146,4 +146,13 @@ typedef NS_OPTIONS(NSUInteger, FIRInstanceIDInvalidTokenReason) {
 - (NSArray<FIRInstanceIDTokenInfo *> *)updateTokensToAPNSDeviceToken:(NSData *)deviceToken
                                                            isSandbox:(BOOL)isSandbox;
 
+/*
+ * This method is only called when Messaging SDK is installed and a new token is triggered
+ * by Messaging.
+ * Update default token in cache if the token is updated from a newer versio of Messaging.
+ * This is used when newer version of Messaging SDK will update the token in storage
+ * and notify instanceID to update its own cache as well. No need to write to storage again.
+ */
+- (void)saveDefaultToken:(NSString *)defaultToken withOptions:(NSDictionary *)tokenOptions;
+
 @end

--- a/Firebase/InstanceID/FIRInstanceIDTokenManager.m
+++ b/Firebase/InstanceID/FIRInstanceIDTokenManager.m
@@ -27,6 +27,7 @@
 #import "FIRInstanceIDTokenFetchOperation.h"
 #import "FIRInstanceIDTokenInfo.h"
 #import "FIRInstanceIDTokenOperation.h"
+#import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "NSError+FIRInstanceID.h"
 
 @interface FIRInstanceIDTokenManager () <FIRInstanceIDStoreDelegate>
@@ -335,6 +336,19 @@
                                                           scope:tokenInfoToDelete.scope];
   }
   return tokenInfosToDelete;
+}
+
+- (void)saveDefaultToken:(NSString *)defaultToken withOptions:(NSDictionary *)tokenOptions {
+  FIROptions *options = FIRApp.defaultApp.options;
+  FIRInstanceIDTokenInfo *tokenInfo =
+      [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:options.GCMSenderID
+                                                         scope:@"*"
+                                                         token:defaultToken
+                                                    appVersion:FIRInstanceIDCurrentAppVersion()
+                                                 firebaseAppID:options.googleAppID];
+  tokenInfo.APNSInfo = [[FIRInstanceIDAPNSInfo alloc] initWithTokenOptionsDictionary:tokenOptions];
+
+  [self.instanceIDStore saveTokenInfoInCacheOnly:tokenInfo];
 }
 
 @end

--- a/Firebase/InstanceID/FIRInstanceIDTokenStore.h
+++ b/Firebase/InstanceID/FIRInstanceIDTokenStore.h
@@ -82,6 +82,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)saveTokenInfo:(FIRInstanceIDTokenInfo *)tokenInfo
               handler:(nullable void (^)(NSError *))handler;
 
+/*
+ * Save the instanceID token info to the cache only.
+ */
+- (void)saveTokenInfoInCacheOnly:(FIRInstanceIDTokenInfo *)tokenInfo;
+
 #pragma mark - Delete
 
 /**

--- a/Firebase/InstanceID/FIRInstanceIDTokenStore.m
+++ b/Firebase/InstanceID/FIRInstanceIDTokenStore.m
@@ -124,6 +124,20 @@ static NSString *const kFIRInstanceIDTokenKeychainId = @"com.google.iid-tokens";
   [self.keychain setData:tokenInfoData forService:service account:account handler:handler];
 }
 
+- (void)saveTokenInfoInCacheOnly:(FIRInstanceIDTokenInfo *)tokenInfo {
+  tokenInfo.cacheTime = [NSDate date];
+  // Always write to the Keychain, so that the cacheTime is up-to-date.
+  NSData *tokenInfoData;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  tokenInfoData = [NSKeyedArchiver archivedDataWithRootObject:tokenInfo];
+#pragma clang diagnostic pop
+  NSString *account = FIRInstanceIDAppIdentifier();
+  NSString *service = [[self class] serviceKeyForAuthorizedEntity:tokenInfo.authorizedEntity
+                                                            scope:tokenInfo.scope];
+  [self.keychain setDataInCache:tokenInfoData forService:service account:account];
+}
+
 #pragma mark - Delete
 
 - (void)removeTokenWithAuthorizedEntity:(nonnull NSString *)authorizedEntity

--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInstanceID'
-  s.version          = '4.5.2'
+  s.version          = '4.6.0'
   s.summary          = 'Firebase InstanceID'
 
   s.description      = <<-DESC

--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseInstanceID'
-  s.version          = '4.5.1'
+  s.version          = '4.5.2'
   s.summary          = 'Firebase InstanceID'
 
   s.description      = <<-DESC

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseMessaging'
-  s.version          = '4.6.1'
+  s.version          = '4.6.2'
   s.summary          = 'Firebase Messaging'
 
   s.description      = <<-DESC
@@ -55,7 +55,7 @@ device, and it is completely free.
   s.osx.framework = 'SystemConfiguration'
   s.weak_framework = 'UserNotifications'
   s.dependency 'FirebaseCore', '~> 6.10'
-  s.dependency 'FirebaseInstanceID', '~> 4.3'
+  s.dependency 'FirebaseInstanceID', '~> 4.5', '>= 4.5.2'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 6.7'
   s.dependency 'GoogleUtilities/Reachability', '~> 6.7'
   s.dependency 'GoogleUtilities/Environment', '~> 6.7'

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -55,7 +55,7 @@ device, and it is completely free.
   s.osx.framework = 'SystemConfiguration'
   s.weak_framework = 'UserNotifications'
   s.dependency 'FirebaseCore', '~> 6.10'
-  s.dependency 'FirebaseInstanceID', '~> 4.5', '>= 4.5.2'
+  s.dependency 'FirebaseInstanceID', '~> 4.6'
   s.dependency 'GoogleUtilities/AppDelegateSwizzler', '~> 6.7'
   s.dependency 'GoogleUtilities/Reachability', '~> 6.7'
   s.dependency 'GoogleUtilities/Environment', '~> 6.7'

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,4 +1,4 @@
-# unreleased
+# 2020-08 -- v.4.6.2
 - [fixed] Fixed an issue that topic doesn't work in watchOS. (#6160)
 
 # 2020-07 -- v4.6.1


### PR DESCRIPTION
When we release Messaging that removes InstanceID dependency, Messaging will handle FCM token on its own. However, developers might still depend on both Messaging and InstanceID, each has its own cache for token, but share the same storage(keychain). We need to add a method in InstanceID to listen to a notification from Messaging for token refresh, if that happens, InstanceID will update its cache, but not storage, as Messaging already updated it. 

We want developers to adopt this version before hand as we can't re-enforce iid version once messaging remove it from its dependency. So I updated the new version of messaging to depend on at least this version of IID.

Manual tested in the chen/fm-master branch which has the latest version of Messaging without IID dependency.
Add/delete token from Messaging API and try getToken in InstanceID should return the same token and FID.

Minor: 
Fixed an issue that the local defaultFCMToken is not updated when calling tokenWithAuthorizedEntity:scope:options:handler. This cause developers won't get notified of token update. It is not discovered probably because not so many developers use this API.