### PR TITLE
Manage platform dependent tests in test targets

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Firebase-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Firebase-Package.xcscheme
@@ -510,6 +510,216 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseAppDistribution-Beta"
+               BuildableName = "FirebaseAppDistribution-Beta"
+               BlueprintName = "FirebaseAppDistribution-Beta"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseFirestoreSwift-Beta"
+               BuildableName = "FirebaseFirestoreSwift-Beta"
+               BlueprintName = "FirebaseFirestoreSwift-Beta"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseStorageSwift-Beta"
+               BuildableName = "FirebaseStorageSwift-Beta"
+               BlueprintName = "FirebaseStorageSwift-Beta"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Firebase_AppDistributionUnit"
+               BuildableName = "Firebase_AppDistributionUnit"
+               BlueprintName = "Firebase_AppDistributionUnit"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseAnalyticsTarget"
+               BuildableName = "FirebaseAnalyticsTarget"
+               BlueprintName = "FirebaseAnalyticsTarget"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseAppDistribution"
+               BuildableName = "FirebaseAppDistribution"
+               BlueprintName = "FirebaseAppDistribution"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseAppDistributionTarget"
+               BuildableName = "FirebaseAppDistributionTarget"
+               BlueprintName = "FirebaseAppDistributionTarget"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseDatabaseTarget"
+               BuildableName = "FirebaseDatabaseTarget"
+               BlueprintName = "FirebaseDatabaseTarget"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseDynamicLinksTarget"
+               BuildableName = "FirebaseDynamicLinksTarget"
+               BlueprintName = "FirebaseDynamicLinksTarget"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseFirestoreSwiftTarget"
+               BuildableName = "FirebaseFirestoreSwiftTarget"
+               BlueprintName = "FirebaseFirestoreSwiftTarget"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseFirestoreTarget"
+               BuildableName = "FirebaseFirestoreTarget"
+               BlueprintName = "FirebaseFirestoreTarget"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseFunctionsTarget"
+               BuildableName = "FirebaseFunctionsTarget"
+               BlueprintName = "FirebaseFunctionsTarget"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseInAppMessagingTarget"
+               BuildableName = "FirebaseInAppMessagingTarget"
+               BlueprintName = "FirebaseInAppMessagingTarget"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseMLModelDownloader"
+               BuildableName = "FirebaseMLModelDownloader"
+               BlueprintName = "FirebaseMLModelDownloader"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseRemoteConfigTarget"
+               BuildableName = "FirebaseRemoteConfigTarget"
+               BlueprintName = "FirebaseRemoteConfigTarget"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -675,6 +885,26 @@
                BlueprintIdentifier = "MessagingUnit"
                BuildableName = "MessagingUnit"
                BlueprintName = "MessagingUnit"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AppDistributionUnit"
+               BuildableName = "AppDistributionUnit"
+               BlueprintName = "AppDistributionUnit"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirebaseMLModelDownloaderUnit"
+               BuildableName = "FirebaseMLModelDownloaderUnit"
+               BlueprintName = "FirebaseMLModelDownloaderUnit"
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>

--- a/FirebaseAppDistribution/Sources/FIRAppDistribution.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistribution.m
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #import <Foundation/Foundation.h>
-#import <TargetConditionals.h>
-#if TARGET_OS_IOS
 
 #import <GoogleUtilities/GULAppDelegateSwizzler.h>
 #import <GoogleUtilities/GULUserDefaults.h>
@@ -335,5 +333,3 @@ NSString *const kFIRFADSignInStateKey = @"FIRFADSignInState";
   return codeHash && [codeHash isEqualToString:[machO codeHash]];
 }
 @end
-
-#endif

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.h
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.h
@@ -12,17 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import <TargetConditionals.h>
-#if TARGET_OS_IOS
-
 #import <AuthenticationServices/AuthenticationServices.h>
 #import <Foundation/Foundation.h>
 #import <SafariServices/SafariServices.h>
 #import <UIKit/UIKit.h>
 
 #import "FirebaseAppDistribution/Sources/Private/FIRAppDistribution.h"
-
-@protocol SFSafariViewControllerDelegate;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -65,5 +60,3 @@ typedef void (^AppDistributionRegistrationFlowCompletion)(NSError *_Nullable err
 @end
 
 NS_ASSUME_NONNULL_END
-
-#endif

--- a/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
+++ b/FirebaseAppDistribution/Sources/FIRAppDistributionUIService.m
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#import <TargetConditionals.h>
-#if TARGET_OS_IOS
-
 #import "FirebaseAppDistribution/Sources/FIRAppDistributionUIService.h"
 #import "FirebaseAppDistribution/Sources/FIRFADLogger.h"
 #import "FirebaseAppDistribution/Sources/Public/FirebaseAppDistribution/FIRAppDistribution.h"
@@ -267,5 +264,3 @@ SFAuthenticationSession *_safariAuthenticationVC;
 }
 
 @end
