### PR TITLE
Add missing #include <cstdlib>, required for abort().

### DIFF
--- a/Firestore/core/src/util/secure_random_openssl.cc
+++ b/Firestore/core/src/util/secure_random_openssl.cc
@@ -20,6 +20,8 @@
 
 #if HAVE_OPENSSL_RAND_H
 
+#include <cstdlib>
+
 #include "openssl/err.h"
 #include "openssl/rand.h"
 


### PR DESCRIPTION
This is masked when using OpenSSL (which includes it for us) but causes the build to be broken with BoringSSL.
