### PR TITLE
Add auth emulator support to public API.

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [removed] Remove deprecated APIs `dataForKey`,`fetchProvidersForEmail:completion`, `signInAndRetrieveDataWithCredential:completion`, `reauthenticateAndRetrieveDataWithCredential:completion`, `linkAndRetrieveDataWithCredential:completion`. (#6607)
+- [added] Add support for the auth emulator. (#6624)
 
 # v6.9.1
 - [fixed] Internal source documentation. (#6371)

--- a/FirebaseAuth/Sources/Auth/FIRAuth_Internal.h
+++ b/FirebaseAuth/Sources/Auth/FIRAuth_Internal.h
@@ -142,11 +142,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (FIRAuthDataResultCallback)signInFlowAuthDataResultCallbackByDecoratingCallback:
     (nullable FIRAuthDataResultCallback)callback;
 
-/** @fn useEmulatorWithHost:port
-    @brief Configures Firebase Auth to connect to an emulated host instead of the remote backend.
- */
-- (void)useEmulatorWithHost:(NSString *)host port:(NSInteger)port;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h
+++ b/FirebaseAuth/Sources/Public/FirebaseAuth/FIRAuth.h
@@ -806,6 +806,11 @@ NS_SWIFT_NAME(Auth)
  */
 - (void)useAppLanguage;
 
+/** @fn useEmulatorWithHost:port
+    @brief Configures Firebase Auth to connect to an emulated host instead of the remote backend.
+ */
+- (void)useEmulatorWithHost:(NSString *)host port:(NSInteger)port;
+
 #if TARGET_OS_IOS
 
 /** @fn canHandleURL:


### PR DESCRIPTION
Add auth emulator support `useEmulatorWithHost:port` to public API.

Implementation added in #6402 