### PR TITLE
Stop creating redundant bundle

### DIFF
--- a/ReleaseTooling/Sources/ZipBuilder/ResourcesManager.swift
+++ b/ReleaseTooling/Sources/ZipBuilder/ResourcesManager.swift
@@ -241,6 +241,11 @@ extension ResourcesManager {
         continue
       }
 
+      if fullPath.lastPathComponent.hasSuffix("bundle") {
+        // It's already a bundle, so no need to create one.
+        continue
+      }
+
       // It's a folder. Generate the name and location based on the folder name.
       let name = fullPath.lastPathComponent + ".bundle"
       let location = dir.appendingPathComponent(name)


### PR DESCRIPTION
Fix #7414

The zip distribution included both matching `GoogleSignIn.bundle` and `GoogleSignIn.bundle.bundle`

#no-changelog