### PR TITLE
GC targets without deserializing Target model

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,5 +1,11 @@
+# Unreleased
+- [fixed] The SDK no longer fully deserializes queries during garbage,
+  collection, which reduces SDK crashes when it encounters invalid data
+  (#6721).
+
 # v7.2.0
-- [added] Made emulator connection API consistent between Auth, Database, Firestore, and Functions (#5916).
+- [added] Made emulator connection API consistent between Auth, Database,
+  Firestore, and Functions (#5916).
 
 # v7.1.0
 - [changed] Added the original query data to error messages for Queries that

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Unreleased
-- [fixed] The SDK no longer fully deserializes queries during garbage,
-  collection, which reduces SDK crashes when it encounters invalid data
-  (#6721).
+- [fixed] Fixed a crash that could happen when the SDK encountered invalid
+  data during garbage collection (#6721).
 
 # v7.2.0
 - [added] Made emulator connection API consistent between Auth, Database,

--- a/Firestore/core/src/local/leveldb_lru_reference_delegate.cc
+++ b/Firestore/core/src/local/leveldb_lru_reference_delegate.cc
@@ -78,7 +78,7 @@ void LevelDbLruReferenceDelegate::RemoveMutationReference(
 void LevelDbLruReferenceDelegate::RemoveTarget(const TargetData& target_data) {
   TargetData updated =
       target_data.WithSequenceNumber(current_sequence_number());
-  db_->target_cache()->UpdateTarget(std::move(updated));
+  db_->target_cache()->UpdateTarget(updated);
 }
 
 void LevelDbLruReferenceDelegate::UpdateLimboDocument(const DocumentKey& key) {
@@ -119,9 +119,9 @@ size_t LevelDbLruReferenceDelegate::GetSequenceNumberCount() {
   return total_count;
 }
 
-void LevelDbLruReferenceDelegate::EnumerateTargets(
-    const TargetCallback& callback) {
-  db_->target_cache()->EnumerateTargets(callback);
+void LevelDbLruReferenceDelegate::EnumerateTargetSequenceNumbers(
+    const SequenceNumberCallback& callback) {
+  db_->target_cache()->EnumerateSequenceNumbers(callback);
 }
 
 void LevelDbLruReferenceDelegate::EnumerateOrphanedDocuments(

--- a/Firestore/core/src/local/leveldb_lru_reference_delegate.h
+++ b/Firestore/core/src/local/leveldb_lru_reference_delegate.h
@@ -60,7 +60,8 @@ class LevelDbLruReferenceDelegate : public LruDelegate {
   util::StatusOr<int64_t> CalculateByteSize() override;
   size_t GetSequenceNumberCount() override;
 
-  void EnumerateTargets(const TargetCallback& callback) override;
+  void EnumerateTargetSequenceNumbers(
+      const SequenceNumberCallback& callback) override;
   void EnumerateOrphanedDocuments(
       const OrphanedDocumentCallback& callback) override;
 

--- a/Firestore/core/src/local/leveldb_target_cache.cc
+++ b/Firestore/core/src/local/leveldb_target_cache.cc
@@ -203,7 +203,7 @@ void LevelDbTargetCache::EnumerateSequenceNumbers(
   }
 }
 
-unsigned long LevelDbTargetCache::RemoveTargets(
+uint64_t LevelDbTargetCache::RemoveTargets(
     ListenSequenceNumber upper_bound,
     const std::unordered_map<model::TargetId, TargetData>& live_targets) {
   std::string target_prefix = LevelDbTargetKey::KeyPrefix();
@@ -212,6 +212,10 @@ unsigned long LevelDbTargetCache::RemoveTargets(
 
   std::unordered_set<model::TargetId> removed_targets;
 
+  // In https://github.com/firebase/firebase-ios-sdk/issues/6721, a customer
+  // reports that their client crashes when deserializing an invalid Target
+  // during an LRU run. Instead of deserializing the value into a full Target
+  // model, we only convert it into the underlying Protobuf message.
   for (; it->Valid() && absl::StartsWith(it->key(), target_prefix);
        it->Next()) {
     StringReader reader{it->value()};

--- a/Firestore/core/src/local/leveldb_target_cache.cc
+++ b/Firestore/core/src/local/leveldb_target_cache.cc
@@ -17,6 +17,7 @@
 #include "Firestore/core/src/local/leveldb_target_cache.h"
 
 #include <string>
+#include <unordered_set>
 #include <utility>
 
 #include "Firestore/core/src/local/leveldb_key.h"
@@ -124,7 +125,7 @@ void LevelDbTargetCache::UpdateTarget(const TargetData& target_data) {
 void LevelDbTargetCache::RemoveTarget(const TargetData& target_data) {
   TargetId target_id = target_data.target_id();
 
-  RemoveAllKeysForTarget(target_id);
+  RemoveAllDocumentKeysForTarget(target_id);
 
   std::string key = LevelDbTargetKey::Key(target_id);
   db_->current_transaction()->Delete(key);
@@ -188,35 +189,52 @@ absl::optional<TargetData> LevelDbTargetCache::GetTarget(const Target& target) {
   return absl::nullopt;
 }
 
-void LevelDbTargetCache::EnumerateTargets(const TargetCallback& callback) {
+void LevelDbTargetCache::EnumerateSequenceNumbers(
+    const SequenceNumberCallback& callback) {
   // Enumerate all targets, give their sequence numbers.
   std::string target_prefix = LevelDbTargetKey::KeyPrefix();
   auto it = db_->current_transaction()->NewIterator();
   it->Seek(target_prefix);
   for (; it->Valid() && absl::StartsWith(it->key(), target_prefix);
        it->Next()) {
-    TargetData target = DecodeTarget(it->value());
-    callback(target);
+    StringReader reader{it->value()};
+    auto target_proto = DecodeTargetProto(&reader);
+    callback(target_proto->last_listen_sequence_number);
   }
 }
 
-int LevelDbTargetCache::RemoveTargets(
+unsigned long LevelDbTargetCache::RemoveTargets(
     ListenSequenceNumber upper_bound,
     const std::unordered_map<model::TargetId, TargetData>& live_targets) {
-  int count = 0;
   std::string target_prefix = LevelDbTargetKey::KeyPrefix();
   auto it = db_->current_transaction()->NewIterator();
   it->Seek(target_prefix);
+
+  std::unordered_set<model::TargetId> removed_targets;
+
   for (; it->Valid() && absl::StartsWith(it->key(), target_prefix);
        it->Next()) {
-    TargetData target_data = DecodeTarget(it->value());
-    if (target_data.sequence_number() <= upper_bound &&
-        live_targets.find(target_data.target_id()) == live_targets.end()) {
-      RemoveTarget(target_data);
-      count++;
+    StringReader reader{it->value()};
+    auto target_proto = DecodeTargetProto(&reader);
+    if (target_proto->last_listen_sequence_number <= upper_bound &&
+        live_targets.find(target_proto->target_id) == live_targets.end()) {
+      TargetId target_id = target_proto->target_id;
+
+      RemoveAllDocumentKeysForTarget(target_id);
+
+      std::string key = LevelDbTargetKey::Key(target_id);
+      db_->current_transaction()->Delete(key);
+
+      removed_targets.insert(target_id);
     }
   }
-  return count;
+
+  RemoveQueryTargetKeyForTargets(removed_targets);
+
+  metadata_->target_count -= removed_targets.size();
+  SaveMetadata();
+
+  return removed_targets.size();
 }
 
 void LevelDbTargetCache::AddMatchingKeys(const DocumentKeySet& keys,
@@ -247,7 +265,7 @@ void LevelDbTargetCache::RemoveMatchingKeys(const DocumentKeySet& keys,
   }
 }
 
-void LevelDbTargetCache::RemoveAllKeysForTarget(TargetId target_id) {
+void LevelDbTargetCache::RemoveAllDocumentKeysForTarget(TargetId target_id) {
   std::string index_prefix = LevelDbTargetDocumentKey::KeyPrefix(target_id);
   auto index_iterator = db_->current_transaction()->NewIterator();
   index_iterator->Seek(index_prefix);
@@ -266,6 +284,24 @@ void LevelDbTargetCache::RemoveAllKeysForTarget(TargetId target_id) {
     db_->current_transaction()->Delete(index_key);
     db_->current_transaction()->Delete(
         LevelDbDocumentTargetKey::Key(document_key, target_id));
+  }
+}
+
+void LevelDbTargetCache::RemoveQueryTargetKeyForTargets(
+    std::unordered_set<TargetId> target_ids) {
+  std::string index_prefix = LevelDbQueryTargetKey::KeyPrefix();
+  auto index_iterator = db_->current_transaction()->NewIterator();
+  index_iterator->Seek(index_prefix);
+
+  LevelDbQueryTargetKey row_key;
+  for (; index_iterator->Valid(); index_iterator->Next()) {
+    if (!row_key.Decode(index_iterator->key())) {
+      break;
+    }
+
+    if (target_ids.find(row_key.target_id()) != target_ids.end()) {
+      db_->current_transaction()->Delete(index_iterator->key());
+    }
   }
 }
 
@@ -386,12 +422,21 @@ void LevelDbTargetCache::SaveMetadata() {
   db_->current_transaction()->Put(LevelDbTargetGlobalKey::Key(), metadata_);
 }
 
+nanopb::Message<firestore_client_Target> LevelDbTargetCache::DecodeTargetProto(
+    nanopb::Reader* reader) {
+  auto message = Message<firestore_client_Target>::TryParse(reader);
+  if (!reader->ok()) {
+    HARD_FAIL("Target proto failed to parse: %s", reader->status().ToString());
+  }
+  return message;
+}
+
 TargetData LevelDbTargetCache::DecodeTarget(absl::string_view encoded) {
   StringReader reader{encoded};
-  auto message = Message<firestore_client_Target>::TryParse(&reader);
+  auto message = DecodeTargetProto(&reader);
   auto result = serializer_->DecodeTargetData(&reader, *message);
   if (!reader.ok()) {
-    HARD_FAIL("Target proto failed to parse: %s, message: %s",
+    HARD_FAIL("Target failed to parse: %s, message: %s",
               reader.status().ToString(), message.ToString());
   }
 

--- a/Firestore/core/src/local/leveldb_target_cache.h
+++ b/Firestore/core/src/local/leveldb_target_cache.h
@@ -75,9 +75,9 @@ class LevelDbTargetCache : public TargetCache {
   void EnumerateSequenceNumbers(
       const SequenceNumberCallback& callback) override;
 
-  uint64_t RemoveTargets(model::ListenSequenceNumber upper_bound,
-                         const std::unordered_map<model::TargetId, TargetData>&
-                             live_targets) override;
+  size_t RemoveTargets(model::ListenSequenceNumber upper_bound,
+                       const std::unordered_map<model::TargetId, TargetData>&
+                           live_targets) override;
 
   // Key-related methods
 
@@ -140,9 +140,9 @@ class LevelDbTargetCache : public TargetCache {
    */
   TargetData DecodeTarget(absl::string_view encoded);
 
-  /** Removes the given targets from the query to target mapping */
+  /** Removes the given targets from the query to target mapping. */
   void RemoveQueryTargetKeyForTargets(
-      std::unordered_set<model::TargetId> target_id);
+      const std::unordered_set<model::TargetId>& target_id);
 
   // The LevelDbTargetCache is owned by LevelDbPersistence.
   LevelDbPersistence* db_;

--- a/Firestore/core/src/local/leveldb_target_cache.h
+++ b/Firestore/core/src/local/leveldb_target_cache.h
@@ -75,10 +75,9 @@ class LevelDbTargetCache : public TargetCache {
   void EnumerateSequenceNumbers(
       const SequenceNumberCallback& callback) override;
 
-  uint64_t RemoveTargets(
-      model::ListenSequenceNumber upper_bound,
-      const std::unordered_map<model::TargetId, TargetData>& live_targets)
-      override;
+  uint64_t RemoveTargets(model::ListenSequenceNumber upper_bound,
+                         const std::unordered_map<model::TargetId, TargetData>&
+                             live_targets) override;
 
   // Key-related methods
 

--- a/Firestore/core/src/local/leveldb_target_cache.h
+++ b/Firestore/core/src/local/leveldb_target_cache.h
@@ -18,6 +18,7 @@
 #define FIRESTORE_CORE_SRC_LOCAL_LEVELDB_TARGET_CACHE_H_
 
 #include <unordered_map>
+#include <unordered_set>
 
 #include "Firestore/Protos/nanopb/firestore/local/target.nanopb.h"
 #include "Firestore/core/src/local/target_cache.h"
@@ -71,11 +72,13 @@ class LevelDbTargetCache : public TargetCache {
 
   absl::optional<TargetData> GetTarget(const core::Target& target) override;
 
-  void EnumerateTargets(const TargetCallback& callback) override;
+  void EnumerateSequenceNumbers(
+      const SequenceNumberCallback& callback) override;
 
-  int RemoveTargets(model::ListenSequenceNumber upper_bound,
-                    const std::unordered_map<model::TargetId, TargetData>&
-                        live_targets) override;
+  unsigned long RemoveTargets(
+      model::ListenSequenceNumber upper_bound,
+      const std::unordered_map<model::TargetId, TargetData>& live_targets)
+      override;
 
   // Key-related methods
 
@@ -91,8 +94,8 @@ class LevelDbTargetCache : public TargetCache {
   void RemoveMatchingKeys(const model::DocumentKeySet& keys,
                           model::TargetId target_id) override;
 
-  /** Removes all the keys in the query results of the given target ID. */
-  void RemoveAllKeysForTarget(model::TargetId target_id);
+  /** Removes all document keys in the query results of the given target ID. */
+  void RemoveAllDocumentKeysForTarget(model::TargetId target_id);
 
   model::DocumentKeySet GetMatchingKeys(model::TargetId target_id) override;
 
@@ -128,11 +131,19 @@ class LevelDbTargetCache : public TargetCache {
   bool UpdateMetadata(const TargetData& target_data);
   void SaveMetadata();
 
+  /** Parses the given bytes as a `firestore_client_Target` protocol buffer. */
+  nanopb::Message<firestore_client_Target> DecodeTargetProto(
+      nanopb::Reader* reader);
+
   /**
    * Parses the given bytes as a `firestore_client_Target` protocol buffer and
    * then converts to the equivalent target data.
    */
   TargetData DecodeTarget(absl::string_view encoded);
+
+  /** Removes the given targets from the query to target mapping */
+  void RemoveQueryTargetKeyForTargets(
+      std::unordered_set<model::TargetId> target_id);
 
   // The LevelDbTargetCache is owned by LevelDbPersistence.
   LevelDbPersistence* db_;

--- a/Firestore/core/src/local/leveldb_target_cache.h
+++ b/Firestore/core/src/local/leveldb_target_cache.h
@@ -75,7 +75,7 @@ class LevelDbTargetCache : public TargetCache {
   void EnumerateSequenceNumbers(
       const SequenceNumberCallback& callback) override;
 
-  unsigned long RemoveTargets(
+  uint64_t RemoveTargets(
       model::ListenSequenceNumber upper_bound,
       const std::unordered_map<model::TargetId, TargetData>& live_targets)
       override;

--- a/Firestore/core/src/local/lru_garbage_collector.cc
+++ b/Firestore/core/src/local/lru_garbage_collector.cc
@@ -197,9 +197,10 @@ ListenSequenceNumber LruGarbageCollector::SequenceNumberForQueryCount(
 
   RollingSequenceNumberBuffer buffer(query_count);
 
-  delegate_->EnumerateTargets([&buffer](const TargetData& target_data) {
-    buffer.AddElement(target_data.sequence_number());
-  });
+  delegate_->EnumerateTargetSequenceNumbers(
+      [&buffer](ListenSequenceNumber sequence_number) {
+        buffer.AddElement(sequence_number);
+      });
 
   delegate_->EnumerateOrphanedDocuments(
       [&buffer](const DocumentKey&, ListenSequenceNumber sequence_number) {

--- a/Firestore/core/src/local/lru_garbage_collector.h
+++ b/Firestore/core/src/local/lru_garbage_collector.h
@@ -78,10 +78,11 @@ class LruDelegate : public ReferenceDelegate {
   virtual size_t GetSequenceNumberCount() = 0;
 
   /**
-   * Enumerates all the targets that the delegate is aware of. This is typically
-   * all of the targets in an TargetCache.
+   * Enumerates the sequence numbers of all the targets that the delegate is
+   * aware of. This is typically all sequence numbers in an TargetCache.
    */
-  virtual void EnumerateTargets(const TargetCallback& callback) = 0;
+  virtual void EnumerateTargetSequenceNumbers(
+      const SequenceNumberCallback& callback) = 0;
 
   /**
    * Enumerates all of the outstanding mutations.

--- a/Firestore/core/src/local/memory_lru_reference_delegate.cc
+++ b/Firestore/core/src/local/memory_lru_reference_delegate.cc
@@ -86,9 +86,9 @@ void MemoryLruReferenceDelegate::OnTransactionCommitted() {
   current_sequence_number_ = kListenSequenceNumberInvalid;
 }
 
-void MemoryLruReferenceDelegate::EnumerateTargets(
-    const TargetCallback& callback) {
-  return persistence_->target_cache()->EnumerateTargets(callback);
+void MemoryLruReferenceDelegate::EnumerateTargetSequenceNumbers(
+    const SequenceNumberCallback& callback) {
+  return persistence_->target_cache()->EnumerateSequenceNumbers(callback);
 }
 
 void MemoryLruReferenceDelegate::EnumerateOrphanedDocuments(

--- a/Firestore/core/src/local/memory_lru_reference_delegate.h
+++ b/Firestore/core/src/local/memory_lru_reference_delegate.h
@@ -68,7 +68,8 @@ class MemoryLruReferenceDelegate : public LruDelegate {
   util::StatusOr<int64_t> CalculateByteSize() override;
   size_t GetSequenceNumberCount() override;
 
-  void EnumerateTargets(const TargetCallback& callback) override;
+  void EnumerateTargetSequenceNumbers(
+      const SequenceNumberCallback& callback) override;
   void EnumerateOrphanedDocuments(
       const OrphanedDocumentCallback& callback) override;
 

--- a/Firestore/core/src/local/memory_target_cache.cc
+++ b/Firestore/core/src/local/memory_target_cache.cc
@@ -75,7 +75,7 @@ void MemoryTargetCache::EnumerateSequenceNumbers(
   }
 }
 
-unsigned long MemoryTargetCache::RemoveTargets(
+uint64_t MemoryTargetCache::RemoveTargets(
     model::ListenSequenceNumber upper_bound,
     const std::unordered_map<TargetId, TargetData>& live_targets) {
   std::vector<const Target*> to_remove;
@@ -94,7 +94,7 @@ unsigned long MemoryTargetCache::RemoveTargets(
   for (const Target* element : to_remove) {
     targets_.erase(*element);
   }
-  return static_cast<int>(to_remove.size());
+  return to_remove.size();
 }
 
 void MemoryTargetCache::AddMatchingKeys(const DocumentKeySet& keys,

--- a/Firestore/core/src/local/memory_target_cache.cc
+++ b/Firestore/core/src/local/memory_target_cache.cc
@@ -68,13 +68,14 @@ absl::optional<TargetData> MemoryTargetCache::GetTarget(const Target& target) {
   return iter == targets_.end() ? absl::optional<TargetData>{} : iter->second;
 }
 
-void MemoryTargetCache::EnumerateTargets(const TargetCallback& callback) {
+void MemoryTargetCache::EnumerateSequenceNumbers(
+    const SequenceNumberCallback& callback) {
   for (const auto& kv : targets_) {
-    callback(kv.second);
+    callback(kv.second.sequence_number());
   }
 }
 
-int MemoryTargetCache::RemoveTargets(
+unsigned long MemoryTargetCache::RemoveTargets(
     model::ListenSequenceNumber upper_bound,
     const std::unordered_map<TargetId, TargetData>& live_targets) {
   std::vector<const Target*> to_remove;

--- a/Firestore/core/src/local/memory_target_cache.cc
+++ b/Firestore/core/src/local/memory_target_cache.cc
@@ -75,7 +75,7 @@ void MemoryTargetCache::EnumerateSequenceNumbers(
   }
 }
 
-uint64_t MemoryTargetCache::RemoveTargets(
+size_t MemoryTargetCache::RemoveTargets(
     model::ListenSequenceNumber upper_bound,
     const std::unordered_map<TargetId, TargetData>& live_targets) {
   std::vector<const Target*> to_remove;

--- a/Firestore/core/src/local/memory_target_cache.h
+++ b/Firestore/core/src/local/memory_target_cache.h
@@ -52,9 +52,9 @@ class MemoryTargetCache : public TargetCache {
   void EnumerateSequenceNumbers(
       const SequenceNumberCallback& callback) override;
 
-  uint64_t RemoveTargets(model::ListenSequenceNumber upper_bound,
-                         const std::unordered_map<model::TargetId, TargetData>&
-                             live_targets) override;
+  size_t RemoveTargets(model::ListenSequenceNumber upper_bound,
+                       const std::unordered_map<model::TargetId, TargetData>&
+                           live_targets) override;
 
   // Key-related methods
   void AddMatchingKeys(const model::DocumentKeySet& keys,

--- a/Firestore/core/src/local/memory_target_cache.h
+++ b/Firestore/core/src/local/memory_target_cache.h
@@ -49,11 +49,13 @@ class MemoryTargetCache : public TargetCache {
 
   absl::optional<TargetData> GetTarget(const core::Target& target) override;
 
-  void EnumerateTargets(const TargetCallback& callback) override;
+  void EnumerateSequenceNumbers(
+      const SequenceNumberCallback& callback) override;
 
-  int RemoveTargets(model::ListenSequenceNumber upper_bound,
-                    const std::unordered_map<model::TargetId, TargetData>&
-                        live_targets) override;
+  unsigned long RemoveTargets(
+      model::ListenSequenceNumber upper_bound,
+      const std::unordered_map<model::TargetId, TargetData>& live_targets)
+      override;
 
   // Key-related methods
   void AddMatchingKeys(const model::DocumentKeySet& keys,

--- a/Firestore/core/src/local/memory_target_cache.h
+++ b/Firestore/core/src/local/memory_target_cache.h
@@ -52,10 +52,9 @@ class MemoryTargetCache : public TargetCache {
   void EnumerateSequenceNumbers(
       const SequenceNumberCallback& callback) override;
 
-  unsigned long RemoveTargets(
-      model::ListenSequenceNumber upper_bound,
-      const std::unordered_map<model::TargetId, TargetData>& live_targets)
-      override;
+  uint64_t RemoveTargets(model::ListenSequenceNumber upper_bound,
+                         const std::unordered_map<model::TargetId, TargetData>&
+                             live_targets) override;
 
   // Key-related methods
   void AddMatchingKeys(const model::DocumentKeySet& keys,

--- a/Firestore/core/src/local/target_cache.h
+++ b/Firestore/core/src/local/target_cache.h
@@ -102,7 +102,7 @@ class TargetCache {
    * @param live_targets Targets to ignore.
    * @return The number of targets removed.
    */
-  virtual unsigned long RemoveTargets(
+  virtual uint64_t RemoveTargets(
       model::ListenSequenceNumber upper_bound,
       const std::unordered_map<model::TargetId, TargetData>& live_targets) = 0;
 

--- a/Firestore/core/src/local/target_cache.h
+++ b/Firestore/core/src/local/target_cache.h
@@ -37,7 +37,7 @@ class TargetData;
 using OrphanedDocumentCallback =
     std::function<void(const model::DocumentKey&, model::ListenSequenceNumber)>;
 
-using TargetCallback = std::function<void(const TargetData&)>;
+using SequenceNumberCallback = std::function<void(model::ListenSequenceNumber)>;
 
 /**
  * Represents cached targets received from the remote backend. This contains
@@ -74,8 +74,10 @@ class TargetCache {
    */
   virtual void UpdateTarget(const TargetData& target_data) = 0;
 
-  /** Removes the cached entry for the given target data. The entry must already
-   * exist in the cache. */
+  /**
+   * Removes the cached entry for the given target data. The entry must already
+   * exist in the cache.
+   */
   virtual void RemoveTarget(const TargetData& target_data) = 0;
 
   /**
@@ -87,9 +89,20 @@ class TargetCache {
    */
   virtual absl::optional<TargetData> GetTarget(const core::Target& target) = 0;
 
-  virtual void EnumerateTargets(const TargetCallback& callback) = 0;
+  /** Enumerates all sequence numbers in the TargetCache. */
+  virtual void EnumerateSequenceNumbers(
+      const SequenceNumberCallback& callback) = 0;
 
-  virtual int RemoveTargets(
+  /**
+   * Removes all target by sequence number up to (and including) the given
+   * sequence number. Targets in `live_targets` are ignored.
+   *
+   * @param upper_bound The upper bound for last target's sequence number
+   *     (inclusive).
+   * @param live_targets Targets to ignore.
+   * @return The number of targets removed.
+   */
+  virtual unsigned long RemoveTargets(
       model::ListenSequenceNumber upper_bound,
       const std::unordered_map<model::TargetId, TargetData>& live_targets) = 0;
 

--- a/Firestore/core/src/local/target_cache.h
+++ b/Firestore/core/src/local/target_cache.h
@@ -102,7 +102,7 @@ class TargetCache {
    * @param live_targets Targets to ignore.
    * @return The number of targets removed.
    */
-  virtual uint64_t RemoveTargets(
+  virtual size_t RemoveTargets(
       model::ListenSequenceNumber upper_bound,
       const std::unordered_map<model::TargetId, TargetData>& live_targets) = 0;
 

--- a/Firestore/core/test/unit/local/leveldb_target_cache_test.cc
+++ b/Firestore/core/test/unit/local/leveldb_target_cache_test.cc
@@ -123,12 +123,12 @@ TEST_F(LevelDbTargetCacheTest, RemoveMatchingKeysForTargetID) {
     ASSERT_TRUE(cache->Contains(key2));
     ASSERT_TRUE(cache->Contains(key3));
 
-    cache->RemoveAllKeysForTarget(1);
+    cache->RemoveAllDocumentKeysForTarget(1);
     ASSERT_FALSE(cache_->Contains(key1));
     ASSERT_FALSE(cache_->Contains(key2));
     ASSERT_TRUE(cache_->Contains(key3));
 
-    cache->RemoveAllKeysForTarget(2);
+    cache->RemoveAllDocumentKeysForTarget(2);
     ASSERT_FALSE(cache_->Contains(key1));
     ASSERT_FALSE(cache_->Contains(key2));
     ASSERT_FALSE(cache_->Contains(key3));

--- a/Firestore/core/test/unit/local/lru_garbage_collector_test.cc
+++ b/Firestore/core/test/unit/local/lru_garbage_collector_test.cc
@@ -376,16 +376,16 @@ TEST_P(LruGarbageCollectorTest, RemoveQueriesUpThroughSequenceNumber) {
   int removed = RemoveTargets(20 + initial_sequence_number_, live_queries);
   ASSERT_EQ(10, removed);
 
+  int detectedRemoval = 0;
+
   // Make sure we removed the next 10 even targets.
   persistence_->Run("verify remaining targets", [&] {
-    int detectedRemoval = 0;
-
     for (const auto& target : targets) {
       auto entry = target_cache_->GetTarget(target.target());
 
       if (live_queries.find(target.target_id()) != live_queries.end()) {
         ASSERT_TRUE(entry.has_value());
-      };
+      }
 
       if (!entry.has_value()) {
         ++detectedRemoval;
@@ -393,6 +393,8 @@ TEST_P(LruGarbageCollectorTest, RemoveQueriesUpThroughSequenceNumber) {
       }
     }
   });
+
+  ASSERT_EQ(10, detectedRemoval);
 }
 
 TEST_P(LruGarbageCollectorTest, RemoveOrphanedDocuments) {

--- a/Firestore/core/test/unit/local/lru_garbage_collector_test.cc
+++ b/Firestore/core/test/unit/local/lru_garbage_collector_test.cc
@@ -376,7 +376,7 @@ TEST_P(LruGarbageCollectorTest, RemoveQueriesUpThroughSequenceNumber) {
   int removed = RemoveTargets(20 + initial_sequence_number_, live_queries);
   ASSERT_EQ(10, removed);
 
-  int detectedRemoval = 0;
+  int detected_removal = 0;
 
   // Make sure we removed the next 10 even targets.
   persistence_->Run("verify remaining targets", [&] {
@@ -388,13 +388,13 @@ TEST_P(LruGarbageCollectorTest, RemoveQueriesUpThroughSequenceNumber) {
       }
 
       if (!entry.has_value()) {
-        ++detectedRemoval;
-        ASSERT_TRUE(detectedRemoval <= removed);
+        ++detected_removal;
+        ASSERT_TRUE(detected_removal <= removed);
       }
     }
   });
 
-  ASSERT_EQ(10, detectedRemoval);
+  ASSERT_EQ(detected_removal, 10);
 }
 
 TEST_P(LruGarbageCollectorTest, RemoveOrphanedDocuments) {

--- a/Firestore/core/test/unit/local/target_cache_test.cc
+++ b/Firestore/core/test/unit/local/target_cache_test.cc
@@ -17,6 +17,7 @@
 #include "Firestore/core/test/unit/local/target_cache_test.h"
 
 #include <set>
+#include <string>
 #include <utility>
 
 #include "Firestore/core/src/core/field_filter.h"
@@ -26,6 +27,7 @@
 #include "Firestore/core/src/local/target_data.h"
 #include "Firestore/core/src/model/document_key.h"
 #include "Firestore/core/test/unit/testutil/testutil.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace firebase {
@@ -40,6 +42,7 @@ using model::SnapshotVersion;
 using model::TargetId;
 using nanopb::ByteString;
 
+using testing::Contains;
 using testutil::Filter;
 using testutil::Key;
 using testutil::ResumeToken;
@@ -97,13 +100,13 @@ TargetCacheTest::TargetCacheTest() : TargetCacheTestBase(GetParam()()) {
 TargetCacheTest::~TargetCacheTest() = default;
 
 TEST_P(TargetCacheTest, ReadQueryNotInCache) {
-  persistence_->Run("test_read_query_not_in_cache", [&]() {
+  persistence_->Run("test_read_query_not_in_cache", [&] {
     ASSERT_EQ(cache_->GetTarget(query_rooms_.ToTarget()), absl::nullopt);
   });
 }
 
 TEST_P(TargetCacheTest, SetAndReadAQuery) {
-  persistence_->Run("test_set_and_read_a_query", [&]() {
+  persistence_->Run("test_set_and_read_a_query", [&] {
     TargetData target_data = MakeTargetData(query_rooms_);
     cache_->AddTarget(target_data);
 
@@ -116,7 +119,7 @@ TEST_P(TargetCacheTest, SetAndReadAQuery) {
 }
 
 TEST_P(TargetCacheTest, CanonicalIDCollision) {
-  persistence_->Run("test_canonical_id_collision", [&]() {
+  persistence_->Run("test_canonical_id_collision", [&] {
     // Type information is currently lost in our canonical_id implementations so
     // this currently an easy way to force colliding canonical_i_ds
     Query q1 = testutil::Query("a").AddingFilter(Filter("foo", "==", 1));
@@ -151,7 +154,7 @@ TEST_P(TargetCacheTest, CanonicalIDCollision) {
 }
 
 TEST_P(TargetCacheTest, SetQueryToNewValue) {
-  persistence_->Run("test_set_query_to_new_value", [&]() {
+  persistence_->Run("test_set_query_to_new_value", [&] {
     TargetData target_data1 = MakeTargetData(query_rooms_, 1, 10, 1);
     cache_->AddTarget(target_data1);
 
@@ -168,7 +171,7 @@ TEST_P(TargetCacheTest, SetQueryToNewValue) {
 
 TEST_P(TargetCacheTest, EnumerateSequenceNumbers) {
   std::unordered_set<ListenSequenceNumber> sequence_numbers;
-  persistence_->Run("test_enumerate_sequence_numbers", [&]() {
+  persistence_->Run("test_enumerate_sequence_numbers", [&] {
     for (int i = 0; i < 10; i++) {
       TargetData target_data =
           MakeTargetData(testutil::Query(std::to_string(i)));
@@ -176,20 +179,18 @@ TEST_P(TargetCacheTest, EnumerateSequenceNumbers) {
       sequence_numbers.insert(target_data.sequence_number());
     }
 
-    int resultCount = 0;
+    int result_count = 0;
     cache_->EnumerateSequenceNumbers([&](ListenSequenceNumber sequence_number) {
-      std::cout << sequence_number;
-      ASSERT_TRUE(sequence_numbers.find(sequence_number) !=
-                  sequence_numbers.end());
-      ++resultCount;
+      EXPECT_THAT(sequence_numbers, Contains(sequence_number));
+      ++result_count;
     });
 
-    ASSERT_EQ(resultCount, 10);
+    ASSERT_EQ(result_count, 10);
   });
 }
 
 TEST_P(TargetCacheTest, RemoveTarget) {
-  persistence_->Run("test_remove_target", [&]() {
+  persistence_->Run("test_remove_target", [&] {
     TargetData target_data1 = MakeTargetData(query_rooms_);
     cache_->AddTarget(target_data1);
 
@@ -201,7 +202,7 @@ TEST_P(TargetCacheTest, RemoveTarget) {
 }
 
 TEST_P(TargetCacheTest, RemoveNonExistentTarget) {
-  persistence_->Run("test_remove_non_existent_target", [&]() {
+  persistence_->Run("test_remove_non_existent_target", [&] {
     TargetData target_data = MakeTargetData(query_rooms_);
 
     // no-op, but make sure it doesn't throw.
@@ -210,7 +211,7 @@ TEST_P(TargetCacheTest, RemoveNonExistentTarget) {
 }
 
 TEST_P(TargetCacheTest, RemoveTargetRemovesMatchingKeysToo) {
-  persistence_->Run("test_remove_target_removes_matching_keys_too", [&]() {
+  persistence_->Run("test_remove_target_removes_matching_keys_too", [&] {
     TargetData rooms = MakeTargetData(query_rooms_);
     cache_->AddTarget(rooms);
 
@@ -229,14 +230,13 @@ TEST_P(TargetCacheTest, RemoveTargetRemovesMatchingKeysToo) {
 }
 
 TEST_P(TargetCacheTest, RemoveTargets) {
-  persistence_->Run("test_remove_targets", [&]() {
+  persistence_->Run("test_remove_targets", [&] {
     TargetData target_data1 = MakeTargetData(testutil::Query("a"));
     cache_->AddTarget(target_data1);
     TargetData target_data2 = MakeTargetData(testutil::Query("b"));
     cache_->AddTarget(target_data2);
 
-    std::unordered_map<model::TargetId, TargetData> live_targets;
-    cache_->RemoveTargets(target_data2.sequence_number(), live_targets);
+    cache_->RemoveTargets(target_data2.sequence_number(), {});
 
     auto result = cache_->GetTarget(target_data1.target());
     ASSERT_EQ(result, absl::nullopt);
@@ -246,7 +246,7 @@ TEST_P(TargetCacheTest, RemoveTargets) {
 }
 
 TEST_P(TargetCacheTest, RemoveTargetsRemovesMatchingKeysToo) {
-  persistence_->Run("test_remove_targets_removes_matching_keys_too", [&]() {
+  persistence_->Run("test_remove_targets_removes_matching_keys_too", [&] {
     TargetData rooms = MakeTargetData(query_rooms_);
     cache_->AddTarget(rooms);
 
@@ -258,15 +258,14 @@ TEST_P(TargetCacheTest, RemoveTargetsRemovesMatchingKeysToo) {
     ASSERT_TRUE(cache_->Contains(key1));
     ASSERT_TRUE(cache_->Contains(key2));
 
-    std::unordered_map<model::TargetId, TargetData> live_targets;
-    cache_->RemoveTargets(rooms.sequence_number(), live_targets);
+    cache_->RemoveTargets(rooms.sequence_number(), {});
     ASSERT_FALSE(cache_->Contains(key1));
     ASSERT_FALSE(cache_->Contains(key2));
   });
 }
 
 TEST_P(TargetCacheTest, AddOrRemoveMatchingKeys) {
-  persistence_->Run("test_add_or_remove_matching_keys", [&]() {
+  persistence_->Run("test_add_or_remove_matching_keys", [&] {
     DocumentKey key = Key("foo/bar");
 
     ASSERT_FALSE(cache_->Contains(key));
@@ -286,7 +285,7 @@ TEST_P(TargetCacheTest, AddOrRemoveMatchingKeys) {
 }
 
 TEST_P(TargetCacheTest, MatchingKeysForTargetID) {
-  persistence_->Run("test_matching_keys_for_target_id", [&]() {
+  persistence_->Run("test_matching_keys_for_target_id", [&] {
     DocumentKey key1 = Key("foo/bar");
     DocumentKey key2 = Key("foo/baz");
     DocumentKey key3 = Key("foo/blah");
@@ -305,7 +304,7 @@ TEST_P(TargetCacheTest, MatchingKeysForTargetID) {
 }
 
 TEST_P(TargetCacheTest, HighestListenSequenceNumber) {
-  persistence_->Run("test_highest_listen_sequence_number", [&]() {
+  persistence_->Run("test_highest_listen_sequence_number", [&] {
     TargetData query1(testutil::Query("rooms").ToTarget(), 1, 10,
                       QueryPurpose::Listen);
     cache_->AddTarget(query1);
@@ -332,7 +331,7 @@ TEST_P(TargetCacheTest, HighestListenSequenceNumber) {
 }
 
 TEST_P(TargetCacheTest, HighestTargetID) {
-  persistence_->Run("test_highest_target_id", [&]() {
+  persistence_->Run("test_highest_target_id", [&] {
     ASSERT_EQ(cache_->highest_target_id(), 0);
 
     TargetData query1(testutil::Query("rooms").ToTarget(), 1, 10,
@@ -369,7 +368,7 @@ TEST_P(TargetCacheTest, HighestTargetID) {
 }
 
 TEST_P(TargetCacheTest, LastRemoteSnapshotVersion) {
-  persistence_->Run("test_last_remote_snapshot_version", [&]() {
+  persistence_->Run("test_last_remote_snapshot_version", [&] {
     ASSERT_EQ(cache_->GetLastRemoteSnapshotVersion(), SnapshotVersion::None());
 
     // Can set the snapshot version.


### PR DESCRIPTION
This works around a crash during LRU by not converting the Target Proto into Target Models, and instead only using the Target ID and the LastListenSequenceNumber for serialization. It is the more complicated version of https://github.com/firebase/firebase-ios-sdk/pull/7026, but it doesn't orphan data on disk. 

Fix: #6721