### PR TITLE
Prevent 2nd listAll callback

### DIFF
--- a/FirebaseStorage/CHANGELOG.md
+++ b/FirebaseStorage/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 7.4.0
+- [Fixed] Prevent second `listAll` callback. (#7197)
+
 # 7.3.0
 - [Fixed] Verify block is still alive before calling it in task callbacks. (#7051)
 

--- a/FirebaseStorage/Sources/FIRStorageReference.m
+++ b/FirebaseStorage/Sources/FIRStorageReference.m
@@ -415,6 +415,7 @@
       ^(FIRStorageListResult *listResult, NSError *error) {
         if (error) {
           completion(nil, error);
+          return;
         }
 
         FIRStorageReference *strongSelf = weakSelf;

--- a/FirebaseStorage/Tests/Unit/FIRStorageListTests.m
+++ b/FirebaseStorage/Tests/Unit/FIRStorageListTests.m
@@ -79,6 +79,29 @@
   [FIRStorageTestHelpers waitForExpectation:self];
 }
 
+- (void)testValidatesListAllCallback {
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"testValidatesListAllCallback"];
+  expectation.expectedFulfillmentCount = 1;
+
+  FIRStoragePath *path = [FIRStorageTestHelpers objectPath];
+  FIRStorageReference *ref = [[FIRStorageReference alloc] initWithStorage:self.storage path:path];
+
+  FIRStorageVoidListError errorBlock = ^(FIRStorageListResult *result, NSError *error) {
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+
+    XCTAssertEqualObjects(error.domain, @"FIRStorageErrorDomain");
+    XCTAssertEqual(error.code, FIRStorageErrorCodeUnknown);
+
+    [expectation fulfill];
+  };
+
+  [ref listAllWithCompletion:errorBlock];
+
+  [FIRStorageTestHelpers waitForExpectation:self];
+}
+
 - (void)testDefaultList {
   XCTestExpectation *expectation = [self expectationWithDescription:@"testDefaultList"];
   NSURL *expectedURL = [NSURL

--- a/FirebaseStorage/Tests/Unit/FIRStorageListTests.m
+++ b/FirebaseStorage/Tests/Unit/FIRStorageListTests.m
@@ -79,9 +79,9 @@
   [FIRStorageTestHelpers waitForExpectation:self];
 }
 
-- (void)testValidatesListAllCallback {
+- (void)testListAllCallbackOnlyCalledOnce {
   XCTestExpectation *expectation =
-      [self expectationWithDescription:@"testValidatesListAllCallback"];
+      [self expectationWithDescription:@"testListAllCallbackOnlyCalledOnce"];
   expectation.expectedFulfillmentCount = 1;
 
   FIRStoragePath *path = [FIRStorageTestHelpers objectPath];
@@ -274,7 +274,7 @@
 - (void)testListWithErrorResponse {
   XCTestExpectation *expectation = [self expectationWithDescription:@"testListWithErrorResponse"];
 
-  NSError *error = [NSError errorWithDomain:@"com.google.firebase.storage" code:-1 userInfo:nil];
+  NSError *error = [NSError errorWithDomain:@"com.google.firebase.storage" code:404 userInfo:nil];
 
   self.fetcherService.testBlock =
       ^(GTMSessionFetcher *fetcher, GTMSessionFetcherTestResponse response) {
@@ -299,6 +299,7 @@
                XCTAssertNil(result);
 
                XCTAssertEqualObjects(error.domain, @"FIRStorageErrorDomain");
+               XCTAssertEqual(error.code, FIRStorageErrorCodeObjectNotFound);
 
                [expectation fulfill];
              }];


### PR DESCRIPTION
Fix #7197 

Adds missing return.
Adds missing `listAll` unit test (that fails without this change)