### PR TITLE
Crashlytics bump down to iOS 9 Deployment Target

### DIFF
--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - [changed] Removed obsolete API calls from upload-symbols
-- [changed] Decreased Crashlytics minimum deployment target from iOS 10 to iOS 9
+- [changed] Decreased Crashlytics CocoaPods minimum deployment target from iOS 10 to iOS 9
 
 # v7.1.0
 - [fixed] Fixed an issue where symbol uploads would fail when there are spaces in the project path, particularly in Unity builds (#6789).

--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - [changed] Removed obsolete API calls from upload-symbols
-- [changed] Bumped Crashlytics minimum deployment target down from iOS 10 to iOS 9
+- [changed] Decreased Crashlytics minimum deployment target from iOS 10 to iOS 9
 
 # v7.1.0
 - [fixed] Fixed an issue where symbol uploads would fail when there are spaces in the project path, particularly in Unity builds (#6789).

--- a/Crashlytics/CHANGELOG.md
+++ b/Crashlytics/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [changed] Removed obsolete API calls from upload-symbols
+- [changed] Bumped Crashlytics minimum deployment target down from iOS 10 to iOS 9
 
 # v7.1.0
 - [fixed] Fixed an issue where symbol uploads would fail when there are spaces in the project path, particularly in Unity builds (#6789).

--- a/FirebaseCrashlytics.podspec
+++ b/FirebaseCrashlytics.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
     :tag => 'CocoaPods-' + s.version.to_s
   }
 
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
   s.watchos.deployment_target = '6.0'


### PR DESCRIPTION
Context:
https://github.com/firebase/firebase-ios-sdk/issues/6882

Believe this is a safe change but going to test just in case.