### PR TITLE
Missing iid handler checking cause crash

### DIFF
--- a/Firebase/InstanceID/CHANGELOG.md
+++ b/Firebase/InstanceID/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased -- 7.0.0
 - [changed] Deprecated private `-[FIRInstanceID appInstanceID:]` method was removed. (#4486)
+- [fixed] Fixed an issue that APNS token is not sent in token request when there's a delay of getting the APNS token from Apple. (#6553)
 
 # 2020-09 -- 4.7.0
 - [deprecated] Deprecated InstanceID. For app instance identity handling, use FirebaseInstallations. For FCM registration token handling, use FirebaseMessaging. (#6585)

--- a/Firebase/InstanceID/FIRInstanceIDTokenManager.m
+++ b/Firebase/InstanceID/FIRInstanceIDTokenManager.m
@@ -89,7 +89,9 @@
         NSError *_Nullable error) {
         FIRInstanceID_STRONGIFY(self);
         if (error) {
-          handler(nil, error);
+          if (handler) {
+            handler(nil, error);
+          }
           return;
         }
         NSString *firebaseAppID = options[kFIRInstanceIDTokenOptionsFirebaseAppIDKey];

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -2,7 +2,6 @@
 - [changed] Remove the deprecated FCM direct channel API and Upstream send API. (#6430)
 - [changed] The `messaging:didReceiveRegistrationToken:` should be able to return a null token. Update the API parameter fcmToken to be nullable. (#5339)
 - [fixed] Fixed an issue that downloading an image failed when there's no extension in the file name but MIME type is set. (#6590)
-- [fixed] Fixed an issue that APNS token is not sent in token request when there's a delay of getting the APNS token from Apple. (#6553)
 
 # 2020-09 -- v.4.7.1
 - [added] InstanceID is deprecated, add macro to suppress deprecation warning. (#6585)


### PR DESCRIPTION
It was introduced when we start calling the token call without passing a handler: Fix #6669

Also the changelog for the whole change should be in IID not messaging.