### PR TITLE
Iterate through all elements of target array for FieldValue::ArrayRemove

### DIFF
--- a/Firestore/core/src/model/transform_operation.cc
+++ b/Firestore/core/src/model/transform_operation.cc
@@ -251,8 +251,8 @@ FieldValue ArrayTransform::Rep::Apply(
       }
     } else {
       HARD_ASSERT(type_ == Type::ArrayRemove);
-      for (int i = 0; i < static_cast<int>(result.size());) {
-        if (type_ == Type::ArrayRemove && element == result.at(i)) {
+      for (size_t i = 0; i < result.size();) {
+        if (element == result.at(i)) {
           result.erase(result.cbegin() + i);
         } else {
           ++i;

--- a/Firestore/core/src/model/transform_operation.cc
+++ b/Firestore/core/src/model/transform_operation.cc
@@ -251,8 +251,12 @@ FieldValue ArrayTransform::Rep::Apply(
       }
     } else {
       HARD_ASSERT(type_ == Type::ArrayRemove);
-      if (pos != result.end()) {
-        result.erase(pos);
+      for (int i = 0; i < static_cast<int>(result.size());) {
+        if (type_ == Type::ArrayRemove && element == result.at(i)) {
+          result.erase(result.cbegin() + i);
+        } else {
+          ++i;
+        }
       }
     }
   }


### PR DESCRIPTION
The previous implementation only deleted the first instance of the ArrayRemove element appearing in the document array. This PR removes all appearances of the ArrayRemove element from the document array.

#no-changelog