### PR TITLE
Crashlytics improve logging for Analytics integration

### DIFF
--- a/Crashlytics/Crashlytics/Helpers/FIRCLSFCRAnalytics.m
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSFCRAnalytics.m
@@ -53,7 +53,8 @@ FOUNDATION_STATIC_INLINE NSNumber *timeIntervalInMillis(NSTimeInterval timeInter
                   toAnalytics:(id<FIRAnalyticsInterop>)analytics {
   if (analytics == nil) {
     FIRCLSDeveloperLog(@"Crashlytics:Crash:Reports:Event",
-                       "Firebase Analytics SDK not detected so crash-free statistics and breadcrumbs will not be reported");
+                       "Firebase Analytics SDK not detected so crash-free statistics and "
+                       "breadcrumbs will not be reported");
     return;
   }
 

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSFCRAnalytics.m
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSFCRAnalytics.m
@@ -53,7 +53,7 @@ FOUNDATION_STATIC_INLINE NSNumber *timeIntervalInMillis(NSTimeInterval timeInter
                   toAnalytics:(id<FIRAnalyticsInterop>)analytics {
   if (analytics == nil) {
     FIRCLSDeveloperLog(@"Crashlytics:Crash:Reports:Event",
-                       "Firebase Analytics SDK not detected so crash-free statistics and "
+                       "Firebase Analytics SDK not detected. Crash-free statistics and "
                        "breadcrumbs will not be reported");
     return;
   }

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSFCRAnalytics.m
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSFCRAnalytics.m
@@ -43,7 +43,8 @@ FOUNDATION_STATIC_INLINE NSNumber *timeIntervalInMillis(NSTimeInterval timeInter
     return;
   }
 
-  FIRCLSDeveloperLog(@"Crashlytics:Crash:Reports:Event", "Sending app_exception event to Firebase Analytics for Crash Free Users");
+  FIRCLSDeveloperLog(@"Crashlytics:Crash:Reports:Event",
+                     "Sending app_exception event to Firebase Analytics for Crash Free Users");
   NSDictionary *params = [self buildLogParamsFromCrash:crashTimeStamp];
   [analytics logEventWithOrigin:kFIREventOriginCrash name:kFIREventAppException parameters:params];
 }
@@ -51,6 +52,8 @@ FOUNDATION_STATIC_INLINE NSNumber *timeIntervalInMillis(NSTimeInterval timeInter
 + (void)registerEventListener:(id<FIRAnalyticsInteropListener>)eventListener
                   toAnalytics:(id<FIRAnalyticsInterop>)analytics {
   if (analytics == nil) {
+    FIRCLSDeveloperLog(@"Crashlytics:Crash:Reports:Event",
+                       "Firebase Analytics SDK not detected so Crash Free Users and breadcrumbs will not be reported");
     return;
   }
 

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSFCRAnalytics.m
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSFCRAnalytics.m
@@ -43,7 +43,7 @@ FOUNDATION_STATIC_INLINE NSNumber *timeIntervalInMillis(NSTimeInterval timeInter
     return;
   }
 
-  FIRCLSDeveloperLog(@"Crashlytics:Crash:Reports:Event", "Sending event.");
+  FIRCLSDeveloperLog(@"Crashlytics:Crash:Reports:Event", "Sending app_exception event to Firebase Analytics for Crash Free Users");
   NSDictionary *params = [self buildLogParamsFromCrash:crashTimeStamp];
   [analytics logEventWithOrigin:kFIREventOriginCrash name:kFIREventAppException parameters:params];
 }
@@ -57,7 +57,7 @@ FOUNDATION_STATIC_INLINE NSNumber *timeIntervalInMillis(NSTimeInterval timeInter
   [analytics registerAnalyticsListener:eventListener withOrigin:kFIREventOriginCrash];
 
   FIRCLSDeveloperLog(@"Crashlytics:Crash:Reports:Event",
-                     "Registered Firebase Analytics event listener");
+                     "Registered Firebase Analytics event listener to receive breadcrumb logs");
 }
 
 /**

--- a/Crashlytics/Crashlytics/Helpers/FIRCLSFCRAnalytics.m
+++ b/Crashlytics/Crashlytics/Helpers/FIRCLSFCRAnalytics.m
@@ -44,7 +44,7 @@ FOUNDATION_STATIC_INLINE NSNumber *timeIntervalInMillis(NSTimeInterval timeInter
   }
 
   FIRCLSDeveloperLog(@"Crashlytics:Crash:Reports:Event",
-                     "Sending app_exception event to Firebase Analytics for Crash Free Users");
+                     "Sending app_exception event to Firebase Analytics for crash-free statistics");
   NSDictionary *params = [self buildLogParamsFromCrash:crashTimeStamp];
   [analytics logEventWithOrigin:kFIREventOriginCrash name:kFIREventAppException parameters:params];
 }
@@ -53,7 +53,7 @@ FOUNDATION_STATIC_INLINE NSNumber *timeIntervalInMillis(NSTimeInterval timeInter
                   toAnalytics:(id<FIRAnalyticsInterop>)analytics {
   if (analytics == nil) {
     FIRCLSDeveloperLog(@"Crashlytics:Crash:Reports:Event",
-                       "Firebase Analytics SDK not detected so Crash Free Users and breadcrumbs will not be reported");
+                       "Firebase Analytics SDK not detected so crash-free statistics and breadcrumbs will not be reported");
     return;
   }
 


### PR DESCRIPTION
The old logs were too nebulous for customers and devrel.

#no-changelog
