### PR TITLE
Update podspecs to min iOS 10

### DIFF
--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -7,6 +7,7 @@ on:
     - 'Interop/Analytics/Public/*.h'
     - '.github/workflows/remoteconfig.yml'
     - 'Gemfile'
+    - 'scripts/generate_access_token.sh'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'

--- a/.travis.yml
+++ b/.travis.yml
@@ -293,5 +293,4 @@ jobs:
 branches:
   only:
     - master
-    - pb-min10
     - firebase7-main

--- a/.travis.yml
+++ b/.travis.yml
@@ -293,3 +293,5 @@ jobs:
 branches:
   only:
     - master
+    - pb-min10
+    - firebase7-main

--- a/CocoapodsIntegrationTest/TestEnvironments/Cocoapods1_6_1_frameworks/Podfile
+++ b/CocoapodsIntegrationTest/TestEnvironments/Cocoapods1_6_1_frameworks/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 target 'CocoapodsIntegrationTest' do
   use_frameworks!

--- a/CocoapodsIntegrationTest/TestEnvironments/Cocoapods1_6_1_staticLibs/Podfile
+++ b/CocoapodsIntegrationTest/TestEnvironments/Cocoapods1_6_1_staticLibs/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 target 'CocoapodsIntegrationTest' do
   pod 'FirebaseABTesting', :path => '../'

--- a/CocoapodsIntegrationTest/TestEnvironments/Cocoapods1_7_0_frameworks/Podfile
+++ b/CocoapodsIntegrationTest/TestEnvironments/Cocoapods1_7_0_frameworks/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 target 'CocoapodsIntegrationTest' do
   use_frameworks!

--- a/CocoapodsIntegrationTest/TestEnvironments/Cocoapods1_7_0_multiprojects_frameworks/Podfile
+++ b/CocoapodsIntegrationTest/TestEnvironments/Cocoapods1_7_0_multiprojects_frameworks/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 target 'CocoapodsIntegrationTest' do
   # Comment the next line if you don't want to use dynamic frameworks

--- a/CocoapodsIntegrationTest/TestEnvironments/Cocoapods1_7_0_multiprojects_staticLibs/Podfile
+++ b/CocoapodsIntegrationTest/TestEnvironments/Cocoapods1_7_0_multiprojects_staticLibs/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 target 'CocoapodsIntegrationTest' do
   pod 'FirebaseABTesting', :path => '../'

--- a/CocoapodsIntegrationTest/TestEnvironments/Cocoapods1_7_0_staticLibs/Podfile
+++ b/CocoapodsIntegrationTest/TestEnvironments/Cocoapods1_7_0_staticLibs/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '9.0'
+platform :ios, '10.0'
 
 target 'CocoapodsIntegrationTest' do
   pod 'FirebaseABTesting', :path => '../'

--- a/CoreOnly/Tests/FirebasePodTest/Podfile
+++ b/CoreOnly/Tests/FirebasePodTest/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-# platform :ios, '9.0'
+platform :ios, '10.0'
 
 source 'https://github.com/firebase/SpecsStaging.git'
 source 'https://cdn.cocoapods.org/'

--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -22,8 +22,8 @@ Simplify your app development, grow your user base, and monetize more effectivel
     "CoreOnly/README.md"
   ]
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
 
   s.cocoapods_version = '>= 1.4.0'
@@ -49,13 +49,14 @@ Simplify your app development, grow your user base, and monetize more effectivel
       }
     end
     # Standard platforms PLUS watchOS.
-    ss.ios.deployment_target = '8.0'
-    ss.osx.deployment_target = '10.11'
+    ss.ios.deployment_target = '9.0'
+    ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '10.0'
     ss.watchos.deployment_target = '6.0'
   end
 
   s.subspec 'Analytics' do |ss|
+    ss.ios.deployment_target = '9.0'
     ss.dependency 'Firebase/Core'
   end
 
@@ -66,15 +67,13 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'AdMob' do |ss|
     ss.dependency 'Firebase/CoreOnly'
-    # 7.64 bumps the minimum iOS version to 9.0, so don't update here until
-    # next major version.
+    ss.ios.deployment_target = '9.0'
     ss.ios.dependency 'Google-Mobile-Ads-SDK', '~> 7.63'
   end
 
   s.subspec 'AppDistribution' do |ss|
     ss.dependency 'Firebase/CoreOnly'
     ss.ios.dependency 'FirebaseAppDistribution', '~> 0.9.1'
-    ss.ios.deployment_target = '9.0'
   end
 
   s.subspec 'Auth' do |ss|
@@ -117,8 +116,8 @@ Simplify your app development, grow your user base, and monetize more effectivel
     ss.dependency 'Firebase/CoreOnly'
     ss.dependency 'FirebaseMessaging', '~> 4.6.2'
     # Standard platforms PLUS watchOS.
