### PR TITLE
Support NSPredicate CONTAINS and IN with new filter queries

### DIFF
--- a/Firestore/Source/API/FIRQuery.mm
+++ b/Firestore/Source/API/FIRQuery.mm
@@ -331,6 +331,8 @@ int32_t SaturatedLimitValue(NSInteger limit) {
         return [self queryWhereField:path isNotEqualTo:value];
       case NSContainsPredicateOperatorType:
         return [self queryWhereField:path arrayContains:value];
+      case NSInPredicateOperatorType:
+        return [self queryWhereField:path in:value];
       default:;  // Fallback below to throw assertion.
     }
   } else if ([comparison.leftExpression expressionType] == NSConstantValueExpressionType &&
@@ -352,6 +354,8 @@ int32_t SaturatedLimitValue(NSInteger limit) {
         return [self queryWhereField:path isNotEqualTo:value];
       case NSContainsPredicateOperatorType:
         return [self queryWhereField:path arrayContains:value];
+      case NSInPredicateOperatorType:
+        return [self queryWhereField:path in:value];
       default:;  // Fallback below to throw assertion.
     }
   } else {

--- a/Firestore/Source/API/FIRQuery.mm
+++ b/Firestore/Source/API/FIRQuery.mm
@@ -329,6 +329,8 @@ int32_t SaturatedLimitValue(NSInteger limit) {
         return [self queryWhereField:path isGreaterThanOrEqualTo:value];
       case NSNotEqualToPredicateOperatorType:
         return [self queryWhereField:path isNotEqualTo:value];
+      case NSContainsPredicateOperatorType:
+        return [self queryWhereField:path arrayContains:value];
       default:;  // Fallback below to throw assertion.
     }
   } else if ([comparison.leftExpression expressionType] == NSConstantValueExpressionType &&
@@ -348,6 +350,8 @@ int32_t SaturatedLimitValue(NSInteger limit) {
         return [self queryWhereField:path isLessThanOrEqualTo:value];
       case NSNotEqualToPredicateOperatorType:
         return [self queryWhereField:path isNotEqualTo:value];
+      case NSContainsPredicateOperatorType:
+        return [self queryWhereField:path arrayContains:value];
       default:;  // Fallback below to throw assertion.
     }
   } else {


### PR DESCRIPTION
Firebase introduced `arrayContainsAny` and `queryWhereField:in` in 2019. This PR adds support to NSPredicate for these queries 