### PR TITLE
Clean up usage of deprecated methods in unit tests

### DIFF
--- a/FirebaseRemoteConfig/Tests/FakeConsole/FakeConsoleTests.swift
+++ b/FirebaseRemoteConfig/Tests/FakeConsole/FakeConsoleTests.swift
@@ -23,43 +23,6 @@ class FakeConsoleTests: APITestBase {
     fakeConsole.config = ["Key1": "Value1"]
   }
 
-  // Test old API.
-  // Contrast with testUnchangedActivateWillError in APITests.swift.
-  func testChangedActivateWillNotError() {
-    let expectation = self.expectation(description: #function)
-    config.fetch { status, error in
-      if let error = error {
-        XCTFail("Fetch Error \(error)")
-      }
-      XCTAssertEqual(status, RemoteConfigFetchStatus.success)
-      self.config.activate { error in
-        if let error = error {
-          print("Activate Error \(error)")
-        }
-        XCTAssertEqual(self.config["Key1"].stringValue, "Value1")
-        expectation.fulfill()
-      }
-    }
-    waitForExpectations()
-
-    // Simulate updating console.
-    fakeConsole.config = ["Key1": "Value2"]
-
-    let expectation2 = self.expectation(description: #function + "2")
-    config.fetch { status, error in
-      if let error = error {
-        XCTFail("Fetch Error \(error)")
-      }
-      XCTAssertEqual(status, RemoteConfigFetchStatus.success)
-      self.config.activate { error in
-        XCTAssertNil(error)
-        XCTAssertEqual(self.config["Key1"].stringValue, "Value2")
-        expectation2.fulfill()
-      }
-    }
-    waitForExpectations()
-  }
-
   // Test New API.
   // Contrast with testUnchangedActivateWillFlag in APITests.swift.
   func testChangedActivateWillNotFlag() {

--- a/FirebaseRemoteConfig/Tests/SwiftAPI/APITests.swift
+++ b/FirebaseRemoteConfig/Tests/SwiftAPI/APITests.swift
@@ -95,42 +95,6 @@ class APITests: APITestBase {
     waitForExpectations()
   }
 
-  // Test old API.
-  // Contrast with testChangedActivateWillNotError in FakeConsole.swift.
-  func testUnchangedActivateWillError() {
-    let expectation = self.expectation(description: #function)
-    config.fetch { status, error in
-      if let error = error {
-        XCTFail("Fetch Error \(error)")
-      }
-      XCTAssertEqual(status, RemoteConfigFetchStatus.success)
-      self.config.activate { error in
-        if let error = error {
-          print("Activate Error \(error)")
-        }
-        XCTAssertEqual(self.config[Constants.key1].stringValue, Constants.value1)
-        expectation.fulfill()
-      }
-    }
-    waitForExpectations()
-    let expectation2 = self.expectation(description: #function + "2")
-    config.fetch { status, error in
-      if let error = error {
-        XCTFail("Fetch Error \(error)")
-      }
-      XCTAssertEqual(status, RemoteConfigFetchStatus.success)
-      self.config.activate { error in
-        XCTAssertNotNil(error)
-        if let error = error {
-          XCTAssertEqual((error as NSError).code, RemoteConfigError.internalError.rawValue)
-        }
-        XCTAssertEqual(self.config[Constants.key1].stringValue, Constants.value1)
-        expectation2.fulfill()
-      }
-    }
-    waitForExpectations()
-  }
-
   // Test New API.
   // Contrast with testChangedActivateWillNotFlag in FakeConsole.swift.
   func testUnchangedActivateWillFlag() {

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -946,6 +946,10 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
       key5 : @(defaultValue5),
     }];
     [_configInstances[i] setDefaults:defaults];
+    if (i == RCNTestRCInstanceSecondNamespace) {
+      [defaults setObject:@"2860" forKey:@"experience"];
+      [_configInstances[i] setDefaults:defaults];
+    }
     // Remove objects right away to make sure dispatch_async gets the copy.
     [defaults removeAllObjects];
 
@@ -964,6 +968,12 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
         @"defaultConfig as string.");
 
     XCTAssertEqual(config[key5].boolValue, defaultValue5, @"Should support bool format");
+
+    if (i == RCNTestRCInstanceSecondNamespace) {
+      XCTAssertEqualObjects(
+          [_configInstances[i] configValueForKey:@"experience"].stringValue, @"2860",
+          @"Only default config has the key, must equal to default config value.");
+    }
 
     // Reset default sets
     [_configInstances[i] setDefaults:nil];
@@ -1167,18 +1177,41 @@ static NSString *UTCToLocal(NSString *utcTime) {
 
 - (void)testSetDefaultsAndNamespaceFromPlist {
   for (int i = 0; i < RCNTestRCNumTotalInstances; i++) {
-    [_configInstances[i] setDefaultsFromPlistFileName:@"Defaults-testInfo"];
-    XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"lastCheckTime"].stringValue,
-                          UTCToLocal(@"2016-02-28 18:33:31"));
-    XCTAssertEqual([_configInstances[i] configValueForKey:@"isPaidUser"].boolValue, YES);
-    XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"dataValue"].stringValue, @"2.4");
-    XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"New item"].numberValue, @(2.4));
-    XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"Languages"].stringValue,
-                          @"English");
-    XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"FileInfo"].stringValue,
-                          @"To setup default config.");
-    XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"format"].stringValue,
-                          @"key to value.");
+    if (i == RCNTestRCInstanceDefault) {
+#if SWIFT_PACKAGE
+      [_configInstances[i] setDefaults:[self getSPMDefaults] namespace:RCNTestsPerfNamespace];
+#else
+      [_configInstances[i] setDefaultsFromPlistFileName:@"Defaults-testInfo"];
+#endif
+      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"lastCheckTime"].stringValue,
+                            UTCToLocal(@"2016-02-28 18:33:31"));
+      XCTAssertEqual([_configInstances[i] configValueForKey:@"isPaidUser"].boolValue, YES);
+      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"dataValue"].stringValue,
+                            @"2.4");
+      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"New item"].numberValue,
+                            @(2.4));
+      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"Languages"].stringValue,
+                            @"English");
+      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"FileInfo"].stringValue,
+                            @"To setup default config.");
+      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"format"].stringValue,
+                            @"key to value.");
+    } else {
+      [_configInstances[i] setDefaultsFromPlistFileName:@"Defaults-testInfo"];
+      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"lastCheckTime"].stringValue,
+                            UTCToLocal(@"2016-02-28 18:33:31"));
+      XCTAssertEqual([_configInstances[i] configValueForKey:@"isPaidUser"].boolValue, YES);
+      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"dataValue"].stringValue,
+                            @"2.4");
+      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"New item"].numberValue,
+                            @(2.4));
+      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"Languages"].stringValue,
+                            @"English");
+      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"FileInfo"].stringValue,
+                            @"To setup default config.");
+      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"format"].stringValue,
+                            @"key to value.");
+    }
   }
 }
 

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -277,27 +277,26 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
                                                            NSError *error) {
       XCTAssertEqual(self->_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusSuccess);
       XCTAssertNil(error);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      XCTAssertTrue([self->_configInstances[i] activateFetched]);
-#pragma clang diagnostic pop
-      NSString *key1 = [NSString stringWithFormat:@"key1-%d", i];
-      NSString *key2 = [NSString stringWithFormat:@"key2-%d", i];
-      NSString *value1 = [NSString stringWithFormat:@"value1-%d", i];
-      NSString *value2 = [NSString stringWithFormat:@"value2-%d", i];
-      XCTAssertEqualObjects(self->_configInstances[i][key1].stringValue, value1);
-      XCTAssertEqualObjects(self->_configInstances[i][key2].stringValue, value2);
+      [self->_configInstances[i] activateWithCompletion:^(BOOL changed, NSError *_Nullable error) {
+        XCTAssertTrue(changed);
+        NSString *key1 = [NSString stringWithFormat:@"key1-%d", i];
+        NSString *key2 = [NSString stringWithFormat:@"key2-%d", i];
+        NSString *value1 = [NSString stringWithFormat:@"value1-%d", i];
+        NSString *value2 = [NSString stringWithFormat:@"value2-%d", i];
+        XCTAssertEqualObjects(self->_configInstances[i][key1].stringValue, value1);
+        XCTAssertEqualObjects(self->_configInstances[i][key2].stringValue, value2);
 
-      OCMVerify([self->_configInstances[i] objectForKeyedSubscript:key1]);
+        OCMVerify([self->_configInstances[i] objectForKeyedSubscript:key1]);
 
-      XCTAssertEqual(status, FIRRemoteConfigFetchStatusSuccess,
-                     @"Callback of first successful config "
-                     @"fetch. Status must equal to FIRRemoteConfigFetchStatusSuccessFresh.");
+        XCTAssertEqual(status, FIRRemoteConfigFetchStatusSuccess,
+                       @"Callback of first successful config "
+                       @"fetch. Status must equal to FIRRemoteConfigFetchStatusSuccessFresh.");
 
-      XCTAssertNotNil(self->_configInstances[i].lastFetchTime);
-      XCTAssertGreaterThan(self->_configInstances[i].lastFetchTime.timeIntervalSince1970, 0,
-                           @"last fetch time interval should be set.");
-      [expectations[i] fulfill];
+        XCTAssertNotNil(self->_configInstances[i].lastFetchTime);
+        XCTAssertGreaterThan(self->_configInstances[i].lastFetchTime.timeIntervalSince1970, 0,
+                             @"last fetch time interval should be set.");
+        [expectations[i] fulfill];
+      }];
     };
     [_configInstances[i] fetchWithExpirationDuration:43200 completionHandler:fetchCompletion];
   }
