### PR TITLE
Simplify FirebaseCore imports

### DIFF
--- a/FirebaseCore/Sources/FIRComponentContainerInternal.h
+++ b/FirebaseCore/Sources/FIRComponentContainerInternal.h
@@ -15,8 +15,8 @@
  */
 #import <Foundation/Foundation.h>
 
-#import "FirebaseCore/Sources/Private/FIRComponent.h"
 #import "FirebaseCore/Sources/Private/FIRComponentContainer.h"
+#import "FirebaseCore/Sources/Private/FIRLibrary.h"
 
 @class FIRApp;
 

--- a/FirebaseCore/Sources/Private/FIRComponentContainer.h
+++ b/FirebaseCore/Sources/Private/FIRComponentContainer.h
@@ -15,15 +15,6 @@
  */
 #import <Foundation/Foundation.h>
 
-// The has_include is a workaround so the old IID needed for the FIS tests can find the headers.
-#if __has_include("FirebaseCore/Sources/Private/FIRComponentType.h")
-#import "FirebaseCore/Sources/Private/FIRComponentType.h"
-#import "FirebaseCore/Sources/Private/FIRLibrary.h"
-#else
-#import <FirebaseCore/FIRComponentType.h>
-#import <FirebaseCore/FIRLibrary.h>
-#endif
-
 NS_ASSUME_NONNULL_BEGIN
 
 /// A type-safe macro to retrieve a component from a container. This should be used to retrieve

--- a/FirebaseCore/Sources/Private/FIRLibrary.h
+++ b/FirebaseCore/Sources/Private/FIRLibrary.h
@@ -19,14 +19,8 @@
 
 #import <Foundation/Foundation.h>
 
-// The has_include is a workaround so the old IID needed for the FIS tests can find the headers.
-#if __has_include("FirebaseCore/Sources/Private/FIRComponent.h")
-#import "FirebaseCore/Sources/Private/FIRComponent.h"
-#else
-#import <FirebaseCore/FIRComponent.h>
-#endif
-
 @class FIRApp;
+@class FIRComponent;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/FirebaseCore/Sources/Private/FirebaseCoreInternal.h
+++ b/FirebaseCore/Sources/Private/FirebaseCoreInternal.h
@@ -20,6 +20,7 @@
 #import "FirebaseCore/Sources/Private/FIRAppInternal.h"
 #import "FirebaseCore/Sources/Private/FIRComponent.h"
 #import "FirebaseCore/Sources/Private/FIRComponentContainer.h"
+#import "FirebaseCore/Sources/Private/FIRComponentType.h"
 #import "FirebaseCore/Sources/Private/FIRDependency.h"
 #import "FirebaseCore/Sources/Private/FIRHeartbeatInfo.h"
 #import "FirebaseCore/Sources/Private/FIRLibrary.h"

--- a/FirebaseCore/Tests/Unit/FIRAppTest.m
+++ b/FirebaseCore/Tests/Unit/FIRAppTest.m
@@ -18,6 +18,7 @@
 #import <GoogleUtilities/GULAppEnvironmentUtil.h>
 #import "FirebaseCore/Sources/FIRAnalyticsConfiguration.h"
 #import "FirebaseCore/Sources/Private/FIRAppInternal.h"
+#import "FirebaseCore/Sources/Private/FIRComponentType.h"
 #import "FirebaseCore/Sources/Private/FIRCoreDiagnosticsConnector.h"
 #import "FirebaseCore/Sources/Private/FIROptionsInternal.h"
 #import "SharedTestUtilities/FIROptionsMock.h"

--- a/FirebaseCore/Tests/Unit/FIRComponentContainerTest.m
+++ b/FirebaseCore/Tests/Unit/FIRComponentContainerTest.m
@@ -15,6 +15,7 @@
 #import "FirebaseCore/Tests/Unit/FIRTestCase.h"
 
 #import "FirebaseCore/Sources/FIRComponentContainerInternal.h"
+#import "FirebaseCore/Sources/Private/FIRComponentType.h"
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 #import "FirebaseCore/Tests/Unit/FIRTestComponents.h"
 #import "SharedTestUtilities/FIROptionsMock.h"

--- a/FirebaseCore/Tests/Unit/FIRTestComponents.m
+++ b/FirebaseCore/Tests/Unit/FIRTestComponents.m
@@ -14,6 +14,7 @@
 
 #import "FirebaseCore/Tests/Unit/FIRTestComponents.h"
 
+#import "FirebaseCore/Sources/Private/FIRComponentType.h"
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 
 #pragma mark - Standard Component

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 # To update, change version below, run bundle install, test,
 # commit Gemfile and Gemfile.lock.
 source 'https://rubygems.org'
-
 gem 'cocoapods', '1.10.0.rc.1'
 
 # Use cocoapod-generate hash until 2.1.0 releases to fix a bug interacting with CocoaPods 1.10.

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 # To update, change version below, run bundle install, test,
 # commit Gemfile and Gemfile.lock.
 source 'https://rubygems.org'
+
 gem 'cocoapods', '1.10.0.rc.1'
 
 # Use cocoapod-generate hash until 2.1.0 releases to fix a bug interacting with CocoaPods 1.10.


### PR DESCRIPTION
Remove unnecessary imports and convert to forward `@class` declarations where possible.

#no-changelog