### PR TITLE
Stop failing on warnings

### DIFF
--- a/GoogleDataTransport.podspec
+++ b/GoogleDataTransport.podspec
@@ -42,7 +42,6 @@ Shared library for iOS SDK data transport needs.
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',
-    'GCC_TREAT_WARNINGS_AS_ERRORS' => 'YES',
     'CLANG_UNDEFINED_BEHAVIOR_SANITIZER_NULLABILITY' => 'YES',
     'GCC_PREPROCESSOR_DEFINITIONS' =>
       # The nanopb pod sets these defs, so we must too. (We *do* require 16bit

--- a/GoogleDataTransport/CHANGELOG.md
+++ b/GoogleDataTransport/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Remove `GCC_TREAT_WARNINGS_AS_ERRORS` from the podspec.
+
 # v8.0.0
 - Source restructuring to limit the public API surface.
 


### PR DESCRIPTION
We already check for warnings in our CI and should avoid causing failures if future versions of Xcode introduce warnings.

More context at https://github.com/flutter/flutter/issues/68813