### PR TITLE
Enable ABT to be a soft dep of RC

### DIFF
--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -35,7 +35,10 @@ jobs:
           FirebaseRemoteConfig/Tests/SwiftAPI/AccessToken.json
     - name: BuildAndUnitTest # can be replaced with pod lib lint with CocoaPods 1.10
       run: scripts/third_party/travis/retry.sh scripts/build.sh RemoteConfig ${{ matrix.target }} unit
+    - name: BuildAndUnitTest # can be replaced with pod lib lint with CocoaPods 1.10
+      run: scripts/third_party/travis/retry.sh scripts/build.sh RemoteConfig ${{ matrix.target }} abt
     - name: Fake Console API Tests
+      if: matrix.target == 'iOS'
       run: scripts/third_party/travis/retry.sh scripts/build.sh RemoteConfig iOS fakeconsole
     - name: IntegrationTest
       if: matrix.target == 'iOS'

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
     - 'FirebaseRemoteConfig**'
+    - 'FirebaseABTesting/Sources/Interop/**'
     - 'Interop/Analytics/Public/*.h'
     - '.github/workflows/remoteconfig.yml'
     - 'Gemfile'

--- a/AddNewPod.md
+++ b/AddNewPod.md
@@ -41,6 +41,8 @@ non-Google open source project should be nested under a `third_party` directory.
 * `FirebaseFoo/Sources/Public` - Public Headers.
 * `FirebaseFoo/Sources/Private` - Private Headers (headers not part of public API, but available for
 explicit import by other Firebase pods)
+* `FirebaseFoo/Sources/Interop` - Headers to manage soft dependencies via 
+[Interop](Interop/FirebaseComponentSystem.md).
 * `FirebaseFoo/Tests/Unit` - Required (If the library only has unit tests, `Unit` can be omitted.)
 * `FirebaseFoo/Tests/Integration` - Encouraged
 * `FirebaseFoo/Tests/Sample` - Optional

--- a/AddNewPod.md
+++ b/AddNewPod.md
@@ -41,7 +41,7 @@ non-Google open source project should be nested under a `third_party` directory.
 * `FirebaseFoo/Sources/Public` - Public Headers.
 * `FirebaseFoo/Sources/Private` - Private Headers (headers not part of public API, but available for
 explicit import by other Firebase pods)
-* `FirebaseFoo/Sources/Interop` - Headers to manage soft dependencies via 
+* `FirebaseFoo/Sources/Interop` - Headers to manage soft dependencies via
 [Interop](Interop/FirebaseComponentSystem.md).
 * `FirebaseFoo/Tests/Unit` - Required (If the library only has unit tests, `Unit` can be omitted.)
 * `FirebaseFoo/Tests/Integration` - Encouraged

--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseABTesting'
-  s.version          = '4.2.0'
+  s.version          = '4.3.0'
   s.summary          = 'Firebase ABTesting'
 
   s.description      = <<-DESC

