### PR TITLE
Remove support for setting timestampsInSnapshotsEnabled

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 # v7.0.0
 - [changed] **Breaking change:** Removed the `areTimestampsInSnapshotsEnabled`
-  setting. Timestamp fields that read from a `FIRDocumentSnapshot` are now
-  always returns `FIRTimestamp` objects. Use `FIRTimestamp.dateValue` to
-  convert to `NSDate` if required.
+  setting. Timestamp fields that read from a `FIRDocumentSnapshot` now always
+  return `FIRTimestamp` objects. Use `FIRTimestamp.dateValue` to convert to
+  `NSDate` if required.
 
 # v1.19.0
 - [changed] Internal improvements for future C++ and Unity support. Includes a

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+# v7.0.0
+- [changed] **Breaking change:** Removed the `areTimestampsInSnapshotsEnabled`
+  setting. Timestamp fields that read from a `FIRDocumentSnapshot` are now
+  always returns `FIRTimestamp` objects. Use `FIRTimestamp.dateValue` to
+  convert to `NSDate` if required.
+
 # v1.19.0
 - [changed] Internal improvements for future C++ and Unity support. Includes a
   breaking change for the Firestore C++ Alpha SDK, but does not affect

--- a/Firestore/Example/Tests/Integration/API/FIRFieldsTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRFieldsTests.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@
 
 #import <XCTest/XCTest.h>
 
-#import "Firestore/core/src/util/warnings.h"
-
 #import "Firestore/Example/Tests/Util/FSTIntegrationTestCase.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface FIRFieldsTests : FSTIntegrationTestCase
 @end
@@ -255,52 +255,7 @@ NSDictionary<NSString *, id> *testDataWithTimestamps(FIRTimestamp *timestamp) {
   XCTAssertEqualObjects(truncatedTimestamp, timestampFromData);
   XCTAssertEqualObjects(timestampFromSnapshot, timestampFromData);
 }
-@end
-
-@interface FIRTimestampsInSnapshotsLegacyBehaviorTests : FSTIntegrationTestCase
-@end
-
-@implementation FIRTimestampsInSnapshotsLegacyBehaviorTests
-
-- (void)setUp {
-  [super setUp];
-  // Settings can only be redefined before client is initialized, so this has to happen in setUp.
-  FIRFirestoreSettings *settings = self.db.settings;
-  SUPPRESS_DEPRECATED_DECLARATIONS_BEGIN()
-  settings.timestampsInSnapshotsEnabled = NO;
-  SUPPRESS_END()
-  self.db.settings = settings;
-}
-
-- (void)testLegacyBehaviorForTimestampFields {
-  NSDate *originalDate = [NSDate date];
-  FIRDocumentReference *doc = [self documentRef];
-  [self writeDocumentRef:doc
-                    data:testDataWithTimestamps([FIRTimestamp timestampWithDate:originalDate])];
-  FIRDocumentSnapshot *snapshot = [self readDocumentForRef:doc];
-  NSDictionary<NSString *, id> *data = [snapshot data];
-  double microsecond = 0.000001;
-
-  NSDate *timestampFromSnapshot = snapshot[@"timestamp"];
-  NSDate *timestampFromData = data[@"timestamp"];
-  XCTAssertEqualObjects(timestampFromSnapshot, timestampFromData);
-  XCTAssertEqualWithAccuracy([timestampFromSnapshot timeIntervalSince1970],
-                             [originalDate timeIntervalSince1970], microsecond);
-
-  timestampFromSnapshot = snapshot[@"nested.timestamp2"];
-  timestampFromData = data[@"nested"][@"timestamp2"];
-  XCTAssertEqualObjects(timestampFromSnapshot, timestampFromData);
-  XCTAssertEqualWithAccuracy([timestampFromSnapshot timeIntervalSince1970],
-                             [originalDate timeIntervalSince1970], microsecond);
-}
-
-- (void)testLegacyBehaviorForServerTimestampFields {
-  FIRDocumentReference *doc = [self documentRef];
-  [self writeDocumentRef:doc data:@{@"when" : [FIRFieldValue fieldValueForServerTimestamp]}];
-
-  FIRDocumentSnapshot *snapshot = [self readDocumentForRef:doc];
-  XCTAssertTrue([snapshot[@"when"] isKindOfClass:[NSDate class]]);
-  XCTAssertTrue([snapshot.data[@"when"] isKindOfClass:[NSDate class]]);
-}
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Firestore/Example/Tests/Integration/API/FIRFieldsTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRFieldsTests.mm
@@ -233,7 +233,7 @@ NSDictionary<NSString *, id> *testDataWithTimestamps(FIRTimestamp *timestamp) {
   return [self readDocumentForRef:doc];
 }
 
