### PR TITLE
Fix a rare RC crash

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v4.9.1
+- [fixed] Fix an `attempt to insert nil object` crash in `fetchWithExpirationDuration:`. (#6522)
+
 # v4.9.0
 - [fixed] Fixed `FirebaseApp.delete()` related crash in `RC Config Fetch`. (#6123)
 

--- a/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigFetch.m
@@ -412,9 +412,9 @@ static const NSInteger sFIRErrorCodeConfigFailed = -114;
         strongSelf->_settings.lastFetchError = FIRRemoteConfigErrorInternalError;
         NSDictionary<NSErrorUserInfoKey, id> *userInfo = @{
           NSLocalizedDescriptionKey :
-              (error ? [error localizedDescription]
-                     : [NSString
-                           stringWithFormat:@"Internal Error. Status code: %ld", (long)statusCode])
+              ([error localizedDescription]
+                   ?: [NSString
+                          stringWithFormat:@"Internal Error. Status code: %ld", (long)statusCode])
         };
         return [strongSelf
             reportCompletionOnHandler:completionHandler


### PR DESCRIPTION
Fix #6522

Even though `[error localizedDescription]` is never supposed to return nil, it seems that it sometime does.  See https://stackoverflow.com/a/34684861/556617.

This change avoids a crash when that happens.