### PR TITLE
Add publish option to release tooling

### DIFF
--- a/ReleaseTooling/Sources/FirebaseReleaser/main.swift
+++ b/ReleaseTooling/Sources/FirebaseReleaser/main.swift
@@ -38,7 +38,12 @@ struct FirebaseReleaser: ParsableCommand {
           help: "Initialize the release branch")
   var initBranch: Bool
 
-  /// Set this option to update podspecs only.
+  /// Set this option to output the commands to generate the ordered `pod trunk push` commands.
+  @Option(default: false,
+          help: "Publish the podspecs to the CocoaPodsTrunk")
+  var publish: Bool
+
+  /// Set this option to only update the podspecs on cpdc.
   @Option(default: false,
           help: "Update the podspecs only")
   var pushOnly: Bool
@@ -68,10 +73,12 @@ struct FirebaseReleaser: ParsableCommand {
                            workingDir: gitRoot)
       Tags.createTags(gitRoot: gitRoot)
       Push.pushPodsToCPDC(gitRoot: gitRoot)
-    } else if pushOnly {
-      Push.pushPodsToCPDC(gitRoot: gitRoot)
     } else if updateTagsOnly {
       Tags.updateTags(gitRoot: gitRoot)
+    } else if pushOnly {
+      Push.pushPodsToCPDC(gitRoot: gitRoot)
+    } else if publish {
+      Push.publishPodsToTrunk(gitRoot: gitRoot)
     }
   }
 

--- a/scripts/build_zip.sh
+++ b/scripts/build_zip.sh
@@ -25,7 +25,7 @@ fi
 # output directory.
 OUTPUT_DIR="$REPO/$1"
 
-cd ReleaseToolings
+cd ReleaseTooling
 swift run zip-builder -keepBuildArtifacts true -updatePodRepo true \
   -templateDir "${REPO}"/ReleaseTooling/Template -localPodspecPath "${REPO}" \
   -outputDir "${OUTPUT_DIR}" -customSpecRepos https://github.com/firebase/SpecsStaging.git


### PR DESCRIPTION
Generate commands to publish a release to CocoaPods trunk.

Companion to internal cl/338150153.

Running with 
```
--publish true
--log-only true
--git-root /path/to/firebase-ios-sdk
```

generates
```
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/GoogleUtilities/7.0.0/GoogleUtilities.podspec.json
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/GoogleDataTransport/8.0.0/GoogleDataTransport.podspec.json
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseCoreDiagnostics/7.0.0/FirebaseCoreDiagnostics.podspec.json
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseCore/7.0.0/FirebaseCore.podspec.json
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseInstallations/7.0.0/FirebaseInstallations.podspec.json
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseInstanceID/7.0.0/FirebaseInstanceID.podspec.json
pod trunk push --skip-tests --synchronous  -skip-import-validation ~/.cocoapods/repos/cpdc-internal-firebase/Specs/GoogleAppMeasurement/7.0.0/GoogleAppMeasurement.podspec.json
pod trunk push --skip-tests --synchronous  -skip-import-validation ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseAnalytics/7.0.0/FirebaseAnalytics.podspec.json
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseABTesting/7.0.0/FirebaseABTesting.podspec.json
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseAppDistribution/7.0.0-beta/FirebaseAppDistribution.podspec.json
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseAuth/7.0.0/FirebaseAuth.podspec.json
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseCrashlytics/7.0.0/FirebaseCrashlytics.podspec.json
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseDatabase/7.0.0/FirebaseDatabase.podspec.json
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseDynamicLinks/7.0.0/FirebaseDynamicLinks.podspec.json
pod trunk push --skip-tests --synchronous --allow-warnings  ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseFirestore/7.0.0/FirebaseFirestore.podspec.json
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseFirestoreSwift/7.0.0-beta/FirebaseFirestoreSwift.podspec.json
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseFunctions/7.0.0/FirebaseFunctions.podspec.json
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseInAppMessaging/7.0.0-beta/FirebaseInAppMessaging.podspec.json
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseMessaging/7.0.0/FirebaseMessaging.podspec.json
pod trunk push --skip-tests --synchronous  -skip-import-validation ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebasePerformance/7.0.0/FirebasePerformance.podspec.json
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseRemoteConfig/7.0.0/FirebaseRemoteConfig.podspec.json
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseStorage/7.0.0/FirebaseStorage.podspec.json
pod trunk push --skip-tests --synchronous   ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseStorageSwift/7.0.0-beta/FirebaseStorageSwift.podspec.json
pod trunk push --skip-tests --synchronous  -skip-import-validation ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseMLCommon/7.0.0-beta/FirebaseMLCommon.podspec.json
pod trunk push --skip-tests --synchronous  -skip-import-validation ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseMLModelInterpreter/7.0.0-beta/FirebaseMLModelInterpreter.podspec.json
pod trunk push --skip-tests --synchronous  -skip-import-validation ~/.cocoapods/repos/cpdc-internal-firebase/Specs/FirebaseMLVision/7.0.0-beta/FirebaseMLVision.podspec.json
pod trunk push --skip-tests --synchronous --allow-warnings -skip-import-validation ~/.cocoapods/repos/cpdc-internal-firebase/Specs/Firebase/7.0.0/Firebase.podspec.json
```