### PR TITLE
FIS: Additional FIRInstallationsItem validation

### DIFF
--- a/FirebaseInstallations/CHANGELOG.md
+++ b/FirebaseInstallations/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v1.7.1 -- Unreleased
+- [changed] Additional `FIRInstallationsItem` validation to catch potential storage issues. (#6570)
+
 # v1.7.0 -- M78
 - [changed] Use ephemeral `NSURLSession` to prevent caching of request/response. (#6226)
 - [changed] Backoff added for some error to prevent unnecessary API requests. (#6232)

--- a/FirebaseInstallations/Source/Library/Errors/FIRInstallationsErrorUtil.h
+++ b/FirebaseInstallations/Source/Library/Errors/FIRInstallationsErrorUtil.h
@@ -56,6 +56,10 @@ void FIRInstallationsItemSetErrorToPointer(NSError *error, NSError **pointer);
 
 + (FBLPromise *)rejectedPromiseWithError:(NSError *)error;
 
++ (NSError *)installationsErrorWithCode:(FIRInstallationsErrorCode)code
+                          failureReason:(nullable NSString *)failureReason
+                        underlyingError:(nullable NSError *)underlyingError;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseInstallations/Source/Library/Errors/FIRInstallationsErrorUtil.m
+++ b/FirebaseInstallations/Source/Library/Errors/FIRInstallationsErrorUtil.m
@@ -128,7 +128,7 @@ void FIRInstallationsItemSetErrorToPointer(NSError *error, NSError **pointer) {
                         underlyingError:(nullable NSError *)underlyingError {
   NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
   userInfo[NSUnderlyingErrorKey] = underlyingError;
-  userInfo[NSLocalizedFailureReasonErrorKey] = failureReason;
+  userInfo[NSLocalizedFailureReasonErrorKey] = failureReason ?: [NSString stringWithFormat:@"Underlying error: %@", underlyingError.localizedDescription];
 
   return [NSError errorWithDomain:kFirebaseInstallationsErrorDomain code:code userInfo:userInfo];
 }

--- a/FirebaseInstallations/Source/Library/Errors/FIRInstallationsErrorUtil.m
+++ b/FirebaseInstallations/Source/Library/Errors/FIRInstallationsErrorUtil.m
@@ -128,7 +128,10 @@ void FIRInstallationsItemSetErrorToPointer(NSError *error, NSError **pointer) {
                         underlyingError:(nullable NSError *)underlyingError {
   NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
   userInfo[NSUnderlyingErrorKey] = underlyingError;
-  userInfo[NSLocalizedFailureReasonErrorKey] = failureReason ?: [NSString stringWithFormat:@"Underlying error: %@", underlyingError.localizedDescription];
+  userInfo[NSLocalizedFailureReasonErrorKey] =
+      failureReason
+          ?: [NSString
+                 stringWithFormat:@"Underlying error: %@", underlyingError.localizedDescription];
 
   return [NSError errorWithDomain:kFirebaseInstallationsErrorDomain code:code userInfo:userInfo];
 }

--- a/FirebaseInstallations/Source/Library/FIRInstallationsItem.h
+++ b/FirebaseInstallations/Source/Library/FIRInstallationsItem.h
@@ -67,11 +67,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSString *)identifier;
 
-/** Validates if all the required item fields are populated and values don't explicitly conflict with each other.
+/** Validates if all the required item fields are populated and values don't explicitly conflict
+ * with each other.
  *  @param outError A reference to be populated with an error containing validation failure details.
  *  @return `YES` if the item it valid, `NO` otherwise.
  */
-- (BOOL)isValid:(NSError * _Nullable *)outError;
+- (BOOL)isValid:(NSError *_Nullable *)outError;
 
 /**
  * The installation identifier.

--- a/FirebaseInstallations/Source/Library/FIRInstallationsItem.h
+++ b/FirebaseInstallations/Source/Library/FIRInstallationsItem.h
@@ -67,6 +67,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSString *)identifier;
 
+/** Validates if all the required item fields are populated and values don't explicitly conflict with each other.
+ *  @param outError A reference to be populated with an error containing validation failure details.
+ *  @return `YES` if the item it valid, `NO` otherwise.
+ */
+- (BOOL)isValid:(NSError * _Nullable *)outError;
+
 /**
  * The installation identifier.
  * @param appID A `FirebaseApp` identifier.

--- a/FirebaseInstallations/Source/Library/FIRInstallationsItem.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallationsItem.m
@@ -37,6 +37,7 @@
   clone.refreshToken = [self.refreshToken copy];
   clone.authToken = [self.authToken copy];
   clone.registrationStatus = self.registrationStatus;
+  clone.IIDDefaultToken = [self.IIDDefaultToken copy];
 
   return clone;
 }

--- a/FirebaseInstallations/Source/Library/FIRInstallationsItem.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallationsItem.m
@@ -63,6 +63,46 @@
   return [[self class] identifierWithAppID:self.appID appName:self.firebaseAppName];
 }
 
+- (BOOL)isValid:(NSError * _Nullable *)outError {
+  NSMutableArray<NSString *> *validationIssues = [NSMutableArray array];
+
+  if (self.appID.length == 0) {
+    [validationIssues addObject:@"`appID` must not be empty"];
+  }
+
+  if (self.firebaseAppName.length == 0) {
+    [validationIssues addObject:@"`firebaseAppName` must not be empty"];
+  }
+
+  if (self.firebaseInstallationID.length == 0) {
+    [validationIssues addObject:@"`firebaseInstallationID` must not be empty"];
+  }
+
+  switch (self.registrationStatus) {
+    case FIRInstallationStatusUnknown:
+      [validationIssues addObject:@"invalid `registrationStatus`"];
+      break;
+
+    case FIRInstallationStatusRegistered:
+      if (self.refreshToken == 0) {
+        [validationIssues addObject:@"registered installation must have non-empty `refreshToken`"];
+      }
+
+      if (self.authToken.token == 0) {
+        [validationIssues addObject:@"registered installation must have non-empty `authToken.token`"];
+      }
+
+      if (self.authToken.expirationDate == nil) {
+        [validationIssues addObject:@"registered installation must have non-empty `authToken.expirationDate`"];
+      }
+
+    case FIRInstallationStatusUnregistered:
+      break;
+  }
+
+  return validationIssues.count == 0;
+}
+
 + (NSString *)identifierWithAppID:(NSString *)appID appName:(NSString *)appName {
   return [appID stringByAppendingString:appName];
 }

--- a/FirebaseInstallations/Source/Library/FIRInstallationsItem.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallationsItem.m
@@ -66,7 +66,7 @@
   return [[self class] identifierWithAppID:self.appID appName:self.firebaseAppName];
 }
 
-- (BOOL)isValid:(NSError * _Nullable *)outError {
+- (BOOL)isValid:(NSError *_Nullable *)outError {
   NSMutableArray<NSString *> *validationIssues = [NSMutableArray array];
 
   if (self.appID.length == 0) {
@@ -92,11 +92,13 @@
       }
 
       if (self.authToken.token == 0) {
-        [validationIssues addObject:@"registered installation must have non-empty `authToken.token`"];
+        [validationIssues
+            addObject:@"registered installation must have non-empty `authToken.token`"];
       }
 
       if (self.authToken.expirationDate == nil) {
-        [validationIssues addObject:@"registered installation must have non-empty `authToken.expirationDate`"];
+        [validationIssues
+            addObject:@"registered installation must have non-empty `authToken.expirationDate`"];
       }
 
     case FIRInstallationStatusUnregistered:
@@ -106,8 +108,13 @@
   BOOL isValid = validationIssues.count == 0;
 
   if (!isValid && outError) {
-    NSString *failureReason = [NSString stringWithFormat:@"FIRInstallationsItem validation errors: %@", [validationIssues componentsJoinedByString:@", "]];
-    *outError = [FIRInstallationsErrorUtil installationsErrorWithCode:FIRInstallationsErrorCodeUnknown failureReason:failureReason underlyingError:nil];
+    NSString *failureReason =
+        [NSString stringWithFormat:@"FIRInstallationsItem validation errors: %@",
+                                   [validationIssues componentsJoinedByString:@", "]];
+    *outError =
+        [FIRInstallationsErrorUtil installationsErrorWithCode:FIRInstallationsErrorCodeUnknown
+                                                failureReason:failureReason
+                                              underlyingError:nil];
   }
 
   return isValid;

--- a/FirebaseInstallations/Source/Library/FIRInstallationsItem.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallationsItem.m
@@ -19,6 +19,8 @@
 #import "FirebaseInstallations/Source/Library/InstallationsStore/FIRInstallationsStoredAuthToken.h"
 #import "FirebaseInstallations/Source/Library/InstallationsStore/FIRInstallationsStoredItem.h"
 
+#import "FirebaseInstallations/Source/Library/Errors/FIRInstallationsErrorUtil.h"
+
 @implementation FIRInstallationsItem
 
 - (instancetype)initWithAppID:(NSString *)appID firebaseAppName:(NSString *)firebaseAppName {
@@ -101,7 +103,14 @@
       break;
   }
 
-  return validationIssues.count == 0;
+  BOOL isValid = validationIssues.count == 0;
+
+  if (!isValid && outError) {
+    NSString *failureReason = [NSString stringWithFormat:@"FIRInstallationsItem validation errors: %@", [validationIssues componentsJoinedByString:@", "]];
+    *outError = [FIRInstallationsErrorUtil installationsErrorWithCode:FIRInstallationsErrorCodeUnknown failureReason:failureReason underlyingError:nil];
+  }
+
+  return isValid;
 }
 
 + (NSString *)identifierWithAppID:(NSString *)appID appName:(NSString *)appName {

--- a/FirebaseInstallations/Source/Library/FIRInstallationsLogger.h
+++ b/FirebaseInstallations/Source/Library/FIRInstallationsLogger.h
@@ -36,6 +36,7 @@ extern NSString *const kFIRInstallationsMessageCodeNewGetInstallationOperationCr
 extern NSString *const kFIRInstallationsMessageCodeNewGetAuthTokenOperationCreated;
 extern NSString *const kFIRInstallationsMessageCodeNewDeleteInstallationOperationCreated;
 extern NSString *const kFIRInstallationsMessageCodeInvalidFirebaseConfiguration;
+extern NSString *const kFIRInstallationsMessageCodeCorruptedStoredInstallation;
 
 // FIRInstallationsStoredItem.m
 extern NSString *const kFIRInstallationsMessageCodeInstallationCoderVersionMismatch;

--- a/FirebaseInstallations/Source/Library/FIRInstallationsLogger.m
+++ b/FirebaseInstallations/Source/Library/FIRInstallationsLogger.m
@@ -34,6 +34,7 @@ NSString *const kFIRInstallationsMessageCodeNewGetInstallationOperationCreated =
 NSString *const kFIRInstallationsMessageCodeNewGetAuthTokenOperationCreated = @"I-FIS002001";
 NSString *const kFIRInstallationsMessageCodeNewDeleteInstallationOperationCreated = @"I-FIS002002";
 NSString *const kFIRInstallationsMessageCodeInvalidFirebaseConfiguration = @"I-FIS002003";
+NSString *const kFIRInstallationsMessageCodeCorruptedStoredInstallation = @"I-FIS002004";
 
 // FIRInstallationsStoredItem.m
 NSString *const kFIRInstallationsMessageCodeInstallationCoderVersionMismatch = @"I-FIS003000";

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -180,9 +180,11 @@ static NSString *const kKeychainService = @"com.firebase.FIRInstallations.instal
 - (FBLPromise<FIRInstallationsItem *> *)getStoredInstallation {
   return [self.installationsStore installationForAppID:self.appID appName:self.appName].validate(
       ^BOOL(FIRInstallationsItem *installation) {
-    NSError *validationError;
+        NSError *validationError;
         BOOL isValid = [installation isValid:&validationError];
-    FIRLogWarning(kFIRLoggerInstallations, kFIRInstallationsMessageCodeCorruptedStoredInstallation, @"Stored installation validation error: %@", validationError.localizedDescription);
+        FIRLogWarning(
+            kFIRLoggerInstallations, kFIRInstallationsMessageCodeCorruptedStoredInstallation,
+            @"Stored installation validation error: %@", validationError.localizedDescription);
         return isValid;
       });
 }

--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -180,18 +180,9 @@ static NSString *const kKeychainService = @"com.firebase.FIRInstallations.instal
 - (FBLPromise<FIRInstallationsItem *> *)getStoredInstallation {
   return [self.installationsStore installationForAppID:self.appID appName:self.appName].validate(
       ^BOOL(FIRInstallationsItem *installation) {
-        BOOL isValid = NO;
-        switch (installation.registrationStatus) {
-          case FIRInstallationStatusUnregistered:
-          case FIRInstallationStatusRegistered:
-            isValid = YES;
-            break;
-
-          case FIRInstallationStatusUnknown:
-            isValid = NO;
-            break;
-        }
-
+    NSError *validationError;
+        BOOL isValid = [installation isValid:&validationError];
+    FIRLogWarning(kFIRLoggerInstallations, kFIRInstallationsMessageCodeCorruptedStoredInstallation, @"Stored installation validation error: %@", validationError.localizedDescription);
         return isValid;
       });
 }

--- a/FirebaseInstallations/Source/Tests/Fixture/APIRegisterInstallationResponseSuccessNoFID.json
+++ b/FirebaseInstallations/Source/Tests/Fixture/APIRegisterInstallationResponseSuccessNoFID.json
@@ -1,0 +1,8 @@
+{
+    "name": "projects/project-id/installations/eapzYQai_g8flVQyfKoGs7",
+    "refreshToken": "aaaaaaabbbbbbbbcccccccccdddddddd00000000",
+    "authToken": {
+      "token": "aaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbb.cccccccccccccccccccccccc",
+      "expiresIn": "604800s"
+    }
+  }

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
@@ -74,12 +74,16 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
 
 - (void)testRegisterInstallationSuccess {
   NSString *fixtureName = @"APIRegisterInstallationResponseSuccess.json";
-  [self assertRegisterInstallationSuccessWithResponseFixtureName:fixtureName responseCode:201 expectedFIDOverride:@"aaaaaaaaaaaaaaaaaaaaaa"];
+  [self assertRegisterInstallationSuccessWithResponseFixtureName:fixtureName
+                                                    responseCode:201
+                                             expectedFIDOverride:@"aaaaaaaaaaaaaaaaaaaaaa"];
 }
 
 - (void)testRegisterInstallationSuccess_NoFIDInResponse {
   NSString *fixtureName = @"APIRegisterInstallationResponseSuccessNoFID.json";
-  [self assertRegisterInstallationSuccessWithResponseFixtureName:fixtureName responseCode:201 expectedFIDOverride:nil];
+  [self assertRegisterInstallationSuccessWithResponseFixtureName:fixtureName
+                                                    responseCode:201
+                                             expectedFIDOverride:nil];
 }
 
 - (void)testRefreshAuthTokenSuccess {

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
@@ -73,155 +73,13 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
 }
 
 - (void)testRegisterInstallationSuccess {
-  FIRInstallationsItem *installation = [[FIRInstallationsItem alloc] initWithAppID:@"app-id"
-                                                                   firebaseAppName:@"name"];
-  installation.firebaseInstallationID = [FIRInstallationsItem generateFID];
-  installation.IIDDefaultToken = @"iid-auth-token";
-
-  // 1. Stub URL session:
-
-  // 1.1. URL request validation.
-  id URLRequestValidation = [OCMArg checkWithBlock:^BOOL(NSURLRequest *request) {
-    XCTAssertEqualObjects(request.HTTPMethod, @"POST");
-    XCTAssertEqualObjects(
-        request.URL.absoluteString,
-        @"https://firebaseinstallations.googleapis.com/v1/projects/project-id/installations/");
-    XCTAssertEqualObjects([request valueForHTTPHeaderField:@"Content-Type"], @"application/json");
-    XCTAssertEqualObjects([request valueForHTTPHeaderField:@"X-Goog-Api-Key"], self.APIKey);
-    XCTAssertEqualObjects([request valueForHTTPHeaderField:@"X-Ios-Bundle-Identifier"],
-                          [[NSBundle mainBundle] bundleIdentifier]);
-    XCTAssertEqualObjects([request valueForHTTPHeaderField:kFIRInstallationsUserAgentKey],
-                          [FIRApp firebaseUserAgent]);
-    XCTAssertEqualObjects([request valueForHTTPHeaderField:kFIRInstallationsHeartbeatKey], @"3");
-
-    NSString *expectedIIDMigrationHeader = installation.IIDDefaultToken;
-    XCTAssertEqualObjects([request valueForHTTPHeaderField:@"x-goog-fis-ios-iid-migration-auth"],
-                          expectedIIDMigrationHeader);
-
-    NSError *error;
-    NSDictionary *body = [NSJSONSerialization JSONObjectWithData:request.HTTPBody
-                                                         options:0
-                                                           error:&error];
-    XCTAssertNotNil(body, @"Error: %@", error);
-
-    XCTAssertEqualObjects(body[@"fid"], installation.firebaseInstallationID);
-    XCTAssertEqualObjects(body[@"authVersion"], @"FIS_v2");
-    XCTAssertEqualObjects(body[@"appId"], installation.appID);
-
-    XCTAssertEqualObjects(body[@"sdkVersion"], [self SDKVersion]);
-
-    return YES;
-  }];
-
-  // 1.2. Capture completion to call it later.
-  __block void (^taskCompletion)(NSData *, NSURLResponse *, NSError *);
-  id completionArg = [OCMArg checkWithBlock:^BOOL(id obj) {
-    taskCompletion = obj;
-    return YES;
-  }];
-
-  // 1.3. Create a data task mock.
-  id mockDataTask = OCMClassMock([NSURLSessionDataTask class]);
-  OCMExpect([(NSURLSessionDataTask *)mockDataTask resume]);
-
-  // 1.4. Expect `dataTaskWithRequest` to be called.
-  OCMExpect([self.mockURLSession dataTaskWithRequest:URLRequestValidation
-                                   completionHandler:completionArg])
-      .andReturn(mockDataTask);
-
-  // 2. Call
-  FBLPromise<FIRInstallationsItem *> *promise = [self.service registerInstallation:installation];
-
-  // 3. Wait for `[NSURLSession dataTaskWithRequest...]` to be called
-  OCMVerifyAllWithDelay(self.mockURLSession, 0.5);
-
-  // 4. Wait for the data task `resume` to be called.
-  OCMVerifyAllWithDelay(mockDataTask, 0.5);
-
-  // 5. Call the data task completion.
-  NSData *successResponseData =
-      [self loadFixtureNamed:@"APIRegisterInstallationResponseSuccess.json"];
-  taskCompletion(successResponseData, [self responseWithStatusCode:201], nil);
-
-  // 6. Check result.
-  XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
-
-  XCTAssertNil(promise.error);
-  XCTAssertNotNil(promise.value);
-
-  XCTAssertNotEqual(promise.value, installation);
-  XCTAssertEqualObjects(promise.value.appID, installation.appID);
-  XCTAssertEqualObjects(promise.value.firebaseAppName, installation.firebaseAppName);
-
-  // Server may respond with a different FID if the sent FID cannot be accepted.
-  XCTAssertEqualObjects(promise.value.firebaseInstallationID, @"aaaaaaaaaaaaaaaaaaaaaa");
-  XCTAssertEqualObjects(promise.value.refreshToken, @"aaaaaaabbbbbbbbcccccccccdddddddd00000000");
-  XCTAssertEqualObjects(promise.value.authToken.token,
-                        @"aaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbb.cccccccccccccccccccccccc");
-  [self assertDate:promise.value.authToken.expirationDate
-      isApproximatelyEqualCurrentPlusTimeInterval:604800];
+  NSString *fixtureName = @"APIRegisterInstallationResponseSuccess.json";
+  [self assertRegisterInstallationSuccessWithResponseFixtureName:fixtureName responseCode:201 expectedFIDOverride:@"aaaaaaaaaaaaaaaaaaaaaa"];
 }
 
-- (void)testRegisterInstallation_WhenError500_ThenRetriesOnce {
-  FIRInstallationsItem *installation = [[FIRInstallationsItem alloc] initWithAppID:@"app-id"
-                                                                   firebaseAppName:@"name"];
-  installation.firebaseInstallationID = [FIRInstallationsItem generateFID];
-
-  // 1. Stub URL session:
-
-  // 1.2. Capture completion to call it later.
-  __block void (^taskCompletion)(NSData *, NSURLResponse *, NSError *);
-  id completionArg = [OCMArg checkWithBlock:^BOOL(id obj) {
-    taskCompletion = obj;
-    return YES;
-  }];
-
-  // 1.3. Create a data task mock.
-  id mockDataTask1 = OCMClassMock([NSURLSessionDataTask class]);
-  OCMExpect([(NSURLSessionDataTask *)mockDataTask1 resume]);
-
-  // 1.4. Expect `dataTaskWithRequest` to be called.
-  OCMExpect([self.mockURLSession dataTaskWithRequest:[OCMArg any] completionHandler:completionArg])
-      .andReturn(mockDataTask1);
-
-  // 2. Call
-  FBLPromise<FIRInstallationsItem *> *promise = [self.service registerInstallation:installation];
-
-  // 3. Wait for `[NSURLSession dataTaskWithRequest...]` to be called
-  OCMVerifyAllWithDelay(self.mockURLSession, 0.5);
-
-  // 4. Wait for the data task `resume` to be called.
-  OCMVerifyAllWithDelay(mockDataTask1, 0.5);
-
-  // 5. Call the data task completion.
-  NSData *successResponseData =
-      [self loadFixtureNamed:@"APIRegisterInstallationResponseSuccess.json"];
-  taskCompletion(successResponseData,
-                 [self responseWithStatusCode:FIRInstallationsHTTPCodesServerInternalError], nil);
-
-  // 6.1. Expect network request to send again.
-  id mockDataTask2 = OCMClassMock([NSURLSessionDataTask class]);
-  OCMExpect([(NSURLSessionDataTask *)mockDataTask2 resume]);
-  OCMExpect([self.mockURLSession dataTaskWithRequest:[OCMArg any] completionHandler:completionArg])
-      .andReturn(mockDataTask2);
-
-  // 6.2. Wait for the second network request to complete.
-  OCMVerifyAllWithDelay(self.mockURLSession, 1.5);
-  OCMVerifyAllWithDelay(mockDataTask2, 1.5);
-
-  // 6.3. Send network response again.
-  taskCompletion(successResponseData,
-                 [self responseWithStatusCode:FIRInstallationsHTTPCodesServerInternalError], nil);
-
-  // 7. Check result.
-  XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
-
-  XCTAssertNil(promise.value);
-  XCTAssertNotNil(promise.error);
-
-  XCTAssertTrue([promise.error isKindOfClass:[FIRInstallationsHTTPError class]]);
-  FIRInstallationsHTTPError *HTTPError = (FIRInstallationsHTTPError *)promise.error;
-  XCTAssertEqual(HTTPError.HTTPResponse.statusCode, FIRInstallationsHTTPCodesServerInternalError);
+- (void)testRegisterInstallationSuccess_NoFIDInResponse {
+  NSString *fixtureName = @"APIRegisterInstallationResponseSuccessNoFID.json";
+  [self assertRegisterInstallationSuccessWithResponseFixtureName:fixtureName responseCode:201 expectedFIDOverride:nil];
 }
 
 - (void)testRefreshAuthTokenSuccess {
@@ -686,6 +544,99 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
 
     return YES;
   }];
+}
+
+- (void)assertRegisterInstallationSuccessWithResponseFixtureName:(NSString *)fixtureName
+                                                    responseCode:(NSInteger)responseCode
+                                             expectedFIDOverride:(nullable NSString *)overrideFID {
+  FIRInstallationsItem *installation = [[FIRInstallationsItem alloc] initWithAppID:@"app-id"
+                                                                   firebaseAppName:@"name"];
+  installation.firebaseInstallationID = [FIRInstallationsItem generateFID];
+  installation.IIDDefaultToken = @"iid-auth-token";
+
+  NSString *expectedFID = overrideFID ?: installation.firebaseInstallationID;
+
+  // 1. Stub URL session:
+
+  // 1.1. URL request validation.
+  id URLRequestValidation = [OCMArg checkWithBlock:^BOOL(NSURLRequest *request) {
+    XCTAssertEqualObjects(request.HTTPMethod, @"POST");
+    XCTAssertEqualObjects(
+        request.URL.absoluteString,
+        @"https://firebaseinstallations.googleapis.com/v1/projects/project-id/installations/");
+    XCTAssertEqualObjects([request valueForHTTPHeaderField:@"Content-Type"], @"application/json");
+    XCTAssertEqualObjects([request valueForHTTPHeaderField:@"X-Goog-Api-Key"], self.APIKey);
+    XCTAssertEqualObjects([request valueForHTTPHeaderField:@"X-Ios-Bundle-Identifier"],
+                          [[NSBundle mainBundle] bundleIdentifier]);
+    XCTAssertEqualObjects([request valueForHTTPHeaderField:kFIRInstallationsUserAgentKey],
+                          [FIRApp firebaseUserAgent]);
+    XCTAssertEqualObjects([request valueForHTTPHeaderField:kFIRInstallationsHeartbeatKey], @"3");
+
+    NSString *expectedIIDMigrationHeader = installation.IIDDefaultToken;
+    XCTAssertEqualObjects([request valueForHTTPHeaderField:@"x-goog-fis-ios-iid-migration-auth"],
+                          expectedIIDMigrationHeader);
+
+    NSError *error;
+    NSDictionary *body = [NSJSONSerialization JSONObjectWithData:request.HTTPBody
+                                                         options:0
+                                                           error:&error];
+    XCTAssertNotNil(body, @"Error: %@", error);
+
+    XCTAssertEqualObjects(body[@"fid"], installation.firebaseInstallationID);
+    XCTAssertEqualObjects(body[@"authVersion"], @"FIS_v2");
+    XCTAssertEqualObjects(body[@"appId"], installation.appID);
+
+    XCTAssertEqualObjects(body[@"sdkVersion"], [self SDKVersion]);
+
+    return YES;
+  }];
+
+  // 1.2. Capture completion to call it later.
+  __block void (^taskCompletion)(NSData *, NSURLResponse *, NSError *);
+  id completionArg = [OCMArg checkWithBlock:^BOOL(id obj) {
+    taskCompletion = obj;
+    return YES;
+  }];
+
+  // 1.3. Create a data task mock.
+  id mockDataTask = OCMClassMock([NSURLSessionDataTask class]);
+  OCMExpect([(NSURLSessionDataTask *)mockDataTask resume]);
+
+  // 1.4. Expect `dataTaskWithRequest` to be called.
+  OCMExpect([self.mockURLSession dataTaskWithRequest:URLRequestValidation
+                                   completionHandler:completionArg])
+      .andReturn(mockDataTask);
+
+  // 2. Call
+  FBLPromise<FIRInstallationsItem *> *promise = [self.service registerInstallation:installation];
+
+  // 3. Wait for `[NSURLSession dataTaskWithRequest...]` to be called
+  OCMVerifyAllWithDelay(self.mockURLSession, 0.5);
+
+  // 4. Wait for the data task `resume` to be called.
+  OCMVerifyAllWithDelay(mockDataTask, 0.5);
+
+  // 5. Call the data task completion.
+  NSData *responseData = [self loadFixtureNamed:fixtureName];
+  taskCompletion(responseData, [self responseWithStatusCode:responseCode], nil);
+
+  // 6. Check result.
+  XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
+
+  XCTAssertNil(promise.error);
+  XCTAssertNotNil(promise.value);
+
+  XCTAssertNotEqual(promise.value, installation);
+  XCTAssertEqualObjects(promise.value.appID, installation.appID);
+  XCTAssertEqualObjects(promise.value.firebaseAppName, installation.firebaseAppName);
+
+  // Server may respond with a different FID if the sent FID cannot be accepted.
+  XCTAssertEqualObjects(promise.value.firebaseInstallationID, expectedFID);
+  XCTAssertEqualObjects(promise.value.refreshToken, @"aaaaaaabbbbbbbbcccccccccdddddddd00000000");
+  XCTAssertEqualObjects(promise.value.authToken.token,
+                        @"aaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbb.cccccccccccccccccccccccc");
+  [self assertDate:promise.value.authToken.expirationDate
+      isApproximatelyEqualCurrentPlusTimeInterval:604800];
 }
 
 - (NSString *)SDKVersion {

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsAPIServiceTests.m
@@ -86,6 +86,19 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
                                              expectedFIDOverride:nil];
 }
 
+- (void)testRegisterInstallationSuccess_InvalidInstallation {
+  FIRInstallationsItem *installation = [FIRInstallationsItem createUnregisteredInstallationItem];
+  installation.firebaseInstallationID = nil;
+
+  __auto_type promise = [self.service registerInstallation:installation];
+
+  XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
+
+  XCTAssertTrue(promise.isRejected);
+  XCTAssertNil(promise.value);
+  XCTAssertNotNil(promise.error);
+}
+
 - (void)testRefreshAuthTokenSuccess {
   FIRInstallationsItem *installation = [FIRInstallationsItem createRegisteredInstallationItem];
   installation.firebaseInstallationID = @"qwertyuiopasdfghjklzxcvbnm";
@@ -553,9 +566,7 @@ typedef FBLPromise * (^FIRInstallationsAPIServiceTask)(void);
 - (void)assertRegisterInstallationSuccessWithResponseFixtureName:(NSString *)fixtureName
                                                     responseCode:(NSInteger)responseCode
                                              expectedFIDOverride:(nullable NSString *)overrideFID {
-  FIRInstallationsItem *installation = [[FIRInstallationsItem alloc] initWithAppID:@"app-id"
-                                                                   firebaseAppName:@"name"];
-  installation.firebaseInstallationID = [FIRInstallationsItem generateFID];
+  FIRInstallationsItem *installation = [FIRInstallationsItem createUnregisteredInstallationItem];
   installation.IIDDefaultToken = @"iid-auth-token";
 
   NSString *expectedFID = overrideFID ?: installation.firebaseInstallationID;

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
@@ -158,15 +158,13 @@
 }
 
 - (void)testGetInstallationItem_WhenNoFIDAndNoIID_ThenFIDIsCreatedAndRegistered {
-  // Stub store get installation.
-  [self expectInstallationsStoreGetInstallationCorruptedFID];
+  [self expectInstallationsStoreGetInstallationNotFound];
   [self expectStoredIIDNotFound];
 
   [self assertGetInstallation_NewFIDCreatedAndRegistered];
 }
 
 - (void)testGetInstallationItem_WhenFIDCorruptedAndNoIID_ThenFIDIsCreatedAndRegistered {
-  // Stub store get installation.
   [self expectInstallationsStoreGetInstallationCorruptedFID];
   [self expectStoredIIDNotFound];
 

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
@@ -235,7 +235,7 @@
   OCMVerifyAll(self.mockBackoffController);
 }
 
-- (void)testGetInstallationItem_WhenThereIsIIDAndNoFIDNotDefaultApp_ThenIIDIsUsedAsFID {
+- (void)testGetInstallationItem_WhenThereIsIIDAndNoFIDNotDefaultApp_ThenIIDIsNotUsedAsFID {
   // 0. Configure controller with not default app.
   NSString *appName = @"appName";
   [self setUpWithAppName:appName];
@@ -315,7 +315,7 @@
   OCMVerifyAll(self.mockBackoffController);
 }
 
-- (void)testGetInstallationItem_WhenThereIsIIDAndNoFID_ThenFIDIsCreatedAndRegistered {
+- (void)testGetInstallationItem_WhenThereIsIIDAndNoFID_ThenIIDIsRegisteredAsFID {
   // 1. Stub store get installation.
   [self expectInstallationsStoreGetInstallationNotFound];
 

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsIDControllerTests.m
@@ -158,81 +158,19 @@
 }
 
 - (void)testGetInstallationItem_WhenNoFIDAndNoIID_ThenFIDIsCreatedAndRegistered {
-  // 1. Stub store get installation.
-  [self expectInstallationsStoreGetInstallationNotFound];
-
-  // 2. Stub store save installation.
-  __block FIRInstallationsItem *createdInstallation;
-
-  OCMExpect([self.mockInstallationsStore
-                saveInstallation:[OCMArg checkWithBlock:^BOOL(FIRInstallationsItem *obj) {
-                  [self assertValidCreatedInstallation:obj];
-
-                  createdInstallation = obj;
-                  return YES;
-                }]])
-      .andReturn([FBLPromise resolvedWith:[NSNull null]]);
-
-  // 3. Stub API register installation.
-
-  // 3.1. Expect backoff controller to be requested.
-  [self expectIsNextRequestAllowedWithResult:YES];
-
-  // 3.2. Verify installation to be registered.
-  id registerInstallationValidation = [OCMArg checkWithBlock:^BOOL(FIRInstallationsItem *obj) {
-    [self assertValidCreatedInstallation:obj];
-    XCTAssertEqual(obj.firebaseInstallationID.length, 22);
-    return YES;
-  }];
-
-  // 3.3. Expect for `registerInstallation` to be called.
-  FBLPromise<FIRInstallationsItem *> *registerPromise = [FBLPromise pendingPromise];
-  OCMExpect([self.mockAPIService registerInstallation:registerInstallationValidation])
-      .andReturn(registerPromise);
-
-  // 3.4. Expect backoff success.
-  [self expectBackoffEvent:FIRInstallationsBackoffEventSuccess];
-
-  // 4. Expect IIDStore to be checked for existing IID.
+  // Stub store get installation.
+  [self expectInstallationsStoreGetInstallationCorruptedFID];
   [self expectStoredIIDNotFound];
 
-  // 5. Call get installation and check.
-  FBLPromise<FIRInstallationsItem *> *getInstallationPromise =
-      [self.controller getInstallationItem];
+  [self assertGetInstallation_NewFIDCreatedAndRegistered];
+}
 
-  // 5.1. Wait for the stored item to be read and saved.
-  OCMVerifyAllWithDelay(self.mockInstallationsStore, 0.5);
+- (void)testGetInstallationItem_WhenFIDCorruptedAndNoIID_ThenFIDIsCreatedAndRegistered {
+  // Stub store get installation.
+  [self expectInstallationsStoreGetInstallationCorruptedFID];
+  [self expectStoredIIDNotFound];
 
-  // 5.2. Wait for `registerInstallation` to be called.
-  OCMVerifyAllWithDelay(self.mockAPIService, 0.5);
-
-  // 5.3. Expect for the registered installation to be saved.
-  FIRInstallationsItem *registeredInstallation = [FIRInstallationsItem
-      createRegisteredInstallationItemWithAppID:createdInstallation.appID
-                                        appName:createdInstallation.firebaseAppName];
-
-  OCMExpect([self.mockInstallationsStore
-                saveInstallation:[OCMArg checkWithBlock:^BOOL(FIRInstallationsItem *obj) {
-                  XCTAssertEqual(registeredInstallation, obj);
-                  return YES;
-                }]])
-      .andReturn([FBLPromise resolvedWith:[NSNull null]]);
-
-  // 5.5. Resolve `registerPromise` to simulate finished registration.
-  [registerPromise fulfill:registeredInstallation];
-
-  // 5.4. Wait for the task to complete.
-  XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
-
-  XCTAssertNil(getInstallationPromise.error);
-  // We expect the initially created installation to be returned - must not wait for registration to
-  // complete here.
-  XCTAssertEqual(getInstallationPromise.value, createdInstallation);
-
-  // 5.5. Verify registered installation was saved.
-  OCMVerifyAll(self.mockInstallationsStore);
-  OCMVerifyAll(self.mockIIDStore);
-  OCMVerifyAll(self.mockBackoffController);
+  [self assertGetInstallation_NewFIDCreatedAndRegistered];
 }
 
 - (void)testGetInstallationItem_WhenThereIsIIDAndNoFIDNotDefaultApp_ThenIIDIsNotUsedAsFID {
@@ -1355,6 +1293,12 @@
       .andReturn(installationNotFoundPromise);
 }
 
+- (void)expectInstallationsStoreGetInstallationCorruptedFID {
+  FIRInstallationsItem *storedInstallations = [FIRInstallationsItem createCorruptedItem];
+  OCMExpect([self.mockInstallationsStore installationForAppID:self.appID appName:self.appName])
+      .andReturn([FBLPromise resolvedWith:storedInstallations]);
+}
+
 - (void)expectStoredIIDNotFound {
   FBLPromise *rejectedPromise = [FBLPromise pendingPromise];
   [rejectedPromise reject:[FIRInstallationsErrorUtil keychainErrorWithFunction:@"" status:-1]];
@@ -1493,6 +1437,78 @@ static const NSInteger kNoBackoffEvents = -1;
   XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
 
   // Get installation returns a value no matter what.
+  XCTAssertNil(getInstallationPromise.error);
+  // We expect the initially created installation to be returned - must not wait for registration to
+  // complete here.
+  XCTAssertEqual(getInstallationPromise.value, createdInstallation);
+
+  // 5.5. Verify registered installation was saved.
+  OCMVerifyAll(self.mockInstallationsStore);
+  OCMVerifyAll(self.mockIIDStore);
+  OCMVerifyAll(self.mockBackoffController);
+}
+
+- (void)assertGetInstallation_NewFIDCreatedAndRegistered {
+  // 2. Stub store save installation.
+  __block FIRInstallationsItem *createdInstallation;
+
+  OCMExpect([self.mockInstallationsStore
+                saveInstallation:[OCMArg checkWithBlock:^BOOL(FIRInstallationsItem *obj) {
+                  [self assertValidCreatedInstallation:obj];
+
+                  createdInstallation = obj;
+                  return YES;
+                }]])
+      .andReturn([FBLPromise resolvedWith:[NSNull null]]);
+
+  // 3. Stub API register installation.
+
+  // 3.1. Expect backoff controller to be requested.
+  [self expectIsNextRequestAllowedWithResult:YES];
+
+  // 3.2. Verify installation to be registered.
+  id registerInstallationValidation = [OCMArg checkWithBlock:^BOOL(FIRInstallationsItem *obj) {
+    [self assertValidCreatedInstallation:obj];
+    XCTAssertEqual(obj.firebaseInstallationID.length, 22);
+    return YES;
+  }];
+
+  // 3.3. Expect for `registerInstallation` to be called.
+  FBLPromise<FIRInstallationsItem *> *registerPromise = [FBLPromise pendingPromise];
+  OCMExpect([self.mockAPIService registerInstallation:registerInstallationValidation])
+      .andReturn(registerPromise);
+
+  // 3.4. Expect backoff success.
+  [self expectBackoffEvent:FIRInstallationsBackoffEventSuccess];
+
+  // 5. Call get installation and check.
+  FBLPromise<FIRInstallationsItem *> *getInstallationPromise =
+      [self.controller getInstallationItem];
+
+  // 5.1. Wait for the stored item to be read and saved.
+  OCMVerifyAllWithDelay(self.mockInstallationsStore, 0.5);
+
+  // 5.2. Wait for `registerInstallation` to be called.
+  OCMVerifyAllWithDelay(self.mockAPIService, 0.5);
+
+  // 5.3. Expect for the registered installation to be saved.
+  FIRInstallationsItem *registeredInstallation = [FIRInstallationsItem
+      createRegisteredInstallationItemWithAppID:createdInstallation.appID
+                                        appName:createdInstallation.firebaseAppName];
+
+  OCMExpect([self.mockInstallationsStore
+                saveInstallation:[OCMArg checkWithBlock:^BOOL(FIRInstallationsItem *obj) {
+                  XCTAssertEqual(registeredInstallation, obj);
+                  return YES;
+                }]])
+      .andReturn([FBLPromise resolvedWith:[NSNull null]]);
+
+  // 5.5. Resolve `registerPromise` to simulate finished registration.
+  [registerPromise fulfill:registeredInstallation];
+
+  // 5.4. Wait for the task to complete.
+  XCTAssert(FBLWaitForPromisesWithTimeout(0.5));
+
   XCTAssertNil(getInstallationPromise.error);
   // We expect the initially created installation to be returned - must not wait for registration to
   // complete here.

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsItemTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsItemTests.m
@@ -15,8 +15,11 @@
  */
 
 #import <XCTest/XCTest.h>
+
 #import "FirebaseInstallations/Source/Library/FIRInstallationsItem.h"
 #import "FirebaseInstallations/Source/Library/InstallationsStore/FIRInstallationsStoredItem.h"
+
+#import "FirebaseInstallations/Source/Tests/Utils/FIRInstallationsItem+Tests.h"
 
 @interface FIRInstallationsItemTests : XCTestCase
 
@@ -48,6 +51,38 @@
   [self assertValidFID:FID2];
 
   XCTAssertNotEqualObjects(FID1, FID2);
+}
+
+- (void)testValidate_InvalidItem {
+  FIRInstallationsItem *unregisteredItem = [[FIRInstallationsItem alloc] initWithAppID:@""
+                                                           firebaseAppName:@""];
+
+  NSError *validationError;
+  XCTAssertFalse([unregisteredItem isValid:&validationError]);
+  XCTAssertTrue([validationError.localizedFailureReason containsString:@"`appID` must not be empty"]);
+  XCTAssertTrue([validationError.localizedFailureReason containsString:@"`firebaseAppName` must not be empty"]);
+  XCTAssertTrue([validationError.localizedFailureReason containsString:@"`firebaseInstallationID` must not be empty"]);
+  XCTAssertTrue([validationError.localizedFailureReason containsString:@"invalid `registrationStatus`"]);
+
+  FIRInstallationsItem *registerredItem = [[FIRInstallationsItem alloc] initWithAppID:@""
+                                                           firebaseAppName:@""];
+  registerredItem.registrationStatus = FIRInstallationStatusRegistered;
+
+  XCTAssertFalse([registerredItem isValid:&validationError]);
+  XCTAssertTrue([validationError.localizedFailureReason containsString:@"`appID` must not be empty"]);
+  XCTAssertTrue([validationError.localizedFailureReason containsString:@"`firebaseAppName` must not be empty"]);
+  XCTAssertTrue([validationError.localizedFailureReason containsString:@"`firebaseInstallationID` must not be empty"]);
+  XCTAssertTrue([validationError.localizedFailureReason containsString:@"registered installation must have non-empty `refreshToken`"]);
+  XCTAssertTrue([validationError.localizedFailureReason containsString:@"registered installation must have non-empty `authToken.token`"]);
+  XCTAssertTrue([validationError.localizedFailureReason containsString:@"registered installation must have non-empty `authToken.expirationDate`"]);
+}
+
+- (void)testValidate_ValidItem {
+  FIRInstallationsItem *item = [FIRInstallationsItem createRegisteredInstallationItem];
+
+  NSError *error;
+  XCTAssertTrue([item isValid:&error]);
+  XCTAssertNil(error);
 }
 
 - (void)assertValidFID:(NSString *)FID {

--- a/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsItemTests.m
+++ b/FirebaseInstallations/Source/Tests/Unit/FIRInstallationsItemTests.m
@@ -55,26 +55,36 @@
 
 - (void)testValidate_InvalidItem {
   FIRInstallationsItem *unregisteredItem = [[FIRInstallationsItem alloc] initWithAppID:@""
-                                                           firebaseAppName:@""];
+                                                                       firebaseAppName:@""];
 
   NSError *validationError;
   XCTAssertFalse([unregisteredItem isValid:&validationError]);
-  XCTAssertTrue([validationError.localizedFailureReason containsString:@"`appID` must not be empty"]);
-  XCTAssertTrue([validationError.localizedFailureReason containsString:@"`firebaseAppName` must not be empty"]);
-  XCTAssertTrue([validationError.localizedFailureReason containsString:@"`firebaseInstallationID` must not be empty"]);
-  XCTAssertTrue([validationError.localizedFailureReason containsString:@"invalid `registrationStatus`"]);
+  XCTAssertTrue(
+      [validationError.localizedFailureReason containsString:@"`appID` must not be empty"]);
+  XCTAssertTrue([validationError.localizedFailureReason
+      containsString:@"`firebaseAppName` must not be empty"]);
+  XCTAssertTrue([validationError.localizedFailureReason
+      containsString:@"`firebaseInstallationID` must not be empty"]);
+  XCTAssertTrue(
+      [validationError.localizedFailureReason containsString:@"invalid `registrationStatus`"]);
 
   FIRInstallationsItem *registerredItem = [[FIRInstallationsItem alloc] initWithAppID:@""
-                                                           firebaseAppName:@""];
+                                                                      firebaseAppName:@""];
   registerredItem.registrationStatus = FIRInstallationStatusRegistered;
 
   XCTAssertFalse([registerredItem isValid:&validationError]);
-  XCTAssertTrue([validationError.localizedFailureReason containsString:@"`appID` must not be empty"]);
-  XCTAssertTrue([validationError.localizedFailureReason containsString:@"`firebaseAppName` must not be empty"]);
-  XCTAssertTrue([validationError.localizedFailureReason containsString:@"`firebaseInstallationID` must not be empty"]);
-  XCTAssertTrue([validationError.localizedFailureReason containsString:@"registered installation must have non-empty `refreshToken`"]);
-  XCTAssertTrue([validationError.localizedFailureReason containsString:@"registered installation must have non-empty `authToken.token`"]);
-  XCTAssertTrue([validationError.localizedFailureReason containsString:@"registered installation must have non-empty `authToken.expirationDate`"]);
+  XCTAssertTrue(
+      [validationError.localizedFailureReason containsString:@"`appID` must not be empty"]);
+  XCTAssertTrue([validationError.localizedFailureReason
+      containsString:@"`firebaseAppName` must not be empty"]);
+  XCTAssertTrue([validationError.localizedFailureReason
+      containsString:@"`firebaseInstallationID` must not be empty"]);
+  XCTAssertTrue([validationError.localizedFailureReason
+      containsString:@"registered installation must have non-empty `refreshToken`"]);
+  XCTAssertTrue([validationError.localizedFailureReason
+      containsString:@"registered installation must have non-empty `authToken.token`"]);
+  XCTAssertTrue([validationError.localizedFailureReason
+      containsString:@"registered installation must have non-empty `authToken.expirationDate`"]);
 }
 
 - (void)testValidate_ValidItem {

--- a/FirebaseInstallations/Source/Tests/Utils/FIRInstallationsItem+Tests.h
+++ b/FirebaseInstallations/Source/Tests/Utils/FIRInstallationsItem+Tests.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (FIRInstallationsItem *)createUnregisteredInstallationItem;
 + (FIRInstallationsItem *)createRegisteredInstallationItem;
++ (FIRInstallationsItem *)createCorruptedItem;
 
 + (FIRInstallationsItem *)createRegisteredInstallationItemWithAppID:(NSString *)appID
                                                             appName:(NSString *)appName;

--- a/FirebaseInstallations/Source/Tests/Utils/FIRInstallationsItem+Tests.m
+++ b/FirebaseInstallations/Source/Tests/Utils/FIRInstallationsItem+Tests.m
@@ -40,6 +40,14 @@
   return item;
 }
 
++ (FIRInstallationsItem *)createCorruptedItem {
+  FIRInstallationsItem *item = [self createRegisteredInstallationItemWithAppID:@"appID"
+                                                                       appName:kFIRDefaultAppName];
+  item.firebaseInstallationID = nil;
+
+  return item;
+}
+
 + (FIRInstallationsItem *)createRegisteredInstallationItemWithAppID:(NSString *)appID
                                                             appName:(NSString *)appName {
   FIRInstallationsItem *item = [[FIRInstallationsItem alloc] initWithAppID:appID


### PR DESCRIPTION
Related to #6563. 

- more detailed validation of `FIRInstallationsItem` read from storage to catch a potential data corruption (e.g. manual modifications of Keychain item on macOS, etc.)
- validation of `FIRInstallationsItem` before sending registration request. 