--- a/FirebaseABTesting/CHANGELOG.md
+++ b/FirebaseABTesting/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v4.3.0
+- [changed] Enabled Firebase ABTesting to be a soft dependency. To use enable ABTesting,
+  make sure to include `Firebase/ABTesting` in the Podfile. This will be required at the next
+  major release.
+
 # v4.1.0
 - [changed] Functionally neutral source reorganization for preliminary Swift Package Manager support. (#6016)
 

--- a/FirebaseABTesting/Sources/Interop/FIRABTInterop.h
+++ b/FirebaseABTesting/Sources/Interop/FIRABTInterop.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Connector for bridging communication between Firebase SDKs and FirebaseABTesting API.
+@protocol FIRABTInterop
+
+/// Updates the list of experiments. Experiments already
+/// existing in payloads are not affected, whose state and payload is preserved. This method
+/// compares whether the experiments have changed or not by their variant ID. This runs in a
+/// background queue..
+/// @param origin         The originating service affected by the experiment.
+/// @param lastStartTime  The last known experiment start timestamp for this affected service.
+///                       (Timestamps are specified by the number of seconds from 00:00:00 UTC on 1
+///                       January 1970.).
+/// @param payloads       List of experiment metadata.
+- (void)updateExperimentsWithServiceOrigin:(NSString *)origin
+                             lastStartTime:(NSTimeInterval)lastStartTime
+                                  payloads:(NSArray<NSData *> *)payloads;
+
+/// Returns the latest experiment start timestamp given a current latest timestamp and a list of
+/// experiment payloads. Timestamps are specified by the number of seconds from 00:00:00 UTC on 1
+/// January 1970.
+/// @param timestamp  Current latest experiment start timestamp. If not known, affected service
+///                   should specify -1;
+/// @param payloads   List of experiment metadata.
+- (NSTimeInterval)latestExperimentStartTimestampBetweenTimestamp:(NSTimeInterval)timestamp
+                                                     andPayloads:(NSArray<NSData *> *)payloads;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/FirebaseABTesting/Sources/Interop/FIRABTInterop.h
+++ b/FirebaseABTesting/Sources/Interop/FIRABTInterop.h
@@ -21,10 +21,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Connector for bridging communication between Firebase SDKs and FirebaseABTesting API.
 @protocol FIRABTInterop
 
-/// Updates the list of experiments. Experiments already
-/// existing in payloads are not affected, whose state and payload is preserved. This method
-/// compares whether the experiments have changed or not by their variant ID. This runs in a
-/// background queue..
+/// Updates the list of experiments. Experiments already existing in payloads are not affected,
+/// whose state and payload is preserved. This method compares whether the experiments have
+/// changed or not by their variant ID. This runs in a background queue.
 /// @param origin         The originating service affected by the experiment.
 /// @param lastStartTime  The last known experiment start timestamp for this affected service.
 ///                       (Timestamps are specified by the number of seconds from 00:00:00 UTC on 1

--- a/FirebaseABTesting/Sources/Public/FirebaseABTesting/FIRExperimentController.h
+++ b/FirebaseABTesting/Sources/Public/FirebaseABTesting/FIRExperimentController.h
@@ -57,10 +57,9 @@ NS_SWIFT_NAME(ExperimentController)
                          completionHandler:
                              (nullable void (^)(NSError *_Nullable error))completionHandler;
 
-/// Updates the list of experiments. Experiments already
-/// existing in payloads are not affected, whose state and payload is preserved. This method
-/// compares whether the experiments have changed or not by their variant ID. This runs in a
-/// background queue..
+/// Updates the list of experiments. Experiments already existing in payloads are not affected,
+/// whose state and payload is preserved. This method compares whether the experiments have
+/// changed or not by their variant ID. This runs in a background queue.
 /// @param origin         The originating service affected by the experiment.
 /// @param events         A list of event names to be used for logging experiment lifecycle events,
 ///                       if they are not defined in the payload.

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -45,7 +45,8 @@ app update.
       'FIRRemoteConfig_VERSION=' + String(s.version),
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
   }
-#  s.dependency 'FirebaseABTesting', '~> 4.2'
+  # TODO(7.0) The FirebaseABTesting dependency should be removed at next major version update.
+  s.dependency 'FirebaseABTesting', '~> 4.2'
   s.dependency 'FirebaseCore', '~> 6.10'
   s.dependency 'FirebaseInstallations', '~> 1.6'
   s.dependency 'GoogleUtilities/Environment', '~> 6.7'

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -59,7 +59,6 @@ app update.
         'FirebaseRemoteConfig/Tests/Unit/RCNConfigDBManagerTest.m',
 #        'FirebaseRemoteConfig/Tests/Unit/RCNConfigSettingsTest.m',
 #        'FirebaseRemoteConfig/Tests/Unit/RCNConfigTest.m',
-        'FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m',
         'FirebaseRemoteConfig/Tests/Unit/RCNConfigValueTest.m',
 #        'FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfig+FIRAppTest.m',
         'FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m',

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -30,7 +30,7 @@ app update.
   s.source_files = [
     base_dir + '**/*.[mh]',
     'Interop/Analytics/Public/*.h',
-    'FirebaseABTesting/Sources/Private/*.h',
+    'FirebaseABTesting/Sources/Interop/*.h',
     'FirebaseCore/Sources/Private/*.h',
     'FirebaseInstallations/Source/Library/Private/*.h',
     'GoogleUtilities/Environment/Private/*.h',
@@ -45,7 +45,7 @@ app update.
       'FIRRemoteConfig_VERSION=' + String(s.version),
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
   }
