### PR TITLE
Small text change to SwiftPackageManager.md

### DIFF
--- a/SwiftPackageManager.md
+++ b/SwiftPackageManager.md
@@ -52,7 +52,7 @@ https://github.com/firebase/firebase-ios-sdk/issues/6472#issuecomment-694449182.
 <img src="docs/resources/SPMObjC.png">
 
 If you're using FirebaseCrashlytics, use
-`${BUILD_DIR}SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run`
+`${BUILD_DIR}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run`
 as the run script that allows Xcode to upload your project's dSYM files.
 
 Another option is to use the


### PR DESCRIPTION
Add a missing '/' into the Run Script for Swift Package Manager installation. I needed it for my build.
