### PR TITLE
Remove deprecated auth APIs

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [removed] Remove deprecated APIs `dataForKey`,`fetchProvidersForEmail:completion`, `signInAndRetrieveDataWithCredential:completion`, `reauthenticateAndRetrieveDataWithCredential:completion`, `linkAndRetrieveDataWithCredential:completion`. (#6607)
+
 # v6.9.1
 - [fixed] Internal source documentation. (#6371)
 

--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -204,15 +204,6 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
 
 @implementation FIRActionCodeInfo
 
-- (NSString *)dataForKey:(FIRActionDataKey)key {
-  switch (key) {
-    case FIRActionCodeEmailKey:
-      return self.email;
-    case FIRActionCodeFromEmailKey:
-      return self.previousEmail;
-  }
-}
-
 - (instancetype)initWithOperation:(FIRActionCodeOperation)operation
                             email:(NSString *)email
                          newEmail:(nullable NSString *)newEmail {
@@ -589,25 +580,6 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
   return result;
 }
 
-- (void)fetchProvidersForEmail:(NSString *)email
-                    completion:(nullable FIRProviderQueryCallback)completion {
-  dispatch_async(FIRAuthGlobalWorkQueue(), ^{
-    FIRCreateAuthURIRequest *request =
-        [[FIRCreateAuthURIRequest alloc] initWithIdentifier:email
-                                                continueURI:@"http://www.google.com/"
-                                       requestConfiguration:self->_requestConfiguration];
-    [FIRAuthBackend
-        createAuthURI:request
-             callback:^(FIRCreateAuthURIResponse *_Nullable response, NSError *_Nullable error) {
-               if (completion) {
-                 dispatch_async(dispatch_get_main_queue(), ^{
-                   completion(response.allProviders, error);
-                 });
-               }
-             }];
-  });
-}
-
 - (void)signInWithProvider:(id<FIRFederatedAuthProvider>)provider
                 UIDelegate:(nullable id<FIRAuthUIDelegate>)UIDelegate
                 completion:(nullable FIRAuthDataResultCallback)completion {
@@ -858,16 +830,8 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
              }];
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)signInWithCredential:(FIRAuthCredential *)credential
                   completion:(nullable FIRAuthDataResultCallback)completion {
-  [self signInAndRetrieveDataWithCredential:credential completion:completion];
-}
-#pragma clang diagnostic pop
-
-- (void)signInAndRetrieveDataWithCredential:(FIRAuthCredential *)credential
-                                 completion:(nullable FIRAuthDataResultCallback)completion {
   dispatch_async(FIRAuthGlobalWorkQueue(), ^{
     FIRAuthDataResultCallback callback =
         [self signInFlowAuthDataResultCallbackByDecoratingCallback:completion];

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h
@@ -176,19 +176,6 @@ typedef void (^FIRApplyActionCodeCallback)(NSError *_Nullable error)
 
 typedef void (^FIRAuthVoidErrorCallback)(NSError *_Nullable) NS_SWIFT_NAME(AuthVoidErrorCallback);
 
-/**
-    @brief Deprecated. Please directly use email or previousEmail properties instead.
-  */
-typedef NS_ENUM(NSInteger, FIRActionDataKey) {
-  /** Deprecated. Please directly use email property instead.  */
-  FIRActionCodeEmailKey = 0,
-
-  /** Deprecated. Please directly use previousEmail property instead. */
-  FIRActionCodeFromEmailKey = 1,
-
-} NS_SWIFT_NAME(ActionDataKey)
-    DEPRECATED_MSG_ATTRIBUTE("Please directly use email or previousEmail properties instead.");
-
 /** @class FIRActionCodeInfo
     @brief Manages information regarding action codes.
  */
@@ -226,12 +213,6 @@ typedef NS_ENUM(NSInteger, FIRActionCodeOperation) {
     @brief The operation being performed.
  */
 @property(nonatomic, readonly) FIRActionCodeOperation operation;
-
-/** @fn dataForKey:
-    @brief Deprecated. Please directly use email or previousEmail properties instead.
- */
-- (NSString *)dataForKey:(FIRActionDataKey)key
-    DEPRECATED_MSG_ATTRIBUTE("Please directly use email or previousEmail properties instead.");
 
 /** @property email
     @brief The email address to which the code was sent. The new email address in the case of
@@ -388,16 +369,6 @@ NS_SWIFT_NAME(Auth)
 - (void)updateCurrentUser:(FIRUser *)user
                completion:(nullable void (^)(NSError *_Nullable error))completion;
 
-/** @fn fetchProvidersForEmail:completion:
-    @brief Please use fetchSignInMethodsForEmail:completion: for Objective-C or
-        fetchSignInMethods(forEmail:completion:) for Swift instead.
- */
-- (void)fetchProvidersForEmail:(NSString *)email
-                    completion:(nullable void (^)(NSArray<NSString *> *_Nullable providers,
-                                                  NSError *_Nullable error))completion
-    DEPRECATED_MSG_ATTRIBUTE("Please use fetchSignInMethodsForEmail:completion: for Objective-C or "
-                             "fetchSignInMethods(forEmail:completion:) for Swift instead.");
-
 /** @fn fetchSignInMethodsForEmail:completion:
     @brief Fetches the list of all sign-in methods previously used for the provided email address.
 
@@ -518,17 +489,6 @@ NS_SWIFT_NAME(Auth)
                 completion:(nullable void (^)(FIRAuthDataResult *_Nullable authResult,
                                               NSError *_Nullable error))completion
     API_UNAVAILABLE(watchos);
-
-/** @fn signInAndRetrieveDataWithCredential:completion:
-    @brief Please use signInWithCredential:completion: for Objective-C or "
-        "signIn(with:completion:) for Swift instead.
- */
-- (void)signInAndRetrieveDataWithCredential:(FIRAuthCredential *)credential
-                                 completion:
-                                     (nullable void (^)(FIRAuthDataResult *_Nullable authResult,
-                                                        NSError *_Nullable error))completion
-    DEPRECATED_MSG_ATTRIBUTE("Please use signInWithCredential:completion: for Objective-C or "
-                             "signIn(with:completion:) for Swift instead.");
 
 /** @fn signInWithCredential:completion:
     @brief Asynchronously signs in to Firebase with the given 3rd-party credentials (e.g. a Facebook

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRUser.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRUser.h
@@ -275,18 +275,6 @@ NS_SWIFT_NAME(User)
                           completion:(nullable void (^)(FIRAuthDataResult *_Nullable authResult,
                                                         NSError *_Nullable error))completion;
 
-/** @fn reauthenticateAndRetrieveDataWithCredential:completion:
-    @brief Please use linkWithCredential:completion: for Objective-C
-        or link(withCredential:completion:) for Swift instead.
- */
-- (void)reauthenticateAndRetrieveDataWithCredential:(FIRAuthCredential *)credential
-                                         completion:(nullable void (^)(
-                                                        FIRAuthDataResult *_Nullable authResult,
-                                                        NSError *_Nullable error))completion
-    DEPRECATED_MSG_ATTRIBUTE("Please use reauthenticateWithCredential:completion: for"
-                             " Objective-C or reauthenticate(withCredential:completion:)"
-                             " for Swift instead.");
-
 /** @fn reauthenticateWithProvider:UIDelegate:completion:
     @brief Renews the user's authentication using the provided auth provider instance.
 
@@ -361,17 +349,6 @@ NS_SWIFT_NAME(User)
 - (void)getIDTokenForcingRefresh:(BOOL)forceRefresh
                       completion:(nullable void (^)(NSString *_Nullable token,
                                                     NSError *_Nullable error))completion;
-
-/** @fn linkAndRetrieveDataWithCredential:completion:
-    @brief Please use linkWithCredential:completion: for Objective-C
-        or link(withCredential:completion:) for Swift instead.
- */
-- (void)linkAndRetrieveDataWithCredential:(FIRAuthCredential *)credential
-                               completion:
-                                   (nullable void (^)(FIRAuthDataResult *_Nullable authResult,
-                                                      NSError *_Nullable error))completion
-    DEPRECATED_MSG_ATTRIBUTE("Please use linkWithCredential:completion: for Objective-C "
-                             "or link(withCredential:completion:) for Swift instead.");
 
 /** @fn linkWithCredential:completion:
     @brief Associates a user account from a third-party identity provider with this user and

--- a/FirebaseAuth/Sources/User/FIRUser.m
+++ b/FirebaseAuth/Sources/User/FIRUser.m
@@ -787,16 +787,8 @@ static void callInMainThreadWithAuthDataResultAndError(
 
 #pragma mark -
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)reauthenticateWithCredential:(FIRAuthCredential *)credential
                           completion:(nullable FIRAuthDataResultCallback)completion {
-  [self reauthenticateAndRetrieveDataWithCredential:credential completion:completion];
-}
-#pragma clang diagnostic pop
-
-- (void)reauthenticateAndRetrieveDataWithCredential:(FIRAuthCredential *)credential
-                                         completion:(nullable FIRAuthDataResultCallback)completion {
   dispatch_async(FIRAuthGlobalWorkQueue(), ^{
     [self->_auth
         internalSignInAndRetrieveDataWithCredential:credential
@@ -1056,16 +1048,8 @@ static void callInMainThreadWithAuthDataResultAndError(
   });
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)linkWithCredential:(FIRAuthCredential *)credential
                 completion:(nullable FIRAuthDataResultCallback)completion {
-  [self linkAndRetrieveDataWithCredential:credential completion:completion];
-}
-#pragma clang diagnostic pop
-
-- (void)linkAndRetrieveDataWithCredential:(FIRAuthCredential *)credential
-                               completion:(nullable FIRAuthDataResultCallback)completion {
   dispatch_async(FIRAuthGlobalWorkQueue(), ^{
     if (self->_providerData[credential.provider]) {
       callInMainThreadWithAuthDataResultAndError(completion, nil,

--- a/FirebaseAuth/Tests/Sample/Sample/MainViewController+User.m
+++ b/FirebaseAuth/Tests/Sample/Sample/MainViewController+User.m
@@ -35,8 +35,6 @@ NS_ASSUME_NONNULL_BEGIN
                                       action:^{ [weakSelf updatePassword]; }],
     [StaticContentTableViewCell cellWithTitle:@"Update Phone Number"
                                       action:^{ [weakSelf updatePhoneNumber]; }],
-    [StaticContentTableViewCell cellWithTitle:@"Get Provider IDs for Email"
-                                      action:^{ [weakSelf getProvidersForEmail]; }],
     [StaticContentTableViewCell cellWithTitle:@"Get Sign-in methods for Email"
                                       action:^{ [weakSelf getAllSignInMethodsForEmail]; }],
     [StaticContentTableViewCell cellWithTitle:@"Reload User"
@@ -110,33 +108,6 @@ NS_ASSUME_NONNULL_BEGIN
       }];
     }];
   }];
-}
-
-- (void)getProvidersForEmail {
-  [self showTextInputPromptWithMessage:@"Email:"
-                       completionBlock:^(BOOL userPressedOK, NSString *_Nullable userInput) {
-   if (!userPressedOK || !userInput.length) {
-     return;
-   }
-   [self showSpinner:^{
-     [[AppManager auth] fetchProvidersForEmail:userInput
-                                    completion:^(NSArray<NSString *> *_Nullable providers,
-                                                 NSError *_Nullable error) {
-      if (error) {
-        [self logFailure:@"get providers for email failed" error:error];
-      } else {
-        [self logSuccess:@"get providers for email succeeded."];
-      }
-      [self hideSpinner:^{
-        if (error) {
-          [self showMessagePrompt:error.localizedDescription];
-          return;
-        }
-        [self showMessagePrompt:[providers componentsJoinedByString:@", "]];
-      }];
-    }];
-   }];
- }];
 }
 
 - (void)getAllSignInMethodsForEmail {

--- a/FirebaseAuth/Tests/Unit/FIRAuthTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthTests.m
@@ -378,39 +378,6 @@ static const NSTimeInterval kWaitInterval = .5;
 
 #pragma mark - Server API Tests
 
-/** @fn testFetchProvidersForEmailSuccess
-    @brief Tests the flow of a successful @c fetchProvidersForEmail:completion: call.
- */
-- (void)testFetchProvidersForEmailSuccess {
-  NSArray<NSString *> *allProviders = @[ FIRGoogleAuthProviderID, FIREmailAuthProviderID ];
-  OCMExpect([_mockBackend createAuthURI:[OCMArg any] callback:[OCMArg any]])
-      .andCallBlock2(
-          ^(FIRCreateAuthURIRequest *_Nullable request, FIRCreateAuthURIResponseCallback callback) {
-            XCTAssertEqualObjects(request.identifier, kEmail);
-            XCTAssertNotNil(request.endpoint);
-            XCTAssertEqualObjects(request.APIKey, kAPIKey);
-            dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
-              id mockCreateAuthURIResponse = OCMClassMock([FIRCreateAuthURIResponse class]);
-              OCMStub([mockCreateAuthURIResponse allProviders]).andReturn(allProviders);
-              callback(mockCreateAuthURIResponse, nil);
-            });
-          });
-  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [[FIRAuth auth]
-      fetchProvidersForEmail:kEmail
-                  completion:^(NSArray<NSString *> *_Nullable providers, NSError *_Nullable error) {
-#pragma clang diagnostic pop
-                    XCTAssertTrue([NSThread isMainThread]);
-                    XCTAssertEqualObjects(providers, allProviders);
-                    XCTAssertNil(error);
-                    [expectation fulfill];
-                  }];
-  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
-  OCMVerifyAll(_mockBackend);
-}
-
 /** @fn testFetchSignInMethodsForEmailSuccess
     @brief Tests the flow of a successful @c fetchSignInMethodsForEmail:completion: call.
  */
@@ -439,30 +406,6 @@ static const NSTimeInterval kWaitInterval = .5;
                                     XCTAssertNil(error);
                                     [expectation fulfill];
                                   }];
