### PR TITLE
More GHA consistency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     paths:
     - '.github/workflows/release.yml'
     - 'scripts/create_spec_repo/**'
+    - 'Gemfile'
   workflow_dispatch:
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times

--- a/.github/workflows/spm.yml
+++ b/.github/workflows/spm.yml
@@ -5,7 +5,7 @@ on:
     paths:
     - '.github/workflows/spm.yml'
     - 'Package.swift'
-    - 'Google*'
+    - 'Gemfile'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'

--- a/.github/workflows/symbolcollision.yml
+++ b/.github/workflows/symbolcollision.yml
@@ -7,6 +7,7 @@ on:
     paths:
     - '.github/workflows/symbolcollision.yml'
     - 'SymbolCollisionTest/**'
+    - 'Gemfile'
   schedule:
     # Run every day at 11pm (PST) - cron uses UTC times
     - cron:  '0 7 * * *'

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -5,6 +5,7 @@ on:
     paths:
     - 'ReleaseTooling/**'
     - '.github/workflows/zip.yml'
+    - 'Gemfile'
     # Don't run based on any markdown only changes.
     - '!ReleaseTooling/*.md'
   schedule:


### PR DESCRIPTION
SPM tests should not run when `GoogleAppMeasurement.podspec.json` or other `Google` files are changed.

Changing `Gemfile` should trigger all workflows.