### PR TITLE
Update Changelogs for 7.1.0

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# v7.1.0
 - [fixed] Fixed an issue where symbol uploads would fail when there are spaces in the project path, particularly in Unity builds (#6789).
 - [changed] Added additional logging when settings requests fail with a 404 status to help customers debug onboarding issues (#6847).
 

--- a/FirebaseMessaging/CHANGELOG.md
+++ b/FirebaseMessaging/CHANGELOG.md
@@ -1,4 +1,7 @@
-# unreleased -- v.7.0.0
+# 2020-11 -- v7.1.0
+- [fixed] Fix crash on iOS 14 when multiple app delegate completion methods are called (#6863)
+
+# 2020-10 -- v7.0.0
 - [changed] Remove the deprecated FCM direct channel API and Upstream send API. (#6430)
 - [changed] The `messaging:didReceiveRegistrationToken:` should be able to return a null token. Update the API parameter fcmToken to be nullable. (#5339)
 - [fixed] Fixed an issue that downloading an image failed when there's no extension in the file name but MIME type is set. (#6590)

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased (v7.0.1)
+# v7.1.0
 - [changed] Added the original query data to error messages for Queries that
   cannot be deserizialized.
 - [fixed] Remove explicit MobileCoreServices library linkage from podspec

--- a/GoogleDataTransport/CHANGELOG.md
+++ b/GoogleDataTransport/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# v8.0.1
 - Remove `GCC_TREAT_WARNINGS_AS_ERRORS` from the podspec.
 - Reduce pre-main startup time footprint. (#6855)
 


### PR DESCRIPTION
We need to update the process for managing Changelogs. In the meantime, here are updates for 7.1.0.