### PR TITLE
Fix a memory leak introduced in #6418

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -5,6 +5,8 @@
   setting. Timestamp fields that read from a `FIRDocumentSnapshot` now always
   return `FIRTimestamp` objects. Use `FIRTimestamp.dateValue` to convert to
   `NSDate` if required.
+- [fixed] Fixed a memory leak introduced in 1.18.0 that may manifest when
+  serializing queries containing equality or non-equality comparisons.
 
 # v1.19.0
 - [changed] Internal improvements for future C++ and Unity support. Includes a


### PR DESCRIPTION
The root of the issue is that when serializing a singular filter, it is being treated as a unary filter before it is definitively established whether it is a unary filter or a field filter. The leak is caused by always serializing the unary filter's field path field for equality and non-equality filters -- if the filter's value turns out not to be NaN or null, the serialization code switches the filter's type to a field filter without clearing the partially-initialized unary filter. `pb_release` would not free the `unary_filter.field.field_path` member variable because it would consider the object not to be a unary filter.

Also a small refactoring to make the function easier to digest.