### PR TITLE
GDT: wrap and bind upload operation using promises

### DIFF
--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
@@ -85,7 +85,7 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
                     conditions:(GDTCORUploadConditions)conditions
                      uploadURL:(NSURL *)uploadURL
                          queue:(dispatch_queue_t)queue
-                       storage:(id<GDTCORStoragePromiseProtocol>) storage
+                       storage:(id<GDTCORStoragePromiseProtocol>)storage
               metadataProvider:(id<GDTCCTUploadMetadataProvider>)metadataProvider {
   self = [super init];
   if (self) {

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploadOperation.m
@@ -16,9 +16,12 @@
 
 #import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploadOperation.h"
 
+#import <FBLPromises/FBLPromises.h>
+
 #import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCORPlatform.h"
 #import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCORRegistrar.h"
 #import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCORStorageProtocol.h"
+#import "GoogleDataTransport/GDTCORLibrary/Private/GDTCORUploadBatch.h"
 #import "GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCORConsoleLogger.h"
 #import "GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCOREvent.h"
 
@@ -120,41 +123,62 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
                   }
                 }];
 
-  dispatch_async(_uploaderQueue, ^{
-    id<GDTCORStorageProtocol> storage = GDTCORStorageInstanceForTarget(target);
+  id<GDTCORStoragePromiseProtocol> storage = GDTCORStoragePromiseInstanceForTarget(target);
 
-    // 1. Fetch events to upload.
-    [self batchToUploadForTarget:target
-                         storage:storage
-                      conditions:conditions
-                      completion:^(NSNumber *_Nullable batchID,
-                                   NSSet<GDTCOREvent *> *_Nullable events) {
-                        // 2. Check if there are events to upload.
-                        if (!events || events.count == 0) {
-                          dispatch_async(self.uploaderQueue, ^{
-                            GDTCORLogDebug(@"Target %ld reported as ready for upload, but no "
-                                           @"events were selected",
-                                           (long)target);
-                            self.isCurrentlyUploading = NO;
-                            backgroundTaskCompletion();
-                          });
+  // 1. Check if the conditions for the target are suitable.
+  [self isReadyToUploadTarget:target conditions:conditions]
+      .thenOn(self.uploaderQueue,
+              ^id(id result) {
+                // 2. Remove previously attempted batches
+                return [storage removeAllBatchesForTarget:target deleteEvents:NO];
+              })
+      .thenOn(self.uploaderQueue,
+              ^FBLPromise<NSNumber *> *(id result) {
+                // There may be a big amount of events stored, so creating a batch may be an
+                // expensive operation.
 
-                          return;
-                        }
-                        // 3. Upload events.
-                        [self uploadBatchWithID:batchID
-                                         events:events
-                                         target:target
-                                        storage:storage
-                                     completion:^{
-                                       [self finishOperation];
-                                       backgroundTaskCompletion();
-                                     }];
-                      }];
-  });
+                // 3. Do a lightweight check if there are any events for the target first to
+                // finish early if there are no.
+                return [storage hasEventsForTarget:target];
+              })
+      .validateOn(self.uploaderQueue,
+                  ^BOOL(NSNumber *hasEvents) {
+                    // Stop operation if there are no events to upload.
+                    return hasEvents.boolValue;
+                  })
+      .thenOn(self.uploaderQueue,
+              ^FBLPromise<GDTCORUploadBatch *> *(id result) {
+                // 4. Fetch events to upload.
+                GDTCORStorageEventSelector *eventSelector = [self eventSelectorTarget:target
+                                                                       withConditions:conditions];
+                return [storage batchWithEventSelector:eventSelector
+                                       batchExpiration:[NSDate dateWithTimeIntervalSinceNow:600]];
+              })
+      .thenOn(self.uploaderQueue, ^FBLPromise *(GDTCORUploadBatch *batch) {
+        // 5. Perform upload URL request.
+        return [self sendURLRequestWithBatchID:batch.batchID
+                                        events:batch.events
+                                        target:target
+                                       storage:storage];
+      });
 }
 
 #pragma mark - Upload implementation details