@@ -367,7 +366,8 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
                                                        NSError *error) {
       XCTAssertEqual(self->_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusSuccess);
       XCTAssertNil(error);
-      [self->_configInstances[i] activateWithCompletionHandler:^(NSError *_Nullable error) {
+      [self->_configInstances[i] activateWithCompletion:^(BOOL changed, NSError *_Nullable error) {
+        XCTAssertTrue(changed);
         XCTAssertNil(error);
         NSString *key1 = [NSString stringWithFormat:@"key1-%d", i];
         NSString *key2 = [NSString stringWithFormat:@"key2-%d", i];
@@ -385,11 +385,13 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
         XCTAssertNotNil(self->_configInstances[i].lastFetchTime);
         XCTAssertGreaterThan(self->_configInstances[i].lastFetchTime.timeIntervalSince1970, 0,
                              @"last fetch time interval should be set.");
-        // A second activate should return an error.
-        [self->_configInstances[i] activateWithCompletionHandler:^(NSError *_Nullable error) {
-          XCTAssertNotNil(error);
-          XCTAssertEqualObjects(error.domain, FIRRemoteConfigErrorDomain);
-        }];
+
+        // A second activate should have no effect.
+        [self->_configInstances[i]
+            activateWithCompletion:^(BOOL changed, NSError *_Nullable error) {
+              XCTAssertFalse(changed);
+              XCTAssertNil(error);
+            }];
         [expectations[i] fulfill];
       }];
     };
@@ -414,36 +416,35 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
                                                            NSError *error) {
       XCTAssertEqual(self->_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusSuccess);
       XCTAssertNil(error);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      XCTAssertTrue([self->_configInstances[i] activateFetched]);
-#pragma clang diagnostic pop
-      NSString *key5 = [NSString stringWithFormat:@"key5-%d", i];
-      NSString *key19 = [NSString stringWithFormat:@"key19-%d", i];
-      NSString *value5 = [NSString stringWithFormat:@"value5-%d", i];
-      NSString *value19 = [NSString stringWithFormat:@"value19-%d", i];
+      [self->_configInstances[i] activateWithCompletion:^(BOOL changed, NSError *_Nullable error) {
+        XCTAssertTrue(changed);
+        NSString *key5 = [NSString stringWithFormat:@"key5-%d", i];
+        NSString *key19 = [NSString stringWithFormat:@"key19-%d", i];
+        NSString *value5 = [NSString stringWithFormat:@"value5-%d", i];
+        NSString *value19 = [NSString stringWithFormat:@"value19-%d", i];
 
-      XCTAssertEqualObjects(self->_configInstances[i][key5].stringValue, value5);
-      XCTAssertEqualObjects(self->_configInstances[i][key19].stringValue, value19);
+        XCTAssertEqualObjects(self->_configInstances[i][key5].stringValue, value5);
+        XCTAssertEqualObjects(self->_configInstances[i][key19].stringValue, value19);
 
-      // Test enumerating config values.
-      for (NSString *key in self->_configInstances[i]) {
-        if ([key isEqualToString:key5]) {
-          XCTAssertEqualObjects(self->_configInstances[i][key5].stringValue, value5);
+        // Test enumerating config values.
+        for (NSString *key in self->_configInstances[i]) {
+          if ([key isEqualToString:key5]) {
+            XCTAssertEqualObjects(self->_configInstances[i][key5].stringValue, value5);
+          }
+          if ([key isEqualToString:key19]) {
+            XCTAssertEqualObjects(self->_configInstances[i][key19].stringValue, value19);
+          }
         }
-        if ([key isEqualToString:key19]) {
-          XCTAssertEqualObjects(self->_configInstances[i][key19].stringValue, value19);
-        }
-      }
-      XCTAssertEqual(status, FIRRemoteConfigFetchStatusSuccess,
-                     @"Callback of first successful config "
-                     @"fetch. Status must equal to FIRRemoteConfigFetchStatusSuccessFresh.");
+        XCTAssertEqual(status, FIRRemoteConfigFetchStatusSuccess,
+                       @"Callback of first successful config "
+                       @"fetch. Status must equal to FIRRemoteConfigFetchStatusSuccessFresh.");
 
-      XCTAssertNotNil(self->_configInstances[i].lastFetchTime);
-      XCTAssertGreaterThan(self->_configInstances[i].lastFetchTime.timeIntervalSince1970, 0,
-                           @"last fetch time interval should be set.");
+        XCTAssertNotNil(self->_configInstances[i].lastFetchTime);
+        XCTAssertGreaterThan(self->_configInstances[i].lastFetchTime.timeIntervalSince1970, 0,
+                             @"last fetch time interval should be set.");
 
-      [expectations[i] fulfill];
+        [expectations[i] fulfill];
+      }];
     };
     [_configInstances[i] fetchWithExpirationDuration:43200 completionHandler:fetchCompletion];
   }
@@ -544,8 +545,6 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
                                                configSettings:settings
                                              configExperiment:nil];
   }
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   // Make the fetch calls for all instances.
   NSMutableArray<XCTestExpectation *> *expectations =
       [[NSMutableArray alloc] initWithCapacity:RCNTestRCNumTotalInstances];
