### PR TITLE
Check token is different from cache and storage before  updating it 

### DIFF
--- a/Example/InstanceID/Tests/FIRInstanceIDTest.m
+++ b/Example/InstanceID/Tests/FIRInstanceIDTest.m
@@ -1328,7 +1328,18 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
 - (void)testRefreshDifferentTokenFromMessaging {
   _instanceID.defaultFCMToken = kToken;
   XCTAssertEqualObjects(_instanceID.defaultFCMToken, kToken);
-  NSString *newTokenFromMessaging = @"test_fake_token_that_is_only_for_this_test";
+  NSString *newTokenFromMessaging = @"a_new_token_from_messaging";
+  FIRInstanceIDTokenInfo *cachedTokenInfo =
+      [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:kAuthorizedEntity
+                                                         scope:kFIRInstanceIDDefaultTokenScope
+                                                         token:kToken
+                                                    appVersion:@""
+                                                 firebaseAppID:kGoogleAppID];
+  OCMStub([self.mockTokenManager
+              cachedTokenInfoWithAuthorizedEntity:kAuthorizedEntity
+                                            scope:kFIRInstanceIDDefaultTokenScope])
+      .andReturn(cachedTokenInfo);
+
   OCMExpect([self.mockTokenManager saveDefaultToken:newTokenFromMessaging
                                         withOptions:[OCMArg any]]);
   [[NSNotificationCenter defaultCenter]
@@ -1345,12 +1356,13 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
   NSString *newTokenFromMessaging = kToken;
   FIRInstanceIDTokenInfo *cachedTokenInfo =
       [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:kAuthorizedEntity
-                                                         scope:kScope
+                                                         scope:kFIRInstanceIDDefaultTokenScope
                                                          token:kToken
                                                     appVersion:@""
                                                  firebaseAppID:kGoogleAppID];
-  OCMStub([self.mockTokenManager cachedTokenInfoWithAuthorizedEntity:kAuthorizedEntity
-                                                               scope:kScope])
+  OCMStub([self.mockTokenManager
+              cachedTokenInfoWithAuthorizedEntity:kAuthorizedEntity
+                                            scope:kFIRInstanceIDDefaultTokenScope])
       .andReturn(cachedTokenInfo);
 
   OCMReject([self.mockTokenManager saveDefaultToken:newTokenFromMessaging
@@ -1371,12 +1383,13 @@ static NSString *const kGoogleAppID = @"1:123:ios:123abc";
 
   FIRInstanceIDTokenInfo *cachedTokenInfo =
       [[FIRInstanceIDTokenInfo alloc] initWithAuthorizedEntity:kAuthorizedEntity
-                                                         scope:kScope
+                                                         scope:kFIRInstanceIDDefaultTokenScope
                                                          token:@"a_outdated_token_in_storage"
                                                     appVersion:@""
                                                  firebaseAppID:kGoogleAppID];
-  OCMStub([self.mockTokenManager cachedTokenInfoWithAuthorizedEntity:kAuthorizedEntity
-                                                               scope:kScope])
+  OCMStub([self.mockTokenManager
+              cachedTokenInfoWithAuthorizedEntity:kAuthorizedEntity
+                                            scope:kFIRInstanceIDDefaultTokenScope])
       .andReturn(cachedTokenInfo);
 
   OCMExpect([self.mockTokenManager saveDefaultToken:newTokenFromMessaging

--- a/Firebase/InstanceID/CHANGELOG.md
+++ b/Firebase/InstanceID/CHANGELOG.md
@@ -1,4 +1,7 @@
-# Unreleased -- 7.0.0
+# Unreleased
+- [changed] Added a check on whether the default token has been changed from Messaging before writing to storage. (#7223)
+
+# 2020-10 -- 7.0.0
 - [changed] Deprecated private `-[FIRInstanceID appInstanceID:]` method was removed. (#4486)
 - [fixed] Fixed an issue that APNS token is not sent in token request when there's a delay of getting the APNS token from Apple. (#6553)
 

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -1138,7 +1138,7 @@ static FIRInstanceID *gInstanceID;
         (self.defaultFCMToken.length && tokenUpdatedFromMessaging.length &&
          ![self.defaultFCMToken isEqualToString:tokenUpdatedFromMessaging]) ||
         (cachedToken.length && tokenUpdatedFromMessaging.length &&
-         ![self.defaultFCMToken isEqualToString:tokenUpdatedFromMessaging])) {
+         ![cachedToken isEqualToString:tokenUpdatedFromMessaging])) {
       self.defaultFCMToken = tokenUpdatedFromMessaging;
       [self.tokenManager saveDefaultToken:tokenUpdatedFromMessaging
                               withOptions:[self defaultTokenOptions]];

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -1127,9 +1127,13 @@ static FIRInstanceID *gInstanceID;
 - (void)messagingTokenDidChangeNotificationReceived:(NSNotification *)notification {
   NSString *tokenUpdatedFromMessaging = notification.object;
   if (!tokenUpdatedFromMessaging || [tokenUpdatedFromMessaging isKindOfClass:[NSString class]]) {
-    self.defaultFCMToken = tokenUpdatedFromMessaging;
-    [self.tokenManager saveDefaultToken:tokenUpdatedFromMessaging
-                            withOptions:[self defaultTokenOptions]];
+    if (self.defaultFCMToken.length != tokenUpdatedFromMessaging.length ||
+        (self.defaultFCMToken.length && tokenUpdatedFromMessaging.length &&
+         ![self.defaultFCMToken isEqualToString:tokenUpdatedFromMessaging])) {
+      self.defaultFCMToken = tokenUpdatedFromMessaging;
+      [self.tokenManager saveDefaultToken:tokenUpdatedFromMessaging
+                              withOptions:[self defaultTokenOptions]];
+    }
   }
 }
 

--- a/Firebase/InstanceID/FIRInstanceID.m
+++ b/Firebase/InstanceID/FIRInstanceID.m
@@ -1127,8 +1127,17 @@ static FIRInstanceID *gInstanceID;
 - (void)messagingTokenDidChangeNotificationReceived:(NSNotification *)notification {
   NSString *tokenUpdatedFromMessaging = notification.object;
   if (!tokenUpdatedFromMessaging || [tokenUpdatedFromMessaging isKindOfClass:[NSString class]]) {
+    // Check the token from storage along with local value.
+    FIRInstanceIDTokenInfo *cachedTokenInfo =
+        [self.tokenManager cachedTokenInfoWithAuthorizedEntity:self.fcmSenderID
+                                                         scope:kFIRInstanceIDDefaultTokenScope];
+    NSString *cachedToken = cachedTokenInfo.token;
+
     if (self.defaultFCMToken.length != tokenUpdatedFromMessaging.length ||
+        cachedToken.length != tokenUpdatedFromMessaging.length ||
         (self.defaultFCMToken.length && tokenUpdatedFromMessaging.length &&
+         ![self.defaultFCMToken isEqualToString:tokenUpdatedFromMessaging]) ||
+        (cachedToken.length && tokenUpdatedFromMessaging.length &&
          ![self.defaultFCMToken isEqualToString:tokenUpdatedFromMessaging])) {
       self.defaultFCMToken = tokenUpdatedFromMessaging;
       [self.tokenManager saveDefaultToken:tokenUpdatedFromMessaging

--- a/FirebaseMessaging/Apps/Shared/ContentView.swift
+++ b/FirebaseMessaging/Apps/Shared/ContentView.swift
@@ -48,6 +48,7 @@ struct ContentView: View {
               // simulator renders a single truncated line even though the Preview renders it
               // appropriately. Potentially a bug in the simulator?
               .layoutPriority(1)
+              .lineLimit(7)
           }
           NavigationLink(destination: SettingsView()) {
             Text("Settings")

--- a/FirebaseMessaging/Apps/Shared/SceneDelegate.swift
+++ b/FirebaseMessaging/Apps/Shared/SceneDelegate.swift
@@ -76,6 +76,5 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, MessagingDelegate {
     print("=============================\n")
     print("Did refresh token:\n", identity.token ?? "")
     print("\n=============================\n")
-
   }
 }

--- a/FirebaseMessaging/Apps/Shared/SceneDelegate.swift
+++ b/FirebaseMessaging/Apps/Shared/SceneDelegate.swift
@@ -73,5 +73,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate, MessagingDelegate {
 
   func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
     identity.token = fcmToken
+    print("=============================\n")
+    print("Did refresh token:\n", identity.token ?? "")
+    print("\n=============================\n")
+
   }
 }


### PR DESCRIPTION
When messaging updates token and notifying InstanceID, instanceID should first check to see the token from Messaging is different than the one in local cache or in the database. 
This extra check helps reduce storage writing in the future when we remove InstanceID and handle token completely from Messaging.