### PR TITLE
Dynamic Links parameters dictionary changed to public variable.

### DIFF
--- a/FirebaseDynamicLinks/Sources/FIRDynamicLink+Private.h
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLink+Private.h
@@ -41,7 +41,7 @@ typedef NS_ENUM(NSUInteger, FIRDynamicLinkMatchConfidence) {
 
 @property(nonatomic, copy, nullable) NSString *matchMessage;
 
-@property(nonatomic, copy, readonly) NSDictionary<NSString *, id> *parametersDictionary;
+@property(nonatomic, copy, readwrite) NSDictionary<NSString *, id> *parametersDictionary;
 
 @property(nonatomic, assign, readwrite) FIRDLMatchType matchType;
 

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLink+Private.h
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLink+Private.h
@@ -41,8 +41,6 @@ typedef NS_ENUM(NSUInteger, FIRDynamicLinkMatchConfidence) {
 
 @property(nonatomic, copy, nullable) NSString *matchMessage;
 
-@property(nonatomic, copy, readwrite) NSDictionary<NSString *, id> *parametersDictionary;
-
 @property(nonatomic, assign, readwrite) FIRDLMatchType matchType;
 
 - (instancetype)initWithParametersDictionary:(NSDictionary<NSString *, id> *)parametersDictionary;

--- a/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FIRDynamicLink.h
+++ b/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FIRDynamicLink.h
@@ -77,6 +77,13 @@ NS_SWIFT_NAME(DynamicLink)
  */
 @property(nonatomic, copy, readonly, nullable) NSString *minimumAppVersion;
 
+/**
+* @property parametersDictionary
+* @abstract The parameters of the Dynamic Link.
+*/
+@property(nonatomic, copy, readonly) NSDictionary<NSString *, id> *parametersDictionary;
+
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FIRDynamicLink.h
+++ b/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FIRDynamicLink.h
@@ -78,9 +78,9 @@ NS_SWIFT_NAME(DynamicLink)
 @property(nonatomic, copy, readonly, nullable) NSString *minimumAppVersion;
 
 /**
-* @property parametersDictionary
-* @abstract The parameters of the Dynamic Link.
-*/
+ * @property parametersDictionary
+ * @abstract The parameters of the Dynamic Link.
+ */
 @property(nonatomic, copy, readonly) NSDictionary<NSString *, id> *parametersDictionary;
 
 @end

--- a/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FIRDynamicLink.h
+++ b/FirebaseDynamicLinks/Sources/Public/FirebaseDynamicLinks/FIRDynamicLink.h
@@ -83,7 +83,6 @@ NS_SWIFT_NAME(DynamicLink)
 */
 @property(nonatomic, copy, readonly) NSDictionary<NSString *, id> *parametersDictionary;
 
-
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
### Problem
In our use case we need to send some parameters(e.g. utm_ campaign, utm_medium etc.) to the backend for checking is any discount available for this campaign. In current developer's can't reach the dynamic links parameters even if received by app. Is it possible to make Dynamic links parameters public?
https://github.com/firebase/firebase-ios-sdk/issues/6730

### Solution
In `FIRDynamicLink+Private.h` file I've change parametersDictionary variable readonly to readwrite. Also I've added parametersDictionary to the `FIRDynamicLink.h` file for make it public. 
