### PR TITLE
Add Crashlytics bulk key/value logging API

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.h
@@ -75,6 +75,7 @@ void FIRCLSUserLoggingInit(FIRCLSUserLoggingReadOnlyContext* roContext,
 
 #ifdef __OBJC__
 void FIRCLSUserLoggingRecordUserKeyValue(NSString* key, id value);
+void FIRCLSUserLoggingRecordUserKeysAndValues(NSDictionary* keysAndValues);
 void FIRCLSUserLoggingRecordInternalKeyValue(NSString* key, id value);
 void FIRCLSUserLoggingWriteInternalKeyValue(NSString* key, NSString* value);
 
@@ -88,6 +89,10 @@ void FIRCLSUserLoggingRecordKeyValue(NSString* key,
                                      id value,
                                      FIRCLSUserLoggingKVStorage* storage,
                                      uint32_t* counter);
+
+void FIRCLSUserLoggingRecordKeysAndValues(NSDictionary* keysAndValues,
+                                          FIRCLSUserLoggingKVStorage* storage,
+                                          uint32_t* counter);
 
 void FIRCLSUserLoggingWriteAndCheckABFiles(FIRCLSUserLoggingABStorage* storage,
                                            const char** activePath,

--- a/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSUserLogging.m
@@ -36,10 +36,9 @@ NSString *const FIRCLSDevelopmentPlatformVersionKey =
 const uint32_t FIRCLSUserLoggingMaxKVEntries = 64;
 
 #pragma mark - Prototypes
-static void FIRCLSUserLoggingWriteKeyValue(NSString *key,
-                                           NSString *value,
-                                           FIRCLSUserLoggingKVStorage *storage,
-                                           uint32_t *counter);
+static void FIRCLSUserLoggingWriteKeysAndValues(NSDictionary *keysAndValues,
+                                                FIRCLSUserLoggingKVStorage *storage,
+                                                uint32_t *counter);
 static void FIRCLSUserLoggingCheckAndSwapABFiles(FIRCLSUserLoggingABStorage *storage,
                                                  const char **activePath,
                                                  off_t fileSize);
@@ -68,13 +67,21 @@ void FIRCLSUserLoggingRecordInternalKeyValue(NSString *key, id value) {
 
 void FIRCLSUserLoggingWriteInternalKeyValue(NSString *key, NSString *value) {
   // Unsynchronized - must be run on the correct queue
-  FIRCLSUserLoggingWriteKeyValue(key, value, &_firclsContext.readonly->logging.internalKVStorage,
-                                 &_firclsContext.writable->logging.internalKVCount);
+  NSDictionary *keysAndValues = key ? @{key : value ?: [NSNull null]} : nil;
+  FIRCLSUserLoggingWriteKeysAndValues(keysAndValues,
+                                      &_firclsContext.readonly->logging.internalKVStorage,
+                                      &_firclsContext.writable->logging.internalKVCount);
 }
 
 void FIRCLSUserLoggingRecordUserKeyValue(NSString *key, id value) {
   FIRCLSUserLoggingRecordKeyValue(key, value, &_firclsContext.readonly->logging.userKVStorage,
                                   &_firclsContext.writable->logging.userKVCount);
+}
+
+void FIRCLSUserLoggingRecordUserKeysAndValues(NSDictionary *keysAndValues) {
+  FIRCLSUserLoggingRecordKeysAndValues(keysAndValues,
+                                       &_firclsContext.readonly->logging.userKVStorage,
+                                       &_firclsContext.writable->logging.userKVCount);
 }
 
 static id FIRCLSUserLoggingGetComponent(NSDictionary *entry,
@@ -140,6 +147,30 @@ NSDictionary *FIRCLSUserLoggingGetCompactedKVEntries(FIRCLSUserLoggingKVStorage 
   return finalKVSet;
 }
 
+static void FIRCLSUserLoggingWriteKVEntriesToFile(
+    NSDictionary<NSString *, NSString *> *keysAndValues, BOOL shouldHexEncode, FIRCLSFile *file) {
+  for (NSString *key in keysAndValues) {
+    NSString *valueObject = [keysAndValues objectForKey:key];
+
+    // map `NSNull` into nil
+    const char *value = (valueObject == (NSString *)[NSNull null] ? nil : [valueObject UTF8String]);
+
+    FIRCLSFileWriteSectionStart(file, "kv");
+    FIRCLSFileWriteHashStart(file);
+
+    if (shouldHexEncode) {
+      FIRCLSFileWriteHashEntryHexEncodedString(file, "key", [key UTF8String]);
+      FIRCLSFileWriteHashEntryHexEncodedString(file, "value", value);
+    } else {
+      FIRCLSFileWriteHashEntryString(file, "key", [key UTF8String]);
+      FIRCLSFileWriteHashEntryString(file, "value", value);
+    }
+
+    FIRCLSFileWriteHashEnd(file);
+    FIRCLSFileWriteSectionEnd(file);
+  }
+}
+
 void FIRCLSUserLoggingCompactKVEntries(FIRCLSUserLoggingKVStorage *storage) {
   if (!FIRCLSIsValidPointer(storage)) {
     FIRCLSSDKLogError("Error: storage invalid\n");
@@ -173,18 +204,7 @@ void FIRCLSUserLoggingCompactKVEntries(FIRCLSUserLoggingKVStorage *storage) {
         [finalKVs dictionaryWithValuesForKeys:[keys subarrayWithRange:NSMakeRange(0, maxCount)]];
   }
 
-  for (NSString *key in finalKVs) {
-    NSString *value = [finalKVs objectForKey:key];
-
-    FIRCLSFileWriteSectionStart(&file, "kv");
-    FIRCLSFileWriteHashStart(&file);
-    // tricky - the values stored incrementally have already been hex-encoded
-    FIRCLSFileWriteHashEntryString(&file, "key", [key UTF8String]);
-    FIRCLSFileWriteHashEntryString(&file, "value", [value UTF8String]);
-    FIRCLSFileWriteHashEnd(&file);
-    FIRCLSFileWriteSectionEnd(&file);
-  }
-
+  FIRCLSUserLoggingWriteKVEntriesToFile(finalKVs, false, &file);
   FIRCLSFileClose(&file);
 
   if (unlink(storage->incrementalPath) != 0) {
@@ -202,33 +222,59 @@ void FIRCLSUserLoggingRecordKeyValue(NSString *key,
     return;
   }
 
-  // ensure that any invalid pointer is actually set to nil
-  if (!FIRCLSIsValidPointer(value) && value != nil) {
-    FIRCLSSDKLogWarn("Bad value pointer being clamped to nil\n");
-    value = nil;
-  }
+  NSDictionary *keysAndValues = @{key : (value ?: [NSNull null])};
+  FIRCLSUserLoggingRecordKeysAndValues(keysAndValues, storage, counter);
+}
 
+void FIRCLSUserLoggingRecordKeysAndValues(NSDictionary *keysAndValues,
+                                          FIRCLSUserLoggingKVStorage *storage,
+                                          uint32_t *counter) {
   if (!FIRCLSContextIsInitialized()) {
     return;
   }
 
-  if ([value respondsToSelector:@selector(description)]) {
-    value = [value description];
-  } else {
-    // passing nil will result in a JSON null being written, which is deserialized as [NSNull null],
-    // signaling to remove the key during compaction
-    value = nil;
+  if (keysAndValues.count == 0) {
+    FIRCLSSDKLogWarn("User provided empty key/value dictionary\n");
+    return;
+  }
+
+  if (!FIRCLSIsValidPointer(keysAndValues)) {
+    FIRCLSSDKLogWarn("User provided bad key/value dictionary\n");
+    return;
+  }
+
+  NSMutableDictionary *sanitizedKeysAndValues = [keysAndValues mutableCopy];
+  for (NSString *key in keysAndValues) {
+    if (!FIRCLSIsValidPointer(key)) {
+      FIRCLSSDKLogWarn("User provided bad key\n");
+      return;
+    }
+
+    id value = keysAndValues[key];
+
+    // ensure that any invalid pointer is actually set to nil
+    if (!FIRCLSIsValidPointer(value) && value != nil) {
+      FIRCLSSDKLogWarn("Bad value pointer being clamped to nil\n");
+      sanitizedKeysAndValues[key] = [NSNull null];
+    }
+
+    if ([value respondsToSelector:@selector(description)]) {
+      sanitizedKeysAndValues[key] = [value description];
+    } else {
+      // passing nil will result in a JSON null being written, which is deserialized as [NSNull
+      // null], signaling to remove the key during compaction
+      sanitizedKeysAndValues[key] = [NSNull null];
+    }
   }
 
   dispatch_sync(FIRCLSGetLoggingQueue(), ^{
-    FIRCLSUserLoggingWriteKeyValue(key, value, storage, counter);
+    FIRCLSUserLoggingWriteKeysAndValues(sanitizedKeysAndValues, storage, counter);
   });
 }
 
-static void FIRCLSUserLoggingWriteKeyValue(NSString *key,
-                                           NSString *value,
-                                           FIRCLSUserLoggingKVStorage *storage,
-                                           uint32_t *counter) {
+static void FIRCLSUserLoggingWriteKeysAndValues(NSDictionary *keysAndValues,
+                                                FIRCLSUserLoggingKVStorage *storage,
+                                                uint32_t *counter) {
   FIRCLSFile file;
 
   if (!FIRCLSIsValidPointer(storage) || !FIRCLSIsValidPointer(counter)) {
@@ -241,16 +287,10 @@ static void FIRCLSUserLoggingWriteKeyValue(NSString *key,
     return;
   }
 
-  FIRCLSFileWriteSectionStart(&file, "kv");
-  FIRCLSFileWriteHashStart(&file);
-  FIRCLSFileWriteHashEntryHexEncodedString(&file, "key", [key UTF8String]);
-  FIRCLSFileWriteHashEntryHexEncodedString(&file, "value", [value UTF8String]);
-  FIRCLSFileWriteHashEnd(&file);
-  FIRCLSFileWriteSectionEnd(&file);
-
+  FIRCLSUserLoggingWriteKVEntriesToFile(keysAndValues, true, &file);
   FIRCLSFileClose(&file);
 
-  *counter += 1;
+  *counter += keysAndValues.count;
   if (*counter >= storage->maxIncrementalCount) {
     dispatch_async(FIRCLSGetLoggingQueue(), ^{
       FIRCLSUserLoggingCompactKVEntries(storage);

--- a/Crashlytics/Crashlytics/FIRCrashlytics.m
+++ b/Crashlytics/Crashlytics/FIRCrashlytics.m
@@ -270,6 +270,10 @@ NSString *const FIRCLSGoogleTransportMappingID = @"1206";
   FIRCLSUserLoggingRecordUserKeyValue(key, value);
 }
 
+- (void)setCustomKeysAndValues:(NSDictionary *)keysAndValues {
+  FIRCLSUserLoggingRecordUserKeysAndValues(keysAndValues);
+}
+
 #pragma mark - API: Development Platform
 // These two methods are depercated by our own API, so
 // its ok to implement them

--- a/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlytics.h
+++ b/Crashlytics/Crashlytics/Public/FirebaseCrashlytics/FIRCrashlytics.h
@@ -84,6 +84,15 @@ NS_SWIFT_NAME(Crashlytics)
 - (void)setCustomValue:(id)value forKey:(NSString *)key;
 
 /**
+ * Sets custom keys and values to be associated with subsequent fatal and non-fatal reports.
+ * The objects in the dictionary are converted to strings. This is
+ * typically done by calling "-[NSObject description]".
+ *
+ * @param keysAndValues The values to be associated with the corresponding keys
+ */
+- (void)setCustomKeysAndValues:(NSDictionary *)keysAndValues;
+
+/**
  * Records a user ID (identifier) that's associated with subsequent fatal and non-fatal reports.
  *
  * If you want to associate a crash with a specific user, we recommend specifying an arbitrary


### PR DESCRIPTION
The key/value logging API atomically writes out changes to
disk. If you set several keys and values consecutively, this
generates a large number of file io operations.

Add an API that accepts an NSDictionary of keys and values
that are written together, reducing the number of file io
ops.