@@ -558,14 +557,15 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
     FIRRemoteConfigFetchCompletion fetchCompletion = ^void(FIRRemoteConfigFetchStatus status,
                                                            NSError *error) {
       XCTAssertEqual(self->_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusFailure);
-      XCTAssertFalse([self->_configInstances[i] activateFetched]);
-      XCTAssertNotNil(error);
-      // No such key, still return a static value.
-      FIRRemoteConfigValue *value = self->_configInstances[RCNTestRCInstanceDefault][@"key1"];
-      XCTAssertEqual((int)value.source, (int)FIRRemoteConfigSourceStatic);
-      XCTAssertEqualObjects(value.stringValue, @"");
-      XCTAssertEqual(value.boolValue, NO);
-      [expectations[i] fulfill];
+      [self->_configInstances[i] activateWithCompletion:^(BOOL changed, NSError *_Nullable error) {
+        XCTAssertFalse(changed);
+        XCTAssertNil(error);
+        FIRRemoteConfigValue *value = self->_configInstances[RCNTestRCInstanceDefault][@"key1"];
+        XCTAssertEqual((int)value.source, (int)FIRRemoteConfigSourceStatic);
+        XCTAssertEqualObjects(value.stringValue, @"");
+        XCTAssertEqual(value.boolValue, NO);
+        [expectations[i] fulfill];
+      }];
     };
     [_configInstances[i] fetchWithExpirationDuration:43200 completionHandler:fetchCompletion];
   }
@@ -668,8 +668,6 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
                                                configSettings:settings
                                              configExperiment:nil];
   }
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   // Make the fetch calls for all instances.
   NSMutableArray<XCTestExpectation *> *expectations =
       [[NSMutableArray alloc] initWithCapacity:RCNTestRCNumTotalInstances];
@@ -682,14 +680,16 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
     FIRRemoteConfigFetchCompletion fetchCompletion = ^void(FIRRemoteConfigFetchStatus status,
                                                            NSError *error) {
       XCTAssertEqual(self->_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusFailure);
-      XCTAssertFalse([self->_configInstances[i] activateFetched]);
-      XCTAssertNotNil(error);
-      // No such key, still return a static value.
-      FIRRemoteConfigValue *value = self->_configInstances[RCNTestRCInstanceDefault][@"key1"];
-      XCTAssertEqual((int)value.source, (int)FIRRemoteConfigSourceStatic);
-      XCTAssertEqualObjects(value.stringValue, @"");
-      XCTAssertEqual(value.boolValue, NO);
-      [expectations[i] fulfill];
+      [self->_configInstances[i] activateWithCompletion:^(BOOL changed, NSError *_Nullable error) {
+        XCTAssertFalse(changed);
+        XCTAssertNil(error);
+        // No such key, still return a static value.
+        FIRRemoteConfigValue *value = self->_configInstances[RCNTestRCInstanceDefault][@"key1"];
+        XCTAssertEqual((int)value.source, (int)FIRRemoteConfigSourceStatic);
+        XCTAssertEqualObjects(value.stringValue, @"");
+        XCTAssertEqual(value.boolValue, NO);
+        [expectations[i] fulfill];
+      }];
     };
     [_configInstances[i] fetchWithExpirationDuration:43200 completionHandler:fetchCompletion];
   }
@@ -797,8 +797,6 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
                                                configSettings:settings
                                              configExperiment:nil];
   }
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   // Make the fetch calls for all instances.
   NSMutableArray<XCTestExpectation *> *expectations =
       [[NSMutableArray alloc] initWithCapacity:RCNTestRCNumTotalInstances];
