### PR TITLE
Add arm64 slice for Catalyst builds.

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/FrameworkBuilder.swift
@@ -32,9 +32,8 @@ enum TargetPlatform: CaseIterable {
     case .iOSDevice: return [.armv7, .arm64]
     // Include arm64 slices in the simulator for Apple silicon Macs.
     case .iOSSimulator: return [.i386, .x86_64, .arm64]
-    // TODO: Evaluate arm64 slice for Catalyst Apple silicon Macs, and x86_64h. Previous builds were
-    // limited to x86_64.
-    case .catalyst: return [.x86_64]
+    // TODO: Evaluate x86_64h slice. Previous builds were limited to x86_64.
+    case .catalyst: return [.x86_64, .arm64]
     }
   }
 


### PR DESCRIPTION
Note: this requires Xcode 12.2 to build. Thankfully, if run an older
system it will just ignore the arm64 flag and build it normally.

#no-changelog yet - unsure when we'll be using this.