+
+- (FBLPromise<NSNull *> *)sendURLRequestWithBatchID:(nullable NSNumber *)batchID
+                                             events:(nullable NSSet<GDTCOREvent *> *)events
+                                             target:(GDTCORTarget)target
+                                            storage:(id<GDTCORStorageProtocol>)storage {
+  // TODO: Break down upload operation on stages with promises.
+  return [FBLPromise onQueue:self.uploaderQueue
+              wrapCompletion:^(FBLPromiseCompletion _Nonnull handler) {
+                [self uploadBatchWithID:batchID
+                                 events:events
+                                 target:target
+                                storage:storage
+                             completion:handler];
+              }];
+}
 
 /** Performs URL request, handles the result and updates the uploader state. */
 - (void)uploadBatchWithID:(nullable NSNumber *)batchID
@@ -266,104 +290,27 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
   self.currentTask = nil;
 }
 
-#pragma mark - Stored events upload
-
-/** Fetches a batch of pending events for the specified target and conditions. Passes `nil` to
- * completion if there are no suitable events to upload. */
-- (void)batchToUploadForTarget:(GDTCORTarget)target
-                       storage:(id<GDTCORStorageProtocol>)storage
-                    conditions:(GDTCORUploadConditions)conditions
-                    completion:(GDTCCTUploaderEventBatchBlock)completion {
-  // 1. Check if the conditions for the target are suitable.
-  if (![self readyToUploadTarget:target conditions:conditions]) {
-    completion(nil, nil);
-    return;
-  }
-
-  // 2. Remove previously attempted batches
-  [self removeBatchesForTarget:target
-                       storage:storage
-                    onComplete:^{
-                      // There may be a big amount of events stored, so creating a batch may be an
-                      // expensive operation.
-
-                      // 3. Do a lightweight check if there are any events for the target first to
-                      // finish early if there are no.
-                      [storage hasEventsForTarget:target
-                                       onComplete:^(BOOL hasEvents) {
-                                         // 4. Proceed with fetching the events.
-                                         [self batchToUploadForTarget:target
-                                                              storage:storage
-                                                           conditions:conditions
-                                                            hasEvents:hasEvents
-                                                           completion:completion];
-                                       }];
-                    }];
-}
-
-/** Makes final checks before and makes */
-- (void)batchToUploadForTarget:(GDTCORTarget)target
-                       storage:(id<GDTCORStorageProtocol>)storage
-                    conditions:(GDTCORUploadConditions)conditions
-                     hasEvents:(BOOL)hasEvents
-                    completion:(GDTCCTUploaderEventBatchBlock)completion {
-  dispatch_async(self.uploaderQueue, ^{
-    if (!hasEvents) {
-      // No events to upload.
-      completion(nil, nil);
-      return;
-    }
-
-    // Check if the conditions are still met before starting upload.
-    if (![self readyToUploadTarget:target conditions:conditions]) {
-      completion(nil, nil);
-      return;
-    }
-
-    // All conditions have been checked and met. Lock uploader for this target to prevent other
-    // targets upload attempts.
-    self.isCurrentlyUploading = YES;
-
-    // Fetch a batch to upload and pass along.
-    GDTCORStorageEventSelector *eventSelector = [self eventSelectorTarget:target
-                                                           withConditions:conditions];
-    [storage batchWithEventSelector:eventSelector
-                    batchExpiration:[NSDate dateWithTimeIntervalSinceNow:600]
-                         onComplete:completion];
-  });
-}
-
-- (void)removeBatchesForTarget:(GDTCORTarget)target
-                       storage:(id<GDTCORStorageProtocol>)storage
-                    onComplete:(dispatch_block_t)onComplete {
-  [storage batchIDsForTarget:target
-                  onComplete:^(NSSet<NSNumber *> *_Nullable batchIDs) {
-                    // No stored batches, no need to remove anything.
-                    if (batchIDs.count < 1) {
-                      onComplete();
-                      return;
-                    }
-
-                    dispatch_group_t dispatchGroup = dispatch_group_create();
-                    for (NSNumber *batchID in batchIDs) {
-                      dispatch_group_enter(dispatchGroup);
-
-                      // Remove batches and moves events back to the storage.
-                      [storage removeBatchWithID:batchID
-                                    deleteEvents:NO
-                                      onComplete:^{
-                                        dispatch_group_leave(dispatchGroup);
-                                      }];
-                    }
-
-                    // Wait until all batches are removed and call completion handler.
-                    dispatch_group_notify(dispatchGroup, self.uploaderQueue, ^{
-                      onComplete();
-                    });
-                  }];
-}
-
 #pragma mark - Private helper methods
