### PR TITLE
Googletest - Xcode integration improvements

### DIFF
--- a/Firestore/core/test/unit/FSTGoogleTestTests.mm
+++ b/Firestore/core/test/unit/FSTGoogleTestTests.mm
@@ -84,14 +84,18 @@ NSSet<NSString*>* _Nullable LoadXCTestConfigurationTestsToRun() {
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 || \
     __MAC_OS_X_VERSION_MAX_ALLOWED >= 101300
-  NSError *error;
-  NSData *data = [NSData dataWithContentsOfFile:filePath options:kNilOptions error:&error];
+  NSError* error;
+  NSData* data = [NSData dataWithContentsOfFile:filePath
+                                        options:kNilOptions
+                                          error:&error];
   if (!data) {
-      NSLog(@"Failed to fill data with contents of file. %@", error);
-      return nil;
+    NSLog(@"Failed to fill data with contents of file. %@", error);
+    return nil;
   }
 
-  id config = [NSKeyedUnarchiver unarchivedObjectOfClass:NSObject.class fromData:data error:&error];
+  id config = [NSKeyedUnarchiver unarchivedObjectOfClass:NSObject.class
+                                                fromData:data
+                                                   error:&error];
 #else
   id config = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
 #endif
@@ -227,8 +231,7 @@ void XCTestMethod(XCTestCase* self, SEL _cmd) {
     // Let XCode know that the test ran and succeeded.
     XCTAssertTrue(true);
     return;
-  }
-  else if (result->Skipped()) {
+  } else if (result->Skipped()) {
     // Let XCode know that the test was skipped.
     XCTSkip();
   }

--- a/Firestore/core/test/unit/FSTGoogleTestTests.mm
+++ b/Firestore/core/test/unit/FSTGoogleTestTests.mm
@@ -82,10 +82,23 @@ NSSet<NSString*>* _Nullable LoadXCTestConfigurationTestsToRun() {
     return nil;
   }
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 || \
+    __MAC_OS_X_VERSION_MAX_ALLOWED >= 101300
+  NSError *error;
+  NSData *data = [NSData dataWithContentsOfFile:filePath options:kNilOptions error:&error];
+  if (!data) {
+      NSLog(@"Failed to fill data with contents of file. %@", error);
+      return nil;
+  }
+
+  id config = [NSKeyedUnarchiver unarchivedObjectOfClass:NSObject.class fromData:data error:&error];
+#else
   id config = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
+#endif
+
   if (!config) {
-    NSLog(@"Failed to load any configuaration from %@=%@", configEnvVar,
-          filePath);
+    NSLog(@"Failed to load any configuaration from %@=%@. %@", configEnvVar,
+          filePath, error);
     return nil;
   }
 

--- a/Firestore/core/test/unit/FSTGoogleTestTests.mm
+++ b/Firestore/core/test/unit/FSTGoogleTestTests.mm
@@ -228,6 +228,10 @@ void XCTestMethod(XCTestCase* self, SEL _cmd) {
     XCTAssertTrue(true);
     return;
   }
+  else if (result->Skipped()) {
+    // Let XCode know that the test was skipped.
+    XCTSkip();
+  }
 
   // Test failed :-(. Record the failure such that XCode will navigate directly
   // to the file:line.

--- a/Firestore/core/test/unit/FSTGoogleTestTests.mm
+++ b/Firestore/core/test/unit/FSTGoogleTestTests.mm
@@ -82,23 +82,23 @@ NSSet<NSString*>* _Nullable LoadXCTestConfigurationTestsToRun() {
     return nil;
   }
 
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 || \
-    __MAC_OS_X_VERSION_MAX_ALLOWED >= 101300
+  id config;
   NSError* error;
-  NSData* data = [NSData dataWithContentsOfFile:filePath
-                                        options:kNilOptions
-                                          error:&error];
-  if (!data) {
-    NSLog(@"Failed to fill data with contents of file. %@", error);
-    return nil;
-  }
+  if (@available(macOS 10.13, iOS 11, tvOS 11, *)) {
+    NSData* data = [NSData dataWithContentsOfFile:filePath
+                                          options:kNilOptions
+                                            error:&error];
+    if (!data) {
+      NSLog(@"Failed to fill data with contents of file. %@", error);
+      return nil;
+    }
 
-  id config = [NSKeyedUnarchiver unarchivedObjectOfClass:NSObject.class
-                                                fromData:data
-                                                   error:&error];
-#else
-  id config = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
-#endif
+    config = [NSKeyedUnarchiver unarchivedObjectOfClass:NSObject.class
+                                               fromData:data
+                                                  error:&error];
+  } else {
+    config = [NSKeyedUnarchiver unarchiveObjectWithFile:filePath];
+  }
 
   if (!config) {
     NSLog(@"Failed to load any configuaration from %@=%@. %@", configEnvVar,
@@ -232,8 +232,12 @@ void XCTestMethod(XCTestCase* self, SEL _cmd) {
     XCTAssertTrue(true);
     return;
   } else if (result->Skipped()) {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130400 || \
+    __TV_OS_VERSION_MAX_ALLOWED >= 130400 ||     \
+    __MAC_OS_X_VERSION_MAX_ALLOWED >= 101504
     // Let XCode know that the test was skipped.
     XCTSkip();
+#endif
   }
 
   // Test failed :-(. Record the failure such that XCode will navigate directly


### PR DESCRIPTION
I added case to support tests that are skipped in google test so Xcode does not show them as fails.

I also removed use of deprecated unarchiveObjectWithFile method, however this needs to be tested. 
scripts/check.sh did not show any problems, but I do not know if edited code is being tested anywhere and I was not able to run any google tests which would use the edited code flow (in Xcode GUI, I specified unit tests to run, disabled selected tests, and so on, but each call of the edited method failed because of empty 'filePath' in both code versions).