### PR TITLE
GDT test server: stop server on dealloc only if running

### DIFF
--- a/GoogleDataTransport/GDTCCTTests/Unit/TestServer/GDTCCTTestServer.m
+++ b/GoogleDataTransport/GDTCCTTests/Unit/TestServer/GDTCCTTestServer.m
@@ -49,7 +49,9 @@
 }
 
 - (void)dealloc {
-  [_server stop];
+  if (_server.isRunning) {
+    [_server stop];
+  }
 }
 
 - (void)start {


### PR DESCRIPTION
Open source version of cl/350236632.

#no-changelog