-  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
-  OCMVerifyAll(_mockBackend);
-}
-
-/** @fn testFetchProvidersForEmailFailure
-    @brief Tests the flow of a failed @c fetchProvidersForEmail:completion: call.
- */
-- (void)testFetchProvidersForEmailFailure {
-  OCMExpect([_mockBackend createAuthURI:[OCMArg any] callback:[OCMArg any]])
-      .andDispatchError2([FIRAuthErrorUtils tooManyRequestsErrorWithMessage:nil]);
-  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [[FIRAuth auth]
-      fetchProvidersForEmail:kEmail
-                  completion:^(NSArray<NSString *> *_Nullable providers, NSError *_Nullable error) {
-
-#pragma clang pop
-                    XCTAssertTrue([NSThread isMainThread]);
-                    XCTAssertNil(providers);
-                    XCTAssertEqual(error.code, FIRAuthErrorCodeTooManyRequests);
-                    XCTAssertNotNil(error.userInfo[NSLocalizedDescriptionKey]);
-                    [expectation fulfill];
-                  }];
   [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
   OCMVerifyAll(_mockBackend);
 }
@@ -1363,11 +1306,11 @@ static const NSTimeInterval kWaitInterval = .5;
 }
 #endif  // TARGET_OS_IOS
 
-/** @fn testSignInAndRetrieveDataWithCredentialSuccess
-    @brief Tests the flow of a successful @c signInAndRetrieveDataWithCredential:completion: call
+/** @fn testSignInWithCredentialSuccess
+    @brief Tests the flow of a successful @c signInWithCredential:completion: call
         with an Google Sign-In credential.
  */
