### PR TITLE
Fix rendering of link in M78

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v6.9.0
 - [added] Added support for multi-tenancy (#6142).
 - [added] Added basic watchOS support. (#4621)
-- [channged] Improved Xcode completion of public API completion handlers in Swift. (#6283)
+- [changed] Improved Xcode completion of public API completion handlers in Swift. (#6283)
 
 # v6.8.0
 - [fixed] Fix bug where multiple keychain entries would result in user persistence failure. (#5906)

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v6.10.1 -- M78
 - [added] Beta release of Swift Package Manager. Details
-  [here]((https://github.com/firebase/firebase-ios-sdk/blob/master/SwiftPackageManager.md). (#3136)
+  [here](https://github.com/firebase/firebase-ios-sdk/blob/master/SwiftPackageManager.md). (#3136)
 - [changed] Firebase's dependencies on nanopb are updated from version 0.3.9.5 to
   version 0.3.9.6 (1.30906.0 in CocoaPods).
 


### PR DESCRIPTION
An extra parentheses prevented the link from rendering properly.