### PR TITLE
GDTCORDirectorySizeTracker: fix NSURL constructor

### DIFF
--- a/GoogleDataTransport/CHANGELOG.md
+++ b/GoogleDataTransport/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - Legacy pre Xcode 10 compatibility checks removed. (#6486)
+- `GDTCORDirectorySizeTracker` crash fixed. (#6540)
 
 # v7.4.0
 - Limit disk space consumed by GoogleDataTransport to store events. (#6365)

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORDirectorySizeTracker.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORDirectorySizeTracker.m
@@ -69,7 +69,7 @@
 - (GDTCORStorageSizeBytes)calculateDirectoryContentSize {
   NSArray *prefetchedProperties = @[ NSURLIsRegularFileKey, NSURLFileSizeKey ];
   uint64_t totalBytes = 0;
-  NSURL *directoryURL = [NSURL URLWithString:self.directoryPath];
+  NSURL *directoryURL = [NSURL fileURLWithPath:self.directoryPath];
 
   NSDirectoryEnumerator *enumerator = [[NSFileManager defaultManager]
                  enumeratorAtURL:directoryURL

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORDirectorySizeTrackerTests.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORDirectorySizeTrackerTests.m
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCORDirectorySizeTracker.h"
+
+@interface GDTCORDirectorySizeTrackerTests : XCTestCase
+
+@end
+
+@implementation GDTCORDirectorySizeTrackerTests
+
+- (void)testDirectoryContentSizeDoesNotCrashWhenDirectoryPathContainsWhitespaces {
+  NSString *pathWithSpaces = [NSTemporaryDirectory() stringByAppendingPathComponent:@"some dir"];
+  GDTCORDirectorySizeTracker *tracker = [[GDTCORDirectorySizeTracker alloc] initWithDirectoryPath:pathWithSpaces];
+
+  XCTAssertNoThrow([tracker directoryContentSize]);
+}
+
+@end

--- a/GoogleDataTransport/GDTCORTests/Unit/GDTCORDirectorySizeTrackerTests.m
+++ b/GoogleDataTransport/GDTCORTests/Unit/GDTCORDirectorySizeTrackerTests.m
@@ -26,7 +26,8 @@
 
 - (void)testDirectoryContentSizeDoesNotCrashWhenDirectoryPathContainsWhitespaces {
   NSString *pathWithSpaces = [NSTemporaryDirectory() stringByAppendingPathComponent:@"some dir"];
-  GDTCORDirectorySizeTracker *tracker = [[GDTCORDirectorySizeTracker alloc] initWithDirectoryPath:pathWithSpaces];
+  GDTCORDirectorySizeTracker *tracker =
+      [[GDTCORDirectorySizeTracker alloc] initWithDirectoryPath:pathWithSpaces];
 
   XCTAssertNoThrow([tracker directoryContentSize]);
 }


### PR DESCRIPTION
Fixes #6540

- replace [URLWithString:](https://developer.apple.com/documentation/foundation/nsurl/1572047-urlwithstring) with [fileURLWithPath](https://developer.apple.com/documentation/foundation/nsurl/1410828-fileurlwithpath) (the later one was originally supposed to be used). `URLWithString:` fails to create a URL for paths that contain symbols like a whitespace which is a valid path symbol. 