### PR TITLE
GDTCORStorage: promise API wrapper

### DIFF
--- a/GoogleDataTransport.podspec
+++ b/GoogleDataTransport.podspec
@@ -36,6 +36,7 @@ Shared library for iOS SDK data transport needs.
   s.libraries = ['z']
 
   s.dependency 'nanopb', '~> 1.30906.0'
+  s.dependency 'PromisesObjC', '~> 1.2'
 
   header_search_paths = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}/"'

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage+Promises.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage+Promises.m
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage+Promises.h"
+
+#import <FBLPromises/FBLPromises.h>
+
+#import "GoogleDataTransport/GDTCORLibrary/Private/GDTCORUploadBatch.h"
+
+@implementation GDTCORFlatFileStorage (Promises)
+
+- (FBLPromise<NSSet<NSNumber *> *> *)batchIDsForTarget:(GDTCORTarget)target {
+  return [FBLPromise onQueue:self.storageQueue
+        wrapObjectCompletion:^(FBLPromiseObjectCompletion _Nonnull handler) {
+          [self batchIDsForTarget:target onComplete:handler];
+        }];
+}
+
+- (FBLPromise<NSNull *> *)removeBatchWithID:(NSNumber *)batchID deleteEvents:(BOOL)deleteEvents {
+  return [FBLPromise onQueue:self.storageQueue
+              wrapCompletion:^(FBLPromiseCompletion _Nonnull handler) {
+                [self removeBatchWithID:batchID deleteEvents:deleteEvents onComplete:handler];
+              }];
+}
+
+- (FBLPromise<NSNull *> *)removeBatchesWithIDs:(NSSet<NSNumber *> *)batchIDs
+                                  deleteEvents:(BOOL)deleteEvents {
+  NSMutableArray<FBLPromise *> *removeBatchPromises =
+      [NSMutableArray arrayWithCapacity:batchIDs.count];
+  for (NSNumber *batchID in batchIDs) {
+    [removeBatchPromises addObject:[self removeBatchWithID:batchID deleteEvents:deleteEvents]];
+  }
+
+  return [FBLPromise onQueue:self.storageQueue all:[removeBatchPromises copy]].thenOn(
+      self.storageQueue, ^id(id result) {
+        return [FBLPromise resolvedWith:[NSNull null]];
+      });
+}
+
+- (FBLPromise<NSNull *> *)removeAllBatchesForTarget:(GDTCORTarget)target
+                                       deleteEvents:(BOOL)deleteEvents {
+  return
+      [self batchIDsForTarget:target].thenOn(self.storageQueue, ^id(NSSet<NSNumber *> *batchIDs) {
+        return [self removeBatchesWithIDs:batchIDs deleteEvents:NO];
+      });
+}
+
+- (FBLPromise<NSNumber *> *)hasEventsForTarget:(GDTCORTarget)target {
+  return [FBLPromise onQueue:self.storageQueue
+          wrapBoolCompletion:^(FBLPromiseBoolCompletion _Nonnull handler) {
+            [self hasEventsForTarget:target onComplete:handler];
+          }];
+}
+
+- (FBLPromise<GDTCORUploadBatch *> *)batchWithEventSelector:
+                                         (GDTCORStorageEventSelector *)eventSelector
+                                            batchExpiration:(NSDate *)expiration {
+  return [FBLPromise
+      onQueue:self.storageQueue
+        async:^(FBLPromiseFulfillBlock _Nonnull fulfill, FBLPromiseRejectBlock _Nonnull reject) {
+          [self batchWithEventSelector:eventSelector
+                       batchExpiration:expiration
+                            onComplete:^(NSNumber *_Nullable newBatchID,
+                                         NSSet<GDTCOREvent *> *_Nullable batchEvents) {
+                              if (newBatchID == nil || batchEvents == nil) {
+                                reject([self genericRejectedPromiseErrorWithReason:
+                                                 @"There are no events for the selector."]);
+                              } else {
+                                fulfill([[GDTCORUploadBatch alloc] initWithBatchID:newBatchID
+                                                                            events:batchEvents]);
+                              }
+                            }];
+        }];
+}
+
+// TODO: More comprehensive error.
+- (NSError *)genericRejectedPromiseErrorWithReason:(NSString *)reason {
+  return [NSError errorWithDomain:@"GDTCORFlatFileStorage"
+                             code:-1
+                         userInfo:@{NSLocalizedFailureReasonErrorKey : reason}];
+}
+
+@end

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORUploadBatch.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORUploadBatch.m
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GoogleDataTransport/GDTCORLibrary/Private/GDTCORUploadBatch.h"
+
+@implementation GDTCORUploadBatch
+
+- (instancetype)initWithBatchID:(NSNumber *)batchID events:(NSSet<GDTCOREvent *> *)events {
+  self = [super init];
+  if (self) {
+    _batchID = batchID;
+    _events = events;
+  }
+  return self;
+}
+
+@end

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage+Promises.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage+Promises.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GoogleDataTransport/GDTCORLibrary/Private/GDTCORFlatFileStorage.h"
+
+@class FBLPromise<ValueType>;
+
+NS_ASSUME_NONNULL_BEGIN
+
+// TODO: Docs.
+// TODO: Consider a generic wrapper around an `id<GDTCORStorageProtocol>` object to make it more
+// universal. But do we need it?
+@interface GDTCORFlatFileStorage (Promises) <GDTCORStoragePromiseProtocol>
+
+- (NSError *)genericRejectedPromiseErrorWithReason:(NSString *)reason;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleDataTransport/GDTCORLibrary/Private/GDTCORUploadBatch.h
+++ b/GoogleDataTransport/GDTCORLibrary/Private/GDTCORUploadBatch.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class GDTCOREvent;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface GDTCORUploadBatch : NSObject
+
+@property(nonatomic, readonly) NSNumber *batchID;
+@property(nonatomic, readonly) NSSet<GDTCOREvent *> *events;
+
+- (instancetype)initWithBatchID:(NSNumber *)batchID events:(NSSet<GDTCOREvent *> *)events;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCORStorageProtocol.h
+++ b/GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCORStorageProtocol.h
@@ -22,6 +22,9 @@
 
 @class GDTCOREvent;
 @class GDTCORClock;
