### PR TITLE
Initial SPM building for watchOS

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -2,6 +2,8 @@
 - [changed] Update minimum iOS version to iOS 10 except for Analytics which is now iOS 9. (#4847)
 - [changed] Update minimum macOS version to 10.12.
 - [added] Swift Package Manager support for Firebase Messaging. (#5641)
+- [added] Swift Package Manager support for Auth, Crashlytics, Messaging, and Storage watchOS
+  targets. (#6584)
 - [changed] The pods developed in this repo are no longer hard coded to be built as static
   frameworks. Instead, their linkage will be controlled by the Podfile. Use the Podfile
   option `use_frameworks! :linkage => :static` to get the Firebase 6.x linkage behavior. (#2022)

--- a/Package.swift
+++ b/Package.swift
@@ -26,11 +26,11 @@ let firebaseVersion = "7.0.0"
 
 let package = Package(
   name: "Firebase",
-  platforms: [.iOS(.v10), .macOS(.v10_12), .tvOS(.v10)],
+  platforms: [.iOS(.v10), .macOS(.v10_12), .tvOS(.v10), .watchOS(.v6)],
   products: [
     .library(
       name: "FirebaseAnalytics",
-      targets: ["FirebaseAnalyticsWrapper"]
+      targets: ["FirebaseAnalyticsTarget"]
     ),
     .library(
       name: "FirebaseAuth",
@@ -197,6 +197,14 @@ let package = Package(
         .headerSearchPath("../../.."),
       ]
     ),
+
+    .target(
+      name: "FirebaseAnalyticsTarget",
+      dependencies: [.target(name: "FirebaseAnalyticsWrapper",
+                             condition: .when(platforms: [.iOS]))],
+      path: "SwiftPM-PlatformExclude/FirebaseAnalyticsWrap"
+    ),
+
     .target(
       name: "FirebaseAnalyticsWrapper",
       dependencies: [
@@ -301,12 +309,19 @@ let package = Package(
       ],
       linkerSettings: [
         .linkedFramework("Security"),
-        .linkedFramework("SystemConfiguration"),
+        .linkedFramework("SystemConfiguration", .when(platforms: .some([.iOS, .macOS, .tvOS]))),
       ]
     ),
 
     .target(
       name: "FirebaseDatabase",
+      dependencies: [.target(name: "FirebaseDatabaseImpl",
+                             condition: .when(platforms: [.iOS, .tvOS, .macOS]))],
+      path: "SwiftPM-PlatformExclude/FirebaseDatabaseWrap"
+    ),
+
+    .target(
+      name: "FirebaseDatabaseImpl",
       dependencies: [
         "FirebaseCore",
         "leveldb",
@@ -325,7 +340,7 @@ let package = Package(
       linkerSettings: [
         .linkedFramework("CFNetwork"),
         .linkedFramework("Security"),
-        .linkedFramework("SystemConfiguration"),
+        .linkedFramework("SystemConfiguration", .when(platforms: .some([.iOS, .macOS, .tvOS]))),
       ]
     ),
     .testTarget(
@@ -343,6 +358,13 @@ let package = Package(
 
     .target(
       name: "FirebaseDynamicLinks",
+      dependencies: [.target(name: "FirebaseDynamicLinksImpl",
+                             condition: .when(platforms: [.iOS]))],
+      path: "SwiftPM-PlatformExclude/FirebaseDynamicLinksWrap"
+    ),
+
+    .target(
+      name: "FirebaseDynamicLinksImpl",
       dependencies: ["FirebaseCore"],
       path: "FirebaseDynamicLinks/Sources",
       publicHeadersPath: "Public",
@@ -358,6 +380,13 @@ let package = Package(
 
     .target(
       name: "FirebaseFirestore",
+      dependencies: [.target(name: "FirebaseFirestoreImpl",
+                             condition: .when(platforms: [.iOS, .tvOS, .macOS]))],
+      path: "SwiftPM-PlatformExclude/FirebaseFirestoreWrap"
+    ),
+
+    .target(
+      name: "FirebaseFirestoreImpl",
       dependencies: [
         "FirebaseCore",
         "leveldb",
@@ -407,21 +436,28 @@ let package = Package(
         .headerSearchPath("../"),
         .headerSearchPath("Source/Public/FirebaseFirestore"),
         .headerSearchPath("Protos/nanopb"),
-
         .define("PB_FIELD_32BIT", to: "1"),
         .define("PB_NO_PACKED_STRUCTS", to: "1"),
         .define("PB_ENABLE_MALLOC", to: "1"),
         .define("FIRFirestore_VERSION", to: firebaseVersion),
       ],
       linkerSettings: [
-        .linkedFramework("SystemConfiguration"),
+        .linkedFramework("SystemConfiguration", .when(platforms: .some([.iOS, .macOS, .tvOS]))),
         .linkedFramework("MobileCoreServices", .when(platforms: .some([.iOS]))),
         .linkedFramework("UIKit", .when(platforms: .some([.iOS, .tvOS]))),
         .linkedLibrary("c++"),
       ]
     ),
+
     .target(
       name: "FirebaseFirestoreSwift",
+      dependencies: [.target(name: "FirebaseFirestoreSwiftImpl",
+                             condition: .when(platforms: [.iOS, .tvOS, .macOS]))],
+      path: "SwiftPM-PlatformExclude/FirebaseFirestoreSwiftWrap"
+    ),
+
+    .target(
+      name: "FirebaseFirestoreSwiftImpl",
       dependencies: ["FirebaseFirestore"],
       path: "Firestore",
       exclude: [
@@ -448,6 +484,13 @@ let package = Package(
 
     .target(
       name: "FirebaseFunctions",
+      dependencies: [.target(name: "FirebaseFunctionsImpl",
+                             condition: .when(platforms: [.iOS, .tvOS, .macOS]))],
+      path: "SwiftPM-PlatformExclude/FirebaseFunctionsWrap"
+    ),
+
+    .target(
+      name: "FirebaseFunctionsImpl",
       dependencies: [
         "FirebaseCore",
         .product(name: "GTMSessionFetcherCore", package: "GTMSessionFetcher"),
@@ -461,6 +504,13 @@ let package = Package(
 
     .target(
       name: "FirebaseInAppMessaging",
+      dependencies: [.target(name: "FirebaseInAppMessagingImpl",
+                             condition: .when(platforms: [.iOS]))],
+      path: "SwiftPM-PlatformExclude/FirebaseInAppMessagingWrap"
+    ),
+
+    .target(
+      name: "FirebaseInAppMessagingImpl",
       dependencies: [
         "FirebaseCore",
         "FirebaseInstallations",
@@ -527,7 +577,7 @@ let package = Package(
         .headerSearchPath("../../"),
       ],
       linkerSettings: [
-        .linkedFramework("SystemConfiguration"),
+        .linkedFramework("SystemConfiguration", .when(platforms: .some([.iOS, .macOS, .tvOS]))),
       ]
     ),
     .testTarget(
@@ -551,8 +601,16 @@ let package = Package(
         .headerSearchPath("../"),
       ]
     ),
+
     .target(
       name: "FirebaseRemoteConfig",
+      dependencies: [.target(name: "FirebaseRemoteConfigImpl",
+                             condition: .when(platforms: [.iOS, .tvOS, .macOS]))],
+      path: "SwiftPM-PlatformExclude/FirebaseRemoteConfigWrap"
+    ),
+
+    .target(
+      name: "FirebaseRemoteConfigImpl",
       dependencies: [
         "FirebaseCore",
         "FirebaseABTesting",
@@ -646,7 +704,7 @@ let package = Package(
         .define("PB_ENABLE_MALLOC", to: "1"),
       ],
       linkerSettings: [
-        .linkedFramework("SystemConfiguration"),
+        .linkedFramework("SystemConfiguration", .when(platforms: .some([.iOS, .macOS, .tvOS]))),
         .linkedFramework("CoreTelephony", .when(platforms: .some([.macOS, .iOS]))),
       ]
     ),

--- a/Package.swift
+++ b/Package.swift
@@ -304,6 +304,7 @@ let package = Package(
         .define("CLS_SDK_NAME", to: "Crashlytics iOS SDK", .when(platforms: .some([.iOS]))),
         .define("CLS_SDK_NAME", to: "Crashlytics macOS SDK", .when(platforms: .some([.macOS]))),
         .define("CLS_SDK_NAME", to: "Crashlytics tvOS SDK", .when(platforms: .some([.tvOS]))),
+        .define("CLS_SDK_NAME", to: "Crashlytics watchOS SDK", .when(platforms: .some([.watchOS]))),
         .define("PB_FIELD_32BIT", to: "1"),
         .define("PB_NO_PACKED_STRUCTS", to: "1"),
         .define("PB_ENABLE_MALLOC", to: "1"),

--- a/Package.swift
+++ b/Package.swift
@@ -42,27 +42,27 @@ let package = Package(
     ),
     .library(
       name: "FirebaseDatabase",
-      targets: ["FirebaseDatabase"]
+      targets: ["FirebaseDatabaseTarget"]
     ),
     .library(
       name: "FirebaseDynamicLinks",
-      targets: ["FirebaseDynamicLinks"]
+      targets: ["FirebaseDynamicLinksTarget"]
     ),
     .library(
       name: "FirebaseFirestore",
-      targets: ["FirebaseFirestore"]
+      targets: ["FirebaseFirestoreTarget"]
     ),
     .library(
       name: "FirebaseFirestoreSwift",
-      targets: ["FirebaseFirestoreSwift"]
+      targets: ["FirebaseFirestoreSwiftTarget"]
     ),
     .library(
       name: "FirebaseFunctions",
-      targets: ["FirebaseFunctions"]
+      targets: ["FirebaseFunctionsTarget"]
     ),
     .library(
       name: "FirebaseInAppMessaging-Beta",
-      targets: ["FirebaseInAppMessaging"]
+      targets: ["FirebaseInAppMessagingTarget"]
     ),
     .library(
       name: "FirebaseInstallations",
@@ -74,7 +74,7 @@ let package = Package(
     ),
     .library(
       name: "FirebaseRemoteConfig",
-      targets: ["FirebaseRemoteConfig"]
+      targets: ["FirebaseRemoteConfigTarget"]
     ),
     .library(
       name: "FirebaseStorage",
@@ -242,6 +242,7 @@ let package = Package(
       url: "https://dl.google.com/firebase/ios/swiftpm/6.34.0/GoogleAppMeasurement.zip",
       checksum: "05f6d2da2aa072781826be135498c6e1730ed43519c2232e01c5f043f5fe7189"
     ),
+
     .target(
       name: "FirebaseAuth",
       dependencies: ["FirebaseCore",
@@ -314,14 +315,14 @@ let package = Package(
     ),
 
     .target(
-      name: "FirebaseDatabase",
-      dependencies: [.target(name: "FirebaseDatabaseImpl",
+      name: "FirebaseDatabaseTarget",
+      dependencies: [.target(name: "FirebaseDatabase",
                              condition: .when(platforms: [.iOS, .tvOS, .macOS]))],
       path: "SwiftPM-PlatformExclude/FirebaseDatabaseWrap"
     ),
 
     .target(
-      name: "FirebaseDatabaseImpl",
+      name: "FirebaseDatabase",
       dependencies: [
         "FirebaseCore",
         "leveldb",
@@ -357,14 +358,14 @@ let package = Package(
     ),
 
     .target(
-      name: "FirebaseDynamicLinks",
-      dependencies: [.target(name: "FirebaseDynamicLinksImpl",
+      name: "FirebaseDynamicLinksTarget",
+      dependencies: [.target(name: "FirebaseDynamicLinks",
                              condition: .when(platforms: [.iOS]))],
       path: "SwiftPM-PlatformExclude/FirebaseDynamicLinksWrap"
     ),
 
     .target(
-      name: "FirebaseDynamicLinksImpl",
+      name: "FirebaseDynamicLinks",
       dependencies: ["FirebaseCore"],
       path: "FirebaseDynamicLinks/Sources",
       publicHeadersPath: "Public",
@@ -379,14 +380,14 @@ let package = Package(
     ),
 
     .target(
-      name: "FirebaseFirestore",
-      dependencies: [.target(name: "FirebaseFirestoreImpl",
+      name: "FirebaseFirestoreTarget",
+      dependencies: [.target(name: "FirebaseFirestore",
                              condition: .when(platforms: [.iOS, .tvOS, .macOS]))],
       path: "SwiftPM-PlatformExclude/FirebaseFirestoreWrap"
     ),
 
     .target(
-      name: "FirebaseFirestoreImpl",
+      name: "FirebaseFirestore",
       dependencies: [
         "FirebaseCore",
         "leveldb",
@@ -450,14 +451,14 @@ let package = Package(
     ),
 
     .target(
-      name: "FirebaseFirestoreSwift",
-      dependencies: [.target(name: "FirebaseFirestoreSwiftImpl",
+      name: "FirebaseFirestoreSwiftTarget",
+      dependencies: [.target(name: "FirebaseFirestoreSwift",
                              condition: .when(platforms: [.iOS, .tvOS, .macOS]))],
       path: "SwiftPM-PlatformExclude/FirebaseFirestoreSwiftWrap"
     ),
 
     .target(
-      name: "FirebaseFirestoreSwiftImpl",
+      name: "FirebaseFirestoreSwift",
       dependencies: ["FirebaseFirestore"],
       path: "Firestore",
       exclude: [
@@ -483,14 +484,14 @@ let package = Package(
     ),
 
     .target(
-      name: "FirebaseFunctions",
-      dependencies: [.target(name: "FirebaseFunctionsImpl",
+      name: "FirebaseFunctionsTarget",
+      dependencies: [.target(name: "FirebaseFunctions",
                              condition: .when(platforms: [.iOS, .tvOS, .macOS]))],
       path: "SwiftPM-PlatformExclude/FirebaseFunctionsWrap"
     ),
 
     .target(
-      name: "FirebaseFunctionsImpl",
+      name: "FirebaseFunctions",
       dependencies: [
         "FirebaseCore",
         .product(name: "GTMSessionFetcherCore", package: "GTMSessionFetcher"),
@@ -503,14 +504,14 @@ let package = Package(
     ),
 
     .target(
-      name: "FirebaseInAppMessaging",
-      dependencies: [.target(name: "FirebaseInAppMessagingImpl",
+      name: "FirebaseInAppMessagingTarget",
+      dependencies: [.target(name: "FirebaseInAppMessaging",
                              condition: .when(platforms: [.iOS]))],
       path: "SwiftPM-PlatformExclude/FirebaseInAppMessagingWrap"
     ),
 
     .target(
-      name: "FirebaseInAppMessagingImpl",
+      name: "FirebaseInAppMessaging",
       dependencies: [
         "FirebaseCore",
         "FirebaseInstallations",
@@ -603,14 +604,14 @@ let package = Package(
     ),
 
     .target(
-      name: "FirebaseRemoteConfig",
-      dependencies: [.target(name: "FirebaseRemoteConfigImpl",
+      name: "FirebaseRemoteConfigTarget",
+      dependencies: [.target(name: "FirebaseRemoteConfig",
                              condition: .when(platforms: [.iOS, .tvOS, .macOS]))],
       path: "SwiftPM-PlatformExclude/FirebaseRemoteConfigWrap"
     ),
 
     .target(
-      name: "FirebaseRemoteConfigImpl",
+      name: "FirebaseRemoteConfig",
       dependencies: [
         "FirebaseCore",
         "FirebaseABTesting",

--- a/SwiftPM-PlatformExclude/FirebaseAnalyticsWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseAnalyticsWrap/dummy.m
@@ -1,0 +1,4 @@
+#import <TargetConditionals.h>
+#if TARGET_OS_WATCH
+#warning "Firebase Analytics only supports the iOS platform"
+#endif

--- a/SwiftPM-PlatformExclude/FirebaseAnalyticsWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseAnalyticsWrap/dummy.m
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #import <TargetConditionals.h>
 #if TARGET_OS_WATCH
 #warning "Firebase Analytics only supports the iOS platform"

--- a/SwiftPM-PlatformExclude/FirebaseAnalyticsWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseAnalyticsWrap/dummy.m
@@ -13,6 +13,6 @@
 // limitations under the License.
 
 #import <TargetConditionals.h>
-#if TARGET_OS_WATCH
+#if !TARGET_OS_IOS
 #warning "Firebase Analytics only supports the iOS platform"
 #endif

--- a/SwiftPM-PlatformExclude/FirebaseAnalyticsWrap/include/dummy.h
+++ b/SwiftPM-PlatformExclude/FirebaseAnalyticsWrap/include/dummy.h
@@ -1,0 +1,15 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Prevent a missing umbrella header warning.

--- a/SwiftPM-PlatformExclude/FirebaseDatabaseWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseDatabaseWrap/dummy.m
@@ -1,0 +1,4 @@
+#import <TargetConditionals.h>
+#if TARGET_OS_WATCH
+#warning "Firebase Database does not support watchOS"
+#endif

--- a/SwiftPM-PlatformExclude/FirebaseDatabaseWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseDatabaseWrap/dummy.m
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #import <TargetConditionals.h>
 #if TARGET_OS_WATCH
 #warning "Firebase Database does not support watchOS"

--- a/SwiftPM-PlatformExclude/FirebaseDatabaseWrap/include/dummy.h
+++ b/SwiftPM-PlatformExclude/FirebaseDatabaseWrap/include/dummy.h
@@ -1,0 +1,15 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Prevent a missing umbrella header warning.

--- a/SwiftPM-PlatformExclude/FirebaseDynamicLinksWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseDynamicLinksWrap/dummy.m
@@ -1,0 +1,4 @@
+#import <TargetConditionals.h>
+#if !TARGET_OS_IOS
+#warning "Firebase Dynamic Links only supports the iOS platform"
+#endif

--- a/SwiftPM-PlatformExclude/FirebaseDynamicLinksWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseDynamicLinksWrap/dummy.m
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #import <TargetConditionals.h>
 #if !TARGET_OS_IOS
 #warning "Firebase Dynamic Links only supports the iOS platform"

--- a/SwiftPM-PlatformExclude/FirebaseDynamicLinksWrap/include/dummy.h
+++ b/SwiftPM-PlatformExclude/FirebaseDynamicLinksWrap/include/dummy.h
@@ -1,0 +1,15 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Prevent a missing umbrella header warning.

--- a/SwiftPM-PlatformExclude/FirebaseFirestoreSwiftWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseFirestoreSwiftWrap/dummy.m
@@ -1,0 +1,4 @@
+#import <TargetConditionals.h>
+#if TARGET_OS_WATCH
+#warning "Firebase FirestoreSwift does not support watchOS"
+#endif

--- a/SwiftPM-PlatformExclude/FirebaseFirestoreSwiftWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseFirestoreSwiftWrap/dummy.m
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #import <TargetConditionals.h>
 #if TARGET_OS_WATCH
 #warning "Firebase FirestoreSwift does not support watchOS"

--- a/SwiftPM-PlatformExclude/FirebaseFirestoreSwiftWrap/include/dummy.h
+++ b/SwiftPM-PlatformExclude/FirebaseFirestoreSwiftWrap/include/dummy.h
@@ -1,0 +1,15 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Prevent a missing umbrella header warning.

--- a/SwiftPM-PlatformExclude/FirebaseFirestoreWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseFirestoreWrap/dummy.m
@@ -1,0 +1,4 @@
+#import <TargetConditionals.h>
+#if TARGET_OS_WATCH
+#warning "Firebase Firestore does not support watchOS"
+#endif

--- a/SwiftPM-PlatformExclude/FirebaseFirestoreWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseFirestoreWrap/dummy.m
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #import <TargetConditionals.h>
 #if TARGET_OS_WATCH
 #warning "Firebase Firestore does not support watchOS"

--- a/SwiftPM-PlatformExclude/FirebaseFirestoreWrap/include/dummy.h
+++ b/SwiftPM-PlatformExclude/FirebaseFirestoreWrap/include/dummy.h
@@ -1,0 +1,18 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <TargetConditionals.h>
+#if TARGET_OS_WATCH
+#warning "Firebase Firestore does not support watchOS"
+#endif

--- a/SwiftPM-PlatformExclude/FirebaseFunctionsWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseFunctionsWrap/dummy.m
@@ -1,0 +1,4 @@
+#import <TargetConditionals.h>
+#if TARGET_OS_WATCH
+#warning "Firebase Functions does not support watchOS"
+#endif

--- a/SwiftPM-PlatformExclude/FirebaseFunctionsWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseFunctionsWrap/dummy.m
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #import <TargetConditionals.h>
 #if TARGET_OS_WATCH
 #warning "Firebase Functions does not support watchOS"

--- a/SwiftPM-PlatformExclude/FirebaseFunctionsWrap/include/dummy.h
+++ b/SwiftPM-PlatformExclude/FirebaseFunctionsWrap/include/dummy.h
@@ -1,0 +1,15 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Prevent a missing umbrella header warning.

--- a/SwiftPM-PlatformExclude/FirebaseInAppMessagingWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseInAppMessagingWrap/dummy.m
@@ -1,0 +1,4 @@
+#import <TargetConditionals.h>
+#if !TARGET_OS_IOS
+#warning "Firebase In App Messaging only supports the iOS platform"
+#endif

--- a/SwiftPM-PlatformExclude/FirebaseInAppMessagingWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseInAppMessagingWrap/dummy.m
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #import <TargetConditionals.h>
 #if !TARGET_OS_IOS
 #warning "Firebase In App Messaging only supports the iOS platform"

--- a/SwiftPM-PlatformExclude/FirebaseInAppMessagingWrap/include/dummy.h
+++ b/SwiftPM-PlatformExclude/FirebaseInAppMessagingWrap/include/dummy.h
@@ -1,0 +1,15 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Prevent a missing umbrella header warning.

--- a/SwiftPM-PlatformExclude/FirebaseRemoteConfigWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseRemoteConfigWrap/dummy.m
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #import <TargetConditionals.h>
 #if TARGET_OS_WATCH
 #warning "Firebase Remote Config does not support watchOS"

--- a/SwiftPM-PlatformExclude/FirebaseRemoteConfigWrap/dummy.m
+++ b/SwiftPM-PlatformExclude/FirebaseRemoteConfigWrap/dummy.m
@@ -1,0 +1,4 @@
+#import <TargetConditionals.h>
+#if TARGET_OS_WATCH
+#warning "Firebase Remote Config does not support watchOS"
+#endif

--- a/SwiftPM-PlatformExclude/FirebaseRemoteConfigWrap/include/dummy.h
+++ b/SwiftPM-PlatformExclude/FirebaseRemoteConfigWrap/include/dummy.h
@@ -1,0 +1,15 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Prevent a missing umbrella header warning.

--- a/SwiftPackageManager.md
+++ b/SwiftPackageManager.md
@@ -12,7 +12,7 @@ Package Manager](https://swift.org/package-manager/) in Beta status.
 - Analytics requires clients to add `-ObjC` linker option.
 - Analytics is only supported for iOS and cannot be used in apps that support other platforms.
 - Messaging, Performance, Firebase ML, and App Distribution are not initially available.
-- watchOS support is not initially available.
+- watchOS support is introduced in 7.0.0 for Auth, Crashlytics, Messaging, and Storage.
 
 ## Installation
 


### PR DESCRIPTION
Fix #6584 

This seems to work for building along with a build warning if a product is selected that doesn't support watchOS.

Testing is an open question since XCTest is not supported and the SPM `.testTarget` automatically tries to link XCTest and fails even if XCTest is not used.

Also manually confirmed the Analytics, Storage, and Firestore quickstarts still run for iOS with SPM.