### PR TITLE
FCM: Fix crash on iOS 14 when multiple app delegate completion methods are called

### DIFF
--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -1499,6 +1499,7 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
     didReceiveRemoteNotification:(NSDictionary *)userInfo
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
   [self canHandleNotification:userInfo];
+  completionHandler(UIBackgroundFetchResultNoData);
 }
 
 // iOS 10 deprecation

--- a/FirebaseMessaging/Sources/FIRMessagingRemoteNotificationsProxy.m
+++ b/FirebaseMessaging/Sources/FIRMessagingRemoteNotificationsProxy.m
@@ -397,6 +397,7 @@ id FIRMessagingPropertyNameFromObject(id object, NSString *propertyName, Class k
     didReceiveRemoteNotification:(NSDictionary *)userInfo
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
   [[FIRMessaging messaging] appDidReceiveMessage:userInfo];
+  completionHandler(UIBackgroundFetchResultNoData);
 }
 
 - (void)application:(UIApplication *)application

--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -21,8 +21,8 @@
 #import "GoogleUtilities/Logger/Public/GoogleUtilities/GULLogger.h"
 #import "GoogleUtilities/Network/Public/GoogleUtilities/GULMutableDictionary.h"
 
-#import <objc/runtime.h>
 #import <dispatch/group.h>
+#import <objc/runtime.h>
 
 // Implementations need to be typed before calling the implementation directly to cast the
 // arguments and the return types correctly. Otherwise, it will crash the app.
@@ -882,7 +882,7 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
   GULRealDidReceiveRemoteNotificationWithCompletionIMP
       didReceiveRemoteNotificationWithCompletionIMP =
           [didReceiveRemoteNotificationWithCompletionIMPPointer pointerValue];
