### PR TITLE
Add Result support to runTransaction Firestore method

### DIFF
--- a/Firestore/Swift/Source/Result/Result/Firestore+RunTransaction
+++ b/Firestore/Swift/Source/Result/Result/Firestore+RunTransaction
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
- import FirebaseFirestore
- 
- extension Firestore {
+
+#if swift(>=5.0)
+
+extension Firestore {
   /**
    * Executes the given updateBlock and then attempts to commit the changes applied within an atomic
    * transaction.
@@ -49,19 +49,36 @@
    * @param completion The block to call with the result or error of the transaction. This
    *     block will run even if the client is offline, unless the process is killed.
    */
-  func runTransaction<T>(_ updateBlock: @escaping (Transaction) -> Result<T, Error>, completion: @escaping (Result<T, Error>) -> Void) {
-    runTransaction { transaction, _ in updateBlock(transaction) } completion: { value, error in
-      if let result = value as? Result<T, Error> {
-        completion(result)
+  func runTransaction<T>(_ updateBlock: @escaping (Transaction) throws -> T, completion: @escaping (Result<T, Error>) -> Void) {
+    runTransaction { transaction, errorPointer in
+      do {
+        return try updateBlock(transaction)
+      } catch {
+        errorPointer?.pointee = error as NSError
+        return nil
+      }
+    } completion: { value, error in
+      if let value = value {
+        if let value = value as? T {
+          completion(.success(value))
+        } else {
+          completion(.failure(NSError(domain: "FirebaseFirestoreSwift",
+                                      code: -1,
+                                      userInfo: [NSLocalizedDescriptionKey:
+                                                    "InternalError - UpdateBlock return type doesn't match completion argument type"
+                                      ])))
+        }
       } else if let error = error {
         completion(.failure(error))
       } else {
         completion(.failure(NSError(domain: "FirebaseFirestoreSwift",
                                     code: -1,
                                     userInfo: [NSLocalizedDescriptionKey:
-                                                "InternalError - Return type and Error code both nil in or updateBlock return type doesn't match completion argument type"
+                                                "InternalError - Return type and Error code are both nil"
                                     ])))
       }
     }
   }
 }
+
+#endif

--- a/Firestore/Swift/Source/Result/Transaction+Result
+++ b/Firestore/Swift/Source/Result/Transaction+Result
@@ -14,8 +14,41 @@
  * limitations under the License.
  */
  
+ import FirebaseFirestore
+ 
  extension Firestore {
-    
+  /**
+   * Executes the given updateBlock and then attempts to commit the changes applied within an atomic
+   * transaction.
+   *
+   * The maximum number of writes allowed in a single transaction is 500, but note that each usage of
+   * `FieldValue.serverTimestamp()`, `FieldValue.arrayUnion()`, `FieldValue.arrayRemove()`, or
+   * `FieldValue.increment()` inside a transaction counts as an additional write.
+   *
+   * In the updateBlock, a set of reads and writes can be performed atomically using the
+   * `Transaction` object passed to the block. After the updateBlock is run, Firestore will attempt
+   * to apply the changes to the server. If any of the data read has been modified outside of this
+   * transaction since being read, then the transaction will be retried by executing the updateBlock
+   * again. If the transaction still fails after 5 retries, then the transaction will fail.
+   *
+   * Since the updateBlock may be executed multiple times, it should avoiding doing anything that
+   * would cause side effects.
+   *
+   * Any value maybe be returned from the updateBlock. If the transaction is successfully committed,
+   * then the completion block will be passed that value. The updateBlock also has an `NSError` out
+   * parameter. If this is set, then the transaction will not attempt to commit, and the given error
+   * will be passed to the completion block.
+   *
+   * The `Transaction` object passed to the updateBlock contains methods for accessing documents
+   * and collections. Unlike other firestore access, data accessed with the transaction will not
+   * reflect local changes that have not been committed. For this reason, it is required that all
+   * reads are performed before any writes. Transactions must be performed while online. Otherwise,
+   * reads will fail, the final commit will fail, and the completion block will return an error.
+   *
+   * @param updateBlock The block to execute within the transaction context.
+   * @param completion The block to call with the result or error of the transaction. This
+   *     block will run even if the client is offline, unless the process is killed.
+   */
   func runTransaction<T>(_ updateBlock: (Transaction) -> Result<T, Error>, completion: (Result<T, Error>) -> Void) {
     runTransaction { transaction, _ in updateBlock(transaction) } completion: { value, error in
       if let result = value as? Result<T, Error> {

--- a/Firestore/Swift/Source/Result/Transaction+Result
+++ b/Firestore/Swift/Source/Result/Transaction+Result
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+ extension Firestore {
+    
+  func runTransaction<T>(_ updateBlock: (Transaction) -> Result<T, Error>, completion: (Result<T, Error>) -> Void) {
+    runTransaction { transaction, _ in updateBlock(transaction) } completion: { value, error in
+      if let result = value as? Result<T, Error> {
+        completion(result)
+      } else if let error = error {
+        completion(.failure(error))
+      } else {
+        completion(.failure(NSError(domain: "FirebaseFirestoreSwift",
+                                    code: -1,
+                                    userInfo: [NSLocalizedDescriptionKey:
+                                                "InternalError - Return type and Error code both nil in or updateBlock return type doesn't match completion argument type"
+                                    ])))
+      }
+    }
+  }
+}

--- a/Firestore/Swift/Source/Result/Transaction+Result
+++ b/Firestore/Swift/Source/Result/Transaction+Result
@@ -49,7 +49,7 @@
    * @param completion The block to call with the result or error of the transaction. This
    *     block will run even if the client is offline, unless the process is killed.
    */
-  func runTransaction<T>(_ updateBlock: (Transaction) -> Result<T, Error>, completion: (Result<T, Error>) -> Void) {
+  func runTransaction<T>(_ updateBlock: @escaping (Transaction) -> Result<T, Error>, completion: @escaping (Result<T, Error>) -> Void) {
     runTransaction { transaction, _ in updateBlock(transaction) } completion: { value, error in
       if let result = value as? Result<T, Error> {
         completion(result)


### PR DESCRIPTION
This is a strong-typed mapping of runTransaction, that makes usage of generics and Result.
The key difference is that Error is not passed with ErrorPointer.pointee but with `return .failure(myError)`
```swift
extension Firestore {
    
    func runTransaction<T>(_ updateBlock: @escaping (Transaction) -> Result<T, Error>, completion: @escaping (Result<T, Error>) -> Void) {
        runTransaction { transaction, _ in updateBlock(transaction) } completion: { value, error in
            if let result = value as? Result<T, Error> {
                completion(result)
            } else if let error = error {
                completion(.failure(error))
            } else {
                completion(.failure(NSError(domain: "FirebaseFirestoreSwift",
                                            code: -1,
                                            userInfo: [NSLocalizedDescriptionKey:
                                                        "InternalError - Return type and Error code both nil in or updateBlock return type doesn't match completion argument type"
                                            ])))
            }
        }
    }
}
```
So [the first example in docs](https://firebase.google.com/docs/firestore/manage-data/transactions):
```swift
let sfReference = db.collection("cities").document("SF")

db.runTransaction({ (transaction, errorPointer) -> Any? in
    let sfDocument: DocumentSnapshot
    do {
        try sfDocument = transaction.getDocument(sfReference)
    } catch let fetchError as NSError {
        errorPointer?.pointee = fetchError
        return nil
    }

    guard let oldPopulation = sfDocument.data()?["population"] as? Int else {
        let error = NSError(
            domain: "AppErrorDomain",
            code: -1,
            userInfo: [
                NSLocalizedDescriptionKey: "Unable to retrieve population from snapshot \(sfDocument)"
            ]
        )
        errorPointer?.pointee = error
        return nil
    }

    // Note: this could be done without a transaction
    //       by updating the population using FieldValue.increment()
    transaction.updateData(["population": oldPopulation + 1], forDocument: sfReference)
    return nil
}) { (object, error) in
    if let error = error {
        print("Transaction failed: \(error)")
    } else {
        print("Transaction successfully committed!")
    }
}
```
becomes:
```swift
let sfReference = db.collection("cities").document("SF")

db.runTransaction { transaction in
    let sfDocument: DocumentSnapshot
    do {
        try sfDocument = transaction.getDocument(sfReference)
    } catch let fetchError as NSError {
        return  .failure(fetchError)
    }

    guard let oldPopulation = sfDocument.data()?["population"] as? Int else {
        let error = NSError(
            domain: "AppErrorDomain",
            code: -1,
            userInfo: [
                NSLocalizedDescriptionKey: "Unable to retrieve population from snapshot \(sfDocument)"
            ]
        )
        return .failure(error)
    }

    // Note: this could be done without a transaction
    //       by updating the population using FieldValue.increment()
    transaction.updateData(["population": oldPopulation + 1], forDocument: sfReference)
    return .success(())
} completion: { result in
    switch result {
    case .success:
         print("Transaction successfully committed!")
    case .failure(let error):
        print("Transaction failed: \(error)")
    }
}
```
Note that in this example is not evident the advantage of using generics.
Hoping this could be useful!