### PR TITLE
Verify that @DocumentID works with custom Codable methods.

### DIFF
--- a/Firestore/Swift/Tests/Integration/CodableIntegrationTests.swift
+++ b/Firestore/Swift/Tests/Integration/CodableIntegrationTests.swift
@@ -248,6 +248,53 @@ class CodableIntegrationTests: FSTIntegrationTestCase {
       let decoded = try readDocument(forRef: docToWrite).data(as: Model.self)
       XCTAssertEqual(decoded!, Model(name: "name", docId: docToWrite))
     }
+
+    func testSelfDocumentIDWithCustomCodable() throws {
+      struct Model: Codable, Equatable {
+        var name: String
+        @DocumentID var docId: DocumentReference?
+
+        enum CodingKeys: String, CodingKey {
+          case name
+          case docId
+        }
+
+        public init(name: String, docId: DocumentReference?) {
+          self.name = name
+          self.docId = docId
+        }
+
+        public init(from decoder: Decoder) throws {
+          let container = try decoder.container(keyedBy: CodingKeys.self)
+          let name = try container.decode(String.self, forKey: .name)
+          let docId = try container.decode(DocumentID<DocumentReference>.self, forKey: .docId)
+          self.init(name: name, docId: docId.wrappedValue)
+        }
+
+        public func encode(to encoder: Encoder) throws {
+          var container = encoder.container(keyedBy: CodingKeys.self)
+          try container.encode(name, forKey: .name)
+          // DocumentId should not be encoded when writing to Firestore; it's auto-populated when
+          // reading.
+        }
+      }
+
+      let docToWrite = documentRef()
+      let model = Model(
+        name: "name",
+        docId: nil
+      )
+
+      try setData(from: model, forDocument: docToWrite, withFlavor: .docRef)
+      let data = readDocument(forRef: docToWrite).data()
+
+      // "docId" is ignored during encoding
+      XCTAssertEqual(data! as! [String: String], ["name": "name"])
+
+      // Decoded result has "docId" auto-populated.
+      let decoded = try readDocument(forRef: docToWrite).data(as: Model.self)
+      XCTAssertEqual(decoded!, Model(name: "name", docId: docToWrite))
+    }
   #endif // swift(>=5.1)
 
   func testSetThenMerge() throws {

--- a/Firestore/Swift/Tests/Integration/CodableIntegrationTests.swift
+++ b/Firestore/Swift/Tests/Integration/CodableIntegrationTests.swift
@@ -266,9 +266,9 @@ class CodableIntegrationTests: FSTIntegrationTestCase {
 
         public init(from decoder: Decoder) throws {
           let container = try decoder.container(keyedBy: CodingKeys.self)
-          let name = try container.decode(String.self, forKey: .name)
-          let docId = try container.decode(DocumentID<DocumentReference>.self, forKey: .docId)
-          self.init(name: name, docId: docId.wrappedValue)
+          name = try container.decode(String.self, forKey: .name)
+          docId = try container.decode(DocumentID<DocumentReference>.self, forKey: .docId)
+            .wrappedValue
         }
 
         public func encode(to encoder: Encoder) throws {


### PR DESCRIPTION
Prompted by #7242.

This shows that property wrappers like `@DocumentID` can be used in custom Codable methods, and produce results essentially identical to `testSelfDocumentID`.

#no-changelog