### PR TITLE
Made public a method to create a stack frame from address.

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [added] Added stackFrameWithAddress API for recording custom errors that are symbolicated on the backend (#5975).
+
 # v4.5.0
 - [fixed] Fixed a compiler warning and removed unused networking code (#6210).
 - [fixed] Fixed a crash that occurred rarely when trying to restart a URL session task without a valid request (#5984).

--- a/Crashlytics/Crashlytics/FIRStackFrame.m
+++ b/Crashlytics/Crashlytics/FIRStackFrame.m
@@ -47,6 +47,14 @@
   return self;
 }
 
++ (instancetype)stackFrameWithAddress:(NSUInteger)address {
+  FIRStackFrame *frame = [self stackFrame];
+
+  [frame setAddress:address];
+
+  return frame;
+}
+
 + (instancetype)stackFrameWithSymbol:(NSString *)symbol file:(NSString *)file line:(NSInteger)line {
   return [[FIRStackFrame alloc] initWithSymbol:symbol file:file line:line];
 }
@@ -55,14 +63,6 @@
 
 + (instancetype)stackFrame {
   return [[self alloc] init];
-}
-
-+ (instancetype)stackFrameWithAddress:(NSUInteger)address {
-  FIRStackFrame *frame = [self stackFrame];
-
-  [frame setAddress:address];
-
-  return frame;
 }
 
 + (instancetype)stackFrameWithSymbol:(NSString *)symbol {

--- a/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRStackFrame.h
+++ b/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRStackFrame.h
@@ -37,6 +37,16 @@ NS_SWIFT_NAME(StackFrame)
 - (instancetype)initWithSymbol:(NSString *)symbol file:(NSString *)file line:(NSInteger)line;
 
 /**
+ * Creates a symbolicated Stack Frame from an address. The address will be
+ * symbolicated in the Crashlytics backend for the customer and reported in the
+ * Crahslytics dashboard with the appropriate file name and line number. If an
+ * invalid address is provided it will appear in the dashboard as <missing>.
+ *
+ * @param address - the address where the exception occurred
+ */
++ (instancetype)stackFrameWithAddress:(NSUInteger)address;
+
+/**
  * Creates a symbolicated Stack Frame with the given required fields. Symbolicated
  * Stack Frames will appear in the Crashlytics dashboard as reported in these fields. *
  *


### PR DESCRIPTION
Added a public method to allow stack frames to be created from addresses, as requested in https://github.com/firebase/firebase-ios-sdk/issues/5975.