### PR TITLE
Remove the `FirebaseOptions()` bare initializer.

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -5,6 +5,8 @@
 - [changed] The pods developed in this repo are no longer hard coded to be built as static
   frameworks. Instead, their linkage will be controlled by the Podfile. Use the Podfile
   option `use_frameworks! :linkage => :static` to get the Firebase 6.x linkage behavior. (#2022)
+- [removed] Removed broken `FirebaseOptions()` initializer. Use `init(contentsOfFile:)` or
+  `init(googleAppID:gcmSenderID:)` instead. (#6633)
 
 # Firebase 6.34.0
 - [fixed] Removed warning related to missing Analytics framework for non-iOS builds since the

--- a/FirebaseCore/Sources/FIROptions.m
+++ b/FirebaseCore/Sources/FIROptions.m
@@ -160,9 +160,8 @@ static dispatch_once_t sDefaultOptionsDictionaryOnceToken;
 }
 
 - (id)copyWithZone:(NSZone *)zone {
-  FIROptions *newOptions = [[[self class] allocWithZone:zone] init];
+  FIROptions *newOptions = [(FIROptions *)[[self class] allocWithZone:zone] initInternalWithOptionsDictionary:self.optionsDictionary];
   if (newOptions) {
-    newOptions.optionsDictionary = self.optionsDictionary;
     newOptions.deepLinkURLScheme = self.deepLinkURLScheme;
     newOptions.appGroupID = self.appGroupID;
     newOptions.editingLocked = self.isEditingLocked;
@@ -172,6 +171,12 @@ static dispatch_once_t sDefaultOptionsDictionaryOnceToken;
 }
 
 #pragma mark - Public instance methods
+
+- (instancetype)init {
+  // Unavailable.
+  [self doesNotRecognizeSelector:_cmd];
+  return nil;
+}
 
 - (instancetype)initWithContentsOfFile:(NSString *)plistPath {
   self = [super init];

--- a/FirebaseCore/Sources/FIROptions.m
+++ b/FirebaseCore/Sources/FIROptions.m
@@ -160,7 +160,8 @@ static dispatch_once_t sDefaultOptionsDictionaryOnceToken;
 }
 
 - (id)copyWithZone:(NSZone *)zone {
-  FIROptions *newOptions = [(FIROptions *)[[self class] allocWithZone:zone] initInternalWithOptionsDictionary:self.optionsDictionary];
+  FIROptions *newOptions = [(FIROptions *)[[self class] allocWithZone:zone]
+      initInternalWithOptionsDictionary:self.optionsDictionary];
   if (newOptions) {
     newOptions.deepLinkURLScheme = self.deepLinkURLScheme;
     newOptions.appGroupID = self.appGroupID;

--- a/FirebaseCore/Sources/Private/FIROptionsInternal.h
+++ b/FirebaseCore/Sources/Private/FIROptionsInternal.h
@@ -51,7 +51,8 @@ extern NSString *const kServiceInfoFileType;
  * Initializes the options with dictionary. The above strings are the keys of the dictionary.
  * This is the designated initializer.
  */
-- (instancetype)initInternalWithOptionsDictionary:(NSDictionary *)serviceInfoDictionary NS_DESIGNATED_INITIALIZER;
+- (instancetype)initInternalWithOptionsDictionary:(NSDictionary *)serviceInfoDictionary
+    NS_DESIGNATED_INITIALIZER;
 
 /**
  * defaultOptions and defaultOptionsDictionary are exposed in order to be used in FIRApp and

--- a/FirebaseCore/Sources/Private/FIROptionsInternal.h
+++ b/FirebaseCore/Sources/Private/FIROptionsInternal.h
@@ -51,7 +51,7 @@ extern NSString *const kServiceInfoFileType;
  * Initializes the options with dictionary. The above strings are the keys of the dictionary.
  * This is the designated initializer.
  */
-- (instancetype)initInternalWithOptionsDictionary:(NSDictionary *)serviceInfoDictionary;
+- (instancetype)initInternalWithOptionsDictionary:(NSDictionary *)serviceInfoDictionary NS_DESIGNATED_INITIALIZER;
 
 /**
  * defaultOptions and defaultOptionsDictionary are exposed in order to be used in FIRApp and

--- a/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
+++ b/FirebaseCore/Sources/Public/FirebaseCore/FIROptions.h
@@ -106,7 +106,7 @@ NS_SWIFT_NAME(FirebaseOptions)
  * FIROptions *options = [[FIROptions alloc] initWithContentsOfFile:filePath];
  * Returns nil if the plist file does not exist or is invalid.
  */
-- (nullable instancetype)initWithContentsOfFile:(NSString *)plistPath;
+- (nullable instancetype)initWithContentsOfFile:(NSString *)plistPath NS_DESIGNATED_INITIALIZER;
 
 /**
  * Initializes a customized instance of FIROptions with required fields. Use the mutable properties
@@ -115,8 +115,11 @@ NS_SWIFT_NAME(FirebaseOptions)
 // clang-format off
 - (instancetype)initWithGoogleAppID:(NSString *)googleAppID
                         GCMSenderID:(NSString *)GCMSenderID
-    NS_SWIFT_NAME(init(googleAppID:gcmSenderID:));
+    NS_SWIFT_NAME(init(googleAppID:gcmSenderID:)) NS_DESIGNATED_INITIALIZER;
 // clang-format on
+
+/** Unavailable. Please use `init(contentsOfFile:)` or `init(googleAppID:gcmSenderID:)` instead. */
+- (instancetype)init NS_UNAVAILABLE;
 
 @end
 

--- a/FirebaseCore/Tests/SwiftUnit/FirebaseAppTests.swift
+++ b/FirebaseCore/Tests/SwiftUnit/FirebaseAppTests.swift
@@ -308,7 +308,9 @@ class FirebaseAppTests: XCTestCase {
   }
 
   func testFirebaseDataCollectionDefaultEnabled() throws {
-    let app = FirebaseApp(instanceWithName: "emptyApp", options: FirebaseOptions())
+    let app = FirebaseApp(instanceWithName: "emptyApp",
+                          options: FirebaseOptions(googleAppID: Constants.Options.googleAppID,
+                                                   gcmSenderID: Constants.Options.gcmSenderID))
 
     // defaults to true unless otherwise set to no in app's Info.plist
     XCTAssertTrue(app.isDataCollectionDefaultEnabled)

--- a/FirebaseCore/Tests/SwiftUnit/FirebaseOptionsTests.swift
+++ b/FirebaseCore/Tests/SwiftUnit/FirebaseOptionsTests.swift
@@ -136,8 +136,9 @@ class FirebaseOptionsTests: XCTestCase {
     XCTAssertEqual(defaultOptions1.hash, defaultOptions2.hash)
     XCTAssertTrue(defaultOptions1.isEqual(defaultOptions2))
 
-    let emptyOptions = FirebaseOptions()
-    XCTAssertFalse(emptyOptions.isEqual(defaultOptions1))
+    let plainOptions = FirebaseOptions(googleAppID: Constants.Options.googleAppID,
+                                       gcmSenderID: Constants.Options.gcmSenderID)
+    XCTAssertFalse(plainOptions.isEqual(defaultOptions1))
   }
 
   // MARK: - Helpers


### PR DESCRIPTION
This was unintentionally surfaced from the ObjC header and should be
removed.

Note: although the existing initializer doesn't work, this is still a
breaking change.

Fixes #5728 

Following recommendations from https://developer.apple.com/videos/play/wwdc2020/10680