### PR TITLE
Clean up usages of deprecated APIs

### DIFF
--- a/FirebaseAuth/Sources/Auth/FIRAuth.m
+++ b/FirebaseAuth/Sources/Auth/FIRAuth.m
@@ -1502,31 +1502,11 @@ static NSMutableDictionary *gKeychainServiceNameForAppName;
   completionHandler(UIBackgroundFetchResultNoData);
 }
 
-// iOS 10 deprecation
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-implementations"
-- (void)application:(UIApplication *)application
-    didReceiveRemoteNotification:(NSDictionary *)userInfo {
-  [self canHandleNotification:userInfo];
-}
-#pragma clang diagnostic pop
-
 - (BOOL)application:(UIApplication *)app
             openURL:(NSURL *)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
   return [self canHandleURL:url];
 }
-
-// iOS 10 deprecation
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-implementations"
-- (BOOL)application:(UIApplication *)application
-              openURL:(NSURL *)url
-    sourceApplication:(nullable NSString *)sourceApplication
-           annotation:(id)annotation {
-  return [self canHandleURL:url];
-}
-#pragma clang diagnostic pop
 
 - (void)setAPNSToken:(NSData *)token type:(FIRAuthAPNSTokenType)type {
   dispatch_sync(FIRAuthGlobalWorkQueue(), ^{

--- a/FirebaseAuth/Sources/SystemService/FIRAuthNotificationManager.m
+++ b/FirebaseAuth/Sources/SystemService/FIRAuthNotificationManager.m
@@ -115,16 +115,6 @@ static const NSTimeInterval kProbingTimeout = 1;
                   didReceiveRemoteNotification:proberNotification
                         fetchCompletionHandler:^(UIBackgroundFetchResult result){
                         }];
-#if !TARGET_OS_TV
-    } else if ([self->_application.delegate
-                   respondsToSelector:@selector(application:didReceiveRemoteNotification:)]) {
-// iOS 10 deprecation
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-      [self->_application.delegate application:self->_application
-                  didReceiveRemoteNotification:proberNotification];
-#pragma clang diagnostic pop
-#endif
     } else {
       FIRLogWarning(kFIRLoggerAuth, @"I-AUT000015",
                     @"The UIApplicationDelegate must handle remote notification for phone number "

--- a/FirebaseAuth/Tests/Unit/FIRAuthTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRAuthTests.m
@@ -2349,20 +2349,6 @@ static const NSTimeInterval kWaitInterval = .5;
   [self.mockTokenManager verify];
 }
 
-- (void)testAppDidReceiveRemoteNotification_NotificationManagerHandleCanNotification {
-  NSDictionary *notification = @{@"test" : @""};
-
-  OCMExpect([self.mockNotificationManager canHandleNotification:notification]);
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  [self.fakeApplicationDelegate application:[GULAppDelegateSwizzler sharedApplication]
-               didReceiveRemoteNotification:notification];
-#pragma clang diagnostic pop
-
-  [self.mockNotificationManager verify];
-}
-
 - (void)testAppDidReceiveRemoteNotificationWithCompletion_NotificationManagerHandleCanNotification {
   NSDictionary *notification = @{@"test" : @""};
 
@@ -2377,33 +2363,14 @@ static const NSTimeInterval kWaitInterval = .5;
 }
 
 - (void)testAppOpenURL_AuthPresenterCanHandleURL {
-  if (@available(iOS 9.0, *)) {
-    // 'application:openURL:options:' is only available on iOS 9.0 or newer.
-    NSURL *url = [NSURL URLWithString:@"https://localhost"];
-
-    [OCMExpect([self.mockAuthURLPresenter canHandleURL:url]) andReturnValue:@(YES)];
-
-    XCTAssertTrue([self.fakeApplicationDelegate
-        application:[GULAppDelegateSwizzler sharedApplication]
-            openURL:url
-            options:@{}]);
-
-    [self.mockAuthURLPresenter verify];
-  }
-}
-
-- (void)testAppOpenURLWithSourceApplication_AuthPresenterCanHandleURL {
+  // 'application:openURL:options:' is only available on iOS 9.0 or newer.
   NSURL *url = [NSURL URLWithString:@"https://localhost"];
 
   [OCMExpect([self.mockAuthURLPresenter canHandleURL:url]) andReturnValue:@(YES)];
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   XCTAssertTrue([self.fakeApplicationDelegate application:[GULAppDelegateSwizzler sharedApplication]
                                                   openURL:url
-                                        sourceApplication:@""
-                                               annotation:[[NSObject alloc] init]]);
-#pragma clang diagnostic pop
+                                                  options:@{}]);
 
   [self.mockAuthURLPresenter verify];
 }

--- a/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
+++ b/GoogleUtilities/AppDelegateSwizzler/GULAppDelegateSwizzler.m
@@ -517,20 +517,13 @@ static dispatch_once_t sProxyAppDelegateRemoteNotificationOnceToken;
       NSSelectorFromString(kGULDidReceiveRemoteNotificationWithCompletionSEL);
   SEL didReceiveRemoteNotificationWithCompletionDonorSEL =
       @selector(application:donor_didReceiveRemoteNotification:fetchCompletionHandler:);
-  if ([appDelegate respondsToSelector:didReceiveRemoteNotificationWithCompletionSEL]) {
-    // Only add the application:didReceiveRemoteNotification:fetchCompletionHandler: method if
-    // the original AppDelegate implements it.
-    // This fixes a bug if an app only implements application:didReceiveRemoteNotification:
-    // (if we add the method with completion, iOS sees that one exists and does not call
-    // the method without the completion, which in this case is the only one the app implements).
 
-    [self proxyDestinationSelector:didReceiveRemoteNotificationWithCompletionSEL
-        implementationsFromSourceSelector:didReceiveRemoteNotificationWithCompletionDonorSEL
-                                fromClass:[GULAppDelegateSwizzler class]
-                                  toClass:appDelegateSubClass
-                                realClass:realClass
-         storeDestinationImplementationTo:realImplementationsBySelector];
-  }
+  [self proxyDestinationSelector:didReceiveRemoteNotificationWithCompletionSEL
+      implementationsFromSourceSelector:didReceiveRemoteNotificationWithCompletionDonorSEL
+                              fromClass:[GULAppDelegateSwizzler class]
+                                toClass:appDelegateSubClass
+                              realClass:realClass
+       storeDestinationImplementationTo:realImplementationsBySelector];
 #endif  // !TARGET_OS_WATCH && !TARGET_OS_OSX
 }
 


### PR DESCRIPTION
Clean up usages of deprecated APIs in Auth now that the minimum iOS version is iOS 10.