### PR TITLE
App distribution add bundle header

### DIFF
--- a/FirebaseAppDistribution/CHANGELOG.md
+++ b/FirebaseAppDistribution/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [changed] Updated header comments (#6321).
+- [fixed] Bug for customers with restricted api keys unable to fetch releases
 
 # v0.9.0
 - Initial beta release.

--- a/FirebaseAppDistribution/CHANGELOG.md
+++ b/FirebaseAppDistribution/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - [changed] Updated header comments (#6321).
-- [fixed] Bug for customers with restricted api keys unable to fetch releases
+- [fixed] Bug for customers with restricted api keys unable to fetch releases.
 
 # v0.9.0
 - Initial beta release.

--- a/FirebaseAppDistribution/Sources/FIRFADApiService.m
+++ b/FirebaseAppDistribution/Sources/FIRFADApiService.m
@@ -26,6 +26,7 @@ NSString *const kReleasesEndpointURLTemplate =
     @"-/testerApps/%@/installations/%@/releases";
 NSString *const kInstallationAuthHeader = @"X-Goog-Firebase-Installations-Auth";
 NSString *const kApiHeaderKey = @"X-Goog-Api-Key";
+NSString *const kApiBundleKey = @"X-Ios-Bundle-Identifier";
 NSString *const kResponseReleasesKey = @"releases";
 
 @implementation FIRFADApiService
@@ -73,6 +74,7 @@ NSString *const kResponseReleasesKey = @"releases";
   [request setHTTPMethod:method];
   [request setValue:authTokenResult.authToken forHTTPHeaderField:kInstallationAuthHeader];
   [request setValue:[[FIRApp defaultApp] options].APIKey forHTTPHeaderField:kApiHeaderKey];
+  [request setValue:[NSBundle mainBundle].bundleIdentifier forHTTPHeaderField:kApiBundleKey];
   return request;
 }
 


### PR DESCRIPTION
### Description
Customers with restricted api keys reported being unable to see new build alerts and saw repeated prompts for login

### Changes
* Added x-ios-bundle-identifier for api keys restricted to ios apps
