### PR TITLE
Restore Firebase.h to pre-6.28.0 style

### DIFF
--- a/CoreOnly/Sources/Firebase.h
+++ b/CoreOnly/Sources/Firebase.h
@@ -12,45 +12,30 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The module qualified imports are for CocoaPods and the simple file names
-// for Swift Package Manager.
+#import <FirebaseCore/FirebaseCore.h>
 
 #if !defined(__has_include)
   #error "Firebase.h won't import anything if your compiler doesn't support __has_include. Please \
           import the headers individually."
 #else
-  #if __has_include(<FirebaseCore/FirebaseCore.h>)
-    #import <FirebaseCore/FirebaseCore.h>
-  #elif __has_include("FirebaseCore.h")
-    #import "FirebaseCore.h"
-  #endif
-
   #if __has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
     #import <FirebaseAnalytics/FirebaseAnalytics.h>
   #endif
 
-  #if __has_include(<FirebaseAuth/FirebaseAuth.h>)
-    #import <FirebaseAuth/FirebaseAuth.h>
-  #elif __has_include("FirebaseAuth.h")
-    #import "FirebaseAuth.h"
-  #endif
-
   #if __has_include(<FirebaseAppDistribution/FirebaseAppDistribution.h>)
     #import <FirebaseAppDistribution/FirebaseAppDistribution.h>
-  #elif  __has_include("FirebaseAppDistribution.h")
-    #import "FirebaseAppDistribution.h"
+  #endif
+
+  #if __has_include(<FirebaseAuth/FirebaseAuth.h>)
+    #import <FirebaseAuth/FirebaseAuth.h>
   #endif
 
   #if __has_include(<FirebaseCrashlytics/FirebaseCrashlytics.h>)
     #import <FirebaseCrashlytics/FirebaseCrashlytics.h>
-  #elif  __has_include("FirebaseCrashlytics.h")
-    #import "FirebaseCrashlytics.h"
   #endif
 
   #if __has_include(<FirebaseDatabase/FirebaseDatabase.h>)
     #import <FirebaseDatabase/FirebaseDatabase.h>
-  #elif __has_include("FirebaseDatabase.h")
-    #import "FirebaseDatabase.h"
   #endif
 
   #if __has_include(<FirebaseDynamicLinks/FirebaseDynamicLinks.h>)
@@ -62,20 +47,14 @@
 Firebase Dynamic Links works as intended."
       #endif // #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
     #endif
-  #elif __has_include("FirebaseDynamicLinks.h")
-    #import "FirebaseDynamicLinks.h"
   #endif
 
   #if __has_include(<FirebaseFirestore/FirebaseFirestore.h>)
     #import <FirebaseFirestore/FirebaseFirestore.h>
-  #elif __has_include("FirebaseFirestore.h")
-    #import "FirebaseFirestore.h"
   #endif
 
   #if __has_include(<FirebaseFunctions/FirebaseFunctions.h>)
     #import <FirebaseFunctions/FirebaseFunctions.h>
-  #elif __has_include("FirebaseFunctions.h")
-    #import "FirebaseFunctions.h"
   #endif
 
   #if __has_include(<FirebaseInAppMessaging/FirebaseInAppMessaging.h>)
@@ -87,8 +66,6 @@ Firebase Dynamic Links works as intended."
 Firebase In App Messaging works as intended."
       #endif // #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
     #endif
-  #elif __has_include("FirebaseInAppMessaging.h")
-    #import "FirebaseInAppMessaging.h"
   #endif
 
   #if __has_include(<FirebaseInstanceID/FirebaseInstanceID.h>)
@@ -104,8 +81,6 @@ Firebase In App Messaging works as intended."
 Firebase Messaging works as intended."
       #endif // #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
     #endif
-  #elif __has_include("FirebaseMessaging.h")
-    #import "FirebaseMessaging.h"
   #endif
 
   #if __has_include(<FirebaseMLCommon/FirebaseMLCommon.h>)
@@ -180,14 +155,10 @@ Firebase Performance works as intended."
 Firebase Remote Config works as intended."
       #endif // #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
     #endif
-  #elif __has_include("FirebaseRemoteConfig.h")
-    #import "FirebaseRemoteConfig.h"
   #endif
 
   #if __has_include(<FirebaseStorage/FirebaseStorage.h>)
     #import <FirebaseStorage/FirebaseStorage.h>
-  #elif __has_include("FirebaseStorage.h")
-    #import "FirebaseStorage.h"
   #endif
 
   #if __has_include(<GoogleMobileAds/GoogleMobileAds.h>)

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Sporadic missing FirebaseApp symbol build issue introduced in Firebase 6.28.0. (#6341)
+
+
 # v6.10.1 -- M78
 - [added] Beta release of Swift Package Manager. Details
   [here](https://github.com/firebase/firebase-ios-sdk/blob/master/SwiftPackageManager.md). (#3136)


### PR DESCRIPTION
now that SPM supports same public header path as CocoaPods

It seems the ifdef around FirebaseCore.h contributed to an Xcode build race condition where the app could try to build before FirebaseCore.

Fix #6341 
