### PR TITLE
Removing client id usage in api call and respective checks

### DIFF
--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,5 +1,5 @@
 # v4.3.1
-- [removed] Client id usage in api call and respective checks in the code.
+- [changed] Client id usage in api call and respective checks in the code.
 
 # v4.3.0
 - [changed] Functionally neutral public header refactor to enable Swift Package

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v4.3.1
+- [removed] Client id usage in api call and respective checks in the code.
+  
 # v4.3.0
 - [changed] Functionally neutral public header refactor to enable Swift Package
   Manager support.

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v4.3.1
 - [removed] Client id usage in api call and respective checks in the code.
-  
+
 # v4.3.0
 - [changed] Functionally neutral public header refactor to enable Swift Package
   Manager support.

--- a/FirebaseDynamicLinks/Sources/FIRDLDefaultRetrievalProcessV2.h
+++ b/FirebaseDynamicLinks/Sources/FIRDLDefaultRetrievalProcessV2.h
@@ -32,7 +32,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FIRDLDefaultRetrievalProcessV2 : NSObject <FIRDLRetrievalProcessProtocol>
 
 - (instancetype)initWithNetworkingService:(FIRDynamicLinkNetworking *)networkingService
-                                 clientID:(NSString *)clientID
                                 URLScheme:(NSString *)URLScheme
                                    APIKey:(NSString *)APIKey
                             FDLSDKVersion:(NSString *)FDLSDKVersion

