### PR TITLE
Firebase pod fix for tvOS and macOS

### DIFF
--- a/Firebase.podspec
+++ b/Firebase.podspec
@@ -32,6 +32,8 @@ Simplify your app development, grow your user base, and monetize more effectivel
 
   s.subspec 'Core' do |ss|
     ss.ios.deployment_target = '9.0'
+    ss.osx.deployment_target = '10.12'
+    ss.tvos.deployment_target = '10.0'
     ss.ios.dependency 'FirebaseAnalytics', '7.3.0'
     ss.dependency 'Firebase/CoreOnly'
   end


### PR DESCRIPTION
When the Firebase pod was installed and other Firebase pods installed directly (not via subspec with `Firebase/`, the Firebase module was not getting installed for tvOS and macOS. 

This should be a rare bug in practice, but it was exposed by a crash in the ZipBuilder when Firebase.h was not installed after a tvOS installation.

#no-changelog