### PR TITLE
Remove explicit MobileCoreServices from podspecs

### DIFF
--- a/FirebaseFirestore.podspec
+++ b/FirebaseFirestore.podspec
@@ -72,7 +72,7 @@ Google Cloud Firestore is a NoSQL document database built for automatic scaling,
   s.dependency 'leveldb-library', '~> 1.22'
   s.dependency 'nanopb', '~> 2.30906.0'
 
-  s.ios.frameworks = 'MobileCoreServices', 'SystemConfiguration', 'UIKit'
+  s.ios.frameworks = 'SystemConfiguration', 'UIKit'
   s.osx.frameworks = 'SystemConfiguration'
   s.tvos.frameworks = 'SystemConfiguration', 'UIKit'
 

--- a/FirebaseStorage.podspec
+++ b/FirebaseStorage.podspec
@@ -31,7 +31,6 @@ Firebase Storage provides robust, secure file uploads and downloads from Firebas
   ]
   s.public_header_files = 'FirebaseStorage/Sources/Public/FirebaseStorage/*.h'
 
-  s.ios.framework = 'MobileCoreServices'
   s.osx.framework = 'CoreServices'
 
   s.dependency 'FirebaseCore', '~> 7.0'

--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 7.1.0
+- [Fixed] Remove explicit MobileCoreServices library linkage from podspec. (#6850)
+
 # 7.0.0
 - [changed] The global variable `FIRStorageVersionString` is deleted.
   `FirebaseVersion()` or `FIRFirebaseVersion()` should be used instead.

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- [Fixed] Remove explicit MobileCoreServices library linkage from podspec. (#6850)
 
 # v7.0.0
 - [changed] **Breaking change:** Removed the `areTimestampsInSnapshotsEnabled`

--- a/Package.swift
+++ b/Package.swift
@@ -445,7 +445,6 @@ let package = Package(
       ],
       linkerSettings: [
         .linkedFramework("SystemConfiguration", .when(platforms: .some([.iOS, .macOS, .tvOS]))),
-        .linkedFramework("MobileCoreServices", .when(platforms: .some([.iOS]))),
         .linkedFramework("UIKit", .when(platforms: .some([.iOS, .tvOS]))),
         .linkedLibrary("c++"),
       ]


### PR DESCRIPTION
Fix #6850 

It seems that it's not necessary with modern Xcode versions to explicitly link `MobileCoreServices` and its linkage is problematic because it causes build warnings with CocoaPods (but not Swift Package Manager).

- MobileCoreServices is used in FirebaseStorage and FirebaseDatabase, but not Firestore
- Only the FirebaseStorage and Firestore podspecs were specifying it
- We saw no issues from FirebaseDatabase including MobileCoreServices but not adding an explicit linkage
- With Firebase 7 updating to a minimum iOS version of 10, we're seeing build warnings even though the docs say MobileCoreServices is not deprecated until iOS 12.