### PR TITLE
Fix integer conversion loss warnings for size_t to int

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 - [fixed] Fixed a crash that could happen when the SDK encountered invalid
   data during garbage collection (#6721).
+- [fixed] Integer precision loss warnings on some platforms.
 
 # v7.2.0
 - [added] Made emulator connection API consistent between Auth, Database,

--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Unreleased
 - [fixed] Fixed a crash that could happen when the SDK encountered invalid
   data during garbage collection (#6721).
-- [fixed] Integer precision loss warnings on some platforms.
 
 # v7.2.0
 - [added] Made emulator connection API consistent between Auth, Database,

--- a/Firestore/core/src/local/leveldb_lru_reference_delegate.cc
+++ b/Firestore/core/src/local/leveldb_lru_reference_delegate.cc
@@ -147,7 +147,8 @@ int LevelDbLruReferenceDelegate::RemoveOrphanedDocuments(
 
 int LevelDbLruReferenceDelegate::RemoveTargets(
     ListenSequenceNumber sequence_number, const LiveQueryMap& live_queries) {
-  return (int)db_->target_cache()->RemoveTargets(sequence_number, live_queries);
+  return static_cast<int>(
+      db_->target_cache()->RemoveTargets(sequence_number, live_queries));
 }
 
 bool LevelDbLruReferenceDelegate::IsPinned(const DocumentKey& key) {

--- a/Firestore/core/src/local/leveldb_lru_reference_delegate.cc
+++ b/Firestore/core/src/local/leveldb_lru_reference_delegate.cc
@@ -147,7 +147,7 @@ int LevelDbLruReferenceDelegate::RemoveOrphanedDocuments(
 
 int LevelDbLruReferenceDelegate::RemoveTargets(
     ListenSequenceNumber sequence_number, const LiveQueryMap& live_queries) {
-  return db_->target_cache()->RemoveTargets(sequence_number, live_queries);
+  return (int)db_->target_cache()->RemoveTargets(sequence_number, live_queries);
 }
 
 bool LevelDbLruReferenceDelegate::IsPinned(const DocumentKey& key) {

--- a/Firestore/core/src/local/memory_lru_reference_delegate.cc
+++ b/Firestore/core/src/local/memory_lru_reference_delegate.cc
@@ -116,8 +116,8 @@ size_t MemoryLruReferenceDelegate::GetSequenceNumberCount() {
 int MemoryLruReferenceDelegate::RemoveTargets(
     model::ListenSequenceNumber sequence_number,
     const LiveQueryMap& live_queries) {
-  return (int)persistence_->target_cache()->RemoveTargets(sequence_number,
-                                                          live_queries);
+  return static_cast<int>(persistence_->target_cache()->RemoveTargets(
+      sequence_number, live_queries));
 }
 
 int MemoryLruReferenceDelegate::RemoveOrphanedDocuments(

--- a/Firestore/core/src/local/memory_lru_reference_delegate.cc
+++ b/Firestore/core/src/local/memory_lru_reference_delegate.cc
@@ -117,7 +117,7 @@ int MemoryLruReferenceDelegate::RemoveTargets(
     model::ListenSequenceNumber sequence_number,
     const LiveQueryMap& live_queries) {
   return (int)persistence_->target_cache()->RemoveTargets(sequence_number,
-                                                     live_queries);
+                                                          live_queries);
 }
 
 int MemoryLruReferenceDelegate::RemoveOrphanedDocuments(

--- a/Firestore/core/src/local/memory_lru_reference_delegate.cc
+++ b/Firestore/core/src/local/memory_lru_reference_delegate.cc
@@ -116,7 +116,7 @@ size_t MemoryLruReferenceDelegate::GetSequenceNumberCount() {
 int MemoryLruReferenceDelegate::RemoveTargets(
     model::ListenSequenceNumber sequence_number,
     const LiveQueryMap& live_queries) {
-  return persistence_->target_cache()->RemoveTargets(sequence_number,
+  return (int)persistence_->target_cache()->RemoveTargets(sequence_number,
                                                      live_queries);
 }
 


### PR DESCRIPTION
`/Users/paulbeusterien/gh6/firebase-ios-sdk/Firestore/core/src/local/leveldb_lru_reference_delegate.cc:150:31: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Wshorten-64-to-32]`