@@ -813,9 +811,11 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
     FIRRemoteConfigFetchCompletion fetchCompletion = ^void(FIRRemoteConfigFetchStatus status,
                                                            NSError *error) {
       XCTAssertEqual(self->_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusSuccess);
-      XCTAssertFalse([self->_configInstances[i] activateFetched]);
-      XCTAssertNil(error);
-      [expectations[i] fulfill];
+      [self->_configInstances[i] activateWithCompletion:^(BOOL changed, NSError *_Nullable error) {
+        XCTAssertFalse(changed);
+        XCTAssertNil(error);
+        [expectations[i] fulfill];
+      }];
     };
     [_configInstances[i] fetchWithExpirationDuration:43200 completionHandler:fetchCompletion];
   }
@@ -837,39 +837,38 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
                                                            NSError *error) {
       XCTAssertEqual(status, FIRRemoteConfigFetchStatusSuccess);
       XCTAssertNil(error);
-      XCTAssertTrue([self->_configInstances[i] activateFetched]);
+      [self->_configInstances[i] activateWithCompletion:^(BOOL changed, NSError *_Nullable error) {
+        XCTAssertTrue(changed);
+        NSString *key1 = [NSString stringWithFormat:@"key1-%d", i];
+        NSString *key2 = [NSString stringWithFormat:@"key2-%d", i];
+        NSString *key3 = [NSString stringWithFormat:@"key3-%d", i];
+        NSString *key7 = [NSString stringWithFormat:@"key7-%d", i];
+        NSString *value1 = [NSString stringWithFormat:@"value1-%d", i];
+        NSString *value2 = [NSString stringWithFormat:@"value2-%d", i];
+        NSString *value3 = [NSString stringWithFormat:@"value3-%d", i];
+        NSString *value7 = [NSString stringWithFormat:@"value7-%d", i];
+        XCTAssertEqualObjects(self->_configInstances[i][key1].stringValue, value1);
+        XCTAssertEqualObjects(self->_configInstances[i][key2].stringValue, value2);
+        OCMVerify([self->_configInstances[i] objectForKeyedSubscript:key1]);
+        XCTAssertEqualObjects([self->_configInstances[i] configValueForKey:key3].stringValue,
+                              value3);
+        if (i == RCNTestRCInstanceDefault) {
+          XCTAssertEqualObjects([self->_configInstances[i] configValueForKey:key7].stringValue,
+                                value7);
+        }
 
-      NSString *key1 = [NSString stringWithFormat:@"key1-%d", i];
-      NSString *key2 = [NSString stringWithFormat:@"key2-%d", i];
-      NSString *key3 = [NSString stringWithFormat:@"key3-%d", i];
-      NSString *key7 = [NSString stringWithFormat:@"key7-%d", i];
-      NSString *value1 = [NSString stringWithFormat:@"value1-%d", i];
-      NSString *value2 = [NSString stringWithFormat:@"value2-%d", i];
-      NSString *value3 = [NSString stringWithFormat:@"value3-%d", i];
-      NSString *value7 = [NSString stringWithFormat:@"value7-%d", i];
-      XCTAssertEqualObjects(self->_configInstances[i][key1].stringValue, value1);
-      XCTAssertEqualObjects(self->_configInstances[i][key2].stringValue, value2);
-      OCMVerify([self->_configInstances[i] objectForKeyedSubscript:key1]);
-      XCTAssertEqualObjects([self->_configInstances[i] configValueForKey:key3].stringValue, value3);
-      if (i == RCNTestRCInstanceDefault) {
-        XCTAssertEqualObjects(
-            [self->_configInstances[i] configValueForKey:key7
-                                               namespace:FIRNamespaceGoogleMobilePlatform]
-                .stringValue,
-            value7);
-      }
+        XCTAssertEqualObjects([self->_configInstances[i] configValueForKey:key7].stringValue,
+                              value7);
+        XCTAssertNotNil([self->_configInstances[i] configValueForKey:nil]);
+        XCTAssertEqual([self->_configInstances[i] configValueForKey:nil].source,
+                       FIRRemoteConfigSourceStatic);
+        XCTAssertEqual([self->_configInstances[i] configValueForKey:nil].source,
+                       FIRRemoteConfigSourceStatic);
+        XCTAssertEqual([self->_configInstances[i] configValueForKey:nil source:-1].source,
+                       FIRRemoteConfigSourceStatic);
 
-      XCTAssertEqualObjects([self->_configInstances[i] configValueForKey:key7].stringValue, value7);
-      XCTAssertNotNil([self->_configInstances[i] configValueForKey:nil]);
-      XCTAssertEqual([self->_configInstances[i] configValueForKey:nil].source,
-                     FIRRemoteConfigSourceStatic);
-      XCTAssertEqual([self->_configInstances[i] configValueForKey:nil namespace:nil].source,
-                     FIRRemoteConfigSourceStatic);
-      XCTAssertEqual(
-          [self->_configInstances[i] configValueForKey:nil namespace:nil source:-1].source,
-          FIRRemoteConfigSourceStatic);
-
-      [expectations[i] fulfill];
+        [expectations[i] fulfill];
+      }];
     };
     [_configInstances[i] fetchWithExpirationDuration:43200 completionHandler:fetchCompletion];
   }
@@ -901,25 +900,21 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
       XCTAssertNil(error);
       XCTAssertEqualObjects(self->_configInstances[i][key1].stringValue, @"default key1");
       XCTAssertEqual(self->_configInstances[i][key1].source, FIRRemoteConfigSourceDefault);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      XCTAssertTrue([self->_configInstances[i] activateFetched]);