-- (void)testTimestampsInSnapshots {
+- (void)testTimestampsAreTruncated {
   FIRTimestamp *originalTimestamp = [FIRTimestamp timestampWithSeconds:100 nanoseconds:123456789];
   FIRDocumentReference *doc = [self documentRef];
   [self writeDocumentRef:doc data:testDataWithTimestamps(originalTimestamp)];

--- a/Firestore/Source/API/FIRDocumentSnapshot.mm
+++ b/Firestore/Source/API/FIRDocumentSnapshot.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -204,10 +204,7 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
 
 - (FieldValueOptions)optionsForServerTimestampBehavior:
     (FIRServerTimestampBehavior)serverTimestampBehavior {
-  SUPPRESS_DEPRECATED_DECLARATIONS_BEGIN()
-  return FieldValueOptions(InternalServerTimestampBehavior(serverTimestampBehavior),
-                           _snapshot.firestore()->settings().timestamps_in_snapshots_enabled());
-  SUPPRESS_END()
+  return FieldValueOptions(InternalServerTimestampBehavior(serverTimestampBehavior));
 }
 
 - (id)convertedValue:(FieldValue)value options:(const FieldValueOptions &)options {
@@ -242,12 +239,7 @@ ServerTimestampBehavior InternalServerTimestampBehavior(FIRServerTimestampBehavi
 }
 
 - (id)convertedTimestamp:(const FieldValue &)value options:(const FieldValueOptions &)options {
-  FIRTimestamp *wrapped = MakeFIRTimestamp(value.timestamp_value());
-  if (options.timestamps_in_snapshots_enabled()) {
-    return wrapped;
-  } else {
-    return [wrapped dateValue];
-  }
+  return MakeFIRTimestamp(value.timestamp_value());
 }
 
 - (id)convertedServerTimestamp:(const FieldValue &)value

--- a/Firestore/Source/API/FIRFirestoreSettings.mm
+++ b/Firestore/Source/API/FIRFirestoreSettings.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 #include "Firestore/core/src/api/settings.h"
 #include "Firestore/core/src/util/exception.h"
 #include "Firestore/core/src/util/string_apple.h"
-#include "Firestore/core/src/util/warnings.h"
 #include "absl/base/attributes.h"
 #include "absl/memory/memory.h"
 
@@ -32,7 +31,7 @@ using util::ThrowInvalidArgument;
 
 // Public constant
 ABSL_CONST_INIT extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited =
-    api::Settings::CacheSizeUnlimited;
+    Settings::CacheSizeUnlimited;
 
 @implementation FIRFirestoreSettings
 
@@ -42,7 +41,6 @@ ABSL_CONST_INIT extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited =
     _sslEnabled = Settings::DefaultSslEnabled;
     _dispatchQueue = dispatch_get_main_queue();
     _persistenceEnabled = Settings::DefaultPersistenceEnabled;
-    _timestampsInSnapshotsEnabled = Settings::DefaultTimestampsInSnapshotsEnabled;
     _cacheSizeBytes = Settings::DefaultCacheSizeBytes;
   }
   return self;
@@ -56,14 +54,11 @@ ABSL_CONST_INIT extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited =
   }
 
   FIRFirestoreSettings *otherSettings = (FIRFirestoreSettings *)other;
-  SUPPRESS_DEPRECATED_DECLARATIONS_BEGIN()
   return [self.host isEqual:otherSettings.host] &&
          self.isSSLEnabled == otherSettings.isSSLEnabled &&
          self.dispatchQueue == otherSettings.dispatchQueue &&
          self.isPersistenceEnabled == otherSettings.isPersistenceEnabled &&
-         self.timestampsInSnapshotsEnabled == otherSettings.timestampsInSnapshotsEnabled &&
          self.cacheSizeBytes == otherSettings.cacheSizeBytes;
-  SUPPRESS_END()
 }
 
 - (NSUInteger)hash {
@@ -71,9 +66,6 @@ ABSL_CONST_INIT extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited =
   result = 31 * result + (self.isSSLEnabled ? 1231 : 1237);
   // Ignore the dispatchQueue to avoid having to deal with sizeof(dispatch_queue_t).
   result = 31 * result + (self.isPersistenceEnabled ? 1231 : 1237);
-  SUPPRESS_DEPRECATED_DECLARATIONS_BEGIN()
-  result = 31 * result + (self.timestampsInSnapshotsEnabled ? 1231 : 1237);
-  SUPPRESS_END()
   result = 31 * result + (NSUInteger)self.cacheSizeBytes;
   return result;
 }
