### PR TITLE
Stop using CocoaPods private headers

### DIFF
--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -35,7 +35,6 @@ Firebase Cloud Messaging and Firebase Remote Config in your app.
   ]
   s.requires_arc = base_dir + '*.m'
   s.public_header_files = base_dir + 'Public/FirebaseABTesting/*.h', base_dir + 'Private/*.h'
-  s.private_header_files = base_dir + 'Private/*.h'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'GCC_PREPROCESSOR_DEFINITIONS' =>

--- a/FirebaseABTesting.podspec
+++ b/FirebaseABTesting.podspec
@@ -34,7 +34,7 @@ Firebase Cloud Messaging and Firebase Remote Config in your app.
    'FirebaseCore/Sources/Private/*.h',
   ]
   s.requires_arc = base_dir + '*.m'
-  s.public_header_files = base_dir + 'Public/FirebaseABTesting/*.h', base_dir + 'Private/*.h'
+  s.public_header_files = base_dir + 'Public/FirebaseABTesting/*.h'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'GCC_PREPROCESSOR_DEFINITIONS' =>

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -30,9 +30,7 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   ]
   s.public_header_files = [
     'FirebaseCore/Sources/Public/FirebaseCore/*.h',
-    'FirebaseCore/Sources/Private/*.h',
   ]
-  s.private_header_files = 'FirebaseCore/Sources/Private/*.h'
 
   s.framework = 'Foundation'
   s.ios.framework = 'UIKit'

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -30,7 +30,10 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   ]
   s.public_header_files = [
     'FirebaseCore/Sources/Public/FirebaseCore/*.h',
+    'FirebaseCore/Sources/Private/*.h',
   ]
+  s.private_header_files = 'FirebaseCore/Sources/Private/*.h'
+
   s.framework = 'Foundation'
   s.ios.framework = 'UIKit'
   s.osx.framework = 'AppKit'

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -31,7 +31,6 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   s.public_header_files = [
     'FirebaseCore/Sources/Public/FirebaseCore/*.h',
   ]
