### PR TITLE
Delay GDTCORUploadCoordinator timer initial run

### DIFF
--- a/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
+++ b/GoogleDataTransport/GDTCORLibrary/GDTCORUploadCoordinator.m
@@ -68,10 +68,12 @@
       return;
     }
 
+    // Delay the timer slightly so it doesn't run while +load calls are still running.
+    dispatch_time_t deadline = dispatch_time(DISPATCH_TIME_NOW, 1 * NSEC_PER_SEC / 2);
+
     self->_timer =
         dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self->_coordinationQueue);
-    dispatch_source_set_timer(self->_timer, DISPATCH_TIME_NOW, self->_timerInterval,
-                              self->_timerLeeway);
+    dispatch_source_set_timer(self->_timer, deadline, self->_timerInterval, self->_timerLeeway);
 
     dispatch_source_set_event_handler(self->_timer, ^{
       if (![[GDTCORApplication sharedApplication] isRunningInBackground]) {


### PR DESCRIPTION
If an upload coordinator gets created during `+load` calls, it can end up running its immediately, while +load calls are still running. It's generally a bad idea to be splitting off threads while +load calls are still running.

The upload coordinator checks every 30 seconds, and doesn't really need to run right away. Since it's easy to transitively create an upload coordinator from other calls that happen during +load, we'll just push off the initial run of the timer slightly. That makes it less likely to interfere (or deadlock) with other load calls.

See #7171 for an example of a problem solved by this change.

Hey there! So you want to contribute to a Firebase SDK?
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here.
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help
    us make Firebase APIs better, please propose your change in a feature request so that we
    can discuss it together.
