### PR TITLE
GDT storage cleanup: optimizations for big amount of pending events

### DIFF
--- a/GoogleDataTransport.podspec
+++ b/GoogleDataTransport.podspec
@@ -65,6 +65,8 @@ Shared library for iOS SDK data transport needs.
         'GoogleDataTransport/GDTTestApp/*.swift',
         'GoogleDataTransport/GDTCORLibrary/Internal/GDTCORRegistrar.h',
         'GoogleDataTransport/GDTCORLibrary/Internal/GDTCORUploader.h',
+        'GoogleDataTransport/GDTCORTests/Common/Categories/GDTCORFlatFileStorage+Testing.h',
+        'GoogleDataTransport/GDTCORTests/Unit/Helpers/*.[hm]',
         'GoogleDataTransport/GDTTestApp/Bridging-Header.h',
       ]
 

--- a/GoogleDataTransport/CHANGELOG.md
+++ b/GoogleDataTransport/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v8.0.2
+- Fix out-of-memory crash for a big amount of pending events. (#6995)
+
 # v8.0.1
 - Remove `GCC_TREAT_WARNINGS_AS_ERRORS` from the podspec.
 - Reduce pre-main startup time footprint. (#6855)

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORDirectorySizeTracker.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORDirectorySizeTracker.m
@@ -80,10 +80,12 @@
                     }];
 
   for (NSURL *fileURL in enumerator) {
-    NSNumber *isRegularFile;
-    [fileURL getResourceValue:&isRegularFile forKey:NSURLIsRegularFileKey error:nil];
-    if (isRegularFile.boolValue) {
-      totalBytes += [self fileSizeAtURL:fileURL];
+    @autoreleasepool {
+      NSNumber *isRegularFile;
+      [fileURL getResourceValue:&isRegularFile forKey:NSURLIsRegularFileKey error:nil];
+      if (isRegularFile.boolValue) {
+        totalBytes += [self fileSizeAtURL:fileURL];
+      }
     }
   }
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -407,16 +407,14 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
     NSArray<NSString *> *batchDataPaths = [fileManager contentsOfDirectoryAtPath:batchDataPath
                                                                            error:nil];
     for (NSString *path in batchDataPaths) {
-      @autoreleasepool {
-        NSString *fileName = [path lastPathComponent];
-        NSDictionary<NSString *, id> *batchComponents = [self batchComponentsFromFilename:fileName];
-        NSDate *expirationDate = batchComponents[kGDTCORBatchComponentsExpirationKey];
+      NSString *fileName = [path lastPathComponent];
+      NSDictionary<NSString *, id> *batchComponents = [self batchComponentsFromFilename:fileName];
+      NSDate *expirationDate = batchComponents[kGDTCORBatchComponentsExpirationKey];
+      NSNumber *batchID = batchComponents[kGDTCORBatchComponentsBatchIDKey];
+      if (expirationDate != nil && expirationDate.timeIntervalSince1970 < now && batchID != nil) {
         NSNumber *batchID = batchComponents[kGDTCORBatchComponentsBatchIDKey];
-        if (expirationDate != nil && expirationDate.timeIntervalSince1970 < now && batchID != nil) {
-          NSNumber *batchID = batchComponents[kGDTCORBatchComponentsBatchIDKey];
-          // Move all events from the expired batch back to the main storage.
-          [self syncThreadUnsafeRemoveBatchWithID:batchID deleteEvents:NO];
-        }
+        // Move all events from the expired batch back to the main storage.
+        [self syncThreadUnsafeRemoveBatchWithID:batchID deleteEvents:NO];
       }
     }
 
@@ -424,28 +422,18 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
     NSString *eventDataPath = [GDTCORFlatFileStorage eventDataStoragePath];
     NSDirectoryEnumerator *enumerator = [fileManager enumeratorAtPath:eventDataPath];
     NSString *path;
-
-    while (YES) {
-      @autoreleasepool {
-
-        // Call `[enumerator nextObject]` under autorelease pool to make sure all autoreleased objects created under the hood are released on each iteration end to avoid unnecessary memory growth.
-        path = [enumerator nextObject];
-        if (path == nil) {
-          break;
-        }
-
-        NSString *fileName = [path lastPathComponent];
-        NSDictionary<NSString *, id> *eventComponents = [self eventComponentsFromFilename:fileName];
-        NSDate *expirationDate = eventComponents[kGDTCOREventComponentsExpirationKey];
-        if (expirationDate != nil && expirationDate.timeIntervalSince1970 < now) {
-          NSString *pathToDelete = [eventDataPath stringByAppendingPathComponent:path];
-          NSError *error;
-          [fileManager removeItemAtPath:pathToDelete error:&error];
-          if (error != nil) {
-            GDTCORLogDebug(@"There was an error deleting an expired item: %@", error);
-          } else {
-            GDTCORLogDebug(@"Item deleted because it expired: %@", pathToDelete);
-          }
+    while ((path = [enumerator nextObject])) {
+      NSString *fileName = [path lastPathComponent];
+      NSDictionary<NSString *, id> *eventComponents = [self eventComponentsFromFilename:fileName];
+      NSDate *expirationDate = eventComponents[kGDTCOREventComponentsExpirationKey];
+      if (expirationDate != nil && expirationDate.timeIntervalSince1970 < now) {
+        NSString *pathToDelete = [eventDataPath stringByAppendingPathComponent:path];
+        NSError *error;
+        [fileManager removeItemAtPath:pathToDelete error:&error];
+        if (error != nil) {
+          GDTCORLogDebug(@"There was an error deleting an expired item: %@", error);
+        } else {
+          GDTCORLogDebug(@"Item deleted because it expired: %@", pathToDelete);
         }
       }
     }
@@ -559,30 +547,28 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
   };
 
   for (NSString *batchDirPath in batchDirPaths) {
-    @autoreleasepool {
-      if (deleteEvents) {
-        removeBatchDir(batchDirPath);
+    if (deleteEvents) {
+      removeBatchDir(batchDirPath);
+    } else {
+      NSString *batchDirName = [batchDirPath lastPathComponent];
+      NSDictionary<NSString *, id> *components = [self batchComponentsFromFilename:batchDirName];
+      NSNumber *target = components[kGDTCORBatchComponentsTargetKey];
+      NSString *destinationPath = [[GDTCORFlatFileStorage eventDataStoragePath]
+          stringByAppendingPathComponent:target.stringValue];
+
+      // `- [NSFileManager moveItemAtPath:toPath:error:]` method fails if an item by the
+      // destination path already exists (which usually is the case for the current method). Move
+      // the events one by one instead.
+      if ([self moveContentsOfDirectoryAtPath:batchDirPath to:destinationPath error:&error]) {
+        GDTCORLogDebug(@"Batched events at path: %@ moved back to the storage: %@", batchDirPath,
+                       destinationPath);
       } else {
-        NSString *batchDirName = [batchDirPath lastPathComponent];
-        NSDictionary<NSString *, id> *components = [self batchComponentsFromFilename:batchDirName];
-        NSNumber *target = components[kGDTCORBatchComponentsTargetKey];
-        NSString *destinationPath = [[GDTCORFlatFileStorage eventDataStoragePath]
-            stringByAppendingPathComponent:target.stringValue];
-
-        // `- [NSFileManager moveItemAtPath:toPath:error:]` method fails if an item by the
-        // destination path already exists (which usually is the case for the current method). Move
-        // the events one by one instead.
-        if ([self moveContentsOfDirectoryAtPath:batchDirPath to:destinationPath error:&error]) {
-          GDTCORLogDebug(@"Batched events at path: %@ moved back to the storage: %@", batchDirPath,
-                         destinationPath);
-        } else {
-          GDTCORLogDebug(@"Error encountered whilst moving events back: %@", error);
-        }
-
-        // Even if not all events where moved back to the storage, there is not much can be done at
-        // this point, so cleanup batch directory now to avoid clattering.
-        removeBatchDir(batchDirPath);
+        GDTCORLogDebug(@"Error encountered whilst moving events back: %@", error);
       }
+
+      // Even if not all events where moved back to the storage, there is not much can be done at
+      // this point, so cleanup batch directory now to avoid clattering.
+      removeBatchDir(batchDirPath);
     }
   }
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -407,14 +407,16 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
     NSArray<NSString *> *batchDataPaths = [fileManager contentsOfDirectoryAtPath:batchDataPath
                                                                            error:nil];
     for (NSString *path in batchDataPaths) {
-      NSString *fileName = [path lastPathComponent];
-      NSDictionary<NSString *, id> *batchComponents = [self batchComponentsFromFilename:fileName];
-      NSDate *expirationDate = batchComponents[kGDTCORBatchComponentsExpirationKey];
-      NSNumber *batchID = batchComponents[kGDTCORBatchComponentsBatchIDKey];
-      if (expirationDate != nil && expirationDate.timeIntervalSince1970 < now && batchID != nil) {
+      @autoreleasepool {
+        NSString *fileName = [path lastPathComponent];
+        NSDictionary<NSString *, id> *batchComponents = [self batchComponentsFromFilename:fileName];
+        NSDate *expirationDate = batchComponents[kGDTCORBatchComponentsExpirationKey];
         NSNumber *batchID = batchComponents[kGDTCORBatchComponentsBatchIDKey];
-        // Move all events from the expired batch back to the main storage.
-        [self syncThreadUnsafeRemoveBatchWithID:batchID deleteEvents:NO];
+        if (expirationDate != nil && expirationDate.timeIntervalSince1970 < now && batchID != nil) {
+          NSNumber *batchID = batchComponents[kGDTCORBatchComponentsBatchIDKey];
+          // Move all events from the expired batch back to the main storage.
+          [self syncThreadUnsafeRemoveBatchWithID:batchID deleteEvents:NO];
+        }
       }
     }
 
@@ -422,18 +424,28 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
     NSString *eventDataPath = [GDTCORFlatFileStorage eventDataStoragePath];
     NSDirectoryEnumerator *enumerator = [fileManager enumeratorAtPath:eventDataPath];
     NSString *path;
-    while ((path = [enumerator nextObject])) {
-      NSString *fileName = [path lastPathComponent];
-      NSDictionary<NSString *, id> *eventComponents = [self eventComponentsFromFilename:fileName];
-      NSDate *expirationDate = eventComponents[kGDTCOREventComponentsExpirationKey];
-      if (expirationDate != nil && expirationDate.timeIntervalSince1970 < now) {
-        NSString *pathToDelete = [eventDataPath stringByAppendingPathComponent:path];
-        NSError *error;
-        [fileManager removeItemAtPath:pathToDelete error:&error];
-        if (error != nil) {
-          GDTCORLogDebug(@"There was an error deleting an expired item: %@", error);
-        } else {
-          GDTCORLogDebug(@"Item deleted because it expired: %@", pathToDelete);
+
+    while (YES) {
+      @autoreleasepool {
+
+        // Call `[enumerator nextObject]` under autorelease pool to make sure all autoreleased objects created under the hood are released on each iteration end to avoid unnecessary memory growth.
+        path = [enumerator nextObject];
+        if (path == nil) {
+          break;
+        }
+
+        NSString *fileName = [path lastPathComponent];
+        NSDictionary<NSString *, id> *eventComponents = [self eventComponentsFromFilename:fileName];
+        NSDate *expirationDate = eventComponents[kGDTCOREventComponentsExpirationKey];
+        if (expirationDate != nil && expirationDate.timeIntervalSince1970 < now) {
+          NSString *pathToDelete = [eventDataPath stringByAppendingPathComponent:path];
+          NSError *error;
+          [fileManager removeItemAtPath:pathToDelete error:&error];
+          if (error != nil) {
+            GDTCORLogDebug(@"There was an error deleting an expired item: %@", error);
+          } else {
+            GDTCORLogDebug(@"Item deleted because it expired: %@", pathToDelete);
+          }
         }
       }
     }
@@ -547,28 +559,30 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
   };
 
   for (NSString *batchDirPath in batchDirPaths) {
-    if (deleteEvents) {
-      removeBatchDir(batchDirPath);
-    } else {
-      NSString *batchDirName = [batchDirPath lastPathComponent];
-      NSDictionary<NSString *, id> *components = [self batchComponentsFromFilename:batchDirName];
-      NSNumber *target = components[kGDTCORBatchComponentsTargetKey];
-      NSString *destinationPath = [[GDTCORFlatFileStorage eventDataStoragePath]
-          stringByAppendingPathComponent:target.stringValue];
-
-      // `- [NSFileManager moveItemAtPath:toPath:error:]` method fails if an item by the
-      // destination path already exists (which usually is the case for the current method). Move
-      // the events one by one instead.
-      if ([self moveContentsOfDirectoryAtPath:batchDirPath to:destinationPath error:&error]) {
-        GDTCORLogDebug(@"Batched events at path: %@ moved back to the storage: %@", batchDirPath,
-                       destinationPath);
+    @autoreleasepool {
+      if (deleteEvents) {
+        removeBatchDir(batchDirPath);
       } else {
-        GDTCORLogDebug(@"Error encountered whilst moving events back: %@", error);
-      }
+        NSString *batchDirName = [batchDirPath lastPathComponent];
+        NSDictionary<NSString *, id> *components = [self batchComponentsFromFilename:batchDirName];
+        NSNumber *target = components[kGDTCORBatchComponentsTargetKey];
+        NSString *destinationPath = [[GDTCORFlatFileStorage eventDataStoragePath]
+            stringByAppendingPathComponent:target.stringValue];
 
-      // Even if not all events where moved back to the storage, there is not much can be done at
-      // this point, so cleanup batch directory now to avoid clattering.
-      removeBatchDir(batchDirPath);
+        // `- [NSFileManager moveItemAtPath:toPath:error:]` method fails if an item by the
+        // destination path already exists (which usually is the case for the current method). Move
+        // the events one by one instead.
+        if ([self moveContentsOfDirectoryAtPath:batchDirPath to:destinationPath error:&error]) {
+          GDTCORLogDebug(@"Batched events at path: %@ moved back to the storage: %@", batchDirPath,
+                         destinationPath);
+        } else {
+          GDTCORLogDebug(@"Error encountered whilst moving events back: %@", error);
+        }
+
+        // Even if not all events where moved back to the storage, there is not much can be done at
+        // this point, so cleanup batch directory now to avoid clattering.
+        removeBatchDir(batchDirPath);
+      }
     }
   }
 

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORFlatFileStorage.m
@@ -427,8 +427,9 @@ const uint64_t kGDTCORFlatFileStorageSizeLimit = 20 * 1000 * 1000;  // 20 MB.
 
     while (YES) {
       @autoreleasepool {
-
-        // Call `[enumerator nextObject]` under autorelease pool to make sure all autoreleased objects created under the hood are released on each iteration end to avoid unnecessary memory growth.
+        // Call `[enumerator nextObject]` under autorelease pool to make sure all autoreleased
+        // objects created under the hood are released on each iteration end to avoid unnecessary
+        // memory growth.
         path = [enumerator nextObject];
         if (path == nil) {
           break;

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
@@ -113,7 +113,9 @@
 }
 
 - (void)signalToStoragesToCheckExpirations {
-  for (id<GDTCORStorageProtocol> storage in [_registrar.targetToStorage allValues]) {
+  // The same storage may be associated with several targets. Make sure we check for expirations only once per storage.
+  NSSet<id<GDTCORStorageProtocol>> *storages = [NSSet setWithArray:[_registrar.targetToStorage allValues]];
+  for (id<GDTCORStorageProtocol> storage in storages) {
     [storage checkForExpirations];
   }
 }

--- a/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
@@ -113,8 +113,10 @@
 }
 
 - (void)signalToStoragesToCheckExpirations {
-  // The same storage may be associated with several targets. Make sure we check for expirations only once per storage.
-  NSSet<id<GDTCORStorageProtocol>> *storages = [NSSet setWithArray:[_registrar.targetToStorage allValues]];
+  // The same storage may be associated with several targets. Make sure to check for expirations
+  // only once per storage.
+  NSSet<id<GDTCORStorageProtocol>> *storages =
+      [NSSet setWithArray:[_registrar.targetToStorage allValues]];
   for (id<GDTCORStorageProtocol> storage in storages) {
     [storage checkForExpirations];
   }

--- a/GoogleDataTransport/GDTTestApp/Bridging-Header.h
+++ b/GoogleDataTransport/GDTTestApp/Bridging-Header.h
@@ -14,3 +14,6 @@
 
 #import "GoogleDataTransport/GDTCORLibrary/Internal/GDTCORUploader.h"
 #import "GoogleDataTransport/GDTCORLibrary/Private/GDTCORUploadCoordinator.h"
+#import "GoogleDataTransport/GDTCORTests/Common/Categories/GDTCORFlatFileStorage+Testing.h"
+
+#import "GoogleDataTransport/GDTCORTests/Unit/Helpers/GDTCOREventGenerator.h"

--- a/GoogleDataTransport/GDTTestApp/EventCleanupPerfTest.swift
+++ b/GoogleDataTransport/GDTTestApp/EventCleanupPerfTest.swift
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+import GoogleDataTransport
+
+import os.signpost
+
+@available(iOS 12.0, *)
+class EventCleanupPerfTest {
+  static let log = OSLog(subsystem: "GoogleDataTransport-TestApp", category: "EventCleanupPerfTest")
+
+  static func run(completion: @escaping () -> Void) {
+    let signpostID = OSSignpostID(log: log)
+
+    generateTestEvents {
+      os_signpost(.begin, log: log, name: "checkForExpirations", signpostID: signpostID)
+      GDTCORFlatFileStorage.sharedInstance().checkForExpirations()
+
+      GDTCORFlatFileStorage.sharedInstance().storageQueue.async {
+        os_signpost(.end, log: log, name: "checkForExpirations", signpostID: signpostID)
+        completion()
+      }
+    }
+  }
+
+  static func generateTestEvents(_ completion: @escaping ()->Void) {
+    let signpostID = OSSignpostID(log: log)
+
+    let group = DispatchGroup()
+
+    os_signpost(.begin, log: log, name: "generateTestEvents", signpostID: signpostID)
+
+    let _ = (0..<1000).compactMap { (_) -> GDTCOREvent? in
+      group.enter()
+      let event = GDTCOREventGenerator.generateEvent(for: .test, qosTier: nil, mappingID: nil)
+      GDTCORFlatFileStorage.sharedInstance().store(event) { (_, _) in
+        group.leave()
+      }
+
+      return event
+    }
+
+    group.notify(queue: .main) {
+      os_signpost(.end, log: log, name: "generateTestEvents", signpostID: signpostID)
+      completion()
+    }
+
+  }
+}

--- a/GoogleDataTransport/GDTTestApp/EventCleanupPerfTest.swift
+++ b/GoogleDataTransport/GDTTestApp/EventCleanupPerfTest.swift
@@ -20,6 +20,7 @@ import GoogleDataTransport
 
 import os.signpost
 
+/// The test actions to run under the profiler to measure performance of `GDTCORFlatFileStorage.checkForExpirations()` method.
 @available(iOS 12.0, *)
 class EventCleanupPerfTest {
   static let log = OSLog(subsystem: "GoogleDataTransport-TestApp", category: "EventCleanupPerfTest")
@@ -38,17 +39,17 @@ class EventCleanupPerfTest {
     }
   }
 
-  static func generateTestEvents(_ completion: @escaping ()->Void) {
+  static func generateTestEvents(_ completion: @escaping () -> Void) {
     let signpostID = OSSignpostID(log: log)
 
     let group = DispatchGroup()
 
     os_signpost(.begin, log: log, name: "generateTestEvents", signpostID: signpostID)
 
-    let _ = (0..<1000).compactMap { (_) -> GDTCOREvent? in
+    _ = (0 ..< 1000).compactMap { (_) -> GDTCOREvent? in
       group.enter()
       let event = GDTCOREventGenerator.generateEvent(for: .test, qosTier: nil, mappingID: nil)
-      GDTCORFlatFileStorage.sharedInstance().store(event) { (_, _) in
+      GDTCORFlatFileStorage.sharedInstance().store(event) { _, _ in
         group.leave()
       }
 
@@ -59,6 +60,5 @@ class EventCleanupPerfTest {
       os_signpost(.end, log: log, name: "generateTestEvents", signpostID: signpostID)
       completion()
     }
-
   }
 }

--- a/GoogleDataTransport/GDTTestApp/EventCleanupPerfTest.swift
+++ b/GoogleDataTransport/GDTTestApp/EventCleanupPerfTest.swift
@@ -28,13 +28,13 @@ class EventCleanupPerfTest {
   static func run(completion: @escaping () -> Void) {
     let signpostID = OSSignpostID(log: log)
 
-      os_signpost(.begin, log: log, name: "checkForExpirations", signpostID: signpostID)
-      GDTCORFlatFileStorage.sharedInstance().checkForExpirations()
+    os_signpost(.begin, log: log, name: "checkForExpirations", signpostID: signpostID)
+    GDTCORFlatFileStorage.sharedInstance().checkForExpirations()
 
-      GDTCORFlatFileStorage.sharedInstance().storageQueue.async {
-        os_signpost(.end, log: log, name: "checkForExpirations", signpostID: signpostID)
-        completion()
-      }
+    GDTCORFlatFileStorage.sharedInstance().storageQueue.async {
+      os_signpost(.end, log: log, name: "checkForExpirations", signpostID: signpostID)
+      completion()
+    }
   }
 
   static func generateTestEvents(count: Int, _ completion: @escaping () -> Void) {

--- a/GoogleDataTransport/GDTTestApp/EventCleanupPerfTest.swift
+++ b/GoogleDataTransport/GDTTestApp/EventCleanupPerfTest.swift
@@ -28,7 +28,6 @@ class EventCleanupPerfTest {
   static func run(completion: @escaping () -> Void) {
     let signpostID = OSSignpostID(log: log)
 
-    generateTestEvents {
       os_signpost(.begin, log: log, name: "checkForExpirations", signpostID: signpostID)
       GDTCORFlatFileStorage.sharedInstance().checkForExpirations()
 
@@ -36,17 +35,16 @@ class EventCleanupPerfTest {
         os_signpost(.end, log: log, name: "checkForExpirations", signpostID: signpostID)
         completion()
       }
-    }
   }
 
-  static func generateTestEvents(_ completion: @escaping () -> Void) {
+  static func generateTestEvents(count: Int, _ completion: @escaping () -> Void) {
     let signpostID = OSSignpostID(log: log)
 
     let group = DispatchGroup()
 
     os_signpost(.begin, log: log, name: "generateTestEvents", signpostID: signpostID)
 
-    _ = (0 ..< 1000).compactMap { (_) -> GDTCOREvent? in
+    _ = (0 ..< count).compactMap { (_) -> GDTCOREvent? in
       group.enter()
       let event = GDTCOREventGenerator.generateEvent(for: .test, qosTier: nil, mappingID: nil)
       GDTCORFlatFileStorage.sharedInstance().store(event) { _, _ in

--- a/GoogleDataTransport/GDTTestApp/app.swift
+++ b/GoogleDataTransport/GDTTestApp/app.swift
@@ -27,6 +27,7 @@ import GoogleDataTransport
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication
                        .LaunchOptionsKey: Any]?) -> Bool {
+      GDTCORConsoleLoggerLoggingLevel = GDTCORLoggingLevel.debug.rawValue
       return true
     }
   }

--- a/GoogleDataTransport/GDTTestApp/app.swift
+++ b/GoogleDataTransport/GDTTestApp/app.swift
@@ -34,6 +34,7 @@ import GoogleDataTransport
   public class ViewController: UIViewController {
     let transport: GDTCORTransport = GDTCORTransport(mappingID: "1234", transformers: nil,
                                                      target: GDTCORTarget.test)!
+    @IBOutlet var statusLabel: UILabel!
   }
 
 // macOS specifics.

--- a/GoogleDataTransport/GDTTestApp/ios/Main.storyboard
+++ b/GoogleDataTransport/GDTTestApp/ios/Main.storyboard
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina6_1" orientation="portrait" appearance="dark"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController storyboardIdentifier="MainViewController" id="BYZ-38-t0r" customClass="ViewController" customModule="GoogleDataTransport_iOS_TestApp" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="MainViewController" id="BYZ-38-t0r" customClass="ViewController" customModule="GoogleDataTransport_TestApp" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="g2S-RU-pP8"/>
                         <viewControllerLayoutGuide type="bottom" id="adO-yW-BBx"/>
@@ -19,103 +19,141 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="674-uo-mtw">
-                                <rect key="frame" x="20" y="98" width="369" height="55"/>
-                                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="55" id="xfr-R6-SiR"/>
-                                </constraints>
-                                <state key="normal" title="Generate data event">
-                                    <color key="titleShadowColor" cocoaTouchSystemColor="darkTextColor"/>
-                                </state>
-                                <connections>
-                                    <action selector="generateDataEventWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="iph-QW-BXy"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FD9-Mn-in7">
-                                <rect key="frame" x="20" y="161" width="369" height="55"/>
-                                <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="55" id="0Uy-Mh-vns"/>
-                                </constraints>
-                                <state key="normal" title="Generate telemetry event">
-                                    <color key="titleShadowColor" cocoaTouchSystemColor="darkTextColor"/>
-                                </state>
-                                <connections>
-                                    <action selector="generateTelemetryEventWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="rcX-UQ-Br6"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IFu-Rf-wNA">
-                                <rect key="frame" x="20" y="224" width="369" height="55"/>
-                                <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="55" id="SQB-HZ-Idj"/>
-                                </constraints>
-                                <state key="normal" title="Generate high priority event (force uploads)">
-                                    <color key="titleShadowColor" cocoaTouchSystemColor="darkTextColor"/>
-                                </state>
-                                <connections>
-                                    <action selector="generateHighPriorityEventWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="yWd-rX-cMS"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yTs-B1-Yoh">
-                                <rect key="frame" x="20" y="287" width="369" height="55"/>
-                                <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="55" id="GCn-oJ-52K"/>
-                                </constraints>
-                                <state key="normal" title="Generate wifi only event">
-                                    <color key="titleShadowColor" cocoaTouchSystemColor="darkTextColor"/>
-                                </state>
-                                <connections>
-                                    <action selector="generateWifiOnlyEventWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wo7-Wu-4YZ"/>
-                                </connections>
-                            </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GoogleDataTransport Test App" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L83-mC-jNW">
-                                <rect key="frame" x="20" y="52" width="236" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QpN-cI-JZa">
-                                <rect key="frame" x="20" y="350" width="369" height="55"/>
-                                <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="55" id="U3o-sp-jte"/>
-                                </constraints>
-                                <state key="normal" title="Generate daily event">
-                                    <color key="titleShadowColor" cocoaTouchSystemColor="darkTextColor"/>
-                                </state>
-                                <connections>
-                                    <action selector="generateDailyEventWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Rfm-OO-P8A"/>
-                                </connections>
-                            </button>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="4bQ-s8-gBo">
+                                <rect key="frame" x="20" y="52" width="374" height="427.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GoogleDataTransport Test App" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L83-mC-jNW">
+                                        <rect key="frame" x="0.0" y="0.0" width="374" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="674-uo-mtw">
+                                        <rect key="frame" x="0.0" y="31.5" width="374" height="55"/>
+                                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="55" id="xfr-R6-SiR"/>
+                                        </constraints>
+                                        <state key="normal" title="Generate data event">
+                                            <color key="titleShadowColor" systemColor="darkTextColor"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="generateDataEventWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="iph-QW-BXy"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FD9-Mn-in7">
+                                        <rect key="frame" x="0.0" y="97.5" width="374" height="55"/>
+                                        <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="55" id="0Uy-Mh-vns"/>
+                                        </constraints>
+                                        <state key="normal" title="Generate telemetry event">
+                                            <color key="titleShadowColor" systemColor="darkTextColor"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="generateTelemetryEventWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="rcX-UQ-Br6"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="IFu-Rf-wNA">
+                                        <rect key="frame" x="0.0" y="163.5" width="374" height="55"/>
+                                        <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="55" id="SQB-HZ-Idj"/>
+                                        </constraints>
+                                        <state key="normal" title="Generate high priority event (force uploads)">
+                                            <color key="titleShadowColor" systemColor="darkTextColor"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="generateHighPriorityEventWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="yWd-rX-cMS"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yTs-B1-Yoh">
+                                        <rect key="frame" x="0.0" y="229.5" width="374" height="55"/>
+                                        <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="55" id="GCn-oJ-52K"/>
+                                        </constraints>
+                                        <state key="normal" title="Generate wifi only event">
+                                            <color key="titleShadowColor" systemColor="darkTextColor"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="generateWifiOnlyEventWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="wo7-Wu-4YZ"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QpN-cI-JZa">
+                                        <rect key="frame" x="0.0" y="295.5" width="374" height="55"/>
+                                        <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="55" id="U3o-sp-jte"/>
+                                        </constraints>
+                                        <state key="normal" title="Generate daily event">
+                                            <color key="titleShadowColor" systemColor="darkTextColor"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="generateDailyEventWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Rfm-OO-P8A"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="k3W-pe-Kkc">
+                                        <rect key="frame" x="0.0" y="361.5" width="374" height="55"/>
+                                        <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="55" id="Uad-9A-UNO"/>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="55" id="m24-0F-HbH"/>
+                                        </constraints>
+                                        <state key="normal" title="Run event cleanup performance test">
+                                            <color key="titleShadowColor" systemColor="darkTextColor"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="runEventCleanupPerformanceTestWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="tvV-UB-Jh5"/>
+                                        </connections>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="m3L-OI-ccA" userLabel="Status label">
+                                        <rect key="frame" x="0.0" y="427.5" width="374" height="0.0"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
                         </subviews>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="FD9-Mn-in7" firstAttribute="trailing" secondItem="674-uo-mtw" secondAttribute="trailing" id="6RX-nn-nw3"/>
-                            <constraint firstItem="FD9-Mn-in7" firstAttribute="leading" secondItem="674-uo-mtw" secondAttribute="leading" id="6rB-CC-4ri"/>
-                            <constraint firstItem="IFu-Rf-wNA" firstAttribute="top" secondItem="FD9-Mn-in7" secondAttribute="bottom" constant="8" symbolic="YES" id="7RB-tf-h86"/>
-                            <constraint firstItem="IFu-Rf-wNA" firstAttribute="trailing" secondItem="yTs-B1-Yoh" secondAttribute="trailing" id="AHV-Z5-4pD"/>
-                            <constraint firstItem="QpN-cI-JZa" firstAttribute="top" secondItem="yTs-B1-Yoh" secondAttribute="bottom" constant="8" symbolic="YES" id="Avp-Kq-C50"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="674-uo-mtw" secondAttribute="trailing" constant="5" id="CLj-XH-qp0"/>
-                            <constraint firstItem="L83-mC-jNW" firstAttribute="top" secondItem="g2S-RU-pP8" secondAttribute="bottom" constant="8" symbolic="YES" id="MGc-ef-mcU"/>
-                            <constraint firstItem="FD9-Mn-in7" firstAttribute="top" secondItem="674-uo-mtw" secondAttribute="bottom" constant="8" symbolic="YES" id="T75-Vp-mDG"/>
-                            <constraint firstItem="IFu-Rf-wNA" firstAttribute="trailing" secondItem="FD9-Mn-in7" secondAttribute="trailing" id="XRG-od-G3K"/>
-                            <constraint firstItem="L83-mC-jNW" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="YGK-Ok-Ln6"/>
-                            <constraint firstItem="IFu-Rf-wNA" firstAttribute="leading" secondItem="QpN-cI-JZa" secondAttribute="leading" id="Z6v-fK-gfp"/>
-                            <constraint firstItem="IFu-Rf-wNA" firstAttribute="trailing" secondItem="QpN-cI-JZa" secondAttribute="trailing" id="aT5-1f-Iyb"/>
-                            <constraint firstItem="yTs-B1-Yoh" firstAttribute="top" secondItem="IFu-Rf-wNA" secondAttribute="bottom" constant="8" symbolic="YES" id="iIw-E4-lhu"/>
-                            <constraint firstItem="674-uo-mtw" firstAttribute="leading" secondItem="L83-mC-jNW" secondAttribute="leading" id="kgc-t5-b1V"/>
-                            <constraint firstItem="IFu-Rf-wNA" firstAttribute="leading" secondItem="FD9-Mn-in7" secondAttribute="leading" id="mmu-pQ-Cow"/>
-                            <constraint firstItem="IFu-Rf-wNA" firstAttribute="leading" secondItem="yTs-B1-Yoh" secondAttribute="leading" id="pIF-9S-nhH"/>
-                            <constraint firstItem="674-uo-mtw" firstAttribute="top" secondItem="L83-mC-jNW" secondAttribute="bottom" constant="25" id="rtd-Ze-Yyd"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="4bQ-s8-gBo" secondAttribute="trailing" id="JmS-yy-kBc"/>
+                            <constraint firstItem="4bQ-s8-gBo" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leadingMargin" id="Ngh-cU-YO7"/>
+                            <constraint firstItem="adO-yW-BBx" firstAttribute="top" relation="greaterThanOrEqual" secondItem="4bQ-s8-gBo" secondAttribute="bottom" id="edh-ow-Z2V"/>
+                            <constraint firstItem="4bQ-s8-gBo" firstAttribute="top" secondItem="g2S-RU-pP8" secondAttribute="bottom" constant="8" symbolic="YES" id="vnr-Uo-kj0"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="statusLabel" destination="m3L-OI-ccA" id="jIx-1q-KeQ"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="134.78260869565219" y="135.9375"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="darkTextColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="darkTextColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="darkTextColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="darkTextColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="darkTextColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="darkTextColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/GoogleDataTransport/GDTTestApp/ios/Main.storyboard
+++ b/GoogleDataTransport/GDTTestApp/ios/Main.storyboard
@@ -20,7 +20,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="4bQ-s8-gBo">
-                                <rect key="frame" x="20" y="52" width="374" height="427.5"/>
+                                <rect key="frame" x="20" y="52" width="374" height="522.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GoogleDataTransport Test App" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L83-mC-jNW">
                                         <rect key="frame" x="0.0" y="0.0" width="374" height="20.5"/>
@@ -93,8 +93,28 @@
                                             <action selector="generateDailyEventWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Rfm-OO-P8A"/>
                                         </connections>
                                     </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cleanup Performance Testing" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="McF-LY-6pN">
+                                        <rect key="frame" x="0.0" y="361.5" width="374" height="18"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iqf-0o-lCf">
+                                        <rect key="frame" x="0.0" y="390.5" width="374" height="55"/>
+                                        <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="55" id="0LI-im-a1Z"/>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="55" id="iZX-wK-eUm"/>
+                                        </constraints>
+                                        <state key="normal" title="Generate events">
+                                            <color key="titleShadowColor" systemColor="darkTextColor"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="generateTestEventsWithButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aL4-k2-rG1"/>
+                                        </connections>
+                                    </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="k3W-pe-Kkc">
-                                        <rect key="frame" x="0.0" y="361.5" width="374" height="55"/>
+                                        <rect key="frame" x="0.0" y="456.5" width="374" height="55"/>
                                         <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="55" id="Uad-9A-UNO"/>
@@ -108,7 +128,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="m3L-OI-ccA" userLabel="Status label">
-                                        <rect key="frame" x="0.0" y="427.5" width="374" height="0.0"/>
+                                        <rect key="frame" x="0.0" y="522.5" width="374" height="0.0"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -134,6 +154,9 @@
         </scene>
     </scenes>
     <resources>
+        <systemColor name="darkTextColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
         <systemColor name="darkTextColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/GoogleDataTransport/GDTTestApp/viewcontroller.swift
+++ b/GoogleDataTransport/GDTTestApp/viewcontroller.swift
@@ -130,6 +130,6 @@ public extension ViewController {
 
   func set(status: String) {
     print("Status: \(status)")
-    self.statusLabel.text = status
+    statusLabel.text = status
   }
 }

--- a/GoogleDataTransport/GDTTestApp/viewcontroller.swift
+++ b/GoogleDataTransport/GDTTestApp/viewcontroller.swift
@@ -63,12 +63,25 @@ public extension ViewController {
     transport.sendDataEvent(event)
   }
 
+  @IBAction func generateTestEvents(button: UIButton) {
+    if #available(iOS 12.0, *) {
+      let numberOfEvents = 10000
+      set(status: "Generating \(numberOfEvents) events")
+
+      EventCleanupPerfTest.generateTestEvents(count: numberOfEvents) {
+        self.set(status: "Generated \(numberOfEvents) events")
+      }
+    } else {
+      print("Performance testing set up for iOS 12.0 and later")
+    }
+  }
+
   @IBAction func runEventCleanupPerformanceTest(button: UIButton) {
     if #available(iOS 12.0, *) {
-      self.statusLabel.text = "Event Cleanup Performance Test started"
+      set(status: "Event Cleanup Performance Test started")
       EventCleanupPerfTest.run {
         DispatchQueue.main.async {
-          self.statusLabel.text = "Event Cleanup Performance Test finished"
+          self.set(status: "Event Cleanup Performance Test finished")
         }
       }
     } else {
@@ -113,5 +126,10 @@ public extension ViewController {
     generateEvent()
     sema.wait()
     completion()
+  }
+
+  func set(status: String) {
+    print("Status: \(status)")
+    self.statusLabel.text = status
   }
 }

--- a/GoogleDataTransport/GDTTestApp/viewcontroller.swift
+++ b/GoogleDataTransport/GDTTestApp/viewcontroller.swift
@@ -63,6 +63,19 @@ public extension ViewController {
     transport.sendDataEvent(event)
   }
 
+  @IBAction func runEventCleanupPerformanceTest(button: UIButton) {
+    if #available(iOS 12.0, *) {
+      self.statusLabel.text = "Event Cleanup Performance Test started"
+      EventCleanupPerfTest.run {
+        DispatchQueue.main.async {
+          self.statusLabel.text = "Event Cleanup Performance Test finished"
+        }
+      }
+    } else {
+      print("Performance testing set up for iOS 12.0 and later")
+    }
+  }
+
   func beginMonkeyTest(completion: () -> Void) {
     print("Beginning monkey test")
 


### PR DESCRIPTION
Fixes #6995. 

- use internal `@autoreleasepool` in path enumeration cycles to ensure memory cleanup on each iteration 
- call `checkForExpirations` only once per storage even if storage associated with several targets
- test app updates to profile the issue

Memory spike reduced from ~150MB to ~2MB for ~20k test events.
Profiler traces available at go/apple-gdt-sdk-issue-6995.