### PR TITLE
Speedup SwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -106,13 +106,13 @@ let package = Package(
     ),
     .package(
       name: "abseil",
-      url: "https://github.com/firebase/abseil-cpp.git",
-      .revision("8ddf129163673642a339d7980327bcb2c117a28e")
+      url: "https://github.com/firebase/abseil-cpp-SwiftPM.git",
+      .revision("05d8107f2971a37e6c77245b7c4c6b0a7e97bc99")
     ),
     .package(
       name: "gRPC",
-      url: "https://github.com/firebase/grpc.git",
-      .revision("b22bc5256665ff2f1763505631df0ee60378b083")
+      url: "https://github.com/firebase/grpc-SwiftPM.git",
+      .revision("5bb2669317ae2183f4cb00c675423af1924f0b46")
     ),
     .package(
       name: "OCMock",


### PR DESCRIPTION
Fix #6606

Speed up Swift Package Manager initialization by using copies of three of the dependency repositories that have substantially smaller git metadata.

Here's an approximate difference in time for a git clone for one of them:

```

$ time git clone git@github.com:paulb777/grpc.git Cloning into 'grpc'... remote: Enumerating objects: 35, done. remote: Counting objects: 100% (35/35), done. remote: Compressing objects: 100% (11/11), done. remote: Total 463922 (delta 25), reused 24 (delta 24), pack-reused 463887 Receiving objects: 100% (463922/463922), 200.91 MiB | 29.75 MiB/s, done. Updating files: 100% (9270/9270), done.

real 0m25.445s user 1m29.526s sys 0m5.475s

vs

time git clone git@github.com:paulb777/grpc2.git Cloning into 'grpc2'... remote: Enumerating objects: 9066, done. remote: Counting objects: 100% (9066/9066), done. remote: Compressing objects: 100% (5033/5033), done. remote: Total 9066 (delta 2243), reused 9066 (delta 2243), pack-reused 0 Receiving objects: 100% (9066/9066), 8.12 MiB | 12.82 MiB/s, done. Updating files: 100% (8180/8180), done.

real 0m3.329s user 0m0.814s sys 0m1.193s
```