### PR TITLE
Update Firestore macOS build for Xcode 12

### DIFF
--- a/.github/workflows/firestore.yml
+++ b/.github/workflows/firestore.yml
@@ -196,6 +196,7 @@ jobs:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     runs-on: macOS-latest
+    needs: check
     steps:
     - uses: actions/checkout@v2
     - name: Xcode 12

--- a/Firestore/core/test/unit/FSTGoogleTestTests.mm
+++ b/Firestore/core/test/unit/FSTGoogleTestTests.mm
@@ -224,7 +224,7 @@ void XCTestMethod(XCTestCase* self, SEL _cmd) {
     const char* path = part.file_name() ? part.file_name() : "";
     int line = part.line_number() > 0 ? part.line_number() : 0;
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000 || __MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
     // Xcode 12
     auto* location = [[XCTSourceCodeLocation alloc] initWithFilePath:@(path)
                                                           lineNumber:line];

--- a/Firestore/core/test/unit/FSTGoogleTestTests.mm
+++ b/Firestore/core/test/unit/FSTGoogleTestTests.mm
@@ -224,7 +224,8 @@ void XCTestMethod(XCTestCase* self, SEL _cmd) {
     const char* path = part.file_name() ? part.file_name() : "";
     int line = part.line_number() > 0 ? part.line_number() : 0;
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000 || __MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000 || \
+    __MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
     // Xcode 12
     auto* location = [[XCTSourceCodeLocation alloc] initWithFilePath:@(path)
                                                           lineNumber:line];


### PR DESCRIPTION
Exposed by GHA updating from Xcode 11.7 to 12.0.1

#no-changelog