### PR TITLE
Migrate libFuzzer from svn to git

### DIFF
--- a/Firestore/Example/FuzzTests/FuzzingResources/Serializer/Corpus/ConvertTextToBinary.sh
+++ b/Firestore/Example/FuzzTests/FuzzingResources/Serializer/Corpus/ConvertTextToBinary.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/bash -l
 
-# Copyright 2018 Google
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,12 @@
 # and SCRIPT_OUTPUT_FILE_0 are defined in the Run Script Build Phase of the
 # XCode build target Firestore_FuzzTests_iOS that executes this script. XCode
 # defines these environment variables and makes them available to the script.
+#
+# By default Xcode build phase scripts run in a stripped down environment that
+# does not include user modifications to the PATH that might come from .profile
+# or similar. The shebang line includes `bash -l` specifically to force the
+# shell to pick up the user profile. This allows `protoc` to be found even if
+# it isn't installed in /usr/local/bin.
 
 if ! [ -x "$(command -v protoc)" ]; then
   echo "This scripts needs the protoc command to be on the PATH."

--- a/Firestore/Example/LibFuzzer.podspec
+++ b/Firestore/Example/LibFuzzer.podspec
@@ -1,4 +1,4 @@
-# Copyright 2018 Google
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,14 +32,16 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.12'
   s.tvos.deployment_target = '10.0'
 
-  # Check out only libFuzzer folder.
   s.source              = {
-    :svn => 'https://llvm.org/svn/llvm-project/compiler-rt/trunk/lib/fuzzer'
+    :git => 'https://github.com/llvm/llvm-project.git'
   }
 
-  # Add all source files, except for the FuzzerMain.cpp.
-  s.source_files        = '*.{h,cpp,def}'
-  s.exclude_files       = 'FuzzerMain.cpp'
+  # The fuzzer is self-contained so only add its source files.
+  s.source_files        = 'compiler-rt/lib/fuzzer/*.{h,cpp,def}'
+
+  # We run fuzz tests via FSTFuzzTestsPrincipal, so avoid linking a `main`
+  # function.
+  s.exclude_files       = 'compiler-rt/lib/fuzzer/FuzzerMain.cpp'
 
   s.library             = 'c++'
 


### PR DESCRIPTION
Now that the LLVM project has completed its migration to git, the svn checkouts are now failing.

Also fix an incidental issue that arose while testing locally--I have homebrew installed in `$HOME/homebrew` and the fuzzer build was failing to find `protoc` as a result.