### PR TITLE
replace set-env with github env file workflow

### DIFF
--- a/scripts/generate_access_token.sh
+++ b/scripts/generate_access_token.sh
@@ -69,7 +69,7 @@ else
     scripts/decrypt_GHA_SECRET.sh $SERVICE_ACCOUNT ~/.credentials/$SERVICE_ACCOUNT_FILE "$plist_secret"
 fi
 
-echo "::set-env name=GOOGLE_APPLICATION_CREDENTIALS::${HOME}/.credentials/${SERVICE_ACCOUNT_FILE}"
+echo "GOOGLE_APPLICATION_CREDENTIALS=${HOME}/.credentials/${SERVICE_ACCOUNT_FILE}" >> $GITHUB_ENV
 export GOOGLE_APPLICATION_CREDENTIALS="${HOME}/.credentials/${SERVICE_ACCOUNT_FILE}"
 
 # Clone Google's Swift Auth Client Library and use it to generate a token.


### PR DESCRIPTION
Suggested workaround for security vulnerability listed at,
https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w

The following error can be spotted in the github workflow logs (example: https://github.com/firebase/firebase-ios-sdk/runs/1382322482?check_suite_focus=true, remote_config(iOS)->"Generate Access Tokens.."),
```
The `set-env` command is deprecated and will be disabled on November 16th. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```
