### PR TITLE
s/withMaxResults/maxResults

### DIFF
--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,10 +1,10 @@
-# Unreleased
-- [fixed] Fixed an issue with the List API that prevented listing of locations
-  that contain the "+" sign.
-
 # 7.0.0
 - [changed] The global variable `FIRStorageVersionString` is deleted.
   `FirebaseVersion()` or `FIRFirebaseVersion()` should be used instead.
+- [fixed] Fixed an issue with the List API that prevented listing of locations
+  that contain the "+" sign.
+- [changed] Renamed `list(withMaxResults:)` to `list(maxResults:)` in the Swift
+  API.
 
 # 3.8.1
 - [fixed] Fixed typo in doc comments (#6485).

--- a/FirebaseStorage/Sources/Public/FirebaseStorage/FIRStorageReference.h
+++ b/FirebaseStorage/Sources/Public/FirebaseStorage/FIRStorageReference.h
@@ -277,7 +277,6 @@ NS_SWIFT_NAME(putData(_:metadata:));
                 completion:
                     (void (^)(FIRStorageListResult *result, NSError *_Nullable error))completion
     NS_SWIFT_NAME(list(maxResults:pageToken:completion:));
-;
 
 #pragma mark - Metadata Operations
 

--- a/FirebaseStorage/Sources/Public/FirebaseStorage/FIRStorageReference.h
+++ b/FirebaseStorage/Sources/Public/FirebaseStorage/FIRStorageReference.h
@@ -252,7 +252,8 @@ NS_SWIFT_NAME(putData(_:metadata:));
  */
 - (void)listWithMaxResults:(int64_t)maxResults
                 completion:
-                    (void (^)(FIRStorageListResult *result, NSError *_Nullable error))completion;
+                    (void (^)(FIRStorageListResult *result, NSError *_Nullable error))completion
+    NS_SWIFT_NAME(list(maxResults:completion:));
 
 /**
  * Resumes a previous call to list(maxResults:completion:)`, starting after a pagination token.
@@ -274,7 +275,9 @@ NS_SWIFT_NAME(putData(_:metadata:));
 - (void)listWithMaxResults:(int64_t)maxResults
                  pageToken:(NSString *)pageToken
                 completion:
-                    (void (^)(FIRStorageListResult *result, NSError *_Nullable error))completion;
+                    (void (^)(FIRStorageListResult *result, NSError *_Nullable error))completion
+    NS_SWIFT_NAME(list(maxResults:pageToken:completion:));
+;
 
 #pragma mark - Metadata Operations
 

--- a/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
@@ -711,7 +711,7 @@ class StorageIntegration: XCTestCase {
     let expectation = self.expectation(description: #function)
     let ref = storage.reference(withPath: "ios/public/list")
 
-    ref.list(withMaxResults: 2, completion: { listResult, error in
+    ref.list(maxResults: 2) { listResult, error in
       XCTAssertNotNil(listResult, "listResult should not be nil")
       XCTAssertNil(error, "Error should be nil")
 
@@ -721,7 +721,7 @@ class StorageIntegration: XCTestCase {
         XCTFail("pageToken should not be nil")
         return
       }
-      ref.list(withMaxResults: 2, pageToken: pageToken, completion: { listResult, error in
+      ref.list(maxResults: 2, pageToken: pageToken) { listResult, error in
         XCTAssertNotNil(listResult, "listResult should not be nil")
         XCTAssertNil(error, "Error should be nil")
 
@@ -729,8 +729,8 @@ class StorageIntegration: XCTestCase {
         XCTAssertEqual(listResult.prefixes, [ref.child("prefix")])
         XCTAssertNil(listResult.pageToken, "pageToken should be nil")
         expectation.fulfill()
-      })
-    })
+      }
+    }
     waitForExpectations()
   }
 
@@ -738,14 +738,14 @@ class StorageIntegration: XCTestCase {
     let expectation = self.expectation(description: #function)
     let ref = storage.reference(withPath: "ios/public/list")
 
-    ref.listAll(completion: { listResult, error in
+    ref.listAll() { listResult, error in
       XCTAssertNotNil(listResult, "listResult should not be nil")
       XCTAssertNil(error, "Error should be nil")
       XCTAssertEqual(listResult.items, [ref.child("a"), ref.child("b")])
       XCTAssertEqual(listResult.prefixes, [ref.child("prefix")])
       XCTAssertNil(listResult.pageToken, "pageToken should be nil")
       expectation.fulfill()
-    })
+    }
     waitForExpectations()
   }
 

--- a/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
+++ b/FirebaseStorage/Tests/SwiftIntegration/StorageIntegration.swift
@@ -738,7 +738,7 @@ class StorageIntegration: XCTestCase {
     let expectation = self.expectation(description: #function)
     let ref = storage.reference(withPath: "ios/public/list")
 
-    ref.listAll() { listResult, error in
+    ref.listAll { listResult, error in
       XCTAssertNotNil(listResult, "listResult should not be nil")
       XCTAssertNil(error, "Error should be nil")
       XCTAssertEqual(listResult.items, [ref.child("a"), ref.child("b")])

--- a/FirebaseStorageSwift/Sources/SwiftAPIExtension.swift
+++ b/FirebaseStorageSwift/Sources/SwiftAPIExtension.swift
@@ -86,16 +86,16 @@ public extension StorageReference {
   /// Only available for projects using Firebase Rules Version 2.
   ///
   /// - Parameters:
-  ///   - withMaxResults The maximum number of results to return in a single page. Must be
-  ///                    greater than 0 and at most 1000.
+  ///   - maxResults The maximum number of results to return in a single page. Must be
+  ///                greater than 0 and at most 1000.
   ///   - pageToken A page token from a previous call to list.
   ///   - completion A completion handler that will be invoked with the next items and
   ///                prefixes under the current StorageReference. It returns a `Result` enum
   ///                with either the list or an `Error`.
-  func list(withMaxResults maxResults: Int64,
+  func list(maxResults: Int64,
             pageToken: String,
             completion: @escaping (Result<StorageListResult, Error>) -> Void) {
-    list(withMaxResults: maxResults,
+    list(maxResults: maxResults,
          pageToken: pageToken,
          completion: getResultCallback(completion: completion))
   }
@@ -109,14 +109,14 @@ public extension StorageReference {
   /// Only available for projects using Firebase Rules Version 2.
   ///
   /// - Parameters:
-  ///   - withMaxResults The maximum number of results to return in a single page. Must be
-  ///                    greater than 0 and at most 1000.
+  ///   - maxResults The maximum number of results to return in a single page. Must be
+  ///                greater than 0 and at most 1000.
   ///   - completion A completion handler that will be invoked with the next items and
   ///                prefixes under the current `StorageReference`. It returns a `Result` enum
   ///                with either the list or an `Error`.
-  func list(withMaxResults maxResults: Int64,
+  func list(maxResults: Int64,
             completion: @escaping (Result<StorageListResult, Error>) -> Void) {
-    list(withMaxResults: maxResults,
+    list(maxResults: maxResults,
          completion: getResultCallback(completion: completion))
   }
 

--- a/FirebaseStorageSwift/Tests/Integration/StorageIntegration.swift
+++ b/FirebaseStorageSwift/Tests/Integration/StorageIntegration.swift
@@ -541,7 +541,7 @@ class StorageIntegration: XCTestCase {
     let expectation = self.expectation(description: #function)
     let ref = storage.reference(withPath: "ios/public/list")
 
-    ref.list(withMaxResults: 2) { result in
+    ref.list(maxResults: 2) { result in
       switch result {
       case let .success(listResult):
         XCTAssertEqual(listResult.items, [ref.child("a"), ref.child("b")])
@@ -551,7 +551,7 @@ class StorageIntegration: XCTestCase {
           expectation.fulfill()
           return
         }
-        ref.list(withMaxResults: 2, pageToken: pageToken) { result in
+        ref.list(maxResults: 2, pageToken: pageToken) { result in
           switch result {
           case let .success(listResult):
             XCTAssertEqual(listResult.items, [])


### PR DESCRIPTION
Feel free to push back, but it would be nice to align this name with `data(maxSize)`.