+
+/** @return A resolved promise if is ready and a rejected promise if not. */
+- (FBLPromise<NSNull *> *)isReadyToUploadTarget:(GDTCORTarget)target
+                                     conditions:(GDTCORUploadConditions)conditions {
+  FBLPromise<NSNull *> *promise = [FBLPromise pendingPromise];
+  if ([self readyToUploadTarget:target conditions:conditions]) {
+    [promise fulfill:[NSNull null]];
+  } else {
+    // TODO: Do we need a more comprehensive message here?
+    [promise reject:[self genericRejectedPromiseErrorWithReason:@"Is not ready."]];
+  }
+  return promise;
+}
+
+// TODO: Move to a separate class/extension/file.
+- (NSError *)genericRejectedPromiseErrorWithReason:(NSString *)reason {
+  return [NSError errorWithDomain:@"GDTCCTUploader"
+                             code:-1
+                         userInfo:@{NSLocalizedFailureReasonErrorKey : reason}];
+}
 
 /** */
 - (BOOL)readyToUploadTarget:(GDTCORTarget)target conditions:(GDTCORUploadConditions)conditions {

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader2.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader2.m
@@ -239,8 +239,8 @@ NSNotificationName const GDTCCTUploadCompleteNotification = @"com.GDTCCTUploader
 
 #if !NDEBUG
 
-- (void)waitForUploadFinished {
-  [self.uploadOperationQueue waitUntilAllOperationsAreFinished];
+- (void)waitForUploadFinished:(dispatch_block_t)completion {
+  [self.uploadOperationQueue addOperationWithBlock:completion];
 }
 
 #endif  // !NDEBUG

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader2.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader2.m
@@ -16,10 +16,10 @@
 
 #import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploader.h"
 
+#import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCORPlatform.h"
+#import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCORRegistrar.h"
 #import "GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCORConsoleLogger.h"
 #import "GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCOREvent.h"
-#import "GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCORPlatform.h"
-#import "GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCORRegistrar.h"
 
 #import "GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploadOperation.h"
 

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader2.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader2.m
@@ -82,11 +82,18 @@ NSNotificationName const GDTCCTUploadCompleteNotification = @"com.GDTCCTUploader
   // 2. Notify the client of upload stages
   // 3. Allow the client cancelling upload requests as needed.
 
+  id<GDTCORStoragePromiseProtocol> storage = GDTCORStoragePromiseInstanceForTarget(target);
+  if (storage == nil) {
+    GDTCORLogError(GDTCORMCEGeneralError, @"Failed to upload target: %ld - could not find corresponding storage instance.", (long)target);
+    return;
+  }
+
   GDTCCTUploadOperation *uploadOperation =
       [[GDTCCTUploadOperation alloc] initWithTarget:target
                                          conditions:conditions
                                           uploadURL:[self serverURLForTarget:target]
                                               queue:self.uploadQueue
+                                            storage:storage
                                    metadataProvider:self];
 
   __weak __auto_type weakSelf = self;

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader2.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader2.m
@@ -96,7 +96,21 @@ NSNotificationName const GDTCCTUploadCompleteNotification = @"com.GDTCCTUploader
     if (weakOperation.uploadAttempted) {
       // Ignore all upload requests received when the upload was in progress.
       [weakSelf.uploadOperationQueue cancelAllOperations];
+
+      // TODO: Should we reconsider GDTCCTUploadCompleteNotification? Maybe a completion handler
+      // instead?
+#if !NDEBUG
+      [[NSNotificationCenter defaultCenter] postNotificationName:GDTCCTUploadCompleteNotification
+                                                          object:nil];
+#endif  // #if !NDEBUG
     }
+
+#if !NDEBUG
+    if (weakSelf.uploadOperationQueue.operationCount == 0) {
+      [[NSNotificationCenter defaultCenter] postNotificationName:GDTCCTUploadCompleteNotification
+                                                          object:nil];
+    }
+#endif  // #if !NDEBUG
   };
 
   [self.uploadOperationQueue addOperation:uploadOperation];
@@ -222,6 +236,14 @@ NSNotificationName const GDTCCTUploadCompleteNotification = @"com.GDTCCTUploader
 
   return nil;
 }
