### PR TITLE
GDTCCTUploader: lazy initialize url session, use ephemeral session

### DIFF
--- a/GoogleDataTransport/CHANGELOG.md
+++ b/GoogleDataTransport/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - Remove `GCC_TREAT_WARNINGS_AS_ERRORS` from the podspec.
+- Reduce pre-main sartup time footprint. (#6855)
 
 # v8.0.0
 - Source restructuring to limit the public API surface.

--- a/GoogleDataTransport/CHANGELOG.md
+++ b/GoogleDataTransport/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - Remove `GCC_TREAT_WARNINGS_AS_ERRORS` from the podspec.
-- Reduce pre-main sartup time footprint. (#6855)
+- Reduce pre-main startup time footprint. (#6855)
 
 # v8.0.0
 - Source restructuring to limit the public API surface.

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
@@ -80,6 +80,8 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
 
 @implementation GDTCCTUploader
 
+@synthesize uploaderSession = _uploaderSession;
+
 + (void)load {
   GDTCCTUploader *uploader = [GDTCCTUploader sharedInstance];
   [[GDTCORRegistrar sharedInstance] registerUploader:uploader target:kGDTCORTargetCCT];
@@ -101,12 +103,18 @@ typedef void (^GDTCCTUploaderEventBatchBlock)(NSNumber *_Nullable batchID,
   self = [super init];
   if (self) {
     _uploaderQueue = dispatch_queue_create("com.google.GDTCCTUploader", DISPATCH_QUEUE_SERIAL);
-    NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+  }
+  return self;
+}
+
+- (NSURLSession *)uploaderSession {
+  if (_uploaderSession == nil) {
+    NSURLSessionConfiguration *config = [NSURLSessionConfiguration ephemeralSessionConfiguration];
     _uploaderSession = [NSURLSession sessionWithConfiguration:config
                                                      delegate:self
                                                 delegateQueue:nil];
   }
-  return self;
+  return _uploaderSession;
 }
 
 /**


### PR DESCRIPTION
Fixes #6855.

- use ephemeral URL session since non of cacheing is required for upload. The ephemeral URL session is "cheaper" to instantiate and use
- lazy initialize the URL session to avoid extra work at pre-main time
