### PR TITLE
Log warning instead of failing SDK when discovering dangling target.

### DIFF
--- a/Firestore/core/src/local/leveldb_target_cache.cc
+++ b/Firestore/core/src/local/leveldb_target_cache.cc
@@ -29,6 +29,7 @@
 #include "Firestore/core/src/model/document_key_set.h"
 #include "Firestore/core/src/nanopb/byte_string.h"
 #include "Firestore/core/src/nanopb/reader.h"
+#include "Firestore/core/src/util/log.h"
 #include "Firestore/core/src/util/string_apple.h"
 #include "absl/strings/match.h"
 
@@ -168,7 +169,7 @@ absl::optional<TargetData> LevelDbTargetCache::GetTarget(const Target& target) {
     std::string target_key = LevelDbTargetKey::Key(row_key.target_id());
     target_iterator->Seek(target_key);
     if (!target_iterator->Valid() || target_iterator->key() != target_key) {
-      HARD_FAIL(
+      LOG_WARN(
           "Dangling query-target reference found: "
           "%s points to %s; seeking there found %s",
           DescribeKey(index_iterator), DescribeKey(target_key),

--- a/Firestore/core/src/local/leveldb_target_cache.cc
+++ b/Firestore/core/src/local/leveldb_target_cache.cc
@@ -174,6 +174,7 @@ absl::optional<TargetData> LevelDbTargetCache::GetTarget(const Target& target) {
           "%s points to %s; seeking there found %s",
           DescribeKey(index_iterator), DescribeKey(target_key),
           DescribeKey(target_iterator));
+      continue;
     }
 
     // Finally after finding a potential match, check that the target is

--- a/Firestore/core/test/unit/local/leveldb_target_cache_test.cc
+++ b/Firestore/core/test/unit/local/leveldb_target_cache_test.cc
@@ -17,6 +17,7 @@
 #include "Firestore/core/src/local/leveldb_target_cache.h"
 
 #include "Firestore/core/include/firebase/firestore/timestamp.h"
+#include "Firestore/core/src/local/leveldb_key.h"
 #include "Firestore/core/src/local/leveldb_persistence.h"
 #include "Firestore/core/src/local/persistence.h"
 #include "Firestore/core/src/local/target_data.h"
@@ -57,6 +58,10 @@ class LevelDbTargetCacheTest : public TargetCacheTestBase {
 
   LevelDbTargetCache* leveldb_cache() {
     return static_cast<LevelDbTargetCache*>(persistence_->target_cache());
+  }
+
+  LevelDbPersistence* leveldb_persistence() {
+    return static_cast<LevelDbPersistence*>(persistence_.get());
   }
 };
 
@@ -127,6 +132,22 @@ TEST_F(LevelDbTargetCacheTest, RemoveMatchingKeysForTargetID) {
     ASSERT_FALSE(cache_->Contains(key1));
     ASSERT_FALSE(cache_->Contains(key2));
     ASSERT_FALSE(cache_->Contains(key3));
+  });
+}
+
+// We see user issues where target data is missing for some reason, and the root
+// cause is unknown. This test makes sure the SDK proceeds even when this
+// happens. See: https://github.com/firebase/firebase-ios-sdk/issues/6644
+TEST_F(LevelDbTargetCacheTest, SurvivesMissingTargetData) {
+  persistence_->Run("test_remove_matching_keys_for_target_id", [&]() {
+    TargetData target_data = MakeTargetData(query_rooms_);
+    cache_->AddTarget(target_data);
+    TargetId target_id = target_data.target_id();
+    std::string key = LevelDbTargetKey::Key(target_id);
+    leveldb_persistence()->current_transaction()->Delete(key);
+
+    auto result = cache_->GetTarget(query_rooms_.ToTarget());
+    ASSERT_EQ(result, absl::nullopt);
   });
 }
 

--- a/Firestore/core/test/unit/local/target_cache_test.cc
+++ b/Firestore/core/test/unit/local/target_cache_test.cc
@@ -115,12 +115,6 @@ TEST_P(TargetCacheTest, SetAndReadAQuery) {
   });
 }
 
-TEST_P(TargetCacheTest, SurviveMissingTarget) {
-  persistence_->Run("test_set_and_read_a_query", [&]() {
-
-  });
-}
-
 TEST_P(TargetCacheTest, CanonicalIDCollision) {
   persistence_->Run("test_canonical_id_collision", [&]() {
     // Type information is currently lost in our canonical_id implementations so

--- a/Firestore/core/test/unit/local/target_cache_test.cc
+++ b/Firestore/core/test/unit/local/target_cache_test.cc
@@ -115,6 +115,12 @@ TEST_P(TargetCacheTest, SetAndReadAQuery) {
   });
 }
 
+TEST_P(TargetCacheTest, SurviveMissingTarget) {
+  persistence_->Run("test_set_and_read_a_query", [&]() {
+
+  });
+}
+
 TEST_P(TargetCacheTest, CanonicalIDCollision) {
   persistence_->Run("test_canonical_id_collision", [&]() {
     // Type information is currently lost in our canonical_id implementations so


### PR DESCRIPTION
Although still not sure of underlying cause, this should make https://github.com/firebase/firebase-ios-sdk/issues/6644 stopping crashing.