### PR TITLE
When building protoc, also check if CMAKE_CROSSCOMPILING is set.

### DIFF
--- a/Firestore/Protos/CMakeLists.txt
+++ b/Firestore/Protos/CMakeLists.txt
@@ -22,7 +22,7 @@ set(OUTPUT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 # On Windows, this *could* work, but it's not worth the time to figure out why
 # because the generated sources are already checked in.
 set(FIREBASE_IOS_PROTOC_GENERATE_SOURCES ON)
-if(WIN32 OR IOS OR ANDROID)
+if(WIN32 OR IOS OR ANDROID OR CMAKE_CROSSCOMPILING)
   set(FIREBASE_IOS_PROTOC_GENERATE_SOURCES OFF)
 endif()
 


### PR DESCRIPTION
CMAKE_CROSSCOMPILING is the standard variable to be set when you are building for a platform that is incompatible with the one you are running on. Checking if this is set allows Firestore to use external protoc in the case of cross-compiling (e.g. arm64 mac builds on an x64 mac) in addition to the current cases of building for mobile.