### PR TITLE
Back to a released version of pod gen

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,5 @@ source 'https://rubygems.org'
 
 gem 'cocoapods', '1.10.0'
 
-# Use cocoapod-generate hash until 2.1.0 releases to fix a bug interacting with CocoaPods 1.10.
-gem 'cocoapods-generate', git: "https://github.com/square/cocoapods-generate.git", ref: "230b0b537b"
+gem 'cocoapods-generate', '2.0.1'
 gem 'danger', '6.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/square/cocoapods-generate.git
-  revision: 230b0b537b5d7f524de157b6dbb3f5e08d317516
-  ref: 230b0b537b
-  specs:
-    cocoapods-generate (2.0.1)
-      cocoapods-disable-podfile-validations (~> 0.1.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -57,6 +49,8 @@ GEM
     cocoapods-deintegrate (1.0.4)
     cocoapods-disable-podfile-validations (0.1.1)
     cocoapods-downloader (1.4.0)
+    cocoapods-generate (2.0.1)
+      cocoapods-disable-podfile-validations (~> 0.1.1)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
@@ -137,7 +131,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (= 1.10.0)
-  cocoapods-generate!
+  cocoapods-generate (= 2.0.1)
   danger (= 6.1.0)
 
 BUNDLED WITH


### PR DESCRIPTION
pod gen 2.0.1 released that fixes the [CocoaPods 1.10.x interoperability issue](https://github.com/square/cocoapods-generate/pull/69)