### PR TITLE
Remove tag before add

### DIFF
--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -x
+set -xe
 
 if [ -f "${HOME}/.cocoapods/repos" ]; then
   find "${HOME}/.cocoapods/repos" -type d -maxdepth 1 -exec sh -c 'pod repo remove $(basename {})' \;
@@ -23,8 +23,16 @@ git config --global user.name "google-oss-bot"
 mkdir -p /tmp/test/firebase-ios-sdk
 git clone -q -b "${podspec_repo_branch}" https://"${BOT_TOKEN}"@github.com/firebase/firebase-ios-sdk.git "${local_sdk_repo_dir}"
 cd  "${local_sdk_repo_dir}"
+
+# Update a tag.
+set +e
+# If tag_version is new to the remote, remote cannot delete an unexisted tag, 
+# so error is allowed here.
+git push origin --delete "${tag_version}" 
+set -e
 git tag -f -a "${tag_version}" -m "release testing"
 git push origin "${tag_version}"
+
 # Update source and tag, e.g.  ":tag => 'CocoaPods-' + s.version.to_s" to
 # ":tag => test"
 sed  -i "" "s/\s*:tag.*/:tag => '${tag_version}'/" *.podspec

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -28,7 +28,7 @@ cd  "${local_sdk_repo_dir}"
 set +e
 # If tag_version is new to the remote, remote cannot delete an unexisted tag, 
 # so error is allowed here.
-git push origin --delete "${tag_version}" 
+# git push origin --delete "${tag_version}" 
 set -e
 git tag -f -a "${tag_version}" -m "release testing"
 git push origin "${tag_version}"

--- a/scripts/release_testing_setup.sh
+++ b/scripts/release_testing_setup.sh
@@ -26,9 +26,9 @@ cd  "${local_sdk_repo_dir}"
 
 # Update a tag.
 set +e
-# If tag_version is new to the remote, remote cannot delete an unexisted tag, 
+# If tag_version is new to the remote, remote cannot delete an unexisted tag,
 # so error is allowed here.
-# git push origin --delete "${tag_version}" 
+git push origin --delete "${tag_version}"
 set -e
 git tag -f -a "${tag_version}" -m "release testing"
 git push origin "${tag_version}"


### PR DESCRIPTION
This change is due to an error observed in a nightly test log: 
```
++ git tag -f -a nightly-test-6.32.1 -m 'release testing'
Updated tag 'nightly-test-6.32.1' (was ec290f2a5)
++ git push origin nightly-test-6.32.1
To https://github.com/firebase/firebase-ios-sdk.git
 ! [rejected]            nightly-test-6.32.1 -> nightly-test-6.32.1 (already exists)
error: failed to push some refs to 'https://github.com/firebase/firebase-ios-sdk.git'
```
Tag updated to a remote should be removed first.

Will uncomment line 31 after review to avoid unexpected issues.
`# git push origin --delete "${tag_version}" `
