### PR TITLE
7.3.1 release for FDL regression fix

### DIFF
--- a/FirebaseDynamicLinks.podspec
+++ b/FirebaseDynamicLinks.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseDynamicLinks'
-  s.version          = '7.3.0'
+  s.version          = '7.3.1'
   s.summary          = 'Firebase Dynamic Links'
 
   s.description      = <<-DESC

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] New callback added in 7.3.0 should be on the main thread. (#7159)
+
 # v7.3.0
 - [added] Manually created dynamic links should be subject to allowed/blocked check (#5853)
 

--- a/FirebaseDynamicLinks/CHANGELOG.md
+++ b/FirebaseDynamicLinks/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# v7.3.1
 - [fixed] New callback added in 7.3.0 should be on the main thread. (#7159)
 
 # v7.3.0

--- a/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
+++ b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m
@@ -401,6 +401,16 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
     dynamicLinkInternalFromUniversalLinkURL:(NSURL *)url
                                  completion:
                                      (nullable FIRDynamicLinkUniversalLinkHandler)completion {
+  // Make sure the completion is always called on the main queue.
+  FIRDynamicLinkUniversalLinkHandler mainQueueCompletion =
+      ^(FIRDynamicLink *_Nullable dynamicLink, NSError *_Nullable error) {
+        if (completion) {
+          dispatch_async(dispatch_get_main_queue(), ^{
+            completion(dynamicLink, error);
+          });
+        }
+      };
+
   if ([self canParseUniversalLinkURL:url]) {
     if (url.query.length > 0) {
       NSDictionary *parameters = FIRDLDictionaryFromQuery(url.query);
@@ -418,9 +428,7 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
               resolveShortLink:url
                  FDLSDKVersion:FIRFirebaseVersion()
                     completion:^(NSURL *_Nullable resolverURL, NSError *_Nullable resolverError) {
-                      if (completion) {
-                        completion(dynamicLink, resolverError);
-                      }
+                      mainQueueCompletion(dynamicLink, resolverError);
                     }];
 #ifdef GIN_SCION_LOGGING
           FIRDLLogEventToScion(FIRDLLogEventAppOpen, parameters[kFIRDLParameterSource],
@@ -432,9 +440,7 @@ static const NSInteger FIRErrorCodeDurableDeepLinkFailed = -119;
       }
     }
   }
-  if (completion) {
-    completion(nil, nil);
-  }
+  mainQueueCompletion(nil, nil);
   return nil;
 }
 

--- a/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
+++ b/FirebaseDynamicLinks/Tests/Unit/FIRDynamicLinksTest.m
@@ -518,6 +518,7 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
       dynamicLinkFromUniversalLinkURL:durabledeepLinkURL
                            completion:^(FIRDynamicLink *_Nullable dynamicLink,
                                         NSError *_Nullable error) {
+                             XCTAssertTrue([NSThread isMainThread]);
                              XCTAssertNotNil(dynamicLink);
                              NSString *deepLinkURLString = dynamicLink.url.absoluteString;
 
@@ -559,6 +560,7 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
       dynamicLinkFromUniversalLinkURL:durabledeepLinkURL
                            completion:^(FIRDynamicLink *_Nullable dynamicLink,
                                         NSError *_Nullable error) {
+                             XCTAssertTrue([NSThread isMainThread]);
                              NSString *deepLinkURLString = dynamicLink.url.absoluteString;
 
                              XCTAssertEqualObjects(
@@ -599,6 +601,7 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
       dynamicLinkFromUniversalLinkURL:durabledeepLinkURL
                            completion:^(FIRDynamicLink *_Nullable dynamicLink,
                                         NSError *_Nullable error) {
+                             XCTAssertTrue([NSThread isMainThread]);
                              NSString *deepLinkURLString = dynamicLink.url.absoluteString;
 
                              XCTAssertEqualObjects(
@@ -649,6 +652,7 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
       dynamicLinkFromUniversalLinkURL:url
                            completion:^(FIRDynamicLink *_Nullable dynamicLink,
                                         NSError *_Nullable error) {
+                             XCTAssertTrue([NSThread isMainThread]);
                              XCTAssertEqual(dynamicLink.matchConfidence,
                                             FIRDynamicLinkMatchConfidenceStrong);
                              XCTAssertEqualObjects(dynamicLink.url.absoluteString, deepLinkString);
@@ -697,6 +701,7 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
   [self.service dynamicLinkFromUniversalLinkURL:url
                                      completion:^(FIRDynamicLink *_Nullable dynamicLink,
                                                   NSError *_Nullable error) {
+                                       XCTAssertTrue([NSThread isMainThread]);
                                        XCTAssertEqual(dynamicLink.matchConfidence,
                                                       FIRDynamicLinkMatchConfidenceStrong);
                                        XCTAssertEqualObjects(dynamicLink.url.absoluteString,
@@ -861,6 +866,7 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
       dynamicLinkFromUniversalLinkURL:url
                            completion:^(FIRDynamicLink *_Nullable dynamicLink,
                                         NSError *_Nullable error) {
+                             XCTAssertTrue([NSThread isMainThread]);
                              NSString *minVersion = dynamicLink.minimumAppVersion;
 
                              XCTAssertNil(minVersion, @"Min app version was not nil when not set.");
@@ -907,6 +913,7 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
       dynamicLinkFromUniversalLinkURL:url
                            completion:^(FIRDynamicLink *_Nullable dynamicLink,
                                         NSError *_Nullable error) {
+                             XCTAssertTrue([NSThread isMainThread]);
                              NSString *minVersion = dynamicLink.minimumAppVersion;
 
                              XCTAssertEqualObjects(expectedMinVersion, minVersion,
@@ -953,6 +960,7 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
       dynamicLinkFromUniversalLinkURL:url
                            completion:^(FIRDynamicLink *_Nullable dynamicLink,
                                         NSError *_Nullable error) {
+                             XCTAssertTrue([NSThread isMainThread]);
                              XCTAssertEqual(dynamicLink.matchConfidence,
                                             FIRDynamicLinkMatchConfidenceStrong);
                              XCTAssertEqualObjects(dynamicLink.url.absoluteString, deepLinkString);
@@ -996,6 +1004,7 @@ static NSString *const kInfoPlistCustomDomainsKey = @"FirebaseDynamicLinksCustom
   [self.service dynamicLinkFromUniversalLinkURL:url
                                      completion:^(FIRDynamicLink *_Nullable dynamicLink,
                                                   NSError *_Nullable error) {
+                                       XCTAssertTrue([NSThread isMainThread]);
                                        XCTAssertEqual(dynamicLink.matchConfidence,
                                                       FIRDynamicLinkMatchConfidenceStrong);
                                        XCTAssertEqualObjects(dynamicLink.url.absoluteString,

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@
 
 import PackageDescription
 
-let firebaseVersion = "7.3.0"
+let firebaseVersion = "7.3.1"
 
 let package = Package(
   name: "Firebase",


### PR DESCRIPTION
The 7.3.0 release had a regression where an FDL callback could occur off the main thread.

This prepares a 7.3.1 release with the fix for the CocoaPods and SPM distributions that I propose to publish on Tuesday.