### PR TITLE
Fixed CHANGELOG location.

### DIFF
--- a/GoogleDataTransport/CHANGELOG.md
+++ b/GoogleDataTransport/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Unreleased
 - Legacy pre Xcode 10 compatibility checks removed. (#6486)
 - `GDTCORDirectorySizeTracker` crash fixed. (#6540)
-- Fixed writing heartbeat to disk on tvOS devices. (#6658)
 
 # v7.4.0
 - Limit disk space consumed by GoogleDataTransport to store events. (#6365)

--- a/GoogleUtilities/CHANGELOG.md
+++ b/GoogleUtilities/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 7.0.0
 - All APIs are now public. All CocoaPods private headers are transitioned to public. Note that
 - GoogleUtilities may have frequent breaking changes than Firebase. (#6588)
+- Fixed writing heartbeat to disk on tvOS devices. (#6658)
 
 # 6.7.1
 - Fix import regression when mixing 6.7.0 with earlier Firebase versions. (#6047)


### PR DESCRIPTION
This was written to the wrong CHANGELOG. Whoops!