-    ss.ios.deployment_target = '8.0'
-    ss.osx.deployment_target = '10.11'
+    ss.ios.deployment_target = '10.0'
+    ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '10.0'
     ss.watchos.deployment_target = '6.0'
   end
@@ -137,8 +136,8 @@ Simplify your app development, grow your user base, and monetize more effectivel
     ss.dependency 'Firebase/CoreOnly'
     ss.dependency 'FirebaseStorage', '~> 3.9.0'
     # Standard platforms PLUS watchOS.
-    ss.ios.deployment_target = '8.0'
-    ss.osx.deployment_target = '10.11'
+    ss.ios.deployment_target = '10.0'
+    ss.osx.deployment_target = '10.12'
     ss.tvos.deployment_target = '10.0'
     ss.watchos.deployment_target = '6.0'
   end

--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -20,8 +20,8 @@ Firebase Cloud Messaging and Firebase Remote Config in your app.
     :tag => 'ABTesting-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
 
   s.cocoapods_version = '>= 1.4.0'

--- a/FirebaseAppDistribution.podspec
+++ b/FirebaseAppDistribution.podspec
@@ -15,7 +15,7 @@ iOS SDK for App Distribution for Firebase.
     :tag => 'AppDistribution-' + s.version.to_s
   }
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '10.0'
 
   s.cocoapods_version = '>= 1.4.0'
   s.static_framework = true

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -17,8 +17,8 @@ supports email and password accounts, as well as several 3rd party authenticatio
     :tag => 'Auth-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '6.0'
 

--- a/FirebaseAuth/Tests/Sample/Podfile
+++ b/FirebaseAuth/Tests/Sample/Podfile
@@ -8,7 +8,7 @@ source 'https://cdn.cocoapods.org/'
 use_frameworks!
 
 target 'AuthSample' do
-  platform :ios, '8.0'
+  platform :ios, '10.0'
   pod 'FirebaseCore', :path => '../../../'
   pod 'FirebaseCoreDiagnostics', :path => '../../../'
   pod 'GoogleDataTransport', :path => '../../../'

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -16,8 +16,8 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
     :tag => 'Core-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '6.0'
 

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Firebase 7.0.0
 - [changed] Update minimum iOS version to iOS 10 except for Analytics which is now iOS 9. (#4847)
-- [changed] Update minimum OSX version to 10.12.
+- [changed] Update minimum macOS version to 10.12.
 
 # Firebase 6.32.0
 - [changed] Swift Package Manager - It's no longer necessary to select the Firebase or

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Firebase 7.0.0
+- [changed] Update minimum iOS version to iOS 10 except for Analytics which is now iOS 9. (#4847)
+- [changed] Update minimum OSX version to 10.12.
+
 # Firebase 6.32.0
 - [changed] Swift Package Manager - It's no longer necessary to select the Firebase or
   FirebaseCore products. Their build targets are implicitly selected when choosing any other

--- a/FirebaseCoreDiagnostics.podspec
+++ b/FirebaseCoreDiagnostics.podspec
@@ -18,8 +18,8 @@ non-Cocoapod integration. This library also respects the Firebase global data co
     :tag => 'CoreDiagnostics-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '6.0'
 

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -11,8 +11,8 @@ Pod::Spec.new do |s|
     :tag => 'Crashlytics-' + s.version.to_s
   }
 
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '6.0'
 

--- a/FirebaseDatabase.podspec
+++ b/FirebaseDatabase.podspec
@@ -16,8 +16,8 @@ Simplify your iOS development, grow your user base, and monetize more effectivel
     :tag => 'Database-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
 
   s.cocoapods_version = '>= 1.4.0'

--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -16,7 +16,7 @@ Firebase Dynamic Links are deep links that enhance user experience and increase 
     :tag => 'DynamicLinks-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '10.0'
 
   s.cocoapods_version = '>= 1.4.0'
   s.static_framework = true

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
@@ -531,16 +531,6 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
 }
 
 - (void)passRetrievedDynamicLinkToApplication:(NSURL *)url {
-  id<UIApplicationDelegate> applicationDelegate = [UIApplication sharedApplication].delegate;
-  if (applicationDelegate &&
-      [applicationDelegate respondsToSelector:@selector(application:openURL:options:)]) {
-    // pass url directly to application delegate to avoid hop into
-    // iOS handling of the universal links
-    if (@available(iOS 9.0, *)) {
-      [applicationDelegate application:[UIApplication sharedApplication] openURL:url options:@{}];
-      return;
-    }
-  }
   [[UIApplication sharedApplication] openURL:url];
 }
 

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
@@ -531,7 +531,7 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
 }
 
 - (void)passRetrievedDynamicLinkToApplication:(NSURL *)url {
-  [[UIApplication sharedApplication] openURL:url];
+  [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
 }
 
 - (void)handlePendingDynamicLinkRetrievalFailureWithErrorCode:(NSInteger)errorCode

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -16,8 +16,8 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
     :tag => 'Firestore-' + s.version.to_s
   }
 
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
 
   s.cocoapods_version = '>= 1.4.0'

