### PR TITLE
Some Release tooling cleanup

### DIFF
--- a/ZipBuilder/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ZipBuilder/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -22,7 +22,7 @@ import Foundation
 public let shared = Manifest(
   version: "7.0.0",
   pods: [
-    Pod("GoogleUtilities", isFirebase: false, podVersion: "7.0.0", releasing: false),
+    Pod("GoogleUtilities", isFirebase: false, podVersion: "7.0.0", releasing: true),
     Pod("GoogleDataTransport", isFirebase: false, podVersion: "8.0.0", releasing: true),
 
     Pod("FirebaseCoreDiagnostics"),

--- a/ZipBuilder/Sources/FirebaseReleaser/Push.swift
+++ b/ZipBuilder/Sources/FirebaseReleaser/Push.swift
@@ -24,10 +24,7 @@ enum Push {
     let cpdcLocation = findCpdc(gitRoot: gitRoot)
     let manifest = FirebaseManifest.shared
 
-    for pod in manifest.pods {
-      if !pod.releasing {
-        continue
-      }
+    for pod in manifest.pods.filter({ $0.releasing }) {
       let warningsOK = pod.allowWarnings ? " --allow-warnings" : ""
 
       Shell.executeCommand("pod repo push --skip-tests --use-json \(warningsOK) \(cpdcLocation) " +

--- a/ZipBuilder/Sources/FirebaseReleaser/Tags.swift
+++ b/ZipBuilder/Sources/FirebaseReleaser/Tags.swift
@@ -27,10 +27,7 @@ enum Tags {
     createTag(gitRoot: gitRoot, tag: "CocoaPods-\(manifest.version)-beta",
               deleteExistingTags: deleteExistingTags)
 
-    for pod in manifest.pods {
-      if pod.isFirebase {
-        continue
-      }
+    for pod in manifest.pods.filter({ !$0.isFirebase && $0.releasing }) {
       if !pod.name.starts(with: "Google") {
         fatalError("Unrecognized Other Pod: \(pod.name). Only Google prefix is recognized")
       }

--- a/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
+++ b/ZipBuilder/Sources/ZipBuilder/LaunchArgs.swift
@@ -182,7 +182,8 @@ struct LaunchArgs {
     var templatePath = defaults.string(forKey: Key.templateDir.rawValue)
     if templatePath == nil, let repoDir = repoDir {
       templatePath = repoDir.path + "/ZipBuilder/Template"
-    } else {
+    }
+    if templatePath == nil {
       LaunchArgs.exitWithUsageAndLog("Missing required key: `\(Key.templateDir)` for the folder " +
         "containing all required files to build frameworks.")
     }


### PR DESCRIPTION
- Fix cron test failure from bad logic when `-templateDir` option was set without `-repoDir`
- More usage of Swift filter function
- Correct GoogleUtilities releasing attribute (broken after 7.0.0 RC was built)

#no-changelog