### PR TITLE
ZipBuilder workaround

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ZipBuilder.swift
@@ -244,7 +244,12 @@ struct ZipBuilder {
           }
         }
         // Union all pods built across platforms.
-        podsBuilt[podName] = podInfo
+        // Be conservative and favor iOS if it exists - and workaround
+        // bug where Firebase.h doesn't get installed for tvOS and macOS.
+        // Fixed in #7284.
+        if podsBuilt[podName] == nil {
+          podsBuilt[podName] = podInfo
+        }
       }
     }
 


### PR DESCRIPTION
Workaround for crash exposed by different tvOS installation. Fixed in #7284 

Keep the workaround longer term to be conservative about preferring the installation form the first platform (iOS) instead of the last (tvOS).

#no-changelog