### PR TITLE
Fix an issue notification is not received during app first install

### DIFF
--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -827,7 +827,20 @@ static FIRInstanceID *gInstanceID;
       if (!APNSRemainedSameDuringFetch && hasFirebaseMessaging) {
         // APNs value did change mid-fetch, so the token should be re-fetched with the current APNs
         // value.
-        [self retryGetDefaultTokenAfter:0];
+        [self.installations installationIDWithCompletion:^(NSString *_Nullable identifier,
+                                                           NSError *_Nullable error) {
+          if (error) {
+            NSError *newError =
+                [NSError errorWithFIRInstanceIDErrorCode:kFIRInstanceIDErrorCodeInvalidKeyPair];
+            aHandler(nil, newError);
+          } else {
+            [self.tokenManager fetchNewTokenWithAuthorizedEntity:self.fcmSenderID
+                                                           scope:kFIRInstanceIDDefaultTokenScope
+                                                      instanceID:identifier
+                                                         options:instanceIDOptions
+                                                         handler:nil];
+          }
+        }];
         FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeRefetchingTokenForAPNS,
                                  @"Received APNS token while fetching default token. "
                                  @"Refetching default token.");

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -834,16 +834,20 @@ static FIRInstanceID *gInstanceID;
                 [NSError errorWithFIRInstanceIDErrorCode:kFIRInstanceIDErrorCodeInvalidKeyPair];
             aHandler(nil, newError);
           } else {
+            // The cached apns token has updated, recollect the default token options from cache.
             [self.tokenManager fetchNewTokenWithAuthorizedEntity:self.fcmSenderID
                                                            scope:kFIRInstanceIDDefaultTokenScope
                                                       instanceID:identifier
-                                                         options:instanceIDOptions
+                                                         options:[self defaultTokenOptions]
                                                          handler:nil];
           }
         }];
         FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeRefetchingTokenForAPNS,
                                  @"Received APNS token while fetching default token. "
-                                 @"Refetching default token.");
+                                 @"Refetching default token. "
+                                 @"Updated cached APNS token: %@\n "
+                                 @"Stale request APNS token: %@",
+                                 self.APNSTupleString, APNSTupleStringInRequest);
         // Do not notify and handle completion handler since this is a retry.
         // Simply return.
         return;

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -827,21 +827,7 @@ static FIRInstanceID *gInstanceID;
       if (!APNSRemainedSameDuringFetch && hasFirebaseMessaging) {
         // APNs value did change mid-fetch, so the token should be re-fetched with the current APNs
         // value.
-        [self.installations installationIDWithCompletion:^(NSString *_Nullable identifier,
-                                                           NSError *_Nullable error) {
-          if (error) {
-            NSError *newError =
-                [NSError errorWithFIRInstanceIDErrorCode:kFIRInstanceIDErrorCodeInvalidKeyPair];
-            aHandler(nil, newError);
-          } else {
-            // The cached apns token has updated, recollect the default token options from cache.
-            [self.tokenManager fetchNewTokenWithAuthorizedEntity:self.fcmSenderID
-                                                           scope:kFIRInstanceIDDefaultTokenScope
-                                                      instanceID:identifier
-                                                         options:[self defaultTokenOptions]
-                                                         handler:nil];
-          }
-        }];
+        [self fetchNewToken];
         FIRInstanceIDLoggerDebug(kFIRInstanceIDMessageCodeRefetchingTokenForAPNS,
                                  @"Received APNS token while fetching default token. "
                                  @"Refetching default token. "
@@ -870,6 +856,23 @@ static FIRInstanceID *gInstanceID;
                             scope:kFIRInstanceIDDefaultTokenScope
                           options:instanceIDOptions
                           handler:newHandler];
+}
+
+- (void)fetchNewToken {
+  [self.installations
+      installationIDWithCompletion:^(NSString *_Nullable identifier, NSError *_Nullable error) {
+        if (error) {
+          FIRInstanceIDLoggerError(kFIRInstanceIDMessageCodeRefetchingTokenForAPNS,
+                                   kFIRInstanceIDInvalidNilHandlerError);
+        } else {
+          // The cached apns token has updated, recollect the default token options from cache.
+          [self.tokenManager fetchNewTokenWithAuthorizedEntity:self.fcmSenderID
+                                                         scope:kFIRInstanceIDDefaultTokenScope
+                                                    instanceID:identifier
+                                                       options:[self defaultTokenOptions]
+                                                       handler:nil];
+        }
+      }];
 }
 
 /**

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,6 +1,7 @@
 # unreleased -- v.7.0.0
 - [changed] Remove the deprecated FCM direct channel API and Upstream send API. (#6430)
 - [fixed] Fixed an issue that downloading an image failed when there's no extension in the file name but MIME type is set. (#6590)
+- [fixed] Fixed an issue that APNS token is not properly set sometimes when swizzling is disabled. (#6669)
 
 # 2020-09 -- v.4.7.1
 - [added] InstanceID is deprecated, add macro to suppress deprecation warning. (#6585)

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,7 +1,7 @@
 # unreleased -- v.7.0.0
 - [changed] Remove the deprecated FCM direct channel API and Upstream send API. (#6430)
 - [fixed] Fixed an issue that downloading an image failed when there's no extension in the file name but MIME type is set. (#6590)
-- [fixed] Fixed an issue that APNS token is not properly set sometimes when swizzling is disabled. (#6669)
+- [fixed] Fixed an issue that APNS token is not properly set sometimes when swizzling is disabled. (#6553)
 
 # 2020-09 -- v.4.7.1
 - [added] InstanceID is deprecated, add macro to suppress deprecation warning. (#6585)

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,7 +1,7 @@
 # unreleased -- v.7.0.0
 - [changed] Remove the deprecated FCM direct channel API and Upstream send API. (#6430)
 - [fixed] Fixed an issue that downloading an image failed when there's no extension in the file name but MIME type is set. (#6590)
-- [fixed] Fixed an issue that APNS token is not properly set sometimes when swizzling is disabled. (#6553)
+- [fixed] Fixed an issue that APNS token is not sent in token request when there's a delay of getting the APNS token from Apple. (#6553)
 
 # 2020-09 -- v.4.7.1
 - [added] InstanceID is deprecated, add macro to suppress deprecation warning. (#6585)


### PR DESCRIPTION
Fixes #6553.

There's a small chance the APNS token is returned from Apple with a delay so the first token request was sent without the apns token info. However, the retry logic didn't really trigger a second request, so fixed that.