@@ -84,9 +76,6 @@ ABSL_CONST_INIT extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited =
   copy.sslEnabled = _sslEnabled;
   copy.dispatchQueue = _dispatchQueue;
   copy.persistenceEnabled = _persistenceEnabled;
-  SUPPRESS_DEPRECATED_DECLARATIONS_BEGIN()
-  copy.timestampsInSnapshotsEnabled = _timestampsInSnapshotsEnabled;
-  SUPPRESS_END()
   copy.cacheSizeBytes = _cacheSizeBytes;
   return copy;
 }
@@ -119,12 +108,11 @@ ABSL_CONST_INIT extern "C" const int64_t kFIRFirestoreCacheSizeUnlimited =
   _cacheSizeBytes = cacheSizeBytes;
 }
 
-- (api::Settings)internalSettings {
-  api::Settings settings;
+- (Settings)internalSettings {
+  Settings settings;
   settings.set_host(util::MakeString(_host));
   settings.set_ssl_enabled(_sslEnabled);
   settings.set_persistence_enabled(_persistenceEnabled);
-  settings.set_timestamps_in_snapshots_enabled(_timestampsInSnapshotsEnabled);
   settings.set_cache_size_bytes(_cacheSizeBytes);
   return settings;
 }

--- a/Firestore/Source/Public/FirebaseFirestore/FIRFirestoreSettings.h
+++ b/Firestore/Source/Public/FirebaseFirestore/FIRFirestoreSettings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google
+ * Copyright 2017 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,26 +47,6 @@ NS_SWIFT_NAME(FirestoreSettings)
 
 /** Set to false to disable local persistent storage. */
 @property(nonatomic, getter=isPersistenceEnabled) BOOL persistenceEnabled;
-
-/**
- * Specifies whether to use FIRTimestamps for timestamp fields in FIRDocumentSnapshots. This is
- * now enabled by default and should not be disabled.
- *
- * Previously, Firestore returned timestamp fields as NSDate but NSDate is implemented as a double
- * which loses precision and causes unexpected behavior when using a timestamp from a snapshot as a
- * part of a subsequent query.
- *
- * So now Firestore returns FIRTimestamp values instead of NSDate, avoiding this kind of problem.
- *
- * To opt into the old behavior of returning NSDate objects, you can temporarily set
- * areTimestampsInSnapshotsEnabled to false.
- *
- * @deprecated This setting now defaults to true and will be removed in a future release. If you are
- * already setting it to true, just remove the setting. If you are setting it to false, you should
- * update your code to expect FIRTimestamp objects instead of NSDate and then remove the setting.
- */
-@property(nonatomic, getter=areTimestampsInSnapshotsEnabled) BOOL timestampsInSnapshotsEnabled
-    __attribute__((deprecated));
 
 /**
  * Sets the cache size threshold above which the SDK will attempt to collect least-recently-used

--- a/Firestore/core/src/api/settings.cc
+++ b/Firestore/core/src/api/settings.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,18 +27,15 @@ constexpr bool Settings::DefaultSslEnabled;
 constexpr bool Settings::DefaultPersistenceEnabled;
 constexpr int64_t Settings::DefaultCacheSizeBytes;
 constexpr int64_t Settings::MinimumCacheSizeBytes;
-constexpr bool Settings::DefaultTimestampsInSnapshotsEnabled;
 
 size_t Settings::Hash() const {
   return util::Hash(host_, ssl_enabled_, persistence_enabled_,
-                    timestamps_in_snapshots_enabled_, cache_size_bytes_);
+                    cache_size_bytes_);
 }
 
 bool operator==(const Settings& lhs, const Settings& rhs) {
   return lhs.host_ == rhs.host_ && lhs.ssl_enabled_ == rhs.ssl_enabled_ &&
          lhs.persistence_enabled_ == rhs.persistence_enabled_ &&
-         lhs.timestamps_in_snapshots_enabled_ ==
-             rhs.timestamps_in_snapshots_enabled_ &&
          lhs.cache_size_bytes_ == rhs.cache_size_bytes_;
 }
 

--- a/Firestore/core/src/api/settings.h
+++ b/Firestore/core/src/api/settings.h
@@ -1,6 +1,6 @@
 
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,6 @@ class Settings {
   static constexpr int64_t DefaultCacheSizeBytes = 100 * 1024 * 1024;
   static constexpr int64_t MinimumCacheSizeBytes = 1 * 1024 * 1024;
   static constexpr int64_t CacheSizeUnlimited = -1;
-  static constexpr bool DefaultTimestampsInSnapshotsEnabled = true;
 
   Settings() = default;
 
@@ -65,13 +64,6 @@ class Settings {
     return persistence_enabled_;
   }
 
-  void set_timestamps_in_snapshots_enabled(bool value) {
-    timestamps_in_snapshots_enabled_ = value;
-  }
-  bool timestamps_in_snapshots_enabled() const {
-    return timestamps_in_snapshots_enabled_;
-  }
-
   void set_cache_size_bytes(int64_t value) {
     cache_size_bytes_ = value;
   }
@@ -90,7 +82,6 @@ class Settings {
   std::string host_ = DefaultHost;
   bool ssl_enabled_ = DefaultSslEnabled;
   bool persistence_enabled_ = DefaultPersistenceEnabled;
-  bool timestamps_in_snapshots_enabled_ = DefaultTimestampsInSnapshotsEnabled;
   int64_t cache_size_bytes_ = DefaultCacheSizeBytes;
 };
 

--- a/Firestore/core/src/model/field_value_options.h
+++ b/Firestore/core/src/model/field_value_options.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,23 +31,16 @@ class FieldValueOptions {
    * Creates an FieldValueOptions instance that specifies deserialization
    * behavior for pending server timestamps.
    */
-  FieldValueOptions(ServerTimestampBehavior server_timestamp_behavior,
-                    bool timestamps_in_snapshots_enabled)
-      : server_timestamp_behavior_(server_timestamp_behavior),
-        timestamps_in_snapshots_enabled_(timestamps_in_snapshots_enabled) {
+  explicit FieldValueOptions(ServerTimestampBehavior server_timestamp_behavior)
+      : server_timestamp_behavior_(server_timestamp_behavior) {
   }
 
   ServerTimestampBehavior server_timestamp_behavior() const {
     return server_timestamp_behavior_;
   }
 
-  bool timestamps_in_snapshots_enabled() const {
-    return timestamps_in_snapshots_enabled_;
-  }
-
  private:
   ServerTimestampBehavior server_timestamp_behavior_;
-  bool timestamps_in_snapshots_enabled_;
 };
 
 }  // namespace model


### PR DESCRIPTION
Snapshots will now always include `FIRTimestamp` values. Use `[FIRTimestamp dateValue]` to convert to `NSDate` if required.

`timestampsInSnapshotsEnabled` was deprecated in Firebase 5.16.0 (January 22, 2019) and has defaulted to true since then.

Projects that have not enabled `timestampsInSnapshotsEnabled` have logged a warning since Firebase 4.12.0 (April 10, 2018).

/cc @var-const Note that this is also a breaking change for the C++ SDK, but only because it currently forces timestamps in snapshots to true. We could remove that in advance of importing M82 without a problem (since `timestampsInSnapshotsEnabled` already defaults to true). Existing users will be unaffected because the dependency on this pod only floats on patch levels.