-  s.dependency 'FirebaseABTesting', '~> 4.2'
+#  s.dependency 'FirebaseABTesting', '~> 4.2'
   s.dependency 'FirebaseCore', '~> 6.10'
   s.dependency 'FirebaseInstallations', '~> 1.6'
   s.dependency 'GoogleUtilities/Environment', '~> 6.7'
@@ -76,6 +76,22 @@ app update.
     unit_tests.requires_app_host = true
     unit_tests.dependency 'OCMock'
     unit_tests.requires_arc = true
+  end
+
+  # Separate unit tests that require FirebaseABTesting.
+  s.test_spec 'abt' do |abt|
+    abt.source_files = [
+        'FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m',
+        'FirebaseRemoteConfig/Tests/Unit/RCNTestUtilities.[hm]',
+        'FirebaseABTesting/Sources/Private/*.h',
+    ]
+    abt.resources = [
+        'FirebaseRemoteConfig/Tests/Unit/TestABTPayload.txt',
+    ]
+    abt.requires_app_host = true
+    abt.dependency 'OCMock'
+    abt.dependency 'FirebaseABTesting', '~> 4.2'
+    abt.requires_arc = true
   end
 
   # Run Swift API tests on a real backend.

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -90,7 +90,7 @@ app update.
     ]
     abt.requires_app_host = true
     abt.dependency 'OCMock'
-    abt.dependency 'FirebaseABTesting', '~> 4.2'
+    abt.dependency 'FirebaseABTesting', '~> 4.3'
     abt.requires_arc = true
   end
 

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseRemoteConfig'
-  s.version          = '4.9.0'
+  s.version          = '4.10.0'
   s.summary          = 'Firebase Remote Config'
 
   s.description      = <<-DESC
@@ -46,7 +46,7 @@ app update.
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}"'
   }
   # TODO(7.0) The FirebaseABTesting dependency should be removed at next major version update.
