### PR TITLE
Update SwiftPackageManager.md with instructions for Crashlytics SPM

### DIFF
--- a/SwiftPackageManager.md
+++ b/SwiftPackageManager.md
@@ -51,7 +51,7 @@ https://github.com/firebase/firebase-ios-sdk/issues/6472#issuecomment-694449182.
 
 <img src="docs/resources/SPMObjC.png">
 
-If you're using FirebaseCrashlytics, use 
+If you're using FirebaseCrashlytics, use
 `${BUILD_DIR%Build/*}SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run`
 as the run script that allows Xcode to upload your project's dSYM files.
 

--- a/SwiftPackageManager.md
+++ b/SwiftPackageManager.md
@@ -52,7 +52,7 @@ https://github.com/firebase/firebase-ios-sdk/issues/6472#issuecomment-694449182.
 <img src="docs/resources/SPMObjC.png">
 
 If you're using FirebaseCrashlytics, use
-`${BUILD_DIR%Build/*}SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run`
+`${BUILD_DIR}SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run`
 as the run script that allows Xcode to upload your project's dSYM files.
 
 ### Alternatively, add Firebase to a `Package.swift` manifest

--- a/SwiftPackageManager.md
+++ b/SwiftPackageManager.md
@@ -51,6 +51,10 @@ https://github.com/firebase/firebase-ios-sdk/issues/6472#issuecomment-694449182.
 
 <img src="docs/resources/SPMObjC.png">
 
+If you're using FirebaseCrashlytics, use 
+`${BUILD_DIR%Build/*}SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run`
+as the run script that allows Xcode to upload your project's dSYM files.
+
 ### Alternatively, add Firebase to a `Package.swift` manifest
 
 To integrate via a `Package.swift` manifest instead of Xcode, you can add


### PR DESCRIPTION
Add instructions for where to find Crashlytics run scripts for Swift Package Manager installation.