### PR TITLE
Update Crashlytics CHANGELOG with 4.6.0 released changes

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Unreleased
+- [fixed] Fixed Apple Watch crash related to sigaction (#6434).
+
+# v4.6.0
 - [added] Added stackFrameWithAddress API for recording custom errors that are symbolicated on the backend (#5975).
 - [fixed] Fixed comment typos (#6363).
 - [fixed] Remove device information from binary image data crash info entries (#6382).
-- [fixed] Fixed Apple Watch crash related to sigaction (#6434).
 
 # v4.5.0
 - [fixed] Fixed a compiler warning and removed unused networking code (#6210).


### PR DESCRIPTION
4.6.1 is releasing with just the Unreleased changes