### PR TITLE
Don't allow logger version deallocation

### DIFF
--- a/FirebaseCore/Sources/FIRLogger.m
+++ b/FirebaseCore/Sources/FIRLogger.m
@@ -58,7 +58,7 @@ static NSRegularExpression *sMessageCodeRegex;
 void FIRLoggerInitializeASL() {
   dispatch_once(&sFIRLoggerOnceToken, ^{
     // Register Firebase Version with GULLogger.
-    GULLoggerRegisterVersion([FIRFirebaseVersion() UTF8String]);
+    GULLoggerRegisterVersion(FIRFirebaseVersion());
 
     // Override the aslOptions to ASL_OPT_STDERR if the override argument is passed in.
     NSArray *arguments = [NSProcessInfo processInfo].arguments;

--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -33,7 +33,7 @@ static BOOL sGULLoggerDebugMode;
 static GULLoggerLevel sGULLoggerMaximumLevel;
 
 // Allow clients to register a version to include in the log.
-static const char *sVersion = "";
+static NSString *sVersion = @"";
 
 static GULLoggerService kGULLoggerLogger = @"[GULLogger]";
 
@@ -139,7 +139,7 @@ BOOL getGULLoggerDebugMode() {
 }
 #endif
 
-void GULLoggerRegisterVersion(const char *version) {
+void GULLoggerRegisterVersion(NSString *version) {
   sVersion = version;
 }
 
@@ -168,7 +168,7 @@ void GULLogBasic(GULLoggerLevel level,
   } else {
     logMsg = [[NSString alloc] initWithFormat:message arguments:args_ptr];
   }
-  logMsg = [NSString stringWithFormat:@"%s - %@[%@] %@", sVersion, service, messageCode, logMsg];
+  logMsg = [NSString stringWithFormat:@"%@ - %@[%@] %@", sVersion, service, messageCode, logMsg];
   dispatch_async(sGULClientQueue, ^{
     asl_log(sGULLoggerClient, NULL, (int)level, "%s", logMsg.UTF8String);
   });

--- a/GoogleUtilities/Logger/Public/GoogleUtilities/GULLogger.h
+++ b/GoogleUtilities/Logger/Public/GoogleUtilities/GULLogger.h
@@ -61,7 +61,7 @@ extern BOOL GULIsLoggableLevel(GULLoggerLevel loggerLevel);
  * Register version to include in logs.
  * (required) version
  */
-extern void GULLoggerRegisterVersion(const char *version);
+extern void GULLoggerRegisterVersion(NSString *version);
 
 /**
  * Logs a message to the Xcode console and the device log. If running from AppStore, will


### PR DESCRIPTION
The logger was printing random strings because of the C string got deallocated.

This change uses a properly retained NSString instead and I verified the issue is fixed in the Analytics quickstart