-  s.dependency 'FirebaseABTesting', '~> 4.2'
+  s.dependency 'FirebaseABTesting', '~> 4.3'
   s.dependency 'FirebaseCore', '~> 6.10'
   s.dependency 'FirebaseInstallations', '~> 1.6'
   s.dependency 'GoogleUtilities/Environment', '~> 6.7'

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Unreleased
+# Unreleased
 - [changed] Enabled Firebase ABTesting to be a soft dependency. To use enable ABTesting,
   make sure to include `Firebase/ABTesting` in the Podfile. This will be required at the next
   major release.

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,3 +1,8 @@
+- Unreleased
+- [changed] Enabled Firebase ABTesting to be a soft dependency. To use enable ABTesting,
+  make sure to include `Firebase/ABTesting` in the Podfile. This will be required at the next
+  major release.
+
 # v4.9.0
 - [fixed] Fixed `FirebaseApp.delete()` related crash in `RC Config Fetch`. (#6123)
 

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,5 +1,5 @@
-# Unreleased
-- [changed] Enabled Firebase ABTesting to be a soft dependency. To use enable ABTesting,
+# v4.10.0
+- [changed] Enable usage of Firebase ABTesting as a soft dependency. To use enable ABTesting,
   make sure to include `Firebase/ABTesting` in the Podfile. This will be required at the next
   major release.
 

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -16,7 +16,6 @@
 
 #import "FirebaseRemoteConfig/Sources/Public/FirebaseRemoteConfig/FIRRemoteConfig.h"
 
-#import "FirebaseABTesting/Sources/Private/FirebaseABTestingInternal.h"
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "FirebaseRemoteConfig/Sources/FIRRemoteConfigComponent.h"
 #import "FirebaseRemoteConfig/Sources/Private/FIRRemoteConfig_Private.h"
@@ -28,6 +27,9 @@
 #import "FirebaseRemoteConfig/Sources/RCNConfigExperiment.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigValue_Internal.h"
 #import "FirebaseRemoteConfig/Sources/RCNDevice.h"
+
+#import "FirebaseABTesting/Sources/Interop/FIRABTInterop.h"
+#import "Interop/Analytics/Public/FIRAnalyticsInterop.h"
 
 /// Remote Config Error Domain.
 /// TODO: Rename according to obj-c style for constants.
@@ -144,7 +146,8 @@ static NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, FIRRemote
                       namespace:(NSString *)FIRNamespace
                       DBManager:(RCNConfigDBManager *)DBManager
                   configContent:(RCNConfigContent *)configContent
-                      analytics:(nullable id<FIRAnalyticsInterop>)analytics {
+                      analytics:(nullable id<FIRAnalyticsInterop>)analytics
+                      abtesting:(nullable id<FIRABTInterop>)abtesting {
   self = [super init];
   if (self) {
     _appName = appName;
@@ -159,9 +162,10 @@ static NSMutableDictionary<NSString *, NSMutableDictionary<NSString *, FIRRemote
                                                    firebaseAppName:appName
                                                        googleAppID:options.googleAppID];
 
-    FIRExperimentController *experimentController = [FIRExperimentController sharedInstance];
-    _configExperiment = [[RCNConfigExperiment alloc] initWithDBManager:_DBManager
-                                                  experimentController:experimentController];
+    if (abtesting != nil) {
+      _configExperiment = [[RCNConfigExperiment alloc] initWithDBManager:_DBManager
+                                                    experimentController:abtesting];
+    }
     /// Serial queue for read and write lock.
     _queue = [FIRRemoteConfig sharedRemoteConfigSerialQueue];
 

--- a/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
+++ b/FirebaseRemoteConfig/Sources/FIRRemoteConfig.m
@@ -16,6 +16,9 @@
 
 #import "FirebaseRemoteConfig/Sources/Public/FirebaseRemoteConfig/FIRRemoteConfig.h"
 
+#import "FirebaseABTesting/Sources/Interop/FIRABTInterop.h"
+#import "Interop/Analytics/Public/FIRAnalyticsInterop.h"
+
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "FirebaseRemoteConfig/Sources/FIRRemoteConfigComponent.h"
 #import "FirebaseRemoteConfig/Sources/Private/FIRRemoteConfig_Private.h"
@@ -27,9 +30,6 @@
 #import "FirebaseRemoteConfig/Sources/RCNConfigExperiment.h"
 #import "FirebaseRemoteConfig/Sources/RCNConfigValue_Internal.h"
 #import "FirebaseRemoteConfig/Sources/RCNDevice.h"
-
-#import "FirebaseABTesting/Sources/Interop/FIRABTInterop.h"
-#import "Interop/Analytics/Public/FIRAnalyticsInterop.h"
 
 /// Remote Config Error Domain.
 /// TODO: Rename according to obj-c style for constants.

--- a/FirebaseRemoteConfig/Sources/Private/FIRRemoteConfig_Private.h
+++ b/FirebaseRemoteConfig/Sources/Private/FIRRemoteConfig_Private.h
@@ -22,6 +22,7 @@
 @class RCNConfigDBManager;
 @class RCNConfigFetch;
 @protocol FIRAnalyticsInterop;
+@protocol FIRABTInterop;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -67,7 +68,8 @@ NS_ASSUME_NONNULL_BEGIN
                       namespace:(NSString *)FIRNamespace
                       DBManager:(RCNConfigDBManager *)DBManager
                   configContent:(RCNConfigContent *)configContent
-                      analytics:(nullable id<FIRAnalyticsInterop>)analytics;
+                      analytics:(nullable id<FIRAnalyticsInterop>)analytics
+                      abtesting:(nullable id<FIRABTInterop>)abtesting;
 
 @end
 

--- a/FirebaseRemoteConfig/Sources/RCNConfigExperiment.h
+++ b/FirebaseRemoteConfig/Sources/RCNConfigExperiment.h
@@ -16,7 +16,9 @@
 
 #import <Foundation/Foundation.h>
 
-@class FIRExperimentController;
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol FIRABTInterop;
 @class RCNConfigDBManager;
 
 /// Handles experiment information update and persistence.
@@ -24,7 +26,7 @@
 
 /// Designated initializer;
 - (instancetype)initWithDBManager:(RCNConfigDBManager *)DBManager
-             experimentController:(FIRExperimentController *)controller NS_DESIGNATED_INITIALIZER;
+             experimentController:(id<FIRABTInterop>)connector NS_DESIGNATED_INITIALIZER;
 
 /// Use `initWithDBManager:` instead.
 - (instancetype)init NS_UNAVAILABLE;
@@ -34,4 +36,6 @@
 
 /// Update experiments to Firebase Analytics when activateFetched happens.
 - (void)updateExperiments;
+
+NS_ASSUME_NONNULL_END
 @end

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m
@@ -86,8 +86,9 @@
 
   FIRExperimentController *experimentController =
       [[FIRExperimentController alloc] initWithAnalytics:nil];
-  _configExperiment = [[RCNConfigExperiment alloc] initWithDBManager:_DBManagerMock
-                                                experimentController:experimentController];
+  _configExperiment =
+      [[RCNConfigExperiment alloc] initWithDBManager:_DBManagerMock
+                                experimentController:(id<FIRABTInterop>)experimentController];
 }
 
 - (void)tearDown {

--- a/FirebaseRemoteConfig/Tests/Unit/RCNInstanceIDTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNInstanceIDTest.m
@@ -153,7 +153,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
                                                       namespace:currentNamespace
                                                       DBManager:_DBManager
                                                   configContent:configContent
-                                                      analytics:nil]);
+                                                      analytics:nil
+                                                      abtesting:nil]);
 
     _configInstances[i] = config;
     RCNConfigSettings *settings =

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -171,7 +171,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
                                                       namespace:currentNamespace
                                                       DBManager:_DBManager
                                                   configContent:configContent