-
-#endif

--- a/Package.swift
+++ b/Package.swift
@@ -756,7 +756,10 @@ let package = Package(
       dependencies: [
         "FirebaseAuth",
         "FirebaseABTesting",
-        "FirebaseAppDistribution",
+        .target(name: "FirebaseAnalytics",
+                condition: .when(platforms: [.iOS])),
+        .target(name: "FirebaseAppDistribution",
+                condition: .when(platforms: [.iOS])),
         "Firebase",
         "FirebaseCrashlytics",
         "FirebaseCore",
@@ -798,7 +801,10 @@ let package = Package(
       dependencies: [
         "FirebaseAuth",
         "FirebaseABTesting",
-        "FirebaseAppDistribution",
+        .target(name: "FirebaseAnalytics",
+                condition: .when(platforms: [.iOS])),
+        .target(name: "FirebaseAppDistribution",
+                condition: .when(platforms: [.iOS])),
         "Firebase",
         "FirebaseCrashlytics",
         "FirebaseCore",

--- a/SwiftPMTests/objc-import-test/objc-header.m
+++ b/SwiftPMTests/objc-import-test/objc-header.m
@@ -14,7 +14,10 @@
 
 #import "Firebase.h"
 #import "FirebaseABTesting/FirebaseABTesting.h"
+#if TARGET_OS_IOS
+#import "FirebaseAnalytics/FirebaseAnalytics.h"
 #import "FirebaseAppDistribution/FirebaseAppDistribution.h"
+#endif
 #import "FirebaseAuth/FirebaseAuth.h"
 #import "FirebaseCore/FirebaseCore.h"
 #import "FirebaseCrashlytics/FirebaseCrashlytics.h"
@@ -30,7 +33,11 @@
 
 #import <Firebase.h>
 #import <FirebaseABTesting/FirebaseABTesting.h>
+#import <TargetConditionals.h>
+#if TARGET_OS_IOS
+#import <FirebaseAnalytics/FirebaseAnalytics.h>
 #import <FirebaseAppDistribution/FirebaseAppDistribution.h>
+#endif
 #import <FirebaseAuth/FirebaseAuth.h>
 #import <FirebaseCore/FirebaseCore.h>
 #import <FirebaseCrashlytics/FirebaseCrashlytics.h>

--- a/SwiftPMTests/objc-import-test/objc-module.m
+++ b/SwiftPMTests/objc-import-test/objc-module.m
@@ -14,7 +14,10 @@
 
 @import FirebaseAuth;
 @import FirebaseABTesting;
+#if TARGET_OS_IOS
+@import FirebaseAnalytics;
 @import FirebaseAppDistribution;
+#endif
 @import Firebase;
 @import FirebaseCrashlytics;
 @import FirebaseCore;

--- a/SwiftPMTests/swift-test/main.swift
+++ b/SwiftPMTests/swift-test/main.swift
@@ -17,7 +17,10 @@ import Firebase
 import FirebaseCore
 import FirebaseAuth
 import FirebaseABTesting
+#if os(iOS)
+import FirebaseAnalytics
 import FirebaseAppDistribution
+#endif
 import FirebaseCrashlytics
 import FirebaseDynamicLinks
 import FirebaseFirestore
@@ -61,6 +64,6 @@ class importTest: XCTestCase {
     XCTAssertNotNil(Int(versionParts[1]))
     XCTAssertNotNil(Int(versionParts[2]))
 
-    print("System version? Answer: \(GULAppEnvironmentUtil.systemVersion() ?? "NONE")")
+    print("System version? Answer: \(GULAppEnvironmentUtil.systemVersion())")
   }
 }

--- a/SwiftPMTests/swift-test/main.swift
+++ b/SwiftPMTests/swift-test/main.swift
@@ -18,8 +18,8 @@ import FirebaseCore
 import FirebaseAuth
 import FirebaseABTesting
 #if os(iOS)
-import FirebaseAnalytics
-import FirebaseAppDistribution
+  import FirebaseAnalytics
+  import FirebaseAppDistribution
 #endif
 import FirebaseCrashlytics
 import FirebaseDynamicLinks


### PR DESCRIPTION
This reverts #7091 and solves the AppDistro macOS/tvOS test failures by adjusting the tests and test targets instead of the libraries themselves.

Also add similar platform based import testing for Analytics.