+
+#if !NDEBUG
+
+- (void)waitForUploadFinished {
+  [self.uploadOperationQueue waitUntilAllOperationsAreFinished];
+}
+
+#endif  // !NDEBUG
 
 @end
 

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader2.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader2.m
@@ -84,7 +84,9 @@ NSNotificationName const GDTCCTUploadCompleteNotification = @"com.GDTCCTUploader
 
   id<GDTCORStoragePromiseProtocol> storage = GDTCORStoragePromiseInstanceForTarget(target);
   if (storage == nil) {
-    GDTCORLogError(GDTCORMCEGeneralError, @"Failed to upload target: %ld - could not find corresponding storage instance.", (long)target);
+    GDTCORLogError(GDTCORMCEGeneralError,
+                   @"Failed to upload target: %ld - could not find corresponding storage instance.",
+                   (long)target);
     return;
   }
 

--- a/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploadOperation.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploadOperation.h
@@ -16,7 +16,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCORUploader.h"
+#import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCORUploader.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploadOperation.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploadOperation.h
@@ -45,6 +45,7 @@ extern NSNotificationName const GDTCCTUploadCompleteNotification;
                     conditions:(GDTCORUploadConditions)conditions
                      uploadURL:(NSURL *)uploadURL
                          queue:(dispatch_queue_t)queue
+                       storage:(id<GDTCORStoragePromiseProtocol>)storage
               metadataProvider:(id<GDTCCTUploadMetadataProvider>)metadataProvider;
 
 /** YES if a batch upload attempt was performed. NO otherwise. If NO for the finished operation,

--- a/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploader.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploader.h
@@ -38,7 +38,7 @@ extern NSNotificationName const GDTCCTUploadCompleteNotification;
 /** An upload URL used across all targets. For testing only. */
 @property(nullable, nonatomic) NSURL *testServerURL;
 
-- (void)waitForUploadFinished;
+- (void)waitForUploadFinished:(dispatch_block_t)completion;
 
 #endif  // !NDEBUG
 

--- a/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploader.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploader.h
@@ -38,6 +38,8 @@ extern NSNotificationName const GDTCCTUploadCompleteNotification;
 /** An upload URL used across all targets. For testing only. */
 @property(nullable, nonatomic) NSURL *testServerURL;
 
+- (void)waitForUploadFinished;
+
 #endif  // !NDEBUG
 
 @end

--- a/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploader.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploader.h
@@ -20,6 +20,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+// TODO: Try to avoid NDEBUG as it is not covered by tests on CI.
 #if !NDEBUG
 /** A notification fired when uploading is complete, detailing the number of events uploaded. */
 extern NSNotificationName const GDTCCTUploadCompleteNotification;

