### PR TITLE
clarify error when logging settings failures

### DIFF
--- a/Crashlytics/Crashlytics/Settings/FIRCLSSettingsOnboardingManager.m
+++ b/Crashlytics/Crashlytics/Settings/FIRCLSSettingsOnboardingManager.m
@@ -181,7 +181,15 @@
 - (void)operation:(FIRCLSDownloadAndSaveSettingsOperation *)operation
     didDownloadAndSaveSettingsWithError:(nullable NSError *)error {
   if (error) {
-    FIRCLSErrorLog(@"Failed to download settings %@", error);
+    NSString *message = @"Failed to download settings.";
+    if (error.userInfo && [error.userInfo objectForKey:@"status_code"] &&
+        [[error.userInfo objectForKey:@"status_code"]
+            isEqualToNumber:[NSNumber numberWithInt:404]]) {
+      NSString *debugHint = @"If this is your first time launching the app, make sure you have "
+                            @"enabled Crashlytics in the Firebase Console.";
+      message = [NSString stringWithFormat:@"%@ %@", message, debugHint];
+    }
+    FIRCLSErrorLog(@"%@ %@", message, error);
     [self finishNetworkingSession];
     return;
   }


### PR DESCRIPTION
When a request to fetch settings fails with a 404 status code, log an error message that can help developers debug the cause.