--- a/FirebaseDynamicLinks/Sources/FIRDLDefaultRetrievalProcessV2.m
+++ b/FirebaseDynamicLinks/Sources/FIRDLDefaultRetrievalProcessV2.m
@@ -46,7 +46,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FIRDLDefaultRetrievalProcessV2 {
   FIRDynamicLinkNetworking *_networkingService;
-  NSString *_clientID;
   NSString *_URLScheme;
   NSString *_APIKey;
   NSString *_FDLSDKVersion;
@@ -60,18 +59,15 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Initialization
 
 - (instancetype)initWithNetworkingService:(FIRDynamicLinkNetworking *)networkingService
-                                 clientID:(NSString *)clientID
                                 URLScheme:(NSString *)URLScheme
                                    APIKey:(NSString *)APIKey
                             FDLSDKVersion:(NSString *)FDLSDKVersion
                                  delegate:(id<FIRDLRetrievalProcessDelegate>)delegate {
   NSParameterAssert(networkingService);
-  NSParameterAssert(clientID);
   NSParameterAssert(URLScheme);
   NSParameterAssert(APIKey);
   if (self = [super init]) {
     _networkingService = networkingService;
-    _clientID = [clientID copy];
     _URLScheme = [URLScheme copy];
     _APIKey = [APIKey copy];
     _FDLSDKVersion = [FDLSDKVersion copy];

--- a/FirebaseDynamicLinks/Sources/FIRDLRetrievalProcessFactory.h
+++ b/FirebaseDynamicLinks/Sources/FIRDLRetrievalProcessFactory.h
@@ -24,7 +24,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FIRDLRetrievalProcessFactory : NSObject
 
 - (instancetype)initWithNetworkingService:(FIRDynamicLinkNetworking *)networkingService
-                                 clientID:(NSString *)clientID
                                 URLScheme:(NSString *)URLScheme
                                    APIKey:(NSString *)APIKey
                             FDLSDKVersion:(NSString *)FDLSDKVersion

--- a/FirebaseDynamicLinks/Sources/FIRDLRetrievalProcessFactory.m
+++ b/FirebaseDynamicLinks/Sources/FIRDLRetrievalProcessFactory.m
@@ -25,7 +25,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation FIRDLRetrievalProcessFactory {
   FIRDynamicLinkNetworking *_networkingService;
-  NSString *_clientID;
   NSString *_URLScheme;
   NSString *_APIKey;
   NSString *_FDLSDKVersion;
@@ -33,14 +32,12 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)initWithNetworkingService:(FIRDynamicLinkNetworking *)networkingService
-                                 clientID:(NSString *)clientID
                                 URLScheme:(NSString *)URLScheme
                                    APIKey:(NSString *)APIKey
                             FDLSDKVersion:(NSString *)FDLSDKVersion
                                  delegate:(id<FIRDLRetrievalProcessDelegate>)delegate {
   if (self = [super init]) {
     _networkingService = networkingService;
-    _clientID = clientID;
     _URLScheme = URLScheme;
     _APIKey = APIKey;
     _FDLSDKVersion = FDLSDKVersion;
@@ -51,7 +48,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id<FIRDLRetrievalProcessProtocol>)automaticRetrievalProcess {
   return [[FIRDLDefaultRetrievalProcessV2 alloc] initWithNetworkingService:_networkingService
-                                                                  clientID:_clientID
                                                                  URLScheme:_URLScheme
                                                                     APIKey:_APIKey
                                                              FDLSDKVersion:_FDLSDKVersion

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.h
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.h
@@ -74,13 +74,11 @@ FOUNDATION_EXPORT NSString *const kApiaryRestBaseUrl;
 @interface FIRDynamicLinkNetworking : NSObject
 
 /**
- * @method initWithAPIKey:clientID:URLScheme:
- * @param clientID Client ID value.
+ * @method initWithAPIKey:URLScheme:
  * @param URLScheme Custom URL scheme of the app.
  * @param APIKey API Key value.
  */
 - (instancetype)initWithAPIKey:(NSString *)APIKey
-                      clientID:(NSString *)clientID
                      URLScheme:(NSString *)URLScheme NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking.m
@@ -86,19 +86,14 @@ NSData *_Nullable FIRDataWithDictionary(NSDictionary *dictionary, NSError **_Nul
 
 @implementation FIRDynamicLinkNetworking {
   NSString *_APIKey;
-  NSString *_clientID;
   NSString *_URLScheme;
 }
 
-- (instancetype)initWithAPIKey:(NSString *)APIKey
-                      clientID:(NSString *)clientID
-                     URLScheme:(NSString *)URLScheme {
+- (instancetype)initWithAPIKey:(NSString *)APIKey URLScheme:(NSString *)URLScheme {
   NSParameterAssert(APIKey);
-  NSParameterAssert(clientID);
   NSParameterAssert(URLScheme);
   if (self = [super init]) {
     _APIKey = [APIKey copy];
-    _clientID = [clientID copy];
     _URLScheme = [URLScheme copy];
   }
   return self;
@@ -260,7 +255,6 @@ NSData *_Nullable FIRDataWithDictionary(NSDictionary *dictionary, NSError **_Nul
     @"invitationId" : @{@"id" : invitationID},
     @"containerClientId" : @{
       @"type" : @"IOS",
-      @"id" : _clientID,
     }
   };
 

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks+FirstParty.h
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks+FirstParty.h
@@ -41,8 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
                       clientID:(NSString *)clientID
                      urlScheme:(nullable NSString *)urlScheme
                   userDefaults:(nullable NSUserDefaults *)userDefaults
-    __attribute((
-        deprecated("Use setUpWithLaunchOptions::apiKey:urlScheme:userDefaults: instead.")));
+    DEPRECATED_MSG_ATTRIBUTE("Use setUpWithLaunchOptions::apiKey:urlScheme:userDefaults: instead.");
 
 /**
  * @method setUpWithLaunchOptions::apiKey:urlScheme:userDefaults:

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks+FirstParty.h
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks+FirstParty.h
@@ -41,7 +41,8 @@ NS_ASSUME_NONNULL_BEGIN
                       clientID:(NSString *)clientID
                      urlScheme:(nullable NSString *)urlScheme
                   userDefaults:(nullable NSUserDefaults *)userDefaults
-    DEPRECATED_MSG_ATTRIBUTE("Use setUpWithLaunchOptions::apiKey:urlScheme:userDefaults: instead.");
+    DEPRECATED_MSG_ATTRIBUTE(
+        "Use [FIRDynamicLinks setUpWithLaunchOptions::apiKey:urlScheme:userDefaults:] instead.");
 
 /**
  * @method setUpWithLaunchOptions::apiKey:urlScheme:userDefaults:

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks+FirstParty.h
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks+FirstParty.h
@@ -40,6 +40,24 @@ NS_ASSUME_NONNULL_BEGIN
                         apiKey:(NSString *)apiKey
                       clientID:(NSString *)clientID
                      urlScheme:(nullable NSString *)urlScheme
+                  userDefaults:(nullable NSUserDefaults *)userDefaults
+    __attribute((
+        deprecated("Use setUpWithLaunchOptions::apiKey:urlScheme:userDefaults: instead.")));
+
+/**
+ * @method setUpWithLaunchOptions::apiKey:urlScheme:userDefaults:
+ * @abstract Set up Dynamic Links.
+ * @param launchOptions launchOptions from |application:didFinishLaunchingWithOptions:|. If nil, the
+ *     deep link may appear twice on iOS 9 if a user clicks on a link before opening the app.
+ * @param apiKey API key for API access.
+ * @param urlScheme A custom url scheme used by the application. If nil, bundle id will be used.
+ * @param userDefaults The defaults from a user’s defaults database. If nil, standard
+ *     NSUserDefaults will be used.
+ * @return whether the Dynamic Links was set up successfully.
+ */
+- (BOOL)setUpWithLaunchOptions:(nullable NSDictionary *)launchOptions
+                        apiKey:(NSString *)apiKey
+                     urlScheme:(nullable NSString *)urlScheme
                   userDefaults:(nullable NSUserDefaults *)userDefaults;
 
 /**

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks+Private.h
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks+Private.h
@@ -45,12 +45,6 @@ FOUNDATION_EXPORT NSString *const kFIRDLReadDeepLinkAfterInstallKey;
 @property(nonatomic, copy, readonly) NSString *APIKey;
 
 /**
- * @property clientID
- * @abstract Client ID for API access.
- */
-@property(nonatomic, copy, readonly) NSString *clientID;
-
-/**
  * @property URLScheme
  * @abstract Custom URL scheme.
  */

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
@@ -255,17 +255,6 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
 
 - (BOOL)setUpWithLaunchOptions:(nullable NSDictionary *)launchOptions
                         apiKey:(NSString *)apiKey
-                      clientID:(NSString *)clientID
-                     urlScheme:(nullable NSString *)urlScheme
-                  userDefaults:(nullable NSUserDefaults *)userDefaults {
-  return [self setUpWithLaunchOptions:launchOptions
-                               apiKey:apiKey
-                            urlScheme:urlScheme
-                         userDefaults:userDefaults];
-}
-
-- (BOOL)setUpWithLaunchOptions:(nullable NSDictionary *)launchOptions
-                        apiKey:(NSString *)apiKey
                      urlScheme:(nullable NSString *)urlScheme
                   userDefaults:(nullable NSUserDefaults *)userDefaults {
   if (apiKey == nil) {
@@ -333,6 +322,17 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
 
 + (instancetype)sharedInstance {
   return [self dynamicLinks];
+}
+
+- (BOOL)setUpWithLaunchOptions:(nullable NSDictionary *)launchOptions
+                        apiKey:(NSString *)apiKey
+                      clientID:(NSString *)clientID
+                     urlScheme:(nullable NSString *)urlScheme
+                  userDefaults:(nullable NSUserDefaults *)userDefaults {
+  return [self setUpWithLaunchOptions:launchOptions
+                               apiKey:apiKey
+                            urlScheme:urlScheme
+                         userDefaults:userDefaults];
 }
 
 - (void)checkForPendingDeepLink {

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
@@ -69,9 +69,6 @@ NS_ASSUME_NONNULL_BEGIN
 // API Key for API access.
 @property(nonatomic, copy) NSString *APIKey;
 
-// Client ID for API access.
-@property(nonatomic, copy) NSString *clientID;
-
 // Custom URL scheme.
 @property(nonatomic, copy) NSString *URLScheme;
 
@@ -167,23 +164,10 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
     errorDescription = [@"API key must not be nil or empty." mutableCopy];
   }
 
-  if (options.clientID.length == 0) {
-    NSString *errorMsg = @"Client ID must not be nil or empty.";
-    if (errorDescription) {
-      [errorDescription appendFormat:@" %@", errorMsg];
-    } else {
-      errorDescription = [errorMsg mutableCopy];
-    }
-  }
-
   if (!errorDescription) {
     // setup FDL if no error detected
     urlScheme = options.deepLinkURLScheme ?: [NSBundle mainBundle].bundleIdentifier;
-    [self setUpWithLaunchOptions:nil
-                          apiKey:options.APIKey
-                        clientID:options.clientID
-                       urlScheme:urlScheme
-                    userDefaults:nil];
+    [self setUpWithLaunchOptions:nil apiKey:options.APIKey urlScheme:urlScheme userDefaults:nil];
   } else {
     error =
         [FIRApp errorForSubspecConfigurationFailureWithDomain:kFirebaseDurableDeepLinkErrorDomain
@@ -274,17 +258,22 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
                       clientID:(NSString *)clientID
                      urlScheme:(nullable NSString *)urlScheme
                   userDefaults:(nullable NSUserDefaults *)userDefaults {
+  return [self setUpWithLaunchOptions:launchOptions
+                               apiKey:apiKey
+                            urlScheme:urlScheme
+                         userDefaults:userDefaults];
+}
+
+- (BOOL)setUpWithLaunchOptions:(nullable NSDictionary *)launchOptions
+                        apiKey:(NSString *)apiKey
+                     urlScheme:(nullable NSString *)urlScheme
+                  userDefaults:(nullable NSUserDefaults *)userDefaults {
   if (apiKey == nil) {
     FDLLog(FDLLogLevelError, FDLLogIdentifierSetupNilAPIKey, @"API Key must not be nil.");
     return NO;
   }
-  if (clientID == nil) {
-    FDLLog(FDLLogLevelError, FDLLogIdentifierSetupNilClientID, @"Client ID must not be nil.");
-    return NO;
-  }
 
   _APIKey = [apiKey copy];
-  _clientID = [clientID copy];
   _URLScheme = urlScheme.length ? [urlScheme copy] : [NSBundle mainBundle].bundleIdentifier;
 
   if (!userDefaults) {
@@ -330,7 +319,6 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
 
   FIRDLRetrievalProcessFactory *factory =
       [[FIRDLRetrievalProcessFactory alloc] initWithNetworkingService:self.dynamicLinkNetworking
-                                                             clientID:_clientID
                                                             URLScheme:_URLScheme
                                                                APIKey:_APIKey
                                                         FDLSDKVersion:kFIRDLVersion
@@ -501,7 +489,6 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
 - (FIRDynamicLinkNetworking *)dynamicLinkNetworking {
   if (!_dynamicLinkNetworking) {
     _dynamicLinkNetworking = [[FIRDynamicLinkNetworking alloc] initWithAPIKey:_APIKey
-                                                                     clientID:_clientID
                                                                     URLScheme:_URLScheme];
   }
   return _dynamicLinkNetworking;

--- a/FirebaseDynamicLinks/Sources/Logging/FDLLogging.h
+++ b/FirebaseDynamicLinks/Sources/Logging/FDLLogging.h
@@ -31,7 +31,7 @@ typedef NS_ENUM(NSInteger, FDLLogLevel) {
  */
 typedef NS_ENUM(NSInteger, FDLLogIdentifier) {
   FDLLogIdentifierSetupNilAPIKey = 0,
-  FDLLogIdentifierSetupNilClientID = 1,
+  FDLLogIdentifierSetupNilClientID = 1,  // Not used anymore
   FDLLogIdentifierSetupNonDefaultApp = 2,
   FDLLogIdentifierSetupInvalidDomainURIPrefixScheme = 3,
   FDLLogIdentifierSetupInvalidDomainURIPrefix = 4,

--- a/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinkNetworkingTests.m
+++ b/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinkNetworkingTests.m
@@ -23,7 +23,6 @@
 #import "GoogleUtilities/SwizzlerTestHelpers/GULSwizzler+Unswizzle.h"
 
 static NSString *const kAPIKey = @"myfakeapikey";
-static NSString *const kClientID = @"myfakeclientid";
 const NSInteger kJSONParsingErrorCode = 3840;
 static NSString *const kURLScheme = @"gindeeplinkurl";
 static const NSTimeInterval kAsyncTestTimout = 0.5;
@@ -42,9 +41,7 @@ static const NSTimeInterval kAsyncTestTimout = 0.5;
 
 - (FIRDynamicLinkNetworking *)service {
   if (!_service) {
-    _service = [[FIRDynamicLinkNetworking alloc] initWithAPIKey:kAPIKey
-                                                       clientID:kClientID
-                                                      URLScheme:kURLScheme];
+    _service = [[FIRDynamicLinkNetworking alloc] initWithAPIKey:kAPIKey URLScheme:kURLScheme];
   }
   return _service;
 }


### PR DESCRIPTION
Removing client id usage in api call and respective checks

FDL SDK was using client id passed in FIROptions to make API calls. From backend side, we no longer needs client id to be sent. So removing the client id usage in FDL SDK along with parameter no null checks.

-Removed the usage of Client id from FIROptions.
-Removed non null parameter checks for client id.
-Deprecated 1p API method setUpWithLaunchOptions::apiKey:clientID:urlScheme:userDefaults: and added setUpWithLaunchOptions::apiKey:urlScheme:userDefaults:
-Removed Client id usage in Unit tests.