--- a/FirebaseFirestoreSwift.podspec
+++ b/FirebaseFirestoreSwift.podspec
@@ -22,8 +22,8 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   }
 
   s.swift_version           = '4.1'
-  s.ios.deployment_target   = '8.0'
-  s.osx.deployment_target   = '10.11'
+  s.ios.deployment_target   = '10.0'
+  s.osx.deployment_target   = '10.12'
   s.tvos.deployment_target  = '10.0'
 
   s.cocoapods_version       = '>= 1.4.0'

--- a/FirebaseFunctions.podspec
+++ b/FirebaseFunctions.podspec
@@ -15,8 +15,8 @@ Cloud Functions for Firebase.
     :tag => 'Functions-' + s.version.to_s
   }
 
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
 
   s.cocoapods_version = '>= 1.4.0'

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -17,7 +17,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
     :tag => 'InAppMessaging-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '10.0'
 
   s.cocoapods_version = '>= 1.4.0'
   s.static_framework = true

--- a/FirebaseInAppMessaging/Tests/Integration/DefaultUITestApp/Podfile
+++ b/FirebaseInAppMessaging/Tests/Integration/DefaultUITestApp/Podfile
@@ -11,7 +11,7 @@ pod 'GoogleUtilities', :path => '../../../..'
 pod 'FirebaseABTesting', :path => '../../../..'
 
 target 'FiamDisplaySwiftExample' do
-  platform :ios, '9.0'
+  platform :ios, '10.0'
   pod 'FirebaseInAppMessaging', :path => '../../../..'
 end
 

--- a/FirebaseInAppMessaging/Tests/Unit/FIRIAMActionUrlFollowerTests.m
+++ b/FirebaseInAppMessaging/Tests/Unit/FIRIAMActionUrlFollowerTests.m
@@ -108,18 +108,12 @@
 
 - (void)setupOpenURLViaIOSForUIApplicationWithReturnValue:(BOOL)returnValue {
   // it would fallback to either openURL:options:completionHandler:
-  //   or openURL: on the UIApplication object to follow the url
-  if ([self.mockApplication respondsToSelector:@selector(openURL:options:completionHandler:)]) {
-    // id types is needed for calling invokeBlockWithArgs
-    id yesOrNo = returnValue ? @YES : @NO;
-    if (@available(iOS 10.0, *)) {
-      OCMStub([self.mockApplication openURL:[OCMArg any]
-                                    options:[OCMArg any]
-                          completionHandler:([OCMArg invokeBlockWithArgs:yesOrNo, nil])]);
-    }
-  } else {
-    OCMStub([self.mockApplication openURL:[OCMArg any]]).andReturn(returnValue);
-  }
+  //   on the UIApplication object to follow the url
+  // id types is needed for calling invokeBlockWithArgs
+  id yesOrNo = returnValue ? @YES : @NO;
+  OCMStub([self.mockApplication openURL:[OCMArg any]
+                                options:[OCMArg any]
+                      completionHandler:([OCMArg invokeBlockWithArgs:yesOrNo, nil])]);
 }
 
 - (void)testUniversalLinkHandlingReturnNo {

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     :tag => 'Installations-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '6.0'
@@ -56,7 +56,7 @@ Pod::Spec.new do |s|
   }
 
   s.test_spec 'unit' do |unit_tests|
-    unit_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}
+    unit_tests.platforms = {:ios => '9.0', :osx => '10.12', :tvos => '10.0'}
     unit_tests.source_files = base_dir + 'Tests/Unit/**/*.[mh]',
                               base_dir + 'Tests/Utils/**/*.[mh]'
     unit_tests.resources = base_dir + 'Tests/Fixture/**/*'
@@ -67,7 +67,7 @@ Pod::Spec.new do |s|
   end
 
   s.test_spec 'integration' do |int_tests|
-    int_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}
+    int_tests.platforms = {:ios => '9.0', :osx => '10.12', :tvos => '10.0'}
     int_tests.source_files = base_dir + 'Tests/Integration/**/*.[mh]'
     int_tests.resources = base_dir + 'Tests/Resources/**/*'
     if ENV['FIS_INTEGRATION_TESTS_REQUIRED'] && ENV['FIS_INTEGRATION_TESTS_REQUIRED'] == '1' then

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -16,8 +16,8 @@ Pod::Spec.new do |s|
     :tag => 'Installations-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '6.0'
 

--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -18,8 +18,8 @@ services.
     :tag => 'InstanceID-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '6.0'
 

