### PR TITLE
Add missing source to Perf podspec

### DIFF
--- a/FirebasePerformance.podspec
+++ b/FirebasePerformance.podspec
@@ -27,6 +27,7 @@ Firebase Performance library to measure performance of Mobile and Web Apps.
     base_dir + 'Sources/**/*.[mh]',
     base_dir + 'ProtoSupport/**/*.[mh]',
     'FirebaseCore/Sources/Private/*.h',
+    'FirebaseInstallations/Source/Library/Private/*.h',
     'FirebaseRemoteConfig/Sources/Private/*.h',
     'GoogleDataTransport/GDTCORLibrary/Internal/*.h',
     'GoogleUtilities/ISASwizzler/Private/*.h',


### PR DESCRIPTION
Confirmed that this fix enables publishing the podspec:

```
$ pod repo push --skip-tests --use-json  cpdc-internal-firebase  FirebasePerformance.podspec --sources=sso://cpdc-internal/firebase.git,https://cdn.cocoapods.org

Validating spec
 -> FirebasePerformance (7.4.0)
    - WARN  | url: The URL (https://twitter.com/Firebase) is not reachable.
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | xcodebuild:  note: Building targets in parallel
    - NOTE  | xcodebuild:  note: Using codesigning identity override: -
    - NOTE  | [iOS] xcodebuild:  note: Planning build
    - NOTE  | [iOS] xcodebuild:  note: Constructing build description
    - NOTE  | [iOS] xcodebuild:  warning: Skipping code signing because the target does not have an Info.plist file and one is not being generated automatically. (in target 'App' from project 'App')

Updating the `cpdc-internal-firebase' repo


Adding the spec to the `cpdc-internal-firebase' repo

 - [Add] FirebasePerformance (7.4.0)

Pushing the `cpdc-internal-firebase' repo
```

#no-changelog