-#pragma clang diagnostic pop
-      XCTAssertEqualObjects(self->_configInstances[i][key1].stringValue, value1);
-      XCTAssertEqual(self->_configInstances[i][key1].source, FIRRemoteConfigSourceRemote);
-      XCTAssertEqualObjects([self->_configInstances[i] defaultValueForKey:key1].stringValue,
-                            @"default key1");
-      XCTAssertEqualObjects(self->_configInstances[i][key2].stringValue, value2);
-      XCTAssertEqualObjects(self->_configInstances[i][key0].stringValue, @"value0-0");
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      XCTAssertNil([self->_configInstances[i] defaultValueForKey:nil namespace:nil]);
-#pragma clang diagnostic pop
-      OCMVerify([self->_configInstances[i] objectForKeyedSubscript:key1]);
-      XCTAssertEqual(status, FIRRemoteConfigFetchStatusSuccess,
-                     @"Callback of first successful config "
-                     @"fetch. Status must equal to FIRRemoteConfigFetchStatusSuccess.");
-      [fetchConfigsExpectation[i] fulfill];
+      [self->_configInstances[i] activateWithCompletion:^(BOOL changed, NSError *_Nullable error) {
+        XCTAssertTrue(changed);
+        XCTAssertEqualObjects(self->_configInstances[i][key1].stringValue, value1);
+        XCTAssertEqual(self->_configInstances[i][key1].source, FIRRemoteConfigSourceRemote);
+        XCTAssertEqualObjects([self->_configInstances[i] defaultValueForKey:key1].stringValue,
+                              @"default key1");
+        XCTAssertEqualObjects(self->_configInstances[i][key2].stringValue, value2);
+        XCTAssertEqualObjects(self->_configInstances[i][key0].stringValue, @"value0-0");
+        XCTAssertNil([self->_configInstances[i] defaultValueForKey:nil]);
+        OCMVerify([self->_configInstances[i] objectForKeyedSubscript:key1]);
+        XCTAssertEqual(status, FIRRemoteConfigFetchStatusSuccess,
+                       @"Callback of first successful config "
+                       @"fetch. Status must equal to FIRRemoteConfigFetchStatusSuccess.");
+        [fetchConfigsExpectation[i] fulfill];
+      }];
     };
     [_configInstances[i] fetchWithExpirationDuration:43200 completionHandler:fetchCompletion];
   }
@@ -951,10 +946,6 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
       key5 : @(defaultValue5),
     }];
     [_configInstances[i] setDefaults:defaults];
-    if (i == RCNTestRCInstanceSecondNamespace) {
-      [defaults setObject:@"2860" forKey:@"experience"];
-      [_configInstances[i] setDefaults:defaults namespace:RCNTestsPerfNamespace];
-    }
     // Remove objects right away to make sure dispatch_async gets the copy.
     [defaults removeAllObjects];
 
@@ -974,13 +965,6 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
 
     XCTAssertEqual(config[key5].boolValue, defaultValue5, @"Should support bool format");
 
-    if (i == RCNTestRCInstanceSecondNamespace) {
-      XCTAssertEqualObjects(
-          [_configInstances[i] configValueForKey:@"experience" namespace:RCNTestsPerfNamespace]
-              .stringValue,
-          @"2860", @"Only default config has the key, must equal to default config value.");
-    }
-
     // Reset default sets
     [_configInstances[i] setDefaults:nil];
     XCTAssertEqual([_configInstances[i] allKeysFromSource:FIRRemoteConfigSourceDefault].count, 0);
@@ -996,16 +980,13 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
             [NSString stringWithFormat:@"Set defaults no callback expectation - instance %d", i]];
     // Should work when passing nil.
     [_configInstances[i] setDefaults:nil];
-    [_configInstances[i] setDefaults:nil namespace:nil];
+    [_configInstances[i] setDefaults:nil];
 
     dispatch_after(
         dispatch_time(DISPATCH_TIME_NOW, (int64_t)(_checkCompletionTimeout * NSEC_PER_SEC)),
         dispatch_get_main_queue(), ^{
           XCTAssertEqual(
-              [self->_configInstances[i] allKeysFromSource:FIRRemoteConfigSourceDefault
-                                                 namespace:FIRNamespaceGoogleMobilePlatform]
-                  .count,
-              0);
+              [self->_configInstances[i] allKeysFromSource:FIRRemoteConfigSourceDefault].count, 0);
           [expectations[i] fulfill];
         });
   }
@@ -1035,17 +1016,20 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
                                                            NSError *error) {
       XCTAssertEqual(self->_configInstances[i].lastFetchStatus, FIRRemoteConfigFetchStatusSuccess);
       XCTAssertNil(error);
-      XCTAssertTrue([self->_configInstances[i] activateFetched]);
-      XCTAssertEqualObjects(self->_configInstances[i][key1].stringValue, value1);
-      XCTAssertEqual(self->_configInstances[i][key1].source, FIRRemoteConfigSourceRemote);
-      XCTAssertEqualObjects([self->_configInstances[i] defaultValueForKey:key1].stringValue,
-                            @"default key1");
-      OCMVerify([self->_configInstances[i] objectForKeyedSubscript:key1]);
 
-      XCTAssertEqual(status, FIRRemoteConfigFetchStatusSuccess,
-                     @"Callback of first successful config "
-                     @"fetch. Status must equal to FIRRemoteConfigFetchStatusSuccess.");
-      [fetchConfigsExpectation[i] fulfill];
+      [self->_configInstances[i] activateWithCompletion:^(BOOL changed, NSError *_Nullable error) {
+        XCTAssertTrue(changed);
+        XCTAssertEqualObjects(self->_configInstances[i][key1].stringValue, value1);
+        XCTAssertEqual(self->_configInstances[i][key1].source, FIRRemoteConfigSourceRemote);
+        XCTAssertEqualObjects([self->_configInstances[i] defaultValueForKey:key1].stringValue,
+                              @"default key1");
+        OCMVerify([self->_configInstances[i] objectForKeyedSubscript:key1]);
+
+        XCTAssertEqual(status, FIRRemoteConfigFetchStatusSuccess,
+                       @"Callback of first successful config "
+                       @"fetch. Status must equal to FIRRemoteConfigFetchStatusSuccess.");
+        [fetchConfigsExpectation[i] fulfill];
+      }];
     };
 
     [_configInstances[i] fetchWithExpirationDuration:43200 completionHandler:fetchCompletion];
@@ -1075,40 +1059,39 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
       XCTAssertNil(error);
       XCTAssertEqualObjects(self->_configInstances[i][key1].stringValue, @"default value1");
       XCTAssertEqual(self->_configInstances[i][key1].source, FIRRemoteConfigSourceDefault);
