### PR TITLE
Binary image performance improvements

### DIFF
--- a/Crashlytics/Crashlytics/Components/FIRCLSContext.m
+++ b/Crashlytics/Crashlytics/Components/FIRCLSContext.m
@@ -182,13 +182,17 @@ bool FIRCLSContextInitialize(FIRCLSInternalReport* report,
     FIRCLSUserLoggingInit(&_firclsContext.readonly->logging, &_firclsContext.writable->logging);
   });
 
-  dispatch_group_async(group, queue, ^{
-    _firclsContext.readonly->binaryimage.path =
-        FIRCLSContextAppendToRoot(rootPath, FIRCLSReportBinaryImageFile);
+  // Only write out binary images if the current ones have expired or this is the first run of the
+  // app.
+  if ([settings doesNeedNewBinaryImages]) {
+    dispatch_group_async(group, queue, ^{
+      _firclsContext.readonly->binaryimage.path =
+        [fileManager.binaryImageFilePath cStringUsingEncoding:NSASCIIStringEncoding];
 
-    FIRCLSBinaryImageInit(&_firclsContext.readonly->binaryimage,
-                          &_firclsContext.writable->binaryImage);
-  });
+      FIRCLSBinaryImageInit(&_firclsContext.readonly->binaryimage,
+                            &_firclsContext.writable->binaryImage);
+    });
+  }
 
   dispatch_group_async(group, queue, ^{
     NSString* rootPath = [NSString stringWithUTF8String:initData->previouslyCrashedFileRootPath];

--- a/Crashlytics/Crashlytics/Models/FIRCLSFileManager.h
+++ b/Crashlytics/Crashlytics/Models/FIRCLSFileManager.h
@@ -33,6 +33,16 @@
 @property(nonatomic, readonly) NSString *settingsFilePath;
 
 /**
+ * Returns the folder containing the binary image file
+ */
+@property(nonatomic, readonly) NSString *binaryImageDirectoryPath;
+
+/**
+ * Returns the path to the binary image file
+ */
+@property(nonatomic, readonly) NSString *binaryImageFilePath;
+
+/**
  * Path to the file that holds the ttl and keys that invalidate settings
  */
 @property(nonatomic, readonly) NSString *settingsCacheKeyPath;

--- a/Crashlytics/Crashlytics/Models/FIRCLSFileManager.m
+++ b/Crashlytics/Crashlytics/Models/FIRCLSFileManager.m
@@ -182,7 +182,7 @@ NSString *const FIRCLSCacheVersion = @"v5";
 
 // This path should be different than the structurePath because the
 // settings download operations will delete the settings directory,
-// which would delete crash reports if these were the same
+// which would delete crash reports and binary images if these were the same
 - (NSString *)settingsDirectoryPath {
   return [[self versionedPath] stringByAppendingPathComponent:@"settings"];
 }
@@ -193,6 +193,15 @@ NSString *const FIRCLSCacheVersion = @"v5";
 
 - (NSString *)settingsCacheKeyPath {
   return [[self settingsDirectoryPath] stringByAppendingPathComponent:@"cache-key.json"];
+}
+
+#pragma - Binary Image Paths
+- (NSString *)binaryImageDirectoryPath {
+  return [[self versionedPath] stringByAppendingPathComponent:@"binary_images"];
+}
+
+- (NSString *)binaryImageFilePath {
+  return [[self binaryImageDirectoryPath] stringByAppendingPathComponent:@"binary_images.clsrecord"];
 }
 
 #pragma - Report Paths

--- a/Crashlytics/Crashlytics/Models/FIRCLSSettings.h
+++ b/Crashlytics/Crashlytics/Models/FIRCLSSettings.h
@@ -64,6 +64,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, readonly) uint32_t cacheDurationSeconds;
 
 /**
+ * Returns true when Binary Images should be written out again
+ */
+@property(nonatomic, readonly) BOOL doesNeedNewBinaryImages;
+
+/**
  * When this is false, Crashlytics will not start up
  */
 @property(nonatomic, readonly) BOOL collectReportsEnabled;


### PR DESCRIPTION
Don't write out binary images each time the app is run. Instead, write once per build/version and rely on this for all subsequent runs of the app