+@class GDTCORUploadBatch;
+
+@class FBLPromise<ValueType>;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -117,6 +120,29 @@ typedef void (^GDTCORStorageBatchBlock)(NSNumber *_Nullable newBatchID,
  * @param onComplete The callback that will be invoked once storage size calculation is complete.
  */
 - (void)storageSizeWithCallback:(void (^)(GDTCORStorageSizeBytes storageSize))onComplete;
+
+@end
+
+// TODO: Consider a different place for this interface.
+// TODO: Consider complete replacing block based API by promise API.
+// TODO: Add API docs.
+@protocol GDTCORStoragePromiseProtocol <GDTCORStorageProtocol>
+
+- (FBLPromise<NSSet<NSNumber *> *> *)batchIDsForTarget:(GDTCORTarget)target;
+
+- (FBLPromise<NSNull *> *)removeBatchWithID:(NSNumber *)batchID deleteEvents:(BOOL)deleteEvents;
+
+- (FBLPromise<NSNull *> *)removeBatchesWithIDs:(NSSet<NSNumber *> *)batchIDs
+                                  deleteEvents:(BOOL)deleteEvents;
+
+- (FBLPromise<NSNull *> *)removeAllBatchesForTarget:(GDTCORTarget)target
+                                       deleteEvents:(BOOL)deleteEvents;
+
+- (FBLPromise<NSNumber *> *)hasEventsForTarget:(GDTCORTarget)target;
+
+- (FBLPromise<GDTCORUploadBatch *> *)batchWithEventSelector:
+                                         (GDTCORStorageEventSelector *)eventSelector
+                                            batchExpiration:(NSDate *)expiration;
 
 @end
 


### PR DESCRIPTION
The next PR from promise refactoring series (b/160018519). 

- promise based API for `GDTCORFlatFileStorage` that will be used in `GDTCCTUploadOperation`

Tests to be fixed and updated in the next PRs.

#no-changelog 