### PR TITLE
FIS: don't log anything on success validation

### DIFF
--- a/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
+++ b/FirebaseInstallations/Source/Library/InstallationsIDController/FIRInstallationsIDController.m
@@ -182,9 +182,13 @@ static NSString *const kKeychainService = @"com.firebase.FIRInstallations.instal
       ^BOOL(FIRInstallationsItem *installation) {
         NSError *validationError;
         BOOL isValid = [installation isValid:&validationError];
-        FIRLogWarning(
-            kFIRLoggerInstallations, kFIRInstallationsMessageCodeCorruptedStoredInstallation,
-            @"Stored installation validation error: %@", validationError.localizedDescription);
+
+        if (!isValid) {
+          FIRLogWarning(
+              kFIRLoggerInstallations, kFIRInstallationsMessageCodeCorruptedStoredInstallation,
+              @"Stored installation validation error: %@", validationError.localizedDescription);
+        }
+
         return isValid;
       });
 }


### PR DESCRIPTION
Prevent message ` [Firebase/Installations][I-FIS002004] Stored installation validation error: (null)` from being logged when everything is ok.

#no-changelog 