### PR TITLE
Fix Catalyst tests for #7050

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -67,26 +67,11 @@ jobs:
     # Don't run on private repo unless it is a PR.
     if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     runs-on: macOS-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Xcode 12
-      run: sudo xcode-select -s /Applications/Xcode_12.app/Contents/Developer
-    - name: Initialize xcodebuild
-      run: xcodebuild -list
-    - name: iOS Unit Tests
-      run: scripts/third_party/travis/retry.sh ./scripts/build.sh AuthUnit iOS spm
-
-  spm-cron:
-    # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
-    runs-on: macOS-latest
     strategy:
       matrix:
-        target: [tvOS, macOS, catalyst]
+        target: [iOS, tvOS, macOS, catalyst]
     steps:
     - uses: actions/checkout@v2
-    - name: Xcode 12
-      run: sudo xcode-select -s /Applications/Xcode_12.app/Contents/Developer
     - name: Initialize xcodebuild
       run: xcodebuild -list
     - name: Unit Tests

--- a/FirebaseAuth.podspec
+++ b/FirebaseAuth.podspec
@@ -50,7 +50,7 @@ supports email and password accounts, as well as several 3rd party authenticatio
 
   s.test_spec 'unit' do |unit_tests|
     # Unit tests can't run on watchOS.
-    unit_tests.platforms = {:ios => '8.0', :osx => '10.11', :tvos => '10.0'}
+    unit_tests.platforms = {:ios => '10.0', :osx => '10.12', :tvos => '10.0'}
     unit_tests.source_files = 'FirebaseAuth/Tests/Unit/*.[mh]'
     unit_tests.osx.exclude_files = [
       'FirebaseAuth/Tests/Unit/FIRAuthAPNSTokenManagerTests.m',

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 7.3.0
+- [fixed] Catalyst browser issue with `verifyPhoneNumber` API. (#7049)
+
 # 7.1.0
 - [fixed] Fixed completion handler issue in `application(_:didReceiveRemoteNotification:fetchCompletionHandler:)` method. (#6863)
 

--- a/FirebaseAuth/Tests/Unit/FIRAuthNotificationManagerTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthNotificationManagerTests.m
@@ -84,24 +84,6 @@ static NSString *const kSecret = @"FAKE_SECRET";
 
 @end
 
-/** @class FIRAuthLegacyForwardingDelegate
-    @brief A fake UIApplicationDelegate that implements the legacy deegate method to receive
-        notification.
- */
-@interface FIRAuthLegacyForwardingDelegate : FIRAuthFakeForwardingDelegate
-@end
-@implementation FIRAuthLegacyForwardingDelegate
-
-- (void)application:(UIApplication *)application
-    didReceiveRemoteNotification:(NSDictionary *)userInfo {
-  self.notificationReceived = YES;
-  if (self.forwardsNotification) {
-    self.notificationhandled = [self.notificationManager canHandleNotification:userInfo];
-  }
-}
-
-@end
-
 /** @class FIRAuthNotificationManagerTests
     @brief Unit tests for @c FIRAuthNotificationManager .
  */
@@ -127,11 +109,6 @@ static NSString *const kSecret = @"FAKE_SECRET";
       @brief The modern fake UIApplicationDelegate for testing.
    */
   FIRAuthModernForwardingDelegate *_modernDelegate;
-
-  /** @var _legacyDelegate
-      @brief The legacy fake UIApplicationDelegate for testing.
-   */
-  FIRAuthLegacyForwardingDelegate *_legacyDelegate;
 }
 
 - (void)setUp {
@@ -142,8 +119,6 @@ static NSString *const kSecret = @"FAKE_SECRET";
                                          appCredentialManager:_mockAppCredentialManager];
   _modernDelegate = [[FIRAuthModernForwardingDelegate alloc] init];
   _modernDelegate.notificationManager = _notificationManager;
-  _legacyDelegate = [[FIRAuthLegacyForwardingDelegate alloc] init];
-  _legacyDelegate.notificationManager = _notificationManager;
 }
 
 /** @fn testForwardingModernDelegate
@@ -153,25 +128,11 @@ static NSString *const kSecret = @"FAKE_SECRET";
   [self verifyForwarding:YES delegate:_modernDelegate];
 }
 
-/** @fn testForwardingLegacyDelegate
-    @brief Tests checking notification forwarding on legacy fake delegate.
- */
-- (void)testForwardingLegacyDelegate {
-  [self verifyForwarding:YES delegate:_legacyDelegate];
-}
-
 /** @fn testNotForwardingModernDelegate
     @brief Tests checking notification not forwarding on modern fake delegate.
  */
 - (void)testNotForwardingModernDelegate {
   [self verifyForwarding:NO delegate:_modernDelegate];
-}
-
-/** @fn testNotForwardingLegacyDelegate
-    @brief Tests checking notification not forwarding on legacy fake delegate.
- */
-- (void)testNotForwardingLegacyDelegate {
-  [self verifyForwarding:NO delegate:_legacyDelegate];
 }
 
 /** @fn verifyForwarding:delegate:
@@ -210,31 +171,6 @@ static NSString *const kSecret = @"FAKE_SECRET";
       }];
   XCTAssertTrue(calledBack);
   XCTAssertFalse(delegate.notificationReceived);
-}
-
-/** @fn testMultipleCallbacks
-    @brief Test multiple callbacks are handled correctly.
- */
-- (void)testMultipleCallbacks {
-  FIRAuthFakeForwardingDelegate *delegate = _legacyDelegate;
-  delegate.forwardsNotification = YES;
-  OCMStub([_mockApplication delegate]).andReturn(delegate);
-  XCTestExpectation *expectation1 = [self expectationWithDescription:@"callback1"];
-  [_notificationManager
-      checkNotificationForwardingWithCallback:^(BOOL isNotificationBeingForwarded) {
-        XCTAssertTrue(isNotificationBeingForwarded);
-        [expectation1 fulfill];
-      }];
-  XCTestExpectation *expectation2 = [self expectationWithDescription:@"callback2"];
-  [_notificationManager
-      checkNotificationForwardingWithCallback:^(BOOL isNotificationBeingForwarded) {
-        XCTAssertTrue(isNotificationBeingForwarded);
-        [expectation2 fulfill];
-      }];
-  XCTAssertFalse(delegate.notificationReceived);
-  [self waitForExpectationsWithTimeout:_notificationManager.timeout * .5 handler:nil];
-  XCTAssertTrue(delegate.notificationReceived);
-  XCTAssertTrue(delegate.notificationhandled);
 }
 
 /** @fn testPassingToCredentialManager

--- a/FirebaseAuth/Tests/Unit/FIRAuthTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthTests.m
@@ -259,13 +259,6 @@ static const NSTimeInterval kWaitInterval = .5;
   return NO;
 }
 
-- (BOOL)application:(UIApplication *)application
-              openURL:(NSURL *)url
-    sourceApplication:(nullable NSString *)sourceApplication
-           annotation:(id)annotation {
-  return NO;
-}
-
 @end
 
 #endif  // TARGET_OS_IOS

--- a/FirebaseAuth/Tests/Unit/FIRAuthURLPresenterTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthURLPresenterTests.m
@@ -101,17 +101,18 @@ static NSTimeInterval kExpectationTimeout = 2;
         [invocation getArgument:&unretainedArgument atIndex:2];
 
         id presentViewController = unretainedArgument;
-        if (@available(iOS 9.0, *)) {  // SFSafariViewController is available
-          SFSafariViewController *viewController = presentViewController;
-          XCTAssertTrue([viewController isKindOfClass:[SFSafariViewController class]]);
-          XCTAssertEqual(viewController.delegate, presenter);
-        } else {
-          UINavigationController *navigationController = presentViewController;
-          XCTAssertTrue([navigationController isKindOfClass:[UINavigationController class]]);
-          FIRAuthWebViewController *webViewController =
-              navigationController.viewControllers.firstObject;
-          XCTAssertTrue([webViewController isKindOfClass:[FIRAuthWebViewController class]]);
-        }
+#if TARGET_OS_MACCATALYST
+        // SFSafariViewController is not available
+        UINavigationController *navigationController = presentViewController;
+        XCTAssertTrue([navigationController isKindOfClass:[UINavigationController class]]);
+        FIRAuthWebViewController *webViewController =
+            navigationController.viewControllers.firstObject;
+        XCTAssertTrue([webViewController isKindOfClass:[FIRAuthWebViewController class]]);
+#else
+        SFSafariViewController *viewController = presentViewController;
+        XCTAssertTrue([viewController isKindOfClass:[SFSafariViewController class]]);
+        XCTAssertEqual(viewController.delegate, presenter);
+#endif
         [UIPresentationExpectation fulfill];
       });
 


### PR DESCRIPTION
The Catalyst cron tests failed last night. See #7024. This fixes that failure and does a few more cleanups.

- Update Auth unit tests for changes from #7050 
- Always run multi-platform unit tests in CI instead of only in cron job
- remove iOS 8 and 9 specific unit testing
- Changelog update for #7050
