### PR TITLE
AppDistribution is only available for iOS

### DIFF
--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -72,6 +72,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
   s.subspec 'AppDistribution' do |ss|
     ss.dependency 'Firebase/CoreOnly'
     ss.ios.dependency 'FirebaseAppDistribution', '~> 0.9.0'
+    ss.ios.deployment_target = '9.0'
   end
 
   s.subspec 'Auth' do |ss|

--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -71,7 +71,7 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'AppDistribution' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    ss.dependency 'FirebaseAppDistribution', '~> 0.9.0'
+    ss.ios.dependency 'FirebaseAppDistribution', '~> 0.9.0'
   end
 
   s.subspec 'Auth' do |ss|


### PR DESCRIPTION
Update Firebase umbrella podspec for AppDistribution only supporting iOS platform and requiring at least 9.0

#no-changelog