### PR TITLE
Generate missing Analytics warning only for iOS

### DIFF
--- a/CoreOnly/Sources/Firebase.h
+++ b/CoreOnly/Sources/Firebase.h
@@ -40,11 +40,10 @@
 
   #if __has_include(<FirebaseDynamicLinks/FirebaseDynamicLinks.h>)
     #import <FirebaseDynamicLinks/FirebaseDynamicLinks.h>
-    #if !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
+    #if TARGET_OS_IOS && !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
       #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
-        #warning "FirebaseAnalytics.framework is not included in your target. Please add \
-`Firebase/Analytics` to your Podfile or add FirebaseAnalytics.framework to your project to ensure \
-Firebase Dynamic Links works as intended."
+        #warning "FirebaseAnalytics.framework is not included in your target. Please add the \
+FirebaseAnalytics dependency to your project to ensure Firebase Dynamic Links works as intended."
       #endif // #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
     #endif
   #endif
@@ -59,11 +58,10 @@ Firebase Dynamic Links works as intended."
 
   #if __has_include(<FirebaseInAppMessaging/FirebaseInAppMessaging.h>)
     #import <FirebaseInAppMessaging/FirebaseInAppMessaging.h>
-    #if !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
+    #if TARGET_OS_IOS && !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
       #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
-        #warning "FirebaseAnalytics.framework is not included in your target. Please add \
-`Firebase/Analytics` to your Podfile or add FirebaseAnalytics.framework to your project to ensure \
-Firebase In App Messaging works as intended."
+        #warning "FirebaseAnalytics.framework is not included in your target. Please add the \
+FirebaseAnalytics dependency to your project to ensure Firebase In App Messaging works as intended."
       #endif // #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
     #endif
   #endif
@@ -74,11 +72,11 @@ Firebase In App Messaging works as intended."
 
   #if __has_include(<FirebaseMessaging/FirebaseMessaging.h>)
     #import <FirebaseMessaging/FirebaseMessaging.h>
-      #if !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
+      #if TARGET_OS_IOS && !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
       #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
-        #warning "FirebaseAnalytics.framework is not included in your target. Please add \
-`Firebase/Analytics` to your Podfile or add FirebaseAnalytics.framework to your project to ensure \
-Firebase Messaging works as intended."
+        #warning "FirebaseAnalytics.framework is not included in your target. Please add the \
+FirebaseAnalytics dependency to your project to ensure Messaging works as intended."
+
       #endif // #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
     #endif
   #endif
@@ -137,22 +135,20 @@ Firebase Messaging works as intended."
 
   #if __has_include(<FirebasePerformance/FirebasePerformance.h>)
     #import <FirebasePerformance/FirebasePerformance.h>
-    #if !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
+    #if TARGET_OS_IOS && !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
       #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
-        #warning "FirebaseAnalytics.framework is not included in your target. Please add \
-`Firebase/Analytics` to your Podfile or add FirebaseAnalytics.framework to your project to ensure \
-Firebase Performance works as intended."
+        #warning "FirebaseAnalytics.framework is not included in your target. Please add the \
+FirebaseAnalytics dependency to your project to ensure Firebase Performance works as intended."
       #endif // #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
     #endif
   #endif
 
   #if __has_include(<FirebaseRemoteConfig/FirebaseRemoteConfig.h>)
     #import <FirebaseRemoteConfig/FirebaseRemoteConfig.h>
-    #if !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
+    #if TARGET_OS_IOS && !__has_include(<FirebaseAnalytics/FirebaseAnalytics.h>)
       #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
-        #warning "FirebaseAnalytics.framework is not included in your target. Please add \
-`Firebase/Analytics` to your Podfile or add FirebaseAnalytics.framework to your project to ensure \
-Firebase Remote Config works as intended."
+        #warning "FirebaseAnalytics.framework is not included in your target. Please add the \
+FirebaseAnalytics dependency to your project to ensure Firebase Remote Config works as intended."
       #endif // #ifndef FIREBASE_ANALYTICS_SUPPRESS_WARNING
     #endif
   #endif


### PR DESCRIPTION
And simplify warning message so it works for any package manager.

Eliminate the warning since it is not currently possible to solve for macOS, tvOS and watchOS and missing Analytics support is documented.

See https://github.com/firebase/firebase-ios-sdk/issues/4557#issuecomment-695011515

For Firebase 7, consider completely eliminating these for iOS as well.

cc: @christibbs @chliangGoogle @eldhosembabu @visumickey @karenyz 