### PR TITLE
Support paths with + in List API

### DIFF
--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Fixed an issue with the List API that prevented listing of locations
+  that contain the "+" sign.
+
 # 7.0.0
 - [changed] The global variable `FIRStorageVersionString` is deleted.
   `FirebaseVersion()` or `FIRFirebaseVersion()` should be used instead.

--- a/FirebaseStorage/Sources/FIRStorageUtils.m
+++ b/FirebaseStorage/Sources/FIRStorageUtils.m
@@ -101,6 +101,12 @@ NSString *const kGCSObjectAllowedCharacterSet =
     [queryItems addObject:[NSURLQueryItem queryItemWithName:key value:queryParams[key]]];
   }
   [components setQueryItems:queryItems];
+  // NSURLComponents does not encode "+" as "%2B". This is however required by our backend, as
+  // it treats "+" as a shorthand encoding for spaces. See also
+  // https://stackoverflow.com/questions/31577188/how-to-encode-into-2b-with-nsurlcomponents
+  [components setPercentEncodedQuery:[[components percentEncodedQuery]
+                                         stringByReplacingOccurrencesOfString:@"+"
+                                                                   withString:@"%2B"]];
 
   NSString *encodedPath = [self encodedURLForPath:path];
   [components setPercentEncodedPath:encodedPath];

--- a/FirebaseStorage/Tests/Unit/FIRStorageListTests.m
+++ b/FirebaseStorage/Tests/Unit/FIRStorageListTests.m
@@ -152,6 +152,42 @@
   [FIRStorageTestHelpers waitForExpectation:self];
 }
 
+- (void)testPercentEncodesPlusToken {
+  XCTestExpectation *expectation = [self expectationWithDescription:@"testPercentEncodesPlusToken"];
+  NSURL *expectedURL = [NSURL URLWithString:@"https://firebasestorage.googleapis.com/v0/b/bucket/"
+                                            @"o?prefix=%2Bfoo/&delimiter=/"];
+
+  self.fetcherService.testBlock =
+      ^(GTMSessionFetcher *fetcher, GTMSessionFetcherTestResponse response) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-retain-cycles"
+        XCTAssertEqualObjects(fetcher.request.URL, expectedURL);  // Implicitly retains self
+        XCTAssertEqualObjects(fetcher.request.HTTPMethod, @"GET");
+#pragma clang diagnostic pop
+        NSHTTPURLResponse *httpResponse = [[NSHTTPURLResponse alloc] initWithURL:fetcher.request.URL
+                                                                      statusCode:200
+                                                                     HTTPVersion:kHTTPVersion
+                                                                    headerFields:nil];
+        response(httpResponse, nil, nil);
+      };
+
+  FIRStoragePath *path =
+      [FIRStoragePath pathFromString:@"https://firebasestorage.googleapis.com/v0/b/bucket/0/+foo"];
+  FIRStorageReference *ref = [[FIRStorageReference alloc] initWithStorage:self.storage path:path];
+  FIRStorageListTask *task = [[FIRStorageListTask alloc]
+      initWithReference:ref
+         fetcherService:self.fetcherService
+          dispatchQueue:self.dispatchQueue
+               pageSize:nil
+      previousPageToken:nil
+             completion:^(FIRStorageListResult *result, NSError *error) {
+               [expectation fulfill];
+             }];
+  [task enqueue];
+
+  [FIRStorageTestHelpers waitForExpectation:self];
+}
+
 - (void)testListWithResponse {
   XCTestExpectation *expectation = [self expectationWithDescription:@"testListWithErrorResponse"];
 


### PR DESCRIPTION
NSQueryParams doesn't encode `+` to `%2B`, which breaks the List API since it treats `+` as space. 

Note that other Storage APIs don't rely on query param encoding. There is already an integration tests that verifies that users can up and download files with `+` signs. 

Fixes b/170259897