### PR TITLE
Remove dynamic framework count from diagnostics.

### DIFF
--- a/Example/CoreDiagnostics/Tests/FIRCoreDiagnosticsTest.m
+++ b/Example/CoreDiagnostics/Tests/FIRCoreDiagnosticsTest.m
@@ -197,7 +197,7 @@ extern void FIRPopulateProtoWithInfoPlistValues(
   config->has_app_count = 1;
   config->use_default_app = 1;
   config->has_use_default_app = 1;
-  config->has_dynamic_framework_count = 0; // Removed from payload.
+  config->has_dynamic_framework_count = 0;  // Removed from payload.
   config->apple_framework_version = FIREncodeString(combinedVersions);
   NSString *minVersion = [[NSBundle mainBundle] infoDictionary][@"MinimumOSVersion"];
   if (minVersion) {

--- a/Example/CoreDiagnostics/Tests/FIRCoreDiagnosticsTest.m
+++ b/Example/CoreDiagnostics/Tests/FIRCoreDiagnosticsTest.m
@@ -160,7 +160,6 @@ extern void FIRPopulateProtoWithInfoPlistValues(
   });
   icoreConfiguration.using_gdt = 1;
   icoreConfiguration.has_using_gdt = 1;
-  FIRPopulateProtoWithNumberOfLinkedFrameworks(&icoreConfiguration);
   FIRPopulateProtoWithInfoPlistValues(&icoreConfiguration);
   icoreConfiguration.configuration_type =
       logs_proto_mobilesdk_ios_ICoreConfiguration_ConfigurationType_CORE;
@@ -198,22 +197,7 @@ extern void FIRPopulateProtoWithInfoPlistValues(
   config->has_app_count = 1;
   config->use_default_app = 1;
   config->has_use_default_app = 1;
-
-  int numFrameworks = -1;  // Subtract the app binary itself.
-  unsigned int numImages;
-  const char **imageNames = objc_copyImageNames(&numImages);
-  for (unsigned int i = 0; i < numImages; i++) {
-    NSString *imageName = [NSString stringWithUTF8String:imageNames[i]];
-    if ([imageName rangeOfString:@"System/Library"].length != 0        // Apple .frameworks
-        || [imageName rangeOfString:@"Developer/Library"].length != 0  // Xcode debug .frameworks
-        || [imageName rangeOfString:@"usr/lib"].length != 0) {         // Public .dylibs
-      continue;
-    }
-    numFrameworks++;
-  }
-  free(imageNames);
-  config->dynamic_framework_count = numFrameworks;
-  config->has_dynamic_framework_count = 1;
+  config->has_dynamic_framework_count = 0; // Removed from payload.
   config->apple_framework_version = FIREncodeString(combinedVersions);
   NSString *minVersion = [[NSBundle mainBundle] infoDictionary][@"MinimumOSVersion"];
   if (minVersion) {

--- a/Firebase/CoreDiagnostics/FIRCDLibrary/FIRCoreDiagnostics.m
+++ b/Firebase/CoreDiagnostics/FIRCDLibrary/FIRCoreDiagnostics.m
@@ -454,29 +454,6 @@ void FIRPopulateProtoWithInstalledServices(logs_proto_mobilesdk_ios_ICoreConfigu
   config->sdk_service_installed_count = (int32_t)sdkServiceInstalledArray.count;
 }
 
-/** Populates the proto with the number of linked frameworks.
- *
- * @param config The proto to populate.
- */
-void FIRPopulateProtoWithNumberOfLinkedFrameworks(
-    logs_proto_mobilesdk_ios_ICoreConfiguration *config) {
-  int numFrameworks = -1;  // Subtract the app binary itself.
-  unsigned int numImages;
-  const char **imageNames = objc_copyImageNames(&numImages);
-  for (unsigned int i = 0; i < numImages; i++) {
-    NSString *imageName = [NSString stringWithUTF8String:imageNames[i]];
-    if ([imageName rangeOfString:@"System/Library"].length != 0        // Apple .frameworks
-        || [imageName rangeOfString:@"Developer/Library"].length != 0  // Xcode debug .frameworks
-        || [imageName rangeOfString:@"usr/lib"].length != 0) {         // Public .dylibs
-      continue;
-    }
-    numFrameworks++;
-  }
-  free(imageNames);
-  config->dynamic_framework_count = numFrameworks;
-  config->has_dynamic_framework_count = 1;
-}
-
 /** Populates the proto with Info.plist values.
  *
  * @param config The proto to populate.
@@ -532,7 +509,6 @@ void FIRPopulateProtoWithInfoPlistValues(logs_proto_mobilesdk_ios_ICoreConfigura
     FIRPopulateProtoWithInfoFromUserInfoParams(&icore_config, diagnosticObjects);
     FIRPopulateProtoWithCommonInfoFromApp(&icore_config, diagnosticObjects);
     FIRPopulateProtoWithInstalledServices(&icore_config);
-    FIRPopulateProtoWithNumberOfLinkedFrameworks(&icore_config);
     FIRPopulateProtoWithInfoPlistValues(&icore_config);
     [self setHeartbeatFlagIfNeededToConfig:&icore_config];
 

--- a/Firebase/CoreDiagnostics/FIRCDLibrary/FIRCoreDiagnostics.m
+++ b/Firebase/CoreDiagnostics/FIRCDLibrary/FIRCoreDiagnostics.m
@@ -37,7 +37,7 @@ static GULLoggerService kFIRCoreDiagnostics = @"[FirebaseCoreDiagnostics/FIRCore
 
 #ifdef FIREBASE_BUILD_ZIP_FILE
 static BOOL kUsingZipFile = YES;
-#else  // FIREBASE_BUILD_ZIP_FILE
+#else   // FIREBASE_BUILD_ZIP_FILE
 static BOOL kUsingZipFile = NO;
 #endif  // FIREBASE_BUILD_ZIP_FILE
 

--- a/FirebaseCore/CHANGELOG.md
+++ b/FirebaseCore/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Unreleased
+- [fixed] Fixed potential deadlock with objc_copyImageNames call. (#7310)
 # Firebase 7.4.0
 - [changed] Patch update to nanopb 0.3.9.7 that fixes a memory leak and other issues. (#7090)
 - [added] Zip distribution now includes community supported macOS and tvOS libraries. Product


### PR DESCRIPTION
This was previously used to help determine if Firebase should switch to
using dynamic frameworks, but now developers have the option themselves.

Fixes #7310
