### PR TITLE
Core: fix and cleanup notification center tests

### DIFF
--- a/Example/CoreDiagnostics/Tests/FIRCoreDiagnosticsTest.m
+++ b/Example/CoreDiagnostics/Tests/FIRCoreDiagnosticsTest.m
@@ -31,7 +31,6 @@
 
 #import "Firebase/CoreDiagnostics/FIRCDLibrary/Protogen/nanopb/firebasecore.nanopb.h"
 
-extern NSString *const kFIRAppDiagnosticsNotification;
 extern NSString *const kFIRLastCheckinDateKey;
 
 static NSString *const kGoogleAppID = @"1:123:ios:123abc";

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCore'
-  s.version          = '7.3.0'
+  s.version          = '7.4.0'
   s.summary          = 'Firebase Core'
 
   s.description      = <<-DESC
@@ -47,7 +47,7 @@ Firebase Core includes FIRApp and FIROptions which provide central configuration
   s.tvos.framework = 'UIKit'
   s.dependency 'GoogleUtilities/Environment', '~> 7.0'
   s.dependency 'GoogleUtilities/Logger', '~> 7.0'
-  s.dependency 'FirebaseCoreDiagnostics', '~> 7.0'
+  s.dependency 'FirebaseCoreDiagnostics', '~> 7.4'
 
   s.pod_target_xcconfig = {
     'GCC_C_LANGUAGE_STANDARD' => 'c99',

--- a/FirebaseCore.podspec
+++ b/FirebaseCore.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCore'
-  s.version          = '7.4.0'
+  s.version          = '7.3.0'
   s.summary          = 'Firebase Core'
 
   s.description      = <<-DESC

--- a/FirebaseCore/Sources/FIRApp.m
+++ b/FirebaseCore/Sources/FIRApp.m
@@ -73,8 +73,6 @@ NSString *const kFIRGlobalAppDataCollectionEnabledDefaultsKeyFormat =
 NSString *const kFIRGlobalAppDataCollectionEnabledPlistKey =
     @"FirebaseDataCollectionDefaultEnabled";
 
-NSString *const kFIRAppDiagnosticsNotification = @"FIRAppDiagnosticsNotification";
-
 NSString *const kFIRAppDiagnosticsConfigurationTypeKey = @"ConfigType";
 NSString *const kFIRAppDiagnosticsErrorKey = @"Error";
 NSString *const kFIRAppDiagnosticsFIRAppKey = @"FIRApp";

--- a/FirebaseCore/Sources/Private/FIRAppInternal.h
+++ b/FirebaseCore/Sources/Private/FIRAppInternal.h
@@ -52,11 +52,6 @@ extern NSString *const kFIRGlobalAppDataCollectionEnabledDefaultsKeyFormat;
  */
 extern NSString *const kFIRGlobalAppDataCollectionEnabledPlistKey;
 
-/**
- * A notification fired containing diagnostic information when SDK errors occur.
- */
-extern NSString *const kFIRAppDiagnosticsNotification;
-
 /** @var FIRAuthStateDidChangeInternalNotification
  @brief The name of the @c NSNotificationCenter notification which is posted when the auth state
  changes (e.g. a new token has been produced, a user logs in or out). The object parameter of

--- a/FirebaseCore/Tests/Unit/FIRAnalyticsConfigurationTest.m
+++ b/FirebaseCore/Tests/Unit/FIRAnalyticsConfigurationTest.m
@@ -19,8 +19,6 @@
 #import "FirebaseCore/Sources/FIRAnalyticsConfiguration.h"
 
 @interface FIRAnalyticsConfigurationTest : FIRTestCase
-/// An observer for NSNotificationCenter.
-@property(nonatomic, strong) id observerMock;
 
 @property(nonatomic, strong) NSNotificationCenter *notificationCenter;
 @end
@@ -30,12 +28,10 @@
 - (void)setUp {
   [super setUp];
 
-  _observerMock = OCMObserverMock();
   _notificationCenter = [NSNotificationCenter defaultCenter];
 }
 
 - (void)tearDown {
-  _observerMock = nil;
   _notificationCenter = nil;
 
   [super tearDown];
@@ -70,16 +66,6 @@
                                  forKey:kFIRAPersistedConfigMeasurementEnabledStateKey]);
 
   [userDefaultsMock stopMocking];
-}
-
-#pragma mark - Private Test Helpers
-
-- (void)expectNotificationForObserver:(id)observer
-                     notificationName:(NSNotificationName)name
-                               object:(nullable id)object
-                             userInfo:(nullable NSDictionary *)userInfo {
-  [self.notificationCenter addMockObserver:self.observerMock name:name object:object];
-  [[observer expect] notificationWithName:name object:object userInfo:userInfo];
 }
 
 @end

--- a/FirebaseCoreDiagnostics.podspec
+++ b/FirebaseCoreDiagnostics.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'FirebaseCoreDiagnostics'
-  s.version          = '7.3.0'
+  s.version          = '7.4.0'
   s.summary          = 'Firebase Core Diagnostics'
 
   s.description      = <<-DESC


### PR DESCRIPTION
- replace deprecated OCMock methods by notification XCTExpectations
- remove unused `kFIRAppDiagnosticsNotification` internal constant