--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -65,7 +65,7 @@ services.
   end
 
    s.test_spec 'integration' do |int_tests|
-    int_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}
+    int_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
     int_tests.source_files = 'Example/InstanceID/IntegrationTests/*.[mh]'
     int_tests.resources = 'Example/InstanceID/Resources/**/*'
     int_tests.requires_app_host = true

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -19,8 +19,8 @@ device, and it is completely free.
     :tag => 'Messaging-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '6.0'
 

--- a/FirebaseMessaging.podspec
+++ b/FirebaseMessaging.podspec
@@ -62,7 +62,7 @@ device, and it is completely free.
   s.dependency 'GoogleUtilities/UserDefaults', '~> 6.7'
 
   s.test_spec 'unit' do |unit_tests|
-    unit_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}
+    unit_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
     unit_tests.source_files = 'FirebaseMessaging/Tests/UnitTests/*.{m,h,swift}'
     unit_tests.requires_app_host = true
     unit_tests.pod_target_xcconfig = {
@@ -72,7 +72,7 @@ device, and it is completely free.
   end
 
   s.test_spec 'integration' do |int_tests|
-    int_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}
+    int_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
     int_tests.source_files = 'FirebaseMessaging/Tests/IntegrationTests/*.swift'
     int_tests.requires_app_host = true
     int_tests.resources = 'FirebaseMessaging/Tests/IntegrationTests/Resources/GoogleService-Info.plist'

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -18,8 +18,8 @@ app update.
     :tag => 'RemoteConfig-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
 
   s.cocoapods_version = '>= 1.4.0'

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -45,7 +45,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   }
 
   s.test_spec 'unit' do |unit_tests|
-    unit_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}
+    unit_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
     unit_tests.source_files = 'FirebaseStorage/Tests/Unit/*.[mh]',
                               'SharedTestUtilities/FIRComponentTestUtilities.*',
                               'SharedTestUtilities/FIRAuthInteropFake.*'
@@ -53,7 +53,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   end
 
   s.test_spec 'integration' do |int_tests|
-    int_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}
+    int_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
     int_tests.source_files = 'FirebaseStorage/Tests/Integration/*.[mh]'
     int_tests.requires_app_host = true
     int_tests.resources = 'FirebaseStorage/Tests/Integration/Resources/1mb.dat',
@@ -62,7 +62,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   end
 
   s.test_spec 'swift-integration' do |swift_int_tests|
-    swift_int_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}
+    swift_int_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
     swift_int_tests.source_files = 'FirebaseStorage/Tests/SwiftIntegration/*.swift'
     swift_int_tests.requires_app_host = true
     swift_int_tests.resources = 'FirebaseStorage/Tests/Integration/Resources/1mb.dat',

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -16,8 +16,8 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
     :tag => 'Storage-' + s.version.to_s
   }
   s.social_media_url = 'https://twitter.com/Firebase'
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '6.0'
 

--- a/FirebaseStorageSwift.podspec
+++ b/FirebaseStorageSwift.podspec
@@ -18,8 +18,8 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   }
 
   s.swift_version           = '5.0'
-  s.ios.deployment_target   = '8.0'
-  s.osx.deployment_target   = '10.11'
+  s.ios.deployment_target   = '10.0'
+  s.osx.deployment_target   = '10.12'
   s.tvos.deployment_target  = '10.0'
   s.watchos.deployment_target = '6.0'
 

--- a/FirebaseStorageSwift.podspec
+++ b/FirebaseStorageSwift.podspec
@@ -34,7 +34,7 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   s.dependency 'FirebaseStorage', '~> 3.6'
 
   s.test_spec 'integration' do |int_tests|
-    int_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}
+    int_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
     int_tests.source_files = 'FirebaseStorageSwift/Tests/Integration/*.swift'
     int_tests.requires_app_host = true
     # Resources are shared with FirebaseStorage's integration tests.

