### PR TITLE
Fix SPM analytics warning introduced yesterday

### DIFF
--- a/FirebaseAnalyticsWrapper/include/dummy.h
+++ b/FirebaseAnalyticsWrapper/include/dummy.h
@@ -14,4 +14,5 @@
  * limitations under the License.
  */
 
-// Swift Package Manager needs at least one source file.
+// Swift Package Manager needs at least one header to prevent a warning. See
+// https://github.com/firebase/firebase-ios-sdk/pull/6504.

--- a/Package.swift
+++ b/Package.swift
@@ -214,7 +214,6 @@ let package = Package(
         .product(name: "nanopb", package: "nanopb"),
       ],
       path: "FirebaseAnalyticsWrapper",
-      publicHeadersPath: "Public",
       linkerSettings: [
         .linkedLibrary("sqlite3"),
         .linkedLibrary("c++"),

--- a/scripts/check_copyright.sh
+++ b/scripts/check_copyright.sh
@@ -24,8 +24,7 @@ options=(
 list=$(git grep "${options[@]}" -- \
     '*.'{c,cc,cmake,h,js,m,mm,py,rb,sh,swift} \
     CMakeLists.txt '**/CMakeLists.txt' \
-    ':(exclude)**/third_party/**' \
-    ':(exclude)FirebaseAnalyticsWrapper/**')
+    ':(exclude)**/third_party/**')
 
 # Allow copyrights before 2020 without LLC.
 result=$(grep -L 'Copyright 20[0-1][0-9].*Google' $list)


### PR DESCRIPTION
Fix #6503 

Adds a dummy header so the SPM-generated umbrella won't give a warning.
Fixes copyrights in FirebaseAnalyticsWrapper directory.

Disregard the CI failure since the failing test is pending the 6.33.0 CocoaPods publish.

#no-changelog