### PR TITLE
Remove Analytics Catalyst tests.

### DIFF
--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -29,7 +29,7 @@ jobs:
 
   cron-only:
     # Don't run on private repo.
-    #    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
 
     runs-on: macOS-latest
     strategy:

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -29,7 +29,7 @@ jobs:
 
   cron-only:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    #    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
 
     runs-on: macOS-latest
     strategy:

--- a/Package.swift
+++ b/Package.swift
@@ -801,8 +801,6 @@ let package = Package(
       dependencies: [
         "FirebaseAuth",
         "FirebaseABTesting",
-        .target(name: "FirebaseAnalytics",
-                condition: .when(platforms: [.iOS])),
         .target(name: "FirebaseAppDistribution",
                 condition: .when(platforms: [.iOS])),
         "Firebase",

--- a/Package.swift
+++ b/Package.swift
@@ -756,8 +756,6 @@ let package = Package(
       dependencies: [
         "FirebaseAuth",
         "FirebaseABTesting",
-        .target(name: "FirebaseAnalytics",
-                condition: .when(platforms: [.iOS])),
         .target(name: "FirebaseAppDistribution",
                 condition: .when(platforms: [.iOS])),
         "Firebase",

--- a/SwiftPMTests/objc-import-test/objc-header.m
+++ b/SwiftPMTests/objc-import-test/objc-header.m
@@ -14,8 +14,7 @@
 
 #import "Firebase.h"
 #import "FirebaseABTesting/FirebaseABTesting.h"
-#if TARGET_OS_IOS
-#import "FirebaseAnalytics/FirebaseAnalytics.h"
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 #import "FirebaseAppDistribution/FirebaseAppDistribution.h"
 #endif
 #import "FirebaseAuth/FirebaseAuth.h"
@@ -34,8 +33,7 @@
 #import <Firebase.h>
 #import <FirebaseABTesting/FirebaseABTesting.h>
 #import <TargetConditionals.h>
-#if TARGET_OS_IOS
-#import <FirebaseAnalytics/FirebaseAnalytics.h>
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 #import <FirebaseAppDistribution/FirebaseAppDistribution.h>
 #endif
 #import <FirebaseAuth/FirebaseAuth.h>

--- a/SwiftPMTests/objc-import-test/objc-module.m
+++ b/SwiftPMTests/objc-import-test/objc-module.m
@@ -14,8 +14,7 @@
 
 @import FirebaseAuth;
 @import FirebaseABTesting;
-#if TARGET_OS_IOS
-@import FirebaseAnalytics;
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
 @import FirebaseAppDistribution;
 #endif
 @import Firebase;

--- a/SwiftPMTests/swift-test/main.swift
+++ b/SwiftPMTests/swift-test/main.swift
@@ -17,8 +17,7 @@ import Firebase
 import FirebaseCore
 import FirebaseAuth
 import FirebaseABTesting
-#if os(iOS)
-  import FirebaseAnalytics
+#if os(iOS) && !targetEnvironment(macCatalyst)
   import FirebaseAppDistribution
 #endif
 import FirebaseCrashlytics


### PR DESCRIPTION
By specifying iOS in the package manifest, it includes Analytics but the
Analytics xcframework doesn't have a Catalyst slice.

#no-changelog