--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -1447,9 +1447,9 @@
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		87553338E42B8ECA05BA987E /* grpc_stream_tester.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = grpc_stream_tester.cc; sourceTree = "<group>"; };
 		88CF09277CFA45EE1273E3BA /* leveldb_transaction_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = leveldb_transaction_test.cc; sourceTree = "<group>"; };
-		899FC22684B0F7BEEAE13527 /* task_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = task_test.cc; sourceTree = "<group>"; };
+		899FC22684B0F7BEEAE13527 /* task_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = task_test.cc; sourceTree = "<group>"; };
 		8A41BBE832158C76BE901BC9 /* mutation_queue_test.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = mutation_queue_test.h; sourceTree = "<group>"; };
-		8ABAC2E0402213D837F73DC3 /* defer_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = defer_test.cc; sourceTree = "<group>"; };
+		8ABAC2E0402213D837F73DC3 /* defer_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = defer_test.cc; sourceTree = "<group>"; };
 		8C058C8BE2723D9A53CCD64B /* persistence_testing.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = persistence_testing.h; sourceTree = "<group>"; };
 		8E002F4AD5D9B6197C940847 /* Firestore.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Firestore.podspec; path = ../Firestore.podspec; sourceTree = "<group>"; };
 		9098A0C535096F2EE9C35DE0 /* create_noop_connectivity_monitor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = create_noop_connectivity_monitor.h; sourceTree = "<group>"; };
@@ -1458,7 +1458,7 @@
 		97C492D2524E92927C11F425 /* Pods-Firestore_FuzzTests_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_FuzzTests_iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_FuzzTests_iOS/Pods-Firestore_FuzzTests_iOS.release.xcconfig"; sourceTree = "<group>"; };
 		98366480BD1FD44A1FEDD982 /* Pods-Firestore_Example_macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Example_macOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Example_macOS/Pods-Firestore_Example_macOS.debug.xcconfig"; sourceTree = "<group>"; };
 		99434327614FEFF7F7DC88EC /* counting_query_engine.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = counting_query_engine.cc; sourceTree = "<group>"; };
-		9B0B005A79E765AF02793DCE /* schedule_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; path = schedule_test.cc; sourceTree = "<group>"; };
+		9B0B005A79E765AF02793DCE /* schedule_test.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = schedule_test.cc; sourceTree = "<group>"; };
 		9CFD366B783AE27B9E79EE7A /* string_format_apple_test.mm */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.objcpp; path = string_format_apple_test.mm; sourceTree = "<group>"; };
 		A5466E7809AD2871FFDE6C76 /* view_testing.cc */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.cpp.cpp; path = view_testing.cc; sourceTree = "<group>"; };
 		A5FA86650A18F3B7A8162287 /* Pods-Firestore_Benchmarks_iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Firestore_Benchmarks_iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-Firestore_Benchmarks_iOS/Pods-Firestore_Benchmarks_iOS.release.xcconfig"; sourceTree = "<group>"; };
@@ -4892,6 +4892,7 @@
 					"\"${PODS_ROOT}/leveldb-library/include\"",
 				);
 				INFOPLIST_FILE = "App/iOS/Firestore-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -4914,6 +4915,7 @@
 					"\"${PODS_ROOT}/leveldb-library/include\"",
 				);
 				INFOPLIST_FILE = "App/iOS/Firestore-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
@@ -5104,7 +5106,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/App/macOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.google.Firestore-macOS";
@@ -5143,7 +5145,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/App/macOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.google.Firestore-macOS";

--- a/Firestore/Example/Firestore.xcodeproj/project.pbxproj
+++ b/Firestore/Example/Firestore.xcodeproj/project.pbxproj
@@ -4517,7 +4517,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.google.Firestore-Tests-macOS";
@@ -4543,7 +4542,6 @@
 				COPY_PHASE_STRIP = NO;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.google.Firestore-Tests-macOS";
@@ -4574,7 +4572,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Debug;
 		};
@@ -4599,7 +4596,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Release;
 		};
@@ -4622,7 +4618,6 @@
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Firestore_Example_tvOS.app/Firestore_Example_tvOS";
-				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Debug;
 		};
@@ -4646,7 +4641,6 @@
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Firestore_Example_tvOS.app/Firestore_Example_tvOS";
-				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Release;
 		};
@@ -4669,7 +4663,6 @@
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Firestore_Example_tvOS.app/Firestore_Example_tvOS";
-				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Debug;
 		};
@@ -4693,7 +4686,6 @@
 				SDKROOT = appletvos;
 				TARGETED_DEVICE_FAMILY = 3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Firestore_Example_tvOS.app/Firestore_Example_tvOS";
-				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Release;
 		};
@@ -4712,7 +4704,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.google.Firestore-IntegrationTests-macOS";
@@ -4738,7 +4729,6 @@
 				COPY_PHASE_STRIP = NO;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "Tests/Tests-Info.plist";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.google.Firestore-IntegrationTests-macOS";
@@ -4823,11 +4813,13 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Debug;
 		};
@@ -4870,11 +4862,13 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_CFLAGS = "";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -4892,7 +4886,6 @@
 					"\"${PODS_ROOT}/leveldb-library/include\"",
 				);
 				INFOPLIST_FILE = "App/iOS/Firestore-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -4915,7 +4908,6 @@
 					"\"${PODS_ROOT}/leveldb-library/include\"",
 				);
 				INFOPLIST_FILE = "App/iOS/Firestore-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.demo.${PRODUCT_NAME:rfc1034identifier}";
@@ -5106,7 +5098,6 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/App/macOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.google.Firestore-macOS";
@@ -5145,7 +5136,6 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/App/macOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.google.Firestore-macOS";

--- a/Firestore/Example/GoogleBenchmark.podspec
+++ b/Firestore/Example/GoogleBenchmark.podspec
@@ -33,8 +33,8 @@ Google's C++ benchmark framework.
       :tag => 'v' + s.version.to_s
   }
 
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
 
   s.requires_arc = false

--- a/Firestore/Example/GoogleTest.podspec
+++ b/Firestore/Example/GoogleTest.podspec
@@ -33,8 +33,8 @@ Google's C++ test framework.
     :tag => 'release-' + s.version.to_s
   }
 
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
 
   s.requires_arc = false

--- a/Firestore/Example/LibFuzzer.podspec
+++ b/Firestore/Example/LibFuzzer.podspec
@@ -28,10 +28,8 @@ Pod::Spec.new do |s|
   s.license             = { :type => 'BSD-Like' }
   s.authors             = 'LLVM Team'
 
-  # LibFuzzer uses thread_local which does not appear to be supported before
-  # iOS 9.
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
 
   # Check out only libFuzzer folder.

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -121,7 +121,7 @@ if is_platform(:ios)
 
     target 'Firestore_FuzzTests_iOS' do
       inherit! :search_paths
-      platform :ios, '9.0'
+      platform :ios, '10.0'
 
       pod 'LibFuzzer', :podspec => 'LibFuzzer.podspec', :inhibit_warnings => true
     end

--- a/Firestore/Example/Podfile
+++ b/Firestore/Example/Podfile
@@ -88,7 +88,7 @@ end
 
 if is_platform(:ios)
   target 'Firestore_Example_iOS' do
-    platform :ios, '8.0'
+    platform :ios, '10.0'
 
     configure_local_pods()
 
@@ -130,7 +130,7 @@ end
 
 if is_platform(:osx)
   target 'Firestore_Example_macOS' do
-    platform :osx, '10.11'
+    platform :osx, '10.12'
 
     configure_local_pods()
 

--- a/Firestore/Example/ProtobufCpp.podspec
+++ b/Firestore/Example/ProtobufCpp.podspec
@@ -29,8 +29,8 @@ Pod::Spec.new do |s|
     :tag => "v#{s.version}"
   }
 
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
 
   s.source_files = 'src/**/*.{h,cc,inc}'

