### PR TITLE
Fix an IID google3 build error

### DIFF
--- a/Example/InstanceID/Tests/FIRInstanceIDTokenOperationsTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTokenOperationsTest.m
@@ -210,13 +210,14 @@ static NSString *kRegistrationToken = @"token-12345";
                                            checkinPreferences:checkinPreferences
                                                    instanceID:self.instanceID];
   operation.performWasCalled = NO;
+  __weak FIRInstanceIDTokenOperationFake *weakOperation = operation;
   [operation addCompletionHandler:^(FIRInstanceIDTokenOperationResult result,
                                     NSString *_Nullable token, NSError *_Nullable error) {
     if (result == FIRInstanceIDTokenOperationCancelled) {
       [cancelledExpectation fulfill];
     }
 
-    if (!operation.performWasCalled) {
+    if (!weakOperation.performWasCalled) {
       [didNotCallPerform fulfill];
     }
   }];


### PR DESCRIPTION
`FIRInstanceIDTokenOperationsTest.m:219:10: error: capturing 'operation' strongly in this block is likely to lead to a retain cycle [-Werror,-Warc-retain-cycles]`

#no-changelog