### PR TITLE
Expose upload URLs so that perf can stop instrumenting these URLs.

### DIFF
--- a/GoogleDataTransport/CHANGELOG.md
+++ b/GoogleDataTransport/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Unreleased (v8.1.0)
 - Expose upload URLs which FirebasePerformance will depend upon.
-
-# v8.0.2
 - Fix out-of-memory crash for a big amount of pending events. (#6995)
 
 # v8.0.1

--- a/GoogleDataTransport/CHANGELOG.md
+++ b/GoogleDataTransport/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased (v8.1.0)
+- Expose upload URLs which FirebasePerformance will depend upon.
+
 # v8.0.2
 - Fix out-of-memory crash for a big amount of pending events. (#6995)
 

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
@@ -168,7 +168,6 @@ static NSURL *_testServerURL = nil;
 }
 
 + (nullable NSURL *)serverURLForTarget:(GDTCORTarget)target {
-  
 #if !NDEBUG
   if (_testServerURL) {
     return _testServerURL;

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
@@ -158,13 +158,17 @@ static NSURL *_testServerURL = nil;
                           p2[31], p1[32], p2[32], p1[33], p2[33], p1[34], p2[34], p1[35], '\0'};
     CSHServerURL = [NSURL URLWithString:[NSString stringWithUTF8String:URL]];
   });
-
-  return @{
-    @(kGDTCORTargetCCT) : CCTServerURL,
-    @(kGDTCORTargetFLL) : FLLServerURL,
-    @(kGDTCORTargetCSH) : CSHServerURL,
-    @(kGDTCORTargetINT) : [NSURL URLWithString:kINTServerURL]
-  };
+  static NSDictionary<NSNumber *, NSURL *> *uploadURLs;
+  static dispatch_once_t URLonceToken;
+  dispatch_once(&URLonceToken, ^{
+    uploadURLs = @{
+      @(kGDTCORTargetCCT) : CCTServerURL,
+      @(kGDTCORTargetFLL) : FLLServerURL,
+      @(kGDTCORTargetCSH) : CSHServerURL,
+      @(kGDTCORTargetINT) : [NSURL URLWithString:kINTServerURL]
+    };
+  });
+  return uploadURLs;
 }
 
 + (nullable NSURL *)serverURLForTarget:(GDTCORTarget)target {

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
@@ -159,8 +159,8 @@ static NSURL *_testServerURL = nil;
     CSHServerURL = [NSURL URLWithString:[NSString stringWithUTF8String:URL]];
   });
   static NSDictionary<NSNumber *, NSURL *> *uploadURLs;
