### PR TITLE
SPM test infra fixes

### DIFF
--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -40,26 +40,23 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme ABTestingUnit test -sdk
-           iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11' | xcpretty
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh ABTestingUnit iOS spm
 
   spm-cron:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        target: [tvos, macos, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12
       run: sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
-    - name: macOS Unit Tests
-      run:  scripts/third_party/travis/retry.sh xcodebuild -scheme ABTestingUnit test | xcpretty
-    - name: tvOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme ABTestingUnit test -sdk
-           appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
-
+    - name: Unit Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh ABTestingUnit ${{ matrix.target }} spm
 
   catalyst:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -44,7 +44,7 @@ jobs:
 
   spm-cron:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
     strategy:
       matrix:

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        target: [tvos, macos, catalyst]
+        target: [tvOS, macOS, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -78,7 +78,7 @@ jobs:
 
   spm-cron:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
     strategy:
       matrix:

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        target: [tvos, macos, catalyst]
+        target: [tvOS, macOS, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -74,25 +74,23 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme AuthUnit test -sdk
-           iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11' | xcpretty
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh AuthUnit iOS spm
 
   spm-cron:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        target: [tvos, macos, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12
       run: sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
-    - name: macOS Unit Tests
-      run:  scripts/third_party/travis/retry.sh xcodebuild -scheme AuthUnit test | xcpretty
-    - name: tvOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme AuthUnit test -sdk
-           appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
+    - name: Unit Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh AuthUnit ${{ matrix.target }} spm
 
   catalyst:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -43,7 +43,7 @@ jobs:
 
   spm-cron:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
     strategy:
       matrix:

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        target: [tvos, macos, catalyst]
+        target: [tvOS, macOS, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -39,25 +39,23 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme CoreUnit test -sdk
-           iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11' | xcpretty
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh CoreUnit iOS spm
 
   spm-cron:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        target: [tvos, macos, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12
       run: sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
-    - name: macOS Unit Tests
-      run:  scripts/third_party/travis/retry.sh xcodebuild -scheme CoreUnit test | xcpretty
-    - name: tvOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme CoreUnit test -sdk
-           appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
+    - name: Unit Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh CoreUnit ${{ matrix.target }} spm
 
   catalyst:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -46,7 +46,7 @@ jobs:
 
   spm-cron:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
     strategy:
       matrix:

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -42,25 +42,23 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme FirebaseCrashlytics build -sdk
-           iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11' | xcpretty
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseCrashlytics iOS spmbuildonly
 
   spm-cron:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        target: [tvos, macos, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12
       run: sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
-    - name: macOS Unit Tests
-      run:  scripts/third_party/travis/retry.sh xcodebuild -scheme FirebaseCrashlytics build | xcpretty
-    - name: tvOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme FirebaseCrashlytics build -sdk
-           appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
+    - name: Unit Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseCrashlytics ${{ matrix.target }} spmbuildonly
 
 
   catalyst:

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        target: [tvos, macos, catalyst]
+        target: [tvOS, macOS, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        target: [tvos, macos, catalyst]
+        target: [tvOS, macOS, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -51,25 +51,23 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme DatabaseUnit test -sdk
-           iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11' | xcpretty
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh DatabaseUnit iOS spm
 
   spm-cron:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        target: [tvos, macos, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12
       run: sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
-    - name: macOS Unit Tests
-      run:  scripts/third_party/travis/retry.sh xcodebuild -scheme DatabaseUnit test | xcpretty
-    - name: tvOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme DatabaseUnit test -sdk
-           appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
+    - name: Unit Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh DatabaseUnit ${{ matrix.target }} spm
 
   catalyst:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -55,7 +55,7 @@ jobs:
 
   spm-cron:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
     strategy:
       matrix:

--- a/.github/workflows/dynamiclinks.yml
+++ b/.github/workflows/dynamiclinks.yml
@@ -35,8 +35,7 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme FirebaseDynamicLinks build -sdk
-           iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11' | xcpretty
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseDynamicLinks iOS spmbuildonly
 
   dynamiclinks-cron-only:
     # Don't run on private repo.

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -204,7 +204,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        target: [tvos, macos, catalyst]
+        target: [tvOS, macOS, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -195,14 +195,14 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
-    - name: iOS Unit Tests
+    - name: iOS Build Test
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFirestore iOS spmbuildonly
     - name: Swift Build
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFirestoreSwift iOS spmbuildonly
 
   spm-cron:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
     strategy:
       matrix:
@@ -213,7 +213,7 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
-    - name: Unit Tests
+    - name: Build Test
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFirestore ${{ matrix.target }} spmbuildonly
     - name: Swift Build
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFirestoreSwift ${{ matrix.target }} spmbuildonly

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -197,6 +197,8 @@ jobs:
       run: xcodebuild -list
     - name: iOS Unit Tests
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFirestore iOS spmbuildonly
+    - name: Swift Build
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFirestoreSwift iOS spmbuildonly
 
   spm-cron:
     # Don't run on private repo.
@@ -213,6 +215,8 @@ jobs:
       run: xcodebuild -list
     - name: Unit Tests
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFirestore ${{ matrix.target }} spmbuildonly
+    - name: Swift Build
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFirestoreSwift ${{ matrix.target }} spmbuildonly
 
   quickstart:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -196,25 +196,23 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme FirebaseFirestore build -sdk
-           iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11' | xcpretty
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFirestore iOS spmbuildonly
 
   spm-cron:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        target: [tvos, macos, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12
       run: sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
-    - name: macOS Unit Tests
-      run:  scripts/third_party/travis/retry.sh xcodebuild -scheme FirebaseFirestore build | xcpretty
-    - name: tvOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme FirebaseFirestore build -sdk
-           appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
+    - name: Unit Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFirestore ${{ matrix.target }} spmbuildonly
 
   quickstart:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -29,7 +29,7 @@ jobs:
 
   spm-cron:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
     strategy:
       matrix:

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: Unit Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFunctions ${{ matrix.target }} spm
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFunctions ${{ matrix.target }} spmbuildonly
 
   quickstart:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        target: [tvos, macos, catalyst]
+        target: [tvOS, macOS, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12

--- a/.github/workflows/functions.yml
+++ b/.github/workflows/functions.yml
@@ -25,25 +25,23 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme FirebaseFunctions build -sdk
-           iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11' | xcpretty
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFunctions iOS spmbuildonly
 
   spm-cron:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        target: [tvos, macos, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12
       run: sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
-    - name: macOS Unit Tests
-      run:  scripts/third_party/travis/retry.sh xcodebuild -scheme FirebaseFunctions build | xcpretty
-    - name: tvOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme FirebaseFunctions build -sdk
-           appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
+    - name: Unit Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseFunctions ${{ matrix.target }} spm
 
   quickstart:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -24,8 +24,7 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme FirebaseInAppMessaging build -sdk
-           iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11' | xcpretty
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseInAppMessaging iOS spmbuildonly
 
   quickstart:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/inappmessaging.yml
+++ b/.github/workflows/inappmessaging.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseInAppMessaging iOS spmbuildonly
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseInAppMessaging-Beta iOS spmbuildonly
 
   quickstart:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        target: [tvos, macos, catalyst]
+        target: [tvOS, macOS, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -55,7 +55,7 @@ jobs:
 
   spm-cron:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
     strategy:
       matrix:

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -51,25 +51,23 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme FirebaseInstanceID build -sdk
-           iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11' | xcpretty
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseInstallations iOS spmbuildonly
 
   spm-cron:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        target: [tvos, macos, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12
       run: sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
-    - name: macOS Unit Tests
-      run:  scripts/third_party/travis/retry.sh xcodebuild -scheme FirebaseInstanceID build | xcpretty
-    - name: tvOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme FirebaseInstanceID build -sdk
-           appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
+    - name: Unit Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseInstallations ${{ matrix.target }} spmbuildonly
 
   # TODO - Catalyst is disabled because `pod gen` does not have a way to get some dependent pods
   # from a local path and the Installations podspec requires that FirebaseInstanceID.podspec not be

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -72,7 +72,7 @@ jobs:
 
   spm-cron:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
     strategy:
       matrix:

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        target: [tvos, macos, catalyst]
+        target: [tvOS, macOS, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -68,25 +68,23 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme RemoteConfigUnit test -sdk
-           iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11' | xcpretty
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh RemoteConfigUnit iOS spm
 
   spm-cron:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        target: [tvos, macos, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12
       run: sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
-    - name: macOS Unit Tests
-      run:  scripts/third_party/travis/retry.sh xcodebuild -scheme RemoteConfigUnit test | xcpretty
-    - name: tvOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme RemoteConfigUnit test -sdk
-           appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
+    - name: Unit Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh RemoteConfigUnit ${{ matrix.target }} spm
 
   catalyst:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -35,6 +35,8 @@ jobs:
     strategy:
       matrix:
         target: [tvOS, macOS, catalyst]
+        # Full set of Firebase-Package tests only run on iOS because of Analytics.
+        test: [objc-import-test, swift-test, version-test]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12
@@ -42,4 +44,4 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: Unit Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package ${{ matrix.target }} spm
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh ${{ matrix.test }} ${{ matrix.target }} spm

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -30,7 +30,7 @@ jobs:
 
   cron-only:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macOS-latest
     steps:
@@ -39,8 +39,13 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
-    - name: macOS Unit Tests
+    - name: macOS Unit Test Build
+      run:  scripts/third_party/travis/retry.sh xcodebuild -scheme Firebase-Package build | xcpretty
+    - name: macOS Unit Test
       run:  scripts/third_party/travis/retry.sh xcodebuild -scheme Firebase-Package test | xcpretty
-    - name: tvOS Unit Tests
+    - name: tvOS Unit Test Build
+      run: scripts/third_party/travis/retry.sh xcodebuild -scheme Firebase-Package build -sdk
+           appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
+    - name: tvOS Unit Test Build
       run: scripts/third_party/travis/retry.sh xcodebuild -scheme Firebase-Package test -sdk
            appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -41,5 +41,5 @@ jobs:
       run: sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
-    - name: macOS Unit Test Build
+    - name: Unit Tests
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package ${{ matrix.target }} spm

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -29,7 +29,7 @@ jobs:
 
   cron-only:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macOS-latest
     strategy:

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        target: [tvos, macos, catalyst]
+        target: [tvOS, macOS, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -25,14 +25,16 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme Firebase-Package test -sdk
-           iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11' | xcpretty
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package iOS spm
 
   cron-only:
     # Don't run on private repo.
 #    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        target: [tvos, macos, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12
@@ -40,16 +42,4 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: macOS Unit Test Build
-      run:  xcodebuild -scheme Firebase-Package build | xcpretty
-    # - name: macOS Unit Test
-    #   run:  scripts/third_party/travis/retry.sh xcodebuild -scheme Firebase-Package test | xcpretty
-    - name: tvOS Unit Test Build
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme Firebase-Package build -sdk
-           appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV'
-    # - name: tvOS Unit Test Build
-    #   run: scripts/third_party/travis/retry.sh xcodebuild -scheme Firebase-Package test -sdk
-    #        appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
-
-    - name: tvOS Unit Test Build 2
-      run: xcodebuild -scheme Firebase-Package build -sdk
-           appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV'
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh Firebase-Package ${{ matrix.target }} spm

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -40,12 +40,16 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: macOS Unit Test Build
-      run:  scripts/third_party/travis/retry.sh xcodebuild -scheme Firebase-Package build | xcpretty
-    - name: macOS Unit Test
-      run:  scripts/third_party/travis/retry.sh xcodebuild -scheme Firebase-Package test | xcpretty
+      run:  xcodebuild -scheme Firebase-Package build | xcpretty
+    # - name: macOS Unit Test
+    #   run:  scripts/third_party/travis/retry.sh xcodebuild -scheme Firebase-Package test | xcpretty
     - name: tvOS Unit Test Build
       run: scripts/third_party/travis/retry.sh xcodebuild -scheme Firebase-Package build -sdk
-           appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
-    - name: tvOS Unit Test Build
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme Firebase-Package test -sdk
-           appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
+           appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV'
+    # - name: tvOS Unit Test Build
+    #   run: scripts/third_party/travis/retry.sh xcodebuild -scheme Firebase-Package test -sdk
+    #        appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
+
+    - name: tvOS Unit Test Build 2
+      run: xcodebuild -scheme Firebase-Package build -sdk
+           appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV'

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -53,10 +53,12 @@ jobs:
       run: xcodebuild -list
     - name: iOS Unit Tests
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh StorageUnit iOS spm
+    - name: Swift Build
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseStorageSwift iOS spmbuildonly
 
   spm-cron:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
     strategy:
       matrix:
@@ -69,6 +71,8 @@ jobs:
       run: xcodebuild -list
     - name: Unit Tests
       run: scripts/third_party/travis/retry.sh ./scripts/build.sh StorageUnit ${{ matrix.target }} spm
+    - name: Swift Build
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh FirebaseStorageSwift ${{ matrix.target }} spmbuildonly
 
   catalyst:
     # Don't run on private repo unless it is a PR.

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        target: [tvos, macos, catalyst]
+        target: [tvOS, macOS, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -52,25 +52,23 @@ jobs:
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme StorageUnit test -sdk
-           iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11' | xcpretty
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh StorageUnit iOS spm
 
   spm-cron:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
-
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        target: [tvos, macos, catalyst]
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12
       run: sudo xcode-select -s /Applications/Xcode_12_beta.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
-    - name: macOS Unit Tests
-      run:  scripts/third_party/travis/retry.sh xcodebuild -scheme StorageUnit test | xcpretty
-    - name: tvOS Unit Tests
-      run: scripts/third_party/travis/retry.sh xcodebuild -scheme StorageUnit test -sdk
-           appletvsimulator -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
+    - name: Unit Tests
+      run: scripts/third_party/travis/retry.sh ./scripts/build.sh StorageUnit ${{ matrix.target }} spm
 
   catalyst:
     # Don't run on private repo unless it is a PR.

--- a/Package.swift
+++ b/Package.swift
@@ -202,9 +202,9 @@ let package = Package(
     .target(
       name: "FirebaseAnalyticsWrapper",
       dependencies: [
-        "FirebaseAnalytics",
-        "FIRAnalyticsConnector",
-        "GoogleAppMeasurement",
+        .target(name: "FirebaseAnalytics", condition: .when(platforms: .some([.iOS]))),
+        .target(name: "FIRAnalyticsConnector", condition: .when(platforms: .some([.iOS]))),
+        .target(name: "GoogleAppMeasurement", condition: .when(platforms: .some([.iOS]))),
         "FirebaseCore",
         "FirebaseInstallations",
         "GoogleUtilities_AppDelegateSwizzler",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -169,8 +169,8 @@ watchos_flags=(
   -destination 'platform=iOS Simulator,name=iPhone 11 Pro'
 )
 catalyst_flags=(
-  ARCHS=x86_64h VALID_ARCHS=x86_64h SUPPORTS_MACCATALYST=YES -sdk macosx 
-  -destination platform=\"OS X\" TARGETED_DEVICE_FAMILY=2
+  ARCHS=x86_64h VALID_ARCHS=x86_64h SUPPORTS_MACCATALYST=YES -sdk macosx
+  -destination platform="OS X" TARGETED_DEVICE_FAMILY=2
   CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 )
 
@@ -544,6 +544,14 @@ case "$product-$platform-$method" in
       build \
       test
     ;;
+
+  *-*-spmbuildonly)
+    RunXcodebuild \
+      -scheme $product \
+      "${xcb_flags[@]}" \
+      build
+    ;;
+
   *)
     echo "Don't know how to build this product-platform-method combination" 1>&2
     echo "  product=$product" 1>&2

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -47,12 +47,14 @@ platform can be one of:
   macOS
   tvOS
   watchOS
+  catalyst
 
 method can be one of:
   xcodebuild (default)
   cmake
   unit
   integration
+  spm
 
 Optionally, reads the environment variable SANITIZERS. If set, it is expected to
 be a string containing a space-separated list with some of the following
@@ -166,6 +168,11 @@ tvos_flags=(
 watchos_flags=(
   -destination 'platform=iOS Simulator,name=iPhone 11 Pro'
 )
+catalyst_flags=(
+  ARCHS=x86_64h VALID_ARCHS=x86_64h SUPPORTS_MACCATALYST=YES -sdk macosx 
+  -destination platform=\"OS X\" TARGETED_DEVICE_FAMILY=2
+  CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+)
 
 # Compute standard flags for all platforms
 case "$platform" in
@@ -190,6 +197,10 @@ case "$platform" in
 
   watchOS)
     xcb_flags=("${watchos_flags[@]}")
+    ;;
+
+  catalyst)
+    xcb_flags=("${catalyst_flags[@]}")
     ;;
 
   all)
@@ -524,6 +535,14 @@ case "$product-$platform-$method" in
       -scheme "GDTCCTWatchOSCompanionTestApp" \
       "${xcb_flags[@]}" \
       build
+    ;;
+
+  *-*-spm)
+    RunXcodebuild \
+      -scheme $product \
+      "${xcb_flags[@]}" \
+      build \
+      test
     ;;
   *)
     echo "Don't know how to build this product-platform-method combination" 1>&2

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -541,7 +541,6 @@ case "$product-$platform-$method" in
     RunXcodebuild \
       -scheme $product \
       "${xcb_flags[@]}" \
-      build \
       test
     ;;
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -169,8 +169,8 @@ watchos_flags=(
   -destination 'platform=iOS Simulator,name=iPhone 11 Pro'
 )
 catalyst_flags=(
-  ARCHS=x86_64h VALID_ARCHS=x86_64h SUPPORTS_MACCATALYST=YES -sdk macosx
-  -destination platform="OS X" TARGETED_DEVICE_FAMILY=2
+  ARCHS=x86_64 VALID_ARCHS=x86_64 SUPPORTS_MACCATALYST=YES -sdk macosx
+  -destination platform="macOS,variant=Mac Catalyst" TARGETED_DEVICE_FAMILY=2
   CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 )
 


### PR DESCRIPTION
Several fixes to SPM test infrastructure
- Test failures weren't reported in GHA because they weren't propagated through xcpretty
- Fixed above by using build.sh with its `set -euo pipefail` setup
- Use matrix for spm cron runs
- Add Catalyst to the test matrix
- Start running SPM tests for Installations (fixed scheme)
- Start running SPM tests for FIAM (fixed scheme)
- Define subset of passing tests for non-iOS platforms in spm.yml
- Add iOS condition for Analytics binary library dependencies

#no-changelog