--- a/GoogleDataTransport/GDTCCTTests/Common/TestStorage/GDTCCTTestStorage.h
+++ b/GoogleDataTransport/GDTCCTTests/Common/TestStorage/GDTCCTTestStorage.h
@@ -30,7 +30,7 @@ typedef void (^GDTCCTTestStorageHasEventsHandler)(GDTCORTarget target,
                                                   GDTCCTTestStorageHasEventsCompletion completion);
 
 // TODO: Add GDTCORStoragePromiseProtocol support to fix tests.
-@interface GDTCCTTestStorage : NSObject <GDTCORStorageProtocol>
+@interface GDTCCTTestStorage : NSObject <GDTCORStoragePromiseProtocol>
 
 #pragma mark - Method call expectations.
 

--- a/GoogleDataTransport/GDTCCTTests/Common/TestStorage/GDTCCTTestStorage.h
+++ b/GoogleDataTransport/GDTCCTTests/Common/TestStorage/GDTCCTTestStorage.h
@@ -29,6 +29,7 @@ typedef void (^GDTCCTTestStorageHasEventsCompletion)(BOOL hasEvents);
 typedef void (^GDTCCTTestStorageHasEventsHandler)(GDTCORTarget target,
                                                   GDTCCTTestStorageHasEventsCompletion completion);
 
+// TODO: Add GDTCORStoragePromiseProtocol support to fix tests.
 @interface GDTCCTTestStorage : NSObject <GDTCORStorageProtocol>
 
 #pragma mark - Method call expectations.

--- a/GoogleDataTransport/GDTCCTTests/Common/TestStorage/GDTCCTTestStorage.m
+++ b/GoogleDataTransport/GDTCCTTests/Common/TestStorage/GDTCCTTestStorage.m
@@ -16,8 +16,8 @@
 
 #import "GoogleDataTransport/GDTCCTTests/Common/TestStorage/GDTCCTTestStorage.h"
 
-#import "GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCOREvent.h"
 #import "GoogleDataTransport/GDTCORLibrary/Private/GDTCORUploadBatch.h"
+#import "GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCOREvent.h"
 
 #import <FBLPromises/FBLPromises.h>
 
@@ -146,14 +146,14 @@
 
 - (FBLPromise<NSSet<NSNumber *> *> *)batchIDsForTarget:(GDTCORTarget)target {
   return [FBLPromise wrapObjectCompletion:^(FBLPromiseObjectCompletion _Nonnull handler) {
-          [self batchIDsForTarget:target onComplete:handler];
-        }];
+    [self batchIDsForTarget:target onComplete:handler];
+  }];
 }
 
 - (FBLPromise<NSNull *> *)removeBatchWithID:(NSNumber *)batchID deleteEvents:(BOOL)deleteEvents {
   return [FBLPromise wrapCompletion:^(FBLPromiseCompletion _Nonnull handler) {
-                [self removeBatchWithID:batchID deleteEvents:deleteEvents onComplete:handler];
-              }];
+    [self removeBatchWithID:batchID deleteEvents:deleteEvents onComplete:handler];
+  }];
 }
 
 - (FBLPromise<NSNull *> *)removeBatchesWithIDs:(NSSet<NSNumber *> *)batchIDs
@@ -164,44 +164,42 @@
     [removeBatchPromises addObject:[self removeBatchWithID:batchID deleteEvents:deleteEvents]];
   }
 
