### PR TITLE
Change numberValue to be nonnull

### DIFF
--- a/FirebaseRemoteConfig/CHANGELOG.md
+++ b/FirebaseRemoteConfig/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v7.0.0
 - [changed] Updated `lastFetchTime` field to readonly. (#6567)
 - [changed] Functionally neutral change to stop using a deprecated method in the AB Testing API. (#6543)
+- [fixed] Updated `numberValue` to be nonnull to align with current behavior. (#6623)
 
 # v4.9.1
 - [fixed] Fix an `attempt to insert nil object` crash in `fetchWithExpirationDuration:`. (#6522)

--- a/FirebaseRemoteConfig/Sources/Public/FirebaseRemoteConfig/FIRRemoteConfig.h
+++ b/FirebaseRemoteConfig/Sources/Public/FirebaseRemoteConfig/FIRRemoteConfig.h
@@ -109,7 +109,7 @@ NS_SWIFT_NAME(RemoteConfigValue)
 /// Gets the value as a string.
 @property(nonatomic, readonly, nullable) NSString *stringValue;
 /// Gets the value as a number value.
-@property(nonatomic, readonly, nullable) NSNumber *numberValue;
+@property(nonatomic, readonly, nonnull) NSNumber *numberValue;
 /// Gets the value as a NSData object.
 @property(nonatomic, readonly, nonnull) NSData *dataValue;
 /// Gets the value as a boolean.


### PR DESCRIPTION
This aligns with behavior on other platforms: [JS](https://github.com/firebase/firebase-js-sdk/blob/master/packages/remote-config/src/value.ts#L49), [Android](https://github.com/firebase/firebase-android-sdk/blob/master/firebase-config/src/main/java/com/google/firebase/remoteconfig/internal/ConfigGetParameterHandler.java#L260)

Fixes #6188.