### PR TITLE
Provide namespace for the Auth Combine Publishers

### DIFF
--- a/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
@@ -14,14 +14,38 @@
 
 #if canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)
 
-  import Combine
-  import FirebaseAuth
+import Combine
+import FirebaseAuth
+import FirebaseCore
 
-  @available(swift 5.0)
-  @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-  extension Auth {
+@available(swift 5.0)
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension Auth {
+    
+    /// Returns a publisher that wraps the auth object for the default Firebase app.
+    ///
+    /// The publisher will emit events on the **main** thread.
+    ///
+    /// - Returns: A publisher that wraps the auth object for the default Firebase app.
+    public class func authPublisher() -> AnyPublisher<Auth, Never> {
+        Just(auth()).eraseToAnyPublisher()
+    }
+    
+    /// Returns a publisher that wraps the auth object for the given Firebase app.
+    ///
+    /// The publisher will emit events on the **main** thread.
+    ///
+    /// - Returns: A publisher that wraps the auth object for the given Firebase app.
+    public class func authPublisher(app: FirebaseApp) -> AnyPublisher<Auth, Never> {
+        Just(auth(app: app)).eraseToAnyPublisher()
+    }
+}
+
+@available(swift 5.0)
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+extension Publisher where Output == Auth, Failure == Never {
     // MARK: - Authentication State Management
-
+    
     /// Registers a publisher that publishes authentication state changes.
     ///
     /// The publisher emits values when:
@@ -34,17 +58,20 @@
     ///
     /// - Returns: A publisher emitting a `User` instance (if the user has signed in) or `nil` (if the user has signed out)
     public func authStateDidChangePublisher() -> AnyPublisher<User?, Never> {
-      let subject = PassthroughSubject<User?, Never>()
-      let handle = addStateDidChangeListener { auth, user in
-        subject.send(user)
-      }
-      return subject
-        .handleEvents(receiveCancel: {
-          self.removeStateDidChangeListener(handle)
-        })
-        .eraseToAnyPublisher()
+        flatMap { auth -> AnyPublisher<User?, Never> in
+            let subject = PassthroughSubject<User?, Never>()
+            let handle = auth.addStateDidChangeListener { _, user in
+                subject.send(user)
+            }
+            
+            return subject
+                .handleEvents(receiveCancel: {
+                    auth.removeStateDidChangeListener(handle)
+                }).eraseToAnyPublisher()
+            
+        }.eraseToAnyPublisher()
     }
-
+    
     /// Registers a publisher that publishes ID token state changes.
     ///
     /// The publisher emits values when:
@@ -58,17 +85,20 @@
     ///
     /// - Returns: A publisher emitting a `User` instance (if a different user as signed in or the ID token of the current user has changed) or `nil` (if the user has signed out)
     public func idTokenDidChangePublisher() -> AnyPublisher<User?, Never> {
-      let subject = PassthroughSubject<User?, Never>()
-      let handle = addIDTokenDidChangeListener { auth, user in
-        subject.send(user)
-      }
-      return subject
-        .handleEvents(receiveCancel: {
-          self.removeIDTokenDidChangeListener(handle)
-        })
+        flatMap { auth -> AnyPublisher<User?, Never> in
+            let subject = PassthroughSubject<User?, Never>()
+            let handle = auth.addIDTokenDidChangeListener { _, user in
+                subject.send(user)
+            }
+            
+            return subject
+                .handleEvents(receiveCancel: {
+                    auth.removeIDTokenDidChangeListener(handle)
+                }).eraseToAnyPublisher()
+        }
         .eraseToAnyPublisher()
     }
-
+    
     /// Sets the currentUser on the calling Auth instance to the provided user object.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -77,20 +107,24 @@
     /// - Returns: A publisher that emits as soon as the user of the calling Auth instance has been
     ///   updated or an error was encountered. The publisher will emit on the *main* thread.
     @discardableResult
-    public func updateCurrentUser(_ user: User) -> Future<Void, Error> {
-      Future<Void, Error> { promise in
-        self.updateCurrentUser(user) { error in
-          if let error = error {
-            promise(.failure(error))
-          } else {
-            promise(.success(()))
-          }
-        }
-      }
+    public func updateCurrentUser(_ user: User) -> AnyPublisher<Void, Error> {
+        setFailureType(to: Error.self)
+            .flatMap { auth in
+                Future<Void, Error> { promise in
+                    auth.updateCurrentUser(user) { error in
+                        if let error = error {
+                            promise(.failure(error))
+                        } else {
+                            promise(.success(()))
+                        }
+                    }
+                }
+            }.eraseToAnyPublisher()
     }
-
+    
+    
     // MARK: - Anonymous Authentication
-
+    
     /// Asynchronously creates and becomes an anonymous user.
     ///
     /// If there is already an anonymous user signed in, that user will be returned instead.
@@ -106,20 +140,23 @@
     ///
     ///   See `AuthErrors` for a list of error codes that are common to all API methods
     @discardableResult
-    public func signInAnonymously() -> Future<AuthDataResult, Error> {
-      Future<AuthDataResult, Error> { promise in
-        self.signInAnonymously { authDataResult, error in
-          if let error = error {
-            promise(.failure(error))
-          } else if let authDataResult = authDataResult {
-            promise(.success(authDataResult))
-          }
-        }
-      }
+    public func signInAnonymously() -> AnyPublisher<AuthDataResult, Error> {
+        setFailureType(to: Error.self)
+            .flatMap { auth in
+                Future<AuthDataResult, Error> { promise in
+                    auth.signInAnonymously { authDataResult, error in
+                        if let error = error {
+                            promise(.failure(error))
+                        } else if let authDataResult = authDataResult {
+                            promise(.success(authDataResult))
+                        }
+                    }
+                }
+            }.eraseToAnyPublisher()
     }
-
+    
     // MARK: - Email/Password Authentication
-
+    
     /// Creates and, on success, signs in a user with the given email address and password.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -143,18 +180,21 @@
     ///   See `AuthErrors` for a list of error codes that are common to all API methods
     @discardableResult
     public func createUser(withEmail email: String,
-                           password: String) -> Future<AuthDataResult, Error> {
-      Future<AuthDataResult, Error> { promise in
-        self.createUser(withEmail: email, password: password) { authDataResult, error in
-          if let error = error {
-            promise(.failure(error))
-          } else if let authDataResult = authDataResult {
-            promise(.success(authDataResult))
-          }
-        }
-      }
+                           password: String) -> AnyPublisher<AuthDataResult, Error> {
+        setFailureType(to: Error.self)
+            .flatMap { auth in
+                Future<AuthDataResult, Error> { promise in
+                    auth.createUser(withEmail: email, password: password) { authDataResult, error in
+                        if let error = error {
+                            promise(.failure(error))
+                        } else if let authDataResult = authDataResult {
+                            promise(.success(authDataResult))
+                        }
+                    }
+                }
+            }.eraseToAnyPublisher()
     }
-
+    
     /// Signs in using an email address and password.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -176,20 +216,23 @@
     ///   See `AuthErrors` for a list of error codes that are common to all API methods
     @discardableResult
     public func signIn(withEmail email: String,
-                       password: String) -> Future<AuthDataResult, Error> {
-      Future<AuthDataResult, Error> { promise in
-        self.signIn(withEmail: email, password: password) { authDataResult, error in
-          if let error = error {
-            promise(.failure(error))
-          } else if let authDataResult = authDataResult {
-            promise(.success(authDataResult))
-          }
-        }
-      }
+                       password: String) -> AnyPublisher<AuthDataResult, Error> {
+        setFailureType(to: Error.self)
+            .flatMap { auth in
+                Future<AuthDataResult, Error> { promise in
+                    auth.signIn(withEmail: email, password: password) { authDataResult, error in
+                        if let error = error {
+                            promise(.failure(error))
+                        } else if let authDataResult = authDataResult {
+                            promise(.success(authDataResult))
+                        }
+                    }
+                }
+            }.eraseToAnyPublisher()
     }
-
+    
     // MARK: - Email/Link Authentication
-
+    
     /// Signs in using an email address and email sign-in link.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -209,18 +252,21 @@
     ///   See `AuthErrors` for a list of error codes that are common to all API methods
     @discardableResult
     public func signIn(withEmail email: String,
-                       link: String) -> Future<AuthDataResult, Error> {
-      Future<AuthDataResult, Error> { promise in
-        self.signIn(withEmail: email, link: link) { authDataResult, error in
-          if let error = error {
-            promise(.failure(error))
-          } else if let authDataResult = authDataResult {
-            promise(.success(authDataResult))
-          }
-        }
-      }
+                       link: String) -> AnyPublisher<AuthDataResult, Error> {
+        setFailureType(to: Error.self)
+            .flatMap { auth in
+                Future<AuthDataResult, Error> { promise in
+                    auth.signIn(withEmail: email, link: link) { authDataResult, error in
+                        if let error = error {
+                            promise(.failure(error))
+                        } else if let authDataResult = authDataResult {
+                            promise(.success(authDataResult))
+                        }
+                    }
+                }
+            }.eraseToAnyPublisher()
     }
-
+    
     /// Sends a sign in with email link to provided email address.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -232,20 +278,23 @@
     /// - Returns: A publisher that emits whether the call was successful or not.
     @discardableResult
     public func sendSignInLink(toEmail email: String,
-                               actionCodeSettings: ActionCodeSettings) -> Future<Void, Error> {
-      Future<Void, Error> { promise in
-        self.sendSignInLink(toEmail: email, actionCodeSettings: actionCodeSettings) { error in
-          if let error = error {
-            promise(.failure(error))
-          } else {
-            promise(.success(()))
-          }
-        }
-      }
+                               actionCodeSettings: ActionCodeSettings) -> AnyPublisher<Void, Error> {
+        setFailureType(to: Error.self)
+            .flatMap { auth in
+                Future<Void, Error> { promise in
+                    auth.sendSignInLink(toEmail: email, actionCodeSettings: actionCodeSettings) { error in
+                        if let error = error {
+                            promise(.failure(error))
+                        } else {
+                            promise(.success(()))
+                        }
+                    }
+                }
+            }.eraseToAnyPublisher()
     }
-
+    
     //  MARK: - Email-based Authentication Helpers
-
+    
     /// Fetches the list of all sign-in methods previously used for the provided email address.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -257,20 +306,23 @@
     ///   - `AuthErrorCodeInvalidEmail` - Indicates the email address is malformed.
     ///
     ///   See `AuthErrors` for a list of error codes that are common to all API methods
-    public func fetchSignInMethods(forEmail email: String) -> Future<[String], Error> {
-      Future<[String], Error> { promise in
-        self.fetchSignInMethods(forEmail: email) { signInMethods, error in
-          if let error = error {
-            promise(.failure(error))
-          } else if let signInMethods = signInMethods {
-            promise(.success(signInMethods))
-          }
-        }
-      }
+    public func fetchSignInMethods(forEmail email: String) -> AnyPublisher<[String], Error> {
+        setFailureType(to: Error.self)
+            .flatMap { auth in
+                Future<[String], Error> { promise in
+                    auth.fetchSignInMethods(forEmail: email) { signInMethods, error in
+                        if let error = error {
+                            promise(.failure(error))
+                        } else if let signInMethods = signInMethods {
+                            promise(.success(signInMethods))
+                        }
+                    }
+                }
+            }.eraseToAnyPublisher()
     }
-
+    
     // MARK: - Password Reset
-
+    
     /// Resets the password given a code sent to the user outside of the app and a new password for the user.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -288,18 +340,21 @@
     ///   See `AuthErrors` for a list of error codes that are common to all API methods
     @discardableResult
     public func confirmPasswordReset(withCode code: String,
-                                     newPassword: String) -> Future<Void, Error> {
-      Future<Void, Error> { promise in
-        self.confirmPasswordReset(withCode: code, newPassword: newPassword) { error in
-          if let error = error {
-            promise(.failure(error))
-          } else {
-            promise(.success(()))
-          }
-        }
-      }
+                                     newPassword: String) -> AnyPublisher<Void, Error> {
+        setFailureType(to: Error.self)
+            .flatMap { auth in
+                Future<Void, Error> { promise in
+                    auth.confirmPasswordReset(withCode: code, newPassword: newPassword) { error in
+                        if let error = error {
+                            promise(.failure(error))
+                        } else {
+                            promise(.success(()))
+                        }
+                    }
+                }
+            }.eraseToAnyPublisher()
     }
-
+    
     /// Checks the validity of a verify password reset code.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -308,18 +363,21 @@
     /// - Returns: A publisher that emits an error if the code could not be verified. If the code could be
     ///   verified, the publisher will emit the email address of the account the code was issued for.
     @discardableResult
-    public func verifyPasswordResetCode(_ code: String) -> Future<String, Error> {
-      Future<String, Error> { promise in
-        self.verifyPasswordResetCode(code) { email, error in
-          if let error = error {
-            promise(.failure(error))
-          } else if let email = email {
-            promise(.success(email))
-          }
-        }
-      }
+    public func verifyPasswordResetCode(_ code: String) -> AnyPublisher<String, Error> {
+        setFailureType(to: Error.self)
+            .flatMap { auth in
+                Future<String, Error> { promise in
+                    auth.verifyPasswordResetCode(code) { email, error in
+                        if let error = error {
+                            promise(.failure(error))
+                        } else if let email = email {
+                            promise(.success(email))
+                        }
+                    }
+                }
+            }.eraseToAnyPublisher()
     }
-
+    
     /// Checks the validity of an out of band code.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -328,18 +386,21 @@
     /// - Returns: A publisher that emits an error if the code could not be verified. If the code could be
     ///   verified, the publisher will emit the email address of the account the code was issued for.
     @discardableResult
-    public func checkActionCode(code: String) -> Future<ActionCodeInfo, Error> {
-      Future<ActionCodeInfo, Error> { promise in
-        self.checkActionCode(code) { actionCodeInfo, error in
-          if let error = error {
-            promise(.failure(error))
-          } else if let actionCodeInfo = actionCodeInfo {
-            promise(.success(actionCodeInfo))
-          }
-        }
-      }
+    public func checkActionCode(code: String) -> AnyPublisher<ActionCodeInfo, Error> {
+        setFailureType(to: Error.self)
+            .flatMap { auth in
+                Future<ActionCodeInfo, Error> { promise in
+                    auth.checkActionCode(code) { actionCodeInfo, error in
+                        if let error = error {
+                            promise(.failure(error))
+                        } else if let actionCodeInfo = actionCodeInfo {
+                            promise(.success(actionCodeInfo))
+                        }
+                    }
+                }
+            }.eraseToAnyPublisher()
     }
-
+    
     /// Applies out of band code.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -349,18 +410,21 @@
     /// - Remark: This method will not work for out of band codes which require an additional parameter,
     ///   such as password reset code.
     @discardableResult
-    public func applyActionCode(code: String) -> Future<Void, Error> {
-      Future<Void, Error> { promise in
-        self.applyActionCode(code) { error in
-          if let error = error {
-            promise(.failure(error))
-          } else {
-            promise(.success(()))
-          }
-        }
-      }
+    public func applyActionCode(code: String) -> AnyPublisher<Void, Error> {
+        setFailureType(to: Error.self)
+            .flatMap { auth in
+                Future<Void, Error> { promise in
+                    auth.applyActionCode(code) { error in
+                        if let error = error {
+                            promise(.failure(error))
+                        } else {
+                            promise(.success(()))
+                        }
+                    }
+                }
+            }.eraseToAnyPublisher()
     }
-
+    
     /// Initiates a password reset for the given email address.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -374,18 +438,21 @@
     ///
     ///   See `AuthErrors` for a list of error codes that are common to all API methods
     @discardableResult
-    public func sendPasswordReset(withEmail email: String) -> Future<Void, Error> {
-      Future<Void, Error> { promise in
-        self.sendPasswordReset(withEmail: email) { error in
-          if let error = error {
-            promise(.failure(error))
-          } else {
-            promise(.success(()))
-          }
-        }
-      }
+    public func sendPasswordReset(withEmail email: String) -> AnyPublisher<Void, Error> {
+        setFailureType(to: Error.self)
+            .flatMap { auth in
+                Future<Void, Error> { promise in
+                    auth.sendPasswordReset(withEmail: email) { error in
+                        if let error = error {
+                            promise(.failure(error))
+                        } else {
+                            promise(.success(()))
+                        }
+                    }
+                }
+            }.eraseToAnyPublisher()
     }
-
+    
     /// Initiates a password reset for the given email address and `ActionCodeSettings`.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -405,20 +472,23 @@
     ///   See `AuthErrors` for a list of error codes that are common to all API methods
     @discardableResult
     public func sendPasswordReset(withEmail email: String,
-                                  actionCodeSettings: ActionCodeSettings) -> Future<Void, Error> {
-      Future<Void, Error> { promise in
-        self.sendPasswordReset(withEmail: email, actionCodeSettings: actionCodeSettings) { error in
-          if let error = error {
-            promise(.failure(error))
-          } else {
-            promise(.success(()))
-          }
-        }
-      }
+                                  actionCodeSettings: ActionCodeSettings) -> AnyPublisher<Void, Error> {
+        setFailureType(to: Error.self)
+            .flatMap { auth in
+                Future<Void, Error> { promise in
+                    auth.sendPasswordReset(withEmail: email, actionCodeSettings: actionCodeSettings) { error in
+                        if let error = error {
+                            promise(.failure(error))
+                        } else {
+                            promise(.success(()))
+                        }
+                    }
+                }
+            }.eraseToAnyPublisher()
     }
-
+    
     // MARK: - Other Authentication providers
-
+    
     /// Signs in using the provided auth provider instance.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -452,18 +522,21 @@
     ///   See `AuthErrors` for a list of error codes that are common to all API methods
     @discardableResult
     public func signIn(with provider: FederatedAuthProvider,
-                       uiDelegate: AuthUIDelegate?) -> Future<AuthDataResult, Error> {
-      Future<AuthDataResult, Error> { promise in
-        self.signIn(with: provider, uiDelegate: uiDelegate) { authDataResult, error in
-          if let error = error {
-            promise(.failure(error))
-          } else if let authDataResult = authDataResult {
-            promise(.success(authDataResult))
-          }
-        }
-      }
+                       uiDelegate: AuthUIDelegate?) -> AnyPublisher<AuthDataResult, Error> {
+        setFailureType(to: Error.self)
+            .flatMap { auth in
+                Future<AuthDataResult, Error> { promise in
+                    auth.signIn(with: provider, uiDelegate: uiDelegate) { authDataResult, error in
+                        if let error = error {
+                            promise(.failure(error))
+                        } else if let authDataResult = authDataResult {
+                            promise(.success(authDataResult))
+                        }
+                    }
+                }
+            }.eraseToAnyPublisher()
     }
-
+    
     /// Asynchronously signs in to Firebase with the given Auth token.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -479,16 +552,19 @@
     ///
     ///   See `AuthErrors` for a list of error codes that are common to all API methods
     @discardableResult
-    public func signIn(withCustomToken token: String) -> Future<AuthDataResult, Error> {
-      Future<AuthDataResult, Error> { promise in
-        self.signIn(withCustomToken: token) { authDataResult, error in
-          if let error = error {
-            promise(.failure(error))
-          } else if let authDataResult = authDataResult {
-            promise(.success(authDataResult))
-          }
-        }
-      }
+    public func signIn(withCustomToken token: String) -> AnyPublisher<AuthDataResult, Error> {
+        setFailureType(to: Error.self)
+            .flatMap { auth in
+                Future<AuthDataResult, Error> { promise in
+                    auth.signIn(withCustomToken: token) { authDataResult, error in
+                        if let error = error {
+                            promise(.failure(error))
+                        } else if let authDataResult = authDataResult {
+                            promise(.success(authDataResult))
+                        }
+                    }
+                }
+            }.eraseToAnyPublisher()
     }
-  }
+}
 #endif

--- a/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
+++ b/FirebaseCombineSwift/Sources/Auth/Auth+Combine.swift
@@ -14,38 +14,37 @@
 
 #if canImport(Combine) && swift(>=5.0) && canImport(FirebaseAuth)
 
-import Combine
-import FirebaseAuth
-import FirebaseCore
+  import Combine
+  import FirebaseAuth
+  import FirebaseCore
 
-@available(swift 5.0)
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-extension Auth {
-    
+  @available(swift 5.0)
+  @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+  extension Auth {
     /// Returns a publisher that wraps the auth object for the default Firebase app.
     ///
     /// The publisher will emit events on the **main** thread.
     ///
     /// - Returns: A publisher that wraps the auth object for the default Firebase app.
     public class func authPublisher() -> AnyPublisher<Auth, Never> {
-        Just(auth()).eraseToAnyPublisher()
+      Just(auth()).eraseToAnyPublisher()
     }
-    
+
     /// Returns a publisher that wraps the auth object for the given Firebase app.
     ///
     /// The publisher will emit events on the **main** thread.
     ///
     /// - Returns: A publisher that wraps the auth object for the given Firebase app.
     public class func authPublisher(app: FirebaseApp) -> AnyPublisher<Auth, Never> {
-        Just(auth(app: app)).eraseToAnyPublisher()
+      Just(auth(app: app)).eraseToAnyPublisher()
     }
-}
+  }
 
-@available(swift 5.0)
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-extension Publisher where Output == Auth, Failure == Never {
+  @available(swift 5.0)
+  @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+  extension Publisher where Output == Auth, Failure == Never {
     // MARK: - Authentication State Management
-    
+
     /// Registers a publisher that publishes authentication state changes.
     ///
     /// The publisher emits values when:
@@ -58,20 +57,20 @@ extension Publisher where Output == Auth, Failure == Never {
     ///
     /// - Returns: A publisher emitting a `User` instance (if the user has signed in) or `nil` (if the user has signed out)
     public func authStateDidChangePublisher() -> AnyPublisher<User?, Never> {
-        flatMap { auth -> AnyPublisher<User?, Never> in
-            let subject = PassthroughSubject<User?, Never>()
-            let handle = auth.addStateDidChangeListener { _, user in
-                subject.send(user)
-            }
-            
-            return subject
-                .handleEvents(receiveCancel: {
-                    auth.removeStateDidChangeListener(handle)
-                }).eraseToAnyPublisher()
-            
-        }.eraseToAnyPublisher()
+      flatMap { auth -> AnyPublisher<User?, Never> in
+        let subject = PassthroughSubject<User?, Never>()
+        let handle = auth.addStateDidChangeListener { _, user in
+          subject.send(user)
+        }
+
+        return subject
+          .handleEvents(receiveCancel: {
+            auth.removeStateDidChangeListener(handle)
+          }).eraseToAnyPublisher()
+
+      }.eraseToAnyPublisher()
     }
-    
+
     /// Registers a publisher that publishes ID token state changes.
     ///
     /// The publisher emits values when:
@@ -85,20 +84,20 @@ extension Publisher where Output == Auth, Failure == Never {
     ///
     /// - Returns: A publisher emitting a `User` instance (if a different user as signed in or the ID token of the current user has changed) or `nil` (if the user has signed out)
     public func idTokenDidChangePublisher() -> AnyPublisher<User?, Never> {
-        flatMap { auth -> AnyPublisher<User?, Never> in
-            let subject = PassthroughSubject<User?, Never>()
-            let handle = auth.addIDTokenDidChangeListener { _, user in
-                subject.send(user)
-            }
-            
-            return subject
-                .handleEvents(receiveCancel: {
-                    auth.removeIDTokenDidChangeListener(handle)
-                }).eraseToAnyPublisher()
+      flatMap { auth -> AnyPublisher<User?, Never> in
+        let subject = PassthroughSubject<User?, Never>()
+        let handle = auth.addIDTokenDidChangeListener { _, user in
+          subject.send(user)
         }
-        .eraseToAnyPublisher()
+
+        return subject
+          .handleEvents(receiveCancel: {
+            auth.removeIDTokenDidChangeListener(handle)
+          }).eraseToAnyPublisher()
+      }
+      .eraseToAnyPublisher()
     }
-    
+
     /// Sets the currentUser on the calling Auth instance to the provided user object.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -108,23 +107,22 @@ extension Publisher where Output == Auth, Failure == Never {
     ///   updated or an error was encountered. The publisher will emit on the *main* thread.
     @discardableResult
     public func updateCurrentUser(_ user: User) -> AnyPublisher<Void, Error> {
-        setFailureType(to: Error.self)
-            .flatMap { auth in
-                Future<Void, Error> { promise in
-                    auth.updateCurrentUser(user) { error in
-                        if let error = error {
-                            promise(.failure(error))
-                        } else {
-                            promise(.success(()))
-                        }
-                    }
-                }
-            }.eraseToAnyPublisher()
+      setFailureType(to: Error.self)
+        .flatMap { auth in
+          Future<Void, Error> { promise in
+            auth.updateCurrentUser(user) { error in
+              if let error = error {
+                promise(.failure(error))
+              } else {
+                promise(.success(()))
+              }
+            }
+          }
+        }.eraseToAnyPublisher()
     }
-    
-    
+
     // MARK: - Anonymous Authentication
-    
+
     /// Asynchronously creates and becomes an anonymous user.
     ///
     /// If there is already an anonymous user signed in, that user will be returned instead.
@@ -141,22 +139,22 @@ extension Publisher where Output == Auth, Failure == Never {
     ///   See `AuthErrors` for a list of error codes that are common to all API methods
     @discardableResult
     public func signInAnonymously() -> AnyPublisher<AuthDataResult, Error> {
-        setFailureType(to: Error.self)
-            .flatMap { auth in
-                Future<AuthDataResult, Error> { promise in
-                    auth.signInAnonymously { authDataResult, error in
-                        if let error = error {
-                            promise(.failure(error))
-                        } else if let authDataResult = authDataResult {
-                            promise(.success(authDataResult))
-                        }
-                    }
-                }
-            }.eraseToAnyPublisher()
+      setFailureType(to: Error.self)
+        .flatMap { auth in
+          Future<AuthDataResult, Error> { promise in
+            auth.signInAnonymously { authDataResult, error in
+              if let error = error {
+                promise(.failure(error))
+              } else if let authDataResult = authDataResult {
+                promise(.success(authDataResult))
+              }
+            }
+          }
+        }.eraseToAnyPublisher()
     }
-    
+
     // MARK: - Email/Password Authentication
-    
+
     /// Creates and, on success, signs in a user with the given email address and password.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -181,20 +179,20 @@ extension Publisher where Output == Auth, Failure == Never {
     @discardableResult
     public func createUser(withEmail email: String,
                            password: String) -> AnyPublisher<AuthDataResult, Error> {
-        setFailureType(to: Error.self)
-            .flatMap { auth in
-                Future<AuthDataResult, Error> { promise in
-                    auth.createUser(withEmail: email, password: password) { authDataResult, error in
-                        if let error = error {
-                            promise(.failure(error))
-                        } else if let authDataResult = authDataResult {
-                            promise(.success(authDataResult))
-                        }
-                    }
-                }
-            }.eraseToAnyPublisher()
+      setFailureType(to: Error.self)
+        .flatMap { auth in
+          Future<AuthDataResult, Error> { promise in
+            auth.createUser(withEmail: email, password: password) { authDataResult, error in
+              if let error = error {
+                promise(.failure(error))
+              } else if let authDataResult = authDataResult {
+                promise(.success(authDataResult))
+              }
+            }
+          }
+        }.eraseToAnyPublisher()
     }
-    
+
     /// Signs in using an email address and password.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -217,22 +215,22 @@ extension Publisher where Output == Auth, Failure == Never {
     @discardableResult
     public func signIn(withEmail email: String,
                        password: String) -> AnyPublisher<AuthDataResult, Error> {
-        setFailureType(to: Error.self)
-            .flatMap { auth in
-                Future<AuthDataResult, Error> { promise in
-                    auth.signIn(withEmail: email, password: password) { authDataResult, error in
-                        if let error = error {
-                            promise(.failure(error))
-                        } else if let authDataResult = authDataResult {
-                            promise(.success(authDataResult))
-                        }
-                    }
-                }
-            }.eraseToAnyPublisher()
+      setFailureType(to: Error.self)
+        .flatMap { auth in
+          Future<AuthDataResult, Error> { promise in
+            auth.signIn(withEmail: email, password: password) { authDataResult, error in
+              if let error = error {
+                promise(.failure(error))
+              } else if let authDataResult = authDataResult {
+                promise(.success(authDataResult))
+              }
+            }
+          }
+        }.eraseToAnyPublisher()
     }
-    
+
     // MARK: - Email/Link Authentication
-    
+
     /// Signs in using an email address and email sign-in link.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -253,20 +251,20 @@ extension Publisher where Output == Auth, Failure == Never {
     @discardableResult
     public func signIn(withEmail email: String,
                        link: String) -> AnyPublisher<AuthDataResult, Error> {
-        setFailureType(to: Error.self)
-            .flatMap { auth in
-                Future<AuthDataResult, Error> { promise in
-                    auth.signIn(withEmail: email, link: link) { authDataResult, error in
-                        if let error = error {
-                            promise(.failure(error))
-                        } else if let authDataResult = authDataResult {
-                            promise(.success(authDataResult))
-                        }
-                    }
-                }
-            }.eraseToAnyPublisher()
+      setFailureType(to: Error.self)
+        .flatMap { auth in
+          Future<AuthDataResult, Error> { promise in
+            auth.signIn(withEmail: email, link: link) { authDataResult, error in
+              if let error = error {
+                promise(.failure(error))
+              } else if let authDataResult = authDataResult {
+                promise(.success(authDataResult))
+              }
+            }
+          }
+        }.eraseToAnyPublisher()
     }
-    
+
     /// Sends a sign in with email link to provided email address.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -278,23 +276,26 @@ extension Publisher where Output == Auth, Failure == Never {
     /// - Returns: A publisher that emits whether the call was successful or not.
     @discardableResult
     public func sendSignInLink(toEmail email: String,
-                               actionCodeSettings: ActionCodeSettings) -> AnyPublisher<Void, Error> {
-        setFailureType(to: Error.self)
-            .flatMap { auth in
-                Future<Void, Error> { promise in
-                    auth.sendSignInLink(toEmail: email, actionCodeSettings: actionCodeSettings) { error in
-                        if let error = error {
-                            promise(.failure(error))
-                        } else {
-                            promise(.success(()))
-                        }
-                    }
+                               actionCodeSettings: ActionCodeSettings)
+      -> AnyPublisher<Void, Error> {
+      setFailureType(to: Error.self)
+        .flatMap { auth in
+          Future<Void, Error> { promise in
+            auth
+              .sendSignInLink(toEmail: email,
+                              actionCodeSettings: actionCodeSettings) { error in
+                if let error = error {
+                  promise(.failure(error))
+                } else {
+                  promise(.success(()))
                 }
-            }.eraseToAnyPublisher()
+              }
+          }
+        }.eraseToAnyPublisher()
     }
-    
+
     //  MARK: - Email-based Authentication Helpers
-    
+
     /// Fetches the list of all sign-in methods previously used for the provided email address.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -307,22 +308,22 @@ extension Publisher where Output == Auth, Failure == Never {
     ///
     ///   See `AuthErrors` for a list of error codes that are common to all API methods
     public func fetchSignInMethods(forEmail email: String) -> AnyPublisher<[String], Error> {
-        setFailureType(to: Error.self)
-            .flatMap { auth in
-                Future<[String], Error> { promise in
-                    auth.fetchSignInMethods(forEmail: email) { signInMethods, error in
-                        if let error = error {
-                            promise(.failure(error))
-                        } else if let signInMethods = signInMethods {
-                            promise(.success(signInMethods))
-                        }
-                    }
-                }
-            }.eraseToAnyPublisher()
+      setFailureType(to: Error.self)
+        .flatMap { auth in
+          Future<[String], Error> { promise in
+            auth.fetchSignInMethods(forEmail: email) { signInMethods, error in
+              if let error = error {
+                promise(.failure(error))
+              } else if let signInMethods = signInMethods {
+                promise(.success(signInMethods))
+              }
+            }
+          }
+        }.eraseToAnyPublisher()
     }
-    
+
     // MARK: - Password Reset
-    
+
     /// Resets the password given a code sent to the user outside of the app and a new password for the user.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -341,20 +342,20 @@ extension Publisher where Output == Auth, Failure == Never {
     @discardableResult
     public func confirmPasswordReset(withCode code: String,
                                      newPassword: String) -> AnyPublisher<Void, Error> {
-        setFailureType(to: Error.self)
-            .flatMap { auth in
-                Future<Void, Error> { promise in
-                    auth.confirmPasswordReset(withCode: code, newPassword: newPassword) { error in
-                        if let error = error {
-                            promise(.failure(error))
-                        } else {
-                            promise(.success(()))
-                        }
-                    }
-                }
-            }.eraseToAnyPublisher()
+      setFailureType(to: Error.self)
+        .flatMap { auth in
+          Future<Void, Error> { promise in
+            auth.confirmPasswordReset(withCode: code, newPassword: newPassword) { error in
+              if let error = error {
+                promise(.failure(error))
+              } else {
+                promise(.success(()))
+              }
+            }
+          }
+        }.eraseToAnyPublisher()
     }
-    
+
     /// Checks the validity of a verify password reset code.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -364,20 +365,20 @@ extension Publisher where Output == Auth, Failure == Never {
     ///   verified, the publisher will emit the email address of the account the code was issued for.
     @discardableResult
     public func verifyPasswordResetCode(_ code: String) -> AnyPublisher<String, Error> {
-        setFailureType(to: Error.self)
-            .flatMap { auth in
-                Future<String, Error> { promise in
-                    auth.verifyPasswordResetCode(code) { email, error in
-                        if let error = error {
-                            promise(.failure(error))
-                        } else if let email = email {
-                            promise(.success(email))
-                        }
-                    }
-                }
-            }.eraseToAnyPublisher()
+      setFailureType(to: Error.self)
+        .flatMap { auth in
+          Future<String, Error> { promise in
+            auth.verifyPasswordResetCode(code) { email, error in
+              if let error = error {
+                promise(.failure(error))
+              } else if let email = email {
+                promise(.success(email))
+              }
+            }
+          }
+        }.eraseToAnyPublisher()
     }
-    
+
     /// Checks the validity of an out of band code.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -387,20 +388,20 @@ extension Publisher where Output == Auth, Failure == Never {
     ///   verified, the publisher will emit the email address of the account the code was issued for.
     @discardableResult
     public func checkActionCode(code: String) -> AnyPublisher<ActionCodeInfo, Error> {
-        setFailureType(to: Error.self)
-            .flatMap { auth in
-                Future<ActionCodeInfo, Error> { promise in
-                    auth.checkActionCode(code) { actionCodeInfo, error in
-                        if let error = error {
-                            promise(.failure(error))
-                        } else if let actionCodeInfo = actionCodeInfo {
-                            promise(.success(actionCodeInfo))
-                        }
-                    }
-                }
-            }.eraseToAnyPublisher()
+      setFailureType(to: Error.self)
+        .flatMap { auth in
+          Future<ActionCodeInfo, Error> { promise in
+            auth.checkActionCode(code) { actionCodeInfo, error in
+              if let error = error {
+                promise(.failure(error))
+              } else if let actionCodeInfo = actionCodeInfo {
+                promise(.success(actionCodeInfo))
+              }
+            }
+          }
+        }.eraseToAnyPublisher()
     }
-    
+
     /// Applies out of band code.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -411,20 +412,20 @@ extension Publisher where Output == Auth, Failure == Never {
     ///   such as password reset code.
     @discardableResult
     public func applyActionCode(code: String) -> AnyPublisher<Void, Error> {
-        setFailureType(to: Error.self)
-            .flatMap { auth in
-                Future<Void, Error> { promise in
-                    auth.applyActionCode(code) { error in
-                        if let error = error {
-                            promise(.failure(error))
-                        } else {
-                            promise(.success(()))
-                        }
-                    }
-                }
-            }.eraseToAnyPublisher()
+      setFailureType(to: Error.self)
+        .flatMap { auth in
+          Future<Void, Error> { promise in
+            auth.applyActionCode(code) { error in
+              if let error = error {
+                promise(.failure(error))
+              } else {
+                promise(.success(()))
+              }
+            }
+          }
+        }.eraseToAnyPublisher()
     }
-    
+
     /// Initiates a password reset for the given email address.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -439,20 +440,20 @@ extension Publisher where Output == Auth, Failure == Never {
     ///   See `AuthErrors` for a list of error codes that are common to all API methods
     @discardableResult
     public func sendPasswordReset(withEmail email: String) -> AnyPublisher<Void, Error> {
-        setFailureType(to: Error.self)
-            .flatMap { auth in
-                Future<Void, Error> { promise in
-                    auth.sendPasswordReset(withEmail: email) { error in
-                        if let error = error {
-                            promise(.failure(error))
-                        } else {
-                            promise(.success(()))
-                        }
-                    }
-                }
-            }.eraseToAnyPublisher()
+      setFailureType(to: Error.self)
+        .flatMap { auth in
+          Future<Void, Error> { promise in
+            auth.sendPasswordReset(withEmail: email) { error in
+              if let error = error {
+                promise(.failure(error))
+              } else {
+                promise(.success(()))
+              }
+            }
+          }
+        }.eraseToAnyPublisher()
     }
-    
+
     /// Initiates a password reset for the given email address and `ActionCodeSettings`.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -472,23 +473,27 @@ extension Publisher where Output == Auth, Failure == Never {
     ///   See `AuthErrors` for a list of error codes that are common to all API methods
     @discardableResult
     public func sendPasswordReset(withEmail email: String,
-                                  actionCodeSettings: ActionCodeSettings) -> AnyPublisher<Void, Error> {
-        setFailureType(to: Error.self)
-            .flatMap { auth in
-                Future<Void, Error> { promise in
-                    auth.sendPasswordReset(withEmail: email, actionCodeSettings: actionCodeSettings) { error in
-                        if let error = error {
-                            promise(.failure(error))
-                        } else {
-                            promise(.success(()))
-                        }
-                    }
-                }
-            }.eraseToAnyPublisher()
+                                  actionCodeSettings: ActionCodeSettings)
+      -> AnyPublisher<Void, Error> {
+      setFailureType(to: Error.self)
+        .flatMap { auth in
+          Future<Void, Error> { promise in
+            auth.sendPasswordReset(
+              withEmail: email,
+              actionCodeSettings: actionCodeSettings
+            ) { error in
+              if let error = error {
+                promise(.failure(error))
+              } else {
+                promise(.success(()))
+              }
+            }
+          }
+        }.eraseToAnyPublisher()
     }
-    
+
     // MARK: - Other Authentication providers
-    
+
     /// Signs in using the provided auth provider instance.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -523,20 +528,20 @@ extension Publisher where Output == Auth, Failure == Never {
     @discardableResult
     public func signIn(with provider: FederatedAuthProvider,
                        uiDelegate: AuthUIDelegate?) -> AnyPublisher<AuthDataResult, Error> {
-        setFailureType(to: Error.self)
-            .flatMap { auth in
-                Future<AuthDataResult, Error> { promise in
-                    auth.signIn(with: provider, uiDelegate: uiDelegate) { authDataResult, error in
-                        if let error = error {
-                            promise(.failure(error))
-                        } else if let authDataResult = authDataResult {
-                            promise(.success(authDataResult))
-                        }
-                    }
-                }
-            }.eraseToAnyPublisher()
+      setFailureType(to: Error.self)
+        .flatMap { auth in
+          Future<AuthDataResult, Error> { promise in
+            auth.signIn(with: provider, uiDelegate: uiDelegate) { authDataResult, error in
+              if let error = error {
+                promise(.failure(error))
+              } else if let authDataResult = authDataResult {
+                promise(.success(authDataResult))
+              }
+            }
+          }
+        }.eraseToAnyPublisher()
     }
-    
+
     /// Asynchronously signs in to Firebase with the given Auth token.
     ///
     /// The publisher will emit events on the **main** thread.
@@ -553,18 +558,18 @@ extension Publisher where Output == Auth, Failure == Never {
     ///   See `AuthErrors` for a list of error codes that are common to all API methods
     @discardableResult
     public func signIn(withCustomToken token: String) -> AnyPublisher<AuthDataResult, Error> {
-        setFailureType(to: Error.self)
-            .flatMap { auth in
-                Future<AuthDataResult, Error> { promise in
-                    auth.signIn(withCustomToken: token) { authDataResult, error in
-                        if let error = error {
-                            promise(.failure(error))
-                        } else if let authDataResult = authDataResult {
-                            promise(.success(authDataResult))
-                        }
-                    }
-                }
-            }.eraseToAnyPublisher()
+      setFailureType(to: Error.self)
+        .flatMap { auth in
+          Future<AuthDataResult, Error> { promise in
+            auth.signIn(withCustomToken: token) { authDataResult, error in
+              if let error = error {
+                promise(.failure(error))
+              } else if let authDataResult = authDataResult {
+                promise(.success(authDataResult))
+              }
+            }
+          }
+        }.eraseToAnyPublisher()
     }
-}
+  }
 #endif

--- a/FirebaseCombineSwift/Tests/Unit/Auth/AnonymousAuthTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/AnonymousAuthTests.swift
@@ -71,12 +71,12 @@ class AnonymousAuthTests: XCTestCase {
   // MARK: - Test method setup
 
   var app: FirebaseApp?
-  var auth: Auth?
+  var auth: AnyPublisher<Auth, Never>?
 
   override func setUp() {
     self.app = FirebaseApp.appForAuthUnitTestsWithName(name: "app1")
     guard let app = app else { fatalError() }
-    auth = Auth.auth(app: app)
+    auth = Auth.authPublisher(app: app)
   }
 
   func testSignInAnonymouslySuccessfully() {

--- a/FirebaseCombineSwift/Tests/Unit/Auth/AuthStateDidChangePublisherTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/AuthStateDidChangePublisherTests.swift
@@ -114,7 +114,7 @@ class AuthStateDidChangePublisherTests: XCTestCase {
     FIRAuthBackend.setBackendImplementation(MockAuthBackend())
 
     let expect = expectation(description: "Publisher emits on main thread")
-    let cancellable = Auth.auth().authStateDidChangePublisher()
+    let cancellable = Auth.authPublisher().authStateDidChangePublisher()
       .sink { user in
         XCTAssertTrue(Thread.isMainThread)
         expect.fulfill()
@@ -131,7 +131,7 @@ class AuthStateDidChangePublisherTests: XCTestCase {
     FIRAuthBackend.setBackendImplementation(MockAuthBackend())
 
     let expect = expectation(description: "Subscribers can receive events on non-main threads")
-    let cancellable = Auth.auth().authStateDidChangePublisher()
+    let cancellable = Auth.authPublisher().authStateDidChangePublisher()
       .receive(on: DispatchQueue.global())
       .sink { user in
         XCTAssertFalse(Thread.isMainThread)
@@ -151,7 +151,7 @@ class AuthStateDidChangePublisherTests: XCTestCase {
     let subscriptionActivatedExpectation =
       expectation(description: "Publisher emits value as soon as it is subscribed")
 
-    let cancellable = Auth.auth().authStateDidChangePublisher()
+    let cancellable = Auth.authPublisher().authStateDidChangePublisher()
       .sink { user in
         XCTAssertNil(user)
         subscriptionActivatedExpectation.fulfill()
@@ -167,7 +167,7 @@ class AuthStateDidChangePublisherTests: XCTestCase {
 
     let signedInExpectation =
       expectation(description: "Publisher emits value when user is signed in")
-    let cancellable = Auth.auth().authStateDidChangePublisher()
+    let cancellable = Auth.authPublisher().authStateDidChangePublisher()
       .sink { user in
         print("Running on the main thread? \(Thread.isMainThread)")
 
@@ -189,7 +189,7 @@ class AuthStateDidChangePublisherTests: XCTestCase {
 
     var expect = expectation(description: "Publisher emits value when user is signed in")
 
-    let cancellable = Auth.auth().authStateDidChangePublisher()
+    let cancellable = Auth.authPublisher().authStateDidChangePublisher()
       .sink { user in
         if let user = user, user.isAnonymous {
           expect.fulfill()
@@ -218,7 +218,7 @@ class AuthStateDidChangePublisherTests: XCTestCase {
     var expect = expectation(description: "Publisher emits value when user is signed in")
     var shouldUserBeNil = false
 
-    let cancellable = Auth.auth().authStateDidChangePublisher()
+    let cancellable = Auth.authPublisher().authStateDidChangePublisher()
       .sink { user in
         if shouldUserBeNil {
           if user == nil {
@@ -254,7 +254,7 @@ class AuthStateDidChangePublisherTests: XCTestCase {
     var expect = expectation(description: "Publisher emits value when user is signed in")
     var shouldUserBeNil = false
 
-    let cancellable = Auth.auth().authStateDidChangePublisher()
+    let cancellable = Auth.authPublisher().authStateDidChangePublisher()
       .sink { user in
         if shouldUserBeNil {
           if user == nil {

--- a/FirebaseCombineSwift/Tests/Unit/Auth/EmailLinkAuthTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/EmailLinkAuthTests.swift
@@ -92,7 +92,7 @@ class EmailLinkAuthTests: XCTestCase {
   func testSignInUserWithEmailAndLink() {
     // given
     FIRAuthBackend.setBackendImplementation(MockAuthBackend())
-    let auth = Auth.auth(app: app())
+    let auth = Auth.authPublisher(app: app())
 
     var cancellables = Set<AnyCancellable>()
     let userSignInExpectation = expectation(description: "User signed in")
@@ -124,7 +124,7 @@ class EmailLinkAuthTests: XCTestCase {
   func testSendSignInLinkToEmail() {
     // given
     FIRAuthBackend.setBackendImplementation(MockAuthBackend())
-    let auth = Auth.auth(app: app())
+    let auth = Auth.authPublisher(app: app())
 
     var cancellables = Set<AnyCancellable>()
     let sendSignInLinkExpectation = expectation(description: "Sign in link sent")

--- a/FirebaseCombineSwift/Tests/Unit/Auth/EmailPasswordAuthTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/EmailPasswordAuthTests.swift
@@ -116,7 +116,7 @@ class EmailPasswordAuthTests: XCTestCase {
     let userCreatedExpectation = expectation(description: "User created")
 
     // when
-    Auth.auth()
+    Auth.authPublisher()
       .createUser(
         withEmail: EmailPasswordAuthTests.email,
         password: EmailPasswordAuthTests.password
@@ -152,7 +152,7 @@ class EmailPasswordAuthTests: XCTestCase {
     let userSignInExpectation = expectation(description: "User signed in")
 
     // when
-    Auth.auth()
+    Auth.authPublisher()
       .signIn(withEmail: EmailPasswordAuthTests.email, password: EmailPasswordAuthTests.password)
       .sink { completion in
         switch completion {

--- a/FirebaseCombineSwift/Tests/Unit/Auth/FetchSignInMethodsTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/FetchSignInMethodsTests.swift
@@ -71,7 +71,7 @@ class FetchSignInMethodsTests: XCTestCase {
     let fetchSignInMethodsExpectation = expectation(description: "Fetched Sign-in methods")
 
     // when
-    Auth.auth()
+    Auth.authPublisher()
       .fetchSignInMethods(forEmail: FetchSignInMethodsTests.email)
       .sink { completion in
         switch completion {

--- a/FirebaseCombineSwift/Tests/Unit/Auth/IDTokenDidChangePublisherTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/IDTokenDidChangePublisherTests.swift
@@ -98,7 +98,7 @@ class IDTokenDidChangePublisherTests: XCTestCase {
     //
     // 1) Publisher should emit as soon as it is registered
     var expect = expectation(description: "Publisher emits value as soon as it is subscribed")
-    var cancellable = Auth.auth()
+    var cancellable = Auth.authPublisher()
       .idTokenDidChangePublisher()
       .sink { user in
         XCTAssertNil(user)
@@ -110,7 +110,7 @@ class IDTokenDidChangePublisherTests: XCTestCase {
     //
     // 2) Publisher should emit when user is signed in
     expect = expectation(description: "Publisher emits value when user is signed in")
-    cancellable = Auth.auth()
+    cancellable = Auth.authPublisher()
       .idTokenDidChangePublisher()
       .sink { user in
         if let user = user, user.isAnonymous {
@@ -126,7 +126,7 @@ class IDTokenDidChangePublisherTests: XCTestCase {
     // 3) Publisher should not fire for signing in again
     expect = expectation(description: "Publisher emits value when user is signed in")
 
-    cancellable = Auth.auth()
+    cancellable = Auth.authPublisher()
       .idTokenDidChangePublisher()
       .sink { user in
         if let user = user, user.isAnonymous {
@@ -153,7 +153,7 @@ class IDTokenDidChangePublisherTests: XCTestCase {
     expect = expectation(description: "Publisher emits value when user is signed in")
     var shouldUserBeNil = false
 
-    cancellable = Auth.auth()
+    cancellable = Auth.authPublisher()
       .idTokenDidChangePublisher()
       .sink { user in
         if shouldUserBeNil {
@@ -187,7 +187,7 @@ class IDTokenDidChangePublisherTests: XCTestCase {
     expect = expectation(description: "Publisher emits value when user is signed in")
     shouldUserBeNil = false
 
-    cancellable = Auth.auth()
+    cancellable = Auth.authPublisher()
       .idTokenDidChangePublisher()
       .sink { user in
         if shouldUserBeNil {

--- a/FirebaseCombineSwift/Tests/Unit/Auth/PasswordResetTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/PasswordResetTests.swift
@@ -70,7 +70,7 @@ class PasswordResetTests: XCTestCase {
     let confirmPasswordResetExpectation = expectation(description: "Password reset confirmed")
 
     // when
-    Auth.auth()
+    Auth.authPublisher()
       .confirmPasswordReset(
         withCode: PasswordResetTests.fakeCode,
         newPassword: PasswordResetTests.fakeNewPassword
@@ -116,7 +116,7 @@ class PasswordResetTests: XCTestCase {
       expectation(description: "Password reset code verified")
 
     // when
-    Auth.auth()
+    Auth.authPublisher()
       .verifyPasswordResetCode(PasswordResetTests.fakeCode)
       .sink { completion in
         switch completion {
@@ -159,7 +159,7 @@ class PasswordResetTests: XCTestCase {
     let checkActionCodeExpectation = expectation(description: "Action code checked")
 
     // when
-    Auth.auth()
+    Auth.authPublisher()
       .checkActionCode(code: PasswordResetTests.fakeCode)
       .sink { completion in
         switch completion {
@@ -197,7 +197,7 @@ class PasswordResetTests: XCTestCase {
     let applyActionCodeExpectation = expectation(description: "Action code applied")
 
     // when
-    Auth.auth()
+    Auth.authPublisher()
       .applyActionCode(code: PasswordResetTests.fakeCode)
       .sink { completion in
         switch completion {
@@ -234,7 +234,7 @@ class PasswordResetTests: XCTestCase {
     let sendPasswordResetExpectation = expectation(description: "Password reset sent")
 
     // when
-    Auth.auth()
+    Auth.authPublisher()
       .sendPasswordReset(withEmail: PasswordResetTests.fakeEmail)
       .sink { completion in
         switch completion {

--- a/FirebaseCombineSwift/Tests/Unit/Auth/SignInWithCustomTokenTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/SignInWithCustomTokenTests.swift
@@ -105,7 +105,7 @@ class SignInWithCustomTokenTests: XCTestCase {
     let userSignInExpectation = expectation(description: "User signed in")
 
     // when
-    Auth.auth()
+    Auth.authPublisher()
       .signIn(withCustomToken: SignInWithCustomTokenTests.customToken)
       .sink { completion in
         switch completion {

--- a/FirebaseCombineSwift/Tests/Unit/Auth/SignInWithProviderTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/SignInWithProviderTests.swift
@@ -135,7 +135,7 @@ class SignInWithProviderTests: XCTestCase {
     let userSignInExpectation = expectation(description: "User signed in")
 
     // when
-    Auth.auth()
+    Auth.authPublisher()
       .signIn(with: authProvider, uiDelegate: nil)
       .sink { completion in
         switch completion {

--- a/FirebaseCombineSwift/Tests/Unit/Auth/UpdateCurrentUserTests.swift
+++ b/FirebaseCombineSwift/Tests/Unit/Auth/UpdateCurrentUserTests.swift
@@ -95,7 +95,7 @@ class UpdateCurrentUserTests: XCTestCase {
 
   func waitForSignIn(with accessToken: String, apiKey: String) {
     let userSignedInExpectation = expectation(description: "User signed in")
-    let cancellable = Auth.auth()
+    let cancellable = Auth.authPublisher()
       .signIn(withEmail: UpdateCurrentUserTests.email, password: UpdateCurrentUserTests.password)
       .sink { completion in
         switch completion {
@@ -136,7 +136,7 @@ class UpdateCurrentUserTests: XCTestCase {
 
     XCTAssertEqual(Auth.auth().currentUser, user2)
 
-    Auth.auth()
+    Auth.authPublisher()
       .updateCurrentUser(user1)
       .sink { completion in
         switch completion {


### PR DESCRIPTION
### Motiviation 

Define a `namespace` for the Auth publishers to avoid overload issues when the compiler cannot decide which overload to favor. For instance, overloading the `signOut` method for  Combine support leads to issues at compile time.

<img width="500" alt="Screenshot 2021-01-19 at 21 38 44" src="https://user-images.githubusercontent.com/1026099/105209270-f2d94e80-5b49-11eb-8b75-9a2d813f5a78.png">
