### PR TITLE
Combine Support: Sign in with 3rd party credentials

### DIFF
--- a/FirebaseCombineSwift/README.md
+++ b/FirebaseCombineSwift/README.md
@@ -62,50 +62,52 @@ end
 #### Sign in with a given 3rd-party credentials 
 
 
-In the `sign(_:didSignInFor:withError:)` method, get a Google ID token and Google access token from the GIDAuthentication object and exchange them for a Firebase credential. Then, Asynchronously sign in to Firebase with the given tokens pair:
+In the `sign(_:didSignInFor:withError:) method, get a Google ID token and Google access token from the GIDAuthentication object and asynchronously exchange them for a Firebase credential:
 
 ```swift 
-    func sign(_ signIn: GIDSignIn!, didSignInFor user: GIDGoogleUser!, withError error: Error?) {
-       // ...
-       if let error = error {
-         // ...
-         return
-       }
+  func sign(_ signIn: GIDSignIn!, didSignInFor user: GIDGoogleUser!, withError error: Error?) {
+    // ...
+    if let error = error {
+      // ...
+      return
+    }
 
-       guard let authentication = user.authentication else { return }
-       let credential = GoogleAuthProvider.credential(withIDToken: authentication.idToken,
-                                                            accessToken: authentication.accessToken)
-        Auth.auth()
-            .signIn(withCredential: credential)
-            .mapError { $0 as NSError }
-            .tryCatch(handleError)
-            .sink { /* ... */ } receiveValue: {  /* ... */  }
-            .store(in: &subscriptions)
-    }
+    guard let authentication = user.authentication else { return }
+    let credential = GoogleAuthProvider.credential(withIDToken: authentication.idToken,
+                                                   accessToken: authentication.accessToken)
+    Auth.auth()
+      .signIn(withCredential: credential)
+      .mapError { $0 as NSError }
+      .tryCatch(handleError)
+      .sink { /* ... */ } receiveValue: {  /* ... */  }
+      .store(in: &subscriptions)
+  } 
     
-    private func handleError(_ error: NSError) throws -> AnyPublisher<AuthDataResult, Error> {
-        guard isMFAEnabled && error.code == AuthErrorCode.secondFactorRequired.rawValue
-        else { throw error }
+  private func handleError(_ error: NSError) throws -> AnyPublisher<AuthDataResult, Error> {
+    guard isMFAEnabled && error.code == AuthErrorCode.secondFactorRequired.rawValue
+    else { throw error }
         
-        // The user is a multi-factor user. Second factor challenge is required.
-        let resolver = error.userInfo[AuthErrorUserInfoMultiFactorResolverKey] as! MultiFactorResolver
-        let displayNameString = resolver.hints.compactMap(\.displayName).joined(separator: " ")
+    // The user is a multi-factor user. Second factor challenge is required.
+    let resolver = error.userInfo[AuthErrorUserInfoMultiFactorResolverKey] as! MultiFactorResolver
+    let displayNameString = resolver.hints.compactMap(\.displayName).joined(separator: " ")
         
-        return showTextInputPrompt(withMessage: "Select factor to sign in\n\(displayNameString)")
-            .compactMap { displayName in
-                resolver.hints.first(where: { displayName == $0.displayName }) as? PhoneMultiFactorInfo
-            }
-            .flatMap { [unowned self] factorInfo in
-                PhoneAuthProvider.provider()
-                    .verifyPhoneNumber(withMultiFactorInfo: factorInfo, multiFactorSession: resolver.session)
-                    .zip(self.showTextInputPrompt(withMessage: "Verification code for \(factorInfo.displayName ?? "")"))
-                    .map { (verificationID, verificationCode) in
-                        let credential = PhoneAuthProvider.provider().credential(withVerificationID: verificationID, 
-                                                                                 verificationCode: verificationCode)
-                        return PhoneMultiFactorGenerator.assertion(with: credential)
-                    }
-            }.flatMap { assertion in
-                resolver.resolveSignIn(withAssertion: assertion)
-            }.eraseToAnyPublisher()
-    }
+    return showTextInputPrompt(withMessage: "Select factor to sign in\n\(displayNameString)")
+      .compactMap { displayName in
+        resolver.hints.first(where: { displayName == $0.displayName }) as? PhoneMultiFactorInfo
+      }
+      .flatMap { [unowned self] factorInfo in
+        PhoneAuthProvider.provider()
+          .verifyPhoneNumber(withMultiFactorInfo: factorInfo, multiFactorSession: resolver.session)
+          .zip(self.showTextInputPrompt(withMessage: "Verification code for \(factorInfo.displayName ?? "")"))
+          .map { (verificationID, verificationCode) in
+            let credential = PhoneAuthProvider.provider().credential(withVerificationID: verificationID, 
+                                                                     verificationCode: verificationCode)
+            return PhoneMultiFactorGenerator.assertion(with: credential)
+          }
+      }
+      .flatMap { assertion in
+        resolver.resolveSignIn(withAssertion: assertion)
+      } 
+      .eraseToAnyPublisher()
+  }
 ```

--- a/FirebaseCombineSwift/README.md
+++ b/FirebaseCombineSwift/README.md
@@ -62,7 +62,7 @@ end
 #### Sign in with a given 3rd-party credentials 
 
 
-In the `sign(_:didSignInFor:withError:) method, get a Google ID token and Google access token from the GIDAuthentication object and asynchronously exchange them for a Firebase credential:
+In the `sign(_:didSignInFor:withError:)` method, get a Google ID token and Google access token from the GIDAuthentication object and asynchronously exchange them for a Firebase credential:
 
 ```swift 
   func sign(_ signIn: GIDSignIn!, didSignInFor user: GIDGoogleUser!, withError error: Error?) {

--- a/FirebaseCombineSwift/README.md
+++ b/FirebaseCombineSwift/README.md
@@ -59,3 +59,53 @@ end
     .assign(to: \.uid, on: self)
     .store(in: &cancellables)
 ```
+#### Sign in with a given 3rd-party credentials 
+
+
+In the `sign(_:didSignInFor:withError:)` method, get a Google ID token and Google access token from the GIDAuthentication object and exchange them for a Firebase credential. Then, Asynchronously sign in to Firebase with the given tokens pair:
+
+```swift 
+    func sign(_ signIn: GIDSignIn!, didSignInFor user: GIDGoogleUser!, withError error: Error?) {
+       // ...
+       if let error = error {
+         // ...
+         return
+       }
+
+       guard let authentication = user.authentication else { return }
+       let credential = GoogleAuthProvider.credential(withIDToken: authentication.idToken,
+                                                            accessToken: authentication.accessToken)
+        Auth.auth()
+            .signIn(withCredential: credential)
+            .mapError { $0 as NSError }
+            .tryCatch(handleError)
+            .sink { /* ... */ } receiveValue: {  /* ... */  }
+            .store(in: &subscriptions)
+    }
+    
+    private func handleError(_ error: NSError) throws -> AnyPublisher<AuthDataResult, Error> {
+        guard isMFAEnabled && error.code == AuthErrorCode.secondFactorRequired.rawValue
+        else { throw error }
+        
+        // The user is a multi-factor user. Second factor challenge is required.
+        let resolver = error.userInfo[AuthErrorUserInfoMultiFactorResolverKey] as! MultiFactorResolver
+        let displayNameString = resolver.hints.compactMap(\.displayName).joined(separator: " ")
+        
+        return showTextInputPrompt(withMessage: "Select factor to sign in\n\(displayNameString)")
+            .compactMap { displayName in
+                resolver.hints.first(where: { displayName == $0.displayName }) as? PhoneMultiFactorInfo
+            }
+            .flatMap { [unowned self] factorInfo in
+                PhoneAuthProvider.provider()
+                    .verifyPhoneNumber(withMultiFactorInfo: factorInfo, multiFactorSession: resolver.session)
+                    .zip(self.showTextInputPrompt(withMessage: "Verification code for \(factorInfo.displayName ?? "")"))
+                    .map { (verificationID, verificationCode) in
+                        let credential = PhoneAuthProvider.provider().credential(withVerificationID: verificationID, 
+                                                                                 verificationCode: verificationCode)
+                        return PhoneMultiFactorGenerator.assertion(with: credential)
+                    }
+            }.flatMap { assertion in
+                resolver.resolveSignIn(withAssertion: assertion)
+            }.eraseToAnyPublisher()
+    }
+```

--- a/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
@@ -490,7 +490,7 @@
         }
       }
     }
-    
+
     /// Asynchronously signs in to Firebase with the given 3rd-party credentials (e.g. a Facebook
     /// login Access Token, a Google ID Token/Access Token pair, etc.) and returns additional
     /// identity provider data.
@@ -531,11 +531,11 @@
     public func signIn(withCredential credential: AuthCredential) -> Future<AuthDataResult, Error> {
       Future<AuthDataResult, Error> { promise in
         self.signIn(with: credential) { authDataResult, error in
-            if let error = error {
-              promise(.failure(error))
-            } else if let authDataResult = authDataResult {
-              promise(.success(authDataResult))
-            }
+          if let error = error {
+            promise(.failure(error))
+          } else if let authDataResult = authDataResult {
+            promise(.success(authDataResult))
+          }
         }
       }
     }

--- a/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
@@ -528,7 +528,7 @@
     ///
     ///   See `AuthErrors` for a list of error codes that are common to all API methods
     @discardableResult
