### PR TITLE
Crashlytics build fix

### DIFF
--- a/Crashlytics/Shared/FIRCLSConstants.m
+++ b/Crashlytics/Shared/FIRCLSConstants.m
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #import "Crashlytics/Shared/FIRCLSConstants.h"
-#import "FirebaseCore/Sources/Public/FirebaseCore/FIRVersion.h"
+#import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -98,7 +98,7 @@ Pod::Spec.new do |s|
 
   s.test_spec 'unit' do |unit_tests|
     # Unit tests can't run on watchOS.
-    unit_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}
+    unit_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
     unit_tests.source_files = 'Crashlytics/UnitTests/*.[mh]',
                               'Crashlytics/UnitTests/*/*.[mh]'
     unit_tests.resources = 'Crashlytics/UnitTests/Data/*',


### PR DESCRIPTION
Fix `pod spec lint` issue. Public headers should not be accessed repo-relatively.

Also fixed missed test_spec target updates from 7.0.0 relelase.