### PR TITLE
Revert "Enable FIAM tvos slice in zip build (#7261)"

### DIFF
--- a/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -42,7 +42,7 @@ public let shared = Manifest(
     Pod("FirebaseFirestore", allowWarnings: true, zip: true),
     Pod("FirebaseFirestoreSwift", isBeta: true),
     Pod("FirebaseFunctions", zip: true),
-    Pod("FirebaseInAppMessaging", isBeta: true, platforms: ["ios", "tvos"], zip: true),
+    Pod("FirebaseInAppMessaging", isBeta: true, platforms: ["ios"], zip: true),
     Pod("FirebaseMessaging", zip: true),
     Pod("FirebasePerformance", platforms: ["ios"], zip: true),
     Pod("FirebaseStorage", zip: true),


### PR DESCRIPTION
FIAM tvOS support is pending CI configuration.

Also, the zip builder needs to add support for different resources for different platforms. FIAM has a different storyboard for tvOS and iOS.