### PR TITLE
Missing Foundation import

### DIFF
--- a/FirebaseABTesting/Sources/ABTConstants.h
+++ b/FirebaseABTesting/Sources/ABTConstants.h
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#import <Foundation/Foundation.h>
 #import "FirebaseCore/Sources/Private/FIRLogger.h"
 
 #define ABT_MSEC_PER_SEC 1000ull


### PR DESCRIPTION
Noticed while working on copybaras

The Foundation import is required for the subsequent `NSString` usages.

#no-changelog

