### PR TITLE
GDT tests: Xcode 12 fixes

### DIFF
--- a/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
+++ b/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
@@ -356,16 +356,11 @@
 #pragma mark - Storage interaction tests
 
 - (void)testStorageSelectorWhenConditionsHighPriority {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
-  __weak __auto_type weakSelf = self;
-#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
-
+  __weak id weakSelf = self;
   [self assertStorageSelectorWithCondition:GDTCORUploadConditionHighPriority
                            validationBlock:^(GDTCORStorageEventSelector *_Nullable eventSelector,
                                              NSDate *expiration) {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
-                             __auto_type self = weakSelf;
-#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
+                             __unused id self = weakSelf;
                              XCTAssertLessThan([expiration timeIntervalSinceNow], 600);
                              XCTAssertEqual(eventSelector.selectedTarget, kGDTCORTargetTest);
                              XCTAssertNil(eventSelector.selectedEventIDs);
@@ -375,17 +370,12 @@
 }
 
 - (void)testStorageSelectorWhenConditionsMobileData {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
-  __weak __auto_type weakSelf = self;
-#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
-
+  __weak id weakSelf = self;
   [self
       assertStorageSelectorWithCondition:GDTCORUploadConditionMobileData
                          validationBlock:^(GDTCORStorageEventSelector *_Nullable eventSelector,
                                            NSDate *expiration) {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
-                           __auto_type self = weakSelf;
-#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
+                           __unused id self = weakSelf;
                            XCTAssertLessThan([expiration timeIntervalSinceNow], 600);
                            XCTAssertEqual(eventSelector.selectedTarget, kGDTCORTargetTest);
                            XCTAssertNil(eventSelector.selectedEventIDs);
@@ -398,18 +388,12 @@
 }
 
 - (void)testStorageSelectorWhenConditionsWifiData {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
-  __weak __auto_type weakSelf = self;
-#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
-
+  __weak id weakSelf = self;
   [self
       assertStorageSelectorWithCondition:GDTCORUploadConditionWifiData
                          validationBlock:^(GDTCORStorageEventSelector *_Nullable eventSelector,
                                            NSDate *expiration) {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
-                           __auto_type self = weakSelf;
-#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
-
+                           __unused id self = weakSelf;
                            XCTAssertLessThan([expiration timeIntervalSinceNow], 600);
                            XCTAssertEqual(eventSelector.selectedTarget, kGDTCORTargetTest);
                            XCTAssertNil(eventSelector.selectedEventIDs);
@@ -595,15 +579,10 @@
                                                 result:(BOOL)hasEvents {
   XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
   __weak __auto_type weakSelf = self;
-#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
-
   self.testStorage.hasEventsForTargetHandler =
       ^(GDTCORTarget target, GDTCCTTestStorageHasEventsCompletion _Nonnull completion) {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
-        __auto_type self = weakSelf;
-#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
+        __unused __auto_type self = weakSelf;
         [expectation fulfill];
         XCTAssertEqual(target, expectedTarget);
         completion(hasEvents);

--- a/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
+++ b/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
@@ -356,11 +356,16 @@
 #pragma mark - Storage interaction tests
 
 - (void)testStorageSelectorWhenConditionsHighPriority {
-  __weak id weakSelf = self;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
+  __weak __auto_type weakSelf = self;
+#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
+
   [self assertStorageSelectorWithCondition:GDTCORUploadConditionHighPriority
                            validationBlock:^(GDTCORStorageEventSelector *_Nullable eventSelector,
                                              NSDate *expiration) {
-                             id self = weakSelf;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
+                             __auto_type self = weakSelf;
+#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
                              XCTAssertLessThan([expiration timeIntervalSinceNow], 600);
                              XCTAssertEqual(eventSelector.selectedTarget, kGDTCORTargetTest);
                              XCTAssertNil(eventSelector.selectedEventIDs);
@@ -370,12 +375,17 @@
 }
 
 - (void)testStorageSelectorWhenConditionsMobileData {
-  __weak id weakSelf = self;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
+  __weak __auto_type weakSelf = self;
+#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
+
   [self
       assertStorageSelectorWithCondition:GDTCORUploadConditionMobileData
                          validationBlock:^(GDTCORStorageEventSelector *_Nullable eventSelector,
                                            NSDate *expiration) {
-                           id self = weakSelf;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
+                           __auto_type self = weakSelf;
+#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
                            XCTAssertLessThan([expiration timeIntervalSinceNow], 600);
                            XCTAssertEqual(eventSelector.selectedTarget, kGDTCORTargetTest);
                            XCTAssertNil(eventSelector.selectedEventIDs);
@@ -388,12 +398,18 @@
 }
 
 - (void)testStorageSelectorWhenConditionsWifiData {
-  __weak id weakSelf = self;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
+  __weak __auto_type weakSelf = self;
+#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
+
   [self
       assertStorageSelectorWithCondition:GDTCORUploadConditionWifiData
                          validationBlock:^(GDTCORStorageEventSelector *_Nullable eventSelector,
                                            NSDate *expiration) {
-                           id self = weakSelf;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
+                           __auto_type self = weakSelf;
+#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
+
                            XCTAssertLessThan([expiration timeIntervalSinceNow], 600);
                            XCTAssertEqual(eventSelector.selectedTarget, kGDTCORTargetTest);
                            XCTAssertNil(eventSelector.selectedEventIDs);
@@ -579,10 +595,15 @@
                                                 result:(BOOL)hasEvents {
   XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
   __weak __auto_type weakSelf = self;
+#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
+
   self.testStorage.hasEventsForTargetHandler =
       ^(GDTCORTarget target, GDTCCTTestStorageHasEventsCompletion _Nonnull completion) {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
         __auto_type self = weakSelf;
+#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
         [expectation fulfill];
         XCTAssertEqual(target, expectedTarget);
         completion(hasEvents);

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORTransformerTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORTransformerTest.m
@@ -168,12 +168,16 @@
   XCTestExpectation *endExpectation = [self expectationWithDescription:@"Background task end"];
 
   GDTCORBackgroundIdentifier taskID = arc4random();
-
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
   __auto_type __weak weakSelf = self;
+#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
 
   self.fakeApplication.beginTaskHandler =
       ^GDTCORBackgroundIdentifier(NSString *_Nonnull name, dispatch_block_t _Nonnull handler) {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
         __auto_type self = weakSelf;
+#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
+
         XCTAssertEqualObjects(expectedName, name);
 
         [beginExpectation fulfill];
@@ -181,7 +185,10 @@
       };
 
   self.fakeApplication.endTaskHandler = ^(GDTCORBackgroundIdentifier endTaskID) {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
     __auto_type self = weakSelf;
+#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
+
     XCTAssert(endTaskID == taskID);
     [endExpectation fulfill];
   };

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORTransformerTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORTransformerTest.m
@@ -168,16 +168,12 @@
   XCTestExpectation *endExpectation = [self expectationWithDescription:@"Background task end"];
 
   GDTCORBackgroundIdentifier taskID = arc4random();
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
+
   __auto_type __weak weakSelf = self;
-#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
 
   self.fakeApplication.beginTaskHandler =
       ^GDTCORBackgroundIdentifier(NSString *_Nonnull name, dispatch_block_t _Nonnull handler) {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
-        __auto_type self = weakSelf;
-#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
-
+        __unused __auto_type self = weakSelf;
         XCTAssertEqualObjects(expectedName, name);
 
         [beginExpectation fulfill];
@@ -185,10 +181,7 @@
       };
 
   self.fakeApplication.endTaskHandler = ^(GDTCORBackgroundIdentifier endTaskID) {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED < 140000  // Before Xcode 12
-    __auto_type self = weakSelf;
-#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED < 140000
-
+    __unused __auto_type self = weakSelf;
     XCTAssert(endTaskID == taskID);
     [endExpectation fulfill];
   };


### PR DESCRIPTION
- `XCAssert` maros family doesn't use `self` reference in Xcode 12 any more, so using `XCAssert...` in blocks doesn't require  `weakSelf`. Added `__unused ` modifier to silent the Xcode 12 warnings that fail `pod lib lint`. 

#no-changelog