### PR TITLE
Remove -fmodules from CMake C++ compilation flags.

### DIFF
--- a/cmake/compiler_setup.cmake
+++ b/cmake/compiler_setup.cmake
@@ -85,7 +85,6 @@ if(APPLE)
   set(
     FIREBASE_IOS_OBJC_FLAGS
     -fobjc-arc
-    -fmodules
     -fno-autolink
   )
   set(


### PR DESCRIPTION
This option doesn't work with C++, and even though the clang compiler
ignores it, clangd does not, and this causes syntax highlighting
failures in CLion.