-
   s.framework = 'Foundation'
   s.ios.framework = 'UIKit'
   s.osx.framework = 'AppKit'

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -5,6 +5,8 @@
 - [changed] The pods developed in this repo are no longer hard coded to be built as static
   frameworks. Instead, their linkage will be controlled by the Podfile. Use the Podfile
   option `use_frameworks! :linkage => :static` to get the Firebase 6.x linkage behavior. (#2022)
+- [changed] Firebase no longer uses the CocoaPods `private_headers` feature to expose internal
+  APIs. (#6572)
 - [removed] Removed broken `FirebaseOptions()` initializer. Use `init(contentsOfFile:)` or
   `init(googleAppID:gcmSenderID:)` instead. (#6633)
 

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -31,7 +31,6 @@ See more product details at https://firebase.google.com/products/in-app-messagin
     'FirebaseInstallations/Source/Library/Private/*.h',
   ]
   s.public_header_files = base_dir + 'Sources/Public/FirebaseInAppMessaging/*.h'
-  s.private_header_files = base_dir + 'Sources/Private/**/*.h'
 
   s.resource_bundles = {
     'InAppMessagingDisplayResources' => [

--- a/FirebaseInstallations.podspec
+++ b/FirebaseInstallations.podspec
@@ -31,9 +31,7 @@ Pod::Spec.new do |s|
   ]
   s.public_header_files = [
     base_dir + 'Library/Public/FirebaseInstallations/*.h',
-    base_dir + 'Library/Private/*.h',
   ]
-  s.private_header_files = base_dir + 'Library/Private/*.h'
 
   s.framework = 'Security'
   s.dependency 'FirebaseCore', '~> 6.10'

--- a/FirebaseInstanceID.podspec
+++ b/FirebaseInstanceID.podspec
@@ -33,8 +33,7 @@ services.
     'FirebaseInstallations/Source/Library/Private/*.h',
   ]
   s.requires_arc = base_dir + '*.m'
-  s.public_header_files = base_dir + 'Public/*.h', base_dir + 'Private/*.h'
-  s.private_header_files = base_dir + 'Private/*.h'
+  s.public_header_files = base_dir + 'Public/*.h'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'GCC_PREPROCESSOR_DEFINITIONS' => 'FIRInstanceID_LIB_VERSION=' + String(s.version),

--- a/FirebaseRemoteConfig.podspec
+++ b/FirebaseRemoteConfig.podspec
@@ -34,7 +34,6 @@ app update.
     'FirebaseInstallations/Source/Library/Private/*.h',
   ]
   s.public_header_files = base_dir + 'Public/FirebaseRemoteConfig/*.h'
-  s.private_header_files = base_dir + 'Private/*.h'
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
     'GCC_PREPROCESSOR_DEFINITIONS' =>

--- a/FirebaseRemoteConfig/Tests/Sample/RemoteConfigSampleApp/ViewController.m
+++ b/FirebaseRemoteConfig/Tests/Sample/RemoteConfigSampleApp/ViewController.m
@@ -19,6 +19,7 @@
 #import <FirebaseCore/FirebaseCore.h>
 #import <FirebaseInstallations/FirebaseInstallations.h>
 #import <FirebaseRemoteConfig/FirebaseRemoteConfig.h>
+#import "../../../Sources/Private/FIRRemoteConfig_Private.h"
 #import "FRCLog.h"
 
 static NSString *const FIRPerfNamespace = @"fireperf";
@@ -410,11 +411,8 @@ static NSString *const FIRSecondFIRAppName = @"secondFIRApp";
                          FIRInstallationsAuthTokenResult *_Nullable tokenResult,
                          NSError *_Nullable error) {
         if (tokenResult.authToken) {
-          // There is no public API available to the sample to set the token. If it is needed a
-          // method should be added and exposed here via a test category like is done for
-          // remoteConfigWithFIRNamespace:
-          //          ((FIRRemoteConfig *)self.RCInstances[self.currentNamespace][self.FIRAppName])
-          //              .settings.configInstallationsToken = tokenResult.authToken;
+          ((FIRRemoteConfig *)self.RCInstances[self.currentNamespace][self.FIRAppName])
+              .settings.configInstallationsToken = tokenResult.authToken;
           [[FRCLog sharedInstance]
               logToConsole:[NSString
                                stringWithFormat:

--- a/FirebaseRemoteConfig/Tests/Sample/RemoteConfigSampleApp/ViewController.m
+++ b/FirebaseRemoteConfig/Tests/Sample/RemoteConfigSampleApp/ViewController.m
@@ -18,14 +18,17 @@
 #import <FirebaseCore/FIROptions.h>
 #import <FirebaseCore/FirebaseCore.h>
 #import <FirebaseInstallations/FirebaseInstallations.h>
-#import <FirebaseRemoteConfig/FIRRemoteConfig_Private.h>
 #import <FirebaseRemoteConfig/FirebaseRemoteConfig.h>
-#import <FirebaseRemoteConfig/RCNConfigSettings.h>
 #import "FRCLog.h"
 
 static NSString *const FIRPerfNamespace = @"fireperf";
 static NSString *const FIRDefaultFIRAppName = @"__FIRAPP_DEFAULT";
 static NSString *const FIRSecondFIRAppName = @"secondFIRApp";
+
+@interface FIRRemoteConfig (Sample)
++(FIRRemoteConfig *)remoteConfigWithFIRNamespace:(NSString *)remoteConfigNamespace
+                                             app:(FIRApp *)app;
+@end
 
 @interface ViewController ()
 @property(nonatomic, strong) IBOutlet UIButton *fetchButton;
@@ -407,8 +410,11 @@ static NSString *const FIRSecondFIRAppName = @"secondFIRApp";
                          FIRInstallationsAuthTokenResult *_Nullable tokenResult,
                          NSError *_Nullable error) {
         if (tokenResult.authToken) {
-          ((FIRRemoteConfig *)self.RCInstances[self.currentNamespace][self.FIRAppName])
-              .settings.configInstallationsToken = tokenResult.authToken;
+// There is no public API available to the sample to set the token. If it is needed a method
+// should be added and exposed here via a test category like is done for
+// remoteConfigWithFIRNamespace:
+//          ((FIRRemoteConfig *)self.RCInstances[self.currentNamespace][self.FIRAppName])
+//              .settings.configInstallationsToken = tokenResult.authToken;
           [[FRCLog sharedInstance]
               logToConsole:[NSString
                                stringWithFormat:

--- a/FirebaseRemoteConfig/Tests/Sample/RemoteConfigSampleApp/ViewController.m
+++ b/FirebaseRemoteConfig/Tests/Sample/RemoteConfigSampleApp/ViewController.m
@@ -26,8 +26,8 @@ static NSString *const FIRDefaultFIRAppName = @"__FIRAPP_DEFAULT";
 static NSString *const FIRSecondFIRAppName = @"secondFIRApp";
 
 @interface FIRRemoteConfig (Sample)
-+(FIRRemoteConfig *)remoteConfigWithFIRNamespace:(NSString *)remoteConfigNamespace
-                                             app:(FIRApp *)app;
++ (FIRRemoteConfig *)remoteConfigWithFIRNamespace:(NSString *)remoteConfigNamespace
+                                              app:(FIRApp *)app;
 @end
 
 @interface ViewController ()
@@ -410,11 +410,11 @@ static NSString *const FIRSecondFIRAppName = @"secondFIRApp";
                          FIRInstallationsAuthTokenResult *_Nullable tokenResult,
                          NSError *_Nullable error) {
         if (tokenResult.authToken) {
-// There is no public API available to the sample to set the token. If it is needed a method
-// should be added and exposed here via a test category like is done for
-// remoteConfigWithFIRNamespace:
-//          ((FIRRemoteConfig *)self.RCInstances[self.currentNamespace][self.FIRAppName])
-//              .settings.configInstallationsToken = tokenResult.authToken;
+          // There is no public API available to the sample to set the token. If it is needed a
+          // method should be added and exposed here via a test category like is done for
+          // remoteConfigWithFIRNamespace:
+          //          ((FIRRemoteConfig *)self.RCInstances[self.currentNamespace][self.FIRAppName])
+          //              .settings.configInstallationsToken = tokenResult.authToken;
           [[FRCLog sharedInstance]
               logToConsole:[NSString
                                stringWithFormat:

--- a/HeadersImports.md
+++ b/HeadersImports.md
@@ -19,9 +19,9 @@ In Swift Package Manager, it's a library target.
 
 * *Private Headers* - Headers that are available to other libraries in the repo, but are not part
   of the public API. These should be located in `FirebaseFoo/Sources/Private`.
-  [Xcode](https://stackoverflow.com/a/8016333) and CocoaPods refer to these as "Private Headers".
-  Note that the usage CocoaPods `private_headers` is deprecated and should instead
-  the `source_files` attribute should be used for access them with a repo-relative import.
+  [Xcode](https://stackoverflow.com/a/8016333). They should be accessed with a repo-relative
+  import. For CocoaPods, do not use the `private_headers` attribute. Instead include them in both
+  the provider and client's `source_files` attribute.
 
 * *Interop Headers* - A special kind of private header that defines an interface to another library.
   Details in [Firebase Component System docs](Interop/FirebaseComponentSystem.md).


### PR DESCRIPTION
Stop using CocoaPods private headers to be more consistent with Swift Package Manager.

Instead internal API's between repo pods should be referenced with repo-relative imports.

FirebaseCore Private's are kept for now because of internal non-Firebase client usage via CocoaPods (Flutter for example)