### PR TITLE
Restore GoogleMLKit to SymbolCollision testing

### DIFF
--- a/SymbolCollisionTest/Podfile
+++ b/SymbolCollisionTest/Podfile
@@ -54,8 +54,7 @@ target 'SymbolCollisionTest' do
     pod 'GoogleInterchangeUtilities'
     pod 'GoogleMaps'
 
-# https://github.com/firebase/firebase-ios-sdk/issues/6655
-#    pod 'GoogleMLKit'
+    pod 'GoogleMLKit'
 #    pod 'GoogleMobileVision' # After Firebase 6.8.0, conflicts with FirebaseML
     pod 'GoogleNetworkingUtilities'
     pod 'GoogleParsingUtilities'


### PR DESCRIPTION
Fix #6655 not that a Firebase 7 compatible version of GoogleMLKit has published

#no-changelog