### PR TITLE
GDT: remove pre Xcode 10 availability checks

### DIFF
--- a/GoogleDataTransport/CHANGELOG.md
+++ b/GoogleDataTransport/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Legacy pre Xcode 10 compatibility checks removed. (#6486)
+
 # v7.4.0
 - Limit disk space consumed by GoogleDataTransport to store events. (#6365)
 - Fix `GDTTransformer` background task handling.  (#6258)

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -127,8 +127,7 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
   if (networkCurrentRadioAccessTechnologyDict.count) {
     networkCurrentRadioAccessTechnology = networkCurrentRadioAccessTechnologyDict.allValues[0];
   }
-#else  // TARGET_OS_MACCATALYST
-#if defined(__IPHONE_12_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 120000
+#else   // TARGET_OS_MACCATALYST
   if (@available(iOS 12.0, *)) {
     NSDictionary<NSString *, NSString *> *networkCurrentRadioAccessTechnologyDict =
         networkInfo.serviceCurrentRadioAccessTechnology;
@@ -138,9 +137,7 @@ GDTCORNetworkMobileSubtype GDTCORNetworkMobileSubTypeMessage() {
       networkCurrentRadioAccessTechnology = networkCurrentRadioAccessTechnologyDict.allValues[0];
     }
   } else {
-#else   // defined(__IPHONE_12_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 120000
-  networkCurrentRadioAccessTechnology = networkInfo.currentRadioAccessTechnology;
-#endif  // // defined(__IPHONE_12_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 120000
+    networkCurrentRadioAccessTechnology = networkInfo.currentRadioAccessTechnology;
   }
 #endif  // TARGET_OS_MACCATALYST
   if (networkCurrentRadioAccessTechnology) {
@@ -194,11 +191,6 @@ NSData *_Nullable GDTCOREncodeArchive(id<NSSecureCoding> obj,
     }
   }
   NSData *resultData;
-#if (defined(__IPHONE_11_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000) || \
-    (defined(__MAC_10_13) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101300) ||      \
-    (defined(__TVOS_11_0) && __TV_OS_VERSION_MAX_ALLOWED >= 110000) ||       \
-    (defined(__WATCHOS_4_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= 040000) ||  \
-    (defined(TARGET_OS_MACCATALYST) && TARGET_OS_MACCATALYST)
   if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4, *)) {
     resultData = [NSKeyedArchiver archivedDataWithRootObject:obj
                                        requiringSecureCoding:YES
@@ -216,7 +208,6 @@ NSData *_Nullable GDTCOREncodeArchive(id<NSSecureCoding> obj,
       }
     }
   } else {
-#endif
     @try {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -248,11 +239,6 @@ id<NSSecureCoding> _Nullable GDTCORDecodeArchive(Class archiveClass,
                                                  NSData *_Nullable archiveData,
                                                  NSError *_Nullable *error) {
   id<NSSecureCoding> unarchivedObject = nil;
-#if (defined(__IPHONE_11_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000) || \
-    (defined(__MAC_10_13) && MAC_OS_X_VERSION_MAX_ALLOWED >= 101300) ||      \
-    (defined(__TVOS_11_0) && __TV_OS_VERSION_MAX_ALLOWED >= 110000) ||       \
-    (defined(__WATCHOS_4_0) && __WATCH_OS_VERSION_MAX_ALLOWED >= 040000) ||  \
-    (defined(TARGET_OS_MACCATALYST) && TARGET_OS_MACCATALYST)
   if (@available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4, *)) {
     NSData *data = archiveData ? archiveData : [NSData dataWithContentsOfFile:archivePath];
     if (data) {
@@ -261,7 +247,6 @@ id<NSSecureCoding> _Nullable GDTCORDecodeArchive(Class archiveClass,
                                                               error:error];
     }
   } else {
-#endif
     @try {
       NSData *archivedData =
           archiveData ? archiveData : [NSData dataWithContentsOfFile:archivePath];
@@ -388,7 +373,6 @@ static NSMutableDictionary<NSNumber *, dispatch_semaphore_t> *gBackgroundIdentif
                                name:name
                              object:nil];
 
-#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     if (@available(iOS 13, tvOS 13.0, *)) {
       [notificationCenter addObserver:self
                              selector:@selector(iOSApplicationWillEnterForeground:)
@@ -399,7 +383,6 @@ static NSMutableDictionary<NSNumber *, dispatch_semaphore_t> *gBackgroundIdentif
                                  name:UISceneWillDeactivateNotification
                                object:nil];
     }
-#endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
 
 #elif TARGET_OS_OSX
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORPlatform.m
@@ -373,6 +373,7 @@ static NSMutableDictionary<NSNumber *, dispatch_semaphore_t> *gBackgroundIdentif
                                name:name
                              object:nil];
 
+#if defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
     if (@available(iOS 13, tvOS 13.0, *)) {
       [notificationCenter addObserver:self
                              selector:@selector(iOSApplicationWillEnterForeground:)
@@ -383,6 +384,7 @@ static NSMutableDictionary<NSNumber *, dispatch_semaphore_t> *gBackgroundIdentif
                                  name:UISceneWillDeactivateNotification
                                object:nil];
     }
+#endif  // defined(__IPHONE_13_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
 
 #elif TARGET_OS_OSX
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];


### PR DESCRIPTION
Related to #6482 and #6483

- Keep Xcode 10 compatibility so far as we still verify it on Travis.