### PR TITLE
Add static-framework testing to CI

### DIFF
--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -94,13 +94,14 @@ jobs:
 
   abtesting-cron-only:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macos-latest
     strategy:
       matrix:
         target: [ios, tvos, macos]
         flags: [
+          '--use-static-frameworks',
           '--use-modular-headers',
           '--use-libraries'
         ]

--- a/.github/workflows/abtesting.yml
+++ b/.github/workflows/abtesting.yml
@@ -94,7 +94,7 @@ jobs:
 
   abtesting-cron-only:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macos-latest
     strategy:
@@ -102,7 +102,6 @@ jobs:
         target: [ios, tvos, macos]
         flags: [
           '--use-static-frameworks',
-          '--use-modular-headers',
           '--use-libraries'
         ]
     needs: pod-lib-lint

--- a/.github/workflows/appdistribution.yml
+++ b/.github/workflows/appdistribution.yml
@@ -30,13 +30,14 @@ jobs:
          --platforms=${{ matrix.target }}
 
   appdistribution-cron-only:
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macos-latest
     strategy:
       matrix:
         target: [ios]
         flags: [
+          '--use-static-frameworks',
           '--use-modular-headers',
           '--use-libraries'
         ]

--- a/.github/workflows/appdistribution.yml
+++ b/.github/workflows/appdistribution.yml
@@ -30,7 +30,7 @@ jobs:
          --platforms=${{ matrix.target }}
 
   appdistribution-cron-only:
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macos-latest
     strategy:
@@ -38,7 +38,6 @@ jobs:
         target: [ios]
         flags: [
           '--use-static-frameworks',
-          '--use-modular-headers',
           '--use-libraries'
         ]
     needs: pod-lib-lint

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -146,8 +146,7 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: PodLibLint Auth Cron
-      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAuth.podspec \
-               --platforms=${{ matrix.target }} ${{ matrix.flags }}
+      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
 
   archive-cron:
     # Don't run on private repo.

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -128,7 +128,7 @@ jobs:
 
   auth-cron-only:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macos-latest
     strategy:
@@ -136,6 +136,7 @@ jobs:
         # The macos and tvos tests can hang, and watchOS doesn't have tests.
         target: [ios, tvos --skip-tests, macos --skip-tests, watchos --skip-tests]
         flags: [
+          '--use-static-frameworks',
           '--use-modular-headers',
           '--use-libraries'
         ]
@@ -145,9 +146,8 @@ jobs:
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: PodLibLint Auth Cron
-      run: |
-        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
-        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAuth.podspec --platforms=${{ matrix.target }} ${{ matrix.flags }}
+      run: scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseAuth.podspec \
+               --platforms=${{ matrix.target }} ${{ matrix.flags }}
 
   archive-cron:
     # Don't run on private repo.

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -128,7 +128,7 @@ jobs:
 
   auth-cron-only:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macos-latest
     strategy:
@@ -137,7 +137,6 @@ jobs:
         target: [ios, tvos --skip-tests, macos --skip-tests, watchos --skip-tests]
         flags: [
           '--use-static-frameworks',
-          '--use-modular-headers',
           '--use-libraries'
         ]
     needs: pod-lib-lint

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -86,7 +86,7 @@ jobs:
 
   core-cron-only:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macos-latest
     strategy:
