### PR TITLE
Allow http schemes when using the auth emulator

### DIFF
--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- [fixed] Allow http schemes when using the auth emulator. (#7350)
+
 # 7.4.0
 - [fixed] Check if the reverse client ID is configured as a custom URL scheme before setting it as the callback scheme. (#7211)
 - [added] Add ability to sync auth state across devices. (#6924)

--- a/FirebaseAuth/CHANGELOG.md
+++ b/FirebaseAuth/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-- [fixed] Allow http schemes when using the auth emulator. (#7350)
+- [fixed] Auth emulator now works across the local network. (#7350)
 
 # 7.4.0
 - [fixed] Check if the reverse client ID is configured as a custom URL scheme before setting it as the callback scheme. (#7211)

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -654,7 +654,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   NSString *emulatorHostAndPort = requestConfiguration.emulatorHostAndPort;
   if (emulatorHostAndPort) {
     fetcher.allowLocalhostRequest = YES;
-    fetcher.allowedInsecureSchemes = @[@"http"];
+    fetcher.allowedInsecureSchemes = @[ @"http" ];
   }
   fetcher.bodyData = body;
   [fetcher beginFetchWithCompletionHandler:handler];

--- a/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
+++ b/FirebaseAuth/Sources/Backend/FIRAuthBackend.m
@@ -654,6 +654,7 @@ static id<FIRAuthBackendImplementation> gBackendImplementation;
   NSString *emulatorHostAndPort = requestConfiguration.emulatorHostAndPort;
   if (emulatorHostAndPort) {
     fetcher.allowLocalhostRequest = YES;
+    fetcher.allowedInsecureSchemes = @[@"http"];
   }
   fetcher.bodyData = body;
   [fetcher beginFetchWithCompletionHandler:handler];


### PR DESCRIPTION
Fix #7342