-      XCTAssertTrue([self->_configInstances[i] activateFetched]);
-      XCTAssertEqualObjects(self->_configInstances[i][key1].stringValue, value1);
-      XCTAssertEqual(self->_configInstances[i][key1].source, FIRRemoteConfigSourceRemote);
-      FIRRemoteConfigValue *value;
-      if (i == RCNTestRCInstanceDefault) {
-        value = [self->_configInstances[i] configValueForKey:key1
-                                                   namespace:FIRNamespaceGoogleMobilePlatform
-                                                      source:FIRRemoteConfigSourceRemote];
-        XCTAssertEqualObjects(value.stringValue, value1);
-        value = [self->_configInstances[i] configValueForKey:key1
-                                                   namespace:FIRNamespaceGoogleMobilePlatform
-                                                      source:FIRRemoteConfigSourceDefault];
-        XCTAssertEqualObjects(value.stringValue, @"default value1");
-        value = [self->_configInstances[i] configValueForKey:key1
-                                                   namespace:FIRNamespaceGoogleMobilePlatform
-                                                      source:FIRRemoteConfigSourceStatic];
-      } else {
-        value = [self->_configInstances[i] configValueForKey:key1
-                                                      source:FIRRemoteConfigSourceRemote];
-        XCTAssertEqualObjects(value.stringValue, value1);
-        value = [self->_configInstances[i] configValueForKey:key1
-                                                      source:FIRRemoteConfigSourceDefault];
-        XCTAssertEqualObjects(value.stringValue, @"default value1");
-        value = [self->_configInstances[i] configValueForKey:key1
-                                                      source:FIRRemoteConfigSourceStatic];
-      }
-      XCTAssertEqualObjects(value.stringValue, @"");
-      XCTAssertEqualObjects(value.numberValue, @(0));
-      XCTAssertEqual(value.boolValue, NO);
+      [self->_configInstances[i] activateWithCompletion:^(BOOL changed, NSError *_Nullable error) {
+        XCTAssertTrue(changed);
+        XCTAssertEqualObjects(self->_configInstances[i][key1].stringValue, value1);
+        XCTAssertEqual(self->_configInstances[i][key1].source, FIRRemoteConfigSourceRemote);
+        FIRRemoteConfigValue *value;
+        if (i == RCNTestRCInstanceDefault) {
+          value = [self->_configInstances[i] configValueForKey:key1
+                                                        source:FIRRemoteConfigSourceRemote];
+          XCTAssertEqualObjects(value.stringValue, value1);
+          value = [self->_configInstances[i] configValueForKey:key1
+                                                        source:FIRRemoteConfigSourceDefault];
+          XCTAssertEqualObjects(value.stringValue, @"default value1");
+          value = [self->_configInstances[i] configValueForKey:key1
+                                                        source:FIRRemoteConfigSourceStatic];
+        } else {
+          value = [self->_configInstances[i] configValueForKey:key1
+                                                        source:FIRRemoteConfigSourceRemote];
+          XCTAssertEqualObjects(value.stringValue, value1);
+          value = [self->_configInstances[i] configValueForKey:key1
+                                                        source:FIRRemoteConfigSourceDefault];
+          XCTAssertEqualObjects(value.stringValue, @"default value1");
+          value = [self->_configInstances[i] configValueForKey:key1
+                                                        source:FIRRemoteConfigSourceStatic];
+        }
+        XCTAssertEqualObjects(value.stringValue, @"");
+        XCTAssertEqualObjects(value.numberValue, @(0));
+        XCTAssertEqual(value.boolValue, NO);
 
-      XCTAssertEqual(status, FIRRemoteConfigFetchStatusSuccess,
-                     @"Callback of first successful config "
-                     @"fetch. Status must equal to FIRRemoteConfigFetchStatusSuccess.");
-      [fetchConfigsExpectation[i] fulfill];
+        XCTAssertEqual(status, FIRRemoteConfigFetchStatusSuccess,
+                       @"Callback of first successful config "
+                       @"fetch. Status must equal to FIRRemoteConfigFetchStatusSuccess.");
+        [fetchConfigsExpectation[i] fulfill];
+      }];
     };
     [_configInstances[i] fetchWithExpirationDuration:43200 completionHandler:fetchCompletion];
   }
@@ -1121,11 +1104,11 @@ typedef NS_ENUM(NSInteger, RCNTestRCInstance) {
     XCTAssertNotNil(value);
     XCTAssertEqual(value.source, FIRRemoteConfigSourceStatic);
 
-    value = [_configInstances[i] configValueForKey:nil namespace:nil];
+    value = [_configInstances[i] configValueForKey:nil];
     XCTAssertNotNil(value);
     XCTAssertEqual(value.source, FIRRemoteConfigSourceStatic);
 
-    value = [_configInstances[i] configValueForKey:nil namespace:nil source:5];
+    value = [_configInstances[i] configValueForKey:nil source:5];
     XCTAssertNotNil(value);
     XCTAssertEqual(value.source, FIRRemoteConfigSourceStatic);
   }
@@ -1175,77 +1158,27 @@ static NSString *UTCToLocal(NSString *utcTime) {
                           UTCToLocal(@"2016-02-28 18:33:31"));
     [_configInstances[i] setDefaultsFromPlistFileName:@"non-existed_file"];
     XCTAssertEqualObjects(_configInstances[i][@"dataValue"].stringValue, @"2.4");
-    [_configInstances[i] setDefaultsFromPlistFileName:nil namespace:nil];
+    [_configInstances[i] setDefaultsFromPlistFileName:nil];
     XCTAssertEqualObjects(_configInstances[i][@"New item"].numberValue, @(2.4));
