### PR TITLE
[App Distribution] Fix crash caused by response being nil

### DIFF
--- a/FirebaseAppDistribution/CHANGELOG.md
+++ b/FirebaseAppDistribution/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 - [changed] Sign out the Tester when the call to fetch releases fails with an unauthenticated error.
+- [fixed] Crash caused by trying to parse response as JSON when response is nil.
 
 # v0.9.3
 - [changed] Updated error log for non-200 API Service calls.

--- a/FirebaseAppDistribution/CHANGELOG.md
+++ b/FirebaseAppDistribution/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - [changed] Sign out the Tester when the call to fetch releases fails with an unauthenticated error.
-- [fixed] Crash caused by trying to parse response as JSON when response is nil.
+- [fixed] Crash caused by trying to parse response as JSON when response is nil (#6996).
 
 # v0.9.3
 - [changed] Updated error log for non-200 API Service calls.

--- a/FirebaseAppDistribution/Sources/FIRFADApiService.m
+++ b/FirebaseAppDistribution/Sources/FIRFADApiService.m
@@ -79,6 +79,10 @@ NSString *const kResponseReleasesKey = @"releases";
 }
 
 + (NSString *)tryParseGoogleAPIErrorFromResponse:(NSData *)data {
+  if (!data) {
+    return @"No data in response.";
+  }
+
   NSError *parseError;
   NSDictionary *responseDict = [NSJSONSerialization JSONObjectWithData:data
                                                                options:0
@@ -151,7 +155,6 @@ NSString *const kResponseReleasesKey = @"releases";
     return [self handleError:error
                  description:@"Unknown http error occurred"
                         code:FIRApiErrorUnknownFailure];
-    ;
   }
 
   if ([httpResponse statusCode] != 200) {

--- a/FirebaseAppDistribution/Tests/Unit/FIRFADApiServiceTests.m
+++ b/FirebaseAppDistribution/Tests/Unit/FIRFADApiServiceTests.m
@@ -175,6 +175,11 @@ NSString *const kFakeErrorDomain = @"test.failure.domain";
   XCTAssertTrue([message isEqualToString:_mockAPINotEnabledMessage]);
 }
 
+- (void)testTryParseGoogleAPIErrorFromNilResponse {
+  NSString *message = [FIRFADApiService tryParseGoogleAPIErrorFromResponse:nil];
+  XCTAssertTrue([message isEqualToString:@"No data in response."]);
+}
+
 - (void)testTryParseGoogleAPIErrorFromResponseParseFailure {
   NSData *data = [@"malformed{json[data" dataUsingEncoding:NSUTF8StringEncoding];
   NSString *message = [FIRFADApiService tryParseGoogleAPIErrorFromResponse:data];


### PR DESCRIPTION
When an error occurs, the response data will be nil. This causes a crash because we are trying to parse the response as JSON. Instead, return a generic error message if the response is nil.

Fixes #6996