### PR TITLE
Fixed broken callback to AppDelegate

### DIFF
--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v4.3.2
+- [fixed] Fixed broken callback to AppDelegate after retrieveing a dynamic link during fresh app start.
+
 # v4.3.1
 - [changed] Client id usage in api call and respective checks in the code.
 - [fixed] Fix attempts to connect to invalid ipv6 domain by updating ipv4 and ipv6 to use a single, valid endpoint (#5032)

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,6 +1,3 @@
-# v4.3.2
-- [fixed] Fixed broken callback to AppDelegate after retrieveing a dynamic link during fresh app start.
-
 # v4.3.1
 - [changed] Client id usage in api call and respective checks in the code.
 - [fixed] Fix attempts to connect to invalid ipv6 domain by updating ipv4 and ipv6 to use a single, valid endpoint (#5032)

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
@@ -509,7 +509,20 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
 }
 
 - (void)passRetrievedDynamicLinkToApplication:(NSURL *)url {
-  [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+  id<UIApplicationDelegate> applicationDelegate = [UIApplication sharedApplication].delegate;
+  if (applicationDelegate &&
+      [applicationDelegate respondsToSelector:@selector(application:openURL:options:)]) {
+    // pass url directly to application delegate to avoid hop into
+    // iOS handling of the universal links
+    if (@available(iOS 9.0, *)) {
+      [applicationDelegate application:[UIApplication sharedApplication] openURL:url options:@{}];
+      return;
+    }
+  }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  [[UIApplication sharedApplication] openURL:url];
+#pragma clang diagnostic pop
 }
 
 - (void)handlePendingDynamicLinkRetrievalFailureWithErrorCode:(NSInteger)errorCode

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
@@ -514,15 +514,11 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
       [applicationDelegate respondsToSelector:@selector(application:openURL:options:)]) {
     // pass url directly to application delegate to avoid hop into
     // iOS handling of the universal links
-    if (@available(iOS 9.0, *)) {
-      [applicationDelegate application:[UIApplication sharedApplication] openURL:url options:@{}];
-      return;
-    }
+    [applicationDelegate application:[UIApplication sharedApplication] openURL:url options:@{}];
+    return;
   }
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [[UIApplication sharedApplication] openURL:url];
-#pragma clang diagnostic pop
+
+  [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
 }
 
 - (void)handlePendingDynamicLinkRetrievalFailureWithErrorCode:(NSInteger)errorCode

--- a/FirebaseDynamicLinks/Tests/Sample/Podfile
+++ b/FirebaseDynamicLinks/Tests/Sample/Podfile
@@ -1,14 +1,10 @@
-# Uncomment the next line to define a global platform for your project
-# platform :ios, '9.0'
-
 target 'FDLBuilderTestAppObjC' do
-  # Comment the next line if you don't want to use dynamic frameworks
+  platform :ios, '10.0'
   use_frameworks!
-  pod 'FirebaseAnalytics'
-  pod 'FirebaseCore', :path => '../../../'
-  pod 'FirebaseInstallations', :path => '../../../'
-  pod 'FirebaseInstanceID', :path => '../../../'
-  pod 'FirebaseDynamicLinks', :path => '../../../'
-  pod 'GoogleUtilities', :path => '../../../'
 
+  pod 'FirebaseCore', :path => '../../../'
+  pod 'FirebaseCoreDiagnostics', :path => '../../../'
+  pod 'GoogleDataTransport', :path => '../../../'
+  pod 'GoogleUtilities', :path => '../../../'
+  pod 'FirebaseDynamicLinks', :path => '../../../'
 end


### PR DESCRIPTION
Fixed broken callback to AppDelegate after retrieving a dynamic link during fresh app start.
The AppDelegate call was broken in PR : https://github.com/firebase/firebase-ios-sdk/pull/6517

- Reverting to the old implementation of dynamic link passing to App delegate with changes to remove iOS 9 checks.
- Using new method instead of the deprecated one.
- Clean up in the sample app pod file.