### PR TITLE
docs(README): note Xcode >=12 / cocoapods >= 1.10 required

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Instructions for the experimental Carthage distribution are at
 To develop Firebase software in this repository, ensure that you have at least
 the following software:
 
-  * Xcode 11.0 (or later)
-  * CocoaPods 1.9.0 (or later)
+  * Xcode 12.0 (or later)
+  * CocoaPods 1.10.0 (or later)
   * [CocoaPods generate](https://github.com/square/cocoapods-generate)
 
 For the pod that you want to develop:


### PR DESCRIPTION
### Discussion

It appears to not be required for every configuration, but probably easier to specify,
as Xcode 12 and cocoapods 1.10 are generally available and will avoid developer
experience surprises 

https://firebase.google.com/support/release-notes/ios#performance-monitoring

### Testing

Docs only change

### API Changes

Docs only change
