### PR TITLE
GDTCORFlatFileStorageTest size limit tests: use timeout proportional to the number of events

### DIFF
--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORFlatFileStorageTest.m
@@ -1170,7 +1170,7 @@
                   onComplete:^{
                     [removeBatchExpectation fulfill];
                   }];
-  [self waitForExpectations:@[ removeBatchExpectation ] timeout:5];
+  [self waitForExpectations:@[ removeBatchExpectation ] timeout:generatedEvents.count * 0.1];
 
   // 6. Try to add another event.
   XCTestExpectation *storeExpectation2 = [self expectationWithDescription:@"storeExpectation2"];


### PR DESCRIPTION
This should fix test flakes like [this](https://github.com/firebase/firebase-ios-sdk/runs/1153709908?check_suite_focus=true)

#no-changelog 