-                                                      analytics:nil]);
+                                                      analytics:nil
+                                                      abtesting:nil]);
 
     _configInstances[i] = config;
     RCNConfigSettings *settings =
@@ -493,7 +494,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
                                                       namespace:currentNamespace
                                                       DBManager:_DBManager
                                                   configContent:configContent
-                                                      analytics:nil]);
+                                                      analytics:nil
+                                                      abtesting:nil]);
 
     _configInstances[i] = config;
     RCNConfigSettings *settings =
@@ -616,7 +618,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
                                                       namespace:currentNamespace
                                                       DBManager:_DBManager
                                                   configContent:configContent
-                                                      analytics:nil]);
+                                                      analytics:nil
+                                                      abtesting:nil]);
 
     _configInstances[i] = config;
     RCNConfigSettings *settings =
@@ -740,7 +743,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
                                                       namespace:currentNamespace
                                                       DBManager:_DBManager
                                                   configContent:configContent
-                                                      analytics:nil]);
+                                                      analytics:nil
+                                                      abtesting:nil]);
 
     _configInstances[i] = config;
     RCNConfigSettings *settings =

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -427,6 +427,16 @@ case "$product-$platform-$method" in
       test
     ;;
 
+  RemoteConfig-*-abt)
+    pod_gen FirebaseRemoteConfig.podspec --platforms="${gen_platform}"
+    RunXcodebuild \
+      -workspace 'gen/FirebaseRemoteConfig/FirebaseRemoteConfig.xcworkspace' \
+      -scheme "FirebaseRemoteConfig-Unit-abt" \
+      "${xcb_flags[@]}" \
+      build \
+      test
+    ;;
+
   RemoteConfig-*-fakeconsole)
     pod_gen FirebaseRemoteConfig.podspec --platforms="${gen_platform}"
     RunXcodebuild \


### PR DESCRIPTION
Fix one of the issues raised in #6345.

- Propose a new location for Interop headers in the one version world.
- Add two Interop APIs for the RC -> ABT interface
- Tested with ABTesting removed from the RC podspec, but added it back until 7.0
- Added a separate unit test target for combined RC and ABT testing
- Will wait for M79 code freeze branch before merging.

#no-changelog