### PR TITLE
Remove deprecated method in ABT public header

### DIFF
--- a/FirebaseABTesting/CHANGELOG.md
+++ b/FirebaseABTesting/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v7.0.0
+- [removed] Removed `FIRExperimentController.updateExperiments(serviceOrigin:events:policy:lastStartTime:payloads:)`, which was deprecated. (#6543)
+
 # v4.1.0
 - [changed] Functionally neutral source reorganization for preliminary Swift Package Manager support. (#6016)
 

--- a/FirebaseABTesting/Sources/FIRExperimentController.m
+++ b/FirebaseABTesting/Sources/FIRExperimentController.m
@@ -191,19 +191,6 @@ NSArray *ABTExperimentsToClearFromPayloads(
   });
 }
 
-- (void)updateExperimentsWithServiceOrigin:(NSString *)origin
-                                    events:(FIRLifecycleEvents *)events
-                                    policy:(ABTExperimentPayloadExperimentOverflowPolicy)policy
-                             lastStartTime:(NSTimeInterval)lastStartTime
-                                  payloads:(NSArray<NSData *> *)payloads {
-  [self updateExperimentsWithServiceOrigin:origin
-                                    events:events
-                                    policy:policy
-                             lastStartTime:lastStartTime
-                                  payloads:payloads
-                         completionHandler:nil];
-}
-
 - (void)
     updateExperimentConditionalUserPropertiesWithServiceOrigin:(NSString *)origin
                                                         events:(FIRLifecycleEvents *)events

--- a/FirebaseABTesting/Sources/Public/FirebaseABTesting/FIRExperimentController.h
+++ b/FirebaseABTesting/Sources/Public/FirebaseABTesting/FIRExperimentController.h
@@ -57,26 +57,6 @@ NS_SWIFT_NAME(ExperimentController)
                          completionHandler:
                              (nullable void (^)(NSError *_Nullable error))completionHandler;
 
-/// Updates the list of experiments. Experiments already
-/// existing in payloads are not affected, whose state and payload is preserved. This method
-/// compares whether the experiments have changed or not by their variant ID. This runs in a
-/// background queue..
-/// @param origin         The originating service affected by the experiment.
-/// @param events         A list of event names to be used for logging experiment lifecycle events,
-///                       if they are not defined in the payload.
-/// @param policy         The policy to handle new experiments when slots are full.
-/// @param lastStartTime  The last known experiment start timestamp for this affected service.
-///                       (Timestamps are specified by the number of seconds from 00:00:00 UTC on 1
-///                       January 1970.).
-/// @param payloads       List of experiment metadata.
-- (void)updateExperimentsWithServiceOrigin:(NSString *)origin
-                                    events:(FIRLifecycleEvents *)events
-                                    policy:(ABTExperimentPayloadExperimentOverflowPolicy)policy
-                             lastStartTime:(NSTimeInterval)lastStartTime
-                                  payloads:(NSArray<NSData *> *)payloads
-    DEPRECATED_MSG_ATTRIBUTE("Please use updateExperimentsWithServiceOrigin:events:policy:"
-                             "lastStartTime:payloads:completionHandler: instead.");
-
 /// Returns the latest experiment start timestamp given a current latest timestamp and a list of
 /// experiment payloads. Timestamps are specified by the number of seconds from 00:00:00 UTC on 1
 /// January 1970.

--- a/FirebaseABTesting/Tests/Unit/FIRExperimentControllerTest.m
+++ b/FirebaseABTesting/Tests/Unit/FIRExperimentControllerTest.m
@@ -331,38 +331,6 @@ extern NSArray *ABTExperimentsToClearFromPayloads(
   XCTAssertTrue(completionHandlerWithErrorCalled);
 }
 
-- (void)testUpdateExperimentsWithNoCompletion {
-  id experimentControllerMock = OCMPartialMock(_experimentController);
-
-  NSString *mockOrigin = @"mockOrigin";
-  FIRLifecycleEvents *mockLifecycleEvents = [[FIRLifecycleEvents alloc] init];
-  ABTExperimentPayloadExperimentOverflowPolicy mockOverflowPolicy =
-      ABTExperimentPayloadExperimentOverflowPolicyDiscardOldest;
-  NSTimeInterval mockLastStartTime = 100;
-  NSArray *mockPayloads = @[];
-
-  [[experimentControllerMock expect] updateExperimentsWithServiceOrigin:mockOrigin
-                                                                 events:mockLifecycleEvents
-                                                                 policy:mockOverflowPolicy
-                                                          lastStartTime:mockLastStartTime
-                                                               payloads:mockPayloads
-                                                      completionHandler:nil];
-
-  // Expect that updateExperimentsWithServiceOrigin:events:policy:lastStartTime:payloads: calls the
-  // full method with completion handler as nil.
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [experimentControllerMock updateExperimentsWithServiceOrigin:mockOrigin
-                                                        events:mockLifecycleEvents
-                                                        policy:mockOverflowPolicy
-                                                 lastStartTime:mockLastStartTime
-                                                      payloads:mockPayloads];
-#pragma clang diagnostic pop
-
-  [experimentControllerMock verify];
-}
-
 - (void)testValidateRunningExperimentsWithEmptyArray {
   NSDate *now = [NSDate date];
 

--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v7.0.0
 - [changed] Updated `lastFetchTime` field to readonly. (#6567)
+- [changed] Functionally neutral change to stop using a deprecated method in the AB Testing API. (#6543)
 
 # v4.9.0
 - [fixed] Fixed `FirebaseApp.delete()` related crash in `RC Config Fetch`. (#6123)

--- a/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
+++ b/FirebaseRemoteConfig/Sources/RCNConfigExperiment.m
@@ -120,15 +120,13 @@ static NSString *const kMethodNameLatestStartTime =
 
   // Update the last experiment start time with the latest payload.
   [self updateExperimentStartTime];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   [self.experimentController
       updateExperimentsWithServiceOrigin:kServiceOrigin
                                   events:lifecycleEvent
                                   policy:ABTExperimentPayloadExperimentOverflowPolicyDiscardOldest
                            lastStartTime:lastStartTime
-                                payloads:_experimentPayloads];
-#pragma clang diagnostic pop
+                                payloads:_experimentPayloads
+                       completionHandler:nil];
 }
 
 - (void)updateExperimentStartTime {

--- a/FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNConfigExperimentTest.m
@@ -212,8 +212,6 @@
 
   NSTimeInterval lastStartTime =
       [experiment.experimentMetadata[@"last_experiment_start_time"] doubleValue];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   OCMStub(
       [mockExperimentController
           updateExperimentsWithServiceOrigin:[OCMArg any]
@@ -221,9 +219,9 @@
                                       policy:
                                           ABTExperimentPayloadExperimentOverflowPolicyDiscardOldest  // NOLINT
                                lastStartTime:lastStartTime
-                                    payloads:[OCMArg any]])
+                                    payloads:[OCMArg any]
+                           completionHandler:[OCMArg any]])
       .andDo(nil);
-#pragma clang diagnostic pop
 
   NSData *payloadData = [[self class] payloadDataFromTestFile];
 


### PR DESCRIPTION
Also remove usages in RC, using the new method with completion handler.

Fixes #6543.