### PR TITLE
Use iPhone 12 Pro for watchOS builds

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -166,7 +166,7 @@ tvos_flags=(
   -destination 'platform=tvOS Simulator,name=Apple TV'
 )
 watchos_flags=(
-  -destination 'platform=iOS Simulator,name=iPhone 11 Pro'
+  -destination 'platform=iOS Simulator,name=iPhone 12 Pro'
 )
 catalyst_flags=(
   ARCHS=x86_64 VALID_ARCHS=x86_64 SUPPORTS_MACCATALYST=YES -sdk macosx

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -148,7 +148,7 @@ if [[ "$xcode_major" -lt 11 ]]; then
 else
   ios_flags=(
     -sdk 'iphonesimulator'
-    -destination 'platform=iOS Simulator,name=iPhone 11'
+    -destination 'platform=iOS Simulator,name=iPhone 12'
   )
 fi
 


### PR DESCRIPTION
This was causing a nightly failure. Xcode 12.2 is the default as of Nov 30th. 