### PR TITLE
Fix warning introduced with Xcode 12

### DIFF
--- a/FirebaseMessaging/Tests/UnitTests/FIRMessagingPendingTopicsListTest.m
+++ b/FirebaseMessaging/Tests/UnitTests/FIRMessagingPendingTopicsListTest.m
@@ -113,13 +113,11 @@
   XCTestExpectation *batchSizeReductionExpectation =
       [self expectationWithDescription:@"Batch size was reduced after topic suscription"];
 
-  __weak id weakSelf = self;
   self.alwaysReadyDelegate.subscriptionHandler =
       ^(NSString *topic, FIRMessagingTopicAction action,
         FIRMessagingTopicOperationCompletion completion) {
         // Simulate that the handler is generally called asynchronously
         dispatch_async(dispatch_get_main_queue(), ^{
-          id self = weakSelf;
           if (action == FIRMessagingTopicActionUnsubscribe) {
             XCTAssertEqual(pendingTopics.numberOfBatches, 1);
             [batchSizeReductionExpectation fulfill];


### PR DESCRIPTION
Fix warning building unit tests exposed by GHA moving to Xcode 12

#no-changelog - Unit test build issue only