-- (void)testSignInAndRetrieveDataWithCredentialSuccess {
+- (void)testSignInWithCredentialSuccess {
   OCMExpect([_mockBackend verifyAssertion:[OCMArg any] callback:[OCMArg any]])
       .andCallBlock2(^(FIRVerifyAssertionRequest *_Nullable request,
                        FIRVerifyAssertionResponseCallback callback) {

--- a/FirebaseAuth/Tests/Unit/FIRUserTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRUserTests.m
@@ -1637,11 +1637,11 @@ static const NSTimeInterval kExpectationTimeout = 2;
   OCMVerifyAll(_mockBackend);
 }
 
-/** @fn testReauthenticateAndRetrieveDataSuccess
-    @brief Tests the flow of a successful @c reauthenticateAndRetrieveDataWithCredential:completion:
+/** @fn testReauthenticateWithCredentialSuccess
+    @brief Tests the flow of a successful @c reauthenticateWithCredential:completion:
         call.
  */
-- (void)testReauthenticateAndRetrieveDataSuccess {
+- (void)testReauthenticateWithCredentialSuccess {
   [self expectVerifyAssertionRequest:FIRGoogleAuthProviderID
                          federatedID:kGoogleID
                          displayName:kGoogleDisplayName
@@ -1864,7 +1864,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 }
 
 /** @fn testlinkAndRetrieveDataSuccess
-    @brief Tests the flow of a successful @c linkAndRetrieveDataWithCredential:completion:
+    @brief Tests the flow of a successful @c linkWithCredential:completion:
         call.
  */
 - (void)testlinkAndRetrieveDataSuccess {
@@ -1932,7 +1932,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 }
 
 /** @fn testlinkAndRetrieveDataError
-    @brief Tests the flow of an unsuccessful @c linkAndRetrieveDataWithCredential:completion:
+    @brief Tests the flow of an unsuccessful @c linkWithCredential:completion:
         call with an error from the backend.
  */
 - (void)testlinkAndRetrieveDataError {
@@ -1992,7 +1992,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 }
 
 /** @fn testlinkAndRetrieveDataProviderAlreadyLinked
-    @brief Tests the flow of an unsuccessful @c linkAndRetrieveDataWithCredential:completion:
+    @brief Tests the flow of an unsuccessful @c linkWithCredential:completion:
         call with FIRAuthErrorCodeProviderAlreadyLinked, which is a client side error.
  */
 - (void)testlinkAndRetrieveDataProviderAlreadyLinked {
@@ -2036,7 +2036,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 }
 
 /** @fn testlinkAndRetrieveDataErrorAutoSignOut
-    @brief Tests the flow of an unsuccessful @c linkAndRetrieveDataWithCredential:completion:
+    @brief Tests the flow of an unsuccessful @c linkWithCredential:completion:
         call that automatically signs out.
  */
 - (void)testlinkAndRetrieveDataErrorAutoSignOut {
@@ -2089,7 +2089,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 }
 
 /** @fn testlinkEmailAndRetrieveDataSuccess
-    @brief Tests the flow of a successful @c linkAndRetrieveDataWithCredential:completion:
+    @brief Tests the flow of a successful @c linkWithCredential:completion:
         invocation for email credential.
  */
 - (void)testlinkEmailAndRetrieveDataSuccess {
@@ -2163,7 +2163,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 }
 
 /** @fn testlinkEmailProviderAlreadyLinkedError
-    @brief Tests the flow of an unsuccessful @c linkAndRetrieveDataWithCredential:completion:
+    @brief Tests the flow of an unsuccessful @c linkWithCredential:completion:
         invocation for email credential and FIRAuthErrorCodeProviderAlreadyLinked which is a client
         side error.
  */
@@ -2250,7 +2250,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 }
 
 /** @fn testlinkEmailAndRetrieveDataError
-    @brief Tests the flow of an unsuccessful @c linkAndRetrieveDataWithCredential:completion:
+    @brief Tests the flow of an unsuccessful @c linkWithCredential:completion:
         invocation for email credential and an error from the backend.
  */
 - (void)testlinkEmailAndRetrieveDataError {
@@ -2305,7 +2305,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 }
 
 /** @fn testlinkEmailAndRetrieveDataError
-    @brief Tests the flow of an unsuccessful @c linkAndRetrieveDataWithCredential:completion:
+    @brief Tests the flow of an unsuccessful @c linkWithCredential:completion:
         invocation that automatically signs out.
  */
 - (void)testlinkEmailAndRetrieveDataErrorAutoSignOut {
@@ -2510,7 +2510,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 
 #if TARGET_OS_IOS
 /** @fn testlinkPhoneAuthCredentialSuccess
-    @brief Tests the flow of a successful @c linkAndRetrieveDataWithCredential:completion:
+    @brief Tests the flow of a successful @c linkWithCredential:completion:
         call using a phoneAuthCredential.
  */
 - (void)testlinkPhoneAuthCredentialSuccess {
@@ -2668,7 +2668,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 }
 
 /** @fn testlinkPhoneAuthCredentialFailure
-    @brief Tests the flow of a failed call to @c linkAndRetrieveDataWithCredential:completion: due
+    @brief Tests the flow of a failed call to @c linkWithCredential:completion: due
         to a phone provider already being linked.
  */
 - (void)testlinkPhoneAuthCredentialFailure {
@@ -2716,7 +2716,7 @@ static const NSTimeInterval kExpectationTimeout = 2;
 }
 
 /** @fn testlinkPhoneCredentialAlreadyExistsError
-    @brief Tests the flow of @c linkAndRetrieveDataWithCredential:completion:
+    @brief Tests the flow of @c linkWithCredential:completion:
         call using a phoneAuthCredential and a credential already exisits error. In this case we
         should get a FIRAuthCredential in the error object.
  */


### PR DESCRIPTION
Remove deprecated APIs `dataForKey`,`fetchProvidersForEmail:completion`, `signInAndRetrieveDataWithCredential:completion`, `reauthenticateAndRetrieveDataWithCredential:completion`, `linkAndRetrieveDataWithCredential:completion`.

Fix #6544