@@ -94,7 +94,6 @@ jobs:
         target: [ios, tvos, macos]
         flags: [
           '--use-static-frameworks',
-          '--use-modular-headers',
           # Tests are skipped since the Swift tests need modules.
           '--skip-tests --use-libraries'
         ]

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -86,13 +86,14 @@ jobs:
 
   core-cron-only:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macos-latest
     strategy:
       matrix:
         target: [ios, tvos, macos]
         flags: [
+          '--use-static-frameworks',
           '--use-modular-headers',
           # Tests are skipped since the Swift tests need modules.
           '--skip-tests --use-libraries'

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -103,7 +103,7 @@ jobs:
 
   crashlytics-cron-only:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macos-latest
     strategy:
@@ -111,7 +111,6 @@ jobs:
         target: [ios, tvos, macos, watchos --skip-tests] # The macos and tvos tests can hang
         flags: [
           '--use-static-frameworks',
-          '--use-modular-headers',
           '--use-libraries'
         ]
     needs: pod-lib-lint

--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -103,13 +103,14 @@ jobs:
 
   crashlytics-cron-only:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macos-latest
     strategy:
       matrix:
         target: [ios, tvos, macos, watchos --skip-tests] # The macos and tvos tests can hang
         flags: [
+          '--use-static-frameworks',
           '--use-modular-headers',
           '--use-libraries'
         ]

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -120,7 +120,7 @@ jobs:
 
   database-cron-only:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macos-latest
     strategy:
       matrix:

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -126,8 +126,7 @@ jobs:
       matrix:
         target: [ios, tvos, macos]
         flags: [
-          '--use-static-frameworks',
-          '--skip-tests --use-modular-headers',
+          '--skip-tests --use-static-frameworks',
           '--skip-tests --use-libraries'
         ]
     needs: pod-lib-lint

--- a/.github/workflows/database.yml
+++ b/.github/workflows/database.yml
@@ -120,12 +120,13 @@ jobs:
 
   database-cron-only:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macos-latest
     strategy:
       matrix:
         target: [ios, tvos, macos]
         flags: [
+          '--use-static-frameworks',
           '--skip-tests --use-modular-headers',
           '--skip-tests --use-libraries'
         ]

--- a/.github/workflows/datatransport.yml
+++ b/.github/workflows/datatransport.yml
@@ -58,7 +58,7 @@ jobs:
 
   datatransport-cron-only:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macos-latest
     strategy:
@@ -66,7 +66,6 @@ jobs:
         target: [ios, tvos, macos, watchos]
         flags: [
           '--use-static-frameworks',
-          '--use-modular-headers',
           '--use-libraries'
         ]
     needs: pod_lib_lint

--- a/.github/workflows/datatransport.yml
+++ b/.github/workflows/datatransport.yml
@@ -58,13 +58,14 @@ jobs:
 
   datatransport-cron-only:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macos-latest
     strategy:
       matrix:
         target: [ios, tvos, macos, watchos]
         flags: [
+          '--use-static-frameworks',
           '--use-modular-headers',
           '--use-libraries'
         ]

--- a/.github/workflows/dynamiclinks.yml
+++ b/.github/workflows/dynamiclinks.yml
@@ -39,14 +39,13 @@ jobs:
 
   dynamiclinks-cron-only:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macos-latest
     strategy:
       matrix:
         flags: [
           '--use-static-frameworks',
-          '--use-modular-headers',
           '--use-libraries'
         ]
     needs: pod_lib_lint

--- a/.github/workflows/dynamiclinks.yml
+++ b/.github/workflows/dynamiclinks.yml
@@ -39,12 +39,13 @@ jobs:
 
   dynamiclinks-cron-only:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macos-latest
     strategy:
       matrix:
         flags: [
+          '--use-static-frameworks',
           '--use-modular-headers',
           '--use-libraries'
         ]

--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -172,6 +172,12 @@ jobs:
     if: github.repository != 'FirebasePrivate/firebase-ios-sdk' || github.event_name == 'pull_request'
     runs-on: macos-latest
     needs: check
+    strategy:
+      matrix:
+        flags: [
+          '--use-static-frameworks',
+          '',
+        ]
 
     steps:
     - uses: actions/checkout@v2
@@ -182,6 +188,7 @@ jobs:
     - name: Pod lib lint
       run: |
         scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseFirestore.podspec \
+            ${{ matrix.flags }} \
             --platforms=ios \
             --allow-warnings
 

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -100,7 +100,7 @@ jobs:
       run: scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Installations swift
 
   installations-cron-only:
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macos-latest
     env:
@@ -110,6 +110,7 @@ jobs:
       matrix:
         target: [ios, tvos, macos]
         flags: [
+          '--use-static-frameworks',
           '--use-modular-headers',
           '--use-libraries'
         ]

--- a/.github/workflows/installations.yml
+++ b/.github/workflows/installations.yml
@@ -100,7 +100,7 @@ jobs:
       run: scripts/third_party/travis/retry.sh scripts/test_quickstart.sh Installations swift
 
   installations-cron-only:
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
 
     runs-on: macos-latest
     env:
@@ -111,7 +111,6 @@ jobs:
         target: [ios, tvos, macos]
         flags: [
           '--use-static-frameworks',
-          '--use-modular-headers',
           '--use-libraries'
         ]
     needs: pod-lib-lint

--- a/.github/workflows/instanceid.yml
+++ b/.github/workflows/instanceid.yml
@@ -53,7 +53,7 @@ jobs:
 
   instanceid-cron-only:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macos-latest
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -62,6 +62,7 @@ jobs:
       matrix:
         target: [ios, tvos, macos]
         flags: [
+          '--use-static-frameworks',
           '--use-modular-headers',
           '--use-libraries'
         ]

--- a/.github/workflows/instanceid.yml
+++ b/.github/workflows/instanceid.yml
@@ -53,7 +53,7 @@ jobs:
 
   instanceid-cron-only:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macos-latest
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -63,7 +63,6 @@ jobs:
         target: [ios, tvos, macos]
         flags: [
           '--use-static-frameworks',
-          '--use-modular-headers',
           '--use-libraries'
         ]
     needs: pod-lib-lint

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -151,13 +151,12 @@ jobs:
 
   messaging-watchos-cron-only:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macos-latest
     strategy:
       matrix:
         flags: [
           '--use-static-frameworks',
-          '--skip-tests --use-modular-headers',
           '--skip-tests --use-libraries'
         ]
     needs: pod-lib-lint-watchos

--- a/.github/workflows/messaging.yml
+++ b/.github/workflows/messaging.yml
@@ -151,11 +151,12 @@ jobs:
 
   messaging-watchos-cron-only:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macos-latest
     strategy:
       matrix:
         flags: [
+          '--use-static-frameworks',
           '--skip-tests --use-modular-headers',
           '--skip-tests --use-libraries'
         ]

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -140,7 +140,7 @@ jobs:
       matrix:
         target: [ios, tvos, macos]
         flags: [
-          '--use-static-frameworks',
+          '--skip-tests --use-static-frameworks',
           '--skip-tests --use-modular-headers',
           '--skip-tests --use-libraries'
         ]

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -134,12 +134,13 @@ jobs:
 
   remoteconfig-cron-only:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macos-latest
     strategy:
       matrix:
         target: [ios, tvos, macos]
         flags: [
+          '--use-static-frameworks',
           '--skip-tests --use-modular-headers',
           '--skip-tests --use-libraries'
         ]

--- a/.github/workflows/remoteconfig.yml
+++ b/.github/workflows/remoteconfig.yml
@@ -134,14 +134,13 @@ jobs:
 
   remoteconfig-cron-only:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macos-latest
     strategy:
       matrix:
         target: [ios, tvos, macos]
         flags: [
           '--skip-tests --use-static-frameworks',
-          '--skip-tests --use-modular-headers',
           '--skip-tests --use-libraries'
         ]
     needs: pod-lib-lint

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -128,7 +128,7 @@ jobs:
        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorageSwift.podspec --skip-tests --platforms=${{ matrix.target }}
 
   storage-cron-only:
-#    # Don't run on private repo.
+    # Don't run on private repo.
     if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macos-latest
     strategy:
@@ -136,7 +136,6 @@ jobs:
         target: [ios, tvos, macos]
         flags: [
           '--skip-tests --use-static-frameworks',
-          '--skip-tests --use-modular-headers',
           '--skip-tests --use-libraries'
         ]
     needs: pod-lib-lint

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -128,13 +128,14 @@ jobs:
        scripts/third_party/travis/retry.sh scripts/pod_lib_lint.rb FirebaseStorageSwift.podspec --skip-tests --platforms=${{ matrix.target }}
 
   storage-cron-only:
-    # Don't run on private repo.
+#    # Don't run on private repo.
     if: github.event_name == 'schedule' && github.repository != 'FirebasePrivate/firebase-ios-sdk'
     runs-on: macos-latest
     strategy:
       matrix:
         target: [ios, tvos, macos]
         flags: [
+          '--skip-tests --use-static-frameworks',
           '--skip-tests --use-modular-headers',
           '--skip-tests --use-libraries'
         ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,6 +107,7 @@ jobs:
         - ./scripts/if_changed.sh ./scripts/install_prereqs.sh # Start integration test server
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --use-static-frameworks
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --use-libraries
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseFunctions.podspec --use-modular-headers
 
@@ -175,6 +176,9 @@ jobs:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleUtilities.podspec --platforms=ios
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleUtilities.podspec --platforms=tvos
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleUtilities.podspec --platforms=macos
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleUtilities.podspec --use-static-frameworks --platforms=ios
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleUtilities.podspec --use-static-frameworks  --platforms=tvos
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb GoogleUtilities.podspec --use-static-frameworks  --platforms=macos
 
     - stage: test
       if: type = cron
@@ -215,6 +219,7 @@ jobs:
         - PROJECT=Firebase METHOD=pod-lib-lint
       script:
         - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec
+        - travis_retry ./scripts/if_changed.sh ./scripts/pod_lib_lint.rb FirebaseInAppMessaging.podspec --use-static-frameworks
 
     # pod lib lint to check build and warnings for static library build - only on cron jobs
     - stage: test

--- a/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinkNetworkingTests.m
+++ b/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinkNetworkingTests.m
@@ -18,8 +18,10 @@
 
 #import <OCMock/OCMock.h>
 
-#import <GoogleUtilities/GULSwizzler+Unswizzle.h>
+// This needs to precede the GULSwizzler+Unswizzle.h import for the --use-libraries build.
 #import <GoogleUtilities/GULSwizzler.h>
+
+#import <GoogleUtilities/GULSwizzler+Unswizzle.h>
 #import "FirebaseDynamicLinks/Sources/FIRDynamicLinkNetworking+Private.h"
 
 static NSString *const kAPIKey = @"myfakeapikey";

--- a/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
+++ b/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
@@ -16,8 +16,10 @@
 
 #import <XCTest/XCTest.h>
 
-#import <GoogleUtilities/GULSwizzler+Unswizzle.h>
+// This needs to precede the GULSwizzler+Unswizzle.h import for the --use-libraries build.
 #import <GoogleUtilities/GULSwizzler.h>
+
+#import <GoogleUtilities/GULSwizzler+Unswizzle.h>
 #import <OCMock/OCMock.h>
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "FirebaseDynamicLinks/Sources/FIRDLDefaultRetrievalProcessV2.h"

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'cocoapods', '1.10.0.rc.1'
-gem 'cocoapods-generate', git: "https://github.com/square/cocoapods-generate.git", branch: "master"
+
+# Use cocoapod-generate hash until 2.1.0 releases to fix a bug interacting with CocoaPods 1.10.
+gem 'cocoapods-generate', git: "https://github.com/square/cocoapods-generate.git", ref: "230b0b537b"
 gem 'danger', '6.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@
 # commit Gemfile and Gemfile.lock.
 source 'https://rubygems.org'
 
-gem 'cocoapods', "1.9.3"
-gem 'cocoapods-generate', '2.0.0'
+gem 'cocoapods', '1.10.0.rc.1'
+gem 'cocoapods-generate', git: "https://github.com/square/cocoapods-generate.git", branch: "master"
 gem 'danger', '6.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,23 @@
+GIT
+  remote: https://github.com/square/cocoapods-generate.git
+  revision: 230b0b537b5d7f524de157b6dbb3f5e08d317516
+  branch: master
+  specs:
+    cocoapods-generate (2.0.1)
+      cocoapods-disable-podfile-validations (~> 0.1.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.2)
-    activesupport (4.2.11.3)
-      i18n (~> 0.7)
+    activesupport (5.2.4.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    algoliasearch (1.27.2)
+    algoliasearch (1.27.4)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
@@ -18,15 +26,14 @@ GEM
       cork
       nap
       open4 (~> 1.3)
-    cocoapods (1.9.3)
-      activesupport (>= 4.0.2, < 5)
+    cocoapods (1.10.0.rc.1)
+      addressable (~> 2.6)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.9.3)
+      cocoapods-core (= 1.10.0.rc.1)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 1.2.2, < 2.0)
+      cocoapods-downloader (>= 1.4.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
-      cocoapods-stats (>= 1.0.0, < 2.0)
       cocoapods-trunk (>= 1.4.0, < 2.0)
       cocoapods-try (>= 1.1.0, < 2.0)
       colored2 (~> 3.1)
@@ -36,30 +43,29 @@ GEM
       molinillo (~> 0.6.6)
       nap (~> 1.0)
       ruby-macho (~> 1.4)
-      xcodeproj (>= 1.14.0, < 2.0)
-    cocoapods-core (1.9.3)
-      activesupport (>= 4.0.2, < 6)
+      xcodeproj (>= 1.17.0, < 2.0)
+    cocoapods-core (1.10.0.rc.1)
+      activesupport (> 5.0, < 6)
+      addressable (~> 2.6)
       algoliasearch (~> 1.0)
       concurrent-ruby (~> 1.1)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
       netrc (~> 0.11)
+      public_suffix
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.4)
     cocoapods-disable-podfile-validations (0.1.1)
-    cocoapods-downloader (1.3.0)
-    cocoapods-generate (2.0.0)
-      cocoapods-disable-podfile-validations (~> 0.1.1)
+    cocoapods-downloader (1.4.0)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
-    cocoapods-stats (1.1.0)
     cocoapods-trunk (1.5.0)
       nap (>= 0.8, < 2.0)
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     cork (0.3.0)
       colored2 (~> 3.1)
     danger (6.1.0)
@@ -82,23 +88,23 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (2.0.0)
       faraday (~> 0.8)
-    ffi (1.12.2)
+    ffi (1.13.1)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     git (1.5.0)
     httpclient (2.8.3)
-    i18n (0.9.5)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    json (2.3.0)
+    json (2.3.1)
     kramdown (2.3.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    minitest (5.14.1)
+    minitest (5.14.2)
     molinillo (0.6.6)
     multipart-post (2.1.1)
-    nanaimo (0.2.6)
+    nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
     no_proxy_fix (0.1.2)
@@ -119,19 +125,19 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
-    xcodeproj (1.16.0)
+    xcodeproj (1.18.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
-      nanaimo (~> 0.2.6)
+      nanaimo (~> 0.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (= 1.9.3)
-  cocoapods-generate (= 2.0.0)
+  cocoapods (= 1.10.0.rc.1)
+  cocoapods-generate!
   danger (= 6.1.0)
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/square/cocoapods-generate.git
   revision: 230b0b537b5d7f524de157b6dbb3f5e08d317516
-  branch: master
+  ref: 230b0b537b
   specs:
     cocoapods-generate (2.0.1)
       cocoapods-disable-podfile-validations (~> 0.1.1)


### PR DESCRIPTION
Now that static framework's are off by default, make sure we still test when it is turned back on.
Remove `--use-modular-headers` testing since it is mostly redundant with `--use-static-frameworks` and no longer a recommended option.

All tests passed before turning cron back on

Note that the `--use-static-framework` pod lib lint option is introduced in CocoaPods 1.10

#no-changelog