### PR TITLE
Make FirestoreException a type defined by Firestore/core

### DIFF
--- a/Firestore/core/src/util/exception.cc
+++ b/Firestore/core/src/util/exception.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 #include <exception>
 #include <stdexcept>
 
+#include "Firestore/core/src/util/firestore_exceptions.h"
 #include "Firestore/core/src/util/hard_assert.h"
 #include "Firestore/core/src/util/log.h"
 #include "absl/strings/str_cat.h"

--- a/Firestore/core/src/util/exception.h
+++ b/Firestore/core/src/util/exception.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,48 +38,9 @@
 #include "Firestore/core/include/firebase/firestore/firestore_errors.h"
 #include "Firestore/core/src/util/string_format.h"
 #include "absl/base/attributes.h"
-#include "absl/base/config.h"
 
 namespace firebase {
 namespace firestore {
-
-#if ABSL_HAVE_EXCEPTIONS
-
-/**
- * An exception thrown if Firestore encounters an unhandled error.
- */
-class FirestoreException : public std::exception {
- public:
-  FirestoreException(const std::string& message, Error code)
-      : message_(message), code_(code) {
-  }
-
-  const char* what() const noexcept override {
-    return message_.c_str();
-  }
-
-  Error code() const {
-    return code_;
-  }
-
- private:
-  std::string message_;
-  Error code_;
-};
-
-/**
- * An exception thrown if Firestore encounters an internal, unrecoverable error.
- */
-class FirestoreInternalError : public FirestoreException {
- public:
-  FirestoreInternalError(const std::string& message,
-                         Error code = Error::kErrorInternal)
-      : FirestoreException(message, code) {
-  }
-};
-
-#endif  // ABSL_HAVE_EXCEPTIONS
-
 namespace util {
 
 /**

--- a/Firestore/core/src/util/exception.h
+++ b/Firestore/core/src/util/exception.h
@@ -35,23 +35,52 @@
 #include <stdexcept>
 #include <string>
 
+#include "Firestore/core/include/firebase/firestore/firestore_errors.h"
 #include "Firestore/core/src/util/string_format.h"
 #include "absl/base/attributes.h"
 #include "absl/base/config.h"
 
 namespace firebase {
 namespace firestore {
-namespace util {
 
 #if ABSL_HAVE_EXCEPTIONS
+
 /**
- * An exception thrown if Firestore encounters an internal error.
+ * An exception thrown if Firestore encounters an unhandled error.
  */
-class FirestoreInternalError : public std::logic_error {
+class FirestoreException : public std::exception {
  public:
-  using std::logic_error::logic_error;
+  FirestoreException(const std::string& message, Error code)
+      : message_(message), code_(code) {
+  }
+
+  const char* what() const noexcept override {
+    return message_.c_str();
+  }
+
+  Error code() const {
+    return code_;
+  }
+
+ private:
+  std::string message_;
+  Error code_;
 };
+
+/**
+ * An exception thrown if Firestore encounters an internal, unrecoverable error.
+ */
+class FirestoreInternalError : public FirestoreException {
+ public:
+  FirestoreInternalError(const std::string& message,
+                         Error code = Error::kErrorInternal)
+      : FirestoreException(message, code) {
+  }
+};
+
 #endif  // ABSL_HAVE_EXCEPTIONS
+
+namespace util {
 
 /**
  * An enumeration of logical exception types mapping to common user visible

--- a/Firestore/core/src/util/firestore_exceptions.h
+++ b/Firestore/core/src/util/firestore_exceptions.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIRESTORE_CORE_SRC_UTIL_FIRESTORE_EXCEPTIONS_H_
+#define FIRESTORE_CORE_SRC_UTIL_FIRESTORE_EXCEPTIONS_H_
+
+// Common C++ exception declarations across iOS and Android. These aren't a
+// public API surface.
+//
+// See exception.h for how to throw exceptions in a platform-agnostic way.
+
+#include <stdexcept>
+#include <string>
+
+#include "Firestore/core/include/firebase/firestore/firestore_errors.h"
+
+#if defined(_STLPORT_VERSION)
+// Abseil does not support STLPort, so avoid their config.h here.
+//
+// TODO(b/163140650): Remove once the Firebase support floor moves to NDK R18.
+//
+// Meanwhile, NDK R16b (the current minimum) includes Clang 5.0.3 and GCC 4.9.
+// While Clang supports `__cpp_exceptions` at that version, GCC does not. Both
+// support `__EXCEPTIONS`.
+#if __EXCEPTIONS
+#define FIRESTORE_HAVE_EXCEPTIONS 1
+#endif
+
+#else  // !defined(_STLPORT_VERSION)
+// On any other supported platform, just take Abseil's word for it.
+#include "absl/base/config.h"
+
+#if ABSL_HAVE_EXCEPTIONS
+#define FIRESTORE_HAVE_EXCEPTIONS 1
+#endif
+#endif  // defined(_STLPORT_VERSION)
+
+namespace firebase {
+namespace firestore {
+
+#if FIRESTORE_HAVE_EXCEPTIONS
+
+/**
+ * An exception thrown if Firestore encounters an unhandled error.
+ */
+class FirestoreException : public std::exception {
+ public:
+  FirestoreException(const std::string& message, Error code)
+      : message_(message), code_(code) {
+  }
+
+  const char* what() const noexcept override {
+    return message_.c_str();
+  }
+
+  Error code() const {
+    return code_;
+  }
+
+ private:
+  std::string message_;
+  Error code_;
+};
+
+/**
+ * An exception thrown if Firestore encounters an internal, unrecoverable error.
+ */
+class FirestoreInternalError : public FirestoreException {
+ public:
+  FirestoreInternalError(const std::string& message,
+                         Error code = Error::kErrorInternal)
+      : FirestoreException(message, code) {
+  }
+};
+
+#endif  // FIRESTORE_HAVE_EXCEPTIONS
+
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIRESTORE_CORE_SRC_UTIL_FIRESTORE_EXCEPTIONS_H_

--- a/Firestore/core/src/util/firestore_exceptions.h
+++ b/Firestore/core/src/util/firestore_exceptions.h
@@ -22,7 +22,7 @@
 //
 // See exception.h for how to throw exceptions in a platform-agnostic way.
 
-#include <stdexcept>
+#include <exception>
 #include <string>
 
 #include "Firestore/core/include/firebase/firestore/firestore_errors.h"


### PR DESCRIPTION
Move FirestoreInternalError to firebase::firestore to match FirestoreException in Android.

When importing this into google3, we'll have to delete the Android-specific version of this type.