### PR TITLE
Bump nanopb to fix Xcode 12 warning

### DIFF
--- a/FirebaseCoreDiagnostics.podspec
+++ b/FirebaseCoreDiagnostics.podspec
@@ -54,7 +54,7 @@ non-Cocoapod integration. This library also respects the Firebase global data co
   s.dependency 'GoogleDataTransport', '~> 7.5'
   s.dependency 'GoogleUtilities/Environment', '~> 7.0'
   s.dependency 'GoogleUtilities/Logger', '~> 7.0'
-  s.dependency 'nanopb', '~> 1.30906.0'
+  s.dependency 'nanopb', '~> 2.30906.0'
 
   s.test_spec 'unit' do |unit_tests|
     unit_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -51,7 +51,7 @@ Pod::Spec.new do |s|
   s.dependency 'FirebaseInstallations', '~> 7.0'
   s.dependency 'PromisesObjC', '~> 1.2'
   s.dependency 'GoogleDataTransport', '~> 7.5'
-  s.dependency 'nanopb', '~> 1.30906.0'
+  s.dependency 'nanopb', '~> 2.30906.0'
 
   s.libraries = 'c++', 'z'
   s.ios.frameworks = 'Security', 'SystemConfiguration'

--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -70,7 +70,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
 
   s.dependency 'gRPC-C++', '~> 1.28.0'
   s.dependency 'leveldb-library', '~> 1.22'
-  s.dependency 'nanopb', '~> 1.30906.0'
+  s.dependency 'nanopb', '~> 2.30906.0'
 
   s.ios.frameworks = 'MobileCoreServices', 'SystemConfiguration', 'UIKit'
   s.osx.frameworks = 'SystemConfiguration'

--- a/FirebaseInAppMessaging.podspec
+++ b/FirebaseInAppMessaging.podspec
@@ -50,7 +50,7 @@ See more product details at https://firebase.google.com/products/in-app-messagin
   s.dependency 'FirebaseInstallations', '~> 7.0'
   s.dependency 'FirebaseABTesting', '~> 7.0'
   s.dependency 'GoogleUtilities/Environment', '~> 7.0'
-  s.dependency 'nanopb', '~> 1.30906.0'
+  s.dependency 'nanopb', '~> 2.30906.0'
 
   s.test_spec 'unit' do |unit_tests|
       unit_tests.source_files = 'FirebaseInAppMessaging/Tests/Unit/*.[mh]'

--- a/GoogleDataTransport.podspec
+++ b/GoogleDataTransport.podspec
@@ -34,7 +34,7 @@ Shared library for iOS SDK data transport needs.
 
   s.libraries = ['z']
 
-  s.dependency 'nanopb', '~> 1.30906.0'
+  s.dependency 'nanopb', '~> 2.30906.0'
 
   header_search_paths = {
     'HEADER_SEARCH_PATHS' => '"${PODS_TARGET_SRCROOT}/"'


### PR DESCRIPTION
Part of #6549 

This is a podspec only change for nanopb to restrict the iOS versions supported and to eliminate the Xcode 12 build warning.

See also https://github.com/google/nanopb-podspec/pull/16

@no-changelog