--- a/GoogleDataTransport.podspec
+++ b/GoogleDataTransport.podspec
@@ -15,8 +15,8 @@ Shared library for iOS SDK data transport needs.
     :tag => 'DataTransport-' + s.version.to_s
   }
 
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '6.0'
 

--- a/GoogleUtilities.podspec
+++ b/GoogleUtilities.podspec
@@ -17,8 +17,8 @@ other Google CocoaPods. They're not intended for direct public usage.
     :tag => 'Utilities-' + s.version.to_s
   }
 
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '6.0'
 

--- a/GoogleUtilitiesComponents.podspec
+++ b/GoogleUtilitiesComponents.podspec
@@ -18,8 +18,8 @@ Not intended for direct public usage.
     :tag => 'UtilitiesComponents-' + s.version.to_s
   }
 
-  s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.11'
+  s.ios.deployment_target = '10.0'
+  s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
 
   s.cocoapods_version = '>= 1.4.0'

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let firebaseVersion = "6.32.0"
 
 let package = Package(
   name: "Firebase",
-  platforms: [.iOS(.v9), .macOS(.v10_11), .tvOS(.v10)],
+  platforms: [.iOS(.v10), .macOS(.v10_12), .tvOS(.v10)],
   products: [
     .library(
       name: "FirebaseAnalytics",

--- a/SymbolCollisionTest/SymbolCollisionTest.xcodeproj/project.pbxproj
+++ b/SymbolCollisionTest/SymbolCollisionTest.xcodeproj/project.pbxproj
@@ -13,13 +13,9 @@
 		DE26C60921B884BB00DE141A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DE26C60821B884BB00DE141A /* Assets.xcassets */; };
 		DE26C60C21B884BB00DE141A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DE26C60A21B884BB00DE141A /* LaunchScreen.storyboard */; };
 		DE26C60F21B884BB00DE141A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = DE26C60E21B884BB00DE141A /* main.m */; };
