### PR TITLE
Twitter dont block main on file ops

### DIFF
--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -410,10 +410,16 @@ static void (^reportSentCallback)(void);
   NSOperationQueue *__weak queue = _operationQueue;
   FBLPromise *__weak unsentReportsHandled = _unsentReportsHandled;
   promise = [promise then:^id _Nullable(NSNumber *_Nullable value) {
-    [queue waitUntilAllOperationsAreFinished];
-    // Signal that to callers of processReports that everything is finished.
-    [unsentReportsHandled fulfill:nil];
-    return value;
+      FBLPromise *allOpsFinished = [FBLPromise pendingPromise];
+      [queue addOperationWithBlock:^{
+          [allOpsFinished fulfill:nil];
+      }];
+
+      return [allOpsFinished onQueue:dispatch_get_main_queue() then:^id _Nullable(id  _Nullable allOpsFinishedValue) {
+          // Signal that to callers of processReports that everything is finished.
+          [unsentReportsHandled fulfill:nil];
+          return value;
+      }];
   }];
 
   return promise;

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -423,7 +423,7 @@ static void (^reportSentCallback)(void);
     }];
   }];
 
-    return promise;
+  return promise;
 }
 
 - (void)checkAndRotateInstallUUIDIfNeededWithReport:(FIRCLSInternalReport *)report {

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -410,19 +410,20 @@ static void (^reportSentCallback)(void);
   NSOperationQueue *__weak queue = _operationQueue;
   FBLPromise *__weak unsentReportsHandled = _unsentReportsHandled;
   promise = [promise then:^id _Nullable(NSNumber *_Nullable value) {
-      FBLPromise *allOpsFinished = [FBLPromise pendingPromise];
-      [queue addOperationWithBlock:^{
-          [allOpsFinished fulfill:nil];
-      }];
+    FBLPromise *allOpsFinished = [FBLPromise pendingPromise];
+    [queue addOperationWithBlock:^{
+      [allOpsFinished fulfill:nil];
+    }];
 
-      return [allOpsFinished onQueue:dispatch_get_main_queue() then:^id _Nullable(id  _Nullable allOpsFinishedValue) {
-          // Signal that to callers of processReports that everything is finished.
-          [unsentReportsHandled fulfill:nil];
-          return value;
-      }];
+    return [allOpsFinished onQueue:dispatch_get_main_queue()
+                              then:^id _Nullable(id  _Nullable allOpsFinishedValue) {
+      // Signal that to callers of processReports that everything is finished.
+      [unsentReportsHandled fulfill:nil];
+      return value;
+    }];
   }];
 
-  return promise;
+    return promise;
 }
 
 - (void)checkAndRotateInstallUUIDIfNeededWithReport:(FIRCLSInternalReport *)report {

--- a/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
+++ b/Crashlytics/Crashlytics/Controllers/FIRCLSReportManager.m
@@ -416,11 +416,12 @@ static void (^reportSentCallback)(void);
     }];
 
     return [allOpsFinished onQueue:dispatch_get_main_queue()
-                              then:^id _Nullable(id  _Nullable allOpsFinishedValue) {
-      // Signal that to callers of processReports that everything is finished.
-      [unsentReportsHandled fulfill:nil];
-      return value;
-    }];
+                              then:^id _Nullable(id _Nullable allOpsFinishedValue) {
+                                // Signal that to callers of processReports that everything is
+                                // finished.
+                                [unsentReportsHandled fulfill:nil];
+                                return value;
+                              }];
   }];
 
   return promise;


### PR DESCRIPTION
Hello. We see the code referenced here blocking the main thread at startup and causing our watchdog system to kill the app. Synchronously waiting for filesystem operations to complete from the main thread can be safely removed.

![image (3)](https://user-images.githubusercontent.com/1906598/104527873-aa0a1e80-55ba-11eb-8bfc-2434c00f5298.png)
