### PR TITLE
Crashlytics move more references to orgID

### DIFF
--- a/Crashlytics/Crashlytics/Models/FIRCLSInternalReport.h
+++ b/Crashlytics/Crashlytics/Models/FIRCLSInternalReport.h
@@ -62,11 +62,6 @@ extern NSString *const FIRCLSReportUserCompactedKVFile;
 // Metadata Helpers
 
 /**
- * Returns the org id for the report.
- **/
-@property(nonatomic, copy, readonly) NSString *orgID;
-
-/**
  * Returns the Install UUID for the report.
  **/
 @property(nonatomic, copy, readonly) NSString *installID;

--- a/Crashlytics/Crashlytics/Models/FIRCLSInternalReport.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSInternalReport.m
@@ -183,11 +183,6 @@ NSString *const FIRCLSReportUserCompactedKVFile = @"user_compacted_kv.clsrecord"
   return _metadataSections;
 }
 
-- (NSString *)orgID {
-  return
-      [[[self.metadataSections objectAtIndex:0] objectForKey:@"identity"] objectForKey:@"org_id"];
-}
-
 - (NSDictionary *)customKeys {
   return nil;
 }

--- a/Crashlytics/Shared/FIRCLSConstants.h
+++ b/Crashlytics/Shared/FIRCLSConstants.h
@@ -40,7 +40,6 @@ FOUNDATION_EXPORT NSString *const FIRCLSNetworkCrashlyticsAPIClientDisplayVersio
 FOUNDATION_EXPORT NSString *const FIRCLSNetworkCrashlyticsAPIClientId;
 FOUNDATION_EXPORT NSString *const FIRCLSNetworkCrashlyticsDeveloperToken;
 FOUNDATION_EXPORT NSString *const FIRCLSNetworkCrashlyticsGoogleAppId;
-FOUNDATION_EXPORT NSString *const FIRCLSNetworkCrashlyticsOrgId;
 FOUNDATION_EXPORT NSString *const FIRCLSNetworkUserAgent;
 FOUNDATION_EXPORT NSString *const FIRCLSNetworkUTF8;
 

--- a/Crashlytics/Shared/FIRCLSConstants.m
+++ b/Crashlytics/Shared/FIRCLSConstants.m
@@ -43,7 +43,6 @@ NSString* const FIRCLSNetworkCrashlyticsAPIClientDisplayVersion =
 NSString* const FIRCLSNetworkCrashlyticsAPIClientId = @"X-Crashlytics-API-Client-Id";
 NSString* const FIRCLSNetworkCrashlyticsDeveloperToken = @"X-Crashlytics-Developer-Token";
 NSString* const FIRCLSNetworkCrashlyticsGoogleAppId = @"X-Crashlytics-Google-App-Id";
-NSString* const FIRCLSNetworkCrashlyticsOrgId = @"X-Crashlytics-Org-Id";
 NSString* const FIRCLSNetworkUserAgent = @"User-Agent";
 NSString* const FIRCLSNetworkUTF8 = @"utf-8";
 


### PR DESCRIPTION
These were extra references that confuse us into thinking this value is still needed, when it's not.

#no-changelog
