### PR TITLE
Fix FirebaseMetadataProvider under VS2015

### DIFF
--- a/Firestore/core/src/remote/firebase_metadata_provider.cc
+++ b/Firestore/core/src/remote/firebase_metadata_provider.cc
@@ -20,12 +20,12 @@ namespace firebase {
 namespace firestore {
 namespace remote {
 
-const char FirebaseMetadataProvider::kXFirebaseClientHeader[]
-    = "x-firebase-client";
-const char FirebaseMetadataProvider::kXFirebaseClientLogTypeHeader[]
-    = "x-firebase-client-log-type";
-const char FirebaseMetadataProvider::kXFirebaseGmpIdHeader[]
-    = "x-firebase-gmpid";
+const char FirebaseMetadataProvider::kXFirebaseClientHeader[] =
+    "x-firebase-client";
+const char FirebaseMetadataProvider::kXFirebaseClientLogTypeHeader[] =
+    "x-firebase-client-log-type";
+const char FirebaseMetadataProvider::kXFirebaseGmpIdHeader[] =
+    "x-firebase-gmpid";
 
 }  // namespace remote
 }  // namespace firestore

--- a/Firestore/core/src/remote/firebase_metadata_provider.cc
+++ b/Firestore/core/src/remote/firebase_metadata_provider.cc
@@ -20,9 +20,12 @@ namespace firebase {
 namespace firestore {
 namespace remote {
 
-constexpr char FirebaseMetadataProvider::kXFirebaseClientHeader[];
-constexpr char FirebaseMetadataProvider::kXFirebaseClientLogTypeHeader[];
-constexpr char FirebaseMetadataProvider::kXFirebaseGmpIdHeader[];
+const char FirebaseMetadataProvider::kXFirebaseClientHeader[]
+    = "x-firebase-client";
+const char FirebaseMetadataProvider::kXFirebaseClientLogTypeHeader[]
+    = "x-firebase-client-log-type";
+const char FirebaseMetadataProvider::kXFirebaseGmpIdHeader[]
+    = "x-firebase-gmpid";
 
 }  // namespace remote
 }  // namespace firestore

--- a/Firestore/core/src/remote/firebase_metadata_provider.h
+++ b/Firestore/core/src/remote/firebase_metadata_provider.h
@@ -31,10 +31,9 @@ namespace remote {
  */
 class FirebaseMetadataProvider {
  public:
-  static constexpr char kXFirebaseClientHeader[] = "x-firebase-client";
-  static constexpr char kXFirebaseClientLogTypeHeader[] =
-      "x-firebase-client-log-type";
-  static constexpr char kXFirebaseGmpIdHeader[] = "x-firebase-gmpid";
+  static const char kXFirebaseClientHeader[];
+  static const char kXFirebaseClientLogTypeHeader[];
+  static const char kXFirebaseGmpIdHeader[];
 
   virtual ~FirebaseMetadataProvider() = default;
 


### PR DESCRIPTION
VS2015 does not support declaring `static constexpr char[]` members of classes.

#no-changelog