-  return [FBLPromise all:[removeBatchPromises copy]].then(
-      ^id(id result) {
-        return [FBLPromise resolvedWith:[NSNull null]];
-      });
+  return [FBLPromise all:[removeBatchPromises copy]].then(^id(id result) {
+    return [FBLPromise resolvedWith:[NSNull null]];
+  });
 }
 
 - (FBLPromise<NSNull *> *)removeAllBatchesForTarget:(GDTCORTarget)target
                                        deleteEvents:(BOOL)deleteEvents {
-  return
-      [self batchIDsForTarget:target].then(^id(NSSet<NSNumber *> *batchIDs) {
-        return [self removeBatchesWithIDs:batchIDs deleteEvents:NO];
-      });
+  return [self batchIDsForTarget:target].then(^id(NSSet<NSNumber *> *batchIDs) {
+    return [self removeBatchesWithIDs:batchIDs deleteEvents:NO];
+  });
 }
 
 - (FBLPromise<NSNumber *> *)hasEventsForTarget:(GDTCORTarget)target {
   return [FBLPromise wrapBoolCompletion:^(FBLPromiseBoolCompletion _Nonnull handler) {
-            [self hasEventsForTarget:target onComplete:handler];
-          }];
+    [self hasEventsForTarget:target onComplete:handler];
+  }];
 }
 
 - (FBLPromise<GDTCORUploadBatch *> *)batchWithEventSelector:
                                          (GDTCORStorageEventSelector *)eventSelector
                                             batchExpiration:(NSDate *)expiration {
   return [FBLPromise
-        async:^(FBLPromiseFulfillBlock _Nonnull fulfill, FBLPromiseRejectBlock _Nonnull reject) {
-          [self batchWithEventSelector:eventSelector
-                       batchExpiration:expiration
-                            onComplete:^(NSNumber *_Nullable newBatchID,
-                                         NSSet<GDTCOREvent *> *_Nullable batchEvents) {
-                              if (newBatchID == nil || batchEvents == nil) {
-                                reject([self genericRejectedPromiseErrorWithReason:
-                                                 @"There are no events for the selector."]);
-                              } else {
-                                fulfill([[GDTCORUploadBatch alloc] initWithBatchID:newBatchID
-                                                                            events:batchEvents]);
-                              }
-                            }];
-        }];
+      async:^(FBLPromiseFulfillBlock _Nonnull fulfill, FBLPromiseRejectBlock _Nonnull reject) {
+        [self batchWithEventSelector:eventSelector
+                     batchExpiration:expiration
+                          onComplete:^(NSNumber *_Nullable newBatchID,
+                                       NSSet<GDTCOREvent *> *_Nullable batchEvents) {
+                            if (newBatchID == nil || batchEvents == nil) {
+                              reject([self genericRejectedPromiseErrorWithReason:
+                                               @"There are no events for the selector."]);
+                            } else {
+                              fulfill([[GDTCORUploadBatch alloc] initWithBatchID:newBatchID
+                                                                          events:batchEvents]);
+                            }
+                          }];
+      }];
 }
 
 // TODO: More comprehensive error.

--- a/GoogleDataTransport/GDTCCTTests/Common/TestStorage/GDTCCTTestStorage.m
+++ b/GoogleDataTransport/GDTCCTTests/Common/TestStorage/GDTCCTTestStorage.m
@@ -17,6 +17,9 @@
 #import "GoogleDataTransport/GDTCCTTests/Common/TestStorage/GDTCCTTestStorage.h"
 
 #import "GoogleDataTransport/GDTCORLibrary/Public/GoogleDataTransport/GDTCOREvent.h"
