### PR TITLE
Skip loading invalid targets

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,5 +1,10 @@
+# Unreleased
+- [fixed] Instead of crashing the client, the SDK will now ignore Queries it
+  cannot deserialize from LevelDB (#6721).
+
 # v7.2.0
-- [added] Made emulator connection API consistent between Auth, Database, Firestore, and Functions (#5916).
+- [added] Made emulator connection API consistent between Auth, Database,
+  Firestore, and Functions (#5916).
 
 # v7.1.0
 - [changed] Added the original query data to error messages for Queries that


### PR DESCRIPTION
This addresses a crash during LRU by simply ignoring targets that cannot be deserialized. We could possibly be smarter about this as we only need the Target ID and the LastListenSequenceNumber to determine what targets to delete, but this for now is the more targeted fix. 

Fix: https://github.com/firebase/firebase-ios-sdk/issues/6721