### PR TITLE
Escaping  url string from dynamic link parameter (issue 6786)

### DIFF
--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
@@ -404,7 +404,8 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
       if (parameters[kFIRDLParameterLink]) {
         FIRDynamicLink *dynamicLink = [[FIRDynamicLink alloc] init];
         NSString *urlString = parameters[kFIRDLParameterLink];
-        NSURL *deepLinkURL = [NSURL URLWithString:urlString];
+        NSString *urlStringEscaped = [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+        NSURL *deepLinkURL = [NSURL URLWithString:urlStringEscaped];
         if (deepLinkURL) {
           dynamicLink.url = deepLinkURL;
           dynamicLink.matchType = FIRDLMatchTypeUnique;


### PR DESCRIPTION
More info here: https://github.com/firebase/firebase-ios-sdk/issues/6786