-  static dispatch_once_t URLonceToken;
-  dispatch_once(&URLonceToken, ^{
+  static dispatch_once_t URLOnceToken;
+  dispatch_once(&URLOnceToken, ^{
     uploadURLs = @{
       @(kGDTCORTargetCCT) : CCTServerURL,
       @(kGDTCORTargetFLL) : FLLServerURL,

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
@@ -178,7 +178,8 @@ static NSURL *_testServerURL = nil;
   }
 #endif  // !NDEBUG
 
-  return [self uploadURLs][@(target)];
+  NSDictionary<NSNumber *, NSURL *> *uploadURLs = [self uploadURLs];
+  return uploadURLs[@(target)];
 }
 
 - (instancetype)init {

--- a/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
+++ b/GoogleDataTransport/GDTCCTLibrary/GDTCCTUploader.m
@@ -109,15 +109,6 @@ static NSURL *_testServerURL = nil;
 }
 
 + (NSDictionary<NSNumber *, NSURL *> *)uploadURLs {
-  return @{
-    @(kGDTCORTargetCCT) : [self serverURLForTarget:kGDTCORTargetCCT],
-    @(kGDTCORTargetFLL) : [self serverURLForTarget:kGDTCORTargetFLL],
-    @(kGDTCORTargetCSH) : [self serverURLForTarget:kGDTCORTargetCSH],
-    @(kGDTCORTargetINT) : [self serverURLForTarget:kGDTCORTargetINT]
-  };
-}
-
-+ (nullable NSURL *)serverURLForTarget:(GDTCORTarget)target {
   // These strings should be interleaved to construct the real URL. This is just to (hopefully)
   // fool github URL scanning bots.
   static NSURL *CCTServerURL;
@@ -168,30 +159,23 @@ static NSURL *_testServerURL = nil;
     CSHServerURL = [NSURL URLWithString:[NSString stringWithUTF8String:URL]];
   });
 
+  return @{
+    @(kGDTCORTargetCCT) : CCTServerURL,
+    @(kGDTCORTargetFLL) : FLLServerURL,
+    @(kGDTCORTargetCSH) : CSHServerURL,
+    @(kGDTCORTargetINT) : [NSURL URLWithString:kINTServerURL]
+  };
+}
+
++ (nullable NSURL *)serverURLForTarget:(GDTCORTarget)target {
+  
 #if !NDEBUG
   if (_testServerURL) {
     return _testServerURL;
   }
 #endif  // !NDEBUG
 
-  switch (target) {
-    case kGDTCORTargetCCT:
-      return CCTServerURL;
-
-    case kGDTCORTargetFLL:
-      return FLLServerURL;
-
-    case kGDTCORTargetCSH:
-      return CSHServerURL;
-
-    case kGDTCORTargetINT:
-      return [NSURL URLWithString:kINTServerURL];
-
-    default:
-      GDTCORLogDebug(@"GDTCCTUploader doesn't support target %ld", (long)target);
-      return nil;
-      break;
-  }
+  return [self uploadURLs][@(target)];
 }
 
 - (instancetype)init {

--- a/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploader.h
+++ b/GoogleDataTransport/GDTCCTLibrary/Private/GDTCCTUploader.h
@@ -28,6 +28,10 @@ extern NSNotificationName const GDTCCTUploadCompleteNotification;
 /** Class capable of uploading events to the CCT backend. */
 @interface GDTCCTUploader : NSObject <GDTCORUploader>
 
+/** Returns the server URL for target.*/
+// TODO: create a separate public header (e.g. GDTCCTUploadURL.h) to make it a public API.
++ (NSDictionary<NSNumber *, NSURL *> *)uploadURLs;
+
 /** The queue on which all CCT uploading will occur. */
 @property(nonatomic, readonly) dispatch_queue_t uploaderQueue;
 
@@ -45,7 +49,7 @@ extern NSNotificationName const GDTCCTUploadCompleteNotification;
 
 #if !NDEBUG
 /** An upload URL used across all targets. For testing only. */
-@property(nullable, nonatomic) NSURL *testServerURL;
+@property(class, nullable, nonatomic) NSURL *testServerURL;
 
 #endif  // !NDEBUG
 

--- a/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
+++ b/GoogleDataTransport/GDTCCTTests/Unit/GDTCCTUploaderTest.m
@@ -60,7 +60,8 @@
   XCTAssertTrue(self.testServer.isRunning);
 
   self.uploader = [[GDTCCTUploader alloc] init];
-  self.uploader.testServerURL = [self.testServer.serverURL URLByAppendingPathComponent:@"logBatch"];
+  GDTCCTUploader.testServerURL =
+      [self.testServer.serverURL URLByAppendingPathComponent:@"logBatch"];
 }
 
 - (void)tearDown {
@@ -71,6 +72,17 @@
 }
 
 #pragma mark - Upload flow tests
+
+- (void)testUploadURLsAreCorrect {
+  GDTCCTUploader.testServerURL = nil;
+  NSDictionary<NSNumber *, NSURL *> *URLs = GDTCCTUploader.uploadURLs;
+  XCTAssertEqualObjects(URLs[@(kGDTCORTargetCCT)], [self serverURLForTarget:kGDTCORTargetCCT]);
+  XCTAssertEqualObjects(URLs[@(kGDTCORTargetFLL)], [self serverURLForTarget:kGDTCORTargetFLL]);
+  XCTAssertEqualObjects(URLs[@(kGDTCORTargetCSH)], [self serverURLForTarget:kGDTCORTargetCSH]);
+  XCTAssertEqualObjects(URLs[@(kGDTCORTargetINT)], [self serverURLForTarget:kGDTCORTargetINT]);
+  GDTCCTUploader.testServerURL =
+      [self.testServer.serverURL URLByAppendingPathComponent:@"logBatch"];
+}
 
 - (void)testUploadTargetWhenThereAreEventsToUpload {
   // 0. Generate test events.
@@ -283,7 +295,8 @@
 }
 
 - (void)testUploadTarget_WhenThereAreNoEventsFirstThenEventsAdded_ThenUploadNewEvent {
-  self.uploader.testServerURL = [self.testServer.serverURL URLByAppendingPathComponent:@"logBatch"];
+  GDTCCTUploader.testServerURL =
+      [self.testServer.serverURL URLByAppendingPathComponent:@"logBatch"];
 
   // 1. Test stored batch upload.
   // 1.1. Set up expectations.
@@ -708,6 +721,78 @@
 
   // 4. Wait for 1st upload finish.
   [self waitForUploadOperationsToFinish:self.uploader];
+}
+
+- (nullable NSURL *)serverURLForTarget:(GDTCORTarget)target {
+  // These strings should be interleaved to construct the real URL. This is just to (hopefully)
+  // fool github URL scanning bots.
+  static NSURL *CCTServerURL;
+  static NSString *const kINTServerURL =
+      @"https://dummyapiverylong-dummy.dummy.com/dummy/api/very/long";
+  static dispatch_once_t CCTOnceToken;
+  dispatch_once(&CCTOnceToken, ^{
+    const char *p1 = "hts/frbslgiggolai.o/0clgbth";
+    const char *p2 = "tp:/ieaeogn.ogepscmvc/o/ac";
+    const char URL[54] = {p1[0],  p2[0],  p1[1],  p2[1],  p1[2],  p2[2],  p1[3],  p2[3],  p1[4],
+                          p2[4],  p1[5],  p2[5],  p1[6],  p2[6],  p1[7],  p2[7],  p1[8],  p2[8],
+                          p1[9],  p2[9],  p1[10], p2[10], p1[11], p2[11], p1[12], p2[12], p1[13],
+                          p2[13], p1[14], p2[14], p1[15], p2[15], p1[16], p2[16], p1[17], p2[17],
+                          p1[18], p2[18], p1[19], p2[19], p1[20], p2[20], p1[21], p2[21], p1[22],
+                          p2[22], p1[23], p2[23], p1[24], p2[24], p1[25], p2[25], p1[26], '\0'};
+    CCTServerURL = [NSURL URLWithString:[NSString stringWithUTF8String:URL]];
+  });
+
+  static NSURL *FLLServerURL;
+  static dispatch_once_t FLLOnceToken;
+  dispatch_once(&FLLOnceToken, ^{
+    const char *p1 = "hts/frbslgigp.ogepscmv/ieo/eaybtho";
+    const char *p2 = "tp:/ieaeogn-agolai.o/1frlglgc/aclg";
+    const char URL[69] = {p1[0],  p2[0],  p1[1],  p2[1],  p1[2],  p2[2],  p1[3],  p2[3],  p1[4],
+                          p2[4],  p1[5],  p2[5],  p1[6],  p2[6],  p1[7],  p2[7],  p1[8],  p2[8],
+                          p1[9],  p2[9],  p1[10], p2[10], p1[11], p2[11], p1[12], p2[12], p1[13],
+                          p2[13], p1[14], p2[14], p1[15], p2[15], p1[16], p2[16], p1[17], p2[17],
+                          p1[18], p2[18], p1[19], p2[19], p1[20], p2[20], p1[21], p2[21], p1[22],
+                          p2[22], p1[23], p2[23], p1[24], p2[24], p1[25], p2[25], p1[26], p2[26],
+                          p1[27], p2[27], p1[28], p2[28], p1[29], p2[29], p1[30], p2[30], p1[31],
+                          p2[31], p1[32], p2[32], p1[33], p2[33], '\0'};
+    FLLServerURL = [NSURL URLWithString:[NSString stringWithUTF8String:URL]];
+  });
+
+  static NSURL *CSHServerURL;
+  static dispatch_once_t CSHOnceToken;
+  dispatch_once(&CSHOnceToken, ^{
+    // These strings should be interleaved to construct the real URL. This is just to (hopefully)
+    // fool github URL scanning bots.
+    const char *p1 = "hts/cahyiseot-agolai.o/1frlglgc/aclg";
+    const char *p2 = "tp:/rsltcrprsp.ogepscmv/ieo/eaybtho";
+    const char URL[72] = {p1[0],  p2[0],  p1[1],  p2[1],  p1[2],  p2[2],  p1[3],  p2[3],  p1[4],
+                          p2[4],  p1[5],  p2[5],  p1[6],  p2[6],  p1[7],  p2[7],  p1[8],  p2[8],
+                          p1[9],  p2[9],  p1[10], p2[10], p1[11], p2[11], p1[12], p2[12], p1[13],
+                          p2[13], p1[14], p2[14], p1[15], p2[15], p1[16], p2[16], p1[17], p2[17],
+                          p1[18], p2[18], p1[19], p2[19], p1[20], p2[20], p1[21], p2[21], p1[22],
+                          p2[22], p1[23], p2[23], p1[24], p2[24], p1[25], p2[25], p1[26], p2[26],
+                          p1[27], p2[27], p1[28], p2[28], p1[29], p2[29], p1[30], p2[30], p1[31],
+                          p2[31], p1[32], p2[32], p1[33], p2[33], p1[34], p2[34], p1[35], '\0'};
+    CSHServerURL = [NSURL URLWithString:[NSString stringWithUTF8String:URL]];
+  });
+
+  switch (target) {
+    case kGDTCORTargetCCT:
+      return CCTServerURL;
+
+    case kGDTCORTargetFLL:
+      return FLLServerURL;
+
+    case kGDTCORTargetCSH:
+      return CSHServerURL;
+
+    case kGDTCORTargetINT:
+      return [NSURL URLWithString:kINTServerURL];
+
+    default:
+      return nil;
+      break;
+  }
 }
 
 @end


### PR DESCRIPTION
Prototype reference: https://github.com/FirebasePrivate/firebase-ios-sdk/pull/731