-		E280D9BCC95F96FDF7BFABD5 /* libPods-SymbolCollisionTest.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7EEA9C6C401724A8231F4133 /* libPods-SymbolCollisionTest.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		2C19189FE79DB7E8DE511B5B /* Pods-SymbolCollisionTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SymbolCollisionTest.debug.xcconfig"; path = "Target Support Files/Pods-SymbolCollisionTest/Pods-SymbolCollisionTest.debug.xcconfig"; sourceTree = "<group>"; };
-		7EEA9C6C401724A8231F4133 /* libPods-SymbolCollisionTest.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SymbolCollisionTest.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		900992D7304A8E5DD4A60C2A /* Pods-SymbolCollisionTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SymbolCollisionTest.release.xcconfig"; path = "Target Support Files/Pods-SymbolCollisionTest/Pods-SymbolCollisionTest.release.xcconfig"; sourceTree = "<group>"; };
 		DE26C5FC21B884BA00DE141A /* SymbolCollisionTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SymbolCollisionTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE26C5FF21B884BA00DE141A /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		DE26C60021B884BA00DE141A /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -37,38 +33,17 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E280D9BCC95F96FDF7BFABD5 /* libPods-SymbolCollisionTest.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		5FBE0AF9D39C2F4583F96FB2 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				7EEA9C6C401724A8231F4133 /* libPods-SymbolCollisionTest.a */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		B09776D8084CF55B6C5FE9C3 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				2C19189FE79DB7E8DE511B5B /* Pods-SymbolCollisionTest.debug.xcconfig */,
-				900992D7304A8E5DD4A60C2A /* Pods-SymbolCollisionTest.release.xcconfig */,
-			);
-			name = Pods;
-			path = Pods;
-			sourceTree = "<group>";
-		};
 		DE26C5F321B884BA00DE141A = {
 			isa = PBXGroup;
 			children = (
 				DE26C5FE21B884BA00DE141A /* SymbolCollisionTest */,
 				DE26C5FD21B884BA00DE141A /* Products */,
-				B09776D8084CF55B6C5FE9C3 /* Pods */,
-				5FBE0AF9D39C2F4583F96FB2 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -103,12 +78,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DE26C61221B884BB00DE141A /* Build configuration list for PBXNativeTarget "SymbolCollisionTest" */;
 			buildPhases = (
-				EA06E99A3B1A665D7D041C13 /* [CP] Check Pods Manifest.lock */,
 				DE26C5F821B884BA00DE141A /* Sources */,
 				DE26C5F921B884BA00DE141A /* Frameworks */,
 				DE26C5FA21B884BA00DE141A /* Resources */,
-				F2C5455F8B789BF5441091D3 /* [CP] Embed Pods Frameworks */,
-				98711F364D7F00E9D0241060 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -163,65 +135,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		98711F364D7F00E9D0241060 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-SymbolCollisionTest/Pods-SymbolCollisionTest-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-SymbolCollisionTest/Pods-SymbolCollisionTest-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SymbolCollisionTest/Pods-SymbolCollisionTest-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		EA06E99A3B1A665D7D041C13 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-SymbolCollisionTest-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F2C5455F8B789BF5441091D3 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-SymbolCollisionTest/Pods-SymbolCollisionTest-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-SymbolCollisionTest/Pods-SymbolCollisionTest-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SymbolCollisionTest/Pods-SymbolCollisionTest-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		DE26C5F821B884BA00DE141A /* Sources */ = {
@@ -370,7 +283,6 @@
 		};
 		DE26C61321B884BB00DE141A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2C19189FE79DB7E8DE511B5B /* Pods-SymbolCollisionTest.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -392,7 +304,6 @@
 		};
 		DE26C61421B884BB00DE141A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 900992D7304A8E5DD4A60C2A /* Pods-SymbolCollisionTest.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;

--- a/SymbolCollisionTest/SymbolCollisionTest.xcodeproj/project.pbxproj
+++ b/SymbolCollisionTest/SymbolCollisionTest.xcodeproj/project.pbxproj
@@ -13,9 +13,13 @@
 		DE26C60921B884BB00DE141A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DE26C60821B884BB00DE141A /* Assets.xcassets */; };
 		DE26C60C21B884BB00DE141A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DE26C60A21B884BB00DE141A /* LaunchScreen.storyboard */; };
 		DE26C60F21B884BB00DE141A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = DE26C60E21B884BB00DE141A /* main.m */; };
+		E280D9BCC95F96FDF7BFABD5 /* libPods-SymbolCollisionTest.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7EEA9C6C401724A8231F4133 /* libPods-SymbolCollisionTest.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2C19189FE79DB7E8DE511B5B /* Pods-SymbolCollisionTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SymbolCollisionTest.debug.xcconfig"; path = "Target Support Files/Pods-SymbolCollisionTest/Pods-SymbolCollisionTest.debug.xcconfig"; sourceTree = "<group>"; };
+		7EEA9C6C401724A8231F4133 /* libPods-SymbolCollisionTest.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-SymbolCollisionTest.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		900992D7304A8E5DD4A60C2A /* Pods-SymbolCollisionTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SymbolCollisionTest.release.xcconfig"; path = "Target Support Files/Pods-SymbolCollisionTest/Pods-SymbolCollisionTest.release.xcconfig"; sourceTree = "<group>"; };
 		DE26C5FC21B884BA00DE141A /* SymbolCollisionTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SymbolCollisionTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE26C5FF21B884BA00DE141A /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		DE26C60021B884BA00DE141A /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -33,17 +37,38 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E280D9BCC95F96FDF7BFABD5 /* libPods-SymbolCollisionTest.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5FBE0AF9D39C2F4583F96FB2 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				7EEA9C6C401724A8231F4133 /* libPods-SymbolCollisionTest.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		B09776D8084CF55B6C5FE9C3 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				2C19189FE79DB7E8DE511B5B /* Pods-SymbolCollisionTest.debug.xcconfig */,
