### PR TITLE
Remove watchOS for Crashlytics Pod Gen

### DIFF
--- a/Crashlytics/generate_project.sh
+++ b/Crashlytics/generate_project.sh
@@ -19,4 +19,4 @@ readonly DIR="$( git rev-parse --show-toplevel )"
 
 "$DIR/Crashlytics/ProtoSupport/generate_crashlytics_protos.sh" || echo "Something went wrong generating protos.";
 
-pod gen "${DIR}/FirebaseCrashlytics.podspec" --auto-open --gen-directory="${DIR}/gen" --local-sources="${DIR}" --platforms=ios,macos,tvos,watchos --clean
+pod gen "${DIR}/FirebaseCrashlytics.podspec" --auto-open --gen-directory="${DIR}/gen" --local-sources="${DIR}" --platforms=ios,macos,tvos --clean


### PR DESCRIPTION
When I pod gen, it gives me this error. Updating our main script to pod gen to remove watchOS.


```
Generating FirebaseCrashlytics in `gen/FirebaseCrashlytics`
    Creating stub application
    Writing Podfile

Installing...
[!] The platform of the target `App-watchOS` (watchOS 6.0) is not compatible with `FirebaseCrashlytics/unit (7.4.0)`, which does not support `watchOS`.
```