### PR TITLE
Restore master version of oss-manifest-generator

### DIFF
--- a/ZipBuilder/Sources/oss-manifest-generator/main.swift
+++ b/ZipBuilder/Sources/oss-manifest-generator/main.swift
@@ -98,7 +98,7 @@ struct OSSManifestGenerator: ParsableCommand {
       // We need to look at the full list of released SDKs to determine if a pod is open source or not.
       guard let existingPod = allSDKs.sdk.filter({ $0.name == pod.sdkName }).first else {
         print("ERROR")
-        print(allSDKs.sdk.map({ $0.name }).joined())
+        print(allSDKs.sdk.map { $0.name }.joined())
         fatalError("Found unexpected pod \(pod.sdkName) that isn't in list of all released SDKs.")
       }
 

--- a/ZipBuilder/Sources/oss-manifest-generator/main.swift
+++ b/ZipBuilder/Sources/oss-manifest-generator/main.swift
@@ -97,8 +97,6 @@ struct OSSManifestGenerator: ParsableCommand {
     for pod in loadedRelease.sdk {
       // We need to look at the full list of released SDKs to determine if a pod is open source or not.
       guard let existingPod = allSDKs.sdk.filter({ $0.name == pod.sdkName }).first else {
-        print("ERROR")
-        print(allSDKs.sdk.map { $0.name }.joined())
         fatalError("Found unexpected pod \(pod.sdkName) that isn't in list of all released SDKs.")
       }
 


### PR DESCRIPTION
The file was mistakenly checked in on the first release branch commit.

#no-changelog