### PR TITLE
Remove ReleaseTooling special casing for non-Firebase pods

### DIFF
--- a/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/FirebaseManifest.swift
@@ -23,9 +23,6 @@ import Foundation
 public let shared = Manifest(
   version: "7.4.0",
   pods: [
-    Pod("GoogleUtilities", isFirebase: false, podVersion: "7.2.0", releasing: true),
-    Pod("GoogleDataTransport", isFirebase: false, podVersion: "8.2.0", releasing: true),
-
     Pod("FirebaseCoreDiagnostics"),
     Pod("FirebaseCore"),
     Pod("FirebaseInstallations"),
@@ -61,6 +58,6 @@ public struct Manifest {
   public let pods: [Pod]
 
   public func versionString(_ pod: Pod) -> String {
-    return pod.podVersion ?? (pod.isBeta ? version + "-beta" : version)
+    return pod.isBeta ? version + "-beta" : version
   }
 }

--- a/ReleaseTooling/Sources/FirebaseManifest/Pod.swift
+++ b/ReleaseTooling/Sources/FirebaseManifest/Pod.swift
@@ -21,17 +21,14 @@ public struct Pod {
   public let name: String
   public let isClosedSource: Bool
   public let isBeta: Bool
-  public let isFirebase: Bool
   public let allowWarnings: Bool // Allow validation warnings. Ideally these should all be false
   public let platforms: Set<String> // Set of platforms to build this pod for
-  public let podVersion: String? // Non-Firebase pods have their own version
   public let releasing: Bool // Non-Firebase pods may not release
   public let zip: Bool // Top level pod in Zip Distribution
 
   init(_ name: String,
        isClosedSource: Bool = false,
        isBeta: Bool = false,
-       isFirebase: Bool = true,
        allowWarnings: Bool = false,
        platforms: Set<String> = ["ios", "macos", "tvos"],
        podVersion: String? = nil,
@@ -40,10 +37,8 @@ public struct Pod {
     self.name = name
     self.isClosedSource = isClosedSource
     self.isBeta = isBeta
-    self.isFirebase = isFirebase
     self.allowWarnings = allowWarnings
     self.platforms = platforms
-    self.podVersion = podVersion
     self.releasing = releasing
     self.zip = zip
   }

--- a/ReleaseTooling/Sources/FirebaseReleaser/InitializeRelease.swift
+++ b/ReleaseTooling/Sources/FirebaseReleaser/InitializeRelease.swift
@@ -71,9 +71,6 @@ struct InitializeRelease {
     }
     let firebaseVersion = manifest.version
     for firebasePod in manifest.pods {
-      if !firebasePod.isFirebase {
-        continue
-      }
       let pod = firebasePod.name
       let version = firebasePod.isBeta ? firebaseVersion + "-beta" : firebaseVersion
       if pod == "Firebase" {

--- a/ReleaseTooling/Sources/FirebaseReleaser/Tags.swift
+++ b/ReleaseTooling/Sources/FirebaseReleaser/Tags.swift
@@ -29,17 +29,6 @@ enum Tags {
               deleteExistingTags: deleteExistingTags)
     createTag(gitRoot: gitRoot, tag: "CocoaPods-\(manifest.version)-beta",
               deleteExistingTags: deleteExistingTags)
-
-    for pod in manifest.pods.filter({ !$0.isFirebase && $0.releasing }) {
-      if !pod.name.starts(with: "Google") {
-        fatalError("Unrecognized Other Pod: \(pod.name). Only Google prefix is recognized")
-      }
-      guard let version = pod.podVersion else {
-        fatalError("Non-Firebase pod \(pod.name) is missing a version")
-      }
-      let tag = pod.name.replacingOccurrences(of: "Google", with: "") + "-" + version
-      createTag(gitRoot: gitRoot, tag: tag, deleteExistingTags: deleteExistingTags)
-    }
   }
 
   static func updateTags(gitRoot: URL) {

--- a/ReleaseTooling/Sources/ZipBuilder/CocoaPodUtils.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/CocoaPodUtils.swift
@@ -514,9 +514,7 @@ enum CocoaPodUtils {
           podspec == "FirebaseCoreDiagnostics.podspec" ||
           podspec == "FirebaseCore.podspec" ||
           podspec == "FirebaseRemoteConfig.podspec" ||
-          podspec == "FirebaseABTesting.podspec" ||
-          podspec == "GoogleUtilities.podspec" ||
-          podspec == "GoogleDataTransport.podspec" {
+          podspec == "FirebaseABTesting.podspec" {
           let podName = podspec.replacingOccurrences(of: ".podspec", with: "")
           podfile += "  pod '\(podName)', :path => '\(localURL.path)/\(podspec)'\n"
         }


### PR DESCRIPTION
Now that GoogleUtilities and GoogleDataTransport have their own repos and release processes

#no-changelog