-  
+
   dispatch_group_t __block callbackGroup = dispatch_group_create();
   UIBackgroundFetchResult __block latestFetchResult = UIBackgroundFetchResultNoData;
   dispatch_group_notify(callbackGroup, dispatch_get_main_queue(), ^() {
@@ -892,20 +892,21 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
   [GULAppDelegateSwizzler
       notifyInterceptorsWithMethodSelector:methodSelector
                                   callback:^(id<GULApplicationDelegate> interceptor) {
-    
                                     dispatch_group_enter(callbackGroup);
-                                    void (^localCompletionHandler)(UIBackgroundFetchResult) = ^void (UIBackgroundFetchResult fetchResult){
-                                      latestFetchResult = fetchResult;
-                                      dispatch_group_leave(callbackGroup);
-                                    };
-                                    
+                                    void (^localCompletionHandler)(UIBackgroundFetchResult) =
+                                        ^void(UIBackgroundFetchResult fetchResult) {
+                                          latestFetchResult = fetchResult;
+                                          dispatch_group_leave(callbackGroup);
+                                        };
+
                                     NSInvocation *invocation = [GULAppDelegateSwizzler
                                         appDelegateInvocationForSelector:methodSelector];
                                     [invocation setTarget:interceptor];
                                     [invocation setSelector:methodSelector];
                                     [invocation setArgument:(void *)(&application) atIndex:2];
                                     [invocation setArgument:(void *)(&userInfo) atIndex:3];
-                                    [invocation setArgument:(void *)(&localCompletionHandler) atIndex:4];
+                                    [invocation setArgument:(void *)(&localCompletionHandler)
+                                                    atIndex:4];
                                     [invocation invoke];
                                   }];
   // Call the real implementation if the real App Delegate has any.

--- a/GoogleUtilities/Tests/Unit/Swizzler/GULAppDelegateSwizzlerTest.m
+++ b/GoogleUtilities/Tests/Unit/Swizzler/GULAppDelegateSwizzlerTest.m
@@ -1089,15 +1089,6 @@ static BOOL gRespondsToHandleBackgroundSession;
   XCTAssertEqual(testAppDelegate.remoteNotification, notification);
 }
 
-- (void)extracted:(UIApplication *)application
-         completion:(void (^)(UIBackgroundFetchResult))completion
-       notification:(NSDictionary *)notification
-    testAppDelegate:(GULTestAppDelegate *)testAppDelegate {
-  [testAppDelegate application:application
-      didReceiveRemoteNotification:notification
-            fetchCompletionHandler:completion];
-}
-
 - (void)testApplicationDidReceiveRemoteNotificationWithCompletionCompletionIsCalledOnce {
   NSDictionary *notification = @{};
   GULApplication *application = [GULApplication sharedApplication];
@@ -1136,10 +1127,9 @@ static BOOL gRespondsToHandleBackgroundSession;
   [GULAppDelegateSwizzler registerAppDelegateInterceptor:interceptor];
   [GULAppDelegateSwizzler registerAppDelegateInterceptor:interceptor2];
 
-  [self extracted:application
-           completion:completion
-         notification:notification
-      testAppDelegate:testAppDelegate];
+  [testAppDelegate application:application
+      didReceiveRemoteNotification:notification
+            fetchCompletionHandler:completion];
   testAppDelegate.remoteNotificationCompletionHandler(UIBackgroundFetchResultNoData);
   OCMVerifyAll(interceptor);
   OCMVerifyAll(interceptor2);
@@ -1179,10 +1169,9 @@ static BOOL gRespondsToHandleBackgroundSession;
 
   [GULAppDelegateSwizzler registerAppDelegateInterceptor:interceptor];
 
-  [self extracted:application
-           completion:completion
-         notification:notification
-      testAppDelegate:testAppDelegate];
+  [testAppDelegate application:application
+      didReceiveRemoteNotification:notification
+            fetchCompletionHandler:completion];
   testAppDelegate.remoteNotificationCompletionHandler(UIBackgroundFetchResultFailed);
   OCMVerifyAll(interceptor);
   [self waitForExpectations:@[ completionExpectation ] timeout:0.1];
@@ -1221,10 +1210,9 @@ static BOOL gRespondsToHandleBackgroundSession;
 
   [GULAppDelegateSwizzler registerAppDelegateInterceptor:interceptor];
 
-  [self extracted:application
-           completion:completion
-         notification:notification
-      testAppDelegate:testAppDelegate];
+  [testAppDelegate application:application
+      didReceiveRemoteNotification:notification
+            fetchCompletionHandler:completion];
   testAppDelegate.remoteNotificationCompletionHandler(UIBackgroundFetchResultNewData);
   OCMVerifyAll(interceptor);
   [self waitForExpectations:@[ completionExpectation ] timeout:0.1];


### PR DESCRIPTION
## Background

Since iOS 7 it is possible to execute the code in the background for iOS apps that receive silent push notifications. Once such push (most likely containing the `content-available` flag) is received, if the application is in the background, it has 30 seconds to complete the background activity and tell iOS that it's done by calling the `completion` block. More info [on application(_:didReceiveRemoteNotification:fetchCompletionHandler:) here](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623013-application)

## Issue we observed

We discovered that on iOS 14 calling the completion block multiple times is leading to a crash. Based on my limited debugging capabilities, it looks like the API is now using dispatch groups to trace the moment when the completion is called, and in the completion block it invokes `dispatch_group_leave`. Once the completion block is called multiple times, the iOS is going to crash since this behavior is unexpected (calling `dispatch_group_leave` more times than `dispatch_group_enter`).

More people complained about the same issue here https://github.com/invertase/react-native-firebase/issues/3944. 

Worth noticing that in our experience the crash is only happening when the app is actually running in the foreground and in case the FCM is used together with the Braze SDK (they are also using `GULAppDelegateSwizzler`).

## Proposed solution

> Similia similibus curantur

It is sufficient to wrap the final completion block provided by iOS into yet another `dispatch_group` that would be entered for every observer of the `application(_:didReceiveRemoteNotification:fetchCompletionHandler:)` and left when the observer is calling to the provided callback.