### PR TITLE
Fix a duplicate key in test data

### DIFF
--- a/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRQueryTests.mm
@@ -614,7 +614,7 @@
     @"f" : @{@"array" : @[ @{@"a" : @42} ]},
     @"g" : @{@"array" : @42},
     @"h" : @{@"array" : @[ [NSNull null] ]},
-    @"g" : @{@"array" : @[ @(NAN) ]},
+    @"i" : @{@"array" : @[ @(NAN) ]},
 
   };
   FIRCollectionReference *collection = [self collectionRefWithDocuments:testDocs];


### PR DESCRIPTION
This triggers the `-Wobjc-dictionary-duplicate-keys` warning, causing the compilation to fail when `-Werror` is used. Introduced in #6871.

#no-changelog