### PR TITLE
Fix build_non_firebase_sdks.sh for 7.x Swift pods

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
     paths:
     - '.github/workflows/release.yml'
     - 'scripts/create_spec_repo/**'
-    - 'scripts/build_non_firebase_sdks.sh'
     - 'Gemfile'
   workflow_dispatch:
   schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     paths:
     - '.github/workflows/release.yml'
     - 'scripts/create_spec_repo/**'
+    - 'scripts/build_non_firebase_sdks.sh'
     - 'Gemfile'
   workflow_dispatch:
   schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       bot_token_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
       local_repo: specstesting
-      nightly_version: "6.32.1"
+      nightly_version: "7.5.0"
       local_sdk_repo_dir: /tmp/test/firebase-ios-sdk
       podspec_repo_branch: master
     runs-on: macOS-latest

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -5,6 +5,7 @@ on:
     paths:
     - 'ReleaseTooling/**'
     - '.github/workflows/zip.yml'
+    - 'scripts/build_non_firebase_sdks.sh'
     - 'Gemfile'
     # Don't run based on any markdown only changes.
     - '!ReleaseTooling/*.md'

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -322,7 +322,7 @@ jobs:
 
   quickstart_framework_firestore:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+#    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
     needs: package
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -322,7 +322,7 @@ jobs:
 
   quickstart_framework_firestore:
     # Don't run on private repo.
-#    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
     needs: package
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}

--- a/scripts/build_non_firebase_sdks.sh
+++ b/scripts/build_non_firebase_sdks.sh
@@ -27,7 +27,13 @@ num_sdk="${#NON_FIREBASE_SDKS[@]}"
 echo "[" >> "${ZIP_POD_JSON}"
 for sdk in "${NON_FIREBASE_SDKS[@]}"
 do
-  echo "{\"name\":\"${sdk}\"}" >>  "${ZIP_POD_JSON}"
+  if [ ${sdk} == "FirebaseFirestoreSwift" ]; then
+    echo "{\"name\":\"FirebaseFirestoreSwift\", \"version\" : \"~> 7.5-beta\"}" >>  "${ZIP_POD_JSON}"
+  elif [ ${sdk} == "FirebaseStorageSwift" ]; then
+    echo "{\"name\":\"FirebaseStorageSwift\", \"version\" : \"~> 7.5-beta\"}" >>  "${ZIP_POD_JSON}"
+  else
+    echo "{\"name\":\"${sdk}\"}" >>  "${ZIP_POD_JSON}"
+  fi
   if [ "$num_sdk" -ne 1 ]; then
     echo ",">>  "${ZIP_POD_JSON}"
   fi
@@ -42,5 +48,3 @@ unzip -o "${REPO}"/sdk_zip/Frameworks.zip -d "${HOME}"/ios_frameworks/Firebase/
 
 # Move Frameworks to Firebase dir, so be align with Firebase SDKs.
 mv -n "${HOME}"/ios_frameworks/Firebase/Binaries "${HOME}"/ios_frameworks/Firebase/NonFirebaseSDKs/
-
-

--- a/scripts/create_spec_repo/Sources/SpecRepoBuilder/main.swift
+++ b/scripts/create_spec_repo/Sources/SpecRepoBuilder/main.swift
@@ -244,7 +244,7 @@ struct SpecRepoBuilder: ParsableCommand {
         )
     shell.run("pod repo update")
 
-    print ("Outcome is \(outcome)")
+    print("Outcome is \(outcome)")
 
     return outcome
   }

--- a/scripts/create_spec_repo/Sources/SpecRepoBuilder/main.swift
+++ b/scripts/create_spec_repo/Sources/SpecRepoBuilder/main.swift
@@ -244,6 +244,8 @@ struct SpecRepoBuilder: ParsableCommand {
         )
     shell.run("pod repo update")
 
+    print ("Outcome is \(outcome)")
+
     return outcome
   }
 
@@ -344,6 +346,7 @@ struct SpecRepoBuilder: ParsableCommand {
       if podExitCode != 0 {
         exitCode = 1
         failedPods.append(pod)
+        print("Failed pod - \(pod)")
       }
     }
     if exitCode != 0 {


### PR DESCRIPTION
The nightly tests were building the FirebaseSwift pods for Firebase 6.x because they weren't updated to include the beta version specification now required with Firebase 7.x.

This went unnoticed until a FirebaseUI regression firebase/FirebaseUI-iOS#936 occurred yesterday exposing this.

Fix #7389