### PR TITLE
Get GoogleUtilitiesComponents from HEAD in symbol collision test

### DIFF
--- a/SymbolCollisionTest/Podfile
+++ b/SymbolCollisionTest/Podfile
@@ -36,6 +36,7 @@ target 'SymbolCollisionTest' do
     pod 'FirebaseStorage', :path => '../'
     pod 'GoogleDataTransport', :path => '../'
     pod 'GoogleUtilities', :path => '../'
+    pod 'GoogleUtilitiesComponents', :path => '../'
 
 #    pod 'FirebaseUI'. - requires use_frameworks!
 


### PR DESCRIPTION
The Symbol Collision test was failing in CI because the GoogleUtilitiesComponents version specified in SpecsStaging is not findable outside of new test infra.

#no-changelog