### PR TITLE
Crashlytics move some noisy logs out of devs logs

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSProcess.c
+++ b/Crashlytics/Crashlytics/Components/FIRCLSProcess.c
@@ -167,7 +167,7 @@ static bool FIRCLSProcessGetThreadState(FIRCLSProcess *process,
                                         thread_t thread,
                                         FIRCLSThreadContext *context) {
   if (!FIRCLSIsValidPointer(context)) {
-    FIRCLSSDKLogError("invalid context supplied");
+    FIRCLSSDKLogError("Invalid context supplied\n");
     return false;
   }
 
@@ -259,7 +259,7 @@ static const char *FIRCLSProcessGetThreadDispatchQueueName(FIRCLSProcess *proces
   infoCount = THREAD_IDENTIFIER_INFO_COUNT;
   if (thread_info(thread, THREAD_IDENTIFIER_INFO, (thread_info_t)&info, &infoCount) !=
       KERN_SUCCESS) {
-    FIRCLSSDKLog("unable to get thread info\n");
+    FIRCLSSDKLog("Unable to get thread info\n");
     return NULL;
   }
 
@@ -395,12 +395,12 @@ static bool FIRCLSProcessRecordThread(FIRCLSProcess *process, thread_t thread, F
   FIRCLSThreadContext context;
 
   if (!FIRCLSProcessGetThreadState(process, thread, &context)) {
-    FIRCLSSDKLogError("unable to get thread state");
+    FIRCLSSDKLogError("Unable to get thread state\n");
     return false;
   }
 
   if (!FIRCLSUnwindInit(&unwindContext, context)) {
-    FIRCLSSDKLog("unable to init unwind context\n");
+    FIRCLSSDKLog("Unable to init unwind context\n");
 
     return false;
   }
@@ -490,7 +490,7 @@ bool FIRCLSProcessRecordAllThreads(FIRCLSProcess *process, FIRCLSFile *file) {
 
     FIRCLSSDKLogInfo("recording thread %d data\n", i);
     if (!FIRCLSProcessRecordThread(process, thread, file)) {
-      FIRCLSSDKLogError("Failed to record thread state. Closing threads JSON to prevent malformed crash report.");
+      FIRCLSSDKLogError("Failed to record thread state. Closing threads JSON to prevent malformed crash report.\n");
 
       FIRCLSFileWriteArrayEnd(file);
 
@@ -503,7 +503,7 @@ bool FIRCLSProcessRecordAllThreads(FIRCLSProcess *process, FIRCLSFile *file) {
 
   FIRCLSFileWriteSectionEnd(file);
 
-  FIRCLSSDKLogInfo("completed recording all thread data\n");
+  FIRCLSSDKLogInfo("Completed recording all thread data\n");
 
   return true;
 }

--- a/Crashlytics/Crashlytics/Models/FIRCLSSymbolResolver.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSSymbolResolver.m
@@ -18,8 +18,8 @@
 
 #include "Crashlytics/Crashlytics/Components/FIRCLSBinaryImage.h"
 #include "Crashlytics/Crashlytics/Helpers/FIRCLSFile.h"
-#import "Crashlytics/Crashlytics/Helpers/FIRCLSLogger.h"
 #import "Crashlytics/Crashlytics/Helpers/FIRCLSInternalLogging.h"
+#import "Crashlytics/Crashlytics/Helpers/FIRCLSLogger.h"
 #import "Crashlytics/Crashlytics/Private/FIRStackFrame_Private.h"
 
 @interface FIRCLSSymbolResolver () {

--- a/Crashlytics/Crashlytics/Models/FIRCLSSymbolResolver.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSSymbolResolver.m
@@ -19,6 +19,7 @@
 #include "Crashlytics/Crashlytics/Components/FIRCLSBinaryImage.h"
 #include "Crashlytics/Crashlytics/Helpers/FIRCLSFile.h"
 #import "Crashlytics/Crashlytics/Helpers/FIRCLSLogger.h"
+#import "Crashlytics/Crashlytics/Helpers/FIRCLSInternalLogging.h"
 #import "Crashlytics/Crashlytics/Private/FIRStackFrame_Private.h"
 
 @interface FIRCLSSymbolResolver () {
@@ -129,7 +130,7 @@
 
   if (![self fillInImageDetails:&imageDetails forUUID:[binaryImage objectForKey:@"uuid"]]) {
 #if DEBUG
-    FIRCLSDebugLog(@"Image not found");
+    FIRCLSSDKLog("Image not found\n");
 #endif
     return NO;
   }
@@ -141,7 +142,7 @@
 
   if (dladdr((void*)addr, &dlInfo) == 0) {
 #if DEBUG
-    FIRCLSDebugLog(@"Could not look up address");
+    FIRCLSSDKLog("Could not look up address\n");
 #endif
     return NO;
   }
@@ -150,7 +151,7 @@
     addr -= 2;
     if (dladdr((void*)addr, &dlInfo) == 0) {
 #if DEBUG
-      FIRCLSDebugLog(@"Could not look up address");
+      FIRCLSSDKLog("Could not look up address after move\n");
 #endif
       return NO;
     }


### PR DESCRIPTION
These logs were either ill-formatted, or went to console log (particularly "Image not found", which shows up way too much).

#no-changelog