-    [_configInstances[i] setDefaultsFromPlistFileName:@"" namespace:@""];
+    [_configInstances[i] setDefaultsFromPlistFileName:@""];
     XCTAssertEqualObjects(_configInstances[i][@"Languages"].stringValue, @"English");
   }
 }
 
 - (void)testSetDefaultsAndNamespaceFromPlist {
   for (int i = 0; i < RCNTestRCNumTotalInstances; i++) {
-    if (i == RCNTestRCInstanceDefault) {
-#if SWIFT_PACKAGE
-      [_configInstances[i] setDefaults:[self getSPMDefaults] namespace:RCNTestsPerfNamespace];
-#else
-      [_configInstances[i] setDefaultsFromPlistFileName:@"Defaults-testInfo"
-                                              namespace:RCNTestsPerfNamespace];
-#endif
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"lastCheckTime"
-                                                         namespace:RCNTestsPerfNamespace]
-                                .stringValue,
-                            UTCToLocal(@"2016-02-28 18:33:31"));
-      XCTAssertEqual([_configInstances[i] configValueForKey:@"isPaidUser"
-                                                  namespace:RCNTestsPerfNamespace]
-                         .boolValue,
-                     YES);
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"dataValue"
-                                                         namespace:RCNTestsPerfNamespace]
-                                .stringValue,
-                            @"2.4");
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"New item"
-                                                         namespace:RCNTestsPerfNamespace]
-                                .numberValue,
-                            @(2.4));
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"Languages"
-                                                         namespace:RCNTestsPerfNamespace]
-                                .stringValue,
-                            @"English");
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"FileInfo"
-                                                         namespace:RCNTestsPerfNamespace]
-                                .stringValue,
-                            @"To setup default config.");
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"format"
-                                                         namespace:RCNTestsPerfNamespace]
-                                .stringValue,
-                            @"key to value.");
-    } else {
-      [_configInstances[i] setDefaultsFromPlistFileName:@"Defaults-testInfo"];
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"lastCheckTime"].stringValue,
-                            UTCToLocal(@"2016-02-28 18:33:31"));
-      XCTAssertEqual([_configInstances[i] configValueForKey:@"isPaidUser"].boolValue, YES);
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"dataValue"].stringValue,
-                            @"2.4");
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"New item"].numberValue,
-                            @(2.4));
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"Languages"].stringValue,
-                            @"English");
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"FileInfo"].stringValue,
-                            @"To setup default config.");
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"format"].stringValue,
-                            @"key to value.");
-    }
-  }
-}
-
-- (void)testSetDeveloperMode {
-  for (int i = 0; i < RCNTestRCNumTotalInstances; i++) {
-    XCTAssertFalse(_configInstances[i].configSettings.isDeveloperModeEnabled);
-    FIRRemoteConfigSettings *settings =
-        [[FIRRemoteConfigSettings alloc] initWithDeveloperModeEnabled:YES];
-
-    _configInstances[i].configSettings = settings;
-    XCTAssertTrue(_configInstances[i].configSettings.isDeveloperModeEnabled);
+    [_configInstances[i] setDefaultsFromPlistFileName:@"Defaults-testInfo"];
+    XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"lastCheckTime"].stringValue,
+                          UTCToLocal(@"2016-02-28 18:33:31"));
+    XCTAssertEqual([_configInstances[i] configValueForKey:@"isPaidUser"].boolValue, YES);
+    XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"dataValue"].stringValue, @"2.4");
+    XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"New item"].numberValue, @(2.4));
+    XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"Languages"].stringValue,
+                          @"English");
+    XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"FileInfo"].stringValue,
+                          @"To setup default config.");
+    XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"format"].stringValue,
+                          @"key to value.");
   }
 }
 
@@ -1265,53 +1198,17 @@ static NSString *UTCToLocal(NSString *utcTime) {
                                                            NSError *error) {
       XCTAssertEqual(status, FIRRemoteConfigFetchStatusSuccess);
       XCTAssertNil(error);
-      XCTAssertTrue([self->_configInstances[i] activateFetched]);
-
-      if (i == RCNTestRCInstanceDefault) {
-        XCTAssertEqual(
-            [self->_configInstances[i] allKeysFromSource:FIRRemoteConfigSourceRemote
-                                               namespace:FIRNamespaceGoogleMobilePlatform]
-                .count,
-            100);
-        XCTAssertEqual(
-            [self->_configInstances[i] allKeysFromSource:FIRRemoteConfigSourceDefault
-                                               namespace:FIRNamespaceGoogleMobilePlatform]
-                .count,
-            2);
-        XCTAssertEqual(
-            [self->_configInstances[i] allKeysFromSource:FIRRemoteConfigSourceStatic
-                                               namespace:FIRNamespaceGoogleMobilePlatform]
-                .count,
-            0);
-      } else {
+      [self->_configInstances[i] activateWithCompletion:^(BOOL changed, NSError *_Nullable error) {
+        XCTAssertTrue(changed);
         XCTAssertEqual(
             [self->_configInstances[i] allKeysFromSource:FIRRemoteConfigSourceRemote].count, 100);
         XCTAssertEqual(
             [self->_configInstances[i] allKeysFromSource:FIRRemoteConfigSourceDefault].count, 2);
         XCTAssertEqual(
             [self->_configInstances[i] allKeysFromSource:FIRRemoteConfigSourceStatic].count, 0);
-      }
 
-      XCTAssertNotNil([self->_configInstances[i] allKeysFromSource:FIRRemoteConfigSourceRemote
-                                                         namespace:@"invalid namespace"]);
-      XCTAssertEqual([self->_configInstances[i] allKeysFromSource:FIRRemoteConfigSourceRemote
-                                                        namespace:@"invalid namespace"]
-                         .count,
-                     0);
-      XCTAssertNotNil([self->_configInstances[i] allKeysFromSource:FIRRemoteConfigSourceRemote
-                                                         namespace:nil]);
-      XCTAssertEqual([self->_configInstances[i] allKeysFromSource:FIRRemoteConfigSourceRemote
-                                                        namespace:nil]
-                         .count,
-                     0);
-      XCTAssertNotNil([self->_configInstances[i] allKeysFromSource:FIRRemoteConfigSourceDefault
-                                                         namespace:nil]);
-      XCTAssertEqual([self->_configInstances[i] allKeysFromSource:FIRRemoteConfigSourceDefault
-                                                        namespace:nil]
-                         .count,
-                     0);
-
-      [fetchConfigsExpectation[i] fulfill];
+        [fetchConfigsExpectation[i] fulfill];
+      }];
     };
     [_configInstances[i] fetchWithExpirationDuration:43200 completionHandler:fetchCompletion];
   }
