### PR TITLE
Check if reverse client ID is a registered URL scheme before setting callback scheme

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Check if the reverse client ID is configured as a custom URL scheme before setting it as the callback scheme. (#7211).
+
 # 7.3.0
 - [fixed] Catalyst browser issue with `verifyPhoneNumber` API. (#7049)
 

--- a/FirebaseAuth/Tests/Unit/FIROAuthProviderTests.m
+++ b/FirebaseAuth/Tests/Unit/FIROAuthProviderTests.m
@@ -268,15 +268,15 @@ static NSString *const kUnknownErrorString =
     @brief Tests a successful invocation of @c getCredentialWithUIDelegte:completion:
  */
 - (void)testGetCredentialWithUIDelegateWithClientID {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIROAuthProvider providerWithProviderID:kFakeProviderID auth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIROAuthProvider providerWithProviderID:kFakeProviderID auth:_mockAuth];
 
   OCMExpect([_mockBackend getProjectConfig:[OCMArg any] callback:[OCMArg any]])
       .andCallBlock2(
@@ -371,15 +371,15 @@ static NSString *const kUnknownErrorString =
         cancelation.
  */
 - (void)testGetCredentialWithUIDelegateUserCancellationWithClientID {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIROAuthProvider providerWithProviderID:kFakeProviderID auth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIROAuthProvider providerWithProviderID:kFakeProviderID auth:_mockAuth];
 
   OCMExpect([_mockBackend getProjectConfig:[OCMArg any] callback:[OCMArg any]])
       .andCallBlock2(
@@ -471,15 +471,15 @@ static NSString *const kUnknownErrorString =
         failed network request within the web context.
  */
 - (void)testGetCredentialWithUIDelegateNetworkRequestFailedWithClientID {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIROAuthProvider providerWithProviderID:kFakeProviderID auth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIROAuthProvider providerWithProviderID:kFakeProviderID auth:_mockAuth];
 
   OCMExpect([_mockBackend getProjectConfig:[OCMArg any] callback:[OCMArg any]])
       .andCallBlock2(
@@ -569,15 +569,15 @@ static NSString *const kUnknownErrorString =
         internal error within the web context.
  */
 - (void)testGetCredentialWithUIDelegateInternalErrorWithClientID {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIROAuthProvider providerWithProviderID:kFakeProviderID auth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIROAuthProvider providerWithProviderID:kFakeProviderID auth:_mockAuth];
 
   OCMExpect([_mockBackend getProjectConfig:[OCMArg any] callback:[OCMArg any]])
       .andCallBlock2(
@@ -668,15 +668,15 @@ static NSString *const kUnknownErrorString =
         use of an invalid client ID.
  */
 - (void)testGetCredentialWithUIDelegateInvalidClientID {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIROAuthProvider providerWithProviderID:kFakeProviderID auth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIROAuthProvider providerWithProviderID:kFakeProviderID auth:_mockAuth];
 
   OCMExpect([_mockBackend getProjectConfig:[OCMArg any] callback:[OCMArg any]])
       .andCallBlock2(
@@ -767,15 +767,15 @@ static NSString *const kUnknownErrorString =
         unknown error.
  */
 - (void)testGetCredentialWithUIDelegateUnknownErrorWithClientID {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIROAuthProvider providerWithProviderID:kFakeProviderID auth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIROAuthProvider providerWithProviderID:kFakeProviderID auth:_mockAuth];
 
   OCMExpect([_mockBackend getProjectConfig:[OCMArg any] callback:[OCMArg any]])
       .andCallBlock2(
@@ -866,14 +866,14 @@ static NSString *const kUnknownErrorString =
     @brief Tests a successful invocation of @c getCredentialWithUIDelegte:completion:
  */
 - (void)testGetCredentialWithUIDelegateWithFirebaseAppID {
-  _provider = [FIROAuthProvider providerWithProviderID:kFakeProviderID auth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeEncodedFirebaseAppID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  _provider = [FIROAuthProvider providerWithProviderID:kFakeProviderID auth:_mockAuth];
 
   OCMExpect([_mockBackend getProjectConfig:[OCMArg any] callback:[OCMArg any]])
       .andCallBlock2(
@@ -968,18 +968,18 @@ static NSString *const kUnknownErrorString =
    emulator.
  */
 - (void)testGetCredentialWithUIDelegateUseEmulator {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  NSString *emulatorHostAndPort =
-      [NSString stringWithFormat:@"%@:%@", kFakeEmulatorHost, kFakeEmulatorPort];
-  OCMStub([_mockRequestConfiguration emulatorHostAndPort]).andReturn(emulatorHostAndPort);
-  _provider = [FIROAuthProvider providerWithProviderID:kFakeProviderID auth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  NSString *emulatorHostAndPort =
+      [NSString stringWithFormat:@"%@:%@", kFakeEmulatorHost, kFakeEmulatorPort];
+  OCMStub([_mockRequestConfiguration emulatorHostAndPort]).andReturn(emulatorHostAndPort);
+  _provider = [FIROAuthProvider providerWithProviderID:kFakeProviderID auth:_mockAuth];
 
   id mockUIDelegate = OCMProtocolMock(@protocol(FIRAuthUIDelegate));
 

--- a/FirebaseAuth/Tests/Unit/FIRPhoneAuthProviderTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRPhoneAuthProviderTests.m
@@ -676,6 +676,141 @@ static const NSTimeInterval kExpectationTimeout = 2;
   OCMVerifyAll(_mockNotificationManager);
 }
 
+/** @fn testVerifyPhoneNumberUIDelegateFirebaseAppIdWhileClientIdPresentFlow
+    @brief Tests a successful invocation of @c verifyPhoneNumber:UIDelegate:completion: when the
+   client ID is present in the plist file, but the encoded app ID is the registered custom URL
+   scheme.
+ */
+- (void)testVerifyPhoneNumberUIDelegateFirebaseAppIdWhileClientIdPresentFlow {
+  id mockBundle = OCMClassMock([NSBundle class]);
+  OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
+  OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
+    @{@"CFBundleURLSchemes" : @[ kFakeEncodedFirebaseAppID ]}
+  ]);
+  OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
+
+  // Simulate missing app token error.
+  OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
+      .andCallBlock1(^(FIRAuthNotificationForwardingCallback callback) {
+        callback(YES);
+      });
+  OCMExpect([_mockAppCredentialManager credential]).andReturn(nil);
+  OCMExpect([_mockAPNSTokenManager getTokenWithCallback:OCMOCK_ANY])
+      .andCallBlock1(^(FIRAuthAPNSTokenCallback callback) {
+        NSError *error = [NSError errorWithDomain:FIRAuthErrorDomain
+                                             code:FIRAuthErrorCodeMissingAppToken
+                                         userInfo:nil];
+        callback(nil, error);
+      });
+  OCMExpect([_mockBackend getProjectConfig:[OCMArg any] callback:[OCMArg any]])
+      .andCallBlock2(
+          ^(FIRGetProjectConfigRequest *request, FIRGetProjectConfigResponseCallback callback) {
+            XCTAssertNotNil(request);
+            dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+              id mockGetProjectConfigResponse = OCMClassMock([FIRGetProjectConfigResponse class]);
+              OCMStub([mockGetProjectConfigResponse authorizedDomains]).andReturn(@[
+                kFakeAuthorizedDomain
+              ]);
+              callback(mockGetProjectConfigResponse, nil);
+            });
+          });
+  id mockUIDelegate = OCMProtocolMock(@protocol(FIRAuthUIDelegate));
+
+  // Expect view controller presentation by UIDelegate.
+  OCMExpect([_mockURLPresenter presentURL:OCMOCK_ANY
+                               UIDelegate:mockUIDelegate
+                          callbackMatcher:OCMOCK_ANY
+                               completion:OCMOCK_ANY])
+      .andDo(^(NSInvocation *invocation) {
+        __unsafe_unretained id unretainedArgument;
+        // Indices 0 and 1 indicate the hidden arguments self and _cmd.
+        // `presentURL` is at index 2.
+        [invocation getArgument:&unretainedArgument atIndex:2];
+        NSURL *presentURL = unretainedArgument;
+        XCTAssertEqualObjects(presentURL.scheme, @"https");
+        XCTAssertEqualObjects(presentURL.host, kFakeAuthorizedDomain);
+        XCTAssertEqualObjects(presentURL.path, @"/__/auth/handler");
+
+        NSURLComponents *actualURLComponents = [NSURLComponents componentsWithURL:presentURL
+                                                          resolvingAgainstBaseURL:NO];
+        NSArray<NSURLQueryItem *> *queryItems = [actualURLComponents queryItems];
+        XCTAssertEqualObjects([FIRAuthWebUtils queryItemValue:@"ibi" from:queryItems],
+                              kFakeBundleID);
+        XCTAssertEqualObjects([FIRAuthWebUtils queryItemValue:@"appId" from:queryItems],
+                              kFakeFirebaseAppID);
+        XCTAssertEqualObjects([FIRAuthWebUtils queryItemValue:@"apiKey" from:queryItems],
+                              kFakeAPIKey);
+        XCTAssertEqualObjects([FIRAuthWebUtils queryItemValue:@"authType" from:queryItems],
+                              @"verifyApp");
+        XCTAssertNotNil([FIRAuthWebUtils queryItemValue:@"v" from:queryItems]);
+        // `callbackMatcher` is at index 4
+        [invocation getArgument:&unretainedArgument atIndex:4];
+        FIRAuthURLCallbackMatcher callbackMatcher = unretainedArgument;
+        NSMutableString *redirectURL = [NSMutableString
+            stringWithString:[kFakeEncodedFirebaseAppID
+                                 stringByAppendingString:kFakeRedirectURLStringWithReCAPTCHAToken]];
+        // Verify that the URL is rejected by the callback matcher without the event ID.
+        XCTAssertFalse(callbackMatcher([NSURL URLWithString:redirectURL]));
+        [redirectURL appendString:@"%26eventId%3D"];
+        [redirectURL appendString:[FIRAuthWebUtils queryItemValue:@"eventId" from:queryItems]];
+        NSURLComponents *originalComponents = [[NSURLComponents alloc] initWithString:redirectURL];
+        // Verify that the URL is accepted by the callback matcher with the matching event ID.
+        XCTAssertTrue(callbackMatcher([originalComponents URL]));
+        NSURLComponents *components = [originalComponents copy];
+        components.query = @"https";
+        XCTAssertFalse(callbackMatcher([components URL]));
+        components = [originalComponents copy];
+        components.host = @"badhost";
+        XCTAssertFalse(callbackMatcher([components URL]));
+        components = [originalComponents copy];
+        components.path = @"badpath";
+        XCTAssertFalse(callbackMatcher([components URL]));
+        components = [originalComponents copy];
+        components.query = @"badquery";
+        XCTAssertFalse(callbackMatcher([components URL]));
+
+        // `completion` is at index 5
+        [invocation getArgument:&unretainedArgument atIndex:5];
+        FIRAuthURLPresentationCompletion completion = unretainedArgument;
+        dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+          completion([NSURL URLWithString:[kFakeEncodedFirebaseAppID
+                                              stringByAppendingString:
+                                                  kFakeRedirectURLStringWithReCAPTCHAToken]],
+                     nil);
+        });
+      });
+
+  OCMExpect([_mockBackend sendVerificationCode:[OCMArg any] callback:[OCMArg any]])
+      .andCallBlock2(^(FIRSendVerificationCodeRequest *request,
+                       FIRSendVerificationCodeResponseCallback callback) {
+        XCTAssertEqualObjects(request.phoneNumber, kTestPhoneNumber);
+        XCTAssertNil(request.appCredential);
+        XCTAssertEqualObjects(request.reCAPTCHAToken, kFakeReCAPTCHAToken);
+        dispatch_async(FIRAuthGlobalWorkQueue(), ^() {
+          id mockSendVerificationCodeResponse =
+              OCMClassMock([FIRSendVerificationCodeResponse class]);
+          OCMStub([mockSendVerificationCodeResponse verificationID]).andReturn(kTestVerificationID);
+          callback(mockSendVerificationCodeResponse, nil);
+        });
+      });
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
+  [_provider verifyPhoneNumber:kTestPhoneNumber
+                    UIDelegate:mockUIDelegate
+                    completion:^(NSString *_Nullable verificationID, NSError *_Nullable error) {
+                      XCTAssertTrue([NSThread isMainThread]);
+                      XCTAssertNil(error);
+                      XCTAssertEqualObjects(verificationID, kTestVerificationID);
+                      [expectation fulfill];
+                    }];
+  [self waitForExpectationsWithTimeout:kExpectationTimeout handler:nil];
+  OCMVerifyAll(_mockBackend);
+  OCMVerifyAll(_mockNotificationManager);
+}
+
 /** @fn testVerifyPhoneNumberUIDelegateClientIdFlow
     @brief Tests a successful invocation of @c verifyPhoneNumber:UIDelegate:completion:.
  */

--- a/FirebaseAuth/Tests/Unit/FIRPhoneAuthProviderTests.m
+++ b/FirebaseAuth/Tests/Unit/FIRPhoneAuthProviderTests.m
@@ -324,15 +324,15 @@ static const NSTimeInterval kExpectationTimeout = 2;
         number was provided.
  */
 - (void)testVerifyEmptyPhoneNumber {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
 
   // Empty phone number is checked on the client side so no backend RPC is mocked.
   XCTestExpectation *expectation = [self expectationWithDescription:@"callback"];
@@ -351,15 +351,15 @@ static const NSTimeInterval kExpectationTimeout = 2;
         number was provided.
  */
 - (void)testVerifyInvalidPhoneNumber {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
 
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
       .andCallBlock1(^(FIRAuthNotificationForwardingCallback callback) {
@@ -397,15 +397,15 @@ static const NSTimeInterval kExpectationTimeout = 2;
     @brief Tests a successful invocation of @c verifyPhoneNumber:completion:.
  */
 - (void)testVerifyPhoneNumber {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
 
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
       .andCallBlock1(^(FIRAuthNotificationForwardingCallback callback) {
@@ -447,15 +447,15 @@ static const NSTimeInterval kExpectationTimeout = 2;
         is disabled.
  */
 - (void)testVerifyPhoneNumberInTestMode {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
 
   // Disable app verification.
   FIRAuthSettings *settings = [[FIRAuthSettings alloc] init];
@@ -499,15 +499,15 @@ static const NSTimeInterval kExpectationTimeout = 2;
         is disabled.
  */
 - (void)testVerifyPhoneNumberInTestModeFailure {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
 
   // Disable app verification.
   FIRAuthSettings *settings = [[FIRAuthSettings alloc] init];
@@ -548,14 +548,14 @@ static const NSTimeInterval kExpectationTimeout = 2;
     @brief Tests a successful invocation of @c verifyPhoneNumber:UIDelegate:completion:.
  */
 - (void)testVerifyPhoneNumberUIDelegateFirebaseAppIdFlow {
-  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeEncodedFirebaseAppID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
 
   // Simulate missing app token error.
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
@@ -680,15 +680,15 @@ static const NSTimeInterval kExpectationTimeout = 2;
     @brief Tests a successful invocation of @c verifyPhoneNumber:UIDelegate:completion:.
  */
 - (void)testVerifyPhoneNumberUIDelegateClientIdFlow {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
 
   // Simulate missing app token error.
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
@@ -814,15 +814,15 @@ static const NSTimeInterval kExpectationTimeout = 2;
         invalid client ID error.
  */
 - (void)testVerifyPhoneNumberUIDelegateInvalidClientID {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
 
   // Simulate missing app token error.
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
@@ -886,15 +886,15 @@ static const NSTimeInterval kExpectationTimeout = 2;
         network request failed error.
  */
 - (void)testVerifyPhoneNumberUIDelegateNetworkRequestFailed {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
 
   // Simulate missing app token error.
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
@@ -958,15 +958,15 @@ static const NSTimeInterval kExpectationTimeout = 2;
         internal error.
  */
 - (void)testVerifyPhoneNumberUIDelegateWebInternalError {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
 
   // Simulate missing app token error.
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
@@ -1030,15 +1030,15 @@ static const NSTimeInterval kExpectationTimeout = 2;
         invalid client ID.
  */
 - (void)testVerifyPhoneNumberUIDelegateUnexpectedError {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
 
   // Simulate missing app token error.
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
@@ -1104,15 +1104,15 @@ static const NSTimeInterval kExpectationTimeout = 2;
         structure of the error response.
  */
 - (void)testVerifyPhoneNumberUIDelegateUnstructuredError {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
 
   // Simulate missing app token error.
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
@@ -1177,14 +1177,15 @@ static const NSTimeInterval kExpectationTimeout = 2;
         exception.
  */
 - (void)testVerifyPhoneNumberUIDelegateRaiseException {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ @"badscheme" ]}
   ]);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
+
   id mockUIDelegate = OCMProtocolMock(@protocol(FIRAuthUIDelegate));
   XCTAssertThrows([_provider
       verifyPhoneNumber:kTestPhoneNumber
@@ -1198,15 +1199,15 @@ static const NSTimeInterval kExpectationTimeout = 2;
     @brief Tests returning an error for the app failing to forward notification.
  */
 - (void)testNotForwardingNotification {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
 
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
       .andCallBlock1(^(FIRAuthNotificationForwardingCallback callback) {
@@ -1229,15 +1230,15 @@ static const NSTimeInterval kExpectationTimeout = 2;
     @brief Tests returning an error for the app failing to provide an APNS device token.
  */
 - (void)testMissingAPNSToken {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
 
   // Simulate missing app token error.
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
@@ -1302,15 +1303,15 @@ static const NSTimeInterval kExpectationTimeout = 2;
     @brief Tests verifying client before sending verification code.
  */
 - (void)testVerifyClient {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
 
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
       .andCallBlock1(^(FIRAuthNotificationForwardingCallback callback) {
@@ -1386,15 +1387,15 @@ static const NSTimeInterval kExpectationTimeout = 2;
     @brief Tests failed retry after failing to send verification code.
  */
 - (void)testSendVerificationCodeFailedRetry {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
 
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
       .andCallBlock1(^(FIRAuthNotificationForwardingCallback callback) {
@@ -1491,15 +1492,15 @@ static const NSTimeInterval kExpectationTimeout = 2;
     @brief Tests successful retry after failing to send verification code.
  */
 - (void)testSendVerificationCodeSuccessFulRetry {
-  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
-  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
-
   id mockBundle = OCMClassMock([NSBundle class]);
   OCMStub(ClassMethod([mockBundle mainBundle])).andReturn(mockBundle);
   OCMStub([mockBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"]).andReturn(@[
     @{@"CFBundleURLSchemes" : @[ kFakeReverseClientID ]}
   ]);
   OCMStub([mockBundle bundleIdentifier]).andReturn(kFakeBundleID);
+
+  OCMStub([_mockOptions clientID]).andReturn(kFakeClientID);
+  _provider = [FIRPhoneAuthProvider providerWithAuth:_mockAuth];
 
   OCMExpect([_mockNotificationManager checkNotificationForwardingWithCallback:OCMOCK_ANY])
       .andCallBlock1(^(FIRAuthNotificationForwardingCallback callback) {


### PR DESCRIPTION
After OAuth provisioning is deferred, the client ID may still be provided in the plist file after Google Sign-in is enabled. Therefore, the presence of the client ID itself is not enough to determine whether to use the client ID or the app ID in generic IDP and phone auth reCAPTCHA fallback flows. Instead, we need to check first if the reverse client ID is registered as a custom URL scheme.