### PR TITLE
Temporarily disable failing test

### DIFF
--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -29,17 +29,19 @@ jobs:
     - name: Install Secret GoogleService-Info.plist
       run: scripts/decrypt_gha_secret.sh scripts/gha-encrypted/RemoteConfigSwiftAPI/GoogleService-Info.plist.gpg \
           FirebaseRemoteConfig/Tests/SwiftAPI/GoogleService-Info.plist "$plist_secret"
-    - name: Generate Access Token for RemoteConfigConsoleAPI in IntegrationTests
-      if: matrix.target == 'iOS'
-      run: scripts/generate_access_token.sh "$plist_secret" scripts/gha-encrypted/RemoteConfigSwiftAPI/ServiceAccount.json.gpg
-          FirebaseRemoteConfig/Tests/SwiftAPI/AccessToken.json
     - name: BuildAndUnitTest # can be replaced with pod lib lint with CocoaPods 1.10
       run: scripts/third_party/travis/retry.sh scripts/build.sh RemoteConfig ${{ matrix.target }} unit
     - name: Fake Console API Tests
       run: scripts/third_party/travis/retry.sh scripts/build.sh RemoteConfig iOS fakeconsole
-    - name: IntegrationTest
-      if: matrix.target == 'iOS'
-      run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh RemoteConfig iOS integration)
+    # Disable Integration test pending https://github.com/googleapis/google-auth-library-swift/issues/38
+    # See failure at https://github.com/firebase/firebase-ios-sdk/runs/1142644469?check_suite_focus=true
+    # - name: Generate Access Token for RemoteConfigConsoleAPI in IntegrationTests
+    #   if: matrix.target == 'iOS'
+    #   run: scripts/generate_access_token.sh "$plist_secret" scripts/gha-encrypted/RemoteConfigSwiftAPI/ServiceAccount.json.gpg
+    #       FirebaseRemoteConfig/Tests/SwiftAPI/AccessToken.json
+    # - name: IntegrationTest
+    #   if: matrix.target == 'iOS'
+    #   run: ([ -z $plist_secret ] || scripts/third_party/travis/retry.sh scripts/build.sh RemoteConfig iOS integration)
 
   pod-lib-lint:
     # Don't run on private repo unless it is a PR.


### PR DESCRIPTION
The RemoteConfig tests have been failing the last few nights because of https://github.com/googleapis/google-auth-library-swift/issues/38 breaking the integration tests.

Temporarily disabling.

#no-changelog