### PR TITLE
Use Xcode 12.0 for watchOS test app

### DIFF
--- a/.github/workflows/datatransport.yml
+++ b/.github/workflows/datatransport.yml
@@ -47,6 +47,8 @@ jobs:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Xcode 12
+      run: sudo xcode-select -s /Applications/Xcode_12.app/Contents/Developer
     - name: Setup Bundler
       run: scripts/setup_bundler.sh
     - name: Prereqs


### PR DESCRIPTION
This ensures the iPhone 11 Pro simulator is available.