### PR TITLE
Crashlytics update run script to quote all arguments passed

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Fixed an issue where symbol uploads would fail with spaces in the path, particularly in Unity builds (#6789).
+
 # v4.6.2
 
 - [changed] Improved upload-symbols conversion speed. Customers with large dSYMs should see a significant improvement in the time it takes to upload Crashlytics symbols.

--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [fixed] Fixed an issue where symbol uploads would fail with spaces in the path, particularly in Unity builds (#6789).
+- [fixed] Fixed an issue where symbol uploads would fail when there are spaces in the project path, particularly in Unity builds (#6789).
 
 # v4.6.2
 

--- a/Crashlytics/run
+++ b/Crashlytics/run
@@ -39,8 +39,8 @@
 #  Figure out where we're being called from
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-#  Build up the arguments list, passing through any flags added
-
+#  Build up the arguments list, passing through any flags added, and quoting
+#  every argument in case there are spaces in any of the the paths.
 ARGUMENTS=''
 for i in "$@"; do
   ARGUMENTS="$ARGUMENTS \"$i\""

--- a/Crashlytics/run
+++ b/Crashlytics/run
@@ -40,7 +40,12 @@
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 #  Build up the arguments list, passing through any flags added
-ARGUMENTS="$@"
+
+ARGUMENTS=''
+for i in "$@"; do
+  ARGUMENTS="$ARGUMENTS \"$i\""
+done
+
 VALIDATE_ARGUMENTS="$ARGUMENTS --build-phase --validate"
 UPLOAD_ARGUMENTS="$ARGUMENTS --build-phase"
 

--- a/Crashlytics/run
+++ b/Crashlytics/run
@@ -39,17 +39,8 @@
 #  Figure out where we're being called from
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-#  If the first argument is specified without a dash, treat it as the Fabric API
-#  Key and add it as an argument.
-if [ -z "$1" ] || [[ $1 == -* ]]; then
-  API_KEY_ARG=""
-else
-  API_KEY_ARG="-a $1"; shift
-fi
-
-#  Build up the arguments list, passing through any flags added after the
-#  API Key
-ARGUMENTS="$API_KEY_ARG $@"
+#  Build up the arguments list, passing through any flags added
+ARGUMENTS="$@"
 VALIDATE_ARGUMENTS="$ARGUMENTS --build-phase --validate"
 UPLOAD_ARGUMENTS="$ARGUMENTS --build-phase"
 


### PR DESCRIPTION
 - Remove handling for the API Key
 - Fixes https://github.com/firebase/quickstart-unity/issues/714
