### PR TITLE
Prevent test build errors under Xcode 12.1

### DIFF
--- a/Firestore/Example/Tests/Integration/FSTDatastoreTests.mm
+++ b/Firestore/Example/Tests/Integration/FSTDatastoreTests.mm
@@ -280,6 +280,7 @@ class RemoteStoreEventCapture : public RemoteStoreCallback {
   XCTestExpectation *expectation = [self expectationWithDescription:@"commitWithCompletion"];
 
   _datastore->CommitMutations({}, [self, expectation](const Status &status) {
+    (void)self;  // Avoid unused lambda capture error in Xcode 12.
     XCTAssertTrue(status.ok(), @"Failed to commit");
     [expectation fulfill];
   });


### PR DESCRIPTION
Xcode 12 changed the XCTest assertions to be macros that no longer implicitly depended on `self`. It seems as if Xcode 12.1 has made -Wunused-lambda-capture part of our default warnings and this breaks Objective-C++ code that lambda captures `self` only for its implicit use with the XCTest macros.

This isn't common, so just suppress the warning by forcing `self` to appear used regardless of whether XCTest assertions reference `self` or not.