+#import "GoogleDataTransport/GDTCORLibrary/Private/GDTCORUploadBatch.h"
+
+#import <FBLPromises/FBLPromises.h>
 
 @implementation GDTCCTTestStorage {
   /** Store the events in memory. */
@@ -139,6 +142,73 @@
   if (onComplete) {
     onComplete(batchID, batchEvents);
   }
+}
+
+- (FBLPromise<NSSet<NSNumber *> *> *)batchIDsForTarget:(GDTCORTarget)target {
+  return [FBLPromise wrapObjectCompletion:^(FBLPromiseObjectCompletion _Nonnull handler) {
+          [self batchIDsForTarget:target onComplete:handler];
+        }];
+}
+
+- (FBLPromise<NSNull *> *)removeBatchWithID:(NSNumber *)batchID deleteEvents:(BOOL)deleteEvents {
+  return [FBLPromise wrapCompletion:^(FBLPromiseCompletion _Nonnull handler) {
+                [self removeBatchWithID:batchID deleteEvents:deleteEvents onComplete:handler];
+              }];
+}
+
+- (FBLPromise<NSNull *> *)removeBatchesWithIDs:(NSSet<NSNumber *> *)batchIDs
+                                  deleteEvents:(BOOL)deleteEvents {
+  NSMutableArray<FBLPromise *> *removeBatchPromises =
+      [NSMutableArray arrayWithCapacity:batchIDs.count];
+  for (NSNumber *batchID in batchIDs) {
+    [removeBatchPromises addObject:[self removeBatchWithID:batchID deleteEvents:deleteEvents]];
+  }
+
+  return [FBLPromise all:[removeBatchPromises copy]].then(
+      ^id(id result) {
+        return [FBLPromise resolvedWith:[NSNull null]];
+      });
+}
+
+- (FBLPromise<NSNull *> *)removeAllBatchesForTarget:(GDTCORTarget)target
+                                       deleteEvents:(BOOL)deleteEvents {
+  return
+      [self batchIDsForTarget:target].then(^id(NSSet<NSNumber *> *batchIDs) {
+        return [self removeBatchesWithIDs:batchIDs deleteEvents:NO];
+      });
+}
+
+- (FBLPromise<NSNumber *> *)hasEventsForTarget:(GDTCORTarget)target {
+  return [FBLPromise wrapBoolCompletion:^(FBLPromiseBoolCompletion _Nonnull handler) {
+            [self hasEventsForTarget:target onComplete:handler];
+          }];
+}
+
+- (FBLPromise<GDTCORUploadBatch *> *)batchWithEventSelector:
+                                         (GDTCORStorageEventSelector *)eventSelector
+                                            batchExpiration:(NSDate *)expiration {
+  return [FBLPromise
+        async:^(FBLPromiseFulfillBlock _Nonnull fulfill, FBLPromiseRejectBlock _Nonnull reject) {
+          [self batchWithEventSelector:eventSelector
+                       batchExpiration:expiration
+                            onComplete:^(NSNumber *_Nullable newBatchID,
+                                         NSSet<GDTCOREvent *> *_Nullable batchEvents) {
+                              if (newBatchID == nil || batchEvents == nil) {
+                                reject([self genericRejectedPromiseErrorWithReason:
+                                                 @"There are no events for the selector."]);
+                              } else {
+                                fulfill([[GDTCORUploadBatch alloc] initWithBatchID:newBatchID
+                                                                            events:batchEvents]);
+                              }
+                            }];
+        }];
+}
+
+// TODO: More comprehensive error.
+- (NSError *)genericRejectedPromiseErrorWithReason:(NSString *)reason {
+  return [NSError errorWithDomain:@"GDTCORFlatFileStorage"
+                             code:-1
+                         userInfo:@{NSLocalizedFailureReasonErrorKey : reason}];
 }
 
 @end

--- a/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
+++ b/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
@@ -566,17 +566,14 @@
 
 - (void)waitForUploadOperationsToFinish:(GDTCCTUploader *)uploader {
   // TODO: Revisit.
+  XCTestExpectation *uploadFinishedExpectation =
+      [self expectationWithDescription:@"uploadFinishedExpectation"];
 
-  //  XCTestExpectation *uploadFinishedExpectation =
-  //      [self expectationWithDescription:@"uploadFinishedExpectation"];
-  //  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)),
-  //                 uploader.uploaderQueue, ^{
-  //                   [uploadFinishedExpectation fulfill];
-  //                   XCTAssertNil(uploader.currentTask);
-  //                 });
-  //  [self waitForExpectations:@[ uploadFinishedExpectation ] timeout:1];
+  [self.uploader waitForUploadFinished:^{
+    [uploadFinishedExpectation fulfill];
+  }];
 
-  [self.uploader waitForUploadFinished];
+  [self waitForExpectations:@[ uploadFinishedExpectation ] timeout:1];
 }
 
 - (XCTestExpectation *)expectStorageHasEventsForTarget:(GDTCORTarget)expectedTarget

