### PR TITLE
Eliminate repo-dir option

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -25,7 +25,8 @@ jobs:
 
   package:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    # TODO: Recomment before master merge
+#    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
     needs: build
     runs-on: macOS-latest
     steps:

--- a/ReleaseTooling/README.md
+++ b/ReleaseTooling/README.md
@@ -39,11 +39,6 @@ You can pass in launch arguments with Xcode by clicking "zip-builder" beside the
 
 These arguments assume you're running the command from the `ReleaseTooling` directory.
 
-**Required** arguments:
-
-- `--repo-dir <PATH_TO_firebase_ios_sdk_REPO>`
-  - The root of the `firebase-ios-sdk` repo.
-
 Typical argument (all use cases except Firebase release build):
 - `--zip-pods <PATH_TO.json>`
   - This is a JSON list of the pods to consolidate into a zip of binary frameworks. For example,
@@ -77,7 +72,6 @@ For release engineers (Googlers packaging an upcoming Firebase release) these co
 be used:
 -  `--custom-spec-repos sso://cpdc-internal/firebase`
   - This pulls the latest podspecs from the CocoaPods staging area.
-- `--repo-dir path` GitHub repo containing Template and Carthage json file inputs.
 - `--enable-carthage-build` Turns on generation of Carthage zips and json file updates.
 - `--keep-build-artifacts` Useful for debugging and verifying the zip build contents.
 
@@ -85,7 +79,6 @@ Putting them all together, here's a common command to build a releaseable Zip fi
 
 ```
 swift run zip-builder --update-pod-repo \
---repo-dir <PATH_TO_current.firebase_ios_sdk.repo> \
 --custom-spec-repos sso://cpdc-internal/firebase \
 --enable-carthage-build \
 --keep-build-artifacts

--- a/scripts/build_non_firebase_sdks.sh
+++ b/scripts/build_non_firebase_sdks.sh
@@ -35,7 +35,7 @@ do
 done
 echo "]" >>  "${ZIP_POD_JSON}"
 mkdir -p "${REPO}"/sdk_zip
-swift run zip-builder --keep-build-artifacts --update-pod-repo --repo-dir "${REPO}" \
+swift run zip-builder --keep-build-artifacts --update-pod-repo\
     --zip-pods "${ZIP_POD_JSON}" --output-dir "${REPO}"/sdk_zip --disable-build-dependencies
 
 unzip -o "${REPO}"/sdk_zip/Frameworks.zip -d "${HOME}"/ios_frameworks/Firebase/

--- a/scripts/build_zip.sh
+++ b/scripts/build_zip.sh
@@ -27,6 +27,6 @@ OUTPUT_DIR="$REPO/$1"
 
 cd ReleaseTooling
 swift run zip-builder --keep-build-artifacts --update-pod-repo \
-    --repo-dir "${REPO}" --local-podspec-path "${REPO}" \
+    --local-podspec-path "${REPO}" \
     --enable-carthage-build --output-dir "${OUTPUT_DIR}" \
     --custom-spec-repos https://github.com/firebase/SpecsStaging.git


### PR DESCRIPTION
Make finding the repo root automatic to eliminate the need to specify the `--repo-dir` option.