### PR TITLE
Add check for unauthenticated error and sign out in fetchNewLatestRelease

### DIFF
--- a/FirebaseAppDistribution/CHANGELOG.md
+++ b/FirebaseAppDistribution/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [changed] Sign out the Tester when the call to fetch releases fails with an unauthenticated error.
+
 # v0.9.3
 - [changed] Updated error log for non-200 API Service calls.
 

--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -252,6 +252,11 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
   [FIRFADApiService
       fetchReleasesWithCompletion:^(NSArray *_Nullable releases, NSError *_Nullable error) {
         if (error) {
+          if ([error code] == FIRFADApiErrorUnauthenticated){
+            FIRFADErrorLog(@"Tester authentication failed when fetching releases. Tester will need to sign in again.");
+            [self signOutTester];
+          }
+
           dispatch_async(dispatch_get_main_queue(), ^{
             completion(nil, [self mapFetchReleasesError:error]);
           });

--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -252,8 +252,9 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
   [FIRFADApiService
       fetchReleasesWithCompletion:^(NSArray *_Nullable releases, NSError *_Nullable error) {
         if (error) {
-          if ([error code] == FIRFADApiErrorUnauthenticated){
-            FIRFADErrorLog(@"Tester authentication failed when fetching releases. Tester will need to sign in again.");
+          if ([error code] == FIRFADApiErrorUnauthenticated) {
+            FIRFADErrorLog(@"Tester authentication failed when fetching releases. Tester will need "
+                           @"to sign in again.");
             [self signOutTester];
           }
 

--- a/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionTests.m
+++ b/FirebaseAppDistribution/Tests/Unit/FIRAppDistributionTests.m
@@ -357,12 +357,13 @@
 
 - (void)testFetchNewLatestReleaseUnauthenticatedFailure {
   NSError *mockError =
-  [NSError errorWithDomain:kFIRFADApiErrorDomain
-                      code:FIRFADApiErrorUnauthenticated
-                  userInfo:@{NSLocalizedDescriptionKey : @"This is unfortunate."}];
+      [NSError errorWithDomain:kFIRFADApiErrorDomain
+                          code:FIRFADApiErrorUnauthenticated
+                      userInfo:@{NSLocalizedDescriptionKey : @"This is unfortunate."}];
   [self mockFetchReleasesCompletion:nil error:mockError];
   OCMStub([_mockMachO codeHash]).andReturn(@"this-is-old");
   [[GULUserDefaults standardUserDefaults] setBool:YES forKey:@"FIRFADSignInState"];
+  XCTAssertTrue([[self appDistribution] isTesterSignedIn]);
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"Fetch latest release fails."];
 


### PR DESCRIPTION
Check for an Unauthenticated error and sign out the Tester from the fetchNewLatestRelease.