+				900992D7304A8E5DD4A60C2A /* Pods-SymbolCollisionTest.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		DE26C5F321B884BA00DE141A = {
 			isa = PBXGroup;
 			children = (
 				DE26C5FE21B884BA00DE141A /* SymbolCollisionTest */,
 				DE26C5FD21B884BA00DE141A /* Products */,
+				B09776D8084CF55B6C5FE9C3 /* Pods */,
+				5FBE0AF9D39C2F4583F96FB2 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -78,9 +103,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DE26C61221B884BB00DE141A /* Build configuration list for PBXNativeTarget "SymbolCollisionTest" */;
 			buildPhases = (
+				EA06E99A3B1A665D7D041C13 /* [CP] Check Pods Manifest.lock */,
 				DE26C5F821B884BA00DE141A /* Sources */,
 				DE26C5F921B884BA00DE141A /* Frameworks */,
 				DE26C5FA21B884BA00DE141A /* Resources */,
+				F2C5455F8B789BF5441091D3 /* [CP] Embed Pods Frameworks */,
+				98711F364D7F00E9D0241060 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -135,6 +163,65 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		98711F364D7F00E9D0241060 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SymbolCollisionTest/Pods-SymbolCollisionTest-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SymbolCollisionTest/Pods-SymbolCollisionTest-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SymbolCollisionTest/Pods-SymbolCollisionTest-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EA06E99A3B1A665D7D041C13 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-SymbolCollisionTest-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F2C5455F8B789BF5441091D3 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SymbolCollisionTest/Pods-SymbolCollisionTest-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-SymbolCollisionTest/Pods-SymbolCollisionTest-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-SymbolCollisionTest/Pods-SymbolCollisionTest-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		DE26C5F821B884BA00DE141A /* Sources */ = {
@@ -283,6 +370,7 @@
 		};
 		DE26C61321B884BB00DE141A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2C19189FE79DB7E8DE511B5B /* Pods-SymbolCollisionTest.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -304,6 +392,7 @@
 		};
 		DE26C61421B884BB00DE141A /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 900992D7304A8E5DD4A60C2A /* Pods-SymbolCollisionTest.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;

--- a/scripts/generate_access_token.sh
+++ b/scripts/generate_access_token.sh
@@ -76,7 +76,6 @@ export GOOGLE_APPLICATION_CREDENTIALS="${HOME}/.credentials/${SERVICE_ACCOUNT_FI
 # The generated token is piped to the specified OUTPUT file.
 git clone https://github.com/googleapis/google-auth-library-swift.git
 cd google-auth-library-swift
-git checkout --quiet 7b1c9cd4ffd8cb784bcd8b7fd599794b69a810cf # Working main branch as of 7/9/20.
 make -f Makefile
 
 # Prepend OUTPUT path with ../ since we cd'd into `google-auth-library-swift`.

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -47,7 +47,7 @@ def main(args)
 
   STDOUT.sync = true
 
-  command = %w(bundle exec pod lib lint --sources=https://github.com/firebase/SpecsStaging.git,https://cdn.cocoapods.org/)
+  command = %w(bundle exec pod lib lint --sources=https://github.com/firebase/SpecsStaging.git,https://github.com/CocoaPods/Specs.git)
 
   # Split arguments that need to be processed by the script itself and passed
   # to the pod command.

--- a/scripts/pod_lib_lint.rb
+++ b/scripts/pod_lib_lint.rb
@@ -47,7 +47,7 @@ def main(args)
 
   STDOUT.sync = true
 
-  command = %w(bundle exec pod lib lint --sources=https://github.com/firebase/SpecsStaging.git,https://github.com/CocoaPods/Specs.git)
+  command = %w(bundle exec pod lib lint --sources=https://github.com/firebase/SpecsStaging.git,https://cdn.cocoapods.org/)
 
   # Split arguments that need to be processed by the script itself and passed
   # to the pod command.


### PR DESCRIPTION
- Update minimum iOS version across project to iOS 10
- Only exceptions are Analytics dependencies which are update to iOS 9 to be consistent with AdMob
- Only library source change is a code deletion from FDL to fix a deprecation warning
- Similar test change in FIAM
- Also osx 10.12 to be consistent with minimum Apple versions at 2016

Fix #4847