### PR TITLE
redact UDID information from binary image data

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 - [added] Added stackFrameWithAddress API for recording custom errors that are symbolicated on the backend (#5975).
 - [fixed] Fixed comment typos (#6363).
+- [fixed] Remove device information from binary image data crash info entries (#6382).
 
 # v4.5.0
 - [fixed] Fixed a compiler warning and removed unused networking code (#6210).

--- a/Crashlytics/Crashlytics/Components/FIRCLSProcess.c
+++ b/Crashlytics/Crashlytics/Components/FIRCLSProcess.c
@@ -800,6 +800,12 @@ static void FIRCLSProcessRecordCrashInfo(FIRCLSFile *file) {
       continue;
     }
 
+    // The crash_info_t's message may contain the device's UDID, in this case,
+    // make sure that we do our best to redact that information before writing the
+    // rest of the message to disk. This also has the effect of not uploading that
+    // information in the subsequent crash report.
+    FIRCLSRedactUUID(string);
+
     FIRCLSFileWriteArrayEntryHexEncodedString(file, string);
   }
 }

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSUtility.h
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSUtility.h
@@ -35,6 +35,7 @@ bool FIRCLSReadString(vm_address_t src, char** dest, size_t maxlen);
 const char* FIRCLSDupString(const char* string);
 
 bool FIRCLSUnlinkIfExists(const char* path);
+void FIRCLSRedactUUID(char* value);
 
 #if __OBJC__
 void FIRCLSDispatchAfter(float timeInSeconds, dispatch_queue_t queue, dispatch_block_t block);

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSUtility.m
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSUtility.m
@@ -177,8 +177,9 @@ void FIRCLSRedactUUID(char* value) {
     // and replace anything that is not a '-' with '*'
     if (closeParen - openParen == 37) {
       for (int i = 1; i < 37; ++i) {
-        if (*(openParen + i) != '-')
+        if (*(openParen + i) != '-') {
           *(openParen + i) = '*';
+        }
       }
       break;
     }

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSUtility.m
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSUtility.m
@@ -156,6 +156,36 @@ NSString* FIRCLSGenerateNormalizedUUID(void) {
   return FIRCLSNormalizeUUID(FIRCLSGenerateUUID());
 }
 
+// Redacts a UUID wrapped in parenthesis from a char* using strchr, which is async safe.
+// Ex.
+//   "foo (bar) (45D62CC2-CFB5-4E33-AB61-B0684627F1B6) baz"
+// becomes
+//   "foo (bar) (********-****-****-****-************) baz"
+void FIRCLSRedactUUID(char* value) {
+  if (value == NULL) {
+    return;
+  }
+  char* openParen = value;
+  // find the index of the first paren
+  while ((openParen = strchr(openParen, '(')) != NULL) {
+    // find index of the matching close paren
+    const char* closeParen = strchr(openParen, ')');
+    if (closeParen == NULL) {
+      break;
+    }
+    // if the distance between them is 37, traverse the characters
+    // and replace anything that is not a '-' with '*'
+    if (closeParen - openParen == 37) {
+      for (int i = 1; i < 37; ++i) {
+        if (*(openParen + i) != '-')
+          *(openParen + i) = '*';
+      }
+      break;
+    }
+    openParen++;
+  }
+}
+
 NSString* FIRCLSNSDataToNSString(NSData* data) {
   NSString* string;
   char* buffer;

--- a/Crashlytics/UnitTests/FIRCLSUtilityTests.m
+++ b/Crashlytics/UnitTests/FIRCLSUtilityTests.m
@@ -77,4 +77,52 @@
   XCTAssertEqualObjects([NSString stringWithUTF8String:string], @"52d04e1f", @"");
 }
 
+- (void)testRedactUUIDWithExpectedPattern {
+  const char* readonly = "CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) (45D62CC2-CFB5-4E33-AB61-B0684627F1B6) - Runtime: iOS 13.4 (17E8260) - DeviceType: iPhone SE (2nd generation)";
+  size_t len = strlen(readonly);
+  char message[len];
+  strcpy(message, readonly);
+
+  FIRCLSRedactUUID(message);
+
+  NSString* actual = [NSString stringWithUTF8String:message];
+  NSString* expected = @"CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) (********-****-****-****-************) - Runtime: iOS 13.4 (17E8260) - DeviceType: iPhone SE (2nd generation)";
+
+  XCTAssertEqualObjects(actual, expected);
+}
+
+- (void)testRedactUUIDWithMalformedPattern {
+  const char* readonly = "CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) (45D62CC2-CFB5-4E33-AB61-B0684627F1B6";
+  size_t len = strlen(readonly);
+  char message[len];
+  strcpy(message, readonly);
+
+  FIRCLSRedactUUID(message);
+
+  NSString* actual = [NSString stringWithUTF8String:message];
+  NSString* expected = @"CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) (45D62CC2-CFB5-4E33-AB61-B0684627F1B6";
+
+  XCTAssertEqualObjects(actual, expected);
+}
+
+- (void)testRedactUUIDWithoutUUID {
+  const char* readonly = "Fatal error: file /Users/test/src/foo/bar/ViewController.swift, line 25";
+  size_t len = strlen(readonly);
+  char message[len];
+  strcpy(message, readonly);
+
+  FIRCLSRedactUUID(message);
+
+  char* redacted = "Fatal error: file /Users/test/src/foo/bar/ViewController.swift, line 25";
+
+  NSString* actual = [NSString stringWithUTF8String:message];
+  NSString* expected = [NSString stringWithUTF8String:redacted];
+
+  XCTAssertEqualObjects(actual, expected);
+}
+
+- (void)testRedactUUIDWithNull {
+  char* message = NULL;
+  XCTAssertNoThrow(FIRCLSRedactUUID(message));
+}
 @end

--- a/Crashlytics/UnitTests/FIRCLSUtilityTests.m
+++ b/Crashlytics/UnitTests/FIRCLSUtilityTests.m
@@ -119,10 +119,8 @@
 
   FIRCLSRedactUUID(message);
 
-  char* redacted = "Fatal error: file /Users/test/src/foo/bar/ViewController.swift, line 25";
-
   NSString* actual = [NSString stringWithUTF8String:message];
-  NSString* expected = [NSString stringWithUTF8String:redacted];
+  NSString* expected = @"Fatal error: file /Users/test/src/foo/bar/ViewController.swift, line 25";
 
   XCTAssertEqualObjects(actual, expected);
 }

--- a/Crashlytics/UnitTests/FIRCLSUtilityTests.m
+++ b/Crashlytics/UnitTests/FIRCLSUtilityTests.m
@@ -78,7 +78,9 @@
 }
 
 - (void)testRedactUUIDWithExpectedPattern {
-  const char* readonly = "CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) (45D62CC2-CFB5-4E33-AB61-B0684627F1B6) - Runtime: iOS 13.4 (17E8260) - DeviceType: iPhone SE (2nd generation)";
+  const char* readonly = "CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) "
+                         "(45D62CC2-CFB5-4E33-AB61-B0684627F1B6) - Runtime: iOS 13.4 (17E8260) - "
+                         "DeviceType: iPhone SE (2nd generation)";
   size_t len = strlen(readonly);
   char message[len];
   strcpy(message, readonly);
@@ -86,13 +88,16 @@
   FIRCLSRedactUUID(message);
 
   NSString* actual = [NSString stringWithUTF8String:message];
-  NSString* expected = @"CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) (********-****-****-****-************) - Runtime: iOS 13.4 (17E8260) - DeviceType: iPhone SE (2nd generation)";
+  NSString* expected = @"CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) "
+                       @"(********-****-****-****-************) - Runtime: iOS 13.4 (17E8260) - "
+                       @"DeviceType: iPhone SE (2nd generation)";
 
   XCTAssertEqualObjects(actual, expected);
 }
 
 - (void)testRedactUUIDWithMalformedPattern {
-  const char* readonly = "CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) (45D62CC2-CFB5-4E33-AB61-B0684627F1B6";
+  const char* readonly = "CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) "
+                         "(45D62CC2-CFB5-4E33-AB61-B0684627F1B6";
   size_t len = strlen(readonly);
   char message[len];
   strcpy(message, readonly);
@@ -100,7 +105,8 @@
   FIRCLSRedactUUID(message);
 
   NSString* actual = [NSString stringWithUTF8String:message];
-  NSString* expected = @"CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) (45D62CC2-CFB5-4E33-AB61-B0684627F1B6";
+  NSString* expected = @"CoreSimulator 704.12.1 - Device: iPhone SE (2nd generation) "
+                       @"(45D62CC2-CFB5-4E33-AB61-B0684627F1B6";
 
   XCTAssertEqualObjects(actual, expected);
 }


### PR DESCRIPTION
It's possible that the binary image data loaded from the OS includes the device's UDID. This makes a best effort at redacting that data before the crash report is written to disk.