--- a/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
+++ b/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
@@ -565,14 +565,18 @@
 }
 
 - (void)waitForUploadOperationsToFinish:(GDTCCTUploader *)uploader {
-  XCTestExpectation *uploadFinishedExpectation =
-      [self expectationWithDescription:@"uploadFinishedExpectation"];
-  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)),
-                 uploader.uploaderQueue, ^{
-                   [uploadFinishedExpectation fulfill];
-                   XCTAssertNil(uploader.currentTask);
-                 });
-  [self waitForExpectations:@[ uploadFinishedExpectation ] timeout:1];
+  // TODO: Revisit.
+
+  //  XCTestExpectation *uploadFinishedExpectation =
+  //      [self expectationWithDescription:@"uploadFinishedExpectation"];
+  //  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)),
+  //                 uploader.uploaderQueue, ^{
+  //                   [uploadFinishedExpectation fulfill];
+  //                   XCTAssertNil(uploader.currentTask);
+  //                 });
+  //  [self waitForExpectations:@[ uploadFinishedExpectation ] timeout:1];
+
+  [self.uploader waitForUploadFinished];
 }
 
 - (XCTestExpectation *)expectStorageHasEventsForTarget:(GDTCORTarget)expectedTarget
@@ -612,7 +616,7 @@
 
   [self.uploader uploadTarget:kGDTCORTargetTest withConditions:conditions];
 
-  [self waitForExpectations:@[ hasEventsExpectation, storageBatchExpectation ] timeout:1];
+  [self waitForExpectations:@[ hasEventsExpectation, storageBatchExpectation ] timeout:100];
 }
 
 - (void)sendEventSuccessfully {

--- a/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
+++ b/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
@@ -613,7 +613,7 @@
 
   [self.uploader uploadTarget:kGDTCORTargetTest withConditions:conditions];
 
-  [self waitForExpectations:@[ hasEventsExpectation, storageBatchExpectation ] timeout:100];
+  [self waitForExpectations:@[ hasEventsExpectation, storageBatchExpectation ] timeout:1];
 }
 
 - (void)sendEventSuccessfully {

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORRegistrar.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORRegistrar.m
@@ -23,6 +23,17 @@ id<GDTCORStorageProtocol> _Nullable GDTCORStorageInstanceForTarget(GDTCORTarget 
   return [GDTCORRegistrar sharedInstance].targetToStorage[@(target)];
 }
 
+FOUNDATION_EXPORT
+id<GDTCORStoragePromiseProtocol> _Nullable GDTCORStoragePromiseInstanceForTarget(
+    GDTCORTarget target) {
+  id storage = [GDTCORRegistrar sharedInstance].targetToStorage[@(target)];
+  if ([storage conformsToProtocol:@protocol(GDTCORStoragePromiseProtocol)]) {
+    return storage;
+  } else {
+    return nil;
+  }
+}
+
 @implementation GDTCORRegistrar {
   /** Backing ivar for targetToUploader property. */
   NSMutableDictionary<NSNumber *, id<GDTCORUploader>> *_targetToUploader;

--- a/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORStorageProtocol.h
+++ b/GoogleDataTransport/GDTCORLibrary/Internal/GDTCORStorageProtocol.h
@@ -154,4 +154,10 @@ typedef void (^GDTCORStorageBatchBlock)(NSNumber *_Nullable newBatchID,
 FOUNDATION_EXPORT
 id<GDTCORStorageProtocol> _Nullable GDTCORStorageInstanceForTarget(GDTCORTarget target);
 
+// TODO: Ideally we should remove completion-based API and use promise-based one. Need to double
+// check if it's ok.
+FOUNDATION_EXPORT
+id<GDTCORStoragePromiseProtocol> _Nullable GDTCORStoragePromiseInstanceForTarget(
+    GDTCORTarget target);
+
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Next uploading refactoring step b/160018519.

- express entire upload operation in a single chain of async steps bound with promises
- remove code not required any more

Next steps:
- break down URL request steps
- error handling
- fix tests

#no-changelog