### PR TITLE
UI_USER_INTERFACE_IDIOM() was deprecated in iOS 14

### DIFF
--- a/Crashlytics/Shared/FIRCLSFABHost.m
+++ b/Crashlytics/Shared/FIRCLSFABHost.m
@@ -97,7 +97,7 @@ NSString *FIRCLSHostModelInfo(void) {
 #elif TARGET_OS_TV
   model = @"tvOS Simulator";
 #elif TARGET_OS_IPHONE
-  switch (UI_USER_INTERFACE_IDIOM()) {
+  switch ([[UIDevice currentDevice] userInterfaceIdiom]) {
     case UIUserInterfaceIdiomPhone:
       model = @"iOS Simulator (iPhone)";
       break;


### PR DESCRIPTION
Hi,

I used Crashlytics with CocoaPods(Deployment Target iOS 13), will happen a warning.

<img width="800" alt="UI_USER_INTERFACE_IDIOM" src="https://user-images.githubusercontent.com/45647069/94357718-3230ea80-00d6-11eb-9c1b-40e5e313f0ef.png">

The `UI_USER_INTERFACE_IDIOM()` was deprecated. And I changed it.

---

Part of the used Podfile.

```Podfile
platform :ios, '13.0'
use_frameworks!

target 'App' do
    pod 'Firebase/Crashlytics'
end

post_install do | pi |
     pi.pods_project.targets.each do | t |
         t.build_configurations.each do | config |
             config.build_settings ['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
         end
     end
end
```

Thanks.