@@ -1333,38 +1230,18 @@ static NSString *UTCToLocal(NSString *utcTime) {
       XCTAssertEqual(status, FIRRemoteConfigFetchStatusSuccess);
       XCTAssertNil(error);
       NSLog(@"Testing _configInstances %d", i);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      XCTAssertTrue([self->_configInstances[i] activateFetched]);
-
-      // Test keysWithPrefix:namespace: method.
-      if (i == RCNTestRCInstanceDefault) {
-        XCTAssertEqual([self->_configInstances[i] keysWithPrefix:@"key"
-                                                       namespace:FIRNamespaceGoogleMobilePlatform]
-                           .count,
-                       100);
-      } else {
+      [self->_configInstances[i] activateWithCompletion:^(BOOL changed, NSError *_Nullable error) {
+        XCTAssertTrue(changed);
+        // Test keysWithPrefix: method.
+        XCTAssertEqual([self->_configInstances[i] keysWithPrefix:@"key1"].count, 12);
         XCTAssertEqual([self->_configInstances[i] keysWithPrefix:@"key"].count, 100);
-      }
 
-      XCTAssertEqual(
-          [self->_configInstances[i] keysWithPrefix:@"pl" namespace:@"invalid namespace"].count, 0);
-      XCTAssertEqual([self->_configInstances[i] keysWithPrefix:@"pl" namespace:nil].count, 0);
-      XCTAssertEqual([self->_configInstances[i] keysWithPrefix:@"pl" namespace:@""].count, 0);
+        XCTAssertEqual([self->_configInstances[i] keysWithPrefix:@"invalid key"].count, 0);
+        XCTAssertEqual([self->_configInstances[i] keysWithPrefix:nil].count, 100);
+        XCTAssertEqual([self->_configInstances[i] keysWithPrefix:@""].count, 100);
 
-      XCTAssertNotNil([self->_configInstances[i] keysWithPrefix:nil namespace:nil]);
-      XCTAssertEqual([self->_configInstances[i] keysWithPrefix:nil namespace:nil].count, 0);
-#pragma clang diagnostic pop
-
-      // Test keysWithPrefix: method.
-      XCTAssertEqual([self->_configInstances[i] keysWithPrefix:@"key1"].count, 12);
-      XCTAssertEqual([self->_configInstances[i] keysWithPrefix:@"key"].count, 100);
-
-      XCTAssertEqual([self->_configInstances[i] keysWithPrefix:@"invalid key"].count, 0);
-      XCTAssertEqual([self->_configInstances[i] keysWithPrefix:nil].count, 100);
-      XCTAssertEqual([self->_configInstances[i] keysWithPrefix:@""].count, 100);
-
-      [fetchConfigsExpectation[i] fulfill];
+        [fetchConfigsExpectation[i] fulfill];
+      }];
     };
     [_configInstances[i] fetchWithExpirationDuration:43200 completionHandler:fetchCompletion];
   }
@@ -1372,22 +1249,6 @@ static NSString *UTCToLocal(NSString *utcTime) {
                                handler:^(NSError *error) {
                                  XCTAssertNil(error);
                                }];
-}
-
-- (void)testSetDeveloperModeConfigSetting {
-  for (int i = 0; i < RCNTestRCNumTotalInstances; i++) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    FIRRemoteConfigSettings *settings =
-        [[FIRRemoteConfigSettings alloc] initWithDeveloperModeEnabled:YES];
-    [_configInstances[i] setConfigSettings:settings];
-    XCTAssertTrue([_configInstances[i] configSettings].isDeveloperModeEnabled);
-
-    settings = [[FIRRemoteConfigSettings alloc] initWithDeveloperModeEnabled:NO];
-    [_configInstances[i] setConfigSettings:settings];
-    XCTAssertFalse([_configInstances[i] configSettings].isDeveloperModeEnabled);
-#pragma clang diagnostic pop
-  }
 }
 
 /// Test the minimum fetch interval is applied and read back correctly.

--- a/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
+++ b/FirebaseRemoteConfig/Tests/Unit/RCNRemoteConfigTest.m
@@ -1175,46 +1175,6 @@ static NSString *UTCToLocal(NSString *utcTime) {
   }
 }
 
-- (void)testSetDefaultsAndNamespaceFromPlist {
-  for (int i = 0; i < RCNTestRCNumTotalInstances; i++) {
-    if (i == RCNTestRCInstanceDefault) {
-#if SWIFT_PACKAGE
-      [_configInstances[i] setDefaults:[self getSPMDefaults] namespace:RCNTestsPerfNamespace];
-#else
-      [_configInstances[i] setDefaultsFromPlistFileName:@"Defaults-testInfo"];
-#endif
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"lastCheckTime"].stringValue,
-                            UTCToLocal(@"2016-02-28 18:33:31"));
-      XCTAssertEqual([_configInstances[i] configValueForKey:@"isPaidUser"].boolValue, YES);
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"dataValue"].stringValue,
-                            @"2.4");
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"New item"].numberValue,
-                            @(2.4));
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"Languages"].stringValue,
-                            @"English");
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"FileInfo"].stringValue,
-                            @"To setup default config.");
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"format"].stringValue,
-                            @"key to value.");
-    } else {
-      [_configInstances[i] setDefaultsFromPlistFileName:@"Defaults-testInfo"];
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"lastCheckTime"].stringValue,
-                            UTCToLocal(@"2016-02-28 18:33:31"));
-      XCTAssertEqual([_configInstances[i] configValueForKey:@"isPaidUser"].boolValue, YES);
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"dataValue"].stringValue,
-                            @"2.4");
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"New item"].numberValue,
-                            @(2.4));
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"Languages"].stringValue,
-                            @"English");
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"FileInfo"].stringValue,
-                            @"To setup default config.");
-      XCTAssertEqualObjects([_configInstances[i] configValueForKey:@"format"].stringValue,
-                            @"key to value.");
-    }
-  }
-}
-
 - (void)testAllKeysFromSource {
   NSMutableArray<XCTestExpectation *> *fetchConfigsExpectation =
       [[NSMutableArray alloc] initWithCapacity:RCNTestRCNumTotalInstances];


### PR DESCRIPTION
Separating this from the actual API removal PR for #6546
- Remove tests for deprecated methods
- Update other tests to no longer call deprecated methods
