### PR TITLE
Update dependent Swift repo to fix CI breakage

### DIFF
--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -7,6 +7,7 @@ on:
     - 'Interop/Analytics/Public/*.h'
     - '.github/workflows/remoteconfig.yml'
     - 'Gemfile'
+    - 'scripts/generate_access_token.sh'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'

--- a/scripts/generate_access_token.sh
+++ b/scripts/generate_access_token.sh
@@ -74,11 +74,8 @@ export GOOGLE_APPLICATION_CREDENTIALS="${HOME}/.credentials/${SERVICE_ACCOUNT_FI
 
 # Clone Google's Swift Auth Client Library and use it to generate a token.
 # The generated token is piped to the specified OUTPUT file.
-
-# Use https://github.com/googleapis/google-auth-library-swift/pull/39 until it merges.
-git clone https://github.com/alexlaurinmath/google-auth-library-swift.git
+git clone https://github.com/googleapis/google-auth-library-swift.git
 cd google-auth-library-swift
-git checkout bump_OS_suported_versions
 make -f Makefile
 
 # Prepend OUTPUT path with ../ since we cd'd into `google-auth-library-swift`.

--- a/scripts/generate_access_token.sh
+++ b/scripts/generate_access_token.sh
@@ -74,9 +74,11 @@ export GOOGLE_APPLICATION_CREDENTIALS="${HOME}/.credentials/${SERVICE_ACCOUNT_FI
 
 # Clone Google's Swift Auth Client Library and use it to generate a token.
 # The generated token is piped to the specified OUTPUT file.
-git clone https://github.com/googleapis/google-auth-library-swift.git
+
+# Use https://github.com/googleapis/google-auth-library-swift/pull/39 until it merges.
+git clone https://github.com/alexlaurinmath/google-auth-library-swift.git
 cd google-auth-library-swift
-git checkout --quiet 7b1c9cd4ffd8cb784bcd8b7fd599794b69a810cf # Working main branch as of 7/9/20.
+git checkout bump_OS_suported_versions
 make -f Makefile
 
 # Prepend OUTPUT path with ../ since we cd'd into `google-auth-library-swift`.


### PR DESCRIPTION
Update to latest google-auth-library-swift with the needed fix at https://github.com/googleapis/google-auth-library-swift/pull/39 to fix [test breakage](https://github.com/firebase/firebase-ios-sdk/runs/1142644469?check_suite_focus=true).

#no-changelog