### PR TITLE
Fix Crashlytics macOS cron test

### DIFF
--- a/.github/workflows/crashlytics.yml
+++ b/.github/workflows/crashlytics.yml
@@ -108,8 +108,8 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        # Disable macos because of #7154. watchos does not support XCTest.
-        target: [ios, tvos, macos --skip-tests, watchos --skip-tests]
+        # Disable watchos because it does not support XCTest.
+        target: [ios, tvos, macos, watchos --skip-tests]
         flags: [
           '--use-static-frameworks',
           '--use-libraries'

--- a/Crashlytics/UnitTests/FIRCLSProcessReportOperationTests.m
+++ b/Crashlytics/UnitTests/FIRCLSProcessReportOperationTests.m
@@ -31,13 +31,13 @@
 
 - (void)setUp {
   [super setUp];
-  // Put setup code here. This method is called before the invocation of each test method in the
-  // class.
+
+  [[NSFileManager defaultManager] removeItemAtPath:self.reportPath error:nil];
 }
 
 - (void)tearDown {
-  // Put teardown code here. This method is called after the invocation of each test method in the
-  // class.
+  [[NSFileManager defaultManager] removeItemAtPath:self.reportPath error:nil];
+
   [super tearDown];
 }
 

--- a/Crashlytics/UnitTests/FIRCLSProcessReportOperationTests.m
+++ b/Crashlytics/UnitTests/FIRCLSProcessReportOperationTests.m
@@ -45,15 +45,17 @@
   return [[NSBundle bundleForClass:[self class]] resourcePath];
 }
 
+- (NSString *)reportPath {
+  return [NSTemporaryDirectory() stringByAppendingPathComponent:@"execution_identifier"];
+}
+
 - (NSString *)pathForResource:(NSString *)name {
   return [[self resourcePath] stringByAppendingPathComponent:name];
 }
 
 - (FIRCLSInternalReport *)createReportAndPath {
-  NSString *reportPath =
-      [NSTemporaryDirectory() stringByAppendingPathComponent:@"execution_identifier"];
   FIRCLSInternalReport *report =
-      [[FIRCLSInternalReport alloc] initWithPath:reportPath
+      [[FIRCLSInternalReport alloc] initWithPath:self.reportPath
                              executionIdentifier:@"execution_identifier"];
 
   // create the directory path


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-ios-sdk/issues/7154 so we can run macOS nightly unit tests.

 - Root cause was a previously deleted test happened to do the teardown and cleanup that this test depended on: https://github.com/firebase/firebase-ios-sdk/commit/5c1a83dd0f7d24b26e5c7174de9f291a8976a191#diff-9e4e9c85fb337baa24ba87256cddd232a6d714bbea09cf7256eed27170928fd0L56-L57

#crashfixit2021 #no-changelog