### PR TITLE
Fix a crash that happens when Firestore is being terminated when the last shared pointer to it is in a listener

### DIFF
--- a/Firestore/CHANGELOG.md
+++ b/Firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [fixed] Fixed a crash that would happen when the app is being deleted and
+  immediately disposed of and there's an active listener (#6909).
+
 # v7.5.0
 - [changed] A write to a document that contains FieldValue transforms is no
   longer split up into two separate operations. This reduces the number of

--- a/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_IntegrationTests_iOS.xcscheme
+++ b/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_IntegrationTests_iOS.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      enableAddressSanitizer = "YES"
       enableASanStackUseAfterReturn = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_IntegrationTests_iOS.xcscheme
+++ b/Firestore/Example/Firestore.xcodeproj/xcshareddata/xcschemes/Firestore_IntegrationTests_iOS.xcscheme
@@ -27,7 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      enableAddressSanitizer = "YES"
       enableASanStackUseAfterReturn = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
@@ -1441,7 +1441,7 @@ using firebase::firestore::util::TimerId;
   XCTAssertTrue(firestore.wrapped->client()->is_terminated());
 }
 
-// The test ensures b/172958106 doesn't regress.
+// Ensures b/172958106 doesn't regress.
 - (void)testDeleteAppWorksWhenLastReferenceToFirestoreIsInListener {
   FIRApp *app = testutil::AppForUnitTesting(util::MakeString([FSTIntegrationTestCase projectID]));
   FIRFirestore *firestore = [FIRFirestore firestoreForApp:app];

--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
@@ -1441,6 +1441,30 @@ using firebase::firestore::util::TimerId;
   XCTAssertTrue(firestore.wrapped->client()->is_terminated());
 }
 
