### PR TITLE
Add getData overload to DatabaseReference

### DIFF
--- a/FirebaseDatabase/Sources/FIRDatabaseReference.m
+++ b/FirebaseDatabase/Sources/FIRDatabaseReference.m
@@ -443,6 +443,12 @@
 // These methods suppress warnings from having method definitions in
 // FIRDatabaseReference.h for docs generation.
 
+- (void)getDataWithCompletionBlock:
+    (void (^_Nonnull)(NSError *__nullable error,
+                      FIRDataSnapshot *snapshot))block {
+    [super getDataWithCompletionBlock:block];
+}
+
 - (FIRDatabaseQuery *)queryLimitedToFirst:(NSUInteger)limit {
     return [super queryLimitedToFirst:limit];
 }

--- a/FirebaseDatabase/Sources/Public/FirebaseDatabase/FIRDatabaseReference.h
+++ b/FirebaseDatabase/Sources/Public/FirebaseDatabase/FIRDatabaseReference.h
@@ -367,6 +367,19 @@ priority is meant to be preserved, you should use setValue:andPriority: instead.
                    withCancelBlock:
                        (nullable void (^)(NSError *error))cancelBlock;
 
+/**
+ * getDataWithCompletionBlock: is used to get the most up-to-date value for
+ * this query. This method updates the cache and raises events if successful. If
+ * not connected, falls back to a locally-cached value.
+ *
+ * @param block The block that should be called with the most up-to-date value
+ * of this query, or an error if no such value could be retrieved.
+ */
+- (void)getDataWithCompletionBlock:
+    (void (^_Nonnull)(NSError *__nullable error,
+                      FIRDataSnapshot *snapshot))block
+    NS_SWIFT_NAME(getData(completion:));
+
 #pragma mark - Detaching observers
 
 /**


### PR DESCRIPTION
The goal is to have the overload show up on the API documentation. This matches all other overloads.