### PR TITLE
Disable generic OAuth checks for Facebook and Apple when using the auth emulator.

### DIFF
--- a/FirebaseAuth/Sources/AuthProvider/OAuth/FIROAuthProvider.m
+++ b/FirebaseAuth/Sources/AuthProvider/OAuth/FIROAuthProvider.m
@@ -203,12 +203,14 @@ static NSString *const kCustomUrlSchemePrefix = @"app-";
     @return An Instance of @c FIROAuthProvider.
   */
 - (nullable instancetype)initWithProviderID:(NSString *)providerID auth:(FIRAuth *)auth {
-  NSAssert(![providerID isEqual:FIRFacebookAuthProviderID],
-           @"Sign in with Facebook is not supported via generic IDP; the Facebook TOS "
-            "dictate that you must use the Facebook iOS SDK for Facebook login.");
-  NSAssert(![providerID isEqual:@"apple.com"],
-           @"Sign in with Apple is not supported via generic IDP; You must use the Apple iOS SDK"
-            " for Sign in with Apple.");
+  if (!auth.requestConfiguration.emulatorHostAndPort) {
+    NSAssert(![providerID isEqual:FIRFacebookAuthProviderID],
+             @"Sign in with Facebook is not supported via generic IDP; the Facebook TOS "
+              "dictate that you must use the Facebook iOS SDK for Facebook login.");
+    NSAssert(![providerID isEqual:@"apple.com"],
+             @"Sign in with Apple is not supported via generic IDP; You must use the Apple iOS SDK"
+              " for Sign in with Apple.");
+  }
   self = [super init];
   if (self) {
     _auth = auth;


### PR DESCRIPTION
When using the auth emulator, disable generic OAuth checks for Facebook and Apple sign in. This is to add support for the auth emulator in FirebaseUI, which should not launch any IDP-provided SDKs so that real accounts are not required.

Launching generic OAuth with the auth emulator launches an emulated widget, and does NOT connect to the actual IDP.