+// The test ensures b/172958106 doesn't regress.
+- (void)testDeleteAppWorksWhenLastReferenceToFirestoreIsInListener {
+  FIRApp *app = testutil::AppForUnitTesting(util::MakeString([FSTIntegrationTestCase projectID]));
+  FIRFirestore *firestore = [FIRFirestore firestoreForApp:app];
+
+  FIRDocumentReference *doc = [firestore documentWithPath:@"abc/123"];
+  // Make sure there is a listener.
+  [doc addSnapshotListener:^(FIRDocumentSnapshot *snapshot, NSError *) {
+  }];
+  NSDictionary<NSString *, id> *data =
+      @{@"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"}};
+  // Make sure the client is initialized.
+  [self writeDocumentRef:doc data:data];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"App is deleted"];
+  [app deleteApp:^(BOOL success) {
+    [expectation fulfill];
+  }];
+  // Let go of the last app reference.
+  app = nil;
+
+  [self awaitExpectations];
+}
+
 - (void)testTerminateCanBeCalledMultipleTimes {
   FIRApp *app = testutil::AppForUnitTesting(util::MakeString([FSTIntegrationTestCase projectID]));
   FIRFirestore *firestore = [FIRFirestore firestoreForApp:app];

--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
@@ -1448,7 +1448,7 @@ using firebase::firestore::util::TimerId;
 
   FIRDocumentReference *doc = [firestore documentWithPath:@"abc/123"];
   // Make sure there is a listener.
-  [doc addSnapshotListener:^(FIRDocumentSnapshot *snapshot, NSError *) {
+  [doc addSnapshotListener:^(FIRDocumentSnapshot *snapshot, NSError *){
   }];
   NSDictionary<NSString *, id> *data =
       @{@"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"}};

--- a/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRDatabaseTests.mm
@@ -1448,7 +1448,7 @@ using firebase::firestore::util::TimerId;
 
   FIRDocumentReference *doc = [firestore documentWithPath:@"abc/123"];
   // Make sure there is a listener.
-  [doc addSnapshotListener:^(FIRDocumentSnapshot *snapshot, NSError *){
+  [doc addSnapshotListener:^(FIRDocumentSnapshot *, NSError *){
   }];
   NSDictionary<NSString *, id> *data =
       @{@"owner" : @{@"name" : @"Jonny", @"email" : @"abc@xyz.com"}};
@@ -1456,7 +1456,7 @@ using firebase::firestore::util::TimerId;
   [self writeDocumentRef:doc data:data];
 
   XCTestExpectation *expectation = [self expectationWithDescription:@"App is deleted"];
-  [app deleteApp:^(BOOL success) {
+  [app deleteApp:^(BOOL) {
     [expectation fulfill];
   }];
   // Let go of the last app reference.

--- a/Firestore/Example/Tests/Integration/API/FIRFieldsTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRFieldsTests.mm
@@ -21,13 +21,6 @@
 
 #import "Firestore/Example/Tests/Util/FSTIntegrationTestCase.h"
 
-#import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
-#include "Firestore/core/src/util/string_apple.h"
-#include "Firestore/core/test/unit/testutil/app_testing.h"
-
-namespace testutil = firebase::firestore::testutil;
-namespace util = firebase::firestore::util;
-
 NS_ASSUME_NONNULL_BEGIN
 
 @interface FIRFieldsTests : FSTIntegrationTestCase

--- a/Firestore/Example/Tests/Integration/API/FIRFieldsTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRFieldsTests.mm
@@ -263,29 +263,6 @@ NSDictionary<NSString *, id> *testDataWithTimestamps(FIRTimestamp *timestamp) {
   XCTAssertEqualObjects(timestampFromSnapshot, timestampFromData);
 }
 
-- (void)testDeleteAppOBC {
-  FIRApp *app = testutil::AppForUnitTesting(util::MakeString([FSTIntegrationTestCase projectID]));
-
-  FIRFirestore *firestore = [FIRFirestore firestoreForApp:app];
-  FIRDocumentReference *doc = [firestore documentWithPath:@"foo/bar"];
-  [doc addSnapshotListener:^(FIRDocumentSnapshot *snapshot, NSError *) {
-  }];
-  [self writeDocumentRef:doc data:@{@"foo": @"bar"}];
-
-  XCTestExpectation *defaultAppDeletedExpectation =
-      [self expectationWithDescription:@"Deleting the default app should invalidate the default "
-                                       @"Firestore instance."];
-  [app deleteApp:^(BOOL success) {
-    [defaultAppDeletedExpectation fulfill];
-  }];
-  app = nil;
-
-  [self waitForExpectationsWithTimeout:2
-                               handler:^(NSError *_Nullable error) {
-                                 XCTAssertNil(error);
-                               }];
-}
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Firestore/Example/Tests/Integration/API/FIRFieldsTests.mm
+++ b/Firestore/Example/Tests/Integration/API/FIRFieldsTests.mm
@@ -22,9 +22,11 @@
 #import "Firestore/Example/Tests/Util/FSTIntegrationTestCase.h"
 
 #import "FirebaseCore/Sources/Private/FirebaseCoreInternal.h"
+#include "Firestore/core/src/util/string_apple.h"
 #include "Firestore/core/test/unit/testutil/app_testing.h"
 
 namespace testutil = firebase::firestore::testutil;
+namespace util = firebase::firestore::util;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -262,7 +264,7 @@ NSDictionary<NSString *, id> *testDataWithTimestamps(FIRTimestamp *timestamp) {
 }
 
 - (void)testDeleteAppOBC {
-  FIRApp *app = testutil::AppForUnitTesting();
+  FIRApp *app = testutil::AppForUnitTesting(util::MakeString([FSTIntegrationTestCase projectID]));
 
   FIRFirestore *firestore = [FIRFirestore firestoreForApp:app];
   FIRDocumentReference *doc = [firestore documentWithPath:@"foo/bar"];

--- a/Firestore/core/src/api/firestore.cc
+++ b/Firestore/core/src/api/firestore.cc
@@ -219,7 +219,8 @@ void Firestore::EnsureClientConfigured() {
     HARD_ASSERT(worker_queue_, "Expected non-null worker queue");
     client_ = FirestoreClient::Create(
         MakeDatabaseInfo(), settings_, std::move(credentials_provider_),
-        user_executor_, worker_queue_, std::move(firebase_metadata_provider_));
+        user_executor_, worker_queue_, std::move(firebase_metadata_provider_),
+        shared_from_this());
   }
 }
 

--- a/Firestore/core/src/api/firestore.cc
+++ b/Firestore/core/src/api/firestore.cc
@@ -219,8 +219,7 @@ void Firestore::EnsureClientConfigured() {
     HARD_ASSERT(worker_queue_, "Expected non-null worker queue");
     client_ = FirestoreClient::Create(
         MakeDatabaseInfo(), settings_, std::move(credentials_provider_),
-        user_executor_, worker_queue_, std::move(firebase_metadata_provider_),
-        shared_from_this());
+        user_executor_, worker_queue_, std::move(firebase_metadata_provider_));
   }
 }
 

--- a/Firestore/core/src/core/firestore_client.cc
+++ b/Firestore/core/src/core/firestore_client.cc
@@ -64,6 +64,7 @@ namespace core {
 using api::DocumentReference;
 using api::DocumentSnapshot;
 using api::DocumentSnapshotListener;
+using api::Firestore;
 using api::ListenerRegistration;
 using api::QuerySnapshot;
 using api::QuerySnapshotListener;

--- a/Firestore/core/src/core/firestore_client.cc
+++ b/Firestore/core/src/core/firestore_client.cc
@@ -236,8 +236,8 @@ void FirestoreClient::Dispose() {
   bool enqueued = false;
   // If termination has finished already, enqueing termination again is not only
   // unnecessary, but also dangerous in the case when `Dispose` is invoked
-  // immediately after the termination, still on the worker queue -- it would
-  // break the sequential order invariant of the queue.
+  // from `TerminateInternal`, still on the worker queue -- it would break the
+  // sequential order invariant of the queue.
   if (!is_terminated()) {
     // Prevent new API invocations from enqueueing further work.
     worker_queue_->EnterRestrictedMode();

--- a/Firestore/core/src/core/firestore_client.cc
+++ b/Firestore/core/src/core/firestore_client.cc
@@ -276,10 +276,10 @@ void FirestoreClient::Dispose() {
 }
 
 void FirestoreClient::TerminateAsync(StatusCallback callback) {
-  std::lock_guard<std::mutex> lock(mutex_);
+  // std::lock_guard<std::mutex> lock(mutex_);
 
-  if (!terminated_) {
-    terminated_ = true;
+  // if (!terminated_) {
+    // terminated_ = true;
 
     worker_queue_->EnterRestrictedMode();
     worker_queue_->EnqueueEvenWhileRestricted([&, this, callback] {
@@ -291,7 +291,7 @@ void FirestoreClient::TerminateAsync(StatusCallback callback) {
         user_executor_->Execute([=] { callback(Status::OK()); });
       }
     });
-  }
+  // }
 }
 
 void FirestoreClient::TerminateInternal() {

--- a/Firestore/core/src/core/firestore_client.cc
+++ b/Firestore/core/src/core/firestore_client.cc
@@ -167,7 +167,7 @@ FirestoreClient::FirestoreClient(
       worker_queue_(std::move(worker_queue)),
       user_executor_(std::move(user_executor)),
       firebase_metadata_provider_(std::move(firebase_metadata_provider)),
-      maybe_firestore_(std::move(firestore)) {
+      weak_firestore_(std::move(firestore)) {
 }
 
 void FirestoreClient::Initialize(const User& user, const Settings& settings) {
@@ -280,7 +280,7 @@ void FirestoreClient::TerminateAsync(StatusCallback callback) {
     auto self = shared_from_this();
     // Make sure that `api::Firestore` is not destroyed during the call to
     // `TerminateInternal`.
-    auto firestore = maybe_firestore_.lock();
+    auto firestore = weak_firestore_.lock();
     TerminateInternal();
 
     if (callback) {

--- a/Firestore/core/src/core/firestore_client.cc
+++ b/Firestore/core/src/core/firestore_client.cc
@@ -64,7 +64,6 @@ namespace core {
 using api::DocumentReference;
 using api::DocumentSnapshot;
 using api::DocumentSnapshotListener;
-using api::Firestore;
 using api::ListenerRegistration;
 using api::QuerySnapshot;
 using api::QuerySnapshotListener;

--- a/Firestore/core/src/core/firestore_client.cc
+++ b/Firestore/core/src/core/firestore_client.cc
@@ -118,7 +118,8 @@ std::shared_ptr<FirestoreClient> FirestoreClient::Create(
   // Have to use `new` because `make_shared` cannot access private constructor.
   std::shared_ptr<FirestoreClient> shared_client(new FirestoreClient(
       database_info, std::move(credentials_provider), std::move(user_executor),
-      std::move(worker_queue), std::move(firebase_metadata_provider), std::move(firestore)));
+      std::move(worker_queue), std::move(firebase_metadata_provider),
+      std::move(firestore)));
 
   std::weak_ptr<FirestoreClient> weak_client(shared_client);
   auto credential_change_listener = [weak_client, settings](User user) mutable {

--- a/Firestore/core/src/core/firestore_client.cc
+++ b/Firestore/core/src/core/firestore_client.cc
@@ -238,9 +238,8 @@ void FirestoreClient::Dispose() {
   // If termination has finished already, enqueing termination again is not only
   // unnecessary, but also dangerous in the case when `Dispose` is invoked
   // immediately after the termination, still on the worker queue -- it would
-  // break the sequential order invariant of the queue, and even if it didn't,
-  // waiting for `signal_disposing` would never finish.
-  if (!terminated_) {
+  // break the sequential order invariant of the queue.
+  if (!is_terminated()) {
     // Prevent new API invocations from enqueueing further work.
     worker_queue_->EnterRestrictedMode();
 
@@ -283,8 +282,7 @@ void FirestoreClient::TerminateAsync(StatusCallback callback) {
 }
 
 void FirestoreClient::TerminateInternal() {
-  if (terminated_) return;
-  terminated_ = true;
+  if (!remote_store_) return;
 
   credentials_provider_->SetCredentialChangeListener(nullptr);
   credentials_provider_.reset();

--- a/Firestore/core/src/core/firestore_client.cc
+++ b/Firestore/core/src/core/firestore_client.cc
@@ -244,7 +244,7 @@ void FirestoreClient::Dispose() {
   // dangerous in the case when `Dispose` is invoked immediately after the
   // termination, still on the worker queue -- it would break the sequential
   // order invariant of the queue.
-  if (is_terminated()) {
+  if (!is_terminated()) {
     // Prevent new API invocations from enqueueing further work.
     worker_queue_->EnterRestrictedMode();
 

--- a/Firestore/core/src/core/firestore_client.cc
+++ b/Firestore/core/src/core/firestore_client.cc
@@ -112,11 +112,13 @@ std::shared_ptr<FirestoreClient> FirestoreClient::Create(
     std::shared_ptr<CredentialsProvider> credentials_provider,
     std::shared_ptr<Executor> user_executor,
     std::shared_ptr<AsyncQueue> worker_queue,
-    std::unique_ptr<FirebaseMetadataProvider> firebase_metadata_provider) {
+    std::unique_ptr<FirebaseMetadataProvider> firebase_metadata_provider,
+    std::shared_ptr<Firestore> firestore) {
   // Have to use `new` because `make_shared` cannot access private constructor.
   std::shared_ptr<FirestoreClient> shared_client(new FirestoreClient(
       database_info, std::move(credentials_provider), std::move(user_executor),
-      std::move(worker_queue), std::move(firebase_metadata_provider)));
+      std::move(worker_queue), std::move(firebase_metadata_provider),
+      std::move(firestore)));
 
   std::weak_ptr<FirestoreClient> weak_client(shared_client);
   auto credential_change_listener = [weak_client, settings](User user) mutable {
@@ -158,12 +160,14 @@ FirestoreClient::FirestoreClient(
     std::shared_ptr<CredentialsProvider> credentials_provider,
     std::shared_ptr<Executor> user_executor,
     std::shared_ptr<AsyncQueue> worker_queue,
-    std::unique_ptr<FirebaseMetadataProvider> firebase_metadata_provider)
+    std::unique_ptr<FirebaseMetadataProvider> firebase_metadata_provider,
+    std::shared_ptr<Firestore> firestore)
     : database_info_(database_info),
       credentials_provider_(std::move(credentials_provider)),
       worker_queue_(std::move(worker_queue)),
       user_executor_(std::move(user_executor)),
-      firebase_metadata_provider_(std::move(firebase_metadata_provider)) {
+      firebase_metadata_provider_(std::move(firebase_metadata_provider)),
+      weak_firestore_(std::move(firestore)) {
 }
 
 void FirestoreClient::Initialize(const User& user, const Settings& settings) {
@@ -234,11 +238,12 @@ void FirestoreClient::Dispose() {
   std::promise<void> signal_disposing;
 
   bool enqueued = false;
-  // If termination has finished already, enqueing termination again is not only
-  // unnecessary, but also dangerous in the case when `Dispose` is invoked
-  // from `TerminateInternal`, still on the worker queue -- it would break the
-  // sequential order invariant of the queue.
-  if (!is_terminated()) {
+  // If `remote_store_` is null, it means termination has finished already. In
+  // that case, enqueing termination is not only unnecessary, but also
+  // dangerous in the case when `Dispose` is invoked immediately after the
+  // termination, still on the worker queue -- it would break the sequential
+  // order invariant of the queue.
+  if (is_terminated()) {
     // Prevent new API invocations from enqueueing further work.
     worker_queue_->EnterRestrictedMode();
 
@@ -272,6 +277,9 @@ void FirestoreClient::TerminateAsync(StatusCallback callback) {
     // Make sure this `FirestoreClient` is not destroyed during
     // `TerminateInternal`, so that `user_executor_` stays valid.
     auto self = shared_from_this();
+    // Make sure that `api::Firestore` is not destroyed during the call to
+    // `TerminateInternal`.
+    auto firestore = weak_firestore_.lock();
     TerminateInternal();
 
     if (callback) {

--- a/Firestore/core/src/core/firestore_client.h
+++ b/Firestore/core/src/core/firestore_client.h
@@ -223,8 +223,6 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
   bool credentials_initialized_ = false;
   local::LruDelegate* _Nullable lru_delegate_;
   util::DelayedOperation lru_callback_;
-
-  bool terminated_ = false;
 };
 
 }  // namespace core

--- a/Firestore/core/src/core/firestore_client.h
+++ b/Firestore/core/src/core/firestore_client.h
@@ -80,7 +80,8 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
       std::shared_ptr<util::Executor> user_executor,
       std::shared_ptr<util::AsyncQueue> worker_queue,
       std::unique_ptr<remote::FirebaseMetadataProvider>
-          firebase_metadata_provider);
+          firebase_metadata_provider,
+      std::shared_ptr<api::Firestore> firestore);
 
   ~FirestoreClient();
 
@@ -185,7 +186,8 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
       std::shared_ptr<util::Executor> user_executor,
       std::shared_ptr<util::AsyncQueue> worker_queue,
       std::unique_ptr<remote::FirebaseMetadataProvider>
-          firebase_metadata_provider);
+          firebase_metadata_provider,
+      std::shared_ptr<api::Firestore> firestore);
 
   void Initialize(const auth::User& user, const api::Settings& settings);
 
@@ -223,6 +225,9 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
   bool credentials_initialized_ = false;
   local::LruDelegate* _Nullable lru_delegate_;
   util::DelayedOperation lru_callback_;
+
+  // Used during shutdown to guarantee lifetimes.
+  std::weak_ptr<api::Firestore> weak_firestore_;
 };
 
 }  // namespace core

--- a/Firestore/core/src/core/firestore_client.h
+++ b/Firestore/core/src/core/firestore_client.h
@@ -227,10 +227,8 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
   local::LruDelegate* _Nullable lru_delegate_;
   util::DelayedOperation lru_callback_;
 
+  // Used during shutdown to guarantee lifetimes.
   std::weak_ptr<api::Firestore> maybe_firestore_;
-
-  std::mutex mutex_;
-  bool terminated_ = false;
 };
 
 }  // namespace core

--- a/Firestore/core/src/core/firestore_client.h
+++ b/Firestore/core/src/core/firestore_client.h
@@ -18,7 +18,6 @@
 #define FIRESTORE_CORE_SRC_CORE_FIRESTORE_CLIENT_H_
 
 #include <memory>
-#include <mutex>  // NOLINT(build/c++11)
 #include <vector>
 
 #include "Firestore/core/src/api/api_fwd.h"
@@ -228,7 +227,7 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
   util::DelayedOperation lru_callback_;
 
   // Used during shutdown to guarantee lifetimes.
-  std::weak_ptr<api::Firestore> maybe_firestore_;
+  std::weak_ptr<api::Firestore> weak_firestore_;
 };
 
 }  // namespace core

--- a/Firestore/core/src/core/firestore_client.h
+++ b/Firestore/core/src/core/firestore_client.h
@@ -18,6 +18,7 @@
 #define FIRESTORE_CORE_SRC_CORE_FIRESTORE_CLIENT_H_
 
 #include <memory>
+#include <mutex>  // NOLINT(build/c++11)
 #include <vector>
 
 #include "Firestore/core/src/api/api_fwd.h"
@@ -80,7 +81,8 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
       std::shared_ptr<util::Executor> user_executor,
       std::shared_ptr<util::AsyncQueue> worker_queue,
       std::unique_ptr<remote::FirebaseMetadataProvider>
-          firebase_metadata_provider);
+          firebase_metadata_provider,
+      std::shared_ptr<api::Firestore> firestore);
 
   ~FirestoreClient();
 
@@ -185,7 +187,8 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
       std::shared_ptr<util::Executor> user_executor,
       std::shared_ptr<util::AsyncQueue> worker_queue,
       std::unique_ptr<remote::FirebaseMetadataProvider>
-          firebase_metadata_provider);
+          firebase_metadata_provider,
+      std::shared_ptr<api::Firestore> firestore);
 
   void Initialize(const auth::User& user, const api::Settings& settings);
 
@@ -223,6 +226,11 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
   bool credentials_initialized_ = false;
   local::LruDelegate* _Nullable lru_delegate_;
   util::DelayedOperation lru_callback_;
+
+  std::weak_ptr<api::Firestore> maybe_firestore_;
+
+  std::mutex mutex_;
+  bool terminated_ = false;
 };
 
 }  // namespace core

--- a/Firestore/core/src/core/firestore_client.h
+++ b/Firestore/core/src/core/firestore_client.h
@@ -80,8 +80,7 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
       std::shared_ptr<util::Executor> user_executor,
       std::shared_ptr<util::AsyncQueue> worker_queue,
       std::unique_ptr<remote::FirebaseMetadataProvider>
-          firebase_metadata_provider,
-      std::shared_ptr<api::Firestore> firestore);
+          firebase_metadata_provider);
 
   ~FirestoreClient();
 
@@ -186,8 +185,7 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
       std::shared_ptr<util::Executor> user_executor,
       std::shared_ptr<util::AsyncQueue> worker_queue,
       std::unique_ptr<remote::FirebaseMetadataProvider>
-          firebase_metadata_provider,
-      std::shared_ptr<api::Firestore> firestore);
+          firebase_metadata_provider);
 
   void Initialize(const auth::User& user, const api::Settings& settings);
 
@@ -226,8 +224,7 @@ class FirestoreClient : public std::enable_shared_from_this<FirestoreClient> {
   local::LruDelegate* _Nullable lru_delegate_;
   util::DelayedOperation lru_callback_;
 
-  // Used during shutdown to guarantee lifetimes.
-  std::weak_ptr<api::Firestore> weak_firestore_;
+  bool terminated_ = false;
 };
 
 }  // namespace core

--- a/Firestore/core/src/util/async_queue.cc
+++ b/Firestore/core/src/util/async_queue.cc
@@ -86,6 +86,7 @@ void AsyncQueue::ExecuteBlocking(const Operation& operation) {
               "ExecuteBlocking may not be called "
               "before the previous operation finishes executing");
 
+  auto self = shared_from_this();
   is_operation_in_progress_ = true;
   operation();
   is_operation_in_progress_ = false;

--- a/Firestore/core/test/unit/util/ordered_code_test.cc
+++ b/Firestore/core/test/unit/util/ordered_code_test.cc
@@ -350,7 +350,7 @@ TEST(OrderedCodeInvalidEncodingsTest, NonCanonical) {
 
 #if defined(NDEBUG)
     EXPECT_ANY_THROW(TestRead<uint64_t>(INCREASING, non_minimal));
-#else  // defined(NDEBUG)
+#else   // defined(NDEBUG)
     absl::string_view s(non_minimal);
     EXPECT_ANY_THROW(OrderedCode::ReadNumIncreasing(&s, NULL));
 #endif  // defined(NDEBUG)
@@ -372,7 +372,7 @@ TEST(OrderedCodeInvalidEncodingsTest, NonCanonical) {
 
 #if defined(NDEBUG)
     EXPECT_ANY_THROW(TestRead<int64_t>(INCREASING, non_minimal));
-#else  // defined(NDEBUG)
+#else   // defined(NDEBUG)
     absl::string_view s(non_minimal);
     EXPECT_ANY_THROW(OrderedCode::ReadSignedNumIncreasing(&s, NULL));
     s = non_minimal;


### PR DESCRIPTION
If a user calls terminate and immediately disposes their reference to Firestore, it's possible that while termination is in process, the last remaining reference (more precisely, shared pointer) to Firestore is in a listener. When that listener is destroyed as part of the termination, it leads to `api::Firestore` being destroyed. Importantly, termination happens on the worker queue. The destructor of `api::Firestore` calls `Dispose` which presumes it's not called from the worker queue and tries to enqueue work, leading to a failing assertion and a crash.

The general problem is that `FirestoreClient::Dispose` may be invoked on the worker queue from `TerminateInternal` and needs a way to handle it gracefully. This PR largely makes `Dispose` a no-op in that case.

Fixes #6909.