### PR TITLE
FIRApp optimize config time

### DIFF
--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Firebase 7.1.0
+- [fixed] `+[FIRApp registerInternalLibrary:withName:]` takes too much time. (#6902)
+
 # Firebase 7.0.0
 - [changed] Update minimum iOS version to iOS 10 except for Analytics which is now iOS 9. (#4847)
 - [changed] Update minimum macOS version to 10.12.

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Firebase 7.1.0
-- [fixed] `+[FIRApp registerInternalLibrary:withName:]` takes too much time. (#6902)
+- [fixed] Reduced `FirebaseApp.configure()` and `+[FIRApp registerInternalLibrary:withName:]` impact on app launch time. (#6902)
 
 # Firebase 7.0.0
 - [changed] Update minimum iOS version to iOS 10 except for Analytics which is now iOS 9. (#4847)

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Firebase 7.1.0
+# Firebase 7.2.0
 - [fixed] Reduced `FirebaseApp.configure()` and `+[FIRApp registerInternalLibrary:withName:]` impact on app launch time. (#6902)
 
 # Firebase 7.0.0

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -348,8 +348,6 @@ static FIRApp *sDefaultApp;
     return NO;
   }
 
-  [self logCoreTelemetryIfEnabled];
-
 #if TARGET_OS_IOS
   // Initialize the Analytics once there is a valid options under default app. Analytics should
   // always initialize first by itself before the other SDKs.
@@ -853,7 +851,9 @@ static FIRApp *sDefaultApp;
 
 - (void)logCoreTelemetryIfEnabled {
   if ([self isDataCollectionDefaultEnabled]) {
-    [FIRCoreDiagnosticsConnector logCoreTelemetryWithOptions:_options];
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+      [FIRCoreDiagnosticsConnector logCoreTelemetryWithOptions:[self options]];
+    });
   }
 }
 

--- a/FirebaseCore/Sources/FIRFirebaseUserAgent.m
+++ b/FirebaseCore/Sources/FIRFirebaseUserAgent.m
@@ -21,6 +21,7 @@
 @interface FIRFirebaseUserAgent ()
 
 @property(nonatomic, readonly) NSMutableDictionary<NSString *, NSString *> *valuesByComponent;
+@property(nonatomic, readonly) NSDictionary<NSString *, NSString *> *environmentComponents;
 @property(nonatomic, readonly) NSString *firebaseUserAgent;
 
 @end
@@ -28,11 +29,12 @@
 @implementation FIRFirebaseUserAgent
 
 @synthesize firebaseUserAgent = _firebaseUserAgent;
+@synthesize environmentComponents = _environmentComponents;
 
 - (instancetype)init {
   self = [super init];
   if (self) {
-    _valuesByComponent = [[[self class] environmentComponents] mutableCopy];
+    _valuesByComponent = [[NSMutableDictionary alloc] init];
   }
   return self;
 }
@@ -40,13 +42,16 @@
 - (NSString *)firebaseUserAgent {
   @synchronized(self) {
     if (_firebaseUserAgent == nil) {
+      NSMutableDictionary<NSString *, NSString *> *allComponents =
+          [self.valuesByComponent mutableCopy];
+      [allComponents setValuesForKeysWithDictionary:self.environmentComponents];
+
       __block NSMutableArray<NSString *> *components =
           [[NSMutableArray<NSString *> alloc] initWithCapacity:self.valuesByComponent.count];
-      [self.valuesByComponent
-          enumerateKeysAndObjectsUsingBlock:^(NSString *_Nonnull name, NSString *_Nonnull value,
-                                              BOOL *_Nonnull stop) {
-            [components addObject:[NSString stringWithFormat:@"%@/%@", name, value]];
-          }];
+      [allComponents enumerateKeysAndObjectsUsingBlock:^(
+                         NSString *_Nonnull name, NSString *_Nonnull value, BOOL *_Nonnull stop) {
+        [components addObject:[NSString stringWithFormat:@"%@/%@", name, value]];
+      }];
       [components sortUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
       _firebaseUserAgent = [components componentsJoinedByString:@" "];
     }
@@ -72,6 +77,13 @@
 }
 
 #pragma mark - Environment components
+
+- (NSDictionary<NSString *, NSString *> *)environmentComponents {
+  if (_environmentComponents == nil) {
+    _environmentComponents = [[self class] environmentComponents];
+  }
+  return _environmentComponents;
+}
 
 + (NSDictionary<NSString *, NSString *> *)environmentComponents {
   NSMutableDictionary<NSString *, NSString *> *components = [NSMutableDictionary dictionary];

--- a/FirebaseCore/Tests/Unit/FIRAppTest.m
+++ b/FirebaseCore/Tests/Unit/FIRAppTest.m
@@ -910,12 +910,6 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
 
 #pragma mark - Core Diagnostics
 
-- (void)testCoreDiagnosticsLoggedWhenFIRAppIsConfigured {
-  [self expectCoreDiagnosticsDataLogWithOptions:[self appOptions]];
-  [self createConfiguredAppWithName:NSStringFromSelector(_cmd)];
-  OCMVerifyAll(self.mockCoreDiagnosticsConnector);
-}
-
 - (void)testCoreDiagnosticsLoggedWhenAppDidBecomeActive {
   FIRApp *app = [self createConfiguredAppWithName:NSStringFromSelector(_cmd)];
   [self expectCoreDiagnosticsDataLogWithOptions:app.options];
@@ -923,7 +917,7 @@ NSString *const kFIRTestAppName2 = @"test-app-name-2";
   [self.notificationCenter postNotificationName:[self appDidBecomeActiveNotificationName]
                                          object:nil];
 
-  OCMVerifyAll(self.mockCoreDiagnosticsConnector);
+  OCMVerifyAllWithDelay(self.mockCoreDiagnosticsConnector, 0.5);
 }
 
 #pragma mark - private


### PR DESCRIPTION
Fixes #6902.

- defer initialization of Firebase user agent
- move CoreDiagnostics call to a background thread

