### PR TITLE
Fix retain cycle build issue

### DIFF
--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingPendingTopicsListTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingPendingTopicsListTest.m
@@ -113,11 +113,13 @@
   XCTestExpectation *batchSizeReductionExpectation =
       [self expectationWithDescription:@"Batch size was reduced after topic suscription"];
 
+  __weak id weakSelf = self;
   self.alwaysReadyDelegate.subscriptionHandler =
       ^(NSString *topic, FIRMessagingTopicAction action,
         FIRMessagingTopicOperationCompletion completion) {
         // Simulate that the handler is generally called asynchronously
         dispatch_async(dispatch_get_main_queue(), ^{
+          id self = weakSelf;
           if (action == FIRMessagingTopicActionUnsubscribe) {
             XCTAssertEqual(pendingTopics.numberOfBatches, 1);
             [batchSizeReductionExpectation fulfill];


### PR DESCRIPTION
```
FIRMessagingPendingTopicsListTest.m:122:13: error: capturing 'self' strongly in this block is likely to lead to a retain cycle [-Werror,-Warc-retain-cycles]
            XCTAssertEqual(pendingTopics.numberOfBatches, 1);
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

#no-changelog