-    public func signIn(withCredential credential: AuthCredential) -> Future<AuthDataResult, Error> {
+    public func signIn(with credential: AuthCredential) -> Future<AuthDataResult, Error> {
       Future<AuthDataResult, Error> { promise in
         self.signIn(with: credential) { authDataResult, error in
           if let error = error {

--- a/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
@@ -472,7 +472,7 @@
     /// - Returns: A publisher that emits an `AuthDataResult` when the sign-in flow completed
     ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
     /// - Remark: Possible error codes:
-    ///   - AuthErrorCodeInvalidCustomToken` - Indicates a validation error with the custom token.
+    ///   - `AuthErrorCodeInvalidCustomToken` - Indicates a validation error with the custom token.
     ///   - `AuthErrorCodeUserDisabled` - Indicates the user's account is disabled.
     ///   - `AuthErrorCodeCustomTokenMismatch` - Indicates the service account and the API key
     ///     belong to different projects.
@@ -487,6 +487,55 @@
           } else if let authDataResult = authDataResult {
             promise(.success(authDataResult))
           }
+        }
+      }
+    }
+    
+    /// Asynchronously signs in to Firebase with the given 3rd-party credentials (e.g. a Facebook
+    /// login Access Token, a Google ID Token/Access Token pair, etc.) and returns additional
+    /// identity provider data.
+    ///
+    /// The publisher will emit events on the **main** thread.
+    ///
+    /// - Parameter credential: The credential supplied by the IdP.
+    /// - Returns: A publisher that emits an `AuthDataResult` when the sign-in flow completed
+    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
+    /// - Remark: Possible error codes:
+    ///   - `FIRAuthErrorCodeInvalidCredential` - Indicates the supplied credential is invalid.
+    ///     This could happen if it has expired or it is malformed.
+    ///   - `FIRAuthErrorCodeOperationNotAllowed` - Indicates that accounts
+    ///     with the identity provider represented by the credential are not enabled.
+    ///     Enable them in the Auth section of the Firebase console.
+    ///   - `FIRAuthErrorCodeAccountExistsWithDifferentCredential` - Indicates the email asserted
+    ///     by the credential (e.g. the email in a Facebook access token) is already in use by an
+    ///     existing account, that cannot be authenticated with this sign-in method. Call
+    ///     fetchProvidersForEmail for this user’s email and then prompt them to sign in with any of
+    ///     the sign-in providers returned. This error will only be thrown if the "One account per
+    ///     email address" setting is enabled in the Firebase console, under Auth settings.
+    ///   - `FIRAuthErrorCodeUserDisabled` - Indicates the user's account is disabled.
+    ///   - `FIRAuthErrorCodeWrongPassword` - Indicates the user attempted sign in with an
+    ///     incorrect password, if credential is of the type EmailPasswordAuthCredential.
+    ///   - `FIRAuthErrorCodeInvalidEmail` - Indicates the email address is malformed.
+    ///   - `FIRAuthErrorCodeMissingVerificationID` - Indicates that the phone auth credential was
+    ///     created with an empty verification ID.
+    ///   - `FIRAuthErrorCodeMissingVerificationCode` - Indicates that the phone auth credential
+    ///     was created with an empty verification code.
+    ///   - `FIRAuthErrorCodeInvalidVerificationCode` - Indicates that the phone auth credential
+    ///     was created with an invalid verification Code.
+    ///   - `FIRAuthErrorCodeInvalidVerificationID` - Indicates that the phone auth credential was
+    ///     created with an invalid verification ID.
+    ///   - `FIRAuthErrorCodeSessionExpired` - Indicates that the SMS code has expired.
+    ///
+    ///   See `AuthErrors` for a list of error codes that are common to all API methods
+    @discardableResult
+    public func signIn(withCredential credential: AuthCredential) -> Future<AuthDataResult, Error> {
+      Future<AuthDataResult, Error> { promise in
+        self.signIn(with: credential) { authDataResult, error in
+            if let error = error {
+              promise(.failure(error))
+            } else if let authDataResult = authDataResult {
+              promise(.success(authDataResult))
+            }
         }
       }
     }

--- a/FirebaseCombineSwift/Sources/Auth/MultiFactorResolver+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/MultiFactorResolver+Combine.swift
@@ -27,7 +27,7 @@
     /// - Parameter assertion: The base class for asserting ownership of a second factor.
     /// - Returns: A publisher that emits an `AuthDataResult` when the sign-in flow completed
     ///   successfully, or an error otherwise.
-    public func resolveSignIn(withAssertion assertion: MultiFactorAssertion)
+    public func resolveSignIn(with assertion: MultiFactorAssertion)
       -> Future<AuthDataResult, Error> {
       Future<AuthDataResult, Error> { promise in
         self.resolveSignIn(with: assertion) { authDataResult, error in

--- a/FirebaseCombineSwift/Sources/Auth/MultiFactorResolver+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/MultiFactorResolver+Combine.swift
@@ -1,0 +1,43 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)
+  import Foundation
+
+  import Combine
+  import FirebaseAuth
+
+  @available(swift 5.0)
+  @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+  extension MultiFactorResolver {
+    
+    /// A helper function to help users complete sign in with a second factor using an
+    /// `MultiFactorAssertion` confirming the user successfully completed the second factor
+    ///
+    /// - Parameter assertion: The base class for asserting ownership of a second factor.
+    /// - Returns: A publisher that emits an `AuthDataResult` when the sign-in flow completed
+    ///   successfully, or an error otherwise.
+    func resolveSignIn(withAssertion assertion: MultiFactorAssertion) -> Future<AuthDataResult, Error> {
+        Future<AuthDataResult, Error> { promise in
+            self.resolveSignIn(with: assertion) { authDataResult, error in
+                if let error = error {
+                  promise(.failure(error))
+                } else if let authDataResult = authDataResult {
+                  promise(.success(authDataResult))
+                }
+            }
+        }
+    }
+  }
+#endif

--- a/FirebaseCombineSwift/Sources/Auth/MultiFactorResolver+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/MultiFactorResolver+Combine.swift
@@ -21,23 +21,23 @@
   @available(swift 5.0)
   @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
   extension MultiFactorResolver {
-    
     /// A helper function to help users complete sign in with a second factor using an
     /// `MultiFactorAssertion` confirming the user successfully completed the second factor
     ///
     /// - Parameter assertion: The base class for asserting ownership of a second factor.
     /// - Returns: A publisher that emits an `AuthDataResult` when the sign-in flow completed
     ///   successfully, or an error otherwise.
-    func resolveSignIn(withAssertion assertion: MultiFactorAssertion) -> Future<AuthDataResult, Error> {
-        Future<AuthDataResult, Error> { promise in
-            self.resolveSignIn(with: assertion) { authDataResult, error in
-                if let error = error {
-                  promise(.failure(error))
-                } else if let authDataResult = authDataResult {
-                  promise(.success(authDataResult))
-                }
-            }
+    public func resolveSignIn(withAssertion assertion: MultiFactorAssertion)
+      -> Future<AuthDataResult, Error> {
+      Future<AuthDataResult, Error> { promise in
+        self.resolveSignIn(with: assertion) { authDataResult, error in
+          if let error = error {
+            promise(.failure(error))
+          } else if let authDataResult = authDataResult {
+            promise(.success(authDataResult))
+          }
         }
+      }
     }
   }
 #endif

--- a/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
@@ -1,0 +1,53 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)
+  import Foundation
+
+  import Combine
+  import FirebaseAuth
+
+  @available(swift 5.0)
+  @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+  extension PhoneAuthProvider {
+    
+    /// Verify ownership of the second factor phone number by the current user.
+    ///
+    /// The publisher will emit events on the **main** thread.
+    /// 
+    /// - Parameters:
+    ///   - phoneNumber: The phone number to be verified.
+    ///   - UIDelegate: An object used to present the SFSafariViewController. The object is retained
+    ///   by this method until the completion block is executed.
+    ///   - multiFactorSession: session A session to identify the MFA flow. For enrollment, this identifies the user
+    ///   trying to enroll. For sign-in, this identifies that the user already passed the first factor challenge.
+    /// - Returns: A publisher that emits an `CerificationID` when the sign-in flow completed
+    ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
+    @discardableResult
+    func verifyPhoneNumber(withMultiFactorInfo phoneMultiFactorInfo: PhoneMultiFactorInfo,
+                           uiDelegate: AuthUIDelegate? = nil,
+                           multiFactorSession: MultiFactorSession?) -> Future<String, Error> {
+        Future<String, Error> { promise in
+            self.verifyPhoneNumber(with: phoneMultiFactorInfo, uiDelegate: uiDelegate,
+                                   multiFactorSession: multiFactorSession) { verificationID, error in
+                if let error = error {
+                  promise(.failure(error))
+                } else if let verificationID = verificationID {
+                  promise(.success(verificationID))
+                }
+            }
+        }
+    }
+}
+#endif

--- a/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
@@ -35,8 +35,9 @@
     ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
     @discardableResult
     public func verifyPhoneNumber(withMultiFactorInfo phoneMultiFactorInfo: PhoneMultiFactorInfo,
-                           uiDelegate: AuthUIDelegate? = nil,
-                           multiFactorSession: MultiFactorSession?) -> Future<String, Error> {
+                                  uiDelegate: AuthUIDelegate? = nil,
+                                  multiFactorSession: MultiFactorSession?)
+      -> Future<String, Error> {
       Future<String, Error> { promise in
         self.verifyPhoneNumber(with: phoneMultiFactorInfo, uiDelegate: uiDelegate,
                                multiFactorSession: multiFactorSession) { verificationID, error in

--- a/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
@@ -34,12 +34,13 @@
     /// - Returns: A publisher that emits an `CerificationID` when the sign-in flow completed
     ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
     @discardableResult
-    public func verifyPhoneNumber(withMultiFactorInfo phoneMultiFactorInfo: PhoneMultiFactorInfo,
+    public func verifyPhoneNumber(with phoneMultiFactorInfo: PhoneMultiFactorInfo,
                                   uiDelegate: AuthUIDelegate? = nil,
                                   multiFactorSession: MultiFactorSession?)
       -> Future<String, Error> {
       Future<String, Error> { promise in
-        self.verifyPhoneNumber(with: phoneMultiFactorInfo, uiDelegate: uiDelegate,
+        self.verifyPhoneNumber(with: phoneMultiFactorInfo,
+                               uiDelegate: uiDelegate,
                                multiFactorSession: multiFactorSession) { verificationID, error in
           if let error = error {
             promise(.failure(error))

--- a/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/PhoneAuthProvider+Combine.swift
@@ -21,11 +21,10 @@
   @available(swift 5.0)
   @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
   extension PhoneAuthProvider {
-    
     /// Verify ownership of the second factor phone number by the current user.
     ///
     /// The publisher will emit events on the **main** thread.
-    /// 
+    ///
     /// - Parameters:
     ///   - phoneNumber: The phone number to be verified.
     ///   - UIDelegate: An object used to present the SFSafariViewController. The object is retained
@@ -35,19 +34,19 @@
     /// - Returns: A publisher that emits an `CerificationID` when the sign-in flow completed
     ///   successfully, or an error otherwise. The publisher will emit on the *main* thread.
     @discardableResult
-    func verifyPhoneNumber(withMultiFactorInfo phoneMultiFactorInfo: PhoneMultiFactorInfo,
+    public func verifyPhoneNumber(withMultiFactorInfo phoneMultiFactorInfo: PhoneMultiFactorInfo,
                            uiDelegate: AuthUIDelegate? = nil,
                            multiFactorSession: MultiFactorSession?) -> Future<String, Error> {
-        Future<String, Error> { promise in
-            self.verifyPhoneNumber(with: phoneMultiFactorInfo, uiDelegate: uiDelegate,
-                                   multiFactorSession: multiFactorSession) { verificationID, error in
-                if let error = error {
-                  promise(.failure(error))
-                } else if let verificationID = verificationID {
-                  promise(.success(verificationID))
-                }
-            }
+      Future<String, Error> { promise in
+        self.verifyPhoneNumber(with: phoneMultiFactorInfo, uiDelegate: uiDelegate,
+                               multiFactorSession: multiFactorSession) { verificationID, error in
+          if let error = error {
+            promise(.failure(error))
+          } else if let verificationID = verificationID {
+            promise(.success(verificationID))
+          }
         }
+      }
     }
-}
+  }
 #endif

--- a/FirebaseCombineSwift/Tests/Unit/Auth/SignInWithCredentialTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/SignInWithCredentialTests.swift
@@ -1,0 +1,571 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Combine
+import XCTest
+import FirebaseAuth
+
+class SignInWithCredentialTests: XCTestCase {
+    override class func setUp() {
+      FirebaseApp.configureForTests()
+    }
+
+    override class func tearDown() {
+      FirebaseApp.app()?.delete { success in
+        if success {
+          print("Shut down app successfully.")
+        } else {
+          print("💥 There was a problem when shutting down the app..")
+        }
+      }
+    }
+
+    override func setUp() {
+      do {
+        try Auth.auth().signOut()
+      } catch {}
+    }
+    
+    static let apiKey = Credentials.apiKey
+    static let accessTokenTimeToLive: TimeInterval = 60 * 60
+    static let refreshToken = "REFRESH_TOKEN"
+    static let accessToken = "ACCESS_TOKEN"
+
+    static let email = "johnnyappleseed@apple.com"
+    static let password = "secret"
+    static let localID = "LOCAL_ID"
+    static let displayName = "Johnny Appleseed"
+    static let passwordHash = "UkVEQUNURUQ="
+
+    static let oAuthSessionID = "sessionID"
+    static let oAuthRequestURI = "requestURI"
+    static let googleID = "GOOGLE_ID"
+    static let googleAccessToken = "GOOGLE_ACCESS_TOKEN"
+    static let googleDisplayName = "Google Doe"
+    static let googleEmail = "user@gmail.com"
+    static let googleProfile: [String: String] = {
+        [
+            "iss": "https://accounts.google.com\\",
+            "email": googleEmail,
+            "given_name": "User",
+            "family_name": "Doe"
+        ]
+    }()
+    
+    static let verificationCode = "12345678"
+    static let verificationID = "55432"
+    
+    static let fakeEmailSignInlink =
+      "https://test.app.goo.gl/?link=https://test.firebaseapp.com/__/auth/action?apiKey%3DtestAPIKey%26mode%3DsignIn%26oobCode%3Dtestoobcode%26continueUrl%3Dhttps://test.apps.com&ibi=com.test.com&ifl=https://test.firebaseapp.com/__/auth/action?apiKey%3DtestAPIKey%26mode%3DsignIn%26oobCode%3Dtestoobcode%26continueUrl%3Dhttps://test.apps.com"
+    static let fakeOOBCode = "testoobcode"
+    
+    
+    
+    class MockEmailLinkSignInResponse: FIREmailLinkSignInResponse {
+      override var idToken: String { SignInWithCredentialTests.accessToken }
+      override var refreshToken: String { SignInWithCredentialTests.refreshToken }
+      override var approximateExpirationDate: Date {
+        Date(timeIntervalSinceNow: SignInWithCredentialTests.accessTokenTimeToLive)
+      }
+    }
+    
+    class MockVerifyPasswordResponse: FIRVerifyPasswordResponse {
+        override var idToken: String? { SignInWithCredentialTests.accessToken }
+        override var refreshToken: String? { SignInWithCredentialTests.refreshToken }
+        override var approximateExpirationDate: Date? {
+            Date(timeIntervalSinceNow: SignInWithCredentialTests.accessTokenTimeToLive)
+        }
+    }
+    
+    class MockVerifyAssertionResponse: FIRVerifyAssertionResponse {
+      override var federatedID: String? { SignInWithCredentialTests.googleID }
+      override var providerID: String? { GoogleAuthProviderID }
+      override var localID: String? { SignInWithCredentialTests.localID }
+      override var displayName: String? { SignInWithCredentialTests.displayName }
+        override var username: String? { SignInWithCredentialTests.displayName }
+        override var profile: [String : NSObject]? {SignInWithCredentialTests.googleProfile as [String: NSString] }
+        
+      override var idToken: String { SignInWithCredentialTests.accessToken }
+      override var refreshToken: String { SignInWithCredentialTests.refreshToken }
+      override var approximateExpirationDate: Date {
+        Date(timeIntervalSinceNow: SignInWithCredentialTests.accessTokenTimeToLive)
+      }
+    }
+    
+    class MockVerifyPhoneNumberResponse: FIRVerifyPhoneNumberResponse {
+        override var idToken: String? { SignInWithCredentialTests.accessToken }
+        override var refreshToken: String? { SignInWithCredentialTests.refreshToken }
+        override var approximateExpirationDate: Date? {
+            Date(timeIntervalSinceNow: SignInWithCredentialTests.accessTokenTimeToLive)
+        }
+    }
+    
+    class MockGetAccountInfoResponseUser: FIRGetAccountInfoResponseUser {
+      override var localID: String { SignInWithCredentialTests.localID }
+      override var email: String { SignInWithCredentialTests.email }
+      override var displayName: String { SignInWithCredentialTests.displayName }
+    }
+
+    class MockGetAccountInfoResponse: FIRGetAccountInfoResponse {
+      override var users: [FIRGetAccountInfoResponseUser] {
+        return [MockGetAccountInfoResponseUser(dictionary: [:])]
+      }
+    }
+    
+    class MockAuthBackend: AuthBackendImplementationMock {
+        
+        var emailLinkSignInCallback: Result<FIREmailLinkSignInResponse, Error> = .success(MockEmailLinkSignInResponse())
+        override func emailLinkSignin(_ request: FIREmailLinkSignInRequest,
+                                      callback: @escaping FIREmailLinkSigninResponseCallback) {
+          XCTAssertEqual(request.apiKey, SignInWithCredentialTests.apiKey)
+          XCTAssertEqual(request.email, SignInWithCredentialTests.email)
+          XCTAssertEqual(request.oobCode, SignInWithCredentialTests.fakeOOBCode)
+            
+            switch emailLinkSignInCallback {
+            case .success(let response):
+                callback(response, nil)
+            case .failure(let error):
+                callback(nil, error)
+            }
+        }
+        
+        override func verifyPhoneNumber(_ request: FIRVerifyPhoneNumberRequest, callback: @escaping FIRVerifyPhoneNumberResponseCallback) {
+            XCTAssertEqual(request.verificationCode, SignInWithCredentialTests.verificationCode)
+            XCTAssertEqual(request.verificationID, SignInWithCredentialTests.verificationID)
+            XCTAssertEqual(request.operation, FIRAuthOperationType.signUpOrSignIn)
+            
+            let response = MockVerifyPhoneNumberResponse()
+            response.isNewUser = true
+            callback(response, nil)
+        }
+        
+        var verifyAssertionCallBack: Result<FIRVerifyAssertionResponse, Error> = .success(MockVerifyAssertionResponse())
+        override func verifyAssertion(_ request: FIRVerifyAssertionRequest,
+                                      callback: @escaping FIRVerifyAssertionResponseCallback) {
+          XCTAssertEqual(request.apiKey, SignInWithCredentialTests.apiKey)
+          XCTAssertEqual(request.providerID, GoogleAuthProviderID)
+          XCTAssertTrue(request.returnSecureToken)
+
+            switch verifyAssertionCallBack {
+            case .success(let response):
+                callback(response, nil)
+            case .failure(let error):
+                callback(nil, error)
+            }
+        }
+        
+        var verifyPasswordCallback: Result<FIRVerifyPasswordResponse, Error> = .success(MockVerifyPasswordResponse())
+        override func verifyPassword(_ request: FIRVerifyPasswordRequest, callback: @escaping FIRVerifyPasswordResponseCallback) {
+            XCTAssertEqual(request.apiKey, SignInWithCredentialTests.apiKey)
+            XCTAssertEqual(request.email, SignInWithCredentialTests.email)
+            XCTAssertEqual(request.password, SignInWithCredentialTests.password)
+            XCTAssertTrue(request.returnSecureToken)
+            
+            switch verifyPasswordCallback {
+            case .success(let response):
+                callback(response, nil)
+            case .failure(let error):
+                callback(nil, error)
+            }
+        }
+
+      override func getAccountInfo(_ request: FIRGetAccountInfoRequest,
+                                   callback: @escaping FIRGetAccountInfoResponseCallback) {
+        XCTAssertEqual(request.apiKey, SignInWithCredentialTests.apiKey)
+        XCTAssertEqual(request.accessToken, SignInWithCredentialTests.accessToken)
+        callback(MockGetAccountInfoResponse(), nil)
+      }
+    }
+    
+    func testSignInWithEmailCredentialSuccess() {
+        // given
+        FIRAuthBackend.setBackendImplementation(MockAuthBackend())
+        
+        var cancellables = Set<AnyCancellable>()
+        let userSignInExpectation = expectation(description: "User signed in")
+        
+        let emailCredential = EmailAuthProvider.credential(withEmail: Self.email, password: Self.password)
+        
+        // when
+        Auth.auth()
+            .signIn(withCredential: emailCredential)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                  print("Finished")
+                case let .failure(error):
+                  XCTFail("💥 Something went wrong: \(error)")
+                }
+            } receiveValue: { authDataResult in
+                let user = authDataResult.user
+                XCTAssertNotNil(user)
+                XCTAssertEqual(user.uid, Self.localID)
+                XCTAssertEqual(user.displayName, Self.displayName)
+                XCTAssertEqual(user.email, Self.email)
+                XCTAssertFalse(user.isAnonymous)
+                XCTAssertEqual(user.providerData.count, 0)
+                
+                userSignInExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+        
+        // then
+        wait(for: [userSignInExpectation], timeout: expectationTimeout)
+    }
+    
+    func testSignInWithEmailCredentialFailure() {
+        // given
+        let authBackend = MockAuthBackend()
+        authBackend.verifyPasswordCallback = .failure(FIRAuthErrorUtils.userDisabledError(withMessage: nil))
+        FIRAuthBackend.setBackendImplementation(authBackend)
+        
+        var cancellables = Set<AnyCancellable>()
+        let userSignInExpectation = expectation(description: "User disabled")
+        
+        let emailCredential = EmailAuthProvider.credential(withEmail: Self.email, password: Self.password)
+        
+        // when
+        Auth.auth()
+            .signIn(withCredential: emailCredential)
+            .sink { completion in
+                if case let .failure(error as NSError) = completion {
+                    XCTAssertEqual(error.code, AuthErrorCode.userDisabled.rawValue)
+                    
+                    userSignInExpectation.fulfill()
+                }
+            } receiveValue: { authDataResult in
+                XCTFail("💥 result unexpected")
+            }
+            .store(in: &cancellables)
+        
+        // then
+        wait(for: [userSignInExpectation], timeout: expectationTimeout)
+    }
+    
+    func testSignInWithEmailCredentialEmptyPassword() {
+        // given
+        FIRAuthBackend.setBackendImplementation(MockAuthBackend())
+        
+        var cancellables = Set<AnyCancellable>()
+        let userSignInExpectation = expectation(description: "User wrong password")
+        
+        let emailCredential = EmailAuthProvider.credential(withEmail: Self.email, password: "")
+        
+        // when
+        Auth.auth()
+            .signIn(withCredential: emailCredential)
+            .sink { completion in
+                if case let .failure(error as NSError) = completion {
+                    XCTAssertEqual(error.code, AuthErrorCode.wrongPassword.rawValue)
+                    
+                    userSignInExpectation.fulfill()
+                }
+            } receiveValue: { authDataResult in
+                XCTFail("💥 result unexpected")
+            }
+            .store(in: &cancellables)
+        
+        // then
+        wait(for: [userSignInExpectation], timeout: expectationTimeout)
+    }
+    
+    func testSignInWithGoogleAccountExistsError() {
+        // given
+        let authBackend = MockAuthBackend()
+        let mockVerifyAssertionResponse = MockVerifyAssertionResponse()
+        mockVerifyAssertionResponse.needConfirmation = true
+        authBackend.verifyAssertionCallBack = .success(mockVerifyAssertionResponse)
+        FIRAuthBackend.setBackendImplementation(authBackend)
+        
+        var cancellables = Set<AnyCancellable>()
+        let userSignInExpectation = expectation(description: "User Google exists")
+        
+        let googleCredential = GoogleAuthProvider.credential(withIDToken: Self.googleID, accessToken: Self.googleAccessToken)
+        
+        // when
+        Auth.auth()
+            .signIn(withCredential: googleCredential)
+            .sink { completion in
+                if case let .failure(error as NSError) = completion {
+                    XCTAssertEqual(error.code, AuthErrorCode.accountExistsWithDifferentCredential.rawValue)
+                    
+                    userSignInExpectation.fulfill()
+                }
+            } receiveValue: { authDataResult in
+                XCTFail("💥 result unexpected")
+            }
+            .store(in: &cancellables)
+        
+        // then
+        wait(for: [userSignInExpectation], timeout: expectationTimeout)
+    }
+    
+    func testSignInWithGoogleCredentialSuccess() {
+        // given
+        FIRAuthBackend.setBackendImplementation(MockAuthBackend())
+    
+        var cancellables = Set<AnyCancellable>()
+        let userSignInExpectation = expectation(description: "User signed in")
+        
+        let googleCredential = GoogleAuthProvider.credential(withIDToken: Self.googleID, accessToken: Self.googleAccessToken)
+        
+        // when
+        Auth.auth()
+            .signIn(withCredential: googleCredential)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                  print("Finished")
+                case let .failure(error):
+                  XCTFail("💥 Something went wrong: \(error)")
+                }
+            } receiveValue: { authDataResult in
+                let user = authDataResult.user
+                XCTAssertNotNil(user)
+                XCTAssertEqual(user.uid, Self.localID)
+                XCTAssertEqual(user.displayName, Self.displayName)
+                XCTAssertEqual(user.email, Self.email)
+                XCTAssertFalse(user.isAnonymous)
+                XCTAssertEqual(user.providerData.count, 0)
+                
+                userSignInExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+        
+        // then
+        wait(for: [userSignInExpectation], timeout: expectationTimeout)
+    }
+    
+    func testSignInWithGoogleCredentialFailure() {
+        // given
+        let authBackend = MockAuthBackend()
+        authBackend.verifyAssertionCallBack = .failure(FIRAuthErrorUtils.emailAlreadyInUseError(withEmail: nil))
+        FIRAuthBackend.setBackendImplementation(authBackend)
+        
+        var cancellables = Set<AnyCancellable>()
+        let userSignInExpectation = expectation(description: "User signed in")
+        
+        let googleCredential = GoogleAuthProvider.credential(withIDToken: Self.googleID, accessToken: Self.googleAccessToken)
+        
+        // when
+        Auth.auth()
+            .signIn(withCredential: googleCredential)
+            .sink { completion in
+                if case let .failure(error as NSError) = completion {
+                    XCTAssertEqual(error.code, AuthErrorCode.emailAlreadyInUse.rawValue)
+                    
+                    userSignInExpectation.fulfill()
+                }
+            } receiveValue: { authDataResult in
+                XCTFail("💥 result unexpected")
+            }
+            .store(in: &cancellables)
+        
+        // then
+        wait(for: [userSignInExpectation], timeout: expectationTimeout)
+    }
+    
+    func testSignInWithCredentialSuccess() {
+        // given
+        FIRAuthBackend.setBackendImplementation(MockAuthBackend())
+    
+        var cancellables = Set<AnyCancellable>()
+        let userSignInExpectation = expectation(description: "User signed in")
+        
+        let googleCredential = GoogleAuthProvider.credential(withIDToken: Self.googleID, accessToken: Self.googleAccessToken)
+        
+        // when
+        Auth.auth()
+            .signIn(withCredential: googleCredential)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                  print("Finished")
+                case let .failure(error):
+                  XCTFail("💥 Something went wrong: \(error)")
+                }
+            } receiveValue: { authDataResult in
+                let user = authDataResult.user
+                XCTAssertNotNil(user)
+                XCTAssertEqual(user.uid, Self.localID)
+                XCTAssertEqual(user.displayName, Self.displayName)
+                XCTAssertEqual(user.email, Self.email)
+                XCTAssertFalse(user.isAnonymous)
+                XCTAssertEqual(user.providerData.count, 0)
+                XCTAssertEqual(authDataResult.additionalUserInfo?.username, Self.displayName)
+                XCTAssertEqual(authDataResult.additionalUserInfo?.profile, Self.googleProfile as [String: NSString])
+                
+                userSignInExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+        
+        // then
+        wait(for: [userSignInExpectation], timeout: expectationTimeout)
+    }
+    
+    func testPhoneAuthSuccess() {
+        // given
+        FIRAuthBackend.setBackendImplementation(MockAuthBackend())
+        
+        var cancellables = Set<AnyCancellable>()
+        let userSignInExpectation = expectation(description: "User signed in")
+        
+        let credential = PhoneAuthProvider.provider().credential(withVerificationID: Self.verificationID, verificationCode: Self.verificationCode)
+        
+        // when
+        Auth.auth()
+            .signIn(withCredential: credential)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                  print("Finished")
+                case let .failure(error):
+                  XCTFail("💥 Something went wrong: \(error)")
+                }
+            } receiveValue: { authDataResult in
+                let user = authDataResult.user
+                XCTAssertNotNil(user)
+                XCTAssertEqual(user.uid, Self.localID)
+                XCTAssertEqual(user.displayName, Self.displayName)
+                XCTAssertEqual(user.email, Self.email)
+                XCTAssertFalse(user.isAnonymous)
+                XCTAssertEqual(user.providerData.count, 0)
+                
+                userSignInExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+        
+        // then
+        wait(for: [userSignInExpectation], timeout: expectationTimeout)
+    }
+    
+    func testPhoneAuthMissingVerificationCode() {
+        // given
+        FIRAuthBackend.setBackendImplementation(MockAuthBackend())
+        
+        var cancellables = Set<AnyCancellable>()
+        let userSignInExpectation = expectation(description: "User missing verification code")
+        
+        let credential = PhoneAuthProvider.provider().credential(withVerificationID: Self.verificationID, verificationCode: "")
+        
+        // when
+        Auth.auth()
+            .signIn(withCredential: credential)
+            .sink { completion in
+                if case let .failure(error as NSError) = completion {
+                    XCTAssertEqual(error.code, AuthErrorCode.missingVerificationCode.rawValue)
+                    
+                    userSignInExpectation.fulfill()
+                }
+            } receiveValue: { authDataResult in
+                XCTFail("💥 result unexpected")
+            }
+            .store(in: &cancellables)
+        
+        // then
+        wait(for: [userSignInExpectation], timeout: expectationTimeout)
+    }
+    
+    func testPhoneAuthMissingVerificationID() {
+        // given
+        FIRAuthBackend.setBackendImplementation(MockAuthBackend())
+        
+        var cancellables = Set<AnyCancellable>()
+        let userSignInExpectation = expectation(description: "User missing verification ID")
+        
+        let credential = PhoneAuthProvider.provider().credential(withVerificationID: "", verificationCode: Self.verificationCode)
+        
+        // when
+        Auth.auth()
+            .signIn(withCredential: credential)
+            .sink { completion in
+                if case let .failure(error as NSError) = completion {
+                    XCTAssertEqual(error.code, AuthErrorCode.missingVerificationID.rawValue)
+                    
+                    userSignInExpectation.fulfill()
+                }
+            } receiveValue: { authDataResult in
+                XCTFail("💥 result unexpected")
+            }
+            .store(in: &cancellables)
+        
+        // then
+        wait(for: [userSignInExpectation], timeout: expectationTimeout)
+    }
+    
+    func testSignInWithEmailLinkCredentialSuccess() {
+        // given
+        FIRAuthBackend.setBackendImplementation(MockAuthBackend())
+        
+        var cancellables = Set<AnyCancellable>()
+        let userSignInExpectation = expectation(description: "User signed in")
+        
+        let emailCrendential = EmailAuthProvider.credential(withEmail: Self.email, link: Self.fakeEmailSignInlink)
+        
+        // when
+        Auth.auth()
+            .signIn(withCredential: emailCrendential)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                  print("Finished")
+                case let .failure(error):
+                  XCTFail("💥 Something went wrong: \(error)")
+                }
+            } receiveValue: { authDataResult in
+                let user = authDataResult.user
+                XCTAssertNotNil(user)
+                XCTAssertEqual(user.refreshToken, Self.refreshToken)
+                XCTAssertEqual(user.displayName, Self.displayName)
+                XCTAssertEqual(user.email, Self.email)
+                XCTAssertFalse(user.isAnonymous)
+                
+                userSignInExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+        
+        // then
+        wait(for: [userSignInExpectation], timeout: expectationTimeout)
+    }
+    
+    func testSignInWithEmailLinkCredentialFailure() {
+        // given
+        let authBackend = MockAuthBackend()
+        authBackend.emailLinkSignInCallback = .failure(FIRAuthErrorUtils.userDisabledError(withMessage: nil))
+        FIRAuthBackend.setBackendImplementation(authBackend)
+        
+        var cancellables = Set<AnyCancellable>()
+        let userSignInExpectation = expectation(description: "User disabled")
+        
+        let emailCrendential = EmailAuthProvider.credential(withEmail: Self.email, link: Self.fakeEmailSignInlink)
+        
+        // when
+        Auth.auth()
+            .signIn(withCredential: emailCrendential)
+            .sink { completion in
+                if case let .failure(error as NSError) = completion {
+                    XCTAssertEqual(error.code, AuthErrorCode.userDisabled.rawValue)
+                    
+                    userSignInExpectation.fulfill()
+                }
+            } receiveValue: { authDataResult in
+                XCTFail("💥 result unexpected")
+            }
+            .store(in: &cancellables)
+        
+        // then
+        wait(for: [userSignInExpectation], timeout: expectationTimeout)
+    }
+}

--- a/FirebaseCombineSwift/Tests/Unit/Auth/SignInWithCredentialTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/SignInWithCredentialTests.swift
@@ -207,7 +207,7 @@ class SignInWithCredentialTests: XCTestCase {
 
     // when
     Auth.auth()
-      .signIn(withCredential: emailCredential)
+      .signIn(with: emailCredential)
       .sink { completion in
         switch completion {
         case .finished:
@@ -249,7 +249,7 @@ class SignInWithCredentialTests: XCTestCase {
 
     // when
     Auth.auth()
-      .signIn(withCredential: emailCredential)
+      .signIn(with: emailCredential)
       .sink { completion in
         if case let .failure(error as NSError) = completion {
           XCTAssertEqual(error.code, AuthErrorCode.userDisabled.rawValue)
@@ -276,7 +276,7 @@ class SignInWithCredentialTests: XCTestCase {
 
     // when
     Auth.auth()
-      .signIn(withCredential: emailCredential)
+      .signIn(with: emailCredential)
       .sink { completion in
         if case let .failure(error as NSError) = completion {
           XCTAssertEqual(error.code, AuthErrorCode.wrongPassword.rawValue)
@@ -310,7 +310,7 @@ class SignInWithCredentialTests: XCTestCase {
 
     // when
     Auth.auth()
-      .signIn(withCredential: googleCredential)
+      .signIn(with: googleCredential)
       .sink { completion in
         if case let .failure(error as NSError) = completion {
           XCTAssertEqual(
@@ -343,7 +343,7 @@ class SignInWithCredentialTests: XCTestCase {
 
     // when
     Auth.auth()
-      .signIn(withCredential: googleCredential)
+      .signIn(with: googleCredential)
       .sink { completion in
         switch completion {
         case .finished:
@@ -386,7 +386,7 @@ class SignInWithCredentialTests: XCTestCase {
 
     // when
     Auth.auth()
-      .signIn(withCredential: googleCredential)
+      .signIn(with: googleCredential)
       .sink { completion in
         if case let .failure(error as NSError) = completion {
           XCTAssertEqual(error.code, AuthErrorCode.emailAlreadyInUse.rawValue)
@@ -416,7 +416,7 @@ class SignInWithCredentialTests: XCTestCase {
 
     // when
     Auth.auth()
-      .signIn(withCredential: googleCredential)
+      .signIn(with: googleCredential)
       .sink { completion in
         switch completion {
         case .finished:
@@ -459,7 +459,7 @@ class SignInWithCredentialTests: XCTestCase {
 
     // when
     Auth.auth()
-      .signIn(withCredential: credential)
+      .signIn(with: credential)
       .sink { completion in
         switch completion {
         case .finished:
@@ -496,7 +496,7 @@ class SignInWithCredentialTests: XCTestCase {
 
     // when
     Auth.auth()
-      .signIn(withCredential: credential)
+      .signIn(with: credential)
       .sink { completion in
         if case let .failure(error as NSError) = completion {
           XCTAssertEqual(error.code, AuthErrorCode.missingVerificationCode.rawValue)
@@ -524,7 +524,7 @@ class SignInWithCredentialTests: XCTestCase {
 
     // when
     Auth.auth()
-      .signIn(withCredential: credential)
+      .signIn(with: credential)
       .sink { completion in
         if case let .failure(error as NSError) = completion {
           XCTAssertEqual(error.code, AuthErrorCode.missingVerificationID.rawValue)
@@ -554,7 +554,7 @@ class SignInWithCredentialTests: XCTestCase {
 
     // when
     Auth.auth()
-      .signIn(withCredential: emailCrendential)
+      .signIn(with: emailCrendential)
       .sink { completion in
         switch completion {
         case .finished:
@@ -595,9 +595,10 @@ class SignInWithCredentialTests: XCTestCase {
 
     // when
     Auth.auth()
-      .signIn(withCredential: emailCrendential)
+      .signIn(with: emailCrendential)
       .sink { completion in
         if case let .failure(error as NSError) = completion {
+          XCTAssertNotNil(error.userInfo[NSLocalizedDescriptionKey])
           XCTAssertEqual(error.code, AuthErrorCode.userDisabled.rawValue)
 
           userSignInExpectation.fulfill()

--- a/FirebaseCombineSwift/Tests/Unit/Auth/SignInWithCredentialTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/SignInWithCredentialTests.swift
@@ -18,554 +18,596 @@ import XCTest
 import FirebaseAuth
 
 class SignInWithCredentialTests: XCTestCase {
-    override class func setUp() {
-      FirebaseApp.configureForTests()
+  override class func setUp() {
+    FirebaseApp.configureForTests()
+  }
+
+  override class func tearDown() {
+    FirebaseApp.app()?.delete { success in
+      if success {
+        print("Shut down app successfully.")
+      } else {
+        print("💥 There was a problem when shutting down the app..")
+      }
+    }
+  }
+
+  override func setUp() {
+    do {
+      try Auth.auth().signOut()
+    } catch {}
+  }
+
+  static let apiKey = Credentials.apiKey
+  static let accessTokenTimeToLive: TimeInterval = 60 * 60
+  static let refreshToken = "REFRESH_TOKEN"
+  static let accessToken = "ACCESS_TOKEN"
+
+  static let email = "johnnyappleseed@apple.com"
+  static let password = "secret"
+  static let localID = "LOCAL_ID"
+  static let displayName = "Johnny Appleseed"
+  static let passwordHash = "UkVEQUNURUQ="
+
+  static let oAuthSessionID = "sessionID"
+  static let oAuthRequestURI = "requestURI"
+  static let googleID = "GOOGLE_ID"
+  static let googleAccessToken = "GOOGLE_ACCESS_TOKEN"
+  static let googleDisplayName = "Google Doe"
+  static let googleEmail = "user@gmail.com"
+  static let googleProfile: [String: String] = {
+    [
+      "iss": "https://accounts.google.com\\",
+      "email": googleEmail,
+      "given_name": "User",
+      "family_name": "Doe",
+    ]
+  }()
+
+  static let verificationCode = "12345678"
+  static let verificationID = "55432"
+
+  static let fakeEmailSignInlink =
+    "https://test.app.goo.gl/?link=https://test.firebaseapp.com/__/auth/action?apiKey%3DtestAPIKey%26mode%3DsignIn%26oobCode%3Dtestoobcode%26continueUrl%3Dhttps://test.apps.com&ibi=com.test.com&ifl=https://test.firebaseapp.com/__/auth/action?apiKey%3DtestAPIKey%26mode%3DsignIn%26oobCode%3Dtestoobcode%26continueUrl%3Dhttps://test.apps.com"
+  static let fakeOOBCode = "testoobcode"
+
+  class MockEmailLinkSignInResponse: FIREmailLinkSignInResponse {
+    override var idToken: String { SignInWithCredentialTests.accessToken }
+    override var refreshToken: String { SignInWithCredentialTests.refreshToken }
+    override var approximateExpirationDate: Date {
+      Date(timeIntervalSinceNow: SignInWithCredentialTests.accessTokenTimeToLive)
+    }
+  }
+
+  class MockVerifyPasswordResponse: FIRVerifyPasswordResponse {
+    override var idToken: String? { SignInWithCredentialTests.accessToken }
+    override var refreshToken: String? { SignInWithCredentialTests.refreshToken }
+    override var approximateExpirationDate: Date? {
+      Date(timeIntervalSinceNow: SignInWithCredentialTests.accessTokenTimeToLive)
+    }
+  }
+
+  class MockVerifyAssertionResponse: FIRVerifyAssertionResponse {
+    override var federatedID: String? { SignInWithCredentialTests.googleID }
+    override var providerID: String? { GoogleAuthProviderID }
+    override var localID: String? { SignInWithCredentialTests.localID }
+    override var displayName: String? { SignInWithCredentialTests.displayName }
+    override var username: String? { SignInWithCredentialTests.displayName }
+    override var profile: [String: NSObject]? {
+      SignInWithCredentialTests.googleProfile as [String: NSString]
     }
 
-    override class func tearDown() {
-      FirebaseApp.app()?.delete { success in
-        if success {
-          print("Shut down app successfully.")
-        } else {
-          print("💥 There was a problem when shutting down the app..")
-        }
+    override var idToken: String { SignInWithCredentialTests.accessToken }
+    override var refreshToken: String { SignInWithCredentialTests.refreshToken }
+    override var approximateExpirationDate: Date {
+      Date(timeIntervalSinceNow: SignInWithCredentialTests.accessTokenTimeToLive)
+    }
+  }
+
+  class MockVerifyPhoneNumberResponse: FIRVerifyPhoneNumberResponse {
+    override var idToken: String? { SignInWithCredentialTests.accessToken }
+    override var refreshToken: String? { SignInWithCredentialTests.refreshToken }
+    override var approximateExpirationDate: Date? {
+      Date(timeIntervalSinceNow: SignInWithCredentialTests.accessTokenTimeToLive)
+    }
+  }
+
+  class MockGetAccountInfoResponseUser: FIRGetAccountInfoResponseUser {
+    override var localID: String { SignInWithCredentialTests.localID }
+    override var email: String { SignInWithCredentialTests.email }
+    override var displayName: String { SignInWithCredentialTests.displayName }
+  }
+
+  class MockGetAccountInfoResponse: FIRGetAccountInfoResponse {
+    override var users: [FIRGetAccountInfoResponseUser] {
+      return [MockGetAccountInfoResponseUser(dictionary: [:])]
+    }
+  }
+
+  class MockAuthBackend: AuthBackendImplementationMock {
+    var emailLinkSignInCallback: Result<FIREmailLinkSignInResponse, Error> =
+      .success(MockEmailLinkSignInResponse())
+    override func emailLinkSignin(_ request: FIREmailLinkSignInRequest,
+                                  callback: @escaping FIREmailLinkSigninResponseCallback) {
+      XCTAssertEqual(request.apiKey, SignInWithCredentialTests.apiKey)
+      XCTAssertEqual(request.email, SignInWithCredentialTests.email)
+      XCTAssertEqual(request.oobCode, SignInWithCredentialTests.fakeOOBCode)
+
+      switch emailLinkSignInCallback {
+      case let .success(response):
+        callback(response, nil)
+      case let .failure(error):
+        callback(nil, error)
       }
     }
 
-    override func setUp() {
-      do {
-        try Auth.auth().signOut()
-      } catch {}
+    override func verifyPhoneNumber(_ request: FIRVerifyPhoneNumberRequest,
+                                    callback: @escaping FIRVerifyPhoneNumberResponseCallback) {
+      XCTAssertEqual(request.verificationCode, SignInWithCredentialTests.verificationCode)
+      XCTAssertEqual(request.verificationID, SignInWithCredentialTests.verificationID)
+      XCTAssertEqual(request.operation, FIRAuthOperationType.signUpOrSignIn)
+
+      let response = MockVerifyPhoneNumberResponse()
+      response.isNewUser = true
+      callback(response, nil)
     }
-    
-    static let apiKey = Credentials.apiKey
-    static let accessTokenTimeToLive: TimeInterval = 60 * 60
-    static let refreshToken = "REFRESH_TOKEN"
-    static let accessToken = "ACCESS_TOKEN"
 
-    static let email = "johnnyappleseed@apple.com"
-    static let password = "secret"
-    static let localID = "LOCAL_ID"
-    static let displayName = "Johnny Appleseed"
-    static let passwordHash = "UkVEQUNURUQ="
+    var verifyAssertionCallBack: Result<FIRVerifyAssertionResponse, Error> =
+      .success(MockVerifyAssertionResponse())
+    override func verifyAssertion(_ request: FIRVerifyAssertionRequest,
+                                  callback: @escaping FIRVerifyAssertionResponseCallback) {
+      XCTAssertEqual(request.apiKey, SignInWithCredentialTests.apiKey)
+      XCTAssertEqual(request.providerID, GoogleAuthProviderID)
+      XCTAssertTrue(request.returnSecureToken)
 
-    static let oAuthSessionID = "sessionID"
-    static let oAuthRequestURI = "requestURI"
-    static let googleID = "GOOGLE_ID"
-    static let googleAccessToken = "GOOGLE_ACCESS_TOKEN"
-    static let googleDisplayName = "Google Doe"
-    static let googleEmail = "user@gmail.com"
-    static let googleProfile: [String: String] = {
-        [
-            "iss": "https://accounts.google.com\\",
-            "email": googleEmail,
-            "given_name": "User",
-            "family_name": "Doe"
-        ]
-    }()
-    
-    static let verificationCode = "12345678"
-    static let verificationID = "55432"
-    
-    static let fakeEmailSignInlink =
-      "https://test.app.goo.gl/?link=https://test.firebaseapp.com/__/auth/action?apiKey%3DtestAPIKey%26mode%3DsignIn%26oobCode%3Dtestoobcode%26continueUrl%3Dhttps://test.apps.com&ibi=com.test.com&ifl=https://test.firebaseapp.com/__/auth/action?apiKey%3DtestAPIKey%26mode%3DsignIn%26oobCode%3Dtestoobcode%26continueUrl%3Dhttps://test.apps.com"
-    static let fakeOOBCode = "testoobcode"
-    
-    
-    
-    class MockEmailLinkSignInResponse: FIREmailLinkSignInResponse {
-      override var idToken: String { SignInWithCredentialTests.accessToken }
-      override var refreshToken: String { SignInWithCredentialTests.refreshToken }
-      override var approximateExpirationDate: Date {
-        Date(timeIntervalSinceNow: SignInWithCredentialTests.accessTokenTimeToLive)
+      switch verifyAssertionCallBack {
+      case let .success(response):
+        callback(response, nil)
+      case let .failure(error):
+        callback(nil, error)
       }
     }
-    
-    class MockVerifyPasswordResponse: FIRVerifyPasswordResponse {
-        override var idToken: String? { SignInWithCredentialTests.accessToken }
-        override var refreshToken: String? { SignInWithCredentialTests.refreshToken }
-        override var approximateExpirationDate: Date? {
-            Date(timeIntervalSinceNow: SignInWithCredentialTests.accessTokenTimeToLive)
-        }
-    }
-    
-    class MockVerifyAssertionResponse: FIRVerifyAssertionResponse {
-      override var federatedID: String? { SignInWithCredentialTests.googleID }
-      override var providerID: String? { GoogleAuthProviderID }
-      override var localID: String? { SignInWithCredentialTests.localID }
-      override var displayName: String? { SignInWithCredentialTests.displayName }
-        override var username: String? { SignInWithCredentialTests.displayName }
-        override var profile: [String : NSObject]? {SignInWithCredentialTests.googleProfile as [String: NSString] }
-        
-      override var idToken: String { SignInWithCredentialTests.accessToken }
-      override var refreshToken: String { SignInWithCredentialTests.refreshToken }
-      override var approximateExpirationDate: Date {
-        Date(timeIntervalSinceNow: SignInWithCredentialTests.accessTokenTimeToLive)
+
+    var verifyPasswordCallback: Result<FIRVerifyPasswordResponse, Error> =
+      .success(MockVerifyPasswordResponse())
+    override func verifyPassword(_ request: FIRVerifyPasswordRequest,
+                                 callback: @escaping FIRVerifyPasswordResponseCallback) {
+      XCTAssertEqual(request.apiKey, SignInWithCredentialTests.apiKey)
+      XCTAssertEqual(request.email, SignInWithCredentialTests.email)
+      XCTAssertEqual(request.password, SignInWithCredentialTests.password)
+      XCTAssertTrue(request.returnSecureToken)
+
+      switch verifyPasswordCallback {
+      case let .success(response):
+        callback(response, nil)
+      case let .failure(error):
+        callback(nil, error)
       }
     }
-    
-    class MockVerifyPhoneNumberResponse: FIRVerifyPhoneNumberResponse {
-        override var idToken: String? { SignInWithCredentialTests.accessToken }
-        override var refreshToken: String? { SignInWithCredentialTests.refreshToken }
-        override var approximateExpirationDate: Date? {
-            Date(timeIntervalSinceNow: SignInWithCredentialTests.accessTokenTimeToLive)
-        }
-    }
-    
-    class MockGetAccountInfoResponseUser: FIRGetAccountInfoResponseUser {
-      override var localID: String { SignInWithCredentialTests.localID }
-      override var email: String { SignInWithCredentialTests.email }
-      override var displayName: String { SignInWithCredentialTests.displayName }
-    }
 
-    class MockGetAccountInfoResponse: FIRGetAccountInfoResponse {
-      override var users: [FIRGetAccountInfoResponseUser] {
-        return [MockGetAccountInfoResponseUser(dictionary: [:])]
+    override func getAccountInfo(_ request: FIRGetAccountInfoRequest,
+                                 callback: @escaping FIRGetAccountInfoResponseCallback) {
+      XCTAssertEqual(request.apiKey, SignInWithCredentialTests.apiKey)
+      XCTAssertEqual(request.accessToken, SignInWithCredentialTests.accessToken)
+      callback(MockGetAccountInfoResponse(), nil)
+    }
+  }
+
+  func testSignInWithEmailCredentialSuccess() {
+    // given
+    FIRAuthBackend.setBackendImplementation(MockAuthBackend())
+
+    var cancellables = Set<AnyCancellable>()
+    let userSignInExpectation = expectation(description: "User signed in")
+
+    let emailCredential = EmailAuthProvider.credential(
+      withEmail: Self.email,
+      password: Self.password
+    )
+
+    // when
+    Auth.auth()
+      .signIn(withCredential: emailCredential)
+      .sink { completion in
+        switch completion {
+        case .finished:
+          print("Finished")
+        case let .failure(error):
+          XCTFail("💥 Something went wrong: \(error)")
+        }
+      } receiveValue: { authDataResult in
+        let user = authDataResult.user
+        XCTAssertNotNil(user)
+        XCTAssertEqual(user.uid, Self.localID)
+        XCTAssertEqual(user.displayName, Self.displayName)
+        XCTAssertEqual(user.email, Self.email)
+        XCTAssertFalse(user.isAnonymous)
+        XCTAssertEqual(user.providerData.count, 0)
+
+        userSignInExpectation.fulfill()
       }
-    }
-    
-    class MockAuthBackend: AuthBackendImplementationMock {
-        
-        var emailLinkSignInCallback: Result<FIREmailLinkSignInResponse, Error> = .success(MockEmailLinkSignInResponse())
-        override func emailLinkSignin(_ request: FIREmailLinkSignInRequest,
-                                      callback: @escaping FIREmailLinkSigninResponseCallback) {
-          XCTAssertEqual(request.apiKey, SignInWithCredentialTests.apiKey)
-          XCTAssertEqual(request.email, SignInWithCredentialTests.email)
-          XCTAssertEqual(request.oobCode, SignInWithCredentialTests.fakeOOBCode)
-            
-            switch emailLinkSignInCallback {
-            case .success(let response):
-                callback(response, nil)
-            case .failure(let error):
-                callback(nil, error)
-            }
-        }
-        
-        override func verifyPhoneNumber(_ request: FIRVerifyPhoneNumberRequest, callback: @escaping FIRVerifyPhoneNumberResponseCallback) {
-            XCTAssertEqual(request.verificationCode, SignInWithCredentialTests.verificationCode)
-            XCTAssertEqual(request.verificationID, SignInWithCredentialTests.verificationID)
-            XCTAssertEqual(request.operation, FIRAuthOperationType.signUpOrSignIn)
-            
-            let response = MockVerifyPhoneNumberResponse()
-            response.isNewUser = true
-            callback(response, nil)
-        }
-        
-        var verifyAssertionCallBack: Result<FIRVerifyAssertionResponse, Error> = .success(MockVerifyAssertionResponse())
-        override func verifyAssertion(_ request: FIRVerifyAssertionRequest,
-                                      callback: @escaping FIRVerifyAssertionResponseCallback) {
-          XCTAssertEqual(request.apiKey, SignInWithCredentialTests.apiKey)
-          XCTAssertEqual(request.providerID, GoogleAuthProviderID)
-          XCTAssertTrue(request.returnSecureToken)
+      .store(in: &cancellables)
 
-            switch verifyAssertionCallBack {
-            case .success(let response):
-                callback(response, nil)
-            case .failure(let error):
-                callback(nil, error)
-            }
-        }
-        
-        var verifyPasswordCallback: Result<FIRVerifyPasswordResponse, Error> = .success(MockVerifyPasswordResponse())
-        override func verifyPassword(_ request: FIRVerifyPasswordRequest, callback: @escaping FIRVerifyPasswordResponseCallback) {
-            XCTAssertEqual(request.apiKey, SignInWithCredentialTests.apiKey)
-            XCTAssertEqual(request.email, SignInWithCredentialTests.email)
-            XCTAssertEqual(request.password, SignInWithCredentialTests.password)
-            XCTAssertTrue(request.returnSecureToken)
-            
-            switch verifyPasswordCallback {
-            case .success(let response):
-                callback(response, nil)
-            case .failure(let error):
-                callback(nil, error)
-            }
-        }
+    // then
+    wait(for: [userSignInExpectation], timeout: expectationTimeout)
+  }
 
-      override func getAccountInfo(_ request: FIRGetAccountInfoRequest,
-                                   callback: @escaping FIRGetAccountInfoResponseCallback) {
-        XCTAssertEqual(request.apiKey, SignInWithCredentialTests.apiKey)
-        XCTAssertEqual(request.accessToken, SignInWithCredentialTests.accessToken)
-        callback(MockGetAccountInfoResponse(), nil)
+  func testSignInWithEmailCredentialFailure() {
+    // given
+    let authBackend = MockAuthBackend()
+    authBackend
+      .verifyPasswordCallback = .failure(FIRAuthErrorUtils.userDisabledError(withMessage: nil))
+    FIRAuthBackend.setBackendImplementation(authBackend)
+
+    var cancellables = Set<AnyCancellable>()
+    let userSignInExpectation = expectation(description: "User disabled")
+
+    let emailCredential = EmailAuthProvider.credential(
+      withEmail: Self.email,
+      password: Self.password
+    )
+
+    // when
+    Auth.auth()
+      .signIn(withCredential: emailCredential)
+      .sink { completion in
+        if case let .failure(error as NSError) = completion {
+          XCTAssertEqual(error.code, AuthErrorCode.userDisabled.rawValue)
+
+          userSignInExpectation.fulfill()
+        }
+      } receiveValue: { authDataResult in
+        XCTFail("💥 result unexpected")
       }
-    }
-    
-    func testSignInWithEmailCredentialSuccess() {
-        // given
-        FIRAuthBackend.setBackendImplementation(MockAuthBackend())
-        
-        var cancellables = Set<AnyCancellable>()
-        let userSignInExpectation = expectation(description: "User signed in")
-        
-        let emailCredential = EmailAuthProvider.credential(withEmail: Self.email, password: Self.password)
-        
-        // when
-        Auth.auth()
-            .signIn(withCredential: emailCredential)
-            .sink { completion in
-                switch completion {
-                case .finished:
-                  print("Finished")
-                case let .failure(error):
-                  XCTFail("💥 Something went wrong: \(error)")
-                }
-            } receiveValue: { authDataResult in
-                let user = authDataResult.user
-                XCTAssertNotNil(user)
-                XCTAssertEqual(user.uid, Self.localID)
-                XCTAssertEqual(user.displayName, Self.displayName)
-                XCTAssertEqual(user.email, Self.email)
-                XCTAssertFalse(user.isAnonymous)
-                XCTAssertEqual(user.providerData.count, 0)
-                
-                userSignInExpectation.fulfill()
-            }
-            .store(in: &cancellables)
-        
-        // then
-        wait(for: [userSignInExpectation], timeout: expectationTimeout)
-    }
-    
-    func testSignInWithEmailCredentialFailure() {
-        // given
-        let authBackend = MockAuthBackend()
-        authBackend.verifyPasswordCallback = .failure(FIRAuthErrorUtils.userDisabledError(withMessage: nil))
-        FIRAuthBackend.setBackendImplementation(authBackend)
-        
-        var cancellables = Set<AnyCancellable>()
-        let userSignInExpectation = expectation(description: "User disabled")
-        
-        let emailCredential = EmailAuthProvider.credential(withEmail: Self.email, password: Self.password)
-        
-        // when
-        Auth.auth()
-            .signIn(withCredential: emailCredential)
-            .sink { completion in
-                if case let .failure(error as NSError) = completion {
-                    XCTAssertEqual(error.code, AuthErrorCode.userDisabled.rawValue)
-                    
-                    userSignInExpectation.fulfill()
-                }
-            } receiveValue: { authDataResult in
-                XCTFail("💥 result unexpected")
-            }
-            .store(in: &cancellables)
-        
-        // then
-        wait(for: [userSignInExpectation], timeout: expectationTimeout)
-    }
-    
-    func testSignInWithEmailCredentialEmptyPassword() {
-        // given
-        FIRAuthBackend.setBackendImplementation(MockAuthBackend())
-        
-        var cancellables = Set<AnyCancellable>()
-        let userSignInExpectation = expectation(description: "User wrong password")
-        
-        let emailCredential = EmailAuthProvider.credential(withEmail: Self.email, password: "")
-        
-        // when
-        Auth.auth()
-            .signIn(withCredential: emailCredential)
-            .sink { completion in
-                if case let .failure(error as NSError) = completion {
-                    XCTAssertEqual(error.code, AuthErrorCode.wrongPassword.rawValue)
-                    
-                    userSignInExpectation.fulfill()
-                }
-            } receiveValue: { authDataResult in
-                XCTFail("💥 result unexpected")
-            }
-            .store(in: &cancellables)
-        
-        // then
-        wait(for: [userSignInExpectation], timeout: expectationTimeout)
-    }
-    
-    func testSignInWithGoogleAccountExistsError() {
-        // given
-        let authBackend = MockAuthBackend()
-        let mockVerifyAssertionResponse = MockVerifyAssertionResponse()
-        mockVerifyAssertionResponse.needConfirmation = true
-        authBackend.verifyAssertionCallBack = .success(mockVerifyAssertionResponse)
-        FIRAuthBackend.setBackendImplementation(authBackend)
-        
-        var cancellables = Set<AnyCancellable>()
-        let userSignInExpectation = expectation(description: "User Google exists")
-        
-        let googleCredential = GoogleAuthProvider.credential(withIDToken: Self.googleID, accessToken: Self.googleAccessToken)
-        
-        // when
-        Auth.auth()
-            .signIn(withCredential: googleCredential)
-            .sink { completion in
-                if case let .failure(error as NSError) = completion {
-                    XCTAssertEqual(error.code, AuthErrorCode.accountExistsWithDifferentCredential.rawValue)
-                    
-                    userSignInExpectation.fulfill()
-                }
-            } receiveValue: { authDataResult in
-                XCTFail("💥 result unexpected")
-            }
-            .store(in: &cancellables)
-        
-        // then
-        wait(for: [userSignInExpectation], timeout: expectationTimeout)
-    }
-    
-    func testSignInWithGoogleCredentialSuccess() {
-        // given
-        FIRAuthBackend.setBackendImplementation(MockAuthBackend())
-    
-        var cancellables = Set<AnyCancellable>()
-        let userSignInExpectation = expectation(description: "User signed in")
-        
-        let googleCredential = GoogleAuthProvider.credential(withIDToken: Self.googleID, accessToken: Self.googleAccessToken)
-        
-        // when
-        Auth.auth()
-            .signIn(withCredential: googleCredential)
-            .sink { completion in
-                switch completion {
-                case .finished:
-                  print("Finished")
-                case let .failure(error):
-                  XCTFail("💥 Something went wrong: \(error)")
-                }
-            } receiveValue: { authDataResult in
-                let user = authDataResult.user
-                XCTAssertNotNil(user)
-                XCTAssertEqual(user.uid, Self.localID)
-                XCTAssertEqual(user.displayName, Self.displayName)
-                XCTAssertEqual(user.email, Self.email)
-                XCTAssertFalse(user.isAnonymous)
-                XCTAssertEqual(user.providerData.count, 0)
-                
-                userSignInExpectation.fulfill()
-            }
-            .store(in: &cancellables)
-        
-        // then
-        wait(for: [userSignInExpectation], timeout: expectationTimeout)
-    }
-    
-    func testSignInWithGoogleCredentialFailure() {
-        // given
-        let authBackend = MockAuthBackend()
-        authBackend.verifyAssertionCallBack = .failure(FIRAuthErrorUtils.emailAlreadyInUseError(withEmail: nil))
-        FIRAuthBackend.setBackendImplementation(authBackend)
-        
-        var cancellables = Set<AnyCancellable>()
-        let userSignInExpectation = expectation(description: "User signed in")
-        
-        let googleCredential = GoogleAuthProvider.credential(withIDToken: Self.googleID, accessToken: Self.googleAccessToken)
-        
-        // when
-        Auth.auth()
-            .signIn(withCredential: googleCredential)
-            .sink { completion in
-                if case let .failure(error as NSError) = completion {
-                    XCTAssertEqual(error.code, AuthErrorCode.emailAlreadyInUse.rawValue)
-                    
-                    userSignInExpectation.fulfill()
-                }
-            } receiveValue: { authDataResult in
-                XCTFail("💥 result unexpected")
-            }
-            .store(in: &cancellables)
-        
-        // then
-        wait(for: [userSignInExpectation], timeout: expectationTimeout)
-    }
-    
-    func testSignInWithCredentialSuccess() {
-        // given
-        FIRAuthBackend.setBackendImplementation(MockAuthBackend())
-    
-        var cancellables = Set<AnyCancellable>()
-        let userSignInExpectation = expectation(description: "User signed in")
-        
-        let googleCredential = GoogleAuthProvider.credential(withIDToken: Self.googleID, accessToken: Self.googleAccessToken)
-        
-        // when
-        Auth.auth()
-            .signIn(withCredential: googleCredential)
-            .sink { completion in
-                switch completion {
-                case .finished:
-                  print("Finished")
-                case let .failure(error):
-                  XCTFail("💥 Something went wrong: \(error)")
-                }
-            } receiveValue: { authDataResult in
-                let user = authDataResult.user
-                XCTAssertNotNil(user)
-                XCTAssertEqual(user.uid, Self.localID)
-                XCTAssertEqual(user.displayName, Self.displayName)
-                XCTAssertEqual(user.email, Self.email)
-                XCTAssertFalse(user.isAnonymous)
-                XCTAssertEqual(user.providerData.count, 0)
-                XCTAssertEqual(authDataResult.additionalUserInfo?.username, Self.displayName)
-                XCTAssertEqual(authDataResult.additionalUserInfo?.profile, Self.googleProfile as [String: NSString])
-                
-                userSignInExpectation.fulfill()
-            }
-            .store(in: &cancellables)
-        
-        // then
-        wait(for: [userSignInExpectation], timeout: expectationTimeout)
-    }
-    
-    func testPhoneAuthSuccess() {
-        // given
-        FIRAuthBackend.setBackendImplementation(MockAuthBackend())
-        
-        var cancellables = Set<AnyCancellable>()
-        let userSignInExpectation = expectation(description: "User signed in")
-        
-        let credential = PhoneAuthProvider.provider().credential(withVerificationID: Self.verificationID, verificationCode: Self.verificationCode)
-        
-        // when
-        Auth.auth()
-            .signIn(withCredential: credential)
-            .sink { completion in
-                switch completion {
-                case .finished:
-                  print("Finished")
-                case let .failure(error):
-                  XCTFail("💥 Something went wrong: \(error)")
-                }
-            } receiveValue: { authDataResult in
-                let user = authDataResult.user
-                XCTAssertNotNil(user)
-                XCTAssertEqual(user.uid, Self.localID)
-                XCTAssertEqual(user.displayName, Self.displayName)
-                XCTAssertEqual(user.email, Self.email)
-                XCTAssertFalse(user.isAnonymous)
-                XCTAssertEqual(user.providerData.count, 0)
-                
-                userSignInExpectation.fulfill()
-            }
-            .store(in: &cancellables)
-        
-        // then
-        wait(for: [userSignInExpectation], timeout: expectationTimeout)
-    }
-    
-    func testPhoneAuthMissingVerificationCode() {
-        // given
-        FIRAuthBackend.setBackendImplementation(MockAuthBackend())
-        
-        var cancellables = Set<AnyCancellable>()
-        let userSignInExpectation = expectation(description: "User missing verification code")
-        
-        let credential = PhoneAuthProvider.provider().credential(withVerificationID: Self.verificationID, verificationCode: "")
-        
-        // when
-        Auth.auth()
-            .signIn(withCredential: credential)
-            .sink { completion in
-                if case let .failure(error as NSError) = completion {
-                    XCTAssertEqual(error.code, AuthErrorCode.missingVerificationCode.rawValue)
-                    
-                    userSignInExpectation.fulfill()
-                }
-            } receiveValue: { authDataResult in
-                XCTFail("💥 result unexpected")
-            }
-            .store(in: &cancellables)
-        
-        // then
-        wait(for: [userSignInExpectation], timeout: expectationTimeout)
-    }
-    
-    func testPhoneAuthMissingVerificationID() {
-        // given
-        FIRAuthBackend.setBackendImplementation(MockAuthBackend())
-        
-        var cancellables = Set<AnyCancellable>()
-        let userSignInExpectation = expectation(description: "User missing verification ID")
-        
-        let credential = PhoneAuthProvider.provider().credential(withVerificationID: "", verificationCode: Self.verificationCode)
-        
-        // when
-        Auth.auth()
-            .signIn(withCredential: credential)
-            .sink { completion in
-                if case let .failure(error as NSError) = completion {
-                    XCTAssertEqual(error.code, AuthErrorCode.missingVerificationID.rawValue)
-                    
-                    userSignInExpectation.fulfill()
-                }
-            } receiveValue: { authDataResult in
-                XCTFail("💥 result unexpected")
-            }
-            .store(in: &cancellables)
-        
-        // then
-        wait(for: [userSignInExpectation], timeout: expectationTimeout)
-    }
-    
-    func testSignInWithEmailLinkCredentialSuccess() {
-        // given
-        FIRAuthBackend.setBackendImplementation(MockAuthBackend())
-        
-        var cancellables = Set<AnyCancellable>()
-        let userSignInExpectation = expectation(description: "User signed in")
-        
-        let emailCrendential = EmailAuthProvider.credential(withEmail: Self.email, link: Self.fakeEmailSignInlink)
-        
-        // when
-        Auth.auth()
-            .signIn(withCredential: emailCrendential)
-            .sink { completion in
-                switch completion {
-                case .finished:
-                  print("Finished")
-                case let .failure(error):
-                  XCTFail("💥 Something went wrong: \(error)")
-                }
-            } receiveValue: { authDataResult in
-                let user = authDataResult.user
-                XCTAssertNotNil(user)
-                XCTAssertEqual(user.refreshToken, Self.refreshToken)
-                XCTAssertEqual(user.displayName, Self.displayName)
-                XCTAssertEqual(user.email, Self.email)
-                XCTAssertFalse(user.isAnonymous)
-                
-                userSignInExpectation.fulfill()
-            }
-            .store(in: &cancellables)
-        
-        // then
-        wait(for: [userSignInExpectation], timeout: expectationTimeout)
-    }
-    
-    func testSignInWithEmailLinkCredentialFailure() {
-        // given
-        let authBackend = MockAuthBackend()
-        authBackend.emailLinkSignInCallback = .failure(FIRAuthErrorUtils.userDisabledError(withMessage: nil))
-        FIRAuthBackend.setBackendImplementation(authBackend)
-        
-        var cancellables = Set<AnyCancellable>()
-        let userSignInExpectation = expectation(description: "User disabled")
-        
-        let emailCrendential = EmailAuthProvider.credential(withEmail: Self.email, link: Self.fakeEmailSignInlink)
-        
-        // when
-        Auth.auth()
-            .signIn(withCredential: emailCrendential)
-            .sink { completion in
-                if case let .failure(error as NSError) = completion {
-                    XCTAssertEqual(error.code, AuthErrorCode.userDisabled.rawValue)
-                    
-                    userSignInExpectation.fulfill()
-                }
-            } receiveValue: { authDataResult in
-                XCTFail("💥 result unexpected")
-            }
-            .store(in: &cancellables)
-        
-        // then
-        wait(for: [userSignInExpectation], timeout: expectationTimeout)
-    }
+      .store(in: &cancellables)
+
+    // then
+    wait(for: [userSignInExpectation], timeout: expectationTimeout)
+  }
+
+  func testSignInWithEmailCredentialEmptyPassword() {
+    // given
+    FIRAuthBackend.setBackendImplementation(MockAuthBackend())
+
+    var cancellables = Set<AnyCancellable>()
+    let userSignInExpectation = expectation(description: "User wrong password")
+
+    let emailCredential = EmailAuthProvider.credential(withEmail: Self.email, password: "")
+
+    // when
+    Auth.auth()
+      .signIn(withCredential: emailCredential)
+      .sink { completion in
+        if case let .failure(error as NSError) = completion {
+          XCTAssertEqual(error.code, AuthErrorCode.wrongPassword.rawValue)
+
+          userSignInExpectation.fulfill()
+        }
+      } receiveValue: { authDataResult in
+        XCTFail("💥 result unexpected")
+      }
+      .store(in: &cancellables)
+
+    // then
+    wait(for: [userSignInExpectation], timeout: expectationTimeout)
+  }
+
+  func testSignInWithGoogleAccountExistsError() {
+    // given
+    let authBackend = MockAuthBackend()
+    let mockVerifyAssertionResponse = MockVerifyAssertionResponse()
+    mockVerifyAssertionResponse.needConfirmation = true
+    authBackend.verifyAssertionCallBack = .success(mockVerifyAssertionResponse)
+    FIRAuthBackend.setBackendImplementation(authBackend)
+
+    var cancellables = Set<AnyCancellable>()
+    let userSignInExpectation = expectation(description: "User Google exists")
+
+    let googleCredential = GoogleAuthProvider.credential(
+      withIDToken: Self.googleID,
+      accessToken: Self.googleAccessToken
+    )
+
+    // when
+    Auth.auth()
+      .signIn(withCredential: googleCredential)
+      .sink { completion in
+        if case let .failure(error as NSError) = completion {
+          XCTAssertEqual(
+            error.code,
+            AuthErrorCode.accountExistsWithDifferentCredential.rawValue
+          )
+
+          userSignInExpectation.fulfill()
+        }
+      } receiveValue: { authDataResult in
+        XCTFail("💥 result unexpected")
+      }
+      .store(in: &cancellables)
+
+    // then
+    wait(for: [userSignInExpectation], timeout: expectationTimeout)
+  }
+
+  func testSignInWithGoogleCredentialSuccess() {
+    // given
+    FIRAuthBackend.setBackendImplementation(MockAuthBackend())
+
+    var cancellables = Set<AnyCancellable>()
+    let userSignInExpectation = expectation(description: "User signed in")
+
+    let googleCredential = GoogleAuthProvider.credential(
+      withIDToken: Self.googleID,
+      accessToken: Self.googleAccessToken
+    )
+
+    // when
+    Auth.auth()
+      .signIn(withCredential: googleCredential)
+      .sink { completion in
+        switch completion {
+        case .finished:
+          print("Finished")
+        case let .failure(error):
+          XCTFail("💥 Something went wrong: \(error)")
+        }
+      } receiveValue: { authDataResult in
+        let user = authDataResult.user
+        XCTAssertNotNil(user)
+        XCTAssertEqual(user.uid, Self.localID)
+        XCTAssertEqual(user.displayName, Self.displayName)
+        XCTAssertEqual(user.email, Self.email)
+        XCTAssertFalse(user.isAnonymous)
+        XCTAssertEqual(user.providerData.count, 0)
+
+        userSignInExpectation.fulfill()
+      }
+      .store(in: &cancellables)
+
+    // then
+    wait(for: [userSignInExpectation], timeout: expectationTimeout)
+  }
+
+  func testSignInWithGoogleCredentialFailure() {
+    // given
+    let authBackend = MockAuthBackend()
+    authBackend
+      .verifyAssertionCallBack = .failure(FIRAuthErrorUtils
+        .emailAlreadyInUseError(withEmail: nil))
+    FIRAuthBackend.setBackendImplementation(authBackend)
+
+    var cancellables = Set<AnyCancellable>()
+    let userSignInExpectation = expectation(description: "User signed in")
+
+    let googleCredential = GoogleAuthProvider.credential(
+      withIDToken: Self.googleID,
+      accessToken: Self.googleAccessToken
+    )
+
+    // when
+    Auth.auth()
+      .signIn(withCredential: googleCredential)
+      .sink { completion in
+        if case let .failure(error as NSError) = completion {
+          XCTAssertEqual(error.code, AuthErrorCode.emailAlreadyInUse.rawValue)
+
+          userSignInExpectation.fulfill()
+        }
+      } receiveValue: { authDataResult in
+        XCTFail("💥 result unexpected")
+      }
+      .store(in: &cancellables)
+
+    // then
+    wait(for: [userSignInExpectation], timeout: expectationTimeout)
+  }
+
+  func testSignInWithCredentialSuccess() {
+    // given
+    FIRAuthBackend.setBackendImplementation(MockAuthBackend())
+
+    var cancellables = Set<AnyCancellable>()
+    let userSignInExpectation = expectation(description: "User signed in")
+
+    let googleCredential = GoogleAuthProvider.credential(
+      withIDToken: Self.googleID,
+      accessToken: Self.googleAccessToken
+    )
+
+    // when
+    Auth.auth()
+      .signIn(withCredential: googleCredential)
+      .sink { completion in
+        switch completion {
+        case .finished:
+          print("Finished")
+        case let .failure(error):
+          XCTFail("💥 Something went wrong: \(error)")
+        }
+      } receiveValue: { authDataResult in
+        let user = authDataResult.user
+        XCTAssertNotNil(user)
+        XCTAssertEqual(user.uid, Self.localID)
+        XCTAssertEqual(user.displayName, Self.displayName)
+        XCTAssertEqual(user.email, Self.email)
+        XCTAssertFalse(user.isAnonymous)
+        XCTAssertEqual(user.providerData.count, 0)
+        XCTAssertEqual(authDataResult.additionalUserInfo?.username, Self.displayName)
+        XCTAssertEqual(
+          authDataResult.additionalUserInfo?.profile,
+          Self.googleProfile as [String: NSString]
+        )
+
+        userSignInExpectation.fulfill()
+      }
+      .store(in: &cancellables)
+
+    // then
+    wait(for: [userSignInExpectation], timeout: expectationTimeout)
+  }
+
+  func testPhoneAuthSuccess() {
+    // given
+    FIRAuthBackend.setBackendImplementation(MockAuthBackend())
+
+    var cancellables = Set<AnyCancellable>()
+    let userSignInExpectation = expectation(description: "User signed in")
+
+    let credential = PhoneAuthProvider.provider()
+      .credential(withVerificationID: Self.verificationID,
+                  verificationCode: Self.verificationCode)
+
+    // when
+    Auth.auth()
+      .signIn(withCredential: credential)
+      .sink { completion in
+        switch completion {
+        case .finished:
+          print("Finished")
+        case let .failure(error):
+          XCTFail("💥 Something went wrong: \(error)")
+        }
+      } receiveValue: { authDataResult in
+        let user = authDataResult.user
+        XCTAssertNotNil(user)
+        XCTAssertEqual(user.uid, Self.localID)
+        XCTAssertEqual(user.displayName, Self.displayName)
+        XCTAssertEqual(user.email, Self.email)
+        XCTAssertFalse(user.isAnonymous)
+        XCTAssertEqual(user.providerData.count, 0)
+
+        userSignInExpectation.fulfill()
+      }
+      .store(in: &cancellables)
+
+    // then
+    wait(for: [userSignInExpectation], timeout: expectationTimeout)
+  }
+
+  func testPhoneAuthMissingVerificationCode() {
+    // given
+    FIRAuthBackend.setBackendImplementation(MockAuthBackend())
+
+    var cancellables = Set<AnyCancellable>()
+    let userSignInExpectation = expectation(description: "User missing verification code")
+
+    let credential = PhoneAuthProvider.provider()
+      .credential(withVerificationID: Self.verificationID, verificationCode: "")
+
+    // when
+    Auth.auth()
+      .signIn(withCredential: credential)
+      .sink { completion in
+        if case let .failure(error as NSError) = completion {
+          XCTAssertEqual(error.code, AuthErrorCode.missingVerificationCode.rawValue)
+
+          userSignInExpectation.fulfill()
+        }
+      } receiveValue: { authDataResult in
+        XCTFail("💥 result unexpected")
+      }
+      .store(in: &cancellables)
+
+    // then
+    wait(for: [userSignInExpectation], timeout: expectationTimeout)
+  }
+
+  func testPhoneAuthMissingVerificationID() {
+    // given
+    FIRAuthBackend.setBackendImplementation(MockAuthBackend())
+
+    var cancellables = Set<AnyCancellable>()
+    let userSignInExpectation = expectation(description: "User missing verification ID")
+
+    let credential = PhoneAuthProvider.provider()
+      .credential(withVerificationID: "", verificationCode: Self.verificationCode)
+
+    // when
+    Auth.auth()
+      .signIn(withCredential: credential)
+      .sink { completion in
+        if case let .failure(error as NSError) = completion {
+          XCTAssertEqual(error.code, AuthErrorCode.missingVerificationID.rawValue)
+
+          userSignInExpectation.fulfill()
+        }
+      } receiveValue: { authDataResult in
+        XCTFail("💥 result unexpected")
+      }
+      .store(in: &cancellables)
+
+    // then
+    wait(for: [userSignInExpectation], timeout: expectationTimeout)
+  }
+
+  func testSignInWithEmailLinkCredentialSuccess() {
+    // given
+    FIRAuthBackend.setBackendImplementation(MockAuthBackend())
+
+    var cancellables = Set<AnyCancellable>()
+    let userSignInExpectation = expectation(description: "User signed in")
+
+    let emailCrendential = EmailAuthProvider.credential(
+      withEmail: Self.email,
+      link: Self.fakeEmailSignInlink
+    )
+
+    // when
+    Auth.auth()
+      .signIn(withCredential: emailCrendential)
+      .sink { completion in
+        switch completion {
+        case .finished:
+          print("Finished")
+        case let .failure(error):
+          XCTFail("💥 Something went wrong: \(error)")
+        }
+      } receiveValue: { authDataResult in
+        let user = authDataResult.user
+        XCTAssertNotNil(user)
+        XCTAssertEqual(user.refreshToken, Self.refreshToken)
+        XCTAssertEqual(user.displayName, Self.displayName)
+        XCTAssertEqual(user.email, Self.email)
+        XCTAssertFalse(user.isAnonymous)
+
+        userSignInExpectation.fulfill()
+      }
+      .store(in: &cancellables)
+
+    // then
+    wait(for: [userSignInExpectation], timeout: expectationTimeout)
+  }
+
+  func testSignInWithEmailLinkCredentialFailure() {
+    // given
+    let authBackend = MockAuthBackend()
+    authBackend
+      .emailLinkSignInCallback = .failure(FIRAuthErrorUtils.userDisabledError(withMessage: nil))
+    FIRAuthBackend.setBackendImplementation(authBackend)
+
+    var cancellables = Set<AnyCancellable>()
+    let userSignInExpectation = expectation(description: "User disabled")
+
+    let emailCrendential = EmailAuthProvider.credential(
+      withEmail: Self.email,
+      link: Self.fakeEmailSignInlink
+    )
+
+    // when
+    Auth.auth()
+      .signIn(withCredential: emailCrendential)
+      .sink { completion in
+        if case let .failure(error as NSError) = completion {
+          XCTAssertEqual(error.code, AuthErrorCode.userDisabled.rawValue)
+
+          userSignInExpectation.fulfill()
+        }
+      } receiveValue: { authDataResult in
+        XCTFail("💥 result unexpected")
+      }
+      .store(in: &cancellables)
+
+    // then
+    wait(for: [userSignInExpectation], timeout: expectationTimeout)
+  }
 }

--- a/FirebaseCombineSwift/Tests/Unit/FirebaseCombineSwift-unit-Bridging-Header.h
+++ b/FirebaseCombineSwift/Tests/Unit/FirebaseCombineSwift-unit-Bridging-Header.h
@@ -15,7 +15,6 @@
 #import "SharedTestUtilities/FIROptionsMock.h"
 
 #import <FirebaseAuth/FIREmailAuthProvider.h>
-#import "FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h"
 #import "FirebaseAuth/Sources/Auth/FIRAuthGlobalWorkQueue.h"
 #import "FirebaseAuth/Sources/AuthProvider/OAuth/FIROAuthCredential_Internal.h"
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"

--- a/FirebaseCombineSwift/Tests/Unit/FirebaseCombineSwift-unit-Bridging-Header.h
+++ b/FirebaseCombineSwift/Tests/Unit/FirebaseCombineSwift-unit-Bridging-Header.h
@@ -14,6 +14,8 @@
 
 #import "SharedTestUtilities/FIROptionsMock.h"
 
+#import <FirebaseAuth/FIREmailAuthProvider.h>
+#import "FirebaseAuth/Sources/Utilities/FIRAuthErrorUtils.h"
 #import "FirebaseAuth/Sources/Auth/FIRAuthGlobalWorkQueue.h"
 #import "FirebaseAuth/Sources/AuthProvider/OAuth/FIROAuthCredential_Internal.h"
 #import "FirebaseAuth/Sources/Backend/FIRAuthBackend.h"


### PR DESCRIPTION
Proposal for Combine support to authenticate with Firebase using third-party credentials.

```swift 
   func sign(_ signIn: GIDSignIn!, didSignInFor user: GIDGoogleUser!, withError error: Error?) {
       // ...
       if let error = error {
         // ...
         return
       }

       guard let authentication = user.authentication else { return }
       let credential = GoogleAuthProvider.credential(withIDToken: authentication.idToken,
                                                            accessToken: authentication.accessToken)
        Auth.auth()
            .signIn(withCredential: credential)
            .mapError { $0 as NSError }
            .tryCatch(handleError)
            .sink { /* ... */ } receiveValue: {  /* ... */  }
            .store(in: &subscriptions)
    }
    
    private func handleError(_ error: NSError) throws -> AnyPublisher<AuthDataResult, Error> {
        guard isMFAEnabled && error.code == AuthErrorCode.secondFactorRequired.rawValue
        else { throw error }
        
        // The user is a multi-factor user. Second factor challenge is required.
        let resolver = error.userInfo[AuthErrorUserInfoMultiFactorResolverKey] as! MultiFactorResolver
        let displayNameString = resolver.hints.compactMap(\.displayName).joined(separator: " ")
        
        return showTextInputPrompt(withMessage: "Select factor to sign in\n\(displayNameString)")
            .compactMap { displayName in
                resolver.hints.first(where: { displayName == $0.displayName }) as? PhoneMultiFactorInfo
            }
            .flatMap { [unowned self] factorInfo in
                PhoneAuthProvider.provider()
                    .verifyPhoneNumber(withMultiFactorInfo: factorInfo, multiFactorSession: resolver.session)
                    .zip(self.showTextInputPrompt(withMessage: "Verification code for \(factorInfo.displayName ?? "")"))
                    .map { (verificationID, verificationCode) in
                        let credential = PhoneAuthProvider.provider().credential(withVerificationID: verificationID, 
                                                                                 verificationCode: verificationCode)
                        return PhoneMultiFactorGenerator.assertion(with: credential)
                    }
            }.flatMap { assertion in
                resolver.resolveSignIn(withAssertion: assertion)
            }.eraseToAnyPublisher()
    }
```