### PR TITLE
Address two comments from last week's PRs

### DIFF
--- a/ReleaseTooling/Sources/FirebaseReleaser/Tags.swift
+++ b/ReleaseTooling/Sources/FirebaseReleaser/Tags.swift
@@ -45,7 +45,7 @@ enum Tags {
 
   private static func createTag(gitRoot: URL, tag: String, deleteExistingTags: Bool) {
     if deleteExistingTags {
-      verifyTagsAreSafeToDelete()
+      verifyTagsAreSafeToDelete(gitRoot: gitRoot)
       Shell.executeCommand("git tag --delete \(tag)", workingDir: gitRoot)
       Shell.executeCommand("git push --delete origin \(tag)", workingDir: gitRoot)
     } else {
@@ -59,13 +59,17 @@ enum Tags {
   /// delete a tag that is being used in production.
   /// It works by checking for the existence of the corresponding Firebase podspec in the
   /// clone of https://github.com/CocoaPods/Specs
-  private static func verifyTagsAreSafeToDelete() {
+  private static func verifyTagsAreSafeToDelete(gitRoot: URL) {
     var homeDirURL: URL
     if #available(OSX 10.12, *) {
       homeDirURL = FileManager.default.homeDirectoryForCurrentUser
     } else {
       fatalError("Run on at least macOS 10.12")
     }
+
+    // Make sure that local master spec repo is up to date.
+    Shell.executeCommand("pod repo update", workingDir: gitRoot)
+
     let manifest = FirebaseManifest.shared
     let firebasePublicURL = homeDirURL.appendingPathComponents(
       [".cocoapods", "repos", "cocoapods", "Specs", "0", "3", "5", "Firebase"]

--- a/ReleaseTooling/Sources/FirebaseReleaser/main.swift
+++ b/ReleaseTooling/Sources/FirebaseReleaser/main.swift
@@ -27,6 +27,8 @@ struct FirebaseReleaser: ParsableCommand {
           transform: URL.init(fileURLWithPath:))
   var gitRoot: URL
 
+  /// Log commands only and do not make any repository or source changes.
+  /// Useful for testing and for generating the list of push commands.
   @Option(default: false,
           help: "Log without executing the shell commands")
   var logOnly: Bool


### PR DESCRIPTION
- `pod repo update` before checking the master spec repo for existing tags
- Comments for `--log-only` option

#no-changelog