### PR TITLE
GHA zip workflow: add manual trigger

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -34,7 +34,7 @@ jobs:
 
   package:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk' || github.event_name == 'pull_request'
     needs: build
     runs-on: macOS-latest
     steps:

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -20,9 +20,6 @@ on:
         required: true
         default: 'https://cpdc-internal.git.corp.google.com/firebase.git'
 
-env:
-  CUSTOM_SPEC_REPOS: ${{ github.event.inputs.output_dir || https://github.com/firebase/SpecsStaging.git }}
-
 jobs:
   build:
     # Don't run on private repo unless it is a PR.
@@ -47,7 +44,7 @@ jobs:
     - name: ZipBuildingTest
       run: |
          mkdir -p zip_output_dir
-         sh -x scripts/build_zip.sh zip_output_dir "${{ env.CUSTOM_SPEC_REPOS }}"
+         sh -x scripts/build_zip.sh zip_output_dir "${{ github.event.inputs.custom_spec_repos || https://github.com/firebase/SpecsStaging.git }}"
     - uses: actions/upload-artifact@v1
       with:
         name: Firebase-actions-dir

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   build:
     # Don't run on private repo unless it is a PR.
-    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request'
+    if: (github.repository == 'Firebase/firebase-ios-sdk' && github.event_name == 'schedule') || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
 
   package:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: (github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk') || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: macOS-latest
     steps:
@@ -54,7 +54,7 @@ jobs:
 
   quickstart_framework_abtesting:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: (github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk') || github.event_name == 'workflow_dispatch'
     needs: package
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -99,7 +99,7 @@ jobs:
 
   quickstart_framework_auth:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: (github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk') || github.event_name == 'workflow_dispatch'
     needs: package
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -143,7 +143,7 @@ jobs:
 
   quickstart_framework_config:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: (github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk') || github.event_name == 'workflow_dispatch'
     needs: package
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -184,7 +184,7 @@ jobs:
 
   quickstart_framework_crashlytics:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: (github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk') || github.event_name == 'workflow_dispatch'
     needs: package
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -234,7 +234,7 @@ jobs:
 
   quickstart_framework_database:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: (github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk') || github.event_name == 'workflow_dispatch'
     needs: package
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -279,7 +279,7 @@ jobs:
 
   quickstart_framework_dynamiclinks:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: (github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk') || github.event_name == 'workflow_dispatch'
     needs: package
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -329,7 +329,7 @@ jobs:
 
   quickstart_framework_firestore:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: (github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk') || github.event_name == 'workflow_dispatch'
     needs: package
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -372,7 +372,7 @@ jobs:
 
   quickstart_framework_inappmessaging:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: (github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk') || github.event_name == 'workflow_dispatch'
     needs: package
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -418,7 +418,7 @@ jobs:
 
   quickstart_framework_messaging:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: (github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk') || github.event_name == 'workflow_dispatch'
     needs: package
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}
@@ -463,7 +463,7 @@ jobs:
 
   quickstart_framework_storage:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
+    if: (github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk') || github.event_name == 'workflow_dispatch'
     needs: package
     env:
       plist_secret: ${{ secrets.GHASecretsGPGPassphrase1 }}

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -44,7 +44,7 @@ jobs:
     - name: ZipBuildingTest
       run: |
          mkdir -p zip_output_dir
-         sh -x scripts/build_zip.sh zip_output_dir "${{ github.event.inputs.custom_spec_repos || https://github.com/firebase/SpecsStaging.git }}"
+         sh -x scripts/build_zip.sh zip_output_dir "${{ github.event.inputs.custom_spec_repos || 'https://github.com/firebase/SpecsStaging.git' }}"
     - uses: actions/upload-artifact@v1
       with:
         name: Firebase-actions-dir

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -34,7 +34,7 @@ jobs:
 
   package:
     # Don't run on private repo.
-    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk' || github.event_name == 'pull_request'
+    if: github.event_name == 'schedule' && github.repository == 'Firebase/firebase-ios-sdk'
     needs: build
     runs-on: macOS-latest
     steps:

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -13,6 +13,16 @@ on:
     # Run every day at midnight(PST) - cron uses UTC times
     - cron:  '0 8 * * *'
 
+  workflow_dispatch:
+    inputs:
+      custom_spec_repos:
+        description: 'Custom Podspec repos'
+        required: true
+        default: 'https://cpdc-internal.git.corp.google.com/firebase.git'
+
+env:
+  CUSTOM_SPEC_REPOS: ${{ github.event.inputs.output_dir || https://github.com/firebase/SpecsStaging.git }}
+
 jobs:
   build:
     # Don't run on private repo unless it is a PR.
@@ -37,7 +47,7 @@ jobs:
     - name: ZipBuildingTest
       run: |
          mkdir -p zip_output_dir
-         sh -x scripts/build_zip.sh zip_output_dir
+         sh -x scripts/build_zip.sh zip_output_dir "${{ env.CUSTOM_SPEC_REPOS }}"
     - uses: actions/upload-artifact@v1
       with:
         name: Firebase-actions-dir

--- a/scripts/build_zip.sh
+++ b/scripts/build_zip.sh
@@ -14,9 +14,10 @@
 set -x
 REPO=`pwd`
 
-if [[ $# -lt 1 ]]; then
-  cat 1>&2 <<EOF
+if [[ $# -lt 2 ]]; then
+  cat 2>&2 <<EOF
 USAGE: $0 [output_directory]
+USAGE: $1 [custom-spec-repos]
 EOF
   exit 1
 fi
@@ -25,8 +26,10 @@ fi
 # output directory.
 OUTPUT_DIR="$REPO/$1"
 
+CUSTOM_SPEC_REPOS="$2"
+
 cd ReleaseTooling
 swift run zip-builder --keep-build-artifacts --update-pod-repo \
     --local-podspec-path "${REPO}" \
     --enable-carthage-build --output-dir "${OUTPUT_DIR}" \
-    --custom-spec-repos https://github.com/firebase/SpecsStaging.git
+    --custom-spec-repos "${CUSTOM_SPEC_REPOS}"


### PR DESCRIPTION
An attempt to add a [manual trigger](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) for zip GHA workflow. 

I was not able to test the trigger itself as the "Run workflow" button didn't appear for me. I guess the change has to land to the default branch to be picked up by GHA.