### PR TITLE
Disable build dependencies.

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -25,7 +25,7 @@ jobs:
 
   package:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    #if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
     needs: build
     runs-on: macOS-latest
     steps:

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -25,7 +25,7 @@ jobs:
 
   package:
     # Don't run on private repo.
-    #if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
     needs: build
     runs-on: macOS-latest
     steps:
@@ -225,8 +225,7 @@ jobs:
 
   quickstart_framework_database:
     # Don't run on private repo.
-    # DO NOT SUBMIT
-    #    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
     needs: package
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -321,8 +320,7 @@ jobs:
 
   quickstart_framework_firestore:
     # Don't run on private repo.
-    # DO NOT SUBMIT.
-    #    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
     needs: package
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -225,7 +225,8 @@ jobs:
 
   quickstart_framework_database:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    # DO NOT SUBMIT
+    #    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
     needs: package
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -320,7 +321,8 @@ jobs:
 
   quickstart_framework_firestore:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    # DO NOT SUBMIT.
+    #    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
     needs: package
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}

--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -109,10 +109,10 @@ struct ZipBuilder {
     /// - Parameter logsOutputDir: The output directory for any logs. If `nil`, a temporary
     ///      directory will be used.
     init(repoDir: URL,
-         buildRoot: URL? = nil,
-         outputDir: URL? = nil,
-         localPodspecPath: URL? = nil,
-         logsOutputDir: URL? = nil) {
+         buildRoot: URL?,
+         outputDir: URL?,
+         localPodspecPath: URL?,
+         logsOutputDir: URL?) {
       self.repoDir = repoDir
       self.buildRoot = buildRoot
       self.outputDir = outputDir

--- a/ReleaseTooling/Sources/ZipBuilder/main.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/main.swift
@@ -205,6 +205,7 @@ struct ZipBuilderTool: ParsableCommand {
     let paths = ZipBuilder.FilesystemPaths(repoDir: repoDir,
                                            buildRoot: buildRoot,
                                            outputDir: outputDir,
+                                           localPodspecPath: localPodspecPath,
                                            logsOutputDir: outputDir?
                                              .appendingPathComponent("build_logs"))
 

--- a/scripts/build_non_firebase_sdks.sh
+++ b/scripts/build_non_firebase_sdks.sh
@@ -36,7 +36,7 @@ done
 echo "]" >>  "${ZIP_POD_JSON}"
 mkdir -p "${REPO}"/sdk_zip
 swift run zip-builder --keep-build-artifacts --update-pod-repo --repo-dir "${REPO}" \
-    --zip-pods "${ZIP_POD_JSON}" --output-dir "${REPO}"/sdk_zip --enable-build-dependencies
+    --zip-pods "${ZIP_POD_JSON}" --output-dir "${REPO}"/sdk_zip --disable-build-dependencies
 
 unzip -o "${REPO}"/sdk_zip/Frameworks.zip -d "${HOME}"/ios_frameworks/Firebase/
 


### PR DESCRIPTION
This should fix #6973. Was accidentally enabled when migrating the argument names.

#no-changelog