### PR TITLE
Always send the user agent regardless of the heartbeat value

### DIFF
--- a/Firestore/core/src/remote/firebase_metadata_provider_apple.mm
+++ b/Firestore/core/src/remote/firebase_metadata_provider_apple.mm
@@ -53,11 +53,11 @@ FirebaseMetadataProviderApple::FirebaseMetadataProviderApple(FIRApp* app)
 void FirebaseMetadataProviderApple::UpdateMetadata(
     grpc::ClientContext& context) {
   FIRHeartbeatInfoCode heartbeat = GetHeartbeat();
-  if (heartbeat == FIRHeartbeatInfoCodeNone) {
-    return;
+  if (heartbeat != FIRHeartbeatInfoCodeNone) {
+    context.AddMetadata(kXFirebaseClientLogTypeHeader,
+                        std::to_string(heartbeat));
   }
 
-  context.AddMetadata(kXFirebaseClientLogTypeHeader, std::to_string(heartbeat));
   context.AddMetadata(kXFirebaseClientHeader, GetUserAgent());
 
   std::string gmp_app_id = GetGmpAppId(app_);

--- a/Firestore/core/src/remote/firebase_metadata_provider_apple.mm
+++ b/Firestore/core/src/remote/firebase_metadata_provider_apple.mm
@@ -53,6 +53,9 @@ FirebaseMetadataProviderApple::FirebaseMetadataProviderApple(FIRApp* app)
 void FirebaseMetadataProviderApple::UpdateMetadata(
     grpc::ClientContext& context) {
   FIRHeartbeatInfoCode heartbeat = GetHeartbeat();
+  // TODO(varconst): don't send any headers if the heartbeat is "none". This
+  // should only be changed once it's possible to notify the heartbeat that the
+  // previous attempt to send it has failed.
   if (heartbeat != FIRHeartbeatInfoCodeNone) {
     context.AddMetadata(kXFirebaseClientLogTypeHeader,
                         std::to_string(heartbeat));


### PR DESCRIPTION
Any non-zero heartbeat value is immediately reset to zero upon retrieval. Thus, should the network request containing the heartbeat value and the user agent string fail, the previous logic would prevent us from sending the user agent string until the next day (when the heartbeat once again returns a non-zero value). Until this is resolved, always send the user agent string, regardless of the heartbeat value. The associated increase in bandwidth usage is minor (~1.2% in _total_ traffic from running the full suite of Firestore integration tests, which represent the worst-case scenario because they recreate the streams much more often than a typical application).