### PR TITLE
Add Info.plist to Carthage binary frameworks

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -2,6 +2,7 @@
 - [fixed] Swift Package Manager - Define system framework and system library dependencies. This
   resolves undefined symbol issues for system dependencies. (#6408, #6413)
 - [fixed] Enable Firebase pod support for Auth and Crashlytics watchOS platform. (#4558)
+- [fixed] Carthage - Some frameworks were missing Info.plist files. (#5562)
 
 # Firebase 6.32.0
 - [changed] Swift Package Manager - It's no longer necessary to select the Firebase or

--- a/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
+++ b/ZipBuilder/Sources/ZipBuilder/CarthageUtils.swift
@@ -280,14 +280,10 @@ extension CarthageUtils {
     }
 
     // Write the Info.plist.
-    let data = generatePlistContents(forName: "Firebase")
-    do { try data.write(to: frameworkDir.appendingPathComponent("Info.plist")) }
-    catch {
-      fatalError("Could not write the Info.plist for Firebase framework in Carthage. \(error)")
-    }
+    generatePlistContents(forName: "Firebase", to: frameworkDir)
   }
 
-  static func generatePlistContents(forName name: String) -> Data {
+  static func generatePlistContents(forName name: String, to location: URL) {
     let plist: [String: String] = ["CFBundleIdentifier": "com.firebase.Firebase-\(name)",
                                    "CFBundleInfoDictionaryVersion": "6.0",
                                    "CFBundlePackageType": "FMWK",
@@ -300,7 +296,8 @@ extension CarthageUtils {
     let encoder = PropertyListEncoder()
     encoder.outputFormat = .xml
     do {
-      return try encoder.encode(plist)
+      let data = try encoder.encode(plist)
+      try data.write(to: location.appendingPathComponent("Info.plist"))
     } catch {
       fatalError("Failed to create Info.plist for \(name) during Carthage build: \(error)")
     }

--- a/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -810,7 +810,8 @@ struct FrameworkBuilder {
     return xcframework
   }
 
-  /// Packages a Carthage framework. Carthage does not yet support xcframeworks, so we exclude the Catalyst slice.
+  /// Packages a Carthage framework. Carthage does not yet support xcframeworks, so we exclude the
+  /// Catalyst slice.
   /// - Parameter withName: The framework name.
   /// - Parameter fromFolder: The almost complete framework folder. Includes everything but the binary.
   /// - Parameter thinArchives: All the thin archives.
@@ -846,14 +847,7 @@ struct FrameworkBuilder {
                      moduleMapContents: moduleMapContents)
 
     // Add Info.plist frameworks to make Carthage happy.
-    let plistPath = frameworkDir.appendingPathComponents(["Info.plist"])
-    // Drop the extension of the framework name.
-    let plist = CarthageUtils.generatePlistContents(forName: framework)
-    do {
-      try plist.write(to: plistPath)
-    } catch {
-      fatalError("Could not copy plist for \(frameworkDir) for Carthage release. \(error)")
-    }
+    CarthageUtils.generatePlistContents(forName: framework, to: frameworkDir)
 
     // Carthage Resources are packaged in the framework.
     let resourceDir = frameworkDir.appendingPathComponent("Resources")

--- a/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ZipBuilder/Sources/ZipBuilder/ZipBuilder.swift
@@ -729,8 +729,10 @@ struct ZipBuilder {
           }
           frameworks.append(zipLocation)
 
-          CarthageUtils.generatePlistContents(forName: framework.lastPathComponent.components(separatedBy: ".").first!,
-                                              to: carthageLocation)
+          CarthageUtils.generatePlistContents(
+            forName: framework.lastPathComponent.components(separatedBy: ".").first!,
+            to: carthageLocation
+          )
           carthageFrameworks.append(carthageLocation)
         }
       }


### PR DESCRIPTION
Fix #5562 

Tested in #6444 and 

```
 $ diff -r ~/zip-m77/2020-08-05T09-21-45/CarthageFirebase/ CarthageFirebase/ | grep "Only in"
Only in CarthageFirebase/FirebaseAnalytics/FIRAnalyticsConnector.framework: Info.plist
Only in CarthageFirebase/FirebaseAnalytics/FirebaseAnalytics.framework: Info.plist
Only in CarthageFirebase/FirebaseAnalytics/GoogleAppMeasurement.framework: Info.plist
Only in CarthageFirebase/: FirebaseAppDistribution
Only in CarthageFirebase/FirebaseMLModelInterpreter/FirebaseMLCommon.framework: Info.plist
Only in CarthageFirebase/FirebaseMLModelInterpreter/FirebaseMLModelInterpreter.framework: Info.plist
Only in CarthageFirebase/FirebaseMLModelInterpreter/TensorFlowLiteC.framework: Info.plist
Only in CarthageFirebase/FirebaseMLVision/FirebaseMLCommon.framework: Info.plist
Only in CarthageFirebase/FirebaseMLVision/FirebaseMLVision.framework: Info.plist
Only in CarthageFirebase/FirebasePerformance/FirebasePerformance.framework: Info.plist
Only in CarthageFirebase/Google-Mobile-Ads-SDK/GoogleMobileAds.framework: Info.plist
Only in CarthageFirebase/Google-Mobile-Ads-SDK: UserMessagingPlatform.framework
Only in CarthageFirebase/GoogleSignIn/GoogleSignIn.framework: Info.plist
```