### PR TITLE
Add the ability to query the compiler version and the C++ standard being used

### DIFF
--- a/Firestore/core/src/api/compiler_info.cc
+++ b/Firestore/core/src/api/compiler_info.cc
@@ -1,0 +1,29 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Firestore/core/src/api/compiler_info.h"
+
+#include "Firestore/core/src/util/compiler_info.h"
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+std::string GetFullCompilerInfo() {
+  return api::GetFullCompilerInfo();
+}
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/core/src/api/compiler_info.cc
+++ b/Firestore/core/src/api/compiler_info.cc
@@ -18,12 +18,12 @@
 
 namespace firebase {
 namespace firestore {
-namespace util {
+namespace api {
 
 std::string GetFullCompilerInfo() {
-  return api::GetFullCompilerInfo();
+  return util::GetFullCompilerInfo();
 }
 
-}  // namespace util
+}  // namespace api
 }  // namespace firestore
 }  // namespace firebase

--- a/Firestore/core/src/api/compiler_info.h
+++ b/Firestore/core/src/api/compiler_info.h
@@ -1,0 +1,32 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FIRESTORE_CORE_SRC_API_COMPILER_INFO_
+#define FIRESTORE_CORE_SRC_API_COMPILER_INFO_
+
+#include <string>
+
+namespace firebase {
+namespace firestore {
+namespace api {
+
+// Returns a string describing the compiler version and settings. See the
+// comments in `util/compiler_info.h` for more information on the format.
+std::string GetFullCompilerInfo();
+
+}  // namespace api
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_SRC_API_COMPILER_INFO_

--- a/Firestore/core/src/remote/grpc_connection.cc
+++ b/Firestore/core/src/remote/grpc_connection.cc
@@ -24,6 +24,7 @@
 
 #include "Firestore/core/include/firebase/firestore/firestore_errors.h"
 #include "Firestore/core/include/firebase/firestore/firestore_version.h"
+#include "Firestore/core/src/util/compiler_info.h"
 #include "Firestore/core/src/auth/token.h"
 #include "Firestore/core/src/model/database_id.h"
 #include "Firestore/core/src/remote/grpc_root_certificate_finder.h"
@@ -35,6 +36,8 @@
 #include "Firestore/core/src/util/warnings.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
+
+#include <iostream>
 
 SUPPRESS_DOCUMENTATION_WARNINGS_BEGIN()
 #include "grpcpp/create_channel.h"
@@ -48,6 +51,7 @@ namespace remote {
 using auth::Token;
 using core::DatabaseInfo;
 using model::DatabaseId;
+using util::GetFullCompilerInfo();
 using util::Filesystem;
 using util::Path;
 using util::Status;
@@ -129,24 +133,7 @@ HostConfigMap& Config() {
 }
 
 std::string GetCppLanguageToken() {
-  const char* cpp_version = [] {
-    switch (__cplusplus) {
-      case 199711L:
-        return "1998";
-      case 201103L:
-        return "2011";
-      case 201402L:
-        return "2014";
-      case 201703L:
-        return "2017";
-      case 202002L:
-        return "2020";
-      default:
-        return "";
-    }
-  }();
-
-  return StringFormat("gl-cpp/%s", cpp_version);
+  return StringFormat("gl-cpp/%s", GetFullCompilerInfo());
 }
 
 class ClientLanguageToken {
@@ -176,6 +163,7 @@ ClientLanguageToken& LanguageToken() {
 void AddCloudApiHeader(grpc::ClientContext& context) {
   auto api_tokens = StringFormat("%s fire/%s grpc/%s", LanguageToken().Get(),
                                  kFirestoreVersionString, grpc::Version());
+  std::cout << "OBC " << api_tokens << std::endl;
   context.AddMetadata(kXGoogAPIClientHeader, api_tokens);
 }
 

--- a/Firestore/core/src/remote/grpc_connection.cc
+++ b/Firestore/core/src/remote/grpc_connection.cc
@@ -51,7 +51,7 @@ namespace remote {
 using auth::Token;
 using core::DatabaseInfo;
 using model::DatabaseId;
-using util::GetFullCompilerInfo();
+using util::GetFullCompilerInfo;
 using util::Filesystem;
 using util::Path;
 using util::Status;

--- a/Firestore/core/src/remote/grpc_connection.cc
+++ b/Firestore/core/src/remote/grpc_connection.cc
@@ -37,8 +37,6 @@
 #include "absl/memory/memory.h"
 #include "absl/strings/str_cat.h"
 
-#include <iostream>
-
 SUPPRESS_DOCUMENTATION_WARNINGS_BEGIN()
 #include "grpcpp/create_channel.h"
 #include "grpcpp/grpcpp.h"
@@ -163,7 +161,6 @@ ClientLanguageToken& LanguageToken() {
 void AddCloudApiHeader(grpc::ClientContext& context) {
   auto api_tokens = StringFormat("%s fire/%s grpc/%s", LanguageToken().Get(),
                                  kFirestoreVersionString, grpc::Version());
-  std::cout << "OBC " << api_tokens << std::endl;
   context.AddMetadata(kXGoogAPIClientHeader, api_tokens);
 }
 

--- a/Firestore/core/src/util/compiler_info.cc
+++ b/Firestore/core/src/util/compiler_info.cc
@@ -1,0 +1,168 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Firestore/core/src/util/compiler_info.h"
+
+#include <sstream>
+#include <utility>
+
+#include "Firestore/core/src/util/string_format.h"
+#include "absl/base/config.h"
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+namespace {
+
+// The code in this file is adapted from
+// https://github.com/googleapis/google-cloud-cpp/blob/master/google/cloud/internal/compiler_info.cc and
+// https://github.com/googleapis/google-cloud-cpp/blob/master/google/cloud/internal/port_platform.cc.
+
+/**
+ * Returns the compiler ID.
+ *
+ * The Compiler ID is a string like "GNU" or "Clang", as described by
+ * https://cmake.org/cmake/help/v3.5/variable/CMAKE_LANG_COMPILER_ID.html
+ */
+std::string CompilerId() {
+  // The macros for determining the compiler ID are taken from:
+  // https://gitlab.kitware.com/cmake/cmake/tree/v3.5.0/Modules/Compiler/\*-DetermineCompiler.cmake
+  // We do not care to detect every single compiler possible and only target the
+  // most popular ones.
+  //
+  // Order is significant as some compilers can define the same macros.
+
+#if defined(__apple_build_version__) && defined(__clang__)
+  return "AppleClang";
+#elif defined(__clang__)
+  return "Clang";
+#elif defined(__GNUC__)
+  return "GNU";
+#elif defined(_MSC_VER)
+  return "MSVC";
+#endif
+
+  return "Unknown";
+}
+
+/** Returns the compiler version. This string will be something like "9.1.1". */
+std::string CompilerVersion() {
+  std::ostringstream os;
+
+#if defined(__apple_build_version__) && defined(__clang__)
+  os << __clang_major__ << "." << __clang_minor__ << "." << __clang_patchlevel__
+     << "." << __apple_build_version__;
+
+#elif defined(__clang__)
+  os << __clang_major__ << "." << __clang_minor__ << "."
+     << __clang_patchlevel__;
+
+#elif defined(__GNUC__)
+  os << __GNUC__ << "." << __GNUC_MINOR__ << "." << __GNUC_PATCHLEVEL__;
+
+#elif defined(_MSC_VER)
+  os << _MSC_VER / 100 << ".";
+  os << _MSC_VER % 100;
+#if defined(_MSC_FULL_VER)
+#if _MSC_VER >= 1400
+  os << "." << _MSC_FULL_VER % 100000;
+#else
+  os << "." << _MSC_FULL_VER % 10000;
+#endif  // _MSC_VER >= 1400
+#endif  // defined(_MSC_VER)
+
+#else
+  os << "Unknown";
+
+#endif  // defined(__apple_build_version__) && defined(__clang__)
+
+  return std::move(os).str();
+}
+
+/**
+ * Returns certain interesting compiler features.
+ *
+ * Currently this returns one of "ex" or "noex" to indicate whether or not
+ * C++ exceptions are enabled.
+ */
+std::string CompilerFeatures() {
+#if ABSL_HAVE_EXCEPTIONS
+  return "ex";
+#else
+  return "noex";
+#endif  // ABSL_HAVE_EXCEPTIONS
+}
+
+// Microsoft Visual Studio does not define `__cplusplus` correctly by default:
+// https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus
+// Instead, `_MSVC_LANG` macro can be used which uses the same version numbers
+// as the standard `__cplusplus` macro (except when the `/std:c++latest` option
+// is used, in which case it will be higher).
+#ifdef _MSC_VER
+#define FIRESTORE__CPLUSPLUS _MSVC_LANG
+#else
+#define FIRESTORE__CPLUSPLUS __cplusplus
+#endif  // _MSC_VER
+
+/** Returns the 4-digit year of the C++ language standard. */
+std::string LanguageVersion() {
+  switch (FIRESTORE__CPLUSPLUS) {
+    case 199711L:
+      return "1998";
+    case 201103L:
+      return "2011";
+    case 201402L:
+      return "2014";
+    case 201703L:
+      return "2017";
+    case 202002L:
+      return "2020";
+    default:
+#ifdef _MSC_VER
+      // According to
+      // https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros,
+      // _MSVC_LANG is "set to a higher, unspecified value when the
+      // `/std:c++latest` option is specified".
+      if (FIRESTORE__CPLUSPLUS > 202002L) {
+        return "latest";
+      }
+#endif  // _MSC_VER
+      return "unknown";
+  }
+}
+
+std::string StandardLibraryVendor() {
+#if defined(_STLPORT_VERSION)
+  return "stlport";
+#elif defined(__GLIBCXX__) || defined(__GLIBCPP__)
+  return "gnustl";
+#elif defined(_LIBCPP_STD_VER)
+  return "libcpp";
+#else
+  return "unknown";
+#endif
+}
+
+}  // namespace
+
+std::string GetFullCompilerInfo() {
+  return StringFormat("%s-%s-%s-%s-%s", CompilerId(), CompilerVersion(),
+                      CompilerFeatures(), LanguageVersion(),
+                      StandardLibraryVendor());
+}
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase

--- a/Firestore/core/src/util/compiler_info.h
+++ b/Firestore/core/src/util/compiler_info.h
@@ -1,0 +1,40 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FIRESTORE_CORE_SRC_UTIL_COMPILER_INFO_
+#define FIRESTORE_CORE_SRC_UTIL_COMPILER_INFO_
+
+#include <string>
+
+namespace firebase {
+namespace firestore {
+namespace util {
+
+// Returns a string describing the compiler version and settings in the
+// following format:
+//
+//   <CompilerId>-<CompilerVersion>-<CompilerFeatures>-<LanguageVersion>-<StandardLibraryVersion>
+//
+// e.g. "AppleClang-11.0.3.11030032-ex-2011-libcpp".
+//
+// The format is based on what is used by Cloud C++ libraries:
+// https://github.com/googleapis/google-cloud-cpp/blob/211006b86c841f2226fedf2f7ae6ced482aa2cc0/google/cloud/internal/api_client_header.cc#L23-L29
+// with the addition of <StandardLibraryVersion> (e.g. "libcpp").
+std::string GetFullCompilerInfo();
+
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_SRC_UTIL_COMPILER_INFO_

--- a/Firestore/core/src/util/exception.h
+++ b/Firestore/core/src/util/exception.h
@@ -37,6 +37,7 @@
 
 #include "Firestore/core/src/util/string_format.h"
 #include "absl/base/attributes.h"
+#include "absl/base/config.h"
 
 namespace firebase {
 namespace firestore {


### PR DESCRIPTION
This is largely adapted from the [Cloud C++ APIs](https://github.com/googleapis/google-cloud-cpp/blob/master/google/cloud/internal/compiler_info.cc) with the following changes:
* added C++20 to the list of possible standards;
* added "latest" as a possible C++ standard for MSVC;
* added the C++ standard library vendor to the compiler info string, primarily to track STLPort.

The string I'm getting when running this code on my Mac is `AppleClang-11.0.3.11030032-ex-2011-libcpp`.

#no-changelog